### PR TITLE
fix(model): resolve provider-prefixed models + upgrade pi-ai for adaptive thinking

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,16 +16,16 @@
     },
     "packages/agent-worker": {
       "name": "@lobu/worker",
-      "version": "12.0.0",
+      "version": "12.1.0",
       "bin": {
         "lobu-worker": "./dist/index.js",
       },
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "@lobu/core": "workspace:*",
-        "@mariozechner/pi-agent-core": "^0.51.6",
-        "@mariozechner/pi-ai": "^0.51.6",
-        "@mariozechner/pi-coding-agent": "^0.51.6",
+        "@mariozechner/pi-agent-core": "^0.73.1",
+        "@mariozechner/pi-ai": "^0.73.1",
+        "@mariozechner/pi-coding-agent": "^0.73.1",
         "@sentry/node": "^10.6.0",
         "@sinclair/typebox": "^0.34.33",
         "form-data": "^4.0.4",
@@ -43,7 +43,7 @@
     },
     "packages/cli": {
       "name": "@lobu/cli",
-      "version": "12.0.0",
+      "version": "12.1.0",
       "bin": {
         "lobu": "bin/lobu.js",
       },
@@ -67,7 +67,7 @@
         "@lobu/core": "workspace:*",
         "@lobu/embeddings": "workspace:*",
         "@lobu/worker": "workspace:*",
-        "@mariozechner/pi-ai": "^0.51.6",
+        "@mariozechner/pi-ai": "^0.73.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
@@ -128,7 +128,7 @@
     },
     "packages/client": {
       "name": "@lobu/client",
-      "version": "12.0.0",
+      "version": "12.1.0",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.86.5",
@@ -137,7 +137,7 @@
     },
     "packages/connector-sdk": {
       "name": "@lobu/connector-sdk",
-      "version": "12.0.0",
+      "version": "12.1.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
         "@sinclair/typebox": "^0.34.41",
@@ -161,7 +161,7 @@
     },
     "packages/connector-worker": {
       "name": "@lobu/connector-worker",
-      "version": "12.0.0",
+      "version": "12.1.0",
       "bin": {
         "connector-worker": "./dist/bin.js",
       },
@@ -199,7 +199,7 @@
     },
     "packages/core": {
       "name": "@lobu/core",
-      "version": "12.0.0",
+      "version": "12.1.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
@@ -217,7 +217,7 @@
     },
     "packages/embeddings": {
       "name": "@lobu/embeddings",
-      "version": "12.0.0",
+      "version": "12.1.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
         "@xenova/transformers": "^2.17.2",
@@ -249,7 +249,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "@lobu/openclaw-plugin",
-      "version": "12.0.0",
+      "version": "12.1.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
       },
@@ -333,7 +333,7 @@
     },
     "packages/pgvector-embedded": {
       "name": "@lobu/pgvector-embedded",
-      "version": "12.0.0",
+      "version": "12.1.0",
       "devDependencies": {
         "@types/node": "20.19.9",
         "typescript": "^5.7.2",
@@ -341,7 +341,7 @@
     },
     "packages/promptfoo-provider": {
       "name": "@lobu/promptfoo-provider",
-      "version": "12.0.0",
+      "version": "12.1.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.3",
@@ -366,7 +366,7 @@
         "@lobu/connector-sdk": "workspace:*",
         "@lobu/connector-worker": "workspace:*",
         "@lobu/core": "workspace:*",
-        "@mariozechner/pi-ai": "^0.51.6",
+        "@mariozechner/pi-ai": "^0.73.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@polyglot-sql/sdk": "^0.1.13",
         "@react-email/components": "^1.0.12",
@@ -840,7 +840,7 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
-    "@google/genai": ["@google/genai@1.34.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.24.0" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-vu53UMPvjmb7PGzlYu6Tzxso8Dfhn+a7eQFaS2uNemVtDZKwzSpJ5+ikqBbXplF7RGB1STcVDqCkPvquiwb2sw=="],
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
     "@googleapis/chat": ["@googleapis/chat@44.6.0", "", { "dependencies": { "googleapis-common": "^8.0.0" } }, "sha512-Bnqzev/bSTXSbE0/N2WS4Stnleo8j9bJJ1LkCBk1fXQnehcArVMv7q543rzPYU6MJql4D34On6diNGAuYtI9xQ=="],
 
@@ -1112,37 +1112,35 @@
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
-    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.2", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.2", "@mariozechner/clipboard-darwin-universal": "0.3.2", "@mariozechner/clipboard-darwin-x64": "0.3.2", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2", "@mariozechner/clipboard-linux-arm64-musl": "0.3.2", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-musl": "0.3.2", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2", "@mariozechner/clipboard-win32-x64-msvc": "0.3.2" } }, "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA=="],
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
 
-    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw=="],
+    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ=="],
 
-    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.2", "", { "os": "darwin" }, "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg=="],
+    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.9", "", { "os": "darwin" }, "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ=="],
 
-    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg=="],
+    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg=="],
 
-    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ=="],
+    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw=="],
 
-    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw=="],
+    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ=="],
 
-    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA=="],
+    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.9", "", { "os": "linux", "cpu": "none" }, "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw=="],
 
-    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A=="],
+    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw=="],
 
-    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw=="],
+    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ=="],
 
-    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg=="],
+    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
 
-    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA=="],
+    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
 
-    "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.73.1", "", { "dependencies": { "@mariozechner/pi-ai": "^0.73.1", "typebox": "^1.1.24" } }, "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ=="],
 
-    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.51.6", "", { "dependencies": { "@mariozechner/pi-ai": "^0.51.6" } }, "sha512-57ybnrRdFssXsEoT0Ot71s+shzAaQJtGfGX2yTSwNicAbgei8L1mYuqWMUgQ1oSNv1fv59GMBo8nphIxw+GDxQ=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.73.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.91.1", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "typebox": "^1.1.24", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.51.6", "", { "dependencies": { "@anthropic-ai/sdk": "0.71.2", "@aws-sdk/client-bedrock-runtime": "^3.966.0", "@google/genai": "1.34.0", "@mistralai/mistralai": "1.10.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.10.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-vzB7M2NPpjQmAZEtSN+v5rgYVhDUBoshtmXUGuHwx4SLIaHl1Z9eSeJg+HwclQPjesNuxhdBiHAHg8CEZ+3Dfg=="],
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.73.1", "", { "dependencies": { "@mariozechner/pi-agent-core": "^0.73.1", "@mariozechner/pi-ai": "^0.73.1", "@mariozechner/pi-tui": "^0.73.1", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "jiti": "^2.7.0", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "typebox": "^1.1.24", "undici": "^7.19.1", "uuid": "^14.0.0", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.5" }, "bin": { "pi": "dist/cli.js" } }, "sha512-gXQh3SaZmWTfVMc4Ao5+LGbVeKvzyO7tolok0nLsZgq9nGjZx/EEU3NM8C+qUnB4Nvs2rswG5qOVgLzQkq0fHQ=="],
 
-    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.51.6", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.51.6", "@mariozechner/pi-ai": "^0.51.6", "@mariozechner/pi-tui": "^0.51.6", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "file-type": "^21.1.1", "glob": "^13.0.1", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.1.1", "proper-lockfile": "^4.1.2", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Rg3/C6a/30E1AoWHShoFUXMlvkvhK9xUEJTdApmIS51kCI4UuPcqw4fe9kq5I8KeMuAlcjo+jweMYrNVVvkNRw=="],
-
-    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.51.6", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" } }, "sha512-mG/RH5qArwLXcbnR3BOb8MRDGj4MvUD+c/AYySmC6XTkF+LVDw6Vc14cUcusblIUaE1GNmp+dxsRORmnh+0whg=="],
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.73.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw=="],
 
     "@marsidev/react-turnstile": ["@marsidev/react-turnstile@1.5.2", "", { "peerDependencies": { "react": "^17.0.2 || ^18.0.0 || ^19.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0" } }, "sha512-+3aBPxp86JzSC0ZmgyonoGoUEENcUkH3LGahXSpkV87ArvD2DzRCmPgh0FyQk6PQRmJwQJDAfwNavFsxUxMQWA=="],
 
@@ -1160,7 +1158,7 @@
 
     "@microsoft/teams.graph-endpoints": ["@microsoft/teams.graph-endpoints@2.0.8", "", {}, "sha512-KjDhMWn8ZcwTjDOw1hL0By/HvHEXe5+Bzy8tmEOsqPGUc/1HfwtBZAYsr8FUVBSBe0CObLYs2Pkh0wiHqWNNPw=="],
 
-    "@mistralai/mistralai": ["@mistralai/mistralai@1.10.0", "", { "dependencies": { "zod": "^3.20.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg=="],
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
 
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
@@ -1990,6 +1988,8 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
+    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
+
     "@typespec/ts-http-runtime": ["@typespec/ts-http-runtime@0.3.5", "", { "dependencies": { "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "tslib": "^2.6.2" } }, "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
@@ -2165,6 +2165,8 @@
     "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
@@ -2512,6 +2514,8 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
+    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -2533,6 +2537,8 @@
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
+
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -2707,6 +2713,8 @@
     "hono-pino": ["hono-pino@0.10.3", "", { "dependencies": { "defu": "^6.1.4" }, "peerDependencies": { "hono": ">=4.0.0", "pino": ">=7.1.0" } }, "sha512-n0RNPIFOoq25Fg8b4D5gus4sVqI0z+8I17ibl96+p43d07UnZ0EMM/It0qSgfc7UtaC+XP5FkFmRHwBp6owsNA=="],
 
     "hookified": ["hookified@1.15.1", "", {}, "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg=="],
+
+    "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
@@ -2891,6 +2899,8 @@
     "klona": ["klona@2.0.6", "", {}, "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="],
 
     "knip": ["knip@5.88.1", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "jiti": "^2.6.0", "minimist": "^1.2.8", "oxc-resolver": "^11.19.1", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.5.2", "strip-json-comments": "5.0.3", "unbash": "^2.2.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "peerDependencies": { "@types/node": ">=18", "typescript": ">=5.0.4 <7" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-tpy5o7zu1MjawVkLPuahymVJekYY3kYjvzcoInhIchgePxTlo+api90tBv2KfhAIe5uXh+mez1tAfmbv8/TiZg=="],
+
+    "koffi": ["koffi@2.16.2", "", {}, "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA=="],
 
     "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
 
@@ -3256,7 +3266,7 @@
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
-    "openai": ["openai@6.10.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A=="],
+    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
     "openapi3-ts": ["openapi3-ts@4.5.0", "", { "dependencies": { "yaml": "^2.8.0" } }, "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ=="],
 
@@ -3327,6 +3337,8 @@
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
     "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
 
@@ -3876,6 +3888,8 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
+    "typebox": ["typebox@1.3.0", "", {}, "sha512-3HaX5iZ13wSzcLSflDH1UJwaXnRghtc8LhQtKnq8qnlcnZvmGOpBOM6rY9PdyPBKNOYBpDHfE9r6BmI41fvp4g=="],
+
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -3954,7 +3968,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -4056,9 +4070,9 @@
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
-    "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
-    "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+    "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
@@ -4196,7 +4210,7 @@
 
     "@lobu/worker/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@mariozechner/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ=="],
+    "@mariozechner/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
     "@mariozechner/pi-coding-agent/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -4211,8 +4225,6 @@
     "@mdx-js/mdx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "@mdx-js/mdx/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
-
-    "@mistralai/mistralai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
@@ -4627,6 +4639,8 @@
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
+    "svix/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -48,9 +48,9 @@
   "dependencies": {
     "@hono/node-server": "^1.19.9",
     "@lobu/core": "workspace:*",
-    "@mariozechner/pi-agent-core": "^0.51.6",
-    "@mariozechner/pi-ai": "^0.51.6",
-    "@mariozechner/pi-coding-agent": "^0.51.6",
+    "@mariozechner/pi-agent-core": "^0.73.1",
+    "@mariozechner/pi-ai": "^0.73.1",
+    "@mariozechner/pi-coding-agent": "^0.73.1",
     "@sentry/node": "^10.6.0",
     "@sinclair/typebox": "^0.34.33",
     "form-data": "^4.0.4",

--- a/packages/agent-worker/src/__tests__/agent-session-bash-env.test.ts
+++ b/packages/agent-worker/src/__tests__/agent-session-bash-env.test.ts
@@ -54,9 +54,11 @@ function getBashTool(tools: { name: string }[]) {
 
 describe("agent session bash inherits Lobu-built bash (Findings #1, #10)", () => {
   test("session bash strips SENSITIVE_WORKER_ENV_KEYS from the spawned env", async () => {
+    const builtins = createOpenClawTools(tempDir);
     const { session } = await buildAgentSession({
       cwd: tempDir,
-      tools: createOpenClawTools(tempDir),
+      tools: builtins.map((t) => t.name),
+      builtinOverrides: builtins,
       customTools: [],
     });
 
@@ -91,9 +93,13 @@ describe("agent session bash inherits Lobu-built bash (Findings #1, #10)", () =>
       },
     };
 
+    const builtins = createOpenClawTools(tempDir, {
+      bashOperations: mockBashOps,
+    });
     const { session } = await buildAgentSession({
       cwd: tempDir,
-      tools: createOpenClawTools(tempDir, { bashOperations: mockBashOps }),
+      tools: builtins.map((t) => t.name),
+      builtinOverrides: builtins,
       customTools: [],
     });
 
@@ -121,7 +127,8 @@ describe("agent session bash inherits Lobu-built bash (Findings #1, #10)", () =>
 
     const { session } = await buildAgentSession({
       cwd: tempDir,
-      tools: lobuTools,
+      tools: lobuTools.map((t) => t.name),
+      builtinOverrides: lobuTools,
       customTools: [],
     });
 

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -42,6 +42,38 @@ describe("resolveModelRef", () => {
     expect(result.modelId).toBe("gpt-4.1");
   });
 
+  test("strips the LOBU slug prefix when it differs from the upstream defaultProvider", () => {
+    // The builder bug: model stored as "claude/…" but the worker is told the
+    // upstream slug "anthropic". Without defaultProviderSlug the "claude/"
+    // prefix survived and 404'd at the Anthropic API.
+    const result = resolveModelRef("claude/claude-opus-4-8", {
+      defaultProvider: "anthropic",
+      defaultProviderSlug: "claude",
+    });
+    expect(result.provider).toBe("anthropic");
+    expect(result.modelId).toBe("claude-opus-4-8");
+  });
+
+  test("still strips the upstream-slug prefix when the model uses it directly", () => {
+    const result = resolveModelRef("anthropic/claude-opus-4-8", {
+      defaultProvider: "anthropic",
+      defaultProviderSlug: "claude",
+    });
+    expect(result.provider).toBe("anthropic");
+    expect(result.modelId).toBe("claude-opus-4-8");
+  });
+
+  test("leaves a foreign-namespace model intact (does not strip a non-matching slug)", () => {
+    // OpenRouter's "anthropic/claude-sonnet-4" is the provider's own model id,
+    // not a Lobu prefix — it must pass through unchanged.
+    const result = resolveModelRef("anthropic/claude-sonnet-4", {
+      defaultProvider: "openrouter",
+      defaultProviderSlug: "openrouter",
+    });
+    expect(result.provider).toBe("openrouter");
+    expect(result.modelId).toBe("anthropic/claude-sonnet-4");
+  });
+
   test("falls back to overrides.defaultModel when rawModelRef is empty", () => {
     const result = resolveModelRef("", {
       defaultModel: "anthropic/claude-sonnet-4-20250514",

--- a/packages/agent-worker/src/__tests__/processor-harden.test.ts
+++ b/packages/agent-worker/src/__tests__/processor-harden.test.ts
@@ -82,10 +82,10 @@ describe("OpenClawProgressProcessor — malformed events don't throw", () => {
     ).not.toThrow();
   });
 
-  test("auto_compaction_end with neither aborted nor result returns true", () => {
+  test("compaction_end with neither aborted nor result returns true", () => {
     const p = new OpenClawProgressProcessor();
     // No aborted, no result — the current implementation still returns true
-    const result = p.processEvent({ type: "auto_compaction_end" } as any);
+    const result = p.processEvent({ type: "compaction_end" } as any);
     expect(result).toBe(true);
   });
 

--- a/packages/agent-worker/src/__tests__/processor.test.ts
+++ b/packages/agent-worker/src/__tests__/processor.test.ts
@@ -101,25 +101,25 @@ describe("OpenClawProgressProcessor", () => {
     expect(p.processEvent(event)).toBe(false);
   });
 
-  test("auto_compaction_start appends message", () => {
+  test("compaction_start appends message", () => {
     const p = new OpenClawProgressProcessor();
-    expect(p.processEvent(makeEvent("auto_compaction_start"))).toBe(true);
+    expect(p.processEvent(makeEvent("compaction_start"))).toBe(true);
     expect(p.getDelta()).toContain("Compacting context");
   });
 
-  test("auto_compaction_end with aborted", () => {
+  test("compaction_end with aborted", () => {
     const p = new OpenClawProgressProcessor();
-    expect(
-      p.processEvent(makeEvent("auto_compaction_end", { aborted: true }))
-    ).toBe(true);
+    expect(p.processEvent(makeEvent("compaction_end", { aborted: true }))).toBe(
+      true
+    );
     expect(p.getDelta()).toContain("Compaction aborted");
   });
 
-  test("auto_compaction_end with result", () => {
+  test("compaction_end with result", () => {
     const p = new OpenClawProgressProcessor();
-    expect(
-      p.processEvent(makeEvent("auto_compaction_end", { result: {} }))
-    ).toBe(true);
+    expect(p.processEvent(makeEvent("compaction_end", { result: {} }))).toBe(
+      true
+    );
     expect(p.getDelta()).toContain("Context compacted");
   });
 

--- a/packages/agent-worker/src/__tests__/turn-terminate-loop.test.ts
+++ b/packages/agent-worker/src/__tests__/turn-terminate-loop.test.ts
@@ -238,8 +238,9 @@ function wireGuardedTools(
       return t.execute(...args);
     },
   }));
-  agent.setTools(
-    wrapToolsWithTurnGuard(instrumented as AgentTool[], controller)
+  agent.state.tools = wrapToolsWithTurnGuard(
+    instrumented as AgentTool[],
+    controller
   );
   return { bodyRuns };
 }
@@ -279,7 +280,7 @@ describe("turn force-terminate via TurnController + real Agent loop", () => {
         ) as never;
       }) as never,
     });
-    agent.setModel(MODEL as never);
+    agent.state.model = MODEL as never;
     wireGuardedTools(agent, controller, [askUser]);
 
     await agent.prompt("help me");
@@ -342,7 +343,7 @@ describe("turn force-terminate via TurnController + real Agent loop", () => {
         ) as never;
       }) as never,
     });
-    agent.setModel(MODEL as never);
+    agent.state.model = MODEL as never;
     wireGuardedTools(agent, controller, [askUser, sibling]);
 
     await agent.prompt("help me");
@@ -382,7 +383,7 @@ describe("turn force-terminate via TurnController + real Agent loop", () => {
         ) as never;
       }) as never,
     });
-    agent.setModel(MODEL as never);
+    agent.state.model = MODEL as never;
     const { bodyRuns } = wireGuardedTools(agent, controller, [spam]);
 
     await agent.prompt("go");
@@ -423,7 +424,7 @@ describe("turn force-terminate via TurnController + real Agent loop", () => {
     const noop = makeRecordingTool("noop", () => {
       // benign tool: no side-effect
     });
-    agent.setModel(MODEL as never);
+    agent.state.model = MODEL as never;
     const { bodyRuns } = wireGuardedTools(agent, controller, [noop]);
 
     await agent.prompt("do one thing");

--- a/packages/agent-worker/src/__tests__/worker-bash-secret-leak-e2e.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-bash-secret-leak-e2e.test.ts
@@ -78,7 +78,8 @@ describe("worker agent bash secret leak (E2E, Finding #1)", () => {
     const tools = createOpenClawTools(tempDir);
     const { session } = await buildAgentSession({
       cwd: tempDir,
-      tools,
+      tools: tools.map((t) => t.name),
+      builtinOverrides: tools,
       customTools: [],
     });
 

--- a/packages/agent-worker/src/openclaw/model-resolver.ts
+++ b/packages/agent-worker/src/openclaw/model-resolver.ts
@@ -153,13 +153,22 @@ export function buildDynamicOpenAIModel(args: {
 
 export function resolveModelRef(
   rawModelRef: string,
-  overrides?: { defaultModel?: string; defaultProvider?: string }
+  overrides?: {
+    defaultModel?: string;
+    defaultProvider?: string;
+    defaultProviderSlug?: string;
+  }
 ): {
   provider: string;
   modelId: string;
 } {
   const defaultModelRef = overrides?.defaultModel || "";
   const defaultProvider = overrides?.defaultProvider || "";
+  // The provider's LOBU id (e.g. "claude"), present only when it differs from
+  // `defaultProvider` (the upstream slug, e.g. "anthropic"). Lobu stores models
+  // prefixed with the Lobu id, so it must be stripped too — otherwise a
+  // "claude/…" model reaches the upstream API verbatim and 404s.
+  const defaultProviderSlug = overrides?.defaultProviderSlug || "";
 
   const normalizedRaw = rawModelRef?.trim();
   const modelRef = normalizedRaw || defaultModelRef;
@@ -198,8 +207,19 @@ export function resolveModelRef(
     // Model". Only the configured provider's OWN id is stripped, so a foreign
     // namespace slug (OpenRouter's "anthropic/claude-sonnet-4") stays intact.
     // Runs after the auto-resolution above so a prefixed default is covered too.
+    //
+    // `defaultProvider` is the UPSTREAM slug ("anthropic"); strip that AND the
+    // LOBU slug ("claude") when they differ, since the stored model is prefixed
+    // with the Lobu id. Without the second strip, "claude/claude-opus-4-8"
+    // reaches the Anthropic API verbatim and 404s.
     if (modelId.startsWith(`${defaultProvider}/`)) {
       modelId = modelId.slice(defaultProvider.length + 1);
+    } else if (
+      defaultProviderSlug &&
+      defaultProviderSlug !== defaultProvider &&
+      modelId.startsWith(`${defaultProviderSlug}/`)
+    ) {
+      modelId = modelId.slice(defaultProviderSlug.length + 1);
     }
     return { provider: defaultProvider, modelId };
   }

--- a/packages/agent-worker/src/openclaw/processor.ts
+++ b/packages/agent-worker/src/openclaw/processor.ts
@@ -136,12 +136,12 @@ export class OpenClawProgressProcessor {
         return false;
       }
 
-      case "auto_compaction_start": {
+      case "compaction_start": {
         this.chronologicalOutput += "🗜️ *Compacting context...*\n";
         return true;
       }
 
-      case "auto_compaction_end": {
+      case "compaction_end": {
         if (event.aborted) {
           this.chronologicalOutput += "🗜️ *Compaction aborted*\n";
         } else if (event.result) {

--- a/packages/agent-worker/src/openclaw/session-context.ts
+++ b/packages/agent-worker/src/openclaw/session-context.ts
@@ -11,6 +11,14 @@ const logger = createLogger("openclaw-session-context");
 interface ProviderConfig {
   credentialEnvVarName?: string;
   defaultProvider?: string;
+  /**
+   * The primary provider's LOBU id (e.g. "claude"), sent only when it differs
+   * from `defaultProvider` (the upstream slug, e.g. "anthropic"). Lobu stores
+   * models prefixed with the Lobu id; the resolver strips this prefix in
+   * addition to `<defaultProvider>/` so a stored "claude/…" model doesn't reach
+   * the provider API verbatim and 404. See resolveModelRef.
+   */
+  defaultProviderSlug?: string;
   defaultModel?: string;
   cliBackends?: Array<{
     providerId: string;

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -106,16 +106,28 @@ const OVERRIDABLE_BUILTIN_NAMES = new Set([
  * preserving every other aspect of `createAgentSession` (model resolution,
  * session restore, image blocking, extension/custom-tool wiring).
  */
-export async function buildAgentSession(
-  options: CreateAgentSessionOptions
-): Promise<CreateAgentSessionResult> {
+type BuildAgentSessionOptions = CreateAgentSessionOptions & {
+  /**
+   * Lobu's hardened built-in tool instances (read/bash/edit/write/…). pi's
+   * `createAgentSession` only takes built-in NAMES via `options.tools` and
+   * rebuilds the instances internally (unhardened bash via getShellEnv()), so
+   * we swap those rebuilt instances for these by name after construction. Pass
+   * the same names in `options.tools` so they're active in the first place.
+   */
+  builtinOverrides?: AgentTool<any>[];
+};
+
+export async function buildAgentSession({
+  builtinOverrides,
+  ...options
+}: BuildAgentSessionOptions): Promise<CreateAgentSessionResult> {
   const result = await createAgentSession(options);
   const { session } = result;
 
   const lobuBuiltins = new Map<string, AgentTool<any>>();
-  for (const tool of options.tools ?? []) {
+  for (const tool of builtinOverrides ?? []) {
     if (OVERRIDABLE_BUILTIN_NAMES.has(tool.name)) {
-      lobuBuiltins.set(tool.name, tool as AgentTool<any>);
+      lobuBuiltins.set(tool.name, tool);
     }
   }
   if (lobuBuiltins.size === 0) {
@@ -126,7 +138,7 @@ export async function buildAgentSession(
   const patched = activeTools.map(
     (tool) => lobuBuiltins.get(tool.name) ?? tool
   );
-  session.agent.setTools(patched);
+  session.agent.state.tools = patched;
 
   return result;
 }
@@ -550,6 +562,7 @@ export async function runAISession(
   const { provider: rawProvider, modelId } = resolveModelRef(modelRef, {
     defaultModel: pc.defaultModel,
     defaultProvider: pc.defaultProvider,
+    defaultProviderSlug: pc.defaultProviderSlug,
   });
   // Map gateway slug to model-registry provider name (e.g. "z-ai" → "zai")
   const provider = PROVIDER_REGISTRY_ALIASES[rawProvider] || rawProvider;
@@ -862,7 +875,10 @@ export async function runAISession(
 
   // Credential injection — resolve API key from the in-memory credential store,
   // falling back to process.env only for values that were present at startup.
-  const authStorage = new AuthStorage();
+  // In-memory only — the worker injects runtime API keys below and never reads
+  // or writes an on-disk auth.json (pi-ai 0.73 made the AuthStorage ctor private
+  // in favour of these factories).
+  const authStorage = AuthStorage.inMemory();
   const credEnvVar = credentialStore.get("CREDENTIAL_ENV_VAR_NAME") || null;
   const credValue = credEnvVar
     ? credentialStore.get(credEnvVar) || process.env[credEnvVar]
@@ -1011,7 +1027,7 @@ Use it when the user references past discussions or you need context.`);
   }
 
   // Apply plugin provider registrations to ModelRegistry
-  const modelRegistry = new ModelRegistry(authStorage);
+  const modelRegistry = ModelRegistry.create(authStorage);
   const allProviders = loadedPlugins.flatMap((p) => p.providers);
   for (const reg of allProviders) {
     try {
@@ -1081,15 +1097,18 @@ Use it when the user references past discussions or you need context.`);
       // names and rebuilds the base tools internally (bash via getShellEnv()
       // = {...process.env}, no env strip, no embedded BashOperations).
       // buildAgentSession() swaps those rebuilt built-ins back to these
-      // Lobu instances after construction so the agent's bash actually runs
-      // with the spawnHook that strips WORKER_TOKEN/DISPATCHER_URL and with
-      // the embedded BashOperations + tool policy wired in above.
+      // Lobu instances (via `builtinOverrides`) after construction so the
+      // agent's bash actually runs with the spawnHook that strips
+      // WORKER_TOKEN/DISPATCHER_URL and with the embedded BashOperations + tool
+      // policy wired in above. `tools` (names) activates exactly this set;
+      // `builtinOverrides` supplies the instances the swap installs.
       // Wrap built-ins with the synchronous runaway guard so the per-turn
       // tool-call cap and identical-call guard bound bash/read/edit/write
       // too. The guard runs inside execute (before the tool body), so the
       // bound is tight — unlike the agent's async tool_execution_start event,
       // which lags several turns behind real execution.
-      tools: wrapToolsWithTurnGuard(tools, turnController),
+      tools: tools.map((tool) => tool.name),
+      builtinOverrides: wrapToolsWithTurnGuard(tools, turnController),
       // Wrap custom tools (plugin + MCP) so plugin before_tool_call/
       // after_tool_call hooks fire around in-process execution — these never
       // hit the gateway proxy, so this is the only place the hooks can run.
@@ -1138,7 +1157,7 @@ Use it when the user references past discussions or you need context.`);
       : [basePrompt, finalInstructionsUpdated]
           .filter(Boolean)
           .join("\n\n---\n\n");
-    session.agent.setSystemPrompt(finalSystemPrompt);
+    session.agent.state.systemPrompt = finalSystemPrompt;
 
     let resolveTurnDone: (() => void) | null = null;
     let turnNonce = 0;

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -499,7 +499,12 @@ export class OpenClawWorker implements WorkerExecutor {
       contextUsage.contextWindow -
       reserveTokens -
       memoryFlushConfig.softThresholdTokens;
-    const projectedContextTokens = contextUsage.tokens + incomingPromptTokens;
+    // `tokens` is null until the first assistant turn reports usage (pi-ai
+    // 0.73 widened it to number | null); treat "no usage yet" as 0 so the
+    // projection is just the incoming prompt and the flush stays below
+    // threshold on turn one.
+    const projectedContextTokens =
+      (contextUsage.tokens ?? 0) + incomingPromptTokens;
 
     if (projectedContextTokens < thresholdTokens) {
       return;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "@lobu/core": "workspace:*",
     "@lobu/embeddings": "workspace:*",
     "@lobu/worker": "workspace:*",
-    "@mariozechner/pi-ai": "^0.51.6",
+    "@mariozechner/pi-ai": "^0.73.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,7 @@
     "@lobu/core": "workspace:*",
     "@lobu/connector-sdk": "workspace:*",
     "@lobu/connector-worker": "workspace:*",
-    "@mariozechner/pi-ai": "^0.51.6",
+    "@mariozechner/pi-ai": "^0.73.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@polyglot-sql/sdk": "^0.1.13",
     "@react-email/components": "^1.0.12",

--- a/packages/server/src/gateway/auth/provider-catalog.ts
+++ b/packages/server/src/gateway/auth/provider-catalog.ts
@@ -174,6 +174,22 @@ export class ProviderCatalogService {
         return provider;
       }
     }
+    // Fallback: a "<providerId>/<model>" ref names its provider directly, so
+    // match by the leading segment even when the provider's option list didn't
+    // contain an exact value. This is essential for providers whose models are
+    // fetched live and may be empty in this resolution context (e.g. Claude,
+    // whose `getModelOptions` lists BARE ids like "claude-opus-4-8" while the
+    // stored model is prefixed "claude/claude-opus-4-8"). Without it, a
+    // claude/… model fails to match and falls through to the first credentialed
+    // provider, mis-routing the request to the wrong upstream.
+    const slashIndex = model.indexOf("/");
+    if (slashIndex > 0) {
+      const prefix = model.slice(0, slashIndex);
+      const byProviderId = candidates.find((p) => p.providerId === prefix);
+      if (byProviderId) {
+        return byProviderId;
+      }
+    }
     return undefined;
   }
 

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -862,6 +862,7 @@ export class WorkerGateway {
   ): Promise<{
     credentialEnvVarName?: string;
     defaultProvider?: string;
+    defaultProviderSlug?: string;
     defaultModel?: string;
     cliBackends?: Array<{
       providerId: string;
@@ -963,6 +964,7 @@ export class WorkerGateway {
     const result: {
       credentialEnvVarName?: string;
       defaultProvider?: string;
+      defaultProviderSlug?: string;
       defaultModel?: string;
       cliBackends?: typeof cliBackends;
       providerBaseUrlMappings?: Record<string, string>;
@@ -974,6 +976,16 @@ export class WorkerGateway {
       result.credentialEnvVarName = primaryProvider.getCredentialEnvVarName();
       const upstream = primaryProvider.getUpstreamConfig?.();
       result.defaultProvider = upstream?.slug || primaryProvider.providerId;
+      // The worker is told `defaultProvider` is the UPSTREAM slug (e.g.
+      // "anthropic") and only strips a `<defaultProvider>/` model prefix. But
+      // Lobu stores models under the provider's LOBU id (e.g.
+      // "claude/claude-opus-4-8"), so for a provider whose Lobu id differs from
+      // its upstream slug the prefix is never stripped and reaches the provider
+      // API verbatim → 404. Hand the worker the Lobu slug too so it can strip
+      // that prefix as well (see resolveModelRef). Omitted when the slugs match.
+      if (upstream?.slug && upstream.slug !== primaryProvider.providerId) {
+        result.defaultProviderSlug = primaryProvider.providerId;
+      }
     }
 
     // Only an explicitly configured model is used — Lobu no longer silently

--- a/packages/server/src/gateway/services/bedrock-openai-service.ts
+++ b/packages/server/src/gateway/services/bedrock-openai-service.ts
@@ -1,6 +1,10 @@
-import { getModel } from "@mariozechner/pi-ai";
-import { streamBedrock } from "@mariozechner/pi-ai/dist/providers/amazon-bedrock.js";
-import type { Model } from "@mariozechner/pi-ai/dist/types.js";
+import { getModel, type Model } from "@mariozechner/pi-ai";
+// pi-ai 0.73 tightened its `exports` map: the bedrock provider is no longer
+// reachable at the deep `dist/providers/amazon-bedrock.js` path and is exposed
+// as `bedrockProviderModule` from the `./bedrock-provider` subpath instead.
+import { bedrockProviderModule } from "@mariozechner/pi-ai/bedrock-provider";
+
+const streamBedrock = bedrockProviderModule.streamBedrock;
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { createLogger } from "@lobu/core";


### PR DESCRIPTION
## What

Fixes claude (and any provider whose Lobu slug differs from its upstream slug) failing to reply, and upgrades the pi agent SDK so adaptive-thinking models work.

Three changes, all verified end-to-end on a local server:

- **Worker prefix strip** — the gateway now hands the worker the provider's Lobu slug (`defaultProviderSlug`) so `resolveModelRef` strips a `claude/…` prefix against the upstream `anthropic` slug. Without it the prefixed model reached the Anthropic API verbatim and 404'd.
- **`findProviderForModel`** — matched only by exact `opt.value === model`, so a `claude/…` model (claude lists bare ids, fetched live) never matched and fell through to the first credentialed provider, mis-routing to e.g. gemini. It now also matches a `<providerId>/…` ref to its provider directly.
- **pi-ai 0.51.6 → 0.73.1** (agent-worker/cli/server) for native adaptive thinking (Opus 4.6/4.7, Sonnet 4.6). Migrated the changed API: `Agent.state.{tools,systemPrompt}` accessors, `AuthStorage`/`ModelRegistry` factories, compaction event rename, the bedrock public export (the old `dist/` deep import broke at runtime), nullable context tokens, and the tests that exercised the old API.

## Verified

- typecheck / unit (610 pass) / integration all green; pi review: 0 bugs, 0 blockers.
- Live e2e: `claude/claude-sonnet-4-6` resolves → replies with real adaptive thinking; a bash tool-use turn runs the hardened bash and returns correct output; server boots clean.

## Known limitation

Opus 4.8 (`claude-opus-4-8`) is newer than the latest pi-ai release — its `supportsAdaptiveThinking` hardcodes up to opus-4-7/sonnet-4-6 — so Opus 4.8 still gets the legacy thinking param and 400s. It will work once pi-ai ships a release that knows opus-4-8. The builder's `sonnet-4-6` default works today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784688613&installation_id=136316292&pr_number=1434&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1434&signature=a8261a64c51601877a0e8ce090bbacfcbb3eb32259f3227f41ef652b6db2a60e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core agent and AI library dependencies to latest versions across packages.

* **New Features**
  * Enhanced model provider resolution with automatic fallback for `provider/model` formatted strings.
  * Added provider slug configuration support for improved model routing accuracy.

* **Refactor**
  * Refactored internal session configuration and model resolution logic for better provider handling.
  * Updated event handling for context management operations.
  * Improved null-safety checks in context token projections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->