### PR TITLE
feat: agent UX consolidation + cross-platform conversations (server + owletto)

### DIFF
--- a/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
+++ b/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
@@ -1,0 +1,202 @@
+/**
+ * `listAgentThreads({ scope: "all" })` — the cross-platform activity feed.
+ *
+ * Verifies that scope=all surfaces, for one agent in one org:
+ *   - the requesting user's own WEB threads (platform "web"),
+ *   - PLATFORM conversations (e.g. `slack:…`) tagged with the derived platform,
+ *   - one WATCHER entry per watcher (platform "watcher", carrying watcherId),
+ * sorted newest-first — and that a watcher's per-run snapshot never leaks in as
+ * its own platform row. Also drives the two read endpoints the feed links to:
+ * readConversationMessages (platform, by raw id) and readWatcherRunThreads.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+	listAgentThreads,
+	readConversationMessages,
+} from "../../gateway/services/agent-thread-list";
+import { buildApiConversationId } from "../../gateway/services/api-conversation-id";
+import { readWatcherRunThreads } from "../../gateway/services/watcher-run-thread";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	createTestAgent,
+	createTestOrganization,
+	createTestUser,
+} from "../setup/test-fixtures";
+
+const AGENT = "thread-list-scope-all-agent";
+const SLACK_CONV = "slack:C123:1781641725.28"; // channel C123 — agent is bound to it
+const SLACK_UNBOUND_CONV = "slack:CSECRET:1781641725.99"; // channel the agent is NOT bound to
+const WATCHER_ID = 990001;
+
+function sessionJsonl(text: string): string {
+	return [
+		JSON.stringify({
+			type: "session",
+			version: 3,
+			id: "s",
+			timestamp: "2026-06-28T00:00:00Z",
+			cwd: "/w",
+		}),
+		JSON.stringify({
+			type: "message",
+			id: "u1",
+			parentId: null,
+			timestamp: "2026-06-28T00:00:01Z",
+			message: { role: "user", content: [{ type: "text", text }] },
+		}),
+	].join("\n");
+}
+
+describe("listAgentThreads scope=all", () => {
+	let org: string;
+	let userId: string;
+
+	beforeAll(async () => {
+		org = (await createTestOrganization()).id;
+		userId = (await createTestUser()).id;
+		await createTestAgent({
+			organizationId: org,
+			agentId: AGENT,
+			ownerUserId: userId,
+		});
+		const sql = getTestDb();
+
+		const insertSnapshot = async (
+			conversationId: string,
+			text: string,
+			at: string,
+		) => {
+			const [run] = await sql<{ id: number }[]>`
+        INSERT INTO runs (run_type, status, organization_id, created_at, completed_at, run_at)
+        VALUES ('chat_message', 'completed', ${org}, ${at}, ${at}, ${at})
+        RETURNING id`;
+			const jsonl = sessionJsonl(text);
+			await sql`
+        INSERT INTO agent_transcript_snapshot
+          (organization_id, agent_id, conversation_id, run_id, snapshot_jsonl, byte_size, terminal_status, created_at)
+        VALUES (${org}, ${AGENT}, ${conversationId}, ${run.id}, ${jsonl}, ${Buffer.byteLength(jsonl)}, 'completed', ${at})`;
+		};
+
+		// The requesting user's own web thread.
+		await insertSnapshot(
+			buildApiConversationId({
+				agentId: AGENT,
+				userId,
+				organizationId: org,
+				threadId: "webthread",
+			}),
+			"hello from web",
+			"2026-06-28T01:00:00Z",
+		);
+		// The agent is bound to channel C123 (per-agent fence) — so its transcript
+		// is listable; CSECRET has no binding and must never surface.
+		const connId = `conn_${WATCHER_ID}`;
+		await sql`
+      INSERT INTO agent_connections (id, organization_id, agent_id, platform, status)
+      VALUES (${connId}, ${org}, ${AGENT}, 'slack', 'active')`;
+		await sql`
+      INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id)
+      VALUES (${org}, ${AGENT}, 'slack', 'slack:C123', 'T1')`;
+
+		// A bound Slack conversation (newest) + an UNBOUND one (must be filtered).
+		await insertSnapshot(SLACK_CONV, "hello from slack", "2026-06-28T02:00:00Z");
+		await insertSnapshot(
+			SLACK_UNBOUND_CONV,
+			"secret channel transcript",
+			"2026-06-28T03:00:00Z",
+		);
+		// A watcher + one of its run snapshots.
+		await sql`
+      INSERT INTO watchers
+        (id, organization_id, agent_id, created_by, watcher_group_id, name, status, notification_channel, notification_priority, min_cooldown_seconds, created_at, updated_at)
+      VALUES (${WATCHER_ID}, ${org}, ${AGENT}, ${userId}, 0, 'Test Watcher', 'active', 'notification', 'normal', 0, now(), now())`;
+		await insertSnapshot(
+			`${AGENT}_watcher_${WATCHER_ID}_run_5`,
+			"watcher run output",
+			"2026-06-28T00:30:00Z",
+		);
+	});
+
+	afterAll(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("returns web + platform + watcher entries with correct platforms, newest-first", async () => {
+		const threads = await listAgentThreads({
+			agentId: AGENT,
+			organizationId: org,
+			userId,
+			scope: "all",
+		});
+		const byPlatform = new Map(threads.map((t) => [t.platform, t]));
+
+		expect(byPlatform.get("web")?.id).toBe("webthread");
+
+		const slack = byPlatform.get("slack");
+		expect(slack?.id).toBe(SLACK_CONV);
+		expect(slack?.conversationId).toBe(SLACK_CONV);
+
+		const watcher = byPlatform.get("watcher");
+		expect(watcher?.watcherId).toBe(WATCHER_ID);
+		expect(watcher?.title).toBe("Test Watcher");
+
+		// Newest VISIBLE is the bound Slack channel at 02:00 — the unbound channel
+		// at 03:00 is fenced out, so it must not take the top slot (or any slot).
+		expect(threads[0]?.platform).toBe("slack");
+		expect(threads[0]?.id).toBe(SLACK_CONV);
+
+		// A watcher's per-run snapshot must NOT surface as its own platform row.
+		expect(threads.some((t) => t.id.includes("_watcher_"))).toBe(false);
+	});
+
+	it("fences out platform conversations on channels the agent isn't bound to", async () => {
+		const threads = await listAgentThreads({
+			agentId: AGENT,
+			organizationId: org,
+			userId,
+			scope: "all",
+		});
+		// CSECRET has no binding — its transcript must never be listed, even though
+		// it's the most recent snapshot.
+		expect(threads.some((t) => t.id === SLACK_UNBOUND_CONV)).toBe(false);
+		expect(threads.some((t) => t.conversationId === SLACK_UNBOUND_CONV)).toBe(
+			false,
+		);
+	});
+
+	it("scope=user (default) excludes platform + watcher conversations", async () => {
+		const threads = await listAgentThreads({
+			agentId: AGENT,
+			organizationId: org,
+			userId,
+			scope: "user",
+		});
+		expect(threads.every((t) => t.platform === "web")).toBe(true);
+		expect(threads.some((t) => t.id === "webthread")).toBe(true);
+	});
+
+	it("reads a platform conversation read-only by its raw id", async () => {
+		const data = await readConversationMessages({
+			agentId: AGENT,
+			organizationId: org,
+			conversationId: SLACK_CONV,
+			cursor: "",
+			limit: 200,
+		});
+		expect(JSON.stringify(data.messages)).toContain("hello from slack");
+	});
+
+	it("readWatcherRunThreads returns the watcher's runs", async () => {
+		const data = await readWatcherRunThreads({
+			agentId: AGENT,
+			organizationId: org,
+			watcherId: WATCHER_ID,
+			limit: 20,
+		});
+		expect(data.runs).toHaveLength(1);
+		expect(JSON.stringify(data.runs[0]?.messages)).toContain(
+			"watcher run output",
+		);
+	});
+});

--- a/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
@@ -275,6 +275,42 @@ describe('slack channel visibility gate (e2e via search_memory)', () => {
     expect(channels).not.toContain('C01SEC');
   });
 
+  it('scopes the production sync to the connection workspace — a second workspace never leaks in', async () => {
+    const { org, agent } = await setupWorkspace();
+    const sql = getTestDb();
+    // CONN is the Acme (T01ACME) workspace bot.
+    await sql`UPDATE agent_connections SET metadata = ${sql.json({ teamId: TEAM })} WHERE id = ${CONN}`;
+    // A binding to a channel in a DIFFERENT workspace (the same agent's second
+    // Slack connection) must NOT be synced under CONN — otherwise CONN would
+    // fetch it with the wrong token and fail closed, or stamp it under itself.
+    await sql`
+      INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id)
+      VALUES (${org.id}, ${agent.agentId}, 'slack', 'C02FOREIGN', 'T02OTHER')
+    `;
+
+    const fetched: string[] = [];
+    const result = await syncSlackConnectionAcl(
+      {
+        slackWeb: {
+          conversationMembers: async (_t, channelId) => {
+            fetched.push(channelId);
+            return ['U01ALICE'];
+          },
+        },
+        // Only the Acme workspace has a token — reaching T02OTHER would fail closed.
+        resolveBotToken: async ({ teamId }) =>
+          teamId === TEAM ? 'xoxb-test-token' : null,
+      },
+      { connectionId: CONN, organizationId: org.id },
+    );
+
+    // The foreign channel is excluded, so the sync stays green and only Acme's
+    // channels are fetched. Pre-fix this threw (no token for T02OTHER) → ok=false.
+    expect(result.ok).toBe(true);
+    expect(result.channelsSynced).toBe(2);
+    expect(fetched.sort()).toEqual(['C01ENG', 'C01SEC']);
+  });
+
   it('resolves a member provisioned through the REAL path (ensureMemberEntity), not a hand-seeded identity', async () => {
     // setupWorkspace seeds Alice via seedSignedInMember, which writes the
     // auth_user_id identity by hand. THIS test instead provisions a second user

--- a/packages/server/src/__tests__/integration/connectors/virtual-feed-read.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/virtual-feed-read.test.ts
@@ -183,4 +183,20 @@ describe('virtual feed flag (Slice 2)', () => {
       readVirtualFeed({ scope: ownerScope(), feedId: nonVirtualFeedId })
     ).rejects.toThrow(/not a virtual feed/i);
   }, 60_000);
+
+  it('refuses to read a PAUSED virtual feed live (status gate)', async () => {
+    // A paused (or error) feed is not deleted but must not serve live reads —
+    // the lookup gates on f.status = 'active', so it resolves to "not found".
+    const db = getTestDb();
+    const [paused] = await db`
+      INSERT INTO feeds (organization_id, connection_id, feed_key, status, virtual, config, created_at, updated_at)
+      VALUES (${orgId}, ${orgConnId}, 'query', 'paused', true,
+        ${db.json({ query: VFEED_SQL, primary_key: 'id', cursor_column: 'id' })}, NOW(), NOW())
+      RETURNING id
+    `;
+    const pausedId = Number((paused as { id: number }).id);
+    await expect(
+      readVirtualFeed({ scope: ownerScope(), feedId: pausedId })
+    ).rejects.toThrow(/not found or not accessible/i);
+  }, 60_000);
 });

--- a/packages/server/src/__tests__/unit/conversation-visibility.test.ts
+++ b/packages/server/src/__tests__/unit/conversation-visibility.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+	type ChannelVisibility,
+	isConversationVisible,
+} from "../../gateway/services/agent-thread-list";
+
+/**
+ * The team-scoped channel ACL for cross-platform conversation history. A Slack
+ * channel id is only unique WITHIN a workspace, so the gate keys on
+ * `{platform}:{team}:{channel}` and refuses to show a conversation it can't tie
+ * to a single team — otherwise the same channel id in two workspaces would
+ * collide and leak a transcript the requester can't read.
+ */
+function vis(opts: {
+	visibleKeys: string[];
+	channelTeams: Record<string, string[]>;
+}): ChannelVisibility {
+	return {
+		visibleKeys: new Set(opts.visibleKeys),
+		channelTeams: new Map(
+			Object.entries(opts.channelTeams).map(([k, v]) => [k, new Set(v)]),
+		),
+	};
+}
+
+describe("isConversationVisible", () => {
+	it("allows a conversation on a single-workspace, member-visible channel", () => {
+		const v = vis({
+			visibleKeys: ["slack:T1:C123"],
+			channelTeams: { "slack:C123": ["T1"] },
+		});
+		expect(isConversationVisible("slack:C123:1781.0", v)).toBe(true);
+	});
+
+	it("fails closed when the channel id is bound in more than one workspace", () => {
+		// Same channel id across two Slack teams — the conversation id carries no
+		// team, so it must NOT show even though T1 is visible.
+		const v = vis({
+			visibleKeys: ["slack:T1:C123"],
+			channelTeams: { "slack:C123": ["T1", "T2"] },
+		});
+		expect(isConversationVisible("slack:C123:1781.0", v)).toBe(false);
+	});
+
+	it("fails closed when the requester isn't a member of the channel's team", () => {
+		const v = vis({
+			visibleKeys: [],
+			channelTeams: { "slack:C123": ["T2"] },
+		});
+		expect(isConversationVisible("slack:C123:1781.0", v)).toBe(false);
+	});
+
+	it("fails closed for an unbound channel", () => {
+		const v = vis({
+			visibleKeys: ["slack:T1:C123"],
+			channelTeams: { "slack:C123": ["T1"] },
+		});
+		expect(isConversationVisible("slack:CSECRET:1781.0", v)).toBe(false);
+	});
+
+	it("handles teamless platforms (telegram) by channel", () => {
+		const v = vis({
+			visibleKeys: ["telegram::998877"],
+			channelTeams: { "telegram:998877": [""] },
+		});
+		expect(isConversationVisible("telegram:998877:1", v)).toBe(true);
+		expect(isConversationVisible("telegram:111:1", v)).toBe(false);
+	});
+});

--- a/packages/server/src/__tests__/unit/derive-conversation-platform.test.ts
+++ b/packages/server/src/__tests__/unit/derive-conversation-platform.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { deriveConversationPlatform } from "../../gateway/services/agent-thread-list";
+
+/**
+ * `scope=all` lists conversations across platforms by deriving the platform
+ * from the conversation-id prefix. The invariant under test: only genuine
+ * platform sessions (colon-prefixed, e.g. `slack:{channel}:{ts}`) map to a
+ * platform; the app's own threads and system/watcher sessions (underscore-
+ * delimited, no colon) stay "web" so they never masquerade as a platform.
+ */
+describe("deriveConversationPlatform", () => {
+	it("derives the platform from a colon-prefixed conversation id", () => {
+		expect(deriveConversationPlatform("slack:C0BAUJJ2RJP:1781641725.28")).toBe(
+			"slack",
+		);
+		expect(deriveConversationPlatform("telegram:998877:1")).toBe("telegram");
+		expect(deriveConversationPlatform("whatsapp:1555:0")).toBe("whatsapp");
+		expect(deriveConversationPlatform("discord:guild:chan")).toBe("discord");
+	});
+
+	it("treats the app's own threads (no colon) as web", () => {
+		expect(
+			deriveConversationPlatform("food-ordering_user_1_org_abc_thread123"),
+		).toBe("web");
+		expect(deriveConversationPlatform("owletto-default_u1_o1_t1")).toBe("web");
+	});
+
+	it("does NOT classify watcher/system ids as a platform", () => {
+		// Watcher runs are underscore-delimited (no colon) — they must never leak
+		// into the cross-platform conversation list as a fake platform.
+		expect(
+			deriveConversationPlatform("food-ordering_watcher_4_run_466129"),
+		).toBe("web");
+	});
+
+	it("ignores a leading colon and non-prefixed ids", () => {
+		expect(deriveConversationPlatform(":weird")).toBe("web");
+		expect(deriveConversationPlatform("nocolon")).toBe("web");
+		expect(deriveConversationPlatform("")).toBe("web");
+	});
+});

--- a/packages/server/src/authz/channel-visibility.ts
+++ b/packages/server/src/authz/channel-visibility.ts
@@ -12,9 +12,12 @@
  *
  * Enforcement is per-connection and OFF by default: a connection's rows are
  * gated only once it has a fresh `authz_source_acl_state` row (`acl_support
- * = 'full'` AND `freshness_state = 'fresh'`). A connection with no/partial/stale
- * ACL state keeps the existing per-agent behavior, so a half-built or absent
- * graph never silently hides (or, worse, mis-enforces) a channel.
+ * = 'full'` AND `freshness_state = 'fresh'`). A connection that was NEVER graphed
+ * (no `authz_source_acl_state` row) keeps the existing per-agent behavior, so an
+ * absent graph never silently hides a channel. But once a row exists, anything
+ * short of full+fresh — partial/none support, stale/failed freshness, or a fresh
+ * row aged past the window — fails CLOSED rather than passing through, so a
+ * half-built or stalled graph can never mis-enforce.
  *
  * Fail-closed: for an ENFORCED connection, a channel is dropped unless the
  * requester is provably a member. An unresolved requester (anonymous/headless,

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -88,10 +88,29 @@ export async function syncSlackConnectionAcl(
     organizationId,
     connectionId,
   });
+
+  // `resolveBoundChannelRows` joins bindings on (org, agent, platform) — NOT on
+  // workspace — so an agent with a SECOND Slack connection (another workspace)
+  // would pull that workspace's channels in here too. A real workspace
+  // connection carries `metadata.teamId`; scope to it so we only ever fetch
+  // members with THIS connection's token and stamp THIS connection's ACL state.
+  // A preview connection (no teamId, the hosted-bot invariant) serves cross-org
+  // bindings by design, so it stays unscoped.
+  const [conn] = await sql<{ team_id: string | null }>`
+		SELECT metadata->>'teamId' AS team_id
+		FROM agent_connections
+		WHERE id = ${connectionId} AND organization_id = ${organizationId}
+		LIMIT 1
+	`;
+  const connTeamId = conn?.team_id ?? null;
+
   // Only Slack rows that carry a team id can be team-scoped into the graph; a
   // channel with no team id is dropped fail-closed by the gate anyway.
   const slackRows = bound.filter(
-    (r) => r.platform.startsWith('slack') && r.team_id,
+    (r) =>
+      r.platform.startsWith('slack') &&
+      r.team_id &&
+      (connTeamId === null || r.team_id === connTeamId),
   );
   if (slackRows.length === 0) {
     return { ok: true, teamsSynced: 0, channelsSynced: 0 };

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -17,11 +17,11 @@ import { resolveOrgId } from "../../../lobu/stores/org-context.js";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
 import type { WorkerConnectionManager } from "../../gateway/connection-manager.js";
 import {
-	conversationChannelKey,
+	isConversationVisible,
 	listAgentThreads,
 	readConversationMessages,
 	readThreadMessages,
-	visibleChannelKeys,
+	resolveChannelVisibility,
 } from "../../services/agent-thread-list.js";
 import { readWatcherRunThreads } from "../../services/watcher-run-thread.js";
 import {
@@ -415,12 +415,12 @@ export function createAgentHistoryRoutes(deps: {
 		// the same per-agent fence ∩ per-user channel gate the listing applies.
 		// Fail closed (404, not 403) so an unauthorized id is indistinguishable
 		// from a non-existent one.
-		const channelKeys = await visibleChannelKeys(getDb(), {
+		const channelVis = await resolveChannelVisibility(getDb(), {
 			organizationId: scope.organizationId,
 			agentId: scope.agentId,
 			userId: scope.userId,
 		});
-		if (!channelKeys.has(conversationChannelKey(conversationId))) {
+		if (!isConversationVisible(conversationId, channelVis)) {
 			return errorResponse(c, "Conversation not found", 404);
 		}
 

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -17,9 +17,11 @@ import { resolveOrgId } from "../../../lobu/stores/org-context.js";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
 import type { WorkerConnectionManager } from "../../gateway/connection-manager.js";
 import {
+	conversationChannelKey,
 	listAgentThreads,
 	readConversationMessages,
 	readThreadMessages,
+	visibleChannelKeys,
 } from "../../services/agent-thread-list.js";
 import { readWatcherRunThreads } from "../../services/watcher-run-thread.js";
 import {
@@ -408,6 +410,20 @@ export function createAgentHistoryRoutes(deps: {
 		if (!conversationId || !/^[a-zA-Z0-9._:-]+$/.test(conversationId)) {
 			return errorResponse(c, "Invalid conversation id", 400);
 		}
+
+		// ACL: the requester must be able to read this conversation's channel —
+		// the same per-agent fence ∩ per-user channel gate the listing applies.
+		// Fail closed (404, not 403) so an unauthorized id is indistinguishable
+		// from a non-existent one.
+		const channelKeys = await visibleChannelKeys(getDb(), {
+			organizationId: scope.organizationId,
+			agentId: scope.agentId,
+			userId: scope.userId,
+		});
+		if (!channelKeys.has(conversationChannelKey(conversationId))) {
+			return errorResponse(c, "Conversation not found", 404);
+		}
+
 		const cursor = c.req.query("cursor") || "";
 		const limit = Math.min(parseInt(c.req.query("limit") || "200", 10), 200);
 

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -18,8 +18,10 @@ import type { UserAgentsStore } from "../../auth/user-agents-store.js";
 import type { WorkerConnectionManager } from "../../gateway/connection-manager.js";
 import {
 	listAgentThreads,
+	readConversationMessages,
 	readThreadMessages,
 } from "../../services/agent-thread-list.js";
+import { readWatcherRunThreads } from "../../services/watcher-run-thread.js";
 import {
 	createOwnershipResolver,
 	resolveSettingsLookupUserId,
@@ -341,10 +343,14 @@ export function createAgentHistoryRoutes(deps: {
 		const scope = await getAuthorizedAgentScope(c);
 		if (!scope) return errorResponse(c, "Unauthorized", 401);
 
+		// `?scope=all` widens the list to every conversation for the agent across
+		// platforms (Slack, Telegram, …), not just the requesting user's threads.
+		const listScope = c.req.query("scope") === "all" ? "all" : "user";
 		const threads = await listAgentThreads({
 			agentId: scope.agentId,
 			organizationId: scope.organizationId,
 			userId: scope.userId,
+			scope: listScope,
 		});
 		return c.json({ threads });
 	});
@@ -386,6 +392,85 @@ export function createAgentHistoryRoutes(deps: {
 						}
 					: message,
 			);
+		}
+		return c.json(data);
+	});
+
+	// Read a PLATFORM conversation (e.g. `slack:{channel}:{ts}`) read-only by its
+	// raw conversation id. The id carries colons, so it's URL-encoded in the path.
+	app.get("/conversations/:conversationId/messages", async (c) => {
+		const scope = await getAuthorizedAgentScope(c);
+		if (!scope) return errorResponse(c, "Unauthorized", 401);
+		if (!scope.organizationId) return c.json({ messages: [] });
+
+		const conversationId = decodeURIComponent(c.req.param("conversationId") || "");
+		// Platform conversation ids are `{platform}:{...}` — alnum/._:- only.
+		if (!conversationId || !/^[a-zA-Z0-9._:-]+$/.test(conversationId)) {
+			return errorResponse(c, "Invalid conversation id", 400);
+		}
+		const cursor = c.req.query("cursor") || "";
+		const limit = Math.min(parseInt(c.req.query("limit") || "200", 10), 200);
+
+		const data = await readConversationMessages({
+			agentId: scope.agentId,
+			organizationId: scope.organizationId,
+			conversationId,
+			cursor,
+			limit,
+		});
+		if (artifactStore && publicGatewayUrl && Array.isArray(data.messages)) {
+			data.messages = data.messages.map((message) =>
+				message.role === "user"
+					? {
+							...message,
+							content: resignFileRefs(
+								message.content,
+								artifactStore,
+								publicGatewayUrl,
+							),
+						}
+					: message,
+			);
+		}
+		return c.json(data);
+	});
+
+	// A watcher's recent completed runs as ready-to-stitch transcripts — the
+	// read-only run history rendered as one conversation. Watcher conversation
+	// ids are org-less but the snapshot row carries the org; the service bridges
+	// that, so we just hand it the requester's resolved org.
+	app.get("/watchers/:watcherId/thread", async (c) => {
+		const scope = await getAuthorizedAgentScope(c);
+		if (!scope) return errorResponse(c, "Unauthorized", 401);
+		if (!scope.organizationId) return c.json({ runs: [] });
+
+		const watcherId = Number(c.req.param("watcherId"));
+		if (!Number.isFinite(watcherId)) {
+			return errorResponse(c, "Invalid watcher id", 400);
+		}
+		const limit = Math.min(parseInt(c.req.query("limit") || "20", 10), 50);
+
+		const data = await readWatcherRunThreads({
+			agentId: scope.agentId,
+			watcherId,
+			organizationId: scope.organizationId,
+			limit,
+		});
+		if (artifactStore && publicGatewayUrl) {
+			for (const run of data.runs) {
+				run.messages = run.messages.map((message) =>
+					message.role === "user"
+						? {
+								...message,
+								content: resignFileRefs(
+									message.content,
+									artifactStore,
+									publicGatewayUrl,
+								),
+							}
+						: message,
+				);
+			}
 		}
 		return c.json(data);
 	});

--- a/packages/server/src/gateway/services/agent-thread-list.ts
+++ b/packages/server/src/gateway/services/agent-thread-list.ts
@@ -22,10 +22,32 @@ function isSafeThreadId(id: string): boolean {
 }
 
 export interface AgentThreadSummary {
+	/** Routing key: a thread id for web conversations (chattable), or the raw
+	 *  conversation id for platform conversations (read-only). */
 	id: string;
 	title: string;
 	createdAt: number;
 	updatedAt: number;
+	/** "web" for the app's own threads; otherwise the source platform derived
+	 *  from the conversation id prefix (slack, telegram, …). */
+	platform: string;
+	/** Raw conversation id — used to read a platform conversation read-only. */
+	conversationId: string;
+}
+
+/**
+ * Platform a conversation originated on, derived from its conversation id.
+ * Platform sessions key on a colon-prefixed id (e.g. `slack:{channel}:{ts}`,
+ * `telegram:{chat}:{topic}`); the app's own threads use `{agentId}_{userId}_…`
+ * (no colon) and are "web".
+ */
+export function deriveConversationPlatform(conversationId: string): string {
+	const colon = conversationId.indexOf(":");
+	if (colon > 0) {
+		const prefix = conversationId.slice(0, colon).toLowerCase();
+		if (/^[a-z][a-z0-9_-]*$/.test(prefix)) return prefix;
+	}
+	return "web";
 }
 
 async function findConversationSessionFile(
@@ -88,8 +110,11 @@ export async function listAgentThreads(args: {
 	agentId: string;
 	organizationId?: string;
 	userId: string;
+	/** "user" (default): only the requesting user's app threads. "all": every
+	 *  conversation for the agent across platforms (Slack, Telegram, …). */
+	scope?: "user" | "all";
 }): Promise<AgentThreadSummary[]> {
-	const { agentId, organizationId, userId } = args;
+	const { agentId, organizationId, userId, scope = "user" } = args;
 	const conversationPrefix = organizationId
 		? `${agentId}_${userId}_${organizationId}_`
 		: `${agentId}_${userId}_`;
@@ -130,6 +155,8 @@ export async function listAgentThreads(args: {
 				),
 				createdAt: at,
 				updatedAt: at,
+				platform: "web",
+				conversationId: row.conversation_id,
 			});
 		}
 	}
@@ -171,10 +198,84 @@ export async function listAgentThreads(args: {
 			),
 			createdAt: at,
 			updatedAt: at,
+			platform: "web",
+			conversationId: workspaceConversationId,
 		});
 	}
 
+	// "all" scope: also surface this agent's PLATFORM conversations (Slack,
+	// Telegram, …). Those key on a colon-prefixed conversation id rather than
+	// the `{agentId}_{userId}_…` app-thread prefix, so they're excluded above.
+	if (scope === "all" && organizationId) {
+		const sql = getDb();
+		const platformRows = await sql<{
+			conversation_id: string;
+			snapshot_jsonl: string;
+			created_at: Date;
+		}>`
+      SELECT DISTINCT ON (conversation_id)
+        conversation_id, snapshot_jsonl, created_at
+      FROM public.agent_transcript_snapshot
+      WHERE organization_id = ${organizationId}
+        AND agent_id = ${agentId}
+        AND terminal_status = 'completed'
+        AND conversation_id LIKE '%:%'
+      ORDER BY conversation_id, run_id DESC
+    `;
+		for (const row of platformRows) {
+			if (byThreadId.has(row.conversation_id)) continue;
+			const at = row.created_at.getTime();
+			byThreadId.set(row.conversation_id, {
+				id: row.conversation_id,
+				title: titleFromSessionJsonl(
+					row.snapshot_jsonl,
+					row.conversation_id,
+				),
+				createdAt: at,
+				updatedAt: at,
+				platform: deriveConversationPlatform(row.conversation_id),
+				conversationId: row.conversation_id,
+			});
+		}
+	}
+
 	return [...byThreadId.values()].sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+/**
+ * Read one conversation's messages by its RAW conversation id (e.g. a platform
+ * thread `slack:{channel}:{ts}`). Read-only — used to render platform
+ * conversations that aren't routable through the app chat composer.
+ */
+export async function readConversationMessages(args: {
+	agentId: string;
+	organizationId: string;
+	conversationId: string;
+	cursor: string;
+	limit: number;
+}) {
+	const { agentId, organizationId, conversationId, cursor, limit } = args;
+	const jsonl = await readSnapshotJsonl({
+		agentId,
+		organizationId,
+		conversationId,
+	});
+	if (jsonl === null) {
+		return {
+			messages: [],
+			nextCursor: null,
+			hasMore: false,
+			sessionId: conversationId,
+			threadId: conversationId,
+		};
+	}
+	return {
+		...paginateSessionMessages(jsonl, cursor, limit, {
+			excludeVerbose: true,
+			sessionIdFallback: conversationId,
+		}),
+		threadId: conversationId,
+	};
 }
 
 export async function loadConversationTranscriptJsonl(

--- a/packages/server/src/gateway/services/agent-thread-list.ts
+++ b/packages/server/src/gateway/services/agent-thread-list.ts
@@ -57,39 +57,81 @@ export function deriveConversationPlatform(conversationId: string): string {
 	return "web";
 }
 
+/** `{platform}:{team}:{channel}` — team-scoped so the same channel id in two
+ *  Slack workspaces never collides. `team` is "" for platforms without one. */
+function channelVisibilityKey(
+	platform: string,
+	teamId: string | null,
+	bareChannelId: string,
+): string {
+	return `${platform.toLowerCase()}:${teamId ?? ""}:${bareChannelId}`;
+}
+
+export interface ChannelVisibility {
+	/** Team-scoped keys the requester may read (per-agent fence ∩ per-user ACL). */
+	visibleKeys: Set<string>;
+	/** `{platform}:{channel}` → the team ids the AGENT is bound to it in. A
+	 *  channel bound in >1 team can't be disambiguated from a conversation id
+	 *  alone, so it fails closed. */
+	channelTeams: Map<string, Set<string>>;
+}
+
 /**
- * Normalized `{platform}:{bareChannelId}` keys the requester may read for this
- * agent: the per-agent channel fence (the agent's bound channels) INTERSECTED
- * with the per-user channel ACL gate ({@link filterChannelsForRequester}). A
- * platform conversation is visible iff its channel is in this set — so a user
- * never sees a channel transcript they're not a member of, exactly like recall.
+ * Which channels may THIS requester read for THIS agent — the per-agent channel
+ * fence (the agent's bound channels) INTERSECTED with the per-user channel ACL
+ * gate ({@link filterChannelsForRequester}), team-scoped. A platform conversation
+ * is visible iff {@link isConversationVisible}. Mirrors recall's gate so a user
+ * never sees a channel transcript they're not a member of.
  */
-export async function visibleChannelKeys(
+export async function resolveChannelVisibility(
 	sql: DbClient,
 	args: { organizationId: string; agentId: string; userId: string | null },
-): Promise<Set<string>> {
+): Promise<ChannelVisibility> {
 	const bound = await resolveBoundChannelRows(sql, {
 		organizationId: args.organizationId,
 		agentId: args.agentId,
 	});
+	const channelTeams = new Map<string, Set<string>>();
+	for (const c of bound) {
+		const bare = stripPlatformPrefix(c.platform, c.channel_id);
+		const pc = `${c.platform.toLowerCase()}:${bare}`;
+		const set = channelTeams.get(pc) ?? new Set<string>();
+		set.add(c.team_id ?? "");
+		channelTeams.set(pc, set);
+	}
 	const visible = await filterChannelsForRequester(sql, {
 		organizationId: args.organizationId,
 		userId: args.userId,
 		rows: bound,
 	});
-	return new Set(
-		visible.map(
-			(c) =>
-				`${c.platform.toLowerCase()}:${stripPlatformPrefix(c.platform, c.channel_id)}`,
+	const visibleKeys = new Set(
+		visible.map((c) =>
+			channelVisibilityKey(
+				c.platform,
+				c.team_id,
+				stripPlatformPrefix(c.platform, c.channel_id),
+			),
 		),
 	);
+	return { visibleKeys, channelTeams };
 }
 
-/** The `{platform}:{channel}` key for a platform conversation id, which is
- *  shaped `{platform}:{channel}:{thread}`. Compare against {@link visibleChannelKeys}. */
-export function conversationChannelKey(conversationId: string): string {
+/** Can the requester read this platform conversation (`{platform}:{channel}:{thread}`)?
+ *  Fail-closed: unbound, or a channel bound in more than one workspace (can't tie
+ *  the conversation to a team), is not visible. */
+export function isConversationVisible(
+	conversationId: string,
+	vis: ChannelVisibility,
+): boolean {
 	const parts = conversationId.split(":");
-	return `${(parts[0] ?? "").toLowerCase()}:${parts[1] ?? ""}`;
+	const platform = (parts[0] ?? "").toLowerCase();
+	const channel = parts[1] ?? "";
+	const teams = vis.channelTeams.get(`${platform}:${channel}`);
+	if (!teams || teams.size !== 1) return false; // unbound or ambiguous workspace
+	const [team] = [...teams];
+	return vis.visibleKeys.has(
+		channelVisibilityKey(platform, team || null, channel),
+	);
 }
 
 async function findConversationSessionFile(
@@ -253,7 +295,7 @@ export async function listAgentThreads(args: {
 		// ACL: a platform conversation is only listed if its channel is in the
 		// agent's bound channels AND (for ACL-graphed connections) the requester
 		// is a member — so a user never sees a channel transcript they can't read.
-		const channelKeys = await visibleChannelKeys(sql, {
+		const channelVis = await resolveChannelVisibility(sql, {
 			organizationId,
 			agentId,
 			userId,
@@ -274,9 +316,7 @@ export async function listAgentThreads(args: {
     `;
 		for (const row of platformRows) {
 			if (byThreadId.has(row.conversation_id)) continue;
-			if (!channelKeys.has(conversationChannelKey(row.conversation_id))) {
-				continue;
-			}
+			if (!isConversationVisible(row.conversation_id, channelVis)) continue;
 			const at = row.created_at.getTime();
 			byThreadId.set(row.conversation_id, {
 				id: row.conversation_id,

--- a/packages/server/src/gateway/services/agent-thread-list.ts
+++ b/packages/server/src/gateway/services/agent-thread-list.ts
@@ -28,11 +28,13 @@ export interface AgentThreadSummary {
 	title: string;
 	createdAt: number;
 	updatedAt: number;
-	/** "web" for the app's own threads; otherwise the source platform derived
-	 *  from the conversation id prefix (slack, telegram, …). */
+	/** "web" for the app's own threads; "watcher" for watcher activity; otherwise
+	 *  the source platform derived from the conversation id prefix (slack, …). */
 	platform: string;
 	/** Raw conversation id — used to read a platform conversation read-only. */
 	conversationId: string;
+	/** Set on `platform: "watcher"` entries — routes to the watcher's page. */
+	watcherId?: number;
 }
 
 /**
@@ -235,6 +237,41 @@ export async function listAgentThreads(args: {
 				updatedAt: at,
 				platform: deriveConversationPlatform(row.conversation_id),
 				conversationId: row.conversation_id,
+			});
+		}
+
+		// One entry per WATCHER (not per run) — its latest run time + name, so the
+		// activity panel can show watcher activity alongside chats and route to the
+		// watcher's page.
+		const watcherRows = await sql<{
+			watcher_id: number;
+			name: string | null;
+			last_at: Date;
+		}>`
+      SELECT w.id AS watcher_id, w.name, mx.last_at
+      FROM (
+        SELECT (regexp_match(conversation_id, '_watcher_([0-9]+)_run_'))[1]::int AS watcher_id,
+               max(created_at) AS last_at
+        FROM public.agent_transcript_snapshot
+        WHERE organization_id = ${organizationId}
+          AND agent_id = ${agentId}
+          AND terminal_status = 'completed'
+          AND conversation_id LIKE '%\\_watcher\\_%\\_run\\_%'
+        GROUP BY 1
+      ) mx
+      JOIN public.watchers w ON w.id = mx.watcher_id
+    `;
+		for (const row of watcherRows) {
+			const key = `watcher_${row.watcher_id}`;
+			const at = row.last_at.getTime();
+			byThreadId.set(key, {
+				id: key,
+				title: row.name ?? `Watcher ${row.watcher_id}`,
+				createdAt: at,
+				updatedAt: at,
+				platform: "watcher",
+				conversationId: key,
+				watcherId: row.watcher_id,
 			});
 		}
 	}

--- a/packages/server/src/gateway/services/agent-thread-list.ts
+++ b/packages/server/src/gateway/services/agent-thread-list.ts
@@ -1,7 +1,12 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { sanitizeConversationId, titleFromSessionJsonl } from "@lobu/core";
-import { getDb } from "../../db/client.js";
+import { filterChannelsForRequester } from "../../authz/channel-visibility.js";
+import { type DbClient, getDb } from "../../db/client.js";
+import {
+	resolveBoundChannelRows,
+	stripPlatformPrefix,
+} from "../channels/bound-channels.js";
 import {
 	buildApiConversationId,
 	extractThreadIdFromConversationId,
@@ -50,6 +55,41 @@ export function deriveConversationPlatform(conversationId: string): string {
 		if (/^[a-z][a-z0-9_-]*$/.test(prefix)) return prefix;
 	}
 	return "web";
+}
+
+/**
+ * Normalized `{platform}:{bareChannelId}` keys the requester may read for this
+ * agent: the per-agent channel fence (the agent's bound channels) INTERSECTED
+ * with the per-user channel ACL gate ({@link filterChannelsForRequester}). A
+ * platform conversation is visible iff its channel is in this set — so a user
+ * never sees a channel transcript they're not a member of, exactly like recall.
+ */
+export async function visibleChannelKeys(
+	sql: DbClient,
+	args: { organizationId: string; agentId: string; userId: string | null },
+): Promise<Set<string>> {
+	const bound = await resolveBoundChannelRows(sql, {
+		organizationId: args.organizationId,
+		agentId: args.agentId,
+	});
+	const visible = await filterChannelsForRequester(sql, {
+		organizationId: args.organizationId,
+		userId: args.userId,
+		rows: bound,
+	});
+	return new Set(
+		visible.map(
+			(c) =>
+				`${c.platform.toLowerCase()}:${stripPlatformPrefix(c.platform, c.channel_id)}`,
+		),
+	);
+}
+
+/** The `{platform}:{channel}` key for a platform conversation id, which is
+ *  shaped `{platform}:{channel}:{thread}`. Compare against {@link visibleChannelKeys}. */
+export function conversationChannelKey(conversationId: string): string {
+	const parts = conversationId.split(":");
+	return `${(parts[0] ?? "").toLowerCase()}:${parts[1] ?? ""}`;
 }
 
 async function findConversationSessionFile(
@@ -210,6 +250,14 @@ export async function listAgentThreads(args: {
 	// the `{agentId}_{userId}_…` app-thread prefix, so they're excluded above.
 	if (scope === "all" && organizationId) {
 		const sql = getDb();
+		// ACL: a platform conversation is only listed if its channel is in the
+		// agent's bound channels AND (for ACL-graphed connections) the requester
+		// is a member — so a user never sees a channel transcript they can't read.
+		const channelKeys = await visibleChannelKeys(sql, {
+			organizationId,
+			agentId,
+			userId,
+		});
 		const platformRows = await sql<{
 			conversation_id: string;
 			snapshot_jsonl: string;
@@ -226,6 +274,9 @@ export async function listAgentThreads(args: {
     `;
 		for (const row of platformRows) {
 			if (byThreadId.has(row.conversation_id)) continue;
+			if (!channelKeys.has(conversationChannelKey(row.conversation_id))) {
+				continue;
+			}
 			const at = row.created_at.getTime();
 			byThreadId.set(row.conversation_id, {
 				id: row.conversation_id,

--- a/packages/server/src/gateway/services/watcher-run-thread.ts
+++ b/packages/server/src/gateway/services/watcher-run-thread.ts
@@ -1,0 +1,69 @@
+import { getDb } from "../../db/client.js";
+import { buildApiConversationId } from "./api-conversation-id.js";
+import { paginateSessionMessages } from "./session-message-page.js";
+
+/**
+ * Read the latest N completed watcher-run transcripts for one watcher, newest
+ * first, ready to be stitched into a single read-only thread on the client.
+ *
+ * Watcher sessions are org-EXEMPT in their conversation id (built as
+ * `{agentId}_watcher_{watcherId}_run_{runId}`, no org segment — see
+ * `routes/public/agent.ts`), yet the persisted `agent_transcript_snapshot` row
+ * still carries the real `organization_id`. So we match rows by org + the
+ * org-less id prefix, and key each run off the `_run_<id>` suffix.
+ */
+export async function readWatcherRunThreads(args: {
+	agentId: string;
+	watcherId: number;
+	organizationId: string;
+	limit: number;
+}): Promise<{
+	runs: Array<{
+		runId: number;
+		completedAt: string;
+		messages: ReturnType<typeof paginateSessionMessages>["messages"];
+	}>;
+}> {
+	const { agentId, watcherId, organizationId, limit } = args;
+	// `{agentId}_watcher_{watcherId}` — the org-less prefix the worker wrote.
+	const prefix = buildApiConversationId({
+		agentId,
+		userId: `watcher_${watcherId}`,
+	});
+
+	const sql = getDb();
+	const rows = await sql<{
+		conversation_id: string;
+		created_at: Date;
+		snapshot_jsonl: string;
+	}>`
+    SELECT DISTINCT ON (conversation_id)
+      conversation_id, created_at, snapshot_jsonl
+    FROM public.agent_transcript_snapshot
+    WHERE organization_id = ${organizationId}
+      AND agent_id = ${agentId}
+      AND conversation_id LIKE ${`${prefix}_run_%`}
+      AND terminal_status = 'completed'
+    ORDER BY conversation_id, created_at DESC
+  `;
+
+	// DISTINCT ON gives the latest snapshot per run; order across runs by recency.
+	const recent = rows
+		.sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
+		.slice(0, limit);
+
+	const runs = recent.map((row) => {
+		const runId = Number(row.conversation_id.match(/_run_(\d+)$/)?.[1] ?? 0);
+		const { messages } = paginateSessionMessages(row.snapshot_jsonl, "", 200, {
+			excludeVerbose: true,
+			sessionIdFallback: row.conversation_id,
+		});
+		return {
+			runId,
+			completedAt: row.created_at.toISOString(),
+			messages,
+		};
+	});
+
+	return { runs };
+}

--- a/packages/server/src/lib/connector-pushdown.ts
+++ b/packages/server/src/lib/connector-pushdown.ts
@@ -179,6 +179,7 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
      WHERE f.id = $1
        AND f.organization_id = $3
        AND f.deleted_at IS NULL
+       AND f.status = 'active'
        AND c.deleted_at IS NULL
        AND c.status = 'active'
        ${vis.sql}


### PR DESCRIPTION
Server endpoints behind the owletto agent-UX consolidation + cross-platform conversations (owletto #376).

## Server (`packages/server`)
- `GET /agents/:id/history/watchers/:watcherId/thread` — a watcher's completed runs as ready-to-stitch transcripts (watcher conversation ids are org-less but the snapshot row carries the org; the service bridges that)
- `GET /agents/:id/history/threads?scope=all` — lists conversations across **all platforms**, deriving `platform` from the conversation-id prefix (`slack:`, `telegram:` → platform; `{agentId}_{userId}_…` → web). No new table/column — platform is already encoded in the id
- `GET /agents/:id/history/conversations/:conversationId/messages` — read a platform conversation read-only by its raw id

## owletto pointer
Bumped to the agent-UX consolidation commit (see owletto #376 for the full frontend change).

Verified locally end-to-end: stitched watcher thread, all five centered sub-page headers, and a real seeded Slack conversation listing with a Slack icon + read-only viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785262455&installation_id=136316292&pr_number=1595&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1595&signature=cbdab8ac339e6df843d927c8221701237c936678104c9e2bd0d12aaecfb6f3f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `scope=all` to expand agent thread browsing beyond personal web threads.
  * Added public endpoints to fetch platform conversation messages and recent completed watcher run transcripts (with attachment re-signing when available).
* **Enhancements**
  * Thread listings now include platform + conversation identifiers and enforce visibility rules for cross-platform/thread access.
* **Bug Fixes**
  * Non-visible conversation IDs are denied (returns not found) to prevent transcript leakage.
* **Tests**
  * Added integration/unit coverage for scoping, platform classification, visibility behavior, and the new public read endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->