### PR TITLE
feat(scheduled): deliver wake_agent replies to the originating platform channel

### DIFF
--- a/db/migrations/20260630120000_scheduled_jobs_delivery_context.sql
+++ b/db/migrations/20260630120000_scheduled_jobs_delivery_context.sql
@@ -1,0 +1,12 @@
+-- migrate:up
+
+-- Add trusted, scheduler-owned chat delivery metadata for wake_agent jobs.
+-- Nullable JSONB column only, no default/backfill: metadata-only catalog change
+-- on Postgres, O(1) regardless of scheduled_jobs size.
+ALTER TABLE public.scheduled_jobs
+  ADD COLUMN IF NOT EXISTS delivery_context jsonb;
+
+-- migrate:down
+
+ALTER TABLE public.scheduled_jobs
+  DROP COLUMN IF EXISTS delivery_context;

--- a/packages/server/src/auth/oauth/types.ts
+++ b/packages/server/src/auth/oauth/types.ts
@@ -205,6 +205,18 @@ export interface AuthInfo {
   clientId: string;
   scopes: string[];
   expiresAt: number; // Unix timestamp
+  /** Verified agent context for worker direct-auth sessions. */
+  agentId?: string | null;
+  /** Verified source conversation for worker direct-auth tool calls. */
+  sourceContext?: {
+    platform?: string;
+    conversationId?: string;
+    channelId?: string;
+    teamId?: string;
+    connectionId?: string;
+    userId?: string;
+    source?: string;
+  } | null;
   resource?: string;
   tokenType: 'access_token' | 'pat';
   /**

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -32,8 +32,8 @@ import { createSlackWebApi, type SlackWebApi } from '../gateway/connections/slac
 import { resolveSecretValue } from '../gateway/secrets/index.js';
 import type { CoreServices } from '../gateway/services/core-services.js';
 import {
-  legacyIdToSlug,
-  slugToLegacyId,
+  runtimeConnectionIdToSlug,
+  slugToRuntimeConnectionId,
 } from '../lobu/stores/connections-projection.js';
 import { getSlackInstallByTeamId } from '../lobu/stores/slack-installations.js';
 import { orgContext } from '../lobu/stores/org-context.js';
@@ -110,7 +110,7 @@ export async function syncSlackConnectionAcl(
   const [conn] = await sql<{ team_id: string | null }>`
 		SELECT COALESCE(external_tenant_id, config->'chatMetadata'->>'teamId') AS team_id
 		FROM connections
-		WHERE slug = ${legacyIdToSlug(connectionId)}
+		WHERE slug = ${runtimeConnectionIdToSlug(connectionId)}
 		  AND organization_id = ${organizationId}
 		  AND credential_mode IS NOT NULL
 		  AND deleted_at IS NULL
@@ -226,7 +226,7 @@ export async function runSlackAclSyncTick(coreServices: CoreServices): Promise<v
 		  AND deleted_at IS NULL
 	`;
   const connections = connRows.map((r) => ({
-    id: slugToLegacyId(r.slug),
+    id: slugToRuntimeConnectionId(r.slug),
     organization_id: r.organization_id,
   }));
   if (connections.length === 0) return;

--- a/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
@@ -194,24 +194,9 @@ async function handleCallToolAuthenticated(
 		// structured `result_summary` (event ids + snippet text) through the
 		// `tool_use` SSE event.
 		const callerFormat = c.req.header("x-mcp-format");
-		const extraHeaders: Record<string, string> = {};
-		if (callerFormat) extraHeaders["x-mcp-format"] = callerFormat;
-
-		// Forward the caller's originating conversation context to channel-scoped
-		// (first-party) MCP servers, so a server-side tool that schedules async
-		// work can deliver the eventual reply back into that channel rather than a
-		// detached session. The channel/connection ids are what let the server
-		// reconstruct a real platform message. Gated on authScope === "channel" so
-		// this context is never leaked to per-user third-party MCP servers.
-		if (httpServer.authScope === "channel") {
-			const td = auth.tokenData;
-			if (td.conversationId) extraHeaders["x-lobu-conversation-id"] = td.conversationId;
-			if (td.channelId) extraHeaders["x-lobu-channel-id"] = td.channelId;
-			if (td.teamId) extraHeaders["x-lobu-team-id"] = td.teamId;
-			if (td.connectionId) extraHeaders["x-lobu-connection-id"] = td.connectionId;
-			if (td.platform) extraHeaders["x-lobu-source-platform"] = td.platform;
-			if (td.userId) extraHeaders["x-lobu-source-user-id"] = td.userId;
-		}
+		const extraHeaders = callerFormat
+			? { "x-mcp-format": callerFormat }
+			: undefined;
 
 		let response = await proxy.upstream.sendUpstreamRequest(
 			httpServer,
@@ -221,7 +206,7 @@ async function handleCallToolAuthenticated(
 			jsonRpcBody,
 			scopeKey,
 			auth.token,
-			Object.keys(extraHeaders).length > 0 ? extraHeaders : undefined,
+			extraHeaders,
 		);
 
 		let data = (await parseJsonRpcResponse(response)) as JsonRpcResponse;
@@ -260,6 +245,7 @@ async function handleCallToolAuthenticated(
 				jsonRpcBody,
 				scopeKey,
 				auth.token,
+				extraHeaders,
 			);
 			data = (await parseJsonRpcResponse(response)) as JsonRpcResponse;
 		}

--- a/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
@@ -197,18 +197,20 @@ async function handleCallToolAuthenticated(
 		const extraHeaders: Record<string, string> = {};
 		if (callerFormat) extraHeaders["x-mcp-format"] = callerFormat;
 
-		// Forward the caller's originating conversation to channel-scoped
+		// Forward the caller's originating conversation context to channel-scoped
 		// (first-party) MCP servers, so a server-side tool that schedules async
-		// work can deliver the eventual reply back into that conversation rather
-		// than a detached session. Gated on authScope === "channel" so a
-		// conversation id is never leaked to per-user third-party MCP servers.
+		// work can deliver the eventual reply back into that channel rather than a
+		// detached session. The channel/connection ids are what let the server
+		// reconstruct a real platform message. Gated on authScope === "channel" so
+		// this context is never leaked to per-user third-party MCP servers.
 		if (httpServer.authScope === "channel") {
-			if (auth.tokenData.conversationId) {
-				extraHeaders["x-lobu-conversation-id"] = auth.tokenData.conversationId;
-			}
-			if (auth.tokenData.platform) {
-				extraHeaders["x-lobu-source-platform"] = auth.tokenData.platform;
-			}
+			const td = auth.tokenData;
+			if (td.conversationId) extraHeaders["x-lobu-conversation-id"] = td.conversationId;
+			if (td.channelId) extraHeaders["x-lobu-channel-id"] = td.channelId;
+			if (td.teamId) extraHeaders["x-lobu-team-id"] = td.teamId;
+			if (td.connectionId) extraHeaders["x-lobu-connection-id"] = td.connectionId;
+			if (td.platform) extraHeaders["x-lobu-source-platform"] = td.platform;
+			if (td.userId) extraHeaders["x-lobu-source-user-id"] = td.userId;
 		}
 
 		let response = await proxy.upstream.sendUpstreamRequest(

--- a/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
@@ -194,9 +194,22 @@ async function handleCallToolAuthenticated(
 		// structured `result_summary` (event ids + snippet text) through the
 		// `tool_use` SSE event.
 		const callerFormat = c.req.header("x-mcp-format");
-		const extraHeaders = callerFormat
-			? { "x-mcp-format": callerFormat }
-			: undefined;
+		const extraHeaders: Record<string, string> = {};
+		if (callerFormat) extraHeaders["x-mcp-format"] = callerFormat;
+
+		// Forward the caller's originating conversation to channel-scoped
+		// (first-party) MCP servers, so a server-side tool that schedules async
+		// work can deliver the eventual reply back into that conversation rather
+		// than a detached session. Gated on authScope === "channel" so a
+		// conversation id is never leaked to per-user third-party MCP servers.
+		if (httpServer.authScope === "channel") {
+			if (auth.tokenData.conversationId) {
+				extraHeaders["x-lobu-conversation-id"] = auth.tokenData.conversationId;
+			}
+			if (auth.tokenData.platform) {
+				extraHeaders["x-lobu-source-platform"] = auth.tokenData.platform;
+			}
+		}
 
 		let response = await proxy.upstream.sendUpstreamRequest(
 			httpServer,
@@ -206,7 +219,7 @@ async function handleCallToolAuthenticated(
 			jsonRpcBody,
 			scopeKey,
 			auth.token,
-			extraHeaders,
+			Object.keys(extraHeaders).length > 0 ? extraHeaders : undefined,
 		);
 
 		let data = (await parseJsonRpcResponse(response)) as JsonRpcResponse;

--- a/packages/server/src/gateway/channels/bound-channels.ts
+++ b/packages/server/src/gateway/channels/bound-channels.ts
@@ -31,7 +31,7 @@
  * workspace (channel ids are workspace-scoped, not global).
  */
 import type { DbClient } from "../../db/client.js";
-import { legacyIdToSlug } from "../../lobu/stores/connections-projection.js";
+import { runtimeConnectionIdToSlug } from "../../lobu/stores/connections-projection.js";
 
 interface BoundChannelRow {
   /** Connection id that owns the post (preview conn for cross-org). */
@@ -52,7 +52,7 @@ export async function resolveBoundChannelRows(
   }
 ): Promise<BoundChannelRow[]> {
   const { organizationId, agentId, connectionId } = opts;
-  const slugFilter = connectionId ? legacyIdToSlug(connectionId) : null;
+  const slugFilter = connectionId ? runtimeConnectionIdToSlug(connectionId) : null;
   // Agent scope is BINDING ownership (`b.agent_id`), NOT the connection's
   // agent_id — a managed Slack install has agent_id NULL but its bindings still
   // belong to the agent that linked them, so filtering on the connection would
@@ -66,7 +66,7 @@ export async function resolveBoundChannelRows(
   // `connections` keys chat rows by `slug` (`agentconn-<id>` for BYO,
   // `slackinst-<id>` verbatim for managed). Callers expect the runtime
   // connection id, so strip the BYO namespace back off in SQL (mirror of
-  // `slugToLegacyId`). Folded columns: platform → `connector_key`,
+  // `slugToRuntimeConnectionId`). Folded columns: platform → `connector_key`,
   // settings/metadata → `config.{settings,chatMetadata}`, teamId →
   // `external_tenant_id`. Chat rows carry `credential_mode IS NOT NULL`.
   return (await sql`

--- a/packages/server/src/gateway/connections/platforms/telegram.ts
+++ b/packages/server/src/gateway/connections/platforms/telegram.ts
@@ -9,7 +9,7 @@
 import { randomUUID } from "node:crypto";
 import { createLogger, isSecretRef } from "@lobu/core";
 import { getDb } from "../../../db/client.js";
-import { legacyIdToSlug } from "../../../lobu/stores/connections-projection.js";
+import { runtimeConnectionIdToSlug } from "../../../lobu/stores/connections-projection.js";
 import { isCloudMode } from "../../../utils/cloud-mode.js";
 import type { IFileHandler } from "../../platform/file-handler.js";
 import { persistSecretValue, resolveSecretValue } from "../../secrets/index.js";
@@ -100,7 +100,7 @@ async function ensureTelegramWebhookSecret(
   // same transaction. Concurrent replicas serialize on the row lock, so only
   // the first writer generates and the rest read its ref. Returns the
   // effective `secret://` ref, or null when there is no stored row to lock.
-  const slug = legacyIdToSlug(connection.id);
+  const slug = runtimeConnectionIdToSlug(connection.id);
   // `connections` is unique per (organization_id, slug) — scope BOTH the lock
   // and the write to this connection's org so a slug shared across orgs can
   // never share or overwrite another tenant's secretToken. A missing org (an

--- a/packages/server/src/gateway/services/platform-helpers.ts
+++ b/packages/server/src/gateway/services/platform-helpers.ts
@@ -159,7 +159,11 @@ export function buildMessagePayload(params: {
   userId: string;
   botId: string;
   conversationId: string;
-  teamId: string;
+  // Optional to match the wire `MessagePayload` (the worker reads
+  // `payload.teamId ?? platformMetadata.teamId`). Slack always supplies it;
+  // teamless platforms (Telegram) and synthetic scheduled wakes omit it
+  // rather than stamping a placeholder.
+  teamId?: string;
   agentId: string;
   organizationId?: string;
   messageId: string;

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -24,7 +24,7 @@ import {
   createPostgresAgentConnectionStore,
 } from './stores/postgres-stores';
 import { orgContext } from './stores/org-context';
-import { legacyIdToSlug } from './stores/connections-projection';
+import { runtimeConnectionIdToSlug } from './stores/connections-projection';
 
 const routes = new Hono<{ Bindings: Env }>();
 
@@ -1161,7 +1161,7 @@ routes.put('/:agentId/platforms/by-stable-id/:stableId', async (c) => {
         VALUES (
           ${claimOrgId}, ${platform}, ${agentId}, ${platform}, 'paused',
           ${sql.json({ settings: {}, chatMetadata: {} })}, 'byo',
-          ${legacyIdToSlug(stableId)}, 'org', ${claimNow}, ${claimNow}
+          ${runtimeConnectionIdToSlug(stableId)}, 'org', ${claimNow}, ${claimNow}
         )
         -- Arbiter on the GLOBAL chat-slug uniqueness (connections_chat_slug_unique),
         -- mirroring the retired ON CONFLICT (agent_connections.id): a re-claim of an

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -1,16 +1,15 @@
 /**
  * The chat ⇄ `connections` mapping + writer. `connections` is the SOLE source of
- * truth for chat connections: the legacy `agent_connections` table is gone, so
- * the chat runtime reads and writes `connections` exclusively. A BYO chat
- * connection is keyed by `slug` (`agentconn-<id>`); a managed Slack install keeps
- * its `slackinst-<id>` external id AS the slug. Adapter config + `settings` +
- * `chatMetadata` fold into the `config` jsonb; the provider tenant lifts into the
- * first-class `external_tenant_id` column.
+ * truth for chat connections: chat runtime reads and writes `connections`
+ * exclusively. A BYO chat connection is keyed by `slug` (`agentconn-<id>`); a
+ * managed Slack install keeps its `slackinst-<id>` external id AS the slug.
+ * Adapter config + `settings` + `chatMetadata` fold into the `config` jsonb; the
+ * provider tenant lifts into the first-class `external_tenant_id` column.
  *
- * This module owns the bidirectional id⇄slug mapping + the projection writer. It
- * does NOT import from `slack-installations.ts` (that file imports the writer
- * here), so the managed-install wire prefix is mirrored locally to keep the
- * dependency one-directional.
+ * This module owns the bidirectional runtime-id⇄slug mapping + the projection
+ * writer. It does NOT import from `slack-installations.ts` (that file imports
+ * the writer here), so the managed-install wire prefix is mirrored locally to
+ * keep the dependency one-directional.
  */
 
 import type { StoredConnection } from "@lobu/core";
@@ -37,17 +36,17 @@ export type ChatCredentialMode = "byo" | "managed";
 /**
  * Runtime connection id → `connections.slug`. BYO ids gain the `agentconn-`
  * namespace; managed Slack ids (`slackinst-…`) ARE the slug. Inverse of
- * {@link slugToLegacyId}.
+ * {@link slugToRuntimeConnectionId}.
  */
-export function legacyIdToSlug(id: string): string {
+export function runtimeConnectionIdToSlug(id: string): string {
   return id.startsWith(SLACK_INSTALLATION_ID_PREFIX)
     ? id
     : `${BYO_SLUG_PREFIX}${id}`;
 }
 
 /** `connections.slug` → the runtime connection id (strips the BYO namespace;
- *  managed slugs pass through). Inverse of {@link legacyIdToSlug}. */
-export function slugToLegacyId(slug: string): string {
+ *  managed slugs pass through). Inverse of {@link runtimeConnectionIdToSlug}. */
+export function slugToRuntimeConnectionId(slug: string): string {
   return slug.startsWith(BYO_SLUG_PREFIX)
     ? slug.slice(BYO_SLUG_PREFIX.length)
     : slug;
@@ -83,7 +82,7 @@ export function connectionsStatusToLegacy(
 /**
  * Map a `connections` chat row (decrypted config) → `StoredConnection`. Un-folds
  * the Stage-1 `config.{settings,chatMetadata}` back into the legacy shape, and
- * preserves the runtime id (`slugToLegacyId`) so secret prefixes, the instance
+ * preserves the runtime id (`slugToRuntimeConnectionId`) so secret prefixes, the instance
  * memo key, `connection_claims.connection_id`, and the webhook URL all stay
  * identical to the legacy runtime.
  */
@@ -100,7 +99,7 @@ export function connectionsRowToStored(
     metadata.teamId = row.external_tenant_id;
   }
   const out: StoredConnection = {
-    id: slugToLegacyId(row.slug),
+    id: slugToRuntimeConnectionId(row.slug),
     platform: row.connector_key,
     config: adapterConfig,
     settings: (settings as StoredConnection["settings"]) ?? {},
@@ -140,7 +139,7 @@ export async function upsertChatConnectionProjection(
   orgId: string,
   credentialMode: ChatCredentialMode,
 ): Promise<void> {
-  const slug = legacyIdToSlug(conn.id);
+  const slug = runtimeConnectionIdToSlug(conn.id);
   const status = legacyStatusToConnections(conn.status);
   const rawTeamId = conn.metadata?.teamId;
   const externalTenantId =
@@ -251,7 +250,7 @@ export async function softDeleteChatConnectionProjection(
   orgId: string | null | undefined,
   connectionId: string,
 ): Promise<void> {
-  const slug = legacyIdToSlug(connectionId);
+  const slug = runtimeConnectionIdToSlug(connectionId);
   if (orgId) {
     await sql`
       UPDATE connections SET deleted_at = now(), updated_at = now()

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -9,7 +9,7 @@ import { getDb, tsTime, tsTimeOrNull } from "../../db/client";
 import { recordLifecycleEvent } from "../../utils/insert-event";
 import {
 	connectionsRowToStored,
-	legacyIdToSlug,
+	runtimeConnectionIdToSlug,
 	softDeleteChatConnectionProjection,
 	upsertChatConnectionProjection,
 } from "./connections-projection";
@@ -316,7 +316,7 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 			const orgId = tryGetOrgId();
 			// `connections` is the sole source of truth (chat rows carry a non-null
 			// credential_mode; data connectors leave it NULL). Keyed by slug.
-			const slug = legacyIdToSlug(connectionId);
+			const slug = runtimeConnectionIdToSlug(connectionId);
 			const projRows = orgId
 				? await sql`
             SELECT * FROM connections
@@ -354,7 +354,7 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 		async saveConnection(connection) {
 			const sql = getDb();
 			const orgId = getOrgId();
-			const slug = legacyIdToSlug(connection.id);
+			const slug = runtimeConnectionIdToSlug(connection.id);
 
 			// One transaction so the secret-preserving read, the
 			// `pg_advisory_xact_lock` taken inside upsertChatConnectionProjection,

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -751,6 +751,12 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
       // Assign it straight through — `hasRequiredMcpScope` fails closed on
       // null, so coercing to null would wrongly deny a valid refreshed session.
       session.authCtx.scopes = freshCtx.scopes;
+      // Identity belongs to the MCP session, but worker-originated source
+      // conversation is per request. The gateway may reuse the same upstream
+      // MCP session across turns for the same user/agent, so keep the mutable
+      // auth context current before tools read ToolContext.sourceContext.
+      session.authCtx.sourceContext = freshCtx.sourceContext ?? null;
+      session.authCtx.adminTools = freshCtx.adminTools ?? null;
 
       if (session.authCtx.scopedToOrg) {
         if (freshCtx.organizationId !== session.authCtx.organizationId) {

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -4,7 +4,7 @@ import type { Context } from "hono";
 import { getDb } from "../db/client";
 import { parseJsonBody } from "../gateway/routes/shared/helpers";
 import type { Env } from "../index";
-import { legacyIdToSlug } from "../lobu/stores/connections-projection";
+import { runtimeConnectionIdToSlug } from "../lobu/stores/connections-projection";
 import { errorMessage } from "../utils/errors";
 import logger from "../utils/logger";
 import { requireOrgUser } from "../utils/require-org-user";
@@ -345,7 +345,7 @@ async function resolvePreviewConnectionOrg(
 	const rows = (await sql`
     SELECT organization_id, agent_id
     FROM connections
-    WHERE slug = ${legacyIdToSlug(connectionId)}
+    WHERE slug = ${runtimeConnectionIdToSlug(connectionId)}
       AND credential_mode IS NOT NULL
       AND deleted_at IS NULL
     LIMIT 1

--- a/packages/server/src/scheduled/__tests__/wake-agent-delivery.test.ts
+++ b/packages/server/src/scheduled/__tests__/wake-agent-delivery.test.ts
@@ -1,0 +1,180 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import type { MessagePayload } from "@lobu/core";
+import { getDb } from "../../db/client";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "../../gateway/__tests__/helpers/db-setup";
+import type { CoreServices } from "../../gateway/services/core-services";
+import { runtimeConnectionIdToSlug } from "../../lobu/stores/connections-projection";
+import { runWakeAgentTask, type WakeAgentTaskPayload } from "../jobs";
+
+const ORG = "org-wake-delivery";
+const AGENT = "agent-wake-delivery";
+const USER = "user-wake-delivery";
+
+/**
+ * Drive the real `wake_agent` handler against the live test DB. The queue
+ * producer is captured; the session manager throws on any access so a fall
+ * through to the api-platform path (createThreadForAgent / enqueueAgentMessage)
+ * is observable as a rejection rather than silently running the legacy path.
+ */
+function fakeCoreServices(enqueued: MessagePayload[]): CoreServices {
+  const sessionManager = new Proxy(
+    {},
+    {
+      get() {
+        throw new Error("API_PATH_REACHED");
+      },
+    }
+  );
+  return {
+    getQueueProducer: () => ({
+      enqueueMessage: async (payload: MessagePayload) => {
+        enqueued.push(payload);
+        return "queued";
+      },
+    }),
+    getSessionManager: () => sessionManager,
+  } as unknown as CoreServices;
+}
+
+async function seedChatConnection(params: {
+  id: string;
+  platform?: string;
+  agentId?: string | null;
+  status?: string;
+  externalTenantId?: string | null;
+}) {
+  const sql = getDb();
+  await sql`
+    INSERT INTO connections (
+      organization_id, connector_key, external_tenant_id, agent_id,
+      display_name, status, config, credential_mode, slug, visibility
+    ) VALUES (
+      ${ORG}, ${params.platform ?? "slack"}, ${params.externalTenantId ?? null},
+      ${params.agentId === undefined ? AGENT : params.agentId}, 'Test chat', ${params.status ?? "active"},
+      ${sql.json({})}, 'byo', ${runtimeConnectionIdToSlug(params.id)}, 'org'
+    )
+  `;
+}
+
+function payload(
+  deliveryContext: unknown,
+  overrides?: Partial<WakeAgentTaskPayload>
+): WakeAgentTaskPayload {
+  return {
+    __organization_id: ORG,
+    __created_by_user: USER,
+    __scheduled_job_id: "job-1",
+    __delivery_context: deliveryContext,
+    agent_id: AGENT,
+    prompt: "wake up",
+    ...overrides,
+  };
+}
+
+describe("runWakeAgentTask chat delivery dispatch", () => {
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedAgentRow(AGENT, { organizationId: ORG, ownerUserId: USER });
+  }, 60_000);
+
+  test("posts back to the channel when delivery context is authorized", async () => {
+    await seedChatConnection({ id: "conn-real" });
+    const enqueued: MessagePayload[] = [];
+
+    await runWakeAgentTask(
+      fakeCoreServices(enqueued),
+      payload({
+        platform: "slack",
+        connectionId: "conn-real",
+        channelId: "C-real",
+        conversationId: "slack:C-real:123",
+        teamId: null,
+        userId: USER,
+      })
+    );
+
+    expect(enqueued).toHaveLength(1);
+    const msg = enqueued[0];
+    expect(msg.platform).toBe("slack");
+    expect(msg.channelId).toBe("C-real");
+    expect(msg.conversationId).toBe("slack:C-real:123");
+    expect(msg.messageText).toBe("wake up");
+    // teamId omitted (not stamped with the platform name) when delivery has none.
+    expect(msg.teamId).toBeUndefined();
+    expect(msg.platformMetadata.connectionId).toBe("conn-real");
+    expect(msg.platformMetadata.teamId).toBeUndefined();
+    expect(msg.platformMetadata.source).toBe("scheduled-job");
+  });
+
+  test("forwards a real teamId through to the message payload", async () => {
+    await seedChatConnection({ id: "conn-real", externalTenantId: "T-real" });
+    const enqueued: MessagePayload[] = [];
+
+    await runWakeAgentTask(
+      fakeCoreServices(enqueued),
+      payload({
+        platform: "slack",
+        connectionId: "conn-real",
+        channelId: "C-real",
+        conversationId: "slack:C-real:123",
+        teamId: "T-real",
+        userId: USER,
+      })
+    );
+
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0].teamId).toBe("T-real");
+    expect(enqueued[0].platformMetadata.teamId).toBe("T-real");
+  });
+
+  test("falls through to the api path when the connection is no longer active", async () => {
+    await seedChatConnection({ id: "conn-real", status: "paused" });
+    const enqueued: MessagePayload[] = [];
+
+    // Unauthorized delivery skips the channel dispatch and runs the api path,
+    // which touches the (throwing) session manager — proving no message was
+    // posted to the channel.
+    await expect(
+      runWakeAgentTask(
+        fakeCoreServices(enqueued),
+        payload({
+          platform: "slack",
+          connectionId: "conn-real",
+          channelId: "C-real",
+          conversationId: "slack:C-real:123",
+          teamId: null,
+          userId: USER,
+        })
+      )
+    ).rejects.toThrow("API_PATH_REACHED");
+    expect(enqueued).toHaveLength(0);
+  });
+
+  test("falls through to the api path for a non-deliverable platform", async () => {
+    await seedChatConnection({ id: "conn-real", platform: "discord" });
+    const enqueued: MessagePayload[] = [];
+
+    await expect(
+      runWakeAgentTask(
+        fakeCoreServices(enqueued),
+        payload({
+          platform: "discord",
+          connectionId: "conn-real",
+          channelId: "C-real",
+          conversationId: "discord:C-real:123",
+          teamId: null,
+          userId: USER,
+        })
+      )
+    ).rejects.toThrow("API_PATH_REACHED");
+    expect(enqueued).toHaveLength(0);
+  });
+});

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -17,7 +17,10 @@ import { checkStalledExecutions } from './check-stalled-executions';
 import { runConnectorHealthCheck } from '../connectors/connector-health';
 import { runClassificationReconciliation } from './classification-reconciliation';
 import { refreshConnectorDefinitions } from './refresh-connector-definitions';
-import { registerScheduledJobsTicker } from './scheduled-jobs-service';
+import {
+  registerScheduledJobsTicker,
+  type ScheduledDeliveryContext,
+} from './scheduled-jobs-service';
 import { TaskScheduler } from './task-scheduler';
 import { triggerEmbedBackfill } from './trigger-embed-backfill';
 import { runReapStaleDeviceWorkers } from './reap-stale-device-workers';
@@ -28,6 +31,73 @@ import {
   enqueueAgentMessage,
 } from '../gateway/services/agent-threads';
 import { buildMessagePayload } from '../gateway/services/platform-helpers';
+import { runtimeConnectionIdToSlug } from '../lobu/stores/connections-projection';
+
+function asDeliveryContext(value: unknown): ScheduledDeliveryContext | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Partial<ScheduledDeliveryContext>;
+  if (
+    typeof candidate.platform !== 'string' ||
+    typeof candidate.conversationId !== 'string' ||
+    typeof candidate.channelId !== 'string' ||
+    typeof candidate.connectionId !== 'string'
+  ) {
+    return null;
+  }
+  return {
+    platform: candidate.platform,
+    conversationId: candidate.conversationId,
+    channelId: candidate.channelId,
+    teamId: typeof candidate.teamId === 'string' ? candidate.teamId : null,
+    connectionId: candidate.connectionId,
+    userId: typeof candidate.userId === 'string' ? candidate.userId : null,
+  };
+}
+
+async function deliveryContextStillAuthorized(params: {
+  organizationId: string;
+  agentId: string;
+  delivery: ScheduledDeliveryContext;
+}): Promise<boolean> {
+  const sql = getDb();
+  const { organizationId, agentId, delivery } = params;
+  const connectionRows = (await sql`
+    SELECT connector_key, agent_id, status
+    FROM connections
+    WHERE organization_id = ${organizationId}
+      AND slug = ${runtimeConnectionIdToSlug(delivery.connectionId)}
+      AND credential_mode IS NOT NULL
+      AND deleted_at IS NULL
+    LIMIT 1
+  `) as unknown as Array<{ connector_key: string; agent_id: string | null; status: string }>;
+  const connection = connectionRows[0];
+  if (!connection) return false;
+  if (connection.connector_key !== delivery.platform) return false;
+  if (connection.status !== 'active') return false;
+  if (connection.agent_id) return connection.agent_id === agentId;
+
+  const bindingRows = delivery.teamId
+    ? await sql`
+        SELECT agent_id
+        FROM agent_channel_bindings
+        WHERE organization_id = ${organizationId}
+          AND platform = ${delivery.platform}
+          AND channel_id = ${delivery.channelId}
+          AND team_id = ${delivery.teamId}
+        LIMIT 1
+      `
+    : await sql`
+        SELECT agent_id
+        FROM agent_channel_bindings
+        WHERE organization_id = ${organizationId}
+          AND platform = ${delivery.platform}
+          AND channel_id = ${delivery.channelId}
+          AND team_id IS NULL
+        LIMIT 1
+      `;
+  const binding = (bindingRows as unknown as Array<{ agent_id: string }>)[0];
+  return binding?.agent_id === agentId;
+}
 
 /**
  * Construct the TaskScheduler, register every periodic task, start dispatch,
@@ -318,22 +388,12 @@ function registerMaintenanceTasks(
       __created_by_user?: string | null;
       __created_by_agent?: string | null;
       __scheduled_job_id?: string;
+      __delivery_context?: unknown;
       organization_id?: string;
       agent_id?: string;
       prompt?: string;
       thread_id?: string | null;
       reason?: string | null;
-      // Optional platform delivery target captured from the conversation that
-      // scheduled the wake (e.g. by a first-party MCP tool). When present the
-      // reply is posted back into that channel instead of the default api thread.
-      delivery?: {
-        platform?: string;
-        conversationId?: string;
-        channelId?: string;
-        teamId?: string | null;
-        connectionId?: string | null;
-        userId?: string | null;
-      } | null;
     };
     const orgId = p.__organization_id ?? p.organization_id;
     if (!orgId || !p.agent_id || !p.prompt) {
@@ -347,7 +407,9 @@ function registerMaintenanceTasks(
     // ghost — so verify the target exists and auto-pause the schedule
     // when it doesn't.
     const agentRows = (await sql`
-      SELECT id FROM agents WHERE id = ${p.agent_id} LIMIT 1
+      SELECT id FROM agents
+      WHERE organization_id = ${orgId} AND id = ${p.agent_id}
+      LIMIT 1
     `) as unknown as Array<{ id: string }>;
     if (agentRows.length === 0) {
       logger.warn(
@@ -362,25 +424,26 @@ function registerMaintenanceTasks(
     const sessionManager = coreServices.getSessionManager();
     const queueProducer = coreServices.getQueueProducer();
 
-    // When the schedule carries a captured platform delivery target (a wake that
-    // originated from a Slack/Telegram conversation), dispatch a real platform
-    // message so the reply posts back into that channel. The default path below
-    // dispatches an api-platform message, which only reaches a connected SSE
-    // client — a background wake has none, so its reply would otherwise drop.
-    const delivery =
-      p.delivery && typeof p.delivery === 'object' ? p.delivery : null;
+    // When the schedule carries trusted gateway-owned delivery context, dispatch
+    // a real platform message so the reply posts back into the originating chat
+    // channel. User action_args never supply this value; the ticker injects it
+    // from scheduled_jobs.delivery_context.
+    const delivery = asDeliveryContext(p.__delivery_context);
     if (
       delivery &&
       (delivery.platform === 'slack' || delivery.platform === 'telegram') &&
-      delivery.channelId &&
-      delivery.connectionId
+      (await deliveryContextStillAuthorized({
+        organizationId: orgId,
+        agentId: p.agent_id,
+        delivery,
+      }))
     ) {
       await queueProducer.enqueueMessage(
         buildMessagePayload({
           platform: delivery.platform,
           userId: delivery.userId || p.__created_by_user || 'scheduled',
           botId: delivery.platform,
-          conversationId: delivery.conversationId || delivery.channelId,
+          conversationId: delivery.conversationId,
           teamId: delivery.teamId || delivery.platform,
           agentId: p.agent_id,
           organizationId: orgId,

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -27,6 +27,7 @@ import {
   createThreadForAgent,
   enqueueAgentMessage,
 } from '../gateway/services/agent-threads';
+import { buildMessagePayload } from '../gateway/services/platform-helpers';
 
 /**
  * Construct the TaskScheduler, register every periodic task, start dispatch,
@@ -322,6 +323,17 @@ function registerMaintenanceTasks(
       prompt?: string;
       thread_id?: string | null;
       reason?: string | null;
+      // Optional platform delivery target captured from the conversation that
+      // scheduled the wake (e.g. by a first-party MCP tool). When present the
+      // reply is posted back into that channel instead of the default api thread.
+      delivery?: {
+        platform?: string;
+        conversationId?: string;
+        channelId?: string;
+        teamId?: string | null;
+        connectionId?: string | null;
+        userId?: string | null;
+      } | null;
     };
     const orgId = p.__organization_id ?? p.organization_id;
     if (!orgId || !p.agent_id || !p.prompt) {
@@ -349,6 +361,48 @@ function registerMaintenanceTasks(
     }
     const sessionManager = coreServices.getSessionManager();
     const queueProducer = coreServices.getQueueProducer();
+
+    // When the schedule carries a captured platform delivery target (a wake that
+    // originated from a Slack/Telegram conversation), dispatch a real platform
+    // message so the reply posts back into that channel. The default path below
+    // dispatches an api-platform message, which only reaches a connected SSE
+    // client — a background wake has none, so its reply would otherwise drop.
+    const delivery =
+      p.delivery && typeof p.delivery === 'object' ? p.delivery : null;
+    if (
+      delivery &&
+      (delivery.platform === 'slack' || delivery.platform === 'telegram') &&
+      delivery.channelId &&
+      delivery.connectionId
+    ) {
+      await queueProducer.enqueueMessage(
+        buildMessagePayload({
+          platform: delivery.platform,
+          userId: delivery.userId || p.__created_by_user || 'scheduled',
+          botId: delivery.platform,
+          conversationId: delivery.conversationId || delivery.channelId,
+          teamId: delivery.teamId || delivery.platform,
+          agentId: p.agent_id,
+          organizationId: orgId,
+          messageId: `wake_${p.__scheduled_job_id ?? p.agent_id}_${Date.now()}`,
+          messageText: p.prompt,
+          channelId: delivery.channelId,
+          platformMetadata: {
+            agentId: p.agent_id,
+            chatId: delivery.channelId,
+            senderId: delivery.userId || undefined,
+            teamId: delivery.teamId || undefined,
+            connectionId: delivery.connectionId,
+            responseChannel: delivery.channelId,
+            organizationId: orgId,
+            source: 'scheduled-job',
+          },
+          agentOptions: {},
+        })
+      );
+      return;
+    }
+
     let threadId = p.thread_id ?? null;
     if (!threadId) {
       const result = await createThreadForAgent(

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -382,117 +382,132 @@ function registerMaintenanceTasks(
   // Handler: wake_agent. Creates a thread for the agent (or reuses one
   // supplied by the caller) and enqueues the prompt as a user message.
   // Lets an agent schedule its own follow-up wake-ups via manage_schedules.
-  scheduler.register('wake_agent', async (ctx) => {
-    const sql = getDb();
-    const p = ctx.payload as {
-      __organization_id?: string;
-      __created_by_user?: string | null;
-      __created_by_agent?: string | null;
-      __scheduled_job_id?: string;
-      __delivery_context?: unknown;
-      organization_id?: string;
-      agent_id?: string;
-      prompt?: string;
-      thread_id?: string | null;
-      reason?: string | null;
-    };
-    const orgId = p.__organization_id ?? p.organization_id;
-    if (!orgId || !p.agent_id || !p.prompt) {
-      logger.warn({ payload: ctx.payload }, '[task] wake_agent missing org/agent/prompt');
-      return;
-    }
-    // Target-agent existence check. The cascade FK on scheduled_jobs only
-    // covers `created_by_agent` (the *scheduler*'s identity), not the
-    // *target* of a wake_agent action. If a user scheduled a wake for
-    // agent X and X was deleted, we'd silently enqueue a message for a
-    // ghost — so verify the target exists and auto-pause the schedule
-    // when it doesn't.
-    const agentRows = (await sql`
-      SELECT id FROM agents
-      WHERE organization_id = ${orgId} AND id = ${p.agent_id}
-      LIMIT 1
-    `) as unknown as Array<{ id: string }>;
-    if (agentRows.length === 0) {
-      logger.warn(
-        { scheduled_job_id: p.__scheduled_job_id, agent_id: p.agent_id },
-        '[task] wake_agent target agent no longer exists; pausing schedule'
-      );
-      if (p.__scheduled_job_id) {
-        await sql`UPDATE scheduled_jobs SET paused = true, updated_at = now() WHERE id = ${p.__scheduled_job_id}`;
-      }
-      return;
-    }
-    const sessionManager = coreServices.getSessionManager();
-    const queueProducer = coreServices.getQueueProducer();
+  scheduler.register('wake_agent', (ctx) =>
+    runWakeAgentTask(coreServices, ctx.payload as WakeAgentTaskPayload)
+  );
+}
 
-    // When the schedule carries trusted gateway-owned delivery context, dispatch
-    // a real platform message so the reply posts back into the originating chat
-    // channel. User action_args never supply this value; the ticker injects it
-    // from scheduled_jobs.delivery_context.
-    const delivery = asDeliveryContext(p.__delivery_context);
-    if (
-      delivery &&
-      isDeliverableChatPlatform(delivery.platform) &&
-      (await deliveryContextStillAuthorized({
-        organizationId: orgId,
+export interface WakeAgentTaskPayload {
+  __organization_id?: string;
+  __created_by_user?: string | null;
+  __created_by_agent?: string | null;
+  __scheduled_job_id?: string;
+  __delivery_context?: unknown;
+  organization_id?: string;
+  agent_id?: string;
+  prompt?: string;
+  thread_id?: string | null;
+  reason?: string | null;
+}
+
+/**
+ * Execute a `wake_agent` scheduled task: post the agent's reply back into the
+ * originating chat channel when the ticker injected a trusted delivery context,
+ * otherwise dispatch the unchanged api-platform message. Exported so the
+ * fire-time delivery dispatch can be driven end-to-end in tests (the
+ * registration above is a thin adapter over it).
+ */
+export async function runWakeAgentTask(
+  coreServices: CoreServices,
+  p: WakeAgentTaskPayload
+): Promise<void> {
+  const sql = getDb();
+  const orgId = p.__organization_id ?? p.organization_id;
+  if (!orgId || !p.agent_id || !p.prompt) {
+    logger.warn({ payload: p }, '[task] wake_agent missing org/agent/prompt');
+    return;
+  }
+  // Target-agent existence check. The cascade FK on scheduled_jobs only
+  // covers `created_by_agent` (the *scheduler*'s identity), not the
+  // *target* of a wake_agent action. If a user scheduled a wake for
+  // agent X and X was deleted, we'd silently enqueue a message for a
+  // ghost — so verify the target exists and auto-pause the schedule
+  // when it doesn't.
+  const agentRows = (await sql`
+    SELECT id FROM agents
+    WHERE organization_id = ${orgId} AND id = ${p.agent_id}
+    LIMIT 1
+  `) as unknown as Array<{ id: string }>;
+  if (agentRows.length === 0) {
+    logger.warn(
+      { scheduled_job_id: p.__scheduled_job_id, agent_id: p.agent_id },
+      '[task] wake_agent target agent no longer exists; pausing schedule'
+    );
+    if (p.__scheduled_job_id) {
+      await sql`UPDATE scheduled_jobs SET paused = true, updated_at = now() WHERE id = ${p.__scheduled_job_id}`;
+    }
+    return;
+  }
+  const sessionManager = coreServices.getSessionManager();
+  const queueProducer = coreServices.getQueueProducer();
+
+  // When the schedule carries trusted gateway-owned delivery context, dispatch
+  // a real platform message so the reply posts back into the originating chat
+  // channel. User action_args never supply this value; the ticker injects it
+  // from scheduled_jobs.delivery_context.
+  const delivery = asDeliveryContext(p.__delivery_context);
+  if (
+    delivery &&
+    isDeliverableChatPlatform(delivery.platform) &&
+    (await deliveryContextStillAuthorized({
+      organizationId: orgId,
+      agentId: p.agent_id,
+      delivery,
+    }))
+  ) {
+    await queueProducer.enqueueMessage(
+      buildMessagePayload({
+        platform: delivery.platform,
+        userId: delivery.userId || p.__created_by_user || 'scheduled',
+        botId: delivery.platform,
+        conversationId: delivery.conversationId,
+        teamId: delivery.teamId ?? undefined,
         agentId: p.agent_id,
-        delivery,
-      }))
-    ) {
-      await queueProducer.enqueueMessage(
-        buildMessagePayload({
-          platform: delivery.platform,
-          userId: delivery.userId || p.__created_by_user || 'scheduled',
-          botId: delivery.platform,
-          conversationId: delivery.conversationId,
-          teamId: delivery.teamId ?? undefined,
-          agentId: p.agent_id,
-          organizationId: orgId,
-          messageId: `wake_${p.__scheduled_job_id ?? p.agent_id}_${Date.now()}`,
-          messageText: p.prompt,
-          channelId: delivery.channelId,
-          platformMetadata: {
-            agentId: p.agent_id,
-            chatId: delivery.channelId,
-            senderId: delivery.userId || undefined,
-            teamId: delivery.teamId || undefined,
-            connectionId: delivery.connectionId,
-            responseChannel: delivery.channelId,
-            organizationId: orgId,
-            source: 'scheduled-job',
-          },
-          agentOptions: {},
-        })
-      );
-      return;
-    }
-
-    let threadId = p.thread_id ?? null;
-    if (!threadId) {
-      const result = await createThreadForAgent(
-        { sessionManager },
-        {
-          agentId: p.agent_id,
-          organizationId: orgId,
-          // The ticker injects the scheduling user under the `__` prefix
-          // so handler payloads can mix scheduler-controlled metadata with
-          // user-supplied action_args without collision. Reading from
-          // p.__created_by_user keeps the wake-up's thread / message
-          // attribution pointing at whoever scheduled it (not the agent
-          // itself, which would obscure the audit trail).
-          createdByUserId: p.__created_by_user ?? undefined,
-          reason: p.reason ?? 'scheduled-wake',
-        }
-      );
-      threadId = result.threadId;
-    }
-    await enqueueAgentMessage(
-      { sessionManager, queueProducer },
-      {
-        threadId,
+        organizationId: orgId,
+        messageId: `wake_${p.__scheduled_job_id ?? p.agent_id}_${Date.now()}`,
         messageText: p.prompt,
-        source: 'scheduled-job',
+        channelId: delivery.channelId,
+        platformMetadata: {
+          agentId: p.agent_id,
+          chatId: delivery.channelId,
+          senderId: delivery.userId || undefined,
+          teamId: delivery.teamId || undefined,
+          connectionId: delivery.connectionId,
+          responseChannel: delivery.channelId,
+          organizationId: orgId,
+          source: 'scheduled-job',
+        },
+        agentOptions: {},
+      })
+    );
+    return;
+  }
+
+  let threadId = p.thread_id ?? null;
+  if (!threadId) {
+    const result = await createThreadForAgent(
+      { sessionManager },
+      {
+        agentId: p.agent_id,
+        organizationId: orgId,
+        // The ticker injects the scheduling user under the `__` prefix
+        // so handler payloads can mix scheduler-controlled metadata with
+        // user-supplied action_args without collision. Reading from
+        // p.__created_by_user keeps the wake-up's thread / message
+        // attribution pointing at whoever scheduled it (not the agent
+        // itself, which would obscure the audit trail).
+        createdByUserId: p.__created_by_user ?? undefined,
+        reason: p.reason ?? 'scheduled-wake',
       }
     );
-  });
+    threadId = result.threadId;
+  }
+  await enqueueAgentMessage(
+    { sessionManager, queueProducer },
+    {
+      threadId,
+      messageText: p.prompt,
+      source: 'scheduled-job',
+    }
+  );
 }

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -18,6 +18,7 @@ import { runConnectorHealthCheck } from '../connectors/connector-health';
 import { runClassificationReconciliation } from './classification-reconciliation';
 import { refreshConnectorDefinitions } from './refresh-connector-definitions';
 import {
+  isDeliverableChatPlatform,
   registerScheduledJobsTicker,
   type ScheduledDeliveryContext,
 } from './scheduled-jobs-service';
@@ -431,7 +432,7 @@ function registerMaintenanceTasks(
     const delivery = asDeliveryContext(p.__delivery_context);
     if (
       delivery &&
-      (delivery.platform === 'slack' || delivery.platform === 'telegram') &&
+      isDeliverableChatPlatform(delivery.platform) &&
       (await deliveryContextStillAuthorized({
         organizationId: orgId,
         agentId: p.agent_id,
@@ -444,7 +445,7 @@ function registerMaintenanceTasks(
           userId: delivery.userId || p.__created_by_user || 'scheduled',
           botId: delivery.platform,
           conversationId: delivery.conversationId,
-          teamId: delivery.teamId || delivery.platform,
+          teamId: delivery.teamId ?? undefined,
           agentId: p.agent_id,
           organizationId: orgId,
           messageId: `wake_${p.__scheduled_job_id ?? p.agent_id}_${Date.now()}`,

--- a/packages/server/src/scheduled/scheduled-jobs-service.ts
+++ b/packages/server/src/scheduled/scheduled-jobs-service.ts
@@ -31,6 +31,19 @@ export interface ScheduledDeliveryContext {
   userId?: string | null;
 }
 
+/**
+ * Chat platforms a scheduled wake can post its reply back into. Single source
+ * of truth shared by the create-time gate (`manage_schedules`) and the
+ * fire-time dispatch (`scheduled/jobs.ts`) so the two can never drift — a
+ * platform accepted at creation but unhandled at execution would store a dead
+ * `delivery_context` and silently fall back to the api path.
+ */
+export const DELIVERABLE_CHAT_PLATFORMS = ['slack', 'telegram'] as const;
+
+export function isDeliverableChatPlatform(platform: string): boolean {
+  return (DELIVERABLE_CHAT_PLATFORMS as readonly string[]).includes(platform);
+}
+
 export interface ScheduledJobRow {
   id: string;
   organization_id: string;

--- a/packages/server/src/scheduled/scheduled-jobs-service.ts
+++ b/packages/server/src/scheduled/scheduled-jobs-service.ts
@@ -22,11 +22,21 @@ import logger from '../utils/logger';
 import type { TaskScheduler } from './task-scheduler';
 import { errorMessage } from '../utils/errors';
 
+export interface ScheduledDeliveryContext {
+  platform: string;
+  conversationId: string;
+  channelId: string;
+  teamId?: string | null;
+  connectionId: string;
+  userId?: string | null;
+}
+
 export interface ScheduledJobRow {
   id: string;
   organization_id: string;
   action_type: string;
   action_args: Record<string, unknown>;
+  delivery_context: ScheduledDeliveryContext | null;
   cron: string | null;
   next_run_at: string;
   last_fired_at: string | null;
@@ -46,6 +56,7 @@ interface CreateScheduledJobParams {
   organizationId: string;
   actionType: string;
   actionArgs: Record<string, unknown>;
+  deliveryContext?: ScheduledDeliveryContext | null;
   description: string;
   cron?: string | null;
   runAt: Date;
@@ -65,13 +76,13 @@ export async function createScheduledJob(
   const sql = getDb();
   const rows = (await sql`
     INSERT INTO scheduled_jobs (
-      organization_id, action_type, action_args, cron, next_run_at,
+      organization_id, action_type, action_args, delivery_context, cron, next_run_at,
       description,
       created_by_user, created_by_agent,
       source_run_id, source_event_id, source_thread_id
     ) VALUES (
       ${params.organizationId}, ${params.actionType},
-      ${sql.json(params.actionArgs)}, ${params.cron ?? null}, ${params.runAt},
+      ${sql.json(params.actionArgs)}, ${params.deliveryContext ? sql.json(params.deliveryContext) : null}, ${params.cron ?? null}, ${params.runAt},
       ${params.description},
       ${params.createdByUser ?? null}, ${params.createdByAgent ?? null},
       ${params.sourceRunId ?? null}, ${params.sourceEventId ?? null},
@@ -177,6 +188,7 @@ export function registerScheduledJobsTicker(scheduler: TaskScheduler): void {
           await scheduler.spawn(row.action_type, {
             ...row.action_args,
             __scheduled_job_id: row.id,
+            __delivery_context: row.delivery_context,
             __scheduled_job_tick: tickIso,
             __organization_id: row.organization_id,
             __created_by_user: row.created_by_user,

--- a/packages/server/src/tools/admin/__tests__/manage-schedules-delivery.test.ts
+++ b/packages/server/src/tools/admin/__tests__/manage-schedules-delivery.test.ts
@@ -1,0 +1,230 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { getDb } from "../../../db/client";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "../../../gateway/__tests__/helpers/db-setup";
+import { runtimeConnectionIdToSlug } from "../../../lobu/stores/connections-projection";
+import { registerScheduledJobsTicker } from "../../../scheduled/scheduled-jobs-service";
+import { manageSchedules } from "../manage_schedules";
+import type { ToolContext } from "../../registry";
+
+const ORG = "org-scheduled-delivery";
+const AGENT = "agent-scheduled-delivery";
+const USER = "user-scheduled-delivery";
+
+function ctx(sourceContext?: ToolContext["sourceContext"]): ToolContext {
+  return {
+    organizationId: ORG,
+    userId: USER,
+    memberRole: "admin",
+    agentId: AGENT,
+    sourceContext: sourceContext ?? null,
+    isAuthenticated: true,
+    clientId: "lobu-worker",
+    scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+    tokenType: "pat",
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  };
+}
+
+async function seedChatConnection(params: {
+  id: string;
+  platform?: string;
+  agentId?: string | null;
+  status?: string;
+  externalTenantId?: string | null;
+}) {
+  const sql = getDb();
+  await sql`
+    INSERT INTO connections (
+      organization_id, connector_key, external_tenant_id, agent_id,
+      display_name, status, config, credential_mode, slug, visibility
+    ) VALUES (
+      ${ORG}, ${params.platform ?? "slack"}, ${params.externalTenantId ?? null},
+      ${params.agentId === undefined ? AGENT : params.agentId}, 'Test chat', ${params.status ?? "active"},
+      ${sql.json({})}, 'byo', ${runtimeConnectionIdToSlug(params.id)}, 'org'
+    )
+  `;
+}
+
+describe("manage_schedules wake_agent chat delivery", () => {
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedAgentRow(AGENT, { organizationId: ORG, ownerUserId: USER });
+  }, 60_000);
+
+  test("ignores and strips caller-supplied delivery payload", async () => {
+    await seedChatConnection({ id: "conn-real" });
+
+    const result = await manageSchedules(
+      {
+        action: "create",
+        description: "forged delivery is ignored",
+        run_at: new Date(Date.now() + 60_000).toISOString(),
+        payload: {
+          type: "wake_agent",
+          agent_id: AGENT,
+          prompt: "wake up",
+          delivery: {
+            platform: "slack",
+            connectionId: "conn-real",
+            channelId: "C-real",
+            conversationId: "slack:C-real:123",
+          },
+        } as any,
+      },
+      {} as any,
+      ctx()
+    );
+
+    expect(result.error).toBeUndefined();
+    const rows = await getDb()`SELECT action_args, delivery_context FROM scheduled_jobs`;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].action_args.delivery).toBeUndefined();
+    expect(rows[0].delivery_context).toBeNull();
+  });
+
+  test("stores trusted delivery context from the worker source context", async () => {
+    await seedChatConnection({ id: "conn-real" });
+
+    const result = await manageSchedules(
+      {
+        action: "create",
+        description: "trusted delivery",
+        run_at: new Date(Date.now() + 60_000).toISOString(),
+        payload: {
+          type: "wake_agent",
+          agent_id: AGENT,
+          prompt: "wake up",
+        },
+      },
+      {} as any,
+      ctx({
+        platform: "slack",
+        connectionId: "conn-real",
+        channelId: "C-real",
+        conversationId: "slack:C-real:123",
+        teamId: "T-real",
+        userId: USER,
+      })
+    );
+
+    expect(result.error).toBeUndefined();
+    const rows = await getDb()`SELECT delivery_context FROM scheduled_jobs`;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].delivery_context).toEqual({
+      platform: "slack",
+      connectionId: "conn-real",
+      channelId: "C-real",
+      conversationId: "slack:C-real:123",
+      teamId: "T-real",
+      userId: USER,
+    });
+  });
+
+  test("scheduled-jobs ticker injects delivery_context into the wake task payload", async () => {
+    await seedChatConnection({ id: "conn-real" });
+
+    const result = await manageSchedules(
+      {
+        action: "create",
+        description: "due trusted delivery",
+        run_at: new Date(Date.now() - 60_000).toISOString(),
+        payload: { type: "wake_agent", agent_id: AGENT, prompt: "wake up" },
+      },
+      {} as any,
+      ctx({
+        platform: "slack",
+        connectionId: "conn-real",
+        channelId: "C-real",
+        conversationId: "slack:C-real:123",
+        teamId: "T-real",
+        userId: USER,
+      })
+    );
+    expect(result.error).toBeUndefined();
+
+    const spawned: Array<{ name: string; payload: any; opts: any }> = [];
+    const handlers = new Map<string, (ctx: { payload: unknown; taskRunId: number }) => Promise<void>>();
+    registerScheduledJobsTicker({
+      register: (name: string, handler: any) => handlers.set(name, handler),
+      spawn: async (name: string, payload: any, opts: any) => {
+        spawned.push({ name, payload, opts });
+        return "spawned-job";
+      },
+    } as any);
+
+    await handlers.get("scheduled-jobs-tick")!({ payload: {}, taskRunId: 1 });
+
+    expect(spawned).toHaveLength(1);
+    expect(spawned[0].name).toBe("wake_agent");
+    expect(spawned[0].payload.__delivery_context).toEqual({
+      platform: "slack",
+      connectionId: "conn-real",
+      channelId: "C-real",
+      conversationId: "slack:C-real:123",
+      teamId: "T-real",
+      userId: USER,
+    });
+  });
+
+  test("requires agentless managed connections to have a matching channel binding", async () => {
+    await seedChatConnection({
+      id: "slackinst-real",
+      agentId: null,
+      externalTenantId: "T-real",
+    });
+
+    const missingBinding = await manageSchedules(
+      {
+        action: "create",
+        description: "missing binding",
+        run_at: new Date(Date.now() + 60_000).toISOString(),
+        payload: { type: "wake_agent", agent_id: AGENT, prompt: "wake up" },
+      },
+      {} as any,
+      ctx({
+        platform: "slack",
+        connectionId: "slackinst-real",
+        channelId: "C-real",
+        conversationId: "slack:C-real:123",
+        teamId: "T-real",
+        userId: USER,
+      })
+    );
+    expect(missingBinding.error).toMatch(/channel is not bound/);
+
+    await getDb()`
+      INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id)
+      VALUES (${ORG}, ${AGENT}, 'slack', 'C-real', 'T-real')
+    `;
+
+    const withBinding = await manageSchedules(
+      {
+        action: "create",
+        description: "with binding",
+        run_at: new Date(Date.now() + 60_000).toISOString(),
+        payload: { type: "wake_agent", agent_id: AGENT, prompt: "wake up" },
+      },
+      {} as any,
+      ctx({
+        platform: "slack",
+        connectionId: "slackinst-real",
+        channelId: "C-real",
+        conversationId: "slack:C-real:123",
+        teamId: "T-real",
+        userId: USER,
+      })
+    );
+    expect(withBinding.error).toBeUndefined();
+    const rows = await getDb()`SELECT delivery_context FROM scheduled_jobs ORDER BY created_at DESC LIMIT 1`;
+    expect(rows[0].delivery_context.connectionId).toBe("slackinst-real");
+  });
+});

--- a/packages/server/src/tools/admin/manage_schedules.ts
+++ b/packages/server/src/tools/admin/manage_schedules.ts
@@ -24,6 +24,7 @@ import {
   createScheduledJob,
   deleteScheduledJob,
   getScheduledJob,
+  isDeliverableChatPlatform,
   listScheduledJobs,
   pauseScheduledJob,
   type ScheduledDeliveryContext,
@@ -231,7 +232,10 @@ function actionArgsForPayload(
 function sourceToDeliveryContext(
   source: ToolSourceContext | null | undefined
 ): ScheduledDeliveryContext | null {
-  if (!source?.platform || source.platform === 'api') return null;
+  // Only platforms the fire-time dispatch can actually deliver into; an
+  // unsupported source platform stores no delivery_context (api fallback)
+  // rather than a dead one that silently never posts.
+  if (!source?.platform || !isDeliverableChatPlatform(source.platform)) return null;
   if (!source.connectionId || !source.channelId || !source.conversationId) return null;
   return {
     platform: source.platform,

--- a/packages/server/src/tools/admin/manage_schedules.ts
+++ b/packages/server/src/tools/admin/manage_schedules.ts
@@ -26,12 +26,15 @@ import {
   getScheduledJob,
   listScheduledJobs,
   pauseScheduledJob,
+  type ScheduledDeliveryContext,
   type ScheduledJobRow,
 } from '../../scheduled/scheduled-jobs-service';
-import type { ToolContext } from '../registry';
+import type { ToolContext, ToolSourceContext } from '../registry';
 import logger from '../../utils/logger';
 import { nextRunAt as nextCronTickAt } from '../../utils/cron';
 import { getErrorMessage } from "@lobu/core";
+import { getDb } from '../../db/client';
+import { runtimeConnectionIdToSlug } from '../../lobu/stores/connections-projection';
 
 // ============================================
 // Schema
@@ -147,22 +150,24 @@ async function handleCreate(
   }
   // action_type comes from the payload's discriminant `type`.
   const actionType = args.payload.type;
-  // Strip the discriminant before persisting — handlers know their own type.
-  const { type: _omit, ...actionArgs } = args.payload as Record<string, unknown> & {
-    type: string;
-  };
+  // Persist only the schema-owned action fields. TypeBox permits additional
+  // properties by default, so never copy the raw payload wholesale into a
+  // durable scheduler row.
+  const actionArgs = actionArgsForPayload(args.payload);
+
+  const delivery = await resolveTrustedDeliveryContext(args.payload, ctx);
+  if (delivery.error) return { error: delivery.error };
 
   const job = await createScheduledJob({
     organizationId: ctx.organizationId,
     actionType,
     actionArgs,
+    deliveryContext: delivery.context,
     description: args.description,
     cron: args.cron ?? null,
     runAt: runAtDate,
     createdByUser: ctx.userId ?? null,
-    // ToolContext doesn't carry an agent attribution today; populated by
-    // the gateway agent path when it lands (TODO once that wiring exists).
-    createdByAgent: null,
+    createdByAgent: ctx.agentId ?? null,
     sourceRunId: args.source_run_id ?? null,
     sourceEventId: args.source_event_id ?? null,
     sourceThreadId: args.source_thread_id ?? null,
@@ -204,12 +209,110 @@ async function handleCancel(
   return { ok: true };
 }
 
+function actionArgsForPayload(
+  payload: Static<typeof CreateAction>['payload']
+): Record<string, unknown> {
+  if (payload.type === 'wake_agent') {
+    return {
+      agent_id: payload.agent_id,
+      prompt: payload.prompt,
+      ...(payload.thread_id ? { thread_id: payload.thread_id } : {}),
+      ...(payload.reason ? { reason: payload.reason } : {}),
+    };
+  }
+  return {
+    title: payload.title,
+    ...(payload.body !== undefined ? { body: payload.body } : {}),
+    ...(payload.recipients !== undefined ? { recipients: payload.recipients } : {}),
+    ...(payload.resource_url !== undefined ? { resource_url: payload.resource_url } : {}),
+  };
+}
+
+function sourceToDeliveryContext(
+  source: ToolSourceContext | null | undefined
+): ScheduledDeliveryContext | null {
+  if (!source?.platform || source.platform === 'api') return null;
+  if (!source.connectionId || !source.channelId || !source.conversationId) return null;
+  return {
+    platform: source.platform,
+    conversationId: source.conversationId,
+    channelId: source.channelId,
+    teamId: source.teamId ?? null,
+    connectionId: source.connectionId,
+    userId: source.userId ?? null,
+  };
+}
+
+async function resolveTrustedDeliveryContext(
+  payload: Static<typeof CreateAction>['payload'],
+  ctx: ToolContext
+): Promise<{ context: ScheduledDeliveryContext | null; error?: string }> {
+  if (payload.type !== 'wake_agent') return { context: null };
+
+  const context = sourceToDeliveryContext(ctx.sourceContext);
+  if (!context) return { context: null };
+
+  const sql = getDb();
+  const connectionRows = (await sql`
+    SELECT connector_key, agent_id, status
+    FROM connections
+    WHERE organization_id = ${ctx.organizationId}
+      AND slug = ${runtimeConnectionIdToSlug(context.connectionId)}
+      AND credential_mode IS NOT NULL
+      AND deleted_at IS NULL
+    LIMIT 1
+  `) as unknown as Array<{ connector_key: string; agent_id: string | null; status: string }>;
+  const connection = connectionRows[0];
+  if (!connection) {
+    return { context: null, error: 'Cannot schedule chat delivery: source connection no longer exists.' };
+  }
+  if (connection.connector_key !== context.platform) {
+    return { context: null, error: 'Cannot schedule chat delivery: source connection platform changed.' };
+  }
+  if (connection.status !== 'active') {
+    return { context: null, error: 'Cannot schedule chat delivery: source connection is not active.' };
+  }
+  if (connection.agent_id) {
+    if (connection.agent_id !== payload.agent_id) {
+      return { context: null, error: 'Cannot schedule chat delivery for a different agent on this connection.' };
+    }
+    return { context };
+  }
+
+  const bindingRows = context.teamId
+    ? await sql`
+        SELECT agent_id
+        FROM agent_channel_bindings
+        WHERE organization_id = ${ctx.organizationId}
+          AND platform = ${context.platform}
+          AND channel_id = ${context.channelId}
+          AND team_id = ${context.teamId}
+        LIMIT 1
+      `
+    : await sql`
+        SELECT agent_id
+        FROM agent_channel_bindings
+        WHERE organization_id = ${ctx.organizationId}
+          AND platform = ${context.platform}
+          AND channel_id = ${context.channelId}
+          AND team_id IS NULL
+        LIMIT 1
+      `;
+  const binding = (bindingRows as unknown as Array<{ agent_id: string }>)[0];
+  if (!binding || binding.agent_id !== payload.agent_id) {
+    return { context: null, error: 'Cannot schedule chat delivery: channel is not bound to the target agent.' };
+  }
+
+  return { context };
+}
+
 function serializeSchedule(row: ScheduledJobRow) {
   return {
     id: row.id,
     organization_id: row.organization_id,
     action_type: row.action_type,
     action_args: row.action_args,
+    delivery_context: row.delivery_context,
     cron: row.cron,
     next_run_at: row.next_run_at,
     last_fired_at: row.last_fired_at,

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -18,7 +18,7 @@ import { getConfiguredPublicOrigin } from '../utils/public-origin';
 import { enforceRoleScopeAccess } from './access-control';
 import { recordToolInvocationAudit } from './audit';
 import { listOrganizations } from './organizations';
-import { getTool, type TokenType, type ToolContext } from './registry';
+import { getTool, type TokenType, type ToolContext, type ToolSourceContext } from './registry';
 
 export interface AuthContext {
   organizationId: string | null;
@@ -34,6 +34,7 @@ export interface AuthContext {
   memberRole: string | null;
   agentId: string | null;
   requestedAgentId: string | null;
+  sourceContext?: ToolSourceContext | null;
   isAuthenticated: boolean;
   clientId: string | null;
   scopes?: string[] | null;
@@ -67,8 +68,9 @@ export function extractAuthContext(c: Context<{ Bindings: Env }>): AuthContext {
     tokenOrganizationId: mcpAuthInfo?.organizationId ?? null,
     userId: mcpAuthInfo?.userId || c.var.session?.userId || null,
     memberRole: c.var.memberRole,
-    agentId: null,
-    requestedAgentId: null,
+    agentId: mcpAuthInfo?.agentId ?? null,
+    requestedAgentId: mcpAuthInfo?.agentId ?? null,
+    sourceContext: mcpAuthInfo?.sourceContext ?? null,
     isAuthenticated: c.var.mcpIsAuthenticated || false,
     clientId: mcpAuthInfo?.clientId ?? null,
     // Token callers (oauth/pat) carry real MCP scopes — pass them straight
@@ -243,6 +245,7 @@ export function toToolContext(authCtx: AuthContext): ToolContext {
     userId: authCtx.userId,
     memberRole: authCtx.memberRole,
     agentId: authCtx.agentId,
+    sourceContext: authCtx.sourceContext ?? null,
     isAuthenticated: authCtx.isAuthenticated,
     clientId: authCtx.clientId,
     scopes: authCtx.scopes,

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -52,6 +52,16 @@ export interface ToolAnnotations {
 
 export type TokenType = 'oauth' | 'session' | 'pat' | 'anonymous';
 
+export interface ToolSourceContext {
+  platform?: string;
+  conversationId?: string;
+  channelId?: string;
+  teamId?: string;
+  connectionId?: string;
+  userId?: string;
+  source?: string;
+}
+
 /**
  * Tool execution context from authentication
  * Passed to all tool handlers for organization scoping
@@ -65,6 +75,8 @@ export interface ToolContext {
   memberRole: string | null;
   /** Durable Lobu/Lobu agent identity bound to this MCP session, when provided. */
   agentId?: string | null;
+  /** Verified source conversation for worker-originated tool calls, when any. */
+  sourceContext?: ToolSourceContext | null;
   /** Whether request was authenticated */
   isAuthenticated: boolean;
   /** OAuth client ID that created this request (null for session/anonymous) */

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -331,6 +331,16 @@ export class MultiTenantProvider implements WorkspaceProvider {
           scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
           expiresAt: Math.floor((tokenData.timestamp + 2 * 60 * 60 * 1000) / 1000),
           tokenType: 'pat',
+          agentId: tokenData.agentId,
+          sourceContext: {
+            platform: tokenData.platform || undefined,
+            conversationId: tokenData.conversationId || undefined,
+            channelId: tokenData.channelId || undefined,
+            teamId: tokenData.teamId || undefined,
+            connectionId: tokenData.connectionId || undefined,
+            userId: tokenData.userId || undefined,
+            source: tokenData.source || undefined,
+          },
           // Builder admin-tool grant rides the per-run worker token (set only
           // for the system agent on an owner/admin turn). Carried through so the
           // execute gate lets the builder call its allowlisted internal tools.


### PR DESCRIPTION
## Problem

A `wake_agent` scheduled job always dispatched an api-platform message, which only reaches a connected SSE client. A background wake (cron-fired, no client attached) had nowhere to deliver its reply, so a task scheduled from a Slack/Telegram conversation couldn't post its result back into the channel that asked for it. It surfaced in the dashboard/transcript instead.

## What changed

The gateway already mints a worker token carrying the verified conversation context (platform, channel, connection, team, user). This plumbs that context through to tools as `ToolContext.sourceContext`, and `manage_schedules` uses it to record a trusted `delivery_context` on the scheduled job. At fire time `wake_agent` re-validates that context against the live connection and channel binding, then dispatches a real platform message via `buildMessagePayload` + `enqueueMessage` so the reply lands in the original channel. No delivery context means the unchanged api-platform path runs, so existing schedules behave exactly as before.

The delivery target is never taken from user-supplied `action_args`. `actionArgsForPayload` strips the payload down to the schema fields, and the only source of `delivery_context` is the gateway-minted token, so an agent can't forge a delivery target for a channel it doesn't own.

Supported platforms (slack, telegram) live in one `DELIVERABLE_CHAT_PLATFORMS` constant shared by the create-time gate and the fire-time dispatch, so the two can't drift. `teamId` is omitted rather than stamped with a placeholder when the platform has none (it's already optional on the wire `MessagePayload`, read as `payload.teamId ?? platformMetadata.teamId`).

## Trust and multi-replica

- `delivery_context` is gateway-owned, validated at create time and re-validated at fire time: connection still exists, is active, same platform, and bound to the target agent.
- Delivery rides the Postgres-backed message queue, and the scheduled-jobs ticker claims rows with `FOR UPDATE SKIP LOCKED` plus a per-tick idempotency key, so it's correct under N replicas and won't double-post.

## Tests

- `manage-schedules-delivery.test.ts`: trusted context is stored from the worker source context, caller-supplied delivery is stripped, the ticker injects it into the task payload, and agentless managed connections require a matching channel binding.
- `wake-agent-delivery.test.ts`: drives the real `runWakeAgentTask` against the test DB. Covers an authorized channel post (teamId omitted), real teamId forwarding, and fall-through to the api path when the connection is inactive or the platform isn't deliverable.

The surrounding delivery machinery (worker exec, Slack/Telegram adapter send) is the same path already running in production for Karloe, where this shipped as gateway bundle patches. This PR upstreams it so it survives version bumps.

## Also in here

- Renames `legacyIdToSlug` / `slugToLegacyId` to `runtimeConnectionIdToSlug` / `slugToRuntimeConnectionId` across call sites. The `agent_connections` table is gone, so the "legacy" name was stale.
- Forwards `extraHeaders` on the MCP proxy session-retry branch so `x-mcp-format` isn't dropped on a retried tool call.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two opt-in capabilities: (1) the scheduled `wake_agent` handler can now post its reply back into the originating Slack/Telegram channel rather than a detached API session, driven by a server-owned `delivery_context` column in `scheduled_jobs`; and (2) the `mcp-handler` refreshes `sourceContext` and `adminTools` on the auth context per request so tools see the current worker turn's conversation metadata. Both changes are backward-compatible — absence of `delivery_context` leaves the existing api-platform path untouched.

- **`delivery_context` column & ticker injection**: a nullable JSONB column is added to `scheduled_jobs`; at job creation `resolveTrustedDeliveryContext` validates the source connection is active and bound to the target agent before persisting it; the ticker then injects it as `__delivery_context` for the handler.
- **Fire-time authorization re-check**: `deliveryContextStillAuthorized` re-queries the connection and binding at execution time so a paused or deleted connection silently falls through to the API path rather than failing loudly.
- **`actionArgsForPayload` field allowlist**: replaces the old spread-minus-type approach with an explicit field allowlist, preventing arbitrary user-supplied keys (including a `delivery` field) from leaking into the durable `action_args` column.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The delivery path is opt-in and backward-compatible, the authorization is re-checked at both create and fire time, and actionArgsForPayload ensures user-supplied fields cannot inject a forged delivery context into the durable row.

The two key security boundaries — create-time resolveTrustedDeliveryContext (validates connection ownership + channel binding) and fire-time deliveryContextStillAuthorized (re-validates before dispatching) — are both present and tested. The agent existence check is now correctly org-scoped. The rename of legacyIdToSlug is mechanical and consistent across all call sites. No path allows the delivery_context to be injected or modified by unprivileged callers.

No files require special attention beyond the two minor style notes in jobs.ts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/server/src/scheduled/jobs.ts | Core of the feature: extracts wake_agent into runWakeAgentTask, adds asDeliveryContext parser, deliveryContextStillAuthorized re-check, and buildMessagePayload dispatch. Agent existence query now correctly scopes by org_id. |
| packages/server/src/tools/admin/manage_schedules.ts | Adds resolveTrustedDeliveryContext (validates source connection + binding at creation time) and actionArgsForPayload (explicit field allowlist to prevent payload injection). Both functions are well-guarded and tested. |
| packages/server/src/scheduled/scheduled-jobs-service.ts | Adds ScheduledDeliveryContext type, DELIVERABLE_CHAT_PLATFORMS constant, and delivery_context column handling. Ticker uses SELECT * so the new column is automatically picked up. |
| packages/server/src/mcp-handler.ts | Refreshes sourceContext and adminTools on the session auth context per request, consistent with existing scopes/userId refresh pattern. |
| packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts | One-line bug fix: extraHeaders was missing from the stale-session retry call, causing x-mcp-format to be dropped on reinit+retry. |
| packages/server/src/workspace/multi-tenant.ts | Worker PAT auth now surfaces agentId and sourceContext from tokenData into mcpAuthInfo without bypassing any existing auth checks. |
| db/migrations/20260630120000_scheduled_jobs_delivery_context.sql | Adds nullable JSONB delivery_context column with IF NOT EXISTS guard and matching down migration. O(1) metadata-only operation on Postgres. |
| packages/server/src/lobu/stores/connections-projection.ts | Renames legacyIdToSlug/slugToLegacyId to runtimeConnectionIdToSlug/slugToRuntimeConnectionId. Pure rename with no logic change; all call sites updated consistently. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Worker as Worker (MCP tool call)
    participant ManageSchedules as manage_schedules tool
    participant DB as scheduled_jobs (DB)
    participant Ticker as scheduled-jobs-tick
    participant WakeAgent as runWakeAgentTask
    participant Queue as Queue
    participant Slack as Slack / Telegram

    Worker->>ManageSchedules: handleCreate(args, toolCtx)
    ManageSchedules->>ManageSchedules: sourceToDeliveryContext → validate platform
    ManageSchedules->>DB: SELECT connections + agent_channel_bindings
    DB-->>ManageSchedules: connection row (active, matching agent)
    ManageSchedules->>DB: INSERT scheduled_jobs (action_args, delivery_context)

    Note over Ticker: Cron fires
    Ticker->>DB: "SELECT * FROM scheduled_jobs FOR UPDATE SKIP LOCKED"
    DB-->>Ticker: rows incl. delivery_context
    Ticker->>WakeAgent: spawn wake_agent with __delivery_context

    WakeAgent->>DB: SELECT agents WHERE org+id
    WakeAgent->>DB: deliveryContextStillAuthorized (re-check)
    DB-->>WakeAgent: authorized
    WakeAgent->>Queue: enqueueMessage(buildMessagePayload)
    Queue->>Slack: deliver reply to channelId

    Note over WakeAgent: No delivery_context → api path unchanged
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Worker as Worker (MCP tool call)
    participant ManageSchedules as manage_schedules tool
    participant DB as scheduled_jobs (DB)
    participant Ticker as scheduled-jobs-tick
    participant WakeAgent as runWakeAgentTask
    participant Queue as Queue
    participant Slack as Slack / Telegram

    Worker->>ManageSchedules: handleCreate(args, toolCtx)
    ManageSchedules->>ManageSchedules: sourceToDeliveryContext → validate platform
    ManageSchedules->>DB: SELECT connections + agent_channel_bindings
    DB-->>ManageSchedules: connection row (active, matching agent)
    ManageSchedules->>DB: INSERT scheduled_jobs (action_args, delivery_context)

    Note over Ticker: Cron fires
    Ticker->>DB: "SELECT * FROM scheduled_jobs FOR UPDATE SKIP LOCKED"
    DB-->>Ticker: rows incl. delivery_context
    Ticker->>WakeAgent: spawn wake_agent with __delivery_context

    WakeAgent->>DB: SELECT agents WHERE org+id
    WakeAgent->>DB: deliveryContextStillAuthorized (re-check)
    DB-->>WakeAgent: authorized
    WakeAgent->>Queue: enqueueMessage(buildMessagePayload)
    Queue->>Slack: deliver reply to channelId

    Note over WakeAgent: No delivery_context → api path unchanged
```

</a>

<sub>Reviews (3): Last reviewed commit: ["refactor(scheduled): extract runWakeAgen..."](https://github.com/lobu-ai/lobu/commit/3cf5d450392141804ccdfd40d7fccb8cd4827229) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40428044)</sub>

<!-- /greptile_comment -->