### PR TITLE
chore(db): drop dead watcher_versions inline render/extraction columns

### DIFF
--- a/db/migrations/20260624030000_drop_watcher_inline_render_columns.sql
+++ b/db/migrations/20260624030000_drop_watcher_inline_render_columns.sql
@@ -1,0 +1,26 @@
+-- migrate:up
+
+-- Contract phase of the watcher inline-render removal.
+--
+-- The columns were made dead in the prior release (lobu#1533, "consolidate
+-- render+schema derivation onto entity types"): render and the extraction schema
+-- now derive from the target entity type, and no code across server, cli, or the
+-- owletto frontend reads or writes watcher_versions.json_template /
+-- .extraction_schema anymore. They are NOT in the query_sql table-schema allowlist
+-- (packages/server/src/utils/table-schema.ts) — already removed there in #1533 —
+-- so no scoped CTE emits them.
+--
+-- MUST ship in a release AFTER #1533 is fully deployed: until every replica runs
+-- the expand-phase code, an old pod's worker-poll query still SELECTs
+-- extraction_schema, and dropping it mid-rollout would break that path. Once #1533
+-- is live, no running replica references either column, so the drop is safe under
+-- a rolling upgrade. DROP COLUMN is an O(1) catalog flip under a brief ACCESS
+-- EXCLUSIVE lock — no table rewrite for these jsonb types.
+
+ALTER TABLE public.watcher_versions DROP COLUMN IF EXISTS extraction_schema;
+ALTER TABLE public.watcher_versions DROP COLUMN IF EXISTS json_template;
+
+-- migrate:down
+
+ALTER TABLE public.watcher_versions ADD COLUMN IF NOT EXISTS extraction_schema jsonb;
+ALTER TABLE public.watcher_versions ADD COLUMN IF NOT EXISTS json_template jsonb;

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -131,11 +131,6 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
     oauth_tokens: new Set(['token_hash']),
     feeds: new Set(['checkpoint']),
     user: new Set(['email', 'phoneNumber', 'phoneNumberVerified']),
-    // Two-phase removal in progress: watcher inline json_template and
-    // extraction_schema were dropped from QUERYABLE_SCHEMA (rendering is the
-    // type's job; the contract is derived/reaction-owned), but the DROP COLUMN
-    // is deferred to a contract release. Omit until the column is gone.
-    watcher_versions: new Set(['json_template', 'extraction_schema']),
   };
 
   it('should have every DB column listed in the schema (or intentionally omitted)', async (ctx) => {


### PR DESCRIPTION
Contract phase (two-phase removal) of #1533.

#1533 stopped all reads of \`watcher_versions.json_template\` and \`.extraction_schema\`: render and the extraction schema now derive from the target entity type (one shared resolver each, reused across watcher-window / entity-detail / event surfaces), and reactions own their input contract via \`reaction_input_schema\`. Those two columns are now dead.

This PR drops them and removes them from the table-schema drift allowlist's \`INTENTIONALLY_OMITTED\`.

## ⚠️ Merge ordering (deploy safety)
**Do not merge/ship this until #1533 is fully deployed to prod.** During #1533's own rollout, old replicas still run the expand-phase-predecessor code whose worker-poll query \`SELECT … wv.extraction_schema\`. If this DROP runs in the same release, those old pods break for the rollout window. Once #1533 is live on every replica, no running code references either column, so the drop is safe under a rolling upgrade. (Same pattern + rationale as #1531's \`drop_workspace_agent_columns\`.)

## Validation
- \`DROP COLUMN IF EXISTS\` applied to a real DB: both columns gone, idempotent on re-run.
- Confirmed no remaining readers in server/cli (grep, non-test).
- `O(1)` catalog flip under a brief ACCESS EXCLUSIVE lock — no table rewrite for jsonb.
- Drift test (`table-schema.test.ts`) updated to match; CI `migrations` (squawk) + `integration` gates verify against a fully-migrated DB.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784926042&installation_id=136316292&pr_number=1556&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1556&signature=ffee670bd0e5d0cef1ff46b1ba0389a9721282df3a6746c58c8f8e3be5466fe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->