### PR TITLE
feat(watchers): sync extracted fields into entities + human-AI field ownership loop

### DIFF
--- a/db/migrations/20260625100000_entity_field_controls.sql
+++ b/db/migrations/20260625100000_entity_field_controls.sql
@@ -1,0 +1,16 @@
+-- migrate:up
+
+-- Per-field human-ownership markers on entities, for the watcher<->human feedback
+-- loop. A key present under field_controls means that field's current value was set
+-- by a human and is authoritative: a watcher may PROPOSE a change (via an approval)
+-- but must never overwrite it directly. Stored as a column on entities (not a side
+-- table) so promotion and prompt-render read it for free with the entity row, and it
+-- is written atomically with entities.metadata under the same FOR UPDATE lock.
+--   shape: { "<field_path>": { "note": text|null, "set_by": "<userId>", "set_at": iso8601 } }
+--   absence of a key = automation may write that field freely.
+-- Constant DEFAULT '{}' is a metadata-only add on PG11+ (no table rewrite).
+ALTER TABLE public.entities
+  ADD COLUMN IF NOT EXISTS field_controls jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+-- migrate:down
+ALTER TABLE public.entities DROP COLUMN IF EXISTS field_controls;

--- a/docs/plans/watcher-entity-feedback-loop.md
+++ b/docs/plans/watcher-entity-feedback-loop.md
@@ -1,0 +1,54 @@
+# Watcher ↔ Entity sync + human–AI feedback loop
+
+## Goal
+Watchers sync extracted values **into entities** (the entity is the source of truth), and a
+human can correct an entity field; the watcher then **respects** that correction and the
+correction **steers** future runs. The human always wins; the AI proposes, the human disposes.
+
+## Validated approach (spikes on glm-5.2, live HN data)
+- Showing the human-set value in context flips respect **0% → 100%**; the model also correctly
+  **updates on genuinely new evidence** (doesn't blindly freeze).
+- Live multi-item HN: **100%** field respect, 80% compositional filter.
+- 2-round human-in-the-loop on a live week: **100%** correction respect + **100%** rule
+  generalization + clean convergence (queue tightened 8→2, self-corrected its own
+  over-generalization, held prior calls).
+- Conclusion: the prompt is the UX optimization (fewer approval cards); the **server merge is the
+  correctness backstop** (deterministic, 100%). An 80%-filter slip is card-spam, not a data bug.
+
+## Architecture (settled)
+- **Value** → `entities.metadata` (unchanged; keeps #1541's deletion of the entity_field projection).
+- **Ownership** → `entities.field_controls jsonb` **column** (NOT a side table): a key present means
+  that field's current value is human-owned. Read for free with the entity row, written atomically
+  with `metadata` under the same `FOR UPDATE` lock. Shape:
+  `{ "<field>": { "note": text|null, "set_by": userId, "set_at": iso } }`.
+  No `mode` enum — human-owned simply means *watcher proposes via approval, never writes directly*.
+- **One merge primitive** → `mergeEntityFields({source})` shared by human edits (`updateEntity`) and
+  watcher promotion. `human` writes every changed field and marks it owned; `watcher` writes only
+  un-owned fields and returns `blocked` for owned ones (the caller emits an approval).
+- **History/audit** → reuse the existing `'change'` event (append-only, entity-scoped, payload-less
+  so it stays out of search/embedding); `metadata.{applied,blocked,source}` carry per-field provenance.
+- **Conflict** → an **approval interaction on the durable runs+events plane** (copy the `manage_agents`
+  gate: pending run + `notifyActionApprovalNeeded` (no SSE dep, headless+multi-replica safe) → web
+  approve via `/mcp` → apply callback → `supersedeActionEvent`). Emitted **post-commit**, never the
+  ephemeral InteractionService plane (that has the runJobToken/connectionId routing trap).
+- **Prompt** → render the entity's current values + owned-field markers (one block from
+  `field_controls`); replaces the separate "Past Corrections" block for entity-typed watchers.
+
+## Build sequence
+1. **Data core (this slice):** `field_controls` column migration + `mergeEntityFields` primitive
+   (pure `computeFieldMerge` core + DB wrapper) + wire the human-edit path in `updateEntity` to mark
+   ownership. Unit test on the pure core.
+2. **Promotion:** `promoteKeyedEntities` calls `mergeEntityFields({source:'watcher'})` — writes
+   un-owned extracted fields, collects `blocked`, returns ids; `complete-window.ts` emits the
+   post-commit approval for blocked fields.
+3. **Approval apply:** new `manage_operations` action_key (`entity_field_change`) mirroring
+   `tryApproveManageAgentsRun` — approve writes the field + marks owned, supersedes the event.
+4. **Prompt/reaction render:** `watcher-mode.ts` + `template-renderer.ts` render metadata +
+   owned markers; reaction gets the watcher's children + blocked proposals.
+5. **Follow-ups:** owletto inline field-edit + annotation UI; device-worker entity context
+   (`poll.ts` ships zero entities today); two-tier relevance (post-now vs track/conditional).
+
+## Notes
+- Two-phase: adding a column + a free-form `'change'` semantic_type is single-phase (additive).
+- Multi-replica: `field_controls` is on the row, written under `FOR UPDATE`; the approval rides the
+  durable Postgres plane — no in-memory cross-pod state.

--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -19,6 +19,9 @@ import { inferWatcherGranularityFromSchedule } from '@lobu/connector-sdk';
 import { slugify } from '@lobu/core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { DbClient } from '../../../db/client';
+import type { Env } from '../../../index';
+import type { AuthContext } from '../../../tools/execute';
+import { executeTool } from '../../../tools/execute';
 import { createWatcherRun } from '../../../runs/queue-service';
 import { computePendingWindow } from '../../../utils/window-utils';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
@@ -52,6 +55,34 @@ const KEYED_EXTRACTED_DATA = {
     { category: 'Performance', name: 'Slow Loading' },
   ],
 };
+
+const TEST_ENV: Env = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+  JWT_SECRET: 'test-jwt-secret-for-testing-only',
+  BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
+};
+
+/** Owner web-session auth context for invoking manage_operations.approve. */
+function ownerAuthCtx(orgId: string, userId: string): AuthContext {
+  return {
+    organizationId: orgId,
+    tokenOrganizationId: orgId,
+    userId,
+    memberRole: 'owner',
+    agentId: null,
+    requestedAgentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    tokenType: 'oauth',
+    requestUrl: `http://localhost/api/${orgId}`,
+    baseUrl: '',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+    allowInternalTools: true,
+  };
+}
 
 async function setupKeyedWatcher() {
   const sql = getTestDb();
@@ -340,17 +371,124 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     expect((afterRerun.metadata as Record<string, unknown>).severity).toBe('high');
 
     // Slice 3: the blocked change is queued as a durable approval the human can act on.
-    const pending = await sql`
-      SELECT action_input FROM runs
+    const pendingRuns = async () => sql`
+      SELECT id, action_input FROM runs
       WHERE organization_id = ${workspace.org.id}
         AND run_type = 'internal'
         AND action_key = 'entity_field_change'
         AND approval_status = 'pending'
     `;
-    expect(pending.length).toBeGreaterThan(0);
+    const pending = await pendingRuns();
+    expect(pending.length).toBe(1);
     const proposal = pending[0].action_input as { entity_id: number; fields: Record<string, unknown> };
     expect(proposal.entity_id).toBe(entityId);
     expect(proposal.fields.severity).toBe('critical');
+
+    // Idempotency: replaying the SAME window again must NOT stack a second
+    // pending approval card (complete_window is replay-safe under retries/replicas).
+    await ctx.api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: token,
+      run_metadata: { watcher_run_id: runId },
+      extracted_data: {
+        problems: [
+          { category: 'Stability', name: 'App Crashes', severity: 'critical' },
+          { category: 'Performance', name: 'Slow Loading', severity: 'low' },
+        ],
+      },
+    });
+    expect((await pendingRuns()).length).toBe(1);
+
+    // Slice 3 (apply): an owner approves via manage_operations → the value lands and
+    // the field stays human-owned (now carrying the approved value).
+    const approveRes = (await executeTool(
+      'manage_operations',
+      { action: 'approve', run_id: Number(pending[0].id) },
+      TEST_ENV,
+      ownerAuthCtx(workspace.org.id, workspace.users.owner.id)
+    )) as { approved?: boolean };
+    expect(approveRes.approved).toBe(true);
+
+    const [applied] = await sql`SELECT metadata, field_controls FROM entities WHERE id = ${entityId}`;
+    expect((applied.metadata as Record<string, unknown>).severity).toBe('critical');
+    // Still owned — an approved watcher value remains human-owned, not watcher-writable.
+    expect((applied.field_controls as Record<string, unknown>).severity).toBeTruthy();
+    const [approvedRun] = await sql`SELECT status, approval_status FROM runs WHERE id = ${Number(pending[0].id)}`;
+    expect(approvedRun.status).toBe('completed');
+    expect(approvedRun.approval_status).toBe('approved');
+  });
+
+  it('approving a STALE proposal does not clobber a value the human moved after it was queued', async () => {
+    const ctx = await setupKeyedWatcher();
+    const { sql, workspace, watcherId } = ctx;
+
+    await createTestEvent({
+      entity_id: ctx.parentEntityId,
+      organization_id: workspace.org.id,
+      content: 'Users report the app crashing.',
+      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    const runId = await queueRunningRun(ctx);
+    const token = await readWindowToken(ctx);
+
+    // Run 1 seeds the entity; human then owns `severity` at 'high'.
+    await ctx.api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: token,
+      run_metadata: { watcher_run_id: runId },
+      extracted_data: {
+        problems: [
+          { category: 'Stability', name: 'App Crashes', severity: 'low' },
+          { category: 'Performance', name: 'Slow Loading', severity: 'low' },
+        ],
+      },
+    });
+    const appCrashesId = `${watcherId}::stability::app-crashes`;
+    const [created] = await sql`
+      SELECT e.id FROM entities e JOIN entity_identities ei ON ei.entity_id = e.id
+      WHERE ei.namespace = 'watcher_key' AND ei.identifier = ${appCrashesId}
+    `;
+    const entityId = Number(created.id);
+    await workspace.owner.entities.update({ entity_id: entityId, metadata: { severity: 'high' } });
+
+    // Run 2: watcher proposes 'critical' against the 'high' snapshot → pending approval.
+    await ctx.api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: token,
+      run_metadata: { watcher_run_id: runId },
+      extracted_data: {
+        problems: [
+          { category: 'Stability', name: 'App Crashes', severity: 'critical' },
+          { category: 'Performance', name: 'Slow Loading', severity: 'low' },
+        ],
+      },
+    });
+    const [pending] = await sql`
+      SELECT id, action_input FROM runs
+      WHERE organization_id = ${workspace.org.id} AND action_key = 'entity_field_change'
+        AND approval_status = 'pending'
+    `;
+    expect((pending.action_input as { current?: Record<string, unknown> }).current?.severity).toBe('high');
+
+    // The human moves severity to 'medium' AFTER the proposal was queued (proposal is now stale).
+    await workspace.owner.entities.update({ entity_id: entityId, metadata: { severity: 'medium' } });
+
+    // Approving the stale proposal must NOT overwrite the human's newer 'medium'.
+    const approveRes = (await executeTool(
+      'manage_operations',
+      { action: 'approve', run_id: Number(pending.id) },
+      TEST_ENV,
+      ownerAuthCtx(workspace.org.id, workspace.users.owner.id)
+    )) as { approved?: boolean; message?: string };
+    expect(approveRes.approved).toBe(true);
+
+    const [after] = await sql`SELECT metadata FROM entities WHERE id = ${entityId}`;
+    expect((after.metadata as Record<string, unknown>).severity).toBe('medium'); // human wins
+    // Run still resolves (terminal), it just applied nothing.
+    const [resolved] = await sql`SELECT status, approval_status FROM runs WHERE id = ${Number(pending.id)}`;
+    expect(resolved.status).toBe('completed');
+    expect(resolved.approval_status).toBe('approved');
   });
 
   it('disambiguates a slug that collides with a pre-existing sibling — window is NOT poison-pilled', async () => {

--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -277,6 +277,82 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     expect(Number(childCount[0].c)).toBe(2);
   });
 
+  it('syncs extracted fields into entities and respects a human-owned field on re-run, queuing an approval', async () => {
+    const ctx = await setupKeyedWatcher();
+    const { sql, workspace, watcherId } = ctx;
+
+    await createTestEvent({
+      entity_id: ctx.parentEntityId,
+      organization_id: workspace.org.id,
+      content: 'Users report the app crashing and loading slowly.',
+      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    const runId = await queueRunningRun(ctx);
+    const token = await readWindowToken(ctx);
+
+    // Run 1: a non-key `severity` field is synced into the promoted entity's metadata.
+    await ctx.api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: token,
+      run_metadata: { watcher_run_id: runId },
+      extracted_data: {
+        problems: [
+          { category: 'Stability', name: 'App Crashes', severity: 'low' },
+          { category: 'Performance', name: 'Slow Loading', severity: 'low' },
+        ],
+      },
+    });
+
+    const appCrashesId = `${watcherId}::stability::app-crashes`;
+    const [created] = await sql`
+      SELECT e.id, e.metadata, e.field_controls
+      FROM entities e JOIN entity_identities ei ON ei.entity_id = e.id
+      WHERE ei.namespace = 'watcher_key' AND ei.identifier = ${appCrashesId}
+    `;
+    // Slice 2 (create): the extracted field value lands in metadata, not just provenance.
+    expect((created.metadata as Record<string, unknown>).severity).toBe('low');
+    expect(created.field_controls).toEqual({});
+    const entityId = Number(created.id);
+
+    // A human takes ownership of `severity`.
+    await workspace.owner.entities.update({ entity_id: entityId, metadata: { severity: 'high' } });
+    const [edited] = await sql`SELECT metadata, field_controls FROM entities WHERE id = ${entityId}`;
+    // Slice 1: human edit applies the value AND marks the field owned.
+    expect((edited.metadata as Record<string, unknown>).severity).toBe('high');
+    expect((edited.field_controls as Record<string, unknown>).severity).toBeTruthy();
+
+    // Run 2 (replay) proposes a different severity for the SAME key.
+    await ctx.api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: token,
+      run_metadata: { watcher_run_id: runId },
+      extracted_data: {
+        problems: [
+          { category: 'Stability', name: 'App Crashes', severity: 'critical' },
+          { category: 'Performance', name: 'Slow Loading', severity: 'low' },
+        ],
+      },
+    });
+
+    // Slice 2 (match): the watcher does NOT overwrite the human-owned value.
+    const [afterRerun] = await sql`SELECT metadata FROM entities WHERE id = ${entityId}`;
+    expect((afterRerun.metadata as Record<string, unknown>).severity).toBe('high');
+
+    // Slice 3: the blocked change is queued as a durable approval the human can act on.
+    const pending = await sql`
+      SELECT action_input FROM runs
+      WHERE organization_id = ${workspace.org.id}
+        AND run_type = 'internal'
+        AND action_key = 'entity_field_change'
+        AND approval_status = 'pending'
+    `;
+    expect(pending.length).toBeGreaterThan(0);
+    const proposal = pending[0].action_input as { entity_id: number; fields: Record<string, unknown> };
+    expect(proposal.entity_id).toBe(entityId);
+    expect(proposal.fields.severity).toBe('critical');
+  });
+
   it('disambiguates a slug that collides with a pre-existing sibling — window is NOT poison-pilled', async () => {
     const ctx = await setupKeyedWatcher();
     const { sql, workspace, parentEntityId } = ctx;

--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -346,12 +346,20 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     expect(created.field_controls).toEqual({});
     const entityId = Number(created.id);
 
-    // A human takes ownership of `severity`.
-    await workspace.owner.entities.update({ entity_id: entityId, metadata: { severity: 'high' } });
+    // A human takes ownership of `severity`, attaching a correction note.
+    await workspace.owner.entities.update({
+      entity_id: entityId,
+      metadata: { severity: 'high' },
+      field_note: 'confirmed critical with eng',
+    });
     const [edited] = await sql`SELECT metadata, field_controls FROM entities WHERE id = ${entityId}`;
-    // Slice 1: human edit applies the value AND marks the field owned.
+    // Slice 1: human edit applies the value AND marks the field owned, carrying the note.
     expect((edited.metadata as Record<string, unknown>).severity).toBe('high');
-    expect((edited.field_controls as Record<string, unknown>).severity).toBeTruthy();
+    const sevControl = (edited.field_controls as Record<string, { note?: string; set_by?: string }>)
+      .severity;
+    expect(sevControl).toBeTruthy();
+    expect(sevControl.note).toBe('confirmed critical with eng');
+    expect(sevControl.set_by).toBe(workspace.users.owner.id);
 
     // Run 2 (replay) proposes a different severity for the SAME key.
     await ctx.api.watchers.completeWindow({

--- a/packages/server/src/sandbox/namespaces/entities.ts
+++ b/packages/server/src/sandbox/namespaces/entities.ts
@@ -40,6 +40,9 @@ export interface EntityUpdateInput {
 	content?: string;
 	metadata?: Record<string, unknown>;
 	enabled_classifiers?: string[];
+	/** Optional note explaining a human correction; stored on the per-field
+	 *  ownership marker for the metadata fields this update sets. */
+	field_note?: string;
 }
 
 export interface EntityLinkInput {

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -1,0 +1,126 @@
+/**
+ * Durable approval gate for a watcher's proposed change to a HUMAN-OWNED entity
+ * field. Mirrors the manage_agents builder gate: a watcher that wants to overwrite
+ * a field a human owns does NOT write — it queues a pending `runs` row
+ * (run_type='internal', action_key='entity_field_change') + an
+ * `interaction_type='approval'` event, and notifies the org's humans (durable
+ * notification, no SSE dependency — headless + multi-replica safe). On approve the
+ * change is applied via `mergeEntityFields` (the field stays human-owned, now
+ * carrying the approved value); on reject nothing changes.
+ *
+ * This leaf owns only the queue + apply (like manage_agents); the
+ * claim/try-approve/try-reject orchestration lives in manage_operations next to
+ * `supersedeActionEvent`.
+ */
+import { getDb } from '../../db/client';
+import { mergeEntityFields, type FieldMergeResult } from '../../utils/entity-field-merge';
+import { insertEvent } from '../../utils/insert-event';
+import logger from '../../utils/logger';
+import { buildEventPermalink } from '../../utils/url-builder';
+import type { ToolContext } from '../registry';
+import { getOrgUrlContext } from '../view-urls';
+import { notifyActionApprovalNeeded } from '../../notifications/triggers';
+
+/** Synthetic runs.action_key tagging a watcher field-change held for approval. */
+export const ENTITY_FIELD_CHANGE_ACTION_KEY = 'entity_field_change';
+
+/** Proposed field changes held in runs.action_input for a field-change gate run. */
+export interface EntityFieldChangeProposal {
+  entity_id: number;
+  /** field_path -> proposed value (what the watcher wanted to write). */
+  fields: Record<string, unknown>;
+  /** field_path -> current human-owned value (for the diff card). */
+  current?: Record<string, unknown>;
+  watcher_id?: number | null;
+  reason?: string | null;
+}
+
+/**
+ * Queue a watcher field-change for approval. Returns the pending run/event ids.
+ * Called post-commit from the watcher promotion path.
+ */
+export async function proposeEntityFieldChange(
+  ctx: ToolContext,
+  proposal: EntityFieldChangeProposal
+): Promise<{ runId: number; eventId: number; approvalUrl?: string }> {
+  const sql = getDb();
+  const inserted = await sql`
+    INSERT INTO runs (
+      organization_id, run_type, action_key, action_input,
+      created_by_user_id, approval_status, status, created_at
+    ) VALUES (
+      ${ctx.organizationId}, 'internal', ${ENTITY_FIELD_CHANGE_ACTION_KEY},
+      ${sql.json(proposal as unknown as Record<string, unknown>)},
+      null, 'pending', 'pending', current_timestamp
+    )
+    RETURNING id
+  `;
+  const runId = Number((inserted[0] as { id: unknown }).id);
+
+  const fieldList = Object.keys(proposal.fields).join(', ');
+  const label = `Watcher proposes changing ${fieldList}`;
+  const event = await insertEvent({
+    entityIds: [proposal.entity_id],
+    organizationId: ctx.organizationId,
+    originId: `run_${runId}_pending`,
+    title: `${label} — pending approval`,
+    content: proposal.reason ?? `A watcher proposed updating ${fieldList} on this entity.`,
+    semanticType: 'operation',
+    runId,
+    interactionType: 'approval',
+    interactionStatus: 'pending',
+    interactionInput: proposal as unknown as Record<string, unknown>,
+    metadata: {
+      tool: 'entity_field_change',
+      action_key: ENTITY_FIELD_CHANGE_ACTION_KEY,
+      entity_id: proposal.entity_id,
+      fields: proposal.fields,
+      current: proposal.current ?? null,
+      watcher_id: proposal.watcher_id ?? null,
+      reason: proposal.reason ?? null,
+      status: 'pending_approval',
+      run_id: runId,
+    },
+    authorName: 'watcher',
+  });
+  const eventId = Number(event.id);
+
+  const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
+  const approvalUrl =
+    ownerSlug && baseUrl ? buildEventPermalink(ownerSlug, eventId, baseUrl) : undefined;
+
+  notifyActionApprovalNeeded({
+    orgId: ctx.organizationId,
+    runId,
+    actionKey: ENTITY_FIELD_CHANGE_ACTION_KEY,
+    connectionName: label,
+    eventId,
+    approvalUrl,
+  }).catch((error) =>
+    logger.error(error, 'Failed to send entity_field_change approval notification')
+  );
+
+  return { runId, eventId, approvalUrl };
+}
+
+/**
+ * Apply an approved field-change proposal. The approver endorsed the value, so it
+ * is written AND marked human-owned (now carrying the approved value) via
+ * mergeEntityFields(source='human').
+ */
+export async function applyEntityFieldChangeProposal(
+  proposal: EntityFieldChangeProposal,
+  approverUserId: string | null
+): Promise<FieldMergeResult> {
+  const sql = getDb();
+  return await sql.begin(async (tx) =>
+    mergeEntityFields({
+      tx,
+      entityId: proposal.entity_id,
+      fields: proposal.fields,
+      source: 'human',
+      actorId: approverUserId,
+      note: proposal.reason ?? null,
+    })
+  );
+}

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -44,6 +44,34 @@ export async function proposeEntityFieldChange(
   proposal: EntityFieldChangeProposal
 ): Promise<{ runId: number; eventId: number; approvalUrl?: string }> {
   const sql = getDb();
+
+  // Idempotency: complete_window is replay-safe (retries + concurrent replicas),
+  // so the same blocked field-change can be proposed more than once. Collapse to a
+  // single pending approval — if an identical pending run already exists for this
+  // org+entity+proposed-fields, reuse it instead of stacking duplicate cards.
+  const existing = await sql<{ id: number; event_id: number | null }>`
+    SELECT r.id,
+           (SELECT e.id FROM events e
+              WHERE e.run_id = r.id
+                AND e.interaction_status = 'pending'
+              ORDER BY e.id DESC LIMIT 1) AS event_id
+    FROM runs r
+    WHERE r.organization_id = ${ctx.organizationId}
+      AND r.run_type = 'internal'
+      AND r.action_key = ${ENTITY_FIELD_CHANGE_ACTION_KEY}
+      AND r.approval_status = 'pending'
+      AND r.status = 'pending'
+      AND r.action_input->>'entity_id' = ${String(proposal.entity_id)}
+      AND r.action_input->'fields' = ${sql.json(proposal.fields)}::jsonb
+    ORDER BY r.id DESC
+    LIMIT 1
+  `;
+  if (existing.length > 0) {
+    const runId = Number(existing[0].id);
+    const eventId = existing[0].event_id != null ? Number(existing[0].event_id) : 0;
+    return { runId, eventId };
+  }
+
   const inserted = await sql`
     INSERT INTO runs (
       organization_id, run_type, action_key, action_input,
@@ -121,6 +149,8 @@ export async function applyEntityFieldChangeProposal(
       source: 'human',
       actorId: approverUserId,
       note: proposal.reason ?? null,
+      // Don't overwrite a field the human re-edited after this proposal was queued.
+      expectedCurrent: proposal.current ?? null,
     })
   );
 }

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -129,6 +129,14 @@ export const ManageEntitySchema = Type.Object({
     })
   ),
 
+  // Human-correction annotation
+  field_note: Type.Optional(
+    Type.String({
+      description:
+        '[update] Optional note explaining a human correction. Stored on the per-field ownership marker for every metadata field this update sets, so a watcher (and the UI) can see why the value was set.',
+    })
+  ),
+
   // List/pagination
   search: Type.Optional(Type.String({ description: '[list] Search by name' })),
   limit: Type.Optional(
@@ -585,6 +593,10 @@ async function handleUpdate(
 
   // Metadata (replaces entire object)
   if (args.metadata !== undefined) updateData.metadata = args.metadata;
+
+  // Human-correction note: annotates the field_controls marker for the fields
+  // this edit claims (why the human set/overrode the value).
+  if (args.field_note !== undefined) updateData.field_note = args.field_note;
 
   const updatedEntity = await updateEntity(entityId, updateData, env, ctx);
   const entityDetails = (await getEntity(updatedEntity.id, env, ctx)) ?? updatedEntity;

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1238,17 +1238,24 @@ async function tryApproveEntityFieldChangeRun(
 
   try {
     const result = await applyEntityFieldChangeProposal(proposal, ctx.userId);
+    const staleFields = Object.keys(result.stale);
+    // The human re-edited every proposed field after the watcher queued this — the
+    // proposal is stale. Resolve the run without clobbering the newer human value.
+    const allStale = Object.keys(result.applied).length === 0 && staleFields.length > 0;
     await getDb()`
       UPDATE runs SET status = 'completed', completed_at = NOW(),
         action_output = ${getDb().json(result as unknown as Record<string, unknown>)}
       WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
     `;
+    const summary = allStale
+      ? `Field change skipped — ${staleFields.join(', ')} already changed since proposed`
+      : `Field change applied: ${fieldList}`;
     const eventId = await supersedeActionEvent(
       args.run_id,
       ctx.organizationId,
       'completed',
-      'entity_field_change — completed',
-      `Field change applied: ${fieldList}`,
+      allStale ? 'entity_field_change — skipped (stale)' : 'entity_field_change — completed',
+      summary,
       { output: result as unknown as Record<string, unknown> }
     );
     return {
@@ -1256,7 +1263,9 @@ async function tryApproveEntityFieldChangeRun(
       approved: true,
       run_id: args.run_id,
       event_id: eventId,
-      message: `Field change approved and applied: ${fieldList}.`,
+      message: allStale
+        ? `Field change skipped: ${staleFields.join(', ')} was changed by a human after the watcher proposed it.`
+        : `Field change approved and applied: ${fieldList}.`,
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -31,6 +31,11 @@ import {
   type ManageAgentsProposal,
   applyManageAgentsProposal,
 } from './manage_agents';
+import {
+  ENTITY_FIELD_CHANGE_ACTION_KEY,
+  type EntityFieldChangeProposal,
+  applyEntityFieldChangeProposal,
+} from './entity-field-approval';
 import { PaginationFields } from './schemas/common-fields';
 import { getErrorMessage } from "@lobu/core";
 
@@ -1168,6 +1173,137 @@ async function tryApproveManageAgentsRun(
   }
 }
 
+/**
+ * Claim a pending entity_field_change run (a watcher field-change held for
+ * approval). Mirrors claimManageAgentsRun. Returns the held proposal, or null when
+ * this run isn't a pending field-change run.
+ */
+async function claimEntityFieldChangeRun(
+  runId: number,
+  organizationId: string,
+  decision: 'approved' | 'rejected',
+  rejectReason?: string
+): Promise<{ proposal: EntityFieldChangeProposal } | null> {
+  const sql = getDb();
+  const rows =
+    decision === 'approved'
+      ? await sql`
+          UPDATE runs
+          SET approval_status = 'approved', status = 'running'
+          WHERE id = ${runId}
+            AND organization_id = ${organizationId}
+            AND approval_status = 'pending'
+            AND run_type = 'internal'
+            AND action_key = ${ENTITY_FIELD_CHANGE_ACTION_KEY}
+          RETURNING action_input
+        `
+      : await sql`
+          UPDATE runs
+          SET approval_status = 'rejected', status = 'cancelled',
+              error_message = ${rejectReason ?? 'Rejected by user'}, completed_at = NOW()
+          WHERE id = ${runId}
+            AND organization_id = ${organizationId}
+            AND approval_status = 'pending'
+            AND run_type = 'internal'
+            AND action_key = ${ENTITY_FIELD_CHANGE_ACTION_KEY}
+          RETURNING action_input
+        `;
+  if (rows.length === 0) return null;
+  const proposal = (rows[0] as { action_input: EntityFieldChangeProposal | null }).action_input;
+  if (!proposal) return null;
+  return { proposal };
+}
+
+/**
+ * Approve + apply a pending entity_field_change run. Returns a result when the run
+ * was a pending field-change run; null to fall through to other approval paths.
+ */
+async function tryApproveEntityFieldChangeRun(
+  args: Static<typeof ApproveAction>,
+  ctx: ToolContext
+): Promise<ManageOperationsResult | null> {
+  const claimed = await claimEntityFieldChangeRun(args.run_id, ctx.organizationId, 'approved');
+  if (!claimed) return null;
+  const { proposal } = claimed;
+  const fieldList = Object.keys(proposal.fields).join(', ');
+
+  await supersedeActionEvent(
+    args.run_id,
+    ctx.organizationId,
+    'confirmed',
+    'entity_field_change — applying',
+    `Field change confirmed: ${fieldList}`,
+    {}
+  );
+
+  try {
+    const result = await applyEntityFieldChangeProposal(proposal, ctx.userId);
+    await getDb()`
+      UPDATE runs SET status = 'completed', completed_at = NOW(),
+        action_output = ${getDb().json(result as unknown as Record<string, unknown>)}
+      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+    `;
+    const eventId = await supersedeActionEvent(
+      args.run_id,
+      ctx.organizationId,
+      'completed',
+      'entity_field_change — completed',
+      `Field change applied: ${fieldList}`,
+      { output: result as unknown as Record<string, unknown> }
+    );
+    return {
+      action: 'approve',
+      approved: true,
+      run_id: args.run_id,
+      event_id: eventId,
+      message: `Field change approved and applied: ${fieldList}.`,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    await getDb()`
+      UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMessage}
+      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+    `;
+    await supersedeActionEvent(
+      args.run_id,
+      ctx.organizationId,
+      'failed',
+      'entity_field_change — failed',
+      `Field change failed: ${errorMessage}`,
+      { error_message: errorMessage }
+    );
+    return { error: `Failed to apply field change: ${errorMessage}` };
+  }
+}
+
+/**
+ * Reject a pending entity_field_change run. Returns a result when the run was a
+ * pending field-change run; null to fall through.
+ */
+async function tryRejectEntityFieldChangeRun(
+  args: Static<typeof RejectAction>,
+  ctx: ToolContext
+): Promise<ManageOperationsResult | null> {
+  const reason = args.reason ?? 'Rejected by user';
+  const claimed = await claimEntityFieldChangeRun(
+    args.run_id,
+    ctx.organizationId,
+    'rejected',
+    reason
+  );
+  if (!claimed) return null;
+  const fieldList = Object.keys(claimed.proposal.fields).join(', ');
+  const eventId = await supersedeActionEvent(
+    args.run_id,
+    ctx.organizationId,
+    'rejected',
+    'entity_field_change — rejected',
+    `Field change rejected: ${fieldList}${args.reason ? ` — ${args.reason}` : ''}`,
+    { reason }
+  );
+  return { action: 'reject', rejected: true, run_id: args.run_id, event_id: eventId };
+}
+
 async function handleApprove(
   args: Static<typeof ApproveAction>,
   ctx: ToolContext,
@@ -1188,6 +1324,11 @@ async function handleApprove(
   // executor.
   const builderResult = await tryApproveManageAgentsRun(args, ctx, env);
   if (builderResult) return builderResult;
+
+  // Watcher field-change gate (run_type='internal', action_key='entity_field_change'):
+  // approve applies the proposed value to the entity (now human-owned).
+  const fieldChangeResult = await tryApproveEntityFieldChangeRun(args, ctx);
+  if (fieldChangeResult) return fieldChangeResult;
 
   const runRows = await sql`
     UPDATE runs
@@ -1313,6 +1454,10 @@ async function handleReject(
     );
     return { action: 'reject', rejected: true, run_id: args.run_id, event_id: eventId };
   }
+
+  // Watcher field-change gate? Cancel it; the entity keeps its human-owned value.
+  const fieldChangeReject = await tryRejectEntityFieldChangeRun(args, ctx);
+  if (fieldChangeReject) return fieldChangeReject;
 
   const updated = await sql`
     UPDATE runs

--- a/packages/server/src/tools/admin/manage_watchers/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_watchers/complete-window.ts
@@ -11,7 +11,11 @@ import type { Env } from '../../../index';
 import { ToolUserError } from '../../../utils/errors';
 import { verifyWindowToken } from '../../../utils/jwt';
 import logger from '../../../utils/logger';
-import { promoteKeyedEntities } from '../../../utils/promote-keyed-entities';
+import {
+  type BlockedFieldProposal,
+  promoteKeyedEntities,
+} from '../../../utils/promote-keyed-entities';
+import { proposeEntityFieldChange } from '../entity-field-approval';
 import { computeStableKeys } from '../../../utils/stable-keys';
 import { deriveWatcherExtractionSchema } from '../../../utils/watcher-extraction-schema';
 import { trackWatcherReaction } from '../../../utils/watcher-reactions';
@@ -416,6 +420,9 @@ export async function handleCompleteWindow(
   //
   // Transaction for data writes.
   // ============================================
+  // Owned-field changes a watcher proposed but couldn't apply; surfaced out of the
+  // transaction and turned into approval cards once the window commits.
+  let blockedProposals: BlockedFieldProposal[] = [];
   const result = await sql.begin(async (tx) => {
     // ============================================
     // STEP 7: Get or create window with FINAL values
@@ -579,7 +586,7 @@ export async function handleCompleteWindow(
     // return above).
     // ============================================
     if (keyingConfig) {
-      await promoteKeyedEntities({
+      const promote = await promoteKeyedEntities({
         tx,
         extractedData,
         keyingConfig,
@@ -589,6 +596,9 @@ export async function handleCompleteWindow(
         parentEntityId,
         createdBy: watcherCreatedBy,
       });
+      // Owned-field changes the watcher couldn't apply — queue an approval for each
+      // AFTER the window transaction commits (an approval must not ride the tx).
+      blockedProposals = promote.blocked;
     }
 
     // ============================================
@@ -648,6 +658,25 @@ export async function handleCompleteWindow(
       window_created: windowCreated,
     };
   });
+
+  // Post-commit: turn any blocked owned-field changes into approval cards. Done
+  // after the window transaction so the durable approval (run + event + notify)
+  // is never rolled back with the window, and a failure here never undoes the
+  // committed sync. Best-effort per proposal.
+  for (const b of blockedProposals) {
+    await proposeEntityFieldChange(ctx, {
+      entity_id: b.entityId,
+      fields: b.fields,
+      current: b.current,
+      watcher_id: Number(watcherId),
+      reason: `Watcher proposes updating ${Object.keys(b.fields).join(', ')} (currently set by you).`,
+    }).catch((err) =>
+      logger.error(
+        { err, watcherId, entityId: b.entityId },
+        '[complete-window] failed to queue entity_field_change approval'
+      )
+    );
+  }
 
   // Execute reaction script inline (in-process via QuickJS WASM sandbox).
   // Fire on linked content OR on a freshly created window: device-run and

--- a/packages/server/src/tools/get_content/watcher-mode.ts
+++ b/packages/server/src/tools/get_content/watcher-mode.ts
@@ -191,7 +191,7 @@ export async function handleWatcherMode(
       cv.condensation_prompt,
       cv.condensation_window_count,
       cv.version_sources,
-      (SELECT COALESCE(json_agg(json_build_object('id', e.id, 'name', e.name, 'type', et.slug)), '[]'::json) FROM entities e JOIN entity_types et ON et.id = e.entity_type_id WHERE e.id = ANY(i.entity_ids)) as entities
+      (SELECT COALESCE(json_agg(json_build_object('id', e.id, 'name', e.name, 'type', et.slug, 'metadata', e.metadata, 'field_controls', e.field_controls)), '[]'::json) FROM entities e JOIN entity_types et ON et.id = e.entity_type_id WHERE e.id = ANY(i.entity_ids)) as entities
     FROM watchers i
     LEFT JOIN watcher_versions cv
       ON cv.id = COALESCE(${pinnedVersionId}::bigint, i.current_version_id)

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -73,6 +73,9 @@ interface ViewTemplateTab {
 export interface ResolvedEntityDetails extends ResolvedPathEntity {
   parent_id: number | null;
   metadata: Record<string, any>;
+  /** Per-field human-ownership markers (key present = a human set that field).
+   *  Lets the UI badge owned fields + show the correction note. */
+  field_controls: Record<string, { note?: string | null; set_by?: string | null; set_at?: string }>;
   json_template: Record<string, any> | null;
   json_template_version: number | null;
   template_data: Record<string, unknown[]> | null;
@@ -105,6 +108,7 @@ interface ResolvedEntityRow {
   name: string;
   parent_id: number | null;
   metadata: Record<string, any> | null;
+  field_controls?: Record<string, unknown> | null;
   created_at: Date;
 }
 
@@ -418,6 +422,7 @@ async function _resolvePath(
           e.name,
           e.parent_id,
           e.metadata,
+          e.field_controls,
           e.created_at,
           COALESCE(vtv_entity.json_template, vtv_et.json_template) as json_template,
           COALESCE(vtv_entity.version, vtv_et.version) as json_template_version,
@@ -572,6 +577,7 @@ async function _resolvePath(
       name: entityRow.name,
       parent_id: entityRow.parent_id,
       metadata: safeEntityMetadata,
+      field_controls: (entityRow.field_controls as ResolvedEntityDetails['field_controls']) ?? {},
       json_template: resolvedTemplate,
       json_template_version: toVersionNumber(entityRow.json_template_version),
       template_data: redactedTemplateData,
@@ -721,6 +727,8 @@ async function resolveDerivedLeaf(
     name,
     parent_id: null,
     metadata: match,
+    // Derived ("view") rows aren't stored entities — no per-field ownership.
+    field_controls: {},
     json_template: null,
     json_template_version: null,
     template_data: null,

--- a/packages/server/src/utils/__tests__/entity-field-merge.test.ts
+++ b/packages/server/src/utils/__tests__/entity-field-merge.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { computeFieldMerge } from '../entity-field-merge';
+
+const NOW = '2026-06-25T12:00:00.000Z';
+
+describe('computeFieldMerge', () => {
+  it('human edit applies the change AND claims ownership', () => {
+    const r = computeFieldMerge({
+      metadata: { status: 'todo' },
+      controls: {},
+      fields: { status: 'done' },
+      source: 'human',
+      actorId: 'usr_1',
+      note: 'shipped it',
+      nowIso: NOW,
+    });
+    expect(r.changed).toBe(true);
+    expect(r.applied).toEqual({ status: { old: 'todo', new: 'done' } });
+    expect(r.nextMetadata.status).toBe('done');
+    expect(r.nextControls.status).toEqual({ note: 'shipped it', set_by: 'usr_1', set_at: NOW });
+    expect(r.blocked).toEqual({});
+  });
+
+  it('human edit that does not change the value is a no-op', () => {
+    const r = computeFieldMerge({
+      metadata: { status: 'done' },
+      controls: {},
+      fields: { status: 'done' },
+      source: 'human',
+      actorId: 'usr_1',
+      note: null,
+      nowIso: NOW,
+    });
+    expect(r.changed).toBe(false);
+    expect(r.applied).toEqual({});
+    expect(r.nextControls).toEqual({}); // no ownership claimed for an unchanged field
+  });
+
+  it('watcher writes a NON-owned field freely (no ownership mark)', () => {
+    const r = computeFieldMerge({
+      metadata: { score: 10 },
+      controls: {},
+      fields: { score: 42 },
+      source: 'watcher',
+      actorId: null,
+      note: null,
+      nowIso: NOW,
+    });
+    expect(r.applied).toEqual({ score: { old: 10, new: 42 } });
+    expect(r.nextMetadata.score).toBe(42);
+    expect(r.nextControls).toEqual({}); // watcher writes never claim ownership
+    expect(r.blocked).toEqual({});
+  });
+
+  it('watcher is BLOCKED from overwriting a human-owned field', () => {
+    const r = computeFieldMerge({
+      metadata: { status: 'done' },
+      controls: { status: { note: 'CI red', set_by: 'usr_1', set_at: NOW } },
+      fields: { status: 'todo' }, // watcher wants to revert it
+      source: 'watcher',
+      actorId: null,
+      note: null,
+      nowIso: NOW,
+    });
+    expect(r.changed).toBe(false);
+    expect(r.applied).toEqual({});
+    expect(r.nextMetadata.status).toBe('done'); // unchanged — human wins
+    expect(r.blocked).toEqual({ status: { current: 'done', proposed: 'todo' } });
+  });
+
+  it('watcher proposing the SAME value as the owned field is not a conflict', () => {
+    const r = computeFieldMerge({
+      metadata: { status: 'done' },
+      controls: { status: { set_by: 'usr_1', set_at: NOW } },
+      fields: { status: 'done' },
+      source: 'watcher',
+      actorId: null,
+      note: null,
+      nowIso: NOW,
+    });
+    expect(r.changed).toBe(false);
+    expect(r.applied).toEqual({});
+    expect(r.blocked).toEqual({});
+  });
+
+  it('mixed batch: watcher applies un-owned, blocks owned, in one pass', () => {
+    const r = computeFieldMerge({
+      metadata: { status: 'done', score: 10 },
+      controls: { status: { set_by: 'usr_1', set_at: NOW } },
+      fields: { status: 'todo', score: 99 },
+      source: 'watcher',
+      actorId: null,
+      note: null,
+      nowIso: NOW,
+    });
+    expect(r.applied).toEqual({ score: { old: 10, new: 99 } });
+    expect(r.blocked).toEqual({ status: { current: 'done', proposed: 'todo' } });
+    expect(r.nextMetadata).toEqual({ status: 'done', score: 99 });
+  });
+});

--- a/packages/server/src/utils/__tests__/entity-field-merge.test.ts
+++ b/packages/server/src/utils/__tests__/entity-field-merge.test.ts
@@ -97,4 +97,39 @@ describe('computeFieldMerge', () => {
     expect(r.blocked).toEqual({ status: { current: 'done', proposed: 'todo' } });
     expect(r.nextMetadata).toEqual({ status: 'done', score: 99 });
   });
+
+  it('deferred apply: stale proposal does NOT clobber a value the human moved since', () => {
+    // Proposal was built when status was 'high'; the human has since moved it to 'medium'.
+    const r = computeFieldMerge({
+      metadata: { status: 'medium' },
+      controls: { status: { set_by: 'usr_1', set_at: NOW } },
+      fields: { status: 'critical' },
+      source: 'human', // approver endorses
+      actorId: 'usr_approver',
+      note: null,
+      nowIso: NOW,
+      expectedCurrent: { status: 'high' },
+    });
+    expect(r.changed).toBe(false);
+    expect(r.applied).toEqual({});
+    expect(r.stale).toEqual({ status: { expected: 'high', live: 'medium' } });
+    expect(r.nextMetadata.status).toBe('medium'); // human's newer value untouched
+  });
+
+  it('deferred apply: proposal applies when the snapshot still matches live', () => {
+    const r = computeFieldMerge({
+      metadata: { status: 'high' },
+      controls: { status: { set_by: 'usr_1', set_at: NOW } },
+      fields: { status: 'critical' },
+      source: 'human',
+      actorId: 'usr_approver',
+      note: null,
+      nowIso: NOW,
+      expectedCurrent: { status: 'high' },
+    });
+    expect(r.changed).toBe(true);
+    expect(r.applied).toEqual({ status: { old: 'high', new: 'critical' } });
+    expect(r.stale).toEqual({});
+    expect(r.nextMetadata.status).toBe('critical');
+  });
 });

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -115,7 +115,7 @@ describe('validateTableQuery', () => {
  */
 describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
   const INTENTIONALLY_OMITTED: Record<string, Set<string>> = {
-    entities: new Set(['embedding', 'content_tsv', 'content_hash']),
+    entities: new Set(['embedding', 'content_tsv', 'content_hash', 'field_controls']),
     events: new Set([]),
     connections: new Set(['credentials', 'unhealthy_alerted_at']),
     // Large per-connector JSONB blobs — too big and structure-dependent to expose

--- a/packages/server/src/utils/entity-field-merge.ts
+++ b/packages/server/src/utils/entity-field-merge.ts
@@ -33,12 +33,21 @@ export interface BlockedChange {
   current: unknown;
   proposed: unknown;
 }
+export interface StaleChange {
+  /** The live value the proposal was based on (proposal.current snapshot). */
+  expected: unknown;
+  /** The value actually in metadata now — a human moved it since the proposal. */
+  live: unknown;
+}
 
 export interface FieldMergeResult {
   /** Fields whose value changed and were written to metadata. */
   applied: Record<string, AppliedChange>;
   /** Owned fields a watcher tried to change — NOT written; surface as an approval. */
   blocked: Record<string, BlockedChange>;
+  /** Fields skipped because the live value drifted from the proposal's snapshot
+   *  (a human re-edited the field after the proposal was queued). NOT written. */
+  stale: Record<string, StaleChange>;
   nextMetadata: Record<string, unknown>;
   nextControls: Record<string, FieldControl>;
   changed: boolean;
@@ -72,16 +81,31 @@ export function computeFieldMerge(args: {
   actorId: string | null;
   note: string | null;
   nowIso: string;
+  /** When provided (deferred apply of a queued proposal), each field is written only
+   *  if its live metadata value still equals the snapshot the proposal was built on.
+   *  A drifted field is skipped (`stale`) so a stale approval can't clobber a value
+   *  the human moved after the proposal was queued. */
+  expectedCurrent?: Record<string, unknown> | null;
 }): FieldMergeResult {
-  const { metadata, controls, fields, source, actorId, note, nowIso } = args;
+  const { metadata, controls, fields, source, actorId, note, nowIso, expectedCurrent } = args;
   const nextMetadata: Record<string, unknown> = { ...metadata };
   const nextControls: Record<string, FieldControl> = { ...controls };
   const applied: Record<string, AppliedChange> = {};
   const blocked: Record<string, BlockedChange> = {};
+  const stale: Record<string, StaleChange> = {};
 
   for (const [field, value] of Object.entries(fields)) {
     const current = metadata[field];
     const owned = Object.hasOwn(controls, field);
+
+    // Deferred-apply staleness guard: the human re-edited the field after this
+    // proposal was queued, so the proposal is based on an outdated value — skip it.
+    if (expectedCurrent && Object.hasOwn(expectedCurrent, field)) {
+      if (!sameValue(current, expectedCurrent[field])) {
+        stale[field] = { expected: expectedCurrent[field] ?? null, live: current ?? null };
+        continue;
+      }
+    }
 
     // A watcher must never overwrite a human-owned field — propose instead.
     if (source === 'watcher' && owned) {
@@ -104,6 +128,7 @@ export function computeFieldMerge(args: {
   return {
     applied,
     blocked,
+    stale,
     nextMetadata,
     nextControls,
     changed: Object.keys(applied).length > 0,
@@ -123,6 +148,8 @@ export async function mergeEntityFields(params: {
   /** User id for a human edit; null/system otherwise. */
   actorId: string | null;
   note?: string | null;
+  /** Snapshot the proposal was built on (deferred-apply staleness guard). */
+  expectedCurrent?: Record<string, unknown> | null;
 }): Promise<FieldMergeResult> {
   const { tx, entityId, fields, source, actorId } = params;
 
@@ -146,6 +173,7 @@ export async function mergeEntityFields(params: {
     actorId,
     note: params.note ?? null,
     nowIso: new Date().toISOString(),
+    expectedCurrent: params.expectedCurrent ?? null,
   });
 
   if (merge.changed) {

--- a/packages/server/src/utils/entity-field-merge.ts
+++ b/packages/server/src/utils/entity-field-merge.ts
@@ -1,0 +1,174 @@
+/**
+ * Shared entity field-merge primitive for the watcher<->human feedback loop.
+ *
+ * The value lives in `entities.metadata`; per-field ownership lives in the sparse
+ * `entities.field_controls` jsonb column (a key present = that field is human-owned).
+ * This is the SINGLE write path for both human edits and watcher promotion:
+ *   - source='human'  : writes every changed field AND marks it owned (note/set_by/set_at).
+ *   - source='watcher': writes only fields that are NOT human-owned; owned fields are
+ *     returned in `blocked` (the caller emits an approval) and never overwritten.
+ *
+ * The risky decision logic is the pure `computeFieldMerge` — unit-tested without a DB.
+ * `mergeEntityFields` is the thin DB wrapper: it locks the entity row FOR UPDATE inside
+ * the caller's transaction, applies the merge, and persists metadata + field_controls
+ * atomically. Callers own the audit `'change'` event (handleUpdate / promotion emit it).
+ */
+
+import type { DbClient } from '../db/client';
+
+export type FieldWriteSource = 'human' | 'watcher';
+
+/** Per-field ownership marker stored under entities.field_controls[field]. */
+export interface FieldControl {
+  note?: string | null;
+  set_by?: string | null;
+  set_at?: string;
+}
+
+export interface AppliedChange {
+  old: unknown;
+  new: unknown;
+}
+export interface BlockedChange {
+  current: unknown;
+  proposed: unknown;
+}
+
+export interface FieldMergeResult {
+  /** Fields whose value changed and were written to metadata. */
+  applied: Record<string, AppliedChange>;
+  /** Owned fields a watcher tried to change — NOT written; surface as an approval. */
+  blocked: Record<string, BlockedChange>;
+  nextMetadata: Record<string, unknown>;
+  nextControls: Record<string, FieldControl>;
+  changed: boolean;
+}
+
+/** Order-insensitive value comparison for change detection. */
+function sameValue(a: unknown, b: unknown): boolean {
+  return stableStringify(a) === stableStringify(b);
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || value === undefined) return 'null';
+  if (typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(',')}}`;
+}
+
+/**
+ * Pure merge decision. Given the current metadata + ownership controls, decide which
+ * proposed `fields` get applied vs blocked, and produce the next metadata/controls.
+ * No DB, no I/O — the unit-tested heart of the feedback loop's correctness.
+ */
+export function computeFieldMerge(args: {
+  metadata: Record<string, unknown>;
+  controls: Record<string, FieldControl>;
+  fields: Record<string, unknown>;
+  source: FieldWriteSource;
+  actorId: string | null;
+  note: string | null;
+  nowIso: string;
+}): FieldMergeResult {
+  const { metadata, controls, fields, source, actorId, note, nowIso } = args;
+  const nextMetadata: Record<string, unknown> = { ...metadata };
+  const nextControls: Record<string, FieldControl> = { ...controls };
+  const applied: Record<string, AppliedChange> = {};
+  const blocked: Record<string, BlockedChange> = {};
+
+  for (const [field, value] of Object.entries(fields)) {
+    const current = metadata[field];
+    const owned = Object.hasOwn(controls, field);
+
+    // A watcher must never overwrite a human-owned field — propose instead.
+    if (source === 'watcher' && owned) {
+      if (!sameValue(current, value)) {
+        blocked[field] = { current: current ?? null, proposed: value };
+      }
+      continue;
+    }
+
+    if (sameValue(current, value)) continue;
+
+    applied[field] = { old: current ?? null, new: value };
+    nextMetadata[field] = value;
+    // A human edit claims ownership of the field it sets.
+    if (source === 'human') {
+      nextControls[field] = { note, set_by: actorId, set_at: nowIso };
+    }
+  }
+
+  return {
+    applied,
+    blocked,
+    nextMetadata,
+    nextControls,
+    changed: Object.keys(applied).length > 0,
+  };
+}
+
+/**
+ * DB wrapper: lock the entity row in the caller's transaction, apply the merge, and
+ * persist metadata + field_controls atomically. Returns applied/blocked so the caller
+ * can emit the audit event (human path) or the approval interactions (watcher path).
+ */
+export async function mergeEntityFields(params: {
+  tx: DbClient;
+  entityId: number;
+  fields: Record<string, unknown>;
+  source: FieldWriteSource;
+  /** User id for a human edit; null/system otherwise. */
+  actorId: string | null;
+  note?: string | null;
+}): Promise<FieldMergeResult> {
+  const { tx, entityId, fields, source, actorId } = params;
+
+  const rows = await tx<{ metadata: unknown; field_controls: unknown }>`
+    SELECT metadata, field_controls FROM entities
+    WHERE id = ${entityId} AND deleted_at IS NULL
+    FOR UPDATE
+  `;
+  if (rows.length === 0) {
+    throw new Error(`Entity ${entityId} not found`);
+  }
+
+  const metadata = parseJsonObject(rows[0].metadata);
+  const controls = parseJsonObject(rows[0].field_controls) as Record<string, FieldControl>;
+
+  const merge = computeFieldMerge({
+    metadata,
+    controls,
+    fields,
+    source,
+    actorId,
+    note: params.note ?? null,
+    nowIso: new Date().toISOString(),
+  });
+
+  if (merge.changed) {
+    await tx`
+      UPDATE entities
+      SET metadata = ${tx.json(merge.nextMetadata)},
+          field_controls = ${tx.json(merge.nextControls)},
+          updated_at = current_timestamp
+      WHERE id = ${entityId}
+    `;
+  }
+
+  return merge;
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> {
+  if (value == null) return {};
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }
+  return value as Record<string, unknown>;
+}

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -100,6 +100,11 @@ export interface EntityData {
   // Metadata - contains all type-specific fields
   metadata?: Record<string, any>;
 
+  // Optional human-correction note: on a human update it is stored on the
+  // field_controls marker for every field this edit claims, so the watcher (and
+  // the UI) can show WHY the value was set. Ignored for agent/system writes.
+  field_note?: string | null;
+
   // Convenience fields - will be merged into metadata
   domain?: string | null;
   category?: string | null;
@@ -410,7 +415,7 @@ export async function updateEntity(
           fields: metadataUpdates,
           source: 'human',
           actorId: ctx.userId,
-          note: null,
+          note: data.field_note ?? null,
           nowIso: new Date().toISOString(),
         });
         mergedMetadata = merge.nextMetadata;

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -18,6 +18,7 @@ import type { Env } from '../index';
 import { querySqlImpl } from '../tools/admin/query_sql';
 import type { ToolContext } from '../tools/registry';
 import { entityLinkMatchSql } from './content-search';
+import { computeFieldMerge, type FieldControl } from './entity-field-merge';
 import { type EntityHookContext, getEntityHooks } from './entity-hooks';
 import { ToolUserError } from './errors';
 import { requireWriteAccess } from './organization-access';
@@ -370,12 +371,18 @@ export async function updateEntity(
   const hasEmbedding = data.embedding !== undefined;
   const embeddingLiteral = toVectorLiteral(data.embedding);
 
+  // A genuine human edit (a real user, not an agent run) claims per-field ownership
+  // so a watcher can't later overwrite it without an approval. Agent/system writes keep
+  // the existing plain-merge behavior; watcher ownership-aware writes go through
+  // mergeEntityFields at the promotion call site.
+  const isHumanEdit = !!ctx.userId && !ctx.agentId;
+
   // Lock the entity row, merge metadata, and write in ONE transaction: concurrent
   // updates to the same entity serialize on the row lock, fixing the pre-existing
   // non-transactional read-modify-write race on entities.metadata.
   const result = await sql.begin(async (tx) => {
     const current = await tx`
-      SELECT metadata, organization_id FROM entities
+      SELECT metadata, field_controls, organization_id FROM entities
       WHERE id = ${entityId} AND deleted_at IS NULL
       FOR UPDATE
     `;
@@ -384,13 +391,33 @@ export async function updateEntity(
     }
 
     let mergedMetadata: Record<string, unknown> | null = null;
+    let mergedControls: Record<string, unknown> | null = null;
     if (hasMetadataUpdates) {
       const existing = (
         typeof current[0].metadata === 'string'
           ? JSON.parse(current[0].metadata as string)
           : (current[0].metadata ?? {})
       ) as Record<string, unknown>;
-      mergedMetadata = { ...existing, ...metadataUpdates };
+      if (isHumanEdit) {
+        const existingControls = (
+          typeof current[0].field_controls === 'string'
+            ? JSON.parse(current[0].field_controls as string)
+            : (current[0].field_controls ?? {})
+        ) as Record<string, FieldControl>;
+        const merge = computeFieldMerge({
+          metadata: existing,
+          controls: existingControls,
+          fields: metadataUpdates,
+          source: 'human',
+          actorId: ctx.userId,
+          note: null,
+          nowIso: new Date().toISOString(),
+        });
+        mergedMetadata = merge.nextMetadata;
+        mergedControls = merge.nextControls;
+      } else {
+        mergedMetadata = { ...existing, ...metadataUpdates };
+      }
     }
 
     await tx`
@@ -399,6 +426,7 @@ export async function updateEntity(
         slug = COALESCE(${newSlug}, slug),
         parent_id = CASE WHEN ${data.parent_id !== undefined} THEN ${data.parent_id ?? null}::bigint ELSE parent_id END,
         metadata = CASE WHEN ${hasMetadataUpdates} THEN ${mergedMetadata ? sql.json(mergedMetadata) : null} ELSE metadata END,
+        field_controls = CASE WHEN ${mergedControls !== null} THEN ${mergedControls ? sql.json(mergedControls) : sql.json({})} ELSE field_controls END,
         enabled_classifiers = CASE WHEN ${data.enabled_classifiers !== undefined} THEN ${data.enabled_classifiers ? pgTextArray(data.enabled_classifiers) : null}::text[] ELSE enabled_classifiers END,
         content = CASE WHEN ${hasContent} THEN ${contentValue} ELSE content END,
         embedding = CASE WHEN ${hasEmbedding} THEN ${embeddingLiteral}::vector ELSE embedding END,

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -422,7 +422,9 @@ export async function promoteKeyedEntities(
     // The extracted record's data fields (everything except the computed stable
     // key) are the entity's field values — synced into metadata on create and,
     // for existing entities, merged honoring human ownership.
-    const { [keyingConfig.key_output_field]: _stableKey, ...fieldValues } = entityRecord;
+    const fieldValues = Object.fromEntries(
+      Object.entries(entityRecord).filter(([k]) => k !== keyingConfig.key_output_field)
+    );
     const metadata: Record<string, unknown> = {
       ...fieldValues,
       watcher_id: watcherId,

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -36,6 +36,7 @@
 import { slugify } from '@lobu/core';
 import type { DbClient } from '../db/client';
 import type { KeyingConfig } from '../types/watchers';
+import { type BlockedChange, mergeEntityFields } from './entity-field-merge';
 import { getValueAtPath } from './object-path';
 import logger from './logger';
 import { isUniqueViolation } from './pg-errors';
@@ -64,11 +65,25 @@ export interface PromoteKeyedEntitiesParams {
   createdBy?: string | null;
 }
 
+/** A field a watcher tried to change on an existing entity but is human-owned. */
+export interface BlockedFieldProposal {
+  entityId: number;
+  /** field_path -> proposed value the watcher wanted to write. */
+  fields: Record<string, unknown>;
+  /** field_path -> current human-owned value (for the approval diff). */
+  current: Record<string, unknown>;
+}
+
 export interface PromoteKeyedEntitiesResult {
   /** Number of distinct keyed rows that resolved to an entity. */
   promoted: number;
   /** Of those, how many created a brand-new entity (vs. matched an existing). */
   created: number;
+  /**
+   * Owned-field changes that were NOT applied — the caller queues an approval for
+   * each (post-commit), never overwriting a human value inline.
+   */
+  blocked: BlockedFieldProposal[];
 }
 
 /**
@@ -247,11 +262,20 @@ async function upsertKeyedEntity(params: {
   name: string;
   baseSlug: string;
   metadata: Record<string, unknown>;
+  /** Extracted entity field values to sync into metadata (excludes the stable key). */
+  fieldValues: Record<string, unknown>;
   createdBy: string;
-}): Promise<{ entityId: number; created: boolean }> {
+}): Promise<{
+  entityId: number;
+  created: boolean;
+  blocked: Record<string, BlockedChange>;
+}> {
   const { tx, organizationId, identifier } = params;
 
-  // 1. Existing identity → reuse its entity (the idempotent fast path).
+  // 1. Existing identity → reuse its entity (the idempotent fast path), and SYNC the
+  //    freshly-extracted field values into it honoring human ownership: un-owned
+  //    fields are written; human-owned fields are returned as `blocked` (the caller
+  //    queues an approval) and never overwritten.
   const existing = await tx<{ entity_id: number | string }>`
     SELECT ei.entity_id
     FROM entity_identities ei
@@ -264,7 +288,15 @@ async function upsertKeyedEntity(params: {
     LIMIT 1
   `;
   if (existing.length > 0) {
-    return { entityId: Number(existing[0].entity_id), created: false };
+    const entityId = Number(existing[0].entity_id);
+    const merge = await mergeEntityFields({
+      tx,
+      entityId,
+      fields: params.fieldValues,
+      source: 'watcher',
+      actorId: null,
+    });
+    return { entityId, created: false, blocked: merge.blocked };
   }
 
   // 2. Create the entity (sequence-allocated id — multi-replica safe),
@@ -295,7 +327,7 @@ async function upsertKeyedEntity(params: {
     RETURNING entity_id
   `;
   if (claimed.length > 0) {
-    return { entityId, created: true };
+    return { entityId, created: true, blocked: {} };
   }
 
   // Lost the race: another live transaction already claimed this key. Resolve
@@ -319,11 +351,11 @@ async function upsertKeyedEntity(params: {
       DELETE FROM entities
       WHERE id = ${entityId} AND organization_id = ${organizationId}
     `;
-    return { entityId: Number(winner[0].entity_id), created: false };
+    return { entityId: Number(winner[0].entity_id), created: false, blocked: {} };
   }
   // Extremely unlikely: the conflicting claim was tombstoned between our INSERT
   // and this re-read. Keep our entity as the canonical one.
-  return { entityId, created: true };
+  return { entityId, created: true, blocked: {} };
 }
 
 /**
@@ -347,6 +379,7 @@ export async function promoteKeyedEntities(
   const result: PromoteKeyedEntitiesResult = {
     promoted: 0,
     created: 0,
+    blocked: [],
   };
 
   const rows = getValueAtPath(extractedData, keyingConfig.entity_path);
@@ -386,7 +419,12 @@ export async function promoteKeyedEntities(
     const identifier = `${watcherId}::${stableKey}`;
     const name = buildEntityName(entityRecord, keyingConfig, stableKey);
     const slug = slugify(name) || stableKey;
+    // The extracted record's data fields (everything except the computed stable
+    // key) are the entity's field values — synced into metadata on create and,
+    // for existing entities, merged honoring human ownership.
+    const { [keyingConfig.key_output_field]: _stableKey, ...fieldValues } = entityRecord;
     const metadata: Record<string, unknown> = {
+      ...fieldValues,
       watcher_id: watcherId,
       stable_key: stableKey,
       source: 'watcher_promotion',
@@ -397,7 +435,7 @@ export async function promoteKeyedEntities(
     };
 
     try {
-      const { created } = await tx.savepoint((sp) =>
+      const { created, blocked, entityId } = await tx.savepoint((sp) =>
         upsertKeyedEntity({
           tx: sp,
           organizationId,
@@ -407,11 +445,20 @@ export async function promoteKeyedEntities(
           name,
           baseSlug: slug,
           metadata,
+          fieldValues,
           createdBy,
         })
       );
       result.promoted += 1;
       if (created) result.created += 1;
+      const blockedFields = Object.keys(blocked);
+      if (blockedFields.length > 0) {
+        result.blocked.push({
+          entityId,
+          fields: Object.fromEntries(blockedFields.map((f) => [f, blocked[f].proposed])),
+          current: Object.fromEntries(blockedFields.map((f) => [f, blocked[f].current])),
+        });
+      }
     } catch (err) {
       // Non-fatal + savepoint-isolated: a single failing row rolls back only its
       // savepoint, never the window-completion transaction. Re-throwing here

--- a/packages/server/src/watchers/template-renderer.ts
+++ b/packages/server/src/watchers/template-renderer.ts
@@ -9,6 +9,26 @@ interface TemplateEntity {
   id: number;
   name: string;
   type: string;
+  /** Current entity field values. */
+  metadata?: Record<string, unknown> | null;
+  /** field_path -> ownership marker; a key present means a human set that field. */
+  field_controls?: Record<string, { note?: string | null } | null> | null;
+}
+
+/**
+ * Render an entity for the prompt, surfacing any HUMAN-OWNED field values inline so
+ * the watcher sees the human's authoritative values (and reasons around them /
+ * proposes a change only on new evidence) rather than re-clobbering them.
+ */
+function renderEntity(e: TemplateEntity): string {
+  const owned = e.field_controls ? Object.keys(e.field_controls) : [];
+  if (owned.length === 0) return e.name;
+  const md = e.metadata ?? {};
+  const parts = owned.map((f) => {
+    const note = e.field_controls?.[f]?.note;
+    return `${f}=${JSON.stringify((md as Record<string, unknown>)[f])}${note ? ` (${note})` : ''}`;
+  });
+  return `${e.name} [set by you — do not change without new evidence: ${parts.join(', ')}]`;
 }
 
 interface TemplateContext {
@@ -87,7 +107,9 @@ function buildContext(context: TemplateContext): Record<string, unknown> {
   }
 
   return {
-    entities: stringifiable(context.entities, () => context.entities.map((e) => e.name).join(', ')),
+    entities: stringifiable(context.entities, () =>
+      context.entities.map(renderEntity).join(', ')
+    ),
     content: formatContentList(context.content),
     sources,
     data,


### PR DESCRIPTION
## What

Closes the watcher → entity feedback loop: watchers now **sync** their extracted field values into the entities they promote (entity metadata is the source of truth), and a human can **correct/own** any field — the watcher then respects that value and never silently overwrites it.

- **One write path** (`mergeEntityFields` / pure `computeFieldMerge`) used by both human edits (`updateEntity`) and watcher promotion. `source='human'` writes + marks the field owned in `entities.field_controls`; `source='watcher'` writes only un-owned fields and returns owned conflicts as `blocked` (never overwrites).
- **Ownership marker** = sparse `entities.field_controls` jsonb column (key present = human-owned). Read for free with the row, atomic with the value. No new table, no event scan.
- **Conflict = a durable approval** on the `runs`+`events` plane (mirrors the `manage_agents` builder gate): a watcher that wants to change an owned field queues a pending `entity_field_change` run + an `approval` event + `notifyActionApprovalNeeded` (no SSE dependency — headless + multi-replica safe). The human approves/rejects via `manage_operations`; on approve the value lands and stays human-owned.
- **Prompt** surfaces owned-field markers inline so the watcher reasons around the human's authoritative value instead of re-clobbering it.

## Multi-replica correctness (the two review blockers)

Both fixed and covered red→green:

1. **Stale approval can't clobber a newer human value.** Applying a queued `entity_field_change` re-checks, under the row lock, that each field's live value still equals the snapshot the proposal was built on (`expectedCurrent`). A field the human re-edited after the proposal was queued is skipped (`result.stale`), not overwritten, and the approve handler reports the skip.
2. **Idempotent `complete_window` replays don't stack duplicate approvals.** `proposeEntityFieldChange` dedupes against an existing pending internal run for the same `org + entity + proposed-fields`, so retries / concurrent replicas collapse to one card.

Also registered `entities.field_controls` in `table-schema`'s `INTENTIONALLY_OMITTED` (internal ownership state, not user-queryable) — fixes the schema-drift gate.

## Tests

- Unit `entity-field-merge.test.ts` — 8/8: human-owns, watcher-blocked, mixed batch, **stale-skip**, **snapshot-match**.
- Integration `promote-keyed-entities.test.ts` — 5/5: create syncs fields → human owns → watcher blocked → approval queued; **dedup replay** (second identical window = still one pending); **approve round-trip** (value applies, stays human-owned, run completed); **stale-approval no-clobber** (human's newer value survives an approved stale proposal).
- typecheck 0, full `make review`: **0 blockers** (the 1 reported bug is in unrelated Slack DM code not touched by this branch).

## Follow-ups (separate PRs, by design)

- **PR2** — condensation/rollup removal (dead feature: server + CLI + 5-col schema drop).
- **PR3** — owletto inline field-edit + annotation UI (the human-correction surface) + the condensation UI removal; lands in the owletto repo with a pointer bump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785008375&installation_id=136316292&pr_number=1573&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1573&signature=58e39680fe5fe0d13d1d76c739a6895729006e435fe36f6777f2cef46d51c328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-field ownership tracking for entities, allowing human-edited values to be preserved while other updates continue to sync.
  * Watcher runs can now queue conflicting field changes for approval instead of overwriting human edits.
  * Entity lists shown to watchers now include ownership details for clearer context.

* **Bug Fixes**
  * Prevented stale or conflicting updates from replacing newer human changes.
  * Improved handling of replayed watcher updates so previously approved values stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->