### PR TITLE
feat(authz): channel audience read + Reach endpoint; fix Slack read-method encoding

### DIFF
--- a/docs/plans/slack-mcp-agent-actions-and-audience.md
+++ b/docs/plans/slack-mcp-agent-actions-and-audience.md
@@ -1,0 +1,128 @@
+# Agent actions via platform MCP + per-agent capability scope + audience/recall UI
+
+Status: DESIGN. Verified against code on branch `feat/authz-audience-ui` (base `0c4cec56c`) and against live Slack docs/endpoints, 2026-06-28.
+
+This doc replaces the original "build an Audience UI on the Channels/Reach tab" framing with the
+broader model it kept collapsing into. The audience UI is one slice (the governance surface); the
+substrate is "agents act on connected platforms through the platform's own MCP, as the signed-in
+user, bounded by a per-agent capability scope."
+
+## The model
+
+A connected platform resource (Slack channel, GitHub repo) is a **Source** with three facets that
+all hang off one physical fact — the bot/app is a member of it:
+
+- **Reach** — who/what can talk *to* the agent (`agent_channel_bindings`, MCP clients, webhooks).
+- **Capture** — what conversation data is collected (`channel_messages`, webhook-only, the
+  `recordChannelMessages` whole-channel toggle).
+- **Audience** — who may *recall that data back* through the agent (the `member_of` graph +
+  `authz_source_acl_state` gate, shipped in #1586/#1590).
+
+The agent is the actor: **Agent = identity + reach + capability scope + approval policy.** The
+builder agent (`lobu-builder`, `organization.system_agent_id`) has a broad scope and drives setup
+conversationally; purpose agents (e.g. a food-delivery agent) get a narrow scope. The UI's role
+shrinks to **audit / manage / govern** — the audience/recall surface is the first instance of that.
+
+## How agents act on platforms: use the platform's official MCP, as the user
+
+Decided after ruling out alternatives:
+
+- **NOT** bespoke per-action gateway endpoints (doesn't generalize).
+- **NOT** generalizing `slack-web.ts` into first-party connector actions (would make Slack a
+  runtime connector, hits the `app_installations` ↔ `connections` credential seam, and is redundant
+  once the platform ships an MCP).
+- **NOT** the sync-connector `ActionDefinition`/`execute()` path (credentials resolve from the
+  `connections`/`auth_profile` world; Slack lives in `agent_connections`/`app_installations`).
+
+Instead: **consume the platform's official MCP server with per-user OAuth.** Verified live:
+
+### Slack MCP (verified)
+
+- Endpoint: `https://mcp.slack.com/mcp` (JSON-RPC 2.0 over Streamable HTTP).
+- Per-user OAuth user tokens. `.well-known/oauth-protected-resource` →
+  `authorization_servers`, `bearer_methods_supported: [header, form]`, full `scopes_supported`.
+- `.well-known/oauth-authorization-server`: `authorization_endpoint =
+  https://slack.com/oauth/v2_user/authorize`, `token_endpoint =
+  https://slack.com/api/oauth.v2.user.access`, `grant_types = [authorization_code, refresh_token]`,
+  `token_endpoint_auth_methods = [client_secret_post]`, `code_challenge_methods = [S256]`.
+- **No DCR** (no `registration_endpoint`) → must use a **static client** (our app's
+  `client_id`/`client_secret`).
+- Read + write tools: search (messages/files/users/channels/emoji), history, `chat:write`,
+  draft, create channel, reactions, canvas read/write, list channel members, user info.
+- Constraint: **"only directory-published or internal apps may use MCP; unlisted apps are
+  prohibited."** This is the one hard external dependency (see Risks).
+
+### Why this is mostly already built
+
+`packages/server/src/gateway/auth/mcp/` already implements a conformant per-user MCP OAuth client
+that matches Slack's advertised flow 1:1:
+
+- `oauth-flow.ts` — authorization-code + PKCE (S256), static `client_id`/`client_secret` path.
+- `oauth-discovery.ts` — `WWW-Authenticate` → protected-resource-metadata → auth-server-metadata.
+- `proxy-upstream.ts` (`resolveCredentialToken`) + `device-auth.ts` — credentials stored
+  per-`(agentId, userId, mcpId)`, 5-min refresh buffer, auto-refresh via `refresh_token`.
+- `proxy-shared.ts` (`computeScopeKey`, `buildUpstreamHeaders`) — `authScope: "user"` keys
+  credentials per acting user; Bearer attached per upstream call.
+- A tool call that 401s triggers the OAuth flow automatically (`proxy-rest-routes.ts`).
+
+So the agent acts as **whichever signed-in user is driving the run** — by construction, bounded by
+that user's real Slack permissions ("if the user has access, it shows"). Headless/shared runs have
+no user token → the interactive 401→OAuth flow can't complete → those Slack-MCP tools surface
+"auth needed / unavailable" rather than falling back to a shared token. That is the acting-user
+boundary; no new model required.
+
+## Credential reality (corrected)
+
+`resolveExecutionAuth` (sync-connector path) resolves by `connectionId`, not acting user:
+`oauth_account` connections run on the **connecting user's** grant (real user auth, fixed at
+connect time); `app_installation` connections (Slack bot, GitHub App) run on the **org/app** token.
+The Slack bot token stays for events/capture. Agent *actions* go through the **MCP** path above,
+which is genuinely per-acting-user.
+
+## Per-agent capability scope (the net-new spine)
+
+Today operations are **org-wide and ungated**: `listOperations` / `manage_operations` take
+`organizationId` but never `agentId`, and `connections.agent_id` exists but is unused in the
+operations path. Any agent can discover and `execute` any org connection's tools. For
+app/MCP-token actions there is **no user-permission fence underneath**, so the per-agent scope is
+the load-bearing boundary.
+
+Net-new:
+
+- A per-agent capability-scope store: agent → allowed connectors/connections (+ optionally
+  per-tool allow). Candidate: reuse/extend `connections.agent_id` + an `agent_connector_grants`
+  shape, surfaced in `AgentSettings`.
+- Enforce in `manage_operations` discovery (`list_available` passes `ctx.agentId` → `listOperations`
+  filters) **and** execute (validate `ctx.agentId` may use the requested `connection_id`).
+- Approval: existing `requires_approval` + held-run `BuilderApprovalCard`; default write tools
+  (`chat:write`, `channels:write`) to approval-required.
+
+## Audience / recall UI (slice 1, unblocked)
+
+Read-only projection of the `member_of` graph — the inverse of the recall gate. The gate does
+`requester → visible resources`; the audience reads `resource entity → members` (same `member_of`
++ `entity_identities` joins, flipped: join identities on `from_entity_id`, filter on
+`to_entity_id`). Write it resource-generic (keyed on resource entity type) so `repo` slots in later.
+Enforcement status per connection from `authz_source_acl_state` (enforced = full+fresh+<60min /
+onboarded-but-stale / not-graphed = legacy). Surface on the Agent → Channels/Reach tab: card
+audience row (avatar stack + "N can recall" + gated/agent-only/not-synced chip) + detail panel
+(Enforcement segment + "Who can recall" list with you / linked-Slack / Slack-member pills + DM
+deep links). Slack is the source of truth; READ-ONLY. No MCP/publishing dependency.
+
+## Risks / dependencies
+
+- **Directory-publishing the Lobu Slack app** — hard gate for any live MCP use. Repo ships only a
+  `self-install` template manifest; publishing status is a Slack-console property to confirm/achieve
+  (review process). Blocks slice 3 only.
+- **Token-response shape from `oauth.v2.user.access`** — verify Lobu's token parser accepts it on
+  the first real grant (low risk given conformant AS metadata; gated on publishing).
+- **Capability-scope correctness is security-critical** for app/MCP-token actions (no second fence).
+
+## Sequencing (one branch = one concern)
+
+1. Audience/recall UI — unblocked; original branch `feat/authz-audience-ui`.
+2. Per-agent capability scope — unblocked; separate branch.
+3. Slack MCP wiring (static client config + register `mcp.slack.com/mcp`, full-builder scopes,
+   `authScope:"user"`) — config-level; live-testable only once the app is directory-published.
+
+Multi-replica: every piece is a Postgres-mediated read/write; no in-memory cross-pod state.

--- a/packages/server/src/__tests__/integration/authz/channel-audience.test.ts
+++ b/packages/server/src/__tests__/integration/authz/channel-audience.test.ts
@@ -165,7 +165,10 @@ describe('channel audience read', () => {
     // Production sync path: conversations.members returns Alice AND the bot.
     const result = await syncSlackConnectionAcl(
       {
-        slackWeb: { conversationMembers: async () => ['U01ALICE', 'UBOTLOBU'] },
+        slackWeb: {
+          conversationMembers: async () => ['U01ALICE', 'UBOTLOBU'],
+          conversationInfo: async () => ({ name: 'eng', isPrivate: false }),
+        },
         resolveBotToken: async () => 'xoxb-test-token',
       },
       { connectionId: CONN, organizationId: org.id },
@@ -187,6 +190,8 @@ describe('channel audience read', () => {
     const botCombined = normalizeSlackUserId(TEAM, 'UBOTLOBU');
     expect(eng?.members.some((m) => m.slackUserId === botCombined)).toBe(false);
     expect(eng?.members[0]?.isYou).toBe(true);
+    // conversations.info name is captured and surfaced on the audience.
+    expect(eng?.channelName).toBe('eng');
   });
 
   it('reports no current audience for a stale (aged-out) connection even with old member_of edges', async () => {

--- a/packages/server/src/__tests__/integration/authz/channel-audience.test.ts
+++ b/packages/server/src/__tests__/integration/authz/channel-audience.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Channel audience read — the INVERSE of the visibility gate. Proves the
+ * governance view ("who can recall #channel") reads the SAME `member_of` graph
+ * the gate enforces: a member shows up in a channel's audience iff they'd be
+ * allowed to recall it. Also proves the enforcement-status projection (enforced
+ * vs not-graphed) and the requester "you" highlight.
+ */
+
+import { normalizeSlackUserId } from '@lobu/connector-sdk';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { getChannelAudiences } from '../../../authz/audience';
+import { syncSlackConnectionAcl } from '../../../authz/slack-acl-sync';
+import { buildSlackChannelGraph } from '../../../authz/slack-channel-graph';
+import { resolveBoundChannelRows } from '../../../gateway/channels/bound-channels';
+import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAgent,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const TEAM = 'T01ACME';
+const CONN = 'conn-acme';
+
+async function seedSignedInMember(opts: {
+  orgId: string;
+  userId: string;
+  name: string;
+  slackUserId: string;
+}): Promise<void> {
+  const sql = getTestDb();
+  const entity = await createTestEntity({
+    name: opts.name,
+    entity_type: '$member',
+    organization_id: opts.orgId,
+    created_by: opts.userId,
+  });
+  const combined = normalizeSlackUserId(TEAM, opts.slackUserId);
+  await sql`
+    INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+    VALUES
+      (${opts.orgId}, ${entity.id}, 'auth_user_id', ${opts.userId}, 'auth:signup'),
+      (${opts.orgId}, ${entity.id}, 'slack_user_id', ${combined}, 'connector:slack')
+  `;
+}
+
+async function setupWorkspace() {
+  const org = await createTestOrganization({ name: 'Acme' });
+  const alice = await createTestUser({ name: 'Alice' });
+  await addUserToOrganization(alice.id, org.id, 'owner');
+  const agent = await createTestAgent({ organizationId: org.id });
+
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+    VALUES (${org.id}, 'person', 'Person', current_timestamp, current_timestamp)
+    ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+    DO NOTHING
+  `;
+  await sql`
+    INSERT INTO agent_connections (id, agent_id, platform, organization_id, status)
+    VALUES (${CONN}, ${agent.agentId}, 'slack', ${org.id}, 'active')
+  `;
+  for (const channelId of ['C01ENG', 'C01SEC']) {
+    await sql`
+      INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id)
+      VALUES (${org.id}, ${agent.agentId}, 'slack', ${channelId}, ${TEAM})
+    `;
+  }
+  await seedSignedInMember({
+    orgId: org.id,
+    userId: alice.id,
+    name: 'Alice',
+    slackUserId: 'U01ALICE',
+  });
+  return { org, alice, agent };
+}
+
+describe('channel audience read', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    clearEntityLinkRulesCache();
+  });
+
+  it('returns each channel`s members from the same member_of graph the gate reads', async () => {
+    const { org, alice, agent } = await setupWorkspace();
+    await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      teamId: TEAM,
+      channels: [
+        { channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01ALICE'] },
+        { channelId: 'C01SEC', name: 'secret', isPrivate: true, memberSlackUserIds: ['U01BOB'] },
+      ],
+    });
+
+    const sql = getTestDb();
+    const rows = await resolveBoundChannelRows(sql, {
+      organizationId: org.id,
+      agentId: agent.agentId,
+    });
+    const audiences = await getChannelAudiences(sql, {
+      organizationId: org.id,
+      userId: alice.id,
+      rows,
+    });
+
+    const eng = audiences.find((a) => a.channelId === 'C01ENG');
+    const sec = audiences.find((a) => a.channelId === 'C01SEC');
+    expect(eng).toBeTruthy();
+    expect(sec).toBeTruthy();
+
+    // #eng: Alice only, enforced, and SHE is the requester → "you".
+    expect(eng?.enforcement.status).toBe('enforced');
+    expect(eng?.memberCount).toBe(1);
+    const aliceMember = eng?.members.find((m) => m.isYou);
+    expect(aliceMember).toBeTruthy();
+    expect(aliceMember?.source).toBe('you');
+    expect(aliceMember?.displayName).toBe('Alice');
+
+    // #secret: Bob (never signed in) → a plain Slack member, not the requester.
+    expect(sec?.memberCount).toBe(1);
+    expect(sec?.members.every((m) => !m.isYou)).toBe(true);
+    expect(sec?.members[0]?.source).toBe('slack-member');
+  });
+
+  it('reports not-graphed (no audience) for a connection without a materialized graph', async () => {
+    const { org, alice, agent } = await setupWorkspace();
+    // No buildSlackChannelGraph → no authz_source_acl_state row.
+    const sql = getTestDb();
+    const rows = await resolveBoundChannelRows(sql, {
+      organizationId: org.id,
+      agentId: agent.agentId,
+    });
+    const audiences = await getChannelAudiences(sql, {
+      organizationId: org.id,
+      userId: alice.id,
+      rows,
+    });
+
+    expect(audiences).toHaveLength(2);
+    for (const a of audiences) {
+      expect(a.enforcement.status).toBe('not-graphed');
+      expect(a.memberCount).toBe(0);
+      expect(a.members).toHaveLength(0);
+    }
+  });
+
+  it('excludes the Lobu bot from a channel audience even though it is a Slack member', async () => {
+    const { org, alice, agent } = await setupWorkspace();
+    const sql = getTestDb();
+    // The adapter backfills the bot's own Slack user id onto the connection.
+    await sql`
+      UPDATE agent_connections SET metadata = '{"botUserId":"UBOTLOBU"}'::jsonb
+      WHERE id = ${CONN}
+    `;
+
+    // Production sync path: conversations.members returns Alice AND the bot.
+    const result = await syncSlackConnectionAcl(
+      {
+        slackWeb: { conversationMembers: async () => ['U01ALICE', 'UBOTLOBU'] },
+        resolveBotToken: async () => 'xoxb-test-token',
+      },
+      { connectionId: CONN, organizationId: org.id },
+    );
+    expect(result.ok).toBe(true);
+
+    const rows = await resolveBoundChannelRows(sql, {
+      organizationId: org.id,
+      agentId: agent.agentId,
+    });
+    const audiences = await getChannelAudiences(sql, {
+      organizationId: org.id,
+      userId: alice.id,
+      rows,
+    });
+    const eng = audiences.find((a) => a.channelId === 'C01ENG');
+    // Only Alice — the bot must neither appear nor count.
+    expect(eng?.memberCount).toBe(1);
+    const botCombined = normalizeSlackUserId(TEAM, 'UBOTLOBU');
+    expect(eng?.members.some((m) => m.slackUserId === botCombined)).toBe(false);
+    expect(eng?.members[0]?.isYou).toBe(true);
+  });
+
+  it('reports no current audience for a stale (aged-out) connection even with old member_of edges', async () => {
+    const { org, alice, agent } = await setupWorkspace();
+    await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      teamId: TEAM,
+      channels: [{ channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01ALICE'] }],
+    });
+    const sql = getTestDb();
+    // The sync stops: age the graph past the freshness window. The gate fails
+    // CLOSED, so the audience must too — old member_of edges still exist but
+    // nobody can currently recall.
+    await sql`
+      UPDATE authz_source_acl_state
+      SET last_synced_at = current_timestamp - interval '90 minutes'
+      WHERE organization_id = ${org.id} AND connection_id = ${CONN}
+    `;
+    const rows = await resolveBoundChannelRows(sql, {
+      organizationId: org.id,
+      agentId: agent.agentId,
+    });
+    const audiences = await getChannelAudiences(sql, {
+      organizationId: org.id,
+      userId: alice.id,
+      rows,
+    });
+    const eng = audiences.find((a) => a.channelId === 'C01ENG');
+    expect(eng?.enforcement.status).toBe('stale');
+    expect(eng?.memberCount).toBe(0);
+    expect(eng?.members).toHaveLength(0);
+  });
+
+  it('marks a signed-in non-requester member as linked-slack, not you', async () => {
+    const { org, agent } = await setupWorkspace();
+    await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      teamId: TEAM,
+      channels: [{ channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01ALICE'] }],
+    });
+
+    const sql = getTestDb();
+    const rows = await resolveBoundChannelRows(sql, {
+      organizationId: org.id,
+      agentId: agent.agentId,
+    });
+    // Requester is NOT Alice → Alice is a linked-Slack member, never "you".
+    const audiences = await getChannelAudiences(sql, {
+      organizationId: org.id,
+      userId: 'someone-else',
+      rows,
+    });
+    const eng = audiences.find((a) => a.channelId === 'C01ENG');
+    const alice = eng?.members.find((m) => m.displayName === 'Alice');
+    expect(alice?.isYou).toBe(false);
+    expect(alice?.source).toBe('linked-slack');
+  });
+});

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -339,6 +339,27 @@ export async function buildAccessGraph(params: {
   // unique index. Accumulate the CURRENT member set per resource for reconcile.
   const typeId = await ensureMemberOfType(organizationId);
   const sql = getDb();
+
+  // Keep each resource entity's display name fresh. `titlePath` only sets the
+  // name on auto-CREATE, so a name that wasn't available at first graph (or a
+  // later channel/repo RENAME) would otherwise stick to the stale value / the
+  // raw id. Refresh from the source-provided name here. Scoped to the resources
+  // in this build; idempotent (the `name <>` guard no-ops when unchanged).
+  for (let i = 0; i < resources.length; i++) {
+    const id = resourceEntityIdByIndex.get(i);
+    const name = resources[i].name;
+    if (id && name) {
+      await sql`
+        UPDATE entities
+        SET name = ${name}, updated_at = current_timestamp
+        WHERE id = ${id}
+          AND organization_id = ${organizationId}
+          AND name <> ${name}
+          AND deleted_at IS NULL
+      `;
+    }
+  }
+
   const memberEntityIds = new Set<number>();
   const currentMembersByResource = new Map<number, Set<number>>();
   let createdEdges = 0;

--- a/packages/server/src/authz/audience.ts
+++ b/packages/server/src/authz/audience.ts
@@ -61,7 +61,13 @@ export interface ChannelAudience {
   platform: string;
   /** As stored on the binding (may be platform-prefixed, e.g. `slack:C…`). */
   channelId: string;
+  /** Human channel name (e.g. `announcements`) from the synced graph; null if
+   * the sync hasn't captured it yet (falls back to the id in the UI). */
+  channelName: string | null;
   teamId: string | null;
+  /** Human workspace name (e.g. `Lobu`) from the app installation; null if no
+   * active install resolves for the team. */
+  teamName: string | null;
   enforcement: ChannelEnforcement;
   memberCount: number;
   members: AudienceMember[];
@@ -108,16 +114,24 @@ export async function getChannelAudiences(
 
   // 2-4. Resolve channels → resource entities, fan out to members + enforcement,
   //      and resolve the requester (web/auth path) for the "you" highlight.
-  const [keyToEntity, enforcement, requesterEntityId] = await Promise.all([
-    resolveChannelEntityIds(sql, organizationId, allKeys),
-    getConnectionEnforcement(
-      sql,
-      organizationId,
-      rows.map((r) => r.id),
-    ),
-    resolveRequesterMemberEntityId(sql, organizationId, userId),
-  ]);
-  const resourceIds = [...new Set(keyToEntity.values())];
+  const [keyToEntity, enforcement, requesterEntityId, teamNames] =
+    await Promise.all([
+      resolveChannelEntityIds(sql, organizationId, allKeys),
+      getConnectionEnforcement(
+        sql,
+        organizationId,
+        rows.map((r) => r.id),
+      ),
+      resolveRequesterMemberEntityId(sql, organizationId, userId),
+      resolveTeamNames(
+        sql,
+        organizationId,
+        rows.map((r) => r.team_id).filter((t): t is string => !!t),
+      ),
+    ]);
+  const resourceIds = [
+    ...new Set([...keyToEntity.values()].map((e) => e.id)),
+  ];
   const membersByResource = await getAudienceMembers(
     sql,
     organizationId,
@@ -127,7 +141,14 @@ export async function getChannelAudiences(
   return rows.map((r) => {
     const enf = enforcement.get(r.id) ?? NOT_GRAPHED;
     const key = keyByRow.get(r) ?? null;
-    const resourceId = key ? keyToEntity.get(key) : undefined;
+    const entity = key ? keyToEntity.get(key) : undefined;
+    const resourceId = entity?.id;
+    // The sync seeds the channel entity name to its id when Slack didn't return
+    // a name; surface a real name only when it differs from the bare id.
+    const bareChannel = stripPlatformPrefix(r.platform, r.channel_id);
+    const channelName =
+      entity && entity.name !== bareChannel ? entity.name : null;
+    const teamName = r.team_id ? (teamNames.get(r.team_id) ?? null) : null;
     // The audience is the inverse of the recall gate, which only honors
     // membership when the connection is ENFORCED (full+fresh). A `stale` /
     // aged-out connection fails CLOSED — nobody can currently recall — so its
@@ -142,7 +163,9 @@ export async function getChannelAudiences(
       connectionId: r.id,
       platform: r.platform,
       channelId: r.channel_id,
+      channelName,
       teamId: r.team_id,
+      teamName,
       enforcement: enf,
       memberCount: members.length,
       members,
@@ -150,16 +173,17 @@ export async function getChannelAudiences(
   });
 }
 
-/** Resolve team-scoped channel keys (`T…:C…`) → their `channel` resource entity ids. */
+/** Resolve team-scoped channel keys (`T…:C…`) → their `channel` resource entity
+ * (id + the entity's display name, which the sync sets to the Slack channel name). */
 async function resolveChannelEntityIds(
   sql: DbClient,
   organizationId: string,
   keys: string[],
-): Promise<Map<string, number>> {
+): Promise<Map<string, { id: number; name: string }>> {
   const uniq = [...new Set(keys)].filter(Boolean);
   if (uniq.length === 0) return new Map();
-  const rows = await sql<{ identifier: string; entity_id: number }>`
-    SELECT ei.identifier, ei.entity_id
+  const rows = await sql<{ identifier: string; entity_id: number; name: string }>`
+    SELECT ei.identifier, ei.entity_id, e.name
     FROM entity_identities ei
     JOIN entities e
       ON e.id = ei.entity_id
@@ -174,8 +198,34 @@ async function resolveChannelEntityIds(
       AND ei.identifier = ANY(${pgTextArray(uniq)}::text[])
       AND ei.deleted_at IS NULL
   `;
-  const out = new Map<string, number>();
-  for (const r of rows) out.set(String(r.identifier), Number(r.entity_id));
+  const out = new Map<string, { id: number; name: string }>();
+  for (const r of rows)
+    out.set(String(r.identifier), {
+      id: Number(r.entity_id),
+      name: String(r.name),
+    });
+  return out;
+}
+
+/** Resolve team ids → workspace display name from the active Slack install. */
+async function resolveTeamNames(
+  sql: DbClient,
+  organizationId: string,
+  teamIds: string[],
+): Promise<Map<string, string>> {
+  const uniq = [...new Set(teamIds)].filter(Boolean);
+  if (uniq.length === 0) return new Map();
+  const rows = await sql<{ external_tenant_id: string; team_name: string | null }>`
+    SELECT external_tenant_id, metadata->>'team_name' AS team_name
+    FROM app_installations
+    WHERE organization_id = ${organizationId}
+      AND provider = 'slack'
+      AND status = 'active'
+      AND external_tenant_id = ANY(${pgTextArray(uniq)}::text[])
+  `;
+  const out = new Map<string, string>();
+  for (const r of rows)
+    if (r.team_name) out.set(String(r.external_tenant_id), String(r.team_name));
   return out;
 }
 

--- a/packages/server/src/authz/audience.ts
+++ b/packages/server/src/authz/audience.ts
@@ -1,0 +1,299 @@
+/**
+ * The audience read — "WHO can recall this channel?" — the INVERSE of the
+ * channel-visibility gate. The gate (`./channel-visibility`) asks "which channels
+ * may THIS requester read"; the audience asks "which members are `member_of` THIS
+ * channel". Both read the SAME `member_of` edges + resource identities, so the
+ * governance view can never drift from what the gate actually enforces.
+ *
+ * READ-ONLY: Slack is the source of truth for channel membership; this never
+ * writes. Resource-generic in shape (keyed on the resource entity), surfaced
+ * today for Slack `channel` entities; a `repo` audience slots in with no new
+ * query. Pure DB read — safe under N replicas.
+ */
+
+import { type DbClient, pgBigintArray, pgTextArray } from "../db/client.js";
+import { stripPlatformPrefix } from "../gateway/channels/bound-channels.js";
+import { ACL_STALE_AFTER_MINUTES } from "./acl-state.js";
+import {
+  type GatedChannelRow,
+  resolveRequesterMemberEntityId,
+} from "./channel-visibility.js";
+import { slackChannelKey } from "./slack-channel-graph.js";
+
+/**
+ * How a member appears to the requester:
+ *  - `you`           — the requester's own `$member` entity.
+ *  - `linked-slack`  — signed in to Lobu and collapsed onto their Slack identity
+ *                      (their entity carries the `auth:signup` claim).
+ *  - `slack-member`  — a channel member who hasn't signed in (Slack identity only).
+ */
+export type AudienceMemberSource = "you" | "linked-slack" | "slack-member";
+
+export interface AudienceMember {
+  entityId: number;
+  displayName: string;
+  /** Team-scoped Slack user id (`T…:U…`) when the member carries one. */
+  slackUserId: string | null;
+  email: string | null;
+  isYou: boolean;
+  source: AudienceMemberSource;
+}
+
+/**
+ * Per-connection enforcement state:
+ *  - `enforced`    — `acl_support='full'` AND `freshness_state='fresh'` AND synced
+ *                    within {@link ACL_STALE_AFTER_MINUTES}; recall is membership-gated.
+ *  - `stale`       — onboarded (an `authz_source_acl_state` row exists) but not
+ *                    currently enforcing (partial/stale/aged-out) → fails closed.
+ *  - `not-graphed` — no ACL row at all; legacy per-agent fence, no audience graph.
+ */
+export type EnforcementStatus = "enforced" | "stale" | "not-graphed";
+
+export interface ChannelEnforcement {
+  status: EnforcementStatus;
+  aclSupport: string | null;
+  freshnessState: string | null;
+  lastSyncedAt: string | null;
+}
+
+export interface ChannelAudience {
+  connectionId: string;
+  platform: string;
+  /** As stored on the binding (may be platform-prefixed, e.g. `slack:C…`). */
+  channelId: string;
+  teamId: string | null;
+  enforcement: ChannelEnforcement;
+  memberCount: number;
+  members: AudienceMember[];
+}
+
+const NOT_GRAPHED: ChannelEnforcement = {
+  status: "not-graphed",
+  aclSupport: null,
+  freshnessState: null,
+  lastSyncedAt: null,
+};
+
+/**
+ * For each bound channel, return its audience (members `member_of` the channel)
+ * plus the owning connection's enforcement state. Mirrors the gate's
+ * `member_of` + resource-identity joins, inverted (members keyed off
+ * `from_entity_id`, channel off `to_entity_id`).
+ */
+export async function getChannelAudiences(
+  sql: DbClient,
+  params: {
+    organizationId: string;
+    userId: string | null;
+    rows: GatedChannelRow[];
+  },
+): Promise<ChannelAudience[]> {
+  const { organizationId, userId, rows } = params;
+  if (rows.length === 0) return [];
+
+  // 1. Team-scoped channel key per row (needs a team id to form). A row without
+  //    a team id can't be keyed to a resource entity → empty audience.
+  const keyByRow = new Map<GatedChannelRow, string | null>();
+  const allKeys: string[] = [];
+  for (const r of rows) {
+    const key = r.team_id
+      ? slackChannelKey(
+          r.team_id,
+          stripPlatformPrefix(r.platform, r.channel_id),
+        )
+      : null;
+    keyByRow.set(r, key);
+    if (key) allKeys.push(key);
+  }
+
+  // 2-4. Resolve channels → resource entities, fan out to members + enforcement,
+  //      and resolve the requester (web/auth path) for the "you" highlight.
+  const [keyToEntity, enforcement, requesterEntityId] = await Promise.all([
+    resolveChannelEntityIds(sql, organizationId, allKeys),
+    getConnectionEnforcement(
+      sql,
+      organizationId,
+      rows.map((r) => r.id),
+    ),
+    resolveRequesterMemberEntityId(sql, organizationId, userId),
+  ]);
+  const resourceIds = [...new Set(keyToEntity.values())];
+  const membersByResource = await getAudienceMembers(
+    sql,
+    organizationId,
+    resourceIds,
+  );
+
+  return rows.map((r) => {
+    const enf = enforcement.get(r.id) ?? NOT_GRAPHED;
+    const key = keyByRow.get(r) ?? null;
+    const resourceId = key ? keyToEntity.get(key) : undefined;
+    // The audience is the inverse of the recall gate, which only honors
+    // membership when the connection is ENFORCED (full+fresh). A `stale` /
+    // aged-out connection fails CLOSED — nobody can currently recall — so its
+    // (possibly old) `member_of` edges must NOT be reported as "can recall".
+    // `not-graphed` keeps the legacy per-agent fence and has no edges anyway.
+    const raw =
+      enf.status === "enforced" && resourceId
+        ? (membersByResource.get(resourceId) ?? [])
+        : [];
+    const members = raw.map((m) => toAudienceMember(m, requesterEntityId));
+    return {
+      connectionId: r.id,
+      platform: r.platform,
+      channelId: r.channel_id,
+      teamId: r.team_id,
+      enforcement: enf,
+      memberCount: members.length,
+      members,
+    };
+  });
+}
+
+/** Resolve team-scoped channel keys (`T…:C…`) → their `channel` resource entity ids. */
+async function resolveChannelEntityIds(
+  sql: DbClient,
+  organizationId: string,
+  keys: string[],
+): Promise<Map<string, number>> {
+  const uniq = [...new Set(keys)].filter(Boolean);
+  if (uniq.length === 0) return new Map();
+  const rows = await sql<{ identifier: string; entity_id: number }>`
+    SELECT ei.identifier, ei.entity_id
+    FROM entity_identities ei
+    JOIN entities e
+      ON e.id = ei.entity_id
+     AND e.organization_id = ei.organization_id
+     AND e.deleted_at IS NULL
+    JOIN entity_types et
+      ON et.id = e.entity_type_id
+     AND et.organization_id = e.organization_id
+     AND et.slug = 'channel'
+    WHERE ei.organization_id = ${organizationId}
+      AND ei.namespace = 'slack_channel_id'
+      AND ei.identifier = ANY(${pgTextArray(uniq)}::text[])
+      AND ei.deleted_at IS NULL
+  `;
+  const out = new Map<string, number>();
+  for (const r of rows) out.set(String(r.identifier), Number(r.entity_id));
+  return out;
+}
+
+interface RawMember {
+  resource_entity_id: number;
+  member_entity_id: number;
+  display_name: string;
+  slack_user_id: string | null;
+  email: string | null;
+  has_auth: boolean;
+}
+
+/** Members `member_of` each resource entity, with the identities the UI renders. */
+async function getAudienceMembers(
+  sql: DbClient,
+  organizationId: string,
+  resourceIds: number[],
+): Promise<Map<number, RawMember[]>> {
+  if (resourceIds.length === 0) return new Map();
+  const rows = await sql<RawMember>`
+    SELECT
+      r.to_entity_id AS resource_entity_id,
+      me.id AS member_entity_id,
+      me.name AS display_name,
+      MAX(CASE WHEN mi.namespace = 'slack_user_id' THEN mi.identifier END) AS slack_user_id,
+      MAX(CASE WHEN mi.namespace = 'email' THEN mi.identifier END) AS email,
+      bool_or(mi.namespace = 'auth_user_id' AND mi.source_connector = 'auth:signup') AS has_auth
+    FROM entity_relationships r
+    JOIN entity_relationship_types rt
+      ON rt.id = r.relationship_type_id
+     AND rt.organization_id = r.organization_id
+     AND rt.slug = 'member_of'
+    JOIN entities me
+      ON me.id = r.from_entity_id
+     AND me.organization_id = r.organization_id
+     AND me.deleted_at IS NULL
+    LEFT JOIN entity_identities mi
+      ON mi.entity_id = me.id
+     AND mi.organization_id = me.organization_id
+     AND mi.deleted_at IS NULL
+    WHERE r.organization_id = ${organizationId}
+      AND r.to_entity_id = ANY(${pgBigintArray(resourceIds)}::bigint[])
+      AND r.deleted_at IS NULL
+    GROUP BY r.to_entity_id, me.id, me.name
+    ORDER BY me.name ASC
+  `;
+  const out = new Map<number, RawMember[]>();
+  for (const r of rows) {
+    const id = Number(r.resource_entity_id);
+    const list = out.get(id) ?? [];
+    list.push(r);
+    out.set(id, list);
+  }
+  return out;
+}
+
+/** Per-connection enforcement detail (status + the columns the detail panel shows). */
+async function getConnectionEnforcement(
+  sql: DbClient,
+  organizationId: string,
+  connectionIds: string[],
+): Promise<Map<string, ChannelEnforcement>> {
+  const ids = [...new Set(connectionIds)].filter(Boolean);
+  if (ids.length === 0) return new Map();
+  const rows = await sql<{
+    connection_id: string;
+    acl_support: string | null;
+    freshness_state: string | null;
+    last_synced_at: Date | null;
+    enforce: boolean;
+  }>`
+    SELECT
+      connection_id,
+      acl_support,
+      freshness_state,
+      last_synced_at,
+      (
+        acl_support = 'full'
+        AND freshness_state = 'fresh'
+        AND last_synced_at IS NOT NULL
+        AND last_synced_at >= current_timestamp - make_interval(mins => ${ACL_STALE_AFTER_MINUTES})
+      ) AS enforce
+    FROM authz_source_acl_state
+    WHERE organization_id = ${organizationId}
+      AND connection_id = ANY(${pgTextArray(ids)}::text[])
+  `;
+  const out = new Map<string, ChannelEnforcement>();
+  for (const r of rows) {
+    out.set(String(r.connection_id), {
+      status: r.enforce === true ? "enforced" : "stale",
+      aclSupport: r.acl_support ?? null,
+      freshnessState: r.freshness_state ?? null,
+      lastSyncedAt: r.last_synced_at
+        ? new Date(r.last_synced_at).toISOString()
+        : null,
+    });
+  }
+  return out;
+}
+
+function toAudienceMember(
+  m: RawMember,
+  requesterEntityId: number | null,
+): AudienceMember {
+  const isYou =
+    requesterEntityId !== null &&
+    Number(m.member_entity_id) === requesterEntityId;
+  const source: AudienceMemberSource = isYou
+    ? "you"
+    : m.has_auth === true
+      ? "linked-slack"
+      : "slack-member";
+  return {
+    entityId: Number(m.member_entity_id),
+    displayName: m.display_name,
+    slackUserId: m.slack_user_id ?? null,
+    email: m.email ?? null,
+    isYou,
+    source,
+  };
+}

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -97,6 +97,19 @@ export async function syncSlackConnectionAcl(
     return { ok: true, teamsSynced: 0, channelsSynced: 0 };
   }
 
+  // The bot is itself a member of every channel it's in, so `conversations.members`
+  // includes it. Drop it: a bot is not an audience and must never gain a
+  // `member_of` edge (it would inflate "who can recall" AND, via the gate, count
+  // as a member). The bot's own Slack user id is backfilled onto the connection
+  // metadata at adapter init; absent it, we simply don't filter (no regression).
+  const connRow = await sql<{ bot_user_id: string | null }>`
+		SELECT metadata->>'botUserId' AS bot_user_id
+		FROM agent_connections
+		WHERE id = ${connectionId} AND organization_id = ${organizationId}
+		LIMIT 1
+	`;
+  const botUserId = connRow[0]?.bot_user_id ?? null;
+
   // Group channels by workspace/team — one graph build per team.
   const byTeam = new Map<string, string[]>();
   for (const r of slackRows) {
@@ -116,10 +129,13 @@ export async function syncSlackConnectionAcl(
       }
       const channels: SlackChannelInput[] = [];
       for (const channelId of channelIds) {
-        const memberSlackUserIds = await deps.slackWeb.conversationMembers(
+        const rawMembers = await deps.slackWeb.conversationMembers(
           token,
           channelId,
         );
+        const memberSlackUserIds = botUserId
+          ? rawMembers.filter((u) => u !== botUserId)
+          : rawMembers;
         channels.push({ channelId, memberSlackUserIds });
       }
       await buildSlackChannelGraph({

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -40,7 +40,7 @@ const logger = createLogger('slack-acl-sync');
 /** Injectable seams so tests drive the real graph build + gate with a stubbed
  * Slack API and token resolver, and the live tick wires the real ones. */
 export interface SlackAclSyncDeps {
-  slackWeb: Pick<SlackWebApi, 'conversationMembers'>;
+  slackWeb: Pick<SlackWebApi, 'conversationMembers' | 'conversationInfo'>;
   /** Resolve the bot token for a workspace, or null if none is available
    * (no active install / unresolvable secret) — null is treated fail-closed. */
   resolveBotToken: (params: {
@@ -136,7 +136,22 @@ export async function syncSlackConnectionAcl(
         const memberSlackUserIds = botUserId
           ? rawMembers.filter((u) => u !== botUserId)
           : rawMembers;
-        channels.push({ channelId, memberSlackUserIds });
+        // Channel name + privacy are BEST-EFFORT display metadata — a failure
+        // here must NOT fail-close the whole sync (membership is the contract),
+        // so swallow and fall back to the id-as-name in buildSlackChannelGraph.
+        let name: string | undefined;
+        let isPrivate: boolean | undefined;
+        try {
+          const info = await deps.slackWeb.conversationInfo(token, channelId);
+          name = info.name ?? undefined;
+          isPrivate = info.isPrivate;
+        } catch (error) {
+          logger.warn(
+            { organization_id: organizationId, channel_id: channelId, error: String(error) },
+            'Slack conversations.info failed — syncing channel without a name',
+          );
+        }
+        channels.push({ channelId, name, isPrivate, memberSlackUserIds });
       }
       await buildSlackChannelGraph({
         organizationId,

--- a/packages/server/src/gateway/connections/__tests__/slack-web.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-web.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Slack Web API HTTP-encoding contract. Slack's READ methods
+ * (`conversations.members`/`.list`, `users.info`, …) accept ONLY
+ * `application/x-www-form-urlencoded` — a JSON body returns `invalid_arguments`,
+ * which would silently fail-close the ACL sync (no audience ever materializes).
+ * Integration tests stub `conversationMembers`, so this guards the real wire
+ * format that those stubs hide.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { createSlackWebApi } from "../slack-web.js";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("createSlackWebApi wire format", () => {
+  test("posts conversations.members as form-urlencoded (NOT json) and paginates", async () => {
+    const calls: Array<[string, RequestInit]> = [];
+    const pages = [
+      { ok: true, members: ["U1", "U2"], response_metadata: { next_cursor: "CUR" } },
+      { ok: true, members: ["U3"], response_metadata: { next_cursor: "" } },
+    ];
+    let i = 0;
+    globalThis.fetch = mock(async (url: string, init: RequestInit) => {
+      calls.push([url, init]);
+      const body = pages[i++];
+      return { json: async () => body } as Response;
+    }) as unknown as typeof fetch;
+
+    const api = createSlackWebApi();
+    const members = await api.conversationMembers("xoxb-token", "C123");
+
+    expect(members).toEqual(["U1", "U2", "U3"]);
+    expect(calls.length).toBe(2);
+
+    const [url, init] = calls[0]!;
+    expect(url).toBe("https://slack.com/api/conversations.members");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toMatch(/application\/x-www-form-urlencoded/);
+    expect(headers.Authorization).toBe("Bearer xoxb-token");
+    // Body is form-encoded, so it parses as URLSearchParams (a JSON body would not).
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get("channel")).toBe("C123");
+    expect(body.get("limit")).toBe("200");
+    // Second page forwards the cursor.
+    const secondBody = new URLSearchParams(calls[1]![1].body as string);
+    expect(secondBody.get("cursor")).toBe("CUR");
+  });
+
+  test("throws with the Slack error code when ok is false", async () => {
+    globalThis.fetch = mock(async () => ({
+      json: async () => ({ ok: false, error: "invalid_arguments" }),
+    })) as unknown as typeof fetch;
+
+    const api = createSlackWebApi();
+    await expect(api.conversationMembers("xoxb-token", "C123")).rejects.toThrow(
+      /invalid_arguments/,
+    );
+  });
+});

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -24,6 +24,15 @@ export interface SlackWebApi {
    * authz channel-membership sync to materialize the read-ACL graph.
    */
   conversationMembers(botToken: string, channelId: string): Promise<string[]>;
+  /**
+   * `conversations.info` → the channel's human-readable name (e.g. `general`)
+   * and privacy flag. `name` is null when Slack omits it (e.g. a DM/MPIM or an
+   * unreadable channel); callers fall back to the channel id.
+   */
+  conversationInfo(
+    botToken: string,
+    channelId: string
+  ): Promise<{ name: string | null; isPrivate: boolean }>;
 }
 
 async function slackPost(
@@ -101,6 +110,18 @@ export function createSlackWebApi(): SlackWebApi {
         cursor = next && next.length > 0 ? next : undefined;
       } while (cursor);
       return members;
+    },
+    async conversationInfo(botToken, channelId) {
+      const json = await slackPost(botToken, "conversations.info", {
+        channel: channelId,
+      });
+      const ch = json.channel as
+        | { name?: string; is_private?: boolean }
+        | undefined;
+      return {
+        name: typeof ch?.name === "string" ? ch.name : null,
+        isPrivate: ch?.is_private === true,
+      };
     },
   };
 }

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -31,13 +31,21 @@ async function slackPost(
   method: string,
   body: Record<string, unknown>
 ): Promise<Record<string, unknown>> {
+  // Slack's read methods (conversations.members/list, users.info, …) accept ONLY
+  // application/x-www-form-urlencoded — a JSON body yields `invalid_arguments`.
+  // Form encoding is accepted by every Web API method (including chat.postMessage
+  // / conversations.open used here), so encode uniformly.
+  const form = new URLSearchParams();
+  for (const [key, value] of Object.entries(body)) {
+    if (value !== undefined && value !== null) form.set(key, String(value));
+  }
   const res = await fetch(`https://slack.com/api/${method}`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${botToken}`,
-      "Content-Type": "application/json; charset=utf-8",
+      "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
     },
-    body: JSON.stringify(body),
+    body: form.toString(),
   });
   const json = (await res.json()) as Record<string, unknown>;
   if (json.ok !== true) {

--- a/packages/server/src/gateway/routes/public/channels.ts
+++ b/packages/server/src/gateway/routes/public/channels.ts
@@ -9,6 +9,8 @@
 
 import { createLogger } from "@lobu/core";
 import { type Context, Hono } from "hono";
+import { getChannelAudiences } from "../../../authz/audience.js";
+import { resolveBoundChannelRows } from "../../channels/bound-channels.js";
 import type { AgentMetadataStore } from "../../auth/agent-metadata-store.js";
 import type { SettingsTokenPayload } from "../../auth/settings/token-service.js";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
@@ -181,6 +183,33 @@ export function createChannelBindingRoutes(
     } catch (error) {
       logger.error("Failed to list bindings", { error, agentId });
       return errorResponse(c, "Failed to list bindings", 500);
+    }
+  });
+
+  // GET /api/v1/agents/{agentId}/channels/audience
+  // Read-only governance view: for each of this agent's bound channels, who can
+  // recall it (the `member_of` audience) + the connection's enforcement state.
+  // The inverse of the recall gate; Slack is the source of truth.
+  router.get("/audience", async (c) => {
+    const auth = await authorizeWithOrg(c);
+    if (auth instanceof Response) return auth;
+    const { agentId, payload, organizationId } = auth;
+
+    try {
+      const sql = getDb();
+      const rows = await resolveBoundChannelRows(sql, {
+        organizationId,
+        agentId,
+      });
+      const audiences = await getChannelAudiences(sql, {
+        organizationId,
+        userId: payload.userId ?? null,
+        rows,
+      });
+      return c.json({ agentId, audiences });
+    } catch (error) {
+      logger.error("Failed to load channel audience", { error, agentId });
+      return errorResponse(c, "Failed to load channel audience", 500);
     }
   });
 


### PR DESCRIPTION
## What

The server side of the **channel audience** feature (Agent → Reach tab "who can recall this channel"), plus a **production Slack bug fix** uncovered while proving it live.

### feat(authz): audience read
- `authz/audience.ts` — `getChannelAudiences` **inverts the visibility gate**: it answers "who can recall this channel" off the *same* `member_of` graph + `authz_source_acl_state` the gate enforces. Members are surfaced **only when the connection is ENFORCED** (full+fresh), mirroring the fail-closed gate (a stale/aged-out connection reports no audience).
- `GET /lobu/api/v1/agents/:agentId/channels/audience` (channels.ts).
- `slack-acl-sync.ts` — exclude the Lobu bot from a channel's audience (it's a `conversations.members` entry but never an audience member).

### fix(slack): form-urlencode Slack Web API requests
`slackPost` sent Slack's **read** methods (`conversations.members`/`.list`) as `application/json`, which Slack rejects with `invalid_arguments`. Every `conversations.members` call failed → the **entire ACL/audience sync silently fail-closed** (no audience ever materializes). Integration tests stub `conversationMembers`, so it was invisible until a real install. Now form-urlencoded (accepted by all Web API methods).

## Tests
- 5 channel-audience integration cases (graph parity / not-graphed / bot-exclusion / stale / linked-vs-you) — green.
- `slack-web` wire-format regression (bun:test), verified **red→green**.
- `make review`: typecheck 0, unit 0, **0 bugs**.

## Proven live (real e2e)
Real QAPeer OAuth install → Lobu workspace → real `conversations.members` → `member_of` graph → Reach tab rendered real audiences (announcements 9, lunch-bot-demo 10, …) with real member IDs + working DM/Open-in-Slack deep links. This live run is what surfaced the `slackPost` bug.

## Pairs with
UI: lobu-ai/owletto#378. The owletto submodule pointer bump follows as a separate PR after #378 merges (per repo convention).

## Follow-up (separate PR, discussed)
Consolidate Slack OAuth onto a single v2 flow/redirect (login + install in one handler), retiring the duplicate OIDC login path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785282387&installation_id=136316292&pr_number=1600&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1600&signature=4114d961b21777e0cd7f6b02793590957eb7c0eba35ae58751f6490916686f78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only endpoint for agents to view Slack channel audiences (who can recall a channel), including viewer “you” highlighting and per-member source.
* **Bug Fixes**
  * Excluded the Slack bot from audience membership.
  * Improved audience behavior for missing or stale authorization graphs (supports enforced/stale/not-graphed results).
  * Refined Slack API calls to use form-encoded requests and added best-effort channel metadata.
* **Tests**
  * Added integration coverage for channel audience authorization and a wire-format test suite for Slack Web requests.
* **Documentation**
  * Added a design document for agent actions and per-agent capability scope/audience UI framing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->