### PR TITLE
feat(api): pending-approvals endpoint + owletto pointer bump (interactive approval cards)

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-session-create.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-session-create.test.ts
@@ -387,6 +387,16 @@ describe("POST /api/v1/agents — default-agent resolution", () => {
       success: false,
       error: "Forbidden",
     });
+
+    // The pending-approvals route returns tool requestIds + args for a
+    // conversation, so it MUST enforce the same cross-org gate — without the
+    // authorizeAgentAccess pre-gate it had no auth at all and leaked another
+    // org's approval payloads (IDOR). The denial fires before the pending-tool
+    // store is touched, so this needs no DB.
+    const pendingDenied = await app.request(
+      `/api/v1/agents/${orgASession}/pending-approvals`
+    );
+    expect(pendingDenied.status).toBe(403);
   });
 
   test("returns 404 when the default agent belongs to a different org", async () => {

--- a/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
+++ b/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
@@ -46,9 +46,16 @@ export async function storePendingTool(
  * on load and replays open approvals as approval cards; resolution stays
  * claim-and-delete via `takePendingTool`, so a row surfaced here disappears the
  * moment the user approves/denies and never replays.
+ *
+ * `organizationId` is REQUIRED — it MUST be the caller's AUTHORIZED org
+ * (resolved by the route's authorizeAgentAccess) and always scopes the read so a
+ * row can never cross tenants, defense-in-depth on top of the conversationId
+ * key. The route returns 403 when no org resolves rather than ever issuing an
+ * unscoped read.
  */
 export async function listPendingToolsForConversation(
 	conversationId: string,
+	organizationId: string,
 ): Promise<Array<PendingToolInvocation & { requestId: string }>> {
 	const sql = getDb();
 	const rows = await sql`
@@ -57,6 +64,7 @@ export async function listPendingToolsForConversation(
     WHERE scope = ${SCOPE}
       AND expires_at > now()
       AND payload->>'conversationId' = ${conversationId}
+      AND payload->>'organizationId' = ${organizationId}
     ORDER BY expires_at ASC
   `;
 	return rows.map((r) => {

--- a/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
+++ b/packages/server/src/gateway/auth/mcp/pending-tool-store.ts
@@ -40,6 +40,32 @@ export async function storePendingTool(
 }
 
 /**
+ * Read (without consuming) the unresolved pending-tool invocations for a
+ * conversation. The live `tool-approval` SSE card is one-shot, so without this
+ * a pending approval vanishes from the web UI on reload. The SPA fetches this
+ * on load and replays open approvals as approval cards; resolution stays
+ * claim-and-delete via `takePendingTool`, so a row surfaced here disappears the
+ * moment the user approves/denies and never replays.
+ */
+export async function listPendingToolsForConversation(
+	conversationId: string,
+): Promise<Array<PendingToolInvocation & { requestId: string }>> {
+	const sql = getDb();
+	const rows = await sql`
+    SELECT id, payload
+    FROM oauth_states
+    WHERE scope = ${SCOPE}
+      AND expires_at > now()
+      AND payload->>'conversationId' = ${conversationId}
+    ORDER BY expires_at ASC
+  `;
+	return rows.map((r) => {
+		const row = r as { id: string; payload: PendingToolInvocation };
+		return { ...row.payload, requestId: row.id };
+	});
+}
+
+/**
  * Atomically fetch and delete a pending tool invocation. Used by the
  * interaction bridge / CLI approve handler to claim the row exactly
  * once — Slack/Telegram webhook retries that arrive after the first

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1575,7 +1575,25 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
   // which is what pending tools are keyed by.
   app.get("/api/v1/agents/:agentId/pending-approvals", async (c) => {
     const conversationId = c.req.param("agentId");
-    const pending = await listPendingToolsForConversation(conversationId);
+    // The path param is the conversationId (sessionKey). Resolve the session to
+    // the real agentId + org and AUTHORIZE the caller BEFORE returning anything:
+    // these rows carry tool requestIds + arguments, so an
+    // unauthorized-for-this-conversation read is an IDOR. Mirror the messages
+    // route's pre-gate exactly.
+    const preSession = await sessMgr.getSession(conversationId);
+    const resolvedAgentId = preSession?.agentId || conversationId;
+    const access = await authorizeAgentAccess(c, resolvedAgentId, preSession);
+    if (access instanceof Response) return access;
+    // The read MUST be org-scoped. authorizeAgentAccess resolves the org for
+    // every legitimate caller; refuse rather than issue an unscoped read if it
+    // somehow didn't.
+    if (!access.organizationId) {
+      return c.json({ success: false, error: "Forbidden" }, 403);
+    }
+    const pending = await listPendingToolsForConversation(
+      conversationId,
+      access.organizationId
+    );
     return c.json({
       approvals: pending.map((p) => ({
         requestId: p.requestId,

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -18,6 +18,7 @@ import { DEFAULT_AGENT_ID } from "../../../auth/default-provisioning.js";
 import { getDb } from "../../../db/client.js";
 import { getCachedOrgBySlug } from "../../../workspace/multi-tenant.js";
 import type { AgentMetadataStore } from "../../auth/agent-metadata-store.js";
+import { listPendingToolsForConversation } from "../../auth/mcp/pending-tool-store.js";
 import { getRevokedTokenStore } from "../../auth/revoked-token-store.js";
 import {
   createApiAuthMiddleware,
@@ -1566,6 +1567,24 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       return c.json({ success: true });
     });
   }
+
+  // GET /api/v1/agents/{agentId}/pending-approvals - Replay open tool approvals
+  // for a conversation so the web SPA can re-render approval cards on reload
+  // (the live `tool-approval` SSE card is one-shot). The path param IS the
+  // conversationId (messagesUrl is /api/v1/agents/{conversationId}/messages),
+  // which is what pending tools are keyed by.
+  app.get("/api/v1/agents/:agentId/pending-approvals", async (c) => {
+    const conversationId = c.req.param("agentId");
+    const pending = await listPendingToolsForConversation(conversationId);
+    return c.json({
+      approvals: pending.map((p) => ({
+        requestId: p.requestId,
+        mcpId: p.mcpId,
+        toolName: p.toolName,
+        args: p.args,
+      })),
+    });
+  });
 
   logger.debug("Hono Agent API routes registered");
 


### PR DESCRIPTION
The server half of the conversational approval-card work, plus the owletto pointer bump that lands the client (owletto-ai/owletto#334, merged).

- New endpoint `GET /api/v1/agents/{agentId}/pending-approvals` returns the still-open tool approvals for a conversation (reads the `pending-tool` rows by `conversationId`). The web client queries it on reload so a tool-approval card re-hydrated from the persisted transcript knows whether its approval is still open (show buttons) or was already resolved (show "handled") — without it, a resolved approval shows live buttons again after reload.
- Bumps the owletto submodule pointer to `b8b5dbe` (the merged #334). This also advances the pin past the stale SHA that was tripping `check-drift`.

Verified end to end this session: the approval card renders, Approve grants and the tool runs, and the card re-hydrates correctly on reload via this endpoint.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784748359&installation_id=136316292&pr_number=1486&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1486&signature=c61e29e9f9cd7bb8d1ea48da776c7fb73016e3f684679d2c40b3fa96fd682008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to retrieve and replay pending tool approvals for conversations after page reload.

* **Tests**
  * Enhanced cross-tenant authorization verification for pending approvals endpoint.

* **Chores**
  * Updated subproject dependency reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->