### PR TITLE
fix: require explicit org selection when pairing a multi-org device (+owletto)

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -1006,6 +1006,68 @@ describe('MCP Authentication', () => {
       expect(body.error).toBe('access_denied');
     });
 
+    it('forces org selection on the device flow even when the user has a personal org', async () => {
+      // A multi-org user WITH a personal org used to be silently bound to that
+      // personal org (no picker), which landed the device in the wrong
+      // workspace. Device pairing must now require an explicit pick.
+      const sql = getTestDb();
+      const pUser = await createTestUser({});
+      const personalOrg = await createTestOrganization({ name: 'Personal Org (device)' });
+      await addUserToOrganization(pUser.id, personalOrg.id);
+      // organization.metadata is text storing JSON (see findExistingPersonalOrg).
+      await sql`
+        UPDATE "organization"
+        SET metadata = ${JSON.stringify({ personal_org_for_user_id: pUser.id })}
+        WHERE id = ${personalOrg.id}
+      `;
+      const otherOrg = await createTestOrganization({ name: 'Other Org (device)' });
+      await addUserToOrganization(pUser.id, otherOrg.id);
+
+      const pSession = await createTestSession(pUser.id);
+      const dc = await createTestDeviceCode(deviceClient.client_id);
+
+      const response = await post('/oauth/device/approve', {
+        body: { user_code: dc.userCode, approved: true },
+        cookie: pSession.cookieHeader,
+        headers: { Origin: 'http://localhost' },
+      });
+
+      const body = await response.json();
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('org_selection_required');
+      const ids = (body.organizations as { id: string }[]).map((o) => o.id);
+      expect(ids).toContain(personalOrg.id);
+      expect(ids).toContain(otherOrg.id);
+    });
+
+    it('still approves with an explicit organization_id when the user has a personal org', async () => {
+      // The override path stays intact — an explicit pick binds the device to it.
+      const sql = getTestDb();
+      const pUser = await createTestUser({});
+      const personalOrg = await createTestOrganization({ name: 'Personal Org (device override)' });
+      await addUserToOrganization(pUser.id, personalOrg.id);
+      await sql`
+        UPDATE "organization"
+        SET metadata = ${JSON.stringify({ personal_org_for_user_id: pUser.id })}
+        WHERE id = ${personalOrg.id}
+      `;
+      const otherOrg = await createTestOrganization({ name: 'Other Org (device override)' });
+      await addUserToOrganization(pUser.id, otherOrg.id);
+
+      const pSession = await createTestSession(pUser.id);
+      const dc = await createTestDeviceCode(deviceClient.client_id);
+
+      const response = await post('/oauth/device/approve', {
+        body: { user_code: dc.userCode, approved: true, organization_id: otherOrg.id },
+        cookie: pSession.cookieHeader,
+        headers: { Origin: 'http://localhost' },
+      });
+
+      const body = await response.json();
+      expect(response.status).toBe(200);
+      expect(body.status).toBe('approved');
+    });
+
     it('attaches a polling device worker to the org its token was approved for', async () => {
       const dc = await createTestDeviceCode(deviceClient.client_id);
 

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -119,8 +119,13 @@ async function resolveOrganizationForGrant(params: {
   userId: string;
   resourceOrgSlug: string | null;
   explicitOrgId: string | undefined;
+  // When true, a user who belongs to more than one org and didn't pass an
+  // explicit org (or resource slug) must pick one — we do NOT silently bind to
+  // their personal org. Used by the first-party device-pairing flow, where a
+  // silent personal-org default landed the device in the wrong workspace.
+  forceSelectionForMultiOrg?: boolean;
 }): Promise<OrgResolutionResult> {
-  const { sql, userId, resourceOrgSlug, explicitOrgId } = params;
+  const { sql, userId, resourceOrgSlug, explicitOrgId, forceSelectionForMultiOrg } = params;
 
   const lookupOrgAccess = async (column: 'slug' | 'id', value: string) => {
     if (column === 'slug') {
@@ -204,6 +209,21 @@ async function resolveOrganizationForGrant(params: {
     return {
       error: createOAuthError('access_denied', 'No organization membership found for MCP scopes'),
       status: 403,
+    };
+  }
+
+  // First-party device pairing: a multi-org user MUST choose explicitly. Skip
+  // the personal-org default below so the device can't be silently bound to the
+  // wrong workspace. Single-org users (length === 1) have no ambiguity and fall
+  // through to the normal resolution.
+  if (forceSelectionForMultiOrg && memberships.length > 1) {
+    return {
+      orgSelectionRequired: true,
+      organizations: memberships.map((m) => ({
+        id: m.organization_id,
+        name: m.name,
+        slug: m.slug,
+      })),
     };
   }
 
@@ -892,6 +912,9 @@ oauthRoutes.post('/oauth/device/approve', requireAuth, async (c) => {
       userId: user.id,
       resourceOrgSlug: getOrgSlugFromResource(deviceCode.resource),
       explicitOrgId: body.organization_id,
+      // Device pairing must not silently default a multi-org user's device to
+      // their personal org — require an explicit pick.
+      forceSelectionForMultiOrg: true,
     });
     if ('error' in orgResult) {
       return c.json(orgResult.error, orgResult.status as 400);


### PR DESCRIPTION
## Problem

A multi-org user pairing the Owletto Chrome extension (or any OAuth device flow) could be silently bound to the **wrong workspace**. `/oauth/device/approve` resolves the new worker's org via `resolveOrganizationForGrant`, which — when no org is passed — silently defaults a multi-org user to their **personal** org. Combined with the consent UI pre-filling that same personal org, the device landed in the personal org while the intended org (e.g. `buremba`) saw no device ("Device not found" / "no online paired extension").

## Fix (server)

Add `forceSelectionForMultiOrg` to `resolveOrganizationForGrant` and set it on the **device-approve** path: a user in >1 org with no explicit org now gets `org_selection_required` instead of the silent personal-org default. The device consent page already renders the workspace picker and handles that response. Single-org users and the `resource`-slug (`/mcp/<slug>`) path are unchanged; the MCP **authorization-code** path keeps its personal-org default (claude.ai/Cursor compatibility).

## Fix (owletto submodule, #375, merged)

`useOrgPreselect` no longer auto-selects the personal org for multi-org users — it leaves the choice empty so the consent/device pages keep Approve disabled until the user consciously picks. Pointer bumped to `c4930f5`.

## Validation

- `make typecheck` clean (server + owletto), after merging `main`.
- MCP auth integration suite: **39 passing** (2 new: force selection despite a personal org; explicit org still approves).
- owletto: `use-org-preselect.test.tsx` 3 passing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785260026&installation_id=136316292&pr_number=1594&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1594&signature=0ed72471d213d8e8e12bb07c1c39ed89b688cbf78e23403d86ee7f6bd459e5bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->