### PR TITLE
fix(provider): stop the system/builder agent defaulting to an unusable provider

### DIFF
--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -157,6 +157,23 @@ describe("resolveModelRef", () => {
   });
 });
 
+describe("DEFAULT_PROVIDER_BASE_URL_ENV — no shared base-URL key", () => {
+  // Worker-side half of the codex collision fix. The OpenAI SDK base URL for
+  // `openai` is read from OPENAI_BASE_URL; the Codex (openai-codex) backend MUST
+  // read its own key, else a clobbered OPENAI_BASE_URL routes openai/<model> to
+  // chatgpt.com/backend-api (the original 403). Pin the exact key + disjointness
+  // so a regression back to OPENAI_BASE_URL fails here, not just at runtime.
+  test("openai-codex uses OPENAI_CODEX_BASE_URL, distinct from openai", () => {
+    expect(DEFAULT_PROVIDER_BASE_URL_ENV["openai-codex"]).toBe(
+      "OPENAI_CODEX_BASE_URL"
+    );
+    expect(DEFAULT_PROVIDER_BASE_URL_ENV.openai).toBe("OPENAI_BASE_URL");
+    expect(DEFAULT_PROVIDER_BASE_URL_ENV["openai-codex"]).not.toBe(
+      DEFAULT_PROVIDER_BASE_URL_ENV.openai
+    );
+  });
+});
+
 describe("registerDynamicProvider", () => {
   const testProviderId = `test-provider-${Date.now()}`;
 

--- a/packages/agent-worker/src/openclaw/model-resolver.ts
+++ b/packages/agent-worker/src/openclaw/model-resolver.ts
@@ -36,7 +36,10 @@ export function getModelDynamic(
 export const DEFAULT_PROVIDER_BASE_URL_ENV: Record<string, string> = {
   anthropic: "ANTHROPIC_BASE_URL",
   openai: "OPENAI_BASE_URL",
-  "openai-codex": "OPENAI_BASE_URL",
+  // Dedicated key (mirrors chatgpt-oauth-module's baseUrlEnvVarName). Must stay
+  // distinct from "openai" so the gateway's per-provider base URLs never
+  // collide on OPENAI_BASE_URL — see chatgpt-oauth-module.ts.
+  "openai-codex": "OPENAI_CODEX_BASE_URL",
   // Keyed by the gateway provider slug (config id), e.g. "gemini" — NOT
   // "google". registerDynamicProvider() overlays the live config values at
   // runtime; these stay as fallbacks for providers not in providers.json.

--- a/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
@@ -31,8 +31,14 @@ const PROVIDERS_JSON = path.resolve(HERE, "../../../../../../config/providers.js
 
 describe("ensureBuilderAgent — provisioning reliability", () => {
 	const sql = getTestDb();
+	const CLAUDE_ENV_VARS = [
+		"ANTHROPIC_API_KEY",
+		"ANTHROPIC_AUTH_TOKEN",
+		"CLAUDE_CODE_OAUTH_TOKEN",
+	];
 	const prevRegistryPath = process.env.LOBU_PROVIDER_REGISTRY_PATH;
 	const prevOpenAI = process.env.OPENAI_API_KEY;
+	const prevClaude: Record<string, string | undefined> = {};
 
 	beforeAll(async () => {
 		await cleanupTestDatabase();
@@ -42,6 +48,15 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		await access(PROVIDERS_JSON); // fail loudly if the path is wrong
 		process.env.LOBU_PROVIDER_REGISTRY_PATH = PROVIDERS_JSON;
 		process.env.OPENAI_API_KEY = "sk-test-builder-provisioning";
+		// Hermetic: clear ambient Claude keys so the openai-pin cases below are
+		// deterministic. Claude is now PREFERRED over openai when its key is
+		// present (resolveBuilderProviders pins the reliable always-API-key
+		// provider first), so a stray ANTHROPIC_API_KEY in the test environment
+		// would otherwise flip these expectations from openai/gpt-4o to claude.
+		for (const v of CLAUDE_ENV_VARS) {
+			prevClaude[v] = process.env[v];
+			delete process.env[v];
+		}
 	});
 
 	afterAll(() => {
@@ -50,6 +65,10 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		else process.env.LOBU_PROVIDER_REGISTRY_PATH = prevRegistryPath;
 		if (prevOpenAI === undefined) delete process.env.OPENAI_API_KEY;
 		else process.env.OPENAI_API_KEY = prevOpenAI;
+		for (const [k, v] of Object.entries(prevClaude)) {
+			if (v === undefined) delete process.env[k];
+			else process.env[k] = v;
+		}
 	});
 
 	async function readBuilder(orgId: string) {
@@ -85,6 +104,32 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		// Deterministic default from providers.json (`openai` → `gpt-4o`).
 		expect(b?.model).toBe("openai/gpt-4o");
 		expect(await readPointer(org.id)).toBe(BUILDER_AGENT_ID);
+	});
+
+	it("prefers Claude over openai when BOTH system keys are present", async () => {
+		// The real-world trap this regression guards: an install carries
+		// OPENAI_API_KEY (which can be a ChatGPT/Codex OAuth token that 403s
+		// against api.openai.com) AND a real ANTHROPIC_API_KEY. The builder must
+		// pin the reliable always-API-key provider (claude), NOT openai/gpt-4o.
+		// The prior test only set OPENAI_API_KEY and asserted openai/gpt-4o, so it
+		// passed while a co-installed builder was dead on arrival in reality.
+		const prev = process.env.ANTHROPIC_API_KEY;
+		process.env.ANTHROPIC_API_KEY = "sk-ant-test-both";
+		try {
+			const org = await createTestOrganization({ name: "builder both keys" });
+			const res = await ensureBuilderAgent(org.id, sql);
+
+			expect(res.created).toBe(true);
+			const b = await readBuilder(org.id);
+			// openai still installs (its key resolves) but must NOT be the pin.
+			expect(
+				b?.installed_providers?.some((p) => p.providerId === "openai"),
+			).toBe(true);
+			expect(b?.model).toBe("claude/claude-sonnet-4-6");
+		} finally {
+			if (prev === undefined) delete process.env.ANTHROPIC_API_KEY;
+			else process.env.ANTHROPIC_API_KEY = prev;
+		}
 	});
 
 	it("repairs a builder stuck with empty providers/model (sentinel no longer makes breakage permanent)", async () => {

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -77,10 +77,10 @@ const BUILDER_MODEL_PROVIDER_PREFERENCE = [
  * Anthropic/Claude is the canonical platform provider but is intentionally NOT
  * in config/providers.json (its model list is fetched live from the provider).
  * Resolve it directly from its env vars so an Anthropic-only deployment still
- * gets a working builder even when the live module registry is empty. The
- * fallback model is a last resort, used only when no config-declared provider
- * model is available — prod also carries openai/gemini keys, so it pins one of
- * those instead and this snapshot is rarely reached.
+ * gets a working builder even when the live module registry is empty. When a
+ * Claude system key is present it is the PREFERRED pin (it is always a real API
+ * key, never an OAuth/Codex backend), so the builder gets a reliable default;
+ * the config-declared providers below are only pinned when Claude is absent.
  */
 const CLAUDE_PROVIDER_ID = 'claude';
 const CLAUDE_SYSTEM_ENV_VARS = [
@@ -173,10 +173,17 @@ async function resolveBuilderProviders(): Promise<ResolvedBuilderProviders> {
     }
     return null;
   };
-  let model: string | null = null;
+  // Prefer Claude (Anthropic) whenever its system key is present. It is the
+  // canonical always-API-key provider — it never routes to an OAuth/Codex
+  // backend, unlike an OPENAI_API_KEY that may actually be a ChatGPT/Codex
+  // token (which 403s against api.openai.com). For the critical system agent we
+  // pin the most reliable provider; the others are only pinned when Claude has
+  // no system key. Claude has no providers.json entry, so it's pinned from
+  // CLAUDE_FALLBACK_MODEL.
+  let model: string | null = hasClaudeSystemKey() ? CLAUDE_FALLBACK_MODEL : null;
   for (const providerId of BUILDER_MODEL_PROVIDER_PREFERENCE) {
-    model = pickModel(providerId);
     if (model) break;
+    model = pickModel(providerId);
   }
   if (!model) {
     for (const providerId of Object.keys(configs)) {
@@ -205,13 +212,6 @@ async function resolveBuilderProviders(): Promise<ResolvedBuilderProviders> {
       // Registry/model fetch unavailable — fall through to the Claude floor.
     }
   }
-  // Registry-independent floor: Claude has no providers.json default, so pin a
-  // current snapshot when it's the only system key available and nothing above
-  // resolved (e.g. an Anthropic-only deploy with an empty registry).
-  if (!model && hasClaudeSystemKey()) {
-    model = CLAUDE_FALLBACK_MODEL;
-  }
-
   return { providers: [...installed.values()], model };
 }
 

--- a/packages/server/src/gateway/__tests__/provider-base-url-collision.test.ts
+++ b/packages/server/src/gateway/__tests__/provider-base-url-collision.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { ApiKeyProviderModule } from "../auth/api-key-provider-module.js";
+import { ChatGPTOAuthModule } from "../auth/chatgpt/chatgpt-oauth-module.js";
+import { detectProviderBaseUrlCollisions } from "../orchestration/base-deployment-manager.js";
+
+/**
+ * Regression: the `chatgpt` (Codex, chatgpt.com/backend-api) provider once
+ * declared `baseUrlEnvVarName: "OPENAI_BASE_URL"` — the SAME key the
+ * sdkCompat:"openai" provider (api.openai.com) emits for the OpenAI SDK. When
+ * both were installed on an agent, the unguarded `Object.assign` merge in
+ * base-deployment-manager let the codex value clobber OPENAI_BASE_URL, so an
+ * `openai/<model>` request egressed to chatgpt.com/backend-api and 403'd
+ * (no ChatGPT session on a fresh install). Each provider MUST own a distinct
+ * base-URL env key so the merge can never mis-route.
+ */
+describe("provider base-URL env key collision", () => {
+  const PROXY = "http://gateway:8080/api/proxy";
+
+  const openaiModule = () =>
+    new ApiKeyProviderModule({
+      providerId: "openai",
+      providerDisplayName: "OpenAI",
+      providerIconUrl: "",
+      envVarName: "OPENAI_API_KEY",
+      apiKeyInstructions: "",
+      apiKeyPlaceholder: "sk-...",
+      slug: "openai",
+      upstreamBaseUrl: "https://api.openai.com/v1",
+      sdkCompat: "openai",
+      defaultModel: "gpt-4o",
+      // Module never touches the manager for base-URL mapping.
+      authProfilesManager: {} as never,
+    });
+  const codexModule = () => new ChatGPTOAuthModule({} as never);
+
+  // A second sdkCompat:"openai" provider — representative of groq/gemini/z-ai/etc.
+  const groqModule = () =>
+    new ApiKeyProviderModule({
+      providerId: "groq",
+      providerDisplayName: "Groq",
+      providerIconUrl: "",
+      envVarName: "GROQ_API_KEY",
+      apiKeyInstructions: "",
+      apiKeyPlaceholder: "gsk-...",
+      slug: "groq",
+      upstreamBaseUrl: "https://api.groq.com/openai/v1",
+      sdkCompat: "openai",
+      defaultModel: "llama-3.3-70b-versatile",
+      authProfilesManager: {} as never,
+    });
+
+  test("openai and chatgpt(codex) do not share any base-URL env key", () => {
+    const openaiKeys = Object.keys(
+      openaiModule().getProxyBaseUrlMappings(PROXY, "a1")
+    );
+    const codexKeys = Object.keys(
+      codexModule().getProxyBaseUrlMappings(PROXY, "a1")
+    );
+    const shared = openaiKeys.filter((k) => codexKeys.includes(k));
+    // Before the fix this was ["OPENAI_BASE_URL"] — a guaranteed clobber.
+    expect(shared).toEqual([]);
+  });
+
+  test("codex routes under its own key; the OpenAI SDK key stays on openai", () => {
+    const codexMap = codexModule().getProxyBaseUrlMappings(PROXY, "a1");
+    // The OpenAI SDK reads OPENAI_BASE_URL — the codex provider must NOT claim it.
+    expect(codexMap.OPENAI_BASE_URL).toBeUndefined();
+    expect(codexMap.OPENAI_CODEX_BASE_URL).toBeDefined();
+    expect(codexMap.OPENAI_CODEX_BASE_URL).toContain("openai-codex");
+
+    const openaiMap = openaiModule().getProxyBaseUrlMappings(PROXY, "a1");
+    // The plain OpenAI provider owns OPENAI_BASE_URL, routed to its own slug.
+    expect(openaiMap.OPENAI_BASE_URL).toBeDefined();
+    expect(openaiMap.OPENAI_BASE_URL).not.toContain("openai-codex");
+  });
+
+  test("only the literal openai provider claims OPENAI_BASE_URL; other sdkCompat providers use their own key", () => {
+    // The general form of the bug: EVERY sdkCompat:"openai" provider used to
+    // emit OPENAI_BASE_URL, so co-installing openai with any of them (groq,
+    // gemini, z-ai, …) let the last-merged one clobber it and an openai/<model>
+    // request egressed to the wrong slug. Only `openai` may own OPENAI_BASE_URL.
+    const openaiMap = openaiModule().getProxyBaseUrlMappings(PROXY, "a1");
+    const groqMap = groqModule().getProxyBaseUrlMappings(PROXY, "a1");
+
+    expect(openaiMap.OPENAI_BASE_URL).toBeDefined();
+    // groq must NOT emit OPENAI_BASE_URL — it resolves via its own key.
+    expect(groqMap.OPENAI_BASE_URL).toBeUndefined();
+    expect(Object.keys(groqMap).some((k) => k.includes("GROQ"))).toBe(true);
+    // No base-URL env key is shared between the two providers.
+    const shared = Object.keys(openaiMap).filter((k) =>
+      Object.keys(groqMap).includes(k)
+    );
+    expect(shared).toEqual([]);
+  });
+});
+
+describe("detectProviderBaseUrlCollisions (deploy-time merge guard)", () => {
+  test("flags two providers claiming the same key with different URLs", () => {
+    const collisions = detectProviderBaseUrlCollisions([
+      { providerId: "openai", mappings: { OPENAI_BASE_URL: "http://gw/openai" } },
+      { providerId: "groq", mappings: { OPENAI_BASE_URL: "http://gw/groq" } },
+    ]);
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0]).toMatchObject({
+      key: "OPENAI_BASE_URL",
+      providerId: "groq",
+      existing: "http://gw/openai",
+      incoming: "http://gw/groq",
+    });
+  });
+
+  test("does not flag distinct keys (the fixed state)", () => {
+    const collisions = detectProviderBaseUrlCollisions([
+      { providerId: "openai", mappings: { OPENAI_BASE_URL: "http://gw/openai" } },
+      {
+        providerId: "chatgpt",
+        mappings: { OPENAI_CODEX_BASE_URL: "http://gw/openai-codex" },
+      },
+      { providerId: "groq", mappings: { GROQ_API_BASE_URL: "http://gw/groq" } },
+    ]);
+    expect(collisions).toEqual([]);
+  });
+
+  test("same key with the SAME value is not a collision (idempotent)", () => {
+    const collisions = detectProviderBaseUrlCollisions([
+      { providerId: "a", mappings: { K: "http://gw/x" } },
+      { providerId: "b", mappings: { K: "http://gw/x" } },
+    ]);
+    expect(collisions).toEqual([]);
+  });
+});

--- a/packages/server/src/gateway/__tests__/provider-registry-contract.test.ts
+++ b/packages/server/src/gateway/__tests__/provider-registry-contract.test.ts
@@ -130,11 +130,20 @@ describe("provider registry contract (config/providers.json)", () => {
 				expect(mappings[baseUrlEnvVar]).toBeDefined();
 				expect(mappings[baseUrlEnvVar]).toContain(`${proxyUrl}/${id}`);
 
-				// OpenAI-compatible providers also remap OPENAI_BASE_URL so the
-				// OpenAI SDK the worker uses resolves through our proxy.
+				// Only the literal `openai` provider may own OPENAI_BASE_URL — the
+				// worker reads DEFAULT_PROVIDER_BASE_URL_ENV.openai === "OPENAI_BASE_URL"
+				// for it. Every OTHER sdkCompat provider resolves through its own
+				// <PROVIDER>_BASE_URL key (asserted above) and applies it as the model
+				// baseUrl explicitly, so it must NOT also claim OPENAI_BASE_URL: sharing
+				// that key let a co-installed provider clobber it on merge and mis-route
+				// openai/<model> requests to the wrong slug.
 				if (provider.sdkCompat === "openai") {
-					expect(mappings.OPENAI_BASE_URL).toBeDefined();
-					expect(mappings.OPENAI_BASE_URL).toContain(`${proxyUrl}/${id}`);
+					if (id === "openai") {
+						expect(mappings.OPENAI_BASE_URL).toBeDefined();
+						expect(mappings.OPENAI_BASE_URL).toContain(`${proxyUrl}/${id}`);
+					} else {
+						expect(mappings.OPENAI_BASE_URL).toBeUndefined();
+					}
 				}
 			});
 

--- a/packages/server/src/gateway/auth/api-key-provider-module.ts
+++ b/packages/server/src/gateway/auth/api-key-provider-module.ts
@@ -67,8 +67,17 @@ export class ApiKeyProviderModule extends BaseProviderModule {
   }
 
   /**
-   * For openai-compatible providers, also map OPENAI_BASE_URL so the
-   * OpenAI SDK resolves through our proxy.
+   * Map OPENAI_BASE_URL so the OpenAI SDK resolves through our proxy — but ONLY
+   * for the literal `openai` provider. The worker reads
+   * DEFAULT_PROVIDER_BASE_URL_ENV.openai === "OPENAI_BASE_URL", so openai needs
+   * it under that exact key. Every OTHER sdkCompat:"openai" provider (groq,
+   * gemini, z-ai, openrouter, …) resolves its base URL through its OWN dedicated
+   * <PROVIDER>_BASE_URL key (super emits it; the worker reads it via
+   * DEFAULT_PROVIDER_BASE_URL_ENV, or falls back to the per-run singular
+   * providerBaseUrl). Emitting OPENAI_BASE_URL for those too made every
+   * sdkCompat provider claim the SAME key, so co-installing openai with any of
+   * them let the last-merged one clobber it and an openai/<model> request
+   * egressed to the wrong slug. Keep this key owned by openai alone.
    */
   override getProxyBaseUrlMappings(
     proxyUrl: string,
@@ -76,7 +85,7 @@ export class ApiKeyProviderModule extends BaseProviderModule {
     context?: import("../embedded.js").ProviderCredentialContext
   ): Record<string, string> {
     const mappings = super.getProxyBaseUrlMappings(proxyUrl, agentId, context);
-    if (this.apiKeyConfig.sdkCompat === "openai") {
+    if (this.apiKeyConfig.sdkCompat === "openai" && this.providerId === "openai") {
       const slug = this.providerConfig.slug || this.providerId;
       mappings.OPENAI_BASE_URL = this.buildAgentScopedProxyUrl(
         proxyUrl,

--- a/packages/server/src/gateway/auth/chatgpt/chatgpt-oauth-module.ts
+++ b/packages/server/src/gateway/auth/chatgpt/chatgpt-oauth-module.ts
@@ -27,7 +27,13 @@ export class ChatGPTOAuthModule extends BaseProviderModule {
         secretEnvVarNames: ["OPENAI_API_KEY"],
         slug: "openai-codex",
         upstreamBaseUrl: "https://chatgpt.com/backend-api",
-        baseUrlEnvVarName: "OPENAI_BASE_URL",
+        // Dedicated key — must NOT be "OPENAI_BASE_URL". The config-driven
+        // `openai` provider (sdkCompat "openai", api.openai.com) also emits
+        // OPENAI_BASE_URL; sharing the key let an unguarded merge clobber it so
+        // an `openai/<model>` request egressed to chatgpt.com/backend-api (403
+        // without a ChatGPT session). Keep this provider's base URL under its
+        // own key so the two never collide.
+        baseUrlEnvVarName: "OPENAI_CODEX_BASE_URL",
         authType: "device-code",
         supportedAuthTypes: ["device-code", "api-key"],
         apiKeyInstructions:

--- a/packages/server/src/gateway/orchestration/base-deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/base-deployment-manager.ts
@@ -30,6 +30,37 @@ import { buildWorkerTokenClaims } from "./worker-token-claims.js";
 const logger = createLogger("orchestrator");
 
 /**
+ * Detect base-URL env keys claimed by more than one provider with CONFLICTING
+ * values. When agents merge every installed provider's proxy base-URL mappings,
+ * two providers sharing a key (e.g. the old bug where every sdkCompat provider
+ * emitted OPENAI_BASE_URL) means the later-merged one silently clobbers the
+ * earlier and a request egresses to the wrong slug. Pure + exported so the guard
+ * is testable independently of a full deploy. Order matches the merge:
+ * last-write-wins, so `incoming` is what survives.
+ */
+export function detectProviderBaseUrlCollisions(
+  perProvider: Array<{ providerId: string; mappings: Record<string, string> }>
+): Array<{ key: string; providerId: string; existing: string; incoming: string }> {
+  const seen: Record<string, string> = {};
+  const collisions: Array<{
+    key: string;
+    providerId: string;
+    existing: string;
+    incoming: string;
+  }> = [];
+  for (const { providerId, mappings } of perProvider) {
+    for (const [key, value] of Object.entries(mappings)) {
+      const existing = seen[key];
+      if (existing !== undefined && existing !== value) {
+        collisions.push({ key, providerId, existing, incoming: value });
+      }
+      seen[key] = value;
+    }
+  }
+  return collisions;
+}
+
+/**
  * Mint the deployment-lifetime WORKER_TOKEN. This is the FALLBACK gateway auth
  * the worker uses when no per-run runJobToken was minted (`session-runner`:
  * `runJobToken || WORKER_TOKEN`). Extracted (mirrors message-consumer's
@@ -1035,13 +1066,26 @@ export abstract class BaseDeploymentManager {
 
     // Build full provider base URL mappings for all installed providers
     const proxyBaseUrl = `${this.getDispatcherUrl()}/api/proxy`;
-    const providerBaseUrlMappings: Record<string, string> = {};
-    for (const provider of effectiveProviders) {
-      const mappings = provider.getProxyBaseUrlMappings(
+    const perProvider = effectiveProviders.map((provider) => ({
+      providerId: provider.providerId,
+      mappings: provider.getProxyBaseUrlMappings(
         proxyBaseUrl,
         agentId,
         providerContext
+      ),
+    }));
+    // Guard against two providers claiming the same base-URL env key with
+    // different values: the later one silently clobbers the earlier and
+    // mis-routes (this is exactly how an `openai/<model>` call once egressed to
+    // the codex backend). Surface it loudly instead of hiding it.
+    for (const c of detectProviderBaseUrlCollisions(perProvider)) {
+      logger.warn(
+        { agentId, ...c },
+        "[base-deployment] provider base-URL env key collision — two providers map the same key to different URLs; the later one wins and may mis-route. Each provider must use a distinct baseUrlEnvVarName."
       );
+    }
+    const providerBaseUrlMappings: Record<string, string> = {};
+    for (const { mappings } of perProvider) {
       Object.assign(providerBaseUrlMappings, mappings);
     }
     if (Object.keys(providerBaseUrlMappings).length > 0) {


### PR DESCRIPTION
The per-org system/builder agent was provisioned with a model that can't actually run on a fresh install, so the builder chat was dead on arrival — it hit `chatgpt.com/backend-api` and 403'd. Two separate bugs.

**Env-key collision.** Every `sdkCompat:"openai"` provider — openai, groq, gemini, z-ai, the chatgpt/Codex backend, all of them — emitted the same `OPENAI_BASE_URL` key. But the worker only reads `OPENAI_BASE_URL` for the literal `openai` provider; every other one resolves through its own `<PROVIDER>_BASE_URL` key and applies it to the model explicitly. So as soon as you installed openai alongside any other sdkCompat provider, the deploy-time merge let whichever sorted last overwrite `OPENAI_BASE_URL` with its own slug, and an `openai/<model>` request egressed to the wrong backend. The builder's `openai/gpt-4o` landed on the Codex backend and 403'd. Fix: only `openai` emits `OPENAI_BASE_URL`; the Codex backend gets its own `OPENAI_CODEX_BASE_URL` key on both the gateway and the worker; and the deploy-time merge now warns loudly if any two providers ever claim the same base-URL key again.

**Builder default-model preference.** It pinned openai first and treated Claude as a last resort, so an Anthropic-keyed install that also carried any `OPENAI_API_KEY` pinned the (now-dead) `openai/gpt-4o`. The builder now prefers Claude — the canonical always-API-key provider — whenever its system key is present.

### Tests
- `provider-base-url-collision`: no two sdkCompat providers share a base-URL key, only openai owns `OPENAI_BASE_URL` (red→green against the old behavior), plus a unit test for the collision guard.
- `provider-registry-contract`: updated to the per-provider-key contract (it previously asserted the buggy shared-key behavior).
- `model-resolver`: a worker-side invariant pinning `openai-codex`'s distinct key.
- `builder-provisioning`: a regression that pins Claude when both system keys are present. The prior test only set `OPENAI_API_KEY` and asserted the model string, so it stayed green while the agent was unusable in reality.

Verified on a fresh local install: the builder provisions to `claude/claude-sonnet-4-6` and runs end to end (the `ask_user` card renders, routed to `api.anthropic.com`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784744326&installation_id=136316292&pr_number=1481&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1481&signature=efd982e5e17ea7e3fe14ba92611aff2b26416a0e076057ca1f1c3abc18d0444f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved environment variable configuration conflicts when multiple AI providers are installed.
  * Improved automatic provider selection to prioritize Claude when available.

* **Tests**
  * Expanded test coverage for provider configuration validation and collision detection scenarios.

* **Improvements**
  * Enhanced provider configuration isolation to prevent environment variable key collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->