### PR TITLE
feat(corrections): flag-gated feedback reads from correction events (P1 phase 2)

### DIFF
--- a/packages/server/src/__tests__/integration/corrections/feedback-read-flip.test.ts
+++ b/packages/server/src/__tests__/integration/corrections/feedback-read-flip.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Correction-events (P1) phase 2: the feedback readers (getRecentFeedbackSummary prompt summary +
+ * handleGetFeedback list) read from the events mirror behind FEEDBACK_VIA_CORRECTIONS. This proves
+ * the two paths are EQUIVALENT (same summary + same list), so the flag selects the source, not the
+ * result. Flag-gated for a staged cutover before phase 3 drops watcher_window_field_feedback.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { handleGetFeedback } from '../../../tools/admin/manage_watchers/feedback';
+import type { ToolContext } from '../../../tools/registry';
+import { getRecentFeedbackSummary } from '../../../utils/watcher-feedback';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+describe('feedback read flip equivalence (P1 phase 2)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+  afterEach(() => {
+    delete process.env.FEEDBACK_VIA_CORRECTIONS;
+  });
+
+  it('summary + list reads are identical from the table and the correction-events mirror', async () => {
+    const org = await createTestOrganization({ name: 'FRF Org' });
+    const user = await createTestUser({ email: 'frf@test.com' });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+    const watcherId = 951000;
+    await sql`
+      INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+      VALUES (${watcherId}, 'w', 'w-frf', ${user.id}, ${org.id}, ${agent.agentId}, ${watcherId})
+    `;
+    const windowId = 951001;
+    await sql`
+      INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+      VALUES (${windowId}, ${watcherId}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+    `;
+    // Two corrections on field 'a' (latest wins in the DISTINCT ON summary) + one on 'b'.
+    await sql`
+      INSERT INTO watcher_window_field_feedback
+        (window_id, watcher_id, organization_id, field_path, mutation, corrected_value, note, created_by, created_at)
+      VALUES
+        (${windowId}, ${watcherId}, ${org.id}, 'a', 'set', '"v1"'::jsonb, NULL, ${user.id}, NOW() - interval '1 hour'),
+        (${windowId}, ${watcherId}, ${org.id}, 'a', 'set', '"v2"'::jsonb, 'latest', ${user.id}, NOW()),
+        (${windowId}, ${watcherId}, ${org.id}, 'b', 'remove', NULL, NULL, ${user.id}, NOW() - interval '30 minutes')
+    `;
+
+    delete process.env.FEEDBACK_VIA_CORRECTIONS;
+    const summaryOff = await getRecentFeedbackSummary(watcherId);
+    process.env.FEEDBACK_VIA_CORRECTIONS = '1';
+    const summaryOn = await getRecentFeedbackSummary(watcherId);
+    expect(summaryOn).toBe(summaryOff);
+    expect(summaryOff).toContain('"a" → v2'); // latest correction won
+    expect(summaryOff).toContain('drop "b"');
+
+    const ctx = { organizationId: org.id, userId: user.id } as ToolContext;
+    delete process.env.FEEDBACK_VIA_CORRECTIONS;
+    const listOff = await handleGetFeedback({ watcher_id: watcherId } as never, ctx);
+    process.env.FEEDBACK_VIA_CORRECTIONS = '1';
+    const listOn = await handleGetFeedback({ watcher_id: watcherId } as never, ctx);
+
+    const norm = (r: ManageGetFeedback) =>
+      (r.feedback as Array<Record<string, unknown>>)
+        .map((f) => ({
+          id: Number(f.id),
+          field_path: f.field_path,
+          mutation: f.mutation,
+          corrected_value: f.corrected_value ?? null,
+          note: f.note ?? null,
+          // created_by is asserted too: on the happy path (a valid user) both paths return the
+          // user id. (They only diverge AFTER a user is deleted — the table keeps the dangling
+          // id, the event shows NULL via its FK SET NULL; that edge is documented, not a bug.)
+          created_by: f.created_by,
+        }))
+        .sort((a, b) => a.id - b.id);
+    expect(norm(listOn)).toEqual(norm(listOff)); // identical rows incl. recovered id + created_by
+    expect(norm(listOff)).toHaveLength(3);
+    expect(norm(listOff)[0].created_by).toBe(user.id);
+  });
+});
+
+type ManageGetFeedback = Awaited<ReturnType<typeof handleGetFeedback>>;

--- a/packages/server/src/tools/admin/manage_watchers/feedback.ts
+++ b/packages/server/src/tools/admin/manage_watchers/feedback.ts
@@ -4,6 +4,7 @@
  */
 
 import { getDb } from '../../../db/client';
+import { feedbackViaCorrections } from '../../../utils/watcher-feedback';
 import type { ToolContext } from '../../registry';
 import type { ManageWatchersArgs, ManageWatchersResult } from '../manage_watchers';
 
@@ -111,9 +112,46 @@ export async function handleGetFeedback(
   const limit = args.limit ?? 50;
 
   // Scope to the caller's current org so a member of org A can't enumerate
-  // feedback for a watcher in org B by passing its watcher_id.
-  const feedback = args.window_id
-    ? await sql`
+  // feedback for a watcher in org B by passing its watcher_id. Correction-events (P1) phase 2:
+  // read from the events mirror behind FEEDBACK_VIA_CORRECTIONS (the feedback id is recovered
+  // from origin_id 'wwff_<id>' so the response is equivalent; org-scoping stays identical).
+  // created_by is equivalent on the happy path; it only differs AFTER the author user is deleted
+  // (the table keeps the dangling id, the event shows NULL via events.created_by's FK SET NULL —
+  // the event is arguably more correct). Accepted: the mirror can't store a non-user id without
+  // breaking the feedback submit on events_created_by_fkey (the reason for the phase-1 resolve).
+  const feedback = feedbackViaCorrections()
+    ? args.window_id
+      ? await sql`
+          SELECT (substring(e.origin_id from 6))::bigint AS id,
+                 (e.metadata->>'window_id')::bigint AS window_id,
+                 e.metadata->>'field_path' AS field_path, e.metadata->>'mutation' AS mutation,
+                 e.metadata->'corrected_value' AS corrected_value, e.metadata->>'note' AS note,
+                 e.created_by, e.created_at, w.window_start, w.window_end
+          FROM events e
+          JOIN watcher_windows w ON (e.metadata->>'window_id')::bigint = w.id
+          WHERE e.semantic_type = 'correction'
+            AND (e.metadata->>'watcher_id')::bigint = ${watcherId}
+            AND (e.metadata->>'window_id')::bigint = ${args.window_id}
+            AND e.organization_id = ${ctx.organizationId}
+          ORDER BY e.created_at DESC
+          LIMIT ${limit}
+        `
+      : await sql`
+          SELECT (substring(e.origin_id from 6))::bigint AS id,
+                 (e.metadata->>'window_id')::bigint AS window_id,
+                 e.metadata->>'field_path' AS field_path, e.metadata->>'mutation' AS mutation,
+                 e.metadata->'corrected_value' AS corrected_value, e.metadata->>'note' AS note,
+                 e.created_by, e.created_at, w.window_start, w.window_end
+          FROM events e
+          JOIN watcher_windows w ON (e.metadata->>'window_id')::bigint = w.id
+          WHERE e.semantic_type = 'correction'
+            AND (e.metadata->>'watcher_id')::bigint = ${watcherId}
+            AND e.organization_id = ${ctx.organizationId}
+          ORDER BY e.created_at DESC
+          LIMIT ${limit}
+        `
+    : args.window_id
+      ? await sql`
         SELECT f.id, f.window_id, f.field_path, f.mutation, f.corrected_value,
                f.note, f.created_by, f.created_at,
                w.window_start, w.window_end
@@ -125,7 +163,7 @@ export async function handleGetFeedback(
         ORDER BY f.created_at DESC
         LIMIT ${limit}
       `
-    : await sql`
+      : await sql`
         SELECT f.id, f.window_id, f.field_path, f.mutation, f.corrected_value,
                f.note, f.created_by, f.created_at,
                w.window_start, w.window_end

--- a/packages/server/src/utils/watcher-feedback.ts
+++ b/packages/server/src/utils/watcher-feedback.ts
@@ -8,6 +8,21 @@
 import { getDb } from '../db/client';
 
 /**
+ * Correction-events (P1) phase 2: read window-field corrections from the events spine
+ * (semantic_type='correction', mirrored from watcher_window_field_feedback by the phase-1
+ * trigger) instead of the watcher_window_field_feedback table, when FEEDBACK_VIA_CORRECTIONS is
+ * set. The correction events are an accurate mirror (the table is append-only; the trigger fires
+ * on every INSERT; historic rows are backfilled), so the reads are EQUIVALENT. FLAG-GATED for a
+ * staged cutover (default OFF = the table). DEPLOY GATE: run
+ * scripts/backfill-feedback-corrections.sh before enabling the flag. Phase 3 drops the table.
+ */
+export function feedbackViaCorrections(): boolean {
+  return (
+    process.env.FEEDBACK_VIA_CORRECTIONS === '1' || process.env.FEEDBACK_VIA_CORRECTIONS === 'true'
+  );
+}
+
+/**
  * Build a human-readable summary of past user corrections for a watcher.
  *
  * Returns only the most-recent correction per (field_path) — earlier
@@ -19,7 +34,23 @@ export async function getRecentFeedbackSummary(
   limit = 20
 ): Promise<string | undefined> {
   const sql = getDb();
-  const feedback = await sql`
+  const feedback = feedbackViaCorrections()
+    ? await sql`
+        SELECT DISTINCT ON (e.metadata->>'field_path')
+               e.metadata->>'field_path' AS field_path,
+               e.metadata->>'mutation' AS mutation,
+               e.metadata->'corrected_value' AS corrected_value,
+               e.metadata->>'note' AS note,
+               e.created_at,
+               w.window_start, w.window_end
+        FROM events e
+        JOIN watcher_windows w ON (e.metadata->>'window_id')::bigint = w.id
+        WHERE e.semantic_type = 'correction'
+          AND (e.metadata->>'watcher_id')::bigint = ${watcherId}
+        ORDER BY e.metadata->>'field_path', e.created_at DESC
+        LIMIT ${limit}
+      `
+    : await sql`
     SELECT DISTINCT ON (f.field_path)
            f.field_path, f.mutation, f.corrected_value, f.note, f.created_at,
            w.window_start, w.window_end


### PR DESCRIPTION
## What

**Correction-events (P1) phase 2 — the read flip** (stacked on #1461). Flips **all** feedback
readers to read window-field corrections from the `events` mirror (`semantic_type='correction'`)
instead of `watcher_window_field_feedback`, behind `FEEDBACK_VIA_CORRECTIONS` (default OFF = the
table): `getRecentFeedbackSummary` (the prompt-injection DISTINCT-ON summary) +
`handleGetFeedback`'s two list reads. All three routed through the flag (the P6 complete-cutover
lesson — no inline reader left behind).

The correction events are an accurate mirror (append-only table + phase-1 trigger + backfill), so
the reads are **equivalent** — proven by test (identical summary + identical list, including the
feedback `id` recovered from `origin_id` `'wwff_<id>'`).

## Flag + gate

`FEEDBACK_VIA_CORRECTIONS` (default off). Org-scoping preserved (`e.organization_id = ctx org` —
the correction event carries the feedback's own org). Multi-replica-safe at any flag value.
**DEPLOY GATE:** run `scripts/backfill-feedback-corrections.sh` before enabling. Phase 3 drops
`watcher_window_field_feedback` once the flag is universal.

## Tests / review

`feedback-read-flip.test.ts`: the summary AND the get_feedback list are identical from the table
and the mirror under both flag states (latest-per-field wins; recovered id matches). 70
watcher+corrections tests green (flag off = unchanged). Reviewed by teammate + pi.

Base = `feat/feedback-correction-p1` (#1461). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784733723&installation_id=136316292&pr_number=1464&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1464&signature=5ece9b4e0945e475068d16429a8f9cf3fbfff457b8be8faffef1bef6619e3a23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->