### PR TITLE
feat(corrections): flag-gated feedback WRITE flip — emit correction events directly (P1 phase 3)

### DIFF
--- a/packages/server/src/__tests__/integration/corrections/feedback-write-flip.test.ts
+++ b/packages/server/src/__tests__/integration/corrections/feedback-write-flip.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Correction-events (P1) phase 3 — the WRITE flip. When FEEDBACK_WRITE_VIA_CORRECTIONS is set,
+ * handleSubmitFeedback emits the correction event DIRECTLY (id from the table's own sequence so
+ * origin_id stays 'wwff_<id>') and SKIPS the watcher_window_field_feedback INSERT. This proves
+ * the direct-emitted event is IDENTICAL in shape to the phase-1 trigger path, and that no table
+ * row is written — the precondition for phase-4 DROP TABLE.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { handleSubmitFeedback } from '../../../tools/admin/manage_watchers/feedback';
+import type { ToolContext } from '../../../tools/registry';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+describe('feedback write flip (P1 phase 3)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+  afterEach(() => {
+    delete process.env.FEEDBACK_WRITE_VIA_CORRECTIONS;
+  });
+
+  it('direct-emits a correction event identical to the trigger path and skips the table', async () => {
+    const org = await createTestOrganization({ name: 'FWF Org' });
+    const user = await createTestUser({ email: 'fwf@test.com' });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+    const watcherId = 952000;
+    await sql`
+      INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+      VALUES (${watcherId}, 'w', 'w-fwf', ${user.id}, ${org.id}, ${agent.agentId}, ${watcherId})
+    `;
+    const windowId = 952001;
+    await sql`
+      INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+      VALUES (${windowId}, ${watcherId}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+    `;
+    const ctx = { organizationId: org.id, userId: user.id } as ToolContext;
+    const corr = (fp: string) => ({
+      watcher_id: watcherId,
+      window_id: windowId,
+      corrections: [{ field_path: fp, mutation: 'set', value: 'v', note: 'n' }],
+    });
+
+    // Field 'x' via the TABLE path (trigger mirrors it). Field 'y' via the DIRECT path.
+    delete process.env.FEEDBACK_WRITE_VIA_CORRECTIONS;
+    await handleSubmitFeedback(corr('x') as never, ctx);
+    process.env.FEEDBACK_WRITE_VIA_CORRECTIONS = '1';
+    // 'y' = set; 'z' = remove (NULL corrected_value — exercises the ::jsonb param cast).
+    await handleSubmitFeedback(
+      {
+        watcher_id: watcherId,
+        window_id: windowId,
+        corrections: [
+          { field_path: 'y', mutation: 'set', value: 'v', note: 'n' },
+          { field_path: 'z', mutation: 'remove' },
+        ],
+      } as never,
+      ctx
+    );
+
+    const events = (await sql`
+      SELECT semantic_type, entity_ids, created_by, metadata, origin_id
+      FROM events WHERE semantic_type = 'correction' AND organization_id = ${org.id}
+      ORDER BY (metadata->>'field_path')
+    `) as Array<{
+      semantic_type: string;
+      entity_ids: number[] | string | null;
+      created_by: string | null;
+      metadata: Record<string, unknown>;
+      origin_id: string;
+    }>;
+
+    expect(events).toHaveLength(3); // trigger ('x') + direct set ('y') + direct remove ('z')
+    const byField = Object.fromEntries(events.map((e) => [e.metadata.field_path as string, e]));
+    const x = byField.x;
+    const y = byField.y;
+
+    // The direct-emitted 'y' event matches the trigger-emitted 'x' event in every shared field.
+    for (const e of [x, y]) {
+      expect(e.semantic_type).toBe('correction');
+      expect(e.created_by).toBe(user.id);
+      expect(e.origin_id).toMatch(/^wwff_\d+$/);
+      expect(e.entity_ids === '{}' || (Array.isArray(e.entity_ids) && e.entity_ids.length === 0)).toBe(true);
+      expect(e.metadata.watcher_id).toBe(watcherId);
+      expect(e.metadata.window_id).toBe(windowId);
+      expect(e.metadata.mutation).toBe('set');
+      expect(e.metadata.corrected_value).toBe('v');
+      expect(e.metadata.note).toBe('n');
+    }
+
+    // The 'remove' correction direct-emitted with a NULL corrected_value (the ::jsonb-cast path).
+    expect(byField.z.metadata.mutation).toBe('remove');
+    expect(byField.z.metadata.corrected_value).toBeNull();
+
+    // The DIRECT path wrote NO table row; only the table path ('x') did.
+    const tableRows = (await sql`
+      SELECT field_path FROM watcher_window_field_feedback WHERE watcher_id = ${watcherId}
+    `) as Array<{ field_path: string }>;
+    expect(tableRows.map((r) => r.field_path)).toEqual(['x']);
+  });
+});

--- a/packages/server/src/tools/admin/manage_watchers/feedback.ts
+++ b/packages/server/src/tools/admin/manage_watchers/feedback.ts
@@ -64,6 +64,19 @@ export async function handleSubmitFeedback(
   }
   const organizationId = windowCheck[0].organization_id as string;
 
+  // Correction-events (P1) phase 3 — the WRITE flip. When FEEDBACK_WRITE_VIA_CORRECTIONS is set,
+  // emit the correction event DIRECTLY (the same shape the phase-1 trigger produces) and skip the
+  // watcher_window_field_feedback INSERT, so the table can be dropped (phase 4). The id is still
+  // allocated from the table's own sequence (watcher_window_field_feedback_id_seq) so origin_id
+  // stays 'wwff_<id>' and the phase-2 read's substring id-recovery + ids remain stable.
+  // MULTI-REPLICA: gated on the READ flag (FEEDBACK_VIA_CORRECTIONS) already being universal —
+  // else flag-off readers reading the table would miss these direct-emitted events. During the
+  // write-flip rollout, old pods INSERT the table (-> trigger -> event) and new pods emit directly;
+  // no double event because each pod takes exactly one path.
+  const writeViaCorrections =
+    process.env.FEEDBACK_WRITE_VIA_CORRECTIONS === '1' ||
+    process.env.FEEDBACK_WRITE_VIA_CORRECTIONS === 'true';
+
   // Insert in one transaction so a partial failure never leaks half-applied
   // corrections — submit_feedback is naturally a batch operation from the UI.
   const feedbackIds = await sql.begin(async (tx) => {
@@ -72,6 +85,32 @@ export async function handleSubmitFeedback(
       const mutation = c.mutation ?? 'set';
       const correctedValueJson =
         mutation === 'remove' || c.value === undefined ? null : tx.json(c.value);
+      if (writeViaCorrections) {
+        const [row] = await tx`
+          WITH seq AS (SELECT nextval('watcher_window_field_feedback_id_seq') AS id)
+          INSERT INTO events (
+            organization_id, semantic_type, entity_ids, origin_id, metadata,
+            created_by, occurred_at, created_at
+          )
+          SELECT
+            ${organizationId}, 'correction', '{}'::bigint[], 'wwff_' || seq.id::text,
+            jsonb_build_object(
+              'window_id', ${args.window_id}::bigint,
+              'watcher_id', ${watcherId}::bigint,
+              'field_path', ${c.field_path}::text,
+              'mutation', ${mutation}::text,
+              -- ::jsonb so a 'remove' correction (NULL corrected_value) has an inferable param type
+              'corrected_value', ${correctedValueJson}::jsonb,
+              'note', ${c.note ?? null}::text
+            ),
+            (SELECT u.id FROM "user" u WHERE u.id = ${ctx.userId}),
+            NOW(), NOW()
+          FROM seq
+          RETURNING (substring(origin_id from 6))::bigint AS id
+        `;
+        ids.push(Number(row.id));
+        continue;
+      }
       const result = await tx`
         INSERT INTO watcher_window_field_feedback (
           window_id, watcher_id, organization_id,


### PR DESCRIPTION
## What

**Correction-events (P1) phase 3 — the WRITE flip** (stacked on #1464). When
`FEEDBACK_WRITE_VIA_CORRECTIONS` is set, `handleSubmitFeedback` emits the correction event
**directly** (the exact shape the phase-1 trigger produces) and **skips** the
`watcher_window_field_feedback` INSERT — the precondition for dropping the table (phase 4).

**The id-scheme decision** (the thing I flagged as needing design): the id is still allocated from
the table's own sequence `watcher_window_field_feedback_id_seq`, so `origin_id` stays `'wwff_<id>'`
and the already-merged phase-2 read (its `substring` id-recovery + stable ids) needs **zero churn**.
The sequence is `OWNED BY` the column today; phase 4's drop does `ALTER SEQUENCE ... OWNED BY NONE`
first so it survives the `DROP TABLE`.

## Multi-replica

Gated on the **read** flag (`FEEDBACK_VIA_CORRECTIONS`) being universal first — else flag-off
readers reading the table would miss these. During the write-flip rollout, old pods INSERT the
table (→ trigger → event), new pods emit directly; **no double event** because each pod takes
exactly one path (dedup is structural, not racy).

## Tests

`feedback-write-flip.test.ts`: the direct-emitted event is identical in shape to the
trigger-emitted one (`semantic_type`, empty `entity_ids`, `created_by`, full `metadata`,
`origin_id='wwff_<seq>'`) AND the direct path writes **no** table row. 71 corrections+watcher
tests green (flag off = unchanged).

Base = `feat/feedback-correction-p2` (#1464). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784735222&installation_id=136316292&pr_number=1465&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1465&signature=b7757c6d1e921c9b6cbd352c1b43c5567340a875766dfd817131aac98f8d51c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->