### PR TITLE
fix(slack): bind publishHomeView so the App Home tab actually publishes

### DIFF
--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -524,16 +524,19 @@ async function publishHome(
     const blocks = await buildSlackHomeBlocks(params);
     await publishHomeView(params.userId, { type: "home", blocks });
   } catch (error) {
-    logger.warn(
-      {
-        error: errorDetail(error),
-        connectionId: params.connection.id,
-        userId: params.userId,
-      },
-			"Failed to publish Slack home tab; falling back to a minimal view",
+    // Message-first form: the console logger drops the metadata object when
+    // called pino-style (`logger.warn({...}, "msg")`), so structured error
+    // detail never reaches the logs. Inline it here. `hasToken` distinguishes
+    // a real publish failure on a token-bearing adapter from a token-less
+    // (multi-workspace / OAuth-fallback) adapter routed here without a bot token.
+    const hasToken = Boolean(
+      (adapter as { defaultBotToken?: unknown } | undefined)?.defaultBotToken,
     );
-    // The rich view failed (likely Block Kit validation). Don't leave the user
-    // staring at a stale cached view — publish a plain text-only home tab.
+    logger.warn(
+      `Failed to publish Slack home tab (conn=${params.connection.id} user=${params.userId} hasToken=${hasToken}); falling back: ${JSON.stringify(errorDetail(error))}`,
+    );
+    // The rich view failed. Don't leave the user staring at a stale cached
+    // view — publish a plain text-only home tab.
     try {
       await publishHomeView(params.userId, {
         type: "home",
@@ -541,12 +544,7 @@ async function publishHome(
       });
     } catch (fallbackError) {
       logger.warn(
-        {
-          error: errorDetail(fallbackError),
-          connectionId: params.connection.id,
-          userId: params.userId,
-        },
-				"Failed to publish fallback Slack home tab",
+        `Failed to publish fallback Slack home tab (conn=${params.connection.id} hasToken=${hasToken}): ${JSON.stringify(errorDetail(fallbackError))}`,
       );
     }
   }

--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -518,33 +518,32 @@ async function publishHome(
   adapter: SlackHomeAdapter | undefined,
 	params: HomeViewParams,
 ): Promise<void> {
-  const publishHomeView = adapter?.publishHomeView;
-  if (typeof publishHomeView !== "function") return;
+  if (typeof adapter?.publishHomeView !== "function") return;
+  // Call `publishHomeView` AS A METHOD on the adapter. Extracting it into a
+  // local (`const fn = adapter.publishHomeView; fn(...)`) drops the `this`
+  // binding, so inside `@chat-adapter/slack` `this` is undefined and
+  // `this.client.views.publish(...)` throws "Cannot read properties of
+  // undefined (reading 'client')" — failing every publish, rich AND fallback,
+  // which is why the App Home tab stayed frozen on its last-published view.
   try {
     const blocks = await buildSlackHomeBlocks(params);
-    await publishHomeView(params.userId, { type: "home", blocks });
+    await adapter.publishHomeView(params.userId, { type: "home", blocks });
   } catch (error) {
-    // Message-first form: the console logger drops the metadata object when
-    // called pino-style (`logger.warn({...}, "msg")`), so structured error
-    // detail never reaches the logs. Inline it here. `hasToken` distinguishes
-    // a real publish failure on a token-bearing adapter from a token-less
-    // (multi-workspace / OAuth-fallback) adapter routed here without a bot token.
-    const hasToken = Boolean(
-      (adapter as { defaultBotToken?: unknown } | undefined)?.defaultBotToken,
-    );
+    // Message-first: the console logger drops the metadata object for
+    // pino-style `logger.warn({...}, "msg")` calls, so inline the detail here.
     logger.warn(
-      `Failed to publish Slack home tab (conn=${params.connection.id} user=${params.userId} hasToken=${hasToken}); falling back: ${JSON.stringify(errorDetail(error))}`,
+      `Failed to publish Slack home tab (conn=${params.connection.id} user=${params.userId}); falling back: ${JSON.stringify(errorDetail(error))}`,
     );
     // The rich view failed. Don't leave the user staring at a stale cached
     // view — publish a plain text-only home tab.
     try {
-      await publishHomeView(params.userId, {
+      await adapter.publishHomeView(params.userId, {
         type: "home",
         blocks: HOME_FALLBACK_BLOCKS,
       });
     } catch (fallbackError) {
       logger.warn(
-        `Failed to publish fallback Slack home tab (conn=${params.connection.id} hasToken=${hasToken}): ${JSON.stringify(errorDetail(fallbackError))}`,
+        `Failed to publish fallback Slack home tab (conn=${params.connection.id}): ${JSON.stringify(errorDetail(fallbackError))}`,
       );
     }
   }


### PR DESCRIPTION
## Root cause
`publishHome` extracted the adapter method into a local and called it unbound:
```ts
const publishHomeView = adapter?.publishHomeView;
await publishHomeView(userId, view); // this === undefined
```
Inside `@chat-adapter/slack`, `publishHomeView` does `this.client.views.publish(...)`. With `this` lost, it throws `Cannot read properties of undefined (reading 'client')` for **every** publish — both the rich view and the minimal fallback — so Slack never accepted a new App Home view and the tab stayed frozen on its last-published (stale 'AI coding assistant') content.

## Fix
Call `adapter.publishHomeView(...)` as a method so `this` stays bound.

## Proof (live, prod)
- Token/scopes/config/endpoint all verified correct; `views.publish` works with the resolved token.
- In-pod against the real adapter: extracted call → `undefined is not an object (evaluating 'this.client')` (exact prod error); method call → publishes OK.
- The instrumented log (from #1543) showed: `Failed to publish Slack home tab (... hasToken=true): Cannot read properties of undefined (reading 'client')`.

Pre-existing bug (failed on pre-#1537 pods too); also keeps the message-first error logging so this class of failure is visible going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784899367&installation_id=136316292&pr_number=1544&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1544&signature=dd3c5649a8f9d4593d53492a94bf2cb0f66e1d775c9b98c05db8f72df2c6d8b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->