### PR TITLE
feat(server): wire entity_types filter for Memory page

### DIFF
--- a/packages/server/src/__tests__/integration/events/get-content-entity-types-filter.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-entity-types-filter.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Integration test: org-wide `entity_types` filter on read_knowledge listings.
+ *
+ * Memory page sends `entity_types` without `entity_id`. The filter should keep
+ * only events whose `entity_ids` overlap entities whose type slug is selected.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getContent } from '../../../tools/get_content';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('getContent > org-wide entity_types filter', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let personEntity: Awaited<ReturnType<typeof createTestEntity>>;
+  let companyEntity: Awaited<ReturnType<typeof createTestEntity>>;
+  let personEventId: number;
+  let companyEventId: number;
+  let unlinkedEventId: number;
+
+  function authedCtx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    };
+  }
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Entity Types Filter Org' });
+    user = await createTestUser({ email: 'entity-types-filter@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    personEntity = await createTestEntity({
+      name: 'Alice',
+      entity_type: 'person',
+      organization_id: org.id,
+    });
+    companyEntity = await createTestEntity({
+      name: 'Acme Corp',
+      entity_type: 'company',
+      organization_id: org.id,
+    });
+
+    personEventId = (
+      await createTestEvent({
+        entity_ids: [personEntity.id],
+        content: 'Person-linked event',
+        organization_id: org.id,
+      })
+    ).id;
+    companyEventId = (
+      await createTestEvent({
+        entity_ids: [companyEntity.id],
+        content: 'Company-linked event',
+        organization_id: org.id,
+      })
+    ).id;
+    unlinkedEventId = (
+      await createTestEvent({
+        entity_ids: [],
+        content: 'Unlinked org event',
+        organization_id: org.id,
+      })
+    ).id;
+  });
+
+  it('returns only events linked to entities of the selected type slugs', async () => {
+    const result = await getContent(
+      {
+        entity_types: ['person'],
+        sort_by: 'date',
+        sort_order: 'desc',
+        limit: 50,
+      },
+      {} as never,
+      authedCtx()
+    );
+
+    const ids = result.content.map((row) => row.id);
+    expect(ids).toContain(personEventId);
+    expect(ids).not.toContain(companyEventId);
+    expect(ids).not.toContain(unlinkedEventId);
+  });
+
+  it('matches any of multiple selected entity type slugs', async () => {
+    const result = await getContent(
+      {
+        entity_types: ['person', 'company'],
+        sort_by: 'date',
+        sort_order: 'desc',
+        limit: 50,
+      },
+      {} as never,
+      authedCtx()
+    );
+
+    const ids = result.content.map((row) => row.id);
+    expect(ids).toContain(personEventId);
+    expect(ids).toContain(companyEventId);
+    expect(ids).not.toContain(unlinkedEventId);
+  });
+
+  it('ignores entity_types when entity_id is set (entity-scoped mode)', async () => {
+    const result = await getContent(
+      {
+        entity_id: companyEntity.id,
+        entity_types: ['person'],
+        sort_by: 'date',
+        sort_order: 'desc',
+        limit: 50,
+      },
+      {} as never,
+      authedCtx()
+    );
+
+    const ids = result.content.map((row) => row.id);
+    expect(ids).toContain(companyEventId);
+    expect(ids).not.toContain(personEventId);
+  });
+});

--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -379,6 +379,15 @@ function parseIdListParam(raw: string | undefined): number[] | undefined {
 	return ids.length > 0 ? ids : undefined;
 }
 
+function parseStringListParam(raw: string | undefined): string[] | undefined {
+	if (!raw) return undefined;
+	const values = raw
+		.split(",")
+		.map((value) => value.trim())
+		.filter((value) => value.length > 0);
+	return values.length > 0 ? values : undefined;
+}
+
 export async function restSearchKnowledge(c: Context<{ Bindings: Env }>) {
 	try {
 		const query = c.req.query("query");
@@ -420,6 +429,7 @@ export async function restSearchKnowledge(c: Context<{ Bindings: Env }>) {
 			after_occurred_at: c.req.query("after_occurred_at") || undefined,
 			after_id: safeParseInt(c.req.query("after_id"), { min: 1 }),
 			interaction_status: c.req.query("interaction_status") || undefined,
+			entity_types: parseStringListParam(c.req.query("entity_types")),
 		};
 
 		const ctx = toToolContext(extractAuthContext(c));
@@ -497,6 +507,7 @@ export async function publicRestSearchKnowledge(c: Context<{ Bindings: Env }>) {
 			after_occurred_at: c.req.query("after_occurred_at") || undefined,
 			after_id: safeParseInt(c.req.query("after_id"), { min: 1 }),
 			interaction_status: c.req.query("interaction_status") || undefined,
+			entity_types: parseStringListParam(c.req.query("entity_types")),
 		};
 
 		return getContent(

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -324,6 +324,7 @@ async function getContentImpl(
         classification_filters: classificationFilters,
         classification_source: args.classification_source,
         semantic_type: args.semantic_type,
+        entity_types: args.entity_types,
         interaction_status: args.interaction_status,
         limit,
         offset,

--- a/packages/server/src/tools/get_content/schema.ts
+++ b/packages/server/src/tools/get_content/schema.ts
@@ -201,6 +201,12 @@ export const GetContentSchema = Type.Object({
       }
     )
   ),
+  entity_types: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        'Org-wide filter: limit to events linked to entities whose type slug is in this list. Ignored when entity_id is set.',
+    })
+  ),
   interaction_status: Type.Optional(
     Type.Union(
       [

--- a/packages/server/src/utils/content-search/__tests__/entity-types-filter.test.ts
+++ b/packages/server/src/utils/content-search/__tests__/entity-types-filter.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { buildEntityTypesFilterClause } from '../entity-types-filter';
+
+describe('buildEntityTypesFilterClause', () => {
+  it('returns empty fragment when entity_types is absent', () => {
+    const result = buildEntityTypesFilterClause({
+      organization_id: 'org-1',
+      baseParamIndex: 3,
+    });
+    expect(result).toEqual({ sql: '', predicate: '', params: [] });
+  });
+
+  it('returns empty fragment when organization_id is absent', () => {
+    const result = buildEntityTypesFilterClause({
+      entity_types: ['person'],
+      baseParamIndex: 3,
+    });
+    expect(result).toEqual({ sql: '', predicate: '', params: [] });
+  });
+
+  it('builds overlap predicate against entities of matching type slugs', () => {
+    const result = buildEntityTypesFilterClause({
+      entity_types: ['person', 'company'],
+      organization_id: 'org-abc',
+      baseParamIndex: 5,
+    });
+
+    expect(result.params).toEqual(['org-abc', '{"person","company"}']);
+    expect(result.sql).toContain('f.entity_ids &&');
+    expect(result.sql).toContain('$5::text');
+    expect(result.sql).toContain('$6::text[]');
+    expect(result.predicate).toContain('et.slug = ANY($6::text[])');
+    expect(result.predicate).toContain('e.organization_id = $5::text');
+  });
+});

--- a/packages/server/src/utils/content-search/entity-types-filter.ts
+++ b/packages/server/src/utils/content-search/entity-types-filter.ts
@@ -1,0 +1,31 @@
+/**
+ * Org-wide event filter: limit to events linked to entities of given type slugs.
+ */
+
+import { pgTextArray } from '../../db/client';
+
+export function buildEntityTypesFilterClause(options: {
+  entity_types?: string[];
+  organization_id?: string;
+  baseParamIndex: number;
+}): { sql: string; predicate: string; params: unknown[] } {
+  if (!options.entity_types?.length || !options.organization_id) {
+    return { sql: '', predicate: '', params: [] };
+  }
+
+  const orgParam = `$${options.baseParamIndex}::text`;
+  const typesParam = `$${options.baseParamIndex + 1}::text[]`;
+
+  const predicate = `f.entity_ids && (
+      SELECT COALESCE(array_agg(e.id), ARRAY[]::bigint[])
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.organization_id = ${orgParam} AND et.slug = ANY(${typesParam})
+    )`;
+
+  return {
+    sql: ` AND ${predicate}`,
+    predicate,
+    params: [options.organization_id, pgTextArray(options.entity_types)],
+  };
+}

--- a/packages/server/src/utils/content-search/list-path.ts
+++ b/packages/server/src/utils/content-search/list-path.ts
@@ -31,6 +31,7 @@ import {
   type ContentSearchResponse,
   type ContentSearchResult,
 } from './types';
+import { buildEntityTypesFilterClause } from './entity-types-filter';
 import { buildConnectionVisibilityClause, buildExcludeWatcherClause, buildOrgScopeWhere } from './visibility';
 import { buildStandardParams, buildStandardWhereSql, WINDOW_JOIN_SQL } from './params';
 
@@ -345,12 +346,21 @@ export async function listContentInternal(
       userId: options.visibility_scope?.userId ?? null,
       baseParamIndex: filterParamsBeforeVisibility.length + 1,
     });
-    const allFilterParams = [...filterParamsBeforeVisibility, ...visibilityClause.params];
+    const filterParamsBeforeEntityTypes = [
+      ...filterParamsBeforeVisibility,
+      ...visibilityClause.params,
+    ];
+    const entityTypesClause = buildEntityTypesFilterClause({
+      entity_types: options.entity_types,
+      organization_id: organizationId,
+      baseParamIndex: filterParamsBeforeEntityTypes.length + 1,
+    });
+    const allFilterParams = [...filterParamsBeforeEntityTypes, ...entityTypesClause.params];
 
     return executeListQuery({
       sql,
       joinSql: '',
-      whereExpr: `${whereSql} ${excludeClause.sql} ${visibilityClause.sql}`,
+      whereExpr: `${whereSql} ${excludeClause.sql} ${visibilityClause.sql}${entityTypesClause.sql}`,
       countParams: allFilterParams,
       threadEntityLinkSqlForP: threadEntityLinkSql,
       needClassifications,
@@ -419,7 +429,13 @@ export async function listContentInternal(
     userId: options.visibility_scope?.userId ?? null,
     baseParamIndex: paramsBeforeVisibility.length + 1,
   });
-  const countParams = [...paramsBeforeVisibility, ...visibilityClause.params];
+  const paramsBeforeEntityTypes = [...paramsBeforeVisibility, ...visibilityClause.params];
+  const entityTypesClause = buildEntityTypesFilterClause({
+    entity_types: options.entity_types,
+    organization_id: organizationId,
+    baseParamIndex: paramsBeforeEntityTypes.length + 1,
+  });
+  const countParams = [...paramsBeforeEntityTypes, ...entityTypesClause.params];
 
   return executeListQuery({
     sql,
@@ -430,7 +446,7 @@ export async function listContentInternal(
           AND ${runCondition}
           ${excludeClause.sql}
           ${visibilityClause.sql}
-          ${orgScope.sql}`,
+          ${orgScope.sql}${entityTypesClause.sql}`,
     countParams,
     threadEntityLinkSqlForP: standardEntityLinkSqlForP,
     needClassifications,

--- a/packages/server/src/utils/content-search/search-path.ts
+++ b/packages/server/src/utils/content-search/search-path.ts
@@ -30,6 +30,7 @@ import {
   type ContentSearchResponse,
   type ContentSearchResult,
 } from './types';
+import { buildEntityTypesFilterClause } from './entity-types-filter';
 import { buildConnectionVisibilityClause, buildExcludeWatcherClause, buildOrgScopeWhere } from './visibility';
 import { getErrorMessage } from "@lobu/core";
 
@@ -118,7 +119,13 @@ export async function searchContentBySingleQuery(
     userId: options.visibility_scope?.userId ?? null,
     baseParamIndex: visibilityParamIdx,
   });
-  const entityLinkParamIdx = visibilityParamIdx + visibilityClause.params.length;
+  const entityTypesParamIdx = visibilityParamIdx + visibilityClause.params.length;
+  const entityTypesClause = buildEntityTypesFilterClause({
+    entity_types: options.entity_types,
+    organization_id: options.organization_id,
+    baseParamIndex: entityTypesParamIdx,
+  });
+  const entityLinkParamIdx = entityTypesParamIdx + entityTypesClause.params.length;
   // Build entity-link UNION (alias `f` for filtered_ids; alias `p` for thread
   // walk). Params slot after visibility, before vector/min_similarity.
   let searchEntityLinkSql: string;
@@ -166,7 +173,7 @@ export async function searchContentBySingleQuery(
           AND ($11::text IS NULL OR f.metadata->>'agent_id' = $11::text)
           ${excludeClause.sql}
           ${visibilityClause.sql}
-          ${orgScope.sql}`;
+          ${orgScope.sql}${entityTypesClause.sql}`;
 
   const textDocumentExpr = buildSearchDocumentExpr('f');
   const resultDocumentExpr = buildSearchDocumentExpr('fi');
@@ -460,6 +467,7 @@ export async function searchContentBySingleQuery(
     ...orgScope.params,
     ...excludeClause.params,
     ...visibilityClause.params,
+    ...entityTypesClause.params,
     ...searchEntityLinkParams,
     ...(hasEmbedding ? [toVectorLiteral(queryEmbedding!), minSimilarity] : []),
     ...cursorClause.params,

--- a/packages/server/src/utils/content-search/types.ts
+++ b/packages/server/src/utils/content-search/types.ts
@@ -36,6 +36,8 @@ export interface ContentSearchOptions {
   limit?: number; // default: 50, max: 100
   content_ids?: number[]; // Filter to specific content IDs
   semantic_type?: string | string[]; // Filter by semantic type — single value or array (matches any)
+  /** Org-wide filter: events whose entity_ids overlap entities of these type slugs. */
+  entity_types?: string[];
   interaction_status?: 'pending' | 'approved' | 'rejected' | 'completed' | 'failed';
 
   // Per-agent memory scope. Filters events whose `metadata->>'agent_id'`


### PR DESCRIPTION
## Summary

The Memory page entity-type rail already sends `entity_types` in URL params and `read_knowledge` requests, but the server ignored the field. This wires the filter end-to-end for org-wide listing/search.

- Add `entity_types` to `read_knowledge` schema and `ContentSearchOptions`
- Apply SQL overlap filter: events linked to entities whose type slug matches
- Parse `entity_types` on public/authed REST knowledge search
- Ignore filter when `entity_id` is set (entity-scoped Events tab unchanged)

## Test plan

- [x] `entity-types-filter.test.ts` (unit, 3/3)
- [x] `get-content-entity-types-filter.test.ts` (integration)
- [ ] CI integration gate

## Owletto

No changes needed — client was already correct.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784852066&installation_id=136316292&pr_number=1529&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1529&signature=7cac16121721da76c02201bf98a67bd94550f84488231abd11e81c5ff52356d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `entity_types` filter parameter to knowledge search endpoints, enabling users to filter results by entity type slugs (e.g., "person", "company"). When `entity_id` is specified, this filter is ignored.

* **Tests**
  * Added integration and unit tests for entity-type filtering functionality and behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->