### PR TITLE
feat(watchers): derive window render from the entity type (P3 server)

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/watcher-render-from-entity.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watcher-render-from-entity.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Integration test: a watcher derives its window RENDER from its target entity
+ * type's view template (consolidation — "render lives on the entity type", the
+ * sibling of the extraction-schema derivation). When a watcher names
+ * keying_config.entity_type and supplies NO inline json_template, get_watchers
+ * serves the entity type's per-record render as `entity_type_render` plus the
+ * record-array path as `entity_render_path` — so the client renders each window
+ * record with the SAME template the entity detail page uses.
+ *
+ * Proves:
+ *   1. deriveWatcherRender resolves a real entity type's render (and the path).
+ *   2. It returns null when the type has no render / the watcher isn't entity-typed.
+ *   3. get_watchers serves entity_type_render only when the watcher carries no
+ *      inline json_template (own render wins).
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { DbClient } from '../../../db/client';
+import type { WatcherMetadata } from '../../../types/watchers';
+import { deriveWatcherRender } from '../../../utils/watcher-render';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
+import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
+
+const TOPIC_METADATA_SCHEMA = {
+  type: 'object',
+  properties: { category: { type: 'string' }, name: { type: 'string' } },
+  required: ['category', 'name'],
+  additionalProperties: true,
+};
+
+// The entity type's per-record render (a JsonTemplate root node — the same shape
+// view_template_versions.json_template stores and the entity detail page renders).
+const TOPIC_RENDER = {
+  type: 'card',
+  children: [{ type: 'card-title', props: { children: '{{name}}' } }],
+};
+
+const KEYING_CONFIG = {
+  entity_path: 'problems',
+  key_fields: ['category', 'name'],
+  key_output_field: 'problem_key',
+  entity_type: 'topic',
+};
+
+async function setupWorkspace(opts: { withRender: boolean }) {
+  const sql = getTestDb();
+  const dbClient = sql as unknown as DbClient;
+  const workspace = await TestWorkspace.create({ name: 'Render-From-Entity Org' });
+  const ownerUserId = workspace.users.owner.id;
+
+  const parentEntity = await createTestEntity({
+    name: 'Parent Brand',
+    organization_id: workspace.org.id,
+    created_by: ownerUserId,
+  });
+
+  // 'topic' type. entity_types' unique index is partial (WHERE deleted_at IS
+  // NULL) so ON CONFLICT can't bind — check then insert.
+  const existing = await sql`
+    SELECT id FROM entity_types
+    WHERE organization_id = ${workspace.org.id} AND slug = 'topic' AND deleted_at IS NULL
+    LIMIT 1
+  `;
+  let topicId: number;
+  if (existing.length > 0) {
+    topicId = Number(existing[0].id);
+    await sql`UPDATE entity_types SET metadata_schema = ${sql.json(TOPIC_METADATA_SCHEMA)} WHERE id = ${topicId}`;
+  } else {
+    const ins = await sql`
+      INSERT INTO entity_types (organization_id, slug, name, metadata_schema, created_at, updated_at)
+      VALUES (${workspace.org.id}, 'topic', 'Topic', ${sql.json(TOPIC_METADATA_SCHEMA)}, current_timestamp, current_timestamp)
+      RETURNING id
+    `;
+    topicId = Number(ins[0].id);
+  }
+
+  if (opts.withRender) {
+    // Set the topic type's default render: a view_template_versions row pointed to
+    // by entity_types.current_view_template_version_id (the resolution my helper
+    // follows).
+    const v = await sql`
+      INSERT INTO view_template_versions
+        (resource_type, resource_id, organization_id, version, tab_name, tab_order, json_template, created_by, created_at)
+      VALUES
+        ('entity_type', 'topic', ${workspace.org.id}, 1, NULL, 0, ${sql.json(TOPIC_RENDER)}, ${ownerUserId}, current_timestamp)
+      RETURNING id
+    `;
+    await sql`UPDATE entity_types SET current_view_template_version_id = ${Number(v[0].id)} WHERE id = ${topicId}`;
+  }
+
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId,
+    agentId: 'render-agent',
+    name: 'Render Agent',
+  });
+
+  const api = await TestApiClient.for({
+    organizationId: workspace.org.id,
+    userId: ownerUserId,
+    memberRole: 'owner',
+  });
+
+  return { sql, dbClient, workspace, api, parentEntityId: parentEntity.id, agent };
+}
+
+describe('deriveWatcherRender', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('resolves a real entity type render + the record-array path', async () => {
+    const ctx = await setupWorkspace({ withRender: true });
+    const derived = await deriveWatcherRender(ctx.dbClient, ctx.workspace.org.id, KEYING_CONFIG);
+    expect(derived).not.toBeNull();
+    expect(derived?.render).toEqual(TOPIC_RENDER);
+    expect(derived?.entityPath).toBe('problems');
+  });
+
+  it('returns null when the entity type carries no render', async () => {
+    const ctx = await setupWorkspace({ withRender: false });
+    const derived = await deriveWatcherRender(ctx.dbClient, ctx.workspace.org.id, KEYING_CONFIG);
+    expect(derived).toBeNull();
+  });
+
+  it('returns null when the watcher is not entity-typed', async () => {
+    const ctx = await setupWorkspace({ withRender: true });
+    const noType = { ...KEYING_CONFIG, entity_type: undefined };
+    const derived = await deriveWatcherRender(ctx.dbClient, ctx.workspace.org.id, noType);
+    expect(derived).toBeNull();
+  });
+});
+
+describe('get_watchers serves the derived render', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('serves entity_type_render + entity_render_path for an entity-typed watcher with no inline json_template', async () => {
+    const ctx = await setupWorkspace({ withRender: true });
+    const created = (await ctx.workspace.owner.watchers.create({
+      entity_id: ctx.parentEntityId,
+      slug: 'render-watcher',
+      name: 'Render Watcher',
+      prompt: 'Extract problems for {{entities}}.',
+      keying_config: KEYING_CONFIG,
+      schedule: '0 9 * * *',
+      agent_id: ctx.agent.agentId,
+    })) as { watcher_id: string };
+
+    const got = (await ctx.workspace.owner.watchers.get(created.watcher_id)) as {
+      watcher?: WatcherMetadata;
+    };
+    expect(got.watcher?.json_template).toBeUndefined();
+    expect(got.watcher?.entity_type_render).toEqual(TOPIC_RENDER);
+    expect(got.watcher?.entity_render_path).toBe('problems');
+  });
+
+  it('does NOT derive a render when the watcher has its own json_template (own render wins)', async () => {
+    const ctx = await setupWorkspace({ withRender: true });
+    const ownTemplate = { type: 'card', children: [{ type: 'text', content: 'own' }] };
+    const created = (await ctx.workspace.owner.watchers.create({
+      entity_id: ctx.parentEntityId,
+      slug: 'own-render-watcher',
+      name: 'Own Render Watcher',
+      prompt: 'Extract problems for {{entities}}.',
+      keying_config: KEYING_CONFIG,
+      json_template: ownTemplate,
+      schedule: '0 9 * * *',
+      agent_id: ctx.agent.agentId,
+    })) as { watcher_id: string };
+
+    const got = (await ctx.workspace.owner.watchers.get(created.watcher_id)) as {
+      watcher?: WatcherMetadata;
+    };
+    expect(got.watcher?.json_template).toEqual(ownTemplate);
+    expect(got.watcher?.entity_type_render).toBeUndefined();
+  });
+});

--- a/packages/server/src/tools/get_watchers.ts
+++ b/packages/server/src/tools/get_watchers.ts
@@ -15,6 +15,7 @@ import { type Static, Type } from '@sinclair/typebox';
 import { createDbClientFromEnv, type DbClient, getDb } from '../db/client';
 import type { Env } from '../index';
 import type {
+  KeyingConfig,
   PendingAnalysis,
   WatcherMetadata,
   WatcherSource,
@@ -22,6 +23,7 @@ import type {
   WatcherWindow,
   WatcherWindowReaction,
 } from '../types/watchers';
+import { deriveWatcherRender } from '../utils/watcher-render';
 import {
   buildEntityLinkUnion,
   STANDARD_IDENTITY_NAMESPACES,
@@ -230,6 +232,7 @@ interface WatcherQueryRow {
   sel_version_version_sources: unknown;
   sel_version_classifiers: unknown;
   sel_version_json_template: unknown;
+  sel_version_keying_config: unknown;
   // Latest window end (folded MAX(window_end) lookup)
   latest_window_end: string | null;
   // jsonb_agg of entities (folded entityCheck/watcherEntityQuery)
@@ -616,6 +619,7 @@ async function getWatcherImpl(
         sv.version_sources as sel_version_version_sources,
         sv.classifiers as sel_version_classifiers,
         sv.json_template as sel_version_json_template,
+        sv.keying_config as sel_version_keying_config,
         -- Latest window end for the unprocessedCount bound
         (SELECT MAX(window_end) FROM watcher_windows WHERE watcher_id = i.id) as latest_window_end,
         -- Entities + parent info for entityInfoForUrl / entitiesForTemplate
@@ -828,6 +832,7 @@ async function getWatcherImpl(
           version_sources: watcherRow.sel_version_version_sources,
           classifiers: watcherRow.sel_version_classifiers,
           json_template: watcherRow.sel_version_json_template,
+          keying_config: watcherRow.sel_version_keying_config,
         }
       : null;
 
@@ -850,6 +855,19 @@ async function getWatcherImpl(
     // Sources come from watcher row (or version if present)
     const watcherSources = parseWatcherSources(watcherRow.sources);
 
+    // Render home: an entity-typed watcher with NO inline json_template renders
+    // its window via the target entity type's render (consolidation — render
+    // lives on the type, sibling of the extraction-schema derivation). The client
+    // iterates the record array at entity_render_path, rendering each record with
+    // entity_type_render (the same template the entity detail page uses).
+    const derivedRender = version?.json_template
+      ? null
+      : await deriveWatcherRender(
+          sql,
+          ctx.organizationId,
+          (version?.keying_config as KeyingConfig | null | undefined) ?? null
+        );
+
     watcherMetadata = {
       watcher_id: watcherRow.watcher_id,
       watcher_name: watcherRow.name || (version?.name as string) || 'Watcher',
@@ -866,6 +884,9 @@ async function getWatcherImpl(
       description: (version?.description as string) || undefined,
       extraction_schema: version?.extraction_schema as Record<string, unknown> | undefined,
       json_template: version?.json_template || undefined,
+      keying_config: (version?.keying_config as KeyingConfig | null | undefined) ?? undefined,
+      entity_type_render: derivedRender?.render,
+      entity_render_path: derivedRender?.entityPath,
       rendered_prompt: version?.prompt
         ? renderPromptPreview(version.prompt as string, entitiesForTemplate)
         : undefined,

--- a/packages/server/src/types/watchers.ts
+++ b/packages/server/src/types/watchers.ts
@@ -125,6 +125,17 @@ export interface WatcherMetadata {
   extraction_schema?: Record<string, unknown>;
   json_template?: unknown;
   keying_config?: KeyingConfig | null;
+  /**
+   * Render home (consolidation): for an entity-typed watcher with no inline
+   * `json_template`, the target entity type's per-record render template — the
+   * client iterates the record array at `entity_render_path` and renders each
+   * record with this template. Undefined when the watcher carries its own
+   * `json_template` or isn't entity-typed (then the client uses `json_template`
+   * / the schema-auto renderer as before).
+   */
+  entity_type_render?: unknown;
+  /** Dotted path into a window's `extracted_data` where the record array lives. */
+  entity_render_path?: string | null;
   rendered_prompt?: string;
   available_versions?: WatcherVersionInfo[];
   reaction_script?: string;

--- a/packages/server/src/utils/watcher-render.ts
+++ b/packages/server/src/utils/watcher-render.ts
@@ -69,7 +69,8 @@ export interface DerivedWatcherRender {
   /**
    * Dotted path into a window's `extracted_data` where the record array lives
    * (from `keying_config.entity_path`). The renderer maps this array, rendering
-   * each record with `render`. Empty string ⇒ the extracted data IS the array.
+   * each record with `render`. Always non-empty — `deriveWatcherRender` returns
+   * null when `entity_path` is missing (the same contract as the schema helper).
    */
   entityPath: string;
 }

--- a/packages/server/src/utils/watcher-render.ts
+++ b/packages/server/src/utils/watcher-render.ts
@@ -1,0 +1,92 @@
+/**
+ * Watcher window render — derived from the target entity type (consolidation:
+ * "render lives on the entity type, not the watcher").
+ *
+ * The sibling of `watcher-extraction-schema.ts`: just as an entity-typed watcher
+ * derives its extraction *schema* from the entity type's `metadata_schema`, it
+ * derives its window *render* from that type's view template. A watcher whose
+ * `keying_config.entity_type` names a type, and which carries NO inline
+ * `json_template`, renders each extracted record with the entity type's render —
+ * the SAME template the entity detail page uses, so a record looks identical
+ * whether viewed in the watcher window or as a promoted entity.
+ *
+ * Composition note: an entity-type render renders ONE record; a watcher window
+ * holds an ARRAY of records (at `keying_config.entity_path`). So this returns the
+ * per-record template plus the path, and the renderer iterates — it does NOT wrap
+ * the template server-side (the render DSL's iteration node binds item scope on
+ * the client, which would require rewriting every binding path). Returns null
+ * when the watcher isn't entity-typed or the type has no render — callers fall
+ * back to the inline `json_template` (the escape hatch for bespoke renders).
+ */
+
+import type { DbClient } from '../db/client';
+import type { KeyingConfig } from '../types/watchers';
+
+/**
+ * Resolve an entity type's current default render template, tenant-first then
+ * public catalog — the same precedence as `resolveEntityTypeMetadataSchema`, so
+ * schema derivation and render derivation agree on which type they resolve. The
+ * render is the version pointed to by `entity_types.current_view_template_version_id`
+ * (the default/overview tab). Returns null when the type carries no render.
+ */
+async function resolveEntityTypeRender(
+  sql: DbClient,
+  organizationId: string,
+  entityTypeSlug: string
+): Promise<Record<string, unknown> | null> {
+  const rows = await sql<{ json_template: Record<string, unknown> | string | null }>`
+    SELECT vtv.json_template
+    FROM entity_types et
+    LEFT JOIN organization o ON o.id = et.organization_id
+    JOIN view_template_versions vtv ON vtv.id = et.current_view_template_version_id
+    WHERE et.slug = ${entityTypeSlug}
+      AND et.deleted_at IS NULL
+      AND (et.organization_id = ${organizationId} OR o.visibility = 'public')
+    ORDER BY (et.organization_id = ${organizationId}) DESC, et.id ASC
+    LIMIT 1
+  `;
+  const raw = rows[0]?.json_template ?? null;
+  if (raw == null) return null;
+  const template = typeof raw === 'string' ? safeParse(raw) : raw;
+  if (!template || typeof template !== 'object' || Object.keys(template).length === 0) {
+    return null;
+  }
+  return template as Record<string, unknown>;
+}
+
+function safeParse(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface DerivedWatcherRender {
+  /** The entity type's per-record render template (JsonTemplate root). */
+  render: Record<string, unknown>;
+  /**
+   * Dotted path into a window's `extracted_data` where the record array lives
+   * (from `keying_config.entity_path`). The renderer maps this array, rendering
+   * each record with `render`. Empty string ⇒ the extracted data IS the array.
+   */
+  entityPath: string;
+}
+
+/**
+ * Derive a watcher's window render from its target entity type. Returns null when
+ * the watcher isn't entity-typed (no `keying_config.entity_type`) or the type has
+ * no render — callers fall back to the inline `json_template`.
+ */
+export async function deriveWatcherRender(
+  sql: DbClient,
+  organizationId: string,
+  keyingConfig: KeyingConfig | null | undefined
+): Promise<DerivedWatcherRender | null> {
+  const entityType = keyingConfig?.entity_type?.trim();
+  if (!entityType || !keyingConfig?.entity_path) return null;
+  const render = await resolveEntityTypeRender(sql, organizationId, entityType);
+  if (!render) return null;
+  return { render, entityPath: keyingConfig.entity_path };
+}


### PR DESCRIPTION
## What — render home (P3), server half

The sibling of the merged extraction-schema derivation (#1514, "schema lives on the entity type"). An **entity-typed watcher** (`keying_config.entity_type` set) with **no inline `json_template`** now derives its window render from the target **entity type's view template**.

`get_watchers` serves:
- `entity_type_render` — the entity type's per-record render (the same template the entity detail page uses)
- `entity_render_path` — the dotted path into `extracted_data` where the record array lives

…so a client renders each extracted record with the type's render. **Render is defined once, on the type.**

## Design — why iterate, not wrap
An entity-type render renders **one** record; a watcher window holds an **array** of records (at `entity_path`). The render DSL's `each` node binds item scope **on the client**, so wrapping the template server-side would require rewriting every binding path. Instead the server returns the per-record template + the path, and the **client iterates** (next PR).

## Changes
- `utils/watcher-render.ts` (new): `resolveEntityTypeRender` (tenant-first then public, mirrors `resolveEntityTypeMetadataSchema`; follows `entity_types.current_view_template_version_id`) + `deriveWatcherRender`.
- `get_watchers.ts`: select `sv.keying_config`; derive + serve the two fields when the version has no `json_template`. **Own `json_template` always wins.**
- `WatcherMetadata` gains the two optional fields.

## Verification
- **5/5 integration tests** (`watcher-render-from-entity.test.ts`): `deriveWatcherRender` resolves render+path; null when the type has no render / not entity-typed; `get_watchers` serves the fields with no inline template; own-render-wins.
- Server `tsc` clean. Pure additive (+304 lines).

## Scope
This is the **additive server (expand) half** — inert until the owletto window renderer consumes the fields. The **owletto frontend PR** (separate repo, `make e2e-browser`) will: iterate the record array at `entity_render_path`, render each via `TemplateRenderer` with `data=record`, **write-prefix** `onCorrection` with `${path}.${i}.` (matching the AutoRenderer dot-path format), and wrap each record in a prefix-scoped `FieldFeedbackProvider` so the "edited" badge displays. That correction path-mapping is the bit that needs visual verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784897255&installation_id=136316292&pr_number=1542&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1542&signature=c5ea3e30f9bc8456cfa2253ef48d316c373eca64f4344f812b0da1700191b0e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->