### PR TITLE
feat(entities): unify the edit event shape — one model (Phase 2)

### DIFF
--- a/db/migrations/20260623040000_entity_field_grained_projection.sql
+++ b/db/migrations/20260623040000_entity_field_grained_projection.sql
@@ -1,0 +1,89 @@
+-- migrate:up
+
+-- One edit model: entity field edits now emit the SAME field-grained shape as a
+-- watcher correction — one 'entity_field' event per field, metadata
+-- { entity_id, field_path, mutation, corrected_value } (was a single fields-map
+-- snapshot { entity_id, fields }). Rewrite the projection trigger to read that
+-- shape: one event → one (entity, field) upsert, keep-greater by observation_id;
+-- a 'remove' mutation deletes the field. Fire condition is unchanged
+-- (semantic_type='entity_field'), so no watcher 'correction' events are touched.
+CREATE OR REPLACE FUNCTION public.project_entity_field() RETURNS trigger AS $$
+DECLARE
+    v_entity_id bigint;
+    v_field text;
+    v_mutation text;
+BEGIN
+    IF coalesce(NEW.metadata->>'entity_id', '') !~ '^[0-9]{1,18}$'
+       OR coalesce(NEW.metadata->>'field_path', '') = '' THEN
+        RETURN NEW;  -- not a field-grained entity edit: skip
+    END IF;
+    v_entity_id := (NEW.metadata->>'entity_id')::bigint;
+    v_field := NEW.metadata->>'field_path';
+    v_mutation := coalesce(NEW.metadata->>'mutation', 'set');
+
+    IF NOT EXISTS (
+        SELECT 1 FROM public.entities
+        WHERE id = v_entity_id
+          AND organization_id = NEW.organization_id
+          AND deleted_at IS NULL
+    ) THEN
+        RETURN NEW;  -- unknown, deleted, or cross-org entity: never project
+    END IF;
+
+    IF v_mutation = 'remove' THEN
+        -- Drop the field, but only if this removal is newer than the stored value
+        -- (keep-greater ordering, same as the set path below).
+        DELETE FROM public.entity_field_state
+        WHERE entity_id = v_entity_id
+          AND field = v_field
+          AND observation_id < NEW.id;
+    ELSE
+        INSERT INTO public.entity_field_state
+            (organization_id, entity_id, field, value, observation_id, updated_at)
+        VALUES
+            (NEW.organization_id, v_entity_id, v_field, NEW.metadata->'corrected_value', NEW.id, now())
+        ON CONFLICT (entity_id, field) DO UPDATE
+            SET value = EXCLUDED.value,
+                observation_id = EXCLUDED.observation_id,
+                updated_at = now()
+            WHERE entity_field_state.observation_id < EXCLUDED.observation_id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- migrate:down
+
+-- Restore the fields-map projection.
+CREATE OR REPLACE FUNCTION public.project_entity_field() RETURNS trigger AS $$
+DECLARE
+    v_entity_id bigint;
+BEGIN
+    IF coalesce(jsonb_typeof(NEW.metadata->'fields'), '') <> 'object'
+       OR coalesce(NEW.metadata->>'entity_id', '') !~ '^[0-9]{1,18}$' THEN
+        RETURN NEW;
+    END IF;
+    v_entity_id := (NEW.metadata->>'entity_id')::bigint;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM public.entities
+        WHERE id = v_entity_id
+          AND organization_id = NEW.organization_id
+          AND deleted_at IS NULL
+    ) THEN
+        RETURN NEW;
+    END IF;
+
+    INSERT INTO public.entity_field_state (organization_id, entity_id, field, value, observation_id, updated_at)
+    SELECT NEW.organization_id, v_entity_id, kv.key, kv.value, NEW.id, now()
+    FROM jsonb_each(NEW.metadata->'fields') kv
+    ON CONFLICT (entity_id, field) DO UPDATE
+        SET value = EXCLUDED.value,
+            observation_id = EXCLUDED.observation_id,
+            updated_at = now()
+        WHERE entity_field_state.observation_id < EXCLUDED.observation_id;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/server/src/__tests__/integration/entities/entity-field-producer.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-field-producer.test.ts
@@ -66,6 +66,24 @@ describe('entity_field projection producer (manage_entity)', () => {
     expect(emp[0].value).toBe(50);
   });
 
+  it('emits a watcher-correction-shaped event per field (one edit model)', async () => {
+    const id = await makeEntity('Shape Co', { tier: 'gold' });
+    const rows = (await sql`
+      SELECT metadata FROM events
+      WHERE semantic_type = 'entity_field'
+        AND (metadata->>'entity_id')::bigint = ${id}
+        AND metadata->>'field_path' = 'tier'
+      ORDER BY id DESC LIMIT 1
+    `) as Array<{ metadata: Record<string, unknown> }>;
+    expect(rows).toHaveLength(1);
+    const md = rows[0].metadata;
+    // Same field-grained shape a watcher correction carries — one edit model.
+    expect(md.field_path).toBe('tier');
+    expect(md.mutation).toBe('set');
+    expect(md.corrected_value).toBe('gold');
+    expect(md.fields).toBeUndefined(); // no longer a fields-map snapshot
+  });
+
   it('update advances the projection and matches entities.metadata', async () => {
     const id = await makeEntity('Globex', { tier: 'silver' });
     const before = await tierState(id);

--- a/packages/server/src/__tests__/integration/entities/entity-field-projection.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-field-projection.test.ts
@@ -43,15 +43,22 @@ async function emitFields(
   entityId: number,
   fields: Record<string, unknown>
 ): Promise<number> {
-  counter += 1;
-  const ev = await insertEvent({
-    entityIds: [],
-    organizationId: orgId,
-    originId: `efield_test_${counter}`,
-    semanticType: 'entity_field',
-    metadata: { entity_id: entityId, fields },
-  });
-  return ev.id;
+  // Field-grained: one 'entity_field' event per field, carrying the same shape
+  // as a watcher correction ({field_path, mutation, corrected_value}). Returns
+  // the last event's id.
+  let lastId = 0;
+  for (const [fieldPath, value] of Object.entries(fields)) {
+    counter += 1;
+    const ev = await insertEvent({
+      entityIds: [],
+      organizationId: orgId,
+      originId: `efield_test_${counter}`,
+      semanticType: 'entity_field',
+      metadata: { entity_id: entityId, field_path: fieldPath, mutation: 'set', corrected_value: value },
+    });
+    lastId = ev.id;
+  }
+  return lastId;
 }
 
 async function fieldState(
@@ -122,10 +129,10 @@ describe('entity_field_state projection substrate (expand phase)', () => {
     // Each of these must resolve (no thrown abort of the events insert) AND
     // leave no projection row.
     const bad: Array<Record<string, unknown>> = [
-      { fields: { x: 1 } }, // entity_id missing
-      { entity_id: 3.9, fields: { x: 1 } }, // non-integer number
-      { entity_id: 99999999999999999999999, fields: { x: 1 } }, // out of bigint range
-      { entity_id: id, fields: 'not-an-object' }, // fields not an object
+      { field_path: 'x', corrected_value: 1 }, // entity_id missing
+      { entity_id: 3.9, field_path: 'x', corrected_value: 1 }, // non-integer number
+      { entity_id: 99999999999999999999999, field_path: 'x', corrected_value: 1 }, // out of bigint range
+      { entity_id: id, corrected_value: 1 }, // field_path missing
     ];
     for (const [i, meta] of bad.entries()) {
       await expect(

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -207,22 +207,35 @@ async function emitEntityFieldEvent(
     createdBy?: string | null;
   }
 ): Promise<void> {
-  if (Object.keys(params.fields).length === 0) return;
+  const entries = Object.entries(params.fields);
+  if (entries.length === 0) return;
+  // One field-grained event PER changed field, carrying the SAME shape as a
+  // watcher correction ({field_path, mutation, corrected_value}) — so an entity
+  // edit and a watcher correction are one model on the events spine, foldable by
+  // the same per-(target, field_path) latest-wins logic. (Was a single
+  // fields-map snapshot; field-grained lets the projection and any reader treat
+  // both kinds of edit identically.)
   // No clientId on purpose: insertEvent's stale-clientId FK fallback retries
   // after a failed insert, which can't recover inside this caller's transaction
   // (a failed statement aborts the txn and would roll back the entity write).
-  // The projection event is internal; it doesn't need a client stamp.
-  await insertEvent(
-    {
-      entityIds: [],
-      organizationId: params.organizationId,
-      originId: `efield_${params.entityId}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
-      semanticType: 'entity_field',
-      metadata: { entity_id: params.entityId, fields: params.fields },
-      createdBy: params.createdBy ?? null,
-    },
-    { sql: tx }
-  );
+  for (const [fieldPath, value] of entries) {
+    await insertEvent(
+      {
+        entityIds: [],
+        organizationId: params.organizationId,
+        originId: `efield_${params.entityId}_${fieldPath.replace(/[^a-zA-Z0-9_]/g, '-').slice(0, 40)}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        semanticType: 'entity_field',
+        metadata: {
+          entity_id: params.entityId,
+          field_path: fieldPath,
+          mutation: 'set',
+          corrected_value: value,
+        },
+        createdBy: params.createdBy ?? null,
+      },
+      { sql: tx }
+    );
+  }
 }
 
 export async function createEntity(


### PR DESCRIPTION
Second of the three consolidations: **entity edits and watcher corrections are one model.**

## What
Entity field edits used to emit a single fields-map snapshot (`{entity_id, fields}`); watcher corrections are field-grained (`{field_path, mutation, corrected_value}`). Two shapes for the same concept. Now entity edits emit **one field-grained event per changed field** carrying the **same shape** as a watcher correction — both ride the events spine and fold by the same per-(target, field_path) latest-wins logic.

- `emitEntityFieldEvent` fans out one `entity_field` event per field: `{ entity_id, field_path, mutation:'set', corrected_value }`.
- `project_entity_field` trigger rewritten to read the field-grained shape (one event → one (entity, field) upsert, keep-greater by observation_id; `remove` deletes the field). Fire condition unchanged (`entity_field`), so watcher `correction` events are untouched. Down-migration restores the fields-map projection.

The semantic_type stays as provenance (`entity_field` = an entity edit, `correction` = a watcher correction) — the *shape* is now identical, which is what "one model" means: any reader/fold treats both alike.

## Verification
- 22/22 entities integration tests green, incl. a new assertion that an entity edit emits the watcher-correction shape (`field_path`/`mutation`/`corrected_value`, no `fields` map).
- 9/9 projection + producer tests green with the new shape.
- `tsc` + biome clean.

## Risk
Contained: `entity_field_state` has no readers yet, so re-shaping its source events affects nothing user-facing. The entity write itself is unchanged (the event is an in-transaction side-record).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784779702&installation_id=136316292&pr_number=1515&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1515&signature=00c3e9840b46fcde5152ec389615c21436680cbf594ac8285379620250f172a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved entity field change tracking to process individual field updates on a per-field basis, enhancing consistency in state projections and event handling. This optimization ensures more precise tracking and better reliability when recording entity field modifications across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->