### PR TITLE
feat(watchers): drop mirror trigger + stop writing watcher_versions.json_template (fold phase 3b)

### DIFF
--- a/db/migrations/20260622210000_drop_watcher_render_trigger.sql
+++ b/db/migrations/20260622210000_drop_watcher_render_trigger.sql
@@ -1,0 +1,59 @@
+-- migrate:up
+
+-- Watcher-render fold phase 3b: the app now writes the render DIRECTLY into
+-- view_template_versions (phase 3a, proven standalone by a trigger-disabled test) on
+-- every replica, so the mirror trigger is retired. Safe after phase 3a is universal:
+-- 3a pods direct-write (don't rely on the trigger). The watcher_versions.json_template
+-- write is dropped from the app INSERTs + the create_version carry-forward read is
+-- flipped to the store in this same release; the column drops in phase 4.
+
+DROP TRIGGER IF EXISTS trg_mirror_watcher_render ON public.watcher_versions;
+DROP FUNCTION IF EXISTS public.mirror_watcher_render();
+
+-- migrate:down
+
+-- Backfill watcher_versions.json_template from the store for rows created while phase 3b
+-- was active (the app stopped writing the source column). Without this, rolling back to
+-- phase-3a code — which reads/carries-forward the source column — would lose those
+-- renders. Runs before the trigger is recreated so it doesn't fire it.
+UPDATE public.watcher_versions wv
+SET json_template = vtv.json_template
+FROM public.view_template_versions vtv
+WHERE vtv.resource_type = 'watcher' AND vtv.resource_id = wv.watcher_id::text
+  AND vtv.version = wv.version AND vtv.tab_name IS NULL
+  AND wv.json_template IS NULL;
+
+-- Recreate the phase-1 mirror trigger (mirror on INSERT/UPDATE, re-key on watcher_id
+-- change, delete-stale on templated->NULL update).
+CREATE OR REPLACE FUNCTION public.mirror_watcher_render() RETURNS trigger AS $$
+DECLARE
+  v_org text;
+BEGIN
+  IF TG_OP = 'UPDATE' AND NEW.watcher_id IS DISTINCT FROM OLD.watcher_id THEN
+    DELETE FROM public.view_template_versions
+    WHERE resource_type = 'watcher' AND resource_id = OLD.watcher_id::text
+      AND tab_name IS NULL AND version = OLD.version;
+  END IF;
+  IF NEW.json_template IS NULL THEN
+    IF TG_OP = 'UPDATE' THEN
+      DELETE FROM public.view_template_versions
+      WHERE resource_type = 'watcher' AND resource_id = NEW.watcher_id::text
+        AND tab_name IS NULL AND version = NEW.version;
+    END IF;
+    RETURN NEW;
+  END IF;
+  SELECT organization_id INTO v_org FROM public.watchers WHERE id = NEW.watcher_id;
+  IF v_org IS NULL THEN RETURN NEW; END IF;
+  INSERT INTO public.view_template_versions
+    (resource_type, resource_id, organization_id, version, tab_name, json_template, created_by)
+  VALUES
+    ('watcher', NEW.watcher_id::text, v_org, NEW.version, NULL, NEW.json_template, NEW.created_by)
+  ON CONFLICT (resource_type, resource_id, organization_id, tab_name, version)
+    DO UPDATE SET json_template = EXCLUDED.json_template;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_mirror_watcher_render
+  AFTER INSERT OR UPDATE OF json_template, watcher_id ON public.watcher_versions
+  FOR EACH ROW EXECUTE FUNCTION public.mirror_watcher_render();

--- a/packages/server/src/__tests__/integration/watchers/watcher-render-mirror.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watcher-render-mirror.test.ts
@@ -1,9 +1,10 @@
 /**
- * Watcher-render consolidation phase 1: watcher_versions.json_template is mirrored
- * into the unified view_template_versions store by a DB trigger, keyed by the watcher
- * GROUP (resource_type='watcher', resource_id=watcher group-root id, org from the root
- * watcher). Versions with no json_template (AutoRenderer) are skipped. No is_current —
- * the watcher display reads a specific selected version. Reads flip in phase 2.
+ * Watcher render lives in the unified view_template_versions store, keyed by the watcher
+ * GROUP (resource_type='watcher', resource_id=group-root id, org from the root watcher).
+ * As of phase 3b the WRITE path (handleCreate + create_version) populates it directly
+ * (the phase-1 mirror trigger is retired); versions with no template (AutoRenderer) are
+ * skipped. The re-parent re-key now lives in the app (entity deletion) — see the
+ * entity-deletion test below.
  */
 
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -122,39 +123,58 @@ describe('watcher render mirrors into view_template_versions (phase 1)', () => {
     expect(rows[1].json_template).toEqual(v2);
   });
 
-  it('clears the mirror when a version json_template is updated to NULL', async () => {
-    const ws = await TestWorkspace.create({ name: 'ClearTmpl Org' });
-    const wid = await makeWatcher(ws, 'clear', { version: 1, root: { type: 'text', content: 'x' } });
-    expect(await mirrored(wid)).toHaveLength(1);
-    // A templated -> NULL transition must drop the mirror row (not leave it stale),
-    // so a reader off the mirror matches a reader off watcher_versions (now NULL).
-    await sql`UPDATE watcher_versions SET json_template = NULL WHERE watcher_id = ${wid}`;
-    expect(await mirrored(wid)).toHaveLength(0);
-  });
-
-  it('re-keys the mirror when a version chain is re-parented to a new root', async () => {
+  it('re-parenting (group-root entity force-delete) re-keys the render to the surviving sibling', async () => {
     const ws = await TestWorkspace.create({ name: 'Reparent Org' });
-    const wid = await makeWatcher(ws, 'rp', { version: 1, root: { type: 'text', content: 'x' } });
-    expect(await mirrored(wid)).toHaveLength(1);
-
-    // A bare new-root watcher in the same org (no versions of its own), then
-    // re-parent the chain — entity-management does this on group-root deletion
-    // with surviving siblings (UPDATE watcher_versions SET watcher_id = new_root).
+    const entityA = await createTestEntity({
+      name: 'A',
+      organization_id: ws.org.id,
+      created_by: ws.users.owner.id,
+    });
+    const entityB = await createTestEntity({
+      name: 'B',
+      organization_id: ws.org.id,
+      created_by: ws.users.owner.id,
+    });
     const agent = await createTestAgent({
       organizationId: ws.org.id,
       ownerUserId: ws.users.owner.id,
     });
-    const newRoot = wid + 7_000_000;
-    await sql`
-      INSERT INTO watchers (id, name, slug, organization_id, agent_id, created_by, watcher_group_id)
-      VALUES (${newRoot}, 'new-root', ${`nr-${newRoot}`}, ${ws.org.id}, ${agent.agentId}, ${ws.users.owner.id}, ${newRoot})
-    `;
-    await sql`UPDATE watcher_versions SET watcher_id = ${newRoot} WHERE watcher_id = ${wid}`;
+    const tmpl = { version: 1, root: { type: 'text', content: 'rp' } };
+    const root = (await ws.owner.watchers.create({
+      entity_id: entityA.id,
+      slug: 'rp-root',
+      name: 'RP',
+      prompt: 'p',
+      extraction_schema: { type: 'object', properties: { s: { type: 'string' } }, required: ['s'] },
+      schedule: '0 9 * * *',
+      agent_id: agent.agentId,
+      json_template: tmpl,
+    })) as { watcher_id: string };
+    const rootId = Number(root.watcher_id);
 
-    expect(await mirrored(wid)).toHaveLength(0); // stale old key cleared
-    const moved = await mirrored(newRoot);
-    expect(moved).toHaveLength(1); // re-keyed under the new root
-    expect(Number(moved[0].version)).toBe(1);
-    expect(moved[0].organization_id).toBe(ws.org.id);
+    // Assign the version chain to entity B (create_from_version → shares the group).
+    const cur = (await sql`
+      SELECT current_version_id FROM watchers WHERE id = ${rootId}
+    `) as Array<{ current_version_id: number }>;
+    const assign = (await manageWatchers(
+      {
+        action: 'create_from_version',
+        version_id: String(cur[0].current_version_id),
+        entity_ids: [entityB.id],
+      } as never,
+      {} as Env,
+      ownerCtx(ws)
+    )) as { created: Array<{ watcher_id: string }> };
+    const assignId = Number(assign.created[0].watcher_id);
+    expect(await mirrored(rootId)).toHaveLength(1);
+
+    // Force-delete entity A (the root watcher's entity): entity-management re-parents the
+    // shared chain to the surviving B assignment, and the app re-keys the render with it.
+    await ws.owner.entities.delete(entityA.id, { force_delete_tree: true });
+
+    expect(await mirrored(rootId)).toHaveLength(0); // old root key cleared
+    const moved = await mirrored(assignId);
+    expect(moved).toHaveLength(1); // re-keyed to the surviving sibling (new group root)
+    expect(moved[0].json_template).toEqual(tmpl);
   });
 });

--- a/packages/server/src/__tests__/integration/watchers/watcher-render-write.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watcher-render-write.test.ts
@@ -75,30 +75,43 @@ describe('watcher render direct write (phase 3a)', () => {
     await cleanupTestDatabase();
   });
 
-  it('app writes the render to view_template_versions standalone (trigger DISABLED — proves 3b)', async () => {
-    try {
-      await sql`ALTER TABLE watcher_versions DISABLE TRIGGER trg_mirror_watcher_render`;
-      const ws = await TestWorkspace.create({ name: 'Direct Org' });
-      const tmpl = { version: 1, root: { type: 'text', content: 'direct' } };
-      const wid = await makeWatcher(ws, 'direct', tmpl);
+  it('app is the sole writer of the render into view_template_versions (trigger retired)', async () => {
+    // Phase 3b: the mirror trigger is dropped and json_template is no longer written to
+    // watcher_versions, so writeWatcherRender (handleCreate + create_version) is the only
+    // thing that can populate view_template_versions.
+    const ws = await TestWorkspace.create({ name: 'Direct Org' });
+    const tmpl = { version: 1, root: { type: 'text', content: 'direct' } };
+    const wid = await makeWatcher(ws, 'direct', tmpl);
 
-      // Trigger off → only the app's writeWatcherRender populated the store (handleCreate).
-      const r1 = await rendered(wid);
-      expect(r1).toHaveLength(1);
-      expect(r1[0].json_template).toEqual(tmpl);
+    const r1 = await rendered(wid);
+    expect(r1).toHaveLength(1);
+    expect(r1[0].json_template).toEqual(tmpl);
+    // And the column is no longer written on watcher_versions.
+    const src = (await sql`
+      SELECT json_template FROM watcher_versions WHERE watcher_id = ${wid}
+    `) as Array<{ json_template: unknown }>;
+    expect(src[0].json_template).toBeNull();
 
-      // create_version also direct-writes its render.
-      const v2 = { version: 1, root: { type: 'text', content: 'direct-v2' } };
-      await manageWatchers(
-        { action: 'create_version', watcher_id: String(wid), json_template: v2 } as never,
-        {} as Env,
-        ownerCtx(ws)
-      );
-      const r2 = await rendered(wid);
-      expect(r2.map((r) => Number(r.version))).toEqual([1, 2]);
-      expect(r2[1].json_template).toEqual(v2);
-    } finally {
-      await sql`ALTER TABLE watcher_versions ENABLE TRIGGER trg_mirror_watcher_render`;
-    }
+    // create_version direct-writes its render, and carries the prev render forward.
+    const v2 = { version: 1, root: { type: 'text', content: 'direct-v2' } };
+    await manageWatchers(
+      { action: 'create_version', watcher_id: String(wid), json_template: v2 } as never,
+      {} as Env,
+      ownerCtx(ws)
+    );
+    const r2 = await rendered(wid);
+    expect(r2.map((r) => Number(r.version))).toEqual([1, 2]);
+    expect(r2[1].json_template).toEqual(v2);
+
+    // Carry-forward: a create_version with NO json_template inherits the prev render
+    // from view_template_versions (not from watcher_versions, which is now NULL).
+    await manageWatchers(
+      { action: 'create_version', watcher_id: String(wid), prompt: 'changed' } as never,
+      {} as Env,
+      ownerCtx(ws)
+    );
+    const r3 = await rendered(wid);
+    expect(r3.map((r) => Number(r.version))).toEqual([1, 2, 3]);
+    expect(r3[2].json_template).toEqual(v2);
   });
 });

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -482,13 +482,13 @@ export async function ensureDefaultWatcher(params: {
         INSERT INTO watcher_versions (
           id, watcher_id, version, name, description,
           prompt, extraction_schema, version_sources,
-          json_template, keying_config, classifiers,
+          keying_config, classifiers,
           condensation_prompt, condensation_window_count,
           reactions_guidance, change_notes, created_by, created_at
         ) VALUES (
           ${versionId}, ${watcherId}, 1, ${DEFAULT_WATCHER_NAME}, NULL,
           ${DEFAULT_WATCHER_PROMPT}, ${tx.json(extractionSchema)}, ${tx.json(sources)},
-          NULL, NULL, NULL,
+          NULL, NULL,
           NULL, NULL,
           NULL, 'Initial version', ${createdBy}, NOW()
         )

--- a/packages/server/src/tools/admin/manage_watchers/crud.ts
+++ b/packages/server/src/tools/admin/manage_watchers/crud.ts
@@ -200,13 +200,13 @@ export async function handleCreate(
       INSERT INTO watcher_versions (
         id, watcher_id, version, name, description,
         prompt, extraction_schema, version_sources,
-        json_template, keying_config, classifiers,
+        keying_config, classifiers,
         condensation_prompt, condensation_window_count,
         reactions_guidance, change_notes, created_by, created_at
       ) VALUES (
         ${versionId}, ${watcherId}, 1, ${args.name ?? args.slug}, ${args.description ?? null},
         ${args.prompt}, ${toJsonParam(tx, extractionSchema)}, ${toJsonParam(tx, sources)},
-        ${toJsonParam(tx, jsonTemplate)}, ${toJsonParam(tx, keyingConfig)}, ${toJsonParam(tx, classifiers)},
+        ${toJsonParam(tx, keyingConfig)}, ${toJsonParam(tx, classifiers)},
         ${args.condensation_prompt ?? null}, ${args.condensation_window_count ?? null},
         ${args.reactions_guidance ?? null}, ${'Initial version'}, ${createdBy}, NOW()
       )

--- a/packages/server/src/tools/admin/manage_watchers/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_watchers/version-actions.ts
@@ -61,12 +61,20 @@ export async function handleCreateVersion(
   // the caller didn't specify.
   const prevRows = await sql`
     SELECT
-      name, description, prompt, extraction_schema, version_sources,
-      json_template, keying_config, classifiers,
-      reactions_guidance, condensation_prompt, condensation_window_count
-    FROM watcher_versions
-    WHERE watcher_id = ${groupId}
-    ORDER BY version DESC LIMIT 1
+      wv.name, wv.description, wv.prompt, wv.extraction_schema, wv.version_sources,
+      -- Watcher-render fold phase 3b: the render lives in view_template_versions; read
+      -- the prev version's render from there so the carry-forward survives the column
+      -- no longer being written to watcher_versions.
+      vtv.json_template,
+      wv.keying_config, wv.classifiers,
+      wv.reactions_guidance, wv.condensation_prompt, wv.condensation_window_count
+    FROM watcher_versions wv
+    LEFT JOIN view_template_versions vtv
+      ON vtv.resource_type = 'watcher' AND vtv.resource_id = wv.watcher_id::text
+     AND vtv.organization_id = ${ctx.organizationId} AND vtv.version = wv.version
+     AND vtv.tab_name IS NULL
+    WHERE wv.watcher_id = ${groupId}
+    ORDER BY wv.version DESC LIMIT 1
   `;
   if (prevRows.length === 0) {
     throw new Error(
@@ -143,7 +151,7 @@ export async function handleCreateVersion(
       INSERT INTO watcher_versions (
         id, watcher_id, version, name, description,
         prompt, extraction_schema, version_sources,
-        json_template, keying_config, classifiers,
+        keying_config, classifiers,
         condensation_prompt, condensation_window_count,
         reactions_guidance, change_notes, created_by, created_at
       ) VALUES (
@@ -151,7 +159,7 @@ export async function handleCreateVersion(
         ${args.name ?? (prev.name as string) ?? 'Watcher'},
         ${args.description !== undefined ? (args.description ?? null) : ((prev.description as string) ?? null)},
         ${prompt}, ${toJsonParam(tx, extractionSchema)}, NULL,
-        ${toJsonParam(tx, jsonTemplate)}, ${toJsonParam(tx, keyingConfig)}, ${toJsonParam(tx, classifiers)},
+        ${toJsonParam(tx, keyingConfig)}, ${toJsonParam(tx, classifiers)},
         ${args.condensation_prompt ?? (prev.condensation_prompt as string) ?? null},
         ${args.condensation_window_count ?? (prev.condensation_window_count as number) ?? null},
         ${args.reactions_guidance ?? (prev.reactions_guidance as string) ?? null},

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -584,6 +584,48 @@ export async function deleteEntity(
       // of the shared watcher_versions chain to a sibling so the upcoming
       // ON DELETE CASCADE doesn't wipe out the version row that the rest
       // of the group still depends on.
+      //
+      // Serialize against create_version (which takes this same per-group advisory
+      // lock): otherwise a concurrent create_version could insert a watcher_versions row
+      // + its render at old_root AFTER the re-key but BEFORE the chain move, orphaning a
+      // render row at the deleted root. Lock every group root being deleted, in id order
+      // to avoid deadlock. (The retired trigger was implicitly serialized by the move.)
+      await tx`
+        SELECT pg_advisory_xact_lock(hashtext('watcher_create_version'), w.id)
+        FROM watchers w
+        WHERE w.id = w.watcher_group_id
+          AND COALESCE(w.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+        ORDER BY w.id
+      `;
+      // Watcher-render fold phase 3b: the mirror trigger used to re-key the render on
+      // this re-parent; with the trigger retired, do it in the app. Re-key the render
+      // rows (resource_id = group root) BEFORE the watcher_versions move below — the
+      // mapping's NOT EXISTS guard (new_root has no versions) only holds pre-move. No key
+      // conflict: renders are ONLY ever keyed by the group root (resource_id = groupId in
+      // writeWatcherRender), and new_root is a non-root sibling, so it has no render rows.
+      await tx`
+        UPDATE view_template_versions vtv
+        SET resource_id = s.new_root::text
+        FROM (
+          SELECT r.old_root, MIN(s.id) AS new_root
+          FROM (
+            SELECT w.id AS old_root
+            FROM watchers w
+            WHERE w.id = w.watcher_group_id
+              AND COALESCE(w.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+          ) r
+          JOIN watchers s
+            ON s.watcher_group_id = r.old_root
+           AND s.id <> r.old_root
+           AND NOT (COALESCE(s.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[])
+           AND NOT EXISTS (
+             SELECT 1 FROM watcher_versions vv WHERE vv.watcher_id = s.id
+           )
+          GROUP BY r.old_root
+        ) s
+        WHERE vtv.resource_type = 'watcher' AND vtv.resource_id = s.old_root::text
+          AND vtv.tab_name IS NULL
+      `;
       await tx`
         UPDATE watcher_versions wv
         SET watcher_id = s.new_root


### PR DESCRIPTION
## What

**Watcher-render consolidation phase 3b** (stacked on #1450). Retires the phase-1 mirror
trigger — the app writes the render directly to `view_template_versions` (phase 3a, every
replica), so the trigger is redundant.

1. Migration: DROP the trigger + function (down recreates the phase-1 form).
2. `crud` + `create_version`: OMIT `json_template` from the `watcher_versions` INSERT (so
   phase 4 can DROP the column with no INSERT referencing it).
3. `create_version` carry-forward: read the prev render from `view_template_versions` (was
   reading `watcher_versions.json_template`, now never written).
4. `entity-management` re-parent: the trigger re-keyed the render on group-root deletion;
   with the trigger gone the app re-keys `view_template_versions` — same proven mapping as
   the `watcher_versions` re-parent, run BEFORE it so the `NOT EXISTS` guard holds.

## Multi-replica safety

Old 3a pods direct-write `view_template_versions` (don't rely on the trigger), so dropping
it is safe once 3a is universal. Rollout caveat: an old-3a-pod re-parent during the 3b
deploy leaves a render stale (rare: group-root entity deletion w/ surviving siblings in a
few-min window; recoverable).

## Review (teammate)

Verified the re-key SQL **correct on all 6 axes** (ordering, byte-identical mapping,
conflict-freedom, multi-root, org, trigger-equivalence) — no logic bug. Caught a real
MEDIUM: the riskiest path (re-key) shipped untested behind a comment that implied
coverage. **Fixed:** added an entity-deletion e2e test that force-deletes a group root with
a surviving sibling and asserts the render re-keys to the new root; corrected the
misleading code comment (conflict-freedom comes from "renders keyed by group root"); added
self-documenting `tab_name IS NULL`.

## Tests

Full watcher suite green incl. the new re-parent e2e + the existing `group-edit` re-parent
(no regression); the write test proves the column is now NULL + carry-forward inherits the
prev render from the store. squawk clean. Phase 4 drops the column.

Base = `feat/watcher-render-fold-p3` (#1450). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784726835&installation_id=136316292&pr_number=1451&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1451&signature=fdf40388953bc35c09bffb4ae8475275234da2ec8dd04774281f8b89a65ccc4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->