### PR TITLE
feat(gateway): schema-driven app-webhook verify + register Jira/Linear plugins

### DIFF
--- a/packages/server/src/gateway/__tests__/app-webhooks.test.ts
+++ b/packages/server/src/gateway/__tests__/app-webhooks.test.ts
@@ -20,6 +20,9 @@ import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import {
 	createAppWebhookRoutes,
 	createGithubAppWebhookProvider,
+	createJiraAppWebhookProvider,
+	createLinearAppWebhookProvider,
+	createSchemaDrivenAppWebhookProvider,
 } from "../routes/public/app-webhooks.js";
 import { createPostgresAppInstallationStore } from "../../lobu/stores/app-installation-store.js";
 import {
@@ -370,5 +373,240 @@ describe("app-webhook router (GitHub)", () => {
 		const res = await app.fetch(ghDelivery(raw));
 		expect(res.status).toBe(401);
 		expect((await eventRows(`webhook:app_install:${installId}`)).length).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Jira — schema-driven verify (`x-hub-signature: sha256=<hex>`), site-host tenant
+// ---------------------------------------------------------------------------
+
+const JIRA_APP_ID = "jira-client-id";
+const JIRA_SECRET = "jira-webhook-secret-0123456789abcdef";
+const JIRA_SITE = "acme.atlassian.net";
+
+/** Jira signs the raw body with the webhook secret → `sha256=<hex>`. */
+function jiraSign(rawBody: string, secret = JIRA_SECRET): string {
+	return `sha256=${createHmac("sha256", secret).update(rawBody).digest("hex")}`;
+}
+
+function buildJiraApp() {
+	return createAppWebhookRoutes({
+		installationStore: createPostgresAppInstallationStore(),
+		secretStore: fakeSecretStore,
+		providers: [createJiraAppWebhookProvider({ appId: JIRA_APP_ID })],
+		resolveAppWebhookSecret: async () => JIRA_SECRET,
+	});
+}
+
+async function seedJiraInstall(): Promise<number> {
+	const store = createPostgresAppInstallationStore();
+	const row = await store.upsert({
+		organizationId: ORG,
+		provider: "jira",
+		providerInstance: "cloud",
+		providerAppId: JIRA_APP_ID,
+		externalTenantId: JIRA_SITE,
+		status: "active",
+	});
+	return row.id;
+}
+
+function jiraDelivery(
+	rawBody: string,
+	{ signature = jiraSign(rawBody) }: { signature?: string } = {},
+): Request {
+	return new Request("http://gateway.test/api/v1/app-webhooks/jira", {
+		method: "POST",
+		body: rawBody,
+		headers: {
+			"content-type": "application/json",
+			"x-hub-signature": signature,
+		},
+	});
+}
+
+describe("app-webhook router (Jira)", () => {
+	test("a signed issue delivery routes to the owning org via its site host", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedJiraInstall();
+		const app = buildJiraApp();
+
+		const raw = JSON.stringify({
+			webhookEvent: "jira:issue_updated",
+			issue: {
+				id: "10000",
+				key: "ACME-1",
+				self: `https://${JIRA_SITE}/rest/api/2/issue/10000`,
+			},
+		});
+		const res = await app.fetch(jiraDelivery(raw));
+		expect(res.status).toBe(202);
+
+		const rows = await eventRows(`webhook:app_install:${installId}`);
+		expect(rows.length).toBe(1);
+		expect(rows[0].organization_id).toBe(ORG);
+		// No delivery-id header → dedupe falls back to a body hash origin_id.
+		expect(typeof rows[0].origin_id).toBe("string");
+	});
+
+	test("a forged signature is rejected with 401 and lands nothing", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedJiraInstall();
+		const app = buildJiraApp();
+
+		const raw = JSON.stringify({
+			webhookEvent: "jira:issue_updated",
+			issue: { self: `https://${JIRA_SITE}/rest/api/2/issue/1` },
+		});
+		const res = await app.fetch(jiraDelivery(raw, { signature: "sha256=forged" }));
+		expect(res.status).toBe(401);
+		expect((await eventRows(`webhook:app_install:${installId}`)).length).toBe(0);
+	});
+
+	test("a delivery with no self URL has no tenant → 200 ack, nothing landed", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedJiraInstall();
+		const app = buildJiraApp();
+
+		const raw = JSON.stringify({ webhookEvent: "jira:test", timestamp: 1 });
+		const res = await app.fetch(jiraDelivery(raw));
+		expect(res.status).toBe(200);
+		expect((await res.json()).landed).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Linear — schema-driven verify (`linear-signature: <hex>`, no prefix),
+// organizationId tenant
+// ---------------------------------------------------------------------------
+
+const LINEAR_APP_ID = "linear-client-id";
+const LINEAR_SECRET = "linear-webhook-secret-0123456789abcdef";
+const LINEAR_ORG_ID = "11111111-2222-3333-4444-555555555555";
+
+/** Linear signs the raw body and sends a BARE hex digest (no prefix). */
+function linearSign(rawBody: string, secret = LINEAR_SECRET): string {
+	return createHmac("sha256", secret).update(rawBody).digest("hex");
+}
+
+function buildLinearApp() {
+	return createAppWebhookRoutes({
+		installationStore: createPostgresAppInstallationStore(),
+		secretStore: fakeSecretStore,
+		providers: [createLinearAppWebhookProvider({ appId: LINEAR_APP_ID })],
+		resolveAppWebhookSecret: async () => LINEAR_SECRET,
+	});
+}
+
+async function seedLinearInstall(): Promise<number> {
+	const store = createPostgresAppInstallationStore();
+	const row = await store.upsert({
+		organizationId: ORG,
+		provider: "linear",
+		providerInstance: "cloud",
+		providerAppId: LINEAR_APP_ID,
+		externalTenantId: LINEAR_ORG_ID,
+		status: "active",
+	});
+	return row.id;
+}
+
+function linearDelivery(
+	rawBody: string,
+	{ signature = linearSign(rawBody) }: { signature?: string } = {},
+): Request {
+	return new Request("http://gateway.test/api/v1/app-webhooks/linear", {
+		method: "POST",
+		body: rawBody,
+		headers: {
+			"content-type": "application/json",
+			"linear-signature": signature,
+		},
+	});
+}
+
+describe("app-webhook router (Linear)", () => {
+	test("a signed issue delivery routes to the owning org via organizationId", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedLinearInstall();
+		const app = buildLinearApp();
+
+		const raw = JSON.stringify({
+			action: "create",
+			type: "Issue",
+			organizationId: LINEAR_ORG_ID,
+			data: { id: "abc", title: "Ship it" },
+		});
+		const res = await app.fetch(linearDelivery(raw));
+		expect(res.status).toBe(202);
+
+		const rows = await eventRows(`webhook:app_install:${installId}`);
+		expect(rows.length).toBe(1);
+		expect(rows[0].organization_id).toBe(ORG);
+	});
+
+	test("a bare-hex signature with a `sha256=` prefix is rejected (no prefix expected)", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedLinearInstall();
+		const app = buildLinearApp();
+
+		const raw = JSON.stringify({ organizationId: LINEAR_ORG_ID, action: "create" });
+		// Linear sends NO prefix; a `sha256=`-prefixed value must fail.
+		const res = await app.fetch(
+			linearDelivery(raw, { signature: `sha256=${linearSign(raw)}` }),
+		);
+		expect(res.status).toBe(401);
+		expect((await eventRows(`webhook:app_install:${installId}`)).length).toBe(0);
+	});
+
+	test("a delivery with no organizationId has no tenant → 200 ack", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedLinearInstall();
+		const app = buildLinearApp();
+
+		const raw = JSON.stringify({ action: "create", type: "Issue" });
+		const res = await app.fetch(linearDelivery(raw));
+		expect(res.status).toBe(200);
+		expect((await res.json()).landed).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Schema-driven verify factory — provider-agnostic HMAC derivation
+// ---------------------------------------------------------------------------
+
+describe("createSchemaDrivenAppWebhookProvider", () => {
+	test("derives verify from the schema header/algorithm/prefix", () => {
+		const provider = createSchemaDrivenAppWebhookProvider({
+			provider: "demo",
+			webhookSchema: {
+				signatureHeader: "x-demo-sig",
+				algorithm: "sha256",
+				signaturePrefix: "sha256=",
+			},
+			extractTenant: () => null,
+		});
+		const raw = new TextEncoder().encode("hello");
+		const secret = "s3cret";
+		const digest = createHmac("sha256", secret).update(raw).digest("hex");
+
+		const good = new Headers({ "x-demo-sig": `sha256=${digest}` });
+		expect(provider.verify(raw, good, secret)).toBe(true);
+
+		const wrongHeader = new Headers({ "x-other": `sha256=${digest}` });
+		expect(provider.verify(raw, wrongHeader, secret)).toBe(false);
+
+		const forged = new Headers({ "x-demo-sig": "sha256=deadbeef" });
+		expect(provider.verify(raw, forged, secret)).toBe(false);
+	});
+
+	test("throws when the schema declares no signatureHeader (must fail closed)", () => {
+		expect(() =>
+			createSchemaDrivenAppWebhookProvider({
+				provider: "unsigned",
+				webhookSchema: { algorithm: "sha256" },
+				extractTenant: () => null,
+			}),
+		).toThrow(/signatureHeader/);
 	});
 });

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -23,9 +23,12 @@ import { createInteractionRoutes } from "../routes/internal/interactions.js";
 import { registerAutoOpenApiRoutes } from "../routes/openapi-auto.js";
 import { createAgentApi } from "../routes/public/agent.js";
 import {
+  type AppWebhookProvider,
   createAppWebhookRoutes,
   createDefaultAppWebhookSecretResolver,
   createGithubAppWebhookProvider,
+  createJiraAppWebhookProvider,
+  createLinearAppWebhookProvider,
 } from "../routes/public/app-webhooks.js";
 import { createAppInstallRoutes } from "../routes/public/app-install.js";
 import { resolveInstallOrgId } from "../routes/public/slack.js";
@@ -702,20 +705,32 @@ export function createGatewayApp(
     app.route("", createConnectionWebhookRoutes(chatInstanceManager));
 
     // Shared multi-tenant app-webhook router (app-installation design §4.3): one
-    // public endpoint per provider for an installed Lobu App. Only the GitHub
-    // plugin ships today, and only when the receiving GitHub App is configured
-    // (GITHUB_APP_ID) — otherwise the route is present but reports the provider
-    // unknown (404), since a missing app id can't match any installation.
+    // public endpoint per provider for an installed Lobu App. A provider plugin
+    // is registered only when its Lobu app id is configured (GitHub App id, or
+    // the provider's OAuth client id) — otherwise the route is present but
+    // reports the provider unknown (404), since a missing app id can't match any
+    // installation. GitHub/Jira/Linear share one schema-driven HMAC verify;
+    // Slack stays a custom plugin (timestamped signing base).
     const appWebhookSecretStore = coreServices.getSecretStore();
+    const appWebhookProviders: AppWebhookProvider[] = [];
     const githubAppId = process.env.GITHUB_APP_ID;
+    if (githubAppId) {
+      appWebhookProviders.push(createGithubAppWebhookProvider({ appId: githubAppId }));
+    }
+    const jiraAppId = process.env.JIRA_CLIENT_ID;
+    if (jiraAppId) {
+      appWebhookProviders.push(createJiraAppWebhookProvider({ appId: jiraAppId }));
+    }
+    const linearAppId = process.env.LINEAR_CLIENT_ID;
+    if (linearAppId) {
+      appWebhookProviders.push(createLinearAppWebhookProvider({ appId: linearAppId }));
+    }
     app.route(
       "",
       createAppWebhookRoutes({
         installationStore: createPostgresAppInstallationStore(),
         secretStore: appWebhookSecretStore,
-        providers: githubAppId
-          ? [createGithubAppWebhookProvider({ appId: githubAppId })]
-          : [],
+        providers: appWebhookProviders,
         resolveAppWebhookSecret:
           createDefaultAppWebhookSecretResolver(appWebhookSecretStore),
       }),

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -16,9 +16,13 @@
  *      per-connection ingest (`connector_key='webhook:<id>'`, reusing the
  *      dedupe index, size cap, and rate limit).
  *
- * Verification is per-PROVIDER (HMAC scheme differs), not schema-driven —
- * `ConnectorWebhookSchema` is HMAC-only and can't express Slack's
- * `v0:{ts}:{body}` or Jira's per-app-type rules. Hence the plugin registry.
+ * Verification is per-PROVIDER (HMAC scheme differs). For pure raw-body HMAC
+ * providers (GitHub, Jira, Linear) the `verify` is DERIVED from the connector's
+ * `ConnectorWebhookSchema` (signatureHeader / algorithm / signaturePrefix) by
+ * {@link createSchemaDrivenAppWebhookProvider} — those plugins supply only the
+ * tenant extractor, never a hand-written verify. Slack stays a custom plugin:
+ * its `v0:{ts}:{rawBody}` + timestamp-freshness scheme can't be expressed by the
+ * HMAC-only schema. Hence the plugin registry.
  *
  * Delivery before the install callback: a provider may deliver before the
  * OAuth/install callback has written the `app_installations` row. That is NOT
@@ -33,6 +37,7 @@
 import { Hono } from "hono";
 import { createLogger } from "@lobu/core";
 import type { StoredConnection } from "@lobu/core";
+import type { ConnectorWebhookSchema } from "@lobu/connector-sdk";
 import {
 	handleWebhookIngest,
 	readBodyWithCap,
@@ -65,11 +70,26 @@ export interface AppWebhookContent {
 }
 
 /**
- * Per-provider verifier + tenant extractor. New providers (Slack, Jira) add a
- * plugin without touching the router — only GitHub ships in this PR.
+ * Per-provider verifier + tenant extractor. New providers add a plugin without
+ * touching the router. Pure-HMAC providers (GitHub, Jira, Linear) are built by
+ * {@link createSchemaDrivenAppWebhookProvider}; Slack ships its own custom
+ * verify (timestamped signing base, not expressible by the HMAC schema).
  */
 export interface AppWebhookProvider {
 	provider: string;
+	/**
+	 * The provider's raw-body HMAC scheme, used by the router to synthesize the
+	 * ingest connection config so `handleWebhookIngest` re-verifies against the
+	 * SAME header/algorithm/prefix the provider just verified — not a hardcoded
+	 * GitHub scheme. `dedupeHeader` is the provider's per-delivery id header
+	 * (when one exists); absent → ingest dedupes on a body hash.
+	 */
+	webhookScheme: {
+		signatureHeader: string;
+		algorithm: "sha256" | "sha1";
+		signaturePrefix?: string;
+		dedupeHeader?: string;
+	};
 	/**
 	 * Verify the delivery against the APP-LEVEL webhook secret. Pure over
 	 * (rawBody, headers, secret) — no I/O — so it's trivially multi-replica
@@ -146,12 +166,73 @@ export function extractGithubWebhookContent(rawBody: Uint8Array): AppWebhookCont
 }
 
 /**
+ * Build an {@link AppWebhookProvider} whose `verify` is DERIVED from a
+ * connector's {@link ConnectorWebhookSchema} — the single source of truth for
+ * the provider's raw-body HMAC scheme. The caller supplies ONLY the
+ * provider-specific tenant extractor (and optionally a content projector); the
+ * verify is identical machinery across every pure-HMAC provider, so it never
+ * gets hand-written again (GitHub, Jira, Linear all flow through here).
+ *
+ * The schema's `signatureHeader` is REQUIRED here: an app-webhook endpoint must
+ * fail closed, so a provider that signs nothing has no schema-driven verify to
+ * derive — it would have to ship a custom plugin (Slack). We throw at
+ * construction rather than silently accepting unverifiable deliveries.
+ *
+ * `algorithm` defaults to `sha256` and `signaturePrefix` to none, matching
+ * {@link ConnectorWebhookSchema} defaults.
+ */
+export function createSchemaDrivenAppWebhookProvider(options: {
+	/** The `:provider` path segment + `app_installations.provider` value. */
+	provider: string;
+	/** The connector's declared HMAC scheme; `verify` is derived from it. */
+	webhookSchema: ConnectorWebhookSchema;
+	/** Pull the tenant tuple from the delivery (the only per-provider verify-free part). */
+	extractTenant(rawBody: Uint8Array, headers: Headers): AppWebhookTenant | null;
+	/** Optional title/source_url projector for the landed row. */
+	extractContent?(rawBody: Uint8Array, headers: Headers): AppWebhookContent;
+}): AppWebhookProvider {
+	const { provider, webhookSchema, extractTenant, extractContent } = options;
+	const signatureHeader = webhookSchema.signatureHeader;
+	if (!signatureHeader) {
+		throw new Error(
+			`Schema-driven app-webhook provider "${provider}" requires a webhook ` +
+				`signatureHeader (a non-signing provider must ship a custom verify plugin).`,
+		);
+	}
+	const algorithm = webhookSchema.algorithm ?? "sha256";
+	const signaturePrefix = webhookSchema.signaturePrefix;
+	return {
+		provider,
+		webhookScheme: {
+			signatureHeader,
+			algorithm,
+			...(signaturePrefix ? { signaturePrefix } : {}),
+			...(webhookSchema.dedupeHeader
+				? { dedupeHeader: webhookSchema.dedupeHeader }
+				: {}),
+		},
+		verify(rawBody, headers, appWebhookSecret) {
+			return verifyWebhookSignature(
+				rawBody,
+				headers.get(signatureHeader),
+				appWebhookSecret,
+				algorithm,
+				signaturePrefix,
+			);
+		},
+		extractTenant,
+		...(extractContent ? { extractContent } : {}),
+	};
+}
+
+/**
  * GitHub App webhook plugin.
  *
- * Verify: GitHub signs the raw request body with the App's webhook secret and
- * sends `x-hub-signature-256: sha256=<hex>`. We reuse the connection-ingest
- * HMAC verifier (constant-time, decoded-length compare — a non-hex right-length
- * header can't slip through or throw).
+ * Verify: schema-driven (GitHub signs the raw body and sends
+ * `x-hub-signature-256: sha256=<hex>`; the scheme is the github connector's
+ * {@link ConnectorWebhookSchema}). The shared HMAC verifier is constant-time
+ * with a decoded-length compare — a non-hex right-length header can't slip
+ * through or throw.
  *
  * Extract: the tenant is the `installation.id` in the JSON body; the Lobu App
  * is the receiving GitHub App (`GITHUB_APP_ID`), and the instance is 'cloud'
@@ -166,16 +247,15 @@ export function createGithubAppWebhookProvider(options: {
 	/** Receiving GitHub App id, stamped as `provider_app_id`. */
 	appId: string;
 }): AppWebhookProvider {
-	return {
+	return createSchemaDrivenAppWebhookProvider({
 		provider: "github",
-		verify(rawBody, headers, appWebhookSecret) {
-			return verifyWebhookSignature(
-				rawBody,
-				headers.get("x-hub-signature-256"),
-				appWebhookSecret,
-				"sha256",
-				"sha256=",
-			);
+		// GitHub raw-body HMAC: `x-hub-signature-256: sha256=<hex>` (sha256).
+		// `x-github-delivery` is the per-delivery UUID used for redelivery dedupe.
+		webhookSchema: {
+			signatureHeader: "x-hub-signature-256",
+			algorithm: "sha256",
+			signaturePrefix: "sha256=",
+			dedupeHeader: "x-github-delivery",
 		},
 		extractTenant(rawBody) {
 			const body = parseJson(rawBody);
@@ -196,7 +276,106 @@ export function createGithubAppWebhookProvider(options: {
 		extractContent(rawBody) {
 			return extractGithubWebhookContent(rawBody);
 		},
-	};
+	});
+}
+
+/** First non-empty `*.self` URL found by a shallow scan of the delivery body. */
+function firstSelfUrl(body: unknown): string | undefined {
+	if (body === null || typeof body !== "object") return undefined;
+	const root = body as Record<string, unknown>;
+	const direct = strField(root, "self");
+	if (direct) return direct;
+	// Jira nests the entity (issue/comment/user/project) one level down; each
+	// entity carries its own REST `self` URL on the same Atlassian site.
+	for (const value of Object.values(root)) {
+		const nested = strField(value, "self");
+		if (nested) return nested;
+	}
+	return undefined;
+}
+
+/**
+ * Jira (Cloud) app webhook plugin.
+ *
+ * Verify: schema-driven from the jira connector's {@link ConnectorWebhookSchema}
+ * — Jira dynamic webhooks HMAC-sign the raw body with the registration secret
+ * and send `x-hub-signature: sha256=<hex>`.
+ *
+ * Extract: the tenant is the Atlassian SITE the delivery came from. Jira webhook
+ * bodies don't carry the cloudId directly, but every entity exposes a REST
+ * `self` URL on its site host (e.g.
+ * `https://acme.atlassian.net/rest/api/2/issue/10000`). We use the site host as
+ * `external_tenant_id` (one install row per site); `provider_app_id` is the Lobu
+ * OAuth/Connect app id. A delivery with no resolvable `self` URL (e.g. a test
+ * ping) has no tenant → null.
+ */
+export function createJiraAppWebhookProvider(options: {
+	/** Lobu Jira app id (`JIRA_CLIENT_ID`), stamped as `provider_app_id`. */
+	appId: string;
+}): AppWebhookProvider {
+	return createSchemaDrivenAppWebhookProvider({
+		provider: "jira",
+		// Jira raw-body HMAC: `x-hub-signature: sha256=<hex>` (sha256).
+		webhookSchema: {
+			signatureHeader: "x-hub-signature",
+			algorithm: "sha256",
+			signaturePrefix: "sha256=",
+		},
+		extractTenant(rawBody) {
+			const body = parseJson(rawBody);
+			const selfUrl = firstSelfUrl(body);
+			if (!selfUrl) return null;
+			let host: string;
+			try {
+				host = new URL(selfUrl).host;
+			} catch {
+				return null;
+			}
+			if (!host) return null;
+			return {
+				providerInstance: "cloud",
+				providerAppId: options.appId,
+				externalTenantId: host,
+			};
+		},
+	});
+}
+
+/**
+ * Linear app webhook plugin.
+ *
+ * Verify: schema-driven from the linear connector's {@link ConnectorWebhookSchema}
+ * — Linear HMAC-signs the raw body and sends a BARE hex digest in
+ * `linear-signature` (no `sha256=` prefix).
+ *
+ * Extract: every Linear webhook delivery carries the top-level `organizationId`
+ * of the workspace it belongs to — that's the tenant (one install row per Linear
+ * workspace). `provider_app_id` is the Lobu Linear OAuth app id. A delivery with
+ * no `organizationId` has no tenant → null.
+ */
+export function createLinearAppWebhookProvider(options: {
+	/** Lobu Linear app id (`LINEAR_CLIENT_ID`), stamped as `provider_app_id`. */
+	appId: string;
+}): AppWebhookProvider {
+	return createSchemaDrivenAppWebhookProvider({
+		provider: "linear",
+		// Linear raw-body HMAC: `linear-signature: <hex>` (sha256, no prefix).
+		webhookSchema: {
+			signatureHeader: "linear-signature",
+			algorithm: "sha256",
+		},
+		extractTenant(rawBody) {
+			const body = parseJson(rawBody);
+			if (body === null || typeof body !== "object") return null;
+			const organizationId = strField(body, "organizationId");
+			if (!organizationId) return null;
+			return {
+				providerInstance: "cloud",
+				providerAppId: options.appId,
+				externalTenantId: organizationId,
+			};
+		},
+	});
 }
 
 /** Dependencies the router needs, injected at registration (testable). */
@@ -316,27 +495,31 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 
 		// 4. Land the RAW delivery through the same event-log path as connection
 		//    ingest. We synthesize a StoredConnection scoped to the install's org
-		//    and keyed on the install id, replaying the GitHub signature scheme
-		//    with the app secret as a plaintext config value so handleWebhookIngest
+		//    and keyed on the install id, replaying the PROVIDER's signature scheme
+		//    (from `provider.webhookScheme`, not a hardcoded GitHub one) with the
+		//    app secret as a plaintext config value so handleWebhookIngest
 		//    re-verifies and lands under connector_key='webhook:app_install:<id>'
 		//    (matches the `webhook:%` dedupe index + size cap + rate limit). A
 		//    fresh Request carries the same raw bytes + headers; the original body
 		//    stream was already consumed above.
+		const scheme = provider.webhookScheme;
 		const synthesized: StoredConnection = {
 			id: `app_install:${install.id}`,
 			platform: "webhook",
 			organizationId: install.organizationId,
 			config: {
 				platform: "webhook",
-				// Replay the GitHub HMAC scheme so the ingest handler's own verify
+				// Replay the provider's HMAC scheme so the ingest handler's own verify
 				// passes against the app secret (plaintext passes resolveSecretValue
-				// through untouched).
-				signatureHeader: "x-hub-signature-256",
-				algorithm: "sha256",
-				signaturePrefix: "sha256=",
+				// through untouched). Providers without a per-delivery id header
+				// (Jira/Linear) omit dedupeHeader → ingest dedupes on a body hash.
+				signatureHeader: scheme.signatureHeader,
+				algorithm: scheme.algorithm,
+				...(scheme.signaturePrefix
+					? { signaturePrefix: scheme.signaturePrefix }
+					: {}),
 				signatureSecret: appSecret,
-				// GitHub stamps a per-delivery UUID; dedupe redeliveries on it.
-				dedupeHeader: "x-github-delivery",
+				...(scheme.dedupeHeader ? { dedupeHeader: scheme.dedupeHeader } : {}),
 				semanticType: "content",
 			},
 			settings: {},


### PR DESCRIPTION
## What

The shared app-webhook router (`POST /api/v1/app-webhooks/:provider`) dispatched to per-provider plugins, but every plugin's `verify` was hand-written and only GitHub shipped — every value GitHub passed to `verifyWebhookSignature` (signatureHeader/algorithm/signaturePrefix) is already declared in the connector's `ConnectorWebhookSchema`.

- Add `createSchemaDrivenAppWebhookProvider({ provider, webhookSchema, extractTenant, extractContent? })` that DERIVES `verify` from the schema. A pure-HMAC provider now supplies only `extractTenant` (+ optional `extractContent`), never a hand-written verify. It throws at construction if the schema declares no `signatureHeader` (an app-webhook endpoint must fail closed).
- GitHub stays the template (rewritten to flow through the factory; behavior unchanged).
- Register **Jira** and **Linear** plugins — they already declared the HMAC scheme but had no plugin, so `/api/v1/app-webhooks/{jira,linear}` were unroutable:
  - Jira: `x-hub-signature: sha256=<hex>`; tenant = the Atlassian site host extracted from a `*.self` URL in the body.
  - Linear: `linear-signature: <hex>` (bare hex, no prefix); tenant = top-level `organizationId`.
- **Slack stays custom** — its `v0:{ts}:{rawBody}` + timestamp-freshness scheme can't be expressed by the HMAC-only schema.

## Bug found + fixed along the way

The router synthesized the ingest connection config with a **hardcoded GitHub signature scheme**, so `handleWebhookIngest`'s re-verify only worked for GitHub (Jira/Linear deliveries 401'd). The router now replays the **provider's** scheme via a new `provider.webhookScheme`. Jira/Linear omit a per-delivery id header, so ingest correctly falls back to body-hash dedupe.

Plugins register only when the provider's Lobu app id is configured (`GITHUB_APP_ID` / `JIRA_CLIENT_ID` / `LINEAR_CLIENT_ID`).

## Tests

`packages/server/src/gateway/__tests__/app-webhooks.test.ts` extended with Jira + Linear describe blocks (real route → schema-driven verify → `handleWebhookIngest` → real Postgres) and unit tests for the factory (derives verify from schema; throws when unsigned). Verified the Linear no-prefix case rejects a `sha256=`-prefixed digest, and the no-delivery-id-header path dedupes on body hash.

```
20 pass / 0 fail (app-webhooks.test.ts)
cd packages/server && bunx tsc --noEmit → 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ug5cEnCRt1VHn8w3gNXAu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784759019&installation_id=136316292&pr_number=1491&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1491&signature=3d99cfb2555790d617b4aa4daf27eda2d1c82b7e72cc469f34f1fda574c83c3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->