### PR TITLE
feat(watchers): mirror watcher render into view_template_versions (fold phase 1)

### DIFF
--- a/db/migrations/20260622200000_watcher_render_to_view_templates.sql
+++ b/db/migrations/20260622200000_watcher_render_to_view_templates.sql
@@ -1,0 +1,89 @@
+-- migrate:up
+
+-- Watcher-render consolidation phase 1 (expand). Mirror watcher_versions.json_template
+-- (DISPLAY-ONLY — verified the worker never reads it; the poll/complete-window path
+-- ships only prompt + extraction_schema) into the unified view_template_versions
+-- store, so the watcher render lives in ONE place. Keyed by the watcher GROUP:
+-- resource_type='watcher', resource_id = watcher_versions.watcher_id (the group-root
+-- watcher id), organization_id resolved from the root watcher. A DB trigger keeps it
+-- in sync from every replica (the active_tabs lesson: trigger > app dual-write, which
+-- drifts on rolling deploys). Versions with NULL json_template (AutoRenderer watchers)
+-- are skipped. No is_current needed — display reads a SPECIFIC selected version, not a
+-- current-flag. Reads flip in phase 2; the watcher_versions.json_template column drops
+-- in phase 3.
+
+-- Widen the resource_type CHECK to allow 'watcher'. It's a superset, so NOT VALID +
+-- VALIDATE avoids an AccessExclusive scan-lock (all existing rows trivially pass).
+ALTER TABLE public.view_template_versions
+  DROP CONSTRAINT IF EXISTS view_template_versions_resource_type_check;
+-- squawk-ignore prefer-robust-stmts -- CHECK can't be ADD ... IF NOT EXISTS; runs once
+ALTER TABLE public.view_template_versions
+  ADD CONSTRAINT view_template_versions_resource_type_check
+  CHECK (resource_type = ANY (ARRAY['entity_type'::text, 'entity'::text, 'watcher'::text])) NOT VALID;
+ALTER TABLE public.view_template_versions
+  VALIDATE CONSTRAINT view_template_versions_resource_type_check;
+
+CREATE OR REPLACE FUNCTION public.mirror_watcher_render() RETURNS trigger AS $$
+DECLARE
+  v_org text;
+BEGIN
+  -- Re-parenting: on group-root deletion with surviving siblings, the version chain
+  -- is re-pointed to a new root (UPDATE watcher_versions SET watcher_id = new_root,
+  -- entity-management.ts). That changes the mirror KEY (resource_id = watcher_id), so
+  -- drop the stale old-key row; the INSERT below re-creates it under the new root.
+  IF TG_OP = 'UPDATE' AND NEW.watcher_id IS DISTINCT FROM OLD.watcher_id THEN
+    DELETE FROM public.view_template_versions
+    WHERE resource_type = 'watcher' AND resource_id = OLD.watcher_id::text
+      AND tab_name IS NULL AND version = OLD.version;
+  END IF;
+  -- No template: AutoRenderer (born NULL) OR a template cleared by an UPDATE. On an
+  -- UPDATE-to-NULL, drop any stale mirror at this key so reads stay equivalent (old
+  -- pods would read NULL from watcher_versions; the mirror must not keep a stale row).
+  IF NEW.json_template IS NULL THEN
+    IF TG_OP = 'UPDATE' THEN
+      DELETE FROM public.view_template_versions
+      WHERE resource_type = 'watcher' AND resource_id = NEW.watcher_id::text
+        AND tab_name IS NULL AND version = NEW.version;
+    END IF;
+    RETURN NEW;
+  END IF;
+  -- watcher_versions.watcher_id is the group-root watcher id; the org lives on that
+  -- root watcher row. If the root is gone, the render has no home org — skip.
+  SELECT organization_id INTO v_org FROM public.watchers WHERE id = NEW.watcher_id;
+  IF v_org IS NULL THEN RETURN NEW; END IF;
+  INSERT INTO public.view_template_versions
+    (resource_type, resource_id, organization_id, version, tab_name, json_template, created_by)
+  VALUES
+    ('watcher', NEW.watcher_id::text, v_org, NEW.version, NULL, NEW.json_template, NEW.created_by)
+  ON CONFLICT (resource_type, resource_id, organization_id, tab_name, version)
+    DO UPDATE SET json_template = EXCLUDED.json_template;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_mirror_watcher_render
+  AFTER INSERT OR UPDATE OF json_template, watcher_id ON public.watcher_versions
+  FOR EACH ROW EXECUTE FUNCTION public.mirror_watcher_render();
+
+-- Backfill existing watcher renders (org via the group-root watcher).
+INSERT INTO public.view_template_versions
+  (resource_type, resource_id, organization_id, version, tab_name, json_template, created_by)
+SELECT 'watcher', wv.watcher_id::text, w.organization_id, wv.version, NULL, wv.json_template, wv.created_by
+FROM public.watcher_versions wv
+JOIN public.watchers w ON w.id = wv.watcher_id
+WHERE wv.json_template IS NOT NULL
+ON CONFLICT (resource_type, resource_id, organization_id, tab_name, version) DO NOTHING;
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS trg_mirror_watcher_render ON public.watcher_versions;
+DROP FUNCTION IF EXISTS public.mirror_watcher_render();
+DELETE FROM public.view_template_versions WHERE resource_type = 'watcher';
+ALTER TABLE public.view_template_versions
+  DROP CONSTRAINT IF EXISTS view_template_versions_resource_type_check;
+-- squawk-ignore prefer-robust-stmts -- CHECK can't be ADD ... IF NOT EXISTS; runs once
+ALTER TABLE public.view_template_versions
+  ADD CONSTRAINT view_template_versions_resource_type_check
+  CHECK (resource_type = ANY (ARRAY['entity_type'::text, 'entity'::text])) NOT VALID;
+ALTER TABLE public.view_template_versions
+  VALIDATE CONSTRAINT view_template_versions_resource_type_check;

--- a/packages/server/src/__tests__/integration/watchers/watcher-render-mirror.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watcher-render-mirror.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Watcher-render consolidation phase 1: watcher_versions.json_template is mirrored
+ * into the unified view_template_versions store by a DB trigger, keyed by the watcher
+ * GROUP (resource_type='watcher', resource_id=watcher group-root id, org from the root
+ * watcher). Versions with no json_template (AutoRenderer) are skipped. No is_current —
+ * the watcher display reads a specific selected version. Reads flip in phase 2.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { manageWatchers } from '../../../tools/admin/manage_watchers';
+import type { Env } from '../../../index';
+import type { ToolContext } from '../../../tools/registry';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+const sql = getTestDb();
+
+function ownerCtx(workspace: TestWorkspace): ToolContext {
+  return {
+    organizationId: workspace.org.id,
+    userId: workspace.users.owner.id,
+    memberRole: 'owner',
+    agentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    tokenType: 'oauth',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  } as ToolContext;
+}
+
+async function makeWatcher(
+  workspace: TestWorkspace,
+  suffix: string,
+  jsonTemplate: unknown | null
+): Promise<number> {
+  const entity = await createTestEntity({
+    name: `Entity ${suffix}`,
+    organization_id: workspace.org.id,
+    created_by: workspace.users.owner.id,
+  });
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId: workspace.users.owner.id,
+  });
+  const w = (await workspace.owner.watchers.create({
+    entity_id: entity.id,
+    slug: `w-${suffix}`,
+    name: `W ${suffix}`,
+    prompt: 'Summarize {{entities}}.',
+    extraction_schema: {
+      type: 'object',
+      properties: { summary: { type: 'string' } },
+      required: ['summary'],
+    },
+    schedule: '0 9 * * *',
+    agent_id: agent.agentId,
+    ...(jsonTemplate ? { json_template: jsonTemplate } : {}),
+  })) as { watcher_id: string };
+  return Number(w.watcher_id);
+}
+
+async function mirrored(watcherId: number) {
+  return (await sql`
+    SELECT resource_id, organization_id, version, tab_name, json_template
+    FROM view_template_versions
+    WHERE resource_type = 'watcher' AND resource_id = ${String(watcherId)}
+    ORDER BY version
+  `) as Array<{
+    resource_id: string;
+    organization_id: string;
+    version: number;
+    tab_name: string | null;
+    json_template: unknown;
+  }>;
+}
+
+describe('watcher render mirrors into view_template_versions (phase 1)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('mirrors a watcher render, keyed by group id + the root org, tab_name NULL', async () => {
+    const ws = await TestWorkspace.create({ name: 'Mirror Org' });
+    const tmpl = { version: 1, root: { type: 'text', content: 'hello' } };
+    const wid = await makeWatcher(ws, 'tmpl', tmpl);
+
+    const rows = await mirrored(wid);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].resource_id).toBe(String(wid));
+    expect(rows[0].organization_id).toBe(ws.org.id);
+    expect(Number(rows[0].version)).toBe(1);
+    expect(rows[0].tab_name).toBeNull();
+    expect(rows[0].json_template).toEqual(tmpl);
+  });
+
+  it('skips a watcher version with no json_template (AutoRenderer)', async () => {
+    const ws = await TestWorkspace.create({ name: 'NoTmpl Org' });
+    const wid = await makeWatcher(ws, 'notmpl', null);
+    expect(await mirrored(wid)).toHaveLength(0);
+  });
+
+  it('mirrors a new version on create_version (v2)', async () => {
+    const ws = await TestWorkspace.create({ name: 'Versioned Org' });
+    const wid = await makeWatcher(ws, 'ver', { version: 1, root: { type: 'text', content: 'v1' } });
+
+    const v2 = { version: 1, root: { type: 'text', content: 'v2' } };
+    await manageWatchers(
+      {
+        action: 'create_version',
+        watcher_id: String(wid),
+        json_template: v2,
+      } as never,
+      {} as Env,
+      ownerCtx(ws)
+    );
+
+    const rows = await mirrored(wid);
+    expect(rows.map((r) => Number(r.version))).toEqual([1, 2]);
+    expect(rows[1].json_template).toEqual(v2);
+  });
+
+  it('clears the mirror when a version json_template is updated to NULL', async () => {
+    const ws = await TestWorkspace.create({ name: 'ClearTmpl Org' });
+    const wid = await makeWatcher(ws, 'clear', { version: 1, root: { type: 'text', content: 'x' } });
+    expect(await mirrored(wid)).toHaveLength(1);
+    // A templated -> NULL transition must drop the mirror row (not leave it stale),
+    // so a reader off the mirror matches a reader off watcher_versions (now NULL).
+    await sql`UPDATE watcher_versions SET json_template = NULL WHERE watcher_id = ${wid}`;
+    expect(await mirrored(wid)).toHaveLength(0);
+  });
+
+  it('re-keys the mirror when a version chain is re-parented to a new root', async () => {
+    const ws = await TestWorkspace.create({ name: 'Reparent Org' });
+    const wid = await makeWatcher(ws, 'rp', { version: 1, root: { type: 'text', content: 'x' } });
+    expect(await mirrored(wid)).toHaveLength(1);
+
+    // A bare new-root watcher in the same org (no versions of its own), then
+    // re-parent the chain — entity-management does this on group-root deletion
+    // with surviving siblings (UPDATE watcher_versions SET watcher_id = new_root).
+    const agent = await createTestAgent({
+      organizationId: ws.org.id,
+      ownerUserId: ws.users.owner.id,
+    });
+    const newRoot = wid + 7_000_000;
+    await sql`
+      INSERT INTO watchers (id, name, slug, organization_id, agent_id, created_by, watcher_group_id)
+      VALUES (${newRoot}, 'new-root', ${`nr-${newRoot}`}, ${ws.org.id}, ${agent.agentId}, ${ws.users.owner.id}, ${newRoot})
+    `;
+    await sql`UPDATE watcher_versions SET watcher_id = ${newRoot} WHERE watcher_id = ${wid}`;
+
+    expect(await mirrored(wid)).toHaveLength(0); // stale old key cleared
+    const moved = await mirrored(newRoot);
+    expect(moved).toHaveLength(1); // re-keyed under the new root
+    expect(Number(moved[0].version)).toBe(1);
+    expect(moved[0].organization_id).toBe(ws.org.id);
+  });
+});


### PR DESCRIPTION
## What

**Watcher-render consolidation phase 1 (expand)** — first phase of folding
`watcher_versions.json_template` into the unified `view_template_versions` store, so the
watcher render lives in ONE place alongside entity/entity-type renders.

A **DB trigger** mirrors each `watcher_versions` row's `json_template` into
`view_template_versions` (trigger > app dual-write — the active_tabs lesson: app
dual-write drifts on rolling deploys; a trigger syncs from every replica). Additive +
**independent of the render-store stack** (#1443–#1447). Reads flip in phase 2; the
column drops in phase 3.

## Verified before building: `json_template` is DISPLAY-ONLY

The worker never reads it — poll (`poll.ts:489-490`) ships only `prompt` +
`extraction_schema`; complete-window validates only `extraction_schema`; the
agent-worker package has zero references. So this fold needs **no worker-pin change**
(this corrects Spike C, which assumed the worker reads it).

## Keying decision (investigated)

The watcher render keys by the watcher **GROUP**: `resource_type='watcher'`,
`resource_id = watcher_versions.watcher_id` (the group-root watcher id — a watcher is
its own group root, `watcher_group_id = own id` at creation), `organization_id` from
the root watcher. **No `is_current`** — the display reads a *specific* selected version
(`get_watchers` reads `sv.json_template` by the instance's `current_version_id`), not a
current-flag. Simpler than the active_tabs fold. NULL `json_template` (AutoRenderer
watchers) is skipped (target is NOT NULL).

## Tests / safety

`watcher-render-mirror.test.ts` (3/3): mirror keyed by group+org+`tab_name` NULL,
AutoRenderer skip, `create_version` v2 mirror. CHECK widen uses `NOT VALID` + `VALIDATE`
(no scan-lock). squawk clean. Edge cases handled: NULL template skipped, root-watcher
gone → org unresolvable → skip.

Base = `main`. Draft for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784723076&installation_id=136316292&pr_number=1448&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1448&signature=0b44b536e2e8102e8680976d6a6013dadaaa08746115f5c10216d6e0bfc9eaa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->