### PR TITLE
feat(server): allow file-only messages + harden attachment transcript refs

### DIFF
--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { ConversationStateStore } from "../connections/conversation-state-store.js";
 import {
+  buildAttachmentTranscriptText,
   type InboundAttachmentLike,
   ingestInboundAttachments,
   isSenderAllowed,
@@ -14,6 +15,67 @@ import {
   createArtifactTestEnv,
   TEST_GATEWAY_URL,
 } from "./setup.js";
+
+describe("buildAttachmentTranscriptText", () => {
+  const file = (id: string, name: string, mimetype: string) => ({
+    id,
+    name,
+    mimetype,
+    size: 1,
+    downloadUrl: `http://gw/api/v1/files/${id}?token=x`,
+  });
+
+  test("appends a tokenless ref for a non-image file", () => {
+    expect(
+      buildAttachmentTranscriptText("see attached", [
+        file("abc", "report.pdf", "application/pdf"),
+      ])
+    ).toBe("see attached\n\n[report.pdf](/api/v1/files/abc)");
+  });
+
+  test("supports a file-only message (empty caption)", () => {
+    expect(
+      buildAttachmentTranscriptText("", [file("xyz", "notes.txt", "text/plain")])
+    ).toBe("[notes.txt](/api/v1/files/xyz)");
+  });
+
+  test("skips images (they persist as inline transcript blocks)", () => {
+    expect(
+      buildAttachmentTranscriptText("hi", [file("img", "pic.png", "image/png")])
+    ).toBe("hi");
+  });
+
+  test("appends one ref per non-image file, images skipped", () => {
+    expect(
+      buildAttachmentTranscriptText("docs", [
+        file("a", "a.pdf", "application/pdf"),
+        file("b", "pic.jpg", "image/jpeg"),
+        file("c", "b.csv", "text/csv"),
+      ])
+    ).toBe("docs\n\n[a.pdf](/api/v1/files/a)\n[b.csv](/api/v1/files/c)");
+  });
+
+  test("sanitizes filenames that would break the [name](url) link grammar", () => {
+    // brackets/parens/newlines in the label are collapsed so the web's
+    // strip/lift regex stays reliable; the real name rides Content-Disposition.
+    const out = buildAttachmentTranscriptText("x", [
+      file("id1", "weird]name)evil[.txt", "text/plain"),
+    ]);
+    expect(out).toBe("x\n\n[weird name evil .txt](/api/v1/files/id1)");
+    // label has no unescaped link-breaking chars
+    expect(/\[[^\]]*\]\(\/api\/v1\/files\/id1\)/.test(out)).toBe(true);
+  });
+
+  test("falls back to 'file' when the name sanitizes to empty", () => {
+    expect(
+      buildAttachmentTranscriptText("", [file("id2", "()[]", "text/plain")])
+    ).toBe("[file](/api/v1/files/id2)");
+  });
+
+  test("returns the original text unchanged when there are no files", () => {
+    expect(buildAttachmentTranscriptText("just text", [])).toBe("just text");
+  });
+});
 
 describe("parsePreviewLinkCode", () => {
   test("bare code paste in a DM", () => {

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -30,12 +30,47 @@ const logger = createLogger("chat-message-bridge");
  * `downloadUrl` is a signed, time-limited public artifact URL the worker
  * can fetch over the proxy without any platform-specific auth.
  */
-interface IngestedFile {
+export interface IngestedFile {
   id: string;
   name: string;
   mimetype: string;
   size: number;
   downloadUrl: string;
+}
+
+/**
+ * Markdown-safe display label for a transcript file reference. The artifact
+ * route's `Content-Disposition` still carries the real filename on download —
+ * this only needs to be a label that can't break the `[name](url)` link
+ * grammar, so the web's strip/lift regex stays reliable for *any* uploaded
+ * filename (e.g. one containing `]`, `)`, or newlines).
+ */
+function sanitizeRefLabel(name: string): string {
+  return name.replace(/[[\]()\r\n]+/g, " ").replace(/\s+/g, " ").trim() || "file";
+}
+
+/**
+ * Append a tokenless artifact-route reference (`[name](/api/v1/files/:id)`) for
+ * each non-image attachment to the user's message text, so non-image uploads
+ * survive in the (text+image-only) pi-ai transcript and the web can lift them
+ * back into attachment chips on reload. Images are skipped — they persist as
+ * inline transcript blocks, so a ref would render a duplicate chip. The history
+ * read path re-signs these tokenless refs with a fresh download token, so the
+ * persisted transcript never embeds an expiring credential.
+ *
+ * Pure + exported for unit testing.
+ */
+export function buildAttachmentTranscriptText(
+  messageContent: string,
+  ingestedFiles: IngestedFile[]
+): string {
+  const refs = ingestedFiles
+    .filter((f) => !f.mimetype?.startsWith("image/"))
+    .map((f) => `[${sanitizeRefLabel(f.name)}](/api/v1/files/${f.id})`);
+  if (refs.length === 0) return messageContent;
+  return [messageContent, refs.join("\n")]
+    .filter((part) => part.length > 0)
+    .join("\n\n");
 }
 
 const AUDIO_MIMES_PREFIX = ["audio/"] as const;

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -28,7 +28,10 @@ import type { ExternalAuthClient } from "../../auth/external/client.js";
 import type { AgentSettingsStore } from "../../auth/settings/agent-settings-store.js";
 import type { SettingsTokenPayload } from "../../auth/settings/token-service.js";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
-import { ingestInboundAttachments } from "../../connections/message-handler-bridge.js";
+import {
+  buildAttachmentTranscriptText,
+  ingestInboundAttachments,
+} from "../../connections/message-handler-bridge.js";
 import type { ArtifactStore } from "../../files/artifact-store.js";
 import type { QueueProducer } from "../../infrastructure/queue/queue-producer.js";
 import type { PlatformRegistry } from "../../platform.js";
@@ -1369,13 +1372,21 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       body = c.req.valid("json");
     }
 
-    const messageContent = body.content || body.message;
+    const rawMessageContent = body.content || body.message;
     const messageId = body.messageId || randomUUID();
     const rawEphemeralContext =
       typeof body.ephemeralContext === "string" ? body.ephemeralContext.trim() : "";
 
-    if (!messageContent || typeof messageContent !== "string") {
-      return c.json({ success: false, error: "content is required" }, 400);
+    if (rawMessageContent != null && typeof rawMessageContent !== "string") {
+      return c.json({ success: false, error: "content must be a string" }, 400);
+    }
+    // A file-only message (attachment with an empty caption) is valid — the web
+    // composer permits it. Require *some* payload: text or at least one file.
+    const messageContent =
+      typeof rawMessageContent === "string" ? rawMessageContent : "";
+    const hasInboundFiles = Array.isArray(files) && files.length > 0;
+    if (!messageContent && !hasInboundFiles) {
+      return c.json({ success: false, error: "content or files required" }, 400);
     }
 
     const platform = body.platform as string | undefined;
@@ -1535,24 +1546,15 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
           ).files
         : [];
 
-      // Persist each attachment as a tokenless artifact-route reference appended
-      // to the user's message text. The pi-ai transcript only carries text +
-      // images, so non-image files would otherwise vanish on reload; this is the
-      // table-free durable record. The web lifts `/api/v1/files/` links back into
-      // native attachment chips, and the history read path re-signs them with a
-      // fresh download token (the tokenless form keeps the transcript portable
-      // and never embeds an expiring credential). Images already survive as
-      // inline transcript blocks, so they're skipped here to avoid a duplicate
-      // chip alongside the rendered image.
-      const persistedFileRefs = ingestedFiles
-        .filter((f) => !f.mimetype?.startsWith("image/"))
-        .map((f) => `[${f.name}](/api/v1/files/${f.id})`);
-      const messageTextForTranscript =
-        persistedFileRefs.length > 0
-          ? [messageContent, persistedFileRefs.join("\n")]
-              .filter((part) => part.length > 0)
-              .join("\n\n")
-          : messageContent;
+      // Persist non-image attachments as tokenless artifact-route references in
+      // the user's message text so they survive in the (text+image-only) pi-ai
+      // transcript and the web can lift them into chips on reload. The history
+      // read path re-signs them with a fresh download token. See
+      // `buildAttachmentTranscriptText`.
+      const messageTextForTranscript = buildAttachmentTranscriptText(
+        messageContent,
+        ingestedFiles
+      );
 
       const jobId = await queueProducer.enqueueMessage({
         userId: session.userId,


### PR DESCRIPTION
Follow-ups to the merged home-chat attachments work (#1551).

## What
- **File-only messages.** `POST /api/v1/agents/:id/messages` now accepts an attachment with an empty caption. The web composer already permits sending a file with no text, but the handler rejected it with `content is required` (400). Now: empty text **and** no files still 400s; a file with empty text goes through.
- **Hardened transcript refs.** Extracted `buildAttachmentTranscriptText` (pure + unit-tested) from the inline logic in `agent.ts`: builds the tokenless `/api/v1/files/:id` refs, skips images (they persist as inline blocks), and **sanitizes the link label** so a filename containing `]`, `)`, `[`, or newlines can't break the `[name](url)` grammar the web strips/lifts. The real filename still rides `Content-Disposition` on download.

## Why
Closes two gaps found reviewing the merged attachments feature: a plausible UX flow (drag a doc, send with no caption) returned 400, and weird filenames could break the markdown-ref strip/lift.

## Tests / verification
- 7 new unit tests for `buildAttachmentTranscriptText` (append, file-only, image-skip, multi-file, filename sanitization, empty-name fallback).
- Server `tsc` clean; existing bridge suite 39/39.
- Live: file-only send returns 200; empty + no files still 400.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784928975&installation_id=136316292&pr_number=1557&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1557&signature=66fdac410999812483358ed5109702cb075010d4f7993b41c02bbcbeb72cb7d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct messages can now be sent with files even when the message text is empty.
  * Attached files are now included in transcripts as clean, clickable references.

* **Bug Fixes**
  * Improved handling of attachment names so transcripts render correctly even with unusual characters.
  * Image attachments are no longer included in the file reference list for transcripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->