### PR TITLE
refactor(server): shared helpers for error/timestamp/org/token idioms

### DIFF
--- a/packages/core/src/__tests__/errors.test.ts
+++ b/packages/core/src/__tests__/errors.test.ts
@@ -3,10 +3,27 @@ import {
   BaseError,
   ConfigError,
   ErrorCode,
+  getErrorMessage,
   OrchestratorError,
   WorkerError,
   WorkspaceError,
 } from "../errors";
+
+describe("getErrorMessage", () => {
+  test("returns .message for Error and subclasses", () => {
+    expect(getErrorMessage(new Error("boom"))).toBe("boom");
+    expect(getErrorMessage(new TypeError("bad type"))).toBe("bad type");
+    expect(getErrorMessage(new ConfigError("bad config"))).toBe("bad config");
+  });
+
+  test("stringifies non-Error throws", () => {
+    expect(getErrorMessage("plain string")).toBe("plain string");
+    expect(getErrorMessage(42)).toBe("42");
+    expect(getErrorMessage(null)).toBe("null");
+    expect(getErrorMessage(undefined)).toBe("undefined");
+    expect(getErrorMessage({ code: "X" })).toBe("[object Object]");
+  });
+});
 
 describe("BaseError (via WorkerError)", () => {
   test("sets name, message, and prototype chain", () => {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,3 +1,14 @@
+/**
+ * Extract a human-readable message from an unknown thrown value.
+ *
+ * Replaces the ubiquitous `error instanceof Error ? error.message : String(error)`
+ * idiom: `Error` (and subclasses) yield `.message`; anything else
+ * (`throw "boom"`, `throw null`, a rejected non-Error) is stringified.
+ */
+export function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /** Base error class for all lobu errors. */
 export abstract class BaseError extends Error {
   abstract readonly name: string;

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -42,6 +42,7 @@ import {
 } from '../gateway/services/provider-registry-service';
 import logger from '../utils/logger';
 import { hasOrgSentinel } from './default-provisioning';
+import { getErrorMessage } from "@lobu/core";
 
 export const BUILDER_AGENT_ID = 'lobu-builder';
 export const BUILDER_AGENT_SENTINEL = 'builder_agent_provisioned';
@@ -126,7 +127,7 @@ async function resolveBuilderProviders(): Promise<ResolvedBuilderProviders> {
     configs = await registry.getProviderConfigs();
   } catch (err) {
     logger.warn(
-      { err: err instanceof Error ? err.message : String(err) },
+      { err: getErrorMessage(err) },
       '[builder-provisioning] providers.json read failed; relying on module registry'
     );
   }
@@ -456,7 +457,7 @@ export async function ensureBuilderAgent(
     logger.warn(
       {
         organizationId,
-        err: err instanceof Error ? err.message : String(err),
+        err: getErrorMessage(err),
       },
       '[builder-provisioning] Builder-agent provisioning failed (non-fatal)'
     );

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -27,6 +27,7 @@ import { getModelProviderModules } from '../gateway/modules/module-system';
 import { getNextNumericId } from '../tools/admin/helpers/db-helpers';
 import { nextRunAt } from '../utils/cron';
 import logger from '../utils/logger';
+import { getErrorMessage } from "@lobu/core";
 
 export const DEFAULT_AGENT_SENTINEL = 'default_agent_provisioned';
 export const DEFAULT_WATCHER_SENTINEL = 'default_watcher_provisioned';
@@ -327,7 +328,7 @@ export async function ensureDefaultAgent(
     return { created: true, reason: 'inserted' };
   } catch (err) {
     logger.warn(
-      { organizationId, err: err instanceof Error ? err.message : String(err) },
+      { organizationId, err: getErrorMessage(err) },
       '[default-provisioning] Default-agent provisioning failed (non-fatal)'
     );
     return { created: false, reason: 'sentinel' };
@@ -523,7 +524,7 @@ export async function ensureDefaultWatcher(params: {
       {
         organizationId: params.organizationId,
         deviceWorkerId: params.deviceWorkerId,
-        err: err instanceof Error ? err.message : String(err),
+        err: getErrorMessage(err),
       },
       '[default-provisioning] Default-watcher provisioning failed (non-fatal)'
     );

--- a/packages/server/src/auth/worker-token.ts
+++ b/packages/server/src/auth/worker-token.ts
@@ -1,28 +1,16 @@
-import { timingSafeEqual } from 'node:crypto';
+import { constantTimeEqual } from '../utils/constant-time-equal';
 
 /**
  * Constant-time comparison of a provided bearer token against the configured
  * `WORKER_API_TOKEN`. The trusted-worker auth path (see `/api/workers/*` in
  * index.ts) grants full cross-org access, so a naive `===` would leak the
- * secret's length and matching prefix via response timing.
- *
- * Mirrors the smoke route's `compareTokens`
- * (gateway/routes/internal/smoke.ts): a length-equality pre-check first
- * (`timingSafeEqual` throws on a length mismatch), then the constant-time
- * compare. A missing `expected` (token unconfigured) or `provided` is rejected
- * — the trusted path is opt-in via env, never granted by omission.
+ * secret's length and matching prefix via response timing. A missing `expected`
+ * (token unconfigured) or `provided` is rejected — the trusted path is opt-in
+ * via env, never granted by omission.
  */
 export function compareWorkerToken(
   provided: string | undefined,
   expected: string | undefined
 ): boolean {
-  if (!provided || !expected) return false;
-  const a = Buffer.from(provided);
-  const b = Buffer.from(expected);
-  if (a.length !== b.length) return false;
-  try {
-    return timingSafeEqual(a, b);
-  } catch {
-    return false;
-  }
+  return constantTimeEqual(provided, expected);
 }

--- a/packages/server/src/connect/webhook-registration.ts
+++ b/packages/server/src/connect/webhook-registration.ts
@@ -25,6 +25,7 @@ import { resolveBaseUrl } from '../auth/base-url';
 import { resolveConnectorCode } from '../utils/ensure-connector-installed';
 import { mergeExecutionConfig, resolveExecutionAuth } from '../utils/execution-context';
 import logger from '../utils/logger';
+import { getErrorMessage } from "@lobu/core";
 
 interface ConnectorConnectionRow {
   id: number;
@@ -228,7 +229,7 @@ export async function registerConnectorWebhook(params: {
     logger.warn(
       {
         connection_id: connectionId,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
       },
       'Connector webhook registration failed (connection stays active)'
     );
@@ -313,7 +314,7 @@ export async function unregisterConnectorWebhook(params: {
     logger.warn(
       {
         connection_id: connectionId,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
       },
       'Connector webhook teardown failed'
     );

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -47,6 +47,40 @@ export function pgBigintArray(values: number[]): string {
 }
 
 /**
+ * Coerce a Postgres timestamp column value to epoch milliseconds, defaulting to
+ * `Date.now()` when the row carried no value.
+ *
+ * postgres.js may hand a `Date` (typed timestamp) or a raw string/number
+ * (untyped / `fetch_types: false`), so row mappers all wrote the same
+ * `x instanceof Date ? x.getTime() : (x ?? Date.now())` triad. Use this instead.
+ */
+export function tsTime(value: unknown): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const ms = new Date(value).getTime();
+    if (!Number.isNaN(ms)) return ms;
+  }
+  return Date.now();
+}
+
+/**
+ * Like {@link tsTime}, but returns `undefined` (not "now") when the row carried
+ * no value — for optional timestamps such as `last_used_at` where absence is
+ * meaningful and must not be coerced to the current time.
+ */
+export function tsTimeOrNull(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const ms = new Date(value).getTime();
+    if (!Number.isNaN(ms)) return ms;
+  }
+  return undefined;
+}
+
+/**
  * Parse a value that may be a JS array or a PostgreSQL array literal
  * (`{a,b,"c d"}`) into a string array. Quoted elements are unquoted and
  * `\"` / `\\` escapes are resolved.

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -1,6 +1,6 @@
 import { createLogger } from "@lobu/core";
 import { Hono } from "hono";
-import { tryGetOrgId } from "../../lobu/stores/org-context.js";
+import { resolveOrgId } from "../../lobu/stores/org-context.js";
 import { readOrgSharedProviderApiKey } from "../../lobu/stores/provider-secrets.js";
 import type { ProviderCredentialContext } from "../embedded.js";
 import {
@@ -30,7 +30,7 @@ async function readOrgSharedProviderKey(
   providerId: string,
   context?: ProviderCredentialContext
 ): Promise<string | null> {
-  const orgId = context?.organizationId ?? tryGetOrgId();
+  const orgId = resolveOrgId(context?.organizationId);
   if (!orgId) return null;
   return readOrgSharedProviderApiKey(providerId, orgId);
 }

--- a/packages/server/src/gateway/auth/mcp/oauth-discovery.ts
+++ b/packages/server/src/gateway/auth/mcp/oauth-discovery.ts
@@ -13,7 +13,10 @@
 
 import { createHash } from "node:crypto";
 import dns from "node:dns/promises";
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import type { WritableSecretStore } from "../../secrets/index.js";
 import { isReservedIp } from "../../proxy/ssrf-guard.js";
 
@@ -166,13 +169,13 @@ async function fetchAuthorizationServerMetadata(
       lastError = error;
       logger.debug("Authorization server metadata probe failed", {
         url: candidate,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
       });
     }
   }
   throw new Error(
     `Unable to fetch authorization server metadata from ${issuer}: ${
-      lastError instanceof Error ? lastError.message : String(lastError)
+      getErrorMessage(lastError)
     }`
   );
 }

--- a/packages/server/src/gateway/auth/mcp/proxy-auth-flows.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-auth-flows.ts
@@ -1,4 +1,8 @@
-import { createLogger, type WorkerTokenData } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+	type WorkerTokenData,
+} from "@lobu/core";
 import { startDeviceAuth } from "../../routes/internal/device-auth.js";
 import type { WritableSecretStore } from "../../secrets/index.js";
 import { startAuthCodeFlow } from "./oauth-flow.js";
@@ -254,7 +258,7 @@ export class McpAuthFlows {
 		} catch (error) {
 			logger.warn("Auto auth-code flow failed", {
 				mcpId: params.mcpId,
-				error: error instanceof Error ? error.message : String(error),
+				error: getErrorMessage(error),
 			});
 			return null;
 		}
@@ -312,7 +316,7 @@ export class McpAuthFlows {
 		} catch (error) {
 			logger.warn("Auto device-auth failed", {
 				mcpId,
-				error: error instanceof Error ? error.message : String(error),
+				error: getErrorMessage(error),
 			});
 			return null;
 		}

--- a/packages/server/src/gateway/auth/mcp/proxy-forward.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-forward.ts
@@ -1,4 +1,8 @@
-import { createLogger, verifyWorkerToken } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+	verifyWorkerToken,
+} from "@lobu/core";
 import type { Context } from "hono";
 import type { McpProxy } from "./proxy.js";
 import {
@@ -264,7 +268,7 @@ async function forwardRequest(
 		} catch (error) {
 			logger.warn("Pre-emptive MCP re-initialization failed", {
 				mcpId,
-				error: error instanceof Error ? error.message : String(error),
+				error: getErrorMessage(error),
 			});
 		}
 	}
@@ -366,7 +370,7 @@ async function forwardRequest(
 		} catch (error) {
 			logger.warn("Stale-session recovery failed on forward", {
 				mcpId,
-				error: error instanceof Error ? error.message : String(error),
+				error: getErrorMessage(error),
 			});
 		}
 	}

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
 	createLogger,
+	getErrorMessage,
 	type GuardrailRegistry,
 	runGuardrailInstances,
 	type WorkerTokenData,
@@ -329,7 +330,7 @@ export class McpProxy {
 				logger.warn("MCP initialize failed (continuing with tools/list)", {
 					mcpId,
 					error:
-						initError instanceof Error ? initError.message : String(initError),
+						getErrorMessage(initError),
 				});
 			}
 
@@ -379,7 +380,7 @@ export class McpProxy {
 		} catch (error) {
 			logger.warn("Failed to fetch tools for MCP, retrying once", {
 				mcpId,
-				error: error instanceof Error ? error.message : String(error),
+				error: getErrorMessage(error),
 			});
 
 			// Retry once after a short delay (upstream may still be starting)
@@ -532,7 +533,7 @@ export class McpProxy {
 				{
 					agentId,
 					toolName,
-					err: err instanceof Error ? err.message : String(err),
+					err: getErrorMessage(err),
 				},
 				"Pre-tool guardrail check failed — proceeding without guardrails",
 			);

--- a/packages/server/src/gateway/auth/provider-model-options.ts
+++ b/packages/server/src/gateway/auth/provider-model-options.ts
@@ -1,4 +1,8 @@
-import { createLogger, type ModelOption } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+	type ModelOption,
+} from "@lobu/core";
 import { getModelProviderModules } from "../modules/module-system.js";
 
 const logger = createLogger("provider-model-options");
@@ -26,7 +30,7 @@ export async function collectProviderModelOptions(
         logger.warn(
           {
             providerId: mod.providerId,
-            error: error instanceof Error ? error.message : String(error),
+            error: getErrorMessage(error),
           },
           "Failed to collect model options for provider"
         );

--- a/packages/server/src/gateway/auth/settings/auth-profiles-manager.ts
+++ b/packages/server/src/gateway/auth/settings/auth-profiles-manager.ts
@@ -1,4 +1,8 @@
-import { type AuthProfile, createLogger } from "@lobu/core";
+import {
+	type AuthProfile,
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import { orgContext, tryGetOrgId } from "../../../lobu/stores/org-context.js";
 import type {
   ProviderCredentialContext,
@@ -235,7 +239,7 @@ export class AuthProfilesManager {
       logger.warn(
         {
           agentId,
-          error: error instanceof Error ? error.message : String(error),
+          error: getErrorMessage(error),
         },
         "agent owner resolver failed; skipping owner credential fallback"
       );
@@ -261,7 +265,7 @@ export class AuthProfilesManager {
       logger.warn(
         {
           agentId,
-          error: error instanceof Error ? error.message : String(error),
+          error: getErrorMessage(error),
         },
         "agent org resolver failed; credential reads run without org context"
       );
@@ -340,7 +344,7 @@ export class AuthProfilesManager {
               agentId,
               profileId: profile.id,
               provider: profile.provider,
-              error: error instanceof Error ? error.message : String(error),
+              error: getErrorMessage(error),
             },
             "Dropping auth profile with unresolvable secret ref"
           );
@@ -693,7 +697,7 @@ export class AuthProfilesManager {
         agentId,
         provider,
         model,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
       });
       return null;
     }
@@ -733,7 +737,7 @@ export class AuthProfilesManager {
         agentId,
         provider,
         model,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
       });
       return null;
     }

--- a/packages/server/src/gateway/auth/settings/user-auth-profile-store.ts
+++ b/packages/server/src/gateway/auth/settings/user-auth-profile-store.ts
@@ -1,4 +1,8 @@
-import { type AuthProfile, createLogger } from "@lobu/core";
+import {
+	type AuthProfile,
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import { getDb } from "../../../db/client.js";
 import {
   deleteSecretsByPrefix,
@@ -64,7 +68,7 @@ export class UserAuthProfileStore {
       logger.warn("Failed to read user auth profiles", {
         userId,
         agentId,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
       });
       return [];
     }

--- a/packages/server/src/gateway/auth/user-agents-store.ts
+++ b/packages/server/src/gateway/auth/user-agents-store.ts
@@ -1,6 +1,6 @@
 import { createLogger } from "@lobu/core";
 import { getDb } from "../../db/client.js";
-import { tryGetOrgId } from "../../lobu/stores/org-context.js";
+import { requireOrgId, resolveOrgId } from "../../lobu/stores/org-context.js";
 
 const logger = createLogger("user-agents-store");
 
@@ -21,12 +21,7 @@ export class UserAgentsStore {
     agentId: string,
     organizationId?: string
   ): Promise<void> {
-    const orgId = organizationId ?? tryGetOrgId();
-    if (!orgId) {
-      throw new Error(
-        "UserAgentsStore.addAgent requires organizationId (explicit or via orgContext)"
-      );
-    }
+    const orgId = requireOrgId(organizationId, "UserAgentsStore.addAgent");
     const sql = getDb();
     await sql`
       INSERT INTO agent_users (organization_id, agent_id, platform, user_id, created_at)
@@ -43,7 +38,7 @@ export class UserAgentsStore {
     organizationId?: string
   ): Promise<void> {
     const sql = getDb();
-    const orgId = organizationId ?? tryGetOrgId();
+    const orgId = resolveOrgId(organizationId);
     if (orgId) {
       await sql`
         DELETE FROM agent_users
@@ -65,7 +60,7 @@ export class UserAgentsStore {
     organizationId?: string
   ): Promise<string[]> {
     const sql = getDb();
-    const orgId = organizationId ?? tryGetOrgId();
+    const orgId = resolveOrgId(organizationId);
     const rows = orgId
       ? await sql`
           SELECT agent_id

--- a/packages/server/src/gateway/channels/binding-service.ts
+++ b/packages/server/src/gateway/channels/binding-service.ts
@@ -1,6 +1,6 @@
 import { createLogger } from "@lobu/core";
-import { getDb } from "../../db/client.js";
-import { tryGetOrgId } from "../../lobu/stores/org-context.js";
+import { getDb, tsTime } from "../../db/client.js";
+import { requireOrgId, resolveOrgId } from "../../lobu/stores/org-context.js";
 
 const logger = createLogger("channel-binding-service");
 
@@ -30,9 +30,7 @@ function rowToBinding(row: Record<string, any>): ChannelBinding {
     agentId: row.agent_id,
     organizationId: row.organization_id ?? undefined,
     createdAt:
-      row.created_at instanceof Date
-        ? row.created_at.getTime()
-        : (row.created_at ?? Date.now()),
+      tsTime(row.created_at),
   };
 }
 
@@ -48,7 +46,7 @@ export class ChannelBindingService {
     organizationId?: string
   ): Promise<ChannelBinding | null> {
     const sql = getDb();
-    const orgId = organizationId ?? tryGetOrgId();
+    const orgId = resolveOrgId(organizationId);
     const rows = teamId
       ? orgId
         ? await sql`
@@ -128,12 +126,10 @@ export class ChannelBindingService {
     options?: { configuredBy?: string; wasAdmin?: boolean; organizationId?: string }
   ): Promise<void> {
     const sql = getDb();
-    const orgId = options?.organizationId ?? tryGetOrgId();
-    if (!orgId) {
-      throw new Error(
-        "ChannelBindingService.createBinding requires organizationId (explicit or via orgContext)"
-      );
-    }
+    const orgId = requireOrgId(
+      options?.organizationId,
+      "ChannelBindingService.createBinding",
+    );
     if (teamId) {
       // The (organization_id, platform, channel_id, team_id) UNIQUE covers the
       // team-id-set case. The key is org-scoped so a sibling tenant binding the
@@ -171,7 +167,7 @@ export class ChannelBindingService {
     organizationId?: string
   ): Promise<boolean> {
     const sql = getDb();
-    const orgId = organizationId ?? tryGetOrgId();
+    const orgId = resolveOrgId(organizationId);
     const existing = await this.getBinding(platform, channelId, teamId, orgId ?? undefined);
     if (!existing) {
       logger.warn(`No binding found for ${platform}/${channelId}`);
@@ -220,7 +216,7 @@ export class ChannelBindingService {
     organizationId?: string
   ): Promise<ChannelBinding[]> {
     const sql = getDb();
-    const orgId = organizationId ?? tryGetOrgId();
+    const orgId = resolveOrgId(organizationId);
     const rows = orgId
       ? await sql`
           SELECT * FROM agent_channel_bindings
@@ -237,7 +233,7 @@ export class ChannelBindingService {
     organizationId?: string
   ): Promise<number> {
     const sql = getDb();
-    const orgId = organizationId ?? tryGetOrgId();
+    const orgId = resolveOrgId(organizationId);
     const rows = orgId
       ? await sql`
           DELETE FROM agent_channel_bindings

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -14,7 +14,11 @@
 
 import { randomUUID } from "node:crypto";
 import type { AgentConnectionStore, StoredConnection } from "@lobu/core";
-import { createLogger, isSecretRef } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+	isSecretRef,
+} from "@lobu/core";
 import { type AdapterPostableMessage, Chat } from "chat";
 import { getDb } from "../../db/client.js";
 import { orgContext, tryGetOrgId } from "../../lobu/stores/org-context.js";
@@ -402,7 +406,7 @@ export class ChatInstanceManager {
       await this.writeConnectionStatus(
         stored,
         "error",
-        `Startup failed: ${error instanceof Error ? error.message : String(error)}`
+        `Startup failed: ${getErrorMessage(error)}`
       );
       throw error;
     }
@@ -539,7 +543,7 @@ export class ChatInstanceManager {
           await this.writeConnectionStatus(
             reread,
             "error",
-            `Startup failed: ${error instanceof Error ? error.message : String(error)}`
+            `Startup failed: ${getErrorMessage(error)}`
           );
           throw error;
         }
@@ -1427,7 +1431,7 @@ export class ChatInstanceManager {
       await this.writeConnectionStatus(
         stored,
         "error",
-        `Startup failed: ${error instanceof Error ? error.message : String(error)}`
+        `Startup failed: ${getErrorMessage(error)}`
       );
       return false;
     }
@@ -1672,7 +1676,7 @@ export class ChatInstanceManager {
           await this.writeConnectionStatus(
             s,
             "error",
-            `Startup failed: ${error instanceof Error ? error.message : String(error)}`
+            `Startup failed: ${getErrorMessage(error)}`
           );
         }
         // Schedule a bounded, exponentially-backed-off retry. The first-failure
@@ -1832,7 +1836,7 @@ export class ChatInstanceManager {
           await this.writeConnectionStatus(
             s,
             "error",
-            `Health check failed: ${error instanceof Error ? error.message : String(error)}`
+            `Health check failed: ${getErrorMessage(error)}`
           );
           result.errored += 1;
         }

--- a/packages/server/src/gateway/connections/webhook-ingest.ts
+++ b/packages/server/src/gateway/connections/webhook-ingest.ts
@@ -34,6 +34,7 @@
 import { createHash, createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 import type { StoredConnection } from "@lobu/core";
 import { getDb } from "../../db/client.js";
+import { constantTimeEqual } from "../../utils/constant-time-equal.js";
 import { insertEvent } from "../../utils/insert-event.js";
 import logger from "../../utils/logger.js";
 import { getClientIP, getRateLimiter } from "../../utils/rate-limiter.js";
@@ -98,11 +99,17 @@ function json(status: number, body: Record<string, unknown>): Response {
 	});
 }
 
-/** Constant-time equality over fixed-length digests (inputs vary in length). */
+/**
+ * Constant-time token equality. The presented/configured tokens vary in length,
+ * which `constantTimeEqual` (and `timingSafeEqual`) can't compare directly — so
+ * hash both to fixed-length sha256 hex digests first and compare THOSE. Equal
+ * tokens hash equal; the length-revealing path can never fire on the digests.
+ */
 function tokensMatch(presented: string, configured: string): boolean {
-	const a = createHash("sha256").update(presented).digest();
-	const b = createHash("sha256").update(configured).digest();
-	return timingSafeEqual(a, b);
+	return constantTimeEqual(
+		createHash("sha256").update(presented).digest("hex"),
+		createHash("sha256").update(configured).digest("hex"),
+	);
 }
 
 /**

--- a/packages/server/src/gateway/files/artifact-store.ts
+++ b/packages/server/src/gateway/files/artifact-store.ts
@@ -3,7 +3,12 @@ import { createReadStream } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { createLogger, decrypt, encrypt } from "@lobu/core";
+import {
+	createLogger,
+	decrypt,
+	getErrorMessage,
+	encrypt,
+} from "@lobu/core";
 
 const logger = createLogger("artifact-store");
 const DEFAULT_ARTIFACTS_DIR = path.join(os.tmpdir(), "lobu-artifacts");
@@ -153,7 +158,7 @@ export class ArtifactStore {
     } catch (error) {
       return {
         valid: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
       };
     }
   }

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -6,10 +6,11 @@ import type {
   WorkerTokenData,
 } from "@lobu/core";
 import {
-  createLogger,
-  encrypt,
-  generateWorkerToken,
-  verifyWorkerToken,
+	createLogger,
+	generateWorkerToken,
+	getErrorMessage,
+	encrypt,
+	verifyWorkerToken,
 } from "@lobu/core";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -204,7 +205,7 @@ export class WorkerGateway {
             mcpId: mcp.id,
             agentId,
             userId,
-            error: error instanceof Error ? error.message : String(error),
+            error: getErrorMessage(error),
           });
         }
 

--- a/packages/server/src/gateway/gateway/transcript-routes.ts
+++ b/packages/server/src/gateway/gateway/transcript-routes.ts
@@ -22,7 +22,11 @@
  */
 
 import type { WorkerTokenData } from "@lobu/core";
-import { createLogger, verifyWorkerToken } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+	verifyWorkerToken,
+} from "@lobu/core";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { getDb } from "../../db/client.js";
@@ -252,7 +256,7 @@ export function createTranscriptRoutes(): Hono {
       return c.json({ id: inserted[0]!.id });
     } catch (err) {
       logger.error(
-        `Snapshot INSERT failed: ${err instanceof Error ? err.message : String(err)}`
+        `Snapshot INSERT failed: ${getErrorMessage(err)}`
       );
       return c.json({ error: "Internal error" }, 500);
     }
@@ -294,7 +298,7 @@ export function createTranscriptRoutes(): Hono {
       return c.json({ deleted: deleted.length });
     } catch (err) {
       logger.error(
-        `Snapshot DELETE failed: ${err instanceof Error ? err.message : String(err)}`
+        `Snapshot DELETE failed: ${getErrorMessage(err)}`
       );
       return c.json({ error: "Internal error" }, 500);
     }

--- a/packages/server/src/gateway/guardrails/audit.ts
+++ b/packages/server/src/gateway/guardrails/audit.ts
@@ -8,7 +8,7 @@
 
 import { insertEvent } from "../../utils/insert-event";
 import logger from "../../utils/logger";
-import type { GuardrailStage } from "@lobu/core";
+import { getErrorMessage, type GuardrailStage } from "@lobu/core";
 
 /**
  * Tracks in-flight `recordGuardrailTrip` calls. Production fires-and-forgets
@@ -101,7 +101,7 @@ async function doRecordGuardrailTrip(
   } catch (err) {
     logger.warn(
       {
-        err: err instanceof Error ? err.message : String(err),
+        err: getErrorMessage(err),
         guardrail: params.guardrail,
         stage: params.stage,
       },

--- a/packages/server/src/gateway/guardrails/output-scan.ts
+++ b/packages/server/src/gateway/guardrails/output-scan.ts
@@ -13,9 +13,10 @@
  */
 
 import {
-  createLogger,
-  type GuardrailRegistry,
-  runGuardrailInstances,
+	createLogger,
+	getErrorMessage,
+	type GuardrailRegistry,
+	runGuardrailInstances,
 } from "@lobu/core";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import { resolveAgentGuardrails } from "./aggregator.js";
@@ -97,7 +98,7 @@ export async function runOutputGuardrailScan(
     };
   } catch (err) {
     logger.warn(
-      { err: err instanceof Error ? err.message : String(err) },
+      { err: getErrorMessage(err) },
       "Output guardrail check failed — proceeding without guardrails"
     );
     return null;

--- a/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
+++ b/packages/server/src/gateway/infrastructure/queue/runs-queue.ts
@@ -19,7 +19,10 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import * as Sentry from "@sentry/node";
 import { intervals } from "../../../config/intervals.js";
 import { getDb, getDbListener, type DbClient } from "../../../db/client.js";
@@ -693,7 +696,7 @@ export class RunsQueue implements IMessageQueue {
 
   private async markFailed(runId: number, err: unknown): Promise<void> {
     const sql = getDb();
-    const message = err instanceof Error ? err.message : String(err);
+    const message = getErrorMessage(err);
     const rows = await sql`
       UPDATE public.runs
       SET status = 'failed',

--- a/packages/server/src/gateway/orchestration/base-deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/base-deployment-manager.ts
@@ -1,12 +1,13 @@
 import { createHash } from "node:crypto";
 import {
-  ConversationOwnedElsewhereError,
-  createLogger,
-  ErrorCode,
-  extractTraceId,
-  generateWorkerToken,
-  type MessagePayload,
-  OrchestratorError,
+	ConversationOwnedElsewhereError,
+	createLogger,
+	ErrorCode,
+	extractTraceId,
+	generateWorkerToken,
+	getErrorMessage,
+	type MessagePayload,
+	OrchestratorError,
 } from "@lobu/core";
 import type { ProviderCredentialContext } from "../embedded.js";
 import type { ModelProviderModule } from "../modules/module-system.js";
@@ -402,7 +403,7 @@ export abstract class BaseDeploymentManager {
           // The "existing" deployment is actually dead (stale snapshot / just
           // exited) — fall through to spawn a fresh one instead of returning.
           logger.warn(
-            `scaleDeployment(${deploymentName}, 1) failed (${scaleErr instanceof Error ? scaleErr.message : String(scaleErr)}); re-spawning`
+            `scaleDeployment(${deploymentName}, 1) failed (${getErrorMessage(scaleErr)}); re-spawning`
           );
         }
       }
@@ -442,7 +443,7 @@ export abstract class BaseDeploymentManager {
       }
       throw new OrchestratorError(
         ErrorCode.DEPLOYMENT_CREATE_FAILED,
-        `Failed to create worker deployment: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to create worker deployment: ${getErrorMessage(error)}`,
         { userId, conversationId, error },
         true
       );
@@ -1150,7 +1151,7 @@ export abstract class BaseDeploymentManager {
     } catch (error) {
       throw new OrchestratorError(
         ErrorCode.DEPLOYMENT_DELETE_FAILED,
-        `Failed to delete deployment for ${deploymentName}: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to delete deployment for ${deploymentName}: ${getErrorMessage(error)}`,
         { deploymentName, error },
         true
       );
@@ -1238,7 +1239,7 @@ export abstract class BaseDeploymentManager {
     } catch (error) {
       logger.error(
         "Error during deployment reconciliation:",
-        error instanceof Error ? error.message : String(error)
+        getErrorMessage(error)
       );
     }
   }

--- a/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
+++ b/packages/server/src/gateway/orchestration/impl/embedded-deployment.ts
@@ -2,12 +2,13 @@ import { type ChildProcess, execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import {
-  ConversationOwnedElsewhereError,
-  createLogger,
-  ErrorCode,
-  type MessagePayload,
-  OrchestratorError,
-  retryWithBackoff,
+	ConversationOwnedElsewhereError,
+	createLogger,
+	ErrorCode,
+	getErrorMessage,
+	type MessagePayload,
+	OrchestratorError,
+	retryWithBackoff,
 } from "@lobu/core";
 import { nixPackageAttrRef as nixPackageAttrRefBase } from "@lobu/connector-sdk/nix-package";
 import { intervals } from "../../../config/intervals.js";
@@ -451,7 +452,7 @@ export async function acquireConversationLock(
         // key triple so the operator can target a manual
         // pg_advisory_unlock from psql if needed.
         logger.error(
-          `Failed to release advisory lock after ${MAX_ATTEMPTS} attempts for ${organizationId}/${agentId}/${conversationId}: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`
+          `Failed to release advisory lock after ${MAX_ATTEMPTS} attempts for ${organizationId}/${agentId}/${conversationId}: ${getErrorMessage(lastErr)}`
         );
       }
       // ALWAYS return the reserved connection to the pool — keeping it
@@ -710,7 +711,7 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
         );
       } catch (err) {
         logger.error(
-          `Failed to acquire conversation lock: ${err instanceof Error ? err.message : String(err)}`
+          `Failed to acquire conversation lock: ${getErrorMessage(err)}`
         );
         throw new OrchestratorError(
           ErrorCode.DEPLOYMENT_CREATE_FAILED,
@@ -937,7 +938,7 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
           WORKER_SANDBOX_REQUIRED_MESSAGE
         ).catch((failErr) => {
           logger.error(
-            `Failed to fail in-flight turns after refusing un-sandboxed worker ${deploymentName}: ${failErr instanceof Error ? failErr.message : String(failErr)}`
+            `Failed to fail in-flight turns after refusing un-sandboxed worker ${deploymentName}: ${getErrorMessage(failErr)}`
           );
         });
         return;
@@ -1007,7 +1008,7 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
       failTurnsForDeployment(deploymentName, WORKER_DIED_MESSAGE).catch(
         (failErr) => {
           logger.error(
-            `Failed to fail in-flight turns after spawn error for ${deploymentName} (client may hang until the turn-liveness sweep): ${failErr instanceof Error ? failErr.message : String(failErr)}`
+            `Failed to fail in-flight turns after spawn error for ${deploymentName} (client may hang until the turn-liveness sweep): ${getErrorMessage(failErr)}`
           );
         }
       );
@@ -1091,7 +1092,7 @@ export class EmbeddedDeploymentManager extends BaseDeploymentManager {
         failTurnsForDeployment(deploymentName, WORKER_DIED_MESSAGE).catch(
           (failErr) => {
             logger.error(
-              `Failed to fail in-flight turns after unexpected exit of ${deploymentName} (client may hang until the turn-liveness sweep): ${failErr instanceof Error ? failErr.message : String(failErr)}`
+              `Failed to fail in-flight turns after unexpected exit of ${deploymentName} (client may hang until the turn-liveness sweep): ${getErrorMessage(failErr)}`
             );
           }
         );

--- a/packages/server/src/gateway/orchestration/index.ts
+++ b/packages/server/src/gateway/orchestration/index.ts
@@ -3,9 +3,10 @@ export * from "./deployment-utils.js";
 export * from "./impl/embedded-deployment.js";
 
 import {
-  createLogger,
-  type GuardrailRegistry,
-  moduleRegistry,
+	createLogger,
+	getErrorMessage,
+	type GuardrailRegistry,
+	moduleRegistry,
 } from "@lobu/core";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import type { ProviderCatalogService } from "../auth/provider-catalog.js";
@@ -214,7 +215,7 @@ export class Orchestrator {
       } catch (error) {
         logger.error(
           "Error during deployment reconciliation:",
-          error instanceof Error ? error.message : String(error)
+          getErrorMessage(error)
         );
       } finally {
         this.activeReconciliation = null;

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -1,18 +1,19 @@
 import {
-  ConversationOwnedElsewhereError,
-  createChildSpan,
-  createLogger,
-  ErrorCode,
-  extractTraceId,
-  generateTraceId,
-  generateWorkerToken,
-  getTraceparent,
-  type GuardrailRegistry,
-  type MessagePayload,
-  OrchestratorError,
-  retryWithBackoff,
-  runGuardrailInstances,
-  SpanStatusCode,
+	ConversationOwnedElsewhereError,
+	createChildSpan,
+	createLogger,
+	ErrorCode,
+	extractTraceId,
+	generateTraceId,
+	generateWorkerToken,
+	getErrorMessage,
+	getTraceparent,
+	type GuardrailRegistry,
+	type MessagePayload,
+	OrchestratorError,
+	retryWithBackoff,
+	runGuardrailInstances,
+	SpanStatusCode,
 } from "@lobu/core";
 import { resolveAgentGuardrails } from "../guardrails/aggregator.js";
 import * as Sentry from "@sentry/node";
@@ -227,7 +228,7 @@ export class MessageConsumer {
     } catch (error) {
       throw new OrchestratorError(
         ErrorCode.QUEUE_JOB_PROCESSING_FAILED,
-        `Failed to start queue consumer: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to start queue consumer: ${getErrorMessage(error)}`,
         { error },
         true
       );
@@ -440,7 +441,7 @@ export class MessageConsumer {
           logger.warn(
             {
               agentId: data.agentId,
-              err: err instanceof Error ? err.message : String(err),
+              err: getErrorMessage(err),
             },
             "Input guardrail check failed — proceeding without guardrails"
           );
@@ -566,7 +567,7 @@ export class MessageConsumer {
         logger.error(
           {
             traceId,
-            error: bgError instanceof Error ? bgError.message : String(bgError),
+            error: getErrorMessage(bgError),
             stack: bgError instanceof Error ? bgError.stack : undefined,
             deploymentName,
             userId: data.userId,
@@ -590,7 +591,7 @@ export class MessageConsumer {
     } catch (error) {
       queueSpan?.setStatus({
         code: SpanStatusCode.ERROR,
-        message: error instanceof Error ? error.message : String(error),
+        message: getErrorMessage(error),
       });
       queueSpan?.end();
       Sentry.captureException(error);
@@ -599,7 +600,7 @@ export class MessageConsumer {
       // Re-throw for queue retry handling
       throw new OrchestratorError(
         ErrorCode.QUEUE_JOB_PROCESSING_FAILED,
-        `Failed to process message job: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to process message job: ${getErrorMessage(error)}`,
         { jobId, data, error },
         true
       );
@@ -644,7 +645,7 @@ export class MessageConsumer {
       logger.error(`❌ [ERROR] sendToWorkerQueue failed:`, error);
       throw new OrchestratorError(
         ErrorCode.QUEUE_JOB_PROCESSING_FAILED,
-        `Failed to send message to thread queue: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to send message to thread queue: ${getErrorMessage(error)}`,
         { deploymentName, data, error },
         true
       );
@@ -844,7 +845,7 @@ export class MessageConsumer {
           deploymentName,
           userId: data.userId,
           conversationId: data.conversationId,
-          error: error instanceof Error ? error.message : String(error),
+          error: getErrorMessage(error),
           stack: error instanceof Error ? error.stack : undefined,
           queueName: `thread_message_${deploymentName}`,
         },
@@ -891,7 +892,7 @@ export class MessageConsumer {
       logger.error("Failed to get queue stats:", error);
       return {
         isRunning: this.isRunning,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
       };
     }
   }

--- a/packages/server/src/gateway/orchestration/turn-liveness.ts
+++ b/packages/server/src/gateway/orchestration/turn-liveness.ts
@@ -39,7 +39,10 @@
  * that holds the client's SSE.
  */
 
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import { intervals } from "../../config/intervals.js";
 import { getDb, type DbClient } from "../../db/client.js";
 import type { IMessageQueue } from "../infrastructure/queue/index.js";
@@ -160,7 +163,7 @@ export async function extendTurnDeadlines(
         deploymentName,
         deadlineMs,
         queue: TURN_TIMEOUT_QUEUE,
-        err: err instanceof Error ? err.message : String(err),
+        err: getErrorMessage(err),
       },
       "Failed to extend turn-timeout deadline — in-flight turns for this deployment may be falsely failed by the sweep if extends keep failing"
     );

--- a/packages/server/src/gateway/permissions/grant-store.ts
+++ b/packages/server/src/gateway/permissions/grant-store.ts
@@ -6,7 +6,11 @@ import {
   type GrantKind,
 } from "@lobu/core";
 import { getDb, pgTextArray } from "../../db/client.js";
-import { tryGetOrgId } from "../../lobu/stores/org-context.js";
+import {
+  orgScope,
+  requireOrgId,
+  resolveOrgId,
+} from "../../lobu/stores/org-context.js";
 
 const logger = createLogger("grant-store");
 
@@ -57,17 +61,6 @@ function buildGrantCandidates(pattern: string, kind: GrantKind): string[] {
   return candidates;
 }
 
-/**
- * Optional `organization_id` filter as a composable SQL fragment, so the
- * org-scoped and legacy (org-less) query variants share a single statement.
- */
-function orgScope(
-  sql: ReturnType<typeof getDb>,
-  orgId: string | null | undefined
-) {
-  return orgId ? sql`AND organization_id = ${orgId}` : sql``;
-}
-
 interface GrantRow {
   pattern: string;
   kind: GrantKind;
@@ -104,12 +97,7 @@ export class GrantStore {
     pattern = normalizeDomainPattern(pattern);
     const kind = inferGrantKind(pattern);
     const expiresAtTs = expiresAt === null ? null : new Date(expiresAt);
-    const orgId = organizationId ?? tryGetOrgId();
-    if (!orgId) {
-      throw new Error(
-        "GrantStore.grant requires organizationId (explicit or via orgContext)"
-      );
-    }
+    const orgId = requireOrgId(organizationId, "GrantStore.grant");
 
     const sql = getDb();
     await sql`
@@ -135,7 +123,7 @@ export class GrantStore {
   ): Promise<boolean> {
     pattern = normalizeDomainPattern(pattern);
     const kind = inferGrantKind(pattern);
-    const orgId = organizationId ?? tryGetOrgId();
+    const orgId = resolveOrgId(organizationId);
 
     // Build the candidate pattern set (exact + wildcards) and look them
     // up in a single query.
@@ -183,7 +171,7 @@ export class GrantStore {
     pattern = normalizeDomainPattern(pattern);
     const kind = inferGrantKind(pattern);
     const candidates = buildGrantCandidates(pattern, kind);
-    const orgId = organizationId ?? tryGetOrgId();
+    const orgId = resolveOrgId(organizationId);
 
     const sql = getDb();
     try {
@@ -214,7 +202,7 @@ export class GrantStore {
    */
   async listGrants(agentId: string, organizationId?: string): Promise<Grant[]> {
     const sql = getDb();
-    const orgId = organizationId ?? tryGetOrgId();
+    const orgId = resolveOrgId(organizationId);
     try {
       const rows = await sql<GrantRow>`
         SELECT pattern, kind, granted_at, expires_at, denied
@@ -248,7 +236,7 @@ export class GrantStore {
   ): Promise<void> {
     const candidates = getDomainGrantCandidates(pattern);
     const kind = inferGrantKind(pattern);
-    const orgId = organizationId ?? tryGetOrgId();
+    const orgId = resolveOrgId(organizationId);
     const sql = getDb();
     await sql`
       DELETE FROM grants

--- a/packages/server/src/gateway/proxy/egress-judge/anthropic-client.ts
+++ b/packages/server/src/gateway/proxy/egress-judge/anthropic-client.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { JudgeClient, JudgeVerdict } from "./types.js";
+import { getErrorMessage } from "@lobu/core";
 
 /**
  * Anthropic-backed judge transport. Calls the Messages API and parses the
@@ -71,7 +72,7 @@ export function parseVerdict(raw: string): JudgeVerdict {
     }
   }
   throw new Error(
-    `Judge response was not valid verdict JSON: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`
+    `Judge response was not valid verdict JSON: ${getErrorMessage(lastErr)}`
   );
 }
 

--- a/packages/server/src/gateway/proxy/egress-judge/judge-runner.ts
+++ b/packages/server/src/gateway/proxy/egress-judge/judge-runner.ts
@@ -1,4 +1,7 @@
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import { AnthropicJudgeClient } from "./anthropic-client.js";
 import { VerdictCache } from "./cache.js";
 import { CircuitBreaker } from "./circuit-breaker.js";
@@ -196,7 +199,7 @@ export abstract class JudgeRunner<TResult> {
           ...input.logFields,
           model,
           timeoutMs: timedOut ? this.judgeTimeoutMs : undefined,
-          error: err instanceof Error ? err.message : String(err),
+          error: getErrorMessage(err),
         }
       );
       return input.decorate(

--- a/packages/server/src/gateway/proxy/http-proxy.ts
+++ b/packages/server/src/gateway/proxy/http-proxy.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import type { LookupAddress } from "node:dns";
 import * as dns from "node:dns/promises";
 import * as http from "node:http";
@@ -6,6 +5,7 @@ import * as net from "node:net";
 import { domainToASCII } from "node:url";
 import type { WorkerTokenData } from "@lobu/core";
 import { createLogger, verifyWorkerToken } from "@lobu/core";
+import { constantTimeEqual } from "../../utils/constant-time-equal.js";
 import {
   isUnrestrictedMode,
   loadAllowedDomains,
@@ -419,12 +419,10 @@ async function validateProxyAuth(
     void store.isRevoked(tokenData.jti).catch(() => {});
   }
 
-  const deploymentMatch =
-    tokenData.deploymentName.length === creds.deploymentName.length &&
-    crypto.timingSafeEqual(
-      Buffer.from(tokenData.deploymentName),
-      Buffer.from(creds.deploymentName)
-    );
+  const deploymentMatch = constantTimeEqual(
+    tokenData.deploymentName,
+    creds.deploymentName
+  );
   if (!deploymentMatch) {
     logger.warn(
       `Proxy auth failed: deployment mismatch (claimed: ${creds.deploymentName}, token: ${tokenData.deploymentName})`

--- a/packages/server/src/gateway/routes/internal/device-auth.ts
+++ b/packages/server/src/gateway/routes/internal/device-auth.ts
@@ -1,4 +1,9 @@
-import { createLogger, type McpOAuthConfig, type SecretRef } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+	type McpOAuthConfig,
+	type SecretRef,
+} from "@lobu/core";
 import { Hono } from "hono";
 import { DEFAULT_MCP_DEVICE_SCOPE } from "../../../auth/oauth/scopes.js";
 import {
@@ -95,7 +100,7 @@ async function getSecretJson<T>(
     logger.warn("Failed to parse JSON payload from secret store", {
       name,
       ...context,
-      error: error instanceof Error ? error.message : String(error),
+      error: getErrorMessage(error),
     });
     return null;
   }
@@ -446,7 +451,7 @@ export async function tryCompletePendingDeviceAuth(
   } catch (error) {
     logger.warn("Auto-complete device auth failed", {
       mcpId,
-      error: error instanceof Error ? error.message : String(error),
+      error: getErrorMessage(error),
     });
     return null;
   }
@@ -660,7 +665,7 @@ export function createDeviceAuthRoutes(
     } catch (error) {
       logger.error("Failed to start device auth", {
         mcpId,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
         stack: error instanceof Error ? error.stack : undefined,
       });
       return errorResponse(c, "Failed to start device authentication", 500);

--- a/packages/server/src/gateway/routes/internal/files.ts
+++ b/packages/server/src/gateway/routes/internal/files.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env bun
 
 import { Readable } from "node:stream";
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import { Hono } from "hono";
 import type { ArtifactStore } from "../../files/artifact-store.js";
 import type { PlatformRegistry } from "../../platform.js";
@@ -172,7 +175,7 @@ export function createFileRoutes(
       });
     } catch (error) {
       logger.error("Failed to upload file", {
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
         stack: error instanceof Error ? error.stack : undefined,
       });
       return errorResponse(c, "Failed to upload file", 500);
@@ -281,7 +284,7 @@ export function createFileRoutes(
       return c.json({ results });
     } catch (error) {
       logger.error("Failed to batch upload files", {
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
         stack: error instanceof Error ? error.stack : undefined,
       });
       return errorResponse(c, "Failed to batch upload files", 500);

--- a/packages/server/src/gateway/routes/internal/history.ts
+++ b/packages/server/src/gateway/routes/internal/history.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env bun
 
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import { Hono } from "hono";
 import { platformRegistry } from "../../platform.js";
 import { errorResponse, getVerifiedWorker } from "../shared/helpers.js";
@@ -66,7 +69,7 @@ export function createHistoryRoutes(): Hono<WorkerContext> {
       });
     } catch (error) {
       logger.error(
-        `Failed to fetch history: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to fetch history: ${getErrorMessage(error)}`
       );
       return errorResponse(c, "Internal server error", 500);
     }

--- a/packages/server/src/gateway/routes/internal/interactions.ts
+++ b/packages/server/src/gateway/routes/internal/interactions.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env bun
 
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import { Hono } from "hono";
 import type { InteractionService } from "../../interactions.js";
 import { errorResponse, getVerifiedWorker } from "../shared/helpers.js";
@@ -109,7 +112,7 @@ export function createInteractionRoutes(
         // convention so the real cause (e.g. assertRoutableInteraction's
         // "connectionId is required") is visible.
         logger.error("Failed to post question", {
-          error: error instanceof Error ? error.message : String(error),
+          error: getErrorMessage(error),
           stack: error instanceof Error ? error.stack : undefined,
         });
         return errorResponse(c, "Failed to post question", 500);
@@ -142,7 +145,7 @@ export function createInteractionRoutes(
       return c.json({ success: true });
     } catch (error) {
       logger.error("Failed to send suggestions", {
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
         stack: error instanceof Error ? error.stack : undefined,
       });
       return errorResponse(c, "Failed to send suggestions", 500);

--- a/packages/server/src/gateway/routes/internal/smoke.ts
+++ b/packages/server/src/gateway/routes/internal/smoke.ts
@@ -70,25 +70,19 @@
  * window.
  */
 
-import { timingSafeEqual } from "node:crypto";
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import { Hono } from "hono";
 import { getDb } from "../../../db/client.js";
+import { constantTimeEqual } from "../../../utils/constant-time-equal.js";
 
 const logger = createLogger("smoke-dispatch");
 
 interface SmokeDispatchBody {
   conversationId?: string;
   messageText?: string;
-}
-
-function compareTokens(provided: string, expected: string): boolean {
-  if (provided.length !== expected.length) return false;
-  try {
-    return timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
-  } catch {
-    return false;
-  }
 }
 
 /**
@@ -170,7 +164,7 @@ export function createSmokeRoutes(): Hono {
       return c.json({ error: "Missing bearer token" }, 401);
     }
     const provided = auth.substring(7);
-    if (!compareTokens(provided, expected)) {
+    if (!constantTimeEqual(provided, expected)) {
       return c.json({ error: "Invalid smoke token" }, 401);
     }
 
@@ -306,7 +300,7 @@ export function createSmokeRoutes(): Hono {
         await sql`SELECT pg_notify('runs_lobu:messages', 'chat_message')`;
       } catch (err) {
         logger.warn(
-          `pg_notify after smoke dispatch failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+          `pg_notify after smoke dispatch failed (non-fatal): ${getErrorMessage(err)}`
         );
       }
 
@@ -316,7 +310,7 @@ export function createSmokeRoutes(): Hono {
       return c.json({ runId, idempotencyKey });
     } catch (err) {
       logger.error(
-        `Smoke dispatch INSERT failed: ${err instanceof Error ? err.message : String(err)}`
+        `Smoke dispatch INSERT failed: ${getErrorMessage(err)}`
       );
       return c.json({ error: "Internal error" }, 500);
     }

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -36,7 +36,10 @@
  */
 
 import { Hono } from "hono";
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import { getDb } from "../../../db/client.js";
 import {
 	ConnectionSlugConflictError,
@@ -566,7 +569,7 @@ async function defaultFetchInstallationRepositories(
 			);
 		} catch (error) {
 			logger.warn(
-				{ error: error instanceof Error ? error.message : String(error), page },
+				{ error: getErrorMessage(error), page },
 				"GitHub /installation/repositories request failed during auto-provision",
 			);
 			return repos;
@@ -672,7 +675,7 @@ export async function autoProvisionGithubIssueFeeds(params: {
 			{
 				install_id: params.installId,
 				connection_id: params.connectionId,
-				error: error instanceof Error ? error.message : String(error),
+				error: getErrorMessage(error),
 			},
 			"Auto-provision skipped: could not mint installation token",
 		);
@@ -750,7 +753,7 @@ export async function autoProvisionGithubIssueFeeds(params: {
 				{
 					feed_id: feedId,
 					connection_id: params.connectionId,
-					error: error instanceof Error ? error.message : String(error),
+					error: getErrorMessage(error),
 				},
 				"Auto-provision: failed to enqueue initial backfill (feed is due, orchestrator will pick it up)",
 			);
@@ -1433,7 +1436,7 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 						organization_id: orgId,
 						install_id: result.installId,
 						connection_id: result.connectionId,
-						error: error instanceof Error ? error.message : String(error),
+						error: getErrorMessage(error),
 					},
 					"GitHub App install bound, but auto-provision failed (feeds can be added manually)",
 				);
@@ -1454,7 +1457,7 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				{
 					organization_id: orgId,
 					installation_id: installationId,
-					error: error instanceof Error ? error.message : String(error),
+					error: getErrorMessage(error),
 				},
 				"GitHub App install callback failed",
 			);

--- a/packages/server/src/gateway/routes/public/mcp-oauth.ts
+++ b/packages/server/src/gateway/routes/public/mcp-oauth.ts
@@ -7,7 +7,10 @@
  * stored PKCE verifier, and render a simple "you can close this tab" page.
  */
 
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import { Hono } from "hono";
 import { completeAuthCodeFlow } from "../../auth/mcp/oauth-flow.js";
 import { postOAuthCompletionPrompt } from "../../auth/mcp/resume-after-oauth.js";
@@ -152,7 +155,7 @@ export function createMcpOAuthRoutes(config: McpOAuthRoutesConfig): Hono {
           logger.warn("Failed to enqueue OAuth resume prompt", {
             mcpId: result.mcpId,
             agentId: result.agentId,
-            error: err instanceof Error ? err.message : String(err),
+            error: getErrorMessage(err),
           });
         }
       }
@@ -171,7 +174,7 @@ export function createMcpOAuthRoutes(config: McpOAuthRoutesConfig): Hono {
       );
     } catch (err) {
       logger.error("Failed to complete MCP OAuth flow", {
-        error: err instanceof Error ? err.message : String(err),
+        error: getErrorMessage(err),
       });
       const safeMessage = escapeHtml(
         err instanceof Error ? err.message : "Unknown error"

--- a/packages/server/src/gateway/secrets/index.ts
+++ b/packages/server/src/gateway/secrets/index.ts
@@ -4,12 +4,13 @@ import {
   SecretsManagerClient,
 } from "@aws-sdk/client-secrets-manager";
 import {
-  createBuiltinSecretRef,
-  createLogger,
-  isSecretRef,
-  parseSecretRef,
-  type SecretRef,
-  safeJsonParse,
+	parseSecretRef,
+	createBuiltinSecretRef,
+	createLogger,
+	getErrorMessage,
+	isSecretRef,
+	safeJsonParse,
+	type SecretRef,
 } from "@lobu/core";
 import { tryGetOrgId } from "../../lobu/stores/org-context.js";
 
@@ -97,7 +98,7 @@ export class AwsSecretsManagerSecretStore implements SecretStore {
       logger.warn(
         {
           ref,
-          error: error instanceof Error ? error.message : String(error),
+          error: getErrorMessage(error),
         },
         "AWS Secrets Manager get failed"
       );
@@ -333,7 +334,7 @@ export class SecretStoreRegistry implements WritableSecretStore {
         logger.warn(
           {
             scheme,
-            error: error instanceof Error ? error.message : String(error),
+            error: getErrorMessage(error),
           },
           "list() failed for writable backend"
         );

--- a/packages/server/src/gateway/services/bedrock-model-catalog.ts
+++ b/packages/server/src/gateway/services/bedrock-model-catalog.ts
@@ -6,7 +6,10 @@ import {
   type FoundationModelSummary,
 } from "@aws-sdk/client-bedrock";
 import { getModels, type Model } from "@mariozechner/pi-ai";
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 
 const logger = createLogger("bedrock-model-catalog");
 
@@ -187,7 +190,7 @@ export class BedrockModelCatalog {
     } catch (error) {
       logger.warn(
         {
-          error: error instanceof Error ? error.message : String(error),
+          error: getErrorMessage(error),
         },
         "Falling back to static Bedrock model registry"
       );

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -5,6 +5,7 @@ import {
 	type AgentConnectionStore,
 	CommandRegistry,
 	createLogger,
+	getErrorMessage,
 	GuardrailRegistry,
 	moduleRegistry,
 	type ProviderRegistryEntry,
@@ -299,7 +300,7 @@ export class CoreServices {
 			}
 		} catch (error) {
 			logger.warn(
-				{ error: error instanceof Error ? error.message : String(error) },
+				{ error: getErrorMessage(error) },
 				"Ephemeral table sweeper failed",
 			);
 		}

--- a/packages/server/src/gateway/services/image-generation-service.ts
+++ b/packages/server/src/gateway/services/image-generation-service.ts
@@ -1,5 +1,8 @@
 import type { AuthProfile } from "@lobu/core";
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import type { AuthProfilesManager } from "../auth/settings/auth-profiles-manager.js";
 
 const logger = createLogger("image-generation-service");
@@ -187,7 +190,7 @@ export class ImageGenerationService {
       };
     } catch (error) {
       const errorMessage =
-        error instanceof Error ? error.message : String(error);
+        getErrorMessage(error);
       logger.error("Image generation failed", {
         agentId,
         provider: config.provider,

--- a/packages/server/src/gateway/services/transcription-service.ts
+++ b/packages/server/src/gateway/services/transcription-service.ts
@@ -12,7 +12,10 @@
  */
 
 import type { ProviderConfigEntry } from "@lobu/core";
-import { createLogger } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import type { AuthProfilesManager } from "../auth/settings/auth-profiles-manager.js";
 
 const logger = createLogger("transcription-service");
@@ -160,7 +163,7 @@ export class TranscriptionService {
         return { text, provider: config.provider };
       } catch (error) {
         const errorMessage =
-          error instanceof Error ? error.message : String(error);
+          getErrorMessage(error);
         logger.error("Transcription failed", {
           agentId,
           provider: config.provider,
@@ -246,7 +249,7 @@ export class TranscriptionService {
       providerConfigs = await this.providerConfigSource();
     } catch (error) {
       logger.warn("Failed to load provider configs for STT", {
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
       });
       return [];
     }
@@ -337,7 +340,7 @@ export class TranscriptionService {
       return { ...result, provider: config.provider };
     } catch (error) {
       const errorMessage =
-        error instanceof Error ? error.message : String(error);
+        getErrorMessage(error);
       logger.error("Synthesis failed", {
         agentId,
         provider: config.provider,

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -39,6 +39,7 @@ import {
 	createPostgresAgentConfigStore,
 	createPostgresAgentConnectionStore,
 } from "./stores/postgres-stores";
+import { getErrorMessage } from "@lobu/core";
 
 // Cache of (userId → orgId) lookups. Keyed by userId; users only see their
 // own row swap when they leave/join orgs, which doesn't happen often. The
@@ -74,7 +75,7 @@ async function resolveDefaultOrgId(userId: string): Promise<string | null> {
 		// The DB may not be reachable yet at request time (e.g. boot races).
 		// Do not cache that transient miss; callers decide how to surface it.
 		logger.warn(
-			{ err: err instanceof Error ? err.message : String(err) },
+			{ err: getErrorMessage(err) },
 			"[Lobu] resolveDefaultOrgId: lookup failed",
 		);
 		throw err;

--- a/packages/server/src/lobu/stores/app-installation-store.ts
+++ b/packages/server/src/lobu/stores/app-installation-store.ts
@@ -1,4 +1,4 @@
-import { getDb } from "../../db/client.js";
+import { getDb, tsTime } from "../../db/client.js";
 
 /** Advisory-lock tag that serializes activation for one tenant tuple. */
 function activeTenantLockTag(key: AppInstallationTenantKey): string {
@@ -170,13 +170,9 @@ function rowToInstallation(row: Record<string, any>): AppInstallationRow {
     status: row.status,
     metadata: row.metadata ?? {},
     createdAt:
-      row.created_at instanceof Date
-        ? row.created_at.getTime()
-        : (row.created_at ?? Date.now()),
+      tsTime(row.created_at),
     updatedAt:
-      row.updated_at instanceof Date
-        ? row.updated_at.getTime()
-        : (row.updated_at ?? Date.now()),
+      tsTime(row.updated_at),
   };
 }
 

--- a/packages/server/src/lobu/stores/org-context.ts
+++ b/packages/server/src/lobu/stores/org-context.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type { getDb } from '../../db/client';
 
 interface OrgContext {
   organizationId: string;
@@ -15,4 +16,39 @@ export function getOrgId(): string {
 
 export function tryGetOrgId(): string | null {
   return orgContext.getStore()?.organizationId ?? null;
+}
+
+/**
+ * Resolve the org id from an explicit argument, falling back to the ambient
+ * request context. Returns null when neither is available.
+ *
+ * Replaces the `organizationId ?? tryGetOrgId()` idiom: an explicit org always
+ * wins (callers with their own scope, e.g. a worker token), otherwise the
+ * AsyncLocalStorage context set by request middleware applies.
+ */
+export function resolveOrgId(explicit?: string | null): string | null {
+  return explicit ?? tryGetOrgId();
+}
+
+/**
+ * Like {@link resolveOrgId} but throws when no org can be resolved — for store
+ * methods that cannot run unscoped. `caller` names the method in the error so a
+ * missing-context bug points at its source (e.g. "GrantStore.grant requires
+ * organizationId (explicit or via orgContext)").
+ */
+export function requireOrgId(explicit: string | null | undefined, caller: string): string {
+  const orgId = resolveOrgId(explicit);
+  if (!orgId) {
+    throw new Error(`${caller} requires organizationId (explicit or via orgContext)`);
+  }
+  return orgId;
+}
+
+/**
+ * Optional `organization_id` filter as a composable SQL fragment, so the
+ * org-scoped and legacy (org-less) query variants share a single statement.
+ * Returns an empty fragment when `orgId` is null/undefined.
+ */
+export function orgScope(sql: ReturnType<typeof getDb>, orgId: string | null | undefined) {
+  return orgId ? sql`AND organization_id = ${orgId}` : sql``;
 }

--- a/packages/server/src/lobu/stores/postgres-secret-store.ts
+++ b/packages/server/src/lobu/stores/postgres-secret-store.ts
@@ -22,10 +22,11 @@ import {
   parseSecretRef,
   type SecretRef,
 } from '@lobu/core';
-import { getDb } from '../../db/client';
+import { getDb, tsTime } from '../../db/client';
 import type { WritableSecretStore } from '../../gateway/secrets/index';
 import logger from '../../utils/logger';
 import { tryGetOrgId } from './org-context';
+import { getErrorMessage } from "@lobu/core";
 
 const GLOBAL_ORG_ID = '';
 
@@ -115,7 +116,7 @@ export class PostgresSecretStore implements WritableSecretStore {
       return decrypt(ciphertext);
     } catch (error) {
       logger.warn(
-        { ref, error: error instanceof Error ? error.message : String(error) },
+        { ref, error: getErrorMessage(error) },
         '[secret-store] Failed to decrypt stored secret'
       );
       return null;
@@ -199,7 +200,7 @@ export class PostgresSecretStore implements WritableSecretStore {
       ref: createBuiltinSecretRef(encodeURIComponent(row.name)),
       backend: BACKEND_NAME,
       name: row.name,
-      updatedAt: row.updated_at instanceof Date ? row.updated_at.getTime() : Date.now(),
+      updatedAt: tsTime(row.updated_at),
     }));
   }
 }

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -6,7 +6,7 @@ import type {
 	ChannelBinding,
 	StoredConnection,
 } from "@lobu/core";
-import { getDb } from "../../db/client";
+import { getDb, tsTime, tsTimeOrNull } from "../../db/client";
 import { recordLifecycleEvent } from "../../utils/insert-event";
 import { getOrgId, tryGetOrgId } from "./org-context";
 
@@ -64,9 +64,7 @@ function rowToSettings(row: Record<string, any>): AgentSettings {
 		preApprovedTools: row.pre_approved_tools ?? undefined,
 		guardrails: row.guardrails ?? undefined,
 		updatedAt:
-			row.updated_at instanceof Date
-				? row.updated_at.getTime()
-				: (row.updated_at ?? Date.now()),
+			tsTime(row.updated_at),
 	};
 }
 
@@ -81,13 +79,9 @@ function rowToMetadata(row: Record<string, any>): AgentMetadata {
 		},
 		organizationId: row.organization_id ?? undefined,
 		createdAt:
-			row.created_at instanceof Date
-				? row.created_at.getTime()
-				: (row.created_at ?? Date.now()),
+			tsTime(row.created_at),
 		lastUsedAt:
-			row.last_used_at instanceof Date
-				? row.last_used_at.getTime()
-				: (row.last_used_at ?? undefined),
+			tsTimeOrNull(row.last_used_at),
 	};
 }
 
@@ -114,13 +108,9 @@ function rowToConnection(row: Record<string, any>): StoredConnection {
 		status: row.status,
 		errorMessage: row.error_message ?? undefined,
 		createdAt:
-			row.created_at instanceof Date
-				? row.created_at.getTime()
-				: (row.created_at ?? Date.now()),
+			tsTime(row.created_at),
 		updatedAt:
-			row.updated_at instanceof Date
-				? row.updated_at.getTime()
-				: (row.updated_at ?? Date.now()),
+			tsTime(row.updated_at),
 	};
 }
 
@@ -131,9 +121,7 @@ function rowToChannelBinding(row: Record<string, any>): ChannelBinding {
 		channelId: row.channel_id,
 		teamId: row.team_id ?? undefined,
 		createdAt:
-			row.created_at instanceof Date
-				? row.created_at.getTime()
-				: (row.created_at ?? Date.now()),
+			tsTime(row.created_at),
 	};
 }
 

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -14,7 +14,11 @@
  * the org that calls this provider).
  */
 
-import { createLogger, decrypt } from "@lobu/core";
+import {
+	createLogger,
+	decrypt,
+	getErrorMessage,
+} from "@lobu/core";
 import { getDb } from "../../db/client.js";
 
 const logger = createLogger("provider-secrets");
@@ -52,7 +56,7 @@ export async function readOrgSharedProviderApiKey(
     return decrypt(ciphertext);
   } catch (error) {
     logger.warn(
-      `Failed to decrypt org-shared key for provider ${providerId}: ${error instanceof Error ? error.message : String(error)}`
+      `Failed to decrypt org-shared key for provider ${providerId}: ${getErrorMessage(error)}`
     );
     return null;
   }

--- a/packages/server/src/sentry.ts
+++ b/packages/server/src/sentry.ts
@@ -8,6 +8,7 @@
 import type { Context } from 'hono';
 import * as Sentry from '@sentry/node';
 import { ToolUserError } from './utils/errors';
+import { getErrorMessage } from "@lobu/core";
 
 const SENTRY_CAPTURED_FLAG = 'sentryErrorCaptured';
 
@@ -82,7 +83,7 @@ export async function trackMCPToolCall<T>(
 
         return result;
       } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
+        const errorMessage = getErrorMessage(error);
 
         // 4xx-class outcomes raised by the tool itself (bad path, not found,
         // schema validation) aren't operational errors — annotate the span

--- a/packages/server/src/tools/admin/action-router.ts
+++ b/packages/server/src/tools/admin/action-router.ts
@@ -3,6 +3,7 @@ import { ToolUserError } from '../../utils/errors';
 import logger from '../../utils/logger';
 import { enforceRoleScopeAccess, isSystemContext } from '../access-control';
 import type { ToolContext } from '../registry';
+import { getErrorMessage } from "@lobu/core";
 
 /**
  * Routes admin tool actions to handler functions with standardized error wrapping.
@@ -66,7 +67,7 @@ export async function routeAction<TResult>(
     logger[errorLogLevel(error)](
       {
         error,
-        error_message: error instanceof Error ? error.message : String(error),
+        error_message: getErrorMessage(error),
         error_stack: error instanceof Error ? error.stack : undefined,
       },
       `${toolName} error:`

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -29,6 +29,7 @@ import { resolveUsernames } from '../../utils/resolve-usernames';
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
 import { defineFlatActionTool, flatAction } from './action-tool';
+import { getErrorMessage } from "@lobu/core";
 
 // ============================================
 // Typebox Schema
@@ -480,7 +481,7 @@ async function handleCreateVersion(
         },
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = getErrorMessage(error);
       logger.error(
         { error, classifier_slug: classifier[0].slug },
         'Version upgrade: failed to delete old classifications'
@@ -665,7 +666,7 @@ async function handleSetCurrentVersion(
       },
     };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorMessage = getErrorMessage(error);
     logger.error({ error, classifierSlug }, 'Version change: failed to delete old classifications');
     return {
       success: true,

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -35,6 +35,7 @@ import { resolveUsernames } from '../../../../utils/resolve-usernames';
 import type { ToolContext } from '../../../registry';
 import type { ManageConnectionsResult, ConnectionsArgs } from '../schemas';
 import { resolveDeviceBinding, isManagedPublicOrgConnect } from './device-binding';
+import { getErrorMessage } from "@lobu/core";
 
 export async function handleConnect(
   args: Extract<ConnectionsArgs, { action: 'connect' }>,
@@ -311,7 +312,7 @@ export async function handleConnect(
   try {
     await assertEntityIdsInOrg(sql, organizationId, args.entity_ids);
   } catch (err) {
-    return { error: err instanceof Error ? err.message : String(err), setup_url: setupUrl };
+    return { error: getErrorMessage(err), setup_url: setupUrl };
   }
   const connectEntityIdsValue =
     args.entity_ids && args.entity_ids.length > 0 ? pgBigintArray(args.entity_ids) : null;

--- a/packages/server/src/tools/admin/manage_connections/handlers/connector-management.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connector-management.ts
@@ -24,6 +24,7 @@ import { buildConnectorDefinitionList } from '../../helpers/connector-definition
 import { maybeUpsertAuthAfterInstall, upsertConnectorAuthProfiles } from '../../helpers/connection-helpers';
 import type { ToolContext } from '../../../registry';
 import type { ManageConnectionsResult, ConnectionsArgs } from '../schemas';
+import { getErrorMessage } from "@lobu/core";
 
 // ============================================
 // handleListConnectorDefinitions
@@ -93,7 +94,7 @@ export async function handleInstallConnector(
     };
   } catch (error) {
     return {
-      error: `Install failed: ${error instanceof Error ? error.message : String(error)}`,
+      error: `Install failed: ${getErrorMessage(error)}`,
     };
   }
 }
@@ -115,7 +116,7 @@ export async function handleUninstallConnector(
       return { error: `Connector '${args.connector_key}' not found or already archived` };
     }
   } catch (error) {
-    return { error: error instanceof Error ? error.message : String(error) };
+    return { error: getErrorMessage(error) };
   }
 
   return { action: 'uninstall_connector', uninstalled: true, connector_key: args.connector_key };
@@ -158,7 +159,7 @@ export async function handleToggleConnectorLogin(
       login_enabled: args.enabled,
     };
   } catch (error) {
-    return { error: error instanceof Error ? error.message : String(error) };
+    return { error: getErrorMessage(error) };
   }
 }
 

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -50,6 +50,7 @@ import { resolveDeviceBinding, isManagedPublicOrgConnect } from './device-bindin
 import { assertConnectorAllowedInCloud } from '../../../../utils/connector-cloud-gate';
 import { ensureConnectorInstalled } from '../../../../utils/ensure-connector-installed';
 import { unregisterConnectorWebhook } from '../../../../connect/webhook-registration';
+import { getErrorMessage } from "@lobu/core";
 
 // ============================================
 // handleList
@@ -302,7 +303,7 @@ export async function handleCreate(
   try {
     assertConnectorAllowedInCloud(args.connector_key);
   } catch (err) {
-    return { error: err instanceof Error ? err.message : String(err) };
+    return { error: getErrorMessage(err) };
   }
 
   // Resolve caller role once — we use it for created_by overrides, explicit
@@ -733,7 +734,7 @@ export async function handleCreate(
   try {
     await assertEntityIdsInOrg(sql, organizationId, args.entity_ids);
   } catch (err) {
-    return { error: err instanceof Error ? err.message : String(err) };
+    return { error: getErrorMessage(err) };
   }
   const entityIdsValue =
     args.entity_ids && args.entity_ids.length > 0 ? pgBigintArray(args.entity_ids) : null;
@@ -1097,7 +1098,7 @@ export async function handleUpdate(
     try {
       await assertEntityIdsInOrg(sql, organizationId, args.entity_ids);
     } catch (err) {
-      return { error: err instanceof Error ? err.message : String(err) };
+      return { error: getErrorMessage(err) };
     }
   }
   // Tri-state, mirrors manage_feeds: undefined = leave unchanged (null → COALESCE

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -29,6 +29,7 @@ import { getDefaultSchedule } from './helpers/connection-helpers';
 import { assertEntityIdsInOrg } from './helpers/db-helpers';
 import { resolveFeedDisplayName } from './helpers/feed-helpers';
 import { PaginationFields } from './schemas/common-fields';
+import { getErrorMessage } from "@lobu/core";
 
 // ============================================
 // Schema
@@ -328,7 +329,7 @@ async function handleCreateFeed(
   try {
     await assertEntityIdsInOrg(sql, organizationId, args.entity_ids);
   } catch (err) {
-    return { error: err instanceof Error ? err.message : String(err) };
+    return { error: getErrorMessage(err) };
   }
   const entityIdsValue =
     args.entity_ids && args.entity_ids.length > 0 ? pgBigintArray(args.entity_ids) : null;
@@ -391,7 +392,7 @@ async function handleUpdateFeed(
     try {
       await assertEntityIdsInOrg(sql, organizationId, args.entity_ids);
     } catch (err) {
-      return { error: err instanceof Error ? err.message : String(err) };
+      return { error: getErrorMessage(err) };
     }
   }
   const entityIdsValue =

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -32,6 +32,7 @@ import {
   applyManageAgentsProposal,
 } from './manage_agents';
 import { PaginationFields } from './schemas/common-fields';
+import { getErrorMessage } from "@lobu/core";
 
 const BackendLiteral = Type.Union([
   Type.Literal('local_action'),
@@ -236,7 +237,7 @@ async function executeLocalActionInline(
       (compiledRows[0] as { compiled_code: string | null } | undefined)?.compiled_code ?? null;
     compiledCode = await resolveConnectorCode(connection.connector_key, rawCode);
   } catch (err) {
-    return failRunInline(runId, organizationId, err instanceof Error ? err.message : String(err));
+    return failRunInline(runId, organizationId, getErrorMessage(err));
   }
 
   const { credentials, connectionCredentials, sessionState } = await resolveExecutionAuth({
@@ -308,7 +309,7 @@ async function executeLocalActionInline(
     }
     return completeRunInline(runId, organizationId, result.output);
   } catch (error) {
-    return failRunInline(runId, organizationId, error instanceof Error ? error.message : String(error));
+    return failRunInline(runId, organizationId, getErrorMessage(error));
   }
 }
 
@@ -465,7 +466,7 @@ async function executeHttpOperationInline(
     await sql`UPDATE runs SET status = 'completed', completed_at = NOW(), action_output = ${sql.json(output)} WHERE id = ${runId} AND organization_id = ${organizationId}`;
     return { status: 'completed', output, metadata };
   } catch (error) {
-    return failRunInline(runId, organizationId, error instanceof Error ? error.message : String(error));
+    return failRunInline(runId, organizationId, getErrorMessage(error));
   }
 }
 

--- a/packages/server/src/tools/admin/manage_schedules.ts
+++ b/packages/server/src/tools/admin/manage_schedules.ts
@@ -31,6 +31,7 @@ import {
 import type { ToolContext } from '../registry';
 import logger from '../../utils/logger';
 import { nextRunAt as nextCronTickAt } from '../../utils/cron';
+import { getErrorMessage } from "@lobu/core";
 
 // ============================================
 // Schema
@@ -140,7 +141,7 @@ async function handleCreate(
       nextCronTickAt(args.cron);
     } catch (err) {
       return {
-        error: `cron expression rejected: ${err instanceof Error ? err.message : String(err)}`,
+        error: `cron expression rejected: ${getErrorMessage(err)}`,
       };
     }
   }

--- a/packages/server/src/tools/admin/manage_watchers/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_watchers/complete-window.ts
@@ -24,6 +24,7 @@ import { getNextNumericId } from '../helpers/db-helpers';
 import type { ToolContext } from '../../registry';
 import type { ManageWatchersArgs } from '../manage_watchers';
 import { normalizeExtractedData, parseJson, requireWatcherAccess } from './shared';
+import { getErrorMessage } from "@lobu/core";
 
 // Initialize AJV for JSON Schema validation
 // removeAdditional: true strips fields like 'embedding' that workers add but aren't in the schema
@@ -103,7 +104,7 @@ export async function handleCompleteWindow(
       windowTokens.map((token) => verifyWindowToken(token, env))
     )) as VerifiedWindowToken[];
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error);
+    const errorMsg = getErrorMessage(error);
     // Agent-recoverable validation (the message says how) — ToolUserError so
     // it returns 400 and stays out of the Sentry feed (was LOBU-BACKEND-D).
     throw new ToolUserError(
@@ -734,7 +735,7 @@ export async function handleCompleteWindow(
     }
   } catch (err) {
     reactionStatus = 'failed';
-    reactionError = err instanceof Error ? err.message : String(err);
+    reactionError = getErrorMessage(err);
     logger.warn({ err }, '[manage_watchers] Failed to execute reaction script');
   }
 

--- a/packages/server/src/tools/admin/manage_watchers/crud.ts
+++ b/packages/server/src/tools/admin/manage_watchers/crud.ts
@@ -28,6 +28,7 @@ import {
   summarizeResults,
   type WatcherOperationResult,
 } from './shared';
+import { getErrorMessage } from "@lobu/core";
 
 // ============================================
 // handleCreate
@@ -437,7 +438,7 @@ export async function handleDelete(args: ManageWatchersArgs): Promise<{
       results.push({
         watcher_id: watcherId,
         success: false,
-        message: error instanceof Error ? error.message : String(error),
+        message: getErrorMessage(error),
       });
     }
   }

--- a/packages/server/src/tools/admin/manage_watchers/shared.ts
+++ b/packages/server/src/tools/admin/manage_watchers/shared.ts
@@ -72,7 +72,7 @@ function coerceJson(
       if (opts.onError === 'keep') return value;
       if (opts.onError === 'throw') {
         throw new Error(
-          `${opts.label} must be valid JSON: ${error instanceof Error ? error.message : String(error)}`
+          `${opts.label} must be valid JSON: ${getErrorMessage(error)}`
         );
       }
       if (opts.onError) return opts.onError.fallback;
@@ -308,6 +308,7 @@ export async function requireWatcherAccess(
 // ============================================
 
 import { entityLinkMatchSql } from '../../../utils/content-search';
+import { getErrorMessage } from "@lobu/core";
 
 /**
  * Batch count unanalyzed content for multiple watchers in a single query.

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -18,6 +18,7 @@ import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
 import { SortOrderField } from './schemas/common-fields';
 import { isAdminOrOwnerRole } from '../access-control';
+import { getErrorMessage } from "@lobu/core";
 
 export const QuerySqlSchema = Type.Object({
   sql: Type.String({
@@ -256,7 +257,7 @@ export async function querySqlImpl(
         execution_time_ms: Date.now() - startTime,
       };
     } catch (err) {
-      return errorResult(err instanceof Error ? err.message : String(err), startTime);
+      return errorResult(getErrorMessage(err), startTime);
     }
   }
 
@@ -271,7 +272,7 @@ export async function querySqlImpl(
     scopedSql = scoped.sql;
     params = scoped.params;
   } catch (err) {
-    return errorResult(err instanceof Error ? err.message : String(err), startTime);
+    return errorResult(getErrorMessage(err), startTime);
   }
 
   // Build search WHERE clause
@@ -332,7 +333,7 @@ export async function querySqlImpl(
       execution_time_ms: Date.now() - startTime,
     };
   } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
+    const msg = getErrorMessage(error);
     logger.error({ error }, 'query_sql error');
 
     if (msg.includes('timeout') || msg.includes('statement timeout')) {

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -20,6 +20,7 @@ import { buildEntityUrl, getPublicWebUrl } from '../utils/url-builder';
 import { getWorkspaceProvider } from '../workspace';
 import type { ToolContext } from './registry';
 import { withValidatedArgs } from './validate-args';
+import { getErrorMessage } from "@lobu/core";
 
 // ============================================
 // Typebox Schema
@@ -350,7 +351,7 @@ async function searchImpl(
           agentIdScope
         ).catch((err) => {
           logger.warn(
-            `[search] content search failed: ${err instanceof Error ? err.message : String(err)}`
+            `[search] content search failed: ${getErrorMessage(err)}`
           );
           return [] as ContentSnippet[];
         })

--- a/packages/server/src/utils/__tests__/shared-helpers.test.ts
+++ b/packages/server/src/utils/__tests__/shared-helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { tsTime, tsTimeOrNull } from "../../db/client";
 import {
 	orgContext,
@@ -8,21 +8,21 @@ import {
 import { constantTimeEqual } from "../constant-time-equal";
 
 describe("tsTime", () => {
-	test("coerces a Date to epoch ms", () => {
+	it("coerces a Date to epoch ms", () => {
 		const d = new Date("2026-06-22T00:00:00.000Z");
 		expect(tsTime(d)).toBe(d.getTime());
 	});
 
-	test("passes a number through", () => {
+	it("passes a number through", () => {
 		expect(tsTime(1234567890)).toBe(1234567890);
 	});
 
-	test("parses a timestamp string", () => {
+	it("parses a timestamp string", () => {
 		const s = "2026-06-22T00:00:00.000Z";
 		expect(tsTime(s)).toBe(new Date(s).getTime());
 	});
 
-	test("defaults to now for null/undefined/garbage", () => {
+	it("defaults to now for null/undefined/garbage", () => {
 		const before = Date.now();
 		expect(tsTime(null)).toBeGreaterThanOrEqual(before);
 		expect(tsTime(undefined)).toBeGreaterThanOrEqual(before);
@@ -31,14 +31,14 @@ describe("tsTime", () => {
 });
 
 describe("tsTimeOrNull", () => {
-	test("coerces a Date, passes numbers, parses strings", () => {
+	it("coerces a Date, passes numbers, parses strings", () => {
 		const d = new Date("2026-06-22T00:00:00.000Z");
 		expect(tsTimeOrNull(d)).toBe(d.getTime());
 		expect(tsTimeOrNull(42)).toBe(42);
 		expect(tsTimeOrNull("2026-06-22T00:00:00.000Z")).toBe(d.getTime());
 	});
 
-	test("returns undefined for null/undefined/garbage (not now)", () => {
+	it("returns undefined for null/undefined/garbage (not now)", () => {
 		expect(tsTimeOrNull(null)).toBeUndefined();
 		expect(tsTimeOrNull(undefined)).toBeUndefined();
 		expect(tsTimeOrNull("not a date")).toBeUndefined();
@@ -46,11 +46,11 @@ describe("tsTimeOrNull", () => {
 });
 
 describe("constantTimeEqual", () => {
-	test("true for equal strings", () => {
+	it("true for equal strings", () => {
 		expect(constantTimeEqual("secret-token", "secret-token")).toBe(true);
 	});
 
-	test("false for different values, lengths, or missing inputs", () => {
+	it("false for different values, lengths, or missing inputs", () => {
 		expect(constantTimeEqual("secret-token", "other-token!")).toBe(false);
 		expect(constantTimeEqual("short", "longer-value")).toBe(false);
 		expect(constantTimeEqual(undefined, "x")).toBe(false);
@@ -61,14 +61,14 @@ describe("constantTimeEqual", () => {
 });
 
 describe("resolveOrgId / requireOrgId", () => {
-	test("explicit wins over ambient context", () => {
+	it("explicit wins over ambient context", () => {
 		orgContext.run({ organizationId: "ambient" }, () => {
 			expect(resolveOrgId("explicit")).toBe("explicit");
 			expect(requireOrgId("explicit", "Caller.method")).toBe("explicit");
 		});
 	});
 
-	test("falls back to ambient context when no explicit value", () => {
+	it("falls back to ambient context when no explicit value", () => {
 		orgContext.run({ organizationId: "ambient" }, () => {
 			expect(resolveOrgId()).toBe("ambient");
 			expect(resolveOrgId(null)).toBe("ambient");
@@ -76,11 +76,11 @@ describe("resolveOrgId / requireOrgId", () => {
 		});
 	});
 
-	test("resolveOrgId returns null with no explicit + no context", () => {
+	it("resolveOrgId returns null with no explicit + no context", () => {
 		expect(resolveOrgId()).toBeNull();
 	});
 
-	test("requireOrgId throws a caller-named error with no org", () => {
+	it("requireOrgId throws a caller-named error with no org", () => {
 		expect(() => requireOrgId(undefined, "Caller.method")).toThrow(
 			/Caller\.method requires organizationId/,
 		);

--- a/packages/server/src/utils/__tests__/shared-helpers.test.ts
+++ b/packages/server/src/utils/__tests__/shared-helpers.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { tsTime, tsTimeOrNull } from "../../db/client";
+import {
+	orgContext,
+	requireOrgId,
+	resolveOrgId,
+} from "../../lobu/stores/org-context";
+import { constantTimeEqual } from "../constant-time-equal";
+
+describe("tsTime", () => {
+	test("coerces a Date to epoch ms", () => {
+		const d = new Date("2026-06-22T00:00:00.000Z");
+		expect(tsTime(d)).toBe(d.getTime());
+	});
+
+	test("passes a number through", () => {
+		expect(tsTime(1234567890)).toBe(1234567890);
+	});
+
+	test("parses a timestamp string", () => {
+		const s = "2026-06-22T00:00:00.000Z";
+		expect(tsTime(s)).toBe(new Date(s).getTime());
+	});
+
+	test("defaults to now for null/undefined/garbage", () => {
+		const before = Date.now();
+		expect(tsTime(null)).toBeGreaterThanOrEqual(before);
+		expect(tsTime(undefined)).toBeGreaterThanOrEqual(before);
+		expect(tsTime("not a date")).toBeGreaterThanOrEqual(before);
+	});
+});
+
+describe("tsTimeOrNull", () => {
+	test("coerces a Date, passes numbers, parses strings", () => {
+		const d = new Date("2026-06-22T00:00:00.000Z");
+		expect(tsTimeOrNull(d)).toBe(d.getTime());
+		expect(tsTimeOrNull(42)).toBe(42);
+		expect(tsTimeOrNull("2026-06-22T00:00:00.000Z")).toBe(d.getTime());
+	});
+
+	test("returns undefined for null/undefined/garbage (not now)", () => {
+		expect(tsTimeOrNull(null)).toBeUndefined();
+		expect(tsTimeOrNull(undefined)).toBeUndefined();
+		expect(tsTimeOrNull("not a date")).toBeUndefined();
+	});
+});
+
+describe("constantTimeEqual", () => {
+	test("true for equal strings", () => {
+		expect(constantTimeEqual("secret-token", "secret-token")).toBe(true);
+	});
+
+	test("false for different values, lengths, or missing inputs", () => {
+		expect(constantTimeEqual("secret-token", "other-token!")).toBe(false);
+		expect(constantTimeEqual("short", "longer-value")).toBe(false);
+		expect(constantTimeEqual(undefined, "x")).toBe(false);
+		expect(constantTimeEqual("x", undefined)).toBe(false);
+		expect(constantTimeEqual(undefined, undefined)).toBe(false);
+		expect(constantTimeEqual("", "")).toBe(false);
+	});
+});
+
+describe("resolveOrgId / requireOrgId", () => {
+	test("explicit wins over ambient context", () => {
+		orgContext.run({ organizationId: "ambient" }, () => {
+			expect(resolveOrgId("explicit")).toBe("explicit");
+			expect(requireOrgId("explicit", "Caller.method")).toBe("explicit");
+		});
+	});
+
+	test("falls back to ambient context when no explicit value", () => {
+		orgContext.run({ organizationId: "ambient" }, () => {
+			expect(resolveOrgId()).toBe("ambient");
+			expect(resolveOrgId(null)).toBe("ambient");
+			expect(requireOrgId(undefined, "Caller.method")).toBe("ambient");
+		});
+	});
+
+	test("resolveOrgId returns null with no explicit + no context", () => {
+		expect(resolveOrgId()).toBeNull();
+	});
+
+	test("requireOrgId throws a caller-named error with no org", () => {
+		expect(() => requireOrgId(undefined, "Caller.method")).toThrow(
+			/Caller\.method requires organizationId/,
+		);
+	});
+});

--- a/packages/server/src/utils/compiler-core.ts
+++ b/packages/server/src/utils/compiler-core.ts
@@ -21,6 +21,7 @@ import { basename, dirname, join } from 'node:path';
 import { EXTERNAL_RUNTIME_DEPS } from '@lobu/connector-worker/compile';
 import { type BuildOptions, build } from 'esbuild';
 import logger from './logger';
+import { getErrorMessage } from "@lobu/core";
 
 const require = createRequire(import.meta.url);
 const SDK_ENTRY = require.resolve('@lobu/connector-sdk');
@@ -133,7 +134,7 @@ export async function compileSource(
       try {
         await build(buildOptions);
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = getErrorMessage(error);
         if (message.includes('The service is no longer running')) {
           logger.warn(`[${config.label}] esbuild service stopped unexpectedly; retrying once...`);
           await build(buildOptions);

--- a/packages/server/src/utils/connector-catalog.ts
+++ b/packages/server/src/utils/connector-catalog.ts
@@ -10,6 +10,7 @@ import { isCloudMode } from './cloud-mode';
 import { CLOUD_RESTRICTED_CONNECTOR_KEYS } from './connector-cloud-gate';
 import { extractConnectorMetadata } from './connector-compiler';
 import logger from './logger';
+import { getErrorMessage } from "@lobu/core";
 
 const DEFAULT_CONNECTOR_DIR_CANDIDATES = [
   // Published CLI runtime: packages/cli/scripts/build.cjs copies bundled
@@ -228,7 +229,7 @@ async function extractConnectorCatalogMetadata(
     return value;
   } catch (error) {
     logger.warn(
-      { file_path: filePath, error: error instanceof Error ? error.message : String(error) },
+      { file_path: filePath, error: getErrorMessage(error) },
       'Skipping connector catalog entry after metadata extraction failed'
     );
     metadataCache.set(filePath, { mtimeMs: fileStat.mtimeMs, value: null });
@@ -298,7 +299,7 @@ async function loadCatalogManifest(dirPath: string): Promise<CatalogManifest['en
     logger.warn(
       {
         manifest_path: manifestPath,
-        error: error instanceof Error ? error.message : String(error),
+        error: getErrorMessage(error),
       },
       'Ignoring unreadable connector catalog manifest; falling back to on-demand compilation'
     );

--- a/packages/server/src/utils/constant-time-equal.ts
+++ b/packages/server/src/utils/constant-time-equal.ts
@@ -1,0 +1,30 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Constant-time string equality for secrets (bearer tokens, deployment names,
+ * token digests). A naive `===` short-circuits on the first differing byte,
+ * leaking the secret's length and matching prefix through response timing.
+ *
+ * - A missing `a` or `b` is rejected — secret comparisons are opt-in, never
+ *   satisfied by an unconfigured/absent value.
+ * - A length mismatch returns false WITHOUT calling `timingSafeEqual` (which
+ *   throws on unequal-length buffers). This does reveal length inequality, which
+ *   is acceptable: the inputs that gate real secrets are either fixed-length
+ *   digests or fixed-length tokens. When comparing variable-length inputs whose
+ *   length must stay secret, hash both to a fixed-length digest first and pass
+ *   the digests here.
+ */
+export function constantTimeEqual(
+  a: string | undefined | null,
+  b: string | undefined | null,
+): boolean {
+  if (!a || !b) return false;
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  try {
+    return timingSafeEqual(bufA, bufB);
+  } catch {
+    return false;
+  }
+}

--- a/packages/server/src/utils/content-search/search-path.ts
+++ b/packages/server/src/utils/content-search/search-path.ts
@@ -31,6 +31,7 @@ import {
   type ContentSearchResult,
 } from './types';
 import { buildConnectionVisibilityClause, buildExcludeWatcherClause, buildOrgScopeWhere } from './visibility';
+import { getErrorMessage } from "@lobu/core";
 
 export async function searchContentBySingleQuery(
   sql: DbClient,
@@ -56,7 +57,7 @@ export async function searchContentBySingleQuery(
       queryEmbedding = embeddings[0] ?? null;
     } catch (err) {
       logger.warn(
-        { err: err instanceof Error ? err.message : String(err) },
+        { err: getErrorMessage(err) },
         '[content-search] Embedding generation failed, falling back to text-only search'
       );
     }
@@ -481,7 +482,7 @@ export async function searchContentBySingleQuery(
       })) as any[];
     } catch (err) {
       logger.warn(
-        { err: err instanceof Error ? err.message : String(err) },
+        { err: getErrorMessage(err) },
         '[content-search] candidate query failed; returning empty content'
       );
       rawRows = [];

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -26,6 +26,7 @@ import {
   SAFE_COLUMN_DEFS,
   validateTableQuery,
 } from './table-schema';
+import { getErrorMessage } from "@lobu/core";
 
 /** A named SQL data source: { name, query } or keyed as Record<string, { query }> */
 export type DataSourceInput =
@@ -668,7 +669,7 @@ export function validateDataSourceQuery(name: string, query: string, parse = fal
         );
       }
     } catch (err) {
-      throw new Error(`Data source '${name}': ${err instanceof Error ? err.message : String(err)}`);
+      throw new Error(`Data source '${name}': ${getErrorMessage(err)}`);
     }
   }
 }
@@ -771,7 +772,7 @@ export async function executeDataSources(
         results[name] = Array.isArray(rows) ? rows.slice(0, MAX_ROWS) : [];
       } catch (err) {
         logger.warn(
-          { error: err instanceof Error ? err.message : String(err), dataSource: name },
+          { error: getErrorMessage(err), dataSource: name },
           'Data source execution failed'
         );
         results[name] = [];

--- a/packages/server/src/utils/execution-context.ts
+++ b/packages/server/src/utils/execution-context.ts
@@ -18,6 +18,7 @@ import { parseJsonObject } from '@lobu/core';
 import { errorMessage } from './errors';
 import { insertEvent } from './insert-event';
 import logger from './logger';
+import { getErrorMessage } from "@lobu/core";
 
 interface ExecutionOAuthCredentials {
   provider: string;
@@ -362,7 +363,7 @@ function recordAppInstallationTenancyTrip(params: {
   }).catch((err) => {
     logger.warn(
       {
-        err: err instanceof Error ? err.message : String(err),
+        err: getErrorMessage(err),
         connection_id: params.connectionId,
         install_id: params.installId,
         reason: params.reason,

--- a/packages/server/src/utils/provisioned-connection.ts
+++ b/packages/server/src/utils/provisioned-connection.ts
@@ -9,6 +9,7 @@ import type { Env } from '../index';
 import { manageConnections } from '../tools/admin/manage_connections';
 import logger from './logger';
 import { getConfiguredPublicOrigin } from './public-origin';
+import { getErrorMessage } from "@lobu/core";
 
 interface CreateProvisionedConnectionParams {
   organizationId: string;
@@ -68,6 +69,6 @@ export async function createProvisionedConnection(
     return { connectionId, error: null };
   } catch (err) {
     logger.error({ err, connectorKey: params.connectorKey }, 'createProvisionedConnection failed');
-    return { connectionId: null, error: err instanceof Error ? err.message : String(err) };
+    return { connectionId: null, error: getErrorMessage(err) };
   }
 }

--- a/packages/server/src/utils/query-rewriter.ts
+++ b/packages/server/src/utils/query-rewriter.ts
@@ -27,6 +27,7 @@
 
 import type { Env } from '../index';
 import logger from './logger';
+import { getErrorMessage } from "@lobu/core";
 
 const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_MODEL = 'gpt-4o-mini';
@@ -96,7 +97,7 @@ export async function rewriteQueries(query: string, env: Env): Promise<string[]>
     // Fail open: any error (timeout/abort, network, parse) means the caller
     // proceeds with the raw query alone.
     logger.warn(
-      { error: error instanceof Error ? error.message : String(error) },
+      { error: getErrorMessage(error) },
       '[query-rewriter] rewrite failed; falling back to raw query'
     );
     return [];

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -20,6 +20,7 @@ import {
   resolveWatcherRunsByMessageIds,
 } from './run-completion';
 import { nextRunAt } from '../utils/cron';
+import { getErrorMessage } from "@lobu/core";
 
 type WatcherRunStatus =
   | 'pending'
@@ -830,7 +831,7 @@ async function preflightWatcherMemoryTools(params: {
   } catch (error) {
     return {
       ok: false,
-      error: `${LOBU_MEMORY_MCP_ID} tools preflight failed: ${error instanceof Error ? error.message : String(error)}`,
+      error: `${LOBU_MEMORY_MCP_ID} tools preflight failed: ${getErrorMessage(error)}`,
     };
   }
 }


### PR DESCRIPTION
## What

No behavior change. Consolidates four widely-duplicated idioms behind named helpers and adopts them at the call sites.

### 1. `getErrorMessage(err)` — `packages/core/src/errors.ts` (barrel-exported)
Replaces `error instanceof Error ? error.message : String(error)`. **119 call sites** swept across `packages/server` (the package the other helpers live in). The pre-existing local `packages/server/src/utils/errors.ts#errorMessage` and its callers are left untouched (out of scope — the task targets the inline ternary).

### 2. `tsTime(value)` / `tsTimeOrNull(value)` — `packages/server/src/db/client.ts`
Replaces the store row-mapping coercion `x instanceof Date ? x.getTime() : (x ?? Date.now())`. **~14 sites** across `postgres-stores`, `app-installation-store`, `postgres-secret-store`, `binding-service`. `tsTimeOrNull` returns `undefined` (not "now") for optional timestamps like `last_used_at`.

### 3. `resolveOrgId(explicit?)` / `requireOrgId(explicit?, caller)` + shared `orgScope(sql, orgId)` — `packages/server/src/lobu/stores/org-context.ts`
Replaces `organizationId ?? tryGetOrgId()` + resolve-or-throw. **14 sites** across `grant-store`, `user-agents-store`, `binding-service`, `base-provider-module`. The private `orgScope` is lifted out of `grant-store` into `org-context` and shared. `requireOrgId` names the caller in its error.

### 4. `constantTimeEqual(a?, b?)` — `packages/server/src/utils/constant-time-equal.ts`
Unifies the **4** reimplemented constant-time token comparisons:
- `auth/worker-token.ts` (`compareWorkerToken` delegates)
- `gateway/routes/internal/smoke.ts` (inlined `compareTokens` removed)
- `gateway/proxy/http-proxy.ts` (deployment-name match; the now-unused `import crypto` removed)
- `gateway/connections/webhook-ingest.ts#tokensMatch` (hashes inputs to fixed-length sha256 hex digests first, then `constantTimeEqual` over the digests — the length-revealing path can't fire)

## Tests

- `packages/core/src/__tests__/errors.test.ts` — `getErrorMessage` (Error subclasses + non-Error throws).
- `packages/server/src/utils/__tests__/shared-helpers.test.ts` — `tsTime`/`tsTimeOrNull`, `constantTimeEqual`, `resolveOrgId`/`requireOrgId`.
- Existing regression suites re-run green: `worker-token` (5), `webhook-ingest` (45), `http-proxy` + `smoke-dispatch` + `grant-store` + `binding-service-org-scope` + `app-installation-store` + `postgres-secret-store` (110), `base-deployment-grants` + `auth-profiles-manager-org-context` + `gateway-org-context` (25).

```
cd packages/server && bunx tsc --noEmit → 0 errors
cd packages/core   && bunx tsc --noEmit → 0 errors
biome clean (server is biome-excluded by repo config; full-repo tsc gate ran in pre-commit)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ug5cEnCRt1VHn8w3gNXAu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784760090&installation_id=136316292&pr_number=1495&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1495&signature=4b451a9acbc7203cbbb369e32a7d4a10b45cf92c3ed2e046b3e8ac79831ab2d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added utility helpers for improved error handling and data conversions across the platform
  * Enhanced organization context resolution with new centralized helpers
  
* **Bug Fixes & Improvements**
  * Standardized error message handling for more consistent logging and debugging
  * Improved constant-time comparison for sensitive token validation, reducing timing-attack exposure
  * Enhanced timestamp conversion logic for better data consistency
  
* **Tests**
  * Added comprehensive test coverage for new utility functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->