### PR TITLE
docs(plans): chat-feeds consolidation program (4-workstream implementation plans)

### DIFF
--- a/docs/plans/chat-feeds/README.md
+++ b/docs/plans/chat-feeds/README.md
@@ -1,0 +1,143 @@
+# Chat-feeds consolidation program
+
+Make chat (Slack first) a first-class **data source**: channels become streaming
+feeds, senders get attributed to person entities, the bot can be driven into
+channels by an agent, and identities bridge across sources (a GitHub committer
+and a Slack sender can be the same person). The feed model is the *home* for all
+of this; the capabilities below are what actually unlock it.
+
+This directory holds the build plan, split into four workstreams (A–D), each with
+its own doc. Read this README first — it carries the cross-cutting decisions and
+the corrections that each workstream depends on.
+
+## Why now / the prod reality
+
+This program targets a subsystem that is **near-empty in production today**:
+
+- `channel_messages` has **3 rows** in prod (read-only count, 2026-06-30).
+- **0** managed-Slack (`slackinst-`) transcripts exist (so the managed read-orphan
+  bug — real in code — has **zero** current blast radius).
+- Listening to all public channels: **absent** (no `conversations.join`/`list`).
+- Slack messages as person events: **absent** (Slack connector is OIDC-login-only,
+  no message ingestion, no `slack_user_id` entity links).
+- Cross-source identity (GitHub committer ↔ Slack sender): **does not work** —
+  no shared identifier bridges the two, and Slack senders aren't entities at all.
+
+So the consolidation is **plumbing ahead of demand**. The high-value work is the
+three unbuilt capabilities (ingestion, channel ops, identity bridge); the feed
+model is where they should live. Prioritize accordingly (see §Sequencing).
+
+## Validated facts (de-risking already done)
+
+- **Channel→connection reconciliation works on real data.** Mapping
+  `channel_messages.connection_id` (text) → `connections.id` (bigint) via
+  `connections.slug = CASE WHEN connection_id LIKE 'slackinst-%' THEN connection_id
+  ELSE 'agentconn-'||connection_id END` (org-scoped) returned **0 orphans** on prod.
+  A `text→bigint` column migration is **not** needed — the deterministic slug-join
+  works on the existing text column.
+- **A channel is already feed-shaped.** `events`↔`feeds` join on
+  `(connection_id, feed_key)`; for a channel, `feed_key = channel_id`. The natural
+  key exists; no per-row `feed_id` denormalization is required for reads.
+- **The two scariest ACL edge cases hold** (proven on a scratch DB): cross-org
+  isolation via a shared preview connection, and duplicate channel bindings across
+  two connections — both stay correct **as long as `organization_id` +
+  `connection_id` remain first-class in the key** (never fold them into a single
+  "feed identity").
+
+## The four workstreams
+
+| WS | Title | Unlocks | Doc |
+|----|-------|---------|-----|
+| **A** | Slack message ingestion as a person-attributed streaming feed | data + attribution + the feed model, together. **Keystone.** | [ws-a-slack-ingestion.md](./ws-a-slack-ingestion.md) |
+| **B** | Slack channel operations (list/join) as connection actions + auto-join driver | builder-agent "add bot to all public channels" | [ws-b-channel-operations.md](./ws-b-channel-operations.md) |
+| **C** | Cross-source identity bridges | GitHub committer ↔ Slack sender = same person | [ws-c-identity-bridges.md](./ws-c-identity-bridges.md) |
+| **D** | Feed model foundation + read registry + Channels UI/API fold | the architectural home; the one standalone correctness win (ACL-gated reader registry) | [ws-d-feed-model-fold.md](./ws-d-feed-model-fold.md) |
+
+## Cross-cutting corrections (each WS depends on these)
+
+The planning surfaced facts that contradict the naive framing — implementers must
+honor them:
+
+1. **`feeds.kind` does not exist on `main`.** It lives only on the abandoned PR
+   #1612 branch (`feat/feed-consolidation`). WS-D owns landing `kind`; WS-A's
+   streaming-feed work depends on it. Exactly one workstream introduces the column —
+   sequence WS-D's `kind` migration before WS-A's streaming materialization (or
+   WS-A ships a guarded `IF NOT EXISTS` precursor). Close #1612 by folding its
+   `kind` migration into WS-D.
+
+2. **`slack_user_id` is team-scoped.** It is stored as
+   `normalizeSlackUserId(teamId, userId)` = `T…:U…` upper-cased — not the bare
+   `U…`. `channel_messages` has **no `team_id`**, and the sign-in OIDC `sub` is the
+   bare `U…`. So both WS-A (attribution) and WS-C (the cheap sign-in win) must
+   reconstruct the `T:U` key from a `team_id` they currently don't have at hand.
+   WS-A adds `channel_messages.team_id`; WS-C reads the Slack `team_id` claim from
+   userinfo.
+
+3. **Slack has no `connections` row.** Install writes only an `app_installations`
+   row (`slackinst-<uuid>`); per-agent `/lobu link` writes `agent_connections`.
+   The operations framework (`manage_operations`) is `connections`-native, so WS-B
+   must first create one `connections` row per (org, workspace) before any Slack
+   action is callable. And neither credential resolver reaches the bot token today
+   — WS-B resolves it natively via the proven `slack-acl-sync` token path.
+
+4. **Email alone cannot merge two already-primaried entities.** A GitHub `person`
+   is primaried on `github_user_id`; a Slack `person` on `slack_user_id`. The
+   resolution engine, when a primary is present, ignores secondary identities
+   (email) for resolution and only *accretes* them — and refuses ambiguous merges.
+   So the third-party GitHub↔Slack bridge does **not** form by lazy accretion; it
+   needs an explicit, confidence-gated **reconciliation/merge job** (WS-C #5). The
+   authenticated-user bridge (one `$member` hub) does work via accretion.
+
+5. **Keep `events` and `channel_messages` as two stores.** `channel_messages` is
+   the cheap, prunable, un-embedded transcript lane that exists specifically to
+   keep high-volume chat out of the embed pipeline (the congestion-collapse path).
+   `kind ⊥ store`: a feed's store pointer is adapter metadata, independent of its
+   kind. Attribution lives on `channel_messages` rows (store-only), **not** by
+   emitting embedded events.
+
+6. **The channels surface is smaller than billed.** The REST island is **6 routes**
+   in one file (`channels.ts`), not ~16; the redundant chat-connection CRUD is
+   already MCP-tool-based (it does not exist as REST). So WS-D's fold is a 6-route
+   re-home + the owletto channel component tree, not a sweeping API deletion.
+
+## Dependency graph & sequencing
+
+```
+Ship first (independent, low-risk, standalone value):
+  WS-D Part 2   Reader registry + ACL gate as a REQUIRED typed arg   (the one correctness win)
+  WS-D Part 1a  Land feeds.kind migration + close #1612
+  WS-C #1       Persist slack_user_id on $member at sign-in          (cheap win, immediate ACL benefit)
+  WS-C #3 G1/G2 Identity-email guardrails                            (must precede any email identity write)
+
+Keystone:
+  WS-A          Slack ingestion as person-attributed streaming feed  (needs feeds.kind from WS-D 1a)
+                └─ folds in the managed-Slack read-orphan fix
+
+Parallel / after:
+  WS-B          Channel operations + auto-join driver                (independent; integrates with WS-A binding/capture)
+  WS-C #2/#3/#5 Slack email capture, GitHub email identity, merge job (rides on WS-A; merge job delivers the 3rd-party bridge)
+  WS-D Part 3   Channels UI/API fold                                 (needs WS-A streaming-feed model)
+
+Explicitly deferred (no caller demand at 3 prod rows):
+  WS-D Phase B  virtual→kind reader flip + drop the virtual column
+  WS-D          full FeedReader<S,L> matrix / ResultFor<L> unification
+```
+
+**Recommended first PRs** (each independently valuable, none requires the others):
+WS-D Part 2 (ACL-gated reader registry), WS-C #1 (sign-in slack_user_id), and
+WS-D Part 1a (land `kind` + close #1612). The keystone (WS-A) follows once `kind`
+is in.
+
+## Invariants no workstream may break
+
+- **Multi-replica:** all streaming runtime/checkpoint state is Postgres-mediated;
+  no in-memory cross-pod state; exclusive transports (Telegram polling) stay
+  single-claimant via the `connection_claims` lease. New scheduled work (auto-join,
+  reconcile) is single-claimant or idempotent.
+- **ACL:** `organization_id` + `connection_id` stay first-class in every recall
+  key; never collapse them into a single feed identity (silent bypass / fail-closed).
+- **Append-only `events`:** never route `channel_messages` into the embed pipeline.
+- **Migrations:** squawk-safe (additive nullable/constant-default; `NOT VALID` +
+  `VALIDATE`; `CONCURRENTLY` indexes in their own migration).
+- **Bug-fix portions** (managed-orphan fix, channel fold) carry a red→green E2E
+  reproducer per the repo's E2E hard gate.

--- a/docs/plans/chat-feeds/ws-a-slack-ingestion.md
+++ b/docs/plans/chat-feeds/ws-a-slack-ingestion.md
@@ -1,0 +1,262 @@
+# WS-A (KEYSTONE) — Slack message ingestion as a person-attributed streaming feed
+
+> Status: plan, ready for an implementer. Depends on WS-D landing `feeds.kind`.
+> Folds in the managed-Slack read-orphan fix. See [README](./README.md) for
+> cross-cutting decisions.
+
+## Goal
+Make inbound Slack channel messages first-class data: each channel becomes a
+`streaming` feed, and senders get attributed to person entities — so "who said
+what across sources" becomes queryable. Keystone that unlocks data + identity +
+the feed model together.
+
+## Verification of grounded findings (confirmed vs corrected)
+
+| Claim | Status | Evidence |
+|---|---|---|
+| `channel_messages` is flat, no `entity_id`/`feed_id`, dedup `UNIQUE(connection_id, channel_id, platform_message_id)` | CONFIRMED | `db/migrations/20260618130000_channel_messages.sql` |
+| 4 writers, all pass runtime text connection id | CONFIRMED | `message-handler-bridge.ts:406`, `:639`; `chat-response-bridge.ts:411`; `routes/internal/conversations.ts:206`; all funnel through `captureChannelMessage` → `persistChannelMessage` (`gateway/connections/channel-transcript.ts:37`) |
+| Slug-join reconciliation rule | CONFIRMED | matches the keys minted by `20260629000030_connections_unify_backfill.sql` |
+| `feeds` natural key `(connection_id, feed_key)`; channel feed = `(connection_id, feed_key=channel_id)` | CONFIRMED logical key, **NOT DB-enforced** | `feeds` pkey is `id` only; no unique index on `(connection_id, feed_key)` exists — must add a partial unique index for idempotent upsert |
+| Entity-link engine runs on `events`, read-time join on `events.metadata->>ns` | CONFIRMED | `utils/entity-link-upsert.ts`, `utils/content-search/entity-link.ts:57-71` |
+| `slack_user_id` is a standard read-time namespace | CONFIRMED | `content-search/entity-link.ts:27` |
+| Recall matches `cm.connection_id = c.id` from `resolveBoundChannelRows`, which never yields `slackinst-` ids | CONFIRMED → managed read-orphan is real | `tools/search.ts:395`, `:408-413`; `bound-channels.ts:72` |
+| `#1630` `createWhen` gate + alias seeding | CONFIRMED | `passesCreateWhen` (`entity-link-upsert.ts:176`); gate on create branch (`:715`); `ensureAliases` (`:203`, `:391`) |
+
+**Corrections to absorb:**
+1. **`feeds.kind` does NOT exist on main** (only on #1612 branch). The
+   `kind='streaming'` model is owned by **WS-D**. WS-A depends on WS-D landing
+   `kind` first, or ships a guarded precursor migration. See §Dependencies.
+2. **`slack_user_id` is team-scoped**: `normalizeSlackUserId(teamId, userId)` →
+   `T…:U…` (`connector-sdk/src/identity-normalize.ts:85`). `channel_messages`
+   stores bare `U…` and has no `team_id`. Attribution needs the team id at
+   resolve-time. Biggest new constraint.
+3. **The scheduler already excludes streaming feeds for free**: a streaming feed
+   with `next_run_at = NULL` is never picked by `check-due-feeds.ts:48`. No
+   scheduler change needed.
+
+## Core design fork — RESOLVED: store-only attribution, no events emitted
+
+**Add `author_entity_id` to `channel_messages` and resolve senders via the
+entity-link engine's primitives, WITHOUT emitting any `events` row.**
+
+- Attribution is an identity join (`slack_user_id` → `entity_identities` →
+  `entities`); it does not require embedding.
+- Emitting a person-attributed event per chat message pushes high-volume
+  operational chat into the curated `events` store — the embed-congestion path the
+  team has hit twice. Rejected.
+- `kind ⊥ store` holds: the feed gets `kind='streaming'`; its store pointer
+  (`config->>'store' = 'channel_messages'`) is adapter metadata, independent of
+  kind. Attribution lives on the store row.
+- Read path stays on `channel_messages` (`tools/search.ts:361`
+  `fetchConversationSnippets`). Putting attribution on that table means the
+  existing recall path light-touches into person attribution.
+- Store `author_entity_id` (denormalized FK) + `team_id` so the row is
+  self-describing and the FK is recomputable on entity merges. `channel_messages`
+  is prunable operational data (not append-only), so a recomputable FK is fine
+  here where it would not be for `events`.
+- Keep `channel_messages` OUT of the embed pipeline: WS-A adds a separate
+  `resolveChannelMessageSender` entry point that calls only the lower-level
+  identity primitives (`lookupMatches`, `createEntityWithIdentities`,
+  `insertIdentities`, `ensureAliases`, `passesCreateWhen`). No `events` INSERT,
+  no embedding enqueue, ever.
+
+## Phase plan (expand → backfill → contract; each phase shippable)
+
+### Phase 0 — Expand schema (additive, no behavior change)
+
+`db/migrations/<ts>_channel_messages_attribution.sql`:
+```sql
+-- migrate:up
+ALTER TABLE public.channel_messages
+    ADD COLUMN IF NOT EXISTS author_entity_id bigint,
+    ADD COLUMN IF NOT EXISTS team_id text;          -- workspace id (T…); reconstructs slack_user_id key
+
+ALTER TABLE public.channel_messages DROP CONSTRAINT IF EXISTS channel_messages_author_entity_fkey;
+ALTER TABLE public.channel_messages
+    ADD CONSTRAINT channel_messages_author_entity_fkey
+    FOREIGN KEY (author_entity_id) REFERENCES public.entities(id) ON DELETE SET NULL NOT VALID;
+ALTER TABLE public.channel_messages VALIDATE CONSTRAINT channel_messages_author_entity_fkey;
+
+CREATE INDEX IF NOT EXISTS idx_channel_messages_author_entity
+    ON public.channel_messages (author_entity_id) WHERE author_entity_id IS NOT NULL;
+-- migrate:down
+ALTER TABLE public.channel_messages DROP CONSTRAINT IF EXISTS channel_messages_author_entity_fkey;
+DROP INDEX IF EXISTS idx_channel_messages_author_entity;
+ALTER TABLE public.channel_messages DROP COLUMN IF EXISTS team_id, DROP COLUMN IF EXISTS author_entity_id;
+```
+
+`db/migrations/<ts>_feeds_streaming_uniq.sql` (idempotent lazy-upsert support):
+```sql
+-- migrate:up
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS feeds_streaming_channel_uniq
+    ON public.feeds (connection_id, feed_key)
+    WHERE kind = 'streaming' AND deleted_at IS NULL;
+-- migrate:down
+DROP INDEX CONCURRENTLY IF EXISTS feeds_streaming_channel_uniq;
+```
+> Blocked on WS-D `feeds.kind`. If WS-D hasn't landed it, ship a guarded precursor
+> (`ALTER TABLE feeds ADD COLUMN IF NOT EXISTS kind text NOT NULL DEFAULT 'collected'`
+> + check constraint allowing `'streaming'`). Exactly one workstream owns the column.
+
+### Phase 1 — Sender → person resolution (the keystone)
+
+New `resolveChannelMessageSender` in `packages/server/src/utils/entity-link-upsert.ts`,
+reusing existing private helpers. Produces NO event item and stamps no
+`events.metadata`; returns the entity id and (on create) seeds `entity_identities`
++ `metadata.aliases`.
+
+```ts
+const SLACK_PERSON_ENTITY_LINK = {
+  entityType: 'person',
+  autoCreate: true,
+  titlePath: 'author_name',
+  createWhen: { path: 'is_bot', equals: false },   // #1630 gate: never mint a person for the bot
+  identities: [
+    { namespace: IDENTITY.SLACK_USER_ID, /* value = normalizeSlackUserId(teamId, slackUserId) */ primary: true },
+    { namespace: IDENTITY.EMAIL /* WS-C, secondary cross-source collapse */ },
+  ],
+};
+```
+Rules:
+- createWhen skips auto-create when `is_bot=true`, `teamId` is null, or no identity
+  normalizes. Matching an existing person is still allowed.
+- Build `normalizeSlackUserId(teamId, slackUserId)`; a bare `U…` without team is
+  dropped, never stored.
+- Because `slack_user_id` is the same namespace the ACL graph uses
+  (`authz/slack-channel-graph.ts:86`, `channel-visibility.ts:109`), a sender
+  resolves onto the SAME entity a signed-in user owns — attribution and ACL
+  converge.
+
+Thread `teamId` into capture (`channel-transcript.ts:19,37,56-67`): add `teamId`
+param; after the INSERT, resolve the sender and set `author_entity_id` + `team_id`
+(or resolve-first then insert both). Keep best-effort/fire-and-forget — resolution
+failure must never block a turn/webhook ack. Bot rows (`is_bot=true`) get NULL
+`author_entity_id` (correct — the bot is not a person).
+
+Wire `teamId` at the 4 call sites (all have it in scope): `message-handler-bridge.ts:406`,
+`:639`; `chat-response-bridge.ts:411` (derive from platform metadata or leave NULL
+for bot rows); `routes/internal/conversations.ts:206` (bot row, optional).
+
+Backfill `db/migrations/<ts>_backfill_channel_message_attribution.sql` (trivial
+volume, ~3 rows): derive `team_id` via slug-join to `connections.external_tenant_id`,
+then match-only UPDATE `author_entity_id` by joining `entity_identities` on
+`namespace='slack_user_id' AND identifier = upper(team_id||':'||author_id)`. No
+auto-create in the backfill; newly-seen senders attribute lazily on next message.
+
+### Phase 2 — Channel → feed materialization (lazy, no mass backfill)
+
+New `ensureStreamingChannelFeed` (in `channel-transcript.ts` or a new
+`gateway/channels/streaming-feed.ts`), called once per message (idempotent):
+1. Resolve `connections.id` from runtime text `connection_id` via the validated
+   slug-join (one indexed lookup on `connections_org_slug_unique`).
+2. `INSERT INTO feeds (...,feed_key=channel_id, kind='streaming',
+   config=jsonb_build_object('store','channel_messages'), virtual=false)
+   ON CONFLICT (connection_id, feed_key) WHERE kind='streaming' AND deleted_at IS NULL
+   DO NOTHING`. Leave `schedule`/`next_run_at`/`checkpoint` NULL so the scheduler
+   never queues it.
+3. Lazy: only the first message per `(connection, channel)` writes.
+
+The message-capture choke point IS the membership signal (the bot only captures
+from channels it is a member of), so "first message captured" ≈ "bot is in this
+channel" — exactly when streaming-feed state is first needed. No separate
+`member_joined_channel` handler required.
+
+### Phase 3 — Recall re-key + managed-Slack read-orphan fix (E2E hard gate)
+
+Re-key `fetchConversationSnippets` (`tools/search.ts:361`) to
+`(org, connection_id, feed_key=channel_id)` — a **naming/conceptual** lift only.
+The physical join columns are unchanged: `connection_id` (runtime text) stays the
+join key against `cm.connection_id` AND the key into `authz_source_acl_state`;
+`feed_key` is the renamed `channel_id`.
+
+> **HARD ACL WARNING:** do NOT collapse `(org, connection_id, channel_id)` into an
+> opaque feed identity or `feeds.id`. `channel-visibility.ts:179-221` gates on
+> `connection_id` (`getConnectionEnforcement`) and `(team_id, channel_id)`. Folding
+> these causes a silent ACL bypass (a feed.id that doesn't carry connection_id
+> can't be enforced) or fail-closed. Keep `organization_id` + `connection_id`
+> first-class; the ACL inputs must be byte-identical before/after. Test asserts it.
+
+Managed-Slack read-orphan fix — new UNION branch (C) in `resolveBoundChannelRows`
+(`bound-channels.ts:60`), org-scoped, joining `app_installations` (provider='slack',
+active) to its bindings, emitting the `slackinst-<external_id>` runtime id as `id`
+so `cm.connection_id = c.id` matches:
+```sql
+UNION
+SELECT ('slackinst-' || COALESCE(ai.metadata->>'external_id','')) AS id, 'slack',
+       b.channel_id, b.team_id, b.created_at
+FROM app_installations ai
+JOIN agent_channel_bindings b
+  ON b.organization_id = ai.organization_id AND b.platform = 'slack' AND b.team_id = ai.external_tenant_id
+WHERE ai.organization_id = ${organizationId} AND ai.provider='slack' AND ai.status='active'
+```
+> The `slackinst-` id must match what the writers persist as
+> `channel_messages.connection_id` AND the id under which `authz_source_acl_state`
+> is stamped. Verify against a real managed install. Land once in `bound-channels.ts`
+> (its header declares it the single source of truth) — consumed by recall,
+> `read_conversation`, notifications, and ACL sync.
+
+### Phase 4 — Contract (out of WS-A core)
+Once `connections` is the sole runtime source, collapse the slug-join into a
+direct `connections.id` FK on `channel_messages` and drop branch-C's text-id
+gymnastics. Not required for WS-A value.
+
+## Multi-replica correctness
+- `resolveChannelMessageSender`: all state in PG; `entity_identities`
+  `UNIQUE(org, namespace, identifier)` + `ON CONFLICT DO NOTHING`; existing
+  lost-create-race handling (`entity-link-upsert.ts:736-764`). No new in-memory
+  cross-pod state.
+- `ensureStreamingChannelFeed`: idempotent upsert on `feeds_streaming_channel_uniq`.
+- Exclusive transports (Telegram polling): untouched; WS-A adds no transport.
+- Streaming feeds carry NULL `checkpoint`/`next_run_at`; the runtime that writes
+  them is the existing message-handler path (webhook idempotency + `channel_messages`
+  dedup constraint).
+
+## Tests (red→green integration; seed connections + channel_messages + feeds)
+1. Attribution, BYO — known `slack_user_id=T1:U1` → `author_entity_id` resolves.
+2. Auto-create + createWhen — unknown non-bot sender mints a person; `is_bot=true`
+   mints nothing (NULL).
+3. No `team_id` → no orphan, no malformed `slack_user_id`.
+4. Cross-source collapse — pre-seeded `$member` with `slack_user_id=T1:U1` →
+   attribution lands on the existing member, no duplicate.
+5. Feed materialization — first capture creates one streaming feed; second is
+   idempotent; `config->>'store'='channel_messages'`, `next_run_at` NULL.
+6. Feed-keyed recall — `fetchConversationSnippets` returns the message + attributed
+   person, joining via `(org, connection_id, feed_key=channel_id)`.
+7. Managed-install recall (orphan fix) — `slackinst-` row becomes recallable.
+8. ACL isolation — enforced connection + non-member → nothing; member → rows.
+   Assert the re-key did not change ACL inputs. **Must not ship without this test.**
+
+E2E hard gate for the bug-fix portion (Phase 3): managed Slack install → user
+posts → recall attributes the right person and respects ACL.
+
+## Files to touch
+New: the 3–4 migrations above; `resolveChannelMessageSender` +
+`SLACK_PERSON_ENTITY_LINK` in `utils/entity-link-upsert.ts`.
+Modify: `gateway/connections/channel-transcript.ts:19,37,56-67,71`;
+`message-handler-bridge.ts:406,639`; `chat-response-bridge.ts:411`;
+`routes/internal/conversations.ts:206`; `gateway/channels/bound-channels.ts:60-115`
+(UNION branch C); `tools/search.ts:361-431` (recall re-key, ACL inputs unchanged).
+
+## Dependencies
+- **WS-C (identity)** — soft/additive: provides sender email; the rule's `email`
+  secondary degrades gracefully (slack_user_id-only) until WS-C lands.
+- **WS-D (feed model)** — hard, on `feeds.kind`: sequence WS-D's `kind` column
+  before WS-A Phase 0, or WS-A ships the guarded precursor. WS-A hands WS-D the
+  materialization choke point + the `kind ⊥ store` convention.
+- **Managed-orphan fix** — shared infra in `bound-channels.ts`; land once.
+
+## Risks (ranked)
+1. **(HIGH) ACL silent-bypass on recall re-key.** Keep org+connection_id
+   first-class; test #8 asserts byte-identical ACL inputs. Must not ship without it.
+2. **(HIGH) Managed-install runtime-id format mismatch.** Branch C must emit the
+   exact `slackinst-…` string the writers persist and that keys `authz_source_acl_state`.
+   Verify against a real managed install before E2E.
+3. **(MED) `feeds.kind` ownership race with WS-D.** Explicit sequencing; guarded
+   `IF NOT EXISTS` precursor.
+4. **(MED) `team_id` at all 4 writers.** Inbound + backfill have it; bot rows don't
+   need attribution.
+5. **(MED) Denormalized `author_entity_id` staleness on entity merge.**
+   Recomputable from retained `team_id`+`author_id`; add a follow-up re-resolve tick.
+6. **(LOW) Auto-create volume / hot-path latency.** createWhen blocks bots;
+   team-scoped key prevents cross-org bleed; keep resolution fire-and-forget.

--- a/docs/plans/chat-feeds/ws-b-channel-operations.md
+++ b/docs/plans/chat-feeds/ws-b-channel-operations.md
@@ -1,0 +1,229 @@
+# WS-B — Slack channel operations (list/join) as connection actions + auto-join driver
+
+> Status: plan, ready for an implementer. Mostly independent; integrates with WS-A
+> for binding/capture. See [README](./README.md) for cross-cutting decisions.
+
+## Goal
+Let an agent (esp. the per-org builder agent) add the Slack bot to public channels
+and enumerate channels via **connection actions**, plus a driver to auto-join all
+public channels so the bot listens workspace-wide. Today the bot only receives
+messages from channels it is manually invited to.
+
+## Central grounded correction (lead with the risk)
+
+**Slack does not live in the operations world at all.** `manage_operations.execute`
+targets rows in the **`connections`** table by `connection_id`
+(`operations/connector-operations.ts:481-495`). Slack writes only an
+`app_installations` row at install (`slack-connection-coordinator.ts:154` —
+*"This is NOT an agent_connections row"*) plus per-agent `agent_connections` rows
+at `/lobu link`. There is **no `connections` row for Slack**. So
+`manage_operations.execute` has nothing to point at, and neither credential
+resolver reaches the bot token:
+- `http_operation` → `resolveCredentialsByConnectionId` hard-joins
+  `auth_profiles … profile_kind='oauth_account'`; the bot token is in the secret
+  store (`installations/<id>/botToken`), not an oauth_account. Returns null.
+- `local_action` → `resolveExecutionAuth` has an app-installation branch, but the
+  installation-token registry only registers `GitHubInstallationTokenProvider`
+  (`gateway/installation/registry.ts:23`) — no Slack provider ⇒ throws.
+
+The **proven** bot-token path already used in prod is `slack-acl-sync.ts:226-235`:
+`getSlackInstallByTeamId(store, teamId)` → `install.config.botToken` →
+`resolveSecretValue(secretStore, ref)` under `orgContext.run({organizationId})`.
+
+→ Two strategies; **Approach 1 (native gateway action handler) recommended** —
+reuses the proven token path, avoids compiling the deliberately-inert Slack
+connector. **Approach 2 (full framework: Slack InstallationTokenProvider +
+compiled connector)** documented as the heavier "framework-pure" alternative.
+
+## Phase 0 — Slack Web API surface (shared by ops + driver)
+`gateway/connections/slack-web.ts`: add to `SlackWebApi` + `createSlackWebApi`,
+reusing the form-encoded `slackPost` helper:
+- `conversationsList(botToken, {types,excludeArchived})` — `conversations.list`,
+  `types='public_channel'`, cursor-paginated. Returns `{id,name,isPrivate,isMember,isArchived}`.
+- `conversationsJoin(botToken, channelId)` — `conversations.join`; treat
+  `already_in_channel` as success, `method_not_supported_for_channel_type`/`is_archived`
+  as non-fatal skips. Needs a raw (`{ok,error}`) variant to inspect errors without
+  the throwing wrapper.
+- `conversationsInvite(botToken, channelId, userIds)` — optional.
+
+Add 429 handling to `slackPost` (read `Retry-After`, bounded retry): `conversations.list`
+is Tier-2 (~20/min), `conversations.join` Tier-3 (~50/min), per-workspace.
+
+## Phase 1 — Scopes & manifest (must precede join)
+`conversations.list` is already permitted (`channels:read`). `conversations.join`
+needs **`channels:join`**, currently missing.
+1. `connectors/src/slack.ts:36-56` — add `'channels:join'` to `SLACK_BOT_SCOPES`.
+2. `config/slack-app-manifest.self-install.json` + `qa-user.json` — add to bot scopes.
+3. (Optional, instant new-channel join) subscribe `channel_created` + add to
+   `SLACK_BOT_EVENTS`.
+4. Keep `scripts/slack-manifest.ts` parity (CI test asserts it).
+
+**Re-consent:** adding a bot scope means every already-installed workspace must
+reinstall before `conversations.join` succeeds (old token → `missing_scope`). The
+driver treats `missing_scope` as a soft, non-fatal, per-workspace condition (log
+once, surface on the connection, nudge admin via the connector-health Slack alert).
+
+## Phase 2 — A `connections` row for the workspace (the missing ops target)
+Create one `connections` row per (org, workspace), bound to the install, mirroring
+the GitHub pattern (`app-install.ts:415-560`, advisory-locked select-or-insert
+keyed on `config->>'installation_ref'`). Add `ensureSlackOperationsConnection(...)`
+in `slack-connection-coordinator.ts` `persistInstallation()` (~`:165`):
+- advisory lock; `SELECT … WHERE connector_key='slack' AND config->>'installation_ref'=$installId`;
+- if absent, `INSERT INTO connections (..., connector_key='slack', slug='slack-<team>',
+  config={installation_ref, team_id})`.
+- `config` carries only `installation_ref` + `team_id` (no channel target), like GitHub.
+
+Workspace-scoped (the bot acts as the app, not a per-agent identity) — correct for
+"add the bot to channels". Backfill: a one-shot task over active Slack
+`app_installations` (can ride the auto-join driver's first tick).
+
+> For Approach 2, `config.installation_ref` must be the **`app_installations`
+> bigint PK** (what `resolveAppInstallationCredential` loads), not the
+> `slackinst-<uuid>` external id. Approach 1 keys on `team_id`, so the PK only
+> matters for Approach 2.
+
+## Phase 3 — Declare Slack connector `actions` (discovery + gating)
+`connectors/src/slack.ts:71-152` — add an `actions` block (projected to
+`connector_definitions.actions_schema`, surfaced by `getLocalActionOperations`).
+Declaration-only; requires no feeds/sync/runtime.
+
+```
+list_channels   requiresApproval:false  input:{types?,exclude_archived?,cursor?}  output:{channels:[{id,name,is_private,is_member,is_archived}],next_cursor?}
+join_channel    requiresApproval:false  input:{channel_id}                        output:{ok,already_in,channel_id}
+post_message    requiresApproval:false  input:{channel_id,text}                   output:{ok,ts?}
+invite_users    requiresApproval:true   input:{channel_id,user_ids[]}             output:{ok}
+```
+`getLocalActionOperations` forces `kind:'write'` (cosmetic for `list_channels`).
+
+**Approval policy:** default `list_channels` + `join_channel` to `auto` (the
+builder agent must operate workspace-wide); `invite_users` to `approval`. Admins
+override per-op via `connection.config.action_modes` (`disabled|approval|auto`).
+The org-wide auto-join driver (Phase 5) bypasses the agent path, so `action_modes`
+governs only agent-initiated joins. The `actions` facet flips true automatically.
+
+## Phase 4 — Wire bot-token execution into the operations executor
+
+### Approach 1 (RECOMMENDED) — native gateway action handler
+Add a dispatch branch in `manage_operations.ts` `executeOperationInline` (`:481-505`):
+for a Slack `local_action`, call `executeSlackNativeAction(...)` instead of the
+compiled executor. The handler:
+1. reads `team_id` from `connection.config.team_id`;
+2. resolves the bot token via the proven `slack-acl-sync.ts:226-235` path under
+   `orgContext.run`; rejects if `install.organizationId !== orgId`;
+3. switches on `operation_key` → `conversationsList`/`conversationsJoin`/`postMessage`/`conversationsInvite`;
+4. after a `join_channel`, fires the per-channel binding/capture step (Phase 6);
+5. persists the run via existing `completeRunInline`/`failRunInline`.
+
+Set `requireCompiledCode:false` for the Slack native case (`:743`). Keep the
+connector-aware branch behind a tiny native-handler registry keyed by
+`connector_key` (mirrors the `onChromeDispatch` seam). Pros: reuses the exact
+proven token path, no Slack compilation, minimal blast radius.
+
+### Approach 2 (alternative) — Slack InstallationTokenProvider
+New `gateway/installation/slack-installation-token-provider.ts` implementing
+`InstallationTokenProvider` (`provider='slack'`, mint from `install.metadata.config.botToken`),
+registered in `registry.ts:20-26`. But `local_action` still requires **compiled
+Slack connector code** with `execute()` handlers — i.e. Slack stops being inert.
+Heavier. Keep steps 1–3 as a fast follow (the "right" abstraction) once another
+Slack op needs the framework path; Phase 2's `installation_ref` makes it a drop-in.
+
+## Phase 5 — Auto-join-all-public-channels driver
+Model exactly on `runSlackAclSyncTick` (`slack-acl-sync.ts:211-249`) — same query,
+token resolution, single-claimant scheduling — so multi-replica safety is inherited.
+
+New `gateway/connections/slack-auto-join.ts`:
+- `syncSlackWorkspaceJoins({organizationId,teamId})`: resolve token →
+  `conversationsList(public, excludeArchived)` → for each `isMember===false`,
+  `conversationsJoin` (idempotent; `missing_scope` → soft-degrade; 429 handled in
+  `slackPost`) → ensure binding+capture (Phase 6). Concurrency 1 (Tier-3 limit).
+- `runSlackAutoJoinTick(coreServices)`: query distinct active Slack workspaces from
+  **`app_installations`** (workspace-level, not per-agent); iterate; aggregate.
+
+Register in `scheduled/jobs.ts` alongside `:139-164`:
+`scheduler.register('slack-auto-join', …, { cron: '*/15 * * * *' })` — single-claimant
+per tick via the TaskScheduler runs-queue (same as `connection-health`/`authz-acl-sync`);
+`conversations.join` idempotency makes accidental double-claims harmless.
+
+Triggers (all idempotent, converge on `syncSlackWorkspaceJoins`):
+1. Install time — fire once after `ensureSlackOperationsConnection`.
+2. Incremental — `channel_created` webhook (if subscribed) joins just that channel.
+3. Periodic — the `*/15` tick (catches down-pod gaps, scope re-grants, drift).
+
+`member_joined_channel` (already subscribed) is the hook to (re)assert binding/capture
+when the bot is manually added — wire to Phase 6.
+
+## Phase 6 — Per-channel binding/capture (routability; WS-A seam)
+A joined channel only produces routable traffic with a binding + capture:
+- `createChannelBinding({organizationId, agentId:system_agent_id, platform:'slack',
+  channelId, teamId})` (`postgres-stores.ts:499-523`, idempotent).
+- Set `connection.settings.recordChannelMessages = true` (`types.ts:152`,
+  consumed at `message-handler-bridge.ts:424-433`) = "listen without responding".
+
+WS-A owns the binding/capture semantics; WS-B calls
+`ensureChannelRoutable(orgId, teamId, channelId)` after each join. If WS-A lands
+together, WS-A implements the body; else WS-B provides a minimal binding+capture.
+
+## Phase 7 — Builder-agent UX & gating
+`manage_operations.list_available {connection_id}` (the Phase-2 workspace row) →
+sees `list_channels`/`join_channel`/`post_message` (filtered by `action_modes`) →
+`execute {operation_key,input}`. `execute` is owner/admin-gated (`tool-access.ts:89`);
+an owner/admin-initiated builder turn (`system_agent_id`) satisfies it. The auto-join
+driver runs server-side, outside this gate. Verify `manage_operations` is exposed to
+the builder turn's tool set.
+
+## Schema / data
+No new tables. `connector_definitions.actions_schema` gains 3–4 actions (Phase 3,
+no DDL). One new `connections` row per (org, workspace) (Phase 2, no DDL).
+Existing `agent_channel_bindings` / `recordChannelMessages` (Phase 6). New runtime
+job row `slack-auto-join`.
+
+## Tests (mock Slack via the injectable `SlackWebApi` seam)
+1. `slack-web.ts` — pagination; `join` maps `already_in_channel`/`missing_scope`/429.
+2. `manage_operations` native dispatch — routes to `executeSlackNativeAction`,
+   resolves token, persists run; cross-org install rejected; `requireCompiledCode`
+   not enforced for Slack.
+3. action listing — `getOperationsSummary('slack').total` becomes 3–4;
+   `list_available` honors `action_modes`.
+4. auto-join — joins only non-member non-archived; idempotent; `missing_scope`
+   soft-degrades without throwing; one workspace failure doesn't abort others.
+5. multi-replica — concurrent `syncSlackWorkspaceJoins` both succeed; single-run per tick.
+6. install-time bridge — exactly one `connections` row per (org,team) under
+   concurrency; reinstall reuses it.
+7. binding/capture — post-join, binding + `recordChannelMessages` set; subscribed
+   non-mention message recorded but no turn.
+8. manifest/scope parity — `channels:join` in both `SLACK_BOT_SCOPES` and the
+   manifest JSONs.
+
+## Rollout / phasing
+1. PR1 — `slack-web.ts` methods + 429 + tests (no behavior change).
+2. PR2 — scopes + manifests + parity; deploy → reinstall hosted app for `channels:join`.
+3. PR3 — Phase 2 connections-row bridge + backfill (idempotent).
+4. PR4 — Phase 3 actions + Phase 4 Approach-1 executor + gating.
+5. PR5 — Phase 5 auto-join driver, **dark-launched** behind
+   `connection.config.auto_join_public` (default off) + kill-switch; pilot one org.
+6. PR6 — Phase 6 binding/capture hardening with WS-A; optional `channel_created`.
+7. PR7 (optional) — Approach-2 Slack InstallationTokenProvider.
+
+## Risks
+- **(High, user-facing) Re-consent gap** — existing installs lack `channels:join`;
+  soft per-workspace degrade + admin nudge; never crash the tick.
+- **(High, verified) Bot-token credential path** — neither resolver reaches it;
+  Approach 1 sidesteps via the native token path.
+- **Rate limits** — Tier-2/3 per workspace; pagination, concurrency 1, 429
+  Retry-After, 15-min cadence; large workspaces join gradually (idempotent).
+- **Noisy joins** — `connection.config.auto_join_public` flag (default off) +
+  optional allow/deny pattern.
+- **Inert-connector tension (Approach 2)** — adding `execute()` contradicts Slack's
+  INERT design; Approach 1 keeps it runtime-free.
+- **Cross-tenant token leak** — existing guards + explicit `install.organizationId === orgId` check.
+
+## Files to touch
+`gateway/connections/slack-web.ts` (methods + 429); `tools/admin/manage_operations.ts`
+(native dispatch `:481-505`, `requireCompiledCode` `:743`); `connectors/src/slack.ts`
+(actions `:71-152`, `channels:join` `:36-56`); new `gateway/connections/slack-auto-join.ts`
+(model on `slack-acl-sync.ts:211-249`) + register in `scheduled/jobs.ts:139-164`;
+`slack-connection-coordinator.ts` (`ensureSlackOperationsConnection` + install-time
+trigger ~`:165`). Secondary: `utils/execution-context.ts:409-591`,
+`gateway/installation/registry.ts` (Approach 2), the manifest JSONs,
+`stores/slack-installations.ts`, `stores/postgres-stores.ts:499-523`,
+`message-handler-bridge.ts:424-433`, `auth/tool-access.ts:89`.

--- a/docs/plans/chat-feeds/ws-c-identity-bridges.md
+++ b/docs/plans/chat-feeds/ws-c-identity-bridges.md
@@ -1,0 +1,199 @@
+# WS-C — Cross-source identity bridges (GitHub committer ↔ Slack sender = same person)
+
+> Status: plan, ready for an implementer. #1 is a cheap standalone win; the
+> third-party bridge needs the merge job (#5). See [README](./README.md).
+
+## Goal
+Let the system know a GitHub commit author and a Slack message sender are the same
+human, and attribute the authenticated user's Slack identity to their member
+entity. Today they stay separate entities with nothing in common.
+
+## Executive correctness summary (two findings change the design)
+
+**Finding A — `slack_user_id` is team-scoped; the OIDC `sub` is not.** The ACL
+channel graph stores `normalizeSlackUserId(teamId,userId)` = `T0XYZ:U12345`
+(`connector-sdk/src/identity-normalize.ts:85-95`). The sign-in OIDC `sub`
+(Better Auth `account.accountId`) is the **bare** `U12345` (`auth/config.ts:237-245`
+drops team). So writing the bare `sub` as `slack_user_id` will NOT match the
+channel-graph key and the ACL person keeps forking. #1 must reconstruct the
+combined `T:U`, which needs the Slack `team_id` claim
+(`https://slack.com/team_id`) from userinfo — available in `rawUserInfo`
+(`auth/social-login-provisioning.ts:59-65`).
+
+**Finding B — email alone CANNOT lazily bridge two already-primaried entities.**
+A GitHub `person` is primaried on `github_user_id` (`github.ts:270`); a Slack
+`person` on `slack_user_id` (`authz/sources.ts:36`). In `resolveLinksByKind`, when
+a primary is present, resolution is governed solely by primary hits; secondary
+identities (email) are only *accreted* (`entity-link-upsert.ts:643-668`), and
+accretion is `ON CONFLICT DO NOTHING` (`:691-696`). The ambiguous-`>1`-skip
+(`:670-681`) refuses to merge. So **two pre-existing primaried entities never merge
+via email**. Therefore:
+- The **authenticated-user bridge** (#1, #4) works — the `$member` is a single hub
+  carrying `slack_user_id` + `email`.
+- The **third-party GitHub↔Slack bridge** does NOT form by accretion — it requires
+  an explicit reconciliation/merge job (#5). #2/#3 are necessary but not sufficient.
+
+## #1 — Persist `slack_user_id` on `$member` at sign-in (CHEAP WIN, ship first)
+
+New `persistLoginSlackIdentity` in `auth/subject-identities.ts` (reuses
+`writeIdentities`), invoked from `auth/index.tsx`
+`databaseHooks.account.create.after` (`:825-854`) and `.update.after`.
+1. Extend `accountSummary` to capture `account.accountId` (the provider account id,
+   not just the Better Auth row PK).
+2. Gate on `providerId === 'slack'`.
+3. Resolve the tenant `$member` via the hardened `resolveTenantMember`
+   (`identity/auth-hook.ts:71-106`) — **export** it rather than duplicating the SQL.
+4. Obtain `team_id`: call `fetchUserInfoWithRaw({provider:'slack', accessToken, userinfoUrl})`
+   and read `raw['https://slack.com/team_id']` (one HTTP call on sign-in, fire-and-forget);
+   or read `auth_data->'identity'->>'https://slack.com/team_id'` from the just-written profile.
+5. `combined = normalizeSlackUserId(teamId, account.accountId)`; if null (missing
+   team / malformed), log and return — never write a bare id.
+6. `writeIdentities(sql, orgId, memberEntityId, 'auth:signup', [{namespace:'slack_user_id', identifier:combined}])`.
+   The `'auth:signup'` source is the anti-hijack guard the channel-visibility gate trusts.
+
+Idempotent (`ON CONFLICT … DO NOTHING`); safe from both hooks. **Immediate effect:**
+the next ACL channel-graph rebuild resolves the workspace member onto `$member`
+instead of forking — `resolveMembers` looks up `slack_user_id` type-agnostically and
+collapses onto ANY entity carrying it (`access-graph.ts:176-225`, union `:214-223`).
+
+**Backfill:** existing slack accounts lack the identity and we don't store team_id.
+Prefer **lazy** backfill via `account.update.after` on next token refresh (zero
+extra code); ship an active backfill (call userinfo per account) only if dormant
+coverage matters.
+
+## #2 — Slack sender email
+Add `'users:read.email'` to `SLACK_BOT_SCOPES` (`connectors/src/slack.ts:36-56`) —
+a manifest/scope change requiring workspace re-consent (existing installs keep the
+old token; email capture degrades gracefully — missing email never blocks ingestion).
+
+Add `usersInfo(botToken, slackUserId)` to `SlackWebApi` (`slack-web.ts:15-127`),
+mirroring `conversationMembers`: `users.info` → `json.user.profile.email` (present
+only with `users:read.email`) + `json.user.team_id`. Lives in **WS-B** (shared
+low-level call); consumed by **WS-A** ingestion.
+
+Where to write: in the channel-graph builder (`authz/slack-channel-graph.ts:84-93`),
+when the scope is granted, enrich each member with `users.info` → add
+`{namespace:'email', value:profileEmail}` to the member's identities, and extend
+`SLACK_SOURCE.memberIdentities` (`sources.ts:36`) to include `{namespace:'email'}`.
+Normalize via `normalizeEmail`. Per Finding B, this writes email onto the slack
+person but does not itself merge with a github person (that's #5). Cache `users.info`
+by `slack_user_id` (Tier-4 limited); never capture for `is_bot`/`is_app_user`.
+
+**Privacy:** `users:read.email` surfaces member PII. Gate behind org opt-in (a
+connection-config flag); exclude bots; document it; treat the email as consent-bearing.
+
+## #3 — GitHub email identity — HIGHEST RISK; guardrails are the crux
+Naive change: add `{namespace:IDENTITY.EMAIL, eventPath:'metadata.author_email'}` to
+`GITHUB_PERSON_ENTITY_LINK.identities` (`github.ts:266-272`). `author_email` is
+already stamped (`github.ts:1123`); the `email` namespace is indexed and standard.
+**Done naively, this is dangerous** — commit author email is self-attested.
+
+Over-merge failure modes:
+1. `…@users.noreply.github.com` — privacy email; never a real mailbox / Slack
+   profile email → merge risk, zero bridge value. **Exclude.**
+2. Shared CI/bot emails (`actions@github.com`, `*[bot]@*`) — many github persons
+   stamp the same email; mis-anchors it to a random human, then #5 would merge a
+   human into a bot. **Exclude.**
+3. Commit under a colleague's email (rebase/squash/`--author`) — self-attested,
+   wrong human. No automated guardrail; argues for confidence-gating the merge.
+4. One human, many emails — benign; the merge job must tolerate multiple emails.
+
+With `github_user_id` primary, email is **accreted only**, never a resolution key on
+the github side — so adding it does NOT change which github person an event resolves
+to; blast radius is downstream (read-time collapse + #5).
+
+Guardrails (layered, implement all):
+- **G1 — source-level exclusion (normalize chokepoint).** In
+  `connector-sdk/src/identity-normalize.ts:40-53`, reject emails whose domain is
+  `users.noreply.github.com` (and the `id+user@` form) and a small denylist of
+  CI/bot locals/domains. Rejecting at `normalizeIdentifier` drops them before
+  `entity_identities` on ANY connector (defense in depth).
+- **G2 — verified-only stamping.** In the commit event builder (`github.ts:1119-1129`),
+  only stamp `author_email` into the `email` identity namespace when
+  `commit.commit.verification.verified === true` (GPG/S-MIME-signed by a key GitHub
+  ties to the account). Unverified commits keep `author_email` as a non-indexed
+  display field only. Precision over recall — the right call for the highest-risk change.
+- **G3 — confidence-gate the merge (#5), not the write.** A shared email is
+  evidence, not proof: #5 merges only when the email is non-excluded and owned by
+  exactly one entity on each side. Refuse merges on multiply-claimed emails (same
+  spirit as the ambiguous-`>1` skip).
+
+Recommendation: ship G1+G2 first; make #5's merge confidence-gated and **off by
+default**; do NOT enable read-time email collapse for github↔third-party-slack until
+G3 is in place. Writing the github email identity is safe under G1+G2; acting on it
+is not without G3.
+
+## #4 — The resulting bridge (two distinct mechanisms)
+**Bridge 1 — authenticated user (works via accretion, no merge job).** After #1,
+`$member` carries `auth_user_id` + `email` + `slack_user_id`. To bridge GitHub too,
+a github identity emitter must write `github_user_id`/`github_login` onto `$member`
+(a follow-on, parallel to the existing Google emitter; `identity/auth-hook.ts:19`
+registers only Google today). With that, `$member` is the single hub and both the
+slack and github persons collapse onto it. Benefits: ACL read gate / `resolveMembers`,
+and read-time recall collapse (`entity-link.ts:57-71`) + per-entity metrics.
+
+**Bridge 2 — third-party human (never signed in).** With #2 + #3 the two entities
+share an `email` identity but do NOT auto-merge (Finding B). The benefit materializes
+only after #5's merge job. Be explicit in any roadmap: #2+#3 alone do not deliver
+Bridge 2.
+
+## #5 — Reconciliation / merge job (mandatory for Bridge 2)
+New `identity/reconcile.ts` `reconcileCrossSourceIdentities(orgId)`:
+1. Candidate pairs: `entity_identities` grouped by `(org, namespace='email', identifier)`
+   with entities of different source signatures (one `github_user_id`, another
+   `slack_user_id`), `deleted_at IS NULL`.
+2. G3 gate: accept only if the email is owned by exactly one entity on each side,
+   passes G1 at merge time (defends against pre-G1 poisoned rows), and (via G2)
+   the github email came from a verified commit.
+3. Merge transactionally + idempotently: pick a survivor (prefer `$member`, else the
+   older person), repoint `entity_identities`, `events.entity_ids`,
+   `metadata.aliases`, ACL membership rows; soft-delete the loser. Reuse an existing
+   `mergeEntities`/dedup primitive if one exists.
+4. Log every merge with the deciding identifier; emit a collision record when the
+   gate refuses (manual review).
+
+**Provenance for G3:** prefer to only ever *write* email identities that passed G2
+(verified) — then presence in `entity_identities` implies verified and the gate
+reduces to "singly-owned + non-excluded" (no schema change). Run once per org after
+#2/#3 data exists, then periodically (or on ACL-graph rebuild / identity ingest).
+
+## Tests (red→green)
+- **A. GitHub↔Slack collapse via merge** — seed a verified github commit event
+  (email) → person with `{github_*, email}`; seed a slack member (email) → a SECOND
+  person (assert they do NOT auto-merge); run #5 → one entity with `{github_*,
+  slack_user_id, email}`. Negative: `actions@github.com`/noreply → no email identity
+  written (G1/G2), no merge.
+- **B. Sign-in member → slack_user_id + ACL collapse** — unit: `persistLoginSlackIdentity`
+  writes `(slack_user_id, 'T1:U1')` with source `auth:signup`; idempotent; missing
+  team → no write. Integration: provision `$member`, write its `slack_user_id`, run
+  `buildSlackChannelGraph` → member resolves to `$member`, not a new person.
+- **C. Guardrail units** — `normalizeEmail` rejects noreply/`*[bot]@*`/`actions@github.com`,
+  accepts real; unverified commit → no email identity, verified → present.
+- **D. Merge-gate** — multiply-claimed email → refused + collision logged;
+  singly-owned → merged.
+
+## Rollout / phasing (value/risk order)
+1. **#1** — ship first; self-contained, immediate ACL benefit, low risk; lazy backfill.
+2. **#3 G1+G2** — before any email write; cheap; must precede email data.
+3. **#3 github email identity (write only)** — behind G1+G2; not yet acted on.
+4. **#2 slack email** — requires re-consent; long pole; org opt-in + privacy.
+5. **#5 merge job** — confidence-gated, off by default; enable per-org once data
+   exists and G3 verified. This is what delivers Bridge 2.
+
+## Risks (ranked)
+1. **(Critical) #3 over-merge** — self-attested emails. G1 + G2 + G3. Residual:
+   commit-under-colleague's-email — never auto-merge on a single unverified signal.
+2. **(High) Finding A mismatch** — bare `sub` silently fails to bridge. Mandatory
+   `normalizeSlackUserId(teamId, sub)` + "no team → no write" + test B.
+3. **(High) Merge-job corruption** — transactional, idempotent, reuse a merge primitive.
+4. **(Medium) Privacy** — `users:read.email` PII; org opt-in + bot exclusion + docs.
+5. **(Medium) Re-consent gap** — #2 activates on reinstall; degrade gracefully.
+6. **(Low) Rate limits** — `users.info` Tier-4; cache + throttle.
+
+## Files to touch
+`auth/subject-identities.ts` (#1 `persistLoginSlackIdentity`); `auth/index.tsx`
+(wire hooks, capture `accountId`); `identity/auth-hook.ts` (export
+`resolveTenantMember`); `github.ts` (#3 email identity `:266-272` + G2 verified-only
+`:1119-1129`); `connector-sdk/src/identity-normalize.ts` (#3 G1 exclusion);
+`authz/slack-channel-graph.ts` + `sources.ts` (#2 email on members); new
+`identity/reconcile.ts` (#5).

--- a/docs/plans/chat-feeds/ws-d-feed-model-fold.md
+++ b/docs/plans/chat-feeds/ws-d-feed-model-fold.md
@@ -1,0 +1,185 @@
+# WS-D — Feed model foundation + read registry + Channels UI/API fold
+
+> Status: plan, ready for an implementer. Parts 1a + 2 ship standalone and first;
+> Part 3 needs WS-A. See [README](./README.md) for cross-cutting decisions.
+
+## Goal
+Make `feeds` the home for all data sources (collected/virtual/streaming),
+generalize the read path behind one registry with the ACL gate as a **required**
+input, fold the bespoke Slack "channels" UI/API into the unified feeds/connections
+surface, and resolve PR #1612. Lowest urgency (3 prod rows) — the architectural
+home, not the unlock.
+
+## Grounding corrections (verified against `main`)
+
+1. **The "RecallSource registry" already has the ACL gate — but as convention, not
+   contract.** `tools/search.ts:460-501` defines `RecallSource`/`RECALL_SOURCES`/
+   `gatherRecall`; the gate is enforced inside each source
+   (`fetchConversationSnippets` → `filterChannelsForRequester` `:374`;
+   `knowledgeSource` passes `visibility_scope` `:302`). A new source can compile
+   without the gate. **Making it a required typed argument is the standalone win.**
+2. **The channel REST island is 6 routes in one file, not ~16.**
+   `gateway/routes/public/channels.ts` (493 LOC), mounted at
+   `/api/v1/agents/:agentId/channels` (`gateway/cli/gateway.ts:668`). Jobs (B)
+   routing/bindings + (C) audience/ACL only.
+3. **Job (A) "redundant chat-connection CRUD REST" does not exist on `main`.**
+   `agent-routes.ts` has no channel/platform CRUD handlers; chat-connection CRUD is
+   already MCP-tool-based (`manage_connections` via `restToolProxy`,
+   `index.ts:1180-1198`); lifecycle is row-driven (`chat-instance-manager.ts`).
+   `/api/agents/platforms` (`index.ts:1319`) is a read-only schema endpoint. **So
+   the (A) work is mostly already done** — the fold is jobs (B)+(C) + the owletto tree.
+
+## Part 0 — Fate of PR #1612: **fold its `kind` migration into WS-D and close #1612**
+- `db/migrations/20260630000000_feeds_kind.sql` is well-formed and squawk-safe
+  (additive `text NOT NULL DEFAULT 'collected'`, backfill, `CHECK NOT VALID` +
+  `VALIDATE`). Take it verbatim.
+- The branch already materializes a real consumer (`lib/streaming-feeds.ts`
+  `ensureWebhookStreamingFeed`, `kind='streaming', virtual=false`, lifecycle NULL)
+  — so the migration is not inert there; its consumer is *webhooks*, not WS-A
+  channels.
+- The check-drift CI failure is an owletto-pointer drift, not a schema problem.
+
+Action: cherry-pick the substantive commits (`c65dc2a4e` kind enum,
+`fbeba9ba6` webhook→streaming, `21d2db712` attribution, `d91b8feac` docs) onto a
+fresh WS-D branch off `main`, drop the owletto-pointer commit, re-bump owletto
+separately. Close #1612 pointing at the WS-D PR. **Coordinate with WS-A** on whether
+webhook-as-streaming-feed lands here or in WS-A (it's the second `kind='streaming'`
+consumer either way).
+
+## Part 1 — `feeds.kind` with a consumer + two-phase `virtual`→`kind` invariant
+### 1a. Land the migration (verbatim from #1612). Trivial at 3-row scale.
+### 1b. Two-phase invariant (the correctness contract)
+The scheduler gate is one line: `scheduled/check-due-feeds.ts:47`
+(`AND f.virtual IS NOT TRUE`). Until it moves to `kind`, every non-collected feed
+writer MUST keep `virtual = (kind = 'virtual')` AND leave
+`schedule`/`next_run_at`/`checkpoint` NULL.
+- **Phase A (this WS):** add `kind`; writers set both columns.
+- **Phase B (later, NOT this WS):** flip readers — `check-due-feeds.ts:47` →
+  `AND f.kind = 'collected'`; `connector-pushdown.ts:203` → `if (feed.kind !== 'virtual')`;
+  then drop the `virtual` column. Keep out of WS-D to avoid a scheduler/writer
+  disagreement window.
+### 1c. `manage_feeds` kind-aware create
+`manage_feeds.ts:350-361` inserts without `kind` (relies on default — correct for
+collected). Add an internal kind-aware insert helper so streaming/virtual creators
+don't re-implement the "virtual + lifecycle-NULL" rule. Defer a public `kind` arg
+until a UI/tool caller exists.
+
+## Part 2 — Reader registry: `RecallSource[]` → readers with the ACL gate as a required arg
+**The standalone-valuable slice. Do it first, independent of WS-A.**
+
+Current: `RecallSource { kind; recall(ctx) }` — gate enforced inside `recall`,
+invisible to the type. Live-pushdown lenses (`connector-pushdown.ts` `runConnectorQuery`,
+`readVirtualFeed`) already take a gate; metric lens in `query_metric.ts` + `run-metric.ts`.
+
+Target (minimal — NOT the full `FeedReader<S,L>` matrix):
+```ts
+interface FeedReader<Ctx, Out> {
+  readonly kind: string;
+  read(gate: AuthzScope, ctx: Ctx): Promise<Out>;   // gate required + distinct, not buried in Ctx
+}
+```
+1. Reuse the existing `AuthzScope` (`authz/scope.ts`) that `readVirtualFeed` takes.
+2. Refold the two `search.ts` sources onto this signature; lift
+   `organizationId`/`userId`/`channelAgentId` out of `RecallContext` into `gate`.
+   `gatherRecall` stays (it already isolates failures); thread `gate` through.
+3. Register `readVirtualFeed` + `runConnectorQuery` under the same interface
+   (adapters, ~30 LOC each, no behavior change).
+4. **Correctness win:** a compile-time guarantee that no reader registers without
+   consuming the gate. Unit test asserts every registry entry calls its visibility
+   compiler (registry is already injectable: `gatherRecall(ctx, sources)`).
+
+Do NOT unify result shapes (`ResultFor<L>`) — different lenses return different
+shapes, no caller demands it. Stop at the gate contract.
+
+## Part 3 — Channels UI/API fold (mostly deletion + re-home; needs WS-A)
+### 3a. API — `channels.ts` (6 routes)
+| Route | Job | Disposition |
+|---|---|---|
+| `GET /` list bindings | B | re-home → `manage_connections` action `list_channel_bindings`; delete REST |
+| `POST /` create binding | B | re-home → `bind_channel`; delete REST |
+| `DELETE /:platform/:channelId` | B | re-home → `unbind_channel`; delete REST |
+| `GET /audience` | C | re-home → `get_channel_audience` (wraps `getChannelAudiences`); delete REST |
+| `GET /installations` | A | delete — redundant with `manage_connections` list; migrate the one caller |
+| `POST /installations/:externalId/connect-dm` | A+B | re-home → `connect_channel_dm` (preserve token resolution + `canonicalSlackChannelId`, `channels.ts:389-489`); delete REST |
+
+Then delete `createChannelBindingRoutes` + its mount (`gateway.ts:660-672`).
+`ChannelBindingService` (`binding-service.ts`) **stays** — it's the store consumed
+by the tool actions and `resolveBoundChannelRows` (which `search.ts:369` depends on).
+Only the HTTP shell dies. Bindings are real and NOT modeled as feeds.
+
+### 3b. UI — retire the bespoke channel tree (owletto)
+Delete in `components/agents/`: `agent-channels-route/index/detail/create.tsx`,
+`agent-channel-platform-detail.tsx`, `agent-channel-bindings.tsx`,
+`channel-catalog-picker.tsx`, `channel-audience-row.tsx`, `channel-badges.tsx`,
+`channel-mcp-actions.tsx`; routes `.../channels/create.tsx`, `.../$channelKey.tsx`;
+the Channels tab wiring; hooks `useAgentPlatforms`/`useAgentChannelBindings`.
+Render channels through the existing connector/connection family + the `/connectors`
+surface (a bound channel = a row/facet under its connection).
+
+> **Flag — unverified:** the brief's "shared `connections-tab/*` (~8400 LOC, reused
+> 3×)" does NOT exist as a `connections-tab` dir on `main`; the analogous family is
+> `components/connectors/` (smaller). The owletto submodule may differ. **Map the
+> actual current Feeds/Connections render path in the owletto submodule before
+> deleting any UI.** Design-validated, path-unconfirmed.
+
+### 3c. Needs WS-A
+3a/3b assume channels render as `kind='streaming'` feed rows — depends on WS-A.
+Sequence Part 3 after WS-A; bundle 3a+3b to avoid a dead intermediate state.
+
+## Part 4 — Two stores stay two stores
+No work, but encode the guardrail: `events` and `channel_messages` stay separate
+(embed-congestion + "Capture ≠ knowledge"). A feed's `store` is adapter metadata,
+orthogonal to `kind`. Add a one-line assertion/comment at the streaming-feed
+creation site that streaming feeds targeting `channel_messages` must never enter the
+embed pipeline. Preserve the `search.ts` `ConversationSnippet` split when refolding
+under the registry. Do NOT add a `store` column or merge tables.
+
+## Sequencing
+```
+Ship first (independent):  Part 2 (reader registry + ACL-required-arg)  ∥  Part 1a (land kind, close #1612)
+Alongside / after WS-A:    Part 1b/1c (kind-aware create)  →  Part 3a (API re-home)  →  Part 3b (retire UI tree)
+Deferred (NOT this WS):    Phase B (virtual→kind flip + drop column);  full FeedReader<S,L> matrix / ResultFor<L>
+```
+
+## Migrations
+`20260630000000_feeds_kind.sql` verbatim from #1612 (additive, lock-safe). No other
+DDL in WS-D. The `virtual` drop is Phase B (a separate later contract migration).
+
+## Tests
+- **Part 2 (the one that matters):** unit test that the registry can't construct a
+  reader bypassing the gate; regression that `gatherRecall` with a non-member
+  `userId` returns no `conversation_messages`.
+- **Part 1:** migration up/down idempotency; `streaming-feeds.ts` invariant test
+  (created feed has `next_run_at IS NULL` so the scheduler skips it).
+- **Part 3a:** parity tests that each new tool action matches the deleted REST
+  route, esp. `connect_channel_dm` (canonical Slack id + token resolution).
+- E2E gate per AGENTS.md before merge for the channel fold (behavior-changing UI/API).
+
+## Risks
+1. **(High severity) Silent ACL bypass during the read refold (Part 2)** — gate as a
+   required typed param + registry test.
+2. **Two-phase invariant violation** — a writer sets `kind` without keeping
+   `virtual`/lifecycle consistent → scheduler queues a streaming feed. Single
+   kind-aware insert helper (1c); never hand-roll the insert.
+3. **owletto UI path unverified (Part 3b)** — map the real render path before
+   deleting; submodule-pointer discipline (push owletto branch before bumping).
+4. **#1612 / WS-A ownership overlap** on the first streaming consumer — coordinate
+   before cherry-picking `fbeba9ba6`/`21d2db712`.
+
+## Honest prioritization (3 prod rows)
+- **Now, standalone:** Part 2 (reader registry + ACL-required-arg) and Part 1a
+  (land `kind`, close #1612) — the home + the one correctness win; low-risk folds.
+- **With WS-A:** Part 1b/1c, Part 3 — no value before WS-A exists.
+- **Defer indefinitely:** full `FeedReader<S,L>` matrix / `ResultFor<L>` — no caller
+  demand; speculative generality the design doc itself warns against.
+
+## Files to touch
+`tools/search.ts` (registry → required gate; Part 2); `lib/connector-pushdown.ts`
+(fold live readers; Phase-B flip site `:203`); `db/migrations/20260630000000_feeds_kind.sql`
+(from #1612; Part 1a); `gateway/routes/public/channels.ts` + its mount
+(`gateway/cli/gateway.ts:660-672`) (Part 3a); `scheduled/check-due-feeds.ts:47`
+(two-phase gate; Part 1b). Supporting: `lib/streaming-feeds.ts`,
+`tools/admin/manage_feeds.ts` (kind-aware create), `authz/scope.ts` +
+`connection-visibility.ts` + `channel-visibility.ts` (the gate), and the owletto
+`components/agents/*channel*` tree + `components/connectors/` family (Part 3b —
+path to confirm in submodule).


### PR DESCRIPTION
## What

Implementation plans for the **chat-feeds consolidation program** — making Slack (chat) a first-class data source: channels become streaming feeds, message senders get attributed to person entities, an agent can drive the bot into channels, and identities bridge across sources (a GitHub committer and a Slack sender can be the same person).

Docs only — no code change. Five files under `docs/plans/chat-feeds/`:

- **README** — program overview, dependency graph, sequencing, the cross-cutting corrections every workstream depends on, and honest prioritization.
- **WS-A (keystone)** — Slack ingestion as a person-attributed streaming feed (store-only attribution, no embedded events; recall re-key; managed-Slack read-orphan fix).
- **WS-B** — Slack channel operations (list/join) as connection actions + auto-join driver.
- **WS-C** — cross-source identity bridges (sign-in `slack_user_id`, email capture, GitHub email identity, reconciliation/merge job + over-merge guardrails).
- **WS-D** — `feeds.kind` (folds + closes #1612), ACL-gated reader registry (the standalone correctness win), channels UI/API fold.

## Why this is grounded, not speculative

- Read-only prod query: `channel_messages` has **3 rows**, **0** managed-Slack transcripts — so this is plumbing ahead of demand; the plans prioritize accordingly.
- Scratch-DB spike validated the channel→connection reconciliation (0 orphans) and the two scariest ACL edge cases (cross-org isolation, duplicate binding).
- Every workstream cites file:line and flags what could not be verified.

## Key corrections surfaced during planning

- `feeds.kind` exists only on the abandoned #1612 branch, not `main` (WS-D owns landing it; close #1612).
- `slack_user_id` is team-scoped (`T:U`), so attribution needs a `team_id` the system doesn't currently have at hand.
- Slack has **no** `connections` row, so operations have nothing to target until one is created; the bot token needs native resolution.
- Email alone can't merge two already-primaried entities → a confidence-gated reconciliation job is mandatory for the third-party bridge.

## Status

Plans, ready to dedicate to implementers. Recommended first PRs (each independently valuable): WS-D Part 2 (ACL-gated reader registry), WS-C #1 (sign-in `slack_user_id`), WS-D Part 1a (land `kind` + close #1612). Keystone (WS-A) follows once `kind` lands.

Related: #1612 (to be closed/folded by WS-D).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785430752&installation_id=136316292&pr_number=1644&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1644&signature=5baee2ad2215b62a1e66f2704224ef2abbb65793205928a6b69292724dc8b999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->