### PR TITLE
fix(embeddings): serialize embed_backfill dispatch to one org per tick

### DIFF
--- a/packages/server/src/__tests__/integration/scheduled/trigger-embed-backfill.test.ts
+++ b/packages/server/src/__tests__/integration/scheduled/trigger-embed-backfill.test.ts
@@ -180,3 +180,70 @@ describe('triggerEmbedBackfill query rewrite', () => {
     expect(enqueued.indexOf(ids.unembeddedNew)).toBeLessThan(enqueued.indexOf(ids.unembeddedOld));
   });
 });
+
+describe('triggerEmbedBackfill org-per-tick cap (serialize)', () => {
+  let originalModel: string | undefined;
+  let originalCap: string | undefined;
+
+  // Three orgs each carrying unembedded backlog, so discovery has more
+  // candidates than any cap under test.
+  beforeAll(async () => {
+    originalModel = process.env.EMBEDDINGS_MODEL;
+    originalCap = process.env.EMBED_BACKFILL_MAX_ORGS_PER_TICK;
+    process.env.EMBEDDINGS_MODEL = MODEL;
+
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    for (let i = 0; i < 3; i++) {
+      const org = await createTestOrganization({ name: `Cap Org ${i}` });
+      const entity = await createTestEntity({ name: `Cap Target ${i}`, organization_id: org.id });
+      await createTestConnectorDefinition({
+        key: `cap-connector-${i}`,
+        name: `Cap ${i}`,
+        organization_id: org.id,
+      });
+      const connection = await createTestConnection({
+        organization_id: org.id,
+        connector_key: `cap-connector-${i}`,
+        entity_ids: [entity.id],
+      });
+      await insertEvent({
+        entityIds: [entity.id],
+        organizationId: org.id,
+        semanticType: 'content',
+        originType: 'content',
+        connectorKey: `cap-connector-${i}`,
+        connectionId: connection.id,
+        originId: `cap-unembedded-${i}`,
+        title: `cap unembedded ${i}`,
+        content: `org ${i} content needing an embedding`,
+        occurredAt: new Date(),
+      });
+    }
+  });
+
+  afterAll(() => {
+    if (originalModel === undefined) delete process.env.EMBEDDINGS_MODEL;
+    else process.env.EMBEDDINGS_MODEL = originalModel;
+    if (originalCap === undefined) delete process.env.EMBED_BACKFILL_MAX_ORGS_PER_TICK;
+    else process.env.EMBED_BACKFILL_MAX_ORGS_PER_TICK = originalCap;
+  });
+
+  it('defaults to a single org per tick — concurrent runs never pile onto the single embeddings service', async () => {
+    delete process.env.EMBED_BACKFILL_MAX_ORGS_PER_TICK;
+    const result = await triggerEmbedBackfill({} as Env);
+    expect(result.runsCreated).toBe(1);
+  });
+
+  it('dispatches up to EMBED_BACKFILL_MAX_ORGS_PER_TICK when the embeddings tier is scaled', async () => {
+    const sql = getTestDb();
+    // Clear the prior tick's run so all three orgs are eligible again
+    // (createBackfillRun skips an org with an active run).
+    await sql`DELETE FROM runs WHERE run_type = 'embed_backfill'`;
+
+    process.env.EMBED_BACKFILL_MAX_ORGS_PER_TICK = '2';
+    const result = await triggerEmbedBackfill({} as Env);
+    expect(result.runsCreated).toBe(2);
+  });
+});

--- a/packages/server/src/scheduled/trigger-embed-backfill.ts
+++ b/packages/server/src/scheduled/trigger-embed-backfill.ts
@@ -40,6 +40,23 @@ const RECENT_SCAN_LIMIT = 5000;
 // re-collects the exact ids per org regardless. Overridable for ops/tests.
 const DISCOVERY_SCAN_TIMEOUT = process.env.EMBED_BACKFILL_SCAN_TIMEOUT || '8s';
 
+// Max organizations to dispatch an embed_backfill run for per */5 tick. Each run
+// is claimed by an independent worker and POSTs its whole batch to the SINGLE
+// embeddings service, which is single-threaded (transformers.js CPU inference
+// blocks the event loop — one batch at a time). N concurrent runs therefore
+// serialize at the service and, on a CPU-constrained node, blow past the
+// worker's 30s embed timeout — every run aborts, the events re-queue, and the
+// backlog never drains (congestion collapse: incident 2026-06-24, embed_backfill
+// 0-completed for hours, EmbedBackfillFailing firing). Default 1 so embed
+// pressure on the service stays serial; raise it only where the embeddings tier
+// is genuinely horizontally scaled. The skipped orgs are not starved — the next
+// tick re-runs discovery and the most-backlogged org that lacks an active run
+// surfaces again (createBackfillRun is idempotent per org).
+function maxOrgsPerTick(): number {
+  const parsed = Number.parseInt(process.env.EMBED_BACKFILL_MAX_ORGS_PER_TICK || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
 interface BackfillResult {
   organizations: number;
   runsCreated: number;
@@ -68,7 +85,7 @@ const NOT_SUPERSEDED_PREDICATE =
   'NOT EXISTS (SELECT 1 FROM events newer WHERE newer.supersedes_event_id = e.id)';
 
 // Org-discovery scan, bounded by statement_timeout and run READ ONLY. Returns
-// the per-org recent-window backlog counts (top 10). If the scan exceeds
+// the per-org recent-window backlog counts (top MAX_ORGS_PER_TICK). If the scan exceeds
 // DISCOVERY_SCAN_TIMEOUT it is aborted by Postgres (SQLSTATE 57014) and we skip
 // this cycle rather than error — see DISCOVERY_SCAN_TIMEOUT for why a heavy
 // scan is dangerous. The timeout is set via tx.unsafe (SET rejects bind
@@ -101,7 +118,7 @@ async function discoverBacklogOrgs(needsEmbedding: string): Promise<readonly Org
         ) sub
         GROUP BY organization_id
         ORDER BY event_count DESC
-        LIMIT 10
+        LIMIT ${maxOrgsPerTick()}
       `;
     });
   } catch (error) {


### PR DESCRIPTION
## Problem (live prod incident 2026-06-24)

`EmbedBackfillFailing` firing; embed_backfill **0 completed since 06:55**, ~3 failed every `*/5` tick, ~6.8k embeddable events stuck. Every run aborted at exactly **30s** with `"The operation was aborted."`.

### Root cause — congestion collapse, not connectivity
- `trigger-embed-backfill.ts` discovered the top **10** backlogged orgs per tick and created one run each (`idx_runs_active_embed_backfill_per_org` = 1 active/org). 3 orgs backlogged → 3 concurrent runs, each ~83 events, claimed by 3 independent workers (2 app embedded-workers + 1 standalone).
- All 3 POST their batches to the **single** `summaries-app-lobu-embeddings` pod at once. That service is single-threaded (transformers.js CPU inference **blocks the event loop** — one batch at a time). On the CPU-constrained single node the concurrent batches serialize and blow past the worker's 30s embed timeout (`packages/connector-worker/src/embeddings.ts`). Failed runs re-queue the same events → self-sustaining.

Evidence it's capacity, not the service: from inside the worker pod `curl /health`=3.7ms, `curl /api/embeddings` on the exact stuck 44-event batch=0.47s, DNS=6ms, TCP connect=1–3ms — but the in-process Node `fetch` to the same URL took **5–17s when the pod was busy**, <50ms idle. Load-correlated.

## Fix
Cap org dispatch per tick via `EMBED_BACKFILL_MAX_ORGS_PER_TICK` (**default 1**) so embed pressure on the single-threaded service stays serial. With 1 run/tick the single pod handles one ~83-event batch (<1s idle) well under the 30s timeout, completes, and the backlog drains. Skipped orgs are not starved — the next tick re-runs discovery and the most-backlogged org without an active run surfaces again. Raise the env only where the embeddings tier is horizontally scaled.

## Test (red→green)
`triggerEmbedBackfill org-per-tick cap` integration test: 3 backlogged orgs.
- default (env unset) → `runsCreated === 1` (green; old `LIMIT 10` code → 3 = red).
- `EMBED_BACKFILL_MAX_ORGS_PER_TICK=2` → `runsCreated === 2`.

Validated via `make review` (suite + pi). The existing single-org behavior test still passes (`runsCreated` toBe 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784893427&installation_id=136316292&pr_number=1536&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1536&signature=d43a30b94d95e956567523ffbff5ffcfcec872dfa014b992b78232fab18837e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->