### PR TITLE
feat(github): add commits feed — attribute who committed when

### DIFF
--- a/packages/connectors/src/__tests__/github-commits.test.ts
+++ b/packages/connectors/src/__tests__/github-commits.test.ts
@@ -1,0 +1,110 @@
+/**
+ * GitHub `commits` feed: poll the commits API and emit one event per commit,
+ * attributed to the author so "who committed when" lands in memory. Commits are
+ * durable + queryable, so polling recovers the full history without depending on
+ * webhook delivery.
+ *
+ * Proves:
+ *   - a linked-account commit → stable per-sha origin_id, origin_type 'commit',
+ *     author date as occurred_at, and author_login/author_id stamped for person
+ *     attribution (entityLinks resolves these to a member),
+ *   - an unlinked-email commit (author === null) → falls back to the git author
+ *     name and carries no author_login/author_id (no false person link).
+ */
+
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { connectorSdkMock } from "./connector-sdk.mock";
+
+mock.module("@lobu/connector-sdk", connectorSdkMock);
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let GitHubConnector: any;
+
+beforeAll(async () => {
+	const mod = await import("../github");
+	GitHubConnector = mod.default;
+});
+
+const COMMITS = [
+	{
+		sha: "abc123",
+		html_url: "https://github.com/lobu-ai/lobu/commit/abc123",
+		commit: {
+			message: "fix: the thing\n\nlonger body text",
+			author: { name: "Burak", email: "b@example.com", date: "2026-06-20T10:00:00Z" },
+			committer: { date: "2026-06-20T10:05:00Z" },
+		},
+		author: { login: "buremba", id: 82745 },
+	},
+	{
+		sha: "def456",
+		html_url: "https://github.com/lobu-ai/lobu/commit/def456",
+		commit: {
+			message: "chore: bump deps",
+			author: { name: "dependabot", email: "dep@example.com", date: "2026-06-19T08:00:00Z" },
+		},
+		author: null, // commit email not tied to a GitHub account
+	},
+];
+
+function buildConnector(commits: unknown[]) {
+	const connector = new GitHubConnector();
+	const calls: Array<{ url: string }> = [];
+	connector.requestJson = async (params: { url: string }) => {
+		calls.push({ url: params.url });
+		// First page returns the canned commits (< per_page=100 → pagination stops);
+		// any later page is empty.
+		return calls.length === 1 ? commits : [];
+	};
+	return { connector, calls };
+}
+
+describe("GitHub commits feed", () => {
+	test("maps each commit to a per-sha event attributed to the linked author", async () => {
+		const { connector, calls } = buildConnector(COMMITS);
+
+		const result = await connector.sync({
+			config: { repo_owner: "lobu-ai", repo_name: "lobu" },
+			feedKey: "commits",
+			checkpoint: null,
+			credentials: { provider: "github", accessToken: "tok" },
+			entityIds: [],
+		});
+
+		expect(calls[0].url).toContain("/repos/lobu-ai/lobu/commits");
+		expect(result.events).toHaveLength(2);
+
+		const linked = result.events[0];
+		expect(linked.origin_id).toBe("commit_lobu-ai_lobu_abc123");
+		expect(linked.origin_type).toBe("commit");
+		expect(linked.title).toBe("fix: the thing");
+		expect(linked.author_name).toBe("buremba");
+		expect(linked.source_url).toBe("https://github.com/lobu-ai/lobu/commit/abc123");
+		expect(new Date(linked.occurred_at).toISOString()).toBe("2026-06-20T10:00:00.000Z");
+		expect(linked.metadata.sha).toBe("abc123");
+		expect(linked.metadata.author_email).toBe("b@example.com");
+		// Person attribution: login (mutable) + immutable id are both stamped.
+		expect(linked.metadata.author_login).toBe("buremba");
+		expect(linked.metadata.author_id).toBe("82745");
+	});
+
+	test("unlinked-email commit falls back to git author name, no false person link", async () => {
+		const { connector } = buildConnector(COMMITS);
+
+		const result = await connector.sync({
+			config: { repo_owner: "lobu-ai", repo_name: "lobu" },
+			feedKey: "commits",
+			checkpoint: null,
+			credentials: { provider: "github", accessToken: "tok" },
+			entityIds: [],
+		});
+
+		const unlinked = result.events[1];
+		expect(unlinked.origin_id).toBe("commit_lobu-ai_lobu_def456");
+		expect(unlinked.author_name).toBe("dependabot"); // git author name fallback
+		// No GitHub account → no author_login/author_id so entityLinks can't
+		// mis-attribute the commit to a person.
+		expect(unlinked.metadata.author_login).toBeUndefined();
+		expect(unlinked.metadata.author_id).toBeUndefined();
+	});
+});

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -31,6 +31,7 @@ type GitHubContentType =
   | 'pr_comments'
   | 'discussions'
   | 'discussion_comments'
+  | 'commits'
   | 'stargazers';
 
 interface GitHubConfig {
@@ -120,6 +121,19 @@ interface GitHubCommentLike {
   created_at: string;
   updated_at: string;
   reactions?: { '+1'?: number; '-1'?: number; total_count?: number };
+}
+
+interface GitHubCommitLike {
+  sha: string;
+  html_url?: string;
+  commit?: {
+    message?: string;
+    author?: { name?: string; email?: string; date?: string };
+    committer?: { name?: string; email?: string; date?: string };
+  };
+  /** Linked GitHub account for the author — null when the commit email isn't tied to one. */
+  author?: { login?: string; id?: number } | null;
+  committer?: { login?: string; id?: number } | null;
 }
 
 interface GraphQLDiscussionNode {
@@ -220,6 +234,11 @@ const LOOKBACK_PROP = {
 
 const STARGAZER_PROFILE_REFRESH_MS = 30 * 24 * 60 * 60 * 1000;
 const STARGAZER_PROFILE_FETCH_LIMIT = 25;
+
+// Bound a single commits sync to 30 pages (3000 commits). Incremental `since`
+// keeps steady-state runs tiny; the cap only matters on a cold backfill of a
+// busy repo, where the remaining history rides subsequent runs.
+const COMMITS_MAX_PAGES = 30;
 
 const LABELS_PROP = {
   labels_filter: {
@@ -517,6 +536,35 @@ export default class GitHubConnector extends ConnectorRuntime {
                 discussion_number: { type: 'number' },
                 updated_at: { type: 'string' },
                 reactions: { type: 'number' },
+                author_login: { type: 'string' },
+                author_id: { type: 'string' },
+              },
+            },
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
+          },
+        },
+      },
+      commits: {
+        key: 'commits',
+        name: 'Commits',
+        requiredScopes: [],
+        description: 'Sync commits pushed to a repository, attributed to their authors.',
+        displayNameTemplate: '{repo_owner}/{repo_name} commits',
+        configSchema: {
+          type: 'object',
+          required: ['repo_owner', 'repo_name'],
+          properties: { ...REPO_PROPS, ...LOOKBACK_PROP },
+        },
+        eventKinds: {
+          commit: {
+            description: 'A commit was authored in the repository',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                sha: { type: 'string' },
+                author_date: { type: 'string' },
+                committed_at: { type: 'string' },
+                author_email: { type: 'string' },
                 author_login: { type: 'string' },
                 author_id: { type: 'string' },
               },
@@ -940,7 +988,73 @@ export default class GitHubConnector extends ConnectorRuntime {
         return await this.syncDiscussions(repo, sinceIso, token);
       case 'discussion_comments':
         return await this.syncDiscussionComments(repo, sinceIso, token);
+      case 'commits':
+        return await this.syncCommits(repo, sinceIso, token);
     }
+  }
+
+  private async syncCommits(
+    repo: RepoRef,
+    sinceIso: string,
+    token: string | null
+  ): Promise<EventEnvelope[]> {
+    const events: EventEnvelope[] = [];
+
+    // Commits are durable and fully queryable, so polling recovers the complete
+    // "who committed when" history — no webhook dependency. `since` filters by
+    // commit date for incremental syncs; pagination is bounded so one run can't
+    // walk an unbounded history (deeper backfill rides subsequent runs).
+    const pages = paginateByOffset<GitHubCommitLike>(
+      async (offset, pageSize) => {
+        const query = new URLSearchParams({
+          per_page: String(pageSize),
+          page: String(offset / pageSize + 1),
+          since: sinceIso,
+        });
+        const url = `https://api.github.com/repos/${repo.owner}/${repo.repo}/commits?${query.toString()}`;
+        const commits = await this.requestJson<GitHubCommitLike[]>({ url, token });
+        return { items: commits, hasMore: commits.length === pageSize };
+      },
+      { pageSize: 100, maxPages: COMMITS_MAX_PAGES }
+    );
+
+    for await (const commits of pages) {
+      for (const commit of commits) {
+        if (!commit.sha) continue;
+        const authoredAtIso = commit.commit?.author?.date;
+        const authoredAt = authoredAtIso ? new Date(authoredAtIso) : null;
+        if (!authoredAt || Number.isNaN(authoredAt.getTime())) continue;
+
+        const message = commit.commit?.message ?? '';
+        const firstLine = message.split('\n', 1)[0].slice(0, 500);
+
+        events.push({
+          // Stable per-commit id (sha is globally unique) so re-syncs dedupe and
+          // a webhook trigger that re-polls supersedes rather than duplicates.
+          origin_id: `commit_${repo.owner}_${repo.repo}_${commit.sha}`,
+          title: firstLine || commit.sha.slice(0, 7),
+          payload_text: message.trim(),
+          // Prefer the linked GitHub login; fall back to the git author name when
+          // the commit email isn't tied to a GitHub account.
+          author_name: commit.author?.login ?? commit.commit?.author?.name,
+          source_url: commit.html_url,
+          occurred_at: authoredAt,
+          origin_type: 'commit',
+          metadata: {
+            sha: commit.sha,
+            author_date: authoredAtIso,
+            committed_at: commit.commit?.committer?.date ?? authoredAtIso,
+            author_email: commit.commit?.author?.email ?? null,
+            // Attribute to a person entity via the linked GitHub account (login +
+            // immutable id). Absent for unlinked-email commits — author_name still
+            // carries the git author.
+            ...this.buildAuthorMetadata(commit.author),
+          },
+        });
+      }
+    }
+
+    return events;
   }
 
   private async syncIssuesAndPulls(


### PR DESCRIPTION
## What

Adds a `commits` feed to the GitHub connector so we capture **who committed when**, attributed to people.

Commits are durable and fully queryable, so **polling recovers the complete commit history** — no dependency on best-effort webhook delivery (which can drop events across deploys). This is the canonical-poll half of the agreed design (poll = source of truth; webhook as a trigger is a separate follow-up).

## Details
- Per-sha stable `origin_id` (`commit_<owner>_<repo>_<sha>`) → re-syncs dedupe/supersede via the existing `insertEvent({onConflictUpdate})` path (keyed on connection_id + origin_id), so a future webhook-triggered re-poll updates rather than duplicates.
- `origin_type: 'commit'`, commit **author date** as `occurred_at` ("when they committed").
- Person attribution via the linked GitHub account — `author_login` + immutable `author_id` stamped for `entityLinks` → resolves to a member/person. Falls back to the git author name when the commit email isn't tied to a GitHub account (no false person link).
- Incremental via `since`; pagination bounded by `COMMITS_MAX_PAGES` (30 = 3000 commits) so a cold backfill of a busy repo can't walk unbounded history in one run — the tail rides subsequent runs.

## Verification
- Red→green test `github-commits.test.ts`: linked-author attribution + unlinked-email fallback.
- Full connectors suite: **158 pass / 0 fail**.
- `github.ts` typechecks clean (the one connectors-tsc line is pre-existing stargazer-checkpoint noise, unrelated; connectors isn't in CI's strict typecheck set).

## Follow-ups (separate PRs)
- Webhook → trigger refactor (mark the repo's feeds due on delivery) + stop the raw `webhook:app_install:*` orphan store + tombstone existing orphans.
- After deploy: refresh lobu-team's github connector_definition to include the commits feed, then create commits feeds for lobu + owletto.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784778935&installation_id=136316292&pr_number=1513&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1513&signature=ac8a4cfb9332fedbe992cfc207117f0a7e5da454de9b4118f09b80c34c912ab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub commits feed support with automatic syncing of repository commit history, including commit metadata, timestamps, and author attribution.

* **Tests**
  * Added comprehensive test suite for GitHub commits feed functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->