### PR TITLE
feat(view-templates): flip named-tab reads to is_current + sync tab_order (phase 2/3)

### DIFF
--- a/db/migrations/20260622170000_view_template_tab_order_sync.sql
+++ b/db/migrations/20260622170000_view_template_tab_order_sync.sql
@@ -1,0 +1,67 @@
+-- migrate:up
+
+-- Render-store consolidation, phase 2: the read-flip (resolve_path.fetchTabs and
+-- manage_view_templates.handleGet now read named tabs + their display order from
+-- view_template_versions.is_current instead of view_template_active_tabs) needs
+-- the is_current version's tab_order to match the active pointer's.
+--
+-- Phase 1's trigger synced only is_current. A rollback re-points to an OLDER
+-- version (which carries its own historical tab_order) without touching
+-- active_tabs.tab_order, so reading order from the version could differ from the
+-- legacy active_tabs order. Extend the trigger to also sync tab_order onto the
+-- current version, and backfill it. (The set-current UPDATE drops the prior
+-- `AND is_current = false` no-op guard so a tab_order-only / re-point update still
+-- refreshes the order; re-setting is_current=true on the already-current row is
+-- idempotent and the clear-first ordering keeps the partial unique index safe.)
+
+CREATE OR REPLACE FUNCTION public.sync_view_template_is_current() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE public.view_template_versions SET is_current = false
+        WHERE resource_type = OLD.resource_type AND resource_id = OLD.resource_id
+          AND organization_id = OLD.organization_id AND tab_name = OLD.tab_name
+          AND is_current = true;
+        RETURN OLD;
+    END IF;
+    UPDATE public.view_template_versions SET is_current = false
+    WHERE resource_type = NEW.resource_type AND resource_id = NEW.resource_id
+      AND organization_id = NEW.organization_id AND tab_name = NEW.tab_name
+      AND is_current = true AND id <> NEW.current_version_id;
+    UPDATE public.view_template_versions
+    SET is_current = true, tab_order = NEW.tab_order
+    WHERE id = NEW.current_version_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Backfill display order onto the current version from the active pointer.
+UPDATE public.view_template_versions v
+SET tab_order = t.tab_order
+FROM public.view_template_active_tabs t
+WHERE t.current_version_id = v.id AND v.tab_order IS DISTINCT FROM t.tab_order;
+
+-- migrate:down
+
+-- Revert the trigger to phase 1's is_current-only function. The backfilled
+-- tab_order values on version rows are intentionally NOT reverted (there's no
+-- clean inverse, and they're harmless: phase-1 reads tab_order from
+-- view_template_active_tabs, not from the version row, so the synced value is
+-- ignored once reads roll back via the app).
+CREATE OR REPLACE FUNCTION public.sync_view_template_is_current() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE public.view_template_versions SET is_current = false
+        WHERE resource_type = OLD.resource_type AND resource_id = OLD.resource_id
+          AND organization_id = OLD.organization_id AND tab_name = OLD.tab_name
+          AND is_current = true;
+        RETURN OLD;
+    END IF;
+    UPDATE public.view_template_versions SET is_current = false
+    WHERE resource_type = NEW.resource_type AND resource_id = NEW.resource_id
+      AND organization_id = NEW.organization_id AND tab_name = NEW.tab_name
+      AND is_current = true AND id <> NEW.current_version_id;
+    UPDATE public.view_template_versions SET is_current = true
+    WHERE id = NEW.current_version_id AND is_current = false;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/server/src/__tests__/integration/tools/view-template-is-current.test.ts
+++ b/packages/server/src/__tests__/integration/tools/view-template-is-current.test.ts
@@ -84,6 +84,55 @@ describe('view_template is_current via trigger (expand phase)', () => {
     expect(cur[0]).toBe(await activeTabId('analytics'));
   });
 
+  it('get() reads the named tab via is_current (phase-2 read-flip)', async () => {
+    // handleGet now reads named tabs from is_current, not active_tabs.
+    const res = (await owner.view_templates.get({
+      resource_type: 'entity_type',
+      resource_id: 'company',
+    })) as { tabs: Array<{ tab_name: string; current_version_id: number }> };
+    const analytics = res.tabs.find((t) => t.tab_name === 'analytics');
+    expect(analytics).toBeDefined();
+    expect(analytics!.current_version_id).toBe(await activeTabId('analytics'));
+  });
+
+  it('tab_order stays in sync with the active pointer after rollback (phase-2 order)', async () => {
+    // v1 at order 1, v2 at order 9; the active pointer keeps order 9.
+    await owner.view_templates.set({
+      resource_type: 'entity_type',
+      resource_id: 'company',
+      tab_name: 'metrics',
+      tab_order: 1,
+      json_template: tmpl(1),
+    });
+    await owner.view_templates.set({
+      resource_type: 'entity_type',
+      resource_id: 'company',
+      tab_name: 'metrics',
+      tab_order: 9,
+      json_template: tmpl(2),
+    });
+    // Rollback to v1 (historical order 1) — the active pointer's order stays 9,
+    // and the trigger must sync that onto the now-current v1 so the phase-2 read
+    // (ORDER BY view_template_versions.tab_order) matches the legacy order.
+    await owner.view_templates.rollback({
+      resource_type: 'entity_type',
+      resource_id: 'company',
+      tab_name: 'metrics',
+      version: 1,
+    });
+    const active = (await sql`
+      SELECT tab_order FROM view_template_active_tabs
+      WHERE resource_type='entity_type' AND resource_id='company' AND tab_name='metrics'
+    `) as Array<{ tab_order: number }>;
+    const current = (await sql`
+      SELECT tab_order FROM view_template_versions
+      WHERE resource_type='entity_type' AND resource_id='company' AND tab_name='metrics'
+        AND is_current = true
+    `) as Array<{ tab_order: number }>;
+    expect(Number(current[0].tab_order)).toBe(Number(active[0].tab_order));
+    expect(Number(current[0].tab_order)).toBe(9);
+  });
+
   it('re-pointing to the already-current version is a no-op (still exactly one current)', async () => {
     // After the rollback above, v1 is current. Roll back to v1 again — the
     // trigger fires with current_version_id unchanged and must not error or

--- a/packages/server/src/tools/admin/manage_view_templates.ts
+++ b/packages/server/src/tools/admin/manage_view_templates.ts
@@ -330,18 +330,20 @@ async function handleGet(
     'created_by'
   );
 
-  // Named tabs
+  // Named tabs — render-store consolidation phase 2: read from is_current on
+  // view_template_versions (trigger-synced with the legacy active_tabs pointer).
   const tabRows = await sql`
     SELECT
-      vtat.tab_name, vtat.tab_order,
+      vtv.tab_name, vtv.tab_order,
       vtv.version as current_version, vtv.id as current_version_id,
       vtv.json_template
-    FROM view_template_active_tabs vtat
-    JOIN view_template_versions vtv ON vtv.id = vtat.current_version_id
-    WHERE vtat.resource_type = ${args.resource_type}
-      AND vtat.resource_id = ${resourceId}
-      AND vtat.organization_id = ${ctx.organizationId}
-    ORDER BY vtat.tab_order ASC, vtat.tab_name ASC
+    FROM view_template_versions vtv
+    WHERE vtv.resource_type = ${args.resource_type}
+      AND vtv.resource_id = ${resourceId}
+      AND vtv.organization_id = ${ctx.organizationId}
+      AND vtv.tab_name IS NOT NULL
+      AND vtv.is_current = true
+    ORDER BY vtv.tab_order ASC, vtv.tab_name ASC
   `;
 
   return {

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -1155,19 +1155,23 @@ async function fetchTabs(
   resourceId: string,
   organizationId: string
 ): Promise<ViewTemplateTab[]> {
+  // Render-store consolidation phase 2: named tabs read from is_current on
+  // view_template_versions (the trigger keeps it in lockstep with the legacy
+  // view_template_active_tabs pointer across all replicas).
   const rows = await sql`
     SELECT
-      vtat.tab_name,
-      vtat.tab_order,
+      vtv.tab_name,
+      vtv.tab_order,
       vtv.json_template,
       vtv.version,
       vtv.id as version_id
-    FROM view_template_active_tabs vtat
-    JOIN view_template_versions vtv ON vtv.id = vtat.current_version_id
-    WHERE vtat.resource_type = ${resourceType}
-      AND vtat.resource_id = ${resourceId}
-      AND vtat.organization_id = ${organizationId}
-    ORDER BY vtat.tab_order ASC, vtat.tab_name ASC
+    FROM view_template_versions vtv
+    WHERE vtv.resource_type = ${resourceType}
+      AND vtv.resource_id = ${resourceId}
+      AND vtv.organization_id = ${organizationId}
+      AND vtv.tab_name IS NOT NULL
+      AND vtv.is_current = true
+    ORDER BY vtv.tab_order ASC, vtv.tab_name ASC
   `;
 
   return rows.map((row) => ({


### PR DESCRIPTION
## What

Render-store consolidation **phase 2 of 3** (stacked on #1443). Flip the named-tab
reads from `view_template_active_tabs` to `view_template_versions.is_current`:
- `resolve_path.fetchTabs` (entity-detail rendering)
- `manage_view_templates.handleGet`

Writes still go to `active_tabs` (firing #1443's trigger, which keeps `is_current`
synced from every replica). Phase 3 will flip writes + drop `active_tabs` + trigger.

## Multi-replica safety

Safe once #1443's trigger is in prod: old pods read `active_tabs`, new pods read
`is_current`, and the trigger keeps both consistent from every pod's writes — no
reconciliation needed.

## tab_order fix (caught by pi review)

The phase-1 trigger synced only `is_current`. A rollback re-points to an older
version that carries its own historical `tab_order` without changing
`active_tabs.tab_order`, so reading order from the version would differ from the
legacy `active_tabs` order. This PR extends the trigger to also sync `tab_order`
onto the current version (+ backfill), so the flipped read returns identical
order in all cases (set / re-set / rollback / re-point).

## Tests / review

`view-template-is-current.test.ts` adds: `get()` reads via `is_current`, and
`tab_order` preserved after rollback (the bug). 9/9 + resolve-path regression
green; squawk clean. Reviewed by 2 teammates + pi: read-flip exactly equivalent
to the old `active_tabs` JOIN; `tab_order` trigger sync index-safe, no history
corruption; no blocking findings.

Base = `feat/render-store-consolidation` (#1443). Draft for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784696157&installation_id=136316292&pr_number=1444&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1444&signature=e9726e8efb1706a8622326529488262ec8877f1b831ca0eac8d87f8d11e140d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->