### PR TITLE
refactor(gateway): relocate generic resolveInstallOrgId, delete slack.ts

### DIFF
--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -37,7 +37,7 @@ import {
   type BundledIntegrationConnector,
   resolveAppInstallCredentials,
 } from "../installation/app-install-credentials.js";
-import { resolveInstallOrgId } from "../routes/public/slack.js";
+import { resolveInstallOrgId } from "../routes/public/install-org.js";
 import { createAgentConfigRoutes } from "../routes/public/agent-config.js";
 import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
 import { createAgentRoutes } from "../routes/public/agents.js";

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -1059,7 +1059,7 @@ export class ChatInstanceManager {
     // can receive any connection's webhook (the LB sprays platform deliveries
     // across pods), so the instance is treated as a memo of the
     // `agent_connections` row: fresh memo → serve, stale/missing → re-hydrate
-    // from the row, gone/stopped row → 404. The coordinator's `/slack/events`
+    // from the row, gone/stopped row → 404. The coordinator's `/api/v1/app-webhooks/slack`
     // pre-call goes through the same check and stays harmless. Mirrors
     // `postMessageToChannel`.
     const running = await this.ensureConnectionRunning(connectionId);
@@ -1202,7 +1202,7 @@ export class ChatInstanceManager {
     // by AsyncLocalStorage org context (see #516). Some callers reach
     // here with org context already bound (HTTP routes via agent-routes
     // middleware); others don't (boot-time initialize(), the public
-    // /slack/events webhook, anywhere ensureConnectionRunning() is
+    // /api/v1/app-webhooks/slack webhook, anywhere ensureConnectionRunning() is
     // triggered without an HTTP request). Always rebind to the
     // connection's owning org id so the per-tenant secret-store query
     // hits the right bucket — including when a caller's org happens to

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -131,7 +131,7 @@ export class SlackConnectionCoordinator {
    * yet still carries that org's bot token). Forwarding an unmatched-team
    * webhook to any tenant-owned row would let one tenant's bot act on (and
    * reply with its own bot token to) another tenant's Slack traffic.
-   * `listSlackConnections()` is platform-scoped only (the public `/slack/events`
+   * `listSlackConnections()` is platform-scoped only (the public `/api/v1/app-webhooks/slack`
    * route carries no org context, so the store's per-tenant predicate doesn't
    * apply) — so we must require the explicit preview marker and otherwise fail
    * closed (return null → handled-by-OAuth-fallback / 503) rather than pick a

--- a/packages/server/src/gateway/routes/public/install-org.ts
+++ b/packages/server/src/gateway/routes/public/install-org.ts
@@ -2,7 +2,7 @@ import { createLogger } from "@lobu/core";
 import type { Context } from "hono";
 import { getDb } from "../../../db/client.js";
 
-const logger = createLogger("slack-routes");
+const logger = createLogger("install-org");
 
 /**
  * Resolve the active organization id for the current request.
@@ -69,17 +69,12 @@ async function resolveSingleTenantOrgId(): Promise<string | null> {
  * Resolve the install-flow org for the current request: session-bound first,
  * then the self-host single-tenant fallback. Returns `null` only when
  * neither path yields a definite org — at which point the route must reject.
+ *
+ * Shared by every app-installation flow (the generic install engine in
+ * `app-install.ts`), so it lives here rather than in any one provider's module.
  */
 export async function resolveInstallOrgId(c: Context): Promise<string | null> {
   const sessionOrgId = readSessionOrgId(c);
   if (sessionOrgId) return sessionOrgId;
   return resolveSingleTenantOrgId();
 }
-
-// The Slack event-webhook route (`POST /slack/events`) has been folded into the
-// generic app-webhook endpoint `POST /api/v1/app-webhooks/slack` — see the
-// declared Slack provider in `app-webhooks.ts`. The OAuth install routes
-// (`/slack/install`, `/slack/oauth_callback`) are now mounted by the generic
-// `createInstallRoutes` engine (`app-install.ts`) from the connector's
-// `installShape: 'oauth-code-exchange'` declaration — no Slack-specific router.
-// This module now only exports the shared `resolveInstallOrgId` helper.

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -24,7 +24,7 @@ import { orgContext } from "./org-context.js";
  *     serve as it, and re-keying provisioned secrets would be destructive);
  *   - the Slack tenant tuple mapping (provider=slack, instance/app='cloud',
  *     external_tenant_id=team_id — Slack routing keys on team_id alone, the
- *     `/slack/events` endpoint carries no org context);
+ *     `/api/v1/app-webhooks/slack` endpoint carries no org context);
  *   - the bot token, persisted to the secret store by ref (never plaintext in
  *     the row); the ref is carried in `metadata.config.botToken`.
  *
@@ -249,7 +249,7 @@ export async function getSlackInstallById(
 }
 
 /**
- * Resolve the ACTIVE install for a team across orgs — the public `/slack/events`
+ * Resolve the ACTIVE install for a team across orgs — the public `/api/v1/app-webhooks/slack`
  * route carries no org context, so routing keys on team_id alone. Returns null
  * when no active install owns the team (a stopped/transferred workspace), which
  * is exactly what the coordinator wants: it then falls through to the OAuth /


### PR DESCRIPTION
Small consolidation follow-up to #1553.

- Move `resolveInstallOrgId` (generic install-flow org resolver, nothing Slack-specific) from `routes/public/slack.ts` → `routes/public/install-org.ts`; **delete `slack.ts`** — the last Slack-named route module.
- Update the single importer (gateway.ts).
- Fix stale comments still referencing the removed `/slack/events` (now `/api/v1/app-webhooks/slack`).

Note: the declared `oauth-code-exchange` `tokenUrl` stays informational for Slack — its code→token exchange runs inside the `@chat-adapter/slack` adapter, which owns Slack's OAuth URL. `tokenUrl` would only drive a future non-adapter oauth-code-exchange app.

Verified: tsc 0; slack-routes + app-webhooks + chat-mgr 57/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784925344&installation_id=136316292&pr_number=1555&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1555&signature=0e5ebbc7d9806427e34454a162e4b12e0febcfea91a3b0fd0ee1278a48bfe8e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->