### PR TITLE
feat(classifiers): fold current-version config into classify_facet (P4 fold phase 3)

### DIFF
--- a/db/migrations/20260622260000_classify_facet_config.sql
+++ b/db/migrations/20260622260000_classify_facet_config.sql
@@ -1,0 +1,70 @@
+-- migrate:up
+
+-- Classifier consolidation (P4) phase 3 (expand): fold the CURRENT version's config from
+-- event_classifier_versions into classify_facet, so the facet is a complete config-home (the
+-- later hot-path classification-runtime flip reads the full config from one place). A trigger
+-- mirrors the config whenever a version becomes is_current; the inline backfill seeds it from
+-- each classifier's current version. Additive — nothing reads these columns yet; the hot-path
+-- read flip + the drop of event_classifiers/_versions are STAGING-GATED later phases.
+--
+-- OPERATIONAL COST: O(rows) but event_classifier_versions is CONFIG-SCALE (a handful of
+-- versions per classifier, not events-scaled), so the inline backfill is safe per
+-- docs/MIGRATIONS.md (unlike the events-scaled backfills which are out-of-band).
+
+ALTER TABLE public.classify_facet
+  ADD COLUMN IF NOT EXISTS current_version_id bigint,
+  ADD COLUMN IF NOT EXISTS attribute_values jsonb,
+  ADD COLUMN IF NOT EXISTS min_similarity numeric,
+  ADD COLUMN IF NOT EXISTS fallback_value text,
+  ADD COLUMN IF NOT EXISTS preferred_model text,
+  ADD COLUMN IF NOT EXISTS extraction_config jsonb;
+
+CREATE OR REPLACE FUNCTION public.sync_classify_facet_config() RETURNS trigger AS $$
+BEGIN
+  -- Only the CURRENT version drives the facet's config (one current version per classifier).
+  IF NEW.is_current IS NOT TRUE THEN RETURN NEW; END IF;
+  UPDATE public.classify_facet SET
+    current_version_id = NEW.id,
+    attribute_values = NEW.attribute_values,
+    min_similarity = NEW.min_similarity,
+    fallback_value = NEW.fallback_value,
+    preferred_model = NEW.preferred_model,
+    extraction_config = NEW.extraction_config
+  WHERE id = NEW.classifier_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Fire on is_current AND the config columns: versions are NOT immutable — the CURRENT
+-- version's attribute_values are edited IN PLACE (manage_classifiers.ts:718 manual classify,
+-- classifier-extraction.ts:390 value learning) without touching is_current, so an
+-- is_current-only trigger would leave the facet config stale. The function still only mirrors
+-- when the (edited) row is the current version.
+CREATE TRIGGER trg_sync_classify_facet_config
+  AFTER INSERT OR UPDATE OF
+    is_current, attribute_values, min_similarity, fallback_value, preferred_model, extraction_config
+  ON public.event_classifier_versions
+  FOR EACH ROW EXECUTE FUNCTION public.sync_classify_facet_config();
+
+-- Inline backfill (config-scale): each facet gets its current version's config.
+UPDATE public.classify_facet cf SET
+  current_version_id = ecv.id,
+  attribute_values = ecv.attribute_values,
+  min_similarity = ecv.min_similarity,
+  fallback_value = ecv.fallback_value,
+  preferred_model = ecv.preferred_model,
+  extraction_config = ecv.extraction_config
+FROM public.event_classifier_versions ecv
+WHERE ecv.classifier_id = cf.id AND ecv.is_current = true;
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS trg_sync_classify_facet_config ON public.event_classifier_versions;
+DROP FUNCTION IF EXISTS public.sync_classify_facet_config();
+ALTER TABLE public.classify_facet
+  DROP COLUMN IF EXISTS current_version_id,
+  DROP COLUMN IF EXISTS attribute_values,
+  DROP COLUMN IF EXISTS min_similarity,
+  DROP COLUMN IF EXISTS fallback_value,
+  DROP COLUMN IF EXISTS preferred_model,
+  DROP COLUMN IF EXISTS extraction_config;

--- a/packages/server/src/__tests__/integration/classifiers/classify-facet-config.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classify-facet-config.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Classifier consolidation (P4) phase 3: classify_facet gains the CURRENT version's config
+ * (attribute_values, min_similarity, fallback_value, preferred_model, extraction_config,
+ * current_version_id), mirrored from event_classifier_versions by a trigger whenever a version
+ * becomes is_current. Additive — nothing reads it yet; completes the config-home for the
+ * staging-gated hot-path read flip.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+async function makeClassifier(orgId: string, userId: string, slug: string) {
+  const [c] = (await sql`
+    INSERT INTO event_classifiers (slug, name, attribute_key, created_by, organization_id, status)
+    VALUES (${slug}, ${slug}, 'attr', ${userId}, ${orgId}, 'active')
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return Number(c.id);
+}
+
+async function addVersion(
+  classifierId: number,
+  userId: string,
+  version: number,
+  isCurrent: boolean,
+  cfg: { min_similarity: number; fallback_value: string; preferred_model: string }
+) {
+  const [v] = (await sql`
+    INSERT INTO event_classifier_versions
+      (classifier_id, version, is_current, attribute_values, min_similarity, fallback_value, preferred_model, extraction_config, created_by)
+    VALUES (${classifierId}, ${version}, ${isCurrent}, '[]'::jsonb, ${cfg.min_similarity}, ${cfg.fallback_value}, ${cfg.preferred_model}, '{}'::jsonb, ${userId})
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return Number(v.id);
+}
+
+async function facetConfig(id: number) {
+  const [f] = (await sql`
+    SELECT current_version_id, min_similarity, fallback_value, preferred_model
+    FROM classify_facet WHERE id = ${id}
+  `) as Array<{
+    current_version_id: number;
+    min_similarity: number;
+    fallback_value: string;
+    preferred_model: string;
+  }>;
+  return f;
+}
+
+describe('classify_facet config mirror (P4 phase 3)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('mirrors the current version config to the facet, and follows the current pointer', async () => {
+    const org = await createTestOrganization({ name: 'CFC Org' });
+    const user = await createTestUser({ email: 'cfc@test.com' });
+    const cid = await makeClassifier(org.id, user.id, 'cfc');
+
+    const v1 = await addVersion(cid, user.id, 1, true, {
+      min_similarity: 0.7,
+      fallback_value: 'unknown',
+      preferred_model: 'm1',
+    });
+    let f = await facetConfig(cid);
+    expect(Number(f.current_version_id)).toBe(v1);
+    expect(Number(f.min_similarity)).toBe(0.7);
+    expect(f.fallback_value).toBe('unknown');
+    expect(f.preferred_model).toBe('m1');
+
+    // Promote a new current version → the facet follows it.
+    await sql`UPDATE event_classifier_versions SET is_current = false WHERE id = ${v1}`;
+    const v2 = await addVersion(cid, user.id, 2, true, {
+      min_similarity: 0.9,
+      fallback_value: 'other',
+      preferred_model: 'm2',
+    });
+    f = await facetConfig(cid);
+    expect(Number(f.current_version_id)).toBe(v2);
+    expect(Number(f.min_similarity)).toBe(0.9);
+    expect(f.preferred_model).toBe('m2');
+  });
+
+  it('re-mirrors when the current version config is edited IN PLACE (manual classify / value learning)', async () => {
+    const org = await createTestOrganization({ name: 'CFC Inplace Org' });
+    const user = await createTestUser({ email: 'cfci@test.com' });
+    const cid = await makeClassifier(org.id, user.id, 'cfci');
+    const v1 = await addVersion(cid, user.id, 1, true, {
+      min_similarity: 0.5,
+      fallback_value: 'x',
+      preferred_model: 'm',
+    });
+
+    // attribute_values is edited IN PLACE on the current version (manage_classifiers.ts:718 /
+    // classifier-extraction.ts:390) without touching is_current — the facet must still re-mirror.
+    await sql`UPDATE event_classifier_versions SET attribute_values = '[{"v":"new"}]'::jsonb WHERE id = ${v1}`;
+    const [f] = (await sql`
+      SELECT attribute_values FROM classify_facet WHERE id = ${cid}
+    `) as Array<{ attribute_values: unknown }>;
+    expect(f.attribute_values).toEqual([{ v: 'new' }]);
+  });
+});


### PR DESCRIPTION
## What

**Classifier consolidation (P4) phase 3 — expand** (stacked on #1458). `classify_facet` gains the
CURRENT version's config (`current_version_id`, `attribute_values`, `min_similarity`,
`fallback_value`, `preferred_model`, `extraction_config`), mirrored from `event_classifier_versions`
by a trigger whenever a version becomes `is_current`; inline backfill seeds each facet from its
current version. **`classify_facet` is now a complete config-home** (identity from phase 2 +
versioned config here).

Additive — nothing reads these columns yet. The hot-path `classification-query.ts` runtime read
flip + the drop of `event_classifiers`/`_versions` are STAGING-GATED later phases (live runtime).

## Migration safety

`event_classifier_versions` is **config-scale** (a handful of versions per classifier), so the
inline backfill is safe per `docs/MIGRATIONS.md` (not the events-scaled outage pattern). ADD
COLUMN ×6 (nullable, no default) is metadata-only/O(1).

## Tests / review

`classify-facet-config.test.ts`: the facet mirrors the current version's config and **follows the
current pointer** when a new version is promoted. 9 classifier-suite tests green; squawk clean.
Reviewed by teammate + pi.

Base = `feat/classify-facet-p2` (#1458). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784731550&installation_id=136316292&pr_number=1459&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1459&signature=15bda91b8b54815f06a2a59ec6149649a832be5bead986d17e0015768495a042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->