### PR TITLE
fix(test): stop leaking the exclusive-lease poller across integration tests

### DIFF
--- a/packages/server/src/lobu/__tests__/agent-routes-rest-platform.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-rest-platform.test.ts
@@ -31,7 +31,7 @@
  * Uses the embedded Postgres gateway test harness; no network.
  */
 
-import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import {
   ensureDbForGatewayTests,
   resetTestDatabase,
@@ -84,6 +84,17 @@ async function seedOrgAndAgent(orgId: string, agentId: string): Promise<void> {
   `;
 }
 
+// Every ChatInstanceManager this file builds is tracked here and shut down in
+// `afterEach`. `initialize()` starts a 15s `connection_claims` exclusive-lease
+// `setInterval` (`startExclusiveRunner`); left running it keeps firing
+// `exclusiveTick` DB queries on the shared app pool AFTER the test finishes,
+// which overlaps the NEXT test's `beforeEach` cleanup `TRUNCATE … CASCADE` and
+// deadlocks (40P01). `shutdown()` clears that interval (and is a safe no-op for
+// managers that were never initialized), so no background DML crosses a test
+// boundary. (#1609's cleanup retry is the resilience net; this stops the leak
+// it papers over.)
+const createdManagers: Array<{ shutdown: () => Promise<void> }> = [];
+
 /**
  * Real ChatInstanceManager over the real Postgres stores — startInstance is
  * NOT stubbed, so an adapter-requiring platform would actually try to boot.
@@ -122,6 +133,7 @@ async function buildRealManager() {
   manager.connectionStore = connectionStore;
   manager.slackCoordinator = manager.buildSlackCoordinator();
 
+  createdManagers.push(manager);
   return { manager, services, connectionStore, orgContext };
 }
 
@@ -143,6 +155,18 @@ beforeEach(async () => {
   const { manager } = await buildRealManager();
   chatManagerStash.manager = manager;
 }, 30_000);
+
+afterEach(async () => {
+  // Stop every manager built during the test so no background exclusive-lease
+  // tick keeps issuing DB statements into the next test's TRUNCATE cleanup.
+  for (const manager of createdManagers.splice(0)) {
+    await manager.shutdown();
+    // Guard: shutdown() must actually clear the 15s exclusive-lease interval —
+    // a leaked timer is exactly what deadlocked the co-running suites.
+    expect((manager as any).exclusiveTimer).toBeUndefined();
+  }
+  chatManagerStash.manager = null;
+});
 
 describe('PUT /agents/:agentId/platforms/by-stable-id — type rest (#1179)', () => {
   test('creates the platform row without instantiating a chat adapter', async () => {


### PR DESCRIPTION
## Root cause

The `integration` job's `server lobu/scheduled/workspace suites (bun:test)` step (`bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__`) intermittently deadlocked with `PostgresError: 40P01` during `beforeEach` cleanup.

`agent-routes-rest-platform.test.ts`'s "boot reconciliation" case calls `replica.initialize(services)`, which starts `ChatInstanceManager`'s 15s `connection_claims` exclusive-lease `setInterval` (`startExclusiveRunner`). The test never calls `shutdown()`, so that timer keeps firing `exclusiveTick` DB queries on the shared app pool **after** the test finished. Those statements overlap the next test's `beforeEach` `TRUNCATE … CASCADE`: TRUNCATE takes `AccessExclusiveLock` on tables in list order while the poller's FK-bearing DML takes child-then-parent row locks in the opposite order → lock-order inversion → `40P01 deadlock detected`.

This is the actual leak that #1609's cleanup-TRUNCATE retry papers over. That retry is kept as the resilience net.

I audited every test in the step's three dirs for unstopped pollers:
- `agent-routes-rest-platform.test.ts` — `replica.initialize()` started the exclusive-lease timer, never stopped. **Fixed.**
- `scheduled/__tests__/task-scheduler.test.ts` — uses a `FakeQueue` (no real interval, no DB DML). No leak.
- `scheduled/__tests__/stale-run-reaper.test.ts` / `check-stalled-no-reap.test.ts` — call `reapStaleRuns()`/`checkStalledExecutions()` directly (one-shot, no interval). No leak.
- `agent-routes-oauth-redirect.test.ts` — already tears down via `afterEach` → `stack.shutdown()`. No leak.

So the manager's exclusive-lease timer was the sole leaking poller in this step.

## Fix

Track every `ChatInstanceManager` the file builds and `shutdown()` all of them in `afterEach`. `shutdown()` clears the interval and is a safe no-op for managers that were never initialized. An `expect(manager.exclusiveTimer).toBeUndefined()` guard asserts the timer is actually cleared. No background DML crosses a test boundary now.

Changes are confined to `agent-routes-rest-platform.test.ts` (test-only). #1609's `40P01` retry and the `42P01`-only catch in `cleanupTestDatabase` are untouched.

## Verification (actually run)

- **Leaked-timer evidence (deterministic):** a temporary timer-lifecycle probe in `ChatInstanceManager` (since removed) showed `startExclusiveRunner` x1 / `shutdown clearing timer` x0 **before** this change, and x1 / x1 **after** — the leaked interval is now cleared within the same test boundary.
- **Stress loop:** `bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__` green **12/12** iterations (91 pass, 0 fail each).
- **Typecheck:** `bunx tsc --noEmit` in `packages/server` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaSJb2d2Mq7q6nWX8R26Kn

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785338320&installation_id=136316292&pr_number=1610&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1610&signature=c7941866628235d03a4b04c71d3191760214e1ae8134abe219c1022d4a38c52c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup to prevent lingering background activity from affecting later test runs.
  * Added stronger teardown checks to ensure test resources are fully shut down and reset between cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an intermittent `40P01` deadlock in the integration test suite caused by a leaked `setInterval` in `ChatInstanceManager`. The "boot reconciliation" test called `replica.initialize(services)`, which started a 15-second exclusive-lease poller, but never called `shutdown()` — leaving background DB DML firing against the shared pool and racing with the next test's `TRUNCATE … CASCADE`.

- Introduces a module-level `createdManagers` array in `agent-routes-rest-platform.test.ts`; every call to `buildRealManager()` now pushes the new manager into it.
- Adds an `afterEach` hook that drains the array via `splice(0)`, awaits `shutdown()` on each manager, and asserts `exclusiveTimer` is `undefined` — confirming the interval was actually cleared rather than just called.

<h3>Confidence Score: 5/5</h3>

Change is confined to a single test file and directly closes the timer leak that caused intermittent deadlocks; no production code is touched.

The fix is minimal and precisely targeted: a module-level tracking array, a two-line push in the factory function, and an afterEach hook that drains the array and asserts the timer is cleared. The shutdown() implementation in ChatInstanceManager already sets exclusiveTimer to undefined, so the guard assertion is reliable. No logic in the test cases themselves changes, and no production paths are affected.

No files require special attention; the single changed file is a test helper with straightforward before/after lifecycle hooks.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/server/src/lobu/__tests__/agent-routes-rest-platform.test.ts | Adds afterEach hook to shut down all ChatInstanceManager instances created during tests, stopping the exclusive-lease setInterval from leaking across test boundaries and deadlocking the next test's TRUNCATE cleanup. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant beforeEach
    participant Test
    participant afterEach
    participant Manager as ChatInstanceManager
    participant DB

    beforeEach->>Manager: new ChatInstanceManager()
    Note over beforeEach,Manager: push to createdManagers
    beforeEach->>Manager: assign to chatManagerStash

    Test->>Manager: replica.initialize(services)
    Manager->>DB: startExclusiveRunner sets 15s setInterval

    Note over Manager,DB: Without fix - interval fires DML after test ends
    Note over Manager,DB: races with next TRUNCATE CASCADE causing 40P01

    afterEach->>Manager: shutdown() via createdManagers.splice(0)
    Manager->>DB: clearInterval(exclusiveTimer)
    afterEach->>Manager: expect(exclusiveTimer).toBeUndefined()
    afterEach->>afterEach: "chatManagerStash.manager = null"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant beforeEach
    participant Test
    participant afterEach
    participant Manager as ChatInstanceManager
    participant DB

    beforeEach->>Manager: new ChatInstanceManager()
    Note over beforeEach,Manager: push to createdManagers
    beforeEach->>Manager: assign to chatManagerStash

    Test->>Manager: replica.initialize(services)
    Manager->>DB: startExclusiveRunner sets 15s setInterval

    Note over Manager,DB: Without fix - interval fires DML after test ends
    Note over Manager,DB: races with next TRUNCATE CASCADE causing 40P01

    afterEach->>Manager: shutdown() via createdManagers.splice(0)
    Manager->>DB: clearInterval(exclusiveTimer)
    afterEach->>Manager: expect(exclusiveTimer).toBeUndefined()
    afterEach->>afterEach: "chatManagerStash.manager = null"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(test): stop leaking the exclusive-le..."](https://github.com/lobu-ai/lobu/commit/31a8dc1e3b98fe55f112e14ace4b99aec33f4258) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40548266)</sub>

<!-- /greptile_comment -->