### PR TITLE
chore(db): drop dead agents.egress_config column (contract phase)

### DIFF
--- a/db/migrations/20260630000030_drop_agents_egress_config.sql
+++ b/db/migrations/20260630000030_drop_agents_egress_config.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+
+-- Contract phase of the egress-judge consolidation. PR #1592 moved the LLM
+-- egress judge into inline guardrails (agents.guardrails_inline entries with
+-- stage='egress' and a domains selector), leaving agents.egress_config
+-- write-dead. Production was checked before this migration was created:
+--   SELECT count(*) FROM agents WHERE egress_config <> '{}'::jsonb;
+-- returned 0, so no live legacy policy data is being discarded.
+--
+-- Safe after #1592 is deployed to every app replica: pre-#1592 pods wrote this
+-- column on agent-settings saves, so this must remain a post-deploy contract
+-- migration. DROP COLUMN is an O(1) catalog change with a brief ACCESS
+-- EXCLUSIVE lock; IF EXISTS keeps local/embedded replays idempotent.
+
+ALTER TABLE public.agents DROP COLUMN IF EXISTS egress_config;
+
+-- migrate:down
+
+-- Rollback-only path (dev): restore the original baseline column shape. Dropped
+-- data is not recoverable because the column was write-dead before removal.
+ALTER TABLE public.agents ADD COLUMN IF NOT EXISTS egress_config jsonb DEFAULT '{}'::jsonb;


### PR DESCRIPTION
Phase 2 (contract) of the egress-judge consolidation. Drops `public.agents.egress_config`, which #1592 made write-dead (the egress judge moved into the inline-guardrail model).

```sql
ALTER TABLE public.agents DROP COLUMN IF EXISTS egress_config;
```

## Merge/deploy safety

#1592 has been deployed past the expand phase; current prod app replicas are running a post-#1592 image (`ghcr.io/lobu-ai/lobu-app:20260630-142048`, 2/2 ready at check time), so old pods that wrote `egress_config` are no longer live.

Production legacy-data check before updating this PR:

```sql
SELECT count(*) FROM agents WHERE egress_config <> '{}'::jsonb;
-- 0
```

So no non-empty legacy egress policy data is being discarded.

## Safety

- Fresh migration timestamp (`20260630000030`) after current latest migrations, so schema-version gating sees it as the new expected contract.
- `IF EXISTS` → idempotent/re-runnable.
- Plain `jsonb` column, no index/constraint, and current production code no longer reads/writes it.
- Drop is an O(1) catalog change with a brief ACCESS EXCLUSIVE lock, no table rewrite.
- squawk clean (`--exclude=ban-drop-column,require-timeout-settings`): 0 issues.

## Verification

- `bun test packages/server/src/utils/__tests__/migrations-format.test.ts`
- `npx --yes squawk-cli@2.58.0 --exclude=ban-drop-column,require-timeout-settings db/migrations/20260630000030_drop_agents_egress_config.sql`
- pre-commit hook: Biome + `tsc --noEmit`
