### PR TITLE
feat(github): attribute member identity from connector ingest

### DIFF
--- a/db/migrations/20260623000010_event_metadata_github_user_id_index.sql
+++ b/db/migrations/20260623000010_event_metadata_github_user_id_index.sql
@@ -1,0 +1,16 @@
+-- migrate:up transaction:false
+
+-- Partial BTREE on events.metadata->>'github_user_id', mirroring the existing
+-- idx_events_metadata_<ns> indexes (email/phone/wa_jid/github_login/…). Required
+-- for read-time entity attribution to key on the IMMUTABLE github_user_id: the
+-- entityLinkMatchSql UNION emits a per-namespace branch that probes events via
+-- this index, so without it the github_user_id branch would seq-scan the events
+-- table. CONCURRENTLY (transaction:false, single statement) so the build never
+-- blocks event ingestion. See packages/server/src/utils/content-search/entity-link.ts.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_metadata_github_user_id
+    ON public.events (((metadata ->> 'github_user_id'::text)))
+    WHERE (metadata ? 'github_user_id'::text);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_events_metadata_github_user_id;

--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -362,6 +362,18 @@ export interface EntityIdentitySpec {
    * not persisted on create or accrete. Defaults to false.
    */
   matchOnly?: boolean;
+  /**
+   * Marks an IMMUTABLE, authoritative identifier (e.g. a numeric provider user
+   * id that survives renames). When a primary identity is PRESENT on an event:
+   *   - if it matches an existing entity → that entity is used;
+   *   - if it is present but matches nothing → resolution does NOT fall through
+   *     to a non-primary match (a fresh primary id means a distinct account; a
+   *     stale, since-reused secondary identifier like a renamed login must not
+   *     conflate the two). A new entity is created keyed on the primary id.
+   * Defaults to false: non-primary identities match equal-weight (a person is
+   * matched by ANY of them — the cross-channel behavior whatsapp/email rely on).
+   */
+  primary?: boolean;
 }
 
 /**

--- a/packages/connector-sdk/src/identity-normalize.ts
+++ b/packages/connector-sdk/src/identity-normalize.ts
@@ -94,6 +94,25 @@ export function normalizeSlackUserId(
   return `${t}:${u}`.toUpperCase();
 }
 
+/**
+ * Canonicalize an already-combined Slack identity (`T0XYZ:U12345`) for the
+ * `normalizeIdentifier` dispatch. Connectors emit the team-prefixed form
+ * (build it with `normalizeSlackUserId(teamId, userId)`); this is the
+ * single-value cleanup pass the ingestion pipeline re-runs. Splits on the
+ * first colon and re-runs the two-part validator so a malformed value (no
+ * team prefix, bad chars) returns null rather than poisoning matching.
+ */
+export function normalizeSlackUserIdCombined(
+  raw: string | null | undefined
+): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const sep = trimmed.indexOf(':');
+  if (sep <= 0 || sep === trimmed.length - 1) return null;
+  return normalizeSlackUserId(trimmed.slice(0, sep), trimmed.slice(sep + 1));
+}
+
 export function normalizeGithubLogin(raw: string | null | undefined): string | null {
   if (typeof raw !== 'string') return null;
   const trimmed = raw.trim().toLowerCase();
@@ -155,6 +174,8 @@ export function normalizeIdentifier(
       return normalizeEmail(raw);
     case 'wa_jid':
       return normalizeWaJid(raw);
+    case 'slack_user_id':
+      return normalizeSlackUserIdCombined(raw);
     case 'github_login':
       return normalizeGithubLogin(raw);
     case 'github_user_id':

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -124,6 +124,7 @@ export {
   normalizeIdentifier,
   normalizePhone,
   normalizeSlackUserId,
+  normalizeSlackUserIdCombined,
   normalizeWaJid,
 } from './identity-normalize.js';
 // HTTP client (auth + retry + 429 Retry-After)

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -14,6 +14,7 @@ import {
   type ConnectorDefinition,
   ConnectorRuntime,
   createHttpClient,
+  type EntityLinkRule,
   type EventEnvelope,
   IDENTITY,
   paginateByOffset,
@@ -98,7 +99,7 @@ interface GitHubIssueLike {
   number: number;
   title: string;
   body: string | null;
-  user?: { login?: string };
+  user?: { login?: string; id?: number };
   html_url: string;
   created_at: string;
   updated_at: string;
@@ -112,7 +113,7 @@ interface GitHubIssueLike {
 interface GitHubCommentLike {
   id: number;
   body: string;
-  user?: { login?: string };
+  user?: { login?: string; id?: number };
   html_url: string;
   issue_url?: string;
   pull_request_url?: string;
@@ -126,7 +127,7 @@ interface GraphQLDiscussionNode {
   number: number;
   title: string;
   body: string;
-  author?: { login?: string };
+  author?: { login?: string; databaseId?: number };
   url: string;
   createdAt: string;
   updatedAt: string;
@@ -138,7 +139,7 @@ interface GraphQLDiscussionNode {
 interface GraphQLDiscussionCommentNode {
   id: string;
   body: string;
-  author?: { login?: string };
+  author?: { login?: string; databaseId?: number };
   url: string;
   createdAt: string;
   updatedAt: string;
@@ -227,6 +228,40 @@ const LABELS_PROP = {
     description: 'Optional label filter',
   },
 } as const;
+
+/**
+ * Person entity-link rule for any authored GitHub event. Attribution is keyed
+ * PRIMARY on the immutable numeric `github_user_id` (a renamed login still
+ * resolves to the same person) and SECONDARY on `github_login` (the indexed
+ * read-time namespace + the human-legible name on auto-create). The ingestion
+ * pipeline (`applyEntityLinks`, run-lifecycle poll/sync path) extracts these
+ * from `metadata.author_id` / `metadata.author_login` — both stamped by
+ * `buildAuthorMetadata` — normalizes them, and looks them up / auto-creates a
+ * `person` in the SAME organization (entity_identities are per-org, never
+ * cross-tenant). `last_authored_at` tracks the most recent contribution.
+ */
+const GITHUB_PERSON_ENTITY_LINK: EntityLinkRule = {
+  entityType: 'person',
+  autoCreate: true,
+  titlePath: 'metadata.author_login',
+  identities: [
+    // PRIMARY: the immutable numeric id is authoritative — when present it
+    // governs resolution, so a renamed-then-reused login can't conflate a new
+    // account into the old person (see entity-link-upsert resolution).
+    { namespace: IDENTITY.GITHUB_USER_ID, eventPath: 'metadata.author_id', primary: true },
+    { namespace: IDENTITY.GITHUB_LOGIN, eventPath: 'metadata.author_login' },
+  ],
+  traits: {
+    github_login: {
+      eventPath: 'metadata.author_login',
+      behavior: 'prefer_non_empty',
+    },
+    last_authored_at: {
+      eventPath: 'occurred_at',
+      behavior: 'overwrite',
+    },
+  },
+};
 
 export default class GitHubConnector extends ConnectorRuntime {
   readonly definition: ConnectorDefinition = {
@@ -339,8 +374,11 @@ export default class GitHubConnector extends ConnectorRuntime {
                 updated_at: { type: 'string' },
                 reactions: { type: 'object' },
                 comments: { type: 'number' },
+                author_login: { type: 'string' },
+                author_id: { type: 'string' },
               },
             },
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
           },
         },
       },
@@ -367,8 +405,11 @@ export default class GitHubConnector extends ConnectorRuntime {
                 updated_at: { type: 'string' },
                 reactions: { type: 'object' },
                 comments: { type: 'number' },
+                author_login: { type: 'string' },
+                author_id: { type: 'string' },
               },
             },
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
           },
         },
       },
@@ -391,8 +432,11 @@ export default class GitHubConnector extends ConnectorRuntime {
               properties: {
                 updated_at: { type: 'string' },
                 reactions: { type: 'object' },
+                author_login: { type: 'string' },
+                author_id: { type: 'string' },
               },
             },
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
           },
         },
       },
@@ -415,8 +459,11 @@ export default class GitHubConnector extends ConnectorRuntime {
               properties: {
                 updated_at: { type: 'string' },
                 reactions: { type: 'object' },
+                author_login: { type: 'string' },
+                author_id: { type: 'string' },
               },
             },
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
           },
         },
       },
@@ -442,8 +489,11 @@ export default class GitHubConnector extends ConnectorRuntime {
                 updated_at: { type: 'string' },
                 comments: { type: 'number' },
                 reactions: { type: 'number' },
+                author_login: { type: 'string' },
+                author_id: { type: 'string' },
               },
             },
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
           },
         },
       },
@@ -467,8 +517,11 @@ export default class GitHubConnector extends ConnectorRuntime {
                 discussion_number: { type: 'number' },
                 updated_at: { type: 'string' },
                 reactions: { type: 'number' },
+                author_login: { type: 'string' },
+                author_id: { type: 'string' },
               },
             },
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
           },
         },
       },
@@ -494,8 +547,11 @@ export default class GitHubConnector extends ConnectorRuntime {
                 action: { type: 'string' },
                 starred_at: { type: 'string' },
                 source: { type: 'string' },
+                author_login: { type: 'string' },
+                author_id: { type: 'string' },
               },
             },
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
           },
           stargazer_unstarred: {
             description: 'A GitHub user unstarred the repository',
@@ -938,6 +994,7 @@ export default class GitHubConnector extends ConnectorRuntime {
           updated_at: item.updated_at,
           reactions: item.reactions ?? {},
           comments: item.comments ?? 0,
+          ...this.buildAuthorMetadata(item.user),
         },
       });
     }
@@ -980,6 +1037,7 @@ export default class GitHubConnector extends ConnectorRuntime {
           metadata: {
             updated_at: comment.updated_at,
             reactions: comment.reactions ?? {},
+            ...this.buildAuthorMetadata(comment.user),
           },
         };
       })
@@ -1019,6 +1077,7 @@ export default class GitHubConnector extends ConnectorRuntime {
           metadata: {
             updated_at: comment.updated_at,
             reactions: comment.reactions ?? {},
+            ...this.buildAuthorMetadata(comment.user),
           },
         };
       })
@@ -1039,7 +1098,7 @@ export default class GitHubConnector extends ConnectorRuntime {
               number
               title
               body
-              author { login }
+              author { login ... on User { databaseId } }
               url
               createdAt
               updatedAt
@@ -1090,6 +1149,7 @@ export default class GitHubConnector extends ConnectorRuntime {
             updated_at: discussion.updatedAt,
             comments: discussion.comments?.totalCount ?? 0,
             reactions: discussion.reactions?.totalCount ?? 0,
+            ...this.buildGraphQLAuthorMetadata(discussion.author),
           },
         };
       })
@@ -1114,7 +1174,7 @@ export default class GitHubConnector extends ConnectorRuntime {
                   url
                   createdAt
                   updatedAt
-                  author { login }
+                  author { login ... on User { databaseId } }
                   reactions { totalCount }
                 }
               }
@@ -1167,6 +1227,7 @@ export default class GitHubConnector extends ConnectorRuntime {
             discussion_number: discussion.number,
             updated_at: comment.updatedAt,
             reactions: comment.reactions?.totalCount ?? 0,
+            ...this.buildGraphQLAuthorMetadata(comment.author),
           },
         });
       }
@@ -1256,6 +1317,7 @@ export default class GitHubConnector extends ConnectorRuntime {
               action: 'starred',
               starred_at: starredAt.toISOString(),
               source: 'github_stargazers_snapshot',
+              ...this.buildAuthorMetadata({ login, id: user.id }),
             },
           });
         }
@@ -1422,6 +1484,35 @@ export default class GitHubConnector extends ConnectorRuntime {
       verification_status: 'observed',
     });
     return identities;
+  }
+
+  /**
+   * Canonical author identity slot for entityLinks. Stamps `author_login`
+   * (the mutable handle, indexed for read-time attribution) and `author_id`
+   * (the immutable numeric GitHub user id, the PRIMARY match/dedupe key) into
+   * event metadata so the ingestion pipeline's `applyEntityLinks` resolves a
+   * `person` from REST payloads. Omitted keys when absent — bots/ghost authors
+   * may lack an id; the login still matches.
+   */
+  private buildAuthorMetadata(
+    user: { login?: string; id?: number } | undefined | null
+  ): Record<string, string> {
+    const out: Record<string, string> = {};
+    const login = asString(user?.login);
+    if (login) out.author_login = login;
+    if (typeof user?.id === 'number' && Number.isFinite(user.id)) {
+      out.author_id = String(user.id);
+    }
+    return out;
+  }
+
+  /** Same as {@link buildAuthorMetadata} but for GraphQL authors (`databaseId`). */
+  private buildGraphQLAuthorMetadata(
+    author: { login?: string; databaseId?: number } | undefined | null
+  ): Record<string, string> {
+    return this.buildAuthorMetadata(
+      author ? { login: author.login, id: author.databaseId } : undefined
+    );
   }
 
   private buildActor(user: GitHubStargazerLike['user'] | GitHubStargazerLike, login: string) {

--- a/packages/server/src/__tests__/integration/connectors/github-identity-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-identity-attribution.test.ts
@@ -1,0 +1,422 @@
+/**
+ * GitHub member-identity attribution contract (#17).
+ *
+ * Two ingestion paths must attribute a GitHub author to a tenant-scoped
+ * `person`, keyed PRIMARY on the immutable `github_user_id` and SECONDARY on
+ * `github_login`:
+ *
+ *   1. poll/sync — `applyEntityLinks` reads the connector's `entityLinks` rules
+ *      from `connector_definitions` and resolves/creates the person.
+ *   2. live webhook — `resolveGithubWebhookActor` (App-webhook path, no feed)
+ *      extracts the actor and resolves the SAME person, returning the entity
+ *      ids to stamp onto `events.entity_ids`.
+ *
+ * Both are org-scoped end to end: entity_identities are UNIQUE per
+ * (org, namespace, identifier), so a second org never resolves to another's
+ * person even with the same login/id.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyEntityLinks,
+  clearEntityLinkRulesCache,
+} from '../../../utils/entity-link-upsert';
+import { resolveGithubWebhookActor } from '../../../gateway/routes/public/github-webhook-actor';
+import { entityLinkMatchSql } from '../../../utils/content-search/entity-link';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const connectorKey = 'github';
+const feedKey = 'issues';
+
+/** The github person entity-link rule, mirrored from the github connector. */
+const githubPersonRule = {
+  entityType: 'person',
+  autoCreate: true,
+  titlePath: 'metadata.author_login',
+  identities: [
+    { namespace: 'github_user_id', eventPath: 'metadata.author_id', primary: true },
+    { namespace: 'github_login', eventPath: 'metadata.author_login' },
+  ],
+  traits: {
+    github_login: { eventPath: 'metadata.author_login', behavior: 'prefer_non_empty' },
+    last_authored_at: { eventPath: 'occurred_at', behavior: 'overwrite' },
+  },
+};
+
+async function ensurePersonType(orgId: string): Promise<void> {
+  const sql = getTestDb();
+  const existing = await sql`
+    SELECT id FROM entity_types
+    WHERE organization_id = ${orgId} AND slug = 'person' AND deleted_at IS NULL
+    LIMIT 1
+  `;
+  if (existing.length === 0) {
+    await sql`
+      INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+      VALUES (${orgId}, 'person', 'Person', current_timestamp, current_timestamp)
+    `;
+  }
+}
+
+async function seedOrg(name: string) {
+  const org = await createTestOrganization({ name });
+  const user = await createTestUser();
+  await addUserToOrganization(user.id, org.id, 'owner');
+  await ensurePersonType(org.id);
+  return org;
+}
+
+async function seedGithubConnector(orgId: string) {
+  await createTestConnectorDefinition({
+    key: connectorKey,
+    name: 'GitHub',
+    organization_id: orgId,
+    feeds_schema: {
+      [feedKey]: {
+        eventKinds: {
+          issue: { entityLinks: [githubPersonRule] },
+        },
+      },
+    },
+  });
+}
+
+async function members(orgId: string) {
+  const sql = getTestDb();
+  return sql<{ id: number; name: string; metadata: Record<string, unknown> }[]>`
+    SELECT e.id, e.name, e.metadata
+    FROM entities e
+    JOIN entity_types et ON et.id = e.entity_type_id
+    WHERE e.organization_id = ${orgId}
+      AND et.slug = 'person'
+      AND e.deleted_at IS NULL
+  `;
+}
+
+async function identitiesFor(entityId: number) {
+  const sql = getTestDb();
+  const rows = await sql<{ namespace: string; identifier: string }[]>`
+    SELECT namespace, identifier
+    FROM entity_identities
+    WHERE entity_id = ${entityId} AND deleted_at IS NULL
+    ORDER BY namespace, identifier
+  `;
+  return rows.map((r) => `${r.namespace}:${r.identifier}`);
+}
+
+describe('github member-identity attribution', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    clearEntityLinkRulesCache();
+  });
+
+  it('poll/sync: a synced issue auto-creates a person with github_user_id + github_login identities and stamps the metadata namespace slot', async () => {
+    const org = await seedOrg('GitHub Poll Org');
+    await seedGithubConnector(org.id);
+    clearEntityLinkRulesCache();
+
+    const item: {
+      origin_type: string;
+      occurred_at: string;
+      metadata: Record<string, unknown>;
+    } = {
+      origin_type: 'issue',
+      // Top-level EventEnvelope field — the `last_authored_at` trait reads it.
+      occurred_at: '2026-06-22T00:00:00.000Z',
+      metadata: {
+        number: 7,
+        author_login: 'Octocat',
+        author_id: '583231',
+      },
+    };
+
+    await applyEntityLinks({ connectorKey, feedKey, orgId: org.id, items: [item] });
+
+    const people = await members(org.id);
+    expect(people).toHaveLength(1);
+    expect(people[0].name).toBe('Octocat');
+    // The `github_login` trait preserves the raw display casing; the identity
+    // (and the read-time metadata slot below) carry the normalized form.
+    expect(people[0].metadata.github_login).toBe('Octocat');
+    expect(people[0].metadata.last_authored_at).toBe('2026-06-22T00:00:00.000Z');
+
+    expect(await identitiesFor(people[0].id)).toEqual([
+      'github_login:octocat',
+      'github_user_id:583231',
+    ]);
+
+    // The canonical read-time namespace slot (normalized) is stamped onto the
+    // item so the entity_identities JOIN surfaces the event.
+    expect(item.metadata.github_login).toBe('octocat');
+    expect(item.metadata.github_user_id).toBe('583231');
+  });
+
+  it('poll/sync: a renamed login still resolves to the same person via the immutable github_user_id', async () => {
+    const org = await seedOrg('GitHub Rename Org');
+    await seedGithubConnector(org.id);
+    clearEntityLinkRulesCache();
+
+    await applyEntityLinks({
+      connectorKey,
+      feedKey,
+      orgId: org.id,
+      items: [
+        {
+          origin_type: 'issue',
+          metadata: { author_login: 'oldname', author_id: '999', occurred_at: '2026-06-01T00:00:00.000Z' },
+        },
+      ],
+    });
+    // Same user id, new login → must NOT create a second person.
+    await applyEntityLinks({
+      connectorKey,
+      feedKey,
+      orgId: org.id,
+      items: [
+        {
+          origin_type: 'issue',
+          metadata: { author_login: 'newname', author_id: '999', occurred_at: '2026-06-22T00:00:00.000Z' },
+        },
+      ],
+    });
+
+    const people = await members(org.id);
+    expect(people).toHaveLength(1);
+    // Both logins are now claimed by the one person (sorted by namespace then
+    // identifier; both logins share the github_login namespace).
+    expect(await identitiesFor(people[0].id)).toEqual([
+      'github_login:newname',
+      'github_login:oldname',
+      'github_user_id:999',
+    ]);
+  });
+
+  it('poll/sync: a renamed-then-reused login does NOT conflate a new account into the old person (github_user_id primary)', async () => {
+    const org = await seedOrg('GitHub Reuse Org');
+    await seedGithubConnector(org.id);
+    clearEntityLinkRulesCache();
+
+    // Login "shared" was user_id 1 → person-1 created and claims github_login:shared.
+    await applyEntityLinks({
+      connectorKey,
+      feedKey,
+      orgId: org.id,
+      items: [{ origin_type: 'issue', metadata: { author_login: 'shared', author_id: '1' } }],
+    });
+    const afterFirst = await members(org.id);
+    expect(afterFirst).toHaveLength(1);
+    const personOneId = afterFirst[0].id;
+
+    // The original "shared" account renamed away; a DIFFERENT account (user_id 2)
+    // now uses the login "shared". The immutable github_user_id is PRIMARY and
+    // present (=2, unmatched), so resolution must NOT fall through to the stale
+    // github_login:shared match → a distinct person-2 is created.
+    await applyEntityLinks({
+      connectorKey,
+      feedKey,
+      orgId: org.id,
+      items: [{ origin_type: 'issue', metadata: { author_login: 'shared', author_id: '2' } }],
+    });
+
+    const people = await members(org.id);
+    expect(people).toHaveLength(2);
+    const personTwo = people.find((p) => p.id !== personOneId);
+    expect(personTwo).toBeDefined();
+    // person-2 owns github_user_id:2. The login stayed with whoever claimed it
+    // first (UNIQUE per org,namespace,identifier), so person-2 only has the id.
+    expect(await identitiesFor(personTwo!.id)).toEqual(['github_user_id:2']);
+    // person-1 is untouched — no conflation.
+    expect(await identitiesFor(personOneId)).toEqual([
+      'github_login:shared',
+      'github_user_id:1',
+    ]);
+  });
+
+  it('poll/sync: a stale secondary identity is NOT mis-claimed in the in-batch matches map', async () => {
+    const org = await seedOrg('GitHub Map Claim Org');
+    await seedGithubConnector(org.id);
+    clearEntityLinkRulesCache();
+
+    // Pre-seed person-1 owning github_login:shared + github_user_id:1.
+    await applyEntityLinks({
+      connectorKey,
+      feedKey,
+      orgId: org.id,
+      items: [{ origin_type: 'issue', metadata: { author_login: 'shared', author_id: '1' } }],
+    });
+    const personOneId = (await members(org.id))[0].id;
+
+    // In ONE batch:
+    //   (a) login "shared" + a FRESH id 2 → creates person-2; the login stays on
+    //       person-1 (ON CONFLICT no-op), so the matches map must NOT claim
+    //       github_login:shared for person-2.
+    //   (b) a login-only "shared" event → must resolve to person-1 (the real
+    //       owner of that login), proving the map wasn't mis-claimed for person-2.
+    await applyEntityLinks({
+      connectorKey,
+      feedKey,
+      orgId: org.id,
+      items: [
+        { origin_type: 'issue', metadata: { author_login: 'shared', author_id: '2' } },
+        { origin_type: 'issue', metadata: { author_login: 'shared' } },
+      ],
+    });
+
+    const people = await members(org.id);
+    // Exactly two people: person-1 (login owner) and person-2 (id:2). The
+    // login-only event resolved to person-1, NOT a third entity or person-2.
+    expect(people).toHaveLength(2);
+    const personTwo = people.find((p) => p.id !== personOneId);
+    expect(personTwo).toBeDefined();
+    expect(await identitiesFor(personTwo!.id)).toEqual(['github_user_id:2']);
+    expect(await identitiesFor(personOneId)).toEqual([
+      'github_login:shared',
+      'github_user_id:1',
+    ]);
+  });
+
+  it('poll/sync READ-TIME: a reused-login event attributes to the user_id-2 person, NOT the old person-1', async () => {
+    const org = await seedOrg('GitHub Read-Time Reuse Org');
+    await seedGithubConnector(org.id);
+    clearEntityLinkRulesCache();
+    const sql = getTestDb();
+
+    // Helper: which events attribute to `entityId` at READ TIME (the
+    // entityLinkMatchSql JOIN against entity_identities + events.metadata).
+    const readTimeEventIds = async (entityId: number): Promise<number[]> => {
+      const rows = await sql<{ id: number }[]>`
+        SELECT f.id FROM events f
+        WHERE f.organization_id = ${org.id}
+          AND ${sql.unsafe(entityLinkMatchSql(`${entityId}::bigint`, 'f'))}
+        ORDER BY f.id
+      `;
+      return rows.map((r) => Number(r.id));
+    };
+
+    // Event 1: login "shared" + user_id 1 → person-1. applyEntityLinks stamps
+    // the attached identifier slots onto item1.metadata.
+    const item1: { origin_type: string; metadata: Record<string, unknown> } = {
+      origin_type: 'issue',
+      metadata: { author_login: 'shared', author_id: '1' },
+    };
+    await applyEntityLinks({ connectorKey, feedKey, orgId: org.id, items: [item1] });
+    const personOneId = (await members(org.id))[0].id;
+    const e1 = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'evt-1',
+      semanticType: 'content',
+      title: 'issue 1',
+      originType: 'issue',
+      connectorKey: 'github',
+      metadata: item1.metadata,
+    });
+
+    // Event 2: same login "shared" reclaimed by a DIFFERENT account (user_id 2)
+    // → person-2 (immutable id primary). applyEntityLinks stamps ONLY the
+    // attached identifier (github_user_id:2), not the stale github_login:shared.
+    const item2: { origin_type: string; metadata: Record<string, unknown> } = {
+      origin_type: 'issue',
+      metadata: { author_login: 'shared', author_id: '2' },
+    };
+    await applyEntityLinks({ connectorKey, feedKey, orgId: org.id, items: [item2] });
+    const people = await members(org.id);
+    expect(people).toHaveLength(2);
+    const personTwoId = people.find((p) => p.id !== personOneId)!.id;
+    const e2 = await insertEvent({
+      entityIds: [],
+      organizationId: org.id,
+      originId: 'evt-2',
+      semanticType: 'content',
+      title: 'issue 2',
+      originType: 'issue',
+      connectorKey: 'github',
+      metadata: item2.metadata,
+    });
+
+    // THE read-time assertion: event-2 attributes to person-2 (via the immutable
+    // github_user_id), NOT to the old person-1 (the reused login is not stamped).
+    expect(await readTimeEventIds(personTwoId)).toEqual([Number(e2.id)]);
+    expect(await readTimeEventIds(personOneId)).toEqual([Number(e1.id)]);
+    // The stale login is not on event-2's metadata, so it can't JOIN person-1.
+    expect(item2.metadata.github_login).toBeUndefined();
+    expect(item2.metadata.github_user_id).toBe('2');
+  });
+
+  it('webhook: resolveGithubWebhookActor resolves the actor to a person and returns entity ids + the github_login metadata slot', async () => {
+    const org = await seedOrg('GitHub Webhook Org');
+
+    const resolution = await resolveGithubWebhookActor({
+      organizationId: org.id,
+      githubEvent: 'issue_comment',
+      payload: {
+        action: 'created',
+        comment: { user: { login: 'Hubot', id: 42 }, html_url: 'https://github.com/x/y/issues/1#c1' },
+        issue: { user: { login: 'someone-else', id: 7 }, title: 'Bug' },
+        sender: { login: 'Hubot', id: 42 },
+      },
+    });
+
+    expect(resolution).not.toBeNull();
+    expect(resolution?.entityIds).toHaveLength(1);
+    // The COMMENT author (Hubot), not the issue author, is attributed.
+    expect(resolution?.metadata.github_login).toBe('hubot');
+    expect(resolution?.metadata.github_user_id).toBe('42');
+
+    const people = await members(org.id);
+    expect(people).toHaveLength(1);
+    expect(people[0].id).toBe(resolution?.entityIds[0]);
+    expect(await identitiesFor(people[0].id)).toEqual([
+      'github_login:hubot',
+      'github_user_id:42',
+    ]);
+    // The `last_authored_at` trait populates on the webhook path too (occurred_at
+    // is on the top-level item, where the rule's trait path reads it).
+    expect(people[0].metadata.last_authored_at).toBeTruthy();
+    expect(typeof people[0].metadata.last_authored_at).toBe('string');
+  });
+
+  it('webhook: an unmapped github event (push) resolves no actor', async () => {
+    const org = await seedOrg('GitHub Push Org');
+    const resolution = await resolveGithubWebhookActor({
+      organizationId: org.id,
+      githubEvent: 'push',
+      payload: { pusher: { name: 'someone' }, sender: { login: 'someone', id: 1 } },
+    });
+    expect(resolution).toBeNull();
+    expect(await members(org.id)).toHaveLength(0);
+  });
+
+  it('tenant-scoped: the same github user in two orgs resolves to two distinct persons', async () => {
+    const orgA = await seedOrg('GitHub Tenant A');
+    const orgB = await seedOrg('GitHub Tenant B');
+
+    const a = await resolveGithubWebhookActor({
+      organizationId: orgA.id,
+      githubEvent: 'issues',
+      payload: { action: 'opened', issue: { user: { login: 'Shared', id: 555 }, title: 'A' } },
+    });
+    const b = await resolveGithubWebhookActor({
+      organizationId: orgB.id,
+      githubEvent: 'issues',
+      payload: { action: 'opened', issue: { user: { login: 'Shared', id: 555 }, title: 'B' } },
+    });
+
+    const peopleA = await members(orgA.id);
+    const peopleB = await members(orgB.id);
+    expect(peopleA).toHaveLength(1);
+    expect(peopleB).toHaveLength(1);
+    // Distinct entities despite identical login + id — entity_identities are
+    // UNIQUE per (org, namespace, identifier), never cross-org.
+    expect(peopleA[0].id).not.toBe(peopleB[0].id);
+    expect(a?.entityIds[0]).toBe(peopleA[0].id);
+    expect(b?.entityIds[0]).toBe(peopleB[0].id);
+  });
+});

--- a/packages/server/src/gateway/__tests__/app-webhooks.test.ts
+++ b/packages/server/src/gateway/__tests__/app-webhooks.test.ts
@@ -56,6 +56,27 @@ function buildApp() {
 	});
 }
 
+/**
+ * Build the router with the github provider's `resolveActor` wrapped in a
+ * counter, so a test can assert exactly one resolution per landed event.
+ */
+function buildAppWithActorCounter(): { app: ReturnType<typeof createAppWebhookRoutes>; calls: () => number } {
+	const provider = createGithubAppWebhookProvider({ appId: APP_ID });
+	const original = provider.resolveActor!.bind(provider);
+	let count = 0;
+	provider.resolveActor = async (params) => {
+		count += 1;
+		return original(params);
+	};
+	const app = createAppWebhookRoutes({
+		installationStore: createPostgresAppInstallationStore(),
+		secretStore: fakeSecretStore,
+		providers: [provider],
+		resolveAppWebhookSecret: async () => APP_SECRET,
+	});
+	return { app, calls: () => count };
+}
+
 /** Seed an ACTIVE github installation for the routed tenant tuple. */
 async function seedActiveInstall(): Promise<number> {
 	const store = createPostgresAppInstallationStore();
@@ -98,6 +119,69 @@ async function eventRows(connectorKey: string): Promise<any[]> {
     WHERE connector_key = ${connectorKey}
     ORDER BY id
   `;
+}
+
+/**
+ * Seed the prerequisites for actor → person resolution in the routed org: an
+ * org member (entities.created_by is NOT NULL — resolveOrgCreator reads it) and
+ * the `person` entity type the github actor rule auto-creates into.
+ */
+async function seedPersonResolutionPrereqs(orgId: string): Promise<void> {
+	const { getDb } = await import("../../db/client.js");
+	const sql = getDb();
+	const userId = `u-${orgId}`;
+	await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${userId}, 'Owner', ${`${userId}@example.com`}, true, NOW(), NOW())
+    ON CONFLICT (id) DO NOTHING
+  `;
+	await sql`
+    INSERT INTO "member" (id, "organizationId", "userId", role, "createdAt")
+    VALUES (${`m-${orgId}`}, ${orgId}, ${userId}, 'owner', NOW())
+    ON CONFLICT (id) DO NOTHING
+  `;
+	await sql`
+    INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+    VALUES (${orgId}, 'person', 'Person', NOW(), NOW())
+    ON CONFLICT DO NOTHING
+  `;
+}
+
+async function personRows(orgId: string): Promise<any[]> {
+	const { getDb } = await import("../../db/client.js");
+	return getDb()`
+    SELECT e.id, e.name, e.metadata
+    FROM entities e
+    JOIN entity_types et ON et.id = e.entity_type_id
+    WHERE e.organization_id = ${orgId} AND et.slug = 'person' AND e.deleted_at IS NULL
+    ORDER BY e.id
+  `;
+}
+
+/**
+ * Parse `events.entity_ids` regardless of how the driver hands it back: this
+ * gateway (bun:test) harness reads the raw column as a Postgres array literal
+ * string (`"{1,2}"` / `"{}"`); other paths return a JS array. Normalize to
+ * number[] so the attribution assertion is driver-agnostic.
+ */
+function parseEntityIds(value: unknown): number[] {
+	if (Array.isArray(value)) return value.map((v) => Number(v));
+	if (typeof value === "string") {
+		const inner = value.replace(/^\{|\}$/g, "").trim();
+		if (!inner) return [];
+		return inner.split(",").map((s) => Number(s));
+	}
+	return [];
+}
+
+async function identitiesFor(entityId: number): Promise<string[]> {
+	const { getDb } = await import("../../db/client.js");
+	const rows = await getDb()`
+    SELECT namespace, identifier FROM entity_identities
+    WHERE entity_id = ${entityId} AND deleted_at IS NULL
+    ORDER BY namespace, identifier
+  `;
+	return rows.map((r: any) => `${r.namespace}:${r.identifier}`);
 }
 
 beforeAll(async () => {
@@ -342,6 +426,188 @@ describe("app-webhook router (GitHub)", () => {
 		const rows = await eventRows(`webhook:app_install:${installId}`);
 		expect(rows.length).toBe(1);
 		expect(rows[0].origin_id).toBe("gh-dupe-1");
+	});
+
+	test("a signed delivery resolves the actor → person and lands NON-EMPTY entity_ids", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedPersonResolutionPrereqs(ORG);
+		const installId = await seedActiveInstall();
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "opened",
+			installation: { id: Number(INSTALLATION_ID) },
+			issue: {
+				number: 11,
+				title: "Prod is down",
+				html_url: "https://github.com/acme/api/issues/11",
+				user: { login: "Octocat", id: 583231 },
+			},
+			sender: { login: "Octocat", id: 583231 },
+			repository: { full_name: "acme/api" },
+		});
+		const res = await app.fetch(ghDelivery(raw, { deliveryId: "gh-attr-1" }));
+		expect(res.status).toBe(202);
+
+		// A person was created for the issue author and the row is attributed.
+		const people = await personRows(ORG);
+		expect(people.length).toBe(1);
+		expect(people[0].name).toBe("Octocat");
+		expect(await identitiesFor(Number(people[0].id))).toEqual([
+			"github_login:octocat",
+			"github_user_id:583231",
+		]);
+
+		const rows = await eventRows(`webhook:app_install:${installId}`);
+		expect(rows.length).toBe(1);
+		// THE assertion the PR claims: the landed row carries the resolved person.
+		expect(parseEntityIds(rows[0].entity_ids)).toEqual([Number(people[0].id)]);
+		// Canonical read-time identity slot stamped onto the row.
+		expect(rows[0].metadata.github_login).toBe("octocat");
+	});
+
+	test("an issue_comment delivery attributes the COMMENT author, not the issue author", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedPersonResolutionPrereqs(ORG);
+		const installId = await seedActiveInstall();
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "created",
+			installation: { id: Number(INSTALLATION_ID) },
+			issue: {
+				number: 11,
+				title: "Prod is down",
+				html_url: "https://github.com/acme/api/issues/11",
+				user: { login: "issue-author", id: 1 },
+			},
+			comment: {
+				id: 555,
+				body: "Looking into it",
+				html_url: "https://github.com/acme/api/issues/11#issuecomment-555",
+				user: { login: "Hubot", id: 42 },
+			},
+			sender: { login: "Hubot", id: 42 },
+			repository: { full_name: "acme/api" },
+		});
+		const res = await app.fetch(
+			ghDelivery(raw, { deliveryId: "gh-attr-2", event: "issue_comment" }),
+		);
+		expect(res.status).toBe(202);
+
+		const people = await personRows(ORG);
+		// Only the comment author is resolved by this delivery.
+		expect(people.length).toBe(1);
+		expect(people[0].name).toBe("Hubot");
+
+		const rows = await eventRows(`webhook:app_install:${installId}`);
+		expect(parseEntityIds(rows[0].entity_ids)).toEqual([Number(people[0].id)]);
+		expect(rows[0].metadata.github_login).toBe("hubot");
+	});
+
+	test("an unmapped event (push) lands the row but resolves no actor (empty entity_ids)", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedPersonResolutionPrereqs(ORG);
+		const installId = await seedActiveInstall();
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			ref: "refs/heads/main",
+			installation: { id: Number(INSTALLATION_ID) },
+			pusher: { name: "someone" },
+			sender: { login: "someone", id: 9 },
+		});
+		const res = await app.fetch(
+			ghDelivery(raw, { deliveryId: "gh-push-1", event: "push" }),
+		);
+		expect(res.status).toBe(202);
+		// Delivery still lands (store-everything), just unattributed.
+		const rows = await eventRows(`webhook:app_install:${installId}`);
+		expect(rows.length).toBe(1);
+		expect(parseEntityIds(rows[0].entity_ids)).toEqual([]);
+		expect(await personRows(ORG)).toHaveLength(0);
+	});
+
+	test("a redelivered (deduped) delivery does NOT create a person, bump the graph, or land a second event", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedPersonResolutionPrereqs(ORG);
+		const installId = await seedActiveInstall();
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "opened",
+			installation: { id: Number(INSTALLATION_ID) },
+			issue: {
+				number: 11,
+				title: "Prod is down",
+				html_url: "https://github.com/acme/api/issues/11",
+				user: { login: "Octocat", id: 583231 },
+			},
+			sender: { login: "Octocat", id: 583231 },
+			repository: { full_name: "acme/api" },
+		});
+
+		// First delivery: persists + resolves the actor → one person.
+		const first = await app.fetch(ghDelivery(raw, { deliveryId: "gh-dedupe-attr" }));
+		expect(first.status).toBe(202);
+		const peopleAfterFirst = await personRows(ORG);
+		expect(peopleAfterFirst.length).toBe(1);
+		const firstAuthoredAt = peopleAfterFirst[0].metadata.last_authored_at;
+		expect(firstAuthoredAt).toBeTruthy();
+
+		// Redelivery of the SAME x-github-delivery: deduped → no new event AND no
+		// entity-graph mutation (no second person, last_authored_at unchanged).
+		const second = await app.fetch(ghDelivery(raw, { deliveryId: "gh-dedupe-attr" }));
+		expect(second.status).toBe(202);
+		expect((await second.json()).duplicate).toBe(true);
+
+		const peopleAfterSecond = await personRows(ORG);
+		expect(peopleAfterSecond.length).toBe(1);
+		// Same person, untouched — resolution never ran on the duplicate.
+		expect(peopleAfterSecond[0].id).toBe(peopleAfterFirst[0].id);
+		expect(peopleAfterSecond[0].metadata.last_authored_at).toBe(firstAuthoredAt);
+
+		// Exactly one event landed.
+		const rows = await eventRows(`webhook:app_install:${installId}`);
+		expect(rows.length).toBe(1);
+	});
+
+	test("TWO concurrent deliveries of the same event resolve the actor exactly once", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedPersonResolutionPrereqs(ORG);
+		const installId = await seedActiveInstall();
+		const { app, calls } = buildAppWithActorCounter();
+
+		const raw = JSON.stringify({
+			action: "opened",
+			installation: { id: Number(INSTALLATION_ID) },
+			issue: {
+				number: 11,
+				title: "Prod is down",
+				html_url: "https://github.com/acme/api/issues/11",
+				user: { login: "Octocat", id: 583231 },
+			},
+			sender: { login: "Octocat", id: 583231 },
+			repository: { full_name: "acme/api" },
+		});
+
+		// Fire both deliveries of the SAME x-github-delivery simultaneously. The
+		// delivery-unique index picks one winner; the loser's tx rolls back before
+		// it ever resolves the actor.
+		const [a, b] = await Promise.all([
+			app.fetch(ghDelivery(raw, { deliveryId: "gh-concurrent" })),
+			app.fetch(ghDelivery(raw, { deliveryId: "gh-concurrent" })),
+		]);
+		expect([a.status, b.status]).toEqual([202, 202]);
+
+		// Exactly one actor resolution, one event, one person, one last_authored_at.
+		expect(calls()).toBe(1);
+		const rows = await eventRows(`webhook:app_install:${installId}`);
+		expect(rows.length).toBe(1);
+		expect(parseEntityIds(rows[0].entity_ids).length).toBe(1);
+		const people = await personRows(ORG);
+		expect(people.length).toBe(1);
+		expect(people[0].metadata.last_authored_at).toBeTruthy();
 	});
 
 	test("an unknown provider path returns 404", async () => {

--- a/packages/server/src/gateway/connections/webhook-ingest.ts
+++ b/packages/server/src/gateway/connections/webhook-ingest.ts
@@ -33,7 +33,7 @@
 
 import { createHash, createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import type { StoredConnection } from "@lobu/core";
-import { getDb } from "../../db/client.js";
+import { type DbClient, getDb } from "../../db/client.js";
 import { constantTimeEqual } from "../../utils/constant-time-equal.js";
 import { insertEvent } from "../../utils/insert-event.js";
 import logger from "../../utils/logger.js";
@@ -325,9 +325,24 @@ async function findExistingDeliveryId(
  * event type. The app-webhook router therefore extracts these per provider and
  * passes them here; when set they take precedence over `config.titlePath`.
  */
+/** Entity attribution for the landed row, produced by {@link WebhookIngestOverrides.resolveActor}. */
+export interface WebhookActorAttribution {
+	/** Entity ids → events.entity_ids (the webhook path has no feed, so read-time JOINs need this). */
+	entityIds?: number[];
+	/** Canonical identifier namespace slots (e.g. github_login) merged onto the row for read-time JOINs. */
+	metadata?: Record<string, unknown>;
+}
+
 export interface WebhookIngestOverrides {
 	title?: string | null;
 	sourceUrl?: string | null;
+	/**
+	 * Resolve the authoring actor → a person. Invoked only on the WINNING insert,
+	 * inside the persist transaction (the `sql` handle IS that tx), so the actor
+	 * graph writes commit atomically with the event and a deduped/lost-race
+	 * delivery never mutates the graph. A null/throw lands the row unattributed.
+	 */
+	resolveActor?: (sql: DbClient) => Promise<WebhookActorAttribution | null>;
 }
 
 /**
@@ -498,8 +513,8 @@ export async function handleWebhookIngest(
 			? config.semanticType
 			: "content";
 
-	// 6. Persist, then ack. A duplicate (pre-checked or raced) is still a 202 —
-	//    the provider delivered successfully; we just already had it.
+	// 6. Persist, then ack. Actor resolution is tied to the winning insert (see
+	//    the transaction below). Fast-path a sequential duplicate first.
 	const existingId = await findExistingDeliveryId(
 		organizationId,
 		connectorKey,
@@ -509,41 +524,82 @@ export async function handleWebhookIngest(
 		return json(202, { ok: true, id: existingId, duplicate: true });
 	}
 
+	const eventMetadata: Record<string, unknown> = {
+		webhook_connection_id: stored.id,
+		dedupe_source: dedupeSource,
+	};
+	const eventTitle =
+		overrides?.title != null && overrides.title.length > 0
+			? overrides.title.slice(0, 500)
+			: extractTitle(parsed, config.titlePath);
+	const eventContent = isSearchableEnabled(config) ? renderPayloadText(parsed) : null;
+
 	try {
-		const inserted = await insertEvent({
-			entityIds: [],
-			organizationId,
-			originId,
-			connectorKey,
-			semanticType,
-			payloadType: "json_template",
-			payloadData,
-			// Opt-in searchable text projection: only when `searchable` is set
-			// do we render payload_text, which is the gate the embed-backfill
-			// keys on (it skips empty payload_text). Default off keeps the row
-			// store-only (watcher SQL) and out of semantic memory. The full
-			// payload always stays in payload_data; this is lossy-by-cap.
-			content: isSearchableEnabled(config) ? renderPayloadText(parsed) : null,
-			// Caller-supplied title/url (app-webhook provider extractor) win over the
-			// static config.titlePath pointer; both fall through to undefined/null.
-			title:
-				overrides?.title != null && overrides.title.length > 0
-					? overrides.title.slice(0, 500)
-					: extractTitle(parsed, config.titlePath),
-			sourceUrl: overrides?.sourceUrl ?? null,
-			occurredAt: new Date(),
-			metadata: {
-				webhook_connection_id: stored.id,
-				dedupe_source: dedupeSource,
-			},
+		const landedId = await getDb().begin(async (tx) => {
+			// Insert FIRST (empty entity_ids). A concurrent duplicate trips the
+			// delivery-unique index → 23505 → this tx rolls back, so the loser never
+			// reaches actor resolution. Only the winner continues.
+			const inserted = await insertEvent(
+				{
+					entityIds: [],
+					organizationId,
+					originId,
+					connectorKey,
+					semanticType,
+					payloadType: "json_template",
+					payloadData,
+					content: eventContent,
+					title: eventTitle,
+					sourceUrl: overrides?.sourceUrl ?? null,
+					occurredAt: new Date(),
+					metadata: eventMetadata,
+				},
+				{ sql: tx as unknown as ReturnType<typeof getDb> },
+			);
+
+			// Winner-only resolution in the same tx: exactly one resolveActor per
+			// landed event, and no window where the row is visible with empty
+			// entity_ids. Best-effort — a miss/throw leaves the row unattributed.
+			let attribution: WebhookActorAttribution | null = null;
+			if (overrides?.resolveActor) {
+				try {
+					attribution = await overrides.resolveActor(
+						tx as unknown as DbClient,
+					);
+				} catch (error) {
+					logger.warn(
+						{ connectionId: stored.id, error: String(error) },
+						"[webhook-ingest] actor resolution failed — landing delivery unattributed",
+					);
+				}
+			}
+			if (
+				attribution &&
+				((attribution.entityIds && attribution.entityIds.length > 0) ||
+					(attribution.metadata && Object.keys(attribution.metadata).length > 0))
+			) {
+				const entityIdsValue =
+					attribution.entityIds && attribution.entityIds.length > 0
+						? `{${attribution.entityIds.join(",")}}`
+						: null;
+				await tx`
+					UPDATE events
+					SET entity_ids = COALESCE(${entityIdsValue}::bigint[], entity_ids),
+					    metadata = metadata || ${tx.json(attribution.metadata ?? {})}
+					WHERE id = ${inserted.id}
+				`;
+			}
+			return inserted.id;
 		});
 		logger.info(
-			{ connectionId: stored.id, eventId: inserted.id, dedupeSource },
+			{ connectionId: stored.id, eventId: landedId, dedupeSource },
 			"[webhook-ingest] delivery persisted",
 		);
-		return json(202, { ok: true, id: inserted.id });
+		return json(202, { ok: true, id: landedId });
 	} catch (error) {
 		if (isUniqueViolation(error)) {
+			// Lost the concurrent race: the winner's row exists; ack as a duplicate.
+			// The rolled-back tx means we never resolved the actor here.
 			const racedId = await findExistingDeliveryId(
 				organizationId,
 				connectorKey,

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -38,6 +38,7 @@ import { Hono } from "hono";
 import { createLogger } from "@lobu/core";
 import type { StoredConnection } from "@lobu/core";
 import type { ConnectorWebhookSchema } from "@lobu/connector-sdk";
+import type { DbClient } from "../../../db/client.js";
 import {
 	handleWebhookIngest,
 	readBodyWithCap,
@@ -46,6 +47,7 @@ import {
 } from "../../connections/webhook-ingest.js";
 import type { SecretStore } from "../../secrets/index.js";
 import type { AppInstallationStore } from "../../../lobu/stores/app-installation-store.js";
+import { resolveGithubWebhookActor } from "./github-webhook-actor.js";
 
 const logger = createLogger("app-webhook-routes");
 
@@ -108,6 +110,19 @@ export interface AppWebhookProvider {
 	extractTenant(rawBody: Uint8Array, headers: Headers): AppWebhookTenant | null;
 	/** Optional title/source_url for the landed row; omitted → empty fields. */
 	extractContent?(rawBody: Uint8Array, headers: Headers): AppWebhookContent;
+	/**
+	 * Optional: resolve the delivery's authoring actor to a tenant-scoped
+	 * `person` → entity ids + identifier metadata slots for the landed row. The
+	 * org is the caller's resolved install, so resolution never crosses orgs.
+	 * Invoked lazily by handleWebhookIngest on the winning insert only; `sql` is
+	 * that insert's transaction, so the graph writes commit atomically with it.
+	 */
+	resolveActor?(params: {
+		organizationId: string;
+		rawBody: Uint8Array;
+		headers: Headers;
+		sql: DbClient;
+	}): Promise<{ entityIds: number[]; metadata: Record<string, string> } | null>;
 }
 
 /** Parse the raw JSON body once; returns undefined on malformed JSON. */
@@ -190,8 +205,11 @@ export function createSchemaDrivenAppWebhookProvider(options: {
 	extractTenant(rawBody: Uint8Array, headers: Headers): AppWebhookTenant | null;
 	/** Optional title/source_url projector for the landed row. */
 	extractContent?(rawBody: Uint8Array, headers: Headers): AppWebhookContent;
+	/** Optional actor → person resolver (see {@link AppWebhookProvider.resolveActor}). */
+	resolveActor?: AppWebhookProvider["resolveActor"];
 }): AppWebhookProvider {
-	const { provider, webhookSchema, extractTenant, extractContent } = options;
+	const { provider, webhookSchema, extractTenant, extractContent, resolveActor } =
+		options;
 	const signatureHeader = webhookSchema.signatureHeader;
 	if (!signatureHeader) {
 		throw new Error(
@@ -222,6 +240,7 @@ export function createSchemaDrivenAppWebhookProvider(options: {
 		},
 		extractTenant,
 		...(extractContent ? { extractContent } : {}),
+		...(resolveActor ? { resolveActor } : {}),
 	};
 }
 
@@ -275,6 +294,17 @@ export function createGithubAppWebhookProvider(options: {
 		},
 		extractContent(rawBody) {
 			return extractGithubWebhookContent(rawBody);
+		},
+		// Resolve the authoring github actor → a tenant-scoped person. Lazy: the
+		// router hands it the persist transaction so the graph writes are atomic
+		// with the event insert (and never run for deduped/lost-race deliveries).
+		async resolveActor({ organizationId, rawBody, headers, sql }) {
+			return resolveGithubWebhookActor({
+				organizationId,
+				githubEvent: headers.get("x-github-event"),
+				payload: parseJson(rawBody),
+				sql,
+			});
 		},
 	});
 }
@@ -535,10 +565,21 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 			body: rawBody,
 		});
 
-		// Project the delivery to a human title + source url for the landed row.
-		// Optional per provider; a miss leaves the row's title/source_url empty
-		// (the prior behaviour) rather than failing the delivery.
+		// Title/source_url for the landed row; a miss leaves them empty.
 		const content = provider.extractContent?.(rawBody, c.req.raw.headers);
+
+		// Resolution runs lazily inside handleWebhookIngest on the winning insert
+		// only — resolving here would mutate the graph for deduped redeliveries.
+		// `sql` is the persist transaction, threaded so the actor writes are atomic.
+		const resolveActor = provider.resolveActor
+			? (sql: DbClient) =>
+					provider.resolveActor!({
+						organizationId: install.organizationId,
+						rawBody,
+						headers: c.req.raw.headers,
+						sql,
+					})
+			: undefined;
 
 		try {
 			return await handleWebhookIngest(
@@ -546,8 +587,12 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 				ingestRequest,
 				deps.secretStore,
 				c.var.peerRemoteAddress,
-				content
-					? { title: content.title, sourceUrl: content.sourceUrl }
+				content || resolveActor
+					? {
+							title: content?.title,
+							sourceUrl: content?.sourceUrl,
+							resolveActor,
+						}
 					: undefined,
 			);
 		} catch (error) {

--- a/packages/server/src/gateway/routes/public/github-webhook-actor.ts
+++ b/packages/server/src/gateway/routes/public/github-webhook-actor.ts
@@ -1,0 +1,168 @@
+/**
+ * GitHub App webhook actor → person resolution. The live App-webhook path used
+ * to land deliveries with empty `events.entity_ids`; this resolves the authoring
+ * actor to a tenant-scoped `person` (mirroring the poll path's entityLinks keys).
+ * Org-scoped via the caller's resolved install; resolution never crosses orgs.
+ */
+
+import type { EntityLinkRule } from "@lobu/connector-sdk";
+import { IDENTITY } from "@lobu/connector-sdk";
+import type { DbClient } from "../../../db/client.js";
+import { resolveEntityLinksForItems } from "../../../utils/entity-link-upsert.js";
+
+// Mirrors the github connector's GITHUB_PERSON_ENTITY_LINK (server can't import
+// the connector package). PRIMARY immutable github_user_id (rename-safe) +
+// secondary github_login.
+const GITHUB_PERSON_RULE: EntityLinkRule = {
+	entityType: "person",
+	autoCreate: true,
+	titlePath: "metadata.author_login",
+	identities: [
+		{
+			namespace: IDENTITY.GITHUB_USER_ID,
+			eventPath: "metadata.author_id",
+			primary: true,
+		},
+		{ namespace: IDENTITY.GITHUB_LOGIN, eventPath: "metadata.author_login" },
+	],
+	traits: {
+		github_login: {
+			eventPath: "metadata.author_login",
+			behavior: "prefer_non_empty",
+		},
+		last_authored_at: { eventPath: "occurred_at", behavior: "overwrite" },
+	},
+};
+
+interface GithubActor {
+	login?: unknown;
+	id?: unknown;
+}
+
+function actorLogin(node: unknown): string | undefined {
+	if (node === null || typeof node !== "object") return undefined;
+	const login = (node as GithubActor).login;
+	return typeof login === "string" && login.length > 0 ? login : undefined;
+}
+
+function actorId(node: unknown): string | undefined {
+	if (node === null || typeof node !== "object") return undefined;
+	const id = (node as GithubActor).id;
+	if (typeof id === "number" && Number.isFinite(id)) return String(id);
+	if (typeof id === "string" && /^\d+$/.test(id.trim())) return id.trim();
+	return undefined;
+}
+
+/**
+ * The authoring actor: the `user` of the subject (comment, then
+ * issue/PR/discussion/review), falling back to `sender` (a user object) so
+ * star/watch/membership events — which carry only `sender` — still attribute.
+ */
+export function extractGithubActor(
+	payload: unknown,
+): { author_login: string; author_id?: string } | null {
+	if (payload === null || typeof payload !== "object") return null;
+	const root = payload as Record<string, unknown>;
+
+	const subjectUser = (key: string): unknown => {
+		const subject = root[key];
+		if (subject === null || typeof subject !== "object") return undefined;
+		return (subject as Record<string, unknown>).user;
+	};
+	const candidates: unknown[] = [
+		subjectUser("comment"),
+		subjectUser("issue"),
+		subjectUser("pull_request"),
+		subjectUser("discussion"),
+		subjectUser("review"),
+		root.sender,
+	];
+
+	for (const node of candidates) {
+		const login = actorLogin(node);
+		if (!login) continue;
+		const id = actorId(node);
+		return id ? { author_login: login, author_id: id } : { author_login: login };
+	}
+	return null;
+}
+
+// x-github-event header → our connector event-kind names. Only authored content
+// kinds map; unmapped events (push, …) resolve no actor.
+const GITHUB_EVENT_TO_KIND: Record<string, string> = {
+	issues: "issue",
+	pull_request: "pull_request",
+	issue_comment: "issue_comment",
+	pull_request_review_comment: "pr_comment",
+	// review.user / comment.user authors — both already handled by extractGithubActor.
+	pull_request_review: "pull_request_review",
+	commit_comment: "commit_comment",
+	discussion: "discussion",
+	discussion_comment: "discussion_comment",
+	star: "stargazer",
+	watch: "stargazer",
+};
+
+export interface GithubActorResolution {
+	/** Resolved/created person entity ids (usually one). */
+	entityIds: number[];
+	/** Canonical identifier namespace slots to stamp onto event metadata. */
+	metadata: Record<string, string>;
+}
+
+/**
+ * Resolve the delivery's authoring actor to a tenant-scoped `person`, returning
+ * the entity ids + identifier metadata slots to stamp on the landed row.
+ * Best-effort: any failure returns null (caller lands the row unattributed).
+ */
+export async function resolveGithubWebhookActor(params: {
+	organizationId: string;
+	githubEvent: string | null;
+	payload: unknown;
+	/** Optional transaction handle so the graph writes are atomic with the caller's insert. */
+	sql?: DbClient;
+}): Promise<GithubActorResolution | null> {
+	if (!params.githubEvent) return null;
+	const kind = GITHUB_EVENT_TO_KIND[params.githubEvent];
+	if (!kind) return null;
+
+	const actor = extractGithubActor(params.payload);
+	if (!actor) return null;
+
+	// occurred_at is a top-level EventEnvelope field — the last_authored_at trait
+	// reads it there, matching the poll path.
+	const item: {
+		origin_type: string;
+		occurred_at: string;
+		metadata: Record<string, unknown>;
+	} = {
+		origin_type: kind,
+		occurred_at: new Date().toISOString(),
+		metadata: {
+			author_login: actor.author_login,
+			...(actor.author_id ? { author_id: actor.author_id } : {}),
+		},
+	};
+
+	const resolved = await resolveEntityLinksForItems(
+		{
+			connectorKey: "github",
+			orgId: params.organizationId,
+			items: [item],
+			rules: { [kind]: [GITHUB_PERSON_RULE] },
+		},
+		params.sql,
+	);
+
+	const entityIds = resolved.get(0) ?? [];
+	// resolveEntityLinksForItems stamped the canonical namespace slots onto
+	// item.metadata; forward only those onto the landed row.
+	const metadata: Record<string, string> = {};
+	for (const ns of [IDENTITY.GITHUB_LOGIN, IDENTITY.GITHUB_USER_ID]) {
+		const value = item.metadata[ns];
+		if (typeof value === "string" && value.length > 0) metadata[ns] = value;
+	}
+
+	if (entityIds.length === 0 && Object.keys(metadata).length === 0) return null;
+	return { entityIds, metadata };
+}

--- a/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
+++ b/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
@@ -7,7 +7,11 @@ import {
   createTestOrganization,
   createTestUser,
 } from '../../__tests__/setup/test-fixtures';
-import { applyEntityLinks, clearEntityLinkRulesCache } from '../entity-link-upsert';
+import {
+  applyEntityLinks,
+  clearEntityLinkRulesCache,
+  resolveEntityLinksForItems,
+} from '../entity-link-upsert';
 import { ensureMemberEntityType } from '../member-entity-type';
 
 const FEED_KEY = 'messages';
@@ -302,5 +306,105 @@ describe('applyEntityLinks', () => {
     `;
     // email was matchOnly, so only crm_contact_id is newly persisted alongside the seed email.
     expect(rows.map((r) => r.namespace)).toEqual(['crm_contact_id', 'email']);
+  });
+
+  it('two concurrent auto-creates for the same new actor → one entity, no orphan', async () => {
+    const { org } = await setupOrg('concurrent autocreate org');
+    const sql = getTestDb();
+
+    const rule: EntityLinkRule = {
+      entityType: '$member',
+      autoCreate: true,
+      titlePath: 'metadata.push_name',
+      identities: [{ namespace: 'phone', eventPath: 'metadata.phone' }],
+      traits: {
+        push_name: { eventPath: 'metadata.push_name', behavior: 'prefer_non_empty' },
+      },
+    };
+    const item = {
+      origin_type: 'msg',
+      metadata: { phone: '14155559999', push_name: 'Casey' },
+    };
+
+    // Both calls race to auto-create the SAME brand-new actor. One wins the
+    // identity insert; the loser's freshly-inserted entity row gets zero
+    // identities (ON CONFLICT) and must be discarded (no orphan), not used.
+    await Promise.all([
+      resolveEntityLinksForItems({
+        connectorKey: 'whatsapp',
+        orgId: org.id,
+        items: [{ ...item, metadata: { ...item.metadata } }],
+        rules: { msg: [rule] },
+      }),
+      resolveEntityLinksForItems({
+        connectorKey: 'whatsapp',
+        orgId: org.id,
+        items: [{ ...item, metadata: { ...item.metadata } }],
+        rules: { msg: [rule] },
+      }),
+    ]);
+
+    // Exactly one entity OWNS the identity. (A lost-race orphan would be an extra
+    // $member row with no entity_identities — assert there is none.)
+    const withIdentity = await sql<{ id: number }[]>`
+      SELECT e.id FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      JOIN entity_identities ei ON ei.entity_id = e.id AND ei.deleted_at IS NULL
+      WHERE e.organization_id = ${org.id} AND et.slug = '$member' AND e.deleted_at IS NULL
+        AND ei.namespace = 'phone' AND ei.identifier = '14155559999'
+    `;
+    expect(withIdentity).toHaveLength(1);
+
+    const orphans = await sql<{ count: string }[]>`
+      SELECT COUNT(*)::text AS count FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.organization_id = ${org.id} AND et.slug = '$member' AND e.deleted_at IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM entity_identities ei WHERE ei.entity_id = e.id AND ei.deleted_at IS NULL
+        )
+    `;
+    expect(orphans[0].count).toBe('0');
+
+    // Traits landed on the real (identity-owning) entity.
+    const winner = await sql<{ metadata: Record<string, unknown> }[]>`
+      SELECT metadata FROM entities WHERE id = ${withIdentity[0].id}
+    `;
+    expect(winner[0].metadata.push_name).toBe('Casey');
+  });
+
+  it('resolveEntityLinksForItems writes through the passed transaction handle', async () => {
+    const { org } = await setupOrg('tx-threaded org');
+    const sql = getTestDb();
+
+    const rule: EntityLinkRule = {
+      entityType: '$member',
+      autoCreate: true,
+      identities: [{ namespace: 'phone', eventPath: 'metadata.phone' }],
+    };
+
+    // Run resolution inside a tx we then ROLL BACK — if the resolver wrote
+    // through the passed handle, the entity must NOT survive the rollback.
+    await sql
+      .begin(async (tx) => {
+        await resolveEntityLinksForItems(
+          {
+            connectorKey: 'whatsapp',
+            orgId: org.id,
+            items: [{ origin_type: 'msg', metadata: { phone: '14155551111' } }],
+            rules: { msg: [rule] },
+          },
+          tx as unknown as ReturnType<typeof getTestDb>,
+        );
+        throw new Error('rollback');
+      })
+      .catch((e) => {
+        if (e.message !== 'rollback') throw e;
+      });
+
+    const rows = await sql<{ count: string }[]>`
+      SELECT COUNT(*)::text AS count FROM entity_identities
+      WHERE organization_id = ${org.id} AND namespace = 'phone' AND identifier = '14155551111'
+    `;
+    expect(rows[0].count).toBe('0');
   });
 });

--- a/packages/server/src/utils/__tests__/identity-normalize.test.ts
+++ b/packages/server/src/utils/__tests__/identity-normalize.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeNumericId,
   normalizePhone,
   normalizeSlackUserId,
+  normalizeSlackUserIdCombined,
   normalizeWaJid,
 } from '@lobu/connector-sdk';
 import { describe, expect, it } from 'vitest';
@@ -88,6 +89,22 @@ describe('normalizeSlackUserId', () => {
   });
 });
 
+describe('normalizeSlackUserIdCombined', () => {
+  it('canonicalizes an already-combined TEAM:USER value, uppercase', () => {
+    expect(normalizeSlackUserIdCombined('T0abc:u123')).toBe('T0ABC:U123');
+    expect(normalizeSlackUserIdCombined(' T0ABC:U123 ')).toBe('T0ABC:U123');
+  });
+
+  it('rejects values without a team prefix or with malformed parts', () => {
+    expect(normalizeSlackUserIdCombined('U123')).toBeNull();
+    expect(normalizeSlackUserIdCombined(':U123')).toBeNull();
+    expect(normalizeSlackUserIdCombined('T0ABC:')).toBeNull();
+    expect(normalizeSlackUserIdCombined('T0 space:U123')).toBeNull();
+    expect(normalizeSlackUserIdCombined('')).toBeNull();
+    expect(normalizeSlackUserIdCombined(null)).toBeNull();
+  });
+});
+
 describe('normalizeGithubLogin', () => {
   it('lowercases valid logins', () => {
     expect(normalizeGithubLogin('Burak-Emre')).toBe('burak-emre');
@@ -150,6 +167,10 @@ describe('normalizeIdentifier dispatcher', () => {
     expect(normalizeIdentifier('github_login', 'Octocat')).toBe('octocat');
     expect(normalizeIdentifier('github_user_id', '  82745 ')).toBe('82745');
     expect(normalizeIdentifier('github_repo_full_name', 'Lobu-AI/Lobu')).toBe('lobu-ai/lobu');
+    // slack_user_id was barrel-exported but had no dispatch case (dead, like
+    // github_login once was) — it now canonicalizes the combined TEAM:USER form.
+    expect(normalizeIdentifier('slack_user_id', 't0abc:u123')).toBe('T0ABC:U123');
+    expect(normalizeIdentifier('slack_user_id', 'no-team-prefix')).toBeNull();
   });
 
   it('falls back to trim-only for unknown namespaces so custom identities still get hygiene', () => {

--- a/packages/server/src/utils/content-search/entity-link.ts
+++ b/packages/server/src/utils/content-search/entity-link.ts
@@ -26,6 +26,10 @@ export const STANDARD_IDENTITY_NAMESPACES = [
   'wa_jid',
   'slack_user_id',
   'github_login',
+  // Immutable id — read-time github attribution rides this so a reused login
+  // (freed by a rename, reclaimed by another account) can't JOIN to the old
+  // person. Backed by idx_events_metadata_github_user_id.
+  'github_user_id',
   'auth_user_id',
   'google_contact_id',
 ] as const;

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -19,7 +19,7 @@
 import { randomBytes } from 'node:crypto';
 import type { EntityLinkOverrides, EntityLinkRule } from '@lobu/connector-sdk';
 import { normalizeIdentifier } from '@lobu/connector-sdk';
-import { getDb, pgTextArray } from '../db/client';
+import { type DbClient, getDb, pgTextArray } from '../db/client';
 import { resolveEntityLinkRules } from './entity-link-validation';
 import logger from './logger';
 import { getValueAtPath } from './object-path';
@@ -105,7 +105,12 @@ export function clearEntityLinkRulesCache(): void {
 }
 
 type ExtractedLink = {
-  identities: Array<{ namespace: string; identifier: string; matchOnly: boolean }>;
+  identities: Array<{
+    namespace: string;
+    identifier: string;
+    matchOnly: boolean;
+    primary: boolean;
+  }>;
   traits: Map<string, unknown>;
   title: string;
 };
@@ -121,6 +126,7 @@ function extractLink(item: BatchItem, rule: EntityLinkRule): ExtractedLink | nul
       namespace: spec.namespace,
       identifier: normalized,
       matchOnly: spec.matchOnly === true,
+      primary: spec.primary === true,
     });
   }
   if (identities.length === 0) return null;
@@ -139,11 +145,14 @@ function extractLink(item: BatchItem, rule: EntityLinkRule): ExtractedLink | nul
   return { identities, traits, title };
 }
 
-async function lookupMatches(params: {
-  orgId: string;
-  entityType: string;
-  identities: ExtractedLink['identities'][];
-}): Promise<Map<string, number>> {
+async function lookupMatches(
+  sql: DbClient,
+  params: {
+    orgId: string;
+    entityType: string;
+    identities: ExtractedLink['identities'][];
+  }
+): Promise<Map<string, number>> {
   const keys = new Set<string>();
   for (const arr of params.identities) {
     for (const id of arr) keys.add(`${id.namespace}\u0000${id.identifier}`);
@@ -158,7 +167,6 @@ async function lookupMatches(params: {
     identifiers.push(ident);
   }
 
-  const sql = getDb();
   const rows = await sql<{ entity_id: number | string; namespace: string; identifier: string }>`
     SELECT ei.entity_id, ei.namespace, ei.identifier
     FROM entity_identities ei
@@ -180,16 +188,18 @@ async function lookupMatches(params: {
   return out;
 }
 
-async function createEntityWithIdentities(params: {
-  orgId: string;
-  connectorKey: string;
-  entityType: string;
-  title: string;
-  identities: ExtractedLink['identities'];
-  traits: Map<string, unknown>;
-  creatorUserId: string;
-}): Promise<number | null> {
-  const sql = getDb();
+async function createEntityWithIdentities(
+  sql: DbClient,
+  params: {
+    orgId: string;
+    connectorKey: string;
+    entityType: string;
+    title: string;
+    identities: ExtractedLink['identities'];
+    traits: Map<string, unknown>;
+    creatorUserId: string;
+  }
+): Promise<{ entityId: number; attached: Array<{ namespace: string; identifier: string }> } | null> {
   const persisted = params.identities.filter((i) => !i.matchOnly);
   if (persisted.length === 0) return null;
 
@@ -257,27 +267,34 @@ async function createEntityWithIdentities(params: {
   }
   if (entityId === null) return null;
 
-  await insertIdentities({
+  const attached = await insertIdentities(sql, {
     orgId: params.orgId,
     entityId,
     connectorKey: params.connectorKey,
     identities: persisted,
   });
-  return entityId;
+  return { entityId, attached };
 }
 
-async function insertIdentities(params: {
-  orgId: string;
-  entityId: number;
-  connectorKey: string;
-  identities: ExtractedLink['identities'];
-}): Promise<void> {
-  if (params.identities.length === 0) return;
-  const sql = getDb();
+/**
+ * Insert identities for `entityId`, RETURNING the `(namespace, identifier)` rows
+ * that actually attached. A row skipped by ON CONFLICT (identifier already owned
+ * by another entity) is NOT returned, so the caller won't mis-claim it.
+ */
+async function insertIdentities(
+  sql: DbClient,
+  params: {
+    orgId: string;
+    entityId: number;
+    connectorKey: string;
+    identities: ExtractedLink['identities'];
+  }
+): Promise<Array<{ namespace: string; identifier: string }>> {
+  if (params.identities.length === 0) return [];
   const namespaces = params.identities.map((i) => i.namespace);
   const identifiers = params.identities.map((i) => i.identifier);
   try {
-    await sql`
+    const attached = await sql<{ namespace: string; identifier: string }>`
       INSERT INTO entity_identities (
         organization_id, entity_id, namespace, identifier, source_connector
       )
@@ -285,21 +302,26 @@ async function insertIdentities(params: {
       FROM unnest(${pgTextArray(namespaces)}::text[], ${pgTextArray(identifiers)}::text[]) AS v(ns, ident)
       ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
       DO NOTHING
+      RETURNING namespace, identifier
     `;
+    return attached.map((r) => ({ namespace: r.namespace, identifier: r.identifier }));
   } catch (err) {
     logger.warn({ err, entityId: params.entityId }, 'entity_identities insert failed');
+    return [];
   }
 }
 
-async function applyTraits(params: {
-  orgId: string;
-  entityId: number;
-  rule: EntityLinkRule;
-  traits: Map<string, unknown>;
-  isCreate: boolean;
-}): Promise<void> {
+async function applyTraits(
+  sql: DbClient,
+  params: {
+    orgId: string;
+    entityId: number;
+    rule: EntityLinkRule;
+    traits: Map<string, unknown>;
+    isCreate: boolean;
+  }
+): Promise<void> {
   if (!params.rule.traits || params.traits.size === 0) return;
-  const sql = getDb();
 
   // init_only traits were written to metadata at create time; nothing to do now.
   const overwrite: Record<string, unknown> = {};
@@ -353,7 +375,8 @@ async function applyTraits(params: {
 /**
  * Per-batch ingestion hook. Looks up or creates target entities for each
  * item using the normalized entity_identities index, then merges declared
- * traits onto the resolved entity.
+ * traits onto the resolved entity. Rules are loaded from the connector
+ * definition (poll/sync path).
  */
 export async function applyEntityLinks(params: {
   connectorKey: string;
@@ -370,77 +393,194 @@ export async function applyEntityLinks(params: {
   });
   if (Object.keys(rulesByKind).length === 0) return;
 
+  await resolveLinksByKind({
+    connectorKey: params.connectorKey,
+    orgId: params.orgId,
+    items: params.items,
+    rulesByKind,
+  });
+}
+
+/**
+ * Resolve entity links for items using caller-supplied rules instead of the
+ * connector-definition store. The live webhook path (handleWebhookIngest /
+ * app-webhooks router) lands under `connector_key='webhook:%'` with no feed, so
+ * it can't load rules from `connector_definitions` — it passes the rule set
+ * directly here. Same machinery as the poll path (normalize → match-or-create →
+ * stamp metadata → merge traits), but it ALSO returns the resolved entity ids
+ * per item (keyed by `items` array index) so the caller can write
+ * `events.entity_ids` (a webhook row is read by id, not via a feed-time JOIN).
+ * `rules` is keyed by event kind (origin_type). Tenant-scoped on `orgId`;
+ * entity_identities are UNIQUE per (org, namespace, identifier), so resolution
+ * never crosses organizations.
+ */
+export async function resolveEntityLinksForItems(
+  params: {
+    connectorKey: string;
+    orgId: string;
+    items: BatchItem[];
+    rules: RuleMap;
+  },
+  // Optional transaction handle — the webhook winner passes its tx so the actor
+  // graph writes commit atomically with the event insert. Omitted → getDb().
+  sql?: DbClient
+): Promise<Map<number, number[]>> {
+  if (params.items.length === 0) return new Map();
+  return resolveLinksByKind(
+    {
+      connectorKey: params.connectorKey,
+      orgId: params.orgId,
+      items: params.items,
+      rulesByKind: params.rules,
+    },
+    sql ?? getDb()
+  );
+}
+
+/**
+ * Core resolver shared by the poll path ({@link applyEntityLinks}) and the
+ * webhook path ({@link resolveEntityLinksForItems}). Given rules grouped by
+ * event kind, resolve or auto-create the target entity for each item, stamp the
+ * canonical identifier metadata slots (for read-time JOINs), and merge declared
+ * traits. Returns a per-item map (by array index) of resolved entity ids.
+ */
+async function resolveLinksByKind(
+  params: {
+    connectorKey: string;
+    orgId: string;
+    items: BatchItem[];
+    rulesByKind: RuleMap;
+  },
+  // The DB handle for ALL match/insert/update writes. The webhook winner threads
+  // its transaction here so the event insert + actor graph writes + entity_ids
+  // update are one atomic tx; the poll path passes nothing → getDb() singleton.
+  sql: DbClient = getDb()
+): Promise<Map<number, number[]>> {
+  const resolvedByItem = new Map<number, number[]>();
+  if (Object.keys(params.rulesByKind).length === 0 || params.items.length === 0) {
+    return resolvedByItem;
+  }
+
   // entities.created_by is NOT NULL; resolve an org owner/admin once per batch
   // so auto-created entities attribute to a real member rather than a seed user.
   const creatorUserId = await resolveOrgCreator(params.orgId);
 
-  // rule -> per-item extracted link
-  const byRule = new Map<EntityLinkRule, ExtractedLink[]>();
-  for (const item of params.items) {
+  // rule -> per-item extracted link, carrying the source item + index (the
+  // caller recovers the resolved entity per item; metadata is stamped onto the
+  // item post-resolution).
+  const byRule = new Map<
+    EntityLinkRule,
+    Array<{ index: number; item: BatchItem; link: ExtractedLink }>
+  >();
+  params.items.forEach((item, index) => {
     const kind = item.origin_type;
-    if (!kind) continue;
-    const rules = rulesByKind[kind];
-    if (!rules) continue;
+    if (!kind) return;
+    const rules = params.rulesByKind[kind];
+    if (!rules) return;
     for (const rule of rules) {
       const link = extractLink(item, rule);
       if (!link) continue;
-      // Stamp the normalized identifier into a canonical metadata slot keyed by
-      // namespace. This is what read-time JOINs (entity_identities.namespace +
-      // identifier) match against, shielding queries from connector-specific
-      // metadata key naming (metadata.from_email, metadata.sender_phone, …).
-      const md = (item.metadata ??= {});
-      for (const id of link.identities) {
-        md[id.namespace] = id.identifier;
-      }
+      // Metadata stamping is deferred to post-resolution (below) — only
+      // attached identifiers are stamped, so a stale one (e.g. a vacated
+      // github_login) can't make read-time JOINs attribute to the wrong person.
       let bucket = byRule.get(rule);
       if (!bucket) {
         bucket = [];
         byRule.set(rule, bucket);
       }
-      bucket.push(link);
+      bucket.push({ index, item, link });
     }
-  }
-  if (byRule.size === 0) return;
+  });
+  if (byRule.size === 0) return resolvedByItem;
 
-  for (const [rule, links] of byRule) {
-    const matches = await lookupMatches({
+  const recordResolved = (index: number, entityId: number): void => {
+    const existing = resolvedByItem.get(index);
+    if (existing) {
+      if (!existing.includes(entityId)) existing.push(entityId);
+    } else {
+      resolvedByItem.set(index, [entityId]);
+    }
+  };
+
+  for (const [rule, entries] of byRule) {
+    const matches = await lookupMatches(sql, {
       orgId: params.orgId,
       entityType: rule.entityType,
-      identities: links.map((l) => l.identities),
+      identities: entries.map((e) => e.link.identities),
     });
 
-    for (const link of links) {
-      const resolved = new Set<number>();
-      for (const id of link.identities) {
-        const hit = matches.get(`${id.namespace}\u0000${id.identifier}`);
-        if (hit !== undefined) resolved.add(hit);
+    for (const { index, item, link } of entries) {
+      // A present `primary` identity (immutable, e.g. github_user_id) is
+      // authoritative: it governs even when it matches nothing (a new account),
+      // so a stale non-primary like a reused github_login can't merge it into the
+      // old person. Without a primary, identities match equal-weight (the
+      // cross-channel behavior whatsapp/email rely on).
+      let entityId: number | null = null;
+      let isCreate = false;
+      let ambiguous = false;
+      const hitFor = (id: { namespace: string; identifier: string }) =>
+        matches.get(`${id.namespace}\u0000${id.identifier}`);
+      const primaries = link.identities.filter((i) => i.primary);
+      if (primaries.length > 0) {
+        const primaryHits = new Set<number>();
+        for (const id of primaries) {
+          const h = hitFor(id);
+          if (h !== undefined) primaryHits.add(h);
+        }
+        if (primaryHits.size > 1) {
+          ambiguous = true;
+        } else if (primaryHits.size === 1) {
+          entityId = [...primaryHits][0];
+        }
+        // size 0 = present-but-unmatched → leave null so a new entity is created.
+      } else {
+        // No primary present → union all identity hits equal-weight.
+        const resolved = new Set<number>();
+        for (const id of link.identities) {
+          const h = hitFor(id);
+          if (h !== undefined) resolved.add(h);
+        }
+        if (resolved.size > 1) {
+          ambiguous = true;
+        } else if (resolved.size === 1) {
+          entityId = [...resolved][0];
+        }
       }
 
-      if (resolved.size > 1) {
+      if (ambiguous) {
         logger.warn(
           {
             orgId: params.orgId,
             connectorKey: params.connectorKey,
             entityType: rule.entityType,
-            candidates: Array.from(resolved),
             identifiers: link.identities.map((i) => `${i.namespace}:${i.identifier}`),
           },
-          'entityLink merge candidate — multiple entities matched'
+          'entityLink merge candidate — multiple entities matched at the same identity tier'
         );
         continue;
       }
 
-      let entityId: number | null = null;
-      let isCreate = false;
-
-      if (resolved.size === 1) {
-        entityId = Array.from(resolved)[0];
-        await insertIdentities({
+      // Identities that ACTUALLY attached to the resolved/created entity. We
+      // only ever claim THESE in the in-memory matches map below — an identifier
+      // that ON CONFLICT-skipped because another entity already owns it stays
+      // with that entity, so the map must not mis-claim it for this one.
+      let attached: Array<{ namespace: string; identifier: string }> = [];
+      if (entityId !== null) {
+        // Matched an existing entity: accrete the non-matchOnly identities; the
+        // identifier(s) we matched on already belong to this entity.
+        attached = await insertIdentities(sql, {
           orgId: params.orgId,
           entityId,
           connectorKey: params.connectorKey,
           identities: link.identities.filter((i) => !i.matchOnly),
         });
+        // The matched identifiers themselves are this entity's even if a
+        // re-insert was a no-op (they were how we found it), so claim them too.
+        for (const id of link.identities) {
+          if (matches.get(`${id.namespace}\u0000${id.identifier}`) === entityId) {
+            attached.push({ namespace: id.namespace, identifier: id.identifier });
+          }
+        }
       } else if (rule.autoCreate) {
         if (!creatorUserId) {
           logger.warn(
@@ -449,7 +589,7 @@ export async function applyEntityLinks(params: {
           );
           continue;
         }
-        entityId = await createEntityWithIdentities({
+        const created = await createEntityWithIdentities(sql, {
           orgId: params.orgId,
           connectorKey: params.connectorKey,
           entityType: rule.entityType,
@@ -458,12 +598,44 @@ export async function applyEntityLinks(params: {
           traits: link.traits,
           creatorUserId,
         });
-        isCreate = entityId !== null;
+        if (created !== null && created.attached.length > 0) {
+          entityId = created.entityId;
+          attached = created.attached;
+          isCreate = true;
+        } else if (created !== null) {
+          // Concurrent auto-create lost the identity race: every identifier went
+          // to the winner via ON CONFLICT, so the row we just inserted is an
+          // identity-less orphan. Hard-delete it (no events reference a row born
+          // this turn) and re-resolve to the winning entity.
+          await sql`
+            DELETE FROM entities
+            WHERE id = ${created.entityId} AND organization_id = ${params.orgId}
+          `;
+          const winner = await lookupMatches(sql, {
+            orgId: params.orgId,
+            entityType: rule.entityType,
+            identities: [link.identities],
+          });
+          const winnerIds = new Set<number>();
+          for (const id of link.identities) {
+            const h = winner.get(`${id.namespace}\u0000${id.identifier}`);
+            if (h !== undefined) winnerIds.add(h);
+          }
+          if (winnerIds.size === 1) {
+            entityId = [...winnerIds][0];
+            for (const id of link.identities) {
+              if (winner.get(`${id.namespace}\u0000${id.identifier}`) === entityId) {
+                attached.push({ namespace: id.namespace, identifier: id.identifier });
+              }
+            }
+          }
+          // size !== 1 (gone/ambiguous) → leave entityId null; skip.
+        }
       }
 
       if (entityId === null) continue;
 
-      await applyTraits({
+      await applyTraits(sql, {
         orgId: params.orgId,
         entityId,
         rule,
@@ -471,11 +643,23 @@ export async function applyEntityLinks(params: {
         isCreate,
       });
 
-      // Cache the new mapping so later items in the same rule-batch that share
-      // identifiers resolve to the entity we just created/matched.
-      for (const id of link.identities) {
+      recordResolved(index, entityId);
+
+      // Cache the mapping for later items in the same batch — only for attached
+      // identifiers, so an identifier that stayed on another entity (ON CONFLICT
+      // no-op) keeps its existing owner and isn't mis-claimed.
+      for (const id of attached) {
         matches.set(`${id.namespace}\u0000${id.identifier}`, entityId);
+      }
+
+      // Stamp metadata slots for attached identifiers only — read-time JOINs key
+      // on events.metadata->>namespace, so a stale slot would mis-attribute.
+      const md = (item.metadata ??= {});
+      for (const id of attached) {
+        md[id.namespace] = id.identifier;
       }
     }
   }
+
+  return resolvedByItem;
 }


### PR DESCRIPTION
## What

GitHub events landed with raw `author_name` strings, empty `entity_ids`, and no person resolution; org membership was fetched then discarded. This wires **member identity attribution** onto the existing entity-identity infra (the same machinery proven for gmail/whatsapp). This is **PR1 of 2** — the team graph (org-membership → `member_of` relationships) is the follow-up.

## What attributes now

**Poll/sync path** — a `person` `entityLinks` rule on every authored github eventKind (issue, pull_request, issue_comment, pr_comment, discussion, discussion_comment, stargazer), keyed PRIMARY on the immutable `github_user_id` + SECONDARY on `github_login`. The existing `applyEntityLinks` (run-lifecycle poll path) resolves/creates the person for free. The connector now stamps `author_login`/`author_id` into event metadata (REST `user.id`, GraphQL `author.databaseId`).

**Live webhook path** — was completely unattributed (`entity_ids:[]`, no resolution). Now:
- `resolveEntityLinksForItems` — same resolution machinery as the poll path, but takes caller-supplied rules (webhook deliveries land under `connector_key=webhook:%` with no feed, so they can't load rules from `connector_definitions`) and returns the resolved entity ids per item.
- `github-webhook-actor` — extracts the authoring actor (`comment.user` → subject `.user` → `sender`) and resolves a tenant-scoped person; the app-webhook router calls it **after** the install (and therefore org) is resolved, then stamps `events.entity_ids` + the `github_login` namespace slot onto the landed row.

**Slack normalizer dispatch** — `normalizeSlackUserIdCombined` + a `slack_user_id` case in `normalizeIdentifier` (it was barrel-exported but had no dispatch case — dead, exactly like `github_login` once was).

## Merge policy

GitHub contributors are `person` entities, kept **separate** from the `$member` (authenticated org user) type. A `github_login` is not proof of org membership, so auto-merging a contributor into a member at ingest is unsafe; principled cross-namespace unification is the identity engine's job (assurance-gated). Documented in the rule.

## Tenant scoping

End to end. `entity_identities` are UNIQUE per `(organization_id, namespace, identifier)`; every read/write filters on `organization_id`. The webhook resolver runs only after the org is resolved from the `app_installations` row. A test proves the same github user in two orgs resolves to **two distinct persons**.

## Tests (real PG)

`packages/server/src/__tests__/integration/connectors/github-identity-attribution.test.ts` (5) + `identity-normalize.test.ts` additions:
- poll-path issue → person + `entity_identities(github_user_id)` + metadata stamp
- renamed login resolves to one person via the immutable id
- webhook actor resolution returns entity ids + `github_login` slot, attributes the comment author
- unmapped event (push) resolves nothing
- cross-org isolation (two distinct persons)
- slack dispatch unit tests

All green. `cd packages/server && bunx tsc --noEmit` adds 0 errors. Existing `entity-links-contract`, `entity-link-upsert`, `entity-link-validation`, and `app-webhooks` suites still pass (the `applyEntityLinks` refactor is backward-compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ug5cEnCRt1VHn8w3gNXAu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784759342&installation_id=136316292&pr_number=1492&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1492&signature=a170cb548e7930a963782ac5cdd5025ebc25b6557c71f174bb9b9c9e8331fdf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authoritative “primary” identity handling to improve entity matching outcomes.
  * GitHub webhooks and sync now auto-attribute authored content to person entities using immutable user ID (primary) and login (secondary), including richer metadata.
  * Extended webhook ingestion with optional actor→person resolution that attaches entity IDs and metadata to landed events.
* **Bug Fixes**
  * Improved Slack identity canonicalization to properly handle already-prefixed `TEAM:USER` values and reject malformed forms.
* **Tests**
  * Added end-to-end integration coverage for GitHub identity attribution across poll/sync and webhook flows, including concurrency/redelivery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->