### PR TITLE
fix(test): retry cleanup TRUNCATE on deadlock with co-running pollers

### DIFF
--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -356,27 +356,72 @@ export async function cleanupTestDatabase(): Promise<void> {
 
   if (tables.length > 0) {
     const quotedTables = tables.map(({ tablename }) => `"${tablename}"`).join(', ');
-    // Disable triggers for faster truncation, but ONLY via `SET LOCAL` inside a
-    // single transaction. `SET LOCAL` is scoped to the transaction and reverts on
-    // COMMIT, and the whole `db.begin` callback runs on ONE reserved connection —
-    // so the `replica` role can never leak back onto a pooled connection.
-    //
-    // The previous version issued `SET session_replication_role = 'replica'` and
-    // the `'origin'` reset as standalone statements over the pool (max 5). Under a
-    // warm pool those two statements routed to DIFFERENT connections, stranding one
-    // connection in `replica` mode indefinitely. Any later test that ran a raw
-    // INSERT/UPDATE on that connection silently skipped BEFORE triggers — which is
-    // exactly how the derived-entity-type guard triggers stopped firing mid-suite
-    // (the INSERT then tripped a NOT NULL constraint instead of the trigger, and
-    // the UPDATEs resolved with no error at all).
-    //
-    // `session_replication_role` is superuser-only; on a non-superuser test role
-    // (the PG15+ fresh-`createdb` shape from #950) we skip the disable entirely.
-    // `TRUNCATE ... CASCADE` respects FK ordering on its own, so this only forgoes
-    // the speedup, never correctness.
+    // Truncate every table, retrying on deadlock. See `truncateAllTables` for
+    // why the trigger-disable runs via `SET LOCAL` inside a transaction (#1607)
+    // and why a co-running background poller's DML can deadlock the cleanup.
     const canDisableTriggers = await connectionCanDisableTriggers(db);
+    await truncateAllTables(db, quotedTables, canDisableTriggers);
+  }
+
+  // Fix check constraints that are out-of-date relative to the app code
+  await fixSchemaConstraints(db);
+}
+
+/**
+ * Max times to re-attempt the cleanup TRUNCATE after a deadlock (40P01).
+ */
+const TRUNCATE_DEADLOCK_RETRIES = 8;
+
+/**
+ * Run the (whole-database) cleanup `TRUNCATE … CASCADE`, retrying on deadlock.
+ *
+ * These bun:test suites co-run many files in ONE process against a SHARED
+ * database, and several of them start background DB pollers that are never
+ * stopped — e.g. `ChatInstanceManager.initialize()`'s 15s exclusive-lease tick,
+ * the task-scheduler, and the stale-run reaper. Those timers keep firing
+ * `INSERT`/`UPDATE` statements on the app connection pool AFTER the test that
+ * created them has finished, overlapping the NEXT test's `beforeEach`
+ * `cleanupTestDatabase()`.
+ *
+ * That overlap is a textbook deadlock cycle:
+ *   - `TRUNCATE … CASCADE` grabs `AccessExclusiveLock` on every table, one at a
+ *     time, in the order they appear in the list (≈ pg_class order).
+ *   - A concurrent `INSERT` into a child table grabs `RowExclusiveLock` on the
+ *     child, then needs a `RowShareLock` on each FK-referenced PARENT to
+ *     validate the foreign key (`agent_connections → organization/agents`,
+ *     and since #1604 `agent_channel_bindings → connections`).
+ *   - If TRUNCATE has already locked the parent and the INSERT already holds the
+ *     child, each waits on a lock the other holds → `40P01 deadlock detected`.
+ *     Postgres aborts one victim; when the victim is OUR `db.begin(…)` TRUNCATE
+ *     transaction, the error propagates out of `cleanupTestDatabase()` and fails
+ *     whichever test's `beforeEach` ran it.
+ *
+ * The conflicting background statement completes in milliseconds, so retrying
+ * the begin/TRUNCATE after a short backoff is deterministic recovery (the lock
+ * the INSERT held is gone by the next attempt) — NOT a probabilistic
+ * odds-lowering hack, and NOT a re-broadening of the 42P01-only catch. We retry
+ * ONLY on 40P01, tolerate ONLY 42P01 (a listed table vanished mid-truncate),
+ * and re-throw every other error and the final deadlock so a genuinely stuck
+ * cleanup still surfaces.
+ */
+export async function truncateAllTables(
+  db: postgres.Sql,
+  quotedTables: string,
+  canDisableTriggers: boolean
+): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
     try {
       if (canDisableTriggers) {
+        // Disable triggers for faster truncation, but ONLY via `SET LOCAL`
+        // inside a single transaction. `SET LOCAL` is scoped to the
+        // transaction and reverts on COMMIT, and the whole `db.begin` callback
+        // runs on ONE reserved connection — so the `replica` role can never
+        // leak back onto a pooled connection (the bug fixed in #1607).
+        //
+        // `session_replication_role` is superuser-only; on a non-superuser test
+        // role (the PG15+ fresh-`createdb` shape from #950) we skip the disable
+        // entirely. `TRUNCATE … CASCADE` respects FK ordering on its own, so
+        // this only forgoes the speedup, never correctness.
         await db.begin(async (tx) => {
           await tx.unsafe(`SET LOCAL session_replication_role = 'replica'`);
           await tx.unsafe(`TRUNCATE ${quotedTables} CASCADE`);
@@ -384,19 +429,25 @@ export async function cleanupTestDatabase(): Promise<void> {
       } else {
         await db.unsafe(`TRUNCATE ${quotedTables} CASCADE`);
       }
+      return;
     } catch (err) {
-      // Only tolerate the intended "a listed table disappeared mid-truncate"
-      // case (undefined_table, 42P01). Anything else — a permission error, a
-      // failed `SET LOCAL`, a transaction abort, a lock timeout — is a real
-      // cleanup failure that would leave the DB dirty for the next test, so
-      // re-throw it rather than silently swallow.
       const code = (err as { code?: string } | null)?.code;
-      if (code !== '42P01') throw err;
+      // 42P01 (undefined_table): a listed table disappeared mid-truncate.
+      // Tolerated — the next test re-runs migrations/cleanup anyway.
+      if (code === '42P01') return;
+      // 40P01 (deadlock_detected): a leaked background poller's DML held FK
+      // row-share locks in the opposite order. Retry after a short backoff.
+      if (code === '40P01' && attempt < TRUNCATE_DEADLOCK_RETRIES) {
+        await new Promise((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
+        continue;
+      }
+      // Anything else — a permission error, a failed `SET LOCAL`, a transaction
+      // abort, a lock timeout — or a deadlock that survived every retry is a
+      // real cleanup failure that would leave the DB dirty for the next test,
+      // so re-throw rather than silently swallow.
+      throw err;
     }
   }
-
-  // Fix check constraints that are out-of-date relative to the app code
-  await fixSchemaConstraints(db);
 }
 
 /**

--- a/packages/server/src/lobu/__tests__/cleanup-truncate-deadlock-retry.test.ts
+++ b/packages/server/src/lobu/__tests__/cleanup-truncate-deadlock-retry.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression: `cleanupTestDatabase()`'s whole-DB `TRUNCATE … CASCADE` must
+ * survive a deadlock (Postgres `40P01`) with a background DML transaction.
+ *
+ * The `lobu/scheduled/workspace` bun:test step co-runs many files in ONE
+ * process against a SHARED database. Several of those files start background DB
+ * pollers that are never stopped — `ChatInstanceManager.initialize()`'s 15s
+ * exclusive-lease tick, the task-scheduler, the stale-run reaper — so their
+ * `INSERT`/`UPDATE` statements keep firing on the app pool after the creating
+ * test finished, overlapping the NEXT test's `beforeEach` cleanup TRUNCATE.
+ *
+ * That overlap is a deadlock cycle: TRUNCATE takes `AccessExclusiveLock` on the
+ * tables in list order, while a concurrent FK-bearing INSERT takes
+ * `RowExclusiveLock` on the child then needs `RowShareLock` on the referenced
+ * parent (e.g. `agent_connections → organization`, and since #1604
+ * `agent_channel_bindings → connections`). Opposite lock-acquire orders → when
+ * Postgres aborts OUR `db.begin(…)` TRUNCATE as the victim, the `40P01`
+ * propagated out of `cleanupTestDatabase()` and failed whichever test's
+ * `beforeEach` ran it (surfaced after #1607 narrowed the catch to rethrow
+ * non-`42P01`).
+ *
+ * `truncateAllTables` now retries the begin/TRUNCATE on `40P01` (the
+ * conflicting background statement clears in milliseconds), while still
+ * tolerating ONLY `42P01` and re-throwing every other error and the final
+ * deadlock. These tests drive the helper with a scripted fake `postgres.Sql`
+ * so they're deterministic and need no real database.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { truncateAllTables } from '../../__tests__/setup/test-db';
+
+type Outcome = '40P01' | '42P01' | '42501' | 'ok';
+
+function pgError(code: string): Error {
+  return Object.assign(new Error(`pg error ${code}`), { code });
+}
+
+/**
+ * Fake `postgres.Sql` whose every TRUNCATE attempt (one `begin` call or one
+ * `unsafe` call) consumes the next scripted outcome; the last entry repeats.
+ */
+function fakeDb(script: Outcome[]) {
+  let i = 0;
+  const consume = () => {
+    const outcome = script[Math.min(i, script.length - 1)];
+    i++;
+    if (outcome !== 'ok') throw pgError(outcome);
+  };
+  const db = {
+    attempts: 0,
+    async unsafe(_sql: string) {
+      // SET LOCAL / non-truncate statements inside begin are no-ops; only the
+      // top-level TRUNCATE attempt (begin or the bare unsafe) counts.
+    },
+    async begin(cb: (tx: { unsafe: (s: string) => Promise<void> }) => Promise<void>) {
+      db.attempts++;
+      await cb({ unsafe: async () => {} });
+      consume();
+    },
+  };
+  return db as typeof db & {
+    unsafe: (s: string) => Promise<void>;
+    begin: (cb: (tx: { unsafe: (s: string) => Promise<void> }) => Promise<void>) => Promise<void>;
+  };
+}
+
+describe('truncateAllTables — deadlock retry', () => {
+  test('recovers when the TRUNCATE deadlocks then succeeds on retry', async () => {
+    const db = fakeDb(['40P01', '40P01', 'ok']);
+    await truncateAllTables(db as any, '"a", "b"', true);
+    expect(db.attempts).toBe(3); // two deadlocks + the winning attempt
+  });
+
+  test('tolerates 42P01 (a listed table vanished) without throwing', async () => {
+    const db = fakeDb(['42P01']);
+    await expect(
+      truncateAllTables(db as any, '"a"', true)
+    ).resolves.toBeUndefined();
+    expect(db.attempts).toBe(1);
+  });
+
+  test('re-throws a non-deadlock error immediately (no retry)', async () => {
+    const db = fakeDb(['42501', 'ok']);
+    await expect(truncateAllTables(db as any, '"a"', true)).rejects.toMatchObject({
+      code: '42501',
+    });
+    expect(db.attempts).toBe(1); // did NOT retry past the first attempt
+  });
+
+  test('re-throws the deadlock once retries are exhausted', async () => {
+    const db = fakeDb(['40P01']); // deadlocks forever
+    await expect(truncateAllTables(db as any, '"a"', true)).rejects.toMatchObject({
+      code: '40P01',
+    });
+    expect(db.attempts).toBeGreaterThan(1); // it really did retry before giving up
+  });
+});


### PR DESCRIPTION
## Problem

`main` CI was red (flaky) on the **integration** job, step `server lobu/scheduled/workspace suites (bun:test, needs Postgres)` (`bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__`):

```
PUT /agents/:agentId/platforms/by-stable-id — type rest (#1179)
  > creates the platform row without instantiating a chat adapter
PostgresError: deadlock detected (40P01)
DETAIL: Process 741 waits for AccessExclusiveLock on relation 472937; blocked by 760.
        Process 760 waits for RowShareLock on relation 473176; blocked by 741.
```

## Root cause

That step co-runs many bun:test files in **one** process against a **shared** Postgres. Several of them start background DB pollers that are never stopped — `ChatInstanceManager.initialize()`'s 15s exclusive-lease tick, the task-scheduler, the stale-run reaper. Those timers keep firing `INSERT`/`UPDATE` on the app pool **after** the creating test finished, overlapping the next test's `beforeEach` cleanup `TRUNCATE … CASCADE`.

The overlap is a deadlock cycle:
- `TRUNCATE … CASCADE` grabs `AccessExclusiveLock` on every table in list order.
- A concurrent FK-bearing `INSERT` grabs `RowExclusiveLock` on the child, then needs `RowShareLock` on the referenced parent (`agent_connections → organization/agents`, and since #1604 `agent_channel_bindings → connections`).
- Opposite lock-acquire orders → `40P01`. When Postgres aborts our `db.begin(…)` TRUNCATE as the victim, the error propagated out of `cleanupTestDatabase()` and failed whichever test's `beforeEach` ran it. (Bun runs files sequentially — verified — so this is a leaked-background-DML overlap, not cross-file parallelism. It surfaced after #1607 narrowed the catch to rethrow non-`42P01`.)

## Fix

`truncateAllTables` retries the begin/TRUNCATE on `40P01` with a short backoff. The conflicting background statement clears in milliseconds, so the retry is **deterministic recovery**, not odds-lowering. It still tolerates **only** `42P01` (a listed table vanished mid-truncate) and re-throws every other error and the final deadlock, so a genuinely stuck cleanup still surfaces — the #1607 catch narrowing is preserved, not re-broadened.

## Verification

- New regression test (`cleanup-truncate-deadlock-retry.test.ts`) drives the helper with a scripted fake `postgres.Sql`. Red→green confirmed: with the retry branch disabled, the recovery + exhaustion cases fail (`2 fail`); with the fix, `4 pass`.
- Full affected suite: **91 pass / 0 fail**, 8/8 clean stress-loop runs locally (brew PG18).
- `bunx tsc --noEmit` clean in `packages/server`.

Note: the natural CI flake did **not** reproduce locally across 50+ runs (incl. `deadlock_timeout=20ms`) — brew PG18 is too fast to hit the window. The fix is a deterministic structural recovery argued from the lock analysis above and proven by the scripted red→green test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaSJb2d2Mq7q6nWX8R26Kn

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785336466&installation_id=136316292&pr_number=1609&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1609&signature=b787c016c72b5a2053e86606490facb21299cebc458c13beccca82d11679ac9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test database cleanup to better handle concurrent background activity during full-database truncation.
  * Added retry handling for transient deadlocks, while still gracefully ignoring missing-table cases and surfacing other errors.
  * Ensured schema constraint adjustments still run after cleanup completes.

* **Tests**
  * Added coverage for deadlock retries, tolerated missing-table responses, immediate failure on non-deadlock errors, and exhausted retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a flaky CI deadlock by adding retry logic to the test-cleanup `TRUNCATE … CASCADE` operation. Background DB pollers started by tests (lease ticks, task-scheduler, stale-run reaper) continue firing `INSERT`/`UPDATE` after their creating test exits, creating a lock-order inversion with the next test's `beforeEach` cleanup and triggering Postgres `40P01`.

- Extracts the TRUNCATE logic into a new exported `truncateAllTables` function with an 8-attempt linear-backoff retry (25 ms × (attempt+1)) on `40P01`; error-handling contract from #1607 is preserved — `42P01` is tolerated, all other errors and an exhausted deadlock still rethrow.
- Adds a regression test (`cleanup-truncate-deadlock-retry.test.ts`) using a scripted fake `postgres.Sql` to verify recovery, `42P01` tolerance, non-deadlock rethrow, and retry exhaustion without needing a real database.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the retry logic is structurally sound, error-handling contracts from prior PRs are preserved, and fixSchemaConstraints remains correctly outside the retry scope.

The production fix in test-db.ts is correct and well-contained. The only gaps are in the new test file: fakeDb.unsafe is a no-op leaving the canDisableTriggers=false branch uncovered, and the exhausted-retry test burns ~900 ms of real wall-clock time.

cleanup-truncate-deadlock-retry.test.ts — the canDisableTriggers=false path and slow exhausted-retry test are the areas to look at.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/server/src/__tests__/setup/test-db.ts | Extracts TRUNCATE into exported `truncateAllTables` with an 8-attempt linear-backoff retry on `40P01` deadlock; preserves `42P01` tolerance and rethrows all other errors; `fixSchemaConstraints` correctly remains in `cleanupTestDatabase` outside the retry scope. |
| packages/server/src/lobu/__tests__/cleanup-truncate-deadlock-retry.test.ts | New regression test for the deadlock-retry path; covers recovery, `42P01` tolerance, non-deadlock rethrow, and retry exhaustion, but only exercises the `canDisableTriggers = true` path because `fakeDb.unsafe` is a no-op. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant BG as Background Poller (leaked timer)
    participant PG as Postgres
    participant CL as cleanupTestDatabase (beforeEach)

    Note over BG,CL: Deadlock scenario before fix
    BG->>PG: INSERT into child table, RowExclusiveLock(child)
    CL->>PG: TRUNCATE CASCADE, AccessExclusiveLock(parent tables)
    BG->>PG: needs RowShareLock(parent) BLOCKED by TRUNCATE
    CL->>PG: needs AccessExclusiveLock(child) BLOCKED by INSERT
    PG-->>CL: 40P01 deadlock detected, TRUNCATE chosen as victim
    CL-->>CL: beforeEach fails, test failure

    Note over BG,CL: After fix, truncateAllTables retry loop
    loop attempt 0 to 7
        CL->>PG: BEGIN / TRUNCATE CASCADE
        PG-->>CL: 40P01 deadlock
        CL->>CL: sleep 25ms x (attempt+1)
        Note over BG: Background INSERT completes, locks released
    end
    CL->>PG: BEGIN / TRUNCATE CASCADE retry N
    PG-->>CL: success
    CL->>PG: fixSchemaConstraints()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant BG as Background Poller (leaked timer)
    participant PG as Postgres
    participant CL as cleanupTestDatabase (beforeEach)

    Note over BG,CL: Deadlock scenario before fix
    BG->>PG: INSERT into child table, RowExclusiveLock(child)
    CL->>PG: TRUNCATE CASCADE, AccessExclusiveLock(parent tables)
    BG->>PG: needs RowShareLock(parent) BLOCKED by TRUNCATE
    CL->>PG: needs AccessExclusiveLock(child) BLOCKED by INSERT
    PG-->>CL: 40P01 deadlock detected, TRUNCATE chosen as victim
    CL-->>CL: beforeEach fails, test failure

    Note over BG,CL: After fix, truncateAllTables retry loop
    loop attempt 0 to 7
        CL->>PG: BEGIN / TRUNCATE CASCADE
        PG-->>CL: 40P01 deadlock
        CL->>CL: sleep 25ms x (attempt+1)
        Note over BG: Background INSERT completes, locks released
    end
    CL->>PG: BEGIN / TRUNCATE CASCADE retry N
    PG-->>CL: success
    CL->>PG: fixSchemaConstraints()
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fserver%2Fsrc%2Flobu%2F__tests__%2Fcleanup-truncate-deadlock-retry.test.ts%3A51-60%0A**%60canDisableTriggers%20%3D%20false%60%20path%20untested**%0A%0A%60fakeDb.unsafe%60%20is%20a%20silent%20no-op%20%E2%80%94%20it%20never%20increments%20%60attempts%60%20and%20never%20calls%20%60consume%28%29%60.%20All%20four%20tests%20pass%20%60true%60%20for%20%60canDisableTriggers%60%2C%20so%20the%20%60db.unsafe%28TRUNCATE%20%E2%80%A6%29%60%20branch%20in%20%60truncateAllTables%60%20%28lines%20429-430%20of%20%60test-db.ts%60%29%20is%20never%20exercised.%20A%20deadlock%20thrown%20from%20the%20%60unsafe%60%20path%20would%20still%20be%20caught%20and%20retried%20by%20the%20same%20loop%2C%20so%20the%20logic%20is%20correct%2C%20but%20the%20tests%20give%20no%20coverage%20for%20that%20code%20path.%20Adding%20a%20test%20case%20with%20%60canDisableTriggers%20%3D%20false%60%20%28and%20making%20%60fakeDb.unsafe%60%20call%20%60consume%28%29%60%20and%20track%20attempts%20when%20invoked%20as%20a%20top-level%20call%20rather%20than%20inside%20%60begin%60%29%20would%20close%20the%20gap.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fserver%2Fsrc%2Flobu%2F__tests__%2Fcleanup-truncate-deadlock-retry.test.ts%3A87-94%0A**Exhausted-retry%20test%20takes%20~900%20ms%20due%20to%20real%20%60setTimeout%60%20delays**%0A%0A%60truncateAllTables%60%20retries%20up%20to%208%20times%20with%20%60setTimeout%28resolve%2C%2025%20*%20%28attempt%20%2B%201%29%29%60%2C%20so%20this%20%22deadlocks%20forever%22%20test%20accumulates%2025%20%2B%2050%20%2B%2075%20%2B%20%E2%80%A6%20%2B%20200%20%3D%20900%20ms%20of%20real%20wall-clock%20time.%20For%20a%20unit%20test%20that%20only%20needs%20to%20verify%20that%20the%20retry%20counter%20is%20bounded%2C%20consider%20making%20the%20backoff%20delay%20injectable%20so%20tests%20can%20pass%20%600%60%20ms%20and%20run%20in%20%3C%201%20ms.%20Alternatively%2C%20accept%20the%20latency%20since%20it%20is%20a%20one-off%20cost%20during%20the%20test%20run%20%E2%80%94%20just%20worth%20noting%20so%20the%20slow%20test%20doesn't%20confuse%20future%20maintainers.%0A%0A&repo=lobu-ai%2Flobu&pr=1609&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lobu-ai%2Flobu%22%20on%20the%20existing%20branch%20%22fix%2Fcleanup-truncate-deadlock-retry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcleanup-truncate-deadlock-retry%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fserver%2Fsrc%2Flobu%2F__tests__%2Fcleanup-truncate-deadlock-retry.test.ts%3A51-60%0A**%60canDisableTriggers%20%3D%20false%60%20path%20untested**%0A%0A%60fakeDb.unsafe%60%20is%20a%20silent%20no-op%20%E2%80%94%20it%20never%20increments%20%60attempts%60%20and%20never%20calls%20%60consume%28%29%60.%20All%20four%20tests%20pass%20%60true%60%20for%20%60canDisableTriggers%60%2C%20so%20the%20%60db.unsafe%28TRUNCATE%20%E2%80%A6%29%60%20branch%20in%20%60truncateAllTables%60%20%28lines%20429-430%20of%20%60test-db.ts%60%29%20is%20never%20exercised.%20A%20deadlock%20thrown%20from%20the%20%60unsafe%60%20path%20would%20still%20be%20caught%20and%20retried%20by%20the%20same%20loop%2C%20so%20the%20logic%20is%20correct%2C%20but%20the%20tests%20give%20no%20coverage%20for%20that%20code%20path.%20Adding%20a%20test%20case%20with%20%60canDisableTriggers%20%3D%20false%60%20%28and%20making%20%60fakeDb.unsafe%60%20call%20%60consume%28%29%60%20and%20track%20attempts%20when%20invoked%20as%20a%20top-level%20call%20rather%20than%20inside%20%60begin%60%29%20would%20close%20the%20gap.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fserver%2Fsrc%2Flobu%2F__tests__%2Fcleanup-truncate-deadlock-retry.test.ts%3A87-94%0A**Exhausted-retry%20test%20takes%20~900%20ms%20due%20to%20real%20%60setTimeout%60%20delays**%0A%0A%60truncateAllTables%60%20retries%20up%20to%208%20times%20with%20%60setTimeout%28resolve%2C%2025%20*%20%28attempt%20%2B%201%29%29%60%2C%20so%20this%20%22deadlocks%20forever%22%20test%20accumulates%2025%20%2B%2050%20%2B%2075%20%2B%20%E2%80%A6%20%2B%20200%20%3D%20900%20ms%20of%20real%20wall-clock%20time.%20For%20a%20unit%20test%20that%20only%20needs%20to%20verify%20that%20the%20retry%20counter%20is%20bounded%2C%20consider%20making%20the%20backoff%20delay%20injectable%20so%20tests%20can%20pass%20%600%60%20ms%20and%20run%20in%20%3C%201%20ms.%20Alternatively%2C%20accept%20the%20latency%20since%20it%20is%20a%20one-off%20cost%20during%20the%20test%20run%20%E2%80%94%20just%20worth%20noting%20so%20the%20slow%20test%20doesn't%20confuse%20future%20maintainers.%0A%0A&repo=lobu-ai%2Flobu&pr=1609&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(test): retry cleanup TRUNCATE on dea..."](https://github.com/lobu-ai/lobu/commit/961a2b49c1a9dca88eb8c3e8b221d6bca0316dcf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40535557)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->