### PR TITLE
refactor(agent-worker): centralize the dynamic getModel cast behind a typed boundary

### DIFF
--- a/packages/agent-worker/src/openclaw/model-resolver.ts
+++ b/packages/agent-worker/src/openclaw/model-resolver.ts
@@ -6,9 +6,31 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { type ConfigProviderMeta, createLogger } from "@lobu/core";
+import { getModel, type Model } from "@mariozechner/pi-ai";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 
 const logger = createLogger("model-resolver");
+
+/**
+ * Look up a pi-ai registry model by RUNTIME-resolved provider + model strings.
+ *
+ * pi-ai's `getModel` is generically typed over its static `MODELS` registry
+ * (`TProvider extends KnownProvider`, `TModelId extends keyof MODELS[TProvider]`),
+ * so it cannot be called with the dynamic strings Lobu resolves at runtime
+ * without a cast. Centralize that one unavoidable cast here — behind a typed
+ * `(string, string) => Model<any> | undefined` boundary — so call sites stay
+ * clean and the dynamic edge is explicit in exactly one place. Returns
+ * `undefined` when the registry has no such entry (callers then build a dynamic
+ * or cloned model).
+ */
+export function getModelDynamic(
+  provider: string,
+  modelId: string
+): Model<any> | undefined {
+  return getModel(provider as never, modelId as never) as
+    | Model<any>
+    | undefined;
+}
 
 /** Hardcoded fallback map for provider base URL env vars. */
 export const DEFAULT_PROVIDER_BASE_URL_ENV: Record<string, string> = {
@@ -95,7 +117,8 @@ interface DynamicOpenAIModel {
   provider: string;
   baseUrl: string;
   reasoning: boolean;
-  input: string[];
+  // Matches pi-ai's `Model.input` so a dynamic entry is assignable to Model<any>.
+  input: ("text" | "image")[];
   cost: {
     input: number;
     output: number;

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -16,7 +16,7 @@ import {
   type ToolsConfig,
 } from "@lobu/core";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import { getModel, type ImageContent } from "@mariozechner/pi-ai";
+import type { ImageContent, Model } from "@mariozechner/pi-ai";
 import {
   AuthStorage,
   type CreateAgentSessionOptions,
@@ -40,6 +40,7 @@ import {
 import {
   buildDynamicOpenAIModel,
   DEFAULT_PROVIDER_BASE_URL_ENV,
+  getModelDynamic,
   openOrCreateSessionManager,
   PROVIDER_REGISTRY_ALIASES,
   registerDynamicProvider,
@@ -600,7 +601,7 @@ export async function runAISession(
     }
   }
 
-  let baseModel = getModel(provider as any, modelId as any) as any;
+  let baseModel: Model<any> | undefined = getModelDynamic(provider, modelId);
   if (!baseModel) {
     // For OpenAI-compatible providers (e.g. nvidia, together-ai), create a
     // dynamic model entry since these models aren't in the static registry.
@@ -630,13 +631,13 @@ export async function runAISession(
         "claude-haiku-4-5-20251001",
         "claude-3-5-sonnet-20241022",
       ]
-        .map((id) => getModel("anthropic" as any, id as any))
+        .map((id) => getModelDynamic("anthropic", id))
         .find(Boolean);
       if (template) {
         logger.info(
           `Creating dynamic Claude model entry for ${modelId} (not in static registry)`
         );
-        baseModel = { ...(template as any), id: modelId, name: modelId };
+        baseModel = { ...template, id: modelId, name: modelId };
       } else {
         throw new Error(
           `Model "${modelId}" not found for provider "${provider}". Check that the model ID is valid and registered in the model registry.`
@@ -647,6 +648,12 @@ export async function runAISession(
         `Model "${modelId}" not found for provider "${provider}". Check that the model ID is valid and registered in the model registry.`
       );
     }
+  }
+  // Every path above either assigns `baseModel` or throws, so it's defined here;
+  // this guard makes that invariant explicit for the type checker (and is a
+  // defensive backstop).
+  if (!baseModel) {
+    throw new Error(`Could not resolve a model for "${provider}/${modelId}".`);
   }
   const resolvedModel = providerBaseUrl
     ? { ...baseModel, baseUrl: providerBaseUrl }


### PR DESCRIPTION
Follow-up cleanup from #1434 (the "use more typed" ask).

pi-ai's `getModel` is generically typed over its static `MODELS` registry, so calling it with Lobu's runtime-resolved provider/model strings required scattered `as any` casts in session-runner — which also masked real type looseness.

- Add a single typed `getModelDynamic(string, string) => Model<any> | undefined` wrapper that owns the one unavoidable cast, so the dynamic boundary is explicit in one place and call sites are clean.
- Tighten `DynamicOpenAIModel.input` (`string[]` → `("text" | "image")[]`) so a dynamic entry is actually assignable to pi-ai's `Model` (the old cast hid the mismatch).
- Make the "baseModel is resolved or thrown" invariant explicit with a guard (the old `as any` hid the `undefined` case).

No behavior change. typecheck 0, agent-worker tests 610 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784690003&installation_id=136316292&pr_number=1437&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1437&signature=6cee3c3df03c52a6d83160de51d23304c0d847761971e6abbcdd40f78a91835d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->