### PR TITLE
feat(personal-agent): value USD/EUR-pocket spend at the user's realised rate (no null GBP)

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -148,6 +148,27 @@ const gbpAmountSql = `CASE
     ELSE NULL
   END`;
 
+// Pocket-spend fallback rate. A spend from a multi-currency pocket (USD/EUR
+// charges from a USD/EUR balance) carries no per-transaction GBP — there is no
+// exact figure to read. Rather than leave those costs null or invent a market
+// rate, we convert at the user's OWN realised rate: the average GBP-per-unit
+// across their actual conversions (rows where `counterpart_currency = 'GBP'`).
+// It's their real, data-grounded rate (USD ≈ 0.76, EUR ≈ 0.85), and it self-
+// updates as they transact. Returns NULL for a currency they've never converted,
+// so the caller can still distinguish "estimated" from "truly unknown".
+const realizedGbpRateSql = (ccyExpr: string) => `(
+    SELECT round(avg(
+      nullif(r.metadata->>'counterpart_amount', '')::numeric
+      / nullif(nullif(r.metadata->>'amount', '')::numeric, 0)
+    ), 6)
+    FROM events r
+    WHERE r.semantic_type = 'transaction'
+      AND r.metadata->>'counterpart_currency' = 'GBP'
+      AND r.metadata->>'currency' = ${ccyExpr}
+      AND nullif(r.metadata->>'amount', '')::numeric > 0
+      AND nullif(r.metadata->>'counterpart_amount', '')::numeric > 0
+  )`;
+
 // Spend rows we treat as real consumption: a COMPLETED outbound CARD_PAYMENT.
 // This single predicate removes the three classes that polluted the old views:
 //   • DECLINED / FAILED / REVERTED / DELETED states (money never moved — e.g.
@@ -301,7 +322,15 @@ SELECT
   max(tx_date)::text AS last_seen,
   round(avg(extract(day from occurred_at)))::int AS billing_day,
   round(sum(amount), 2) AS total_spent,
-  round(sum(gbp), 2) AS total_spent_gbp,
+  nullif(
+    round(
+      coalesce(sum(gbp), 0)
+      + coalesce(sum(amount) FILTER (WHERE gbp IS NULL), 0)
+        * coalesce(${realizedGbpRateSql("max(card.currency)")}, 0),
+      2
+    ),
+    0
+  ) AS total_spent_gbp,
   count(*)::int AS charge_count,
   count(distinct date_trunc('month', occurred_at))::int AS active_months
 FROM card
@@ -370,7 +399,7 @@ const subscription = defineEntityType({
     total_spent_gbp: {
       type: "number",
       description:
-        "Total in GBP where exactly known (native GBP + Revolut-booked GBP counterpart); null portion = USD/EUR-pocket charges funded at an earlier exchange",
+        "Total in GBP: exact where known (native GBP + Revolut-booked GBP counterpart), and pocket charges (USD/EUR) valued at the user's own realised conversion rate",
     },
     charge_count: { type: "integer" },
     active_months: { type: "integer" },
@@ -436,18 +465,28 @@ SELECT
   round(sum(gbp), 2) AS gbp_known,
   nullif(
     round(
+      -- exact card GBP (native + GBP counterpart)
       coalesce(sum(gbp), 0)
-      + (
-        SELECT coalesce(sum(nullif(e.metadata->>'amount', '')::numeric), 0)
-        FROM events e
-        WHERE e.semantic_type = 'transaction'
-          AND e.metadata->>'transaction_type' = 'EXCHANGE'
-          AND e.metadata->>'state' = 'COMPLETED'
-          AND e.metadata->>'currency' = 'GBP'
-          AND e.metadata->>'direction' = 'out'
-          AND e.metadata->>'description' = 'Exchanged to ' || mode() WITHIN GROUP (ORDER BY tx.currency)
-          AND e.occurred_at::date BETWEEN min(tx.d) - 21 AND max(tx.d) + 3
-      ), 2
+      -- plus the pocket-spend cost: the GBP exchanged into the local currency
+      -- around the trip (exact) when present, else the untraced pocket spend
+      -- valued at the user's realised rate (covers long-held USD/EUR pockets
+      -- with no in-window exchange).
+      + coalesce(
+          nullif((
+            SELECT coalesce(sum(nullif(e.metadata->>'amount', '')::numeric), 0)
+            FROM events e
+            WHERE e.semantic_type = 'transaction'
+              AND e.metadata->>'transaction_type' = 'EXCHANGE'
+              AND e.metadata->>'state' = 'COMPLETED'
+              AND e.metadata->>'currency' = 'GBP'
+              AND e.metadata->>'direction' = 'out'
+              AND e.metadata->>'description' = 'Exchanged to ' || mode() WITHIN GROUP (ORDER BY tx.currency)
+              AND e.occurred_at::date BETWEEN min(tx.d) - 21 AND max(tx.d) + 3
+          ), 0),
+          coalesce(sum(amount) FILTER (WHERE gbp IS NULL), 0)
+            * coalesce(${realizedGbpRateSql("mode() WITHIN GROUP (ORDER BY tx.currency)")}, 0)
+        ),
+      2
     ),
     0
   ) AS gbp_cost,
@@ -499,7 +538,7 @@ const trip = defineEntityType({
     gbp_cost: {
       type: "number",
       description:
-        "Best GBP estimate of the trip: exact card GBP plus GBP exchanged into the local currency around the trip",
+        "Best GBP estimate of the trip: exact card GBP, plus pocket cost — GBP exchanged into the local currency around the trip, or (for long-held pockets with no in-window exchange) pocket spend at the user's realised rate",
       "x-table-column": true,
       "x-table-label": "GBP cost",
     },


### PR DESCRIPTION
## What

Subscriptions and trips left GBP **null** for spend from multi-currency pockets (USD/EUR charges paid from a USD/EUR balance) because those transactions carry no per-transaction GBP — there's no exact figure to read.

## Fix

Convert pocket spend at the user's **own realised rate**: the average GBP-per-unit across their actual GBP conversions (`counterpart_currency='GBP'` rows). It's data-grounded (USD ≈ 0.76, EUR ≈ 0.85, from 276/37 real conversions), self-updating, and not a market guess. Returns null only for a currency they've genuinely never converted.

- **subscriptions** — `total_spent_gbp` = exact (native GBP + GBP counterpart) + pocket charges at the realised rate.
- **trips** — `gbp_cost` pocket portion = exact in-window exchange when present, else pocket spend at the realised rate. `gbp_known` stays exact-only for transparency.

No double-counting (exchange-funded and rate-estimate are either/or per trip); the existing exact paths are unchanged.

## Verified live (buremba, via the deduped entity-read path)

- 9 USD subs now costed: Hetzner $329→£250, Cloudflare $261→£198, Stripe $24→£18, Rave Coffee $15→£11, Lime $15→£11.
- Trips: **0 null costs** (was several). BG USD-pocket trip null→£177; VN unchanged at £1,188 (£688 exact card + £500 exchanged to VND).
- Validator-accepted: the realised-rate subquery is a qualified aggregate (`max(card.currency)` / `mode()`), which the derived-view reference checker resolves.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785429779&installation_id=136316292&pr_number=1642&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1642&signature=284b08dd7b74b16273a3390824260d37ceb3d4803c041150d961ab7e0be94408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->