### PR TITLE
feat(entities): emit entity_field events transactionally (P5 producer)

### DIFF
--- a/packages/server/src/__tests__/integration/entities/entity-field-producer.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-field-producer.test.ts
@@ -1,0 +1,96 @@
+/**
+ * entity_field projection PRODUCER — manage_entity create/update emit an
+ * entity_field event INSIDE the entity-write transaction, so the projection
+ * (entity_field_state) tracks entities.metadata. Because emission is synchronous
+ * (awaited in the txn), reads need no polling.
+ *
+ * The concurrency test is the load-bearing one: it proves the projection
+ * converges to the SAME value as the authoritative entities.metadata even under
+ * concurrent updates to the same field — i.e. the FOR UPDATE + same-txn emission
+ * orders the projection consistently with the metadata write.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { TestApiClient } from '../../setup/test-mcp-client';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+
+const sql = getTestDb();
+
+let owner: TestApiClient;
+
+async function makeEntity(name: string, metadata?: Record<string, unknown>): Promise<number> {
+  const created = (await owner.entities.create({ type: 'company', name, metadata })) as {
+    entity?: { id: number };
+  };
+  return created.entity!.id;
+}
+
+async function tierState(entityId: number): Promise<{ value: unknown; obs: number } | undefined> {
+  const rows = (await sql`
+    SELECT value, observation_id FROM entity_field_state
+    WHERE entity_id = ${entityId} AND field = 'tier'
+  `) as Array<{ value: unknown; observation_id: string }>;
+  if (rows.length === 0) return undefined;
+  return { value: rows[0].value, obs: Number(rows[0].observation_id) };
+}
+
+async function entityTier(entityId: number): Promise<unknown> {
+  const rows = (await sql`
+    SELECT metadata->>'tier' AS tier FROM entities WHERE id = ${entityId}
+  `) as Array<{ tier: string | null }>;
+  return rows[0]?.tier ?? null;
+}
+
+describe('entity_field projection producer (manage_entity)', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Producer Org' });
+    const u = await createTestUser({ email: 'producer-owner@test.com' });
+    await addUserToOrganization(u.id, org.id, 'owner');
+    owner = await TestApiClient.for({ organizationId: org.id, userId: u.id, memberRole: 'owner' });
+    await owner.entity_schema.createType({ slug: 'company', name: 'Company' });
+  });
+
+  it('create populates the projection (synchronously, no polling)', async () => {
+    const id = await makeEntity('Acme', { tier: 'gold', employees: 50 });
+    const tier = await tierState(id);
+    expect(tier?.value).toBe('gold');
+    const emp = (await sql`
+      SELECT value FROM entity_field_state WHERE entity_id = ${id} AND field = 'employees'
+    `) as Array<{ value: unknown }>;
+    expect(emp[0].value).toBe(50);
+  });
+
+  it('update advances the projection and matches entities.metadata', async () => {
+    const id = await makeEntity('Globex', { tier: 'silver' });
+    const before = await tierState(id);
+    await owner.entities.update({ entity_id: id, metadata: { tier: 'platinum' } });
+    const after = await tierState(id);
+    expect(after?.value).toBe('platinum');
+    expect(after!.obs).toBeGreaterThan(before!.obs);
+    expect(after?.value).toBe(await entityTier(id));
+  });
+
+  it('concurrent updates: projection converges to the SAME value as entities.metadata', async () => {
+    const id = await makeEntity('Race Co', { tier: 'v0' });
+    // Fire several concurrent updates to the same field; FOR UPDATE serializes
+    // them and the same-txn event emission orders the projection identically.
+    await Promise.all([
+      owner.entities.update({ entity_id: id, metadata: { tier: 'a' } }),
+      owner.entities.update({ entity_id: id, metadata: { tier: 'b' } }),
+      owner.entities.update({ entity_id: id, metadata: { tier: 'c' } }),
+      owner.entities.update({ entity_id: id, metadata: { tier: 'd' } }),
+    ]);
+    const projected = await tierState(id);
+    const authoritative = await entityTier(id);
+    // Whatever won the row lock last is in entities.metadata; the projection must
+    // agree (no stale/inverted winner).
+    expect(projected?.value).toBe(authoritative);
+    expect(['a', 'b', 'c', 'd']).toContain(authoritative);
+  });
+});

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -20,6 +20,7 @@ import type { ToolContext } from '../tools/registry';
 import { entityLinkMatchSql } from './content-search';
 import { type EntityHookContext, getEntityHooks } from './entity-hooks';
 import { ToolUserError } from './errors';
+import { insertEvent } from './insert-event';
 import { requireWriteAccess } from './organization-access';
 import { RESERVED_ENTITY_TYPES } from './reserved';
 
@@ -189,6 +190,41 @@ async function loadEntityTreeIds(sql: DbClient, entityId: number): Promise<numbe
  * Create new entity
  * Entity is created in the user's organization
  */
+/**
+ * Emit one 'entity_field' event INSIDE the given transaction — the projection
+ * source for entity_field_state. Emitting in the same txn as the entity write
+ * (under the row lock for updates) makes the event's events.id order consistently
+ * with the metadata write, which is what the projection's keep-greater fold
+ * relies on. entity_ids is empty (NULL) so the event never matches entity-linked
+ * content queries; org + entity id + the changed fields ride in metadata.
+ */
+async function emitEntityFieldEvent(
+  tx: ReturnType<typeof getDb>,
+  params: {
+    entityId: number;
+    organizationId: string;
+    fields: Record<string, unknown>;
+    createdBy?: string | null;
+  }
+): Promise<void> {
+  if (Object.keys(params.fields).length === 0) return;
+  // No clientId on purpose: insertEvent's stale-clientId FK fallback retries
+  // after a failed insert, which can't recover inside this caller's transaction
+  // (a failed statement aborts the txn and would roll back the entity write).
+  // The projection event is internal; it doesn't need a client stamp.
+  await insertEvent(
+    {
+      entityIds: [],
+      organizationId: params.organizationId,
+      originId: `efield_${params.entityId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      semanticType: 'entity_field',
+      metadata: { entity_id: params.entityId, fields: params.fields },
+      createdBy: params.createdBy ?? null,
+    },
+    { sql: tx }
+  );
+}
+
 export async function createEntity(
   data: EntityData,
   opts?: EntityCreateOptions
@@ -284,24 +320,38 @@ export async function createEntity(
   const contentHash = data.content_hash || null;
 
   try {
-    const result = await sql<Omit<CreatedEntity, 'entity_type'>>`
-      INSERT INTO entities (
-        organization_id, entity_type_id, name, slug, parent_id, metadata, enabled_classifiers, created_by, content, embedding, content_hash, created_at, updated_at
-      ) VALUES (
-        ${data.organization_id}, ${entityTypeId}, ${data.name.trim()}, ${slug}, ${data.parent_id || null},
-        ${sql.json(metadata)}, ${data.enabled_classifiers || null}, ${createdBy},
-        ${contentValue}, ${embeddingLiteral}::vector, ${contentHash}, current_timestamp, current_timestamp
-      )
-      RETURNING id, name, slug, parent_id, metadata, created_at
-    `;
-
-    if (result.length === 0) {
-      throw new Error('Failed to create entity');
-    }
+    const inserted = await sql.begin(async (tx) => {
+      const rows = await tx<Omit<CreatedEntity, 'entity_type'>>`
+        INSERT INTO entities (
+          organization_id, entity_type_id, name, slug, parent_id, metadata, enabled_classifiers, created_by, content, embedding, content_hash, created_at, updated_at
+        ) VALUES (
+          ${data.organization_id}, ${entityTypeId}, ${data.name.trim()}, ${slug}, ${data.parent_id || null},
+          ${sql.json(metadata)}, ${data.enabled_classifiers || null}, ${createdBy},
+          ${contentValue}, ${embeddingLiteral}::vector, ${contentHash}, current_timestamp, current_timestamp
+        )
+        RETURNING id, name, slug, parent_id, metadata, created_at
+      `;
+      if (rows.length === 0) {
+        throw new Error('Failed to create entity');
+      }
+      // Project the created metadata into entity_field_state in THIS txn — the
+      // new entity row is already visible to the trigger's ownership check.
+      const createdMetadata: Record<string, unknown> =
+        typeof rows[0].metadata === 'string'
+          ? JSON.parse(rows[0].metadata)
+          : ((rows[0].metadata as Record<string, unknown> | null) ?? {});
+      await emitEntityFieldEvent(tx as unknown as ReturnType<typeof getDb>, {
+        entityId: rows[0].id,
+        organizationId: data.organization_id as string,
+        fields: createdMetadata,
+        createdBy: createdBy === 'system' ? null : createdBy,
+      });
+      return rows[0];
+    });
 
     // The validator above already resolved data.entity_type → entityTypeId.
     // Pass the slug back through directly rather than JOIN-ing on every insert.
-    const created: CreatedEntity = { ...result[0], entity_type: data.entity_type };
+    const created: CreatedEntity = { ...inserted, entity_type: data.entity_type };
 
     // Run afterCreate hook
     if (!opts?.skipHooks && opts?.hookContext) {
@@ -363,55 +413,78 @@ export async function updateEntity(
   const metadataUpdates = mergeConvenienceFields(data, data.metadata ?? {}, 'update');
   const hasMetadataUpdates = Object.keys(metadataUpdates).length > 0;
 
-  // First get the current entity so we can merge metadata
-  const current = await sql`
-    SELECT metadata FROM entities WHERE id = ${entityId} AND deleted_at IS NULL
-  `;
-  if (current.length === 0) {
-    throw new Error(`Entity ${entityId} not found`);
-  }
-
-  // Merge metadata in TypeScript
-  let mergedMetadata: Record<string, unknown> | null = null;
-  if (hasMetadataUpdates) {
-    const existing =
-      typeof current[0].metadata === 'string'
-        ? JSON.parse(current[0].metadata as string)
-        : (current[0].metadata ?? {});
-    mergedMetadata = { ...existing, ...metadataUpdates };
-  }
-
   const hasContent = data.content !== undefined;
   const contentValue = data.content?.trim() || null;
   const hasEmbedding = data.embedding !== undefined;
   const embeddingLiteral = toVectorLiteral(data.embedding);
 
-  await sql`
-    UPDATE entities SET
-      name = COALESCE(${data.name ?? null}, name),
-      slug = COALESCE(${newSlug}, slug),
-      parent_id = CASE WHEN ${data.parent_id !== undefined} THEN ${data.parent_id ?? null}::bigint ELSE parent_id END,
-      metadata = CASE WHEN ${hasMetadataUpdates} THEN ${mergedMetadata ? sql.json(mergedMetadata) : null} ELSE metadata END,
-      enabled_classifiers = CASE WHEN ${data.enabled_classifiers !== undefined} THEN ${data.enabled_classifiers ?? null}::text[] ELSE enabled_classifiers END,
-      content = CASE WHEN ${hasContent} THEN ${contentValue} ELSE content END,
-      embedding = CASE WHEN ${hasEmbedding} THEN ${embeddingLiteral}::vector ELSE embedding END,
-      updated_at = current_timestamp
-    WHERE id = ${entityId} AND deleted_at IS NULL
-  `;
+  // Lock the entity row, merge metadata, write, and emit the projection event in
+  // ONE transaction: concurrent updates to the same entity serialize on the row
+  // lock, so the emitted entity_field event's events.id orders consistently with
+  // this metadata write — which is exactly what the projection's keep-greater
+  // fold relies on. (Also fixes the pre-existing non-transactional read-modify-
+  // write race on entities.metadata.)
+  const result = await sql.begin(async (tx) => {
+    const current = await tx`
+      SELECT metadata, organization_id FROM entities
+      WHERE id = ${entityId} AND deleted_at IS NULL
+      FOR UPDATE
+    `;
+    if (current.length === 0) {
+      throw new Error(`Entity ${entityId} not found`);
+    }
+    const orgId = current[0].organization_id as string;
 
-  const result = await sql<CreatedEntity>`
-    SELECT e.id, et.slug AS entity_type, e.name, e.slug, e.parent_id, e.metadata, e.created_at
-    FROM entities e
-    JOIN entity_types et ON et.id = e.entity_type_id
-    WHERE e.id = ${entityId}
-    LIMIT 1
-  `;
+    let mergedMetadata: Record<string, unknown> | null = null;
+    const changedFields: Record<string, unknown> = {};
+    if (hasMetadataUpdates) {
+      const existing = (
+        typeof current[0].metadata === 'string'
+          ? JSON.parse(current[0].metadata as string)
+          : (current[0].metadata ?? {})
+      ) as Record<string, unknown>;
+      mergedMetadata = { ...existing, ...metadataUpdates };
+      for (const [k, v] of Object.entries(metadataUpdates)) {
+        if (JSON.stringify(existing[k]) !== JSON.stringify(v)) {
+          changedFields[k] = v;
+        }
+      }
+    }
 
-  if (result.length === 0) {
-    throw new Error(`Entity ${entityId} not found`);
-  }
+    await tx`
+      UPDATE entities SET
+        name = COALESCE(${data.name ?? null}, name),
+        slug = COALESCE(${newSlug}, slug),
+        parent_id = CASE WHEN ${data.parent_id !== undefined} THEN ${data.parent_id ?? null}::bigint ELSE parent_id END,
+        metadata = CASE WHEN ${hasMetadataUpdates} THEN ${mergedMetadata ? sql.json(mergedMetadata) : null} ELSE metadata END,
+        enabled_classifiers = CASE WHEN ${data.enabled_classifiers !== undefined} THEN ${data.enabled_classifiers ?? null}::text[] ELSE enabled_classifiers END,
+        content = CASE WHEN ${hasContent} THEN ${contentValue} ELSE content END,
+        embedding = CASE WHEN ${hasEmbedding} THEN ${embeddingLiteral}::vector ELSE embedding END,
+        updated_at = current_timestamp
+      WHERE id = ${entityId} AND deleted_at IS NULL
+    `;
 
-  return result[0];
+    await emitEntityFieldEvent(tx as unknown as ReturnType<typeof getDb>, {
+      entityId,
+      organizationId: orgId,
+      fields: changedFields,
+      createdBy: ctx.userId ?? null,
+    });
+
+    const sel = await tx<CreatedEntity>`
+      SELECT e.id, et.slug AS entity_type, e.name, e.slug, e.parent_id, e.metadata, e.created_at
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.id = ${entityId}
+      LIMIT 1
+    `;
+    if (sel.length === 0) {
+      throw new Error(`Entity ${entityId} not found`);
+    }
+    return sel[0];
+  });
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
## What

P5 **producer**, stacked on #1440 (the substrate). `createEntity`/`updateEntity`
now emit one `entity_field` event **inside the entity-write transaction**, so the
`entity_field_state` projection tracks `entities.metadata`.

`updateEntity` takes `SELECT ... FOR UPDATE` on the row, then writes, then emits
via `insertEvent({...}, { sql: tx })` in the same txn. Because the event's
`events.id` is drawn inside that serialized critical section, the projection's
keep-greater fold lands the same winner that `entities.metadata` ends on — even
under concurrent updates to the same field. This also fixes a **pre-existing
non-transactional read-modify-write race** on `entities.metadata` (SELECT-then-
UPDATE → SELECT FOR UPDATE in one txn).

## Tests

`entity-field-producer.test.ts`: create populates the projection (synchronously),
update advances + matches `entities.metadata`, and **concurrent updates converge
to the same value as `entities.metadata`** (the ordering guarantee). 9/9 with the
substrate tests; 27 entity/event regression tests green.

## Review

3 teammates: ordering/deadlock (core claim confirmed — FOR UPDATE serializes,
no lock cycle, `events.id` drawn in the critical section), behavior-preservation
(every column write / merge / error path / hook ordering intact), and
perf/correctness. Two MEDIUM fixes applied from the last: use order-insensitive
`stableJson` for the changed-field diff (no churn on key-order-different nested
objects), and skip `undefined`-valued keys.

## Notes

- Every entity create/update now writes 2 events (the existing `change` audit +
  the new `entity_field`) — by design for event-sourcing.
- `entity_field` events carry empty `entity_ids` (no content-count pollution);
  emission is atomic with the write (a failed emit rolls back, and the hardened
  trigger can't abort it).

Stacked on #1440 — base will retarget to `main` once that merges. Draft for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784693946&installation_id=136316292&pr_number=1442&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1442&signature=9cc21cc9de0a723ebdf981daafaf7957e0e3ff16709e3dde7b843ce87bc86316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->