### PR TITLE
feat(connectors): chrome.watch_observations feed (+owletto pointer)

### DIFF
--- a/packages/connectors/src/chrome.ts
+++ b/packages/connectors/src/chrome.ts
@@ -152,6 +152,46 @@ export default class ChromeConnector extends ConnectorRuntime {
           },
         },
       },
+      watch_observations: {
+        key: 'watch_observations',
+        name: 'Watch observations',
+        description:
+          'Form input + submit events captured while the user has "Watch active tab" turned on (the orange badge). Streamed only while watch is active — empty otherwise. Sensitive fields (password, one-time-code, credit-card autocomplete) are redacted in the page before the value ever reaches the buffer. No extra permission required (baseline `scripting`).',
+        configSchema: { type: 'object', properties: {} },
+        eventKinds: {
+          watch_observation: {
+            description:
+              'One row per observed input or form submit on a watched tab. event_type is one of: input, submit.',
+            metadataSchema: {
+              type: 'object',
+              required: ['source', 'origin_id', 'event_type'],
+              properties: {
+                source: { type: 'string', const: 'chrome_watch' },
+                origin_id: { type: 'string' },
+                event_type: { enum: ['input', 'submit'] },
+                url: { type: 'string' },
+                field_label: {
+                  type: 'string',
+                  description: 'For input events, the field the user typed into.',
+                },
+                tag: { type: 'string' },
+                type: { type: 'string' },
+                length: { type: 'integer' },
+                form_action: {
+                  type: 'string',
+                  description: 'For submit events, the form action URL.',
+                },
+                fields: {
+                  type: 'array',
+                  description:
+                    'For submit events, the form fields (sensitive values redacted).',
+                  items: { type: 'object' },
+                },
+              },
+            },
+          },
+        },
+      },
     },
     actions: {
       navigate: {


### PR DESCRIPTION
## What
Declares the `watch_observations` feed on the chrome connector definition (`packages/connectors/src/chrome.ts`) so `device-reconcile` auto-wires it and the gateway schedules feed runs for it. Mirrors the existing `tab_events` feed shape; metadata `source: chrome_watch`, `event_type: input|submit`.

Bumps the `packages/owletto` submodule pointer to the extension side (lobu-ai/owletto#327), which drains the watch buffer to this feed with peek-then-commit semantics and adds adaptive poll backoff.

## Why
The "Watch active tab" feature captured input/submit events into an SW-local buffer that never reached the agent. This is the gateway half that turns it into a real ambient signal source. Sensitive values are redacted in the page before buffering.

## Test
- Extension unit tests (79 chrome-ext, incl. new watch/poll-schedule) green in owletto#327.
- Root `tsc --noEmit` clean (pre-commit gate).

## Order / not-yet-verified
Land owletto#327 first (pointer already targets its commit). Live extension↔gateway round trip via `make e2e-browser` pending — draft until verified alongside Batch A2.

Depends on: lobu-ai/owletto#327

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784739606&installation_id=136316292&pr_number=1476&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1476&signature=e363a001fc56ced32345b33f672a1c85ce93531f3dacdf3ddb94016c2e9cb41d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->