### PR TITLE
fix(server): wire grant + policy stores into the HTTP egress proxy at boot

### DIFF
--- a/packages/server/src/gateway/proxy/proxy-manager.ts
+++ b/packages/server/src/gateway/proxy/proxy-manager.ts
@@ -1,10 +1,47 @@
 import type { Server } from "node:http";
 import { createLogger } from "@lobu/core";
-import { startHttpProxy, stopHttpProxy } from "./http-proxy.js";
+import type { GrantStore } from "../permissions/grant-store.js";
+import type { PolicyStore } from "../permissions/policy-store.js";
+import {
+  setProxyGrantStore,
+  setProxyPolicyStore,
+  startHttpProxy,
+  stopHttpProxy,
+} from "./http-proxy.js";
 
 const logger = createLogger("proxy-manager");
 
 let proxyServer: Server | null = null;
+
+/**
+ * Wire the grant + policy stores the deployment manager WRITES into the HTTP
+ * egress proxy, which READS them per request. Without this the proxy's
+ * `proxyGrantStore`/`proxyPolicyStore` stay null and `checkDomainAccess`
+ * silently skips per-agent grants and the LLM egress judge, leaving only the
+ * global `WORKER_ALLOWED_DOMAINS` allowlist in force. (This wiring was dropped
+ * in #672's dead-code sweep when the proxy stores still looked unused;
+ * `startFilteringProxy()` was re-added at the gateway boot site but these two
+ * calls were not.) `setProxyPolicyStore` also lazily constructs the real
+ * `EgressJudge`, so judged-domain rules become enforceable.
+ *
+ * Lives here (not in `lobu/gateway.ts`) so it can be unit-tested without pulling
+ * in the heavyweight, route-test-mocked gateway module — the regression slipped
+ * through precisely because every proxy test injects these stores itself, so
+ * nothing covered the boot path.
+ */
+export function wireProxyEgressStores(services: {
+  getGrantStore(): GrantStore | undefined;
+  getPolicyStore(): PolicyStore | undefined;
+}): void {
+  const grantStore = services.getGrantStore();
+  if (grantStore) {
+    setProxyGrantStore(grantStore);
+  }
+  const policyStore = services.getPolicyStore();
+  if (policyStore) {
+    setProxyPolicyStore(policyStore);
+  }
+}
 
 /**
  * Start filtering HTTP proxy for worker network isolation. Workers can

--- a/packages/server/src/lobu/__tests__/wire-proxy-egress-stores.test.ts
+++ b/packages/server/src/lobu/__tests__/wire-proxy-egress-stores.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Regression guard for the gateway boot wiring of the HTTP egress proxy.
+ *
+ * The proxy READS per-agent grants + judged-domain policy from module-level
+ * stores that must be injected at boot (`setProxyGrantStore` /
+ * `setProxyPolicyStore`). #672's dead-code sweep deleted those two boot calls
+ * (it kept `startFilteringProxy()`), so at runtime the proxy silently skipped
+ * grants and never consulted the egress judge — only the global
+ * `WORKER_ALLOWED_DOMAINS` allowlist stayed in force. Every proxy test injects
+ * the stores itself, so nothing covered the boot path and the regression shipped.
+ *
+ * `wireProxyEgressStores` is the extracted boot step. These tests prove, in the
+ * red→green sense, that:
+ *   - WITHOUT it, a per-agent grant / judged-domain rule has no effect (the
+ *     exact regression behavior); and
+ *   - WITH it, the grant is honored and the judged domain reaches the judge.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { GrantStore } from "../../gateway/permissions/grant-store.js";
+import type {
+  PolicyStore,
+  ResolvedJudgeRule,
+} from "../../gateway/permissions/policy-store.js";
+import { EgressJudge } from "../../gateway/proxy/egress-judge/judge.js";
+import type {
+  JudgeClient,
+  JudgeVerdict,
+} from "../../gateway/proxy/egress-judge/types.js";
+import {
+  __testOnly,
+  resolveNetworkConfig,
+  setProxyEgressJudge,
+} from "../../gateway/proxy/http-proxy.js";
+import { wireProxyEgressStores } from "../../gateway/proxy/proxy-manager.js";
+
+// Deny-all global config so every decision falls through to the per-agent grant
+// store / judged-domain policy — the layers the boot wiring is responsible for.
+function denyAllConfig() {
+  const prev = process.env.WORKER_ALLOWED_DOMAINS;
+  process.env.WORKER_ALLOWED_DOMAINS = "";
+  const config = resolveNetworkConfig();
+  if (prev === undefined) delete process.env.WORKER_ALLOWED_DOMAINS;
+  else process.env.WORKER_ALLOWED_DOMAINS = prev;
+  return config;
+}
+
+function grantStoreAllowing(
+  agentId: string,
+  hostname: string,
+  orgId: string
+): GrantStore {
+  return {
+    async hasGrant(a: string, h: string, o?: string): Promise<boolean> {
+      return a === agentId && h === hostname && o === orgId;
+    },
+    async isDenied(): Promise<boolean> {
+      return false;
+    },
+  } as unknown as GrantStore;
+}
+
+function policyStoreReturning(rule: ResolvedJudgeRule): PolicyStore {
+  return { resolve: () => rule } as unknown as PolicyStore;
+}
+
+describe("wireProxyEgressStores — boot wiring of the HTTP egress proxy", () => {
+  beforeEach(() => {
+    // Start from the unwired runtime state — the regression baseline.
+    __testOnly.reset();
+  });
+
+  test("UNWIRED: a per-agent grant has no effect (regression behavior)", async () => {
+    const config = denyAllConfig();
+    const decision = await __testOnly.checkDomainAccess(
+      config,
+      "github.com",
+      "agent-a",
+      "org-1"
+    );
+    // No grant store wired → grant path skipped → blocked by global deny-all.
+    expect(decision.allowed).toBe(false);
+    expect(decision.source).toBe("global");
+  });
+
+  test("WIRED: the grant store is connected so a per-agent grant is honored", async () => {
+    wireProxyEgressStores({
+      getGrantStore: () => grantStoreAllowing("agent-a", "github.com", "org-1"),
+      getPolicyStore: () => undefined,
+    });
+
+    const config = denyAllConfig();
+    const decision = await __testOnly.checkDomainAccess(
+      config,
+      "github.com",
+      "agent-a",
+      "org-1"
+    );
+    expect(decision.allowed).toBe(true);
+    expect(decision.source).toBe("grant");
+  });
+
+  test("UNWIRED: a judged domain is never judged (falls through to deny)", async () => {
+    const config = denyAllConfig();
+    const decision = await __testOnly.checkDomainAccess(
+      config,
+      "api.github.com",
+      "agent-a",
+      "org-1"
+    );
+    expect(decision.source).not.toBe("judge");
+    expect(decision.allowed).toBe(false);
+  });
+
+  test("WIRED: the policy store is connected so a judged domain reaches the egress judge", async () => {
+    const rule: ResolvedJudgeRule = {
+      judgeName: "repo-owner-only",
+      policy: "allow only repos the user owns",
+      policyHash: "policy-hash-1",
+    };
+    wireProxyEgressStores({
+      getGrantStore: () => undefined,
+      getPolicyStore: () => policyStoreReturning(rule),
+    });
+    // `setProxyPolicyStore` lazily builds a real EgressJudge; swap in a fake
+    // client so the verdict is deterministic and no model is called. This proves
+    // the policy store was wired (the judge path is only reached when resolve()
+    // returns a rule from the wired store).
+    const denyClient: JudgeClient = {
+      async judge(): Promise<JudgeVerdict> {
+        return { verdict: "deny", reason: "not permitted" };
+      },
+    };
+    setProxyEgressJudge(
+      new EgressJudge({ client: denyClient, defaultModel: "judge-test" })
+    );
+
+    const config = denyAllConfig();
+    const decision = await __testOnly.checkDomainAccess(
+      config,
+      "api.github.com",
+      "agent-a",
+      "org-1"
+    );
+    expect(decision.source).toBe("judge");
+    expect(decision.judge?.verdict).toBe("deny");
+  });
+});

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -28,6 +28,7 @@ import { Orchestrator } from "../gateway/orchestration/index";
 import {
 	startFilteringProxy,
 	stopFilteringProxy,
+	wireProxyEgressStores,
 } from "../gateway/proxy/proxy-manager";
 import { SecretStoreRegistry } from "../gateway/secrets/index";
 import type { Env } from "../index";
@@ -386,6 +387,9 @@ export async function initLobuGateway(): Promise<Hono | null> {
 			coreServices.getAgentSettingsStore() ?? undefined,
 		);
 		logger.info("[Lobu] Embedded orchestrator injected core services");
+
+		wireProxyEgressStores(coreServices);
+		logger.info("[Lobu] Egress grant + policy stores wired into HTTP proxy");
 
 		// Wire the deployment manager's idle clock into the worker gateway so every
 		// worker-driven HTTP response (delta / status_update / ACK / terminal reply)


### PR DESCRIPTION
**Stacked on #1598** (`fix/proxy-network-config-per-server`) — review/merge that first; this PR's diff is just the second commit.

## Problem (security regression)

The HTTP egress proxy *reads* per-agent grants and judged-domain policy from module-level stores that must be injected at boot via `setProxyGrantStore` / `setProxyPolicyStore`. Commit #672 ("simplification sweep — dead code") deleted those two boot calls from `cli/gateway.ts`; `startFilteringProxy()` was later re-added in the embedded gateway boot (`lobu/gateway.ts`) but the two `setProxy*` calls were **not**.

Net effect at runtime: `proxyGrantStore` / `proxyPolicyStore` stay `null`, so `checkDomainAccess` silently skips per-agent grants and **never consults the LLM egress judge** — only the global `WORKER_ALLOWED_DOMAINS` allowlist is enforced. The deployment-manager keeps *writing* grants + policy bundles into stores that nothing reads.

### Why it shipped undetected

Every proxy test injects the stores itself (`setProxyPolicyStore(...)` in `proxy-hardening` / `http-proxy-judge` / `egress-judge-guardrail-audit`), so the suite proved the *enforcement logic* while nothing covered the *boot wiring*. That's also why an earlier e2e "passed" — it wired the seam the product had stopped wiring.

## Fix

- Extract `wireProxyEgressStores(coreServices)` and call it from `initLobuGateway` right after core services are available. `setProxyPolicyStore` also lazily constructs the real `EgressJudge`, so judged-domain rules become enforceable again.
- Add a **red→green** regression test (`wire-proxy-egress-stores.test.ts`) that exercises the wiring directly:
  - UNWIRED (regression behavior): a per-agent grant / judged domain has no effect.
  - WIRED: the grant is honored (`source: grant`) and the judged domain reaches the egress judge (`source: judge`).
  - Verified red→green: neutering the wiring fails the two WIRED tests; restoring passes all four.

## Verification
- `bun test wire-proxy-egress-stores.test.ts` → 4 pass / 0 fail; red→green confirmed.
- server tsc: 0 errors. Pre-commit (biome + tsc) green.

## Follow-up worth considering
A boot-level smoke test that drives `initLobuGateway()` end-to-end would catch "boot forgot to call a wiring helper" for the whole composition root, not just this one seam.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785279651&installation_id=136316292&pr_number=1599&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1599&signature=eb16ab4b011f056c89983c1530f46ab1a301a3e099d0f9462a63c8a936dfc77b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The gateway now connects proxy access checks to available permission and policy data at startup.
  * Per-request domain access can now reflect configured grants and policy-based judgment when those stores are available.

* **Bug Fixes**
  * Fixed proxy startup so access decisions no longer fall back to deny-only behavior when permission or policy data is present.
  * Added regression coverage to verify both grant-based access and judged-domain handling work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->