### PR TITLE
refactor(authz): dedup audience/gate ACL helpers + harden audience read

### DIFF
--- a/packages/server/src/__tests__/integration/authz/channel-audience.test.ts
+++ b/packages/server/src/__tests__/integration/authz/channel-audience.test.ts
@@ -156,20 +156,20 @@ describe('channel audience read', () => {
   it('excludes the Lobu bot from a channel audience even though it is a Slack member', async () => {
     const { org, alice, agent } = await setupWorkspace();
     const sql = getTestDb();
-    // The adapter backfills the bot's own Slack user id onto the connection.
-    await sql`
-      UPDATE agent_connections SET metadata = '{"botUserId":"UBOTLOBU"}'::jsonb
-      WHERE id = ${CONN}
-    `;
 
-    // Production sync path: conversations.members returns Alice AND the bot.
+    // Production sync path: conversations.members returns Alice AND the bot. The
+    // bot's own Slack user id comes from the INSTALL (resolveBotIdentity), not the
+    // connection metadata — so it filters even before the adapter has backfilled.
     const result = await syncSlackConnectionAcl(
       {
         slackWeb: {
           conversationMembers: async () => ['U01ALICE', 'UBOTLOBU'],
           conversationInfo: async () => ({ name: 'eng', isPrivate: false }),
         },
-        resolveBotToken: async () => 'xoxb-test-token',
+        resolveBotIdentity: async () => ({
+          token: 'xoxb-test-token',
+          botUserId: 'UBOTLOBU',
+        }),
       },
       { connectionId: CONN, organizationId: org.id },
     );

--- a/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
@@ -260,7 +260,7 @@ describe('slack channel visibility gate (e2e via search_memory)', () => {
         slackWeb: {
           conversationMembers: async (_token, channelId) => membersByChannel[channelId] ?? [],
         },
-        resolveBotToken: async () => 'xoxb-test-token',
+        resolveBotIdentity: async () => ({ token: 'xoxb-test-token', botUserId: null }),
       },
       { connectionId: CONN, organizationId: org.id },
     );
@@ -298,8 +298,8 @@ describe('slack channel visibility gate (e2e via search_memory)', () => {
           },
         },
         // Only the Acme workspace has a token — reaching T02OTHER would fail closed.
-        resolveBotToken: async ({ teamId }) =>
-          teamId === TEAM ? 'xoxb-test-token' : null,
+        resolveBotIdentity: async ({ teamId }) =>
+          teamId === TEAM ? { token: 'xoxb-test-token', botUserId: null } : null,
       },
       { connectionId: CONN, organizationId: org.id },
     );
@@ -386,7 +386,7 @@ describe('slack channel visibility gate (e2e via search_memory)', () => {
     await syncSlackConnectionAcl(
       {
         slackWeb: { conversationMembers: async () => ['U01ALICE'] },
-        resolveBotToken: async () => 'xoxb-test-token',
+        resolveBotIdentity: async () => ({ token: 'xoxb-test-token', botUserId: null }),
       },
       { connectionId: CONN, organizationId: org.id },
     );
@@ -403,7 +403,7 @@ describe('slack channel visibility gate (e2e via search_memory)', () => {
             throw new Error('slack outage');
           },
         },
-        resolveBotToken: async () => 'xoxb-test-token',
+        resolveBotIdentity: async () => ({ token: 'xoxb-test-token', botUserId: null }),
       },
       { connectionId: CONN, organizationId: org.id },
     );

--- a/packages/server/src/authz/acl-state.ts
+++ b/packages/server/src/authz/acl-state.ts
@@ -1,9 +1,14 @@
 /**
  * Shared ACL-enforcement-state helpers — used by BOTH read gates (the Slack
  * channel gate `./channel-visibility` and the generic resource gate
- * `./resource-visibility`) so the "is this connection enforcing right now?"
- * rule lives in one place and cannot drift between them.
+ * `./resource-visibility`) AND the audience read (`./audience`) so the "is this
+ * connection enforcing right now?" rule and the team-scoped channel key live in
+ * one place and cannot drift between them.
  */
+
+import { type DbClient, pgTextArray } from "../db/client.js";
+import { stripPlatformPrefix } from "../gateway/channels/bound-channels.js";
+import { slackChannelKey } from "./slack-channel-graph.js";
 
 /**
  * How long a `fresh` ACL graph stays trusted without a re-sync. The background
@@ -27,4 +32,106 @@ export function enforcedConnectionsSelectSql(orgParam: string): string {
       AND freshness_state = 'fresh'
       AND last_synced_at IS NOT NULL
       AND last_synced_at >= current_timestamp - make_interval(mins => ${ACL_STALE_AFTER_MINUTES})`;
+}
+
+/**
+ * Per-connection enforcement state, the single shape BOTH the gate
+ * (`./channel-visibility`) and the audience read (`./audience`) project from the
+ * `authz_source_acl_state` row:
+ *  - `enforced`    — `acl_support='full'` AND `freshness_state='fresh'` AND synced
+ *                    within {@link ACL_STALE_AFTER_MINUTES}; recall is membership-gated.
+ *  - `stale`       — onboarded (a row exists) but not currently enforcing
+ *                    (partial/stale/aged-out) → fails closed.
+ *  - `not-graphed` — no row at all (a connection ABSENT from
+ *                    {@link getConnectionEnforcement}'s map); legacy per-agent fence.
+ */
+export type EnforcementStatus = "enforced" | "stale" | "not-graphed";
+
+export interface ChannelEnforcement {
+  status: EnforcementStatus;
+  aclSupport: string | null;
+  freshnessState: string | null;
+  lastSyncedAt: string | null;
+}
+
+/** The state for a connection with no `authz_source_acl_state` row. */
+export const NOT_GRAPHED: ChannelEnforcement = {
+  status: "not-graphed",
+  aclSupport: null,
+  freshnessState: null,
+  lastSyncedAt: null,
+};
+
+/**
+ * Resolve each connection's enforcement state. A connection ABSENT from the
+ * returned map has no `authz_source_acl_state` row — it was never graphed, so it
+ * keeps the legacy per-agent fence ({@link NOT_GRAPHED}). A connection PRESENT is
+ * either `enforced` (full+fresh+in-window) or `stale` (anything else, which fails
+ * closed). This is the ONE place the enforce predicate is evaluated for the
+ * parameterized read paths, so the gate and the audience can never disagree.
+ */
+export async function getConnectionEnforcement(
+  sql: DbClient,
+  organizationId: string,
+  connectionIds: string[],
+): Promise<Map<string, ChannelEnforcement>> {
+  const ids = [...new Set(connectionIds)].filter(Boolean);
+  if (ids.length === 0) return new Map();
+  const rows = await sql<{
+    connection_id: string;
+    acl_support: string | null;
+    freshness_state: string | null;
+    last_synced_at: Date | null;
+    enforce: boolean;
+  }>`
+    SELECT
+      connection_id,
+      acl_support,
+      freshness_state,
+      last_synced_at,
+      (
+        acl_support = 'full'
+        AND freshness_state = 'fresh'
+        AND last_synced_at IS NOT NULL
+        AND last_synced_at >= current_timestamp - make_interval(mins => ${ACL_STALE_AFTER_MINUTES})
+      ) AS enforce
+    FROM authz_source_acl_state
+    WHERE organization_id = ${organizationId}
+      AND connection_id = ANY(${pgTextArray(ids)}::text[])
+  `;
+  const out = new Map<string, ChannelEnforcement>();
+  for (const r of rows) {
+    out.set(String(r.connection_id), {
+      status: r.enforce === true ? "enforced" : "stale",
+      aclSupport: r.acl_support ?? null,
+      freshnessState: r.freshness_state ?? null,
+      lastSyncedAt: r.last_synced_at
+        ? new Date(r.last_synced_at).toISOString()
+        : null,
+    });
+  }
+  return out;
+}
+
+/** A row carrying the fields needed to form a team-scoped Slack channel key. */
+export interface ChannelKeyRow {
+  platform: string;
+  /** As stored on the binding — may be platform-prefixed (`slack:C…`) or bare. */
+  channel_id: string;
+  /** Slack workspace id (`T…`); required to form the key. */
+  team_id: string | null;
+}
+
+/**
+ * The team-scoped channel key (`T…:C…`) for a bound row, or null when the row
+ * has no team id (can't be keyed → the gate drops it fail-closed, the audience
+ * reports an empty member set). The ONE definition shared by the gate and the
+ * audience so a key-format change can't desync them.
+ */
+export function rowToChannelKey(row: ChannelKeyRow): string | null {
+  if (!row.team_id) return null;
+  return slackChannelKey(
+    row.team_id,
+    stripPlatformPrefix(row.platform, row.channel_id),
+  );
 }

--- a/packages/server/src/authz/audience.ts
+++ b/packages/server/src/authz/audience.ts
@@ -13,12 +13,16 @@
 
 import { type DbClient, pgBigintArray, pgTextArray } from "../db/client.js";
 import { stripPlatformPrefix } from "../gateway/channels/bound-channels.js";
-import { ACL_STALE_AFTER_MINUTES } from "./acl-state.js";
+import {
+  type ChannelEnforcement,
+  getConnectionEnforcement,
+  NOT_GRAPHED,
+  rowToChannelKey,
+} from "./acl-state.js";
 import {
   type GatedChannelRow,
-  resolveRequesterMemberEntityId,
+  resolveRequesterMember,
 } from "./channel-visibility.js";
-import { slackChannelKey } from "./slack-channel-graph.js";
 
 /**
  * How a member appears to the requester:
@@ -34,26 +38,8 @@ export interface AudienceMember {
   displayName: string;
   /** Team-scoped Slack user id (`T…:U…`) when the member carries one. */
   slackUserId: string | null;
-  email: string | null;
   isYou: boolean;
   source: AudienceMemberSource;
-}
-
-/**
- * Per-connection enforcement state:
- *  - `enforced`    — `acl_support='full'` AND `freshness_state='fresh'` AND synced
- *                    within {@link ACL_STALE_AFTER_MINUTES}; recall is membership-gated.
- *  - `stale`       — onboarded (an `authz_source_acl_state` row exists) but not
- *                    currently enforcing (partial/stale/aged-out) → fails closed.
- *  - `not-graphed` — no ACL row at all; legacy per-agent fence, no audience graph.
- */
-export type EnforcementStatus = "enforced" | "stale" | "not-graphed";
-
-export interface ChannelEnforcement {
-  status: EnforcementStatus;
-  aclSupport: string | null;
-  freshnessState: string | null;
-  lastSyncedAt: string | null;
 }
 
 export interface ChannelAudience {
@@ -72,13 +58,6 @@ export interface ChannelAudience {
   memberCount: number;
   members: AudienceMember[];
 }
-
-const NOT_GRAPHED: ChannelEnforcement = {
-  status: "not-graphed",
-  aclSupport: null,
-  freshnessState: null,
-  lastSyncedAt: null,
-};
 
 /**
  * For each bound channel, return its audience (members `member_of` the channel)
@@ -102,41 +81,49 @@ export async function getChannelAudiences(
   const keyByRow = new Map<GatedChannelRow, string | null>();
   const allKeys: string[] = [];
   for (const r of rows) {
-    const key = r.team_id
-      ? slackChannelKey(
-          r.team_id,
-          stripPlatformPrefix(r.platform, r.channel_id),
-        )
-      : null;
+    const key = rowToChannelKey(r);
     keyByRow.set(r, key);
     if (key) allKeys.push(key);
   }
 
-  // 2-4. Resolve channels → resource entities, fan out to members + enforcement,
-  //      and resolve the requester (web/auth path) for the "you" highlight.
-  const [keyToEntity, enforcement, requesterEntityId, teamNames] =
-    await Promise.all([
-      resolveChannelEntityIds(sql, organizationId, allKeys),
-      getConnectionEnforcement(
-        sql,
-        organizationId,
-        rows.map((r) => r.id),
-      ),
-      resolveRequesterMemberEntityId(sql, organizationId, userId),
-      resolveTeamNames(
-        sql,
-        organizationId,
-        rows.map((r) => r.team_id).filter((t): t is string => !!t),
-      ),
-    ]);
-  const resourceIds = [
-    ...new Set([...keyToEntity.values()].map((e) => e.id)),
-  ];
-  const membersByResource = await getAudienceMembers(
-    sql,
-    organizationId,
-    resourceIds,
-  );
+  // 2. Resolve channels → resource entities, the per-connection enforcement
+  //    state, and workspace names. (Requester + members come next, once we know
+  //    which connections actually enforce — see step 3.)
+  const [keyToEntity, enforcement, teamNames] = await Promise.all([
+    resolveChannelEntityIds(sql, organizationId, allKeys),
+    getConnectionEnforcement(
+      sql,
+      organizationId,
+      rows.map((r) => r.id),
+    ),
+    resolveTeamNames(
+      sql,
+      organizationId,
+      rows.map((r) => r.team_id).filter((t): t is string => !!t),
+    ),
+  ]);
+
+  // 3. The audience mirrors the gate: members are only reported for ENFORCED
+  //    connections (a stale/aged-out connection fails closed). So only fetch
+  //    members for resources whose connection enforces — fetching the rest would
+  //    just be discarded — and map each enforced resource to its channel team so
+  //    a member's Slack id can be scoped to THIS workspace.
+  const enforcedResourceTeam = new Map<number, string>();
+  const enforcingTeamIds = new Set<string>();
+  for (const r of rows) {
+    if (enforcement.get(r.id)?.status !== "enforced") continue;
+    if (r.team_id) enforcingTeamIds.add(r.team_id);
+    const key = keyByRow.get(r);
+    const entity = key ? keyToEntity.get(key) : undefined;
+    if (entity && r.team_id) enforcedResourceTeam.set(entity.id, r.team_id);
+  }
+
+  // 4. Resolve the requester (auth + in-Slack fallback) for the "you" highlight,
+  //    and fetch members for the enforced resources, in parallel.
+  const [requesterEntityId, membersByResource] = await Promise.all([
+    resolveRequesterMember(sql, organizationId, userId, [...enforcingTeamIds]),
+    getAudienceMembers(sql, organizationId, enforcedResourceTeam),
+  ]);
 
   return rows.map((r) => {
     const enf = enforcement.get(r.id) ?? NOT_GRAPHED;
@@ -233,25 +220,38 @@ interface RawMember {
   resource_entity_id: number;
   member_entity_id: number;
   display_name: string;
-  slack_user_id: string | null;
-  email: string | null;
   has_auth: boolean;
 }
 
-/** Members `member_of` each resource entity, with the identities the UI renders. */
+/** A member resolved for one resource, with the Slack id scoped to that
+ * resource's channel team. */
+interface AudienceRow {
+  member_entity_id: number;
+  display_name: string;
+  slack_user_id: string | null;
+  has_auth: boolean;
+}
+
+/**
+ * Members `member_of` each enforced resource entity, with the identities the UI
+ * renders. `resourceTeam` maps each resource entity id to its Slack workspace so
+ * a member's Slack id is scoped to THIS channel's team — a member who belongs to
+ * several workspaces carries one `slack_user_id` identity per team, and the
+ * audience for a channel must show the id for that channel's workspace, not an
+ * arbitrary one.
+ */
 async function getAudienceMembers(
   sql: DbClient,
   organizationId: string,
-  resourceIds: number[],
-): Promise<Map<number, RawMember[]>> {
+  resourceTeam: Map<number, string>,
+): Promise<Map<number, AudienceRow[]>> {
+  const resourceIds = [...resourceTeam.keys()];
   if (resourceIds.length === 0) return new Map();
   const rows = await sql<RawMember>`
     SELECT
       r.to_entity_id AS resource_entity_id,
       me.id AS member_entity_id,
       me.name AS display_name,
-      MAX(CASE WHEN mi.namespace = 'slack_user_id' THEN mi.identifier END) AS slack_user_id,
-      MAX(CASE WHEN mi.namespace = 'email' THEN mi.identifier END) AS email,
       bool_or(mi.namespace = 'auth_user_id' AND mi.source_connector = 'auth:signup') AS has_auth
     FROM entity_relationships r
     JOIN entity_relationship_types rt
@@ -272,62 +272,53 @@ async function getAudienceMembers(
     GROUP BY r.to_entity_id, me.id, me.name
     ORDER BY me.name ASC
   `;
-  const out = new Map<number, RawMember[]>();
-  for (const r of rows) {
-    const id = Number(r.resource_entity_id);
-    const list = out.get(id) ?? [];
-    list.push(r);
-    out.set(id, list);
-  }
-  return out;
-}
 
-/** Per-connection enforcement detail (status + the columns the detail panel shows). */
-async function getConnectionEnforcement(
-  sql: DbClient,
-  organizationId: string,
-  connectionIds: string[],
-): Promise<Map<string, ChannelEnforcement>> {
-  const ids = [...new Set(connectionIds)].filter(Boolean);
-  if (ids.length === 0) return new Map();
-  const rows = await sql<{
-    connection_id: string;
-    acl_support: string | null;
-    freshness_state: string | null;
-    last_synced_at: Date | null;
-    enforce: boolean;
-  }>`
-    SELECT
-      connection_id,
-      acl_support,
-      freshness_state,
-      last_synced_at,
-      (
-        acl_support = 'full'
-        AND freshness_state = 'fresh'
-        AND last_synced_at IS NOT NULL
-        AND last_synced_at >= current_timestamp - make_interval(mins => ${ACL_STALE_AFTER_MINUTES})
-      ) AS enforce
-    FROM authz_source_acl_state
-    WHERE organization_id = ${organizationId}
-      AND connection_id = ANY(${pgTextArray(ids)}::text[])
-  `;
-  const out = new Map<string, ChannelEnforcement>();
+  // Fetch each member's team-scoped Slack ids in a separate scalar query (no
+  // array readback, safe under fetch_types:false) and pick the one matching the
+  // resource's team at grouping time.
+  const memberIds = [...new Set(rows.map((r) => Number(r.member_entity_id)))];
+  const slackIdsByMember = new Map<number, string[]>();
+  if (memberIds.length > 0) {
+    const idRows = await sql<{ entity_id: number; identifier: string }>`
+      SELECT entity_id, identifier
+      FROM entity_identities
+      WHERE organization_id = ${organizationId}
+        AND namespace = 'slack_user_id'
+        AND entity_id = ANY(${pgBigintArray(memberIds)}::bigint[])
+        AND deleted_at IS NULL
+    `;
+    for (const r of idRows) {
+      const id = Number(r.entity_id);
+      const list = slackIdsByMember.get(id) ?? [];
+      list.push(String(r.identifier));
+      slackIdsByMember.set(id, list);
+    }
+  }
+
+  const out = new Map<number, AudienceRow[]>();
   for (const r of rows) {
-    out.set(String(r.connection_id), {
-      status: r.enforce === true ? "enforced" : "stale",
-      aclSupport: r.acl_support ?? null,
-      freshnessState: r.freshness_state ?? null,
-      lastSyncedAt: r.last_synced_at
-        ? new Date(r.last_synced_at).toISOString()
-        : null,
+    const resourceId = Number(r.resource_entity_id);
+    const memberId = Number(r.member_entity_id);
+    // `slack_user_id` identities are stored uppercased (`T…:U…`); scope to the
+    // resource's team so a multi-workspace member shows this channel's id.
+    const teamPrefix = `${resourceTeam.get(resourceId)?.toUpperCase()}:`;
+    const slackUserId =
+      slackIdsByMember.get(memberId)?.find((i) => i.startsWith(teamPrefix)) ??
+      null;
+    const list = out.get(resourceId) ?? [];
+    list.push({
+      member_entity_id: memberId,
+      display_name: r.display_name,
+      slack_user_id: slackUserId,
+      has_auth: r.has_auth,
     });
+    out.set(resourceId, list);
   }
   return out;
 }
 
 function toAudienceMember(
-  m: RawMember,
+  m: AudienceRow,
   requesterEntityId: number | null,
 ): AudienceMember {
   const isYou =
@@ -342,7 +333,6 @@ function toAudienceMember(
     entityId: Number(m.member_entity_id),
     displayName: m.display_name,
     slackUserId: m.slack_user_id ?? null,
-    email: m.email ?? null,
     isYou,
     source,
   };

--- a/packages/server/src/authz/channel-visibility.ts
+++ b/packages/server/src/authz/channel-visibility.ts
@@ -26,9 +26,7 @@
 
 import { normalizeSlackUserId } from '@lobu/connector-sdk';
 import { type DbClient, pgTextArray } from '../db/client.js';
-import { stripPlatformPrefix } from '../gateway/channels/bound-channels.js';
-import { ACL_STALE_AFTER_MINUTES } from './acl-state.js';
-import { slackChannelKey } from './slack-channel-graph.js';
+import { getConnectionEnforcement, rowToChannelKey } from './acl-state.js';
 
 /** A bound channel the gate decides on. Mirrors the fields `resolveBoundChannelRows`
  * returns (`id` is the connection id). */
@@ -116,47 +114,28 @@ async function resolveRequesterBySlackUserId(
   return rows.length > 0 ? Number(rows[0].entity_id) : null;
 }
 
-
 /**
- * The ACL state of each connection that has been onboarded into the authz
- * program. A connection ABSENT from the returned map has no
- * `authz_source_acl_state` row at all — it was never graphed, so it keeps the
- * legacy per-agent fence. A connection PRESENT in the map has been onboarded and
- * MUST be enforced: it may use membership filtering only when `enforce` is true
- * (`acl_support='full'` AND `freshness_state='fresh'` AND the graph was synced
- * within {@link ACL_STALE_AFTER_MINUTES}). Any other state — stale/failed/unknown
- * freshness, partial/none support, or a `fresh` row that has aged out — fails
- * closed: its channels are dropped, never passed through as legacy. Otherwise a
- * connection whose graph goes stale would silently re-expose every channel.
+ * Resolve the requester to a `$member` entity id, combining BOTH paths the
+ * authz program supports: prefer the auth-server signup claim (web/app sign-in),
+ * then fall back to the team-scoped `slack_user_id` claim for someone talking to
+ * the bot INSIDE Slack (whose only id is a Slack user id). `enforcingTeamIds`
+ * scopes the Slack fallback to the teams whose connections are actually
+ * enforcing. Returns null when neither resolves (→ fail closed).
+ *
+ * The single resolver shared by the gate ({@link filterChannelsForRequester})
+ * and the audience read's "you" highlight, so the two never disagree on who the
+ * requester is.
  */
-export async function getConnectionAclStates(
+export async function resolveRequesterMember(
   sql: DbClient,
   organizationId: string,
-  connectionIds: string[],
-): Promise<Map<string, { enforce: boolean }>> {
-  const ids = [...new Set(connectionIds)].filter(Boolean);
-  if (ids.length === 0) return new Map();
-  const rows = await sql<{
-    connection_id: string;
-    enforce: boolean;
-  }>`
-		SELECT
-			connection_id,
-			(
-				acl_support = 'full'
-				AND freshness_state = 'fresh'
-				AND last_synced_at IS NOT NULL
-				AND last_synced_at >= current_timestamp - make_interval(mins => ${ACL_STALE_AFTER_MINUTES})
-			) AS enforce
-		FROM authz_source_acl_state
-		WHERE organization_id = ${organizationId}
-		  AND connection_id = ANY(${pgTextArray(ids)}::text[])
-	`;
-  const out = new Map<string, { enforce: boolean }>();
-  for (const r of rows) {
-    out.set(String(r.connection_id), { enforce: r.enforce === true });
-  }
-  return out;
+  userId: string | null,
+  enforcingTeamIds: string[],
+): Promise<number | null> {
+  if (!userId) return null;
+  const byAuth = await resolveRequesterMemberEntityId(sql, organizationId, userId);
+  if (byAuth !== null) return byAuth;
+  return resolveRequesterBySlackUserId(sql, organizationId, userId, enforcingTeamIds);
 }
 
 /**
@@ -204,7 +183,7 @@ export async function filterChannelsForRequester<T extends GatedChannelRow>(
   const { organizationId, userId, rows } = params;
   if (rows.length === 0) return rows;
 
-  const states = await getConnectionAclStates(
+  const states = await getConnectionEnforcement(
     sql,
     organizationId,
     rows.map((r) => r.id),
@@ -216,29 +195,17 @@ export async function filterChannelsForRequester<T extends GatedChannelRow>(
   // Only resolve the requester's membership when at least one connection is
   // actively enforcing (full+fresh). Onboarded-but-stale connections fail closed
   // regardless of who is asking, so they need no membership lookup.
-  const anyEnforcing = [...states.values()].some((s) => s.enforce);
-  // Resolve the requester to a member. Prefer the auth_user_id claim (web/app
-  // path); fall back to the team-scoped slack_user_id claim for someone talking
-  // to the bot inside Slack, whose id is a Slack user id, not an auth id.
-  let memberEntityId: number | null = null;
-  if (anyEnforcing) {
-    memberEntityId = await resolveRequesterMemberEntityId(sql, organizationId, userId);
-    if (memberEntityId === null) {
-      const enforcingTeamIds = [
-        ...new Set(
-          rows
-            .filter((r) => states.get(r.id)?.enforce && r.team_id)
-            .map((r) => r.team_id as string),
-        ),
-      ];
-      memberEntityId = await resolveRequesterBySlackUserId(
-        sql,
-        organizationId,
-        userId,
-        enforcingTeamIds,
-      );
-    }
-  }
+  const anyEnforcing = [...states.values()].some((s) => s.status === "enforced");
+  const enforcingTeamIds = [
+    ...new Set(
+      rows
+        .filter((r) => states.get(r.id)?.status === "enforced" && r.team_id)
+        .map((r) => r.team_id as string),
+    ),
+  ];
+  const memberEntityId = anyEnforcing
+    ? await resolveRequesterMember(sql, organizationId, userId, enforcingTeamIds)
+    : null;
   const visibleKeys =
     memberEntityId === null
       ? new Set<string>()
@@ -247,9 +214,9 @@ export async function filterChannelsForRequester<T extends GatedChannelRow>(
   return rows.filter((r) => {
     const state = states.get(r.id);
     if (!state) return true; // never graphed → legacy fence still applies
-    if (!state.enforce) return false; // onboarded but stale/unsupported → fail closed
-    if (!r.team_id) return false; // can't form the key → fail closed
-    const key = slackChannelKey(r.team_id, stripPlatformPrefix(r.platform, r.channel_id));
+    if (state.status !== "enforced") return false; // stale/unsupported → fail closed
+    const key = rowToChannelKey(r);
+    if (key === null) return false; // no team id → can't form the key → fail closed
     return visibleKeys.has(key);
   });
 }

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -41,12 +41,19 @@ const logger = createLogger('slack-acl-sync');
  * Slack API and token resolver, and the live tick wires the real ones. */
 export interface SlackAclSyncDeps {
   slackWeb: Pick<SlackWebApi, 'conversationMembers' | 'conversationInfo'>;
-  /** Resolve the bot token for a workspace, or null if none is available
-   * (no active install / unresolvable secret) — null is treated fail-closed. */
-  resolveBotToken: (params: {
+  /**
+   * Resolve the bot IDENTITY for a workspace — its token plus the bot's own
+   * Slack user id — from the app installation, or null if none is available (no
+   * active install / unresolvable secret), which is treated fail-closed. The bot
+   * id is sourced from the install (stamped at install time), NOT from the
+   * connection metadata, whose `botUserId` is only backfilled lazily at adapter
+   * init: in the window before the adapter first runs it is null, which would let
+   * the bot slip into the `member_of` graph and the audience.
+   */
+  resolveBotIdentity: (params: {
     organizationId: string;
     teamId: string;
-  }) => Promise<string | null>;
+  }) => Promise<{ token: string; botUserId: string | null } | null>;
 }
 
 export interface SlackAclSyncResult {
@@ -116,19 +123,6 @@ export async function syncSlackConnectionAcl(
     return { ok: true, teamsSynced: 0, channelsSynced: 0 };
   }
 
-  // The bot is itself a member of every channel it's in, so `conversations.members`
-  // includes it. Drop it: a bot is not an audience and must never gain a
-  // `member_of` edge (it would inflate "who can recall" AND, via the gate, count
-  // as a member). The bot's own Slack user id is backfilled onto the connection
-  // metadata at adapter init; absent it, we simply don't filter (no regression).
-  const connRow = await sql<{ bot_user_id: string | null }>`
-		SELECT metadata->>'botUserId' AS bot_user_id
-		FROM agent_connections
-		WHERE id = ${connectionId} AND organization_id = ${organizationId}
-		LIMIT 1
-	`;
-  const botUserId = connRow[0]?.bot_user_id ?? null;
-
   // Group channels by workspace/team — one graph build per team.
   const byTeam = new Map<string, string[]>();
   for (const r of slackRows) {
@@ -142,16 +136,22 @@ export async function syncSlackConnectionAcl(
   let channelsSynced = 0;
   try {
     for (const [teamId, channelIds] of byTeam) {
-      const token = await deps.resolveBotToken({ organizationId, teamId });
-      if (!token) {
+      const identity = await deps.resolveBotIdentity({ organizationId, teamId });
+      if (!identity) {
         throw new Error(`No bot token for team ${teamId}`);
       }
+      const { token, botUserId } = identity;
       const channels: SlackChannelInput[] = [];
       for (const channelId of channelIds) {
         const rawMembers = await deps.slackWeb.conversationMembers(
           token,
           channelId,
         );
+        // The bot is itself a member of every channel it's in, so
+        // `conversations.members` includes it. Drop it: a bot is not an audience
+        // and must never gain a `member_of` edge (it would inflate "who can
+        // recall" AND, via the gate, count as a member). The bot id is the
+        // install's, scoped to THIS team. Absent it, we don't filter (no regression).
         const memberSlackUserIds = botUserId
           ? rawMembers.filter((u) => u !== botUserId)
           : rawMembers;
@@ -223,14 +223,15 @@ export async function runSlackAclSyncTick(coreServices: CoreServices): Promise<v
 
   const deps: SlackAclSyncDeps = {
     slackWeb,
-    resolveBotToken: async ({ teamId }) => {
+    resolveBotIdentity: async ({ teamId }) => {
       const install = await getSlackInstallByTeamId(installStore, teamId);
       if (!install || install.status !== 'active') return null;
       const tokenRef = (install.config as { botToken?: string }).botToken;
       const token = await orgContext.run({ organizationId: install.organizationId }, () =>
         resolveSecretValue(secretStore, tokenRef),
       );
-      return token ?? null;
+      if (!token) return null;
+      return { token, botUserId: install.botUserId ?? null };
     },
   };
 

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -46,14 +46,7 @@ async function slackPost(
   // / conversations.open used here), so encode uniformly.
   const form = new URLSearchParams();
   for (const [key, value] of Object.entries(body)) {
-    if (value === undefined || value === null) continue;
-    // Slack's structured params (e.g. `blocks`, `attachments`) must be JSON
-    // strings in a form body — `String(obj)` would emit "[object Object]".
-    // Scalars (channel, text, limit, cursor) pass through unchanged.
-    form.set(
-      key,
-      typeof value === "object" ? JSON.stringify(value) : String(value)
-    );
+    if (value !== undefined && value !== null) form.set(key, String(value));
   }
   const res = await fetch(`https://slack.com/api/${method}`, {
     method: "POST",

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -46,7 +46,14 @@ async function slackPost(
   // / conversations.open used here), so encode uniformly.
   const form = new URLSearchParams();
   for (const [key, value] of Object.entries(body)) {
-    if (value !== undefined && value !== null) form.set(key, String(value));
+    if (value === undefined || value === null) continue;
+    // Slack's structured params (e.g. `blocks`, `attachments`) must be JSON
+    // strings in a form body — `String(obj)` would emit "[object Object]".
+    // Scalars (channel, text, limit, cursor) pass through unchanged.
+    form.set(
+      key,
+      typeof value === "object" ? JSON.stringify(value) : String(value)
+    );
   }
   const res = await fetch(`https://slack.com/api/${method}`, {
     method: "POST",


### PR DESCRIPTION
First of the post-PR1 split (PR-C of C→B→A→D). Folds the review cleanups from the audience PR into one pass over the authz read path. Behavior-preserving except where it tightens (PII drop, bot-leak window, team-scoped ids).

## What changed

**Dedup (kill drift between the gate and the audience read)**
- Moved the enforce predicate + the team-scoped channel key into `acl-state.ts`: `getConnectionEnforcement` (rich status) and `rowToChannelKey`. The gate (`channel-visibility.ts`) and the audience (`audience.ts`) now share one definition instead of each carrying its own copy.
- Extracted a combined requester resolver `resolveRequesterMember` (auth_user_id, then in-Slack `slack_user_id` fallback) used by both the gate and the audience "you" highlight (audience was auth-only before, so an in-Slack viewer never got the "you" marker).

**Harden the audience read (`audience.ts`)**
- Fetch members ONLY for enforced resources — it used to query members for every channel then discard the non-enforced ones.
- Scope each member's `slack_user_id` to the channel's workspace. A member in several workspaces carries one id per team; the old `MAX(CASE …)` picked an arbitrary one. Done with a separate scalar query (no array readback under `fetch_types:false`).
- Drop `email` from the response. The agent owner viewing the Reach tab need not be a channel member, so member emails were PII leaking to a non-member.

**Fix the bot-id source (`slack-acl-sync.ts`)**
- Source the bot's own Slack user id from the app INSTALL per team (`resolveBotIdentity → {token, botUserId}`), not `agent_connections.metadata.botUserId`. The latter is only backfilled lazily at adapter init; in that window it's null, so the bot slipped into the `member_of` graph and the audience.

**Defensive (`slack-web.ts`)**
- `slackPost` now JSON-stringifies object/array form values (`blocks`/`attachments`) instead of `String()` → `"[object Object]"`. No current caller passes structured params; this is just removing the latent trap.

**owletto**
- Drop the `email` field from `ChannelAudienceMember` + the `memberHandle` email fallback (end-to-end PII removal). Pointer bumped to `lobu-ai/owletto@4c15765`.

## Tests
- `channel-audience` + `slack-channel-visibility` integration suites updated to the `resolveBotIdentity` shape; the bot-exclusion test now proves the bot is filtered via the install id even with no connection metadata.
- Ran locally: 15 authz integration tests pass, 2 slack-web unit tests pass, server `tsc --noEmit` 0 errors, owletto `tsc -b` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785287994&installation_id=136316292&pr_number=1603&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1603&signature=b0be0ca0a6162c46cefe78a11b6652195654125fecbe12386171dd6042c6074e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->