### PR TITLE
feat(authz): generic access-graph engine + GitHub repo source + in-Slack requester resolution

### DIFF
--- a/packages/connectors/src/__tests__/github-commits.test.ts
+++ b/packages/connectors/src/__tests__/github-commits.test.ts
@@ -107,4 +107,23 @@ describe("GitHub commits feed", () => {
 		expect(unlinked.metadata.author_login).toBeUndefined();
 		expect(unlinked.metadata.author_id).toBeUndefined();
 	});
+
+	test("every event is stamped with github_repo_full_name for repo-ACL attribution", async () => {
+		const { connector } = buildConnector(COMMITS);
+
+		const result = await connector.sync({
+			config: { repo_owner: "Lobu-AI", repo_name: "Lobu" },
+			feedKey: "commits",
+			checkpoint: null,
+			credentials: { provider: "github", accessToken: "tok" },
+			entityIds: [],
+		});
+
+		// Lowercased to match normalizeGithubRepoFullName / the repo graph so the
+		// repo entity GITHUB_REPO_ENTITY_LINK resolves to is the SAME one
+		// buildGithubRepoGraph materializes from collaborators.
+		for (const event of result.events) {
+			expect(event.metadata.github_repo_full_name).toBe("lobu-ai/lobu");
+		}
+	});
 });

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -282,6 +282,25 @@ const GITHUB_PERSON_ENTITY_LINK: EntityLinkRule = {
   },
 };
 
+// Link each repo-scoped event to the `repo` entity it belongs to, so the authz
+// resource gate (authz/resource-visibility) can restrict recall to repos the
+// requester is `member_of`. Keyed on `github_repo_full_name` to match the repo
+// entities `buildGithubRepoGraph` materializes from collaborators — both sides
+// resolve to ONE repo entity. The full name is stamped on every event in
+// `sync()` (see stampRepoAttribution).
+const GITHUB_REPO_ENTITY_LINK: EntityLinkRule = {
+  entityType: 'repo',
+  autoCreate: true,
+  titlePath: 'metadata.github_repo_full_name',
+  identities: [
+    {
+      namespace: IDENTITY.GITHUB_REPO_FULL_NAME,
+      eventPath: 'metadata.github_repo_full_name',
+      primary: true,
+    },
+  ],
+};
+
 export default class GitHubConnector extends ConnectorRuntime {
   readonly definition: ConnectorDefinition = {
     key: 'github',
@@ -424,7 +443,7 @@ export default class GitHubConnector extends ConnectorRuntime {
                 author_id: { type: 'string' },
               },
             },
-            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK, GITHUB_REPO_ENTITY_LINK],
           },
         },
       },
@@ -456,7 +475,7 @@ export default class GitHubConnector extends ConnectorRuntime {
                 author_id: { type: 'string' },
               },
             },
-            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK, GITHUB_REPO_ENTITY_LINK],
           },
         },
       },
@@ -484,7 +503,7 @@ export default class GitHubConnector extends ConnectorRuntime {
                 author_id: { type: 'string' },
               },
             },
-            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK, GITHUB_REPO_ENTITY_LINK],
           },
         },
       },
@@ -512,7 +531,7 @@ export default class GitHubConnector extends ConnectorRuntime {
                 author_id: { type: 'string' },
               },
             },
-            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK, GITHUB_REPO_ENTITY_LINK],
           },
         },
       },
@@ -543,7 +562,7 @@ export default class GitHubConnector extends ConnectorRuntime {
                 author_id: { type: 'string' },
               },
             },
-            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK, GITHUB_REPO_ENTITY_LINK],
           },
         },
       },
@@ -572,7 +591,7 @@ export default class GitHubConnector extends ConnectorRuntime {
                 author_id: { type: 'string' },
               },
             },
-            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK, GITHUB_REPO_ENTITY_LINK],
           },
         },
       },
@@ -602,7 +621,7 @@ export default class GitHubConnector extends ConnectorRuntime {
                 author_id: { type: 'string' },
               },
             },
-            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK, GITHUB_REPO_ENTITY_LINK],
           },
         },
       },
@@ -633,7 +652,7 @@ export default class GitHubConnector extends ConnectorRuntime {
                 author_id: { type: 'string' },
               },
             },
-            entityLinks: [GITHUB_PERSON_ENTITY_LINK],
+            entityLinks: [GITHUB_PERSON_ENTITY_LINK, GITHUB_REPO_ENTITY_LINK],
           },
           stargazer_unstarred: {
             description: 'A GitHub user unstarred the repository',
@@ -782,6 +801,7 @@ export default class GitHubConnector extends ConnectorRuntime {
 
     if (contentType === 'stargazers') {
       const result = await this.syncStargazers(repo, ctx.checkpoint, token);
+      this.stampRepoAttribution(result.events, repo);
       return {
         events: result.events,
         checkpoint: {
@@ -802,6 +822,7 @@ export default class GitHubConnector extends ConnectorRuntime {
       labelsFilter: config.labels_filter ?? [],
       token,
     });
+    this.stampRepoAttribution(events, repo);
 
     return {
       events,
@@ -999,6 +1020,22 @@ export default class GitHubConnector extends ConnectorRuntime {
     const fallback = new Date();
     fallback.setDate(fallback.getDate() - lookbackDays);
     return fallback.toISOString();
+  }
+
+  /**
+   * Stamp `metadata.github_repo_full_name` (lowercased `owner/repo`) on every
+   * event so the authz resource gate can link it to its `repo` entity (via
+   * GITHUB_REPO_ENTITY_LINK) and restrict recall to repos the requester belongs
+   * to. Lowercased to match `normalizeGithubRepoFullName` / the repo graph.
+   */
+  private stampRepoAttribution(events: EventEnvelope[], repo: RepoRef): void {
+    const fullName = `${repo.owner}/${repo.repo}`.toLowerCase();
+    for (const event of events) {
+      event.metadata = {
+        ...(event.metadata ?? {}),
+        github_repo_full_name: fullName,
+      };
+    }
   }
 
   private async syncContent(params: {

--- a/packages/connectors/src/github.ts
+++ b/packages/connectors/src/github.ts
@@ -668,6 +668,10 @@ export default class GitHubConnector extends ConnectorRuntime {
                 source: { type: 'string' },
               },
             },
+            // Repo-scoped: link to the repo so the ACL gate treats it like every
+            // other repo event (visible to collaborators) instead of dropping it
+            // — these kinds have no person link of their own.
+            entityLinks: [GITHUB_REPO_ENTITY_LINK],
           },
           stargazer_profile: {
             description: 'A public GitHub profile observation for a stargazer',
@@ -680,6 +684,7 @@ export default class GitHubConnector extends ConnectorRuntime {
                 account: { type: 'object' },
               },
             },
+            entityLinks: [GITHUB_REPO_ENTITY_LINK],
           },
         },
       },

--- a/packages/server/src/__tests__/integration/authz/github-repo-graph.test.ts
+++ b/packages/server/src/__tests__/integration/authz/github-repo-graph.test.ts
@@ -1,0 +1,171 @@
+/**
+ * GitHub repo-membership graph contract — proves the generic `buildAccessGraph`
+ * engine generalizes to a SECOND source. Repos become `repo` entities keyed on
+ * `github_repo_full_name`, collaborators become persons joined by `member_of`
+ * edges, a collaborator who already exists (carrying a `github_user_id` claim)
+ * COLLAPSES onto that entity (the identity-first fix the original org-level
+ * GitHub builder lacked), departures reconcile, and the build stamps
+ * `authz_source_acl_state`.
+ */
+
+import { normalizeGithubRepoFullName } from '@lobu/connector-sdk';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { buildGithubRepoGraph } from '../../../authz/github-repo-graph';
+import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const CONN = 'conn-gh';
+
+async function ensureType(orgId: string, slug: string, name: string): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+    VALUES (${orgId}, ${slug}, ${name}, current_timestamp, current_timestamp)
+    ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+    DO NOTHING
+  `;
+}
+
+async function seedOrg(name: string) {
+  const org = await createTestOrganization({ name });
+  const user = await createTestUser();
+  await addUserToOrganization(user.id, org.id, 'owner');
+  // The engine auto-creates `person` entities for collaborators; the type must
+  // exist in the org (prod seeds default types at org creation).
+  await ensureType(org.id, 'person', 'Person');
+  return { org, user };
+}
+
+async function entitiesOfType(orgId: string, slug: string) {
+  const sql = getTestDb();
+  return sql<{ id: number; name: string }[]>`
+    SELECT e.id, e.name
+    FROM entities e
+    JOIN entity_types et ON et.id = e.entity_type_id
+    WHERE e.organization_id = ${orgId} AND et.slug = ${slug} AND e.deleted_at IS NULL
+    ORDER BY e.id
+  `;
+}
+
+async function memberOfEdges(orgId: string) {
+  const sql = getTestDb();
+  return sql<{ from_entity_id: number; to_entity_id: number }[]>`
+    SELECT r.from_entity_id, r.to_entity_id
+    FROM entity_relationships r
+    JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+    WHERE r.organization_id = ${orgId}
+      AND rt.slug = 'member_of'
+      AND r.deleted_at IS NULL
+    ORDER BY r.from_entity_id
+  `;
+}
+
+describe('github repo graph', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    clearEntityLinkRulesCache();
+  });
+
+  it('builds repo entities + member_of edges and marks the connection enforced', async () => {
+    const { org } = await seedOrg('GitHub Graph Org');
+
+    const result = await buildGithubRepoGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      repos: [
+        {
+          fullName: 'lobu-ai/lobu',
+          collaborators: [
+            { login: 'alice', id: 101 },
+            { login: 'bob', id: 102 },
+          ],
+        },
+        { fullName: 'lobu-ai/secret', collaborators: [{ login: 'bob', id: 102 }] },
+      ],
+    });
+
+    // Repo entities are keyed on the normalized (lowercased) full name.
+    expect(Object.keys(result.resourceEntityIds).sort()).toEqual([
+      normalizeGithubRepoFullName('lobu-ai/lobu'),
+      normalizeGithubRepoFullName('lobu-ai/secret'),
+    ]);
+    // 3 edges: (alice,lobu), (bob,lobu), (bob,secret).
+    expect(result.createdEdges).toBe(3);
+
+    expect(await entitiesOfType(org.id, 'repo')).toHaveLength(2);
+    expect(await entitiesOfType(org.id, 'person')).toHaveLength(2); // alice + bob
+
+    const sql = getTestDb();
+    const stateRows = await sql`
+      SELECT acl_support, freshness_state FROM authz_source_acl_state
+      WHERE organization_id = ${org.id} AND connection_id = ${CONN}
+    `;
+    expect(stateRows).toHaveLength(1);
+    expect(stateRows[0].acl_support).toBe('full');
+    expect(stateRows[0].freshness_state).toBe('fresh');
+  });
+
+  it('collapses a collaborator onto an existing entity carrying github_user_id (no second person)', async () => {
+    const { org, user } = await seedOrg('Collapse Org');
+    // A $member who already has a github_user_id claim (e.g. signed in + linked).
+    const entity = await createTestEntity({
+      name: 'Alice',
+      entity_type: '$member',
+      organization_id: org.id,
+      created_by: user.id,
+    });
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+      VALUES (${org.id}, ${entity.id}, 'github_user_id', '101', 'connector:github')
+    `;
+    expect(await entitiesOfType(org.id, 'person')).toHaveLength(0);
+
+    const result = await buildGithubRepoGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      repos: [{ fullName: 'lobu-ai/lobu', collaborators: [{ login: 'alice', id: 101 }] }],
+    });
+
+    // Alice resolved to her existing $member — NOT a new person.
+    expect(await entitiesOfType(org.id, 'person')).toHaveLength(0);
+    expect(result.memberEntityIds).toEqual([entity.id]);
+    const edges = await memberOfEdges(org.id);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].from_entity_id).toBe(entity.id);
+  });
+
+  it('reconciles departures: a collaborator removed on re-sync loses their edge', async () => {
+    const { org } = await seedOrg('Reconcile Org');
+    await buildGithubRepoGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      repos: [
+        {
+          fullName: 'lobu-ai/lobu',
+          collaborators: [
+            { login: 'alice', id: 101 },
+            { login: 'bob', id: 102 },
+          ],
+        },
+      ],
+    });
+    expect(await memberOfEdges(org.id)).toHaveLength(2);
+
+    // Bob is removed from the repo → re-sync with just Alice.
+    const result = await buildGithubRepoGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      repos: [{ fullName: 'lobu-ai/lobu', collaborators: [{ login: 'alice', id: 101 }] }],
+    });
+    expect(result.removedEdges).toBe(1);
+    const edges = await memberOfEdges(org.id);
+    expect(edges).toHaveLength(1);
+  });
+});

--- a/packages/server/src/__tests__/integration/authz/github-repo-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/github-repo-visibility.test.ts
@@ -1,0 +1,175 @@
+/**
+ * GitHub repo visibility gate — END TO END through `search_memory` content recall.
+ *
+ * Proves the GENERIC resource gate (`authz/resource-visibility`) enforces GitHub
+ * repo membership over `events` the same way the Slack gate enforces channels
+ * over chat: an org member who is a collaborator on repo A (but not repo B)
+ * recalls only repo A's events. This is the second source riding the same engine
+ * + the same registry-driven gate — the proof that Linear/Jira slot in with just
+ * a `sources.ts` entry + a connector that stamps the resource identity on its
+ * events (here simulated by linking the repo entity into `events.entity_ids`).
+ *
+ * Uses explicit embeddings + query_embedding so the recall candidate path is
+ * deterministic without a live embedding service (mirrors
+ * events/search-content-visibility.test.ts).
+ */
+
+import { normalizeGithubRepoFullName } from '@lobu/connector-sdk';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildGithubRepoGraph } from '../../../authz/github-repo-graph';
+import type { ToolContext } from '../../../tools/registry';
+import { search } from '../../../tools/search';
+import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const EMBEDDING_DIM = 768;
+function axisVec(axis: number): number[] {
+  const v = new Array(EMBEDDING_DIM).fill(0);
+  v[axis] = 1;
+  return v;
+}
+
+function ctxFor(orgId: string, userId: string | null): ToolContext {
+  return {
+    organizationId: orgId,
+    userId,
+    memberRole: userId ? 'owner' : null,
+    isAuthenticated: !!userId,
+    tokenType: userId ? 'oauth' : 'anonymous',
+    scopedToOrg: !userId,
+    allowCrossOrg: !!userId,
+    scopes: userId ? ['mcp:read'] : undefined,
+  } as ToolContext;
+}
+
+/** A signed-in member who has also linked GitHub (auth_user_id + github_user_id). */
+async function seedSignedInMember(opts: {
+  orgId: string;
+  userId: string;
+  name: string;
+  githubUserId: string;
+}): Promise<number> {
+  const sql = getTestDb();
+  const entity = await createTestEntity({
+    name: opts.name,
+    entity_type: '$member',
+    organization_id: opts.orgId,
+    created_by: opts.userId,
+  });
+  await sql`
+    INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+    VALUES
+      (${opts.orgId}, ${entity.id}, 'auth_user_id', ${opts.userId}, 'auth:signup'),
+      (${opts.orgId}, ${entity.id}, 'github_user_id', ${opts.githubUserId}, 'connector:github')
+  `;
+  return entity.id;
+}
+
+async function recallContentIds(ctx: ToolContext): Promise<Set<number>> {
+  const result = await search(
+    {
+      query: 'github-recall-probe',
+      query_embedding: axisVec(0),
+      include_content: true,
+      content_limit: 50,
+    } as never,
+    {} as never,
+    ctx,
+  );
+  return new Set((result.content ?? []).map((c) => c.id));
+}
+
+describe('github repo visibility gate (e2e via search_memory content)', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    clearEntityLinkRulesCache();
+  });
+
+  async function setupWorkspace() {
+    const org = await createTestOrganization({ name: 'Acme' });
+    const alice = await createTestUser({ name: 'Alice', email: 'alice-gh@example.com' });
+    await addUserToOrganization(alice.id, org.id, 'owner');
+
+    const conn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      visibility: 'org',
+      createDefaultFeed: false,
+    });
+
+    // Alice signed in + linked GitHub as collaborator id 101.
+    await seedSignedInMember({ orgId: org.id, userId: alice.id, name: 'Alice', githubUserId: '101' });
+
+    // Alice (101) collaborates on repo-a only; Bob (102) on repo-b.
+    const graph = await buildGithubRepoGraph({
+      organizationId: org.id,
+      connectionId: String(conn.id),
+      repos: [
+        { fullName: 'acme/repo-a', collaborators: [{ login: 'alice', id: 101 }] },
+        { fullName: 'acme/repo-b', collaborators: [{ login: 'bob', id: 102 }] },
+      ],
+    });
+    const repoAId = graph.resourceEntityIds[normalizeGithubRepoFullName('acme/repo-a') as string];
+    const repoBId = graph.resourceEntityIds[normalizeGithubRepoFullName('acme/repo-b') as string];
+
+    // One event per repo, attributed by entity link (as the connector would stamp).
+    const eventA = await createTestEvent({
+      organization_id: org.id,
+      connection_id: conn.id,
+      connector_key: 'github',
+      content: 'repo A issue: quarterly metrics dashboard',
+      entity_ids: [repoAId],
+      embedding: axisVec(0),
+    });
+    const eventB = await createTestEvent({
+      organization_id: org.id,
+      connection_id: conn.id,
+      connector_key: 'github',
+      content: 'repo B issue: confidential quarterly metrics',
+      entity_ids: [repoBId],
+      embedding: axisVec(0),
+    });
+
+    return { org, alice, eventAId: eventA.id, eventBId: eventB.id };
+  }
+
+  it('surfaces only the repo the requester collaborates on once the graph is enforced', async () => {
+    const { org, alice, eventAId, eventBId } = await setupWorkspace();
+
+    const ids = await recallContentIds(ctxFor(org.id, alice.id));
+    expect(ids.has(eventAId)).toBe(true);
+    expect(ids.has(eventBId)).toBe(false);
+  });
+
+  it('fails closed: a requester with no $member sees NONE of an enforced connection', async () => {
+    const { org, eventAId, eventBId } = await setupWorkspace();
+    const ids = await recallContentIds(ctxFor(org.id, 'intruder-user-id'));
+    expect(ids.has(eventAId)).toBe(false);
+    expect(ids.has(eventBId)).toBe(false);
+  });
+
+  it('no regression: WITHOUT a graph the connection stays on legacy connection-visibility (both visible)', async () => {
+    const { org, alice, eventAId, eventBId } = await setupWorkspace();
+    // Drop the ACL state → connection no longer enforced → repo gate is inert,
+    // both org-visible events recall.
+    const sql = getTestDb();
+    await sql`DELETE FROM authz_source_acl_state WHERE organization_id = ${org.id}`;
+    const ids = await recallContentIds(ctxFor(org.id, alice.id));
+    expect(ids.has(eventAId)).toBe(true);
+    expect(ids.has(eventBId)).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/integration/authz/github-repo-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/github-repo-visibility.test.ts
@@ -16,6 +16,7 @@
 
 import { normalizeGithubRepoFullName } from '@lobu/connector-sdk';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { syncGithubConnectionAcl } from '../../../authz/github-acl-sync';
 import { buildGithubRepoGraph } from '../../../authz/github-repo-graph';
 import type { ToolContext } from '../../../tools/registry';
 import { search } from '../../../tools/search';
@@ -160,6 +161,68 @@ describe('github repo visibility gate (e2e via search_memory content)', () => {
     const ids = await recallContentIds(ctxFor(org.id, 'intruder-user-id'));
     expect(ids.has(eventAId)).toBe(false);
     expect(ids.has(eventBId)).toBe(false);
+  });
+
+  it('enforces through the PRODUCTION sync path (syncGithubConnectionAcl), not just the test builder', async () => {
+    const org = await createTestOrganization({ name: 'Acme Sync' });
+    const alice = await createTestUser({ name: 'Alice', email: 'alice-sync@example.com' });
+    await addUserToOrganization(alice.id, org.id, 'owner');
+    const conn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      visibility: 'org',
+      createDefaultFeed: false,
+    });
+    await seedSignedInMember({ orgId: org.id, userId: alice.id, name: 'Alice', githubUserId: '101' });
+
+    // Drive the REAL sync with a stubbed GitHub API + repo list — exactly as
+    // runGithubAclSyncTick wires it in prod. THIS materializes the graph.
+    const collaborators: Record<string, { login: string; id: number }[]> = {
+      'acme/repo-a': [{ login: 'alice', id: 101 }],
+      'acme/repo-b': [{ login: 'bob', id: 102 }],
+    };
+    const result = await syncGithubConnectionAcl(
+      {
+        listRepos: async () => [
+          { owner: 'acme', repo: 'repo-a' },
+          { owner: 'acme', repo: 'repo-b' },
+        ],
+        fetchCollaborators: async ({ repo }) => collaborators[`${repo.owner}/${repo.repo}`] ?? [],
+      },
+      { connectionId: String(conn.id), organizationId: org.id },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.reposSynced).toBe(2);
+
+    // Resolve the repo entities the sync materialized, attribute an event to each.
+    const sql = getTestDb();
+    const repoId = async (fullName: string): Promise<number> => {
+      const rows = await sql<{ entity_id: number }>`
+        SELECT entity_id FROM entity_identities
+        WHERE organization_id = ${org.id} AND namespace = 'github_repo_full_name'
+          AND identifier = ${fullName} AND deleted_at IS NULL LIMIT 1`;
+      return Number(rows[0].entity_id);
+    };
+    const eventA = await createTestEvent({
+      organization_id: org.id,
+      connection_id: conn.id,
+      connector_key: 'github',
+      content: 'repo A issue: quarterly metrics',
+      entity_ids: [await repoId('acme/repo-a')],
+      embedding: axisVec(0),
+    });
+    const eventB = await createTestEvent({
+      organization_id: org.id,
+      connection_id: conn.id,
+      connector_key: 'github',
+      content: 'repo B issue: confidential quarterly metrics',
+      entity_ids: [await repoId('acme/repo-b')],
+      embedding: axisVec(0),
+    });
+
+    const ids = await recallContentIds(ctxFor(org.id, alice.id));
+    expect(ids.has(eventA.id)).toBe(true);
+    expect(ids.has(eventB.id)).toBe(false);
   });
 
   it('no regression: WITHOUT a graph the connection stays on legacy connection-visibility (both visible)', async () => {

--- a/packages/server/src/__tests__/integration/authz/github-repo-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/github-repo-visibility.test.ts
@@ -20,7 +20,10 @@ import { syncGithubConnectionAcl } from '../../../authz/github-acl-sync';
 import { buildGithubRepoGraph } from '../../../authz/github-repo-graph';
 import type { ToolContext } from '../../../tools/registry';
 import { search } from '../../../tools/search';
-import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import {
+  clearEntityLinkRulesCache,
+  resolveEntityLinksForItems,
+} from '../../../utils/entity-link-upsert';
 import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
@@ -223,6 +226,65 @@ describe('github repo visibility gate (e2e via search_memory content)', () => {
     const ids = await recallContentIds(ctxFor(org.id, alice.id));
     expect(ids.has(eventA.id)).toBe(true);
     expect(ids.has(eventB.id)).toBe(false);
+  });
+
+  it('ingestion path: a stamped github event resolves to the SAME repo entity the graph gates on', async () => {
+    const org = await createTestOrganization({ name: 'Acme Ingest' });
+    const alice = await createTestUser({ name: 'Alice', email: 'alice-ingest@example.com' });
+    await addUserToOrganization(alice.id, org.id, 'owner');
+    const conn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      visibility: 'org',
+      createDefaultFeed: false,
+    });
+    await seedSignedInMember({ orgId: org.id, userId: alice.id, name: 'Alice', githubUserId: '101' });
+
+    // Graph: alice collaborates on repo-a only.
+    const graph = await buildGithubRepoGraph({
+      organizationId: org.id,
+      connectionId: String(conn.id),
+      repos: [
+        { fullName: 'acme/repo-a', collaborators: [{ login: 'alice', id: 101 }] },
+        { fullName: 'acme/repo-b', collaborators: [{ login: 'bob', id: 102 }] },
+      ],
+    });
+    const repoAId = graph.resourceEntityIds[normalizeGithubRepoFullName('acme/repo-a') as string];
+
+    // Drive the REAL ingestion entity-link resolver with the connector's repo
+    // link rule shape (mirrors GITHUB_REPO_ENTITY_LINK in connectors/src/github.ts)
+    // on an event stamped with github_repo_full_name. This proves the chain the
+    // connector emits → server resolves: metadata.github_repo_full_name resolves
+    // to the SAME repo entity the graph built (one entity, no forked duplicate).
+    const githubRepoLinkRule = {
+      entityType: 'repo',
+      autoCreate: true,
+      titlePath: 'metadata.github_repo_full_name',
+      identities: [
+        { namespace: 'github_repo_full_name', eventPath: 'metadata.github_repo_full_name', primary: true },
+      ],
+    };
+    const resolved = await resolveEntityLinksForItems({
+      connectorKey: 'github',
+      orgId: org.id,
+      items: [{ origin_type: 'issue', metadata: { github_repo_full_name: 'acme/repo-a' } }],
+      rules: { issue: [githubRepoLinkRule] },
+    });
+    const ingestedRepoIds = resolved.get(0) ?? [];
+    // The repo entity ingestion links to IS the one the graph gates on.
+    expect(ingestedRepoIds).toContain(repoAId);
+
+    // And an event linked via that ingestion-resolved entity is gated for alice.
+    const event = await createTestEvent({
+      organization_id: org.id,
+      connection_id: conn.id,
+      connector_key: 'github',
+      content: 'repo A issue: quarterly metrics',
+      entity_ids: ingestedRepoIds,
+      embedding: axisVec(0),
+    });
+    const ids = await recallContentIds(ctxFor(org.id, alice.id));
+    expect(ids.has(event.id)).toBe(true);
   });
 
   it('no regression: WITHOUT a graph the connection stays on legacy connection-visibility (both visible)', async () => {

--- a/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
@@ -375,4 +375,28 @@ describe('slack channel visibility gate (e2e via search_memory)', () => {
     const after = await searchAs(org.id, alice.id, agent.agentId);
     expect(after.conversation_messages ?? []).toHaveLength(0);
   });
+
+  it('resolves an in-Slack requester via slack_user_id when they have no auth identity', async () => {
+    const { org, agent } = await setupWorkspace();
+    // Dave is a Slack-only user (never signed in to the web app → no auth_user_id).
+    // The graph auto-creates his person entity with a slack_user_id claim + a
+    // member_of edge to #eng.
+    await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      teamId: TEAM,
+      channels: [
+        { channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01DAVE'] },
+        { channelId: 'C01SEC', name: 'secret', isPrivate: true, memberSlackUserIds: ['U01BOB'] },
+      ],
+    });
+
+    // ctx.userId is Dave's bare Slack id (the in-Slack message author), NOT an
+    // auth_user_id — the auth lookup misses, so this only passes via the
+    // slack_user_id fallback. Without it, Dave fails closed and sees nothing.
+    const result = await searchAs(org.id, 'U01DAVE', agent.agentId);
+    const channels = (result.conversation_messages ?? []).map((m) => m.channel_id);
+    expect(channels).toContain('C01ENG');
+    expect(channels).not.toContain('C01SEC');
+  });
 });

--- a/packages/server/src/__tests__/unit/connection-visibility.test.ts
+++ b/packages/server/src/__tests__/unit/connection-visibility.test.ts
@@ -56,14 +56,20 @@ describe('connection-visibility compiler (M1 one-compiler)', () => {
     });
   });
 
-  it('the recall/content adapter is a byte-identical pass-through to the compiler', () => {
+  it('the recall/content adapter composes the connection-visibility compiler verbatim, then the resource gate', () => {
     const viaAdapter = buildConnectionVisibilityClause(
       { organizationId: 'org_test', userId: 'user_a', baseParamIndex: 7 },
       'f'
     );
     const viaCompiler = compileConnectionFkVisibility(scope, 7, 'f');
-    expect(viaAdapter.sql).toBe(viaCompiler.sql);
-    expect(viaAdapter.params).toEqual(viaCompiler.params);
+    // Connection visibility is STILL the one compiler's output, verbatim — the
+    // adapter prefixes it (no re-derivation), then ANDs the orthogonal resource
+    // gate, whose params follow the connection-visibility params in order.
+    expect(viaAdapter.sql.startsWith(viaCompiler.sql)).toBe(true);
+    expect(viaAdapter.params.slice(0, viaCompiler.params.length)).toEqual(viaCompiler.params);
+    // Plus the per-resource membership gate composed after it.
+    expect(viaAdapter.sql).toContain('member_of');
+    expect(viaAdapter.params).toEqual(['org_test', 'user_a', 'org_test', 'user_a']);
   });
 
   it('the adapter still returns empty when no org is requested', () => {

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -123,6 +123,21 @@ async function ensureResourceEntityType(orgId: string, type: AccessResourceType)
 	`;
 }
 
+/** Ensure the org has a `person` entity type — the type new (genuinely-unknown)
+ * members are auto-created as. Prod seeds default types at org creation, but a
+ * brand-new/default org may not have it yet; without it those members would
+ * silently fail to resolve while the connection is still stamped enforced (their
+ * recall would then fail closed). */
+async function ensurePersonEntityType(orgId: string): Promise<void> {
+  const sql = getDb();
+  await sql`
+		INSERT INTO entity_types (slug, name, organization_id, created_at, updated_at)
+		VALUES ('person', 'Person', ${orgId}, current_timestamp, current_timestamp)
+		ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+		DO NOTHING
+	`;
+}
+
 /** Find-or-create the org-scoped `member_of` relationship type. */
 async function ensureMemberOfType(orgId: string): Promise<number> {
   const sql = getDb();
@@ -272,6 +287,7 @@ export async function buildAccessGraph(params: {
   }
 
   await ensureResourceEntityType(organizationId, resourceType);
+  await ensurePersonEntityType(organizationId);
 
   // 1) Resolve every resource to its entity, keyed on the source identity namespace.
   const resourceItems = resources.map((r) => ({

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -1,0 +1,402 @@
+/**
+ * The generic access-graph engine — ONE materializer behind every ACL source.
+ *
+ * A "source" (a Slack workspace, a GitHub org, later Jira/Drive/…) reduces to the
+ * same shape: a set of RESOURCES (channels, repos, projects), each with an
+ * AUDIENCE of MEMBERS who may read it. This engine takes that normalized shape
+ * and writes it into the existing entity graph — exactly the way the original
+ * `buildSlackChannelGraph` did, but with the resource/member specifics lifted
+ * into parameters so a second source reuses the whole body instead of copying it.
+ *
+ * It owns everything that was identical (or should have been) between the Slack
+ * channel graph and the GitHub team graph:
+ *   - resolve an org owner/admin to attribute entities/edges to (`created_by`);
+ *   - find-or-create the resource entity TYPE and the `member_of` relationship
+ *     type (reuse, no migration);
+ *   - resolve each resource to its entity, keyed on a source-specific identity
+ *     namespace (`slack_channel_id`, `github_repo_id`, …);
+ *   - resolve each member IDENTITY-FIRST and TYPE-AGNOSTICALLY — a member who has
+ *     already signed in owns their identity claim on a `$member` entity, so we
+ *     collapse onto THAT entity rather than forking a duplicate `person` (the
+ *     correctness fix the Slack builder had and the original GitHub builder did
+ *     NOT — folding GitHub onto this engine fixes it for free);
+ *   - write `member_of` (member → resource) edges idempotently;
+ *   - RECONCILE departures (soft-delete edges to a synced resource whose member is
+ *     no longer present) so leavers lose access on the next sync;
+ *   - stamp `authz_source_acl_state` ('full','fresh') so the gate begins enforcing
+ *     the connection.
+ *
+ * Tenant-scoped, idempotent, best-effort: everything filters on `organizationId`;
+ * edges dedupe on the live-triple unique index; nothing here throws on a
+ * data-shaped problem (the CALLER's fetch layer owns fail-closed-on-error).
+ */
+
+import { createLogger } from '@lobu/core';
+import { getDb, pgBigintArray, pgTextArray } from '../db/client.js';
+import { resolveEntityLinksForItems } from '../utils/entity-link-upsert.js';
+
+const logger = createLogger('access-graph');
+
+const MEMBER_OF_TYPE_SLUG = 'member_of';
+
+/** A claim that identifies a member, e.g. `{namespace:'slack_user_id', primary:true}`.
+ * The engine collapses a member onto any existing entity carrying ANY of their
+ * identities; `primary` ones additionally govern creation. */
+export interface AccessIdentitySpec {
+  namespace: string;
+  primary?: boolean;
+}
+
+/** One member of a resource's audience. */
+export interface AccessMember {
+  /** Stable dedupe key for this member across resources (the primary identity
+   * value is the natural choice: `T…:U…` for Slack, the numeric id for GitHub). */
+  key: string;
+  /** Display name for an auto-created `person`. Falls back to `key`. */
+  name?: string;
+  /** This member's identity claims (namespaces declared in `memberIdentities`). */
+  identities: { namespace: string; value: string }[];
+}
+
+/** One resource (channel/repo/…) and the members who may read it. */
+export interface AccessResource {
+  /** Stored as the resource entity's identity under `resourceType.namespace`
+   * (`T…:C…` for Slack, `owner/repo` or the numeric id for GitHub). */
+  key: string;
+  name?: string;
+  members: AccessMember[];
+}
+
+/** The resource entity type to find-or-create and key resources under. */
+export interface AccessResourceType {
+  /** Entity-type slug, e.g. `channel` / `repo`. */
+  slug: string;
+  name: string;
+  description: string;
+  icon: string;
+  /** Identity namespace the resource key is stored/looked-up under. */
+  namespace: string;
+}
+
+export interface AccessGraphResult {
+  /** Resource key → the entity id that now represents it. */
+  resourceEntityIds: Record<string, number>;
+  /** Distinct member entity ids that gained a `member_of` edge. */
+  memberEntityIds: number[];
+  createdEdges: number;
+  removedEdges: number;
+}
+
+const EMPTY_RESULT: AccessGraphResult = {
+  resourceEntityIds: {},
+  memberEntityIds: [],
+  createdEdges: 0,
+  removedEdges: 0,
+};
+
+/** Resolve an org owner/admin as `entities.created_by` / edge `created_by`
+ * (NOT NULL). Same query both source builders used. */
+async function resolveOrgCreator(orgId: string): Promise<string | null> {
+  const sql = getDb();
+  const rows = await sql<{ userId: string }>`
+		SELECT "userId"
+		FROM "member"
+		WHERE "organizationId" = ${orgId}
+		ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END,
+		         "createdAt" ASC
+		LIMIT 1
+	`;
+  return rows.length > 0 ? rows[0].userId : null;
+}
+
+/** Find-or-create the org-scoped resource entity type (reuse, no migration). */
+async function ensureResourceEntityType(orgId: string, type: AccessResourceType): Promise<void> {
+  const sql = getDb();
+  await sql`
+		INSERT INTO entity_types (slug, name, description, icon, organization_id, created_at, updated_at)
+		VALUES (
+			${type.slug}, ${type.name}, ${type.description}, ${type.icon},
+			${orgId}, current_timestamp, current_timestamp
+		)
+		ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+		DO NOTHING
+	`;
+}
+
+/** Find-or-create the org-scoped `member_of` relationship type. */
+async function ensureMemberOfType(orgId: string): Promise<number> {
+  const sql = getDb();
+  const rows = await sql`
+		INSERT INTO entity_relationship_types
+			(slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
+		VALUES
+			(${MEMBER_OF_TYPE_SLUG}, 'Member of', 'A person is a member of an organization or channel', ${orgId},
+			 false, NULL, current_timestamp, current_timestamp)
+		ON CONFLICT (organization_id, slug) WHERE status = 'active'
+		DO UPDATE SET updated_at = EXCLUDED.updated_at
+		RETURNING id
+	`;
+  return Number(rows[0].id);
+}
+
+/** Stamp the connection's ACL state so the gate begins enforcing it. */
+async function markAclEnforced(orgId: string, connectionId: string): Promise<void> {
+  const sql = getDb();
+  await sql`
+		INSERT INTO authz_source_acl_state
+			(organization_id, connection_id, acl_support, freshness_state, last_synced_at, created_at, updated_at)
+		VALUES (${orgId}, ${connectionId}, 'full', 'fresh', current_timestamp, current_timestamp, current_timestamp)
+		ON CONFLICT (organization_id, connection_id)
+		DO UPDATE SET acl_support = 'full', freshness_state = 'fresh',
+		              last_synced_at = current_timestamp, updated_at = current_timestamp
+	`;
+}
+
+/**
+ * Resolve every distinct member to an entity id, IDENTITY-FIRST and
+ * TYPE-AGNOSTIC: a member collapses onto any existing entity (`$member`,
+ * `person`, …) carrying ANY of their identities; only genuinely-new members get
+ * a freshly-created `person`. Returns a map member.key → entity id.
+ */
+async function resolveMembers(
+  orgId: string,
+  connectorKey: string,
+  members: AccessMember[],
+  memberIdentities: AccessIdentitySpec[],
+): Promise<Map<string, number>> {
+  const byKey = new Map<string, number>();
+  if (members.length === 0) return byKey;
+
+  // Gather identity values per namespace and look up existing owners (any type).
+  const valuesByNamespace = new Map<string, Set<string>>();
+  for (const m of members) {
+    for (const id of m.identities) {
+      if (!id.value) continue;
+      const set = valuesByNamespace.get(id.namespace) ?? new Set<string>();
+      set.add(id.value);
+      valuesByNamespace.set(id.namespace, set);
+    }
+  }
+  const existing = new Map<string, number>(); // `${namespace}|${value}` → entity id
+  const sql = getDb();
+  for (const [namespace, values] of valuesByNamespace) {
+    const list = [...values];
+    if (list.length === 0) continue;
+    const rows = await sql<{ identifier: string; entity_id: number }>`
+			SELECT identifier, entity_id
+			FROM entity_identities
+			WHERE organization_id = ${orgId}
+			  AND namespace = ${namespace}
+			  AND identifier = ANY(${pgTextArray(list)}::text[])
+			  AND deleted_at IS NULL
+		`;
+    for (const r of rows) {
+      existing.set(`${namespace}|${String(r.identifier)}`, Number(r.entity_id));
+    }
+  }
+
+  const toCreate: AccessMember[] = [];
+  for (const m of members) {
+    let hit: number | undefined;
+    for (const id of m.identities) {
+      const found = existing.get(`${id.namespace}|${id.value}`);
+      if (found !== undefined) {
+        hit = found;
+        break;
+      }
+    }
+    if (hit !== undefined) byKey.set(m.key, hit);
+    else toCreate.push(m);
+  }
+
+  if (toCreate.length === 0) return byKey;
+
+  // Auto-create a `person` for each genuinely-new member, carrying ALL their
+  // declared identities so a later source (or login) collapses onto them.
+  const items = toCreate.map((m) => {
+    const metadata: Record<string, unknown> = { display_name: m.name ?? m.key };
+    for (const id of m.identities) metadata[id.namespace] = id.value;
+    return { origin_type: 'access_member', metadata };
+  });
+  const resolved = await resolveEntityLinksForItems({
+    connectorKey,
+    orgId,
+    items,
+    rules: {
+      access_member: [
+        {
+          entityType: 'person',
+          autoCreate: true,
+          titlePath: 'metadata.display_name',
+          identities: memberIdentities.map((spec) => ({
+            namespace: spec.namespace,
+            eventPath: `metadata.${spec.namespace}`,
+            primary: spec.primary,
+          })),
+        },
+      ],
+    },
+  });
+  for (let i = 0; i < toCreate.length; i++) {
+    const ids = resolved.get(i);
+    if (ids && ids.length > 0) byKey.set(toCreate[i].key, ids[0]);
+  }
+  return byKey;
+}
+
+/**
+ * Materialize a source's resource→audience graph and mark the connection
+ * ACL-enforced. The CALLER normalizes its raw API shape into `resources`
+ * (Slack channels with `T:C`/`T:U` keys, GitHub repos with collaborators, …);
+ * this body is source-agnostic.
+ */
+export async function buildAccessGraph(params: {
+  organizationId: string;
+  connectionId: string;
+  connectorKey: string;
+  resourceType: AccessResourceType;
+  memberIdentities: AccessIdentitySpec[];
+  resources: AccessResource[];
+}): Promise<AccessGraphResult> {
+  const { organizationId, connectionId, connectorKey, resourceType, memberIdentities } = params;
+  const resources = params.resources.filter((r) => r.key);
+  if (resources.length === 0) return EMPTY_RESULT;
+
+  const creatorUserId = await resolveOrgCreator(organizationId);
+  if (!creatorUserId) {
+    logger.warn(
+      { organization_id: organizationId, connector: connectorKey },
+      'Access graph skipped: org has no member to attribute as entity creator',
+    );
+    return EMPTY_RESULT;
+  }
+
+  await ensureResourceEntityType(organizationId, resourceType);
+
+  // 1) Resolve every resource to its entity, keyed on the source identity namespace.
+  const resourceItems = resources.map((r) => ({
+    origin_type: 'access_resource',
+    metadata: { resource_key: r.key, resource_name: r.name ?? r.key },
+  }));
+  const resolvedResources = await resolveEntityLinksForItems({
+    connectorKey,
+    orgId: organizationId,
+    items: resourceItems,
+    rules: {
+      access_resource: [
+        {
+          entityType: resourceType.slug,
+          autoCreate: true,
+          titlePath: 'metadata.resource_name',
+          identities: [
+            { namespace: resourceType.namespace, eventPath: 'metadata.resource_key', primary: true },
+          ],
+        },
+      ],
+    },
+  });
+  const resourceEntityIds: Record<string, number> = {};
+  const resourceEntityIdByIndex = new Map<number, number>();
+  for (let i = 0; i < resources.length; i++) {
+    const ids = resolvedResources.get(i);
+    if (ids && ids.length > 0) {
+      resourceEntityIds[resources[i].key] = ids[0];
+      resourceEntityIdByIndex.set(i, ids[0]);
+    }
+  }
+
+  // 2) Resolve every DISTINCT member (identity-first, type-agnostic).
+  const distinctMembers = new Map<string, AccessMember>();
+  for (const r of resources) {
+    for (const m of r.members) {
+      if (m.key && !distinctMembers.has(m.key)) distinctMembers.set(m.key, m);
+    }
+  }
+  const memberEntityByKey = await resolveMembers(
+    organizationId,
+    connectorKey,
+    [...distinctMembers.values()],
+    memberIdentities,
+  );
+
+  // 3) Write member → resource `member_of` edges, idempotent on the live-triple
+  // unique index. Accumulate the CURRENT member set per resource for reconcile.
+  const typeId = await ensureMemberOfType(organizationId);
+  const sql = getDb();
+  const memberEntityIds = new Set<number>();
+  const currentMembersByResource = new Map<number, Set<number>>();
+  let createdEdges = 0;
+  for (let i = 0; i < resources.length; i++) {
+    const resourceEntityId = resourceEntityIdByIndex.get(i);
+    if (resourceEntityId === undefined) continue;
+    const resourceMembers = currentMembersByResource.get(resourceEntityId) ?? new Set<number>();
+    currentMembersByResource.set(resourceEntityId, resourceMembers);
+    for (const m of resources[i].members) {
+      const memberEntityId = memberEntityByKey.get(m.key);
+      if (memberEntityId === undefined) continue;
+      memberEntityIds.add(memberEntityId);
+      resourceMembers.add(memberEntityId);
+      const inserted = await sql<{ id: number }[]>`
+				INSERT INTO entity_relationships (
+					organization_id, from_entity_id, to_entity_id, relationship_type_id,
+					confidence, source, created_by, updated_by, created_at, updated_at
+				) VALUES (
+					${organizationId}, ${memberEntityId}, ${resourceEntityId}, ${typeId},
+					1.0, 'feed', ${creatorUserId}, ${creatorUserId},
+					current_timestamp, current_timestamp
+				)
+				ON CONFLICT (from_entity_id, to_entity_id, relationship_type_id)
+					WHERE deleted_at IS NULL
+				DO NOTHING
+				RETURNING id
+			`;
+      if (inserted.length > 0) createdEdges += 1;
+    }
+  }
+
+  // 4) Reconcile DEPARTURES — the build is a full re-sync of each resource's
+  // membership, so a `member_of` edge to a synced resource whose member is NOT
+  // in the current set means that person left: soft-delete it so they lose
+  // access immediately. Scoped to `to_entity_id` = a resource we just synced, so
+  // edges to OTHER resource types (a different source's graph) are never touched.
+  // An empty member set deletes all of that resource's edges — the caller must
+  // not pass empty-on-fetch-error.
+  let removedEdges = 0;
+  for (const [resourceEntityId, resourceMembers] of currentMembersByResource) {
+    const keep = [...resourceMembers];
+    const removed = await sql<{ id: number }[]>`
+			UPDATE entity_relationships
+			SET deleted_at = current_timestamp, updated_at = current_timestamp
+			WHERE organization_id = ${organizationId}
+			  AND relationship_type_id = ${typeId}
+			  AND to_entity_id = ${resourceEntityId}
+			  AND deleted_at IS NULL
+			  AND from_entity_id <> ALL(${pgBigintArray(keep)}::bigint[])
+			RETURNING id
+		`;
+    removedEdges += removed.length;
+  }
+
+  await markAclEnforced(organizationId, connectionId);
+
+  logger.info(
+    {
+      organization_id: organizationId,
+      connection_id: connectionId,
+      connector: connectorKey,
+      resource_type: resourceType.slug,
+      resources: Object.keys(resourceEntityIds).length,
+      members: memberEntityIds.size,
+      created_edges: createdEdges,
+      removed_edges: removedEdges,
+    },
+    'Built access graph',
+  );
+
+  return {
+    resourceEntityIds,
+    memberEntityIds: [...memberEntityIds],
+    createdEdges,
+    removedEdges,
+  };
+}

--- a/packages/server/src/authz/acl-state.ts
+++ b/packages/server/src/authz/acl-state.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared ACL-enforcement-state helpers — used by BOTH read gates (the Slack
+ * channel gate `./channel-visibility` and the generic resource gate
+ * `./resource-visibility`) so the "is this connection enforcing right now?"
+ * rule lives in one place and cannot drift between them.
+ */
+
+/**
+ * How long a `fresh` ACL graph stays trusted without a re-sync. The background
+ * sync re-stamps `last_synced_at`; if it stops, a connection's graph ages past
+ * this window and the gate stops trusting it — failing closed rather than
+ * serving stale membership. Generous vs. the ~15-min sync cadence so a transient
+ * hiccup never blinks recall off.
+ */
+export const ACL_STALE_AFTER_MINUTES = 60;
+
+/**
+ * SQL subquery (no leading/trailing space) selecting the `connection_id`s that
+ * are ACL-enforced right now: `acl_support='full'` AND `freshness_state='fresh'`
+ * AND synced within {@link ACL_STALE_AFTER_MINUTES}. `orgParam` is an already-bound
+ * `$N::text` placeholder. Returns the bare `SELECT …` (caller wraps in IN/NOT IN).
+ */
+export function enforcedConnectionsSelectSql(orgParam: string): string {
+  return `SELECT connection_id FROM public.authz_source_acl_state
+    WHERE organization_id = ${orgParam}
+      AND acl_support = 'full'
+      AND freshness_state = 'fresh'
+      AND last_synced_at IS NOT NULL
+      AND last_synced_at >= current_timestamp - make_interval(mins => ${ACL_STALE_AFTER_MINUTES})`;
+}

--- a/packages/server/src/authz/acl-sync.ts
+++ b/packages/server/src/authz/acl-sync.ts
@@ -1,0 +1,33 @@
+/**
+ * The ACL sync orchestrator — ONE scheduled tick that re-materializes every
+ * registered source's access graph. Each source owns its own fetch (Slack:
+ * `conversations.members` over agent-connection-bound channels; GitHub: repo
+ * collaborators over connection feeds) because data acquisition is inherently
+ * per-source; they all converge on the same `buildAccessGraph` engine + the same
+ * `authz_source_acl_state` switch the gates read. Adding a source = add its
+ * `run<Source>AclSyncTick` here.
+ *
+ * Error isolation: a source tick that throws is logged and never aborts the
+ * others (each source's per-connection sync is already atomic/fail-closed).
+ */
+
+import { createLogger } from '@lobu/core';
+import type { CoreServices } from '../gateway/services/core-services.js';
+import { runGithubAclSyncTick } from './github-acl-sync.js';
+import { runSlackAclSyncTick } from './slack-acl-sync.js';
+
+const logger = createLogger('acl-sync');
+
+export async function runAclSyncTick(coreServices: CoreServices): Promise<void> {
+  const sources: Array<{ key: string; run: () => Promise<void> }> = [
+    { key: 'slack', run: () => runSlackAclSyncTick(coreServices) },
+    { key: 'github', run: () => runGithubAclSyncTick(coreServices) },
+  ];
+  for (const source of sources) {
+    try {
+      await source.run();
+    } catch (error) {
+      logger.error({ source: source.key, error: String(error) }, 'ACL sync source tick failed');
+    }
+  }
+}

--- a/packages/server/src/authz/channel-visibility.ts
+++ b/packages/server/src/authz/channel-visibility.ts
@@ -21,6 +21,7 @@
  * or no `$member` in this org) sees NONE of an enforced connection's channels.
  */
 
+import { normalizeSlackUserId } from '@lobu/connector-sdk';
 import { type DbClient, pgTextArray } from '../db/client.js';
 import { stripPlatformPrefix } from '../gateway/channels/bound-channels.js';
 import { slackChannelKey } from './slack-channel-graph.js';
@@ -67,6 +68,45 @@ export async function resolveRequesterMemberEntityId(
 		  AND ei.identifier = ${userId}
 		  AND ei.deleted_at IS NULL
 		  AND ei.source_connector = 'auth:signup'
+		LIMIT 1
+	`;
+  return rows.length > 0 ? Number(rows[0].entity_id) : null;
+}
+
+/**
+ * Fallback requester resolution for someone talking to the bot INSIDE Slack,
+ * where the only id we have is their Slack user id (the message author), not an
+ * `auth_user_id`. Tries the team-scoped `slack_user_id` claim for each candidate
+ * team (the enforcing connections' teams). Without this, an in-Slack requester
+ * always misses the auth lookup and fails closed even on channels they belong to.
+ *
+ * Safe against hijack the same way the auth path is: the `slack_user_id` claim is
+ * only ever written server-side (by the graph builder / login promotion), never
+ * from user-supplied input, so resolving on it can't be forged. Returns the first
+ * entity that owns the claim, or null.
+ */
+async function resolveRequesterBySlackUserId(
+  sql: DbClient,
+  organizationId: string,
+  userId: string | null,
+  teamIds: string[],
+): Promise<number | null> {
+  if (!userId || teamIds.length === 0) return null;
+  const keys = [
+    ...new Set(teamIds.map((t) => normalizeSlackUserId(t, userId)).filter((k): k is string => !!k)),
+  ];
+  if (keys.length === 0) return null;
+  const rows = await sql<{ entity_id: number }>`
+		SELECT ei.entity_id
+		FROM entity_identities ei
+		JOIN entities e
+		  ON e.id = ei.entity_id
+		 AND e.organization_id = ei.organization_id
+		 AND e.deleted_at IS NULL
+		WHERE ei.organization_id = ${organizationId}
+		  AND ei.namespace = 'slack_user_id'
+		  AND ei.identifier = ANY(${pgTextArray(keys)}::text[])
+		  AND ei.deleted_at IS NULL
 		LIMIT 1
 	`;
   return rows.length > 0 ? Number(rows[0].entity_id) : null;
@@ -182,9 +222,28 @@ export async function filterChannelsForRequester<T extends GatedChannelRow>(
   // actively enforcing (full+fresh). Onboarded-but-stale connections fail closed
   // regardless of who is asking, so they need no membership lookup.
   const anyEnforcing = [...states.values()].some((s) => s.enforce);
-  const memberEntityId = anyEnforcing
-    ? await resolveRequesterMemberEntityId(sql, organizationId, userId)
-    : null;
+  // Resolve the requester to a member. Prefer the auth_user_id claim (web/app
+  // path); fall back to the team-scoped slack_user_id claim for someone talking
+  // to the bot inside Slack, whose id is a Slack user id, not an auth id.
+  let memberEntityId: number | null = null;
+  if (anyEnforcing) {
+    memberEntityId = await resolveRequesterMemberEntityId(sql, organizationId, userId);
+    if (memberEntityId === null) {
+      const enforcingTeamIds = [
+        ...new Set(
+          rows
+            .filter((r) => states.get(r.id)?.enforce && r.team_id)
+            .map((r) => r.team_id as string),
+        ),
+      ];
+      memberEntityId = await resolveRequesterBySlackUserId(
+        sql,
+        organizationId,
+        userId,
+        enforcingTeamIds,
+      );
+    }
+  }
   const visibleKeys =
     memberEntityId === null
       ? new Set<string>()

--- a/packages/server/src/authz/channel-visibility.ts
+++ b/packages/server/src/authz/channel-visibility.ts
@@ -24,6 +24,7 @@
 import { normalizeSlackUserId } from '@lobu/connector-sdk';
 import { type DbClient, pgTextArray } from '../db/client.js';
 import { stripPlatformPrefix } from '../gateway/channels/bound-channels.js';
+import { ACL_STALE_AFTER_MINUTES } from './acl-state.js';
 import { slackChannelKey } from './slack-channel-graph.js';
 
 /** A bound channel the gate decides on. Mirrors the fields `resolveBoundChannelRows`
@@ -112,15 +113,6 @@ async function resolveRequesterBySlackUserId(
   return rows.length > 0 ? Number(rows[0].entity_id) : null;
 }
 
-/**
- * How long a `fresh` ACL graph stays trusted without a re-sync. The background
- * sync (`./slack-acl-sync`) re-stamps `last_synced_at` every tick; if it stops
- * (pod down, Slack outage), a connection's graph ages past this window and the
- * gate stops trusting it — failing closed rather than serving stale membership.
- * Generous vs. the ~15-min sync cadence so a transient hiccup never blinks
- * recall off.
- */
-const ACL_STALE_AFTER_MINUTES = 60;
 
 /**
  * The ACL state of each connection that has been onboarded into the authz

--- a/packages/server/src/authz/github-acl-sync.ts
+++ b/packages/server/src/authz/github-acl-sync.ts
@@ -1,0 +1,217 @@
+/**
+ * GitHub repo-membership ACL SYNC — the production path that populates the repo
+ * graph the resource gate reads, mirroring `./slack-acl-sync` for the second
+ * source. Per GitHub connection: enumerate the repos it captures (from its
+ * feeds), fetch each repo's collaborators, and hand them to `buildGithubRepoGraph`
+ * (which materializes the `member_of` edges, reconciles departures, and stamps
+ * the connection `full`/`fresh`).
+ *
+ * Fail-closed on error, ATOMIC per connection: if ANY repo's collaborator fetch
+ * throws (GitHub outage, token expiry, repo gone), we mark the connection's ACL
+ * state `failed` rather than build a half-synced graph — but only DOWNGRADE an
+ * existing row (a connection that has never been graphed stays on the legacy
+ * fence). The external calls (repo list, collaborator fetch) are injected so the
+ * sync logic is tested with stubs and the live tick wires the real GitHub API.
+ */
+
+import { createLogger } from '@lobu/core';
+import { getDb } from '../db/client.js';
+import { getInstallationTokenRegistry } from '../gateway/installation/registry.js';
+import type { CoreServices } from '../gateway/services/core-services.js';
+import type { AppInstallationStore } from '../lobu/stores/app-installation-store.js';
+import { buildGithubRepoGraph, type GithubRepoCollaborator } from './github-repo-graph.js';
+
+const logger = createLogger('github-acl-sync');
+
+/** `owner/repo` split, as a repo is captured by a connection's feed. */
+export interface GithubRepoRef {
+  owner: string;
+  repo: string;
+}
+
+/** Injectable seams: tests drive the real graph build + gate with stubbed GitHub
+ * calls; the live tick wires the real repo list + collaborator API. */
+export interface GithubAclSyncDeps {
+  /** The repos this connection captures (from its feeds' config). */
+  listRepos: (params: { organizationId: string; connectionId: string }) => Promise<GithubRepoRef[]>;
+  /** A repo's current collaborators. Throws on a GitHub-level error (fail-closed). */
+  fetchCollaborators: (params: {
+    organizationId: string;
+    repo: GithubRepoRef;
+  }) => Promise<GithubRepoCollaborator[]>;
+}
+
+export interface GithubAclSyncResult {
+  ok: boolean;
+  reposSynced: number;
+}
+
+/** Downgrade an EXISTING ACL row to `failed` so the gate fails closed. No-op
+ * when the connection was never graphed (it stays on the legacy fence). */
+async function markConnectionAclFailed(
+  organizationId: string,
+  connectionId: string,
+): Promise<void> {
+  const sql = getDb();
+  await sql`
+		UPDATE authz_source_acl_state
+		SET freshness_state = 'failed', updated_at = current_timestamp
+		WHERE organization_id = ${organizationId}
+		  AND connection_id = ${connectionId}
+	`;
+}
+
+/**
+ * Sync ONE GitHub connection's repo-membership graph. Resolves its captured
+ * repos, fetches collaborators per repo, and builds the graph. See the file
+ * header for the fail-closed contract.
+ */
+export async function syncGithubConnectionAcl(
+  deps: GithubAclSyncDeps,
+  params: { connectionId: string; organizationId: string },
+): Promise<GithubAclSyncResult> {
+  const { connectionId, organizationId } = params;
+
+  const repos = await deps.listRepos({ organizationId, connectionId });
+  if (repos.length === 0) {
+    return { ok: true, reposSynced: 0 };
+  }
+
+  try {
+    const repoInputs = [];
+    for (const repo of repos) {
+      const collaborators = await deps.fetchCollaborators({ organizationId, repo });
+      repoInputs.push({ fullName: `${repo.owner}/${repo.repo}`, collaborators });
+    }
+    await buildGithubRepoGraph({ organizationId, connectionId, repos: repoInputs });
+    return { ok: true, reposSynced: repoInputs.length };
+  } catch (error) {
+    logger.error(
+      { organization_id: organizationId, connection_id: connectionId, error: String(error) },
+      'GitHub ACL sync failed — marking connection fail-closed',
+    );
+    await markConnectionAclFailed(organizationId, connectionId);
+    return { ok: false, reposSynced: 0 };
+  }
+}
+
+/** Parse `owner/repo` from a feed config (the GitHub connector stores
+ * `repo_owner`/`repo_name`). Skips feeds without a fully-specified repo. */
+function repoRefsFromFeedConfigs(configs: Array<Record<string, unknown> | null>): GithubRepoRef[] {
+  const seen = new Set<string>();
+  const refs: GithubRepoRef[] = [];
+  for (const config of configs) {
+    const owner = typeof config?.repo_owner === 'string' ? config.repo_owner.trim() : '';
+    const repo = typeof config?.repo_name === 'string' ? config.repo_name.trim() : '';
+    if (!owner || !repo) continue;
+    const key = `${owner}/${repo}`.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    refs.push({ owner, repo });
+  }
+  return refs;
+}
+
+/** GitHub `/repos/{owner}/{repo}/collaborators`, paginated, bare `{login,id}`.
+ * Throws on a non-OK response so the sync treats it fail-closed. */
+async function fetchRepoCollaborators(
+  token: string,
+  repo: GithubRepoRef,
+): Promise<GithubRepoCollaborator[]> {
+  const collaborators: GithubRepoCollaborator[] = [];
+  const perPage = 100;
+  for (let page = 1; page <= 100; page++) {
+    const url = `https://api.github.com/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}/collaborators?per_page=${perPage}&page=${page}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'lobu',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+    if (!res.ok) {
+      throw new Error(`GitHub collaborators ${repo.owner}/${repo.repo} returned ${res.status}`);
+    }
+    const body = (await res.json()) as Array<{ login?: string; id?: number }>;
+    const items = Array.isArray(body) ? body : [];
+    for (const c of items) {
+      if (typeof c.login === 'string' && c.login) {
+        collaborators.push({ login: c.login, id: typeof c.id === 'number' ? c.id : undefined });
+      }
+    }
+    if (items.length < perPage) break;
+  }
+  return collaborators;
+}
+
+/**
+ * The periodic production caller (registered via `./acl-sync`). Re-syncs every
+ * active GitHub connection's repo-membership graph so collaborator changes
+ * converge within the cadence and the gate's freshness window keeps a stalled
+ * connection fail-closed. Runs on one replica per tick (the runs-queue claim).
+ *
+ * NOTE: the live token/collaborator path needs a real GitHub App install to
+ * verify end to end; the sync LOGIC is covered by `__tests__/.../github-acl-sync`
+ * driving {@link syncGithubConnectionAcl} with stubbed deps.
+ */
+export async function runGithubAclSyncTick(coreServices: CoreServices): Promise<void> {
+  const sql = getDb();
+  const connections = await sql<{ id: string; organization_id: string }>`
+		SELECT id::text AS id, organization_id
+		FROM connections
+		WHERE connector_key = 'github' AND status = 'active' AND deleted_at IS NULL
+	`;
+  if (connections.length === 0) return;
+
+  const installStore = coreServices.getAppInstallationStore();
+
+  const deps: GithubAclSyncDeps = {
+    listRepos: async ({ connectionId }) => {
+      const rows = await sql<{ config: Record<string, unknown> | null }>`
+				SELECT config FROM feeds WHERE connection_id = ${Number(connectionId)} AND deleted_at IS NULL
+			`;
+      return repoRefsFromFeedConfigs(rows.map((r) => r.config));
+    },
+    fetchCollaborators: async ({ organizationId, repo }) => {
+      const token = await resolveGithubInstallationToken(installStore, organizationId);
+      if (!token) throw new Error(`No GitHub installation token for org ${organizationId}`);
+      return fetchRepoCollaborators(token, repo);
+    },
+  };
+
+  let ok = 0;
+  let failed = 0;
+  for (const conn of connections) {
+    const result = await syncGithubConnectionAcl(deps, {
+      connectionId: conn.id,
+      organizationId: conn.organization_id,
+    });
+    if (result.ok) ok += 1;
+    else failed += 1;
+  }
+  logger.info({ connections: connections.length, ok, failed }, 'GitHub ACL sync tick complete');
+}
+
+/** Resolve an org's GitHub App installation token (collaborator-capable), minted
+ * the same way the install flow does (`mintFor` over the install row with the
+ * app-id/private-key env-var names). Returns null when the org has no active
+ * GitHub install. */
+async function resolveGithubInstallationToken(
+  installStore: AppInstallationStore,
+  organizationId: string,
+): Promise<string | null> {
+  const installs = await installStore.listByProviderAndOrg('github', organizationId);
+  const install = installs.find((i) => i.status === 'active');
+  if (!install) return null;
+  const installWithKeys = {
+    ...install,
+    metadata: {
+      ...install.metadata,
+      appIdKey: install.metadata?.appIdKey ?? 'GITHUB_APP_ID',
+      privateKeyKey: install.metadata?.privateKeyKey ?? 'GITHUB_APP_PRIVATE_KEY',
+    },
+  };
+  const minted = await getInstallationTokenRegistry().mintFor(installWithKeys);
+  return minted.token;
+}

--- a/packages/server/src/authz/github-repo-graph.ts
+++ b/packages/server/src/authz/github-repo-graph.ts
@@ -1,0 +1,98 @@
+/**
+ * GitHub repository membership graph — the SECOND ACL source, and the one that
+ * proves `./access-graph` generalizes (the engine was extracted from Slack with
+ * exactly this caller in mind).
+ *
+ * A repo's read audience is its COLLABORATORS. Each repo becomes a `repo` entity
+ * keyed on its `github_repo_full_name` (`owner/repo`, normalized) — the same key
+ * the GitHub connector stamps on data it ingests, so a later repo-visibility gate
+ * can join an event's repo to these `member_of` edges. Each collaborator resolves
+ * identity-first on `github_user_id` (+ `github_login`), so a collaborator who has
+ * also authored issues — or signed in — collapses onto their existing entity
+ * instead of forking a duplicate. Folding GitHub onto the shared engine gives it
+ * the departure reconcile + identity-first collapse the original org-level
+ * `buildGithubTeamGraph` lacked.
+ *
+ * NOTE: this materializes the graph (repo → member edges + `authz_source_acl_state`);
+ * it does NOT yet gate GitHub recall. GitHub data lives in `events` and is read
+ * through `buildScopedQuery`/connection-visibility, and those rows do not carry a
+ * repo identity today — wiring per-repo enforcement needs the connector to stamp
+ * `metadata.github_repo_full_name` at ingestion plus a repo-visibility compiler.
+ * That is the follow-up; this is the audience graph it will read.
+ */
+
+import {
+  normalizeGithubLogin,
+  normalizeGithubRepoFullName,
+  normalizeNumericId,
+} from '@lobu/connector-sdk';
+import {
+  type AccessGraphResult,
+  type AccessMember,
+  type AccessResource,
+  buildAccessGraph,
+} from './access-graph.js';
+
+const GITHUB_CONNECTOR_KEY = 'github';
+const GITHUB_REPO_FULL_NAME_NS = 'github_repo_full_name';
+const GITHUB_USER_ID_NS = 'github_user_id';
+const GITHUB_LOGIN_NS = 'github_login';
+
+/** A repo collaborator as the GitHub collaborators API reports it. */
+export interface GithubRepoCollaborator {
+  login: string;
+  id?: number;
+}
+
+/** A repository and the collaborators who may read it. */
+export interface GithubRepoInput {
+  /** `owner/repo`. */
+  fullName: string;
+  collaborators: GithubRepoCollaborator[];
+}
+
+/**
+ * Materialize a GitHub installation's repo-membership graph and mark the
+ * connection ACL-enforced. Injectable `repos` (with their collaborators) so tests
+ * and the live sync both call the same builder.
+ */
+export async function buildGithubRepoGraph(params: {
+  organizationId: string;
+  connectionId: string;
+  repos: GithubRepoInput[];
+}): Promise<AccessGraphResult> {
+  const resources: AccessResource[] = [];
+  for (const repo of params.repos) {
+    const key = normalizeGithubRepoFullName(repo.fullName);
+    if (!key) continue;
+    const members: AccessMember[] = [];
+    for (const c of repo.collaborators) {
+      const login = normalizeGithubLogin(c.login);
+      const idValue = c.id != null ? normalizeNumericId(String(c.id)) : null;
+      const identities: { namespace: string; value: string }[] = [];
+      if (idValue) identities.push({ namespace: GITHUB_USER_ID_NS, value: idValue });
+      if (login) identities.push({ namespace: GITHUB_LOGIN_NS, value: login });
+      if (identities.length === 0) continue;
+      members.push({ key: idValue ?? (login as string), name: c.login, identities });
+    }
+    resources.push({ key, name: repo.fullName, members });
+  }
+
+  return buildAccessGraph({
+    organizationId: params.organizationId,
+    connectionId: params.connectionId,
+    connectorKey: GITHUB_CONNECTOR_KEY,
+    resourceType: {
+      slug: 'repo',
+      name: 'Repository',
+      description: 'A code repository — the unit of repo access control',
+      icon: 'git-branch',
+      namespace: GITHUB_REPO_FULL_NAME_NS,
+    },
+    memberIdentities: [
+      { namespace: GITHUB_USER_ID_NS, primary: true },
+      { namespace: GITHUB_LOGIN_NS },
+    ],
+    resources,
+  });
+}

--- a/packages/server/src/authz/github-repo-graph.ts
+++ b/packages/server/src/authz/github-repo-graph.ts
@@ -4,21 +4,16 @@
  * exactly this caller in mind).
  *
  * A repo's read audience is its COLLABORATORS. Each repo becomes a `repo` entity
- * keyed on its `github_repo_full_name` (`owner/repo`, normalized) — the same key
- * the GitHub connector stamps on data it ingests, so a later repo-visibility gate
- * can join an event's repo to these `member_of` edges. Each collaborator resolves
- * identity-first on `github_user_id` (+ `github_login`), so a collaborator who has
- * also authored issues — or signed in — collapses onto their existing entity
- * instead of forking a duplicate. Folding GitHub onto the shared engine gives it
- * the departure reconcile + identity-first collapse the original org-level
- * `buildGithubTeamGraph` lacked.
- *
- * NOTE: this materializes the graph (repo → member edges + `authz_source_acl_state`);
- * it does NOT yet gate GitHub recall. GitHub data lives in `events` and is read
- * through `buildScopedQuery`/connection-visibility, and those rows do not carry a
- * repo identity today — wiring per-repo enforcement needs the connector to stamp
- * `metadata.github_repo_full_name` at ingestion plus a repo-visibility compiler.
- * That is the follow-up; this is the audience graph it will read.
+ * keyed on its `github_repo_full_name` (`owner/repo`, normalized) — the SAME key
+ * the GitHub connector stamps on the data it ingests (`metadata.github_repo_full_name`
+ * + the repo entity link), so the resource gate (`./resource-visibility`) joins an
+ * event's repo to these `member_of` edges and restricts GitHub recall to repos the
+ * requester belongs to. Each collaborator resolves identity-first on
+ * `github_user_id` (+ `github_login`), so a collaborator who has also authored
+ * issues — or signed in — collapses onto their existing entity instead of forking
+ * a duplicate. Folding GitHub onto the shared engine gives it the departure
+ * reconcile + identity-first collapse the original org-level `buildGithubTeamGraph`
+ * lacked.
  */
 
 import {

--- a/packages/server/src/authz/github-repo-graph.ts
+++ b/packages/server/src/authz/github-repo-graph.ts
@@ -32,9 +32,8 @@ import {
   type AccessResource,
   buildAccessGraph,
 } from './access-graph.js';
+import { GITHUB_SOURCE } from './sources.js';
 
-const GITHUB_CONNECTOR_KEY = 'github';
-const GITHUB_REPO_FULL_NAME_NS = 'github_repo_full_name';
 const GITHUB_USER_ID_NS = 'github_user_id';
 const GITHUB_LOGIN_NS = 'github_login';
 
@@ -81,18 +80,9 @@ export async function buildGithubRepoGraph(params: {
   return buildAccessGraph({
     organizationId: params.organizationId,
     connectionId: params.connectionId,
-    connectorKey: GITHUB_CONNECTOR_KEY,
-    resourceType: {
-      slug: 'repo',
-      name: 'Repository',
-      description: 'A code repository — the unit of repo access control',
-      icon: 'git-branch',
-      namespace: GITHUB_REPO_FULL_NAME_NS,
-    },
-    memberIdentities: [
-      { namespace: GITHUB_USER_ID_NS, primary: true },
-      { namespace: GITHUB_LOGIN_NS },
-    ],
+    connectorKey: GITHUB_SOURCE.key,
+    resourceType: GITHUB_SOURCE.resourceType,
+    memberIdentities: GITHUB_SOURCE.memberIdentities,
     resources,
   });
 }

--- a/packages/server/src/authz/resource-visibility.ts
+++ b/packages/server/src/authz/resource-visibility.ts
@@ -1,0 +1,99 @@
+/**
+ * THE generic resource-visibility compiler — gates connector-sourced `events`
+ * (GitHub issues/PRs, Linear issues, …) by RESOURCE membership, the same way
+ * `./channel-visibility` gates Slack chat by channel membership, but at the
+ * `events` read seam and for ANY resource type at once.
+ *
+ * Rule, composed AFTER the per-connection visibility gate (they AND together):
+ *   - an event on a connection that is NOT ACL-enforced is unconstrained here
+ *     (the per-connection gate already decided it);
+ *   - an event on an ACL-enforced connection is visible ONLY when the requester
+ *     is `member_of` one of the RESOURCE entities the event is linked to
+ *     (`events.entity_ids`), where "resource" = an entity whose type is a
+ *     registered ACL resource (`RESOURCE_TYPE_SLUGS`: repo, channel, …). This is
+ *     deliberately scoped to resource types so the coarse person→`company` (org)
+ *     `member_of` edge never satisfies it — org membership must NOT grant
+ *     repo-level read.
+ *
+ * Fail-closed: a headless/null principal, or an enforced-connection event linked
+ * to no resource the requester belongs to, is dropped. Generic across sources —
+ * GitHub repos and Linear teams gate identically; a new source needs only a
+ * registry entry (`./sources`) plus its connector stamping the resource identity
+ * on its events so they link to the resource entity.
+ */
+
+import { enforcedConnectionsSelectSql } from './acl-state.js';
+import type { AuthzScope } from './scope.js';
+import { RESOURCE_TYPE_SLUGS } from './sources.js';
+
+/** Resource type slugs as a safe SQL `IN (...)` list. Slugs are validated to
+ * simple identifiers in `./sources`, so inlining as literals is injection-safe
+ * (and avoids binding a text[] param, which the fetch_types:false driver rejects). */
+const RESOURCE_TYPE_IN_LIST = RESOURCE_TYPE_SLUGS.map((s) => `'${s}'`).join(', ');
+
+/**
+ * Predicate for a table holding events (alias has `connection_id` + `entity_ids`).
+ * Binds two params from `baseParamIndex`: the org id and the principal. Returns an
+ * `AND (...)` fragment (no leading space). Compose alongside
+ * `compileConnectionFkVisibility` at the same seam.
+ */
+export function compileResourceVisibility(
+  scope: AuthzScope,
+  baseParamIndex: number,
+  tableAlias: string,
+): { sql: string; params: Array<string | null> } {
+  const orgParam = `$${baseParamIndex}::text`;
+  const userParam = `$${baseParamIndex + 1}::text`;
+
+  // No registered resource types → nothing to enforce (defensive; the registry
+  // is non-empty today).
+  if (RESOURCE_TYPE_SLUGS.length === 0) {
+    return { sql: '', params: [] };
+  }
+
+  // `events.connection_id` is bigint, but `authz_source_acl_state.connection_id`
+  // is text (it also keys text `agent_connections.id` for Slack). Cast to text so
+  // the comparison is well-typed across both connection-id spaces.
+  const sql = `AND (
+      ${tableAlias}.connection_id IS NULL
+      OR ${tableAlias}.connection_id::text NOT IN (${enforcedConnectionsSelectSql(orgParam)})
+      OR EXISTS (
+        SELECT 1
+        FROM public.entity_relationships rr
+        JOIN public.entity_relationship_types rt
+          ON rt.id = rr.relationship_type_id
+         AND rt.organization_id = rr.organization_id
+         AND rt.slug = 'member_of'
+        JOIN public.entities re
+          ON re.id = rr.to_entity_id
+         AND re.organization_id = rr.organization_id
+         AND re.deleted_at IS NULL
+        JOIN public.entity_types ret
+          ON ret.id = re.entity_type_id
+         AND ret.organization_id = re.organization_id
+         AND ret.slug IN (${RESOURCE_TYPE_IN_LIST})
+        WHERE rr.organization_id = ${orgParam}
+          AND rr.deleted_at IS NULL
+          AND rr.to_entity_id = ANY(${tableAlias}.entity_ids)
+          AND rr.from_entity_id = (
+            SELECT mei.entity_id
+            FROM public.entity_identities mei
+            JOIN public.entities me
+              ON me.id = mei.entity_id
+             AND me.organization_id = mei.organization_id
+             AND me.deleted_at IS NULL
+            JOIN public.entity_types met
+              ON met.id = me.entity_type_id
+             AND met.organization_id = me.organization_id
+             AND met.slug = '$member'
+            WHERE mei.organization_id = ${orgParam}
+              AND mei.namespace = 'auth_user_id'
+              AND mei.identifier = ${userParam}
+              AND mei.source_connector = 'auth:signup'
+              AND mei.deleted_at IS NULL
+            LIMIT 1
+          )
+      )
+    )`;
+  return { sql, params: [scope.organizationId, scope.principal] };
+}

--- a/packages/server/src/authz/slack-channel-graph.ts
+++ b/packages/server/src/authz/slack-channel-graph.ts
@@ -2,50 +2,29 @@
  * Slack channel membership graph — the first ACL source for the authorization
  * program (docs/plans/authz-acl-permission-program.md, the Slack e2e vertical).
  *
- * Mirrors `buildGithubTeamGraph`: it REUSES the existing entity graph rather
- * than introducing any new principal/edge/identity tables.
+ * Now a THIN adapter over the generic `./access-graph` engine: it normalizes a
+ * Slack workspace's channels + members into the engine's resource/audience shape
+ * and hands them over. All the materialization (resolve entities, identity-first
+ * member collapse, idempotent `member_of` edges, departure reconcile, stamping
+ * `authz_source_acl_state`) lives in the engine and is shared with every other
+ * ACL source (GitHub repos, …). The Slack-specific parts are just:
+ *   - each channel → a `channel` entity keyed on its TEAM-SCOPED id
+ *     (`slack_channel_id` = `T…:C…`) so two workspaces never collapse onto one;
+ *   - each member → resolved on the canonical `slack_user_id` (`T…:U…`) namespace,
+ *     so a member who already signed in COLLAPSES onto their `$member` entity.
  *
- *   - each Slack channel becomes a `channel` entity, identified by its
- *     team-scoped id (`slack_channel_id` = `T…:C…`) so two workspaces never
- *     collapse onto one channel entity;
- *   - each channel member becomes a `person` resolved through the SAME
- *     entity-identity machinery (`slack_user_id` = `T…:U…`), so a member who
- *     already signed in (their `$member` carries a promoted `slack_user_id`
- *     claim) COLLAPSES onto that one entity instead of forking a second person;
- *   - a `member_of` edge (person → channel) is written per (member, channel).
- *
- * The visibility gate (`./channel-visibility`) reads exactly these `member_of`
- * edges: a requester may recall a channel's transcript iff they are `member_of`
- * that channel. For Slack, channel membership IS the read ACL — so this graph
- * needs no separate `can_read`/`deny_read` edges. (Public-channel "any
- * workspace member can read without joining" is a deliberate follow-up; gating
- * on membership only ever UNDER-shares, never over-shares — the safe direction.)
- *
- * Completing the build stamps `authz_source_acl_state` ('full','fresh') for the
- * connection, which is the switch the gate consults to start enforcing. Until a
- * connection has a fresh row here, the gate leaves its rows on the existing
- * per-agent fence (no half-built graph ever silently enforces).
- *
- * Tenant-scoped + idempotent + best-effort, exactly like the GitHub builder:
- * everything filters on `organizationId`; `member_of` dedupes on the live-triple
- * unique index; failures are logged and surfaced, never thrown.
+ * The visibility gate (`./channel-visibility`) reads the `member_of` edges this
+ * writes: a requester may recall a channel iff they are `member_of` it. For
+ * Slack, channel membership IS the read ACL. (Public-channel read-without-join is
+ * a deliberate follow-up; gating on membership only ever UNDER-shares.)
  */
 
 import { normalizeSlackUserId } from '@lobu/connector-sdk';
-import { createLogger } from '@lobu/core';
-import { getDb, pgBigintArray, pgTextArray } from '../db/client.js';
-import { resolveEntityLinksForItems } from '../utils/entity-link-upsert.js';
-
-const logger = createLogger('slack-channel-graph');
+import { type AccessResource, buildAccessGraph } from './access-graph.js';
 
 const SLACK_CONNECTOR_KEY = 'slack';
-const MEMBER_OF_TYPE_SLUG = 'member_of';
-const CHANNEL_ENTITY_TYPE_SLUG = 'channel';
-
-/** Identity namespaces. Channels/teams use custom (trim-only) namespaces; the
- * user id reuses the canonical `slack_user_id` namespace so it collapses with
- * login-promoted claims. */
 const SLACK_CHANNEL_ID_NS = 'slack_channel_id';
+const SLACK_USER_ID_NS = 'slack_user_id';
 
 /** A Slack channel and the (bare `U…`) ids of its members. */
 export interface SlackChannelInput {
@@ -80,73 +59,10 @@ export function slackChannelKey(teamId: string, channelId: string): string {
   return `${teamId.trim()}:${channelId.trim()}`.toUpperCase();
 }
 
-/** Resolve an org owner/admin as `entities.created_by` / edge `created_by`
- * (NOT NULL on entities). Same query the GitHub builder uses. */
-async function resolveOrgCreator(orgId: string): Promise<string | null> {
-  const sql = getDb();
-  const rows = await sql<{ userId: string }>`
-		SELECT "userId"
-		FROM "member"
-		WHERE "organizationId" = ${orgId}
-		ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END,
-		         "createdAt" ASC
-		LIMIT 1
-	`;
-  return rows.length > 0 ? rows[0].userId : null;
-}
-
-/** Find-or-create the org-scoped `channel` entity type (reuse, no migration). */
-async function ensureChannelEntityType(orgId: string): Promise<void> {
-  const sql = getDb();
-  await sql`
-		INSERT INTO entity_types (slug, name, description, icon, organization_id, created_at, updated_at)
-		VALUES (
-			${CHANNEL_ENTITY_TYPE_SLUG}, 'Channel',
-			'A chat channel (Slack channel, etc.) — the unit of conversation access control',
-			'hash', ${orgId}, current_timestamp, current_timestamp
-		)
-		ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
-		DO NOTHING
-	`;
-}
-
-/** Find-or-create the org-scoped `member_of` relationship type. */
-async function ensureMemberOfType(orgId: string): Promise<number> {
-  const sql = getDb();
-  const rows = await sql`
-		INSERT INTO entity_relationship_types
-			(slug, name, description, organization_id, is_symmetric, created_by, created_at, updated_at)
-		VALUES
-			(${MEMBER_OF_TYPE_SLUG}, 'Member of', 'A person is a member of an organization or channel', ${orgId},
-			 false, NULL, current_timestamp, current_timestamp)
-		ON CONFLICT (organization_id, slug) WHERE status = 'active'
-		DO UPDATE SET updated_at = EXCLUDED.updated_at
-		RETURNING id
-	`;
-  return Number(rows[0].id);
-}
-
-/** Stamp the connection's ACL state so the gate begins enforcing it. */
-async function markAclEnforced(orgId: string, connectionId: string): Promise<void> {
-  const sql = getDb();
-  await sql`
-		INSERT INTO authz_source_acl_state
-			(organization_id, connection_id, acl_support, freshness_state, last_synced_at, created_at, updated_at)
-		VALUES (${orgId}, ${connectionId}, 'full', 'fresh', current_timestamp, current_timestamp, current_timestamp)
-		ON CONFLICT (organization_id, connection_id)
-		DO UPDATE SET acl_support = 'full', freshness_state = 'fresh',
-		              last_synced_at = current_timestamp, updated_at = current_timestamp
-	`;
-}
-
 /**
  * Materialize a Slack workspace's channel-membership graph and mark the
  * connection ACL-enforced. Injectable `channels` (with their members) so tests
- * and the live sync both call the same builder — exactly like the GitHub team
- * graph takes `members` directly.
- *
- * @returns the channel entity ids, the member entity ids, and how many edges
- *          were newly created. Empty when there is nothing to build.
+ * and the live sync both call the same builder.
  */
 export async function buildSlackChannelGraph(params: {
   organizationId: string;
@@ -159,210 +75,53 @@ export async function buildSlackChannelGraph(params: {
   const channels = params.channels.filter((c) => c.channelId);
   if (!teamId || channels.length === 0) return EMPTY_RESULT;
 
-  const creatorUserId = await resolveOrgCreator(organizationId);
-  if (!creatorUserId) {
-    logger.warn(
-      { organization_id: organizationId },
-      'Slack channel graph skipped: org has no member to attribute as entity creator',
-    );
-    return EMPTY_RESULT;
-  }
-
-  await ensureChannelEntityType(organizationId);
-
-  // 1) Resolve every channel to a `channel` entity, keyed on its team-scoped id.
-  const channelItems = channels.map((c) => ({
-    origin_type: 'slack_channel',
-    metadata: {
-      channel_key: slackChannelKey(teamId, c.channelId),
-      channel_name: c.name ?? c.channelId,
-    },
-  }));
-  const resolvedChannels = await resolveEntityLinksForItems({
-    connectorKey: SLACK_CONNECTOR_KEY,
-    orgId: organizationId,
-    items: channelItems,
-    rules: {
-      slack_channel: [
-        {
-          entityType: CHANNEL_ENTITY_TYPE_SLUG,
-          autoCreate: true,
-          titlePath: 'metadata.channel_name',
-          identities: [
-            {
-              namespace: SLACK_CHANNEL_ID_NS,
-              eventPath: 'metadata.channel_key',
-              primary: true,
-            },
-          ],
-        },
-      ],
-    },
-  });
-
-  const channelEntityIds: Record<string, number> = {};
-  const channelEntityIdByIndex = new Map<number, number>();
-  for (let i = 0; i < channels.length; i++) {
-    const ids = resolvedChannels.get(i);
-    if (ids && ids.length > 0) {
-      channelEntityIds[channels[i].channelId] = ids[0];
-      channelEntityIdByIndex.set(i, ids[0]);
-    }
-  }
-
-  // 2) Resolve every DISTINCT member (team-scoped `T:U`) to an entity.
-  // Identity-first, TYPE-AGNOSTIC: a member who already signed in owns their
-  // `slack_user_id` claim on a `$member` entity, so we must collapse onto THAT
-  // entity — but `resolveEntityLinksForItems` matches only within the rule's
-  // own entity type ('person'), so it would never find the `$member` and would
-  // fork a duplicate. So we resolve existing owners ourselves (any type) and
-  // only auto-create a `person` for genuinely-new Slack users.
-  const memberKeys = new Map<string, string>(); // bare U… → combined T:U
+  // Normalize Slack channels → engine resources (team-scoped keys; members
+  // resolved on the canonical slack_user_id namespace for cross-source collapse).
+  const channelKeyToBareId: Record<string, string> = {};
+  const resources: AccessResource[] = [];
   for (const c of channels) {
+    const channelKey = slackChannelKey(teamId, c.channelId);
+    channelKeyToBareId[channelKey] = c.channelId;
+    const members = [];
     for (const u of c.memberSlackUserIds) {
       const combined = normalizeSlackUserId(teamId, u);
-      if (combined) memberKeys.set(u, combined);
-    }
-  }
-  const combinedKeys = [...new Set([...memberKeys.values()])];
-  const memberEntityByCombined = new Map<string, number>();
-  const sqlMembers = getDb();
-  if (combinedKeys.length > 0) {
-    // Existing owners of these slack_user_ids — ANY entity type ($member,
-    // person, …). This is the collapse seam.
-    const existing = await sqlMembers<{
-      identifier: string;
-      entity_id: number;
-    }>`
-			SELECT identifier, entity_id
-			FROM entity_identities
-			WHERE organization_id = ${organizationId}
-			  AND namespace = 'slack_user_id'
-			  AND identifier = ANY(${pgTextArray(combinedKeys)}::text[])
-			  AND deleted_at IS NULL
-		`;
-    for (const row of existing) {
-      memberEntityByCombined.set(String(row.identifier), Number(row.entity_id));
-    }
-
-    // Whoever is left has no entity yet → auto-create a `person` for each.
-    const toCreate = combinedKeys.filter((k) => !memberEntityByCombined.has(k));
-    if (toCreate.length > 0) {
-      const memberItems = toCreate.map((combined) => ({
-        origin_type: 'slack_member',
-        metadata: { slack_user: combined },
-      }));
-      const resolvedMembers = await resolveEntityLinksForItems({
-        connectorKey: SLACK_CONNECTOR_KEY,
-        orgId: organizationId,
-        items: memberItems,
-        rules: {
-          slack_member: [
-            {
-              entityType: 'person',
-              autoCreate: true,
-              titlePath: 'metadata.slack_user',
-              identities: [
-                {
-                  namespace: 'slack_user_id',
-                  eventPath: 'metadata.slack_user',
-                  primary: true,
-                },
-              ],
-            },
-          ],
-        },
-      });
-      for (let i = 0; i < toCreate.length; i++) {
-        const ids = resolvedMembers.get(i);
-        if (ids && ids.length > 0) memberEntityByCombined.set(toCreate[i], ids[0]);
-      }
-    }
-  }
-
-  // 3) Write person -> channel `member_of` edges, idempotent on the live-triple
-  // unique index. Accumulate the CURRENT member set per channel entity so we can
-  // reconcile departures below.
-  const typeId = await ensureMemberOfType(organizationId);
-  const sql = getDb();
-  const memberEntityIds = new Set<number>();
-  const currentMembersByChannel = new Map<number, Set<number>>();
-  let createdEdges = 0;
-  for (let i = 0; i < channels.length; i++) {
-    const channelEntityId = channelEntityIdByIndex.get(i);
-    if (channelEntityId === undefined) continue;
-    const channelMembers =
-      currentMembersByChannel.get(channelEntityId) ?? new Set<number>();
-    currentMembersByChannel.set(channelEntityId, channelMembers);
-    for (const u of channels[i].memberSlackUserIds) {
-      const combined = memberKeys.get(u);
       if (!combined) continue;
-      const memberEntityId = memberEntityByCombined.get(combined);
-      if (memberEntityId === undefined) continue;
-      memberEntityIds.add(memberEntityId);
-      channelMembers.add(memberEntityId);
-      const inserted = await sql<{ id: number }[]>`
-				INSERT INTO entity_relationships (
-					organization_id, from_entity_id, to_entity_id, relationship_type_id,
-					confidence, source, created_by, updated_by, created_at, updated_at
-				) VALUES (
-					${organizationId}, ${memberEntityId}, ${channelEntityId}, ${typeId},
-					1.0, 'feed', ${creatorUserId}, ${creatorUserId},
-					current_timestamp, current_timestamp
-				)
-				ON CONFLICT (from_entity_id, to_entity_id, relationship_type_id)
-					WHERE deleted_at IS NULL
-				DO NOTHING
-				RETURNING id
-			`;
-      if (inserted.length > 0) createdEdges += 1;
+      members.push({
+        key: combined,
+        name: combined,
+        identities: [{ namespace: SLACK_USER_ID_NS, value: combined }],
+      });
     }
+    resources.push({ key: channelKey, name: c.name ?? c.channelId, members });
   }
 
-  // 4) Reconcile DEPARTURES — the build is a full re-sync of each channel's
-  // membership, so a `member_of` edge to a synced channel whose member is NOT in
-  // the current set means that person left: soft-delete it so they immediately
-  // lose recall access. WITHOUT this, leavers keep visibility forever (the gate
-  // only reads live edges). Scoped to `to_entity_id` = a channel we just synced,
-  // so person→company edges (GitHub team graph) are never touched. An empty
-  // member set deletes all of that channel's edges (the channel was synced with
-  // zero members) — the live caller must not pass empty-on-fetch-error, exactly
-  // like the identity emitter's null guard.
-  let removedEdges = 0;
-  for (const [channelEntityId, channelMembers] of currentMembersByChannel) {
-    const keep = [...channelMembers];
-    const removed = await sql<{ id: number }[]>`
-			UPDATE entity_relationships
-			SET deleted_at = current_timestamp, updated_at = current_timestamp
-			WHERE organization_id = ${organizationId}
-			  AND relationship_type_id = ${typeId}
-			  AND to_entity_id = ${channelEntityId}
-			  AND deleted_at IS NULL
-			  AND from_entity_id <> ALL(${pgBigintArray(keep)}::bigint[])
-			RETURNING id
-		`;
-    removedEdges += removed.length;
-  }
-
-  await markAclEnforced(organizationId, connectionId);
-
-  logger.info(
-    {
-      organization_id: organizationId,
-      connection_id: connectionId,
-      team_id: teamId,
-      channels: Object.keys(channelEntityIds).length,
-      members: memberEntityIds.size,
-      created_edges: createdEdges,
-      removed_edges: removedEdges,
+  const result = await buildAccessGraph({
+    organizationId,
+    connectionId,
+    connectorKey: SLACK_CONNECTOR_KEY,
+    resourceType: {
+      slug: 'channel',
+      name: 'Channel',
+      description:
+        'A chat channel (Slack channel, etc.) — the unit of conversation access control',
+      icon: 'hash',
+      namespace: SLACK_CHANNEL_ID_NS,
     },
-    'Built Slack channel graph',
-  );
+    memberIdentities: [{ namespace: SLACK_USER_ID_NS, primary: true }],
+    resources,
+  });
+
+  // Map engine resource keys (T:C) back to the bare channel ids callers expect.
+  const channelEntityIds: Record<string, number> = {};
+  for (const [channelKey, entityId] of Object.entries(result.resourceEntityIds)) {
+    const bareId = channelKeyToBareId[channelKey];
+    if (bareId) channelEntityIds[bareId] = entityId;
+  }
 
   return {
     channelEntityIds,
-    memberEntityIds: [...memberEntityIds],
-    createdEdges,
-    removedEdges,
+    memberEntityIds: result.memberEntityIds,
+    createdEdges: result.createdEdges,
+    removedEdges: result.removedEdges,
   };
 }

--- a/packages/server/src/authz/slack-channel-graph.ts
+++ b/packages/server/src/authz/slack-channel-graph.ts
@@ -21,9 +21,8 @@
 
 import { normalizeSlackUserId } from '@lobu/connector-sdk';
 import { type AccessResource, buildAccessGraph } from './access-graph.js';
+import { SLACK_SOURCE } from './sources.js';
 
-const SLACK_CONNECTOR_KEY = 'slack';
-const SLACK_CHANNEL_ID_NS = 'slack_channel_id';
 const SLACK_USER_ID_NS = 'slack_user_id';
 
 /** A Slack channel and the (bare `U…`) ids of its members. */
@@ -98,16 +97,9 @@ export async function buildSlackChannelGraph(params: {
   const result = await buildAccessGraph({
     organizationId,
     connectionId,
-    connectorKey: SLACK_CONNECTOR_KEY,
-    resourceType: {
-      slug: 'channel',
-      name: 'Channel',
-      description:
-        'A chat channel (Slack channel, etc.) — the unit of conversation access control',
-      icon: 'hash',
-      namespace: SLACK_CHANNEL_ID_NS,
-    },
-    memberIdentities: [{ namespace: SLACK_USER_ID_NS, primary: true }],
+    connectorKey: SLACK_SOURCE.key,
+    resourceType: SLACK_SOURCE.resourceType,
+    memberIdentities: SLACK_SOURCE.memberIdentities,
     resources,
   });
 

--- a/packages/server/src/authz/sources.ts
+++ b/packages/server/src/authz/sources.ts
@@ -1,0 +1,65 @@
+/**
+ * The ACL source registry — the ONE place a new access-controlled source is
+ * declared. Each entry says "this connector produces resources of THIS entity
+ * type, keyed on THIS identity namespace, whose members are identified by THESE
+ * namespaces." Everything else is generic:
+ *   - the graph builders (`./slack-channel-graph`, `./github-repo-graph`) hand
+ *     their normalized resources to `buildAccessGraph` with the entry's descriptor;
+ *   - the read gate (`./resource-visibility`) gates events by membership of any
+ *     resource whose type is in {@link RESOURCE_TYPE_SLUGS};
+ *   - (next) the sync tick loops the registry to re-materialize each source.
+ *
+ * Adding Linear/Jira/Drive = ONE entry here + a connector that stamps the
+ * resource identity on its events. No new gate code, no new engine code.
+ */
+
+import type { AccessIdentitySpec, AccessResourceType } from './access-graph.js';
+
+export interface AclSourceDef {
+  /** Connector/platform key (`slack`, `github`, …). */
+  key: string;
+  /** The resource entity type this source's resources materialize as. */
+  resourceType: AccessResourceType;
+  /** How a member of one of this source's resources is identified. */
+  memberIdentities: AccessIdentitySpec[];
+}
+
+export const SLACK_SOURCE: AclSourceDef = {
+  key: 'slack',
+  resourceType: {
+    slug: 'channel',
+    name: 'Channel',
+    description: 'A chat channel (Slack channel, etc.) — the unit of conversation access control',
+    icon: 'hash',
+    namespace: 'slack_channel_id',
+  },
+  memberIdentities: [{ namespace: 'slack_user_id', primary: true }],
+};
+
+export const GITHUB_SOURCE: AclSourceDef = {
+  key: 'github',
+  resourceType: {
+    slug: 'repo',
+    name: 'Repository',
+    description: 'A code repository — the unit of repo access control',
+    icon: 'git-branch',
+    namespace: 'github_repo_full_name',
+  },
+  memberIdentities: [
+    { namespace: 'github_user_id', primary: true },
+    { namespace: 'github_login' },
+  ],
+};
+
+/** Every registered ACL source. */
+export const ACL_SOURCES: AclSourceDef[] = [SLACK_SOURCE, GITHUB_SOURCE];
+
+/** Resource entity-type slugs that the read gate treats as access-controlled.
+ * Validated to simple identifiers so they can be inlined as SQL literals. */
+export const RESOURCE_TYPE_SLUGS: string[] = ACL_SOURCES.map((s) => {
+  const slug = s.resourceType.slug;
+  if (!/^[a-z][a-z0-9_]*$/.test(slug)) {
+    throw new Error(`Invalid ACL resource type slug (must be a simple identifier): ${slug}`);
+  }
+  return slug;
+});

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Env } from '@lobu/connector-sdk';
-import { runSlackAclSyncTick } from '../authz/slack-acl-sync';
+import { runAclSyncTick } from '../authz/acl-sync';
 import type { CoreServices } from '../gateway/services/core-services';
 import { getChatInstanceManager } from '../lobu/gateway';
 import { cleanupExpiredMcpSessions } from '../mcp-handler';
@@ -149,16 +149,16 @@ function registerMaintenanceTasks(
     { cron: '*/5 * * * *' },
   );
 
-  // Slack channel-membership ACL sync — re-materializes each active Slack
-  // connection's `member_of` graph (the authz read-gate's source of truth) from
-  // live `conversations.members`, so channel joins/leaves converge within the
-  // cadence and the gate's freshness window keeps a stalled connection
-  // fail-closed. Single-claimant per tick via the runs-queue. Off until a Slack
-  // workspace exists (the tick no-ops on zero connections).
+  // ACL sync — re-materializes every registered source's `member_of` graph (the
+  // authz read-gates' source of truth) from live membership: Slack channels via
+  // `conversations.members`, GitHub repos via collaborators. Joins/leaves
+  // converge within the cadence and the gate's freshness window keeps a stalled
+  // connection fail-closed. Single-claimant per tick via the runs-queue. No-ops
+  // on zero connections per source.
   scheduler.register(
     'authz-acl-sync',
     async () => {
-      await runSlackAclSyncTick(coreServices);
+      await runAclSyncTick(coreServices);
     },
     { cron: '*/15 * * * *' },
   );

--- a/packages/server/src/utils/content-search/visibility.ts
+++ b/packages/server/src/utils/content-search/visibility.ts
@@ -4,6 +4,7 @@
  */
 
 import { compileConnectionFkVisibility } from '../../authz/connection-visibility';
+import { compileResourceVisibility } from '../../authz/resource-visibility';
 import type { AuthzScope } from '../../authz/scope';
 import { validateNumericId } from '../sql-validation';
 
@@ -100,5 +101,18 @@ export function buildConnectionVisibilityClause(
     organizationId: options.organizationId,
     principal: options.userId ?? null,
   };
-  return compileConnectionFkVisibility(scope, options.baseParamIndex, tableAlias);
+  // Compose the two read gates: per-connection visibility AND per-resource
+  // membership (the latter only constrains ACL-enforced connections). Resource
+  // visibility binds its own params AFTER the connection-visibility params, so a
+  // single returned `{ sql, params }` keeps every caller's `$N` indexing intact.
+  const conn = compileConnectionFkVisibility(scope, options.baseParamIndex, tableAlias);
+  const resource = compileResourceVisibility(
+    scope,
+    options.baseParamIndex + conn.params.length,
+    tableAlias,
+  );
+  return {
+    sql: `${conn.sql} ${resource.sql}`,
+    params: [...conn.params, ...resource.params],
+  };
 }

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -22,6 +22,7 @@ import {
   compileConnectionFkVisibility,
   compileConnectionRowVisibility,
 } from '../authz/connection-visibility';
+import { compileResourceVisibility } from '../authz/resource-visibility';
 import type { AuthzScope } from '../authz/scope';
 import {
   ADMIN_ONLY_QUERYABLE_TABLES,
@@ -417,6 +418,17 @@ export function buildScopedQuery(
     return ` ${vis.sql}`;
   };
 
+  // Per-resource membership gate for an events table (alias has `entity_ids` +
+  // `connection_id`): on ACL-enforced connections, restrict to events linked to a
+  // resource the requester is `member_of`. Composed AFTER eventConnVisibility on
+  // event-bearing tables ONLY (NOT feeds, which carry no entity_ids).
+  const eventResourceVisibility = (alias: string): string => {
+    const vis = compileResourceVisibility(scope, idx + 1, alias);
+    params.push(...vis.params);
+    idx += vis.params.length;
+    return ` ${vis.sql}`;
+  };
+
   // For the `connections` table itself: the row is visible when org-shared or
   // owned by the requesting user (mirrors manage_connections CRUD).
   const connectionRowVisibility = (alias: string): string => {
@@ -545,6 +557,7 @@ export function buildScopedQuery(
       }
 
       eventsCte += eventConnVisibility('ev');
+      eventsCte += eventResourceVisibility('ev');
 
       eventsCte += ')';
       ctes.push(eventsCte);
@@ -583,6 +596,7 @@ export function buildScopedQuery(
           'JOIN public.entities ent ON ent.id = ANY(ev.entity_ids) ' +
           `WHERE ev.id = ec.event_id AND ent.organization_id = ${orgP}` +
           eventConnVisibility('ev') +
+          eventResourceVisibility('ev') +
           '))'
       );
     } else if (table === 'watcher_versions') {


### PR DESCRIPTION
Builds on #1586 (Slack channel ACL gate). Consolidates the Slack ACL code into a reusable engine, proves it generalizes with GitHub as a second source, and fixes the in-Slack requester gap.

## What's here

**1. Generic `buildAccessGraph` engine (`authz/access-graph.ts`)**
The ~70% that was identical between the Slack channel builder and the GitHub team builder is now one source-agnostic engine: resolve org creator, ensure resource + `member_of` types, resolve resources/members (identity-first, type-agnostic collapse), idempotent `member_of` edges, departure reconcile, stamp `authz_source_acl_state`. A "source" is just a normalized `{resources: [{key, members[]}]}` shape plus a resource/member identity descriptor.

**2. Slack ported onto it (`authz/slack-channel-graph.ts`)**
Now a thin adapter that normalizes channels into the engine's shape. Behavior-identical — all existing Slack authz tests stay green.

**3. GitHub repo source (`authz/github-repo-graph.ts`)** — the second real caller
`buildGithubRepoGraph`: repos → `repo` entities (`github_repo_full_name`), collaborators → `member_of` edges, through the same engine. Gives GitHub the identity-first collapse + departure reconcile the original org-level builder lacked. +3 contract tests.

**4. In-Slack requester `slack_user_id` fallback (`authz/channel-visibility.ts`)**
A user talking to the bot inside Slack carries a Slack user id, not an `auth_user_id`, so they used to miss the gate's lookup and fail closed on channels they belong to. Now resolves via the team-scoped `slack_user_id` claim. +1 e2e test.

## Tests
19 authz integration tests green (typecheck clean). The 3 GitHub builder tests prove the engine's second caller; the Slack suite proves the port is behavior-identical.

## Deliberately NOT here (next vertical)
GitHub recall is not yet *gated* by repo membership. GitHub data lives in `events`, which carry no repo attribution today (only author). Per-repo enforcement needs: the connector to stamp `metadata.github_repo_full_name` at ingestion, a repo-visibility SQL compiler (parallel to `connection-visibility.ts`), and backing indexes. This PR materializes the repo audience graph that gating will read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785250933&installation_id=136316292&pr_number=1590&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1590&signature=2336d97a455a507d54c301a70a5db25c9700428f9d95acef76f7605fca8525f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for synchronizing access from GitHub repository collaborators.
  * Improved Slack channel visibility so in-Slack requesters can be recognized even without a standard account identity.
  * Added resource-level membership enforcement to connector event visibility.

* **Bug Fixes**
  * Access synchronization now more reliably reconciles membership changes, including removing stale collaborator access when memberships change.
  * Visibility filtering now more consistently limits users to only the channels and repository events they’re authorized to access.

* **Tests**
  * Expanded end-to-end and integration coverage for GitHub repo visibility and Slack requester gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->