### PR TITLE
refactor(connectors): adopt SDK http-client + paginateByCursor helpers

### DIFF
--- a/packages/connectors/src/__tests__/connector-sdk.mock.ts
+++ b/packages/connectors/src/__tests__/connector-sdk.mock.ts
@@ -8,9 +8,13 @@
 //
 // The SDK pulls in playwright; stubbing lets the pure connector logic be
 // imported without the browser stack. The runtime-only symbols throw if a
-// test actually reaches them; extensionDomScrape is faithfully re-implemented
-// so the home-feed path exercises the same dispatch shape (the real helper has
-// its own tests in packages/connector-sdk).
+// test actually reaches them; extensionDomScrape and the paginateBy* generators
+// are faithfully re-implemented so connectors that delegate their sync loops
+// exercise the real paging semantics (the real helpers have their own tests in
+// packages/connector-sdk). They are re-implemented inline rather than imported
+// from connector-sdk/src because this mock is copied verbatim into the cli's
+// dist/ for the packaged-connector test run, where that cross-package source
+// path does not resolve.
 
 interface DomScrapeOpts {
   dispatcher: {
@@ -23,6 +27,38 @@ interface DomScrapeOpts {
   allowedOrigins: string[];
   persistent?: boolean;
   focus?: boolean;
+}
+
+// Faithful copies of the SDK's pure pagination generators (no browser stack).
+// Kept byte-for-byte in step with packages/connector-sdk/src/pagination.ts.
+async function* paginateByCursor<T, C = string>(
+  fetchPage: (cursor: C | null) => Promise<{ items: T[]; nextCursor: C | null | undefined }>,
+  options: { maxPages?: number; initialCursor?: C | null; delayMs?: number } = {}
+): AsyncGenerator<T[], void, void> {
+  const maxPages = options.maxPages ?? Number.POSITIVE_INFINITY;
+  let cursor: C | null = options.initialCursor ?? null;
+  for (let page = 0; page < maxPages; page++) {
+    if (page > 0 && options.delayMs) await new Promise((r) => setTimeout(r, options.delayMs));
+    const { items, nextCursor } = await fetchPage(cursor);
+    yield items;
+    if (nextCursor === null || nextCursor === undefined) return;
+    cursor = nextCursor;
+  }
+}
+
+async function* paginateByOffset<T>(
+  fetchPage: (offset: number, pageSize: number) => Promise<{ items: T[]; hasMore: boolean }>,
+  options: { pageSize: number; maxPages?: number; startOffset?: number; delayMs?: number }
+): AsyncGenerator<T[], void, void> {
+  const maxPages = options.maxPages ?? Number.POSITIVE_INFINITY;
+  let offset = options.startOffset ?? 0;
+  for (let page = 0; page < maxPages; page++) {
+    if (page > 0 && options.delayMs) await new Promise((r) => setTimeout(r, options.delayMs));
+    const { items, hasMore } = await fetchPage(offset, options.pageSize);
+    yield items;
+    if (!hasMore) return;
+    offset += options.pageSize;
+  }
 }
 
 export function connectorSdkMock() {
@@ -42,8 +78,8 @@ export function connectorSdkMock() {
       request: notUsed('http.request'),
     }),
     requireBearerClient: notUsed('requireBearerClient'),
-    paginateByCursor: notUsed('paginateByCursor'),
-    paginateByOffset: notUsed('paginateByOffset'),
+    paginateByCursor,
+    paginateByOffset,
     ConnectorRuntime: class {},
     calculateEngagementScore: () => 0,
     IDENTITY: {

--- a/packages/connectors/src/__tests__/gmaps.test.ts
+++ b/packages/connectors/src/__tests__/gmaps.test.ts
@@ -1,0 +1,74 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
+import { connectorSdkMock } from './connector-sdk.mock';
+
+mock.module('@lobu/connector-sdk', connectorSdkMock);
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let GoogleMapsConnector: any;
+
+beforeAll(async () => {
+  const mod = await import('../gmaps');
+  GoogleMapsConnector = mod.default;
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+describe('GoogleMapsConnector.sync', () => {
+  test('searches by business_name then fetches details via the http client', async () => {
+    const connector = new GoogleMapsConnector();
+    const urls: string[] = [];
+    // Override the class-field client with a fake `raw()` (the SDK mock returns
+    // an inert client at construction).
+    connector.http = {
+      raw: async (url: string) => {
+        urls.push(url);
+        if (url.includes('findplacefromtext')) {
+          return jsonResponse({ candidates: [{ place_id: 'PID' }] });
+        }
+        return jsonResponse({
+          status: 'OK',
+          result: {
+            name: 'Acme',
+            url: 'https://maps/acme',
+            reviews: [
+              {
+                author_name: 'Reviewer',
+                rating: 5,
+                text: 'Great place',
+                time: 1_700_000_000,
+              },
+            ],
+          },
+        });
+      },
+    };
+
+    const result = await connector.sync({
+      config: { GOOGLE_MAPS_API_KEY: 'key', business_name: 'Acme' },
+      checkpoint: null,
+    });
+
+    expect(urls[0]).toContain('findplacefromtext');
+    expect(urls[1]).toContain('place_id=PID');
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].payload_text).toBe('Great place');
+  });
+
+  test('throws with the place-details status when the API returns non-ok', async () => {
+    const connector = new GoogleMapsConnector();
+    connector.http = {
+      raw: async () => jsonResponse({}, 500),
+    };
+
+    await expect(
+      connector.sync({ config: { GOOGLE_MAPS_API_KEY: 'key', place_id: 'PID' }, checkpoint: null })
+    ).rejects.toThrow(/Google Places details failed \(500\)/);
+  });
+});

--- a/packages/connectors/src/__tests__/google_calendar.test.ts
+++ b/packages/connectors/src/__tests__/google_calendar.test.ts
@@ -1,0 +1,152 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
+// The connector now drives both sync loops through the real cursor paginator.
+import { paginateByCursor } from '../../../connector-sdk/src/pagination.ts';
+import { connectorSdkMock } from './connector-sdk.mock';
+
+mock.module('@lobu/connector-sdk', () => ({
+  ...connectorSdkMock(),
+  paginateByCursor,
+}));
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let GoogleCalendarConnector: any;
+
+beforeAll(async () => {
+  const mod = await import('../google_calendar');
+  GoogleCalendarConnector = mod.default;
+});
+
+interface CalPage {
+  status?: number;
+  items?: Array<Record<string, unknown>>;
+  nextPageToken?: string;
+  nextSyncToken?: string;
+}
+
+/** Fake http client whose `raw()` serves a queue of events.list pages. */
+function fakeHttp(pages: CalPage[]) {
+  const calls: Array<string | null> = [];
+  let i = 0;
+  return {
+    calls,
+    client: {
+      raw: async (url: string) => {
+        const u = new URL(url);
+        calls.push(u.searchParams.get('pageToken'));
+        const page = pages[i++] ?? { items: [] };
+        const status = page.status ?? 200;
+        return {
+          ok: status >= 200 && status < 300,
+          status,
+          json: async () => ({
+            kind: 'calendar#events',
+            items: page.items ?? [],
+            nextPageToken: page.nextPageToken,
+            nextSyncToken: page.nextSyncToken,
+          }),
+          text: async () => 'err',
+        } as unknown as Response;
+      },
+    },
+  };
+}
+
+function calEvent(id: string, startIso: string) {
+  return {
+    id,
+    status: 'confirmed',
+    htmlLink: `https://cal/${id}`,
+    summary: id,
+    start: { dateTime: startIso },
+    end: { dateTime: startIso },
+    created: startIso,
+    updated: startIso,
+  };
+}
+
+describe('GoogleCalendarConnector full sync', () => {
+  test('captures nextSyncToken from the LAST page and pages until tokens exhaust', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client, calls } = fakeHttp([
+      { items: [calEvent('a', '2026-01-01T10:00:00Z')], nextPageToken: 'p2' },
+      // last page: no nextPageToken, but carries the nextSyncToken.
+      { items: [calEvent('b', '2026-01-02T10:00:00Z')], nextSyncToken: 'SYNC_TOKEN' },
+    ]);
+    connector.client = () => client;
+
+    const result = await connector.sync({
+      config: { calendar_id: 'primary', max_results: 100 },
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    expect(result.events).toHaveLength(2);
+    expect(result.checkpoint.sync_token).toBe('SYNC_TOKEN');
+    expect(calls).toEqual([null, 'p2']);
+  });
+
+  test('keeps paginating past max_results to reach the trailing sync token, but stops appending', async () => {
+    const connector = new GoogleCalendarConnector();
+    const { client } = fakeHttp([
+      { items: [calEvent('a', '2026-01-01T10:00:00Z')], nextPageToken: 'p2' },
+      { items: [calEvent('b', '2026-01-02T10:00:00Z')], nextSyncToken: 'SYNC2' },
+    ]);
+    connector.client = () => client;
+
+    const result = await connector.sync({
+      config: { calendar_id: 'primary', max_results: 1 }, // cap at 1 stored event
+      credentials: { accessToken: 'tok' },
+      checkpoint: {},
+    });
+
+    // Only 1 event stored (cap), but the second page was still fetched so the
+    // trailing sync token is captured.
+    expect(result.events).toHaveLength(1);
+    expect(result.checkpoint.sync_token).toBe('SYNC2');
+  });
+});
+
+describe('GoogleCalendarConnector incremental sync', () => {
+  test('an expired syncToken (410) falls through to a full sync', async () => {
+    const connector = new GoogleCalendarConnector();
+    // First raw() call (incremental, has syncToken) returns 410; subsequent
+    // calls are the full-sync path and succeed.
+    let call = 0;
+    const calls: Array<Record<string, string | null>> = [];
+    connector.client = () => ({
+      raw: async (url: string) => {
+        const u = new URL(url);
+        calls.push({
+          syncToken: u.searchParams.get('syncToken'),
+          pageToken: u.searchParams.get('pageToken'),
+        });
+        call++;
+        if (call === 1) {
+          return { ok: false, status: 410, json: async () => ({}), text: async () => 'gone' } as unknown as Response;
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            kind: 'calendar#events',
+            items: [calEvent('full-1', '2026-02-01T10:00:00Z')],
+            nextSyncToken: 'FRESH',
+          }),
+          text: async () => '',
+        } as unknown as Response;
+      },
+    });
+
+    const result = await connector.sync({
+      config: { calendar_id: 'primary', max_results: 100 },
+      credentials: { accessToken: 'tok' },
+      checkpoint: { sync_token: 'STALE' },
+    });
+
+    // Incremental attempt used the stale token; full sync recovered events + a
+    // fresh sync token.
+    expect(calls[0]?.syncToken).toBe('STALE');
+    expect(result.events).toHaveLength(1);
+    expect(result.checkpoint.sync_token).toBe('FRESH');
+  });
+});

--- a/packages/connectors/src/__tests__/google_calendar.test.ts
+++ b/packages/connectors/src/__tests__/google_calendar.test.ts
@@ -1,12 +1,10 @@
 import { beforeAll, describe, expect, mock, test } from 'bun:test';
-// The connector now drives both sync loops through the real cursor paginator.
-import { paginateByCursor } from '../../../connector-sdk/src/pagination.ts';
+// The connector drives both sync loops through the cursor paginator; the shared
+// mock provides a faithful real generator (not a throwing stub), so this
+// exercises the genuine paging semantics while keeping the browser stack out.
 import { connectorSdkMock } from './connector-sdk.mock';
 
-mock.module('@lobu/connector-sdk', () => ({
-  ...connectorSdkMock(),
-  paginateByCursor,
-}));
+mock.module('@lobu/connector-sdk', () => connectorSdkMock());
 
 // biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
 let GoogleCalendarConnector: any;

--- a/packages/connectors/src/__tests__/ios_appstore.test.ts
+++ b/packages/connectors/src/__tests__/ios_appstore.test.ts
@@ -1,0 +1,64 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
+import { connectorSdkMock } from './connector-sdk.mock';
+
+mock.module('@lobu/connector-sdk', connectorSdkMock);
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let IOSAppStoreConnector: any;
+
+beforeAll(async () => {
+  const mod = await import('../ios_appstore');
+  IOSAppStoreConnector = mod.default;
+});
+
+function reviewEntry(id: string, updated: string, rating = '5') {
+  return {
+    id: { label: id },
+    title: { label: `t-${id}` },
+    content: { label: `body-${id}` },
+    author: { name: { label: 'Author' } },
+    updated: { label: updated },
+    'im:rating': { label: rating },
+  };
+}
+
+function feedResponse(entries: unknown[], status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => ({ feed: { entry: entries } }),
+    text: async () => 'body',
+  } as unknown as Response;
+}
+
+describe('IOSAppStoreConnector.sync', () => {
+  test('page 1 non-ok throws via the adopted http client', async () => {
+    const connector = new IOSAppStoreConnector();
+    connector.http = { raw: async () => feedResponse([], 503) };
+
+    await expect(
+      connector.sync({ config: { app_id: '123', country: 'US' }, checkpoint: {} })
+    ).rejects.toThrow(/RSS feed returned 503/);
+  });
+
+  test('a non-ok response past page 1 ends the feed (break, not throw)', async () => {
+    const connector = new IOSAppStoreConnector();
+    let page = 0;
+    connector.http = {
+      raw: async () => {
+        page++;
+        if (page === 1) return feedResponse([reviewEntry('r1', '2026-03-01T00:00:00Z')]);
+        return feedResponse([], 500); // page 2 fails -> treated as end of feed
+      },
+    };
+
+    const result = await connector.sync({
+      config: { app_id: '123', country: 'US' },
+      checkpoint: {},
+    });
+
+    // Page 1's review survives; the page-2 failure stopped paging without error.
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].origin_id).toBe('r1');
+  });
+});

--- a/packages/connectors/src/__tests__/jira.test.ts
+++ b/packages/connectors/src/__tests__/jira.test.ts
@@ -1,0 +1,91 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
+// Use the real cursor paginator (the connector now delegates its sync loop to
+// it); the shared mock stubs it as throwing, so this file supplies its own SDK
+// stub that re-exports the genuine generator while keeping the browser stack out.
+import { paginateByCursor } from '../../../connector-sdk/src/pagination.ts';
+import { connectorSdkMock } from './connector-sdk.mock';
+
+mock.module('@lobu/connector-sdk', () => ({
+  ...connectorSdkMock(),
+  paginateByCursor,
+}));
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let JiraConnector: any;
+
+beforeAll(async () => {
+  const mod = await import('../jira');
+  JiraConnector = mod.default;
+});
+
+interface JiraPage {
+  issues?: Array<{ id?: string; key?: string; fields?: Record<string, unknown> }>;
+  nextPageToken?: string;
+}
+
+/** Build a fake http client whose `json()` serves a queue of /search/jql pages. */
+function fakeHttp(pages: JiraPage[]) {
+  const calls: Array<string | null> = [];
+  let i = 0;
+  return {
+    calls,
+    client: {
+      json: async (url: string) => {
+        const u = new URL(url, 'https://api.atlassian.com');
+        calls.push(u.searchParams.get('nextPageToken'));
+        return pages[i++] ?? { issues: [] };
+      },
+    },
+  };
+}
+
+function makeCtx() {
+  return {
+    config: { cloud_id: 'cloud-1', jql: 'order by updated DESC' },
+    credentials: { accessToken: 'tok' },
+    sessionState: null,
+    checkpoint: null,
+  };
+}
+
+describe('JiraConnector.sync pagination', () => {
+  test('follows nextPageToken across pages and stops when the token is absent', async () => {
+    const connector = new JiraConnector();
+    const { client, calls } = fakeHttp([
+      { issues: [{ id: '1' }, { id: '2' }], nextPageToken: 'p2' },
+      { issues: [{ id: '3' }], nextPageToken: 'p3' },
+      { issues: [{ id: '4' }] }, // no token -> last page
+    ]);
+    connector.client = () => client;
+
+    const result = await connector.sync(makeCtx());
+
+    // 4 issues across 3 pages, all mapped to events.
+    expect(result.events).toHaveLength(4);
+    expect(result.events.map((e: { origin_id: string }) => e.origin_id)).toEqual([
+      'jira_issue_1',
+      'jira_issue_2',
+      'jira_issue_3',
+      'jira_issue_4',
+    ]);
+    // First page sends no cursor, then follows p2, p3.
+    expect(calls).toEqual([null, 'p2', 'p3']);
+    expect(result.metadata).toEqual({ items_found: 4 });
+  });
+
+  test('stops on an empty page even when a token is returned (degenerate cursor guard)', async () => {
+    const connector = new JiraConnector();
+    const { client, calls } = fakeHttp([
+      { issues: [{ id: '1' }], nextPageToken: 'p2' },
+      { issues: [], nextPageToken: 'p3' }, // empty page but token present -> must stop
+      { issues: [{ id: 'should-not-fetch' }] },
+    ]);
+    connector.client = () => client;
+
+    const result = await connector.sync(makeCtx());
+
+    expect(result.events).toHaveLength(1);
+    // Only two fetches: page 1, then the empty page 2; page 3 is never requested.
+    expect(calls).toEqual([null, 'p2']);
+  });
+});

--- a/packages/connectors/src/__tests__/jira.test.ts
+++ b/packages/connectors/src/__tests__/jira.test.ts
@@ -1,14 +1,10 @@
 import { beforeAll, describe, expect, mock, test } from 'bun:test';
-// Use the real cursor paginator (the connector now delegates its sync loop to
-// it); the shared mock stubs it as throwing, so this file supplies its own SDK
-// stub that re-exports the genuine generator while keeping the browser stack out.
-import { paginateByCursor } from '../../../connector-sdk/src/pagination.ts';
+// The connector delegates its sync loop to the cursor paginator; the shared mock
+// provides a faithful real generator (not a throwing stub), so this exercises
+// the genuine paging semantics while keeping the browser stack out.
 import { connectorSdkMock } from './connector-sdk.mock';
 
-mock.module('@lobu/connector-sdk', () => ({
-  ...connectorSdkMock(),
-  paginateByCursor,
-}));
+mock.module('@lobu/connector-sdk', () => connectorSdkMock());
 
 // biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
 let JiraConnector: any;

--- a/packages/connectors/src/gmaps.ts
+++ b/packages/connectors/src/gmaps.ts
@@ -8,6 +8,7 @@ import {
   type ConnectorDefinition,
   ConnectorRuntime,
   calculateEngagementScore,
+  createHttpClient,
   type EventEnvelope,
   type SyncContext,
   type SyncResult,
@@ -101,6 +102,11 @@ export default class GoogleMapsConnector extends ConnectorRuntime {
     },
   };
 
+  // Google Places authenticates via the `key` query param, not a bearer header,
+  // so the client carries no token — it's adopted purely for retry/backoff on
+  // transient 429/5xx and consistent error formatting.
+  private readonly http = createHttpClient({ errorPrefix: 'Google Places' });
+
   async sync(ctx: SyncContext): Promise<SyncResult> {
     const apiKey = ctx.config.GOOGLE_MAPS_API_KEY as string | undefined;
     if (!apiKey) {
@@ -117,7 +123,7 @@ export default class GoogleMapsConnector extends ConnectorRuntime {
     // If no place_id, search by business name
     if (!placeId && businessName) {
       const searchUrl = `https://maps.googleapis.com/maps/api/place/findplacefromtext/json?input=${encodeURIComponent(businessName)}&inputtype=textquery&fields=place_id&key=${apiKey}`;
-      const searchResponse = await fetch(searchUrl);
+      const searchResponse = await this.http.raw(searchUrl);
       if (!searchResponse.ok) {
         throw new Error(
           `Google Places search failed (${searchResponse.status}): ${await searchResponse.text()}`
@@ -132,7 +138,7 @@ export default class GoogleMapsConnector extends ConnectorRuntime {
 
     // Fetch place details with reviews
     const detailsUrl = `https://maps.googleapis.com/maps/api/place/details/json?place_id=${placeId}&fields=name,reviews,url&key=${apiKey}`;
-    const detailsResponse = await fetch(detailsUrl);
+    const detailsResponse = await this.http.raw(detailsUrl);
     if (!detailsResponse.ok) {
       throw new Error(
         `Google Places details failed (${detailsResponse.status}): ${await detailsResponse.text()}`

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -10,7 +10,10 @@ import {
   type ActionResult,
   type ConnectorDefinition,
   ConnectorRuntime,
+  createHttpClient,
   type EventEnvelope,
+  type HttpClient,
+  paginateByCursor,
   type SyncContext,
   type SyncResult,
 } from '@lobu/connector-sdk';
@@ -230,6 +233,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
       throw new Error('Google Calendar requires Google OAuth credentials.');
     }
 
+    const http = this.client(token);
     const calendarId = (ctx.config.calendar_id as string) || 'primary';
     const maxResults = Math.min((ctx.config.max_results as number) ?? 100, 2500);
     const lookbackDays = (ctx.config.lookback_days as number) ?? 30;
@@ -239,7 +243,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
 
     // Try incremental sync with syncToken first
     if (checkpoint.sync_token) {
-      const result = await this.syncWithToken(token, calendarId, checkpoint.sync_token, maxResults);
+      const result = await this.syncWithToken(http, calendarId, checkpoint.sync_token, maxResults);
       if (result) {
         return this.buildResult(result.events, result.nextSyncToken, result.events.length);
       }
@@ -252,58 +256,58 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     const timeMax = new Date();
     timeMax.setDate(timeMax.getDate() + 365); // Include future events
 
-    let pageToken: string | undefined;
     let nextSyncToken: string | undefined;
 
     // Safety bound — at 250 events/page, 200 pages = 50k events, more than
     // any reasonable calendar window. Stops a runaway loop if the upstream
     // ever returns a self-referential page token.
     const MAX_PAGES = 200;
-    let pages = 0;
 
-    while (pages < MAX_PAGES) {
-      pages++;
-      // Always request a full page — `maxResults` is a soft cap on *stored*
-      // events, not a reason to shrink the request size (shrinking to 1 once the
-      // cap is hit would crawl a busy calendar one event per round-trip).
-      const params = new URLSearchParams({
-        maxResults: '250',
-        orderBy: 'startTime',
-        singleEvents: 'true',
-        timeMin: timeMin.toISOString(),
-        timeMax: timeMax.toISOString(),
-      });
-      if (pageToken) {
-        params.set('pageToken', pageToken);
-      }
-
-      const url = `${this.BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`;
-      const response = await this.apiGet(url, token);
-
-      if (!response.ok) {
-        throw new Error(
-          `Calendar events.list error (${response.status}): ${await response.text()}`
-        );
-      }
-
-      const data = (await response.json()) as CalendarEventListResponse;
-
-      if (data.items) {
-        for (const calEvent of data.items) {
-          if (events.length >= maxResults) break;
-          const envelope = this.calendarEventToEnvelope(calEvent);
-          if (envelope) events.push(envelope);
+    const pages = paginateByCursor<CalendarEvent, string>(
+      async (pageToken) => {
+        // Always request a full page — `maxResults` is a soft cap on *stored*
+        // events, not a reason to shrink the request size (shrinking to 1 once
+        // the cap is hit would crawl a busy calendar one event per round-trip).
+        const params = new URLSearchParams({
+          maxResults: '250',
+          orderBy: 'startTime',
+          singleEvents: 'true',
+          timeMin: timeMin.toISOString(),
+          timeMax: timeMax.toISOString(),
+        });
+        if (pageToken) {
+          params.set('pageToken', pageToken);
         }
-      }
 
-      nextSyncToken = data.nextSyncToken;
-      pageToken = data.nextPageToken;
-      // Google only returns nextSyncToken on the LAST page (no nextPageToken).
-      // Must keep paginating until pageToken is exhausted, otherwise the sync
-      // token is never obtained and every subsequent sync re-runs the full
-      // window from scratch — so we keep paging past `maxResults`, just stop
-      // appending events once the cap is reached.
-      if (!pageToken) break;
+        const url = `${this.BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`;
+        const response = await http.raw(url);
+
+        if (!response.ok) {
+          throw new Error(
+            `Calendar events.list error (${response.status}): ${await response.text()}`
+          );
+        }
+
+        const data = (await response.json()) as CalendarEventListResponse;
+        // Google only returns nextSyncToken on the LAST page (no nextPageToken).
+        // Capture it whenever present so the trailing value survives; the
+        // generator keeps paging until nextPageToken is exhausted, otherwise the
+        // sync token is never obtained and every subsequent sync re-runs the full
+        // window from scratch.
+        nextSyncToken = data.nextSyncToken;
+        return { items: data.items ?? [], nextCursor: data.nextPageToken };
+      },
+      { maxPages: MAX_PAGES }
+    );
+
+    // Keep paginating past `maxResults`, just stop appending events once the cap
+    // is reached, so the trailing nextSyncToken is still captured.
+    for await (const items of pages) {
+      for (const calEvent of items) {
+        if (events.length >= maxResults) break;
+        const envelope = this.calendarEventToEnvelope(calEvent);
+        if (envelope) events.push(envelope);
+      }
     }
 
     return this.buildResult(events, nextSyncToken, events.length);
@@ -323,15 +327,17 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
         };
       }
 
+      const http = this.client(token);
+
       switch (ctx.actionKey) {
         case 'create_event':
-          return await this.createEvent(token, ctx.input);
+          return await this.createEvent(http, ctx.input);
         case 'update_event':
-          return await this.updateEvent(token, ctx.input);
+          return await this.updateEvent(http, ctx.input);
         case 'delete_event':
-          return await this.deleteEvent(token, ctx.input);
+          return await this.deleteEvent(http, ctx.input);
         case 'get_event':
-          return await this.getEvent(token, ctx.input);
+          return await this.getEvent(http, ctx.input);
         default:
           return { success: false, error: `Unknown action: ${ctx.actionKey}` };
       }
@@ -348,57 +354,62 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
   // -------------------------------------------------------------------------
 
   private async syncWithToken(
-    token: string,
+    http: HttpClient,
     calendarId: string,
     syncToken: string,
     maxResults: number
   ): Promise<{ events: EventEnvelope[]; nextSyncToken?: string } | null> {
     const events: EventEnvelope[] = [];
-    let pageToken: string | undefined;
     let nextSyncToken: string | undefined;
+    // 410 Gone means the syncToken is expired — abort and let the caller fall
+    // through to a full sync. Signalled out of the generator via this flag.
+    let syncTokenExpired = false;
 
     // Same hard ceiling as the full-sync path — defensive only.
     const MAX_PAGES = 200;
-    let pages = 0;
 
-    while (pages < MAX_PAGES) {
-      pages++;
-      const params = new URLSearchParams({
-        maxResults: String(Math.max(1, Math.min(250, maxResults - events.length))),
-        syncToken,
-      });
-      if (pageToken) {
-        params.set('pageToken', pageToken);
-      }
-
-      const url = `${this.BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`;
-      const response = await this.apiGet(url, token);
-
-      // 410 Gone means syncToken is expired
-      if (response.status === 410) {
-        return null;
-      }
-
-      if (!response.ok) {
-        throw new Error(
-          `Calendar events.list error (${response.status}): ${await response.text()}`
-        );
-      }
-
-      const data = (await response.json()) as CalendarEventListResponse;
-
-      if (data.items) {
-        for (const calEvent of data.items) {
-          const envelope = this.calendarEventToEnvelope(calEvent);
-          if (envelope) events.push(envelope);
+    const pages = paginateByCursor<CalendarEvent, string>(
+      async (pageToken) => {
+        const params = new URLSearchParams({
+          // Page size shrinks toward the remaining cap as events accumulate,
+          // matching the original dynamic sizing.
+          maxResults: String(Math.max(1, Math.min(250, maxResults - events.length))),
+          syncToken,
+        });
+        if (pageToken) {
+          params.set('pageToken', pageToken);
         }
-      }
 
-      nextSyncToken = data.nextSyncToken;
-      pageToken = data.nextPageToken;
-      // Paginate until exhausted so we capture the trailing nextSyncToken.
-      if (!pageToken) break;
+        const url = `${this.BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`;
+        const response = await http.raw(url);
+
+        if (response.status === 410) {
+          syncTokenExpired = true;
+          return { items: [], nextCursor: undefined };
+        }
+
+        if (!response.ok) {
+          throw new Error(
+            `Calendar events.list error (${response.status}): ${await response.text()}`
+          );
+        }
+
+        const data = (await response.json()) as CalendarEventListResponse;
+        // Capture the trailing nextSyncToken; generator pages until exhausted.
+        nextSyncToken = data.nextSyncToken;
+        return { items: data.items ?? [], nextCursor: data.nextPageToken };
+      },
+      { maxPages: MAX_PAGES }
+    );
+
+    for await (const items of pages) {
+      for (const calEvent of items) {
+        const envelope = this.calendarEventToEnvelope(calEvent);
+        if (envelope) events.push(envelope);
+      }
     }
+
+    if (syncTokenExpired) return null;
 
     return { events, nextSyncToken };
   }
@@ -407,7 +418,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
   // Actions
   // -------------------------------------------------------------------------
 
-  private async createEvent(token: string, input: Record<string, unknown>): Promise<ActionResult> {
+  private async createEvent(http: HttpClient, input: Record<string, unknown>): Promise<ActionResult> {
     const summary = input.summary as string;
     const start = input.start as string;
     const end = input.end as string;
@@ -441,12 +452,9 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     }
 
     const url = `${this.BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events`;
-    const response = await fetch(url, {
+    const response = await http.raw(url, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(eventBody),
     });
 
@@ -469,7 +477,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     };
   }
 
-  private async updateEvent(token: string, input: Record<string, unknown>): Promise<ActionResult> {
+  private async updateEvent(http: HttpClient, input: Record<string, unknown>): Promise<ActionResult> {
     const eventId = input.event_id as string;
     const calendarId = (input.calendar_id as string) || 'primary';
 
@@ -485,12 +493,9 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     if (input.end !== undefined) patch.end = { dateTime: input.end as string };
 
     const url = `${this.BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`;
-    const response = await fetch(url, {
+    const response = await http.raw(url, {
       method: 'PATCH',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(patch),
     });
 
@@ -511,7 +516,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     };
   }
 
-  private async deleteEvent(token: string, input: Record<string, unknown>): Promise<ActionResult> {
+  private async deleteEvent(http: HttpClient, input: Record<string, unknown>): Promise<ActionResult> {
     const eventId = input.event_id as string;
     const calendarId = (input.calendar_id as string) || 'primary';
 
@@ -520,10 +525,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     }
 
     const url = `${this.BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`;
-    const response = await fetch(url, {
-      method: 'DELETE',
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const response = await http.raw(url, { method: 'DELETE' });
 
     if (!response.ok) {
       const errText = await response.text();
@@ -536,7 +538,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     };
   }
 
-  private async getEvent(token: string, input: Record<string, unknown>): Promise<ActionResult> {
+  private async getEvent(http: HttpClient, input: Record<string, unknown>): Promise<ActionResult> {
     const eventId = input.event_id as string;
     const calendarId = (input.calendar_id as string) || 'primary';
 
@@ -545,7 +547,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     }
 
     const url = `${this.BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`;
-    const response = await this.apiGet(url, token);
+    const response = await http.raw(url);
 
     if (!response.ok) {
       const errText = await response.text();
@@ -645,9 +647,10 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
     };
   }
 
-  private async apiGet(url: string, token: string): Promise<Response> {
-    return fetch(url, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+  // Auth-aware client (Bearer + retry/backoff on transient 429/5xx). Built per
+  // token so each sync/action uses its own credentials. `.raw()` preserves the
+  // existing `response.ok`/status-code branching (e.g. 410 sync-token expiry).
+  private client(token: string): HttpClient {
+    return createHttpClient({ token, errorPrefix: 'Calendar API' });
   }
 }

--- a/packages/connectors/src/ios_appstore.ts
+++ b/packages/connectors/src/ios_appstore.ts
@@ -8,6 +8,7 @@ import {
   type ConnectorDefinition,
   ConnectorRuntime,
   calculateEngagementScore,
+  createHttpClient,
   type EventEnvelope,
   type SyncContext,
   type SyncResult,
@@ -98,6 +99,10 @@ export default class IOSAppStoreConnector extends ConnectorRuntime {
     },
   };
 
+  // RSS feeds are unauthenticated (authSchema: none); the client is adopted for
+  // retry/backoff on transient 429/5xx. IOS_HEADERS are applied per request.
+  private readonly http = createHttpClient({ errorPrefix: 'iOS App Store RSS' });
+
   async sync(ctx: SyncContext): Promise<SyncResult> {
     const appId = ctx.config.app_id as string;
     const country = ctx.config.country as string;
@@ -111,7 +116,18 @@ export default class IOSAppStoreConnector extends ConnectorRuntime {
     for (let page = 1; shouldContinue && page <= MAX_PAGES; page++) {
       const rssUrl = `https://itunes.apple.com/${country}/rss/customerreviews/page=${page}/id=${appId}/sortby=mostrecent/json`;
 
-      const response = await fetch(rssUrl, { headers: IOS_HEADERS });
+      // `.raw()` retries transient 429/5xx, then resolves non-2xx responses for
+      // our own handling — except a still-transient status throws after retries
+      // are exhausted. Page 1 surfaces any failure; later pages treat it as the
+      // end of the feed (the original break-on-non-ok behavior), so a thrown
+      // transient error past page 1 must collapse to the same break.
+      let response: Response;
+      try {
+        response = await this.http.raw(rssUrl, { headers: IOS_HEADERS });
+      } catch (error) {
+        if (page === 1) throw error;
+        break;
+      }
       if (!response.ok) {
         if (page === 1) {
           throw new Error(`RSS feed returned ${response.status}: ${rssUrl}`);

--- a/packages/connectors/src/jira.ts
+++ b/packages/connectors/src/jira.ts
@@ -12,6 +12,7 @@ import {
   type ConnectorDefinition,
   ConnectorRuntime,
   type EventEnvelope,
+  paginateByCursor,
   requireBearerClient,
   type SyncContext,
   type SyncCredentials,
@@ -210,33 +211,35 @@ export default class JiraConnector extends ConnectorRuntime<JiraCheckpoint, Jira
     const jql = ctx.config.jql ?? `updated >= -${lookbackDays}d order by updated DESC`;
 
     const events: EventEnvelope[] = [];
-    let nextPageToken: string | undefined;
-    let pages = 0;
 
-    while (pages < this.MAX_PAGES) {
-      // `/rest/api/3/search` was removed by Atlassian (CHANGE-2046); the
-      // replacement `/search/jql` paginates with an opaque nextPageToken and
-      // returns no total — iterate until the token is absent.
-      const params = new URLSearchParams({
-        jql,
-        maxResults: String(this.PAGE_SIZE),
-        fields: 'summary,description,status,assignee,reporter,created,updated',
-      });
-      if (nextPageToken) params.set('nextPageToken', nextPageToken);
-      const data = await http.json<JiraSearchResponse>(`${base}/search/jql?${params.toString()}`, {
-        method: 'GET',
-        headers: { Accept: 'application/json' },
-      });
+    // `/rest/api/3/search` was removed by Atlassian (CHANGE-2046); the
+    // replacement `/search/jql` paginates with an opaque nextPageToken and
+    // returns no total — iterate until the token is absent.
+    const pages = paginateByCursor<JiraIssue, string>(
+      async (nextPageToken) => {
+        const params = new URLSearchParams({
+          jql,
+          maxResults: String(this.PAGE_SIZE),
+          fields: 'summary,description,status,assignee,reporter,created,updated',
+        });
+        if (nextPageToken) params.set('nextPageToken', nextPageToken);
+        const data = await http.json<JiraSearchResponse>(
+          `${base}/search/jql?${params.toString()}`,
+          { method: 'GET', headers: { Accept: 'application/json' } }
+        );
+        return { items: data.issues ?? [], nextCursor: data.nextPageToken };
+      },
+      { maxPages: this.MAX_PAGES }
+    );
 
-      const issues = data.issues ?? [];
+    for await (const issues of pages) {
       for (const issue of issues) {
         const event = this.issueEvent(issue);
         if (event) events.push(event);
       }
-
-      pages += 1;
-      nextPageToken = data.nextPageToken;
-      if (!nextPageToken || issues.length === 0) break;
+      // Preserve the original early-exit on an empty page even when a token is
+      // returned — guards against a degenerate self-referential cursor.
+      if (issues.length === 0) break;
     }
 
     return {


### PR DESCRIPTION
## What

Reduce per-connector duplication by migrating connectors off hand-rolled `fetch`/cursor loops onto the existing connector-SDK helpers (`createHttpClient`, `paginateByCursor`). Connectors gain retry/backoff on transient 429/5xx for free; request shape and error semantics are preserved.

### Migrations
- **gmaps** — Places `findplacefromtext` + `details` fetches now go through `createHttpClient().raw()`. The API key stays in the query string (Places doesn't use a bearer header), so the client carries no token; it's adopted purely for retry + consistent error formatting.
- **ios_appstore** — RSS fetch routed through `createHttpClient().raw()`. Behavior preserved: page 1 surfaces any failure (throws), later pages treat a failure as end-of-feed (break) — including a thrown transient error after retries are exhausted.
- **google_calendar** — adopt `createHttpClient` for the `events.list` GETs and the create/update/delete/get actions; convert **both** cursor loops (full sync + incremental) to `paginateByCursor`. Preserves: `nextSyncToken` capture on the last page only, dynamic incremental page sizing (`maxResults - events.length`), the 410 sync-token fall-through to a full sync, and the `maxResults` soft-cap (keep paging to capture the trailing sync token, just stop appending).
- **jira** — convert the `/search/jql` cursor loop to `paginateByCursor`, keeping the empty-page early-exit guard.

### Not changed
- **youtube** — already routes its API calls through `this.http.raw` on `main` (the `apiGet` shim builds `createHttpClient` and uses it). The remaining raw `fetch`es are transcript scrapes of `youtube.com` watch pages / timedtext XML — not bearer-authenticated JSON API calls — and stay as-is.
- **parseRelativeDate promotion (dropped)** — the "X weeks/days ago" parser exists in exactly one place (capterra), and it lives **inside `page.evaluate(() => {...})`** (a Playwright/CDP browser context, serialized to run in the page). g2 and trustpilot parse `datePublished` / `<time datetime>` with `new Date(...)` and have no relative-date parser. A Node-side SDK util is unreachable from inside the serialized browser function, so promoting + adopting it would break capterra. There is no real duplication to consolidate.

## Tests
Added minimal unit tests for the four migrated connectors (none had tests before): jira + calendar pagination (cursor following, empty-page guard, nextSyncToken-on-last-page, past-cap paging, 410 fall-through), gmaps (search→details + non-ok throw), ios_appstore (page-1 throw vs page-2 break). Full connectors suite: **156 pass / 0 fail**.

## Notes
- Typecheck verified per-file against the `origin/main` baseline: zero new tsc errors in the touched files (the package-local `tsc` config is missing `allowImportingTsExtensions`/DOM lib; pre-existing errors are identical before/after).
- Biome clean.
- `make review` not run (pi quota exhausted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ug5cEnCRt1VHn8w3gNXAu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784771807&installation_id=136316292&pr_number=1504&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1504&signature=b7ed898b19b585f2aa3b651f7049dd9aed062838ef9c7124648f74eb14705fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and pagination reliability across Google Maps, Google Calendar, iOS App Store, and Jira connectors.
  * Added fallback mechanisms for transient API failures and stale sync tokens.
  * Enhanced handling of rate-limiting and server errors during data synchronization.

* **Tests**
  * Added comprehensive test suites for connector sync functionality and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->