### PR TITLE
feat(contacts): signal-gate person autoCreate + seed metric aliases on create

### DIFF
--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -547,12 +547,42 @@ export interface EntityLinkRule {
    * When false, unmatched events stay unlinked and no entity is created.
    */
   autoCreate?: boolean;
+  /**
+   * Gate `autoCreate` on a per-event signal. Matching an EXISTING entity is
+   * unaffected; this only decides whether a NEW entity is minted on a miss.
+   * Omitted → create whenever `autoCreate` is true (the historical behavior).
+   *
+   * Lets a connector ingest every event into `entity_identities` aliases but
+   * only materialize a typed entity for senders that clear an interaction bar —
+   * e.g. WhatsApp mints a `person` only for 1:1 chats
+   * (`{ path: 'metadata.is_group', equals: false }`), never for the group flood.
+   */
+  createWhen?: EntityLinkPredicate;
   /** Dot path used for `entities.name` on create. */
   titlePath?: string;
   /** Identifier specs. At least one is required. */
   identities: EntityIdentitySpec[];
   /** Optional descriptive fields written to entities.metadata. */
   traits?: Record<string, EntityTraitSpec>;
+}
+
+/**
+ * A small, JSON-serializable predicate evaluated against the ingested event
+ * item (`{ metadata, title, origin_type }`) to gate `autoCreate`. All declared
+ * conditions are ANDed; an omitted condition is ignored. `path` is a dot-path
+ * resolved the same way as identity `eventPath` (e.g. `metadata.is_group`).
+ * Deliberately closed — no expressions, no SQL — so it stays cheap to evaluate
+ * inline at ingest and safe to persist as untrusted JSON in an install override.
+ */
+export interface EntityLinkPredicate {
+  /** Dot-path into the event item, e.g. `metadata.is_group`. */
+  path: string;
+  /** Create only when the value strictly equals this (`===`). */
+  equals?: string | number | boolean;
+  /** Create only when the value does NOT strictly equal this. */
+  notEquals?: string | number | boolean;
+  /** `true` → value must be present (not null/undefined/`''`); `false` → must be absent. */
+  exists?: boolean;
 }
 
 /**
@@ -572,6 +602,11 @@ export interface EntityLinkOverride {
   retargetEntityType?: string;
   /** Override autoCreate on the matched rule. */
   autoCreate?: boolean;
+  /**
+   * Override the createWhen gate on the matched rule. `null` clears it (mint on
+   * every miss); an object replaces it. Omitted leaves the connector's gate.
+   */
+  createWhen?: EntityLinkPredicate | null;
   /** Filter out identity specs by namespace before matching/persisting. */
   maskIdentities?: string[];
 }

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -65,6 +65,7 @@ export type {
   EntityIdentitySpec,
   EntityLinkOverride,
   EntityLinkOverrides,
+  EntityLinkPredicate,
   EntityLinkRule,
   EntityTraitSpec,
   EventEnvelope,

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -146,7 +146,14 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
             entityLinks: [
               {
                 entityType: 'person',
-                autoCreate: true,
+                // Don't mint a contact per inbound sender. Every from-address is a
+                // sender — overwhelmingly brands, newsletters, and no-reply system
+                // addresses, all of which carry a from_name, so no per-event signal
+                // separates a real contact from a brand. The identifier still lands
+                // in entity_identities and links to an existing contact on match;
+                // promoting a real email contact is interaction-driven (a reply /
+                // contacts-source bridge), handled outside ingest.
+                autoCreate: false,
                 titlePath: 'metadata.from_name',
                 identities: [{ namespace: IDENTITY.EMAIL, eventPath: 'metadata.from_email' }],
                 traits: {

--- a/packages/connectors/src/whatsapp.ts
+++ b/packages/connectors/src/whatsapp.ts
@@ -179,6 +179,12 @@ export default class WhatsAppConnector extends ConnectorRuntime {
               {
                 entityType: 'person',
                 autoCreate: true,
+                // Only mint a contact for 1:1 chats. Group messages still link to
+                // a contact if one already exists, but the group-member flood
+                // (hundreds of @lid senders you've never spoken to 1:1) never
+                // materializes a `person` row. Outbound messages carry no
+                // sender_jid, so they produce no identity and no-op here too.
+                createWhen: { path: 'metadata.is_group', equals: false },
                 titlePath: 'metadata.push_name',
                 identities: [
                   { namespace: IDENTITY.WA_JID, eventPath: 'metadata.sender_jid' },

--- a/packages/connectors/src/whatsapp_local.ts
+++ b/packages/connectors/src/whatsapp_local.ts
@@ -89,6 +89,12 @@ export default class WhatsAppLocalConnector extends BridgeOnlyConnector {
               {
                 entityType: 'person',
                 autoCreate: true,
+                // Only mint a contact for 1:1 chats. Group messages still link to
+                // a contact if one already exists, but the group-member flood
+                // (hundreds of @lid senders you've never spoken to 1:1) never
+                // materializes a `person` row. Outbound messages carry no
+                // sender_jid, so they produce no identity and no-op here too.
+                createWhen: { path: 'metadata.is_group', equals: false },
                 titlePath: 'metadata.push_name',
                 identities: [
                   { namespace: IDENTITY.WA_JID, eventPath: 'metadata.sender_jid' },

--- a/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
+++ b/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
@@ -562,6 +562,62 @@ describe('applyEntityLinks', () => {
     ]);
   });
 
+  it('backfills metadata.aliases on a normal match for a legacy entity that has none', async () => {
+    const { org, user } = await setupOrg('aliases-backfill org');
+    const sql = getTestDb();
+
+    // Legacy entity: has the identity row but NO aliases key in metadata (created
+    // by the pre-aliases path). A plain matching message must repair it.
+    const [{ id: entityId }] = await sql<{ id: number | string }[]>`
+      INSERT INTO entities (organization_id, entity_type_id, name, slug, metadata, created_by)
+      VALUES (
+        ${org.id},
+        (SELECT id FROM entity_types WHERE slug = '$member' AND organization_id = ${org.id} AND deleted_at IS NULL),
+        'Rob', 'member-legacy', '{"push_name":"Rob"}'::jsonb, ${user.id}
+      )
+      RETURNING id
+    `;
+    await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+      VALUES (${org.id}, ${Number(entityId)}, 'wa_jid', '14155551234@s.whatsapp.net', 'seed')
+    `;
+
+    await installRule(org.id, 'whatsapp', 'message', {
+      entityType: '$member',
+      autoCreate: true,
+      createWhen: { path: 'metadata.is_group', equals: false },
+      identities: [
+        { namespace: 'wa_jid', eventPath: 'metadata.sender_jid' },
+        { namespace: 'phone', eventPath: 'metadata.sender_phone' },
+      ],
+    });
+
+    await applyEntityLinks({
+      connectorKey: 'whatsapp',
+      feedKey: FEED_KEY,
+      orgId: org.id,
+      items: [
+        {
+          origin_type: 'message',
+          metadata: {
+            sender_jid: '14155551234@s.whatsapp.net',
+            sender_phone: '14155551234',
+            is_group: false,
+          },
+        },
+      ],
+    });
+
+    const rows = await sql<{ metadata: { aliases?: string[] } }[]>`
+      SELECT metadata FROM entities WHERE id = ${Number(entityId)}
+    `;
+    // The matched-on wa_jid AND the newly-accreted phone are both repaired in.
+    expect([...(rows[0].metadata.aliases ?? [])].sort()).toEqual([
+      '14155551234',
+      '14155551234@s.whatsapp.net',
+    ]);
+  });
+
   it('resolveEntityLinksForItems writes through the passed transaction handle', async () => {
     const { org } = await setupOrg('tx-threaded org');
     const sql = getTestDb();

--- a/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
+++ b/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
@@ -372,6 +372,196 @@ describe('applyEntityLinks', () => {
     expect(winner[0].metadata.push_name).toBe('Casey');
   });
 
+  it('createWhen gates auto-create: group message mints nothing, 1:1 mints a contact', async () => {
+    const { org } = await setupOrg('createWhen gate org');
+    const sql = getTestDb();
+
+    await installRule(org.id, 'whatsapp', 'message', {
+      entityType: '$member',
+      autoCreate: true,
+      createWhen: { path: 'metadata.is_group', equals: false },
+      titlePath: 'metadata.push_name',
+      identities: [{ namespace: 'wa_jid', eventPath: 'metadata.sender_jid' }],
+    });
+
+    await applyEntityLinks({
+      connectorKey: 'whatsapp',
+      feedKey: FEED_KEY,
+      orgId: org.id,
+      items: [
+        // group sender → gated out, no entity
+        {
+          origin_type: 'message',
+          metadata: { sender_jid: '99@lid', is_group: true, push_name: 'Group Member' },
+        },
+        // 1:1 partner → minted
+        {
+          origin_type: 'message',
+          metadata: { sender_jid: '14155551234@s.whatsapp.net', is_group: false, push_name: 'Rob' },
+        },
+      ],
+    });
+
+    const rows = await sql<{ name: string }[]>`
+      SELECT e.name FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.organization_id = ${org.id} AND et.slug = '$member' AND e.deleted_at IS NULL
+    `;
+    expect(rows.map((r) => r.name)).toEqual(['Rob']);
+
+    // The gated-out group sender's identifier is NOT claimed by any entity.
+    const groupIdent = await sql<{ count: string }[]>`
+      SELECT COUNT(*)::text AS count FROM entity_identities
+      WHERE organization_id = ${org.id} AND namespace = 'wa_jid' AND identifier = '99@lid'
+    `;
+    expect(groupIdent[0].count).toBe('0');
+  });
+
+  it('createWhen gates only CREATE: a group message still accretes onto an existing contact', async () => {
+    const { org, user } = await setupOrg('createWhen match org');
+    const sql = getTestDb();
+
+    const [{ id: entityId }] = await sql<{ id: number | string }[]>`
+      INSERT INTO entities (organization_id, entity_type_id, name, slug, metadata, created_by)
+      VALUES (
+        ${org.id},
+        (SELECT id FROM entity_types WHERE slug = '$member' AND organization_id = ${org.id} AND deleted_at IS NULL),
+        'Rob', 'member-rob', '{"aliases":["14155551234@s.whatsapp.net"]}'::jsonb, ${user.id}
+      )
+      RETURNING id
+    `;
+    await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+      VALUES (${org.id}, ${Number(entityId)}, 'wa_jid', '14155551234@s.whatsapp.net', 'seed')
+    `;
+
+    await installRule(org.id, 'whatsapp', 'message', {
+      entityType: '$member',
+      autoCreate: true,
+      createWhen: { path: 'metadata.is_group', equals: false },
+      identities: [
+        { namespace: 'wa_jid', eventPath: 'metadata.sender_jid' },
+        { namespace: 'phone', eventPath: 'metadata.sender_phone' },
+      ],
+    });
+
+    // A GROUP message from the known contact, carrying a new phone identifier.
+    await applyEntityLinks({
+      connectorKey: 'whatsapp',
+      feedKey: FEED_KEY,
+      orgId: org.id,
+      items: [
+        {
+          origin_type: 'message',
+          metadata: {
+            sender_jid: '14155551234@s.whatsapp.net',
+            sender_phone: '14155551234',
+            is_group: true,
+          },
+        },
+      ],
+    });
+
+    // Matched the existing entity (gate doesn't block match) and accreted phone.
+    const idents = await sql<{ namespace: string }[]>`
+      SELECT namespace FROM entity_identities
+      WHERE organization_id = ${org.id} AND entity_id = ${Number(entityId)} ORDER BY namespace
+    `;
+    expect(idents.map((r) => r.namespace)).toEqual(['phone', 'wa_jid']);
+    // No SECOND entity was created from the group message.
+    const count = await sql<{ count: string }[]>`
+      SELECT COUNT(*)::text AS count FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.organization_id = ${org.id} AND et.slug = '$member' AND e.deleted_at IS NULL
+    `;
+    expect(count[0].count).toBe('1');
+  });
+
+  it('seeds metadata.aliases from identifiers on create (metric resolution path)', async () => {
+    const { org } = await setupOrg('aliases-on-create org');
+    const sql = getTestDb();
+
+    await installRule(org.id, 'whatsapp', 'message', {
+      entityType: '$member',
+      autoCreate: true,
+      identities: [
+        { namespace: 'wa_jid', eventPath: 'metadata.sender_jid' },
+        { namespace: 'phone', eventPath: 'metadata.sender_phone' },
+      ],
+    });
+
+    await applyEntityLinks({
+      connectorKey: 'whatsapp',
+      feedKey: FEED_KEY,
+      orgId: org.id,
+      items: [
+        {
+          origin_type: 'message',
+          metadata: { sender_jid: '14155551234@s.whatsapp.net', sender_phone: '+1 (415) 555-1234' },
+        },
+      ],
+    });
+
+    const rows = await sql<{ metadata: { aliases?: string[] } }[]>`
+      SELECT e.metadata FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.organization_id = ${org.id} AND et.slug = '$member' AND e.deleted_at IS NULL
+    `;
+    expect(rows).toHaveLength(1);
+    expect([...(rows[0].metadata.aliases ?? [])].sort()).toEqual([
+      '14155551234',
+      '14155551234@s.whatsapp.net',
+    ]);
+  });
+
+  it('appends a cross-channel identifier to metadata.aliases on accrete', async () => {
+    const { org, user } = await setupOrg('aliases-accrete org');
+    const sql = getTestDb();
+
+    const [{ id: entityId }] = await sql<{ id: number | string }[]>`
+      INSERT INTO entities (organization_id, entity_type_id, name, slug, metadata, created_by)
+      VALUES (
+        ${org.id},
+        (SELECT id FROM entity_types WHERE slug = '$member' AND organization_id = ${org.id} AND deleted_at IS NULL),
+        'Rob', 'member-rob2', '{"aliases":["14155551234@s.whatsapp.net"]}'::jsonb, ${user.id}
+      )
+      RETURNING id
+    `;
+    await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+      VALUES (${org.id}, ${Number(entityId)}, 'wa_jid', '14155551234@s.whatsapp.net', 'seed')
+    `;
+
+    await installRule(org.id, 'whatsapp', 'message', {
+      entityType: '$member',
+      autoCreate: true,
+      identities: [
+        { namespace: 'wa_jid', eventPath: 'metadata.sender_jid' },
+        { namespace: 'phone', eventPath: 'metadata.sender_phone' },
+      ],
+    });
+
+    await applyEntityLinks({
+      connectorKey: 'whatsapp',
+      feedKey: FEED_KEY,
+      orgId: org.id,
+      items: [
+        {
+          origin_type: 'message',
+          metadata: { sender_jid: '14155551234@s.whatsapp.net', sender_phone: '14155551234' },
+        },
+      ],
+    });
+
+    const rows = await sql<{ metadata: { aliases?: string[] } }[]>`
+      SELECT metadata FROM entities WHERE id = ${Number(entityId)}
+    `;
+    expect([...(rows[0].metadata.aliases ?? [])].sort()).toEqual([
+      '14155551234',
+      '14155551234@s.whatsapp.net',
+    ]);
+  });
+
   it('resolveEntityLinksForItems writes through the passed transaction handle', async () => {
     const { org } = await setupOrg('tx-threaded org');
     const sql = getTestDb();

--- a/packages/server/src/utils/__tests__/entity-link-validation.test.ts
+++ b/packages/server/src/utils/__tests__/entity-link-validation.test.ts
@@ -34,6 +34,20 @@ describe('validateEntityLinkOverrides', () => {
         /maskIdentities: must be an array of strings/.test(e)
       )
     ).toBe(true);
+    expect(
+      validateEntityLinkOverrides({ $member: { createWhen: { equals: false } } }).some((e) =>
+        /createWhen: must be null or an object with a string 'path'/.test(e)
+      )
+    ).toBe(true);
+  });
+
+  it('accepts a well-formed createWhen override and null', () => {
+    expect(
+      validateEntityLinkOverrides({
+        $member: { createWhen: { path: 'metadata.is_group', equals: false } },
+        chat_group: { createWhen: null },
+      })
+    ).toEqual([]);
   });
 });
 
@@ -61,5 +75,17 @@ describe('resolveEntityLinkRules', () => {
         $member: { maskIdentities: ['phone', 'email'] },
       })
     ).toEqual([]);
+  });
+
+  it('preserves a connector-declared createWhen through overrides', () => {
+    const gated: EntityLinkRule = { ...baseRule, createWhen: { path: 'metadata.is_group', equals: false } };
+    const [out] = resolveEntityLinkRules([gated], { $member: { autoCreate: false } });
+    expect(out.createWhen).toEqual({ path: 'metadata.is_group', equals: false });
+  });
+
+  it('createWhen: null in an override clears the gate', () => {
+    const gated: EntityLinkRule = { ...baseRule, createWhen: { path: 'metadata.is_group', equals: false } };
+    const [out] = resolveEntityLinkRules([gated], { $member: { createWhen: null } });
+    expect(out.createWhen).toBeUndefined();
   });
 });

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -190,30 +190,40 @@ function passesCreateWhen(predicate: EntityLinkPredicate | undefined, item: Batc
  * flat alias array the metric compiler resolves event fields against
  * (`metadata->'aliases'`). entity_identities serves recall/authz; aliases serve
  * metrics; both must carry a contact's identifiers or its per-entity metrics
- * silently drop. Read-modify-write, only writing when something is missing, so
- * repeat messages from a known sender (no new identifier) cost nothing.
+ * silently drop.
+ *
+ * Done as ONE atomic UPDATE that unions the row's existing aliases with the new
+ * identifiers in SQL — a JS read-modify-write would let concurrent ingests on
+ * the same entity clobber each other's additions. The `@>` guard means the write
+ * is skipped (0 rows) when every identifier is already present, so repeat
+ * messages from a known, fully-aliased sender cost only a PK lookup. Passing the
+ * entity's full identifier set (not just freshly-inserted ones) also repairs a
+ * legacy entity whose `entity_identities` predate aliases-on-create.
  */
 async function ensureAliases(
   sql: DbClient,
   params: { orgId: string; entityId: number; identifiers: string[] }
 ): Promise<void> {
   if (params.identifiers.length === 0) return;
-  const rows = await sql<{ metadata: Record<string, unknown> | null }>`
-    SELECT metadata FROM entities
-    WHERE id = ${params.entityId} AND organization_id = ${params.orgId} AND deleted_at IS NULL
-    LIMIT 1
-  `;
-  if (rows.length === 0) return;
-  const current = rows[0].metadata ?? {};
-  const existing = Array.isArray(current.aliases) ? (current.aliases as unknown[]).map(String) : [];
-  const merged = new Set(existing);
-  for (const id of params.identifiers) merged.add(id);
-  if (merged.size === existing.length) return; // nothing new
-  const next = { ...current, aliases: [...merged] };
   await sql`
     UPDATE entities
-    SET metadata = ${sql.json(next)}, updated_at = current_timestamp
-    WHERE id = ${params.entityId} AND organization_id = ${params.orgId} AND deleted_at IS NULL
+    SET metadata = jsonb_set(
+          COALESCE(metadata, '{}'::jsonb),
+          '{aliases}',
+          (
+            SELECT to_jsonb(array_agg(DISTINCT a))
+            FROM (
+              SELECT jsonb_array_elements_text(COALESCE(metadata->'aliases', '[]'::jsonb)) AS a
+              UNION
+              SELECT unnest(${pgTextArray(params.identifiers)}::text[]) AS a
+            ) u
+          )
+        ),
+        updated_at = current_timestamp
+    WHERE id = ${params.entityId}
+      AND organization_id = ${params.orgId}
+      AND deleted_at IS NULL
+      AND NOT (COALESCE(metadata->'aliases', '[]'::jsonb) @> ${sql.json(params.identifiers)}::jsonb)
   `;
 }
 
@@ -685,16 +695,16 @@ async function resolveLinksByKind(
           identities: link.identities.filter((i) => !i.matchOnly),
         });
         attached = [...fresh];
-        // Mirror only genuinely-new identifiers into metadata.aliases for metric
-        // resolution. A re-insert that ON CONFLICT-skipped returns nothing, so a
-        // repeat message from a known sender does no alias write at all.
-        if (fresh.length > 0) {
-          await ensureAliases(sql, {
-            orgId: params.orgId,
-            entityId,
-            identifiers: fresh.map((a) => a.identifier),
-          });
-        }
+        // Mirror this link's non-matchOnly identifiers into metadata.aliases for
+        // metric resolution. Passing the full set (not just `fresh`) repairs a
+        // legacy entity whose identities predate aliases-on-create; ensureAliases'
+        // `@>` guard makes it a no-op write once the aliases are complete, so a
+        // repeat message from a known sender stays cheap.
+        await ensureAliases(sql, {
+          orgId: params.orgId,
+          entityId,
+          identifiers: link.identities.filter((i) => !i.matchOnly).map((i) => i.identifier),
+        });
         // The matched identifiers themselves are this entity's even if a
         // re-insert was a no-op (they were how we found it), so claim them too.
         for (const id of link.identities) {

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -17,7 +17,11 @@
  */
 
 import { randomBytes } from 'node:crypto';
-import type { EntityLinkOverrides, EntityLinkRule } from '@lobu/connector-sdk';
+import type {
+  EntityLinkOverrides,
+  EntityLinkPredicate,
+  EntityLinkRule,
+} from '@lobu/connector-sdk';
 import { normalizeIdentifier } from '@lobu/connector-sdk';
 import { type DbClient, getDb, pgTextArray } from '../db/client';
 import { resolveEntityLinkRules } from './entity-link-validation';
@@ -162,6 +166,56 @@ type ExtractedLink = {
   traits: Map<string, unknown>;
   title: string;
 };
+
+/**
+ * Evaluate a rule's `createWhen` gate against the event item. Returns true (mint
+ * allowed) when the predicate is absent or every declared condition holds; all
+ * conditions AND together. Only gates the CREATE-on-miss branch — matching an
+ * existing entity is never affected.
+ */
+function passesCreateWhen(predicate: EntityLinkPredicate | undefined, item: BatchItem): boolean {
+  if (!predicate) return true;
+  const value = getValueAtPath(item, predicate.path);
+  if (predicate.equals !== undefined && value !== predicate.equals) return false;
+  if (predicate.notEquals !== undefined && value === predicate.notEquals) return false;
+  if (predicate.exists !== undefined) {
+    const present = value !== undefined && value !== null && value !== '';
+    if (present !== predicate.exists) return false;
+  }
+  return true;
+}
+
+/**
+ * Ensure each identifier value is present in `entities.metadata.aliases` — the
+ * flat alias array the metric compiler resolves event fields against
+ * (`metadata->'aliases'`). entity_identities serves recall/authz; aliases serve
+ * metrics; both must carry a contact's identifiers or its per-entity metrics
+ * silently drop. Read-modify-write, only writing when something is missing, so
+ * repeat messages from a known sender (no new identifier) cost nothing.
+ */
+async function ensureAliases(
+  sql: DbClient,
+  params: { orgId: string; entityId: number; identifiers: string[] }
+): Promise<void> {
+  if (params.identifiers.length === 0) return;
+  const rows = await sql<{ metadata: Record<string, unknown> | null }>`
+    SELECT metadata FROM entities
+    WHERE id = ${params.entityId} AND organization_id = ${params.orgId} AND deleted_at IS NULL
+    LIMIT 1
+  `;
+  if (rows.length === 0) return;
+  const current = rows[0].metadata ?? {};
+  const existing = Array.isArray(current.aliases) ? (current.aliases as unknown[]).map(String) : [];
+  const merged = new Set(existing);
+  for (const id of params.identifiers) merged.add(id);
+  if (merged.size === existing.length) return; // nothing new
+  const next = { ...current, aliases: [...merged] };
+  await sql`
+    UPDATE entities
+    SET metadata = ${sql.json(next)}, updated_at = current_timestamp
+    WHERE id = ${params.entityId} AND organization_id = ${params.orgId} AND deleted_at IS NULL
+  `;
+}
 
 function extractLink(item: BatchItem, rule: EntityLinkRule): ExtractedLink | null {
   const identities: ExtractedLink['identities'] = [];
@@ -320,6 +374,14 @@ async function createEntityWithIdentities(
     entityId,
     connectorKey: params.connectorKey,
     identities: persisted,
+  });
+  // Seed metadata.aliases from the identifiers that actually attached, so the
+  // metric compiler (which resolves event fields against metadata->'aliases')
+  // can attribute this contact's events from the moment it's created.
+  await ensureAliases(sql, {
+    orgId: params.orgId,
+    entityId,
+    identifiers: attached.map((a) => a.identifier),
   });
   return { entityId, attached };
 }
@@ -616,12 +678,23 @@ async function resolveLinksByKind(
       if (entityId !== null) {
         // Matched an existing entity: accrete the non-matchOnly identities; the
         // identifier(s) we matched on already belong to this entity.
-        attached = await insertIdentities(sql, {
+        const fresh = await insertIdentities(sql, {
           orgId: params.orgId,
           entityId,
           connectorKey: params.connectorKey,
           identities: link.identities.filter((i) => !i.matchOnly),
         });
+        attached = [...fresh];
+        // Mirror only genuinely-new identifiers into metadata.aliases for metric
+        // resolution. A re-insert that ON CONFLICT-skipped returns nothing, so a
+        // repeat message from a known sender does no alias write at all.
+        if (fresh.length > 0) {
+          await ensureAliases(sql, {
+            orgId: params.orgId,
+            entityId,
+            identifiers: fresh.map((a) => a.identifier),
+          });
+        }
         // The matched identifiers themselves are this entity's even if a
         // re-insert was a no-op (they were how we found it), so claim them too.
         for (const id of link.identities) {
@@ -629,7 +702,7 @@ async function resolveLinksByKind(
             attached.push({ namespace: id.namespace, identifier: id.identifier });
           }
         }
-      } else if (rule.autoCreate) {
+      } else if (rule.autoCreate && passesCreateWhen(rule.createWhen, item)) {
         if (!creatorUserId) {
           logger.warn(
             { orgId: params.orgId, entityType: rule.entityType },

--- a/packages/server/src/utils/entity-link-validation.ts
+++ b/packages/server/src/utils/entity-link-validation.ts
@@ -30,6 +30,12 @@ export function validateEntityLinkOverrides(overrides: unknown): string[] {
     if (o.autoCreate !== undefined && typeof o.autoCreate !== 'boolean') {
       errors.push(`${ctx}.autoCreate: must be a boolean`);
     }
+    if (o.createWhen !== undefined && o.createWhen !== null) {
+      const p = o.createWhen;
+      if (typeof p !== 'object' || Array.isArray(p) || typeof (p as { path?: unknown }).path !== 'string') {
+        errors.push(`${ctx}.createWhen: must be null or an object with a string 'path'`);
+      }
+    }
     if (
       o.maskIdentities !== undefined &&
       (!Array.isArray(o.maskIdentities) || !o.maskIdentities.every((s) => typeof s === 'string'))
@@ -102,6 +108,9 @@ export function resolveEntityLinkRules(
       ...rule,
       entityType: ov.retargetEntityType || rule.entityType,
       autoCreate: typeof ov.autoCreate === 'boolean' ? ov.autoCreate : rule.autoCreate,
+      // `null` clears the gate (mint on every miss); an object replaces it;
+      // omitted keeps the connector's declared gate (preserved by `...rule`).
+      createWhen: ov.createWhen === null ? undefined : (ov.createWhen ?? rule.createWhen),
       identities: nextIdentities,
     });
   }


### PR DESCRIPTION
## Problem

Connectors auto-created a `person` for every ingested WhatsApp sender / Gmail from-address. In `buremba` that's ~966 person rows = **784 raw WhatsApp identifiers** (phone / `@lid` group members, no real name) + **~178 email-sender brands** (Spotify, eBay, no-reply@…). Few are usable contacts. Issue: #1626.

## Approach

Add a declarative **`createWhen`** predicate to `EntityLinkRule` that gates **only** the auto-create-on-miss branch — matching an existing entity is never affected. A connector can ingest every identifier into `entity_identities` but materialize a typed entity only for senders that clear an interaction bar.

- **WhatsApp** (`whatsapp` + `whatsapp_local`): `createWhen: { path: 'metadata.is_group', equals: false }` → mint a contact only for 1:1 chats. Group-member flood and outbound-only messages (blank `sender_jid`) never create a row. Keeps `sender_jid` keying (no identity churn).
- **Gmail**: `autoCreate: false` on the person link — every from-address is a sender (brands/newsletters/no-reply, all carrying a `from_name`), so no per-event signal separates a real contact. Identifier still lands in `entity_identities` and links on match. Real email-contact promotion is interaction-driven, handled later.

## Durable fix (metrics)

The metric compiler resolves event fields against `entities.metadata->'aliases'`; `entity_identities` serves recall/authz. **Nothing in the codebase wrote `metadata.aliases`** — so a contact created by the modern path would silently drop from its per-entity metrics. `entity-link-upsert` now seeds `metadata.aliases` from the persisted identifiers on create, and appends genuinely-new identifiers on cross-channel accrete (no write for repeat messages from a known sender).

`createWhen` composes with install overrides (`null` clears the gate).

## Verification

- **Real-data replay** (buremba's actual sender population through the real `applyEntityLinks`): 1119 senders → **exactly 544** 1:1 contacts minted, **0** group-only senders leaked.
- **Red→green**: removing the gate makes the new test fail (group sender gets created); restoring it passes.
- **Metric end-to-end**: a gated 1:1 contact resolves `messages_received = 3` through the real metric compiler via the aliases this code seeds (no manual alias write).
- 6 new tests added (`entity-link-upsert.test.ts`, `entity-link-validation.test.ts`); `entity-link-upsert` 11/11, `entity-link-validation` 9/9, `entity-links-contract` 2/2, `metric-tools` regression 3/3. `make build-packages` clean.

## Follow-ups (out of scope)

- Prod data prune of the existing group-only + brand persons (run manually after deploy; the 544 1:1 contacts stay).
- person/company classification at promotion; cross-channel contacts bridge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785375732&installation_id=136316292&pr_number=1630&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1630&signature=19b9ece79b2190a0d22994c0761e53ba557d701773a8a1ad01c5bbced3330024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->