### PR TITLE
feat(connectors+gateway): GitHub App install flow + device_worker_id serverless fix + tenancy audit

### DIFF
--- a/packages/connectors/src/__tests__/connector-sdk.mock.ts
+++ b/packages/connectors/src/__tests__/connector-sdk.mock.ts
@@ -33,12 +33,31 @@ export function connectorSdkMock() {
     acquireBrowser: notUsed('acquireBrowser'),
     captureErrorArtifacts: notUsed('captureErrorArtifacts'),
     extensionNetworkSync: notUsed('extensionNetworkSync'),
-    createHttpClient: notUsed('createHttpClient'),
+    // Connectors create their HTTP client as a class field at construction, so a
+    // throwing stub would break `new XConnector()`. Return an inert client whose
+    // network methods throw only IF actually called — tests that exercise a
+    // request path override `connector.http` / `connector.requestJson` first.
+    createHttpClient: () => ({
+      json: notUsed('http.json'),
+      request: notUsed('http.request'),
+    }),
     requireBearerClient: notUsed('requireBearerClient'),
     paginateByCursor: notUsed('paginateByCursor'),
     paginateByOffset: notUsed('paginateByOffset'),
     ConnectorRuntime: class {},
     calculateEngagementScore: () => 0,
+    IDENTITY: {
+      PHONE: 'phone',
+      EMAIL: 'email',
+      WA_JID: 'wa_jid',
+      SLACK_USER_ID: 'slack_user_id',
+      GITHUB_LOGIN: 'github_login',
+      GITHUB_USER_ID: 'github_user_id',
+      GITHUB_REPO_ID: 'github_repo_id',
+      GITHUB_REPO_FULL_NAME: 'github_repo_full_name',
+      AUTH_USER_ID: 'auth_user_id',
+      GOOGLE_CONTACT_ID: 'google_contact_id',
+    },
     extensionDomScrape: async (opts: DomScrapeOpts) => {
       const observation = await opts.dispatcher.dispatch('navigate', {
         cs_scrape: true,

--- a/packages/connectors/src/__tests__/github-webhook-gate.test.ts
+++ b/packages/connectors/src/__tests__/github-webhook-gate.test.ts
@@ -1,0 +1,119 @@
+/**
+ * GitHub connector webhook registration gate (regression).
+ *
+ * Bug: the connector no-op'd registerWebhook/unregisterWebhook whenever its
+ * STATIC `definition.webhook.delivery === 'app_installation'` — which is true for
+ * EVERY github connection. That disabled per-connection webhook registration for
+ * OAuth/PAT connections (which still need their own hook). The fix gates the
+ * no-op on the CONNECTION's resolved auth (`config.installation_ref` /
+ * `ctx.installation`), not the static delivery mode.
+ *
+ * This proves both branches:
+ *   - an app_installation connection (config.installation_ref set) → register is
+ *     a no-op (the HTTP layer is never reached),
+ *   - an OAuth/PAT connection (org target + token, no installation_ref) → register
+ *     DOES create a hook (the HTTP layer IS reached), and unregister DOES delete.
+ */
+
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { connectorSdkMock } from "./connector-sdk.mock";
+
+mock.module("@lobu/connector-sdk", connectorSdkMock);
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let GitHubConnector: any;
+
+beforeAll(async () => {
+	const mod = await import("../github");
+	GitHubConnector = mod.default;
+});
+
+/**
+ * Build a connector with `requestJson` (POST hook create) and `http.request`
+ * (DELETE hook) replaced by spies, so we can assert whether the per-connection
+ * provider call was reached without touching the network.
+ */
+function buildConnector() {
+	const connector = new GitHubConnector();
+	const requestJsonCalls: Array<Record<string, unknown>> = [];
+	const httpRequestCalls: Array<{ url: string }> = [];
+	// requestJson is the POST that creates the hook (returns { id }).
+	connector.requestJson = async (params: Record<string, unknown>) => {
+		requestJsonCalls.push(params);
+		return { id: 998877 };
+	};
+	// http.request is the DELETE that tears the hook down.
+	connector.http = {
+		request: async (url: string) => {
+			httpRequestCalls.push({ url });
+			return new Response(null, { status: 204 });
+		},
+	};
+	return { connector, requestJsonCalls, httpRequestCalls };
+}
+
+describe("GitHub webhook registration gate", () => {
+	test("app_installation connection (installation_ref set) → register is a no-op, no HTTP call", async () => {
+		const { connector, requestJsonCalls } = buildConnector();
+
+		const result = await connector.registerWebhook({
+			config: { installation_ref: 4242 },
+			credentials: null,
+			callbackUrl: "https://gw.test/api/v1/webhooks/1",
+		});
+
+		expect(result.externalId).toBe("");
+		expect(result.metadata?.delivery).toBe("app_installation");
+		expect(result.metadata?.noop).toBe(true);
+		// CRITICAL: the per-connection provider hook-create was NEVER reached.
+		expect(requestJsonCalls.length).toBe(0);
+	});
+
+	test("app_installation connection → unregister is a no-op, no HTTP call", async () => {
+		const { connector, httpRequestCalls } = buildConnector();
+
+		await connector.unregisterWebhook({
+			config: { installation_ref: "4242" },
+			credentials: null,
+			callbackUrl: "https://gw.test/api/v1/webhooks/1",
+			externalId: "should-be-ignored",
+		});
+
+		expect(httpRequestCalls.length).toBe(0);
+	});
+
+	test("OAuth/PAT connection (org target + token, no installation_ref) → register DOES create a hook", async () => {
+		const { connector, requestJsonCalls } = buildConnector();
+
+		const result = await connector.registerWebhook({
+			config: { org: "acme-co" },
+			credentials: { provider: "github", accessToken: "gho_oauth_token" },
+			callbackUrl: "https://gw.test/api/v1/webhooks/2",
+		});
+
+		// A real per-connection hook id came back from the (spied) provider call.
+		expect(result.externalId).toBe("998877");
+		expect(result.metadata?.scope).toBe("org");
+		// CRITICAL: the per-connection provider hook-create WAS reached exactly once,
+		// against the org hooks endpoint.
+		expect(requestJsonCalls.length).toBe(1);
+		expect(requestJsonCalls[0].url).toBe("https://api.github.com/orgs/acme-co/hooks");
+	});
+
+	test("OAuth/PAT connection → unregister DOES delete the per-connection hook", async () => {
+		const { connector, httpRequestCalls } = buildConnector();
+
+		await connector.unregisterWebhook({
+			config: { org: "acme-co" },
+			credentials: { provider: "github", accessToken: "gho_oauth_token" },
+			callbackUrl: "https://gw.test/api/v1/webhooks/2",
+			externalId: "55501",
+		});
+
+		// CRITICAL: the per-connection hook DELETE WAS reached, targeting the hook id.
+		expect(httpRequestCalls.length).toBe(1);
+		expect(httpRequestCalls[0].url).toBe(
+			"https://api.github.com/orgs/acme-co/hooks/55501",
+		);
+	});
+});

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -48,6 +48,15 @@ interface GitHubConfig {
   lookback_days?: number;
   labels_filter?: string[];
   env_overrides?: Record<string, unknown>;
+  /**
+   * `app_installations.id` when this connection is backed by the Lobu GitHub
+   * App (written by the install callback). Its presence — NOT the connector's
+   * static `webhook.delivery` — is what marks a connection as app-installation
+   * auth: webhook deliveries for those arrive on the shared App-level endpoint,
+   * so per-connection registerWebhook/unregisterWebhook are no-ops. OAuth/PAT
+   * connections carry no `installation_ref` and DO register per connection.
+   */
+  installation_ref?: number | string;
 }
 
 interface GitHubCheckpoint {
@@ -713,13 +722,35 @@ export default class GitHubConnector extends ConnectorRuntime {
     return null;
   }
 
+  /**
+   * Whether THIS connection resolves to GitHub App-installation auth — i.e. it
+   * was bound to an install row (`config.installation_ref`) or the gateway
+   * stamped an installation context onto the registration call. Gating the
+   * webhook no-op on this (not the connector's static `webhook.delivery`) is
+   * what keeps per-connection webhook registration working for the OAuth/PAT
+   * connections, which carry no installation_ref. App-backed connections get
+   * deliveries on the shared App-level endpoint instead, so there's no
+   * per-connection hook to create or tear down.
+   */
+  private isAppInstallationConnection(
+    ctx: WebhookRegistrationContext<GitHubConfig>
+  ): boolean {
+    if (ctx.installation) return true;
+    const ref = ctx.config?.installation_ref;
+    if (typeof ref === 'number') return Number.isFinite(ref);
+    if (typeof ref === 'string') return ref.trim().length > 0;
+    return false;
+  }
+
   async registerWebhook(
     ctx: WebhookRegistrationContext<GitHubConfig>
   ): Promise<WebhookRegistration> {
-    // App-installation delivery: the App-level webhook is provisioned once at
-    // install time, not per connection — so register is a no-op. The provider
-    // subscription already exists; there is no per-connection hook to create.
-    if (this.definition.webhook?.delivery === 'app_installation') {
+    // App-installation auth: the App-level webhook is provisioned once at install
+    // time, not per connection — so register is a no-op FOR THIS CONNECTION. Gate
+    // on the connection's resolved auth (installation_ref / installation ctx), NOT
+    // the connector's static webhook.delivery, so OAuth/PAT connections still
+    // register their own per-connection hook below.
+    if (this.isAppInstallationConnection(ctx)) {
       return { externalId: '', metadata: { delivery: 'app_installation', noop: true } };
     }
 
@@ -761,9 +792,11 @@ export default class GitHubConnector extends ConnectorRuntime {
   }
 
   async unregisterWebhook(ctx: WebhookRegistrationContext<GitHubConfig>): Promise<void> {
-    // App-installation delivery: nothing to tear down per connection — the
-    // App-level webhook is removed when the org uninstalls the App, not here.
-    if (this.definition.webhook?.delivery === 'app_installation') return;
+    // App-installation auth: nothing to tear down per connection — the App-level
+    // webhook is removed when the org uninstalls the App, not here. Gate on this
+    // connection's resolved auth, NOT the static webhook.delivery, so OAuth/PAT
+    // connections still tear down their own per-connection hook below.
+    if (this.isAppInstallationConnection(ctx)) return;
 
     const externalId = ctx.externalId;
     if (!externalId) return;

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -266,7 +266,13 @@ export default class GitHubConnector extends ConnectorRuntime {
           // by the install UI from the configured App slug; the user picks the
           // org/repos to grant during GitHub's install flow.
           installUrlTemplate: 'https://github.com/apps/{{app_slug}}/installations/new',
-          permissions: ['issues', 'pull_requests', 'contents', 'metadata', 'discussions'],
+          // NOTE: this permissions array is METADATA ONLY (declares what the App
+          // needs; it does not grant anything). 'members' (Organization → Members:
+          // read) is required by the install-callback org-admin check
+          // (GET /user/memberships/orgs/{org}). The LIVE GitHub App must ALSO be
+          // granted Organization → Members → Read in its settings (out-of-band,
+          // user action) or every real org admin's membership lookup 403s.
+          permissions: ['issues', 'pull_requests', 'contents', 'metadata', 'discussions', 'members'],
           events: ['issues', 'pull_request', 'issue_comment', 'discussion', 'discussion_comment'],
           required: false,
           description:

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -231,9 +231,38 @@ export default class GitHubConnector extends ConnectorRuntime {
       algorithm: 'sha256',
       signaturePrefix: 'sha256=',
       dedupeHeader: 'x-github-delivery',
+      // App-installation delivery: one App-level webhook is configured ONCE on
+      // the GitHub App (not per connection), and inbound deliveries route via
+      // the shared `/api/v1/app-webhooks/github` endpoint keyed on
+      // `installation.id`. In this mode registerWebhook/unregisterWebhook are
+      // no-ops (see those methods); per-connection hook creation is the
+      // OAuth/PAT fallback path's concern, gated by a configured repo/org target.
+      delivery: 'app_installation',
+      routingKeyPath: 'installation.id',
     },
     authSchema: {
+      // Precedence (design §4.5): app_installation (primary, org-scoped GitHub
+      // App) → oauth (user-scoped) → env_keys (deployment GITHUB_TOKEN fallback).
+      // The per-org oauth_app-profile requirement no longer applies to GitHub
+      // connect because app_installation is available — orgs install the App
+      // instead of hand-creating an OAuth app profile.
       methods: [
+        {
+          type: 'app_installation',
+          provider: 'github',
+          providerInstance: 'cloud',
+          appIdKey: 'GITHUB_APP_ID',
+          privateKeyKey: 'GITHUB_APP_PRIVATE_KEY',
+          // Install URL for the Lobu GitHub App. `{{app_slug}}` is substituted
+          // by the install UI from the configured App slug; the user picks the
+          // org/repos to grant during GitHub's install flow.
+          installUrlTemplate: 'https://github.com/apps/{{app_slug}}/installations/new',
+          permissions: ['issues', 'pull_requests', 'contents', 'metadata', 'discussions'],
+          events: ['issues', 'pull_request', 'issue_comment', 'discussion', 'discussion_comment'],
+          required: false,
+          description:
+            'Install the Lobu GitHub App on your org to grant tenant-scoped access (no per-connection token). Repo/issue/PR reads and write actions flow through the App installation.',
+        },
         {
           type: 'oauth',
           provider: 'github',
@@ -687,6 +716,13 @@ export default class GitHubConnector extends ConnectorRuntime {
   async registerWebhook(
     ctx: WebhookRegistrationContext<GitHubConfig>
   ): Promise<WebhookRegistration> {
+    // App-installation delivery: the App-level webhook is provisioned once at
+    // install time, not per connection — so register is a no-op. The provider
+    // subscription already exists; there is no per-connection hook to create.
+    if (this.definition.webhook?.delivery === 'app_installation') {
+      return { externalId: '', metadata: { delivery: 'app_installation', noop: true } };
+    }
+
     const token = this.resolveToken(ctx.credentials?.accessToken, ctx.config);
     if (!token) {
       throw new Error('GitHub webhook registration requires OAuth or GITHUB_TOKEN.');
@@ -725,6 +761,10 @@ export default class GitHubConnector extends ConnectorRuntime {
   }
 
   async unregisterWebhook(ctx: WebhookRegistrationContext<GitHubConfig>): Promise<void> {
+    // App-installation delivery: nothing to tear down per connection — the
+    // App-level webhook is removed when the org uninstalls the App, not here.
+    if (this.definition.webhook?.delivery === 'app_installation') return;
+
     const externalId = ctx.externalId;
     if (!externalId) return;
 

--- a/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
@@ -41,7 +41,12 @@ function ctxFor(organizationId: string, userId: string): ToolContext {
 	} as ToolContext;
 }
 
-/** Seed a connector whose PRIMARY auth method is app_installation (like github). */
+/**
+ * Seed a connector whose PRIMARY auth method is app_installation, with oauth +
+ * env_keys fallbacks — mirroring github's real schema (app_installation, oauth,
+ * env_keys). The fallbacks let the selection-aware guard be exercised: a create
+ * that targets oauth (auth_profile_slug) or env (config DEMO_TOKEN) must pass.
+ */
 async function seedAppInstallConnector(organizationId: string): Promise<void> {
 	await createTestConnectorDefinition({
 		key: CONNECTOR_KEY,
@@ -56,7 +61,14 @@ async function seedAppInstallConnector(organizationId: string): Promise<void> {
 					appIdKey: "DEMO_APP_ID",
 					privateKeyKey: "DEMO_APP_PRIVATE_KEY",
 				},
-				// A fallback method is present, but app_installation is PRIMARY.
+				{
+					type: "oauth",
+					provider: "github",
+					requiredScopes: ["read:user"],
+					clientIdKey: "DEMO_CLIENT_ID",
+					clientSecretKey: "DEMO_CLIENT_SECRET",
+					tokenUrl: "https://example.test/token",
+				},
 				{ type: "env_keys", fields: [{ key: "DEMO_TOKEN" }] },
 			],
 		},
@@ -167,5 +179,157 @@ describe("manage_connections — app_installation create guard", () => {
 		} else {
 			expect(await connectionCount(org.id)).toBe(1);
 		}
+	});
+});
+
+describe("manage_connections — app_installation guard is SELECTION-AWARE (regression)", () => {
+	/** Assert the create/connect was NOT rejected by the app-install guard. */
+	function expectGuardSkipped(res: unknown): void {
+		if (res && typeof res === "object" && "error" in res) {
+			// A later failure (e.g. missing OAuth profile) is fine — it must just NOT
+			// be the install-flow guidance the guard produces.
+			expect((res as { error: string }).error).not.toMatch(
+				/\/github\/app\/install/,
+			);
+		}
+		// No error at all is also a pass (guard skipped, create proceeded).
+	}
+
+	it("create WITH auth_profile_slug (oauth intent) is ALLOWED past the guard", async () => {
+		const org = await createTestOrganization({ name: "OAuth Profile Create Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "oauth-create",
+				display_name: "OAuth Create",
+				device_worker_id: null,
+				auth_profile_slug: "some-oauth-profile",
+			},
+			TEST_ENV,
+			ctx,
+		);
+		expectGuardSkipped(res);
+	});
+
+	it("connect WITH auth_profile_slug (oauth intent) is ALLOWED past the guard", async () => {
+		const org = await createTestOrganization({ name: "OAuth Profile Connect Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = await manageConnections(
+			{
+				action: "connect",
+				connector_key: CONNECTOR_KEY,
+				slug: "oauth-connect",
+				auth_profile_slug: "some-oauth-profile",
+			},
+			TEST_ENV,
+			ctx,
+		);
+		expectGuardSkipped(res);
+	});
+
+	it("create WITH env/PAT creds in config is ALLOWED past the guard", async () => {
+		const org = await createTestOrganization({ name: "PAT Create Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "pat-create",
+				display_name: "PAT Create",
+				device_worker_id: null,
+				// The connector's declared env field key — supplying it is env/PAT intent.
+				config: { DEMO_TOKEN: "ghp_xxx_personal_access_token" },
+			},
+			TEST_ENV,
+			ctx,
+		);
+		expectGuardSkipped(res);
+	});
+
+	it("create WITH app_auth_profile_slug is ALLOWED past the guard", async () => {
+		const org = await createTestOrganization({ name: "App Profile Create Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "appprofile-create",
+				display_name: "App Profile Create",
+				device_worker_id: null,
+				app_auth_profile_slug: "some-oauth-app",
+			},
+			TEST_ENV,
+			ctx,
+		);
+		expectGuardSkipped(res);
+	});
+
+	it("lobu-apply-style oauth create (auth_profile_slug, no installation_ref) is ALLOWED", async () => {
+		// `lobu apply` of a declared github oauth connection sends auth_profile_slug
+		// (createConnection in apply/client.ts). It must pass the guard (it did on
+		// origin/main — the over-broad guard broke it).
+		const org = await createTestOrganization({ name: "Apply OAuth Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "apply-oauth-conn",
+				display_name: "Apply OAuth Conn",
+				device_worker_id: null,
+				auth_profile_slug: "gh-oauth",
+				app_auth_profile_slug: "gh-oauth-app",
+			},
+			TEST_ENV,
+			ctx,
+		);
+		expectGuardSkipped(res);
+	});
+
+	it("STILL rejects: create with NO creds and NO installation_ref → install-flow guidance", async () => {
+		// The core intent must remain: a bare create (no auth intent) falls through
+		// to the app_installation primary and is rejected.
+		const org = await createTestOrganization({ name: "Bare Create Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "bare-create",
+				display_name: "Bare Create",
+				device_worker_id: null,
+			},
+			TEST_ENV,
+			ctx,
+		);
+		expect("error" in res).toBe(true);
+		expect((res as { error: string }).error).toMatch(/\/github\/app\/install/);
+		expect(await connectionCount(org.id)).toBe(0);
 	});
 });

--- a/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
@@ -1,0 +1,171 @@
+/**
+ * manage_connections create/connect guard: a connector whose PRIMARY auth method
+ * is `app_installation` (e.g. github) must NOT be created directly with no
+ * `installation_ref`. The only legitimate creator is the App install callback
+ * (`linkGithubAppInstallation`), which stamps `config.installation_ref`. A direct
+ * create with no ref would be a dead, unbound connection — so we reject it and
+ * point the user at the install flow.
+ *
+ * The guard is connector-agnostic (keys on the auth method type), so this seeds a
+ * generic `app_installation`-primary connector rather than github specifically.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import type { ToolContext } from "../../../tools/registry";
+import { manageConnections } from "../../../tools/admin/manage_connections";
+import { getTestDb } from "../../setup/test-db";
+import { initWorkspaceProvider } from "../../../workspace";
+import {
+	addUserToOrganization,
+	createTestConnectorDefinition,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const TEST_ENV = {} as Env;
+const CONNECTOR_KEY = "demo.appinstall.guard";
+
+function ctxFor(organizationId: string, userId: string): ToolContext {
+	return {
+		organizationId,
+		userId,
+		memberRole: "owner",
+		agentId: null,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+	} as ToolContext;
+}
+
+/** Seed a connector whose PRIMARY auth method is app_installation (like github). */
+async function seedAppInstallConnector(organizationId: string): Promise<void> {
+	await createTestConnectorDefinition({
+		key: CONNECTOR_KEY,
+		name: "Demo App Install Guard",
+		organization_id: organizationId,
+		auth_schema: {
+			methods: [
+				{
+					type: "app_installation",
+					provider: "github",
+					providerInstance: "cloud",
+					appIdKey: "DEMO_APP_ID",
+					privateKeyKey: "DEMO_APP_PRIVATE_KEY",
+				},
+				// A fallback method is present, but app_installation is PRIMARY.
+				{ type: "env_keys", fields: [{ key: "DEMO_TOKEN" }] },
+			],
+		},
+		feeds_schema: { items: {} },
+	});
+}
+
+async function connectionCount(organizationId: string): Promise<number> {
+	const sql = getTestDb();
+	const rows = (await sql`
+		SELECT count(*)::int AS n FROM connections
+		WHERE organization_id = ${organizationId}
+			AND connector_key = ${CONNECTOR_KEY}
+			AND deleted_at IS NULL
+	`) as unknown as Array<{ n: number }>;
+	return rows[0].n;
+}
+
+beforeAll(async () => {
+	await initWorkspaceProvider();
+});
+
+afterEach(async () => {
+	const sql = getTestDb();
+	await sql`DELETE FROM connections WHERE connector_key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM connector_definitions WHERE key = ${CONNECTOR_KEY}`;
+});
+
+describe("manage_connections — app_installation create guard", () => {
+	it("create with NO installation_ref is rejected with install-flow guidance, no row written", async () => {
+		const org = await createTestOrganization({ name: "App Install Guard Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "should-not-exist",
+				display_name: "Should Not Exist",
+				device_worker_id: null,
+			},
+			TEST_ENV,
+			ctx,
+		);
+
+		expect("error" in res).toBe(true);
+		const err = (res as { error: string }).error;
+		expect(err).toMatch(/install/i);
+		expect(err).toMatch(/\/github\/app\/install/);
+		// Zero rows created.
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("connect with NO installation_ref is also rejected (same guard, connect path)", async () => {
+		const org = await createTestOrganization({ name: "App Install Connect Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = await manageConnections(
+			{
+				action: "connect",
+				connector_key: CONNECTOR_KEY,
+				slug: "should-not-exist-connect",
+			},
+			TEST_ENV,
+			ctx,
+		);
+
+		expect("error" in res).toBe(true);
+		expect((res as { error: string }).error).toMatch(/\/github\/app\/install/);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("create WITH installation_ref in config is allowed past the guard (the callback's shape)", async () => {
+		// The install callback creates the connection with config.installation_ref
+		// set. The guard must NOT block that shape — it should pass through (any
+		// later failure is unrelated to this guard).
+		const org = await createTestOrganization({ name: "App Install Bound Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "bound-conn",
+				display_name: "Bound Conn",
+				device_worker_id: null,
+				config: { installation_ref: 12345 },
+			},
+			TEST_ENV,
+			ctx,
+		);
+
+		// The guard did not reject it: either it created the row, or it failed for
+		// some OTHER reason — but NOT with the install-flow guidance.
+		if ("error" in res) {
+			expect((res as { error: string }).error).not.toMatch(
+				/\/github\/app\/install/,
+			);
+		} else {
+			expect(await connectionCount(org.id)).toBe(1);
+		}
+	});
+});

--- a/packages/server/src/__tests__/integration/connectors/app-installation-credential.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/app-installation-credential.test.ts
@@ -354,6 +354,62 @@ describe("app-installation credential — tenancy + shape guards", () => {
 		expect(event?.metadata?.method_provider).toBe("github");
 	});
 
+	it("SECURITY: after a cross-org TRANSFER the losing org's suspended install NEVER mints", async () => {
+		const orgA = await createTestOrganization({ name: "Losing Org A" });
+		const orgB = await createTestOrganization({ name: "Winning Org B" });
+		const store = createPostgresAppInstallationStore();
+
+		// Org A installs first (active) for tenant T.
+		const aInstall = await store.upsert({
+			organizationId: orgA.id,
+			provider: PROVIDER,
+			providerInstance: PROVIDER_INSTANCE,
+			providerAppId: "demo-app",
+			externalTenantId: "transfer-tenant",
+			status: "active",
+		});
+		// Org A's connection points at A's install row.
+		const { connectionId } = await seedAppInstallConnection({
+			organizationId: orgA.id,
+			installationRef: aInstall.id,
+		});
+
+		// Sanity: while A's install is active, A mints fine.
+		const before = await resolveExecutionAuth({
+			organizationId: orgA.id,
+			connectionId,
+			credentialDb: getDb(),
+		});
+		expect(before.credentials).not.toBeNull();
+		expect(spy.mintCalls).toHaveLength(1);
+
+		// Org B re-installs the SAME tenant → transfer: A's row is demoted to
+		// 'suspended', B gets a new active row. A's connection still points at A's
+		// now-suspended row.
+		const bInstall = await store.upsert({
+			organizationId: orgB.id,
+			provider: PROVIDER,
+			providerInstance: PROVIDER_INSTANCE,
+			providerAppId: "demo-app",
+			externalTenantId: "transfer-tenant",
+			status: "active",
+		});
+		expect(bInstall.id).not.toBe(aInstall.id);
+		const aAfter = await store.getById(aInstall.id);
+		expect(aAfter?.status).toBe("suspended");
+
+		// Now the losing org A resolves its connection → the install is suspended →
+		// NULL credentials and the provider is NEVER asked to mint again.
+		spy.mintCalls = [];
+		const after = await resolveExecutionAuth({
+			organizationId: orgA.id,
+			connectionId,
+			credentialDb: getDb(),
+		});
+		expect(after.credentials).toBeNull();
+		expect(spy.mintCalls).toHaveLength(0);
+	});
+
 	it("method that omits providerInstance defaults to 'cloud' and rejects a non-cloud install", async () => {
 		const org = await createTestOrganization({ name: "Omit Instance Org" });
 		// Install lives on a self-hosted (non-cloud) instance...

--- a/packages/server/src/__tests__/integration/connectors/app-installation-credential.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/app-installation-credential.test.ts
@@ -64,6 +64,40 @@ class SpyInstallationTokenProvider implements InstallationTokenProvider {
 
 let spy: SpyInstallationTokenProvider;
 
+/** A `guardrail-trip` audit row written by the tenancy guard (subset we assert). */
+interface TenancyTripEventRow {
+	semantic_type: string;
+	origin_type: string | null;
+	metadata: Record<string, unknown>;
+}
+
+/**
+ * The tenancy audit write is fire-and-forget (best-effort, never blocks
+ * resolution), so the row may land just after `resolveExecutionAuth` returns.
+ * Poll briefly for the guardrail-trip row scoped to this org + connection.
+ */
+async function waitForTenancyTripEvent(
+	sql: ReturnType<typeof getTestDb>,
+	organizationId: string,
+	connectionId: number,
+): Promise<TenancyTripEventRow | null> {
+	for (let attempt = 0; attempt < 40; attempt++) {
+		const rows = (await sql`
+			SELECT semantic_type, origin_type, metadata
+			FROM events
+			WHERE organization_id = ${organizationId}
+				AND semantic_type = 'guardrail-trip'
+				AND origin_type = 'guardrail-app-installation'
+				AND (metadata ->> 'connection_id') = ${String(connectionId)}
+			ORDER BY id DESC
+			LIMIT 1
+		`) as unknown as TenancyTripEventRow[];
+		if (rows.length > 0) return rows[0];
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+	return null;
+}
+
 /**
  * Create a per-org connector definition declaring an `app_installation` auth
  * method, plus a connection in that org. `installationRef` is what we write into
@@ -252,6 +286,72 @@ describe("app-installation credential — tenancy + shape guards", () => {
 
 		expect(resolved.credentials).toBeNull();
 		expect(spy.mintCalls).toHaveLength(0);
+	});
+
+	it("AUDIT: a cross-tenant rejection emits a guardrail-trip event (security signal)", async () => {
+		const orgA = await createTestOrganization({ name: "Audit Attacker Org" });
+		const orgB = await createTestOrganization({ name: "Audit Victim Org" });
+
+		const victimInstall = await seedInstall({
+			organizationId: orgB.id,
+			externalTenantId: "audit-victim-tenant",
+		});
+		const { connectionId } = await seedAppInstallConnection({
+			organizationId: orgA.id,
+			installationRef: victimInstall.id,
+		});
+
+		const resolved = await resolveExecutionAuth({
+			organizationId: orgA.id,
+			connectionId,
+			credentialDb: getDb(),
+		});
+		expect(resolved.credentials).toBeNull();
+		expect(spy.mintCalls).toHaveLength(0);
+
+		// The audit write is best-effort/fire-and-forget — poll for the row.
+		const sql = getTestDb();
+		const event = await waitForTenancyTripEvent(sql, orgA.id, connectionId);
+		expect(event).not.toBeNull();
+		expect(event?.semantic_type).toBe("guardrail-trip");
+		expect(event?.metadata?.guardrail).toBe("app-installation-tenancy");
+		expect(event?.metadata?.reason).toBe("cross_tenant_org");
+		expect(String(event?.metadata?.install_id)).toBe(String(victimInstall.id));
+		expect(event?.metadata?.install_org).toBe(orgB.id);
+		// The audit row is left in place — `events` is append-only and the row is
+		// scoped to a throwaway test org, so it can't leak into other suites' asserts.
+	});
+
+	it("AUDIT: a provider/instance mismatch emits a guardrail-trip event", async () => {
+		const org = await createTestOrganization({ name: "Audit Mismatch Org" });
+		// Install is 'slack'; the connector method declares 'github'.
+		const install = await seedInstall({
+			organizationId: org.id,
+			provider: "slack",
+			providerInstance: PROVIDER_INSTANCE,
+			externalTenantId: "audit-slack-tenant",
+		});
+		const { connectionId } = await seedAppInstallConnection({
+			organizationId: org.id,
+			installationRef: install.id,
+			provider: PROVIDER,
+			providerInstance: PROVIDER_INSTANCE,
+		});
+
+		const resolved = await resolveExecutionAuth({
+			organizationId: org.id,
+			connectionId,
+			credentialDb: getDb(),
+		});
+		expect(resolved.credentials).toBeNull();
+		expect(spy.mintCalls).toHaveLength(0);
+
+		const sql = getTestDb();
+		const event = await waitForTenancyTripEvent(sql, org.id, connectionId);
+		expect(event).not.toBeNull();
+		expect(event?.metadata?.reason).toBe("provider_instance_mismatch");
+		expect(event?.metadata?.install_provider).toBe("slack");
+		expect(event?.metadata?.method_provider).toBe("github");
 	});
 
 	it("method that omits providerInstance defaults to 'cloud' and rejects a non-cloud install", async () => {

--- a/packages/server/src/__tests__/integration/connectors/github-app-install-callback.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-app-install-callback.test.ts
@@ -1,0 +1,163 @@
+/**
+ * GitHub App install callback (app-installation design §4.4, PR5).
+ *
+ * `linkGithubAppInstallation` is the callback's pure core: given an org + a
+ * GitHub `installation_id`, it must
+ *   1. upsert an active `app_installations` row for the tenant tuple, and
+ *   2. create (or relink) the org's `github` connector connection with
+ *      `config.installation_ref` = the install id — the shape
+ *      resolveExecutionAuth reads to mint a tenant-scoped token.
+ *
+ * It must be idempotent: a re-install / callback retry reuses the existing
+ * install + connection instead of duplicating either.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "../../../db/client";
+import { linkGithubAppInstallation } from "../../../gateway/routes/public/app-install";
+import { createPostgresAppInstallationStore } from "../../../lobu/stores/app-installation-store";
+import { getTestDb } from "../../setup/test-db";
+import { initWorkspaceProvider } from "../../../workspace";
+import {
+	createTestConnectorDefinition,
+	createTestOrganization,
+} from "../../setup/test-fixtures";
+
+const CONNECTOR_KEY = "github";
+const PROVIDER_APP_ID = "test-github-app";
+
+async function seedGithubConnector(organizationId: string): Promise<void> {
+	await createTestConnectorDefinition({
+		key: CONNECTOR_KEY,
+		name: "GitHub",
+		organization_id: organizationId,
+		auth_schema: {
+			methods: [
+				{
+					type: "app_installation",
+					provider: "github",
+					providerInstance: "cloud",
+					appIdKey: "GITHUB_APP_ID",
+					privateKeyKey: "GITHUB_APP_PRIVATE_KEY",
+				},
+			],
+		},
+		feeds_schema: { issues: {} },
+	});
+}
+
+beforeAll(async () => {
+	await initWorkspaceProvider();
+});
+
+beforeEach(async () => {
+	// Keep the shared DB clean across runs of this suite.
+	const sql = getTestDb();
+	await sql`DELETE FROM connections WHERE connector_key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM connector_definitions WHERE key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM app_installations WHERE provider_app_id = ${PROVIDER_APP_ID}`;
+});
+
+afterEach(async () => {
+	const sql = getTestDb();
+	await sql`DELETE FROM connections WHERE connector_key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM connector_definitions WHERE key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM app_installations WHERE provider_app_id = ${PROVIDER_APP_ID}`;
+});
+
+describe("GitHub App install callback — link installation", () => {
+	it("install: writes an active app_installations row + a connection bound to it", async () => {
+		const org = await createTestOrganization({ name: "Installer Org" });
+		await seedGithubConnector(org.id);
+		const store = createPostgresAppInstallationStore();
+
+		const result = await linkGithubAppInstallation({
+			organizationId: org.id,
+			installationId: "9001",
+			store,
+			providerAppId: PROVIDER_APP_ID,
+			metadata: { account_login: "acme-co" },
+		});
+
+		expect(result.createdConnection).toBe(true);
+		expect(result.installId).toBeGreaterThan(0);
+		expect(result.connectionId).toBeGreaterThan(0);
+		expect(result.accountLogin).toBe("acme-co");
+
+		// app_installations row: active, github/cloud, external_tenant_id = installation_id.
+		const install = await store.getById(result.installId);
+		expect(install).not.toBeNull();
+		expect(install?.organizationId).toBe(org.id);
+		expect(install?.provider).toBe("github");
+		expect(install?.providerInstance).toBe("cloud");
+		expect(install?.providerAppId).toBe(PROVIDER_APP_ID);
+		expect(install?.externalTenantId).toBe("9001");
+		expect(install?.status).toBe("active");
+		expect(install?.metadata?.account_login).toBe("acme-co");
+
+		// Resolvable as the active install for its tenant tuple (the webhook router's lookup).
+		const active = await store.resolveActiveByTenant({
+			provider: "github",
+			providerInstance: "cloud",
+			providerAppId: PROVIDER_APP_ID,
+			externalTenantId: "9001",
+		});
+		expect(active?.id).toBe(result.installId);
+
+		// connection: github connector, active, config.installation_ref = install id.
+		const sql = getDb();
+		const rows = (await sql`
+			SELECT connector_key, status, config
+			FROM connections
+			WHERE id = ${result.connectionId} AND organization_id = ${org.id}
+			LIMIT 1
+		`) as unknown as Array<{
+			connector_key: string;
+			status: string;
+			config: Record<string, unknown> | null;
+		}>;
+		expect(rows).toHaveLength(1);
+		expect(rows[0].connector_key).toBe("github");
+		expect(rows[0].status).toBe("active");
+		expect(Number(rows[0].config?.installation_ref)).toBe(result.installId);
+	});
+
+	it("idempotent: a re-install for the same org+installation reuses the install + connection", async () => {
+		const org = await createTestOrganization({ name: "Reinstall Org" });
+		await seedGithubConnector(org.id);
+		const store = createPostgresAppInstallationStore();
+
+		const first = await linkGithubAppInstallation({
+			organizationId: org.id,
+			installationId: "9100",
+			store,
+			providerAppId: PROVIDER_APP_ID,
+			metadata: { account_login: "reinstaller" },
+		});
+		const second = await linkGithubAppInstallation({
+			organizationId: org.id,
+			installationId: "9100",
+			store,
+			providerAppId: PROVIDER_APP_ID,
+			metadata: { account_login: "reinstaller" },
+		});
+
+		// Same install row (same-org reinstall refreshes in place), no duplicate connection.
+		expect(second.installId).toBe(first.installId);
+		expect(second.connectionId).toBe(first.connectionId);
+		expect(second.createdConnection).toBe(false);
+
+		const sql = getDb();
+		const connCount = (await sql`
+			SELECT count(*)::int AS n FROM connections
+			WHERE organization_id = ${org.id} AND connector_key = 'github' AND deleted_at IS NULL
+		`) as unknown as Array<{ n: number }>;
+		expect(connCount[0].n).toBe(1);
+
+		const installCount = (await sql`
+			SELECT count(*)::int AS n FROM app_installations
+			WHERE provider_app_id = ${PROVIDER_APP_ID} AND external_tenant_id = '9100'
+		`) as unknown as Array<{ n: number }>;
+		expect(installCount[0].n).toBe(1);
+	});
+});

--- a/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
@@ -54,11 +54,31 @@ async function seedGithubConnector(organizationId: string): Promise<void> {
 	});
 }
 
-/** Build the install router; `resolveInstallOrgId` is fixed for the start route. */
-function buildRouter(installOrgId: string | null) {
+/**
+ * Build the install router. The two GitHub HTTP calls (OAuth code exchange +
+ * `/user/installations`) are mocked via DI so tests NEVER hit real GitHub.
+ *  - `ownedInstallationIds`: the set the (mocked) `/user/installations` returns.
+ *    Pass `null` to simulate a GitHub fetch failure.
+ *  - `exchangeReturns`: the user token the (mocked) code exchange yields; `null`
+ *    simulates a failed exchange. Defaults to a fake token.
+ */
+function buildRouter(
+	installOrgId: string | null,
+	opts: {
+		ownedInstallationIds?: number[] | null;
+		exchangeReturns?: string | null;
+	} = {},
+) {
+	const exchangeReturns =
+		opts.exchangeReturns === undefined ? "fake-user-token" : opts.exchangeReturns;
+	const owned =
+		opts.ownedInstallationIds === undefined ? [] : opts.ownedInstallationIds;
 	const deps: AppInstallRouterDeps = {
 		installationStore: createPostgresAppInstallationStore(),
 		resolveInstallOrgId: async () => installOrgId,
+		exchangeInstallOAuthCode: async () => exchangeReturns,
+		fetchUserInstallationIds: async () =>
+			owned === null ? null : new Set(owned),
 	};
 	return createAppInstallRoutes(deps);
 }
@@ -84,8 +104,22 @@ async function installCount(organizationId: string): Promise<number> {
 	return rows[0].n;
 }
 
-const ORIGINAL_APP_ID = process.env.GITHUB_APP_ID;
-const ORIGINAL_APP_SLUG = process.env.GITHUB_APP_SLUG;
+const ENV_KEYS = [
+	"GITHUB_APP_ID",
+	"GITHUB_APP_SLUG",
+	"GITHUB_APP_CLIENT_ID",
+	"GITHUB_APP_CLIENT_SECRET",
+] as const;
+const ORIGINAL_ENV: Record<string, string | undefined> = {};
+for (const k of ENV_KEYS) ORIGINAL_ENV[k] = process.env[k];
+
+async function cleanTables(): Promise<void> {
+	const sql = getTestDb();
+	await sql`DELETE FROM connections WHERE connector_key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM connector_definitions WHERE key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM app_installations WHERE provider_app_id = ${PROVIDER_APP_ID}`;
+	await sql`DELETE FROM oauth_states WHERE scope = 'github:app_install:state'`;
+}
 
 beforeAll(async () => {
 	await initWorkspaceProvider();
@@ -94,23 +128,19 @@ beforeAll(async () => {
 beforeEach(async () => {
 	process.env.GITHUB_APP_ID = PROVIDER_APP_ID;
 	process.env.GITHUB_APP_SLUG = APP_SLUG;
-	const sql = getTestDb();
-	await sql`DELETE FROM connections WHERE connector_key = ${CONNECTOR_KEY}`;
-	await sql`DELETE FROM connector_definitions WHERE key = ${CONNECTOR_KEY}`;
-	await sql`DELETE FROM app_installations WHERE provider_app_id = ${PROVIDER_APP_ID}`;
-	await sql`DELETE FROM oauth_states WHERE scope = 'github:app_install:state'`;
+	// App OAuth creds present by default so ownership verification can run; the
+	// "unset" test deletes them explicitly.
+	process.env.GITHUB_APP_CLIENT_ID = "Iv-test-app-client-id";
+	process.env.GITHUB_APP_CLIENT_SECRET = "test-app-client-secret";
+	await cleanTables();
 });
 
 afterEach(async () => {
-	if (ORIGINAL_APP_ID === undefined) delete process.env.GITHUB_APP_ID;
-	else process.env.GITHUB_APP_ID = ORIGINAL_APP_ID;
-	if (ORIGINAL_APP_SLUG === undefined) delete process.env.GITHUB_APP_SLUG;
-	else process.env.GITHUB_APP_SLUG = ORIGINAL_APP_SLUG;
-	const sql = getTestDb();
-	await sql`DELETE FROM connections WHERE connector_key = ${CONNECTOR_KEY}`;
-	await sql`DELETE FROM connector_definitions WHERE key = ${CONNECTOR_KEY}`;
-	await sql`DELETE FROM app_installations WHERE provider_app_id = ${PROVIDER_APP_ID}`;
-	await sql`DELETE FROM oauth_states WHERE scope = 'github:app_install:state'`;
+	for (const k of ENV_KEYS) {
+		if (ORIGINAL_ENV[k] === undefined) delete process.env[k];
+		else process.env[k] = ORIGINAL_ENV[k];
+	}
+	await cleanTables();
 });
 
 describe("GitHub App install callback — signed-state CSRF guard", () => {
@@ -149,7 +179,7 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 		expect(await connectionCount(org.id)).toBe(0);
 	});
 
-	it("accepts a callback carrying a valid signed state and binds to the STATE's org", async () => {
+	it("accepts a callback with valid state + code + owned installation, binds to the STATE's org", async () => {
 		const stateOrg = await createTestOrganization({ name: "Initiator Org" });
 		const ambientOrg = await createTestOrganization({ name: "Ambient Other Org" });
 		await seedGithubConnector(stateOrg.id);
@@ -160,11 +190,12 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 		const state = await stateStore.create({ organizationId: stateOrg.id });
 
 		// The callback session resolves to a DIFFERENT (ambient) org — the install
-		// must STILL land in the state's org, never the ambient one.
-		const router = buildRouter(ambientOrg.id);
+		// must STILL land in the state's org, never the ambient one. The (mocked)
+		// /user/installations returns the supplied id, so ownership passes.
+		const router = buildRouter(ambientOrg.id, { ownedInstallationIds: [7003] });
 		const res = await router.fetch(
 			new Request(
-				`http://gw.test/github/app/install/callback?installation_id=7003&setup_action=install&state=${state}`,
+				`http://gw.test/github/app/install/callback?installation_id=7003&setup_action=install&state=${state}&code=valid-oauth-code`,
 			),
 		);
 
@@ -182,11 +213,11 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 		await seedGithubConnector(org.id);
 		const stateStore = createGithubInstallStateStore();
 		const state = await stateStore.create({ organizationId: org.id });
-		const router = buildRouter(org.id);
+		const router = buildRouter(org.id, { ownedInstallationIds: [7004] });
 
 		const first = await router.fetch(
 			new Request(
-				`http://gw.test/github/app/install/callback?installation_id=7004&setup_action=install&state=${state}`,
+				`http://gw.test/github/app/install/callback?installation_id=7004&setup_action=install&state=${state}&code=valid-oauth-code`,
 			),
 		);
 		expect(first.status).toBe(200);
@@ -196,7 +227,7 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 		// Replay the SAME state — it was consumed, so this is rejected.
 		const replay = await router.fetch(
 			new Request(
-				`http://gw.test/github/app/install/callback?installation_id=7004&setup_action=install&state=${state}`,
+				`http://gw.test/github/app/install/callback?installation_id=7004&setup_action=install&state=${state}&code=valid-oauth-code`,
 			),
 		);
 		expect(replay.status).toBe(400);
@@ -222,5 +253,124 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 		// The minted state resolves to the org server-side (Postgres-backed nonce).
 		const peeked = await createGithubInstallStateStore().peek(minted as string);
 		expect(peeked?.organizationId).toBe(org.id);
+	});
+});
+
+describe("GitHub App install callback — installation ownership guard", () => {
+	it("ATTACKER: valid state + code, but installation_id NOT in /user/installations → 403, zero mutation", async () => {
+		// Attacker has their own valid state (their own org A) and a code that
+		// exchanges fine — but supplies a VICTIM's installation_id that the
+		// attacker's GitHub account does not administer.
+		const attackerOrg = await createTestOrganization({ name: "Attacker Org" });
+		await seedGithubConnector(attackerOrg.id);
+		const state = await createGithubInstallStateStore().create({
+			organizationId: attackerOrg.id,
+		});
+		// /user/installations returns only the attacker's OWN installs (e.g. 555),
+		// NOT the victim id 8888 they're trying to steal.
+		const router = buildRouter(attackerOrg.id, { ownedInstallationIds: [555] });
+
+		const res = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=8888&setup_action=install&state=${state}&code=valid-oauth-code`,
+			),
+		);
+
+		expect(res.status).toBe(403);
+		// CRITICAL: no install/connection written for the foreign installation_id.
+		expect(await installCount(attackerOrg.id)).toBe(0);
+		expect(await connectionCount(attackerOrg.id)).toBe(0);
+	});
+
+	it("LEGIT: valid state + code + installation_id IS owned → 200, binds install + connection", async () => {
+		const org = await createTestOrganization({ name: "Legit Owner Org" });
+		await seedGithubConnector(org.id);
+		const state = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+		const router = buildRouter(org.id, { ownedInstallationIds: [4242, 999] });
+
+		const res = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=4242&setup_action=install&state=${state}&code=valid-oauth-code`,
+			),
+		);
+
+		expect(res.status).toBe(200);
+		expect(await installCount(org.id)).toBe(1);
+		expect(await connectionCount(org.id)).toBe(1);
+		// The bound install carries the owned installation id (mint path reads this).
+		const sql = getDb();
+		const rows = (await sql`
+			SELECT external_tenant_id FROM app_installations
+			WHERE organization_id = ${org.id} AND provider_app_id = ${PROVIDER_APP_ID}
+			LIMIT 1
+		`) as unknown as Array<{ external_tenant_id: string }>;
+		expect(rows[0].external_tenant_id).toBe("4242");
+	});
+
+	it("MISSING code → 400, zero mutation (ownership cannot be verified without it)", async () => {
+		const org = await createTestOrganization({ name: "NoCode Org" });
+		await seedGithubConnector(org.id);
+		const state = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+		// Even though the (mocked) ownership set WOULD contain the id, the absence
+		// of `code` must reject before any exchange/lookup.
+		const router = buildRouter(org.id, { ownedInstallationIds: [7777] });
+
+		const res = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=7777&setup_action=install&state=${state}`,
+			),
+		);
+
+		expect(res.status).toBe(400);
+		expect(await installCount(org.id)).toBe(0);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("GITHUB_APP_CLIENT_ID/SECRET unset → 503, zero mutation (fail safe)", async () => {
+		delete process.env.GITHUB_APP_CLIENT_ID;
+		delete process.env.GITHUB_APP_CLIENT_SECRET;
+		const org = await createTestOrganization({ name: "NoOAuthCreds Org" });
+		await seedGithubConnector(org.id);
+		const state = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+		const router = buildRouter(org.id, { ownedInstallationIds: [6001] });
+
+		const res = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=6001&setup_action=install&state=${state}&code=valid-oauth-code`,
+			),
+		);
+
+		expect(res.status).toBe(503);
+		expect(await installCount(org.id)).toBe(0);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("a failed OAuth code exchange → 403, zero mutation", async () => {
+		const org = await createTestOrganization({ name: "BadCode Org" });
+		await seedGithubConnector(org.id);
+		const state = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+		// Exchange returns null (bad_verification_code) → cannot prove identity.
+		const router = buildRouter(org.id, {
+			ownedInstallationIds: [5005],
+			exchangeReturns: null,
+		});
+
+		const res = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=5005&setup_action=install&state=${state}&code=stale-or-forged-code`,
+			),
+		);
+
+		expect(res.status).toBe(403);
+		expect(await installCount(org.id)).toBe(0);
+		expect(await connectionCount(org.id)).toBe(0);
 	});
 });

--- a/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
@@ -54,31 +54,65 @@ async function seedGithubConnector(organizationId: string): Promise<void> {
 	});
 }
 
+/** A mocked GitHub account that owns an installation the authed user can see. */
+type MockAccount = { login: string; type: "User" | "Organization" };
+
 /**
- * Build the install router. The two GitHub HTTP calls (OAuth code exchange +
- * `/user/installations`) are mocked via DI so tests NEVER hit real GitHub.
- *  - `ownedInstallationIds`: the set the (mocked) `/user/installations` returns.
- *    Pass `null` to simulate a GitHub fetch failure.
- *  - `exchangeReturns`: the user token the (mocked) code exchange yields; `null`
- *    simulates a failed exchange. Defaults to a fake token.
+ * Build the install router. ALL GitHub HTTP calls (OAuth code exchange,
+ * `/user/installations`, `/user`, `/user/memberships/orgs/{org}`) are mocked via
+ * DI so tests NEVER hit real GitHub. Options:
+ *  - `installations`: map of installation_id → owning account the (mocked)
+ *    `/user/installations` reports. Pass `null` to simulate an HTTP failure
+ *    (returns undefined → "cannot verify").
+ *  - `authedLogin`: the login `/user` returns (defaults to "installer-user").
+ *  - `orgRoles`: map of org-login → membership `{state, role}` returned by
+ *    `/user/memberships/orgs/{org}`. Missing org → non-member (state:none).
+ *    Pass `null` to simulate an HTTP failure for the membership call.
+ *  - `exchangeReturns`: user token the (mocked) exchange yields; `null` =
+ *    failed exchange. Defaults to a fake token.
+ *  - `ownedInstallationIds` (shorthand): personal-account installs owned by
+ *    `authedLogin` — convenience for the simpler cases.
  */
 function buildRouter(
 	installOrgId: string | null,
 	opts: {
-		ownedInstallationIds?: number[] | null;
+		installations?: Record<number, MockAccount> | null;
+		ownedInstallationIds?: number[];
+		authedLogin?: string;
+		orgRoles?: Record<string, { state: string; role: string }> | null;
 		exchangeReturns?: string | null;
 	} = {},
 ) {
 	const exchangeReturns =
 		opts.exchangeReturns === undefined ? "fake-user-token" : opts.exchangeReturns;
-	const owned =
-		opts.ownedInstallationIds === undefined ? [] : opts.ownedInstallationIds;
+	const authedLogin = opts.authedLogin ?? "installer-user";
+
+	// Resolve the installations map: explicit `installations`, else the
+	// `ownedInstallationIds` shorthand (personal installs owned by authedLogin).
+	const installations: Record<number, MockAccount> | null =
+		opts.installations !== undefined
+			? opts.installations
+			: Object.fromEntries(
+					(opts.ownedInstallationIds ?? []).map((id) => [
+						id,
+						{ login: authedLogin, type: "User" as const },
+					]),
+				);
+
 	const deps: AppInstallRouterDeps = {
 		installationStore: createPostgresAppInstallationStore(),
 		resolveInstallOrgId: async () => installOrgId,
 		exchangeInstallOAuthCode: async () => exchangeReturns,
-		fetchUserInstallationIds: async () =>
-			owned === null ? null : new Set(owned),
+		fetchInstallationAccount: async (_token, installationId) => {
+			if (installations === null) return undefined; // HTTP failure
+			const acct = installations[installationId];
+			return acct ? acct : null; // null = not in the user's set
+		},
+		fetchAuthedUserLogin: async () => authedLogin,
+		fetchOrgMembershipRole: async (_token, org) => {
+			if (opts.orgRoles === null) return undefined; // HTTP failure
+			return opts.orgRoles?.[org] ?? { state: "none", role: "none" };
+		},
 	};
 	return createAppInstallRoutes(deps);
 }
@@ -372,5 +406,168 @@ describe("GitHub App install callback — installation ownership guard", () => {
 		expect(res.status).toBe(403);
 		expect(await installCount(org.id)).toBe(0);
 		expect(await connectionCount(org.id)).toBe(0);
+	});
+});
+
+describe("GitHub App install callback — account-ownership (admin vs member)", () => {
+	// Helper: drive a callback for an org-account installation with a given
+	// membership role for the authed user.
+	async function runOrgInstall(opts: {
+		installationId: number;
+		orgLogin: string;
+		role: { state: string; role: string } | null; // null → membership HTTP fail
+	}) {
+		const org = await createTestOrganization({ name: "Org Install Tenant" });
+		await seedGithubConnector(org.id);
+		const state = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+		const router = buildRouter(org.id, {
+			installations: {
+				[opts.installationId]: { login: opts.orgLogin, type: "Organization" },
+			},
+			orgRoles:
+				opts.role === null ? null : { [opts.orgLogin]: opts.role },
+		});
+		const res = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=${opts.installationId}&setup_action=install&state=${state}&code=valid-oauth-code`,
+			),
+		);
+		return { org, res };
+	}
+
+	it("ORG install + user role 'admin' (active) → 200, binds", async () => {
+		const { org, res } = await runOrgInstall({
+			installationId: 3001,
+			orgLogin: "acme-org",
+			role: { state: "active", role: "admin" },
+		});
+		expect(res.status).toBe(200);
+		expect(await installCount(org.id)).toBe(1);
+		expect(await connectionCount(org.id)).toBe(1);
+	});
+
+	it("ORG install + user role 'member' (active) → 403, zero mutation (the blocker case)", async () => {
+		// A non-admin member can SEE the org's installation via /user/installations
+		// but MUST NOT be able to bind it. This is the membership-≠-admin hole.
+		const { org, res } = await runOrgInstall({
+			installationId: 3002,
+			orgLogin: "victim-org",
+			role: { state: "active", role: "member" },
+		});
+		expect(res.status).toBe(403);
+		expect(await installCount(org.id)).toBe(0);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("ORG install + membership state not active (pending admin) → 403, zero mutation", async () => {
+		const { org, res } = await runOrgInstall({
+			installationId: 3003,
+			orgLogin: "pending-org",
+			role: { state: "pending", role: "admin" },
+		});
+		expect(res.status).toBe(403);
+		expect(await installCount(org.id)).toBe(0);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("ORG install + membership lookup fails → 403, zero mutation (cannot verify)", async () => {
+		const { org, res } = await runOrgInstall({
+			installationId: 3004,
+			orgLogin: "unreachable-org",
+			role: null,
+		});
+		expect(res.status).toBe(403);
+		expect(await installCount(org.id)).toBe(0);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("USER (personal) install + authedLogin === account.login → 200, binds", async () => {
+		const org = await createTestOrganization({ name: "Personal Owner Org" });
+		await seedGithubConnector(org.id);
+		const state = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+		const router = buildRouter(org.id, {
+			authedLogin: "Octocat",
+			installations: {
+				4100: { login: "octocat", type: "User" }, // case-insensitive match
+			},
+		});
+		const res = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=4100&setup_action=install&state=${state}&code=valid-oauth-code`,
+			),
+		);
+		expect(res.status).toBe(200);
+		expect(await installCount(org.id)).toBe(1);
+		expect(await connectionCount(org.id)).toBe(1);
+	});
+
+	it("USER install + authedLogin !== account.login → 403, zero mutation", async () => {
+		const org = await createTestOrganization({ name: "Wrong Personal Org" });
+		await seedGithubConnector(org.id);
+		const state = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+		// The user can SEE this personal install (collaborator) but does not OWN it.
+		const router = buildRouter(org.id, {
+			authedLogin: "attacker",
+			installations: {
+				4200: { login: "victim", type: "User" },
+			},
+		});
+		const res = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=4200&setup_action=install&state=${state}&code=valid-oauth-code`,
+			),
+		);
+		expect(res.status).toBe(403);
+		expect(await installCount(org.id)).toBe(0);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+});
+
+describe("GitHub App install callback — connection creation is race-safe", () => {
+	it("two parallel callbacks for the same install create exactly one connection", async () => {
+		const org = await createTestOrganization({ name: "Concurrency Org" });
+		await seedGithubConnector(org.id);
+		const installationId = 5150;
+
+		// Two independent routers (two pods), each with its own valid single-use
+		// state, racing the SAME installation. The advisory-lock-wrapped
+		// find-or-create must converge to one connection.
+		const stateA = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+		const stateB = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+		const routerA = buildRouter(org.id, {
+			ownedInstallationIds: [installationId],
+		});
+		const routerB = buildRouter(org.id, {
+			ownedInstallationIds: [installationId],
+		});
+
+		const [resA, resB] = await Promise.all([
+			routerA.fetch(
+				new Request(
+					`http://gw.test/github/app/install/callback?installation_id=${installationId}&setup_action=install&state=${stateA}&code=valid-oauth-code`,
+				),
+			),
+			routerB.fetch(
+				new Request(
+					`http://gw.test/github/app/install/callback?installation_id=${installationId}&setup_action=install&state=${stateB}&code=valid-oauth-code`,
+				),
+			),
+		]);
+
+		expect(resA.status).toBe(200);
+		expect(resB.status).toBe(200);
+		// Exactly one connection and one active install despite the race.
+		expect(await connectionCount(org.id)).toBe(1);
+		expect(await installCount(org.id)).toBe(1);
 	});
 });

--- a/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
@@ -233,6 +233,46 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 		expect(await connectionCount(org.id)).toBe(0);
 	});
 
+	it("rejects a callback with a MISSING setup_action → 400, zero mutation", async () => {
+		const org = await createTestOrganization({ name: "Org NoSetupAction" });
+		await seedGithubConnector(org.id);
+		// A valid state exists, but setup_action is absent — must 400 before any
+		// state validation or mutation (not be treated like install/update).
+		const state = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+		const { router } = buildRouter(org.id, { ownedInstallationIds: [7011] });
+
+		const res = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=7011&state=${state}&code=valid-oauth-code`,
+			),
+		);
+
+		expect(res.status).toBe(400);
+		expect(await installCount(org.id)).toBe(0);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("rejects a callback with a GARBAGE setup_action → 400, zero mutation", async () => {
+		const org = await createTestOrganization({ name: "Org GarbageSetupAction" });
+		await seedGithubConnector(org.id);
+		const state = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+		const { router } = buildRouter(org.id, { ownedInstallationIds: [7012] });
+
+		const res = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=7012&setup_action=delete-everything&state=${state}&code=valid-oauth-code`,
+			),
+		);
+
+		expect(res.status).toBe(400);
+		expect(await installCount(org.id)).toBe(0);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
 	it("FIXATION: completing session org ≠ state org → 403 org_mismatch, zero mutation, nonce NOT consumed", async () => {
 		// Confused-deputy: attacker (stateOrg) mints the link and sends it to a
 		// victim, whose browser/session resolves to a DIFFERENT (ambient) org. Even

--- a/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
@@ -73,6 +73,14 @@ type MockAccount = { login: string; type: "User" | "Organization" };
  *  - `ownedInstallationIds` (shorthand): personal-account installs owned by
  *    `authedLogin` — convenience for the simpler cases.
  */
+/** Captures what the mocked OAuth exchange was called with (for assertions). */
+interface RouterCapture {
+	exchangeRedirectUri?: string;
+	exchangeCalls: number;
+}
+
+const PUBLIC_GATEWAY_URL = "https://app.lobu.ai";
+
 function buildRouter(
 	installOrgId: string | null,
 	opts: {
@@ -81,8 +89,10 @@ function buildRouter(
 		authedLogin?: string;
 		orgRoles?: Record<string, { state: string; role: string }> | null;
 		exchangeReturns?: string | null;
+		/** Public gateway base for redirect_uri; defaults to PUBLIC_GATEWAY_URL. */
+		publicGatewayUrl?: string | undefined;
 	} = {},
-) {
+): { router: ReturnType<typeof createAppInstallRoutes>; captured: RouterCapture } {
 	const exchangeReturns =
 		opts.exchangeReturns === undefined ? "fake-user-token" : opts.exchangeReturns;
 	const authedLogin = opts.authedLogin ?? "installer-user";
@@ -99,10 +109,20 @@ function buildRouter(
 					]),
 				);
 
+	const captured: RouterCapture = { exchangeCalls: 0 };
+
 	const deps: AppInstallRouterDeps = {
 		installationStore: createPostgresAppInstallationStore(),
 		resolveInstallOrgId: async () => installOrgId,
-		exchangeInstallOAuthCode: async () => exchangeReturns,
+		getPublicGatewayUrl: () =>
+			opts.publicGatewayUrl === undefined
+				? PUBLIC_GATEWAY_URL
+				: opts.publicGatewayUrl,
+		exchangeInstallOAuthCode: async (p) => {
+			captured.exchangeCalls += 1;
+			captured.exchangeRedirectUri = p.redirectUri;
+			return exchangeReturns;
+		},
 		fetchInstallationAccount: async (_token, installationId) => {
 			if (installations === null) return undefined; // HTTP failure
 			const acct = installations[installationId];
@@ -114,7 +134,7 @@ function buildRouter(
 			return opts.orgRoles?.[org] ?? { state: "none", role: "none" };
 		},
 	};
-	return createAppInstallRoutes(deps);
+	return { router: createAppInstallRoutes(deps), captured };
 }
 
 async function connectionCount(organizationId: string): Promise<number> {
@@ -183,7 +203,7 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 		await seedGithubConnector(org.id);
 		// The attacker's ambient session resolves to the victim org — proving the
 		// reject is driven by the missing state, not org resolution.
-		const router = buildRouter(org.id);
+		const { router } = buildRouter(org.id);
 
 		const res = await router.fetch(
 			new Request(
@@ -200,7 +220,7 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 	it("rejects a callback with an INVALID/forged state and writes nothing", async () => {
 		const org = await createTestOrganization({ name: "Victim Org BadState" });
 		await seedGithubConnector(org.id);
-		const router = buildRouter(org.id);
+		const { router } = buildRouter(org.id);
 
 		const res = await router.fetch(
 			new Request(
@@ -213,20 +233,52 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 		expect(await connectionCount(org.id)).toBe(0);
 	});
 
-	it("accepts a callback with valid state + code + owned installation, binds to the STATE's org", async () => {
-		const stateOrg = await createTestOrganization({ name: "Initiator Org" });
-		const ambientOrg = await createTestOrganization({ name: "Ambient Other Org" });
+	it("FIXATION: completing session org ≠ state org → 403 org_mismatch, zero mutation, nonce NOT consumed", async () => {
+		// Confused-deputy: attacker (stateOrg) mints the link and sends it to a
+		// victim, whose browser/session resolves to a DIFFERENT (ambient) org. Even
+		// though the ownership check would pass (victim owns the installation), the
+		// completing session's org must match the state's org or we reject — else the
+		// victim's installation would land in the attacker's org. (This previously
+		// asserted SUCCESS, codifying the vulnerability; flipped to assert the fix.)
+		const stateOrg = await createTestOrganization({ name: "Attacker Initiator Org" });
+		const ambientOrg = await createTestOrganization({ name: "Victim Session Org" });
 		await seedGithubConnector(stateOrg.id);
 		await seedGithubConnector(ambientOrg.id);
 
-		// Mint a state bound to stateOrg (as GET /github/app/install would).
 		const stateStore = createGithubInstallStateStore();
 		const state = await stateStore.create({ organizationId: stateOrg.id });
 
-		// The callback session resolves to a DIFFERENT (ambient) org — the install
-		// must STILL land in the state's org, never the ambient one. The (mocked)
-		// /user/installations returns the supplied id, so ownership passes.
-		const router = buildRouter(ambientOrg.id, { ownedInstallationIds: [7003] });
+		// resolveInstallOrgId resolves to the ambient (victim-session) org, NOT the
+		// state's org → mismatch.
+		const { router } = buildRouter(ambientOrg.id, { ownedInstallationIds: [7003] });
+		const res = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=7003&setup_action=install&state=${state}&code=valid-oauth-code`,
+			),
+		);
+
+		expect(res.status).toBe(403);
+		// Zero mutation in BOTH orgs.
+		expect(await installCount(stateOrg.id)).toBe(0);
+		expect(await connectionCount(stateOrg.id)).toBe(0);
+		expect(await installCount(ambientOrg.id)).toBe(0);
+		expect(await connectionCount(ambientOrg.id)).toBe(0);
+		// The org check ran on a PEEK — the still-valid nonce was NOT burned, so the
+		// legitimate org can still complete it.
+		const stillThere = await stateStore.peek(state);
+		expect(stillThere?.organizationId).toBe(stateOrg.id);
+	});
+
+	it("happy path: completing session org === state org → 200, binds to that org", async () => {
+		const org = await createTestOrganization({ name: "Same Session Org" });
+		await seedGithubConnector(org.id);
+		const state = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+
+		// resolveInstallOrgId === the state's org (the admin completes in the same
+		// session they started in).
+		const { router } = buildRouter(org.id, { ownedInstallationIds: [7003] });
 		const res = await router.fetch(
 			new Request(
 				`http://gw.test/github/app/install/callback?installation_id=7003&setup_action=install&state=${state}&code=valid-oauth-code`,
@@ -234,12 +286,37 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 		);
 
 		expect(res.status).toBe(200);
-		// Install + connection landed in the STATE's org.
-		expect(await installCount(stateOrg.id)).toBe(1);
-		expect(await connectionCount(stateOrg.id)).toBe(1);
-		// Nothing landed in the ambient org.
-		expect(await installCount(ambientOrg.id)).toBe(0);
-		expect(await connectionCount(ambientOrg.id)).toBe(0);
+		expect(await installCount(org.id)).toBe(1);
+		expect(await connectionCount(org.id)).toBe(1);
+		// The legit flow DID consume the nonce (single-use).
+		const consumed = await createGithubInstallStateStore().peek(state);
+		expect(consumed).toBeNull();
+	});
+
+	it("redirect_uri passed to the OAuth exchange is the public registered callback URL", async () => {
+		const org = await createTestOrganization({ name: "Redirect URI Org" });
+		await seedGithubConnector(org.id);
+		const state = await createGithubInstallStateStore().create({
+			organizationId: org.id,
+		});
+		const { router, captured } = buildRouter(org.id, {
+			ownedInstallationIds: [7050],
+		});
+
+		const res = await router.fetch(
+			new Request(
+				// The request URL is the INTERNAL pod URL (http, pod host) — the
+				// redirect_uri must NOT be derived from it.
+				`http://internal-pod-host:8080/github/app/install/callback?installation_id=7050&setup_action=install&state=${state}&code=valid-oauth-code`,
+			),
+		);
+
+		expect(res.status).toBe(200);
+		expect(captured.exchangeCalls).toBe(1);
+		// Exactly the App's registered public Callback URL — not the pod URL.
+		expect(captured.exchangeRedirectUri).toBe(
+			`${PUBLIC_GATEWAY_URL}/github/app/install/callback`,
+		);
 	});
 
 	it("treats a consumed state as single-use: a replay is rejected with no extra row", async () => {
@@ -247,7 +324,7 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 		await seedGithubConnector(org.id);
 		const stateStore = createGithubInstallStateStore();
 		const state = await stateStore.create({ organizationId: org.id });
-		const router = buildRouter(org.id, { ownedInstallationIds: [7004] });
+		const { router } = buildRouter(org.id, { ownedInstallationIds: [7004] });
 
 		const first = await router.fetch(
 			new Request(
@@ -273,7 +350,7 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 	it("the start route redirects to GitHub with a signed state bound to the org", async () => {
 		const org = await createTestOrganization({ name: "Start Org" });
 		await seedGithubConnector(org.id);
-		const router = buildRouter(org.id);
+		const { router } = buildRouter(org.id);
 
 		const res = await router.fetch(
 			new Request("http://gw.test/github/app/install"),
@@ -302,7 +379,7 @@ describe("GitHub App install callback — installation ownership guard", () => {
 		});
 		// /user/installations returns only the attacker's OWN installs (e.g. 555),
 		// NOT the victim id 8888 they're trying to steal.
-		const router = buildRouter(attackerOrg.id, { ownedInstallationIds: [555] });
+		const { router } = buildRouter(attackerOrg.id, { ownedInstallationIds: [555] });
 
 		const res = await router.fetch(
 			new Request(
@@ -322,7 +399,7 @@ describe("GitHub App install callback — installation ownership guard", () => {
 		const state = await createGithubInstallStateStore().create({
 			organizationId: org.id,
 		});
-		const router = buildRouter(org.id, { ownedInstallationIds: [4242, 999] });
+		const { router } = buildRouter(org.id, { ownedInstallationIds: [4242, 999] });
 
 		const res = await router.fetch(
 			new Request(
@@ -351,7 +428,7 @@ describe("GitHub App install callback — installation ownership guard", () => {
 		});
 		// Even though the (mocked) ownership set WOULD contain the id, the absence
 		// of `code` must reject before any exchange/lookup.
-		const router = buildRouter(org.id, { ownedInstallationIds: [7777] });
+		const { router } = buildRouter(org.id, { ownedInstallationIds: [7777] });
 
 		const res = await router.fetch(
 			new Request(
@@ -372,7 +449,7 @@ describe("GitHub App install callback — installation ownership guard", () => {
 		const state = await createGithubInstallStateStore().create({
 			organizationId: org.id,
 		});
-		const router = buildRouter(org.id, { ownedInstallationIds: [6001] });
+		const { router } = buildRouter(org.id, { ownedInstallationIds: [6001] });
 
 		const res = await router.fetch(
 			new Request(
@@ -392,7 +469,7 @@ describe("GitHub App install callback — installation ownership guard", () => {
 			organizationId: org.id,
 		});
 		// Exchange returns null (bad_verification_code) → cannot prove identity.
-		const router = buildRouter(org.id, {
+		const { router } = buildRouter(org.id, {
 			ownedInstallationIds: [5005],
 			exchangeReturns: null,
 		});
@@ -422,7 +499,7 @@ describe("GitHub App install callback — account-ownership (admin vs member)", 
 		const state = await createGithubInstallStateStore().create({
 			organizationId: org.id,
 		});
-		const router = buildRouter(org.id, {
+		const { router } = buildRouter(org.id, {
 			installations: {
 				[opts.installationId]: { login: opts.orgLogin, type: "Organization" },
 			},
@@ -489,7 +566,7 @@ describe("GitHub App install callback — account-ownership (admin vs member)", 
 		const state = await createGithubInstallStateStore().create({
 			organizationId: org.id,
 		});
-		const router = buildRouter(org.id, {
+		const { router } = buildRouter(org.id, {
 			authedLogin: "Octocat",
 			installations: {
 				4100: { login: "octocat", type: "User" }, // case-insensitive match
@@ -512,7 +589,7 @@ describe("GitHub App install callback — account-ownership (admin vs member)", 
 			organizationId: org.id,
 		});
 		// The user can SEE this personal install (collaborator) but does not OWN it.
-		const router = buildRouter(org.id, {
+		const { router } = buildRouter(org.id, {
 			authedLogin: "attacker",
 			installations: {
 				4200: { login: "victim", type: "User" },
@@ -544,10 +621,10 @@ describe("GitHub App install callback — connection creation is race-safe", () 
 		const stateB = await createGithubInstallStateStore().create({
 			organizationId: org.id,
 		});
-		const routerA = buildRouter(org.id, {
+		const { router: routerA } = buildRouter(org.id, {
 			ownedInstallationIds: [installationId],
 		});
-		const routerB = buildRouter(org.id, {
+		const { router: routerB } = buildRouter(org.id, {
 			ownedInstallationIds: [installationId],
 		});
 

--- a/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
@@ -1,0 +1,226 @@
+/**
+ * GitHub App install callback — CSRF / cross-tenant guard (signed state).
+ *
+ * The `/github/app/install/callback` route is a public, unauthenticated GET that
+ * mutates org state (writes an `app_installations` row + a `github` connection).
+ * Without a verified `state`, a forged GET could plant a connection into a
+ * victim's org (CSRF) or cross-tenant. This suite proves:
+ *
+ *   1. a callback with NO `state` is rejected (4xx) and writes NOTHING,
+ *   2. a callback with an INVALID/forged `state` is rejected (4xx) and writes
+ *      NOTHING,
+ *   3. the `GET /github/app/install` start route mints a signed state bound to
+ *      the initiating org, and the callback carrying that state succeeds and
+ *      binds the install to the STATE's org — never the ambient callback session,
+ *   4. the state is single-use (replay of a consumed state is rejected).
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getDb } from "../../../db/client";
+import {
+	type AppInstallRouterDeps,
+	createAppInstallRoutes,
+} from "../../../gateway/routes/public/app-install";
+import { createGithubInstallStateStore } from "../../../gateway/auth/oauth/state-store";
+import { createPostgresAppInstallationStore } from "../../../lobu/stores/app-installation-store";
+import { getTestDb } from "../../setup/test-db";
+import { initWorkspaceProvider } from "../../../workspace";
+import {
+	createTestConnectorDefinition,
+	createTestOrganization,
+} from "../../setup/test-fixtures";
+
+const CONNECTOR_KEY = "github";
+const PROVIDER_APP_ID = "test-github-app-state";
+const APP_SLUG = "lobu-test-app";
+
+async function seedGithubConnector(organizationId: string): Promise<void> {
+	await createTestConnectorDefinition({
+		key: CONNECTOR_KEY,
+		name: "GitHub",
+		organization_id: organizationId,
+		auth_schema: {
+			methods: [
+				{
+					type: "app_installation",
+					provider: "github",
+					providerInstance: "cloud",
+					appIdKey: "GITHUB_APP_ID",
+					privateKeyKey: "GITHUB_APP_PRIVATE_KEY",
+				},
+			],
+		},
+		feeds_schema: { issues: {} },
+	});
+}
+
+/** Build the install router; `resolveInstallOrgId` is fixed for the start route. */
+function buildRouter(installOrgId: string | null) {
+	const deps: AppInstallRouterDeps = {
+		installationStore: createPostgresAppInstallationStore(),
+		resolveInstallOrgId: async () => installOrgId,
+	};
+	return createAppInstallRoutes(deps);
+}
+
+async function connectionCount(organizationId: string): Promise<number> {
+	const sql = getDb();
+	const rows = (await sql`
+		SELECT count(*)::int AS n FROM connections
+		WHERE organization_id = ${organizationId}
+			AND connector_key = ${CONNECTOR_KEY}
+			AND deleted_at IS NULL
+	`) as unknown as Array<{ n: number }>;
+	return rows[0].n;
+}
+
+async function installCount(organizationId: string): Promise<number> {
+	const sql = getDb();
+	const rows = (await sql`
+		SELECT count(*)::int AS n FROM app_installations
+		WHERE organization_id = ${organizationId}
+			AND provider_app_id = ${PROVIDER_APP_ID}
+	`) as unknown as Array<{ n: number }>;
+	return rows[0].n;
+}
+
+const ORIGINAL_APP_ID = process.env.GITHUB_APP_ID;
+const ORIGINAL_APP_SLUG = process.env.GITHUB_APP_SLUG;
+
+beforeAll(async () => {
+	await initWorkspaceProvider();
+});
+
+beforeEach(async () => {
+	process.env.GITHUB_APP_ID = PROVIDER_APP_ID;
+	process.env.GITHUB_APP_SLUG = APP_SLUG;
+	const sql = getTestDb();
+	await sql`DELETE FROM connections WHERE connector_key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM connector_definitions WHERE key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM app_installations WHERE provider_app_id = ${PROVIDER_APP_ID}`;
+	await sql`DELETE FROM oauth_states WHERE scope = 'github:app_install:state'`;
+});
+
+afterEach(async () => {
+	if (ORIGINAL_APP_ID === undefined) delete process.env.GITHUB_APP_ID;
+	else process.env.GITHUB_APP_ID = ORIGINAL_APP_ID;
+	if (ORIGINAL_APP_SLUG === undefined) delete process.env.GITHUB_APP_SLUG;
+	else process.env.GITHUB_APP_SLUG = ORIGINAL_APP_SLUG;
+	const sql = getTestDb();
+	await sql`DELETE FROM connections WHERE connector_key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM connector_definitions WHERE key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM app_installations WHERE provider_app_id = ${PROVIDER_APP_ID}`;
+	await sql`DELETE FROM oauth_states WHERE scope = 'github:app_install:state'`;
+});
+
+describe("GitHub App install callback — signed-state CSRF guard", () => {
+	it("rejects a callback with NO state and writes no install/connection row", async () => {
+		const org = await createTestOrganization({ name: "Victim Org NoState" });
+		await seedGithubConnector(org.id);
+		// The attacker's ambient session resolves to the victim org — proving the
+		// reject is driven by the missing state, not org resolution.
+		const router = buildRouter(org.id);
+
+		const res = await router.fetch(
+			new Request(
+				"http://gw.test/github/app/install/callback?installation_id=7001&setup_action=install",
+			),
+		);
+
+		expect(res.status).toBe(400);
+		// CRITICAL: zero mutation.
+		expect(await installCount(org.id)).toBe(0);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("rejects a callback with an INVALID/forged state and writes nothing", async () => {
+		const org = await createTestOrganization({ name: "Victim Org BadState" });
+		await seedGithubConnector(org.id);
+		const router = buildRouter(org.id);
+
+		const res = await router.fetch(
+			new Request(
+				"http://gw.test/github/app/install/callback?installation_id=7002&setup_action=install&state=forged-not-in-db",
+			),
+		);
+
+		expect(res.status).toBe(400);
+		expect(await installCount(org.id)).toBe(0);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("accepts a callback carrying a valid signed state and binds to the STATE's org", async () => {
+		const stateOrg = await createTestOrganization({ name: "Initiator Org" });
+		const ambientOrg = await createTestOrganization({ name: "Ambient Other Org" });
+		await seedGithubConnector(stateOrg.id);
+		await seedGithubConnector(ambientOrg.id);
+
+		// Mint a state bound to stateOrg (as GET /github/app/install would).
+		const stateStore = createGithubInstallStateStore();
+		const state = await stateStore.create({ organizationId: stateOrg.id });
+
+		// The callback session resolves to a DIFFERENT (ambient) org — the install
+		// must STILL land in the state's org, never the ambient one.
+		const router = buildRouter(ambientOrg.id);
+		const res = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=7003&setup_action=install&state=${state}`,
+			),
+		);
+
+		expect(res.status).toBe(200);
+		// Install + connection landed in the STATE's org.
+		expect(await installCount(stateOrg.id)).toBe(1);
+		expect(await connectionCount(stateOrg.id)).toBe(1);
+		// Nothing landed in the ambient org.
+		expect(await installCount(ambientOrg.id)).toBe(0);
+		expect(await connectionCount(ambientOrg.id)).toBe(0);
+	});
+
+	it("treats a consumed state as single-use: a replay is rejected with no extra row", async () => {
+		const org = await createTestOrganization({ name: "Replay Org" });
+		await seedGithubConnector(org.id);
+		const stateStore = createGithubInstallStateStore();
+		const state = await stateStore.create({ organizationId: org.id });
+		const router = buildRouter(org.id);
+
+		const first = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=7004&setup_action=install&state=${state}`,
+			),
+		);
+		expect(first.status).toBe(200);
+		expect(await installCount(org.id)).toBe(1);
+		expect(await connectionCount(org.id)).toBe(1);
+
+		// Replay the SAME state — it was consumed, so this is rejected.
+		const replay = await router.fetch(
+			new Request(
+				`http://gw.test/github/app/install/callback?installation_id=7004&setup_action=install&state=${state}`,
+			),
+		);
+		expect(replay.status).toBe(400);
+		// Still exactly one install + one connection — no duplicate from the replay.
+		expect(await installCount(org.id)).toBe(1);
+		expect(await connectionCount(org.id)).toBe(1);
+	});
+
+	it("the start route redirects to GitHub with a signed state bound to the org", async () => {
+		const org = await createTestOrganization({ name: "Start Org" });
+		await seedGithubConnector(org.id);
+		const router = buildRouter(org.id);
+
+		const res = await router.fetch(
+			new Request("http://gw.test/github/app/install"),
+		);
+		expect(res.status).toBe(302);
+		const location = res.headers.get("location") ?? "";
+		expect(location).toContain(`https://github.com/apps/${APP_SLUG}/installations/new`);
+		const minted = new URL(location).searchParams.get("state");
+		expect(minted).toBeTruthy();
+
+		// The minted state resolves to the org server-side (Postgres-backed nonce).
+		const peeked = await createGithubInstallStateStore().peek(minted as string);
+		expect(peeked?.organizationId).toBe(org.id);
+	});
+});

--- a/packages/server/src/__tests__/integration/connectors/serverless-device-worker.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/serverless-device-worker.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression: `manage_connections` create must accept a serverless connection
+ * (no device worker). The UI/serverless callers send `device_worker_id: null`
+ * explicitly; the create-path schema used a bare `Type.String`, so validation
+ * rejected null with "Invalid arguments for manage_connections:
+ * /device_worker_id: Expected string" before a connection was ever created.
+ *
+ * The fix makes the create (and connect) `device_worker_id` nullable —
+ * `Type.Union([Type.String(), Type.Null()])` — matching the update action and
+ * `resolveDeviceBinding`, which already normalizes null/empty to serverless.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import type { ToolContext } from "../../../tools/registry";
+import { manageConnections } from "../../../tools/admin/manage_connections";
+import { getTestDb } from "../../setup/test-db";
+import { initWorkspaceProvider } from "../../../workspace";
+import {
+	addUserToOrganization,
+	createTestConnectorDefinition,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const TEST_ENV = {} as Env;
+const CONNECTOR_KEY = "demo.serverless";
+
+function ctxFor(organizationId: string, userId: string): ToolContext {
+	return {
+		organizationId,
+		userId,
+		memberRole: "owner",
+		agentId: null,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+	} as ToolContext;
+}
+
+beforeAll(async () => {
+	await initWorkspaceProvider();
+});
+
+async function seedConnector(organizationId: string): Promise<void> {
+	await createTestConnectorDefinition({
+		key: CONNECTOR_KEY,
+		name: "Demo Serverless",
+		organization_id: organizationId,
+		auth_schema: { methods: [{ type: "none" }] },
+		feeds_schema: { items: {} },
+	});
+}
+
+afterEach(async () => {
+	const sql = getTestDb();
+	await sql`DELETE FROM connections WHERE connector_key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM connector_definitions WHERE key = ${CONNECTOR_KEY}`;
+});
+
+describe("manage_connections — serverless create (no device worker)", () => {
+	it("create with device_worker_id: null succeeds and runs serverless", async () => {
+		const org = await createTestOrganization({ name: "Serverless Null Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "serverless-null",
+				display_name: "Serverless Null",
+				device_worker_id: null,
+			},
+			TEST_ENV,
+			ctx,
+		);
+
+		expect("error" in res).toBe(false);
+		if (!("connection" in res)) throw new Error("expected a connection in result");
+		const connection = res.connection as { id: number; device_worker_id: unknown };
+		expect(connection.id).toBeGreaterThan(0);
+		// Serverless: no device bound.
+		expect(connection.device_worker_id ?? null).toBeNull();
+	});
+
+	it("create with device_worker_id omitted succeeds and runs serverless", async () => {
+		const org = await createTestOrganization({ name: "Serverless Omit Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "serverless-omit",
+				display_name: "Serverless Omit",
+			},
+			TEST_ENV,
+			ctx,
+		);
+
+		expect("error" in res).toBe(false);
+		if (!("connection" in res)) throw new Error("expected a connection in result");
+		const connection = res.connection as { id: number; device_worker_id: unknown };
+		expect(connection.id).toBeGreaterThan(0);
+		expect(connection.device_worker_id ?? null).toBeNull();
+	});
+});

--- a/packages/server/src/gateway/auth/oauth/state-store.ts
+++ b/packages/server/src/gateway/auth/oauth/state-store.ts
@@ -171,6 +171,21 @@ export function createSlackInstallStateStore(): OAuthStateStore<SlackInstallStat
   return new OAuthStateStore("slack:oauth:state", "slack-install-state");
 }
 
+interface GithubInstallStateData {
+  /**
+   * Active org of the session that initiated the GitHub App install. The
+   * install callback verifies a valid, unexpired state row exists and binds
+   * the resulting `app_installations` row + connection to THIS org — never the
+   * ambient callback-session org. Without it, a public GET to the callback
+   * could plant a connection into a victim's org (CSRF / cross-tenant).
+   */
+  organizationId: string;
+}
+
+export function createGithubInstallStateStore(): OAuthStateStore<GithubInstallStateData> {
+  return new OAuthStateStore("github:app_install:state", "github-install-state");
+}
+
 export type ProviderOAuthStateStore = OAuthStateStore<ProviderOAuthStateData>;
 
 /**

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -729,6 +729,7 @@ export function createGatewayApp(
       createAppInstallRoutes({
         installationStore: createPostgresAppInstallationStore(),
         resolveInstallOrgId,
+        getPublicGatewayUrl: () => coreServices.getPublicGatewayUrl(),
       }),
     );
     app.route(

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -27,6 +27,8 @@ import {
   createDefaultAppWebhookSecretResolver,
   createGithubAppWebhookProvider,
 } from "../routes/public/app-webhooks.js";
+import { createAppInstallRoutes } from "../routes/public/app-install.js";
+import { resolveInstallOrgId } from "../routes/public/slack.js";
 import { createAgentConfigRoutes } from "../routes/public/agent-config.js";
 import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
 import { createAgentRoutes } from "../routes/public/agents.js";
@@ -716,6 +718,17 @@ export function createGatewayApp(
           : [],
         resolveAppWebhookSecret:
           createDefaultAppWebhookSecretResolver(appWebhookSecretStore),
+      }),
+    );
+
+    // GitHub App post-install callback (app-installation design §4.4): records
+    // the installation + links the org's github connection to it. Session-bound
+    // org resolution shares the Slack install flow's resolver.
+    app.route(
+      "",
+      createAppInstallRoutes({
+        installationStore: createPostgresAppInstallationStore(),
+        resolveInstallOrgId,
       }),
     );
     app.route(

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -680,6 +680,20 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 			);
 		}
 
+		// setup_action must be one of install|update|request (request handled above).
+		// A missing/unrecognized value must NOT be treated like install/update —
+		// reject (400) before any state validation or mutation. parseSetupAction
+		// returns null for both missing and garbage.
+		if (setupAction === null) {
+			return c.html(
+				renderOAuthErrorPage(
+					"invalid_request",
+					"The GitHub install callback has a missing or invalid setup_action (expected install, update, or request).",
+				),
+				400,
+			);
+		}
+
 		if (!installationIdRaw || !installationIdRaw.trim()) {
 			return c.html(
 				renderOAuthErrorPage(

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -1,0 +1,345 @@
+/**
+ * GitHub App install callback (PR5 of the app-installation design,
+ * docs/design/app-installation.md §4.4).
+ *
+ * After a user installs the Lobu GitHub App on their org/repos, GitHub redirects
+ * the browser to this callback with `installation_id` + `setup_action`
+ * (`install` | `update` | `request`). This route:
+ *
+ *   1. resolves the active org for the request (session-bound, falling back to a
+ *      single-tenant deployment's sole org — mirrors the Slack install flow), then
+ *   2. on `install`/`update`: upserts the `app_installations` row for the tenant
+ *      tuple (provider=github, provider_instance=cloud, provider_app_id=
+ *      GITHUB_APP_ID, external_tenant_id=installation_id, status=active) via the
+ *      store's reject/transfer upsert (idempotent + ownership-safe), then
+ *   3. creates or relinks a `connections` row for the org's `github` connector
+ *      with `config.installation_ref` = the install id (the shape
+ *      resolveExecutionAuth reads to mint a tenant-scoped token).
+ *
+ * `request` (the user asked an org admin to approve the install) writes nothing —
+ * there's no installation yet — and just acks.
+ *
+ * Multi-replica: stateless. Org resolution + the two upserts read/write Postgres
+ * only; the store upsert serializes ownership on a Postgres advisory lock +
+ * partial unique index, so concurrent callbacks across pods converge to one
+ * active owner. No per-pod memo.
+ *
+ * Cross-org safety: the install is bound to the CALLBACK session's active org.
+ * The owletto "Install on GitHub" UI (separate PR) will additionally carry a
+ * signed `state` so a phished install link can't plant a connection into the
+ * wrong tenant; until then the session org is the authority (an unauthenticated
+ * hit with no single-tenant fallback is rejected, never silently tenanted).
+ */
+
+import { Hono } from "hono";
+import { createLogger } from "@lobu/core";
+import { getDb } from "../../../db/client.js";
+import {
+	ConnectionSlugConflictError,
+	insertConnectionWithSlug,
+	resolveNewConnectionSlug,
+} from "../../../utils/connections.js";
+import {
+	getAppInstallationAuthMethods,
+	normalizeConnectorAuthSchema,
+} from "../../../utils/connector-auth.js";
+import type { AppInstallationStore } from "../../../lobu/stores/app-installation-store.js";
+import {
+	renderOAuthErrorPage,
+	renderOAuthSuccessPage,
+} from "../../auth/oauth-templates.js";
+
+const logger = createLogger("app-install-routes");
+
+/** The GitHub App connector key whose connection an install links. */
+const GITHUB_CONNECTOR_KEY = "github";
+const GITHUB_PROVIDER = "github";
+const GITHUB_PROVIDER_INSTANCE = "cloud";
+
+export type GithubSetupAction = "install" | "update" | "request";
+
+function parseSetupAction(raw: string | undefined): GithubSetupAction | null {
+	if (raw === "install" || raw === "update" || raw === "request") return raw;
+	return null;
+}
+
+/** Result of {@link linkGithubAppInstallation}. */
+export interface LinkGithubInstallationResult {
+	installId: number;
+	connectionId: number;
+	/** True when a new connection row was created (vs an existing one relinked). */
+	createdConnection: boolean;
+	accountLogin: string | null;
+}
+
+/**
+ * Upsert the `app_installations` row for a GitHub App install and create/relink
+ * the org's `github` connector connection so its `config.installation_ref` points
+ * at the install. Pure of HTTP — the route is a thin wrapper, and tests drive
+ * this directly. Idempotent: re-running for the same (org, installation_id)
+ * refreshes the install (reject/transfer upsert) and reuses an existing linked
+ * connection instead of creating a duplicate.
+ */
+export async function linkGithubAppInstallation(params: {
+	organizationId: string;
+	installationId: string;
+	store: AppInstallationStore;
+	/** GitHub App id (provider_app_id); defaults to GITHUB_APP_ID env. */
+	providerAppId: string;
+	/** Account/metadata stamped onto the install row (account login, etc.). */
+	metadata?: Record<string, unknown>;
+	createdBy?: string | null;
+}): Promise<LinkGithubInstallationResult> {
+	const sql = getDb();
+	const accountLogin =
+		typeof params.metadata?.account_login === "string"
+			? (params.metadata.account_login as string)
+			: null;
+
+	// 1. Upsert the install row (reject/transfer ownership on the active-tenant
+	//    invariant — same-org reinstall refreshes in place, different-org install
+	//    transfers ownership). auth_profile_id stays null: the GitHub App
+	//    credential (app id + private key) lives in gateway env, not auth_profiles.
+	const install = await params.store.upsert({
+		organizationId: params.organizationId,
+		provider: GITHUB_PROVIDER,
+		providerInstance: GITHUB_PROVIDER_INSTANCE,
+		providerAppId: params.providerAppId,
+		externalTenantId: params.installationId,
+		status: "active",
+		metadata: params.metadata ?? {},
+	});
+
+	// 2. Find an existing connection in this org for the github connector already
+	//    bound to this install (idempotent re-install / callback retry). The
+	//    install id is the stable key; match on config.installation_ref.
+	const existing = (await sql`
+		SELECT id, config
+		FROM connections
+		WHERE organization_id = ${params.organizationId}
+			AND connector_key = ${GITHUB_CONNECTOR_KEY}
+			AND deleted_at IS NULL
+			AND (
+				config ->> 'installation_ref' = ${String(install.id)}
+				OR config ->> 'installation_ref' = ${String(params.installationId)}
+			)
+		ORDER BY id ASC
+		LIMIT 1
+	`) as unknown as Array<{ id: number; config: Record<string, unknown> | null }>;
+
+	if (existing.length > 0) {
+		const connectionId = Number(existing[0].id);
+		const mergedConfig = {
+			...(existing[0].config ?? {}),
+			installation_ref: install.id,
+		};
+		await sql`
+			UPDATE connections
+			SET config = ${sql.json(mergedConfig)},
+				status = 'active',
+				updated_at = NOW()
+			WHERE id = ${connectionId}
+				AND organization_id = ${params.organizationId}
+		`;
+		return {
+			installId: install.id,
+			connectionId,
+			createdConnection: false,
+			accountLogin,
+		};
+	}
+
+	// 3. No existing linked connection — create one bound to the install. The
+	//    config carries ONLY installation_ref (no repo/org target), so the
+	//    connect-flow webhook gate (connectionWantsWebhook) never fires: inbound
+	//    deliveries route through the shared /app-webhooks/github endpoint, and
+	//    resolveExecutionAuth mints a tenant-scoped token from the install.
+	const displayName = accountLogin
+		? `GitHub (${accountLogin})`
+		: "GitHub App";
+	const slugResult = await resolveNewConnectionSlug({
+		organizationId: params.organizationId,
+		connectorKey: GITHUB_CONNECTOR_KEY,
+		displayName,
+	});
+	if ("error" in slugResult) {
+		throw new Error(slugResult.error);
+	}
+
+	const inserted = await insertConnectionWithSlug<
+		Array<{ id: number; slug: string }>
+	>({
+		organizationId: params.organizationId,
+		connectorKey: GITHUB_CONNECTOR_KEY,
+		displayName,
+		initialSlug: slugResult.slug,
+		explicit: false,
+		doInsert: (slug) => sql`
+			INSERT INTO connections (
+				organization_id, connector_key, slug, display_name, status, config, created_by
+			) VALUES (
+				${params.organizationId}, ${GITHUB_CONNECTOR_KEY}, ${slug}, ${displayName},
+				'active', ${sql.json({ installation_ref: install.id })}, ${params.createdBy ?? null}
+			)
+			RETURNING id, slug
+		`,
+	}).catch((err) => {
+		if (err instanceof ConnectionSlugConflictError) throw new Error(err.message);
+		throw err;
+	});
+
+	return {
+		installId: install.id,
+		connectionId: Number(inserted[0].id),
+		createdConnection: true,
+		accountLogin,
+	};
+}
+
+/** Dependencies the install routes need (injected for testability). */
+export interface AppInstallRouterDeps {
+	installationStore: AppInstallationStore;
+	/** Resolve the active org for the request (session-bound + single-tenant). */
+	resolveInstallOrgId(c: import("hono").Context): Promise<string | null>;
+}
+
+/**
+ * Build the GitHub App install routes.
+ *
+ * Mounted at the gateway root like the Slack routes (`app.route("", ...)`), so
+ * the callback lives at `<gateway-base>/github/app/install/callback`.
+ */
+export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
+	const router = new Hono();
+
+	router.get("/github/app/install/callback", async (c) => {
+		const appId = process.env.GITHUB_APP_ID;
+		if (!appId) {
+			return c.html(
+				renderOAuthErrorPage(
+					"github_app_not_configured",
+					"The Lobu GitHub App is not configured on this gateway (GITHUB_APP_ID unset).",
+				),
+				503,
+			);
+		}
+
+		const setupAction = parseSetupAction(c.req.query("setup_action"));
+		const installationIdRaw = c.req.query("installation_id");
+
+		// `request`: the user asked an org admin to approve the install — there is
+		// no installation to record yet. Ack and tell them what happens next.
+		if (setupAction === "request") {
+			return c.html(
+				renderOAuthSuccessPage("GitHub", undefined, {
+					title: "Install requested",
+					description:
+						"Your GitHub organization admin needs to approve the Lobu App install. We'll wire it up automatically once they do.",
+				}),
+			);
+		}
+
+		if (!installationIdRaw || !installationIdRaw.trim()) {
+			return c.html(
+				renderOAuthErrorPage(
+					"invalid_request",
+					"The GitHub install callback is missing installation_id.",
+				),
+				400,
+			);
+		}
+
+		const orgId = await deps.resolveInstallOrgId(c);
+		if (!orgId) {
+			return c.html(
+				renderOAuthErrorPage(
+					"unauthorized",
+					"Sign in to your organization before installing the GitHub App.",
+				),
+				401,
+			);
+		}
+
+		// Guard: the org must actually have the github connector definition with an
+		// app_installation auth method, otherwise there's nothing to link the
+		// install to (and a connection would dangle).
+		const sql = getDb();
+		const defRows = (await sql`
+			SELECT auth_schema FROM connector_definitions
+			WHERE key = ${GITHUB_CONNECTOR_KEY}
+				AND organization_id = ${orgId}
+				AND status = 'active'
+			LIMIT 1
+		`) as unknown as Array<{ auth_schema: unknown }>;
+		const hasAppInstallMethod =
+			defRows.length > 0 &&
+			getAppInstallationAuthMethods(normalizeConnectorAuthSchema(defRows[0].auth_schema))
+				.length > 0;
+		if (!hasAppInstallMethod) {
+			return c.html(
+				renderOAuthErrorPage(
+					"github_connector_missing",
+					"The GitHub connector is not installed for this organization, or it does not support App installs. Add the GitHub connector and try again.",
+				),
+				400,
+			);
+		}
+
+		try {
+			const result = await linkGithubAppInstallation({
+				organizationId: orgId,
+				installationId: installationIdRaw.trim(),
+				store: deps.installationStore,
+				providerAppId: appId,
+				metadata: buildInstallMetadata(c),
+			});
+			logger.info(
+				{
+					organization_id: orgId,
+					install_id: result.installId,
+					connection_id: result.connectionId,
+					created_connection: result.createdConnection,
+					setup_action: setupAction,
+				},
+				"GitHub App install linked",
+			);
+			return c.html(
+				renderOAuthSuccessPage(result.accountLogin ?? "GitHub", undefined, {
+					title: "GitHub App installed",
+					description:
+						"Your GitHub organization is connected to Lobu. Issues, PRs, and discussions will sync, and agents can act on them.",
+				}),
+			);
+		} catch (error) {
+			logger.error(
+				{
+					organization_id: orgId,
+					installation_id: installationIdRaw,
+					error: error instanceof Error ? error.message : String(error),
+				},
+				"GitHub App install callback failed",
+			);
+			return c.html(
+				renderOAuthErrorPage(
+					"github_install_failed",
+					error instanceof Error ? error.message : "GitHub App install failed.",
+				),
+				500,
+			);
+		}
+	});
+
+	return router;
+}
+
+/** Pull the account login GitHub passes (when present) into install metadata. */
+function buildInstallMetadata(c: import("hono").Context): Record<string, unknown> {
+	const metadata: Record<string, unknown> = {};
+	// GitHub doesn't pass the account login on the install redirect, but a
+	// future state-bound flow / the owletto UI can; accept it if present.
+	const accountLogin = c.req.query("account_login") || c.req.query("login");
+	if (accountLogin) metadata.account_login = accountLogin;
+	const setupAction = c.req.query("setup_action");
+	if (setupAction) metadata.setup_action = setupAction;
+	return metadata;
+}

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -78,6 +78,30 @@ export function githubAppInstallUrl(appSlug: string, state: string): string {
 }
 
 /**
+ * Build the GitHub App install callback URL — the OAuth `redirect_uri` passed to
+ * the token exchange. It MUST exactly equal the App's registered Callback URL
+ * (`<public-gateway-base>/github/app/install/callback`), or GitHub returns
+ * `redirect_uri_mismatch` and the exchange yields no token.
+ *
+ * Prefer the configured public gateway base (mirrors slack.ts's
+ * `slackOAuthCallbackUrl`): behind a TLS-terminating ingress `c.req.url` is the
+ * INTERNAL pod URL (`http://<pod-host>/…`), which never matches the registered
+ * https URL. Fall back to deriving it from the request only when no public base
+ * is configured (self-host single-origin), stripping the query.
+ */
+export function githubInstallCallbackUrl(
+	gatewayBaseUrl: string | undefined,
+	requestUrl: string,
+): string {
+	if (gatewayBaseUrl) {
+		return `${gatewayBaseUrl.replace(/\/+$/, "")}/github/app/install/callback`;
+	}
+	const url = new URL(requestUrl);
+	url.search = "";
+	return url.toString();
+}
+
+/**
  * Exchange the OAuth `code` GitHub returns on the install redirect for a USER
  * token, then prove the OAuth'd user is the OWNER of the installation's account:
  *   - the personal-account owner for a User install, or
@@ -414,6 +438,12 @@ export interface AppInstallRouterDeps {
 	/** Resolve the active org for the request (session-bound + single-tenant). */
 	resolveInstallOrgId(c: import("hono").Context): Promise<string | null>;
 	/**
+	 * The public gateway base URL (e.g. `https://app.lobu.ai`) used to build the
+	 * OAuth `redirect_uri`, which must equal the App's registered Callback URL.
+	 * Undefined falls back to the request origin (self-host single-origin).
+	 */
+	getPublicGatewayUrl?(): string | undefined;
+	/**
 	 * Exchange the install-redirect OAuth `code` for a GitHub USER token.
 	 * Injected so tests can mock the exchange (never hits real GitHub). Returns
 	 * null on a failed exchange. Defaults to the App's install-time OAuth.
@@ -662,11 +692,14 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 
 		// CSRF / cross-tenant guard. The callback is a public, unauthenticated GET,
 		// so the org MUST come from the signed `state` minted by GET
-		// /github/app/install — NOT the ambient callback session. Verify + consume
-		// the state BEFORE any DB write: a missing/invalid/expired state rejects
-		// (4xx) with zero mutation, so a forged GET can't plant a connection into a
-		// victim's org. `consume` is an atomic DELETE … RETURNING (single-use,
-		// replay-safe across replicas).
+		// /github/app/install — NOT the ambient callback session. A missing/invalid/
+		// expired state rejects (4xx) with zero mutation, so a forged GET can't plant
+		// a connection into a victim's org.
+		//
+		// We PEEK (non-destructive) first, run the side-channel checks (session-org
+		// match, ownership), and only CONSUME the single-use nonce right before the
+		// write — mirroring slack.ts. That way a benign mismatch or a transient
+		// ownership-check failure doesn't burn a still-valid install link.
 		const stateParam = c.req.query("state");
 		if (!stateParam) {
 			return c.html(
@@ -678,7 +711,7 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 			);
 		}
 		const stateStore = createGithubInstallStateStore();
-		const installState = await stateStore.consume(stateParam);
+		const installState = await stateStore.peek(stateParam);
 		if (!installState) {
 			logger.warn(
 				{ installation_id: installationIdRaw },
@@ -692,7 +725,34 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				400,
 			);
 		}
-		// Bind to the org encoded in the verified state — never the callback session.
+
+		// Confused-deputy / installation-fixation guard. The signed state proves
+		// WHICH org MINTED the link, but not that the BROWSER completing the callback
+		// belongs to that org. Without this, an attacker (org A) could mint a link,
+		// send the genuine github.com/apps/<slug>/installations/new?state=S to a
+		// victim, the victim installs the App on THEIR org V and passes the ownership
+		// check (they own V) — and V's installation lands in the attacker's org A.
+		// Require the completing session's org to equal the state's org (mirrors
+		// slack.ts). The legit admin completes in the same session (A === A).
+		const callbackOrgId = await deps.resolveInstallOrgId(c);
+		if (!callbackOrgId || callbackOrgId !== installState.organizationId) {
+			logger.warn(
+				{
+					state_org: installState.organizationId,
+					callback_org: callbackOrgId ?? null,
+					installation_id: installationIdRaw,
+				},
+				"Rejecting GitHub install callback: completing session org does not match install state",
+			);
+			return c.html(
+				renderOAuthErrorPage(
+					"org_mismatch",
+					"This GitHub install link was started in a different organization. Sign in to that organization and try again.",
+				),
+				403,
+			);
+		}
+		// Bind to the org encoded in the verified state (== callbackOrgId).
 		const orgId = installState.organizationId;
 
 		// Ownership proof. The signed state proves WHICH org initiated, but NOT that
@@ -714,13 +774,15 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				400,
 			);
 		}
-		// The redirect_uri must match the URL GitHub redirected to — derive it from
-		// this request (query stripped) so it matches the App's Callback URL exactly.
-		const callbackUrl = (() => {
-			const u = new URL(c.req.url);
-			u.search = "";
-			return u.toString();
-		})();
+		// The redirect_uri must EXACTLY equal the App's registered Callback URL.
+		// Derive it from the public gateway base — NOT c.req.url, which behind the
+		// prod TLS-terminating ingress is the internal pod URL and would trigger
+		// GitHub `redirect_uri_mismatch` on every legit install. Falls back to the
+		// request origin only on self-host (no public base configured).
+		const callbackUrl = githubInstallCallbackUrl(
+			deps.getPublicGatewayUrl?.(),
+			c.req.url,
+		);
 		const ownership = await verifyInstallationOwnership({
 			code: c.req.query("code"),
 			installationId,
@@ -767,6 +829,21 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				renderOAuthErrorPage(
 					"github_connector_missing",
 					"The GitHub connector is not installed for this organization, or it does not support App installs. Add the GitHub connector and try again.",
+				),
+				400,
+			);
+		}
+
+		// All side-channel checks passed — atomically consume the single-use nonce
+		// now (right before the write) so the link can't be replayed. If the row is
+		// gone between peek and consume (a racing tab/redelivery already consumed
+		// it), fall through to the same invalid_state response — no double-bind.
+		const consumed = await stateStore.consume(stateParam);
+		if (!consumed) {
+			return c.html(
+				renderOAuthErrorPage(
+					"invalid_state",
+					"This GitHub install link is invalid or has expired. Start the install again from your Lobu dashboard.",
 				),
 				400,
 			);

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -48,6 +48,7 @@ import {
 	normalizeConnectorAuthSchema,
 } from "../../../utils/connector-auth.js";
 import type { AppInstallationStore } from "../../../lobu/stores/app-installation-store.js";
+import { exchangeCodeForTokens } from "../../../connect/oauth-providers.js";
 import { createGithubInstallStateStore } from "../../auth/oauth/state-store.js";
 import {
 	renderOAuthErrorPage,
@@ -74,6 +75,92 @@ export function githubAppInstallUrl(appSlug: string, state: string): string {
 	);
 	url.searchParams.set("state", state);
 	return url.toString();
+}
+
+/**
+ * Exchange the OAuth `code` GitHub returns on the install redirect for a USER
+ * token, then list the installations that user can administer and confirm the
+ * callback's `installation_id` is among them. This is the ownership proof that
+ * closes the cross-tenant token-theft hole: installation_ids are enumerable
+ * integers, so without it an attacker (with their OWN valid state/org) could
+ * supply a VICTIM's installation_id and bind the victim's GitHub installation —
+ * and the minted tokens for its repos — into the attacker's org.
+ *
+ * Uses the GitHub *App's* OAuth credentials (GITHUB_APP_CLIENT_ID /
+ * GITHUB_APP_CLIENT_SECRET) — NOT the separate "Lobu" login OAuth app
+ * (GITHUB_CLIENT_ID/SECRET). Requires the App setting "Request user
+ * authorization (OAuth) during installation" ON so `code` is present.
+ *
+ * Returns a discriminated result so the caller maps each failure to a precise
+ * HTTP status WITHOUT mutating any DB state.
+ */
+export type InstallOwnershipResult =
+	| { ok: true }
+	| { ok: false; status: 400 | 403 | 503; code: string; message: string };
+
+/** Default GitHub user-token OAuth exchange (the App's install-time OAuth). */
+async function defaultExchangeInstallOAuthCode(params: {
+	code: string;
+	clientId: string;
+	clientSecret: string;
+	redirectUri: string;
+}): Promise<string | null> {
+	const tokens = await exchangeCodeForTokens({
+		provider: "github",
+		code: params.code,
+		clientId: params.clientId,
+		clientSecret: params.clientSecret,
+		redirectUri: params.redirectUri,
+	});
+	return tokens?.accessToken ?? null;
+}
+
+/**
+ * List the installation ids the authenticated user can administer
+ * (`GET /user/installations`). Paginated (per_page=100) — keeps fetching while
+ * the collected count is below `total_count` and a page is non-empty, so a user
+ * with >100 installations is still verified correctly. Returns null on any HTTP
+ * failure (treated by the caller as "cannot verify" → reject, no mutation).
+ */
+async function defaultFetchUserInstallationIds(
+	userToken: string,
+): Promise<Set<number> | null> {
+	const ids = new Set<number>();
+	const perPage = 100;
+	let page = 1;
+	let total = Number.POSITIVE_INFINITY;
+	// Hard page cap so a hostile/looping total_count can't spin forever.
+	const MAX_PAGES = 100;
+	while (ids.size < total && page <= MAX_PAGES) {
+		const url = `https://api.github.com/user/installations?per_page=${perPage}&page=${page}`;
+		const res = await fetch(url, {
+			headers: {
+				Authorization: `Bearer ${userToken}`,
+				Accept: "application/vnd.github+json",
+				"User-Agent": "lobu",
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+		});
+		if (!res.ok) {
+			logger.warn(
+				{ status: res.status, page },
+				"GitHub /user/installations returned non-OK while verifying install ownership",
+			);
+			return null;
+		}
+		const body = (await res.json()) as {
+			total_count?: number;
+			installations?: Array<{ id?: number }>;
+		};
+		total = typeof body.total_count === "number" ? body.total_count : ids.size;
+		const installs = Array.isArray(body.installations) ? body.installations : [];
+		if (installs.length === 0) break;
+		for (const inst of installs) {
+			if (typeof inst.id === "number") ids.add(inst.id);
+		}
+		page += 1;
+	}
+	return ids;
 }
 
 export type GithubSetupAction = "install" | "update" | "request";
@@ -221,6 +308,100 @@ export interface AppInstallRouterDeps {
 	installationStore: AppInstallationStore;
 	/** Resolve the active org for the request (session-bound + single-tenant). */
 	resolveInstallOrgId(c: import("hono").Context): Promise<string | null>;
+	/**
+	 * Exchange the install-redirect OAuth `code` for a GitHub USER token.
+	 * Injected so tests can mock the exchange (never hits real GitHub). Returns
+	 * null on a failed exchange. Defaults to the App's install-time OAuth.
+	 */
+	exchangeInstallOAuthCode?(params: {
+		code: string;
+		clientId: string;
+		clientSecret: string;
+		redirectUri: string;
+	}): Promise<string | null>;
+	/**
+	 * List the installation ids the user (identified by `userToken`) can
+	 * administer. Injected so tests can mock `/user/installations`. Returns null
+	 * when GitHub can't be reached (caller treats as "cannot verify" → reject).
+	 */
+	fetchUserInstallationIds?(userToken: string): Promise<Set<number> | null>;
+}
+
+/**
+ * Verify the installer actually owns the supplied installation_id (ownership
+ * proof). Performs the OAuth code exchange + `/user/installations` membership
+ * check. Pure of HTTP routing and of any DB mutation — the caller only proceeds
+ * to bind the install when this returns `{ ok: true }`.
+ */
+async function verifyInstallationOwnership(params: {
+	code: string | undefined;
+	installationId: number;
+	redirectUri: string;
+	exchange: NonNullable<AppInstallRouterDeps["exchangeInstallOAuthCode"]>;
+	fetchIds: NonNullable<AppInstallRouterDeps["fetchUserInstallationIds"]>;
+}): Promise<InstallOwnershipResult> {
+	// The App's OAuth creds (NOT the Lobu login OAuth app). Fail safe if unset.
+	const clientId = process.env.GITHUB_APP_CLIENT_ID;
+	const clientSecret = process.env.GITHUB_APP_CLIENT_SECRET;
+	if (!clientId || !clientSecret) {
+		return {
+			ok: false,
+			status: 503,
+			code: "github_app_oauth_not_configured",
+			message:
+				"GitHub App user-authorization is not configured on this gateway (set GITHUB_APP_CLIENT_ID and GITHUB_APP_CLIENT_SECRET, and enable 'Request user authorization (OAuth) during installation' on the App).",
+		};
+	}
+
+	// No code → we cannot prove the caller owns the installation. Reject.
+	if (!params.code || !params.code.trim()) {
+		return {
+			ok: false,
+			status: 400,
+			code: "missing_oauth_code",
+			message:
+				"This GitHub install callback is missing the OAuth code needed to verify you own the installation. Enable 'Request user authorization (OAuth) during installation' on the App and try again.",
+		};
+	}
+
+	const userToken = await params.exchange({
+		code: params.code.trim(),
+		clientId,
+		clientSecret,
+		redirectUri: params.redirectUri,
+	});
+	if (!userToken) {
+		return {
+			ok: false,
+			status: 403,
+			code: "oauth_exchange_failed",
+			message:
+				"We couldn't verify your GitHub identity for this install. Start the install again from your Lobu dashboard.",
+		};
+	}
+
+	const ownedIds = await params.fetchIds(userToken);
+	if (!ownedIds) {
+		return {
+			ok: false,
+			status: 403,
+			code: "ownership_check_unavailable",
+			message:
+				"We couldn't confirm you own this GitHub installation. Try again in a moment.",
+		};
+	}
+
+	if (!ownedIds.has(params.installationId)) {
+		return {
+			ok: false,
+			status: 403,
+			code: "installation_not_owned",
+			message:
+				"This GitHub installation does not belong to your GitHub account. Install the Lobu App on an organization you administer.",
+		};
+	}
+
+	return { ok: true };
 }
 
 /**
@@ -338,6 +519,53 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 		}
 		// Bind to the org encoded in the verified state — never the callback session.
 		const orgId = installState.organizationId;
+
+		// Ownership proof. The signed state proves WHICH org initiated, but NOT that
+		// the caller actually owns the supplied installation_id (an enumerable
+		// integer). Without this, an attacker with their own valid state could pass
+		// a victim's installation_id and bind/transfer the victim's GitHub
+		// installation — and its minted repo tokens — into the attacker's org. Prove
+		// ownership via OAuth-during-install: exchange the `code` for a user token,
+		// then confirm the installation is one the user can administer. ALL of this
+		// runs BEFORE any DB write — every failure returns 4xx/503 with zero mutation.
+		const installationId = Number(installationIdRaw.trim());
+		if (!Number.isInteger(installationId) || installationId <= 0) {
+			return c.html(
+				renderOAuthErrorPage(
+					"invalid_request",
+					"The GitHub install callback carried an invalid installation_id.",
+				),
+				400,
+			);
+		}
+		// The redirect_uri must match the URL GitHub redirected to — derive it from
+		// this request (query stripped) so it matches the App's Callback URL exactly.
+		const callbackUrl = (() => {
+			const u = new URL(c.req.url);
+			u.search = "";
+			return u.toString();
+		})();
+		const ownership = await verifyInstallationOwnership({
+			code: c.req.query("code"),
+			installationId,
+			redirectUri: callbackUrl,
+			exchange: deps.exchangeInstallOAuthCode ?? defaultExchangeInstallOAuthCode,
+			fetchIds: deps.fetchUserInstallationIds ?? defaultFetchUserInstallationIds,
+		});
+		if (!ownership.ok) {
+			logger.warn(
+				{
+					organization_id: orgId,
+					installation_id: installationIdRaw,
+					reason: ownership.code,
+				},
+				"Rejecting GitHub install callback: installation ownership not verified",
+			);
+			return c.html(
+				renderOAuthErrorPage(ownership.code, ownership.message),
+				ownership.status,
+			);
+		}
 
 		// Guard: the org must actually have the github connector definition with an
 		// app_installation auth method, otherwise there's nothing to link the

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -79,12 +79,16 @@ export function githubAppInstallUrl(appSlug: string, state: string): string {
 
 /**
  * Exchange the OAuth `code` GitHub returns on the install redirect for a USER
- * token, then list the installations that user can administer and confirm the
- * callback's `installation_id` is among them. This is the ownership proof that
- * closes the cross-tenant token-theft hole: installation_ids are enumerable
- * integers, so without it an attacker (with their OWN valid state/org) could
- * supply a VICTIM's installation_id and bind the victim's GitHub installation —
- * and the minted tokens for its repos — into the attacker's org.
+ * token, then prove the OAuth'd user is the OWNER of the installation's account:
+ *   - the personal-account owner for a User install, or
+ *   - an active admin/owner of the org for an Organization install.
+ *
+ * This closes the cross-tenant token-theft hole AND the subtler membership-≠-
+ * admin hole: `GET /user/installations` returns installations the user merely
+ * has ACCESS to (org membership / repo collaborator), not ones they administer,
+ * so a non-admin member of a victim org could otherwise bind that org's
+ * installation into their OWN Lobu org and mint tokens for its repos. We require
+ * account ownership, not access.
  *
  * Uses the GitHub *App's* OAuth credentials (GITHUB_APP_CLIENT_ID /
  * GITHUB_APP_CLIENT_SECRET) — NOT the separate "Lobu" login OAuth app
@@ -97,6 +101,13 @@ export function githubAppInstallUrl(appSlug: string, state: string): string {
 export type InstallOwnershipResult =
 	| { ok: true }
 	| { ok: false; status: 400 | 403 | 503; code: string; message: string };
+
+/** A user-administerable installation's owning account, as GitHub reports it. */
+export interface InstallationAccount {
+	login: string;
+	/** GitHub account type: a personal account or an organization. */
+	type: "User" | "Organization" | string;
+}
 
 /** Default GitHub user-token OAuth exchange (the App's install-time OAuth). */
 async function defaultExchangeInstallOAuthCode(params: {
@@ -115,52 +126,126 @@ async function defaultExchangeInstallOAuthCode(params: {
 	return tokens?.accessToken ?? null;
 }
 
-/**
- * List the installation ids the authenticated user can administer
- * (`GET /user/installations`). Paginated (per_page=100) — keeps fetching while
- * the collected count is below `total_count` and a page is non-empty, so a user
- * with >100 installations is still verified correctly. Returns null on any HTTP
- * failure (treated by the caller as "cannot verify" → reject, no mutation).
- */
-async function defaultFetchUserInstallationIds(
+/** Authenticated GitHub GET → parsed JSON, or null on any HTTP/parse failure. */
+async function githubUserGet<T>(
+	url: string,
 	userToken: string,
-): Promise<Set<number> | null> {
-	const ids = new Set<number>();
+): Promise<{ ok: true; data: T } | { ok: false; status: number }> {
+	const res = await fetch(url, {
+		headers: {
+			Authorization: `Bearer ${userToken}`,
+			Accept: "application/vnd.github+json",
+			"User-Agent": "lobu",
+			"X-GitHub-Api-Version": "2022-11-28",
+		},
+	});
+	if (!res.ok) return { ok: false, status: res.status };
+	const data = (await res.json()) as T;
+	return { ok: true, data };
+}
+
+/**
+ * Find the account that owns the installation the user is trying to link, among
+ * the installations the user can administer (`GET /user/installations`,
+ * paginated). Returns the account `{login, type}` for the matching id, `null`
+ * when the id is not in the user's set ("not owned"), or `undefined` on an HTTP
+ * failure (the caller treats that as "cannot verify" → reject, no mutation).
+ */
+async function defaultFetchInstallationAccount(
+	userToken: string,
+	installationId: number,
+): Promise<InstallationAccount | null | undefined> {
 	const perPage = 100;
 	let page = 1;
 	let total = Number.POSITIVE_INFINITY;
-	// Hard page cap so a hostile/looping total_count can't spin forever.
-	const MAX_PAGES = 100;
-	while (ids.size < total && page <= MAX_PAGES) {
-		const url = `https://api.github.com/user/installations?per_page=${perPage}&page=${page}`;
-		const res = await fetch(url, {
+	let seen = 0;
+	const MAX_PAGES = 100; // page cap so a hostile total_count can't loop forever
+	while (seen < total && page <= MAX_PAGES) {
+		const result = await githubUserGet<{
+			total_count?: number;
+			installations?: Array<{ id?: number; account?: InstallationAccount }>;
+		}>(
+			`https://api.github.com/user/installations?per_page=${perPage}&page=${page}`,
+			userToken,
+		);
+		if (!result.ok) {
+			logger.warn(
+				{ status: result.status, page },
+				"GitHub /user/installations returned non-OK while verifying install ownership",
+			);
+			return undefined;
+		}
+		const body = result.data;
+		total = typeof body.total_count === "number" ? body.total_count : seen;
+		const installs = Array.isArray(body.installations) ? body.installations : [];
+		if (installs.length === 0) break;
+		for (const inst of installs) {
+			seen += 1;
+			if (inst.id === installationId && inst.account?.login) {
+				return { login: inst.account.login, type: inst.account.type };
+			}
+		}
+		page += 1;
+	}
+	return null;
+}
+
+/** The authenticated user's GitHub login (`GET /user`), or undefined on failure. */
+async function defaultFetchAuthedUserLogin(
+	userToken: string,
+): Promise<string | undefined> {
+	const result = await githubUserGet<{ login?: string }>(
+		"https://api.github.com/user",
+		userToken,
+	);
+	if (!result.ok || typeof result.data.login !== "string") {
+		if (!result.ok) {
+			logger.warn(
+				{ status: result.status },
+				"GitHub /user returned non-OK while verifying install ownership",
+			);
+		}
+		return undefined;
+	}
+	return result.data.login;
+}
+
+/**
+ * The authenticated user's membership role in `org`
+ * (`GET /user/memberships/orgs/{org}` — returns the CALLER's own membership, so
+ * the user token suffices). Returns `{ state, role }`, or undefined on failure
+ * (treated as "cannot verify"). A 404/403 (not a member) is surfaced as a
+ * defined value with empty fields so the caller maps it to "not admin", not
+ * "cannot verify".
+ */
+async function defaultFetchOrgMembershipRole(
+	userToken: string,
+	org: string,
+): Promise<{ state: string; role: string } | undefined> {
+	const res = await fetch(
+		`https://api.github.com/user/memberships/orgs/${encodeURIComponent(org)}`,
+		{
 			headers: {
 				Authorization: `Bearer ${userToken}`,
 				Accept: "application/vnd.github+json",
 				"User-Agent": "lobu",
 				"X-GitHub-Api-Version": "2022-11-28",
 			},
-		});
-		if (!res.ok) {
-			logger.warn(
-				{ status: res.status, page },
-				"GitHub /user/installations returned non-OK while verifying install ownership",
-			);
-			return null;
-		}
-		const body = (await res.json()) as {
-			total_count?: number;
-			installations?: Array<{ id?: number }>;
-		};
-		total = typeof body.total_count === "number" ? body.total_count : ids.size;
-		const installs = Array.isArray(body.installations) ? body.installations : [];
-		if (installs.length === 0) break;
-		for (const inst of installs) {
-			if (typeof inst.id === "number") ids.add(inst.id);
-		}
-		page += 1;
+		},
+	);
+	// 403/404 = the user is not a member of that org → definitively "not admin".
+	if (res.status === 403 || res.status === 404) {
+		return { state: "none", role: "none" };
 	}
-	return ids;
+	if (!res.ok) {
+		logger.warn(
+			{ status: res.status, org },
+			"GitHub /user/memberships/orgs returned non-OK while verifying install admin",
+		);
+		return undefined;
+	}
+	const body = (await res.json()) as { state?: string; role?: string };
+	return { state: body.state ?? "", role: body.role ?? "" };
 }
 
 export type GithubSetupAction = "install" | "update" | "request";
@@ -217,90 +302,110 @@ export async function linkGithubAppInstallation(params: {
 		metadata: params.metadata ?? {},
 	});
 
-	// 2. Find an existing connection in this org for the github connector already
-	//    bound to this install (idempotent re-install / callback retry). The
-	//    install id is the stable key; match on config.installation_ref.
-	const existing = (await sql`
-		SELECT id, config
-		FROM connections
-		WHERE organization_id = ${params.organizationId}
-			AND connector_key = ${GITHUB_CONNECTOR_KEY}
-			AND deleted_at IS NULL
-			AND (
-				config ->> 'installation_ref' = ${String(install.id)}
-				OR config ->> 'installation_ref' = ${String(params.installationId)}
-			)
-		ORDER BY id ASC
-		LIMIT 1
-	`) as unknown as Array<{ id: number; config: Record<string, unknown> | null }>;
+	// 2 + 3. Find-or-create the connection bound to this install, serialized by a
+	//    transaction-scoped advisory lock keyed on (org, install.id). Without it,
+	//    two concurrent callbacks for the same install both SELECT-miss and both
+	//    INSERT → duplicate connections. The lock lives in Postgres (not memory),
+	//    so it serializes across replicas; mirrors the app-installation store's
+	//    pg_advisory_xact_lock convergence pattern. The install row upsert (step 1)
+	//    has its own lock in the store, so it stays outside this transaction.
+	const connectionLockTag = `github_app_install_connection:${params.organizationId}:${install.id}`;
+	return sql.begin(async (tx) => {
+		await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
+			connectionLockTag,
+		]);
 
-	if (existing.length > 0) {
-		const connectionId = Number(existing[0].id);
-		const mergedConfig = {
-			...(existing[0].config ?? {}),
-			installation_ref: install.id,
-		};
-		await sql`
-			UPDATE connections
-			SET config = ${sql.json(mergedConfig)},
-				status = 'active',
-				updated_at = NOW()
-			WHERE id = ${connectionId}
-				AND organization_id = ${params.organizationId}
-		`;
+		// Find an existing connection already bound to this install (idempotent
+		// re-install / callback retry). The install id is the stable key; match on
+		// config.installation_ref. Read under the lock so a racing callback that
+		// already created the row is seen here instead of double-inserted.
+		const existing = (await tx`
+			SELECT id, config
+			FROM connections
+			WHERE organization_id = ${params.organizationId}
+				AND connector_key = ${GITHUB_CONNECTOR_KEY}
+				AND deleted_at IS NULL
+				AND (
+					config ->> 'installation_ref' = ${String(install.id)}
+					OR config ->> 'installation_ref' = ${String(params.installationId)}
+				)
+			ORDER BY id ASC
+			LIMIT 1
+		`) as unknown as Array<{
+			id: number;
+			config: Record<string, unknown> | null;
+		}>;
+
+		if (existing.length > 0) {
+			const connectionId = Number(existing[0].id);
+			const mergedConfig = {
+				...(existing[0].config ?? {}),
+				installation_ref: install.id,
+			};
+			await tx`
+				UPDATE connections
+				SET config = ${tx.json(mergedConfig)},
+					status = 'active',
+					updated_at = NOW()
+				WHERE id = ${connectionId}
+					AND organization_id = ${params.organizationId}
+			`;
+			return {
+				installId: install.id,
+				connectionId,
+				createdConnection: false,
+				accountLogin,
+			};
+		}
+
+		// No existing linked connection — create one bound to the install. The
+		// config carries ONLY installation_ref (no repo/org target), so the
+		// connect-flow webhook gate (connectionWantsWebhook) never fires: inbound
+		// deliveries route through the shared /app-webhooks/github endpoint, and
+		// resolveExecutionAuth mints a tenant-scoped token from the install.
+		const displayName = accountLogin
+			? `GitHub (${accountLogin})`
+			: "GitHub App";
+		const slugResult = await resolveNewConnectionSlug({
+			organizationId: params.organizationId,
+			connectorKey: GITHUB_CONNECTOR_KEY,
+			displayName,
+			db: tx,
+		});
+		if ("error" in slugResult) {
+			throw new Error(slugResult.error);
+		}
+
+		const inserted = await insertConnectionWithSlug<
+			Array<{ id: number; slug: string }>
+		>({
+			organizationId: params.organizationId,
+			connectorKey: GITHUB_CONNECTOR_KEY,
+			displayName,
+			initialSlug: slugResult.slug,
+			explicit: false,
+			db: tx,
+			doInsert: (slug) => tx`
+				INSERT INTO connections (
+					organization_id, connector_key, slug, display_name, status, config, created_by
+				) VALUES (
+					${params.organizationId}, ${GITHUB_CONNECTOR_KEY}, ${slug}, ${displayName},
+					'active', ${tx.json({ installation_ref: install.id })}, ${params.createdBy ?? null}
+				)
+				RETURNING id, slug
+			`,
+		}).catch((err) => {
+			if (err instanceof ConnectionSlugConflictError) throw new Error(err.message);
+			throw err;
+		});
+
 		return {
 			installId: install.id,
-			connectionId,
-			createdConnection: false,
+			connectionId: Number(inserted[0].id),
+			createdConnection: true,
 			accountLogin,
 		};
-	}
-
-	// 3. No existing linked connection — create one bound to the install. The
-	//    config carries ONLY installation_ref (no repo/org target), so the
-	//    connect-flow webhook gate (connectionWantsWebhook) never fires: inbound
-	//    deliveries route through the shared /app-webhooks/github endpoint, and
-	//    resolveExecutionAuth mints a tenant-scoped token from the install.
-	const displayName = accountLogin
-		? `GitHub (${accountLogin})`
-		: "GitHub App";
-	const slugResult = await resolveNewConnectionSlug({
-		organizationId: params.organizationId,
-		connectorKey: GITHUB_CONNECTOR_KEY,
-		displayName,
 	});
-	if ("error" in slugResult) {
-		throw new Error(slugResult.error);
-	}
-
-	const inserted = await insertConnectionWithSlug<
-		Array<{ id: number; slug: string }>
-	>({
-		organizationId: params.organizationId,
-		connectorKey: GITHUB_CONNECTOR_KEY,
-		displayName,
-		initialSlug: slugResult.slug,
-		explicit: false,
-		doInsert: (slug) => sql`
-			INSERT INTO connections (
-				organization_id, connector_key, slug, display_name, status, config, created_by
-			) VALUES (
-				${params.organizationId}, ${GITHUB_CONNECTOR_KEY}, ${slug}, ${displayName},
-				'active', ${sql.json({ installation_ref: install.id })}, ${params.createdBy ?? null}
-			)
-			RETURNING id, slug
-		`,
-	}).catch((err) => {
-		if (err instanceof ConnectionSlugConflictError) throw new Error(err.message);
-		throw err;
-	});
-
-	return {
-		installId: install.id,
-		connectionId: Number(inserted[0].id),
-		createdConnection: true,
-		accountLogin,
-	};
 }
 
 /** Dependencies the install routes need (injected for testability). */
@@ -320,25 +425,45 @@ export interface AppInstallRouterDeps {
 		redirectUri: string;
 	}): Promise<string | null>;
 	/**
-	 * List the installation ids the user (identified by `userToken`) can
-	 * administer. Injected so tests can mock `/user/installations`. Returns null
-	 * when GitHub can't be reached (caller treats as "cannot verify" → reject).
+	 * Resolve the owning account of the installation the user is linking, among
+	 * the installations the user can administer (`GET /user/installations`).
+	 * `{login,type}` when found, `null` when the id is not in the user's set,
+	 * `undefined` on an HTTP failure ("cannot verify" → reject). Injected so
+	 * tests can mock GitHub.
 	 */
-	fetchUserInstallationIds?(userToken: string): Promise<Set<number> | null>;
+	fetchInstallationAccount?(
+		userToken: string,
+		installationId: number,
+	): Promise<InstallationAccount | null | undefined>;
+	/** The authed user's GitHub login (`GET /user`); undefined on failure. */
+	fetchAuthedUserLogin?(userToken: string): Promise<string | undefined>;
+	/**
+	 * The authed user's membership in `org` (`GET /user/memberships/orgs/{org}`);
+	 * undefined on failure. A non-member is reported as a defined value with
+	 * non-admin fields, not undefined.
+	 */
+	fetchOrgMembershipRole?(
+		userToken: string,
+		org: string,
+	): Promise<{ state: string; role: string } | undefined>;
 }
 
 /**
- * Verify the installer actually owns the supplied installation_id (ownership
- * proof). Performs the OAuth code exchange + `/user/installations` membership
- * check. Pure of HTTP routing and of any DB mutation — the caller only proceeds
- * to bind the install when this returns `{ ok: true }`.
+ * Verify the OAuth'd user is the OWNER of the installation's account (ownership,
+ * not mere access). Performs: code exchange → resolve the installation's owning
+ * account from the user's administerable installations → authorize by account
+ * type (personal-account login match, or active org admin/owner). Pure of HTTP
+ * routing and of any DB mutation — the caller only binds when this returns
+ * `{ ok: true }`.
  */
 async function verifyInstallationOwnership(params: {
 	code: string | undefined;
 	installationId: number;
 	redirectUri: string;
 	exchange: NonNullable<AppInstallRouterDeps["exchangeInstallOAuthCode"]>;
-	fetchIds: NonNullable<AppInstallRouterDeps["fetchUserInstallationIds"]>;
+	fetchAccount: NonNullable<AppInstallRouterDeps["fetchInstallationAccount"]>;
+	fetchLogin: NonNullable<AppInstallRouterDeps["fetchAuthedUserLogin"]>;
+	fetchMembership: NonNullable<AppInstallRouterDeps["fetchOrgMembershipRole"]>;
 }): Promise<InstallOwnershipResult> {
 	// The App's OAuth creds (NOT the Lobu login OAuth app). Fail safe if unset.
 	const clientId = process.env.GITHUB_APP_CLIENT_ID;
@@ -380,8 +505,11 @@ async function verifyInstallationOwnership(params: {
 		};
 	}
 
-	const ownedIds = await params.fetchIds(userToken);
-	if (!ownedIds) {
+	// 1. Resolve the installation's owning account among the user's
+	//    administerable installations. undefined = cannot verify; null = the user
+	//    has no access to this installation at all → not owned.
+	const account = await params.fetchAccount(userToken, params.installationId);
+	if (account === undefined) {
 		return {
 			ok: false,
 			status: 403,
@@ -390,8 +518,7 @@ async function verifyInstallationOwnership(params: {
 				"We couldn't confirm you own this GitHub installation. Try again in a moment.",
 		};
 	}
-
-	if (!ownedIds.has(params.installationId)) {
+	if (account === null) {
 		return {
 			ok: false,
 			status: 403,
@@ -401,6 +528,54 @@ async function verifyInstallationOwnership(params: {
 		};
 	}
 
+	// 2. The authed user's login (needed for the personal-account match).
+	const authedLogin = await params.fetchLogin(userToken);
+	if (!authedLogin) {
+		return {
+			ok: false,
+			status: 403,
+			code: "ownership_check_unavailable",
+			message:
+				"We couldn't confirm your GitHub identity for this install. Try again in a moment.",
+		};
+	}
+
+	// 3. Authorize by account type. Access ≠ ownership: a non-admin org member
+	//    appears in /user/installations but must NOT be able to bind the org's
+	//    installation. Require the personal-account owner, or an active org admin.
+	if (account.type === "Organization") {
+		const membership = await params.fetchMembership(userToken, account.login);
+		if (membership === undefined) {
+			return {
+				ok: false,
+				status: 403,
+				code: "ownership_check_unavailable",
+				message:
+					"We couldn't confirm your role in this GitHub organization. Try again in a moment.",
+			};
+		}
+		if (membership.state !== "active" || membership.role !== "admin") {
+			return {
+				ok: false,
+				status: 403,
+				code: "installation_not_admin",
+				message:
+					"You must be an admin of this GitHub organization to connect its installation to Lobu.",
+			};
+		}
+		return { ok: true };
+	}
+
+	// Personal-account install: the OAuth'd user must BE the account owner.
+	if (authedLogin.toLowerCase() !== account.login.toLowerCase()) {
+		return {
+			ok: false,
+			status: 403,
+			code: "installation_not_owned",
+			message:
+				"This GitHub installation belongs to a different account. Install the Lobu App from the account that owns it.",
+		};
+	}
 	return { ok: true };
 }
 
@@ -521,13 +696,14 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 		const orgId = installState.organizationId;
 
 		// Ownership proof. The signed state proves WHICH org initiated, but NOT that
-		// the caller actually owns the supplied installation_id (an enumerable
-		// integer). Without this, an attacker with their own valid state could pass
-		// a victim's installation_id and bind/transfer the victim's GitHub
-		// installation — and its minted repo tokens — into the attacker's org. Prove
-		// ownership via OAuth-during-install: exchange the `code` for a user token,
-		// then confirm the installation is one the user can administer. ALL of this
-		// runs BEFORE any DB write — every failure returns 4xx/503 with zero mutation.
+		// the caller OWNS the supplied installation_id (an enumerable integer).
+		// Without this, an attacker with their own valid state could pass a victim's
+		// installation_id and bind/transfer the victim's GitHub installation — and
+		// its minted repo tokens — into the attacker's org. And mere membership is
+		// not enough: a non-admin org member can SEE the org's installation, so we
+		// require account OWNERSHIP (personal-account owner, or active org admin).
+		// Prove it via OAuth-during-install — ALL of this runs BEFORE any DB write,
+		// so every failure returns 4xx/503 with zero mutation.
 		const installationId = Number(installationIdRaw.trim());
 		if (!Number.isInteger(installationId) || installationId <= 0) {
 			return c.html(
@@ -550,7 +726,11 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 			installationId,
 			redirectUri: callbackUrl,
 			exchange: deps.exchangeInstallOAuthCode ?? defaultExchangeInstallOAuthCode,
-			fetchIds: deps.fetchUserInstallationIds ?? defaultFetchUserInstallationIds,
+			fetchAccount:
+				deps.fetchInstallationAccount ?? defaultFetchInstallationAccount,
+			fetchLogin: deps.fetchAuthedUserLogin ?? defaultFetchAuthedUserLogin,
+			fetchMembership:
+				deps.fetchOrgMembershipRole ?? defaultFetchOrgMembershipRole,
 		});
 		if (!ownership.ok) {
 			logger.warn(

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -22,13 +22,17 @@
  * Multi-replica: stateless. Org resolution + the two upserts read/write Postgres
  * only; the store upsert serializes ownership on a Postgres advisory lock +
  * partial unique index, so concurrent callbacks across pods converge to one
- * active owner. No per-pod memo.
+ * active owner. The signed `state` is a Postgres-backed nonce (oauth_states),
+ * readable/consumable from any replica. No per-pod memo.
  *
- * Cross-org safety: the install is bound to the CALLBACK session's active org.
- * The owletto "Install on GitHub" UI (separate PR) will additionally carry a
- * signed `state` so a phished install link can't plant a connection into the
- * wrong tenant; until then the session org is the authority (an unauthenticated
- * hit with no single-tenant fallback is rejected, never silently tenanted).
+ * Cross-org safety (CSRF / cross-tenant): the install URL the UI sends the user
+ * to is minted by `GET /github/app/install`, which binds a signed `state` nonce
+ * to the INITIATING session's org. GitHub passes `state` through to the callback
+ * Setup URL. The callback verifies + consumes that state BEFORE any DB write and
+ * binds the install to the org encoded in the state — NOT the ambient callback
+ * session. A callback with a missing/invalid/expired `state` is rejected (4xx)
+ * with zero mutation, so a phished/forged GET can never plant a connection into
+ * a victim's org.
  */
 
 import { Hono } from "hono";
@@ -44,6 +48,7 @@ import {
 	normalizeConnectorAuthSchema,
 } from "../../../utils/connector-auth.js";
 import type { AppInstallationStore } from "../../../lobu/stores/app-installation-store.js";
+import { createGithubInstallStateStore } from "../../auth/oauth/state-store.js";
 import {
 	renderOAuthErrorPage,
 	renderOAuthSuccessPage,
@@ -55,6 +60,21 @@ const logger = createLogger("app-install-routes");
 const GITHUB_CONNECTOR_KEY = "github";
 const GITHUB_PROVIDER = "github";
 const GITHUB_PROVIDER_INSTANCE = "cloud";
+
+/**
+ * Build the GitHub App install URL the user is redirected to. `app_slug` is the
+ * Lobu GitHub App's slug (the `github.com/apps/<slug>` segment); `state` is the
+ * signed nonce the callback verifies. GitHub passes `state` through verbatim to
+ * the App's configured Setup URL (our callback), which is how we round-trip the
+ * initiating org without trusting the callback session.
+ */
+export function githubAppInstallUrl(appSlug: string, state: string): string {
+	const url = new URL(
+		`https://github.com/apps/${encodeURIComponent(appSlug)}/installations/new`,
+	);
+	url.searchParams.set("state", state);
+	return url.toString();
+}
 
 export type GithubSetupAction = "install" | "update" | "request";
 
@@ -212,6 +232,41 @@ export interface AppInstallRouterDeps {
 export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 	const router = new Hono();
 
+	// Start of the GitHub App install flow. Binds a signed `state` nonce to the
+	// initiating session's org and redirects to GitHub's install page. The
+	// callback verifies that state before mutating anything — this is the CSRF /
+	// cross-tenant guard (the callback is otherwise a public, unauthenticated GET).
+	router.get("/github/app/install", async (c) => {
+		const appSlug = process.env.GITHUB_APP_SLUG;
+		if (!process.env.GITHUB_APP_ID || !appSlug) {
+			return c.html(
+				renderOAuthErrorPage(
+					"github_app_not_configured",
+					"The Lobu GitHub App is not configured on this gateway (set GITHUB_APP_ID and GITHUB_APP_SLUG).",
+				),
+				503,
+			);
+		}
+
+		// Bind the install to the initiating session's active org (single-tenant
+		// fallback for self-host). Without this the resulting state would carry no
+		// authoritative org and the callback couldn't tell which tenant initiated.
+		const orgId = await deps.resolveInstallOrgId(c);
+		if (!orgId) {
+			return c.html(
+				renderOAuthErrorPage(
+					"unauthorized",
+					"Sign in to your organization before installing the GitHub App.",
+				),
+				401,
+			);
+		}
+
+		const stateStore = createGithubInstallStateStore();
+		const state = await stateStore.create({ organizationId: orgId });
+		return c.redirect(githubAppInstallUrl(appSlug, state), 302);
+	});
+
 	router.get("/github/app/install/callback", async (c) => {
 		const appId = process.env.GITHUB_APP_ID;
 		if (!appId) {
@@ -249,16 +304,40 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 			);
 		}
 
-		const orgId = await deps.resolveInstallOrgId(c);
-		if (!orgId) {
+		// CSRF / cross-tenant guard. The callback is a public, unauthenticated GET,
+		// so the org MUST come from the signed `state` minted by GET
+		// /github/app/install — NOT the ambient callback session. Verify + consume
+		// the state BEFORE any DB write: a missing/invalid/expired state rejects
+		// (4xx) with zero mutation, so a forged GET can't plant a connection into a
+		// victim's org. `consume` is an atomic DELETE … RETURNING (single-use,
+		// replay-safe across replicas).
+		const stateParam = c.req.query("state");
+		if (!stateParam) {
 			return c.html(
 				renderOAuthErrorPage(
-					"unauthorized",
-					"Sign in to your organization before installing the GitHub App.",
+					"invalid_state",
+					"This GitHub install callback is missing its security token. Start the install from your Lobu dashboard.",
 				),
-				401,
+				400,
 			);
 		}
+		const stateStore = createGithubInstallStateStore();
+		const installState = await stateStore.consume(stateParam);
+		if (!installState) {
+			logger.warn(
+				{ installation_id: installationIdRaw },
+				"Rejecting GitHub install callback: missing/invalid/expired state",
+			);
+			return c.html(
+				renderOAuthErrorPage(
+					"invalid_state",
+					"This GitHub install link is invalid or has expired. Start the install again from your Lobu dashboard.",
+				),
+				400,
+			);
+		}
+		// Bind to the org encoded in the verified state — never the callback session.
+		const orgId = installState.organizationId;
 
 		// Guard: the org must actually have the github connector definition with an
 		// app_installation auth method, otherwise there's nothing to link the

--- a/packages/server/src/gateway/routes/public/slack.ts
+++ b/packages/server/src/gateway/routes/public/slack.ts
@@ -78,7 +78,7 @@ async function resolveSingleTenantOrgId(): Promise<string | null> {
  * then the self-host single-tenant fallback. Returns `null` only when
  * neither path yields a definite org — at which point the route must reject.
  */
-async function resolveInstallOrgId(c: Context): Promise<string | null> {
+export async function resolveInstallOrgId(c: Context): Promise<string | null> {
   const sessionOrgId = readSessionOrgId(c);
   if (sessionOrgId) return sessionOrgId;
   return resolveSingleTenantOrgId();

--- a/packages/server/src/tools/admin/helpers/app-installation-guard.ts
+++ b/packages/server/src/tools/admin/helpers/app-installation-guard.ts
@@ -1,47 +1,96 @@
 /**
- * Guard against creating an unbound `app_installation` connection.
+ * Guard against creating an UNBOUND `app_installation` connection.
  *
- * When a connector's PRIMARY auth method is `app_installation` (e.g. github),
- * the ONLY legitimate creator of a connection is the App install callback's
- * `linkGithubAppInstallation`, which stamps `config.installation_ref`. A user
- * creating such a connection through the normal manage_connections create/connect
- * path with no `installation_ref` would produce a dead, unbound connection
- * (resolveAppInstallationCredential falls through to a missing fallback). Reject
- * it up front and point the user at the install flow.
+ * When a connector's primary auth method is `app_installation` (e.g. github),
+ * a connection bound to an install is created by the App install callback's
+ * `linkGithubAppInstallation`, which stamps `config.installation_ref`. The guard
+ * rejects a create/connect that would resolve to `app_installation` auth with no
+ * `installation_ref` — a dead, unbound connection — and points the user at the
+ * install flow.
  *
- * Connector-agnostic: keys on the auth method type, so it covers any future
- * app_installation connector — not just github.
+ * SELECTION-AWARE: it must NOT block a connection that resolves to a DIFFERENT
+ * auth method. github also declares oauth + env_keys, so a legit create/connect
+ * that supplies an auth profile slug, env/PAT creds in config, or a managedBy
+ * grant uses one of those methods — the guard skips entirely. Only when no such
+ * intent is present (and there is no installation_ref) does the connection fall
+ * through to the app_installation primary, which is what we reject.
+ *
+ * Connector-agnostic: keys on the resolved auth method type (not on `github`),
+ * so it covers any future app_installation connector.
  */
 
 import { parseJsonObject } from '@lobu/core';
 import {
+  getEnvAuthFieldKeys,
   isPrimaryAuthMethodAppInstallation,
   normalizeConnectorAuthSchema,
 } from '../../../utils/connector-auth';
+
+function hasInstallationRef(config: Record<string, unknown>): boolean {
+  const ref = config.installation_ref;
+  return (
+    (typeof ref === 'number' && Number.isFinite(ref)) ||
+    (typeof ref === 'string' && ref.trim().length > 0)
+  );
+}
+
+function hasManagedByOrg(config: Record<string, unknown>): boolean {
+  const managedBy = config.managedBy;
+  if (!managedBy || typeof managedBy !== 'object' || Array.isArray(managedBy)) {
+    return false;
+  }
+  const org = (managedBy as Record<string, unknown>).org;
+  return typeof org === 'string' && org.trim().length > 0;
+}
 
 /**
  * Returns an `{ error }` result to short-circuit the create/connect handler when
  * the connection would be an unbound app_installation connection, else null.
  *
- * @param authSchema  the connector definition's `auth_schema` (raw jsonb/string)
- * @param config      the connection `config` being created (may carry installation_ref)
+ * The caller passes the auth-INTENT signals it received so the guard can tell a
+ * deliberate oauth/PAT/env/managed create from a bare one that falls through to
+ * app_installation.
+ *
+ * @param authSchema          the connector definition's `auth_schema` (raw jsonb/string)
+ * @param config              the connection `config` being created
+ * @param connectorKey        for the (connector-agnostic) error message
+ * @param authProfileSlug     an explicitly selected auth profile (oauth/env/browser)
+ * @param appAuthProfileSlug  an explicitly selected OAuth app profile
  */
 export function rejectUnboundAppInstallationCreate(params: {
   authSchema: unknown;
   config: unknown;
+  connectorKey: string;
+  authProfileSlug?: string | null;
+  appAuthProfileSlug?: string | null;
 }): { error: string } | null {
   const schema = normalizeConnectorAuthSchema(params.authSchema);
+  // Only connectors whose PRIMARY method is app_installation are in scope.
   if (!isPrimaryAuthMethodAppInstallation(schema)) return null;
 
   const config = parseJsonObject(params.config);
-  const ref = config.installation_ref;
-  const hasRef =
-    (typeof ref === 'number' && Number.isFinite(ref)) ||
-    (typeof ref === 'string' && ref.trim().length > 0);
-  if (hasRef) return null;
 
+  // Already bound (the install-callback shape) → allow.
+  if (hasInstallationRef(config)) return null;
+
+  // A deliberate non-app_installation auth selection → the connection will use
+  // THAT method, not app_installation. Skip the guard.
+  if (params.authProfileSlug?.trim() || params.appAuthProfileSlug?.trim()) {
+    return null;
+  }
+  if (hasManagedByOrg(config)) return null;
+  // Env/PAT creds supplied directly in config (e.g. GITHUB_TOKEN) → env auth.
+  const envKeys = getEnvAuthFieldKeys(schema);
+  if (envKeys.some((key) => config[key] !== undefined && config[key] !== null)) {
+    return null;
+  }
+
+  // No installation_ref and no other auth intent → this would resolve to the
+  // app_installation primary with nothing to bind. Reject with install guidance.
   return {
     error:
-      'This connector is connected by installing the GitHub App, not by creating a connection directly. Start the install from the GitHub App install flow (/github/app/install) — the install callback links the connection automatically.',
+      `Connector '${params.connectorKey}' is connected by installing its app (which links the connection automatically), not by creating a connection directly. ` +
+      `Start the app install flow instead — for GitHub that's /github/app/install. ` +
+      `(To use a different auth method this connector supports, pass an auth profile or credentials.)`,
   };
 }

--- a/packages/server/src/tools/admin/helpers/app-installation-guard.ts
+++ b/packages/server/src/tools/admin/helpers/app-installation-guard.ts
@@ -1,0 +1,47 @@
+/**
+ * Guard against creating an unbound `app_installation` connection.
+ *
+ * When a connector's PRIMARY auth method is `app_installation` (e.g. github),
+ * the ONLY legitimate creator of a connection is the App install callback's
+ * `linkGithubAppInstallation`, which stamps `config.installation_ref`. A user
+ * creating such a connection through the normal manage_connections create/connect
+ * path with no `installation_ref` would produce a dead, unbound connection
+ * (resolveAppInstallationCredential falls through to a missing fallback). Reject
+ * it up front and point the user at the install flow.
+ *
+ * Connector-agnostic: keys on the auth method type, so it covers any future
+ * app_installation connector — not just github.
+ */
+
+import { parseJsonObject } from '@lobu/core';
+import {
+  isPrimaryAuthMethodAppInstallation,
+  normalizeConnectorAuthSchema,
+} from '../../../utils/connector-auth';
+
+/**
+ * Returns an `{ error }` result to short-circuit the create/connect handler when
+ * the connection would be an unbound app_installation connection, else null.
+ *
+ * @param authSchema  the connector definition's `auth_schema` (raw jsonb/string)
+ * @param config      the connection `config` being created (may carry installation_ref)
+ */
+export function rejectUnboundAppInstallationCreate(params: {
+  authSchema: unknown;
+  config: unknown;
+}): { error: string } | null {
+  const schema = normalizeConnectorAuthSchema(params.authSchema);
+  if (!isPrimaryAuthMethodAppInstallation(schema)) return null;
+
+  const config = parseJsonObject(params.config);
+  const ref = config.installation_ref;
+  const hasRef =
+    (typeof ref === 'number' && Number.isFinite(ref)) ||
+    (typeof ref === 'string' && ref.trim().length > 0);
+  if (hasRef) return null;
+
+  return {
+    error:
+      'This connector is connected by installing the GitHub App, not by creating a connection directly. Start the install from the GitHub App install flow (/github/app/install) — the install callback links the connection automatically.',
+  };
+}

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -24,6 +24,7 @@ import {
   resolveConnectionVisibility,
 } from '../../helpers/connection-helpers';
 import { assertEntityIdsInOrg } from '../../helpers/db-helpers';
+import { rejectUnboundAppInstallationCreate } from '../../helpers/app-installation-guard';
 import { type FeedDefinition, splitConfigByFeedScope } from '../../helpers/feed-helpers';
 import { getScopedConnectorDefinition } from '../../connector-definition-helpers';
 import { buildConnectionsUrl } from '../../../../utils/url-builder';
@@ -68,6 +69,14 @@ export async function handleConnect(
       setup_url: buildSetupUrl({ install: args.connector_key }),
     };
   }
+
+  // Reject a direct connect of an unbound app_installation connection — those are
+  // created only by the App install callback (which sets installation_ref).
+  const appInstallGuard = rejectUnboundAppInstallationCreate({
+    authSchema: connector.auth_schema,
+    config: args.config,
+  });
+  if (appInstallGuard) return appInstallGuard;
 
   const deviceBinding = await resolveDeviceBinding({
     organizationId,

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -70,11 +70,17 @@ export async function handleConnect(
     };
   }
 
-  // Reject a direct connect of an unbound app_installation connection — those are
-  // created only by the App install callback (which sets installation_ref).
+  // Reject a direct connect of an UNBOUND app_installation connection (no
+  // installation_ref AND no other auth intent) — those are created only by the
+  // App install callback. Selection-aware: a connect that supplies an auth
+  // profile / app profile / env creds / managedBy resolves to a different method
+  // and is allowed through.
   const appInstallGuard = rejectUnboundAppInstallationCreate({
     authSchema: connector.auth_schema,
     config: args.config,
+    connectorKey: args.connector_key,
+    authProfileSlug: args.auth_profile_slug,
+    appAuthProfileSlug: args.app_auth_profile_slug,
   });
   if (appInstallGuard) return appInstallGuard;
 

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -41,6 +41,7 @@ import {
   resolveConnectionVisibility,
 } from '../../helpers/connection-helpers';
 import { assertEntityIdsInOrg, callerIsAdmin as resolveCallerIsAdmin } from '../../helpers/db-helpers';
+import { rejectUnboundAppInstallationCreate } from '../../helpers/app-installation-guard';
 import { type FeedDefinition, splitConfigByFeedScope } from '../../helpers/feed-helpers';
 import { getScopedConnectorDefinition } from '../../connector-definition-helpers';
 import type { ToolContext } from '../../../registry';
@@ -357,6 +358,15 @@ export async function handleCreate(
   if (!connector) {
     return { error: `Connector '${args.connector_key}' not found or not active` };
   }
+
+  // Reject a direct create of an unbound app_installation connection — those are
+  // created only by the App install callback (which sets installation_ref). The
+  // user must start the install flow instead.
+  const appInstallGuard = rejectUnboundAppInstallationCreate({
+    authSchema: connector.auth_schema,
+    config: args.config,
+  });
+  if (appInstallGuard) return appInstallGuard;
 
   const deviceBinding = await resolveDeviceBinding({
     organizationId,

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -359,12 +359,17 @@ export async function handleCreate(
     return { error: `Connector '${args.connector_key}' not found or not active` };
   }
 
-  // Reject a direct create of an unbound app_installation connection — those are
-  // created only by the App install callback (which sets installation_ref). The
-  // user must start the install flow instead.
+  // Reject a direct create of an UNBOUND app_installation connection (no
+  // installation_ref AND no other auth intent) — those are created only by the
+  // App install callback. Selection-aware: a create that supplies an auth profile
+  // / app profile / env creds / managedBy resolves to a different method and is
+  // allowed through.
   const appInstallGuard = rejectUnboundAppInstallationCreate({
     authSchema: connector.auth_schema,
     config: args.config,
+    connectorKey: args.connector_key,
+    authProfileSlug: args.auth_profile_slug,
+    appAuthProfileSlug: args.app_auth_profile_slug,
   });
   if (appInstallGuard) return appInstallGuard;
 

--- a/packages/server/src/tools/admin/manage_connections/schemas.ts
+++ b/packages/server/src/tools/admin/manage_connections/schemas.ts
@@ -83,9 +83,13 @@ export const CreateAction = Type.Object({
     })
   ),
   device_worker_id: Type.Optional(
-    Type.String({
+    // Nullable: serverless connections (no device) send `null`, not just omit.
+    // The UI/serverless callers pass `device_worker_id: null` explicitly, which
+    // a bare `Type.String` rejected ("Expected string"); `resolveDeviceBinding`
+    // normalizes null/empty to serverless.
+    Type.Union([Type.String(), Type.Null()], {
       description:
-        "Run this connection's syncs/actions on a specific device worker (its device_workers.id) instead of the Lobu server (runs serverless). Required for connectors that declare a required_capability; optional otherwise. The device must belong to you or be granted to this org.",
+        "Run this connection's syncs/actions on a specific device worker (its device_workers.id) instead of the Lobu server (runs serverless). Null/omit runs serverless. Required for connectors that declare a required_capability. The device must belong to you or be granted to this org.",
     })
   ),
   entity_ids: Type.Optional(
@@ -201,9 +205,10 @@ export const ConnectAction = Type.Object({
     Type.Record(Type.String(), Type.Any(), { description: 'Connection config' })
   ),
   device_worker_id: Type.Optional(
-    Type.String({
+    // Nullable for serverless connections — see CreateAction note.
+    Type.Union([Type.String(), Type.Null()], {
       description:
-        "Run this connection's syncs/actions on a specific device worker (its device_workers.id) instead of the Lobu server (runs serverless). Required for connectors that declare a required_capability; optional otherwise. The device must belong to you or be granted to this org.",
+        "Run this connection's syncs/actions on a specific device worker (its device_workers.id) instead of the Lobu server (runs serverless). Null/omit runs serverless. Required for connectors that declare a required_capability. The device must belong to you or be granted to this org.",
     })
   ),
   entity_ids: Type.Optional(

--- a/packages/server/src/utils/connector-auth.ts
+++ b/packages/server/src/utils/connector-auth.ts
@@ -214,6 +214,22 @@ export function getAppInstallationAuthMethods(
   );
 }
 
+/**
+ * Whether the connector's PRIMARY (highest-precedence) auth method is
+ * `app_installation` — i.e. the first declared method that actually carries
+ * credentials (`none` is a no-op and skipped). When true, a connection for this
+ * connector is meant to be created ONLY by the App install callback (which sets
+ * `config.installation_ref`); a direct create with no `installation_ref` would be
+ * a dead, unbound connection. Connector-agnostic (keys on the method type, not
+ * on `github`) so it covers any future app_installation connector.
+ */
+export function isPrimaryAuthMethodAppInstallation(
+  authSchema: ConnectorAuthSchema
+): boolean {
+  const primary = authSchema.methods.find((method) => method.type !== 'none');
+  return primary?.type === 'app_installation';
+}
+
 function dedupeAuthFields(fields: ConnectorAuthEnvField[]): ConnectorAuthEnvField[] {
   const seen = new Set<string>();
   const deduped: ConnectorAuthEnvField[] = [];

--- a/packages/server/src/utils/connector-auth.ts
+++ b/packages/server/src/utils/connector-auth.ts
@@ -200,6 +200,13 @@ function getEnvAuthMethods(authSchema: ConnectorAuthSchema): ConnectorAuthEnvKey
   );
 }
 
+/** Every env-key field key the connector declares (across all env_keys methods). */
+export function getEnvAuthFieldKeys(authSchema: ConnectorAuthSchema): string[] {
+  return getEnvAuthMethods(authSchema).flatMap((method) =>
+    method.fields.map((field) => field.key)
+  );
+}
+
 export function getOAuthAuthMethods(authSchema: ConnectorAuthSchema): ConnectorAuthOAuthMethod[] {
   return authSchema.methods.filter(
     (method): method is ConnectorAuthOAuthMethod => method.type === 'oauth'

--- a/packages/server/src/utils/execution-context.ts
+++ b/packages/server/src/utils/execution-context.ts
@@ -16,6 +16,7 @@ import {
 import { getInstallationTokenRegistry } from '../gateway/installation/registry';
 import { parseJsonObject } from '@lobu/core';
 import { errorMessage } from './errors';
+import { insertEvent } from './insert-event';
 import logger from './logger';
 
 interface ExecutionOAuthCredentials {
@@ -322,6 +323,56 @@ const NOT_APP_INSTALLATION: AppInstallationCredentialResult = {
 };
 
 /**
+ * Best-effort security audit for a rejected app-installation reference. A
+ * connection trying to resolve an install it doesn't own (cross-tenant) or one
+ * whose provider/instance doesn't match its connector method is a tenancy
+ * signal worth surfacing beyond the log line — operators can review these the
+ * same way they review `guardrail-trip` rows.
+ *
+ * Mirrors the guardrail-trip audit shape (`semantic_type='guardrail-trip'`,
+ * `guardrail` discriminator in metadata) so existing audit tooling/queries pick
+ * it up. Append-only: one `events` row per rejection.
+ *
+ * Fire-and-forget and never throws — resolution must NOT crash because the
+ * audit write failed; a dropped row is logged so the gap is still visible.
+ */
+function recordAppInstallationTenancyTrip(params: {
+  organizationId: string;
+  connectionId: number;
+  installId: number;
+  reason: 'cross_tenant_org' | 'provider_instance_mismatch';
+  details: Record<string, unknown>;
+}): void {
+  const originId = `app_installation_tenancy_trip_${params.reason}_${params.connectionId}_${params.installId}_${Date.now()}`;
+  void insertEvent({
+    entityIds: [],
+    organizationId: params.organizationId,
+    originId,
+    title: `App-installation reference rejected (${params.reason})`,
+    semanticType: 'guardrail-trip',
+    originType: 'guardrail-app-installation',
+    metadata: {
+      guardrail: 'app-installation-tenancy',
+      stage: 'pre-tool',
+      reason: params.reason,
+      connection_id: params.connectionId,
+      install_id: params.installId,
+      ...params.details,
+    },
+  }).catch((err) => {
+    logger.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        connection_id: params.connectionId,
+        install_id: params.installId,
+        reason: params.reason,
+      },
+      'Failed to record app-installation tenancy audit event (security log gap)'
+    );
+  });
+}
+
+/**
  * Resolve a tenant-scoped credential for an App-installation-backed connection.
  *
  * Wiring contract:
@@ -422,6 +473,13 @@ async function resolveAppInstallationCredential(
       },
       'Cross-tenant app-installation reference rejected: install org does not match connection org'
     );
+    recordAppInstallationTenancyTrip({
+      organizationId,
+      connectionId,
+      installId,
+      reason: 'cross_tenant_org',
+      details: { connection_org: organizationId, install_org: install.organizationId },
+    });
     return { handled: true, credentials: null };
   }
 
@@ -446,6 +504,18 @@ async function resolveAppInstallationCredential(
       },
       'App-installation reference rejected: install provider/instance does not match connector method'
     );
+    recordAppInstallationTenancyTrip({
+      organizationId,
+      connectionId,
+      installId,
+      reason: 'provider_instance_mismatch',
+      details: {
+        install_provider: install.provider,
+        method_provider: method.provider,
+        install_provider_instance: install.providerInstance,
+        method_provider_instance: method.providerInstance ?? 'cloud',
+      },
+    });
     return { handled: true, credentials: null };
   }
 

--- a/packages/server/src/utils/execution-context.ts
+++ b/packages/server/src/utils/execution-context.ts
@@ -340,7 +340,7 @@ function recordAppInstallationTenancyTrip(params: {
   organizationId: string;
   connectionId: number;
   installId: number;
-  reason: 'cross_tenant_org' | 'provider_instance_mismatch';
+  reason: 'cross_tenant_org' | 'provider_instance_mismatch' | 'install_not_active';
   details: Record<string, unknown>;
 }): void {
   const originId = `app_installation_tenancy_trip_${params.reason}_${params.connectionId}_${params.installId}_${Date.now()}`;
@@ -515,6 +515,32 @@ async function resolveAppInstallationCredential(
         install_provider_instance: install.providerInstance,
         method_provider_instance: method.providerInstance ?? 'cloud',
       },
+    });
+    return { handled: true, credentials: null };
+  }
+
+  // Status guard: only an ACTIVE install may mint. After a cross-org TRANSFER the
+  // store demotes the losing org's row to 'suspended' (and a 'revoked' row is a
+  // hard uninstall), but the losing org's connection still points its
+  // installation_ref at that row. Without this check a suspended/revoked install
+  // would keep minting GitHub tokens for the new owner's repos — a cross-tenant
+  // leak. Reject any non-active status: null creds, never mint.
+  if (install.status !== 'active') {
+    logger.warn(
+      {
+        ...logContext,
+        connection_id: connectionId,
+        install_id: installId,
+        install_status: install.status,
+      },
+      'App-installation reference rejected: install is not active (transferred/suspended/revoked)'
+    );
+    recordAppInstallationTenancyTrip({
+      organizationId,
+      connectionId,
+      installId,
+      reason: 'install_not_active',
+      details: { install_status: install.status },
     });
     return { handled: true, credentials: null };
   }


### PR DESCRIPTION
PR5 of the app-installation design (`docs/design/app-installation.md` §3/§4), building on the merged backend (SDK types #1428, table+store #1429, token provider #1430, webhook router #1431). The owletto "Install on GitHub" UI is a **separate PR** — not touched here.

## What's in this PR

### 1. GitHub connector → `app_installation` authSchema
`packages/connectors/src/github.ts`: added an `app_installation` auth method (primary per §4.5) — `provider: github`, `providerInstance: cloud`, `appIdKey: GITHUB_APP_ID`, `privateKeyKey: GITHUB_APP_PRIVATE_KEY`, `installUrlTemplate`, declared permissions/events. OAuth + env-PAT fallbacks kept (GitHub no longer forces a per-org `oauth_app` profile because the App install path exists; `oauth_app` stays for other connectors). Webhook block set to `delivery: 'app_installation'` + `routingKeyPath: 'installation.id'`; `registerWebhook`/`unregisterWebhook` short-circuit to no-ops in that mode (the App-level hook is provisioned once at install, and the server-side `connectionWantsWebhook` gate never fires for an install-bound connection since it carries no repo/org target).

### 2. Install callback handler (server)
New `packages/server/src/gateway/routes/public/app-install.ts` → `GET /github/app/install/callback`. Reads `installation_id` + `setup_action` (`install`/`update`/`request`). On install/update: upserts the `app_installations` row (reject/transfer upsert — idempotent + ownership-safe) and creates/relinks the org's `github` connection with `config.installation_ref` = install id (the shape `resolveExecutionAuth` reads). Session-bound org resolution reuses the Slack install flow's resolver (`resolveInstallOrgId`, now exported). `request` acks without writing. Pure core (`linkGithubAppInstallation`) is unit-tested. Wired into `gateway.ts` next to the app-webhooks router.

### 3. `device_worker_id` create-path fix (real prod bug)
`manage_connections` create/connect rejected serverless connections with `"/device_worker_id: Expected string"` because the schema was a bare `Type.String` but the UI/serverless sends `null`. Made it `Type.Optional(Type.Union([Type.String(), Type.Null()]))` (matching `update`, which `resolveDeviceBinding` already normalizes to serverless).

### 4. Tenancy audit event
`execution-context.ts`: cross-tenant and provider/instance-mismatch `app_installation` rejections (the #1430 guards) now emit a best-effort `guardrail-trip` audit event (`origin_type: guardrail-app-installation`, `metadata.guardrail: app-installation-tenancy`) — was log-only. Fire-and-forget; never crashes resolution.

## Tests (embedded PG, green)
- `github-app-install-callback.test.ts` — install → `app_installations` row + connection with `config.installation_ref`; idempotency (no dup install/connection).
- `serverless-device-worker.test.ts` — serverless create with `device_worker_id: null` and omitted both succeed.
- `app-installation-credential.test.ts` (extended) — cross-tenant and provider-mismatch rejections each emit the `guardrail-trip` audit row.

11/11 pass. `cd packages/server && bunx tsc --noEmit` → 0 errors. Root `bun run typecheck` clean. Server bundle builds (0 errors). Connectors typecheck: only a pre-existing TS2352 in untouched `parseStargazerCheckpoint` (the connectors package has pervasive pre-existing DOM/import errors and isn't a strict gate).

## Not done here / follow-ups
- owletto "Install on GitHub" UI (separate PR) — generates the install URL with a signed `state` for cross-org binding hardening (the callback currently binds to the callback session's active org, same model as Slack install).
- Live verification against a real GitHub App (not done — no App configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ug5cEnCRt1VHn8w3gNXAu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784688947&installation_id=136316292&pr_number=1435&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1435&signature=dd8f7a7a184edde635c11ae83d841fbe45e5a5a8a30f3183f309d7ffc05e2de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub App installation onboarding (install initiation + callback) with idempotent connection creation and installation-aware webhook handling.
* **Security**
  * Strengthened app-installation callback protections with signed, single-use state and org mismatch checks.
  * Added audit event logging for app-installation tenancy violations and provider/instance mismatches.
  * Prevented creating or connecting app-installation connections when unbound (missing installation reference).
* **Bug Fixes**
  * Ensured webhook register/unregister behaves as no-ops for installation-backed connections.
* **Admin/API**
  * Allowed `device_worker_id: null` for serverless connection creation/connect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->