### PR TITLE
feat(connections): unify model — Stage 1 expand/backfill (additive, no cutover)

### DIFF
--- a/db/migrations/20260629000000_connections_unify_columns.sql
+++ b/db/migrations/20260629000000_connections_unify_columns.sql
@@ -1,0 +1,67 @@
+-- migrate:up
+
+-- Connections-unify Stage 1 (expand), reuse-first. `connections` is ALREADY the
+-- intended unified table (its baseline comment: "Replaces the legacy
+-- chat_connections + per-platform tables"; lists Slack/Telegram/GitHub/Linear)
+-- and already has the slots chat needs — connector_key (platform), config (adapter
+-- config + secret:// refs), auth_profile_id / app_auth_profile_id (credential
+-- backing), agent_id, status, visibility, slug. `app_installations` +
+-- `agent_connections` are parallel duplicates added later. So we do NOT add a
+-- faceted column set; we FINISH folding chat into `connections`, reusing columns.
+--
+-- TWO genuinely-new columns:
+--   external_tenant_id — the provider workspace/tenant id (Slack team_id, …). A
+--     first-class routing + uniqueness key: Stage-2 Slack routing queries it on
+--     the hot path and the one-active-chat-per-tenant invariant keys on it, so it
+--     gets a real indexed column (mirroring app_installations.external_tenant_id +
+--     app_installations_active_tenant), not a jsonb expression. NULL for
+--     tenantless chat (Telegram) and for data connectors.
+--   credential_mode (managed | byo) — for chat the bot token is a secret:// ref in
+--     `config` for BOTH modes and auth_profile_id / app_auth_profile_id are NULL,
+--     so neither auth slot distinguishes a Lobu-hosted OAuth install (managed)
+--     from a customer-supplied token (byo). Deriving it from `agent_id IS NULL`
+--     would overload agent_id and mislabel a future org-level BYO connection, so
+--     it is stored explicitly. NULL for data connectors (which use auth_profiles),
+--     so `credential_mode IS NOT NULL` also reads as "this is a chat connection".
+--
+-- Capabilities/facets are DERIVED, not stored (Data=feeds, Chat=bindings,
+-- Actions=operations/MCP, Audience=authz_source_acl_state). settings/metadata
+-- fold into `config` / `display_name` / `slug` (see the backfill).
+
+ALTER TABLE public.connections
+    ADD COLUMN IF NOT EXISTS external_tenant_id text,
+    ADD COLUMN IF NOT EXISTS credential_mode text;
+
+-- credential_mode domain. DROP-IF-EXISTS keeps the ADD re-runnable; NOT VALID
+-- avoids a scan-lock (the column is brand-new/all-NULL so VALIDATE is instant).
+ALTER TABLE public.connections DROP CONSTRAINT IF EXISTS connections_credential_mode_check;
+ALTER TABLE public.connections
+    ADD CONSTRAINT connections_credential_mode_check
+    CHECK (credential_mode IS NULL OR credential_mode IN ('managed', 'byo')) NOT VALID;
+ALTER TABLE public.connections VALIDATE CONSTRAINT connections_credential_mode_check;
+
+-- Bindings gain a connection_id FK (nullable, secondary in Stage 1 — bindings
+-- still route by (platform, team_id) until Stage 3). ON DELETE SET NULL: deleting
+-- a connection must NOT cascade-delete bindings yet. NOT VALID then VALIDATE so
+-- the FK build doesn't lock both tables at prod scale.
+ALTER TABLE public.agent_channel_bindings
+    ADD COLUMN IF NOT EXISTS connection_id bigint;
+ALTER TABLE public.agent_channel_bindings
+    DROP CONSTRAINT IF EXISTS agent_channel_bindings_connection_id_fkey;
+ALTER TABLE public.agent_channel_bindings
+    ADD CONSTRAINT agent_channel_bindings_connection_id_fkey
+    FOREIGN KEY (connection_id) REFERENCES public.connections(id) ON DELETE SET NULL NOT VALID;
+ALTER TABLE public.agent_channel_bindings VALIDATE CONSTRAINT agent_channel_bindings_connection_id_fkey;
+
+-- migrate:down
+
+ALTER TABLE public.agent_channel_bindings
+    DROP CONSTRAINT IF EXISTS agent_channel_bindings_connection_id_fkey;
+ALTER TABLE public.agent_channel_bindings
+    DROP COLUMN IF EXISTS connection_id;
+
+ALTER TABLE public.connections
+    DROP CONSTRAINT IF EXISTS connections_credential_mode_check;
+ALTER TABLE public.connections
+    DROP COLUMN IF EXISTS credential_mode,
+    DROP COLUMN IF EXISTS external_tenant_id;

--- a/db/migrations/20260629000010_connections_active_chat_tenant_index.sql
+++ b/db/migrations/20260629000010_connections_active_chat_tenant_index.sql
@@ -1,0 +1,24 @@
+-- migrate:up transaction:false
+
+-- The one-active-chat-per-tenant invariant — the unified-model analogue of
+-- `app_installations_active_tenant`, keyed on the first-class
+-- `external_tenant_id` column and `connector_key` (the platform). At most ONE
+-- active chat connection may own a given (org, platform, tenant): this is what
+-- enforces BYO-vs-managed mutual exclusivity for a workspace (the Stage 1
+-- backfill demotes the loser to 'paused'; Stage 2's runtime writes will rely on
+-- this index the same way the Slack store relies on the app_installations index).
+--
+-- Partial: only chat connectors with a non-null tenant participate. Telegram (no
+-- team) has external_tenant_id IS NULL and is excluded — it is keyed per
+-- bot/connection, not per tenant. CONCURRENTLY (transaction:false, one
+-- statement) so the build never blocks writes on a populated table.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS connections_active_chat_tenant
+    ON public.connections (organization_id, connector_key, external_tenant_id)
+    WHERE deleted_at IS NULL
+      AND status = 'active'
+      AND external_tenant_id IS NOT NULL
+      AND connector_key IN ('slack', 'telegram', 'discord', 'whatsapp', 'teams', 'gchat');
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.connections_active_chat_tenant;

--- a/db/migrations/20260629000020_agent_channel_bindings_connection_id_index.sql
+++ b/db/migrations/20260629000020_agent_channel_bindings_connection_id_index.sql
@@ -1,0 +1,13 @@
+-- migrate:up transaction:false
+
+-- Lookup index for the new bindings.connection_id FK (Stage 3 will route
+-- bindings by connection_id; Stage 1 backfills it). Partial on NOT NULL so the
+-- index stays small while the column is still mostly unpopulated. CONCURRENTLY
+-- (transaction:false, one statement) to avoid locking the bindings table.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_agent_channel_bindings_connection_id
+    ON public.agent_channel_bindings (connection_id)
+    WHERE connection_id IS NOT NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_agent_channel_bindings_connection_id;

--- a/db/migrations/20260629000030_connections_unify_backfill.sql
+++ b/db/migrations/20260629000030_connections_unify_backfill.sql
@@ -1,0 +1,235 @@
+-- migrate:up
+
+-- Connections-unify Stage 1 (backfill), reuse-first: fold the two out-of-table
+-- chat stores into `connections`, populating only EXISTING columns plus the one
+-- new `credential_mode`. Fully IDEMPOTENT (guarded on the unique `slug`) and
+-- NON-DESTRUCTIVE (agent_connections / app_installations stay the runtime source
+-- of truth until the Stage 4 drop; this only materializes the unified
+-- projection). NO runtime/store/UI cutover (Stage 2).
+--
+-- Column reuse:
+--   connector_key      = platform ('slack' | 'telegram' | …)
+--   external_tenant_id = the provider tenant id (Slack team_id); the
+--                        one-active-chat-per-tenant index keys on it (new column).
+--   config             = the adapter config (incl. the botToken secret:// ref) +
+--                        folded { settings, chatMetadata } — no new settings /
+--                        metadata columns.
+--   app_auth_profile_id= the managed install's credential backing
+--                        (app_installations.auth_profile_id; NULL for Slack today,
+--                        whose token is the secret:// ref in config).
+--   auth_profile_id    = the BYO connection's credential profile, when it had one.
+--   agent_id           = the BYO row's owning agent; NULL for org-level managed.
+--   credential_mode    = 'byo' | 'managed' (new column).
+--   slug               = idempotency key: 'agentconn-'||id (byo) / external_id
+--                        (managed). UNIQUE per org via connections_org_slug_unique.
+--
+-- Chat platforms ≔ the PlatformAdapterConfigSchema chat union minus 'webhook'
+-- (ingest/data) and 'api'. GitHub/other app_installations are data/actions,
+-- already represented as `connections` rows at install time, and are NOT folded.
+
+-- ── Step 1: BYO chat connections (agent_connections) ────────────────────────
+-- Done BEFORE the managed step so BYO wins a contended (org, platform, team).
+-- BYO-wins / latest-wins: rank a tenant group by updated_at DESC; only rank 1
+-- claims 'active' (the in-batch rank dedupes within one INSERT; the correlated
+-- subquery additionally yields to any active chat row already present, for
+-- re-run safety). Tenantless rows (Telegram, no teamId) skip the contest.
+WITH src AS (
+    SELECT
+        ac.id,
+        ac.organization_id,
+        ac.agent_id,
+        ac.platform,
+        ac.config,
+        ac.settings,
+        ac.metadata,
+        ac.created_at,
+        ac.updated_at,
+        NULLIF(ac.metadata ->> 'teamId', '') AS team_id,
+        CASE ac.status
+            WHEN 'active' THEN 'active'
+            WHEN 'error' THEN 'error'
+            ELSE 'paused'
+        END AS mapped_status
+    FROM public.agent_connections ac
+    WHERE ac.platform IN ('slack', 'telegram', 'discord', 'whatsapp', 'teams', 'gchat')
+      AND NOT EXISTS (
+          SELECT 1 FROM public.connections c
+          WHERE c.organization_id = ac.organization_id
+            AND c.slug = 'agentconn-' || ac.id
+            AND c.deleted_at IS NULL
+      )
+),
+ranked AS (
+    SELECT
+        src.*,
+        CASE
+            WHEN team_id IS NOT NULL AND mapped_status = 'active'
+            THEN ROW_NUMBER() OVER (
+                PARTITION BY organization_id, platform, team_id
+                ORDER BY updated_at DESC, id DESC
+            )
+            ELSE 1
+        END AS active_rank
+    FROM src
+)
+INSERT INTO public.connections (
+    organization_id, connector_key, external_tenant_id, agent_id, display_name, status,
+    config, credential_mode, slug, visibility, created_at, updated_at
+)
+SELECT
+    r.organization_id,
+    r.platform,
+    r.team_id,
+    r.agent_id,
+    COALESCE(NULLIF(r.metadata ->> 'teamName', ''), r.platform),
+    CASE
+        WHEN r.mapped_status = 'active'
+             AND r.active_rank = 1
+             AND (
+                 r.team_id IS NULL
+                 OR NOT EXISTS (
+                     SELECT 1 FROM public.connections c2
+                     WHERE c2.organization_id = r.organization_id
+                       AND c2.connector_key = r.platform
+                       AND c2.external_tenant_id = r.team_id
+                       AND c2.status = 'active'
+                       AND c2.deleted_at IS NULL
+                 )
+             )
+        THEN 'active'
+        WHEN r.mapped_status = 'active' THEN 'paused'
+        ELSE r.mapped_status
+    END,
+    -- Reuse `config`: keep the adapter config (incl. botToken ref) and fold
+    -- settings + the residual metadata losslessly (so nothing is dropped before
+    -- Stage 2 reads it). The tenant id lives in the external_tenant_id column.
+    COALESCE(r.config, '{}'::jsonb)
+        || jsonb_build_object('settings', r.settings, 'chatMetadata', r.metadata),
+    'byo',
+    'agentconn-' || r.id,
+    'org',
+    r.created_at,
+    r.updated_at
+FROM ranked r;
+
+-- ── Step 2: managed Slack installs (app_installations) ──────────────────────
+-- Runs AFTER step 1, so the active-row guard sees a BYO row already holding the
+-- team's slot and demotes the managed row to 'paused' (BYO-wins, loser kept for
+-- audit). external_id (slackinst-<uuid>) is preserved as slug + idempotency key.
+WITH src AS (
+    SELECT
+        ai.id,
+        ai.organization_id,
+        ai.external_tenant_id AS team_id,
+        ai.auth_profile_id,
+        ai.metadata,
+        ai.created_at,
+        ai.updated_at,
+        CASE ai.status
+            WHEN 'active' THEN 'active'
+            WHEN 'error' THEN 'error'
+            ELSE 'paused'
+        END AS mapped_status,
+        COALESCE(NULLIF(ai.metadata ->> 'external_id', ''), 'slackinst-' || ai.id) AS ext_id
+    FROM public.app_installations ai
+    WHERE ai.provider = 'slack'
+      AND NOT EXISTS (
+          SELECT 1 FROM public.connections c
+          WHERE c.organization_id = ai.organization_id
+            AND c.slug = COALESCE(NULLIF(ai.metadata ->> 'external_id', ''), 'slackinst-' || ai.id)
+            AND c.deleted_at IS NULL
+      )
+),
+ranked AS (
+    SELECT
+        src.*,
+        CASE
+            WHEN mapped_status = 'active'
+            THEN ROW_NUMBER() OVER (
+                PARTITION BY organization_id, team_id
+                ORDER BY updated_at DESC, id DESC
+            )
+            ELSE 1
+        END AS active_rank
+    FROM src
+)
+INSERT INTO public.connections (
+    organization_id, connector_key, external_tenant_id, app_auth_profile_id, display_name, status,
+    config, credential_mode, slug, visibility, created_at, updated_at
+)
+SELECT
+    r.organization_id,
+    'slack',
+    r.team_id,
+    r.auth_profile_id,
+    COALESCE(NULLIF(r.metadata ->> 'team_name', ''), 'slack'),
+    CASE
+        WHEN r.mapped_status = 'active'
+             AND r.active_rank = 1
+             AND NOT EXISTS (
+                 SELECT 1 FROM public.connections c2
+                 WHERE c2.organization_id = r.organization_id
+                   AND c2.connector_key = 'slack'
+                   AND c2.external_tenant_id = r.team_id
+                   AND c2.status = 'active'
+                   AND c2.deleted_at IS NULL
+             )
+        THEN 'active'
+        WHEN r.mapped_status = 'active' THEN 'paused'
+        ELSE r.mapped_status
+    END,
+    COALESCE(r.metadata -> 'config', '{}'::jsonb)
+        || jsonb_build_object('chatMetadata', r.metadata),
+    'managed',
+    r.ext_id,
+    'org',
+    r.created_at,
+    r.updated_at
+FROM ranked r;
+
+-- ── Step 3: link existing bindings to the backfilled chat connection ────────
+-- `credential_mode IS NOT NULL` identifies the backfilled chat connections.
+-- Match an unlinked binding to the ACTIVE chat connection for its (org,
+-- platform, team); tenantless bindings (Telegram) match on the source agent.
+UPDATE public.agent_channel_bindings b
+SET connection_id = (
+    SELECT c.id FROM public.connections c
+    WHERE c.deleted_at IS NULL
+      AND c.status = 'active'
+      AND c.credential_mode IS NOT NULL
+      AND c.organization_id = b.organization_id
+      AND c.connector_key = b.platform
+      AND (
+          (b.team_id IS NOT NULL AND c.external_tenant_id = b.team_id)
+          OR (b.team_id IS NULL AND c.external_tenant_id IS NULL AND c.agent_id = b.agent_id)
+      )
+    ORDER BY c.updated_at DESC
+    LIMIT 1
+)
+WHERE b.connection_id IS NULL
+  AND EXISTS (
+      SELECT 1 FROM public.connections c
+      WHERE c.deleted_at IS NULL
+        AND c.status = 'active'
+        AND c.credential_mode IS NOT NULL
+        AND c.organization_id = b.organization_id
+        AND c.connector_key = b.platform
+        AND (
+            (b.team_id IS NOT NULL AND c.external_tenant_id = b.team_id)
+            OR (b.team_id IS NULL AND c.external_tenant_id IS NULL AND c.agent_id = b.agent_id)
+        )
+  );
+
+-- migrate:down
+
+-- Unlink bindings that point at a backfilled chat connection, then remove the
+-- backfilled chat rows. Best-effort dev rollback (source tables untouched).
+UPDATE public.agent_channel_bindings
+SET connection_id = NULL
+WHERE connection_id IN (
+    SELECT id FROM public.connections WHERE credential_mode IN ('byo', 'managed')
+);
+
+DELETE FROM public.connections
+WHERE credential_mode IN ('byo', 'managed')
+  AND (slug LIKE 'agentconn-%' OR slug LIKE 'slackinst-%');

--- a/packages/server/src/__tests__/integration/connectors/connections-unify-backfill.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connections-unify-backfill.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Connections-unify Stage 1 — reuse-first expand/backfill migration.
+ *
+ * Proves the idempotent backfill (20260629000030_connections_unify_backfill.sql)
+ * folds the two out-of-table chat stores into the unified `connections` table
+ * using EXISTING columns plus the one new `credential_mode`:
+ *   1. existing data connectors are left untouched (credential_mode NULL);
+ *   2. agent_connections chat rows become credential_mode='byo' connections —
+ *      connector_key=platform, tenant in config->>'teamId', token kept in config,
+ *      agent_id carried, slug='agentconn-'||id;
+ *   3. slack app_installations become credential_mode='managed' connections —
+ *      connector_key='slack', app_auth_profile_id from the install, slug=external_id;
+ *   4. BYO-WINS: a BYO row and a managed install contending for the same
+ *      (org, platform, team) → BYO holds 'active', managed demoted to 'paused';
+ *   5. existing agent_channel_bindings get connection_id linked (by team, or by
+ *      agent for tenantless platforms);
+ *   6. re-running the backfill is a no-op (idempotency, keyed on the unique slug).
+ *
+ * The test seeds rows on `lobu_test` (scoped to a fresh org) and executes the
+ * migration's `-- migrate:up` body verbatim — the same SQL prod runs — so it
+ * can't drift from what ships.
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getDb } from "../../../db/client";
+import { loadMigrationUpSection } from "../../../db/migration-loader";
+import { initWorkspaceProvider } from "../../../workspace";
+import {
+	createTestAgent,
+	createTestConnection,
+	createTestOrganization,
+} from "../../setup/test-fixtures";
+
+const BACKFILL_MIGRATION = "20260629000030_connections_unify_backfill.sql";
+
+function resolveMigrationsDir(): string {
+	let dir = __dirname;
+	for (let i = 0; i < 8; i++) {
+		const candidate = join(dir, "db/migrations");
+		if (existsSync(candidate)) return candidate;
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	throw new Error("Could not locate db/migrations from the test directory");
+}
+
+/** Run the backfill migration's up-section verbatim (the SQL prod applies). */
+async function runBackfill(): Promise<void> {
+	const upSection = loadMigrationUpSection(
+		resolveMigrationsDir(),
+		BACKFILL_MIGRATION,
+	);
+	await getDb().unsafe(upSection);
+}
+
+interface ConnRow {
+	id: string;
+	connector_key: string;
+	status: string;
+	credential_mode: string | null;
+	external_tenant_id: string | null;
+	app_auth_profile_id: string | null;
+	agent_id: string | null;
+	slug: string;
+	config: Record<string, unknown> | null;
+}
+
+/** A backfilled connection by its (org-unique) slug. */
+async function connBySlug(orgId: string, slug: string): Promise<ConnRow | null> {
+	const rows = (await getDb()`
+		SELECT id, connector_key, status, credential_mode, external_tenant_id,
+		       app_auth_profile_id, agent_id, slug, config
+		FROM connections
+		WHERE organization_id = ${orgId} AND slug = ${slug}
+	`) as unknown as ConnRow[];
+	return rows[0] ? { ...rows[0], id: String(rows[0].id) } : null;
+}
+
+async function chatConnCount(orgId: string): Promise<number> {
+	const [{ count }] = (await getDb()`
+		SELECT COUNT(*)::int AS count FROM connections
+		WHERE organization_id = ${orgId} AND credential_mode IS NOT NULL
+	`) as Array<{ count: number }>;
+	return Number(count);
+}
+
+describe("connections-unify Stage 1 backfill (reuse-first)", () => {
+	let orgId: string;
+	let agentA: string;
+	let dataConnectionId: number;
+
+	beforeAll(async () => {
+		await initWorkspaceProvider();
+		const sql = getDb();
+
+		const org = await createTestOrganization();
+		orgId = org.id;
+		agentA = (await createTestAgent({ organizationId: orgId })).agentId;
+
+		// (1) an existing data connector — must be left untouched (mode NULL).
+		dataConnectionId = (
+			await createTestConnection({
+				organization_id: orgId,
+				connector_key: "github",
+				createDefaultFeed: false,
+			})
+		).id;
+
+		// (2) BYO Slack for team T1 — will WIN the T1 slot over the managed install.
+		await insertAgentConnection(sql, {
+			id: "ac-slack-t1",
+			orgId,
+			agentId: agentA,
+			platform: "slack",
+			metadata: { teamId: "T1", teamName: "Acme" },
+			settings: { previewMode: false },
+			config: { platform: "slack", botToken: "secret://byo-t1" },
+			status: "active",
+			updatedAt: "2026-06-01T00:00:00Z",
+		});
+
+		// (3) Telegram BYO (tenantless) — config.teamId NULL.
+		await insertAgentConnection(sql, {
+			id: "ac-tg-a",
+			orgId,
+			agentId: agentA,
+			platform: "telegram",
+			metadata: {},
+			settings: {},
+			config: { platform: "telegram", botToken: "secret://tg" },
+			status: "active",
+			updatedAt: "2026-06-01T00:00:00Z",
+		});
+
+		// (4) Managed Slack install for T1 (contended → demoted to paused).
+		await insertAppInstallation(sql, {
+			orgId,
+			externalTenantId: "T1",
+			status: "active",
+			metadata: {
+				external_id: "slackinst-t1",
+				team_name: "Acme",
+				config: { platform: "slack", botToken: "secret://mgd-t1" },
+			},
+		});
+		// (4b) Managed Slack install for T2 (uncontended → stays active).
+		await insertAppInstallation(sql, {
+			orgId,
+			externalTenantId: "T2",
+			status: "active",
+			metadata: {
+				external_id: "slackinst-t2",
+				team_name: "Beta",
+				config: { platform: "slack", botToken: "secret://mgd-t2" },
+			},
+		});
+
+		// (5) Bindings to link.
+		await insertBinding(sql, {
+			orgId,
+			agentId: agentA,
+			platform: "slack",
+			channelId: "C1",
+			teamId: "T1",
+		});
+		await insertBinding(sql, {
+			orgId,
+			agentId: agentA,
+			platform: "telegram",
+			channelId: "C2",
+			teamId: null,
+		});
+
+		await runBackfill();
+	});
+
+	afterAll(async () => {
+		const sql = getDb();
+		await sql`DELETE FROM agent_channel_bindings WHERE organization_id = ${orgId}`;
+		await sql`DELETE FROM connections WHERE organization_id = ${orgId}`;
+		await sql`DELETE FROM agent_connections WHERE organization_id = ${orgId}`;
+		await sql`DELETE FROM app_installations WHERE organization_id = ${orgId}`;
+	});
+
+	it("leaves existing data connectors untouched (credential_mode NULL)", async () => {
+		const [row] = (await getDb()`
+			SELECT credential_mode FROM connections WHERE id = ${dataConnectionId}
+		`) as Array<{ credential_mode: string | null }>;
+		expect(row.credential_mode).toBeNull();
+	});
+
+	it("folds BYO slack into a credential_mode=byo connection (tenant column)", async () => {
+		const row = await connBySlug(orgId, "agentconn-ac-slack-t1");
+		expect(row).toBeTruthy();
+		expect(row!.credential_mode).toBe("byo");
+		expect(row!.connector_key).toBe("slack");
+		expect(row!.status).toBe("active");
+		expect(row!.external_tenant_id).toBe("T1");
+		expect(row!.config?.botToken).toBe("secret://byo-t1");
+		// settings folded into config losslessly.
+		expect((row!.config?.settings as Record<string, unknown>)?.previewMode).toBe(
+			false,
+		);
+		expect(row!.agent_id).toBe(agentA);
+	});
+
+	it("folds telegram BYO as tenantless chat (external_tenant_id NULL)", async () => {
+		const row = await connBySlug(orgId, "agentconn-ac-tg-a");
+		expect(row!.credential_mode).toBe("byo");
+		expect(row!.connector_key).toBe("telegram");
+		expect(row!.status).toBe("active");
+		expect(row!.external_tenant_id).toBeNull();
+		expect(row!.agent_id).toBe(agentA);
+	});
+
+	it("BYO wins over a managed install for the same team (managed → paused)", async () => {
+		const managed = await connBySlug(orgId, "slackinst-t1");
+		expect(managed!.credential_mode).toBe("managed");
+		expect(managed!.external_tenant_id).toBe("T1");
+		expect(managed!.status).toBe("paused");
+		// app_auth_profile_id reuses the install's auth_profile_id (NULL for slack).
+		expect(managed!.app_auth_profile_id).toBeNull();
+
+		// Exactly one ACTIVE chat connection for (org, slack, T1).
+		const [{ count }] = (await getDb()`
+			SELECT COUNT(*)::int AS count FROM connections
+			WHERE organization_id = ${orgId} AND connector_key = 'slack'
+			  AND external_tenant_id = 'T1' AND status = 'active' AND deleted_at IS NULL
+		`) as Array<{ count: number }>;
+		expect(Number(count)).toBe(1);
+	});
+
+	it("keeps an uncontended managed install active", async () => {
+		const managed = await connBySlug(orgId, "slackinst-t2");
+		expect(managed!.credential_mode).toBe("managed");
+		expect(managed!.status).toBe("active");
+		expect(managed!.external_tenant_id).toBe("T2");
+	});
+
+	it("links existing bindings to the active backfilled chat connection", async () => {
+		const byoT1 = await connBySlug(orgId, "agentconn-ac-slack-t1");
+		const telegram = await connBySlug(orgId, "agentconn-ac-tg-a");
+
+		const [slackBinding] = (await getDb()`
+			SELECT connection_id FROM agent_channel_bindings
+			WHERE organization_id = ${orgId} AND platform = 'slack' AND channel_id = 'C1'
+		`) as Array<{ connection_id: string | null }>;
+		expect(String(slackBinding.connection_id)).toBe(byoT1!.id);
+
+		const [tgBinding] = (await getDb()`
+			SELECT connection_id FROM agent_channel_bindings
+			WHERE organization_id = ${orgId} AND platform = 'telegram' AND channel_id = 'C2'
+		`) as Array<{ connection_id: string | null }>;
+		expect(String(tgBinding.connection_id)).toBe(telegram!.id);
+	});
+
+	it("is idempotent — re-running inserts no duplicates", async () => {
+		const before = await chatConnCount(orgId);
+		await runBackfill();
+		const after = await chatConnCount(orgId);
+		expect(after).toBe(before);
+	});
+});
+
+// ── seed helpers ────────────────────────────────────────────────────────────
+
+async function insertAgentConnection(
+	sql: ReturnType<typeof getDb>,
+	opts: {
+		id: string;
+		orgId: string;
+		agentId: string;
+		platform: string;
+		metadata: Record<string, unknown>;
+		settings: Record<string, unknown>;
+		config: Record<string, unknown>;
+		status: string;
+		updatedAt: string;
+	},
+): Promise<void> {
+	await sql`
+		INSERT INTO agent_connections (
+			id, organization_id, agent_id, platform, config, settings, metadata,
+			status, created_at, updated_at
+		) VALUES (
+			${opts.id}, ${opts.orgId}, ${opts.agentId}, ${opts.platform},
+			${sql.json(opts.config)}, ${sql.json(opts.settings)}, ${sql.json(opts.metadata)},
+			${opts.status}, ${opts.updatedAt}, ${opts.updatedAt}
+		)
+	`;
+}
+
+async function insertAppInstallation(
+	sql: ReturnType<typeof getDb>,
+	opts: {
+		orgId: string;
+		externalTenantId: string;
+		status: string;
+		metadata: Record<string, unknown>;
+	},
+): Promise<void> {
+	await sql`
+		INSERT INTO app_installations (
+			organization_id, provider, provider_instance, provider_app_id,
+			external_tenant_id, status, metadata
+		) VALUES (
+			${opts.orgId}, 'slack', 'cloud', 'cloud',
+			${opts.externalTenantId}, ${opts.status}, ${sql.json(opts.metadata)}
+		)
+	`;
+}
+
+async function insertBinding(
+	sql: ReturnType<typeof getDb>,
+	opts: {
+		orgId: string;
+		agentId: string;
+		platform: string;
+		channelId: string;
+		teamId: string | null;
+	},
+): Promise<void> {
+	await sql`
+		INSERT INTO agent_channel_bindings (
+			organization_id, agent_id, platform, channel_id, team_id, created_at
+		) VALUES (
+			${opts.orgId}, ${opts.agentId}, ${opts.platform}, ${opts.channelId},
+			${opts.teamId}, NOW()
+		)
+	`;
+}

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -111,7 +111,9 @@ export const QUERYABLE_SCHEMA = {
         'visibility',
         'deleted_at',
         'agent_id',
-        'device_worker_id'
+        'device_worker_id',
+        'external_tenant_id',
+        'credential_mode'
       ),
     },
     // watchers


### PR DESCRIPTION
**Stage 1 of 4** in the connections-unify program (expand/backfill → cutover → bindings → cleanup). Purely **additive, zero runtime cutover** — Stage 2 repoints reads.

## Why
`connections` already declares itself *"the replacement for the legacy chat_connections + per-platform tables"* (Slack/Telegram/GitHub/Linear) and already has the slots chat needs. `app_installations` + chat `agent_connections` are parallel duplicates added later. This finishes folding chat into `connections`, reusing its columns.

## Schema (the entire delta)
- `connections` += **`external_tenant_id`** (provider workspace/tenant id — routing + uniqueness key, mirrors `app_installations.external_tenant_id`) and **`credential_mode`** (`managed|byo` + CHECK — non-derivable: chat tokens are `secret://` refs in `config` for both modes, auth slots NULL).
- `agent_channel_bindings` += **`connection_id`** FK (`ON DELETE SET NULL`).
- 2 `CONCURRENTLY` indexes: partial-unique one-active-chat per `(org, connector_key, external_tenant_id)` (BYO-vs-managed exclusivity) + the bindings FK lookup.

**Dropped from the original 6-column proposal (redundant):** `capabilities`/`facets` (derived from feeds/bindings/operations/`authz_source_acl_state`), `settings` (→`config.settings`), `metadata` (→`config`/`display_name`/`slug`).

## Backfill (idempotent, non-destructive)
chat `agent_connections` → `byo` rows; Slack `app_installations` → `managed` rows; BYO wins a contended workspace (loser → `paused`); bindings linked. Idempotency via the unique `slug`. Source tables untouched.

## Validation
- `tsc --noEmit` clean · squawk **0 issues** on all 4 migrations · backfill integration test **7/7** (seeds all three tables + bindings, runs the migration's up-section verbatim, asserts credential_mode/external_tenant_id/BYO-wins/linkage/idempotency).

## Deferred
- **Stage 2** dual-read cutover (ChatInstanceManager + Slack coordinator read `connections`) + the `/connectors` UI.
- **Stage 3** route bindings by `connection_id`.
- **Stage 4** drop the legacy chat paths. NOTE: `app_installations` also backs GitHub/Jira installs and `agent_connections` may hold webhook rows — see PR discussion for the full table-drop plan.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785294151&installation_id=136316292&pr_number=1604&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1604&signature=21175e2c92178282eadb7d62fcb0bc96d007a6ae144e3f829b898f45aa94d0eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat connections now support unified tenant and credential details, improving consistency across connection types.
  * Existing chat integrations are automatically grouped into the new unified connection structure, with bindings linked where possible.

* **Bug Fixes**
  * Added safeguards to prevent duplicate active chat connections for the same tenant.
  * Improved handling of conflicting managed and BYO connections so the correct one stays active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->