### PR TITLE
chore(dev): provision lobu_test on postgresql@18, retire @17 integration DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,9 @@ test-unit:
 
 # Integration suite — vitest under Node + bun:test packages that need Postgres.
 # Requires DATABASE_URL pointing at a Postgres with pgvector installed.
-# Tip for a clean local DB:
+# Local (macOS): `make setup` provisions brew postgresql@18 + lobu_test on :5418 — just:
+#   export DATABASE_URL=postgres://$USER@127.0.0.1:5418/lobu_test PGSSLMODE=disable
+# Linux / no brew:
 #   sudo apt-get install -y postgresql-16-pgvector
 #   sudo -u postgres createdb lobu_test
 #   sudo -u postgres psql -d lobu_test -c "CREATE EXTENSION vector"

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 command -v bun >/dev/null || { echo "Install bun: curl -fsSL https://bun.sh/install | bash"; exit 1; }
 
 # Provision the shared dev Postgres: brew postgresql@18 on :5418 — the default
-# `make dev` / dev-db.sh backend, same MAJOR as the product's embedded PG18.
-# Coexists with @17 on 5432 (lobu_test / the integration suite). Idempotent, and
+# `make dev` / dev-db.sh backend AND the `make test-integration` database, same
+# MAJOR as the product's embedded PG18. One local Postgres for everything; an
+# older brew major (e.g. @17 on 5432) is no longer needed. Idempotent, and
 # skipped gracefully if brew/@18 are absent — `make dev-embedded` still needs none.
 if command -v brew >/dev/null 2>&1 && brew list postgresql@18 >/dev/null 2>&1; then
   PGDATA18="$(brew --prefix)/var/postgresql@18"
@@ -22,7 +23,11 @@ if command -v brew >/dev/null 2>&1 && brew list postgresql@18 >/dev/null 2>&1; t
     # Role DB so `psql`/dev-db.sh connect as $USER (pgvector is installed per-DB on
     # first boot via LOBU_RUN_OWNS_DB; the extension bottle is already present).
     "$PGBIN18/createdb" -h localhost -p 5418 "$USER" 2>/dev/null || true
-    echo "✓ brew postgresql@18 running on :5418 (the default 'make dev' backend)"
+    # lobu_test for `make test-integration` (DATABASE_URL=…:5418/lobu_test), so the
+    # manual integration suite runs on PG18 too — no separate @17 cluster needed.
+    "$PGBIN18/createdb" -h localhost -p 5418 lobu_test 2>/dev/null || true
+    "$PGBIN18/psql" -h localhost -p 5418 -d lobu_test -c "CREATE EXTENSION IF NOT EXISTS vector" >/dev/null 2>&1 || true
+    echo "✓ brew postgresql@18 running on :5418 (the default 'make dev' backend + lobu_test)"
   else
     echo "✗ postgresql@18 did not come up on :5418 — 'make dev' will fail its preflight." >&2
     echo "  Check 'brew services list', or use the zero-dependency loop: make dev-embedded" >&2


### PR DESCRIPTION
Completes the dev-Postgres consolidation: one local Postgres (brew `postgresql@18` on `:5418`, the product's major) now serves both `make dev` (dev-db) **and** `make test-integration` — no separate `@17` cluster needed.

- `setup-dev.sh` creates `lobu_test` (+ pgvector) on @18:5418 alongside the role DB.
- The `make test-integration` comment now points the local example at `:5418/lobu_test` (Linux/no-brew path kept).

`make review` already runs integration on an ephemeral embedded PG18, so the gate was already PG18; this just aligns the manual integration path and lets `@17` be retired locally.

Verified: `postgres-secret-store` integration test migrates + passes 16/16 against `postgres://…:5418/lobu_test`. Scripts/comment only — no submodule or TS change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784766910&installation_id=136316292&pr_number=1501&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1501&signature=088f6100e06f925f2e6a4de60b42cd85911c9f5c5b4dc02f42e659ff55ac1267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->