### PR TITLE
fix(server): guardrail validation, Slack DM binding, non-OIDC OAuth (+owletto cleanup)

### DIFF
--- a/packages/server/src/auth/__tests__/config.test.ts
+++ b/packages/server/src/auth/__tests__/config.test.ts
@@ -11,7 +11,9 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  buildGenericOAuthEntry,
   collectEnabledLoginProviderConfigs,
+  type EnabledLoginProviderConfig,
   getAuthConfig,
   getLoginProviderScopes,
   mergeLoginProviderConfigs,
@@ -216,5 +218,95 @@ describe('getAuthConfig', () => {
 
   it('should export getAuthConfig function', () => {
     expect(typeof getAuthConfig).toBe('function');
+  });
+});
+
+describe('non-OIDC login provider config (PKCE / basic-auth / extra params)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('collectEnabledLoginProviderConfigs threads usePkce, tokenEndpointAuthMethod and authParams', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const configs = collectEnabledLoginProviderConfigs([
+      {
+        key: 'custom.pkce',
+        auth_schema: {
+          methods: [
+            {
+              type: 'oauth',
+              provider: 'custompkce',
+              loginScopes: ['openid', 'email'],
+              authorizationUrl: 'https://idp.example.com/authorize',
+              tokenUrl: 'https://idp.example.com/token',
+              userinfoUrl: 'https://idp.example.com/userinfo',
+              tokenEndpointAuthMethod: 'client_secret_basic',
+              usePkce: true,
+              authParams: { prompt: 'consent', access_type: 'offline' },
+            },
+          ],
+        },
+      },
+    ]);
+    expect(configs).toHaveLength(1);
+    expect(configs[0]).toMatchObject({
+      provider: 'custompkce',
+      tokenEndpointAuthMethod: 'client_secret_basic',
+      usePkce: true,
+      authParams: { prompt: 'consent', access_type: 'offline' },
+    });
+  });
+
+  const baseRow: EnabledLoginProviderConfig = {
+    connectorKey: 'custom.pkce',
+    provider: 'custompkce',
+    loginScopes: ['openid', 'email'],
+    clientIdKey: 'CUSTOMPKCE_CLIENT_ID',
+    clientSecretKey: 'CUSTOMPKCE_CLIENT_SECRET',
+    authorizationUrl: 'https://idp.example.com/authorize',
+    tokenUrl: 'https://idp.example.com/token',
+    userinfoUrl: 'https://idp.example.com/userinfo',
+  };
+
+  it('buildGenericOAuthEntry threads pkce + basic authentication + authorizationUrlParams', () => {
+    const entry = buildGenericOAuthEntry(
+      {
+        ...baseRow,
+        tokenEndpointAuthMethod: 'client_secret_basic',
+        usePkce: true,
+        authParams: { prompt: 'consent' },
+      },
+      'cid',
+      'secret'
+    );
+    expect(entry).not.toBeNull();
+    expect(entry).toMatchObject({
+      providerId: 'custompkce',
+      clientId: 'cid',
+      clientSecret: 'secret',
+      authorizationUrl: 'https://idp.example.com/authorize',
+      tokenUrl: 'https://idp.example.com/token',
+      userInfoUrl: 'https://idp.example.com/userinfo',
+      scopes: ['openid', 'email'],
+      pkce: true,
+      authentication: 'basic',
+      authorizationUrlParams: { prompt: 'consent' },
+    });
+  });
+
+  it('maps client_secret_post → post and omits pkce/params when unset', () => {
+    const entry = buildGenericOAuthEntry(
+      { ...baseRow, tokenEndpointAuthMethod: 'client_secret_post' },
+      'cid',
+      'secret'
+    );
+    expect(entry?.authentication).toBe('post');
+    expect(entry).not.toHaveProperty('pkce');
+    expect(entry).not.toHaveProperty('authorizationUrlParams');
+  });
+
+  it('returns null (→ socialProviders route) when any endpoint is missing', () => {
+    const { userinfoUrl, ...noUserinfo } = baseRow;
+    expect(buildGenericOAuthEntry(noUserinfo, 'cid', 'secret')).toBeNull();
   });
 });

--- a/packages/server/src/auth/config.ts
+++ b/packages/server/src/auth/config.ts
@@ -29,7 +29,7 @@ type TokenEndpointAuthMethod =
 	| "client_secret_basic"
 	| "none";
 
-interface EnabledLoginProviderConfig {
+export interface EnabledLoginProviderConfig {
 	connectorKey: string;
 	provider: string;
 	loginScopes: string[];
@@ -39,6 +39,10 @@ interface EnabledLoginProviderConfig {
 	tokenUrl?: string;
 	userinfoUrl?: string;
 	tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
+	/** PKCE for non-OIDC / public-client OAuth2 flows. */
+	usePkce?: boolean;
+	/** Extra params merged into the authorization URL (e.g. `prompt`, `access_type`). */
+	authParams?: Record<string, string>;
 }
 
 interface AuthConfigOptions {
@@ -57,6 +61,8 @@ type OAuthMethod = {
 	tokenUrl?: string;
 	userinfoUrl?: string;
 	tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
+	usePkce?: boolean;
+	authParams?: Record<string, string>;
 	loginProvisioning?: {
 		autoCreateConnection?: boolean;
 	};
@@ -172,6 +178,11 @@ export function collectEnabledLoginProviderConfigs(
 				...(method.tokenEndpointAuthMethod && {
 					tokenEndpointAuthMethod: method.tokenEndpointAuthMethod,
 				}),
+				...(method.usePkce === true && { usePkce: true }),
+				...(method.authParams &&
+					typeof method.authParams === "object" && {
+						authParams: method.authParams,
+					}),
 			});
 		}
 	}
@@ -181,6 +192,88 @@ export function collectEnabledLoginProviderConfigs(
 
 function hasValue(value?: string): boolean {
 	return Boolean(value && value.trim().length > 0);
+}
+
+/**
+ * A self-describing OAuth login provider mapped onto Better Auth's
+ * provider-agnostic `genericOAuth` plugin config. Field names follow the
+ * plugin's `GenericOAuthConfig` (note `userInfoUrl` casing, `authentication`,
+ * `pkce`, `authorizationUrlParams`).
+ */
+export interface GenericOAuthEntry {
+	providerId: string;
+	clientId: string;
+	clientSecret: string;
+	authorizationUrl: string;
+	tokenUrl: string;
+	userInfoUrl: string;
+	scopes?: string[];
+	pkce?: boolean;
+	authentication?: "basic" | "post";
+	authorizationUrlParams?: Record<string, string>;
+	mapProfileToUser: (profile: Record<string, unknown>) => {
+		id: string;
+		email?: string;
+		name?: string;
+		image?: string;
+		emailVerified?: boolean;
+	};
+}
+
+function betterAuthTokenAuth(
+	method?: TokenEndpointAuthMethod,
+): "basic" | "post" | undefined {
+	if (method === "client_secret_basic") return "basic";
+	if (method === "client_secret_post") return "post";
+	// `none` (public client) has no client-secret auth — fall back to the
+	// plugin default and rely on PKCE; callers without a secret are filtered
+	// out upstream.
+	return undefined;
+}
+
+// Standard OIDC claim mapping — no provider special-casing. A self-describing
+// `userInfoUrl` (e.g. Slack's openid.connect.userInfo) returns `sub` (stable
+// user id) plus the usual email/name/picture claims.
+function mapOidcProfileToUser(profile: Record<string, unknown>) {
+	return {
+		id: String(profile.sub ?? ""),
+		email: typeof profile.email === "string" ? profile.email : undefined,
+		name: typeof profile.name === "string" ? profile.name : undefined,
+		image: typeof profile.picture === "string" ? profile.picture : undefined,
+		emailVerified: profile.email_verified === true,
+	};
+}
+
+/**
+ * Map a self-describing login provider onto a Better Auth `genericOAuth` entry,
+ * or `null` if it isn't self-describing (no authorize/token/userinfo endpoints —
+ * those route to the built-in `socialProviders` map instead). Threads the
+ * non-OIDC knobs (`usePkce`, `tokenEndpointAuthMethod`, `authParams`) through to
+ * the plugin so PKCE / basic-auth / extra-param providers can actually sign in.
+ */
+export function buildGenericOAuthEntry(
+	row: EnabledLoginProviderConfig,
+	clientId: string,
+	clientSecret: string,
+): GenericOAuthEntry | null {
+	if (!(row.authorizationUrl && row.tokenUrl && row.userinfoUrl)) return null;
+	const authentication = betterAuthTokenAuth(row.tokenEndpointAuthMethod);
+	return {
+		providerId: row.provider,
+		clientId,
+		clientSecret,
+		authorizationUrl: row.authorizationUrl,
+		tokenUrl: row.tokenUrl,
+		userInfoUrl: row.userinfoUrl,
+		...(row.loginScopes.length > 0 && { scopes: row.loginScopes }),
+		...(row.usePkce && { pkce: true }),
+		...(authentication && { authentication }),
+		...(row.authParams &&
+			Object.keys(row.authParams).length > 0 && {
+				authorizationUrlParams: row.authParams,
+			}),
+		mapProfileToUser: mapOidcProfileToUser,
+	};
 }
 
 const RESERVED_TOP_LEVEL_ROUTES = new Set([

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -37,6 +37,8 @@ import {
 import { TtlCache } from "../utils/ttl-cache";
 import { resolveBaseUrl, safeParseUrl } from "./base-url";
 import {
+	buildGenericOAuthEntry,
+	type GenericOAuthEntry,
 	getAuthConfig as getAuthConfigFromEnv,
 	getEnabledLoginProviderConfigs,
 	resolveLoginProviderCredentials,
@@ -120,22 +122,7 @@ export async function createAuth(
 		string,
 		{ clientId: string; clientSecret: string; scope?: string[] }
 	> = {};
-	const genericOAuthConfigs: Array<{
-		providerId: string;
-		clientId: string;
-		clientSecret: string;
-		authorizationUrl: string;
-		tokenUrl: string;
-		userInfoUrl: string;
-		scopes?: string[];
-		mapProfileToUser: (profile: Record<string, unknown>) => {
-			id: string;
-			email?: string;
-			name?: string;
-			image?: string;
-			emailVerified?: boolean;
-		};
-	}> = [];
+	const genericOAuthConfigs: GenericOAuthEntry[] = [];
 
 	for (const row of providerRows) {
 		const provider = row.provider;
@@ -152,32 +139,13 @@ export async function createAuth(
 
 		if (!clientId || !clientSecret) continue;
 
-		// Self-describing connector → generic-oauth route.
-		if (row.authorizationUrl && row.tokenUrl && row.userinfoUrl) {
+		// Self-describing connector → generic-oauth route. The builder threads the
+		// non-OIDC knobs (PKCE, token-endpoint auth method, extra auth params) so
+		// providers that need them can actually complete sign-in.
+		const genericEntry = buildGenericOAuthEntry(row, clientId, clientSecret);
+		if (genericEntry) {
 			if (genericOAuthConfigs.some((c) => c.providerId === provider)) continue;
-			genericOAuthConfigs.push({
-				providerId: provider,
-				clientId,
-				clientSecret,
-				authorizationUrl: row.authorizationUrl,
-				tokenUrl: row.tokenUrl,
-				userInfoUrl: row.userinfoUrl,
-				...(row.loginScopes.length > 0 && { scopes: row.loginScopes }),
-				// Standard OIDC claim mapping — no provider special-casing. Slack's
-				// openid.connect.userInfo returns `sub` (stable user id) plus the
-				// usual email/name/picture claims.
-				mapProfileToUser: (profile) => ({
-					id: String(profile.sub ?? ""),
-					email:
-						typeof profile.email === "string" ? profile.email : undefined,
-					name: typeof profile.name === "string" ? profile.name : undefined,
-					image:
-						typeof profile.picture === "string"
-							? profile.picture
-							: undefined,
-					emailVerified: profile.email_verified === true,
-				}),
-			});
+			genericOAuthConfigs.push(genericEntry);
 			continue;
 		}
 

--- a/packages/server/src/gateway/__tests__/channel-installations-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/channel-installations-routes.test.ts
@@ -193,16 +193,27 @@ describe("channel installation routes", () => {
     // The DM was opened with the caller's linked Slack identity.
     expect(stub.openDmCalledWith).toBe(SLACK_USER_ID);
 
-    // A binding row now routes the DM channel to this agent.
+    // A binding row now routes the DM channel to this agent. It MUST be stored
+    // under the canonical `slack:<id>` key — inbound Slack messages reach the
+    // dispatcher with `thread.channelId` already in that form, so a raw `D…`
+    // key would never match and the DM would silently fail to route.
+    const canonicalDm = `slack:${DM_CHANNEL_ID}`;
     const bindings = await orgContext.run({ organizationId: ORG_ID }, () =>
       channelBindingService.listBindings(AGENT_ID, ORG_ID)
     );
     expect(bindings).toHaveLength(1);
     expect(bindings[0]!.platform).toBe("slack");
-    expect(bindings[0]!.channelId).toBe(DM_CHANNEL_ID);
+    expect(bindings[0]!.channelId).toBe(canonicalDm);
     expect(bindings[0]!.teamId).toBe(TEAM_ID);
 
-    // And the welcome DM was posted to that channel.
+    // The inbound lookup path (canonical key + team) resolves this binding.
+    const looked = await orgContext.run({ organizationId: ORG_ID }, () =>
+      channelBindingService.getBinding("slack", canonicalDm, TEAM_ID, ORG_ID)
+    );
+    expect(looked?.agentId).toBe(AGENT_ID);
+
+    // And the welcome DM was posted to that channel — using the RAW id, which
+    // the Slack Web API expects (only the stored binding key is canonicalized).
     expect(stub.posted).toHaveLength(1);
     expect(stub.posted[0]!.channel).toBe(DM_CHANNEL_ID);
   });

--- a/packages/server/src/gateway/guardrails/__tests__/guardrails.test.ts
+++ b/packages/server/src/gateway/guardrails/__tests__/guardrails.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, test } from "bun:test";
 import {
   createNoopGuardrail,
   GuardrailRegistry,
+  type GuardrailStage,
   type SkillConfig,
 } from "@lobu/core";
 import {
@@ -641,6 +642,29 @@ describe("resolveAgentGuardrails (aggregator)", () => {
       ],
     });
     expect(out.names.input).not.toContain("off-rail");
+  });
+
+  test("inline guardrail with an invalid stage is skipped, not thrown", () => {
+    const reg = setupRegistry();
+    // A malformed persisted row (out-of-band write, or pre-validation data)
+    // carries a stage outside {input,output,pre-tool}. Resolution must skip it,
+    // not crash the whole message handler by indexing `seen[badStage]`.
+    let out!: ReturnType<typeof resolveAgentGuardrails>;
+    expect(() => {
+      out = resolveAgentGuardrails({ guardrails: [] }, [], reg, {
+        inline: [
+          {
+            name: "bad-stage",
+            enabled: true,
+            stage: "outupt" as GuardrailStage,
+            policy: "block everything",
+          },
+        ],
+      });
+    }).not.toThrow();
+    expect(out.names.input).not.toContain("bad-stage");
+    expect(out.names.output).not.toContain("bad-stage");
+    expect(out.names["pre-tool"]).not.toContain("bad-stage");
   });
 
   test("inline judge carries the operator name + stage onto the instance", () => {

--- a/packages/server/src/gateway/guardrails/aggregator.ts
+++ b/packages/server/src/gateway/guardrails/aggregator.ts
@@ -129,6 +129,17 @@ export function resolveAgentGuardrails(
   // edit UI rejects such names up front so this stays a defensive guard.
   for (const entry of extras.inline ?? []) {
     if (entry.enabled === false) continue;
+    // Defensive: a malformed persisted row can carry an invalid `stage`
+    // (the write path validates, but older rows or out-of-band writes might
+    // not). Indexing `seen[bad]` would be `undefined` and throw mid-message —
+    // skip and log instead of crashing the whole message handler.
+    if (!seen[entry.stage]) {
+      logger.warn(
+        { name: entry.name, stage: entry.stage },
+        "Inline guardrail has an invalid stage; skipping"
+      );
+      continue;
+    }
     const g = createJudgeGuardrail(entry.stage, entry.policy, {
       name: entry.name,
       model: entry.model,

--- a/packages/server/src/gateway/routes/public/channels.ts
+++ b/packages/server/src/gateway/routes/public/channels.ts
@@ -18,6 +18,7 @@ import {
   type SlackWebApi,
 } from "../../connections/slack-web.js";
 import { getDb } from "../../../db/client.js";
+import { canonicalSlackChannelId } from "../../../preview/slack.js";
 import type { AppInstallationStore } from "../../../lobu/stores/app-installation-store.js";
 import { orgContext } from "../../../lobu/stores/org-context.js";
 import type { SecretStore } from "../../secrets/index.js";
@@ -420,10 +421,15 @@ export function createChannelBindingRoutes(
         return errorResponse(c, "Could not open a Slack DM with you", 502);
       }
 
+      // Store the binding under the canonical `slack:<id>` channel key. Inbound
+      // Slack messages reach the dispatcher with `thread.channelId` already in
+      // canonical form, so a raw `D…` key here would never match and the DM
+      // would silently fail to route. (`dmChannelId` stays raw for the Slack
+      // Web API calls below, which expect the unprefixed id.)
       await config.channelBindingService.createBinding(
         agentId,
         "slack",
-        dmChannelId,
+        canonicalSlackChannelId(dmChannelId),
         install.externalTenantId,
         { configuredBy: payload.userId, organizationId }
       );

--- a/packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit coverage for `validateGuardrailsInline` — the write-boundary validation
+ * that protects the guardrail aggregator from malformed `guardrailsInline` rows.
+ * An entry with an invalid `stage` (or missing name/policy) would otherwise be
+ * persisted verbatim and then crash the aggregator mid-message when it indexes
+ * `seen[stage]`. The PATCH `/:agentId/config` route rejects such payloads (400).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { validateGuardrailsInline } from '../agent-routes.js';
+
+describe('validateGuardrailsInline', () => {
+  test('returns null for an absent payload', () => {
+    expect(validateGuardrailsInline(undefined)).toBeNull();
+  });
+
+  test('returns null for an empty array', () => {
+    expect(validateGuardrailsInline([])).toBeNull();
+  });
+
+  test('accepts a fully-valid inline guardrail', () => {
+    expect(
+      validateGuardrailsInline([
+        {
+          name: 'tone-check',
+          enabled: true,
+          stage: 'output',
+          policy: 'no profanity',
+          model: 'anthropic/claude-haiku-4-5',
+          tools: ['bash'],
+        },
+      ])
+    ).toBeNull();
+  });
+
+  test('rejects a non-array payload', () => {
+    expect(validateGuardrailsInline({})).toMatch(/must be an array/);
+  });
+
+  test('rejects an invalid stage — the crash vector', () => {
+    const err = validateGuardrailsInline([
+      { name: 'bad', enabled: true, stage: 'outupt', policy: 'x' },
+    ]);
+    expect(err).toMatch(/stage must be one of/);
+  });
+
+  test('rejects a missing/blank name', () => {
+    expect(
+      validateGuardrailsInline([
+        { name: '   ', enabled: true, stage: 'input', policy: 'x' },
+      ])
+    ).toMatch(/name must be a non-empty string/);
+  });
+
+  test('rejects a non-boolean enabled', () => {
+    expect(
+      validateGuardrailsInline([
+        { name: 'g', enabled: 'yes', stage: 'input', policy: 'x' },
+      ])
+    ).toMatch(/enabled must be a boolean/);
+  });
+
+  test('rejects a blank policy', () => {
+    expect(
+      validateGuardrailsInline([
+        { name: 'g', enabled: true, stage: 'input', policy: '' },
+      ])
+    ).toMatch(/policy must be a non-empty string/);
+  });
+
+  test('rejects a non-string model', () => {
+    expect(
+      validateGuardrailsInline([
+        { name: 'g', enabled: true, stage: 'input', policy: 'x', model: 42 },
+      ])
+    ).toMatch(/model must be a string/);
+  });
+
+  test('rejects tools that are not a string array', () => {
+    expect(
+      validateGuardrailsInline([
+        { name: 'g', enabled: true, stage: 'input', policy: 'x', tools: [1] },
+      ])
+    ).toMatch(/tools must be an array of strings/);
+  });
+});

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -740,6 +740,49 @@ routes.put('/:agentId/providers/:providerId/api-key', async (c) => {
 
 // ── Update agent config (settings) ───────────────────────────────────────────
 
+const GUARDRAIL_STAGES = new Set(['input', 'output', 'pre-tool']);
+
+/**
+ * Validate a `guardrailsInline` payload before it is persisted to agent
+ * settings. Returns a human-readable error string on the first invalid entry,
+ * or `null` when the payload is absent or fully valid. Persisting an entry with
+ * an invalid `stage` would crash the guardrail aggregator at message time, so
+ * we reject malformed input at the write boundary instead.
+ */
+export function validateGuardrailsInline(value: unknown): string | null {
+  if (value === undefined) return null;
+  if (!Array.isArray(value)) return 'guardrailsInline must be an array';
+  for (let i = 0; i < value.length; i++) {
+    const entry = value[i];
+    if (typeof entry !== 'object' || entry === null) {
+      return `guardrailsInline[${i}] must be an object`;
+    }
+    const g = entry as Record<string, unknown>;
+    if (typeof g.name !== 'string' || g.name.trim() === '') {
+      return `guardrailsInline[${i}].name must be a non-empty string`;
+    }
+    if (typeof g.enabled !== 'boolean') {
+      return `guardrailsInline[${i}].enabled must be a boolean`;
+    }
+    if (typeof g.stage !== 'string' || !GUARDRAIL_STAGES.has(g.stage)) {
+      return `guardrailsInline[${i}].stage must be one of: input, output, pre-tool`;
+    }
+    if (typeof g.policy !== 'string' || g.policy.trim() === '') {
+      return `guardrailsInline[${i}].policy must be a non-empty string`;
+    }
+    if (g.model !== undefined && typeof g.model !== 'string') {
+      return `guardrailsInline[${i}].model must be a string`;
+    }
+    if (
+      g.tools !== undefined &&
+      (!Array.isArray(g.tools) || g.tools.some((t) => typeof t !== 'string'))
+    ) {
+      return `guardrailsInline[${i}].tools must be an array of strings`;
+    }
+  }
+  return null;
+}
+
 routes.patch('/:agentId/config', async (c) => {
   const denied = requireSessionOrAdminPat(c);
   if (denied) return denied;
@@ -748,6 +791,19 @@ routes.patch('/:agentId/config', async (c) => {
 
   if (!(await configStore.hasAgent(agentId))) {
     return c.json({ error: 'Agent not found' }, 404);
+  }
+
+  // Validate inline guardrail shape before it is persisted. An invalid `stage`
+  // (or missing name/policy) would otherwise be written verbatim and then crash
+  // the guardrail aggregator mid-message (it indexes `seen[stage]`).
+  const guardrailError = validateGuardrailsInline(
+    (updates as { guardrailsInline?: unknown }).guardrailsInline
+  );
+  if (guardrailError) {
+    return c.json(
+      { error: 'invalid_guardrail', error_description: guardrailError },
+      400
+    );
   }
 
   // Custom guardrails are LLM judges and need a model. With no gateway default


### PR DESCRIPTION
Watcher→entity feedback-loop follow-ups. Three pre-existing `main` bugs (confirmed not from the merged feature work) fixed with red→green reproducers, plus the owletto entity-UI cleanup pointer bump.

## Bugs fixed (each red→green verified)

**1. Inline guardrail with an invalid `stage` crashed message handling.**
`PATCH /agents/:id/config` persisted `guardrailsInline` verbatim; a bad `stage` then threw in the aggregator (`seen[stage].has` on `undefined`) mid-message. Now validated at the write boundary (400) **and** defensively skipped+logged at resolve time.
- RED: `TypeError: undefined is not an object (evaluating 'seen[entry.stage].has')`
- GREEN: entry skipped, message handling unaffected.

**2. Slack Connect DM binding never matched inbound messages.**
`connect-dm` stored the binding under the raw `D…` id, but inbound Slack messages arrive with `thread.channelId` already canonical (`slack:<id>`) — so connected DMs silently failed to route. Now stored canonical (raw id still used for the Slack Web API calls).
- RED: binding stored `D_TEST_DM`, lookup expects `slack:D_TEST_DM`.
- GREEN: canonical key stored + resolves via the inbound lookup path.

**3. Generic OAuth dropped non-OIDC knobs.**
A self-describing login provider declaring PKCE (`usePkce`), basic token-endpoint auth (`tokenEndpointAuthMethod`), or extra auth params (`authParams`) had them dropped when building the better-auth `genericOAuth` config → sign-in failed. Now collected and mapped to the plugin's `pkce` / `authentication` / `authorizationUrlParams` via a pure, unit-tested `buildGenericOAuthEntry`.
- RED: built entry missing `pkce` / `authentication`.
- GREEN: knobs threaded through.

## Tests
- `guardrails.test.ts` (+1), `agent-routes-guardrail-validation.test.ts` (new, 10), `channel-installations-routes.test.ts` (tightened), `config.test.ts` (+4). 76 bun + 13 vitest green; server `tsc --noEmit` clean.

## Owletto cleanup (submodule)
Bumps the pointer for **lobu-ai/owletto#371** (EntityAvatar in list table + dedupe FieldControl). **Merge order:** merge owletto#371 first, then I re-point this PR to the owletto squash SHA (submodule drift stays red until then), then merge here.

## Not in this PR (deliberately)
- **Condensation contract migration (DROP COLUMN)** is hard-gated: the expand-phase PR #1575 (merged today) is not yet in any release, so dropping those columns now would crash still-running pre-#1575 pods. Held on a separate branch until #1575 ships to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785084108&installation_id=136316292&pr_number=1579&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1579&signature=001d72081d3f8319438d448b7be134d32930b2255041e6868f30858ebffd4559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth sign-in now supports PKCE and extra authorization parameters for compatible providers.
  * Self-describing OAuth connectors are handled more consistently across the app.

* **Bug Fixes**
  * DM channel connections now store Slack channel bindings in the correct canonical format for routing.
  * Invalid guardrail stages are now skipped safely instead of causing failures.
  * Agent guardrail updates now reject malformed settings with clear validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->