### PR TITLE
feat(connectors): system-audio (meeting) device connector

### DIFF
--- a/packages/connectors/src/apple_system_audio.ts
+++ b/packages/connectors/src/apple_system_audio.ts
@@ -1,0 +1,59 @@
+/**
+ * System Audio (meeting) Connector — Lobu for Mac only.
+ *
+ * Lobu for Mac captures system audio via ScreenCaptureKit (user-triggered
+ * "Record meeting") into short AAC segments and ships each finalized segment
+ * as an audio attachment under this connector's `recordings` feed. The
+ * gateway's inline-attachment TranscriptionService turns each segment into a
+ * transcript (same path WhatsApp voice notes use) — the placeholder
+ * `[meeting audio]` payload is superseded by the transcribed text.
+ *
+ * Audio bytes are captured + held on the device; only the (capped) segment
+ * attachments leave it, and recording only happens while the user has it on.
+ */
+
+import { BridgeOnlyConnector, type ConnectorDefinition } from '@lobu/connector-sdk';
+
+const BRIDGE_ONLY =
+  'apple.system_audio runs only on a worker advertising capability "system_audio" (Lobu for Mac with Screen Recording access).';
+
+export default class AppleSystemAudioConnector extends BridgeOnlyConnector {
+  constructor() {
+    super(BRIDGE_ONLY);
+  }
+
+  readonly definition: ConnectorDefinition = {
+    key: 'apple.system_audio',
+    name: 'Meeting Audio',
+    description:
+      'Record system audio (meetings) on this Mac via Lobu for Mac and transcribe it. Audio is captured on the device; only short segments are shipped, and only while recording is on.',
+    version: '0.1.0',
+    faviconDomain: 'apple.com',
+    requiredCapability: 'system_audio',
+    runtime: { platforms: ['macos'] },
+    authSchema: { methods: [{ type: 'none' }] },
+    feeds: {
+      recordings: {
+        key: 'recordings',
+        name: 'Recordings',
+        description: 'System-audio segments captured while recording; transcribed server-side.',
+        configSchema: { type: 'object', properties: {} },
+        eventKinds: {
+          recording: {
+            description: 'A single captured audio segment (transcribed after ingest).',
+            metadataSchema: {
+              type: 'object',
+              required: ['source', 'origin_id'],
+              properties: {
+                source: { type: 'string', const: 'system_audio' },
+                origin_id: { type: 'string' },
+                filename: { type: 'string' },
+                size_bytes: { type: 'integer' },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -52,6 +52,7 @@ export const MAC_DEVICE_CAPABILITIES = [
   "healthkit",
   "photos",
   "whatsapp_local",
+  "system_audio",
 ] as const;
 
 const PLATFORM_ALLOWLIST: Record<string, readonly string[]> = {


### PR DESCRIPTION
## What
`apple.system_audio` connector (capability `system_audio` added to `MAC_DEVICE_CAPABILITIES`) for the ScreenCaptureKit meeting-capture in owletto. Segments ship as audio attachments and are transcribed by the existing inline-attachment `TranscriptionService`. Bumps the `packages/owletto` pointer.

## Test
- Pre-commit `tsc --noEmit` clean; connector compiles into the catalog manifest.
- owletto Mac app builds clean with the capture service.

## Order
Land lobu-ai/owletto (system-audio) first; pointer targets its commit. On-device verification pending — draft.

Depends on: lobu-ai/owletto system-audio PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784744784&installation_id=136316292&pr_number=1482&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1482&signature=9773538ad0a4b4baf308265c8ba8b2ad125d875aea0db3c7f6e3fb74712e61f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->