### PR TITLE
feat(windows): flag-gated watcher_id_hint window reads from event_edges (P6 phase 3d)

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/watcher-membership-read.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watcher-membership-read.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Windows-as-events (P6) phase 3d: the watcher_id-keyed window reads (get_watchers "not in any
+ * window of this watcher" + the linked-per-month histograms in get_watchers / watcher-mode) read
+ * from the event_edges mirror via watcher_id_hint (replacing the watcher_windows JOIN), behind
+ * WATCHER_WINDOWS_VIA_EVENT_EDGES. This proves the watcher_id_hint reads return the SAME rows as
+ * the watcher_window_events -> watcher_windows JOIN.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+describe('watcher-membership (watcher_id_hint) read flip equivalence (P6 phase 3d)', () => {
+  it('not-in-window + linked-count are identical from the table-JOIN and the event_edges hint', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'WMem Org' });
+    const user = await createTestUser({ email: 'wmem@test.com' });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+
+    const mkEvent = async (slug: string) => {
+      const [e] = (await sql`
+        INSERT INTO events (organization_id, semantic_type, origin_id, payload_text, occurred_at, created_at)
+        VALUES (${org.id}, 'content', ${slug}, 'c', NOW(), NOW())
+        RETURNING id
+      `) as Array<{ id: number }>;
+      return Number(e.id);
+    };
+    const linked = await mkEvent('wm_linked');
+    const unlinked = await mkEvent('wm_unlinked');
+
+    const watcherId = 963000;
+    await sql`
+      INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+      VALUES (${watcherId}, 'w', 'w-wm', ${user.id}, ${org.id}, ${agent.agentId}, ${watcherId})
+    `;
+    const windowId = 963001;
+    await sql`
+      INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+      VALUES (${windowId}, ${watcherId}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+    `;
+    await sql`INSERT INTO watcher_window_events (window_id, event_id) VALUES (${windowId}, ${linked})`;
+
+    // "NOT in any window of this watcher" — table JOIN vs event_edges hint.
+    const notInTable = (await sql`
+      SELECT f.id FROM events f
+      WHERE f.organization_id = ${org.id}
+        AND NOT EXISTS (
+          SELECT 1 FROM watcher_window_events iwc
+          JOIN watcher_windows iw ON iw.id = iwc.window_id
+          WHERE iwc.event_id = f.id AND iw.watcher_id = ${watcherId}
+        )
+      ORDER BY f.id
+    `) as Array<{ id: number }>;
+    const notInEdges = (await sql`
+      SELECT f.id FROM events f
+      WHERE f.organization_id = ${org.id}
+        AND NOT EXISTS (
+          SELECT 1 FROM event_edges iwc
+          WHERE iwc.child_event_id = f.id AND iwc.watcher_id_hint = ${watcherId} AND iwc.edge_type = 'membership'
+        )
+      ORDER BY f.id
+    `) as Array<{ id: number }>;
+    expect(notInEdges.map((r) => Number(r.id))).toEqual(notInTable.map((r) => Number(r.id)));
+    expect(notInTable.map((r) => Number(r.id))).toEqual([unlinked]); // only the unlinked event
+
+    // linked-count for the watcher — JOIN-through-windows vs hint.
+    const linkedTable = (await sql`
+      SELECT CAST(COUNT(DISTINCT f.id) AS INTEGER) AS n FROM events f
+      JOIN watcher_window_events iwc ON f.id = iwc.event_id
+      JOIN watcher_windows iw ON iwc.window_id = iw.id
+      WHERE iw.watcher_id = ${watcherId}
+    `) as Array<{ n: number }>;
+    const linkedEdges = (await sql`
+      SELECT CAST(COUNT(DISTINCT f.id) AS INTEGER) AS n FROM events f
+      JOIN event_edges iwc ON f.id = iwc.child_event_id AND iwc.edge_type = 'membership'
+      WHERE iwc.watcher_id_hint = ${watcherId}
+    `) as Array<{ n: number }>;
+    expect(linkedEdges[0].n).toBe(linkedTable[0].n);
+    expect(linkedTable[0].n).toBe(1); // the one linked event
+  });
+});

--- a/packages/server/src/tools/get_content/watcher-mode.ts
+++ b/packages/server/src/tools/get_content/watcher-mode.ts
@@ -14,6 +14,7 @@ import type { UnprocessedRange, WatcherSource } from '../../types/watchers';
 import { parseDateAlias, toEndOfDay } from '../../utils/date-aliases';
 import { type DataSourceContext, executeDataSources } from '../../utils/execute-data-sources';
 import logger from '../../utils/logger';
+import { windowMembershipViaEventEdges } from '../../utils/content-search';
 import { getRecentFeedbackSummary } from '../../utils/watcher-feedback';
 import { getAvailableOperations, getPastReactionsSummary } from '../../utils/watcher-reactions';
 import {
@@ -415,7 +416,14 @@ export async function handleWatcherMode(
   // This helps agents understand what months need processing
   let unprocessedRanges: UnprocessedRange[] | undefined;
   if (!args.since && !args.until) {
-    // Query content and linked counts by month in parallel
+    // Query content and linked counts by month in parallel. P6 watcher-membership read: the
+    // linked histogram reads the event_edges mirror (watcher_id_hint) when flagged.
+    const wmViaEdges = windowMembershipViaEventEdges();
+    const wmLinkedJoin = wmViaEdges
+      ? `JOIN event_edges iwc ON c.id = iwc.child_event_id AND iwc.edge_type = 'membership'`
+      : `JOIN watcher_window_events iwc ON c.id = iwc.event_id
+        JOIN watcher_windows iw ON iwc.window_id = iw.id`;
+    const wmWatcherCol = wmViaEdges ? 'iwc.watcher_id_hint' : 'iw.watcher_id';
     const [monthlyContent, monthlyLinked] = await Promise.all([
       sql.unsafe(
         `
@@ -435,10 +443,9 @@ export async function handleWatcherMode(
           DATE_TRUNC('month', c.occurred_at) as month,
           COUNT(DISTINCT c.id) as linked
         FROM current_event_records c
-        JOIN watcher_window_events iwc ON c.id = iwc.event_id
-        JOIN watcher_windows iw ON iwc.window_id = iw.id
+        ${wmLinkedJoin}
         WHERE c.entity_ids && ARRAY[${entityIdPlaceholders}]::bigint[]
-          AND iw.watcher_id = $${sourceEntityIds.length + 1}
+          AND ${wmWatcherCol} = $${sourceEntityIds.length + 1}
         GROUP BY DATE_TRUNC('month', c.occurred_at)
       `,
         [...sourceEntityIds, watcherId]

--- a/packages/server/src/tools/get_watchers.ts
+++ b/packages/server/src/tools/get_watchers.ts
@@ -964,7 +964,14 @@ async function getWatcherImpl(
     const watcherScopedParams = [args.watcher_id, ...entityLinkParams, effectiveBound];
     const noWatcherParams = [...entityLinkOnlyParams, effectiveBound];
 
-    const notInWindowClause = `NOT EXISTS (
+    // P6 watcher-membership read: "content NOT in any window of this watcher" via the event_edges
+    // mirror (watcher_id_hint replaces the watcher_windows JOIN) when flagged.
+    const notInWindowClause = windowMembershipViaEventEdges()
+      ? `NOT EXISTS (
+        SELECT 1 FROM event_edges iwc
+        WHERE iwc.child_event_id = f.id AND iwc.watcher_id_hint = $1 AND iwc.edge_type = 'membership'
+      )`
+      : `NOT EXISTS (
         SELECT 1 FROM watcher_window_events iwc
         JOIN watcher_windows iw ON iw.id = iwc.window_id
         WHERE iwc.event_id = f.id AND iw.watcher_id = $1
@@ -995,6 +1002,13 @@ async function getWatcherImpl(
       watcherScopedParams
     );
 
+    // P6 watcher-membership read: the "linked per month" histogram via the event_edges mirror.
+    const histViaEdges = windowMembershipViaEventEdges();
+    const histLinkedJoin = histViaEdges
+      ? `JOIN event_edges iwc ON f.id = iwc.child_event_id AND iwc.edge_type = 'membership'`
+      : `JOIN watcher_window_events iwc ON f.id = iwc.event_id
+              JOIN watcher_windows iw ON iwc.window_id = iw.id`;
+    const histWatcherCol = histViaEdges ? 'iwc.watcher_id_hint' : 'iw.watcher_id';
     const histogramPromise = args.include_pending_ranges
       ? Promise.all([
           sql.unsafe(
@@ -1009,11 +1023,10 @@ async function getWatcherImpl(
           sql.unsafe(
             `SELECT DATE_TRUNC('month', f.occurred_at) as month, COUNT(DISTINCT f.id) as linked
               FROM current_event_records f
-              JOIN watcher_window_events iwc ON f.id = iwc.event_id
-              JOIN watcher_windows iw ON iwc.window_id = iw.id
+              ${histLinkedJoin}
               WHERE ${entityScopeCondition}
                 ${occurredAtBound ? `AND ${occurredAtBound}` : ''}
-                AND iw.watcher_id = $1
+                AND ${histWatcherCol} = $1
               GROUP BY DATE_TRUNC('month', f.occurred_at)`,
             watcherScopedParams
           ),


### PR DESCRIPTION
## What

**P6 phase 3d — watcher_id_hint window reads**, stacked on #1473. Flips the remaining
watcher_id-keyed window READS to `event_edges` via `watcher_id_hint` (replacing the
`watcher_window_events → watcher_windows` JOIN), behind `WATCHER_WINDOWS_VIA_EVENT_EDGES`:
- `get_watchers.ts` `notInWindowClause` (content NOT in any window of a watcher → the unprocessed badge)
- `get_watchers.ts` linked-per-month histogram
- `get_content/watcher-mode.ts` linked-per-month histogram

All drop the `watcher_windows` JOIN and read `iwc.watcher_id_hint` (set by the phase-1 trigger) +
`edge_type='membership'`.

**With this, ALL `watcher_window_events` READS are flipped** (window-membership 3a-3c +
watcher_id_hint 3d).

## Tests

`watcher-membership-read.test.ts`: not-in-window + linked-count are **identical** from the table
JOIN and the `event_edges` hint, both flag states. 78 watcher tests green (flag off = unchanged).

## Remaining for P6 DROP

The WRITES (`complete-window` INSERT/DELETE, `entity-management` DELETE cascades) → `event_edges`
directly behind a separate write flag (gated on the reads being universal), then
`DROP watcher_window_events`. (Same write-flip→drop pattern P1 already rode to a working DROP.)

Base = `feat/event-edges-p3c-display-reads` (#1473). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784738682&installation_id=136316292&pr_number=1474&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1474&signature=4f5fee371c19ac6524bfa438a8d4d5a486da19f88efde6967bf34d220acf892e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->