### PR TITLE
feat(view-templates): write is_current directly (render-store phase 3a)

### DIFF
--- a/packages/server/src/__tests__/integration/tools/view-template-is-current.test.ts
+++ b/packages/server/src/__tests__/integration/tools/view-template-is-current.test.ts
@@ -159,4 +159,54 @@ describe('view_template is_current via trigger (expand phase)', () => {
     expect(await currentIds('analytics')).toHaveLength(0);
     expect(await activeTabId('analytics')).toBeNull();
   });
+
+  it('app maintains is_current standalone with the trigger DISABLED (proves phase-3b trigger-drop is safe)', async () => {
+    await sql`ALTER TABLE view_template_active_tabs DISABLE TRIGGER trg_sync_view_template_is_current`;
+    try {
+      await owner.view_templates.set({
+        resource_type: 'entity_type',
+        resource_id: 'company',
+        tab_name: 'standalone',
+        tab_order: 3,
+        json_template: tmpl(1),
+      });
+      let cur = await currentIds('standalone');
+      expect(cur).toHaveLength(1);
+      expect(cur[0]).toBe(await activeTabId('standalone'));
+
+      await owner.view_templates.set({
+        resource_type: 'entity_type',
+        resource_id: 'company',
+        tab_name: 'standalone',
+        tab_order: 7,
+        json_template: tmpl(2),
+      });
+      await owner.view_templates.rollback({
+        resource_type: 'entity_type',
+        resource_id: 'company',
+        tab_name: 'standalone',
+        version: 1,
+      });
+      cur = await currentIds('standalone');
+      expect(cur).toHaveLength(1);
+      expect(cur[0]).toBe(await activeTabId('standalone'));
+      // trigger-OFF rollback: the app reads the outgoing current version's order
+      // (v2 @ 7) and applies it to the rolled-back v1 — preserved display order.
+      const order = (await sql`
+        SELECT tab_order FROM view_template_versions
+        WHERE resource_type='entity_type' AND resource_id='company'
+          AND tab_name='standalone' AND is_current = true
+      `) as Array<{ tab_order: number }>;
+      expect(Number(order[0].tab_order)).toBe(7);
+
+      await owner.view_templates.removeTab({
+        resource_type: 'entity_type',
+        resource_id: 'company',
+        tab_name: 'standalone',
+      });
+      expect(await currentIds('standalone')).toHaveLength(0);
+    } finally {
+      await sql`ALTER TABLE view_template_active_tabs ENABLE TRIGGER trg_sync_view_template_is_current`;
+    }
+  });
 });

--- a/packages/server/src/tools/admin/manage_view_templates.ts
+++ b/packages/server/src/tools/admin/manage_view_templates.ts
@@ -268,6 +268,17 @@ async function handleSet(
         ON CONFLICT (resource_type, resource_id, organization_id, tab_name)
         DO UPDATE SET current_version_id = ${vid}, tab_order = ${tabOrder}
       `;
+      // Phase 3a: also maintain is_current + tab_order directly on the version
+      // rows (transition off the trigger — kept until phase 3b drops it; both
+      // produce the same result). Clear-then-set keeps the partial unique index
+      // safe. tab_order is the requested display order for a set.
+      await tx`
+        UPDATE view_template_versions SET is_current = false
+        WHERE resource_type = ${args.resource_type} AND resource_id = ${resourceId}
+          AND organization_id = ${ctx.organizationId} AND tab_name = ${tabName}
+          AND is_current = true AND id <> ${vid}
+      `;
+      await tx`UPDATE view_template_versions SET is_current = true, tab_order = ${tabOrder} WHERE id = ${vid}`;
     }
 
     return row;
@@ -411,6 +422,28 @@ async function handleRollback(
       if (updated.length === 0) {
         throw new Error(`Tab '${tabName}' has no active entry to rollback`);
       }
+      // Phase 3a: maintain is_current + tab_order directly, preserving the tab's
+      // display order across the rollback (order is a tab-level property; rollback
+      // changes only which version is current). The order read below resolves to
+      // the unchanged pointer order in BOTH trigger states: trigger-ON it reads the
+      // just-re-pointed current version (the trigger already stamped the pointer
+      // order onto it); trigger-OFF (phase 3b) it reads the still-current outgoing
+      // version, which carries the same tab-level order. Either way the rolled-back
+      // version inherits the preserved order.
+      const curOrderRows = await tx`
+        SELECT tab_order FROM view_template_versions
+        WHERE resource_type = ${args.resource_type} AND resource_id = ${resourceId}
+          AND organization_id = ${ctx.organizationId} AND tab_name = ${tabName}
+          AND is_current = true LIMIT 1
+      `;
+      const curOrder = curOrderRows.length > 0 ? Number(curOrderRows[0].tab_order) : 0;
+      await tx`
+        UPDATE view_template_versions SET is_current = false
+        WHERE resource_type = ${args.resource_type} AND resource_id = ${resourceId}
+          AND organization_id = ${ctx.organizationId} AND tab_name = ${tabName}
+          AND is_current = true AND id <> ${versionId}
+      `;
+      await tx`UPDATE view_template_versions SET is_current = true, tab_order = ${curOrder} WHERE id = ${versionId}`;
     }
 
     return row;
@@ -442,18 +475,27 @@ async function handleRemoveTab(
   await verifyAccess(sql, args, ctx, true);
   const resourceId = rid(args);
 
-  const deleted = await sql`
-    DELETE FROM view_template_active_tabs
-    WHERE resource_type = ${args.resource_type}
-      AND resource_id = ${resourceId}
-      AND organization_id = ${ctx.organizationId}
-      AND tab_name = ${args.tab_name}
-    RETURNING id
-  `;
-
-  if (deleted.length === 0) {
-    throw new Error(`Tab '${args.tab_name}' not found`);
-  }
+  // Phase 3a: delete the active pointer and clear is_current atomically (reads
+  // are now on is_current, so a partial remove would leave a phantom tab).
+  await sql.begin(async (tx) => {
+    const del = await tx`
+      DELETE FROM view_template_active_tabs
+      WHERE resource_type = ${args.resource_type}
+        AND resource_id = ${resourceId}
+        AND organization_id = ${ctx.organizationId}
+        AND tab_name = ${args.tab_name}
+      RETURNING id
+    `;
+    if (del.length === 0) {
+      throw new Error(`Tab '${args.tab_name}' not found`);
+    }
+    await tx`
+      UPDATE view_template_versions SET is_current = false
+      WHERE resource_type = ${args.resource_type} AND resource_id = ${resourceId}
+        AND organization_id = ${ctx.organizationId} AND tab_name = ${args.tab_name}
+        AND is_current = true
+    `;
+  });
 
   emit(ctx.organizationId, {
     keys: ['resolve-path', 'entity-types', 'view-template-history'],


### PR DESCRIPTION
## What

Render-store consolidation **phase 3a** (stacked on #1444). `manage_view_templates`
set/rollback/remove_tab now maintain `is_current` + `tab_order` **directly** on
`view_template_versions` (clear-then-set), alongside the existing `active_tabs`
writes. The phase-1/2 trigger still runs and produces the identical result — both
are kept until **phase 3b drops the trigger**.

This is the transition that lets `active_tabs` + the trigger be retired:
- 3a (this): app maintains `is_current` directly + trigger (belt-and-suspenders).
- 3b: drop the trigger + stop writing `active_tabs`.
- 3c: drop `view_template_active_tabs`.

## Design decision (made here, documented)

A version's `tab_order` is its **last-active display order**; rollback **preserves**
the tab's current display order (matching today's `active_tabs` behavior, whose
`tab_order` is unchanged by rollback). The rollback reads the current order and
applies it to the rolled-back version — correct in both trigger-on (3a) and
trigger-off (3b) states. `remove_tab` is now transactional (delete + `is_current`
clear atomic, since reads are on `is_current`).

## Tests / review

`view-template-is-current.test.ts` adds the load-bearing one: **trigger DISABLED**,
the app alone maintains `is_current` + `tab_order` correctly through
set/rollback/remove — proving phase 3b's trigger-drop is safe. 7/7 + resolve-path
regression green; tsc clean. Reviewed by 2 teammates: app+trigger coexistence
converges, concurrency serializes on the active_tabs unique row + partial unique
index, no blocking findings.

Base = `feat/render-store-phase2` (#1444). Draft for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784697013&installation_id=136316292&pr_number=1445&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1445&signature=ad73bd55667024254594218eea2cf40bf6e80218b9df2ec3c47958fb7ed750f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->