### PR TITLE
fix(server): auto-bind chrome connection to the online extension on dispatch

### DIFF
--- a/packages/server/src/__tests__/integration/dispatch-chrome-autobind.test.ts
+++ b/packages/server/src/__tests__/integration/dispatch-chrome-autobind.test.ts
@@ -1,0 +1,130 @@
+/**
+ * resolveOnlineChromeConnection — integration test against real Postgres.
+ *
+ * The generic `chrome` action connection (used by server-side connectors like
+ * Revolut/LinkedIn to dispatch a browser scrape) must reach an extension that is
+ * ONLINE in the org, regardless of which worker — if any — it's currently pinned
+ * to. Re-pairing mints a new device worker and leaves the chrome connection
+ * pinned to the old (offline) one or NULL, which used to make dispatch fail with
+ * "no online paired extension". The resolver self-heals the pin to the online
+ * worker.
+ */
+
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { resolveOnlineChromeConnection } from '../../worker-api/dispatch-chrome-action';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { createTestOrganization, createTestUser } from '../setup/test-fixtures';
+
+const sql = getTestDb();
+const DEBUGGER_CAPS = ['browser.tabs', 'browser.scripting', 'browser.debugger'];
+
+async function seedChromeConn(
+  orgId: string,
+  userId: string,
+  deviceWorkerId: string | null
+): Promise<number> {
+  const slug = `chrome-${Math.random().toString(36).slice(2, 8)}`;
+  const [row] = (await sql`
+    INSERT INTO connections (
+      organization_id, connector_key, slug, display_name, status,
+      created_by, visibility, device_worker_id, created_at, updated_at
+    ) VALUES (
+      ${orgId}, 'chrome', ${slug}, 'Chrome', 'active',
+      ${userId}, 'private', ${deviceWorkerId}::uuid, NOW(), NOW()
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+  return Number(row.id);
+}
+
+async function seedExtWorker(
+  userId: string,
+  orgId: string,
+  opts: { online: boolean; capabilities?: string[] }
+): Promise<string> {
+  const workerId = `ext-${Math.random().toString(36).slice(2, 10)}`;
+  const lastSeen = opts.online
+    ? new Date()
+    : new Date(Date.now() - 2 * 60 * 60 * 1000); // 2h ago → offline
+  const [row] = (await sql`
+    INSERT INTO device_workers (
+      user_id, worker_id, platform, capabilities, label, organization_id, last_seen_at
+    ) VALUES (
+      ${userId}, ${workerId}, 'chrome-extension',
+      ${sql.json(opts.capabilities ?? DEBUGGER_CAPS)}, 'Test Ext', ${orgId}, ${lastSeen}
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  return String(row.id);
+}
+
+async function pinOf(connectionId: number): Promise<string | null> {
+  const [row] = (await sql`
+    SELECT device_worker_id FROM connections WHERE id = ${connectionId}
+  `) as unknown as Array<{ device_worker_id: string | null }>;
+  return row.device_worker_id;
+}
+
+describe('resolveOnlineChromeConnection — self-healing chrome pin', () => {
+  let orgId: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Chrome Autobind Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'chrome-autobind@test.com' });
+    userId = user.id;
+  });
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('binds an unpinned (NULL) chrome connection to the online extension worker', async () => {
+    const connId = await seedChromeConn(orgId, userId, null);
+    const workerId = await seedExtWorker(userId, orgId, { online: true });
+
+    const res = await resolveOnlineChromeConnection(orgId, sql);
+
+    expect(res).not.toBeNull();
+    expect(res?.connectionId).toBe(connId);
+    expect(res?.deviceWorkerId).toBe(workerId);
+    // The connection is now pinned to the online worker (so the poll can claim).
+    expect(await pinOf(connId)).toBe(workerId);
+  });
+
+  it('repins a connection stuck on an offline worker (the re-pair case)', async () => {
+    const stale = await seedExtWorker(userId, orgId, { online: false });
+    const connId = await seedChromeConn(orgId, userId, stale);
+    const fresh = await seedExtWorker(userId, orgId, { online: true });
+
+    const res = await resolveOnlineChromeConnection(orgId, sql);
+
+    expect(res?.deviceWorkerId).toBe(fresh);
+    expect(await pinOf(connId)).toBe(fresh); // repinned away from the stale worker
+  });
+
+  it('returns null and leaves the pin untouched when no extension is online', async () => {
+    const connId = await seedChromeConn(orgId, userId, null);
+    await seedExtWorker(userId, orgId, { online: false }); // only an offline worker
+
+    const res = await resolveOnlineChromeConnection(orgId, sql);
+
+    expect(res).toBeNull();
+    expect(await pinOf(connId)).toBeNull();
+  });
+
+  it('ignores an online extension that lacks the browser.debugger capability', async () => {
+    const connId = await seedChromeConn(orgId, userId, null);
+    await seedExtWorker(userId, orgId, {
+      online: true,
+      capabilities: ['browser.tabs', 'browser.scripting'], // no debugger
+    });
+
+    const res = await resolveOnlineChromeConnection(orgId, sql);
+
+    expect(res).toBeNull();
+    expect(await pinOf(connId)).toBeNull();
+  });
+});

--- a/packages/server/src/worker-api/dispatch-chrome-action.ts
+++ b/packages/server/src/worker-api/dispatch-chrome-action.ts
@@ -48,6 +48,62 @@ export interface ChromeActionDispatchResult {
 }
 
 /**
+ * Resolve an online Owletto Chrome extension to run a chrome action against, and
+ * self-heal the org's `chrome` connection pin to it.
+ *
+ * Both this dispatch and the poll claim gate on `connections.device_worker_id`,
+ * but nothing keeps the generic `chrome` action connection bound to the current
+ * extension worker: re-pairing mints a NEW device worker and leaves the chrome
+ * connection pinned to the old (now offline) one — or never pinned at all (it's
+ * not a bundled device connector, so `device-reconcile` doesn't touch it). The
+ * result: a server-side chrome connector (Revolut, LinkedIn) can't reach an
+ * extension that IS online, and dispatch fails with "no online paired
+ * extension". So resolve any online, debugger-capable chrome-extension worker in
+ * the org INDEPENDENT of the existing pin, then repin the connection to it
+ * before enqueuing — fixing both the NULL-pin and stale-pin (post-re-pair) cases.
+ *
+ * Returns the chrome connection id + the resolved worker, or null when no online
+ * extension exists in the org.
+ */
+export async function resolveOnlineChromeConnection(
+  organizationId: string,
+  sql = getDb()
+): Promise<{ connectionId: number; deviceWorkerId: string } | null> {
+  const rows = (await sql`
+    SELECT
+      con.id AS connection_id,
+      con.device_worker_id AS current_pin,
+      dw.id AS online_worker_id
+    FROM connections con
+    JOIN device_workers dw ON dw.organization_id = con.organization_id
+    WHERE con.organization_id = ${organizationId}
+      AND con.connector_key = 'chrome'
+      AND con.status = 'active'
+      AND con.deleted_at IS NULL
+      AND dw.platform = 'chrome-extension'
+      AND dw.capabilities::jsonb @> '["browser.debugger"]'::jsonb
+      AND dw.last_seen_at > now() - make_interval(mins => ${DEVICE_ONLINE_WINDOW_MINUTES})
+    ORDER BY dw.last_seen_at DESC
+    LIMIT 1
+  `) as Array<{ connection_id: number; current_pin: string | null; online_worker_id: string }>;
+
+  if (rows.length === 0) return null;
+  const { connection_id, current_pin, online_worker_id } = rows[0];
+
+  // Self-heal the pin so the poll claim (which gates on device_worker_id) routes
+  // the run to the online worker. Covers a NULL pin and a stale post-re-pair pin.
+  if (current_pin !== online_worker_id) {
+    await sql`
+      UPDATE connections
+      SET device_worker_id = ${online_worker_id}::uuid, updated_at = now()
+      WHERE id = ${connection_id}
+    `;
+  }
+
+  return { connectionId: connection_id, deviceWorkerId: online_worker_id };
+}
+
+/**
  * Core chrome-action dispatch, callable in-process (no HTTP Context):
  *
  *   1. Pick an online paired Owletto chrome connection in `organizationId`.
@@ -74,43 +130,24 @@ export async function dispatchChromeActionToExtension(params: {
     params;
   const sql = getDb();
 
-  // (1) Pick an online chrome connection in this org.
-  const chromeConnectionRows = (await sql`
-    SELECT
-      con.id AS connection_id,
-      con.device_worker_id,
-      dw.last_seen_at
-    FROM connections con
-    JOIN device_workers dw ON dw.id = con.device_worker_id
-    WHERE con.organization_id = ${organizationId}
-      AND con.connector_key = 'chrome'
-      AND con.status = 'active'
-      AND con.deleted_at IS NULL
-      AND dw.capabilities::jsonb @> '["browser.debugger"]'::jsonb
-      AND dw.last_seen_at > now() - make_interval(mins => ${DEVICE_ONLINE_WINDOW_MINUTES})
-    ORDER BY dw.last_seen_at DESC
-    LIMIT 1
-  `) as Array<{
-    connection_id: number;
-    device_worker_id: string;
-    last_seen_at: Date | string;
-  }>;
-
-  if (chromeConnectionRows.length === 0) {
+  // (1) Pick an online chrome extension in this org and pin the chrome
+  //     connection to it (self-heals NULL / stale-after-re-pair pins so the
+  //     poll claim can route the run). See resolveOnlineChromeConnection.
+  const chromeConnection = await resolveOnlineChromeConnection(organizationId, sql);
+  if (!chromeConnection) {
     return {
       status: 'failed',
       error_message:
         'No online paired Owletto Chrome extension in this organization. Pair a Chrome extension first (and make sure it is running).',
     };
   }
-  const chromeConnection = chromeConnectionRows[0];
 
   // (2) Insert a device-bound chrome connector action run.
   let runId: number;
   try {
     runId = await createConnectorOperationRun({
       organizationId,
-      connectionId: chromeConnection.connection_id,
+      connectionId: chromeConnection.connectionId,
       connectorKey: 'chrome',
       operationKey: actionKey,
       operationInput: actionInput ?? {},
@@ -131,8 +168,8 @@ export async function dispatchChromeActionToExtension(params: {
       run_id: runId,
       parent_run_id: parentRunId,
       action_key: actionKey,
-      chrome_connection_id: chromeConnection.connection_id,
-      device_worker_id: chromeConnection.device_worker_id,
+      chrome_connection_id: chromeConnection.connectionId,
+      device_worker_id: chromeConnection.deviceWorkerId,
     },
     '[dispatchChromeAction] dispatched'
   );


### PR DESCRIPTION
## Problem

Server-side chrome connectors (Revolut, LinkedIn) dispatch a browser scrape through the org's generic `chrome` action connection. Both the dispatch SELECT (`dispatch-chrome-action.ts`) and the poll **claim** (`poll.ts`) route by `connections.device_worker_id`. But nothing keeps that pin current:

- `chrome` is **not** a bundled device connector, so `device-reconcile` (which pins the chrome.*/apple.* device connectors) never touches it.
- Re-pairing the extension mints a **new** device worker and leaves the `chrome` connection pinned to the **old, offline** worker — or `NULL`.

Result: dispatch fails with **"No online paired Owletto Chrome extension"** even though an extension *is* online in the org. This is exactly what blocked the Revolut backfill earlier — I had to bind `connections.device_worker_id` by hand.

## Fix

`resolveOnlineChromeConnection` now finds **any** online, `browser.debugger`-capable chrome-extension worker in the org **independent of the existing pin**, and self-heals `connections.device_worker_id` to it before enqueuing the run. The poll claim then routes the run to that worker via the pinned-device branch. Covers both the NULL-pin and stale-pin (post-re-pair) cases, and self-heals on every dispatch.

## Validation

- New `dispatch-chrome-autobind.test.ts` (4 cases): binds a NULL pin to the online worker; repins off a stale/offline worker (the re-pair case); returns null + leaves the pin untouched when no extension is online; ignores an online extension lacking `browser.debugger`. **Passing.**
- `make typecheck` clean.

Follow-up of the manual workaround from the earlier Revolut session. With this, a re-paired extension dispatches without any hand-binding.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785270814&installation_id=136316292&pr_number=1597&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1597&signature=1ee6dabfc969f7f9d75a97fc92d6b6e1147fc353a1ea9df9c749ce7a8bdee023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->