### PR TITLE
refactor(watchers): drop watcher_versions.json_template column (fold phase 4b, final)

### DIFF
--- a/db/migrations/20260622220000_drop_watcher_versions_json_template.sql
+++ b/db/migrations/20260622220000_drop_watcher_versions_json_template.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+
+-- Watcher-render fold phase 4b (final): drop the now-dead watcher_versions.json_template
+-- column. The render moved to view_template_versions (reads flipped in phase 2, writes in
+-- 3a, mirror trigger retired + INSERTs stopped writing it in 3b). Removed from
+-- QUERYABLE_SCHEMA in phase 4a, so buildScopedQuery no longer emits it in query_sql CTEs.
+-- Safe after 4a is universal: no pod reads, writes, or queries the column.
+
+ALTER TABLE public.watcher_versions DROP COLUMN IF EXISTS json_template;
+
+-- migrate:down
+
+-- Re-add the column (nullable). Backfill from view_template_versions for current renders
+-- so a rollback to pre-4b code that reads watcher_versions.json_template sees data.
+ALTER TABLE public.watcher_versions ADD COLUMN IF NOT EXISTS json_template jsonb;
+UPDATE public.watcher_versions wv
+SET json_template = vtv.json_template
+FROM public.view_template_versions vtv
+WHERE vtv.resource_type = 'watcher' AND vtv.resource_id = wv.watcher_id::text
+  AND vtv.version = wv.version AND vtv.tab_name IS NULL;

--- a/packages/server/src/__tests__/integration/watchers/watcher-render-write.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watcher-render-write.test.ts
@@ -86,11 +86,6 @@ describe('watcher render direct write (phase 3a)', () => {
     const r1 = await rendered(wid);
     expect(r1).toHaveLength(1);
     expect(r1[0].json_template).toEqual(tmpl);
-    // And the column is no longer written on watcher_versions.
-    const src = (await sql`
-      SELECT json_template FROM watcher_versions WHERE watcher_id = ${wid}
-    `) as Array<{ json_template: unknown }>;
-    expect(src[0].json_template).toBeNull();
 
     // create_version direct-writes its render, and carries the prev render forward.
     const v2 = { version: 1, root: { type: 'text', content: 'direct-v2' } };


### PR DESCRIPTION
## What

**Watcher-render fold phase 4b — FINAL.** Drops the now-dead `watcher_versions.json_template`
column. This **completes the watcher render fold**: the render is fully consolidated onto
`view_template_versions`.

The full fold (stacked #1448 → #1453):
- #1448 mirror trigger (expand) → #1449 flip all reads → #1450 write dual-write →
  #1451 drop trigger + stop writing the column → #1452 remove from QUERYABLE_SCHEMA →
  **this: DROP COLUMN**.

## Safety

- Reads flipped (phase 2), writes direct (3a), trigger retired + INSERTs stopped writing
  it (3b), removed from `QUERYABLE_SCHEMA` so `buildScopedQuery` no longer emits it (4a).
  Nothing reads, writes, or queries the column → drop is safe after 4a is universal.
- `down`: re-adds the column + backfills from `view_template_versions` (rollback fidelity).
- No FK / index / view on the column.

## Result

`watcher_versions` now keeps only the pinned **extract bundle** the worker reads (prompt +
extraction_schema + classifiers + keying_config); the render lives in `view_template_versions`
alongside entity/entity-type renders — one render store.

Tested: 75 watcher tests green with the column dropped. squawk clean (ban-drop-column is the
repo's standard exclude). Base = `feat/watcher-render-fold-p4` (#1452). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784727431&installation_id=136316292&pr_number=1453&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1453&signature=b155e52dcec1427dc2f05dd86b3e67f4666505b40d04afa4f6b6519b814b025b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->