### PR TITLE
feat(slack): web-first connected-apps onboarding (server)

### DIFF
--- a/docs/plans/connected-apps-installations.md
+++ b/docs/plans/connected-apps-installations.md
@@ -1,0 +1,97 @@
+# Connected apps — generic installations surface
+
+Status: PLAN. Supersedes the Slack-specific framing in
+`slack-agent-onboarding.md`. Core insight (user): `app_installations` is
+**provider-agnostic**; "load the user's installations and let them act on one"
+is a generic feature, not a Slack panel. Slack is the first `deliveryKind:'chat'`
+specialization.
+
+## Framing
+
+- One row per `(org, provider, provider_app_id, external_tenant_id)` in
+  `app_installations` (provider ∈ github | slack | jira | …). Bot token / app
+  creds live in the secret store via `auth_profile_id`.
+- The **list** is generic. The **action** on an install specializes by the
+  connector's declared `deliveryKind`:
+  - `chat` (slack/telegram) → bind a channel/DM to an agent.
+  - `data` (github/jira) → a connection that feeds org memory (already exists).
+- The **install handshake** is already generic: `createInstallRoutes` mounts
+  `/{provider}/install` + `/{provider}/oauth_callback` per bundled connector from
+  its `authSchema` (no provider branch). So "+ Add an app" reuses declared paths.
+
+## Current state (verified)
+
+- Store speaks generically: `AppInstallationStore.listByOrg(org)` and
+  `listByProviderAndOrg(provider, org)` (`lobu/stores/app-installation-store.ts:106,127`).
+  Slack projection over it: `listSlackInstalls(org)` (`slack-installations.ts:272`).
+- `slack_installations` table is **dropped** (`db/migrations/20260623000000_*`);
+  everything is `app_installations` now.
+- **No API endpoint** exposes the install list to the UI. Two split surfaces:
+  - `$owner/sources/*` — data connectors (deliveryKind:data) as connections.
+  - `components/agents/agent-channel-platform-detail.tsx` — chat reach; hardcodes
+    a static "Add to Slack" (`managedInstallPath`) + a `/lobu link` code minter.
+    It never lists existing installs → always nags "Add to Slack" even when the
+    workspace is already connected.
+- `deliveryKind` is on the connector decl (`connectors/src/slack.ts:90` = 'chat').
+- `/lobu link` code is **not needed** for an installed workspace: with the bot
+  token we open the DM (`conversations.open`) and list/join channels directly.
+  Link survives only as the install-less hosted-preview / no-Slack-identity
+  fallback.
+
+## Generic model to build
+
+1. **Generic list endpoint** — `GET /api/{org}/installations?provider=&deliveryKind=`
+   → `listByOrg(org)` joined with connector metadata (provider, deliveryKind,
+   display name, install path). Returns `[{ provider, tenantId, tenantName,
+   status, deliveryKind }]`. Token-free (listing only).
+2. **Action dispatch by deliveryKind** (consumed per surface):
+   - chat → "pick a connected workspace → bind a DM/channel to this agent"
+     (resolve bot token from the install → `conversations.open` / `conversations.list`
+     + `conversations.join` → `POST /api/v1/agents/{id}/channels`).
+   - data → link to the existing Sources connection (no new action).
+3. **"+ Add an app"** — when no install for the wanted provider, link to the
+   declared `/{provider}/install` path (generic, already mounted).
+4. **Identity match** — since the user signed in with Slack, match their Slack
+   team (from their `account` row) to an install → "Your workspace *Acme* is
+   connected", auto-select it.
+
+## First slice (web-first chat onboarding)
+
+Replace the "always Add to Slack" reach UI with: load installs → show connected
+workspaces → pick → bind a DM (auto) or channel (picker). Add-to-Slack demoted to
+"+ Add another workspace", primary only when the list is empty. Built on the
+generic endpoint; Slack is just the first deliveryKind:chat consumer.
+
+## Event-sourcing the connect (from prior discussion)
+
+- At bind time: (a) **inline** "Connected ✓ — try asking me X" DM (immediate;
+  do NOT route through a cron watcher), and (b) append a `slack_connected` /
+  `app_connected` lifecycle **event** to the user's `$member` entity
+  (semantic_type `event`).
+- Watchers are `scheduled`/`manual` only (no event push trigger), but can DM via
+  the `notify` tool (supports bot-connection delivery + rich cards + watcher
+  attribution). So **deferred** onboarding (drip, re-engagement, "you connected
+  but set no goal") = a scheduled watcher reading those events. Editable, not
+  hardcoded.
+
+## Phasing
+
+1. **P1** — generic list endpoint + reach-UI flip (load installs, pick, bind DM)
+   + identity match. Slack first; the endpoint is provider-generic.
+2. **P2** — `conversations.list/join` channel picker (bind shared channels) +
+   inline welcome DM + the `app_connected` lifecycle event.
+3. **P3** — starter onboarding watcher (scheduled) reading the events → `notify`.
+4. **P4** (optional) — unify Sources (data) on the same generic list primitive;
+   org-level "Connected apps" page spanning all providers.
+
+## Open decisions
+
+- **Surface**: build an org-level "Connected apps" page now (all providers), or
+  just consume the generic endpoint inside the existing per-surface UIs
+  (agent-channels for chat, Sources for data) for now? (Lean: endpoint now,
+  consume in agent-channels first; org-level page = P4.)
+- **v1 action scope**: chat-bind only (slack/telegram), data installs shown
+  read-only linking to Sources?
+- **Bind granularity v1**: DM-only auto-bind (one click) vs DM + channel picker.
+- **Stacking**: build on #1562 (Sign-in-with-Slack) before it merges, or wait for
+  merge to avoid a stacked branch?

--- a/docs/plans/slack-agent-onboarding.md
+++ b/docs/plans/slack-agent-onboarding.md
@@ -1,0 +1,152 @@
+# Slack agent onboarding — "set up an agent for your DM/channel"
+
+Status: PLAN (not started). Goal: let both technical and non-technical Slack
+users connect an agent to their DM/channel properly, beyond the CLI-only
+`/lobu link <code>` path. Inspired by Anthropic's "Claude Tag" model.
+
+## Background facts (verified this session)
+
+- **The link code already works in any workspace the bot is in (hosted OR
+  OAuth-installed).** `consumePreviewClaim` (`packages/server/src/preview/slack.ts:263`)
+  binds whatever `team`/`channel` the `/lobu link` ran in; the claim payload
+  (`ClaimPayload`, slack.ts:54) encodes only `{organizationId, agentId,
+  allowedSurfaces, createdBy}` — **no workspace restriction**. The "Join the
+  hosted Lobu slack workspace" copy is misleading default text → fix it.
+- **`app_home_opened` carries no `team_id`** (the adapter event is
+  `{adapter, channelId, userId}`), and the Slack adapter exposes no team getter.
+  BUT **interactive action payloads DO include `team.id` + `user.id`**. → Any
+  flow that needs the workspace id must hang off a *button click*, not passive
+  render.
+- **Don't mint tokens at render.** Slack caches the published App Home view, so a
+  single-use token baked into a button URL goes stale (expired/used by click
+  time) and write-amplifies (a DB row per passive open). → Mint **on-demand** in
+  the action handler.
+- Bind primitive: `upsertBinding(tx, platform, channelId, teamId, agentId,
+  organizationId)` (slack.ts:222). Identity: `chat_user_identities`
+  (`resolveChatUserIdentity` slack.ts:503). Claims live in `oauth_states`
+  (scope `slack-preview-claim`, one-time DELETE-on-consume, TTL). Web mint
+  endpoint exists: `POST /api/:orgSlug/preview/claims` → `createPreviewClaim`.
+- OAuth install primitive shipped: `slack_installations` / `app_installations`
+  (one-click "Add to Slack", org+team keyed) — see memory
+  `project_slack_oauth_installs_shipped`. Currently **0 installs** in prod.
+
+## Inspiration: how Anthropic does it ("Claude Tag", shipped 2026-06-23)
+
+Claude Tag *replaced* per-user Claude-in-Slack because per-user OAuth caused
+1-hour tokens w/ no refresh, refresh-race invalidation, multi-replica stale
+caches, and hard 401s — **the same failure modes Lobu has hit**. New model:
+
+1. **Install + admin-provision = auth.** Org admin provisions a service account
+   once, designates channels; users just `@mention` — no per-user OAuth.
+2. **App Home = setup + status hub** (unlinked → "connect" CTA; linked → agent
+   name + health + reconnect).
+3. **Graceful expiry**: proactive refresh + a "reconnect" affordance, never a
+   silent 401.
+4. **Two tiers**: org/service-account agents (instant, org-billed) + optional
+   personal agents (one connect, user-scoped).
+
+Sources: support.claude.com "Claude Tag", "Claude in Slack", "Connectors";
+code.claude.com/docs/en/slack.
+
+## Design — two onboarding tiers
+
+### Tier 1 — Org / installed workspace (Claude-Tag-style, lowest friction)
+
+For workspaces that install Lobu (OAuth → `slack_installations`):
+- Admin provisions/links an org agent + designates channels (web dashboard).
+- Users `@mention` / DM → works. The **install is the auth**; no per-user code.
+- App Home shows: connected org + agent + health; admin-only reconfigure.
+- This is the strategic direction. Most of the primitive exists
+  (`slack_installations`); the gap is the admin "provision + designate channels"
+  UX and routing default-binding.
+
+### Tier 2 — Personal / per-DM bind (the "Set up your agent" button)
+
+For individuals (hosted preview, or personal use in an installed workspace).
+Replaces the misleading root link. **On-demand, signed-context, web-confirmed.**
+
+Flow:
+1. App Home shows an interactive button **"Set up your agent"** (`action_id`,
+   NOT a pre-baked URL).
+2. Click → our `onAction` handler fires. Payload gives `team.id`, `user.id`;
+   channel is the user's DM. Handler **mints a fresh context claim** in
+   `oauth_states` (new scope `slack-connect-context`, payload
+   `{platform, teamId, channelId, slackUserId}`, ~15 min TTL, one-time) and a
+   short human code (paste fallback). Delivers BOTH via an ephemeral message /
+   DM: a clickable link `…/slack/connect?t=<token>` + "or paste `K7QF-93` at
+   app.lobu.ai/connect".
+3. User opens link → **web login** (existing auth) → `/slack/connect` page:
+   "Connect *your DM in <workspace>* to:" + agent picker + "Create an agent
+   (Builder)".
+4. Confirm → `POST /api/.../slack/connect`: verify+consume claim (one-time) →
+   `upsertBinding(platform, channelId, teamId, agentId, org)` → record
+   `chat_user_identities(slackUserId → lobuUserId)` → respond.
+5. Bot DMs the channel: "Linked. I'll reply here now."
+
+Paste fallback: `/connect` page accepts the human code → same claim lookup.
+
+### Security model (why this is safe)
+
+- team/channel are **not secrets** → fine in a URL.
+- The real risk is an **unauthenticated bind** (stranger pointing someone's DM at
+  their agent). Gated by: (a) the claim is a **context-authentication** token
+  (signed/stored, one-time, short TTL) that proves the team/channel/slackUser
+  came from a real Slack action — NOT a capability token that auto-binds; (b) the
+  bind requires **web login**; (c) the user explicitly picks the agent and
+  confirms. Visiting the URL does nothing by itself.
+- Bind authorization: the claim binds `claim.slackUserId`'s DM only; for channel
+  binds, require the web user to be a workspace member / channel-authorized
+  (reuse `bindChatToAgentForOwner` org-membership checks).
+
+## Secondary fixes (bundled or fast-follow)
+
+- **Copy**: update the `/lobu link` mint message (CLI + web) — it works in
+  installed workspaces too, not just hosted. (slack.ts link-help strings.)
+- **App Home states** (Claude-Tag idea): unlinked → setup button; linked → "Connected to <agent>" + health + reconnect. Needs per-user linked-status (we
+  already resolve `chat_user_identities`).
+- **Notifications team-scoping (pi blocker on PR #1546)**: passive home-open lacks
+  `team_id`, so per-user notifications can't be safely team-scoped on render.
+  Options: (a) drop notifications from passive home; surface them only after a
+  button-click flow that yields team; (b) lean on Tier-1 install identity. Decide
+  alongside this work — do NOT ship the unscoped lookup.
+- **Graceful expiry**: on credential expiry, DM a "reconnect" button instead of
+  silent failure (mirrors Claude Tag; we've hit the 2h WORKER_TOKEN issue).
+
+## Testing in Slack sandbox workspaces
+
+1. Create a free Slack **dev/sandbox workspace** (or two, to test cross-workspace
+   isolation + the notifications team-scoping concern).
+2. Install the Lobu app there via "Add to Slack" (exercises `slack_installations`,
+   currently 0 in prod — validates the install path end to end).
+3. Tier 2: open App Home → click "Set up your agent" → verify fresh link+code,
+   web login, pick/create agent, confirm, bot DM confirmation. Re-click → fresh
+   token (no stale reuse). Test paste-code fallback.
+4. Verify `/lobu link <code>` works in the **installed** sandbox (confirms the
+   "works in installed workspaces" claim live).
+5. Two-workspace test: same Slack user-id space can't cross-read notifications
+   (validates team-scoping decision).
+6. Tier 1: provision an org agent + designate a channel; `@mention` → works with
+   no per-user step.
+
+## Phased implementation (suggested PRs)
+
+1. **P1 — copy + App Home states**: fix the hosted-only link text; App Home
+   unlinked/linked states; replace the root setup button with the on-demand
+   action button (mint fresh claim on click, deliver link+code). Resolve the
+   notifications team-scoping (gate or drop on passive render).
+2. **P2 — web connect flow**: `/slack/connect` owletto page + `POST
+   /api/.../slack/connect` consume endpoint (verify claim, bind, record identity,
+   bot DM confirm) + the `/connect` paste page. Reuse `upsertBinding` +
+   `oauth_states`.
+3. **P3 — Tier 1 org provisioning**: admin "provision + designate channels" UX on
+   installs; default channel→agent routing; App Home admin view.
+4. **P4 — graceful expiry / reconnect** DMs.
+
+## Open decisions
+
+- Tier-1 vs Tier-2 priority: which audience first? (Org installs = strategic, but
+  0 installs today; personal DM = the immediate ask.)
+- Notifications on the App Home: keep (needs team via button-flow) or drop until
+  Tier-1 install identity makes it clean?
+- Whether the on-demand button delivers the link via ephemeral message, DM, or a
+  Slack modal (modal is cleanest but more Block Kit surface).

--- a/packages/server/src/gateway/__tests__/channel-installations-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/channel-installations-routes.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { getDb } from "../../db/client.js";
+import { ChannelBindingService } from "../channels/binding-service.js";
+import { createPostgresAppInstallationStore } from "../../lobu/stores/app-installation-store.js";
+import { orgContext } from "../../lobu/stores/org-context.js";
+import type { SecretStore } from "../secrets/index.js";
+import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
+import { UserAgentsStore } from "../auth/user-agents-store.js";
+import { createPostgresAgentConfigStore } from "../../lobu/stores/postgres-stores.js";
+import { createChannelBindingRoutes } from "../routes/public/channels.js";
+import { setAuthProvider } from "../routes/public/settings-auth.js";
+import type { SlackWebApi } from "../connections/slack-web.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "./helpers/db-setup.js";
+
+const ORG_ID = "test-org-installs";
+const USER_ID = "user-installs-1";
+const AGENT_ID = "agent-installs-1";
+const TEAM_ID = "T_TEST_TEAM";
+const EXTERNAL_ID = "slackinst-testabc";
+const SLACK_USER_ID = "U_TEST_USER";
+const DM_CHANNEL_ID = "D_TEST_DM";
+
+// The bot token is stored PLAINTEXT (not a `secret://` ref) so resolveSecretValue
+// returns it directly and the stub secret store is never consulted.
+const BOT_TOKEN = "xoxb-test-token";
+
+const noopSecretStore: SecretStore = { get: async () => null };
+
+function makeSlackWebStub() {
+  const posted: Array<{ channel: string; text: string }> = [];
+  let openDmCalledWith: string | null = null;
+  const api: SlackWebApi = {
+    async openDm(_botToken, slackUserId) {
+      openDmCalledWith = slackUserId;
+      return DM_CHANNEL_ID;
+    },
+    async postMessage(_botToken, channel, text) {
+      posted.push({ channel, text });
+    },
+  };
+  return {
+    api,
+    posted,
+    get openDmCalledWith() {
+      return openDmCalledWith;
+    },
+  };
+}
+
+describe("channel installation routes", () => {
+  let agentMetadataStore: AgentMetadataStore;
+  let userAgentsStore: UserAgentsStore;
+  let channelBindingService: ChannelBindingService;
+
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  });
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    agentMetadataStore = new AgentMetadataStore(createPostgresAgentConfigStore());
+    userAgentsStore = new UserAgentsStore();
+    channelBindingService = new ChannelBindingService();
+
+    await orgContext.run({ organizationId: ORG_ID }, async () => {
+      await seedAgentRow(AGENT_ID, {
+        organizationId: ORG_ID,
+        name: "Installs Agent",
+        ownerPlatform: "external",
+        ownerUserId: USER_ID,
+      });
+      await userAgentsStore.addAgent("external", USER_ID, AGENT_ID);
+
+      // A connected Slack workspace for this org.
+      await createPostgresAppInstallationStore().upsert({
+        organizationId: ORG_ID,
+        provider: "slack",
+        providerInstance: "cloud",
+        providerAppId: "cloud",
+        externalTenantId: TEAM_ID,
+        status: "active",
+        metadata: {
+          external_id: EXTERNAL_ID,
+          team_name: "Test Workspace",
+          config: { platform: "slack", botToken: BOT_TOKEN },
+        },
+      });
+
+      // The caller's user + its linked "Sign in with Slack" account.
+      await getDb()`
+        INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt", principal_kind)
+        VALUES (${USER_ID}, ${"Test User"}, ${"test@example.com"}, ${false}, now(), now(), ${"human"})
+        ON CONFLICT (id) DO NOTHING
+      `;
+      await getDb()`
+        INSERT INTO account (id, "accountId", "providerId", "userId", "createdAt", "updatedAt")
+        VALUES (${"acct-1"}, ${SLACK_USER_ID}, ${"slack"}, ${USER_ID}, now(), now())
+      `;
+    });
+  });
+
+  afterEach(() => {
+    setAuthProvider(null);
+  });
+
+  function createApp(slackWeb: SlackWebApi) {
+    const app = new Hono();
+    app.route(
+      "/api/v1/agents/:agentId/channels",
+      createChannelBindingRoutes({
+        channelBindingService,
+        userAgentsStore,
+        agentMetadataStore,
+        appInstallationStore: createPostgresAppInstallationStore(),
+        secretStore: noopSecretStore,
+        slackWeb,
+      })
+    );
+    return app;
+  }
+
+  function authAs(userId: string) {
+    setAuthProvider(() => ({
+      userId,
+      platform: "external",
+      exp: Date.now() + 60_000,
+    }));
+  }
+
+  test("GET /installations lists the org's connected workspaces", async () => {
+    authAs(USER_ID);
+    const stub = makeSlackWebStub();
+    const res = await orgContext.run({ organizationId: ORG_ID }, () =>
+      createApp(stub.api).request(
+        `/api/v1/agents/${AGENT_ID}/channels/installations?provider=slack`,
+        { method: "GET", headers: { host: "localhost" } }
+      )
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      installations: Array<Record<string, unknown>>;
+    };
+    expect(body.installations).toHaveLength(1);
+    const install = body.installations[0]!;
+    expect(install.provider).toBe("slack");
+    expect(install.externalId).toBe(EXTERNAL_ID);
+    expect(install.tenantId).toBe(TEAM_ID);
+    expect(install.tenantName).toBe("Test Workspace");
+    expect(install.status).toBe("active");
+  });
+
+  test("GET /installations rejects a session that does not own the agent", async () => {
+    authAs("intruder");
+    const stub = makeSlackWebStub();
+    const res = await orgContext.run({ organizationId: ORG_ID }, () =>
+      createApp(stub.api).request(
+        `/api/v1/agents/${AGENT_ID}/channels/installations`,
+        { method: "GET", headers: { host: "localhost" } }
+      )
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("POST connect-dm opens a DM, binds it, and welcomes the user", async () => {
+    authAs(USER_ID);
+    const stub = makeSlackWebStub();
+    const res = await orgContext.run({ organizationId: ORG_ID }, () =>
+      createApp(stub.api).request(
+        `/api/v1/agents/${AGENT_ID}/channels/installations/${EXTERNAL_ID}/connect-dm`,
+        { method: "POST", headers: { host: "localhost" } }
+      )
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.success).toBe(true);
+    expect(body.channelId).toBe(DM_CHANNEL_ID);
+    expect(body.teamId).toBe(TEAM_ID);
+
+    // The DM was opened with the caller's linked Slack identity.
+    expect(stub.openDmCalledWith).toBe(SLACK_USER_ID);
+
+    // A binding row now routes the DM channel to this agent.
+    const bindings = await orgContext.run({ organizationId: ORG_ID }, () =>
+      channelBindingService.listBindings(AGENT_ID, ORG_ID)
+    );
+    expect(bindings).toHaveLength(1);
+    expect(bindings[0]!.platform).toBe("slack");
+    expect(bindings[0]!.channelId).toBe(DM_CHANNEL_ID);
+    expect(bindings[0]!.teamId).toBe(TEAM_ID);
+
+    // And the welcome DM was posted to that channel.
+    expect(stub.posted).toHaveLength(1);
+    expect(stub.posted[0]!.channel).toBe(DM_CHANNEL_ID);
+  });
+
+  test("POST connect-dm 404s for an external id outside the caller's org", async () => {
+    authAs(USER_ID);
+    const stub = makeSlackWebStub();
+    const res = await orgContext.run({ organizationId: ORG_ID }, () =>
+      createApp(stub.api).request(
+        `/api/v1/agents/${AGENT_ID}/channels/installations/slackinst-nope/connect-dm`,
+        { method: "POST", headers: { host: "localhost" } }
+      )
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/server/src/gateway/__tests__/channel-installations-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/channel-installations-routes.test.ts
@@ -9,6 +9,7 @@ import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
 import { UserAgentsStore } from "../auth/user-agents-store.js";
 import { createPostgresAgentConfigStore } from "../../lobu/stores/postgres-stores.js";
 import { createChannelBindingRoutes } from "../routes/public/channels.js";
+import { listCatalogConnectorDefinitions } from "../../utils/connector-catalog.js";
 import { setAuthProvider } from "../routes/public/settings-auth.js";
 import type { SlackWebApi } from "../connections/slack-web.js";
 import {
@@ -35,11 +36,13 @@ function makeSlackWebStub() {
   const posted: Array<{ channel: string; text: string }> = [];
   let openDmCalledWith: string | null = null;
   const api: SlackWebApi = {
-    async openDm(_botToken, slackUserId) {
+    async openDm(botToken, slackUserId) {
+      expect(botToken).toBe(BOT_TOKEN);
       openDmCalledWith = slackUserId;
       return DM_CHANNEL_ID;
     },
-    async postMessage(_botToken, channel, text) {
+    async postMessage(botToken, channel, text) {
+      expect(botToken).toBe(BOT_TOKEN);
       posted.push({ channel, text });
     },
   };
@@ -59,7 +62,13 @@ describe("channel installation routes", () => {
 
   beforeAll(async () => {
     await ensureDbForGatewayTests();
-  });
+    // Warm the connector catalog: GET /installations joins connector metadata via
+    // listCatalogConnectorDefinitions, which cold-compiles the bundled connectors
+    // (~5s) the first time when no prebuilt manifest exists (CI's integration job
+    // skips build:server). Warming here (cached) keeps the per-test handler call
+    // under the 5s timeout.
+    await listCatalogConnectorDefinitions();
+  }, 30_000);
 
   beforeEach(async () => {
     await resetTestDatabase();
@@ -208,5 +217,32 @@ describe("channel installation routes", () => {
       )
     );
     expect(res.status).toBe(404);
+  });
+
+  test("POST connect-dm rejects a revoked/suspended install — no DM, no binding", async () => {
+    authAs(USER_ID);
+    // Turn the connected workspace off. A revoked/suspended install must not
+    // yield a bot token or create a binding (the token may be dead and the
+    // workspace was intentionally disabled).
+    await orgContext.run({ organizationId: ORG_ID }, () =>
+      createPostgresAppInstallationStore().setStatusByExternalId(
+        "slack",
+        EXTERNAL_ID,
+        "suspended"
+      )
+    );
+    const stub = makeSlackWebStub();
+    const res = await orgContext.run({ organizationId: ORG_ID }, () =>
+      createApp(stub.api).request(
+        `/api/v1/agents/${AGENT_ID}/channels/installations/${EXTERNAL_ID}/connect-dm`,
+        { method: "POST", headers: { host: "localhost" } }
+      )
+    );
+    expect(res.status).toBe(404);
+    expect(stub.openDmCalledWith).toBeNull();
+    const bindings = await orgContext.run({ organizationId: ORG_ID }, () =>
+      channelBindingService.listBindings(AGENT_ID, ORG_ID)
+    );
+    expect(bindings).toHaveLength(0);
   });
 });

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -695,6 +695,8 @@ export function createGatewayApp(
         channelBindingService,
         userAgentsStore: coreServices.getUserAgentsStore(),
         agentMetadataStore: coreServices.getAgentMetadataStore(),
+        appInstallationStore: createPostgresAppInstallationStore(),
+        secretStore: coreServices.getSecretStore(),
       });
       app.route("/api/v1/agents/:agentId/channels", channelBindingRouter);
       logger.debug(

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -1,0 +1,68 @@
+import { createLogger } from "@lobu/core";
+
+const logger = createLogger("slack-web");
+
+/**
+ * Minimal Slack Web API surface used by the connected-apps onboarding flow:
+ * open a DM channel with a user and post a message into it.
+ *
+ * Deliberately a dependency-free `fetch` wrapper — NOT `@slack/web-api`, NOT the
+ * chat adapter. These are one-shot calls made with an INSTALLED workspace's bot
+ * token, outside any live connection (the user clicks "Connect my DM" on the web
+ * app), so spinning up the full adapter would be wasteful. Behind the
+ * {@link SlackWebApi} interface so routes can inject a stub in tests.
+ */
+export interface SlackWebApi {
+  /** `conversations.open` with a single user → the IM channel id (`D…`). */
+  openDm(botToken: string, slackUserId: string): Promise<string>;
+  /** `chat.postMessage` of a plain-text body. Throws on a Slack-level error. */
+  postMessage(botToken: string, channel: string, text: string): Promise<void>;
+}
+
+async function slackPost(
+  botToken: string,
+  method: string,
+  body: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`https://slack.com/api/${method}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${botToken}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as Record<string, unknown>;
+  if (json.ok !== true) {
+    throw new Error(`Slack ${method} failed: ${String(json.error ?? res.status)}`);
+  }
+  return json;
+}
+
+export function createSlackWebApi(): SlackWebApi {
+  return {
+    async openDm(botToken, slackUserId) {
+      const json = await slackPost(botToken, "conversations.open", {
+        users: slackUserId,
+      });
+      const channel = json.channel as { id?: string } | undefined;
+      const channelId = channel?.id;
+      if (typeof channelId !== "string" || !channelId) {
+        throw new Error("Slack conversations.open returned no channel id");
+      }
+      return channelId;
+    },
+    async postMessage(botToken, channel, text) {
+      try {
+        await slackPost(botToken, "chat.postMessage", { channel, text });
+      } catch (error) {
+        // The welcome message is best-effort; the binding is the contract.
+        logger.warn(
+          { channel, error: String(error) },
+          "Slack chat.postMessage failed"
+        );
+        throw error;
+      }
+    },
+  };
+}

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -1892,13 +1892,34 @@ function mountOAuthCodeExchangeRoutes(
 				consumed.redirectUri,
 				oauthState.organizationId,
 			);
+			// Redirect back into the Lobu web app so the user can wire an agent in
+			// one click — the agents list surfaces the now-connected workspace with
+			// a "Connect my DM" action, replacing the legacy "run /lobu link <code>"
+			// page. Falls back to the success page when the web origin or org slug
+			// can't be resolved (e.g. a headless/self-host install with no slug).
+			const webBase = params.getPublicGatewayUrl?.()?.replace(/\/+$/, "");
+			let orgSlug: string | null = null;
+			try {
+				const rows = (await getDb()`
+					SELECT slug FROM organization WHERE id = ${oauthState.organizationId} LIMIT 1
+				`) as Array<{ slug: string }>;
+				orgSlug = rows[0]?.slug ?? null;
+			} catch {
+				orgSlug = null;
+			}
+			if (webBase && orgSlug) {
+				return c.redirect(
+					`${webBase}/${orgSlug}/agents?connected=${encodeURIComponent(provider)}`,
+					302,
+				);
+			}
 			return c.html(
 				renderOAuthSuccessPage(result.teamName || result.teamId, undefined, {
 					title: `${providerDisplayName(provider)} installed`,
 					description:
-						"Workspace connected to Lobu. In a channel, run /lobu link <code> to wire an agent:",
+						"Workspace connected to Lobu. Open an agent's Reach tab to wire your DM — no code needed.",
 					details:
-						"Get a code from an agent's Deploy tab in your Lobu dashboard.",
+						"Your connected workspace now appears under the agent's Reach tab with a one-click Connect.",
 				}),
 			);
 		} catch (error) {

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -63,6 +63,7 @@ import {
 } from "../../auth/oauth-templates.js";
 import {
 	getOrgAppInstallationMethod,
+	getPrimedBundledMethod,
 	renderAppInstallUrl,
 	resolveAppInstallCredentials,
 } from "../../installation/app-install-credentials.js";
@@ -1782,11 +1783,16 @@ function mountOAuthCodeExchangeRoutes(
 
 		// Resolve clientId + scopes from the org's connector declaration (the env
 		// var NAMES are declared; the gateway reads the values). No env literal.
-		const method = await getOrgAppInstallationMethod(
-			installOrgId,
-			connectorKey,
-			provider,
-		);
+		// Fall back to the env-primed bundled method when the org has no per-org
+		// `connector_definitions` row: the HOSTED app's credentials are the same
+		// for every tenant, so a system-key deployment must not require each org
+		// to first persist a connector row before "Add to <app>" works. This
+		// mirrors the token-exchange completion, which already reads the primed
+		// bundled method (slack-connection-coordinator).
+		const method =
+			(await getOrgAppInstallationMethod(installOrgId, connectorKey, provider)) ??
+			getPrimedBundledMethod(connectorKey, provider) ??
+			null;
 		const creds = method ? resolveAppInstallCredentials(method) : null;
 		const clientId = creds?.clientId;
 		if (!clientId) {

--- a/packages/server/src/gateway/routes/public/channels.ts
+++ b/packages/server/src/gateway/routes/public/channels.ts
@@ -371,7 +371,11 @@ export function createChannelBindingRoutes(
 
     try {
       // Resolve the install and confirm it belongs to the caller's org — never
-      // bind across tenants off a guessed external id.
+      // bind across tenants off a guessed external id. Require an ACTIVE install:
+      // `resolveByExternalId` falls back to the most-recent row when no active one
+      // exists, so a revoked/suspended workspace must not yield a bot token or a
+      // binding (the token may be dead and the workspace was intentionally turned
+      // off). Treat non-active as not-found.
       const install = await config.appInstallationStore.resolveByExternalId(
         "slack",
         externalId
@@ -379,7 +383,8 @@ export function createChannelBindingRoutes(
       if (
         !install ||
         install.provider !== "slack" ||
-        install.organizationId !== organizationId
+        install.organizationId !== organizationId ||
+        install.status !== "active"
       ) {
         return errorResponse(c, "Installation not found", 404);
       }

--- a/packages/server/src/gateway/routes/public/channels.ts
+++ b/packages/server/src/gateway/routes/public/channels.ts
@@ -13,7 +13,20 @@ import type { AgentMetadataStore } from "../../auth/agent-metadata-store.js";
 import type { SettingsTokenPayload } from "../../auth/settings/token-service.js";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
 import type { ChannelBindingService } from "../../channels/binding-service.js";
-import { createTokenVerifier } from "../shared/agent-ownership.js";
+import {
+  createSlackWebApi,
+  type SlackWebApi,
+} from "../../connections/slack-web.js";
+import { getDb } from "../../../db/client.js";
+import type { AppInstallationStore } from "../../../lobu/stores/app-installation-store.js";
+import { orgContext } from "../../../lobu/stores/org-context.js";
+import type { SecretStore } from "../../secrets/index.js";
+import { resolveSecretValue } from "../../secrets/index.js";
+import { listCatalogConnectorDefinitions } from "../../../utils/connector-catalog.js";
+import {
+  createOwnershipResolver,
+  createTokenVerifier,
+} from "../shared/agent-ownership.js";
 import { errorResponse } from "../shared/helpers.js";
 import { verifySettingsSession } from "./settings-auth.js";
 
@@ -23,6 +36,55 @@ interface ChannelBindingRoutesConfig {
   channelBindingService: ChannelBindingService;
   userAgentsStore?: UserAgentsStore;
   agentMetadataStore?: AgentMetadataStore;
+  /**
+   * Generic app-installation store. When present the router exposes
+   * `/installations` (list the agent org's connected apps) and the chat-bind
+   * actions that consume them. Optional so a runtime without installations
+   * configured simply omits the surface.
+   */
+  appInstallationStore?: AppInstallationStore;
+  /** Resolves an install's bot-token `secret://` ref to call provider APIs. */
+  secretStore?: SecretStore;
+  /** Slack Web API client (injectable for tests). Defaults to a real one. */
+  slackWeb?: SlackWebApi;
+}
+
+/** A connected app as the web UI consumes it (provider-generic). */
+interface InstallationDto {
+  /** Stable external id (e.g. Slack's `slackinst-…`); the action handle. */
+  externalId: string;
+  provider: string;
+  /** Provider tenant id (Slack team_id, GitHub installation_id, …). */
+  tenantId: string;
+  /** Human label for the tenant (workspace/account name), when known. */
+  tenantName: string | null;
+  status: string;
+  /** `chat` | `data` | null — drives which action the UI offers. */
+  deliveryKind: string | null;
+  connectorName: string;
+  faviconDomain: string | null;
+}
+
+/**
+ * Resolve the Slack user id to DM for the caller. A Slack chat settings session
+ * already IS that user (its `userId` is the Slack user id); a web/OAuth session
+ * is matched to its linked "Sign in with Slack" account (`account.accountId` =
+ * the Slack OIDC subject). Null when neither resolves — the caller has no Slack
+ * identity to open a DM with.
+ */
+async function resolveCallerSlackUserId(
+  payload: SettingsTokenPayload
+): Promise<string | null> {
+  if (payload.platform === "slack" && payload.userId) {
+    return payload.userId;
+  }
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT "accountId" FROM account
+    WHERE "providerId" = 'slack' AND "userId" = ${payload.userId}
+    LIMIT 1
+  `) as Array<{ accountId: string }>;
+  return rows[0]?.accountId ?? null;
 }
 
 /**
@@ -35,6 +97,43 @@ export function createChannelBindingRoutes(
   const router = new Hono();
 
   const verifyToken = createTokenVerifier(config);
+  const resolveOwnership = createOwnershipResolver(config);
+  const slackWeb = config.slackWeb ?? createSlackWebApi();
+
+  // Authorize the caller for `agentId` AND resolve the agent's org in one step.
+  // Unlike `authorize` (which only proves ownership), the install routes query
+  // org-scoped resources, so they need the org id from the authoritative
+  // `agent_users` mapping — not the request's ambient org context.
+  const authorizeWithOrg = async (
+    c: Context
+  ): Promise<
+    | { agentId: string; payload: SettingsTokenPayload; organizationId: string }
+    | Response
+  > => {
+    const agentId = c.req.param("agentId");
+    if (!agentId) {
+      return errorResponse(c, "Missing agentId", 400);
+    }
+    const session = await verifySettingsSession(c);
+    const result = await resolveOwnership(session, agentId);
+    if (!result.authorized || !session) {
+      return errorResponse(c, "Unauthorized", 401);
+    }
+    // Prefer the org the ownership check pinned from `agent_users` (the caller
+    // demonstrably owns the agent there). When that's absent — an admin session,
+    // which is authorized but carries no session-bound org — fall back to the
+    // agent's OWN org from its metadata. That's tenant-safe here: installations
+    // are scoped to the agent's org, not the caller's ambient context.
+    let organizationId = result.organizationId;
+    if (!organizationId && config.agentMetadataStore) {
+      const metadata = await config.agentMetadataStore.getMetadata(agentId);
+      organizationId = metadata?.organizationId ?? undefined;
+    }
+    if (!organizationId) {
+      return errorResponse(c, "Organization could not be resolved", 409);
+    }
+    return { agentId, payload: session, organizationId };
+  };
 
   const verifyAuth = async (
     c: Context,
@@ -192,6 +291,160 @@ export function createChannelBindingRoutes(
     } catch (error) {
       logger.error("Failed to delete binding", { error, agentId });
       return errorResponse(c, "Failed to delete binding", 500);
+    }
+  });
+
+  // GET /api/v1/agents/{agentId}/channels/installations?provider=slack
+  // List the agent org's connected apps (provider-generic). The UI uses this to
+  // show "your workspace X is connected" instead of always nagging "Add to App".
+  router.get("/installations", async (c) => {
+    const auth = await authorizeWithOrg(c);
+    if (auth instanceof Response) return auth;
+    const { organizationId } = auth;
+
+    if (!config.appInstallationStore) {
+      return c.json({ installations: [] satisfies InstallationDto[] });
+    }
+
+    try {
+      const providerFilter = c.req.query("provider");
+      const rows = providerFilter
+        ? await config.appInstallationStore.listByProviderAndOrg(
+            providerFilter,
+            organizationId
+          )
+        : await config.appInstallationStore.listByOrg(organizationId);
+
+      // Join connector metadata (display name, deliveryKind, favicon) so the UI
+      // can render + decide the action without hardcoding provider knowledge.
+      const defs = await listCatalogConnectorDefinitions();
+      const byKey = new Map(defs.map((d) => [d.key, d]));
+
+      const installations: InstallationDto[] = rows.map((r) => {
+        const def = byKey.get(r.provider);
+        const webhook = (def?.webhook ?? null) as {
+          deliveryKind?: string;
+        } | null;
+        const externalId =
+          typeof r.metadata.external_id === "string" && r.metadata.external_id
+            ? r.metadata.external_id
+            : String(r.id);
+        return {
+          externalId,
+          provider: r.provider,
+          tenantId: r.externalTenantId,
+          tenantName:
+            (r.metadata.team_name as string | undefined) ??
+            (r.metadata.account_login as string | undefined) ??
+            null,
+          status: r.status,
+          deliveryKind: webhook?.deliveryKind ?? null,
+          connectorName: def?.name ?? r.provider,
+          faviconDomain: def?.favicon_domain ?? null,
+        };
+      });
+
+      return c.json({ installations });
+    } catch (error) {
+      logger.error("Failed to list installations", { error });
+      return errorResponse(c, "Failed to list installations", 500);
+    }
+  });
+
+  // POST /api/v1/agents/{agentId}/channels/installations/{externalId}/connect-dm
+  // Auto-bind the caller's Slack DM (with the installed workspace's bot) to this
+  // agent — the web-first onboarding "one click connects my DM" action. Resolves
+  // the bot token from the install, opens the DM with the caller's Slack user id,
+  // creates the binding, and posts a best-effort welcome.
+  router.post("/installations/:externalId/connect-dm", async (c) => {
+    const auth = await authorizeWithOrg(c);
+    if (auth instanceof Response) return auth;
+    const { agentId, payload, organizationId } = auth;
+
+    const externalId = c.req.param("externalId");
+    if (!externalId) {
+      return errorResponse(c, "Missing externalId", 400);
+    }
+    if (!config.appInstallationStore || !config.secretStore) {
+      return errorResponse(c, "Installations not available", 503);
+    }
+
+    try {
+      // Resolve the install and confirm it belongs to the caller's org — never
+      // bind across tenants off a guessed external id.
+      const install = await config.appInstallationStore.resolveByExternalId(
+        "slack",
+        externalId
+      );
+      if (
+        !install ||
+        install.provider !== "slack" ||
+        install.organizationId !== organizationId
+      ) {
+        return errorResponse(c, "Installation not found", 404);
+      }
+
+      // Bot token lives in the secret store, scoped to the install's org.
+      const tokenRef = (
+        install.metadata.config as { botToken?: string } | undefined
+      )?.botToken;
+      const botToken = await orgContext.run({ organizationId }, () =>
+        resolveSecretValue(config.secretStore!, tokenRef)
+      );
+      if (!botToken) {
+        return errorResponse(c, "Workspace bot token unavailable", 409);
+      }
+
+      const slackUserId = await resolveCallerSlackUserId(payload);
+      if (!slackUserId) {
+        return errorResponse(
+          c,
+          "No linked Slack identity for your account. Sign in with Slack first.",
+          409
+        );
+      }
+
+      let dmChannelId: string;
+      try {
+        dmChannelId = await slackWeb.openDm(botToken, slackUserId);
+      } catch (error) {
+        logger.error("Failed to open Slack DM", {
+          error: String(error),
+          externalId,
+        });
+        return errorResponse(c, "Could not open a Slack DM with you", 502);
+      }
+
+      await config.channelBindingService.createBinding(
+        agentId,
+        "slack",
+        dmChannelId,
+        install.externalTenantId,
+        { configuredBy: payload.userId, organizationId }
+      );
+
+      // Best-effort inline welcome — the binding is the contract, not this DM.
+      void slackWeb
+        .postMessage(
+          botToken,
+          dmChannelId,
+          "✅ Connected. I'm now wired to this DM — ask me anything to get started."
+        )
+        .catch(() => {});
+
+      logger.info(
+        `Connected Slack DM ${dmChannelId} (team ${install.externalTenantId}) -> ${agentId}`
+      );
+
+      return c.json({
+        success: true,
+        platform: "slack",
+        channelId: dmChannelId,
+        teamId: install.externalTenantId,
+      });
+    } catch (error) {
+      logger.error("Failed to connect Slack DM", { error, agentId });
+      return errorResponse(c, "Failed to connect Slack DM", 500);
     }
   });
 


### PR DESCRIPTION
Web-first Slack onboarding: a user who installed the hosted Slack app can wire their DM to an agent in **one click** — no `/lobu link` code.

## What's here
- `GET /api/v1/agents/:id/channels/installations?provider=slack` — lists the org's connected workspaces, joining connector catalog metadata (name / deliveryKind / favicon). Provider-generic.
- `POST .../installations/:externalId/connect-dm` — resolves the install's bot token, opens the caller's Slack DM via their linked Sign-in-with-Slack identity (`conversations.open`), binds it to the agent, posts a welcome. Requires an **active** install (revoked/suspended → 404, no token, no binding).
- `slack-web.ts` — minimal dependency-free `conversations.open` / `chat.postMessage`.
- Install OAuth callback now **redirects back into the app** (agents list) instead of the legacy "run `/lobu link <code>`" page.
- Install start falls back to the **env-primed bundled method** when an org has no per-org `connector_definitions` row — hosted-app installs work for any org without a manual seed (matches the token-exchange completion path).

## Verification
- **Live e2e against real Slack**: Add-to-Slack install → `connect-dm` → real `conversations.open` → real DM bound to the agent + welcome posted. Confirmed via DB rows + API responses.
- **Integration tests** (real Postgres, Slack HTTP stubbed): 5 cases incl. the revoked-install regression. typecheck + unit green locally.
- Addresses the pi blocker from the earlier #1566 review (revoked/suspended installs were accepted) + its test nits (assert bot token; warm connector catalog to avoid the CI cold-compile timeout).

## Notes
- The reach-panel **UI is a separate owletto PR** (connected-workspaces list + "Connect my DM"); the submodule pointer bump follows after it merges.
- Not stacked on the genericOAuth login work — independent.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784948987&installation_id=136316292&pr_number=1568&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1568&signature=2109493bbf9d1515cb67bd23965d68ce6b9908bb32314b6f0451fb66523ebfdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generic connected-app installations listing to surface available app connections in the UI.
  * Added Slack one-click “connect DM” flow: opens a DM, creates the channel binding, and sends a welcome message.
  * Improved OAuth install completion by redirecting back into the web app when possible, with updated fallback messaging.
* **Bug Fixes**
  * Enhanced Slack onboarding/channel connection handling for missing identities, inactive installs, and DM open failures.
* **Documentation**
  * Added rollout plans for generic connected-app installations and Slack agent onboarding.
* **Tests**
  * Introduced server route coverage for installations and DM connection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->