### PR TITLE
docs(readme): consolidate Security and Privacy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,12 @@ The quick start above is the fastest path. For production self-hosting, see the 
 
 ## Security and Privacy
 
-- [**Network isolation**](https://lobu.ai/guides/security/#network-isolation) — workers route egress through the gateway proxy with allowlist/blocklist + LLM egress judge.
-- [**Secrets stay in gateway**](https://lobu.ai/guides/secret-proxy/) — provider credentials and OAuth live in Lobu; workers never see real keys.
-- [**Threat model**](https://lobu.ai/guides/security/) — `just-bash` and `isolated-vm` are policy + best-effort sandboxes, not security boundaries for hostile code.
+Secrets, egress policy, and MCP credential injection stay on the gateway; each worker runs in an isolated sandbox per channel or DM. Guides: [Security](https://lobu.ai/guides/security/) · [Secret proxy](https://lobu.ai/guides/secret-proxy/) · [Guardrails](https://lobu.ai/guides/guardrails/) · [threat model](docs/SECURITY.md).
+
+- [**Worker egress through the gateway proxy**](https://lobu.ai/guides/security/#network-isolation) — `HTTP_PROXY=http://localhost:8118` with domain allowlist/blocklist and an optional [LLM egress judge](https://lobu.ai/guides/egress-judge/) for ambiguous hosts. On Linux production, worker spawn uses `systemd-run --user --scope` with `IPAddressDeny=any` to enforce egress at the kernel; on macOS dev the proxy is best-effort.
+- [**Secrets stay in the gateway**](https://lobu.ai/guides/secret-proxy/) — provider credentials and `${env:}` substitution; OAuth and MCP tokens live in Lobu. Workers get opaque placeholders; the secret proxy swaps real values at egress. Workers never see API keys or refresh tokens.
+- [**Threat model**](https://lobu.ai/guides/security/) — `just-bash` and `isolated-vm` are policy + best-effort sandboxes, not security boundaries for hostile code. Read [docs/SECURITY.md](docs/SECURITY.md) before exposing Lobu to untrusted users.
+- [**Nix system packages**](docs/SECURITY.md#skills-and-policy) — per-agent reproducible tooling and skill policy via `runtime.nix.packages` and `lobu.config.ts`.
 
 ## Support & Consultancy
 


### PR DESCRIPTION
Restore the full security bullets from the old README (egress, secrets, threat model, Nix) with links to lobu.ai guides and docs/SECURITY.md.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784848844&installation_id=136316292&pr_number=1527&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1527&signature=578ec5d7cfce2d006c69eece42c412ac0b0547eb224736d7bfbaea7e9e88b465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->