### PR TITLE
feat(windows): flag-gated window-membership display reads from event_edges (P6 phase 3c)

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/window-display-counts.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/window-display-counts.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Windows-as-events (P6) phase 3c: the display/admin window reads (get_watchers classification
+ * stats, shared.ts analyzed_count, index.ts window content_count) flip iwc/iwf from
+ * watcher_window_events to event_edges with aggregate column renames (COUNT(event_id) ->
+ * COUNT(child_event_id), window_id -> parent_event_id). This proves the renames preserve the
+ * COUNTS — the rename risk — by running the membership-count + classification-stats shapes both
+ * ways and asserting identical results.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createTestAgent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+describe('window display-count read flip equivalence (P6 phase 3c)', () => {
+  it('membership COUNT + classification stats are identical from the table and event_edges', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'WinCount Org' });
+    const user = await createTestUser({ email: 'wincount@test.com' });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+
+    const mkEvent = async (slug: string) => {
+      const [e] = (await sql`
+        INSERT INTO events (organization_id, semantic_type, origin_id, payload_text, occurred_at, created_at)
+        VALUES (${org.id}, 'content', ${slug}, 'content', NOW(), NOW())
+        RETURNING id
+      `) as Array<{ id: number }>;
+      return Number(e.id);
+    };
+    const e1 = await mkEvent('wc_1');
+    const e2 = await mkEvent('wc_2');
+    await mkEvent('wc_unlinked'); // NOT in the window
+
+    const watcherId = 961000;
+    await sql`
+      INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+      VALUES (${watcherId}, 'w', 'w-wc', ${user.id}, ${org.id}, ${agent.agentId}, ${watcherId})
+    `;
+    const windowId = 961001;
+    await sql`
+      INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+      VALUES (${windowId}, ${watcherId}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+    `;
+    // Link e1 + e2 → the phase-1 trigger populates 2 event_edges membership edges.
+    await sql`INSERT INTO watcher_window_events (window_id, event_id) VALUES (${windowId}, ${e1}), (${windowId}, ${e2})`;
+
+    // index/shared shape: COUNT of window content via each source.
+    const countTable = (await sql`
+      SELECT CAST(COUNT(iwf.event_id) AS INTEGER) AS n
+      FROM watcher_windows iw
+      LEFT JOIN watcher_window_events iwf ON iwf.window_id = iw.id
+      WHERE iw.id = ${windowId}
+    `) as Array<{ n: number }>;
+    const countEdges = (await sql`
+      SELECT CAST(COUNT(iwf.child_event_id) AS INTEGER) AS n
+      FROM watcher_windows iw
+      LEFT JOIN event_edges iwf ON iwf.parent_event_id = iw.id AND iwf.edge_type = 'membership'
+      WHERE iw.id = ${windowId}
+    `) as Array<{ n: number }>;
+    expect(countEdges[0].n).toBe(countTable[0].n);
+    expect(countTable[0].n).toBe(2);
+
+    // shared analyzed_count shape: COUNT(DISTINCT content) across a watcher's windows.
+    const distTable = (await sql`
+      SELECT CAST(COUNT(DISTINCT iwc.event_id) AS INTEGER) AS n
+      FROM watcher_windows iw
+      LEFT JOIN watcher_window_events iwc ON iwc.window_id = iw.id
+      WHERE iw.watcher_id = ${watcherId}
+    `) as Array<{ n: number }>;
+    const distEdges = (await sql`
+      SELECT CAST(COUNT(DISTINCT iwc.child_event_id) AS INTEGER) AS n
+      FROM watcher_windows iw
+      LEFT JOIN event_edges iwc ON iwc.parent_event_id = iw.id AND iwc.edge_type = 'membership'
+      WHERE iw.watcher_id = ${watcherId}
+    `) as Array<{ n: number }>;
+    expect(distEdges[0].n).toBe(distTable[0].n);
+    expect(distTable[0].n).toBe(2);
+
+    // get_watchers stats shape: a classifier label on e1 → per-(window,classifier,value) count.
+    const [cls] = (await sql`
+      INSERT INTO event_classifiers (slug, name, attribute_key, created_by, organization_id, status)
+      VALUES ('wc-cls', 'WC', 'attr', ${user.id}, ${org.id}, 'active') RETURNING id
+    `) as Array<{ id: number }>;
+    const [ver] = (await sql`
+      INSERT INTO event_classifier_versions (classifier_id, version, is_current, attribute_values, created_by)
+      VALUES (${Number(cls.id)}, 1, true, '[]'::jsonb, ${user.id}) RETURNING id
+    `) as Array<{ id: number }>;
+    await sql`
+      INSERT INTO event_classifications (event_id, classifier_version_id, "values", source)
+      VALUES (${e1}, ${Number(ver.id)}, ARRAY['high'], 'embedding')
+    `;
+
+    const statsTable = (await sql`
+      SELECT iwc.window_id AS window_id, cc.slug AS slug, value AS value, CAST(COUNT(*) AS INTEGER) AS count
+      FROM watcher_window_events iwc
+      JOIN event_classifications cls ON iwc.event_id = cls.event_id
+      JOIN event_classifier_versions ccv ON cls.classifier_version_id = ccv.id
+      JOIN event_classifiers cc ON ccv.classifier_id = cc.id
+      CROSS JOIN unnest(cls."values") AS t(value)
+      WHERE iwc.window_id IN (${windowId})
+      GROUP BY iwc.window_id, cc.slug, value
+    `) as Array<{ window_id: number; slug: string; value: string; count: number }>;
+    const statsEdges = (await sql`
+      SELECT iwc.parent_event_id AS window_id, cc.slug AS slug, value AS value, CAST(COUNT(*) AS INTEGER) AS count
+      FROM event_edges iwc
+      JOIN event_classifications cls ON iwc.child_event_id = cls.event_id
+      JOIN event_classifier_versions ccv ON cls.classifier_version_id = ccv.id
+      JOIN event_classifiers cc ON ccv.classifier_id = cc.id
+      CROSS JOIN unnest(cls."values") AS t(value)
+      WHERE iwc.parent_event_id IN (${windowId}) AND iwc.edge_type = 'membership'
+      GROUP BY iwc.parent_event_id, cc.slug, value
+    `) as Array<{ window_id: number; slug: string; value: string; count: number }>;
+    expect(statsEdges).toEqual(statsTable);
+    expect(statsTable).toEqual([{ window_id: windowId, slug: 'wc-cls', value: 'high', count: 1 }]);
+  });
+});

--- a/packages/server/src/__tests__/integration/watchers/window-membership-read.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/window-membership-read.test.ts
@@ -130,4 +130,57 @@ describe('window-membership read flip equivalence (P6 phase 3)', () => {
     expect(off).toEqual([inWin]); // the search path filtered to the in-window match
     expect(on).toEqual(off); // event_edges path identical
   });
+
+  it('the score-sort path (sort_by=score + window_id) returns the same content from table and event_edges', async () => {
+    const org = await createTestOrganization({ name: 'Win Score Org' });
+    const user = await createTestUser({ email: 'winscore@test.com' });
+    const entity = await createTestEntity({
+      organization_id: org.id,
+      created_by: user.id,
+      name: 'WinScoreEntity',
+    });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+
+    const mkEvent = async (slug: string) => {
+      const [e] = (await sql`
+        INSERT INTO events (organization_id, semantic_type, entity_ids, origin_id, payload_text, score, occurred_at, created_at)
+        VALUES (${org.id}, 'content', ARRAY[${Number(entity.id)}]::bigint[], ${slug}, 'scored', 5, NOW(), NOW())
+        RETURNING id
+      `) as Array<{ id: number }>;
+      return Number(e.id);
+    };
+    const inWin = await mkEvent('sc_in');
+    await mkEvent('sc_out'); // entity-linked, not in the window
+
+    const watcherId = 962000;
+    await sql`
+      INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+      VALUES (${watcherId}, 'w', 'w-winscore', ${user.id}, ${org.id}, ${agent.agentId}, ${watcherId})
+    `;
+    const windowId = 962001;
+    await sql`
+      INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+      VALUES (${windowId}, ${watcherId}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+    `;
+    await sql`INSERT INTO watcher_window_events (window_id, event_id) VALUES (${windowId}, ${inWin})`;
+
+    const runScore = async () => {
+      const res = await searchContentByText(null, {
+        organization_id: org.id,
+        entity_id: Number(entity.id),
+        window_id: windowId,
+        sort_by: 'score',
+        limit: 50,
+      });
+      return res.content.map((c) => Number(c.id)).sort((a, b) => a - b);
+    };
+
+    delete process.env.WATCHER_WINDOWS_VIA_EVENT_EDGES;
+    const off = await runScore();
+    process.env.WATCHER_WINDOWS_VIA_EVENT_EDGES = '1';
+    const on = await runScore();
+
+    expect(off).toEqual([inWin]); // the score path filtered to the in-window content
+    expect(on).toEqual(off); // event_edges path identical
+  });
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -67,7 +67,7 @@ import {
   restToolProxy,
   restUpdateContentClassification,
 } from './rest-api';
-import { entityLinkMatchSql } from './utils/content-search';
+import { entityLinkMatchSql, windowMembershipViaEventEdges } from './utils/content-search';
 import { isValidFrameAncestor } from './utils/csp';
 import { errorMessage } from './utils/errors';
 import logger from './utils/logger';
@@ -985,8 +985,15 @@ app.get('/api/:orgSlug/watchers/windows/:windowId', mcpAuth, async (c) => {
   const organizationId = c.var.organizationId;
 
   try {
-    // Get window details with watcher info
-    const windowResult = await sql`
+    // Get window details with watcher info. P6 window-membership read: count window content via
+    // the event_edges mirror when flagged (sql.unsafe so the iwf column/join can flip).
+    const iwfViaEdges = windowMembershipViaEventEdges();
+    const iwfContentCol = iwfViaEdges ? 'iwf.child_event_id' : 'iwf.event_id';
+    const iwfJoin = iwfViaEdges
+      ? `LEFT JOIN event_edges iwf ON iwf.parent_event_id = iw.id AND iwf.edge_type = 'membership'`
+      : `LEFT JOIN watcher_window_events iwf ON iwf.window_id = iw.id`;
+    const windowResult = await sql.unsafe(
+      `
       SELECT
         iw.*,
         i.entity_ids,
@@ -995,18 +1002,20 @@ app.get('/api/:orgSlug/watchers/windows/:windowId', mcpAuth, async (c) => {
         e.name as entity_name,
         et.slug AS entity_type,
         parent.name as parent_name,
-        CAST(COUNT(iwf.event_id) AS INTEGER) as content_count
+        CAST(COUNT(${iwfContentCol}) AS INTEGER) as content_count
       FROM watcher_windows iw
       JOIN watchers i ON iw.watcher_id = i.id
       JOIN entities e ON e.id = ANY(i.entity_ids)
       JOIN entity_types et ON et.id = e.entity_type_id
       LEFT JOIN entities parent ON e.parent_id = parent.id
-      LEFT JOIN watcher_window_events iwf ON iwf.window_id = iw.id
-      WHERE iw.id = ${windowId}
-        AND e.organization_id = ${organizationId}
+      ${iwfJoin}
+      WHERE iw.id = $1
+        AND e.organization_id = $2
         AND i.status = 'active'
       GROUP BY iw.id, i.entity_ids, i.slug, i.name, e.name, et.slug, parent.name
-    `;
+    `,
+      [windowId, organizationId]
+    );
 
     if (windowResult.length === 0) {
       return c.json({ error: 'Window not found' }, 404);

--- a/packages/server/src/tools/admin/manage_watchers/shared.ts
+++ b/packages/server/src/tools/admin/manage_watchers/shared.ts
@@ -307,7 +307,7 @@ export async function requireWatcherAccess(
 // Batch content counting
 // ============================================
 
-import { entityLinkMatchSql } from '../../../utils/content-search';
+import { entityLinkMatchSql, windowMembershipViaEventEdges } from '../../../utils/content-search';
 
 /**
  * Batch count unanalyzed content for multiple watchers in a single query.
@@ -334,6 +334,12 @@ export async function batchCountUnanalyzedContent(
   // semantics above the cap; the only consumer is a list-row badge that
   // doesn't need exact counts above a threshold.
   const TOTAL_CAP = 1000;
+  // P6 window-membership read: count analyzed events via the event_edges mirror when flagged.
+  const iwcViaEdges = windowMembershipViaEventEdges();
+  const iwcContentCol = iwcViaEdges ? 'iwc.child_event_id' : 'iwc.event_id';
+  const iwcWindowJoin = iwcViaEdges
+    ? `LEFT JOIN event_edges iwc ON iwc.parent_event_id = iw.id AND iwc.edge_type = 'membership'`
+    : `LEFT JOIN watcher_window_events iwc ON iwc.window_id = iw.id`;
   const result = await sql.unsafe(
     `
     WITH watcher_entities AS (
@@ -345,10 +351,10 @@ export async function batchCountUnanalyzedContent(
     analyzed_counts AS (
       SELECT
         ie.watcher_id,
-        COUNT(DISTINCT iwc.event_id) as analyzed_count
+        COUNT(DISTINCT ${iwcContentCol}) as analyzed_count
       FROM (SELECT DISTINCT watcher_id FROM watcher_entities) ie
       LEFT JOIN watcher_windows iw ON iw.watcher_id = ie.watcher_id
-      LEFT JOIN watcher_window_events iwc ON iwc.window_id = iw.id
+      ${iwcWindowJoin}
       GROUP BY ie.watcher_id
     ),
     total_counts AS (

--- a/packages/server/src/tools/get_watchers.ts
+++ b/packages/server/src/tools/get_watchers.ts
@@ -26,6 +26,7 @@ import {
   buildEntityLinkUnion,
   STANDARD_IDENTITY_NAMESPACES,
   type EntityIdentityScope,
+  windowMembershipViaEventEdges,
 } from '../utils/content-search';
 import { formatDateISO, parseDateAlias } from '../utils/date-aliases';
 import { parseJsonObject } from '@lobu/core';
@@ -673,21 +674,29 @@ async function getWatcherImpl(
   if (windowIds.length > 0 && includeClassificationSummary) {
     try {
       logger.info({ windowCount: windowIds.length }, '[get_watcher] Fetching classification stats');
+      // P6 window-membership read: flip iwc from watcher_window_events to the event_edges mirror
+      // (the classifier JOINs are P4's concern, untouched). The window-id column is aliased back
+      // to `window_id` so the result shape is unchanged.
+      const viaEdges = windowMembershipViaEventEdges();
+      const iwcFrom = viaEdges ? 'event_edges iwc' : 'watcher_window_events iwc';
+      const iwcContentCol = viaEdges ? 'iwc.child_event_id' : 'iwc.event_id';
+      const iwcWindowCol = viaEdges ? 'iwc.parent_event_id' : 'iwc.window_id';
+      const iwcEdgeFilter = viaEdges ? `AND iwc.edge_type = 'membership'` : '';
       const statsResult = await sql.unsafe(
         `
         SELECT
-          iwc.window_id,
+          ${iwcWindowCol} AS window_id,
           cc.slug as classifier_slug,
           value as value,
           CAST(COUNT(*) AS INTEGER) as count
-        FROM watcher_window_events iwc
-        JOIN event_classifications cls ON iwc.event_id = cls.event_id
+        FROM ${iwcFrom}
+        JOIN event_classifications cls ON ${iwcContentCol} = cls.event_id
         JOIN event_classifier_versions ccv ON cls.classifier_version_id = ccv.id
         JOIN event_classifiers cc ON ccv.classifier_id = cc.id
         CROSS JOIN unnest(cls."values") AS t(value)
-        WHERE iwc.window_id IN (${windowIds.map((_: unknown, i: number) => `$${i + 1}`).join(', ')})
-        GROUP BY iwc.window_id, cc.slug, value
-        ORDER BY iwc.window_id, cc.slug, count DESC
+        WHERE ${iwcWindowCol} IN (${windowIds.map((_: unknown, i: number) => `$${i + 1}`).join(', ')}) ${iwcEdgeFilter}
+        GROUP BY ${iwcWindowCol}, cc.slug, value
+        ORDER BY ${iwcWindowCol}, cc.slug, count DESC
       `,
         windowIds
       );

--- a/packages/server/src/utils/content-scoring.ts
+++ b/packages/server/src/utils/content-scoring.ts
@@ -11,6 +11,7 @@ import {
   entityLinkMatchSql,
   excludeWatcherNotExists,
   fetchEntityIdentityScopes,
+  windowMembershipViaEventEdges,
 } from './content-search';
 import {
   buildClassificationExistsClauses,
@@ -171,9 +172,17 @@ async function buildFilterConditionsAndJoins(
 
   if (filters?.window_id !== undefined) {
     const validatedWindowId = validateNumericId(filters.window_id, 'window_id');
-    additionalJoins.push('JOIN watcher_window_events iwc ON iwc.event_id = f.id');
     params.push(validatedWindowId);
-    filterConditions.push(`iwc.window_id = $${paramIndex++}`);
+    // P6 window-membership read: the score-sort path joins the same cutover as the date path.
+    if (windowMembershipViaEventEdges()) {
+      additionalJoins.push(
+        "JOIN event_edges iwc ON iwc.child_event_id = f.id AND iwc.edge_type = 'membership'"
+      );
+      filterConditions.push(`iwc.parent_event_id = $${paramIndex++}`);
+    } else {
+      additionalJoins.push('JOIN watcher_window_events iwc ON iwc.event_id = f.id');
+      filterConditions.push(`iwc.window_id = $${paramIndex++}`);
+    }
   }
 
   if (filters?.exclude_watcher_id !== undefined) {

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -23,6 +23,8 @@ export {
   excludeWatcherNotExists,
 } from './content-search/visibility';
 
+export { windowMembershipViaEventEdges } from './content-search/params';
+
 import { getDb } from '../db/client';
 import type { Env } from '../index';
 import { listContentInternal } from './content-search/list-path';

--- a/packages/server/src/utils/content-search/params.ts
+++ b/packages/server/src/utils/content-search/params.ts
@@ -1,6 +1,6 @@
 /**
  * Standard parameter-building helpers for the listing path:
- * buildStandardParams, buildStandardWhereSql, WINDOW_JOIN_SQL.
+ * buildStandardParams, buildStandardWhereSql, windowJoinSql, windowMembershipViaEventEdges.
  */
 
 import { pgTextArray } from '../../db/client';


### PR DESCRIPTION
## What

**P6 phase 3c — window-membership display reads**, stacked on #1472. Completes the `window_id`
membership flip behind `WATCHER_WINDOWS_VIA_EVENT_EDGES`. The 3 display/admin reads carry
**aggregate column renames** (the rename risk):
- `get_watchers.ts` classification stats: `iwc` → `event_edges` (`event_id`→`child_event_id`,
  `window_id`→`parent_event_id` aliased back to `window_id`, + `edge_type` filter). The classifier
  JOINs are P4's concern, untouched.
- `shared.ts` `analyzed_count`: `COUNT(DISTINCT iwc.event_id)` → `child_event_id` + the LEFT JOIN.
- `index.ts` window detail: tagged template → `sql.unsafe` so `COUNT(iwf.event_id)` →
  `child_event_id` + the JOIN flip; params bound positionally.

## Tests

`window-display-counts.test.ts`: the membership `COUNT`, the `COUNT(DISTINCT)` analyzed_count, AND
the per-`(window,classifier,value)` classification stats are **identical** from the table and
`event_edges` — the rename risk is covered by asserting the actual counts. 76 watcher tests green
(flag off = unchanged).

## P6 status

All `window_id`-membership reads now flipped (3a #1469, 3b #1472, 3c this). **Remaining for DROP:**
the `watcher_id_hint` reads (`get_watchers:959/1001` — exclude-style) + the write-flips
(`complete-window`, `entity-management` → `event_edges`) + `DROP watcher_window_events`.

Base = `feat/event-edges-p3b-window-reads` (#1472). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784737930&installation_id=136316292&pr_number=1473&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1473&signature=ff13cfc6fc9c4e871b0f967a32ca58ab84a7a71f1c981acb54f4c9b83d079376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->