### PR TITLE
fix(server): notify user to re-login when a connector's site session expires

### DIFF
--- a/packages/server/src/__tests__/integration/connector-health-reauth-notify.test.ts
+++ b/packages/server/src/__tests__/integration/connector-health-reauth-notify.test.ts
@@ -1,0 +1,144 @@
+/**
+ * connector-health → browser-auth-expired user notification (integration).
+ *
+ * When a connection goes unhealthy because its SITE SESSION expired (e.g. an
+ * extension-scrape connector like Revolut whose Revolut login lapsed), the
+ * health scan must notify the org's admins to re-login — on top of the operator
+ * Slack alert. A connection that's unhealthy for a NON-auth reason (offline
+ * device / transport) must NOT produce that user notification. And the notice
+ * fires once per unhealthy episode (deduped by the unhealthy_alerted_at claim).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { runConnectorHealthCheck } from '../../connectors/connector-health';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { addUserToOrganization, createTestOrganization, createTestUser } from '../setup/test-fixtures';
+
+// Comfortably outside the 24h min-age grace window so age never masks a flag.
+const OLD = new Date(Date.now() - 48 * 60 * 60 * 1000);
+
+async function seedConn(
+  orgId: string,
+  userId: string,
+  connectorKey: string,
+  slug: string
+): Promise<number> {
+  const sql = getTestDb();
+  const [row] = await sql`
+    INSERT INTO connections (
+      organization_id, connector_key, slug, display_name, status,
+      created_by, visibility, created_at, updated_at
+    ) VALUES (
+      ${orgId}, ${connectorKey}, ${slug}, ${`Conn ${slug}`}, 'active',
+      ${userId}, 'org', ${OLD}, ${OLD}
+    )
+    RETURNING id
+  `;
+  return Number(row.id);
+}
+
+async function seedFailingFeed(
+  orgId: string,
+  connectionId: number,
+  feedKey: string,
+  lastError: string
+): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO feeds (
+      organization_id, connection_id, feed_key, status,
+      last_sync_status, last_sync_at, consecutive_failures, last_error,
+      created_at, updated_at
+    ) VALUES (
+      ${orgId}, ${connectionId}, ${feedKey}, 'active',
+      'failed', ${new Date()}, 5, ${lastError}, NOW(), NOW()
+    )
+  `;
+}
+
+async function authNotifsFor(
+  orgId: string,
+  connectionId: number
+): Promise<Array<{ id: number; title: string; payload_text: string | null }>> {
+  const sql = getTestDb();
+  return (await sql`
+    SELECT id, title, payload_text
+    FROM events
+    WHERE organization_id = ${orgId}
+      AND semantic_type = 'notification'
+      AND metadata->>'notification_type' = 'browser_auth_expired'
+      AND metadata->>'resource_id' = ${String(connectionId)}
+  `) as unknown as Array<{ id: number; title: string; payload_text: string | null }>;
+}
+
+describe('connector-health → browser-auth-expired notification', () => {
+  let orgId: string;
+  let ownerId: string;
+  let authConnId: number;
+  let offlineConnId: number;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Reauth Notify Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'reauth-owner@test.com' });
+    ownerId = user.id;
+    await addUserToOrganization(ownerId, orgId, 'owner');
+
+    // (A) Expired site session — should notify.
+    authConnId = await seedConn(orgId, ownerId, 'revolut', 'revolut-auth');
+    await seedFailingFeed(
+      orgId,
+      authConnId,
+      'transactions',
+      'Revolut session needs sign-in (redirected to https://sso.revolut.com/signin)'
+    );
+
+    // (B) Offline device / transport — unhealthy, but NOT an auth failure.
+    offlineConnId = await seedConn(orgId, ownerId, 'revolut', 'revolut-offline');
+    await seedFailingFeed(
+      orgId,
+      offlineConnId,
+      'transactions',
+      'No online paired Owletto Chrome extension in this organization. Pair a Chrome extension first (and make sure it is running).'
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('notifies the owner on an expired session, but not on an offline device', async () => {
+    const res = await runConnectorHealthCheck();
+
+    // Both connections are flagged unhealthy (every feed failing)...
+    const flagged = new Set(res.details.map((d) => d.connectionId));
+    expect(flagged.has(authConnId)).toBe(true);
+    expect(flagged.has(offlineConnId)).toBe(true);
+
+    // ...but only the expired-session one produced a user notification.
+    expect(res.authNotified).toBe(1);
+
+    const authNotifs = await authNotifsFor(orgId, authConnId);
+    expect(authNotifs).toHaveLength(1);
+    expect(authNotifs[0].title.toLowerCase()).toContain('needs sign-in');
+
+    // The owner is a target of that notification.
+    const sql = getTestDb();
+    const targets = (await sql`
+      SELECT user_id FROM notification_targets WHERE event_id = ${Number(authNotifs[0].id)}
+    `) as unknown as Array<{ user_id: string }>;
+    expect(targets.map((t) => t.user_id)).toContain(ownerId);
+
+    // The offline-device connection produced NO browser-auth-expired notification.
+    expect(await authNotifsFor(orgId, offlineConnId)).toHaveLength(0);
+  });
+
+  it('does not re-notify while still unhealthy (deduped by the unhealthy claim)', async () => {
+    const res = await runConnectorHealthCheck();
+    expect(res.newlyAlerted).toBe(0);
+    expect(res.authNotified).toBe(0);
+    // Still exactly one notification — no duplicate on the second scan.
+    expect(await authNotifsFor(orgId, authConnId)).toHaveLength(1);
+  });
+});

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -23,7 +23,22 @@
  */
 
 import { type DbClient, getDb } from '../db/client';
+import { notifyBrowserAuthExpired } from '../notifications/triggers';
 import logger from '../utils/logger';
+
+/**
+ * Does this feed error look like an expired/invalid site session (the user must
+ * re-login), rather than infra/transport (offline device, network, 5xx)? Used
+ * to fire a user-facing "needs sign-in" notification on top of the operator
+ * alert. Kept deliberately tight so device-offline ("No online paired Owletto
+ * Chrome extension …") and generic failures are NOT misclassified as auth.
+ */
+const AUTH_EXPIRED_RE =
+  /(sign[\s-]?in|\bsso\b|re-?auth|reauthenticat|session\s+(?:expired|needs|invalid|timed)|cookies?[\s\S]{0,30}expired|authentication\s+failed|unauthor|login\s+required|not\s+logged\s*in)/i;
+
+export function isBrowserAuthExpiredError(lastError: string | null | undefined): boolean {
+  return !!lastError && AUTH_EXPIRED_RE.test(lastError);
+}
 
 /**
  * A feed is "failing" if its most recent sync failed OR it has accumulated at
@@ -87,6 +102,9 @@ export interface ConnectorHealthResult {
   newlyAlerted: number;
   /** Connections that recovered on THIS run (marker re-armed). */
   recovered: number;
+  /** Newly-unhealthy connections whose failure was an expired site session,
+   * for which a user-facing "needs sign-in" notification was sent. */
+  authNotified: number;
   details: UnhealthyConnection[];
 }
 
@@ -94,6 +112,8 @@ interface HealthDeps {
   sql?: DbClient;
   config?: ConnectorHealthConfig;
   now?: () => number;
+  /** Injectable for tests; defaults to the real browser-auth-expired trigger. */
+  notifyAuthExpired?: typeof notifyBrowserAuthExpired;
 }
 
 interface UnhealthyRow {
@@ -201,6 +221,7 @@ export async function runConnectorHealthCheck(
   const sql = deps.sql ?? getDb();
   const cfg = deps.config ?? DEFAULT_CONNECTOR_HEALTH_CONFIG;
   const nowMs = (deps.now ?? (() => Date.now()))();
+  const notifyAuthExpired = deps.notifyAuthExpired ?? notifyBrowserAuthExpired;
 
   const rows = await loadConnectionHealthRows(sql, cfg);
 
@@ -209,6 +230,7 @@ export async function runConnectorHealthCheck(
     unhealthy: 0,
     newlyAlerted: 0,
     recovered: 0,
+    authNotified: 0,
     details: [],
   };
 
@@ -281,6 +303,27 @@ export async function runConnectorHealthCheck(
       },
       `[connector-health] connector unhealthy (${reason}): ${row.connector_key}`
     );
+
+    // On the unhealthy transition, if the failure is an expired site session
+    // (not an offline device / transport error), also notify the org's admins
+    // to re-login — the operator alert above can't reach the person who has to
+    // sign in. Deduped by the same unhealthy_alerted_at claim, so it fires once
+    // per episode. Best-effort: a notification failure must not break the scan.
+    if (isBrowserAuthExpiredError(row.last_error)) {
+      try {
+        await notifyAuthExpired({
+          orgId: row.organization_id,
+          connectionId,
+          connectorKey: row.connector_key,
+        });
+        result.authNotified += 1;
+      } catch (err) {
+        logger.warn(
+          { err, connection_id: connectionId },
+          '[connector-health] failed to send browser-auth-expired notification'
+        );
+      }
+    }
   }
 
   return result;

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -106,15 +106,23 @@ export async function notifyBrowserAuthExpired(params: {
   orgId: string;
   connectionId: number;
   connectorKey: string;
-  authProfileSlug: string;
+  /**
+   * Set for connectors that store a `browser_session` auth profile (the CLI /
+   * Mac browser-auth capture flow). Omitted for extension-scrape connectors
+   * (e.g. Revolut, LinkedIn) that reuse the live browser session and have no
+   * stored auth profile — those just need the user to re-login on the site.
+   */
+  authProfileSlug?: string | null;
 }): Promise<void> {
   await notifyOrgAdmins(params.orgId, (orgSlug) => ({
     type: 'browser_auth_expired',
-    title: `Browser auth expired for ${params.connectorKey}`,
-    body:
-      'Session needs re-authentication.\n' +
-      'Enable remote debugging in Chrome: chrome://inspect/#remote-debugging\n' +
-      `Or run: lobu memory browser-auth --connector ${params.connectorKey} --auth-profile-slug ${params.authProfileSlug}`,
+    title: `${params.connectorKey} needs sign-in`,
+    body: params.authProfileSlug
+      ? 'Session needs re-authentication.\n' +
+        'Enable remote debugging in Chrome: chrome://inspect/#remote-debugging\n' +
+        `Or run: lobu memory browser-auth --connector ${params.connectorKey} --auth-profile-slug ${params.authProfileSlug}`
+      : `Your ${params.connectorKey} session has expired, so syncing has stopped. ` +
+        `Open ${params.connectorKey} in the browser where your Owletto extension runs and sign in to resume.`,
     resourceType: 'connection',
     resourceId: String(params.connectionId),
     resourceUrl: orgSlug ? `/${orgSlug}/connectors` : undefined,


### PR DESCRIPTION
## Problem

When a browser-scrape connector's **site session expires**, the user is never told — so it sits broken silently (exactly what happened with Revolut here). `notifyBrowserAuthExpired` (`browser_auth_expired` → inbox + Slack/Telegram) existed, but only fired from `run-lifecycle.ts`, which requires a stored `browser_session` **auth profile** + a posted `auth_update`. Extension-scrape connectors (Revolut, LinkedIn) have **no auth profile** — they reuse the live browser session — so the expiry just produces a failed run ("needs sign-in / redirected to sso…") that only reaches operators via Sentry/Slack, never the person who has to re-login.

## Fix

Wire the existing notification into `connector-health` — the module that already detects the unhealthy connection, dedupes via the `unhealthy_alerted_at` claim, and whose header literally calls out "expired Revolut sessions … surface to nobody":

- On the unhealthy transition, classify the feed's `last_error`. If it's an expired/invalid **site session**, also fire `notifyBrowserAuthExpired` to the org admins.
- Offline-device / transport failures ("No online paired … extension") are deliberately **not** classified as auth, so they don't produce a re-login nudge.
- The two paths are disjoint: `browser_session` connectors flip to `pending_auth` (not scanned by connector-health, which only scans `status='active'`), so no double-notify.
- `notifyBrowserAuthExpired` now handles connectors **without** an auth profile (a plain "open <connector> and sign in" body instead of the CLI re-auth steps).

## Validation

- New `connector-health-reauth-notify.test.ts`: expired session → owner notified (inbox row + target); offline device → **not** notified; re-run → no duplicate (deduped). **Passing.**
- Existing `connector-health-alert.test.ts` still green; `make typecheck` clean.

Follow-up (separate): the earlier finding that re-pairing doesn't auto-bind the org's `chrome` connection to the new worker (had to bind connection 369 by hand).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785269049&installation_id=136316292&pr_number=1596&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1596&signature=9a4cbf9a6e01b5917f62a2509decf8f3f55f00970c16f803bf8e77e7b1bcc369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->