### PR TITLE
Consolidate: skills = behavior, MCP = connection, egress judge = guardrail

### DIFF
--- a/examples/sales/skills/account-brief/SKILL.md
+++ b/examples/sales/skills/account-brief/SKILL.md
@@ -3,19 +3,6 @@ name: account-brief
 description: Build a pre-renewal brief for a tracked account from its recent public news and announcements. Use before a renewal call or QBR, after the account-health watcher flags a risk. Reading public news is allowed; do not log in, submit forms, or touch any CRM write endpoint.
 nixPackages:
   - jq
-network:
-  allow:
-    - .reuters.com
-    - .apnews.com
-  judge:
-    - domain: newsapi.org
-      judge: news-read
-    - domain: .newsapi.org
-      judge: news-read
-judges:
-  news-read: >
-    Allow GET reads of public news and headlines. Deny logins, posting,
-    and any account, billing, or write action. Fail closed if unclear.
 ---
 
 # Account brief

--- a/packages/cli/src/commands/_lib/apply/__tests__/load-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/load-config.test.ts
@@ -185,7 +185,7 @@ describe("loadDesiredStateFromConfig", () => {
     );
   });
 
-  test("loads agent-dir markdown + a file skill, merging skill network/nix", async () => {
+  test("loads agent-dir markdown + a file skill, merging skill nix", async () => {
     dir = mkdtempSync(join(import.meta.dir, "agentdir-"));
     const agentDir = join(dir, "agents", "crm");
     mkdirSync(join(agentDir, "skills", "crm-ops"), { recursive: true });
@@ -196,8 +196,6 @@ describe("loadDesiredStateFromConfig", () => {
       [
         `---`,
         `name: crm-ops`,
-        `network:`,
-        `  allow: ["api.crm.com"]`,
         `nixPackages: ["jq"]`,
         `---`,
         `Use the CRM API.`,
@@ -226,15 +224,13 @@ describe("loadDesiredStateFromConfig", () => {
     expect(settings?.soulMd).toBe("You are the CRM agent.");
     expect(settings?.identityMd).toBe("CRM identity.");
     expect(settings?.skillsConfig?.skills[0]?.name).toBe("crm-ops");
-    // Agent + skill network domains are unioned.
-    expect(settings?.networkConfig?.allowedDomains).toEqual([
-      "github.com",
-      "api.crm.com",
-    ]);
+    // Skills no longer contribute network — only the agent's domains remain.
+    expect(settings?.networkConfig?.allowedDomains).toEqual(["github.com"]);
+    // Skill nix packages still merge into the agent's worker sandbox.
     expect(settings?.nixConfig?.packages).toEqual(["jq"]);
   });
 
-  test("an inline defineSkill carries content + network with no files", async () => {
+  test("an inline defineSkill carries content with no files", async () => {
     dir = mkdtempSync(join(import.meta.dir, "inline-"));
     writeFileSync(
       join(dir, "lobu.config.ts"),
@@ -244,7 +240,6 @@ describe("loadDesiredStateFromConfig", () => {
         `  name: "greet",`,
         `  description: "Greet someone.",`,
         `  content: "Generate a warm greeting.",`,
-        `  network: { allowed: ["api.greet.com"] },`,
         `});`,
         `export default defineConfig({`,
         `  agents: [defineAgent({ id: "a", skills: [greet] })],`,
@@ -258,38 +253,6 @@ describe("loadDesiredStateFromConfig", () => {
     expect(skill?.name).toBe("greet");
     expect(skill?.content).toBe("Generate a warm greeting.");
     expect(skill?.description).toBe("Greet someone.");
-    expect(state.agents[0]?.settings.networkConfig?.allowedDomains).toEqual([
-      "api.greet.com",
-    ]);
-  });
-
-  test("an inline skill MCP server merges into agent mcpServers", async () => {
-    dir = mkdtempSync(join(import.meta.dir, "skillmcp-"));
-    writeFileSync(
-      join(dir, "lobu.config.ts"),
-      [
-        `import { defineAgent, defineConfig, defineSkill } from "@lobu/cli/config";`,
-        `const api = defineSkill({`,
-        `  name: "api",`,
-        `  content: "Use the API.",`,
-        `  mcpServers: { "support-api": { url: "https://api.example.com/mcp", type: "sse" } },`,
-        `});`,
-        `export default defineConfig({`,
-        `  agents: [defineAgent({ id: "a", skills: [api] })],`,
-        `});`,
-        ``,
-      ].join("\n")
-    );
-
-    const { state } = await loadDesiredStateFromConfig({ cwd: dir });
-    const mcp = (state.agents[0]?.settings.mcpServers ?? {}) as Record<
-      string,
-      { url?: string; type?: string }
-    >;
-    expect(mcp["support-api"]).toEqual({
-      url: "https://api.example.com/mcp",
-      type: "sse",
-    });
   });
 
   test("two agents: custom + default dirs keep index alignment", async () => {

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -822,7 +822,7 @@ describe("mergeAgentDirArtifacts", () => {
     expect(settings.skillsConfig?.skills[0]?.name).toBe("s");
   });
 
-  test("unions network allowed/denied/nix; agent wins on judged + judges", () => {
+  test("preserves agent network; unions skill nix packages", () => {
     const settings: Partial<AgentSettings> = {
       networkConfig: {
         allowedDomains: ["agent.com"],
@@ -838,57 +838,16 @@ describe("mergeAgentDirArtifacts", () => {
         content: "b",
         enabled: true,
         nixPackages: ["python311", "ffmpeg"],
-        networkConfig: {
-          allowedDomains: ["skill.com", "*"],
-          deniedDomains: ["bad.com"],
-          judgedDomains: [
-            { domain: "shared.com", judge: "skill-policy" },
-            { domain: "skill-only.com" },
-          ],
-          judges: { p: "skill prompt", q: "skill q" },
-        },
       },
     ]);
-    // "*" from a skill is dropped; agent + skill domains unioned + deduped.
-    expect(settings.networkConfig?.allowedDomains).toEqual([
-      "agent.com",
-      "skill.com",
-    ]);
-    expect(settings.networkConfig?.deniedDomains).toEqual(["bad.com"]);
-    // Agent wins on the shared judged domain; skill-only domain kept.
+    // Skills no longer contribute network — the agent's config is untouched.
+    expect(settings.networkConfig?.allowedDomains).toEqual(["agent.com"]);
     expect(settings.networkConfig?.judgedDomains).toEqual([
       { domain: "shared.com", judge: "agent-policy" },
-      { domain: "skill-only.com" },
     ]);
-    // Agent wins on the shared judge key; skill-only key kept.
-    expect(settings.networkConfig?.judges).toEqual({
-      p: "agent prompt",
-      q: "skill q",
-    });
+    expect(settings.networkConfig?.judges).toEqual({ p: "agent prompt" });
+    // Agent + skill nix packages are unioned + deduped.
     expect(settings.nixConfig?.packages).toEqual(["ffmpeg", "python311"]);
-  });
-
-  test("agent MCP servers win; skills add only new ids", () => {
-    const settings: Partial<AgentSettings> = {
-      mcpServers: { gmail: { url: "https://agent" } },
-    };
-    mergeAgentDirArtifacts(settings, {}, [
-      {
-        repo: "local/s",
-        name: "s",
-        content: "b",
-        enabled: true,
-        mcpServers: [
-          { id: "gmail", url: "https://skill-should-not-win" },
-          { id: "linear", url: "https://skill", type: "sse" },
-        ],
-      },
-    ]);
-    expect(settings.mcpServers?.gmail).toEqual({ url: "https://agent" });
-    expect(settings.mcpServers?.linear).toEqual({
-      url: "https://skill",
-      type: "sse",
-    });
   });
 
   test("no markdown / no skills leaves settings untouched", () => {

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -574,16 +574,12 @@ describe("mapProjectToDesiredState", () => {
     expect(state.agents).toHaveLength(1);
   });
 
-  test("maps network judged domains + named judge policies", () => {
+  test("maps network allow/deny domains", () => {
     const agent = defineAgent({
       id: "ofc",
       network: {
         allowed: ["api.z.ai"],
-        judged: [
-          { domain: "deliveroo.co.uk", judge: "deliveroo" },
-          { domain: ".deliveroo.co.uk", judge: "deliveroo" },
-        ],
-        judges: { deliveroo: "Allow reads; deny checkout." },
+        denied: ["evil.example.com"],
       },
     });
     const state = mapProjectToDesiredState(
@@ -592,17 +588,12 @@ describe("mapProjectToDesiredState", () => {
     );
     const net = state.agents[0]?.settings.networkConfig;
     expect(net?.allowedDomains).toEqual(["api.z.ai"]);
-    expect(net?.judgedDomains).toEqual([
-      { domain: "deliveroo.co.uk", judge: "deliveroo" },
-      { domain: ".deliveroo.co.uk", judge: "deliveroo" },
-    ]);
-    expect(net?.judges).toEqual({ deliveroo: "Allow reads; deny checkout." });
+    expect(net?.deniedDomains).toEqual(["evil.example.com"]);
   });
 
-  test("maps egress, tools, guardrails, nix packages", () => {
+  test("maps tools, guardrails, nix packages", () => {
     const agent = defineAgent({
       id: "a",
-      egress: { extraPolicy: "no payments", judgeModel: "haiku" },
       tools: {
         preApproved: ["/mcp/gmail/tools/send_email"],
         allowed: ["Bash", "Bash"],
@@ -616,10 +607,6 @@ describe("mapProjectToDesiredState", () => {
       defineConfig({ agents: [agent] }),
       env
     ).agents[0]?.settings;
-    expect(settings?.egressConfig).toEqual({
-      extraPolicy: "no payments",
-      judgeModel: "haiku",
-    });
     expect(settings?.preApprovedTools).toEqual(["/mcp/gmail/tools/send_email"]);
     expect(settings?.toolsConfig).toEqual({
       allowedTools: ["Bash"],
@@ -738,25 +725,6 @@ describe("mapProjectToDesiredState", () => {
     expect(mapped?.platforms?.[0]?.type).toBe("rest");
   });
 
-  test("dedups judged domains by domain (last wins), matching buildAgentSettings", () => {
-    const agent = defineAgent({
-      id: "a",
-      network: {
-        judged: [
-          { domain: "x.com", judge: "first" },
-          { domain: "x.com", judge: "second" },
-          { domain: "y.com" },
-        ],
-      },
-    });
-    const net = mapProjectToDesiredState(defineConfig({ agents: [agent] }), env)
-      .agents[0]?.settings.networkConfig;
-    expect(net?.judgedDomains).toEqual([
-      { domain: "x.com", judge: "second" },
-      { domain: "y.com" },
-    ]);
-  });
-
   test("collects mcp env + oauth clientId/clientSecret $VAR refs (parity with collectEnvRefs)", () => {
     const agent = defineAgent({
       id: "a",
@@ -798,7 +766,6 @@ describe("mapProjectToDesiredState", () => {
       env
     ).agents[0]?.settings;
     expect(settings).not.toHaveProperty("networkConfig");
-    expect(settings).not.toHaveProperty("egressConfig");
     expect(settings).not.toHaveProperty("toolsConfig");
     expect(settings).not.toHaveProperty("preApprovedTools");
     expect(settings).not.toHaveProperty("guardrails");
@@ -826,8 +793,7 @@ describe("mergeAgentDirArtifacts", () => {
     const settings: Partial<AgentSettings> = {
       networkConfig: {
         allowedDomains: ["agent.com"],
-        judgedDomains: [{ domain: "shared.com", judge: "agent-policy" }],
-        judges: { p: "agent prompt" },
+        deniedDomains: ["blocked.com"],
       },
       nixConfig: { packages: ["ffmpeg"] },
     };
@@ -842,10 +808,7 @@ describe("mergeAgentDirArtifacts", () => {
     ]);
     // Skills no longer contribute network — the agent's config is untouched.
     expect(settings.networkConfig?.allowedDomains).toEqual(["agent.com"]);
-    expect(settings.networkConfig?.judgedDomains).toEqual([
-      { domain: "shared.com", judge: "agent-policy" },
-    ]);
-    expect(settings.networkConfig?.judges).toEqual({ p: "agent prompt" });
+    expect(settings.networkConfig?.deniedDomains).toEqual(["blocked.com"]);
     // Agent + skill nix packages are unioned + deduped.
     expect(settings.nixConfig?.packages).toEqual(["ffmpeg", "python311"]);
   });

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -201,7 +201,7 @@ export interface DesiredAgent {
   metadata: DesiredAgentMetadata;
   /**
    * Settings payload destined for `PATCH /:agentId/config`. Built by the mapper
-   * + agent-dir loader: networkConfig, skillsConfig, egressConfig,
+   * + agent-dir loader: networkConfig, skillsConfig,
    * preApprovedTools, guardrails, toolsConfig, nixConfig, mcpServers,
    * modelSelection, providerModelPreferences, installedProviders,
    * identityMd/soulMd/userMd.

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -266,29 +266,6 @@ interface SkillFrontmatter {
   name?: string;
   description?: string;
   nixPackages?: string[];
-  network?: {
-    allow?: string[];
-    deny?: string[];
-    judge?: Array<string | { domain: string; judge?: string }>;
-  };
-  judges?: Record<string, string>;
-  mcpServers?: SkillMcpInput;
-}
-
-function normalizeDomainPattern(pattern: string): string {
-  const trimmed = pattern.trim().toLowerCase();
-  if (!trimmed) return "";
-  if (trimmed === "*") return "*";
-  if (trimmed.startsWith("*.")) return `.${trimmed.slice(2)}`;
-  return trimmed;
-}
-
-function normalizeDomainPatterns(patterns?: string[]): string[] | undefined {
-  if (!patterns?.length) return undefined;
-  const normalized = [
-    ...new Set(patterns.map(normalizeDomainPattern).filter(Boolean)),
-  ];
-  return normalized.length > 0 ? normalized : undefined;
 }
 
 async function parseSkillFrontmatter(raw: string): Promise<{
@@ -309,16 +286,12 @@ type SkillConfigEntry = NonNullable<
   AgentSettings["skillsConfig"]
 >["skills"][number];
 
-type SkillMcpInput = Record<
-  string,
-  { url?: string; type?: string; command?: string; args?: string[] }
->;
-
 /**
  * Map a resolved skill (inline `defineSkill` or file-loaded `skillFromFile`)
  * into a `SkillConfig` entry — the shape stored on agent settings and synced to
- * the worker's `.skills/`. The network/nix/mcp here merge into the agent's
- * worker sandbox at apply time, which is why skills resolve eagerly.
+ * the worker's `.skills/`. The nix packages here merge into the agent's worker
+ * sandbox at apply time, which is why skills resolve eagerly. Skills are
+ * prompt/behavior only — they declare no network or MCP config.
  */
 function skillToConfig(args: {
   name: string;
@@ -326,11 +299,6 @@ function skillToConfig(args: {
   source: "inline" | "file";
   description?: string;
   nixPackages?: string[];
-  allow?: string[];
-  deny?: string[];
-  judged?: Array<{ domain: string; judge?: string }>;
-  judges?: Record<string, string>;
-  mcpServers?: SkillMcpInput;
 }): SkillConfigEntry {
   const skill: SkillConfigEntry = {
     repo: `${args.source}/${args.name}`,
@@ -340,37 +308,6 @@ function skillToConfig(args: {
   };
   if (args.description) skill.description = args.description;
   if (args.nixPackages?.length) skill.nixPackages = args.nixPackages;
-
-  const judgedDomains = (args.judged ?? []).map((entry) => ({
-    domain: normalizeDomainPattern(entry.domain),
-    ...(entry.judge ? { judge: entry.judge } : {}),
-  }));
-  const allowedDomains = normalizeDomainPatterns(args.allow);
-  const deniedDomains = normalizeDomainPatterns(args.deny);
-  if (
-    allowedDomains ||
-    deniedDomains ||
-    judgedDomains.length > 0 ||
-    args.judges
-  ) {
-    skill.networkConfig = {
-      allowedDomains,
-      deniedDomains,
-      ...(judgedDomains.length > 0 ? { judgedDomains } : {}),
-      ...(args.judges ? { judges: args.judges } : {}),
-    };
-  }
-
-  const mcpEntries = Object.entries(args.mcpServers ?? {});
-  if (mcpEntries.length > 0) {
-    skill.mcpServers = mcpEntries.map(([id, mcp]) => ({
-      id,
-      url: mcp.url,
-      type: mcp.type as "sse" | "stdio" | undefined,
-      command: mcp.command,
-      args: mcp.args,
-    }));
-  }
   return skill;
 }
 
@@ -418,32 +355,17 @@ async function resolveSkill(
       source: "file",
       description: fm?.description,
       nixPackages: fm?.nixPackages,
-      allow: fm?.network?.allow,
-      deny: fm?.network?.deny,
-      judged: (fm?.network?.judge ?? []).map((e) =>
-        typeof e === "string"
-          ? { domain: e }
-          : { domain: e.domain, ...(e.judge ? { judge: e.judge } : {}) }
-      ),
-      judges: fm?.judges,
-      mcpServers: fm?.mcpServers,
     });
   }
   if (!skill.name) {
     throw new ValidationError("defineSkill requires a `name`.");
   }
-  const net = skill.network;
   return skillToConfig({
     name: skill.name,
     content: skill.content ?? "",
     source: "inline",
     description: skill.description,
     nixPackages: skill.nixPackages,
-    allow: net?.allowed,
-    deny: net?.denied,
-    judged: net?.judged,
-    judges: net?.judges,
-    mcpServers: skill.mcpServers,
   });
 }
 

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -309,7 +309,6 @@ function diffAgent(
  */
 const SETTINGS_FIELDS: Array<keyof AgentSettings> = [
   "networkConfig",
-  "egressConfig",
   "nixConfig",
   "mcpServers",
   "skillsConfig",

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -191,10 +191,9 @@ export interface AgentMarkdown {
  * results in) so it can be unit-tested directly.
  *
  * Mirrors `buildAgentSettings`'s skill-merge semantics exactly: agent-level
- * network/nix/mcp is laid down first (already in `settings`), then skills are
- * merged on top — allowed/denied/nix are unioned (deduped), judged-domains and
- * judges are skill-first with the AGENT WINNING on conflicts, and skill MCP
- * servers add only ids the agent didn't already define.
+ * nix is laid down first (already in `settings`), then skill nix packages are
+ * unioned on top (deduped). Skills are prompt/behavior only — they no longer
+ * contribute network or MCP config.
  */
 export function mergeAgentDirArtifacts(
   settings: Partial<AgentSettings>,
@@ -209,46 +208,6 @@ export function mergeAgentDirArtifacts(
     settings.skillsConfig = { skills: localSkills };
   }
 
-  // Network merge — agent values are already in settings.networkConfig.
-  const allowed = [...(settings.networkConfig?.allowedDomains ?? [])];
-  const denied = [...(settings.networkConfig?.deniedDomains ?? [])];
-  const judgedByDomain = new Map<string, { domain: string; judge?: string }>();
-  const judges: Record<string, string> = {};
-  // Skills first.
-  for (const skill of localSkills) {
-    const net = skill.networkConfig;
-    if (!net) continue;
-    if (net.allowedDomains?.length) {
-      allowed.push(...net.allowedDomains.filter((d) => d !== "*"));
-    }
-    if (net.deniedDomains?.length) denied.push(...net.deniedDomains);
-    for (const rule of net.judgedDomains ?? []) {
-      judgedByDomain.set(rule.domain, rule);
-    }
-    if (net.judges) Object.assign(judges, net.judges);
-  }
-  // Agent overrides skills on judged/judges.
-  for (const rule of settings.networkConfig?.judgedDomains ?? []) {
-    judgedByDomain.set(rule.domain, rule);
-  }
-  Object.assign(judges, settings.networkConfig?.judges ?? {});
-
-  const judgedDomains = [...judgedByDomain.values()];
-  const hasJudges = Object.keys(judges).length > 0;
-  if (
-    allowed.length > 0 ||
-    denied.length > 0 ||
-    judgedDomains.length > 0 ||
-    hasJudges
-  ) {
-    settings.networkConfig = {
-      ...(allowed.length > 0 ? { allowedDomains: [...new Set(allowed)] } : {}),
-      ...(denied.length > 0 ? { deniedDomains: [...new Set(denied)] } : {}),
-      ...(judgedDomains.length > 0 ? { judgedDomains } : {}),
-      ...(hasJudges ? { judges } : {}),
-    };
-  }
-
   // Nix merge — agent packages first, then skill packages, deduped.
   const nixPackages = [
     ...(settings.nixConfig?.packages ?? []),
@@ -259,23 +218,6 @@ export function mergeAgentDirArtifacts(
       ...settings.nixConfig,
       packages: [...new Set(nixPackages)],
     };
-  }
-
-  // MCP merge — agent servers win; skills add only ids the agent didn't define.
-  const mcpServers: Record<string, unknown> = { ...settings.mcpServers };
-  for (const skill of localSkills) {
-    for (const mcp of skill.mcpServers ?? []) {
-      if (mcpServers[mcp.id]) continue;
-      mcpServers[mcp.id] = {
-        ...(mcp.url ? { url: mcp.url } : {}),
-        ...(mcp.type ? { type: mcp.type } : {}),
-        ...(mcp.command ? { command: mcp.command } : {}),
-        ...(mcp.args ? { args: mcp.args } : {}),
-      };
-    }
-  }
-  if (Object.keys(mcpServers).length > 0) {
-    settings.mcpServers = mcpServers as AgentSettings["mcpServers"];
   }
 }
 

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -305,40 +305,11 @@ function mapAgent(
 
   const allowed = agent.network?.allowed ?? [];
   const denied = agent.network?.denied ?? [];
-  const judges = agent.network?.judges ?? {};
-  const hasJudges = Object.keys(judges).length > 0;
-  // Dedup judged rules by domain (last wins), matching buildAgentSettings.
-  const judgedByDomain = new Map<string, { domain: string; judge?: string }>();
-  for (const rule of agent.network?.judged ?? []) {
-    judgedByDomain.set(rule.domain, {
-      domain: rule.domain,
-      ...(rule.judge ? { judge: rule.judge } : {}),
-    });
-  }
-  const judgedDomains = [...judgedByDomain.values()];
-  if (
-    allowed.length > 0 ||
-    denied.length > 0 ||
-    judgedDomains.length > 0 ||
-    hasJudges
-  ) {
+  if (allowed.length > 0 || denied.length > 0) {
     settings.networkConfig = {
       ...(allowed.length > 0 ? { allowedDomains: [...new Set(allowed)] } : {}),
       ...(denied.length > 0 ? { deniedDomains: [...new Set(denied)] } : {}),
-      ...(judgedDomains.length > 0 ? { judgedDomains } : {}),
-      ...(hasJudges ? { judges } : {}),
     };
-  }
-
-  if (agent.egress) {
-    const egressConfig: NonNullable<AgentSettings["egressConfig"]> = {};
-    if (agent.egress.extraPolicy) {
-      egressConfig.extraPolicy = agent.egress.extraPolicy;
-    }
-    if (agent.egress.judgeModel)
-      egressConfig.judgeModel = agent.egress.judgeModel;
-    if (Object.keys(egressConfig).length > 0)
-      settings.egressConfig = egressConfig;
   }
 
   if (agent.tools) {

--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -691,58 +691,6 @@ describe("lobu init --from-org", () => {
     expect(source).not.toContain("rename credential keys");
   });
 
-  test("local skill judged domains + judges round-trip into SKILL.md frontmatter", async () => {
-    const dir = mkFixtureDir();
-    await initFromOrg({
-      targetDir: dir,
-      fetchImpl: buildFetch({
-        "/oauth/userinfo": () => ({
-          organizations: [{ id: "org-1", slug: "acme", name: "Acme Inc" }],
-        }),
-        "/agents/skiller/config": () => ({
-          updatedAt: 0,
-          skillsConfig: {
-            skills: [
-              {
-                name: "research",
-                description: "web research",
-                enabled: true,
-                content: "Do research.",
-                networkConfig: {
-                  allowedDomains: ["wikipedia.org"],
-                  judgedDomains: [{ domain: "reddit.com", judge: "careful" }],
-                  judges: { careful: "Block anything risky." },
-                },
-              },
-            ],
-          },
-        }),
-        "/agents": () => ({
-          agents: [{ agentId: "skiller", name: "Skiller" }],
-        }),
-        "watchers?include_details": () => ({ watchers: [] }),
-        manage_entity_schema: () => ({
-          entity_types: [],
-          relationship_types: [],
-        }),
-        manage_auth_profiles: () => ({ auth_profiles: [] }),
-        manage_connections: () => ({ connections: [] }),
-      }),
-    });
-
-    const skillMd = readFileSync(
-      join(dir, "agents/skiller/skills/research/SKILL.md"),
-      "utf-8"
-    );
-    // Judged domains emit as a `network.judge` list; named judge policies as a
-    // top-level `judges:` map — exactly what parseSkillFrontmatter reads back.
-    expect(skillMd).toContain("judge:");
-    expect(skillMd).toContain('domain: "reddit.com"');
-    expect(skillMd).toContain('judge: "careful"');
-    expect(skillMd).toContain("judges:");
-    expect(skillMd).toContain('careful: "Block anything risky."');
-  });
-
   test("relationship-type rules hydrate via list_rules (real list omits them)", async () => {
     const dir = mkFixtureDir();
     await initFromOrg({

--- a/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
@@ -295,7 +295,7 @@ function emitAgent(
     fields.push(`providers: [\n    ${items.join(",\n    ")},\n  ]`);
   }
 
-  // network ← networkConfig (allowed/denied/judged/judges).
+  // network ← networkConfig (allowed/denied).
   const net = settings?.networkConfig;
   if (net) {
     const netFields: string[] = [];
@@ -305,35 +305,9 @@ function emitAgent(
     if (net.deniedDomains?.length) {
       netFields.push(`denied: ${emitValue(net.deniedDomains, 2)}`);
     }
-    if (net.judgedDomains?.length) {
-      netFields.push(
-        `judged: ${emitValue(
-          net.judgedDomains.map((r) => ({
-            domain: r.domain,
-            ...(r.judge ? { judge: r.judge } : {}),
-          })),
-          2
-        )}`
-      );
-    }
-    if (net.judges && Object.keys(net.judges).length > 0) {
-      netFields.push(`judges: ${emitValue(net.judges, 2)}`);
-    }
     if (netFields.length > 0) {
       fields.push(`network: ${objectLiteral(netFields, 1)}`);
     }
-  }
-
-  // egress ← egressConfig.
-  const egress = settings?.egressConfig;
-  if (egress && (egress.extraPolicy || egress.judgeModel)) {
-    const egFields: string[] = [];
-    if (egress.extraPolicy) {
-      egFields.push(`extraPolicy: ${str(egress.extraPolicy)}`);
-    }
-    if (egress.judgeModel)
-      egFields.push(`judgeModel: ${str(egress.judgeModel)}`);
-    fields.push(`egress: ${objectLiteral(egFields, 1)}`);
   }
 
   // tools ← toolsConfig + preApprovedTools.

--- a/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
@@ -535,49 +535,11 @@ function emitSkillFile(
 ): string {
   const fm: string[] = [`name: ${skill.name}`];
   if (skill.description) fm.push(`description: ${skill.description}`);
-  const net = skill.networkConfig;
-  if (
-    net?.allowedDomains?.length ||
-    net?.deniedDomains?.length ||
-    net?.judgedDomains?.length
-  ) {
-    fm.push("network:");
-    if (net?.allowedDomains?.length) {
-      fm.push(`  allow: [${net.allowedDomains.map((d) => str(d)).join(", ")}]`);
-    }
-    if (net?.deniedDomains?.length) {
-      fm.push(`  deny: [${net.deniedDomains.map((d) => str(d)).join(", ")}]`);
-    }
-    // Judged domains round-trip as a `network.judge` YAML list of
-    // `{ domain, judge? }` — the exact shape the SKILL.md frontmatter loader
-    // reads back (parseSkillFrontmatter → `fm.network.judge`). Omitting these
-    // (the prior behaviour) silently dropped per-skill egress-judge rules.
-    if (net?.judgedDomains?.length) {
-      fm.push("  judge:");
-      for (const rule of net.judgedDomains) {
-        fm.push(`    - domain: ${str(rule.domain)}`);
-        if (rule.judge) fm.push(`      judge: ${str(rule.judge)}`);
-      }
-    }
-  }
-  // Named judge policies (referenced by `network.judge[].judge`) live at the
-  // frontmatter top level under `judges:` (str() emits a JSON-quoted scalar,
-  // which is valid YAML even for multi-line policy text).
-  if (net?.judges && Object.keys(net.judges).length > 0) {
-    fm.push("judges:");
-    for (const [name, policy] of Object.entries(net.judges)) {
-      fm.push(`  ${name}: ${str(policy)}`);
-    }
-  }
   if (skill.nixPackages?.length) {
     fm.push(
       `nixPackages: [${skill.nixPackages.map((p) => str(p)).join(", ")}]`
     );
   }
-  // NOTE: skill-level `mcpServers` (rare) are not emitted yet — the stored
-  // shape is SkillMcpServer[] while the frontmatter loader expects a YAML
-  // record, and secret-bearing fields would need `$VAR` placeholders. Agent
-  // mcpServers DO round-trip (emitMcpServers). Tracked as a follow-up.
   const body = skill.content ?? "";
   return `---\n${fm.join("\n")}\n---\n${body}\n`;
 }

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -401,30 +401,11 @@ export interface ProviderConfig {
   key?: string | SecretRef;
 }
 
-/** Per-domain egress-judge rule: route `domain` through the named judge policy. */
-export interface JudgedDomain {
-  domain: string;
-  /** Name of a policy declared in {@link NetworkConfig.judges}. */
-  judge?: string;
-}
-
 export interface NetworkConfig {
   /** Domains the worker may reach (exact or `.wildcard`). */
   allowed?: string[];
   /** Domains explicitly blocked (takes precedence over `allowed`). */
   denied?: string[];
-  /** Domains routed through the LLM egress judge. */
-  judged?: JudgedDomain[];
-  /** Named judge policies (prompt text), referenced by `judged[].judge`. */
-  judges?: Record<string, string>;
-}
-
-/** Operator-level overrides for the LLM egress judge. */
-export interface EgressConfig {
-  /** Extra instructions appended to the egress judge prompt. */
-  extraPolicy?: string;
-  /** Override the model the egress judge runs on. */
-  judgeModel?: string;
 }
 
 /** Worker-side tool permissions. */
@@ -516,7 +497,6 @@ export interface Agent {
   skills?: Skill[];
   providers?: ProviderConfig[];
   network?: NetworkConfig;
-  egress?: EgressConfig;
   tools?: ToolsConfig;
   /** Guardrails enabled for this agent, by registered name. */
   guardrails?: string[];

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -546,20 +546,8 @@ export function defineAgent(config: Omit<Agent, "kind">): Agent {
 // ---------------------------------------------------------------------------
 
 /**
- * MCP server a skill declares. Skills support the basic transport shape only;
- * for servers that need auth (custom headers or OAuth), declare them on the
- * agent via `defineAgent({ mcpServers })`, which has full secret support.
- */
-export interface SkillMcpServer {
-  url?: string;
-  command?: string;
-  args?: string[];
-  type?: "sse" | "streamable-http" | "stdio";
-}
-
-/**
- * A skill an agent can use — an instruction block (`content`) plus the egress,
- * nix, and MCP it declares. Skills are referenced explicitly from
+ * A skill an agent can use — an instruction block (`content`) plus the nix
+ * packages it declares. Skills are referenced explicitly from
  * {@link Agent.skills}; there is no directory auto-discovery.
  *
  * Build one of two ways, both producing this same object:
@@ -569,9 +557,9 @@ export interface SkillMcpServer {
  *     fields from its frontmatter + body. `path` is mutually exclusive with the
  *     inline fields.
  *
- * The frontmatter a skill declares (`network`, `nixPackages`, `mcpServers`) is
- * merged into the agent's worker sandbox at apply time — that's why skills are
- * resolved eagerly, not loaded by the worker at run time.
+ * The frontmatter a skill declares (`nixPackages`) is merged into the agent's
+ * worker sandbox at apply time — that's why skills are resolved eagerly, not
+ * loaded by the worker at run time.
  */
 export interface Skill {
   readonly kind: "skill";
@@ -586,13 +574,6 @@ export interface Skill {
   content?: string;
   /** Nix packages provisioned into the worker when this skill is present. */
   nixPackages?: string[];
-  /** Egress the skill needs — merged into the agent's network allowlist. */
-  network?: NetworkConfig;
-  /**
-   * MCP servers the skill declares, keyed by id. Basic transport shape only; a
-   * server that needs auth (headers/OAuth) belongs on the agent's `mcpServers`.
-   */
-  mcpServers?: Record<string, SkillMcpServer>;
   /**
    * Load body + frontmatter from a `SKILL.md`, relative to the config file. Set
    * by {@link skillFromFile}; resolved by the loader. Mutually exclusive with

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -8,7 +8,6 @@
 
 import type { PluginsConfig } from "./plugin-types";
 import type {
-  AgentEgressConfig,
   AgentInlineGuardrail,
   AuthProfile,
   InstalledProvider,
@@ -38,8 +37,6 @@ export interface AgentSettings {
   providerModelPreferences?: ProviderModelPreferences;
   /** Network access configuration */
   networkConfig?: NetworkConfig;
-  /** Egress judge configuration (operator-level overrides for the LLM egress judge). */
-  egressConfig?: AgentEgressConfig;
   /** Nix environment configuration */
   nixConfig?: NixConfig;
   /** Additional MCP servers */

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -25,15 +25,6 @@ export interface ModelOption {
   value: string;
 }
 
-export interface SkillMcpServerInfo {
-  id: string;
-  name?: string;
-  url?: string;
-  type?: "sse" | "streamable-http" | "stdio";
-  command?: string;
-  args?: string[];
-}
-
 export interface Skill {
   repo: string;
   name: string;
@@ -42,7 +33,6 @@ export interface Skill {
   system?: boolean;
   content?: string;
   contentFetchedAt?: number;
-  mcpServers?: SkillMcpServerInfo[];
   nixPackages?: string[];
   permissions?: string[];
   providers?: string[];

--- a/packages/core/src/guardrails/index.ts
+++ b/packages/core/src/guardrails/index.ts
@@ -2,6 +2,7 @@ export { createNoopGuardrail } from "./builtins/noop";
 export { GuardrailRegistry } from "./registry";
 export { runGuardrailInstances, runGuardrails } from "./runner";
 export type {
+  EgressGuardrailContext,
   Guardrail,
   GuardrailContext,
   GuardrailResult,

--- a/packages/core/src/guardrails/types.ts
+++ b/packages/core/src/guardrails/types.ts
@@ -10,12 +10,17 @@
  *   - `input`    — user message before dispatch to worker
  *   - `output`   — worker-produced text/attachments before user rendering
  *   - `pre-tool` — tool call authorization (agent → gateway MCP proxy)
+ *   - `egress`   — outbound network request authorization, evaluated in the
+ *                  http-proxy egress plane (LLM egress judge). Enforcement
+ *                  stays in the proxy — this stage is NOT run by the message
+ *                  pipeline; it exists so egress denials share the guardrail
+ *                  stage taxonomy and audit trail (`guardrail-trip` events).
  *
  * Register guardrails in a {@link GuardrailRegistry} and enable them per-agent
  * via `defineAgent({ guardrails: ["name-a", "name-b"] })` in `lobu.config.ts`.
  */
 
-export type GuardrailStage = "input" | "output" | "pre-tool";
+export type GuardrailStage = "input" | "output" | "pre-tool" | "egress";
 
 /**
  * Context shape passed to each stage. Each stage has a distinct payload so
@@ -48,10 +53,27 @@ export interface PreToolGuardrailContext {
   conversationId?: string;
 }
 
+/**
+ * Context for an egress decision. Unlike the other stages this is NOT
+ * evaluated in the message pipeline — it is produced by the http-proxy egress
+ * plane (the LLM egress judge) which owns enforcement. The stage exists so
+ * egress denials are typed against the same taxonomy and emit the same
+ * `guardrail-trip` audit events as message-pipeline guardrails.
+ */
+export interface EgressGuardrailContext {
+  agentId: string;
+  organizationId: string;
+  /** Destination host the worker is attempting to reach. */
+  hostname: string;
+  method?: string;
+  path?: string;
+}
+
 export type GuardrailContext = {
   input: InputGuardrailContext;
   output: OutputGuardrailContext;
   "pre-tool": PreToolGuardrailContext;
+  egress: EgressGuardrailContext;
 };
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,7 +29,6 @@ export type {
   PrefillMcp,
   PrefillSkill,
   Skill,
-  SkillMcpServerInfo,
 } from "./api-types";
 export * from "./capabilities";
 export type { CommandContext, CommandDefinition } from "./command-registry";
@@ -119,7 +118,6 @@ export type {
   RegistryEntry,
   SessionContext,
   SkillConfig,
-  SkillMcpServer,
   SkillPreToolGuardrail,
   SkillsConfig,
   SuggestedPrompt,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,7 +94,6 @@ export { getSentry, initSentry } from "./sentry";
 export { extractTraceId, generateTraceId } from "./trace";
 // Core types
 export type {
-  AgentEgressConfig,
   AgentInlineGuardrail,
   AgentMcpConfig,
   AgentOptions,
@@ -102,7 +101,6 @@ export type {
   CliBackendConfig,
   ConversationMessage,
   DeclaredCredential,
-  DomainJudgeRule,
   HistoryMessage,
   InstalledProvider,
   InstructionContext,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -235,6 +235,11 @@ export interface AgentInlineGuardrail {
   model?: string;
   /** `pre-tool` only: narrow to specific tool names (empty = every tool). */
   tools?: string[];
+  /**
+   * `egress` only: hostnames this judge gates (exact or `.wildcard`), mirroring
+   * `tools` for pre-tool. Empty/omitted = no egress routing.
+   */
+  domains?: string[];
 }
 
 /**
@@ -279,43 +284,6 @@ export interface NetworkConfig {
   allowedDomains?: string[];
   /** Domains explicitly blocked (takes precedence over allowedDomains). */
   deniedDomains?: string[];
-  /**
-   * Domains that require an LLM judge verdict per request. Matched after the
-   * global blocklist/allowlist and before fail-closed. When matched, the
-   * proxy invokes the named judge policy (or "default") and allows only if
-   * the verdict is "allow".
-   */
-  judgedDomains?: DomainJudgeRule[];
-  /**
-   * Named judge policies. Keys are referenced by {@link DomainJudgeRule.judge};
-   * the entry "default" is used when a rule omits `judge`.
-   */
-  judges?: Record<string, string>;
-}
-
-/**
- * Per-domain rule that routes matching requests through the LLM egress judge.
- */
-export interface DomainJudgeRule {
-  /** Domain pattern — same format as {@link NetworkConfig.allowedDomains}. */
-  domain: string;
-  /** Named judge policy key; defaults to "default". */
-  judge?: string;
-}
-
-/**
- * Agent-level egress judge configuration (operator-controlled).
- *
- * The agent's {@link NetworkConfig} supplies per-domain rules and named judge
- * policies. This struct is merged on top at runtime:
- *   - {@link extraPolicy} is appended to every judge prompt for this agent.
- *   - {@link judgeModel} overrides the built-in judge model.
- */
-export interface AgentEgressConfig {
-  /** Operator policy appended to every judge prompt for this agent. */
-  extraPolicy?: string;
-  /** Judge model identifier (defaults to a fast Haiku model). */
-  judgeModel?: string;
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -126,9 +126,6 @@ export interface ConversationMessage {
  */
 export type ThinkingLevel = "off" | "low" | "medium" | "high";
 
-/**
- * MCP server declared by a skill manifest.
- */
 export interface McpOAuthConfig {
   /** Authorization endpoint (user verification page for device-code flow). */
   authUrl?: string;
@@ -146,18 +143,6 @@ export interface McpOAuthConfig {
   registrationUrl?: string;
   /** RFC 8707 resource indicator included in token requests. */
   resource?: string;
-}
-
-export interface SkillMcpServer {
-  id: string;
-  name?: string;
-  url?: string;
-  type?: "sse" | "streamable-http" | "stdio";
-  command?: string;
-  args?: string[];
-  oauth?: McpOAuthConfig;
-  inputs?: Array<{ id: string; label?: string; type?: string }>;
-  headers?: Record<string, string>;
 }
 
 /**
@@ -181,17 +166,8 @@ export interface SkillConfig {
   content?: string;
   /** When the content was last fetched (timestamp ms) */
   contentFetchedAt?: number;
-  /** MCP servers declared by the skill */
-  mcpServers?: SkillMcpServer[];
   /** System packages declared by the skill (nix) */
   nixPackages?: string[];
-  /** Network access policy declared by the skill */
-  networkConfig?: {
-    allowedDomains?: string[];
-    deniedDomains?: string[];
-    judgedDomains?: DomainJudgeRule[];
-    judges?: Record<string, string>;
-  };
   /** AI providers the skill requires */
   providers?: string[];
   /** Preferred model for this skill (e.g., "anthropic/claude-opus-4") */
@@ -330,8 +306,8 @@ export interface DomainJudgeRule {
 /**
  * Agent-level egress judge configuration (operator-controlled).
  *
- * Skills supply per-domain rules and named judge policies via their
- * {@link NetworkConfig}. This struct is merged on top at runtime:
+ * The agent's {@link NetworkConfig} supplies per-domain rules and named judge
+ * policies. This struct is merged on top at runtime:
  *   - {@link extraPolicy} is appended to every judge prompt for this agent.
  *   - {@link judgeModel} overrides the built-in judge model.
  */

--- a/packages/core/src/worker/wire.ts
+++ b/packages/core/src/worker/wire.ts
@@ -8,14 +8,14 @@
  *
  * Before this lived in core, the worker had its own `MessagePayload`
  * declaration that was a structural subset of the gateway's (missing
- * `organizationId`, `networkConfig`, `egressConfig`, `mcpConfig`, `nixConfig`,
+ * `organizationId`, `networkConfig`, `mcpConfig`, `nixConfig`,
  * `preApprovedTools`). At runtime the worker's zod schema was patched with
  * `.passthrough()` so the extra fields survived parsing, but the static type
  * silently lied. Hoisting closes the gap.
  */
 
 import type {
-  AgentEgressConfig,
+  AgentInlineGuardrail,
   AgentMcpConfig,
   AgentOptions,
   NetworkConfig,
@@ -97,8 +97,14 @@ export interface MessagePayload {
    */
   runJobToken?: string;
 
-  /** Per-agent egress judge configuration. */
-  egressConfig?: AgentEgressConfig;
+  /**
+   * Per-agent operator-authored inline guardrails. Threaded alongside
+   * `networkConfig` so the deployment manager can sync the `egress`-stage
+   * entries into the egress policy store (the proxy-plane LLM judge). The
+   * input/output/pre-tool entries are resolved separately by the message
+   * pipeline from agent settings; they ride here only for the egress sync.
+   */
+  guardrailsInline?: AgentInlineGuardrail[];
 
   /** Per-agent MCP configuration (additive to global MCPs). */
   mcpConfig?: AgentMcpConfig;

--- a/packages/server/src/catalog/installed.ts
+++ b/packages/server/src/catalog/installed.ts
@@ -143,9 +143,7 @@ export async function listAgentInstalled(
 				enabled: skill.enabled,
 				description: skill.description,
 				system: skill.system,
-				mcp_servers: skill.mcpServers,
 				nix_packages: skill.nixPackages,
-				network_config: skill.networkConfig,
 			},
 		}));
 		result.skills = {

--- a/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
+++ b/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
@@ -150,26 +150,38 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     const barebones = new TestDeploymentManager(TEST_CONFIG);
     barebones.setPolicyStore(policyStore);
 
+    // Egress judges are sourced from the agent's `egress`-stage inline
+    // guardrails — each becomes a named judge gating its `domains`.
     await barebones.syncNetworkConfigGrants(
       buildPayload({
-        networkConfig: {
-          judgedDomains: [{ domain: "api.example.com" }],
-          judges: { default: "initial policy" },
-        },
-        egressConfig: { extraPolicy: "operator policy" },
+        guardrailsInline: [
+          {
+            name: "default",
+            enabled: true,
+            stage: "egress",
+            policy: "initial policy",
+            model: "model-x",
+            domains: ["api.example.com"],
+          },
+        ],
       })
     );
 
     let resolved = policyStore.resolve("test-org", "agent-1", "api.example.com");
     expect(resolved?.policy).toContain("initial policy");
-    expect(resolved?.policy).toContain("operator policy");
+    expect(resolved?.judgeModel).toBe("model-x");
 
     await barebones.syncNetworkConfigGrants(
       buildPayload({
-        networkConfig: {
-          judgedDomains: [{ domain: "api.example.com" }],
-          judges: { default: "updated policy" },
-        },
+        guardrailsInline: [
+          {
+            name: "default",
+            enabled: true,
+            stage: "egress",
+            policy: "updated policy",
+            domains: ["api.example.com"],
+          },
+        ],
       })
     );
 

--- a/packages/server/src/gateway/__tests__/egress-judge-guardrail-audit.test.ts
+++ b/packages/server/src/gateway/__tests__/egress-judge-guardrail-audit.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Egress denials are part of the guardrail audit trail.
+ *
+ * Enforcement of the LLM egress judge stays in the http-proxy plane, but a
+ * judge DENY must now emit a `guardrail-trip` event (stage `egress`) just like
+ * a message-pipeline guardrail. This test drives the real `checkDomainAccess`
+ * decision path with a judge that denies and asserts the audit row is written
+ * with `stage: "egress"` and the judge's name. The DB is faked at the
+ * `insertEvent` seam so no Postgres is required.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Capture `insertEvent` calls instead of hitting Postgres. `recordGuardrailTrip`
+// (the audit path) is the only consumer reached here; the other exports are
+// stubbed so any transitive importer in the proxy graph still resolves.
+const insertEventCalls: Array<Record<string, unknown>> = [];
+mock.module("../../utils/insert-event", () => ({
+  insertEvent: async (params: Record<string, unknown>) => {
+    insertEventCalls.push(params);
+  },
+  recordChangeEvent: () => {},
+  recordLifecycleEvent: () => {},
+  eventDedupLockKey: () => 0,
+}));
+
+import { flushPendingGuardrailAudits } from "../guardrails/audit.js";
+import type {
+  PolicyStore,
+  ResolvedJudgeRule,
+} from "../permissions/policy-store.js";
+import { EgressJudge } from "../proxy/egress-judge/judge.js";
+import {
+  __testOnly,
+  setProxyEgressJudge,
+  setProxyPolicyStore,
+} from "../proxy/http-proxy.js";
+import type { JudgeClient, JudgeVerdict } from "../proxy/egress-judge/types.js";
+
+class DenyClient implements JudgeClient {
+  async judge(_args: {
+    model: string;
+    systemPrompt: string;
+    userPrompt: string;
+  }): Promise<JudgeVerdict> {
+    return { verdict: "deny", reason: "host not permitted by policy" };
+  }
+}
+
+function policyStoreReturning(rule: ResolvedJudgeRule): PolicyStore {
+  return { resolve: () => rule } as unknown as PolicyStore;
+}
+
+describe("egress judge deny → guardrail-trip audit", () => {
+  beforeEach(() => {
+    insertEventCalls.length = 0;
+    // Complete-isolation global config so the host is never globally allowed
+    // and the decision falls through to the judge.
+    process.env.WORKER_ALLOWED_DOMAINS = "";
+    process.env.WORKER_DISALLOWED_DOMAINS = "";
+    __testOnly.reset();
+  });
+
+  test("a judged-domain DENY records a guardrail-trip with stage egress", async () => {
+    const rule: ResolvedJudgeRule = {
+      judgeName: "repo-owner-only",
+      policy: "allow only repos the user owns",
+      policyHash: "policy-hash-1",
+    };
+    setProxyPolicyStore(policyStoreReturning(rule));
+    setProxyEgressJudge(
+      new EgressJudge({ client: new DenyClient(), defaultModel: "judge-test" })
+    );
+
+    const decision = await __testOnly.checkDomainAccess(
+      "api.github.com",
+      "agent-a",
+      "org-1"
+    );
+
+    // Decision logic unchanged: judge deny → blocked.
+    expect(decision.allowed).toBe(false);
+    expect(decision.source).toBe("judge");
+    expect(decision.judge?.verdict).toBe("deny");
+
+    await flushPendingGuardrailAudits();
+
+    expect(insertEventCalls.length).toBe(1);
+    const event = insertEventCalls[0];
+    expect(event?.semanticType).toBe("guardrail-trip");
+    const metadata = event?.metadata as Record<string, unknown>;
+    expect(metadata?.stage).toBe("egress");
+    expect(metadata?.guardrail).toBe("repo-owner-only");
+    const judgeMetadata = metadata?.guardrail_metadata as Record<
+      string,
+      unknown
+    >;
+    expect(judgeMetadata?.hostname).toBe("api.github.com");
+    expect(judgeMetadata?.verdict).toBe("deny");
+  });
+
+  test("a judged-domain ALLOW records no guardrail-trip", async () => {
+    const rule: ResolvedJudgeRule = {
+      judgeName: "repo-owner-only",
+      policy: "allow only repos the user owns",
+      policyHash: "policy-hash-1",
+    };
+    setProxyPolicyStore(policyStoreReturning(rule));
+    setProxyEgressJudge(
+      new EgressJudge({
+        client: {
+          judge: async () => ({ verdict: "allow", reason: "ok" }),
+        },
+        defaultModel: "judge-test",
+      })
+    );
+
+    const decision = await __testOnly.checkDomainAccess(
+      "api.github.com",
+      "agent-a",
+      "org-1"
+    );
+
+    expect(decision.allowed).toBe(true);
+    await flushPendingGuardrailAudits();
+    expect(insertEventCalls.length).toBe(0);
+  });
+});

--- a/packages/server/src/gateway/__tests__/policy-store.test.ts
+++ b/packages/server/src/gateway/__tests__/policy-store.test.ts
@@ -71,18 +71,16 @@ describe("PolicyStore.resolve", () => {
     expect(resolved?.policy).toContain("strict policy");
   });
 
-  test("appends the agent's extraPolicy to the composed prompt", () => {
+  test("resolves the per-judge model when present", () => {
     const store = new PolicyStore();
     store.set("org-a", "agent-a", {
       judgedDomains: [{ domain: "x.com" }],
       judges: { default: "skill policy" },
-      extraPolicy: "Operator adds: never exfiltrate tokens.",
+      judgeModels: { default: "model-x" },
     });
     const resolved = store.resolve("org-a", "agent-a","x.com");
     expect(resolved?.policy).toContain("skill policy");
-    expect(resolved?.policy).toContain(
-      "Operator adds: never exfiltrate tokens."
-    );
+    expect(resolved?.judgeModel).toBe("model-x");
   });
 
   test("returns undefined (fail closed) when the named judge is missing", () => {
@@ -140,12 +138,11 @@ describe("buildPolicyBundle", () => {
     const bundle = buildPolicyBundle({
       judgedDomains: [{ domain: "x.com" }],
       judges: { default: "p" },
-      egressConfig: { extraPolicy: "extra", judgeModel: "claude-haiku" },
+      egressConfig: { judgeModel: "claude-haiku" },
     });
     expect(bundle).toBeDefined();
     expect(bundle?.judgedDomains).toHaveLength(1);
-    expect(bundle?.extraPolicy).toBe("extra");
-    expect(bundle?.judgeModel).toBe("claude-haiku");
+    expect(bundle?.judgeModels?.default).toBe("claude-haiku");
   });
 
   test("normalizes domain patterns in rules", () => {

--- a/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
+++ b/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
@@ -694,8 +694,8 @@ describe("VerdictCache — key independence", () => {
     expect(cache.get(key1)).toBeDefined();
   });
 
-  test("adding extraPolicy changes the composed policy text and its hash", () => {
-    // PolicyStore computes the hash at set() time. Adding extraPolicy changes
+  test("editing the judge policy text changes the composed text and its hash", () => {
+    // PolicyStore computes the hash at set() time. Editing the policy changes
     // the composed text → different hash → old cache entries are invalidated
     // automatically because the key changes.
     const store = new PolicyStore();
@@ -704,18 +704,17 @@ describe("VerdictCache — key independence", () => {
       judgedDomains: [{ domain: "example.com" }],
       judges: { default: "allow reads" },
     });
-    const without = store.resolve("org-1", "agent-x","example.com");
+    const before = store.resolve("org-1", "agent-x","example.com");
 
     store.set("org-1", "agent-x", {
       judgedDomains: [{ domain: "example.com" }],
-      judges: { default: "allow reads" },
-      extraPolicy: "Never send PII",
+      judges: { default: "allow reads. Never send PII" },
     });
-    const withExtra = store.resolve("org-1", "agent-x","example.com");
+    const after = store.resolve("org-1", "agent-x","example.com");
 
-    expect(without).toBeDefined();
-    expect(withExtra).toBeDefined();
-    expect(without!.policyHash).not.toBe(withExtra!.policyHash);
+    expect(before).toBeDefined();
+    expect(after).toBeDefined();
+    expect(before!.policyHash).not.toBe(after!.policyHash);
   });
 
   test("same policy text in two agents produces different policyHash (no cross-agent cache collision)", () => {

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -667,18 +667,6 @@ export class WorkerGateway {
           skillsConfig = skills
             .filter((s) => s.enabled && s.content)
             .map((s) => ({ name: s.name, content: s.content! }));
-          // Build MCP context map: MCP server ID → skill instructions
-          for (const skill of skills) {
-            if (
-              skill.enabled &&
-              skill.instructions?.trim() &&
-              skill.mcpServers?.length
-            ) {
-              for (const mcp of skill.mcpServers) {
-                mcpContext[mcp.id] = skill.instructions.trim();
-              }
-            }
-          }
         } catch (error) {
           logger.error("Failed to fetch skills config for worker sync", {
             error,

--- a/packages/server/src/gateway/guardrails/aggregator.ts
+++ b/packages/server/src/gateway/guardrails/aggregator.ts
@@ -135,6 +135,10 @@ export function resolveAgentGuardrails(
   // edit UI rejects such names up front so this stays a defensive guard.
   for (const entry of extras.inline ?? []) {
     if (entry.enabled === false) continue;
+    // `egress` guardrails are enforced in the http-proxy plane (the policy
+    // store + EgressJudge), never the message pipeline — skip them here so
+    // they are not materialized into a stage that's never run.
+    if (entry.stage === "egress") continue;
     // Defensive: a malformed persisted row can carry an invalid `stage`
     // (the write path validates, but older rows or out-of-band writes might
     // not). Indexing `seen[bad]` would be `undefined` and throw mid-message —

--- a/packages/server/src/gateway/guardrails/aggregator.ts
+++ b/packages/server/src/gateway/guardrails/aggregator.ts
@@ -55,10 +55,14 @@ interface ResolvedAgentGuardrails {
 }
 
 function emptyByStage(): Record<GuardrailStage, Guardrail[]> {
-  return { input: [], output: [], "pre-tool": [] };
+  // `egress` is part of the stage taxonomy but is never resolved/run by the
+  // message pipeline — enforcement lives in the http-proxy egress plane. The
+  // slot stays empty here; the resolution loops below iterate only the three
+  // message-pipeline stages so nothing is ever pushed into it.
+  return { input: [], output: [], "pre-tool": [], egress: [] };
 }
 function emptyNames(): Record<GuardrailStage, string[]> {
-  return { input: [], output: [], "pre-tool": [] };
+  return { input: [], output: [], "pre-tool": [], egress: [] };
 }
 
 /**
@@ -94,6 +98,8 @@ export function resolveAgentGuardrails(
     input: new Map(),
     output: new Map(),
     "pre-tool": new Map(),
+    // Never populated — egress is enforced in the http-proxy plane, not here.
+    egress: new Map(),
   };
 
   // ── 1. Agent's enabled built-ins (all stages) ──────────────────────────

--- a/packages/server/src/gateway/guardrails/stage-text.ts
+++ b/packages/server/src/gateway/guardrails/stage-text.ts
@@ -42,6 +42,12 @@ export function extractStageText<S extends GuardrailStage>(
         ? `tool: ${c.toolName}\narguments: ${args}`
         : args;
     }
+    case "egress":
+      // Egress has no message text — the judge inspects hostname/method/path,
+      // not free-form content. This extractor is only used by the
+      // message-pipeline scanners (pii-scan / judge-factory), which never run
+      // at the egress stage, so an empty string is the correct no-op.
+      return "";
     default:
       if (options.throwOnUnknown) {
         throw new Error(`Unknown guardrail stage: ${String(stage)}`);

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -20,7 +20,7 @@ import type { ProviderCredentialContext } from "../embedded.js";
 import type { ModelProviderModule } from "../modules/module-system.js";
 import type { GrantStore } from "../permissions/grant-store.js";
 import {
-  buildPolicyBundle,
+  egressGuardrailsToPolicyBundle,
   type PolicyStore,
 } from "../permissions/policy-store.js";
 import {
@@ -1024,9 +1024,10 @@ export class DeploymentManager {
   }
 
   /**
-   * Sync per-agent egress judge policies (judgedDomains + named judges +
-   * operator extra_policy) into the policy store so the HTTP proxy can
-   * resolve them at request time.
+   * Sync per-agent egress judge policies into the policy store so the HTTP
+   * proxy can resolve them at request time. The source is the agent's
+   * `egress`-stage inline guardrails — each contributes a named judge (its
+   * `policy` + optional `model`) and routes its `domains` through it.
    */
   private syncEgressPolicy(
     messageData: MessagePayload,
@@ -1047,11 +1048,10 @@ export class DeploymentManager {
       return;
     }
 
-    const bundle = buildPolicyBundle({
-      judgedDomains: messageData.networkConfig?.judgedDomains,
-      judges: messageData.networkConfig?.judges,
-      egressConfig: messageData.egressConfig,
-    });
+    const egressGuardrails = (messageData.guardrailsInline ?? []).filter(
+      (g) => g.stage === "egress" && g.enabled
+    );
+    const bundle = egressGuardrailsToPolicyBundle(egressGuardrails);
     if (bundle) {
       this.policyStore.set(organizationId, agentId, bundle);
       if (deploymentName) {

--- a/packages/server/src/gateway/permissions/__tests__/policy-store.test.ts
+++ b/packages/server/src/gateway/permissions/__tests__/policy-store.test.ts
@@ -11,15 +11,16 @@
  *   - resolve: returns undefined when named judge is missing (fails closed)
  *   - buildPolicyBundle: deduplicates equivalent domain patterns
  *   - buildPolicyBundle: returns undefined when no judged domains
- *   - buildPolicyBundle: appends extraPolicy to each judge
+ *   - buildPolicyBundle: maps the legacy agent-wide judgeModel onto judges
  *   - set/clear: clear removes the agent's policy
  *   - policyHash: stable between calls for same input
- *   - policyHash: changes when extraPolicy changes (cache key discipline)
  */
 
+import type { AgentInlineGuardrail } from "@lobu/core";
 import { describe, expect, test } from "bun:test";
 import {
   buildPolicyBundle,
+  egressGuardrailsToPolicyBundle,
   PolicyStore,
 } from "../policy-store.js";
 
@@ -179,35 +180,32 @@ describe("PolicyStore — policyHash", () => {
     expect(h1).toBe(h2);
   });
 
-  test("policyHash differs when extraPolicy changes", () => {
+  test("policyHash differs when the judge policy text changes", () => {
     const store = new PolicyStore();
     store.set("org-1", "agent-1", {
       judgedDomains: [{ domain: "api.example.com" }],
-      judges: { default: "Base policy." },
-      extraPolicy: "Extra A.",
+      judges: { default: "Base policy A." },
     });
     const hashA = store.resolve("org-1", "agent-1", "api.example.com")!.policyHash;
 
     store.set("org-1", "agent-1", {
       judgedDomains: [{ domain: "api.example.com" }],
-      judges: { default: "Base policy." },
-      extraPolicy: "Extra B.",
+      judges: { default: "Base policy B." },
     });
     const hashB = store.resolve("org-1", "agent-1", "api.example.com")!.policyHash;
 
     expect(hashA).not.toBe(hashB);
   });
 
-  test("extraPolicy is appended to composed policy text", () => {
+  test("resolve carries the per-judge model", () => {
     const store = new PolicyStore();
     store.set("org-1", "agent-1", {
       judgedDomains: [{ domain: "api.example.com" }],
       judges: { default: "Base policy." },
-      extraPolicy: "Additional constraint.",
+      judgeModels: { default: "model-x" },
     });
     const result = store.resolve("org-1", "agent-1", "api.example.com")!;
-    expect(result.policy).toContain("Base policy.");
-    expect(result.policy).toContain("Additional constraint.");
+    expect(result.judgeModel).toBe("model-x");
   });
 });
 
@@ -255,21 +253,99 @@ describe("buildPolicyBundle", () => {
     expect(bundle!.judgedDomains[0]!.domain).toBe("api.example.com");
   });
 
-  test("carries extraPolicy from egressConfig", () => {
-    const bundle = buildPolicyBundle({
-      judgedDomains: [{ domain: "api.example.com" }],
-      judges: { default: "Base." },
-      egressConfig: { extraPolicy: "Never leak tokens." },
-    });
-    expect(bundle!.extraPolicy).toBe("Never leak tokens.");
-  });
-
-  test("carries judgeModel from egressConfig", () => {
+  test("maps the legacy agent-wide judgeModel onto each named judge", () => {
     const bundle = buildPolicyBundle({
       judgedDomains: [{ domain: "api.example.com" }],
       judges: { default: "Base." },
       egressConfig: { judgeModel: "claude-haiku-4-5-20251001" },
     });
-    expect(bundle!.judgeModel).toBe("claude-haiku-4-5-20251001");
+    expect(bundle!.judgeModels?.default).toBe("claude-haiku-4-5-20251001");
+  });
+});
+
+// ─── egress-guardrail → policy-bundle equivalence (the safety net) ────────────
+//
+// Proves the NEW source (an `egress`-stage inline guardrail) resolves to the
+// SAME `ResolvedJudgeRule` the EgressJudge consumes as the LEGACY
+// `network.judged`/`judges`/`egressConfig` source did. Only the bundle SOURCE
+// changed; enforcement (PolicyStore.resolve → EgressJudge.decide) is untouched.
+
+describe("egressGuardrailsToPolicyBundle — equivalence with the legacy path", () => {
+  test("resolves identically to the old network.judged/judges/judgeModel path", () => {
+    const org = "org-eq";
+    const agent = "agent-eq";
+    const host = "api.github.com";
+
+    // NEW path: a single egress inline guardrail.
+    const guardrail: AgentInlineGuardrail = {
+      name: "repo",
+      enabled: true,
+      stage: "egress",
+      policy: "only github",
+      domains: [".github.com"],
+      model: "x",
+    };
+    const newBundle = egressGuardrailsToPolicyBundle([guardrail]);
+    expect(newBundle).toBeDefined();
+    const newStore = new PolicyStore();
+    newStore.set(org, agent, newBundle!);
+    const fromNew = newStore.resolve(org, agent, host);
+
+    // OLD path: the exact inputs the legacy source produced.
+    const oldBundle = buildPolicyBundle({
+      judgedDomains: [{ domain: ".github.com", judge: "repo" }],
+      judges: { repo: "only github" },
+      egressConfig: { judgeModel: "x" },
+    });
+    expect(oldBundle).toBeDefined();
+    // Same (org, agent) so the agent-scoped policyHash is comparable; separate
+    // store instance so the two bundles don't clobber one another.
+    const oldStore = new PolicyStore();
+    oldStore.set(org, agent, oldBundle!);
+    const fromOld = oldStore.resolve(org, agent, host);
+
+    expect(fromNew).toBeDefined();
+    expect(fromOld).toBeDefined();
+    // Behaviour-preserving for EgressJudge.decide: identical composed policy,
+    // cache-keying hash, judge name, and per-judge model.
+    expect(fromNew!.policy).toBe(fromOld!.policy);
+    expect(fromNew!.policyHash).toBe(fromOld!.policyHash);
+    expect(fromNew!.judgeName).toBe(fromOld!.judgeName);
+    expect(fromNew!.judgeModel).toBe(fromOld!.judgeModel);
+    expect(fromNew!.judgeModel).toBe("x");
+  });
+
+  test("returns undefined when no egress guardrail declares a domain", () => {
+    expect(egressGuardrailsToPolicyBundle([])).toBeUndefined();
+    expect(
+      egressGuardrailsToPolicyBundle([
+        {
+          name: "no-domains",
+          enabled: true,
+          stage: "egress",
+          policy: "p",
+          model: "m",
+        },
+      ])
+    ).toBeUndefined();
+    // Disabled / non-egress entries are ignored.
+    expect(
+      egressGuardrailsToPolicyBundle([
+        {
+          name: "disabled",
+          enabled: false,
+          stage: "egress",
+          policy: "p",
+          domains: [".github.com"],
+        },
+        {
+          name: "wrong-stage",
+          enabled: true,
+          stage: "pre-tool",
+          policy: "p",
+          tools: ["bash"],
+        },
+      ])
+    ).toBeUndefined();
   });
 });

--- a/packages/server/src/gateway/permissions/policy-store.ts
+++ b/packages/server/src/gateway/permissions/policy-store.ts
@@ -1,8 +1,20 @@
 import crypto from "node:crypto";
-import type { AgentEgressConfig, DomainJudgeRule } from "@lobu/core";
+import type { AgentInlineGuardrail } from "@lobu/core";
 import { createLogger, normalizeDomainPattern } from "@lobu/core";
 
 const logger = createLogger("policy-store");
+
+/**
+ * Per-domain rule that routes matching requests through a named egress judge.
+ * Internal to the egress policy plane (the public agent-facing surface is the
+ * `egress`-stage inline guardrail + its `domains` selector).
+ */
+interface JudgedDomainRule {
+  /** Domain pattern — exact or `.wildcard`, same format as allow/deny lists. */
+  domain: string;
+  /** Named judge policy key. */
+  judge?: string;
+}
 
 /**
  * Per-agent bundle of egress judge policies. Populated by the deployment
@@ -11,19 +23,18 @@ const logger = createLogger("policy-store");
  */
 interface JudgePolicyBundle {
   /** Domain rules that require a judge verdict. */
-  judgedDomains: DomainJudgeRule[];
-  /** Named judge policy texts. Key "default" is used when a rule omits `judge`. */
+  judgedDomains: JudgedDomainRule[];
+  /** Named judge policy texts. */
   judges: Record<string, string>;
-  /** Operator policy appended to every judge prompt. */
-  extraPolicy?: string;
-  /** Optional judge model override. */
-  judgeModel?: string;
+  /** Optional per-judge model override, keyed by judge name. */
+  judgeModels?: Record<string, string>;
 }
 
 /**
  * Resolved judge rule data returned by {@link PolicyStore.resolve}.
- * `policy` is the composed policy text (skill's selected judge + agent's
- * extra policy), `policyHash` keys the verdict cache.
+ * `policy` is the composed policy text, `policyHash` keys the verdict cache,
+ * and `judgeModel` is the per-judge model (undefined falls back to the
+ * gateway default in the {@link EgressJudge}/JudgeRunner downstream).
  */
 export interface ResolvedJudgeRule {
   judgeName: string;
@@ -35,12 +46,12 @@ export interface ResolvedJudgeRule {
 interface PreparedJudge {
   policy: string;
   policyHash: string;
+  model?: string;
 }
 
 interface PreparedBundle {
-  judgedDomains: DomainJudgeRule[];
+  judgedDomains: JudgedDomainRule[];
   preparedJudges: Record<string, PreparedJudge>;
-  judgeModel?: string;
 }
 
 /**
@@ -74,7 +85,6 @@ export class PolicyStore {
       agentId,
       domains: prepared.judgedDomains.length,
       judges: Object.keys(prepared.preparedJudges).length,
-      hasExtraPolicy: !!bundle.extraPolicy,
     });
   }
 
@@ -119,25 +129,65 @@ export class PolicyStore {
       judgeName,
       policy: judge.policy,
       policyHash: judge.policyHash,
-      judgeModel: prepared.judgeModel,
+      judgeModel: judge.model,
     };
   }
 }
 
 /**
- * Build a {@link JudgePolicyBundle} from the pieces the deployment manager
- * already holds. Returns `undefined` when the agent has no judged-domain
- * rules (common case — no need to occupy a map slot).
+ * Translate an agent's `egress`-stage inline guardrails into a
+ * {@link JudgePolicyBundle}. Each enabled egress guardrail becomes a named
+ * judge (`judges[g.name] = { policy: g.policy, model: g.model }`) and routes
+ * every hostname in its `domains` selector through that judge. Returns
+ * `undefined` when no egress guardrail declares any domain (common case — no
+ * need to occupy a map slot).
+ *
+ * This is the sole production path into the policy store; it produces the same
+ * bundle shape the legacy `network.judged`/`judges`/`egressConfig` path did
+ * (see {@link buildPolicyBundle}, kept as the equivalence-test oracle).
  */
-export function buildPolicyBundle(input: {
-  judgedDomains?: DomainJudgeRule[];
-  judges?: Record<string, string>;
-  egressConfig?: AgentEgressConfig;
-}): JudgePolicyBundle | undefined {
+export function egressGuardrailsToPolicyBundle(
+  guardrails: AgentInlineGuardrail[]
+): JudgePolicyBundle | undefined {
   // Normalize first, then dedupe by normalized domain. Equivalent rules
   // (e.g. `*.slack.com` and `.slack.com`, or case variants) collapse to one;
-  // last declaration wins so operator-level rules can override skill-level.
-  const dedupedByDomain = new Map<string, DomainJudgeRule>();
+  // last declaration wins, matching the legacy path.
+  const dedupedByDomain = new Map<string, JudgedDomainRule>();
+  const judges: Record<string, string> = {};
+  const judgeModels: Record<string, string> = {};
+  for (const g of guardrails) {
+    if (!g.enabled || g.stage !== "egress") continue;
+    if (typeof g.policy !== "string" || g.policy.trim() === "") continue;
+    judges[g.name] = g.policy;
+    if (g.model) judgeModels[g.name] = g.model;
+    for (const domain of g.domains ?? []) {
+      if (!domain) continue;
+      const normalized = normalizeDomainPattern(domain);
+      dedupedByDomain.set(normalized, { domain: normalized, judge: g.name });
+    }
+  }
+  const judgedDomains = Array.from(dedupedByDomain.values());
+  if (judgedDomains.length === 0) return undefined;
+  return {
+    judgedDomains,
+    judges,
+    ...(Object.keys(judgeModels).length > 0 ? { judgeModels } : {}),
+  };
+}
+
+/**
+ * Reference (oracle) builder for the LEGACY `network.judged`/`judges`/
+ * `egressConfig` source. No longer wired into production — kept so the
+ * equivalence test can prove {@link egressGuardrailsToPolicyBundle} resolves
+ * identically to the path it replaced. The legacy agent-wide `judgeModel` maps
+ * onto every named judge.
+ */
+export function buildPolicyBundle(input: {
+  judgedDomains?: JudgedDomainRule[];
+  judges?: Record<string, string>;
+  egressConfig?: { judgeModel?: string };
+}): JudgePolicyBundle | undefined {
+  const dedupedByDomain = new Map<string, JudgedDomainRule>();
   for (const r of input.judgedDomains ?? []) {
     if (!r?.domain) continue;
     const normalized = normalizeDomainPattern(r.domain);
@@ -147,20 +197,20 @@ export function buildPolicyBundle(input: {
     });
   }
   const judgedDomains = Array.from(dedupedByDomain.values());
-
   if (judgedDomains.length === 0) return undefined;
 
-  const bundle: JudgePolicyBundle = {
-    judgedDomains,
-    judges: input.judges ?? {},
-  };
-  if (input.egressConfig?.extraPolicy) {
-    bundle.extraPolicy = input.egressConfig.extraPolicy;
-  }
+  const judges = { ...(input.judges ?? {}) };
+  const judgeModels: Record<string, string> = {};
   if (input.egressConfig?.judgeModel) {
-    bundle.judgeModel = input.egressConfig.judgeModel;
+    for (const name of Object.keys(judges)) {
+      judgeModels[name] = input.egressConfig.judgeModel;
+    }
   }
-  return bundle;
+  return {
+    judgedDomains,
+    judges,
+    ...(Object.keys(judgeModels).length > 0 ? { judgeModels } : {}),
+  };
 }
 
 function prepareBundle(
@@ -170,25 +220,24 @@ function prepareBundle(
 ): PreparedBundle {
   const preparedJudges: Record<string, PreparedJudge> = {};
   for (const [name, rawPolicy] of Object.entries(bundle.judges)) {
-    const composed = bundle.extraPolicy
-      ? `${rawPolicy.trim()}\n\nAdditional operator policy:\n${bundle.extraPolicy.trim()}`
-      : rawPolicy.trim();
+    const composed = rawPolicy.trim();
+    const model = bundle.judgeModels?.[name];
     preparedJudges[name] = {
       policy: composed,
       policyHash: hashPolicy(organizationId, agentId, name, composed),
+      ...(model ? { model } : {}),
     };
   }
   return {
     judgedDomains: bundle.judgedDomains,
     preparedJudges,
-    ...(bundle.judgeModel ? { judgeModel: bundle.judgeModel } : {}),
   };
 }
 
 function findMatchingRule(
   hostname: string,
-  rules: DomainJudgeRule[]
-): DomainJudgeRule | undefined {
+  rules: JudgedDomainRule[]
+): JudgedDomainRule | undefined {
   const normalized = hostname.toLowerCase();
 
   const exact = rules.find(

--- a/packages/server/src/gateway/proxy/http-proxy.ts
+++ b/packages/server/src/gateway/proxy/http-proxy.ts
@@ -13,6 +13,7 @@ import {
 } from "../config/network-allowlist.js";
 import type { RevokedTokenStore } from "../auth/revoked-token-store.js";
 import { getRevokedTokenStore } from "../auth/revoked-token-store.js";
+import { recordGuardrailTrip } from "../guardrails/audit.js";
 import type { GrantStore } from "../permissions/grant-store.js";
 import type { PolicyStore } from "../permissions/policy-store.js";
 import { EgressJudge } from "./egress-judge/judge.js";
@@ -211,8 +212,29 @@ async function checkDomainAccess(
         },
         rule
       );
+      const allowed = decision.verdict === "allow";
+      if (!allowed) {
+        // Egress denials share the guardrail audit trail: a judge DENY writes a
+        // `guardrail-trip` event (stage `egress`) just like message-pipeline
+        // guardrails. Enforcement stays here in the proxy — this is audit only.
+        // Fire-and-forget: `recordGuardrailTrip` never rejects, so we don't
+        // await it on the egress hot path. `agentId`/`organizationId` are both
+        // guaranteed present by the enclosing guard.
+        void recordGuardrailTrip({
+          organizationId,
+          agentId,
+          stage: "egress",
+          guardrail: decision.judgeName,
+          reason: decision.reason,
+          metadata: {
+            hostname,
+            verdict: decision.verdict,
+            judgeSource: decision.source,
+          },
+        });
+      }
       return {
-        allowed: decision.verdict === "allow",
+        allowed,
         source: "judge",
         judge: decision,
       };

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1518,6 +1518,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
 
       const {
         networkConfig: settingsNetwork,
+        guardrailsInline: settingsGuardrailsInline,
         mcpServers: settingsMcpServers,
         ...remainingOptions
       } = agentOptions;
@@ -1588,6 +1589,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         },
         agentOptions: remainingOptions,
         networkConfig: session.networkConfig || settingsNetwork,
+        guardrailsInline: settingsGuardrailsInline,
         mcpConfig: settingsMcpServers
           ? { mcpServers: settingsMcpServers }
           : session.mcpConfig,

--- a/packages/server/src/gateway/services/platform-helpers.ts
+++ b/packages/server/src/gateway/services/platform-helpers.ts
@@ -149,8 +149,8 @@ export async function resolveAgentOptions(
   if (settings.networkConfig) {
     mergedOptions.networkConfig = settings.networkConfig;
   }
-  if (settings.egressConfig) {
-    mergedOptions.egressConfig = settings.egressConfig;
+  if (settings.guardrailsInline?.length) {
+    mergedOptions.guardrailsInline = settings.guardrailsInline;
   }
   if (settings.nixConfig) {
     mergedOptions.nixConfig = settings.nixConfig;
@@ -184,8 +184,8 @@ export async function resolveAgentOptions(
 
 /**
  * Build a MessagePayload from common fields.
- * Extracts networkConfig, nixConfig, mcpServers, preApprovedTools from
- * agentOptions before constructing the payload.
+ * Extracts networkConfig, guardrailsInline, nixConfig, mcpServers,
+ * preApprovedTools from agentOptions before constructing the payload.
  */
 export function buildMessagePayload(params: {
   platform: string;
@@ -203,7 +203,7 @@ export function buildMessagePayload(params: {
 }): MessagePayload {
   const {
     networkConfig,
-    egressConfig,
+    guardrailsInline,
     nixConfig,
     mcpServers,
     preApprovedTools,
@@ -224,7 +224,7 @@ export function buildMessagePayload(params: {
     platformMetadata: params.platformMetadata,
     agentOptions: remainingOptions,
     networkConfig,
-    egressConfig,
+    guardrailsInline,
     nixConfig,
     mcpConfig: mcpServers ? { mcpServers } : undefined,
     preApprovedTools,

--- a/packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts
@@ -83,4 +83,33 @@ describe('validateGuardrailsInline', () => {
       ])
     ).toMatch(/tools must be an array of strings/);
   });
+
+  test('accepts an egress guardrail with a domains selector (round-trip)', () => {
+    expect(
+      validateGuardrailsInline([
+        {
+          name: 'egress-github',
+          enabled: true,
+          stage: 'egress',
+          policy: 'only allow github reads',
+          model: 'anthropic/claude-haiku-4-5',
+          domains: ['.github.com', 'api.github.com'],
+        },
+      ])
+    ).toBeNull();
+  });
+
+  test('rejects domains that are not a string array', () => {
+    expect(
+      validateGuardrailsInline([
+        {
+          name: 'g',
+          enabled: true,
+          stage: 'egress',
+          policy: 'x',
+          domains: [1],
+        },
+      ])
+    ).toMatch(/domains must be an array of strings/);
+  });
 });

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -740,7 +740,7 @@ routes.put('/:agentId/providers/:providerId/api-key', async (c) => {
 
 // ── Update agent config (settings) ───────────────────────────────────────────
 
-const GUARDRAIL_STAGES = new Set(['input', 'output', 'pre-tool']);
+const GUARDRAIL_STAGES = new Set(['input', 'output', 'pre-tool', 'egress']);
 
 /**
  * Validate a `guardrailsInline` payload before it is persisted to agent
@@ -765,7 +765,7 @@ export function validateGuardrailsInline(value: unknown): string | null {
       return `guardrailsInline[${i}].enabled must be a boolean`;
     }
     if (typeof g.stage !== 'string' || !GUARDRAIL_STAGES.has(g.stage)) {
-      return `guardrailsInline[${i}].stage must be one of: input, output, pre-tool`;
+      return `guardrailsInline[${i}].stage must be one of: input, output, pre-tool, egress`;
     }
     if (typeof g.policy !== 'string' || g.policy.trim() === '') {
       return `guardrailsInline[${i}].policy must be a non-empty string`;
@@ -778,6 +778,13 @@ export function validateGuardrailsInline(value: unknown): string | null {
       (!Array.isArray(g.tools) || g.tools.some((t) => typeof t !== 'string'))
     ) {
       return `guardrailsInline[${i}].tools must be an array of strings`;
+    }
+    if (
+      g.domains !== undefined &&
+      (!Array.isArray(g.domains) ||
+        g.domains.some((d) => typeof d !== 'string'))
+    ) {
+      return `guardrailsInline[${i}].domains must be an array of strings`;
     }
   }
   return null;

--- a/packages/server/src/lobu/stores/__tests__/postgres-agent-config-store.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/postgres-agent-config-store.test.ts
@@ -1,10 +1,9 @@
 /**
  * PostgresAgentConfigStore round-trip tests.
  *
- * Pins the persistence of three settings fields the file-loader produces from
- * lobu.config.ts — egressConfig, preApprovedTools, guardrails — that previously
- * had no columns in the agents table and were silently dropped on every
- * saveSettings(). PR-1 of `docs/plans/lobu-apply.md`.
+ * Pins the persistence of three settings fields — guardrailsInline,
+ * preApprovedTools, guardrails — that previously had no columns in the agents
+ * table and were silently dropped on every saveSettings().
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -36,16 +35,22 @@ describe('PostgresAgentConfigStore — apply-fields round-trip', () => {
     await db`TRUNCATE agents CASCADE`;
   });
 
-  it('round-trips egressConfig, preApprovedTools, and guardrails when populated', async () => {
+  it('round-trips guardrailsInline, preApprovedTools, and guardrails when populated', async () => {
     const store = createPostgresAgentConfigStore();
     const now = Date.now();
 
     await orgContext.run({ organizationId: orgId }, async () => {
       await store.saveSettings(agentId, {
-        egressConfig: {
-          extraPolicy: 'Never exfiltrate PATs or bearer tokens.',
-          judgeModel: 'claude-haiku-4-5-20251001',
-        },
+        guardrailsInline: [
+          {
+            name: 'egress-github',
+            enabled: true,
+            stage: 'egress',
+            policy: 'Never exfiltrate PATs or bearer tokens.',
+            model: 'claude-haiku-4-5-20251001',
+            domains: ['.github.com'],
+          },
+        ],
         preApprovedTools: [
           '/mcp/gmail/tools/send_email',
           '/mcp/linear/tools/*',
@@ -56,10 +61,16 @@ describe('PostgresAgentConfigStore — apply-fields round-trip', () => {
 
       const loaded = await store.getSettings(agentId);
       expect(loaded).not.toBeNull();
-      expect(loaded?.egressConfig).toEqual({
-        extraPolicy: 'Never exfiltrate PATs or bearer tokens.',
-        judgeModel: 'claude-haiku-4-5-20251001',
-      });
+      expect(loaded?.guardrailsInline).toEqual([
+        {
+          name: 'egress-github',
+          enabled: true,
+          stage: 'egress',
+          policy: 'Never exfiltrate PATs or bearer tokens.',
+          model: 'claude-haiku-4-5-20251001',
+          domains: ['.github.com'],
+        },
+      ]);
       expect(loaded?.preApprovedTools).toEqual([
         '/mcp/gmail/tools/send_email',
         '/mcp/linear/tools/*',
@@ -78,9 +89,9 @@ describe('PostgresAgentConfigStore — apply-fields round-trip', () => {
 
       const loaded = await store.getSettings(agentId);
       expect(loaded).not.toBeNull();
-      // saveSettings coerces undefined -> default ({} / []), so getSettings
+      // saveSettings coerces undefined -> default ([] ), so getSettings
       // sees the defaults rather than raw NULL. Assert exactly that contract.
-      expect(loaded?.egressConfig).toEqual({});
+      expect(loaded?.guardrailsInline).toEqual([]);
       expect(loaded?.preApprovedTools).toEqual([]);
       expect(loaded?.guardrails).toEqual([]);
     });
@@ -92,7 +103,16 @@ describe('PostgresAgentConfigStore — apply-fields round-trip', () => {
 
     await orgContext.run({ organizationId: orgId }, async () => {
       await store.saveSettings(agentId, {
-        egressConfig: { extraPolicy: 'noop', judgeModel: 'm' },
+        guardrailsInline: [
+          {
+            name: 'g',
+            enabled: true,
+            stage: 'egress',
+            policy: 'noop',
+            model: 'm',
+            domains: ['x.com'],
+          },
+        ],
         preApprovedTools: ['/mcp/x/tools/y'],
         guardrails: ['g1'],
         updatedAt: now,
@@ -102,7 +122,7 @@ describe('PostgresAgentConfigStore — apply-fields round-trip', () => {
 
       const loaded = await store.getSettings(agentId);
       expect(loaded).not.toBeNull();
-      expect(loaded?.egressConfig).toEqual({});
+      expect(loaded?.guardrailsInline).toEqual([]);
       expect(loaded?.preApprovedTools).toEqual([]);
       expect(loaded?.guardrails).toEqual([]);
     });

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -50,7 +50,6 @@ function rowToSettings(row: Record<string, any>): AgentSettings {
 		modelSelection: row.model_selection ?? undefined,
 		providerModelPreferences: row.provider_model_preferences ?? undefined,
 		networkConfig: row.network_config ?? undefined,
-		egressConfig: row.egress_config ?? undefined,
 		nixConfig: row.nix_config ?? undefined,
 		mcpServers: row.mcp_servers ?? undefined,
 		soulMd: row.soul_md ?? undefined,
@@ -139,7 +138,7 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			const rows = orgId
 				? await sql`
             SELECT model, model_selection, provider_model_preferences,
-                   network_config, egress_config, nix_config, mcp_servers,
+                   network_config, nix_config, mcp_servers,
                    soul_md, user_md, identity_md,
                    skills_config, tools_config, plugins_config,
                    installed_providers, verbose_logging, show_tool_calls,
@@ -149,7 +148,7 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
           `
 				: await sql`
             SELECT model, model_selection, provider_model_preferences,
-                   network_config, egress_config, nix_config, mcp_servers,
+                   network_config, nix_config, mcp_servers,
                    soul_md, user_md, identity_md,
                    skills_config, tools_config, plugins_config,
                    installed_providers, verbose_logging, show_tool_calls,
@@ -170,7 +169,6 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
           model_selection = ${sql.json(settings.modelSelection ?? {})},
           provider_model_preferences = ${sql.json(settings.providerModelPreferences ?? {})},
           network_config = ${sql.json(settings.networkConfig ?? {})},
-          egress_config = ${sql.json(settings.egressConfig ?? {})},
           nix_config = ${sql.json(settings.nixConfig ?? {})},
           mcp_servers = ${sql.json(settings.mcpServers ?? {})},
           soul_md = ${settings.soulMd ?? ""},
@@ -204,7 +202,7 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			await sql`
         UPDATE agents SET
           model = NULL, model_selection = '{}', provider_model_preferences = '{}',
-          network_config = '{}', egress_config = '{}', nix_config = '{}',
+          network_config = '{}', nix_config = '{}',
           mcp_servers = '{}',
           soul_md = '', user_md = '', identity_md = '',
           skills_config = '{"skills": []}', tools_config = '{}', plugins_config = '{}',


### PR DESCRIPTION
## What & why

Collapses three overlapping config surfaces into the agent's three real concepts: **skills** (behavior), **connections** (external reach + tools), **guardrails** (policy).

### 1. Skills are prompt/behavior only
Removes skill-level `mcpServers` and `networkConfig`. Remote MCP servers are already added as connections (`installConnectorFromMcpUrl`), so the skill path was redundant; network policy isn't a skill capability. Agent-level config is untouched.

### 2. Egress judge is a guardrail, not a network setting
The LLM egress judge becomes an `egress`-stage entry in `guardrailsInline` with a `domains` selector — the egress parallel to pre-tool's `tools` selector. Its denials ride the same `guardrail-trip` audit trail as input/output/pre-tool guardrails, and it's authored in the guardrails UI. The judge config leaves the agent `network`/`egress` surface entirely (`AgentEgressConfig`, `DomainJudgeRule`, `network.judged/judges`, CLI `egress`/`network.judged` all removed).

## Enforcement is byte-unchanged
`http-proxy`, `egress-judge/`, and `proxy-manager` have an empty diff. Only the *source* of the policy bundle moved: `deployment-manager` now translates egress inline guardrails into the existing bundle shape via `egressGuardrailsToPolicyBundle`, so `policy-store.resolve` / `EgressJudge` stay identical. An equivalence test proves an egress guardrail resolves to the same `policy`/`policyHash`/`judgeName`/`judgeModel` as the legacy `network.judged` path. Per-judge model replaces the old agent-wide `judgeModel`; agent-wide `extraPolicy` is dropped (folded into each guardrail's self-contained policy).

## Commits
- `refactor(skills)` — remove mcpServers + networkConfig from skills
- `feat(guardrails)` — egress stage + judge denials on the guardrail-trip audit trail
- `feat(guardrails)` — unify egress judge into the inline-guardrail model
- `chore(owletto)` — pointer bump (owletto branch `feat/consolidate-skill-network-mcp`)

## Verification
- `make review`: typecheck 0, unit 0, no bugs in any changed file, tests_adequate. (The one pi blocker is a migration from #1580, already merged — outside this diff; integration failures are in untouched watcher/github-app/identity paths.)
- Red-green: equivalence test (egress guardrail ≡ legacy path), validation round-trip, egress `guardrail-trip` audit.

## Owed before merge
- Live egress e2e (UI + API + judge gating) with recording — in progress.
- Follow-ups: `DROP COLUMN egress_config` contract migration; optional CLI inline-guardrail authoring for code-first parity.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785257191&installation_id=136316292&pr_number=1592&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1592&signature=8a7d2b3f79985371ca8fbe7fc10a49b08f9813b82f17e4759a70ed29b09fd6ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for **egress** guardrails with **domain selectors** and **per-judge model** selection via inline guardrails.
  * Inline guardrails are now propagated through message handling for egress policy enforcement.
* **Bug Fixes**
  * When an egress judge denies access, the system now records an **egress guardrail audit event** for easier troubleshooting.
* **Chores**
  * Updated CLI and server outputs/settings to remove legacy skill/network/MCP contributions and egress judge config; installed skill details now expose only nix packages (not network/MCP).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->