### PR TITLE
feat(server): per-user connection visibility on the SQL scoping seam

### DIFF
--- a/packages/server/src/__tests__/integration/events/per-user-connection-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/events/per-user-connection-visibility.test.ts
@@ -1,0 +1,140 @@
+/**
+ * S0 integration proof (real Postgres rows): the buildScopedQuery seam
+ * (query_sql / client.query / metrics) must enforce PER-USER connection
+ * visibility, not just org scope. Two users each own a PRIVATE connection;
+ * a third connection is org-visible. Each user must see org-visible events +
+ * their OWN private-connection events — never the other user's private data.
+ *
+ * Before S0, this seam applied org scope only, so `userA` saw `userB`'s
+ * private-connection events (the leak). After S0 it threads the requesting
+ * user through buildConnectionVisibilityClause, matching what
+ * search_memory/get_content already enforce.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { validateAndScopeQuery } from '../../../utils/execute-data-sources';
+import { getTestDb } from '../../setup/test-db';
+import {
+  createTestConnection,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+async function originIdsVisibleTo(orgId: string, userId: string | null): Promise<string[]> {
+  const { sql, params } = validateAndScopeQuery('SELECT origin_id FROM events', orgId, {
+    userId,
+  });
+  const rows = await getTestDb().unsafe(sql, params as unknown[]);
+  return rows.map((r: Record<string, unknown>) => String(r.origin_id));
+}
+
+async function connectionIdsVisibleTo(orgId: string, userId: string | null): Promise<number[]> {
+  const { sql, params } = validateAndScopeQuery('SELECT id FROM connections', orgId, {
+    userId,
+  });
+  const rows = await getTestDb().unsafe(sql, params as unknown[]);
+  return rows.map((r: Record<string, unknown>) => Number(r.id));
+}
+
+// feeds derive from a connection (connection_id NOT NULL) — they must inherit
+// the owning connection's per-user visibility.
+async function feedConnIdsVisibleTo(orgId: string, userId: string | null): Promise<number[]> {
+  const { sql, params } = validateAndScopeQuery('SELECT connection_id FROM feeds', orgId, {
+    userId,
+  });
+  const rows = await getTestDb().unsafe(sql, params as unknown[]);
+  return rows.map((r: Record<string, unknown>) => Number(r.connection_id));
+}
+
+describe('buildScopedQuery — per-user connection visibility (S0, real rows)', () => {
+  it('isolates private-connection events per requesting user', async () => {
+    const org = await createTestOrganization({ name: 'S0 Org' });
+    const userA = await createTestUser();
+    const userB = await createTestUser();
+
+    const connA = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'slack',
+      created_by: userA.id,
+      visibility: 'private',
+    });
+    const connB = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'slack',
+      created_by: userB.id,
+      visibility: 'private',
+    });
+    const connOrg = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'slack',
+      visibility: 'org',
+    });
+
+    const evA = await createTestEvent({
+      organization_id: org.id,
+      connection_id: connA.id,
+      content: 'A private',
+      connector_key: 'slack',
+    });
+    const evB = await createTestEvent({
+      organization_id: org.id,
+      connection_id: connB.id,
+      content: 'B private',
+      connector_key: 'slack',
+    });
+    const evOrg = await createTestEvent({
+      organization_id: org.id,
+      connection_id: connOrg.id,
+      content: 'org shared',
+      connector_key: 'slack',
+    });
+
+    // userA: own private + org-visible, NOT userB's private (the leak S0 closes).
+    const aSees = await originIdsVisibleTo(org.id, userA.id);
+    expect(aSees).toContain(evA.origin_id);
+    expect(aSees).toContain(evOrg.origin_id);
+    expect(aSees).not.toContain(evB.origin_id);
+
+    // userB: mirror image.
+    const bSees = await originIdsVisibleTo(org.id, userB.id);
+    expect(bSees).toContain(evB.origin_id);
+    expect(bSees).toContain(evOrg.origin_id);
+    expect(bSees).not.toContain(evA.origin_id);
+
+    // No user (headless/service): org-visible only — private data fails closed.
+    const anonSees = await originIdsVisibleTo(org.id, null);
+    expect(anonSees).toContain(evOrg.origin_id);
+    expect(anonSees).not.toContain(evA.origin_id);
+    expect(anonSees).not.toContain(evB.origin_id);
+
+    // The connections ROW itself is per-user too: a private connection's
+    // metadata (display_name, account_id, config) must not leak to other users.
+    const aConns = await connectionIdsVisibleTo(org.id, userA.id);
+    expect(aConns).toContain(connA.id);
+    expect(aConns).toContain(connOrg.id);
+    expect(aConns).not.toContain(connB.id);
+
+    const bConns = await connectionIdsVisibleTo(org.id, userB.id);
+    expect(bConns).toContain(connB.id);
+    expect(bConns).toContain(connOrg.id);
+    expect(bConns).not.toContain(connA.id);
+
+    const anonConns = await connectionIdsVisibleTo(org.id, null);
+    expect(anonConns).toContain(connOrg.id);
+    expect(anonConns).not.toContain(connA.id);
+    expect(anonConns).not.toContain(connB.id);
+
+    // feeds inherit their connection's visibility (each test connection auto-
+    // creates a default feed). userA must not enumerate userB's private feeds.
+    const aFeeds = await feedConnIdsVisibleTo(org.id, userA.id);
+    expect(aFeeds).toContain(connA.id);
+    expect(aFeeds).toContain(connOrg.id);
+    expect(aFeeds).not.toContain(connB.id);
+
+    const anonFeeds = await feedConnIdsVisibleTo(org.id, null);
+    expect(anonFeeds).toContain(connOrg.id);
+    expect(anonFeeds).not.toContain(connA.id);
+    expect(anonFeeds).not.toContain(connB.id);
+  });
+});

--- a/packages/server/src/__tests__/integration/metrics/run-metric-user-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/metrics/run-metric-user-visibility.test.ts
@@ -1,0 +1,141 @@
+/**
+ * M0 deny-test for the metric path (query_metric → runMetric → validateAndScopeQuery).
+ * runMetric compiles a declared measure over `events` and runs it through the
+ * SAME buildScopedQuery seam as query_sql/client.query, so per-user connection
+ * visibility must hold here too: a member charting a metric can't count another
+ * user's PRIVATE-connection events.
+ *
+ * This guards the regression "a wrapper forgot to forward userId": runMetric is
+ * a distinct input type (`userId` field) from the inline `ctx.userId` callers,
+ * so it's the easiest to drop. Seeds two users with private connections + one
+ * org-visible connection, all feeding identical aliased transactions, and
+ * asserts the per-user COUNT through the real aggregation path.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { TestApiClient } from '../../setup/test-mcp-client';
+import { runMetric } from '../../../metrics/run-metric';
+
+const METRICS = {
+  eventSets: {
+    txns: {
+      by: 'alias',
+      field: "metadata->>'description'",
+      against: 'aliases',
+      where: "semantic_type='transaction' AND connector_key='revolut'",
+    },
+  },
+  measures: {
+    txn_count: {
+      eventSet: 'txns',
+      agg: 'count',
+      description: 'Number of matched transactions.',
+    },
+  },
+};
+
+describe('runMetric — per-user connection visibility (M0 deny-test)', () => {
+  let orgId: string;
+  let userAId: string;
+  let userBId: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Metric Visibility Org' });
+    orgId = org.id;
+
+    const userA = await createTestUser({ email: 'metric-vis-a@test.com' });
+    const userB = await createTestUser({ email: 'metric-vis-b@test.com' });
+    userAId = userA.id;
+    userBId = userB.id;
+    await addUserToOrganization(userA.id, org.id, 'owner');
+    await addUserToOrganization(userB.id, org.id, 'owner');
+
+    const owner = await TestApiClient.for({
+      organizationId: org.id,
+      userId: userA.id,
+      memberRole: 'owner',
+    });
+    await owner.entity_schema.createType({
+      slug: 'vendor',
+      name: 'Vendor',
+      metrics_config: METRICS,
+    });
+
+    const vendor = await createTestEntity({
+      name: 'Acme',
+      entity_type: 'vendor',
+      organization_id: orgId,
+    });
+    const sql = getTestDb();
+    await sql`
+      UPDATE entities SET metadata = ${sql.json({ aliases: ['Acme'] })}
+      WHERE id = ${vendor.id}
+    `;
+
+    const connA = await createTestConnection({
+      organization_id: orgId,
+      connector_key: 'revolut',
+      created_by: userA.id,
+      visibility: 'private',
+    });
+    const connB = await createTestConnection({
+      organization_id: orgId,
+      connector_key: 'revolut',
+      created_by: userB.id,
+      visibility: 'private',
+    });
+    const connOrg = await createTestConnection({
+      organization_id: orgId,
+      connector_key: 'revolut',
+      visibility: 'org',
+    });
+
+    // One identical aliased transaction per connection. Per-user filtering — not
+    // the alias matcher — is what must differentiate the counts.
+    const txn = (connectionId: number) =>
+      createTestEvent({
+        organization_id: orgId,
+        connection_id: connectionId,
+        content: 'charge',
+        semantic_type: 'transaction',
+        connector_key: 'revolut',
+        metadata: { description: 'Acme', amount: 10, direction: 'out' },
+      });
+    await txn(connA.id);
+    await txn(connB.id);
+    await txn(connOrg.id);
+  });
+
+  const count = async (userId: string | null): Promise<number> => {
+    const rows = await runMetric({
+      organizationId: orgId,
+      entityType: 'vendor',
+      measure: 'txn_count',
+      userId,
+    });
+    // No `by`, so a single aggregate row.
+    return rows.length ? Number(rows[0].txn_count) : 0;
+  };
+
+  it('counts userA own-private + org, never userB private', async () => {
+    expect(await count(userAId)).toBe(2);
+  });
+
+  it('counts userB own-private + org, never userA private', async () => {
+    expect(await count(userBId)).toBe(2);
+  });
+
+  it('headless (no user) counts org-visible only — fails closed on private', async () => {
+    expect(await count(null)).toBe(1);
+  });
+});

--- a/packages/server/src/__tests__/unit/scoped-query-user-visibility.test.ts
+++ b/packages/server/src/__tests__/unit/scoped-query-user-visibility.test.ts
@@ -1,0 +1,69 @@
+/**
+ * S0 spike: the events CTE in `buildScopedQuery` (query_sql / metrics /
+ * watchers / client.query) must intersect with PER-USER connection visibility,
+ * not just org scope — otherwise a multi-user agent's `client.query` can read
+ * another user's private-connection events. The content-search/recall seams
+ * already apply `buildConnectionVisibilityClause`; this pins that the
+ * buildScopedQuery seam does too.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { buildScopedQuery } from '../../utils/execute-data-sources';
+
+describe('buildScopedQuery events CTE — per-user connection visibility (S0)', () => {
+  it('restricts connection-sourced events to the requesting user (visibility=org OR created_by=user)', () => {
+    const { sql, params } = buildScopedQuery('SELECT * FROM events', ['events'], {
+      organizationId: 'org_test',
+      userId: 'user_a',
+    });
+
+    // The events CTE must intersect with connection visibility, not just org scope.
+    expect(sql).toContain("vc.visibility = 'org'");
+    expect(sql).toContain('vc.created_by');
+
+    // The requesting user is bound as a param so private connections created by
+    // OTHER users are excluded.
+    expect(params).toContain('user_a');
+  });
+
+  it('still emits org scope when no userId is provided (no regression)', () => {
+    const { sql } = buildScopedQuery('SELECT * FROM events', ['events'], {
+      organizationId: 'org_test',
+    });
+    expect(sql).toContain('ev.organization_id');
+  });
+
+  it('gates event_classifications too (excerpts carry verbatim source text)', () => {
+    // The EXISTS over `ev` must apply the same per-user connection visibility,
+    // else a member reads classifications of another user's private events.
+    const { sql, params } = buildScopedQuery(
+      'SELECT excerpts FROM event_classifications',
+      ['event_classifications'],
+      { organizationId: 'org_test', userId: 'user_a' }
+    );
+    expect(sql).toContain('ev.connection_id');
+    expect(sql).toContain("vc.visibility = 'org'");
+    expect(params).toContain('user_a');
+  });
+
+  it('gates the connections row itself (private-connection metadata)', () => {
+    const { sql, params } = buildScopedQuery(
+      'SELECT display_name FROM connections',
+      ['connections'],
+      { organizationId: 'org_test', userId: 'user_a' }
+    );
+    expect(sql).toContain("cn.visibility = 'org'");
+    expect(sql).toContain('cn.created_by');
+    expect(params).toContain('user_a');
+  });
+
+  it('gates feeds via their owning connection (connection_id NOT NULL)', () => {
+    const { sql, params } = buildScopedQuery('SELECT config FROM feeds', ['feeds'], {
+      organizationId: 'org_test',
+      userId: 'user_a',
+    });
+    expect(sql).toContain('fd.connection_id');
+    expect(sql).toContain("vc.visibility = 'org'");
+    expect(params).toContain('user_a');
+  });
+});

--- a/packages/server/src/metrics/run-metric.ts
+++ b/packages/server/src/metrics/run-metric.ts
@@ -26,6 +26,12 @@ interface RunMetricInput {
   segment?: string;
   /** Restrict to one entity (entities.id). */
   entityId?: number;
+  /**
+   * The requesting user, threaded into the events CTE for per-user connection
+   * visibility. Omit/null for headless callers (scheduled rollups, warehouse
+   * jobs) — yields org-visible-only, fail-closed for private-connection data.
+   */
+  userId?: string | null;
 }
 
 export async function runMetric(input: RunMetricInput): Promise<Record<string, unknown>[]> {
@@ -52,7 +58,9 @@ export async function runMetric(input: RunMetricInput): Promise<Record<string, u
     segment: input.segment,
     entityId: input.entityId,
   });
-  const scoped = validateAndScopeQuery(rawSql, input.organizationId);
+  const scoped = validateAndScopeQuery(rawSql, input.organizationId, {
+    userId: input.userId ?? null,
+  });
 
   const rows = await sql.begin(async (tx: typeof sql) => {
     await tx`SET TRANSACTION READ ONLY`;

--- a/packages/server/src/sandbox/client-sdk.ts
+++ b/packages/server/src/sandbox/client-sdk.ts
@@ -227,7 +227,9 @@ export function buildClientSDK(
 				import("../db/client"),
 				import("../utils/execute-data-sources"),
 			]);
-			const scoped = validateAndScopeQuery(querySql, ctx.organizationId);
+			const scoped = validateAndScopeQuery(querySql, ctx.organizationId, {
+				userId: ctx.userId,
+			});
 			const rows = await raceAbort(
 				getDb().begin(async (tx) => {
 					await tx.unsafe("SET TRANSACTION READ ONLY");

--- a/packages/server/src/tools/admin/metric_series.ts
+++ b/packages/server/src/tools/admin/metric_series.ts
@@ -76,6 +76,9 @@ async function metricSeriesImpl(
     // `connections` can't pull credential columns the allowlist withholds.
     safeColumns: SAFE_COLUMN_DEFS,
     restrictedTables: isAdmin ? undefined : ADMIN_ONLY_QUERYABLE_TABLES,
+    // Charts are filtered to the requesting user's connection visibility, so a
+    // member can't sparkline another user's private-connection events.
+    userId: ctx.userId,
   });
   const db = getDb();
 

--- a/packages/server/src/tools/admin/query_metric.ts
+++ b/packages/server/src/tools/admin/query_metric.ts
@@ -51,6 +51,7 @@ async function queryMetricImpl(
     by: args.by,
     segment: args.segment,
     entityId: args.entity_id,
+    userId: ctx.userId,
   });
   return { rows, row_count: rows.length };
 }

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -268,6 +268,10 @@ export async function querySqlImpl(
     const scoped = validateAndScopeQuery(baseSql, targetOrgId, {
       safeColumns: SAFE_COLUMN_DEFS,
       restrictedTables: callerIsAdmin ? undefined : ADMIN_ONLY_QUERYABLE_TABLES,
+      // Per-user connection visibility: even an admin sees another user's
+      // PRIVATE-connection events only when org-visible. Cross-org reuses the
+      // same global user id, re-validated against the target org above.
+      userId: ctx.userId,
     });
     scopedSql = scoped.sql;
     params = scoped.params;

--- a/packages/server/src/utils/content-search/visibility.ts
+++ b/packages/server/src/utils/content-search/visibility.ts
@@ -93,7 +93,7 @@ export function buildConnectionVisibilityClause(
   const userParam = `$${options.baseParamIndex + 1}::text`;
   return {
     sql: `AND (${tableAlias}.connection_id IS NULL OR ${tableAlias}.connection_id IN (
-      SELECT vc.id FROM connections vc
+      SELECT vc.id FROM public.connections vc
       WHERE vc.organization_id = ${orgParam}
         AND vc.deleted_at IS NULL
         AND (vc.visibility = 'org' OR (${userParam} IS NOT NULL AND vc.created_by = ${userParam}))

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -18,6 +18,7 @@
 import { Dialect, ast, parse as parseSql } from '@polyglot-sql/sdk';
 import type { DbClient } from '../db/client';
 import logger from './logger';
+import { buildConnectionVisibilityClause } from './content-search/visibility';
 import {
   ADMIN_ONLY_QUERYABLE_TABLES,
   buildColumnList,
@@ -35,6 +36,13 @@ export type DataSourceInput =
 
 export interface DataSourceContext {
   organizationId: string;
+  /**
+   * The requesting user. When set, the events CTE additionally intersects with
+   * per-user connection visibility (visibility='org' OR created_by=userId) so
+   * query_sql / metrics / client.query don't leak other users' private-connection
+   * data — matching what search_memory/get_content already enforce.
+   */
+  userId?: string | null;
   /** When set, events CTE filters to events belonging to any of these entities */
   entityIds?: number[];
   query?: Record<string, string>;
@@ -304,6 +312,13 @@ export function validateAndScopeQuery(
      * metric_series. Omit for admin / server-internal callers (full access).
      */
     restrictedTables?: ReadonlySet<string>;
+    /**
+     * The requesting user. Threaded into the events CTE so connection-sourced
+     * rows are filtered to org-visible connections or this user's own private
+     * ones (per-user visibility). Omit for service/headless callers — null
+     * yields org-visible-only (fail-closed for private data).
+     */
+    userId?: string | null;
   }
 ): { sql: string; params: unknown[] } {
   const trimmed = rawSql.trim();
@@ -344,7 +359,12 @@ export function validateAndScopeQuery(
     }
   }
 
-  return buildScopedQuery(trimmed, tableRefs, { organizationId }, options);
+  return buildScopedQuery(
+    trimmed,
+    tableRefs,
+    { organizationId, userId: options?.userId ?? null },
+    options
+  );
 }
 
 // ============================================
@@ -357,7 +377,7 @@ export function validateAndScopeQuery(
  * Core tables get predefined scoping patterns. Unknown table names are
  * treated as entity_type slugs (filtered from the entities table).
  */
-function buildScopedQuery(
+export function buildScopedQuery(
   userQuery: string,
   tableRefs: string[],
   context: DataSourceContext,
@@ -370,6 +390,39 @@ function buildScopedQuery(
   idx++;
   params.push(context.organizationId);
   const orgP = `$${idx}`;
+
+  // Per-user connection visibility (S0). Applied to EVERY CTE on this seam that
+  // exposes connection-sourced event content — `events`, `event_classifications`
+  // (whose `excerpts` is verbatim source text), and `connections` — so query_sql
+  // / metrics / client.query never surface another user's private-connection data.
+  // This is the same gate search_memory/get_content already enforce. `userId`
+  // null (headless/service) yields org-visible-only, fail-closed for private data.
+
+  // For a table holding events (alias has a `connection_id` col): restrict to
+  // org-visible connections or the requesting user's own private ones.
+  const eventConnVisibility = (alias: string): string => {
+    const vis = buildConnectionVisibilityClause(
+      {
+        organizationId: context.organizationId,
+        userId: context.userId ?? null,
+        baseParamIndex: idx + 1,
+      },
+      alias
+    );
+    if (!vis.sql) return '';
+    params.push(...vis.params);
+    idx += vis.params.length;
+    return ` ${vis.sql}`;
+  };
+
+  // For the `connections` table itself: the row is visible when org-shared or
+  // owned by the requesting user (mirrors manage_connections CRUD).
+  const connectionRowVisibility = (alias: string): string => {
+    idx += 1;
+    params.push(context.userId ?? null);
+    const userP = `$${idx}::text`;
+    return ` AND (${alias}.visibility = 'org' OR (${userP} IS NOT NULL AND ${alias}.created_by = ${userP}))`;
+  };
 
   // {{entityId}} substitution — only allocates a param when the query uses it
   let processedQuery = userQuery;
@@ -489,11 +542,22 @@ function buildScopedQuery(
         eventsCte += ` AND ev.occurred_at >= ${windowStartP}::timestamptz AND ev.occurred_at < ${windowEndP}::timestamptz`;
       }
 
+      eventsCte += eventConnVisibility('ev');
+
       eventsCte += ')';
       ctes.push(eventsCte);
     } else if (table === 'connections') {
+      // A private connection's own row (display_name, account_id, config) is
+      // per-user too — mirror manage_connections CRUD so a member can't read
+      // another user's private-connection metadata via raw SQL.
+      // Soft-deleted rows are intentionally NOT excluded here — query_sql is an
+      // audit/debug surface and there's no cross-user leak (a deleted private
+      // connection still carries created_by, so the visibility predicate blocks
+      // it). The per-user predicate is the security boundary.
       ctes.push(
-        `"${safeName}" AS (SELECT ${sel(table)} FROM public.connections WHERE organization_id = ${orgP})`
+        `"${safeName}" AS (SELECT ${sel(table, 'cn')} FROM public.connections cn WHERE cn.organization_id = ${orgP}` +
+          connectionRowVisibility('cn') +
+          ')'
       );
     } else if (table === 'watchers') {
       // security-allowed: see block comment above the for-loop
@@ -504,11 +568,19 @@ function buildScopedQuery(
       );
     } else if (table === 'event_classifications') {
       // security-allowed: see block comment above the for-loop
+      // `excerpts`/`values`/`reasoning` carry verbatim source-event content, so
+      // the EXISTS must apply per-user connection visibility on `ev` — otherwise
+      // any member reads classifications of another user's private-connection
+      // events (the same leak the events CTE closes, on the joined table).
+      // Use current_event_records (not public.events) for tombstone parity with
+      // the events CTE — a superseded event's classifications shouldn't surface.
       ctes.push(
         `"${safeName}" AS (SELECT ${sel(table, 'ec')} FROM public.event_classifications ec WHERE EXISTS (` +
-          'SELECT 1 FROM public.events ev ' +
+          'SELECT 1 FROM public.current_event_records ev ' +
           'JOIN public.entities ent ON ent.id = ANY(ev.entity_ids) ' +
-          `WHERE ev.id = ec.event_id AND ent.organization_id = ${orgP}))`
+          `WHERE ev.id = ec.event_id AND ent.organization_id = ${orgP}` +
+          eventConnVisibility('ev') +
+          '))'
       );
     } else if (table === 'watcher_versions') {
       // security-allowed: see block comment above the for-loop
@@ -541,8 +613,13 @@ function buildScopedQuery(
           `WHERE m."organizationId" = ${orgP})`
       );
     } else if (table === 'feeds') {
+      // Every feed derives from a connection (`connection_id` NOT NULL), so a
+      // private connection's feeds (display_name, config, last_error) are
+      // per-user too — gate via the owning connection's visibility.
       ctes.push(
-        `"${safeName}" AS (SELECT ${sel(table)} FROM public.feeds WHERE organization_id = ${orgP})`
+        `"${safeName}" AS (SELECT ${sel(table, 'fd')} FROM public.feeds fd WHERE fd.organization_id = ${orgP}` +
+          eventConnVisibility('fd') +
+          ')'
       );
     } else if (table === 'connector_definitions') {
       ctes.push(


### PR DESCRIPTION
## What

The SQL scoping seam (`buildScopedQuery` — used by `query_sql`, `metric_series`, `query_metric`/`runMetric`, and the admin-gated `client.query`) scoped `events` by **org only**. The content-search/recall seams (`search_memory`, `get_content`) already apply **per-user connection visibility**, so an agent's SQL path could read another user's **private-connection** data that the recall path would hide.

This threads the requesting `userId` through every SQL caller and applies the per-user connection-visibility gate to **all connection-bearing CTEs** on the seam.

## The guarantee

An agent reads within its org scope, but connection-sourced data never reaches a user beyond what that user can access — `connections.visibility ∈ {'org','private'}` (default `'org'`), a `private` connection's data belongs to its `created_by` user. `userId` null (headless/service) ⇒ org-visible-only, **fail-closed**. Admins are **not** exempt: a Lobu org-admin is not an admin in a user's private source system (Slack/bank), so the privacy boundary is per-user regardless of Lobu role.

## CTEs gated

| CTE | Before | After |
|---|---|---|
| `events` | org-only (the leak) | per-user connection visibility |
| `event_classifications` | org-only — leaked verbatim `excerpts` | gated inside the `EXISTS` on `ev`; reads `current_event_records` for tombstone parity |
| `connections` | org-only | row-level visibility (`visibility='org' OR created_by`), mirrors `manage_connections` CRUD |
| `feeds` | org-only — leaked private-conn feeds | gated via owning connection (`connection_id` NOT NULL) |

Two shared helpers (`eventConnVisibility` / `connectionRowVisibility`) centralize the param-index math.

Callers threaded: `client.query`, `query_sql`, `metric_series`, `query_metric`→`runMetric`.

## Tests (real embedded Postgres, all green)

- **Unit:** shape gates for events / event_classifications / connections / feeds + the 72-test bypass-prevention suite.
- **Integration:** real-row per-user isolation for events, connections, and feeds (userA sees own-private + org, never another user's private; headless = org-only); `runMetric` aggregation (userA=2, userB=2, headless=1).
- **Regression:** query-tool MCP e2e + client-sdk-org + metrics/connections seams.

## Scope / deferrals

This is **M0** of the authorization foundation: per-user visibility on the live-read SQL seam, at parity with what content-search already enforces. Derived-content provenance (`watcher_windows.content_analyzed`/`extracted_data`, null-connection derivations) is explicitly deferred to **M7** (egress/provenance) — those lose connection lineage and are not live-read parity.

## Review notes

Two adversarial review rounds (GLM-5.2) drove this: round 1 found the `event_classifications.excerpts` leak (P0) and the `connections` metadata leak; round 2 found the `feeds` leak. All three are fixed and have deny-tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785008451&installation_id=136316292&pr_number=1574&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1574&signature=34e98ee9f5dfef15c9a92b4bd8746802b98ac161a81e7ccb095af70a15fd6333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Query results now respect the requesting user’s connection visibility, so private data from other users stays hidden while org-visible data remains accessible.
  * Metric runs and SQL-based queries now apply the same user-aware visibility rules, including for feed- and connection-derived results.
  * Access without a user now safely returns only org-visible data.

* **Tests**
  * Added integration and unit coverage for per-user visibility across events, connections, feeds, and metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->