### PR TITLE
docs: connector authorization & data attribution model (RFC)

### DIFF
--- a/docs/plans/authz-acl-permission-program.md
+++ b/docs/plans/authz-acl-permission-program.md
@@ -1,5 +1,11 @@
 # Authorization / ACL — finalized architecture
 
+> **Related design docs:** connector authorization & data attribution model →
+> [`connector-authz-model.md`](connector-authz-model.md) (org backbone + ACL gate +
+> per-user overlay, decisions D1–D5). The **closed** enterprise IdP layer (SAML/SCIM/
+> enforced SSO/IdP-group federation, D6–D8) is speced in the `owletto` repo at
+> `docs/enterprise-idp-rfc.md` — intentionally kept out of OSS core.
+
 **Status: FINALIZED (decisions locked via interview; pi-reviewed — 7 correctness
 fixes folded in: two-sided `user ∩ agent` gate, explicit `deny_read`, ACL-expr →
 effective principals, freshness-inside-gate, team-scoped Slack ids, fail-closed

--- a/docs/plans/connector-authz-model.md
+++ b/docs/plans/connector-authz-model.md
@@ -171,6 +171,21 @@ Ordered by how much they threaten the stated requirements.
 - **D5 — First source: GitHub.** Repo-collaborator ACL sync already exists; resource = repo;
   GitHub App = clean org backbone. Lowest new work, best end-to-end proof of P2.
 
+### Identity & login — what ships today (no enterprise layer needed)
+
+The D1 identity link works on the OSS path now: better-auth `genericOAuth` + built-in
+`socialProviders`, credential-resolved **per org** (an org can use its own OAuth app). So
+"log in with your company Google/GSuite (or GitHub, or any OIDC provider) and see only your
+data" works today — the access decision uses the user's *verified* login identity + the
+**source's own ACL** (GitHub collaborators, Slack channels). No SCIM or directory sync is
+required for a connector vertical.
+
+The enterprise identity layer — SAML, SCIM provisioning, enforced/domain-routed SSO, and
+IdP-group→access federation — is intentionally **kept out of this OSS core** and speced
+separately as a closed layer (owletto `docs/enterprise-idp-rfc.md`). It plugs in via the
+existing seams (the better-auth `plugins` array + the authz `sources.ts` registry) without
+forking core, and is additive — verticals ship on the path above first.
+
 ### Implied next steps
 1. GitHub P2 vertical: org-App backbone connection + confirm repo ACL sync feeds the gate +
    connector stamps repo resource id (per the authz program, mostly wiring an existing path).

--- a/docs/plans/connector-authz-model.md
+++ b/docs/plans/connector-authz-model.md
@@ -1,0 +1,144 @@
+# Connector authorization & data attribution model
+
+Status: design / RFC. Builds on `authz-acl-permission-program.md` (the access-graph
+engine + fail-closed resource-visibility gate, already live for Slack + GitHub) and
+`feeds-and-connections-model.md`.
+
+## Problem
+
+For team/work tools (Jira, Linear, GitHub, Slack), we have to decide how a connector
+is authorized and how its data is attributed to users:
+
+- **Per-user**: each user authorizes their own account; we only ever see their slice.
+  Simple permissions, but no shared picture and no cross-user reasoning.
+- **Org scrape + attribute**: an admin connects once, we ingest the full picture, and
+  each user only sees the subset they're allowed to see in the source tool.
+
+Decided requirements (from product):
+
+1. The agent must answer **both** personal ("my tickets") and org-wide ("sprint status,
+   who's blocked") questions.
+2. Setup is **admin once, with optional per-user** connections layered on.
+3. Visibility is a **strict mirror, fail-closed** of the source tool's own permissions.
+4. Whether we need data the admin token can't see (private/restricted) is **undecided**.
+
+## How Claude / ChatGPT connectors do it (reference point)
+
+They use **pure per-user OAuth + live retrieval**. You add a connector, authorize it with
+your own account, and at query time the model calls the remote MCP server **with your
+token**. Access is **delegated to the source** — you see exactly what your token can see,
+enforced by Jira/GitHub, not by the assistant. There is **no central scrape**, so there is
+**nothing to attribute**: every request already runs as the asking user.
+
+The cost of that simplicity is exactly the capability Lobu exists to provide: a shared,
+persistent, cross-user picture. The moment you keep a central copy you inherit the
+attribution problem Claude designed around. **The ACL mirror is the price of the shared
+corpus** — you cannot have Lobu's shared memory *and* Claude's "no attribution needed."
+
+## Recommended model: org backbone + ACL mirror + per-user overlay
+
+A superset of Claude's model:
+
+- **Ingest (full picture)** — admin installs one connection per source (GitHub App,
+  Jira/Linear OAuth, broad scope). Everything that install can see lands in `events`.
+- **Gate (per-user, fail-closed)** — the existing `authz/*` layer attributes visibility:
+  map each Lobu user → their source identity; sync source membership (repos/projects/teams)
+  on a cron; `resource-visibility` shows an event iff the user is `member_of` its resource;
+  unknown/stale membership → hidden. "Both" falls out for free — org-wide is the same gate
+  for a user whose membership spans the org; "my tickets" is the same gate filtered to one
+  person. One mechanism, not two code paths.
+- **Overlay (optional per-user)** — a user connects their own account to reach what the
+  admin token can't (restricted projects, private repos/DMs). Ingests tagged to them; the
+  gate naturally shows it only to them. This sub-path **is** Claude's model.
+
+### Phasing
+
+- **P1 — per-user (Claude-style).** Per-user connect via `manage_connections` (already
+  returns `connect_url`; the agent sends it in chat). Source-enforced, zero new ACL work.
+  Safe default for any source, and the only viable mode for personal sources (Gmail, bank).
+- **P2 — org backbone + gate, per source.** Admin org connection + an ACL sync + a
+  `sources.ts` entry + the connector stamping the resource id. Per the authz program, a new
+  source is "1 `sources.ts` entry + connector stamp, no gate/engine change."
+- **P3 — per-user overlay for gaps.** Only build per source when a real private-data gap
+  bites (resolves requirement #4: don't speculate).
+
+### In-chat "needs auth" UX
+
+P1: the agent just sends the `connect_url` as a message (no new infra; reliable because
+it's a normal assistant turn). Later: reuse `postLinkButton` (the `oauth` linkType already
+exists and rides owner-routed delivery) for a button affordance. Do **not** reuse
+`status-message:created` (wrong semantics; currently orphaned).
+
+For a **not-logged-in** user the connect step *is* the identity step: the OAuth round-trip
+both authenticates them and links their source identity. An unlinked user has no membership
+→ fail-closed → sees nothing → the agent prompts "sign in here to connect."
+
+## Gaps & open questions
+
+Ordered by how much they threaten the stated requirements.
+
+1. **Identity link in pure-backbone mode (the model's structural hole).** The gate needs an
+   authoritative Lobu-user → source-identity mapping. In backbone mode the user never
+   connects their own account, so there's no OAuth to prove the link. Options: admin-provided
+   mapping (SCIM/CSV), a grant-nothing "verify your GitHub" OAuth, or directory email-match
+   (risky — wrong mapping over-shares). **Must not guess by email.** This is the prerequisite
+   the backbone model doesn't supply on its own.
+
+2. **Granularity mismatch vs "strict mirror" (req #3).** The gate is resource-membership
+   (repo/project). Sources have finer ACLs: issue-level restrictions, Jira field-level
+   security, private comments, confidential issues, draft PRs. Repo/project membership is
+   **coarser than the source**, so a project member could see a restricted issue they
+   couldn't see in Jira — which violates "strict mirror." Either ingest the finer ACL
+   (expensive) or consciously accept coarser-than-source and downgrade the promise to
+   "resource-level mirror."
+
+3. **Derived-data leakage.** Per-event gating is not enough. Summaries, embeddings, entity
+   fields, watcher outputs, and `metric_layer` rollups computed over the full corpus can leak
+   restricted info to a user who can't see the underlying events. Derived/aggregate layers
+   need the same gate (or per-audience computation), or they're a side channel.
+
+4. **Write-back = confused deputy.** Reads can use the backbone, but **actions** (create
+   issue, comment, merge) must run as the user, not the admin token — otherwise the agent
+   performs writes the user isn't allowed to make. Strongly implies the per-user overlay (P3)
+   is required for *writes* even where reads use the backbone. Decide: block writes without
+   per-user creds, or require overlay for any write.
+
+5. **Partial org-wide results.** A user not in every project gets a rollup of only their
+   accessible subset. Does the agent silently return a partial "sprint status," or disclose
+   "limited to what you can access"? Silent truncation is a correctness/trust issue.
+
+6. **Revocation latency.** Membership syncs on a cron (e.g. */15). Between a source-side
+   permission removal and the next sync there's a window. Fail-closed handles *unknown*
+   membership (over-hide, safe) but a freshly-*revoked* user may still see data until resync.
+   Document the SLA; consider event-driven invalidation for high-sensitivity sources.
+
+7. **Concentration of risk.** The org backbone makes a central copy of potentially very
+   sensitive data whose only protection is the gate. A gate bug → mass leak. Minimize ingest
+   scope, encrypt at rest, audit recall. The blast radius is strictly larger than Claude's
+   per-user model.
+
+8. **Sources without an ACL API.** The gate needs a queryable membership/ACL source
+   (GitHub collaborators, `conversations.members`). Webhook/email/CSV feeds expose none →
+   fail-closed (nobody sees anything) or org-wide-visible (violates strict mirror). Per-source
+   decision.
+
+9. **Backbone + overlay dedup.** If both the org backbone and a user's overlay ingest the
+   same resource, events double-count in memory/metrics. Cross-path dedup (different
+   connection sources, same upstream object) is new vs the existing single-path advisory-lock
+   dedup.
+
+10. **Scrape cost/scale.** Full-org history ingest is expensive (storage + embeddings; see
+    prior embed-backfill incidents). May need selective/lazy/recent-window ingest rather than
+    "scrape everything."
+
+11. **"Empty" disambiguation for UX.** The agent should distinguish "empty because you have
+    no access" from "empty because there's no data," to give a useful message (prompt connect
+    vs say nothing found).
+
+## Decisions needed
+
+- D1: Identity-link mechanism for backbone mode (gap #1).
+- D2: Accept resource-level mirror, or invest in sub-resource ACLs (gap #2)?
+- D3: Writes — block without per-user creds, or require overlay (gap #4)?
+- D4: Partial-result disclosure policy (gap #5).
+- D5: First source to take through P2 (GitHub is closest — repo ACL sync already exists).

--- a/docs/plans/connector-authz-model.md
+++ b/docs/plans/connector-authz-model.md
@@ -35,6 +35,21 @@ persistent, cross-user picture. The moment you keep a central copy you inherit t
 attribution problem Claude designed around. **The ACL mirror is the price of the shared
 corpus** — you cannot have Lobu's shared memory *and* Claude's "no attribution needed."
 
+## How Glean / Copilot do it (the org-backbone reference point)
+
+Glean is the canonical "org backbone + ACL mirror" product, and it shows the identity step
+done well: the **admin** connects each source once and Glean crawls everything, mirroring
+each document's **ACL** into the index. The **user logs in once via SSO** — never to the
+individual tools. Identity is **federated from a shared corporate IdP** (Okta/Google/Azure
+AD): the SSO assertion gives an *authoritative, verified* email/subject, and because every
+source sits behind that same IdP, "this user = this Jira accountId = this GitHub SAML
+identity" is a SCIM directory lookup, not a guess. Microsoft Copilot does the same via
+Azure AD/Graph.
+
+Takeaway: requiring users to log into every tool individually is *more* friction than Glean
+and is only necessary when there is **no** shared IdP. "Email match" is risky only when
+*guessed*; from a verified SSO assertion it is authoritative — that is the whole trick.
+
 ## Recommended model: org backbone + ACL mirror + per-user overlay
 
 A superset of Claude's model:
@@ -135,10 +150,32 @@ Ordered by how much they threaten the stated requirements.
     no access" from "empty because there's no data," to give a useful message (prompt connect
     vs say nothing found).
 
-## Decisions needed
+## Decisions made (2026-06-29)
 
-- D1: Identity-link mechanism for backbone mode (gap #1).
-- D2: Accept resource-level mirror, or invest in sub-resource ACLs (gap #2)?
-- D3: Writes — block without per-user creds, or require overlay (gap #4)?
-- D4: Partial-result disclosure policy (gap #5).
-- D5: First source to take through P2 (GitHub is closest — repo ACL sync already exists).
+- **D1 — Identity link: hybrid (IdP-federated + verify-OAuth fallback).** SSO orgs federate
+  identity from the verified SSO assertion + SCIM (Glean-style, login once); no-SSO/personal
+  accounts fall back to one-click per-source verify-OAuth (Claude-style). Authoritative in
+  both modes — never email-guessing. Slots into the existing `$member` identity collapse
+  (`auth:signup` identity).
+- **D2 — ACL fidelity: resource-level, upgrade per source.** Ship repo/project-membership
+  gating now (reuses the engine); tighten to sub-resource only where a source needs it. The
+  promise is "resource-level mirror," tightened per source — not a blanket "exactly matches
+  the source." High-sensitivity sources needing sub-resource fidelity are candidates to stay
+  per-user (Claude-style) instead of joining the backbone.
+- **D3 — Writes: require per-user creds.** Reads may come from the backbone, but any action
+  (create/comment/merge) runs as the user's connected account. No admin-token writes
+  (confused-deputy). Implies the per-user overlay is a prerequisite for write-enabled tools.
+- **D4 — Partial results: disclose when likely incomplete.** The gate must emit a "rows were
+  filtered" signal; the agent flags "limited to what you can access" only when it fires.
+  Requires a filtered-count signal out of `resource-visibility`.
+- **D5 — First source: GitHub.** Repo-collaborator ACL sync already exists; resource = repo;
+  GitHub App = clean org backbone. Lowest new work, best end-to-end proof of P2.
+
+### Implied next steps
+1. GitHub P2 vertical: org-App backbone connection + confirm repo ACL sync feeds the gate +
+   connector stamps repo resource id (per the authz program, mostly wiring an existing path).
+2. Identity: SSO/SCIM-federated identity link (D1) + verify-OAuth fallback; map onto `$member`.
+3. Gate signal for D4 (filtered-count) surfaced to the worker for disclosure.
+4. Write path (D3): per-user-cred requirement enforced at the connector-operation layer.
+5. Derived-data gating (gap #3) and backbone/overlay dedup (gap #9) before scaling beyond
+   one source.


### PR DESCRIPTION
RFC for how work-tool connectors (Jira/Linear/GitHub) are authorized and how their data is attributed per user.

- Frames the two naive models (per-user vs org-scrape-and-attribute) and why each alone fails the product requirements (answer both personal + org-wide; admin + optional per-user setup; strict fail-closed mirror).
- Contrasts with how Claude/ChatGPT connectors work (pure per-user OAuth + live retrieval, source-enforced, no central scrape → no attribution) and why Lobu can't just copy it without giving up shared memory.
- Recommends **org backbone + ACL-mirror gate + optional per-user overlay** (a superset of Claude's model), reusing the already-merged `authz/*` engine, phased: per-user first → org backbone+gate per source → overlay for private gaps.
- **Gaps & open questions** section: identity link in backbone mode, ACL granularity vs strict-mirror, derived-data leakage, write-back confused-deputy, partial-result disclosure, revocation latency, concentration-of-risk, sources without ACL APIs, backbone/overlay dedup, scrape cost.

Doc only — no code. References `authz-acl-permission-program.md` and `feeds-and-connections-model.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785360705&installation_id=136316292&pr_number=1619&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1619&signature=19ff7722adc408203363747a376bf1b418300776eab8ed5383d4445f6d238d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the design document with a more concrete, time-stamped authorization and data attribution model.
  * Defines a hybrid identity-link approach, resource-level ACL mirroring, and per-user credential enforcement for write operations.
  * Specifies disclosure of likely-incomplete partial organization results via a filtered-count signal.
  * Selects GitHub as the first Phase 2 connector and adds implied next steps, including initial wiring and derived-data gating guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new design document (`docs/plans/connector-authz-model.md`) that serves as an RFC for how work-tool connectors (Jira, Linear, GitHub) are authorized and how their data is attributed per user. The document recommends an "org backbone + ACL mirror + optional per-user overlay" model as a superset of Claude/ChatGPT's per-user approach, building on the already-finalized `authz-acl-permission-program.md`.

- Frames the problem space with two naive models and their trade-offs, references Glean/Copilot as the org-backbone archetype, and recommends a three-layer architecture (ingest → gate → optional overlay) phased as P1/P2/P3.
- Enumerates 11 gaps/open questions, followed by a \"Decisions made\" section (D1–D5, dated 2026-06-29) that closes out the most critical gaps; D5 names GitHub as the first P2 backbone source.
- Gaps 2, 4, and 5 remain listed as open questions despite being answered by D2, D3, and D4 in the same document — adding back-references would prevent re-litigation.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no code; safe to merge.

The change is a single new markdown file with no executable code. The architectural reasoning is sound and the 'Decisions made' section provides concrete closure on the major open questions. The only notable issue is that several gaps in the middle of the document are answered by decisions later in the same document without explicit cross-references, which could mislead implementers — but this does not block merging.

No files require special attention; the internal cross-reference gap between the 'Gaps' and 'Decisions made' sections is the only item worth a follow-up edit.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/plans/connector-authz-model.md | New RFC documenting the connector authorization and data attribution model; doc-only, no code changes. Well-structured with clear phasing, comparison references, and a decisions section. A few gaps remain that are resolved within the document itself without cross-references. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User query] --> B{User identity linked?}
    B -- No --> C[fail-closed: sees nothing\nagent prompts connect_url]
    B -- Yes --> D{Backbone mode?}

    D -- P1 per-user --> E[Per-user OAuth token\nsource-enforced access\nlive retrieval]
    E --> F[Return results]

    D -- P2 backbone --> G[Admin org connection\nfull corpus in events]
    G --> H[authz gate\nresource-visibility SQL]
    H --> I{freshness_state = fresh?}
    I -- No / stale --> J[DENY — fail-closed]
    I -- Yes --> K{user member_of resource?}
    K -- No --> J
    K -- Yes --> L[Visible events]
    L --> M{Write action?}
    M -- Yes --> N{Per-user creds present?\nP3 overlay}
    N -- No --> O[Block write — D3]
    N -- Yes --> F
    M -- No --> P{filtered rows > 0?}
    P -- Yes --> Q[Disclose partial results — D4]
    P -- No --> F
    Q --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User query] --> B{User identity linked?}
    B -- No --> C[fail-closed: sees nothing\nagent prompts connect_url]
    B -- Yes --> D{Backbone mode?}

    D -- P1 per-user --> E[Per-user OAuth token\nsource-enforced access\nlive retrieval]
    E --> F[Return results]

    D -- P2 backbone --> G[Admin org connection\nfull corpus in events]
    G --> H[authz gate\nresource-visibility SQL]
    H --> I{freshness_state = fresh?}
    I -- No / stale --> J[DENY — fail-closed]
    I -- Yes --> K{user member_of resource?}
    K -- No --> J
    K -- Yes --> L[Visible events]
    L --> M{Write action?}
    M -- Yes --> N{Per-user creds present?\nP3 overlay}
    N -- No --> O[Block write — D3]
    N -- Yes --> F
    M -- No --> P{filtered rows > 0?}
    P -- Yes --> Q[Disclose partial results — D4]
    P -- No --> F
    Q --> F
```

</a>

<sub>Reviews (2): Last reviewed commit: ["docs: record connector-authz decisions (..."](https://github.com/lobu-ai/lobu/commit/3d974388bce37036817c4b39823e6fe7d2a31959) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40649256)</sub>

<!-- /greptile_comment -->