### PR TITLE
feat(server): authorization/ACL program — Slack channel visibility gate (vertical 1)

### DIFF
--- a/db/migrations/20260628000000_authz_source_acl_state.sql
+++ b/db/migrations/20260628000000_authz_source_acl_state.sql
@@ -3,17 +3,26 @@
 -- Per-(org, connection) ACL enforcement state — the single switch the
 -- visibility gate reads to decide "is this connection's data access-controlled
 -- yet?" A connection is ENFORCED (per-user channel gating active) only when
--- `acl_support = 'full'` AND `freshness_state = 'fresh'`. Anything else (no row,
--- partial support, stale/unknown/failed freshness) means the gate does NOT
--- restrict this connection's rows beyond the existing per-agent fence — so a
--- connector whose ACL compiler hasn't run (or has gone stale) never silently
--- enforces a half-built graph. This is decision 5/7 of the authz program
+-- `acl_support = 'full'` AND `freshness_state = 'fresh'` AND the graph was synced
+-- recently (the gate ages out a `fresh` row past its staleness window). The two
+-- cases differ:
+--   * NO row at all (connection never graphed) → the gate leaves this
+--     connection on the existing per-agent fence, so a connector whose ACL
+--     compiler has never run is never silently half-enforced.
+--   * A row in ANY non-enforcing state (partial support, or stale/unknown/failed
+--     freshness, or a `fresh` row aged past the window) → the gate FAILS CLOSED:
+--     it drops the connection's channels rather than reverting to legacy, because
+--     an onboarded connection whose graph goes stale must not silently re-expose
+--     every channel.
+-- This is decision 5/7 of the authz program
 -- (docs/plans/authz-acl-permission-program.md): "rollout = the permanent model,
--- not a flag"; the (acl_support, freshness_state) pair IS that data.
+-- not a flag"; the (acl_support, freshness_state, last_synced_at) triple IS that
+-- data.
 --
--- buildSlackChannelGraph stamps a row here ('full','fresh') once it has
--- materialized a workspace's channel membership graph. Later milestones add the
--- freshness reconcile job that flips stale connections back to 'stale'.
+-- buildSlackChannelGraph stamps a row here ('full','fresh', now()) once it has
+-- materialized a workspace's channel membership graph; the periodic
+-- authz-acl-sync tick re-stamps last_synced_at, and the gate's age window flips a
+-- connection fail-closed if that tick stops.
 CREATE TABLE IF NOT EXISTS public.authz_source_acl_state (
     organization_id text NOT NULL,
     connection_id text NOT NULL,

--- a/db/migrations/20260628000000_authz_source_acl_state.sql
+++ b/db/migrations/20260628000000_authz_source_acl_state.sql
@@ -1,0 +1,40 @@
+-- migrate:up
+
+-- Per-(org, connection) ACL enforcement state — the single switch the
+-- visibility gate reads to decide "is this connection's data access-controlled
+-- yet?" A connection is ENFORCED (per-user channel gating active) only when
+-- `acl_support = 'full'` AND `freshness_state = 'fresh'`. Anything else (no row,
+-- partial support, stale/unknown/failed freshness) means the gate does NOT
+-- restrict this connection's rows beyond the existing per-agent fence — so a
+-- connector whose ACL compiler hasn't run (or has gone stale) never silently
+-- enforces a half-built graph. This is decision 5/7 of the authz program
+-- (docs/plans/authz-acl-permission-program.md): "rollout = the permanent model,
+-- not a flag"; the (acl_support, freshness_state) pair IS that data.
+--
+-- buildSlackChannelGraph stamps a row here ('full','fresh') once it has
+-- materialized a workspace's channel membership graph. Later milestones add the
+-- freshness reconcile job that flips stale connections back to 'stale'.
+CREATE TABLE IF NOT EXISTS public.authz_source_acl_state (
+    organization_id text NOT NULL,
+    connection_id text NOT NULL,
+    -- How completely this connection's ACLs are modeled: none | partial | full.
+    acl_support text NOT NULL DEFAULT 'none',
+    -- Confidence the modeled ACLs reflect the source right now:
+    -- fresh | stale | unknown | failed. The gate fails closed on anything but
+    -- 'fresh'.
+    freshness_state text NOT NULL DEFAULT 'unknown',
+    -- When the ACL graph for this connection was last (re)materialized.
+    last_synced_at timestamp with time zone,
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT authz_source_acl_state_pkey PRIMARY KEY (organization_id, connection_id),
+    CONSTRAINT authz_source_acl_state_acl_support_check
+        CHECK (acl_support IN ('none', 'partial', 'full')),
+    CONSTRAINT authz_source_acl_state_freshness_check
+        CHECK (freshness_state IN ('fresh', 'stale', 'unknown', 'failed'))
+);
+
+-- migrate:down
+
+-- squawk-ignore ban-drop-table
+DROP TABLE IF EXISTS public.authz_source_acl_state;

--- a/docs/plans/authz-acl-permission-program.md
+++ b/docs/plans/authz-acl-permission-program.md
@@ -1,0 +1,168 @@
+# Authorization / ACL — finalized architecture
+
+**Status: FINALIZED (decisions locked via interview; pi-reviewed — 7 correctness
+fixes folded in: two-sided `user ∩ agent` gate, explicit `deny_read`, ACL-expr →
+effective principals, freshness-inside-gate, team-scoped Slack ids, fail-closed
+derived provenance, stale prototype removed).** Supersedes the draft
+`authz-identity-foundation-plan.md`: keeps its IF-1..IF-5 identity spine, re-anchors
+everything on the existing entity graph (`entities`/`entity_relationships`/
+`entity_identities`, the #1494 pattern), and adds the gate. **No new principal
+tables; no rollout scaffolding.**
+
+## 0. The requirement
+A requester — human or an agent acting for them — must never see
+connection-sourced data beyond their access in the source system, while we cache
+everything centrally and do zero per-query federation across (tens of) tools.
+Honest bound: "never" holds up to **ACL freshness** (see §5).
+
+## 1. Locked decisions
+1. **Store: PG-native, reuse the entity graph.** Memberships = `entity_relationships`;
+   ACLs = compiled flat principal sets; one SQL gate. No external ReBAC engine
+   (fights "Postgres is the only external"). No new principal/edge/identity tables.
+2. **Revocation: bounded per-source SLA + fail-closed on stale.** Per-source
+   `freshness_state`; deny when freshness is unknown/stale. Customer wording:
+   "reflected within connector-specific freshness guarantees," not literal "never."
+3. **Agent access = agent ∩ user.** An agent acting for a user sees ≤ that user.
+   Autonomous/headless agents get NO ambient org memory. The SAME gate covers
+   agent tool-calls + RAG, not just UI search.
+4. **Unsupported-ACL connector ⇒ fail closed (owner-only).** A connector's
+   restricted data is searchable per-user only after its ACL compiler is tested.
+5. **Cross-provider identity link: verified-email both sides + no primary-id
+   conflict.** Conflict (two members, same verified email) → approval, never
+   silent merge. Name / unverified-email never link.
+6. **Derived artifacts inherit ACLs: visible iff the viewer can see ALL sources.**
+   Provenance-tracked; no cross-ACL blending.
+7. **Rollout = the permanent model, not a flag.** The gate is always on; a
+   connector flips owner-only → enforced via its `aclSupport`/`freshness_state`
+   (data, not scaffolding); the "what did the gate decide" visibility is the
+   permanent audit log you need anyway; per-connector ACL test suites catch
+   compiler bugs pre-ship. **No shadow-mode tech debt.**
+8. **First vertical: Slack, end-to-end.**
+
+Adopted without a separate question (veto-able): **DI-1** promote verified login
+facts → `entity_identities` claims (O(1) webhook resolution); **`$member` and the
+connector-ingested `person` collapse to one entity** via those claims; ACL edges
+use a **`can_read`** relationship type (max reuse of `entity_relationships`).
+
+## 2. Identity (the foundation — IF-1..IF-4, re-anchored)
+- **Resolver:** `resolveRequesterToMember(org, {authUserId | provider+id | email})`
+  → `$member` entity. Extends the existing private `resolveTenantMember`
+  (`identity/auth-hook.ts`) which already resolves `auth_user_id` →
+  `entities('$member')` via `entity_identities`.
+- **Thread into the gate:** set `AuthzScope.principal = $member entity id`
+  (replacing the raw user-id placeholder in `authz/scope.ts`), fail-safe to user
+  id when unresolved (then fail-closed once Slack ACLs enforce).
+- **Promote claims (DI-1):** at login, write the provider's verified identity
+  (`slack_user_id` `T..:U..`, `github_user_id`/`github_login`, google sub, okta
+  sub) as an `entity_identities` claim tied to the `$member`, with an **assurance**
+  marker; mirror `identity/connectors/google.ts`. Backfill from `identity_fact`
+  events.
+- **Linking:** auto-link two providers only on verified-email match both sides +
+  no primary-id conflict; conflict → durable approval plane (reuse manage_agents/
+  watcher field-ownership gate). Per-org `$member`.
+
+## 3. The graph (reuse, zero new tables)
+- **Principals = `entities`** (person/`$member`, company=workspace, group=channel/
+  usergroup). **All Slack identifiers are team-scoped** (`T…:U…` users, `T…:C…`
+  channels, usergroups likewise; Slack Connect / external users carry their own
+  team prefix) so `entity_identities` uniqueness never collapses principals or
+  resources across workspaces.
+- **Memberships = `entity_relationships` `member_of`** (the #1494 machinery;
+  `ensureMemberOfType` + idempotent live-triple unique index).
+- **ACL = `entity_relationships` edges with explicit effect: `can_read` (allow)
+  and `deny_read` (deny)** — deny-wins needs a place to read denies from. `resource
+  → audience` principal. Private channel → `can_read` its member-group; public →
+  `can_read` the workspace company.
+- Boolean ACL **expressions** (Jira `browse AND issue-security`) compile to
+  **effective-read principals** (a synthetic intersection principal or a concrete
+  member set) — **NEVER** naive `can_read` edges to both groups (that is OR → a
+  leak). "Flat principal sets" are safe only because they are *effective-read*
+  principals. If a source can't compile to effective principals safely, it's
+  `aclSupport: none` ⇒ owner-only (decision 4). Slack needs no expressions
+  (membership is already effective).
+
+## 4. The gate (one SQL function, used everywhere) — two-sided, fail-closed
+A row is visible iff **ALL** hold (in one SQL function — no caller conventions):
+1. **User side:** some `can_read` principal ∈ the viewer `$member` closure AND no
+   `deny_read` principal ∈ it (deny wins).
+2. **Agent side:** it is within the run's agent/channel scope. The effective
+   access is **`user ∩ agent`** — an agent NEVER widens beyond both its own scope
+   and the user's. Headless/autonomous agent → empty set.
+3. **Freshness:** the source's `freshness_state = fresh` — checked **inside the
+   gate SQL**, so missing/unknown/stale ACL state DENIES in the same query.
+
+Viewer closure = `$member` + trusted source identities + transitive `member_of`
+(recursive CTE; materialized closure later) + org/public audiences. Returns
+visible resource ids → filters `channel_messages` / `events`. Applied uniformly:
+`search.ts` recall, RAG, agent tool-calls, feeds route, exports — no bypass.
+**Do NOT simply replace the agent-bound-channel fence with the user gate** — that
+widens access from "agent's channels" to "all the user's channels"; intersect them.
+
+## 5. Freshness / revocation
+Per-source `freshness_state` (fresh|stale|unknown|failed) + `aclSupport`
+(full|partial|none) + `strict_mode`. Membership removals are high-priority
+invalidation (Slack `member_left_channel`, already-subscribed events + reconcile
+job). Bounded SLA (Slack private <30s target; others <1-5min); fail closed when
+stale/unknown. Storage: a small `authz_source_acl_state` (org, connection) — the
+ONE genuinely-new small table besides provenance.
+
+## 6. Derived-artifact ACLs (AI oversharing)
+`derived_artifact_sources(artifact_event_id, source_event_id)` provenance; an
+artifact (summary/embedding/memory/cached answer) is visible iff the viewer can
+see ALL its sources. Provenance must be **complete + transitive**; **missing,
+deleted, stale, or unknown-ACL source → DENY the artifact** (fail closed — partial
+provenance is not visibility). RAG: filter candidates → build prompt → revalidate
+citations.
+
+## 7. Database changes (minimal — this is the consolidation payoff)
+- `entity_identities`: add `assurance` (+ `verified_at`), two-phase (squawk gate).
+  [extends existing table]
+- `authz_source_acl_state`: small per-(org,connection) freshness/strict-mode row. [new, small]
+- `derived_artifact_sources`: provenance for derived artifacts. [new, small]
+- `can_read` + `deny_read` relationship types: **data, no migration** (runtime `ensure*Type`).
+- Channels/workspaces as entities, memberships, ACL edges: **no migration** (reuse).
+
+Net: **1 column add + 2 small tables** — vs. the 5 new tables the from-scratch
+approach implied.
+
+## 8. SDK shape (extends ConnectorRuntime; Okta = a connector, no IdP subsystem)
+Connectors emit a typed record union during sync: `event` (today) + `acl`
+(per-item, boolean expr) + `principal` + `membership` + `identity`; declare
+`provides[]` + `aclSupport`. **Okta** = `provides:['principals','groups','identity']`,
+no feeds. **Slack** = event + acl(membership) + principals/groups + identity.
+Per-connector ACL compiler = the trusted security boundary (test suites + golden
+fixtures + "unsupported feature ⇒ fail closed").
+
+## 9. Per-connector reliability (the named targets)
+| connector | emits | hard part |
+|---|---|---|
+| **Slack** (first) | content + acl(membership) + identity(slack_user_id) + groups(usergroups) | private removal = high-pri invalidation; Connect external users explicit |
+| **Okta** | principals + groups + membership + identity (SCIM/OIDC) | canonical person/group layer; not source-native ACLs |
+| **GSuite** | content + acl + identity(google) | link-sharing variants (distinct principals, configurable), domain/inherited |
+| **Jira** | content + acl(**expr**: browse AND issue-security) | intersectional → needs AclExpr; dynamic principals; fail closed if uncompilable |
+| **Linear** | content + acl(team membership) | private teams; identity → person |
+
+## 10. The Slack e2e vertical (first proof, one PR)
+Spine, each step testable, ending in the e2e:
+1. **IF-1** — `resolveRequesterToMember` + thread `$member` into `AuthzScope.principal`.
+2. **Slack identity claim** — promote verified `slack_user_id` claim (subset of IF-2).
+3. **`buildSlackChannelGraph`** — mirror `buildGithubTeamGraph`: `$member member_of #channel`, `can_read` edges, channel/workspace entities; seed via conversations.members, fresh via member_joined/left.
+4. **Gate** — `getVisibleChannelIds($member)` over `entity_relationships`; fail-closed on stale.
+5. **Wire** — replace the agent-bound-channel fence in `search.ts` recall with the `$member` gate.
+6. **E2E (red→green):** a `$member` of `#eng` (not `#secret`) calls `search_memory` → gets `#eng`, not `#secret`; unresolved identity → fail closed.
+
+## 11. Phasing + size
+- **P-Slack** (this vertical, ~3-4 PRs): IF-1 + claim + graph + gate + recall wiring + e2e.
+- **P-Identity breadth** (IF-3 assurance/dedup, IF-4 Okta, IF-5 docs).
+- **P-Sources** (per connector: GSuite → Jira → Linear; each = a tested ACL compiler).
+- **P-Freshness** (reconcile, revocation priority, strict mode).
+- **P-Derived** (provenance + summary/embedding gating).
+Rough: ~10-14 PRs total; the per-connector ACL compilers are the long tail. The
+Slack vertical proves the whole chain first.
+
+## 12. Files (Slack vertical)
+- `identity/auth-hook.ts` (export/generalize resolver), `authz/scope.ts` (thread `$member`).
+- `identity/connectors/slack.ts` (verified-claim emitter, mirror google.ts).
+- new `gateway/.../slack-channel-graph.ts` (mirror `github-team-graph.ts`).
+- new `authz/principal-graph.ts` (the gate over `entity_relationships`).
+- `tools/search.ts` (recall wiring) + the new small migration (assurance col / freshness table).

--- a/packages/server/src/__tests__/integration/authz/slack-channel-graph.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-graph.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Slack channel-membership graph contract (authz program, Slack vertical).
+ *
+ * Mirrors the GitHub team-graph contract: channels become `channel` entities,
+ * members become persons joined by `member_of` edges, and a member who already
+ * signed in (their `$member` carries a `slack_user_id` claim) COLLAPSES onto
+ * that one entity instead of forking a second person. Also asserts idempotency,
+ * tenant scoping, and that the build stamps `authz_source_acl_state` so the gate
+ * starts enforcing the connection.
+ */
+
+import { normalizeSlackUserId } from '@lobu/connector-sdk';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { buildSlackChannelGraph, slackChannelKey } from '../../../authz/slack-channel-graph';
+import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const TEAM = 'T01ENG';
+
+async function ensureType(orgId: string, slug: string, name: string): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+    VALUES (${orgId}, ${slug}, ${name}, current_timestamp, current_timestamp)
+    ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+    DO NOTHING
+  `;
+}
+
+async function seedOrg(name: string) {
+  const org = await createTestOrganization({ name });
+  const user = await createTestUser();
+  await addUserToOrganization(user.id, org.id, 'owner');
+  // The Slack builder auto-creates `person` entities for members; the type must
+  // exist in the org (prod seeds default types at org creation). Mirror the
+  // GitHub team-graph test.
+  await ensureType(org.id, 'person', 'Person');
+  return { org, user };
+}
+
+/** Seed a `$member` entity carrying both an auth_user_id and a (combined)
+ * slack_user_id claim — i.e. a user who signed in AND linked Slack. */
+async function seedSignedInMember(opts: {
+  orgId: string;
+  userId: string;
+  name: string;
+  slackUserId: string;
+}): Promise<number> {
+  const sql = getTestDb();
+  const entity = await createTestEntity({
+    name: opts.name,
+    entity_type: '$member',
+    organization_id: opts.orgId,
+    created_by: opts.userId,
+  });
+  const combined = normalizeSlackUserId(TEAM, opts.slackUserId);
+  await sql`
+    INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+    VALUES
+      (${opts.orgId}, ${entity.id}, 'auth_user_id', ${opts.userId}, 'auth:signup'),
+      (${opts.orgId}, ${entity.id}, 'slack_user_id', ${combined}, 'connector:slack')
+  `;
+  return entity.id;
+}
+
+async function entitiesOfType(orgId: string, slug: string) {
+  const sql = getTestDb();
+  return sql<{ id: number; name: string }[]>`
+    SELECT e.id, e.name
+    FROM entities e
+    JOIN entity_types et ON et.id = e.entity_type_id
+    WHERE e.organization_id = ${orgId} AND et.slug = ${slug} AND e.deleted_at IS NULL
+    ORDER BY e.id
+  `;
+}
+
+async function memberOfEdges(orgId: string) {
+  const sql = getTestDb();
+  return sql<{ from_entity_id: number; to_entity_id: number }[]>`
+    SELECT r.from_entity_id, r.to_entity_id
+    FROM entity_relationships r
+    JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+    WHERE r.organization_id = ${orgId}
+      AND rt.slug = 'member_of'
+      AND r.deleted_at IS NULL
+    ORDER BY r.from_entity_id
+  `;
+}
+
+describe('slack channel graph', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    clearEntityLinkRulesCache();
+  });
+
+  it('builds channel entities + member_of edges and marks the connection enforced', async () => {
+    const { org } = await seedOrg('Slack Graph Org');
+
+    const result = await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: 'conn-acme',
+      teamId: TEAM,
+      channels: [
+        {
+          channelId: 'C01ENG',
+          name: 'eng',
+          memberSlackUserIds: ['U01ALICE', 'U01BOB'],
+        },
+        {
+          channelId: 'C01SEC',
+          name: 'secret',
+          isPrivate: true,
+          memberSlackUserIds: ['U01BOB'],
+        },
+      ],
+    });
+
+    expect(Object.keys(result.channelEntityIds)).toEqual(['C01ENG', 'C01SEC']);
+    // 3 edges: (alice,eng), (bob,eng), (bob,secret).
+    expect(result.createdEdges).toBe(3);
+
+    const channels = await entitiesOfType(org.id, 'channel');
+    expect(channels).toHaveLength(2);
+    const people = await entitiesOfType(org.id, 'person');
+    expect(people).toHaveLength(2); // alice + bob (neither signed in here)
+
+    // The connection is now ACL-enforced.
+    const sql = getTestDb();
+    const stateRows = await sql`
+      SELECT acl_support, freshness_state FROM authz_source_acl_state
+      WHERE organization_id = ${org.id} AND connection_id = 'conn-acme'
+    `;
+    expect(stateRows).toHaveLength(1);
+    expect(stateRows[0].acl_support).toBe('full');
+    expect(stateRows[0].freshness_state).toBe('fresh');
+  });
+
+  it('collapses a member onto an already-signed-in $member (no second person)', async () => {
+    const { org, user } = await seedOrg('Collapse Org');
+    const memberEntityId = await seedSignedInMember({
+      orgId: org.id,
+      userId: user.id,
+      name: 'Alice',
+      slackUserId: 'U01ALICE',
+    });
+    // Before the build there are no persons — only the $member.
+    expect(await entitiesOfType(org.id, 'person')).toHaveLength(0);
+
+    const result = await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: 'conn-acme',
+      teamId: TEAM,
+      channels: [{ channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01ALICE'] }],
+    });
+
+    // Alice resolved to her existing $member — NOT a new person.
+    expect(await entitiesOfType(org.id, 'person')).toHaveLength(0);
+    expect(result.memberEntityIds).toEqual([memberEntityId]);
+    const edges = await memberOfEdges(org.id);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].from_entity_id).toBe(memberEntityId);
+  });
+
+  it('is idempotent on re-run (edges + entities deduped, new member adds one edge)', async () => {
+    const { org } = await seedOrg('Idempotent Org');
+    const base = {
+      organizationId: org.id,
+      connectionId: 'conn-acme',
+      teamId: TEAM,
+    };
+    const first = await buildSlackChannelGraph({
+      ...base,
+      channels: [{ channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01ALICE'] }],
+    });
+    expect(first.createdEdges).toBe(1);
+
+    const second = await buildSlackChannelGraph({
+      ...base,
+      channels: [
+        {
+          channelId: 'C01ENG',
+          name: 'eng',
+          memberSlackUserIds: ['U01ALICE', 'U01BOB'],
+        },
+      ],
+    });
+    expect(second.createdEdges).toBe(1); // only bob is new
+    expect(await entitiesOfType(org.id, 'channel')).toHaveLength(1);
+    expect(await memberOfEdges(org.id)).toHaveLength(2);
+  });
+
+  it('tenant-scopes channels by team — the same channel id in two orgs is two entities', async () => {
+    const a = await seedOrg('Tenant A');
+    const b = await seedOrg('Tenant B');
+    for (const org of [a.org, b.org]) {
+      await buildSlackChannelGraph({
+        organizationId: org.id,
+        connectionId: 'conn-x',
+        teamId: TEAM,
+        channels: [
+          {
+            channelId: 'C01ENG',
+            name: 'eng',
+            memberSlackUserIds: ['U01ALICE'],
+          },
+        ],
+      });
+    }
+    const chA = await entitiesOfType(a.org.id, 'channel');
+    const chB = await entitiesOfType(b.org.id, 'channel');
+    expect(chA).toHaveLength(1);
+    expect(chB).toHaveLength(1);
+    expect(chA[0].id).not.toBe(chB[0].id);
+  });
+
+  it('builds nothing without a team id or channels', async () => {
+    const { org } = await seedOrg('Empty Org');
+    const noTeam = await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: 'c',
+      teamId: '',
+      channels: [{ channelId: 'C01ENG', memberSlackUserIds: ['U01ALICE'] }],
+    });
+    expect(noTeam.createdEdges).toBe(0);
+    expect(Object.keys(noTeam.channelEntityIds)).toHaveLength(0);
+
+    const noChannels = await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: 'c',
+      teamId: TEAM,
+      channels: [],
+    });
+    expect(noChannels.createdEdges).toBe(0);
+  });
+
+  it('exposes a stable team-scoped channel key', () => {
+    expect(slackChannelKey('T01eng', 'c01eng')).toBe('T01ENG:C01ENG');
+  });
+});

--- a/packages/server/src/__tests__/integration/authz/slack-channel-graph.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-graph.test.ts
@@ -195,6 +195,28 @@ describe('slack channel graph', () => {
     expect(await memberOfEdges(org.id)).toHaveLength(2);
   });
 
+  it('revokes a departed member — re-sync without Alice soft-deletes her edge', async () => {
+    const { org } = await seedOrg('Revoke Org');
+    const base = { organizationId: org.id, connectionId: 'conn-acme', teamId: TEAM };
+
+    await buildSlackChannelGraph({
+      ...base,
+      channels: [
+        { channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01ALICE', 'U01BOB'] },
+      ],
+    });
+    expect(await memberOfEdges(org.id)).toHaveLength(2);
+
+    // Alice left #eng — re-sync reflects the source's current membership.
+    const rerun = await buildSlackChannelGraph({
+      ...base,
+      channels: [{ channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01BOB'] }],
+    });
+    expect(rerun.removedEdges).toBe(1);
+    expect(rerun.createdEdges).toBe(0);
+    expect(await memberOfEdges(org.id)).toHaveLength(1); // only Bob remains
+  });
+
   it('tenant-scopes channels by team — the same channel id in two orgs is two entities', async () => {
     const a = await seedOrg('Tenant A');
     const b = await seedOrg('Tenant B');

--- a/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Slack channel visibility gate — END TO END through `search_memory`.
+ *
+ * Proves the authz program's core guarantee for chat recall: an agent bound to
+ * BOTH a channel the user belongs to (#eng) and one they DON'T (#secret)
+ * surfaces only #eng's transcript when that user asks — connection-sourced data
+ * never reaches a user beyond their access in the source system. Also proves the
+ * two fail-closed edges (unresolved requester sees nothing of an enforced
+ * connection) and that a connection WITHOUT a materialized ACL graph keeps the
+ * legacy per-agent behavior (no regression until a workspace is graphed).
+ */
+
+import { normalizeSlackUserId } from '@lobu/connector-sdk';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildSlackChannelGraph } from '../../../authz/slack-channel-graph';
+import { search } from '../../../tools/search';
+import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAgent,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const TEAM = 'T01ACME';
+const CONN = 'conn-acme';
+
+type SearchCtx = Parameters<typeof search>[2];
+
+async function seedSignedInMember(opts: {
+  orgId: string;
+  userId: string;
+  name: string;
+  slackUserId: string;
+}): Promise<number> {
+  const sql = getTestDb();
+  const entity = await createTestEntity({
+    name: opts.name,
+    entity_type: '$member',
+    organization_id: opts.orgId,
+    created_by: opts.userId,
+  });
+  const combined = normalizeSlackUserId(TEAM, opts.slackUserId);
+  await sql`
+    INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+    VALUES
+      (${opts.orgId}, ${entity.id}, 'auth_user_id', ${opts.userId}, 'auth:signup'),
+      (${opts.orgId}, ${entity.id}, 'slack_user_id', ${combined}, 'connector:slack')
+  `;
+  return entity.id;
+}
+
+/** Bind a channel to the agent (with team id) and drop one matching message. */
+async function bindChannel(opts: {
+  orgId: string;
+  agentId: string;
+  channelId: string;
+  text: string;
+}): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id)
+    VALUES (${opts.orgId}, ${opts.agentId}, 'slack', ${opts.channelId}, ${TEAM})
+  `;
+  await sql`
+    INSERT INTO channel_messages (
+      organization_id, connection_id, platform, channel_id,
+      platform_message_id, author_name, is_bot, text, occurred_at
+    ) VALUES (
+      ${opts.orgId}, ${CONN}, 'slack', ${opts.channelId},
+      ${`${opts.channelId}-0`}, 'Alice', false, ${opts.text}, NOW()
+    )
+  `;
+}
+
+function searchAs(orgId: string, userId: string | null, agentId: string) {
+  return search(
+    { query: 'quarterly revenue', include_content: true },
+    {} as Parameters<typeof search>[1],
+    { organizationId: orgId, userId, agentId } as SearchCtx,
+  );
+}
+
+describe('slack channel visibility gate (e2e via search_memory)', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    clearEntityLinkRulesCache();
+  });
+
+  async function setupWorkspace() {
+    const org = await createTestOrganization({ name: 'Acme' });
+    const alice = await createTestUser({ name: 'Alice' });
+    await addUserToOrganization(alice.id, org.id, 'owner');
+    const agent = await createTestAgent({ organizationId: org.id });
+
+    // The builder auto-creates `person` entities for channel members; the type
+    // must exist in the org (prod seeds default types at org creation).
+    const sqlType = getTestDb();
+    await sqlType`
+      INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+      VALUES (${org.id}, 'person', 'Person', current_timestamp, current_timestamp)
+      ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+      DO NOTHING
+    `;
+
+    // The bot connection + bindings to BOTH channels.
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO agent_connections (id, agent_id, platform, organization_id, status)
+      VALUES (${CONN}, ${agent.agentId}, 'slack', ${org.id}, 'active')
+    `;
+    await bindChannel({
+      orgId: org.id,
+      agentId: agent.agentId,
+      channelId: 'C01ENG',
+      text: 'We discussed the quarterly revenue forecast',
+    });
+    await bindChannel({
+      orgId: org.id,
+      agentId: agent.agentId,
+      channelId: 'C01SEC',
+      text: 'Secret: the quarterly revenue numbers are confidential',
+    });
+
+    // Alice signed in + linked Slack.
+    await seedSignedInMember({
+      orgId: org.id,
+      userId: alice.id,
+      name: 'Alice',
+      slackUserId: 'U01ALICE',
+    });
+    return { org, alice, agent };
+  }
+
+  it('surfaces only the channel the user belongs to once the graph is enforced', async () => {
+    const { org, alice, agent } = await setupWorkspace();
+
+    // Alice is a member of #eng only. Bob is the lone member of #secret.
+    await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      teamId: TEAM,
+      channels: [
+        { channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01ALICE'] },
+        {
+          channelId: 'C01SEC',
+          name: 'secret',
+          isPrivate: true,
+          memberSlackUserIds: ['U01BOB'],
+        },
+      ],
+    });
+
+    const result = await searchAs(org.id, alice.id, agent.agentId);
+    const channels = (result.conversation_messages ?? []).map((m) => m.channel_id);
+    expect(channels).toContain('C01ENG');
+    expect(channels).not.toContain('C01SEC');
+  });
+
+  it('fails closed: an unresolved requester sees NONE of an enforced connection', async () => {
+    const { org, agent } = await setupWorkspace();
+    await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      teamId: TEAM,
+      channels: [
+        { channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01ALICE'] },
+        {
+          channelId: 'C01SEC',
+          name: 'secret',
+          isPrivate: true,
+          memberSlackUserIds: ['U01BOB'],
+        },
+      ],
+    });
+
+    // A user with no $member in this org → resolves to nothing → fail closed.
+    const result = await searchAs(org.id, 'intruder-user-id', agent.agentId);
+    expect(result.conversation_messages ?? []).toHaveLength(0);
+  });
+
+  it('no regression: WITHOUT a materialized graph the legacy per-agent fence applies', async () => {
+    const { org, alice, agent } = await setupWorkspace();
+    // No buildSlackChannelGraph → connection is not enforced → both channels recall.
+    const result = await searchAs(org.id, alice.id, agent.agentId);
+    const channels = (result.conversation_messages ?? []).map((m) => m.channel_id);
+    expect(channels).toContain('C01ENG');
+    expect(channels).toContain('C01SEC');
+  });
+});

--- a/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
@@ -16,6 +16,7 @@ import { syncSlackConnectionAcl } from '../../../authz/slack-acl-sync';
 import { buildSlackChannelGraph } from '../../../authz/slack-channel-graph';
 import { search } from '../../../tools/search';
 import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import { ensureMemberEntity } from '../../../utils/member-entity';
 import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
@@ -270,6 +271,75 @@ describe('slack channel visibility gate (e2e via search_memory)', () => {
     // only) recalls #eng, never #secret.
     const search1 = await searchAs(org.id, alice.id, agent.agentId);
     const channels = (search1.conversation_messages ?? []).map((m) => m.channel_id);
+    expect(channels).toContain('C01ENG');
+    expect(channels).not.toContain('C01SEC');
+  });
+
+  it('resolves a member provisioned through the REAL path (ensureMemberEntity), not a hand-seeded identity', async () => {
+    // setupWorkspace seeds Alice via seedSignedInMember, which writes the
+    // auth_user_id identity by hand. THIS test instead provisions a second user
+    // (Carol) the way production does — through ensureMemberEntity (the
+    // shared-org join path) — and DOES NOT touch entity_identities for her
+    // auth_user_id. If ensureMemberEntity stops writing that identity, Carol
+    // resolves to nothing and the gate fails closed → this test goes red. That
+    // is the production gap the hand-seeded tests masked.
+    const { org, agent } = await setupWorkspace();
+    const carol = await createTestUser({ name: 'Carol' });
+    await addUserToOrganization(carol.id, org.id, 'member');
+
+    // Real provisioning — writes the $member entity AND its auth_user_id identity.
+    await ensureMemberEntity({
+      organizationId: org.id,
+      userId: carol.id,
+      name: 'Carol',
+      email: 'carol@acme.test',
+      role: 'member',
+      status: 'active',
+    });
+    // The Slack link is a separate real mechanism (Connect-my-DM / email claim);
+    // attach it so the channel member collapses onto Carol's $member.
+    const sql = getTestDb();
+    const memberRows = await sql<{ entity_id: number }>`
+      SELECT entity_id FROM entity_identities
+      WHERE organization_id = ${org.id}
+        AND namespace = 'email' AND identifier = 'carol@acme.test'
+        AND deleted_at IS NULL
+      LIMIT 1
+    `;
+    // The email identity is written by ensureMemberEntity-adjacent provisioning;
+    // fall back to looking the member up by metadata if email identity is absent.
+    let memberEntityId: number | null = memberRows.length > 0 ? Number(memberRows[0].entity_id) : null;
+    if (memberEntityId === null) {
+      const byMeta = await sql<{ id: number }>`
+        SELECT e.id FROM entities e
+        JOIN entity_types et ON et.id = e.entity_type_id AND et.slug = '$member'
+        WHERE e.organization_id = ${org.id}
+          AND e.metadata->>'email' = 'carol@acme.test'
+          AND e.deleted_at IS NULL
+        LIMIT 1
+      `;
+      memberEntityId = byMeta.length > 0 ? Number(byMeta[0].id) : null;
+    }
+    expect(memberEntityId).not.toBeNull();
+    const combined = normalizeSlackUserId(TEAM, 'U01CAROL');
+    await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+      VALUES (${org.id}, ${memberEntityId}, 'slack_user_id', ${combined}, 'connector:slack')
+    `;
+
+    // Carol is a member of #eng only.
+    await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      teamId: TEAM,
+      channels: [
+        { channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01CAROL'] },
+        { channelId: 'C01SEC', name: 'secret', isPrivate: true, memberSlackUserIds: ['U01BOB'] },
+      ],
+    });
+
+    const result = await searchAs(org.id, carol.id, agent.agentId);
+    const channels = (result.conversation_messages ?? []).map((m) => m.channel_id);
     expect(channels).toContain('C01ENG');
     expect(channels).not.toContain('C01SEC');
   });

--- a/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
@@ -12,6 +12,7 @@
 
 import { normalizeSlackUserId } from '@lobu/connector-sdk';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { syncSlackConnectionAcl } from '../../../authz/slack-acl-sync';
 import { buildSlackChannelGraph } from '../../../authz/slack-channel-graph';
 import { search } from '../../../tools/search';
 import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
@@ -215,5 +216,93 @@ describe('slack channel visibility gate (e2e via search_memory)', () => {
     const channels = (result.conversation_messages ?? []).map((m) => m.channel_id);
     expect(channels).toContain('C01ENG');
     expect(channels).toContain('C01SEC');
+  });
+
+  it('fails closed when the graph ages past the freshness window (no stale-membership re-exposure)', async () => {
+    const { org, alice, agent } = await setupWorkspace();
+    // Alice is a member of #eng → a FRESH graph lets her recall it.
+    await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      teamId: TEAM,
+      channels: [{ channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01ALICE'] }],
+    });
+    const fresh = await searchAs(org.id, alice.id, agent.agentId);
+    expect((fresh.conversation_messages ?? []).map((m) => m.channel_id)).toContain('C01ENG');
+
+    // The sync stops: age this connection's graph past the 60-min window. An
+    // onboarded-but-stale connection must FAIL CLOSED (drop its channels), NOT
+    // fall back to the legacy fence — serving stale membership is the hole the
+    // age-based gate closes. Alice loses recall even though she's still a member.
+    const sql = getTestDb();
+    await sql`
+      UPDATE authz_source_acl_state
+      SET last_synced_at = current_timestamp - interval '90 minutes'
+      WHERE organization_id = ${org.id} AND connection_id = ${CONN}
+    `;
+    const stale = await searchAs(org.id, alice.id, agent.agentId);
+    expect(stale.conversation_messages ?? []).toHaveLength(0);
+  });
+
+  it('enforces through the PRODUCTION sync path (syncSlackConnectionAcl), not just the test builder', async () => {
+    const { org, alice, agent } = await setupWorkspace();
+
+    // Drive the real production caller with a stubbed Slack API + token resolver,
+    // exactly as runSlackAclSyncTick wires it in prod. THIS is what activates the
+    // gate for a live connection — buildSlackChannelGraph is never called by hand.
+    const membersByChannel: Record<string, string[]> = {
+      C01ENG: ['U01ALICE'],
+      C01SEC: ['U01BOB'],
+    };
+    const result = await syncSlackConnectionAcl(
+      {
+        slackWeb: {
+          conversationMembers: async (_token, channelId) => membersByChannel[channelId] ?? [],
+        },
+        resolveBotToken: async () => 'xoxb-test-token',
+      },
+      { connectionId: CONN, organizationId: org.id },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.channelsSynced).toBe(2);
+
+    // The gate now enforces off the materialized graph: Alice (member of #eng
+    // only) recalls #eng, never #secret.
+    const search1 = await searchAs(org.id, alice.id, agent.agentId);
+    const channels = (search1.conversation_messages ?? []).map((m) => m.channel_id);
+    expect(channels).toContain('C01ENG');
+    expect(channels).not.toContain('C01SEC');
+  });
+
+  it('production sync FAILS CLOSED for an already-graphed connection when Slack fetch throws', async () => {
+    const { org, alice, agent } = await setupWorkspace();
+    // First a good sync so the connection has a materialized (enforced) graph.
+    await syncSlackConnectionAcl(
+      {
+        slackWeb: { conversationMembers: async () => ['U01ALICE'] },
+        resolveBotToken: async () => 'xoxb-test-token',
+      },
+      { connectionId: CONN, organizationId: org.id },
+    );
+    expect((await searchAs(org.id, alice.id, agent.agentId)).conversation_messages ?? []).not
+      .toHaveLength(0);
+
+    // Slack outage on the next tick: ANY channel fetch throws → the sync must
+    // mark the connection failed (not leave a half-synced graph), and the gate
+    // then drops every channel until a later tick succeeds.
+    const result = await syncSlackConnectionAcl(
+      {
+        slackWeb: {
+          conversationMembers: async () => {
+            throw new Error('slack outage');
+          },
+        },
+        resolveBotToken: async () => 'xoxb-test-token',
+      },
+      { connectionId: CONN, organizationId: org.id },
+    );
+    expect(result.ok).toBe(false);
+    const after = await searchAs(org.id, alice.id, agent.agentId);
+    expect(after.conversation_messages ?? []).toHaveLength(0);
   });
 });

--- a/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
@@ -185,6 +185,29 @@ describe('slack channel visibility gate (e2e via search_memory)', () => {
     expect(result.conversation_messages ?? []).toHaveLength(0);
   });
 
+  it('revokes on departure: a member who leaves #eng loses recall on the next sync', async () => {
+    const { org, alice, agent } = await setupWorkspace();
+    // Alice is in #eng → can recall it.
+    await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      teamId: TEAM,
+      channels: [{ channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01ALICE'] }],
+    });
+    const before = await searchAs(org.id, alice.id, agent.agentId);
+    expect((before.conversation_messages ?? []).map((m) => m.channel_id)).toContain('C01ENG');
+
+    // Alice leaves #eng → re-sync with the new membership (just Bob).
+    await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      teamId: TEAM,
+      channels: [{ channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01BOB'] }],
+    });
+    const after = await searchAs(org.id, alice.id, agent.agentId);
+    expect((after.conversation_messages ?? []).map((m) => m.channel_id)).not.toContain('C01ENG');
+  });
+
   it('no regression: WITHOUT a materialized graph the legacy per-agent fence applies', async () => {
     const { org, alice, agent } = await setupWorkspace();
     // No buildSlackChannelGraph → connection is not enforced → both channels recall.

--- a/packages/server/src/authz/channel-visibility.ts
+++ b/packages/server/src/authz/channel-visibility.ts
@@ -1,0 +1,164 @@
+/**
+ * The Slack channel visibility gate — "which channels may THIS requester read?"
+ *
+ * Reads the `member_of` edges that `./slack-channel-graph` materializes: a
+ * requester may recall a channel's transcript iff their `$member` entity is
+ * `member_of` that channel. This is the two-sided, fail-closed gate from the
+ * authz program (docs/plans/authz-acl-permission-program.md §4) applied to chat
+ * recall: the existing per-agent channel fence is one side (the agent only sees
+ * its bound channels); this is the other (the user only sees channels they
+ * belong to). The two INTERSECT — an agent acting for a user never widens past
+ * either bound.
+ *
+ * Enforcement is per-connection and OFF by default: a connection's rows are
+ * gated only once it has a fresh `authz_source_acl_state` row (`acl_support
+ * = 'full'` AND `freshness_state = 'fresh'`). A connection with no/partial/stale
+ * ACL state keeps the existing per-agent behavior, so a half-built or absent
+ * graph never silently hides (or, worse, mis-enforces) a channel.
+ *
+ * Fail-closed: for an ENFORCED connection, a channel is dropped unless the
+ * requester is provably a member. An unresolved requester (anonymous/headless,
+ * or no `$member` in this org) sees NONE of an enforced connection's channels.
+ */
+
+import { type DbClient, pgTextArray } from '../db/client.js';
+import { stripPlatformPrefix } from '../gateway/channels/bound-channels.js';
+import { slackChannelKey } from './slack-channel-graph.js';
+
+/** A bound channel the gate decides on. Mirrors the fields `resolveBoundChannelRows`
+ * returns (`id` is the connection id). */
+export interface GatedChannelRow {
+  /** Connection id that owns the channel binding. */
+  id: string;
+  platform: string;
+  /** As stored on the binding — may be platform-prefixed (`slack:C…`) or bare. */
+  channel_id: string;
+  /** Slack workspace id (`T…`); required to form the team-scoped channel key. */
+  team_id: string | null;
+}
+
+/**
+ * Resolve the requester's `$member` entity id in a SPECIFIC org. Restricted to
+ * the auth-server signup claim (`namespace='auth_user_id'`,
+ * `source_connector='auth:signup'`) so a user-supplied identity row can't hijack
+ * the lookup — the same guard `resolveTenantMember` uses, but scoped to the org
+ * the read happens in rather than the user's personal org. Returns null when the
+ * user has no `$member` here (→ fail closed for enforced connections).
+ */
+export async function resolveRequesterMemberEntityId(
+  sql: DbClient,
+  organizationId: string,
+  userId: string | null,
+): Promise<number | null> {
+  if (!userId) return null;
+  const rows = await sql<{ entity_id: number }>`
+		SELECT e.id AS entity_id
+		FROM entity_identities ei
+		JOIN entities e
+		  ON e.id = ei.entity_id
+		 AND e.organization_id = ei.organization_id
+		 AND e.deleted_at IS NULL
+		JOIN entity_types et
+		  ON et.id = e.entity_type_id
+		 AND et.organization_id = e.organization_id
+		 AND et.slug = '$member'
+		WHERE ei.organization_id = ${organizationId}
+		  AND ei.namespace = 'auth_user_id'
+		  AND ei.identifier = ${userId}
+		  AND ei.deleted_at IS NULL
+		  AND ei.source_connector = 'auth:signup'
+		LIMIT 1
+	`;
+  return rows.length > 0 ? Number(rows[0].entity_id) : null;
+}
+
+/**
+ * The subset of `connectionIds` whose ACLs are enforced right now
+ * (`acl_support='full'` AND `freshness_state='fresh'`). Everything else keeps
+ * the legacy per-agent fence.
+ */
+export async function getEnforcedConnectionIds(
+  sql: DbClient,
+  organizationId: string,
+  connectionIds: string[],
+): Promise<Set<string>> {
+  const ids = [...new Set(connectionIds)].filter(Boolean);
+  if (ids.length === 0) return new Set();
+  const rows = await sql<{ connection_id: string }>`
+		SELECT connection_id
+		FROM authz_source_acl_state
+		WHERE organization_id = ${organizationId}
+		  AND connection_id = ANY(${pgTextArray(ids)}::text[])
+		  AND acl_support = 'full'
+		  AND freshness_state = 'fresh'
+	`;
+  return new Set(rows.map((r) => String(r.connection_id)));
+}
+
+/**
+ * The team-scoped channel keys (`T…:C…`) the member can read, via `member_of`
+ * edges to `channel` entities carrying a `slack_channel_id` identity.
+ */
+export async function getVisibleChannelKeysForMember(
+  sql: DbClient,
+  organizationId: string,
+  memberEntityId: number,
+): Promise<Set<string>> {
+  const rows = await sql<{ channel_key: string }>`
+		SELECT ei.identifier AS channel_key
+		FROM entity_relationships r
+		JOIN entity_relationship_types rt
+		  ON rt.id = r.relationship_type_id
+		 AND rt.organization_id = r.organization_id
+		 AND rt.slug = 'member_of'
+		JOIN entity_identities ei
+		  ON ei.entity_id = r.to_entity_id
+		 AND ei.organization_id = r.organization_id
+		 AND ei.namespace = 'slack_channel_id'
+		 AND ei.deleted_at IS NULL
+		WHERE r.organization_id = ${organizationId}
+		  AND r.from_entity_id = ${memberEntityId}
+		  AND r.deleted_at IS NULL
+	`;
+  return new Set(rows.map((r) => String(r.channel_key)));
+}
+
+/**
+ * Filter bound channels down to what the requester may actually read. Channels
+ * on NON-enforced connections pass through unchanged; channels on enforced
+ * connections survive only when the requester is provably `member_of` them.
+ * Fail-closed throughout: an enforced channel with no team id, or an
+ * unresolvable requester, is dropped.
+ *
+ * Returns the surviving rows (same objects, filtered) — the caller keeps its
+ * existing per-channel query shape, just over a possibly-smaller set.
+ */
+export async function filterChannelsForRequester<T extends GatedChannelRow>(
+  sql: DbClient,
+  params: { organizationId: string; userId: string | null; rows: T[] },
+): Promise<T[]> {
+  const { organizationId, userId, rows } = params;
+  if (rows.length === 0) return rows;
+
+  const enforced = await getEnforcedConnectionIds(
+    sql,
+    organizationId,
+    rows.map((r) => r.id),
+  );
+  // Nothing enforced → no per-user gating to apply; preserve legacy behavior
+  // without paying for member resolution.
+  if (enforced.size === 0) return rows;
+
+  const memberEntityId = await resolveRequesterMemberEntityId(sql, organizationId, userId);
+  const visibleKeys =
+    memberEntityId === null
+      ? new Set<string>()
+      : await getVisibleChannelKeysForMember(sql, organizationId, memberEntityId);
+
+  return rows.filter((r) => {
+    if (!enforced.has(r.id)) return true; // legacy fence still applies
+    if (!r.team_id) return false; // can't form the key → fail closed
+    const key = slackChannelKey(r.team_id, stripPlatformPrefix(r.platform, r.channel_id));
+    return visibleKeys.has(key);
+  });
+}

--- a/packages/server/src/authz/channel-visibility.ts
+++ b/packages/server/src/authz/channel-visibility.ts
@@ -73,26 +73,55 @@ export async function resolveRequesterMemberEntityId(
 }
 
 /**
- * The subset of `connectionIds` whose ACLs are enforced right now
- * (`acl_support='full'` AND `freshness_state='fresh'`). Everything else keeps
- * the legacy per-agent fence.
+ * How long a `fresh` ACL graph stays trusted without a re-sync. The background
+ * sync (`./slack-acl-sync`) re-stamps `last_synced_at` every tick; if it stops
+ * (pod down, Slack outage), a connection's graph ages past this window and the
+ * gate stops trusting it — failing closed rather than serving stale membership.
+ * Generous vs. the ~15-min sync cadence so a transient hiccup never blinks
+ * recall off.
  */
-export async function getEnforcedConnectionIds(
+const ACL_STALE_AFTER_MINUTES = 60;
+
+/**
+ * The ACL state of each connection that has been onboarded into the authz
+ * program. A connection ABSENT from the returned map has no
+ * `authz_source_acl_state` row at all — it was never graphed, so it keeps the
+ * legacy per-agent fence. A connection PRESENT in the map has been onboarded and
+ * MUST be enforced: it may use membership filtering only when `enforce` is true
+ * (`acl_support='full'` AND `freshness_state='fresh'` AND the graph was synced
+ * within {@link ACL_STALE_AFTER_MINUTES}). Any other state — stale/failed/unknown
+ * freshness, partial/none support, or a `fresh` row that has aged out — fails
+ * closed: its channels are dropped, never passed through as legacy. Otherwise a
+ * connection whose graph goes stale would silently re-expose every channel.
+ */
+export async function getConnectionAclStates(
   sql: DbClient,
   organizationId: string,
   connectionIds: string[],
-): Promise<Set<string>> {
+): Promise<Map<string, { enforce: boolean }>> {
   const ids = [...new Set(connectionIds)].filter(Boolean);
-  if (ids.length === 0) return new Set();
-  const rows = await sql<{ connection_id: string }>`
-		SELECT connection_id
+  if (ids.length === 0) return new Map();
+  const rows = await sql<{
+    connection_id: string;
+    enforce: boolean;
+  }>`
+		SELECT
+			connection_id,
+			(
+				acl_support = 'full'
+				AND freshness_state = 'fresh'
+				AND last_synced_at IS NOT NULL
+				AND last_synced_at >= current_timestamp - make_interval(mins => ${ACL_STALE_AFTER_MINUTES})
+			) AS enforce
 		FROM authz_source_acl_state
 		WHERE organization_id = ${organizationId}
 		  AND connection_id = ANY(${pgTextArray(ids)}::text[])
-		  AND acl_support = 'full'
-		  AND freshness_state = 'fresh'
 	`;
-  return new Set(rows.map((r) => String(r.connection_id)));
+  const out = new Map<string, { enforce: boolean }>();
+  for (const r of rows) {
+    out.set(String(r.connection_id), { enforce: r.enforce === true });
+  }
+  return out;
 }
 
 /**
@@ -140,23 +169,31 @@ export async function filterChannelsForRequester<T extends GatedChannelRow>(
   const { organizationId, userId, rows } = params;
   if (rows.length === 0) return rows;
 
-  const enforced = await getEnforcedConnectionIds(
+  const states = await getConnectionAclStates(
     sql,
     organizationId,
     rows.map((r) => r.id),
   );
-  // Nothing enforced → no per-user gating to apply; preserve legacy behavior
-  // without paying for member resolution.
-  if (enforced.size === 0) return rows;
+  // No connection onboarded into authz → no per-user gating to apply; preserve
+  // legacy behavior without paying for member resolution.
+  if (states.size === 0) return rows;
 
-  const memberEntityId = await resolveRequesterMemberEntityId(sql, organizationId, userId);
+  // Only resolve the requester's membership when at least one connection is
+  // actively enforcing (full+fresh). Onboarded-but-stale connections fail closed
+  // regardless of who is asking, so they need no membership lookup.
+  const anyEnforcing = [...states.values()].some((s) => s.enforce);
+  const memberEntityId = anyEnforcing
+    ? await resolveRequesterMemberEntityId(sql, organizationId, userId)
+    : null;
   const visibleKeys =
     memberEntityId === null
       ? new Set<string>()
       : await getVisibleChannelKeysForMember(sql, organizationId, memberEntityId);
 
   return rows.filter((r) => {
-    if (!enforced.has(r.id)) return true; // legacy fence still applies
+    const state = states.get(r.id);
+    if (!state) return true; // never graphed → legacy fence still applies
+    if (!state.enforce) return false; // onboarded but stale/unsupported → fail closed
     if (!r.team_id) return false; // can't form the key → fail closed
     const key = slackChannelKey(r.team_id, stripPlatformPrefix(r.platform, r.channel_id));
     return visibleKeys.has(key);

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -1,0 +1,198 @@
+/**
+ * Slack channel-membership SYNC — the production path that populates the authz
+ * graph the visibility gate reads. Without this, `buildSlackChannelGraph` would
+ * only ever run from tests and the gate would never enforce a real connection.
+ *
+ * Per Slack connection: resolve the channels it actually captures
+ * (`resolveBoundChannelRows` — the same source of truth the gate filters), fetch
+ * each channel's current membership from Slack (`conversations.members`), and
+ * hand the whole set to `buildSlackChannelGraph`, which materializes the
+ * `member_of` edges, reconciles departures, and stamps the connection
+ * `full`/`fresh`. A periodic tick (`runSlackAclSyncTick`, wired in
+ * `scheduled/jobs.ts`) re-runs this so membership changes (joins/leaves) converge
+ * within the sync cadence, and the gate's freshness window fails the connection
+ * closed if the tick ever stops.
+ *
+ * Fail-closed on error: the sync is ATOMIC per connection. If ANY channel's
+ * membership fetch throws (Slack outage, bot removed, missing token), we do NOT
+ * build a half-synced graph — we mark the connection's ACL state `failed` so the
+ * gate drops all its channels until a later tick succeeds. We only DOWNGRADE an
+ * existing row; a connection that has never been graphed stays on the legacy
+ * fence (a brand-new connection whose first sync fails must not suddenly hide
+ * every channel).
+ */
+
+import { createLogger } from '@lobu/core';
+import { getDb } from '../db/client.js';
+import {
+  resolveBoundChannelRows,
+  stripPlatformPrefix,
+} from '../gateway/channels/bound-channels.js';
+import { createSlackWebApi, type SlackWebApi } from '../gateway/connections/slack-web.js';
+import { resolveSecretValue } from '../gateway/secrets/index.js';
+import type { CoreServices } from '../gateway/services/core-services.js';
+import { getSlackInstallByTeamId } from '../lobu/stores/slack-installations.js';
+import { orgContext } from '../lobu/stores/org-context.js';
+import { buildSlackChannelGraph, type SlackChannelInput } from './slack-channel-graph.js';
+
+const logger = createLogger('slack-acl-sync');
+
+/** Injectable seams so tests drive the real graph build + gate with a stubbed
+ * Slack API and token resolver, and the live tick wires the real ones. */
+export interface SlackAclSyncDeps {
+  slackWeb: Pick<SlackWebApi, 'conversationMembers'>;
+  /** Resolve the bot token for a workspace, or null if none is available
+   * (no active install / unresolvable secret) — null is treated fail-closed. */
+  resolveBotToken: (params: {
+    organizationId: string;
+    teamId: string;
+  }) => Promise<string | null>;
+}
+
+export interface SlackAclSyncResult {
+  /** True when every bound Slack channel was fetched and graphed. */
+  ok: boolean;
+  teamsSynced: number;
+  channelsSynced: number;
+}
+
+/** Downgrade an EXISTING ACL row to `failed` so the gate fails closed. A no-op
+ * when the connection was never graphed (no row) — it stays on the legacy
+ * fence rather than flipping to drop-everything on its first failure. */
+async function markConnectionAclFailed(
+  organizationId: string,
+  connectionId: string,
+): Promise<void> {
+  const sql = getDb();
+  await sql`
+		UPDATE authz_source_acl_state
+		SET freshness_state = 'failed', updated_at = current_timestamp
+		WHERE organization_id = ${organizationId}
+		  AND connection_id = ${connectionId}
+	`;
+}
+
+/**
+ * Sync ONE Slack connection's channel-membership graph. Resolves its captured
+ * channels, fetches members per channel, and builds the graph (per team). See
+ * the file header for the fail-closed contract.
+ */
+export async function syncSlackConnectionAcl(
+  deps: SlackAclSyncDeps,
+  params: { connectionId: string; organizationId: string },
+): Promise<SlackAclSyncResult> {
+  const { connectionId, organizationId } = params;
+  const sql = getDb();
+
+  const bound = await resolveBoundChannelRows(sql, {
+    organizationId,
+    connectionId,
+  });
+  // Only Slack rows that carry a team id can be team-scoped into the graph; a
+  // channel with no team id is dropped fail-closed by the gate anyway.
+  const slackRows = bound.filter(
+    (r) => r.platform.startsWith('slack') && r.team_id,
+  );
+  if (slackRows.length === 0) {
+    return { ok: true, teamsSynced: 0, channelsSynced: 0 };
+  }
+
+  // Group channels by workspace/team — one graph build per team.
+  const byTeam = new Map<string, string[]>();
+  for (const r of slackRows) {
+    const channelId = stripPlatformPrefix(r.platform, r.channel_id);
+    const list = byTeam.get(r.team_id as string) ?? [];
+    list.push(channelId);
+    byTeam.set(r.team_id as string, list);
+  }
+
+  let teamsSynced = 0;
+  let channelsSynced = 0;
+  try {
+    for (const [teamId, channelIds] of byTeam) {
+      const token = await deps.resolveBotToken({ organizationId, teamId });
+      if (!token) {
+        throw new Error(`No bot token for team ${teamId}`);
+      }
+      const channels: SlackChannelInput[] = [];
+      for (const channelId of channelIds) {
+        const memberSlackUserIds = await deps.slackWeb.conversationMembers(
+          token,
+          channelId,
+        );
+        channels.push({ channelId, memberSlackUserIds });
+      }
+      await buildSlackChannelGraph({
+        organizationId,
+        connectionId,
+        teamId,
+        channels,
+      });
+      teamsSynced += 1;
+      channelsSynced += channels.length;
+    }
+    return { ok: true, teamsSynced, channelsSynced };
+  } catch (error) {
+    logger.error(
+      {
+        organization_id: organizationId,
+        connection_id: connectionId,
+        error: String(error),
+      },
+      'Slack ACL sync failed — marking connection fail-closed',
+    );
+    await markConnectionAclFailed(organizationId, connectionId);
+    return { ok: false, teamsSynced, channelsSynced };
+  }
+}
+
+/**
+ * The periodic production caller (registered in `scheduled/jobs.ts`). Re-syncs
+ * every active Slack connection's channel-membership graph so joins/leaves
+ * converge within the tick cadence and the gate's freshness window keeps a
+ * stalled connection fail-closed. Runs on one replica per tick (the TaskScheduler
+ * runs-queue claim), iterating connections sequentially — membership sync is not
+ * latency-critical.
+ *
+ * Token resolution keys on the workspace install (`getSlackInstallByTeamId`), so
+ * it covers the prod OAuth-install path; a connection whose team has no active
+ * install is skipped (its sync throws → fail-closed via {@link syncSlackConnectionAcl}).
+ */
+export async function runSlackAclSyncTick(coreServices: CoreServices): Promise<void> {
+  const sql = getDb();
+  const connections = await sql<{ id: string; organization_id: string }>`
+		SELECT id, organization_id
+		FROM agent_connections
+		WHERE platform = 'slack' AND status = 'active'
+	`;
+  if (connections.length === 0) return;
+
+  const installStore = coreServices.getAppInstallationStore();
+  const secretStore = coreServices.getSecretStore();
+  const slackWeb = createSlackWebApi();
+
+  const deps: SlackAclSyncDeps = {
+    slackWeb,
+    resolveBotToken: async ({ teamId }) => {
+      const install = await getSlackInstallByTeamId(installStore, teamId);
+      if (!install || install.status !== 'active') return null;
+      const tokenRef = (install.config as { botToken?: string }).botToken;
+      const token = await orgContext.run({ organizationId: install.organizationId }, () =>
+        resolveSecretValue(secretStore, tokenRef),
+      );
+      return token ?? null;
+    },
+  };
+
+  let ok = 0;
+  let failed = 0;
+  for (const conn of connections) {
+    const result = await syncSlackConnectionAcl(deps, {
+      connectionId: conn.id,
+      organizationId: conn.organization_id,
+    });
+    if (result.ok) ok += 1;
+    else failed += 1;
+  }
+  logger.info({ connections: connections.length, ok, failed }, 'Slack ACL sync tick complete');
+}

--- a/packages/server/src/authz/slack-channel-graph.ts
+++ b/packages/server/src/authz/slack-channel-graph.ts
@@ -1,0 +1,332 @@
+/**
+ * Slack channel membership graph — the first ACL source for the authorization
+ * program (docs/plans/authz-acl-permission-program.md, the Slack e2e vertical).
+ *
+ * Mirrors `buildGithubTeamGraph`: it REUSES the existing entity graph rather
+ * than introducing any new principal/edge/identity tables.
+ *
+ *   - each Slack channel becomes a `channel` entity, identified by its
+ *     team-scoped id (`slack_channel_id` = `T…:C…`) so two workspaces never
+ *     collapse onto one channel entity;
+ *   - each channel member becomes a `person` resolved through the SAME
+ *     entity-identity machinery (`slack_user_id` = `T…:U…`), so a member who
+ *     already signed in (their `$member` carries a promoted `slack_user_id`
+ *     claim) COLLAPSES onto that one entity instead of forking a second person;
+ *   - a `member_of` edge (person → channel) is written per (member, channel).
+ *
+ * The visibility gate (`./channel-visibility`) reads exactly these `member_of`
+ * edges: a requester may recall a channel's transcript iff they are `member_of`
+ * that channel. For Slack, channel membership IS the read ACL — so this graph
+ * needs no separate `can_read`/`deny_read` edges. (Public-channel "any
+ * workspace member can read without joining" is a deliberate follow-up; gating
+ * on membership only ever UNDER-shares, never over-shares — the safe direction.)
+ *
+ * Completing the build stamps `authz_source_acl_state` ('full','fresh') for the
+ * connection, which is the switch the gate consults to start enforcing. Until a
+ * connection has a fresh row here, the gate leaves its rows on the existing
+ * per-agent fence (no half-built graph ever silently enforces).
+ *
+ * Tenant-scoped + idempotent + best-effort, exactly like the GitHub builder:
+ * everything filters on `organizationId`; `member_of` dedupes on the live-triple
+ * unique index; failures are logged and surfaced, never thrown.
+ */
+
+import { normalizeSlackUserId } from '@lobu/connector-sdk';
+import { createLogger } from '@lobu/core';
+import { getDb, pgTextArray } from '../db/client.js';
+import { resolveEntityLinksForItems } from '../utils/entity-link-upsert.js';
+
+const logger = createLogger('slack-channel-graph');
+
+const SLACK_CONNECTOR_KEY = 'slack';
+const MEMBER_OF_TYPE_SLUG = 'member_of';
+const CHANNEL_ENTITY_TYPE_SLUG = 'channel';
+
+/** Identity namespaces. Channels/teams use custom (trim-only) namespaces; the
+ * user id reuses the canonical `slack_user_id` namespace so it collapses with
+ * login-promoted claims. */
+const SLACK_CHANNEL_ID_NS = 'slack_channel_id';
+
+/** A Slack channel and the (bare `U…`) ids of its members. */
+export interface SlackChannelInput {
+  /** Bare Slack channel id (`C…` / `G…`). */
+  channelId: string;
+  name?: string;
+  isPrivate?: boolean;
+  /** Bare Slack user ids (`U…`) of the channel's members. */
+  memberSlackUserIds: string[];
+}
+
+export interface SlackChannelGraphResult {
+  /** Bare channel id → the `channel` entity id that now represents it. */
+  channelEntityIds: Record<string, number>;
+  /** Distinct member person/`$member` entity ids that gained a `member_of` edge. */
+  memberEntityIds: number[];
+  /** How many `member_of` edges were newly created (vs already present). */
+  createdEdges: number;
+}
+
+const EMPTY_RESULT: SlackChannelGraphResult = {
+  channelEntityIds: {},
+  memberEntityIds: [],
+  createdEdges: 0,
+};
+
+/** The team-scoped channel key the gate matches on (`T…:C…`, upper-cased). */
+export function slackChannelKey(teamId: string, channelId: string): string {
+  return `${teamId.trim()}:${channelId.trim()}`.toUpperCase();
+}
+
+/** Resolve an org owner/admin as `entities.created_by` / edge `created_by`
+ * (NOT NULL on entities). Same query the GitHub builder uses. */
+async function resolveOrgCreator(orgId: string): Promise<string | null> {
+  const sql = getDb();
+  const rows = await sql<{ userId: string }>`
+		SELECT "userId"
+		FROM "member"
+		WHERE "organizationId" = ${orgId}
+		ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END,
+		         "createdAt" ASC
+		LIMIT 1
+	`;
+  return rows.length > 0 ? rows[0].userId : null;
+}
+
+/** Find-or-create the org-scoped `channel` entity type (reuse, no migration). */
+async function ensureChannelEntityType(orgId: string): Promise<void> {
+  const sql = getDb();
+  await sql`
+		INSERT INTO entity_types (slug, name, description, icon, organization_id, created_at, updated_at)
+		VALUES (
+			${CHANNEL_ENTITY_TYPE_SLUG}, 'Channel',
+			'A chat channel (Slack channel, etc.) — the unit of conversation access control',
+			'hash', ${orgId}, current_timestamp, current_timestamp
+		)
+		ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+		DO NOTHING
+	`;
+}
+
+/** Find-or-create the org-scoped `member_of` relationship type. */
+async function ensureMemberOfType(orgId: string): Promise<number> {
+  const sql = getDb();
+  const rows = await sql`
+		INSERT INTO entity_relationship_types
+			(slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
+		VALUES
+			(${MEMBER_OF_TYPE_SLUG}, 'Member of', 'A person is a member of an organization or channel', ${orgId},
+			 false, NULL, current_timestamp, current_timestamp)
+		ON CONFLICT (organization_id, slug) WHERE status = 'active'
+		DO UPDATE SET updated_at = EXCLUDED.updated_at
+		RETURNING id
+	`;
+  return Number(rows[0].id);
+}
+
+/** Stamp the connection's ACL state so the gate begins enforcing it. */
+async function markAclEnforced(orgId: string, connectionId: string): Promise<void> {
+  const sql = getDb();
+  await sql`
+		INSERT INTO authz_source_acl_state
+			(organization_id, connection_id, acl_support, freshness_state, last_synced_at, created_at, updated_at)
+		VALUES (${orgId}, ${connectionId}, 'full', 'fresh', current_timestamp, current_timestamp, current_timestamp)
+		ON CONFLICT (organization_id, connection_id)
+		DO UPDATE SET acl_support = 'full', freshness_state = 'fresh',
+		              last_synced_at = current_timestamp, updated_at = current_timestamp
+	`;
+}
+
+/**
+ * Materialize a Slack workspace's channel-membership graph and mark the
+ * connection ACL-enforced. Injectable `channels` (with their members) so tests
+ * and the live sync both call the same builder — exactly like the GitHub team
+ * graph takes `members` directly.
+ *
+ * @returns the channel entity ids, the member entity ids, and how many edges
+ *          were newly created. Empty when there is nothing to build.
+ */
+export async function buildSlackChannelGraph(params: {
+  organizationId: string;
+  connectionId: string;
+  /** The workspace/team id (`T…`); used to team-scope every channel + member key. */
+  teamId: string;
+  channels: SlackChannelInput[];
+}): Promise<SlackChannelGraphResult> {
+  const { organizationId, connectionId, teamId } = params;
+  const channels = params.channels.filter((c) => c.channelId);
+  if (!teamId || channels.length === 0) return EMPTY_RESULT;
+
+  const creatorUserId = await resolveOrgCreator(organizationId);
+  if (!creatorUserId) {
+    logger.warn(
+      { organization_id: organizationId },
+      'Slack channel graph skipped: org has no member to attribute as entity creator',
+    );
+    return EMPTY_RESULT;
+  }
+
+  await ensureChannelEntityType(organizationId);
+
+  // 1) Resolve every channel to a `channel` entity, keyed on its team-scoped id.
+  const channelItems = channels.map((c) => ({
+    origin_type: 'slack_channel',
+    metadata: {
+      channel_key: slackChannelKey(teamId, c.channelId),
+      channel_name: c.name ?? c.channelId,
+    },
+  }));
+  const resolvedChannels = await resolveEntityLinksForItems({
+    connectorKey: SLACK_CONNECTOR_KEY,
+    orgId: organizationId,
+    items: channelItems,
+    rules: {
+      slack_channel: [
+        {
+          entityType: CHANNEL_ENTITY_TYPE_SLUG,
+          autoCreate: true,
+          titlePath: 'metadata.channel_name',
+          identities: [
+            {
+              namespace: SLACK_CHANNEL_ID_NS,
+              eventPath: 'metadata.channel_key',
+              primary: true,
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  const channelEntityIds: Record<string, number> = {};
+  const channelEntityIdByIndex = new Map<number, number>();
+  for (let i = 0; i < channels.length; i++) {
+    const ids = resolvedChannels.get(i);
+    if (ids && ids.length > 0) {
+      channelEntityIds[channels[i].channelId] = ids[0];
+      channelEntityIdByIndex.set(i, ids[0]);
+    }
+  }
+
+  // 2) Resolve every DISTINCT member (team-scoped `T:U`) to an entity.
+  // Identity-first, TYPE-AGNOSTIC: a member who already signed in owns their
+  // `slack_user_id` claim on a `$member` entity, so we must collapse onto THAT
+  // entity — but `resolveEntityLinksForItems` matches only within the rule's
+  // own entity type ('person'), so it would never find the `$member` and would
+  // fork a duplicate. So we resolve existing owners ourselves (any type) and
+  // only auto-create a `person` for genuinely-new Slack users.
+  const memberKeys = new Map<string, string>(); // bare U… → combined T:U
+  for (const c of channels) {
+    for (const u of c.memberSlackUserIds) {
+      const combined = normalizeSlackUserId(teamId, u);
+      if (combined) memberKeys.set(u, combined);
+    }
+  }
+  const combinedKeys = [...new Set([...memberKeys.values()])];
+  const memberEntityByCombined = new Map<string, number>();
+  const sqlMembers = getDb();
+  if (combinedKeys.length > 0) {
+    // Existing owners of these slack_user_ids — ANY entity type ($member,
+    // person, …). This is the collapse seam.
+    const existing = await sqlMembers<{
+      identifier: string;
+      entity_id: number;
+    }>`
+			SELECT identifier, entity_id
+			FROM entity_identities
+			WHERE organization_id = ${organizationId}
+			  AND namespace = 'slack_user_id'
+			  AND identifier = ANY(${pgTextArray(combinedKeys)}::text[])
+			  AND deleted_at IS NULL
+		`;
+    for (const row of existing) {
+      memberEntityByCombined.set(String(row.identifier), Number(row.entity_id));
+    }
+
+    // Whoever is left has no entity yet → auto-create a `person` for each.
+    const toCreate = combinedKeys.filter((k) => !memberEntityByCombined.has(k));
+    if (toCreate.length > 0) {
+      const memberItems = toCreate.map((combined) => ({
+        origin_type: 'slack_member',
+        metadata: { slack_user: combined },
+      }));
+      const resolvedMembers = await resolveEntityLinksForItems({
+        connectorKey: SLACK_CONNECTOR_KEY,
+        orgId: organizationId,
+        items: memberItems,
+        rules: {
+          slack_member: [
+            {
+              entityType: 'person',
+              autoCreate: true,
+              titlePath: 'metadata.slack_user',
+              identities: [
+                {
+                  namespace: 'slack_user_id',
+                  eventPath: 'metadata.slack_user',
+                  primary: true,
+                },
+              ],
+            },
+          ],
+        },
+      });
+      for (let i = 0; i < toCreate.length; i++) {
+        const ids = resolvedMembers.get(i);
+        if (ids && ids.length > 0) memberEntityByCombined.set(toCreate[i], ids[0]);
+      }
+    }
+  }
+
+  // 3) Write person -> channel `member_of` edges, idempotent on the live-triple
+  // unique index.
+  const typeId = await ensureMemberOfType(organizationId);
+  const sql = getDb();
+  const memberEntityIds = new Set<number>();
+  let createdEdges = 0;
+  for (let i = 0; i < channels.length; i++) {
+    const channelEntityId = channelEntityIdByIndex.get(i);
+    if (channelEntityId === undefined) continue;
+    for (const u of channels[i].memberSlackUserIds) {
+      const combined = memberKeys.get(u);
+      if (!combined) continue;
+      const memberEntityId = memberEntityByCombined.get(combined);
+      if (memberEntityId === undefined) continue;
+      memberEntityIds.add(memberEntityId);
+      const inserted = await sql<{ id: number }[]>`
+				INSERT INTO entity_relationships (
+					organization_id, from_entity_id, to_entity_id, relationship_type_id,
+					confidence, source, created_by, updated_by, created_at, updated_at
+				) VALUES (
+					${organizationId}, ${memberEntityId}, ${channelEntityId}, ${typeId},
+					1.0, 'feed', ${creatorUserId}, ${creatorUserId},
+					current_timestamp, current_timestamp
+				)
+				ON CONFLICT (from_entity_id, to_entity_id, relationship_type_id)
+					WHERE deleted_at IS NULL
+				DO NOTHING
+				RETURNING id
+			`;
+      if (inserted.length > 0) createdEdges += 1;
+    }
+  }
+
+  await markAclEnforced(organizationId, connectionId);
+
+  logger.info(
+    {
+      organization_id: organizationId,
+      connection_id: connectionId,
+      team_id: teamId,
+      channels: Object.keys(channelEntityIds).length,
+      members: memberEntityIds.size,
+      created_edges: createdEdges,
+    },
+    'Built Slack channel graph',
+  );
+
+  return {
+    channelEntityIds,
+    memberEntityIds: [...memberEntityIds],
+    createdEdges,
+  };
+}

--- a/packages/server/src/authz/slack-channel-graph.ts
+++ b/packages/server/src/authz/slack-channel-graph.ts
@@ -33,7 +33,7 @@
 
 import { normalizeSlackUserId } from '@lobu/connector-sdk';
 import { createLogger } from '@lobu/core';
-import { getDb, pgTextArray } from '../db/client.js';
+import { getDb, pgBigintArray, pgTextArray } from '../db/client.js';
 import { resolveEntityLinksForItems } from '../utils/entity-link-upsert.js';
 
 const logger = createLogger('slack-channel-graph');
@@ -64,12 +64,15 @@ export interface SlackChannelGraphResult {
   memberEntityIds: number[];
   /** How many `member_of` edges were newly created (vs already present). */
   createdEdges: number;
+  /** How many stale `member_of` edges were soft-deleted (members who left). */
+  removedEdges: number;
 }
 
 const EMPTY_RESULT: SlackChannelGraphResult = {
   channelEntityIds: {},
   memberEntityIds: [],
   createdEdges: 0,
+  removedEdges: 0,
 };
 
 /** The team-scoped channel key the gate matches on (`T…:C…`, upper-cased). */
@@ -278,20 +281,26 @@ export async function buildSlackChannelGraph(params: {
   }
 
   // 3) Write person -> channel `member_of` edges, idempotent on the live-triple
-  // unique index.
+  // unique index. Accumulate the CURRENT member set per channel entity so we can
+  // reconcile departures below.
   const typeId = await ensureMemberOfType(organizationId);
   const sql = getDb();
   const memberEntityIds = new Set<number>();
+  const currentMembersByChannel = new Map<number, Set<number>>();
   let createdEdges = 0;
   for (let i = 0; i < channels.length; i++) {
     const channelEntityId = channelEntityIdByIndex.get(i);
     if (channelEntityId === undefined) continue;
+    const channelMembers =
+      currentMembersByChannel.get(channelEntityId) ?? new Set<number>();
+    currentMembersByChannel.set(channelEntityId, channelMembers);
     for (const u of channels[i].memberSlackUserIds) {
       const combined = memberKeys.get(u);
       if (!combined) continue;
       const memberEntityId = memberEntityByCombined.get(combined);
       if (memberEntityId === undefined) continue;
       memberEntityIds.add(memberEntityId);
+      channelMembers.add(memberEntityId);
       const inserted = await sql<{ id: number }[]>`
 				INSERT INTO entity_relationships (
 					organization_id, from_entity_id, to_entity_id, relationship_type_id,
@@ -310,6 +319,31 @@ export async function buildSlackChannelGraph(params: {
     }
   }
 
+  // 4) Reconcile DEPARTURES — the build is a full re-sync of each channel's
+  // membership, so a `member_of` edge to a synced channel whose member is NOT in
+  // the current set means that person left: soft-delete it so they immediately
+  // lose recall access. WITHOUT this, leavers keep visibility forever (the gate
+  // only reads live edges). Scoped to `to_entity_id` = a channel we just synced,
+  // so person→company edges (GitHub team graph) are never touched. An empty
+  // member set deletes all of that channel's edges (the channel was synced with
+  // zero members) — the live caller must not pass empty-on-fetch-error, exactly
+  // like the identity emitter's null guard.
+  let removedEdges = 0;
+  for (const [channelEntityId, channelMembers] of currentMembersByChannel) {
+    const keep = [...channelMembers];
+    const removed = await sql<{ id: number }[]>`
+			UPDATE entity_relationships
+			SET deleted_at = current_timestamp, updated_at = current_timestamp
+			WHERE organization_id = ${organizationId}
+			  AND relationship_type_id = ${typeId}
+			  AND to_entity_id = ${channelEntityId}
+			  AND deleted_at IS NULL
+			  AND from_entity_id <> ALL(${pgBigintArray(keep)}::bigint[])
+			RETURNING id
+		`;
+    removedEdges += removed.length;
+  }
+
   await markAclEnforced(organizationId, connectionId);
 
   logger.info(
@@ -320,6 +354,7 @@ export async function buildSlackChannelGraph(params: {
       channels: Object.keys(channelEntityIds).length,
       members: memberEntityIds.size,
       created_edges: createdEdges,
+      removed_edges: removedEdges,
     },
     'Built Slack channel graph',
   );
@@ -328,5 +363,6 @@ export async function buildSlackChannelGraph(params: {
     channelEntityIds,
     memberEntityIds: [...memberEntityIds],
     createdEdges,
+    removedEdges,
   };
 }

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -17,6 +17,13 @@ export interface SlackWebApi {
   openDm(botToken: string, slackUserId: string): Promise<string>;
   /** `chat.postMessage` of a plain-text body. Throws on a Slack-level error. */
   postMessage(botToken: string, channel: string, text: string): Promise<void>;
+  /**
+   * `conversations.members` for one channel — the bare `U…` ids of every member,
+   * following `response_metadata.next_cursor` to completion. Throws on a
+   * Slack-level error (the ACL sync treats a throw as fail-closed). Used by the
+   * authz channel-membership sync to materialize the read-ACL graph.
+   */
+  conversationMembers(botToken: string, channelId: string): Promise<string[]>;
 }
 
 async function slackPost(
@@ -63,6 +70,29 @@ export function createSlackWebApi(): SlackWebApi {
         );
         throw error;
       }
+    },
+    async conversationMembers(botToken, channelId) {
+      const members: string[] = [];
+      let cursor: string | undefined;
+      do {
+        const json = await slackPost(botToken, "conversations.members", {
+          channel: channelId,
+          limit: 200,
+          ...(cursor ? { cursor } : {}),
+        });
+        const page = Array.isArray(json.members)
+          ? (json.members as unknown[]).filter(
+              (m): m is string => typeof m === "string"
+            )
+          : [];
+        members.push(...page);
+        const meta = json.response_metadata as
+          | { next_cursor?: string }
+          | undefined;
+        const next = meta?.next_cursor;
+        cursor = next && next.length > 0 ? next : undefined;
+      } while (cursor);
+      return members;
     },
   };
 }

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Env } from '@lobu/connector-sdk';
+import { runSlackAclSyncTick } from '../authz/slack-acl-sync';
 import type { CoreServices } from '../gateway/services/core-services';
 import { getChatInstanceManager } from '../lobu/gateway';
 import { cleanupExpiredMcpSessions } from '../mcp-handler';
@@ -146,6 +147,20 @@ function registerMaintenanceTasks(
       }
     },
     { cron: '*/5 * * * *' },
+  );
+
+  // Slack channel-membership ACL sync — re-materializes each active Slack
+  // connection's `member_of` graph (the authz read-gate's source of truth) from
+  // live `conversations.members`, so channel joins/leaves converge within the
+  // cadence and the gate's freshness window keeps a stalled connection
+  // fail-closed. Single-claimant per tick via the runs-queue. Off until a Slack
+  // workspace exists (the tick no-ops on zero connections).
+  scheduler.register(
+    'authz-acl-sync',
+    async () => {
+      await runSlackAclSyncTick(coreServices);
+    },
+    { cron: '*/15 * * * *' },
   );
 
   // Connector health alerter — surfaces connectors that have silently died

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -13,6 +13,7 @@ import { getDb } from '../db/client';
 import type { Env } from '../index';
 import { entityLinkMatchSql, searchContentByText } from '../utils/content-search';
 import { resolveBoundChannelRows, stripPlatformPrefix } from '../gateway/channels/bound-channels';
+import { filterChannelsForRequester } from '../authz/channel-visibility';
 import { toVectorLiteral } from '../utils/entity-management';
 import { ToolUserError } from '../utils/errors';
 import logger from '../utils/logger';
@@ -341,10 +342,17 @@ const RECALL_STOPWORDS = new Set([
 /**
  * Keyword/recency hits from the chat transcript (`channel_messages`) — no
  * embeddings. Scoped HARD to the channels the calling agent is bound to
- * (`resolveBoundChannelRows`), which IS the tenant fence: channel_messages has
- * no agent_id/user_id of its own, so an agent may only recall its own
- * conversations, exactly like read_conversation. channel_messages carries only
- * the recency index, so the scan is bounded to those channels.
+ * (`resolveBoundChannelRows`), which IS the per-agent tenant fence:
+ * channel_messages has no agent_id/user_id of its own, so an agent may only
+ * recall its own conversations, exactly like read_conversation. channel_messages
+ * carries only the recency index, so the scan is bounded to those channels.
+ *
+ * The bound-channel set is then INTERSECTED with what the requesting USER may
+ * read (`filterChannelsForRequester`): for a connection whose channel-ACL graph
+ * is materialized + fresh, a channel survives only if the user is `member_of`
+ * it, so an agent acting for a user never surfaces a channel the user isn't in.
+ * Connections without a fresh ACL graph pass through on the per-agent fence
+ * alone (no behavior change). See authz/channel-visibility.
  *
  * Distinctive terms are AND-matched (ILIKE). A prompt with NO distinctive term
  * ("what did we talk about earlier") falls back to the most recent messages in
@@ -353,11 +361,21 @@ const RECALL_STOPWORDS = new Set([
 async function fetchConversationSnippets(
   query: string,
   organizationId: string,
+  userId: string | null,
   agentId: string,
   limit: number
 ): Promise<ConversationSnippet[]> {
   const sql = getDb();
-  const channels = await resolveBoundChannelRows(sql, { organizationId, agentId });
+  const boundChannels = await resolveBoundChannelRows(sql, { organizationId, agentId });
+  if (boundChannels.length === 0) return [];
+  // Per-user ACL gate: drop channels the requester isn't a member of, for
+  // connections that have a fresh channel-ACL graph. Non-enforced connections
+  // are returned unchanged, so this is a no-op until a workspace is graphed.
+  const channels = await filterChannelsForRequester(sql, {
+    organizationId,
+    userId,
+    rows: boundChannels,
+  });
   if (channels.length === 0) return [];
 
   // Distinctive >2-char terms (generic recall words dropped). Tokenize on word
@@ -466,11 +484,13 @@ const conversationSource: RecallSource = {
   kind: 'conversation',
   recall: async (ctx) => {
     // Needs a calling agent (its bindings are the tenant fence) and a text query
-    // (keyword match has no embedding path).
+    // (keyword match has no embedding path). The requesting user (`ctx.userId`)
+    // is the per-user side of the gate — see fetchConversationSnippets.
     if (!ctx.query || !ctx.channelAgentId) return {};
     const conversation_messages = await fetchConversationSnippets(
       ctx.query,
       ctx.organizationId,
+      ctx.userId,
       ctx.channelAgentId,
       ctx.contentLimit
     );

--- a/packages/server/src/utils/member-entity.ts
+++ b/packages/server/src/utils/member-entity.ts
@@ -50,40 +50,63 @@ export async function ensureMemberEntity(params: EnsureMemberEntityParams): Prom
   await ensureMemberEntityType(params.organizationId);
   const { emailField, imageField } = await resolveMemberSchemaFields(params.organizationId);
 
-  // Check if a $member entity with this email already exists
-  const existing = await sql.unsafe(
-    `SELECT e.id
-    FROM entities e
-    JOIN entity_types et ON et.id = e.entity_type_id
-    WHERE et.slug = '$member'
-      AND e.organization_id = $1
-      AND e.metadata->>$2 = $3
-      AND e.deleted_at IS NULL
-    LIMIT 1`,
-    [params.organizationId, emailField, params.email]
-  );
-  if (existing.length > 0) return;
-
-  const metadata: Record<string, unknown> = {
-    [emailField]: params.email,
-    status: params.status ?? 'active',
+  const findIdByEmail = async (): Promise<number | null> => {
+    const rows = await sql.unsafe<{ id: number }>(
+      `SELECT e.id
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE et.slug = '$member'
+        AND e.organization_id = $1
+        AND e.metadata->>$2 = $3
+        AND e.deleted_at IS NULL
+      LIMIT 1`,
+      [params.organizationId, emailField, params.email]
+    );
+    return rows.length > 0 ? Number(rows[0].id) : null;
   };
-  if (params.image && imageField) metadata[imageField] = params.image;
-  if (params.role) metadata.role = params.role;
 
-  const entityData: Record<string, unknown> = {
+  // Check if a $member entity with this email already exists; create it if not.
+  let memberEntityId = await findIdByEmail();
+  if (memberEntityId === null) {
+    const metadata: Record<string, unknown> = {
+      [emailField]: params.email,
+      status: params.status ?? 'active',
+    };
+    if (params.image && imageField) metadata[imageField] = params.image;
+    if (params.role) metadata.role = params.role;
+
+    const entityData: Record<string, unknown> = {
       entity_type: '$member',
       name: params.name.trim(),
       organization_id: params.organizationId,
       metadata,
-  };
-  if (params.userId) {
-    (entityData as any).created_by = params.userId;
+    };
+    if (params.userId) {
+      (entityData as any).created_by = params.userId;
+    }
+    await createEntity(entityData as any, { skipHooks: true });
+    memberEntityId = await findIdByEmail();
   }
-  await createEntity(
-    entityData as any,
-    { skipHooks: true }
-  );
+
+  // Write the org-scoped auth_user_id identity so identity-based resolution (the
+  // authz channel-visibility gate's resolveRequesterMemberEntityId) can find this
+  // member in THIS org — not only the user's personal org. Without it, a member
+  // provisioned via a shared-org join (join-public) would resolve to nothing and
+  // every enforced connection would fail closed for them. Idempotent, and applied
+  // to existing members too so ones created before this gets backfilled. The
+  // 'auth:signup' source is the gate's anti-hijack guard — only written here from
+  // trusted server-side provisioning with a verified user id.
+  if (params.userId && memberEntityId !== null) {
+    await sql`
+      INSERT INTO entity_identities (
+        organization_id, entity_id, namespace, identifier, source_connector
+      ) VALUES (
+        ${params.organizationId}, ${memberEntityId}, 'auth_user_id', ${params.userId}, 'auth:signup'
+      )
+      ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+      DO NOTHING
+    `;
+  }
 }
 
 /**


### PR DESCRIPTION
## What

First implementation slice of the authorization/ACL program. Ships the **finalized architecture doc** (`docs/plans/authz-acl-permission-program.md`, interview-locked + pi-reviewed) **and** the **Slack e2e vertical** it specifies (§10): a user — or an agent acting for one — never recalls a channel's transcript beyond their access in the source system, while everything stays cached centrally (zero per-query federation).

The guarantee is enforced as a SQL gate over the **existing entity graph** (`entities` / `entity_relationships` / `entity_identities`) — **no new principal tables**, mirroring the `#1494` `buildGithubTeamGraph` pattern.

## How

- **`authz/slack-channel-graph.ts` — `buildSlackChannelGraph`** (mirrors `buildGithubTeamGraph`): each Slack channel → a `channel` entity (team-scoped `slack_channel_id` = `T:C`); each member → a `person` (`slack_user_id` = `T:U`) that **collapses onto an already-signed-in `$member`**; joined by `member_of` edges. Collapse is **identity-first across entity types** (the type-scoped `resolveEntityLinksForItems` match would otherwise fork a duplicate person past the `$member`).
- **`authz/channel-visibility.ts` — the gate**: a requester may read a channel iff their `$member` is `member_of` it. **Two-sided + fail-closed** — the existing per-agent channel fence AND the per-user membership **intersect** (an agent acting for a user never widens past either).
- **Enforcement is per-connection and OFF until materialized**: a connection's rows are gated only once its graph is built + fresh (`authz_source_acl_state`, `acl_support='full'` + `freshness_state='fresh'`). A half-built or absent graph never silently enforces — **existing recall is unchanged until a workspace is graphed**.
- **Wired into `search_memory`** conversation recall (`tools/search.ts`): the bound-channel set is intersected with the user-visible set.

## DB changes

One new small table: **`authz_source_acl_state`** (per `(org, connection)`: `acl_support`, `freshness_state`, `last_synced_at`). No other schema changes — channels/members/edges reuse the entity graph.

## E2E (red → green)

`__tests__/integration/authz/slack-channel-visibility.test.ts` drives the real `search_memory` tool:
- ✅ a `$member` of `#eng` (not `#secret`), with an agent bound to **both**, recalls `#eng` and **not** `#secret`;
- ✅ an unresolved requester (no `$member`) sees **none** of an enforced connection (fail closed);
- ✅ a connection **without** a materialized graph keeps the legacy per-agent behavior (no regression).

Plus the builder contract (`slack-channel-graph.test.ts`): `$member` collapse, idempotency, tenant scoping, ACL-state stamping. **9/9 green**; server `tsc` clean; existing `search-channel-recall` / `recall-sources` / `table-schema` drift tests still green (22/22).

## Scope / follow-ups (per the doc's phasing)

This is the gate + graph + recall wiring, proven end-to-end with injected membership. Deliberately **deferred to the next PRs**: live Slack seeding (`conversations.members` sync + `member_joined/left` freshness reconcile), login-time `slack_user_id` claim promotion, public-channel "read-without-join" (today gating on membership only ever under-shares — the safe direction), and extending the gate to RAG/exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785202234&installation_id=136316292&pr_number=1586&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1586&signature=ac1562798e1efafda0e0de595c04d6613fddccf290637f42de98cf049a8f23cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack channel membership visibility is now enforced via an ACL “freshness” gate.
  * A new periodic Slack ACL sync job materializes and refreshes the visibility graph.
* **Bug Fixes**
  * Conversation recall now filters results to only the Slack channels the requesting user can access.
  * Authorization is fail-closed when freshness/state can’t be verified, sync fails, or the requester can’t be resolved.
  * Channel membership changes are reconciled on sync so departing members lose access promptly.
* **Tests**
  * Added end-to-end integration coverage for Slack channel graph building and visibility gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->