### PR TITLE
fix(connections): resolve asserted auth-profile slug in app_installation guard

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
@@ -13,6 +13,7 @@
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { Env } from "../../../index";
 import type { ToolContext } from "../../../tools/registry";
+import { manageAuthProfiles } from "../../../tools/admin/manage_auth_profiles";
 import { manageConnections } from "../../../tools/admin/manage_connections";
 import { getTestDb } from "../../setup/test-db";
 import { initWorkspaceProvider } from "../../../workspace";
@@ -76,6 +77,40 @@ async function seedAppInstallConnector(organizationId: string): Promise<void> {
 	});
 }
 
+/**
+ * Create a REAL, resolvable auth profile for the seeded connector so the
+ * selection-aware guard sees a slug that actually resolves (the guard resolves
+ * the slug against auth_profiles — a bare asserted string no longer satisfies
+ * it). Returns the slug the profile ended up with.
+ */
+async function createRealAuthProfile(
+	ctx: ToolContext,
+	opts: {
+		profileKind: "env" | "oauth_app";
+		slug: string;
+		credentials: Record<string, string>;
+	},
+): Promise<string> {
+	const res = await manageAuthProfiles(
+		{
+			action: "create_auth_profile",
+			connector_key: CONNECTOR_KEY,
+			profile_kind: opts.profileKind,
+			display_name: opts.slug,
+			slug: opts.slug,
+			credentials: opts.credentials,
+		},
+		TEST_ENV,
+		ctx,
+	);
+	if (!("auth_profile" in res)) {
+		throw new Error(
+			`Failed to seed ${opts.profileKind} auth profile: ${JSON.stringify(res)}`,
+		);
+	}
+	return (res.auth_profile as { slug: string }).slug;
+}
+
 async function connectionCount(organizationId: string): Promise<number> {
 	const sql = getTestDb();
 	const rows = (await sql`
@@ -94,6 +129,7 @@ beforeAll(async () => {
 afterEach(async () => {
 	const sql = getTestDb();
 	await sql`DELETE FROM connections WHERE connector_key = ${CONNECTOR_KEY}`;
+	await sql`DELETE FROM auth_profiles WHERE connector_key = ${CONNECTOR_KEY}`;
 	await sql`DELETE FROM connector_definitions WHERE key = ${CONNECTOR_KEY}`;
 });
 
@@ -195,8 +231,71 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 		// No error at all is also a pass (guard skipped, create proceeded).
 	}
 
-	it("create WITH auth_profile_slug (oauth intent) is ALLOWED past the guard", async () => {
+	/** Assert the create/connect WAS rejected by the app-install guard. */
+	function expectGuardRejected(res: unknown): void {
+		expect(res && typeof res === "object" && "error" in res).toBe(true);
+		expect((res as { error: string }).error).toMatch(/\/github\/app\/install/);
+	}
+
+	it("create WITH a RESOLVABLE auth_profile_slug (oauth intent) is ALLOWED past the guard", async () => {
 		const org = await createTestOrganization({ name: "OAuth Profile Create Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+		// A REAL env-backed profile the guard can resolve to.
+		const slug = await createRealAuthProfile(ctx, {
+			profileKind: "env",
+			slug: "real-env-profile",
+			credentials: { DEMO_TOKEN: "ghp_real_token" },
+		});
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "oauth-create",
+				display_name: "OAuth Create",
+				device_worker_id: null,
+				auth_profile_slug: slug,
+			},
+			TEST_ENV,
+			ctx,
+		);
+		expectGuardSkipped(res);
+	});
+
+	it("connect WITH a RESOLVABLE auth_profile_slug (oauth intent) is ALLOWED past the guard", async () => {
+		const org = await createTestOrganization({ name: "OAuth Profile Connect Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+		const slug = await createRealAuthProfile(ctx, {
+			profileKind: "env",
+			slug: "real-env-profile-connect",
+			credentials: { DEMO_TOKEN: "ghp_real_token" },
+		});
+
+		const res = await manageConnections(
+			{
+				action: "connect",
+				connector_key: CONNECTOR_KEY,
+				slug: "oauth-connect",
+				auth_profile_slug: slug,
+			},
+			TEST_ENV,
+			ctx,
+		);
+		expectGuardSkipped(res);
+	});
+
+	it("create WITH a NON-EXISTENT auth_profile_slug + no installation_ref is REJECTED (bypass closed)", async () => {
+		// The latent gap: the guard used to TRUST the asserted slug. A caller could
+		// pass a bogus, non-resolvable slug to bypass the guard and create a dead,
+		// unbound app_installation connection. The guard now RESOLVES the slug —
+		// an unresolvable one is treated as no slug at all → rejected.
+		const org = await createTestOrganization({ name: "Bogus Slug Create Org" });
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
 		await seedAppInstallConnector(org.id);
@@ -206,19 +305,21 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 			{
 				action: "create",
 				connector_key: CONNECTOR_KEY,
-				slug: "oauth-create",
-				display_name: "OAuth Create",
+				slug: "bogus-slug-create",
+				display_name: "Bogus Slug Create",
 				device_worker_id: null,
-				auth_profile_slug: "some-oauth-profile",
+				// No such auth profile exists for this org/connector.
+				auth_profile_slug: "does-not-exist-anywhere",
 			},
 			TEST_ENV,
 			ctx,
 		);
-		expectGuardSkipped(res);
+		expectGuardRejected(res);
+		expect(await connectionCount(org.id)).toBe(0);
 	});
 
-	it("connect WITH auth_profile_slug (oauth intent) is ALLOWED past the guard", async () => {
-		const org = await createTestOrganization({ name: "OAuth Profile Connect Org" });
+	it("connect WITH a NON-EXISTENT auth_profile_slug + no installation_ref is REJECTED (bypass closed)", async () => {
+		const org = await createTestOrganization({ name: "Bogus Slug Connect Org" });
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
 		await seedAppInstallConnector(org.id);
@@ -228,13 +329,37 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 			{
 				action: "connect",
 				connector_key: CONNECTOR_KEY,
-				slug: "oauth-connect",
-				auth_profile_slug: "some-oauth-profile",
+				slug: "bogus-slug-connect",
+				auth_profile_slug: "does-not-exist-anywhere",
 			},
 			TEST_ENV,
 			ctx,
 		);
-		expectGuardSkipped(res);
+		expectGuardRejected(res);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("create WITH a NON-EXISTENT app_auth_profile_slug + no installation_ref is REJECTED (bypass closed)", async () => {
+		const org = await createTestOrganization({ name: "Bogus App Slug Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "bogus-app-slug-create",
+				display_name: "Bogus App Slug Create",
+				device_worker_id: null,
+				app_auth_profile_slug: "no-such-oauth-app",
+			},
+			TEST_ENV,
+			ctx,
+		);
+		expectGuardRejected(res);
+		expect(await connectionCount(org.id)).toBe(0);
 	});
 
 	it("create WITH env/PAT creds in config is ALLOWED past the guard", async () => {
@@ -260,12 +385,21 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 		expectGuardSkipped(res);
 	});
 
-	it("create WITH app_auth_profile_slug is ALLOWED past the guard", async () => {
+	it("create WITH a RESOLVABLE app_auth_profile_slug is ALLOWED past the guard", async () => {
 		const org = await createTestOrganization({ name: "App Profile Create Org" });
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
 		await seedAppInstallConnector(org.id);
 		const ctx = ctxFor(org.id, user.id);
+		// A REAL oauth_app profile (local client creds) the guard can resolve to.
+		const appSlug = await createRealAuthProfile(ctx, {
+			profileKind: "oauth_app",
+			slug: "real-oauth-app",
+			credentials: {
+				DEMO_CLIENT_ID: "client-id",
+				DEMO_CLIENT_SECRET: "client-secret",
+			},
+		});
 
 		const res = await manageConnections(
 			{
@@ -274,7 +408,7 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 				slug: "appprofile-create",
 				display_name: "App Profile Create",
 				device_worker_id: null,
-				app_auth_profile_slug: "some-oauth-app",
+				app_auth_profile_slug: appSlug,
 			},
 			TEST_ENV,
 			ctx,
@@ -282,11 +416,47 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 		expectGuardSkipped(res);
 	});
 
-	it("lobu-apply-style oauth create (auth_profile_slug, no installation_ref) is ALLOWED", async () => {
+	it("lobu-apply-style oauth create (RESOLVABLE auth_profile_slug, no installation_ref) is ALLOWED", async () => {
 		// `lobu apply` of a declared github oauth connection sends auth_profile_slug
 		// (createConnection in apply/client.ts). It must pass the guard (it did on
-		// origin/main — the over-broad guard broke it).
+		// origin/main — the over-broad guard broke it) — provided the slug resolves.
 		const org = await createTestOrganization({ name: "Apply OAuth Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+		const accountSlug = await createRealAuthProfile(ctx, {
+			profileKind: "env",
+			slug: "gh-oauth",
+			credentials: { DEMO_TOKEN: "ghp_real_token" },
+		});
+		const appSlug = await createRealAuthProfile(ctx, {
+			profileKind: "oauth_app",
+			slug: "gh-oauth-app",
+			credentials: {
+				DEMO_CLIENT_ID: "client-id",
+				DEMO_CLIENT_SECRET: "client-secret",
+			},
+		});
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "apply-oauth-conn",
+				display_name: "Apply OAuth Conn",
+				device_worker_id: null,
+				auth_profile_slug: accountSlug,
+				app_auth_profile_slug: appSlug,
+			},
+			TEST_ENV,
+			ctx,
+		);
+		expectGuardSkipped(res);
+	});
+
+	it("create WITH a managedBy.org grant is ALLOWED past the guard", async () => {
+		const org = await createTestOrganization({ name: "ManagedBy Create Org" });
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
 		await seedAppInstallConnector(org.id);
@@ -296,11 +466,10 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 			{
 				action: "create",
 				connector_key: CONNECTOR_KEY,
-				slug: "apply-oauth-conn",
-				display_name: "Apply OAuth Conn",
+				slug: "managed-create",
+				display_name: "Managed Create",
 				device_worker_id: null,
-				auth_profile_slug: "gh-oauth",
-				app_auth_profile_slug: "gh-oauth-app",
+				config: { managedBy: { org: org.id } },
 			},
 			TEST_ENV,
 			ctx,

--- a/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
@@ -362,6 +362,75 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 		expect(await connectionCount(org.id)).toBe(0);
 	});
 
+	it("create WITH auth_profile_slug pointing at an oauth_app (WRONG KIND) + no installation_ref is REJECTED", async () => {
+		// auth_profile_slug must resolve to a CREDENTIAL profile (env / account /
+		// browser / interactive). An oauth_app carries only the app's
+		// client_id/secret — it does NOT provide the connection's auth, so pointing
+		// auth_profile_slug at one is the wrong kind and must NOT satisfy the guard.
+		const org = await createTestOrganization({ name: "Wrong Kind Account Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+		// Seed a REAL, resolvable oauth_app profile, then mis-target it.
+		const appSlug = await createRealAuthProfile(ctx, {
+			profileKind: "oauth_app",
+			slug: "wrong-kind-app-profile",
+			credentials: {
+				DEMO_CLIENT_ID: "client-id",
+				DEMO_CLIENT_SECRET: "client-secret",
+			},
+		});
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "wrong-kind-account-create",
+				display_name: "Wrong Kind Account Create",
+				device_worker_id: null,
+				// Resolvable, but it's an oauth_app — wrong kind for auth_profile_slug.
+				auth_profile_slug: appSlug,
+			},
+			TEST_ENV,
+			ctx,
+		);
+		expectGuardRejected(res);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
+	it("create WITH app_auth_profile_slug pointing at a non-oauth_app profile (WRONG KIND) + no installation_ref is REJECTED", async () => {
+		// app_auth_profile_slug must resolve to an oauth_app. Pointing it at a real
+		// env (credential) profile is the wrong kind and must NOT satisfy the guard.
+		const org = await createTestOrganization({ name: "Wrong Kind App Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedAppInstallConnector(org.id);
+		const ctx = ctxFor(org.id, user.id);
+		// Seed a REAL, resolvable env profile, then mis-target it as the app profile.
+		const envSlug = await createRealAuthProfile(ctx, {
+			profileKind: "env",
+			slug: "wrong-kind-env-profile",
+			credentials: { DEMO_TOKEN: "ghp_real_token" },
+		});
+
+		const res = await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTOR_KEY,
+				slug: "wrong-kind-app-create",
+				display_name: "Wrong Kind App Create",
+				device_worker_id: null,
+				// Resolvable, but it's an env profile — wrong kind for app_auth_profile_slug.
+				app_auth_profile_slug: envSlug,
+			},
+			TEST_ENV,
+			ctx,
+		);
+		expectGuardRejected(res);
+		expect(await connectionCount(org.id)).toBe(0);
+	});
+
 	it("create WITH env/PAT creds in config is ALLOWED past the guard", async () => {
 		const org = await createTestOrganization({ name: "PAT Create Org" });
 		const user = await createTestUser();

--- a/packages/server/src/tools/admin/helpers/app-installation-guard.ts
+++ b/packages/server/src/tools/admin/helpers/app-installation-guard.ts
@@ -15,11 +15,19 @@
  * intent is present (and there is no installation_ref) does the connection fall
  * through to the app_installation primary, which is what we reject.
  *
+ * RESOLVED, NOT ASSERTED: a passed `auth_profile_slug` / `app_auth_profile_slug`
+ * only satisfies the guard when it RESOLVES to a real auth profile for this
+ * org/connector (same resolver the create/connect flow uses). A non-existent or
+ * non-resolvable slug is treated as if no slug was provided — otherwise a caller
+ * could assert a bogus slug to bypass the guard and create a dead, unbound
+ * app_installation connection.
+ *
  * Connector-agnostic: keys on the resolved auth method type (not on `github`),
  * so it covers any future app_installation connector.
  */
 
 import { parseJsonObject } from '@lobu/core';
+import { resolveAuthProfileSlugToId } from '../../../utils/auth-profiles';
 import {
   getEnvAuthFieldKeys,
   isPrimaryAuthMethodAppInstallation,
@@ -49,21 +57,24 @@ function hasManagedByOrg(config: Record<string, unknown>): boolean {
  *
  * The caller passes the auth-INTENT signals it received so the guard can tell a
  * deliberate oauth/PAT/env/managed create from a bare one that falls through to
- * app_installation.
+ * app_installation. An asserted auth-profile slug is RESOLVED against the org's
+ * auth profiles (not trusted as a bare string) so a bogus slug can't bypass it.
  *
+ * @param organizationId      the org the connection is being created in (slug scope)
  * @param authSchema          the connector definition's `auth_schema` (raw jsonb/string)
  * @param config              the connection `config` being created
- * @param connectorKey        for the (connector-agnostic) error message
+ * @param connectorKey        for the (connector-agnostic) error message + slug scope
  * @param authProfileSlug     an explicitly selected auth profile (oauth/env/browser)
  * @param appAuthProfileSlug  an explicitly selected OAuth app profile
  */
-export function rejectUnboundAppInstallationCreate(params: {
+export async function rejectUnboundAppInstallationCreate(params: {
+  organizationId: string;
   authSchema: unknown;
   config: unknown;
   connectorKey: string;
   authProfileSlug?: string | null;
   appAuthProfileSlug?: string | null;
-}): { error: string } | null {
+}): Promise<{ error: string } | null> {
   const schema = normalizeConnectorAuthSchema(params.authSchema);
   // Only connectors whose PRIMARY method is app_installation are in scope.
   if (!isPrimaryAuthMethodAppInstallation(schema)) return null;
@@ -74,9 +85,26 @@ export function rejectUnboundAppInstallationCreate(params: {
   if (hasInstallationRef(config)) return null;
 
   // A deliberate non-app_installation auth selection → the connection will use
-  // THAT method, not app_installation. Skip the guard.
-  if (params.authProfileSlug?.trim() || params.appAuthProfileSlug?.trim()) {
-    return null;
+  // THAT method, not app_installation. Skip the guard — but only when the slug
+  // RESOLVES to a real profile for this org/connector. An asserted-but-bogus
+  // slug must NOT satisfy the guard (it would create a dead, unbound
+  // app_installation connection), so resolve it the same way the create/connect
+  // flow does before trusting it as an alternate auth selection.
+  if (params.authProfileSlug?.trim()) {
+    const resolved = await resolveAuthProfileSlugToId({
+      organizationId: params.organizationId,
+      slug: params.authProfileSlug,
+      connectorKey: params.connectorKey,
+    });
+    if (resolved) return null;
+  }
+  if (params.appAuthProfileSlug?.trim()) {
+    const resolvedApp = await resolveAuthProfileSlugToId({
+      organizationId: params.organizationId,
+      slug: params.appAuthProfileSlug,
+      connectorKey: params.connectorKey,
+    });
+    if (resolvedApp) return null;
   }
   if (hasManagedByOrg(config)) return null;
   // Env/PAT creds supplied directly in config (e.g. GITHUB_TOKEN) → env auth.

--- a/packages/server/src/tools/admin/helpers/app-installation-guard.ts
+++ b/packages/server/src/tools/admin/helpers/app-installation-guard.ts
@@ -64,8 +64,8 @@ function hasManagedByOrg(config: Record<string, unknown>): boolean {
  * @param authSchema          the connector definition's `auth_schema` (raw jsonb/string)
  * @param config              the connection `config` being created
  * @param connectorKey        for the (connector-agnostic) error message + slug scope
- * @param authProfileSlug     an explicitly selected auth profile (oauth/env/browser)
- * @param appAuthProfileSlug  an explicitly selected OAuth app profile
+ * @param authProfileSlug     an explicitly selected credential profile (env/oauth_account/browser/interactive — NOT oauth_app)
+ * @param appAuthProfileSlug  an explicitly selected OAuth app profile (oauth_app only)
  */
 export async function rejectUnboundAppInstallationCreate(params: {
   organizationId: string;
@@ -86,23 +86,33 @@ export async function rejectUnboundAppInstallationCreate(params: {
 
   // A deliberate non-app_installation auth selection → the connection will use
   // THAT method, not app_installation. Skip the guard — but only when the slug
-  // RESOLVES to a real profile for this org/connector. An asserted-but-bogus
-  // slug must NOT satisfy the guard (it would create a dead, unbound
-  // app_installation connection), so resolve it the same way the create/connect
-  // flow does before trusting it as an alternate auth selection.
+  // RESOLVES to a real profile OF THE RIGHT KIND for this org/connector. An
+  // asserted-but-bogus slug, OR one that resolves to the wrong kind for its
+  // param, must NOT satisfy the guard (it would create a dead, unbound
+  // app_installation connection), so resolve + kind-check it the same way the
+  // create/connect flow does before trusting it as an alternate auth selection.
+  //
+  // `auth_profile_slug` is the connection's CREDENTIAL profile — any kind that
+  // actually provides connection auth (env / oauth_account / browser_session /
+  // interactive). An `oauth_app` carries only the app's client_id/secret, not
+  // the connection's credentials, so it does NOT satisfy auth_profile_slug.
   if (params.authProfileSlug?.trim()) {
     const resolved = await resolveAuthProfileSlugToId({
       organizationId: params.organizationId,
       slug: params.authProfileSlug,
       connectorKey: params.connectorKey,
     });
-    if (resolved) return null;
+    if (resolved && resolved.profile_kind !== 'oauth_app') return null;
   }
+  // `app_auth_profile_slug` selects the OAuth app (local client credentials);
+  // only an `oauth_app` profile is a valid target. resolveAuthProfileSlugToId's
+  // expectedKind enforces that — a wrong-kind slug resolves to null here.
   if (params.appAuthProfileSlug?.trim()) {
     const resolvedApp = await resolveAuthProfileSlugToId({
       organizationId: params.organizationId,
       slug: params.appAuthProfileSlug,
       connectorKey: params.connectorKey,
+      expectedKind: 'oauth_app',
     });
     if (resolvedApp) return null;
   }

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -75,7 +75,8 @@ export async function handleConnect(
   // App install callback. Selection-aware: a connect that supplies an auth
   // profile / app profile / env creds / managedBy resolves to a different method
   // and is allowed through.
-  const appInstallGuard = rejectUnboundAppInstallationCreate({
+  const appInstallGuard = await rejectUnboundAppInstallationCreate({
+    organizationId,
     authSchema: connector.auth_schema,
     config: args.config,
     connectorKey: args.connector_key,

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -364,7 +364,8 @@ export async function handleCreate(
   // App install callback. Selection-aware: a create that supplies an auth profile
   // / app profile / env creds / managedBy resolves to a different method and is
   // allowed through.
-  const appInstallGuard = rejectUnboundAppInstallationCreate({
+  const appInstallGuard = await rejectUnboundAppInstallationCreate({
+    organizationId,
     authSchema: connector.auth_schema,
     config: args.config,
     connectorKey: args.connector_key,


### PR DESCRIPTION
## What

The unbound-`app_installation` guard (`rejectUnboundAppInstallationCreate`) skipped when a caller passed an `auth_profile_slug` / `app_auth_profile_slug` — but it **trusted the slug as a bare string** instead of resolving it. A caller could assert a non-existent / non-resolvable slug to bypass the guard and create a dead, unbound `app_installation` connection.

Latent today (not exploitable for `github` — oauth/env fallbacks backstop it), but it must be hardened before the first fallback-free `app_installation` connector. This closes that gap (task #12).

## Fix

The guard now **resolves** each asserted slug against the org's `auth_profiles` via `resolveAuthProfileSlugToId` — the same resolver the create/connect flow uses (`resolveConnectionAuthSelection`) — and only skips when the slug resolves to a real profile for the org/connector. An unresolvable slug is treated as if no slug was provided, so it no longer satisfies the guard.

- Guard is now `async`; both call sites (`crud.ts` create, `connect.ts` connect) `await` it and pass `organizationId`.
- Legitimate selections keep working: a real resolvable slug, `managedBy.org`, env/PAT creds in config, and `installation_ref`.

## Tests (E2E reproducer, red→green)

`app-installation-create-guard.test.ts` (13 tests, all green):

| case | result |
|------|--------|
| (a) non-existent `auth_profile_slug`, no `installation_ref` (create + connect) | **REJECTED** (the bug) |
| non-existent `app_auth_profile_slug`, no ref | **REJECTED** |
| (b) real resolvable `auth_profile_slug` / `app_auth_profile_slug` | allowed |
| (c) `installation_ref` present | allowed |
| (d) env-creds in config / `managedBy.org` | allowed |
| (e) bare create, nothing | rejected |

**Red→green proof:** temporarily reverting the guard to the asserted-slug behavior fails **exactly** the 3 new bypass tests (`3 failed | 10 passed`); the fix makes all 13 pass. So the tests catch the real vulnerability without over-rejecting legitimate selections.

Suites run (Node 22, `lobu_test`):
- `app-installation-create-guard.test.ts` — 13/13
- `app-installation-credential.test.ts` — 8/8
- gateway `app-installation-e2e` + `app-installation-store` (bun test) — 18/18

`cd packages/server && bunx tsc --noEmit` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ug5cEnCRt1VHn8w3gNXAu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784756124&installation_id=136316292&pr_number=1488&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1488&signature=c9160ab8714589aa0de190f10fa258365bacdbd4800db10b7cef1ad3a1daaff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of authentication profiles during app installation and connection flows, ensuring proper error detection and guidance when auth profiles are missing or cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->