### PR TITLE
feat(watchers): dual-write render to view_template_versions (fold phase 3a)

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/watcher-render-write.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watcher-render-write.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Watcher-render consolidation phase 3a: the write path (handleCreate v1 +
+ * create_version) now also writes the render DIRECTLY into view_template_versions
+ * (alongside watcher_versions + the mirror trigger), so the trigger +
+ * watcher_versions.json_template can be retired in phase 3b/4. Validated with the
+ * mirror trigger DISABLED — the app alone must populate view_template_versions.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { manageWatchers } from '../../../tools/admin/manage_watchers';
+import type { Env } from '../../../index';
+import type { ToolContext } from '../../../tools/registry';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+const sql = getTestDb();
+
+function ownerCtx(workspace: TestWorkspace): ToolContext {
+  return {
+    organizationId: workspace.org.id,
+    userId: workspace.users.owner.id,
+    memberRole: 'owner',
+    agentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    tokenType: 'oauth',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  } as ToolContext;
+}
+
+async function makeWatcher(
+  workspace: TestWorkspace,
+  suffix: string,
+  jsonTemplate: unknown
+): Promise<number> {
+  const entity = await createTestEntity({
+    name: `Entity ${suffix}`,
+    organization_id: workspace.org.id,
+    created_by: workspace.users.owner.id,
+  });
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId: workspace.users.owner.id,
+  });
+  const w = (await workspace.owner.watchers.create({
+    entity_id: entity.id,
+    slug: `w-${suffix}`,
+    name: `W ${suffix}`,
+    prompt: 'Summarize {{entities}}.',
+    extraction_schema: {
+      type: 'object',
+      properties: { summary: { type: 'string' } },
+      required: ['summary'],
+    },
+    schedule: '0 9 * * *',
+    agent_id: agent.agentId,
+    json_template: jsonTemplate as Record<string, unknown>,
+  })) as { watcher_id: string };
+  return Number(w.watcher_id);
+}
+
+async function rendered(watcherId: number) {
+  return (await sql`
+    SELECT version, json_template FROM view_template_versions
+    WHERE resource_type = 'watcher' AND resource_id = ${String(watcherId)}
+    ORDER BY version
+  `) as Array<{ version: number; json_template: unknown }>;
+}
+
+describe('watcher render direct write (phase 3a)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('app writes the render to view_template_versions standalone (trigger DISABLED — proves 3b)', async () => {
+    try {
+      await sql`ALTER TABLE watcher_versions DISABLE TRIGGER trg_mirror_watcher_render`;
+      const ws = await TestWorkspace.create({ name: 'Direct Org' });
+      const tmpl = { version: 1, root: { type: 'text', content: 'direct' } };
+      const wid = await makeWatcher(ws, 'direct', tmpl);
+
+      // Trigger off → only the app's writeWatcherRender populated the store (handleCreate).
+      const r1 = await rendered(wid);
+      expect(r1).toHaveLength(1);
+      expect(r1[0].json_template).toEqual(tmpl);
+
+      // create_version also direct-writes its render.
+      const v2 = { version: 1, root: { type: 'text', content: 'direct-v2' } };
+      await manageWatchers(
+        { action: 'create_version', watcher_id: String(wid), json_template: v2 } as never,
+        {} as Env,
+        ownerCtx(ws)
+      );
+      const r2 = await rendered(wid);
+      expect(r2.map((r) => Number(r.version))).toEqual([1, 2]);
+      expect(r2[1].json_template).toEqual(v2);
+    } finally {
+      await sql`ALTER TABLE watcher_versions ENABLE TRIGGER trg_mirror_watcher_render`;
+    }
+  });
+});

--- a/packages/server/src/tools/admin/manage_watchers/crud.ts
+++ b/packages/server/src/tools/admin/manage_watchers/crud.ts
@@ -24,6 +24,7 @@ import {
   assertWatcherVersionConfigValid,
   parseJsonInput,
   toJsonParam,
+  writeWatcherRender,
   toTextArrayParam,
   summarizeResults,
   type WatcherOperationResult,
@@ -210,6 +211,18 @@ export async function handleCreate(
         ${args.reactions_guidance ?? null}, ${'Initial version'}, ${createdBy}, NOW()
       )
     `;
+
+    // Watcher-render fold phase 3a: also write the render directly into the unified
+    // view_template_versions store (transition off the mirror trigger; retired in 3b/4).
+    await writeWatcherRender(tx, {
+      groupId: watcherId,
+      // Non-null here: the watchers INSERT above used organizationId (a NOT NULL column),
+      // so a null would already have thrown before reaching this line.
+      organizationId: organizationId as string,
+      version: 1,
+      jsonTemplate,
+      createdBy,
+    });
 
     // 3. Point watcher to the newly created current version
     await tx`

--- a/packages/server/src/tools/admin/manage_watchers/shared.ts
+++ b/packages/server/src/tools/admin/manage_watchers/shared.ts
@@ -136,6 +136,36 @@ export function toJsonParam(sql: DbClient, value: unknown): unknown {
   return sql.json(value);
 }
 
+/**
+ * Watcher-render fold phase 3a: write the watcher render DIRECTLY into
+ * view_template_versions, keyed by the watcher GROUP + version (same key the mirror
+ * trigger uses). This establishes the app as a direct writer so the mirror trigger +
+ * watcher_versions.json_template can be retired in phase 3b/4. Runs inside the caller's
+ * version-write tx, AFTER the watcher_versions INSERT (idempotent ON CONFLICT — in 3a it
+ * overwrites the row the trigger just wrote with the same value; in 3b the trigger is
+ * gone and this is the sole writer). Skips NULL templates (AutoRenderer).
+ */
+export async function writeWatcherRender(
+  tx: DbClient,
+  params: {
+    groupId: number;
+    organizationId: string;
+    version: number;
+    jsonTemplate: unknown;
+    createdBy: string;
+  }
+): Promise<void> {
+  if (params.jsonTemplate === undefined || params.jsonTemplate === null) return;
+  await tx`
+    INSERT INTO view_template_versions
+      (resource_type, resource_id, organization_id, version, tab_name, json_template, created_by)
+    VALUES ('watcher', ${String(params.groupId)}, ${params.organizationId}, ${params.version},
+            NULL, ${toJsonParam(tx, params.jsonTemplate)}, ${params.createdBy})
+    ON CONFLICT (resource_type, resource_id, organization_id, tab_name, version)
+      DO UPDATE SET json_template = EXCLUDED.json_template
+  `;
+}
+
 export function toTextArrayParam(values: string[]): string {
   const arr = normalizeStringArray(values);
   if (arr.length === 0) return '{}';

--- a/packages/server/src/tools/admin/manage_watchers/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_watchers/version-actions.ts
@@ -15,6 +15,7 @@ import {
   parseJson,
   normalizeStoredJsonField,
   toJsonParam,
+  writeWatcherRender,
 } from './shared';
 
 // ============================================
@@ -157,6 +158,16 @@ export async function handleCreateVersion(
         ${args.change_notes ?? null}, ${createdBy}, NOW()
       )
     `;
+
+    // Watcher-render fold phase 3a: also write the render directly into the unified
+    // view_template_versions store (transition off the mirror trigger; retired in 3b/4).
+    await writeWatcherRender(tx, {
+      groupId,
+      organizationId: ctx.organizationId,
+      version: lockedNextVersion,
+      jsonTemplate,
+      createdBy,
+    });
 
     // Update watcher to new version if set_as_current (default: true).
     // Group-shared fields (current_version_id, version, name) cascade to


### PR DESCRIPTION
## What

**Watcher-render consolidation phase 3a** (stacked on #1449). The write path now writes
the render DIRECTLY into `view_template_versions` (shared `writeWatcherRender` helper),
alongside the existing `watcher_versions` write — establishing the app as a direct
writer so the mirror trigger + `watcher_versions.json_template` can be retired in
phase 3b/4. Called in `crud.ts` handleCreate (v1) and `version-actions` create_version.
The phase-1 mirror trigger still runs (both upsert the same row — idempotent transition).

## Multi-replica safety

Old pods (write `watcher_versions` → trigger) and new pods (direct write + trigger) both
keep `view_template_versions` consistent. Once all pods direct-write, the trigger drop
(3b) is safe — no data change.

## Review (teammate + pi)

Both verified: dual-write is **idempotent and org-consistent** (the app's org always
equals the trigger's root-watcher org — groups can't span orgs, enforced by
`create_from_version` + the access gate), no divergence possible. No blocking findings.
Applied 2 LOW hardening tweaks (DISABLE-trigger inside `try`; documented the non-null
org cast). **Noted for 3b:** the trigger-only paths (`entity-management.ts` re-parent /
templated→NULL clear) must be app-covered or the trigger narrowed before it's dropped.

## Tests

`watcher-render-write.test.ts`: with the mirror trigger DISABLED, the app alone
populates `view_template_versions` for both handleCreate (v1) and create_version (v2) —
proving the 3b precondition. 9/9 watcher-render tests green; squawk N/A (no migration).

Phase 3b drops the trigger + stops the `watcher_versions.json_template` write; phase 4
drops the column. Base = `feat/watcher-render-fold-p2` (#1449). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784725645&installation_id=136316292&pr_number=1450&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1450&signature=733ee6e75833c744f35d39b47b5a5c56a04c2ca33c99ef6df309556292ae6eab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->