### PR TITLE
feat(view-templates): remove active_tabs writes + advisory lock (render-store phase 3b)

### DIFF
--- a/packages/server/src/__tests__/integration/tools/view-template-is-current.test.ts
+++ b/packages/server/src/__tests__/integration/tools/view-template-is-current.test.ts
@@ -1,10 +1,11 @@
 /**
- * Render-store consolidation, expand phase: view_template_versions.is_current is
- * maintained by a DB trigger on view_template_active_tabs (the app still writes
- * only active_tabs). Asserts is_current stays in lockstep with active_tabs across
- * set / rollback / re-point / remove_tab, and that at most one version per
- * (resource, tab) is current (the partial unique index invariant). Reads still
- * use active_tabs this phase; the flip + table drop are later releases.
+ * Render-store consolidation phase 3b: manage_view_templates maintains
+ * view_template_versions.is_current + tab_order DIRECTLY (the
+ * view_template_active_tabs pointer table and its sync trigger are retired; reads
+ * already use is_current). Asserts is_current is correct on its own across
+ * set / re-set / rollback / re-point / remove_tab, with exactly one current
+ * version per named tab (the partial unique index invariant), and that get()
+ * surfaces named tabs from is_current.
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
@@ -21,25 +22,17 @@ let owner: TestApiClient;
 
 const tmpl = (n: number) => ({ version: 1, root: { type: 'text', content: `v${n}` } });
 
-async function currentIds(tabName: string): Promise<number[]> {
+async function current(tabName: string): Promise<Array<{ id: number; order: number }>> {
   const rows = (await sql`
-    SELECT id FROM view_template_versions
+    SELECT id, tab_order FROM view_template_versions
     WHERE resource_type = 'entity_type' AND resource_id = 'company'
       AND tab_name = ${tabName} AND is_current = true
     ORDER BY id
-  `) as Array<{ id: string }>;
-  return rows.map((r) => Number(r.id));
+  `) as Array<{ id: string; tab_order: number }>;
+  return rows.map((r) => ({ id: Number(r.id), order: Number(r.tab_order) }));
 }
 
-async function activeTabId(tabName: string): Promise<number | null> {
-  const rows = (await sql`
-    SELECT current_version_id FROM view_template_active_tabs
-    WHERE resource_type = 'entity_type' AND resource_id = 'company' AND tab_name = ${tabName}
-  `) as Array<{ current_version_id: string }>;
-  return rows.length ? Number(rows[0].current_version_id) : null;
-}
-
-describe('view_template is_current via trigger (expand phase)', () => {
+describe('view_template is_current direct (phase 3b — active_tabs + trigger retired)', () => {
   beforeAll(async () => {
     await cleanupTestDatabase();
     const org = await createTestOrganization({ name: 'VT Org' });
@@ -49,164 +42,110 @@ describe('view_template is_current via trigger (expand phase)', () => {
     await owner.entity_schema.createType({ slug: 'company', name: 'Company' });
   });
 
-  it('set marks exactly one is_current, matching active_tabs, and advances on re-set', async () => {
+  it('set marks exactly one current and advances on re-set', async () => {
     await owner.view_templates.set({
       resource_type: 'entity_type',
       resource_id: 'company',
       tab_name: 'analytics',
+      tab_order: 2,
       json_template: tmpl(1),
     });
-    const cur1 = await currentIds('analytics');
-    expect(cur1).toHaveLength(1);
-    expect(cur1[0]).toBe(await activeTabId('analytics'));
+    const c1 = await current('analytics');
+    expect(c1).toHaveLength(1);
+    expect(c1[0].order).toBe(2);
 
     await owner.view_templates.set({
       resource_type: 'entity_type',
       resource_id: 'company',
       tab_name: 'analytics',
+      tab_order: 5,
       json_template: tmpl(2),
     });
-    const cur2 = await currentIds('analytics');
-    expect(cur2).toHaveLength(1); // still exactly one current (unique invariant)
-    expect(cur2[0]).toBe(await activeTabId('analytics'));
-    expect(cur2[0]).toBeGreaterThan(cur1[0]); // advanced to the new version
+    const c2 = await current('analytics');
+    expect(c2).toHaveLength(1);
+    expect(c2[0].id).toBeGreaterThan(c1[0].id);
+    expect(c2[0].order).toBe(5);
   });
 
-  it('rollback moves is_current back, in sync with active_tabs', async () => {
+  it('rollback re-points and preserves the tab display order', async () => {
+    // current is v2 @ order 5; rollback to v1 must keep order 5.
     await owner.view_templates.rollback({
       resource_type: 'entity_type',
       resource_id: 'company',
       tab_name: 'analytics',
       version: 1,
     });
-    const cur = await currentIds('analytics');
-    expect(cur).toHaveLength(1);
-    expect(cur[0]).toBe(await activeTabId('analytics'));
+    const c = await current('analytics');
+    expect(c).toHaveLength(1);
+    expect(c[0].order).toBe(5);
   });
 
-  it('get() reads the named tab via is_current (phase-2 read-flip)', async () => {
-    // handleGet now reads named tabs from is_current, not active_tabs.
+  it('re-pointing to the already-current version is a no-op', async () => {
+    const before = await current('analytics');
+    await owner.view_templates.rollback({
+      resource_type: 'entity_type',
+      resource_id: 'company',
+      tab_name: 'analytics',
+      version: 1,
+    });
+    expect(await current('analytics')).toEqual(before);
+  });
+
+  it('get() surfaces the named tab from is_current', async () => {
     const res = (await owner.view_templates.get({
       resource_type: 'entity_type',
       resource_id: 'company',
     })) as { tabs: Array<{ tab_name: string; current_version_id: number }> };
     const analytics = res.tabs.find((t) => t.tab_name === 'analytics');
     expect(analytics).toBeDefined();
-    expect(analytics!.current_version_id).toBe(await activeTabId('analytics'));
+    expect(analytics!.current_version_id).toBe((await current('analytics'))[0].id);
   });
 
-  it('tab_order stays in sync with the active pointer after rollback (phase-2 order)', async () => {
-    // v1 at order 1, v2 at order 9; the active pointer keeps order 9.
-    await owner.view_templates.set({
-      resource_type: 'entity_type',
-      resource_id: 'company',
-      tab_name: 'metrics',
-      tab_order: 1,
-      json_template: tmpl(1),
-    });
-    await owner.view_templates.set({
-      resource_type: 'entity_type',
-      resource_id: 'company',
-      tab_name: 'metrics',
-      tab_order: 9,
-      json_template: tmpl(2),
-    });
-    // Rollback to v1 (historical order 1) — the active pointer's order stays 9,
-    // and the trigger must sync that onto the now-current v1 so the phase-2 read
-    // (ORDER BY view_template_versions.tab_order) matches the legacy order.
-    await owner.view_templates.rollback({
-      resource_type: 'entity_type',
-      resource_id: 'company',
-      tab_name: 'metrics',
-      version: 1,
-    });
-    const active = (await sql`
-      SELECT tab_order FROM view_template_active_tabs
-      WHERE resource_type='entity_type' AND resource_id='company' AND tab_name='metrics'
-    `) as Array<{ tab_order: number }>;
-    const current = (await sql`
-      SELECT tab_order FROM view_template_versions
-      WHERE resource_type='entity_type' AND resource_id='company' AND tab_name='metrics'
-        AND is_current = true
-    `) as Array<{ tab_order: number }>;
-    expect(Number(current[0].tab_order)).toBe(Number(active[0].tab_order));
-    expect(Number(current[0].tab_order)).toBe(9);
+  it('concurrent same-tab sets serialize on the advisory lock (no unique-violation 500)', async () => {
+    // Without the per-tab advisory lock these would race on clear-then-set and one
+    // could 500 on the partial unique index. They must all succeed, leaving exactly
+    // one current version.
+    await Promise.all([
+      owner.view_templates.set({
+        resource_type: 'entity_type',
+        resource_id: 'company',
+        tab_name: 'race',
+        tab_order: 1,
+        json_template: tmpl(1),
+      }),
+      owner.view_templates.set({
+        resource_type: 'entity_type',
+        resource_id: 'company',
+        tab_name: 'race',
+        tab_order: 1,
+        json_template: tmpl(2),
+      }),
+      owner.view_templates.set({
+        resource_type: 'entity_type',
+        resource_id: 'company',
+        tab_name: 'race',
+        tab_order: 1,
+        json_template: tmpl(3),
+      }),
+    ]);
+    expect(await current('race')).toHaveLength(1);
   });
 
-  it('re-pointing to the already-current version is a no-op (still exactly one current)', async () => {
-    // After the rollback above, v1 is current. Roll back to v1 again — the
-    // trigger fires with current_version_id unchanged and must not error or
-    // produce zero/two current rows.
-    const before = await currentIds('analytics');
-    expect(before).toHaveLength(1);
-    await owner.view_templates.rollback({
-      resource_type: 'entity_type',
-      resource_id: 'company',
-      tab_name: 'analytics',
-      version: 1,
-    });
-    const after = await currentIds('analytics');
-    expect(after).toEqual(before); // same single current id, no change
-    expect(after[0]).toBe(await activeTabId('analytics'));
-  });
-
-  it('remove_tab clears is_current (matching the active_tabs delete)', async () => {
+  it('remove_tab clears is_current; rollback on a missing tab errors', async () => {
     await owner.view_templates.removeTab({
       resource_type: 'entity_type',
       resource_id: 'company',
       tab_name: 'analytics',
     });
-    expect(await currentIds('analytics')).toHaveLength(0);
-    expect(await activeTabId('analytics')).toBeNull();
-  });
+    expect(await current('analytics')).toHaveLength(0);
 
-  it('app maintains is_current standalone with the trigger DISABLED (proves phase-3b trigger-drop is safe)', async () => {
-    await sql`ALTER TABLE view_template_active_tabs DISABLE TRIGGER trg_sync_view_template_is_current`;
-    try {
-      await owner.view_templates.set({
+    await expect(
+      owner.view_templates.rollback({
         resource_type: 'entity_type',
         resource_id: 'company',
-        tab_name: 'standalone',
-        tab_order: 3,
-        json_template: tmpl(1),
-      });
-      let cur = await currentIds('standalone');
-      expect(cur).toHaveLength(1);
-      expect(cur[0]).toBe(await activeTabId('standalone'));
-
-      await owner.view_templates.set({
-        resource_type: 'entity_type',
-        resource_id: 'company',
-        tab_name: 'standalone',
-        tab_order: 7,
-        json_template: tmpl(2),
-      });
-      await owner.view_templates.rollback({
-        resource_type: 'entity_type',
-        resource_id: 'company',
-        tab_name: 'standalone',
+        tab_name: 'analytics',
         version: 1,
-      });
-      cur = await currentIds('standalone');
-      expect(cur).toHaveLength(1);
-      expect(cur[0]).toBe(await activeTabId('standalone'));
-      // trigger-OFF rollback: the app reads the outgoing current version's order
-      // (v2 @ 7) and applies it to the rolled-back v1 — preserved display order.
-      const order = (await sql`
-        SELECT tab_order FROM view_template_versions
-        WHERE resource_type='entity_type' AND resource_id='company'
-          AND tab_name='standalone' AND is_current = true
-      `) as Array<{ tab_order: number }>;
-      expect(Number(order[0].tab_order)).toBe(7);
-
-      await owner.view_templates.removeTab({
-        resource_type: 'entity_type',
-        resource_id: 'company',
-        tab_name: 'standalone',
-      });
-      expect(await currentIds('standalone')).toHaveLength(0);
-    } finally {
-      await sql`ALTER TABLE view_template_active_tabs ENABLE TRIGGER trg_sync_view_template_is_current`;
-    }
+      })
+    ).rejects.toThrow(/no active entry/i);
   });
 });

--- a/packages/server/src/tools/admin/manage_view_templates.ts
+++ b/packages/server/src/tools/admin/manage_view_templates.ts
@@ -228,6 +228,11 @@ async function handleSet(
   const tabOrder = args.tab_order ?? 0;
 
   const versionRow = await sql.begin(async (tx: typeof sql) => {
+    // Per-(resource, tab) advisory lock FIRST: serializes concurrent same-tab
+    // writes across both the version-number computation (MAX(version)+1 below) and
+    // the is_current flip, so neither races (the active_tabs unique row used to
+    // provide this serialization before phase 3b).
+    await tx`SELECT pg_advisory_xact_lock(hashtext(${`vt:${args.resource_type}:${resourceId}:${ctx.organizationId}:${tabName ?? ''}`})::bigint)`;
     const inserted = await tx`
       INSERT INTO view_template_versions (
         resource_type, resource_id, organization_id, version, tab_name, tab_order,
@@ -258,20 +263,9 @@ async function handleSet(
         [vid, rowId]
       );
     } else {
-      await tx`
-        INSERT INTO view_template_active_tabs (
-          resource_type, resource_id, organization_id, tab_name, tab_order, current_version_id
-        ) VALUES (
-          ${args.resource_type}, ${resourceId}, ${ctx.organizationId},
-          ${tabName}, ${tabOrder}, ${vid}
-        )
-        ON CONFLICT (resource_type, resource_id, organization_id, tab_name)
-        DO UPDATE SET current_version_id = ${vid}, tab_order = ${tabOrder}
-      `;
-      // Phase 3a: also maintain is_current + tab_order directly on the version
-      // rows (transition off the trigger — kept until phase 3b drops it; both
-      // produce the same result). Clear-then-set keeps the partial unique index
-      // safe. tab_order is the requested display order for a set.
+      // Phase 3b: maintain is_current + tab_order directly (active_tabs writes
+      // removed; the now-dormant trigger is dropped in 3c). Serialized by the
+      // per-tab advisory lock taken at the top of this transaction.
       await tx`
         UPDATE view_template_versions SET is_current = false
         WHERE resource_type = ${args.resource_type} AND resource_id = ${resourceId}
@@ -341,8 +335,8 @@ async function handleGet(
     'created_by'
   );
 
-  // Named tabs — render-store consolidation phase 2: read from is_current on
-  // view_template_versions (trigger-synced with the legacy active_tabs pointer).
+  // Named tabs read from is_current on view_template_versions (maintained directly
+  // by the write handlers; the legacy active_tabs pointer table is retired).
   const tabRows = await sql`
     SELECT
       vtv.tab_name, vtv.tab_order,
@@ -410,33 +404,22 @@ async function handleRollback(
         [versionId, rowId]
       );
     } else {
-      const updated = await tx`
-        UPDATE view_template_active_tabs
-        SET current_version_id = ${versionId}
-        WHERE resource_type = ${args.resource_type}
-          AND resource_id = ${resourceId}
-          AND organization_id = ${ctx.organizationId}
-          AND tab_name = ${tabName}
-        RETURNING id
-      `;
-      if (updated.length === 0) {
-        throw new Error(`Tab '${tabName}' has no active entry to rollback`);
-      }
-      // Phase 3a: maintain is_current + tab_order directly, preserving the tab's
-      // display order across the rollback (order is a tab-level property; rollback
-      // changes only which version is current). The order read below resolves to
-      // the unchanged pointer order in BOTH trigger states: trigger-ON it reads the
-      // just-re-pointed current version (the trigger already stamped the pointer
-      // order onto it); trigger-OFF (phase 3b) it reads the still-current outgoing
-      // version, which carries the same tab-level order. Either way the rolled-back
-      // version inherits the preserved order.
+      // Per-tab advisory lock (serializes with concurrent set/rollback/remove).
+      // Phase 3b: re-point is_current directly (active_tabs writes removed; trigger
+      // dropped in 3c). The current version's tab_order is the tab's display order;
+      // preserve it across the rollback. Its presence is also the "tab exists"
+      // guard (matches the old active_tabs "no active entry to rollback" behavior).
+      await tx`SELECT pg_advisory_xact_lock(hashtext(${`vt:${args.resource_type}:${resourceId}:${ctx.organizationId}:${tabName}`})::bigint)`;
       const curOrderRows = await tx`
         SELECT tab_order FROM view_template_versions
         WHERE resource_type = ${args.resource_type} AND resource_id = ${resourceId}
           AND organization_id = ${ctx.organizationId} AND tab_name = ${tabName}
           AND is_current = true LIMIT 1
       `;
-      const curOrder = curOrderRows.length > 0 ? Number(curOrderRows[0].tab_order) : 0;
+      if (curOrderRows.length === 0) {
+        throw new Error(`Tab '${tabName}' has no active entry to rollback`);
+      }
+      const curOrder = Number(curOrderRows[0].tab_order);
       await tx`
         UPDATE view_template_versions SET is_current = false
         WHERE resource_type = ${args.resource_type} AND resource_id = ${resourceId}
@@ -475,27 +458,21 @@ async function handleRemoveTab(
   await verifyAccess(sql, args, ctx, true);
   const resourceId = rid(args);
 
-  // Phase 3a: delete the active pointer and clear is_current atomically (reads
-  // are now on is_current, so a partial remove would leave a phantom tab).
-  await sql.begin(async (tx) => {
-    const del = await tx`
-      DELETE FROM view_template_active_tabs
-      WHERE resource_type = ${args.resource_type}
-        AND resource_id = ${resourceId}
-        AND organization_id = ${ctx.organizationId}
-        AND tab_name = ${args.tab_name}
-      RETURNING id
-    `;
-    if (del.length === 0) {
-      throw new Error(`Tab '${args.tab_name}' not found`);
-    }
-    await tx`
+  // Per-tab advisory lock + clear is_current directly (active_tabs writes removed;
+  // trigger dropped in 3c). RETURNING drives the not-found guard.
+  const cleared = await sql.begin(async (tx) => {
+    await tx`SELECT pg_advisory_xact_lock(hashtext(${`vt:${args.resource_type}:${resourceId}:${ctx.organizationId}:${args.tab_name}`})::bigint)`;
+    return tx`
       UPDATE view_template_versions SET is_current = false
       WHERE resource_type = ${args.resource_type} AND resource_id = ${resourceId}
         AND organization_id = ${ctx.organizationId} AND tab_name = ${args.tab_name}
         AND is_current = true
+      RETURNING id
     `;
   });
+  if (cleared.length === 0) {
+    throw new Error(`Tab '${args.tab_name}' not found`);
+  }
 
   emit(ctx.organizationId, {
     keys: ['resolve-path', 'entity-types', 'view-template-history'],

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -1155,9 +1155,9 @@ async function fetchTabs(
   resourceId: string,
   organizationId: string
 ): Promise<ViewTemplateTab[]> {
-  // Render-store consolidation phase 2: named tabs read from is_current on
-  // view_template_versions (the trigger keeps it in lockstep with the legacy
-  // view_template_active_tabs pointer across all replicas).
+  // Render-store consolidation: named tabs read from is_current on
+  // view_template_versions (maintained directly by manage_view_templates;
+  // the legacy view_template_active_tabs pointer table is retired).
   const rows = await sql`
     SELECT
       vtv.tab_name,


### PR DESCRIPTION
## What

Render-store consolidation **phase 3b** (stacked on #1445). Removes the
`view_template_active_tabs` writes from `manage_view_templates` set/rollback/
remove_tab — the app now maintains `view_template_versions.is_current` + `tab_order`
**directly** (phase 3a, proven standalone by a trigger-disabled test). Reads were
already on `is_current` (phase 2). **App-only (no migration).**

## Per-tab advisory lock (fixes a pre-existing race)

Dropping the `active_tabs` writes also drops the per-tab serialization its unique
row provided. This adds a `pg_advisory_xact_lock` keyed on (resource, tab) at the
top of each write transaction, serializing both the **version-number computation**
(`MAX(version)+1`) and the `is_current` flip. A new concurrency test surfaced (and
this fixes) a **pre-existing bug**: concurrent same-tab `set`s collided on
`view_template_versions_unique` and 500'd.

## Safety (addressing review)

Review flagged that dropping the trigger in 3b is only safe if 3a is universal
first. So the **trigger drop is deferred to phase 3c** (with the table) — it's left
dormant here (nothing fires it), which keeps 3b safe even if it deploys before 3a
is fully rolled out (the trigger still covers any lingering old-pod `active_tabs`
writes). Known rollout-window limitation: during the 3a→3b overlap, an old 3a pod's
rollback/remove guard (still keyed on `active_tabs`) may briefly reject a tab a new
3b pod created — rare admin op, recoverable.

## Tests / review

`view-template-is-current.test.ts`: is_current correct standalone across
set/re-set/rollback(order preserved)/re-point/**concurrent same-tab sets (no 500)**/
remove + missing-tab error; `get()` reads tabs. 6/6 + resolve-path/validation
regression (12/12) green. Reviewed by 2 teammates + pi (2 Mediums fixed: the
advisory lock + deferring the trigger drop).

Base = `feat/render-store-phase3` (#1445). Draft for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784698053&installation_id=136316292&pr_number=1446&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1446&signature=35232bd602c2f64b0250f52dab69def9c18973fe96e1ef9ca8a58e4591585b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->