### PR TITLE
feat(slack): dashboard deep-link, org counts, and recent activity on App Home

### DIFF
--- a/packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts
@@ -335,6 +335,89 @@ describe("Slack platform bridge", () => {
     expect(view.blocks.some((b) => b.type === "header")).toBe(false);
   });
 
+  test("home tab renders the dashboard card with a slug deep link and org counts", async () => {
+    const h = makeHomeChat();
+    const resolveHomeContext = mock(async () => ({
+      orgSlug: "acme",
+      entitiesTracked: 976,
+      capturedToday: 5,
+    }));
+    registerSlackAppHome(h.chat, connection(), {
+      publicGatewayUrl: "https://gw.example/",
+      resolveHomeContext,
+    });
+    const publishHomeView = mock(async () => undefined);
+    await h.open("U123", publishHomeView);
+
+    expect(resolveHomeContext).toHaveBeenCalledWith("org-test");
+    const text = blocksText(
+      publishHomeView.mock.calls[0]![1] as {
+        blocks?: Array<Record<string, unknown>>;
+      }
+    );
+    // Deep link uses the org slug, trailing slash trimmed.
+    expect(text).toContain("https://gw.example/acme");
+    expect(text).toContain("Open dashboard");
+    // Counts render as a context line.
+    expect(text).toContain("976 tracked");
+    expect(text).toContain("5 captured today");
+  });
+
+  test("dashboard card links to the web root and omits counts when context is unavailable", async () => {
+    const h = makeHomeChat();
+    registerSlackAppHome(h.chat, connection(), {
+      publicGatewayUrl: "https://gw.example",
+      resolveHomeContext: mock(async () => null),
+    });
+    const publishHomeView = mock(async () => undefined);
+    await h.open("U123", publishHomeView);
+
+    const view = publishHomeView.mock.calls[0]![1] as {
+      blocks: Array<Record<string, unknown>>;
+    };
+    const text = blocksText(view);
+    expect(text).toContain('"url":"https://gw.example"');
+    expect(text).toContain("Open dashboard");
+    // No counts line, and no crash on a null context.
+    expect(view.blocks.some((b) => b.type === "context")).toBe(false);
+  });
+
+  test("dashboard card is skipped without a public gateway url", async () => {
+    const h = makeHomeChat();
+    registerSlackAppHome(h.chat, connection(), {
+      resolveHomeContext: mock(async () => ({
+        orgSlug: "acme",
+        entitiesTracked: 1,
+        capturedToday: 1,
+      })),
+    });
+    const publishHomeView = mock(async () => undefined);
+    await h.open("U123", publishHomeView);
+    expect(blocksText(publishHomeView.mock.calls[0]![1] as any)).not.toContain(
+      "Open dashboard"
+    );
+  });
+
+  test("preview workspaces don't render the dashboard card", async () => {
+    const h = makeHomeChat();
+    const resolveHomeContext = mock(async () => ({
+      orgSlug: "acme",
+      entitiesTracked: 1,
+      capturedToday: 1,
+    }));
+    registerSlackAppHome(
+      h.chat,
+      connection({ settings: { previewMode: true } }),
+      { publicGatewayUrl: "https://gw.example", resolveHomeContext }
+    );
+    const publishHomeView = mock(async () => undefined);
+    await h.open("U123", publishHomeView);
+    expect(resolveHomeContext).not.toHaveBeenCalled();
+    expect(blocksText(publishHomeView.mock.calls[0]![1] as any)).not.toContain(
+      "Open dashboard"
+    );
+  });
+
   test("falls back to a minimal home view if the rich view is rejected", async () => {
     const h = makeHomeChat();
     registerSlackAppHome(h.chat, connection(), {});

--- a/packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts
@@ -341,6 +341,10 @@ describe("Slack platform bridge", () => {
       orgSlug: "acme",
       entitiesTracked: 976,
       capturedToday: 5,
+      recent: [
+        { title: "Acme raised a Series B", platform: "gmail", ts: 1_700_000_000 },
+        { title: "Standup notes", platform: null, ts: 1_700_000_100 },
+      ],
     }));
     registerSlackAppHome(h.chat, connection(), {
       publicGatewayUrl: "https://gw.example/",
@@ -361,6 +365,31 @@ describe("Slack platform bridge", () => {
     // Counts render as a context line.
     expect(text).toContain("976 tracked");
     expect(text).toContain("5 captured today");
+    // Recent activity list renders with a source label and a Slack date token.
+    expect(text).toContain("Recent activity");
+    expect(text).toContain("Acme raised a Series B");
+    expect(text).toContain("Gmail");
+    expect(text).toContain("<!date^1700000000");
+  });
+
+  test("recent titles are escaped and the list is skipped when empty", async () => {
+    const h = makeHomeChat();
+    registerSlackAppHome(h.chat, connection(), {
+      publicGatewayUrl: "https://gw.example",
+      resolveHomeContext: mock(async () => ({
+        orgSlug: "acme",
+        entitiesTracked: 1,
+        capturedToday: 0,
+        recent: [{ title: "<script>&", platform: null, ts: 1 }],
+      })),
+    });
+    const publishHomeView = mock(async () => undefined);
+    await h.open("U123", publishHomeView);
+    const text = blocksText(publishHomeView.mock.calls[0]![1] as any);
+    expect(text).toContain("Recent activity");
+    // mrkdwn control chars escaped, JSON-encoded in the serialized blocks.
+    expect(text).toContain("&lt;script&gt;&amp;");
+    expect(text).not.toContain("<script>");
   });
 
   test("dashboard card links to the web root and omits counts when context is unavailable", async () => {
@@ -389,6 +418,7 @@ describe("Slack platform bridge", () => {
         orgSlug: "acme",
         entitiesTracked: 1,
         capturedToday: 1,
+        recent: [],
       })),
     });
     const publishHomeView = mock(async () => undefined);
@@ -404,6 +434,7 @@ describe("Slack platform bridge", () => {
       orgSlug: "acme",
       entitiesTracked: 1,
       capturedToday: 1,
+      recent: [],
     }));
     registerSlackAppHome(
       h.chat,

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -75,22 +75,57 @@ const logger = createLogger("chat-instance-manager");
  * per-agent or per-user attribution. Returns null on any failure so the home
  * tab degrades to a slug-less dashboard link rather than failing to render.
  */
+/** How many recent events the home tab's "Recent activity" list shows. */
+const SLACK_HOME_RECENT_LIMIT = 5;
+
+/** Title an event for the recent list: its title, else a payload snippet. */
+function recentDisplayTitle(
+  title: string | null,
+  payloadText: string | null,
+): string {
+  const t = title?.trim();
+  if (t) return t;
+  const snippet = payloadText?.replace(/\s+/g, " ").trim();
+  if (snippet) {
+    return snippet.length > 60 ? `${snippet.slice(0, 59)}…` : snippet;
+  }
+  return "(untitled)";
+}
+
 async function resolveSlackHomeContext(
   organizationId: string,
 ): Promise<SlackHomeContext | null> {
   try {
-    const rows = await getDb()`
-      SELECT
-        (SELECT slug FROM organization WHERE id = ${organizationId}) AS org_slug,
-        (SELECT count(*) FROM entities
-           WHERE organization_id = ${organizationId} AND deleted_at IS NULL)
-          AS entities_tracked,
-        (SELECT count(*) FROM events
-           WHERE organization_id = ${organizationId}
-             AND created_at >= date_trunc('day', now()))
-          AS captured_today
-    `;
-    const row = rows[0] as
+    const db = getDb();
+    const [countRows, recentRows] = await Promise.all([
+      db`
+        SELECT
+          (SELECT slug FROM organization WHERE id = ${organizationId}) AS org_slug,
+          (SELECT count(*) FROM entities
+             WHERE organization_id = ${organizationId} AND deleted_at IS NULL)
+            AS entities_tracked,
+          (SELECT count(*) FROM events
+             WHERE organization_id = ${organizationId}
+               AND created_at >= date_trunc('day', now()))
+            AS captured_today
+      `,
+      // Mirrors the web "recent" feed (resolve_path.ts fetchRecentContent):
+      // supersession-masked, internal corrections excluded, newest first.
+      db`
+        SELECT
+          ev.title,
+          ev.payload_text,
+          COALESCE(ev.connector_key, cn.connector_key) AS platform,
+          extract(epoch FROM COALESCE(ev.occurred_at, ev.created_at))::bigint AS ts
+        FROM current_event_records ev
+        LEFT JOIN connections cn ON cn.id = ev.connection_id
+        WHERE ev.organization_id = ${organizationId}
+          AND ev.semantic_type <> 'correction'
+        ORDER BY COALESCE(ev.occurred_at, ev.created_at) DESC
+        LIMIT ${SLACK_HOME_RECENT_LIMIT}
+      `,
+    ]);
+    const row = countRows[0] as
       | {
           org_slug: string | null;
           entities_tracked: number | string;
@@ -98,10 +133,23 @@ async function resolveSlackHomeContext(
         }
       | undefined;
     if (!row) return null;
+    const recent = (
+      recentRows as {
+        title: string | null;
+        payload_text: string | null;
+        platform: string | null;
+        ts: number | string | null;
+      }[]
+    ).map((r) => ({
+      title: recentDisplayTitle(r.title, r.payload_text),
+      platform: r.platform,
+      ts: Number(r.ts) || 0,
+    }));
     return {
       orgSlug: row.org_slug,
       entitiesTracked: Number(row.entities_tracked) || 0,
       capturedToday: Number(row.captured_today) || 0,
+      recent,
     };
   } catch (error) {
     logger.warn(

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -55,6 +55,7 @@ import { SlackConnectionCoordinator } from "./slack-connection-coordinator.js";
 import {
   registerSlackAppHome,
   registerSlackPlatformHandlers,
+  type SlackHomeContext,
 } from "./slack-platform-bridge.js";
 import { createGatewayStateAdapter } from "./state-adapter.js";
 import {
@@ -67,6 +68,49 @@ import { configsEqual } from "./config-equal.js";
 
 
 const logger = createLogger("chat-instance-manager");
+
+/**
+ * Org-scoped counts + slug for the Slack App Home dashboard card. One
+ * round-trip; all counts are organization-wide because `events` carries no
+ * per-agent or per-user attribution. Returns null on any failure so the home
+ * tab degrades to a slug-less dashboard link rather than failing to render.
+ */
+async function resolveSlackHomeContext(
+  organizationId: string,
+): Promise<SlackHomeContext | null> {
+  try {
+    const rows = await getDb()`
+      SELECT
+        (SELECT slug FROM organization WHERE id = ${organizationId}) AS org_slug,
+        (SELECT count(*) FROM entities
+           WHERE organization_id = ${organizationId} AND deleted_at IS NULL)
+          AS entities_tracked,
+        (SELECT count(*) FROM events
+           WHERE organization_id = ${organizationId}
+             AND created_at >= date_trunc('day', now()))
+          AS captured_today
+    `;
+    const row = rows[0] as
+      | {
+          org_slug: string | null;
+          entities_tracked: number | string;
+          captured_today: number | string;
+        }
+      | undefined;
+    if (!row) return null;
+    return {
+      orgSlug: row.org_slug,
+      entitiesTracked: Number(row.entities_tracked) || 0,
+      capturedToday: Number(row.captured_today) || 0,
+    };
+  } catch (error) {
+    logger.warn(
+      { error, organizationId },
+      "Failed to load Slack home dashboard context",
+    );
+    return null;
+  }
+}
 
 /**
  * Exclusive-transport lease cadence. Each replica ticks every
@@ -1147,6 +1191,7 @@ export class ChatInstanceManager {
         mcpConfigService: this.services.getMcpConfigService(),
         secretStore: this.services.getSecretStore(),
         publicGatewayUrl: this.publicGatewayUrl,
+        resolveHomeContext: resolveSlackHomeContext,
       });
 
       chat.registerSingleton();

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -70,25 +70,34 @@ import { configsEqual } from "./config-equal.js";
 const logger = createLogger("chat-instance-manager");
 
 /**
- * Org-scoped counts + slug for the Slack App Home dashboard card. One
- * round-trip; all counts are organization-wide because `events` carries no
- * per-agent or per-user attribution. Returns null on any failure so the home
- * tab degrades to a slug-less dashboard link rather than failing to render.
+ * Org-scoped counts + slug + recent feed for the Slack App Home dashboard
+ * card. Runs the counts and recent queries in parallel. All counts are
+ * organization-wide because `events` carries no per-agent or per-user
+ * attribution. Returns null on any failure so the home tab degrades to a
+ * slug-less dashboard link rather than failing to render.
  */
 /** How many recent events the home tab's "Recent activity" list shows. */
 const SLACK_HOME_RECENT_LIMIT = 5;
 
-/** Title an event for the recent list: its title, else a payload snippet. */
+/** Collapse whitespace and clamp to a bounded length for a one-line Slack row. */
+function clampRecentText(text: string): string {
+  const s = text.replace(/\s+/g, " ").trim();
+  return s.length > 60 ? `${s.slice(0, 59)}…` : s;
+}
+
+/**
+ * Title an event for the recent list: its title, else a payload snippet. Both
+ * paths are clamped so an unbounded title can't blow past Slack's section text
+ * limit and force the home view into its minimal fallback.
+ */
 function recentDisplayTitle(
   title: string | null,
   payloadText: string | null,
 ): string {
   const t = title?.trim();
-  if (t) return t;
-  const snippet = payloadText?.replace(/\s+/g, " ").trim();
-  if (snippet) {
-    return snippet.length > 60 ? `${snippet.slice(0, 59)}…` : snippet;
-  }
+  if (t) return clampRecentText(t);
+  const snippet = payloadText?.trim();
+  if (snippet) return clampRecentText(snippet);
   return "(untitled)";
 }
 

--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -149,6 +149,20 @@ type SlackActionEvent = {
   raw?: unknown;
 };
 
+/**
+ * Glanceable, org-scoped context for the home tab's dashboard card. `events`
+ * has no per-agent or per-user attribution column, so every count here is
+ * organization-wide — never present it as "your" items.
+ */
+export interface SlackHomeContext {
+  /** Org slug for the dashboard deep link, or null if it can't be resolved. */
+  orgSlug: string | null;
+  /** Non-deleted entities tracked in the org. */
+  entitiesTracked: number;
+  /** Events captured today (org-wide, local server day). */
+  capturedToday: number;
+}
+
 /** Dependencies the App Home tab needs to render status and run OAuth. */
 interface SlackAppHomeDeps {
   /**
@@ -160,8 +174,18 @@ interface SlackAppHomeDeps {
   adapter?: SlackHomeAdapter;
   mcpConfigService?: McpConfigService;
   secretStore?: WritableSecretStore;
-  /** Public origin of the gateway — used to build the OAuth redirect URI. */
+  /**
+   * Public origin of the gateway — used to build the OAuth redirect URI and,
+   * since the web SPA is served same-origin, the dashboard deep link.
+   */
   publicGatewayUrl?: string;
+  /**
+   * Resolves the org dashboard slug + glanceable counts for the home tab.
+   * Read-only; failures degrade gracefully to a slug-less dashboard link.
+   */
+  resolveHomeContext?: (
+    organizationId: string,
+  ) => Promise<SlackHomeContext | null>;
 }
 
 // Internal plumbing MCPs (e.g. the Lobu memory backend) — not user integrations.
@@ -239,6 +263,56 @@ function integrationSection(
   };
 }
 
+/** Trim a trailing slash so we can append `/segment` cleanly. */
+function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+/**
+ * The dashboard card: a "Open dashboard" deep link into the web app plus a
+ * context line of org-wide counts. Returns `[]` when there's nowhere to link
+ * (no public URL), so the home tab still renders without it.
+ */
+function dashboardBlocks(
+  webBaseUrl: string | undefined,
+  context: SlackHomeContext | null,
+): Record<string, unknown>[] {
+  if (!webBaseUrl) return [];
+  const base = trimTrailingSlash(webBaseUrl);
+  const dashboardUrl = context?.orgSlug ? `${base}/${context.orgSlug}` : base;
+
+  const blocks: Record<string, unknown>[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Your dashboard*\nBrowse everything I've captured, review entities, and tune what I watch.",
+      },
+      accessory: {
+        type: "button",
+        text: { type: "plain_text", text: "Open dashboard ↗" },
+        url: dashboardUrl,
+        style: "primary",
+      },
+    },
+  ];
+
+  if (context && (context.entitiesTracked > 0 || context.capturedToday > 0)) {
+    blocks.push({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: `:bar_chart: ${context.entitiesTracked.toLocaleString()} tracked  ·  ${context.capturedToday.toLocaleString()} captured today`,
+        },
+      ],
+    });
+  }
+
+  blocks.push({ type: "divider" });
+  return blocks;
+}
+
 interface HomeViewParams {
   connection: PlatformConnection;
   deps: SlackAppHomeDeps;
@@ -263,11 +337,25 @@ async function buildSlackHomeBlocks(
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*${botName}* :wave:\n\nMention me in any channel, or send me a DM, to start a thread.`,
+        text: `*${botName}* :wave:\n\nI watch your tools, build shared memory, and act on your goals. Mention me in any channel, or send me a DM, to start a thread.`,
       },
     },
     { type: "divider" },
   ];
+
+  if (!isPreview && connection.organizationId) {
+    let context: SlackHomeContext | null = null;
+    try {
+      context =
+        (await deps.resolveHomeContext?.(connection.organizationId)) ?? null;
+    } catch (error) {
+      logger.warn(
+        { error, organizationId: connection.organizationId },
+        "Failed to resolve Slack home dashboard context; rendering link without counts",
+      );
+    }
+    blocks.push(...dashboardBlocks(deps.publicGatewayUrl, context));
+  }
 
   if (!isPreview && connection.agentId && deps.mcpConfigService) {
     try {

--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -149,10 +149,22 @@ type SlackActionEvent = {
   raw?: unknown;
 };
 
+/** A single "what's recent" row for the home tab, mirroring the web's recent feed. */
+export interface SlackHomeRecentItem {
+  /** Display title (event title, or a payload snippet, or a fallback). */
+  title: string;
+  /** Source label (connector key / platform), or null when unknown. */
+  platform: string | null;
+  /** Unix seconds of occurred_at|created_at — rendered via a Slack date token. */
+  ts: number;
+}
+
 /**
  * Glanceable, org-scoped context for the home tab's dashboard card. `events`
  * has no per-agent or per-user attribution column, so every count here is
- * organization-wide — never present it as "your" items.
+ * organization-wide — never present it as "your" items. (Per-user delivery
+ * lives in `notification_targets`, but it's keyed on Lobu user ids and is
+ * empty for unlinked Slack users, so it isn't surfaced here.)
  */
 export interface SlackHomeContext {
   /** Org slug for the dashboard deep link, or null if it can't be resolved. */
@@ -161,6 +173,8 @@ export interface SlackHomeContext {
   entitiesTracked: number;
   /** Events captured today (org-wide, local server day). */
   capturedToday: number;
+  /** Most-recent org events (mirrors the web "recent" feed), newest first. */
+  recent: SlackHomeRecentItem[];
 }
 
 /** Dependencies the App Home tab needs to render status and run OAuth. */
@@ -268,6 +282,43 @@ function trimTrailingSlash(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
+/** Turn a connector key like `apple.screen_time` into `Apple Screen Time`. */
+function humanizeSource(platform: string | null): string | null {
+  if (!platform) return null;
+  return platform.replace(/[._-]+/g, " ").replace(/\b\w/g, (c) =>
+    c.toUpperCase(),
+  );
+}
+
+/** Escape Slack mrkdwn control chars so titles can't inject formatting. */
+function escapeMrkdwn(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Render the "Recent activity" list as a single section, or `[]` if empty. */
+function recentBlocks(
+  recent: SlackHomeRecentItem[],
+): Record<string, unknown>[] {
+  if (recent.length === 0) return [];
+  const lines = recent.map((item) => {
+    const title = escapeMrkdwn(item.title);
+    const source = humanizeSource(item.platform);
+    // `<!date^…>` renders in the viewer's own timezone; the pipe text is the
+    // fallback Slack shows if it can't resolve the token.
+    const when = `<!date^${item.ts}^{date_short_pretty}|recently>`;
+    return source
+      ? `• *${title}*  ·  ${escapeMrkdwn(source)}  ·  ${when}`
+      : `• *${title}*  ·  ${when}`;
+  });
+  return [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: `*Recent activity*\n${lines.join("\n")}` },
+    },
+    { type: "divider" },
+  ];
+}
+
 /**
  * The dashboard card: a "Open dashboard" deep link into the web app plus a
  * context line of org-wide counts. Returns `[]` when there's nowhere to link
@@ -355,6 +406,7 @@ async function buildSlackHomeBlocks(
       );
     }
     blocks.push(...dashboardBlocks(deps.publicGatewayUrl, context));
+    blocks.push(...recentBlocks(context?.recent ?? []));
   }
 
   if (!isPreview && connection.agentId && deps.mcpConfigService) {


### PR DESCRIPTION
## What

Replaces the static Slack App Home welcome with a live, on-brand home tab:

- **On-brand copy** — watch / understand / act framing instead of the old "coding assistant" line.
- **Dashboard card** — an "Open dashboard ↗" button deep-linking into the web SPA (same-origin via `publicGatewayUrl`, org slug appended), plus a glanceable counts line (`N tracked · M captured today`).
- **Recent activity** — org-scoped list mirroring the web's recent feed (`current_event_records`, `correction` excluded, newest first, top 5). Titles fall back to a payload snippet, are clamped and mrkdwn-escaped; timestamps render via a Slack date token in the viewer's timezone.

## Design decisions (reliability-first)

- **No magic-link/token auth handoff.** The button just deep-links; existing web sessions land straight in, others hit normal login. Auto-login is a noted follow-up.
- **Counts are org-scoped, not per-user.** `events` has no per-agent/per-Slack-user attribution column, so counts are honestly org-wide ("tracked / captured today"), never "your items".
- **Per-user notifications (`notification_targets`) intentionally not surfaced.** It keys on Lobu user ids and is empty for unlinked Slack users — would be blank/unreliable. Documented in code; this is the per-user follow-up once a Slack→Lobu identity mapping is in place.
- **Degrades gracefully.** Any DB failure → slug-less link to the web root, home still renders. Counts/recent hidden when empty. Preview workspaces skip the card.

## Validation

- 15/15 `slack-platform-bridge` unit tests (rendering asserted on the published Block Kit).
- Full-repo `tsc` clean; `make review`: bug_free 82 / simplicity 84 / 0 bugs / 0 blockers. (Integration exit=1 is a pre-existing env timeout in unchanged routes/media code, per pi — not this diff.)
- Both count and recent SQL ran clean against migrated dev DBs (incl. the 18k-event `owletto_local`).
- Applied both pi suggestions (clamp titles; fix resolver comment).

## Not in scope

- The "Use the Settings button above" text in the current screenshot is likely an older deployed Block Kit home (the exact strings exist nowhere in the repo); this branch replaces it. If it turns out to be the static Slack "About" description, that's an api.slack.com settings edit, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784894218&installation_id=136316292&pr_number=1537&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1537&signature=22aba1ebcb852ada68709685e7cb6bb94c1a4568b119471933b0f16663bf1b1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->