### PR TITLE
fix(server): stop session_replication_role leaking across the test pool

### DIFF
--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -354,26 +354,39 @@ export async function cleanupTestDatabase(): Promise<void> {
     AND tablename NOT LIKE 'schema_migrations%'
   `;
 
-  // Disable triggers temporarily for faster truncation. `session_replication_role`
-  // is superuser-only, so on a non-superuser test role (the PG15+ fresh-`createdb`
-  // shape from #950, where DATABASE_URL points at a plain CREATE-granted user) this
-  // throws `permission denied to set parameter` (42501). Treat it as best-effort:
-  // `TRUNCATE ... CASCADE` already respects FK ordering on its own, so skipping the
-  // trigger-disable only forgoes the speedup, never correctness.
-  const triggersDisabled = await trySetReplicationRole(db, 'replica');
-
   if (tables.length > 0) {
     const quotedTables = tables.map(({ tablename }) => `"${tablename}"`).join(', ');
+    // Disable triggers for faster truncation, but ONLY via `SET LOCAL` inside a
+    // single transaction. `SET LOCAL` is scoped to the transaction and reverts on
+    // COMMIT, and the whole `db.begin` callback runs on ONE reserved connection —
+    // so the `replica` role can never leak back onto a pooled connection.
+    //
+    // The previous version issued `SET session_replication_role = 'replica'` and
+    // the `'origin'` reset as standalone statements over the pool (max 5). Under a
+    // warm pool those two statements routed to DIFFERENT connections, stranding one
+    // connection in `replica` mode indefinitely. Any later test that ran a raw
+    // INSERT/UPDATE on that connection silently skipped BEFORE triggers — which is
+    // exactly how the derived-entity-type guard triggers stopped firing mid-suite
+    // (the INSERT then tripped a NOT NULL constraint instead of the trigger, and
+    // the UPDATEs resolved with no error at all).
+    //
+    // `session_replication_role` is superuser-only; on a non-superuser test role
+    // (the PG15+ fresh-`createdb` shape from #950) we skip the disable entirely.
+    // `TRUNCATE ... CASCADE` respects FK ordering on its own, so this only forgoes
+    // the speedup, never correctness.
+    const canDisableTriggers = await connectionCanDisableTriggers(db);
     try {
-      await db.unsafe(`TRUNCATE ${quotedTables} CASCADE`);
+      if (canDisableTriggers) {
+        await db.begin(async (tx) => {
+          await tx.unsafe(`SET LOCAL session_replication_role = 'replica'`);
+          await tx.unsafe(`TRUNCATE ${quotedTables} CASCADE`);
+        });
+      } else {
+        await db.unsafe(`TRUNCATE ${quotedTables} CASCADE`);
+      }
     } catch {
       // Ignore errors for tables that may not exist.
     }
-  }
-
-  // Re-enable triggers only if we managed to disable them.
-  if (triggersDisabled) {
-    await trySetReplicationRole(db, 'origin');
   }
 
   // Fix check constraints that are out-of-date relative to the app code
@@ -381,23 +394,21 @@ export async function cleanupTestDatabase(): Promise<void> {
 }
 
 /**
- * Best-effort `SET session_replication_role`. Returns true if the role was set,
- * false if the connection user lacks the superuser right (42501) — the caller
- * then proceeds without trigger-disabling, which is safe for `TRUNCATE CASCADE`.
- * Any other error is a real problem and surfaces.
+ * Whether this connection's role may set `session_replication_role` (superuser
+ * only). Cached for the process — the DATABASE_URL user never changes mid-run.
+ * Embedded Postgres / CI's `postgres` role are superusers; the #950 non-owner
+ * test role is not.
  */
-async function trySetReplicationRole(
-  db: postgres.Sql,
-  role: 'replica' | 'origin'
-): Promise<boolean> {
+let cachedCanDisableTriggers: boolean | null = null;
+async function connectionCanDisableTriggers(db: postgres.Sql): Promise<boolean> {
+  if (cachedCanDisableTriggers !== null) return cachedCanDisableTriggers;
   try {
-    await db.unsafe(`SET session_replication_role = '${role}'`);
-    return true;
-  } catch (err) {
-    const code = (err as { code?: string } | null)?.code;
-    if (code === '42501') return false;
-    throw err;
+    const [row] = await db`SELECT current_setting('is_superuser') AS is_superuser`;
+    cachedCanDisableTriggers = String(row?.is_superuser).toLowerCase() === 'on';
+  } catch {
+    cachedCanDisableTriggers = false;
   }
+  return cachedCanDisableTriggers;
 }
 
 /**

--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -384,8 +384,14 @@ export async function cleanupTestDatabase(): Promise<void> {
       } else {
         await db.unsafe(`TRUNCATE ${quotedTables} CASCADE`);
       }
-    } catch {
-      // Ignore errors for tables that may not exist.
+    } catch (err) {
+      // Only tolerate the intended "a listed table disappeared mid-truncate"
+      // case (undefined_table, 42P01). Anything else — a permission error, a
+      // failed `SET LOCAL`, a transaction abort, a lock timeout — is a real
+      // cleanup failure that would leave the DB dirty for the next test, so
+      // re-throw it rather than silently swallow.
+      const code = (err as { code?: string } | null)?.code;
+      if (code !== '42P01') throw err;
     }
   }
 


### PR DESCRIPTION
## Problem

`main` integration CI has been red for 3 commits. The `integration` job failed with **4 tests failed | 1572 passed** — the three DB-trigger tests in `derived-entity-query.test.ts` plus flaky collateral (`classify-facet-sole-table`, `transcript`, `dispatch-chrome-autobind`, `scheduling-contract` varied run to run).

## Root cause

`cleanupTestDatabase()` disabled triggers to speed up `TRUNCATE` by issuing `SET session_replication_role = 'replica'` and the `'origin'` reset as **two standalone statements over the postgres.js connection pool** (`max: 5`). Sequential awaits reuse one connection when the pool is idle, but under a warm pool the two statements route to **different** connections — leaving one connection stranded in `replica` mode indefinitely.

Any later test that runs a raw `db\`INSERT/UPDATE\`` on that leaked connection silently **skips BEFORE triggers**. That is exactly why the derived-entity-type guard triggers "stopped firing":

- the direct `INSERT INTO entities` tripped the `entities.created_by` NOT NULL constraint instead of the trigger (`expected … /derived/ … but got 'null value in column "created_by"'`)
- the direct `UPDATE`s resolved `[]` with no error at all

The suite passes the file in isolation; it only fails in the full run once the pool is warm — which is why it presents as order/flake-dependent.

Verified the mechanism directly: with 5 warmed pooled connections, the standalone `SET replica` / `TRUNCATE` / `SET origin` sequence leaves one connection reporting `replica`; the `SET LOCAL`-in-a-transaction form leaves all five at `origin`.

## Fix

Disable triggers only via `SET LOCAL session_replication_role = 'replica'` inside a single `db.begin` transaction. The whole callback runs on one reserved connection and `SET LOCAL` reverts at COMMIT, so the role can never leak back onto the pool. Superuser-gated (the GUC is superuser-only); non-superuser test roles skip the disable, which only forgoes the `TRUNCATE` speedup, not correctness (`TRUNCATE … CASCADE` respects FK ordering on its own). Removes the leaky `trySetReplicationRole` helper.

## Verification (red→green)

- Before: full `packages/server` integration suite red — 3 `derived-entity-query` trigger tests failed (reproduced locally exactly as in CI).
- After: `bunx tsc --noEmit` clean; full integration suite **129 files / 792 tests passed, 0 failed**, green across **two** consecutive full runs (deterministic).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785332814&installation_id=136316292&pr_number=1607&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1607&signature=4790fa15e3f48d99321b7c74d390caa42848a9b6ca98310efdd25b6c5a654851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved database cleanup for automated tests, making test runs more reliable and reducing the risk of leftover data affecting later tests.
  * Added a safer fallback for environments with limited permissions, so cleanup continues to work more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a pool-poisoning bug in `cleanupTestDatabase()` where issuing `SET session_replication_role = 'replica'` and its `'origin'` reset as two separate statements over a pooled connection could route them to different connections, leaving one stranded in `replica` mode and silently suppressing BEFORE triggers for all subsequent tests on that connection.

- Wraps the `SET LOCAL session_replication_role = 'replica'` and `TRUNCATE … CASCADE` in a single `db.begin` transaction so both run on one reserved connection and the GUC reverts automatically at COMMIT.
- Replaces the per-call `trySetReplicationRole` helper with a process-cached `connectionCanDisableTriggers` check that queries `is_superuser` once and reuses the result, skipping the disable on non-superuser roles.
- Tightens the catch block to re-throw every error except `42P01` (undefined_table), surfacing real cleanup failures instead of silently no-oping.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is narrowly scoped to the test cleanup helper and correctly addresses the root cause without introducing new failure modes.

The transaction-scoped SET LOCAL approach is the canonical PostgreSQL pattern for this; db.begin guarantees a single reserved connection for the whole callback so the GUC can never escape onto the pool. Error handling is now strictly tighter than before (only 42P01 is swallowed). The superuser pre-check is reliable and the process-level cache is an appropriate optimisation for a value that genuinely cannot change mid-run.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/server/src/__tests__/setup/test-db.ts | Replaces leaky standalone SET statements with a SET LOCAL inside a db.begin transaction to prevent session_replication_role from stranding pooled connections in replica mode; adds superuser pre-check with process-level caching and tightens the catch block to only swallow 42P01. |

<sub>Reviews (2): Last reviewed commit: ["fix(server): narrow test-cleanup TRUNCAT..."](https://github.com/lobu-ai/lobu/commit/a5ade069dcfb97ebd8f180ab1256aacdb35e7d9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40521152)</sub>

<!-- /greptile_comment -->