### PR TITLE
refactor(watchers): remove json_template from watcher_versions QUERYABLE_SCHEMA (fold phase 4a)

### DIFF
--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -188,7 +188,10 @@ export const QUERYABLE_SCHEMA = {
         'prompt',
         'extraction_schema',
         'sources',
-        'json_template',
+        // json_template removed: the watcher render moved to view_template_versions
+        // (watcher-render fold). This allowlist removal (phase 4a) must ship a release
+        // before the DROP COLUMN (4b) — buildScopedQuery emits these columns in query_sql
+        // CTEs, so dropping while still listed would break user data_sources SQL.
         'keying_config',
         'classifiers',
         'condensation_prompt',


### PR DESCRIPTION
## What

**Watcher-render fold phase 4a** (stacked on #1451). Removes `json_template` from the
`watcher_versions` entry in `QUERYABLE_SCHEMA` (`table-schema.ts`). The render moved to
`view_template_versions`, so user `data_sources` SQL should query it there.

## Why a separate phase (two-phase column retirement)

`QUERYABLE_SCHEMA` is **not** validate-only — `buildScopedQuery` emits its columns in
`query_sql` CTEs (`SAFE_COLUMN_DEFS`). So per the established two-phase rule, the allowlist
removal must ship a release **before** the `DROP COLUMN` (phase 4b); dropping while still
listed would make the CTE reference a non-existent column and break user `data_sources` SQL.

## Multi-replica safety

Old pods still list `json_template` (emit it in CTEs — column still exists); new pods don't.
Both fine during the rollout. Once 4a is universal, no pod emits it → phase 4b drops the
column.

App-only, no DB change. tsc + pre-commit clean. Base = `feat/watcher-render-fold-p3b`
(#1451). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784727146&installation_id=136316292&pr_number=1452&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1452&signature=4b6e0a9ab4e11ef5bc5de7967f78d4895e3a778dfae31f98ee229a040dd04e6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->