### PR TITLE
fix(worker): expose customTools to the model (pi 0.73.x treats options.tools as a hard allowlist)

### DIFF
--- a/packages/agent-worker/src/__tests__/active-tool-names.test.ts
+++ b/packages/agent-worker/src/__tests__/active-tool-names.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { activeToolNames } from "../openclaw/active-tool-names";
+
+/**
+ * Regression for the pi 0.73.x P0: `options.tools` is a HARD allowlist, so the
+ * list handed to createAgentSession MUST include the customTool names or every
+ * MCP/built-in custom tool (ask_user, memory, query_sql, image/audio, plugins)
+ * is filtered out before the model — agents were left with only the base
+ * built-ins (read/write/edit/bash/grep/find/ls).
+ */
+describe("activeToolNames — pi treats `tools` as a hard allowlist", () => {
+  test("unions base AND custom tool names (custom must survive the allowlist)", () => {
+    const base = [{ name: "read" }, { name: "bash" }];
+    const custom = [
+      { name: "ask_user" },
+      { name: "search_memory" },
+      { name: "query_sql" },
+    ];
+
+    const names = activeToolNames(base, custom);
+
+    expect(names).toEqual([
+      "read",
+      "bash",
+      "ask_user",
+      "search_memory",
+      "query_sql",
+    ]);
+    // The exact P0: dropping these made every custom tool vanish from the agent.
+    for (const c of custom) {
+      expect(names).toContain(c.name);
+    }
+  });
+
+  test("custom tools survive alongside the full bare built-in set", () => {
+    const base = ["read", "write", "edit", "bash", "grep", "find", "ls"].map(
+      (name) => ({ name })
+    );
+    const custom = [{ name: "ask_user" }, { name: "save_memory" }];
+
+    const names = activeToolNames(base, custom);
+
+    expect(names).toContain("ask_user");
+    expect(names).toContain("save_memory");
+    expect(names.length).toBe(base.length + custom.length);
+  });
+
+  test("empty custom set yields exactly the base names (no accidental extras)", () => {
+    expect(activeToolNames([{ name: "bash" }], [])).toEqual(["bash"]);
+  });
+});

--- a/packages/agent-worker/src/openclaw/active-tool-names.ts
+++ b/packages/agent-worker/src/openclaw/active-tool-names.ts
@@ -1,0 +1,22 @@
+/**
+ * Build the tool-name list handed to pi's `createAgentSession({ tools })`.
+ *
+ * pi (0.73.x+) treats this list as BOTH the initial active set AND a hard
+ * allowlist (`allowedToolNames = options.tools`; agent-session filters every
+ * registered/custom tool whose name isn't in it). It therefore MUST include the
+ * customTool names (ask_user, MCP tools, memory, plugins, image/audio) — passing
+ * only the base built-in names silently drops every customTool before the model
+ * sees it, leaving agents with just read/write/edit/bash/grep/find/ls.
+ *
+ * Kept as a tiny pure function so the base+custom union is unit-testable without
+ * standing up a full session.
+ */
+export function activeToolNames(
+  baseTools: ReadonlyArray<{ name: string }>,
+  customTools: ReadonlyArray<{ name: string }>
+): string[] {
+  return [
+    ...baseTools.map((tool) => tool.name),
+    ...customTools.map((tool) => tool.name),
+  ];
+}

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -54,6 +54,7 @@ import {
   wrapToolsWithPluginToolHooks,
 } from "./plugin-loader";
 import type { OpenClawProgressProcessor } from "./processor";
+import { activeToolNames } from "./active-tool-names";
 import { getOpenClawSessionContext } from "./session-context";
 import {
   buildToolPolicy,
@@ -1114,7 +1115,17 @@ Use it when the user references past discussions or you need context.`);
       // too. The guard runs inside execute (before the tool body), so the
       // bound is tight — unlike the agent's async tool_execution_start event,
       // which lags several turns behind real execution.
-      tools: tools.map((tool) => tool.name),
+      // pi 0.73.x treats `tools` as BOTH the initial active set AND a hard
+      // allowlist (sdk.js: `allowedToolNames = options.tools`; agent-session
+      // filters every registered/custom tool whose name isn't in it). Passing
+      // only the base built-in names therefore silently dropped EVERY customTool
+      // (ask_user, MCP tools, memory, plugins, image/audio) before the model
+      // saw it — agents were left with just read/write/edit/bash/grep/find/ls.
+      // activeToolNames() unions the customTool names in so they survive the
+      // allowlist and stay active. (`builtinOverrides` still supplies the
+      // base-tool instances; the customTool instances come from the
+      // `customTools` option below.)
+      tools: activeToolNames(tools, customTools),
       builtinOverrides: wrapToolsWithTurnGuard(tools, turnController),
       // Wrap custom tools (plugin + MCP) so plugin before_tool_call/
       // after_tool_call hooks fire around in-process execution — these never


### PR DESCRIPTION
pi 0.73.x changed `createAgentSession`'s `tools` option: it's now both the initial active set **and** a hard allowlist (`allowedToolNames = options.tools`). Any registered or custom tool whose name isn't in that list is filtered out before the model ever sees it.

The session runner passed only the base built-in names, so every customTool — `ask_user`, all the MCP tools (memory, `query_sql`, connections, watchers, agents), plugins, image/audio — was silently dropped. Agents were left with just `read/write/edit/bash/grep/find/ls`. This hit every agent on the affected pi version.

The fix unions the customTool names into the allowlist. I pulled the list-building into a small pure `activeToolNames` helper so it's unit-testable — the test asserts the custom names survive (red→green: dropping the union fails it), closing the coverage gap that let this ship the first time.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784747334&installation_id=136316292&pr_number=1484&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1484&signature=a1aa4609e6818d0c819c17ed57b795f6f9ae3e8f956543b0604535f3b088b825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent sessions to properly include custom tools in the active tool allowlist, enabling the agent to access all configured plugins and custom features.

* **Tests**
  * Added test coverage for tool-name handling and allowlist behavior in agent sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->