### PR TITLE
feat(github): poll-canonical webhook triggers + direct-store for stars

### DIFF
--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -324,6 +324,27 @@ export interface FeedDefinition {
    * `local.directory.files` needs a per-folder `folder_id` from the Mac app.
    */
   userManaged?: boolean;
+  /**
+   * Routes inbound app-webhook deliveries to this feed. Lives on the feed (not
+   * the connector's webhook schema) because feeds_schema is the persisted,
+   * server-readable surface — the app-webhook router reads this to dispatch a
+   * delivery WITHOUT hardcoding provider event types. The connector owns this
+   * knowledge (which event updates which feed, and whether the payload is
+   * complete enough to store):
+   *  - `mode: 'trigger'` (default) — the poll brings more than the webhook, so
+   *    mark this feed due and let the poll fetch the complete record (deduped by
+   *    origin_id). Use for events whose poll endpoint returns richer data.
+   *  - `mode: 'store'` — the payload is event-complete (e.g. a GitHub `star`
+   *    carries the actor + starred_at) and re-polling the whole list is wasteful,
+   *    so the router stores the structured event directly, consolidating with the
+   *    poll on the same origin_id.
+   */
+  webhook?: {
+    /** Provider webhook event types (e.g. `x-github-event` values) that update this feed. */
+    events: string[];
+    /** How a matching delivery is handled. Default `'trigger'`. */
+    mode?: 'trigger' | 'store';
+  };
   /** Event kinds this feed produces, keyed by kind slug */
   eventKinds?: Record<
     string,

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -327,7 +327,21 @@ export default class GitHubConnector extends ConnectorRuntime {
           // granted Organization → Members → Read in its settings (out-of-band,
           // user action) or every real org admin's membership lookup 403s.
           permissions: ['issues', 'pull_requests', 'contents', 'metadata', 'discussions', 'members'],
-          events: ['issues', 'pull_request', 'issue_comment', 'discussion', 'discussion_comment'],
+          // Webhook subscriptions the live App must enable. Must cover every
+          // event referenced by a feed's `webhook.events` above (push → commits,
+          // star/watch → stargazers, pull_request_review_comment → pr_comments),
+          // or those feeds get no deliveries and fall back to the schedule.
+          events: [
+            'issues',
+            'pull_request',
+            'issue_comment',
+            'pull_request_review_comment',
+            'discussion',
+            'discussion_comment',
+            'push',
+            'star',
+            'watch',
+          ],
           required: false,
           description:
             'Install the Lobu GitHub App on your org to grant tenant-scoped access (no per-connection token). Repo/issue/PR reads and write actions flow through the App installation.',
@@ -376,6 +390,7 @@ export default class GitHubConnector extends ConnectorRuntime {
         requiredScopes: [],
         description: 'Sync GitHub issues from a repository.',
         displayNameTemplate: '{repo_owner}/{repo_name} issues',
+        webhook: { events: ['issues'] },
         configSchema: {
           type: 'object',
           required: ['repo_owner', 'repo_name'],
@@ -407,6 +422,7 @@ export default class GitHubConnector extends ConnectorRuntime {
         requiredScopes: [],
         description: 'Sync GitHub pull requests from a repository.',
         displayNameTemplate: '{repo_owner}/{repo_name} PRs',
+        webhook: { events: ['pull_request'] },
         configSchema: {
           type: 'object',
           required: ['repo_owner', 'repo_name'],
@@ -438,6 +454,7 @@ export default class GitHubConnector extends ConnectorRuntime {
         requiredScopes: [],
         description: 'Sync comments on GitHub issues.',
         displayNameTemplate: '{repo_owner}/{repo_name} issue comments',
+        webhook: { events: ['issue_comment'] },
         configSchema: {
           type: 'object',
           required: ['repo_owner', 'repo_name'],
@@ -465,6 +482,7 @@ export default class GitHubConnector extends ConnectorRuntime {
         requiredScopes: [],
         description: 'Sync comments on GitHub pull requests.',
         displayNameTemplate: '{repo_owner}/{repo_name} PR comments',
+        webhook: { events: ['pull_request_review_comment'] },
         configSchema: {
           type: 'object',
           required: ['repo_owner', 'repo_name'],
@@ -492,6 +510,7 @@ export default class GitHubConnector extends ConnectorRuntime {
         requiredScopes: [],
         description: 'Sync GitHub discussions from a repository.',
         displayNameTemplate: '{repo_owner}/{repo_name} discussions',
+        webhook: { events: ['discussion'] },
         configSchema: {
           type: 'object',
           required: ['repo_owner', 'repo_name'],
@@ -522,6 +541,7 @@ export default class GitHubConnector extends ConnectorRuntime {
         requiredScopes: [],
         description: 'Sync comments on GitHub discussions.',
         displayNameTemplate: '{repo_owner}/{repo_name} discussion comments',
+        webhook: { events: ['discussion_comment'] },
         configSchema: {
           type: 'object',
           required: ['repo_owner', 'repo_name'],
@@ -550,6 +570,7 @@ export default class GitHubConnector extends ConnectorRuntime {
         requiredScopes: [],
         description: 'Sync commits pushed to a repository, attributed to their authors.',
         displayNameTemplate: '{repo_owner}/{repo_name} commits',
+        webhook: { events: ['push'] },
         configSchema: {
           type: 'object',
           required: ['repo_owner', 'repo_name'],
@@ -579,6 +600,7 @@ export default class GitHubConnector extends ConnectorRuntime {
         requiredScopes: [],
         description: 'Sync GitHub users who starred a repository.',
         displayNameTemplate: '{repo_owner}/{repo_name} stargazers',
+        webhook: { events: ['star', 'watch'], mode: 'store' },
         configSchema: {
           type: 'object',
           required: ['repo_owner', 'repo_name'],

--- a/packages/server/src/__tests__/integration/connectors/github-identity-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-identity-attribution.test.ts
@@ -352,6 +352,10 @@ describe('github member-identity attribution', () => {
 
   it('webhook: resolveGithubWebhookActor resolves the actor to a person and returns entity ids + the github_login metadata slot', async () => {
     const org = await seedOrg('GitHub Webhook Org');
+    // The rule is loaded from the connector definition (not mirrored), so the
+    // webhook path needs the github def seeded just like the poll path.
+    await seedGithubConnector(org.id);
+    clearEntityLinkRulesCache();
 
     const resolution = await resolveGithubWebhookActor({
       organizationId: org.id,
@@ -397,6 +401,9 @@ describe('github member-identity attribution', () => {
   it('tenant-scoped: the same github user in two orgs resolves to two distinct persons', async () => {
     const orgA = await seedOrg('GitHub Tenant A');
     const orgB = await seedOrg('GitHub Tenant B');
+    await seedGithubConnector(orgA.id);
+    await seedGithubConnector(orgB.id);
+    clearEntityLinkRulesCache();
 
     const a = await resolveGithubWebhookActor({
       organizationId: orgA.id,

--- a/packages/server/src/gateway/__tests__/app-installation-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/app-installation-e2e.test.ts
@@ -11,10 +11,11 @@
  *
  * Chain under test:
  *   1. install (store.upsert) → signed GitHub `issues` delivery → router →
- *      `handleWebhookIngest` → `events` row in the OWNING org; redelivery dedupes.
+ *      `onDelivery` trigger marks the OWNING org's feeds due (no raw event —
+ *      github is poll-canonical); redelivery just re-stamps next_run_at.
  *   2. reject/transfer: org A active → transfer to org B (atomic demote+activate)
- *      → delivery now routes to B, not A; a 2nd concurrent active insert for the
- *      same tenant is rejected by the partial unique index.
+ *      → delivery now triggers B's feeds, not A's; a 2nd concurrent active insert
+ *      for the same tenant is rejected by the partial unique index.
  *   3. token mint via `resolveExecutionAuth`: an app_installation-backed
  *      connection mints + returns a usable bearer credential, with the GitHub
  *      `/access_tokens` exchange MOCKED (registry seam / injected fetch — never
@@ -105,19 +106,58 @@ function issuesBody(tenant = TENANT, extra: Record<string, unknown> = {}) {
 	};
 }
 
-async function eventRows(connectorKey: string): Promise<any[]> {
-	const { getDb } = await import("../../db/client.js");
-	return getDb()`
-    SELECT * FROM events WHERE connector_key = ${connectorKey} ORDER BY id
-  `;
-}
-
 async function allInstallEventCount(): Promise<number> {
 	const { getDb } = await import("../../db/client.js");
 	const rows = await getDb()`
     SELECT count(*)::int AS n FROM events WHERE connector_key LIKE 'webhook:app_install:%'
   `;
 	return rows[0].n as number;
+}
+
+/**
+ * Seed a `github` connection (the trigger path keys on connector_key='github')
+ * bound to `installId` via config.installation_ref, plus one ACTIVE issues feed
+ * for {owner,name} with next_run_at NULL. A delivery for that repo flips it to
+ * now(), so NULL→NOT NULL proves the webhook marked the org's feed due.
+ */
+async function seedGithubFeed(
+	organizationId: string,
+	installId: number,
+	owner = "acme",
+	name = "api",
+): Promise<number> {
+	const { getDb } = await import("../../db/client.js");
+	const sql = getDb();
+	const [conn] = await sql`
+    INSERT INTO connections (organization_id, connector_key, slug, status, config)
+    VALUES (
+      ${organizationId}, ${"github"}, ${`gh-feed-${organizationId}-${owner}-${name}`},
+      ${"active"}, ${sql.json({ installation_ref: installId })}
+    )
+    RETURNING id
+  `;
+	const [feed] = await sql`
+    INSERT INTO feeds (organization_id, connection_id, feed_key, status, config, next_run_at)
+    VALUES (
+      ${organizationId}, ${conn.id}, ${"issues"}, ${"active"},
+      ${sql.json({ repo_owner: owner, repo_name: name })}, NULL
+    )
+    RETURNING id
+  `;
+	return Number(feed.id);
+}
+
+/** Current `next_run_at` of a feed (NULL until a trigger marks it due). */
+async function feedNextRunAt(feedId: number): Promise<unknown> {
+	const { getDb } = await import("../../db/client.js");
+	const [row] = await getDb()`SELECT next_run_at FROM feeds WHERE id = ${feedId}`;
+	return row?.next_run_at ?? null;
+}
+
+/** Reset a feed back to "not due" so a later delivery's effect is observable. */
+async function clearFeedDue(feedId: number): Promise<void> {
+	const { getDb } = await import("../../db/client.js");
+	await getDb()`UPDATE feeds SET next_run_at = NULL WHERE id = ${feedId}`;
 }
 
 /** Seed one active github install for a tenant tuple under an org. */
@@ -214,34 +254,34 @@ afterEach(async () => {
 	__resetInstallationTokenRegistryForTests();
 });
 
-describe("app-installation e2e: install → webhook → ingest (happy path)", () => {
-	test("a signed delivery routes to the owning org, lands one event, and redelivery dedupes", async () => {
+describe("app-installation e2e: install → webhook → trigger (happy path)", () => {
+	test("a signed delivery routes to the owning org and marks its feeds due, storing no raw event", async () => {
 		await seedAgentRow(AGENT_A, { organizationId: ORG_A });
 		const installId = await seedActiveInstall(ORG_A);
+		const feedId = await seedGithubFeed(ORG_A, installId);
 		const router = buildRouter();
 
-		// First delivery lands.
+		// First delivery triggers the org's feed (next_run_at NULL → now()).
 		const res = await router.fetch(
 			issuesDelivery(issuesBody(), { deliveryId: "gh-happy-1" }),
 		);
-		expect(res.status).toBe(202);
+		expect(res.status).toBe(200);
+		expect((await res.json()).triggered).toBe(true);
 
-		const key = `webhook:app_install:${installId}`;
-		let rows = await eventRows(key);
-		expect(rows.length).toBe(1);
-		// Routed into the install's owning org; the RAW GitHub payload landed.
-		expect(rows[0].organization_id).toBe(ORG_A);
-		expect(rows[0].origin_id).toBe("gh-happy-1");
-		expect(rows[0].payload_data).toEqual(issuesBody());
+		// github is a poll-canonical connector: the webhook stores no raw event…
+		expect(await allInstallEventCount()).toBe(0);
+		// …it just marks the affected feed due, in the install's owning org.
+		expect(await feedNextRunAt(feedId)).not.toBeNull();
 
-		// Redelivery of the same x-github-delivery dedupes — no second row.
+		// Redelivery is idempotent: re-stamps next_run_at, still lands no event.
+		await clearFeedDue(feedId);
 		const redelivery = await router.fetch(
 			issuesDelivery(issuesBody(), { deliveryId: "gh-happy-1" }),
 		);
-		expect(redelivery.status).toBe(202);
-		expect((await redelivery.json()).duplicate).toBe(true);
-		rows = await eventRows(key);
-		expect(rows.length).toBe(1);
+		expect(redelivery.status).toBe(200);
+		expect((await redelivery.json()).triggered).toBe(true);
+		expect(await feedNextRunAt(feedId)).not.toBeNull();
+		expect(await allInstallEventCount()).toBe(0);
 	});
 });
 
@@ -260,14 +300,17 @@ describe("app-installation e2e: reject / transfer ownership", () => {
 			externalTenantId: TENANT,
 			status: "active",
 		});
+		const feedA = await seedGithubFeed(ORG_A, a.id);
 		const router = buildRouter();
 
-		// A delivery routes to org A.
+		// A delivery triggers org A's feed.
 		const first = await router.fetch(
 			issuesDelivery(issuesBody(), { deliveryId: "gh-xfer-1" }),
 		);
-		expect(first.status).toBe(202);
-		expect((await eventRows(`webhook:app_install:${a.id}`)).length).toBe(1);
+		expect(first.status).toBe(200);
+		expect(await feedNextRunAt(feedA)).not.toBeNull();
+		// Reset so a later trigger of org A's feed (which must NOT happen) is visible.
+		await clearFeedDue(feedA);
 
 		// Org B re-installs the SAME tenant → transfer (A demoted, B active) in one tx.
 		const b = await store.upsert({
@@ -280,6 +323,7 @@ describe("app-installation e2e: reject / transfer ownership", () => {
 		});
 		expect(b.id).not.toBe(a.id);
 		expect(b.organizationId).toBe(ORG_B);
+		const feedB = await seedGithubFeed(ORG_B, b.id);
 
 		// Prior owner demoted (kept for audit), exactly one active owner remains.
 		const aAfter = await store.getById(a.id);
@@ -293,14 +337,16 @@ describe("app-installation e2e: reject / transfer ownership", () => {
 		expect(active?.id).toBe(b.id);
 		expect(active?.organizationId).toBe(ORG_B);
 
-		// A new delivery now routes to org B, NOT org A.
+		// A new delivery now triggers org B's feed, NOT org A's.
 		const second = await router.fetch(
 			issuesDelivery(issuesBody(), { deliveryId: "gh-xfer-2" }),
 		);
-		expect(second.status).toBe(202);
-		expect((await eventRows(`webhook:app_install:${b.id}`)).length).toBe(1);
-		// Org A got nothing new — its single event is the pre-transfer one.
-		expect((await eventRows(`webhook:app_install:${a.id}`)).length).toBe(1);
+		expect(second.status).toBe(200);
+		expect(await feedNextRunAt(feedB)).not.toBeNull();
+		// Org A's feed was left untouched — routing follows the active install.
+		expect(await feedNextRunAt(feedA)).toBeNull();
+		// No raw events on either side throughout the transfer.
+		expect(await allInstallEventCount()).toBe(0);
 	});
 
 	test("a 2nd concurrent active insert for the same tenant is rejected by the unique index", async () => {
@@ -528,14 +574,15 @@ describe("app-installation e2e: token mint via resolveExecutionAuth", () => {
 });
 
 describe("app-installation e2e: multi-replica safety", () => {
-	test("a delivery lands with NO warm in-memory state (stateless, Postgres-mediated)", async () => {
+	test("a delivery triggers with NO warm in-memory state (stateless, Postgres-mediated)", async () => {
 		await seedAgentRow(AGENT_A, { organizationId: ORG_A });
 		const installId = await seedActiveInstall(ORG_A);
+		const feedId = await seedGithubFeed(ORG_A, installId);
 
 		// Simulate a COLD pod: a freshly-built router + a freshly-built store, no
 		// memoized instance, no warm cache. The delivery must still resolve the
-		// install from Postgres and land — proving any replica can serve any
-		// delivery.
+		// install from Postgres and mark the feed due — proving any replica can
+		// serve any delivery.
 		const coldRouter = createAppWebhookRoutes({
 			installationStore: createPostgresAppInstallationStore(),
 			secretStore: { get: async () => null },
@@ -546,10 +593,10 @@ describe("app-installation e2e: multi-replica safety", () => {
 		const res = await coldRouter.fetch(
 			issuesDelivery(issuesBody(), { deliveryId: "gh-cold-1" }),
 		);
-		expect(res.status).toBe(202);
-		const rows = await eventRows(`webhook:app_install:${installId}`);
-		expect(rows.length).toBe(1);
-		expect(rows[0].organization_id).toBe(ORG_A);
+		expect(res.status).toBe(200);
+		expect((await res.json()).triggered).toBe(true);
+		expect(await feedNextRunAt(feedId)).not.toBeNull();
+		expect(await allInstallEventCount()).toBe(0);
 	});
 
 	test("concurrent install upserts for one tenant converge to exactly one active row", async () => {

--- a/packages/server/src/gateway/__tests__/app-installation-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/app-installation-e2e.test.ts
@@ -38,6 +38,7 @@ import {
 	ensureEncryptionKey,
 	resetTestDatabase,
 	seedAgentRow,
+	seedGithubConnectorDef,
 } from "./helpers/db-setup.js";
 
 // One Lobu GitHub App receiving deliveries for many installed tenants.
@@ -255,6 +256,14 @@ beforeEach(async () => {
 		"../installation/registry.js"
 	);
 	__resetInstallationTokenRegistryForTests();
+	// Webhook routing + person rule are read from the connector definition; seed
+	// it for both orgs (the transfer case routes to ORG_B).
+	const { clearEntityLinkRulesCache } = await import(
+		"../../utils/entity-link-upsert.js"
+	);
+	clearEntityLinkRulesCache();
+	await seedGithubConnectorDef(ORG_A);
+	await seedGithubConnectorDef(ORG_B);
 }, 30_000);
 
 afterEach(async () => {

--- a/packages/server/src/gateway/__tests__/app-installation-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/app-installation-e2e.test.ts
@@ -127,30 +127,36 @@ async function githubEvents(organizationId: string): Promise<any[]> {
 
 /**
  * Seed a `github` connection (the trigger path keys on connector_key='github')
- * bound to `installId` via config.installation_ref, plus one ACTIVE issues feed
- * for {owner,name} with next_run_at NULL. A delivery for that repo flips it to
- * now(), so NULL→NOT NULL proves the webhook marked the org's feed due.
+ * bound to `installId` via config.installation_ref, plus one ACTIVE feed (default
+ * `issues`) for {owner,name} with next_run_at NULL. A trigger flips it to now(),
+ * so NULL→NOT NULL proves the webhook marked the org's feed due. The connection
+ * is reused per (org, repo) so multiple feed types don't collide on the slug.
  */
 async function seedGithubFeed(
 	organizationId: string,
 	installId: number,
 	owner = "acme",
 	name = "api",
+	feedKey = "issues",
 ): Promise<number> {
 	const { getDb } = await import("../../db/client.js");
 	const sql = getDb();
-	const [conn] = await sql`
-    INSERT INTO connections (organization_id, connector_key, slug, status, config)
-    VALUES (
-      ${organizationId}, ${"github"}, ${`gh-feed-${organizationId}-${owner}-${name}`},
-      ${"active"}, ${sql.json({ installation_ref: installId })}
-    )
-    RETURNING id
-  `;
+	const slug = `gh-feed-${organizationId}-${owner}-${name}`;
+	let [conn] = await sql`SELECT id FROM connections WHERE organization_id = ${organizationId} AND slug = ${slug}`;
+	if (!conn) {
+		[conn] = await sql`
+      INSERT INTO connections (organization_id, connector_key, slug, status, config)
+      VALUES (
+        ${organizationId}, ${"github"}, ${slug},
+        ${"active"}, ${sql.json({ installation_ref: installId })}
+      )
+      RETURNING id
+    `;
+	}
 	const [feed] = await sql`
     INSERT INTO feeds (organization_id, connection_id, feed_key, status, config, next_run_at)
     VALUES (
-      ${organizationId}, ${conn.id}, ${"issues"}, ${"active"},
+      ${organizationId}, ${conn.id}, ${feedKey}, ${"active"},
       ${sql.json({ repo_owner: owner, repo_name: name })}, NULL
     )
     RETURNING id
@@ -308,7 +314,9 @@ describe("app-installation e2e: star delivery stored directly (event-complete)",
 	test("a star lands a stargazer event under the install's github connection, no poll", async () => {
 		await seedAgentRow(AGENT_A, { organizationId: ORG_A });
 		const installId = await seedActiveInstall(ORG_A);
-		// seeds the github connection (+ an issues feed) the store path resolves.
+		// The store path is gated on a configured stargazers feed (like the trigger
+		// path). Also seed an issues feed to prove the star store doesn't touch it.
+		const stargazersFeed = await seedGithubFeed(ORG_A, installId, "acme", "api", "stargazers");
 		const issuesFeed = await seedGithubFeed(ORG_A, installId);
 		const router = buildRouter();
 
@@ -332,6 +340,9 @@ describe("app-installation e2e: star delivery stored directly (event-complete)",
 		expect(events.length).toBe(1);
 		expect(events[0].origin_type).toBe("stargazer");
 		expect(events[0].origin_id).toBe("stargazer_acme_api_github_user_id_583231");
+		// Store, not trigger: neither the stargazers feed nor the issues feed is
+		// marked due, and no raw app-install event is landed.
+		expect(await feedNextRunAt(stargazersFeed)).toBeNull();
 		expect(await feedNextRunAt(issuesFeed)).toBeNull();
 		expect(await allInstallEventCount()).toBe(0);
 	});

--- a/packages/server/src/gateway/__tests__/app-installation-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/app-installation-e2e.test.ts
@@ -114,6 +114,16 @@ async function allInstallEventCount(): Promise<number> {
 	return rows[0].n as number;
 }
 
+/** Structured github events (connector_key='github') in an org, newest first. */
+async function githubEvents(organizationId: string): Promise<any[]> {
+	const { getDb } = await import("../../db/client.js");
+	return getDb()`
+    SELECT origin_id, origin_type, connection_id, metadata FROM events
+    WHERE organization_id = ${organizationId} AND connector_key = 'github'
+    ORDER BY id
+  `;
+}
+
 /**
  * Seed a `github` connection (the trigger path keys on connector_key='github')
  * bound to `installId` via config.installation_ref, plus one ACTIVE issues feed
@@ -281,6 +291,39 @@ describe("app-installation e2e: install → webhook → trigger (happy path)", (
 		expect(redelivery.status).toBe(200);
 		expect((await redelivery.json()).triggered).toBe(true);
 		expect(await feedNextRunAt(feedId)).not.toBeNull();
+		expect(await allInstallEventCount()).toBe(0);
+	});
+});
+
+describe("app-installation e2e: star delivery stored directly (event-complete)", () => {
+	test("a star lands a stargazer event under the install's github connection, no poll", async () => {
+		await seedAgentRow(AGENT_A, { organizationId: ORG_A });
+		const installId = await seedActiveInstall(ORG_A);
+		// seeds the github connection (+ an issues feed) the store path resolves.
+		const issuesFeed = await seedGithubFeed(ORG_A, installId);
+		const router = buildRouter();
+
+		const starBody = {
+			action: "created",
+			starred_at: "2026-06-20T10:00:00Z",
+			installation: { id: Number(TENANT) },
+			sender: { login: "Octocat", id: 583231 },
+			repository: { owner: { login: "acme" }, name: "api" },
+		};
+		const res = await router.fetch(
+			issuesDelivery(starBody, { deliveryId: "gh-star-e2e", event: "star" }),
+		);
+		expect(res.status).toBe(200);
+		expect((await res.json()).triggered).toBe(true);
+
+		// The structured stargazer event landed under the github connection (so the
+		// scheduled /stargazers poll dedupes it on the same origin_id) — and the
+		// store path did NOT mark the issues feed due (it's a store, not a trigger).
+		const events = await githubEvents(ORG_A);
+		expect(events.length).toBe(1);
+		expect(events[0].origin_type).toBe("stargazer");
+		expect(events[0].origin_id).toBe("stargazer_acme_api_github_user_id_583231");
+		expect(await feedNextRunAt(issuesFeed)).toBeNull();
 		expect(await allInstallEventCount()).toBe(0);
 	});
 });

--- a/packages/server/src/gateway/__tests__/app-webhooks.test.ts
+++ b/packages/server/src/gateway/__tests__/app-webhooks.test.ts
@@ -6,12 +6,14 @@
  * provider POST). We hold the app webhook secret, so we compute a real HMAC
  * over the raw body.
  *
- * GitHub is a TRIGGER provider: it has a sync mapping, so the canonical record
- * is the poll, not the webhook. A signed delivery resolves the acting user into
- * a `person` (keeps the member graph live in real time) and marks the affected
- * repo's feeds due (`next_run_at = now()`) so the poll fetches the structured
- * update — it never stores a raw `events` row. Jira/Linear have no sync mapping,
- * so they still land the raw delivery (connector_key='webhook:app_install:<id>').
+ * GitHub is poll-canonical: it has a sync mapping, so the canonical record is
+ * the poll, not the webhook. Per event type the provider either TRIGGERS (marks
+ * the one affected feed due so the poll fetches the complete record — no actor
+ * resolution; the poll resolves the person once) or, for event-complete signals
+ * (stars), STORES the structured event directly + resolves the actor, keyed on
+ * the same origin_id the poll uses. It never stores a raw `events` row. Jira/
+ * Linear have no sync mapping, so they still land the raw delivery
+ * (connector_key='webhook:app_install:<id>').
  *
  * Under test (GitHub):
  *  1. A signed delivery for a CONFIGURED repo → 200, feeds marked due, NO raw event.

--- a/packages/server/src/gateway/__tests__/app-webhooks.test.ts
+++ b/packages/server/src/gateway/__tests__/app-webhooks.test.ts
@@ -295,6 +295,31 @@ describe("app-webhook router (GitHub)", () => {
 		expect(await feedNextRunAt(otherFeedId)).toBeNull();
 	});
 
+	test("a delivery for an active feed on a PAUSED connection is a no-op", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		const installId = await seedActiveInstall();
+		const feedId = await seedGithubFeed({ installId, owner: "acme", name: "api" });
+		// Pause the github connection; the feed row stays active.
+		const { getDb } = await import("../../db/client.js");
+		await getDb()`
+			UPDATE connections SET status = 'paused'
+			WHERE organization_id = ${ORG} AND connector_key = 'github'
+		`;
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "opened",
+			installation: { id: Number(INSTALLATION_ID) },
+			issue: { number: 1, title: "x" },
+			repository: { owner: { login: "acme" }, name: "api" },
+		});
+		const res = await app.fetch(ghDelivery(raw, { deliveryId: "gh-paused-conn" }));
+		expect(res.status).toBe(200);
+		// Connection isn't active → no feed woken, even though the feed row is.
+		expect((await res.json()).triggered).toBe(false);
+		expect(await feedNextRunAt(feedId)).toBeNull();
+	});
+
 	test("a forged signature is rejected with 401 and lands nothing", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		const installId = await seedActiveInstall();

--- a/packages/server/src/gateway/__tests__/app-webhooks.test.ts
+++ b/packages/server/src/gateway/__tests__/app-webhooks.test.ts
@@ -1,18 +1,23 @@
 /**
  * Shared multi-tenant app-webhook router (app-installation design §4.3).
  *
- * Drives the REAL Hono route (`createAppWebhookRoutes`) → GitHub provider
- * plugin → `handleWebhookIngest` → real Postgres, the path an actual GitHub App
- * delivery exercises (minus the live provider POST). We hold the app webhook
- * secret, so we compute a real `x-hub-signature-256` HMAC over the raw body.
+ * Drives the REAL Hono route (`createAppWebhookRoutes`) → provider plugin →
+ * real Postgres, the path an actual App delivery exercises (minus the live
+ * provider POST). We hold the app webhook secret, so we compute a real HMAC
+ * over the raw body.
  *
- * Under test:
- *  1. A signed `issues` delivery with a seeded ACTIVE install routes to the
- *     owning org and lands an `events` row (connector_key='webhook:app_install:<id>').
- *  2. A forged signature → 401, nothing landed.
- *  3. An unknown tenant (no active install) → 200 ack, nothing landed (the
- *     delivery-before-install-callback case must NOT 500).
- *  4. Redelivery (same x-github-delivery) dedupes to one event.
+ * GitHub is a TRIGGER provider: it has a sync mapping, so the canonical record
+ * is the poll, not the webhook. A signed delivery resolves the acting user into
+ * a `person` (keeps the member graph live in real time) and marks the affected
+ * repo's feeds due (`next_run_at = now()`) so the poll fetches the structured
+ * update — it never stores a raw `events` row. Jira/Linear have no sync mapping,
+ * so they still land the raw delivery (connector_key='webhook:app_install:<id>').
+ *
+ * Under test (GitHub):
+ *  1. A signed delivery for a CONFIGURED repo → 200, feeds marked due, NO raw event.
+ *  2. A delivery for an UNCONFIGURED repo → 200 triggered:false, nothing stored.
+ *  3. The acting user is resolved into a tenant-scoped person (identity graph).
+ *  4. Forged/wrong-secret/tampered → 401; unknown tenant / no install → 200 ack.
  */
 
 import { createHmac } from "node:crypto";
@@ -54,27 +59,6 @@ function buildApp() {
 		providers: [createGithubAppWebhookProvider({ appId: APP_ID })],
 		resolveAppWebhookSecret: async () => APP_SECRET,
 	});
-}
-
-/**
- * Build the router with the github provider's `resolveActor` wrapped in a
- * counter, so a test can assert exactly one resolution per landed event.
- */
-function buildAppWithActorCounter(): { app: ReturnType<typeof createAppWebhookRoutes>; calls: () => number } {
-	const provider = createGithubAppWebhookProvider({ appId: APP_ID });
-	const original = provider.resolveActor!.bind(provider);
-	let count = 0;
-	provider.resolveActor = async (params) => {
-		count += 1;
-		return original(params);
-	};
-	const app = createAppWebhookRoutes({
-		installationStore: createPostgresAppInstallationStore(),
-		secretStore: fakeSecretStore,
-		providers: [provider],
-		resolveAppWebhookSecret: async () => APP_SECRET,
-	});
-	return { app, calls: () => count };
 }
 
 /** Seed an ACTIVE github installation for the routed tenant tuple. */
@@ -121,6 +105,57 @@ async function eventRows(connectorKey: string): Promise<any[]> {
   `;
 }
 
+/** Count every raw app-install event regardless of which install key it landed under. */
+async function appInstallEventCount(): Promise<number> {
+	const { getDb } = await import("../../db/client.js");
+	const [row] = await getDb()`
+    SELECT count(*)::int AS n FROM events WHERE connector_key LIKE 'webhook:app_install:%'
+  `;
+	return row.n;
+}
+
+/**
+ * Seed a github connection bound to `installId` (its config.installation_ref is
+ * the app_installations row id, exactly as the install callback writes it) plus
+ * one ACTIVE feed for {owner,name} with `next_run_at` NULL. A trigger sets it to
+ * now(), so NULL→NOT NULL cleanly proves the webhook marked the feed due.
+ */
+async function seedGithubFeed(opts: {
+	installId: number;
+	owner: string;
+	name: string;
+	feedKey?: string;
+}): Promise<number> {
+	const { getDb } = await import("../../db/client.js");
+	const sql = getDb();
+	const [conn] = await sql`
+    INSERT INTO connections (
+      organization_id, connector_key, slug, display_name, status, config, visibility, created_at, updated_at
+    ) VALUES (
+      ${ORG}, 'github', ${`github-${opts.owner}-${opts.name}`}, 'GitHub', 'active',
+      ${sql.json({ installation_ref: opts.installId })}, 'org', NOW(), NOW()
+    )
+    RETURNING id
+  `;
+	const [feed] = await sql`
+    INSERT INTO feeds (
+      organization_id, connection_id, feed_key, display_name, status, config, next_run_at
+    ) VALUES (
+      ${ORG}, ${conn.id}, ${opts.feedKey ?? "issues"}, 'Issues', 'active',
+      ${sql.json({ repo_owner: opts.owner, repo_name: opts.name })}, NULL
+    )
+    RETURNING id
+  `;
+	return Number(feed.id);
+}
+
+/** Current `next_run_at` of a feed (NULL until a trigger marks it due). */
+async function feedNextRunAt(feedId: number): Promise<unknown> {
+	const { getDb } = await import("../../db/client.js");
+	const [row] = await getDb()`SELECT next_run_at FROM feeds WHERE id = ${feedId}`;
+	return row?.next_run_at ?? null;
+}
+
 /**
  * Seed the prerequisites for actor → person resolution in the routed org: an
  * org member (entities.created_by is NOT NULL — resolveOrgCreator reads it) and
@@ -158,22 +193,6 @@ async function personRows(orgId: string): Promise<any[]> {
   `;
 }
 
-/**
- * Parse `events.entity_ids` regardless of how the driver hands it back: this
- * gateway (bun:test) harness reads the raw column as a Postgres array literal
- * string (`"{1,2}"` / `"{}"`); other paths return a JS array. Normalize to
- * number[] so the attribution assertion is driver-agnostic.
- */
-function parseEntityIds(value: unknown): number[] {
-	if (Array.isArray(value)) return value.map((v) => Number(v));
-	if (typeof value === "string") {
-		const inner = value.replace(/^\{|\}$/g, "").trim();
-		if (!inner) return [];
-		return inner.split(",").map((s) => Number(s));
-	}
-	return [];
-}
-
 async function identitiesFor(entityId: number): Promise<string[]> {
 	const { getDb } = await import("../../db/client.js");
 	const rows = await getDb()`
@@ -198,9 +217,16 @@ beforeEach(async () => {
 }, 30_000);
 
 describe("app-webhook router (GitHub)", () => {
-	test("a signed issues delivery routes to the owning org and lands an event", async () => {
+	test("a signed delivery for a configured repo marks its feeds due and stores NO raw event", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		const installId = await seedActiveInstall();
+		// A github connection bound to this install + an active issues feed for the
+		// repo the delivery is about. next_run_at starts NULL.
+		const feedId = await seedGithubFeed({
+			installId,
+			owner: "acme",
+			name: "api",
+		});
 		const app = buildApp();
 
 		const raw = JSON.stringify({
@@ -211,90 +237,43 @@ describe("app-webhook router (GitHub)", () => {
 				title: "Prod is down",
 				html_url: "https://github.com/acme/api/issues/11",
 			},
-			repository: { full_name: "acme/api" },
+			repository: { owner: { login: "acme" }, name: "api", full_name: "acme/api" },
 		});
 		const res = await app.fetch(ghDelivery(raw));
-		expect(res.status).toBe(202);
+		// Trigger path acks 200 (not 202 — nothing was landed as a record).
+		expect(res.status).toBe(200);
+		expect((await res.json()).triggered).toBe(true);
 
-		const rows = await eventRows(`webhook:app_install:${installId}`);
-		expect(rows.length).toBe(1);
-		// EL: the raw GitHub payload is what landed — untransformed.
-		expect(rows[0].payload_data).toEqual({
-			action: "opened",
-			installation: { id: Number(INSTALLATION_ID) },
-			issue: {
-				number: 11,
-				title: "Prod is down",
-				html_url: "https://github.com/acme/api/issues/11",
-			},
-			repository: { full_name: "acme/api" },
-		});
-		// Routed into the install's owning org, deduped on the delivery id.
-		expect(rows[0].organization_id).toBe(ORG);
-		expect(rows[0].origin_id).toBe("gh-app-1");
-		// Title + source_url projected from the issue (not left empty).
-		expect(rows[0].title).toBe("Prod is down");
-		expect(rows[0].source_url).toBe("https://github.com/acme/api/issues/11");
+		// The poll is the canonical record, so the webhook stores no raw event…
+		expect(await appInstallEventCount()).toBe(0);
+		// …it just marks the affected feed due (NULL → now()).
+		expect(await feedNextRunAt(feedId)).not.toBeNull();
 	});
 
-	test("an issue_comment delivery lands the parent issue title + comment url", async () => {
+	test("a delivery for an unconfigured repo acks 200 triggered:false and stores nothing", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		const installId = await seedActiveInstall();
-		const app = buildApp();
-
-		const raw = JSON.stringify({
-			action: "created",
-			installation: { id: Number(INSTALLATION_ID) },
-			issue: {
-				number: 11,
-				title: "Prod is down",
-				html_url: "https://github.com/acme/api/issues/11",
-			},
-			comment: {
-				id: 555,
-				body: "Looking into it",
-				html_url: "https://github.com/acme/api/issues/11#issuecomment-555",
-			},
-			repository: { full_name: "acme/api" },
+		// A feed exists, but for a DIFFERENT repo than the delivery is about.
+		const otherFeedId = await seedGithubFeed({
+			installId,
+			owner: "acme",
+			name: "other",
 		});
-		const res = await app.fetch(
-			ghDelivery(raw, { deliveryId: "gh-comment-1", event: "issue_comment" }),
-		);
-		expect(res.status).toBe(202);
-
-		const rows = await eventRows(`webhook:app_install:${installId}`);
-		expect(rows.length).toBe(1);
-		// Title is the PARENT issue's; url deep-links the comment itself.
-		expect(rows[0].title).toBe("Prod is down");
-		expect(rows[0].source_url).toBe(
-			"https://github.com/acme/api/issues/11#issuecomment-555",
-		);
-	});
-
-	test("a pull_request delivery lands the PR title + html_url", async () => {
-		await seedAgentRow(AGENT, { organizationId: ORG });
-		const installId = await seedActiveInstall();
 		const app = buildApp();
 
 		const raw = JSON.stringify({
 			action: "opened",
 			installation: { id: Number(INSTALLATION_ID) },
-			pull_request: {
-				number: 42,
-				title: "Add app_installation auth method",
-				html_url: "https://github.com/acme/api/pull/42",
-			},
-			repository: { full_name: "acme/api" },
+			issue: { number: 1, title: "x" },
+			repository: { owner: { login: "acme" }, name: "api", full_name: "acme/api" },
 		});
-		const res = await app.fetch(
-			ghDelivery(raw, { deliveryId: "gh-pr-1", event: "pull_request" }),
-		);
-		expect(res.status).toBe(202);
-
-		const rows = await eventRows(`webhook:app_install:${installId}`);
-		expect(rows.length).toBe(1);
-		expect(rows[0].title).toBe("Add app_installation auth method");
-		expect(rows[0].source_url).toBe("https://github.com/acme/api/pull/42");
+		const res = await app.fetch(ghDelivery(raw, { deliveryId: "gh-unconf-1" }));
+		expect(res.status).toBe(200);
+		// No matching feed for acme/api → triggered:false, a no-op (not an error).
+		expect((await res.json()).triggered).toBe(false);
+		expect(await appInstallEventCount()).toBe(0);
+		// The unrelated repo's feed was left untouched.
+		expect(await feedNextRunAt(otherFeedId)).toBeNull();
 	});
 
 	test("a forged signature is rejected with 401 and lands nothing", async () => {
@@ -408,30 +387,33 @@ describe("app-webhook router (GitHub)", () => {
 		expect((await res.json()).landed).toBe(false);
 	});
 
-	test("redelivery of the same x-github-delivery dedupes to one event", async () => {
+	test("a redelivery just re-stamps next_run_at — idempotent, still no event", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		const installId = await seedActiveInstall();
+		const feedId = await seedGithubFeed({ installId, owner: "acme", name: "api" });
 		const app = buildApp();
 
 		const raw = JSON.stringify({
 			action: "edited",
 			installation: { id: Number(INSTALLATION_ID) },
 			issue: { number: 9 },
+			repository: { owner: { login: "acme" }, name: "api" },
 		});
 		const first = await app.fetch(ghDelivery(raw, { deliveryId: "gh-dupe-1" }));
 		const second = await app.fetch(ghDelivery(raw, { deliveryId: "gh-dupe-1" }));
-		expect(first.status).toBe(202);
-		expect(second.status).toBe(202);
-		expect((await second.json()).duplicate).toBe(true);
-		const rows = await eventRows(`webhook:app_install:${installId}`);
-		expect(rows.length).toBe(1);
-		expect(rows[0].origin_id).toBe("gh-dupe-1");
+		expect(first.status).toBe(200);
+		expect(second.status).toBe(200);
+		expect((await second.json()).triggered).toBe(true);
+		// Re-stamping next_run_at is idempotent; the poll (not the webhook) dedupes
+		// the actual content by stable origin_id, so still nothing landed raw.
+		expect(await feedNextRunAt(feedId)).not.toBeNull();
+		expect(await appInstallEventCount()).toBe(0);
 	});
 
-	test("a signed delivery resolves the actor → person and lands NON-EMPTY entity_ids", async () => {
+	test("a signed delivery resolves the acting user into a tenant-scoped person (no raw event)", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		await seedPersonResolutionPrereqs(ORG);
-		const installId = await seedActiveInstall();
+		await seedActiveInstall();
 		const app = buildApp();
 
 		const raw = JSON.stringify({
@@ -444,12 +426,13 @@ describe("app-webhook router (GitHub)", () => {
 				user: { login: "Octocat", id: 583231 },
 			},
 			sender: { login: "Octocat", id: 583231 },
-			repository: { full_name: "acme/api" },
+			repository: { owner: { login: "acme" }, name: "api" },
 		});
 		const res = await app.fetch(ghDelivery(raw, { deliveryId: "gh-attr-1" }));
-		expect(res.status).toBe(202);
+		expect(res.status).toBe(200);
 
-		// A person was created for the issue author and the row is attributed.
+		// The webhook keeps the member graph live: a person was created for the
+		// issue author, keyed on the same identity namespaces as the poll path…
 		const people = await personRows(ORG);
 		expect(people.length).toBe(1);
 		expect(people[0].name).toBe("Octocat");
@@ -457,19 +440,14 @@ describe("app-webhook router (GitHub)", () => {
 			"github_login:octocat",
 			"github_user_id:583231",
 		]);
-
-		const rows = await eventRows(`webhook:app_install:${installId}`);
-		expect(rows.length).toBe(1);
-		// THE assertion the PR claims: the landed row carries the resolved person.
-		expect(parseEntityIds(rows[0].entity_ids)).toEqual([Number(people[0].id)]);
-		// Canonical read-time identity slot stamped onto the row.
-		expect(rows[0].metadata.github_login).toBe("octocat");
+		// …without storing a raw event (the poll is the canonical record).
+		expect(await appInstallEventCount()).toBe(0);
 	});
 
 	test("an issue_comment delivery attributes the COMMENT author, not the issue author", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		await seedPersonResolutionPrereqs(ORG);
-		const installId = await seedActiveInstall();
+		await seedActiveInstall();
 		const app = buildApp();
 
 		const raw = JSON.stringify({
@@ -488,27 +466,25 @@ describe("app-webhook router (GitHub)", () => {
 				user: { login: "Hubot", id: 42 },
 			},
 			sender: { login: "Hubot", id: 42 },
-			repository: { full_name: "acme/api" },
+			repository: { owner: { login: "acme" }, name: "api" },
 		});
 		const res = await app.fetch(
 			ghDelivery(raw, { deliveryId: "gh-attr-2", event: "issue_comment" }),
 		);
-		expect(res.status).toBe(202);
+		expect(res.status).toBe(200);
 
 		const people = await personRows(ORG);
 		// Only the comment author is resolved by this delivery.
 		expect(people.length).toBe(1);
 		expect(people[0].name).toBe("Hubot");
-
-		const rows = await eventRows(`webhook:app_install:${installId}`);
-		expect(parseEntityIds(rows[0].entity_ids)).toEqual([Number(people[0].id)]);
-		expect(rows[0].metadata.github_login).toBe("hubot");
+		expect(await appInstallEventCount()).toBe(0);
 	});
 
-	test("an unmapped event (push) lands the row but resolves no actor (empty entity_ids)", async () => {
+	test("an unmapped event (push) triggers the repo sync but resolves no actor", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		await seedPersonResolutionPrereqs(ORG);
 		const installId = await seedActiveInstall();
+		const feedId = await seedGithubFeed({ installId, owner: "acme", name: "api" });
 		const app = buildApp();
 
 		const raw = JSON.stringify({
@@ -516,22 +492,25 @@ describe("app-webhook router (GitHub)", () => {
 			installation: { id: Number(INSTALLATION_ID) },
 			pusher: { name: "someone" },
 			sender: { login: "someone", id: 9 },
+			repository: { owner: { login: "acme" }, name: "api" },
 		});
 		const res = await app.fetch(
 			ghDelivery(raw, { deliveryId: "gh-push-1", event: "push" }),
 		);
-		expect(res.status).toBe(202);
-		// Delivery still lands (store-everything), just unattributed.
-		const rows = await eventRows(`webhook:app_install:${installId}`);
-		expect(rows.length).toBe(1);
-		expect(parseEntityIds(rows[0].entity_ids)).toEqual([]);
+		expect(res.status).toBe(200);
+		// push carries a repo, so it still marks the feed due…
+		expect((await res.json()).triggered).toBe(true);
+		expect(await feedNextRunAt(feedId)).not.toBeNull();
+		// …but `push` is not an authored-content event, so no person is resolved.
 		expect(await personRows(ORG)).toHaveLength(0);
+		expect(await appInstallEventCount()).toBe(0);
 	});
 
-	test("a redelivered (deduped) delivery does NOT create a person, bump the graph, or land a second event", async () => {
+	test("two deliveries of the same actor resolve to ONE person (idempotent), never an event", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		await seedPersonResolutionPrereqs(ORG);
 		const installId = await seedActiveInstall();
+		await seedGithubFeed({ installId, owner: "acme", name: "api" });
 		const app = buildApp();
 
 		const raw = JSON.stringify({
@@ -544,70 +523,20 @@ describe("app-webhook router (GitHub)", () => {
 				user: { login: "Octocat", id: 583231 },
 			},
 			sender: { login: "Octocat", id: 583231 },
-			repository: { full_name: "acme/api" },
+			repository: { owner: { login: "acme" }, name: "api" },
 		});
 
-		// First delivery: persists + resolves the actor → one person.
-		const first = await app.fetch(ghDelivery(raw, { deliveryId: "gh-dedupe-attr" }));
-		expect(first.status).toBe(202);
-		const peopleAfterFirst = await personRows(ORG);
-		expect(peopleAfterFirst.length).toBe(1);
-		const firstAuthoredAt = peopleAfterFirst[0].metadata.last_authored_at;
-		expect(firstAuthoredAt).toBeTruthy();
+		const first = await app.fetch(ghDelivery(raw, { deliveryId: "gh-idem-1" }));
+		const second = await app.fetch(ghDelivery(raw, { deliveryId: "gh-idem-2" }));
+		expect(first.status).toBe(200);
+		expect(second.status).toBe(200);
 
-		// Redelivery of the SAME x-github-delivery: deduped → no new event AND no
-		// entity-graph mutation (no second person, last_authored_at unchanged).
-		const second = await app.fetch(ghDelivery(raw, { deliveryId: "gh-dedupe-attr" }));
-		expect(second.status).toBe(202);
-		expect((await second.json()).duplicate).toBe(true);
-
-		const peopleAfterSecond = await personRows(ORG);
-		expect(peopleAfterSecond.length).toBe(1);
-		// Same person, untouched — resolution never ran on the duplicate.
-		expect(peopleAfterSecond[0].id).toBe(peopleAfterFirst[0].id);
-		expect(peopleAfterSecond[0].metadata.last_authored_at).toBe(firstAuthoredAt);
-
-		// Exactly one event landed.
-		const rows = await eventRows(`webhook:app_install:${installId}`);
-		expect(rows.length).toBe(1);
-	});
-
-	test("TWO concurrent deliveries of the same event resolve the actor exactly once", async () => {
-		await seedAgentRow(AGENT, { organizationId: ORG });
-		await seedPersonResolutionPrereqs(ORG);
-		const installId = await seedActiveInstall();
-		const { app, calls } = buildAppWithActorCounter();
-
-		const raw = JSON.stringify({
-			action: "opened",
-			installation: { id: Number(INSTALLATION_ID) },
-			issue: {
-				number: 11,
-				title: "Prod is down",
-				html_url: "https://github.com/acme/api/issues/11",
-				user: { login: "Octocat", id: 583231 },
-			},
-			sender: { login: "Octocat", id: 583231 },
-			repository: { full_name: "acme/api" },
-		});
-
-		// Fire both deliveries of the SAME x-github-delivery simultaneously. The
-		// delivery-unique index picks one winner; the loser's tx rolls back before
-		// it ever resolves the actor.
-		const [a, b] = await Promise.all([
-			app.fetch(ghDelivery(raw, { deliveryId: "gh-concurrent" })),
-			app.fetch(ghDelivery(raw, { deliveryId: "gh-concurrent" })),
-		]);
-		expect([a.status, b.status]).toEqual([202, 202]);
-
-		// Exactly one actor resolution, one event, one person, one last_authored_at.
-		expect(calls()).toBe(1);
-		const rows = await eventRows(`webhook:app_install:${installId}`);
-		expect(rows.length).toBe(1);
-		expect(parseEntityIds(rows[0].entity_ids).length).toBe(1);
+		// The entity-link upsert is idempotent: two deliveries → one person, and
+		// the webhook never stores an event on either delivery.
 		const people = await personRows(ORG);
 		expect(people.length).toBe(1);
 		expect(people[0].metadata.last_authored_at).toBeTruthy();
+		expect(await appInstallEventCount()).toBe(0);
 	});
 
 	test("an unknown provider path returns 404", async () => {

--- a/packages/server/src/gateway/__tests__/app-webhooks.test.ts
+++ b/packages/server/src/gateway/__tests__/app-webhooks.test.ts
@@ -128,15 +128,21 @@ async function seedGithubFeed(opts: {
 }): Promise<number> {
 	const { getDb } = await import("../../db/client.js");
 	const sql = getDb();
-	const [conn] = await sql`
-    INSERT INTO connections (
-      organization_id, connector_key, slug, display_name, status, config, visibility, created_at, updated_at
-    ) VALUES (
-      ${ORG}, 'github', ${`github-${opts.owner}-${opts.name}`}, 'GitHub', 'active',
-      ${sql.json({ installation_ref: opts.installId })}, 'org', NOW(), NOW()
-    )
-    RETURNING id
-  `;
+	// One github connection per (install, repo), reused across feed types — so
+	// seeding e.g. both issues + commits feeds doesn't collide on the slug.
+	const slug = `github-${opts.owner}-${opts.name}`;
+	let [conn] = await sql`SELECT id FROM connections WHERE organization_id = ${ORG} AND slug = ${slug}`;
+	if (!conn) {
+		[conn] = await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status, config, visibility, created_at, updated_at
+      ) VALUES (
+        ${ORG}, 'github', ${slug}, 'GitHub', 'active',
+        ${sql.json({ installation_ref: opts.installId })}, 'org', NOW(), NOW()
+      )
+      RETURNING id
+    `;
+	}
 	const [feed] = await sql`
     INSERT INTO feeds (
       organization_id, connection_id, feed_key, display_name, status, config, next_run_at
@@ -217,15 +223,17 @@ beforeEach(async () => {
 }, 30_000);
 
 describe("app-webhook router (GitHub)", () => {
-	test("a signed delivery for a configured repo marks its feeds due and stores NO raw event", async () => {
+	test("an issues delivery marks ONLY the issues feed due (scoped, no raw event)", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		const installId = await seedActiveInstall();
-		// A github connection bound to this install + an active issues feed for the
-		// repo the delivery is about. next_run_at starts NULL.
-		const feedId = await seedGithubFeed({
+		// Two feeds on the same repo. An `issues` delivery must trigger only the
+		// issues feed — not re-poll commits.
+		const issuesFeed = await seedGithubFeed({ installId, owner: "acme", name: "api" });
+		const commitsFeed = await seedGithubFeed({
 			installId,
 			owner: "acme",
 			name: "api",
+			feedKey: "commits",
 		});
 		const app = buildApp();
 
@@ -246,8 +254,9 @@ describe("app-webhook router (GitHub)", () => {
 
 		// The poll is the canonical record, so the webhook stores no raw event…
 		expect(await appInstallEventCount()).toBe(0);
-		// …it just marks the affected feed due (NULL → now()).
-		expect(await feedNextRunAt(feedId)).not.toBeNull();
+		// …it marks the issues feed due (NULL → now()) and leaves commits untouched.
+		expect(await feedNextRunAt(issuesFeed)).not.toBeNull();
+		expect(await feedNextRunAt(commitsFeed)).toBeNull();
 	});
 
 	test("a delivery for an unconfigured repo acks 200 triggered:false and stores nothing", async () => {
@@ -410,29 +419,40 @@ describe("app-webhook router (GitHub)", () => {
 		expect(await appInstallEventCount()).toBe(0);
 	});
 
-	test("a signed delivery resolves the acting user into a tenant-scoped person (no raw event)", async () => {
+	test("a star delivery stores a stargazer event + resolves the actor, without triggering a poll", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		await seedPersonResolutionPrereqs(ORG);
-		await seedActiveInstall();
+		const installId = await seedActiveInstall();
+		// The stargazers feed exists as the scheduled backstop; the store path must
+		// NOT mark it due (re-polling the whole list to capture one star is waste).
+		const stargazersFeed = await seedGithubFeed({
+			installId,
+			owner: "acme",
+			name: "api",
+			feedKey: "stargazers",
+		});
 		const app = buildApp();
 
 		const raw = JSON.stringify({
-			action: "opened",
+			action: "created",
+			starred_at: "2026-06-20T10:00:00Z",
 			installation: { id: Number(INSTALLATION_ID) },
-			issue: {
-				number: 11,
-				title: "Prod is down",
-				html_url: "https://github.com/acme/api/issues/11",
-				user: { login: "Octocat", id: 583231 },
-			},
-			sender: { login: "Octocat", id: 583231 },
+			sender: { login: "Octocat", id: 583231, html_url: "https://github.com/Octocat" },
 			repository: { owner: { login: "acme" }, name: "api" },
 		});
-		const res = await app.fetch(ghDelivery(raw, { deliveryId: "gh-attr-1" }));
+		const res = await app.fetch(ghDelivery(raw, { deliveryId: "gh-star-1", event: "star" }));
 		expect(res.status).toBe(200);
+		expect((await res.json()).triggered).toBe(true);
 
-		// The webhook keeps the member graph live: a person was created for the
-		// issue author, keyed on the same identity namespaces as the poll path…
+		// A structured stargazer event landed under the github connection, keyed on
+		// the SAME origin_id the poll uses — so the /stargazers backstop dedupes it.
+		const events = await eventRows("github");
+		expect(events.length).toBe(1);
+		expect(events[0].origin_type).toBe("stargazer");
+		expect(events[0].origin_id).toBe("stargazer_acme_api_github_user_id_583231");
+		expect(events[0].metadata.action).toBe("starred");
+
+		// The actor was resolved to a person (the poll won't run for this feed)…
 		const people = await personRows(ORG);
 		expect(people.length).toBe(1);
 		expect(people[0].name).toBe("Octocat");
@@ -440,51 +460,59 @@ describe("app-webhook router (GitHub)", () => {
 			"github_login:octocat",
 			"github_user_id:583231",
 		]);
-		// …without storing a raw event (the poll is the canonical record).
-		expect(await appInstallEventCount()).toBe(0);
+		// …and the wasteful poll was NOT triggered.
+		expect(await feedNextRunAt(stargazersFeed)).toBeNull();
 	});
 
-	test("an issue_comment delivery attributes the COMMENT author, not the issue author", async () => {
-		await seedAgentRow(AGENT, { organizationId: ORG });
-		await seedPersonResolutionPrereqs(ORG);
-		await seedActiveInstall();
-		const app = buildApp();
-
-		const raw = JSON.stringify({
-			action: "created",
-			installation: { id: Number(INSTALLATION_ID) },
-			issue: {
-				number: 11,
-				title: "Prod is down",
-				html_url: "https://github.com/acme/api/issues/11",
-				user: { login: "issue-author", id: 1 },
-			},
-			comment: {
-				id: 555,
-				body: "Looking into it",
-				html_url: "https://github.com/acme/api/issues/11#issuecomment-555",
-				user: { login: "Hubot", id: 42 },
-			},
-			sender: { login: "Hubot", id: 42 },
-			repository: { owner: { login: "acme" }, name: "api" },
-		});
-		const res = await app.fetch(
-			ghDelivery(raw, { deliveryId: "gh-attr-2", event: "issue_comment" }),
-		);
-		expect(res.status).toBe(200);
-
-		const people = await personRows(ORG);
-		// Only the comment author is resolved by this delivery.
-		expect(people.length).toBe(1);
-		expect(people[0].name).toBe("Hubot");
-		expect(await appInstallEventCount()).toBe(0);
-	});
-
-	test("an unmapped event (push) triggers the repo sync but resolves no actor", async () => {
+	test("with storeWebhookEvents off, a star falls back to a poll trigger (nothing stored)", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		await seedPersonResolutionPrereqs(ORG);
 		const installId = await seedActiveInstall();
-		const feedId = await seedGithubFeed({ installId, owner: "acme", name: "api" });
+		const stargazersFeed = await seedGithubFeed({
+			installId,
+			owner: "acme",
+			name: "api",
+			feedKey: "stargazers",
+		});
+		const app = createAppWebhookRoutes({
+			installationStore: createPostgresAppInstallationStore(),
+			secretStore: fakeSecretStore,
+			providers: [
+				createGithubAppWebhookProvider({ appId: APP_ID, storeWebhookEvents: false }),
+			],
+			resolveAppWebhookSecret: async () => APP_SECRET,
+		});
+
+		const raw = JSON.stringify({
+			action: "created",
+			starred_at: "2026-06-20T10:00:00Z",
+			installation: { id: Number(INSTALLATION_ID) },
+			sender: { login: "Octocat", id: 583231 },
+			repository: { owner: { login: "acme" }, name: "api" },
+		});
+		const res = await app.fetch(ghDelivery(raw, { deliveryId: "gh-star-off", event: "star" }));
+		expect(res.status).toBe(200);
+		expect((await res.json()).triggered).toBe(true);
+
+		// Flag off → no direct store; the stargazers feed is marked due for the poll
+		// instead, and no person is resolved on the trigger path.
+		expect(await eventRows("github")).toHaveLength(0);
+		expect(await personRows(ORG)).toHaveLength(0);
+		expect(await feedNextRunAt(stargazersFeed)).not.toBeNull();
+	});
+
+	test("a push delivery triggers the COMMITS feed (not issues) and resolves no actor", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedPersonResolutionPrereqs(ORG);
+		const installId = await seedActiveInstall();
+		// push maps to the commits feed; an issues feed on the same repo must stay put.
+		const commitsFeed = await seedGithubFeed({
+			installId,
+			owner: "acme",
+			name: "api",
+			feedKey: "commits",
+		});
+		const issuesFeed = await seedGithubFeed({ installId, owner: "acme", name: "api" });
 		const app = buildApp();
 
 		const raw = JSON.stringify({
@@ -498,45 +526,42 @@ describe("app-webhook router (GitHub)", () => {
 			ghDelivery(raw, { deliveryId: "gh-push-1", event: "push" }),
 		);
 		expect(res.status).toBe(200);
-		// push carries a repo, so it still marks the feed due…
+		// push → commits feed marked due; issues feed untouched.
 		expect((await res.json()).triggered).toBe(true);
-		expect(await feedNextRunAt(feedId)).not.toBeNull();
-		// …but `push` is not an authored-content event, so no person is resolved.
+		expect(await feedNextRunAt(commitsFeed)).not.toBeNull();
+		expect(await feedNextRunAt(issuesFeed)).toBeNull();
+		// push isn't an authored-content event for the trigger path, and triggers
+		// never resolve actors anyway, so no person is created.
 		expect(await personRows(ORG)).toHaveLength(0);
 		expect(await appInstallEventCount()).toBe(0);
 	});
 
-	test("two deliveries of the same actor resolve to ONE person (idempotent), never an event", async () => {
+	test("two star deliveries from the same user consolidate to ONE event + ONE person", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		await seedPersonResolutionPrereqs(ORG);
 		const installId = await seedActiveInstall();
-		await seedGithubFeed({ installId, owner: "acme", name: "api" });
+		await seedGithubFeed({ installId, owner: "acme", name: "api", feedKey: "stargazers" });
 		const app = buildApp();
 
 		const raw = JSON.stringify({
-			action: "opened",
+			action: "created",
+			starred_at: "2026-06-20T10:00:00Z",
 			installation: { id: Number(INSTALLATION_ID) },
-			issue: {
-				number: 11,
-				title: "Prod is down",
-				html_url: "https://github.com/acme/api/issues/11",
-				user: { login: "Octocat", id: 583231 },
-			},
 			sender: { login: "Octocat", id: 583231 },
 			repository: { owner: { login: "acme" }, name: "api" },
 		});
 
-		const first = await app.fetch(ghDelivery(raw, { deliveryId: "gh-idem-1" }));
-		const second = await app.fetch(ghDelivery(raw, { deliveryId: "gh-idem-2" }));
+		const first = await app.fetch(ghDelivery(raw, { deliveryId: "gh-star-a", event: "star" }));
+		const second = await app.fetch(ghDelivery(raw, { deliveryId: "gh-star-b", event: "star" }));
 		expect(first.status).toBe(200);
 		expect(second.status).toBe(200);
 
-		// The entity-link upsert is idempotent: two deliveries → one person, and
-		// the webhook never stores an event on either delivery.
+		// Same actor → same origin_id → the insert upserts: one stargazer event,
+		// and the entity-link upsert keeps it to one person.
+		expect(await eventRows("github")).toHaveLength(1);
 		const people = await personRows(ORG);
 		expect(people.length).toBe(1);
 		expect(people[0].metadata.last_authored_at).toBeTruthy();
-		expect(await appInstallEventCount()).toBe(0);
 	});
 
 	test("an unknown provider path returns 404", async () => {

--- a/packages/server/src/gateway/__tests__/app-webhooks.test.ts
+++ b/packages/server/src/gateway/__tests__/app-webhooks.test.ts
@@ -497,6 +497,32 @@ describe("app-webhook router (GitHub)", () => {
 		expect(await personRows(ORG)).toHaveLength(0);
 	});
 
+	test("a star with different repo casing matches the feed and uses the feed's canonical origin_id", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedPersonResolutionPrereqs(ORG);
+		const installId = await seedActiveInstall();
+		// Feed config is lowercase acme/api; the delivery uses display casing.
+		await seedGithubFeed({ installId, owner: "acme", name: "api", feedKey: "stargazers" });
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "created",
+			starred_at: "2026-06-20T10:00:00Z",
+			installation: { id: Number(INSTALLATION_ID) },
+			sender: { login: "Octocat", id: 583231 },
+			repository: { owner: { login: "ACME" }, name: "API" },
+		});
+		const res = await app.fetch(ghDelivery(raw, { deliveryId: "gh-star-case", event: "star" }));
+		expect(res.status).toBe(200);
+		expect((await res.json()).triggered).toBe(true);
+
+		// Matched case-insensitively, and origin_id uses the feed's casing so it
+		// consolidates with the poll (which keys off the feed config, not the payload).
+		const events = await eventRows("github");
+		expect(events.length).toBe(1);
+		expect(events[0].origin_id).toBe("stargazer_acme_api_github_user_id_583231");
+	});
+
 	test("with storeWebhookEvents off, a star falls back to a poll trigger (nothing stored)", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		await seedPersonResolutionPrereqs(ORG);

--- a/packages/server/src/gateway/__tests__/app-webhooks.test.ts
+++ b/packages/server/src/gateway/__tests__/app-webhooks.test.ts
@@ -474,6 +474,29 @@ describe("app-webhook router (GitHub)", () => {
 		expect(await feedNextRunAt(stargazersFeed)).toBeNull();
 	});
 
+	test("a star for a repo with no stargazers feed configured is a no-op (nothing stored)", async () => {
+		await seedAgentRow(AGENT, { organizationId: ORG });
+		await seedPersonResolutionPrereqs(ORG);
+		// Routing comes from the seeded connector def (star → store), but there is
+		// NO stargazers feed instance for acme/api — so the store path must no-op,
+		// mirroring the trigger path's "unconfigured feed → nothing happens".
+		await seedActiveInstall();
+		const app = buildApp();
+
+		const raw = JSON.stringify({
+			action: "created",
+			starred_at: "2026-06-20T10:00:00Z",
+			installation: { id: Number(INSTALLATION_ID) },
+			sender: { login: "Octocat", id: 583231 },
+			repository: { owner: { login: "acme" }, name: "api" },
+		});
+		const res = await app.fetch(ghDelivery(raw, { deliveryId: "gh-star-nofeed", event: "star" }));
+		expect(res.status).toBe(200);
+		expect((await res.json()).triggered).toBe(false);
+		expect(await eventRows("github")).toHaveLength(0);
+		expect(await personRows(ORG)).toHaveLength(0);
+	});
+
 	test("with storeWebhookEvents off, a star falls back to a poll trigger (nothing stored)", async () => {
 		await seedAgentRow(AGENT, { organizationId: ORG });
 		await seedPersonResolutionPrereqs(ORG);

--- a/packages/server/src/gateway/__tests__/app-webhooks.test.ts
+++ b/packages/server/src/gateway/__tests__/app-webhooks.test.ts
@@ -37,6 +37,7 @@ import {
 	ensureEncryptionKey,
 	resetTestDatabase,
 	seedAgentRow,
+	seedGithubConnectorDef,
 } from "./helpers/db-setup.js";
 
 const ORG = "org-app-webhook";
@@ -222,6 +223,13 @@ beforeEach(async () => {
 		"../../utils/rate-limiter.js"
 	);
 	resetRateLimiterForTests();
+	// The github webhook routing + person rule are read from the connector
+	// definition (feeds_schema), so every github delivery test needs it seeded.
+	const { clearEntityLinkRulesCache } = await import(
+		"../../utils/entity-link-upsert.js"
+	);
+	clearEntityLinkRulesCache();
+	await seedGithubConnectorDef(ORG);
 }, 30_000);
 
 describe("app-webhook router (GitHub)", () => {

--- a/packages/server/src/gateway/__tests__/helpers/db-setup.ts
+++ b/packages/server/src/gateway/__tests__/helpers/db-setup.ts
@@ -135,3 +135,70 @@ export async function seedAgentRow(
   `;
   return orgId;
 }
+
+/**
+ * Seed a `github` connector_definitions row whose feeds_schema carries the
+ * webhook routing (`webhook: { events, mode }`) + the person entity-link rule —
+ * the exact persisted surface the app-webhook router reads (routing via
+ * loadGithubWebhookRoutes, the rule via loadEntityLinkRuleByType). Mirrors the
+ * real github connector's declarations so the gateway tests exercise the
+ * DB-driven path, not a server-side hardcode.
+ */
+export async function seedGithubConnectorDef(orgId: string): Promise<void> {
+  const sql = getDb();
+  await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${orgId}, ${orgId}, ${orgId})
+    ON CONFLICT (id) DO NOTHING
+  `;
+  const personRule = {
+    entityType: "person",
+    autoCreate: true,
+    titlePath: "metadata.author_login",
+    identities: [
+      { namespace: "github_user_id", eventPath: "metadata.author_id", primary: true },
+      { namespace: "github_login", eventPath: "metadata.author_login" },
+    ],
+    traits: {
+      github_login: { eventPath: "metadata.author_login", behavior: "prefer_non_empty" },
+      last_authored_at: { eventPath: "occurred_at", behavior: "overwrite" },
+    },
+  };
+  const kind = (k: string) => ({ eventKinds: { [k]: { entityLinks: [personRule] } } });
+  const feedsSchema = {
+    issues: { key: "issues", name: "Issues", webhook: { events: ["issues"] }, ...kind("issue") },
+    pull_requests: {
+      key: "pull_requests",
+      name: "Pull Requests",
+      webhook: { events: ["pull_request"] },
+      ...kind("pull_request"),
+    },
+    issue_comments: {
+      key: "issue_comments",
+      name: "Issue Comments",
+      webhook: { events: ["issue_comment"] },
+      ...kind("issue_comment"),
+    },
+    pr_comments: {
+      key: "pr_comments",
+      name: "PR Comments",
+      webhook: { events: ["pull_request_review_comment"] },
+      ...kind("pr_comment"),
+    },
+    commits: { key: "commits", name: "Commits", webhook: { events: ["push"] }, ...kind("commit") },
+    stargazers: {
+      key: "stargazers",
+      name: "Stargazers",
+      webhook: { events: ["star", "watch"], mode: "store" },
+      ...kind("stargazer"),
+    },
+  };
+  await sql`
+    INSERT INTO connector_definitions (
+      organization_id, key, name, version, feeds_schema, status, created_at, updated_at
+    ) VALUES (
+      ${orgId}, 'github', 'GitHub', '1.0.0', ${sql.json(feedsSchema)}, 'active', NOW(), NOW()
+    )
+    ON CONFLICT DO NOTHING
+  `;
+}

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -715,7 +715,14 @@ export function createGatewayApp(
     const appWebhookProviders: AppWebhookProvider[] = [];
     const githubAppId = process.env.GITHUB_APP_ID;
     if (githubAppId) {
-      appWebhookProviders.push(createGithubAppWebhookProvider({ appId: githubAppId }));
+      appWebhookProviders.push(
+        createGithubAppWebhookProvider({
+          appId: githubAppId,
+          // Land event-complete deliveries (stars) directly instead of re-polling.
+          // Default on; GITHUB_WEBHOOK_STORE_EVENTS=false makes every delivery a trigger.
+          storeWebhookEvents: process.env.GITHUB_WEBHOOK_STORE_EVENTS !== "false",
+        }),
+      );
     }
     const jiraAppId = process.env.JIRA_CLIENT_ID;
     if (jiraAppId) {

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -421,8 +421,8 @@ async function markGithubFeedDue(params: {
 		  AND c.connector_key = 'github'
 		  AND (c.config->>'installation_ref') = ${String(install.id)}
 		  AND f.feed_key = ${feedKey}
-		  AND f.config->>'repo_owner' = ${repo.owner}
-		  AND f.config->>'repo_name' = ${repo.name}
+		  AND lower(f.config->>'repo_owner') = lower(${repo.owner})
+		  AND lower(f.config->>'repo_name') = lower(${repo.name})
 		  AND f.status = 'active'
 		  AND f.deleted_at IS NULL
 		RETURNING f.id
@@ -442,24 +442,39 @@ async function resolveGithubFeedTarget(params: {
 	install: { id: number | string; organizationId: string };
 	repo: { owner: string; name: string };
 	feedKey: string;
-}): Promise<{ connectionId: number; feedId: number } | null> {
+}): Promise<{
+	connectionId: number;
+	feedId: number;
+	owner: string;
+	name: string;
+} | null> {
 	const { sql, install, repo, feedKey } = params;
+	// GitHub owner/repo are case-insensitive; match accordingly and return the
+	// feed config's canonical casing so the store builds the SAME origin_id the
+	// poll does (the connector keys origin_id off the feed config, not the
+	// webhook payload's display casing) — otherwise consolidation would break.
 	const [row] = await sql`
-		SELECT f.id AS feed_id, f.connection_id
+		SELECT f.id AS feed_id, f.connection_id,
+		       f.config->>'repo_owner' AS repo_owner, f.config->>'repo_name' AS repo_name
 		FROM feeds f
 		JOIN connections c ON c.id = f.connection_id
 		WHERE c.organization_id = ${install.organizationId}
 		  AND c.connector_key = 'github'
 		  AND (c.config->>'installation_ref') = ${String(install.id)}
 		  AND f.feed_key = ${feedKey}
-		  AND f.config->>'repo_owner' = ${repo.owner}
-		  AND f.config->>'repo_name' = ${repo.name}
+		  AND lower(f.config->>'repo_owner') = lower(${repo.owner})
+		  AND lower(f.config->>'repo_name') = lower(${repo.name})
 		  AND f.status = 'active'
 		  AND f.deleted_at IS NULL
 		LIMIT 1
 	`;
 	return row
-		? { connectionId: Number(row.connection_id), feedId: Number(row.feed_id) }
+		? {
+				connectionId: Number(row.connection_id),
+				feedId: Number(row.feed_id),
+				owner: String(row.repo_owner),
+				name: String(row.repo_name),
+			}
 		: null;
 }
 
@@ -497,15 +512,17 @@ async function storeGithubWebhookEvent(params: {
 	const actor = extractGithubActor(payload);
 	if (!actor) return false;
 	// Gate on the configured feed (same as the trigger path) so an unconfigured
-	// repo never lands a stray event; use the feed's own connection + id.
+	// repo never lands a stray event; use the feed's own connection + id, and its
+	// canonical owner/name casing so origin_id matches the poll's exactly.
 	const target = await resolveGithubFeedTarget({ sql, install, repo, feedKey });
 	if (!target) return false;
+	const { owner, name } = target;
 
 	// origin_id mirrors the connector: key on the immutable user id when present.
 	const key = actor.author_id
 		? `github_user_id:${actor.author_id}`
 		: `github_login:${actor.author_login.toLowerCase()}`;
-	const originId = `stargazer_${repo.owner}_${repo.name}_${key.replace(/[^a-z0-9]+/gi, "_")}`;
+	const originId = `stargazer_${owner}_${name}_${key.replace(/[^a-z0-9]+/gi, "_")}`;
 	const starredAt = strField(root, "starred_at") ?? new Date().toISOString();
 	const profileUrl =
 		strField(root.sender, "html_url") ??
@@ -529,7 +546,7 @@ async function storeGithubWebhookEvent(params: {
 			originId,
 			originType: "stargazer",
 			semanticType: "content",
-			title: `${actor.author_login} starred ${repo.owner}/${repo.name}`,
+			title: `${actor.author_login} starred ${owner}/${name}`,
 			authorName: actor.author_login,
 			sourceUrl: profileUrl,
 			occurredAt: starredAt,

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -419,6 +419,8 @@ async function markGithubFeedDue(params: {
 		WHERE f.connection_id = c.id
 		  AND c.organization_id = ${install.organizationId}
 		  AND c.connector_key = 'github'
+		  AND c.status = 'active'
+		  AND c.deleted_at IS NULL
 		  AND (c.config->>'installation_ref') = ${String(install.id)}
 		  AND f.feed_key = ${feedKey}
 		  AND lower(f.config->>'repo_owner') = lower(${repo.owner})
@@ -460,6 +462,8 @@ async function resolveGithubFeedTarget(params: {
 		JOIN connections c ON c.id = f.connection_id
 		WHERE c.organization_id = ${install.organizationId}
 		  AND c.connector_key = 'github'
+		  AND c.status = 'active'
+		  AND c.deleted_at IS NULL
 		  AND (c.config->>'installation_ref') = ${String(install.id)}
 		  AND f.feed_key = ${feedKey}
 		  AND lower(f.config->>'repo_owner') = lower(${repo.owner})

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -125,15 +125,19 @@ export interface AppWebhookProvider {
 		sql: DbClient;
 	}): Promise<{ entityIds: number[]; metadata: Record<string, string> } | null>;
 	/**
-	 * Optional: handle the delivery as a TRIGGER instead of storing a raw event.
-	 * For connectors with a sync mapping (github), the canonical record is the
-	 * poll — so a delivery just resolves identity (real-time person-graph signal)
-	 * and marks the affected feeds due (`next_run_at = now()`), letting the poll
-	 * fetch the structured update that dedupes/supersedes by stable origin_id. No
-	 * raw blob is stored. Providers that define this NEVER fall through to the raw
-	 * ingest path; providers without it keep raw store (jira/linear). `triggered`
-	 * reports whether a matching feed was marked due (telemetry only — the router
-	 * acks 200 either way; an unconfigured repo is a no-op, not an error).
+	 * Optional: handle the delivery itself instead of storing a raw event. For
+	 * connectors with a sync mapping (github) the canonical record is the poll, so
+	 * the provider decides per event type (see the github plugin):
+	 *  - TRIGGER (most events) — mark the affected feed due (`next_run_at = now()`)
+	 *    and let the poll fetch the complete record (dedupes/supersedes by stable
+	 *    origin_id). No identity resolution here — the poll resolves it once.
+	 *  - STORE (event-complete signals, e.g. stars) — resolve the actor and insert
+	 *    the structured event directly, keyed on the same origin_id the poll uses.
+	 * No raw blob is stored either way. Providers that define this NEVER fall
+	 * through to the raw ingest path; providers without it keep raw store
+	 * (jira/linear). `triggered` reports whether a feed was marked due OR an event
+	 * stored (telemetry only — the router acks 200 either way; an unconfigured
+	 * repo/feed is a no-op, not an error).
 	 */
 	onDelivery?(params: {
 		rawBody: Uint8Array;

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -47,7 +47,8 @@ import {
 } from "../../connections/webhook-ingest.js";
 import type { SecretStore } from "../../secrets/index.js";
 import type { AppInstallationStore } from "../../../lobu/stores/app-installation-store.js";
-import { resolveGithubWebhookActor } from "./github-webhook-actor.js";
+import { insertEvent } from "../../../utils/insert-event.js";
+import { extractGithubActor, resolveGithubWebhookActor } from "./github-webhook-actor.js";
 
 const logger = createLogger("app-webhook-routes");
 
@@ -226,6 +227,38 @@ export function createSchemaDrivenAppWebhookProvider(options: {
 }
 
 /**
+ * How the github provider handles each webhook event type. `feedKey` names the
+ * connector feed the event belongs to. `store` distinguishes two strategies:
+ *
+ *  - TRIGGER (`store` falsey) — the poll brings strictly more than the webhook,
+ *    so re-fetch is required for a correct record. Examples: an `issues` payload
+ *    omits reaction/comment counts the list endpoint computes; a `push` payload
+ *    carries only the git author name/email, NOT the immutable github user id
+ *    that `/commits` returns (so a webhook-landed commit couldn't be attributed
+ *    to a person). The delivery just marks THAT ONE feed due so the poll fetches
+ *    the complete record — scoped to the feed, so an `issues` push never
+ *    re-polls commits/stargazers.
+ *  - STORE (`store: true`) — the webhook payload is already complete and the
+ *    poll alternative is wasteful. A `star` carries the actor + `starred_at`;
+ *    re-polling the entire stargazer list to capture one new star is pure waste.
+ *    We land the structured event directly, keyed on the SAME origin_id the poll
+ *    uses, so the scheduled poll (the backstop) supersedes/dedupes it cleanly.
+ *
+ * Event types absent from this map (e.g. label edits) are acked as no-ops.
+ */
+const GITHUB_EVENT_FEED: Record<string, { feedKey: string; store?: boolean }> = {
+	issues: { feedKey: "issues" },
+	pull_request: { feedKey: "pull_requests" },
+	issue_comment: { feedKey: "issue_comments" },
+	pull_request_review_comment: { feedKey: "pr_comments" },
+	discussion: { feedKey: "discussions" },
+	discussion_comment: { feedKey: "discussion_comments" },
+	push: { feedKey: "commits" },
+	star: { feedKey: "stargazers", store: true },
+	watch: { feedKey: "stargazers", store: true },
+};
+
+/**
  * GitHub App webhook plugin.
  *
  * Verify: schema-driven (GitHub signs the raw body and sends
@@ -239,15 +272,22 @@ export function createSchemaDrivenAppWebhookProvider(options: {
  * (GHES would be the host — out of scope here). A delivery with no
  * `installation.id` (rare app-level events) has no tenant to route to → null.
  *
- * Delivery: github has a sync mapping, so deliveries are TRIGGERS, not stored
- * raw — `onDelivery` resolves the acting user (real-time person graph) and marks
- * the affected repo's feeds due so the canonical poll fetches the structured
- * update (dedupes/supersedes by stable origin_id). Push + backfill stay one set.
+ * Delivery: github has a sync mapping, so most deliveries are TRIGGERS — they
+ * mark the one affected feed due and let the poll fetch the complete record (it
+ * brings more than the webhook). Event-complete signals (stars) are STORED
+ * directly, consolidating with the poll on origin_id. See {@link GITHUB_EVENT_FEED}.
  */
 export function createGithubAppWebhookProvider(options: {
 	/** Receiving GitHub App id, stamped as `provider_app_id`. */
 	appId: string;
+	/**
+	 * Land event-complete deliveries (stars) directly instead of re-polling.
+	 * Default true. Set false to make every delivery a trigger (the scheduled
+	 * poll then captures stars on its next backstop run).
+	 */
+	storeWebhookEvents?: boolean;
 }): AppWebhookProvider {
+	const storeWebhookEvents = options.storeWebhookEvents ?? true;
 	return createSchemaDrivenAppWebhookProvider({
 		provider: "github",
 		// GitHub raw-body HMAC: `x-hub-signature-256: sha256=<hex>` (sha256).
@@ -274,23 +314,39 @@ export function createGithubAppWebhookProvider(options: {
 				externalTenantId,
 			};
 		},
-		// GitHub has a sync mapping, so the canonical record is the POLL, not the
-		// webhook. Treat each delivery as a trigger: resolve the acting user into a
-		// person (keeps the member graph's real-time signal) and mark the affected
-		// repo's feeds due so the poll fetches the structured update now — which
-		// dedupes/supersedes by stable origin_id. No raw blob is stored, so push
-		// and backfill stay one consolidated dataset.
 		async onDelivery({ rawBody, headers, install, sql }) {
+			const event = headers.get("x-github-event");
+			const policy = event ? GITHUB_EVENT_FEED[event] : undefined;
+			if (!policy) return { triggered: false };
 			const payload = parseJson(rawBody);
-			await resolveGithubWebhookActor({
-				organizationId: install.organizationId,
-				githubEvent: headers.get("x-github-event"),
-				payload,
-				sql,
-			}).catch(() => null);
 			const repo = extractGithubRepo(payload);
 			if (!repo) return { triggered: false };
-			const triggered = await markGithubFeedsDue({ sql, install, repo });
+
+			// Event-complete signals (stars): land the structured event directly,
+			// consolidating with the poll on origin_id — no wasteful re-poll. The
+			// scheduled poll stays the backstop. Resolution happens here because the
+			// poll won't run for this feed on the webhook's account.
+			if (policy.store && storeWebhookEvents) {
+				const stored = await storeGithubWebhookEvent({
+					sql,
+					install,
+					repo,
+					event: event as string,
+					payload,
+				});
+				return { triggered: stored };
+			}
+
+			// Everything else: the poll brings more, so mark THAT feed due and let
+			// the poll fetch the complete record (dedupes/supersedes by origin_id).
+			// No actor resolution here — the poll resolves the person once, avoiding
+			// the double work that buys only sub-poll-latency freshness we don't need.
+			const triggered = await markGithubFeedDue({
+				sql,
+				install,
+				repo,
+				feedKey: policy.feedKey,
+			});
 			return { triggered };
 		},
 	});
@@ -317,18 +373,20 @@ function extractGithubRepo(
 }
 
 /**
- * Mark every active github feed for (install, repo) due NOW so the orchestrator
- * syncs it on its next tick — the webhook becomes the "when to run" signal, with
- * the schedule as the self-covering backstop. Idempotent: redeliveries just
- * re-stamp `next_run_at`. Returns whether any feed matched (telemetry only — an
- * unconfigured repo is a no-op, not an error).
+ * Mark the active github feed for (install, repo, feedKey) due NOW so the
+ * orchestrator syncs it on its next tick — the webhook becomes the "when to run"
+ * signal, with the schedule as the self-covering backstop. Scoped to the one
+ * feed the event belongs to, so unrelated feeds aren't re-polled. Idempotent:
+ * redeliveries just re-stamp `next_run_at`. Returns whether the feed matched
+ * (telemetry only — an unconfigured repo/feed is a no-op, not an error).
  */
-async function markGithubFeedsDue(params: {
+async function markGithubFeedDue(params: {
 	sql: DbClient;
 	install: { id: number | string; organizationId: string };
 	repo: { owner: string; name: string };
+	feedKey: string;
 }): Promise<boolean> {
-	const { sql, install, repo } = params;
+	const { sql, install, repo, feedKey } = params;
 	const rows = await sql`
 		UPDATE feeds f
 		SET next_run_at = now(), updated_at = now()
@@ -337,6 +395,7 @@ async function markGithubFeedsDue(params: {
 		  AND c.organization_id = ${install.organizationId}
 		  AND c.connector_key = 'github'
 		  AND (c.config->>'installation_ref') = ${String(install.id)}
+		  AND f.feed_key = ${feedKey}
 		  AND f.config->>'repo_owner' = ${repo.owner}
 		  AND f.config->>'repo_name' = ${repo.name}
 		  AND f.status = 'active'
@@ -344,6 +403,108 @@ async function markGithubFeedsDue(params: {
 		RETURNING f.id
 	`;
 	return rows.length > 0;
+}
+
+/**
+ * The github connection bound to an install (so webhook-landed events share the
+ * poll's connection_id and consolidate on origin_id), or null.
+ */
+async function resolveGithubConnectionId(
+	sql: DbClient,
+	install: { id: number | string; organizationId: string },
+): Promise<number | null> {
+	const [conn] = await sql`
+		SELECT id FROM connections
+		WHERE organization_id = ${install.organizationId}
+		  AND connector_key = 'github'
+		  AND (config->>'installation_ref') = ${String(install.id)}
+		  AND status = 'active'
+		  AND deleted_at IS NULL
+		LIMIT 1
+	`;
+	return conn ? Number(conn.id) : null;
+}
+
+/**
+ * Land an event-complete github delivery (star/watch) as a structured event
+ * instead of re-polling. The origin_id mirrors the github connector's stargazer
+ * scheme (`stargazer_<owner>_<repo>_<github_user_id:ID | github_login:login>`,
+ * non-alnum → `_`) and the event is stored under the install's github
+ * connection, so the scheduled `/stargazers` poll supersedes/dedupes it on the
+ * SAME (connection_id, origin_id). The actor is resolved to a person here (the
+ * poll won't run on the webhook's account). Unstars are transient — not tracked
+ * (the user opted out of delete signals). Returns false (no-op) when the install
+ * has no github connection or the delivery isn't an actionable new star.
+ */
+async function storeGithubWebhookEvent(params: {
+	sql: DbClient;
+	install: { id: number | string; organizationId: string };
+	repo: { owner: string; name: string };
+	event: string;
+	payload: unknown;
+}): Promise<boolean> {
+	const { sql, install, repo, event, payload } = params;
+	const root =
+		payload && typeof payload === "object"
+			? (payload as Record<string, unknown>)
+			: null;
+	if (!root) return false;
+	// `star` → action created/deleted; `watch` → action started. Only a NEW star
+	// is landed; unstars/transient states are intentionally ignored.
+	const action = strField(root, "action");
+	if (event === "star" && action !== "created") return false;
+	if (event === "watch" && action !== "started") return false;
+
+	const actor = extractGithubActor(payload);
+	if (!actor) return false;
+	const connectionId = await resolveGithubConnectionId(sql, install);
+	if (connectionId === null) return false;
+
+	// origin_id mirrors the connector: key on the immutable user id when present.
+	const key = actor.author_id
+		? `github_user_id:${actor.author_id}`
+		: `github_login:${actor.author_login.toLowerCase()}`;
+	const originId = `stargazer_${repo.owner}_${repo.name}_${key.replace(/[^a-z0-9]+/gi, "_")}`;
+	const starredAt = strField(root, "starred_at") ?? new Date().toISOString();
+	const profileUrl =
+		strField(root.sender, "html_url") ??
+		`https://github.com/${actor.author_login}`;
+
+	// Resolve the actor → person so the star is attributed exactly like the poll.
+	const resolution = await resolveGithubWebhookActor({
+		organizationId: install.organizationId,
+		githubEvent: event,
+		payload,
+		sql,
+	}).catch(() => null);
+
+	await insertEvent(
+		{
+			organizationId: install.organizationId,
+			connectorKey: "github",
+			connectionId,
+			feedKey: "stargazers",
+			originId,
+			originType: "stargazer",
+			semanticType: "content",
+			title: `${actor.author_login} starred ${repo.owner}/${repo.name}`,
+			authorName: actor.author_login,
+			sourceUrl: profileUrl,
+			occurredAt: starredAt,
+			score: 1,
+			entityIds: resolution?.entityIds ?? [],
+			metadata: {
+				action: "starred",
+				starred_at: starredAt,
+				source: "github_star_webhook",
+				author_login: actor.author_login,
+				...(actor.author_id ? { author_id: actor.author_id } : {}),
+				...(resolution?.metadata ?? {}),
+			},
+		},
+		{ onConflictUpdate: true },
+	);
+	return true;
 }
 
 /** First non-empty `*.self` URL found by a shallow scan of the delivery body. */

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -38,7 +38,7 @@ import { Hono } from "hono";
 import { createLogger } from "@lobu/core";
 import type { StoredConnection } from "@lobu/core";
 import type { ConnectorWebhookSchema } from "@lobu/connector-sdk";
-import type { DbClient } from "../../../db/client.js";
+import { type DbClient, getDb } from "../../../db/client.js";
 import {
 	handleWebhookIngest,
 	readBodyWithCap,
@@ -123,6 +123,23 @@ export interface AppWebhookProvider {
 		headers: Headers;
 		sql: DbClient;
 	}): Promise<{ entityIds: number[]; metadata: Record<string, string> } | null>;
+	/**
+	 * Optional: handle the delivery as a TRIGGER instead of storing a raw event.
+	 * For connectors with a sync mapping (github), the canonical record is the
+	 * poll — so a delivery just resolves identity (real-time person-graph signal)
+	 * and marks the affected feeds due (`next_run_at = now()`), letting the poll
+	 * fetch the structured update that dedupes/supersedes by stable origin_id. No
+	 * raw blob is stored. Providers that define this NEVER fall through to the raw
+	 * ingest path; providers without it keep raw store (jira/linear). `triggered`
+	 * reports whether a matching feed was marked due (telemetry only — the router
+	 * acks 200 either way; an unconfigured repo is a no-op, not an error).
+	 */
+	onDelivery?(params: {
+		rawBody: Uint8Array;
+		headers: Headers;
+		install: { id: number | string; organizationId: string };
+		sql: DbClient;
+	}): Promise<{ triggered: boolean }>;
 }
 
 /** Parse the raw JSON body once; returns undefined on malformed JSON. */
@@ -139,45 +156,6 @@ function strField(node: unknown, key: string): string | undefined {
 	if (node === null || typeof node !== "object") return undefined;
 	const value = (node as Record<string, unknown>)[key];
 	return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-/**
- * Project a GitHub webhook payload to a human title + source url.
- *
- * GitHub event payloads put the subject under one of a handful of top-level
- * keys, each with `title` + `html_url`:
- *   - `issues`         → `issue.{title,html_url}`
- *   - `pull_request`   → `pull_request.{title,html_url}`
- *   - `discussion`     → `discussion.{title,html_url}`
- * Comment events (`issue_comment`, `pull_request_review_comment`,
- * `discussion_comment`, `commit_comment`) carry the comment under `comment`
- * (whose `html_url` deep-links the comment) AND the parent subject alongside it
- * (`issue`/`pull_request`/`discussion`) — the title belongs to the PARENT, so
- * we read the title from the parent and prefer the comment's own `html_url`.
- * Falls back across keys so a new comment-bearing event still lands a title.
- */
-export function extractGithubWebhookContent(rawBody: Uint8Array): AppWebhookContent {
-	const body = parseJson(rawBody);
-	if (body === null || typeof body !== "object") return {};
-	const root = body as Record<string, unknown>;
-
-	// The subject the title comes from: a comment's parent, else the subject
-	// itself. Order matters only for the parent lookup — a payload has exactly
-	// one of these for a given event.
-	const subject =
-		root.issue ?? root.pull_request ?? root.discussion ?? root.release;
-	const comment = root.comment;
-
-	const title = strField(subject, "title");
-	// Prefer the comment's deep link when this is a comment event; else the
-	// subject's own url.
-	const sourceUrl =
-		strField(comment, "html_url") ?? strField(subject, "html_url");
-
-	const content: AppWebhookContent = {};
-	if (title) content.title = title;
-	if (sourceUrl) content.sourceUrl = sourceUrl;
-	return content;
 }
 
 /**
@@ -207,8 +185,10 @@ export function createSchemaDrivenAppWebhookProvider(options: {
 	extractContent?(rawBody: Uint8Array, headers: Headers): AppWebhookContent;
 	/** Optional actor → person resolver (see {@link AppWebhookProvider.resolveActor}). */
 	resolveActor?: AppWebhookProvider["resolveActor"];
+	/** Optional trigger handler (see {@link AppWebhookProvider.onDelivery}). */
+	onDelivery?: AppWebhookProvider["onDelivery"];
 }): AppWebhookProvider {
-	const { provider, webhookSchema, extractTenant, extractContent, resolveActor } =
+	const { provider, webhookSchema, extractTenant, extractContent, resolveActor, onDelivery } =
 		options;
 	const signatureHeader = webhookSchema.signatureHeader;
 	if (!signatureHeader) {
@@ -241,6 +221,7 @@ export function createSchemaDrivenAppWebhookProvider(options: {
 		extractTenant,
 		...(extractContent ? { extractContent } : {}),
 		...(resolveActor ? { resolveActor } : {}),
+		...(onDelivery ? { onDelivery } : {}),
 	};
 }
 
@@ -258,9 +239,10 @@ export function createSchemaDrivenAppWebhookProvider(options: {
  * (GHES would be the host — out of scope here). A delivery with no
  * `installation.id` (rare app-level events) has no tenant to route to → null.
  *
- * Content: issue/PR/discussion title + html_url (a comment's title is its
- * parent's; its url is the comment deep-link) populate `events.title` +
- * `events.source_url` so the landed row is legible without digging payload_data.
+ * Delivery: github has a sync mapping, so deliveries are TRIGGERS, not stored
+ * raw — `onDelivery` resolves the acting user (real-time person graph) and marks
+ * the affected repo's feeds due so the canonical poll fetches the structured
+ * update (dedupes/supersedes by stable origin_id). Push + backfill stay one set.
  */
 export function createGithubAppWebhookProvider(options: {
 	/** Receiving GitHub App id, stamped as `provider_app_id`. */
@@ -292,21 +274,76 @@ export function createGithubAppWebhookProvider(options: {
 				externalTenantId,
 			};
 		},
-		extractContent(rawBody) {
-			return extractGithubWebhookContent(rawBody);
-		},
-		// Resolve the authoring github actor → a tenant-scoped person. Lazy: the
-		// router hands it the persist transaction so the graph writes are atomic
-		// with the event insert (and never run for deduped/lost-race deliveries).
-		async resolveActor({ organizationId, rawBody, headers, sql }) {
-			return resolveGithubWebhookActor({
-				organizationId,
+		// GitHub has a sync mapping, so the canonical record is the POLL, not the
+		// webhook. Treat each delivery as a trigger: resolve the acting user into a
+		// person (keeps the member graph's real-time signal) and mark the affected
+		// repo's feeds due so the poll fetches the structured update now — which
+		// dedupes/supersedes by stable origin_id. No raw blob is stored, so push
+		// and backfill stay one consolidated dataset.
+		async onDelivery({ rawBody, headers, install, sql }) {
+			const payload = parseJson(rawBody);
+			await resolveGithubWebhookActor({
+				organizationId: install.organizationId,
 				githubEvent: headers.get("x-github-event"),
-				payload: parseJson(rawBody),
+				payload,
 				sql,
-			});
+			}).catch(() => null);
+			const repo = extractGithubRepo(payload);
+			if (!repo) return { triggered: false };
+			const triggered = await markGithubFeedsDue({ sql, install, repo });
+			return { triggered };
 		},
 	});
+}
+
+/** Extract the {owner, name} of the repo a GitHub delivery is about, or null. */
+export function extractGithubRepo(
+	body: unknown,
+): { owner: string; name: string } | null {
+	if (body === null || typeof body !== "object") return null;
+	const repository = (body as Record<string, unknown>).repository;
+	if (repository === null || typeof repository !== "object") return null;
+	const repo = repository as Record<string, unknown>;
+	const name = typeof repo.name === "string" ? repo.name : undefined;
+	const owner = strField(repo.owner, "login");
+	if (owner && name) return { owner, name };
+	// Fall back to full_name ("owner/name") when the split fields are absent.
+	const fullName = typeof repo.full_name === "string" ? repo.full_name : undefined;
+	if (fullName?.includes("/")) {
+		const [o, n] = fullName.split("/", 2);
+		if (o && n) return { owner: o, name: n };
+	}
+	return null;
+}
+
+/**
+ * Mark every active github feed for (install, repo) due NOW so the orchestrator
+ * syncs it on its next tick — the webhook becomes the "when to run" signal, with
+ * the schedule as the self-covering backstop. Idempotent: redeliveries just
+ * re-stamp `next_run_at`. Returns whether any feed matched (telemetry only — an
+ * unconfigured repo is a no-op, not an error).
+ */
+export async function markGithubFeedsDue(params: {
+	sql: DbClient;
+	install: { id: number | string; organizationId: string };
+	repo: { owner: string; name: string };
+}): Promise<boolean> {
+	const { sql, install, repo } = params;
+	const rows = await sql`
+		UPDATE feeds f
+		SET next_run_at = now(), updated_at = now()
+		FROM connections c
+		WHERE f.connection_id = c.id
+		  AND c.organization_id = ${install.organizationId}
+		  AND c.connector_key = 'github'
+		  AND (c.config->>'installation_ref') = ${String(install.id)}
+		  AND f.config->>'repo_owner' = ${repo.owner}
+		  AND f.config->>'repo_name' = ${repo.name}
+		  AND f.status = 'active'
+		  AND f.deleted_at IS NULL
+		RETURNING f.id
+	`;
+	return rows.length > 0;
 }
 
 /** First non-empty `*.self` URL found by a shallow scan of the delivery body. */
@@ -523,7 +560,30 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 			return json(200, { ok: true, landed: false });
 		}
 
-		// 4. Land the RAW delivery through the same event-log path as connection
+		// 4. Trigger-handling providers (github) treat the delivery as a "sync now"
+		//    signal rather than a record: resolve identity + mark the affected
+		//    repo's feeds due, no raw event. The canonical record is the poll, so
+		//    push and backfill stay one consolidated dataset. Providers without
+		//    onDelivery fall through to the raw store below (jira/linear).
+		if (provider.onDelivery) {
+			try {
+				const { triggered } = await provider.onDelivery({
+					rawBody,
+					headers: c.req.raw.headers,
+					install,
+					sql: getDb(),
+				});
+				return json(200, { ok: true, triggered });
+			} catch (error) {
+				logger.error(
+					{ provider: providerName, installationId: install.id, error: String(error) },
+					"[app-webhook] onDelivery trigger failed",
+				);
+				return json(500, { error: "Failed to handle delivery" });
+			}
+		}
+
+		// 5. Land the RAW delivery through the same event-log path as connection
 		//    ingest. We synthesize a StoredConnection scoped to the install's org
 		//    and keyed on the install id, replaying the PROVIDER's signature scheme
 		//    (from `provider.webhookScheme`, not a hardcoded GitHub one) with the

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -297,7 +297,7 @@ export function createGithubAppWebhookProvider(options: {
 }
 
 /** Extract the {owner, name} of the repo a GitHub delivery is about, or null. */
-export function extractGithubRepo(
+function extractGithubRepo(
 	body: unknown,
 ): { owner: string; name: string } | null {
 	if (body === null || typeof body !== "object") return null;
@@ -323,7 +323,7 @@ export function extractGithubRepo(
  * re-stamp `next_run_at`. Returns whether any feed matched (telemetry only — an
  * unconfigured repo is a no-op, not an error).
  */
-export async function markGithubFeedsDue(params: {
+async function markGithubFeedsDue(params: {
 	sql: DbClient;
 	install: { id: number | string; organizationId: string };
 	repo: { owner: string; name: string };

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -230,37 +230,53 @@ export function createSchemaDrivenAppWebhookProvider(options: {
 	};
 }
 
+/** Webhook routing for one feed: which feed a delivery updates, and how. */
+interface WebhookRoute {
+	feedKey: string;
+	mode: "trigger" | "store";
+}
+
 /**
- * How the github provider handles each webhook event type. `feedKey` names the
- * connector feed the event belongs to. `store` distinguishes two strategies:
+ * Build the github event → feed routing from the org's connector definition
+ * feeds_schema, where each feed declares `webhook: { events, mode }`. Read from
+ * the DB — the same persisted surface the poll path reads its entity-link rules
+ * from — so the server hardcodes NO provider event types or feed names. A
+ * per-delivery query (webhooks are low-frequency); an org with no active github
+ * definition yields an empty map → deliveries ack as no-ops.
  *
- *  - TRIGGER (`store` falsey) — the poll brings strictly more than the webhook,
- *    so re-fetch is required for a correct record. Examples: an `issues` payload
- *    omits reaction/comment counts the list endpoint computes; a `push` payload
- *    carries only the git author name/email, NOT the immutable github user id
- *    that `/commits` returns (so a webhook-landed commit couldn't be attributed
- *    to a person). The delivery just marks THAT ONE feed due so the poll fetches
- *    the complete record — scoped to the feed, so an `issues` push never
- *    re-polls commits/stargazers.
- *  - STORE (`store: true`) — the webhook payload is already complete and the
- *    poll alternative is wasteful. A `star` carries the actor + `starred_at`;
- *    re-polling the entire stargazer list to capture one new star is pure waste.
- *    We land the structured event directly, keyed on the SAME origin_id the poll
- *    uses, so the scheduled poll (the backstop) supersedes/dedupes it cleanly.
- *
- * Event types absent from this map (e.g. label edits) are acked as no-ops.
+ * Routing strategies (declared by the connector per feed):
+ *  - TRIGGER — the poll brings strictly more than the webhook (an `issues`
+ *    payload omits computed counts; a `push` lacks the immutable github user id
+ *    `/commits` returns), so the delivery marks THAT feed due and the poll
+ *    fetches the complete record.
+ *  - STORE — the payload is event-complete (a `star` carries actor + starred_at)
+ *    and re-polling the whole list is waste, so the event is stored directly.
  */
-const GITHUB_EVENT_FEED: Record<string, { feedKey: string; store?: boolean }> = {
-	issues: { feedKey: "issues" },
-	pull_request: { feedKey: "pull_requests" },
-	issue_comment: { feedKey: "issue_comments" },
-	pull_request_review_comment: { feedKey: "pr_comments" },
-	discussion: { feedKey: "discussions" },
-	discussion_comment: { feedKey: "discussion_comments" },
-	push: { feedKey: "commits" },
-	star: { feedKey: "stargazers", store: true },
-	watch: { feedKey: "stargazers", store: true },
-};
+async function loadGithubWebhookRoutes(
+	organizationId: string,
+): Promise<Map<string, WebhookRoute>> {
+	const rows = await getDb()`
+		SELECT feeds_schema FROM connector_definitions
+		WHERE key = 'github' AND organization_id = ${organizationId} AND status = 'active'
+		ORDER BY updated_at DESC
+		LIMIT 1
+	`;
+	const routes = new Map<string, WebhookRoute>();
+	const feedsSchema = rows[0]?.feeds_schema as
+		| Record<string, { webhook?: { events?: unknown; mode?: unknown } }>
+		| null
+		| undefined;
+	if (!feedsSchema) return routes;
+	for (const [feedKey, feed] of Object.entries(feedsSchema)) {
+		const events = feed?.webhook?.events;
+		if (!Array.isArray(events)) continue;
+		const mode = feed.webhook?.mode === "store" ? "store" : "trigger";
+		for (const event of events) {
+			if (typeof event === "string" && event) routes.set(event, { feedKey, mode });
+		}
+	}
+	return routes;
+}
 
 /**
  * GitHub App webhook plugin.
@@ -276,10 +292,10 @@ const GITHUB_EVENT_FEED: Record<string, { feedKey: string; store?: boolean }> = 
  * (GHES would be the host — out of scope here). A delivery with no
  * `installation.id` (rare app-level events) has no tenant to route to → null.
  *
- * Delivery: github has a sync mapping, so most deliveries are TRIGGERS — they
- * mark the one affected feed due and let the poll fetch the complete record (it
- * brings more than the webhook). Event-complete signals (stars) are STORED
- * directly, consolidating with the poll on origin_id. See {@link GITHUB_EVENT_FEED}.
+ * Delivery: routing comes from {@link loadGithubWebhookRoutes} (the connector's
+ * feeds_schema), not a hardcoded map. Most events TRIGGER the affected feed's
+ * poll; event-complete signals (stars) are STORED directly, consolidating with
+ * the poll on origin_id.
  */
 export function createGithubAppWebhookProvider(options: {
 	/** Receiving GitHub App id, stamped as `provider_app_id`. */
@@ -320,36 +336,41 @@ export function createGithubAppWebhookProvider(options: {
 		},
 		async onDelivery({ rawBody, headers, install, sql }) {
 			const event = headers.get("x-github-event");
-			const policy = event ? GITHUB_EVENT_FEED[event] : undefined;
-			if (!policy) return { triggered: false };
+			if (!event) return { triggered: false };
+			// Routing is declared by the connector (feeds_schema), read from the DB.
+			const route = (await loadGithubWebhookRoutes(install.organizationId)).get(
+				event,
+			);
+			if (!route) return { triggered: false };
 			const payload = parseJson(rawBody);
 			const repo = extractGithubRepo(payload);
 			if (!repo) return { triggered: false };
 
-			// Event-complete signals (stars): land the structured event directly,
-			// consolidating with the poll on origin_id — no wasteful re-poll. The
-			// scheduled poll stays the backstop. Resolution happens here because the
-			// poll won't run for this feed on the webhook's account.
-			if (policy.store && storeWebhookEvents) {
+			// STORE (event-complete signals, e.g. stars): land the structured event
+			// directly, consolidating with the poll on origin_id — no wasteful
+			// re-poll. Resolution happens here because the poll won't run for this
+			// feed on the webhook's account. Gated by storeWebhookEvents; when off,
+			// fall through to a trigger so the scheduled poll picks it up.
+			if (route.mode === "store" && storeWebhookEvents) {
 				const stored = await storeGithubWebhookEvent({
 					sql,
 					install,
 					repo,
-					event: event as string,
+					event,
+					feedKey: route.feedKey,
 					payload,
 				});
 				return { triggered: stored };
 			}
 
-			// Everything else: the poll brings more, so mark THAT feed due and let
-			// the poll fetch the complete record (dedupes/supersedes by origin_id).
-			// No actor resolution here — the poll resolves the person once, avoiding
-			// the double work that buys only sub-poll-latency freshness we don't need.
+			// TRIGGER: the poll brings more, so mark THAT feed due and let the poll
+			// fetch the complete record (dedupes/supersedes by origin_id) and resolve
+			// the person once — no webhook-side resolution (avoids double work).
 			const triggered = await markGithubFeedDue({
 				sql,
 				install,
 				repo,
-				feedKey: policy.feedKey,
+				feedKey: route.feedKey,
 			});
 			return { triggered };
 		},
@@ -445,9 +466,10 @@ async function storeGithubWebhookEvent(params: {
 	install: { id: number | string; organizationId: string };
 	repo: { owner: string; name: string };
 	event: string;
+	feedKey: string;
 	payload: unknown;
 }): Promise<boolean> {
-	const { sql, install, repo, event, payload } = params;
+	const { sql, install, repo, event, feedKey, payload } = params;
 	const root =
 		payload && typeof payload === "object"
 			? (payload as Record<string, unknown>)
@@ -487,7 +509,7 @@ async function storeGithubWebhookEvent(params: {
 			organizationId: install.organizationId,
 			connectorKey: "github",
 			connectionId,
-			feedKey: "stargazers",
+			feedKey,
 			originId,
 			originType: "stargazer",
 			semanticType: "content",

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -533,12 +533,20 @@ async function storeGithubWebhookEvent(params: {
 		`https://github.com/${actor.author_login}`;
 
 	// Resolve the actor → person so the star is attributed exactly like the poll.
+	// Best-effort by design: a failure leaves the event unattributed (the poll
+	// backstop re-resolves on its next run), but we log it so it isn't invisible.
 	const resolution = await resolveGithubWebhookActor({
 		organizationId: install.organizationId,
 		githubEvent: event,
 		payload,
 		sql,
-	}).catch(() => null);
+	}).catch((error) => {
+		logger.warn(
+			{ event, originId, error: String(error) },
+			"[app-webhook] github star actor resolution failed; storing unattributed",
+		);
+		return null;
+	});
 
 	await insertEvent(
 		{

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -431,23 +431,36 @@ async function markGithubFeedDue(params: {
 }
 
 /**
- * The github connection bound to an install (so webhook-landed events share the
- * poll's connection_id and consolidate on origin_id), or null.
+ * The active github feed matching (install, repo, feedKey) and its connection.
+ * The store path is gated on this exactly like the trigger path
+ * ({@link markGithubFeedDue}) — a repo with no such feed configured is a no-op,
+ * not an unconfigured event. The connection id is the feed's own, so the stored
+ * event shares the poll's (connection_id, origin_id) and consolidates.
  */
-async function resolveGithubConnectionId(
-	sql: DbClient,
-	install: { id: number | string; organizationId: string },
-): Promise<number | null> {
-	const [conn] = await sql`
-		SELECT id FROM connections
-		WHERE organization_id = ${install.organizationId}
-		  AND connector_key = 'github'
-		  AND (config->>'installation_ref') = ${String(install.id)}
-		  AND status = 'active'
-		  AND deleted_at IS NULL
+async function resolveGithubFeedTarget(params: {
+	sql: DbClient;
+	install: { id: number | string; organizationId: string };
+	repo: { owner: string; name: string };
+	feedKey: string;
+}): Promise<{ connectionId: number; feedId: number } | null> {
+	const { sql, install, repo, feedKey } = params;
+	const [row] = await sql`
+		SELECT f.id AS feed_id, f.connection_id
+		FROM feeds f
+		JOIN connections c ON c.id = f.connection_id
+		WHERE c.organization_id = ${install.organizationId}
+		  AND c.connector_key = 'github'
+		  AND (c.config->>'installation_ref') = ${String(install.id)}
+		  AND f.feed_key = ${feedKey}
+		  AND f.config->>'repo_owner' = ${repo.owner}
+		  AND f.config->>'repo_name' = ${repo.name}
+		  AND f.status = 'active'
+		  AND f.deleted_at IS NULL
 		LIMIT 1
 	`;
-	return conn ? Number(conn.id) : null;
+	return row
+		? { connectionId: Number(row.connection_id), feedId: Number(row.feed_id) }
+		: null;
 }
 
 /**
@@ -458,8 +471,8 @@ async function resolveGithubConnectionId(
  * connection, so the scheduled `/stargazers` poll supersedes/dedupes it on the
  * SAME (connection_id, origin_id). The actor is resolved to a person here (the
  * poll won't run on the webhook's account). Unstars are transient — not tracked
- * (the user opted out of delete signals). Returns false (no-op) when the install
- * has no github connection or the delivery isn't an actionable new star.
+ * (the user opted out of delete signals). Returns false (no-op) when no active
+ * matching feed is configured for the repo or the delivery isn't a new star.
  */
 async function storeGithubWebhookEvent(params: {
 	sql: DbClient;
@@ -483,8 +496,10 @@ async function storeGithubWebhookEvent(params: {
 
 	const actor = extractGithubActor(payload);
 	if (!actor) return false;
-	const connectionId = await resolveGithubConnectionId(sql, install);
-	if (connectionId === null) return false;
+	// Gate on the configured feed (same as the trigger path) so an unconfigured
+	// repo never lands a stray event; use the feed's own connection + id.
+	const target = await resolveGithubFeedTarget({ sql, install, repo, feedKey });
+	if (!target) return false;
 
 	// origin_id mirrors the connector: key on the immutable user id when present.
 	const key = actor.author_id
@@ -508,8 +523,9 @@ async function storeGithubWebhookEvent(params: {
 		{
 			organizationId: install.organizationId,
 			connectorKey: "github",
-			connectionId,
+			connectionId: target.connectionId,
 			feedKey,
+			feedId: target.feedId,
 			originId,
 			originType: "stargazer",
 			semanticType: "content",

--- a/packages/server/src/gateway/routes/public/github-webhook-actor.ts
+++ b/packages/server/src/gateway/routes/public/github-webhook-actor.ts
@@ -5,34 +5,12 @@
  * Org-scoped via the caller's resolved install; resolution never crosses orgs.
  */
 
-import type { EntityLinkRule } from "@lobu/connector-sdk";
 import { IDENTITY } from "@lobu/connector-sdk";
 import type { DbClient } from "../../../db/client.js";
-import { resolveEntityLinksForItems } from "../../../utils/entity-link-upsert.js";
-
-// Mirrors the github connector's GITHUB_PERSON_ENTITY_LINK (server can't import
-// the connector package). PRIMARY immutable github_user_id (rename-safe) +
-// secondary github_login.
-const GITHUB_PERSON_RULE: EntityLinkRule = {
-	entityType: "person",
-	autoCreate: true,
-	titlePath: "metadata.author_login",
-	identities: [
-		{
-			namespace: IDENTITY.GITHUB_USER_ID,
-			eventPath: "metadata.author_id",
-			primary: true,
-		},
-		{ namespace: IDENTITY.GITHUB_LOGIN, eventPath: "metadata.author_login" },
-	],
-	traits: {
-		github_login: {
-			eventPath: "metadata.author_login",
-			behavior: "prefer_non_empty",
-		},
-		last_authored_at: { eventPath: "occurred_at", behavior: "overwrite" },
-	},
-};
+import {
+	loadEntityLinkRuleByType,
+	resolveEntityLinksForItems,
+} from "../../../utils/entity-link-upsert.js";
 
 interface GithubActor {
 	login?: unknown;
@@ -129,6 +107,16 @@ export async function resolveGithubWebhookActor(params: {
 	const actor = extractGithubActor(params.payload);
 	if (!actor) return null;
 
+	// The person entity-link rule is read from the connector definition (same
+	// source the poll path uses) — not mirrored here. Absent def/rule → no
+	// attribution (best-effort).
+	const rule = await loadEntityLinkRuleByType({
+		connectorKey: "github",
+		orgId: params.organizationId,
+		entityType: "person",
+	});
+	if (!rule) return null;
+
 	// occurred_at is a top-level EventEnvelope field — the last_authored_at trait
 	// reads it there, matching the poll path.
 	const item: {
@@ -149,7 +137,7 @@ export async function resolveGithubWebhookActor(params: {
 			connectorKey: "github",
 			orgId: params.organizationId,
 			items: [item],
-			rules: { [kind]: [GITHUB_PERSON_RULE] },
+			rules: { [kind]: [rule] },
 		},
 		params.sql,
 	);

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -99,6 +99,54 @@ async function loadEntityLinkRules(params: {
   });
 }
 
+/**
+ * Load the FIRST entity-link rule for `entityType` declared anywhere in the
+ * connector's feeds_schema. The live app-webhook path resolves an actor without
+ * a feed context (a delivery names an event, not a feed), and a connector's
+ * person rule is identical across its feeds — so any feed's rule serves. Reads
+ * from connector_definitions like the poll path, so the webhook path no longer
+ * mirrors the connector's rule server-side. Returns null when absent.
+ */
+export async function loadEntityLinkRuleByType(params: {
+  connectorKey: string;
+  orgId: string;
+  entityType: string;
+}): Promise<EntityLinkRule | null> {
+  const cacheKey = `${params.orgId}:${params.connectorKey}:__bytype__:${params.entityType}`;
+  const map = await rulesCache.getOrSet(cacheKey, async () => {
+    const sql = getDb();
+    const rows = await sql`
+      SELECT feeds_schema, entity_link_overrides
+      FROM connector_definitions
+      WHERE key = ${params.connectorKey}
+        AND organization_id = ${params.orgId}
+      LIMIT 1
+    `;
+    const result: RuleMap = {};
+    const feedsSchema = rows[0]?.feeds_schema as Record<string, any> | null | undefined;
+    const overrides = rows[0]?.entity_link_overrides as EntityLinkOverrides | null | undefined;
+    if (feedsSchema) {
+      for (const feed of Object.values(feedsSchema)) {
+        const eventKinds = (feed as { eventKinds?: Record<string, { entityLinks?: EntityLinkRule[] }> })
+          ?.eventKinds;
+        if (!eventKinds) continue;
+        for (const def of Object.values(eventKinds)) {
+          if (!Array.isArray(def?.entityLinks)) continue;
+          const match = resolveEntityLinkRules(def.entityLinks, overrides).find(
+            (r) => r.entityType === params.entityType,
+          );
+          if (match) {
+            result[params.entityType] = [match];
+            return result;
+          }
+        }
+      }
+    }
+    return result;
+  });
+  return map[params.entityType]?.[0] ?? null;
+}
+
 export function clearEntityLinkRulesCache(): void {
   rulesCache.clear();
   creatorCache.clear();


### PR DESCRIPTION
## What

GitHub has a poll/sync connector, so the canonical record for an issue/PR/comment/commit is the structured event the **poll** fetches (deduped + superseded by stable `origin_id`). The App-webhook path was also storing the raw delivery, producing orphan blobs that never reconciled with the backfill. This reworks the webhook into an efficient **ETL scheduling signal** instead of a second source of data.

## How it works now

**Per-event policy** (`GITHUB_EVENT_FEED`) — each `x-github-event` maps to the one feed it affects, with one of two strategies:

- **Trigger** (issues, pull_request, comments, push) — the poll brings *more* than the webhook, so re-fetch is required for a correct record. The cleanest example: a `push` payload carries only the git author name/email, **not** the immutable `github_user_id` that `/commits` returns — so a webhook-landed commit couldn't be attributed to a person. The delivery just marks **that one feed** due (`next_run_at = now()`), scoped so an `issues` event never re-polls commits/stargazers. The poll then fetches the complete record. No actor resolution on this path — the poll resolves the person once.
- **Store** (star, watch) — the payload is already complete (actor + `starred_at`), and re-polling the entire stargazer list to capture one star is pure waste. So we land a structured `stargazer` event directly, keyed on the **same `origin_id`** the connector's poll uses, under the install's github connection — so the scheduled `/stargazers` poll supersedes/dedupes it as the backstop. The actor is resolved to a person here (the poll won't run for this feed on the webhook's account).

**Optional via flag** — `createGithubAppWebhookProvider({ storeWebhookEvents })`, wired from `GITHUB_WEBHOOK_STORE_EVENTS` (default on). Off → stars fall back to a poll trigger.

Net: total poll volume ≈ actual activity; each complete fetch happens exactly once; no orphan blobs; no double person-resolution. jira/linear (no sync mapping) keep the raw-store path unchanged.

## Why not webhook-as-data everywhere

For issues/PRs/commits the poll genuinely returns fields the webhook doesn't (the `github_user_id` on commits, computed reaction/comment counts), so a webhook-landed record would be incomplete. We don't need realtime (inference is batch), so a flicker of incomplete-then-corrected data buys nothing. Only event-complete signals (stars) are stored directly.

## Test

- 34 gateway tests (real Postgres through the real router): per-feed scoping (issues→issues only; push→commits only), star direct-store + consolidation on `origin_id` + actor resolution, flag-off fallback to trigger, cross-org star e2e, verify-failure / unknown-tenant cases.
- `github-identity-attribution` integration test unchanged (8/8) — it targets `resolveGithubWebhookActor` directly, still used by the store path.
- Over-the-wire e2e (real socket + real Postgres, prod router factory): valid signed delivery → feed flips due / forged → 401 / actor resolved / no raw event.
- Server `tsc --noEmit` clean.

## Follow-up (separate, post-deploy)

- Loosen the github poll schedule from 6h to a sparse daily backstop now that the webhook drives cadence (a prod feed change, not code).
- Tombstone the existing raw `webhook:app_install:1` orphan events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-level delivery handling for app webhooks, with responses indicating `triggered`.
  * GitHub App webhooks now use a “poll is canonical” flow: they mark the appropriate scheduled feed(s) as due and can optionally persist structured webhook events.
* **Bug Fixes**
  * Improved idempotency for repeated deliveries so scheduling is refreshed without creating duplicate raw webhook event rows.
  * Correct handling for repo transfers and unconfigured repos to avoid impacting unrelated feeds.
* **Tests**
  * Updated end-to-end webhook suites to assert canonical trigger behavior and structured event storage (including redelivery and star paths).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->