### PR TITLE
feat(watchers): backend support for conversational watcher UX

### DIFF
--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -899,7 +899,12 @@ export class GatewayClient {
 
   private payloadToWorkerConfig(payload: MessagePayload): WorkerConfig {
     const conversationId = payload.conversationId || "default";
-    const platformMetadata = payload.platformMetadata;
+    const platformMetadata: Record<string, unknown> = {
+      ...payload.platformMetadata,
+      ...(payload.ephemeralContext?.trim()
+        ? { ephemeralContext: payload.ephemeralContext.trim() }
+        : {}),
+    };
 
     const agentOptions = {
       ...(payload.agentOptions || {}),

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -1484,7 +1484,15 @@ Use it when the user references past discussions or you need context.`);
       })
       .join("\n\n");
 
-    const effectivePromptText = `${configNotice}${sessionSummary ? `${sessionSummary}\n\n` : ""}${prependContexts ? `${prependContexts}\n\n` : ""}${userPrompt}`;
+    const ephemeralContext =
+      typeof (platformMetadata as Record<string, unknown> | null)
+        ?.ephemeralContext === "string"
+        ? String(
+            (platformMetadata as Record<string, unknown>).ephemeralContext
+          ).trim()
+        : "";
+
+    const effectivePromptText = `${configNotice}${sessionSummary ? `${sessionSummary}\n\n` : ""}${ephemeralContext ? `${ephemeralContext}\n\n` : ""}${prependContexts ? `${prependContexts}\n\n` : ""}${userPrompt}`;
 
     // Load image attachments for vision-capable models
     const images = await loadImageAttachments();

--- a/packages/core/src/worker/wire.ts
+++ b/packages/core/src/worker/wire.ts
@@ -65,6 +65,12 @@ export interface MessagePayload {
   // ── Message content (used by worker) ───────────────────────────────
   messageText: string;
 
+  /**
+   * Ephemeral context prepended to the user prompt for this turn only.
+   * Not stored in the transcript snapshot — use for watcher preprompts, etc.
+   */
+  ephemeralContext?: string;
+
   // ── Platform-specific data (used by worker for context) ────────────
   platformMetadata: Record<string, unknown>;
 

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1358,6 +1358,8 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
 
     const messageContent = body.content || body.message;
     const messageId = body.messageId || randomUUID();
+    const rawEphemeralContext =
+      typeof body.ephemeralContext === "string" ? body.ephemeralContext.trim() : "";
 
     if (!messageContent || typeof messageContent !== "string") {
       return c.json({ success: false, error: "content is required" }, 400);
@@ -1496,6 +1498,9 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         ...remainingOptions
       } = agentOptions;
 
+      const applyEphemeralContext =
+        rawEphemeralContext.length > 0 && (session.turnCount ?? 0) === 0;
+
       const jobId = await queueProducer.enqueueMessage({
         userId: session.userId,
         conversationId: session.conversationId || agentId,
@@ -1509,6 +1514,9 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         botId: "lobu-api",
         platform: "api",
         messageText: messageContent,
+        ...(applyEphemeralContext
+          ? { ephemeralContext: rawEphemeralContext.slice(0, 2048) }
+          : {}),
         platformMetadata: {
           agentId: realAgentId,
           // Echoed back on every response row (gateway-integration carries

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -78,6 +78,8 @@ const ListRunsAction = Type.Object({
   approval_status: Type.Optional(Type.String()),
   /** Filter by run_type. Omit to list every run type (sync, action, auth, …). */
   run_types: Type.Optional(Type.Array(Type.String())),
+  /** Filter watcher runs by watcher id(s). */
+  watcher_ids: Type.Optional(Type.Array(Type.Number())),
   /** Keyset cursor: return runs ordered before (before_created_at, before_id). */
   before_id: Type.Optional(Type.Number()),
   before_created_at: Type.Optional(Type.String()),
@@ -919,6 +921,9 @@ async function handleListRuns(
   if (args.approval_status) {
     where = sql`${where} AND r.approval_status = ${args.approval_status}`;
   }
+  if (args.watcher_ids && args.watcher_ids.length > 0) {
+    where = sql`${where} AND r.watcher_id = ANY(${pgBigintArray(args.watcher_ids)}::bigint[])`;
+  }
 
   const countQuery = sql`SELECT COUNT(*)::int AS total FROM runs r WHERE ${where}`;
 
@@ -927,7 +932,7 @@ async function handleListRuns(
     pageWhere = sql`${pageWhere} AND (r.created_at, r.id) < (${args.before_created_at}::timestamptz, ${args.before_id})`;
   }
   const query = sql`
-    SELECT r.id, r.run_type, r.connection_id, r.feed_id, r.connector_key, r.connector_version,
+    SELECT r.id, r.run_type, r.watcher_id, r.connection_id, r.feed_id, r.connector_key, r.connector_version,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.items_collected, r.checkpoint,
            r.created_at, r.completed_at,

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -466,6 +466,26 @@ export const ListWatchersSchema = Type.Object({
       description: 'Include prompt, schema, and sources in response (default: false)',
     })
   ),
+  watcher_group_id: Type.Optional(
+    Type.Number({
+      description: 'Filter watchers sharing a watcher_group_id (for legacy group URL resolution)',
+    })
+  ),
+  order_by: Type.Optional(
+    Type.Union([Type.Literal('last_fired_at'), Type.Literal('created_at')], {
+      description: 'Sort field. Omit for created_at DESC (default, backward compatible).',
+    })
+  ),
+  order_dir: Type.Optional(
+    Type.Union([Type.Literal('asc'), Type.Literal('desc')], {
+      description: 'Sort direction (default: desc)',
+    })
+  ),
+  limit: Type.Optional(
+    Type.Number({
+      description: 'Maximum watchers to return (omit for all)',
+    })
+  ),
 });
 
 // ============================================

--- a/packages/server/src/tools/admin/manage_watchers/list.ts
+++ b/packages/server/src/tools/admin/manage_watchers/list.ts
@@ -2,21 +2,29 @@
  * list_watchers handler for manage_watchers.
  */
 
-import { getDb } from '../../../db/client';
-import type { Env } from '../../../index';
-import logger from '../../../utils/logger';
-import { getOrganizationSlug, getPublicWebUrl, buildWatchersUrl } from '../../../utils/url-builder';
-import { toEntityInfo } from '../../view-urls';
-import { buildLatestWatcherRunJoinSql } from '../../../watchers/automation';
-import type { ToolContext } from '../../registry';
-import { batchCountUnanalyzedContent } from './shared';
+import { getDb } from "../../../db/client";
+import type { Env } from "../../../index";
+import logger from "../../../utils/logger";
+import {
+	buildWatchersUrl,
+	getOrganizationSlug,
+	getPublicWebUrl,
+} from "../../../utils/url-builder";
+import { buildLatestWatcherRunJoinSql } from "../../../watchers/automation";
+import type { ToolContext } from "../../registry";
+import { toEntityInfo } from "../../view-urls";
+import { batchCountUnanalyzedContent } from "./shared";
 
 export type ListWatchersArgs = {
-  watcher_id?: string;
-  entity_id?: number;
-  agent_id?: string;
-  status?: string;
-  include_details?: boolean;
+	watcher_id?: string;
+	entity_id?: number;
+	agent_id?: string;
+	watcher_group_id?: number;
+	status?: string;
+	include_details?: boolean;
+	order_by?: "last_fired_at" | "created_at";
+	order_dir?: "asc" | "desc";
+	limit?: number;
 };
 
 export type ListWatchersResult = { watchers: any[] };
@@ -26,20 +34,21 @@ export type ListWatchersResult = { watchers: any[] };
 // ============================================
 
 export async function handleList(
-  args: ListWatchersArgs,
-  _env: Env,
-  ctx: ToolContext
+	args: ListWatchersArgs,
+	_env: Env,
+	ctx: ToolContext,
 ): Promise<ListWatchersResult> {
-  const sql = getDb();
+	const sql = getDb();
 
-  if (args.entity_id) {
-    const entityCheck = await sql`SELECT id FROM entities WHERE id = ${args.entity_id}`;
-    if (entityCheck.length === 0) {
-      throw new Error(`Entity with ID ${args.entity_id} not found`);
-    }
-  }
+	if (args.entity_id) {
+		const entityCheck =
+			await sql`SELECT id FROM entities WHERE id = ${args.entity_id}`;
+		if (entityCheck.length === 0) {
+			throw new Error(`Entity with ID ${args.entity_id} not found`);
+		}
+	}
 
-  let query = `
+	let query = `
     SELECT
       i.id as watcher_id,
       i.name,
@@ -85,8 +94,8 @@ export async function handleList(
       (SELECT COUNT(*) FROM watcher_windows iw WHERE iw.watcher_id = i.id) as windows_count
   `;
 
-  if (args.include_details) {
-    query += `,
+	if (args.include_details) {
+		query += `,
       cv.description,
       cv.prompt,
       cv.extraction_schema,
@@ -97,125 +106,150 @@ export async function handleList(
       cv.condensation_window_count,
       cv.reactions_guidance
     `;
-  }
+	}
 
-  query += `
+	query += `
     FROM watchers i
     LEFT JOIN entities e ON e.id = ANY(i.entity_ids)
     LEFT JOIN entity_types et ON et.id = e.entity_type_id
     LEFT JOIN entities parent ON e.parent_id = parent.id
     LEFT JOIN entity_types pet ON pet.id = parent.entity_type_id
     LEFT JOIN watcher_versions cv ON i.current_version_id = cv.id
-    ${buildLatestWatcherRunJoinSql('i', 'wr')}
+    ${buildLatestWatcherRunJoinSql("i", "wr")}
   `;
 
-  const conditions: string[] = [];
-  const params: any[] = [];
-  let paramCount = 1;
+	const conditions: string[] = [];
+	const params: any[] = [];
+	let paramCount = 1;
 
-  conditions.push(`i.organization_id = $${paramCount}::text`);
-  params.push(ctx.organizationId);
-  paramCount++;
+	conditions.push(`i.organization_id = $${paramCount}::text`);
+	params.push(ctx.organizationId);
+	paramCount++;
 
-  if (args.entity_id) {
-    conditions.push(`$${paramCount} = ANY(i.entity_ids)`);
-    params.push(args.entity_id);
-    paramCount++;
-  }
+	if (args.entity_id) {
+		conditions.push(`$${paramCount} = ANY(i.entity_ids)`);
+		params.push(args.entity_id);
+		paramCount++;
+	}
 
-  if (args.watcher_id) {
-    conditions.push(`i.id = $${paramCount}`);
-    params.push(args.watcher_id);
-    paramCount++;
-  }
+	if (args.watcher_id) {
+		conditions.push(`i.id = $${paramCount}`);
+		params.push(args.watcher_id);
+		paramCount++;
+	}
 
-  if (args.agent_id) {
-    conditions.push(`i.agent_id = $${paramCount}`);
-    params.push(args.agent_id);
-    paramCount++;
-  }
+	if (args.agent_id) {
+		conditions.push(`i.agent_id = $${paramCount}`);
+		params.push(args.agent_id);
+		paramCount++;
+	}
 
-  if (args.status) {
-    conditions.push(`i.status = $${paramCount}`);
-    params.push(args.status);
-    paramCount++;
-  } else {
-    // Default to active watchers only (exclude archived)
-    conditions.push(`i.status = 'active'`);
-  }
+	if (args.watcher_group_id != null) {
+		conditions.push(`i.watcher_group_id = $${paramCount}`);
+		params.push(args.watcher_group_id);
+		paramCount++;
+	}
 
-  query += ` WHERE ${conditions.join(' AND ')}`;
-  query += ' ORDER BY i.created_at DESC';
+	if (args.status) {
+		conditions.push(`i.status = $${paramCount}`);
+		params.push(args.status);
+		paramCount++;
+	} else {
+		// Default to active watchers only (exclude archived)
+		conditions.push(`i.status = 'active'`);
+	}
 
-  const result = await sql.unsafe(query, params);
+	query += ` WHERE ${conditions.join(" AND ")}`;
 
-  const baseUrl = getPublicWebUrl(ctx.requestUrl, ctx.baseUrl);
-  const watcherIds = (result as any[]).map((i) => Number(i.watcher_id));
+	const orderDir = args.order_dir === "asc" ? "ASC" : "DESC";
+	if (args.order_by === "last_fired_at") {
+		query += ` ORDER BY i.last_fired_at ${orderDir} NULLS LAST, i.updated_at ${orderDir}`;
+	} else {
+		query += ` ORDER BY i.created_at ${orderDir}`;
+	}
 
-  let counts: Map<number, { pending: number; historical: number }>;
-  try {
-    counts = await batchCountUnanalyzedContent(watcherIds);
-  } catch (error) {
-    logger.error({ error }, '[manage_watchers] Error batch counting unanalyzed content');
-    counts = new Map();
-  }
+	if (args.limit != null && args.limit > 0) {
+		query += ` LIMIT $${paramCount}`;
+		params.push(args.limit);
+		paramCount++;
+	}
 
-  const uniqueOrgIds = [
-    ...new Set((result as any[]).map((r) => r.organization_id as string).filter(Boolean)),
-  ];
-  const orgSlugMap = new Map<string, string>();
-  for (const orgId of uniqueOrgIds) {
-    const slug = await getOrganizationSlug(orgId);
-    if (slug) orgSlugMap.set(orgId, slug);
-  }
+	const result = await sql.unsafe(query, params);
 
-  const watchersWithPendingCount = (result as any[]).map((watcher) => {
-    const watcherId = Number(watcher.watcher_id);
-    const countData = counts.get(watcherId) || { pending: 0, historical: 0 };
-    const orgSlug = orgSlugMap.get(watcher.organization_id as string) ?? null;
+	const baseUrl = getPublicWebUrl(ctx.requestUrl, ctx.baseUrl);
+	const watcherIds = (result as any[]).map((i) => Number(i.watcher_id));
 
-    const entityInfo = orgSlug
-      ? toEntityInfo(orgSlug, {
-          entity_type: watcher.entity_type,
-          slug: watcher.entity_slug,
-          parent_entity_type: watcher.parent_entity_type ?? null,
-          parent_slug: watcher.parent_slug ?? null,
-        })
-      : null;
-    const viewUrl = entityInfo ? buildWatchersUrl(entityInfo, baseUrl) : undefined;
+	let counts: Map<number, { pending: number; historical: number }>;
+	try {
+		counts = await batchCountUnanalyzedContent(watcherIds);
+	} catch (error) {
+		logger.error(
+			{ error },
+			"[manage_watchers] Error batch counting unanalyzed content",
+		);
+		counts = new Map();
+	}
 
-    const { organization_id: _orgId, ...rest } = watcher;
+	const uniqueOrgIds = [
+		...new Set(
+			(result as any[]).map((r) => r.organization_id as string).filter(Boolean),
+		),
+	];
+	const orgSlugMap = new Map<string, string>();
+	for (const orgId of uniqueOrgIds) {
+		const slug = await getOrganizationSlug(orgId);
+		if (slug) orgSlugMap.set(orgId, slug);
+	}
 
-    if (!args.include_details) {
-      delete (rest as Record<string, unknown>).prompt;
-      delete (rest as Record<string, unknown>).extraction_schema;
-      delete (rest as Record<string, unknown>).classifiers;
-      delete (rest as Record<string, unknown>).json_template;
-      delete (rest as Record<string, unknown>).description;
-    }
+	const watchersWithPendingCount = (result as any[]).map((watcher) => {
+		const watcherId = Number(watcher.watcher_id);
+		const countData = counts.get(watcherId) || { pending: 0, historical: 0 };
+		const orgSlug = orgSlugMap.get(watcher.organization_id as string) ?? null;
 
-    // Stringify `watcher_id` to match the rest of the manage_watchers
-    // contract: `handleCreate` returns `String(watcherId)`, the input schema
-    // declares `watcher_id` as a string, and downstream callers (CLI
-    // `apply-cmd.ts` → `updateWatcher`, MCP tools) forward whatever they
-    // receive straight back. Without the cast the raw integer leaks through
-    // and a follow-up `update`/`upgrade` call fails the schema gate with
-    // `/watcher_id: Expected string`. Same bug pattern for `current_version_id`
-    // (kept as-is — no consumer feeds it back into manage_watchers today).
-    if ((rest as Record<string, unknown>).watcher_id != null) {
-      (rest as Record<string, unknown>).watcher_id = String(
-        (rest as Record<string, unknown>).watcher_id,
-      );
-    }
+		const entityInfo = orgSlug
+			? toEntityInfo(orgSlug, {
+					entity_type: watcher.entity_type,
+					slug: watcher.entity_slug,
+					parent_entity_type: watcher.parent_entity_type ?? null,
+					parent_slug: watcher.parent_slug ?? null,
+				})
+			: null;
+		const viewUrl = entityInfo
+			? buildWatchersUrl(entityInfo, baseUrl)
+			: undefined;
 
-    return {
-      ...rest,
-      organization_slug: orgSlug,
-      pending_content_count: countData.pending,
-      historical_content_count: countData.historical,
-      view_url: viewUrl,
-    };
-  });
+		const { organization_id: _orgId, ...rest } = watcher;
 
-  return { watchers: watchersWithPendingCount };
+		if (!args.include_details) {
+			delete (rest as Record<string, unknown>).prompt;
+			delete (rest as Record<string, unknown>).extraction_schema;
+			delete (rest as Record<string, unknown>).classifiers;
+			delete (rest as Record<string, unknown>).json_template;
+			delete (rest as Record<string, unknown>).description;
+		}
+
+		// Stringify `watcher_id` to match the rest of the manage_watchers
+		// contract: `handleCreate` returns `String(watcherId)`, the input schema
+		// declares `watcher_id` as a string, and downstream callers (CLI
+		// `apply-cmd.ts` → `updateWatcher`, MCP tools) forward whatever they
+		// receive straight back. Without the cast the raw integer leaks through
+		// and a follow-up `update`/`upgrade` call fails the schema gate with
+		// `/watcher_id: Expected string`. Same bug pattern for `current_version_id`
+		// (kept as-is — no consumer feeds it back into manage_watchers today).
+		if ((rest as Record<string, unknown>).watcher_id != null) {
+			(rest as Record<string, unknown>).watcher_id = String(
+				(rest as Record<string, unknown>).watcher_id,
+			);
+		}
+
+		return {
+			...rest,
+			organization_slug: orgSlug,
+			pending_content_count: countData.pending,
+			historical_content_count: countData.historical,
+			view_url: viewUrl,
+		};
+	});
+
+	return { watchers: watchersWithPendingCount };
 }


### PR DESCRIPTION
## Summary

Backend support for the conversational watchers UX (owletto #348).

- \`list_watchers\`: \`order_by\`, \`limit\`, \`watcher_group_id\` filters
- \`list_runs\`: \`watcher_ids\` filter + \`watcher_id\` in SELECT (runs strip)
- \`ephemeralContext\` preprompt pipeline: gateway first message → worker session prepend
- Owletto submodule bumped to merged main (\`9dea50d\`)

Depends on owletto #348 (merged).

## Test plan

- [x] \`bun run typecheck\` passes
- [ ] Watcher detail chat sends preprompt on first message
- [ ] Watcher runs strip loads runs filtered by watcher id

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784841418&installation_id=136316292&pr_number=1523&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1523&signature=5081e890c25c7bce41181ddd9a6a85f16ad5c605bfb6afeda3522018fe37cb87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->