### PR TITLE
fix(server): bound embed-backfill discovery scan with statement_timeout

### DIFF
--- a/packages/server/src/scheduled/trigger-embed-backfill.ts
+++ b/packages/server/src/scheduled/trigger-embed-backfill.ts
@@ -10,7 +10,7 @@ import { getDb } from '../db/client';
 import { needsEmbeddingSql } from '../utils/embeddings';
 import type { Env } from '../index';
 import logger from '../utils/logger';
-import { isUniqueViolation } from '../utils/pg-errors';
+import { isQueryCanceled, isUniqueViolation } from '../utils/pg-errors';
 import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
 import { materializeDueItems } from './due-materializer';
 
@@ -26,6 +26,19 @@ const BATCH_LIMIT = 100;
 // reclaimed once an org's recent backlog clears (then it IS the newest
 // unembedded row — see the DESC scan in createBackfillRun).
 const RECENT_SCAN_LIMIT = 5000;
+
+// Hard ceiling on the org-discovery scan below. The query is *designed* to be
+// ~30ms (newest-N partial-index scan — see RECENT_SCAN_LIMIT), but its three
+// correlated NOT EXISTS anti-joins degrade badly when the recent window fills
+// with unembedded rows — e.g. the embeddings service is OOM-looping and not
+// draining the backlog. On the shared single-instance DB node a scan that heavy
+// spikes CPU enough to starve the Postgres liveness probe, which CNPG answers
+// by RESTARTING the primary — a full prod outage with no replica to fail over
+// to (incident 2026-06-22: this scan hit 14.5s and took prod down). Bounding it
+// makes a degraded scan abort cheaply instead of melting the node; a skipped
+// cycle is harmless — the next */5 tick retries, and createBackfillRun
+// re-collects the exact ids per org regardless. Overridable for ops/tests.
+const DISCOVERY_SCAN_TIMEOUT = process.env.EMBED_BACKFILL_SCAN_TIMEOUT || '8s';
 
 interface BackfillResult {
   organizations: number;
@@ -54,21 +67,19 @@ function needsEmbeddingPredicate(): string {
 const NOT_SUPERSEDED_PREDICATE =
   'NOT EXISTS (SELECT 1 FROM events newer WHERE newer.supersedes_event_id = e.id)';
 
-export async function triggerEmbedBackfill(_env: Env): Promise<BackfillResult> {
+// Org-discovery scan, bounded by statement_timeout and run READ ONLY. Returns
+// the per-org recent-window backlog counts (top 10). If the scan exceeds
+// DISCOVERY_SCAN_TIMEOUT it is aborted by Postgres (SQLSTATE 57014) and we skip
+// this cycle rather than error — see DISCOVERY_SCAN_TIMEOUT for why a heavy
+// scan is dangerous. The timeout is set via tx.unsafe (SET rejects bind
+// params; the value is a server-controlled constant, not user input).
+async function discoverBacklogOrgs(needsEmbedding: string): Promise<readonly OrgBatch[]> {
   const sql = getDb();
-  const needsEmbedding = needsEmbeddingPredicate();
-
   try {
-    let totalEvents = 0;
-
-    const counts = await materializeDueItems<OrgBatch>({
-      label: 'EmbedBackfill',
-      // Find organizations with events missing/stale embeddings, grouped for
-      // batch runs. Scoped to the most-recent RECENT_SCAN_LIMIT unembedded
-      // events (the genuine backlog is recent — see RECENT_SCAN_LIMIT), then
-      // grouped by org. event_count is the recent-window count, used only to
-      // rank/log; createBackfillRun re-collects the exact ids per org.
-      fetchDue: () => sql<OrgBatch>`
+    return await sql.begin(async (tx) => {
+      await tx`SET TRANSACTION READ ONLY`;
+      await tx.unsafe(`SET LOCAL statement_timeout = '${DISCOVERY_SCAN_TIMEOUT}'`);
+      return await tx<OrgBatch>`
         SELECT organization_id, COUNT(*)::int AS event_count
         FROM (
           SELECT e.organization_id
@@ -76,8 +87,8 @@ export async function triggerEmbedBackfill(_env: Env): Promise<BackfillResult> {
           WHERE e.payload_text IS NOT NULL
             AND e.payload_text != ''
             AND e.organization_id IS NOT NULL
-            AND ${sql.unsafe(needsEmbedding)}
-            AND ${sql.unsafe(NOT_SUPERSEDED_PREDICATE)}
+            AND ${tx.unsafe(needsEmbedding)}
+            AND ${tx.unsafe(NOT_SUPERSEDED_PREDICATE)}
             AND NOT EXISTS (
               SELECT 1
               FROM runs r
@@ -91,7 +102,35 @@ export async function triggerEmbedBackfill(_env: Env): Promise<BackfillResult> {
         GROUP BY organization_id
         ORDER BY event_count DESC
         LIMIT 10
-      `,
+      `;
+    });
+  } catch (error) {
+    if (isQueryCanceled(error)) {
+      logger.warn(
+        { timeout: DISCOVERY_SCAN_TIMEOUT },
+        '[EmbedBackfill] Org-discovery scan exceeded statement_timeout — skipping this cycle. The recent-events window is likely saturated with unembedded rows (embeddings service behind?); the scan was aborted to protect DB CPU.'
+      );
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function triggerEmbedBackfill(_env: Env): Promise<BackfillResult> {
+  const needsEmbedding = needsEmbeddingPredicate();
+
+  try {
+    let totalEvents = 0;
+
+    const counts = await materializeDueItems<OrgBatch>({
+      label: 'EmbedBackfill',
+      // Find organizations with events missing/stale embeddings, grouped for
+      // batch runs. Scoped to the most-recent RECENT_SCAN_LIMIT unembedded
+      // events (the genuine backlog is recent — see RECENT_SCAN_LIMIT), then
+      // grouped by org. event_count is the recent-window count, used only to
+      // rank/log; createBackfillRun re-collects the exact ids per org. Bounded
+      // by DISCOVERY_SCAN_TIMEOUT so a degraded scan can't spike DB CPU.
+      fetchDue: () => discoverBacklogOrgs(needsEmbedding),
       createRun: async (batch) => {
         const created = await createBackfillRun(batch.organization_id);
         if (!created) return 'skipped';

--- a/packages/server/src/utils/__tests__/pg-errors.test.ts
+++ b/packages/server/src/utils/__tests__/pg-errors.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { isQueryCanceled, isUniqueViolation } from '../pg-errors';
+
+describe('pg-errors', () => {
+  describe('isQueryCanceled', () => {
+    it('is true for a statement_timeout abort (SQLSTATE 57014)', () => {
+      // postgres.js surfaces a statement_timeout cancellation as code 57014;
+      // the embed-backfill discovery scan relies on this to skip a degraded
+      // cycle instead of erroring (and to never run long enough to spike DB CPU).
+      expect(isQueryCanceled({ code: '57014' })).toBe(true);
+    });
+
+    it('is false for other PG errors and non-errors', () => {
+      expect(isQueryCanceled({ code: '23505' })).toBe(false); // unique violation
+      expect(isQueryCanceled({ code: '57P03' })).toBe(false); // admin shutdown
+      expect(isQueryCanceled(new Error('boom'))).toBe(false);
+      expect(isQueryCanceled(null)).toBe(false);
+      expect(isQueryCanceled(undefined)).toBe(false);
+      expect(isQueryCanceled('57014')).toBe(false);
+    });
+  });
+
+  describe('isUniqueViolation', () => {
+    it('matches 23505 on the named constraint only', () => {
+      expect(isUniqueViolation({ code: '23505', constraint: 'idx_foo' }, 'idx_foo')).toBe(true);
+      expect(isUniqueViolation({ code: '23505', constraint_name: 'idx_foo' }, 'idx_foo')).toBe(true);
+      expect(isUniqueViolation({ code: '23505', constraint: 'idx_bar' }, 'idx_foo')).toBe(false);
+      expect(isUniqueViolation({ code: '23503', constraint: 'idx_foo' }, 'idx_foo')).toBe(false);
+      expect(isUniqueViolation(null, 'idx_foo')).toBe(false);
+    });
+  });
+});

--- a/packages/server/src/utils/pg-errors.ts
+++ b/packages/server/src/utils/pg-errors.ts
@@ -13,3 +13,13 @@ export function isUniqueViolation(error: unknown, constraintName: string): boole
   const constraint = pg.constraint ?? pg.constraint_name;
   return pg.code === '23505' && constraint === constraintName;
 }
+
+/**
+ * Check whether a caught error is a PG query-canceled (57014) — raised when a
+ * statement exceeds `statement_timeout`. Callers that bound a scan with a
+ * timeout use this to skip gracefully instead of erroring the whole tick.
+ */
+export function isQueryCanceled(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  return (error as { code?: string }).code === '57014';
+}


### PR DESCRIPTION
## Why
Part of the fix for the 2026-06-22 `app.lobu.ai` outage (Cloudflare 525, ~2.5 min). The `*/5` embed-backfill **org-discovery scan** is designed to be ~30ms (newest-N partial-index scan), but its three correlated `NOT EXISTS` anti-joins degrade to **>10s** when the recent-events window fills with unembedded rows (the embeddings service was OOM-looping and not draining a 1.14M-event backlog). On the shared **single-instance** DB node, a scan that heavy spiked CPU enough to starve the Postgres liveness probe → CNPG restarted the primary → app `/health/ready` 503 → app pods killed → 525.

**Reproducer (prod, ground truth):** the discovery query measured **14.5s** in the prod DB logs at the outage; 541ms under no load with the backlog still present. The query fires every 5 minutes, so any coincident CPU peak repeats the outage.

## What
Run the discovery scan **READ ONLY inside a transaction bounded by `statement_timeout`** (default `8s`, overridable via `EMBED_BACKFILL_SCAN_TIMEOUT`). If it exceeds the cap, Postgres aborts it (SQLSTATE `57014`) and we **skip the cycle with a warning** instead of spiking CPU. A skipped cycle is harmless — the next `*/5` tick retries and `createBackfillRun` re-collects the exact ids per org regardless.

- `scheduled/trigger-embed-backfill.ts`: extract the discovery query into a bounded `discoverBacklogOrgs()`; graceful skip on timeout. Query **semantics unchanged**.
- `utils/pg-errors.ts`: add `isQueryCanceled(error)` (57014 classifier) + unit test.

This is **defense-in-depth**; the operational root cause (embeddings OOM, single-node DB probe fragility) is fixed in the paired GitOps PR (owletto#319: embeddings memory 3Gi→6Gi, tolerant CNPG liveness probe, OOM/restart alerts).

## Validation
- Strict `tsc --noEmit` clean (husky pre-commit passed); `make build-packages` green.
- `isQueryCanceled` covered by a new unit test (6 cases) + verified standalone.
- Existing integration test (`trigger-embed-backfill.test.ts`) unchanged and now also exercises the bounded read-only path, locking query correctness.
- Full local server integration suite needs the `@lobu/pgvector-embedded` native build + test DB — deferred to CI / `make review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784733021&installation_id=136316292&pr_number=1462&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1462&signature=85591db595622c57931c21b2ac88b4e4559dff827ea3bc1a8b6457055e493321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->