### PR TITLE
feat(classifiers): add stable classifier_id to event_classifications (P4 fold phase 1)

### DIFF
--- a/db/migrations/20260622230000_event_classifications_stable_classifier_id.sql
+++ b/db/migrations/20260622230000_event_classifications_stable_classifier_id.sql
@@ -1,0 +1,48 @@
+-- migrate:up
+
+-- Classifier consolidation (P4) phase 1 (expand): add a STABLE classifier_id to
+-- event_classifications. Today the output only carries classifier_version_id (per-version,
+-- churns on every config bump); the stable classifier identity is reachable only by joining
+-- event_classifier_versions. A denormalized classifier_id lets future reads resolve the
+-- stable classifier directly, and is the foundation for repointing the output to a stable
+-- classifier home so labels survive config version churn / the version table being retired.
+--
+-- Additive + low-risk: nothing READS classifier_id yet. A BEFORE-trigger keeps it populated
+-- from every replica's writes (the hot-path classification runtime does DELETE+INSERT here);
+-- the lookup is a single PK hit on event_classifier_versions.
+--
+-- OPERATIONAL COST (per docs/MIGRATIONS.md): this migration is O(1) at deploy — a nullable
+-- column add (metadata-only) + trigger create. NO inline backfill: event_classifications is
+-- events-scaled (prod ~1M+ rows), so a full-table UPDATE in the Helm hook would risk the
+-- statement_timeout / non-zero-exit outage pattern (PR #767). Historic rows stay NULL until
+-- the out-of-band batched backfill (scripts/backfill-classifier-stable-id.sh, ~10k/batch);
+-- nothing reads classifier_id until the staging-gated read phase, so there's no urgency.
+
+-- squawk-ignore prefer-bigint-over-int -- bigint stores the integer classifier id; matches classifier_version_id width
+ALTER TABLE public.event_classifications ADD COLUMN IF NOT EXISTS classifier_id bigint;
+
+CREATE OR REPLACE FUNCTION public.set_event_classification_classifier_id() RETURNS trigger AS $$
+BEGIN
+  IF NEW.classifier_version_id IS NULL THEN
+    NEW.classifier_id := NULL;
+    RETURN NEW;
+  END IF;
+  SELECT ecv.classifier_id INTO NEW.classifier_id
+  FROM public.event_classifier_versions ecv
+  WHERE ecv.id = NEW.classifier_version_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_set_event_classification_classifier_id
+  BEFORE INSERT OR UPDATE OF classifier_version_id ON public.event_classifications
+  FOR EACH ROW EXECUTE FUNCTION public.set_event_classification_classifier_id();
+
+-- Historic rows are backfilled OUT OF BAND (batched) — see the header note + the runbook
+-- scripts/backfill-classifier-stable-id.sh. NOT done inline (events-scaled hot table).
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS trg_set_event_classification_classifier_id ON public.event_classifications;
+DROP FUNCTION IF EXISTS public.set_event_classification_classifier_id();
+ALTER TABLE public.event_classifications DROP COLUMN IF EXISTS classifier_id;

--- a/packages/server/src/__tests__/integration/classifiers/classifier-stable-id.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classifier-stable-id.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Classifier consolidation (P4) phase 1: event_classifications gains a stable classifier_id
+ * (denormalized from the version → classifier mapping). A BEFORE trigger keeps it populated
+ * on every write; a backfill seeds existing rows. Additive — nothing reads it yet; this is
+ * the stable-id foundation for repointing classifier OUTPUT off the per-version id.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestEvent, createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+async function makeClassifier(orgId: string, userId: string, slug: string) {
+  const [c] = (await sql`
+    INSERT INTO event_classifiers (slug, name, attribute_key, created_by, organization_id)
+    VALUES (${slug}, ${slug}, 'attr', ${userId}, ${orgId})
+    RETURNING id
+  `) as Array<{ id: number }>;
+  const [v] = (await sql`
+    INSERT INTO event_classifier_versions (classifier_id, version, attribute_values, created_by)
+    VALUES (${c.id}, 1, '[]'::jsonb, ${userId})
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return { classifierId: Number(c.id), versionId: Number(v.id) };
+}
+
+describe('event_classifications stable classifier_id (P4 phase 1)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('trigger populates classifier_id from the version on insert', async () => {
+    const org = await createTestOrganization({ name: 'Cls Org' });
+    const user = await createTestUser({ email: 'cls@test.com' });
+    const event = await createTestEvent({ content: 'x', organization_id: org.id });
+    const { classifierId, versionId } = await makeClassifier(org.id, user.id, 'c1');
+
+    const [ec] = (await sql`
+      INSERT INTO event_classifications (event_id, classifier_version_id, values, source)
+      VALUES (${event.id}, ${versionId}, ARRAY['v']::text[], 'llm')
+      RETURNING classifier_id
+    `) as Array<{ classifier_id: number }>;
+    expect(Number(ec.classifier_id)).toBe(classifierId);
+  });
+
+  it('backfill populates classifier_id for rows written with the trigger disabled', async () => {
+    const org = await createTestOrganization({ name: 'Cls Org 2' });
+    const user = await createTestUser({ email: 'cls2@test.com' });
+    const event = await createTestEvent({ content: 'y', organization_id: org.id });
+    const { classifierId, versionId } = await makeClassifier(org.id, user.id, 'c2');
+
+    let ecId = 0;
+    try {
+      await sql`ALTER TABLE event_classifications DISABLE TRIGGER trg_set_event_classification_classifier_id`;
+      const [ec] = (await sql`
+        INSERT INTO event_classifications (event_id, classifier_version_id, values, source)
+        VALUES (${event.id}, ${versionId}, ARRAY['v']::text[], 'llm')
+        RETURNING id, classifier_id
+      `) as Array<{ id: number; classifier_id: number | null }>;
+      expect(ec.classifier_id).toBeNull(); // trigger off → unpopulated
+      ecId = Number(ec.id);
+    } finally {
+      await sql`ALTER TABLE event_classifications ENABLE TRIGGER trg_set_event_classification_classifier_id`;
+    }
+
+    // Same backfill as the migration.
+    await sql`
+      UPDATE event_classifications ec
+      SET classifier_id = ecv.classifier_id
+      FROM event_classifier_versions ecv
+      WHERE ecv.id = ec.classifier_version_id AND ec.classifier_id IS NULL
+    `;
+    const [r] = (await sql`
+      SELECT classifier_id FROM event_classifications WHERE id = ${ecId}
+    `) as Array<{ classifier_id: number }>;
+    expect(Number(r.classifier_id)).toBe(classifierId);
+  });
+});

--- a/scripts/backfill-classifier-stable-id.sh
+++ b/scripts/backfill-classifier-stable-id.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Out-of-band batched backfill of event_classifications.classifier_id (classifier fold
+# phase 1). Per docs/MIGRATIONS.md, event_classifications is events-scaled (~1M+ rows in
+# prod), so the stable-id migration (20260622230000) adds the column + trigger ONLY — new
+# rows are populated by the BEFORE trigger; this script backfills the historic rows in
+# ~10k-row batches, each its own transaction with a sleep between, so VACUUM keeps up and no
+# single statement risks the Helm-hook statement_timeout outage.
+#
+# Idempotent + resumable: re-running only touches still-NULL rows. Safe to run anytime; must
+# complete before the read/FK phase (which relies on classifier_id being populated).
+#
+# Usage: DATABASE_URL=postgres://... ./scripts/backfill-classifier-stable-id.sh
+#   BATCH=10000  rows per batch (default 10000)
+#   SLEEP=0.2    seconds between batches (default 0.2)
+
+set -euo pipefail
+
+: "${DATABASE_URL:?set DATABASE_URL}"
+BATCH=${BATCH:-10000}
+SLEEP=${SLEEP:-0.2}
+
+echo "Backfilling event_classifications.classifier_id (batch=${BATCH}, sleep=${SLEEP}s)…"
+total=0
+while :; do
+  # FOR UPDATE SKIP LOCKED so a concurrent live write never blocks the batch (and vice versa);
+  # each psql -c is its own transaction.
+  n=$(psql "$DATABASE_URL" -tA -c "
+    WITH batch AS (
+      SELECT id FROM event_classifications
+      WHERE classifier_id IS NULL AND classifier_version_id IS NOT NULL
+      ORDER BY id
+      LIMIT ${BATCH}
+      FOR UPDATE SKIP LOCKED
+    ), upd AS (
+      UPDATE event_classifications ec
+      SET classifier_id = ecv.classifier_id
+      FROM event_classifier_versions ecv
+      WHERE ec.id IN (SELECT id FROM batch) AND ecv.id = ec.classifier_version_id
+      RETURNING ec.id
+    )
+    SELECT count(*) FROM upd;
+  ")
+  n=${n//[[:space:]]/}
+  total=$((total + n))
+  echo "  batch: ${n} (total ${total})"
+  [ "${n}" -eq 0 ] && break
+  sleep "${SLEEP}"
+done
+echo "Done. Backfilled ${total} rows."


### PR DESCRIPTION
## What

**Classifier consolidation (P4) phase 1 — expand.** Adds a stable `classifier_id` to
`event_classifications` (today it only carries the per-version `classifier_version_id`).
Populated by a BEFORE trigger on every write + an out-of-band batched backfill for historic
rows. Additive — **nothing reads it yet**; this is the stable-id foundation so classifier
OUTPUT survives config version churn / the version tables being retired.

The full P4 fold (flip the hot-path classification reads/writes, then drop
`event_classifiers`/`_versions`) is a **staging-gated sub-project** per the audit — NOT this PR.

## Migration safety (review-driven)

Review (teammate) caught that an inline backfill UPDATE on `event_classifications`
(events-scaled, ~1M+ rows) in the Helm hook is the exact `docs/MIGRATIONS.md` outage pattern
(statement_timeout → dbmate non-zero → schema mismatch, PR #767). **Fixed:** the migration is
now O(1) (nullable column add + trigger create only); historic rows are backfilled by
`scripts/backfill-classifier-stable-id.sh` (~10k/batch, `FOR UPDATE SKIP LOCKED`, sleep
between, idempotent/resumable). New rows are populated by the trigger. Added the required
operational-cost note to the migration header.

## Tests

`classifier-stable-id.test.ts`: trigger populates `classifier_id` on insert; backfill SQL
populates trigger-disabled rows. 2/2 + 8 classifier-suite tests green; squawk clean.
The 3 hot-path writers (`classification-query.ts`, `manage_classifiers.ts`,
`classifier-extraction.ts`) all use explicit column lists → the new column is transparent.

Base = `main`. Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784728572&installation_id=136316292&pr_number=1454&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1454&signature=157d6351c02b3344d335dacf9595ed78bb58ccd35125429c5332a6c039748fd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->