### PR TITLE
chore(db): drop dead watcher condensation columns (contract phase) — DO NOT MERGE until #1575 ships

### DIFF
--- a/db/migrations/20260626000000_drop_watcher_condensation_columns.sql
+++ b/db/migrations/20260626000000_drop_watcher_condensation_columns.sql
@@ -1,0 +1,65 @@
+-- migrate:up
+
+-- Contract phase of the watcher condensation/rollup removal.
+--
+-- The columns were made dead in the prior release (#1575, "remove dead
+-- condensation/rollup feature — expand phase"): no code across server,
+-- agent-worker, cli, or the owletto frontend reads or writes any of them, and
+-- they are NOT in the query_sql table-schema allowlist
+-- (packages/server/src/utils/table-schema.ts) — so no scoped CTE emits them.
+--
+-- MUST ship in a release AFTER #1575 is fully deployed to every replica. Until
+-- then an old pod still runs pre-#1575 code; dropping the columns mid-rollout
+-- would break it. Once #1575 is live, no running replica references any of
+-- these, so the drop is safe under a rolling upgrade. DROP COLUMN is an O(1)
+-- catalog flip under a brief ACCESS EXCLUSIVE lock — no table rewrite.
+
+-- Dead rollup artifacts (is_rollup = true) were never period-unique against leaf
+-- rows (the old index below only constrained is_rollup = false). Remove them
+-- BEFORE recreating the index without that predicate, otherwise a former rollup
+-- row could collide with a leaf row on (watcher_id, window_start, window_end).
+DELETE FROM public.watcher_windows WHERE is_rollup = true;
+
+-- Dropping is_rollup auto-drops the partial unique index
+-- idx_watcher_windows_unique_period (its predicate references the column).
+ALTER TABLE public.watcher_windows DROP COLUMN IF EXISTS is_rollup;
+ALTER TABLE public.watcher_windows DROP COLUMN IF EXISTS source_window_ids;
+ALTER TABLE public.watcher_windows DROP COLUMN IF EXISTS depth;
+
+ALTER TABLE public.watcher_versions DROP COLUMN IF EXISTS condensation_prompt;
+ALTER TABLE public.watcher_versions DROP COLUMN IF EXISTS condensation_window_count;
+
+-- Recreate the period-uniqueness index without the now-removed `is_rollup`
+-- predicate (it is always-true post-removal, so a plain unique index is the
+-- equivalent constraint). complete-window.ts relies on the 23505 it raises to
+-- guard concurrent window creation. The brief ACCESS EXCLUSIVE lock during the
+-- build is acceptable in the deploy hook at this table's size; CONCURRENTLY
+-- cannot run inside dbmate's migration transaction.
+-- squawk-ignore prefer-robust-stmts,require-concurrent-index-creation
+CREATE UNIQUE INDEX idx_watcher_windows_unique_period
+  ON public.watcher_windows USING btree (watcher_id, window_start, window_end);
+
+-- migrate:down
+-- Rollback-only path (dev). The integer column types and the brief DROP INDEX
+-- lock below intentionally restore the ORIGINAL baseline schema; the per-
+-- statement lint directives reflect that.
+
+-- squawk-ignore require-concurrent-index-deletion -- dev rollback; brief lock is fine
+DROP INDEX IF EXISTS idx_watcher_windows_unique_period;
+
+-- squawk-ignore prefer-bigint-over-int -- restores original integer column
+ALTER TABLE public.watcher_versions ADD COLUMN IF NOT EXISTS condensation_window_count integer DEFAULT 4;
+ALTER TABLE public.watcher_versions ADD COLUMN IF NOT EXISTS condensation_prompt text;
+
+-- squawk-ignore prefer-bigint-over-int -- restores original integer column
+ALTER TABLE public.watcher_windows ADD COLUMN IF NOT EXISTS depth integer DEFAULT 0;
+-- squawk-ignore prefer-bigint-over-int -- restores original integer[] column
+ALTER TABLE public.watcher_windows ADD COLUMN IF NOT EXISTS source_window_ids integer[];
+ALTER TABLE public.watcher_windows ADD COLUMN IF NOT EXISTS is_rollup boolean DEFAULT false;
+
+-- Restore the original partial unique index (deleted rollup rows are not
+-- restored — down is a schema rollback only).
+-- squawk-ignore prefer-robust-stmts,require-concurrent-index-creation
+CREATE UNIQUE INDEX idx_watcher_windows_unique_period
+  ON public.watcher_windows USING btree (watcher_id, window_start, window_end)
+  WHERE (is_rollup = false);

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -131,10 +131,6 @@ describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
     oauth_tokens: new Set(['token_hash']),
     feeds: new Set(['checkpoint']),
     user: new Set(['email', 'phoneNumber', 'phoneNumberVerified']),
-    // Dead "condensation"/"rollup" watcher feature — code removed; the columns
-    // remain in the DB this release and a follow-up migration drops them.
-    watcher_versions: new Set(['condensation_prompt', 'condensation_window_count']),
-    watcher_windows: new Set(['is_rollup', 'source_window_ids', 'depth']),
   };
 
   it('should have every DB column listed in the schema (or intentionally omitted)', async (ctx) => {


### PR DESCRIPTION
⛔ **DRAFT / HARD-GATED — do not merge until #1575 is deployed to every prod replica.**

Contract phase for the watcher condensation/rollup removal. The expand phase (#1575, merged 2026-06-26) removed all code that reads/writes these columns; this drops them. Dropping mid-rollout — while any pod still runs pre-#1575 code — would crash that pod, so this MUST ship in a release strictly after #1575 is live everywhere. As of opening, #1575 is not yet in any release (latest is v13.1.0, 2026-06-24).

## What it does
- DROP `watcher_versions.condensation_prompt`, `watcher_versions.condensation_window_count`
- DROP `watcher_windows.is_rollup`, `watcher_windows.source_window_ids`, `watcher_windows.depth`
- `DELETE FROM watcher_windows WHERE is_rollup = true` first (dead rollup artifacts) so the de-predicated index can't collide
- Replace the partial unique index `idx_watcher_windows_unique_period` (`WHERE is_rollup = false`) with a plain unique index on `(watcher_id, window_start, window_end)` — the `complete-window.ts` 23505 race-guard is preserved
- Remove the obsolete `INTENTIONALLY_OMITTED` entries from `table-schema.test.ts` (keeps `entities.field_controls`, a real column)

## Verification
- `squawk-cli@2.58.0 --exclude=ban-drop-column,require-timeout-settings` → **0 issues** (down-block `prefer-bigint`/`require-concurrent-index-deletion` ignored with rationale; they restore the original baseline)
- Zero runtime references to all 5 columns across server/agent-worker/cli/owletto (grep-verified)
- `dbmate up` on a fresh full-chain DB ✅ → columns gone, index plain (no predicate). `dbmate down` ✅ → partial index + columns restored. Re-`up` ✅.

## Before merging
1. Confirm #1575 is in a released, fully-rolled-out version.
2. Bump the migration timestamp if newer migrations have landed meanwhile (avoid out-of-order apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785084597&installation_id=136316292&pr_number=1580&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1580&signature=427a7da77bdae2d0f708a6dcd8bb0281a2717f8312db98dc10dfd2b1d5f4afa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete watcher rollup-related database fields and cleaned up duplicate rollup records to avoid key conflicts.
  * Updated the watcher period uniqueness rule so records are enforced consistently.
* **Tests**
  * Adjusted schema checks to require the current watcher columns, helping catch unexpected database drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->