### PR TITLE
feat(windows): flag-gated window-membership reads from event_edges — list path (P6 phase 3a)

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/window-membership-read.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/window-membership-read.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Windows-as-events (P6) phase 3: the content-search window-membership reads (the window_id
+ * filter — windowJoinSql + buildStandardWhereSql + the list-path EXISTS) read from the
+ * event_edges mirror (parent_event_id = window id, edge_type='membership') instead of
+ * watcher_window_events, behind WATCHER_WINDOWS_VIA_EVENT_EDGES. This proves the two paths return
+ * the SAME content for a window_id filter — the flag selects the source, not the result.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { searchContentByText } from '../../../utils/content-search';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestAgent,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+describe('window-membership read flip equivalence (P6 phase 3)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+  afterEach(() => {
+    delete process.env.WATCHER_WINDOWS_VIA_EVENT_EDGES;
+  });
+
+  it('the window_id filter returns the same content from the table and the event_edges mirror', async () => {
+    const org = await createTestOrganization({ name: 'Win Org' });
+    const user = await createTestUser({ email: 'win@test.com' });
+    const entity = await createTestEntity({
+      organization_id: org.id,
+      created_by: user.id,
+      name: 'WinEntity',
+    });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+
+    const mkEvent = async (slug: string, text: string) => {
+      const [e] = (await sql`
+        INSERT INTO events (organization_id, semantic_type, entity_ids, origin_id, payload_text, occurred_at, created_at)
+        VALUES (${org.id}, 'content', ARRAY[${Number(entity.id)}]::bigint[], ${slug}, ${text}, NOW(), NOW())
+        RETURNING id
+      `) as Array<{ id: number }>;
+      return Number(e.id);
+    };
+    const inWin = await mkEvent('win_in', 'in window content');
+    await mkEvent('win_out', 'out of window content'); // entity-linked but NOT in the window
+
+    const watcherId = 960000;
+    await sql`
+      INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+      VALUES (${watcherId}, 'w', 'w-win', ${user.id}, ${org.id}, ${agent.agentId}, ${watcherId})
+    `;
+    const windowId = 960001;
+    await sql`
+      INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+      VALUES (${windowId}, ${watcherId}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+    `;
+    // Link the in-window event — the phase-1 trigger populates the event_edges membership edge.
+    await sql`INSERT INTO watcher_window_events (window_id, event_id) VALUES (${windowId}, ${inWin})`;
+
+    const runList = async () => {
+      const res = await searchContentByText(null, {
+        organization_id: org.id,
+        entity_id: Number(entity.id),
+        window_id: windowId,
+        limit: 50,
+      });
+      return res.content.map((c) => Number(c.id)).sort((a, b) => a - b);
+    };
+
+    delete process.env.WATCHER_WINDOWS_VIA_EVENT_EDGES;
+    const off = await runList();
+    process.env.WATCHER_WINDOWS_VIA_EVENT_EDGES = '1';
+    const on = await runList();
+
+    expect(off).toEqual([inWin]); // the table path returns only the in-window event
+    expect(on).toEqual(off); // the event_edges path returns the identical set
+  });
+});

--- a/packages/server/src/utils/content-search/list-path.ts
+++ b/packages/server/src/utils/content-search/list-path.ts
@@ -32,7 +32,12 @@ import {
   type ContentSearchResult,
 } from './types';
 import { buildConnectionVisibilityClause, buildExcludeWatcherClause, buildOrgScopeWhere } from './visibility';
-import { buildStandardParams, buildStandardWhereSql, WINDOW_JOIN_SQL } from './params';
+import {
+  buildStandardParams,
+  buildStandardWhereSql,
+  windowJoinSql,
+  windowMembershipViaEventEdges,
+} from './params';
 
 /**
  * Shared count + query-pair execution for both `listContentInternal` branches.
@@ -293,7 +298,9 @@ export async function listContentInternal(
     if (options.window_id != null) {
       baseParams.push(options.window_id);
       baseConditions.push(
-        `EXISTS (SELECT 1 FROM watcher_window_events iwf WHERE iwf.event_id = f.id AND iwf.window_id = $${baseParams.length})`
+        windowMembershipViaEventEdges()
+          ? `EXISTS (SELECT 1 FROM event_edges iwf WHERE iwf.child_event_id = f.id AND iwf.parent_event_id = $${baseParams.length} AND iwf.edge_type = 'membership')`
+          : `EXISTS (SELECT 1 FROM watcher_window_events iwf WHERE iwf.event_id = f.id AND iwf.window_id = $${baseParams.length})`
       );
     }
     if (options.engagement_min != null) {
@@ -423,7 +430,7 @@ export async function listContentInternal(
 
   return executeListQuery({
     sql,
-    joinSql: WINDOW_JOIN_SQL,
+    joinSql: windowJoinSql(),
     whereExpr: `${standardWhereSql}
           AND ${connectionCondition}
           AND ${feedCondition}

--- a/packages/server/src/utils/content-search/params.ts
+++ b/packages/server/src/utils/content-search/params.ts
@@ -47,12 +47,30 @@ export function buildStandardParams(
  * passing it in avoids re-emitting (and re-planning) the 7-branch generic
  * UNION for every query.
  */
+/**
+ * Windows-as-events (P6) phase 3: read window MEMBERSHIP from the event_edges mirror
+ * (parent_event_id = window id, child_event_id = content event id, edge_type='membership')
+ * instead of the watcher_window_events table, when WATCHER_WINDOWS_VIA_EVENT_EDGES is set.
+ * event_edges is an accurate mirror (the phase-1 trigger syncs INSERT+DELETE + the backfill), so
+ * the window-membership JOIN + its filter are equivalent. FLAG-GATED for a staged cutover (default
+ * OFF = the table). The `iwf` alias is shared by `windowJoinSql()` and `buildStandardWhereSql`, so
+ * both flip together: the window-id column is `window_id` on the table, `parent_event_id` on the
+ * mirror. DEPLOY GATE: run scripts/backfill-event-edges.sh before enabling.
+ */
+export function windowMembershipViaEventEdges(): boolean {
+  return (
+    process.env.WATCHER_WINDOWS_VIA_EVENT_EDGES === '1' ||
+    process.env.WATCHER_WINDOWS_VIA_EVENT_EDGES === 'true'
+  );
+}
+
 export function buildStandardWhereSql(entityLinkSql: string): string {
+  const windowCol = windowMembershipViaEventEdges() ? 'iwf.parent_event_id' : 'iwf.window_id';
   return `($1::bigint IS NULL OR ${entityLinkSql})
           AND ($2::text IS NULL OR f.connector_key = $2::text)
           AND ($3::timestamptz IS NULL OR f.occurred_at >= $3::timestamptz)
           AND ($4::timestamptz IS NULL OR f.occurred_at <= $4::timestamptz)
-          AND ($5::int IS NULL OR iwf.window_id = $5::int)
+          AND ($5::int IS NULL OR ${windowCol} = $5::int)
           AND ($6::numeric IS NULL OR f.score >= $6::numeric)
           AND ($7::numeric IS NULL OR f.score <= $7::numeric)
           AND ($8::text IS NULL OR EXISTS (
@@ -65,7 +83,16 @@ export function buildStandardWhereSql(entityLinkSql: string): string {
           AND ($11::text IS NULL OR f.metadata->>'agent_id' = $11::text)`;
 }
 
-export const WINDOW_JOIN_SQL = `LEFT JOIN watcher_window_events iwf
+export function windowJoinSql(): string {
+  if (windowMembershipViaEventEdges()) {
+    return `LEFT JOIN event_edges iwf
+          ON iwf.child_event_id = f.id
+          AND ($5::int IS NOT NULL)
+          AND iwf.parent_event_id = $5::int
+          AND iwf.edge_type = 'membership'`;
+  }
+  return `LEFT JOIN watcher_window_events iwf
           ON iwf.event_id = f.id
           AND ($5::int IS NOT NULL)
           AND iwf.window_id = $5::int`;
+}


### PR DESCRIPTION
## What

**Windows-as-events (P6) phase 3a — window-membership read flip (list path)**, stacked on #1456.
This is the `window_id`-membership read (filter content to a specific window), distinct from the
`exclude_watcher_id` reads already flipped in #1456. Flips the **shared** list-path helpers to read
`event_edges` (`parent_event_id` = window id, `edge_type='membership'`) instead of
`watcher_window_events`, behind `WATCHER_WINDOWS_VIA_EVENT_EDGES` (default off):

- `params.ts`: `WINDOW_JOIN_SQL` const → `windowJoinSql()` fn + `buildStandardWhereSql`'s window
  column. The `iwf` alias is shared by the JOIN and its WHERE filter, so both flip together
  (`window_id` on the table, `parent_event_id` on the mirror).
- `list-path.ts`: the inline membership EXISTS + the `joinSql` usage routed through the helpers.

`event_edges` is an accurate mirror (phase-1 trigger + backfill), so the reads are **equivalent**.
Multi-replica-safe at any flag value. DEPLOY GATE: backfill before flag-on.

## Tests

`window-membership-read.test.ts`: a `window_id` filter returns the **identical** content set from
the table and the `event_edges` mirror (in-window event matched, out-of-window excluded, both flag
states). 83 events-suite tests green (flag off = unchanged).

## Remaining (same flag, before it's enabled)

The other `window_id` sites — `search-path.ts` (×3 + its `$6` WHERE), `get_content/query.ts` (×2),
`get_watchers.ts` window-stats, `shared.ts`, `index.ts` — flip behind the same flag in follow-ons;
then the write-flips (`complete-window`, `entity-management`) and the DROP. (The audit mapped every
site file:line → target SQL.)

Base = `feat/event-edges-p2-read` (#1456). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784737029&installation_id=136316292&pr_number=1469&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1469&signature=296ce8394cec4bf5b0b1fa1dcacb24d230ad9ce68cfc95a6e1f088a14d6148f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->