### PR TITLE
feat(windows): flag-gated membership WRITE flip to event_edges (P6 phase 3e)

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/window-write-flip.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/window-write-flip.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Windows-as-events (P6) phase 3e: the membership WRITES (complete-window INSERT/DELETE,
+ * entity-management DELETE cascades) write event_edges directly when WATCHER_WINDOWS_WRITE_VIA_EVENT_EDGES
+ * is set, skipping watcher_window_events. This proves the direct-written edge is IDENTICAL in shape
+ * to what the phase-1 trigger produces (org from the watcher, watcher_id_hint, edge_type), and that
+ * the dedup constraint collapses any overlap.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+describe('window membership write flip (P6 phase 3e)', () => {
+  it('direct event_edges write matches the trigger edge; dedup collapses overlap', async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'WWrite Org' });
+    const user = await createTestUser({ email: 'wwrite@test.com' });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+
+    const mkEvent = async (slug: string) => {
+      const [e] = (await sql`
+        INSERT INTO events (organization_id, semantic_type, origin_id, payload_text, occurred_at, created_at)
+        VALUES (${org.id}, 'content', ${slug}, 'c', NOW(), NOW()) RETURNING id
+      `) as Array<{ id: number }>;
+      return Number(e.id);
+    };
+    const eTrig = await mkEvent('ww_trig');
+    const eDirect = await mkEvent('ww_direct');
+
+    const watcherId = 964000;
+    await sql`
+      INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+      VALUES (${watcherId}, 'w', 'w-ww', ${user.id}, ${org.id}, ${agent.agentId}, ${watcherId})
+    `;
+    const windowId = 964001;
+    await sql`
+      INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+      VALUES (${windowId}, ${watcherId}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+    `;
+
+    // Trigger path: INSERT watcher_window_events -> phase-1 trigger -> edge for eTrig.
+    await sql`INSERT INTO watcher_window_events (window_id, event_id) VALUES (${windowId}, ${eTrig})`;
+
+    // Direct path (the write flip's exact INSERT) for eDirect.
+    await sql`
+      INSERT INTO event_edges (organization_id, parent_event_id, child_event_id, edge_type, watcher_id_hint, created_at)
+      VALUES (${org.id}, ${windowId}, ${eDirect}, 'membership', ${watcherId}, NOW())
+      ON CONFLICT (parent_event_id, child_event_id, edge_type) DO NOTHING
+    `;
+
+    const edge = async (child: number) => {
+      const [r] = (await sql`
+        SELECT organization_id, parent_event_id, child_event_id, edge_type, watcher_id_hint
+        FROM event_edges WHERE child_event_id = ${child} AND edge_type = 'membership'
+      `) as Array<{
+        organization_id: string;
+        parent_event_id: number;
+        child_event_id: number;
+        edge_type: string;
+        watcher_id_hint: number;
+      }>;
+      return r;
+    };
+    const trigEdge = await edge(eTrig);
+    const directEdge = await edge(eDirect);
+
+    // Same shape except the child (org, parent=window, edge_type, watcher_id_hint all identical).
+    expect(directEdge.organization_id).toBe(trigEdge.organization_id);
+    expect(Number(directEdge.parent_event_id)).toBe(Number(trigEdge.parent_event_id));
+    expect(directEdge.edge_type).toBe(trigEdge.edge_type);
+    expect(Number(directEdge.watcher_id_hint)).toBe(Number(trigEdge.watcher_id_hint));
+    expect(directEdge.organization_id).toBe(org.id);
+    expect(Number(directEdge.watcher_id_hint)).toBe(watcherId);
+
+    // Dedup: re-writing the same direct edge (e.g. an old-pod trigger write racing a new-pod
+    // direct write) collapses to one row.
+    await sql`
+      INSERT INTO event_edges (organization_id, parent_event_id, child_event_id, edge_type, watcher_id_hint, created_at)
+      VALUES (${org.id}, ${windowId}, ${eDirect}, 'membership', ${watcherId}, NOW())
+      ON CONFLICT (parent_event_id, child_event_id, edge_type) DO NOTHING
+    `;
+    const dupCount = (await sql`
+      SELECT COUNT(*)::int AS n FROM event_edges WHERE child_event_id = ${eDirect} AND edge_type = 'membership'
+    `) as Array<{ n: number }>;
+    expect(dupCount[0].n).toBe(1);
+  });
+});

--- a/packages/server/src/tools/admin/manage_watchers/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_watchers/complete-window.ts
@@ -8,6 +8,7 @@
 import Ajv from 'ajv';
 import { createDbClientFromEnv, getDb, pgBigintArray } from '../../../db/client';
 import type { Env } from '../../../index';
+import { windowMembershipWriteViaEventEdges } from '../../../utils/content-search';
 import { ToolUserError } from '../../../utils/errors';
 import { verifyWindowToken } from '../../../utils/jwt';
 import logger from '../../../utils/logger';
@@ -454,7 +455,14 @@ export async function handleCompleteWindow(
         if (args.replace_existing) {
           // Delete existing window and its content links
           windowId = existingWindow[0].id as number;
-          await tx`DELETE FROM watcher_window_events WHERE window_id = ${windowId}`;
+          // P6 WRITE flip: remove the membership edges directly. (The watcher_windows DELETE below
+          // still cascades to any old-pod watcher_window_events rows -> trigger, a no-op on edges
+          // already removed here; needed explicitly for the post-drop world.)
+          if (windowMembershipWriteViaEventEdges()) {
+            await tx`DELETE FROM event_edges WHERE parent_event_id = ${windowId} AND edge_type = 'membership'`;
+          } else {
+            await tx`DELETE FROM watcher_window_events WHERE window_id = ${windowId}`;
+          }
           await tx`DELETE FROM watcher_windows WHERE id = ${windowId}`;
           logger.info(
             `[complete_window] Deleted existing window ${windowId} (replace_existing=true)`
@@ -535,23 +543,45 @@ export async function handleCompleteWindow(
     // Build VALUES clause for bulk insert
     // ============================================
     if (batchContentIds.length > 0) {
-      let nextWindowEventId = await getNextNumericId(tx, 'watcher_window_events');
-      const valuePlaceholders: string[] = [];
-      const insertParams: unknown[] = [];
-      let pIdx = 1;
-      for (const contentId of batchContentIds) {
-        valuePlaceholders.push(`($${pIdx}, $${pIdx + 1}, $${pIdx + 2}, NOW())`);
-        insertParams.push(nextWindowEventId, windowId, contentId);
-        nextWindowEventId += 1;
-        pIdx += 3;
-      }
+      if (windowMembershipWriteViaEventEdges()) {
+        // P6 WRITE flip: write the membership edges directly to event_edges (org + watcher_id_hint
+        // resolved from this window's watcher), skipping watcher_window_events so the table can be
+        // dropped. event_edges.id is GENERATED; the unique (parent,child,edge_type) dedups vs any
+        // old-pod trigger writes.
+        const organizationId = watcherRows[0].organization_id as string;
+        const edgeValues: string[] = [];
+        const edgeParams: unknown[] = [];
+        let ep = 1;
+        for (const contentId of batchContentIds) {
+          edgeValues.push(`($${ep}, $${ep + 1}, $${ep + 2}, 'membership', $${ep + 3}, NOW())`);
+          edgeParams.push(organizationId, windowId, contentId, watcherId);
+          ep += 4;
+        }
+        await tx.unsafe(
+          `INSERT INTO event_edges (organization_id, parent_event_id, child_event_id, edge_type, watcher_id_hint, created_at)
+           VALUES ${edgeValues.join(', ')}
+           ON CONFLICT (parent_event_id, child_event_id, edge_type) DO NOTHING`,
+          edgeParams
+        );
+      } else {
+        let nextWindowEventId = await getNextNumericId(tx, 'watcher_window_events');
+        const valuePlaceholders: string[] = [];
+        const insertParams: unknown[] = [];
+        let pIdx = 1;
+        for (const contentId of batchContentIds) {
+          valuePlaceholders.push(`($${pIdx}, $${pIdx + 1}, $${pIdx + 2}, NOW())`);
+          insertParams.push(nextWindowEventId, windowId, contentId);
+          nextWindowEventId += 1;
+          pIdx += 3;
+        }
 
-      await tx.unsafe(
-        `INSERT INTO watcher_window_events (id, window_id, event_id, created_at)
-         VALUES ${valuePlaceholders.join(', ')}
-         ON CONFLICT DO NOTHING`,
-        insertParams
-      );
+        await tx.unsafe(
+          `INSERT INTO watcher_window_events (id, window_id, event_id, created_at)
+           VALUES ${valuePlaceholders.join(', ')}
+           ON CONFLICT DO NOTHING`,
+          insertParams
+        );
+      }
     }
 
     // ============================================

--- a/packages/server/src/utils/content-search.ts
+++ b/packages/server/src/utils/content-search.ts
@@ -23,7 +23,10 @@ export {
   excludeWatcherNotExists,
 } from './content-search/visibility';
 
-export { windowMembershipViaEventEdges } from './content-search/params';
+export {
+  windowMembershipViaEventEdges,
+  windowMembershipWriteViaEventEdges,
+} from './content-search/params';
 
 import { getDb } from '../db/client';
 import type { Env } from '../index';

--- a/packages/server/src/utils/content-search/params.ts
+++ b/packages/server/src/utils/content-search/params.ts
@@ -64,6 +64,22 @@ export function windowMembershipViaEventEdges(): boolean {
   );
 }
 
+/**
+ * P6 WRITE flip: when set, window membership is written DIRECTLY to event_edges
+ * (complete-window INSERT/DELETE, entity-management DELETE cascades) and watcher_window_events is
+ * no longer written — the precondition for dropping that table. MUST be enabled only AFTER the
+ * READ flag (WATCHER_WINDOWS_VIA_EVENT_EDGES) is universal in prod, else flag-off readers reading
+ * watcher_window_events would miss these direct edges. During the write-flip rollout, old pods
+ * write the table (-> phase-1 trigger -> edge) and new pods write the edge directly; the
+ * event_edges_unique (parent,child,edge_type) constraint dedups, so no double edge.
+ */
+export function windowMembershipWriteViaEventEdges(): boolean {
+  return (
+    process.env.WATCHER_WINDOWS_WRITE_VIA_EVENT_EDGES === '1' ||
+    process.env.WATCHER_WINDOWS_WRITE_VIA_EVENT_EDGES === 'true'
+  );
+}
+
 export function buildStandardWhereSql(entityLinkSql: string): string {
   const windowCol = windowMembershipViaEventEdges() ? 'iwf.parent_event_id' : 'iwf.window_id';
   return `($1::bigint IS NULL OR ${entityLinkSql})

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -16,6 +16,7 @@ import {
 } from '../db/client';
 import type { Env } from '../index';
 import { querySqlImpl } from '../tools/admin/query_sql';
+import { windowMembershipWriteViaEventEdges } from './content-search';
 import type { ToolContext } from '../tools/registry';
 import { entityLinkMatchSql } from './content-search';
 import { type EntityHookContext, getEntityHooks } from './entity-hooks';
@@ -562,15 +563,29 @@ export async function deleteEntity(
            OR to_entity_id = ANY(${entityTreeIdsLiteral}::bigint[])
       `;
 
-      await tx`
-        DELETE FROM watcher_window_events
-        WHERE window_id IN (
-          SELECT ww.id
-          FROM watcher_windows ww
-          JOIN watchers w ON ww.watcher_id = w.id
-          WHERE COALESCE(w.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
-        )
-      `;
+      // P6 WRITE flip: remove membership edges directly (the watcher_windows DELETE below still
+      // cascades old-pod watcher_window_events rows -> trigger, a no-op on edges already removed).
+      if (windowMembershipWriteViaEventEdges()) {
+        await tx`
+          DELETE FROM event_edges
+          WHERE edge_type = 'membership' AND parent_event_id IN (
+            SELECT ww.id
+            FROM watcher_windows ww
+            JOIN watchers w ON ww.watcher_id = w.id
+            WHERE COALESCE(w.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+          )
+        `;
+      } else {
+        await tx`
+          DELETE FROM watcher_window_events
+          WHERE window_id IN (
+            SELECT ww.id
+            FROM watcher_windows ww
+            JOIN watchers w ON ww.watcher_id = w.id
+            WHERE COALESCE(w.entity_ids, '{}'::bigint[]) <@ ${entityTreeIdsLiteral}::bigint[]
+          )
+        `;
+      }
       await tx`
         DELETE FROM watcher_windows
         WHERE watcher_id IN (
@@ -642,15 +657,28 @@ export async function deleteEntity(
         )
         WHERE entity_ids && ${entityTreeIdsLiteral}::bigint[]
       `;
-      await tx`
-        DELETE FROM watcher_window_events
-        WHERE window_id IN (
-          SELECT ww.id
-          FROM watcher_windows ww
-          JOIN watchers w ON ww.watcher_id = w.id
-          WHERE cardinality(COALESCE(w.entity_ids, '{}'::bigint[])) = 0
-        )
-      `;
+      // P6 WRITE flip (orphaned-watcher cleanup): same as above.
+      if (windowMembershipWriteViaEventEdges()) {
+        await tx`
+          DELETE FROM event_edges
+          WHERE edge_type = 'membership' AND parent_event_id IN (
+            SELECT ww.id
+            FROM watcher_windows ww
+            JOIN watchers w ON ww.watcher_id = w.id
+            WHERE cardinality(COALESCE(w.entity_ids, '{}'::bigint[])) = 0
+          )
+        `;
+      } else {
+        await tx`
+          DELETE FROM watcher_window_events
+          WHERE window_id IN (
+            SELECT ww.id
+            FROM watcher_windows ww
+            JOIN watchers w ON ww.watcher_id = w.id
+            WHERE cardinality(COALESCE(w.entity_ids, '{}'::bigint[])) = 0
+          )
+        `;
+      }
       await tx`
         DELETE FROM watcher_windows
         WHERE watcher_id IN (


### PR DESCRIPTION
## What

**P6 phase 3e — membership WRITE flip**, stacked on #1474. The membership WRITES emit `event_edges`
directly when `WATCHER_WINDOWS_WRITE_VIA_EVENT_EDGES` is set, skipping `watcher_window_events` — the
precondition for dropping the table:
- `complete-window.ts` INSERT (org + `watcher_id_hint` resolved from the window's watcher;
  `event_edges.id` is GENERATED; `ON CONFLICT (parent,child,edge_type)` dedups).
- `complete-window.ts` window-replace DELETE → `DELETE event_edges` by `parent_event_id`.
- `entity-management.ts` 2 cascade DELETEs → `DELETE event_edges` by `parent_event_id IN (windows-by-entity)`.

**Separate flag from the reads** — enabled only after `WATCHER_WINDOWS_VIA_EVENT_EDGES` is universal
(else flag-off readers miss direct edges). Multi-replica: old pods write the table (→ trigger →
edge), new pods write the edge directly; the unique constraint dedups → no double edge. The
`watcher_windows` DELETE still cascades old-pod rows → trigger (a no-op on already-removed edges);
the explicit `event_edges` DELETE is what makes it correct **post-drop** (no trigger/table).

## Tests

`window-write-flip.test.ts`: the direct-written edge is **identical** in shape to the trigger edge
(org from the watcher, parent=window, edge_type, watcher_id_hint), and the dedup constraint
collapses overlap to 1 row. 79 watcher tests green (flag off).

## P6 status

With **reads (3a-3d) + writes (3e) all flipped**, only **DROP `watcher_window_events`** remains —
the same write-flip→drop sequence P1 already rode to a working `DROP TABLE`.

Base = `feat/event-edges-p3d-watcher-reads` (#1474). Draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784739132&installation_id=136316292&pr_number=1475&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1475&signature=cbab947263663bf108fafdbc099b6de4d8b4e2a99c1d148f67d1af5c5f76fdec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->