### PR TITLE
feat(watchers): flip all render readers to view_template_versions (fold phase 2)

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/watcher-render-read.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watcher-render-read.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Watcher-render consolidation phase 2: the display readers (get_watchers,
+ * window-utils windows query, manage_watchers list) read the render from
+ * view_template_versions (the phase-1 mirror) instead of watcher_versions.json_template.
+ * Multi-replica-safe: the mirror trigger keeps both in sync, so old pods (read
+ * watcher_versions) and new pods (read the mirror) return the same render.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+const sql = getTestDb();
+
+async function makeWatcher(
+  workspace: TestWorkspace,
+  suffix: string,
+  jsonTemplate: unknown
+): Promise<number> {
+  const entity = await createTestEntity({
+    name: `Entity ${suffix}`,
+    organization_id: workspace.org.id,
+    created_by: workspace.users.owner.id,
+  });
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId: workspace.users.owner.id,
+  });
+  const w = (await workspace.owner.watchers.create({
+    entity_id: entity.id,
+    slug: `w-${suffix}`,
+    name: `W ${suffix}`,
+    prompt: 'Summarize {{entities}}.',
+    extraction_schema: {
+      type: 'object',
+      properties: { summary: { type: 'string' } },
+      required: ['summary'],
+    },
+    schedule: '0 9 * * *',
+    agent_id: agent.agentId,
+    json_template: jsonTemplate as Record<string, unknown>,
+  })) as { watcher_id: string };
+  return Number(w.watcher_id);
+}
+
+function renderOf(got: unknown): unknown {
+  const g = got as { watcher?: { json_template?: unknown }; json_template?: unknown };
+  return g.watcher?.json_template ?? g.json_template;
+}
+
+describe('watcher render reads from view_template_versions (phase 2)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  // Edit the mirror row to a sentinel (watcher_versions keeps the original) to prove
+  // a reader is reading FROM the mirror, not from watcher_versions.json_template.
+  async function pokeMirror(watcherId: number, value: object) {
+    await sql`
+      UPDATE view_template_versions SET json_template = ${sql.json(value)}
+      WHERE resource_type = 'watcher' AND resource_id = ${String(watcherId)}
+    `;
+  }
+
+  it('get() reads the render from the mirror, not watcher_versions', async () => {
+    const ws = await TestWorkspace.create({ name: 'Read Org' });
+    const tmpl = { version: 1, root: { type: 'text', content: 'rendered' } };
+    const wid = await makeWatcher(ws, 'r', tmpl);
+
+    // Baseline: the flipped get() finds the mirror row by (group, version, org).
+    expect(renderOf(await ws.owner.watchers.get(wid))).toEqual(tmpl);
+
+    // Prove the read is off the MIRROR: poke the mirror to a sentinel (the source
+    // column still holds tmpl). get() must return the sentinel.
+    const sentinel = { version: 1, root: { type: 'text', content: 'from-mirror' } };
+    await pokeMirror(wid, sentinel);
+    expect(renderOf(await ws.owner.watchers.get(wid))).toEqual(sentinel);
+  });
+
+  it('list() reads the current-version render from the mirror', async () => {
+    const ws = await TestWorkspace.create({ name: 'List Org' });
+    const tmpl = { version: 1, root: { type: 'text', content: 'listed' } };
+    const wid = await makeWatcher(ws, 'l', tmpl);
+
+    const sentinel = { version: 1, root: { type: 'text', content: 'list-from-mirror' } };
+    await pokeMirror(wid, sentinel);
+
+    const listed = (await ws.owner.watchers.list({ include_details: true })) as {
+      watchers?: Array<{ watcher_id?: string | number; json_template?: unknown }>;
+    };
+    const arr = Array.isArray(listed) ? listed : (listed.watchers ?? []);
+    const row = arr.find((w) => String(w.watcher_id) === String(wid));
+    expect(row?.json_template).toEqual(sentinel);
+  });
+
+  it('get_version_details reads the render from the mirror', async () => {
+    const ws = await TestWorkspace.create({ name: 'Detail Org' });
+    const tmpl = { version: 1, root: { type: 'text', content: 'detail' } };
+    const wid = await makeWatcher(ws, 'd', tmpl);
+
+    const sentinel = { version: 1, root: { type: 'text', content: 'detail-from-mirror' } };
+    await pokeMirror(wid, sentinel);
+
+    const got = (await ws.owner.watchers.getVersionDetails({
+      watcher_id: String(wid),
+    })) as { json_template?: unknown };
+    expect(got.json_template).toEqual(sentinel);
+  });
+});

--- a/packages/server/src/tools/admin/manage_watchers/list.ts
+++ b/packages/server/src/tools/admin/manage_watchers/list.ts
@@ -91,7 +91,7 @@ export async function handleList(
       cv.prompt,
       cv.extraction_schema,
       cv.classifiers,
-      cv.json_template,
+      cvr.json_template,
       cv.keying_config,
       cv.condensation_prompt,
       cv.condensation_window_count,
@@ -106,6 +106,10 @@ export async function handleList(
     LEFT JOIN entities parent ON e.parent_id = parent.id
     LEFT JOIN entity_types pet ON pet.id = parent.entity_type_id
     LEFT JOIN watcher_versions cv ON i.current_version_id = cv.id
+    LEFT JOIN view_template_versions cvr
+      ON cvr.resource_type = 'watcher' AND cvr.resource_id = cv.watcher_id::text
+     AND cvr.organization_id = i.organization_id AND cvr.version = cv.version
+     AND cvr.tab_name IS NULL
     ${buildLatestWatcherRunJoinSql('i', 'wr')}
   `;
 

--- a/packages/server/src/tools/admin/manage_watchers/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_watchers/version-actions.ts
@@ -348,25 +348,36 @@ export async function handleGetVersionDetails(
   if (args.version !== undefined) {
     rows = await sql`
       SELECT
-        id, version, name, description, prompt,
-        extraction_schema, version_sources, json_template,
-        keying_config, classifiers,
-        condensation_prompt, condensation_window_count,
-        reactions_guidance
-      FROM watcher_versions
-      WHERE watcher_id = ${args.watcher_id} AND version = ${args.version}
+        wv.id, wv.version, wv.name, wv.description, wv.prompt,
+        wv.extraction_schema, wv.version_sources, vtv.json_template,
+        wv.keying_config, wv.classifiers,
+        wv.condensation_prompt, wv.condensation_window_count,
+        wv.reactions_guidance
+      FROM watcher_versions wv
+      -- Watcher-render fold phase 2: render lives in view_template_versions (mirror).
+      LEFT JOIN watchers root ON root.id = wv.watcher_id
+      LEFT JOIN view_template_versions vtv
+        ON vtv.resource_type = 'watcher' AND vtv.resource_id = wv.watcher_id::text
+       AND vtv.organization_id = root.organization_id AND vtv.version = wv.version
+       AND vtv.tab_name IS NULL
+      WHERE wv.watcher_id = ${args.watcher_id} AND wv.version = ${args.version}
       LIMIT 1
     `;
   } else {
     rows = await sql`
       SELECT
         v.id, v.version, v.name, v.description, v.prompt,
-        v.extraction_schema, v.version_sources, v.json_template,
+        v.extraction_schema, v.version_sources, vtv.json_template,
         v.keying_config, v.classifiers,
         v.condensation_prompt, v.condensation_window_count,
         v.reactions_guidance
       FROM watcher_versions v
       JOIN watchers w ON v.id = w.current_version_id
+      -- Watcher-render fold phase 2: render lives in view_template_versions (mirror).
+      LEFT JOIN view_template_versions vtv
+        ON vtv.resource_type = 'watcher' AND vtv.resource_id = v.watcher_id::text
+       AND vtv.organization_id = w.organization_id AND vtv.version = v.version
+       AND vtv.tab_name IS NULL
       WHERE w.id = ${args.watcher_id}
       LIMIT 1
     `;

--- a/packages/server/src/tools/get_watchers.ts
+++ b/packages/server/src/tools/get_watchers.ts
@@ -615,7 +615,10 @@ async function getWatcherImpl(
         sv.extraction_schema as sel_version_extraction_schema,
         sv.version_sources as sel_version_version_sources,
         sv.classifiers as sel_version_classifiers,
-        sv.json_template as sel_version_json_template,
+        -- Watcher-render fold phase 2: the render now lives in view_template_versions
+        -- (mirrored from watcher_versions by trigger), keyed by the watcher group +
+        -- version. NULL when the version has no template (AutoRenderer).
+        svr.json_template as sel_version_json_template,
         -- Latest window end for the unprocessedCount bound
         (SELECT MAX(window_end) FROM watcher_windows WHERE watcher_id = i.id) as latest_window_end,
         -- Entities + parent info for entityInfoForUrl / entitiesForTemplate
@@ -659,6 +662,12 @@ async function getWatcherImpl(
                 LIMIT 1)
            )
        AND sv.watcher_id = i.watcher_group_id
+      LEFT JOIN view_template_versions svr
+        ON svr.resource_type = 'watcher'
+       AND svr.resource_id = sv.watcher_id::text
+       AND svr.organization_id = i.organization_id
+       AND svr.version = sv.version
+       AND svr.tab_name IS NULL
       ${buildLatestWatcherRunJoinSql('i', 'wr')}
       WHERE i.id = $1
     `,

--- a/packages/server/src/utils/window-utils.ts
+++ b/packages/server/src/utils/window-utils.ts
@@ -174,12 +174,24 @@ export function buildWindowsSelectClause(): string {
       iw.execution_time_ms,
       iw.created_at,
       iw.version_id,
-      COALESCE(window_v.json_template, watcher_v.json_template) as json_template,
+      -- Watcher-render fold phase 2: render now lives in view_template_versions
+      -- (mirrored by trigger), keyed by watcher group + version. window_vr = the
+      -- window's snapshotted version render; watcher_vr = the watcher's current
+      -- version render (the original version-vs-version COALESCE, both from the mirror).
+      COALESCE(window_vr.json_template, watcher_vr.json_template) as json_template,
       CAST(COUNT(*) OVER () AS INTEGER) as total_count
     FROM watcher_windows iw
     JOIN watchers i ON iw.watcher_id = i.id
     LEFT JOIN watcher_versions watcher_v ON i.current_version_id = watcher_v.id
     LEFT JOIN watcher_versions window_v ON iw.version_id = window_v.id
+    LEFT JOIN view_template_versions watcher_vr
+      ON watcher_vr.resource_type = 'watcher' AND watcher_vr.resource_id = watcher_v.watcher_id::text
+     AND watcher_vr.organization_id = i.organization_id AND watcher_vr.version = watcher_v.version
+     AND watcher_vr.tab_name IS NULL
+    LEFT JOIN view_template_versions window_vr
+      ON window_vr.resource_type = 'watcher' AND window_vr.resource_id = window_v.watcher_id::text
+     AND window_vr.organization_id = i.organization_id AND window_vr.version = window_v.version
+     AND window_vr.tab_name IS NULL
   `.trim();
 }
 


### PR DESCRIPTION
## What

**Watcher-render consolidation phase 2** (stacked on #1448). Flips ALL watcher render
readers to read `json_template` from `view_template_versions` (the phase-1 mirror)
instead of `watcher_versions.json_template`, keyed by `(watcher group id, version, org)`:
- `get_watchers` main query (`svr`) — selected version render.
- `window-utils` windows query (`window_vr`/`watcher_vr`) — window-vs-current COALESCE.
- `manage_watchers` list (`cvr`) — current version render.
- `manage_watchers` `get_version_details` (`vtv`) — explicit + current branches.

`resolve_path` reads ENTITY renders from `view_template_versions` already — not a
watcher reader, untouched.

## Multi-replica safety

The phase-1 mirror trigger keeps `view_template_versions` in sync with every replica's
`watcher_versions` writes, so during a rolling deploy old pods (read `watcher_versions`)
and new pods (read the mirror) return the same render.

## Review-driven fixes (2 teammates + pi)

- **Phase-1 trigger hardened** (in #1448): a templated→NULL `json_template` UPDATE now
  **deletes** the mirror row instead of leaving it stale — pi caught that the old
  behavior would diverge old/new pods on such a transition. Added a clear-template test.
- **Test proof strengthened**: instead of the (now-incorrect) null-out, each reader test
  pokes a sentinel DIRECTLY into the mirror (`watcher_versions` keeps the original) and
  asserts the reader returns the sentinel — a true proof the read is off the mirror.
- **`get_version_details` included** (teammate + pi flagged it as a 4th reader that must
  flip before phase 3) — both query branches now read the mirror.

## Tests

`watcher-render-read.test.ts` (3/3): get()/list()/get_version_details each read the
mirror. Plus phase-1 `watcher-render-mirror.test.ts` (5/5). 8/8 total. squawk clean.

Only the WRITE path (`create_version` writes `json_template`) + the column drop remain
for phase 3. Base = `feat/watcher-render-fold-p1` (#1448). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784724923&installation_id=136316292&pr_number=1449&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1449&signature=574c2eba0e520f76e32c3fe2f0f81756ac2a8ab96162c9627f1e73a0939b61a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->