### PR TITLE
feat(connectors): notify when Revolut needs browser sign-in

### DIFF
--- a/examples/personal-agent/revolut-transactions.connector.ts
+++ b/examples/personal-agent/revolut-transactions.connector.ts
@@ -386,6 +386,28 @@ export class RevolutAuthWallError extends Error {
   }
 }
 
+async function notifyRevolutAuthWall(
+  dispatcher: ChromeActionDispatcher,
+  landedUrl: string,
+  tabId?: number
+): Promise<void> {
+  try {
+    await dispatcher.dispatch("show_notification", {
+      notification_id: "revolut-auth-wall",
+      title: "Revolut needs sign-in",
+      message:
+        "Enter your Revolut passcode in the focused Chrome window, then rerun the sync.",
+      body: "Enter your Revolut passcode in the focused Chrome window, then rerun the sync.",
+      landed_url: landedUrl,
+      click_url: landedUrl,
+      ...(typeof tabId === "number" ? { tab_id: tabId } : {}),
+    });
+  } catch {
+    // Best-effort only: lack of notification permission or an unavailable
+    // extension notification API must not hide the real auth-wall failure.
+  }
+}
+
 // ---------------------------------------------------------------------------
 // DOM scrape (declarative cs_scrape via the extension's content script)
 // ---------------------------------------------------------------------------
@@ -475,7 +497,9 @@ async function scrapeTransactionRows(
     persistent: false,
   });
   if (!result.loggedIn) {
-    throw new RevolutAuthWallError(result.landedUrl ?? url);
+    const landedUrl = result.landedUrl ?? url;
+    await notifyRevolutAuthWall(dispatcher, landedUrl, result.tabId);
+    throw new RevolutAuthWallError(landedUrl);
   }
   return result.items;
 }

--- a/packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts
+++ b/packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts
@@ -63,6 +63,7 @@ describe('extensionDomScrape', () => {
     expect(res.loggedIn).toBe(true);
     expect(res.count).toBe(2);
     expect(res.host).toBe('www.example.com');
+    expect(res.tabId).toBe(7);
   });
 
   test('treats absent loggedIn as logged in and defaults count to item length', async () => {
@@ -95,22 +96,20 @@ describe('extensionDomScrape', () => {
     expect(res.count).toBe(0);
   });
 
-  test('honors persistent/focus overrides and handles a missing result envelope', async () => {
+  test('honors persistent/focus overrides and fails loudly on a missing result envelope', async () => {
     const { dispatcher, log } = makeDispatcher({});
-    const res = await extensionDomScrape<{ id?: string }>({
-      dispatcher,
-      url: 'https://www.example.com/feed/',
-      config: {},
-      parseRows: (rows) => rows as { id?: string }[],
-      allowedOrigins: ['example.com'],
-      persistent: false,
-      focus: false,
-    });
+    await expect(
+      extensionDomScrape<{ id?: string }>({
+        dispatcher,
+        url: 'https://www.example.com/feed/',
+        config: {},
+        parseRows: (rows) => rows as { id?: string }[],
+        allowedOrigins: ['example.com'],
+        persistent: false,
+        focus: false,
+      })
+    ).rejects.toThrow(/cs_scrape returned no result/);
     expect(log[0].input.persistent).toBe(false);
     expect(log[0].input.focus).toBe(false);
-    // No `result` → empty rows, logged-in by default, count 0.
-    expect(res.items).toEqual([]);
-    expect(res.loggedIn).toBe(true);
-    expect(res.count).toBe(0);
   });
 });

--- a/packages/connector-sdk/src/extension-dom-scrape.ts
+++ b/packages/connector-sdk/src/extension-dom-scrape.ts
@@ -53,6 +53,8 @@ export interface ExtensionDomScrapeResult<TItem> {
   count: number;
   host?: string;
   landedUrl?: string;
+  /** Tab the content-script scrape ran in. Useful for focusing an auth-wall tab. */
+  tabId?: number;
 }
 
 /**
@@ -98,5 +100,6 @@ export async function extensionDomScrape<TItem>(opts: {
     count: result.count ?? items.length,
     host: result.host,
     landedUrl: result.landedUrl,
+    tabId: observation.tab_id,
   };
 }

--- a/packages/connectors/src/chrome.ts
+++ b/packages/connectors/src/chrome.ts
@@ -352,6 +352,43 @@ export default class ChromeConnector extends ConnectorRuntime {
           properties: { tab_id: { type: 'integer' } },
         },
       },
+      show_notification: {
+        key: 'show_notification',
+        name: 'Show desktop notification',
+        description:
+          'Show an urgent Chrome desktop notification from Owletto. No-ops when the user has not granted the optional notifications permission.',
+        requiresApproval: false,
+        inputSchema: {
+          type: 'object',
+          required: ['title'],
+          properties: {
+            title: { type: 'string', maxLength: 80 },
+            message: { type: 'string', maxLength: 240 },
+            body: { type: 'string', maxLength: 240 },
+            notification_id: { type: 'string', maxLength: 120 },
+            tab_id: {
+              type: 'integer',
+              description:
+                'Tab to focus when the notification is clicked. Falls back to click_url if the tab is gone.',
+            },
+            click_url: {
+              type: 'string',
+              format: 'uri',
+              description:
+                'URL to open when clicked if tab_id is absent or the tab no longer exists.',
+            },
+            landed_url: { type: 'string', format: 'uri' },
+          },
+        },
+        outputSchema: {
+          type: 'object',
+          properties: {
+            shown: { type: 'boolean' },
+            reason: { type: 'string' },
+            notification_id: { type: 'string' },
+          },
+        },
+      },
       network_intercept_start: {
         key: 'network_intercept_start',
         name: 'Start network interception',

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -20,6 +20,7 @@ export const BROWSER_CAPABILITIES = [
   "browser.history",
   "browser.bookmarks",
   "browser.downloads",
+  "browser.notifications",
   "browser.debugger",
   // browser.cookies intentionally absent in v1 — high-trust, not approved
 ] as const;


### PR DESCRIPTION
## What

- Wires the project-local Revolut connector to show a best-effort Chrome desktop notification when its scrape lands on Revolut's auth/passcode wall.
- The notification includes both the auth-wall `tab_id` and `click_url`, so clicking it focuses the original tab/window, or opens the URL if the tab was closed.
- Propagates `tabId` from `extensionDomScrape` results so DOM-scrape connectors can target auth-wall tabs.
- Adds `browser.notifications` to the authorized Chrome-extension capability allowlist.
- Adds `chrome/show_notification` action metadata to the Chrome connector catalog.
- Bumps the Owletto submodule to lobu-ai/owletto@8417dae.

## Why

The server already creates an in-app `browser_auth_expired` notification, but users do not get a Chrome desktop notification. For browser-backed auth walls, the connector itself has the live dispatcher and knows the focused passcode tab, so the immediate alert belongs in the connector path.

## Behavior

- If the user granted Chrome notifications: Revolut auth-wall failure shows a native notification.
- Clicking the notification focuses the Revolut passcode tab/window.
- If permission was not granted: `show_notification` no-ops successfully and the connector still throws the normal `RevolutAuthWallError`.

## Tests

- `bun test packages/owletto/apps/chrome/tools.test.js` → 34 pass
- `bun test packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts` → 4 pass
- `bun run typecheck` → pass
- `make build-packages` → pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785343656&installation_id=136316292&pr_number=1613&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1613&signature=5a87e354abad745b5771cd06f2cade65fda9e9a0e56f672f8124ecd7ac773e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the Revolut connector to emit a Chrome desktop notification when its DOM scrape hits an auth/passcode wall, giving users an immediate prompt to re-authenticate. It also fixes a pre-existing silent-failure in `extensionDomScrape` where a missing result envelope was coerced into a zero-row "success".

- **`extensionDomScrape`**: propagates `tab_id` from the observation envelope, and now throws on a missing `result` instead of silently returning empty rows (also tested in the companion test file).
- **Revolut connector**: calls the new `notifyRevolutAuthWall` helper (best-effort, errors swallowed) before re-throwing `RevolutAuthWallError`, supplying both `tab_id` and `click_url` so Chrome can focus the auth tab or open the URL if the tab was already closed.
- **Chrome catalog / capabilities**: registers `show_notification` as a dispatchable action and adds `browser.notifications` to the authorized capability allowlist.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the notification path is best-effort with all errors swallowed, the auth-wall error still propagates correctly, and the silent-failure fix in extensionDomScrape is an intentional correctness improvement backed by updated tests.

All changed paths are covered by tests, the behavior change to extensionDomScrape (throwing on a missing result instead of returning empty rows) is explicitly documented and tested, and the notification dispatch cannot mask the real RevolutAuthWallError. LinkedIn and Deliveroo connectors that also use extensionDomScrape benefit from the stricter error behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| examples/personal-agent/revolut-transactions.connector.ts | Adds notifyRevolutAuthWall helper (errors swallowed) and calls it before throwing RevolutAuthWallError; notification fields look correct; message/body duplication already flagged in a prior thread. |
| packages/connector-sdk/src/extension-dom-scrape.ts | Adds tabId to ExtensionDomScrapeResult, read from observation.tab_id; changes missing-result from silent empty-success to a thrown error — intentional and well-justified by inline comments. |
| packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts | Tests updated to assert tabId propagation and to expect a thrown error on missing result envelope; coverage is adequate for the changed behavior. |
| packages/connectors/src/chrome.ts | Adds show_notification action descriptor with well-formed inputSchema/outputSchema; requiresApproval correctly set to false; placed logically between close_tab and network_intercept_start. |
| packages/core/src/capabilities.ts | Adds browser.notifications to BROWSER_CAPABILITIES; flows correctly through PLATFORM_ALLOWLIST for chrome-extension and macos platforms. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant R as Revolut Connector
    participant S as extensionDomScrape
    participant D as ChromeActionDispatcher
    participant E as Chrome Extension (Owletto)
    participant U as User

    R->>S: "extensionDomScrape({ persistent:false, ... })"
    S->>D: "dispatch(navigate, { cs_scrape:true, ... })"
    D->>E: cs_scrape navigate
    E-->>D: "observation { tab_id, result: { loggedIn:false, landedUrl } }"
    D-->>S: observation
    S-->>R: "{ loggedIn:false, landedUrl, tabId }"

    R->>D: "dispatch(show_notification, { tab_id, click_url, ... })"
    Note over D,E: best-effort — errors are swallowed
    D->>E: show_notification
    E-->>U: Chrome desktop notification

    R->>R: throw RevolutAuthWallError(landedUrl)

    U->>E: click notification
    alt tab still alive
        E->>U: focus passcode tab (tab_id)
    else tab closed
        E->>U: open click_url in new tab
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant R as Revolut Connector
    participant S as extensionDomScrape
    participant D as ChromeActionDispatcher
    participant E as Chrome Extension (Owletto)
    participant U as User

    R->>S: "extensionDomScrape({ persistent:false, ... })"
    S->>D: "dispatch(navigate, { cs_scrape:true, ... })"
    D->>E: cs_scrape navigate
    E-->>D: "observation { tab_id, result: { loggedIn:false, landedUrl } }"
    D-->>S: observation
    S-->>R: "{ loggedIn:false, landedUrl, tabId }"

    R->>D: "dispatch(show_notification, { tab_id, click_url, ... })"
    Note over D,E: best-effort — errors are swallowed
    D->>E: show_notification
    E-->>U: Chrome desktop notification

    R->>R: throw RevolutAuthWallError(landedUrl)

    U->>E: click notification
    alt tab still alive
        E->>U: focus passcode tab (tab_id)
    else tab closed
        E->>U: open click_url in new tab
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore: update owletto notification point..."](https://github.com/lobu-ai/lobu/commit/e4609bc925fdfa11ec698d5f5da510b1a80ffebf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40571962)</sub>

<!-- /greptile_comment -->