### PR TITLE
feat(server): shared system-provider resolution and managed platform metadata

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -275,6 +275,9 @@
         "@codemirror/state": "^6.5.4",
         "@codemirror/view": "^6.39.15",
         "@daveyplate/better-auth-ui": "^3.3.15",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@jsonforms/core": "^3.7.0",
         "@jsonforms/react": "^3.7.0",
         "@lobu/connector-sdk": "workspace:*",
@@ -743,6 +746,14 @@
     "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
 
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.4.4", "", {}, "sha512-g/6CWAJ4XOkObWCWAQ2IReZD8VvsDy3poRHSKvpRR2F96F8WJ3HVbjpso3gN7l0q6QPPgvxSSpl/qo5k8a7mkQ=="],
 

--- a/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
@@ -10,9 +10,9 @@
  * builders stuck in the broken state.
  */
 
+import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { access, readFile } from "node:fs/promises";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
 	BUILDER_AGENT_ID,
@@ -27,7 +27,10 @@ import {
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 // packages/server/src/__tests__/integration/auth → repo root (6 levels up).
-const PROVIDERS_JSON = path.resolve(HERE, "../../../../../../config/providers.json");
+const PROVIDERS_JSON = path.resolve(
+	HERE,
+	"../../../../../../config/providers.json",
+);
 
 describe("ensureBuilderAgent — provisioning reliability", () => {
 	const sql = getTestDb();
@@ -36,9 +39,11 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		"ANTHROPIC_AUTH_TOKEN",
 		"CLAUDE_CODE_OAUTH_TOKEN",
 	];
+	const ZAI_ENV_VARS = ["Z_AI_API_KEY", "ZAI_API_KEY"];
 	const prevRegistryPath = process.env.LOBU_PROVIDER_REGISTRY_PATH;
 	const prevOpenAI = process.env.OPENAI_API_KEY;
 	const prevClaude: Record<string, string | undefined> = {};
+	const prevZai: Record<string, string | undefined> = {};
 
 	beforeAll(async () => {
 		await cleanupTestDatabase();
@@ -57,6 +62,10 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 			prevClaude[v] = process.env[v];
 			delete process.env[v];
 		}
+		for (const v of ZAI_ENV_VARS) {
+			prevZai[v] = process.env[v];
+			delete process.env[v];
+		}
 	});
 
 	afterAll(() => {
@@ -66,6 +75,10 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		if (prevOpenAI === undefined) delete process.env.OPENAI_API_KEY;
 		else process.env.OPENAI_API_KEY = prevOpenAI;
 		for (const [k, v] of Object.entries(prevClaude)) {
+			if (v === undefined) delete process.env[k];
+			else process.env[k] = v;
+		}
+		for (const [k, v] of Object.entries(prevZai)) {
 			if (v === undefined) delete process.env[k];
 			else process.env[k] = v;
 		}
@@ -98,9 +111,9 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		expect(b).toBeTruthy();
 		expect(Array.isArray(b?.installed_providers)).toBe(true);
 		expect(b?.installed_providers?.length ?? 0).toBeGreaterThan(0);
-		expect(
-			b?.installed_providers?.some((p) => p.providerId === "openai"),
-		).toBe(true);
+		expect(b?.installed_providers?.some((p) => p.providerId === "openai")).toBe(
+			true,
+		);
 		// Deterministic default from providers.json (`openai` → `gpt-4o`).
 		expect(b?.model).toBe("openai/gpt-4o");
 		expect(await readPointer(org.id)).toBe(BUILDER_AGENT_ID);
@@ -173,7 +186,9 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		expect(b?.model).toBeTruthy();
 		// Invariant: the pinned model's provider is always installed.
 		const pid = b?.model?.slice(0, b.model.indexOf("/")) ?? "";
-		expect(b?.installed_providers?.some((p) => p.providerId === pid)).toBe(true);
+		expect(b?.installed_providers?.some((p) => p.providerId === pid)).toBe(
+			true,
+		);
 	});
 
 	it("provisions a usable builder when ONLY an Anthropic system key is present (not in providers.json)", async () => {

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -30,191 +30,28 @@
  * (set via `manage_agents.set_system_agent`).
  */
 
-import type { ProviderConfigEntry } from '@lobu/core';
-import { getDb } from '../db/client';
-import type { DbClient } from '../db/client';
-import { collectProviderModelOptions } from '../gateway/auth/provider-model-options';
-import { resolveEnv } from '../gateway/auth/mcp/string-substitution';
-import { getModelProviderModules } from '../gateway/modules/module-system';
-import {
-  ProviderRegistryService,
-  resolveProviderRegistryPath,
-} from '../gateway/services/provider-registry-service';
-import logger from '../utils/logger';
-import { hasOrgSentinel } from './default-provisioning';
 import { getErrorMessage } from "@lobu/core";
+import type { DbClient } from "../db/client";
+import { getDb } from "../db/client";
+import logger from "../utils/logger";
+import { hasOrgSentinel } from "./default-provisioning";
+import {
+	type InstalledProvider,
+	resolveSystemKeyProvidersAndModel,
+} from "./system-provider-resolution";
 
-export const BUILDER_AGENT_ID = 'lobu-builder';
-export const BUILDER_AGENT_SENTINEL = 'builder_agent_provisioned';
+export const BUILDER_AGENT_ID = "lobu-builder";
+export const BUILDER_AGENT_SENTINEL = "builder_agent_provisioned";
 
-const BUILDER_AGENT_NAME = 'Builder';
+const BUILDER_AGENT_NAME = "Builder";
 const BUILDER_AGENT_IDENTITY =
-  "You are the organization's Builder — its setup and management assistant. " +
-  'You help the owner configure their workspace: creating and editing agents, ' +
-  'wiring up connections and integrations, setting up watchers and scheduled ' +
-  'workflows, and keeping the org healthy. ' +
-  'Be concrete and action-oriented; prefer making the change over describing it. ' +
-  "If you don't yet have access to something the user wants to manage, say so " +
-  'clearly and suggest what they could connect or grant next.';
-
-/**
- * Preference for the builder's *pinned* model among providers declared in
- * config/providers.json. We pin the first provider here that (a) has a system
- * key in this environment and (b) declares a `defaultModel`. These ids are
- * config-maintained, so they stay current without a code change. Providers not
- * listed are still installed; they just aren't preferred for the initial pin.
- */
-const BUILDER_MODEL_PROVIDER_PREFERENCE = [
-  'openai',
-  'gemini',
-  'groq',
-  'mistral',
-  'deepseek',
-  'cohere',
-  'xai',
-];
-
-/**
- * Anthropic/Claude is the canonical platform provider but is intentionally NOT
- * in config/providers.json (its model list is fetched live from the provider).
- * Resolve it directly from its env vars so an Anthropic-only deployment still
- * gets a working builder even when the live module registry is empty. When a
- * Claude system key is present it is the PREFERRED pin (it is always a real API
- * key, never an OAuth/Codex backend), so the builder gets a reliable default;
- * the config-declared providers below are only pinned when Claude is absent.
- */
-const CLAUDE_PROVIDER_ID = 'claude';
-const CLAUDE_SYSTEM_ENV_VARS = [
-  'ANTHROPIC_API_KEY',
-  'ANTHROPIC_AUTH_TOKEN',
-  'CLAUDE_CODE_OAUTH_TOKEN',
-];
-const CLAUDE_FALLBACK_MODEL = 'claude/claude-sonnet-4-6';
-
-function hasClaudeSystemKey(): boolean {
-  return CLAUDE_SYSTEM_ENV_VARS.some((v) => !!resolveEnv(v));
-}
-
-interface InstalledProvider {
-  providerId: string;
-  installedAt: number;
-}
-
-interface ResolvedBuilderProviders {
-  providers: InstalledProvider[];
-  model: string | null;
-}
-
-/**
- * Resolve the system-key providers + a default model to install on the builder.
- *
- * Primary source is `config/providers.json` (read directly — independent of the
- * runtime module registry), so this returns the same result regardless of
- * whether the gateway's `moduleRegistry` has been initialized in this process.
- * We additionally union in any system-key providers the live registry knows
- * about (e.g. anthropic / OAuth backends that aren't in providers.json) when it
- * happens to be available — purely additive, never required.
- */
-async function resolveBuilderProviders(): Promise<ResolvedBuilderProviders> {
-  const now = Date.now();
-  const installed = new Map<string, InstalledProvider>();
-
-  // (1) Deterministic floor: providers declared in config/providers.json whose
-  // env var is present in this process.
-  let configs: Record<string, ProviderConfigEntry> = {};
-  try {
-    const registry = new ProviderRegistryService(resolveProviderRegistryPath());
-    configs = await registry.getProviderConfigs();
-  } catch (err) {
-    logger.warn(
-      { err: getErrorMessage(err) },
-      '[builder-provisioning] providers.json read failed; relying on module registry'
-    );
-  }
-  for (const [providerId, cfg] of Object.entries(configs)) {
-    if (cfg.envVarName && resolveEnv(cfg.envVarName)) {
-      installed.set(providerId, { providerId, installedAt: now });
-    }
-  }
-
-  // (2) Anthropic/Claude — the canonical platform provider, not in
-  // providers.json. Resolve it from its env vars directly so an Anthropic-only
-  // deployment still gets a provider, registry or not.
-  if (hasClaudeSystemKey()) {
-    installed.set(CLAUDE_PROVIDER_ID, {
-      providerId: CLAUDE_PROVIDER_ID,
-      installedAt: now,
-    });
-  }
-
-  // (3) Best-effort union with the live module registry (additive — picks up
-  // any further providers it knows about when it happens to be initialized).
-  try {
-    for (const m of getModelProviderModules()) {
-      if (m.hasSystemKey() && !installed.has(m.providerId)) {
-        installed.set(m.providerId, { providerId: m.providerId, installedAt: now });
-      }
-    }
-  } catch {
-    // Registry not available — the providers.json + Claude floor already applies.
-  }
-
-  // Pin a model deterministically from providers.json `defaultModel`, preferring
-  // the capability order above, then any other env-matched provider that
-  // declares a default.
-  const pickModel = (providerId: string): string | null => {
-    const cfg = configs[providerId];
-    const dm = cfg?.defaultModel?.trim();
-    if (cfg?.envVarName && resolveEnv(cfg.envVarName) && dm) {
-      // A model ref is parsed as `providerId/<rest>` (split on the FIRST slash),
-      // and a model id can itself contain slashes (e.g. openrouter's
-      // `anthropic/claude-sonnet-4`, together-ai's `meta-llama/...`). Always
-      // prefix the providerId so the ref resolves to the right provider.
-      return `${providerId}/${dm}`;
-    }
-    return null;
-  };
-  // Prefer Claude (Anthropic) whenever its system key is present. It is the
-  // canonical always-API-key provider — it never routes to an OAuth/Codex
-  // backend, unlike an OPENAI_API_KEY that may actually be a ChatGPT/Codex
-  // token (which 403s against api.openai.com). For the critical system agent we
-  // pin the most reliable provider; the others are only pinned when Claude has
-  // no system key. Claude has no providers.json entry, so it's pinned from
-  // CLAUDE_FALLBACK_MODEL.
-  let model: string | null = hasClaudeSystemKey() ? CLAUDE_FALLBACK_MODEL : null;
-  for (const providerId of BUILDER_MODEL_PROVIDER_PREFERENCE) {
-    if (model) break;
-    model = pickModel(providerId);
-  }
-  if (!model) {
-    for (const providerId of Object.keys(configs)) {
-      model = pickModel(providerId);
-      if (model) break;
-    }
-  }
-  // Module-only providers that aren't in providers.json (e.g. Bedrock) declare
-  // their model only via the live registry. This is reached only when no
-  // config-declared provider resolved a model — i.e. a module-only deployment,
-  // where the registry is populated by definition (those providers came from
-  // it). Best-effort; covers any such provider generically.
-  if (!model && installed.size > 0) {
-    try {
-      const optionsByProvider = await collectProviderModelOptions('', '');
-      for (const { providerId } of installed.values()) {
-        const first = optionsByProvider[providerId]?.[0]?.value?.trim();
-        if (first) {
-          model = first.startsWith(`${providerId}/`)
-            ? first
-            : `${providerId}/${first}`;
-          break;
-        }
-      }
-    } catch {
-      // Registry/model fetch unavailable — fall through to the Claude floor.
-    }
-  }
-  return { providers: [...installed.values()], model };
-}
+	"You are the organization's Builder — its setup and management assistant. " +
+	"You help the owner configure their workspace: creating and editing agents, " +
+	"wiring up connections and integrations, setting up watchers and scheduled " +
+	"workflows, and keeping the org healthy. " +
+	"Be concrete and action-oriented; prefer making the change over describing it. " +
+	"If you don't yet have access to something the user wants to manage, say so " +
+	"clearly and suggest what they could connect or grant next.";
 
 /**
  * Read the JSON-decoded `organization.metadata` for the given org. Returns an
@@ -223,22 +60,22 @@ async function resolveBuilderProviders(): Promise<ResolvedBuilderProviders> {
  * `personal_org_for_user_id` marker tenant-safely.
  */
 async function readOrgMetadata(
-  sql: DbClient,
-  organizationId: string
+	sql: DbClient,
+	organizationId: string,
 ): Promise<Record<string, unknown>> {
-  const rows = (await sql`
+	const rows = (await sql`
     SELECT metadata FROM "organization" WHERE id = ${organizationId} LIMIT 1
   `) as unknown as Array<{ metadata: string | null }>;
-  const raw = rows[0]?.metadata;
-  if (!raw) return {};
-  try {
-    const parsed = JSON.parse(raw);
-    return typeof parsed === 'object' && parsed !== null
-      ? (parsed as Record<string, unknown>)
-      : {};
-  } catch {
-    return {};
-  }
+	const raw = rows[0]?.metadata;
+	if (!raw) return {};
+	try {
+		const parsed = JSON.parse(raw);
+		return typeof parsed === "object" && parsed !== null
+			? (parsed as Record<string, unknown>)
+			: {};
+	} catch {
+		return {};
+	}
 }
 
 /**
@@ -247,27 +84,27 @@ async function readOrgMetadata(
  * default-provisioning's `writeOrgSentinel`.
  */
 async function writeOrgSentinel(
-  sql: DbClient,
-  organizationId: string,
-  key: string,
-  value: string
+	sql: DbClient,
+	organizationId: string,
+	key: string,
+	value: string,
 ): Promise<void> {
-  const current = await readOrgMetadata(sql, organizationId);
-  current[key] = value;
-  const serialized = JSON.stringify(current);
-  await sql`
+	const current = await readOrgMetadata(sql, organizationId);
+	current[key] = value;
+	const serialized = JSON.stringify(current);
+	await sql`
     UPDATE "organization" SET metadata = ${serialized} WHERE id = ${organizationId}
   `;
 }
 
 /** Resolve the org's canonical owner from the personal-org metadata marker. */
 async function resolveOwnerUserId(
-  sql: DbClient,
-  organizationId: string
+	sql: DbClient,
+	organizationId: string,
 ): Promise<string | null> {
-  const md = await readOrgMetadata(sql, organizationId);
-  const raw = md['personal_org_for_user_id'];
-  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+	const md = await readOrgMetadata(sql, organizationId);
+	const raw = md["personal_org_for_user_id"];
+	return typeof raw === "string" && raw.length > 0 ? raw : null;
 }
 
 /**
@@ -276,18 +113,18 @@ async function resolveOwnerUserId(
  * explicit `set_system_agent` choice is never clobbered.
  */
 async function linkOwnerAndPointer(
-  sql: DbClient,
-  organizationId: string,
-  ownerUserId: string | null
+	sql: DbClient,
+	organizationId: string,
+	ownerUserId: string | null,
 ): Promise<void> {
-  if (ownerUserId) {
-    await sql`
+	if (ownerUserId) {
+		await sql`
       INSERT INTO agent_users (organization_id, agent_id, platform, user_id, created_at)
       VALUES (${organizationId}, ${BUILDER_AGENT_ID}, 'external', ${ownerUserId}, now())
       ON CONFLICT (organization_id, agent_id, platform, user_id) DO NOTHING
     `;
-  }
-  await sql`
+	}
+	await sql`
     UPDATE "organization"
     SET system_agent_id = ${BUILDER_AGENT_ID}
     WHERE id = ${organizationId}
@@ -312,63 +149,64 @@ async function linkOwnerAndPointer(
  * swallowed.
  */
 export async function ensureBuilderAgent(
-  organizationId: string,
-  sql?: DbClient
+	organizationId: string,
+	sql?: DbClient,
 ): Promise<{ created: boolean }> {
-  const client = sql ?? getDb();
-  try {
-    const rows = (await client`
+	const client = sql ?? getDb();
+	try {
+		const rows = (await client`
       SELECT installed_providers, model FROM agents
       WHERE organization_id = ${organizationId} AND id = ${BUILDER_AGENT_ID}
       LIMIT 1
     `) as unknown as Array<{
-      installed_providers: InstalledProvider[] | null;
-      model: string | null;
-    }>;
-    const existing = rows[0];
+			installed_providers: InstalledProvider[] | null;
+			model: string | null;
+		}>;
+		const existing = rows[0];
 
-    if (existing) {
-      const providersEmpty =
-        !Array.isArray(existing.installed_providers) ||
-        existing.installed_providers.length === 0;
-      const modelEmpty = !existing.model || String(existing.model).trim() === '';
+		if (existing) {
+			const providersEmpty =
+				!Array.isArray(existing.installed_providers) ||
+				existing.installed_providers.length === 0;
+			const modelEmpty =
+				!existing.model || String(existing.model).trim() === "";
 
-      // Heal providers/model only when broken, keeping providers + model
-      // CONSISTENT — the pinned model's provider must always be installed, so we
-      // never leave a dangling ref (e.g. model=openai/... with providers=[claude]).
-      // The healthy path skips this provider-config read entirely.
-      if (providersEmpty || modelEmpty) {
-        const resolved = await resolveBuilderProviders();
-        const existingProviders: InstalledProvider[] = Array.isArray(
-          existing.installed_providers
-        )
-          ? existing.installed_providers
-          : [];
-        // Keep an existing model if present, otherwise take the resolved pick.
-        const newModel = modelEmpty ? resolved.model : existing.model;
-        // Providers = existing ∪ resolved, plus the (new) model's own provider.
-        const providerMap = new Map<string, InstalledProvider>();
-        for (const p of existingProviders) providerMap.set(p.providerId, p);
-        for (const p of resolved.providers) {
-          if (!providerMap.has(p.providerId)) providerMap.set(p.providerId, p);
-        }
-        if (newModel) {
-          const slash = newModel.indexOf('/');
-          const modelProviderId = slash > 0 ? newModel.slice(0, slash) : '';
-          if (modelProviderId && !providerMap.has(modelProviderId)) {
-            providerMap.set(modelProviderId, {
-              providerId: modelProviderId,
-              installedAt: Date.now(),
-            });
-          }
-        }
-        const mergedProviders = [...providerMap.values()];
-        // Union only ever grows, so a length change means we added a provider.
-        const writeProviders =
-          mergedProviders.length !== existingProviders.length;
-        const writeModel = modelEmpty && !!newModel;
-        if (writeProviders || writeModel) {
-          await client`
+			// Heal providers/model only when broken, keeping providers + model
+			// CONSISTENT — the pinned model's provider must always be installed, so we
+			// never leave a dangling ref (e.g. model=openai/... with providers=[claude]).
+			// The healthy path skips this provider-config read entirely.
+			if (providersEmpty || modelEmpty) {
+				const resolved = await resolveSystemKeyProvidersAndModel();
+				const existingProviders: InstalledProvider[] = Array.isArray(
+					existing.installed_providers,
+				)
+					? existing.installed_providers
+					: [];
+				// Keep an existing model if present, otherwise take the resolved pick.
+				const newModel = modelEmpty ? resolved.model : existing.model;
+				// Providers = existing ∪ resolved, plus the (new) model's own provider.
+				const providerMap = new Map<string, InstalledProvider>();
+				for (const p of existingProviders) providerMap.set(p.providerId, p);
+				for (const p of resolved.providers) {
+					if (!providerMap.has(p.providerId)) providerMap.set(p.providerId, p);
+				}
+				if (newModel) {
+					const slash = newModel.indexOf("/");
+					const modelProviderId = slash > 0 ? newModel.slice(0, slash) : "";
+					if (modelProviderId && !providerMap.has(modelProviderId)) {
+						providerMap.set(modelProviderId, {
+							providerId: modelProviderId,
+							installedAt: Date.now(),
+						});
+					}
+				}
+				const mergedProviders = [...providerMap.values()];
+				// Union only ever grows, so a length change means we added a provider.
+				const writeProviders =
+					mergedProviders.length !== existingProviders.length;
+				const writeModel = modelEmpty && !!newModel;
+				if (writeProviders || writeModel) {
+					await client`
             UPDATE agents SET
               installed_providers = CASE WHEN ${writeProviders}
                 THEN ${client.json(mergedProviders)} ELSE installed_providers END,
@@ -377,48 +215,48 @@ export async function ensureBuilderAgent(
               updated_at = now()
             WHERE organization_id = ${organizationId} AND id = ${BUILDER_AGENT_ID}
           `;
-          logger.info(
-            { organizationId, writeProviders, writeModel, model: newModel },
-            '[builder-provisioning] Repaired builder providers/model'
-          );
-        }
-      }
+					logger.info(
+						{ organizationId, writeProviders, writeModel, model: newModel },
+						"[builder-provisioning] Repaired builder providers/model",
+					);
+				}
+			}
 
-      // Reconcile ownership + pointer + sentinel on every call — cheap idempotent
-      // writes that heal a builder whose create crashed between the INSERT and
-      // the follow-up writes (NULL system_agent_id, missing agent_users row, or
-      // missing deletion sentinel). Metadata is read once.
-      const md = await readOrgMetadata(client, organizationId);
-      const ownerRaw = md['personal_org_for_user_id'];
-      const ownerUserId =
-        typeof ownerRaw === 'string' && ownerRaw.length > 0 ? ownerRaw : null;
-      await linkOwnerAndPointer(client, organizationId, ownerUserId);
-      if (!md[BUILDER_AGENT_SENTINEL]) {
-        await writeOrgSentinel(
-          client,
-          organizationId,
-          BUILDER_AGENT_SENTINEL,
-          new Date().toISOString()
-        );
-      }
-      return { created: false };
-    }
+			// Reconcile ownership + pointer + sentinel on every call — cheap idempotent
+			// writes that heal a builder whose create crashed between the INSERT and
+			// the follow-up writes (NULL system_agent_id, missing agent_users row, or
+			// missing deletion sentinel). Metadata is read once.
+			const md = await readOrgMetadata(client, organizationId);
+			const ownerRaw = md["personal_org_for_user_id"];
+			const ownerUserId =
+				typeof ownerRaw === "string" && ownerRaw.length > 0 ? ownerRaw : null;
+			await linkOwnerAndPointer(client, organizationId, ownerUserId);
+			if (!md[BUILDER_AGENT_SENTINEL]) {
+				await writeOrgSentinel(
+					client,
+					organizationId,
+					BUILDER_AGENT_SENTINEL,
+					new Date().toISOString(),
+				);
+			}
+			return { created: false };
+		}
 
-    // Builder row absent. Respect deletion stickiness: a set sentinel means an
-    // admin deleted the builder — do not recreate it.
-    const provisioned = await hasOrgSentinel(
-      organizationId,
-      BUILDER_AGENT_SENTINEL,
-      client
-    );
-    if (provisioned) {
-      return { created: false };
-    }
+		// Builder row absent. Respect deletion stickiness: a set sentinel means an
+		// admin deleted the builder — do not recreate it.
+		const provisioned = await hasOrgSentinel(
+			organizationId,
+			BUILDER_AGENT_SENTINEL,
+			client,
+		);
+		if (provisioned) {
+			return { created: false };
+		}
 
-    const resolved = await resolveBuilderProviders();
-    const ownerUserId = await resolveOwnerUserId(client, organizationId);
+		const resolved = await resolveSystemKeyProvidersAndModel();
+		const ownerUserId = await resolveOwnerUserId(client, organizationId);
 
-    await client`
+		await client`
       INSERT INTO agents (
         id, organization_id, name, identity_md,
         owner_platform, owner_user_id,
@@ -433,34 +271,34 @@ export async function ensureBuilderAgent(
       ON CONFLICT (organization_id, id) DO NOTHING
     `;
 
-    await linkOwnerAndPointer(client, organizationId, ownerUserId);
+		await linkOwnerAndPointer(client, organizationId, ownerUserId);
 
-    await writeOrgSentinel(
-      client,
-      organizationId,
-      BUILDER_AGENT_SENTINEL,
-      new Date().toISOString()
-    );
+		await writeOrgSentinel(
+			client,
+			organizationId,
+			BUILDER_AGENT_SENTINEL,
+			new Date().toISOString(),
+		);
 
-    logger.info(
-      {
-        organizationId,
-        agentId: BUILDER_AGENT_ID,
-        ownerUserId,
-        providers: resolved.providers.length,
-        model: resolved.model,
-      },
-      '[builder-provisioning] Provisioned builder agent'
-    );
-    return { created: true };
-  } catch (err) {
-    logger.warn(
-      {
-        organizationId,
-        err: getErrorMessage(err),
-      },
-      '[builder-provisioning] Builder-agent provisioning failed (non-fatal)'
-    );
-    return { created: false };
-  }
+		logger.info(
+			{
+				organizationId,
+				agentId: BUILDER_AGENT_ID,
+				ownerUserId,
+				providers: resolved.providers.length,
+				model: resolved.model,
+			},
+			"[builder-provisioning] Provisioned builder agent",
+		);
+		return { created: true };
+	} catch (err) {
+		logger.warn(
+			{
+				organizationId,
+				err: getErrorMessage(err),
+			},
+			"[builder-provisioning] Builder-agent provisioning failed (non-fatal)",
+		);
+		return { created: false };
+	}
 }

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -21,39 +21,42 @@
  *     exact device via `device_worker_id`.
  */
 
-import { getDb } from '../db/client';
-import type { DbClient } from '../db/client';
-import { getModelProviderModules } from '../gateway/modules/module-system';
-import { getNextNumericId } from '../tools/admin/helpers/db-helpers';
-import { nextRunAt } from '../utils/cron';
-import logger from '../utils/logger';
 import { getErrorMessage } from "@lobu/core";
+import type { DbClient } from "../db/client";
+import { getDb } from "../db/client";
+import { getNextNumericId } from "../tools/admin/helpers/db-helpers";
+import { nextRunAt } from "../utils/cron";
+import logger from "../utils/logger";
+import {
+	type InstalledProvider,
+	resolveSystemKeyProvidersAndModel,
+} from "./system-provider-resolution";
 
-export const DEFAULT_AGENT_SENTINEL = 'default_agent_provisioned';
-export const DEFAULT_WATCHER_SENTINEL = 'default_watcher_provisioned';
+export const DEFAULT_AGENT_SENTINEL = "default_agent_provisioned";
+export const DEFAULT_WATCHER_SENTINEL = "default_watcher_provisioned";
 
-export const DEFAULT_AGENT_ID = 'owletto-default';
-const DEFAULT_AGENT_NAME = 'Owletto Personal';
+export const DEFAULT_AGENT_ID = "owletto-default";
+const DEFAULT_AGENT_NAME = "Owletto Personal";
 const DEFAULT_AGENT_IDENTITY =
-  "You are the user's personal assistant on their Mac. " +
-  'You help them stay productive by surfacing relevant context ' +
-  'and useful summaries. ' +
-  "If you don't have access to recent history or context, say so " +
-  'clearly and suggest what the user could connect or track next.';
+	"You are the user's personal assistant on their Mac. " +
+	"You help them stay productive by surfacing relevant context " +
+	"and useful summaries. " +
+	"If you don't have access to recent history or context, say so " +
+	"clearly and suggest what the user could connect or track next.";
 
-export const DEFAULT_WATCHER_SLUG = 'daily-checkin';
-const DEFAULT_WATCHER_NAME = 'Daily check-in';
-const DEFAULT_WATCHER_SCHEDULE = '0 9 * * *';
+export const DEFAULT_WATCHER_SLUG = "daily-checkin";
+const DEFAULT_WATCHER_NAME = "Daily check-in";
+const DEFAULT_WATCHER_SCHEDULE = "0 9 * * *";
 const DEFAULT_WATCHER_PROMPT =
-  'Summarize what the user worked on yesterday in 1-2 sentences. ' +
-  'Suggest 1-3 concrete priorities for today. ' +
-  "If you don't have recent history or context for this user, " +
-  'say that clearly and suggest what the user could connect ' +
-  'or track next (calendar, browser activity, etc.).';
+	"Summarize what the user worked on yesterday in 1-2 sentences. " +
+	"Suggest 1-3 concrete priorities for today. " +
+	"If you don't have recent history or context for this user, " +
+	"say that clearly and suggest what the user could connect " +
+	"or track next (calendar, browser activity, etc.).";
 
 const DEFAULT_WATCHER_EXTRACTION_SCHEMA = {
-  type: 'object',
-  properties: { summary: { type: 'string' } },
+	type: "object",
+	properties: { summary: { type: "string" } },
 };
 
 /**
@@ -61,25 +64,28 @@ const DEFAULT_WATCHER_EXTRACTION_SCHEMA = {
  * Returns an empty object if the row is missing or the JSON is invalid.
  */
 async function readOrgMetadata(
-  sql: DbClient,
-  organizationId: string
+	sql: DbClient,
+	organizationId: string,
 ): Promise<Record<string, unknown>> {
-  const rows = (await sql`
+	const rows = (await sql`
     SELECT metadata FROM "organization" WHERE id = ${organizationId} LIMIT 1
   `) as unknown as Array<{ metadata: string | null }>;
-  const raw = rows[0]?.metadata;
-  if (!raw) return {};
-  try {
-    const parsed = JSON.parse(raw);
-    return typeof parsed === 'object' && parsed !== null
-      ? (parsed as Record<string, unknown>)
-      : {};
-  } catch {
-    // Defensive: legacy rows might hold non-JSON text. Treat as empty so the
-    // sentinel-write below produces a valid JSON object going forward.
-    logger.warn({ organizationId }, '[default-provisioning] organization.metadata is not valid JSON; resetting');
-    return {};
-  }
+	const raw = rows[0]?.metadata;
+	if (!raw) return {};
+	try {
+		const parsed = JSON.parse(raw);
+		return typeof parsed === "object" && parsed !== null
+			? (parsed as Record<string, unknown>)
+			: {};
+	} catch {
+		// Defensive: legacy rows might hold non-JSON text. Treat as empty so the
+		// sentinel-write below produces a valid JSON object going forward.
+		logger.warn(
+			{ organizationId },
+			"[default-provisioning] organization.metadata is not valid JSON; resetting",
+		);
+		return {};
+	}
 }
 
 /**
@@ -89,15 +95,15 @@ async function readOrgMetadata(
  * key presence is what we read for the existence check).
  */
 async function writeOrgSentinel(
-  sql: DbClient,
-  organizationId: string,
-  key: string,
-  value: string
+	sql: DbClient,
+	organizationId: string,
+	key: string,
+	value: string,
 ): Promise<void> {
-  const current = await readOrgMetadata(sql, organizationId);
-  current[key] = value;
-  const serialized = JSON.stringify(current);
-  await sql`
+	const current = await readOrgMetadata(sql, organizationId);
+	current[key] = value;
+	const serialized = JSON.stringify(current);
+	await sql`
     UPDATE "organization" SET metadata = ${serialized} WHERE id = ${organizationId}
   `;
 }
@@ -108,13 +114,13 @@ async function writeOrgSentinel(
  * it even if the row it created has since been deleted.
  */
 export async function hasOrgSentinel(
-  organizationId: string,
-  key: string,
-  sql?: DbClient
+	organizationId: string,
+	key: string,
+	sql?: DbClient,
 ): Promise<boolean> {
-  const client = sql ?? getDb();
-  const metadata = await readOrgMetadata(client, organizationId);
-  return key in metadata;
+	const client = sql ?? getDb();
+	const metadata = await readOrgMetadata(client, organizationId);
+	return key in metadata;
 }
 
 /**
@@ -133,77 +139,130 @@ export async function hasOrgSentinel(
  * silently when the row is absent (caller decides whether to INSERT).
  */
 async function backfillDefaultAgent(
-  organizationId: string,
-  client: DbClient
+	organizationId: string,
+	client: DbClient,
 ): Promise<void> {
-  const rows = (await client`
-    SELECT owner_platform, owner_user_id, installed_providers
+	const rows = (await client`
+    SELECT owner_platform, owner_user_id, installed_providers, model, model_selection
       FROM agents
      WHERE organization_id = ${organizationId}
        AND id = ${DEFAULT_AGENT_ID}
      LIMIT 1
   `) as unknown as Array<{
-    owner_platform: string | null;
-    owner_user_id: string | null;
-    installed_providers: unknown;
-  }>;
-  const row = rows[0];
-  if (!row) return;
+		owner_platform: string | null;
+		owner_user_id: string | null;
+		installed_providers: unknown;
+		model: string | null;
+		model_selection: { mode?: string; pinnedModel?: string } | null;
+	}>;
+	const row = rows[0];
+	if (!row) return;
 
-  const orgMetadata = await readOrgMetadata(client, organizationId);
-  const ownerUserIdRaw = orgMetadata['personal_org_for_user_id'];
-  const ownerUserId =
-    typeof ownerUserIdRaw === 'string' && ownerUserIdRaw.length > 0
-      ? ownerUserIdRaw
-      : null;
+	const orgMetadata = await readOrgMetadata(client, organizationId);
+	const ownerUserIdRaw = orgMetadata["personal_org_for_user_id"];
+	const ownerUserId =
+		typeof ownerUserIdRaw === "string" && ownerUserIdRaw.length > 0
+			? ownerUserIdRaw
+			: null;
 
-  const installedNow = Array.isArray(row.installed_providers)
-    ? (row.installed_providers as Array<{ providerId: string }>)
-    : [];
-  const installedIds = new Set(installedNow.map((p) => p.providerId));
-  const missingSystemProviders = getModelProviderModules()
-    .filter((m) => m.hasSystemKey() && !installedIds.has(m.providerId))
-    .map((m) => ({ providerId: m.providerId, installedAt: Date.now() }));
+	const installedNow = Array.isArray(row.installed_providers)
+		? (row.installed_providers as Array<{ providerId: string }>)
+		: [];
+	const providersEmpty = installedNow.length === 0;
 
-  const needsOwnerFix =
-    ownerUserId &&
-    (row.owner_user_id !== ownerUserId || row.owner_platform !== 'external');
-  const needsProvidersFix =
-    installedNow.length === 0 && missingSystemProviders.length > 0;
+	const modelEmpty = !row.model || String(row.model).trim() === "";
+	const configuredModel = modelEmpty ? null : String(row.model).trim();
+	const selectionMode = row.model_selection?.mode;
+	const needsSelectionFix = !!configuredModel && selectionMode === "auto";
+	const needsOwnerFix =
+		ownerUserId &&
+		(row.owner_user_id !== ownerUserId || row.owner_platform !== "external");
+	const needsProvidersFix = providersEmpty;
+	const needsModelFix = modelEmpty;
 
-  if (needsOwnerFix || needsProvidersFix) {
-    const nextProviders = needsProvidersFix
-      ? missingSystemProviders
-      : installedNow;
-    await client`
+	if (
+		needsOwnerFix ||
+		needsProvidersFix ||
+		needsModelFix ||
+		needsSelectionFix
+	) {
+		const resolved =
+			needsModelFix || needsProvidersFix
+				? await resolveSystemKeyProvidersAndModel()
+				: null;
+		const existingProviders: InstalledProvider[] = installedNow.map((p) => ({
+			providerId: p.providerId,
+			installedAt: Date.now(),
+		}));
+		const newModel =
+			modelEmpty && resolved?.model ? resolved.model : configuredModel;
+
+		let nextProviders = existingProviders;
+		if (needsProvidersFix && resolved) {
+			nextProviders = resolved.providers;
+		} else if (resolved) {
+			const providerMap = new Map<string, InstalledProvider>();
+			for (const p of existingProviders) providerMap.set(p.providerId, p);
+			for (const p of resolved.providers) {
+				if (!providerMap.has(p.providerId)) providerMap.set(p.providerId, p);
+			}
+			if (newModel) {
+				const slash = newModel.indexOf("/");
+				const modelProviderId = slash > 0 ? newModel.slice(0, slash) : "";
+				if (modelProviderId && !providerMap.has(modelProviderId)) {
+					providerMap.set(modelProviderId, {
+						providerId: modelProviderId,
+						installedAt: Date.now(),
+					});
+				}
+			}
+			nextProviders = [...providerMap.values()];
+		}
+
+		const writeProviders =
+			needsProvidersFix || nextProviders.length !== existingProviders.length;
+		const writeModel = modelEmpty && !!newModel;
+		const writeSelection = (writeModel || needsSelectionFix) && !!newModel;
+
+		const pinnedSelection = newModel
+			? { mode: "pinned" as const, pinnedModel: newModel }
+			: null;
+		await client`
       UPDATE agents SET
-        owner_platform = ${needsOwnerFix ? 'external' : row.owner_platform},
+        owner_platform = ${needsOwnerFix ? "external" : row.owner_platform},
         owner_user_id = ${needsOwnerFix ? ownerUserId : row.owner_user_id},
-        installed_providers = ${client.json(nextProviders)},
+        installed_providers = CASE WHEN ${writeProviders}
+          THEN ${client.json(nextProviders)} ELSE installed_providers END,
+        model = CASE WHEN ${writeModel}
+          THEN ${newModel} ELSE model END,
+        model_selection = CASE WHEN ${writeSelection}
+          THEN ${client.json(pinnedSelection!)} ELSE model_selection END,
         updated_at = NOW()
       WHERE organization_id = ${organizationId}
         AND id = ${DEFAULT_AGENT_ID}
     `;
-    logger.info(
-      {
-        organizationId,
-        agentId: DEFAULT_AGENT_ID,
-        ownerFixed: !!needsOwnerFix,
-        providersAdded: needsProvidersFix
-          ? missingSystemProviders.map((p) => p.providerId)
-          : [],
-      },
-      '[default-provisioning] Backfilled default agent'
-    );
-  }
+		logger.info(
+			{
+				organizationId,
+				agentId: DEFAULT_AGENT_ID,
+				ownerFixed: !!needsOwnerFix,
+				providersAdded: writeProviders
+					? nextProviders.map((p) => p.providerId)
+					: [],
+				modelPinned: writeModel ? newModel : undefined,
+				selectionFixed: writeSelection,
+			},
+			"[default-provisioning] Backfilled default agent",
+		);
+	}
 
-  if (ownerUserId) {
-    await client`
+	if (ownerUserId) {
+		await client`
       INSERT INTO agent_users (organization_id, agent_id, platform, user_id, created_at)
       VALUES (${organizationId}, ${DEFAULT_AGENT_ID}, 'external', ${ownerUserId}, now())
       ON CONFLICT (organization_id, agent_id, platform, user_id) DO NOTHING
     `;
-  }
+	}
 }
 
 /**
@@ -223,116 +282,122 @@ async function backfillDefaultAgent(
  * not break the boot path that called us.
  */
 export async function ensureDefaultAgent(
-  organizationId: string,
-  sql?: DbClient
-): Promise<{ created: boolean; reason: 'sentinel' | 'has_agents' | 'inserted' }> {
-  const client = sql ?? getDb();
-  try {
-    // Always run the backfill — it's idempotent and only writes when there's
-    // a divergence to fix. Legacy installs that ran ensureDefaultAgent before
-    // this PR have the row but with `owner_user_id = NULL` and
-    // `installed_providers = []`; the sentinel-fast-path would have skipped
-    // them otherwise, and `lobu chat -c local` would still hit 403 / "No
-    // model configured" on those installs.
-    await backfillDefaultAgent(organizationId, client);
+	organizationId: string,
+	sql?: DbClient,
+): Promise<{
+	created: boolean;
+	reason: "sentinel" | "has_agents" | "inserted";
+}> {
+	const client = sql ?? getDb();
+	try {
+		// Always run the backfill — it's idempotent and only writes when there's
+		// a divergence to fix. Legacy installs that ran ensureDefaultAgent before
+		// this PR have the row but with `owner_user_id = NULL` and
+		// `installed_providers = []`; the sentinel-fast-path would have skipped
+		// them otherwise, and `lobu chat -c local` would still hit 403 / "No
+		// model configured" on those installs.
+		await backfillDefaultAgent(organizationId, client);
 
-    const provisioned = await hasOrgSentinel(organizationId, DEFAULT_AGENT_SENTINEL, client);
-    if (provisioned) {
-      return { created: false, reason: 'sentinel' };
-    }
+		const provisioned = await hasOrgSentinel(
+			organizationId,
+			DEFAULT_AGENT_SENTINEL,
+			client,
+		);
+		if (provisioned) {
+			return { created: false, reason: "sentinel" };
+		}
 
-    // Ignore the auto-provisioned builder/system agent ('lobu-builder', see
-    // builder-provisioning.ts BUILDER_AGENT_ID) — it's provisioned on the same
-    // org-creation paths, so counting it here would wrongly trip the
-    // "org already has agents" guard and skip the default personal agent.
-    const existingAgents = (await client`
+		// Ignore the auto-provisioned builder/system agent ('lobu-builder', see
+		// builder-provisioning.ts BUILDER_AGENT_ID) — it's provisioned on the same
+		// org-creation paths, so counting it here would wrongly trip the
+		// "org already has agents" guard and skip the default personal agent.
+		const existingAgents = (await client`
       SELECT 1 FROM agents
       WHERE organization_id = ${organizationId} AND id <> 'lobu-builder'
       LIMIT 1
     `) as unknown as Array<unknown>;
-    if (existingAgents.length > 0) {
-      // Still write the sentinel so we don't re-check on every boot.
-      await writeOrgSentinel(
-        client,
-        organizationId,
-        DEFAULT_AGENT_SENTINEL,
-        new Date().toISOString()
-      );
-      return { created: false, reason: 'has_agents' };
-    }
+		if (existingAgents.length > 0) {
+			// Still write the sentinel so we don't re-check on every boot.
+			await writeOrgSentinel(
+				client,
+				organizationId,
+				DEFAULT_AGENT_SENTINEL,
+				new Date().toISOString(),
+			);
+			return { created: false, reason: "has_agents" };
+		}
 
-    // Resolve the set of model providers that have a system-level credential
-    // available at this boot (env-var API keys, claude OAuth-discovery, etc.)
-    // and install them onto the default agent up front. Without this, the row
-    // exists but `installed_providers = '[]'` and `lobu chat -c local` would
-    // immediately hit "No model configured" — even though the env keys are
-    // sitting right there in the same process.
-    const systemProviders = getModelProviderModules()
-      .filter((m) => m.hasSystemKey())
-      .map((m) => ({
-        providerId: m.providerId,
-        installedAt: Date.now(),
-      }));
+		// Resolve the set of model providers that have a system-level credential
+		// available at this boot (env-var API keys, claude OAuth-discovery, etc.)
+		// and install them onto the default agent up front. Without this, the row
+		// exists but `installed_providers = '[]'` and `lobu chat -c local` would
+		// immediately hit "No model configured" — even though the env keys are
+		// sitting right there in the same process.
+		const resolved = await resolveSystemKeyProvidersAndModel();
 
-    // Resolve the owning user — the personal_org metadata is the canonical
-    // marker. The default agent is shown as user-owned (rather than the
-    // legacy `'lobu', NULL` org-level marker) so the per-user ownership
-    // check in `verifyOwnedAgentAccess` recognizes this user as the agent's
-    // owner: without it, a PAT session for the user can't open a session
-    // against their own org's default agent.
-    const orgMetadataForInsert = await readOrgMetadata(client, organizationId);
-    const ownerForInsertRaw = orgMetadataForInsert['personal_org_for_user_id'];
-    const ownerUserId =
-      typeof ownerForInsertRaw === 'string' && ownerForInsertRaw.length > 0
-        ? ownerForInsertRaw
-        : null;
+		// Resolve the owning user — the personal_org metadata is the canonical
+		// marker. The default agent is shown as user-owned (rather than the
+		// legacy `'lobu', NULL` org-level marker) so the per-user ownership
+		// check in `verifyOwnedAgentAccess` recognizes this user as the agent's
+		// owner: without it, a PAT session for the user can't open a session
+		// against their own org's default agent.
+		const orgMetadataForInsert = await readOrgMetadata(client, organizationId);
+		const ownerForInsertRaw = orgMetadataForInsert["personal_org_for_user_id"];
+		const ownerUserId =
+			typeof ownerForInsertRaw === "string" && ownerForInsertRaw.length > 0
+				? ownerForInsertRaw
+				: null;
 
-    // Insert the default agent. The PK is (organization_id, id) so we can
-    // ON CONFLICT DO NOTHING to guard against a parallel boot.
-    await client`
+		// Insert the default agent. The PK is (organization_id, id) so we can
+		// ON CONFLICT DO NOTHING to guard against a parallel boot.
+		const pinnedSelection = resolved.model
+			? { mode: "pinned" as const, pinnedModel: resolved.model }
+			: {};
+		await client`
       INSERT INTO agents (
         id, organization_id, name, identity_md,
         owner_platform, owner_user_id,
-        installed_providers,
+        installed_providers, model, model_selection,
         created_at, updated_at
       ) VALUES (
         ${DEFAULT_AGENT_ID}, ${organizationId}, ${DEFAULT_AGENT_NAME}, ${DEFAULT_AGENT_IDENTITY},
         'external', ${ownerUserId},
-        ${client.json(systemProviders)},
+        ${client.json(resolved.providers)}, ${resolved.model},
+        ${client.json(pinnedSelection)},
         NOW(), NOW()
       )
       ON CONFLICT (organization_id, id) DO NOTHING
     `;
 
-    // Mirror the ownership into agent_users so `userAgentsStore.ownsAgent`
-    // returns true on the PAT-session path used by `lobu chat -c local`.
-    if (ownerUserId) {
-      await client`
+		// Mirror the ownership into agent_users so `userAgentsStore.ownsAgent`
+		// returns true on the PAT-session path used by `lobu chat -c local`.
+		if (ownerUserId) {
+			await client`
         INSERT INTO agent_users (organization_id, agent_id, platform, user_id, created_at)
         VALUES (${organizationId}, ${DEFAULT_AGENT_ID}, 'external', ${ownerUserId}, now())
         ON CONFLICT (organization_id, agent_id, platform, user_id) DO NOTHING
       `;
-    }
+		}
 
-    await writeOrgSentinel(
-      client,
-      organizationId,
-      DEFAULT_AGENT_SENTINEL,
-      new Date().toISOString()
-    );
+		await writeOrgSentinel(
+			client,
+			organizationId,
+			DEFAULT_AGENT_SENTINEL,
+			new Date().toISOString(),
+		);
 
-    logger.info(
-      { organizationId, agentId: DEFAULT_AGENT_ID, ownerUserId },
-      '[default-provisioning] Provisioned default agent'
-    );
-    return { created: true, reason: 'inserted' };
-  } catch (err) {
-    logger.warn(
-      { organizationId, err: getErrorMessage(err) },
-      '[default-provisioning] Default-agent provisioning failed (non-fatal)'
-    );
-    return { created: false, reason: 'sentinel' };
-  }
+		logger.info(
+			{ organizationId, agentId: DEFAULT_AGENT_ID, ownerUserId },
+			"[default-provisioning] Provisioned default agent",
+		);
+		return { created: true, reason: "inserted" };
+	} catch (err) {
+		logger.warn(
+			{ organizationId, err: getErrorMessage(err) },
+			"[default-provisioning] Default-agent provisioning failed (non-fatal)",
+		);
+		return { created: false, reason: "sentinel" };
+	}
 }
 
 /**
@@ -351,113 +416,119 @@ export async function ensureDefaultAgent(
  * failure doesn't break the poll response.
  */
 export async function ensureDefaultWatcher(params: {
-  organizationId: string;
-  agentId: string;
-  deviceWorkerId: string;
-  sql?: DbClient;
-}): Promise<{ created: boolean; reason: 'sentinel' | 'slug_taken' | 'inserted' | 'no_agent' }> {
-  const sql = params.sql ?? getDb();
-  try {
-    const provisioned = await hasOrgSentinel(
-      params.organizationId,
-      DEFAULT_WATCHER_SENTINEL,
-      sql
-    );
-    if (provisioned) {
-      return { created: false, reason: 'sentinel' };
-    }
+	organizationId: string;
+	agentId: string;
+	deviceWorkerId: string;
+	sql?: DbClient;
+}): Promise<{
+	created: boolean;
+	reason: "sentinel" | "slug_taken" | "inserted" | "no_agent";
+}> {
+	const sql = params.sql ?? getDb();
+	try {
+		const provisioned = await hasOrgSentinel(
+			params.organizationId,
+			DEFAULT_WATCHER_SENTINEL,
+			sql,
+		);
+		if (provisioned) {
+			return { created: false, reason: "sentinel" };
+		}
 
-    // The agent we pin to must actually exist. If the user deleted the
-    // default agent before the device first polled, fall back to ANY agent
-    // in the org so the watcher still has a valid foreign key. If there's
-    // no agent at all (zombied org), set the sentinel and skip — there's
-    // nothing useful we can wire up.
-    const agentRows = (await sql`
+		// The agent we pin to must actually exist. If the user deleted the
+		// default agent before the device first polled, fall back to ANY agent
+		// in the org so the watcher still has a valid foreign key. If there's
+		// no agent at all (zombied org), set the sentinel and skip — there's
+		// nothing useful we can wire up.
+		const agentRows = (await sql`
       SELECT id FROM agents
       WHERE organization_id = ${params.organizationId}
         AND id = ${params.agentId}
       LIMIT 1
     `) as unknown as Array<{ id: string }>;
-    let resolvedAgentId = agentRows[0]?.id ?? null;
-    if (!resolvedAgentId) {
-      const fallback = (await sql`
+		let resolvedAgentId = agentRows[0]?.id ?? null;
+		if (!resolvedAgentId) {
+			const fallback = (await sql`
         SELECT id FROM agents
         WHERE organization_id = ${params.organizationId}
         ORDER BY created_at ASC
         LIMIT 1
       `) as unknown as Array<{ id: string }>;
-      resolvedAgentId = fallback[0]?.id ?? null;
-    }
-    if (!resolvedAgentId) {
-      await writeOrgSentinel(
-        sql,
-        params.organizationId,
-        DEFAULT_WATCHER_SENTINEL,
-        new Date().toISOString()
-      );
-      return { created: false, reason: 'no_agent' };
-    }
+			resolvedAgentId = fallback[0]?.id ?? null;
+		}
+		if (!resolvedAgentId) {
+			await writeOrgSentinel(
+				sql,
+				params.organizationId,
+				DEFAULT_WATCHER_SENTINEL,
+				new Date().toISOString(),
+			);
+			return { created: false, reason: "no_agent" };
+		}
 
-    // Slug-uniqueness guard (matches the implicit uniqueness handleCreate enforces).
-    const slugClash = (await sql`
+		// Slug-uniqueness guard (matches the implicit uniqueness handleCreate enforces).
+		const slugClash = (await sql`
       SELECT 1 FROM watchers
       WHERE organization_id = ${params.organizationId}
         AND slug = ${DEFAULT_WATCHER_SLUG}
       LIMIT 1
     `) as unknown as Array<unknown>;
-    if (slugClash.length > 0) {
-      await writeOrgSentinel(
-        sql,
-        params.organizationId,
-        DEFAULT_WATCHER_SENTINEL,
-        new Date().toISOString()
-      );
-      return { created: false, reason: 'slug_taken' };
-    }
+		if (slugClash.length > 0) {
+			await writeOrgSentinel(
+				sql,
+				params.organizationId,
+				DEFAULT_WATCHER_SENTINEL,
+				new Date().toISOString(),
+			);
+			return { created: false, reason: "slug_taken" };
+		}
 
-    // The `watchers.created_by` FK references `user(id)` ON DELETE RESTRICT.
-    // Pick the org owner (any member with role='owner', falling back to any
-    // member) so the row stays attributable. The `system` user fallback is
-    // for tests and local dev where the bootstrap path may not have run yet.
-    const createdByRows = (await sql`
+		// The `watchers.created_by` FK references `user(id)` ON DELETE RESTRICT.
+		// Pick the org owner (any member with role='owner', falling back to any
+		// member) so the row stays attributable. The `system` user fallback is
+		// for tests and local dev where the bootstrap path may not have run yet.
+		const createdByRows = (await sql`
       SELECT "userId" FROM "member"
       WHERE "organizationId" = ${params.organizationId}
       ORDER BY CASE WHEN role = 'owner' THEN 0 ELSE 1 END ASC, "createdAt" ASC
       LIMIT 1
     `) as unknown as Array<{ userId: string }>;
-    const ownerUserId = createdByRows[0]?.userId ?? null;
-    let createdBy: string | null = ownerUserId;
-    if (!createdBy) {
-      const systemRows = (await sql`
+		const ownerUserId = createdByRows[0]?.userId ?? null;
+		let createdBy: string | null = ownerUserId;
+		if (!createdBy) {
+			const systemRows = (await sql`
         SELECT id FROM "user" WHERE id = 'system' LIMIT 1
       `) as unknown as Array<{ id: string }>;
-      createdBy = systemRows[0]?.id ?? null;
-    }
-    if (!createdBy) {
-      logger.warn(
-        { organizationId: params.organizationId },
-        '[default-provisioning] No user available to attribute watcher creation — skipping'
-      );
-      await writeOrgSentinel(
-        sql,
-        params.organizationId,
-        DEFAULT_WATCHER_SENTINEL,
-        new Date().toISOString()
-      );
-      return { created: false, reason: 'no_agent' };
-    }
+			createdBy = systemRows[0]?.id ?? null;
+		}
+		if (!createdBy) {
+			logger.warn(
+				{ organizationId: params.organizationId },
+				"[default-provisioning] No user available to attribute watcher creation — skipping",
+			);
+			await writeOrgSentinel(
+				sql,
+				params.organizationId,
+				DEFAULT_WATCHER_SENTINEL,
+				new Date().toISOString(),
+			);
+			return { created: false, reason: "no_agent" };
+		}
 
-    const extractionSchema = DEFAULT_WATCHER_EXTRACTION_SCHEMA;
-    const sources = [
-      { name: 'content', query: 'SELECT * FROM events ORDER BY occurred_at DESC' },
-    ];
+		const extractionSchema = DEFAULT_WATCHER_EXTRACTION_SCHEMA;
+		const sources = [
+			{
+				name: "content",
+				query: "SELECT * FROM events ORDER BY occurred_at DESC",
+			},
+		];
 
-    await sql.begin(async (tx) => {
-      const watcherId = await getNextNumericId(tx, 'watchers');
-      const versionId = await getNextNumericId(tx, 'watcher_versions');
-      const scheduledNextRun = nextRunAt(DEFAULT_WATCHER_SCHEDULE);
+		await sql.begin(async (tx) => {
+			const watcherId = await getNextNumericId(tx, "watchers");
+			const versionId = await getNextNumericId(tx, "watcher_versions");
+			const scheduledNextRun = nextRunAt(DEFAULT_WATCHER_SCHEDULE);
 
-      await tx`
+			await tx`
         INSERT INTO watchers (
           id, name, slug, organization_id, entity_ids,
           schedule, next_run_at, agent_id, scheduler_client_id, model_config, sources, version,
@@ -467,11 +538,11 @@ export async function ensureDefaultWatcher(params: {
           notification_channel, notification_priority, min_cooldown_seconds
         ) VALUES (
           ${watcherId}, ${DEFAULT_WATCHER_NAME}, ${DEFAULT_WATCHER_SLUG},
-          ${params.organizationId}, ${'{}'}::bigint[],
+          ${params.organizationId}, ${"{}"}::bigint[],
           ${DEFAULT_WATCHER_SCHEDULE}, ${scheduledNextRun},
           ${resolvedAgentId}, NULL,
           ${tx.json({})}, ${tx.json(sources)},
-          1, NULL, ${'{}'}::text[],
+          1, NULL, ${"{}"}::text[],
           'active', ${createdBy}, NOW(), NOW(),
           ${watcherId},
           ${params.deviceWorkerId}::uuid, NULL,
@@ -479,7 +550,7 @@ export async function ensureDefaultWatcher(params: {
         )
       `;
 
-      await tx`
+			await tx`
         INSERT INTO watcher_versions (
           id, watcher_id, version, name, description,
           prompt, extraction_schema, version_sources,
@@ -495,39 +566,39 @@ export async function ensureDefaultWatcher(params: {
         )
       `;
 
-      await tx`
+			await tx`
         UPDATE watchers
         SET current_version_id = ${versionId}
         WHERE id = ${watcherId}
       `;
-    });
+		});
 
-    await writeOrgSentinel(
-      sql,
-      params.organizationId,
-      DEFAULT_WATCHER_SENTINEL,
-      new Date().toISOString()
-    );
+		await writeOrgSentinel(
+			sql,
+			params.organizationId,
+			DEFAULT_WATCHER_SENTINEL,
+			new Date().toISOString(),
+		);
 
-    logger.info(
-      {
-        organizationId: params.organizationId,
-        agentId: resolvedAgentId,
-        deviceWorkerId: params.deviceWorkerId,
-        slug: DEFAULT_WATCHER_SLUG,
-      },
-      '[default-provisioning] Provisioned default watcher pinned to device'
-    );
-    return { created: true, reason: 'inserted' };
-  } catch (err) {
-    logger.warn(
-      {
-        organizationId: params.organizationId,
-        deviceWorkerId: params.deviceWorkerId,
-        err: getErrorMessage(err),
-      },
-      '[default-provisioning] Default-watcher provisioning failed (non-fatal)'
-    );
-    return { created: false, reason: 'sentinel' };
-  }
+		logger.info(
+			{
+				organizationId: params.organizationId,
+				agentId: resolvedAgentId,
+				deviceWorkerId: params.deviceWorkerId,
+				slug: DEFAULT_WATCHER_SLUG,
+			},
+			"[default-provisioning] Provisioned default watcher pinned to device",
+		);
+		return { created: true, reason: "inserted" };
+	} catch (err) {
+		logger.warn(
+			{
+				organizationId: params.organizationId,
+				deviceWorkerId: params.deviceWorkerId,
+				err: getErrorMessage(err),
+			},
+			"[default-provisioning] Default-watcher provisioning failed (non-fatal)",
+		);
+		return { created: false, reason: "sentinel" };
+	}
 }

--- a/packages/server/src/auth/system-provider-resolution.ts
+++ b/packages/server/src/auth/system-provider-resolution.ts
@@ -1,0 +1,151 @@
+/**
+ * Resolve system-key model providers and a default pinned model for
+ * auto-provisioned agents (builder, owletto-default).
+ *
+ * Reads `config/providers.json` directly so provisioning is deterministic
+ * regardless of whether the gateway module registry is initialized.
+ */
+
+import type { ProviderConfigEntry } from "@lobu/core";
+import { getErrorMessage } from "@lobu/core";
+import { resolveEnv } from "../gateway/auth/mcp/string-substitution";
+import { collectProviderModelOptions } from "../gateway/auth/provider-model-options";
+import { getModelProviderModules } from "../gateway/modules/module-system";
+import {
+	ProviderRegistryService,
+	resolveProviderRegistryPath,
+} from "../gateway/services/provider-registry-service";
+import logger from "../utils/logger";
+
+export interface InstalledProvider {
+	providerId: string;
+	installedAt: number;
+}
+
+export interface ResolvedSystemProviders {
+	providers: InstalledProvider[];
+	model: string | null;
+}
+
+const MODEL_PROVIDER_PREFERENCE = [
+	"openai",
+	"gemini",
+	"groq",
+	"mistral",
+	"deepseek",
+	"cohere",
+	"xai",
+];
+
+const ZAI_PROVIDER_ID = "z-ai";
+const ZAI_SYSTEM_ENV_VARS = ["Z_AI_API_KEY", "ZAI_API_KEY"];
+export const ZAI_FALLBACK_MODEL = "z-ai/glm-5.2";
+
+const CLAUDE_PROVIDER_ID = "claude";
+const CLAUDE_SYSTEM_ENV_VARS = [
+	"ANTHROPIC_API_KEY",
+	"ANTHROPIC_AUTH_TOKEN",
+	"CLAUDE_CODE_OAUTH_TOKEN",
+];
+export const CLAUDE_FALLBACK_MODEL = "claude/claude-sonnet-4-6";
+
+function hasZaiSystemKey(): boolean {
+	return ZAI_SYSTEM_ENV_VARS.some((v) => !!resolveEnv(v));
+}
+
+function hasClaudeSystemKey(): boolean {
+	return CLAUDE_SYSTEM_ENV_VARS.some((v) => !!resolveEnv(v));
+}
+
+export async function resolveSystemKeyProvidersAndModel(): Promise<ResolvedSystemProviders> {
+	const now = Date.now();
+	const installed = new Map<string, InstalledProvider>();
+
+	let configs: Record<string, ProviderConfigEntry> = {};
+	try {
+		const registry = new ProviderRegistryService(resolveProviderRegistryPath());
+		configs = await registry.getProviderConfigs();
+	} catch (err) {
+		logger.warn(
+			{ err: getErrorMessage(err) },
+			"[system-provider-resolution] providers.json read failed; relying on module registry",
+		);
+	}
+	for (const [providerId, cfg] of Object.entries(configs)) {
+		if (cfg.envVarName && resolveEnv(cfg.envVarName)) {
+			installed.set(providerId, { providerId, installedAt: now });
+		}
+	}
+
+	if (hasZaiSystemKey()) {
+		installed.set(ZAI_PROVIDER_ID, {
+			providerId: ZAI_PROVIDER_ID,
+			installedAt: now,
+		});
+	}
+
+	if (hasClaudeSystemKey()) {
+		installed.set(CLAUDE_PROVIDER_ID, {
+			providerId: CLAUDE_PROVIDER_ID,
+			installedAt: now,
+		});
+	}
+
+	try {
+		for (const m of getModelProviderModules()) {
+			if (m.hasSystemKey() && !installed.has(m.providerId)) {
+				installed.set(m.providerId, {
+					providerId: m.providerId,
+					installedAt: now,
+				});
+			}
+		}
+	} catch {
+		// Registry not available — the providers.json + Claude floor already applies.
+	}
+
+	const pickModel = (providerId: string): string | null => {
+		const cfg = configs[providerId];
+		const dm = cfg?.defaultModel?.trim();
+		if (cfg?.envVarName && resolveEnv(cfg.envVarName) && dm) {
+			return `${providerId}/${dm}`;
+		}
+		return null;
+	};
+
+	// Prefer Claude (always a real API key) over ZAI and config-declared providers.
+	// ZAI is still installed when its key is present; it is only pinned when Claude
+	// is absent and no providers.json default resolves.
+	let model: string | null = hasClaudeSystemKey()
+		? CLAUDE_FALLBACK_MODEL
+		: hasZaiSystemKey()
+			? ZAI_FALLBACK_MODEL
+			: null;
+	for (const providerId of MODEL_PROVIDER_PREFERENCE) {
+		if (model) break;
+		model = pickModel(providerId);
+	}
+	if (!model) {
+		for (const providerId of Object.keys(configs)) {
+			model = pickModel(providerId);
+			if (model) break;
+		}
+	}
+	if (!model && installed.size > 0) {
+		try {
+			const optionsByProvider = await collectProviderModelOptions("", "");
+			for (const { providerId } of installed.values()) {
+				const first = optionsByProvider[providerId]?.[0]?.value?.trim();
+				if (first) {
+					model = first.startsWith(`${providerId}/`)
+						? first
+						: `${providerId}/${first}`;
+					break;
+				}
+			}
+		} catch {
+			// Registry/model fetch unavailable — model may stay null.
+		}
+	}
+	return { providers: [...installed.values()], model };
+}

--- a/packages/server/src/lobu/client-routes.ts
+++ b/packages/server/src/lobu/client-routes.ts
@@ -1,37 +1,41 @@
-import { Hono } from 'hono';
-import { mcpAuth } from '../auth/middleware';
-import { OAuthClientsStore } from '../auth/oauth/clients';
-import { getDb, pgTextArray } from '../db/client';
-import type { Env } from '../index';
-import { revokeInMemoryMcpSessionsForClient } from '../mcp-handler';
-import { orgContext } from './stores/org-context';
+import { Hono } from "hono";
+import { mcpAuth } from "../auth/middleware";
+import { OAuthClientsStore } from "../auth/oauth/clients";
+import { getDb, pgTextArray } from "../db/client";
+import type { Env } from "../index";
+import { revokeInMemoryMcpSessionsForClient } from "../mcp-handler";
+import {
+	isManagedChatPlatform,
+	MANAGED_PLATFORM_INSTALL,
+} from "../preview/managed-platforms";
+import { orgContext } from "./stores/org-context";
 
 const routes = new Hono<{ Bindings: Env }>();
 const platformSchemaRoutes = new Hono<{ Bindings: Env }>();
 
 type MessagingClientRecord = {
-  id: string;
-  kind: 'messaging';
-  title: string;
-  identifier: string | null;
-  platform: string;
-  assignedAgentId: string;
-  assignedAgentName: string;
-  status: string;
-  authState: string;
-  lastSeenAt: number;
-  userAgent: null;
-  capabilities: null;
-  externalUrl: string | null;
-  linkedUserName: null;
-  linkedUserEmail: null;
-  /** True for Lobu's own surfaces (CLI, Mac/iOS bridges) — never for messaging clients. */
-  firstParty: false;
-  details: {
-    connectionId: string | null;
-    description: string | null;
-    connectionMetadata: Record<string, unknown> | null;
-  };
+	id: string;
+	kind: "messaging";
+	title: string;
+	identifier: string | null;
+	platform: string;
+	assignedAgentId: string;
+	assignedAgentName: string;
+	status: string;
+	authState: string;
+	lastSeenAt: number;
+	userAgent: null;
+	capabilities: null;
+	externalUrl: string | null;
+	linkedUserName: null;
+	linkedUserEmail: null;
+	/** True for Lobu's own surfaces (CLI, Mac/iOS bridges) — never for messaging clients. */
+	firstParty: false;
+	details: {
+		connectionId: string | null;
+		description: string | null;
+		connectionMetadata: Record<string, unknown> | null;
+	};
 };
 
 /**
@@ -39,11 +43,11 @@ type MessagingClientRecord = {
  * signal for first-party clients. (Keep in sync with the CLI / bridge clients.)
  */
 const LOBU_FIRST_PARTY_SOFTWARE_IDS = new Set([
-  'lobu-cli',
-  'lobu',
-  'lobu-mac-bridge',
-  'lobu-ios-bridge',
-  'lobu-bridge',
+	"lobu-cli",
+	"lobu",
+	"lobu-mac-bridge",
+	"lobu-ios-bridge",
+	"lobu-bridge",
 ]);
 
 /**
@@ -54,276 +58,321 @@ const LOBU_FIRST_PARTY_SOFTWARE_IDS = new Set([
  * register without a known software id (and could in theory be spoofed — this
  * is a display category, not an access boundary).
  */
-function isFirstPartyLobuClient(name: string | null, softwareId: string | null): boolean {
-  const s = (softwareId ?? '').trim().toLowerCase();
-  if (s && LOBU_FIRST_PARTY_SOFTWARE_IDS.has(s)) return true;
-  const n = (name ?? '').trim().toLowerCase();
-  return n === 'lobu' || n.startsWith('lobu ') || n.startsWith('lobu-');
+function isFirstPartyLobuClient(
+	name: string | null,
+	softwareId: string | null,
+): boolean {
+	const s = (softwareId ?? "").trim().toLowerCase();
+	if (s && LOBU_FIRST_PARTY_SOFTWARE_IDS.has(s)) return true;
+	const n = (name ?? "").trim().toLowerCase();
+	return n === "lobu" || n.startsWith("lobu ") || n.startsWith("lobu-");
 }
 
 const PLATFORM_SCHEMAS: Record<
-  string,
-  { name: string; icon: string; schema: Record<string, any> }
+	string,
+	{ name: string; icon: string; schema: Record<string, any> }
 > = {
-  telegram: {
-    name: 'Telegram',
-    icon: 'telegram',
-    schema: {
-      type: 'object',
-      properties: {
-        botToken: {
-          type: 'string',
-          title: 'Bot Token',
-          description:
-            'Telegram bot token from BotFather. Falls back to TELEGRAM_BOT_TOKEN env var.',
-        },
-        mode: {
-          type: 'string',
-          title: 'Mode',
-          enum: ['auto', 'webhook', 'polling'],
-          description: 'Runtime mode: auto (default), webhook, or polling.',
-        },
-        secretToken: {
-          type: 'string',
-          title: 'Secret Token',
-          description: 'Webhook secret token for verification.',
-        },
-        userName: { type: 'string', title: 'Bot Username', description: 'Override bot username.' },
-      },
-    },
-  },
-  slack: {
-    name: 'Slack',
-    icon: 'slack',
-    schema: {
-      type: 'object',
-      properties: {
-        botToken: {
-          type: 'string',
-          title: 'Bot Token',
-          description: 'Bot token (xoxb-...). Required for single-workspace mode.',
-        },
-        signingSecret: {
-          type: 'string',
-          title: 'Signing Secret',
-          description: 'Signing secret for webhook verification.',
-        },
-        clientId: {
-          type: 'string',
-          title: 'Client ID',
-          description: 'Slack app client ID (required for OAuth / multi-workspace).',
-        },
-        clientSecret: {
-          type: 'string',
-          title: 'Client Secret',
-          description: 'Slack app client secret.',
-        },
-        userName: { type: 'string', title: 'Bot Username', description: 'Override bot username.' },
-      },
-    },
-  },
-  discord: {
-    name: 'Discord',
-    icon: 'discord',
-    schema: {
-      type: 'object',
-      properties: {
-        botToken: { type: 'string', title: 'Bot Token', description: 'Discord bot token.' },
-        applicationId: {
-          type: 'string',
-          title: 'Application ID',
-          description: 'Discord application ID.',
-        },
-        publicKey: {
-          type: 'string',
-          title: 'Public Key',
-          description: 'Application public key for webhook signature verification.',
-        },
-        userName: { type: 'string', title: 'Bot Username', description: 'Override bot username.' },
-      },
-    },
-  },
-  whatsapp: {
-    name: 'WhatsApp',
-    icon: 'whatsapp',
-    schema: {
-      type: 'object',
-      properties: {
-        accessToken: {
-          type: 'string',
-          title: 'Access Token',
-          description: 'System User access token for WhatsApp Cloud API.',
-        },
-        phoneNumberId: {
-          type: 'string',
-          title: 'Phone Number ID',
-          description: 'WhatsApp Business phone number ID.',
-        },
-        appSecret: {
-          type: 'string',
-          title: 'App Secret',
-          description: 'Meta App Secret for webhook HMAC-SHA256 signature verification.',
-        },
-        verifyToken: {
-          type: 'string',
-          title: 'Verify Token',
-          description: 'Verify token for webhook challenge-response.',
-        },
-        userName: { type: 'string', title: 'Bot Name', description: 'Bot display name.' },
-      },
-    },
-  },
-  teams: {
-    name: 'Microsoft Teams',
-    icon: 'teams',
-    schema: {
-      type: 'object',
-      properties: {
-        appId: { type: 'string', title: 'App ID', description: 'Microsoft App ID.' },
-        appPassword: {
-          type: 'string',
-          title: 'App Password',
-          description: 'Microsoft App Password.',
-        },
-        appTenantId: {
-          type: 'string',
-          title: 'Tenant ID',
-          description: 'Microsoft App Tenant ID.',
-        },
-        appType: {
-          type: 'string',
-          title: 'App Type',
-          enum: ['MultiTenant', 'SingleTenant'],
-          description: 'Microsoft App Type.',
-        },
-        userName: { type: 'string', title: 'Bot Username', description: 'Override bot username.' },
-      },
-    },
-  },
-  gchat: {
-    name: 'Google Chat',
-    icon: 'gchat',
-    schema: {
-      type: 'object',
-      properties: {
-        credentials: {
-          type: 'string',
-          title: 'Service Account JSON',
-          description: 'Service account credentials JSON string.',
-        },
-        useApplicationDefaultCredentials: {
-          type: 'boolean',
-          title: 'Use ADC',
-          description: 'Use Application Default Credentials instead of service account JSON.',
-        },
-        endpointUrl: {
-          type: 'string',
-          title: 'Endpoint URL',
-          description: 'HTTP endpoint URL for button click actions.',
-        },
-        googleChatProjectNumber: {
-          type: 'string',
-          title: 'Project Number',
-          description: 'Google Cloud project number for verifying webhook JWTs.',
-        },
-        userName: { type: 'string', title: 'Bot Username', description: 'Override bot username.' },
-      },
-    },
-  },
-  webhook: {
-    name: 'Webhook (inbound)',
-    icon: 'webhook',
-    schema: {
-      type: 'object',
-      properties: {
-        token: {
-          type: 'string',
-          title: 'Token',
-          description:
-            'Bearer token for inbound deliveries. Auto-generated when left empty.',
-        },
-        allowQueryAuth: {
-          type: 'boolean',
-          title: 'Allow ?token= auth',
-          description:
-            'Accept the token as a query parameter for senders that cannot set headers (e.g. Sentry legacy WebHooks plugin).',
-        },
-        dedupeHeader: {
-          type: 'string',
-          title: 'Dedupe Header',
-          description:
-            'Header carrying the delivery id (e.g. x-github-delivery). Defaults to a hash of the body.',
-        },
-        semanticType: {
-          type: 'string',
-          title: 'Semantic Type',
-          description: 'semantic_type stamped on ingested events. Default: content.',
-        },
-        titlePath: {
-          type: 'string',
-          title: 'Title Path',
-          description: 'JSON pointer extracted as the event title, e.g. /event/title.',
-        },
-        searchable: {
-          type: 'boolean',
-          title: 'Searchable (semantic memory)',
-          description:
-            'Index ingested payloads into semantic memory so agents can recall them. Default off — watcher SQL only.',
-        },
-      },
-    },
-  },
+	telegram: {
+		name: "Telegram",
+		icon: "telegram",
+		schema: {
+			type: "object",
+			properties: {
+				botToken: {
+					type: "string",
+					title: "Bot Token",
+					description:
+						"Telegram bot token from BotFather. Falls back to TELEGRAM_BOT_TOKEN env var.",
+				},
+				mode: {
+					type: "string",
+					title: "Mode",
+					enum: ["auto", "webhook", "polling"],
+					description: "Runtime mode: auto (default), webhook, or polling.",
+				},
+				secretToken: {
+					type: "string",
+					title: "Secret Token",
+					description: "Webhook secret token for verification.",
+				},
+				userName: {
+					type: "string",
+					title: "Bot Username",
+					description: "Override bot username.",
+				},
+			},
+		},
+	},
+	slack: {
+		name: "Slack",
+		icon: "slack",
+		schema: {
+			type: "object",
+			properties: {
+				botToken: {
+					type: "string",
+					title: "Bot Token",
+					description:
+						"Bot token (xoxb-...). Required for single-workspace mode.",
+				},
+				signingSecret: {
+					type: "string",
+					title: "Signing Secret",
+					description: "Signing secret for webhook verification.",
+				},
+				clientId: {
+					type: "string",
+					title: "Client ID",
+					description:
+						"Slack app client ID (required for OAuth / multi-workspace).",
+				},
+				clientSecret: {
+					type: "string",
+					title: "Client Secret",
+					description: "Slack app client secret.",
+				},
+				userName: {
+					type: "string",
+					title: "Bot Username",
+					description: "Override bot username.",
+				},
+			},
+		},
+	},
+	discord: {
+		name: "Discord",
+		icon: "discord",
+		schema: {
+			type: "object",
+			properties: {
+				botToken: {
+					type: "string",
+					title: "Bot Token",
+					description: "Discord bot token.",
+				},
+				applicationId: {
+					type: "string",
+					title: "Application ID",
+					description: "Discord application ID.",
+				},
+				publicKey: {
+					type: "string",
+					title: "Public Key",
+					description:
+						"Application public key for webhook signature verification.",
+				},
+				userName: {
+					type: "string",
+					title: "Bot Username",
+					description: "Override bot username.",
+				},
+			},
+		},
+	},
+	whatsapp: {
+		name: "WhatsApp",
+		icon: "whatsapp",
+		schema: {
+			type: "object",
+			properties: {
+				accessToken: {
+					type: "string",
+					title: "Access Token",
+					description: "System User access token for WhatsApp Cloud API.",
+				},
+				phoneNumberId: {
+					type: "string",
+					title: "Phone Number ID",
+					description: "WhatsApp Business phone number ID.",
+				},
+				appSecret: {
+					type: "string",
+					title: "App Secret",
+					description:
+						"Meta App Secret for webhook HMAC-SHA256 signature verification.",
+				},
+				verifyToken: {
+					type: "string",
+					title: "Verify Token",
+					description: "Verify token for webhook challenge-response.",
+				},
+				userName: {
+					type: "string",
+					title: "Bot Name",
+					description: "Bot display name.",
+				},
+			},
+		},
+	},
+	teams: {
+		name: "Microsoft Teams",
+		icon: "teams",
+		schema: {
+			type: "object",
+			properties: {
+				appId: {
+					type: "string",
+					title: "App ID",
+					description: "Microsoft App ID.",
+				},
+				appPassword: {
+					type: "string",
+					title: "App Password",
+					description: "Microsoft App Password.",
+				},
+				appTenantId: {
+					type: "string",
+					title: "Tenant ID",
+					description: "Microsoft App Tenant ID.",
+				},
+				appType: {
+					type: "string",
+					title: "App Type",
+					enum: ["MultiTenant", "SingleTenant"],
+					description: "Microsoft App Type.",
+				},
+				userName: {
+					type: "string",
+					title: "Bot Username",
+					description: "Override bot username.",
+				},
+			},
+		},
+	},
+	gchat: {
+		name: "Google Chat",
+		icon: "gchat",
+		schema: {
+			type: "object",
+			properties: {
+				credentials: {
+					type: "string",
+					title: "Service Account JSON",
+					description: "Service account credentials JSON string.",
+				},
+				useApplicationDefaultCredentials: {
+					type: "boolean",
+					title: "Use ADC",
+					description:
+						"Use Application Default Credentials instead of service account JSON.",
+				},
+				endpointUrl: {
+					type: "string",
+					title: "Endpoint URL",
+					description: "HTTP endpoint URL for button click actions.",
+				},
+				googleChatProjectNumber: {
+					type: "string",
+					title: "Project Number",
+					description:
+						"Google Cloud project number for verifying webhook JWTs.",
+				},
+				userName: {
+					type: "string",
+					title: "Bot Username",
+					description: "Override bot username.",
+				},
+			},
+		},
+	},
+	webhook: {
+		name: "Webhook (inbound)",
+		icon: "webhook",
+		schema: {
+			type: "object",
+			properties: {
+				token: {
+					type: "string",
+					title: "Token",
+					description:
+						"Bearer token for inbound deliveries. Auto-generated when left empty.",
+				},
+				allowQueryAuth: {
+					type: "boolean",
+					title: "Allow ?token= auth",
+					description:
+						"Accept the token as a query parameter for senders that cannot set headers (e.g. Sentry legacy WebHooks plugin).",
+				},
+				dedupeHeader: {
+					type: "string",
+					title: "Dedupe Header",
+					description:
+						"Header carrying the delivery id (e.g. x-github-delivery). Defaults to a hash of the body.",
+				},
+				semanticType: {
+					type: "string",
+					title: "Semantic Type",
+					description:
+						"semantic_type stamped on ingested events. Default: content.",
+				},
+				titlePath: {
+					type: "string",
+					title: "Title Path",
+					description:
+						"JSON pointer extracted as the event title, e.g. /event/title.",
+				},
+				searchable: {
+					type: "boolean",
+					title: "Searchable (semantic memory)",
+					description:
+						"Index ingested payloads into semantic memory so agents can recall them. Default off — watcher SQL only.",
+				},
+			},
+		},
+	},
 };
 
 function withOrg(c: any, fn: () => Promise<Response>): Promise<Response> {
-  const organizationId = c.get('organizationId');
-  if (!organizationId) {
-    return Promise.resolve(c.json({ error: 'Organization required' }, 401));
-  }
-  return orgContext.run({ organizationId }, fn);
+	const organizationId = c.get("organizationId");
+	if (!organizationId) {
+		return Promise.resolve(c.json({ error: "Organization required" }, 401));
+	}
+	return orgContext.run({ organizationId }, fn);
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
 }
 
 function asTimestamp(value: unknown): number | null {
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (typeof value === 'string') {
-    const parsed = Date.parse(value);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-  if (value instanceof Date) return value.getTime();
-  return null;
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string") {
+		const parsed = Date.parse(value);
+		return Number.isFinite(parsed) ? parsed : null;
+	}
+	if (value instanceof Date) return value.getTime();
+	return null;
 }
 
 function asNonEmptyString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: null;
 }
 
 function externalUrlForMessagingIdentity(
-  platform: string,
-  identifier?: string | null
+	platform: string,
+	identifier?: string | null,
 ): string | null {
-  if (!identifier) return null;
+	if (!identifier) return null;
 
-  if (platform === 'telegram') {
-    const normalized = identifier.replace(/^@/, '').trim();
-    if (/^[a-zA-Z][a-zA-Z0-9_]{3,}$/.test(normalized)) {
-      return `https://t.me/${normalized}`;
-    }
-  }
+	if (platform === "telegram") {
+		const normalized = identifier.replace(/^@/, "").trim();
+		if (/^[a-zA-Z][a-zA-Z0-9_]{3,}$/.test(normalized)) {
+			return `https://t.me/${normalized}`;
+		}
+	}
 
-  if (platform === 'whatsapp') {
-    const digits = identifier.replace(/[^\d]/g, '');
-    if (digits) {
-      return `https://wa.me/${digits}`;
-    }
-  }
+	if (platform === "whatsapp") {
+		const digits = identifier.replace(/[^\d]/g, "");
+		if (digits) {
+			return `https://wa.me/${digits}`;
+		}
+	}
 
-  return null;
+	return null;
 }
 
 /**
@@ -332,11 +381,11 @@ function externalUrlForMessagingIdentity(
  * messaging client visible to admins.
  */
 async function listMessagingClients(options: {
-  organizationId: string;
-  agentId?: string | null;
+	organizationId: string;
+	agentId?: string | null;
 }): Promise<MessagingClientRecord[]> {
-  const sql = getDb();
-  const rows = (await sql`
+	const sql = getDb();
+	const rows = (await sql`
     SELECT
       au.agent_id,
       au.platform,
@@ -350,158 +399,175 @@ async function listMessagingClients(options: {
       ${options.agentId ? sql`AND au.agent_id = ${options.agentId}` : sql``}
     ORDER BY au.created_at DESC
   `) as Array<{
-    agent_id: string;
-    platform: string;
-    user_id: string;
-    created_at: unknown;
-    agent_name: string;
-  }>;
+		agent_id: string;
+		platform: string;
+		user_id: string;
+		created_at: unknown;
+		agent_name: string;
+	}>;
 
-  return rows.map((row) => {
-    const lastSeenAt = asTimestamp(row.created_at) ?? Date.now();
-    const platform = row.platform || 'messaging';
-    return {
-      id: `${row.agent_id}:${row.platform}:${row.user_id}`,
-      kind: 'messaging' as const,
-      title: row.user_id || `${platform} user`,
-      identifier: row.user_id,
-      platform,
-      assignedAgentId: row.agent_id,
-      assignedAgentName: row.agent_name,
-      status: 'linked',
-      authState: 'linked',
-      lastSeenAt,
-      userAgent: null,
-      capabilities: null,
-      externalUrl: externalUrlForMessagingIdentity(platform, row.user_id),
-      linkedUserName: null,
-      linkedUserEmail: null,
-      firstParty: false as const,
-      details: {
-        connectionId: null,
-        description: null,
-        connectionMetadata: null,
-      },
-    };
-  });
+	return rows.map((row) => {
+		const lastSeenAt = asTimestamp(row.created_at) ?? Date.now();
+		const platform = row.platform || "messaging";
+		return {
+			id: `${row.agent_id}:${row.platform}:${row.user_id}`,
+			kind: "messaging" as const,
+			title: row.user_id || `${platform} user`,
+			identifier: row.user_id,
+			platform,
+			assignedAgentId: row.agent_id,
+			assignedAgentName: row.agent_name,
+			status: "linked",
+			authState: "linked",
+			lastSeenAt,
+			userAgent: null,
+			capabilities: null,
+			externalUrl: externalUrlForMessagingIdentity(platform, row.user_id),
+			linkedUserName: null,
+			linkedUserEmail: null,
+			firstParty: false as const,
+			details: {
+				connectionId: null,
+				description: null,
+				connectionMetadata: null,
+			},
+		};
+	});
 }
 
 export async function countRuntimeMessagingClientsByAgent(
-  organizationId: string
+	organizationId: string,
 ): Promise<Map<string, Set<string>>> {
-  const clients = await listMessagingClients({ organizationId });
-  const counts = new Map<string, Set<string>>();
+	const clients = await listMessagingClients({ organizationId });
+	const counts = new Map<string, Set<string>>();
 
-  for (const client of clients) {
-    let ids = counts.get(client.assignedAgentId);
-    if (!ids) {
-      ids = new Set<string>();
-      counts.set(client.assignedAgentId, ids);
-    }
-    ids.add(client.id);
-  }
+	for (const client of clients) {
+		let ids = counts.get(client.assignedAgentId);
+		if (!ids) {
+			ids = new Set<string>();
+			counts.set(client.assignedAgentId, ids);
+		}
+		ids.add(client.id);
+	}
 
-  return counts;
+	return counts;
 }
 
-routes.get('/', mcpAuth, async (c) => {
-  return withOrg(c, async () => {
-    const organizationId = c.get('organizationId') as string;
-    const agentId = c.req.query('agentId')?.trim() || null;
-    const sql = getDb();
-    const oauthClientsStore = new OAuthClientsStore(sql);
-    const oauthClients = await oauthClientsStore.listClientsByOrganization(organizationId);
+routes.get("/", mcpAuth, async (c) => {
+	return withOrg(c, async () => {
+		const organizationId = c.get("organizationId") as string;
+		const agentId = c.req.query("agentId")?.trim() || null;
+		const sql = getDb();
+		const oauthClientsStore = new OAuthClientsStore(sql);
+		const oauthClients =
+			await oauthClientsStore.listClientsByOrganization(organizationId);
 
-    const referencedAgentIds = new Set<string>();
-    for (const client of oauthClients) {
-      const metadata = asRecord(client.metadata);
-      const lastAgentId =
-        typeof metadata?.last_agent_id === 'string' ? metadata.last_agent_id : null;
-      if (lastAgentId) referencedAgentIds.add(lastAgentId);
-    }
+		const referencedAgentIds = new Set<string>();
+		for (const client of oauthClients) {
+			const metadata = asRecord(client.metadata);
+			const lastAgentId =
+				typeof metadata?.last_agent_id === "string"
+					? metadata.last_agent_id
+					: null;
+			if (lastAgentId) referencedAgentIds.add(lastAgentId);
+		}
 
-    const agentNames = new Map<string, string>();
-    if (referencedAgentIds.size > 0) {
-      const rows = await sql`
+		const agentNames = new Map<string, string>();
+		if (referencedAgentIds.size > 0) {
+			const rows = await sql`
         SELECT id, name
         FROM agents
         WHERE organization_id = ${organizationId}
           AND id = ANY(${pgTextArray([...referencedAgentIds])}::text[])
       `;
-      for (const row of rows as Array<{ id: string; name: string }>) {
-        agentNames.set(row.id, row.name);
-      }
-    }
+			for (const row of rows as Array<{ id: string; name: string }>) {
+				agentNames.set(row.id, row.name);
+			}
+		}
 
-    const mcpClients = oauthClients
-      .map((client) => {
-        const metadata = asRecord(client.metadata);
-        const clientInfo = asRecord(metadata?.last_client_info);
-        const capabilities = asRecord(metadata?.last_capabilities);
-        const lastSeenAt = asTimestamp(metadata?.last_seen_at) ?? client.client_id_issued_at * 1000;
-        const assignedAgentId =
-          typeof metadata?.last_agent_id === 'string' ? metadata.last_agent_id : null;
+		const mcpClients = oauthClients
+			.map((client) => {
+				const metadata = asRecord(client.metadata);
+				const clientInfo = asRecord(metadata?.last_client_info);
+				const capabilities = asRecord(metadata?.last_capabilities);
+				const lastSeenAt =
+					asTimestamp(metadata?.last_seen_at) ??
+					client.client_id_issued_at * 1000;
+				const assignedAgentId =
+					typeof metadata?.last_agent_id === "string"
+						? metadata.last_agent_id
+						: null;
 
-        if (agentId && assignedAgentId !== agentId) return null;
+				if (agentId && assignedAgentId !== agentId) return null;
 
-        const title = asNonEmptyString(clientInfo?.name) || asNonEmptyString(client.client_name);
-        const softwareId = asNonEmptyString(client.software_id);
+				const title =
+					asNonEmptyString(clientInfo?.name) ||
+					asNonEmptyString(client.client_name);
+				const softwareId = asNonEmptyString(client.software_id);
 
-        return {
-          id: client.client_id,
-          kind: 'mcp' as const,
-          title,
-          identifier: client.client_id,
-          platform: softwareId,
-          assignedAgentId,
-          assignedAgentName: assignedAgentId
-            ? (agentNames.get(assignedAgentId) ?? assignedAgentId)
-            : null,
-          status: client.active_token_count > 0 ? 'connected' : 'disconnected',
-          authState: client.active_token_count > 0 ? 'authorized' : 'revoked',
-          lastSeenAt,
-          userAgent:
-            typeof metadata?.last_user_agent === 'string' ? metadata.last_user_agent : null,
-          capabilities,
-          externalUrl:
-            typeof client.client_uri === 'string' && client.client_uri.length > 0
-              ? client.client_uri
-              : null,
-          linkedUserName: client.user_name ?? null,
-          linkedUserEmail: client.user_email ?? null,
-          firstParty: isFirstPartyLobuClient(title, softwareId),
-          details: {
-            softwareVersion: client.software_version ?? null,
-            redirectUris: client.redirect_uris,
-            activeTokenCount: client.active_token_count,
-            clientInfo,
-          },
-        };
-      })
-      .filter((client): client is NonNullable<typeof client> => client !== null);
+				return {
+					id: client.client_id,
+					kind: "mcp" as const,
+					title,
+					identifier: client.client_id,
+					platform: softwareId,
+					assignedAgentId,
+					assignedAgentName: assignedAgentId
+						? (agentNames.get(assignedAgentId) ?? assignedAgentId)
+						: null,
+					status: client.active_token_count > 0 ? "connected" : "disconnected",
+					authState: client.active_token_count > 0 ? "authorized" : "revoked",
+					lastSeenAt,
+					userAgent:
+						typeof metadata?.last_user_agent === "string"
+							? metadata.last_user_agent
+							: null,
+					capabilities,
+					externalUrl:
+						typeof client.client_uri === "string" &&
+						client.client_uri.length > 0
+							? client.client_uri
+							: null,
+					linkedUserName: client.user_name ?? null,
+					linkedUserEmail: client.user_email ?? null,
+					firstParty: isFirstPartyLobuClient(title, softwareId),
+					details: {
+						softwareVersion: client.software_version ?? null,
+						redirectUris: client.redirect_uris,
+						activeTokenCount: client.active_token_count,
+						clientInfo,
+					},
+				};
+			})
+			.filter(
+				(client): client is NonNullable<typeof client> => client !== null,
+			);
 
-    const messagingClients = await listMessagingClients({ organizationId, agentId });
+		const messagingClients = await listMessagingClients({
+			organizationId,
+			agentId,
+		});
 
-    const clients = [...mcpClients, ...messagingClients].sort((a, b) => {
-      const aSeen = a.lastSeenAt ?? 0;
-      const bSeen = b.lastSeenAt ?? 0;
-      return bSeen - aSeen;
-    });
+		const clients = [...mcpClients, ...messagingClients].sort((a, b) => {
+			const aSeen = a.lastSeenAt ?? 0;
+			const bSeen = b.lastSeenAt ?? 0;
+			return bSeen - aSeen;
+		});
 
-    return c.json({ clients });
-  });
+		return c.json({ clients });
+	});
 });
 
-routes.delete('/mcp/:clientId', mcpAuth, async (c) => {
-  return withOrg(c, async () => {
-    const organizationId = c.get('organizationId') as string;
-    const clientId = c.req.param('clientId');
-    if (!clientId) {
-      return c.json({ error: 'Client ID is required' }, 400);
-    }
-    const sql = getDb();
+routes.delete("/mcp/:clientId", mcpAuth, async (c) => {
+	return withOrg(c, async () => {
+		const organizationId = c.get("organizationId") as string;
+		const clientId = c.req.param("clientId");
+		if (!clientId) {
+			return c.json({ error: "Client ID is required" }, 400);
+		}
+		const sql = getDb();
 
-    const rows = await sql`
+		const rows = await sql`
       SELECT oc.id
       FROM oauth_clients oc
       WHERE oc.id = ${clientId}
@@ -517,26 +583,60 @@ routes.delete('/mcp/:clientId', mcpAuth, async (c) => {
       LIMIT 1
     `;
 
-    if (rows.length === 0) {
-      return c.json({ error: 'Client not found' }, 404);
-    }
+		if (rows.length === 0) {
+			return c.json({ error: "Client not found" }, 404);
+		}
 
-    const clientsStore = new OAuthClientsStore(sql);
-    await clientsStore.revokeClientForOrganization(clientId, organizationId);
-    await revokeInMemoryMcpSessionsForClient(clientId, organizationId);
-    return c.json({ success: true });
-  });
+		const clientsStore = new OAuthClientsStore(sql);
+		await clientsStore.revokeClientForOrganization(clientId, organizationId);
+		await revokeInMemoryMcpSessionsForClient(clientId, organizationId);
+		return c.json({ success: true });
+	});
 });
 
-platformSchemaRoutes.get('/', (c) => {
-  return c.json({ platforms: PLATFORM_SCHEMAS });
+type PlatformSchemaResponse = {
+	name: string;
+	icon: string;
+	schema: Record<string, any>;
+	managed?: boolean;
+	managedInstallPath?: string;
+	managedInstallLabel?: string;
+};
+
+function withManagedMetadata(
+	platform: string,
+	entry: PlatformSchemaResponse,
+): PlatformSchemaResponse {
+	if (!isManagedChatPlatform(platform)) return entry;
+	const install =
+		MANAGED_PLATFORM_INSTALL[platform as keyof typeof MANAGED_PLATFORM_INSTALL];
+	return {
+		...entry,
+		managed: true,
+		...(install
+			? {
+					managedInstallPath: install.path,
+					managedInstallLabel: install.label,
+				}
+			: {}),
+	};
+}
+
+platformSchemaRoutes.get("/", (c) => {
+	const platforms = Object.fromEntries(
+		Object.entries(PLATFORM_SCHEMAS).map(([key, value]) => [
+			key,
+			withManagedMetadata(key, value),
+		]),
+	);
+	return c.json({ platforms });
 });
 
-platformSchemaRoutes.get('/:platform', (c) => {
-  const { platform } = c.req.param();
-  const schema = PLATFORM_SCHEMAS[platform];
-  if (!schema) return c.json({ error: 'Unknown platform' }, 404);
-  return c.json(schema);
+platformSchemaRoutes.get("/:platform", (c) => {
+	const { platform } = c.req.param();
+	const schema = PLATFORM_SCHEMAS[platform];
+	if (!schema) return c.json({ error: "Unknown platform" }, 404);
+	return c.json(withManagedMetadata(platform, schema));
 });
 
-export { routes as clientRoutes, platformSchemaRoutes };
+export { platformSchemaRoutes, routes as clientRoutes };

--- a/packages/server/src/preview/managed-platforms.ts
+++ b/packages/server/src/preview/managed-platforms.ts
@@ -1,0 +1,19 @@
+/** Platforms that support the hosted Lobu managed bot (link codes, channel bindings). */
+export const MANAGED_CHAT_PLATFORMS = ["slack", "telegram"] as const;
+
+export type ManagedChatPlatform = (typeof MANAGED_CHAT_PLATFORMS)[number];
+
+export const MANAGED_CHAT_PLATFORMS_SET = new Set<string>(
+	MANAGED_CHAT_PLATFORMS,
+);
+
+/** Optional one-click install affordances for managed platforms (UI metadata). */
+export const MANAGED_PLATFORM_INSTALL: Partial<
+	Record<ManagedChatPlatform, { path: string; label: string }>
+> = {
+	slack: { path: "/lobu/slack/install", label: "Add to Slack" },
+};
+
+export function isManagedChatPlatform(platform: string): boolean {
+	return MANAGED_CHAT_PLATFORMS_SET.has(platform);
+}

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -1,12 +1,13 @@
-import { createHash, randomInt } from 'node:crypto';
-import { slugify } from '@lobu/core';
-import type { Context } from 'hono';
-import { getDb } from '../db/client';
-import type { Env } from '../index';
-import { errorMessage } from '../utils/errors';
-import logger from '../utils/logger';
-import { requireOrgUser } from '../utils/require-org-user';
-import { parseJsonBody } from '../gateway/routes/shared/helpers';
+import { createHash, randomInt } from "node:crypto";
+import { slugify } from "@lobu/core";
+import type { Context } from "hono";
+import { getDb } from "../db/client";
+import { parseJsonBody } from "../gateway/routes/shared/helpers";
+import type { Env } from "../index";
+import { errorMessage } from "../utils/errors";
+import logger from "../utils/logger";
+import { requireOrgUser } from "../utils/require-org-user";
+import { MANAGED_CHAT_PLATFORMS_SET } from "./managed-platforms";
 
 // Slack Preview lets people trying Lobu locally talk to their agent through the
 // hosted "Lobu Developer" Slack workspace before they have their own bot token.
@@ -20,86 +21,87 @@ import { parseJsonBody } from '../gateway/routes/shared/helpers';
 //     connection uses.
 
 // Slack DM channel ids start with `D`; the canonical binding key is `slack:<id>`.
-const SLACK_PLATFORM = 'slack';
-const CLAIM_SCOPE = 'slack-preview-claim';
+const SLACK_PLATFORM = "slack";
+const CLAIM_SCOPE = "slack-preview-claim";
 const DEFAULT_TTL_MINUTES = 15;
 const MAX_TTL_MINUTES = 60;
-const SURFACES = new Set(['dm', 'channel']);
+const SURFACES = new Set(["dm", "channel"]);
 
 // Hosted preview bots — the platforms a `preview.<platform>` block / claim mint
 // is allowed for (currently Slack and Telegram), and the default join links.
 // Both Slack and Telegram route through the same Chat SDK adapter path.
-const PREVIEW_PLATFORMS = new Set(['slack', 'telegram']);
+const PREVIEW_PLATFORMS = MANAGED_CHAT_PLATFORMS_SET;
 const PREVIEW_JOIN_DEFAULTS: Record<string, string> = {
-  slack: 'https://lobu.ai/slack',
-  telegram: 'https://t.me/lobuaibot',
+	slack: "https://lobu.ai/slack",
+	telegram: "https://t.me/lobuaibot",
 };
 
-type SurfaceType = 'dm' | 'channel';
+type SurfaceType = "dm" | "channel";
 
 // Slash-command spellings differ by platform: Slack only delivers the
 // natively-registered `/lobu`, so its subcommands are `/lobu try` etc.; other
 // platforms register each command directly (`/try`, `/agents`, `/link`).
 function tryCommand(platform: string): string {
-  return platform === 'slack' ? '/lobu try' : '/try';
+	return platform === "slack" ? "/lobu try" : "/try";
 }
 function listCommand(platform: string): string {
-  return platform === 'slack' ? '/lobu agents' : '/agents';
+	return platform === "slack" ? "/lobu agents" : "/agents";
 }
 function linkCommand(platform: string): string {
-  return platform === 'slack' ? '/lobu link' : '/link';
+	return platform === "slack" ? "/lobu link" : "/link";
 }
 
 interface ClaimPayload {
-  organizationId: string;
-  agentId: string;
-  createdBy: string | null;
-  allowedSurfaces: SurfaceType[];
-  createdAt: number;
+	organizationId: string;
+	agentId: string;
+	createdBy: string | null;
+	allowedSurfaces: SurfaceType[];
+	createdAt: number;
 }
 
 function codeHash(code: string): string {
-  return createHash('sha256').update(code.trim().toLowerCase()).digest('hex');
+	return createHash("sha256").update(code.trim().toLowerCase()).digest("hex");
 }
 
 // Uppercase letters + digits — readable, no ambiguous punctuation, and a fixed
 // length (the old base64url-then-strip approach could yield < 6 chars when the
 // random bytes happened to land on `-`/`_`).
-const CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+const CODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
 function randomCodeSuffix(): string {
-  let out = '';
-  for (let i = 0; i < 6; i++) out += CODE_ALPHABET[randomInt(CODE_ALPHABET.length)];
-  return out;
+	let out = "";
+	for (let i = 0; i < 6; i++)
+		out += CODE_ALPHABET[randomInt(CODE_ALPHABET.length)];
+	return out;
 }
 
 function normalizeSurfaces(input: unknown): SurfaceType[] {
-  if (!Array.isArray(input) || input.length === 0) return ['dm'];
-  const values = input
-    .map((value) => (typeof value === 'string' ? value.trim() : ''))
-    .filter((value): value is SurfaceType => SURFACES.has(value));
-  return Array.from(new Set(values.length > 0 ? values : ['dm']));
+	if (!Array.isArray(input) || input.length === 0) return ["dm"];
+	const values = input
+		.map((value) => (typeof value === "string" ? value.trim() : ""))
+		.filter((value): value is SurfaceType => SURFACES.has(value));
+	return Array.from(new Set(values.length > 0 ? values : ["dm"]));
 }
 
 function normalizeTtlMinutes(input: unknown): number {
-  const parsed = typeof input === 'number' ? input : Number(input);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TTL_MINUTES;
-  return Math.min(Math.trunc(parsed), MAX_TTL_MINUTES);
+	const parsed = typeof input === "number" ? input : Number(input);
+	if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TTL_MINUTES;
+	return Math.min(Math.trunc(parsed), MAX_TTL_MINUTES);
 }
 
 // "Join the hosted workspace" link for a preview platform — overridable per
 // platform via `LOBU_PREVIEW_<PLATFORM>_URL` on the deployment.
 function previewJoinUrl(platform: string): string {
-  return (
-    process.env[`LOBU_PREVIEW_${platform.toUpperCase()}_URL`] ||
-    PREVIEW_JOIN_DEFAULTS[platform] ||
-    ''
-  );
+	return (
+		process.env[`LOBU_PREVIEW_${platform.toUpperCase()}_URL`] ||
+		PREVIEW_JOIN_DEFAULTS[platform] ||
+		""
+	);
 }
 
 /** The slash command to send to the hosted bot to redeem a code. */
 function previewLinkCommand(platform: string, code: string): string {
-  return platform === 'slack' ? `/lobu link ${code}` : `/link ${code}`;
+	return platform === "slack" ? `/lobu link ${code}` : `/link ${code}`;
 }
 
 /**
@@ -110,9 +112,9 @@ function previewLinkCommand(platform: string, code: string): string {
  * transport prefix is left as-is.
  */
 export function canonicalSlackChannelId(channelId: string): string {
-  return /^[a-z]+:/i.test(channelId)
-    ? channelId
-    : `${SLACK_PLATFORM}:${channelId}`;
+	return /^[a-z]+:/i.test(channelId)
+		? channelId
+		: `${SLACK_PLATFORM}:${channelId}`;
 }
 
 /**
@@ -121,91 +123,95 @@ export function canonicalSlackChannelId(channelId: string): string {
  * Body: `{ agent_id, platform, surfaces?, ttl_minutes? }`.
  */
 export async function createPreviewClaim(c: Context<{ Bindings: Env }>) {
-  const auth = requireOrgUser(c);
-  if (!auth) return c.json({ error: 'Unauthorized' }, 401);
+	const auth = requireOrgUser(c);
+	if (!auth) return c.json({ error: "Unauthorized" }, 401);
 
-  const body = await parseJsonBody<Record<string, unknown>>(
-    c,
-    'Invalid or missing JSON body'
-  );
-  if (body instanceof Response) return body;
+	const body = await parseJsonBody<Record<string, unknown>>(
+		c,
+		"Invalid or missing JSON body",
+	);
+	if (body instanceof Response) return body;
 
-  const agentId = typeof body.agent_id === 'string' ? body.agent_id.trim() : '';
-  if (!agentId) return c.json({ error: 'agent_id is required' }, 400);
+	const agentId = typeof body.agent_id === "string" ? body.agent_id.trim() : "";
+	if (!agentId) return c.json({ error: "agent_id is required" }, 400);
 
-  const platform =
-    typeof body.platform === 'string' ? body.platform.trim().toLowerCase() : '';
-  if (!PREVIEW_PLATFORMS.has(platform)) {
-    return c.json(
-      {
-        error: 'Unsupported preview platform',
-        message: `platform must be one of: ${[...PREVIEW_PLATFORMS].join(', ')}`,
-      },
-      400
-    );
-  }
+	const platform =
+		typeof body.platform === "string" ? body.platform.trim().toLowerCase() : "";
+	if (!PREVIEW_PLATFORMS.has(platform)) {
+		return c.json(
+			{
+				error: "Unsupported preview platform",
+				message: `platform must be one of: ${[...PREVIEW_PLATFORMS].join(", ")}`,
+			},
+			400,
+		);
+	}
 
-  const surfaces = normalizeSurfaces(body.surfaces);
-  const ttlMinutes = normalizeTtlMinutes(body.ttl_minutes);
-  const codePrefix = slugify(agentId, { maxLength: 32 }) || 'agent';
-  const sql = getDb();
+	const surfaces = normalizeSurfaces(body.surfaces);
+	const ttlMinutes = normalizeTtlMinutes(body.ttl_minutes);
+	const codePrefix = slugify(agentId, { maxLength: 32 }) || "agent";
+	const sql = getDb();
 
-  const agentRows = await sql<{ id: string }>`
+	const agentRows = await sql<{ id: string }>`
     SELECT id
     FROM agents
     WHERE id = ${agentId}
       AND organization_id = ${auth.organizationId}
     LIMIT 1
   `;
-  if (agentRows.length === 0) {
-    return c.json(
-      {
-        error: 'Agent not found',
-        message: 'Run `lobu apply` first so the preview bot can bind to this agent in Lobu Cloud.',
-      },
-      404
-    );
-  }
+	if (agentRows.length === 0) {
+		return c.json(
+			{
+				error: "Agent not found",
+				message:
+					"Run `lobu apply` first so the preview bot can bind to this agent in Lobu Cloud.",
+			},
+			404,
+		);
+	}
 
-  const expiresAt = new Date(Date.now() + ttlMinutes * 60_000);
+	const expiresAt = new Date(Date.now() + ttlMinutes * 60_000);
 
-  for (let attempt = 0; attempt < 5; attempt++) {
-    const code = `${codePrefix}-${randomCodeSuffix()}`;
-    const payload: ClaimPayload = {
-      organizationId: auth.organizationId,
-      agentId,
-      createdBy: auth.userId,
-      allowedSurfaces: surfaces,
-      createdAt: Date.now(),
-    };
-    try {
-      await sql`
+	for (let attempt = 0; attempt < 5; attempt++) {
+		const code = `${codePrefix}-${randomCodeSuffix()}`;
+		const payload: ClaimPayload = {
+			organizationId: auth.organizationId,
+			agentId,
+			createdBy: auth.userId,
+			allowedSurfaces: surfaces,
+			createdAt: Date.now(),
+		};
+		try {
+			await sql`
         INSERT INTO oauth_states (id, scope, payload, expires_at)
         VALUES (${codeHash(code)}, ${CLAIM_SCOPE}, ${sql.json(payload)}, ${expiresAt})
       `;
-      return c.json({
-        provider: `lobu-public-${platform}`,
-        platform,
-        code,
-        command: previewLinkCommand(platform, code),
-        join_url: previewJoinUrl(platform),
-        expires_at: expiresAt.toISOString(),
-        allowed_surfaces: surfaces,
-      });
-    } catch (err: unknown) {
-      if ((err as { code?: string }).code === '23505') continue;
-      logger.error({ err: errorMessage(err), platform }, '[preview] create claim failed');
-      return c.json({ error: errorMessage(err) }, 500);
-    }
-  }
+			return c.json({
+				provider: `lobu-public-${platform}`,
+				platform,
+				code,
+				command: previewLinkCommand(platform, code),
+				join_url: previewJoinUrl(platform),
+				expires_at: expiresAt.toISOString(),
+				allowed_surfaces: surfaces,
+			});
+		} catch (err: unknown) {
+			if ((err as { code?: string }).code === "23505") continue;
+			logger.error(
+				{ err: errorMessage(err), platform },
+				"[preview] create claim failed",
+			);
+			return c.json({ error: errorMessage(err) }, 500);
+		}
+	}
 
-  return c.json({ error: 'Could not allocate a unique preview code' }, 500);
+	return c.json({ error: "Could not allocate a unique preview code" }, 500);
 }
 
 type ConsumeClaimResult =
-  | { status: 'bound'; agentId: string; organizationId: string }
-  | { status: 'not_found' }
-  | { status: 'surface_not_allowed'; surfaceType: SurfaceType };
+	| { status: "bound"; agentId: string; organizationId: string }
+	| { status: "not_found" }
+	| { status: "surface_not_allowed"; surfaceType: SurfaceType };
 
 // `agent_channel_bindings` upsert — last link for THIS org's chat wins. The
 // uniqueness is org-scoped (org_id, platform, channel_id[, team_id]) so a
@@ -214,23 +220,23 @@ type ConsumeClaimResult =
 // so a binding cannot change owners. The team_id IS NULL branch upserts via the
 // org-scoped partial unique index. `tx` is a `sql` or a `sql.begin` handle.
 async function upsertBinding(
-  tx: ReturnType<typeof getDb>,
-  platform: string,
-  channelId: string,
-  teamId: string | undefined,
-  agentId: string,
-  organizationId: string
+	tx: ReturnType<typeof getDb>,
+	platform: string,
+	channelId: string,
+	teamId: string | undefined,
+	agentId: string,
+	organizationId: string,
 ): Promise<void> {
-  if (teamId) {
-    await tx`
+	if (teamId) {
+		await tx`
       INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
       VALUES (${organizationId}, ${agentId}, ${platform}, ${channelId}, ${teamId}, now())
       ON CONFLICT (organization_id, platform, channel_id, team_id) DO UPDATE SET
         agent_id = EXCLUDED.agent_id,
         created_at = EXCLUDED.created_at
     `;
-  } else {
-    await tx`
+	} else {
+		await tx`
       INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
       VALUES (${organizationId}, ${agentId}, ${platform}, ${channelId}, NULL, now())
       ON CONFLICT (organization_id, platform, channel_id)
@@ -238,7 +244,7 @@ async function upsertBinding(
         DO UPDATE SET agent_id = EXCLUDED.agent_id,
           created_at = EXCLUDED.created_at
     `;
-  }
+	}
 }
 
 /**
@@ -255,52 +261,60 @@ async function upsertBinding(
  * account in `chat_user_identities` so later links can skip the code.
  */
 export async function consumePreviewClaim(args: {
-  code: string;
-  platform: string;
-  /** Workspace id for platforms that have one (Slack); undefined otherwise. */
-  teamId?: string;
-  channelId: string;
-  surfaceType: SurfaceType;
-  /** Sender's platform user id (e.g. Slack `U…`), if known. */
-  platformUserId?: string;
+	code: string;
+	platform: string;
+	/** Workspace id for platforms that have one (Slack); undefined otherwise. */
+	teamId?: string;
+	channelId: string;
+	surfaceType: SurfaceType;
+	/** Sender's platform user id (e.g. Slack `U…`), if known. */
+	platformUserId?: string;
 }): Promise<ConsumeClaimResult> {
-  const { code, platform, teamId, channelId, surfaceType, platformUserId } = args;
-  const sql = getDb();
+	const { code, platform, teamId, channelId, surfaceType, platformUserId } =
+		args;
+	const sql = getDb();
 
-  return sql.begin(async (tx) => {
-    const claims = await tx<{ payload: ClaimPayload }>`
+	return sql.begin(async (tx) => {
+		const claims = await tx<{ payload: ClaimPayload }>`
       DELETE FROM oauth_states
       WHERE id = ${codeHash(code)}
         AND scope = ${CLAIM_SCOPE}
         AND expires_at > now()
       RETURNING payload
     `;
-    const claim = claims[0]?.payload;
-    if (!claim) return { status: 'not_found' as const };
-    if (!claim.allowedSurfaces.includes(surfaceType)) {
-      return { status: 'surface_not_allowed' as const, surfaceType };
-    }
+		const claim = claims[0]?.payload;
+		if (!claim) return { status: "not_found" as const };
+		if (!claim.allowedSurfaces.includes(surfaceType)) {
+			return { status: "surface_not_allowed" as const, surfaceType };
+		}
 
-    await upsertBinding(tx, platform, channelId, teamId, claim.agentId, claim.organizationId);
+		await upsertBinding(
+			tx,
+			platform,
+			channelId,
+			teamId,
+			claim.agentId,
+			claim.organizationId,
+		);
 
-    // The code was minted by an authenticated `lobu run`, so the sender is the
-    // same Lobu user. Record the chat-platform → Lobu-user link so they can
-    // re-bind chats with `/lobu link <agentId>` without a fresh code.
-    if (claim.createdBy && platformUserId) {
-      await tx`
+		// The code was minted by an authenticated `lobu run`, so the sender is the
+		// same Lobu user. Record the chat-platform → Lobu-user link so they can
+		// re-bind chats with `/lobu link <agentId>` without a fresh code.
+		if (claim.createdBy && platformUserId) {
+			await tx`
         INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id, updated_at)
-        VALUES (${platform}, ${teamId ?? ''}, ${platformUserId}, ${claim.createdBy}, now())
+        VALUES (${platform}, ${teamId ?? ""}, ${platformUserId}, ${claim.createdBy}, now())
         ON CONFLICT (platform, team_id, platform_user_id)
           DO UPDATE SET lobu_user_id = EXCLUDED.lobu_user_id, updated_at = now()
       `;
-    }
+		}
 
-    return {
-      status: 'bound' as const,
-      agentId: claim.agentId,
-      organizationId: claim.organizationId,
-    };
-  });
+		return {
+			status: "bound" as const,
+			agentId: claim.agentId,
+			organizationId: claim.organizationId,
+		};
+	});
 }
 
 // ── Public-preview "try a demo agent" ────────────────────────────────────────
@@ -313,9 +327,9 @@ export async function consumePreviewClaim(args: {
 // connection's own placeholder/concierge agent is excluded from the list.
 
 interface PreviewAgent {
-  agentId: string;
-  name: string;
-  description: string | null;
+	agentId: string;
+	name: string;
+	description: string | null;
 }
 
 /**
@@ -324,18 +338,18 @@ interface PreviewAgent {
  * Returns null when the connection or its owning agent can't be resolved.
  */
 async function resolvePreviewConnectionOrg(
-  connectionId: string
+	connectionId: string,
 ): Promise<{ organizationId: string; owningAgentId: string } | null> {
-  const sql = getDb();
-  const rows = (await sql`
+	const sql = getDb();
+	const rows = (await sql`
     SELECT organization_id, agent_id
     FROM agent_connections
     WHERE id = ${connectionId}
     LIMIT 1
   `) as Array<{ organization_id: string | null; agent_id: string | null }>;
-  const row = rows[0];
-  if (!row?.organization_id || !row.agent_id) return null;
-  return { organizationId: row.organization_id, owningAgentId: row.agent_id };
+	const row = rows[0];
+	if (!row?.organization_id || !row.agent_id) return null;
+	return { organizationId: row.organization_id, owningAgentId: row.agent_id };
 }
 
 /**
@@ -344,36 +358,42 @@ async function resolvePreviewConnectionOrg(
  * runs on the hot path of every unlinked message and the worst case is a
  * fallback notice instead of the menu.
  */
-export async function listPreviewAgents(connectionId: string): Promise<PreviewAgent[]> {
-  try {
-    const org = await resolvePreviewConnectionOrg(connectionId);
-    if (!org) return [];
-    const sql = getDb();
-    const rows = (await sql`
+export async function listPreviewAgents(
+	connectionId: string,
+): Promise<PreviewAgent[]> {
+	try {
+		const org = await resolvePreviewConnectionOrg(connectionId);
+		if (!org) return [];
+		const sql = getDb();
+		const rows = (await sql`
       SELECT id, name, description
       FROM agents
       WHERE organization_id = ${org.organizationId}
         AND id <> ${org.owningAgentId}
       ORDER BY name NULLS LAST, id
-    `) as Array<{ id: string; name: string | null; description: string | null }>;
-    return rows.map((r) => ({
-      agentId: r.id,
-      name: r.name ?? r.id,
-      description: r.description ?? null,
-    }));
-  } catch (err) {
-    logger.warn(
-      { err: errorMessage(err), connectionId },
-      '[preview] listPreviewAgents failed'
-    );
-    return [];
-  }
+    `) as Array<{
+			id: string;
+			name: string | null;
+			description: string | null;
+		}>;
+		return rows.map((r) => ({
+			agentId: r.id,
+			name: r.name ?? r.id,
+			description: r.description ?? null,
+		}));
+	} catch (err) {
+		logger.warn(
+			{ err: errorMessage(err), connectionId },
+			"[preview] listPreviewAgents failed",
+		);
+		return [];
+	}
 }
 
 type BindPreviewAgentResult =
-  | { status: 'bound'; agentId: string }
-  | { status: 'not_available' }
-  | { status: 'no_connection' };
+	| { status: "bound"; agentId: string }
+	| { status: "not_available" }
+	| { status: "no_connection" };
 
 /**
  * Bind a chat to a demo agent for a preview connection. The agent must live in
@@ -382,46 +402,57 @@ type BindPreviewAgentResult =
  * Last bind wins; re-running with another agent just rebinds.
  */
 export async function bindChatToPreviewAgent(args: {
-  connectionId: string;
-  agentId: string;
-  platform: string;
-  /** Workspace id for platforms that have one (Slack); undefined otherwise. */
-  teamId?: string;
-  /** Canonical channel id the message handler looks bindings up by. */
-  channelId: string;
+	connectionId: string;
+	agentId: string;
+	platform: string;
+	/** Workspace id for platforms that have one (Slack); undefined otherwise. */
+	teamId?: string;
+	/** Canonical channel id the message handler looks bindings up by. */
+	channelId: string;
 }): Promise<BindPreviewAgentResult> {
-  const org = await resolvePreviewConnectionOrg(args.connectionId);
-  if (!org) return { status: 'no_connection' };
-  const sql = getDb();
-  const agentRows = (await sql`
+	const org = await resolvePreviewConnectionOrg(args.connectionId);
+	if (!org) return { status: "no_connection" };
+	const sql = getDb();
+	const agentRows = (await sql`
     SELECT id FROM agents
     WHERE id = ${args.agentId} AND organization_id = ${org.organizationId}
     LIMIT 1
   `) as Array<{ id: string }>;
-  const target = agentRows[0];
-  if (!target) return { status: 'not_available' };
+	const target = agentRows[0];
+	if (!target) return { status: "not_available" };
 
-  const { platform, teamId, channelId } = args;
-  // Org-scoped upsert (same dance as `upsertBinding`): another tenant's binding
-  // for the same platform+channel is a different row and cannot be clobbered,
-  // and `organization_id` is never reassigned, so a binding can't change owners.
-  await upsertBinding(sql, platform, channelId, teamId, target.id, org.organizationId);
-  return { status: 'bound', agentId: target.id };
+	const { platform, teamId, channelId } = args;
+	// Org-scoped upsert (same dance as `upsertBinding`): another tenant's binding
+	// for the same platform+channel is a different row and cannot be clobbered,
+	// and `organization_id` is never reassigned, so a binding can't change owners.
+	await upsertBinding(
+		sql,
+		platform,
+		channelId,
+		teamId,
+		target.id,
+		org.organizationId,
+	);
+	return { status: "bound", agentId: target.id };
 }
 
 /** The "pick a demo agent" menu — shown on `/lobu try` / `/lobu agents`. */
-export function previewAgentMenu(platform: string, agents: PreviewAgent[]): string {
-  if (agents.length === 0) {
-    return 'No demo agents are available here yet.';
-  }
-  return [
-    'Demo agents you can try here:',
-    ...agents.map(
-      (a) => `• \`${tryCommand(platform)} ${a.agentId}\` — ${a.description || a.name}`
-    ),
-    '',
-    `Pick one, then just send a message. \`${listCommand(platform)}\` shows this list again.`,
-  ].join('\n');
+export function previewAgentMenu(
+	platform: string,
+	agents: PreviewAgent[],
+): string {
+	if (agents.length === 0) {
+		return "No demo agents are available here yet.";
+	}
+	return [
+		"Demo agents you can try here:",
+		...agents.map(
+			(a) =>
+				`• \`${tryCommand(platform)} ${a.agentId}\` — ${a.description || a.name}`,
+		),
+		"",
+		`Pick one, then just send a message. \`${listCommand(platform)}\` shows this list again.`,
+	].join("\n");
 }
 
 /**
@@ -431,25 +462,25 @@ export function previewAgentMenu(platform: string, agents: PreviewAgent[]): stri
  * there's nothing useful to say (unknown platform).
  */
 export async function previewUnlinkedNotice(
-  platform: string,
-  connectionId: string
+	platform: string,
+	connectionId: string,
 ): Promise<string | null> {
-  if (!PREVIEW_PLATFORMS.has(platform)) return null;
-  const agents = await listPreviewAgents(connectionId);
-  if (agents.length > 0) {
-    return [
-      `👋 Welcome! ${previewAgentMenu(platform, agents)}`,
-      '',
-      `(Building your own agent? Run \`lobu run\` and send the \`${linkCommand(platform)} <code>\` it prints.)`,
-    ].join('\n');
-  }
-  return [
-    "👋 This chat isn't linked to a Lobu agent yet.",
-    '',
-    'New to Lobu? Scaffold a project with `npx @lobu/cli init`, then:',
-    '`lobu apply` to sync it, and `lobu run` to get a ' +
-      `\`${linkCommand(platform)} <code>\` — paste that code here to link this chat.`,
-  ].join('\n');
+	if (!PREVIEW_PLATFORMS.has(platform)) return null;
+	const agents = await listPreviewAgents(connectionId);
+	if (agents.length > 0) {
+		return [
+			`👋 Welcome! ${previewAgentMenu(platform, agents)}`,
+			"",
+			`(Building your own agent? Run \`lobu run\` and send the \`${linkCommand(platform)} <code>\` it prints.)`,
+		].join("\n");
+	}
+	return [
+		"👋 This chat isn't linked to a Lobu agent yet.",
+		"",
+		"New to Lobu? Scaffold a project with `npx @lobu/cli init`, then:",
+		"`lobu apply` to sync it, and `lobu run` to get a " +
+			`\`${linkCommand(platform)} <code>\` — paste that code here to link this chat.`,
+	].join("\n");
 }
 
 /**
@@ -461,31 +492,29 @@ export async function previewUnlinkedNotice(
  * (OAuth install is Slack-only today).
  */
 export function workspaceUnlinkedNotice(platform: string): string | null {
-  if (platform !== 'slack') return null;
-  return [
-    "👋 Thanks for adding Lobu! This channel isn't linked to one of your agents yet.",
-    '',
-    `Run \`${linkCommand(platform)} <code>\` here with a link code from your Lobu dashboard (or \`lobu run\`) to connect an agent.`,
-  ].join('\n');
+	if (platform !== "slack") return null;
+	return [
+		"👋 Thanks for adding Lobu! This channel isn't linked to one of your agents yet.",
+		"",
+		`Run \`${linkCommand(platform)} <code>\` here with a link code from your Lobu dashboard (or \`lobu run\`) to connect an agent.`,
+	].join("\n");
 }
 
 /** The Lobu user id a chat-platform user has linked to, or null. */
 export async function resolveChatUserIdentity(
-  platform: string,
-  teamId: string | undefined,
-  platformUserId: string
+	platform: string,
+	teamId: string | undefined,
+	platformUserId: string,
 ): Promise<string | null> {
-  const rows = await getDb()<{ lobu_user_id: string }>`
+	const rows = await getDb()<{ lobu_user_id: string }>`
     SELECT lobu_user_id FROM chat_user_identities
-    WHERE platform = ${platform} AND team_id = ${teamId ?? ''} AND platform_user_id = ${platformUserId}
+    WHERE platform = ${platform} AND team_id = ${teamId ?? ""} AND platform_user_id = ${platformUserId}
     LIMIT 1
   `;
-  return rows[0]?.lobu_user_id ?? null;
+	return rows[0]?.lobu_user_id ?? null;
 }
 
-type BindForOwnerResult =
-  | { status: 'bound' }
-  | { status: 'forbidden' };
+type BindForOwnerResult = { status: "bound" } | { status: "forbidden" };
 
 /**
  * Re-bind a chat to one of the caller's agents by id, without a code — only
@@ -493,25 +522,25 @@ type BindForOwnerResult =
  * and only for agents in an org they're a member of.
  */
 export async function bindChatToAgentForOwner(args: {
-  platform: string;
-  teamId?: string;
-  channelId: string;
-  agentId: string;
-  lobuUserId: string;
+	platform: string;
+	teamId?: string;
+	channelId: string;
+	agentId: string;
+	lobuUserId: string;
 }): Promise<BindForOwnerResult> {
-  const { platform, teamId, channelId, agentId, lobuUserId } = args;
-  const sql = getDb();
-  const owned = await sql<{ organization_id: string }>`
+	const { platform, teamId, channelId, agentId, lobuUserId } = args;
+	const sql = getDb();
+	const owned = await sql<{ organization_id: string }>`
     SELECT a.organization_id
     FROM agents a
     JOIN "member" m ON m."organizationId" = a.organization_id
     WHERE a.id = ${agentId} AND m."userId" = ${lobuUserId}
     LIMIT 1
   `;
-  if (owned.length === 0) return { status: 'forbidden' };
-  const organizationId = owned[0].organization_id;
-  await sql.begin((tx) =>
-    upsertBinding(tx, platform, channelId, teamId, agentId, organizationId)
-  );
-  return { status: 'bound' };
+	if (owned.length === 0) return { status: "forbidden" };
+	const organizationId = owned[0].organization_id;
+	await sql.begin((tx) =>
+		upsertBinding(tx, platform, channelId, teamId, agentId, organizationId),
+	);
+	return { status: "bound" };
 }


### PR DESCRIPTION
## Summary

Completes the remaining grok-dev server work for the conversational UI merge:

- Extracts `resolveSystemKeyProvidersAndModel()` so builder and default-agent provisioning both resolve providers/model from `providers.json` when the module registry is empty (same fix as builder #1523 path).
- Backfills `owletto-default` when `model`, `installed_providers`, or `model_selection` are broken.
- Exposes `managed`, `managedInstallPath`, and `managedInstallLabel` on the platform schema API (required for owletto #349 channels UI).
- Centralizes `MANAGED_CHAT_PLATFORMS` for Slack preview + schema routes.

## Review fixes applied

- Model pin order: Claude → ZAI → config providers (preserves builder reliability contract).
- Default-agent backfill uses `providersEmpty` (not registry-only gate), matching builder repair.
- Builder e2e clears ambient `Z_AI_API_KEY` / `ZAI_API_KEY` for hermetic tests.

## Validation

- `bun run typecheck` ✓
- `builder-provisioning-e2e.test.ts` (9 tests) ✓
- `default-provisioning.test.ts` (11 tests) ✓

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784846336&installation_id=136316292&pr_number=1525&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1525&signature=6f9bc7268fc2cb31c07a14703f981aa36731f65ccf560c7c606729013f4cd5c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added managed platform metadata to platform schema API responses
  * Slack and Telegram now designated as supported managed chat platforms with installation guidance

* **Bug Fixes**
  * Improved agent auto-provisioning reliability with enhanced model and provider resolution
  * Fixed provisioning to repair incomplete agent configurations

* **Tests**
  * Enhanced test determinism for provider and model resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->