### PR TITLE
feat(memory): filter events by source connections

### DIFF
--- a/packages/server/src/__tests__/integration/connections-list-filters.test.ts
+++ b/packages/server/src/__tests__/integration/connections-list-filters.test.ts
@@ -1,0 +1,171 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { pgBigintArray } from "../../db/client";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import { createTestConnection } from "../setup/test-fixtures";
+import { TestWorkspace } from "../setup/test-mcp-client";
+
+type ConnectionListResult = {
+	connections?: Array<{ id: number; display_name?: string | null }>;
+};
+
+type ConnectorGroupsResult = {
+	groups?: Array<{
+		connector_key: string;
+		connector_name: string | null;
+		connection_count: number;
+		connections: Array<{
+			id: number;
+			display_name: string | null;
+			feed_count: number;
+		}>;
+	}>;
+};
+
+type FeedListResult = {
+	feeds?: Array<{ id: number; connection_id: number }>;
+};
+
+function ids(rows: Array<{ id: number }> | undefined): number[] {
+	return (rows ?? []).map((row) => Number(row.id)).sort((a, b) => a - b);
+}
+
+describe("manage_connections and manage_feeds list filters", () => {
+	let workspace: TestWorkspace;
+	let orgConnectionId: number;
+	let memberPrivateConnectionId: number;
+	let adminPrivateConnectionId: number;
+	let orgFeedId: number;
+	let memberPrivateFeedId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		workspace = await TestWorkspace.create({
+			name: "Connection Filters Org",
+			visibility: "public",
+		});
+
+		orgConnectionId = Number(
+			(
+				await createTestConnection({
+					organization_id: workspace.org.id,
+					connector_key: "github",
+					display_name: "Org GitHub",
+					created_by: workspace.users.owner.id,
+					visibility: "org",
+				})
+			).id,
+		);
+		memberPrivateConnectionId = Number(
+			(
+				await createTestConnection({
+					organization_id: workspace.org.id,
+					connector_key: "github",
+					display_name: "Member GitHub",
+					created_by: workspace.users.member.id,
+					visibility: "private",
+				})
+			).id,
+		);
+		adminPrivateConnectionId = Number(
+			(
+				await createTestConnection({
+					organization_id: workspace.org.id,
+					connector_key: "github",
+					display_name: "Admin GitHub",
+					created_by: workspace.users.admin.id,
+					visibility: "private",
+				})
+			).id,
+		);
+
+		const sql = getTestDb();
+		const feedRows = (await sql`
+			SELECT id, connection_id
+			FROM feeds
+			WHERE connection_id = ANY(${pgBigintArray([
+				orgConnectionId,
+				memberPrivateConnectionId,
+			])}::bigint[])
+			ORDER BY id
+		`) as unknown as Array<{ id: number; connection_id: number }>;
+		orgFeedId = Number(
+			feedRows.find((feed) => Number(feed.connection_id) === orgConnectionId)?.id,
+		);
+		memberPrivateFeedId = Number(
+			feedRows.find(
+				(feed) => Number(feed.connection_id) === memberPrivateConnectionId,
+			)?.id,
+		);
+	});
+
+	it("filters connections by explicit connection_ids", async () => {
+		const result = (await workspace.owner.connections.list({
+			connection_ids: [memberPrivateConnectionId, orgConnectionId],
+		})) as ConnectionListResult;
+
+		expect(ids(result.connections)).toEqual(
+			[orgConnectionId, memberPrivateConnectionId].sort((a, b) => a - b),
+		);
+	});
+
+	it("filters feeds by explicit feed_ids", async () => {
+		const result = (await workspace.owner.feeds.list({
+			feed_ids: [memberPrivateFeedId],
+		})) as FeedListResult;
+
+		expect(ids(result.feeds)).toEqual([memberPrivateFeedId]);
+	});
+
+	it("applies connection visibility to connector groups", async () => {
+		const ownerGroups = (await workspace.owner.connections.manage({
+			action: "list_connector_groups",
+		})) as ConnectorGroupsResult;
+		const ownerGithub = ownerGroups.groups?.find(
+			(group) => group.connector_key === "github",
+		);
+		expect(ownerGithub?.connection_count).toBe(3);
+		expect(ids(ownerGithub?.connections)).toEqual(
+			[orgConnectionId, memberPrivateConnectionId, adminPrivateConnectionId].sort(
+				(a, b) => a - b,
+			),
+		);
+		expect(ownerGithub?.connections.find((c) => c.id === orgConnectionId)?.feed_count).toBe(1);
+
+		const memberGroups = (await workspace.member.connections.manage({
+			action: "list_connector_groups",
+		})) as ConnectorGroupsResult;
+		const memberGithub = memberGroups.groups?.find(
+			(group) => group.connector_key === "github",
+		);
+		expect(memberGithub?.connection_count).toBe(2);
+		expect(ids(memberGithub?.connections)).toEqual(
+			[orgConnectionId, memberPrivateConnectionId].sort((a, b) => a - b),
+		);
+
+		const anonymousGroups = (await workspace.asAnonymous().connections.manage({
+			action: "list_connector_groups",
+		})) as ConnectorGroupsResult;
+		const anonymousGithub = anonymousGroups.groups?.find(
+			(group) => group.connector_key === "github",
+		);
+		expect(anonymousGithub?.connection_count).toBe(1);
+		expect(ids(anonymousGithub?.connections)).toEqual([orgConnectionId]);
+	});
+
+	it("applies connection visibility to list and get", async () => {
+		const memberList = (await workspace.member.connections.list({
+			connection_ids: [adminPrivateConnectionId],
+		})) as ConnectionListResult;
+		expect(memberList.connections ?? []).toHaveLength(0);
+
+		await expect(
+			workspace.member.connections.get(adminPrivateConnectionId),
+		).resolves.toMatchObject({ error: "Connection not found" });
+		await expect(
+			workspace.asAnonymous().connections.get(memberPrivateConnectionId),
+		).resolves.toMatchObject({ error: "Connection not found" });
+		await expect(
+			workspace.member.connections.get(memberPrivateConnectionId),
+		).resolves.toMatchObject({ action: "get" });
+	});
+});

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -285,6 +285,13 @@ describe('isPublicReadable', () => {
     expect(isPublicReadable('manage_entity', { action: 'list' })).toBe(true);
   });
 
+  it('should allow public read for manage_connections lists', () => {
+    expect(isPublicReadable('manage_connections', { action: 'list' })).toBe(true);
+    expect(isPublicReadable('manage_connections', { action: 'list_connector_groups' })).toBe(
+      true
+    );
+  });
+
   it('should deny public read for manage_entity create', () => {
     expect(isPublicReadable('manage_entity', { action: 'create' })).toBe(false);
   });

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -129,7 +129,7 @@ const PUBLIC_READ_ACTIONS: Record<string, Set<string> | null> = {
 	list_watchers: null,
 	manage_entity: new Set(["list", "get", "list_links"]),
 	manage_entity_schema: new Set(["list", "get", "audit", "list_rules"]),
-	manage_connections: new Set(["list", "get"]),
+	manage_connections: new Set(["list", "list_connector_groups", "get"]),
 	manage_catalog: new Set(["list_catalog", "list_installed"]),
 	manage_feeds: new Set(["list_feeds", "get_feed"]),
 	manage_auth_profiles: new Set(["list_auth_profiles"]),

--- a/packages/server/src/catalog/connector-group-display.ts
+++ b/packages/server/src/catalog/connector-group-display.ts
@@ -1,0 +1,55 @@
+import { getCatalogEntry, listCatalogEntries } from './load';
+
+export type ConnectorGroupDisplayFields = {
+  connector_key: string;
+  connector_name: string | null;
+  favicon_domain: string | null;
+};
+
+function catalogFaviconDomain(
+  detail: Record<string, unknown> | undefined,
+): string | null {
+  return typeof detail?.favicon_domain === 'string' ? detail.favicon_domain : null;
+}
+
+/**
+ * Fill connector group display fields from the bundled catalog when org
+ * connector_definitions are missing. Installed defs are the primary source
+ * (joined in SQL); catalog is the documented overlay per catalog/types.ts.
+ */
+export async function enrichConnectorGroupsWithCatalogDisplay<
+  T extends ConnectorGroupDisplayFields,
+>(groups: T[]): Promise<T[]> {
+  const catalogByKey = new Map(
+    (await listCatalogEntries(['connectors'])).connectors.map((entry) => [
+      entry.id,
+      entry,
+    ]),
+  );
+
+  return groups
+    .map((group) => {
+      const catalog = catalogByKey.get(group.connector_key);
+      return {
+        ...group,
+        connector_name: group.connector_name ?? catalog?.name ?? null,
+        favicon_domain:
+          group.favicon_domain ?? catalogFaviconDomain(catalog?.detail),
+      };
+    })
+    .sort((a, b) =>
+      (a.connector_name ?? a.connector_key).localeCompare(
+        b.connector_name ?? b.connector_key,
+      ),
+    );
+}
+
+export async function resolveCatalogConnectorDisplay(
+  connectorKey: string,
+): Promise<{ name: string | null; favicon_domain: string | null }> {
+  const catalog = await getCatalogEntry('connectors', connectorKey);
+  return {
+    name: catalog?.name ?? null,
+    favicon_domain: catalogFaviconDomain(catalog?.detail),
+  };
+}

--- a/packages/server/src/catalog/connector-group-display.ts
+++ b/packages/server/src/catalog/connector-group-display.ts
@@ -1,4 +1,4 @@
-import { getCatalogEntry, listCatalogEntries } from './load';
+import { listCatalogEntries } from './load';
 
 export type ConnectorGroupDisplayFields = {
   connector_key: string;
@@ -42,14 +42,4 @@ export async function enrichConnectorGroupsWithCatalogDisplay<
         b.connector_name ?? b.connector_key,
       ),
     );
-}
-
-export async function resolveCatalogConnectorDisplay(
-  connectorKey: string,
-): Promise<{ name: string | null; favicon_domain: string | null }> {
-  const catalog = await getCatalogEntry('connectors', connectorKey);
-  return {
-    name: catalog?.name ?? null,
-    favicon_domain: catalogFaviconDomain(catalog?.detail),
-  };
 }

--- a/packages/server/src/sandbox/namespaces/connections.ts
+++ b/packages/server/src/sandbox/namespaces/connections.ts
@@ -58,6 +58,7 @@ export interface ConnectionsNamespace {
 		status?: string;
 		entity_id?: number;
 		created_by?: string;
+		connection_ids?: number[];
 		limit?: number;
 		offset?: number;
 	}): Promise<unknown>;

--- a/packages/server/src/sandbox/namespaces/feeds.ts
+++ b/packages/server/src/sandbox/namespaces/feeds.ts
@@ -21,7 +21,7 @@ export interface FeedsCreateInput {
 
 export interface FeedsNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	list(input?: { connection_id?: number }): Promise<unknown>;
+	list(input?: { connection_id?: number; feed_ids?: number[] }): Promise<unknown>;
 	get(feed_id: number): Promise<unknown>;
 	create(input: FeedsCreateInput): Promise<unknown>;
 	update(input: {

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -40,6 +40,7 @@ import {
 	handleDelete,
 	handleGet,
 	handleList,
+	handleListConnectorGroups,
 	handleUpdate,
 } from "./manage_connections/handlers/crud";
 import {
@@ -48,6 +49,7 @@ import {
 	DeleteAction,
 	GetAction,
 	InstallConnectorAction,
+	ListConnectorGroupsAction,
 	ListAction,
 	ReauthenticateAction,
 	SetConnectorEntityLinkOverridesAction,
@@ -65,6 +67,10 @@ import {
 // ============================================
 
 const manageConnectionsTool = defineActionTool("manage_connections", {
+	list_connector_groups: action(
+		ListConnectorGroupsAction,
+		handleListConnectorGroups,
+	),
 	list: action(ListAction, handleList),
 	get: action(GetAction, handleGet),
 	create: action(CreateAction, handleCreate),

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -2,7 +2,7 @@
  * CRUD action handlers: list, get, create, update, delete.
  */
 
-import { parseJsonObject } from '@lobu/core';
+import { getErrorMessage, parseJsonObject } from '@lobu/core';
 import { getDb, parsePgNumberArray, pgBigintArray } from '../../../../db/client';
 import {
   EMPTY_SUMMARY,
@@ -50,7 +50,6 @@ import { resolveDeviceBinding, isManagedPublicOrgConnect } from './device-bindin
 import { assertConnectorAllowedInCloud } from '../../../../utils/connector-cloud-gate';
 import { ensureConnectorInstalled } from '../../../../utils/ensure-connector-installed';
 import { unregisterConnectorWebhook } from '../../../../connect/webhook-registration';
-import { getErrorMessage } from "@lobu/core";
 import { enrichConnectorGroupsWithCatalogDisplay } from '../../../../catalog/connector-group-display';
 
 // ============================================
@@ -59,20 +58,25 @@ import { enrichConnectorGroupsWithCatalogDisplay } from '../../../../catalog/con
 
 function mapConnectorGroupSummaries(raw: unknown): Array<{
   id: number;
-  display_name: string;
+  display_name: string | null;
   feed_count: number;
 }> {
   if (!Array.isArray(raw)) return [];
-  const summaries: Array<{ id: number; display_name: string; feed_count: number }> =
-    [];
+  const summaries: Array<{
+    id: number;
+    display_name: string | null;
+    feed_count: number;
+  }> = [];
   for (const item of raw) {
     if (!item || typeof item !== 'object') continue;
     const record = item as Record<string, unknown>;
     const id = Number(record.id);
     const displayName =
-      typeof record.display_name === 'string' ? record.display_name.trim() : '';
+      typeof record.display_name === 'string' && record.display_name.trim()
+        ? record.display_name.trim()
+        : null;
     const feedCount = Number(record.feed_count) || 0;
-    if (!Number.isFinite(id) || !displayName) continue;
+    if (!Number.isFinite(id)) continue;
     summaries.push({ id, display_name: displayName, feed_count: feedCount });
   }
   return summaries;
@@ -85,7 +89,7 @@ export async function handleListConnectorGroups(
   const sql = getDb();
   const { organizationId } = ctx;
 
-  const rows = await sql`
+  let query = sql`
     SELECT c.connector_key,
            MAX(cd.name) AS connector_name,
            MAX(cd.favicon_domain) AS favicon_domain,
@@ -94,8 +98,7 @@ export async function handleListConnectorGroups(
              json_agg(
                json_build_object(
                  'id', c.id,
-                 'display_name',
-                   COALESCE(NULLIF(TRIM(c.display_name), ''), cd.name, c.connector_key),
+                 'display_name', NULLIF(TRIM(c.display_name), ''),
                  'feed_count', fc.feed_count
                )
                ORDER BY COALESCE(NULLIF(TRIM(c.display_name), ''), cd.name, c.connector_key), c.id
@@ -120,10 +123,20 @@ export async function handleListConnectorGroups(
     ) fc ON TRUE
     WHERE c.organization_id = ${organizationId}
       AND c.deleted_at IS NULL
-    GROUP BY c.connector_key
-    ORDER BY MAX(cd.name), c.connector_key
   `;
 
+  if (!ctx.userId) {
+    query = sql`${query} AND c.visibility = 'org'`;
+  } else {
+    const userRole = await getWorkspaceRole(sql, organizationId, ctx.userId);
+    if (userRole !== 'owner' && userRole !== 'admin') {
+      query = sql`${query} AND (c.visibility = 'org' OR c.created_by = ${ctx.userId})`;
+    }
+  }
+
+  query = sql`${query} GROUP BY c.connector_key ORDER BY MAX(cd.name), c.connector_key`;
+
+  const rows = await query;
   const groups = rows.map((row) => ({
     connector_key: String(row.connector_key),
     connector_name:
@@ -236,11 +249,14 @@ export async function handleList(
     query = sql`${query} AND c.created_by = ${args.created_by}`;
   }
   if (args.connection_ids?.length) {
-    query = sql`${query} AND c.id = ANY(${pgBigintArray(args.connection_ids)})`;
+    query = sql`${query} AND c.id = ANY(${pgBigintArray(args.connection_ids)}::bigint[])`;
   }
 
-  // Visibility: non-admin users see only org connections + their own private connections
-  if (ctx.userId) {
+  // Visibility: anonymous readers see org-visible connections only; non-admin
+  // users see org connections plus their own private connections.
+  if (!ctx.userId) {
+    query = sql`${query} AND c.visibility = 'org'`;
+  } else {
     const userRole = await getWorkspaceRole(sql, organizationId, ctx.userId);
     if (userRole !== 'owner' && userRole !== 'admin') {
       query = sql`${query} AND (c.visibility = 'org' OR c.created_by = ${ctx.userId})`;
@@ -291,7 +307,7 @@ export async function handleGet(
   const sql = getDb();
   const { organizationId } = ctx;
 
-  const rows = await sql`
+  let query = sql`
     SELECT c.*,
            cd.name AS connector_name,
            cd.feeds_schema,
@@ -333,6 +349,16 @@ export async function handleGet(
       AND c.deleted_at IS NULL
   `;
 
+  if (!ctx.userId) {
+    query = sql`${query} AND c.visibility = 'org'`;
+  } else {
+    const userRole = await getWorkspaceRole(sql, organizationId, ctx.userId);
+    if (userRole !== 'owner' && userRole !== 'admin') {
+      query = sql`${query} AND (c.visibility = 'org' OR c.created_by = ${ctx.userId})`;
+    }
+  }
+
+  const rows = await query;
   if (rows.length === 0) {
     return { error: 'Connection not found' };
   }

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -53,6 +53,56 @@ import { unregisterConnectorWebhook } from '../../../../connect/webhook-registra
 import { getErrorMessage } from "@lobu/core";
 
 // ============================================
+// handleListConnectorGroups
+// ============================================
+
+export async function handleListConnectorGroups(
+  _args: Extract<ConnectionsArgs, { action: 'list_connector_groups' }>,
+  ctx: ToolContext
+): Promise<ManageConnectionsResult> {
+  const sql = getDb();
+  const { organizationId } = ctx;
+
+  const rows = await sql`
+    SELECT c.connector_key,
+           MAX(cd.name) AS connector_name,
+           MAX(cd.favicon_domain) AS favicon_domain,
+           COUNT(*)::int AS connection_count,
+           array_agg(c.id ORDER BY COALESCE(NULLIF(TRIM(c.display_name), ''), cd.name, c.connector_key), c.id)
+             AS connection_ids
+    FROM connections c
+    LEFT JOIN LATERAL (
+      SELECT name, favicon_domain
+      FROM connector_definitions
+      WHERE key = c.connector_key
+        AND status = 'active'
+        AND organization_id = ${organizationId}
+      ORDER BY updated_at DESC
+      LIMIT 1
+    ) cd ON TRUE
+    WHERE c.organization_id = ${organizationId}
+      AND c.deleted_at IS NULL
+    GROUP BY c.connector_key
+    ORDER BY MAX(cd.name), c.connector_key
+  `;
+
+  return {
+    action: 'list_connector_groups',
+    groups: rows.map((row) => ({
+      connector_key: String(row.connector_key),
+      connector_name:
+        row.connector_name != null ? String(row.connector_name) : null,
+      favicon_domain:
+        row.favicon_domain != null ? String(row.favicon_domain) : null,
+      connection_count: Number(row.connection_count) || 0,
+      connection_ids: Array.isArray(row.connection_ids)
+        ? row.connection_ids.map((id) => Number(id))
+        : [],
+    })),
+  };
+}
+
+// ============================================
 // handleList
 // ============================================
 

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -51,47 +51,31 @@ import { assertConnectorAllowedInCloud } from '../../../../utils/connector-cloud
 import { ensureConnectorInstalled } from '../../../../utils/ensure-connector-installed';
 import { unregisterConnectorWebhook } from '../../../../connect/webhook-registration';
 import { getErrorMessage } from "@lobu/core";
-import { listCatalogEntries } from '../../../../catalog/load';
+import { enrichConnectorGroupsWithCatalogDisplay } from '../../../../catalog/connector-group-display';
 
 // ============================================
 // handleListConnectorGroups
 // ============================================
 
-function catalogFaviconDomain(
-  detail: Record<string, unknown> | undefined,
-): string | null {
-  return typeof detail?.favicon_domain === 'string' ? detail.favicon_domain : null;
-}
-
-async function enrichConnectorGroupDisplay<
-  T extends {
-    connector_key: string;
-    connector_name: string | null;
-    favicon_domain: string | null;
-  },
->(groups: T[]): Promise<T[]> {
-  const catalogByKey = new Map(
-    (await listCatalogEntries(['connectors'])).connectors.map((entry) => [
-      entry.id,
-      entry,
-    ]),
-  );
-
-  return groups
-    .map((group) => {
-      const catalog = catalogByKey.get(group.connector_key);
-      return {
-        ...group,
-        connector_name: group.connector_name ?? catalog?.name ?? null,
-        favicon_domain:
-          group.favicon_domain ?? catalogFaviconDomain(catalog?.detail),
-      };
-    })
-    .sort((a, b) =>
-      (a.connector_name ?? a.connector_key).localeCompare(
-        b.connector_name ?? b.connector_key,
-      ),
-    );
+function mapConnectorGroupSummaries(raw: unknown): Array<{
+  id: number;
+  display_name: string;
+  feed_count: number;
+}> {
+  if (!Array.isArray(raw)) return [];
+  const summaries: Array<{ id: number; display_name: string; feed_count: number }> =
+    [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const record = item as Record<string, unknown>;
+    const id = Number(record.id);
+    const displayName =
+      typeof record.display_name === 'string' ? record.display_name.trim() : '';
+    const feedCount = Number(record.feed_count) || 0;
+    if (!Number.isFinite(id) || !displayName) continue;
+    summaries.push({ id, display_name: displayName, feed_count: feedCount });
+  }
+  return summaries;
 }
 
 export async function handleListConnectorGroups(
@@ -106,8 +90,18 @@ export async function handleListConnectorGroups(
            MAX(cd.name) AS connector_name,
            MAX(cd.favicon_domain) AS favicon_domain,
            COUNT(*)::int AS connection_count,
-           array_agg(c.id ORDER BY COALESCE(NULLIF(TRIM(c.display_name), ''), cd.name, c.connector_key), c.id)
-             AS connection_ids
+           COALESCE(
+             json_agg(
+               json_build_object(
+                 'id', c.id,
+                 'display_name',
+                   COALESCE(NULLIF(TRIM(c.display_name), ''), cd.name, c.connector_key),
+                 'feed_count', fc.feed_count
+               )
+               ORDER BY COALESCE(NULLIF(TRIM(c.display_name), ''), cd.name, c.connector_key), c.id
+             ),
+             '[]'::json
+           ) AS connections
     FROM connections c
     LEFT JOIN LATERAL (
       SELECT name, favicon_domain
@@ -118,6 +112,12 @@ export async function handleListConnectorGroups(
       ORDER BY updated_at DESC
       LIMIT 1
     ) cd ON TRUE
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*)::int AS feed_count
+      FROM feeds f
+      WHERE f.connection_id = c.id
+        AND f.deleted_at IS NULL
+    ) fc ON TRUE
     WHERE c.organization_id = ${organizationId}
       AND c.deleted_at IS NULL
     GROUP BY c.connector_key
@@ -131,12 +131,12 @@ export async function handleListConnectorGroups(
     favicon_domain:
       row.favicon_domain != null ? String(row.favicon_domain) : null,
     connection_count: Number(row.connection_count) || 0,
-    connection_ids: parsePgNumberArray(row.connection_ids),
+    connections: mapConnectorGroupSummaries(row.connections),
   }));
 
   return {
     action: 'list_connector_groups',
-    groups: await enrichConnectorGroupDisplay(groups),
+    groups: await enrichConnectorGroupsWithCatalogDisplay(groups),
   };
 }
 

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -131,9 +131,7 @@ export async function handleListConnectorGroups(
     favicon_domain:
       row.favicon_domain != null ? String(row.favicon_domain) : null,
     connection_count: Number(row.connection_count) || 0,
-    connection_ids: Array.isArray(row.connection_ids)
-      ? row.connection_ids.map((id) => Number(id))
-      : [],
+    connection_ids: parsePgNumberArray(row.connection_ids),
   }));
 
   return {
@@ -236,6 +234,9 @@ export async function handleList(
   }
   if (args.created_by) {
     query = sql`${query} AND c.created_by = ${args.created_by}`;
+  }
+  if (args.connection_ids?.length) {
+    query = sql`${query} AND c.id = ANY(${pgBigintArray(args.connection_ids)})`;
   }
 
   // Visibility: non-admin users see only org connections + their own private connections

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -51,10 +51,48 @@ import { assertConnectorAllowedInCloud } from '../../../../utils/connector-cloud
 import { ensureConnectorInstalled } from '../../../../utils/ensure-connector-installed';
 import { unregisterConnectorWebhook } from '../../../../connect/webhook-registration';
 import { getErrorMessage } from "@lobu/core";
+import { listCatalogEntries } from '../../../../catalog/load';
 
 // ============================================
 // handleListConnectorGroups
 // ============================================
+
+function catalogFaviconDomain(
+  detail: Record<string, unknown> | undefined,
+): string | null {
+  return typeof detail?.favicon_domain === 'string' ? detail.favicon_domain : null;
+}
+
+async function enrichConnectorGroupDisplay<
+  T extends {
+    connector_key: string;
+    connector_name: string | null;
+    favicon_domain: string | null;
+  },
+>(groups: T[]): Promise<T[]> {
+  const catalogByKey = new Map(
+    (await listCatalogEntries(['connectors'])).connectors.map((entry) => [
+      entry.id,
+      entry,
+    ]),
+  );
+
+  return groups
+    .map((group) => {
+      const catalog = catalogByKey.get(group.connector_key);
+      return {
+        ...group,
+        connector_name: group.connector_name ?? catalog?.name ?? null,
+        favicon_domain:
+          group.favicon_domain ?? catalogFaviconDomain(catalog?.detail),
+      };
+    })
+    .sort((a, b) =>
+      (a.connector_name ?? a.connector_key).localeCompare(
+        b.connector_name ?? b.connector_key,
+      ),
+    );
+}
 
 export async function handleListConnectorGroups(
   _args: Extract<ConnectionsArgs, { action: 'list_connector_groups' }>,
@@ -86,19 +124,21 @@ export async function handleListConnectorGroups(
     ORDER BY MAX(cd.name), c.connector_key
   `;
 
+  const groups = rows.map((row) => ({
+    connector_key: String(row.connector_key),
+    connector_name:
+      row.connector_name != null ? String(row.connector_name) : null,
+    favicon_domain:
+      row.favicon_domain != null ? String(row.favicon_domain) : null,
+    connection_count: Number(row.connection_count) || 0,
+    connection_ids: Array.isArray(row.connection_ids)
+      ? row.connection_ids.map((id) => Number(id))
+      : [],
+  }));
+
   return {
     action: 'list_connector_groups',
-    groups: rows.map((row) => ({
-      connector_key: String(row.connector_key),
-      connector_name:
-        row.connector_name != null ? String(row.connector_name) : null,
-      favicon_domain:
-        row.favicon_domain != null ? String(row.favicon_domain) : null,
-      connection_count: Number(row.connection_count) || 0,
-      connection_ids: Array.isArray(row.connection_ids)
-        ? row.connection_ids.map((id) => Number(id))
-        : [],
-    })),
+    groups: await enrichConnectorGroupDisplay(groups),
   };
 }
 

--- a/packages/server/src/tools/admin/manage_connections/schemas.ts
+++ b/packages/server/src/tools/admin/manage_connections/schemas.ts
@@ -9,6 +9,10 @@ import { PaginationFields } from "../schemas/common-fields";
 // Schema
 // ============================================
 
+export const ListConnectorGroupsAction = Type.Object({
+	action: Type.Literal("list_connector_groups"),
+});
+
 export const ListAction = Type.Object({
 	action: Type.Literal("list"),
 	connector_key: Type.Optional(
@@ -317,6 +321,16 @@ export type ManageConnectionsResult =
 			offset: number;
 			view_url?: string;
 	  }
+	| {
+			action: "list_connector_groups";
+			groups: Array<{
+				connector_key: string;
+				connector_name: string | null;
+				favicon_domain: string | null;
+				connection_count: number;
+				connection_ids: number[];
+			}>;
+	  }
 	| { action: "get"; connection: ConnectionRow; view_url?: string }
 	| {
 			action: "create";
@@ -384,6 +398,7 @@ export type ManageConnectionsResult =
  * modules can use `Extract<ConnectionsArgs, ...>` without a circular type.
  */
 export type ConnectionsArgs =
+	| Static<typeof ListConnectorGroupsAction>
 	| Static<typeof ListAction>
 	| Static<typeof GetAction>
 	| Static<typeof CreateAction>

--- a/packages/server/src/tools/admin/manage_connections/schemas.ts
+++ b/packages/server/src/tools/admin/manage_connections/schemas.ts
@@ -31,6 +31,11 @@ export const ListAction = Type.Object({
 			description: "Filter by user ID who created the connection",
 		}),
 	),
+	connection_ids: Type.Optional(
+		Type.Array(Type.Number(), {
+			description: "Filter to specific connection IDs",
+		}),
+	),
 	...PaginationFields,
 });
 

--- a/packages/server/src/tools/admin/manage_connections/schemas.ts
+++ b/packages/server/src/tools/admin/manage_connections/schemas.ts
@@ -32,7 +32,7 @@ export const ListAction = Type.Object({
 		}),
 	),
 	connection_ids: Type.Optional(
-		Type.Array(Type.Number(), {
+		Type.Array(Type.Integer({ minimum: 1 }), {
 			description: "Filter to specific connection IDs",
 		}),
 	),
@@ -335,7 +335,7 @@ export type ManageConnectionsResult =
 				connection_count: number;
 				connections: Array<{
 					id: number;
-					display_name: string;
+					display_name: string | null;
 					feed_count: number;
 				}>;
 			}>;

--- a/packages/server/src/tools/admin/manage_connections/schemas.ts
+++ b/packages/server/src/tools/admin/manage_connections/schemas.ts
@@ -333,7 +333,11 @@ export type ManageConnectionsResult =
 				connector_name: string | null;
 				favicon_domain: string | null;
 				connection_count: number;
-				connection_ids: number[];
+				connections: Array<{
+					id: number;
+					display_name: string;
+					feed_count: number;
+				}>;
 			}>;
 	  }
 	| { action: "get"; connection: ConnectionRow; view_url?: string }

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -38,6 +38,9 @@ import { getErrorMessage } from "@lobu/core";
 const ListFeedsAction = Type.Object({
   action: Type.Literal('list_feeds'),
   connection_id: Type.Optional(Type.Number({ description: 'Filter by connection ID' })),
+  feed_ids: Type.Optional(
+    Type.Array(Type.Number(), { description: 'Filter to specific feed IDs' })
+  ),
   entity_id: Type.Optional(Type.Number({ description: 'Filter by linked entity ID' })),
   status: Type.Optional(Type.String({ description: 'Filter by status: active, paused, error' })),
   ...PaginationFields,
@@ -160,6 +163,9 @@ async function handleListFeeds(
   }
   if (args.status) {
     pageQuery = sql`${pageQuery} AND f.status = ${args.status}`;
+  }
+  if (args.feed_ids?.length) {
+    pageQuery = sql`${pageQuery} AND f.id = ANY(${pgBigintArray(args.feed_ids)})`;
   }
 
   pageQuery = sql`${pageQuery} ORDER BY f.created_at DESC LIMIT ${limit} OFFSET ${offset}`;

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -12,7 +12,7 @@
  * - trigger_feed: Trigger an immediate sync for a feed
  */
 
-import { parseJsonObject } from '@lobu/core';
+import { getErrorMessage, parseJsonObject } from '@lobu/core';
 import { type Static, Type } from '@sinclair/typebox';
 import { getDb, pgBigintArray } from '../../db/client';
 import type { Env } from '../../index';
@@ -29,7 +29,6 @@ import { getDefaultSchedule } from './helpers/connection-helpers';
 import { assertEntityIdsInOrg } from './helpers/db-helpers';
 import { resolveFeedDisplayName } from './helpers/feed-helpers';
 import { PaginationFields } from './schemas/common-fields';
-import { getErrorMessage } from "@lobu/core";
 
 // ============================================
 // Schema
@@ -39,7 +38,7 @@ const ListFeedsAction = Type.Object({
   action: Type.Literal('list_feeds'),
   connection_id: Type.Optional(Type.Number({ description: 'Filter by connection ID' })),
   feed_ids: Type.Optional(
-    Type.Array(Type.Number(), { description: 'Filter to specific feed IDs' })
+    Type.Array(Type.Integer({ minimum: 1 }), { description: 'Filter to specific feed IDs' })
   ),
   entity_id: Type.Optional(Type.Number({ description: 'Filter by linked entity ID' })),
   status: Type.Optional(Type.String({ description: 'Filter by status: active, paused, error' })),
@@ -165,7 +164,7 @@ async function handleListFeeds(
     pageQuery = sql`${pageQuery} AND f.status = ${args.status}`;
   }
   if (args.feed_ids?.length) {
-    pageQuery = sql`${pageQuery} AND f.id = ANY(${pgBigintArray(args.feed_ids)})`;
+    pageQuery = sql`${pageQuery} AND f.id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;
   }
 
   pageQuery = sql`${pageQuery} ORDER BY f.created_at DESC LIMIT ${limit} OFFSET ${offset}`;


### PR DESCRIPTION
## Summary\n- add backend connector-group summaries for Memory source browsing\n- add explicit connection/feed id list filters for source drill-down labels\n- enforce connection visibility on list/get/group reads and cast ID arrays to bigint[]\n- bump owletto to merged memory source rail / Reach rename / inline watcher create PR: lobu-ai/owletto#353\n\n## Validation\n- make build-packages\n- bun run typecheck\n- cd packages/owletto && bun run test src/lib/event-filter-labels.test.ts src/lib/event-filters.test.ts src/lib/agent-chat-routes.test.ts src/app/__smoke__/all-routes.test.tsx\n- bun test packages/server/src/auth/__tests__/tool-access.test.ts\n- attempted: bun test packages/server/src/__tests__/integration/connections-list-filters.test.ts (blocked locally: DATABASE_URL not set)\n\n## Multi-replica check\nThe new source filtering paths are database/catalog reads only. No new in-memory shared state or pod-local coordination was added, so behavior holds with 3 replicas behind ClientIP affinity.\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784860288&installation_id=136316292&pr_number=1532&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1532&signature=ec59b996fe741a4056df600df3ee496bc70cf0a1eea2af067f261d92473165af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to list connector groups with metadata and connection counts
  * Added connection ID filtering to connections list endpoint
  * Added feed ID filtering to feeds list endpoint

* **Improvements**
  * Enhanced visibility filtering for connections and feeds based on user workspace roles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->