### PR TITLE
chore(slack): drop duplicate SLACK_BOT_SCOPES env name

### DIFF
--- a/packages/server/src/gateway/routes/public/slack.ts
+++ b/packages/server/src/gateway/routes/public/slack.ts
@@ -120,8 +120,7 @@ function splitScopes(scopes: string): string[] {
 }
 
 async function loadSlackBotScopes(): Promise<string[]> {
-  const envScopes =
-    process.env.SLACK_OAUTH_SCOPES || process.env.SLACK_BOT_SCOPES;
+  const envScopes = process.env.SLACK_OAUTH_SCOPES;
   if (envScopes) {
     return splitScopes(envScopes);
   }


### PR DESCRIPTION
## What

`SLACK_OAUTH_SCOPES` and `SLACK_BOT_SCOPES` were two env names for the same value — the comma-separated bot-scope override read in `loadSlackBotScopes()` (`packages/server/src/gateway/routes/public/slack.ts`). Consolidate to `SLACK_OAUTH_SCOPES` (the name both test suites already use) and remove the `SLACK_BOT_SCOPES` fallback. No compat alias, per repo convention.

```diff
-  const envScopes =
-    process.env.SLACK_OAUTH_SCOPES || process.env.SLACK_BOT_SCOPES;
+  const envScopes = process.env.SLACK_OAUTH_SCOPES;
```

The `DEFAULT_SLACK_BOT_SCOPES` constant (the literal default-scope list, not an env name) is unrelated and unchanged.

## Other env candidates checked (left as-is — all live)
Asked to verify three other suspected-dead env vars before removing. Grepped for readers; **all three are live and functional**, so none were removed:
- `RUNS_RETENTION_DAYS` — read in `runs-queue.ts` `sweepCompletedRuns()` (retention window for completed runs).
- `FAILED_RUNS_RETENTION_DAYS` — read in the same function (independent dead-letter retention window).
- `SECRET_PROXY_UPSTREAM_URL` — read in `gateway/config/index.ts` (secret-proxy upstream URL fallback).

## Tests
- `slack-routes.test.ts`: 10 pass / 0 fail
- `rest-api-hardening.test.ts`: 45 pass / 0 fail
- Both suites reference only `SLACK_OAUTH_SCOPES` (the survivor).
- Server tsc: error count identical to `origin/main` baseline (83 = 83, none in `slack.ts`); biome clean.

`make review` not run (pi quota exhausted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ug5cEnCRt1VHn8w3gNXAu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784771821&installation_id=136316292&pr_number=1505&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1505&signature=3ca571217af1bd26ed2365ff079916d76ad22bd0aa6e4fe532f6da4ee3647666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->