### PR TITLE
feat(dev): parallel local instances + DB-per-branch on local Postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 # Development Makefile for Lobu
 
-.PHONY: help setup build test clean dev build-packages ensure-submodule clean-workers clean-test-pg test-unit test-integration test-e2e test-e2e-sdk test-e2e-cli test-providers-live typecheck task-setup task-clean e2e-browser bump review
+.PHONY: help setup build test clean dev dev-db build-packages ensure-submodule clean-workers clean-test-pg test-unit test-integration test-e2e test-e2e-sdk test-e2e-cli test-providers-live typecheck task-setup task-clean e2e-browser bump review
 
 # Default target
 help:
 	@echo "Available commands:"
 	@echo "  make setup                                 - Setup development environment (run once)"
 	@echo "  make dev                                   - Start the embedded Lobu stack (Postgres via DATABASE_URL, Vite HMR)"
+	@echo "  make dev-db [NAME=<x>] [FROM=<db>]          - Local dev against the brew Postgres, one database per worktree/branch (NAME defaults to the branch; FROM=<db> forks a dataset)"
 	@echo "  make build-packages                        - Build all TypeScript packages"
 	@echo "  make test                                  - Run test bot"
 	@echo "  make test-unit                             - Run the CI unit suite (no Postgres needed)"
@@ -70,6 +71,15 @@ ensure-submodule:
 # all in-process. Requires Postgres via DATABASE_URL.
 dev: ensure-submodule
 	@./scripts/dev-native.sh
+
+# Local dev against the local (brew) Postgres — one database per worktree/branch,
+# no embedded cluster. NAME defaults to the current branch; FROM=<db> forks an
+# existing dataset for a disposable preview. Embedded `make dev` is unchanged.
+#   make dev-db NAME=sidebar
+#   make dev-db NAME=preview FROM=owletto_local
+#   make dev-db NAME=sidebar PORT=8931 WORKER_PROXY_PORT=8131
+dev-db: ensure-submodule
+	@NAME="$(NAME)" FROM="$(FROM)" PORT="$(PORT)" WORKER_PROXY_PORT="$(WORKER_PROXY_PORT)" PGHOST="$(PGHOST)" PGPORT="$(PGPORT)" PGUSER="$(PGUSER)" ./scripts/dev-db.sh
 
 # Setup development environment (run once)
 setup:

--- a/scripts/dev-db.sh
+++ b/scripts/dev-db.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Local dev against the local (brew) Postgres — one DATABASE per worktree/branch,
+# so a single name keys the worktree, its database, and (with portless) its URL.
+# No embedded cluster, so none of the shm-slot / data-dir-lock gotchas; and
+# `FROM=<db>` forks an existing dataset for a safe, disposable preview.
+#
+#   make dev-db                                    # DB = current branch
+#   make dev-db NAME=sidebar
+#   make dev-db NAME=preview FROM=owletto_local    # fork real dev data
+#   make dev-db NAME=sidebar PORT=8931 WORKER_PROXY_PORT=8131
+#
+# Embedded `make dev` is unchanged and stays the zero-dependency default.
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Name defaults to the current git branch (the worktree's branch) so the
+# database tracks the worktree. Sanitize to a legal lowercase PG identifier —
+# `feat/sidebar` → `lobu_feat_sidebar`.
+RAW_NAME="${NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo dev)}"
+SLUG="$(printf '%s' "$RAW_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
+DB="lobu_${SLUG:-dev}"
+# Postgres silently truncates identifiers past 63 bytes, which would collide two
+# long branch names into one database and break db_exists. Cap with a short hash
+# of the full name so distinct long branches stay distinct.
+if [ "${#DB}" -gt 63 ]; then
+  DB="${DB:0:52}_$(printf '%s' "$DB" | cksum | cut -d' ' -f1)"
+fi
+
+PGHOST="${PGHOST:-localhost}"
+PGPORT="${PGPORT:-5432}"
+PGUSER="${PGUSER:-$USER}"
+export PGHOST PGPORT PGUSER
+
+db_exists() {
+  psql -tAc "select 1 from pg_database where datname='$1'" postgres 2>/dev/null | grep -q 1
+}
+
+if db_exists "$DB"; then
+  echo "→ using existing database $DB"
+elif [ -n "${FROM:-}" ]; then
+  # Fork via dump/restore so it works even when $FROM has live connections
+  # (CREATE DATABASE ... TEMPLATE refuses to copy an in-use database — and a live
+  # dev DB is exactly when you want to fork). The source must still be at the
+  # current schema; an old/drifted DB won't migrate forward.
+  echo "→ forking $FROM → $DB (pg_dump)"
+  createdb "$DB"
+  if ! pg_dump --no-owner --no-privileges "$FROM" | psql -q -v ON_ERROR_STOP=1 -d "$DB" >/dev/null; then
+    echo "✗ fork failed while copying '$FROM' → '$DB'." >&2
+    dropdb --if-exists "$DB" 2>/dev/null
+    exit 1
+  fi
+else
+  echo "→ creating database $DB (the app migrates the schema on first boot)"
+  createdb "$DB"
+fi
+
+export DATABASE_URL="postgres://${PGUSER}@${PGHOST}:${PGPORT}/${DB}"
+export PORT="${PORT:-8930}"
+# portless owns the front-door PORT, but it can't see Lobu's internal worker
+# egress proxy — so auto-pick a free port for it (unless one was given) and
+# parallel previews never collide on it.
+if [ -z "${WORKER_PROXY_PORT:-}" ]; then
+  WORKER_PROXY_PORT="$(node -e 'const s=require("net").createServer();s.listen(0,"127.0.0.1",()=>{const p=s.address().port;s.close(()=>console.log(p))})')"
+fi
+export WORKER_PROXY_PORT
+# Single-operator local install: own the database lifecycle — apply migrations
+# to the target DB (so a fresh DB gets the schema and a fork is upgraded to the
+# current version; runMigrations is idempotent) and seed the first user/org so
+# /api/local-init works. Same flag `lobu run` uses; prod never sets it.
+export LOBU_RUN_OWNS_DB=1
+echo "→ DATABASE_URL=$DATABASE_URL"
+echo "→ server on :$PORT   (worker proxy :$WORKER_PROXY_PORT)"
+echo ""
+# dev-native.sh routes the postgres:// URL to the external path and, for a
+# localhost host, defaults PGSSLMODE=disable — so brew Postgres just works.
+exec "$REPO_ROOT/scripts/dev-native.sh"

--- a/scripts/dev-native.sh
+++ b/scripts/dev-native.sh
@@ -129,26 +129,63 @@ mkdir -p "$LOBU_WORKSPACE_ROOT"
 
 # --- Run -------------------------------------------------------------------
 
-if [ -z "${DATABASE_URL:-}" ]; then
-  # No external Postgres → boot the embedded Postgres backend (src/server.ts).
-  # DATABASE_URL=file://<dir> is the single backend selector; the cluster lives
-  # at <dir>/.lobu/pgdata. First run mints a web login (dev@lobu.local /
-  # lobudev123, org "dev"). Vite HMR still runs in-process.
-  DEV_DATA_ROOT="$REPO_ROOT/.lobu-dev"
-  export DATABASE_URL="file://${DEV_DATA_ROOT}"
-  export PGSSLMODE=disable
+# Backend is selected by the DATABASE_URL *scheme*, not its mere presence: only
+# a postgres:// URL takes the external path. An unset URL or a file:// path runs
+# embedded Postgres. This lets `DATABASE_URL=file://<dir>` point at an alternate
+# data dir (another worktree's, a snapshot) without being mis-routed to the
+# external branch and its sslmode=require default — the trap that made "run it
+# against existing data" fall over.
+case "${DATABASE_URL:-}" in
+  postgres://* | postgresql://*) _LOBU_EMBEDDED=0 ;;
+  *)                             _LOBU_EMBEDDED=1 ;;
+esac
+
+if [ "$_LOBU_EMBEDDED" = 1 ]; then
+  # Default the data root when none was given. Override with LOBU_DEV_DATA_ROOT
+  # (or pass DATABASE_URL=file://<dir>) to run multiple isolated instances from
+  # ONE repo root — each gets its own cluster + lock. Pair with PORT /
+  # WORKER_PROXY_PORT overrides so the rails don't collide:
+  #   LOBU_DEV_DATA_ROOT=/tmp/lobu-a PORT=8930 WORKER_PROXY_PORT=8130 make dev
+  #   LOBU_DEV_DATA_ROOT=/tmp/lobu-b PORT=8931 WORKER_PROXY_PORT=8131 make dev
+  # The embedded PG port is auto-picked free per instance, so it never clashes.
+  if [ -z "${DATABASE_URL:-}" ]; then
+    DEV_DATA_ROOT="${LOBU_DEV_DATA_ROOT:-$REPO_ROOT/.lobu-dev}"
+    export DATABASE_URL="file://${DEV_DATA_ROOT}"
+  else
+    DEV_DATA_ROOT="${DATABASE_URL#file://}"
+  fi
+  export PGSSLMODE="${PGSSLMODE:-disable}"
   mkdir -p "$DEV_DATA_ROOT"
-  echo "→ no DATABASE_URL set — booting embedded Postgres"
+  echo "→ embedded Postgres   cluster: $DEV_DATA_ROOT/.lobu/pgdata"
   echo "→ server on http://${HOST}:${PORT}   (Vite HMR in-process)"
-  echo "→ data dir: $DEV_DATA_ROOT/.lobu/pgdata"
   echo "→ first run seeds a web login: dev@lobu.local / lobudev123   (org 'dev')"
   echo "→ then run \`lobu apply\` from a project dir to sync its lobu.config.ts"
   echo ""
   exec bun run --filter '@lobu/server' dev:local
 fi
 
-export PGSSLMODE="${PGSSLMODE:-require}"
+# External Postgres (postgres:// URL). Point this at a running instance's
+# embedded cluster to SHARE its data with a second app (no extra lock): pin the
+# primary's PG port, then attach —
+#   LOBU_PG_PORT=5544 make dev                                  # primary
+#   DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5544/postgres \
+#     PORT=8931 WORKER_PROXY_PORT=8131 make dev                 # shares its data
+# Default sslmode by host: a local Postgres (brew, a container) speaks no TLS,
+# so localhost defaults to `disable`; anything remote defaults to `require`.
+# This is the local-dev launcher only — prod/cloud paths are untouched. An
+# explicit PGSSLMODE always wins.
+# Host from postgres://[user[:pass]@]host[:port][/db][?params], incl. [IPv6].
+_lobu_db_rest="${DATABASE_URL#*://}"; _lobu_db_rest="${_lobu_db_rest##*@}"
+case "$_lobu_db_rest" in
+  '['*) _lobu_db_host="${_lobu_db_rest#\[}"; _lobu_db_host="${_lobu_db_host%%]*}" ;;
+  *)    _lobu_db_host="${_lobu_db_rest%%[:/?]*}" ;;
+esac
+case "$_lobu_db_host" in
+  localhost | 127.0.0.1 | ::1) export PGSSLMODE="${PGSSLMODE:-disable}" ;;
+  *)                           export PGSSLMODE="${PGSSLMODE:-require}" ;;
+esac
 
+echo "→ external Postgres (sslmode=${PGSSLMODE})"
 echo "→ server on http://${HOST}:${PORT}"
 echo "→ embedded gateway proxy on :${WORKER_PROXY_PORT}"
 echo "→ Vite HMR in-process (same port)"


### PR DESCRIPTION
## What
Local-dev tooling to run multiple instances in parallel and preview a branch against a copy of real data — no schema changes, prod untouched.

- **`dev-native.sh`**: pick embedded vs external Postgres by URL *scheme* (a `file://` data-dir override was mis-routed to the external `sslmode=require` path); `LOBU_DEV_DATA_ROOT` to run isolated embedded instances from one repo root; default `PGSSLMODE` by host (localhost → disable, remote → require).
- **`scripts/dev-db.sh` + `make dev-db`** (new): one database per worktree/branch on the local (brew) Postgres. `NAME` defaults to the branch, `FROM=<db>` forks a dataset for a disposable preview, the worker-proxy port auto-frees, and `LOBU_RUN_OWNS_DB` migrates the target DB. Embedded `make dev` is unchanged.

## Verified
- Two isolated embedded instances booted green side by side (own data dirs + ports).
- A fresh DB-per-branch booted clean against brew PG 17 (migrated baseline → current 20260618141000, schema gate passed).
- `bash -n` clean on both scripts; host→sslmode parse verified.

## Notes
- DB-per-instance (not schemas) is deliberate: the query layer qualifies `public.` for tenant-isolation security, so schema isolation would touch prod security code. Databases need zero app changes.
- `FROM=` forks a *current-schema* source only; an old/drifted DB won't migrate forward (mutable-baseline drift), so default to fresh DBs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784689416&installation_id=136316292&pr_number=1436&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1436&signature=3d9d18b3acdb863ca63ebe7fd8954e5306eae23d39ed61209ebdd164b2296ff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `make dev-db` command for streamlined local development database setup with configurable options (database name, port, source database).
  * Improved database selection logic to intelligently switch between embedded and external Postgres based on configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->