### PR TITLE
feat(windows): add event_edges + membership trigger (windows-as-events P6 phase 1)

### DIFF
--- a/db/migrations/20260622240000_event_edges.sql
+++ b/db/migrations/20260622240000_event_edges.sql
@@ -1,0 +1,85 @@
+-- migrate:up
+
+-- Windows-as-events consolidation (P6) phase 1 (expand). Introduce a relational
+-- event_edges table that will replace watcher_window_events (membership) + the window
+-- hierarchy (parent_window_id / source_window_ids). Phase 1 covers ONLY 'membership' edges
+-- (the watcher_window_events replacement) — the content-search consumers need these. A
+-- trigger populates new edges from every watcher_window_events INSERT; historic rows are
+-- backfilled OUT OF BAND (scripts/backfill-event-edges.sh), never inline (watcher_window_events
+-- is events-scaled ~3-5M rows — an in-hook UPDATE is the docs/MIGRATIONS.md outage pattern).
+--
+-- OPERATIONAL COST: O(1) at deploy — CREATE TABLE (empty) + two indexes on the empty table
+-- (plain CREATE INDEX is instant when empty) + a trigger. No table rewrite, no hot-table scan.
+--
+-- ORG SCOPING (verified — cross-org-leak surface): watcher_window_events has NO
+-- organization_id; the edge's org resolves via window -> watcher_windows.watcher_id ->
+-- watchers.organization_id (the window's owning watcher). If the org can't be resolved
+-- (orphan window/watcher), the edge is SKIPPED rather than guessing — no cross-org leak.
+-- watcher_id_hint = the window's watcher_id, matching the exclude_watcher_id consumer's
+-- `watcher_windows.watcher_id = $N` filter (content-scoring.ts / visibility.ts).
+
+CREATE TABLE IF NOT EXISTS public.event_edges (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  organization_id text NOT NULL,
+  -- parent_event_id currently holds watcher_windows.id (the window). Named forward for
+  -- windows-as-events, where the window becomes an events.id; child_event_id is events.id.
+  parent_event_id bigint NOT NULL,
+  child_event_id bigint NOT NULL,
+  edge_type text NOT NULL,
+  -- watcher_id_hint stores watcher_windows.watcher_id (integer); bigint for lint + future width.
+  watcher_id_hint bigint,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT event_edges_unique UNIQUE (parent_event_id, child_event_id, edge_type)
+);
+
+-- exclude_watcher_id / visibility: NOT EXISTS by (child content event, watcher) — the hot
+-- read-knowledge() filter. Partial on the membership edge type. Plain (non-concurrent) index
+-- is instant here: the table is empty at creation (backfill is out-of-band, post-deploy).
+-- squawk-ignore require-concurrent-index-creation -- empty table at creation
+CREATE INDEX IF NOT EXISTS idx_event_edges_membership_child
+  ON public.event_edges (child_event_id, watcher_id_hint)
+  WHERE edge_type = 'membership';
+-- squawk-ignore require-concurrent-index-creation -- empty table at creation
+CREATE INDEX IF NOT EXISTS idx_event_edges_parent
+  ON public.event_edges (parent_event_id, edge_type);
+
+-- SYNC (not just populate): watcher_window_events rows are also DELETEd — on window-replace
+-- (complete-window.ts) and entity deletion (entity-management.ts), plus the FK cascade from
+-- watcher_windows. The membership edge must track BOTH so event_edges stays an accurate mirror
+-- (required before the phase-2 read flip — a stale edge would wrongly exclude live content).
+CREATE OR REPLACE FUNCTION public.sync_event_edge_membership() RETURNS trigger AS $$
+DECLARE
+  v_watcher_id integer;
+  v_org text;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    DELETE FROM public.event_edges
+    WHERE edge_type = 'membership'
+      AND parent_event_id = OLD.window_id AND child_event_id = OLD.event_id;
+    RETURN OLD;
+  END IF;
+  SELECT ww.watcher_id, w.organization_id INTO v_watcher_id, v_org
+  FROM public.watcher_windows ww
+  JOIN public.watchers w ON w.id = ww.watcher_id
+  WHERE ww.id = NEW.window_id;
+  -- Can't resolve the owning org (orphan) -> skip rather than guess (no cross-org leak).
+  IF v_org IS NULL THEN RETURN NEW; END IF;
+  INSERT INTO public.event_edges
+    (organization_id, parent_event_id, child_event_id, edge_type, watcher_id_hint, created_at)
+  VALUES
+    (v_org, NEW.window_id, NEW.event_id, 'membership', v_watcher_id, COALESCE(NEW.created_at, now()))
+  ON CONFLICT (parent_event_id, child_event_id, edge_type) DO NOTHING;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_sync_event_edge_membership
+  AFTER INSERT OR DELETE ON public.watcher_window_events
+  FOR EACH ROW EXECUTE FUNCTION public.sync_event_edge_membership();
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS trg_sync_event_edge_membership ON public.watcher_window_events;
+DROP FUNCTION IF EXISTS public.sync_event_edge_membership();
+-- squawk-ignore ban-drop-table
+DROP TABLE IF EXISTS public.event_edges;

--- a/packages/server/src/__tests__/integration/watchers/event-edges.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/event-edges.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Windows-as-events (P6) phase 1: a trigger populates event_edges 'membership' edges from
+ * watcher_window_events inserts, resolving org via window -> watcher_windows.watcher_id ->
+ * watchers.organization_id (the window's owning watcher; NOT NULL, FK-backed, so always
+ * resolvable — the defensive org-NULL skip is belt-and-suspenders). watcher_id_hint = the
+ * window's watcher_id, matching the exclude_watcher_id consumer filter. Additive — nothing
+ * reads event_edges yet (reads flip in staging-gated phases 2-4).
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestAgent,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+async function seed(suffix: string, base: number) {
+  const org = await createTestOrganization({ name: `Edge Org ${suffix}` });
+  const user = await createTestUser({ email: `edge-${suffix}@test.com` });
+  const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+  const event = await createTestEvent({ content: `c-${suffix}`, organization_id: org.id });
+  const watcherId = base;
+  await sql`
+    INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+    VALUES (${watcherId}, ${`w-${suffix}`}, ${`w-${suffix}`}, ${user.id}, ${org.id}, ${agent.agentId}, ${watcherId})
+  `;
+  const windowId = base + 1;
+  await sql`
+    INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+    VALUES (${windowId}, ${watcherId}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+  `;
+  return { orgId: org.id, watcherId, windowId, eventId: Number(event.id) };
+}
+
+async function edges(windowId: number) {
+  return (await sql`
+    SELECT organization_id, parent_event_id, child_event_id, edge_type, watcher_id_hint
+    FROM event_edges WHERE parent_event_id = ${windowId}
+  `) as Array<{
+    organization_id: string;
+    parent_event_id: number;
+    child_event_id: number;
+    edge_type: string;
+    watcher_id_hint: number;
+  }>;
+}
+
+describe('event_edges membership trigger (P6 phase 1)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('creates a membership edge with org + watcher_id_hint resolved from the window watcher', async () => {
+    const { orgId, watcherId, windowId, eventId } = await seed('a', 900100);
+    await sql`INSERT INTO watcher_window_events (window_id, event_id) VALUES (${windowId}, ${eventId})`;
+
+    const rows = await edges(windowId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].organization_id).toBe(orgId);
+    expect(Number(rows[0].parent_event_id)).toBe(windowId);
+    expect(Number(rows[0].child_event_id)).toBe(eventId);
+    expect(Number(rows[0].watcher_id_hint)).toBe(watcherId);
+    expect(rows[0].edge_type).toBe('membership');
+  });
+
+  it('is idempotent — a re-linked content event does not duplicate the edge', async () => {
+    const { windowId, eventId } = await seed('b', 900200);
+    await sql`
+      INSERT INTO watcher_window_events (window_id, event_id) VALUES (${windowId}, ${eventId})
+      ON CONFLICT (window_id, event_id) DO NOTHING
+    `;
+    // Re-insert the same link (the completion path uses ON CONFLICT DO NOTHING).
+    await sql`
+      INSERT INTO watcher_window_events (window_id, event_id) VALUES (${windowId}, ${eventId})
+      ON CONFLICT (window_id, event_id) DO NOTHING
+    `;
+    expect(await edges(windowId)).toHaveLength(1);
+  });
+
+  it('removes the membership edge when the content link is deleted (window-replace / entity-delete)', async () => {
+    const { windowId, eventId } = await seed('del', 900400);
+    await sql`INSERT INTO watcher_window_events (window_id, event_id) VALUES (${windowId}, ${eventId})`;
+    expect(await edges(windowId)).toHaveLength(1);
+
+    // complete-window.ts (window replace) + entity-management.ts (entity delete) DELETE
+    // watcher_window_events; the edge must track that so the mirror stays accurate.
+    await sql`DELETE FROM watcher_window_events WHERE window_id = ${windowId} AND event_id = ${eventId}`;
+    expect(await edges(windowId)).toHaveLength(0);
+  });
+
+  it('edge org is the WATCHER org, even when the linked content event is in another org', async () => {
+    // A watcher in org A can legitimately analyze/link an event whose home org is B (via a
+    // shared entity/connection). The edge's org is deliberately the WATCHER's org — read-time
+    // org isolation comes from the outer content-search scope (keyed on the content event's
+    // own org), and the exclude_watcher_id read is keyed on watcher_id_hint, not edge org.
+    // Locking this so a future refactor can't "fix" it into a real leak.
+    const { orgId: orgA, windowId } = await seed('xorg', 900300);
+    const orgB = await createTestOrganization({ name: 'Edge Org B' });
+    const eventB = await createTestEvent({ content: 'cross-org', organization_id: orgB.id });
+    await sql`INSERT INTO watcher_window_events (window_id, event_id) VALUES (${windowId}, ${Number(eventB.id)})`;
+
+    const rows = await edges(windowId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].organization_id).toBe(orgA); // edge org = watcher's org A
+    const [ev] = (await sql`
+      SELECT organization_id FROM events WHERE id = ${Number(eventB.id)}
+    `) as Array<{ organization_id: string }>;
+    expect(ev.organization_id).toBe(orgB.id); // content event keeps its own home org B
+  });
+});

--- a/scripts/backfill-event-edges.sh
+++ b/scripts/backfill-event-edges.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Out-of-band batched backfill of event_edges 'membership' edges from watcher_window_events
+# (windows-as-events P6 phase 1). watcher_window_events is events-scaled (~3-5M rows), so the
+# migration (20260622240000) creates the table + trigger ONLY — new links are populated by the
+# AFTER trigger; this backfills historic links in ~10k-row batches, each its own transaction
+# with a sleep, so no single statement risks the Helm-hook statement_timeout outage.
+#
+# ORG SCOPING (cross-org-leak surface): the edge's org resolves via
+# watcher_window_events.window_id -> watcher_windows.watcher_id -> watchers.organization_id
+# (the window's owning watcher). Rows whose org can't be resolved are skipped (the JOIN omits
+# them), never assigned a guessed org. watcher_id_hint = the window's watcher_id.
+#
+# Idempotent + resumable (ON CONFLICT DO NOTHING). Must complete before the read phase.
+#
+# Usage: DATABASE_URL=postgres://... ./scripts/backfill-event-edges.sh
+#   BATCH=10000  rows per batch    SLEEP=0.5  seconds between batches
+
+set -euo pipefail
+
+: "${DATABASE_URL:?set DATABASE_URL}"
+BATCH=${BATCH:-10000}
+SLEEP=${SLEEP:-0.5}
+
+echo "Backfilling event_edges membership (batch=${BATCH}, sleep=${SLEEP}s)…"
+total=0
+while :; do
+  # The batch INNER-JOINs to resolve org, so rows whose owning watcher/org can't be resolved
+  # are excluded (never selected -> no infinite loop on orphans, just silently skipped — an
+  # orphan window has no valid org, so no edge). Loop terminates once all resolvable
+  # without-an-edge rows are inserted (count 0).
+  n=$(psql "$DATABASE_URL" -tA -c "
+    WITH batch AS (
+      SELECT wwe.window_id, wwe.event_id, wwe.created_at, ww.watcher_id, w.organization_id
+      FROM watcher_window_events wwe
+      JOIN watcher_windows ww ON ww.id = wwe.window_id
+      JOIN watchers w ON w.id = ww.watcher_id
+      WHERE NOT EXISTS (
+        SELECT 1 FROM event_edges ee
+        WHERE ee.parent_event_id = wwe.window_id
+          AND ee.child_event_id = wwe.event_id
+          AND ee.edge_type = 'membership'
+      )
+      ORDER BY wwe.window_id, wwe.event_id
+      LIMIT ${BATCH}
+    ), ins AS (
+      INSERT INTO event_edges
+        (organization_id, parent_event_id, child_event_id, edge_type, watcher_id_hint, created_at)
+      SELECT organization_id, window_id, event_id, 'membership', watcher_id, COALESCE(created_at, now())
+      FROM batch
+      ON CONFLICT (parent_event_id, child_event_id, edge_type) DO NOTHING
+      RETURNING 1
+    )
+    SELECT count(*) FROM ins;
+  ")
+  n=${n//[[:space:]]/}
+  total=$((total + n))
+  echo "  batch: ${n} (total ${total})"
+  [ "${n}" -eq 0 ] && break
+  sleep "${SLEEP}"
+done
+echo "Done. Backfilled ${total} membership edges."


### PR DESCRIPTION
## What

**Windows-as-events (P6) phase 1 — expand.** Introduces a relational `event_edges` table that
will replace `watcher_window_events` (membership) + the window hierarchy. Phase 1 covers
'membership' edges — the watcher_window_events replacement the hot content-search consumers
(`exclude_watcher_id`, runs on every `read_knowledge()`) will read in later phases.

A trigger populates new edges from every `watcher_window_events` INSERT; historic rows
backfill **out-of-band** (`scripts/backfill-event-edges.sh`, batched ~10k) — never inline
(watcher_window_events is events-scaled ~3-5M rows). **Additive — nothing reads `event_edges` yet.**

## Migration safety

O(1) at deploy: CREATE TABLE (empty) + 2 indexes on the empty table + trigger — no rewrite,
no hot-table scan (per `docs/MIGRATIONS.md`). The events-scaled backfill is the out-of-band
batched script (`FOR`-less INNER-JOIN batch → terminates on orphans, idempotent via ON CONFLICT).

## Cross-org-leak surface (verified)

`watcher_window_events` has no `organization_id`; the edge org resolves via
`window → watcher_windows.watcher_id → watchers.organization_id` (FK-backed, NOT NULL → always
resolvable; skip-if-NULL is defensive, never guesses). **Review clarified an important subtlety:**
the edge org is *deliberately* the watcher's org, which can differ from the linked content
event's org (a watcher analyzing another org's content via a shared entity). That's correct —
read-time org isolation comes from the outer content-search scope (keyed on the event's own
org); the `exclude_watcher_id` read is keyed on `watcher_id_hint`, not edge org. A dedicated
cross-org test locks this behavior.

## Tests / review

`event-edges.test.ts` (3/3): edge created with resolved org + `watcher_id_hint`; idempotent;
**cross-org** (watcher org A linking event org B → edge org A, event keeps org B). 69 watcher
tests green (incl. `complete-window`, which fires the trigger). squawk clean. Reviewed by a
teammate (PASS all 7 points, no blocking — FK/NOT-NULL chain proven) + pi (no findings).

Phases 2-4 (flip the hot `exclude_watcher_id`/scoring reads to `event_edges`, then retire
watcher_window_events) are **staging-gated** on read-latency. Base = `main`. Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784729652&installation_id=136316292&pr_number=1455&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1455&signature=5866ae33be2eb23696a27ce3a8cb31a56e3738575d2b950eadf2f26b0836ec4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->