### PR TITLE
feat(windows): flag-gated window-membership reads — search + get_content (P6 phase 3b)

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/window-membership-read.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/window-membership-read.test.ts
@@ -78,4 +78,56 @@ describe('window-membership read flip equivalence (P6 phase 3)', () => {
     expect(off).toEqual([inWin]); // the table path returns only the in-window event
     expect(on).toEqual(off); // the event_edges path returns the identical set
   });
+
+  it('the search path (text query + window_id) returns the same content from table and event_edges', async () => {
+    const org = await createTestOrganization({ name: 'Win Search Org' });
+    const user = await createTestUser({ email: 'winsearch@test.com' });
+    const entity = await createTestEntity({
+      organization_id: org.id,
+      created_by: user.id,
+      name: 'WinSearchEntity',
+    });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+
+    const mkEvent = async (slug: string, text: string) => {
+      const [e] = (await sql`
+        INSERT INTO events (organization_id, semantic_type, entity_ids, origin_id, payload_text, occurred_at, created_at)
+        VALUES (${org.id}, 'content', ARRAY[${Number(entity.id)}]::bigint[], ${slug}, ${text}, NOW(), NOW())
+        RETURNING id
+      `) as Array<{ id: number }>;
+      return Number(e.id);
+    };
+    const inWin = await mkEvent('ws_in', 'galaxander widget report');
+    await mkEvent('ws_out', 'galaxander widget summary'); // matches the query but NOT in the window
+
+    const watcherId = 960100;
+    await sql`
+      INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+      VALUES (${watcherId}, 'w', 'w-winsearch', ${user.id}, ${org.id}, ${agent.agentId}, ${watcherId})
+    `;
+    const windowId = 960101;
+    await sql`
+      INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+      VALUES (${windowId}, ${watcherId}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+    `;
+    await sql`INSERT INTO watcher_window_events (window_id, event_id) VALUES (${windowId}, ${inWin})`;
+
+    const runSearch = async () => {
+      const res = await searchContentByText('galaxander', {
+        organization_id: org.id,
+        entity_id: Number(entity.id),
+        window_id: windowId,
+        limit: 50,
+      });
+      return res.content.map((c) => Number(c.id)).sort((a, b) => a - b);
+    };
+
+    delete process.env.WATCHER_WINDOWS_VIA_EVENT_EDGES;
+    const off = await runSearch();
+    process.env.WATCHER_WINDOWS_VIA_EVENT_EDGES = '1';
+    const on = await runSearch();
+
+    expect(off).toEqual([inWin]); // the search path filtered to the in-window match
+    expect(on).toEqual(off); // event_edges path identical
+  });
 });

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -11,6 +11,7 @@ import {
   excludeWatcherNotExists,
   fetchEntityIdentityScopes,
 } from '../../utils/content-search';
+import { windowMembershipViaEventEdges } from '../../utils/content-search/params';
 import logger from '../../utils/logger';
 import { validateNumericId } from '../../utils/sql-validation';
 import type { GetContentArgs } from './schema';
@@ -291,7 +292,9 @@ export async function fetchIncludeSuperseded(opts: {
   }
   if (args.window_id !== undefined) {
     conditions.push(
-      `EXISTS (SELECT 1 FROM watcher_window_events iwf WHERE iwf.event_id = e.id AND iwf.window_id = $${paramIndex})`
+      windowMembershipViaEventEdges()
+        ? `EXISTS (SELECT 1 FROM event_edges iwf WHERE iwf.child_event_id = e.id AND iwf.parent_event_id = $${paramIndex} AND iwf.edge_type = 'membership')`
+        : `EXISTS (SELECT 1 FROM watcher_window_events iwf WHERE iwf.event_id = e.id AND iwf.window_id = $${paramIndex})`
     );
     queryParams.push(args.window_id);
     paramIndex += 1;
@@ -454,7 +457,9 @@ export async function fetchClassificationStats(opts: {
   }
   let windowJoinSql = '';
   if (args.window_id) {
-    windowJoinSql = `JOIN watcher_window_events iwf ON iwf.event_id = f.id AND iwf.window_id = $${paramIndex}`;
+    windowJoinSql = windowMembershipViaEventEdges()
+      ? `JOIN event_edges iwf ON iwf.child_event_id = f.id AND iwf.parent_event_id = $${paramIndex} AND iwf.edge_type = 'membership'`
+      : `JOIN watcher_window_events iwf ON iwf.event_id = f.id AND iwf.window_id = $${paramIndex}`;
     params.push(args.window_id);
     paramIndex++;
   }

--- a/packages/server/src/utils/content-search/search-path.ts
+++ b/packages/server/src/utils/content-search/search-path.ts
@@ -30,6 +30,26 @@ import {
   type ContentSearchResponse,
   type ContentSearchResult,
 } from './types';
+import { windowMembershipViaEventEdges } from './params';
+
+/**
+ * Windows-as-events (P6) phase 3: the search-path window-membership LEFT JOIN ($6 = window id),
+ * reading event_edges (parent_event_id = window id, edge_type='membership') when
+ * WATCHER_WINDOWS_VIA_EVENT_EDGES is set, else watcher_window_events. The `iwf` alias is shared
+ * with the standardFiltersSQL WHERE, so the window-id column flips in lockstep.
+ */
+function searchWindowMembershipJoin(): string {
+  return windowMembershipViaEventEdges()
+    ? `LEFT JOIN event_edges iwf
+          ON iwf.child_event_id = f.id
+          AND ($6::int IS NOT NULL)
+          AND iwf.parent_event_id = $6::int
+          AND iwf.edge_type = 'membership'`
+    : `LEFT JOIN watcher_window_events iwf
+          ON iwf.event_id = f.id
+          AND ($6::int IS NOT NULL)
+          AND iwf.window_id = $6::int`;
+}
 import { buildConnectionVisibilityClause, buildExcludeWatcherClause, buildOrgScopeWhere } from './visibility';
 
 export async function searchContentBySingleQuery(
@@ -150,6 +170,7 @@ export async function searchContentBySingleQuery(
   // present) so a hostile float can't break out of the comparison expression.
   const minSimilarityParamIdx = baseParamIdx + (hasEmbedding ? 1 : 0);
 
+  const win6Col = windowMembershipViaEventEdges() ? 'iwf.parent_event_id' : 'iwf.window_id';
   const standardFiltersSQL = `($2::bigint IS NULL OR ${searchEntityLinkSql})
           AND ${connectionCondition}
           AND ${feedCondition}
@@ -157,7 +178,7 @@ export async function searchContentBySingleQuery(
           AND ($3::text IS NULL OR f.connector_key = $3::text)
           AND ($4::timestamptz IS NULL OR f.occurred_at >= $4::timestamptz)
           AND ($5::timestamptz IS NULL OR f.occurred_at <= $5::timestamptz)
-          AND ($6::int IS NULL OR iwf.window_id = $6::int)
+          AND ($6::int IS NULL OR ${win6Col} = $6::int)
           AND ($7::numeric IS NULL OR f.score >= $7::numeric)
           AND ($8::numeric IS NULL OR f.score <= $8::numeric)
           AND ($9::text[] IS NULL OR f.semantic_type = ANY($9::text[]))
@@ -307,10 +328,7 @@ export async function searchContentBySingleQuery(
     // (useDateFeed is false here, so there is no cursor block before it).
     const tsqueryParamIdx = offsetParamIdx + 1;
     const candidateFilterJoins = `LEFT JOIN connections c ON c.id = f.connection_id
-          LEFT JOIN watcher_window_events iwf
-            ON iwf.event_id = f.id
-            AND ($6::int IS NOT NULL)
-            AND iwf.window_id = $6::int`;
+          ${searchWindowMembershipJoin()}`;
     const branches: string[] = [];
     // ivfflat ANN — the only shape that index serves. Multi-vector: the ANN now
     // ranks CHUNK rows, so over-fetch chunks then collapse to distinct events by
@@ -367,10 +385,7 @@ export async function searchContentBySingleQuery(
         FROM current_event_records f
         ${useCandidatePath ? 'JOIN search_candidates sc ON sc.id = f.id' : ''}
         LEFT JOIN connections c ON c.id = f.connection_id
-        LEFT JOIN watcher_window_events iwf
-          ON iwf.event_id = f.id
-          AND ($6::int IS NOT NULL)
-          AND iwf.window_id = $6::int
+        ${searchWindowMembershipJoin()}
         WHERE ${useCandidatePath ? standardFiltersSQL : searchWhereSQL}
       )`;
 
@@ -380,10 +395,7 @@ export async function searchContentBySingleQuery(
         SELECT f.id, f.score, f.occurred_at, f.title, f.payload_text, ${bestSimSelect} AS best_sim, f.search_tsv
         FROM current_event_records f
         LEFT JOIN connections c ON c.id = f.connection_id
-        LEFT JOIN watcher_window_events iwf
-          ON iwf.event_id = f.id
-          AND ($6::int IS NOT NULL)
-          AND iwf.window_id = $6::int
+        ${searchWindowMembershipJoin()}
         WHERE ${searchWhereSQL}
       ),
       full_count AS (


### PR DESCRIPTION
## What

**P6 phase 3b — window-membership reads (search + get_content)**, stacked on #1469. Continues the
`window_id` membership flip behind `WATCHER_WINDOWS_VIA_EVENT_EDGES`:

- `search-path.ts`: a local `searchWindowMembershipJoin()` helper (`$6` window id) replaces the 3
  inline LEFT JOINs; the `standardFiltersSQL` window column flips in lockstep (`searchWhereSQL`
  includes `standardFiltersSQL`, so both query shapes are covered by one column flip).
- `get_content/query.ts`: the `window_id` EXISTS (content_ids branch) + the window JOIN
  (include_superseded branch).

`event_edges` is an accurate mirror, so the reads are **equivalent**; multi-replica-safe at any flag.

## Tests

`window-membership-read.test.ts` now covers **both the list path AND the search path** (text query):
each returns the identical content set for a `window_id` filter, table vs `event_edges`, both flag
states. 83 events-suite tests green (flag off = unchanged).

## Remaining for P6 drop

3 display/admin reads (`get_watchers` window-stats, `shared.ts` analyzed_count, `index.ts` window
detail) in 3c, then the write-flips (`complete-window`, `entity-management`) and the DROP.

Base = `feat/event-edges-p3-window-reads` (#1469). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784737527&installation_id=136316292&pr_number=1472&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1472&signature=63c9c8ea97e87671f444c92713afb38f8abebc9b640e256a014b329e4cf3f8d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->