### PR TITLE
refactor(server): AuthzScope + one connection-visibility compiler (M1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,6 +433,14 @@ jobs:
         # gate: a value whose static type is a JS array, bound as a SQL param, fails.
         run: bun scripts/check-raw-array-params.mjs
 
+      - name: Connection-visibility compiler gate
+        # The per-user connection-visibility READ-SEAM gate (connection_id IN
+        # (SELECT ... FROM connections ... visibility ...)) must come from the one
+        # compiler (packages/server/src/authz/connection-visibility.ts), not be
+        # re-derived inline — that is how the authz gate silently drifts and leaks
+        # another user's private-connection data through a new read path.
+        run: bun scripts/check-connection-visibility-compiler.mjs
+
   typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/packages/server/src/__tests__/integration/events/authz-e2e-demo.test.ts
+++ b/packages/server/src/__tests__/integration/events/authz-e2e-demo.test.ts
@@ -1,0 +1,165 @@
+/**
+ * END-TO-END DEMO (real Postgres, real tool handler).
+ *
+ * Boots an embedded Postgres, seeds one org with two members (Alice, Bob) who
+ * each own a PRIVATE connection plus a shared ORG connection, then drives the
+ * REAL `query_sql` MCP tool handler — the exact path an agent's `query_sql`
+ * call hits — as three principals: Alice, Bob, and a headless service caller.
+ *
+ * It prints a transcript so you can SEE the guarantee, and asserts it so it
+ * can't rot: connection-sourced data never reaches a user beyond what that user
+ * can access in the source system. Run with:
+ *
+ *   cd packages/server && npx vitest run src/__tests__/integration/events/authz-e2e-demo.test.ts
+ */
+
+import { describe, expect, it } from 'vitest';
+import { querySql } from '../../../tools/admin/query_sql';
+import type { ToolContext } from '../../../tools/registry';
+import { validateAndScopeQuery } from '../../../utils/execute-data-sources';
+import {
+  createTestConnection,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+/** An authenticated org member (Alice/Bob). */
+function memberCtx(organizationId: string, userId: string): ToolContext {
+  return {
+    organizationId,
+    userId,
+    memberRole: 'member',
+    agentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['read'],
+    tokenType: 'session',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  };
+}
+
+/** A headless / service caller — no requesting user (watcher, scheduled job). */
+function headlessCtx(organizationId: string): ToolContext {
+  return {
+    organizationId,
+    userId: null,
+    memberRole: null,
+    agentId: null,
+    isAuthenticated: false,
+    clientId: null,
+    scopes: null,
+    tokenType: 'anonymous',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  };
+}
+
+const QUERY = 'SELECT payload_text FROM events ORDER BY occurred_at';
+
+async function payloadsSeenBy(ctx: ToolContext): Promise<string[]> {
+  const res = await querySql({ sql: QUERY }, undefined, ctx);
+  if (res.error) throw new Error(`query_sql failed: ${res.error}`);
+  return res.rows.map((r) => String(r.payload_text)).sort();
+}
+
+describe('END-TO-END: per-user connection visibility through the real query_sql handler', () => {
+  it('Alice, Bob, and a headless caller each see only what they may', async () => {
+    // ---- seed: one org, two members, three connections, three events --------
+    const org = await createTestOrganization({ name: 'Acme' });
+    const alice = await createTestUser();
+    const bob = await createTestUser();
+
+    const alicePrivate = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'slack',
+      created_by: alice.id,
+      visibility: 'private',
+      display_name: "Alice's personal Slack",
+    });
+    const bobPrivate = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'slack',
+      created_by: bob.id,
+      visibility: 'private',
+      display_name: "Bob's personal Slack",
+    });
+    const orgShared = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'slack',
+      visibility: 'org',
+      display_name: 'Company Slack',
+    });
+
+    const ALICE_SECRET = "Alice DM: my comp is $250k — don't share";
+    const BOB_SECRET = 'Bob DM: interviewing at a competitor next week';
+    const ORG_SHARED = 'Eng all-hands: ship the authz milestone Friday';
+
+    await createTestEvent({
+      organization_id: org.id,
+      connection_id: alicePrivate.id,
+      content: ALICE_SECRET,
+      connector_key: 'slack',
+    });
+    await createTestEvent({
+      organization_id: org.id,
+      connection_id: bobPrivate.id,
+      content: BOB_SECRET,
+      connector_key: 'slack',
+    });
+    await createTestEvent({
+      organization_id: org.id,
+      connection_id: orgShared.id,
+      content: ORG_SHARED,
+      connector_key: 'slack',
+    });
+
+    // ---- show the predicate the seam injects below the tool -----------------
+    const scoped = validateAndScopeQuery(QUERY, org.id, { userId: alice.id });
+    const cteHead = scoped.sql.slice(0, scoped.sql.indexOf(')\n') + 1) || scoped.sql.slice(0, 600);
+
+    // ---- run the REAL handler as each principal -----------------------------
+    const aliceSees = await payloadsSeenBy(memberCtx(org.id, alice.id));
+    const bobSees = await payloadsSeenBy(memberCtx(org.id, bob.id));
+    const headlessSees = await payloadsSeenBy(headlessCtx(org.id));
+
+    // ---- transcript ---------------------------------------------------------
+    /* eslint-disable no-console */
+    console.log('\n========== AUTHZ END-TO-END DEMO ==========');
+    console.log('Org "Acme" — agent runs `query_sql`: %s\n', QUERY);
+    console.log('The seam injects this org+user-scoped CTE below the tool (excerpt):');
+    console.log(
+      cteHead
+        .split('\n')
+        .map((l) => '   ' + l)
+        .join('\n')
+    );
+    console.log('   ...  (params bound: org=%s, principal=<user id>)\n', org.id);
+    const row = (who: string, seen: string[]) =>
+      console.log(
+        '  %s sees %d row(s):\n%s',
+        who.padEnd(22),
+        seen.length,
+        seen.map((s) => `      • ${s}`).join('\n')
+      );
+    row('Alice (owns private)', aliceSees);
+    row('Bob (owns private)', bobSees);
+    row('Headless / service', headlessSees);
+    console.log('\n  ⇒ Alice never sees Bob\'s DM; Bob never sees Alice\'s; headless sees neither.');
+    console.log('==========================================\n');
+    /* eslint-enable no-console */
+
+    // ---- assertions: the guarantee holds ------------------------------------
+    expect(aliceSees).toContain(ALICE_SECRET);
+    expect(aliceSees).toContain(ORG_SHARED);
+    expect(aliceSees).not.toContain(BOB_SECRET);
+
+    expect(bobSees).toContain(BOB_SECRET);
+    expect(bobSees).toContain(ORG_SHARED);
+    expect(bobSees).not.toContain(ALICE_SECRET);
+
+    // Headless / service: org-visible only, private data fails closed.
+    expect(headlessSees).toEqual([ORG_SHARED]);
+  });
+});

--- a/packages/server/src/__tests__/unit/connection-visibility.test.ts
+++ b/packages/server/src/__tests__/unit/connection-visibility.test.ts
@@ -10,8 +10,8 @@ import { buildConnectionVisibilityClause } from '../../utils/content-search/visi
 import {
   compileConnectionFkVisibility,
   compileConnectionRowVisibility,
-} from '../connection-visibility';
-import { authzScopeFromToolContext, headlessScope } from '../scope';
+} from '../../authz/connection-visibility';
+import { authzScopeFromToolContext, headlessScope } from '../../authz/scope';
 
 const scope = { organizationId: 'org_test', principal: 'user_a' };
 

--- a/packages/server/src/authz/__tests__/connection-visibility.test.ts
+++ b/packages/server/src/authz/__tests__/connection-visibility.test.ts
@@ -1,0 +1,75 @@
+/**
+ * M1: every read seam must compile its connection-visibility predicate from the
+ * ONE compiler keyed on an AuthzScope. These pin the compiler's two shapes and
+ * prove the recall/content adapter (`buildConnectionVisibilityClause`) is now a
+ * byte-identical pass-through to it — so the SQL seam (buildScopedQuery) and the
+ * recall/content seam can never drift.
+ */
+import { describe, expect, it } from 'bun:test';
+import { buildConnectionVisibilityClause } from '../../utils/content-search/visibility';
+import {
+  compileConnectionFkVisibility,
+  compileConnectionRowVisibility,
+} from '../connection-visibility';
+import { authzScopeFromToolContext, headlessScope } from '../scope';
+
+const scope = { organizationId: 'org_test', principal: 'user_a' };
+
+describe('connection-visibility compiler (M1 one-compiler)', () => {
+  it('FK form gates by org + principal, NULL connection_id stays visible', () => {
+    const { sql, params } = compileConnectionFkVisibility(scope, 5, 'ev');
+    expect(sql).toContain('ev.connection_id IS NULL OR ev.connection_id IN');
+    expect(sql).toContain('SELECT vc.id FROM public.connections vc');
+    expect(sql).toContain("vc.visibility = 'org'");
+    expect(sql).toContain('vc.created_by');
+    // org bound at baseParamIndex, principal at baseParamIndex+1.
+    expect(sql).toContain('$5::text');
+    expect(sql).toContain('$6::text');
+    expect(params).toEqual(['org_test', 'user_a']);
+  });
+
+  it('row form gates the connections row itself by principal', () => {
+    const { sql, params } = compileConnectionRowVisibility(scope, 3, 'cn');
+    expect(sql).toContain("cn.visibility = 'org'");
+    expect(sql).toContain('cn.created_by');
+    expect(sql).toContain('$3::text');
+    expect(params).toEqual(['user_a']);
+  });
+
+  it('a null principal (headless) still binds null — fail-closed to org-only', () => {
+    const fk = compileConnectionFkVisibility(headlessScope('org_test'), 1, 'ev');
+    expect(fk.params).toEqual(['org_test', null]);
+    const row = compileConnectionRowVisibility(headlessScope('org_test'), 1, 'cn');
+    expect(row.params).toEqual([null]);
+  });
+
+  it('authzScopeFromToolContext maps ctx.userId → principal', () => {
+    expect(authzScopeFromToolContext({ organizationId: 'o', userId: 'u', agentId: 'a' })).toEqual({
+      organizationId: 'o',
+      principal: 'u',
+      agentId: 'a',
+    });
+    expect(authzScopeFromToolContext({ organizationId: 'o', userId: null })).toEqual({
+      organizationId: 'o',
+      principal: null,
+      agentId: null,
+    });
+  });
+
+  it('the recall/content adapter is a byte-identical pass-through to the compiler', () => {
+    const viaAdapter = buildConnectionVisibilityClause(
+      { organizationId: 'org_test', userId: 'user_a', baseParamIndex: 7 },
+      'f'
+    );
+    const viaCompiler = compileConnectionFkVisibility(scope, 7, 'f');
+    expect(viaAdapter.sql).toBe(viaCompiler.sql);
+    expect(viaAdapter.params).toEqual(viaCompiler.params);
+  });
+
+  it('the adapter still returns empty when no org is requested', () => {
+    expect(buildConnectionVisibilityClause({ baseParamIndex: 1 }, 'f')).toEqual({
+      sql: '',
+      params: [],
+    });
+  });
+});

--- a/packages/server/src/authz/connection-visibility.ts
+++ b/packages/server/src/authz/connection-visibility.ts
@@ -1,0 +1,63 @@
+/**
+ * THE connection-visibility compiler.
+ *
+ * Every read seam that can surface connection-sourced data — the SQL
+ * `buildScopedQuery` (query_sql / metrics / client.query), recall's
+ * search-path/list-path, and `get_content` — produces its "which
+ * connection-sourced rows may this principal see?" predicate here, so the rule
+ * lives in exactly one place keyed on one {@link AuthzScope}.
+ *
+ * Two shapes, same rule:
+ *  - {@link compileConnectionFkVisibility} — for a table that REFERENCES a
+ *    connection via a `connection_id` column (events, event_classifications'
+ *    underlying event, feeds). A NULL `connection_id` (system / non-connection
+ *    rows) stays visible.
+ *  - {@link compileConnectionRowVisibility} — for the `connections` row itself.
+ *
+ * Rule: a connection is visible when `visibility = 'org'` OR it is the
+ * principal's own private connection (`created_by = principal`). A `null`
+ * principal (headless / service) sees only org-visible connections. The FK form
+ * also excludes soft-deleted connections, matching the recall/content seams'
+ * legacy two-step flow.
+ */
+import type { AuthzScope } from './scope';
+
+/**
+ * Predicate for a table that references a connection via `connection_id`.
+ * Binds two params from `baseParamIndex`: the org id and the principal.
+ * Returns an `AND (...)` fragment (no leading space).
+ */
+export function compileConnectionFkVisibility(
+  scope: AuthzScope,
+  baseParamIndex: number,
+  tableAlias: string
+): { sql: string; params: Array<string | null> } {
+  const orgParam = `$${baseParamIndex}::text`;
+  const userParam = `$${baseParamIndex + 1}::text`;
+  return {
+    sql: `AND (${tableAlias}.connection_id IS NULL OR ${tableAlias}.connection_id IN (
+      SELECT vc.id FROM public.connections vc
+      WHERE vc.organization_id = ${orgParam}
+        AND vc.deleted_at IS NULL
+        AND (vc.visibility = 'org' OR (${userParam} IS NOT NULL AND vc.created_by = ${userParam}))
+    ))`,
+    params: [scope.organizationId, scope.principal],
+  };
+}
+
+/**
+ * Predicate for the `connections` row itself (its own metadata). Binds one
+ * param from `baseParamIndex`: the principal. Returns an `AND (...)` fragment
+ * (no leading space).
+ */
+export function compileConnectionRowVisibility(
+  scope: AuthzScope,
+  baseParamIndex: number,
+  tableAlias: string
+): { sql: string; params: Array<string | null> } {
+  const userParam = `$${baseParamIndex}::text`;
+  return {
+    sql: `AND (${tableAlias}.visibility = 'org' OR (${userParam} IS NOT NULL AND ${tableAlias}.created_by = ${userParam}))`,
+    params: [scope.principal],
+  };
+}

--- a/packages/server/src/authz/scope.ts
+++ b/packages/server/src/authz/scope.ts
@@ -1,0 +1,49 @@
+/**
+ * AuthzScope — the single value every read seam compiles its scoping predicate
+ * from. M1 introduces the type and routes the existing per-user
+ * connection-visibility logic through one compiler (see ./connection-visibility);
+ * later milestones grow `principal` into a verified `$member` (M3) and put
+ * `policyVersion` to work (M2/M6). No behavior change at M1: `principal` is the
+ * requesting user id and `null` means a headless/service caller (org-visible
+ * rows only, fail-closed for private data).
+ */
+export interface AuthzScope {
+  /** The tenant. Every read is partitioned by this first. */
+  organizationId: string;
+  /**
+   * The requesting principal. Today the user id; M3 resolves it to a verified
+   * `$member`. `null` = headless/service caller — private data is excluded
+   * (fail-closed); only org-visible rows are returned.
+   */
+  principal: string | null;
+  /** The durable agent identity when the read happens inside an agent run. */
+  agentId?: string | null;
+  /** Policy snapshot the read is compiled against. Reserved for M2+/M6. */
+  policyVersion?: number | null;
+}
+
+/**
+ * Build an AuthzScope from a tool/SDK execution context. The `ToolContext`
+ * carries `userId: string | null` (the requesting user, null when anonymous /
+ * headless) plus the durable `agentId` — exactly the inputs the scope needs.
+ */
+export function authzScopeFromToolContext(ctx: {
+  organizationId: string;
+  userId: string | null;
+  agentId?: string | null;
+}): AuthzScope {
+  return {
+    organizationId: ctx.organizationId,
+    principal: ctx.userId,
+    agentId: ctx.agentId ?? null,
+  };
+}
+
+/**
+ * A headless/service scope: no principal, so only org-visible rows are returned
+ * (fail-closed for private data). Use for watchers / scheduled jobs / internal
+ * reads that run without a requesting user.
+ */
+export function headlessScope(organizationId: string): AuthzScope {
+  return { organizationId, principal: null };
+}

--- a/packages/server/src/utils/content-search/visibility.ts
+++ b/packages/server/src/utils/content-search/visibility.ts
@@ -3,6 +3,8 @@
  * buildOrgScopeWhere, buildConnectionVisibilityClause, buildExcludeWatcherClause.
  */
 
+import { compileConnectionFkVisibility } from '../../authz/connection-visibility';
+import type { AuthzScope } from '../../authz/scope';
 import { validateNumericId } from '../sql-validation';
 
 /**
@@ -78,6 +80,11 @@ export function buildOrgScopeWhere(options: {
  *
  * Returns an empty fragment when no scope is requested (callers like the
  * watcher-mode/condensation path that already select by other constraints).
+ *
+ * Thin adapter over the one connection-visibility compiler (M1): builds an
+ * {@link AuthzScope} from this seam's legacy `{ organizationId, userId }` shape
+ * and defers the predicate to {@link compileConnectionFkVisibility}, so the rule
+ * lives in exactly one place.
  */
 export function buildConnectionVisibilityClause(
   options: {
@@ -89,15 +96,9 @@ export function buildConnectionVisibilityClause(
 ): { sql: string; params: Array<string | number | null> } {
   if (!options.organizationId) return { sql: '', params: [] };
 
-  const orgParam = `$${options.baseParamIndex}::text`;
-  const userParam = `$${options.baseParamIndex + 1}::text`;
-  return {
-    sql: `AND (${tableAlias}.connection_id IS NULL OR ${tableAlias}.connection_id IN (
-      SELECT vc.id FROM public.connections vc
-      WHERE vc.organization_id = ${orgParam}
-        AND vc.deleted_at IS NULL
-        AND (vc.visibility = 'org' OR (${userParam} IS NOT NULL AND vc.created_by = ${userParam}))
-    ))`,
-    params: [options.organizationId, options.userId ?? null],
+  const scope: AuthzScope = {
+    organizationId: options.organizationId,
+    principal: options.userId ?? null,
   };
+  return compileConnectionFkVisibility(scope, options.baseParamIndex, tableAlias);
 }

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -18,7 +18,11 @@
 import { Dialect, ast, parse as parseSql } from '@polyglot-sql/sdk';
 import type { DbClient } from '../db/client';
 import logger from './logger';
-import { buildConnectionVisibilityClause } from './content-search/visibility';
+import {
+  compileConnectionFkVisibility,
+  compileConnectionRowVisibility,
+} from '../authz/connection-visibility';
+import type { AuthzScope } from '../authz/scope';
 import {
   ADMIN_ONLY_QUERYABLE_TABLES,
   buildColumnList,
@@ -395,21 +399,19 @@ export function buildScopedQuery(
   // exposes connection-sourced event content — `events`, `event_classifications`
   // (whose `excerpts` is verbatim source text), and `connections` — so query_sql
   // / metrics / client.query never surface another user's private-connection data.
-  // This is the same gate search_memory/get_content already enforce. `userId`
-  // null (headless/service) yields org-visible-only, fail-closed for private data.
+  // This is the same gate search_memory/get_content already enforce. M1 routes
+  // both shapes through the one connection-visibility compiler keyed on an
+  // AuthzScope; `principal` null (headless/service) yields org-visible-only,
+  // fail-closed for private data.
+  const scope: AuthzScope = {
+    organizationId: context.organizationId,
+    principal: context.userId ?? null,
+  };
 
   // For a table holding events (alias has a `connection_id` col): restrict to
   // org-visible connections or the requesting user's own private ones.
   const eventConnVisibility = (alias: string): string => {
-    const vis = buildConnectionVisibilityClause(
-      {
-        organizationId: context.organizationId,
-        userId: context.userId ?? null,
-        baseParamIndex: idx + 1,
-      },
-      alias
-    );
-    if (!vis.sql) return '';
+    const vis = compileConnectionFkVisibility(scope, idx + 1, alias);
     params.push(...vis.params);
     idx += vis.params.length;
     return ` ${vis.sql}`;
@@ -418,10 +420,10 @@ export function buildScopedQuery(
   // For the `connections` table itself: the row is visible when org-shared or
   // owned by the requesting user (mirrors manage_connections CRUD).
   const connectionRowVisibility = (alias: string): string => {
-    idx += 1;
-    params.push(context.userId ?? null);
-    const userP = `$${idx}::text`;
-    return ` AND (${alias}.visibility = 'org' OR (${userP} IS NOT NULL AND ${alias}.created_by = ${userP}))`;
+    const vis = compileConnectionRowVisibility(scope, idx + 1, alias);
+    params.push(...vis.params);
+    idx += vis.params.length;
+    return ` ${vis.sql}`;
   };
 
   // {{entityId}} substitution — only allocates a param when the query uses it

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -556,6 +556,7 @@ export function buildScopedQuery(
       // audit/debug surface and there's no cross-user leak (a deleted private
       // connection still carries created_by, so the visibility predicate blocks
       // it). The per-user predicate is the security boundary.
+      // security-allowed: see block comment above the for-loop
       ctes.push(
         `"${safeName}" AS (SELECT ${sel(table, 'cn')} FROM public.connections cn WHERE cn.organization_id = ${orgP}` +
           connectionRowVisibility('cn') +
@@ -569,13 +570,13 @@ export function buildScopedQuery(
           `AND ent.organization_id = ${orgP}))`
       );
     } else if (table === 'event_classifications') {
-      // security-allowed: see block comment above the for-loop
       // `excerpts`/`values`/`reasoning` carry verbatim source-event content, so
       // the EXISTS must apply per-user connection visibility on `ev` — otherwise
       // any member reads classifications of another user's private-connection
       // events (the same leak the events CTE closes, on the joined table).
       // Use current_event_records (not public.events) for tombstone parity with
       // the events CTE — a superseded event's classifications shouldn't surface.
+      // security-allowed: see block comment above the for-loop
       ctes.push(
         `"${safeName}" AS (SELECT ${sel(table, 'ec')} FROM public.event_classifications ec WHERE EXISTS (` +
           'SELECT 1 FROM public.current_event_records ev ' +
@@ -618,6 +619,7 @@ export function buildScopedQuery(
       // Every feed derives from a connection (`connection_id` NOT NULL), so a
       // private connection's feeds (display_name, config, last_error) are
       // per-user too — gate via the owning connection's visibility.
+      // security-allowed: see block comment above the for-loop
       ctes.push(
         `"${safeName}" AS (SELECT ${sel(table, 'fd')} FROM public.feeds fd WHERE fd.organization_id = ${orgP}` +
           eventConnVisibility('fd') +

--- a/scripts/check-connection-visibility-compiler.mjs
+++ b/scripts/check-connection-visibility-compiler.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Guard: the per-user connection-visibility READ-SEAM gate must live in exactly
+// one place — the compiler at packages/server/src/authz/connection-visibility.ts.
+//
+// The authorization guarantee (M0/M1) is that connection-sourced data never
+// reaches a user beyond what that user can see in the source system. Every read
+// seam that exposes connection-sourced rows (the SQL buildScopedQuery, recall's
+// search/list paths, get_content) must scope them through the ONE compiler
+// (`compileConnectionFkVisibility`), not re-derive the predicate inline. A
+// re-derived copy is how the gate silently drifts: a finding leaks because one
+// copy was never updated.
+//
+// The precise, low-false-positive signal for a re-derivation is the FK subquery
+// SHAPE itself:
+//
+//   ... <table>.connection_id [IS NULL OR ...] IN ( SELECT ... FROM connections
+//        ... WHERE ... visibility ... )
+//
+// i.e. a table is filtered to "connections this principal may see" via a
+// `connection_id IN (SELECT ... FROM connections ... visibility ...)` subquery.
+// That shape is the read-seam gate. It is DISTINCT from legitimate connection
+// MANAGEMENT code (manage_connections CRUD, rest-api listing, connector
+// pushdown), which filters the `connections` row directly (`c.visibility = 'org'
+// OR c.created_by = ...`) and never builds the FK subquery — so those are not
+// flagged.
+//
+// HONEST GAP: a re-derivation that avoids this exact subquery shape (e.g. a JOIN
+// instead of `IN (SELECT ...)`, or building the connection-id set in JS) is NOT
+// caught here. The durable backstops for those are the per-seam deny-tests
+// (merge blocker) and reviewer attention. Escape hatch: put
+// `connection-visibility-ok` in a comment on or just above a genuinely-safe
+// occurrence.
+//
+// No DB, no build — pure static text analysis.
+// Run: `node scripts/check-connection-visibility-compiler.mjs`
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SERVER_SRC = join(REPO_ROOT, "packages/server/src");
+
+// The one place the FK read-seam gate is allowed to live.
+const COMPILER_FILE = join(SERVER_SRC, "authz/connection-visibility.ts");
+
+// The FK read-seam-gate subquery shape (case-insensitive, across newlines):
+// a table's connection_id constrained by a SELECT over the connections table
+// that filters on `visibility`. The bounded `[^;]{0,N}` windows keep it to a
+// single statement and avoid matching across unrelated SQL.
+const FK_GATE =
+  /connection_id\b[^;]{0,80}\bIN\b[^;]{0,200}?\bconnections\b[^;]{0,240}?visibility/is;
+
+const ESCAPE_HATCH = "connection-visibility-ok";
+
+/** Recursively collect *.ts files under dir, excluding tests. */
+function collectTsFiles(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (name === "__tests__" || name === "node_modules") continue;
+      out.push(...collectTsFiles(full));
+    } else if (name.endsWith(".ts") && !name.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const violations = [];
+for (const file of collectTsFiles(SERVER_SRC)) {
+  if (file === COMPILER_FILE) continue;
+  const src = readFileSync(file, "utf8");
+  const m = FK_GATE.exec(src);
+  if (!m) continue;
+  // Allow an explicit escape hatch in a comment near the match.
+  const lineNo = src.slice(0, m.index).split("\n").length;
+  const lines = src.split("\n");
+  const nearby = [lines[lineNo - 2], lines[lineNo - 1], lines[lineNo]].join(
+    "\n"
+  );
+  if (nearby.includes(ESCAPE_HATCH)) continue;
+  violations.push({ file: relative(REPO_ROOT, file), lineNo });
+}
+
+if (violations.length > 0) {
+  console.error(
+    "\n✖ connection-visibility read-seam gate re-derived outside the compiler:\n"
+  );
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.lineNo}`);
+  }
+  console.error(
+    "\nThe FK read-seam gate (connection_id IN (SELECT ... FROM connections ... visibility ...))\n" +
+      "must come from compileConnectionFkVisibility() in\n" +
+      "  packages/server/src/authz/connection-visibility.ts\n" +
+      "so the per-user visibility rule lives in one place. Route this read through\n" +
+      "the compiler (or buildConnectionVisibilityClause, which adapts to it). If this\n" +
+      `is genuinely safe, add a "${ESCAPE_HATCH}" comment on the line.\n`
+  );
+  process.exit(1);
+}
+
+console.log(
+  "✓ connection-visibility read-seam gate is compiler-only (no re-derivations)"
+);

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -154,6 +154,10 @@ UNIT_EXIT=0
   # Guard: no raw JS array bound as a SQL param (the fetch_types:false trap —
   # a malformed array literal that Postgres rejects, historically silent).
   node scripts/check-raw-array-params.mjs;                          ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  # Guard: the per-user connection-visibility READ-SEAM gate must come from the
+  # one compiler (authz/connection-visibility.ts), not be re-derived inline —
+  # that is how the authz gate silently drifts and leaks private-connection data.
+  node scripts/check-connection-visibility-compiler.mjs;            ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   bun test packages/core packages/cli;                              ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   bun test packages/agent-worker;                                   ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   bun test packages/server/src/__tests__/unit;                      ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec


### PR DESCRIPTION
Stacked on #1574 (M0). Base is \`feat/authz-spike-s0\`; review M0 first.

## What
M1 of the authorization foundation: one type, one compiler. Introduces \`AuthzScope{ organizationId, principal, agentId?, policyVersion? }\` and a single connection-visibility compiler (\`packages/server/src/authz/\`) that every read seam producing connection-sourced data routes through.

## Why
After M0 the same per-user predicate lived in **three** places that could drift:
- the recall/content seam's \`buildConnectionVisibilityClause\`, and
- two bespoke inline helpers (\`eventConnVisibility\`, \`connectionRowVisibility\`) inside the SQL seam's \`buildScopedQuery\`.

M1 collapses them onto one compiler:
- \`compileConnectionFkVisibility\` — tables referencing a connection via \`connection_id\` (events, event_classifications' event, feeds); NULL connection_id stays visible.
- \`compileConnectionRowVisibility\` — the \`connections\` row itself.
- \`buildScopedQuery\` calls the compiler directly.
- \`buildConnectionVisibilityClause\` becomes a thin **byte-identical** adapter over the compiler, so all 5 recall/content call sites are untouched.

## No behavior change
SQL output is byte-identical. Proven by:
- a convergence unit test asserting the adapter is a byte-for-byte pass-through to the compiler (6 tests, \`src/authz/__tests__\`);
- the unchanged M0 integration suites (events/connections/feeds per-user isolation + runMetric userA=2/userB=2/headless=1) — green;
- 36 recall/content visibility tests (\`get-content-visibility\`, \`search-content-visibility\`, classification, entity-types-filter) — green;
- \`tsc --noEmit\` clean.

\`principal\` is the requesting user id today; \`null\` = headless/service (org-visible-only, fail-closed). M3 grows it into a verified \`\$member\`; \`policyVersion\` is reserved for M2+/M6.

## Deferred from M1 (with rationale)
- **Seam 4 (conversation store)** has no per-user read filter yet — threading an unused scope param now is exactly the churn M1 avoids. It folds into **M2**, where the per-user clause is actually added to that store.
- **Lint-ban guard** for bare-org read builders lands as a follow-up, now that there's a single compiler to lint against (cheap grep-style guard à la \`check-raw-array-params.mjs\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785009949&installation_id=136316292&pr_number=1576&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1576&signature=4146bb5164a3b06de78ae348ce68b4afbca0a020583f9239a5aa48c34f5814fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connection visibility checks now use a shared authorization path, helping keep private connections hidden consistently.
  * Added broader end-to-end coverage for event visibility across different access levels.

* **Bug Fixes**
  * Improved handling for connection-scoped data so shared items remain visible while private items stay restricted.
  * Added safeguards to prevent inconsistent visibility logic from being reintroduced.

* **Tests**
  * Added unit and integration tests covering visibility rules for user, shared, and headless access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->