### PR TITLE
fix(dev): make dev-db a walk-in single-user install

### DIFF
--- a/scripts/dev-db.sh
+++ b/scripts/dev-db.sh
@@ -69,6 +69,12 @@ export WORKER_PROXY_PORT
 # current version; runMigrations is idempotent) and seed the first user/org so
 # /api/local-init works. Same flag `lobu run` uses; prod never sets it.
 export LOBU_RUN_OWNS_DB=1
+# Single-user mode: makes /api/auth-config report singleUserMode=true, so the SPA
+# signs you in automatically via the loopback /api/local-init handshake instead
+# of showing the cloud login form. The embedded runtime defaults this on; the
+# external-Postgres path (this script) doesn't, so set it here for the walk-in
+# local UX. Override with LOBU_SINGLE_USER=0 to test the multi-user login form.
+export LOBU_SINGLE_USER="${LOBU_SINGLE_USER:-1}"
 echo "→ DATABASE_URL=$DATABASE_URL"
 echo "→ server on :$PORT   (worker proxy :$WORKER_PROXY_PORT)"
 echo ""


### PR DESCRIPTION
make dev-db set LOBU_RUN_OWNS_DB but not LOBU_SINGLE_USER, so /api/auth-config reported singleUserMode=false and the SPA showed the cloud login form instead of the loopback /api/local-init auto-sign-in. The embedded runtime defaults this on; the external-Postgres path didn't. Default it on (overridable via LOBU_SINGLE_USER=0). Verified: the preview now walks straight in to /local-install with no login.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784692478&installation_id=136316292&pr_number=1441&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1441&signature=c674e95b19c55e9843b763ebc8ffc4345b27e7c8e458880b23ca4d760ddd793e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->