### PR TITLE
feat(entities): event-sourced entity field projection substrate (expand phase)

### DIFF
--- a/db/migrations/20260622150000_entity_field_projection.sql
+++ b/db/migrations/20260622150000_entity_field_projection.sql
@@ -1,0 +1,104 @@
+-- migrate:up
+
+-- Event-sourced entity field state — SUBSTRATE (expand phase, 1 of N).
+--
+-- entity_field_state is a trigger-maintained projection of the events log: the
+-- current value of each (entity_id, metadata field) is the latest 'entity_field'
+-- event carrying it. The events log stays the source of truth; this table is a
+-- rebuildable cache. Validated by a live PG17 concurrency prototype — correct
+-- under maximum contention (the keep-greater ON CONFLICT row-lock serializes
+-- concurrent writers, N>1-safe), microsecond PK reads, ~1.4s rebuild over 2M events.
+--
+-- This migration ships the SUBSTRATE only — nothing emits 'entity_field' events
+-- yet, so the projection is empty and inert in prod (the WHEN-gated trigger costs
+-- nothing on non-field inserts). The producer (manage_entity emitting field
+-- events inside the entity-update transaction, for correct ordering) is a
+-- separate follow-up; it must respect the event contract below.
+--
+-- EVENT CONTRACT for 'entity_field':
+--   semantic_type   = 'entity_field'
+--   entity_ids      = '{}'  (INTENTIONALLY EMPTY — these rows must never match
+--                            entity-linked content counts / feeds / search, which
+--                            key on entity_ids; cf. recordLifecycleEvent's empty
+--                            entity_ids precedent)
+--   organization_id = <the events.organization_id column>  (tenancy)
+--   metadata        = { "entity_id": <number>, "fields": { "<key>": <value>, ... } }
+
+CREATE TABLE IF NOT EXISTS public.entity_field_state (
+    organization_id text   NOT NULL,
+    entity_id       bigint NOT NULL,
+    field           text   NOT NULL,
+    value           jsonb,
+    observation_id  bigint NOT NULL,
+    updated_at      timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT entity_field_state_pkey PRIMARY KEY (entity_id, field)
+);
+
+-- organization_id is stored for tenancy + the contract-phase orphan sweep (entity
+-- ids are globally unique, so it is not part of the PK). The supporting index
+-- lands with that sweep, not here — nothing scans by org in the expand phase.
+
+COMMENT ON TABLE public.entity_field_state IS
+    'Trigger-maintained projection of the latest entity_field event per (entity_id, field). Rebuildable cache; the events log is the source of truth. No FK to entities (an append-only log may reference deleted entities; orphans are harmless cache rows swept in the contract phase).';
+
+-- keep-greater-observation_id upsert. events.id is monotonic at assignment, so a
+-- later write carries the higher id; the ON CONFLICT row-lock serializes two
+-- concurrent upserts on the same (entity_id, field). Multi-replica-safe:
+-- serialization happens in Postgres, not in any pod's memory.
+--
+-- Two hard safety properties, since this fires on the HOT append-only events
+-- table and the table has no org in its PK / no FK:
+--   * NULL-safe, integer-validated guard (coalesce + 1..18-digit regex) BEFORE
+--     the ::bigint cast — a missing / float / overflowing / non-object payload
+--     degrades to a no-op and can NEVER abort the host events insert.
+--   * Tenancy boundary: only projects for an entity that actually belongs to the
+--     event's organization, so a cross-org event can't hijack or re-stamp a row
+--     (organization_id is therefore NOT updated on conflict — it's immutable per
+--     entity). Unknown/deleted entities are skipped (also covers the no-FK case).
+CREATE OR REPLACE FUNCTION public.project_entity_field() RETURNS trigger AS $$
+DECLARE
+    v_entity_id bigint;
+BEGIN
+    IF coalesce(jsonb_typeof(NEW.metadata->'fields'), '') <> 'object'
+       OR coalesce(NEW.metadata->>'entity_id', '') !~ '^[0-9]{1,18}$' THEN
+        RETURN NEW;
+    END IF;
+    v_entity_id := (NEW.metadata->>'entity_id')::bigint;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM public.entities
+        WHERE id = v_entity_id
+          AND organization_id = NEW.organization_id
+          AND deleted_at IS NULL
+    ) THEN
+        RETURN NEW;  -- unknown, deleted, or cross-org entity: skip, never project
+    END IF;
+
+    INSERT INTO public.entity_field_state (organization_id, entity_id, field, value, observation_id, updated_at)
+    SELECT NEW.organization_id, v_entity_id, kv.key, kv.value, NEW.id, now()
+    FROM jsonb_each(NEW.metadata->'fields') kv
+    ON CONFLICT (entity_id, field) DO UPDATE
+        SET value = EXCLUDED.value,
+            observation_id = EXCLUDED.observation_id,
+            updated_at = now()
+        WHERE entity_field_state.observation_id < EXCLUDED.observation_id;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- WHEN clause keeps the 99% non-field inserts from ever entering the plpgsql
+-- frame (predicate evaluated in C). Sibling of the append-only BEFORE DELETE
+-- guard — disjoint timing/event, no conflict.
+DROP TRIGGER IF EXISTS trg_project_entity_field ON public.events;
+CREATE TRIGGER trg_project_entity_field
+    AFTER INSERT ON public.events
+    FOR EACH ROW
+    WHEN (NEW.semantic_type = 'entity_field')
+    EXECUTE FUNCTION public.project_entity_field();
+
+-- migrate:down
+DROP TRIGGER IF EXISTS trg_project_entity_field ON public.events;
+DROP FUNCTION IF EXISTS public.project_entity_field();
+-- squawk-ignore ban-drop-table
+DROP TABLE IF EXISTS public.entity_field_state;

--- a/packages/server/src/__tests__/integration/entities/entity-field-projection.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-field-projection.test.ts
@@ -1,0 +1,168 @@
+/**
+ * entity_field_state projection SUBSTRATE — expand phase.
+ *
+ * The DB trigger `project_entity_field` folds 'entity_field' events into
+ * `entity_field_state` (latest event per (entity_id, field) wins, keep-greater on
+ * the monotonic event id) — but ONLY for a well-formed event whose entity belongs
+ * to the event's org. The trigger fires synchronously with the event insert, so
+ * no polling is needed. Asserts:
+ *   1. fields land in the projection (org-scoped),
+ *   2. a later event advances value + observation_id,
+ *   3. keep-greater REJECTS an event with a lower observation_id (out-of-order),
+ *   4. a malformed event NEVER aborts the host events insert (degrades to no-op),
+ *   5. a cross-org event CANNOT touch another org's projection row (tenancy),
+ *   6. entity_field events carry no entity link (no content-count pollution).
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { TestApiClient } from '../../setup/test-mcp-client';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { insertEvent } from '../../../utils/insert-event';
+
+const sql = getTestDb();
+
+let orgA: string;
+let orgB: string;
+let clientA: TestApiClient;
+let counter = 0;
+
+async function makeEntity(client: TestApiClient, name: string): Promise<number> {
+  const created = (await client.entities.create({ type: 'company', name })) as {
+    entity?: { id: number };
+  };
+  return created.entity!.id;
+}
+
+async function emitFields(
+  orgId: string,
+  entityId: number,
+  fields: Record<string, unknown>
+): Promise<number> {
+  counter += 1;
+  const ev = await insertEvent({
+    entityIds: [],
+    organizationId: orgId,
+    originId: `efield_test_${counter}`,
+    semanticType: 'entity_field',
+    metadata: { entity_id: entityId, fields },
+  });
+  return ev.id;
+}
+
+async function fieldState(
+  entityId: number
+): Promise<Record<string, { value: unknown; obs: number; org: string }>> {
+  const rows = (await sql`
+    SELECT organization_id, field, value, observation_id
+    FROM entity_field_state WHERE entity_id = ${entityId}
+  `) as Array<{ organization_id: string; field: string; value: unknown; observation_id: string }>;
+  const out: Record<string, { value: unknown; obs: number; org: string }> = {};
+  for (const r of rows) {
+    out[r.field] = { value: r.value, obs: Number(r.observation_id), org: r.organization_id };
+  }
+  return out;
+}
+
+describe('entity_field_state projection substrate (expand phase)', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+
+    const oa = await createTestOrganization({ name: 'Projection Org A' });
+    orgA = oa.id;
+    const ua = await createTestUser({ email: 'proj-a@test.com' });
+    await addUserToOrganization(ua.id, oa.id, 'owner');
+    clientA = await TestApiClient.for({ organizationId: oa.id, userId: ua.id, memberRole: 'owner' });
+    await clientA.entity_schema.createType({ slug: 'company', name: 'Company' });
+
+    const ob = await createTestOrganization({ name: 'Projection Org B' });
+    orgB = ob.id;
+    const ub = await createTestUser({ email: 'proj-b@test.com' });
+    await addUserToOrganization(ub.id, ob.id, 'owner');
+  });
+
+  it('folds entity_field events into the projection (org-scoped)', async () => {
+    const id = await makeEntity(clientA, 'Acme');
+    await emitFields(orgA, id, { tier: 'gold', employees: 50 });
+    const st = await fieldState(id);
+    expect(st.tier.value).toBe('gold');
+    expect(st.employees.value).toBe(50);
+    expect(st.tier.org).toBe(orgA);
+  });
+
+  it('a later event advances the projected value and observation_id', async () => {
+    const id = await makeEntity(clientA, 'Globex');
+    await emitFields(orgA, id, { tier: 'silver' });
+    const before = await fieldState(id);
+    await emitFields(orgA, id, { tier: 'platinum' });
+    const after = await fieldState(id);
+    expect(after.tier.value).toBe('platinum');
+    expect(after.tier.obs).toBeGreaterThan(before.tier.obs);
+  });
+
+  it('keep-greater REJECTS an event with a lower observation_id (out-of-order)', async () => {
+    const id = await makeEntity(clientA, 'Initech');
+    await emitFields(orgA, id, { tier: 'gold' });
+    // Simulate a much later event already projected.
+    await sql`
+      UPDATE entity_field_state SET observation_id = 9223372036854775000
+      WHERE entity_id = ${id} AND field = 'tier'
+    `;
+    await emitFields(orgA, id, { tier: 'bronze' });
+    const st = await fieldState(id);
+    expect(st.tier.value).toBe('gold'); // lower id rejected
+  });
+
+  it('a malformed entity_field event NEVER aborts the host events insert', async () => {
+    const id = await makeEntity(clientA, 'Malformed Co');
+    // Each of these must resolve (no thrown abort of the events insert) AND
+    // leave no projection row.
+    const bad: Array<Record<string, unknown>> = [
+      { fields: { x: 1 } }, // entity_id missing
+      { entity_id: 3.9, fields: { x: 1 } }, // non-integer number
+      { entity_id: 99999999999999999999999, fields: { x: 1 } }, // out of bigint range
+      { entity_id: id, fields: 'not-an-object' }, // fields not an object
+    ];
+    for (const [i, meta] of bad.entries()) {
+      await expect(
+        insertEvent({
+          entityIds: [],
+          organizationId: orgA,
+          originId: `efield_bad_${i}`,
+          semanticType: 'entity_field',
+          metadata: meta,
+        })
+      ).resolves.toBeTruthy();
+    }
+    expect(Object.keys(await fieldState(id))).toHaveLength(0);
+  });
+
+  it("a cross-org event CANNOT touch another org's projection row (tenancy)", async () => {
+    const id = await makeEntity(clientA, 'Tenancy Co'); // owned by org A
+    await emitFields(orgA, id, { tier: 'gold' });
+
+    // Org B emits a field event for org A's entity id — the ownership check must
+    // skip it (entity does not belong to org B), even though its event id is higher.
+    await emitFields(orgB, id, { tier: 'HIJACKED' });
+
+    const st = await fieldState(id);
+    expect(st.tier.value).toBe('gold'); // unchanged
+    expect(st.tier.org).toBe(orgA); // org not re-stamped to B
+  });
+
+  it('does not pollute entity-linked content: entity_field events carry no entity link', async () => {
+    const id = await makeEntity(clientA, 'Clean Co');
+    await emitFields(orgA, id, { tier: 'gold' });
+    const rows = (await sql`
+      SELECT count(*)::int AS n FROM events
+      WHERE semantic_type = 'entity_field'
+        AND organization_id = ${orgA}
+        AND entity_ids IS NOT NULL AND array_length(entity_ids, 1) >= 1
+    `) as Array<{ n: number }>;
+    expect(rows[0].n).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Adds `entity_field_state` — a trigger-maintained projection of the latest
`entity_field` event per `(entity_id, field)`. First slice of the event-sourced
entity-metadata consolidation: the events log becomes the source of truth and the
current per-field value is a rebuildable cache the DB maintains.

This is the **expand phase, substrate only**: the table + a `WHEN`-gated
`AFTER INSERT` trigger that folds field events keep-greater (monotonic event id
wins; the `ON CONFLICT` row-lock serializes concurrent writers — correct under
N>1 replicas, serialization lives entirely in Postgres). Nothing emits
`entity_field` events yet, so it's inert in prod (the `WHEN` gate keeps the
plpgsql frame off the 99.99% non-field inserts).

## Event contract

`entity_field` events carry **empty `entity_ids`** (so they never match
entity-linked content counts / feeds / search), org via the `events.organization_id`
column, and `{ entity_id, fields }` in metadata.

## Hardening (this trigger fires on the hot append-only events table)

- **Never aborts the host insert.** A NULL-safe, integer-validated guard
  (`coalesce` + a 1..18-digit regex) runs before the `::bigint` cast — missing /
  float / out-of-range / non-object payloads degrade to a no-op.
- **Tenancy.** Projects only for an entity that belongs to the event's org, so a
  cross-org event can't hijack or re-stamp a row (`organization_id` is immutable
  per entity); unknown/deleted entities are skipped (covers the no-FK case).

## Tests (red→green)

`entity-field-projection.test.ts` drives the substrate through the real
`insertEvent` path + live trigger: fold, advance, keep-greater rejection of a
lower id, **malformed-never-aborts**, **cross-org tenancy**, and no-pollution.
6/6 green; migration applies and reverses cleanly; squawk clean.

## Review

Reviewed by 10 agents across distinct aspects + 2 `pi` passes. The first pass
caught two real blockers that this PR fixes: `entity_field` events were polluting
~12 entity-linked content consumers (fixed by empty `entity_ids`), and an
async fire-and-forget producer could pick the wrong keep-greater winner — so the
**producer was removed entirely** and deferred to a transactional follow-up. The
second pass + teammates caught the malformed-abort and cross-org issues fixed above.

## Deferred follow-ups (not in this PR)

- **Producer:** `manage_entity` emitting `entity_field` events **inside the
  entity-update transaction** (required for correct ordering).
- **Rebuild index + reader flip + orphan sweep:** the contract phase.

Draft — for review before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784692267&installation_id=136316292&pr_number=1440&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1440&signature=201e2eb2002859e15828f10d4b48fa93c5c107e3ce84d528c83097c24ed91397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->