### PR TITLE
fix(catalog): address PR #1518 review findings

### DIFF
--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -440,7 +440,12 @@ describe("lobu init --from-org", () => {
           if (body.action === "list_catalog") {
             return { catalogs: { connectors: { entries: [stripe] } } };
           }
-          return { installed: { connectors: { items: [stripe] } } };
+          if (body.action === "list_installed") {
+            return { installed: { connectors: { items: [stripe] } } };
+          }
+          throw new Error(
+            `unexpected manage_catalog action: ${String(body.action)}`,
+          );
         },
       }),
     });
@@ -675,7 +680,12 @@ describe("lobu init --from-org", () => {
           if (body.action === "list_catalog") {
             return { catalogs: { connectors: { entries: [slack] } } };
           }
-          return { installed: { connectors: { items: [slack] } } };
+          if (body.action === "list_installed") {
+            return { installed: { connectors: { items: [slack] } } };
+          }
+          throw new Error(
+            `unexpected manage_catalog action: ${String(body.action)}`,
+          );
         },
       }),
     });

--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -444,7 +444,7 @@ describe("lobu init --from-org", () => {
             return { installed: { connectors: { items: [stripe] } } };
           }
           throw new Error(
-            `unexpected manage_catalog action: ${String(body.action)}`,
+            `unexpected manage_catalog action: ${String(body.action)}`
           );
         },
       }),
@@ -684,7 +684,7 @@ describe("lobu init --from-org", () => {
             return { installed: { connectors: { items: [slack] } } };
           }
           throw new Error(
-            `unexpected manage_catalog action: ${String(body.action)}`,
+            `unexpected manage_catalog action: ${String(body.action)}`
           );
         },
       }),

--- a/packages/cli/src/commands/memory/_lib/browser-auth-cmd.ts
+++ b/packages/cli/src/commands/memory/_lib/browser-auth-cmd.ts
@@ -137,10 +137,10 @@ async function resolveConnectorDomains(
 
   const installedItems: any[] = parsed?.installed?.connectors?.items ?? [];
   const connectors: any[] = installedItems.map((item: any) => ({
+    ...(item.detail ?? {}),
     key: item.id,
     name: item.name,
     favicon_domain: item.detail?.favicon_domain,
-    ...item.detail,
   }));
   const connector = connectors.find((c: any) => c.key === connectorKey);
 

--- a/packages/server/src/auth/__tests__/config.baseline.integration.test.ts
+++ b/packages/server/src/auth/__tests__/config.baseline.integration.test.ts
@@ -16,6 +16,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getTestDb } from "../../__tests__/setup/test-db";
 import { createTestOrganization } from "../../__tests__/setup/test-fixtures";
+import { clearCatalogCacheForTests } from "../../catalog/load";
 import type { Env } from "../../index";
 import {
 	clearLoginProviderCachesForTests,
@@ -54,7 +55,6 @@ describe("login provider baseline (integration)", () => {
 	beforeAll(async () => {
 		prevCatalogUris = process.env.LOBU_CATALOG_URIS;
 		delete process.env.LOBU_CATALOG_URIS;
-		const { clearCatalogCacheForTests } = await import("../../catalog/load");
 		clearCatalogCacheForTests();
 		for (const key of CREDENTIAL_ENV_KEYS) {
 			ambientCredentials.set(key, process.env[key]);
@@ -66,7 +66,6 @@ describe("login provider baseline (integration)", () => {
 	afterAll(async () => {
 		if (prevCatalogUris === undefined) delete process.env.LOBU_CATALOG_URIS;
 		else process.env.LOBU_CATALOG_URIS = prevCatalogUris;
-		const { clearCatalogCacheForTests } = await import("../../catalog/load");
 		clearCatalogCacheForTests();
 		for (const [key, value] of ambientCredentials) {
 			if (value === undefined) delete process.env[key];

--- a/packages/server/src/catalog/__tests__/load.test.ts
+++ b/packages/server/src/catalog/__tests__/load.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { clearCatalogCacheForTests, listCatalogEntries } from "../load";
 
@@ -24,9 +27,6 @@ describe("catalog/load", () => {
 
 	it("deduplicates catalog entries by id within a kind", async () => {
 		const prev = process.env.LOBU_CATALOG_URIS;
-		const { mkdtemp, writeFile } = await import("node:fs/promises");
-		const { join } = await import("node:path");
-		const { tmpdir } = await import("node:os");
 		const dir = await mkdtemp(join(tmpdir(), "lobu-catalog-test-"));
 		const manifestPath = join(dir, "connectors.json");
 		await writeFile(

--- a/packages/server/src/catalog/__tests__/uris.test.ts
+++ b/packages/server/src/catalog/__tests__/uris.test.ts
@@ -1,0 +1,19 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { getDefaultCatalogDir } from "../uris";
+
+describe("catalog/uris", () => {
+	it("getDefaultCatalogDir returns the first existing candidate", () => {
+		const here =
+			import.meta.dirname ?? fileURLToPath(new URL(".", import.meta.url));
+		const candidates = [
+			resolve(here, "../../dist/catalogs"),
+			resolve(here, "../../../dist/catalogs"),
+			resolve(process.cwd(), "packages/server/dist/catalogs"),
+		];
+		const expected = candidates.find((candidate) => existsSync(candidate));
+		expect(getDefaultCatalogDir()).toBe(expected ?? candidates[0]);
+	});
+});

--- a/packages/server/src/catalog/__tests__/uris.test.ts
+++ b/packages/server/src/catalog/__tests__/uris.test.ts
@@ -6,14 +6,21 @@ import { getDefaultCatalogDir } from "../uris";
 
 describe("catalog/uris", () => {
 	it("getDefaultCatalogDir returns the first existing candidate", () => {
-		const here =
-			import.meta.dirname ?? fileURLToPath(new URL(".", import.meta.url));
+		// Mirror uris.ts candidate resolution from the catalog module dir, not
+		// this test file's __tests__ location (vitest/bun cwd layouts differ).
+		const catalogModuleDir = fileURLToPath(new URL("..", import.meta.url));
 		const candidates = [
-			resolve(here, "../../dist/catalogs"),
-			resolve(here, "../../../dist/catalogs"),
+			resolve(catalogModuleDir, "../../dist/catalogs"),
+			resolve(catalogModuleDir, "../../../dist/catalogs"),
 			resolve(process.cwd(), "packages/server/dist/catalogs"),
 		];
-		const expected = candidates.find((candidate) => existsSync(candidate));
-		expect(getDefaultCatalogDir()).toBe(expected ?? candidates[0]);
+		const expected =
+			candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
+		const result = getDefaultCatalogDir();
+
+		expect(result).toBe(expected);
+		if (existsSync(result)) {
+			expect(candidates).toContain(result);
+		}
 	});
 });

--- a/packages/server/src/catalog/installed.ts
+++ b/packages/server/src/catalog/installed.ts
@@ -173,20 +173,20 @@ export async function listAgentInstalled(
 		const enabled = new Set(settings.guardrails ?? []);
 		const core = getLobuCoreServices();
 		const registry = core?.getGuardrailRegistry?.();
-		if (!registry) return result;
-
-		const stages: GuardrailStage[] = ["input", "output", "pre-tool"];
 		const items: InstalledItem[] = [];
-		for (const stage of stages) {
-			for (const guardrail of registry.list(stage)) {
-				items.push({
-					id: guardrail.name,
-					name: guardrail.name,
-					detail: {
-						stage: guardrail.stage,
-						enabled: enabled.has(guardrail.name),
-					},
-				});
+		if (registry) {
+			const stages: GuardrailStage[] = ["input", "output", "pre-tool"];
+			for (const stage of stages) {
+				for (const guardrail of registry.list(stage)) {
+					items.push({
+						id: guardrail.name,
+						name: guardrail.name,
+						detail: {
+							stage: guardrail.stage,
+							enabled: enabled.has(guardrail.name),
+						},
+					});
+				}
 			}
 		}
 		result.guardrails = { kind: "guardrails", items };

--- a/packages/server/src/catalog/uris.ts
+++ b/packages/server/src/catalog/uris.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -53,7 +54,7 @@ export function getDefaultCatalogDir(): string {
 		resolve(process.cwd(), "packages/server/dist/catalogs"),
 	];
 	for (const candidate of candidates) {
-		return candidate;
+		if (existsSync(candidate)) return candidate;
 	}
 	return candidates[0]!;
 }

--- a/packages/server/src/gateway/routes/public/agent-config.ts
+++ b/packages/server/src/gateway/routes/public/agent-config.ts
@@ -444,11 +444,7 @@ function redactSensitiveFields(value: unknown): unknown {
 	const output: Record<string, unknown> = {};
 
 	for (const [key, rawValue] of Object.entries(input)) {
-		if (
-			typeof rawValue === "string" &&
-			rawValue.length > 0 &&
-			SENSITIVE_KEY_PATTERN.test(key)
-		) {
+		if (SENSITIVE_KEY_PATTERN.test(key)) {
 			output[key] = REDACTED_VALUE;
 			continue;
 		}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1405,7 +1405,11 @@ app.post("/api/:orgSlug/:toolName", mcpAuth, async (c) => {
 // this polled endpoint into a Map lookup instead of an O(tools × schema) walk.
 const openApiSpecCache = new Map<string, object>();
 app.get("/openapi.json", (c) => {
-	const serverUrl = new URL(c.req.url).origin;
+	const configuredOrigin = getConfiguredPublicOrigin();
+	const serverUrl = configuredOrigin ?? new URL(c.req.url).origin;
+	if (!configuredOrigin) {
+		return c.json(generateOpenAPISpec(serverUrl));
+	}
 	let spec = openApiSpecCache.get(serverUrl);
 	if (!spec) {
 		spec = generateOpenAPISpec(serverUrl);

--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -114,6 +114,12 @@ async function withPublicOrg<T>(
 		const result = await handler(organizationId);
 		return c.json(toJsonSafe(result));
 	} catch (error) {
+		if (error instanceof ToolUserError) {
+			return c.json(
+				{ error: error.message },
+				error.httpStatus as 400 | 403 | 404 | 409 | 422,
+			);
+		}
 		return c.json({ error: errorMessage(error) }, 400);
 	}
 }
@@ -306,11 +312,12 @@ export async function restListTools(c: Context<{ Bindings: Env }>) {
 			: authCtx.memberRole === "owner" || authCtx.memberRole === "admin"
 				? "admin"
 				: "write";
-		const scopeAccessLevel = !authCtx.scopes
+		const scopes = authCtx.scopes ?? SCOPE_CHECK_NOT_APPLICABLE;
+		const scopeAccessLevel = scopes.includes("*")
 			? "admin"
-			: authCtx.scopes.includes("mcp:admin")
+			: scopes.includes("mcp:admin")
 				? "admin"
-				: authCtx.scopes.includes("mcp:write")
+				: scopes.includes("mcp:write")
 					? "write"
 					: "read";
 		const maxAccessLevel =
@@ -571,7 +578,7 @@ export async function publicRestGetConnector(c: Context<{ Bindings: Env }>) {
 		});
 
 		if (!connector) {
-			throw new Error("Connector not found");
+			throw new ToolUserError("Connector not found", 404);
 		}
 
 		const feeds = await sql`

--- a/packages/server/src/tools/admin/__tests__/manage_catalog.test.ts
+++ b/packages/server/src/tools/admin/__tests__/manage_catalog.test.ts
@@ -1,21 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const listOrgInstalled = vi.fn(async () => ({
-	connectors: { kind: "connectors", items: [] },
-}));
-const listAgentInstalled = vi.fn(async () => ({
-	skills: { kind: "skills", items: [] },
-}));
-
-vi.mock("../../../catalog/installed", () => ({
-	listOrgInstalled,
-	listAgentInstalled,
-}));
-
-vi.mock("../../../catalog/load", () => ({
-	listCatalogEntries: vi.fn(),
-}));
-
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as installed from "../../../catalog/installed";
 import { manageCatalog } from "../manage_catalog";
 
 const ctx = {
@@ -33,8 +17,16 @@ const ctx = {
 
 describe("manage_catalog list_installed", () => {
 	beforeEach(() => {
-		listOrgInstalled.mockClear();
-		listAgentInstalled.mockClear();
+		vi.spyOn(installed, "listOrgInstalled").mockResolvedValue({
+			connectors: { kind: "connectors", items: [] },
+		});
+		vi.spyOn(installed, "listAgentInstalled").mockResolvedValue({
+			skills: { kind: "skills", items: [] },
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
 	});
 
 	it("does not default to org connectors when kinds is explicitly agent-scoped", async () => {
@@ -46,7 +38,7 @@ describe("manage_catalog list_installed", () => {
 		expect(result).toEqual({
 			error: "`agent_id` is required for agent-scoped installed kinds.",
 		});
-		expect(listOrgInstalled).not.toHaveBeenCalled();
+		expect(installed.listOrgInstalled).not.toHaveBeenCalled();
 	});
 
 	it("honors explicit org kinds without adding agent defaults", async () => {
@@ -60,8 +52,17 @@ describe("manage_catalog list_installed", () => {
 			ctx,
 		);
 
-		expect(listOrgInstalled).toHaveBeenCalledWith("org-1", ["watchers"], ctx);
-		expect(listAgentInstalled).not.toHaveBeenCalled();
+		expect(installed.listOrgInstalled).toHaveBeenCalledWith(
+			"org-1",
+			["watchers"],
+			expect.objectContaining({
+				organizationId: "org-1",
+				userId: "user-1",
+				memberRole: "owner",
+				isAuthenticated: true,
+			}),
+		);
+		expect(installed.listAgentInstalled).not.toHaveBeenCalled();
 		expect(result).toEqual({
 			action: "list_installed",
 			installed: { connectors: { kind: "connectors", items: [] } },

--- a/packages/server/src/tools/admin/__tests__/manage_catalog.test.ts
+++ b/packages/server/src/tools/admin/__tests__/manage_catalog.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listOrgInstalled = vi.fn(async () => ({
+	connectors: { kind: "connectors", items: [] },
+}));
+const listAgentInstalled = vi.fn(async () => ({
+	skills: { kind: "skills", items: [] },
+}));
+
+vi.mock("../../../catalog/installed", () => ({
+	listOrgInstalled,
+	listAgentInstalled,
+}));
+
+vi.mock("../../../catalog/load", () => ({
+	listCatalogEntries: vi.fn(),
+}));
+
+import { manageCatalog } from "../manage_catalog";
+
+const ctx = {
+	organizationId: "org-1",
+	userId: "user-1",
+	memberRole: "owner" as const,
+	isAuthenticated: true,
+	clientId: null,
+	tokenType: "session" as const,
+	scopedToOrg: true,
+	allowCrossOrg: false,
+	requestUrl: "http://localhost:8787",
+	scopes: ["mcp:admin"],
+};
+
+describe("manage_catalog list_installed", () => {
+	beforeEach(() => {
+		listOrgInstalled.mockClear();
+		listAgentInstalled.mockClear();
+	});
+
+	it("does not default to org connectors when kinds is explicitly agent-scoped", async () => {
+		const result = await manageCatalog(
+			{ action: "list_installed", kinds: ["skills"] },
+			{} as never,
+			ctx,
+		);
+		expect(result).toEqual({
+			error: "`agent_id` is required for agent-scoped installed kinds.",
+		});
+		expect(listOrgInstalled).not.toHaveBeenCalled();
+	});
+
+	it("honors explicit org kinds without adding agent defaults", async () => {
+		const result = await manageCatalog(
+			{
+				action: "list_installed",
+				agent_id: "agent-1",
+				kinds: ["watchers"],
+			},
+			{} as never,
+			ctx,
+		);
+
+		expect(listOrgInstalled).toHaveBeenCalledWith("org-1", ["watchers"], ctx);
+		expect(listAgentInstalled).not.toHaveBeenCalled();
+		expect(result).toEqual({
+			action: "list_installed",
+			installed: { connectors: { kind: "connectors", items: [] } },
+		});
+	});
+});

--- a/packages/server/src/tools/admin/manage_catalog.ts
+++ b/packages/server/src/tools/admin/manage_catalog.ts
@@ -70,30 +70,43 @@ async function handleListInstalled(
 	args: ListInstalledArgs,
 	ctx: ToolContext,
 ): Promise<unknown> {
-	const agentKinds = (args.kinds ?? []).filter((k): k is AgentInstalledKind =>
-		(AGENT_INSTALLED_KINDS as readonly string[]).includes(k),
-	);
-	const orgKinds = (args.kinds ?? []).filter((k): k is OrgInstalledKind =>
-		(ORG_INSTALLED_KINDS as readonly string[]).includes(k),
-	);
+	const requestedKinds = args.kinds?.length ? args.kinds : undefined;
+	const isAgentKind = (k: string): k is AgentInstalledKind =>
+		(AGENT_INSTALLED_KINDS as readonly string[]).includes(k);
+	const isOrgKind = (k: string): k is OrgInstalledKind =>
+		(ORG_INSTALLED_KINDS as readonly string[]).includes(k);
 
-	const resolvedOrgKinds =
-		orgKinds.length > 0
-			? orgKinds
-			: args.agent_id
-				? []
-				: (["connectors"] as OrgInstalledKind[]);
-	const resolvedAgentKinds =
-		agentKinds.length > 0
-			? agentKinds
-			: args.agent_id
-				? ([
-						"skills",
-						"providers",
-						"guardrails",
-						"channels",
-					] as AgentInstalledKind[])
-				: [];
+	const agentKinds = (requestedKinds ?? []).filter(isAgentKind);
+	const orgKinds = (requestedKinds ?? []).filter(isOrgKind);
+	const unknownKinds = (requestedKinds ?? []).filter(
+		(k) => !isAgentKind(k) && !isOrgKind(k),
+	);
+	if (unknownKinds.length > 0) {
+		return {
+			error: `Unsupported installed kind(s): ${unknownKinds.join(", ")}`,
+		};
+	}
+	if (!args.agent_id && agentKinds.length > 0) {
+		return {
+			error: "`agent_id` is required for agent-scoped installed kinds.",
+		};
+	}
+
+	const resolvedOrgKinds = requestedKinds
+		? orgKinds
+		: args.agent_id
+			? []
+			: (["connectors"] as OrgInstalledKind[]);
+	const resolvedAgentKinds = requestedKinds
+		? agentKinds
+		: args.agent_id
+			? ([
+					"skills",
+					"providers",
+					"guardrails",
+					"channels",
+				] as AgentInstalledKind[])
+			: [];
 
 	const installed: Record<string, unknown> = {};
 
@@ -115,8 +128,8 @@ async function handleListInstalled(
 }
 
 const manageCatalogTool = defineActionTool("manage_catalog", {
-	list_catalog: action(ListCatalogAction, (_args, _ctx, _env) =>
-		handleListCatalog(_args as ListCatalogArgs),
+	list_catalog: action(ListCatalogAction, (args) =>
+		handleListCatalog(args as ListCatalogArgs),
 	),
 	list_installed: action(ListInstalledAction, (args, ctx) =>
 		handleListInstalled(args as ListInstalledArgs, ctx),


### PR DESCRIPTION
## Summary

Follow-up on merged #1518 — addresses the actionable CodeRabbit review items that were not fixed before merge.

- **`uris.ts`**: `getDefaultCatalogDir()` now checks `existsSync` before returning a candidate (was always returning the first path)
- **`installed.ts`**: missing guardrail registry no longer short-circuits; empty guardrails section is returned and later kinds (e.g. channels) still load
- **`manage_catalog`**: explicit `kinds` are honored; agent-scoped kinds require `agent_id`; defaults only apply when `kinds` is omitted
- **`browser-auth-cmd.ts`**: spread `detail` before assigning canonical `key`/`name`
- **`rest-api.ts`**: `ToolUserError` 404s propagate from `withPublicOrg`; session `["*"]` scope sentinel treated as admin for `/tools`
- **`index.ts`**: OpenAPI spec cache only when `getConfiguredPublicOrigin()` is set
- **`agent-config.ts`**: redact sensitive keys regardless of value type
- Tests: static imports, explicit `list_installed` mocks, `manage_catalog` + `uris` unit coverage

## Test plan

- [x] `bun run typecheck` (server)
- [x] `bun test` catalog + manage_catalog unit tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784835025&installation_id=136316292&pr_number=1519&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1519&signature=c1e6c6581b085856544eed879487d0ae1460ba38f3ff9912026968e62849f5ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->