### PR TITLE
feat(entities): event-sourced entity field projection (P5, collapsed)

### DIFF
--- a/db/migrations/20260622150000_entity_field_projection.sql
+++ b/db/migrations/20260622150000_entity_field_projection.sql
@@ -1,0 +1,104 @@
+-- migrate:up
+
+-- Event-sourced entity field state — SUBSTRATE (expand phase, 1 of N).
+--
+-- entity_field_state is a trigger-maintained projection of the events log: the
+-- current value of each (entity_id, metadata field) is the latest 'entity_field'
+-- event carrying it. The events log stays the source of truth; this table is a
+-- rebuildable cache. Validated by a live PG17 concurrency prototype — correct
+-- under maximum contention (the keep-greater ON CONFLICT row-lock serializes
+-- concurrent writers, N>1-safe), microsecond PK reads, ~1.4s rebuild over 2M events.
+--
+-- This migration ships the SUBSTRATE only — nothing emits 'entity_field' events
+-- yet, so the projection is empty and inert in prod (the WHEN-gated trigger costs
+-- nothing on non-field inserts). The producer (manage_entity emitting field
+-- events inside the entity-update transaction, for correct ordering) is a
+-- separate follow-up; it must respect the event contract below.
+--
+-- EVENT CONTRACT for 'entity_field':
+--   semantic_type   = 'entity_field'
+--   entity_ids      = '{}'  (INTENTIONALLY EMPTY — these rows must never match
+--                            entity-linked content counts / feeds / search, which
+--                            key on entity_ids; cf. recordLifecycleEvent's empty
+--                            entity_ids precedent)
+--   organization_id = <the events.organization_id column>  (tenancy)
+--   metadata        = { "entity_id": <number>, "fields": { "<key>": <value>, ... } }
+
+CREATE TABLE IF NOT EXISTS public.entity_field_state (
+    organization_id text   NOT NULL,
+    entity_id       bigint NOT NULL,
+    field           text   NOT NULL,
+    value           jsonb,
+    observation_id  bigint NOT NULL,
+    updated_at      timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT entity_field_state_pkey PRIMARY KEY (entity_id, field)
+);
+
+-- organization_id is stored for tenancy + the contract-phase orphan sweep (entity
+-- ids are globally unique, so it is not part of the PK). The supporting index
+-- lands with that sweep, not here — nothing scans by org in the expand phase.
+
+COMMENT ON TABLE public.entity_field_state IS
+    'Trigger-maintained projection of the latest entity_field event per (entity_id, field). Rebuildable cache; the events log is the source of truth. No FK to entities (an append-only log may reference deleted entities; orphans are harmless cache rows swept in the contract phase).';
+
+-- keep-greater-observation_id upsert. events.id is monotonic at assignment, so a
+-- later write carries the higher id; the ON CONFLICT row-lock serializes two
+-- concurrent upserts on the same (entity_id, field). Multi-replica-safe:
+-- serialization happens in Postgres, not in any pod's memory.
+--
+-- Two hard safety properties, since this fires on the HOT append-only events
+-- table and the table has no org in its PK / no FK:
+--   * NULL-safe, integer-validated guard (coalesce + 1..18-digit regex) BEFORE
+--     the ::bigint cast — a missing / float / overflowing / non-object payload
+--     degrades to a no-op and can NEVER abort the host events insert.
+--   * Tenancy boundary: only projects for an entity that actually belongs to the
+--     event's organization, so a cross-org event can't hijack or re-stamp a row
+--     (organization_id is therefore NOT updated on conflict — it's immutable per
+--     entity). Unknown/deleted entities are skipped (also covers the no-FK case).
+CREATE OR REPLACE FUNCTION public.project_entity_field() RETURNS trigger AS $$
+DECLARE
+    v_entity_id bigint;
+BEGIN
+    IF coalesce(jsonb_typeof(NEW.metadata->'fields'), '') <> 'object'
+       OR coalesce(NEW.metadata->>'entity_id', '') !~ '^[0-9]{1,18}$' THEN
+        RETURN NEW;
+    END IF;
+    v_entity_id := (NEW.metadata->>'entity_id')::bigint;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM public.entities
+        WHERE id = v_entity_id
+          AND organization_id = NEW.organization_id
+          AND deleted_at IS NULL
+    ) THEN
+        RETURN NEW;  -- unknown, deleted, or cross-org entity: skip, never project
+    END IF;
+
+    INSERT INTO public.entity_field_state (organization_id, entity_id, field, value, observation_id, updated_at)
+    SELECT NEW.organization_id, v_entity_id, kv.key, kv.value, NEW.id, now()
+    FROM jsonb_each(NEW.metadata->'fields') kv
+    ON CONFLICT (entity_id, field) DO UPDATE
+        SET value = EXCLUDED.value,
+            observation_id = EXCLUDED.observation_id,
+            updated_at = now()
+        WHERE entity_field_state.observation_id < EXCLUDED.observation_id;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- WHEN clause keeps the 99% non-field inserts from ever entering the plpgsql
+-- frame (predicate evaluated in C). Sibling of the append-only BEFORE DELETE
+-- guard — disjoint timing/event, no conflict.
+DROP TRIGGER IF EXISTS trg_project_entity_field ON public.events;
+CREATE TRIGGER trg_project_entity_field
+    AFTER INSERT ON public.events
+    FOR EACH ROW
+    WHEN (NEW.semantic_type = 'entity_field')
+    EXECUTE FUNCTION public.project_entity_field();
+
+-- migrate:down
+DROP TRIGGER IF EXISTS trg_project_entity_field ON public.events;
+DROP FUNCTION IF EXISTS public.project_entity_field();
+-- squawk-ignore ban-drop-table
+DROP TABLE IF EXISTS public.entity_field_state;

--- a/packages/server/src/__tests__/integration/entities/entity-field-producer.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-field-producer.test.ts
@@ -1,0 +1,96 @@
+/**
+ * entity_field projection PRODUCER — manage_entity create/update emit an
+ * entity_field event INSIDE the entity-write transaction, so the projection
+ * (entity_field_state) tracks entities.metadata. Because emission is synchronous
+ * (awaited in the txn), reads need no polling.
+ *
+ * The concurrency test is the load-bearing one: it proves the projection
+ * converges to the SAME value as the authoritative entities.metadata even under
+ * concurrent updates to the same field — i.e. the FOR UPDATE + same-txn emission
+ * orders the projection consistently with the metadata write.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { TestApiClient } from '../../setup/test-mcp-client';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+
+const sql = getTestDb();
+
+let owner: TestApiClient;
+
+async function makeEntity(name: string, metadata?: Record<string, unknown>): Promise<number> {
+  const created = (await owner.entities.create({ type: 'company', name, metadata })) as {
+    entity?: { id: number };
+  };
+  return created.entity!.id;
+}
+
+async function tierState(entityId: number): Promise<{ value: unknown; obs: number } | undefined> {
+  const rows = (await sql`
+    SELECT value, observation_id FROM entity_field_state
+    WHERE entity_id = ${entityId} AND field = 'tier'
+  `) as Array<{ value: unknown; observation_id: string }>;
+  if (rows.length === 0) return undefined;
+  return { value: rows[0].value, obs: Number(rows[0].observation_id) };
+}
+
+async function entityTier(entityId: number): Promise<unknown> {
+  const rows = (await sql`
+    SELECT metadata->>'tier' AS tier FROM entities WHERE id = ${entityId}
+  `) as Array<{ tier: string | null }>;
+  return rows[0]?.tier ?? null;
+}
+
+describe('entity_field projection producer (manage_entity)', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Producer Org' });
+    const u = await createTestUser({ email: 'producer-owner@test.com' });
+    await addUserToOrganization(u.id, org.id, 'owner');
+    owner = await TestApiClient.for({ organizationId: org.id, userId: u.id, memberRole: 'owner' });
+    await owner.entity_schema.createType({ slug: 'company', name: 'Company' });
+  });
+
+  it('create populates the projection (synchronously, no polling)', async () => {
+    const id = await makeEntity('Acme', { tier: 'gold', employees: 50 });
+    const tier = await tierState(id);
+    expect(tier?.value).toBe('gold');
+    const emp = (await sql`
+      SELECT value FROM entity_field_state WHERE entity_id = ${id} AND field = 'employees'
+    `) as Array<{ value: unknown }>;
+    expect(emp[0].value).toBe(50);
+  });
+
+  it('update advances the projection and matches entities.metadata', async () => {
+    const id = await makeEntity('Globex', { tier: 'silver' });
+    const before = await tierState(id);
+    await owner.entities.update({ entity_id: id, metadata: { tier: 'platinum' } });
+    const after = await tierState(id);
+    expect(after?.value).toBe('platinum');
+    expect(after!.obs).toBeGreaterThan(before!.obs);
+    expect(after?.value).toBe(await entityTier(id));
+  });
+
+  it('concurrent updates: projection converges to the SAME value as entities.metadata', async () => {
+    const id = await makeEntity('Race Co', { tier: 'v0' });
+    // Fire several concurrent updates to the same field; FOR UPDATE serializes
+    // them and the same-txn event emission orders the projection identically.
+    await Promise.all([
+      owner.entities.update({ entity_id: id, metadata: { tier: 'a' } }),
+      owner.entities.update({ entity_id: id, metadata: { tier: 'b' } }),
+      owner.entities.update({ entity_id: id, metadata: { tier: 'c' } }),
+      owner.entities.update({ entity_id: id, metadata: { tier: 'd' } }),
+    ]);
+    const projected = await tierState(id);
+    const authoritative = await entityTier(id);
+    // Whatever won the row lock last is in entities.metadata; the projection must
+    // agree (no stale/inverted winner).
+    expect(projected?.value).toBe(authoritative);
+    expect(['a', 'b', 'c', 'd']).toContain(authoritative);
+  });
+});

--- a/packages/server/src/__tests__/integration/entities/entity-field-projection.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-field-projection.test.ts
@@ -1,0 +1,168 @@
+/**
+ * entity_field_state projection SUBSTRATE — expand phase.
+ *
+ * The DB trigger `project_entity_field` folds 'entity_field' events into
+ * `entity_field_state` (latest event per (entity_id, field) wins, keep-greater on
+ * the monotonic event id) — but ONLY for a well-formed event whose entity belongs
+ * to the event's org. The trigger fires synchronously with the event insert, so
+ * no polling is needed. Asserts:
+ *   1. fields land in the projection (org-scoped),
+ *   2. a later event advances value + observation_id,
+ *   3. keep-greater REJECTS an event with a lower observation_id (out-of-order),
+ *   4. a malformed event NEVER aborts the host events insert (degrades to no-op),
+ *   5. a cross-org event CANNOT touch another org's projection row (tenancy),
+ *   6. entity_field events carry no entity link (no content-count pollution).
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { TestApiClient } from '../../setup/test-mcp-client';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { insertEvent } from '../../../utils/insert-event';
+
+const sql = getTestDb();
+
+let orgA: string;
+let orgB: string;
+let clientA: TestApiClient;
+let counter = 0;
+
+async function makeEntity(client: TestApiClient, name: string): Promise<number> {
+  const created = (await client.entities.create({ type: 'company', name })) as {
+    entity?: { id: number };
+  };
+  return created.entity!.id;
+}
+
+async function emitFields(
+  orgId: string,
+  entityId: number,
+  fields: Record<string, unknown>
+): Promise<number> {
+  counter += 1;
+  const ev = await insertEvent({
+    entityIds: [],
+    organizationId: orgId,
+    originId: `efield_test_${counter}`,
+    semanticType: 'entity_field',
+    metadata: { entity_id: entityId, fields },
+  });
+  return ev.id;
+}
+
+async function fieldState(
+  entityId: number
+): Promise<Record<string, { value: unknown; obs: number; org: string }>> {
+  const rows = (await sql`
+    SELECT organization_id, field, value, observation_id
+    FROM entity_field_state WHERE entity_id = ${entityId}
+  `) as Array<{ organization_id: string; field: string; value: unknown; observation_id: string }>;
+  const out: Record<string, { value: unknown; obs: number; org: string }> = {};
+  for (const r of rows) {
+    out[r.field] = { value: r.value, obs: Number(r.observation_id), org: r.organization_id };
+  }
+  return out;
+}
+
+describe('entity_field_state projection substrate (expand phase)', () => {
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+
+    const oa = await createTestOrganization({ name: 'Projection Org A' });
+    orgA = oa.id;
+    const ua = await createTestUser({ email: 'proj-a@test.com' });
+    await addUserToOrganization(ua.id, oa.id, 'owner');
+    clientA = await TestApiClient.for({ organizationId: oa.id, userId: ua.id, memberRole: 'owner' });
+    await clientA.entity_schema.createType({ slug: 'company', name: 'Company' });
+
+    const ob = await createTestOrganization({ name: 'Projection Org B' });
+    orgB = ob.id;
+    const ub = await createTestUser({ email: 'proj-b@test.com' });
+    await addUserToOrganization(ub.id, ob.id, 'owner');
+  });
+
+  it('folds entity_field events into the projection (org-scoped)', async () => {
+    const id = await makeEntity(clientA, 'Acme');
+    await emitFields(orgA, id, { tier: 'gold', employees: 50 });
+    const st = await fieldState(id);
+    expect(st.tier.value).toBe('gold');
+    expect(st.employees.value).toBe(50);
+    expect(st.tier.org).toBe(orgA);
+  });
+
+  it('a later event advances the projected value and observation_id', async () => {
+    const id = await makeEntity(clientA, 'Globex');
+    await emitFields(orgA, id, { tier: 'silver' });
+    const before = await fieldState(id);
+    await emitFields(orgA, id, { tier: 'platinum' });
+    const after = await fieldState(id);
+    expect(after.tier.value).toBe('platinum');
+    expect(after.tier.obs).toBeGreaterThan(before.tier.obs);
+  });
+
+  it('keep-greater REJECTS an event with a lower observation_id (out-of-order)', async () => {
+    const id = await makeEntity(clientA, 'Initech');
+    await emitFields(orgA, id, { tier: 'gold' });
+    // Simulate a much later event already projected.
+    await sql`
+      UPDATE entity_field_state SET observation_id = 9223372036854775000
+      WHERE entity_id = ${id} AND field = 'tier'
+    `;
+    await emitFields(orgA, id, { tier: 'bronze' });
+    const st = await fieldState(id);
+    expect(st.tier.value).toBe('gold'); // lower id rejected
+  });
+
+  it('a malformed entity_field event NEVER aborts the host events insert', async () => {
+    const id = await makeEntity(clientA, 'Malformed Co');
+    // Each of these must resolve (no thrown abort of the events insert) AND
+    // leave no projection row.
+    const bad: Array<Record<string, unknown>> = [
+      { fields: { x: 1 } }, // entity_id missing
+      { entity_id: 3.9, fields: { x: 1 } }, // non-integer number
+      { entity_id: 99999999999999999999999, fields: { x: 1 } }, // out of bigint range
+      { entity_id: id, fields: 'not-an-object' }, // fields not an object
+    ];
+    for (const [i, meta] of bad.entries()) {
+      await expect(
+        insertEvent({
+          entityIds: [],
+          organizationId: orgA,
+          originId: `efield_bad_${i}`,
+          semanticType: 'entity_field',
+          metadata: meta,
+        })
+      ).resolves.toBeTruthy();
+    }
+    expect(Object.keys(await fieldState(id))).toHaveLength(0);
+  });
+
+  it("a cross-org event CANNOT touch another org's projection row (tenancy)", async () => {
+    const id = await makeEntity(clientA, 'Tenancy Co'); // owned by org A
+    await emitFields(orgA, id, { tier: 'gold' });
+
+    // Org B emits a field event for org A's entity id — the ownership check must
+    // skip it (entity does not belong to org B), even though its event id is higher.
+    await emitFields(orgB, id, { tier: 'HIJACKED' });
+
+    const st = await fieldState(id);
+    expect(st.tier.value).toBe('gold'); // unchanged
+    expect(st.tier.org).toBe(orgA); // org not re-stamped to B
+  });
+
+  it('does not pollute entity-linked content: entity_field events carry no entity link', async () => {
+    const id = await makeEntity(clientA, 'Clean Co');
+    await emitFields(orgA, id, { tier: 'gold' });
+    const rows = (await sql`
+      SELECT count(*)::int AS n FROM events
+      WHERE semantic_type = 'entity_field'
+        AND organization_id = ${orgA}
+        AND entity_ids IS NOT NULL AND array_length(entity_ids, 1) >= 1
+    `) as Array<{ n: number }>;
+    expect(rows[0].n).toBe(0);
+  });
+});

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -20,6 +20,7 @@ import type { ToolContext } from '../tools/registry';
 import { entityLinkMatchSql } from './content-search';
 import { type EntityHookContext, getEntityHooks } from './entity-hooks';
 import { ToolUserError } from './errors';
+import { insertEvent } from './insert-event';
 import { requireWriteAccess } from './organization-access';
 import { RESERVED_ENTITY_TYPES } from './reserved';
 
@@ -189,6 +190,41 @@ async function loadEntityTreeIds(sql: DbClient, entityId: number): Promise<numbe
  * Create new entity
  * Entity is created in the user's organization
  */
+/**
+ * Emit one 'entity_field' event INSIDE the given transaction — the projection
+ * source for entity_field_state. Emitting in the same txn as the entity write
+ * (under the row lock for updates) makes the event's events.id order consistently
+ * with the metadata write, which is what the projection's keep-greater fold
+ * relies on. entity_ids is empty (NULL) so the event never matches entity-linked
+ * content queries; org + entity id + the changed fields ride in metadata.
+ */
+async function emitEntityFieldEvent(
+  tx: ReturnType<typeof getDb>,
+  params: {
+    entityId: number;
+    organizationId: string;
+    fields: Record<string, unknown>;
+    createdBy?: string | null;
+  }
+): Promise<void> {
+  if (Object.keys(params.fields).length === 0) return;
+  // No clientId on purpose: insertEvent's stale-clientId FK fallback retries
+  // after a failed insert, which can't recover inside this caller's transaction
+  // (a failed statement aborts the txn and would roll back the entity write).
+  // The projection event is internal; it doesn't need a client stamp.
+  await insertEvent(
+    {
+      entityIds: [],
+      organizationId: params.organizationId,
+      originId: `efield_${params.entityId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      semanticType: 'entity_field',
+      metadata: { entity_id: params.entityId, fields: params.fields },
+      createdBy: params.createdBy ?? null,
+    },
+    { sql: tx }
+  );
+}
+
 export async function createEntity(
   data: EntityData,
   opts?: EntityCreateOptions
@@ -284,24 +320,38 @@ export async function createEntity(
   const contentHash = data.content_hash || null;
 
   try {
-    const result = await sql<Omit<CreatedEntity, 'entity_type'>>`
-      INSERT INTO entities (
-        organization_id, entity_type_id, name, slug, parent_id, metadata, enabled_classifiers, created_by, content, embedding, content_hash, created_at, updated_at
-      ) VALUES (
-        ${data.organization_id}, ${entityTypeId}, ${data.name.trim()}, ${slug}, ${data.parent_id || null},
-        ${sql.json(metadata)}, ${data.enabled_classifiers ? pgTextArray(data.enabled_classifiers) : null}::text[], ${createdBy},
-        ${contentValue}, ${embeddingLiteral}::vector, ${contentHash}, current_timestamp, current_timestamp
-      )
-      RETURNING id, name, slug, parent_id, metadata, created_at
-    `;
-
-    if (result.length === 0) {
-      throw new Error('Failed to create entity');
-    }
+    const inserted = await sql.begin(async (tx) => {
+      const rows = await tx<Omit<CreatedEntity, 'entity_type'>>`
+        INSERT INTO entities (
+          organization_id, entity_type_id, name, slug, parent_id, metadata, enabled_classifiers, created_by, content, embedding, content_hash, created_at, updated_at
+        ) VALUES (
+          ${data.organization_id}, ${entityTypeId}, ${data.name.trim()}, ${slug}, ${data.parent_id || null},
+          ${sql.json(metadata)}, ${data.enabled_classifiers ? pgTextArray(data.enabled_classifiers) : null}::text[], ${createdBy},
+          ${contentValue}, ${embeddingLiteral}::vector, ${contentHash}, current_timestamp, current_timestamp
+        )
+        RETURNING id, name, slug, parent_id, metadata, created_at
+      `;
+      if (rows.length === 0) {
+        throw new Error('Failed to create entity');
+      }
+      // Project the created metadata into entity_field_state in THIS txn — the
+      // new entity row is already visible to the trigger's ownership check.
+      const createdMetadata: Record<string, unknown> =
+        typeof rows[0].metadata === 'string'
+          ? JSON.parse(rows[0].metadata)
+          : ((rows[0].metadata as Record<string, unknown> | null) ?? {});
+      await emitEntityFieldEvent(tx as unknown as ReturnType<typeof getDb>, {
+        entityId: rows[0].id,
+        organizationId: data.organization_id as string,
+        fields: createdMetadata,
+        createdBy: createdBy === 'system' ? null : createdBy,
+      });
+      return rows[0];
+    });
 
     // The validator above already resolved data.entity_type → entityTypeId.
     // Pass the slug back through directly rather than JOIN-ing on every insert.
-    const created: CreatedEntity = { ...result[0], entity_type: data.entity_type };
+    const created: CreatedEntity = { ...inserted, entity_type: data.entity_type };
 
     // Run afterCreate hook
     if (!opts?.skipHooks && opts?.hookContext) {
@@ -363,55 +413,78 @@ export async function updateEntity(
   const metadataUpdates = mergeConvenienceFields(data, data.metadata ?? {}, 'update');
   const hasMetadataUpdates = Object.keys(metadataUpdates).length > 0;
 
-  // First get the current entity so we can merge metadata
-  const current = await sql`
-    SELECT metadata FROM entities WHERE id = ${entityId} AND deleted_at IS NULL
-  `;
-  if (current.length === 0) {
-    throw new Error(`Entity ${entityId} not found`);
-  }
-
-  // Merge metadata in TypeScript
-  let mergedMetadata: Record<string, unknown> | null = null;
-  if (hasMetadataUpdates) {
-    const existing =
-      typeof current[0].metadata === 'string'
-        ? JSON.parse(current[0].metadata as string)
-        : (current[0].metadata ?? {});
-    mergedMetadata = { ...existing, ...metadataUpdates };
-  }
-
   const hasContent = data.content !== undefined;
   const contentValue = data.content?.trim() || null;
   const hasEmbedding = data.embedding !== undefined;
   const embeddingLiteral = toVectorLiteral(data.embedding);
 
-  await sql`
-    UPDATE entities SET
-      name = COALESCE(${data.name ?? null}, name),
-      slug = COALESCE(${newSlug}, slug),
-      parent_id = CASE WHEN ${data.parent_id !== undefined} THEN ${data.parent_id ?? null}::bigint ELSE parent_id END,
-      metadata = CASE WHEN ${hasMetadataUpdates} THEN ${mergedMetadata ? sql.json(mergedMetadata) : null} ELSE metadata END,
-      enabled_classifiers = CASE WHEN ${data.enabled_classifiers !== undefined} THEN ${data.enabled_classifiers ? pgTextArray(data.enabled_classifiers) : null}::text[] ELSE enabled_classifiers END,
-      content = CASE WHEN ${hasContent} THEN ${contentValue} ELSE content END,
-      embedding = CASE WHEN ${hasEmbedding} THEN ${embeddingLiteral}::vector ELSE embedding END,
-      updated_at = current_timestamp
-    WHERE id = ${entityId} AND deleted_at IS NULL
-  `;
+  // Lock the entity row, merge metadata, write, and emit the projection event in
+  // ONE transaction: concurrent updates to the same entity serialize on the row
+  // lock, so the emitted entity_field event's events.id orders consistently with
+  // this metadata write — which is exactly what the projection's keep-greater
+  // fold relies on. (Also fixes the pre-existing non-transactional read-modify-
+  // write race on entities.metadata.)
+  const result = await sql.begin(async (tx) => {
+    const current = await tx`
+      SELECT metadata, organization_id FROM entities
+      WHERE id = ${entityId} AND deleted_at IS NULL
+      FOR UPDATE
+    `;
+    if (current.length === 0) {
+      throw new Error(`Entity ${entityId} not found`);
+    }
+    const orgId = current[0].organization_id as string;
 
-  const result = await sql<CreatedEntity>`
-    SELECT e.id, et.slug AS entity_type, e.name, e.slug, e.parent_id, e.metadata, e.created_at
-    FROM entities e
-    JOIN entity_types et ON et.id = e.entity_type_id
-    WHERE e.id = ${entityId}
-    LIMIT 1
-  `;
+    let mergedMetadata: Record<string, unknown> | null = null;
+    const changedFields: Record<string, unknown> = {};
+    if (hasMetadataUpdates) {
+      const existing = (
+        typeof current[0].metadata === 'string'
+          ? JSON.parse(current[0].metadata as string)
+          : (current[0].metadata ?? {})
+      ) as Record<string, unknown>;
+      mergedMetadata = { ...existing, ...metadataUpdates };
+      for (const [k, v] of Object.entries(metadataUpdates)) {
+        if (JSON.stringify(existing[k]) !== JSON.stringify(v)) {
+          changedFields[k] = v;
+        }
+      }
+    }
 
-  if (result.length === 0) {
-    throw new Error(`Entity ${entityId} not found`);
-  }
+    await tx`
+      UPDATE entities SET
+        name = COALESCE(${data.name ?? null}, name),
+        slug = COALESCE(${newSlug}, slug),
+        parent_id = CASE WHEN ${data.parent_id !== undefined} THEN ${data.parent_id ?? null}::bigint ELSE parent_id END,
+        metadata = CASE WHEN ${hasMetadataUpdates} THEN ${mergedMetadata ? sql.json(mergedMetadata) : null} ELSE metadata END,
+        enabled_classifiers = CASE WHEN ${data.enabled_classifiers !== undefined} THEN ${data.enabled_classifiers ? pgTextArray(data.enabled_classifiers) : null}::text[] ELSE enabled_classifiers END,
+        content = CASE WHEN ${hasContent} THEN ${contentValue} ELSE content END,
+        embedding = CASE WHEN ${hasEmbedding} THEN ${embeddingLiteral}::vector ELSE embedding END,
+        updated_at = current_timestamp
+      WHERE id = ${entityId} AND deleted_at IS NULL
+    `;
 
-  return result[0];
+    await emitEntityFieldEvent(tx as unknown as ReturnType<typeof getDb>, {
+      entityId,
+      organizationId: orgId,
+      fields: changedFields,
+      createdBy: ctx.userId ?? null,
+    });
+
+    const sel = await tx<CreatedEntity>`
+      SELECT e.id, et.slug AS entity_type, e.name, e.slug, e.parent_id, e.metadata, e.created_at
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.id = ${entityId}
+      LIMIT 1
+    `;
+    if (sel.length === 0) {
+      throw new Error(`Entity ${entityId} not found`);
+    }
+    return sel[0];
+  });
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
Collapses the P5 stack (#1440 substrate + #1442 producer) into one PR onto current main, per the consolidation plan (P4-style single PR per track).

## What
- New `entity_field_state` table — a trigger-maintained projection of `entity_field` events. Current value of each `(entity_id, field)` = latest event carrying it; keep-greater `ON CONFLICT` row-lock makes it multi-replica-safe (validated by the live PG concurrency prototype: 0 skew under max contention, µs PK reads, ~1.4s rebuild over 2M events). Inert until the producer emits.
- Producer: `createEntity`/`updateEntity` emit `entity_field` events **inside the write transaction** (`updateEntity` takes a `FOR UPDATE` row lock so the event id orders consistently with the metadata write — also fixes a pre-existing non-transactional metadata read-modify-write race).

## Conflict resolution
`entity-management.ts` conflicted with current main (the stack predates P4 #1483). Resolved by keeping the P4 `enabled_classifiers` `pgTextArray(...)::text[]` bind (the fetch_types:false raw-array-trap fix) inside the new transactional create/update paths.

## Verification
- `tsc --noEmit` clean.
- 9/9 integration tests green on real Postgres (`entity-field-projection.test.ts` 6, `entity-field-producer.test.ts` 3).
- Migration `20260622150000` — no version collision with current main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784774592&installation_id=136316292&pr_number=1508&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1508&signature=236246793b20a0c52201cc50e6c92db67aed77365ef3ee957dea9b11e2f94abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entity field changes are now automatically tracked and projected when creating or updating entities.
  * Field-level change events are emitted transactionally within the same operation as entity modifications for consistent event ordering.
  * Entity field state is reliably maintained and remains consistent even under concurrent update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->