### PR TITLE
feat(connectors): Calendar + Reminders device connectors (EventKit)

### DIFF
--- a/packages/connectors/src/apple_calendar.ts
+++ b/packages/connectors/src/apple_calendar.ts
@@ -1,0 +1,59 @@
+/**
+ * Calendar Connector — Lobu for Mac only.
+ *
+ * Reads the user's calendar events via EventKit on the Mac (Lobu for Mac
+ * advertises the `calendar` capability). One event per occurrence in a
+ * rolling window around now; titles/times/locations/attendees flow up, the
+ * underlying calendar database stays on the device.
+ */
+
+import { BridgeOnlyConnector, type ConnectorDefinition } from '@lobu/connector-sdk';
+
+const BRIDGE_ONLY =
+  'apple.calendar runs only on a worker advertising capability "calendar" (Lobu for Mac with Calendar access).';
+
+export default class AppleCalendarConnector extends BridgeOnlyConnector {
+  constructor() {
+    super(BRIDGE_ONLY);
+  }
+
+  readonly definition: ConnectorDefinition = {
+    key: 'apple.calendar',
+    name: 'Calendar',
+    description:
+      'Sync your calendar events (titles, times, locations, attendees) from this Mac via Lobu for Mac. Events stay on the device.',
+    version: '0.1.0',
+    faviconDomain: 'apple.com',
+    requiredCapability: 'calendar',
+    runtime: { platforms: ['macos'] },
+    authSchema: { methods: [{ type: 'none' }] },
+    feeds: {
+      events: {
+        key: 'events',
+        name: 'Events',
+        description: 'Calendar events from the Mac, in a rolling window around now.',
+        configSchema: { type: 'object', properties: {} },
+        eventKinds: {
+          calendar_event: {
+            description: 'A single calendar event occurrence.',
+            metadataSchema: {
+              type: 'object',
+              required: ['source', 'origin_id', 'start'],
+              properties: {
+                source: { type: 'string', const: 'apple_calendar' },
+                origin_id: { type: 'string' },
+                calendar: { type: 'string' },
+                start: { type: 'string' },
+                end: { type: 'string' },
+                all_day: { type: 'boolean' },
+                location: { type: 'string' },
+                organizer: { type: 'string' },
+                attendee_count: { type: 'integer' },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/packages/connectors/src/apple_reminders.ts
+++ b/packages/connectors/src/apple_reminders.ts
@@ -1,0 +1,57 @@
+/**
+ * Reminders Connector — Lobu for Mac only.
+ *
+ * Reads the user's reminders via EventKit on the Mac (Lobu for Mac advertises
+ * the `reminders` capability). Incomplete reminders plus recently-completed
+ * ones; titles/notes/due-dates/completion flow up, the underlying database
+ * stays on the device.
+ */
+
+import { BridgeOnlyConnector, type ConnectorDefinition } from '@lobu/connector-sdk';
+
+const BRIDGE_ONLY =
+  'apple.reminders runs only on a worker advertising capability "reminders" (Lobu for Mac with Reminders access).';
+
+export default class AppleRemindersConnector extends BridgeOnlyConnector {
+  constructor() {
+    super(BRIDGE_ONLY);
+  }
+
+  readonly definition: ConnectorDefinition = {
+    key: 'apple.reminders',
+    name: 'Reminders',
+    description:
+      'Sync your reminders (titles, notes, due dates, completion) from this Mac via Lobu for Mac. Reminders stay on the device.',
+    version: '0.1.0',
+    faviconDomain: 'apple.com',
+    requiredCapability: 'reminders',
+    runtime: { platforms: ['macos'] },
+    authSchema: { methods: [{ type: 'none' }] },
+    feeds: {
+      reminders: {
+        key: 'reminders',
+        name: 'Reminders',
+        description: 'Reminders from the Mac — incomplete plus recently completed.',
+        configSchema: { type: 'object', properties: {} },
+        eventKinds: {
+          reminder: {
+            description: 'A single reminder.',
+            metadataSchema: {
+              type: 'object',
+              required: ['source', 'origin_id', 'completed'],
+              properties: {
+                source: { type: 'string', const: 'apple_reminders' },
+                origin_id: { type: 'string' },
+                list: { type: 'string' },
+                completed: { type: 'boolean' },
+                due: { type: 'string' },
+                completed_at: { type: 'string' },
+                priority: { type: 'integer' },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -52,6 +52,8 @@ export const MAC_DEVICE_CAPABILITIES = [
   "healthkit",
   "photos",
   "whatsapp_local",
+  "calendar",
+  "reminders",
 ] as const;
 
 const PLATFORM_ALLOWLIST: Record<string, readonly string[]> = {


### PR DESCRIPTION
## What
`apple.calendar` + `apple.reminders` connector definitions (capabilities `calendar`/`reminders` added to `MAC_DEVICE_CAPABILITIES`) for the EventKit sync services in owletto. Mirrors the existing `apple.*` device connectors; events stay on the device, only structured fields flow up.

Bumps `packages/owletto` to the Batch B commit (recursive `local.directory` sync + EventKit Calendar/Reminders).

## Test
- Pre-commit `tsc --noEmit` clean; connector defs compile into the catalog manifest (verified via `make dev` connector-catalog build).
- owletto Mac app builds clean with the EventKit service.

## Order
Land lobu-ai/owletto (Batch B) first; pointer already targets its commit. On-device verification (Calendar/Reminders ingest) pending — draft.

Depends on: lobu-ai/owletto#<batch-B PR>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784743305&installation_id=136316292&pr_number=1480&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1480&signature=502c30bef796b5d02225716bf8dedd4850288e6153475648628dcf6221a4a227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->