### PR TITLE
test(server): fix stale slack oauth_callback test (web-first redirect regression from #1568)

### DIFF
--- a/packages/server/src/gateway/__tests__/slack-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-routes.test.ts
@@ -214,7 +214,7 @@ describe("slack OAuth install routes", () => {
     expect(completeSlackOAuthInstall).not.toHaveBeenCalled();
   });
 
-  test("GET /slack/oauth_callback completes install and clears state", async () => {
+  test("GET /slack/oauth_callback completes install and redirects into the web app", async () => {
     const sql = getDb();
     const expiresAt = new Date(Date.now() + 600_000);
     await sql`
@@ -234,14 +234,14 @@ describe("slack OAuth install routes", () => {
     const response = await app.request(
       "/slack/oauth_callback?code=test-code&state=test-state"
     );
-    const body = await response.text();
 
-    expect(response.status).toBe(200);
-    expect(body).toContain("Slack installed");
-    // New install-store flow: the success page points users at /lobu link
-    // instead of surfacing an agent_connections id.
-    expect(body).toContain("/lobu link");
-    expect(body).toContain("Deploy tab");
+    // Web-first onboarding: on success the callback redirects back into the
+    // Lobu web app (org's /agents list, ?connected=<provider>) so the user can
+    // wire an agent in one click — instead of the legacy success HTML page.
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://gateway.example.com/org-default/agents?connected=slack"
+    );
     expect(completeSlackOAuthInstall).toHaveBeenCalledTimes(1);
     expect(completeSlackOAuthInstall.mock.calls[0]?.[1]).toBe(
       "https://gateway.example.com/slack/oauth_callback"


### PR DESCRIPTION
## What

#1568 (`feat(slack): web-first connected-apps onboarding (server)`, merged this morning) changed the `/slack/oauth_callback` success path from rendering a **200** HTML success page to issuing a **302** redirect back into the web app (`/<orgSlug>/agents?connected=<provider>`), so the user lands on the agents list to wire their DM in one click.

It did **not** update `slack-routes.test.ts`, which still asserted the old 200 page + `"Slack installed"` / `"/lobu link"` / `"Deploy tab"` body strings. That test has failed **deterministically** on `main` ever since #1568 landed, blocking the `integration` CI gate (and therefore the release PR #1558 and every other PR).

This was initially mistaken for a flake; it is not — CI was green only on commits predating #1568.

## Fix

Update the `completes install` test to assert the new redirect contract: `302` + `Location: https://gateway.example.com/org-default/agents?connected=slack`, while keeping the existing `completeSlackOAuthInstall` call-args and state-consumed assertions.

## Reproducer (red → green)

Ran against a local Postgres, replicating the CI `bun test src/gateway/__tests__` invocation.

**Red (before fix, on `origin/main` edf0ee10e):**
```
error: expect(received).toBe(expected)
Expected: 200
Received: 302
  at slack-routes.test.ts:239
(fail) slack OAuth install routes > GET /slack/oauth_callback completes install and clears state
```
Captured the 302 `Location`: `https://gateway.example.com/org-default/agents?connected=slack` — confirming the success-redirect, not an error path.

**Green (after fix):**
```
slack-routes.test.ts:  16 pass  0 fail
full src/gateway/__tests__ dir:  1401 pass  2 skip  0 fail  (104 files)
```

Pre-commit `biome` + `tsc --noEmit` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784985418&installation_id=136316292&pr_number=1570&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1570&signature=b931f69fcb0e38ccc48916856c8478214eb510e08ad47e3f31fe953d098bd815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->