### PR TITLE
fix(server): allow published Chrome Web Store extension ID in CSP + CORS

### DIFF
--- a/packages/server/src/__tests__/unit/cors-origin.test.ts
+++ b/packages/server/src/__tests__/unit/cors-origin.test.ts
@@ -38,9 +38,13 @@ afterEach(() => {
 });
 
 describe('getOwnedOwlettoExtensionIds', () => {
-  test('always includes the canonical published extension id', () => {
+  test('always includes both the dev/unpacked and published store ids', () => {
     const ids = getOwnedOwlettoExtensionIds(makeEnv());
+    // Dev/unpacked id, derived from the manifest `key`.
     expect(ids).toContain('amnnhclgmbldmfcfamonoggjhfidemmm');
+    // Chrome Web Store id — without this, app.lobu.ai's frame-ancestors
+    // blocked the published sidepanel iframe even though local dev worked.
+    expect(ids).toContain('jhgcecbdpnoehfnhpdfihlchjddapepi');
   });
 
   test('merges in well-formed ids from LOBU_OWLETTO_EXTENSION_IDS', () => {
@@ -49,16 +53,27 @@ describe('getOwnedOwlettoExtensionIds', () => {
       makeEnv({ LOBU_OWLETTO_EXTENSION_IDS: `  ${fakeDevId} , bogus-id, ` })
     );
     expect(ids).toContain('amnnhclgmbldmfcfamonoggjhfidemmm');
+    expect(ids).toContain('jhgcecbdpnoehfnhpdfihlchjddapepi');
     expect(ids).toContain(fakeDevId);
     expect(ids).not.toContain('bogus-id');
   });
 });
 
 describe('isAllowedCorsOrigin — chrome-extension://', () => {
-  test('accepts the canonical Owletto extension origin', () => {
+  test('accepts the dev/unpacked Owletto extension origin', () => {
     expect(
       isAllowedCorsOrigin(
         'chrome-extension://amnnhclgmbldmfcfamonoggjhfidemmm',
+        makeEnv(),
+        REQUEST_URL
+      )
+    ).toBe(true);
+  });
+
+  test('accepts the published Chrome Web Store extension origin', () => {
+    expect(
+      isAllowedCorsOrigin(
+        'chrome-extension://jhgcecbdpnoehfnhpdfihlchjddapepi',
         makeEnv(),
         REQUEST_URL
       )

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -101,18 +101,30 @@ export type { Env };
 
 const LOCALHOST_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
-// The published Owletto for Chrome extension ID, pinned via the manifest's
-// `key` field (see lobu-ai/owletto:apps/chrome/manifest.json). Identity for
-// CSP frame-ancestors AND CORS — both have to agree that this extension is
-// "us", otherwise either iframe embedding or fetch-from-SW breaks.
-const CANONICAL_OWLETTO_EXTENSION_ID = "amnnhclgmbldmfcfamonoggjhfidemmm";
+// Owned Owletto for Chrome extension IDs. Identity for CSP frame-ancestors
+// AND CORS — both have to agree that an extension is "us", otherwise either
+// iframe embedding or fetch-from-SW breaks. There are two distinct IDs and
+// both are production facts, so both are pinned here:
+//   - DEV/UNPACKED: derived from the manifest `key` field (see
+//     lobu-ai/owletto:apps/chrome/manifest.json). This is the ID our local
+//     harness and any unpacked build loads as.
+//   - PUBLISHED: assigned by the Chrome Web Store, which overrides the
+//     manifest `key` with its own signing key, so the store build runs under
+//     a different ID (see lobu-ai/owletto:store-assets/STORE-LISTING.md and
+//     apps/mac/Owletto/OwlettoApp.swift). The store ID was previously missing
+//     from this list, so app.lobu.ai's frame-ancestors blocked the published
+//     sidepanel iframe even though local dev worked.
+const OWLETTO_EXTENSION_IDS = [
+	"amnnhclgmbldmfcfamonoggjhfidemmm", // dev/unpacked (manifest `key`)
+	"jhgcecbdpnoehfnhpdfihlchjddapepi", // Chrome Web Store (published)
+] as const;
 
 const CHROME_EXTENSION_ID_RE = /^[a-p]{32}$/;
 
 /**
- * Owned Owletto extension IDs (canonical + anything pinned via the
- * LOBU_OWLETTO_EXTENSION_IDS env so a dev build with a different manifest
- * key can be allowed alongside the published one). Same source for both
+ * Owned Owletto extension IDs (the pinned dev + published IDs, plus anything
+ * pinned via the LOBU_OWLETTO_EXTENSION_IDS env so an ad-hoc build with a
+ * different manifest key can be allowed alongside them). Same source for both
  * the CSP frame-ancestors directive on HTML responses and the CORS
  * allowlist that lets the service worker fetch /api/workers/poll.
  */
@@ -121,7 +133,7 @@ export function getOwnedOwlettoExtensionIds(env: Env): string[] {
 		.split(",")
 		.map((s) => s.trim())
 		.filter((s) => CHROME_EXTENSION_ID_RE.test(s));
-	return [CANONICAL_OWLETTO_EXTENSION_ID, ...extra];
+	return [...OWLETTO_EXTENSION_IDS, ...extra];
 }
 
 export function isAllowedCorsOrigin(


### PR DESCRIPTION
## Problem

The published Owletto for Chrome extension showed a blank sidepanel with this console error (not reproducible on the local/unpacked build):

```
Framing 'https://app.lobu.ai/' violates the following Content Security Policy
directive: "frame-ancestors 'self' https://lobu.ai https://*.lobu.ai
chrome-extension://amnnhclgmbldmfcfamonoggjhfidemmm". The request has been blocked.
```

## Root cause

`app.lobu.ai` emits `frame-ancestors` (and a matching CORS allowlist) from a single source — `getOwnedOwlettoExtensionIds` in `packages/server/src/index.ts`. It only pinned `amnnhclgmbldmfcfamonoggjhfidemmm`, which is the ID **derived from the manifest `key`** (verified: SHA-256 of the DER key → first 16 bytes → a–p map → that exact string). That's the ID the **local/unpacked** build loads as.

The **Chrome Web Store overrides the manifest `key` with its own signing key**, so the published build runs under a different ID, `jhgcecbdpnoehfnhpdfihlchjddapepi` (see `owletto:store-assets/STORE-LISTING.md` and `apps/mac/Owletto/OwlettoApp.swift`, where it's already trusted). That ID was never in the server allowlist, and no prod env sets `LOBU_OWLETTO_EXTENSION_IDS` — so `frame-ancestors` blocked the published sidepanel iframe. Local dev worked because its ID *was* listed.

## Fix

Pin both IDs in a new `OWLETTO_EXTENSION_IDS` array; `getOwnedOwlettoExtensionIds` spreads it into both the CSP directive and the CORS allowlist. The `LOBU_OWLETTO_EXTENSION_IDS` env escape hatch is preserved for ad-hoc builds.

## Verification

- `cors-origin.test.ts`: added coverage for the published origin — **10 pass / 0 fail**.
- `tsc --noEmit` on `packages/server`: clean.
- Both IDs pass the `/^[a-p]{32}$/` validation regex.
- Live unblock can only be confirmed post-deploy (the CSP header is emitted server-side).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784903198&installation_id=136316292&pr_number=1547&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1547&signature=7356aeb7192022970e2dd501b199f1e9ce5194b096161005c839acfabc950127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->