### PR TITLE
feat(watchers): derive extraction schema from the entity type (Phase 1 — schema home)

### DIFF
--- a/db/migrations/20260623030000_watcher_extraction_schema_nullable.sql
+++ b/db/migrations/20260623030000_watcher_extraction_schema_nullable.sql
@@ -1,0 +1,15 @@
+-- migrate:up
+
+-- Schema lives on the entity type: a watcher that names keying_config.entity_type
+-- derives its extraction schema from that type's metadata_schema, so it stores NO
+-- inline extraction_schema (NULL = "derive from the entity type"). Relax the
+-- NOT NULL so entity-typed watchers can omit it. Existing watchers keep their
+-- inline schema unchanged. DROP NOT NULL is a fast catalog-only change.
+ALTER TABLE public.watcher_versions ALTER COLUMN extraction_schema DROP NOT NULL;
+
+-- migrate:down
+
+-- Re-impose NOT NULL. Backfill the entity-typed watchers' NULLs with an empty
+-- object so the constraint can be restored without data loss.
+UPDATE public.watcher_versions SET extraction_schema = '{}'::jsonb WHERE extraction_schema IS NULL;
+ALTER TABLE public.watcher_versions ALTER COLUMN extraction_schema SET NOT NULL;

--- a/packages/server/src/__tests__/integration/watchers/watcher-schema-from-entity.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watcher-schema-from-entity.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Integration test: a watcher derives its extraction schema from its target
+ * entity type's metadata_schema (consolidation — "schema lives on the entity
+ * type"). When a watcher names keying_config.entity_type and supplies NO inline
+ * extraction_schema, complete_window validates the extracted data against the
+ * entity type's schema — the SAME schema that validates manual entity writes, so
+ * a record's shape is defined exactly once.
+ *
+ * Proves:
+ *   1. wrapMetadataSchemaAtPath builds the array-of-records output contract
+ *      (single + nested entity_path).
+ *   2. deriveWatcherExtractionSchema resolves a real entity type's schema.
+ *   3. complete_window REJECTS extracted data that violates the entity type's
+ *      schema and ACCEPTS data that conforms — with no inline extraction_schema.
+ */
+
+import { inferWatcherGranularityFromSchedule } from '@lobu/connector-sdk';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { DbClient } from '../../../db/client';
+import { createWatcherRun } from '../../../runs/queue-service';
+import { deriveWatcherExtractionSchema, wrapMetadataSchemaAtPath } from '../../../utils/watcher-extraction-schema';
+import { computePendingWindow } from '../../../utils/window-utils';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestEntity, createTestEvent } from '../../setup/test-fixtures';
+import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
+
+const TOPIC_METADATA_SCHEMA = {
+  type: 'object',
+  properties: {
+    category: { type: 'string' },
+    name: { type: 'string' },
+  },
+  required: ['category', 'name'],
+  additionalProperties: true,
+};
+
+const KEYING_CONFIG = {
+  entity_path: 'problems',
+  key_fields: ['category', 'name'],
+  key_output_field: 'problem_key',
+  entity_type: 'topic',
+};
+
+describe('wrapMetadataSchemaAtPath', () => {
+  it('wraps a per-record schema as an array at a single-segment path', () => {
+    const wrapped = wrapMetadataSchemaAtPath(TOPIC_METADATA_SCHEMA, 'problems') as Record<string, any>;
+    expect(wrapped.type).toBe('object');
+    expect(wrapped.required).toEqual(['problems']);
+    expect(wrapped.properties.problems.type).toBe('array');
+    expect(wrapped.properties.problems.items).toEqual(TOPIC_METADATA_SCHEMA);
+  });
+
+  it('nests required objects for a dotted path', () => {
+    const wrapped = wrapMetadataSchemaAtPath(TOPIC_METADATA_SCHEMA, 'analysis.results.problems') as Record<
+      string,
+      any
+    >;
+    expect(wrapped.required).toEqual(['analysis']);
+    expect(wrapped.properties.analysis.properties.results.properties.problems.type).toBe('array');
+    expect(wrapped.properties.analysis.properties.results.properties.problems.items).toEqual(
+      TOPIC_METADATA_SCHEMA
+    );
+  });
+});
+
+async function setupEntityTypedWatcher() {
+  const sql = getTestDb();
+  const dbClient = sql as unknown as DbClient;
+  const workspace = await TestWorkspace.create({ name: 'Schema-From-Entity Org' });
+  const ownerUserId = workspace.users.owner.id;
+
+  const parentEntity = await createTestEntity({
+    name: 'Parent Brand',
+    organization_id: workspace.org.id,
+    created_by: ownerUserId,
+  });
+
+  // The 'topic' type carries the metadata_schema that becomes the watcher's
+  // extraction contract. entity_types' unique index is partial (WHERE deleted_at
+  // IS NULL), so ON CONFLICT can't bind — check then insert/update.
+  const existingType = await sql`
+    SELECT id FROM entity_types
+    WHERE organization_id = ${workspace.org.id} AND slug = 'topic' AND deleted_at IS NULL
+    LIMIT 1
+  `;
+  if (existingType.length > 0) {
+    await sql`
+      UPDATE entity_types SET metadata_schema = ${sql.json(TOPIC_METADATA_SCHEMA)}
+      WHERE id = ${existingType[0].id}
+    `;
+  } else {
+    await sql`
+      INSERT INTO entity_types (organization_id, slug, name, metadata_schema, created_at, updated_at)
+      VALUES (${workspace.org.id}, 'topic', 'Topic', ${sql.json(TOPIC_METADATA_SCHEMA)}, current_timestamp, current_timestamp)
+    `;
+  }
+
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId,
+    agentId: 'schema-agent',
+    name: 'Schema Agent',
+  });
+
+  // NB: NO extraction_schema — the watcher relies on the entity type's schema.
+  const watcher = (await workspace.owner.watchers.create({
+    entity_id: parentEntity.id,
+    slug: 'schema-watcher',
+    name: 'Schema Watcher',
+    prompt: 'Extract problems for {{entities}}.',
+    keying_config: KEYING_CONFIG,
+    schedule: '0 9 * * *',
+    agent_id: agent.agentId,
+  })) as { watcher_id: string };
+  const watcherId = Number(watcher.watcher_id);
+
+  await sql`UPDATE watchers SET next_run_at = NOW() - INTERVAL '10 minutes' WHERE id = ${watcherId}`;
+
+  const api = await TestApiClient.for({
+    organizationId: workspace.org.id,
+    userId: ownerUserId,
+    memberRole: 'owner',
+  });
+
+  return { sql, dbClient, workspace, api, parentEntityId: parentEntity.id, agent, watcherId };
+}
+
+type Ctx = Awaited<ReturnType<typeof setupEntityTypedWatcher>>;
+
+async function queueRunningRun(ctx: Ctx) {
+  const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
+  const { windowStart, windowEnd } = await computePendingWindow(ctx.dbClient, ctx.watcherId, granularity);
+  const queued = await createWatcherRun({
+    organizationId: ctx.workspace.org.id,
+    watcherId: ctx.watcherId,
+    agentId: ctx.agent.agentId,
+    windowStart: windowStart.toISOString(),
+    windowEnd: windowEnd.toISOString(),
+    dispatchSource: 'scheduled',
+  });
+  await ctx.sql`
+    UPDATE runs SET status = 'running', claimed_at = NOW(), claimed_by = ${`lobu:${ctx.agent.agentId}`}
+    WHERE id = ${queued.runId}
+  `;
+  return queued.runId;
+}
+
+async function readWindowToken(ctx: Ctx): Promise<string> {
+  const content = (await ctx.api.knowledge.read({ watcher_id: ctx.watcherId })) as { window_token: string };
+  return content.window_token;
+}
+
+describe('complete_window derives its schema from the entity type', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('resolves a real entity type metadata_schema into an extraction schema', async () => {
+    const ctx = await setupEntityTypedWatcher();
+    const derived = (await deriveWatcherExtractionSchema(
+      ctx.dbClient,
+      ctx.workspace.org.id,
+      KEYING_CONFIG
+    )) as Record<string, any>;
+    expect(derived).not.toBeNull();
+    expect(derived.properties.problems.items.required).toEqual(['category', 'name']);
+  });
+
+  it('REJECTS extracted data missing a field the entity type requires', async () => {
+    const ctx = await setupEntityTypedWatcher();
+    await createTestEvent({
+      entity_id: ctx.parentEntityId,
+      organization_id: ctx.workspace.org.id,
+      content: 'Users report problems.',
+      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    const runId = await queueRunningRun(ctx);
+    const token = await readWindowToken(ctx);
+
+    // 'name' is required by topic's metadata_schema but missing here.
+    await expect(
+      ctx.api.watchers.completeWindow({
+        watcher_id: String(ctx.watcherId),
+        window_token: token,
+        extracted_data: { problems: [{ category: 'Stability' }] },
+        run_metadata: { watcher_run_id: runId },
+      })
+    ).rejects.toThrow(/extraction_schema|does not match|name/i);
+  });
+
+  it('ACCEPTS extracted data that conforms to the entity type schema (no inline schema)', async () => {
+    const ctx = await setupEntityTypedWatcher();
+    await createTestEvent({
+      entity_id: ctx.parentEntityId,
+      organization_id: ctx.workspace.org.id,
+      content: 'Users report problems.',
+      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    const runId = await queueRunningRun(ctx);
+    const token = await readWindowToken(ctx);
+
+    const completion = (await ctx.api.watchers.completeWindow({
+      watcher_id: String(ctx.watcherId),
+      window_token: token,
+      extracted_data: { problems: [{ category: 'Stability', name: 'App Crashes' }] },
+      run_metadata: { watcher_run_id: runId },
+    })) as { action: string };
+    expect(completion.action).toBe('complete_window');
+
+    // And the conforming record promoted into a topic entity under the parent.
+    const promoted = await ctx.sql`
+      SELECT e.name FROM entities e
+      JOIN entity_identities ei ON ei.entity_id = e.id
+      WHERE ei.organization_id = ${ctx.workspace.org.id} AND ei.namespace = 'watcher_key'
+    `;
+    expect(promoted.length).toBe(1);
+  });
+});

--- a/packages/server/src/tools/admin/manage_watchers/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_watchers/complete-window.ts
@@ -13,6 +13,7 @@ import { verifyWindowToken } from '../../../utils/jwt';
 import logger from '../../../utils/logger';
 import { promoteKeyedEntities } from '../../../utils/promote-keyed-entities';
 import { computeStableKeys } from '../../../utils/stable-keys';
+import { deriveWatcherExtractionSchema } from '../../../utils/watcher-extraction-schema';
 import { trackWatcherReaction } from '../../../utils/watcher-reactions';
 import {
   getFieldsToStrip,
@@ -272,10 +273,17 @@ export async function handleCompleteWindow(
   const parentEntityId = boundEntityIds.length > 0 ? boundEntityIds[0] : null;
 
   // ============================================
-  // STEP 2.5: Validate extracted_data against template's extraction_schema
+  // STEP 2.5: Validate extracted_data against the extraction schema.
+  // The schema is the watcher's inline extraction_schema, OR — when the watcher
+  // is entity-typed (keying_config.entity_type) and gave no inline schema —
+  // derived from that entity type's metadata_schema (consolidation: "schema lives
+  // on the entity type"). Same helper the worker payload uses, so the contract the
+  // device extracts against and the contract we validate against never drift.
   // ============================================
-  if (templateData?.extraction_schema) {
-    const extractionSchema = templateData.extraction_schema;
+  const extractionSchema: Record<string, any> | null =
+    templateData?.extraction_schema ??
+    (await deriveWatcherExtractionSchema(getDb(), watcherOrgId, keyingConfig));
+  if (extractionSchema) {
     const validate = ajv.compile(extractionSchema);
     // Validate a deep copy since removeAdditional:true mutates the data
     // This allows workers to include internal fields like 'embedding' that aren't in the schema

--- a/packages/server/src/tools/admin/manage_watchers/crud.ts
+++ b/packages/server/src/tools/admin/manage_watchers/crud.ts
@@ -48,15 +48,25 @@ export async function handleCreate(
 }> {
   const sql = getDb();
 
-  // Require slug + prompt + extraction_schema for create
+  // Require slug + prompt for create. extraction_schema is required too, UNLESS
+  // the watcher is entity-typed: a watcher that names keying_config.entity_type
+  // derives its output schema from that entity type's metadata_schema (schema
+  // lives on the type), so it needs no inline one.
   if (!args.slug) {
     throw new ToolUserError('slug is required for create action');
   }
   if (!args.prompt) {
     throw new ToolUserError('prompt is required for create action');
   }
-  if (!args.extraction_schema) {
-    throw new ToolUserError('extraction_schema is required for create action');
+  const keyingEntityType =
+    args.keying_config && typeof args.keying_config === 'object'
+      ? (args.keying_config as { entity_type?: unknown }).entity_type
+      : undefined;
+  const isEntityTyped = typeof keyingEntityType === 'string' && keyingEntityType.trim().length > 0;
+  if (!args.extraction_schema && !isEntityTyped) {
+    throw new ToolUserError(
+      'extraction_schema is required for create action (unless keying_config.entity_type is set)'
+    );
   }
   assertValidExecutionConfig(args.execution_config, ctx);
   // A device pin runs the watcher's agent CLI on the device owner's machine —
@@ -86,6 +96,7 @@ export async function handleCreate(
   assertWatcherVersionConfigValid({
     prompt: args.prompt,
     extractionSchema,
+    entityTyped: isEntityTyped,
     classifiers,
     sources,
   });

--- a/packages/server/src/tools/admin/manage_watchers/shared.ts
+++ b/packages/server/src/tools/admin/manage_watchers/shared.ts
@@ -156,6 +156,7 @@ export function summarizeResults(results: WatcherOperationResult[]) {
 function validateWatcherConfig(input: {
   prompt?: string;
   extraction_schema?: unknown;
+  entityTyped?: boolean;
   classifiers?: unknown[];
   sources?: Array<{ name: string; query: string }>;
 }): string | null {
@@ -168,13 +169,16 @@ function validateWatcherConfig(input: {
     return `prompt: ${templateValidation}`;
   }
 
-  if (!input.extraction_schema || typeof input.extraction_schema !== 'object') {
+  // extraction_schema is required UNLESS the watcher is entity-typed — it then
+  // derives its schema from the target entity type's metadata_schema (schema
+  // lives on the type). If an inline schema IS supplied either way, validate it.
+  if (input.extraction_schema && typeof input.extraction_schema === 'object') {
+    const schemaValidation = validateExtractionSchema(input.extraction_schema);
+    if (schemaValidation) {
+      return `extraction_schema: ${schemaValidation}`;
+    }
+  } else if (!input.entityTyped) {
     return 'extraction_schema is required and must be an object';
-  }
-
-  const schemaValidation = validateExtractionSchema(input.extraction_schema);
-  if (schemaValidation) {
-    return `extraction_schema: ${schemaValidation}`;
   }
 
   if (input.classifiers !== undefined) {
@@ -212,12 +216,14 @@ function validateWatcherConfig(input: {
 export function assertWatcherVersionConfigValid(parsed: {
   prompt?: string;
   extractionSchema?: unknown;
+  entityTyped?: boolean;
   classifiers?: unknown[];
   sources?: Array<{ name: string; query: string }>;
 }): void {
   const validation = validateWatcherConfig({
     prompt: parsed.prompt,
     extraction_schema: parsed.extractionSchema,
+    entityTyped: parsed.entityTyped,
     classifiers: parsed.classifiers,
     sources: parsed.sources,
   });

--- a/packages/server/src/tools/admin/manage_watchers/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_watchers/version-actions.ts
@@ -99,8 +99,11 @@ export async function handleCreateVersion(
     parseJsonInput<unknown[]>(args.classifiers, 'classifiers') ??
     normalizeStoredJsonField(prev.classifiers, undefined as unknown[] | undefined);
 
-  // Validate
-  assertWatcherVersionConfigValid({ prompt, extractionSchema, classifiers, sources });
+  // Validate. An entity-typed watcher (keying_config.entity_type) derives its
+  // schema from the entity type, so an inline extraction_schema isn't required.
+  const keyingEntityType = (keyingConfig as { entity_type?: unknown } | undefined)?.entity_type;
+  const entityTyped = typeof keyingEntityType === 'string' && keyingEntityType.trim().length > 0;
+  assertWatcherVersionConfigValid({ prompt, extractionSchema, entityTyped, classifiers, sources });
 
   if (args.schedule) {
     const scheduleError = validateSchedule(args.schedule);

--- a/packages/server/src/utils/watcher-extraction-schema.ts
+++ b/packages/server/src/utils/watcher-extraction-schema.ts
@@ -1,0 +1,103 @@
+/**
+ * Watcher extraction schema — derived from the target entity type (consolidation:
+ * "schema lives on the entity type, not the watcher").
+ *
+ * A watcher that names an `entity_type` in its `keying_config` and supplies NO
+ * inline `extraction_schema` derives its output contract from that entity type's
+ * `metadata_schema`: the extraction must produce an array of records (at
+ * `keying_config.entity_path`) that each conform to the type's schema. This is
+ * the single source of truth — the same schema validates manual entity writes
+ * (`schema-validation.ts`), so a record's shape is defined ONCE, on the type.
+ *
+ * Both the worker payload (poll.ts — ships the contract to the device) and
+ * window completion (complete-window.ts — validates the returned data) resolve
+ * the schema through this helper, so extraction and validation can never drift.
+ * Returns null when the watcher isn't entity-typed or the type has no schema —
+ * callers then fall back to the inline `extraction_schema` (the escape hatch for
+ * heterogeneous / non-entity-shaped watchers).
+ */
+
+import type { DbClient } from '../db/client';
+import type { KeyingConfig } from '../types/watchers';
+
+/**
+ * Resolve an entity type's `metadata_schema` (JSON Schema Draft-7), tenant-first
+ * then public catalog — the same precedence as `schema-validation.ts` and the
+ * keyed-promotion type resolver, so derivation and promotion agree on the type.
+ */
+async function resolveEntityTypeMetadataSchema(
+  sql: DbClient,
+  organizationId: string,
+  entityTypeSlug: string
+): Promise<Record<string, unknown> | null> {
+  const rows = await sql<{ metadata_schema: Record<string, unknown> | string | null }>`
+    SELECT et.metadata_schema
+    FROM entity_types et
+    LEFT JOIN organization o ON o.id = et.organization_id
+    WHERE et.slug = ${entityTypeSlug}
+      AND et.deleted_at IS NULL
+      AND (et.organization_id = ${organizationId} OR o.visibility = 'public')
+    ORDER BY (et.organization_id = ${organizationId}) DESC, et.id ASC
+    LIMIT 1
+  `;
+  const raw = rows[0]?.metadata_schema ?? null;
+  if (raw == null) return null;
+  const schema = typeof raw === 'string' ? safeParse(raw) : raw;
+  if (!schema || typeof schema !== 'object' || Object.keys(schema).length === 0) {
+    return null;
+  }
+  return schema as Record<string, unknown>;
+}
+
+function safeParse(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Wrap a per-record metadata schema as the full extraction-output schema: an
+ * array of those records living at `entityPath`. A dotted path
+ * (`analysis.results.problems`) becomes nested required objects, so the LLM's
+ * output object is validated end to end, not just the leaf array.
+ */
+export function wrapMetadataSchemaAtPath(
+  metadataSchema: Record<string, unknown>,
+  entityPath: string
+): Record<string, unknown> {
+  const segments = entityPath.split('.').filter((s) => s.length > 0);
+  if (segments.length === 0) {
+    // No path — the whole output is the array of records.
+    return { type: 'array', items: metadataSchema };
+  }
+  // Build from the leaf array outward.
+  let node: Record<string, unknown> = { type: 'array', items: metadataSchema };
+  for (let i = segments.length - 1; i >= 0; i--) {
+    node = {
+      type: 'object',
+      properties: { [segments[i]]: node },
+      required: [segments[i]],
+    };
+  }
+  return node;
+}
+
+/**
+ * Derive a watcher's extraction schema from its target entity type. Returns null
+ * when the watcher isn't entity-typed (no `keying_config.entity_type`) or the
+ * type carries no schema — callers fall back to the inline `extraction_schema`.
+ */
+export async function deriveWatcherExtractionSchema(
+  sql: DbClient,
+  organizationId: string,
+  keyingConfig: KeyingConfig | null | undefined
+): Promise<Record<string, unknown> | null> {
+  const entityType = keyingConfig?.entity_type?.trim();
+  if (!entityType || !keyingConfig?.entity_path) return null;
+  const metadataSchema = await resolveEntityTypeMetadataSchema(sql, organizationId, entityType);
+  if (!metadataSchema) return null;
+  return wrapMetadataSchemaAtPath(metadataSchema, keyingConfig.entity_path);
+}

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -8,6 +8,8 @@
 import { authorizeCapabilities } from '@lobu/core';
 import type { Context } from 'hono';
 import { getDb, pgTextArray } from '../db/client';
+import type { KeyingConfig } from '../types/watchers';
+import { deriveWatcherExtractionSchema } from '../utils/watcher-extraction-schema';
 import { withDbRetry } from '../db/with-retry';
 import type { Env } from '../index';
 import { materializeDueFeeds } from '../scheduled/check-due-feeds';
@@ -488,7 +490,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         w.notification_priority AS watcher_notification_priority,
         w.execution_config AS watcher_execution_config,
         wv.prompt AS watcher_prompt,
-        wv.extraction_schema AS watcher_extraction_schema
+        wv.extraction_schema AS watcher_extraction_schema,
+        wv.keying_config AS watcher_keying_config
       FROM runs r
       LEFT JOIN feeds f ON f.id = r.feed_id
       LEFT JOIN connections conn ON conn.id = r.connection_id
@@ -569,6 +572,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     watcher_execution_config: Record<string, unknown> | null;
     watcher_prompt: string | null;
     watcher_extraction_schema: Record<string, unknown> | string | null;
+    watcher_keying_config: Record<string, unknown> | string | null;
     // Auth run fields
     run_auth_profile_id: number | null;
     auth_profile_auth_data: Record<string, unknown> | null;
@@ -594,6 +598,17 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       typeof approved['agent_kind'] === 'string' && (approved['agent_kind'] as string).trim()
         ? (approved['agent_kind'] as string).trim()
         : null;
+    // Output contract for the device: the watcher's inline extraction_schema, or —
+    // when it's entity-typed with no inline schema — derived from the target entity
+    // type's metadata_schema (schema lives on the type). Same helper complete_window
+    // validates with, so the device extracts against exactly what we'll validate.
+    const watcherExtractionSchema =
+      parseClaimJson(row.watcher_extraction_schema) ??
+      (await deriveWatcherExtractionSchema(
+        getDb(),
+        row.organization_id,
+        parseClaimJson(row.watcher_keying_config) as KeyingConfig | null
+      ));
     return c.json({
       run_id: row.run_id,
       run_type: row.run_type,
@@ -628,7 +643,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
           // complete_window pipeline (schema validation included). Null when
           // the watcher has no schema — the dispatcher then asks for a
           // free-form `{"summary": ...}` object.
-          extraction_schema: parseClaimJson(row.watcher_extraction_schema),
+          extraction_schema: watcherExtractionSchema,
         },
         event: {
           trigger_event_id: null,


### PR DESCRIPTION
First of the three consolidations: **the record's schema lives on the entity type, not duplicated on the watcher.**

## What
A watcher that names `keying_config.entity_type` and supplies **no inline `extraction_schema`** now derives its output contract from that entity type's `metadata_schema` — the *same* schema `validateEntityMetadata` enforces on manual entity writes. Define a record's shape once, on the type.

- New `deriveWatcherExtractionSchema` / `wrapMetadataSchemaAtPath`: resolves the type's `metadata_schema` (tenant-then-public, same precedence as promotion) and wraps it as an array-of-records at `keying_config.entity_path` (dotted paths nest into required objects).
- **Both** `complete-window` STEP 2.5 (validation) **and** the worker `poll.ts` payload (the contract shipped to the device) resolve through the one helper, so the device extracts against exactly what completion validates — no drift.
- Inline `extraction_schema` remains the escape hatch for heterogeneous / non-entity-shaped watchers.
- `create` / `create_version` no longer require `extraction_schema` when the watcher is entity-typed; `watcher_versions.extraction_schema` relaxed to nullable (NULL = "derive from the type"). Migration is a fast catalog-only `DROP NOT NULL`; down backfills `{}` before re-imposing it.

## Verification
- 5 new tests: `wrapMetadataSchemaAtPath` (single + nested path), `deriveWatcherExtractionSchema` against a real type, and end-to-end through real completion — **REJECTS** data missing a type-required field, **ACCEPTS** conforming data and promotes it (all with no inline schema).
- 75/75 existing watcher tests green — the inline-schema path is unchanged.

## Notes
- Additive + escape-hatch-preserving; only affects watchers explicitly configured entity-typed-with-no-schema (a new config — no existing watcher is shaped this way).
- This *removes* duplication (schema defined once) rather than adding it. Phases 2 (one edit model) and 3 (render home) follow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784778945&installation_id=136316292&pr_number=1514&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1514&signature=79c6c002148fef7061226d44cbde238abdfa77904177f329443e99b744c73190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->