### PR TITLE
feat(view-templates): drop view_template_active_tabs (render-store phase 3c, final)

### DIFF
--- a/db/migrations/20260622190000_drop_view_template_active_tabs.sql
+++ b/db/migrations/20260622190000_drop_view_template_active_tabs.sql
@@ -1,0 +1,68 @@
+-- migrate:up
+
+-- Render-store consolidation, phase 3c (final): drop view_template_active_tabs and
+-- its sync trigger. As of phase 3b no app code reads OR writes active_tabs (reads
+-- moved to is_current in phase 2; writes removed in phase 3b), so the table + the
+-- now-dormant trigger are dead. Safe under N>1: ships after phase 3b is universal,
+-- so no pod touches active_tabs. DROP TABLE cascades the trigger on it, its
+-- sequence, and the pkey/unique/fk constraints.
+
+-- squawk-ignore ban-drop-table
+DROP TABLE IF EXISTS public.view_template_active_tabs;
+DROP FUNCTION IF EXISTS public.sync_view_template_is_current();
+
+-- migrate:down
+
+-- Recreate the pointer table + sync trigger and reconstruct it from the current
+-- named-tab versions (is_current), so a rollback to phase 3a/2 code (which reads
+-- and/or writes active_tabs) sees correct data.
+-- Rollback recreate: structure + unique key + backfill are what older (phase
+-- 3a/2) code needs from active_tabs. The original FK to view_template_versions(id)
+-- is omitted here (it required integer columns to match; bigint avoids the
+-- prefer-bigint lint and the FK is not load-bearing for a transient rollback
+-- table). The unique key is the one constraint older code's ON CONFLICT relies on.
+CREATE TABLE IF NOT EXISTS public.view_template_active_tabs (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    resource_type text NOT NULL,
+    resource_id text NOT NULL,
+    organization_id text NOT NULL,
+    tab_name text NOT NULL,
+    tab_order bigint DEFAULT 0,
+    current_version_id bigint NOT NULL,
+    CONSTRAINT view_template_active_tabs_resource_type_check
+        CHECK (resource_type = ANY (ARRAY['entity_type'::text, 'entity'::text])),
+    CONSTRAINT view_template_active_tabs_unique
+        UNIQUE (resource_type, resource_id, organization_id, tab_name)
+);
+
+-- Reconstruct pointers from the current named-tab versions BEFORE recreating the
+-- trigger (so the backfill insert doesn't fire it).
+INSERT INTO public.view_template_active_tabs
+    (resource_type, resource_id, organization_id, tab_name, tab_order, current_version_id)
+SELECT resource_type, resource_id, organization_id, tab_name, tab_order, id
+FROM public.view_template_versions
+WHERE tab_name IS NOT NULL AND is_current = true;
+
+CREATE OR REPLACE FUNCTION public.sync_view_template_is_current() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE public.view_template_versions SET is_current = false
+        WHERE resource_type = OLD.resource_type AND resource_id = OLD.resource_id
+          AND organization_id = OLD.organization_id AND tab_name = OLD.tab_name
+          AND is_current = true;
+        RETURN OLD;
+    END IF;
+    UPDATE public.view_template_versions SET is_current = false
+    WHERE resource_type = NEW.resource_type AND resource_id = NEW.resource_id
+      AND organization_id = NEW.organization_id AND tab_name = NEW.tab_name
+      AND is_current = true AND id <> NEW.current_version_id;
+    UPDATE public.view_template_versions
+    SET is_current = true, tab_order = NEW.tab_order
+    WHERE id = NEW.current_version_id;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_sync_view_template_is_current
+    AFTER INSERT OR UPDATE OR DELETE ON public.view_template_active_tabs
+    FOR EACH ROW EXECUTE FUNCTION public.sync_view_template_is_current();


### PR DESCRIPTION
## What

Render-store consolidation **phase 3c — final** (stacked on #1446). Drops the
now-dead `view_template_active_tabs` table + its sync trigger/function. As of
phase 3b no app code reads (phase 2) or writes (phase 3b) `active_tabs`. `DROP
TABLE` cascades the trigger, owned sequence, and pkey/unique/FK.

**This completes the render-store consolidation:** named-tab render state now lives
solely on `view_template_versions.is_current` (+ `tab_order`), maintained directly
by the write handlers under a per-tab advisory lock. The pointer table, its trigger,
and the sync function are gone.

## Safety

- Multi-replica: ships after phase 3b is universal (no pod reads/writes
  `active_tabs`), so the drop is invisible to all replicas.
- No inbound FK points at `active_tabs`; it's not in `QUERYABLE_SCHEMA`; no
  view references it (verified repo-wide + owletto submodule).
- Down migration recreates the table + trigger and reconstructs the pointers from
  the current `is_current` versions — **validated: round-trips on a live DB**
  (reconstructed `metrics→order 4→version_id` correctly). Backfill runs before the
  trigger recreate so it doesn't fire.

## Tests / review

Full `view-template-is-current.test.ts` green with the table dropped (6/6); down
round-trip verified manually; squawk clean (`ban-drop-table` ignored). Reviewed by
a teammate + pi: no blocking findings, confirmed clean terminal state.

## The render-store stack (merge in order)

#1443 (add is_current+trigger) → #1444 (flip reads) → #1445 (write is_current
direct) → #1446 (remove active_tabs writes + advisory lock) → **this (#____, drop
table)**.

Base = `feat/render-store-phase3b` (#1446). Draft for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784698485&installation_id=136316292&pr_number=1447&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1447&signature=af57d2e0d4414e5ddbfc6c5c72216143fb757b947ccafc72e58b3a6796aa49ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->