### PR TITLE
feat(server): Settings escape hatch on the extension bootstrap error card

### DIFF
--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -534,19 +534,33 @@ credentialRoutes.get('/extension-bootstrap', (c) => {
   history.replaceState(null, "", location.pathname);
   var next = worker ? "/#worker=" + encodeURIComponent(worker) : "/";
   if (!token) { location.replace("/"); return; }
+  var retried = false;
   function fail(msg) {
     // Surface a real error instead of redirecting to a token-less app, which
     // would just render signed-out and hang on a spinner — the exact failure
-    // this whole flow exists to avoid.
+    // this whole flow exists to avoid. Retry re-submits the SAME deep-link
+    // token captured in the URL fragment, so once it has failed at least once
+    // we also offer an escape hatch to the panel's Settings (change-server /
+    // re-pair) — the only path that recovers a token this page can't refresh.
     document.body.innerHTML =
       '<div style="font:14px/1.5 system-ui,sans-serif;color:#334155;padding:24px;max-width:24rem">' +
       '<p style="margin:0 0 .5rem;font-weight:600">Could not connect to your Owletto.</p>' +
       '<p style="margin:0 0 1rem;color:#64748b"></p>' +
       '<button id="owl-retry" style="font:inherit;padding:.4rem .9rem;border:1px solid #cbd5e1;border-radius:.4rem;background:#f8fafc;cursor:pointer">Retry</button>' +
+      (retried
+        ? '<button id="owl-settings" style="font:inherit;margin-left:.5rem;padding:.4rem .9rem;border:1px solid #cbd5e1;border-radius:.4rem;background:#f8fafc;cursor:pointer">Change server</button>'
+        : '') +
       '</div>';
     document.querySelectorAll("p")[1].textContent = msg;
     var b = document.getElementById("owl-retry");
-    if (b) b.onclick = attempt;
+    if (b) b.onclick = function () { retried = true; attempt(); };
+    // The bootstrap page is a cross-origin iframe inside the extension side
+    // panel and can't open Settings itself — ask the panel parent to switch to
+    // its Settings view (origin-checked on the receiving end).
+    var s = document.getElementById("owl-settings");
+    if (s) s.onclick = function () {
+      try { window.parent.postMessage({ owletto: "open-settings" }, "*"); } catch (e) {}
+    };
   }
   function attempt() {
     document.body.textContent = "Connecting\\u2026";


### PR DESCRIPTION
## Problem

A user reported the Owletto Chrome extension stuck offline (`app.lobu.ai returned 502 on poll` + "session may have expired"), and clicking **Retry** never recovered. Root cause (verified against prod): the `/api/extension-bootstrap` iframe bakes the deep-link access token into its URL fragment and **Retry re-POSTs that same frozen token**. When the SW refreshes the token in storage (poll recovers to 200), the iframe is never re-mounted with the new token, so Retry 401s forever and the user has no escape hatch — even though the panel's Settings (change-server / re-pair) would recover them. The 502 itself was a transient edge blip during a deploy; the app never returns 502.

## Change

- **`routes.ts`** (this repo): after the first failed Retry, the bootstrap error card also renders a **Change server** button that `postMessage`s the panel parent `{owletto:"open-settings"}`.
- **`sidepanel.js`** (owletto submodule, lobu-ai/owletto#369): handles that message (after the existing origin check) by switching to the Settings view.

Graceful degradation: if the deployed extension predates the handler, the message is a harmless no-op.

## Verified

Card behavior verified **live in a real browser** against a local server (`make dev`, :8965):
1. First bootstrap failure → **Retry only**, no Change server.
2. After one failed Retry → **Change server** appears.
3. Clicking it posts `{owletto:"open-settings"}` to the parent.

The sidepanel handler routes that to the existing, proven `show("permissions")`.

## Cross-repo

Owletto PR lobu-ai/owletto#369 merges first; the submodule pointer here re-points to its squash SHA before merge (drift check red until then).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784987222&installation_id=136316292&pr_number=1572&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1572&signature=313f35916bbc1ac28f681c222c18a7e2b0e13db84b7f0be310f4b6b394a0ab85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the extension bootstrap failure screen with a clearer recovery flow.
  * After a failed retry, users can now choose to change server settings from the error screen.

* **Bug Fixes**
  * Added retry-state handling so the app can distinguish between a first failure and a repeated failure, showing the right options at each step.

* **Chores**
  * Updated the bundled subproject to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->