### PR TITLE
feat(server): resolve GitHub App-install credentials from connector declaration

### DIFF
--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -268,6 +268,24 @@ export interface ConnectorAuthAppInstallation {
   appIdKey?: string;
   /** Env var holding the App private key used to mint tokens (GitHub). Gateway-side. */
   privateKeyKey?: string;
+  /**
+   * Env var holding the App's URL slug (e.g. `GITHUB_APP_SLUG`), substituted into
+   * {@link installUrlTemplate} as `{{app_slug}}`. Gateway-side.
+   */
+  appSlugKey?: string;
+  /**
+   * Env var holding the App's OAuth client id used for the user-authorization
+   * leg of installation (e.g. `GITHUB_APP_CLIENT_ID`). Distinct from a separate
+   * user-login OAuth method's `clientIdKey`. Gateway-side.
+   */
+  clientIdKey?: string;
+  /** Env var holding the App's OAuth client secret (e.g. `GITHUB_APP_CLIENT_SECRET`). Gateway-side. */
+  clientSecretKey?: string;
+  /**
+   * Env var holding the secret used to verify inbound app-webhook deliveries
+   * (e.g. `GITHUB_APP_WEBHOOK_SECRET`). Gateway-side.
+   */
+  webhookSecretKey?: string;
   /** Template URL the UI sends the user to in order to install the App. */
   installUrlTemplate?: string;
   /** Declared App permissions (informational; surfaced in the install UI). */

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -316,6 +316,13 @@ export default class GitHubConnector extends ConnectorRuntime {
           providerInstance: 'cloud',
           appIdKey: 'GITHUB_APP_ID',
           privateKeyKey: 'GITHUB_APP_PRIVATE_KEY',
+          appSlugKey: 'GITHUB_APP_SLUG',
+          // The App's OWN OAuth client (used for the user-authorization leg of
+          // install / recovery), distinct from the user-login `oauth` method's
+          // GITHUB_CLIENT_ID/SECRET below.
+          clientIdKey: 'GITHUB_APP_CLIENT_ID',
+          clientSecretKey: 'GITHUB_APP_CLIENT_SECRET',
+          webhookSecretKey: 'GITHUB_APP_WEBHOOK_SECRET',
           // Install URL for the Lobu GitHub App. `{{app_slug}}` is substituted
           // by the install UI from the configured App slug; the user picks the
           // org/repos to grant during GitHub's install flow.

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -30,6 +30,10 @@ import {
   createJiraAppWebhookProvider,
   createLinearAppWebhookProvider,
 } from "../routes/public/app-webhooks.js";
+import {
+  getCachedAppInstallationMethod,
+  resolveAppInstallCredentials,
+} from "../installation/app-install-credentials.js";
 import { createAppInstallRoutes } from "../routes/public/app-install.js";
 import { resolveInstallOrgId } from "../routes/public/slack.js";
 import { createAgentConfigRoutes } from "../routes/public/agent-config.js";
@@ -713,7 +717,12 @@ export function createGatewayApp(
     // Slack stays a custom plugin (timestamped signing base).
     const appWebhookSecretStore = coreServices.getSecretStore();
     const appWebhookProviders: AppWebhookProvider[] = [];
-    const githubAppId = process.env.GITHUB_APP_ID;
+    // GitHub App id resolved from the connector's declared `appIdKey` (primed
+    // during async boot via primeAppInstallationMethods), not a server literal.
+    const githubInstallMethod = getCachedAppInstallationMethod("github", "github");
+    const githubAppId = githubInstallMethod
+      ? resolveAppInstallCredentials(githubInstallMethod).appId
+      : undefined;
     if (githubAppId) {
       appWebhookProviders.push(
         createGithubAppWebhookProvider({

--- a/packages/server/src/gateway/installation/__tests__/app-install-credentials.test.ts
+++ b/packages/server/src/gateway/installation/__tests__/app-install-credentials.test.ts
@@ -1,0 +1,92 @@
+import type { ConnectorAuthAppInstallation } from "@lobu/connector-sdk";
+import { describe, expect, it } from "bun:test";
+import {
+	renderAppInstallUrl,
+	resolveAppInstallCredentials,
+} from "../app-install-credentials.js";
+
+const method: ConnectorAuthAppInstallation = {
+	type: "app_installation",
+	provider: "github",
+	providerInstance: "cloud",
+	appIdKey: "GITHUB_APP_ID",
+	privateKeyKey: "GITHUB_APP_PRIVATE_KEY",
+	appSlugKey: "GITHUB_APP_SLUG",
+	clientIdKey: "GITHUB_APP_CLIENT_ID",
+	clientSecretKey: "GITHUB_APP_CLIENT_SECRET",
+	webhookSecretKey: "GITHUB_APP_WEBHOOK_SECRET",
+	installUrlTemplate: "https://github.com/apps/{{app_slug}}/installations/new",
+};
+
+describe("resolveAppInstallCredentials", () => {
+	it("reads each credential from the env var NAME the connector declares", () => {
+		const env = {
+			GITHUB_APP_ID: "4112538",
+			GITHUB_APP_PRIVATE_KEY: "pk",
+			GITHUB_APP_SLUG: "lobu-ai",
+			GITHUB_APP_CLIENT_ID: "Iv23xxx",
+			GITHUB_APP_CLIENT_SECRET: "shh",
+			GITHUB_APP_WEBHOOK_SECRET: "whsec",
+		} as unknown as NodeJS.ProcessEnv;
+		const creds = resolveAppInstallCredentials(method, env);
+		expect(creds).toMatchObject({
+			appId: "4112538",
+			privateKey: "pk",
+			appSlug: "lobu-ai",
+			clientId: "Iv23xxx",
+			clientSecret: "shh",
+			webhookSecret: "whsec",
+			appIdKey: "GITHUB_APP_ID",
+			privateKeyKey: "GITHUB_APP_PRIVATE_KEY",
+		});
+	});
+
+	it("leaves values undefined when the declared env var is unset (no literal fallback)", () => {
+		const creds = resolveAppInstallCredentials(method, {} as NodeJS.ProcessEnv);
+		expect(creds.appId).toBeUndefined();
+		expect(creds.clientId).toBeUndefined();
+		expect(creds.webhookSecret).toBeUndefined();
+		// declared key NAMES are still surfaced for stamping onto the install row
+		expect(creds.appIdKey).toBe("GITHUB_APP_ID");
+	});
+
+	it("ignores credentials whose key the connector does not declare", () => {
+		const partial: ConnectorAuthAppInstallation = {
+			type: "app_installation",
+			provider: "x",
+			appIdKey: "X_APP_ID",
+		};
+		const creds = resolveAppInstallCredentials(partial, {
+			X_APP_ID: "1",
+			X_APP_CLIENT_ID: "should-be-ignored",
+		} as unknown as NodeJS.ProcessEnv);
+		expect(creds.appId).toBe("1");
+		expect(creds.clientId).toBeUndefined();
+	});
+});
+
+describe("renderAppInstallUrl", () => {
+	it("substitutes {{app_slug}} and appends state", () => {
+		const url = renderAppInstallUrl(
+			method.installUrlTemplate,
+			"lobu-ai",
+			"state-123",
+		);
+		expect(url).toBe(
+			"https://github.com/apps/lobu-ai/installations/new?state=state-123",
+		);
+	});
+
+	it("url-encodes the slug", () => {
+		const url = renderAppInstallUrl(
+			"https://github.com/apps/{{app_slug}}/installations/new",
+			"a b/c",
+			"s",
+		);
+		expect(url).toContain("apps/a%20b%2Fc/installations/new");
+	});
+
+	it("returns null when no template is declared", () => {
+		expect(renderAppInstallUrl(undefined, "lobu-ai", "s")).toBeNull();
+	});
+});

--- a/packages/server/src/gateway/installation/app-install-credentials.ts
+++ b/packages/server/src/gateway/installation/app-install-credentials.ts
@@ -1,0 +1,151 @@
+/**
+ * Resolve app-installation credentials from the connector's DECLARED auth schema
+ * instead of hardcoding `process.env.GITHUB_*` literals in the server.
+ *
+ * The connector's `app_installation` method declares the *names* of the env vars
+ * that hold each credential (`appIdKey`, `privateKeyKey`, `appSlugKey`,
+ * `clientIdKey`, `clientSecretKey`, `webhookSecretKey`) plus the `installUrlTemplate`.
+ * This module reads those declared names and returns the resolved values, so the
+ * server holds no provider-specific env literal — adding/relocating a credential
+ * env var is a connector edit, not a server edit.
+ *
+ * The declaration is sourced from the BUNDLED connector on disk (the same compile
+ * path `ensure-connector-installed` uses): env-var names are deployment-wide
+ * constants, not per-org, so one resolve per (connectorKey, provider) per process
+ * is correct. `compileConnectorFromFile` is mtime-cached and the resolved method
+ * is memoised here, so route/startup callers pay the extract cost at most once.
+ */
+
+import type { ConnectorAuthAppInstallation } from "@lobu/connector-sdk";
+import {
+	getAppInstallationAuthMethods,
+	normalizeConnectorAuthSchema,
+} from "../../utils/connector-auth.js";
+import {
+	compileConnectorFromFile,
+	findBundledConnectorFile,
+} from "../../utils/connector-catalog.js";
+import { extractConnectorMetadata } from "../../utils/connector-compiler.js";
+
+const methodCache = new Map<string, ConnectorAuthAppInstallation | null>();
+
+/**
+ * The declared `app_installation` auth method for a bundled connector (or null
+ * when the connector has no bundled source / no app_installation method).
+ * Memoised per (connectorKey, provider).
+ */
+export async function getBundledAppInstallationMethod(
+	connectorKey: string,
+	provider?: string,
+): Promise<ConnectorAuthAppInstallation | null> {
+	const cacheKey = `${connectorKey}::${provider ?? ""}`;
+	const cached = methodCache.get(cacheKey);
+	if (cached !== undefined) return cached;
+
+	const file = findBundledConnectorFile(connectorKey);
+	if (!file) {
+		methodCache.set(cacheKey, null);
+		return null;
+	}
+	const code = await compileConnectorFromFile(file);
+	const metadata = await extractConnectorMetadata(code);
+	const methods = getAppInstallationAuthMethods(
+		normalizeConnectorAuthSchema(metadata.authSchema),
+	);
+	const method =
+		methods.find((m) => !provider || m.provider === provider) ?? null;
+	methodCache.set(cacheKey, method);
+	return method;
+}
+
+/**
+ * Synchronous read of a previously-resolved (primed) app_installation method.
+ * Returns undefined when the (connectorKey, provider) pair has not been primed —
+ * callers in synchronous contexts (gateway route wiring) must
+ * {@link primeAppInstallationMethods} during async boot first.
+ */
+export function getCachedAppInstallationMethod(
+	connectorKey: string,
+	provider?: string,
+): ConnectorAuthAppInstallation | null | undefined {
+	return methodCache.get(`${connectorKey}::${provider ?? ""}`);
+}
+
+/**
+ * Warm the method cache during async boot so synchronous wiring (e.g.
+ * `createGatewayApp`) can read declarations via {@link getCachedAppInstallationMethod}
+ * without going async. Per-spec failures are swallowed (logged by the compile
+ * path) and leave that entry unprimed — the provider simply isn't registered,
+ * identical to a missing app-id env, never a boot failure.
+ */
+export async function primeAppInstallationMethods(
+	specs: Array<{ connectorKey: string; provider?: string }>,
+): Promise<void> {
+	await Promise.all(
+		specs.map(async (spec) => {
+			try {
+				await getBundledAppInstallationMethod(spec.connectorKey, spec.provider);
+			} catch {
+				// leave unprimed; getCachedAppInstallationMethod returns undefined
+			}
+		}),
+	);
+}
+
+/** Test-only: drop the memoised methods so a re-declared connector is re-read. */
+export function clearAppInstallationMethodCache(): void {
+	methodCache.clear();
+}
+
+export interface ResolvedAppInstallCredentials {
+	appId?: string;
+	privateKey?: string;
+	appSlug?: string;
+	clientId?: string;
+	clientSecret?: string;
+	webhookSecret?: string;
+	installUrlTemplate?: string;
+	/** The declared env-var names, stamped onto the install row so token minting reads the right vars. */
+	appIdKey?: string;
+	privateKeyKey?: string;
+}
+
+/** Read each declared credential env var by the NAME the connector declares. */
+export function resolveAppInstallCredentials(
+	method: ConnectorAuthAppInstallation,
+	env: NodeJS.ProcessEnv = process.env,
+): ResolvedAppInstallCredentials {
+	const read = (key?: string): string | undefined =>
+		key ? env[key] : undefined;
+	return {
+		appId: read(method.appIdKey),
+		privateKey: read(method.privateKeyKey),
+		appSlug: read(method.appSlugKey),
+		clientId: read(method.clientIdKey),
+		clientSecret: read(method.clientSecretKey),
+		webhookSecret: read(method.webhookSecretKey),
+		installUrlTemplate: method.installUrlTemplate,
+		appIdKey: method.appIdKey,
+		privateKeyKey: method.privateKeyKey,
+	};
+}
+
+/**
+ * Build the App install URL from the connector's declared `installUrlTemplate`,
+ * substituting `{{app_slug}}` and stamping the CSRF `state`. Falls back to null
+ * when no template is declared.
+ */
+export function renderAppInstallUrl(
+	template: string | undefined,
+	appSlug: string | undefined,
+	state: string,
+): string | null {
+	if (!template) return null;
+	const filled = template.replace(
+		/\{\{\s*app_slug\s*\}\}/g,
+		encodeURIComponent(appSlug ?? ""),
+	);
+	const url = new URL(filled);
+	url.searchParams.set("state", state);
+	return url.toString();
+}

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -57,6 +57,11 @@ import {
 	renderOAuthErrorPage,
 	renderOAuthSuccessPage,
 } from "../../auth/oauth-templates.js";
+import {
+	getBundledAppInstallationMethod,
+	renderAppInstallUrl,
+	resolveAppInstallCredentials,
+} from "../../installation/app-install-credentials.js";
 import { getInstallationTokenRegistry } from "../../installation/registry.js";
 import { createSyncRun } from "../../../runs/queue-service.js";
 import {
@@ -674,12 +679,20 @@ export async function autoProvisionGithubIssueFeeds(params: {
 		);
 		return result;
 	}
+	// Pre-stamp rows (linked before app_installation keys were recorded) lack
+	// metadata.{appIdKey,privateKeyKey}; fall back to the connector's declaration
+	// rather than a hardcoded literal.
+	const fallbackMethod = await getBundledAppInstallationMethod(
+		GITHUB_CONNECTOR_KEY,
+		"github",
+	);
 	const installWithKeys = {
 		...install,
 		metadata: {
 			...install.metadata,
-			appIdKey: install.metadata?.appIdKey ?? "GITHUB_APP_ID",
-			privateKeyKey: install.metadata?.privateKeyKey ?? "GITHUB_APP_PRIVATE_KEY",
+			appIdKey: install.metadata?.appIdKey ?? fallbackMethod?.appIdKey,
+			privateKeyKey:
+				install.metadata?.privateKeyKey ?? fallbackMethod?.privateKeyKey,
 		},
 	};
 
@@ -825,12 +838,20 @@ export async function provisionGithubTeamGraph(params: {
 		);
 		return empty;
 	}
+	// Pre-stamp rows (linked before app_installation keys were recorded) lack
+	// metadata.{appIdKey,privateKeyKey}; fall back to the connector's declaration
+	// rather than a hardcoded literal.
+	const fallbackMethod = await getBundledAppInstallationMethod(
+		GITHUB_CONNECTOR_KEY,
+		"github",
+	);
 	const installWithKeys = {
 		...install,
 		metadata: {
 			...install.metadata,
-			appIdKey: install.metadata?.appIdKey ?? "GITHUB_APP_ID",
-			privateKeyKey: install.metadata?.privateKeyKey ?? "GITHUB_APP_PRIVATE_KEY",
+			appIdKey: install.metadata?.appIdKey ?? fallbackMethod?.appIdKey,
+			privateKeyKey:
+				install.metadata?.privateKeyKey ?? fallbackMethod?.privateKeyKey,
 		},
 	};
 
@@ -980,9 +1001,17 @@ async function verifyInstallationOwnership(params: {
 		AppInstallRouterDeps["fetchSoleAccessibleInstallation"]
 	>;
 }): Promise<InstallOwnershipResult> {
-	// The App's OAuth creds (NOT the Lobu login OAuth app). Fail safe if unset.
-	const clientId = process.env.GITHUB_APP_CLIENT_ID;
-	const clientSecret = process.env.GITHUB_APP_CLIENT_SECRET;
+	// The App's OAuth creds (NOT the Lobu login OAuth app), read from the
+	// connector's declared `clientIdKey`/`clientSecretKey`. Fail safe if unset.
+	const ownershipMethod = await getBundledAppInstallationMethod(
+		GITHUB_CONNECTOR_KEY,
+		"github",
+	);
+	const ownershipCreds = ownershipMethod
+		? resolveAppInstallCredentials(ownershipMethod)
+		: null;
+	const clientId = ownershipCreds?.clientId;
+	const clientSecret = ownershipCreds?.clientSecret;
 	if (!clientId || !clientSecret) {
 		return {
 			ok: false,
@@ -1194,8 +1223,13 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 	// `installation_id`). The callback derives the installation from
 	// /user/installations and runs the SAME ownership + session-org guards.
 	router.get("/github/app/install", async (c) => {
-		const appSlug = process.env.GITHUB_APP_SLUG;
-		const appId = process.env.GITHUB_APP_ID;
+		const method = await getBundledAppInstallationMethod(
+			GITHUB_CONNECTOR_KEY,
+			"github",
+		);
+		const creds = method ? resolveAppInstallCredentials(method) : null;
+		const appSlug = creds?.appSlug;
+		const appId = creds?.appId;
 		if (!appId || !appSlug) {
 			return c.html(
 				renderOAuthErrorPage(
@@ -1225,7 +1259,7 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 		// the install page would dead-end). Recovery needs the App's OAuth client id
 		// to send the user through user-authorization.
 		const explicitRecovery = c.req.query("recovery") === "1";
-		const clientId = process.env.GITHUB_APP_CLIENT_ID;
+		const clientId = creds?.clientId;
 		const alreadyHasInstallRow = await orgHasGithubInstallRow(orgId, appId);
 		const useRecovery = (explicitRecovery || alreadyHasInstallRow) && !!clientId;
 
@@ -1246,11 +1280,19 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 		}
 
 		const state = await stateStore.create({ organizationId: orgId });
-		return c.redirect(githubAppInstallUrl(appSlug, state), 302);
+		const installUrl =
+			renderAppInstallUrl(creds?.installUrlTemplate, appSlug, state) ??
+			githubAppInstallUrl(appSlug, state);
+		return c.redirect(installUrl, 302);
 	});
 
 	router.get("/github/app/install/callback", async (c) => {
-		const appId = process.env.GITHUB_APP_ID;
+		const method = await getBundledAppInstallationMethod(
+			GITHUB_CONNECTOR_KEY,
+			"github",
+		);
+		const creds = method ? resolveAppInstallCredentials(method) : null;
+		const appId = creds?.appId;
 		if (!appId) {
 			return c.html(
 				renderOAuthErrorPage(
@@ -1505,6 +1547,13 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				// team-graph build and UI rely on, falling back to any query value.
 				metadata: {
 					...buildInstallMetadata(c),
+					// Stamp the connector-declared credential env-var names so the
+					// installation token provider mints with the right gateway vars,
+					// instead of relying on a hardcoded server default.
+					...(creds?.appIdKey ? { appIdKey: creds.appIdKey } : {}),
+					...(creds?.privateKeyKey
+						? { privateKeyKey: creds.privateKeyKey }
+						: {}),
 					account_login: ownerAccount.login,
 					account_type: ownerAccount.type,
 					...(typeof ownerAccount.id === "number"

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -45,6 +45,7 @@ import {
 	verifyWebhookSignature,
 	WEBHOOK_INGEST_MAX_BODY_BYTES,
 } from "../../connections/webhook-ingest.js";
+import { getCachedAppInstallationMethod } from "../../installation/app-install-credentials.js";
 import type { SecretStore } from "../../secrets/index.js";
 import type { AppInstallationStore } from "../../../lobu/stores/app-installation-store.js";
 import { insertEvent } from "../../../utils/insert-event.js";
@@ -692,17 +693,20 @@ export interface AppWebhookRouterDeps {
 }
 
 /**
- * Default app-webhook secret resolver: env var first
- * (`GITHUB_APP_WEBHOOK_SECRET` etc.), then a conventional secret-store ref
- * (`secret://app-webhook/<provider>`) so prod can seal it like any other
- * credential. Plaintext env wins for local/dev parity with the rest of the
- * gateway (`.env` is the single source of truth).
+ * Default app-webhook secret resolver: the connector-declared `webhookSecretKey`
+ * env var first (falling back to the `<PROVIDER>_APP_WEBHOOK_SECRET` convention
+ * for providers that don't declare an app_installation method, e.g. jira/linear),
+ * then a conventional secret-store ref (`secret://app-webhook/<provider>`) so prod
+ * can seal it like any other credential. Plaintext env wins for local/dev parity
+ * with the rest of the gateway (`.env` is the single source of truth).
  */
 export function createDefaultAppWebhookSecretResolver(
 	secretStore: SecretStore,
 ): (provider: string) => Promise<string | undefined> {
 	return async (provider) => {
-		const envName = `${provider.toUpperCase()}_APP_WEBHOOK_SECRET`;
+		const declaredKey =
+			getCachedAppInstallationMethod(provider, provider)?.webhookSecretKey;
+		const envName = declaredKey ?? `${provider.toUpperCase()}_APP_WEBHOOK_SECRET`;
 		const fromEnv = process.env[envName];
 		if (fromEnv) return fromEnv;
 		return (await secretStore.get(`secret://app-webhook/${provider}`)) ?? undefined;

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -16,6 +16,7 @@ import { authenticatePat, extractPatBearer } from "../auth/pat-auth";
 import { getDb } from "../db/client";
 import { ApiPlatform } from "../gateway/api/platform";
 import { createGatewayApp } from "../gateway/cli/gateway";
+import { primeAppInstallationMethods } from "../gateway/installation/app-install-credentials";
 import { buildGatewayConfig } from "../gateway/config/index";
 import { ChatInstanceManager } from "../gateway/connections/chat-instance-manager";
 import { ChatResponseBridge } from "../gateway/connections/chat-response-bridge";
@@ -460,6 +461,12 @@ export async function initLobuGateway(): Promise<Hono | null> {
 			{ hasWorkerGateway: !!workerGateway, hasGetApp: !!workerGateway?.getApp },
 			"[Lobu] Worker gateway check",
 		);
+		// Warm app-installation credential declarations so createGatewayApp (sync)
+		// can resolve the GitHub App id from the connector's declared appIdKey
+		// rather than a hardcoded env literal.
+		await primeAppInstallationMethods([
+			{ connectorKey: "github", provider: "github" },
+		]);
 		const rawLobuApp = createGatewayApp({
 			secretProxy: coreServices.getSecretProxy(),
 			workerGateway,


### PR DESCRIPTION
## What

Make the GitHub App install/webhook **credential env reading driven by the connector's declared `auth_schema`** instead of hardcoded `process.env.GITHUB_APP_*` literals in the server. Credential env-var *names* now live in the connector, not the gateway.

Scope: **GitHub only** (P0–P3 of the broader app-installation genericization). Slack consolidation and the webhook route-fold are intentionally deferred — folding `/slack/events` into the generic router would break the live BYO Slack bot (prod Slack is an `agent_connections` row; the generic router resolves only via `app_installations`), so that needs the fallback-chain port + its own e2e.

## Changes
- **connector-sdk**: `ConnectorAuthAppInstallation` gains `appSlugKey`, `clientIdKey`, `clientSecretKey`, `webhookSecretKey`.
- **github connector**: declares `GITHUB_APP_SLUG` / `GITHUB_APP_CLIENT_ID` / `GITHUB_APP_CLIENT_SECRET` / `GITHUB_APP_WEBHOOK_SECRET` on its `app_installation` method.
- **new `app-install-credentials.ts`**: resolver reads each declared env-var name from the bundled connector (single source of truth) + a primed sync cache so the synchronous gateway wiring resolves without going async.
- **app-install.ts**: install route, recovery, callback, ownership check, install-row metadata stamping, and token-mint fallback all read via the resolver; install URL built from `installUrlTemplate`. No `GITHUB_*` literal remains.
- **gateway.ts**: GitHub app-webhook provider registration reads the App id from the declaration (primed at boot); webhook-secret resolver prefers the declared `webhookSecretKey`, keeping the `<PROVIDER>_APP_WEBHOOK_SECRET` convention for jira/linear.

## Safety
Behavior-preserving — github declares the exact env names prod already sets (verified against the live pod env). Multi-replica safe (resolver is a pure per-pod env read).

## Tests
- New resolver unit tests (6 pass).
- `app-installation-e2e.test.ts` (11 pass) — exercises link + token mint + webhook routing through the changed paths against embedded PG.
- `app-webhooks.test.ts` (26 pass).
- `make review` covers the full integration suite.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784909207&installation_id=136316292&pr_number=1550&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1550&signature=e3811109ec0d0e26387995aa49bd1da5241dcfe6a3c33296974e32ca16ccb06e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->