### PR TITLE
docs: align README and landing with pipeline-first positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# Lobu — Multi-tenant OpenClaw for Organizations
+# Lobu — Open-source backend for AI teammates
 
-**Lobu** is an open-source multi-tenant gateway for [OpenClaw](https://github.com/openclaw/openclaw): one sandbox and filesystem per user/channel, shared memory across contexts, and agents that never see secrets. OpenClaw is a full agent runtime (~800k LOC) but it's [single-tenant by design](https://x.com/steipete/status/2026092642623201379) — every user shares the same filesystem and bash session. Lobu rewrites only the gateway layer (~40k LOC) to be multi-tenant and keeps OpenClaw's Pi harness untouched inside each worker.
+**Lobu** is open-source infrastructure for autonomous agents that **watch**, **remember**, and **act** where your team already works. Connect company tools, build living memory, and let agents run on schedules, in Slack threads, or over MCP — with sandboxed execution per user or channel and credentials agents never see.
 
-**Embedded mode** uses [just-bash](https://www.npmjs.com/package/just-bash) + Nix for reproducible packages: each user gets an isolated virtual filesystem and bash session at ~50MB per instance — tested at 300 concurrent instances on a single machine, no Docker needed. Embed OpenClaw-powered agents into your product, or give your team agents without managing a separate instance per person.
+Under the hood, workers run an [OpenClaw](https://openclaw.ai/)-style agent loop (bash, files, MCP tools, skills) inside an isolated sandbox per conversation. One Node process serves many agents and channels; shared memory and connectors live in Postgres (pgvector). Embed agents in your product, or give your team their own without running a separate instance per person.
 
 https://github.com/user-attachments/assets/d72a9286-0325-4b8b-afc0-c1efe9c96f4e
 
-## Quick Start
+## Two ways in
 
-Scaffold and run via the CLI. Lobu boots as a single Node process with a zero-config embedded Postgres by default (or bring your own — pgvector required — via `DATABASE_URL`).
+### 1. Full agent — Slack, Telegram, watchers, connectors
+
+Scaffold and run locally with the CLI. Lobu boots as a single Node process with zero-config embedded Postgres by default (or bring your own — pgvector required — via `DATABASE_URL`). `lobu run` opens the web UI on `:8787` and can wire Slack via the hosted bot or your own app.
 
 ```bash
 npx @lobu/cli@latest init my-bot
@@ -17,7 +19,21 @@ npx @lobu/cli@latest run                      # boots the stack and applies your
 npx @lobu/cli@latest chat -c local "hello"    # talk to it
 ```
 
-`lobu run` (embedded) auto-applies your `lobu.config.ts`, so the scaffolded agent is usable immediately. To use an external Postgres, set `DATABASE_URL` in `.env`; to push later config changes, run `lobu apply`. The same agents are reachable over a [REST API](https://lobu.ai/reference/api-reference/) and every chat platform — see [Channels](#channels).
+`lobu run` auto-applies your `lobu.config.ts`, so the scaffolded agent is usable immediately. To use an external Postgres, set `DATABASE_URL` in `.env`; to push later config changes, run `lobu apply`.
+
+Next steps: [Getting started](https://lobu.ai/getting-started/) (project layout, develop with your coding agent, evals) · [Memory](https://lobu.ai/getting-started/memory/) · [Skills](https://lobu.ai/getting-started/skills/) · [Channels](#channels)
+
+### 2. Memory for Claude Code (and Claude Desktop)
+
+Give Claude durable, structured memory via MCP — the same graph your Lobu agents use. Full setup: [Connect from Claude](https://lobu.ai/connect-from/claude/).
+
+```bash
+claude mcp add --transport http lobu https://lobu.ai/mcp   # or http://localhost:8787/mcp locally
+```
+
+Complete the OAuth flow when prompted, then enable the connector. Pair it with a project instruction or skill that tells Claude when to search memory and when to save what it learned.
+
+Works the same for [ChatGPT](https://lobu.ai/connect-from/chatgpt/) and [OpenClaw](https://lobu.ai/connect-from/openclaw/) — one memory backend across clients.
 
 ## Architecture
 
@@ -28,6 +44,7 @@ flowchart LR
   WhatsApp[WhatsApp] <--> GW
   Discord[Discord] <--> GW
   API[REST API] <--> GW
+  MCP[MCP clients] <--> GW
 
   GW <--> PG[(Postgres)]
   GW -->|spawn| W[Worker]
@@ -39,58 +56,55 @@ flowchart LR
   W -.->|HTTP proxy| GW
   W -.->|MCP proxy| GW
   GW -->|domain filter| Internet((Internet))
-  GW -->|scoped tokens| MCP[MCP Servers]
+  GW -->|scoped tokens| ExtMCP[MCP Servers]
 ```
 
 ## Capabilities
 
-Every Lobu agent ships with tools for autonomous execution and persistence:
+Most agent stacks treat MCP as the memory: every turn, the agent calls GitHub, Slack, and CRM tools to reconstruct what happened. That knowledge stays siloed in the session and disappears when the chat ends.
 
-| Feature | Built-in Tools |
-| --- | --- |
-| **Autonomous scheduling** — one-time or cron | `manage_schedules` |
-| **Human-in-the-loop** — pause on button input, resume on answer | `ask_user` |
-| **Full Linux toolbox** — sandboxed shell, file edit, search | `bash`, `read`, `write`, `edit`, `grep`, `find`, `ls` |
-| **Conversation context** — pull earlier thread messages | `get_channel_history` |
-| **File & media delivery** — share reports, charts, audio | `upload_file`, `generate_audio`, `generate_image` |
-| **Skills** — extend via `lobu.config.ts` or admin settings | `lobu.config.ts`, Settings UI |
-| **Connected APIs** — GitHub, Google, etc. with Lobu-managed OAuth | MCP tools via Lobu |
-| **Managed MCP proxy** — any MCP server with secret injection | [MCP Proxy](docs/SECURITY.md#credentials) |
-| **Nix + external MCP** — browsing, headless UI, custom tools | `bash` (Nix), MCP servers |
+Lobu runs a **data pipeline** instead. Connectors poll and webhooks push into one durable, append-only event log. Watchers and chat agents read the same org-scoped knowledge graph — typed entities, relationships, searchable events — so anyone can resume where the organization left off, not where one conversation left off.
+
+### Memory — ingest, entities, watchers
+
+**Ingest.** [Connectors](https://lobu.ai/sdks/connectors/) pull on a schedule; webhooks and the [REST API](https://lobu.ai/sdks/rest-api/) push. Stripe charges, GitHub PRs, form submissions, and connector polls all land as rows in the same log — a stable record of what happened in the world, not something the agent has to re-fetch through MCP every turn.
+
+**Entities.** You define the schema (`Company`, `Project`, `Incident`, …) in `lobu.config.ts`. Events attach to entity instances (`Company:Acme`) and build a live knowledge graph the whole org shares. Corrections supersede old facts; nothing is deleted, so provenance and time-travel stay intact.
+
+**Watchers.** Standing goals on a cron or tight interval: read new rows in the log (including webhook-fed events like `pull_request.opened`), extract structured memory onto dynamic entities, and optionally run a [reaction](https://lobu.ai/sdks/reactions/) to notify Slack, open a ticket, or kick off agent work — while nobody is in chat.
+
+Docs: [Memory](https://lobu.ai/getting-started/memory/) · [Connectors](https://lobu.ai/sdks/connectors/) · [Reactions](https://lobu.ai/sdks/reactions/)
+
+### Agents — read the graph, branch to act
+
+Chat agents **look up** what the pipeline already captured — search entities, read the event log, pull thread history — then **branch** into an isolated sandbox ([just-bash](https://www.npmjs.com/package/just-bash) + Nix) to run bash, edit files, and call MCP tools for side effects. MCP is for *doing*; the knowledge graph is for *knowing*. Pick any of [16 LLM providers](https://lobu.ai/reference/providers/); credentials stay on the gateway.
+
+Behavior comes from a **role file model** — `IDENTITY.md` (who), `SOUL.md` (rules), `USER.md` (context). **Guardrails** gate input, output, and tool calls (`secret-scan`, `pii-scan`, inline LLM judges) so policy holds even when the prompt doesn't. Destructive MCP calls wait for in-thread approval; every action writes back to the log.
+
+Docs: [Agent workspace](https://lobu.ai/guides/agent-prompts/) · [Guardrails](https://lobu.ai/guides/guardrails/) · [Security](https://lobu.ai/guides/security/)
 
 ### Channels
 
-One instance serves **Slack, Telegram, WhatsApp, Discord, Teams, Google Chat**, and a [REST API](https://lobu.ai/reference/api-reference/) [![API Docs](https://img.shields.io/badge/API_Docs-0096FF?style=for-the-badge&logo=readme&logoColor=white)](https://lobu.ai/reference/api-reference/). Each channel/DM gets its own runtime, model, tools, credentials, and Nix packages. Webhook is the default transport (Telegram also supports polling).
-
-### Popular MCP integrations
-
-- **Productivity:** Google Calendar, Slack, Jira, Notion
-- **Development:** GitHub, GitLab, Postgres, Docker
-- **Knowledge:** Wikipedia, Brave Search, YouTube, PDF Search
-
-### Runtime
-
-- **OpenClaw runtime.** Workers run [OpenClaw Pi Agent](https://openclaw.ai/) with per-agent model selection, OpenClaw skills, and `IDENTITY.md` / `SOUL.md` / `USER.md` workspace files.
-- **Multi-provider auth.** 16 LLM providers (OpenAI, Gemini, Groq, DeepSeek, Mistral, …) via a config-driven registry. API keys stay on the gateway.
+One instance serves **Slack, Telegram, WhatsApp, Discord, Teams, Google Chat**, and a [REST API](https://lobu.ai/reference/api-reference/) [![API Docs](https://img.shields.io/badge/API_Docs-0096FF?style=for-the-badge&logo=readme&logoColor=white)](https://lobu.ai/reference/api-reference/). Each channel/DM gets its own runtime, model, tools, credentials, and Nix packages. Platform setup: [Slack](https://lobu.ai/platforms/slack/) · [Telegram](https://lobu.ai/platforms/telegram/) · [Discord](https://lobu.ai/platforms/discord/) · [WhatsApp](https://lobu.ai/platforms/whatsapp/) · [Teams](https://lobu.ai/platforms/teams/) · [Google Chat](https://lobu.ai/platforms/google-chat/).
 
 ## How Lobu Differs
 
 Lobu is the **infrastructure layer** for autonomous agents. Frameworks like LangChain or CrewAI help you *write* agent logic; Lobu is the delivery layer that runs those agents at scale — sandboxing, persistence, and messaging connectivity.
 
-| | Lobu | OpenClaw |
-| --- | --- | --- |
-| Scale to zero | Workers scale down when idle | Requires always-on machine |
-| Multi-tenant | Single bot, per-channel/DM isolation | One instance per setup |
-| Multi-platform | Slack, Telegram, WhatsApp, Discord, Teams, Google Chat, REST API | [15+ chat platforms](https://openclaw.ai/integrations) |
-| Runtime | OpenClaw engine (sandboxed/proxied) | Native OpenClaw |
-| Onboarding | Config page with per-provider OAuth | CLI setup |
-| MCP access | Proxied through gateway, secrets isolated | Direct from agent |
-| Network | Sandboxed, domain-filtered egress | No built-in isolation |
-| Deployment | Single Node process (BYO Postgres) | Single node |
+**vs OpenClaw:** OpenClaw is [single-tenant by design](https://x.com/steipete/status/2026092642623201379) — every user shares the same filesystem and bash session. Lobu keeps the same autonomous loop but runs it **multi-tenant**: one gateway, an isolated sandbox per channel or DM, and org-scoped memory your whole team can share. Full write-up: [lobu.ai/getting-started/comparison](https://lobu.ai/getting-started/comparison/).
+
+| | Lobu | Claude Tag | OpenClaw |
+| --- | --- | --- | --- |
+| Tenancy | Multi-tenant — per-channel/DM isolation | Per-channel @Claude | Single-tenant — one shared runtime |
+| Open source / self-host | Yes | No | Yes |
+| Model choice | 16 providers | Claude only | Per setup |
+| Multi-platform | Slack, Telegram, WhatsApp, Discord, Teams, Google Chat, REST API, MCP | Slack (beta) | [15+ chat platforms](https://openclaw.ai/integrations) |
+| Custom connectors / watchers | Yes (`lobu.config.ts`) | Admin-provisioned tools | Skills + local setup |
+| Secrets & network | Gateway proxy, domain-filtered egress | Managed | Direct from agent, no built-in isolation |
 
 ## Agent configuration
 
-Runtime configuration is managed through the web app or the same org-scoped REST API used by the CLI:
+Runtime configuration is managed through the web app or the same org-scoped REST API used by the CLI. See the [CLI reference](https://lobu.ai/reference/cli/) and [`lobu apply`](https://lobu.ai/reference/lobu-apply/).
 
 ```bash
 npx @lobu/cli@latest login
@@ -102,27 +116,13 @@ Local `lobu.config.ts` projects are still useful for `lobu validate` and `lobu a
 
 ## Deployment
 
-Single-process Node remains the simplest deployment: run it with `node`, `pm2`, `systemd`, or another process supervisor. The app needs `DATABASE_URL` (Postgres + pgvector) reachable from its environment.
-
-- **Local dev** (contributing to Lobu itself): clone, `make setup` (provisions brew `postgresql@18`), `make dev` (gateway + workers + Vite HMR on `:8787`, against the shared brew Postgres@18; use `make dev-embedded` for the zero-dependency embedded Postgres).
-- **Production (VM/bare metal)**: `bun run --cwd packages/server build:server`, then `node packages/server/dist/server.bundle.mjs` under your process supervisor of choice.
-- **Production (Docker)**: a single self-hosting image — see [docs/DOCKER.md](docs/DOCKER.md).
-- **Production (Kubernetes)**: use the public Helm chart in `charts/lobu`:
-  ```bash
-  helm install lobu oci://ghcr.io/lobu-ai/charts/lobu \
-    --namespace lobu --create-namespace \
-    -f your-values.yaml
-  ```
-  See `charts/lobu/values.yaml` for the full set of tunables. At minimum supply an
-  ingress host, a `secretName` Secret containing `DATABASE_URL` + `ENCRYPTION_KEY` +
-  `BETTER_AUTH_SECRET` + provider API keys, and a `database.existingSecret`.
+The quick start above is the fastest path. For production self-hosting, see the [deployment docs](https://lobu.ai/deployment/docker/): [Docker](https://lobu.ai/deployment/docker/) · [Cloud](https://lobu.ai/deployment/cloud/) · [Kubernetes](https://lobu.ai/deployment/kubernetes/).
 
 ## Security and Privacy
 
-- [**Worker egress through the gateway proxy**](docs/SECURITY.md#network-egress) — `HTTP_PROXY=http://localhost:8118` with allowlist/blocklist + LLM egress judge. On Linux production hosts the worker spawn uses `systemd-run --user --scope` with `IPAddressDeny=any` to enforce egress at the kernel level; in dev (macOS) the proxy is best-effort.
-- [**Secrets stay in gateway**](docs/SECURITY.md#credentials) — provider credentials and `${env:}` substitution; OAuth lives in Lobu. Workers never see real keys.
-- [**Threat model: single-tenant local isolation**](docs/SECURITY.md) — `just-bash` and `isolated-vm` are policy + best-effort sandboxes, not security boundaries for hostile code. See `docs/SECURITY.md` before exposing Lobu to untrusted users.
-- [**Nix system packages**](docs/SECURITY.md#skills-and-policy) — per-agent reproducible tooling and skill policy.
+- [**Network isolation**](https://lobu.ai/guides/security/#network-isolation) — workers route egress through the gateway proxy with allowlist/blocklist + LLM egress judge.
+- [**Secrets stay in gateway**](https://lobu.ai/guides/secret-proxy/) — provider credentials and OAuth live in Lobu; workers never see real keys.
+- [**Threat model**](https://lobu.ai/guides/security/) — `just-bash` and `isolated-vm` are policy + best-effort sandboxes, not security boundaries for hostile code.
 
 ## Support & Consultancy
 
@@ -132,7 +132,7 @@ Lobu is open source, but deploying production-grade agents usually means tuning 
 - **Automated customer support** — multi-step ticket handling with human-in-the-loop.
 - **Autonomous workflows** — long-running, scheduled background jobs with persistent state.
 - **Managed infrastructure** — private Lobu deployments with updates and scaling.
-- **Custom tooling & skills** — bespoke MCP servers, Nix runtimes, and OpenClaw skills.
+- **Custom tooling & skills** — bespoke MCP servers, Nix runtimes, and agent skills.
 
 I'm a second-time technical founder. Previously founded [rakam.io](https://rakam.io) (enterprise analytics PaaS), acquired by [LiveRamp](https://liveramp.com) (NYSE: RAMP).
 

--- a/packages/landing/public/index.md
+++ b/packages/landing/public/index.md
@@ -1,66 +1,43 @@
 # Lobu
 
-> Open-source infrastructure for multi-tenant AI agents: sandboxed execution, shared memory, and an SDK that pulls live company data and acts on your high-level goals.
+> Open-source infrastructure for AI teammates that watch, remember, and act. Connectors and webhooks build a live org knowledge graph in an append-only log; agents look it up and branch into isolated sandboxes to do work.
 
 ## What Lobu does
 
-Lobu runs goal-driven AI teammates where your team already works: Slack, Telegram, WhatsApp, Discord, Microsoft Teams, Google Chat, REST API, and MCP-capable clients. Agents connect to company systems, turn updates into shared memory, collaborate with humans, and act safely in your tools. Each user or channel gets an isolated worker with gateway-mediated credentials, scoped network egress, and approval flows for sensitive tool calls.
+Lobu runs goal-driven AI teammates where your team already works: Slack, Telegram, WhatsApp, Discord, Microsoft Teams, Google Chat, REST API, and MCP-capable clients. Connectors poll and webhooks push into one durable event log; watchers and chat agents share typed entity memory instead of re-fetching state through MCP every turn. Each user or channel gets an isolated worker with gateway-mediated credentials, guardrails, scoped network egress, and approval flows for sensitive tool calls.
 
 ## Connect any agent to Lobu
 
-The canonical MCP endpoint at [https://lobu.ai/mcp](https://lobu.ai/mcp) lets MCP-capable clients such as Claude, ChatGPT, Claude Code, and OpenClaw sign in once, list available organizations, and switch to the right workspace per conversation. See [/mcp](https://lobu.ai/mcp/) for per-client setup.
+The canonical MCP endpoint at [https://lobu.ai/mcp](https://lobu.ai/mcp) lets MCP-capable clients such as Claude, ChatGPT, Claude Code, and OpenClaw sign in once and read/write the same org graph your Slack agents use. MCP is for recall and write; ingestion still flows through connectors and webhooks. See [/mcp](https://lobu.ai/mcp/) and [Connect from Claude](https://lobu.ai/connect-from/claude/).
 
 ## Start here
 
-- [Home](https://lobu.ai/): Product overview, connectors, memory, agents, platforms, and architecture
+- [Home](https://lobu.ai/): Product overview, memory pipeline, skills, platforms
 - [Getting started](https://lobu.ai/getting-started/): Install and run your first agent
-- [Comparison](https://lobu.ai/getting-started/comparison/): How Lobu compares to other agent platforms
+- [Comparison](https://lobu.ai/getting-started/comparison/): Lobu vs OpenClaw, Claude Tag, and others
 - [Serverless OpenClaw](https://lobu.ai/serverless-openclaw/): Managed runtime and usage-based billing
 
 ## Core concepts
 
 - [Skills](https://lobu.ai/getting-started/skills/): Reusable agent capabilities via SKILL.md
-- [Memory](https://lobu.ai/getting-started/memory/): Persistent typed memory for agents
+- [Memory](https://lobu.ai/getting-started/memory/): Connectors, entities, watchers, append-only org memory
 - [Architecture](https://lobu.ai/guides/architecture/): Gateway, workers, proxy, and sandboxing model
 - [Security](https://lobu.ai/guides/security/): Sandboxing, network policy, and credential isolation
-- [Tool policy](https://lobu.ai/guides/tool-policy/): Approval model for destructive MCP tools
-
-## Deployment
-
-- [Lobu Cloud](https://lobu.ai/deployment/cloud/): Managed deployment with no infrastructure to run
-- [Docker](https://lobu.ai/deployment/docker/): Run the Lobu app container on a single host
-- [Kubernetes](https://lobu.ai/deployment/kubernetes/): Deploy Lobu with the public Helm chart
-- [Getting started](https://lobu.ai/getting-started/): Boot Lobu locally with `lobu run`
-- [Architecture](https://lobu.ai/guides/architecture/): Embedded gateway + worker deployment model
-
-## Messaging platforms
-
-- [Slack](https://lobu.ai/platforms/slack/)
-- [Telegram](https://lobu.ai/platforms/telegram/)
-- [WhatsApp](https://lobu.ai/platforms/whatsapp/)
-- [Discord](https://lobu.ai/platforms/discord/)
-- [Microsoft Teams](https://lobu.ai/platforms/teams/)
-- [Google Chat](https://lobu.ai/platforms/google-chat/)
-- [REST API](https://lobu.ai/platforms/rest-api/)
 
 ## Connect external agents
 
-- [ChatGPT](https://lobu.ai/connect-from/chatgpt/)
 - [Claude](https://lobu.ai/connect-from/claude/)
+- [ChatGPT](https://lobu.ai/connect-from/chatgpt/)
 - [OpenClaw](https://lobu.ai/connect-from/openclaw/)
 
 ## Reference
 
-- [API reference](https://lobu.ai/reference/api-reference/)
-- [lobu.config.ts](https://lobu.ai/reference/lobu-config/)
-- [SKILL.md](https://lobu.ai/reference/skill-md/)
-- [Providers](https://lobu.ai/reference/providers/)
 - [CLI](https://lobu.ai/reference/cli/)
-- [Lobu memory CLI](https://lobu.ai/reference/lobu-memory/)
+- [lobu.config.ts](https://lobu.ai/reference/lobu-config/)
+- [REST API reference](https://lobu.ai/reference/api-reference/)
 
-## Project
+## Optional
 
 - [GitHub](https://github.com/lobu-ai/lobu)
-- [Blog](https://lobu.ai/blog/)
 - [Privacy](https://lobu.ai/privacy/)
 - [Terms](https://lobu.ai/terms/)

--- a/packages/landing/public/llms.txt
+++ b/packages/landing/public/llms.txt
@@ -1,29 +1,31 @@
 # Lobu
 
-> Open-source backend for multi-user AI agents with isolated workers, per-user OAuth, connected sources, shared memory, and secrets agents never see. Self-hosted Lobu runs as a single Node process and uses Postgres with pgvector as the only required external service.
+> Open-source infrastructure for AI teammates that watch, remember, and act. Connectors and webhooks build a live org knowledge graph in an append-only log; agents look it up and branch into isolated sandboxes to do work. Self-hosted Lobu runs as a single Node process with embedded Postgres (or BYO Postgres + pgvector).
 
 ## Start here
 
-- [Home](https://lobu.ai/): Product overview, memory, skills, platforms, and architecture
+- [Home](https://lobu.ai/): Product overview, memory pipeline, skills, platforms
 - [Getting started](https://lobu.ai/getting-started/): Install and run your first agent
-- [Comparison](https://lobu.ai/getting-started/comparison/): How Lobu compares to other agent platforms
+- [Comparison](https://lobu.ai/getting-started/comparison/): Lobu vs OpenClaw, Claude Tag, and others
 - [Serverless OpenClaw](https://lobu.ai/serverless-openclaw/): Managed runtime and usage-based billing
 
 ## Core concepts
 
 - [Skills](https://lobu.ai/getting-started/skills/): Reusable agent capabilities via SKILL.md
-- [Memory](https://lobu.ai/getting-started/memory/): Persistent typed memory for agents
+- [Memory](https://lobu.ai/getting-started/memory/): Connectors, entities, watchers, append-only org memory
+- [Connectors](https://lobu.ai/sdks/connectors/): Ingest APIs, webhooks, and files into the event stream
+- [Reactions](https://lobu.ai/sdks/reactions/): Act after a watcher extracts data
 - [Architecture](https://lobu.ai/guides/architecture/): Gateway, workers, proxy, and sandboxing model
 - [Security](https://lobu.ai/guides/security/): Sandboxing, network policy, and credential isolation
+- [Guardrails](https://lobu.ai/guides/guardrails/): Input, output, and pre-tool policy checks
 - [Tool policy](https://lobu.ai/guides/tool-policy/): Approval model for destructive MCP tools
 
 ## Deployment
 
+- [Getting started](https://lobu.ai/getting-started/): Boot Lobu locally with `lobu run`
 - [Lobu Cloud](https://lobu.ai/deployment/cloud/): Managed deployment with no infrastructure to run
 - [Docker](https://lobu.ai/deployment/docker/): Run the Lobu app container on a single host
 - [Kubernetes](https://lobu.ai/deployment/kubernetes/): Deploy Lobu with the public Helm chart
-- [Getting started](https://lobu.ai/getting-started/): Boot Lobu locally with `lobu run`
-- [Architecture](https://lobu.ai/guides/architecture/): Embedded gateway + worker deployment model
 
 ## Messaging platforms
 
@@ -37,8 +39,8 @@
 
 ## Connect external agents
 
+- [Claude](https://lobu.ai/connect-from/claude/): Claude Code, Desktop, claude.ai via MCP
 - [ChatGPT](https://lobu.ai/connect-from/chatgpt/)
-- [Claude](https://lobu.ai/connect-from/claude/)
 - [OpenClaw](https://lobu.ai/connect-from/openclaw/)
 
 ## Reference
@@ -63,6 +65,7 @@
 
 ## Blog
 
+- [The agent loop is the new SaaS](https://lobu.ai/blog/the-agent-loop-is-the-new-saas/)
 - [Filesystem vs database agent memory](https://lobu.ai/blog/filesystem-vs-database-agent-memory/)
 - [MCP is overengineered, skills are too primitive](https://lobu.ai/blog/mcp-is-overengineered-skills-are-too-primitive/)
 - [Introducing Lobu](https://lobu.ai/blog/hello-world/)

--- a/packages/landing/src/components/LandingPage.tsx
+++ b/packages/landing/src/components/LandingPage.tsx
@@ -69,6 +69,8 @@ Repo: https://github.com/lobu-ai/lobu. Docs: https://lobu.ai/getting-started/`;
 
 // The canonical "test it" command, kept in sync with InstallSection.
 const QUICKSTART_CMD = "npx @lobu/cli@latest init my-agent";
+const CLAUDE_MCP_CMD =
+  "claude mcp add --transport http lobu https://lobu.ai/mcp";
 
 export function LandingPage(props: {
   latestPosts?: LatestBlogPost[];
@@ -183,12 +185,16 @@ function SectionHeading(props: {
 function Hero() {
   // Tracks which of the two copy actions fired last, so each shows its own
   // confirmation: the quickstart command (primary) or the setup prompt (sub).
-  const [copied, setCopied] = useState<"cmd" | "prompt" | null>(null);
+  const [copied, setCopied] = useState<"cmd" | "mcp" | "prompt" | null>(null);
 
-  const copy = async (which: "cmd" | "prompt") => {
+  const copy = async (which: "cmd" | "mcp" | "prompt") => {
     try {
       await navigator.clipboard.writeText(
-        which === "cmd" ? QUICKSTART_CMD : SETUP_PROMPT
+        which === "cmd"
+          ? QUICKSTART_CMD
+          : which === "mcp"
+            ? CLAUDE_MCP_CMD
+            : SETUP_PROMPT
       );
       setCopied(which);
       window.setTimeout(() => setCopied(null), 2200);
@@ -217,9 +223,9 @@ function Hero() {
           class="hero-rise hero-rise-2 mx-auto mt-5 max-w-[44rem] text-[17px] leading-[1.55]"
           style={{ color: "var(--color-page-text-muted)" }}
         >
-          Open-source infrastructure for multi-tenant AI agents: sandboxed
-          execution, shared memory, and an SDK that pulls live company data and
-          acts on your high-level goals.
+          Open-source infrastructure for AI teammates that watch, remember,
+          and act. Connectors and webhooks build a live org knowledge graph;
+          agents look it up and branch into a sandbox to do work.
         </p>
         <div class="hero-rise hero-rise-3 mt-8 flex flex-wrap items-center justify-center gap-3">
           <button
@@ -280,6 +286,33 @@ function Hero() {
             <CopyIcon copied={copied === "cmd"} />
           </button>
           {copied === "cmd" ? <span>copied</span> : null}
+        </p>
+        <p
+          class="hero-rise hero-rise-4 mt-2.5 flex flex-wrap items-center justify-center gap-2 text-[13px]"
+          style={{ color: "var(--color-page-text-muted)" }}
+        >
+          Or plug memory into Claude Code:
+          <button
+            type="button"
+            class="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 font-mono text-[12.5px] transition-colors hover:border-[color:var(--color-tg-accent)]"
+            onClick={() => copy("mcp")}
+            style={{
+              borderColor: "var(--color-page-border)",
+              color: "var(--color-page-text)",
+            }}
+          >
+            <span style={{ opacity: 0.5 }}>$</span>
+            {CLAUDE_MCP_CMD}
+            <CopyIcon copied={copied === "mcp"} />
+          </button>
+          {copied === "mcp" ? <span>copied</span> : null}
+          <a
+            href="/connect-from/claude/"
+            class="font-medium transition-colors hover:text-[color:var(--color-tg-accent)]"
+            style={{ color: "var(--color-page-text-muted)" }}
+          >
+            Setup docs →
+          </a>
         </p>
       </Container>
     </section>
@@ -776,9 +809,10 @@ function RunAnywhereSection() {
     {
       eyebrow: "Self-host",
       title: "Run in your cloud.",
-      body: "Deploy with Docker or Helm when data and controls need to stay with you.",
+      body: "Docker, cloud VM, or Kubernetes when data and controls need to stay with you.",
       links: [
-        { label: "Docker", href: "/deployment/docker/" },
+        { label: "Deployment docs", href: "/deployment/docker/" },
+        { label: "Cloud", href: "/deployment/cloud/" },
         { label: "Kubernetes", href: "/deployment/kubernetes/" },
       ],
     },

--- a/packages/landing/src/components/LandingPage.tsx
+++ b/packages/landing/src/components/LandingPage.tsx
@@ -223,9 +223,9 @@ function Hero() {
           class="hero-rise hero-rise-2 mx-auto mt-5 max-w-[44rem] text-[17px] leading-[1.55]"
           style={{ color: "var(--color-page-text-muted)" }}
         >
-          Open-source infrastructure for AI teammates that watch, remember,
-          and act. Connectors and webhooks build a live org knowledge graph;
-          agents look it up and branch into a sandbox to do work.
+          Open-source infrastructure for AI teammates that watch, remember, and
+          act. Connectors and webhooks build a live org knowledge graph; agents
+          look it up and branch into a sandbox to do work.
         </p>
         <div class="hero-rise hero-rise-3 mt-8 flex flex-wrap items-center justify-center gap-3">
           <button

--- a/packages/landing/src/components/Nav.tsx
+++ b/packages/landing/src/components/Nav.tsx
@@ -26,6 +26,39 @@ type MegaMenu = {
   widthRem: number;
 };
 
+const CONNECT_MENU: MegaMenu = {
+  id: "connect",
+  label: "Connect",
+  width: "min(28rem, calc(100vw - 2rem))",
+  widthRem: 28,
+  columns: [
+    {
+      heading: "MEMORY FOR",
+      variant: "rich",
+      links: [
+        {
+          label: "Claude",
+          description: "Claude Code, Desktop, and claude.ai via MCP",
+          href: "/connect-from/claude/",
+          emoji: "✳️",
+        },
+        {
+          label: "ChatGPT",
+          description: "Org-scoped memory through one MCP endpoint",
+          href: "/connect-from/chatgpt/",
+          emoji: "💬",
+        },
+        {
+          label: "OpenClaw",
+          description: "Shared entity memory across OpenClaw agents",
+          href: "/connect-from/openclaw/",
+          emoji: "🦞",
+        },
+      ],
+    },
+  ],
+};
+
 const RESOURCES_MENU: MegaMenu = {
   id: "resources",
   label: "Resources",
@@ -307,6 +340,11 @@ export function Nav({ currentPath: _currentPath = "/" }: NavProps) {
             >
               Docs
             </a>
+            <MegaMenuTrigger
+              menu={CONNECT_MENU}
+              openId={openId}
+              setOpenId={setOpenId}
+            />
             <MegaMenuTrigger
               menu={RESOURCES_MENU}
               openId={openId}

--- a/packages/landing/src/components/ProactiveLoop.tsx
+++ b/packages/landing/src/components/ProactiveLoop.tsx
@@ -710,7 +710,7 @@ export const SALES_LOOP: LoopData = {
     eyebrow: "Why Lobu",
     title: "Catch what you'd miss.",
     subtitle:
-      "Connect your data. Set a goal. Lobu watches for changes and prepares the next step.",
+      "Most stacks make agents call MCP every turn to reconstruct state. Lobu ingests connectors and webhooks into one append-only log first — so agents resume where the org left off.",
   },
   connectors: {
     items: [

--- a/packages/landing/src/components/connect-from/ConnectFromDocContent.astro
+++ b/packages/landing/src/components/connect-from/ConnectFromDocContent.astro
@@ -55,6 +55,10 @@ const relatedLinks = client.docsRelated.map((link) => {
 });
 ---
 
+{client.docsPipelineNote.map((paragraph) => (
+  <p>{paragraph}</p>
+))}
+
 <p>{client.valueProp}</p>
 
 <TryItSection

--- a/packages/landing/src/connect-from-config.ts
+++ b/packages/landing/src/connect-from-config.ts
@@ -24,6 +24,8 @@ type ConnectFromClientConfig = {
   label: string;
   docsHref: string;
   docsLabel: string;
+  /** Shown above the value prop: MCP-as-memory vs Lobu's ingest pipeline. */
+  docsPipelineNote: string[];
   /**
    * One-liner shown directly under the page title that explains what Lobu
    * adds to this agent.
@@ -50,6 +52,11 @@ const mcpClientDescribe =
   (label: string) => (showcase: LandingUseCaseShowcase) =>
     `Use ${label} with the ${showcase.label.toLowerCase()} workspace so it can use the same org-scoped memory, sources, and tools shown here.`;
 
+const MCP_PIPELINE_NOTE = [
+  "Most agent setups treat MCP as the memory: every turn, the agent calls GitHub or Slack tools to reconstruct what happened. That knowledge stays siloed in the session.",
+  "Lobu runs a data pipeline instead. Connectors poll and webhooks push into one append-only org log; watchers and chat agents share the same knowledge graph. MCP here is for recall and write — ingestion still flows through connectors and webhooks.",
+];
+
 const connectFromClientConfigs: Record<
   ConnectFromClientId,
   ConnectFromClientConfig
@@ -59,6 +66,7 @@ const connectFromClientConfigs: Record<
     label: "ChatGPT",
     docsHref: "/connect-from/chatgpt/",
     docsLabel: "ChatGPT setup docs",
+    docsPipelineNote: MCP_PIPELINE_NOTE,
     valueProp:
       "Add structured, queryable long-term memory to ChatGPT, the same graph other agents share, recalled and updated through one MCP endpoint.",
     installPrompt:
@@ -83,6 +91,7 @@ const connectFromClientConfigs: Record<
     label: "Claude",
     docsHref: "/connect-from/claude/",
     docsLabel: "Claude setup docs",
+    docsPipelineNote: MCP_PIPELINE_NOTE,
     valueProp:
       "Give Claude durable, structured memory it can search and append to, so the same recall is available across Claude, ChatGPT, and your own agents.",
     installPrompt:
@@ -115,6 +124,10 @@ const connectFromClientConfigs: Record<
     label: "OpenClaw",
     docsHref: "/connect-from/openclaw/",
     docsLabel: "OpenClaw setup docs",
+    docsPipelineNote: [
+      ...MCP_PIPELINE_NOTE,
+      "The OpenClaw plugin layers this graph on top of filesystem memory so multiple OpenClaw agents converge on the same entities instead of separate notebooks.",
+    ],
     valueProp:
       "Layer structured, shareable Lobu memory on top of OpenClaw's built-in filesystem memory. The plugin extends OpenClaw's filesystem plugin and can optionally take over its memory slot, so different OpenClaw agents can talk to each other through the same Lobu graph.",
     installPrompt:

--- a/packages/landing/src/content/docs/getting-started/comparison.md
+++ b/packages/landing/src/content/docs/getting-started/comparison.md
@@ -3,17 +3,17 @@ title: Comparison
 description: How Lobu compares to other agent deployment options.
 ---
 
-Lobu is the open-source backend for multi-user AI agents. It handles isolation, per-user OAuth, connected sources, shared memory, and platform delivery so you can ship agents without rebuilding that plumbing.
+Lobu is the open-source backend for AI teammates that watch, remember, and act. Connectors and webhooks build a live org knowledge graph; agents look it up and branch into a sandbox to do work — with per-channel isolation, OAuth, and credentials agents never see.
 
-This page compares Lobu against other ways to run agents for multiple users.
+This page compares Lobu against other ways to run agents for multiple users, including [Claude Tag](https://www.anthropic.com/news/introducing-claude-tag) (@Claude in Slack).
 
 ## At a glance
 
-| | Lobu | OpenClaw (direct) | DeepAgents Deploy | Claude Managed Agents |
+| | Lobu | OpenClaw (direct) | DeepAgents Deploy | Claude Tag |
 |---|---|---|---|---|
-| **What it is** | Open-source backend for multi-user agents | Single-user agent runtime | Hosted agent deployment (LangSmith) | Hosted managed agents |
-| **Multi-tenant** | Per-user/channel isolation | Single user | Per-thread sandbox | Per-conversation |
-| **Platforms** | Slack, Telegram, WhatsApp, Discord, Teams, Google Chat, REST API | CLI and API | API endpoints (MCP, A2A, Agent Protocol) | API |
+| **What it is** | Open-source backend for multi-user agents | Single-tenant agent runtime | Hosted agent deployment (LangSmith) | @Claude in Slack (team agents, beta) |
+| **Multi-tenant** | Per-user/channel isolation | Single-tenant — shared filesystem | Per-thread sandbox | Per-channel @Claude |
+| **Platforms** | Slack, Telegram, WhatsApp, Discord, Teams, Google Chat, REST API, MCP | CLI and API | API endpoints (MCP, A2A, Agent Protocol) | Slack (beta) |
 | **Embeddable** | Mount inside Next.js, Express, Hono, Fastify | No | No | No |
 | **Self-hosted** | Single Node process (embedded Postgres, or BYO Postgres) | Single process | LangSmith hosted (self-host option) | Cloud only |
 | **Model support** | Any provider via config | Any provider | Any LangChain-compatible provider | Anthropic only |
@@ -23,7 +23,8 @@ This page compares Lobu against other ways to run agents for multiple users.
 | **MCP support** | Proxied through gateway with secret injection | Direct | HTTP/SSE only | Yes |
 | **Agent Protocol / A2A** | Not yet | No | Yes | No |
 | **Built-in evals** | YAML eval framework with model comparison | No | No | No |
-| **Memory** | Self-hosted Lobu plugin | Local | LangSmith APIs | Platform-managed |
+| **Memory** | Append-only org graph (connectors, entities, watchers) | Local filesystem | LangSmith APIs | Channel-scoped, admin-provisioned |
+| **Custom connectors / watchers** | Yes (`lobu.config.ts`) | Skills + local setup | Limited | Admin-provisioned tools only |
 | **Worker lifecycle** | Persistent subprocess per channel; reaped on config change / shutdown | Always running | Managed by LangSmith | Managed |
 | **Config format** | `lobu.config.ts` (TypeScript) + IDENTITY/SOUL/USER.md | CLI flags | `deepagents.toml` + AGENTS.md | Dashboard |
 | **License** | Open source | Open source | MIT (harness), proprietary (hosting) | Proprietary |
@@ -82,7 +83,7 @@ Uses [just-bash](https://www.npmjs.com/package/just-bash) (virtual bash) + **Nix
 
 Workers call MCP tools through the gateway. The gateway resolves `${env:VAR}` secrets and injects OAuth tokens before forwarding to the upstream MCP server. Workers never see credentials — they receive opaque proxy URLs.
 
-| | Lobu | DeepAgents Deploy | Claude Managed Agents | Direct MCP |
+| | Lobu | DeepAgents Deploy | Claude Tag | Direct MCP |
 |---|---|---|---|---|
 | Secret injection | Gateway proxy resolves at request time | Environment variables | Platform-managed | Direct env vars |
 | OAuth management | Lobu handles token refresh | Manual | Platform-managed | Manual |
@@ -94,7 +95,7 @@ For compliance-bound deployments, agent code never touches API keys or OAuth tok
 
 ## Why Lobu for on-premise
 
-Hosted platforms (DeepAgents Deploy, Claude Managed Agents) require sending your data, prompts, and agent memory to a third party. For regulated industries (finance, healthcare, government) or organizations with data residency requirements, this is a non-starter.
+Hosted platforms (DeepAgents Deploy, Claude Tag) require sending your data, prompts, and agent memory to a third party. For regulated industries (finance, healthcare, government) or organizations with data residency requirements, this is a non-starter.
 
 Lobu runs entirely on your infrastructure:
 - **Data stays in your network** — Postgres, workspaces, and memory are all self-hosted
@@ -157,21 +158,26 @@ Inside each Lobu worker, the full OpenClaw runtime runs untouched. Lobu rewrites
 
 **Choose Lobu** if you need multi-tenant isolation for your users, platform-native messaging, embeddability in your app, or full infrastructure control.
 
-## Lobu vs Claude Managed Agents
+## Lobu vs Claude Tag
 
-Claude Managed Agents is Anthropic's hosted agent platform.
+[Claude Tag](https://www.anthropic.com/news/introducing-claude-tag) is Anthropic's @Claude in Slack: multiplayer team agents with channel memory, managed connectors, and async tasks. It validates the category Lobu has been building — but Lobu is the open-source path to run your own.
 
-| | Lobu | Claude Managed Agents |
+| | Lobu | Claude Tag |
 |---|---|---|
-| Model support | Any provider | Anthropic only |
-| Self-hosted | Yes | Cloud only |
+| Tenancy | Multi-tenant — per-channel/DM sandbox isolation | Per-channel @Claude |
+| Model support | Any provider (16 via config) | Claude only |
+| Self-hosted | Yes | Cloud only (Enterprise / Team) |
 | Open source | Yes | Proprietary |
-| Platform delivery | Slack, Telegram, WhatsApp, Discord, Teams, Google Chat | API |
+| Platform delivery | Slack, Telegram, WhatsApp, Discord, Teams, Google Chat, REST API, MCP | Slack (beta) |
+| Data pipeline | Connectors, webhooks, append-only org log | Admin-provisioned connectors |
+| Custom watchers / reactions | Yes (`lobu.config.ts`) | Not user-configurable |
 | Embeddable | Yes | No |
-| Network isolation | Domain-filtered egress | Platform-managed |
+| Network isolation | Domain-filtered egress, gateway proxy | Platform-managed |
 | Evals | Built-in | Not included |
 
-**Choose Claude Managed Agents** if you're committed to Anthropic models and want a fully managed experience.
+**Choose Claude Tag** if you want a fully managed @Claude in Slack on Claude Enterprise or Team and don't need self-hosting, multi-platform delivery, or custom ingest/watchers.
+
+**Choose Lobu** if you want to build your own team agents — your bot, your data, your connectors, any model — or layer org memory into Claude Code via MCP on the same graph your Slack agents use.
 
 **Choose Lobu** if you need model flexibility, self-hosting, platform delivery, or the ability to embed agents in your product.
 


### PR DESCRIPTION
## Summary

Align GitHub and lobu.ai on the same product story for the Claude Tag moment.

### README
- Benefit-led headline; OpenClaw as under-the-hood detail, not the product name
- Dual entry: full agent (`lobu run`) vs Claude Code memory (`claude mcp add`)
- Capabilities: ingest → entities → watchers vs siloed MCP-as-memory; agents sandbox/guardrails/append-only memory
- Claude Tag comparison row; deployment deferred to docs links

### Landing (lobu.ai)
- Hero subline: watch, remember, act + knowledge graph framing
- Claude Code MCP copy chip + link to `/connect-from/claude/`
- ProactiveLoop subtitle: MCP-every-turn vs append-only org log
- **Connect** nav menu (Claude · ChatGPT · OpenClaw)
- Connect-from docs: pipeline vs MCP intro paragraphs
- Comparison page: Claude Tag (replaces Claude Managed Agents)
- `llms.txt` + `public/index.md` synced to new voice
- Run anywhere: deployment docs link first; K8s demoted to a link

## Still TODO (follow-up)
- Replace hero demo video on README (still old CLI recording); add to homepage when recorded

## Test plan
- [x] `cd packages/landing && bun run build`
- [ ] Visual check homepage hero + Connect nav + comparison page after deploy