### PR TITLE
feat(github): build org-membership team graph on App install

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/github-team-graph.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-team-graph.test.ts
@@ -1,0 +1,220 @@
+/**
+ * GitHub org-membership team graph contract (#17, PR2).
+ *
+ * On install/refresh the org's members build a team graph: the org becomes a
+ * `company` entity, each member a `person`, joined by `member_of` edges. Asserts
+ * the entity model (reuse `company` + `member_of`, no `team` type), idempotency,
+ * person-collapse with an already-authored contributor, and that User-account
+ * installs (no members) build nothing.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyEntityLinks,
+  clearEntityLinkRulesCache,
+} from '../../../utils/entity-link-upsert';
+import { buildGithubTeamGraph } from '../../../gateway/routes/public/github-team-graph';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+async function ensureType(orgId: string, slug: string, name: string): Promise<void> {
+  const sql = getTestDb();
+  const existing = await sql`
+    SELECT id FROM entity_types
+    WHERE organization_id = ${orgId} AND slug = ${slug} AND deleted_at IS NULL
+    LIMIT 1
+  `;
+  if (existing.length === 0) {
+    await sql`
+      INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+      VALUES (${orgId}, ${slug}, ${name}, current_timestamp, current_timestamp)
+    `;
+  }
+}
+
+async function seedOrg(name: string) {
+  const org = await createTestOrganization({ name });
+  const user = await createTestUser();
+  await addUserToOrganization(user.id, org.id, 'owner');
+  await ensureType(org.id, 'person', 'Person');
+  await ensureType(org.id, 'company', 'Company');
+  return org;
+}
+
+async function entitiesOfType(orgId: string, slug: string) {
+  const sql = getTestDb();
+  return sql<{ id: number; name: string }[]>`
+    SELECT e.id, e.name
+    FROM entities e
+    JOIN entity_types et ON et.id = e.entity_type_id
+    WHERE e.organization_id = ${orgId} AND et.slug = ${slug} AND e.deleted_at IS NULL
+    ORDER BY e.id
+  `;
+}
+
+async function memberOfEdges(orgId: string) {
+  const sql = getTestDb();
+  return sql<{ from_entity_id: number; to_entity_id: number }[]>`
+    SELECT r.from_entity_id, r.to_entity_id
+    FROM entity_relationships r
+    JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+    WHERE r.organization_id = ${orgId}
+      AND rt.slug = 'member_of'
+      AND r.deleted_at IS NULL
+    ORDER BY r.from_entity_id
+  `;
+}
+
+const orgAccount = { login: 'acme-co', id: 100, type: 'Organization' };
+
+describe('github team graph', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    clearEntityLinkRulesCache();
+  });
+
+  it('builds the org company, member persons, and member_of edges (idempotent on re-run)', async () => {
+    const org = await seedOrg('Team Graph Org');
+
+    const result = await buildGithubTeamGraph({
+      organizationId: org.id,
+      account: orgAccount,
+      members: [
+        { login: 'Alice', id: 1 },
+        { login: 'Bob', id: 2 },
+      ],
+    });
+
+    expect(result.companyEntityId).not.toBeNull();
+    expect(result.memberEntityIds).toHaveLength(2);
+    expect(result.createdEdges).toBe(2);
+
+    // One company (the org), reusing the `company` type — no `team` type created.
+    const companies = await entitiesOfType(org.id, 'company');
+    expect(companies).toHaveLength(1);
+    expect(companies[0].name).toBe('acme-co');
+    const noTeamType = await getTestDb()`
+      SELECT id FROM entity_types WHERE organization_id = ${org.id} AND slug = 'team'
+    `;
+    expect(noTeamType).toHaveLength(0);
+
+    const people = await entitiesOfType(org.id, 'person');
+    expect(people).toHaveLength(2);
+
+    const edges = await memberOfEdges(org.id);
+    expect(edges).toHaveLength(2);
+    // Every edge points person -> company.
+    for (const e of edges) {
+      expect(e.to_entity_id).toBe(companies[0].id);
+      expect(people.map((p) => p.id)).toContain(e.from_entity_id);
+    }
+
+    // Re-run with the same members + one new one: idempotent edges, +1 created.
+    const rerun = await buildGithubTeamGraph({
+      organizationId: org.id,
+      account: orgAccount,
+      members: [
+        { login: 'Alice', id: 1 },
+        { login: 'Bob', id: 2 },
+        { login: 'Carol', id: 3 },
+      ],
+    });
+    expect(rerun.createdEdges).toBe(1);
+    expect(await entitiesOfType(org.id, 'company')).toHaveLength(1);
+    expect(await entitiesOfType(org.id, 'person')).toHaveLength(3);
+    expect(await memberOfEdges(org.id)).toHaveLength(3);
+  });
+
+  it('collapses a member onto an already-authored contributor (one person, not two)', async () => {
+    const org = await seedOrg('Collapse Org');
+    // Octocat authored an issue first (poll path) — creates a person keyed on id.
+    await createTestConnectorDefinition({
+      key: 'github',
+      name: 'GitHub',
+      organization_id: org.id,
+      feeds_schema: {
+        issues: {
+          eventKinds: {
+            issue: {
+              entityLinks: [
+                {
+                  entityType: 'person',
+                  autoCreate: true,
+                  titlePath: 'metadata.author_login',
+                  identities: [
+                    { namespace: 'github_user_id', eventPath: 'metadata.author_id' },
+                    { namespace: 'github_login', eventPath: 'metadata.author_login' },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    clearEntityLinkRulesCache();
+    await applyEntityLinks({
+      connectorKey: 'github',
+      feedKey: 'issues',
+      orgId: org.id,
+      items: [{ origin_type: 'issue', metadata: { author_login: 'Octocat', author_id: '42' } }],
+    });
+    expect(await entitiesOfType(org.id, 'person')).toHaveLength(1);
+
+    // Now Octocat shows up in the org membership with the SAME id → must reuse
+    // the existing person, not create a second one.
+    const result = await buildGithubTeamGraph({
+      organizationId: org.id,
+      account: orgAccount,
+      members: [{ login: 'Octocat', id: 42 }],
+    });
+    expect(result.memberEntityIds).toHaveLength(1);
+    expect(await entitiesOfType(org.id, 'person')).toHaveLength(1);
+    const edges = await memberOfEdges(org.id);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].from_entity_id).toBe(result.memberEntityIds[0]);
+  });
+
+  it('builds nothing for a User-account install (no org members)', async () => {
+    const org = await seedOrg('User Install Org');
+    const result = await buildGithubTeamGraph({
+      organizationId: org.id,
+      account: { login: 'solo-dev', id: 7, type: 'User' },
+      members: [{ login: 'solo-dev', id: 7 }],
+    });
+    expect(result.companyEntityId).toBeNull();
+    expect(result.memberEntityIds).toHaveLength(0);
+    expect(await entitiesOfType(org.id, 'company')).toHaveLength(0);
+    expect(await entitiesOfType(org.id, 'person')).toHaveLength(0);
+  });
+
+  it('tenant-scoped: the same member in two orgs builds two distinct persons + companies', async () => {
+    const orgA = await seedOrg('Tenant A');
+    const orgB = await seedOrg('Tenant B');
+
+    await buildGithubTeamGraph({
+      organizationId: orgA.id,
+      account: orgAccount,
+      members: [{ login: 'Shared', id: 999 }],
+    });
+    await buildGithubTeamGraph({
+      organizationId: orgB.id,
+      account: orgAccount,
+      members: [{ login: 'Shared', id: 999 }],
+    });
+
+    const peopleA = await entitiesOfType(orgA.id, 'person');
+    const peopleB = await entitiesOfType(orgB.id, 'person');
+    expect(peopleA).toHaveLength(1);
+    expect(peopleB).toHaveLength(1);
+    expect(peopleA[0].id).not.toBe(peopleB[0].id);
+
+    expect(await memberOfEdges(orgA.id)).toHaveLength(1);
+    expect(await memberOfEdges(orgB.id)).toHaveLength(1);
+  });
+});

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -59,6 +59,13 @@ import {
 } from "../../auth/oauth-templates.js";
 import { getInstallationTokenRegistry } from "../../installation/registry.js";
 import { createSyncRun } from "../../../runs/queue-service.js";
+import {
+	buildGithubTeamGraph,
+	defaultFetchOrgMembers,
+	type GithubOrgAccount,
+	type GithubOrgMember,
+	type TeamGraphResult,
+} from "./github-team-graph.js";
 
 const logger = createLogger("app-install-routes");
 
@@ -152,7 +159,7 @@ export function githubInstallCallbackUrl(
  * HTTP status WITHOUT mutating any DB state.
  */
 export type InstallOwnershipResult =
-	| { ok: true; installationId: number }
+	| { ok: true; installationId: number; account: InstallationAccount }
 	| { ok: false; status: 400 | 403 | 503; code: string; message: string };
 
 /** A user-administerable installation's owning account, as GitHub reports it. */
@@ -160,6 +167,8 @@ export interface InstallationAccount {
 	login: string;
 	/** GitHub account type: a personal account or an organization. */
 	type: "User" | "Organization" | string;
+	/** The account's numeric GitHub id (orgs and users share the id space). */
+	id?: number;
 }
 
 /** Default GitHub user-token OAuth exchange (the App's install-time OAuth). */
@@ -235,7 +244,11 @@ async function defaultFetchInstallationAccount(
 		for (const inst of installs) {
 			seen += 1;
 			if (inst.id === installationId && inst.account?.login) {
-				return { login: inst.account.login, type: inst.account.type };
+				return {
+					login: inst.account.login,
+					type: inst.account.type,
+					id: inst.account.id,
+				};
 			}
 		}
 		page += 1;
@@ -297,7 +310,11 @@ async function defaultFetchSoleAccessibleInstallation(
 			if (typeof inst.id === "number" && inst.account?.login) {
 				found.push({
 					installationId: inst.id,
-					account: { login: inst.account.login, type: inst.account.type },
+					account: {
+						login: inst.account.login,
+						type: inst.account.type,
+						id: inst.account.id,
+					},
 				});
 				// More than one → ambiguous; we can't safely pick which to recover.
 				if (found.length > 1) return "ambiguous";
@@ -773,6 +790,76 @@ export async function autoProvisionGithubIssueFeeds(params: {
 	return result;
 }
 
+/**
+ * After a successful org install, build the team graph: enumerate the org's
+ * members with the install's OWN scoped token (Members:read) and persist the
+ * org `company` + each member `person` + a `member_of` edge. Tenant-safe (the
+ * install token only sees its own org) and idempotent. Best-effort: the bind
+ * already committed; any failure is logged and surfaced, never thrown. User
+ * installs (no org) and mint/enumeration failures yield an empty result.
+ */
+export async function provisionGithubTeamGraph(params: {
+	organizationId: string;
+	installId: number;
+	account: GithubOrgAccount;
+	store: AppInstallationStore;
+	/** Override member enumeration (tests mock GitHub here). */
+	fetchOrgMembers?(
+		installationToken: string,
+		org: string,
+	): Promise<GithubOrgMember[]>;
+}): Promise<TeamGraphResult> {
+	const empty: TeamGraphResult = {
+		companyEntityId: null,
+		memberEntityIds: [],
+		createdEdges: 0,
+	};
+	// Only orgs have members.
+	if (params.account.type !== "Organization") return empty;
+
+	const install = await params.store.getById(params.installId);
+	if (!install || install.status !== "active") {
+		logger.warn(
+			{ install_id: params.installId, organization_id: params.organizationId },
+			"Team-graph skipped: install missing or not active",
+		);
+		return empty;
+	}
+	const installWithKeys = {
+		...install,
+		metadata: {
+			...install.metadata,
+			appIdKey: install.metadata?.appIdKey ?? "GITHUB_APP_ID",
+			privateKeyKey: install.metadata?.privateKeyKey ?? "GITHUB_APP_PRIVATE_KEY",
+		},
+	};
+
+	let token: string;
+	try {
+		const minted = await getInstallationTokenRegistry().mintFor(installWithKeys);
+		token = minted.token;
+	} catch (error) {
+		logger.warn(
+			{
+				install_id: params.installId,
+				organization_id: params.organizationId,
+				error: error instanceof Error ? error.message : String(error),
+			},
+			"Team-graph skipped: could not mint installation token",
+		);
+		return empty;
+	}
+
+	const fetchMembers = params.fetchOrgMembers ?? defaultFetchOrgMembers;
+	const members = await fetchMembers(token, params.account.login);
+
+	return buildGithubTeamGraph({
+		organizationId: params.organizationId,
+		account: params.account,
+		members,
+	});
+}
+
 /** Dependencies the install routes need (injected for testability). */
 export interface AppInstallRouterDeps {
 	installationStore: AppInstallationStore;
@@ -852,6 +939,16 @@ export interface AppInstallRouterDeps {
 	 * Injected so tests assert it fired; defaults to the real `createSyncRun`.
 	 */
 	enqueueSyncRun?(feedId: number): Promise<number | null>;
+	/**
+	 * Enumerate the org's members with the installation's OWN scoped token
+	 * (`GET /orgs/{org}/members`, Members:read). Injected so tests mock GitHub;
+	 * defaults to the real paginated call. The team-graph build mints the token
+	 * itself, so this receives it.
+	 */
+	fetchOrgMembers?(
+		installationToken: string,
+		org: string,
+	): Promise<GithubOrgMember[]>;
 }
 
 /**
@@ -1036,7 +1133,7 @@ async function verifyInstallationOwnership(params: {
 					"You must be an admin of this GitHub organization to connect its installation to Lobu.",
 			};
 		}
-		return { ok: true, installationId };
+		return { ok: true, installationId, account };
 	}
 
 	// Personal-account install: the OAuth'd user must BE the account owner.
@@ -1049,7 +1146,7 @@ async function verifyInstallationOwnership(params: {
 				"This GitHub installation belongs to a different account. Install the Lobu App from the account that owns it.",
 		};
 	}
-	return { ok: true, installationId };
+	return { ok: true, installationId, account };
 }
 
 /**
@@ -1350,6 +1447,9 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 		}
 		// The verified installation id (supplied for install, derived for recovery).
 		const installationId = ownership.installationId;
+		// The ownership-verified owning account (org/user login, type, numeric id)
+		// — the team-graph build (org members) and install-row metadata read it.
+		const ownerAccount = ownership.account;
 
 		// Guard: the org must actually have the github connector definition with an
 		// app_installation auth method, otherwise there's nothing to link the
@@ -1400,7 +1500,17 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				installationId: String(installationId),
 				store: deps.installationStore,
 				providerAppId: appId,
-				metadata: buildInstallMetadata(c),
+				// Record the ownership-verified account (GitHub omits it from the
+				// redirect query) so the install row carries the org login/type/id the
+				// team-graph build and UI rely on, falling back to any query value.
+				metadata: {
+					...buildInstallMetadata(c),
+					account_login: ownerAccount.login,
+					account_type: ownerAccount.type,
+					...(typeof ownerAccount.id === "number"
+						? { account_id: ownerAccount.id }
+						: {}),
+				},
 			});
 			logger.info(
 				{
@@ -1439,6 +1549,28 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 						error: getErrorMessage(error),
 					},
 					"GitHub App install bound, but auto-provision failed (feeds can be added manually)",
+				);
+			}
+
+			// Team graph: enumerate the org's members (Members:read) and persist the
+			// org company + member persons + member_of edges. Org installs only;
+			// best-effort and idempotent — never turns a successful bind into an error.
+			try {
+				await provisionGithubTeamGraph({
+					organizationId: orgId,
+					installId: result.installId,
+					account: ownerAccount,
+					store: deps.installationStore,
+					fetchOrgMembers: deps.fetchOrgMembers,
+				});
+			} catch (error) {
+				logger.warn(
+					{
+						organization_id: orgId,
+						install_id: result.installId,
+						error: error instanceof Error ? error.message : String(error),
+					},
+					"GitHub App install bound, but team-graph build failed (members can be backfilled later)",
 				);
 			}
 

--- a/packages/server/src/gateway/routes/public/github-team-graph.ts
+++ b/packages/server/src/gateway/routes/public/github-team-graph.ts
@@ -174,7 +174,12 @@ async function ensureOrgCompany(params: {
 					autoCreate: true,
 					titlePath: "metadata.org_login",
 					identities: [
-						{ namespace: IDENTITY.GITHUB_USER_ID, eventPath: "metadata.org_id" },
+						// PRIMARY: the org's immutable numeric id is authoritative (rename-safe).
+						{
+							namespace: IDENTITY.GITHUB_USER_ID,
+							eventPath: "metadata.org_id",
+							primary: true,
+						},
 						{ namespace: IDENTITY.GITHUB_LOGIN, eventPath: "metadata.org_login" },
 					],
 					traits: {
@@ -266,7 +271,12 @@ export async function buildGithubTeamGraph(params: {
 					autoCreate: true,
 					titlePath: "metadata.author_login",
 					identities: [
-						{ namespace: IDENTITY.GITHUB_USER_ID, eventPath: "metadata.author_id" },
+						// PRIMARY: immutable id governs resolution when present (rename-safe).
+						{
+							namespace: IDENTITY.GITHUB_USER_ID,
+							eventPath: "metadata.author_id",
+							primary: true,
+						},
 						{ namespace: IDENTITY.GITHUB_LOGIN, eventPath: "metadata.author_login" },
 					],
 					traits: {

--- a/packages/server/src/gateway/routes/public/github-team-graph.ts
+++ b/packages/server/src/gateway/routes/public/github-team-graph.ts
@@ -1,0 +1,332 @@
+/**
+ * GitHub org-membership team graph (#17, PR2).
+ *
+ * On GitHub App install/refresh the org's members are now ENUMERATED (the App is
+ * granted Organization → Members:read) and persisted as a team graph, instead of
+ * being fetched-then-discarded:
+ *
+ *   - the org itself becomes a `company` entity, identified by the org's
+ *     `github_login` + (immutable) `github_user_id` — orgs and users share
+ *     GitHub's numeric id space;
+ *   - each member becomes a `person` (resolved via the SAME entity-identity
+ *     machinery PR1 uses, so a member who has also authored issues collapses to
+ *     one entity);
+ *   - a `member_of` relationship (person → company) is written per member.
+ *
+ * Entity-model decision: REUSE `company` for the org + a `member_of`
+ * relationship-type, rather than introducing a `team` entity type. The org is a
+ * company; "team" is the relationship, which the entity_relationships +
+ * relationship-type machinery already expresses. No new entity type, no
+ * migration.
+ *
+ * Idempotent: the company entity dedupes on its github identity; `member_of`
+ * dedupes on the live-triple unique index
+ * (from_entity_id, to_entity_id, relationship_type_id) WHERE deleted_at IS NULL.
+ * A re-install/refresh adds new members and re-affirms existing edges without
+ * duplicating anything.
+ *
+ * Tenant-scoped: the org id is the verified install's owning org; every
+ * read/write filters on it, and entity_identities are UNIQUE per
+ * (org, namespace, identifier) — never cross-tenant.
+ *
+ * Best-effort: like auto-provision, the install bind has already committed when
+ * this runs, so any failure is logged and surfaced in the result, never thrown.
+ */
+
+import { IDENTITY } from "@lobu/connector-sdk";
+import { getDb } from "../../../db/client.js";
+import { createLogger } from "@lobu/core";
+import { resolveEntityLinksForItems } from "../../../utils/entity-link-upsert.js";
+
+const logger = createLogger("github-team-graph");
+
+const GITHUB_CONNECTOR_KEY = "github";
+const MEMBER_OF_TYPE_SLUG = "member_of";
+
+/** A GitHub org member as the org-members API reports it. */
+export interface GithubOrgMember {
+	login: string;
+	id?: number;
+}
+
+/** The org account an installation belongs to. */
+export interface GithubOrgAccount {
+	login: string;
+	id?: number;
+	/** "Organization" enables the team graph; "User" installs have no members. */
+	type: string;
+}
+
+export interface TeamGraphResult {
+	/** The company entity id for the org, or null when not built. */
+	companyEntityId: number | null;
+	/** Member person entity ids that now have a member_of edge to the company. */
+	memberEntityIds: number[];
+	/** How many member_of edges were newly created (vs already present). */
+	createdEdges: number;
+}
+
+const EMPTY_RESULT: TeamGraphResult = {
+	companyEntityId: null,
+	memberEntityIds: [],
+	createdEdges: 0,
+};
+
+/**
+ * Default org-members enumeration with the installation's OWN scoped token
+ * (`GET /orgs/{org}/members`, paginated). Tenant-safe: the token only ever sees
+ * the installed org. Returns `[]` on any HTTP/parse failure (best-effort).
+ */
+export async function defaultFetchOrgMembers(
+	installationToken: string,
+	org: string,
+): Promise<GithubOrgMember[]> {
+	const perPage = 100;
+	const MAX_PAGES = 100;
+	const members: GithubOrgMember[] = [];
+	let page = 1;
+	while (page <= MAX_PAGES) {
+		let res: Response;
+		try {
+			res = await fetch(
+				`https://api.github.com/orgs/${encodeURIComponent(org)}/members?per_page=${perPage}&page=${page}`,
+				{
+					headers: {
+						Authorization: `Bearer ${installationToken}`,
+						Accept: "application/vnd.github+json",
+						"User-Agent": "lobu",
+						"X-GitHub-Api-Version": "2022-11-28",
+					},
+				},
+			);
+		} catch (error) {
+			logger.warn(
+				{ error: error instanceof Error ? error.message : String(error), page },
+				"GitHub /orgs/{org}/members request failed during team-graph build",
+			);
+			return members;
+		}
+		if (!res.ok) {
+			logger.warn(
+				{ status: res.status, page },
+				"GitHub /orgs/{org}/members returned non-OK during team-graph build",
+			);
+			return members;
+		}
+		const body = (await res.json()) as Array<{ login?: string; id?: number }>;
+		const pageMembers = Array.isArray(body) ? body : [];
+		if (pageMembers.length === 0) break;
+		for (const m of pageMembers) {
+			if (typeof m.login === "string" && m.login.length > 0) {
+				members.push({
+					login: m.login,
+					id: typeof m.id === "number" ? m.id : undefined,
+				});
+			}
+		}
+		if (pageMembers.length < perPage) break;
+		page += 1;
+	}
+	return members;
+}
+
+/** Resolve an org owner/admin as `entities.created_by` (NOT NULL). */
+async function resolveOrgCreator(orgId: string): Promise<string | null> {
+	const sql = getDb();
+	const rows = await sql<{ userId: string }>`
+		SELECT "userId"
+		FROM "member"
+		WHERE "organizationId" = ${orgId}
+		ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END,
+		         "createdAt" ASC
+		LIMIT 1
+	`;
+	return rows.length > 0 ? rows[0].userId : null;
+}
+
+/**
+ * Find-or-create the `company` entity for the org, identified by the org's
+ * github_login (+ immutable github_user_id when known). Reuses the person
+ * resolver's entity-identity machinery by targeting entityType `company`, so the
+ * org entity dedupes on its github identity exactly like members do.
+ */
+async function ensureOrgCompany(params: {
+	orgId: string;
+	account: GithubOrgAccount;
+}): Promise<number | null> {
+	const item: { origin_type: string; metadata: Record<string, unknown> } = {
+		origin_type: "org",
+		metadata: {
+			org_login: params.account.login,
+			...(typeof params.account.id === "number"
+				? { org_id: String(params.account.id) }
+				: {}),
+		},
+	};
+	const resolved = await resolveEntityLinksForItems({
+		connectorKey: GITHUB_CONNECTOR_KEY,
+		orgId: params.orgId,
+		items: [item],
+		rules: {
+			org: [
+				{
+					entityType: "company",
+					autoCreate: true,
+					titlePath: "metadata.org_login",
+					identities: [
+						{ namespace: IDENTITY.GITHUB_USER_ID, eventPath: "metadata.org_id" },
+						{ namespace: IDENTITY.GITHUB_LOGIN, eventPath: "metadata.org_login" },
+					],
+					traits: {
+						github_login: {
+							eventPath: "metadata.org_login",
+							behavior: "prefer_non_empty",
+						},
+					},
+				},
+			],
+		},
+	});
+	const ids = resolved.get(0) ?? [];
+	return ids.length > 0 ? ids[0] : null;
+}
+
+/** Find-or-create the org-scoped `member_of` relationship type. */
+async function ensureMemberOfType(orgId: string): Promise<number> {
+	const sql = getDb();
+	const rows = await sql`
+		INSERT INTO entity_relationship_types
+			(slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
+		VALUES
+			(${MEMBER_OF_TYPE_SLUG}, 'Member of', 'A person is a member of an organization', ${orgId},
+			 false, NULL, current_timestamp, current_timestamp)
+		ON CONFLICT (organization_id, slug) WHERE status = 'active'
+		DO UPDATE SET updated_at = EXCLUDED.updated_at
+		RETURNING id
+	`;
+	return Number(rows[0].id);
+}
+
+/**
+ * Build the team graph for a GitHub App install: upsert the org `company`,
+ * resolve each member to a `person`, and write `member_of` edges. Injectable
+ * `fetchMembers` so tests never hit GitHub.
+ *
+ * @returns counts of what was built; empty when the install is a User account
+ *          (no members) or no members resolved.
+ */
+export async function buildGithubTeamGraph(params: {
+	organizationId: string;
+	account: GithubOrgAccount;
+	/** Members to persist. Tests pass these directly; prod fetches them. */
+	members: GithubOrgMember[];
+}): Promise<TeamGraphResult> {
+	// User-account installs have no org membership to graph.
+	if (params.account.type !== "Organization") return EMPTY_RESULT;
+	if (params.members.length === 0) return EMPTY_RESULT;
+
+	const creatorUserId = await resolveOrgCreator(params.organizationId);
+	if (!creatorUserId) {
+		logger.warn(
+			{ organization_id: params.organizationId },
+			"Team-graph skipped: org has no member to attribute as entity creator",
+		);
+		return EMPTY_RESULT;
+	}
+
+	const companyEntityId = await ensureOrgCompany({
+		orgId: params.organizationId,
+		account: params.account,
+	});
+	if (companyEntityId === null) {
+		logger.warn(
+			{ organization_id: params.organizationId, org_login: params.account.login },
+			"Team-graph skipped: could not resolve/create the org company entity",
+		);
+		return EMPTY_RESULT;
+	}
+
+	// Resolve every member to a person in ONE batch (shared entity-identity
+	// machinery — a member who also authored issues collapses to one person).
+	const memberItems = params.members.map((m) => ({
+		origin_type: "org_member",
+		metadata: {
+			author_login: m.login,
+			...(typeof m.id === "number" ? { author_id: String(m.id) } : {}),
+		},
+	}));
+	const resolvedMembers = await resolveEntityLinksForItems({
+		connectorKey: GITHUB_CONNECTOR_KEY,
+		orgId: params.organizationId,
+		items: memberItems,
+		rules: {
+			org_member: [
+				{
+					entityType: "person",
+					autoCreate: true,
+					titlePath: "metadata.author_login",
+					identities: [
+						{ namespace: IDENTITY.GITHUB_USER_ID, eventPath: "metadata.author_id" },
+						{ namespace: IDENTITY.GITHUB_LOGIN, eventPath: "metadata.author_login" },
+					],
+					traits: {
+						github_login: {
+							eventPath: "metadata.author_login",
+							behavior: "prefer_non_empty",
+						},
+					},
+				},
+			],
+		},
+	});
+
+	const memberEntityIds: number[] = [];
+	for (let i = 0; i < memberItems.length; i++) {
+		const ids = resolvedMembers.get(i);
+		if (ids && ids.length > 0) memberEntityIds.push(ids[0]);
+	}
+	const uniqueMemberIds = [...new Set(memberEntityIds)];
+	if (uniqueMemberIds.length === 0) {
+		return { companyEntityId, memberEntityIds: [], createdEdges: 0 };
+	}
+
+	const typeId = await ensureMemberOfType(params.organizationId);
+	const sql = getDb();
+	let createdEdges = 0;
+	for (const memberId of uniqueMemberIds) {
+		// person -> company. Idempotent on the live-triple unique index; a re-bind
+		// re-affirms the edge without duplicating it.
+		const inserted = await sql<{ id: number }[]>`
+			INSERT INTO entity_relationships (
+				organization_id, from_entity_id, to_entity_id, relationship_type_id,
+				confidence, source, created_by, updated_by, created_at, updated_at
+			) VALUES (
+				${params.organizationId}, ${memberId}, ${companyEntityId}, ${typeId},
+				1.0, 'feed', ${creatorUserId}, ${creatorUserId},
+				current_timestamp, current_timestamp
+			)
+			ON CONFLICT (from_entity_id, to_entity_id, relationship_type_id)
+				WHERE deleted_at IS NULL
+			DO NOTHING
+			RETURNING id
+		`;
+		if (inserted.length > 0) createdEdges += 1;
+	}
+
+	logger.info(
+		{
+			organization_id: params.organizationId,
+			org_login: params.account.login,
+			company_entity_id: companyEntityId,
+			members: uniqueMemberIds.length,
+			created_edges: createdEdges,
+		},
+		"Built GitHub team graph",
+	);
+
+	return {
+		companyEntityId,
+		memberEntityIds: uniqueMemberIds,
+		createdEdges,
+	};
+}


### PR DESCRIPTION
## What

**PR2 of 2** (stacked on #1492). GitHub org membership was fetched during the install ownership check, then **discarded**. Now, on org install/refresh, it persists a team graph.

## Entity model decision

**Reuse `company` for the org + a `member_of` relationship type** — no `team` entity type, no migration. The org *is* a company; "team" is the *relationship*, which the `entity_relationships` + relationship-type machinery already expresses. (A test asserts no `team` type is created.)

## How

- `buildGithubTeamGraph` — upserts the org `company` (identified by the org's `github_login` + immutable `github_user_id`), resolves each member to a `person` via the **same** entity-identity machinery as PR1 (so a member who has also authored issues collapses to one entity), and writes person→company `member_of` edges.
- `provisionGithubTeamGraph` — mints the install's OWN scoped token (Members:read), enumerates `GET /orgs/{org}/members`, and builds the graph. Injectable `fetchOrgMembers` so tests never hit GitHub.
- `app-install` — threads the ownership-verified account (`login`/`type`/`id`) out of `verifyInstallationOwnership` into the install-row metadata + the team-graph build; calls `provisionGithubTeamGraph` after auto-provision. Org installs only; best-effort — never turns a successful bind into an error page.

## Idempotent

The company dedupes on its github identity; `member_of` dedupes on the live-triple unique index `(from, to, type) WHERE deleted_at IS NULL`. A re-bind adds new members and re-affirms existing edges without duplicating.

## Tenant scoping

The org id is the verified install's owning org; every read/write filters on it; `entity_identities` are UNIQUE per `(organization_id, namespace, identifier)`. A test proves the same member in two orgs builds two distinct persons + companies. User-account installs (no members) build nothing.

## Tests (real PG)

`github-team-graph.test.ts` (4):
- org members → company + persons + `member_of` edges; idempotent re-run (+1 member adds exactly one edge)
- member collapses onto an already-authored contributor (one person, not two)
- User-account install builds nothing
- cross-org isolation

All green. Existing `app-installation-e2e` (10) still passes (the `InstallOwnershipResult` shape change is backward-compatible). `cd packages/server && bunx tsc --noEmit` adds 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ug5cEnCRt1VHn8w3gNXAu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784759784&installation_id=136316292&pr_number=1494&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1494&signature=8d932c48dad3b31d9bb6e5b0a73dc0a942629fd6de304d0a6e9408ac7d0782ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->