### PR TITLE
feat(corrections): retire watcher_window_field_feedback onto correction events (P1, collapsed)

### DIFF
--- a/db/migrations/20260622270000_feedback_correction_events.sql
+++ b/db/migrations/20260622270000_feedback_correction_events.sql
@@ -1,0 +1,51 @@
+-- migrate:up
+
+-- Correction-events consolidation (P1) phase 1 (expand): mirror watcher_window_field_feedback
+-- (append-only window-field corrections) into the events spine as semantic_type='correction'
+-- (the single edit model). A trigger mirrors new feedback rows; historic rows backfill OUT OF
+-- BAND (scripts/backfill-feedback-corrections.sh). Additive — nothing reads the correction
+-- events yet (feedback reads still use watcher_window_field_feedback; flip in phase 2).
+--
+-- Pollution-safe (Spike F lesson): entity_ids=[] + NO payload_text + semantic_type='correction'
+-- keep these OUT of content/search/embedding consumers.
+-- FK-safe: created_by is resolved to NULL if it isn't a valid user, so the mirror can NEVER
+-- break a feedback submit on the events_created_by_fkey (feedback already requires a user, but
+-- this is belt-and-suspenders for backfilled/edge rows).
+-- O(1) at deploy: trigger create only; the (events-spine) backfill is out-of-band batched.
+
+CREATE OR REPLACE FUNCTION public.mirror_feedback_correction() RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public.events
+    (organization_id, semantic_type, entity_ids, origin_id, metadata, created_by, occurred_at, created_at)
+  VALUES (
+    NEW.organization_id,
+    'correction',
+    '{}'::bigint[],
+    'wwff_' || NEW.id::text,
+    jsonb_build_object(
+      'window_id', NEW.window_id,
+      'watcher_id', NEW.watcher_id,
+      'field_path', NEW.field_path,
+      'mutation', NEW.mutation,
+      'corrected_value', NEW.corrected_value,
+      'note', NEW.note
+    ),
+    (SELECT u.id FROM public."user" u WHERE u.id = NEW.created_by),
+    NEW.created_at,
+    NEW.created_at
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_mirror_feedback_correction
+  AFTER INSERT ON public.watcher_window_field_feedback
+  FOR EACH ROW EXECUTE FUNCTION public.mirror_feedback_correction();
+
+-- migrate:down
+
+-- events is APPEND-ONLY (never DELETE FROM events). The down removes only the trigger +
+-- function; the mirrored 'correction' events remain (harmless — pre-P1 readers don't read
+-- semantic_type='correction'). Tombstone semantics, per the append-only invariant.
+DROP TRIGGER IF EXISTS trg_mirror_feedback_correction ON public.watcher_window_field_feedback;
+DROP FUNCTION IF EXISTS public.mirror_feedback_correction();

--- a/db/migrations/20260622280000_drop_watcher_window_field_feedback.sql
+++ b/db/migrations/20260622280000_drop_watcher_window_field_feedback.sql
@@ -1,0 +1,78 @@
+-- migrate:up
+
+-- Correction-events (P1): watcher_window_field_feedback is fully retired — all reads AND writes now
+-- use the events spine (semantic_type='correction'). This migration ships COLLAPSED (expand +
+-- read/write flip + drop in one release / flag-day), so the historic backfill that the staged
+-- rollout ran out-of-band (scripts/backfill-feedback-corrections.sh) is folded inline BELOW —
+-- existing feedback is mirrored into correction events before the table is dropped, so no history
+-- is lost. (Multi-replica note: feedback submit/get is a rare human op; old pods may briefly 500 on
+-- it during the rolling deploy until replaced — accepted, same flag-day tradeoff as the P4 drop.)
+
+-- Keep the id sequence ALIVE past the table: the write path still allocates 'wwff_<seq>' ids.
+ALTER SEQUENCE public.watcher_window_field_feedback_id_seq OWNED BY NONE;
+
+-- Fold the historic backfill inline (table is human-scale, not events-scale → safe in-migration).
+-- Idempotent via origin_id; created_by FK-safe-resolved (NULL if not a live user), matching the
+-- trigger. Mirrors every not-yet-mirrored feedback row into a 'correction' event before the drop.
+INSERT INTO public.events
+  (organization_id, semantic_type, entity_ids, origin_id, metadata, created_by, occurred_at, created_at)
+SELECT
+  f.organization_id, 'correction', '{}'::bigint[], 'wwff_' || f.id::text,
+  jsonb_build_object(
+    'window_id', f.window_id, 'watcher_id', f.watcher_id, 'field_path', f.field_path,
+    'mutation', f.mutation, 'corrected_value', f.corrected_value, 'note', f.note),
+  (SELECT u.id FROM public."user" u WHERE u.id = f.created_by),
+  f.created_at, f.created_at
+FROM public.watcher_window_field_feedback f
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.events e
+  WHERE e.origin_id = 'wwff_' || f.id::text AND e.semantic_type = 'correction'
+);
+
+DROP TRIGGER IF EXISTS trg_mirror_feedback_correction ON public.watcher_window_field_feedback;
+DROP FUNCTION IF EXISTS public.mirror_feedback_correction();
+
+-- squawk-ignore ban-drop-table
+DROP TABLE IF EXISTS public.watcher_window_field_feedback;
+
+-- migrate:down
+
+-- Restore the table structure + sequence ownership + the mirror trigger. NOTE: the correction
+-- DATA lives in events (semantic_type='correction') and is NOT moved back by this down.
+CREATE TABLE IF NOT EXISTS public.watcher_window_field_feedback (
+  id bigint PRIMARY KEY DEFAULT nextval('public.watcher_window_field_feedback_id_seq'),
+  -- squawk-ignore prefer-bigint-over-int -- restores the original integer FK columns (referencing integer PKs)
+  window_id integer NOT NULL REFERENCES public.watcher_windows(id) ON DELETE CASCADE,
+  -- squawk-ignore prefer-bigint-over-int -- restores the original integer FK columns (referencing integer PKs)
+  watcher_id integer NOT NULL REFERENCES public.watchers(id) ON DELETE CASCADE,
+  organization_id text NOT NULL,
+  field_path text NOT NULL,
+  mutation text NOT NULL DEFAULT 'set',
+  corrected_value jsonb,
+  note text,
+  created_by text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT watcher_window_field_feedback_mutation_check
+    CHECK (mutation IN ('set', 'remove', 'add'))
+);
+ALTER SEQUENCE public.watcher_window_field_feedback_id_seq
+  OWNED BY public.watcher_window_field_feedback.id;
+
+CREATE OR REPLACE FUNCTION public.mirror_feedback_correction() RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public.events
+    (organization_id, semantic_type, entity_ids, origin_id, metadata, created_by, occurred_at, created_at)
+  VALUES (
+    NEW.organization_id, 'correction', '{}'::bigint[], 'wwff_' || NEW.id::text,
+    jsonb_build_object('window_id', NEW.window_id, 'watcher_id', NEW.watcher_id,
+      'field_path', NEW.field_path, 'mutation', NEW.mutation,
+      'corrected_value', NEW.corrected_value, 'note', NEW.note),
+    (SELECT u.id FROM public."user" u WHERE u.id = NEW.created_by),
+    NEW.created_at, NEW.created_at
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER trg_mirror_feedback_correction
+  AFTER INSERT ON public.watcher_window_field_feedback
+  FOR EACH ROW EXECUTE FUNCTION public.mirror_feedback_correction();

--- a/packages/server/src/__tests__/integration/corrections/feedback-steady-state.test.ts
+++ b/packages/server/src/__tests__/integration/corrections/feedback-steady-state.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Correction-events (P1) STEADY STATE (post phase-4 contract): watcher_window_field_feedback is
+ * retired; every submit emits a correction event directly and every read comes from the events
+ * spine (semantic_type='correction'). No flags, no table. This is the end-state round-trip.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  handleGetFeedback,
+  handleSubmitFeedback,
+} from '../../../tools/admin/manage_watchers/feedback';
+import type { ToolContext } from '../../../tools/registry';
+import { getRecentFeedbackSummary } from '../../../utils/watcher-feedback';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const sql = getTestDb();
+
+describe('feedback correction-events steady state (P1 phase 4)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('submit -> get -> summary round-trips entirely through correction events (no table)', async () => {
+    const org = await createTestOrganization({ name: 'FSS Org' });
+    const user = await createTestUser({ email: 'fss@test.com' });
+    const agent = await createTestAgent({ organizationId: org.id, ownerUserId: user.id });
+    const watcherId = 953000;
+    await sql`
+      INSERT INTO watchers (id, name, slug, created_by, organization_id, agent_id, watcher_group_id)
+      VALUES (${watcherId}, 'w', 'w-fss', ${user.id}, ${org.id}, ${agent.agentId}, ${watcherId})
+    `;
+    const windowId = 953001;
+    await sql`
+      INSERT INTO watcher_windows (id, watcher_id, granularity, window_start, window_end, content_analyzed, extracted_data)
+      VALUES (${windowId}, ${watcherId}, 'daily', NOW(), NOW(), 0, '{}'::jsonb)
+    `;
+    const ctx = { organizationId: org.id, userId: user.id } as ToolContext;
+
+    const submitted = await handleSubmitFeedback(
+      {
+        watcher_id: watcherId,
+        window_id: windowId,
+        corrections: [
+          { field_path: 'a', mutation: 'set', value: 'v', note: 'n' },
+          { field_path: 'b', mutation: 'remove' },
+        ],
+      } as never,
+      ctx
+    );
+    expect((submitted as { feedback_ids: number[] }).feedback_ids).toHaveLength(2);
+
+    // The table is retired — this PR's migration drops it; the submit went entirely to events.
+    const reg = (await sql`
+      SELECT to_regclass('public.watcher_window_field_feedback') AS t
+    `) as Array<{ t: string | null }>;
+    expect(reg[0].t).toBeNull();
+
+    // get_feedback returns both, from events, with recovered ids + org scoping.
+    const got = (await handleGetFeedback({ watcher_id: watcherId } as never, ctx)) as {
+      feedback: Array<{ id: number; field_path: string; mutation: string; created_by: string }>;
+    };
+    expect(got.feedback).toHaveLength(2);
+    expect(got.feedback.every((f) => Number.isFinite(f.id) && f.created_by === user.id)).toBe(true);
+    expect(got.feedback.map((f) => f.field_path).sort()).toEqual(['a', 'b']);
+
+    // The prompt summary renders the latest-per-field corrections from events.
+    const summary = await getRecentFeedbackSummary(watcherId);
+    expect(summary).toContain('"a" → v');
+    expect(summary).toContain('drop "b"');
+  });
+});

--- a/packages/server/src/__tests__/integration/watchers/feedback-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/feedback-contract.test.ts
@@ -89,10 +89,19 @@ describe('watcher feedback contract', () => {
   });
 
   beforeEach(async () => {
-    await getTestDb()`DELETE FROM watcher_window_field_feedback WHERE watcher_id = ${Number(watcherId)}`;
+    // Corrections are now append-only 'correction' events; use the documented escape hatch to
+    // isolate each test (watcher_window_field_feedback was retired in the P1 consolidation).
+    await getTestDb().begin(async (tx) => {
+      await tx`SET LOCAL lobu.allow_event_delete = 'on'`;
+      await tx`
+        DELETE FROM events
+        WHERE semantic_type = 'correction'
+          AND (metadata->>'watcher_id')::bigint = ${Number(watcherId)}
+      `;
+    });
   });
 
-  it('stores set/remove/add field corrections from one batch as separate rows', async () => {
+  it('stores set/remove/add field corrections from one batch as separate correction events', async () => {
     const result = (await manageWatchers(
       {
         action: 'submit_feedback',
@@ -111,10 +120,11 @@ describe('watcher feedback contract', () => {
     expect(result.feedback_ids).toHaveLength(3);
 
     const rows = await getTestDb()`
-      SELECT field_path, mutation, corrected_value, note
-      FROM watcher_window_field_feedback
-      WHERE watcher_id = ${Number(watcherId)}
-      ORDER BY field_path ASC
+      SELECT metadata->>'field_path' AS field_path, metadata->>'mutation' AS mutation,
+             metadata->'corrected_value' AS corrected_value, metadata->>'note' AS note
+      FROM events
+      WHERE semantic_type = 'correction' AND (metadata->>'watcher_id')::bigint = ${Number(watcherId)}
+      ORDER BY metadata->>'field_path' ASC
     `;
     expect(rows).toHaveLength(3);
     expect(rows.map((row) => `${row.field_path}:${row.mutation}`)).toEqual([

--- a/packages/server/src/tools/admin/manage_watchers/feedback.ts
+++ b/packages/server/src/tools/admin/manage_watchers/feedback.ts
@@ -63,27 +63,39 @@ export async function handleSubmitFeedback(
   }
   const organizationId = windowCheck[0].organization_id as string;
 
-  // Insert in one transaction so a partial failure never leaks half-applied
-  // corrections — submit_feedback is naturally a batch operation from the UI.
+  // Correction-events (P1): every submit emits a correction event directly to the events spine
+  // (semantic_type='correction'). The id is allocated from the retired table's sequence
+  // (watcher_window_field_feedback_id_seq, kept alive via ALTER SEQUENCE OWNED BY NONE) so
+  // origin_id stays 'wwff_<id>' and the reader's substring id-recovery + ids remain stable.
+  // One transaction so a partial failure never leaks half-applied corrections.
   const feedbackIds = await sql.begin(async (tx) => {
     const ids: number[] = [];
     for (const c of corrections) {
       const mutation = c.mutation ?? 'set';
       const correctedValueJson =
         mutation === 'remove' || c.value === undefined ? null : tx.json(c.value);
-      const result = await tx`
-        INSERT INTO watcher_window_field_feedback (
-          window_id, watcher_id, organization_id,
-          field_path, mutation, corrected_value, note, created_by
+      const [row] = await tx`
+        WITH seq AS (SELECT nextval('watcher_window_field_feedback_id_seq') AS id)
+        INSERT INTO events (
+          organization_id, semantic_type, entity_ids, origin_id, metadata,
+          created_by, occurred_at, created_at
         )
-        VALUES (
-          ${args.window_id}, ${watcherId}, ${organizationId},
-          ${c.field_path}, ${mutation}, ${correctedValueJson},
-          ${c.note ?? null}, ${ctx.userId}
-        )
-        RETURNING id
+        SELECT
+          ${organizationId}, 'correction', '{}'::bigint[], 'wwff_' || seq.id::text,
+          jsonb_build_object(
+            'window_id', ${args.window_id}::bigint,
+            'watcher_id', ${watcherId}::bigint,
+            'field_path', ${c.field_path}::text,
+            'mutation', ${mutation}::text,
+            'corrected_value', ${correctedValueJson}::jsonb,
+            'note', ${c.note ?? null}::text
+          ),
+          (SELECT u.id FROM "user" u WHERE u.id = ${ctx.userId}),
+          NOW(), NOW()
+        FROM seq
+        RETURNING (substring(origin_id from 6))::bigint AS id
       `;
-      ids.push(Number(result[0].id));
+      ids.push(Number(row.id));
     }
     return ids;
   });
@@ -110,30 +122,39 @@ export async function handleGetFeedback(
   const watcherId = Number(args.watcher_id);
   const limit = args.limit ?? 50;
 
-  // Scope to the caller's current org so a member of org A can't enumerate
-  // feedback for a watcher in org B by passing its watcher_id.
+  // Scope to the caller's current org so a member of org A can't enumerate feedback for a watcher
+  // in org B by passing its watcher_id. Correction-events (P1): read from the events spine
+  // (semantic_type='correction'); the feedback id is recovered from origin_id 'wwff_<id>'.
+  // created_by is the author user id, or NULL once that user is deleted (events.created_by FK
+  // SET NULL) — the dangling-id behavior the retired table had is intentionally not reproduced.
   const feedback = args.window_id
     ? await sql`
-        SELECT f.id, f.window_id, f.field_path, f.mutation, f.corrected_value,
-               f.note, f.created_by, f.created_at,
-               w.window_start, w.window_end
-        FROM watcher_window_field_feedback f
-        JOIN watcher_windows w ON f.window_id = w.id
-        WHERE f.watcher_id = ${watcherId}
-          AND f.window_id = ${args.window_id}
-          AND f.organization_id = ${ctx.organizationId}
-        ORDER BY f.created_at DESC
+        SELECT (substring(e.origin_id from 6))::bigint AS id,
+               (e.metadata->>'window_id')::bigint AS window_id,
+               e.metadata->>'field_path' AS field_path, e.metadata->>'mutation' AS mutation,
+               e.metadata->'corrected_value' AS corrected_value, e.metadata->>'note' AS note,
+               e.created_by, e.created_at, w.window_start, w.window_end
+        FROM events e
+        JOIN watcher_windows w ON (e.metadata->>'window_id')::bigint = w.id
+        WHERE e.semantic_type = 'correction'
+          AND (e.metadata->>'watcher_id')::bigint = ${watcherId}
+          AND (e.metadata->>'window_id')::bigint = ${args.window_id}
+          AND e.organization_id = ${ctx.organizationId}
+        ORDER BY e.created_at DESC
         LIMIT ${limit}
       `
     : await sql`
-        SELECT f.id, f.window_id, f.field_path, f.mutation, f.corrected_value,
-               f.note, f.created_by, f.created_at,
-               w.window_start, w.window_end
-        FROM watcher_window_field_feedback f
-        JOIN watcher_windows w ON f.window_id = w.id
-        WHERE f.watcher_id = ${watcherId}
-          AND f.organization_id = ${ctx.organizationId}
-        ORDER BY f.created_at DESC
+        SELECT (substring(e.origin_id from 6))::bigint AS id,
+               (e.metadata->>'window_id')::bigint AS window_id,
+               e.metadata->>'field_path' AS field_path, e.metadata->>'mutation' AS mutation,
+               e.metadata->'corrected_value' AS corrected_value, e.metadata->>'note' AS note,
+               e.created_by, e.created_at, w.window_start, w.window_end
+        FROM events e
+        JOIN watcher_windows w ON (e.metadata->>'window_id')::bigint = w.id
+        WHERE e.semantic_type = 'correction'
+          AND (e.metadata->>'watcher_id')::bigint = ${watcherId}
+          AND e.organization_id = ${ctx.organizationId}
+        ORDER BY e.created_at DESC
         LIMIT ${limit}
       `;
 

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -853,6 +853,8 @@ async function fetchScopeSummary(
         SELECT COUNT(*)::int
         FROM current_event_records ev
         WHERE ev.organization_id = ${organizationId}
+          -- Exclude null-shaped internal events (P1 corrections) from the org content count.
+          AND ev.semantic_type <> 'correction'
       ) AS total_content,
       (
         SELECT COUNT(*)::int
@@ -915,6 +917,8 @@ async function fetchRecentContent(
     FROM current_event_records ev
     LEFT JOIN connections cn ON cn.id = ev.connection_id
     WHERE ev.organization_id = $1
+      -- Exclude null-shaped internal events (P1 corrections) from the recent-content list.
+      AND ev.semantic_type <> 'correction'
       ${entityFilter}
     ORDER BY COALESCE(ev.occurred_at, ev.created_at) DESC
     LIMIT $2

--- a/packages/server/src/utils/watcher-feedback.ts
+++ b/packages/server/src/utils/watcher-feedback.ts
@@ -10,9 +10,9 @@ import { getDb } from '../db/client';
 /**
  * Build a human-readable summary of past user corrections for a watcher.
  *
- * Returns only the most-recent correction per (field_path) — earlier
- * superseded corrections are dropped so the prompt does not accumulate
- * historical noise. Returns undefined if no feedback exists.
+ * Reads window-field corrections from the events spine (semantic_type='correction'). Returns
+ * only the most-recent correction per (field_path) — earlier superseded corrections are dropped
+ * so the prompt does not accumulate historical noise. Returns undefined if no feedback exists.
  */
 export async function getRecentFeedbackSummary(
   watcherId: number | string,
@@ -20,15 +20,20 @@ export async function getRecentFeedbackSummary(
 ): Promise<string | undefined> {
   const sql = getDb();
   const feedback = await sql`
-    SELECT DISTINCT ON (f.field_path)
-           f.field_path, f.mutation, f.corrected_value, f.note, f.created_at,
-           w.window_start, w.window_end
-    FROM watcher_window_field_feedback f
-    JOIN watcher_windows w ON f.window_id = w.id
-    WHERE f.watcher_id = ${watcherId}
-    ORDER BY f.field_path, f.created_at DESC
-    LIMIT ${limit}
-  `;
+        SELECT DISTINCT ON (e.metadata->>'field_path')
+               e.metadata->>'field_path' AS field_path,
+               e.metadata->>'mutation' AS mutation,
+               e.metadata->'corrected_value' AS corrected_value,
+               e.metadata->>'note' AS note,
+               e.created_at,
+               w.window_start, w.window_end
+        FROM events e
+        JOIN watcher_windows w ON (e.metadata->>'window_id')::bigint = w.id
+        WHERE e.semantic_type = 'correction'
+          AND (e.metadata->>'watcher_id')::bigint = ${watcherId}
+        ORDER BY e.metadata->>'field_path', e.created_at DESC
+        LIMIT ${limit}
+      `;
 
   if (feedback.length === 0) return undefined;
 

--- a/scripts/backfill-feedback-corrections.sh
+++ b/scripts/backfill-feedback-corrections.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Correction-events (P1) phase 1 backfill: mirror historic watcher_window_field_feedback rows
+# into the events spine as semantic_type='correction'. OUT OF BAND + batched (events is large);
+# idempotent via NOT EXISTS on origin_id (re-runnable). Each batch is its own tx. created_by is
+# FK-safe-resolved (NULL if not a valid user), matching the trigger.
+set -euo pipefail
+PSQL=(psql "${DATABASE_URL:?set DATABASE_URL}" -v ON_ERROR_STOP=1 -tAc)
+BATCH="${BATCH:-5000}"
+while :; do
+  N=$("${PSQL[@]}" "
+    WITH batch AS (
+      SELECT f.* FROM watcher_window_field_feedback f
+      WHERE NOT EXISTS (
+        SELECT 1 FROM events e WHERE e.origin_id = 'wwff_' || f.id::text AND e.semantic_type = 'correction'
+      )
+      ORDER BY f.id LIMIT ${BATCH}
+    ), ins AS (
+      INSERT INTO events
+        (organization_id, semantic_type, entity_ids, origin_id, metadata, created_by, occurred_at, created_at)
+      SELECT b.organization_id, 'correction', '{}'::bigint[], 'wwff_' || b.id::text,
+        jsonb_build_object('window_id', b.window_id, 'watcher_id', b.watcher_id, 'field_path', b.field_path,
+          'mutation', b.mutation, 'corrected_value', b.corrected_value, 'note', b.note),
+        (SELECT u.id FROM \"user\" u WHERE u.id = b.created_by), b.created_at, b.created_at
+      FROM batch b RETURNING 1
+    ) SELECT count(*) FROM ins;
+  ")
+  echo "backfilled batch: ${N}"
+  [ "${N}" -eq 0 ] && break
+  sleep 0.2
+done
+echo "feedback->correction backfill complete"


### PR DESCRIPTION
Collapses the P1 stack (#1461 mirror → #1464 read-flip → #1465 write-flip → #1466 drop) into one PR onto current main. This is the substrate for your human-in-review-as-events direction: every human field correction on a watcher window now lives in the append-only events log instead of a side table.

## What
- Human field corrections read AND write as `correction` events (`semantic_type='correction'`, `origin_id='wwff_<id>'`, metadata = window_id/watcher_id/field_path/mutation/corrected_value/note).
- `watcher_window_field_feedback` **dropped**. Its id sequence is detached (`OWNED BY NONE`) and kept alive so the write path keeps allocating `wwff_<id>` ids — the load-bearing detail (an owned sequence would drop with the table → `nextval` 500s).

## Data safety (collapse-specific)
The staged rollout ran the historic backfill out-of-band (`backfill-feedback-corrections.sh`) before the drop. A one-release collapse can't, so I **folded an idempotent backfill into the drop migration** — every not-yet-mirrored feedback row becomes a correction event *before* the `DROP TABLE`. No history lost. (Table is human-scale, so inline is safe.)

## Verification
- `tsc` clean; biome clean.
- 4/4 integration tests green on real Postgres (`feedback-steady-state` + `feedback-contract`) **with the table actually dropped**.
- Zero live code refs to the dropped table remain (only the surviving id sequence).

## Honest caveats
- **Flag-day multi-replica window:** feedback submit/get is a rare human op; during the rolling deploy old pods may briefly 500 on it until replaced. Same tradeoff accepted for the P4 drop.
- The inline historic-backfill SQL mirrors the (previously tested) phase-1 trigger shape but isn't directly unit-tested here (the table is gone post-migration). Low risk.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784776970&installation_id=136316292&pr_number=1512&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1512&signature=ecad84d0d049673e53eaab43e1202461aac3946682b45647570f6dba385e69b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->