### PR TITLE
fix(server): resolve proxy network config per-server, not via a lazy global

### DIFF
--- a/packages/server/src/gateway/__tests__/egress-judge-guardrail-audit.test.ts
+++ b/packages/server/src/gateway/__tests__/egress-judge-guardrail-audit.test.ts
@@ -9,7 +9,7 @@
  * `insertEvent` seam so no Postgres is required.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // Capture `insertEvent` calls instead of hitting Postgres. `recordGuardrailTrip`
 // (the audit path) is the only consumer reached here; the other exports are
@@ -59,12 +59,24 @@ describe("egress judge deny → guardrail-trip audit", () => {
   // checkDomainAccess call — no shared module state.
   let config: ResolvedNetworkConfig;
 
+  const prevAllowed = process.env.WORKER_ALLOWED_DOMAINS;
+  const prevDisallowed = process.env.WORKER_DISALLOWED_DOMAINS;
+
   beforeEach(() => {
     insertEventCalls.length = 0;
     process.env.WORKER_ALLOWED_DOMAINS = "";
     process.env.WORKER_DISALLOWED_DOMAINS = "";
     config = resolveNetworkConfig();
     __testOnly.reset();
+  });
+
+  afterEach(() => {
+    // Restore the pre-suite env so the blank allow/deny settings can't leak into
+    // later files in Bun's shared process and reintroduce order-dependence.
+    if (prevAllowed === undefined) delete process.env.WORKER_ALLOWED_DOMAINS;
+    else process.env.WORKER_ALLOWED_DOMAINS = prevAllowed;
+    if (prevDisallowed === undefined) delete process.env.WORKER_DISALLOWED_DOMAINS;
+    else process.env.WORKER_DISALLOWED_DOMAINS = prevDisallowed;
   });
 
   test("a judged-domain DENY records a guardrail-trip with stage egress", async () => {

--- a/packages/server/src/gateway/__tests__/egress-judge-guardrail-audit.test.ts
+++ b/packages/server/src/gateway/__tests__/egress-judge-guardrail-audit.test.ts
@@ -32,6 +32,8 @@ import type {
 import { EgressJudge } from "../proxy/egress-judge/judge.js";
 import {
   __testOnly,
+  type ResolvedNetworkConfig,
+  resolveNetworkConfig,
   setProxyEgressJudge,
   setProxyPolicyStore,
 } from "../proxy/http-proxy.js";
@@ -52,12 +54,16 @@ function policyStoreReturning(rule: ResolvedJudgeRule): PolicyStore {
 }
 
 describe("egress judge deny → guardrail-trip audit", () => {
+  // Complete-isolation config snapshot so the host is never globally allowed and
+  // the decision falls through to the judge. Passed explicitly into each
+  // checkDomainAccess call — no shared module state.
+  let config: ResolvedNetworkConfig;
+
   beforeEach(() => {
     insertEventCalls.length = 0;
-    // Complete-isolation global config so the host is never globally allowed
-    // and the decision falls through to the judge.
     process.env.WORKER_ALLOWED_DOMAINS = "";
     process.env.WORKER_DISALLOWED_DOMAINS = "";
+    config = resolveNetworkConfig();
     __testOnly.reset();
   });
 
@@ -73,6 +79,7 @@ describe("egress judge deny → guardrail-trip audit", () => {
     );
 
     const decision = await __testOnly.checkDomainAccess(
+      config,
       "api.github.com",
       "agent-a",
       "org-1"
@@ -116,6 +123,7 @@ describe("egress judge deny → guardrail-trip audit", () => {
     );
 
     const decision = await __testOnly.checkDomainAccess(
+      config,
       "api.github.com",
       "agent-a",
       "org-1"

--- a/packages/server/src/gateway/__tests__/http-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/http-proxy.test.ts
@@ -14,6 +14,8 @@ import { generateWorkerToken, verifyWorkerToken } from "@lobu/core";
 import type { RevokedTokenStore } from "../auth/revoked-token-store.js";
 import {
   __testOnly,
+  type ResolvedNetworkConfig,
+  resolveNetworkConfig,
   setProxyRevokedTokenStore,
   startHttpProxy,
   stopHttpProxy,
@@ -28,7 +30,10 @@ let proxyServer: http.Server;
 
 beforeAll(async () => {
   process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
-  // Default to unrestricted for auth tests; domain tests use per-deployment config
+  // Unrestricted for the auth + unrestricted-mode tests. `startHttpProxy`
+  // snapshots this env into the server's immutable config, so every request in
+  // this file sees "*" regardless of what a sibling test file left in the shared
+  // module/env — no ordering dependence, no reset needed.
   process.env.WORKER_ALLOWED_DOMAINS = "*";
 
   proxyPort = 10000 + Math.floor(Math.random() * 50000);
@@ -418,20 +423,24 @@ describe("HTTP Proxy IDN/Unicode egress matching", () => {
   const HTTP_HOST = "xn--mnchen-3ya.de"; // what `new URL("http://münchen.de/").hostname` yields
   const CONNECT_HOST = "münchen.de"; // what the CONNECT parser returns verbatim
 
+  // Snapshot the unrestricted-with-blocklist config and pass it into each
+  // checkDomainAccess call — no shared module state, no cross-file env race.
+  let config: ResolvedNetworkConfig;
+
   beforeAll(() => {
     process.env.WORKER_ALLOWED_DOMAINS = "*";
     process.env.WORKER_DISALLOWED_DOMAINS = "münchen.de";
-    __testOnly.reset();
+    config = resolveNetworkConfig();
   });
 
   afterAll(() => {
     process.env.WORKER_ALLOWED_DOMAINS = "*";
     delete process.env.WORKER_DISALLOWED_DOMAINS;
-    __testOnly.reset();
   });
 
   test("punycode host (HTTP path) is blocked by the Unicode blocklist entry", async () => {
     const decision = await __testOnly.checkDomainAccess(
+      config,
       HTTP_HOST,
       "idn-test-agent",
       undefined
@@ -442,6 +451,7 @@ describe("HTTP Proxy IDN/Unicode egress matching", () => {
 
   test("Unicode host (CONNECT path) is blocked by the same blocklist entry", async () => {
     const decision = await __testOnly.checkDomainAccess(
+      config,
       CONNECT_HOST,
       "idn-test-agent",
       undefined

--- a/packages/server/src/gateway/__tests__/http-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/http-proxy.test.ts
@@ -427,6 +427,9 @@ describe("HTTP Proxy IDN/Unicode egress matching", () => {
   // checkDomainAccess call — no shared module state, no cross-file env race.
   let config: ResolvedNetworkConfig;
 
+  const prevAllowed = process.env.WORKER_ALLOWED_DOMAINS;
+  const prevDisallowed = process.env.WORKER_DISALLOWED_DOMAINS;
+
   beforeAll(() => {
     process.env.WORKER_ALLOWED_DOMAINS = "*";
     process.env.WORKER_DISALLOWED_DOMAINS = "münchen.de";
@@ -434,8 +437,12 @@ describe("HTTP Proxy IDN/Unicode egress matching", () => {
   });
 
   afterAll(() => {
-    process.env.WORKER_ALLOWED_DOMAINS = "*";
-    delete process.env.WORKER_DISALLOWED_DOMAINS;
+    // Restore the pre-suite env rather than hardcoding cleanup, so this block
+    // can't leak its blocklist into later files in Bun's shared process.
+    if (prevAllowed === undefined) delete process.env.WORKER_ALLOWED_DOMAINS;
+    else process.env.WORKER_ALLOWED_DOMAINS = prevAllowed;
+    if (prevDisallowed === undefined) delete process.env.WORKER_DISALLOWED_DOMAINS;
+    else process.env.WORKER_DISALLOWED_DOMAINS = prevDisallowed;
   });
 
   test("punycode host (HTTP path) is blocked by the Unicode blocklist entry", async () => {

--- a/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
+++ b/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
@@ -36,6 +36,8 @@ import { VerdictCache } from "../proxy/egress-judge/cache.js";
 import { withFreePortRetry } from "../../__tests__/setup/free-port.js";
 import {
   __testOnly,
+  type ResolvedNetworkConfig,
+  resolveNetworkConfig,
   setProxyEgressJudge,
   setProxyPolicyStore,
   setProxyRevokedTokenStore,
@@ -1063,10 +1065,15 @@ describe("egress denylist — trailing-dot FQDN canonicalization", () => {
   const prevAllowed = process.env.WORKER_ALLOWED_DOMAINS;
   const prevDisallowed = process.env.WORKER_DISALLOWED_DOMAINS;
 
+  // Config snapshot for this block — built from the env set in beforeEach and
+  // passed into each checkDomainAccess call, so the assertions don't depend on
+  // any shared module state.
+  let config: ResolvedNetworkConfig;
+
   beforeEach(() => {
     process.env.WORKER_ALLOWED_DOMAINS = "*";
     process.env.WORKER_DISALLOWED_DOMAINS = "pastebin.com";
-    __testOnly.reset();
+    config = resolveNetworkConfig();
   });
 
   afterEach(() => {
@@ -1074,28 +1081,32 @@ describe("egress denylist — trailing-dot FQDN canonicalization", () => {
     else process.env.WORKER_ALLOWED_DOMAINS = prevAllowed;
     if (prevDisallowed === undefined) delete process.env.WORKER_DISALLOWED_DOMAINS;
     else process.env.WORKER_DISALLOWED_DOMAINS = prevDisallowed;
-    __testOnly.reset();
   });
 
   test("blocks a denylisted host written with a trailing dot", async () => {
     expect(
-      (await __testOnly.checkDomainAccess("pastebin.com", undefined, undefined)).allowed
+      (await __testOnly.checkDomainAccess(config, "pastebin.com", undefined, undefined))
+        .allowed
     ).toBe(false);
     // The bug: this returned allowed:true before the canonicalization fix.
     expect(
-      (await __testOnly.checkDomainAccess("pastebin.com.", undefined, undefined)).allowed
+      (await __testOnly.checkDomainAccess(config, "pastebin.com.", undefined, undefined))
+        .allowed
     ).toBe(false);
     expect(
-      (await __testOnly.checkDomainAccess("pastebin.com..", undefined, undefined)).allowed
+      (await __testOnly.checkDomainAccess(config, "pastebin.com..", undefined, undefined))
+        .allowed
     ).toBe(false);
   });
 
   test("still allows a non-denylisted host (trailing dot or not) in unrestricted mode", async () => {
     expect(
-      (await __testOnly.checkDomainAccess("example.com", undefined, undefined)).allowed
+      (await __testOnly.checkDomainAccess(config, "example.com", undefined, undefined))
+        .allowed
     ).toBe(true);
     expect(
-      (await __testOnly.checkDomainAccess("example.com.", undefined, undefined)).allowed
+      (await __testOnly.checkDomainAccess(config, "example.com.", undefined, undefined))
+        .allowed
     ).toBe(true);
   });
 });

--- a/packages/server/src/gateway/proxy/http-proxy.ts
+++ b/packages/server/src/gateway/proxy/http-proxy.ts
@@ -26,9 +26,31 @@ import {
 
 const logger = createLogger("http-proxy");
 
-interface ResolvedNetworkConfig {
+/**
+ * The worker network allow/deny config for one proxy server, resolved once from
+ * the environment when the server starts. It is an immutable snapshot threaded
+ * through the request handlers — there is deliberately NO process-wide mutable
+ * cache. A lazily-populated module global (the previous design) read `process.env`
+ * at whatever moment the first request happened to fire and then froze that value
+ * for the life of the process, which made behavior order-dependent (and, in the
+ * test runner where the module + env are shared across files, leaked one file's
+ * env into another's). Resolving per-server removes that coupling entirely.
+ */
+export interface ResolvedNetworkConfig {
   allowedDomains: string[];
   deniedDomains: string[];
+}
+
+/**
+ * Resolve the worker network allow/deny config from the current environment.
+ * Called once per {@link startHttpProxy}. The pattern lists are pre-lowercased
+ * here so the per-request matcher never re-lowercases on the hot path.
+ */
+export function resolveNetworkConfig(): ResolvedNetworkConfig {
+  return {
+    allowedDomains: loadAllowedDomains().map((d) => d.toLowerCase()),
+    deniedDomains: loadDisallowedDomains().map((d) => d.toLowerCase()),
+  };
 }
 
 interface TargetResolutionResult {
@@ -38,9 +60,6 @@ interface TargetResolutionResult {
   clientMessage?: string;
   reason?: string;
 }
-
-// Cache for global defaults (used when no deployment identified)
-let globalConfig: ResolvedNetworkConfig | null = null;
 
 // Module-level grant store reference for domain grant checks
 let proxyGrantStore: GrantStore | null = null;
@@ -103,18 +122,6 @@ export function setProxyEgressJudge(judge: EgressJudge): void {
   proxyEgressJudge = judge;
 }
 
-function getGlobalConfig(): ResolvedNetworkConfig {
-  if (!globalConfig) {
-    // Pre-lowercase the env-driven pattern lists once so the per-request
-    // matcher doesn't re-lowercase every pattern on every outbound request.
-    globalConfig = {
-      allowedDomains: loadAllowedDomains().map((d) => d.toLowerCase()),
-      deniedDomains: loadDisallowedDomains().map((d) => d.toLowerCase()),
-    };
-  }
-  return globalConfig;
-}
-
 /**
  * Outcome of a full access decision. When the judge is consulted,
  * `judge` carries the verdict so the caller can surface the reason to
@@ -136,12 +143,13 @@ interface AccessDecision {
  *    host → invoke the LLM judge → allow/block based on verdict
  */
 async function checkDomainAccess(
+  config: ResolvedNetworkConfig,
   hostname: string,
   agentId: string | undefined,
   organizationId: string | undefined,
   requestContext?: { method?: string; path?: string }
 ): Promise<AccessDecision> {
-  const global = getGlobalConfig();
+  const global = config;
 
   // Canonicalize once so the denylist, allowlist, grant store, and judge all
   // match the same name (closes the trailing-dot FQDN blocklist bypass).
@@ -267,9 +275,13 @@ export const __testOnly = {
   isBlockedIpAddress,
   checkDomainAccess,
   canonicalizeHostname,
-  /** Reset cached global config + module-level stores so tests can rebuild them. */
+  /**
+   * Clear the explicitly-injected test doubles (stores + DNS override) so one
+   * test file's injection doesn't leak into another. Network config is NOT here:
+   * it's no longer a module global — each {@link startHttpProxy} resolves its own
+   * immutable snapshot, and direct {@link checkDomainAccess} callers pass one in.
+   */
   reset: () => {
-    globalConfig = null;
     proxyGrantStore = null;
     proxyPolicyStore = null;
     proxyEgressJudge = null;
@@ -604,6 +616,7 @@ function extractConnectHostname(url: string): string | null {
  * Handle HTTPS CONNECT tunneling with per-deployment network config
  */
 async function handleConnect(
+  config: ResolvedNetworkConfig,
   req: http.IncomingMessage,
   clientSocket: import("stream").Duplex,
   head: Buffer
@@ -664,6 +677,7 @@ async function handleConnect(
   // TLS CONNECT tunneling means we cannot see the method or path — the
   // judge decides on hostname alone.
   const decision = await checkDomainAccess(
+    config,
     hostname,
     tokenData.agentId,
     tokenData.organizationId
@@ -773,6 +787,7 @@ async function handleConnect(
  * Handle regular HTTP proxy requests with per-deployment network config
  */
 async function handleProxyRequest(
+  config: ResolvedNetworkConfig,
   req: http.IncomingMessage,
   res: http.ServerResponse
 ): Promise<void> {
@@ -812,10 +827,16 @@ async function handleProxyRequest(
   // Check domain access: global config → grant store → LLM egress judge.
   // Plain HTTP: method and path are visible and are passed through to the
   // judge so policies can reason about specific endpoints.
-  const decision = await checkDomainAccess(hostname, tokenData.agentId, tokenData.organizationId, {
-    method: req.method,
-    path: parsedUrl.pathname + parsedUrl.search,
-  });
+  const decision = await checkDomainAccess(
+    config,
+    hostname,
+    tokenData.agentId,
+    tokenData.organizationId,
+    {
+      method: req.method,
+      path: parsedUrl.pathname + parsedUrl.search,
+    }
+  );
   logAccessDecision(
     req.method ?? "?",
     hostname,
@@ -912,17 +933,21 @@ async function handleProxyRequest(
  *
  * @param port - Port to listen on (default 8118)
  * @param host - Bind address (default "::" for all interfaces)
+ * @param config - Network allow/deny config for this server. Defaults to a fresh
+ *   snapshot resolved from the environment; tests pass one explicitly so the
+ *   server's behavior is fully determined by its arguments, not ambient state.
  * @returns Promise that resolves with the server once listening, or rejects on error
  */
 export function startHttpProxy(
   port: number = 8118,
-  host: string = "::"
+  host: string = "::",
+  config: ResolvedNetworkConfig = resolveNetworkConfig()
 ): Promise<http.Server> {
   return new Promise((resolve, reject) => {
-    const global = getGlobalConfig();
+    const global = config;
 
     const server = http.createServer((req, res) => {
-      handleProxyRequest(req, res).catch((err) => {
+      handleProxyRequest(config, req, res).catch((err) => {
         logger.error("Error handling proxy request:", err);
         if (!res.headersSent) {
           res.writeHead(500, { "Content-Type": "text/plain" });
@@ -933,7 +958,7 @@ export function startHttpProxy(
 
     // Handle CONNECT method for HTTPS tunneling
     server.on("connect", (req, clientSocket, head) => {
-      handleConnect(req, clientSocket, head).catch((err) => {
+      handleConnect(config, req, clientSocket, head).catch((err) => {
         logger.error("Error handling CONNECT:", err);
         try {
           clientSocket.write("HTTP/1.1 500 Internal Server Error\r\n\r\n");


### PR DESCRIPTION
## Problem

CI's `integration` job intermittently failed on the **server gateway suites** step: `http-proxy.test.ts` returned `403 Domain not allowed` for hosts that should be allowed (auth "accepts CONNECT 200" + all "unrestricted mode" tests).

Root cause: the proxy stored its worker network allow/deny rules in a **lazily-populated, mutable, module-level `globalConfig`** that read `process.env` on the first request and then froze for the life of the process. In bun's test runner the module registry **and** `process.env` are shared across every file in one `bun test <dir>` process, so a sibling test that built `globalConfig` under a restrictive env leaked it into `http-proxy.test.ts`. The flake was order-dependent (CI discovers files in filesystem, not alphabetical, order).

The previous mitigation — sprinkling `__testOnly.reset()` — only papered over the hidden global.

## Fix (root cause, not a workaround)

Eliminate the hidden mutable global:

- Add `resolveNetworkConfig()` and exported `ResolvedNetworkConfig`.
- `startHttpProxy(port, host, config = resolveNetworkConfig())` resolves the config **once, eagerly, at startup** and threads it as an immutable per-server value through `handleConnect` / `handleProxyRequest` / `checkDomainAccess`.
- Delete `globalConfig` and `getGlobalConfig()`. `__testOnly.reset()` now only clears the explicitly-injected test doubles (stores + DNS override), which remain a legitimate dynamic injection seam.
- Tests calling `checkDomainAccess` directly pass an explicit config snapshot.

This makes the cross-file leak **structurally impossible**, and matches how `proxy-hardening.test.ts` already worked (set env → then `startHttpProxy`). Production behavior is unchanged: env is fixed at boot and the proxy starts once, so a per-server snapshot is identical to the old first-request read — just without the process-wide cache.

## Verification

- tsc: 0 errors (after `make build-packages`).
- Red→green: a deny-all polluter (dirty env, no reset) that previously broke the suite now passes 3/3 reruns.
- All proxy suites (http-proxy, judge, hardening, guardrail-audit, ssrf): 129 pass / 0 fail.
- Full `src/gateway/__tests__` dir: 1402 pass — identical failure set to clean origin/main (2 pre-existing, local-Postgres-dependent e2e/timeout tests that pass in CI). No regressions.

## Note (out of scope)

While scoping this I noticed the proxy's per-agent grant/policy/judge read-side setters (`setProxyGrantStore` / `setProxyPolicyStore` / `setProxyEgressJudge`) aren't called in the embedded gateway boot (`lobu/gateway.ts`) — the deployment-manager writes to those stores but the proxy's module globals have no singleton fallback. Worth verifying separately whether the egress judge / per-agent grants actually fire at runtime in the embedded path; this PR does not change those seams.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785277659&installation_id=136316292&pr_number=1598&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1598&signature=a83b5c066547ffaccf13a9a33912990aecce037d7696f16832893081a82d8c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy access checks to apply a single, consistent network allow/deny policy across both standard HTTP requests and CONNECT tunneling, reducing inconsistent routing decisions.
  * Fixed internationalized domain (IDN) and trailing-dot FQDN handling so access rules are evaluated more reliably for both allowed and blocked destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->