### PR TITLE
chore(providers): clarify OpenAI API vs ChatGPT subscription card labels

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -279,11 +279,11 @@
     },
     {
       "id": "openai",
-      "name": "OpenAI",
-      "description": "OpenAI Models",
+      "name": "OpenAI API",
+      "description": "OpenAI platform API. Uses your OpenAI API key (sk-...), billed per token.",
       "providers": [
         {
-          "displayName": "OpenAI",
+          "displayName": "OpenAI API",
           "iconUrl": "https://www.google.com/s2/favicons?domain=openai.com&sz=128",
           "envVarName": "OPENAI_API_KEY",
           "upstreamBaseUrl": "https://api.openai.com/v1",

--- a/packages/server/src/gateway/auth/chatgpt/chatgpt-oauth-module.ts
+++ b/packages/server/src/gateway/auth/chatgpt/chatgpt-oauth-module.ts
@@ -20,7 +20,7 @@ export class ChatGPTOAuthModule extends BaseProviderModule {
     super(
       {
         providerId: "chatgpt",
-        providerDisplayName: "ChatGPT",
+        providerDisplayName: "ChatGPT (subscription login)",
         providerIconUrl:
           "https://www.google.com/s2/favicons?domain=chatgpt.com&sz=128",
         credentialEnvVarName: "OPENAI_API_KEY",
@@ -39,7 +39,8 @@ export class ChatGPTOAuthModule extends BaseProviderModule {
         apiKeyInstructions:
           'Enter your <a href="https://platform.openai.com/api-keys" target="_blank" class="text-blue-600 underline">OpenAI API key</a>:',
         apiKeyPlaceholder: "sk-...",
-        catalogDescription: "OpenAI's ChatGPT with device code authentication",
+        catalogDescription:
+          "Sign in with your ChatGPT Plus/Pro subscription (device code). No API key; uses your subscription, not metered API billing.",
       },
       authProfilesManager
     );


### PR DESCRIPTION
Relabels the `openai` and `chatgpt` provider cards so they're not mistakable.

- **ChatGPT** -> "ChatGPT (subscription login)" + description noting device-code login, no API key, subscription billing.
- **OpenAI** -> "OpenAI API" + description noting API key (sk-...), per-token billing.

Labels and catalog descriptions only. No slug/routing/auth/model-namespace changes. Server tsc passes; no test or generated landing file references the old strings.

Refs #1563

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784938551&installation_id=136316292&pr_number=1564&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1564&signature=9f94287c066cbc43f9247e4facb0463371b69b20b55ec8f249a4ef4bfb2e22b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->