### PR TITLE
fix(dev): drop per-branch dev DB on task-clean + clean-merged sweep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,13 @@ task-clean:
 	@: $${NAME?Usage: make task-clean NAME=<name> [FORCE=1]}
 	@./scripts/task-clean.sh "$(NAME)" $$( [ "$(FORCE)" = "1" ] && echo --force )
 
+# Reap task worktrees whose PR is already merged (worktree + branches + dev DB
+# + Lobu context). Dry-run by default — prints what it would remove; pass
+# APPLY=1 to actually run task-clean on each. Squash-merge-safe: gates on the
+# GitHub PR state, not git ancestry.
+clean-merged:
+	@./scripts/clean-merged.sh $$( [ "$(APPLY)" = "1" ] && echo --apply )
+
 # Stable Owletto Chrome harness for e2e: one persistent profile, paired once,
 # reused from any agent session (mirrors the installed Mac app). Loads the
 # extension from the current worktree; RESTART=1 forces a fresh launch.

--- a/scripts/clean-merged.sh
+++ b/scripts/clean-merged.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# clean-merged.sh — reap task worktrees whose PR is already merged.
+#
+# Usage:
+#   make clean-merged            # dry-run: print what WOULD be reaped
+#   make clean-merged APPLY=1    # actually run task-clean on each
+#
+# Dry-run by default. A worktree is reaped only when ALL hold:
+#   - it lives under .claude/worktrees/<name>  (a managed task worktree)
+#   - its branch is exactly feat/<name>        (the task-setup convention)
+#   - its PR is MERGED on GitHub               (the real gate — squash-safe,
+#     unlike `git merge-base --is-ancestor`, which a squash merge defeats)
+#   - the working tree is clean                (no uncommitted local work)
+# Anything else is KEPT with a printed reason, so this never surprises you.
+
+set -euo pipefail
+
+apply=0
+[[ "${1:-}" == "--apply" ]] && apply=1
+
+command -v gh >/dev/null 2>&1 || { echo "error: gh CLI required" >&2; exit 1; }
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(dirname "$(git -C "$script_dir" rev-parse --path-format=absolute --git-common-dir)")"
+wt_root="$repo/.claude/worktrees"
+
+echo "→ fetching merged PRs from GitHub…"
+merged="$(gh pr list --state merged --limit 1000 --json headRefName -q '.[].headRefName' 2>/dev/null || true)"
+[[ -n "$merged" ]] || { echo "error: could not list merged PRs (gh auth / network?)" >&2; exit 1; }
+is_merged() { grep -qxF "$1" <<<"$merged"; }
+
+reap=()
+
+# Parse `git worktree list --porcelain` into "<path>\t<branch>" for attached
+# worktrees (detached HEADs print no branch line and are skipped).
+while IFS=$'\t' read -r path ref; do
+  branch="${ref#refs/heads/}"
+  [[ "$branch" == "main" ]] && continue
+  name="$(basename "$path")"
+  # Only manage worktrees that live directly under .claude/worktrees/<name>.
+  [[ "$path" == "$wt_root/$name" ]] || continue
+
+  if [[ "$branch" != "feat/$name" ]]; then
+    printf "  keep   %-32s non-standard branch (%s)\n" "$name" "$branch"
+    continue
+  fi
+  if ! is_merged "$branch"; then
+    printf "  keep   %-32s PR not merged (open/none)\n" "$name"
+    continue
+  fi
+  if [[ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]]; then
+    printf "  keep   %-32s merged but has uncommitted changes\n" "$name"
+    continue
+  fi
+  printf "  REAP   %-32s merged + clean\n" "$name"
+  reap+=("$name")
+done < <(git -C "$repo" worktree list --porcelain | awk '
+  /^worktree /{wt=$2}
+  /^branch /{print wt"\t"$2}
+')
+
+echo ""
+if [[ ${#reap[@]} -eq 0 ]]; then
+  echo "Nothing to reap."
+  exit 0
+fi
+
+if [[ $apply -eq 0 ]]; then
+  echo "${#reap[@]} worktree(s) would be reaped. Re-run with APPLY=1 to remove them."
+  exit 0
+fi
+
+echo "Reaping ${#reap[@]} worktree(s)…"
+for name in "${reap[@]}"; do
+  echo "── $name ──"
+  # --force is safe here: the merged-PR gate already proved the work is landed,
+  # and we only reach this for a clean working tree.
+  "$script_dir/task-clean.sh" "$name" --force || echo "warning: task-clean failed for '$name'" >&2
+done
+echo "✓ done"

--- a/scripts/clean-merged.sh
+++ b/scripts/clean-merged.sh
@@ -55,7 +55,7 @@ while IFS=$'\t' read -r path ref; do
   branch="${ref#refs/heads/}"
   name="$(basename "$path")"
   [[ "$path" == "$wt_root/$name" ]] || continue   # managed worktrees only
-  [[ "$branch" == "main" ]] && continue
+  [[ "$branch" == "main" || "$branch" == "master" ]] && continue
 
   tag=""; is_active "$path" && { tag=" [ACTIVE]"; }
 

--- a/scripts/clean-merged.sh
+++ b/scripts/clean-merged.sh
@@ -7,11 +7,16 @@
 #
 # Dry-run by default. A worktree is reaped only when ALL hold:
 #   - it lives under .claude/worktrees/<name>  (a managed task worktree)
-#   - its branch is exactly feat/<name>        (the task-setup convention)
-#   - its PR is MERGED on GitHub               (the real gate — squash-safe,
-#     unlike `git merge-base --is-ancestor`, which a squash merge defeats)
-#   - the working tree is clean                (no uncommitted local work)
-# Anything else is KEPT with a printed reason, so this never surprises you.
+#   - its branch's PR is MERGED on GitHub      (squash-safe: gates on PR state,
+#     not `git merge-base --is-ancestor`, which a squash merge defeats)
+#   - the local branch tip is CONTAINED in the merged PR head — i.e. there are
+#     NO local commits beyond what was merged. This is the load-bearing guard:
+#     a branch can be merged AND carry unpushed local work on top, and reaping
+#     that would destroy the work. (Earlier a naive "working tree clean" check
+#     did exactly that to a branch with an unpushed fix.)
+#   - the working tree is clean                (no uncommitted local changes)
+#   - the worktree is NOT active               (no running dev server / bound port)
+# Anything else is KEPT with a printed reason. Active worktrees are tagged.
 
 set -euo pipefail
 
@@ -25,41 +30,65 @@ repo="$(dirname "$(git -C "$script_dir" rev-parse --path-format=absolute --git-c
 wt_root="$repo/.claude/worktrees"
 
 echo "→ fetching merged PRs from GitHub…"
-merged="$(gh pr list --state merged --limit 1000 --json headRefName -q '.[].headRefName' 2>/dev/null || true)"
-[[ -n "$merged" ]] || { echo "error: could not list merged PRs (gh auth / network?)" >&2; exit 1; }
-is_merged() { grep -qxF "$1" <<<"$merged"; }
+# Map of head branch → the commit SHA that was on the PR head when it merged.
+merged_map="$(gh pr list --state merged --limit 1000 --json headRefName,headRefOid \
+  -q '.[] | .headRefName + "\t" + .headRefOid' 2>/dev/null || true)"
+[[ -n "$merged_map" ]] || { echo "error: could not list merged PRs (gh auth / network?)" >&2; exit 1; }
+# First match wins — gh lists most-recent first, so a reused branch name resolves
+# to its latest merged PR head.
+merged_head_oid() { awk -F'\t' -v b="$1" '$1==b{print $2; exit}' <<<"$merged_map"; }
+
+# A worktree is "active" if a process is running from inside it, or its dev-server
+# port (from .env.local) is being listened on.
+is_active() {
+  local path="$1" port
+  pgrep -f "$path" >/dev/null 2>&1 && return 0
+  port="$(awk -F= '/^PORT=/{print $2; exit}' "$path/.env.local" 2>/dev/null | tr -d '[:space:]')"
+  [[ "$port" =~ ^[0-9]+$ ]] && lsof -nP -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1 && return 0
+  return 1
+}
 
 reap=()
+active_kept=0
 
-# Parse `git worktree list --porcelain` into "<path>\t<branch>" for attached
-# worktrees (detached HEADs print no branch line and are skipped).
 while IFS=$'\t' read -r path ref; do
   branch="${ref#refs/heads/}"
-  [[ "$branch" == "main" ]] && continue
   name="$(basename "$path")"
-  # Only manage worktrees that live directly under .claude/worktrees/<name>.
-  [[ "$path" == "$wt_root/$name" ]] || continue
+  [[ "$path" == "$wt_root/$name" ]] || continue   # managed worktrees only
+  [[ "$branch" == "main" ]] && continue
 
-  if [[ "$branch" != "feat/$name" ]]; then
-    printf "  keep   %-32s non-standard branch (%s)\n" "$name" "$branch"
-    continue
+  tag=""; is_active "$path" && { tag=" [ACTIVE]"; }
+
+  if [[ -z "$branch" || "$ref" != refs/heads/* ]]; then
+    printf "  keep   %-32s detached HEAD%s\n" "$name" "$tag"; continue
   fi
-  if ! is_merged "$branch"; then
-    printf "  keep   %-32s PR not merged (open/none)\n" "$name"
-    continue
+  head_oid="$(merged_head_oid "$branch")"
+  if [[ -z "$head_oid" ]]; then
+    printf "  keep   %-32s PR not merged (open/none)%s\n" "$name" "$tag"; continue
+  fi
+  local_tip="$(git -C "$path" rev-parse HEAD 2>/dev/null || echo none)"
+  if ! git -C "$path" merge-base --is-ancestor "$local_tip" "$head_oid" 2>/dev/null; then
+    printf "  keep   %-32s has local commits beyond merged PR (unpushed)%s\n" "$name" "$tag"; continue
   fi
   if [[ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]]; then
-    printf "  keep   %-32s merged but has uncommitted changes\n" "$name"
-    continue
+    printf "  keep   %-32s merged but has uncommitted changes%s\n" "$name" "$tag"; continue
   fi
-  printf "  REAP   %-32s merged + clean\n" "$name"
+  if [[ -n "$tag" ]]; then
+    printf "  keep   %-32s merged + clean but ACTIVE (server running)\n" "$name"
+    active_kept=$((active_kept + 1)); continue
+  fi
+  printf "  REAP   %-32s merged + clean + fully pushed\n" "$name"
   reap+=("$name")
 done < <(git -C "$repo" worktree list --porcelain | awk '
-  /^worktree /{wt=$2}
-  /^branch /{print wt"\t"$2}
+  /^worktree /{wt=$2; br=""}
+  /^branch /{br=$2}
+  /^detached/{br="detached"}
+  /^$/{if(wt!=""){print wt"\t"br; wt=""}}
+  END{if(wt!=""){print wt"\t"br}}
 ')
 
 echo ""
+[[ $active_kept -gt 0 ]] && echo "($active_kept merged worktree(s) kept because they are ACTIVE — stop the server to reap them.)"
 if [[ ${#reap[@]} -eq 0 ]]; then
   echo "Nothing to reap."
   exit 0
@@ -73,8 +102,9 @@ fi
 echo "Reaping ${#reap[@]} worktree(s)…"
 for name in "${reap[@]}"; do
   echo "── $name ──"
-  # --force is safe here: the merged-PR gate already proved the work is landed,
-  # and we only reach this for a clean working tree.
+  # --force is safe here: we proved the local tip is contained in the merged PR
+  # head (nothing unpushed) and the tree is clean. task-clean reads the
+  # worktree's real branch, so a non-standard branch is cleaned correctly.
   "$script_dir/task-clean.sh" "$name" --force || echo "warning: task-clean failed for '$name'" >&2
 done
 echo "✓ done"

--- a/scripts/dev-db.sh
+++ b/scripts/dev-db.sh
@@ -14,18 +14,14 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# shellcheck source=scripts/lib/db-name.sh
+. "$REPO_ROOT/scripts/lib/db-name.sh"
+
 # Name defaults to the current git branch (the worktree's branch) so the
-# database tracks the worktree. Sanitize to a legal lowercase PG identifier —
-# `feat/sidebar` → `lobu_feat_sidebar`.
+# database tracks the worktree. `lobu_db_name` derives `lobu_feat_sidebar` from
+# `feat/sidebar` — and `task-clean.sh` uses the same helper to drop it.
 RAW_NAME="${NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo dev)}"
-SLUG="$(printf '%s' "$RAW_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
-DB="lobu_${SLUG:-dev}"
-# Postgres silently truncates identifiers past 63 bytes, which would collide two
-# long branch names into one database and break db_exists. Cap with a short hash
-# of the full name so distinct long branches stay distinct.
-if [ "${#DB}" -gt 63 ]; then
-  DB="${DB:0:52}_$(printf '%s' "$DB" | cksum | cut -d' ' -f1)"
-fi
+DB="$(lobu_db_name "$RAW_NAME")"
 
 PGHOST="${PGHOST:-localhost}"
 PGPORT="${PGPORT:-5432}"

--- a/scripts/lib/db-name.sh
+++ b/scripts/lib/db-name.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Single source of truth for the per-branch dev database name.
+# `dev-db.sh` creates `lobu_<slug>`; `task-clean.sh` drops it. Keeping the slug
+# derivation here means the two can never drift — a mismatch would silently
+# orphan databases (the exact bug this consolidation prevents).
+#
+# Usage:  db="$(lobu_db_name "$raw_name")"
+
+lobu_db_name() {
+  local raw="$1" slug db
+  # Sanitize to a legal lowercase PG identifier — `feat/sidebar` → `feat_sidebar`.
+  slug="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/_/g; s/^_+|_+$//g')"
+  db="lobu_${slug:-dev}"
+  # Postgres silently truncates identifiers past 63 bytes, which would collide
+  # two long branch names into one database. Cap with a short hash of the full
+  # name so distinct long branches stay distinct.
+  if [ "${#db}" -gt 63 ]; then
+    db="${db:0:52}_$(printf '%s' "$db" | cksum | cut -d' ' -f1)"
+  fi
+  printf '%s' "$db"
+}

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -185,11 +185,14 @@ for raw in "$name" "$branch" "$default_branch"; do
   db="$(lobu_db_name "$raw")"
   case " $dropped_dbs " in *" $db "*) continue ;; esac
   dropped_dbs="$dropped_dbs $db"
-  # Never drop the shared integration-test DB. Match it EXACTLY — a `*_test`
-  # glob would wrongly skip legitimate per-task DBs like lobu_feature_test.
-  if [[ "$db" == "lobu_test" ]]; then
-    echo "→ skipping protected database '$db'"; continue
-  fi
+  # Never drop a shared/long-lived DB: the integration-test DB, or the
+  # main/master dev DBs (`make dev-db` on main creates lobu_main). Match EXACTLY —
+  # a `*_test` glob would wrongly skip legitimate per-task DBs like
+  # lobu_feature_test, and only these exact names are off-limits.
+  case "$db" in
+    lobu_test | lobu_main | lobu_master)
+      echo "→ skipping protected database '$db'"; continue ;;
+  esac
   exists="$(psql -tAc "select 1 from pg_database where datname='$db'" postgres 2>/dev/null || true)"
   [[ "$exists" == "1" ]] || continue
   # --force evicts a still-connected dev server; --if-exists guards the race.

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -127,11 +127,20 @@ branch_is_pushed() { # <gitdir> <b>
   return 1
 }
 
+# Never delete a long-lived integration branch, even if a worktree was somehow
+# moved onto it (removing the worktree first would free the ref, so `branch -D`
+# would otherwise succeed and nuke main/master).
+is_protected_branch() { case "$1" in main|master) return 0 ;; *) return 1 ;; esac; }
+
 # Delete the branch the worktree was actually on. Safety for THIS branch is
 # enforced upstream — the force=0 ahead-of-origin guard above, or clean-merged's
 # merged-head gate — so by the time we get here, deleting it is sanctioned.
 delete_actual() { # <gitdir> <label>
   local gitdir="$1" label="$2"
+  if is_protected_branch "$branch"; then
+    echo "→ refusing to delete protected $label branch '$branch'" >&2
+    return 0
+  fi
   if git -C "$gitdir" show-ref --verify --quiet "refs/heads/$branch"; then
     echo "→ deleting $label branch $branch"
     git -C "$gitdir" branch -D "$branch"
@@ -145,6 +154,7 @@ delete_actual() { # <gitdir> <label>
 delete_default_if_pushed() { # <gitdir> <label>
   local gitdir="$1" label="$2"
   [[ "$default_branch" != "$branch" ]] || return 0
+  is_protected_branch "$default_branch" && return 0
   git -C "$gitdir" show-ref --verify --quiet "refs/heads/$default_branch" || return 0
   if branch_is_pushed "$gitdir" "$default_branch"; then
     echo "→ deleting $label branch $default_branch (feat default, fully pushed)"

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -44,6 +44,9 @@ repo="$(dirname "$(git -C "$script_dir" rev-parse --path-format=absolute --git-c
 worktree_dir="$repo/.claude/worktrees/$name"
 branch="feat/$name"
 
+# shellcheck source=scripts/lib/db-name.sh
+. "$script_dir/lib/db-name.sh"
+
 if [[ ! -d "$worktree_dir" ]]; then
   echo "error: no worktree at $worktree_dir" >&2
   exit 1
@@ -115,6 +118,30 @@ if [[ -d "$repo/packages/owletto" ]] \
   echo "→ deleting owletto branch $branch"
   git -C "$repo/packages/owletto" branch -D "$branch"
 fi
+
+# Drop the per-branch dev database created by `make dev-db`. The name depends on
+# how dev-db was invoked: `make dev-db` inside the worktree keys off the branch
+# (lobu_feat_<name>), while `make dev-db NAME=<name>` keys off the bare name
+# (lobu_<name>). Drop both candidates via the shared `lobu_db_name` helper so the
+# name can't drift from what dev-db created. Non-fatal: a missing DB or an
+# unreachable Postgres just skips (cleanup must still finish).
+export PGHOST="${PGHOST:-localhost}" PGPORT="${PGPORT:-5432}" PGUSER="${PGUSER:-$USER}"
+for raw in "$name" "$branch"; do
+  db="$(lobu_db_name "$raw")"
+  # Never drop a shared database. The only realistic collision is a task named
+  # "test" → lobu_test (the shared integration-test DB).
+  case "$db" in
+    *_test) echo "→ skipping protected database '$db'"; continue ;;
+  esac
+  exists="$(psql -tAc "select 1 from pg_database where datname='$db'" postgres 2>/dev/null || true)"
+  [[ "$exists" == "1" ]] || continue
+  # --force evicts a still-connected dev server; --if-exists guards the race.
+  if dropdb --if-exists --force "$db" 2>/dev/null; then
+    echo "→ dropped dev database '$db'"
+  else
+    echo "warning: failed to drop '$db' — drop it manually: dropdb --force $db" >&2
+  fi
+done
 
 if command -v lobu >/dev/null 2>&1; then
   if lobu context rm "$name" >/dev/null 2>&1; then

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -115,22 +115,51 @@ fi
 echo "→ removing worktree $worktree_dir"
 git -C "$repo" worktree remove "$worktree_dir" --force
 
-# Delete the branch the worktree was on AND the feat/<name> default (they can
-# differ). De-dup so we don't try the same branch twice.
-delete_branch() { # <gitdir> <label>
-  local gitdir="$1" label="$2" seen=""
-  for b in "$branch" "$default_branch"; do
-    [[ -n "$b" ]] || continue
-    case " $seen " in *" $b "*) continue ;; esac
-    seen="$seen $b"
-    if git -C "$gitdir" show-ref --verify --quiet "refs/heads/$b"; then
-      echo "→ deleting $label branch $b"
-      git -C "$gitdir" branch -D "$b"
-    fi
-  done
+# Returns 0 if branch <b> in <gitdir> carries no local-only commits (its tip is
+# reachable from origin/main, or equals its pushed remote ref). Used to protect
+# the feat/<name> default below — we never auto-delete unpushed work.
+branch_is_pushed() { # <gitdir> <b>
+  local gitdir="$1" b="$2" tip
+  tip="$(git -C "$gitdir" rev-parse "$b" 2>/dev/null)" || return 0
+  git -C "$gitdir" merge-base --is-ancestor "$tip" origin/main 2>/dev/null && return 0
+  git -C "$gitdir" rev-parse --verify "origin/$b" >/dev/null 2>&1 \
+    && [[ "$tip" == "$(git -C "$gitdir" rev-parse "origin/$b")" ]] && return 0
+  return 1
 }
-delete_branch "$repo" lobu
-[[ -d "$repo/packages/owletto" ]] && delete_branch "$repo/packages/owletto" owletto
+
+# Delete the branch the worktree was actually on. Safety for THIS branch is
+# enforced upstream — the force=0 ahead-of-origin guard above, or clean-merged's
+# merged-head gate — so by the time we get here, deleting it is sanctioned.
+delete_actual() { # <gitdir> <label>
+  local gitdir="$1" label="$2"
+  if git -C "$gitdir" show-ref --verify --quiet "refs/heads/$branch"; then
+    echo "→ deleting $label branch $branch"
+    git -C "$gitdir" branch -D "$branch"
+  fi
+}
+
+# Also clean up the feat/<name> default when the worktree had been moved onto a
+# different branch — but ONLY if it has no unpushed commits. The upstream guard
+# never inspected this branch, so deleting it blind could discard work the user
+# didn't target (exactly the failure mode that lost an unpushed fix earlier).
+delete_default_if_pushed() { # <gitdir> <label>
+  local gitdir="$1" label="$2"
+  [[ "$default_branch" != "$branch" ]] || return 0
+  git -C "$gitdir" show-ref --verify --quiet "refs/heads/$default_branch" || return 0
+  if branch_is_pushed "$gitdir" "$default_branch"; then
+    echo "→ deleting $label branch $default_branch (feat default, fully pushed)"
+    git -C "$gitdir" branch -D "$default_branch"
+  else
+    echo "→ keeping $label branch $default_branch (has unpushed commits; delete manually if intended)" >&2
+  fi
+}
+
+for spec in "$repo:lobu" "$repo/packages/owletto:owletto"; do
+  gitdir="${spec%:*}"; label="${spec##*:}"
+  [[ "$label" == "lobu" || -d "$gitdir" ]] || continue
+  delete_actual "$gitdir" "$label"
+  delete_default_if_pushed "$gitdir" "$label"
+done
 
 # Drop the per-branch dev database created by `make dev-db`. The name depends on
 # how dev-db was invoked: `make dev-db` inside the worktree keys off the branch
@@ -146,11 +175,11 @@ for raw in "$name" "$branch" "$default_branch"; do
   db="$(lobu_db_name "$raw")"
   case " $dropped_dbs " in *" $db "*) continue ;; esac
   dropped_dbs="$dropped_dbs $db"
-  # Never drop a shared database. The only realistic collision is a task named
-  # "test" → lobu_test (the shared integration-test DB).
-  case "$db" in
-    *_test) echo "→ skipping protected database '$db'"; continue ;;
-  esac
+  # Never drop the shared integration-test DB. Match it EXACTLY — a `*_test`
+  # glob would wrongly skip legitimate per-task DBs like lobu_feature_test.
+  if [[ "$db" == "lobu_test" ]]; then
+    echo "→ skipping protected database '$db'"; continue
+  fi
   exists="$(psql -tAc "select 1 from pg_database where datname='$db'" postgres 2>/dev/null || true)"
   [[ "$exists" == "1" ]] || continue
   # --force evicts a still-connected dev server; --if-exists guards the race.

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -42,7 +42,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # `make task-clean` from inside a worktree targets the right paths.
 repo="$(dirname "$(git -C "$script_dir" rev-parse --path-format=absolute --git-common-dir)")"
 worktree_dir="$repo/.claude/worktrees/$name"
-branch="feat/$name"
+default_branch="feat/$name"
+branch="$default_branch"
 
 # shellcheck source=scripts/lib/db-name.sh
 . "$script_dir/lib/db-name.sh"
@@ -51,6 +52,12 @@ if [[ ! -d "$worktree_dir" ]]; then
   echo "error: no worktree at $worktree_dir" >&2
   exit 1
 fi
+
+# task-setup creates feat/<name>, but a worktree may sit on any branch. Clean up
+# the branch it's ACTUALLY on (so a non-standard branch — revert/…, chore/… — is
+# deleted, not silently left behind), keeping feat/<name> as the fallback.
+actual_branch="$(git -C "$worktree_dir" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+[[ -n "$actual_branch" ]] && branch="$actual_branch"
 
 # Count commits on $branch that aren't reachable from $upstream. Echoes 0 when
 # $upstream is missing (treats "no upstream" as "no proven publish"; caller
@@ -108,26 +115,37 @@ fi
 echo "→ removing worktree $worktree_dir"
 git -C "$repo" worktree remove "$worktree_dir" --force
 
-if git -C "$repo" show-ref --verify --quiet "refs/heads/$branch"; then
-  echo "→ deleting lobu branch $branch"
-  git -C "$repo" branch -D "$branch"
-fi
-
-if [[ -d "$repo/packages/owletto" ]] \
-   && git -C "$repo/packages/owletto" show-ref --verify --quiet "refs/heads/$branch"; then
-  echo "→ deleting owletto branch $branch"
-  git -C "$repo/packages/owletto" branch -D "$branch"
-fi
+# Delete the branch the worktree was on AND the feat/<name> default (they can
+# differ). De-dup so we don't try the same branch twice.
+delete_branch() { # <gitdir> <label>
+  local gitdir="$1" label="$2" seen=""
+  for b in "$branch" "$default_branch"; do
+    [[ -n "$b" ]] || continue
+    case " $seen " in *" $b "*) continue ;; esac
+    seen="$seen $b"
+    if git -C "$gitdir" show-ref --verify --quiet "refs/heads/$b"; then
+      echo "→ deleting $label branch $b"
+      git -C "$gitdir" branch -D "$b"
+    fi
+  done
+}
+delete_branch "$repo" lobu
+[[ -d "$repo/packages/owletto" ]] && delete_branch "$repo/packages/owletto" owletto
 
 # Drop the per-branch dev database created by `make dev-db`. The name depends on
 # how dev-db was invoked: `make dev-db` inside the worktree keys off the branch
 # (lobu_feat_<name>), while `make dev-db NAME=<name>` keys off the bare name
-# (lobu_<name>). Drop both candidates via the shared `lobu_db_name` helper so the
-# name can't drift from what dev-db created. Non-fatal: a missing DB or an
-# unreachable Postgres just skips (cleanup must still finish).
+# (lobu_<name>). Try every candidate — the bare name, the actual branch, and the
+# feat/<name> default — via the shared `lobu_db_name` helper so the name can't
+# drift from what dev-db created. Non-fatal: a missing DB or an unreachable
+# Postgres just skips (cleanup must still finish).
 export PGHOST="${PGHOST:-localhost}" PGPORT="${PGPORT:-5432}" PGUSER="${PGUSER:-$USER}"
-for raw in "$name" "$branch"; do
+dropped_dbs=""
+for raw in "$name" "$branch" "$default_branch"; do
+  [[ -n "$raw" ]] || continue
   db="$(lobu_db_name "$raw")"
+  case " $dropped_dbs " in *" $db "*) continue ;; esac
+  dropped_dbs="$dropped_dbs $db"
   # Never drop a shared database. The only realistic collision is a task named
   # "test" → lobu_test (the shared integration-test DB).
   case "$db" in


### PR DESCRIPTION
task-clean tore down the worktree, branches, and Lobu context but never dropped the lobu_<branch> database that dev-db creates. So per-branch dev DBs leaked forever — I found lobu_sidebar, lobu_e2e, lobu_1180, lobu_slackpreview_dev sitting around with no live worktree.

What this does:

Extracts the DB-name slug logic into scripts/lib/db-name.sh so dev-db (which creates lobu_<branch>) and task-clean (which now drops it) share one definition and cannot drift. A drift is exactly what silently orphans databases.

task-clean now drops both name forms — lobu_<name> and lobu_feat_<name> — covering both `make dev-db NAME=foo` and the branch-derived default. It uses dropdb --force to evict a still-connected dev server (a plain dropdb fails when make dev is running), --if-exists for the race, and guards *_test so a task named "test" can never drop the shared lobu_test. Fully non-fatal: a missing DB or unreachable Postgres just skips so cleanup always finishes.

Adds `make clean-merged` (scripts/clean-merged.sh): reaps task worktrees whose PR is already merged. Dry-run by default, APPLY=1 to act. It gates on the GitHub PR state rather than git ancestry, because squash merges defeat `git merge-base --is-ancestor`. It only reaps worktrees that are merged AND clean AND on the feat/<name> convention; everything else is kept with a printed reason.

Testing:

Red→green e2e: created both DB name forms, held a live connection to one (the condition that made a plain dropdb fail), ran the edited task-clean, confirmed both dropped plus worktree/branch/context gone. Unit-checked the slug helper produces output identical to the old inline logic and that the *_test guard holds. Dry-ran clean-merged against the current 41 worktrees — it correctly flagged 13 merged+clean for reaping and kept the not-merged / dirty / non-standard-branch ones (including this PR's own worktree).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784730923&installation_id=136316292&pr_number=1457&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1457&signature=ef5d160cbd307a968148b199b40f30ad1f7bd334c7d6b556e2e2f76dc2c927e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `clean-merged` make target to safely detect managed task worktrees whose pull requests are already merged. It runs in dry-run mode by default; set `APPLY=1` to perform cleanup.
* **Improvements**
  * Improved task cleanup to target the actual checked-out branch, avoid deleting important long-lived branches, and handle “default” branches only when fully pushed.
  * Added safer per-task development database cleanup, using standardized, collision-resistant database naming and continuing even if individual drops fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->