### PR TITLE
feat(windows): flag-gated exclude_watcher_id read from event_edges (P6 phase 2)

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/exclude-watcher-event-edges.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/exclude-watcher-event-edges.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Windows-as-events (P6) phase 2: buildExcludeWatcherClause reads membership from the
+ * event_edges mirror when WATCHER_EXCLUDE_VIA_EVENT_EDGES is set, instead of the
+ * watcher_window_events -> watcher_windows JOIN. This proves the two clauses are EQUIVALENT
+ * (same content excluded) — the flag selects the path, not the result. Flag-gated so the hot
+ * read (every read_knowledge()) can be A/B latency-validated in staging before cutover.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildExcludeWatcherClause } from '../../../utils/content-search/visibility';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestAgent,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+// Returns true if the event is EXCLUDED (filtered out) by the current clause path.
+async function isExcluded(eventId: number, watcherId: number): Promise<boolean> {
+  const clause = buildExcludeWatcherClause(watcherId, 1, 'f');
+  const rows = await sql.unsafe(`SELECT f.id FROM events f WHERE f.id = $2 ${clause.sql}`, [
+    clause.params[0],
+    eventId,
+  ]);
+  return rows.length === 0;
+}
+
+describe('exclude_watcher_id read flip equivalence (P6 phase 2)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+  afterEach(() => {
+    delete process.env.WATCHER_EXCLUDE_VIA_EVENT_EDGES;
+  });
+
+  it('the event_edges clause excludes exactly the same content as the watcher_window_events JOIN', async () => {
+    const org = await createTestOrganization({ name: 'Excl Org' });
+    const user = await createTestUser({ email: 'excl@test.com' });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+    const linked = Number((await createTestEvent({ content: 'linked', organization_id: org.id })).id);
+    const unlinked = Number(
+      (await createTestEvent({ content: 'unlinked', organization_id: org.id })).id
+    );
+    const watcherId = 901000;
+    await sql`
+      INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+      VALUES (${watcherId}, 'w', 'w-excl', ${user.id}, ${org.id}, ${agent.agentId}, ${watcherId})
+    `;
+    const windowId = 901001;
+    await sql`
+      INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+      VALUES (${windowId}, ${watcherId}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+    `;
+    // Linking the content fires the phase-1 trigger → event_edges membership edge.
+    await sql`INSERT INTO watcher_window_events (window_id, event_id) VALUES (${windowId}, ${linked})`;
+
+    // OLD path (flag off): watcher_window_events JOIN.
+    delete process.env.WATCHER_EXCLUDE_VIA_EVENT_EDGES;
+    expect(await isExcluded(linked, watcherId)).toBe(true);
+    expect(await isExcluded(unlinked, watcherId)).toBe(false);
+
+    // NEW path (flag on): event_edges. Same result on both rows.
+    process.env.WATCHER_EXCLUDE_VIA_EVENT_EDGES = '1';
+    expect(await isExcluded(linked, watcherId)).toBe(true);
+    expect(await isExcluded(unlinked, watcherId)).toBe(false);
+
+    // And after the link is removed (window-replace / entity-delete), neither path excludes it
+    // (the DELETE trigger keeps the mirror accurate).
+    await sql`DELETE FROM watcher_window_events WHERE window_id = ${windowId} AND event_id = ${linked}`;
+    expect(await isExcluded(linked, watcherId)).toBe(false);
+    delete process.env.WATCHER_EXCLUDE_VIA_EVENT_EDGES;
+    expect(await isExcluded(linked, watcherId)).toBe(false);
+  });
+
+  it('multi-window (same watcher) and different-watcher cases match under both flag states', async () => {
+    const org = await createTestOrganization({ name: 'Excl Org 2' });
+    const user = await createTestUser({ email: 'excl2@test.com' });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+    const evtMulti = Number((await createTestEvent({ content: 'multi', organization_id: org.id })).id);
+    const evtOther = Number((await createTestEvent({ content: 'other', organization_id: org.id })).id);
+    const N = 902000;
+    const M = 902100;
+    for (const [wid, slug] of [
+      [N, 'n'],
+      [M, 'm'],
+    ] as const) {
+      await sql`
+        INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+        VALUES (${wid}, ${slug}, ${`w-${slug}`}, ${user.id}, ${org.id}, ${agent.agentId}, ${wid})
+      `;
+    }
+    // N: TWO windows (distinct periods — the unique (watcher,start,end) constraint) both link
+    // evtMulti (multi-window same watcher → must still exclude once, not double-count).
+    await sql`
+      INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+      VALUES (${N + 1}, ${N}, 'daily', NOW() - interval '1 day', NOW(), 0, '{}'::jsonb),
+             (${N + 2}, ${N}, 'daily', NOW() - interval '2 day', NOW() - interval '1 day', 0, '{}'::jsonb)
+    `;
+    await sql`INSERT INTO watcher_window_events (window_id, event_id) VALUES (${N + 1}, ${evtMulti}), (${N + 2}, ${evtMulti})`;
+    // M: one window links evtOther (different watcher).
+    await sql`
+      INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+      VALUES (${M + 1}, ${M}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+    `;
+    await sql`INSERT INTO watcher_window_events (window_id, event_id) VALUES (${M + 1}, ${evtOther})`;
+
+    for (const flag of [undefined, '1'] as const) {
+      if (flag) process.env.WATCHER_EXCLUDE_VIA_EVENT_EDGES = flag;
+      else delete process.env.WATCHER_EXCLUDE_VIA_EVENT_EDGES;
+      expect(await isExcluded(evtMulti, N)).toBe(true); // in 2 windows of N → excluded (once)
+      expect(await isExcluded(evtOther, N)).toBe(false); // in M's window, not N's → not excluded by N
+      expect(await isExcluded(evtOther, M)).toBe(true); // in M's window → excluded by M
+    }
+  });
+});

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -8,6 +8,7 @@ import { type DbClient, pgTextArray } from '../../db/client';
 import {
   buildConnectionVisibilityClause,
   buildEntityLinkUnion,
+  excludeWatcherNotExists,
   fetchEntityIdentityScopes,
 } from '../../utils/content-search';
 import logger from '../../utils/logger';
@@ -296,9 +297,8 @@ export async function fetchIncludeSuperseded(opts: {
     paramIndex += 1;
   }
   if (args.exclude_watcher_id !== undefined) {
-    conditions.push(
-      `NOT EXISTS (SELECT 1 FROM watcher_window_events exc_iwe JOIN watcher_windows exc_iw ON exc_iw.id = exc_iwe.window_id WHERE exc_iwe.event_id = e.id AND exc_iw.watcher_id = $${paramIndex})`
-    );
+    // Shared flag-gated clause (P6 phase 2 reads event_edges when enabled).
+    conditions.push(excludeWatcherNotExists('e.id', paramIndex));
     queryParams.push(args.exclude_watcher_id);
     paramIndex += 1;
   }

--- a/packages/server/src/utils/content-scoring.ts
+++ b/packages/server/src/utils/content-scoring.ts
@@ -9,6 +9,7 @@ import {
   buildEntityLinkUnion,
   type EntityIdentityScope,
   entityLinkMatchSql,
+  excludeWatcherNotExists,
   fetchEntityIdentityScopes,
 } from './content-search';
 import {
@@ -178,11 +179,8 @@ async function buildFilterConditionsAndJoins(
   if (filters?.exclude_watcher_id !== undefined) {
     const validatedWatcherId = validateNumericId(filters.exclude_watcher_id, 'exclude_watcher_id');
     params.push(validatedWatcherId);
-    filterConditions.push(`NOT EXISTS (
-      SELECT 1 FROM watcher_window_events exc_iwc
-      JOIN watcher_windows exc_iw ON exc_iw.id = exc_iwc.window_id
-      WHERE exc_iwc.event_id = f.id AND exc_iw.watcher_id = $${paramIndex++}
-    )`);
+    // Shared flag-gated clause (P6 phase 2 reads event_edges when enabled).
+    filterConditions.push(excludeWatcherNotExists('f.id', paramIndex++));
   }
 
   if (filters?.semantic_type) {

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -17,7 +17,11 @@ export {
   STANDARD_IDENTITY_NAMESPACES,
 } from './content-search/entity-link';
 
-export { buildConnectionVisibilityClause, buildOrgScopeWhere } from './content-search/visibility';
+export {
+  buildConnectionVisibilityClause,
+  buildOrgScopeWhere,
+  excludeWatcherNotExists,
+} from './content-search/visibility';
 
 import { getDb } from '../db/client';
 import type { Env } from '../index';

--- a/packages/server/src/utils/content-search/visibility.ts
+++ b/packages/server/src/utils/content-search/visibility.ts
@@ -16,6 +16,43 @@ import { validateNumericId } from '../sql-validation';
  * @param tableAlias - Alias for the content table (default: 'f')
  * @returns `{ sql, params }` — empty strings/arrays when no filter is applied
  */
+/**
+ * The flag-gated `exclude_watcher_id` membership NOT EXISTS, returned WITHOUT a leading `AND`
+ * so it can be pushed into a conditions array OR spliced after `AND`. The single source of
+ * truth for ALL exclude_watcher_id reads (the search/list helper below + the score/superseded
+ * inline paths in content-scoring.ts / get_content/query.ts) so the flag governs every
+ * read_knowledge() path and phase 3 has ONE place to retire the JOIN.
+ *
+ * Windows-as-events (P6) phase 2: read membership from the event_edges mirror — a single-table
+ * NOT EXISTS via the (child_event_id, watcher_id_hint) partial index — instead of the
+ * watcher_window_events -> watcher_windows JOIN. event_edges is an accurate mirror (the trigger
+ * syncs INSERT+DELETE; historic rows are backfilled), so the two are equivalent. FLAG-GATED for
+ * a staged, A/B-validated cutover of this hot read. DEPLOY GATE: run
+ * scripts/backfill-event-edges.sh to completion BEFORE setting the flag, else event_edges
+ * misses historic links and wrongly includes them.
+ *
+ * @param contentIdExpr - SQL expression for the content event id (e.g. `f.id`, `e.id`)
+ * @param paramN - the 1-based `$N` index already bound to the (validated) watcher id
+ */
+export function excludeWatcherNotExists(contentIdExpr: string, paramN: number): string {
+  if (
+    process.env.WATCHER_EXCLUDE_VIA_EVENT_EDGES === '1' ||
+    process.env.WATCHER_EXCLUDE_VIA_EVENT_EDGES === 'true'
+  ) {
+    return `NOT EXISTS (
+    SELECT 1 FROM event_edges exc_ee
+    WHERE exc_ee.child_event_id = ${contentIdExpr}
+      AND exc_ee.watcher_id_hint = $${paramN}::bigint
+      AND exc_ee.edge_type = 'membership'
+  )`;
+  }
+  return `NOT EXISTS (
+    SELECT 1 FROM watcher_window_events exc_iwe
+    JOIN watcher_windows exc_iw ON exc_iw.id = exc_iwe.window_id
+    WHERE exc_iwe.event_id = ${contentIdExpr} AND exc_iw.watcher_id = $${paramN}::bigint
+  )`;
+}
+
 export function buildExcludeWatcherClause(
   excludeWatcherId: number | undefined,
   baseParamIndex: number,
@@ -24,11 +61,7 @@ export function buildExcludeWatcherClause(
   if (excludeWatcherId === undefined) return { sql: '', params: [] };
   const validated = validateNumericId(excludeWatcherId, 'exclude_watcher_id');
   return {
-    sql: ` AND NOT EXISTS (
-    SELECT 1 FROM watcher_window_events exc_iwe
-    JOIN watcher_windows exc_iw ON exc_iw.id = exc_iwe.window_id
-    WHERE exc_iwe.event_id = ${tableAlias}.id AND exc_iw.watcher_id = $${baseParamIndex}::bigint
-  )`,
+    sql: ` AND ${excludeWatcherNotExists(`${tableAlias}.id`, baseParamIndex)}`,
     params: [validated],
   };
 }


### PR DESCRIPTION
## What

**Windows-as-events (P6) phase 2** (stacked on #1455). Flag-gates ALL `exclude_watcher_id`
membership reads to read from the `event_edges` mirror (single-table NOT EXISTS via the
`(child_event_id, watcher_id_hint)` partial index) instead of the
`watcher_window_events → watcher_windows` JOIN. `event_edges` is an accurate mirror (phase-1
trigger syncs INSERT+DELETE + the backfill), so the two clauses are **equivalent** — proven.

Extracted the flag-gated clause into one shared `excludeWatcherNotExists` helper and routed
**all three** consumers through it (review caught that two — the score path `content-scoring.ts`
and the superseded path `get_content/query.ts` — were inline copies the flag missed). So the
flag now governs every `read_knowledge()` path, and phase 3 has ONE place to retire the JOIN.

## Flag + deploy gate

`WATCHER_EXCLUDE_VIA_EVENT_EDGES` — default OFF = current JOIN (zero behavior change).
Multi-replica-safe at any flag value (both clauses agree since `event_edges` mirrors the
source). **DEPLOY GATE:** run `scripts/backfill-event-edges.sh` to completion BEFORE enabling
the flag, else `event_edges` misses historic links → wrongly includes them. The flag enables a
staged, A/B-latency-validated cutover (this read runs on every `read_knowledge()`).

## Tests / review

`exclude-watcher-event-edges.test.ts`: equivalence under both flag states for single-window,
**multi-window same watcher** (excluded once), **different watcher** (not over-excluded), and
**post-DELETE** (mirror accurate). 6/6 + 28 all-tools-e2e + 17 content-search green (flag off =
unchanged). Reviewed by a teammate (equivalence HIGH on all 8 cases; caught the incomplete
cutover — fixed) + pi. squawk N/A (no migration).

Phases 3-4 retire the JOIN path + `watcher_window_events` once the flag is universal.
Base = `feat/event-edges-p1` (#1455). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784730750&installation_id=136316292&pr_number=1456&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1456&signature=eab2f56d57955efd9c39ba1b5c48553b5d824ac2ac0c5876b01795901bd8b66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->