### PR TITLE
feat(feeds): virtual feed flag (Slice 2) — live-read declarable feeds

### DIFF
--- a/db/migrations/20260626000000_feeds_virtual_flag.sql
+++ b/db/migrations/20260626000000_feeds_virtual_flag.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+
+-- Slice 2 — virtual feed flag. A VIRTUAL feed is read LIVE against its source
+-- at request time (connector query()/search()) and NEVER synced: no events are
+-- persisted, no checkpoint is kept, and the feed scheduler (check-due-feeds)
+-- skips it via `AND f.virtual IS NOT TRUE`. A user-configured virtual feed is a
+-- `feeds` row with virtual=true whose sync-lifecycle columns (schedule /
+-- next_run_at / checkpoint) stay NULL.
+--
+-- Additive boolean with a constant default → PG11+ fills it as metadata with no
+-- table rewrite, so this is lock-safe at prod row counts (squawk-clean, mirrors
+-- the existing `agents.show_tool_calls` add).
+ALTER TABLE public.feeds
+    ADD COLUMN IF NOT EXISTS virtual boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.feeds.virtual IS
+    'When true, the feed is read live via the connector query()/search() pushdown at request time and is never synced — the sync scheduler excludes it and its sync-lifecycle columns stay NULL.';
+
+-- migrate:down
+
+ALTER TABLE public.feeds DROP COLUMN IF EXISTS virtual;

--- a/docs/plans/virtual-feed-flag-slice2.md
+++ b/docs/plans/virtual-feed-flag-slice2.md
@@ -1,0 +1,164 @@
+# Virtual feed flag — Slice 2
+
+Status: implemented (this PR). Conflict-safe slice of the larger "Conversation feeds
+/ FeedReader registry" program. This slice ships the **capability layer + migration**
+that lets a feed be *read live* instead of synced; the FeedReader registry + feed
+enumeration that consume it land in a sibling stream (Stream A, owned separately).
+
+## Goal
+
+Make a feed *declarable as virtual*: read LIVE against its source at request time via
+the connector `query()` / `search()` pushdown, and NEVER synced (no events persisted,
+no checkpoint, no schedule). This is the `(virtual-live-dataset, recall)` tuple in the
+three-feed-kinds model — `KIND = virtual-live-dataset`, `LENS = recall` (keyword) or a
+plain live read.
+
+## Where this sits in the program (conflict-safe ordering)
+
+- **Phase 0** — feed enumeration / `listConnectionFeeds` (Stream A owner). Not touched here.
+- **Stream A** — the `FeedReader<S, L>` registry + recall-source wiring in
+  `packages/server/src/tools/search.ts` (Stream A owner). Not touched here.
+- **Slice 2 (this PR)** — declare `virtual` on a feed, persist it, skip it in the sync
+  scheduler, add the connector `search()` recall capability, and expose a stable
+  `readVirtualFeed(...)` pushdown seam. Stream A registers virtual as the
+  `(virtual-live-dataset, recall)` tuple by calling that seam.
+- **Stream B Phase 2** — virtual-feed UI (owletto). Not in this slice.
+
+The single integration point between this slice and Stream A is the exported function
+`readVirtualFeed` (below). Stream A imports and calls it; this slice never touches
+`search.ts`.
+
+## Verified current state (pre-Slice-2)
+
+- `FeedDefinition` had no `virtual` field — `packages/connector-sdk/src/connector-types.ts`.
+- Connector live-read method already exists — `ConnectorRuntime.query(ctx: QueryContext)`
+  (`connector-runtime.ts`), lowered from `defineConnector({ query })` (`define-connector.ts`).
+- `QueryContext.feedKey` is documented "present for a virtual-feed read" — `connector-types.ts`.
+- Server pushdown stub existed: `connector-pushdown.ts` ran `runConnectorQuery` for
+  `query_sql({ connection })` and carried a "(later) by virtual-feed reads" TODO — that
+  "later" is implemented here.
+- The postgres connector already had a hardened live `query()` with
+  `validateReadOnlySelect` / `guardDbHost` / `setReadOnly` / `POOL_OPTS`
+  (`packages/connectors/src/postgres.ts`). Slice 2 reuses every one of those guards for
+  `search()`.
+- Feed scheduler: `packages/server/src/scheduled/check-due-feeds.ts` selects due feeds
+  by `next_run_at <= now()`.
+
+## What was built
+
+1. **Declaration** — `virtual?: boolean` on `FeedDefinition` (`connector-types.ts`),
+   carried through `buildDefinition` in `define-connector.ts`. When true the feed is read
+   live and never synced; its sync-lifecycle columns stay NULL.
+
+2. **Persistence / migration** — `feeds.virtual boolean NOT NULL DEFAULT false`
+   (`db/migrations/20260626000000_feeds_virtual_flag.sql`). Additive constant-default →
+   no table rewrite, squawk-clean (`squawk-cli@2.58.0` reports 0 issues). A user-configured
+   virtual feed = a `feeds` row with `virtual = true` and NULL sync-lifecycle columns.
+
+3. **Scheduler skip** — `AND f.virtual IS NOT TRUE` added to the `check-due-feeds`
+   due-selection query. A virtual feed is never picked for `sync()`, even with a past
+   `next_run_at`. (E2E proves: with the guard "Found 1 due feeds"; without it "Found 2".)
+
+4. **Connector `search()` capability** — a NEW optional `ConnectorRuntime.search(ctx:
+   SearchContext): Promise<QueryResult>` (default throws "recall over virtual unsupported").
+   `SearchContext extends QueryContext` + `terms: string[]`. Lowered from
+   `defineConnector({ search })`. Wired through the executor as a `search` job/result mode
+   (`packages/connector-worker/src/executor/interface.ts` + `child-runner.ts`).
+   Implemented for postgres: probes output columns (LIMIT 0), then for each term ORs an
+   `ILIKE` across every column cast to text; terms AND together (a row matches when every
+   term hits ≥1 column). Terms are bound params and wildcard-escaped; runs inside the SAME
+   read-only transaction + egress guard as `query()`, with a bounded LIMIT.
+
+5. **`readVirtualFeed` pushdown seam** — implemented the "(later) virtual-feed reads" path
+   in `connector-pushdown.ts`. **This is the stable export Stream A consumes.** It resolves
+   the feed + backing connection under the AuthzScope visibility compiler, asserts the feed
+   is virtual, reads its `config.query`, then runs `search()` (when terms present) or
+   `query()` in the connector subprocess. Persists nothing.
+
+6. **Authz / egress** — feed resolution goes through `compileConnectionRowVisibility` from
+   `packages/server/src/authz/connection-visibility.ts` (the same seam `query_sql` /
+   recall use), keyed on an `AuthzScope`. A member is fenced from another user's private
+   virtual feed exactly as on the SQL seam. The postgres read stays inside the read-only
+   transaction + `LOBU_DB_EGRESS_POLICY` guard (`block-private` under cloud mode).
+
+### The integration seam (import this from search.ts)
+
+```ts
+import { readVirtualFeed } from '../lib/connector-pushdown';
+// or, with types:
+import {
+  readVirtualFeed,
+  type ReadVirtualFeedParams,
+  type ReadVirtualFeedResult,
+} from '../lib/connector-pushdown';
+
+export interface ReadVirtualFeedParams {
+  scope: AuthzScope;            // organizationId + principal; the visibility fence
+  feedId: number;              // a feeds.id with virtual = true
+  terms?: string[];            // present ⇒ search() (recall); absent ⇒ query() (plain live read)
+  limit?: number;
+  offset?: number;
+  sort?: { column: string; order: 'asc' | 'desc' };
+}
+export interface ReadVirtualFeedResult {
+  rows: Record<string, unknown>[];
+  columns: { name: string; type: string }[];
+  total?: number;
+}
+export function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVirtualFeedResult>;
+```
+
+Errors thrown (surface, don't branch on them): `not found or not accessible` (missing /
+fenced), `is not a virtual feed` (a non-virtual row), `has no \`query\` in its config`,
+and the connector capability errors (`does not support recall over virtual feeds` /
+`does not support live queries`).
+
+## Open decisions (chosen)
+
+- **`search()` as a NEW optional method** (chosen) vs a `QueryContext.search` predicate.
+  Rationale: a missing method cleanly signals "recall over virtual unsupported" as a
+  capability gap — no runtime branch on a flag, and `query()` (plain live read) stays
+  independent of recall. Documented at the `ConnectorRuntime.search` definition.
+- **feeds-row for virtual feeds** (chosen) vs rowless. A user-configured virtual feed is a
+  real `feeds` row (`virtual = true`) so it carries its own config, visibility (via its
+  connection), and identity — and Stream A's enumeration finds it like any other feed.
+- **Recall push-down (ILIKE at source)** (chosen) vs pull-bounded-then-filter. The terms
+  are translated to a source-side predicate so recall is computed where the data lives,
+  inside the read-only transaction, with a bounded LIMIT — never pulling the whole feed.
+
+## Multi-replica correctness
+
+A virtual read is a pure per-request read: all state in Postgres, no pod-local state, the
+connector subprocess opens its own socket behind the worker egress controls. Runnable on
+any replica; nothing to fan out. The scheduler skip is a pure SQL predicate.
+
+## E2E (hard gate)
+
+`packages/server/src/__tests__/integration/connectors/virtual-feed-read.test.ts` — drives
+the real chain (resolve → compile bundled postgres connector → fork subprocess → live DB),
+the "external" DB pointing back at the test DB:
+
+- (a) scheduler skips the virtual feed but selects the non-virtual control (red→green:
+  guard present ⇒ "Found 1 due feeds"; guard removed ⇒ "Found 2" and the test fails);
+- (b) `readVirtualFeed` returns live rows via `query()` and via `search(['ap'])`
+  (ILIKE pushdown, `total` reflects the filtered count), with `events` count staying 0;
+- (c) a member is fenced from the owner's PRIVATE virtual feed (`not found or not
+  accessible`); the owner still reads it;
+- a non-virtual feed is refused (`not a virtual feed`).
+
+Run: from `packages/server`,
+`DATABASE_URL=… PGSSLMODE=disable npx vitest run src/__tests__/integration/connectors/virtual-feed-read.test.ts`.
+
+## Files touched
+
+- `packages/connector-sdk/src/connector-types.ts` — `FeedDefinition.virtual`, `SearchContext`.
+- `packages/connector-sdk/src/connector-runtime.ts` — `ConnectorRuntime.search()` default.
+- `packages/connector-sdk/src/define-connector.ts` — lower `search`, carry `virtual`.
+- `packages/connector-sdk/src/index.ts` — export `SearchContext`.
+- `packages/connector-worker/src/executor/interface.ts` — `search` job + result mode.
+- `packages/connector-worker/src/executor/child-runner.ts` — dispatch `search`.
+- `packages/connectors/src/postgres.ts` — `search()` ILIKE pushdown.
+- `packages/server/src/scheduled/check-due-feeds.ts` — `AND f.virtual IS NOT TRUE`.
+- `packages/server/src/lib/connector-pushdown.ts` — `readVirtualFeed` seam.
+- `db/migrations/20260626000000_feeds_virtual_flag.sql` — `feeds.virtual` column.
+- `packages/server/src/__tests__/integration/connectors/virtual-feed-read.test.ts` — E2E.

--- a/packages/connector-sdk/src/connector-runtime.ts
+++ b/packages/connector-sdk/src/connector-runtime.ts
@@ -15,6 +15,7 @@ import type {
   QueryResult,
   ReflectContext,
   ReflectResult,
+  SearchContext,
   SyncContext,
   SyncResult,
   WebhookRegistration,
@@ -96,6 +97,18 @@ export abstract class ConnectorRuntime<C = Record<string, unknown>, F = Record<s
   // biome-ignore lint/correctness/noUnusedFunctionParameters: contract signature — subclasses receive the full QueryContext
   async query(ctx: QueryContext<F>): Promise<QueryResult> {
     throw new Error(`${this.definition.key} does not support live queries`);
+  }
+
+  /**
+   * Keyword RECALL over a virtual feed: read LIVE against the source pushing the
+   * caller's `ctx.terms` DOWN as a source-side predicate (no copy, no events).
+   * Same read-only contract as {@link query}. Default implementation throws —
+   * a connector that doesn't override signals "recall over virtual unsupported"
+   * (a capability gap surfaced to the caller, not a runtime branch).
+   */
+  // biome-ignore lint/correctness/noUnusedFunctionParameters: contract signature — subclasses receive the full SearchContext
+  async search(ctx: SearchContext<F>): Promise<QueryResult> {
+    throw new Error(`${this.definition.key} does not support recall over virtual feeds`);
   }
 
   /**

--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -430,6 +430,17 @@ export interface FeedDefinition {
    */
   userManaged?: boolean;
   /**
+   * When true, this feed is a VIRTUAL feed: it is read LIVE against the source
+   * via {@link ConnectorRuntime.query} (or {@link ConnectorRuntime.search} for
+   * keyword recall) at read time and NEVER synced — no events are persisted, no
+   * checkpoint is kept, and the feed scheduler never selects it for `sync()`.
+   * A user-configured virtual feed is a `feeds` row with `virtual = true` whose
+   * sync-lifecycle columns (schedule / next_run_at / checkpoint) stay NULL.
+   * The live query lives in the feed's stored `config` (for the postgres
+   * connector, `config.query` — the same read-only SELECT shape sync uses).
+   */
+  virtual?: boolean;
+  /**
    * Routes inbound app-webhook deliveries to this feed. Lives on the feed (not
    * the connector's webhook schema) because feeds_schema is the persisted,
    * server-readable surface — the app-webhook router reads this to dispatch a
@@ -874,6 +885,20 @@ export interface QueryResult {
   columns?: { name: string; type: string }[];
   /** Total matching rows (for pagination), when cheaply available. */
   total?: number;
+}
+
+/**
+ * Context passed to ConnectorRuntime.search() — a virtual-feed RECALL read.
+ * Same live, read-only, no-persistence contract as {@link QueryContext}, plus
+ * the keyword `terms` to push DOWN to the external source (e.g. an `ILIKE`
+ * predicate over the validated subquery), so recall is computed at the source
+ * instead of pulling the whole feed and filtering in-process. A connector that
+ * does not implement `search()` signals "recall over virtual unsupported" — a
+ * capability gap, not a runtime branch.
+ */
+export interface SearchContext<F = Record<string, unknown>> extends QueryContext<F> {
+  /** Keyword terms to match at the source. A row matches when every term hits at least one column. */
+  terms: string[];
 }
 
 // =============================================================================

--- a/packages/connector-sdk/src/define-connector.ts
+++ b/packages/connector-sdk/src/define-connector.ts
@@ -40,6 +40,7 @@ import type {
   QueryResult,
   ReflectContext,
   ReflectResult,
+  SearchContext,
   SyncContext,
   SyncResult,
   WebhookRegistration,
@@ -81,6 +82,13 @@ export interface ConnectorSpec
    * entities (returns rows, no persistence). Omitted ⇒ live queries unsupported.
    */
   query?(ctx: QueryContext): Promise<QueryResult>;
+  /**
+   * Optional virtual-feed recall handler. When provided, lowers to
+   * `ConnectorRuntime.search` — the platform calls it to read a virtual feed
+   * live with the caller's keyword terms pushed down to the source. Omitted ⇒
+   * recall over this connector's virtual feeds is unsupported.
+   */
+  search?(ctx: SearchContext): Promise<QueryResult>;
   /**
    * Optional metric-reflection handler. When provided, lowers to
    * `ConnectorRuntime.reflectMetrics` — contributes entity types federating the
@@ -133,6 +141,7 @@ function buildDefinition(spec: ConnectorSpec): ConnectorDefinition {
           displayNameTemplate: feed.displayNameTemplate,
           configSchema: feed.configSchema,
           userManaged: feed.userManaged,
+          virtual: feed.virtual,
           eventKinds: feed.eventKinds,
         },
       ]),
@@ -204,6 +213,13 @@ export function defineConnector(spec: ConnectorSpec): ConnectorClass {
         return super.query(ctx);
       }
       return spec.query(ctx);
+    }
+
+    async search(ctx: SearchContext): Promise<QueryResult> {
+      if (!spec.search) {
+        return super.search(ctx);
+      }
+      return spec.search(ctx);
     }
 
     async reflectMetrics(ctx: ReflectContext): Promise<ReflectResult> {

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -80,6 +80,7 @@ export type {
   Run,
   RunStatus,
   RunType,
+  SearchContext,
   SyncContext,
   SyncCredentials,
   SyncResult,

--- a/packages/connector-worker/src/executor/child-runner.ts
+++ b/packages/connector-worker/src/executor/child-runner.ts
@@ -253,6 +253,28 @@ async function executeConnectorRuntime(
     };
   }
 
+  if (job.mode === 'search') {
+    // Virtual-feed recall: live read with keyword terms pushed down. Persists
+    // nothing (like `query`/`action`).
+    const searchResult = await instance.search({
+      feedKey: job.feedKey ?? undefined,
+      query: job.query,
+      terms: job.terms,
+      config: { ...job.env, ...job.config },
+      credentials: job.credentials,
+      sessionState: job.sessionState,
+      limit: job.limit,
+      offset: job.offset,
+      sort: job.sort,
+    });
+    return {
+      mode: 'search',
+      rows: searchResult.rows ?? [],
+      columns: searchResult.columns,
+      total: searchResult.total,
+    };
+  }
+
   // mode === 'sync'
   const emitEvents = async (events: EventEnvelope[]) => {
     for (let index = 0; index < events.length; index += EVENT_CHUNK_SIZE) {

--- a/packages/connector-worker/src/executor/interface.ts
+++ b/packages/connector-worker/src/executor/interface.ts
@@ -52,6 +52,21 @@ export type ExecutorJob =
       sort?: { column: string; order: 'asc' | 'desc' };
     }
   | {
+      // Virtual-feed RECALL: same live, no-persistence read as `query`, plus the
+      // caller's keyword `terms` pushed down to the source.
+      mode: 'search';
+      feedKey?: string | null;
+      query: string;
+      terms: string[];
+      config: Record<string, unknown>;
+      credentials: SyncCredentials | null;
+      sessionState: Record<string, unknown> | null;
+      env: Record<string, string | undefined>;
+      limit?: number;
+      offset?: number;
+      sort?: { column: string; order: 'asc' | 'desc' };
+    }
+  | {
       // Subscribe with the provider at connect time so deliveries flow to
       // `callbackUrl` (`/api/v1/webhooks/:connectionId`). Runs once per
       // connection, not per delivery. Returns the provider subscription id +
@@ -98,6 +113,12 @@ export type ExecutorResult =
     }
   | {
       mode: 'query';
+      rows: Record<string, unknown>[];
+      columns?: { name: string; type: string }[];
+      total?: number;
+    }
+  | {
+      mode: 'search';
       rows: Record<string, unknown>[];
       columns?: { name: string; type: string }[];
       total?: number;

--- a/packages/connectors/src/postgres.ts
+++ b/packages/connectors/src/postgres.ts
@@ -37,6 +37,7 @@ import {
   type EventEnvelope,
   type QueryContext,
   type QueryResult,
+  type SearchContext,
   type SyncContext,
   type SyncResult,
 } from '@lobu/connector-sdk';
@@ -144,6 +145,19 @@ function assertIdentifier(value: string, label: string): string {
     );
   }
   return value;
+}
+
+/** Double embedded quotes so a probed column name is safe inside `q."…"`. */
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Escape LIKE/ILIKE wildcards so a user search term matches literally — the
+ * default Postgres escape char is backslash, so `\%` / `\_` / `\\` are literals.
+ */
+function escapeLike(term: string): string {
+  return term.replace(/[\\%_]/g, (c) => `\\${c}`);
 }
 
 /**
@@ -486,6 +500,87 @@ export default class PostgresConnector extends ConnectorRuntime {
       }
       const columns = cols.map((c) => ({ name: c.name, type: PG_OID[c.type]?.display ?? 'unknown' }));
       return { rows, columns, total };
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+  }
+
+  /**
+   * Virtual-feed RECALL: live read with the caller's keyword `terms` pushed DOWN
+   * as an `ILIKE` predicate over the validated subquery, inside the SAME
+   * read-only transaction + egress guard as query(). The output columns are
+   * probed (LIMIT 0) so each term is matched against EVERY column cast to text;
+   * a row matches when every term hits at least one column. Terms are bound
+   * parameters (never interpolated) and wildcard-escaped, so a term like `50%`
+   * matches literally. Empty `terms` ⇒ behaves like query() (no predicate).
+   */
+  async search(ctx: SearchContext): Promise<QueryResult> {
+    const connectionString = (ctx.config as Record<string, unknown>).DATABASE_URL as
+      | string
+      | undefined;
+    if (!connectionString) {
+      throw new Error('DATABASE_URL is required');
+    }
+    const baseSql = validateReadOnlySelect(ctx.query);
+    const terms = (ctx.terms ?? []).map((t) => t.trim()).filter(Boolean);
+    const limit =
+      ctx.limit !== undefined ? Math.min(Math.max(Math.trunc(ctx.limit), 1), 5000) : 1000;
+    const offset = ctx.offset !== undefined ? Math.max(Math.trunc(ctx.offset), 0) : 0;
+    let orderBy = '';
+    if (ctx.sort?.column) {
+      const col = assertIdentifier(ctx.sort.column, 'sort.column');
+      orderBy = `ORDER BY q."${col}" ${ctx.sort.order === 'desc' ? 'DESC' : 'ASC'}`;
+    }
+
+    await guardDbHost(connectionString, ctx.config as Record<string, unknown>);
+    const sql = postgres(connectionString, POOL_OPTS);
+    try {
+      const { data, columns, total } = (await sql.begin(async (tx) => {
+        await setReadOnly(tx, 30000);
+        // Probe output columns so recall spans every column (cast to text).
+        const probe = await tx.unsafe(`SELECT * FROM (\n${baseSql}\n) q LIMIT 0`);
+        const cols =
+          (probe as unknown as { columns?: Array<{ name: string; type: number }> }).columns ?? [];
+        const names = cols.map((c) => c.name);
+        if (new Set(names).size !== names.length) {
+          throw new Error(
+            'query has duplicate output column names — alias each selected column to a distinct name (the row object would otherwise drop a value).',
+          );
+        }
+
+        // Each term → an OR across all columns; terms AND together. Terms are
+        // bound params ($1..$n); column identifiers come from the live result
+        // set and are quote-escaped. No columns or no terms ⇒ no predicate.
+        const params: unknown[] = [];
+        let whereClause = '';
+        if (terms.length > 0 && names.length > 0) {
+          const perTerm = terms.map((term) => {
+            params.push(`%${escapeLike(term)}%`);
+            const idx = params.length;
+            const ors = names.map((n) => `q.${quoteIdent(n)}::text ILIKE $${idx}`).join(' OR ');
+            return `(${ors})`;
+          });
+          whereClause = `WHERE ${perTerm.join(' AND ')}`;
+        }
+
+        const wrapped = `SELECT * FROM (\n${baseSql}\n) q\n${whereClause}\n${orderBy}\nLIMIT ${limit} OFFSET ${offset}`;
+        const countSql = `SELECT count(*)::int AS n FROM (\n${baseSql}\n) q\n${whereClause}`;
+        const rows = await tx.unsafe(wrapped, params as never[]);
+        const counted = (await tx.unsafe(countSql, params as never[])) as unknown as Array<{
+          n: number;
+        }>;
+        return { data: rows, columns: cols, total: counted[0]?.n };
+      })) as unknown as {
+        data: Array<Record<string, unknown>>;
+        columns: Array<{ name: string; type: number }>;
+        total: number | undefined;
+      };
+      const rows = Array.isArray(data) ? (data as Array<Record<string, unknown>>) : [];
+      const outCols = columns.map((c) => ({
+        name: c.name,
+        type: PG_OID[c.type]?.display ?? 'unknown',
+      }));
+      return { rows, columns: outCols, total };
     } finally {
       await sql.end({ timeout: 5 });
     }

--- a/packages/server/src/__tests__/integration/connectors/virtual-feed-read.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/virtual-feed-read.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Virtual feed flag (Slice 2) — end-to-end.
+ *
+ * Proves the three capability guarantees:
+ *  (a) the sync scheduler NEVER selects a `virtual = true` feed for sync — even
+ *      one whose next_run_at is in the past (so the guard, not a NULL schedule,
+ *      is what excludes it);
+ *  (b) `readVirtualFeed` returns LIVE rows via the connector's query()/search()
+ *      pushdown WITHOUT writing to `events`;
+ *  (c) an out-of-scope user is fenced by the AuthzScope connection-visibility
+ *      rule (a member cannot read another user's PRIVATE virtual feed).
+ *
+ * Red→green: without `AND f.virtual IS NOT TRUE` in check-due-feeds, assertion
+ * (a) fails (the virtual feed gets a sync run); without the `virtual` column +
+ * readVirtualFeed seam, (b)/(c) don't compile/run.
+ *
+ * The "external" connection points back at the test DB URL, so the connector
+ * opens a fresh pool and reads a throwaway table as if it were an external source.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { AuthzScope } from '../../../authz/scope';
+import type { Env } from '../../../index';
+import { readVirtualFeed } from '../../../lib/connector-pushdown';
+import { materializeDueFeeds } from '../../../scheduled/check-due-feeds';
+import { createAuthProfile } from '../../../utils/auth-profiles';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { addUserToOrganization, createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+const VFEED_SQL = 'SELECT id, name, amount FROM vfeed_ext';
+
+describe('virtual feed flag (Slice 2)', () => {
+  let orgId: string;
+  let ownerId: string;
+  let orgConnId: number;
+  let orgFeedId: number;
+  let privFeedId: number;
+  let nonVirtualFeedId: number;
+
+  const ownerScope = (): AuthzScope => ({ organizationId: orgId, principal: ownerId });
+  const memberScope = (): AuthzScope => ({ organizationId: orgId, principal: 'member-x' });
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'VirtualFeed' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'vfeed@test.com' });
+    ownerId = user.id;
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    const db = getTestDb();
+    await db`DROP TABLE IF EXISTS vfeed_ext`;
+    await db`CREATE TABLE vfeed_ext (id bigserial primary key, name text, amount numeric)`;
+    await db`INSERT INTO vfeed_ext (name, amount) VALUES ('apple', 10), ('banana', 5), ('apricot', 7)`;
+
+    const profile = await createAuthProfile({
+      organizationId: orgId,
+      connectorKey: 'postgres',
+      displayName: 'ext db',
+      profileKind: 'env',
+      authData: { DATABASE_URL: process.env.DATABASE_URL as string },
+    });
+
+    // Register the postgres connector for this org so the scheduler's
+    // createSyncRun resolves it as runnable (the non-virtual control feed gets a
+    // real run instead of being soft-deleted as an orphan). compiled_code is
+    // NULL — postgres is a BUNDLED connector, so it's runnable from the bundle
+    // and the live read still compiles it on demand (no stub to break query()).
+    await db`
+      INSERT INTO connector_definitions
+        (key, name, version, feeds_schema, auth_schema, organization_id, status, created_at, updated_at)
+      VALUES ('postgres', 'PostgreSQL', '1.0.0', ${db.json({})}, ${db.json({})}, ${orgId}, 'active', NOW(), NOW())
+      ON CONFLICT DO NOTHING
+    `;
+    await db`
+      INSERT INTO connector_versions (connector_key, version, compiled_code, source_path, created_at)
+      VALUES ('postgres', '1.0.0', NULL, NULL, NOW())
+      ON CONFLICT DO NOTHING
+    `;
+
+    // Org-visible connection + a VIRTUAL feed (virtual=true; sync-lifecycle
+    // columns NULL). config.query holds the live read-only SELECT.
+    const [orgConn] = await db`
+      INSERT INTO connections
+        (organization_id, connector_key, slug, display_name, status, auth_profile_id, visibility, created_by, created_at, updated_at)
+      VALUES
+        (${orgId}, 'postgres', 'vfeed-org-db', 'Org DB', 'active', ${profile.id}, 'org', ${ownerId}, NOW(), NOW())
+      RETURNING id
+    `;
+    orgConnId = Number((orgConn as { id: number }).id);
+    const [orgFeed] = await db`
+      INSERT INTO feeds (organization_id, connection_id, feed_key, status, virtual, config, created_at, updated_at)
+      VALUES (${orgId}, ${orgConnId}, 'query', 'active', true,
+        ${db.json({ query: VFEED_SQL, primary_key: 'id', cursor_column: 'id' })}, NOW(), NOW())
+      RETURNING id
+    `;
+    orgFeedId = Number((orgFeed as { id: number }).id);
+
+    // A NON-virtual feed on the same connection, due in the past — the scheduler
+    // control: it MUST be picked while the virtual one is skipped.
+    const [normalFeed] = await db`
+      INSERT INTO feeds (organization_id, connection_id, feed_key, status, virtual, config, next_run_at, schedule, created_at, updated_at)
+      VALUES (${orgId}, ${orgConnId}, 'query', 'active', false,
+        ${db.json({ query: VFEED_SQL, primary_key: 'id', cursor_column: 'id' })},
+        NOW() - INTERVAL '1 minute', '*/5 * * * *', NOW(), NOW())
+      RETURNING id
+    `;
+    nonVirtualFeedId = Number((normalFeed as { id: number }).id);
+
+    // A PRIVATE connection owned by the owner + its virtual feed — a member must
+    // not reach it through the AuthzScope visibility rule.
+    const [privConn] = await db`
+      INSERT INTO connections
+        (organization_id, connector_key, slug, display_name, status, auth_profile_id, visibility, created_by, created_at, updated_at)
+      VALUES
+        (${orgId}, 'postgres', 'vfeed-priv-db', 'Private DB', 'active', ${profile.id}, 'private', ${ownerId}, NOW(), NOW())
+      RETURNING id
+    `;
+    const privConnId = Number((privConn as { id: number }).id);
+    const [privFeed] = await db`
+      INSERT INTO feeds (organization_id, connection_id, feed_key, status, virtual, config, created_at, updated_at)
+      VALUES (${orgId}, ${privConnId}, 'query', 'active', true,
+        ${db.json({ query: VFEED_SQL, primary_key: 'id', cursor_column: 'id' })}, NOW(), NOW())
+      RETURNING id
+    `;
+    privFeedId = Number((privFeed as { id: number }).id);
+  }, 120_000);
+
+  afterAll(async () => {
+    await getTestDb()`DROP TABLE IF EXISTS vfeed_ext`;
+  });
+
+  it('(a) the sync scheduler skips the virtual feed but selects the non-virtual one', async () => {
+    const db = getTestDb();
+    // Force the virtual feed "due" — past next_run_at — to prove the `virtual`
+    // guard (not a NULL schedule) is what excludes it.
+    await db`UPDATE feeds SET next_run_at = NOW() - INTERVAL '1 minute' WHERE id = ${orgFeedId}`;
+
+    await materializeDueFeeds({} as Env, db);
+
+    const virtualRuns = await db`
+      SELECT count(*)::int AS n FROM runs WHERE feed_id = ${orgFeedId} AND run_type = 'sync'
+    `;
+    expect(Number((virtualRuns[0] as { n: number }).n)).toBe(0);
+
+    const normalRuns = await db`
+      SELECT count(*)::int AS n FROM runs WHERE feed_id = ${nonVirtualFeedId} AND run_type = 'sync'
+    `;
+    expect(Number((normalRuns[0] as { n: number }).n)).toBeGreaterThan(0);
+  }, 60_000);
+
+  it('(b) readVirtualFeed returns live rows via query() and persists no events', async () => {
+    const res = await readVirtualFeed({ scope: ownerScope(), feedId: orgFeedId, limit: 10 });
+    expect(res.rows.map((r) => r.name).sort()).toEqual(['apple', 'apricot', 'banana']);
+
+    // No events were written — a virtual read is live, never a sync.
+    const events = await getTestDb()`SELECT count(*)::int AS n FROM events WHERE connection_id = ${orgConnId}`;
+    expect(Number((events[0] as { n: number }).n)).toBe(0);
+  }, 60_000);
+
+  it('(b) readVirtualFeed pushes keyword terms down via search() (ILIKE at source)', async () => {
+    const res = await readVirtualFeed({ scope: ownerScope(), feedId: orgFeedId, terms: ['ap'] });
+    // 'apple' + 'apricot' match 'ap'; 'banana' does not.
+    expect(res.rows.map((r) => r.name).sort()).toEqual(['apple', 'apricot']);
+    expect(res.total).toBe(2);
+
+    const events = await getTestDb()`SELECT count(*)::int AS n FROM events WHERE connection_id = ${orgConnId}`;
+    expect(Number((events[0] as { n: number }).n)).toBe(0);
+  }, 60_000);
+
+  it('(c) a member cannot read another user’s PRIVATE virtual feed (AuthzScope fence)', async () => {
+    await expect(
+      readVirtualFeed({ scope: memberScope(), feedId: privFeedId })
+    ).rejects.toThrow(/not found or not accessible/i);
+
+    // …and the owner still can.
+    const ok = await readVirtualFeed({ scope: ownerScope(), feedId: privFeedId });
+    expect(ok.rows.length).toBe(3);
+  }, 60_000);
+
+  it('refuses to read a NON-virtual feed live', async () => {
+    await expect(
+      readVirtualFeed({ scope: ownerScope(), feedId: nonVirtualFeedId })
+    ).rejects.toThrow(/not a virtual feed/i);
+  }, 60_000);
+});

--- a/packages/server/src/lib/connector-pushdown.ts
+++ b/packages/server/src/lib/connector-pushdown.ts
@@ -1,12 +1,15 @@
 /**
  * Pushdown: run a read-only query LIVE against a connection's source by invoking
  * its connector in `query` mode — no copy, no events. Used by query_sql when a
- * `connection` is given, and (later) by virtual-feed reads. The DB socket lives
- * in the connector subprocess (behind the worker egress controls), never in the
- * gateway. Reuses the same inline-run path as operations.execute (feed-sync.ts).
+ * `connection` is given, and by virtual-feed reads ({@link readVirtualFeed}).
+ * The DB socket lives in the connector subprocess (behind the worker egress
+ * controls), never in the gateway. Reuses the same inline-run path as
+ * operations.execute (feed-sync.ts).
  */
 
 import { executeCompiledConnector } from '@lobu/connector-worker/executor/runtime';
+import { compileConnectionRowVisibility } from '../authz/connection-visibility';
+import type { AuthzScope } from '../authz/scope';
 import { getDb } from '../db/client';
 import { isCloudMode } from '../utils/cloud-mode';
 import { assertConnectorAllowedInCloud } from '../utils/connector-cloud-gate';
@@ -113,6 +116,164 @@ export async function runConnectorQuery(p: ConnectorQueryParams): Promise<Connec
 
   if (result.mode !== 'query') {
     throw new Error(`Expected query result, got mode=${result.mode}`);
+  }
+  return { rows: result.rows, columns: result.columns ?? [], total: result.total };
+}
+
+/** Params for {@link readVirtualFeed}. */
+export interface ReadVirtualFeedParams {
+  /**
+   * The requesting principal + tenant. The feed's backing connection is resolved
+   * through the SAME connection-visibility compiler every read seam uses, so a
+   * user is fenced exactly as on the SQL seam: org-visible connections, or a
+   * private connection they own. A `null` principal (headless) sees org-only.
+   */
+  scope: AuthzScope;
+  /** The virtual feed to read (feeds.id). Must be a `virtual = true` row. */
+  feedId: number;
+  /**
+   * Keyword terms for RECALL. When present and non-empty, the connector's
+   * `search()` runs (terms pushed down to the source); otherwise its `query()`
+   * runs (plain live read). A connector lacking the needed method throws a
+   * "recall over virtual unsupported" / "live queries unsupported" capability
+   * error — surfaced, not branched on.
+   */
+  terms?: string[];
+  /** Row cap pushed down to the source (connector clamps it). */
+  limit?: number;
+  offset?: number;
+  sort?: { column: string; order: 'asc' | 'desc' };
+}
+
+/** Result from {@link readVirtualFeed} — live rows, never persisted. */
+export interface ReadVirtualFeedResult {
+  rows: Record<string, unknown>[];
+  columns: { name: string; type: string }[];
+  total?: number;
+}
+
+/**
+ * Read a VIRTUAL feed LIVE by id — the "(later) virtual-feed reads" seam this
+ * module was built for. Resolves the feed + its backing connection under the
+ * AuthzScope connection-visibility rule, asserts the feed is virtual, then runs
+ * the connector's `search()` (when `terms` are given) or `query()` in the
+ * subprocess behind the worker egress controls. Persists NOTHING (no events, no
+ * checkpoint). Multi-replica safe: a pure per-request read with all state in
+ * Postgres — no pod-local state, runnable on any replica.
+ *
+ * The live SQL is the feed's stored `config.query` (the same read-only SELECT
+ * shape sync uses), so a connector author keeps one query authoring surface.
+ */
+export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVirtualFeedResult> {
+  const sql = getDb();
+
+  // Resolve the feed + connection, fenced by the SAME visibility compiler the
+  // SQL seam uses. Params: $1 feedId, $2 principal (compiler), $3 organizationId.
+  const vis = compileConnectionRowVisibility(p.scope, 2, 'c');
+  const feedRows = (await sql.unsafe(
+    `SELECT f.id, f.feed_key, f.config, f.virtual,
+            c.id AS connection_id, c.connector_key,
+            c.auth_profile_id, c.app_auth_profile_id
+     FROM feeds f
+     JOIN connections c ON c.id = f.connection_id
+     WHERE f.id = $1
+       AND f.organization_id = $3
+       AND f.deleted_at IS NULL
+       AND c.deleted_at IS NULL
+       AND c.status = 'active'
+       ${vis.sql}
+     LIMIT 1`,
+    [p.feedId, ...vis.params, p.scope.organizationId],
+  )) as unknown as Array<{
+    id: number;
+    feed_key: string;
+    config: Record<string, unknown> | null;
+    virtual: boolean;
+    connection_id: number;
+    connector_key: string;
+    auth_profile_id: number | null;
+    app_auth_profile_id: number | null;
+  }>;
+
+  if (feedRows.length === 0) {
+    throw new Error(`virtual feed '${p.feedId}' not found or not accessible`);
+  }
+  const feed = feedRows[0];
+  if (feed.virtual !== true) {
+    throw new Error(`feed '${p.feedId}' is not a virtual feed — only virtual feeds can be read live`);
+  }
+
+  const feedConfig = (feed.config ?? {}) as Record<string, unknown>;
+  const liveQuery = typeof feedConfig.query === 'string' ? feedConfig.query : null;
+  if (!liveQuery) {
+    throw new Error(`virtual feed '${p.feedId}' has no \`query\` in its config`);
+  }
+
+  // Execution-time cloud gate, identical to the slug pushdown above.
+  assertConnectorAllowedInCloud(feed.connector_key);
+
+  const compiledRows = await sql`
+    SELECT compiled_code FROM connector_versions
+    WHERE connector_key = ${feed.connector_key}
+    ORDER BY created_at DESC LIMIT 1
+  `;
+  const rawCode =
+    (compiledRows[0] as { compiled_code: string | null } | undefined)?.compiled_code ?? null;
+  const compiledCode = await resolveConnectorCode(feed.connector_key, rawCode);
+
+  const { credentials, connectionCredentials, sessionState } = await resolveExecutionAuth({
+    organizationId: p.scope.organizationId,
+    connectionId: feed.connection_id,
+    authProfileId: Number(feed.auth_profile_id) || null,
+    appAuthProfileId: Number(feed.app_auth_profile_id) || null,
+    credentialDb: getDb(),
+    logContext: { feedId: String(p.feedId) },
+    logMessage: 'Failed to resolve virtual feed read credentials',
+  });
+
+  // Same credential/egress discipline as runConnectorQuery: only the
+  // connection's own credentials reach ctx.config, with the egress policy
+  // injected LAST so neither config nor credentials can override it.
+  const config = {
+    ...connectionCredentials,
+    ...feedConfig,
+    LOBU_DB_EGRESS_POLICY: isCloudMode() ? 'block-private' : 'allow-private',
+  };
+
+  const terms = (p.terms ?? []).map((t) => t.trim()).filter(Boolean);
+  const result = await executeCompiledConnector({
+    compiledCode,
+    job:
+      terms.length > 0
+        ? {
+            mode: 'search',
+            feedKey: feed.feed_key,
+            query: liveQuery,
+            terms,
+            config,
+            env: {},
+            sessionState,
+            credentials,
+            limit: p.limit,
+            offset: p.offset,
+            sort: p.sort,
+          }
+        : {
+            mode: 'query',
+            feedKey: feed.feed_key,
+            query: liveQuery,
+            config,
+            env: {},
+            sessionState,
+            credentials,
+            limit: p.limit,
+            offset: p.offset,
+            sort: p.sort,
+          },
+  });
+
+  if (result.mode !== 'query' && result.mode !== 'search') {
+    throw new Error(`Expected query/search result, got mode=${result.mode}`);
   }
   return { rows: result.rows, columns: result.columns ?? [], total: result.total };
 }

--- a/packages/server/src/scheduled/check-due-feeds.ts
+++ b/packages/server/src/scheduled/check-due-feeds.ts
@@ -42,6 +42,9 @@ export async function materializeDueFeeds(env: Env, db?: DbClient): Promise<Chec
         AND c.status = 'active'
         AND c.deleted_at IS NULL
         AND f.deleted_at IS NULL
+        -- Virtual feeds are read LIVE at request time (query()/search()), never
+        -- synced — exclude them from the sync scheduler entirely.
+        AND f.virtual IS NOT TRUE
         AND f.next_run_at <= current_timestamp
         AND NOT EXISTS (
           SELECT 1 FROM runs r

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -305,7 +305,8 @@ export const QUERYABLE_SCHEMA = {
         'repair_attempt_count',
         'last_repair_at',
         'first_failure_at',
-        'last_repair_post_hash'
+        'last_repair_post_hash',
+        'virtual'
       ),
     },
     // connector_definitions (excludes: large *_config JSONB blobs)


### PR DESCRIPTION
## Slice 2 — the virtual feed flag

Capability layer that lets a feed be **read live** instead of synced. A virtual feed is read at request time via the connector `query()` / `search()` pushdown and is **never** synced (no events, no checkpoint, no schedule). This is the `(virtual-live-dataset, recall)` tuple of the three-feed-kinds model.

Conflict-safe: does **not** touch `tools/search.ts` or feed enumeration (Stream A owns those). The only integration point is the exported `readVirtualFeed(...)` seam, which Stream A will call from `search.ts`.

### What's in here
- **SDK** — `FeedDefinition.virtual`; new `SearchContext` + optional `ConnectorRuntime.search()` (default throws "recall over virtual unsupported"); lowered via `defineConnector({ search })`.
- **Executor** — `search` job/result mode + `child-runner` dispatch.
- **postgres connector** — `search()` pushes keyword terms DOWN as `ILIKE` across output columns, inside the SAME read-only transaction + egress guard as `query()`, bounded LIMIT.
- **Migration** — `feeds.virtual boolean NOT NULL DEFAULT false` (additive constant default → no rewrite; `squawk-cli@2.58.0` = 0 issues).
- **Scheduler** — `check-due-feeds` adds `AND f.virtual IS NOT TRUE`.
- **Seam** — `readVirtualFeed({ scope, feedId, terms?, limit?, offset?, sort? })` in `lib/connector-pushdown.ts`: resolves feed + connection under the **AuthzScope** visibility compiler, asserts virtual, runs `search()`/`query()` live, persists nothing. Multi-replica safe (pure per-request read).
- **Spec** — `docs/plans/virtual-feed-flag-slice2.md`.

### Integration point for Stream A
```ts
import { readVirtualFeed } from '../lib/connector-pushdown';
readVirtualFeed({ scope, feedId, terms, limit }): Promise<{ rows; columns; total? }>
```

### E2E (hard gate) — `virtual-feed-read.test.ts`, all 5 pass
Real chain: resolve → compile bundled postgres connector → fork subprocess → live DB.
- **(a)** scheduler skips the virtual feed, selects the non-virtual control. Red→green: guard present ⇒ "Found 1 due feeds"; guard removed ⇒ "Found 2" and the test fails (verified).
- **(b)** `readVirtualFeed` returns live rows via `query()` and via `search(['ap'])` (ILIKE pushdown, `total` = filtered count); `events` count stays 0.
- **(c)** a member is fenced from the owner's PRIVATE virtual feed; the owner still reads it.
- a non-virtual feed is refused.

Run: from `packages/server`, `DATABASE_URL=… PGSSLMODE=disable npx vitest run src/__tests__/integration/connectors/virtual-feed-read.test.ts`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785093090&installation_id=136316292&pr_number=1581&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1581&signature=94f2550de041fa35acce6de8b55ea1c652d5abd5e17de5410a8d1ac0fa437e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for virtual feeds that are read live instead of being synced.
  * Live reads can now return search-style results when terms are provided.

* **Bug Fixes**
  * Virtual feeds are now excluded from scheduled sync runs.
  * Access checks now apply consistently to live feed reads, including private feeds.
  * Live reads now return results without creating sync events or checkpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->