### PR TITLE
feat(server): attribute egress guardrail trips to their conversation

### DIFF
--- a/packages/server/src/gateway/proxy/http-proxy.ts
+++ b/packages/server/src/gateway/proxy/http-proxy.ts
@@ -147,7 +147,12 @@ async function checkDomainAccess(
   hostname: string,
   agentId: string | undefined,
   organizationId: string | undefined,
-  requestContext?: { method?: string; path?: string }
+  requestContext?: {
+    method?: string;
+    path?: string;
+    conversationId?: string;
+    userId?: string;
+  }
 ): Promise<AccessDecision> {
   const global = config;
 
@@ -231,6 +236,8 @@ async function checkDomainAccess(
         void recordGuardrailTrip({
           organizationId,
           agentId,
+          conversationId: requestContext?.conversationId,
+          userId: requestContext?.userId,
           stage: "egress",
           guardrail: decision.judgeName,
           reason: decision.reason,
@@ -680,7 +687,11 @@ async function handleConnect(
     config,
     hostname,
     tokenData.agentId,
-    tokenData.organizationId
+    tokenData.organizationId,
+    {
+      conversationId: tokenData.conversationId,
+      userId: tokenData.userId,
+    }
   );
   logAccessDecision(
     "CONNECT",
@@ -835,6 +846,8 @@ async function handleProxyRequest(
     {
       method: req.method,
       path: parsedUrl.pathname + parsedUrl.search,
+      conversationId: tokenData.conversationId,
+      userId: tokenData.userId,
     }
   );
   logAccessDecision(

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -514,6 +514,10 @@ routes.get('/:agentId/guardrail-trips', async (c) => {
   // asks for just that guardrail's catches.
   const guardrail = c.req.query('guardrail');
 
+  // Optional narrowing to one conversation — the chat view asks for just the
+  // trips that fired during this conversation so it can flag the affected turn.
+  const conversationId = c.req.query('conversationId');
+
   const sql = getDb();
   // `recordGuardrailTrip` writes `created_at` (default now()) but leaves
   // `occurred_at` null, so coalesce to `created_at` — otherwise the UI shows
@@ -525,6 +529,7 @@ routes.get('/:agentId/guardrail-trips', async (c) => {
        AND semantic_type = 'guardrail-trip'
        AND metadata->>'agent_id' = ${agentId}
        ${guardrail ? sql`AND metadata->>'guardrail' = ${guardrail}` : sql``}
+       ${conversationId ? sql`AND metadata->>'conversation_id' = ${conversationId}` : sql``}
      ORDER BY COALESCE(occurred_at, created_at) DESC, id DESC
      LIMIT ${limit}
   `;
@@ -536,6 +541,7 @@ routes.get('/:agentId/guardrail-trips', async (c) => {
       stage?: string;
       guardrail?: string;
       reason?: string | null;
+      conversation_id?: string | null;
     };
     const occurredAt =
       row.occurred_at instanceof Date
@@ -551,6 +557,9 @@ routes.get('/:agentId/guardrail-trips', async (c) => {
       stage: metadata.stage,
       guardrailName: metadata.guardrail,
       ...(metadata.reason ? { reason: metadata.reason } : {}),
+      ...(metadata.conversation_id
+        ? { conversationId: metadata.conversation_id }
+        : {}),
     };
   });
 


### PR DESCRIPTION
**Stacked on #1599** (egress wiring). Pairs with owletto #380 (inline notice).

## What

Make an egress judge **deny** visible in the chat where it happened, not only on the Guardrails tab.

- `http-proxy`: thread `conversationId` + `userId` from the worker token → `checkDomainAccess` → the egress `recordGuardrailTrip` call, so the `guardrail-trip` event carries `conversation_id`. (Previously the egress trip had **no** conversation link.)
- `agent-routes`: `/:agentId/guardrail-trips` accepts an optional `conversationId` filter and returns `conversationId` per trip, so the chat view fetches just the trips for the open conversation.

## Verified (real `make dev`)

Configured an egress-judge guardrail (`example.com`, deny), produced a real LLM judge deny (`judgeLatencyMs:1086`, `verdict:deny`, 403), the trip recorded with `conversation_id=guardrail-demo`, and the owletto inline notice rendered in that conversation: "Guardrail blocked: block-example (egress) — Policy denies all outbound requests unconditionally."

Caveat: the worker sandbox has no `curl`, so I drove the egress request with a real `lobu-builder` worker token rather than the agent's shell — same policy, judge, proxy, trip, and conversation attribution.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785285624&installation_id=136316292&pr_number=1601&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1601&signature=1870bcca208762b6e5c986fddd6586c6da17830a853ffd3c9e3e31ec718e70d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->