### PR TITLE
feat(view-templates): fold active-tabs into is_current via trigger (render-store consolidation, phase 1/3)

### DIFF
--- a/db/migrations/20260622160000_view_template_is_current.sql
+++ b/db/migrations/20260622160000_view_template_is_current.sql
@@ -1,0 +1,63 @@
+-- migrate:up
+
+-- Render-store consolidation, EXPAND phase (1 of 3): fold the
+-- view_template_active_tabs pointer table into an is_current flag on
+-- view_template_versions (mirrors event_classifier_versions.is_current).
+--
+-- is_current is maintained by a DB TRIGGER on view_template_active_tabs, so it
+-- stays consistent no matter which app replica (old OR new) writes the pointer
+-- table during a rolling deploy — no app-level dual-write, no drift, no
+-- non-atomic remove. This release only ADDS is_current + the trigger; READS
+-- still use view_template_active_tabs. A later release flips reads to is_current;
+-- the final release drops view_template_active_tabs (and this trigger, with the
+-- app then writing is_current directly).
+--
+-- Operational cost: view_template_versions / active_tabs are low-volume UI-driven
+-- config tables (a handful of rows per org, far under the ~100k threshold). The
+-- constant DEFAULT false ADD COLUMN is a metadata-only flip (no rewrite, PG11+);
+-- the backfill UPDATE touches only the rows active_tabs points at. (Not measured
+-- against prod size, but these are config-scale tables.)
+
+ALTER TABLE public.view_template_versions
+    ADD COLUMN IF NOT EXISTS is_current boolean NOT NULL DEFAULT false;
+
+-- Keep view_template_versions.is_current in lockstep with the
+-- view_template_active_tabs pointer (named tabs only — default tabs track current
+-- via the parent FK current_view_template_version_id, never is_current). The
+-- clear-then-set ordering avoids a transient two-current violation of the partial
+-- unique index; concurrent writers for the same tab serialize on the active_tabs
+-- unique row, so their triggers fire serially.
+CREATE OR REPLACE FUNCTION public.sync_view_template_is_current() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE public.view_template_versions SET is_current = false
+        WHERE resource_type = OLD.resource_type AND resource_id = OLD.resource_id
+          AND organization_id = OLD.organization_id AND tab_name = OLD.tab_name
+          AND is_current = true;
+        RETURN OLD;
+    END IF;
+    UPDATE public.view_template_versions SET is_current = false
+    WHERE resource_type = NEW.resource_type AND resource_id = NEW.resource_id
+      AND organization_id = NEW.organization_id AND tab_name = NEW.tab_name
+      AND is_current = true AND id <> NEW.current_version_id;
+    UPDATE public.view_template_versions SET is_current = true
+    WHERE id = NEW.current_version_id AND is_current = false;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_sync_view_template_is_current ON public.view_template_active_tabs;
+CREATE TRIGGER trg_sync_view_template_is_current
+    AFTER INSERT OR UPDATE OR DELETE ON public.view_template_active_tabs
+    FOR EACH ROW EXECUTE FUNCTION public.sync_view_template_is_current();
+
+-- Backfill existing pointers (the trigger only fires on future writes).
+UPDATE public.view_template_versions v
+SET is_current = true
+FROM public.view_template_active_tabs t
+WHERE t.current_version_id = v.id;
+
+-- migrate:down
+DROP TRIGGER IF EXISTS trg_sync_view_template_is_current ON public.view_template_active_tabs;
+DROP FUNCTION IF EXISTS public.sync_view_template_is_current();
+ALTER TABLE public.view_template_versions DROP COLUMN IF EXISTS is_current;

--- a/db/migrations/20260622160100_idx_view_template_current.sql
+++ b/db/migrations/20260622160100_idx_view_template_current.sql
@@ -1,0 +1,14 @@
+-- migrate:up transaction:false
+
+-- One current named-tab version per (resource, tab). Partial: excludes the
+-- default-tab rows (tab_name NULL — those track current via the parent FK
+-- current_view_template_version_id, not is_current). CONCURRENTLY since
+-- view_template_versions is read on the entity-detail path; the partial predicate
+-- keeps it tiny. squawk-ignore prefer-robust-stmts
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_view_template_versions_current
+    ON public.view_template_versions (resource_type, resource_id, organization_id, tab_name)
+    WHERE is_current = true AND tab_name IS NOT NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_view_template_versions_current;

--- a/packages/server/src/__tests__/integration/tools/view-template-is-current.test.ts
+++ b/packages/server/src/__tests__/integration/tools/view-template-is-current.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Render-store consolidation, expand phase: view_template_versions.is_current is
+ * maintained by a DB trigger on view_template_active_tabs (the app still writes
+ * only active_tabs). Asserts is_current stays in lockstep with active_tabs across
+ * set / rollback / re-point / remove_tab, and that at most one version per
+ * (resource, tab) is current (the partial unique index invariant). Reads still
+ * use active_tabs this phase; the flip + table drop are later releases.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { TestApiClient } from '../../setup/test-mcp-client';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+
+const sql = getTestDb();
+let owner: TestApiClient;
+
+const tmpl = (n: number) => ({ version: 1, root: { type: 'text', content: `v${n}` } });
+
+async function currentIds(tabName: string): Promise<number[]> {
+  const rows = (await sql`
+    SELECT id FROM view_template_versions
+    WHERE resource_type = 'entity_type' AND resource_id = 'company'
+      AND tab_name = ${tabName} AND is_current = true
+    ORDER BY id
+  `) as Array<{ id: string }>;
+  return rows.map((r) => Number(r.id));
+}
+
+async function activeTabId(tabName: string): Promise<number | null> {
+  const rows = (await sql`
+    SELECT current_version_id FROM view_template_active_tabs
+    WHERE resource_type = 'entity_type' AND resource_id = 'company' AND tab_name = ${tabName}
+  `) as Array<{ current_version_id: string }>;
+  return rows.length ? Number(rows[0].current_version_id) : null;
+}
+
+describe('view_template is_current via trigger (expand phase)', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'VT Org' });
+    const u = await createTestUser({ email: 'vt-owner@test.com' });
+    await addUserToOrganization(u.id, org.id, 'owner');
+    owner = await TestApiClient.for({ organizationId: org.id, userId: u.id, memberRole: 'owner' });
+    await owner.entity_schema.createType({ slug: 'company', name: 'Company' });
+  });
+
+  it('set marks exactly one is_current, matching active_tabs, and advances on re-set', async () => {
+    await owner.view_templates.set({
+      resource_type: 'entity_type',
+      resource_id: 'company',
+      tab_name: 'analytics',
+      json_template: tmpl(1),
+    });
+    const cur1 = await currentIds('analytics');
+    expect(cur1).toHaveLength(1);
+    expect(cur1[0]).toBe(await activeTabId('analytics'));
+
+    await owner.view_templates.set({
+      resource_type: 'entity_type',
+      resource_id: 'company',
+      tab_name: 'analytics',
+      json_template: tmpl(2),
+    });
+    const cur2 = await currentIds('analytics');
+    expect(cur2).toHaveLength(1); // still exactly one current (unique invariant)
+    expect(cur2[0]).toBe(await activeTabId('analytics'));
+    expect(cur2[0]).toBeGreaterThan(cur1[0]); // advanced to the new version
+  });
+
+  it('rollback moves is_current back, in sync with active_tabs', async () => {
+    await owner.view_templates.rollback({
+      resource_type: 'entity_type',
+      resource_id: 'company',
+      tab_name: 'analytics',
+      version: 1,
+    });
+    const cur = await currentIds('analytics');
+    expect(cur).toHaveLength(1);
+    expect(cur[0]).toBe(await activeTabId('analytics'));
+  });
+
+  it('re-pointing to the already-current version is a no-op (still exactly one current)', async () => {
+    // After the rollback above, v1 is current. Roll back to v1 again — the
+    // trigger fires with current_version_id unchanged and must not error or
+    // produce zero/two current rows.
+    const before = await currentIds('analytics');
+    expect(before).toHaveLength(1);
+    await owner.view_templates.rollback({
+      resource_type: 'entity_type',
+      resource_id: 'company',
+      tab_name: 'analytics',
+      version: 1,
+    });
+    const after = await currentIds('analytics');
+    expect(after).toEqual(before); // same single current id, no change
+    expect(after[0]).toBe(await activeTabId('analytics'));
+  });
+
+  it('remove_tab clears is_current (matching the active_tabs delete)', async () => {
+    await owner.view_templates.removeTab({
+      resource_type: 'entity_type',
+      resource_id: 'company',
+      tab_name: 'analytics',
+    });
+    expect(await currentIds('analytics')).toHaveLength(0);
+    expect(await activeTabId('analytics')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Render-store consolidation, **phase 1 of 3**: fold the `view_template_active_tabs`
pointer table into an `is_current` flag on `view_template_versions` (the repo's
own pattern, cf. `event_classifier_versions.is_current`).

**Migration-only.** `is_current` is maintained by a DB **trigger** on
`view_template_active_tabs` — so it stays consistent no matter which app replica
(old or new) writes the pointer during a rolling deploy. No app-level dual-write,
no drift, no non-atomic remove. A backfill seeds existing pointers; a partial
unique index enforces one current named-tab version per `(resource, tab)`.

Reads still use `active_tabs` this release (purely additive, correct under N>1).

## Why a trigger (not app dual-write)

The first cut dual-wrote `is_current` in the app handlers. Review (2 teammates +
pi) flagged that an **old pod** during a rolling deploy writes only `active_tabs`,
leaving `is_current` stale — which would make the phase-2 read-flip unsafe without
a separate reconciliation. A DB trigger fires for *every* writer regardless of pod
version, eliminating the drift class entirely. Reverted the app changes; the
consolidation is now migration-only.

## The 3-phase plan

1. **This PR** — add `is_current` + trigger + backfill; reads stay on `active_tabs`.
2. Flip reads (`resolve_path.ts:1165`, `handleGet`) to `is_current` (safe — the
   trigger keeps it consistent across all pods, no reconciliation needed).
3. Drop `view_template_active_tabs` + the trigger; app writes `is_current` directly.

## Tests / review

`view-template-is-current.test.ts`: `is_current` tracks `active_tabs` through
set / re-set / rollback / idempotent re-point / remove_tab (exactly one current
per tab). 4/4 + view-template/resolve-path regression green; squawk clean.
Reviewed by 2 teammates + pi: trigger correct, multi-replica safe, additive,
no blocking findings.

Branches off `main` (independent of the P5 entity-field PRs). Draft for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784695508&installation_id=136316292&pr_number=1443&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1443&signature=24a189dc3cd3bc20b366788379c0bab1500fbf4316aeb6e161a11fe6c842ec99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->