### PR TITLE
feat(auth): server-proven onboarding intents for new-signup app installs

### DIFF
--- a/db/migrations/20260630000030_auth_onboarding_intents.sql
+++ b/db/migrations/20260630000030_auth_onboarding_intents.sql
@@ -1,0 +1,49 @@
+-- migrate:up
+
+-- One-shot, server-proven onboarding intents emitted by auth hooks.
+-- Used to carry facts that only the server can know reliably (for example,
+-- "this request just created a new user via provider X") across the auth
+-- callback -> SPA redirect boundary. Intents are short-lived and consumed
+-- before the client performs the suggested onboarding action, so returning
+-- users are never redirected based on weak heuristics like "no connections".
+
+CREATE TABLE IF NOT EXISTS public.auth_onboarding_intents (
+    id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    user_id text NOT NULL REFERENCES public."user"(id) ON DELETE CASCADE,
+    kind text NOT NULL,
+    provider text,
+    connector_key text,
+    action text NOT NULL,
+    payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    expires_at timestamptz NOT NULL,
+    consumed_at timestamptz
+);
+
+-- New empty table — non-concurrent index builds block nothing.
+-- squawk-ignore require-concurrent-index-creation
+CREATE INDEX IF NOT EXISTS auth_onboarding_intents_pending_user_idx
+    ON public.auth_onboarding_intents (user_id, kind, created_at)
+    WHERE consumed_at IS NULL;
+
+-- squawk-ignore require-concurrent-index-creation
+CREATE INDEX IF NOT EXISTS auth_onboarding_intents_expires_idx
+    ON public.auth_onboarding_intents (expires_at);
+
+-- One pending new-user marker is enough; the account hook consumes it and turns
+-- it into a concrete action intent when the signup provider maps to one.
+-- squawk-ignore require-concurrent-index-creation
+CREATE UNIQUE INDEX IF NOT EXISTS auth_onboarding_new_user_pending_uniq
+    ON public.auth_onboarding_intents (user_id, kind)
+    WHERE consumed_at IS NULL AND kind = 'new_user_signup';
+
+-- Do not enqueue duplicate pending install actions for the same connector.
+-- squawk-ignore require-concurrent-index-creation
+CREATE UNIQUE INDEX IF NOT EXISTS auth_onboarding_install_pending_uniq
+    ON public.auth_onboarding_intents (user_id, action, connector_key)
+    WHERE consumed_at IS NULL AND action = 'install_app';
+
+-- migrate:down
+
+-- squawk-ignore ban-drop-table
+DROP TABLE IF EXISTS public.auth_onboarding_intents;

--- a/packages/server/src/auth/__tests__/onboarding-intents.test.ts
+++ b/packages/server/src/auth/__tests__/onboarding-intents.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import {
+	installUrlFor,
+	resolveAppInstallOnboardingCandidate,
+} from "../onboarding-intent-decision";
+
+const slackAuthSchema = {
+	methods: [
+		{
+			type: "app_installation",
+			provider: "slack",
+			installShape: "oauth-code-exchange",
+		},
+		{
+			type: "oauth",
+			provider: "slack",
+			requiredScopes: ["openid"],
+			loginScopes: ["openid", "email", "profile"],
+		},
+	],
+};
+
+describe("auth onboarding intent decisions", () => {
+	test("creates an app install candidate for new social signups", () => {
+		expect(
+			resolveAppInstallOnboardingCandidate({
+				hasNewUserMarker: true,
+				providerId: "slack",
+				connectors: [{ key: "slack", auth_schema: slackAuthSchema }],
+			}),
+		).toEqual({
+			connectorKey: "slack",
+			provider: "slack",
+			installShape: "oauth-code-exchange",
+		});
+	});
+
+	test("does not create a candidate for returning users or account links", () => {
+		expect(
+			resolveAppInstallOnboardingCandidate({
+				hasNewUserMarker: false,
+				providerId: "slack",
+				connectors: [{ key: "slack", auth_schema: slackAuthSchema }],
+			}),
+		).toBeNull();
+	});
+
+	test("requires the login provider to also have an app installation method", () => {
+		expect(
+			resolveAppInstallOnboardingCandidate({
+				hasNewUserMarker: true,
+				providerId: "slack",
+				connectors: [
+					{
+						key: "generic_oauth",
+						auth_schema: {
+							methods: [
+								{
+									type: "oauth",
+									provider: "slack",
+									requiredScopes: ["openid"],
+									loginScopes: ["openid"],
+								},
+							],
+						},
+					},
+				],
+			}),
+		).toBeNull();
+	});
+
+	test("builds provider install URLs from install shape", () => {
+		expect(installUrlFor("slack", "oauth-code-exchange")).toBe(
+			"/lobu/slack/install",
+		);
+		expect(installUrlFor("github", "github-app")).toBe(
+			"/lobu/github/app/install",
+		);
+	});
+});

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -44,6 +44,10 @@ import {
 	resolveLoginProviderCredentials,
 	resolveRequestOrganizationId,
 } from "./config";
+import {
+	enqueueAppInstallOnboardingForNewSignup,
+	markNewUserForOnboarding,
+} from "./onboarding-intents";
 import { findExistingPersonalOrg } from "./personal-org-provisioning";
 // Side-effect imports: each connector self-registers on load, so the
 // registry is fully populated before any auth hook can fire. Add a new
@@ -719,6 +723,15 @@ export async function createAuth(
 					},
 					after: async (user, context) => {
 						try {
+							await markNewUserForOnboarding(user.id);
+						} catch (error) {
+							console.error(
+								"[Auth] Failed to mark new user onboarding intent:",
+								error,
+							);
+						}
+
+						try {
 							const { ensurePersonalOrganization } = await import(
 								"./personal-org-provisioning"
 							);
@@ -834,6 +847,17 @@ export async function createAuth(
 								| string
 								| null,
 						};
+						try {
+							await enqueueAppInstallOnboardingForNewSignup({
+								userId: account.userId,
+								providerId: account.providerId,
+							});
+						} catch (error) {
+							console.error(
+								"[Auth] Failed to enqueue app-install onboarding intent:",
+								error,
+							);
+						}
 						try {
 							const { provisionConnectorFromSocialLogin } = await import(
 								"./social-login-provisioning"

--- a/packages/server/src/auth/onboarding-intent-decision.ts
+++ b/packages/server/src/auth/onboarding-intent-decision.ts
@@ -1,0 +1,72 @@
+import {
+	getAppInstallationAuthMethods,
+	getOAuthAuthMethods,
+	normalizeConnectorAuthSchema,
+} from "../utils/connector-auth";
+
+export type OnboardingConnectorCandidate = {
+	key: string;
+	auth_schema: unknown;
+};
+
+export type AppInstallOnboardingCandidate = {
+	connectorKey: string;
+	provider: string;
+	installShape: string | null;
+};
+
+export function lowerProvider(
+	provider: string | null | undefined,
+): string | null {
+	const normalized = provider?.trim().toLowerCase();
+	return normalized || null;
+}
+
+export function installUrlFor(provider: string, installShape: unknown): string {
+	// The Lobu gateway is mounted under /lobu. GitHub App install owns the
+	// /<provider>/app/install route; OAuth-code-exchange app installs (Slack)
+	// mount /<provider>/install.
+	if (installShape === "github-app") {
+		return `/lobu/${encodeURIComponent(provider)}/app/install`;
+	}
+	return `/lobu/${encodeURIComponent(provider)}/install`;
+}
+
+export function findAppInstallLoginMatch(
+	rows: OnboardingConnectorCandidate[],
+	provider: string,
+): AppInstallOnboardingCandidate | null {
+	for (const row of rows) {
+		const authSchema = normalizeConnectorAuthSchema(row.auth_schema);
+		const hasMatchingLogin = getOAuthAuthMethods(authSchema).some(
+			(method) =>
+				lowerProvider(method.provider) === provider &&
+				Array.isArray(method.loginScopes) &&
+				method.loginScopes.length > 0,
+		);
+		if (!hasMatchingLogin) continue;
+
+		const appInstall = getAppInstallationAuthMethods(authSchema).find(
+			(method) => lowerProvider(method.provider) === provider,
+		);
+		if (!appInstall) continue;
+
+		return {
+			connectorKey: row.key,
+			provider,
+			installShape: appInstall.installShape ?? null,
+		};
+	}
+	return null;
+}
+
+export function resolveAppInstallOnboardingCandidate(params: {
+	hasNewUserMarker: boolean;
+	providerId: string | null | undefined;
+	connectors: OnboardingConnectorCandidate[];
+}): AppInstallOnboardingCandidate | null {
+	if (!params.hasNewUserMarker) return null;
+	const provider = lowerProvider(params.providerId);
+	if (!provider) return null;
+	return findAppInstallLoginMatch(params.connectors, provider);
+}

--- a/packages/server/src/auth/onboarding-intents.ts
+++ b/packages/server/src/auth/onboarding-intents.ts
@@ -1,0 +1,197 @@
+import { createLogger } from "@lobu/core";
+import { getDb } from "../db/client";
+import { listCatalogConnectorDefinitions } from "../utils/connector-catalog";
+import {
+	installUrlFor,
+	lowerProvider,
+	resolveAppInstallOnboardingCandidate,
+	type OnboardingConnectorCandidate,
+} from "./onboarding-intent-decision";
+import { findExistingPersonalOrg } from "./personal-org-provisioning";
+
+const logger = createLogger("auth-onboarding-intents");
+
+const NEW_USER_KIND = "new_user_signup";
+const INSTALL_APP_ACTION = "install_app";
+const MARKER_TTL_MINUTES = 15;
+const INTENT_TTL_HOURS = 24;
+
+type Sql = ReturnType<typeof getDb>;
+
+type PendingIntentRow = {
+	id: string | number;
+	provider: string | null;
+	connector_key: string | null;
+	payload: Record<string, unknown> | null;
+};
+
+async function resolveOnboardingOrgId(
+	userId: string,
+	sql: Sql,
+): Promise<string | null> {
+	const personalOrg = await findExistingPersonalOrg(userId, sql);
+	if (personalOrg?.id) return personalOrg.id;
+
+	const [membership] = (await sql`
+    SELECT "organizationId" AS organization_id
+    FROM "member"
+    WHERE "userId" = ${userId}
+    ORDER BY "createdAt" ASC
+    LIMIT 1
+  `) as Array<{ organization_id: string }>;
+	return membership?.organization_id ?? null;
+}
+
+export async function markNewUserForOnboarding(userId: string): Promise<void> {
+	const sql = getDb();
+	await sql`
+    INSERT INTO auth_onboarding_intents (
+      user_id, kind, action, payload, expires_at
+    ) VALUES (
+      ${userId}, ${NEW_USER_KIND}, 'marker', '{}'::jsonb,
+      NOW() + (${`${MARKER_TTL_MINUTES} minutes`})::interval
+    )
+    ON CONFLICT (user_id, kind)
+      WHERE consumed_at IS NULL AND kind = 'new_user_signup'
+    DO UPDATE SET expires_at = EXCLUDED.expires_at
+  `;
+}
+
+export async function enqueueAppInstallOnboardingForNewSignup(params: {
+	userId: string;
+	providerId: string | null | undefined;
+}): Promise<void> {
+	const provider = lowerProvider(params.providerId);
+	if (!provider || !params.userId) return;
+
+	const sql = getDb();
+	await sql.begin(async (tx) => {
+		const [marker] = (await tx`
+      SELECT id
+      FROM auth_onboarding_intents
+      WHERE user_id = ${params.userId}
+        AND kind = ${NEW_USER_KIND}
+        AND consumed_at IS NULL
+        AND expires_at > NOW()
+      ORDER BY created_at ASC
+      LIMIT 1
+      FOR UPDATE
+    `) as Array<{ id: string | number }>;
+
+		// No server-created new-user marker means this is a normal login or account
+		// link. Do not redirect returning users based on connector absence.
+		if (!marker) return;
+
+		const organizationId = await resolveOnboardingOrgId(
+			params.userId,
+			tx as Sql,
+		);
+		if (!organizationId) {
+			await tx`
+        UPDATE auth_onboarding_intents
+        SET consumed_at = NOW()
+        WHERE id = ${marker.id}
+      `;
+			return;
+		}
+
+		const connectorRows = (await tx`
+      SELECT key, auth_schema
+      FROM connector_definitions
+      WHERE organization_id = ${organizationId}
+        AND status = 'active'
+      ORDER BY updated_at DESC
+    `) as OnboardingConnectorCandidate[];
+
+		let match = resolveAppInstallOnboardingCandidate({
+			hasNewUserMarker: true,
+			providerId: provider,
+			connectors: connectorRows,
+		});
+		if (!match) {
+			const catalogRows = await listCatalogConnectorDefinitions();
+			match = resolveAppInstallOnboardingCandidate({
+				hasNewUserMarker: true,
+				providerId: provider,
+				connectors: catalogRows.map((row) => ({
+					key: row.key,
+					auth_schema: row.auth_schema,
+				})),
+			});
+		}
+		if (!match) {
+			await tx`
+        UPDATE auth_onboarding_intents
+        SET consumed_at = NOW()
+        WHERE id = ${marker.id}
+      `;
+			return;
+		}
+
+		await tx`
+      INSERT INTO auth_onboarding_intents (
+        user_id, kind, provider, connector_key, action, payload, expires_at
+      ) VALUES (
+        ${params.userId}, 'app_install', ${provider}, ${match.connectorKey},
+        ${INSTALL_APP_ACTION},
+        ${tx.json({ installShape: match.installShape })},
+        NOW() + (${`${INTENT_TTL_HOURS} hours`})::interval
+      )
+      ON CONFLICT (user_id, action, connector_key)
+        WHERE consumed_at IS NULL AND action = 'install_app'
+      DO NOTHING
+    `;
+
+		await tx`
+      UPDATE auth_onboarding_intents
+      SET consumed_at = NOW()
+      WHERE id = ${marker.id}
+    `;
+	});
+}
+
+export async function consumePendingOnboardingIntent(userId: string): Promise<{
+	action: "install_app";
+	connectorKey: string;
+	provider: string;
+	installUrl: string;
+} | null> {
+	const sql = getDb();
+	const consumed = await sql.begin(async (tx) => {
+		const [row] = (await tx`
+      SELECT id, provider, connector_key, payload
+      FROM auth_onboarding_intents
+      WHERE user_id = ${userId}
+        AND action = ${INSTALL_APP_ACTION}
+        AND consumed_at IS NULL
+        AND expires_at > NOW()
+      ORDER BY created_at ASC
+      LIMIT 1
+      FOR UPDATE
+    `) as PendingIntentRow[];
+
+		if (!row) return null;
+
+		await tx`
+      UPDATE auth_onboarding_intents
+      SET consumed_at = NOW()
+      WHERE id = ${row.id}
+    `;
+		return row;
+	});
+
+	if (!consumed) return null;
+	const provider = lowerProvider(consumed.provider);
+	const connectorKey = consumed.connector_key?.trim();
+	if (!provider || !connectorKey) {
+		logger.warn({ userId, consumed }, "Skipping malformed onboarding intent");
+		return null;
+	}
+
+	return {
+		action: "install_app",
+		connectorKey,
+		provider,
+		installUrl: installUrlFor(provider, consumed.payload?.installShape),
+	};
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,6 +18,7 @@ import { LOBU_LOGO_PNG_BASE64 } from "./assets/logo";
 import { createAuth } from "./auth";
 import { getAuthConfig as getAuthConfigFromEnv } from "./auth/config";
 import { mcpAuth } from "./auth/middleware";
+import { consumePendingOnboardingIntent } from "./auth/onboarding-intents";
 import { oauthRoutes } from "./auth/oauth/routes";
 import { findExistingPersonalOrg } from "./auth/personal-org-provisioning";
 import { credentialRoutes } from "./auth/routes";
@@ -940,6 +941,12 @@ app.delete("/api/me/devices/:id", mcpAuth, deleteDeviceWorker);
 // Mint a child device-worker token for the caller — used by the Owletto Mac
 // bridge's native-messaging host to auto-pair Owletto for Chrome.
 app.post("/api/me/devices/mint-child-token", mcpAuth, mintDeviceChildToken);
+app.post("/api/me/onboarding/intent/consume", mcpAuth, async (c) => {
+	const user = c.get("user");
+	if (!user) return c.json({ error: "Unauthorized" }, 401);
+	const intent = await consumePendingOnboardingIntent(user.id);
+	return c.json({ intent });
+});
 // UI → worker signal channel. Separate path prefix so the worker API auth
 // middleware above doesn't cover it (this one is hit from the web session).
 app.get("/api/auth-runs/active", getActiveAuthRun);


### PR DESCRIPTION
## What

Give the SPA a reliable signal to route a **brand-new social signup** straight into the matching app-installation connector's install flow (e.g. Slack), instead of dropping them on an empty owner dashboard. The fact that "this request just created a new user via provider X" is something only the server can know reliably, so it's carried across the auth callback → SPA redirect boundary as a short-lived, one-shot intent rather than reconstructed client-side from weak heuristics like "no connections".

Frontend half: lobu-ai/owletto#397.

## Changes

- **`auth_onboarding_intents` table** (migration `20260630000030`): short-lived one-shot intents.
  - The user-create `after` hook drops a `new_user_signup` marker (15m TTL).
  - The account hook consumes that marker and, when the signup provider maps to an app-installation connector, enqueues a concrete `install_app` intent (24h TTL). No marker → no intent, so returning users and account links are never redirected.
  - Partial unique indexes keep the marker and per-connector install intents idempotent.
- **`POST /api/me/onboarding/intent/consume`**: atomically claims + consumes the caller's pending `install_app` intent (`FOR UPDATE`), returning `{ connectorKey, provider, installUrl }` with the install URL derived from the connector's install shape (`github-app` → `/lobu/<provider>/app/install`, else `/lobu/<provider>/install`).
- **Pure decision module** (`onboarding-intent-decision.ts`, unit-tested): a connector matches only if it declares **both** a login OAuth method for the provider (with `loginScopes`) **and** an `app_installation` method.

## Safety

- Every auth hook is wrapped to **fail open** — a failure here logs and never blocks signup/login.
- **Multi-replica safe**: all state lives in Postgres; the consume path is a single `FOR UPDATE` transaction, no in-memory coordination.
- Org resolution falls back gracefully (personal org → first membership → consume-and-skip if none).

## Validation

- New unit test `onboarding-intents.test.ts` (4 tests) passes.
- `packages/server` `tsc --noEmit` clean (after rebuilding workspace packages).
- Migration passes the squawk lock-safety gate (`squawk-cli@2.58.0`, 0 issues): identity PK, `IF NOT EXISTS`, `squawk-ignore` on the new-table index builds + down-migration drop.

## Follow-up

- Submodule pointer bump for owletto#397 lands as a **separate PR after that merges** (per repo cross-repo policy).
- E2E not yet run against a live social-signup → install handshake; the endpoint + migration are backward-compatible and inert until the owletto frontend deploys.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785424644&installation_id=136316292&pr_number=1639&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1639&signature=f7b785d6eed1dd29ee72fbe5120b15ecef280262a8e6c140a360fe57d6e8b476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->