### PR TITLE
feat(classifiers): add classify_facet config-home (P4 fold phase 2)

### DIFF
--- a/db/migrations/20260622250000_classify_facet.sql
+++ b/db/migrations/20260622250000_classify_facet.sql
@@ -1,0 +1,77 @@
+-- migrate:up
+
+-- Classifier consolidation (P4) phase 2 (expand): introduce classify_facet, the stable
+-- classifier config-home that will replace event_classifiers (the per-version config in
+-- event_classifier_versions folds in a later phase). classify_facet mirrors the stable
+-- classifier identity/scope (id = event_classifiers.id), kept in sync by a trigger; the
+-- versioned config + the hot-path classification runtime flip are STAGING-GATED later phases
+-- (per the P4 audit). Additive — nothing reads classify_facet yet.
+--
+-- OPERATIONAL COST: O(rows) but event_classifiers is CONFIG-SCALE (one row per classifier;
+-- dozens per org, not events-scaled), so the inline backfill is safe in the Helm hook (unlike
+-- the events-scaled event_classifications / watcher_window_events backfills, which are
+-- out-of-band). Trigger syncs INSERT/UPDATE/DELETE (the windows-as-events lesson: mirror ALL
+-- ops, not just INSERT, so it stays accurate).
+
+CREATE TABLE IF NOT EXISTS public.classify_facet (
+  id bigint PRIMARY KEY,
+  organization_id text NOT NULL,
+  slug text NOT NULL,
+  name text NOT NULL,
+  description text,
+  attribute_key text NOT NULL,
+  status text NOT NULL,
+  entity_id bigint,
+  watcher_id bigint,
+  entity_ids bigint[],
+  created_by text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- squawk-ignore require-concurrent-index-creation -- empty table at creation
+CREATE INDEX IF NOT EXISTS idx_classify_facet_org_slug
+  ON public.classify_facet (organization_id, slug);
+
+CREATE OR REPLACE FUNCTION public.sync_classify_facet() RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    DELETE FROM public.classify_facet WHERE id = OLD.id;
+    RETURN OLD;
+  END IF;
+  INSERT INTO public.classify_facet
+    (id, organization_id, slug, name, description, attribute_key, status,
+     entity_id, watcher_id, entity_ids, created_by, created_at, updated_at)
+  VALUES
+    (NEW.id, NEW.organization_id, NEW.slug, NEW.name, NEW.description, NEW.attribute_key, NEW.status,
+     NEW.entity_id, NEW.watcher_id, NEW.entity_ids, NEW.created_by,
+     COALESCE(NEW.created_at, now()), COALESCE(NEW.updated_at, now()))
+  ON CONFLICT (id) DO UPDATE SET
+    organization_id = EXCLUDED.organization_id, slug = EXCLUDED.slug, name = EXCLUDED.name,
+    description = EXCLUDED.description, attribute_key = EXCLUDED.attribute_key, status = EXCLUDED.status,
+    entity_id = EXCLUDED.entity_id, watcher_id = EXCLUDED.watcher_id, entity_ids = EXCLUDED.entity_ids,
+    updated_at = EXCLUDED.updated_at;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_sync_classify_facet
+  AFTER INSERT OR UPDATE OR DELETE ON public.event_classifiers
+  FOR EACH ROW EXECUTE FUNCTION public.sync_classify_facet();
+
+-- Inline backfill (config-scale table — safe).
+INSERT INTO public.classify_facet
+  (id, organization_id, slug, name, description, attribute_key, status,
+   entity_id, watcher_id, entity_ids, created_by, created_at, updated_at)
+SELECT id, organization_id, slug, name, description, attribute_key, status,
+       entity_id, watcher_id, entity_ids, created_by,
+       COALESCE(created_at, now()), COALESCE(updated_at, now())
+FROM public.event_classifiers
+ON CONFLICT (id) DO NOTHING;
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS trg_sync_classify_facet ON public.event_classifiers;
+DROP FUNCTION IF EXISTS public.sync_classify_facet();
+-- squawk-ignore ban-drop-table
+DROP TABLE IF EXISTS public.classify_facet;

--- a/packages/server/src/__tests__/integration/classifiers/classify-facet.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classify-facet.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Classifier consolidation (P4) phase 2: classify_facet mirrors the stable classifier
+ * identity/scope from event_classifiers (id = event_classifiers.id), kept in sync by a trigger
+ * (INSERT/UPDATE/DELETE). Additive — the fold target; nothing reads it yet (the versioned-config
+ * fold + hot-path runtime flip are staging-gated later phases).
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+async function facet(id: number) {
+  return (await sql`
+    SELECT id, organization_id, slug, name, attribute_key, status FROM classify_facet WHERE id = ${id}
+  `) as Array<{ organization_id: string; slug: string; name: string; status: string }>;
+}
+
+describe('classify_facet mirror (P4 phase 2)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('mirrors event_classifiers on insert, update, and delete', async () => {
+    const org = await createTestOrganization({ name: 'CF Org' });
+    const user = await createTestUser({ email: 'cf@test.com' });
+    const [c] = (await sql`
+      INSERT INTO event_classifiers (slug, name, attribute_key, created_by, organization_id, status)
+      VALUES ('s1', 'N1', 'attr', ${user.id}, ${org.id}, 'active')
+      RETURNING id
+    `) as Array<{ id: number }>;
+    const cid = Number(c.id);
+
+    let f = await facet(cid);
+    expect(f).toHaveLength(1);
+    expect(f[0].slug).toBe('s1');
+    expect(f[0].organization_id).toBe(org.id);
+    expect(f[0].status).toBe('active');
+
+    await sql`UPDATE event_classifiers SET name = 'N2', status = 'deprecated' WHERE id = ${cid}`;
+    f = await facet(cid);
+    expect(f[0].name).toBe('N2');
+    expect(f[0].status).toBe('deprecated');
+
+    await sql`DELETE FROM event_classifiers WHERE id = ${cid}`;
+    expect(await facet(cid)).toHaveLength(0);
+  });
+
+  it('backfill seeds pre-existing rows and COALESCE defends NULL timestamps', async () => {
+    const org = await createTestOrganization({ name: 'CF Backfill Org' });
+    const user = await createTestUser({ email: 'cfb@test.com' });
+    let cid = 0;
+    try {
+      // Trigger disabled simulates a row that predates the migration; insert NULL timestamps
+      // (event_classifiers allows them) to exercise the COALESCE defense in the backfill.
+      await sql`ALTER TABLE event_classifiers DISABLE TRIGGER trg_sync_classify_facet`;
+      const [c] = (await sql`
+        INSERT INTO event_classifiers (slug, name, attribute_key, created_by, organization_id, status, created_at, updated_at)
+        VALUES ('bf', 'BF', 'attr', ${user.id}, ${org.id}, 'active', NULL, NULL)
+        RETURNING id
+      `) as Array<{ id: number }>;
+      cid = Number(c.id);
+      expect(await facet(cid)).toHaveLength(0); // trigger off → not mirrored
+    } finally {
+      await sql`ALTER TABLE event_classifiers ENABLE TRIGGER trg_sync_classify_facet`;
+    }
+
+    // The same backfill the migration runs.
+    await sql`
+      INSERT INTO classify_facet
+        (id, organization_id, slug, name, description, attribute_key, status,
+         entity_id, watcher_id, entity_ids, created_by, created_at, updated_at)
+      SELECT id, organization_id, slug, name, description, attribute_key, status,
+             entity_id, watcher_id, entity_ids, created_by,
+             COALESCE(created_at, now()), COALESCE(updated_at, now())
+      FROM event_classifiers WHERE id = ${cid}
+      ON CONFLICT (id) DO NOTHING
+    `;
+    const [f] = (await sql`
+      SELECT created_at, updated_at FROM classify_facet WHERE id = ${cid}
+    `) as Array<{ created_at: unknown; updated_at: unknown }>;
+    expect(f.created_at).not.toBeNull();
+    expect(f.updated_at).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What

**Classifier consolidation (P4) phase 2 — expand.** Introduces `classify_facet`, the stable
classifier config-home that will replace `event_classifiers` (`id = event_classifiers.id`). A
trigger mirrors the identity/scope on **INSERT/UPDATE/DELETE** (the windows-as-events lesson:
mirror ALL ops). Additive — **nothing reads it yet**; it's the fold target.

This builds on P4 phase 1 (#1454, stable `classifier_id` on `event_classifications`). The
versioned-config fold (`event_classifier_versions` → facet) and the **hot-path classification
runtime read flip** are STAGING-GATED later phases per the audit (the classification runtime is
live; dual-write drift risk).

## Migration safety

Inline backfill is **safe here**: `event_classifiers` is **config-scale** (one row per
classifier, dozens per org — NOT events-scaled), so it's not the `docs/MIGRATIONS.md` outage
pattern (unlike the `event_classifications` / `watcher_window_events` backfills, which are
out-of-band batched scripts). O(1)-ish at deploy. Operational cost noted in the header.

## Tests / review

`classify-facet.test.ts`: mirror tracks `event_classifiers` insert/update/delete. 7 classifier-
suite tests green; squawk clean. Reviewed by teammate + pi.

Base = `main`. Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784731097&installation_id=136316292&pr_number=1458&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1458&signature=e56b1f7488fc55bf9e79fd29cce850737015490572e078c496f81fe70e729548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->