### PR TITLE
docs(browser-testing): driving the paired Owletto extension via operations.execute

### DIFF
--- a/docs/BROWSER_TESTING.md
+++ b/docs/BROWSER_TESTING.md
@@ -52,3 +52,32 @@ agent-browser --session lobu-verify click @e13        # interact
 agent-browser --session lobu-verify screenshot --full /tmp/out.png
 agent-browser --session lobu-verify close
 ```
+
+## Driving the paired Owletto extension (connector debugging)
+
+The cookie-forging above and `claude-in-chrome` both drive a *separate* browser that lacks the user's real logged-in sessions — Revolut, for instance, redirects them to `sso.revolut.com/signin`. To run JS or browser actions in the **paired Owletto extension** (the Chrome that holds the user's live sessions, which is what extension-scrape connectors like Revolut/LinkedIn use), go through the connector-operations bridge instead. No deploy required.
+
+`lobu connector run` is the wrong tool here — it only does local Playwright/CDP against a `browser_session` auth profile, so it errors `Missing --auth-profile` for device-worker connectors (Revolut has no auth profile). Use the SDK `operations` namespace via `lobu memory exec` / `run_sdk`:
+
+```js
+// chrome connection id: client.connections.list() → connector_key 'chrome'
+const ops = await client.operations.listAvailable({ connection_id: CHROME_CONN_ID });
+// navigate opens a fresh background tab in the paired Chrome and returns tab_id
+const nav = await client.operations.execute({
+  connection_id: CHROME_CONN_ID, operation_key: 'navigate',
+  input: { url: 'https://app.revolut.com/transactions', open_in_new_tab: true, wait_for_load: true },
+});
+// evaluate runs arbitrary JS on that tab and returns the JSON-serialised result
+await client.operations.execute({
+  connection_id: CHROME_CONN_ID, operation_key: 'evaluate',
+  input: { tab_id: nav.output.tab_id, expression: '(async()=>{ /* read DOM */ return out })()', await_promise: true },
+});
+```
+
+`operations.execute` → `dispatchChromeActionToExtension` (`worker-api/dispatch-chrome-action.ts`) → device-worker queue → the paired extension — the same bridge the office-bot Deliveroo connector uses. Chrome ops: `navigate`, `evaluate`, `get_accessibility_tree`, `wait_for_selector`, `click_ref`, `type_ref`, `screenshot`, `show_notification`, `network_intercept_*`, `close_tab`.
+
+Gotchas:
+- `search_sdk` does **not** surface the `operations` namespace (nor several others). Discover the real surface with `Object.keys(client)` inside a `run_sdk` script.
+- Sessions that re-auth often (Revolut, ~hourly) must be freshly logged in *in the paired Chrome* right before you navigate+evaluate, or the fresh tab redirects to the sign-in wall.
+- Per-call dispatch latency is 5–60s and virtualized lists recycle content out — for paginated scrapes, iterate inside the connector's own run, not via one-shot `evaluate`s.
+- **Connector-side changes ship via re-apply, not the app release.** Per-org connectors (`examples/personal-agent`) live in `connector_definitions`/`connector_versions` and only update on `lobu apply` (or `connections.installConnector` for a single bundle). An app deploy that adds a *capability* (e.g. `show_notification`) does nothing until the connector that *calls* it is re-applied. **And a new chrome action also needs the matching handler in the extension build** — dispatching `show_notification` to an older installed extension fails with `Owletto for Chrome: unknown dispatch ... action_key='show_notification'`. So three things gate such a notification: an up-to-date extension build (the handler), a re-applied connector (the call), and macOS notification permission on the extension.


### PR DESCRIPTION
Adds a 'Driving the paired Owletto extension (connector debugging)' section to docs/BROWSER_TESTING.md — how to run JS/browser actions in the user's paired Owletto extension (the one with live logged-in sessions like Revolut) via the SDK `operations` namespace, vs the cookie-forged agent-browser / claude-in-chrome paths that lack those sessions. Captures the `operations.execute` recipe, the `dispatchChromeActionToExtension` bridge, and the gotchas surfaced this session (search_sdk hides `operations`; short-lived sessions; 5-60s dispatch latency; connector re-apply + extension-build handler requirements for new chrome actions). Docs-only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785371912&installation_id=136316292&pr_number=1627&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1627&signature=6da9a42b39441bda73c7f8fbd40f058e46090393e0bd8bb1facce5d4c18de86e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->