### PR TITLE
feat(corrections): mirror watcher_window_field_feedback into correction events (P1 phase 1)

### DIFF
--- a/db/migrations/20260622270000_feedback_correction_events.sql
+++ b/db/migrations/20260622270000_feedback_correction_events.sql
@@ -1,0 +1,51 @@
+-- migrate:up
+
+-- Correction-events consolidation (P1) phase 1 (expand): mirror watcher_window_field_feedback
+-- (append-only window-field corrections) into the events spine as semantic_type='correction'
+-- (the single edit model). A trigger mirrors new feedback rows; historic rows backfill OUT OF
+-- BAND (scripts/backfill-feedback-corrections.sh). Additive — nothing reads the correction
+-- events yet (feedback reads still use watcher_window_field_feedback; flip in phase 2).
+--
+-- Pollution-safe (Spike F lesson): entity_ids=[] + NO payload_text + semantic_type='correction'
+-- keep these OUT of content/search/embedding consumers.
+-- FK-safe: created_by is resolved to NULL if it isn't a valid user, so the mirror can NEVER
+-- break a feedback submit on the events_created_by_fkey (feedback already requires a user, but
+-- this is belt-and-suspenders for backfilled/edge rows).
+-- O(1) at deploy: trigger create only; the (events-spine) backfill is out-of-band batched.
+
+CREATE OR REPLACE FUNCTION public.mirror_feedback_correction() RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public.events
+    (organization_id, semantic_type, entity_ids, origin_id, metadata, created_by, occurred_at, created_at)
+  VALUES (
+    NEW.organization_id,
+    'correction',
+    '{}'::bigint[],
+    'wwff_' || NEW.id::text,
+    jsonb_build_object(
+      'window_id', NEW.window_id,
+      'watcher_id', NEW.watcher_id,
+      'field_path', NEW.field_path,
+      'mutation', NEW.mutation,
+      'corrected_value', NEW.corrected_value,
+      'note', NEW.note
+    ),
+    (SELECT u.id FROM public."user" u WHERE u.id = NEW.created_by),
+    NEW.created_at,
+    NEW.created_at
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_mirror_feedback_correction
+  AFTER INSERT ON public.watcher_window_field_feedback
+  FOR EACH ROW EXECUTE FUNCTION public.mirror_feedback_correction();
+
+-- migrate:down
+
+-- events is APPEND-ONLY (never DELETE FROM events). The down removes only the trigger +
+-- function; the mirrored 'correction' events remain (harmless — pre-P1 readers don't read
+-- semantic_type='correction'). Tombstone semantics, per the append-only invariant.
+DROP TRIGGER IF EXISTS trg_mirror_feedback_correction ON public.watcher_window_field_feedback;
+DROP FUNCTION IF EXISTS public.mirror_feedback_correction();

--- a/packages/server/src/__tests__/integration/corrections/feedback-correction-mirror.test.ts
+++ b/packages/server/src/__tests__/integration/corrections/feedback-correction-mirror.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Correction-events (P1) phase 1: watcher_window_field_feedback (append-only window-field
+ * corrections) is mirrored into the events spine as semantic_type='correction' by a trigger.
+ * Additive — nothing reads the correction events yet. Pollution-safe (entity_ids=[], no
+ * payload_text, semantic_type='correction'); FK-safe created_by (NULL if not a valid user).
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+async function seedWatcherWindow(orgId: string, userId: string, agentId: string) {
+  const watcherId = 950000;
+  await sql`
+    INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+    VALUES (${watcherId}, 'w', 'w-fc', ${userId}, ${orgId}, ${agentId}, ${watcherId})
+  `;
+  const windowId = 950001;
+  await sql`
+    INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+    VALUES (${windowId}, ${watcherId}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+  `;
+  return { watcherId, windowId };
+}
+
+describe('feedback -> correction-event mirror (P1 phase 1)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('mirrors a feedback row into a pollution-safe correction event', async () => {
+    const org = await createTestOrganization({ name: 'FC Org' });
+    const user = await createTestUser({ email: 'fc@test.com' });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+    const { watcherId, windowId } = await seedWatcherWindow(org.id, user.id, agent.agentId);
+
+    const [fb] = (await sql`
+      INSERT INTO watcher_window_field_feedback
+        (window_id, watcher_id, organization_id, field_path, mutation, corrected_value, note, created_by)
+      VALUES (${windowId}, ${watcherId}, ${org.id}, 'a.b', 'set', '"v"'::jsonb, 'note1', ${user.id})
+      RETURNING id
+    `) as Array<{ id: number }>;
+    const fbId = Number(fb.id);
+
+    const [ev] = (await sql`
+      SELECT organization_id, semantic_type, entity_ids, payload_text, created_by, metadata
+      FROM events WHERE origin_id = ${`wwff_${fbId}`}
+    `) as Array<{
+      organization_id: string;
+      semantic_type: string;
+      entity_ids: number[] | string | null;
+      payload_text: string | null;
+      created_by: string | null;
+      metadata: Record<string, unknown>;
+    }>;
+
+    expect(ev).toBeDefined();
+    expect(ev.semantic_type).toBe('correction');
+    expect(ev.organization_id).toBe(org.id);
+    // pollution-safe: not entity-linked (empty bigint[] — driver returns it as '{}' or [])
+    const eids = ev.entity_ids;
+    expect(eids === '{}' || (Array.isArray(eids) && eids.length === 0)).toBe(true);
+    expect(ev.payload_text).toBeNull(); // pollution-safe: not embedded/searchable
+    expect(ev.created_by).toBe(user.id);
+    expect(ev.metadata.window_id).toBe(windowId);
+    expect(ev.metadata.watcher_id).toBe(watcherId);
+    expect(ev.metadata.field_path).toBe('a.b');
+    expect(ev.metadata.mutation).toBe('set');
+    expect(ev.metadata.corrected_value).toBe('v');
+    expect(ev.metadata.note).toBe('note1');
+  });
+
+  it('correction events do NOT pollute the org-root content count or recent list (Spike F)', async () => {
+    const org = await createTestOrganization({ name: 'FC Noise Org' });
+    const user = await createTestUser({ email: 'fcn@test.com' });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+    const { watcherId, windowId } = await seedWatcherWindow(org.id, user.id, agent.agentId);
+
+    // A normal content event (counted) + a correction (mirrored from feedback, must NOT count).
+    await sql`
+      INSERT INTO events (organization_id, semantic_type, origin_id, payload_text, created_by)
+      VALUES (${org.id}, 'content', 'real_1', 'hello', ${user.id})
+    `;
+    await sql`
+      INSERT INTO watcher_window_field_feedback
+        (window_id, watcher_id, organization_id, field_path, mutation, corrected_value, note, created_by)
+      VALUES (${windowId}, ${watcherId}, ${org.id}, 'x', 'set', '"v"'::jsonb, NULL, ${user.id})
+    `;
+
+    // The resolve_path bootstrap queries, with the Spike F exclusion.
+    const [{ total_content }] = (await sql`
+      SELECT COUNT(*)::int AS total_content FROM current_event_records ev
+      WHERE ev.organization_id = ${org.id} AND ev.semantic_type <> 'correction'
+    `) as Array<{ total_content: number }>;
+    expect(total_content).toBe(1); // only the content event, not the correction
+
+    const recent = (await sql`
+      SELECT ev.id, ev.semantic_type FROM current_event_records ev
+      WHERE ev.organization_id = ${org.id} AND ev.semantic_type <> 'correction'
+      ORDER BY COALESCE(ev.occurred_at, ev.created_at) DESC
+    `) as Array<{ semantic_type: string }>;
+    expect(recent).toHaveLength(1);
+    expect(recent[0].semantic_type).toBe('content');
+  });
+});

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -853,6 +853,8 @@ async function fetchScopeSummary(
         SELECT COUNT(*)::int
         FROM current_event_records ev
         WHERE ev.organization_id = ${organizationId}
+          -- Exclude null-shaped internal events (P1 corrections) from the org content count.
+          AND ev.semantic_type <> 'correction'
       ) AS total_content,
       (
         SELECT COUNT(*)::int
@@ -915,6 +917,8 @@ async function fetchRecentContent(
     FROM current_event_records ev
     LEFT JOIN connections cn ON cn.id = ev.connection_id
     WHERE ev.organization_id = $1
+      -- Exclude null-shaped internal events (P1 corrections) from the recent-content list.
+      AND ev.semantic_type <> 'correction'
       ${entityFilter}
     ORDER BY COALESCE(ev.occurred_at, ev.created_at) DESC
     LIMIT $2

--- a/scripts/backfill-feedback-corrections.sh
+++ b/scripts/backfill-feedback-corrections.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Correction-events (P1) phase 1 backfill: mirror historic watcher_window_field_feedback rows
+# into the events spine as semantic_type='correction'. OUT OF BAND + batched (events is large);
+# idempotent via NOT EXISTS on origin_id (re-runnable). Each batch is its own tx. created_by is
+# FK-safe-resolved (NULL if not a valid user), matching the trigger.
+set -euo pipefail
+PSQL=(psql "${DATABASE_URL:?set DATABASE_URL}" -v ON_ERROR_STOP=1 -tAc)
+BATCH="${BATCH:-5000}"
+while :; do
+  N=$("${PSQL[@]}" "
+    WITH batch AS (
+      SELECT f.* FROM watcher_window_field_feedback f
+      WHERE NOT EXISTS (
+        SELECT 1 FROM events e WHERE e.origin_id = 'wwff_' || f.id::text AND e.semantic_type = 'correction'
+      )
+      ORDER BY f.id LIMIT ${BATCH}
+    ), ins AS (
+      INSERT INTO events
+        (organization_id, semantic_type, entity_ids, origin_id, metadata, created_by, occurred_at, created_at)
+      SELECT b.organization_id, 'correction', '{}'::bigint[], 'wwff_' || b.id::text,
+        jsonb_build_object('window_id', b.window_id, 'watcher_id', b.watcher_id, 'field_path', b.field_path,
+          'mutation', b.mutation, 'corrected_value', b.corrected_value, 'note', b.note),
+        (SELECT u.id FROM \"user\" u WHERE u.id = b.created_by), b.created_at, b.created_at
+      FROM batch b RETURNING 1
+    ) SELECT count(*) FROM ins;
+  ")
+  echo "backfilled batch: ${N}"
+  [ "${N}" -eq 0 ] && break
+  sleep 0.2
+done
+echo "feedback->correction backfill complete"


### PR DESCRIPTION
## What

**Correction-events consolidation (P1) phase 1 — expand.** A trigger mirrors
`watcher_window_field_feedback` (append-only window-field corrections) into the `events` spine as
`semantic_type='correction'` (`metadata={window_id,watcher_id,field_path,mutation,corrected_value,note}`).
Historic rows backfill **out-of-band** (`scripts/backfill-feedback-corrections.sh`, batched +
idempotent via `NOT EXISTS` on `origin_id`). **Additive** — nothing reads the correction events yet
(feedback reads still use `watcher_window_field_feedback`; the read flip + drop are later phases).

This starts the last unstarted consolidation target (P1 retires `watcher_window_field_feedback`).

## Safety

- **Pollution-safe (Spike F):** `entity_ids=[]` + NO `payload_text` + `semantic_type='correction'`
  keep these OUT of entity-linked queries, search, embedding, and connection/feed counts (same
  null-shape as the P5 `entity_field` producer).
- **FK-safe:** `created_by` is resolved to NULL if it isn't a valid user, so the mirror can NEVER
  break a feedback submit on `events_created_by_fkey`.
- **Append-only respected:** `events` is never DELETEd — the down drops only the trigger+function;
  the mirrored events remain (pre-P1 readers don't read `semantic_type='correction'`).
- **Multi-replica:** pure DB trigger — per-replica-correct.

## Tests / review

`feedback-correction-mirror.test.ts`: a feedback row mirrors to a pollution-safe correction event
(empty entity_ids, NULL payload_text, full metadata). 67 watcher-suite tests green (the trigger
fires on every feedback INSERT without breaking submission). squawk clean. Reviewed by teammate
(Spike F event-noise audit) + pi.

Base = `main`. Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784732872&installation_id=136316292&pr_number=1461&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1461&signature=827e6e50a10c95a6036b9856ed3d1d7292923407fed0dc803978751211fc4374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->