### PR TITLE
feat(connectors): refresh built-in connector defs across deploys + populate github webhook title/url

### DIFF
--- a/packages/server/src/gateway/__tests__/app-webhooks.test.ts
+++ b/packages/server/src/gateway/__tests__/app-webhooks.test.ts
@@ -119,7 +119,11 @@ describe("app-webhook router (GitHub)", () => {
 		const raw = JSON.stringify({
 			action: "opened",
 			installation: { id: Number(INSTALLATION_ID) },
-			issue: { number: 11, title: "Prod is down" },
+			issue: {
+				number: 11,
+				title: "Prod is down",
+				html_url: "https://github.com/acme/api/issues/11",
+			},
 			repository: { full_name: "acme/api" },
 		});
 		const res = await app.fetch(ghDelivery(raw));
@@ -131,12 +135,79 @@ describe("app-webhook router (GitHub)", () => {
 		expect(rows[0].payload_data).toEqual({
 			action: "opened",
 			installation: { id: Number(INSTALLATION_ID) },
-			issue: { number: 11, title: "Prod is down" },
+			issue: {
+				number: 11,
+				title: "Prod is down",
+				html_url: "https://github.com/acme/api/issues/11",
+			},
 			repository: { full_name: "acme/api" },
 		});
 		// Routed into the install's owning org, deduped on the delivery id.
 		expect(rows[0].organization_id).toBe(ORG);
 		expect(rows[0].origin_id).toBe("gh-app-1");
+		// Title + source_url projected from the issue (not left empty).
+		expect(rows[0].title).toBe("Prod is down");
+		expect(rows[0].source_url).toBe("https://github.com/acme/api/issues/11");
+	});
+
+	test("an issue_comment delivery lands the parent issue title + comment url", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedActiveInstall();
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "created",
+			installation: { id: Number(INSTALLATION_ID) },
+			issue: {
+				number: 11,
+				title: "Prod is down",
+				html_url: "https://github.com/acme/api/issues/11",
+			},
+			comment: {
+				id: 555,
+				body: "Looking into it",
+				html_url: "https://github.com/acme/api/issues/11#issuecomment-555",
+			},
+			repository: { full_name: "acme/api" },
+		});
+		const res = await app.fetch(
+			ghDelivery(raw, { deliveryId: "gh-comment-1", event: "issue_comment" }),
+		);
+		expect(res.status).toBe(202);
+
+		const rows = await eventRows(`webhook:app_install:${installId}`);
+		expect(rows.length).toBe(1);
+		// Title is the PARENT issue's; url deep-links the comment itself.
+		expect(rows[0].title).toBe("Prod is down");
+		expect(rows[0].source_url).toBe(
+			"https://github.com/acme/api/issues/11#issuecomment-555",
+		);
+	});
+
+	test("a pull_request delivery lands the PR title + html_url", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedActiveInstall();
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "opened",
+			installation: { id: Number(INSTALLATION_ID) },
+			pull_request: {
+				number: 42,
+				title: "Add app_installation auth method",
+				html_url: "https://github.com/acme/api/pull/42",
+			},
+			repository: { full_name: "acme/api" },
+		});
+		const res = await app.fetch(
+			ghDelivery(raw, { deliveryId: "gh-pr-1", event: "pull_request" }),
+		);
+		expect(res.status).toBe(202);
+
+		const rows = await eventRows(`webhook:app_install:${installId}`);
+		expect(rows.length).toBe(1);
+		expect(rows[0].title).toBe("Add app_installation auth method");
+		expect(rows[0].source_url).toBe("https://github.com/acme/api/pull/42");
 	});
 
 	test("a forged signature is rejected with 401 and lands nothing", async () => {

--- a/packages/server/src/gateway/__tests__/refresh-connector-definitions.test.ts
+++ b/packages/server/src/gateway/__tests__/refresh-connector-definitions.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Connector-definition refresh (#14, Goal A).
+ *
+ * `connector_definitions` rows are per-org point-in-time snapshots of a
+ * connector's code-defined schema, written once at first install and never
+ * re-synced. So an org that added github before the connector gained the
+ * `app_installation` auth method keeps a stale `auth_schema` ([oauth,env_keys]),
+ * and the GitHub App install callback rejects it (`github_connector_missing`).
+ *
+ * `refreshConnectorDefinitions()` re-syncs every org's EXISTING built-in
+ * definition from the on-disk registry. This drives the real path against real
+ * Postgres + the real bundled github connector source.
+ *
+ * Under test:
+ *  1. An org with a STALE github def (no app_installation method) gets the
+ *     app_installation method after refresh, with login_enabled preserved.
+ *  2. The refresh is idempotent (a second run changes nothing observable).
+ *  3. It does NOT install a connector into an org that didn't already have it.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { getDb } from "../../db/client.js";
+import { refreshConnectorDefinitions } from "../../scheduled/refresh-connector-definitions.js";
+import {
+	getAppInstallationAuthMethods,
+	normalizeConnectorAuthSchema,
+} from "../../utils/connector-auth.js";
+import {
+	ensureDbForGatewayTests,
+	ensureEncryptionKey,
+	resetTestDatabase,
+	seedAgentRow,
+} from "./helpers/db-setup.js";
+
+const ORG = "org-refresh";
+const OTHER_ORG = "org-refresh-other";
+const GITHUB_KEY = "github";
+
+/** The pre-PR5 github auth_schema: oauth + env_keys only, no app_installation. */
+const STALE_GITHUB_AUTH_SCHEMA = {
+	methods: [
+		{ type: "oauth", provider: "github", clientIdKey: "GITHUB_CLIENT_ID" },
+		{ type: "env_keys", fields: [{ key: "GITHUB_TOKEN" }] },
+	],
+};
+
+/** Insert an active, deliberately-stale github definition for an org. */
+async function seedStaleGithubDef(
+	orgId: string,
+	opts: { loginEnabled?: boolean } = {},
+): Promise<void> {
+	const sql = getDb();
+	await sql`
+    INSERT INTO connector_definitions (
+      organization_id, key, name, version,
+      auth_schema, status, login_enabled
+    ) VALUES (
+      ${orgId}, ${GITHUB_KEY}, 'GitHub', '0.0.1',
+      ${sql.json(STALE_GITHUB_AUTH_SCHEMA)}, 'active', ${opts.loginEnabled ?? false}
+    )
+  `;
+}
+
+async function loadGithubDef(orgId: string): Promise<{
+	auth_schema: unknown;
+	version: string;
+	login_enabled: boolean;
+} | undefined> {
+	const sql = getDb();
+	const rows = (await sql`
+    SELECT auth_schema, version, login_enabled
+    FROM connector_definitions
+    WHERE organization_id = ${orgId} AND key = ${GITHUB_KEY} AND status = 'active'
+    LIMIT 1
+  `) as unknown as Array<{
+		auth_schema: unknown;
+		version: string;
+		login_enabled: boolean;
+	}>;
+	return rows[0];
+}
+
+beforeAll(async () => {
+	await ensureDbForGatewayTests();
+}, 60_000);
+
+beforeEach(async () => {
+	await resetTestDatabase();
+	ensureEncryptionKey();
+}, 30_000);
+
+describe("refreshConnectorDefinitions", () => {
+	test("a stale github def gains the app_installation method after refresh", async () => {
+		await seedAgentRow("agent-refresh", { organizationId: ORG });
+		await seedStaleGithubDef(ORG, { loginEnabled: true });
+
+		// Precondition: the seeded def has NO app_installation method.
+		const before = await loadGithubDef(ORG);
+		expect(before).toBeDefined();
+		expect(
+			getAppInstallationAuthMethods(
+				normalizeConnectorAuthSchema(before?.auth_schema),
+			).length,
+		).toBe(0);
+
+		const result = await refreshConnectorDefinitions();
+		expect(result.refreshed).toBeGreaterThanOrEqual(1);
+
+		const after = await loadGithubDef(ORG);
+		expect(after).toBeDefined();
+		// The code-defined github schema carries an app_installation method now,
+		// so the install callback's hasAppInstallMethod check passes.
+		const appMethods = getAppInstallationAuthMethods(
+			normalizeConnectorAuthSchema(after?.auth_schema),
+		);
+		expect(appMethods.length).toBeGreaterThanOrEqual(1);
+		expect(appMethods[0].provider).toBe("github");
+		// Version was bumped from the stale 0.0.1 to whatever the code declares.
+		expect(after?.version).not.toBe("0.0.1");
+		// Org-specific config (login_enabled) is preserved across the refresh.
+		expect(after?.login_enabled).toBe(true);
+	});
+
+	test("refresh is idempotent — a second run changes nothing observable", async () => {
+		await seedAgentRow("agent-refresh", { organizationId: ORG });
+		await seedStaleGithubDef(ORG);
+
+		await refreshConnectorDefinitions();
+		const first = await loadGithubDef(ORG);
+
+		await refreshConnectorDefinitions();
+		const second = await loadGithubDef(ORG);
+
+		expect(second?.version).toBe(first?.version);
+		expect(
+			getAppInstallationAuthMethods(
+				normalizeConnectorAuthSchema(second?.auth_schema),
+			).length,
+		).toBe(
+			getAppInstallationAuthMethods(
+				normalizeConnectorAuthSchema(first?.auth_schema),
+			).length,
+		);
+	});
+
+	test("does not install a connector into an org that didn't have it", async () => {
+		await seedAgentRow("agent-refresh", { organizationId: ORG });
+		await seedAgentRow("agent-other", { organizationId: OTHER_ORG });
+		// Only ORG has github; OTHER_ORG has none.
+		await seedStaleGithubDef(ORG);
+
+		await refreshConnectorDefinitions();
+
+		const other = await loadGithubDef(OTHER_ORG);
+		expect(other).toBeUndefined();
+	});
+});

--- a/packages/server/src/gateway/__tests__/refresh-connector-definitions.test.ts
+++ b/packages/server/src/gateway/__tests__/refresh-connector-definitions.test.ts
@@ -1,21 +1,6 @@
 /**
- * Connector-definition refresh (#14, Goal A).
- *
- * `connector_definitions` rows are per-org point-in-time snapshots of a
- * connector's code-defined schema, written once at first install and never
- * re-synced. So an org that added github before the connector gained the
- * `app_installation` auth method keeps a stale `auth_schema` ([oauth,env_keys]),
- * and the GitHub App install callback rejects it (`github_connector_missing`).
- *
- * `refreshConnectorDefinitions()` re-syncs every org's EXISTING built-in
- * definition from the on-disk registry. This drives the real path against real
- * Postgres + the real bundled github connector source.
- *
- * Under test:
- *  1. An org with a STALE github def (no app_installation method) gets the
- *     app_installation method after refresh, with login_enabled preserved.
- *  2. The refresh is idempotent (a second run changes nothing observable).
- *  3. It does NOT install a connector into an org that didn't already have it.
+ * Connector-definition refresh (#14). Drives refreshConnectorDefinitions()
+ * against real Postgres + the real bundled github connector source.
  */
 
 import { beforeAll, beforeEach, describe, expect, test } from "bun:test";

--- a/packages/server/src/gateway/connections/webhook-ingest.ts
+++ b/packages/server/src/gateway/connections/webhook-ingest.ts
@@ -309,6 +309,21 @@ async function findExistingDeliveryId(
 }
 
 /**
+ * Caller-supplied projections for `events.title` / `events.source_url`.
+ *
+ * Connection ingest reads `events.title` from a static `config.titlePath` JSON
+ * pointer and never sets a source url. App-webhook deliveries (GitHub App) carry
+ * provider-specific shapes a single pointer can't express — a comment's title
+ * lives on its parent issue, the url is `html_url` on a different object per
+ * event type. The app-webhook router therefore extracts these per provider and
+ * passes them here; when set they take precedence over `config.titlePath`.
+ */
+export interface WebhookIngestOverrides {
+	title?: string | null;
+	sourceUrl?: string | null;
+}
+
+/**
  * Handle one inbound delivery for a `platform: "webhook"` connection.
  *
  * The caller passes the RAW stored row (config still holding `secret://`
@@ -321,6 +336,7 @@ export async function handleWebhookIngest(
 	request: Request,
 	secretStore: SecretStore,
 	peerAddress?: string | null,
+	overrides?: WebhookIngestOverrides,
 ): Promise<Response> {
 	const organizationId = stored.organizationId;
 	if (!organizationId) {
@@ -501,7 +517,13 @@ export async function handleWebhookIngest(
 			// store-only (watcher SQL) and out of semantic memory. The full
 			// payload always stays in payload_data; this is lossy-by-cap.
 			content: isSearchableEnabled(config) ? renderPayloadText(parsed) : null,
-			title: extractTitle(parsed, config.titlePath),
+			// Caller-supplied title/url (app-webhook provider extractor) win over the
+			// static config.titlePath pointer; both fall through to undefined/null.
+			title:
+				overrides?.title != null && overrides.title.length > 0
+					? overrides.title.slice(0, 500)
+					: extractTitle(parsed, config.titlePath),
+			sourceUrl: overrides?.sourceUrl ?? null,
 			occurredAt: new Date(),
 			metadata: {
 				webhook_connection_id: stored.id,

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -55,17 +55,12 @@ export interface AppWebhookTenant {
 }
 
 /**
- * Human-facing projections a plugin pulls off a delivery for the `events` row.
- * Without these the landed row has an empty `title`/`source_url` and the content
- * is only reachable by digging into `payload_data` (a watcher SQL slog and a
- * useless card). The provider knows where the title/url live per event type
- * (issue/PR/discussion vs. a comment, whose title is its parent's) — a single
- * config JSON pointer can't express that, so the extraction is per provider.
+ * `events.title` / `events.source_url` for the landed row. Extracted per
+ * provider, not via a config JSON pointer: a comment's title lives on its parent
+ * subject, so where the title/url live varies by event type.
  */
 export interface AppWebhookContent {
-	/** `events.title` — the issue/PR/discussion title (comment → its parent's). */
 	title?: string;
-	/** `events.source_url` — the `html_url` of the subject (or its parent). */
 	sourceUrl?: string;
 }
 
@@ -91,12 +86,7 @@ export interface AppWebhookProvider {
 	 * installation), in which case the router acks 200 without landing.
 	 */
 	extractTenant(rawBody: Uint8Array, headers: Headers): AppWebhookTenant | null;
-	/**
-	 * Pull the human-facing title + source url off the delivery for the landed
-	 * `events` row. Optional — a provider without a meaningful subject (or before
-	 * the extractor exists) simply omits it and the row keeps an empty
-	 * title/source_url. Pure over (rawBody, headers): multi-replica safe.
-	 */
+	/** Optional title/source_url for the landed row; omitted → empty fields. */
 	extractContent?(rawBody: Uint8Array, headers: Headers): AppWebhookContent;
 }
 

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -55,6 +55,21 @@ export interface AppWebhookTenant {
 }
 
 /**
+ * Human-facing projections a plugin pulls off a delivery for the `events` row.
+ * Without these the landed row has an empty `title`/`source_url` and the content
+ * is only reachable by digging into `payload_data` (a watcher SQL slog and a
+ * useless card). The provider knows where the title/url live per event type
+ * (issue/PR/discussion vs. a comment, whose title is its parent's) — a single
+ * config JSON pointer can't express that, so the extraction is per provider.
+ */
+export interface AppWebhookContent {
+	/** `events.title` — the issue/PR/discussion title (comment → its parent's). */
+	title?: string;
+	/** `events.source_url` — the `html_url` of the subject (or its parent). */
+	sourceUrl?: string;
+}
+
+/**
  * Per-provider verifier + tenant extractor. New providers (Slack, Jira) add a
  * plugin without touching the router — only GitHub ships in this PR.
  */
@@ -76,6 +91,13 @@ export interface AppWebhookProvider {
 	 * installation), in which case the router acks 200 without landing.
 	 */
 	extractTenant(rawBody: Uint8Array, headers: Headers): AppWebhookTenant | null;
+	/**
+	 * Pull the human-facing title + source url off the delivery for the landed
+	 * `events` row. Optional — a provider without a meaningful subject (or before
+	 * the extractor exists) simply omits it and the row keeps an empty
+	 * title/source_url. Pure over (rawBody, headers): multi-replica safe.
+	 */
+	extractContent?(rawBody: Uint8Array, headers: Headers): AppWebhookContent;
 }
 
 /** Parse the raw JSON body once; returns undefined on malformed JSON. */
@@ -85,6 +107,52 @@ function parseJson(rawBody: Uint8Array): unknown {
 	} catch {
 		return undefined;
 	}
+}
+
+/** Narrow an unknown JSON node to a string field, or undefined. */
+function strField(node: unknown, key: string): string | undefined {
+	if (node === null || typeof node !== "object") return undefined;
+	const value = (node as Record<string, unknown>)[key];
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Project a GitHub webhook payload to a human title + source url.
+ *
+ * GitHub event payloads put the subject under one of a handful of top-level
+ * keys, each with `title` + `html_url`:
+ *   - `issues`         → `issue.{title,html_url}`
+ *   - `pull_request`   → `pull_request.{title,html_url}`
+ *   - `discussion`     → `discussion.{title,html_url}`
+ * Comment events (`issue_comment`, `pull_request_review_comment`,
+ * `discussion_comment`, `commit_comment`) carry the comment under `comment`
+ * (whose `html_url` deep-links the comment) AND the parent subject alongside it
+ * (`issue`/`pull_request`/`discussion`) — the title belongs to the PARENT, so
+ * we read the title from the parent and prefer the comment's own `html_url`.
+ * Falls back across keys so a new comment-bearing event still lands a title.
+ */
+export function extractGithubWebhookContent(rawBody: Uint8Array): AppWebhookContent {
+	const body = parseJson(rawBody);
+	if (body === null || typeof body !== "object") return {};
+	const root = body as Record<string, unknown>;
+
+	// The subject the title comes from: a comment's parent, else the subject
+	// itself. Order matters only for the parent lookup — a payload has exactly
+	// one of these for a given event.
+	const subject =
+		root.issue ?? root.pull_request ?? root.discussion ?? root.release;
+	const comment = root.comment;
+
+	const title = strField(subject, "title");
+	// Prefer the comment's deep link when this is a comment event; else the
+	// subject's own url.
+	const sourceUrl =
+		strField(comment, "html_url") ?? strField(subject, "html_url");
+
+	const content: AppWebhookContent = {};
+	if (title) content.title = title;
+	if (sourceUrl) content.sourceUrl = sourceUrl;
+	return content;
 }
 
 /**
@@ -99,6 +167,10 @@ function parseJson(rawBody: Uint8Array): unknown {
  * is the receiving GitHub App (`GITHUB_APP_ID`), and the instance is 'cloud'
  * (GHES would be the host — out of scope here). A delivery with no
  * `installation.id` (rare app-level events) has no tenant to route to → null.
+ *
+ * Content: issue/PR/discussion title + html_url (a comment's title is its
+ * parent's; its url is the comment deep-link) populate `events.title` +
+ * `events.source_url` so the landed row is legible without digging payload_data.
  */
 export function createGithubAppWebhookProvider(options: {
 	/** Receiving GitHub App id, stamped as `provider_app_id`. */
@@ -130,6 +202,9 @@ export function createGithubAppWebhookProvider(options: {
 				providerAppId: options.appId,
 				externalTenantId,
 			};
+		},
+		extractContent(rawBody) {
+			return extractGithubWebhookContent(rawBody);
 		},
 	};
 }
@@ -287,12 +362,20 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 			body: rawBody,
 		});
 
+		// Project the delivery to a human title + source url for the landed row.
+		// Optional per provider; a miss leaves the row's title/source_url empty
+		// (the prior behaviour) rather than failing the delivery.
+		const content = provider.extractContent?.(rawBody, c.req.raw.headers);
+
 		try {
 			return await handleWebhookIngest(
 				synthesized,
 				ingestRequest,
 				deps.secretStore,
 				c.var.peerRemoteAddress,
+				content
+					? { title: content.title, sourceUrl: content.sourceUrl }
+					: undefined,
 			);
 		} catch (error) {
 			logger.error(

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -15,6 +15,7 @@ import { runWatcherAutomationTick } from '../watchers/automation';
 import { checkStalledExecutions } from './check-stalled-executions';
 import { runConnectorHealthCheck } from '../connectors/connector-health';
 import { runClassificationReconciliation } from './classification-reconciliation';
+import { refreshConnectorDefinitions } from './refresh-connector-definitions';
 import { registerScheduledJobsTicker } from './scheduled-jobs-service';
 import { TaskScheduler } from './task-scheduler';
 import { triggerEmbedBackfill } from './trigger-embed-backfill';
@@ -180,6 +181,24 @@ function registerMaintenanceTasks(
       logger.info({ ...result }, '[task] classification-reconciliation completed');
     },
     { cron: '*/5 * * * *' },
+  );
+
+  // Connector-definition refresh — re-syncs every org's existing built-in
+  // connector definition from the on-disk registry, so code-side schema changes
+  // (e.g. github gaining the app_installation auth method) reach orgs that
+  // installed the connector before the change. Idempotent; preserves org config
+  // (login_enabled / default_connection_config). Single-claimant per tick. The
+  // first tick after a deploy converges the fleet without an operator step;
+  // hourly thereafter is plenty since it only matters across releases.
+  scheduler.register(
+    'refresh-connector-definitions',
+    async () => {
+      const result = await refreshConnectorDefinitions();
+      if (result.refreshed > 0 || result.errored > 0) {
+        logger.info({ ...result }, '[task] refresh-connector-definitions completed');
+      }
+    },
+    { cron: '0 * * * *' },
   );
 
   // Watcher automation: reconcile in-flight runs, materialize newly-due runs,

--- a/packages/server/src/scheduled/refresh-connector-definitions.ts
+++ b/packages/server/src/scheduled/refresh-connector-definitions.ts
@@ -1,0 +1,146 @@
+/**
+ * Scheduled Job: Refresh built-in connector definitions.
+ *
+ * `connector_definitions` rows are per-org, point-in-time SNAPSHOTS of a
+ * connector's code-defined schema, written once when the org first adds the
+ * connector (`ensureConnectorInstalled`, which inserts only when no active row
+ * exists and never re-syncs an existing one). So when a bundled connector's code
+ * gains a capability — e.g. github gaining the `app_installation` auth method —
+ * orgs that installed it earlier keep the STALE schema. The GitHub App install
+ * callback then rejects with `github_connector_missing` because the org's
+ * `auth_schema` still lists only `[oauth, env_keys]` (see
+ * `gateway/routes/public/app-install.ts` hasAppInstallMethod).
+ *
+ * This task re-syncs every org's existing built-in definition from the on-disk
+ * connector registry: for each bundled connector key that some org has an active
+ * definition for, recompile the bundled source, extract its metadata, and upsert
+ * (`auth_schema`/`feeds_schema`/`actions_schema`/`version`/…) by
+ * `(organization_id, key)`. It is purely a refresh — it never installs a
+ * connector into an org that didn't already have it.
+ *
+ * Idempotent: a no-op once every row already matches code (the UPDATE just
+ * rewrites identical JSON). Org-specific config is preserved — the shared
+ * `upsertConnectorDefinitionRecords` UPDATE re-reads and writes back
+ * `login_enabled` and never touches `default_connection_config`.
+ *
+ * Multi-replica: runs as a single-claimant cron row in the runs queue (one pod
+ * per tick), reads/writes Postgres only, no per-pod state. Fires on the first
+ * scheduler tick after a deploy, so a schema-changing release converges without
+ * an operator step.
+ */
+
+import { getDb } from '../db/client';
+import {
+  compileConnectorFromFile,
+  findBundledConnectorFile,
+} from '../utils/connector-catalog';
+import {
+  extractConnectorMetadata,
+  validateConnectorMetadata,
+} from '../utils/connector-compiler';
+import { upsertConnectorDefinitionRecords } from '../utils/connector-definition-install';
+import logger from '../utils/logger';
+
+interface RefreshResult {
+  /** Distinct (org, key) active definitions considered. */
+  scanned: number;
+  /** Definitions whose schema was re-synced from code. */
+  refreshed: number;
+  /** Keys skipped because they have no bundled source on disk (user-uploaded). */
+  skippedNoSource: number;
+  /** Definitions that errored during recompile/upsert (logged, not fatal). */
+  errored: number;
+}
+
+interface DefRow {
+  organization_id: string;
+  key: string;
+}
+
+export async function refreshConnectorDefinitions(): Promise<RefreshResult> {
+  const sql = getDb();
+
+  // Every (org, key) that currently has an ACTIVE built-in definition. We only
+  // refresh what an org already installed — never auto-install a new connector.
+  const rows = (await sql`
+    SELECT DISTINCT organization_id, key
+    FROM connector_definitions
+    WHERE status = 'active'
+      AND organization_id IS NOT NULL
+    ORDER BY key
+  `) as unknown as DefRow[];
+
+  const result: RefreshResult = {
+    scanned: rows.length,
+    refreshed: 0,
+    skippedNoSource: 0,
+    errored: 0,
+  };
+
+  // Compile each bundled connector once per refresh (mtime-cached anyway) and
+  // reuse the metadata across every org that has that key. null = no bundled
+  // source (genuinely user-uploaded connector) — those carry no code to sync
+  // from, so they're left untouched.
+  const metadataByKey = new Map<
+    string,
+    Awaited<ReturnType<typeof extractConnectorMetadata>> | null
+  >();
+
+  for (const row of rows) {
+    let metadata = metadataByKey.get(row.key);
+    if (metadata === undefined) {
+      const filePath = findBundledConnectorFile(row.key);
+      if (!filePath) {
+        metadataByKey.set(row.key, null);
+        metadata = null;
+      } else {
+        try {
+          const compiled = await compileConnectorFromFile(filePath);
+          metadata = await extractConnectorMetadata(compiled);
+          validateConnectorMetadata(metadata);
+          metadataByKey.set(row.key, metadata);
+        } catch (err) {
+          logger.error(
+            { connector_key: row.key, err },
+            '[refresh-connector-definitions] Failed to compile bundled connector; skipping all orgs for this key'
+          );
+          metadataByKey.set(row.key, null);
+          metadata = null;
+        }
+      }
+    }
+
+    if (!metadata) {
+      result.skippedNoSource += 1;
+      continue;
+    }
+
+    try {
+      // Source row is NOT rewritten here (versionRecord all-null): the runtime
+      // recompiles bundled connectors from source_path on demand
+      // (resolveConnectorCode), so we only need the definition's schema columns
+      // re-synced. upsertConnectorDefinitionRecords' connector_versions upsert
+      // COALESCEs nulls, leaving any existing version row intact.
+      await upsertConnectorDefinitionRecords({
+        sql,
+        organizationId: row.organization_id,
+        metadata,
+        versionRecord: {
+          compiledCode: null,
+          compiledCodeHash: null,
+          sourceCode: null,
+          sourcePath: null,
+        },
+      });
+      result.refreshed += 1;
+    } catch (err) {
+      result.errored += 1;
+      logger.error(
+        { connector_key: row.key, organization_id: row.organization_id, err },
+        '[refresh-connector-definitions] Failed to refresh definition for org'
+      );
+    }
+  }
+
+  return result;
+}

--- a/packages/server/src/scheduled/refresh-connector-definitions.ts
+++ b/packages/server/src/scheduled/refresh-connector-definitions.ts
@@ -1,33 +1,9 @@
 /**
- * Scheduled Job: Refresh built-in connector definitions.
- *
- * `connector_definitions` rows are per-org point-in-time SNAPSHOTS of a
- * connector's code-defined schema, written once when the org first adds the
- * connector (`ensureConnectorInstalled`, which inserts only when no active row
- * exists and never re-syncs an existing one). So when a bundled connector's code
- * gains a capability — e.g. github gaining the `app_installation` auth method —
- * orgs that installed it earlier keep the STALE schema. The GitHub App install
- * callback then rejects with `github_connector_missing` because the org's
- * `auth_schema` still lists only `[oauth, env_keys]` (see
- * `gateway/routes/public/app-install.ts` hasAppInstallMethod).
- *
- * This task re-syncs every org's EXISTING built-in definition through the SAME
- * code→`connector_definitions` write path the install flow uses
- * (`upsertBundledConnectorForOrg` — there is no second writer): for each
- * `(organization_id, key)` that already has an active definition, recompile the
- * bundled source and upsert by `(organization_id, key)`. It is purely a refresh
- * — it never installs a connector into an org that didn't already have it (the
- * shared writer is only invoked for keys an org already holds).
- *
- * Idempotent: a no-op once every row already matches code (the UPDATE just
- * rewrites identical JSON). Org-specific config is preserved by the shared
- * upsert (`login_enabled` re-read and written back; `default_connection_config`
- * never touched).
- *
- * Multi-replica: runs as a single-claimant cron row in the runs queue (one pod
- * per tick), reads/writes Postgres only, no per-pod state. Fires on the first
- * scheduler tick after a deploy, so a schema-changing release converges without
- * an operator step.
+ * `connector_definitions` are per-org snapshots written once at install and
+ * never re-synced, so a connector gaining a capability in code (e.g. github's
+ * `app_installation` auth method) leaves earlier installers on a stale schema.
+ * This single-claimant cron re-syncs every org's EXISTING built-in definition
+ * through the install write path so a deploy converges without an operator step.
  */
 
 import { getDb } from '../db/client';

--- a/packages/server/src/scheduled/refresh-connector-definitions.ts
+++ b/packages/server/src/scheduled/refresh-connector-definitions.ts
@@ -1,7 +1,7 @@
 /**
  * Scheduled Job: Refresh built-in connector definitions.
  *
- * `connector_definitions` rows are per-org, point-in-time SNAPSHOTS of a
+ * `connector_definitions` rows are per-org point-in-time SNAPSHOTS of a
  * connector's code-defined schema, written once when the org first adds the
  * connector (`ensureConnectorInstalled`, which inserts only when no active row
  * exists and never re-syncs an existing one). So when a bundled connector's code
@@ -11,17 +11,18 @@
  * `auth_schema` still lists only `[oauth, env_keys]` (see
  * `gateway/routes/public/app-install.ts` hasAppInstallMethod).
  *
- * This task re-syncs every org's existing built-in definition from the on-disk
- * connector registry: for each bundled connector key that some org has an active
- * definition for, recompile the bundled source, extract its metadata, and upsert
- * (`auth_schema`/`feeds_schema`/`actions_schema`/`version`/…) by
- * `(organization_id, key)`. It is purely a refresh — it never installs a
- * connector into an org that didn't already have it.
+ * This task re-syncs every org's EXISTING built-in definition through the SAME
+ * code→`connector_definitions` write path the install flow uses
+ * (`upsertBundledConnectorForOrg` — there is no second writer): for each
+ * `(organization_id, key)` that already has an active definition, recompile the
+ * bundled source and upsert by `(organization_id, key)`. It is purely a refresh
+ * — it never installs a connector into an org that didn't already have it (the
+ * shared writer is only invoked for keys an org already holds).
  *
  * Idempotent: a no-op once every row already matches code (the UPDATE just
- * rewrites identical JSON). Org-specific config is preserved — the shared
- * `upsertConnectorDefinitionRecords` UPDATE re-reads and writes back
- * `login_enabled` and never touches `default_connection_config`.
+ * rewrites identical JSON). Org-specific config is preserved by the shared
+ * upsert (`login_enabled` re-read and written back; `default_connection_config`
+ * never touched).
  *
  * Multi-replica: runs as a single-claimant cron row in the runs queue (one pod
  * per tick), reads/writes Postgres only, no per-pod state. Fires on the first
@@ -30,15 +31,7 @@
  */
 
 import { getDb } from '../db/client';
-import {
-  compileConnectorFromFile,
-  findBundledConnectorFile,
-} from '../utils/connector-catalog';
-import {
-  extractConnectorMetadata,
-  validateConnectorMetadata,
-} from '../utils/connector-compiler';
-import { upsertConnectorDefinitionRecords } from '../utils/connector-definition-install';
+import { upsertBundledConnectorForOrg } from '../utils/ensure-connector-installed';
 import logger from '../utils/logger';
 
 interface RefreshResult {
@@ -77,61 +70,28 @@ export async function refreshConnectorDefinitions(): Promise<RefreshResult> {
     errored: 0,
   };
 
-  // Compile each bundled connector once per refresh (mtime-cached anyway) and
-  // reuse the metadata across every org that has that key. null = no bundled
-  // source (genuinely user-uploaded connector) — those carry no code to sync
-  // from, so they're left untouched.
-  const metadataByKey = new Map<
-    string,
-    Awaited<ReturnType<typeof extractConnectorMetadata>> | null
-  >();
+  // Keys already known to have no bundled source (genuinely user-uploaded) —
+  // skip the repeated registry lookup across the org rows sharing that key.
+  const noSourceKeys = new Set<string>();
 
   for (const row of rows) {
-    let metadata = metadataByKey.get(row.key);
-    if (metadata === undefined) {
-      const filePath = findBundledConnectorFile(row.key);
-      if (!filePath) {
-        metadataByKey.set(row.key, null);
-        metadata = null;
-      } else {
-        try {
-          const compiled = await compileConnectorFromFile(filePath);
-          metadata = await extractConnectorMetadata(compiled);
-          validateConnectorMetadata(metadata);
-          metadataByKey.set(row.key, metadata);
-        } catch (err) {
-          logger.error(
-            { connector_key: row.key, err },
-            '[refresh-connector-definitions] Failed to compile bundled connector; skipping all orgs for this key'
-          );
-          metadataByKey.set(row.key, null);
-          metadata = null;
-        }
-      }
-    }
-
-    if (!metadata) {
+    if (noSourceKeys.has(row.key)) {
       result.skippedNoSource += 1;
       continue;
     }
-
     try {
-      // Source row is NOT rewritten here (versionRecord all-null): the runtime
-      // recompiles bundled connectors from source_path on demand
-      // (resolveConnectorCode), so we only need the definition's schema columns
-      // re-synced. upsertConnectorDefinitionRecords' connector_versions upsert
-      // COALESCEs nulls, leaving any existing version row intact.
-      await upsertConnectorDefinitionRecords({
-        sql,
+      // SAME write path as install (upsertBundledConnectorForOrg): recompile
+      // bundled source → upsert this org's definition. compileConnectorFromFile
+      // is mtime-LRU-cached, so re-resolving the same key across orgs is cheap.
+      const refreshed = await upsertBundledConnectorForOrg({
         organizationId: row.organization_id,
-        metadata,
-        versionRecord: {
-          compiledCode: null,
-          compiledCodeHash: null,
-          sourceCode: null,
-          sourcePath: null,
-        },
+        connectorKey: row.key,
       });
+      if (!refreshed) {
+        noSourceKeys.add(row.key);
+        result.skippedNoSource += 1;
+        continue;
+      }
       result.refreshed += 1;
     } catch (err) {
       result.errored += 1;

--- a/packages/server/src/utils/ensure-connector-installed.ts
+++ b/packages/server/src/utils/ensure-connector-installed.ts
@@ -42,6 +42,48 @@ export async function resolveConnectorCode(
   throw new Error(`No compiled code for '${connectorKey}' and source not found on disk.`);
 }
 
+/**
+ * Compile the bundled connector for `connectorKey` and upsert its definition for
+ * one org from the on-disk registry: the single code→`connector_definitions`
+ * write path. `ensureConnectorInstalled` calls it on first install;
+ * `refreshConnectorDefinitions` calls it to re-sync an org's existing definition
+ * across deploys. Both share THIS body — there is no second writer.
+ *
+ * Stores `source_path` (not `compiled_code`) so the runtime recompiles from
+ * source on demand (`resolveConnectorCode`); the shared upsert preserves
+ * org-specific config (`login_enabled`, `default_connection_config`).
+ *
+ * Returns false when the key has no bundled source on disk (a genuinely
+ * user-uploaded connector — nothing to sync from). Throws on
+ * compile/extract/validate/write failure; callers decide how to handle it.
+ */
+export async function upsertBundledConnectorForOrg(params: {
+  organizationId: string;
+  connectorKey: string;
+}): Promise<boolean> {
+  const filePath = findBundledConnectorFile(params.connectorKey);
+  if (!filePath) return false;
+
+  // Compile to extract metadata (key, name, feeds, auth schema, etc.).
+  const compiledCode = await compileConnectorFromFile(filePath);
+  const metadata = await extractConnectorMetadata(compiledCode);
+  validateConnectorMetadata(metadata);
+
+  const sourcePath = bundledConnectorSourcePath(filePath);
+  await upsertConnectorDefinitionRecords({
+    sql: getDb(),
+    organizationId: params.organizationId,
+    metadata,
+    versionRecord: {
+      compiledCode: null,
+      compiledCodeHash: null,
+      sourceCode: null,
+      sourcePath,
+    },
+  });
+  return true;
+}
+
 export async function ensureConnectorInstalled(params: {
   organizationId: string;
   connectorKey: string;
@@ -56,33 +98,13 @@ export async function ensureConnectorInstalled(params: {
   `;
   if (existing.length > 0) return true;
 
-  const filePath = findBundledConnectorFile(params.connectorKey);
-  if (!filePath) return false;
-
   try {
-    // Compile temporarily to extract metadata (key, name, feeds, etc.)
-    const compiledCode = await compileConnectorFromFile(filePath);
-    const metadata = await extractConnectorMetadata(compiledCode);
-    validateConnectorMetadata(metadata);
-
-    const sourcePath = bundledConnectorSourcePath(filePath);
-    await upsertConnectorDefinitionRecords({
-      sql,
-      organizationId: params.organizationId,
-      metadata,
-      versionRecord: {
-        compiledCode: null,
-        compiledCodeHash: null,
-        sourceCode: null,
-        sourcePath,
-      },
-    });
-
+    const installed = await upsertBundledConnectorForOrg(params);
+    if (!installed) return false;
     logger.info(
       {
         connector_key: params.connectorKey,
         organization_id: params.organizationId,
-        source_path: sourcePath,
       },
       'Auto-installed bundled connector for org (source_path only, no compiled_code)'
     );


### PR DESCRIPTION
## #14 — connector-definition refresh + github webhook extractor polish

### Goal A — connector-definition refresh
`connector_definitions` rows are per-org point-in-time snapshots of a connector's code-defined schema, written once at first install (`ensureConnectorInstalled` inserts only when no active row exists, then never re-syncs). So an org that added `github` before the connector gained the `app_installation` auth method keeps a stale `auth_schema` (`[oauth, env_keys]`), and the GitHub App install callback rejects it with `github_connector_missing` (`app-install.ts` `hasAppInstallMethod`).

**Mechanism chosen:** a new `refresh-connector-definitions` scheduled maintenance task (registered in `scheduled/jobs.ts`, cron `0 * * * *`). It re-syncs every org's *existing* built-in definition from the on-disk connector registry:
- query distinct active `(organization_id, key)` definitions
- for each bundled key, recompile the bundled source once (mtime-cached), `extractConnectorMetadata` + `validateConnectorMetadata`
- `upsertConnectorDefinitionRecords` per org → re-syncs `auth_schema`/`feeds_schema`/`actions_schema`/`options_schema`/`mcp_config`/`openapi_config`/`version`/etc.

**Why a scheduled task (not boot-time / apply-step):**
- multi-replica safe by construction — runs as a single-claimant cron row in the runs queue (one pod per tick), reads/writes Postgres only, no per-pod state. Matches the existing `connection-health` / `trigger-embed-backfill` pattern.
- fires on the first scheduler tick after a deploy, so a schema-changing release converges the whole fleet with no operator step; hourly thereafter (only matters across releases).
- reuses the already-correct shared upsert, which preserves `login_enabled` and never touches `default_connection_config`.

**Idempotent / non-clobbering:** a no-op once rows match code; `login_enabled` is re-read and written back, `default_connection_config` is never in the UPDATE SET list; `connector_versions` upsert COALESCEs nulls so existing version rows stay intact. Never installs a connector into an org that didn't already have it (refresh-only).

### Goal B — github webhook extractor polish
GitHub app-webhook deliveries landed with empty `title` + `source_url` (content only in `payload_data`). Added an optional `extractContent()` to the `AppWebhookProvider` plugin and implemented it for github: issue/PR/discussion title + `html_url`; comment events take the title from the parent subject and the url from the comment deep-link. Threaded into `handleWebhookIngest` via a new `WebhookIngestOverrides` param that takes precedence over the static `config.titlePath` pointer (a single JSON pointer can't express "comment title = parent's title").

### Tests
- `refresh-connector-definitions.test.ts` (real PG + real bundled github source): a stale github def gains the `app_installation` method after refresh, `login_enabled` preserved, version bumped off `0.0.1`; idempotent; no cross-org install.
- `app-webhooks.test.ts` extended: `issues` lands non-empty title + `source_url`; `issue_comment` lands the parent issue title + the comment deep-link url; `pull_request` lands the PR title + url.

```
refresh-connector-definitions.test.ts   3 pass / 0 fail
app-webhooks.test.ts                    12 pass / 0 fail
app-installation-e2e.test.ts            10 pass / 0 fail
packages/server bunx tsc --noEmit       0 errors
```

### Migration / schema
None. `events.title` and `events.source_url` already exist; `insertEvent` already accepts `sourceUrl`. No new tables/columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ug5cEnCRt1VHn8w3gNXAu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784736290&installation_id=136316292&pr_number=1467&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1467&signature=3919ac67f7553c66e8c795f0e09c20be9be71241ad8ffe5423de949cf2735b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook events now automatically extract and store title and source URL information from GitHub issues, pull requests, and comments for improved tracking.
  * Connector definitions refresh automatically on an hourly schedule to stay current with latest configurations and authentication methods.
  * Enhanced GitHub webhook processing enables richer event data extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->