### PR TITLE
fix(slack): surface App Home publish errors in logs

### DIFF
--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -524,16 +524,19 @@ async function publishHome(
     const blocks = await buildSlackHomeBlocks(params);
     await publishHomeView(params.userId, { type: "home", blocks });
   } catch (error) {
-    logger.warn(
-      {
-        error: errorDetail(error),
-        connectionId: params.connection.id,
-        userId: params.userId,
-      },
-			"Failed to publish Slack home tab; falling back to a minimal view",
+    // Message-first form: the console logger drops the metadata object when
+    // called pino-style (`logger.warn({...}, "msg")`), so structured error
+    // detail never reaches the logs. Inline it here. `hasToken` distinguishes
+    // a real publish failure on a token-bearing adapter from a token-less
+    // (multi-workspace / OAuth-fallback) adapter routed here without a bot token.
+    const hasToken = Boolean(
+      (adapter as { defaultBotToken?: unknown } | undefined)?.defaultBotToken,
     );
-    // The rich view failed (likely Block Kit validation). Don't leave the user
-    // staring at a stale cached view — publish a plain text-only home tab.
+    logger.warn(
+      `Failed to publish Slack home tab (conn=${params.connection.id} user=${params.userId} hasToken=${hasToken}); falling back: ${JSON.stringify(errorDetail(error))}`,
+    );
+    // The rich view failed. Don't leave the user staring at a stale cached
+    // view — publish a plain text-only home tab.
     try {
       await publishHomeView(params.userId, {
         type: "home",
@@ -541,12 +544,7 @@ async function publishHome(
       });
     } catch (fallbackError) {
       logger.warn(
-        {
-          error: errorDetail(fallbackError),
-          connectionId: params.connection.id,
-          userId: params.userId,
-        },
-				"Failed to publish fallback Slack home tab",
+        `Failed to publish fallback Slack home tab (conn=${params.connection.id} hasToken=${hasToken}): ${JSON.stringify(errorDetail(fallbackError))}`,
       );
     }
   }


### PR DESCRIPTION
The console logger drops the metadata object for pino-style `logger.warn({error}, "msg")` calls (renders only the message), so the real Slack `views.publish` failure behind the stale App Home tab was invisible in prod. This logs it message-first, plus whether the publishing adapter carries a bot token — to pinpoint the root cause of the home-tab not updating.

Diagnostic-leaning but a genuine fix: structured error detail should not be silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784898622&installation_id=136316292&pr_number=1543&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1543&signature=276b5e163eea222370892e9d8b377a8b5094882f3856d553d3e064ce90febd1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->