### PR TITLE
refactor(scheduled): single validateDeliveryAuthorization for create + fire gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,7 @@ jobs:
         # (src/lobu/stores/__tests__) that vitest owns, so we target
         # src/lobu/__tests__ specifically rather than the whole src/lobu tree.
         working-directory: packages/server
-        run: bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__
+        run: bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__
 
   format-lint:
     runs-on: ubuntu-latest

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -21,6 +21,7 @@ import {
   isDeliverableChatPlatform,
   registerScheduledJobsTicker,
   type ScheduledDeliveryContext,
+  validateDeliveryAuthorization,
 } from './scheduled-jobs-service';
 import { TaskScheduler } from './task-scheduler';
 import { triggerEmbedBackfill } from './trigger-embed-backfill';
@@ -32,7 +33,6 @@ import {
   enqueueAgentMessage,
 } from '../gateway/services/agent-threads';
 import { buildMessagePayload } from '../gateway/services/platform-helpers';
-import { runtimeConnectionIdToSlug } from '../lobu/stores/connections-projection';
 
 function asDeliveryContext(value: unknown): ScheduledDeliveryContext | null {
   if (!value || typeof value !== 'object') return null;
@@ -55,50 +55,6 @@ function asDeliveryContext(value: unknown): ScheduledDeliveryContext | null {
   };
 }
 
-async function deliveryContextStillAuthorized(params: {
-  organizationId: string;
-  agentId: string;
-  delivery: ScheduledDeliveryContext;
-}): Promise<boolean> {
-  const sql = getDb();
-  const { organizationId, agentId, delivery } = params;
-  const connectionRows = (await sql`
-    SELECT connector_key, agent_id, status
-    FROM connections
-    WHERE organization_id = ${organizationId}
-      AND slug = ${runtimeConnectionIdToSlug(delivery.connectionId)}
-      AND credential_mode IS NOT NULL
-      AND deleted_at IS NULL
-    LIMIT 1
-  `) as unknown as Array<{ connector_key: string; agent_id: string | null; status: string }>;
-  const connection = connectionRows[0];
-  if (!connection) return false;
-  if (connection.connector_key !== delivery.platform) return false;
-  if (connection.status !== 'active') return false;
-  if (connection.agent_id) return connection.agent_id === agentId;
-
-  const bindingRows = delivery.teamId
-    ? await sql`
-        SELECT agent_id
-        FROM agent_channel_bindings
-        WHERE organization_id = ${organizationId}
-          AND platform = ${delivery.platform}
-          AND channel_id = ${delivery.channelId}
-          AND team_id = ${delivery.teamId}
-        LIMIT 1
-      `
-    : await sql`
-        SELECT agent_id
-        FROM agent_channel_bindings
-        WHERE organization_id = ${organizationId}
-          AND platform = ${delivery.platform}
-          AND channel_id = ${delivery.channelId}
-          AND team_id IS NULL
-        LIMIT 1
-      `;
-  const binding = (bindingRows as unknown as Array<{ agent_id: string }>)[0];
-  return binding?.agent_id === agentId;
-}
 
 /**
  * Construct the TaskScheduler, register every periodic task, start dispatch,
@@ -449,11 +405,13 @@ export async function runWakeAgentTask(
   if (
     delivery &&
     isDeliverableChatPlatform(delivery.platform) &&
-    (await deliveryContextStillAuthorized({
-      organizationId: orgId,
-      agentId: p.agent_id,
-      delivery,
-    }))
+    (
+      await validateDeliveryAuthorization({
+        organizationId: orgId,
+        agentId: p.agent_id,
+        delivery,
+      })
+    ).authorized
   ) {
     await queueProducer.enqueueMessage(
       buildMessagePayload({

--- a/packages/server/src/scheduled/scheduled-jobs-service.ts
+++ b/packages/server/src/scheduled/scheduled-jobs-service.ts
@@ -17,6 +17,7 @@
  */
 
 import { getDb } from '../db/client';
+import { runtimeConnectionIdToSlug } from '../lobu/stores/connections-projection';
 import { nextRunAt as nextCronTickAt } from '../utils/cron';
 import logger from '../utils/logger';
 import type { TaskScheduler } from './task-scheduler';
@@ -42,6 +43,84 @@ export const DELIVERABLE_CHAT_PLATFORMS = ['slack', 'telegram'] as const;
 
 export function isDeliverableChatPlatform(platform: string): boolean {
   return (DELIVERABLE_CHAT_PLATFORMS as readonly string[]).includes(platform);
+}
+
+export type DeliveryAuthzDenyReason =
+  | 'connection-missing'
+  | 'platform-changed'
+  | 'connection-inactive'
+  | 'agent-mismatch'
+  | 'channel-unbound';
+
+export type DeliveryAuthzResult =
+  | { authorized: true }
+  | { authorized: false; reason: DeliveryAuthzDenyReason };
+
+/**
+ * Is `agentId` authorized to deliver into the connection/channel named by a
+ * delivery context? Single source of truth shared by the create-time gate
+ * (`manage_schedules`, which maps the deny reason to a user-facing error) and
+ * the fire-time re-check (`scheduled/jobs.ts`, which only needs the boolean).
+ * Both must agree, and a cron can fire long after creation, so the same
+ * validation runs at both points against the live connection + binding rows.
+ */
+export async function validateDeliveryAuthorization(params: {
+  organizationId: string;
+  agentId: string;
+  delivery: ScheduledDeliveryContext;
+}): Promise<DeliveryAuthzResult> {
+  const sql = getDb();
+  const { organizationId, agentId, delivery } = params;
+  const connectionRows = (await sql`
+    SELECT connector_key, agent_id, status
+    FROM connections
+    WHERE organization_id = ${organizationId}
+      AND slug = ${runtimeConnectionIdToSlug(delivery.connectionId)}
+      AND credential_mode IS NOT NULL
+      AND deleted_at IS NULL
+    LIMIT 1
+  `) as unknown as Array<{
+    connector_key: string;
+    agent_id: string | null;
+    status: string;
+  }>;
+  const connection = connectionRows[0];
+  if (!connection) return { authorized: false, reason: 'connection-missing' };
+  if (connection.connector_key !== delivery.platform) {
+    return { authorized: false, reason: 'platform-changed' };
+  }
+  if (connection.status !== 'active') {
+    return { authorized: false, reason: 'connection-inactive' };
+  }
+  if (connection.agent_id) {
+    return connection.agent_id === agentId
+      ? { authorized: true }
+      : { authorized: false, reason: 'agent-mismatch' };
+  }
+
+  const bindingRows = delivery.teamId
+    ? await sql`
+        SELECT agent_id
+        FROM agent_channel_bindings
+        WHERE organization_id = ${organizationId}
+          AND platform = ${delivery.platform}
+          AND channel_id = ${delivery.channelId}
+          AND team_id = ${delivery.teamId}
+        LIMIT 1
+      `
+    : await sql`
+        SELECT agent_id
+        FROM agent_channel_bindings
+        WHERE organization_id = ${organizationId}
+          AND platform = ${delivery.platform}
+          AND channel_id = ${delivery.channelId}
+          AND team_id IS NULL
+        LIMIT 1
+      `;
+  const binding = (bindingRows as unknown as Array<{ agent_id: string }>)[0];
+  return binding?.agent_id === agentId
+    ? { authorized: true }
+    : { authorized: false, reason: 'channel-unbound' };
 }
 
 export interface ScheduledJobRow {

--- a/packages/server/src/tools/admin/manage_schedules.ts
+++ b/packages/server/src/tools/admin/manage_schedules.ts
@@ -22,6 +22,7 @@ import { type Static, Type } from '@sinclair/typebox';
 import { action, defineActionTool } from './action-tool';
 import {
   createScheduledJob,
+  type DeliveryAuthzDenyReason,
   deleteScheduledJob,
   getScheduledJob,
   isDeliverableChatPlatform,
@@ -29,13 +30,12 @@ import {
   pauseScheduledJob,
   type ScheduledDeliveryContext,
   type ScheduledJobRow,
+  validateDeliveryAuthorization,
 } from '../../scheduled/scheduled-jobs-service';
 import type { ToolContext, ToolSourceContext } from '../registry';
 import logger from '../../utils/logger';
 import { nextRunAt as nextCronTickAt } from '../../utils/cron';
 import { getErrorMessage } from "@lobu/core";
-import { getDb } from '../../db/client';
-import { runtimeConnectionIdToSlug } from '../../lobu/stores/connections-projection';
 
 // ============================================
 // Schema
@@ -247,6 +247,19 @@ function sourceToDeliveryContext(
   };
 }
 
+const DELIVERY_DENY_MESSAGE: Record<DeliveryAuthzDenyReason, string> = {
+  'connection-missing':
+    'Cannot schedule chat delivery: source connection no longer exists.',
+  'platform-changed':
+    'Cannot schedule chat delivery: source connection platform changed.',
+  'connection-inactive':
+    'Cannot schedule chat delivery: source connection is not active.',
+  'agent-mismatch':
+    'Cannot schedule chat delivery for a different agent on this connection.',
+  'channel-unbound':
+    'Cannot schedule chat delivery: channel is not bound to the target agent.',
+};
+
 async function resolveTrustedDeliveryContext(
   payload: Static<typeof CreateAction>['payload'],
   ctx: ToolContext
@@ -256,57 +269,14 @@ async function resolveTrustedDeliveryContext(
   const context = sourceToDeliveryContext(ctx.sourceContext);
   if (!context) return { context: null };
 
-  const sql = getDb();
-  const connectionRows = (await sql`
-    SELECT connector_key, agent_id, status
-    FROM connections
-    WHERE organization_id = ${ctx.organizationId}
-      AND slug = ${runtimeConnectionIdToSlug(context.connectionId)}
-      AND credential_mode IS NOT NULL
-      AND deleted_at IS NULL
-    LIMIT 1
-  `) as unknown as Array<{ connector_key: string; agent_id: string | null; status: string }>;
-  const connection = connectionRows[0];
-  if (!connection) {
-    return { context: null, error: 'Cannot schedule chat delivery: source connection no longer exists.' };
+  const result = await validateDeliveryAuthorization({
+    organizationId: ctx.organizationId,
+    agentId: payload.agent_id,
+    delivery: context,
+  });
+  if (!result.authorized) {
+    return { context: null, error: DELIVERY_DENY_MESSAGE[result.reason] };
   }
-  if (connection.connector_key !== context.platform) {
-    return { context: null, error: 'Cannot schedule chat delivery: source connection platform changed.' };
-  }
-  if (connection.status !== 'active') {
-    return { context: null, error: 'Cannot schedule chat delivery: source connection is not active.' };
-  }
-  if (connection.agent_id) {
-    if (connection.agent_id !== payload.agent_id) {
-      return { context: null, error: 'Cannot schedule chat delivery for a different agent on this connection.' };
-    }
-    return { context };
-  }
-
-  const bindingRows = context.teamId
-    ? await sql`
-        SELECT agent_id
-        FROM agent_channel_bindings
-        WHERE organization_id = ${ctx.organizationId}
-          AND platform = ${context.platform}
-          AND channel_id = ${context.channelId}
-          AND team_id = ${context.teamId}
-        LIMIT 1
-      `
-    : await sql`
-        SELECT agent_id
-        FROM agent_channel_bindings
-        WHERE organization_id = ${ctx.organizationId}
-          AND platform = ${context.platform}
-          AND channel_id = ${context.channelId}
-          AND team_id IS NULL
-        LIMIT 1
-      `;
-  const binding = (bindingRows as unknown as Array<{ agent_id: string }>)[0];
-  if (!binding || binding.agent_id !== payload.agent_id) {
-    return { context: null, error: 'Cannot schedule chat delivery: channel is not bound to the target agent.' };
-  }
-
   return { context };
 }
 

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -30,6 +30,9 @@ export default defineConfig({
       "src/lobu/__tests__/**",
       "src/scheduled/**/__tests__/**",
       "src/workspace/**/__tests__/**",
+      // src/tools/admin/__tests__ is bun:test (schedule-delivery suites), run via
+      // the same `bun test … src/tools/admin/__tests__` job — keep it off vitest.
+      "src/tools/admin/__tests__/**",
       "**/node_modules/**",
       "**/dist/**",
     ],

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -189,7 +189,7 @@ INTEGRATION_EXIT=0
       bun test "$d" || rc=1
     done
     exit $rc );                                                                        ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
-  (cd packages/server && bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__); ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
+  (cd packages/server && bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__); ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
 } > "$INTEGRATION_LOG" 2>&1
 set -e
 


### PR DESCRIPTION
Follow-up cleanup to #1589.

`resolveTrustedDeliveryContext` (create-time, in manage_schedules) and `deliveryContextStillAuthorized` (fire-time, in scheduled/jobs.ts) ran the same connection + channel-binding authorization query, differing only in their return shape (a user-facing error string vs a boolean).

This collapses both into one `validateDeliveryAuthorization` in `scheduled-jobs-service.ts` that returns a discriminated `{ authorized: true } | { authorized: false, reason }`. `manage_schedules` maps the reason to its existing error message via `DELIVERY_DENY_MESSAGE`; `scheduled/jobs.ts` reads the boolean. One copy of the authorization logic instead of two that could drift.

No behavior change. The existing delivery tests cover both seams (create-time storage/stripping/binding + fire-time dispatch/fall-through), and I also live-verified it: a real running app's ticker fired a seeded wake_agent job, the dedupe validator authorized it against the live connection, and the handler enqueued the slack platform message (delivery path, not the api fallback) for the originating channel.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785430255&installation_id=136316292&pr_number=1643&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1643&signature=86b8d545c3f1e376cb29b4ade102dfef3fbe13671c3a0dc48d8de59b7b35fa2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->