### PR TITLE
feat(classifiers): flag-gated classification runtime reads config from classify_facet (P4 phase 4)

### DIFF
--- a/packages/server/src/__tests__/integration/classifiers/classify-facet-read.test.ts
+++ b/packages/server/src/__tests__/integration/classifiers/classify-facet-read.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Classifier consolidation (P4) phase 4: the hot classification runtime (classification-query.ts)
+ * reads the classifier config from classify_facet (flag CLASSIFY_VIA_FACET) instead of the
+ * event_classifiers -> event_classifier_versions(is_current) JOIN. This proves the two reads are
+ * EQUIVALENT (same classifier_id / version_id / config). Flag-gated so the hot read can be
+ * A/B-latency-validated in staging before cutover.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+describe('classification config read flip equivalence (P4 phase 4)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('the classify_facet config read matches the event_classifier_versions JOIN', async () => {
+    const org = await createTestOrganization({ name: 'CFR Org' });
+    const user = await createTestUser({ email: 'cfr@test.com' });
+    const [c] = (await sql`
+      INSERT INTO event_classifiers (slug, name, attribute_key, created_by, organization_id, status)
+      VALUES ('cfr', 'CFR', 'attr', ${user.id}, ${org.id}, 'active')
+      RETURNING id
+    `) as Array<{ id: number }>;
+    const cid = Number(c.id);
+    await sql`
+      INSERT INTO event_classifier_versions
+        (classifier_id, version, is_current, attribute_values, min_similarity, fallback_value, preferred_model, extraction_config, created_by)
+      VALUES (${cid}, 1, true, '[{"v":"x"}]'::jsonb, 0.6, 'fb', 'm1', '{"a":1}'::jsonb, ${user.id})
+    `;
+
+    // The production runtime's config SELECT, both variants (slug pinned to this classifier).
+    const joinRows = await sql`
+      SELECT fc.id as classifier_id, fcv.id as version_id, fcv.min_similarity, fcv.fallback_value,
+             fcv.attribute_values, fc.entity_ids
+      FROM event_classifiers fc
+      JOIN event_classifier_versions fcv ON fc.id = fcv.classifier_id AND fcv.is_current = true
+      WHERE fc.slug = 'cfr' AND fc.status = 'active' AND fc.watcher_id IS NULL
+    `;
+    const facetRows = await sql`
+      SELECT cf.id as classifier_id, cf.current_version_id as version_id, cf.min_similarity,
+             cf.fallback_value, cf.attribute_values, cf.entity_ids
+      FROM classify_facet cf
+      WHERE cf.slug = 'cfr' AND cf.status = 'active' AND cf.watcher_id IS NULL
+        AND cf.current_version_id IS NOT NULL
+    `;
+
+    expect(facetRows).toHaveLength(1);
+    expect(facetRows).toEqual(joinRows); // identical classifier_id/version_id/config
+  });
+
+  it('stays equivalent across version-switch and soft-delete (the mutation paths)', async () => {
+    const org = await createTestOrganization({ name: 'CFR2 Org' });
+    const user = await createTestUser({ email: 'cfr2@test.com' });
+    const [c] = (await sql`
+      INSERT INTO event_classifiers (slug, name, attribute_key, created_by, organization_id, status)
+      VALUES ('cfr2', 'CFR2', 'attr', ${user.id}, ${org.id}, 'active') RETURNING id
+    `) as Array<{ id: number }>;
+    const cid = Number(c.id);
+    await sql`
+      INSERT INTO event_classifier_versions (classifier_id, version, is_current, attribute_values, min_similarity, fallback_value, created_by)
+      VALUES (${cid}, 1, true, '[{"v":"a"}]'::jsonb, 0.5, 'fb1', ${user.id})
+    `;
+
+    const readJoin = async () => sql`
+      SELECT fc.id as classifier_id, fcv.id as version_id, fcv.min_similarity, fcv.fallback_value, fcv.attribute_values, fc.entity_ids
+      FROM event_classifiers fc JOIN event_classifier_versions fcv ON fc.id = fcv.classifier_id AND fcv.is_current = true
+      WHERE fc.slug = 'cfr2' AND fc.status = 'active' AND fc.watcher_id IS NULL
+    `;
+    const readFacet = async () => sql`
+      SELECT cf.id as classifier_id, cf.current_version_id as version_id, cf.min_similarity, cf.fallback_value, cf.attribute_values, cf.entity_ids
+      FROM classify_facet cf
+      WHERE cf.slug = 'cfr2' AND cf.status = 'active' AND cf.watcher_id IS NULL AND cf.current_version_id IS NOT NULL
+    `;
+
+    // Promote a new current version — both reads follow it identically.
+    await sql`UPDATE event_classifier_versions SET is_current = false WHERE classifier_id = ${cid}`;
+    await sql`
+      INSERT INTO event_classifier_versions (classifier_id, version, is_current, attribute_values, min_similarity, fallback_value, created_by)
+      VALUES (${cid}, 2, true, '[{"v":"b"}]'::jsonb, 0.8, 'fb2', ${user.id})
+    `;
+    expect(await readFacet()).toEqual(await readJoin());
+
+    // Soft-delete (status='deprecated') — both reads exclude it identically.
+    await sql`UPDATE event_classifiers SET status = 'deprecated' WHERE id = ${cid}`;
+    expect(await readFacet()).toHaveLength(0);
+    expect(await readJoin()).toHaveLength(0);
+  });
+});

--- a/packages/server/src/utils/classification-query.ts
+++ b/packages/server/src/utils/classification-query.ts
@@ -13,6 +13,22 @@ import { configuredEmbeddingModelSqlLiteral } from './embeddings';
 import logger from './logger';
 
 /**
+ * Classifier consolidation (P4) phase 4: read the classifier config from classify_facet (the
+ * config-home that mirrors event_classifiers identity + the CURRENT version's config) instead
+ * of the event_classifiers -> event_classifier_versions(is_current) JOIN. classify_facet is an
+ * accurate mirror (triggers sync identity + config incl. in-place edits), so the reads are
+ * equivalent. FLAG-GATED for a staged, A/B-validated cutover of this HOT classification runtime.
+ * Default off = the JOIN. DEPLOY GATE: classify_facet must be populated (phases 2-3 migrations
+ * backfill it inline — config-scale — so no separate backfill is required, unlike events-scaled
+ * tables).
+ */
+function classifyViaFacet(): boolean {
+  return (
+    process.env.CLASSIFY_VIA_FACET === '1' || process.env.CLASSIFY_VIA_FACET === 'true'
+  );
+}
+
+/**
  * Default weights for combining child and parent embeddings.
  * Child weight: 0.7 (70%) - emphasizes direct content
  * Parent weight: 0.3 (30%) - incorporates context
@@ -184,12 +200,19 @@ async function fetchTargetContent(
 
     // Get current classifier version IDs
     const versionRows = await sql.unsafe<{ version_id: number }>(
-      `SELECT fcv.id as version_id
-       FROM event_classifiers fc
-       JOIN event_classifier_versions fcv ON fc.id = fcv.classifier_id AND fcv.is_current = true
-       WHERE fc.slug IN (${classifierPlaceholders})
-         AND fc.status = 'active'
-         AND fc.watcher_id IS NULL`,
+      classifyViaFacet()
+        ? `SELECT cf.current_version_id as version_id
+           FROM classify_facet cf
+           WHERE cf.slug IN (${classifierPlaceholders})
+             AND cf.status = 'active'
+             AND cf.watcher_id IS NULL
+             AND cf.current_version_id IS NOT NULL`
+        : `SELECT fcv.id as version_id
+           FROM event_classifiers fc
+           JOIN event_classifier_versions fcv ON fc.id = fcv.classifier_id AND fcv.is_current = true
+           WHERE fc.slug IN (${classifierPlaceholders})
+             AND fc.status = 'active'
+             AND fc.watcher_id IS NULL`,
       enabledClassifiers
     );
     const versionIds = versionRows.map((r) => r.version_id);
@@ -271,19 +294,32 @@ async function fetchClassifierTemplates(
     attribute_values: string | Record<string, unknown>;
     entity_ids: number[] | null;
   }>(
-    `SELECT DISTINCT
-       fc.id as classifier_id,
-       fcv.id as version_id,
-       fcv.min_similarity,
-       fcv.fallback_value,
-       fcv.attribute_values,
-       fc.entity_ids
-     FROM event_classifiers fc
-     JOIN event_classifier_versions fcv
-       ON fc.id = fcv.classifier_id AND fcv.is_current = true
-     WHERE fc.slug IN (${classifierPlaceholders})
-       AND fc.status = 'active'
-       AND fc.watcher_id IS NULL`,
+    classifyViaFacet()
+      ? `SELECT DISTINCT
+           cf.id as classifier_id,
+           cf.current_version_id as version_id,
+           cf.min_similarity,
+           cf.fallback_value,
+           cf.attribute_values,
+           cf.entity_ids
+         FROM classify_facet cf
+         WHERE cf.slug IN (${classifierPlaceholders})
+           AND cf.status = 'active'
+           AND cf.watcher_id IS NULL
+           AND cf.current_version_id IS NOT NULL`
+      : `SELECT DISTINCT
+           fc.id as classifier_id,
+           fcv.id as version_id,
+           fcv.min_similarity,
+           fcv.fallback_value,
+           fcv.attribute_values,
+           fc.entity_ids
+         FROM event_classifiers fc
+         JOIN event_classifier_versions fcv
+           ON fc.id = fcv.classifier_id AND fcv.is_current = true
+         WHERE fc.slug IN (${classifierPlaceholders})
+           AND fc.status = 'active'
+           AND fc.watcher_id IS NULL`,
     enabledClassifiers
   );
 


### PR DESCRIPTION
## What

**Classifier consolidation (P4) phase 4 — the hot-path runtime read flip** (stacked on #1459).
Flips the live classification runtime (`classification-query.ts`, the embedding-classification
path) to read the classifier config from `classify_facet` (single-table) instead of the
`event_classifiers → event_classifier_versions(is_current)` JOIN, behind `CLASSIFY_VIA_FACET`
(default OFF = the JOIN). Both config reads flipped (the current-version-id list + the
`attribute_values`/`min_similarity`/`fallback` config). **The embedding-similarity + dedup logic
is unchanged — only the config SOURCE flips.**

`classify_facet` is an accurate mirror (phase-2 identity + phase-3 versioned config, including
in-place edits), so the two reads are **equivalent** — proven by test (identical
`classifier_id`/`version_id`/config rows).

## Flag + gate

`CLASSIFY_VIA_FACET` (default off) — staged, A/B-latency-validated cutover of this hot runtime.
Multi-replica-safe at any flag value (facet mirrors the source). `classify_facet` is populated by
the phase-2/3 **inline** backfills (config-scale — no separate backfill needed, unlike the
events-scaled tables). Phase 5 retires `event_classifiers`/`_versions` once the flag is universal.

## Tests / review

`classify-facet-read.test.ts`: the `classify_facet` config read returns EXACTLY the JOIN's
classifier/config rows. 11 classifier-suite tests green (flag off = unchanged runtime). Reviewed
by teammate + pi (equivalence is the load-bearing check on this hot path).

Base = `feat/classify-facet-p3-config` (#1459). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784731940&installation_id=136316292&pr_number=1460&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1460&signature=48076962062032d379d61d517841370a9202d26fb6a6b820786f944e85f90a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->