### PR TITLE
test(gateway): guard findProviderForModel prefix routing

### DIFF
--- a/packages/server/src/gateway/auth/__tests__/provider-catalog-find-provider.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/provider-catalog-find-provider.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { ProviderCatalogService } from "../provider-catalog.js";
+
+/**
+ * findProviderForModel routes a stored model string to the provider module that
+ * owns it. The subtle case (regressed once, now guarded): Lobu stores models
+ * PREFIXED with the provider's lobu id ("claude/claude-sonnet-4-6"), but
+ * Claude's `getModelOptions` lists BARE ids ("claude-sonnet-4-6", fetched live
+ * and sometimes empty in this resolution context). With exact-match only, a
+ * "claude/…" model matched nothing and fell through to the first credentialed
+ * provider — mis-routing the request to e.g. gemini's openai-compat endpoint and
+ * surfacing as a confusing 404. The "<providerId>/…" prefix fallback fixes that.
+ *
+ * findProviderForModel reads only its arguments (never `this`), so we exercise
+ * the real method with injected fake provider modules — no store/auth/registry
+ * wiring required.
+ */
+describe("ProviderCatalogService.findProviderForModel — prefix routing", () => {
+  const catalog = new ProviderCatalogService(
+    {} as never,
+    {} as never,
+    {} as never
+  );
+
+  // Mirrors the bug's provider set: gemini is credentialed FIRST, claude lists
+  // BARE ids (no "claude/" prefix), and the stored model is PREFIXED.
+  const fakeProviders = [
+    {
+      providerId: "gemini",
+      getModelOptions: async () => [{ value: "gemini-2.5-flash" }],
+    },
+    {
+      providerId: "claude",
+      getModelOptions: async () => [
+        { value: "claude-sonnet-4-6" },
+        { value: "claude-opus-4-8" },
+      ],
+    },
+  ] as never;
+
+  test("routes a prefixed claude/ model to the claude provider (not the first credentialed)", async () => {
+    const picked = await catalog.findProviderForModel(
+      "claude/claude-sonnet-4-6",
+      fakeProviders
+    );
+    expect(picked?.providerId).toBe("claude");
+  });
+
+  test("opus-4-8 (bare id absent from a sparse live list) still routes by prefix", async () => {
+    const sparse = [
+      {
+        providerId: "gemini",
+        getModelOptions: async () => [{ value: "gemini-2.5-flash" }],
+      },
+      // Live Claude list came back empty in this context — only the prefix can
+      // identify the provider now.
+      { providerId: "claude", getModelOptions: async () => [] },
+    ] as never;
+    const picked = await catalog.findProviderForModel(
+      "claude/claude-opus-4-8",
+      sparse
+    );
+    expect(picked?.providerId).toBe("claude");
+  });
+
+  test("an exact bare-id match still wins (non-prefixed model)", async () => {
+    const picked = await catalog.findProviderForModel(
+      "gemini-2.5-flash",
+      fakeProviders
+    );
+    expect(picked?.providerId).toBe("gemini");
+  });
+
+  test("exact match is preferred over the prefix fallback", async () => {
+    // A provider literally lists "claude/legacy" as a value; the bare-loop must
+    // match it before the prefix fallback ever runs.
+    const providers = [
+      {
+        providerId: "openrouter",
+        getModelOptions: async () => [{ value: "claude/legacy" }],
+      },
+      {
+        providerId: "claude",
+        getModelOptions: async () => [{ value: "claude-sonnet-4-6" }],
+      },
+    ] as never;
+    const picked = await catalog.findProviderForModel(
+      "claude/legacy",
+      providers
+    );
+    expect(picked?.providerId).toBe("openrouter");
+  });
+
+  test("returns undefined when neither an exact value nor a prefix provider matches", async () => {
+    const picked = await catalog.findProviderForModel(
+      "mystery/model-x",
+      fakeProviders
+    );
+    expect(picked).toBeUndefined();
+  });
+
+  test("a bare unknown id (no slash) does not match anything", async () => {
+    const picked = await catalog.findProviderForModel(
+      "totally-unknown",
+      fakeProviders
+    );
+    expect(picked).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds the missing unit test for `ProviderCatalogService.findProviderForModel`'s prefix-match fallback (shipped in #1434 but previously untested).

## Why

Lobu stores models prefixed with the provider's lobu id (`claude/claude-sonnet-4-6`), while a provider's `getModelOptions` lists **bare** ids (`claude-sonnet-4-6`, fetched live and sometimes empty). With exact-match only, a `claude/…` model matched nothing and fell through to the first credentialed provider — mis-routing the request to the wrong upstream (e.g. gemini's openai-compat endpoint → confusing 404). #1434 added a `<providerId>/…` prefix fallback; this locks it in.

## Coverage

- prefixed `claude/…` routes to claude, not the first credentialed provider
- sparse/empty live list still routes by prefix (the opus-4-8 case)
- exact bare-id match still wins
- exact match preferred over the prefix fallback
- no exact value + no prefix provider → `undefined`
- bare unknown id (no slash) → `undefined`

## Verification

`bun test` green (6/6). A mutation check — disabling the `slashIndex` fallback — turns exactly the two prefix-routing cases red, confirming the test guards the regression rather than passing vacuously.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784691862&installation_id=136316292&pr_number=1439&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1439&signature=71906c254a439d564d79cf1088967bea90eaac84ad222da51e9ce4abe5c61774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for provider model routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->