### PR TITLE
chore(server): remove dead Slack App Home MCP UI + config-service oauth shims + stale docs

### DIFF
--- a/packages/landing/src/content/docs/getting-started/index.mdx
+++ b/packages/landing/src/content/docs/getting-started/index.mdx
@@ -77,13 +77,13 @@ See [Skills](/getting-started/skills/) for which coding agents this supports and
 | `agents/my-agent/IDENTITY.md` | "Make this a customer support agent for Acme Corp" |
 | `agents/my-agent/SOUL.md` | "Add rules: never share pricing, always confirm before cancellations" |
 | `agents/my-agent/USER.md` | "Set timezone to US/Pacific, company plan is Enterprise" |
-| `lobu.config.ts` | "Add a GitHub MCP server and allow github.com and api.linear.app" |
+| `lobu.config.ts` | "Allow this agent to reach github.com and api.linear.app" |
 | `agents/my-agent/evals/` | "Write an eval that tests the agent follows the cancellation rule" |
 | `agents/my-agent/skills/` | "Create a custom skill for our internal API" |
 
 ## Configuration
 
-`lobu.config.ts` plus the files under `agents/<id>/` are the source of truth: agents, providers, network policy, tool policy, MCP servers, and (optionally) the memory schema. `lobu.config.ts` is a TypeScript module that default-exports `defineConfig({...})` and imports its authoring functions from `@lobu/cli/config`. Edit it locally and `lobu run` picks it up immediately.
+`lobu.config.ts` plus the files under `agents/<id>/` are the source of truth: agents, providers, network policy, tool policy, connectors, and (optionally) the memory schema. `lobu.config.ts` is a TypeScript module that default-exports `defineConfig({...})` and imports its authoring functions from `@lobu/cli/config`. Edit it locally and `lobu run` picks it up immediately.
 
 To run an agent on **Lobu Cloud**, push the same project up with `lobu apply`:
 

--- a/packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts
@@ -1,16 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
 
-// Stub the MCP OAuth flow so the home-tab "Connect" path doesn't hit the
-// network for discovery. Must be registered before slack-platform-bridge is
-// imported (it captures the `startAuthCodeFlow` binding at module eval).
-const startAuthCodeFlowMock = mock(async (opts: any) => ({
-  authorizationUrl: `${opts?.staticOauth?.authUrl ?? "https://auth.example/authorize"}?state=test-state`,
-  state: "test-state",
-}));
-mock.module("../auth/mcp/oauth-flow.js", () => ({
-  startAuthCodeFlow: startAuthCodeFlowMock,
-}));
-
 import {
   parseSlackTeamJoinEvent,
   postSlackTeamJoinWelcome,
@@ -28,43 +17,18 @@ type HomeHandler = (event: {
     publishHomeView?: (u: string, v: Record<string, unknown>) => Promise<void>;
   };
 }) => Promise<void>;
-type ActionHandler = (event: {
-  actionId: string;
-  value?: string;
-  user: { userId: string };
-  adapter?: {
-    publishHomeView?: (u: string, v: Record<string, unknown>) => Promise<void>;
-  };
-  raw?: unknown;
-}) => Promise<void>;
 
 function makeHomeChat() {
   let homeHandler: HomeHandler | undefined;
-  let actionHandler: ActionHandler | undefined;
   const chat = {
     onAppHomeOpened: mock((h: HomeHandler) => {
       homeHandler = h;
-    }),
-    onAction: mock((_ids: string[], h: ActionHandler) => {
-      actionHandler = h;
     }),
   };
   return {
     chat,
     open: (userId: string, publishHomeView: ReturnType<typeof mock>) =>
       homeHandler?.({ userId, adapter: { publishHomeView } }),
-    click: (
-      actionId: string,
-      value: string,
-      userId: string,
-      publishHomeView: ReturnType<typeof mock>
-    ) =>
-      actionHandler?.({
-        actionId,
-        value,
-        user: { userId },
-        adapter: { publishHomeView },
-      }),
   };
 }
 
@@ -160,170 +124,7 @@ describe("Slack platform bridge", () => {
       ...over,
     }) as any;
 
-  const mcpStatus = [
-    { id: "github", name: "github", requiresAuth: true, requiresInput: false },
-    {
-      id: "google-drive",
-      name: "google-drive",
-      requiresAuth: true,
-      requiresInput: false,
-    },
-    {
-      id: "weather",
-      name: "weather",
-      requiresAuth: false,
-      requiresInput: false,
-    },
-    {
-      id: "lobu-memory",
-      name: "lobu-memory",
-      requiresAuth: false,
-      requiresInput: false,
-    },
-  ];
-
-  // Fake WritableSecretStore: GitHub has a stored credential, nothing else.
-  const fakeSecretStore = () => {
-    const del = mock(async (_name: string) => undefined);
-    return {
-      del,
-      store: {
-        get: mock(async (ref: string) =>
-          ref.includes("github") ? JSON.stringify({ accessToken: "x" }) : null
-        ),
-        put: mock(async () => "secret://x"),
-        delete: del,
-        list: mock(async () => []),
-      } as any,
-    };
-  };
-
-  test("home tab shows per-user connect/disconnect status for integrations", async () => {
-    const h = makeHomeChat();
-    const { store } = fakeSecretStore();
-    registerSlackAppHome(h.chat, connection(), {
-      mcpConfigService: { getMcpStatus: mock(async () => mcpStatus) } as any,
-      secretStore: store,
-      publicGatewayUrl: "https://gw.example",
-    });
-
-    const publishHomeView = mock(async () => undefined);
-    await h.open("U123", publishHomeView);
-
-    expect(publishHomeView).toHaveBeenCalledTimes(1);
-    const view = publishHomeView.mock.calls[0]![1] as {
-      type: string;
-      blocks: Array<Record<string, any>>;
-    };
-    expect(view.type).toBe("home");
-    const text = blocksText(view);
-    expect(text).toContain("Lobster");
-    expect(text).toContain("Github");
-    expect(text).toContain("Google Drive");
-    expect(text).toContain("Weather");
-    // Internal plumbing MCP is hidden.
-    expect(text).not.toContain("Lobu Memory");
-
-    // GitHub has a credential → Disconnect button.
-    const githubSection = view.blocks.find(
-      (b) => b.accessory?.value === "github"
-    );
-    expect(githubSection?.accessory?.action_id).toBe("lobu_home_disconnect");
-    // Google Drive is not connected → Connect button.
-    const gdriveSection = view.blocks.find(
-      (b) => b.accessory?.value === "google-drive"
-    );
-    expect(gdriveSection?.accessory?.action_id).toBe("lobu_home_connect");
-  });
-
-  test("Disconnect button revokes the credential and re-publishes the home tab", async () => {
-    const h = makeHomeChat();
-    const { store, del } = fakeSecretStore();
-    registerSlackAppHome(h.chat, connection(), {
-      mcpConfigService: { getMcpStatus: mock(async () => mcpStatus) } as any,
-      secretStore: store,
-      publicGatewayUrl: "https://gw.example",
-    });
-
-    const publishHomeView = mock(async () => undefined);
-    await h.click("lobu_home_disconnect", "github", "U123", publishHomeView);
-
-    // deleteCredential removes both the credential and device-auth secret rows.
-    expect(del).toHaveBeenCalled();
-    expect(del.mock.calls.some(([name]) => String(name).includes("github"))).toBe(
-      true
-    );
-    expect(publishHomeView).toHaveBeenCalledTimes(1);
-    expect(publishHomeView.mock.calls[0]![0]).toBe("U123");
-  });
-
-  test("ignores a Disconnect action for an integration the agent doesn't have", async () => {
-    const h = makeHomeChat();
-    const { store, del } = fakeSecretStore();
-    registerSlackAppHome(h.chat, connection(), {
-      mcpConfigService: { getMcpStatus: mock(async () => mcpStatus) } as any,
-      secretStore: store,
-      publicGatewayUrl: "https://gw.example",
-    });
-
-    const publishHomeView = mock(async () => undefined);
-    await h.click(
-      "lobu_home_disconnect",
-      "../../other-agent/U999/github/credential",
-      "U123",
-      publishHomeView
-    );
-
-    // No secret deleted, no home re-publish — the crafted id is rejected.
-    expect(del).not.toHaveBeenCalled();
-    expect(publishHomeView).not.toHaveBeenCalled();
-  });
-
-  test("Connect button mints an auth URL and re-publishes with a sign-in link", async () => {
-    const h = makeHomeChat();
-    startAuthCodeFlowMock.mockClear();
-    const getHttpServer = mock(async () => ({
-      id: "github",
-      upstreamUrl: "https://github-mcp.example/mcp",
-      oauth: {
-        authUrl: "https://github-mcp.example/oauth/authorize",
-        tokenUrl: "https://github-mcp.example/oauth/token",
-        clientId: "client-123",
-      },
-    }));
-    registerSlackAppHome(h.chat, connection(), {
-      mcpConfigService: {
-        getMcpStatus: mock(async () => mcpStatus),
-        getHttpServer,
-      } as any,
-      secretStore: { get: mock(async () => null), put: mock(), delete: mock(), list: mock(async () => []) } as any,
-      publicGatewayUrl: "https://gw.example",
-    });
-
-    const publishHomeView = mock(async () => undefined);
-    await h.click("lobu_home_connect", "github", "U123", publishHomeView);
-
-    expect(getHttpServer).toHaveBeenCalled();
-    expect(startAuthCodeFlowMock).toHaveBeenCalledTimes(1);
-    const flowOpts = startAuthCodeFlowMock.mock.calls[0]![0] as any;
-    expect(flowOpts.mcpId).toBe("github");
-    expect(flowOpts.scopeKey).toBe("U123");
-    expect(flowOpts.platform).toBe("slack");
-
-    expect(publishHomeView).toHaveBeenCalledTimes(1);
-    const view = publishHomeView.mock.calls[0]![1] as {
-      blocks: Array<Record<string, any>>;
-    };
-    const githubSection = view.blocks.find((b) =>
-      String(b.text?.text ?? "").includes("Github")
-    );
-    expect(githubSection?.accessory?.url).toContain(
-      "https://github-mcp.example/oauth/authorize"
-    );
-    expect(githubSection?.accessory?.url).toContain("state=test-state");
-  });
-
-  test("home tab renders without the integrations section when the MCP config service is absent", async () => {
+  test("home tab renders the bot intro with only the default deps", async () => {
     const h = makeHomeChat();
     registerSlackAppHome(h.chat, connection(), {});
     const publishHomeView = mock(async () => undefined);
@@ -332,7 +133,6 @@ describe("Slack platform bridge", () => {
       blocks: Array<Record<string, unknown>>;
     };
     expect(blocksText(view)).toContain("Lobster");
-    expect(view.blocks.some((b) => b.type === "header")).toBe(false);
   });
 
   test("home tab renders the dashboard card with a slug deep link and org counts", async () => {
@@ -566,15 +366,12 @@ describe("Slack platform bridge", () => {
     expect(blocksText(fallback)).toContain("/lobu help");
   });
 
-  test("renders the preview-workspace home tab without touching the MCP config", async () => {
+  test("renders the preview-workspace home tab with the setup prompt", async () => {
     const h = makeHomeChat();
-    const getMcpStatus = mock(async () => mcpStatus);
     registerSlackAppHome(
       h.chat,
       connection({ agentId: "placeholder", settings: { previewMode: true } }),
       {
-        mcpConfigService: { getMcpStatus } as any,
-        secretStore: { getStoredCredential: mock(async () => null) } as any,
         publicGatewayUrl: "https://gw.example",
       }
     );
@@ -582,7 +379,6 @@ describe("Slack platform bridge", () => {
     const publishHomeView = mock(async () => undefined);
     await h.open("U123", publishHomeView);
 
-    expect(getMcpStatus).not.toHaveBeenCalled();
     const text = blocksText(
       publishHomeView.mock.calls[0]![1] as {
         blocks?: Array<Record<string, unknown>>;

--- a/packages/server/src/gateway/auth/mcp/config-service.ts
+++ b/packages/server/src/gateway/auth/mcp/config-service.ts
@@ -7,10 +7,6 @@ const LOBU_MEMORY_MCP_ID = "lobu-memory";
 interface HttpMcpServerConfig {
   id: string;
   upstreamUrl: string;
-  oauth?: undefined;
-  inputs?: undefined;
-  headers?: undefined;
-  authScope?: undefined;
   /**
    * Marks the embedded Lobu MCP server. The gateway proxy passes the worker JWT
    * directly, bypasses the SSRF localhost guard, and stamps the upstream

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -1407,8 +1407,6 @@ export class ChatInstanceManager {
         // The initialized adapter (with the live Slack WebClient) — `chat.initialize()`
         // below mutates it to add `.client`; event handlers fire only afterwards.
         adapter,
-        mcpConfigService: this.services.getMcpConfigService(),
-        secretStore: this.services.getSecretStore(),
         publicGatewayUrl: this.publicGatewayUrl,
         resolveHomeContext: resolveSlackHomeContext,
         resolveUserInbox: resolveSlackHomeUserInbox,

--- a/packages/server/src/gateway/connections/slack-platform-bridge.ts
+++ b/packages/server/src/gateway/connections/slack-platform-bridge.ts
@@ -1,14 +1,6 @@
 import { createLogger } from "@lobu/core";
-import type { McpConfigService } from "../auth/mcp/config-service.js";
-import { startAuthCodeFlow } from "../auth/mcp/oauth-flow.js";
-import { runWithOrganizationContext } from "../auth/mcp/proxy-shared.js";
 import type { CommandDispatcher } from "../commands/command-dispatcher.js";
 import { createChatReply } from "../commands/command-reply-adapters.js";
-import {
-  deleteCredential,
-  getStoredCredential,
-} from "../routes/internal/device-auth.js";
-import type { WritableSecretStore } from "../secrets/index.js";
 import type { PlatformConnection } from "./types.js";
 
 const logger = createLogger("slack-platform-bridge");
@@ -17,9 +9,6 @@ const DEFAULT_SLACK_COMMAND = "/lobu";
 const DEFAULT_SLACK_TEAM_JOIN_WELCOME =
   "Mention me in a channel or send me a DM to start a thread. Use `/lobu help` to see the built-in commands.";
 const DEFAULT_SLACK_APP_NAME = "Lobu";
-
-const HOME_ACTION_CONNECT = "lobu_home_connect";
-const HOME_ACTION_DISCONNECT = "lobu_home_disconnect";
 
 type SlackSlashEvent = {
   text?: string;
@@ -141,14 +130,6 @@ type SlackAppHomeEvent = {
   adapter?: SlackHomeAdapter;
 };
 
-type SlackActionEvent = {
-  actionId: string;
-  value?: string;
-  user: { userId: string };
-  adapter?: SlackHomeAdapter;
-  raw?: unknown;
-};
-
 /** A single "what's recent" row for the home tab, mirroring the web's recent feed. */
 export interface SlackHomeRecentItem {
   /** Display title (event title, or a payload snippet, or a fallback). */
@@ -206,11 +187,9 @@ interface SlackAppHomeDeps {
    * go through this one.
    */
   adapter?: SlackHomeAdapter;
-  mcpConfigService?: McpConfigService;
-  secretStore?: WritableSecretStore;
   /**
-   * Public origin of the gateway — used to build the OAuth redirect URI and,
-   * since the web SPA is served same-origin, the dashboard deep link.
+   * Public origin of the gateway — since the web SPA is served same-origin,
+   * this is the base for the dashboard deep link and preview setup prompt.
    */
   publicGatewayUrl?: string;
   /**
@@ -230,81 +209,6 @@ interface SlackAppHomeDeps {
     slackUserId: string,
     teamId: string,
   ) => Promise<SlackHomeInbox | null>;
-}
-
-// Internal plumbing MCPs (e.g. the Lobu memory backend) — not user integrations.
-const HIDDEN_HOME_INTEGRATION_IDS = new Set(["lobu-memory"]);
-
-function humanizeIntegrationName(id: string): string {
-	return id.replace(/[-_]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
-function teamIdFromRawPayload(raw: unknown): string | undefined {
-  const team = (raw as { team?: { id?: unknown } } | undefined)?.team?.id;
-  return typeof team === "string" ? team : undefined;
-}
-
-type IntegrationStatus = {
-  id: string;
-  name: string;
-  requiresAuth: boolean;
-  connected: boolean;
-};
-
-function integrationSection(
-  status: IntegrationStatus,
-	pendingAuthUrl?: string,
-): Record<string, unknown> {
-  if (!status.requiresAuth) {
-    return {
-      type: "section",
-      text: { type: "mrkdwn", text: `:white_circle: *${status.name}*` },
-    };
-  }
-  if (status.connected) {
-    return {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `:white_check_mark: *${status.name}*  ·  connected`,
-      },
-      accessory: {
-        type: "button",
-        text: { type: "plain_text", text: "Disconnect" },
-        action_id: HOME_ACTION_DISCONNECT,
-        value: status.id,
-        style: "danger",
-      },
-    };
-  }
-  if (pendingAuthUrl) {
-    return {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: `:hourglass_flowing_sand: *${status.name}*  ·  finish signing in`,
-      },
-      accessory: {
-        type: "button",
-        text: { type: "plain_text", text: "Open sign-in ↗" },
-        url: pendingAuthUrl,
-      },
-    };
-  }
-  return {
-    type: "section",
-    text: {
-      type: "mrkdwn",
-      text: `:white_circle: *${status.name}*  ·  not connected`,
-    },
-    accessory: {
-      type: "button",
-      text: { type: "plain_text", text: "Connect" },
-      action_id: HOME_ACTION_CONNECT,
-      value: status.id,
-      style: "primary",
-    },
-  };
 }
 
 /** Trim a trailing slash so we can append `/segment` cleanly. */
@@ -477,14 +381,12 @@ interface HomeViewParams {
   deps: SlackAppHomeDeps;
   /** Slack user the home tab is being rendered for (credential scope key). */
   userId: string;
-  /** MCP ids → freshly-minted authorization URL, shown as an "Open sign-in" link. */
-  pendingAuthUrls?: Record<string, string>;
 }
 
 async function buildSlackHomeBlocks(
 	params: HomeViewParams,
 ): Promise<unknown[]> {
-  const { connection, deps, userId, pendingAuthUrls } = params;
+  const { connection, deps, userId } = params;
   const botName =
     (typeof connection.metadata?.botUsername === "string" &&
       connection.metadata.botUsername) ||
@@ -536,40 +438,6 @@ async function buildSlackHomeBlocks(
     blocks.push(...recentBlocks(context?.recent ?? []));
   }
 
-  if (!isPreview && connection.agentId && deps.mcpConfigService) {
-    try {
-      const statuses = await loadIntegrationStatusesScoped(
-        connection.agentId,
-        userId,
-				connection.organizationId,
-				deps,
-      );
-      blocks.push({
-        type: "header",
-        text: { type: "plain_text", text: "Integrations" },
-      });
-      if (statuses.length === 0) {
-        blocks.push({
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: "_No integrations connected yet._",
-          },
-        });
-      } else {
-        for (const status of statuses) {
-          blocks.push(integrationSection(status, pendingAuthUrls?.[status.id]));
-        }
-      }
-      blocks.push({ type: "divider" });
-    } catch (error) {
-      logger.warn(
-        { error, agentId: connection.agentId },
-				"Failed to load integrations for Slack home tab; rendering without them",
-      );
-    }
-  }
-
   if (isPreview) {
     blocks.push(...setupBlocks(deps.publicGatewayUrl, inbox?.orgSlug ?? null));
   }
@@ -585,42 +453,6 @@ async function buildSlackHomeBlocks(
   });
 
   return blocks;
-}
-
-// Resolve the agent's integrations plus this user's connection status. The
-// Slack user id is the credential scope key (home-tab connect is per-user).
-async function loadIntegrationStatusesScoped(
-  agentId: string,
-  userId: string,
-	organizationId: string | undefined,
-	deps: SlackAppHomeDeps,
-): Promise<IntegrationStatus[]> {
-  const mcpConfigService = deps.mcpConfigService;
-  if (!mcpConfigService) return [];
-  const statuses = (await mcpConfigService.getMcpStatus(agentId)).filter(
-		(s) => !HIDDEN_HOME_INTEGRATION_IDS.has(s.id),
-  );
-  const result: IntegrationStatus[] = [];
-  for (const s of statuses) {
-    let connected = false;
-		const secretStore = deps.secretStore;
-		if (s.requiresAuth && secretStore) {
-      try {
-				connected = !!(await runWithOrganizationContext(organizationId, () =>
-					getStoredCredential(secretStore, agentId, userId, s.id),
-        ));
-      } catch {
-        connected = false;
-      }
-    }
-    result.push({
-      id: s.id,
-      name: humanizeIntegrationName(s.name || s.id),
-      requiresAuth: s.requiresAuth,
-      connected,
-    });
-  }
-  return result;
 }
 
 /** Extract something useful out of a Slack `WebAPIPlatformError` (or anything). */
@@ -681,75 +513,12 @@ async function publishHome(
 }
 
 /**
- * Guard against a crafted `block_actions` payload pointing at an MCP the agent
- * doesn't actually have configured. Connect already validates implicitly (a
- * missing `getHttpServer` is a no-op); this keeps Disconnect from issuing a
- * `secretStore.delete` with an attacker-supplied key string.
- */
-async function isKnownIntegration(
-  agentId: string,
-  mcpId: string,
-	deps: SlackAppHomeDeps,
-): Promise<boolean> {
-  if (HIDDEN_HOME_INTEGRATION_IDS.has(mcpId)) return false;
-  const mcpConfigService = deps.mcpConfigService;
-  if (!mcpConfigService) return false;
-  try {
-    const statuses = await mcpConfigService.getMcpStatus(agentId);
-    return statuses.some((s) => s.id === mcpId);
-  } catch {
-    return false;
-  }
-}
-
-async function startMcpConnectFlow(params: {
-  connection: PlatformConnection;
-  deps: SlackAppHomeDeps;
-  agentId: string;
-  userId: string;
-  mcpId: string;
-  teamId?: string;
-}): Promise<string | null> {
-  const { connection, deps, agentId, userId, mcpId, teamId } = params;
-  const mcpConfigService = deps.mcpConfigService;
-  if (!mcpConfigService || !deps.secretStore || !deps.publicGatewayUrl) {
-    return null;
-  }
-  const httpServer = await mcpConfigService.getHttpServer(mcpId, agentId);
-  if (!httpServer) return null;
-  const organizationId = connection.organizationId;
-  if (!organizationId) return null;
-  const redirectUri = `${deps.publicGatewayUrl.replace(/\/+$/, "")}/mcp/oauth/callback`;
-  const { authorizationUrl } = await startAuthCodeFlow({
-    secretStore: deps.secretStore,
-    mcpId,
-    upstreamUrl: httpServer.upstreamUrl,
-    agentId,
-    userId,
-		organizationId,
-    // Home-tab connect is always per-user.
-    scopeKey: userId,
-    wwwAuthenticate: null,
-    redirectUri,
-    staticOauth: httpServer.oauth,
-    platform: "slack",
-    channelId: userId,
-    conversationId: userId,
-    teamId,
-    connectionId: connection.id,
-  });
-  return authorizationUrl;
-}
-
-/**
- * Publish the Slack App Home tab and wire its Connect / Disconnect buttons.
+ * Publish the Slack App Home tab when a user opens it.
  *
- * The home view lists the integrations the owning agent can use, with a live
- * per-user status: `Disconnect` for ones the user has authorised, `Connect`
- * for the rest. `Connect` runs the MCP OAuth auth-code flow and re-publishes
- * the home tab with an `Open sign-in ↗` link; `Disconnect` revokes the stored
- * credential. Skipped for preview workspaces and when the MCP config / secret
- * store aren't available.
+ * The home view shows the bot intro, the user's personal notification inbox
+ * (when they've linked a Lobu identity), the org dashboard card with recent
+ * activity, and a preview-workspace setup prompt. It re-renders on every
+ * `app_home_opened` event.
  */
 export function registerSlackAppHome(
   chat: any,
@@ -767,71 +536,6 @@ export function registerSlackAppHome(
       userId: event.userId,
     });
   });
-
-  chat.onAction(
-    [HOME_ACTION_CONNECT, HOME_ACTION_DISCONNECT],
-    async (event: SlackActionEvent) => {
-      const mcpId = event.value;
-      const userId = event.user?.userId;
-      const agentId = connection.agentId;
-      if (!mcpId || !userId || !agentId) return;
-      // `mcpId` comes from the (Slack-signed) button payload, but only the
-      // button labels are ours — reject anything not in the agent's config.
-      if (!(await isKnownIntegration(agentId, mcpId, deps))) {
-        logger.warn(
-          { agentId, userId, mcpId, actionId: event.actionId },
-					"Ignoring Slack home action for an unknown integration",
-        );
-        return;
-      }
-
-      if (event.actionId === HOME_ACTION_DISCONNECT) {
-				const secretStore = deps.secretStore;
-				if (secretStore) {
-          try {
-						await runWithOrganizationContext(connection.organizationId, () =>
-							deleteCredential(secretStore, agentId, userId, mcpId),
-						);
-          } catch (error) {
-            logger.warn(
-              { error, agentId, userId, mcpId },
-							"Failed to disconnect MCP credential from Slack home tab",
-            );
-          }
-        }
-				await publishHome(deps.adapter ?? event.adapter, {
-					connection,
-					deps,
-					userId,
-				});
-        return;
-      }
-
-      // Connect: mint an authorization URL, then re-publish with the link.
-      let authorizationUrl: string | null = null;
-      try {
-        authorizationUrl = await startMcpConnectFlow({
-          connection,
-          deps,
-          agentId,
-          userId,
-          mcpId,
-          teamId: teamIdFromRawPayload(event.raw),
-        });
-      } catch (error) {
-        logger.warn(
-          { error, agentId, userId, mcpId },
-					"Failed to start MCP OAuth flow from Slack home tab",
-        );
-      }
-      await publishHome(deps.adapter ?? event.adapter, {
-        connection,
-        deps,
-        userId,
-        pendingAuthUrls: authorizationUrl ? { [mcpId]: authorizationUrl } : {},
-      });
-		},
-  );
 }
 
 export function parseSlackTeamJoinEvent(


### PR DESCRIPTION
## Summary
Follow-up to #1614. With agent-level MCP servers removed, `McpConfigService` only ever surfaces the internal `lobu-memory` server, which the Slack App Home explicitly hides. That made the home-tab integrations UI unreachable:

- `getMcpStatus()` returns only `lobu-memory`, filtered out by `HIDDEN_HOME_INTEGRATION_IDS` → the integrations section always rendered "_No integrations connected yet._" and never drew a Connect button.
- Even a crafted/replayed Slack button payload is rejected: `isKnownIntegration()` returns false for `lobu-memory` and requires any other `mcpId` to be in `getMcpStatus()` (only the hidden one) → the `HOME_ACTION_CONNECT`/`DISCONNECT` handler always early-returned before `startMcpConnectFlow`.

## Changes
- Remove `startMcpConnectFlow`, `isKnownIntegration`, the Connect/Disconnect `chat.onAction` handler, `integrationSection`/`IntegrationStatus`, `loadIntegrationStatusesScoped`, `HIDDEN_HOME_INTEGRATION_IDS`, `humanizeIntegrationName`, `teamIdFromRawPayload`, the integrations block in `buildSlackHomeBlocks`, and the `SlackActionEvent` type.
- Drop the now-unused `mcpConfigService`/`secretStore` home deps and their wiring in `chat-instance-manager.ts`.
- Trim the dead OAuth/credential imports.
- Update the affected tests (remove the connect/disconnect/connect-mint tests; keep intro, dashboard, recent-activity, notifications, preview-setup coverage).

The home tab keeps its intro, notification inbox, dashboard card, recent activity, and preview setup prompt. `getHttpServer`/`getAllHttpServers` stay — the MCP proxy still uses them to serve `lobu-memory`.

## Validation
- `packages/server` `tsc --noEmit` clean
- `bun test slack-platform-bridge.test.ts` (16 pass) + `device-auth.test.ts` (1 pass)
- Net: +10 / -512 across 3 files, no dangling references

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785350025&installation_id=136316292&pr_number=1615&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1615&signature=77a6bed963f3881c3f6c6771683c72216ad32e3a8eb463f08a3cf746049c8457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Slack App Home to provide a richer experience including bot intro, notifications, dashboard/recent context, and a preview-workspace setup prompt.
  * Home tab deep links now use the public gateway URL for improved navigation.

* **Bug Fixes**
  * Improved Slack App Home rendering by relying on default resolvers when optional configuration isn’t available.

* **Documentation**
  * Refreshed the getting-started configuration example to clarify `lobu.config.ts` as the source of truth and update allowed domains.

* **Tests**
  * Reshaped Slack platform-bridge App Home test coverage to match the updated home flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the dead MCP integration UI from the Slack App Home tab, following the removal of agent-level MCP servers in #1614. Because `McpConfigService` now only surfaces `lobu-memory`, which is always hidden by `HIDDEN_HOME_INTEGRATION_IDS`, the integrations section was permanently stuck at "_No integrations connected yet._" and the Connect/Disconnect button handlers always early-returned — making the entire feature unreachable.

- Deletes ~500 lines from `slack-platform-bridge.ts`: `startMcpConnectFlow`, `isKnownIntegration`, `integrationSection`, `loadIntegrationStatusesScoped`, both action handlers, and their supporting types/constants.
- Drops `mcpConfigService` and `secretStore` from `registerSlackAppHome`'s deps interface and from the wiring in `chat-instance-manager.ts`; cleans up the related test coverage for connect/disconnect/connect-mint flows.
- Removes `oauth?: undefined`, `inputs?: undefined`, `headers?: undefined`, and `authScope?: undefined` discriminant fields from `HttpMcpServerConfig` in `config-service.ts` since they were only needed to type-narrow the OAuth path that is now gone.

<h3>Confidence Score: 5/5</h3>

Safe to merge — removes only dead UI code that was already unreachable at runtime; no functional paths change.

Every deleted function was already a no-op: getMcpStatus returned only lobu-memory, which the HIDDEN_HOME_INTEGRATION_IDS filter immediately discarded, so the integrations section never rendered. The action handlers similarly always early-returned because isKnownIntegration had nothing to match. The remaining home tab (intro, notifications, dashboard, recent activity, setup prompt) is untouched and all 16 tests pass. Docs and config-service changes are narrowly scoped and correct.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/server/src/gateway/connections/slack-platform-bridge.ts | Removes all MCP OAuth connect/disconnect logic, action handlers, and integration UI blocks; the remaining home tab (intro, notifications, dashboard, recent activity, setup prompt) is intact and correctly wired. |
| packages/server/src/gateway/connections/chat-instance-manager.ts | Drops mcpConfigService and secretStore from the registerSlackAppHome call site — consistent with the removed deps fields in SlackAppHomeDeps. |
| packages/server/src/gateway/auth/mcp/config-service.ts | Removes four ?: undefined discriminant fields from HttpMcpServerConfig; getMcpStatus / getHttpServer / getAllHttpServers are retained for the MCP proxy path. |
| packages/server/src/gateway/__tests__/slack-platform-bridge.test.ts | Removes the connect/disconnect/oauth-mint test cases and their supporting mocks; remaining test coverage (intro, dashboard, recent activity, notifications, preview setup) is clean. |
| packages/landing/src/content/docs/getting-started/index.mdx | Removes the reference to adding a GitHub MCP server from the config table example and replaces 'MCP servers' with 'connectors' in the prose — aligns docs with the new architecture. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[app_home_opened event] --> B[registerSlackAppHome]
    B --> C[publishHome]
    C --> D[buildSlackHomeBlocks]
    D --> E[Bot intro block]
    E --> F{resolveUserInbox?}
    F -->|yes| G[notificationBlocks]
    F -->|no| H{isPreview?}
    G --> H
    H -->|no| I[resolveHomeContext]
    I --> J[dashboardBlocks]
    J --> K[recentBlocks]
    K --> L[Tips block]
    H -->|yes| M[setupBlocks]
    M --> L

    subgraph REMOVED["Removed - was dead code"]
        direction LR
        R1[onAction handler CONNECT / DISCONNECT]
        R2[loadIntegrationStatusesScoped]
        R3[isKnownIntegration]
        R4[startMcpConnectFlow]
        R5[integrationSection blocks]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[app_home_opened event] --> B[registerSlackAppHome]
    B --> C[publishHome]
    C --> D[buildSlackHomeBlocks]
    D --> E[Bot intro block]
    E --> F{resolveUserInbox?}
    F -->|yes| G[notificationBlocks]
    F -->|no| H{isPreview?}
    G --> H
    H -->|no| I[resolveHomeContext]
    I --> J[dashboardBlocks]
    J --> K[recentBlocks]
    K --> L[Tips block]
    H -->|yes| M[setupBlocks]
    M --> L

    subgraph REMOVED["Removed - was dead code"]
        direction LR
        R1[onAction handler CONNECT / DISCONNECT]
        R2[loadIntegrationStatusesScoped]
        R3[isKnownIntegration]
        R4[startMcpConnectFlow]
        R5[integrationSection blocks]
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore: drop config-service oauth shim fi..."](https://github.com/lobu-ai/lobu/commit/f4da1542b0d169fa4072e7cee578178cfeac29b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40602350)</sub>

<!-- /greptile_comment -->