### PR TITLE
fix(runtime): gateway-authoritative egress allowlist + propagate SSE abort

### DIFF
--- a/packages/agent-worker/src/__tests__/generic-runtime-bash.test.ts
+++ b/packages/agent-worker/src/__tests__/generic-runtime-bash.test.ts
@@ -3,7 +3,6 @@ import { createGenericRuntimeBashOps } from "../embedded/runtime/generic-runtime
 import { getWorkerRuntimeProvider } from "../embedded/runtime/index";
 
 const originalEnv = {
-  JUST_BASH_ALLOWED_DOMAINS: process.env.JUST_BASH_ALLOWED_DOMAINS,
   LOBU_RUNTIME_PROVIDER: process.env.LOBU_RUNTIME_PROVIDER,
 };
 const originalFetch = globalThis.fetch;
@@ -18,7 +17,6 @@ function restoreEnv(name: keyof typeof originalEnv): void {
 }
 
 afterEach(() => {
-  restoreEnv("JUST_BASH_ALLOWED_DOMAINS");
   restoreEnv("LOBU_RUNTIME_PROVIDER");
   globalThis.fetch = originalFetch;
   mock.restore();
@@ -36,12 +34,6 @@ describe("worker runtime registry", () => {
 
 describe("createGenericRuntimeBashOps", () => {
   test("posts bash execution to the generic runtime route without naming a provider", async () => {
-    process.env.JUST_BASH_ALLOWED_DOMAINS = JSON.stringify([
-      "github.com",
-      ".npmjs.org",
-      "bad domain",
-    ]);
-
     const fetchMock = mock(async () =>
       Response.json({ stdout: "ok\n", stderr: "", exitCode: 0 })
     );
@@ -87,6 +79,9 @@ describe("createGenericRuntimeBashOps", () => {
     const body = JSON.parse(String(init.body));
     // The worker never selects a provider — the gateway derives it from the token.
     expect(body).not.toHaveProperty("provider");
+    // …and never supplies the egress allowlist: the gateway reads it from the
+    // signed token so a worker can't widen its own sandbox network policy.
+    expect(body).not.toHaveProperty("allowedDomains");
     expect(body).toEqual({
       command: "echo ok",
       cwd: "/subdir",
@@ -102,7 +97,6 @@ describe("createGenericRuntimeBashOps", () => {
         TEMP: "/vercel/sandbox/.tmp",
         XDG_CACHE_HOME: "/vercel/sandbox/.cache",
       },
-      allowedDomains: ["github.com", ".npmjs.org"],
     });
   });
 

--- a/packages/agent-worker/src/embedded/runtime/generic-runtime-bash.ts
+++ b/packages/agent-worker/src/embedded/runtime/generic-runtime-bash.ts
@@ -11,8 +11,6 @@ type RuntimeExecResponse = {
   error?: unknown;
 };
 
-const DOMAIN_PATTERN = /^[A-Za-z0-9.*_-]+(?::\d+)?$/;
-
 /**
  * The worker egresses through a local gateway HTTP proxy (`HTTP_PROXY=…:8118`),
  * which is meaningless inside a remote sandbox — the sandbox enforces egress
@@ -29,21 +27,6 @@ const REMOTE_UNSUPPORTED_ENV_KEYS = [
   "http_proxy",
   "no_proxy",
 ] as const;
-
-function parseAllowedDomains(): string[] {
-  const raw = process.env.JUST_BASH_ALLOWED_DOMAINS;
-  if (!raw) return [];
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed
-      .filter((entry): entry is string => typeof entry === "string")
-      .map((entry) => entry.trim())
-      .filter((entry) => entry === "*" || DOMAIN_PATTERN.test(entry));
-  } catch {
-    return [];
-  }
-}
 
 function commandEnv(
   env: NodeJS.ProcessEnv | undefined,
@@ -84,7 +67,9 @@ export function createGenericRuntimeBashOps(
           workspaceDir: params.gw.workspaceDir,
           timeoutMs,
           env: commandEnv(env, provider.remoteEnv),
-          allowedDomains: parseAllowedDomains(),
+          // NOTE: the egress allowlist is NOT sent here — the gateway reads it
+          // from the signed worker token (the worker is the sandbox-ee and must
+          // not be able to widen its own sandbox network policy).
         }),
         signal,
       });

--- a/packages/client/src/rest.ts
+++ b/packages/client/src/rest.ts
@@ -75,7 +75,6 @@ export class LobuRestClient {
     const queue: Array<LobuSseEvent<TData>> = [];
     let done = options.signal?.aborted === true;
     let pumpDone = false;
-    let stoppedByCaller = done;
     let pumpError: unknown;
     let wake: (() => void) | undefined;
 
@@ -85,7 +84,14 @@ export class LobuRestClient {
     };
     const abort = () => {
       done = true;
-      stoppedByCaller = true;
+      // Cancel the in-flight SSE request immediately — without this, a caller
+      // aborting their external signal only breaks the local loop while the
+      // underlying fetch + the generated client's reconnect loop keep running.
+      try {
+        controller.abort();
+      } catch {
+        // Bun can throw from stream cancellation during abort propagation.
+      }
       wakeReader();
     };
     options.signal?.addEventListener("abort", abort, { once: true });
@@ -155,7 +161,12 @@ export class LobuRestClient {
       }
       if (pumpError) throw pumpError;
     } finally {
-      if (!stoppedByCaller || pumpDone) {
+      // Abort whenever the generator exits before the pump finished — a caller
+      // `break`, an external-signal abort, or a throw all land here with the
+      // underlying SSE request still open. Only skip when pumpDone (the stream
+      // already ended on its own). The prior guard skipped the abort exactly on
+      // a caller-initiated stop, leaking the fetch and the client's reconnect loop.
+      if (!pumpDone) {
         try {
           controller.abort();
         } catch {

--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -85,6 +85,15 @@ export interface WorkerTokenData {
    * credential from system env only. Set together with `runtimeProviderId`.
    */
   environmentId?: string;
+  /**
+   * Egress allowlist (the agent's resolved `networkConfig.allowedDomains`) for a
+   * remote runtime sandbox. Carried as a SIGNED claim — set gateway-side at mint
+   * from the agent's network config — because the generic `/internal/runtime/exec`
+   * route must NOT trust a worker-supplied list: the worker is the sandbox-ee, so
+   * a compromised one could send `["*"]` and get an allow-all sandbox, bypassing
+   * egress policy. Absent/empty → the sandbox is `deny-all` (fail closed).
+   */
+  allowedDomains?: string[];
 }
 
 export function generateWorkerToken(
@@ -124,6 +133,8 @@ export function generateWorkerToken(
     runtimeProviderId?: string;
     /** Selected environment id backing the runtime credential. See WorkerTokenData.environmentId. */
     environmentId?: string;
+    /** Resolved egress allowlist for a remote runtime sandbox. See WorkerTokenData.allowedDomains. */
+    allowedDomains?: string[];
   }
 ): string {
   if (!options.channelId) {
@@ -150,6 +161,7 @@ export function generateWorkerToken(
     adminTools: options.adminTools,
     runtimeProviderId: options.runtimeProviderId,
     environmentId: options.environmentId,
+    allowedDomains: options.allowedDomains,
   };
 
   return encrypt(JSON.stringify(payload));

--- a/packages/server/src/gateway/__tests__/runtime-route.test.ts
+++ b/packages/server/src/gateway/__tests__/runtime-route.test.ts
@@ -93,7 +93,11 @@ function restoreEnv(name: keyof typeof originalEnv): void {
 }
 
 function token(
-  options: { agentId?: string; runtimeProviderId?: string } = {}
+  options: {
+    agentId?: string;
+    runtimeProviderId?: string;
+    allowedDomains?: string[];
+  } = {}
 ): string {
   return generateWorkerToken("user-1", "conv-1", "deploy-1", {
     channelId: "chan-1",
@@ -102,6 +106,7 @@ function token(
     organizationId: "org-1",
     agentId: options.agentId,
     runtimeProviderId: options.runtimeProviderId,
+    allowedDomains: options.allowedDomains,
   });
 }
 
@@ -347,6 +352,38 @@ describe("createRuntimeRoutes", () => {
     expect(getOrCreateMock).toHaveBeenCalledTimes(1);
   });
 
+  test("ignores a body-supplied egress allowlist and uses the signed token claim", async () => {
+    setVercelSystemCreds();
+    const workspaceDir = path.resolve("workspaces", "verceltestagent", "conv-1");
+
+    const router = createRuntimeRoutes();
+    const res = await router.request("/internal/runtime/exec", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token({
+          agentId: "verceltestagent",
+          runtimeProviderId: "vercel",
+          // The gateway-signed allowlist for this agent.
+          allowedDomains: ["github.com"],
+        })}`,
+        "content-type": "application/json",
+      },
+      // A compromised worker tries to widen egress to everything via the body.
+      body: JSON.stringify({
+        command: "pwd",
+        workspaceDir,
+        allowedDomains: ["*"],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    // The sandbox network policy reflects the TOKEN's allowlist, NOT the body's
+    // "*": the body must not be able to escalate to an allow-all sandbox.
+    expect(getOrCreateMock.mock.calls[0]?.[0]).toMatchObject({
+      networkPolicy: { allow: ["github.com"] },
+    });
+  });
+
   test("executes in a persistent named sandbox without local file sync", async () => {
     setVercelSystemCreds();
     process.env.LOBU_VERCEL_SANDBOX_NAME_PREFIX = "lobu-test";
@@ -364,6 +401,8 @@ describe("createRuntimeRoutes", () => {
         authorization: `Bearer ${token({
           agentId: "verceltestagent",
           runtimeProviderId: "vercel",
+          // The egress allowlist now rides the signed token, not the body.
+          allowedDomains: ["github.com", ".npmjs.org", "bad domain"],
         })}`,
         "content-type": "application/json",
       },
@@ -372,7 +411,6 @@ describe("createRuntimeRoutes", () => {
         cwd: subdir,
         workspaceDir,
         timeoutMs: 1_000,
-        allowedDomains: ["github.com", ".npmjs.org", "bad domain"],
       }),
     });
 

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -755,6 +755,9 @@ export class WorkerGateway {
         // after the token rotates mid-turn.
         runtimeProviderId: tokenData.runtimeProviderId,
         environmentId: tokenData.environmentId,
+        // Preserve the egress allowlist too — otherwise a refreshed token would
+        // fall to deny-all and break the sandbox's network mid-turn.
+        allowedDomains: tokenData.allowedDomains,
       }
     );
 

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -633,6 +633,8 @@ export function buildDeploymentWorkerToken(args: {
   runtimeProviderId?: string;
   environmentId?: string;
   runtimeExplicit?: boolean;
+  /** Resolved egress allowlist for a remote runtime sandbox (signed claim). */
+  allowedDomains?: string[];
 }): string {
   return generateWorkerToken(
     args.userId,
@@ -1515,6 +1517,9 @@ export class DeploymentManager {
       runtimeProviderId: runtimeSelection.runtimeProviderId,
       environmentId: runtimeSelection.environmentId,
       runtimeExplicit: runtimeSelection.explicit,
+      // Same allowlist synced to the grant store / JUST_BASH_ALLOWED_DOMAINS — so
+      // the runtime route reads it off the signed token, not the worker's body.
+      allowedDomains: messageData?.networkConfig?.allowedDomains,
     });
 
     const dispatcherHost = this.getDispatcherHost();

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -144,6 +144,8 @@ export function buildRunJobToken(args: {
   runtimeProviderId?: string;
   environmentId?: string;
   runtimeExplicit?: boolean;
+  /** Resolved egress allowlist for a remote runtime sandbox (signed claim). */
+  allowedDomains?: string[];
 }): string | undefined {
   if (args.runId === undefined) return undefined;
   return generateWorkerToken(
@@ -378,6 +380,9 @@ export class MessageConsumer {
         runtimeProviderId: runtimeSelection.runtimeProviderId,
         environmentId: runtimeSelection.environmentId,
         runtimeExplicit: runtimeSelection.explicit,
+        // Egress allowlist as a signed claim (kept in lockstep with the
+        // deployment-token mint) — the runtime route reads it, never the body.
+        allowedDomains: data.networkConfig?.allowedDomains,
       });
 
       logger.info(

--- a/packages/server/src/gateway/orchestration/worker-token-claims.ts
+++ b/packages/server/src/gateway/orchestration/worker-token-claims.ts
@@ -35,6 +35,12 @@ export interface WorkerTokenClaimsArgs {
    * pinned to builtin doesn't inherit the deployment-wide LOBU_RUNTIME_PROVIDER.
    */
   runtimeExplicit?: boolean;
+  /**
+   * The agent's resolved egress allowlist (`networkConfig.allowedDomains`). Set
+   * here so the runtime route can read it off the SIGNED token instead of
+   * trusting a worker-supplied body — see WorkerTokenData.allowedDomains.
+   */
+  allowedDomains?: string[];
 }
 
 /**
@@ -61,6 +67,7 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
   source?: string;
   runtimeProviderId?: string;
   environmentId?: string;
+  allowedDomains?: string[];
 } {
   // Per-agent environment selection wins; otherwise the deployment-wide
   // selector covers self-host / org-default — UNLESS the agent made an explicit
@@ -90,5 +97,9 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
     // env-var fallback has no environment row, so credentials resolve from
     // system env.
     environmentId: runtimeProviderId ? args.environmentId : undefined,
+    // Non-empty only; an empty list is equivalent to absent (deny-all) and
+    // keeps the token payload minimal.
+    allowedDomains:
+      args.allowedDomains && args.allowedDomains.length > 0 ? args.allowedDomains : undefined,
   };
 }

--- a/packages/server/src/gateway/routes/internal/runtime.ts
+++ b/packages/server/src/gateway/routes/internal/runtime.ts
@@ -15,7 +15,9 @@ type ExecRequest = {
   workspaceDir?: unknown;
   env?: unknown;
   timeoutMs?: unknown;
-  allowedDomains?: unknown;
+  // NOTE: no `allowedDomains` here — the egress allowlist is NOT trusted from the
+  // request body (the worker is the sandbox-ee). It's read from the signed worker
+  // token claim below, same as `runtimeProviderId`.
 };
 
 /**
@@ -93,7 +95,9 @@ export function createRuntimeRoutes(): Hono<WorkerContext> {
         cwd: body.cwd,
         env: commandEnv(body.env),
         timeoutMs,
-        allowedDomains: body.allowedDomains,
+        // Authoritative egress allowlist from the SIGNED token, never the body —
+        // a compromised worker cannot widen its own sandbox network policy.
+        allowedDomains: worker.allowedDomains,
       });
 
       return c.json({


### PR DESCRIPTION
Two findings from the **#1618** (Environments / generic RuntimeProvider) review. Verified real against committed code before fixing.

## 1. Egress allowlist was trusted from the worker (security)

`/internal/runtime/exec` read `allowedDomains` from the request **body**, and the Vercel provider's `networkPolicyFromDomains` maps `["*"]` → an **allow-all** sandbox. The worker is the sandbox-ee, so a compromised worker could send `["*"]` and widen its own egress past policy — directly contradicting the route's own docstring ("the provider is chosen from the signed worker-token claim, never the request body").

**Fix:** carry the agent's resolved `networkConfig.allowedDomains` as a **signed worker-token claim** — identical plumbing to the existing `runtimeProviderId`/`environmentId` claims, via the shared `buildWorkerTokenClaims`, set at both the deployment-token and per-run mints and preserved across token refresh. The route reads it from the verified token; the worker no longer sends it. Fail-closed: absent/empty → `deny-all`.

## 2. SSE abort didn't cancel the underlying request (resource leak)

In `streamEvents`, a caller-initiated abort set the stop flags but **skipped `controller.abort()`** (the `!stoppedByCaller || pumpDone` guard was false exactly on a caller stop), leaking the underlying fetch and the generated client's reconnect loop. Now: abort the controller eagerly in the signal handler, and in `finally` whenever the generator exits before the pump finished (`!pumpDone`). Removed the now-dead `stoppedByCaller`.

## Verification
- `runtime-route.test.ts`: new test asserts a body-supplied `["*"]` is ignored and the **token's** allowlist drives the sandbox `networkPolicy` (`{allow:["github.com"]}`, not allow-all). Existing sandbox test updated to mint the allowlist on the token. 12/12 pass.
- `generic-runtime-bash.test.ts`: asserts the worker no longer puts `allowedDomains` in the body. 3/3 pass.
- New `rest-stream-abort.test.ts`: external abort cancels the underlying SSE request — **red→green verified** (fails against the pre-fix `rest.ts`).
- `make build-packages` clean (tsc across core/server/worker/cli).

Branched off `origin/main` (#1618 is on main; local main was stale). No dependency or owletto changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785380240&installation_id=136316292&pr_number=1631&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1631&signature=44daf42ca12500ca506a8bd34a2f9a5f4fd0de39a1a2def2c47e5b874d67fc44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime access rules now come from signed worker credentials, making network permissions more consistent across runs and refreshes.
  * Worker tokens can now carry an allowlist for outbound domains.

* **Bug Fixes**
  * Fixed cases where outbound access could be lost or ignored during execution, token refresh, or sandbox setup.
  * Improved streaming event cleanup so canceled requests stop promptly and don’t keep running in the background.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->