### PR TITLE
fix(migrate): fail fast when a pending SET NOT NULL has unbacked NULLs

### DIFF
--- a/docker/app/start.sh
+++ b/docker/app/start.sh
@@ -45,6 +45,113 @@ try {
 NODE
 }
 
+# Fail FAST, before dbmate touches anything, when a PENDING migration will
+# `ALTER COLUMN ... SET NOT NULL` on a column that still has NULL rows. That is
+# the signature of a contract migration whose out-of-band backfill precondition
+# was skipped (incident 2026-06-24: a classifier-collapse contract migration hit
+# this, dbmate errored mid-run, the Helm pre-upgrade hook failed, and the
+# HelmRelease wedged + rolled back for hours, spamming #devops). dbmate's own
+# error ("column X contains null values") is buried after partial work; this
+# surfaces the exact table.column + NULL count + remediation up front.
+#
+# Fail OPEN by design: any parse/connect/unknown error logs a warning and
+# continues so the preflight can never itself become a new deploy wedge. It only
+# HARD-fails when it positively finds NULLs in an existing targeted column.
+preflight_not_null_preconditions() {
+  echo "Checking pending migrations for unsatisfied NOT NULL preconditions..."
+  MIGRATIONS_DIR=/app/db/migrations node --input-type=module <<'NODE'
+import postgres from "postgres";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const databaseUrl = process.env.DATABASE_URL;
+const dir = process.env.MIGRATIONS_DIR || "/app/db/migrations";
+if (!databaseUrl) {
+  console.error("ERROR: DATABASE_URL not set");
+  process.exit(1);
+}
+
+const sql = postgres(databaseUrl, { max: 1, connect_timeout: 10, idle_timeout: 1, onnotice: () => {} });
+
+try {
+  let applied;
+  try {
+    const rows = await sql`SELECT version FROM schema_migrations`;
+    applied = new Set(rows.map((r) => r.version));
+  } catch {
+    // Fresh DB with no schema_migrations yet → nothing applied and no rows that
+    // could violate a NOT NULL. Nothing to check.
+    console.log("schema_migrations not present — skipping NOT NULL preflight");
+    process.exit(0);
+  }
+
+  let files;
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith(".sql")).sort();
+  } catch (e) {
+    console.warn(`preflight: cannot read ${dir} (${e.message}) — skipping`);
+    process.exit(0);
+  }
+
+  const violations = [];
+  for (const file of files) {
+    const version = file.split("_")[0];
+    if (applied.has(version)) continue; // already applied
+
+    let text;
+    try {
+      text = readFileSync(join(dir, file), "utf8");
+    } catch {
+      continue;
+    }
+    // Only consider the up section, statement by statement. A statement that
+    // both names a table and SETs a column NOT NULL targets an existing column.
+    const up = text.split(/--\s*migrate:down/i)[0];
+    for (const stmt of up.split(";")) {
+      if (!/alter\s+column/i.test(stmt) || !/set\s+not\s+null/i.test(stmt)) continue;
+      const tableM = stmt.match(/alter\s+table\s+(?:only\s+)?(?:public\.)?"?(\w+)"?/i);
+      const colM = stmt.match(/alter\s+column\s+"?(\w+)"?\s+set\s+not\s+null/i);
+      if (!tableM || !colM) continue;
+      const table = tableM[1];
+      const col = colM[1];
+      try {
+        // table/col are \w+ extracted from our own migration files — not user input.
+        const rows = await sql.unsafe(
+          `SELECT count(*)::bigint AS n FROM public.${table} WHERE ${col} IS NULL`
+        );
+        const n = Number(rows[0]?.n ?? 0);
+        if (n > 0) violations.push({ file, table, col, n });
+      } catch (e) {
+        // Column/table may be created by an earlier still-pending migration, so
+        // it can't be pre-verified — let dbmate handle it. Fail open.
+        console.warn(`preflight: cannot check ${table}.${col} (${file}): ${e.message}`);
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error("");
+    console.error("ERROR: refusing to run migrations — a pending NOT NULL constraint has unbacked NULLs:");
+    for (const v of violations) {
+      console.error(`  - ${v.file}: ${v.table}.${v.col} SET NOT NULL, but ${v.n} row(s) are NULL`);
+    }
+    console.error("");
+    console.error("This is a contract migration whose out-of-band backfill must run to completion FIRST");
+    console.error("(see the migration header / scripts/). Run the backfill, confirm 0 NULLs, then redeploy.");
+    console.error("Aborting before dbmate so the deploy fails fast with a clear cause, not mid-migration.");
+    process.exit(1);
+  }
+  console.log("NOT NULL preflight passed");
+} catch (error) {
+  // Never let an unexpected preflight error block a deploy.
+  console.warn(`preflight: unexpected error, continuing (${error instanceof Error ? error.message : String(error)})`);
+  process.exit(0);
+} finally {
+  await sql.end({ timeout: 1 }).catch(() => {});
+}
+NODE
+}
+
 run_migrations() {
   if [ -z "$DATABASE_URL" ]; then
     echo "ERROR: DATABASE_URL not set"
@@ -54,6 +161,8 @@ run_migrations() {
   if [ "${NODE_ENV:-}" = "production" ] && [ "${ALLOW_DB_CREATE:-0}" != "1" ]; then
     preflight_database
   fi
+
+  preflight_not_null_preconditions
 
   echo ""
   echo "Running database migrations..."


### PR DESCRIPTION
## Problem
A contract migration that does `ALTER COLUMN ... SET NOT NULL` relies on its out-of-band backfill having run to completion first. When that precondition is skipped, `dbmate` errors **mid-run** (`column X contains null values`), the Helm pre-upgrade migrate hook fails, and the HelmRelease wedges + rolls back for hours — spamming #devops (incident 2026-06-24: classifier-collapse contract migration, `event_classifications.classifier_id` had 2187 NULLs).

## Fix
Add a preflight in `run_migrations()` (`docker/app/start.sh`) that, **before dbmate touches anything**, scans PENDING migrations for `ALTER COLUMN ... SET NOT NULL` and verifies each targeted (already-existing) column has no NULL rows — aborting with the exact `table.column` + NULL count + remediation.

**Fails open by design:** any parse/connect/unknown error logs a warning and continues, so the preflight can never itself wedge a deploy. It only HARD-fails on a positive NULL finding.

## Validation (against the real prod DB, read-only)
Ran the exact preflight logic against `owletto` with a synthetic pending migration:
- `ALTER COLUMN author_name SET NOT NULL` (121,037 NULLs) → **ABORT exit 1**: `events.author_name, 121037 NULL row(s)`
- same on `id` (0 NULLs) → **PASS exit 0**

This is exactly the signal that would have caught this morning's incident in ~1s instead of a multi-hour deploy wedge. Pairs with owletto #358 (state-based `LobuMigrateHookFailed` alert) and #1536 (embed dispatch serialization).

Note: logic lives in a shell heredoc (mirrors the existing `preflight_database`), so it has no committed unit test; validated end-to-end against prod as above + `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784894311&installation_id=136316292&pr_number=1538&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1538&signature=3e9c9a58790b45ff2ebae4b5f3ebb646aedd71aa2904d29fb88b0c0838f98ff6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a migration safety check that stops database updates before applying changes that would mark columns as required while existing records still contain empty values.
  * Improved migration error reporting with clearer details when a blocking data issue is found.
  * Made migration startup more resilient by continuing safely when a check cannot be completed due to unresolved dependencies or unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->