### PR TITLE
feat(auth): stamp slack_user_id on Slack sign-in so ACL collapses onto $member

### DIFF
--- a/packages/server/src/__tests__/integration/authz/signin-slack-identity-collapse.test.ts
+++ b/packages/server/src/__tests__/integration/authz/signin-slack-identity-collapse.test.ts
@@ -9,7 +9,8 @@
  * `$member` and minted a separate `person` for the same human.
  *
  * Flow: provision a `$member` with ONLY `auth_user_id` (the pre-fix state) →
- * run `persistLoginSlackIdentity` (network reads stubbed, real DB write) →
+ * run `persistLoginSlackIdentity` via the PRIMARY id_token path (the injected
+ * network deps THROW, proving no userinfo fetch is needed; real DB write) →
  * build the channel graph with that user as a channel member → assert the
  * member edge lands on the EXISTING `$member`, and no new `person` was created.
  */
@@ -36,31 +37,27 @@ const TEAM = "T01ACME";
 const CONN = "conn-acme";
 const SLACK_USER = "U01ALICE";
 
-/** persistLoginSlackIdentity deps: real tenant resolution, stubbed network. */
-function slackDeps(teamId: string | undefined) {
-	return {
-		resolveTenantMember,
-		getEnabledLoginProviderConfigs: async () => [
-			{
-				connectorKey: "slack",
-				provider: "slack",
-				loginScopes: [],
-				clientIdKey: "SLACK_CLIENT_ID",
-				clientSecretKey: "SLACK_CLIENT_SECRET",
-				userinfoUrl: "https://slack.test/userInfo",
-			},
-		],
-		fetchUserInfoWithRaw: async () => ({
-			raw: teamId
-				? {
-						"https://slack.com/team_id": teamId,
-						"https://slack.com/user_id": SLACK_USER,
-					}
-				: { "https://slack.com/user_id": SLACK_USER },
-			normalized: null,
-		}),
-	};
+/** Build an (unsigned-but-well-formed) JWT carrying the given claims. */
+function makeJwt(claims: Record<string, unknown>): string {
+	const b64 = (o: unknown) =>
+		Buffer.from(JSON.stringify(o)).toString("base64url");
+	return `${b64({ alg: "HS256", typ: "JWT" })}.${b64(claims)}.sig`;
 }
+
+/**
+ * persistLoginSlackIdentity deps for the PRIMARY (id_token) path: real tenant
+ * resolution, and a network layer that THROWS — proving the id_token path needs
+ * no userinfo fetch / provider-config read at all.
+ */
+const noNetworkDeps = {
+	resolveTenantMember,
+	getEnabledLoginProviderConfigs: async () => {
+		throw new Error("provider-config lookup must not run on the id_token path");
+	},
+	fetchUserInfoWithRaw: async () => {
+		throw new Error("userinfo fetch must not run on the id_token path");
+	},
+};
 
 describe("sign-in slack_user_id collapse (e2e via channel graph)", () => {
 	beforeAll(async () => {
@@ -113,15 +110,21 @@ describe("sign-in slack_user_id collapse (e2e via channel graph)", () => {
 			status: "active",
 		});
 
-		// Slack sign-in writes the team-scoped slack_user_id onto the SAME $member.
+		// Slack sign-in writes the team-scoped slack_user_id onto the SAME $member,
+		// reading team + user straight from the stored id_token (no network).
 		await persistLoginSlackIdentity(
 			{
 				providerId: "slack",
 				userId: alice.id,
 				accessToken: "xoxp-token",
 				accountId: SLACK_USER,
+				idToken: makeJwt({
+					"https://slack.com/team_id": TEAM,
+					"https://slack.com/user_id": SLACK_USER,
+					sub: SLACK_USER,
+				}),
 			},
-			slackDeps(TEAM),
+			noNetworkDeps,
 		);
 
 		// Build the channel graph with Alice as a member of #eng.

--- a/packages/server/src/__tests__/integration/authz/signin-slack-identity-collapse.test.ts
+++ b/packages/server/src/__tests__/integration/authz/signin-slack-identity-collapse.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Sign-in collapse — END TO END through the ACL channel graph.
+ *
+ * Proves the production effect of stamping `slack_user_id` on Slack sign-in:
+ * the workspace member COLLAPSES onto the user's existing `$member` entity
+ * instead of forking a new `person`. Before the fix, sign-in wrote only
+ * `auth_user_id` + `email`, so the channel-graph builder — which resolves
+ * members on the canonical `slack_user_id` namespace — never matched the
+ * `$member` and minted a separate `person` for the same human.
+ *
+ * Flow: provision a `$member` with ONLY `auth_user_id` (the pre-fix state) →
+ * run `persistLoginSlackIdentity` (network reads stubbed, real DB write) →
+ * build the channel graph with that user as a channel member → assert the
+ * member edge lands on the EXISTING `$member`, and no new `person` was created.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	persistLoginSlackIdentity,
+	provisionMemberAndCoreIdentities,
+} from "../../../auth/subject-identities";
+import { buildSlackChannelGraph } from "../../../authz/slack-channel-graph";
+import { resolveTenantMember } from "../../../identity/auth-hook";
+import { clearEntityLinkRulesCache } from "../../../utils/entity-link-upsert";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestAgent,
+	createTestOrganization,
+	createTestUser,
+	insertChatConnectionRow,
+} from "../../setup/test-fixtures";
+
+const TEAM = "T01ACME";
+const CONN = "conn-acme";
+const SLACK_USER = "U01ALICE";
+
+/** persistLoginSlackIdentity deps: real tenant resolution, stubbed network. */
+function slackDeps(teamId: string | undefined) {
+	return {
+		resolveTenantMember,
+		getEnabledLoginProviderConfigs: async () => [
+			{
+				connectorKey: "slack",
+				provider: "slack",
+				loginScopes: [],
+				clientIdKey: "SLACK_CLIENT_ID",
+				clientSecretKey: "SLACK_CLIENT_SECRET",
+				userinfoUrl: "https://slack.test/userInfo",
+			},
+		],
+		fetchUserInfoWithRaw: async () => ({
+			raw: teamId
+				? {
+						"https://slack.com/team_id": teamId,
+						"https://slack.com/user_id": SLACK_USER,
+					}
+				: { "https://slack.com/user_id": SLACK_USER },
+			normalized: null,
+		}),
+	};
+}
+
+describe("sign-in slack_user_id collapse (e2e via channel graph)", () => {
+	beforeAll(async () => {
+		await initWorkspaceProvider();
+	});
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		clearEntityLinkRulesCache();
+	});
+
+	it("collapses the workspace member onto the existing $member, never forking a person", async () => {
+		const org = await createTestOrganization({
+			name: "Acme",
+			visibility: "private",
+		});
+		const alice = await createTestUser({
+			name: "Alice",
+			email: "alice@acme.test",
+		});
+		await addUserToOrganization(alice.id, org.id, "owner");
+		const agent = await createTestAgent({ organizationId: org.id });
+
+		// The channel-graph builder auto-creates `person` entities for unmatched
+		// members; the type must exist in the org (prod seeds it at org creation).
+		const sql = getTestDb();
+		await sql`
+      INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+      VALUES (${org.id}, 'person', 'Person', current_timestamp, current_timestamp)
+      ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+      DO NOTHING
+    `;
+
+		// Pre-fix sign-in state: $member exists with auth_user_id + email, NO slack_user_id.
+		const { memberEntityId } = await provisionMemberAndCoreIdentities(org.id, {
+			userId: alice.id,
+			email: "alice@acme.test",
+			name: "Alice",
+		});
+		const before = await sql<{ n: number }>`
+      SELECT COUNT(*)::int AS n FROM entity_identities
+      WHERE organization_id = ${org.id} AND namespace = 'slack_user_id' AND deleted_at IS NULL
+    `;
+		expect(Number(before[0].n)).toBe(0);
+
+		await insertChatConnectionRow({
+			id: CONN,
+			agentId: agent.agentId,
+			platform: "slack",
+			organizationId: org.id,
+			status: "active",
+		});
+
+		// Slack sign-in writes the team-scoped slack_user_id onto the SAME $member.
+		await persistLoginSlackIdentity(
+			{
+				providerId: "slack",
+				userId: alice.id,
+				accessToken: "xoxp-token",
+				accountId: SLACK_USER,
+			},
+			slackDeps(TEAM),
+		);
+
+		// Build the channel graph with Alice as a member of #eng.
+		const result = await buildSlackChannelGraph({
+			organizationId: org.id,
+			connectionId: CONN,
+			teamId: TEAM,
+			channels: [
+				{ channelId: "C01ENG", name: "eng", memberSlackUserIds: [SLACK_USER] },
+			],
+		});
+
+		// The member edge lands on the EXISTING $member — not a fresh person.
+		expect(result.memberEntityIds).toContain(memberEntityId);
+
+		// And no person entity was minted carrying that slack_user_id.
+		const personRows = await sql<{ id: number; slug: string }>`
+      SELECT e.id, et.slug
+      FROM entity_identities ei
+      JOIN entities e ON e.id = ei.entity_id
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE ei.organization_id = ${org.id}
+        AND ei.namespace = 'slack_user_id'
+        AND ei.identifier = ${`${TEAM}:${SLACK_USER}`}
+        AND ei.deleted_at IS NULL
+        AND e.deleted_at IS NULL
+    `;
+		// Exactly one entity carries the slack id, and it is the $member.
+		expect(personRows).toHaveLength(1);
+		expect(personRows[0].slug).toBe("$member");
+		expect(Number(personRows[0].id)).toBe(memberEntityId);
+	});
+});

--- a/packages/server/src/auth/__tests__/persist-login-slack-identity.test.ts
+++ b/packages/server/src/auth/__tests__/persist-login-slack-identity.test.ts
@@ -2,9 +2,11 @@
  * Unit coverage for `persistLoginSlackIdentity`.
  *
  * On Slack sign-in we stamp the user's team-scoped `slack_user_id` (`T…:U…`)
- * onto their `$member` entity, sourced `auth:signup`. These cases pin the four
- * branches that matter: a clean write, idempotency, the missing-team guard
- * (never write a bare id), and the non-Slack no-op.
+ * onto their `$member` entity, sourced `auth:signup`. Resolution is id_token
+ * PRIMARY (decode the stored OIDC id_token — no network) with a userinfo-fetch
+ * FALLBACK. These cases pin: the id_token path (and that it makes NO fetch),
+ * a clean fallback write, idempotency, the missing-team guard (never write a
+ * bare id), malformed-id_token → fallback, and the non-Slack no-op.
  *
  * The network reads (userinfo fetch + provider config) are injected stubs; the
  * DB write path is REAL against the embedded test database — the `isolate:false`
@@ -51,6 +53,13 @@ async function seedMember(): Promise<{
 	return { orgId: org.id, userId: user.id, memberEntityId };
 }
 
+/** Build an (unsigned-but-well-formed) JWT carrying the given claims. */
+function makeJwt(claims: Record<string, unknown>): string {
+	const b64 = (o: unknown) =>
+		Buffer.from(JSON.stringify(o)).toString("base64url");
+	return `${b64({ alg: "HS256", typ: "JWT" })}.${b64(claims)}.sig`;
+}
+
 /** Deps that resolve the real tenant member but stub the two network reads. */
 function depsWith(
 	raw: Record<string, unknown> | null,
@@ -68,6 +77,31 @@ function depsWith(
 			},
 		],
 		fetchUserInfoWithRaw: async () => ({ raw, normalized: null }),
+	};
+}
+
+/**
+ * Deps that record whether the network fallback was reached. `raw` is what the
+ * fetch returns when it IS called (the fallback path).
+ */
+function trackingDeps(raw: Record<string, unknown> | null): {
+	deps: PersistLoginSlackIdentityDeps;
+	calls: { fetched: boolean; configs: boolean };
+} {
+	const calls = { fetched: false, configs: false };
+	return {
+		calls,
+		deps: {
+			resolveTenantMember,
+			getEnabledLoginProviderConfigs: async () => {
+				calls.configs = true;
+				return [];
+			},
+			fetchUserInfoWithRaw: async () => {
+				calls.fetched = true;
+				return { raw, normalized: null };
+			},
+		},
 	};
 }
 
@@ -96,7 +130,44 @@ describe("persistLoginSlackIdentity", () => {
 		await cleanupTestDatabase();
 	});
 
-	it("writes the team-scoped slack_user_id onto the $member (source auth:signup)", async () => {
+	it("PRIMARY: decodes the stored id_token and writes (slack_user_id) with NO network fetch", async () => {
+		const { orgId, userId, memberEntityId } = await seedMember();
+		const { deps, calls } = trackingDeps(null);
+
+		await persistLoginSlackIdentity(
+			{
+				providerId: "slack",
+				userId,
+				accessToken: "xoxp-token",
+				accountId: USER,
+				idToken: makeJwt({
+					"https://slack.com/team_id": TEAM,
+					"https://slack.com/user_id": USER,
+					sub: USER,
+				}),
+			},
+			deps,
+		);
+
+		// The id_token carried everything → neither the userinfo fetch nor the
+		// provider-config lookup was reached.
+		expect(calls.fetched).toBe(false);
+		expect(calls.configs).toBe(false);
+
+		const sql = getTestDb();
+		const rows = await sql<{ entity_id: number }>`
+      SELECT entity_id FROM entity_identities
+      WHERE organization_id = ${orgId}
+        AND namespace = 'slack_user_id'
+        AND identifier = ${`${TEAM}:${USER}`}
+        AND source_connector = 'auth:signup'
+        AND deleted_at IS NULL
+    `;
+		expect(rows).toHaveLength(1);
+		expect(Number(rows[0].entity_id)).toBe(memberEntityId);
+	});
+
+	it("FALLBACK: no id_token → fetches userinfo and writes the team-scoped slack_user_id", async () => {
 		const { orgId, userId, memberEntityId } = await seedMember();
 
 		await persistLoginSlackIdentity(
@@ -120,6 +191,26 @@ describe("persistLoginSlackIdentity", () => {
     `;
 		expect(rows).toHaveLength(1);
 		expect(Number(rows[0].entity_id)).toBe(memberEntityId);
+	});
+
+	it("FALLBACK: a malformed id_token falls back to the userinfo fetch", async () => {
+		const { orgId, userId } = await seedMember();
+		const { deps, calls } = trackingDeps({ "https://slack.com/team_id": TEAM });
+
+		await persistLoginSlackIdentity(
+			{
+				providerId: "slack",
+				userId,
+				accessToken: "xoxp-token",
+				accountId: USER,
+				idToken: "not-a-jwt",
+			},
+			deps,
+		);
+
+		// Malformed token decoded to nothing → fell through to the fetch path.
+		expect(calls.fetched).toBe(true);
+		expect(await slackIdentityCount(orgId, `${TEAM}:${USER}`)).toBe(1);
 	});
 
 	it("is idempotent — a second call writes no duplicate", async () => {

--- a/packages/server/src/auth/__tests__/persist-login-slack-identity.test.ts
+++ b/packages/server/src/auth/__tests__/persist-login-slack-identity.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit coverage for `persistLoginSlackIdentity`.
+ *
+ * On Slack sign-in we stamp the user's team-scoped `slack_user_id` (`T…:U…`)
+ * onto their `$member` entity, sourced `auth:signup`. These cases pin the four
+ * branches that matter: a clean write, idempotency, the missing-team guard
+ * (never write a bare id), and the non-Slack no-op.
+ *
+ * The network reads (userinfo fetch + provider config) are injected stubs; the
+ * DB write path is REAL against the embedded test database — the `isolate:false`
+ * vitest run makes `vi.mock` of shared singletons unreliable, so dependency
+ * injection is the durable seam.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTestDatabase, getTestDb } from "../../__tests__/setup/test-db";
+import {
+	addUserToOrganization,
+	createTestOrganization,
+	createTestUser,
+} from "../../__tests__/setup/test-fixtures";
+import { resolveTenantMember } from "../../identity/auth-hook";
+import type { PersistLoginSlackIdentityDeps } from "../subject-identities";
+import {
+	persistLoginSlackIdentity,
+	provisionMemberAndCoreIdentities,
+} from "../subject-identities";
+
+const TEAM = "T1";
+const USER = "U1";
+
+async function seedMember(): Promise<{
+	orgId: string;
+	userId: string;
+	memberEntityId: number;
+}> {
+	const org = await createTestOrganization({
+		name: "Acme",
+		visibility: "private",
+	});
+	const user = await createTestUser({
+		name: "Alice",
+		email: "alice@acme.test",
+	});
+	await addUserToOrganization(user.id, org.id, "owner");
+	const { memberEntityId } = await provisionMemberAndCoreIdentities(org.id, {
+		userId: user.id,
+		email: "alice@acme.test",
+		name: "Alice",
+	});
+	return { orgId: org.id, userId: user.id, memberEntityId };
+}
+
+/** Deps that resolve the real tenant member but stub the two network reads. */
+function depsWith(
+	raw: Record<string, unknown> | null,
+): PersistLoginSlackIdentityDeps {
+	return {
+		resolveTenantMember,
+		getEnabledLoginProviderConfigs: async () => [
+			{
+				connectorKey: "slack",
+				provider: "slack",
+				loginScopes: [],
+				clientIdKey: "SLACK_CLIENT_ID",
+				clientSecretKey: "SLACK_CLIENT_SECRET",
+				userinfoUrl: "https://slack.test/openid/connect/userInfo",
+			},
+		],
+		fetchUserInfoWithRaw: async () => ({ raw, normalized: null }),
+	};
+}
+
+async function slackIdentityCount(
+	orgId: string,
+	identifier: string,
+): Promise<number> {
+	const sql = getTestDb();
+	const rows = await sql<{ n: number }>`
+    SELECT COUNT(*)::int AS n
+    FROM entity_identities
+    WHERE organization_id = ${orgId}
+      AND namespace = 'slack_user_id'
+      AND identifier = ${identifier}
+      AND source_connector = 'auth:signup'
+      AND deleted_at IS NULL
+  `;
+	return Number(rows[0]?.n ?? 0);
+}
+
+describe("persistLoginSlackIdentity", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
+	afterEach(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("writes the team-scoped slack_user_id onto the $member (source auth:signup)", async () => {
+		const { orgId, userId, memberEntityId } = await seedMember();
+
+		await persistLoginSlackIdentity(
+			{
+				providerId: "slack",
+				userId,
+				accessToken: "xoxp-token",
+				accountId: USER,
+			},
+			depsWith({ "https://slack.com/team_id": TEAM }),
+		);
+
+		const sql = getTestDb();
+		const rows = await sql<{ entity_id: number }>`
+      SELECT entity_id FROM entity_identities
+      WHERE organization_id = ${orgId}
+        AND namespace = 'slack_user_id'
+        AND identifier = ${`${TEAM}:${USER}`}
+        AND source_connector = 'auth:signup'
+        AND deleted_at IS NULL
+    `;
+		expect(rows).toHaveLength(1);
+		expect(Number(rows[0].entity_id)).toBe(memberEntityId);
+	});
+
+	it("is idempotent — a second call writes no duplicate", async () => {
+		const { orgId, userId } = await seedMember();
+		const deps = depsWith({ "https://slack.com/team_id": TEAM });
+		const account = {
+			providerId: "slack",
+			userId,
+			accessToken: "xoxp-token",
+			accountId: USER,
+		};
+
+		await persistLoginSlackIdentity(account, deps);
+		await persistLoginSlackIdentity(account, deps);
+
+		expect(await slackIdentityCount(orgId, `${TEAM}:${USER}`)).toBe(1);
+	});
+
+	it("never writes a bare id when team_id is missing", async () => {
+		const { orgId, userId } = await seedMember();
+
+		await persistLoginSlackIdentity(
+			{
+				providerId: "slack",
+				userId,
+				accessToken: "xoxp-token",
+				accountId: USER,
+			},
+			// No team_id in the userinfo body → normalizeSlackUserId returns null.
+			depsWith({ sub: USER }),
+		);
+
+		const sql = getTestDb();
+		const rows = await sql<{ n: number }>`
+      SELECT COUNT(*)::int AS n FROM entity_identities
+      WHERE organization_id = ${orgId} AND namespace = 'slack_user_id'
+        AND deleted_at IS NULL
+    `;
+		expect(Number(rows[0].n)).toBe(0);
+	});
+
+	it("is a no-op for a non-Slack provider", async () => {
+		const { orgId, userId } = await seedMember();
+		let fetched = false;
+
+		await persistLoginSlackIdentity(
+			{
+				providerId: "google",
+				userId,
+				accessToken: "ya29-token",
+				accountId: USER,
+			},
+			{
+				resolveTenantMember,
+				getEnabledLoginProviderConfigs: async () => [],
+				fetchUserInfoWithRaw: async () => {
+					fetched = true;
+					return {
+						raw: { "https://slack.com/team_id": TEAM },
+						normalized: null,
+					};
+				},
+			},
+		);
+
+		expect(fetched).toBe(false);
+		const sql = getTestDb();
+		const rows = await sql<{ n: number }>`
+      SELECT COUNT(*)::int AS n FROM entity_identities
+      WHERE organization_id = ${orgId} AND namespace = 'slack_user_id'
+        AND deleted_at IS NULL
+    `;
+		expect(Number(rows[0].n)).toBe(0);
+	});
+});

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -60,6 +60,7 @@ import {
 	scheduleIdentityIngest,
 	scheduleIdentityTombstoneOnAccountDelete,
 } from "../identity/auth-hook";
+import { persistLoginSlackIdentity } from "./subject-identities";
 
 function gravatarUrl(email: string): string {
 	const hash = createHash("md5")
@@ -95,7 +96,7 @@ export function clearAuthCacheForTests(): void {
 // a clean (Docker) install layout and trips TS2742 during `tsc --noEmit`.
 export async function createAuth(
 	env: Env,
-	request?: Request
+	request?: Request,
 ): Promise<ReturnType<typeof betterAuth>> {
 	const organizationId = (await resolveRequestOrganizationId(request)) ?? null;
 	const cacheKey = organizationId ?? "__system__";
@@ -833,6 +834,9 @@ export async function createAuth(
 							scope: (account as Record<string, unknown>).scope as
 								| string
 								| null,
+							accountId: (account as Record<string, unknown>).accountId as
+								| string
+								| null,
 						};
 						try {
 							const { provisionConnectorFromSocialLogin } = await import(
@@ -851,6 +855,9 @@ export async function createAuth(
 						}
 						// Identity engine ingest. Fire-and-forget; sign-in never blocks.
 						scheduleIdentityIngest(accountSummary);
+						// Slack sign-in: collapse the workspace member onto this $member by
+						// stamping their team-scoped slack_user_id. Fire-and-forget.
+						void persistLoginSlackIdentity(accountSummary);
 					},
 				},
 				update: {
@@ -863,6 +870,9 @@ export async function createAuth(
 								| string
 								| null,
 							scope: (account as Record<string, unknown>).scope as
+								| string
+								| null,
+							accountId: (account as Record<string, unknown>).accountId as
 								| string
 								| null,
 						};
@@ -882,6 +892,8 @@ export async function createAuth(
 							);
 						}
 						scheduleIdentityIngest(accountSummary);
+						// Slack re-link / token refresh: keep the slack_user_id stamped.
+						void persistLoginSlackIdentity(accountSummary);
 					},
 				},
 				delete: {

--- a/packages/server/src/auth/index.tsx
+++ b/packages/server/src/auth/index.tsx
@@ -837,6 +837,9 @@ export async function createAuth(
 							accountId: (account as Record<string, unknown>).accountId as
 								| string
 								| null,
+							idToken: (account as Record<string, unknown>).idToken as
+								| string
+								| null,
 						};
 						try {
 							const { provisionConnectorFromSocialLogin } = await import(
@@ -873,6 +876,9 @@ export async function createAuth(
 								| string
 								| null,
 							accountId: (account as Record<string, unknown>).accountId as
+								| string
+								| null,
+							idToken: (account as Record<string, unknown>).idToken as
 								| string
 								| null,
 						};

--- a/packages/server/src/auth/subject-identities.ts
+++ b/packages/server/src/auth/subject-identities.ts
@@ -133,6 +133,32 @@ export interface LoginAccountForSlackIdentity {
 	 * from the BetterAuth row PK. Preferred over the userinfo body when present.
 	 */
 	accountId?: string | null;
+	/**
+	 * The OIDC id_token BetterAuth stored on the account row at the login code
+	 * exchange. Slack's id_token payload carries both `https://slack.com/team_id`
+	 * and `https://slack.com/user_id`, so when present we read them straight from
+	 * it — no second HTTP round-trip / provider-config lookup needed.
+	 */
+	idToken?: string | null;
+}
+
+/**
+ * Decode the claims (payload) of a JWT without verifying its signature. Safe
+ * here because this is our own server-stored token from a TLS code exchange —
+ * same trust level as the access token we already store and use. Mirrors
+ * better-auth's own `decodeJwt`. Returns null on any malformation.
+ */
+function decodeJwtClaims(jwt: string): Record<string, unknown> | null {
+	const seg = jwt.split(".")[1];
+	if (!seg) return null;
+	try {
+		return JSON.parse(Buffer.from(seg, "base64url").toString("utf8")) as Record<
+			string,
+			unknown
+		>;
+	} catch {
+		return null;
+	}
 }
 
 /**
@@ -182,24 +208,43 @@ export async function persistLoginSlackIdentity(
 			return;
 		}
 
-		const cfgs = await deps.getEnabledLoginProviderConfigs(
-			resolved.tenantOrganizationId,
-		);
-		const slackCfg = cfgs.find((c) => c.provider.toLowerCase() === "slack");
+		let teamId: string | null | undefined;
+		let bareUser: string | null | undefined;
+		let source: "id_token" | "userinfo-fallback" = "id_token";
 
-		const { raw } = await deps.fetchUserInfoWithRaw({
-			provider: "slack",
-			accessToken: account.accessToken,
-			userinfoUrl: slackCfg?.userinfoUrl,
-		});
+		// PRIMARY: read team + user straight out of the stored id_token. No network.
+		if (account.idToken) {
+			const claims = decodeJwtClaims(account.idToken);
+			if (claims) {
+				teamId = claims["https://slack.com/team_id"] as
+					| string
+					| null
+					| undefined;
+				bareUser = (account.accountId ??
+					claims["https://slack.com/user_id"] ??
+					claims.sub) as string | null | undefined;
+			}
+		}
 
-		const teamId = raw?.["https://slack.com/team_id"] as
-			| string
-			| null
-			| undefined;
-		const bareUser = (account.accountId ??
-			raw?.["https://slack.com/user_id"] ??
-			raw?.sub) as string | null | undefined;
+		// FALLBACK: no id_token (or it yielded no team_id) → the userinfo endpoint.
+		// One extra HTTP round-trip + a provider-config DB read, kept behind the
+		// injected deps seam so it stays testable.
+		if (!teamId) {
+			source = "userinfo-fallback";
+			const cfgs = await deps.getEnabledLoginProviderConfigs(
+				resolved.tenantOrganizationId,
+			);
+			const slackCfg = cfgs.find((c) => c.provider.toLowerCase() === "slack");
+			const { raw } = await deps.fetchUserInfoWithRaw({
+				provider: "slack",
+				accessToken: account.accessToken,
+				userinfoUrl: slackCfg?.userinfoUrl,
+			});
+			teamId = raw?.["https://slack.com/team_id"] as string | null | undefined;
+			bareUser = (account.accountId ??
+				raw?.["https://slack.com/user_id"] ??
+				raw?.sub) as string | null | undefined;
+		}
 
 		// null = missing team id or malformed → NEVER write a bare, un-scoped id
 		// (two workspaces can share a `U…`, so a bare id would bleed across orgs).
@@ -220,7 +265,11 @@ export async function persistLoginSlackIdentity(
 			[{ namespace: "slack_user_id", identifier: combined }],
 		);
 		log.debug(
-			{ userId: account.userId, organizationId: resolved.tenantOrganizationId },
+			{
+				userId: account.userId,
+				organizationId: resolved.tenantOrganizationId,
+				source,
+			},
 			"slack-identity: wrote slack_user_id onto $member",
 		);
 	} catch (err) {

--- a/packages/server/src/auth/subject-identities.ts
+++ b/packages/server/src/auth/subject-identities.ts
@@ -6,11 +6,21 @@
  * single entity_identities lookup.
  */
 
+import { normalizeSlackUserId } from "@lobu/connector-sdk";
+import { fetchUserInfoWithRaw } from "../connect/oauth-providers";
 import { getDb } from "../db/client";
+import {
+	type ResolvedTenantMember,
+	resolveTenantMember,
+} from "../identity/auth-hook";
+import logger from "../utils/logger";
 import {
 	ensureMemberEntity,
 	resolveMemberSchemaFields,
 } from "../utils/member-entity";
+import { getEnabledLoginProviderConfigs } from "./config";
+
+const log = logger.child({ module: "auth-subject-identities" });
 
 interface PersonalSubject {
 	userId: string;
@@ -108,4 +118,115 @@ export async function provisionMemberAndCoreIdentities(
 	]);
 
 	return { memberEntityId };
+}
+
+/**
+ * The slice of a BetterAuth social-login account this needs. Structurally
+ * satisfied by the `accountSummary` the auth hooks already build.
+ */
+export interface LoginAccountForSlackIdentity {
+	providerId: string;
+	userId: string;
+	accessToken?: string | null;
+	/**
+	 * The provider's external account id (the bare Slack `U…` sub), distinct
+	 * from the BetterAuth row PK. Preferred over the userinfo body when present.
+	 */
+	accountId?: string | null;
+}
+
+/**
+ * Injected boundary so tests can stub the network reads (userinfo fetch +
+ * provider config) while exercising the real DB write path. Defaults wire the
+ * production implementations. This is the `isolate: false` vitest-safe seam:
+ * the integration suite shares one module graph, so `vi.mock` of these shared
+ * singletons is unreliable — dependency injection is the durable alternative.
+ */
+export interface PersistLoginSlackIdentityDeps {
+	resolveTenantMember: (userId: string) => Promise<ResolvedTenantMember | null>;
+	getEnabledLoginProviderConfigs: typeof getEnabledLoginProviderConfigs;
+	fetchUserInfoWithRaw: typeof fetchUserInfoWithRaw;
+}
+
+const defaultPersistDeps: PersistLoginSlackIdentityDeps = {
+	resolveTenantMember,
+	getEnabledLoginProviderConfigs,
+	fetchUserInfoWithRaw,
+};
+
+/**
+ * On Slack sign-in, write the user's team-scoped `slack_user_id` (`T…:U…`) onto
+ * their `$member` entity, sourced `auth:signup`. Idempotent — a duplicate is a
+ * no-op via the `entity_identities` unique index.
+ *
+ * Effect: the ACL Slack channel-graph collapses the workspace member onto the
+ * existing `$member` instead of forking a separate `person`, because both sides
+ * now resolve on the same canonical `slack_user_id`.
+ *
+ * Fire-and-forget — failures log and never throw into the auth hook.
+ */
+export async function persistLoginSlackIdentity(
+	account: LoginAccountForSlackIdentity,
+	deps: PersistLoginSlackIdentityDeps = defaultPersistDeps,
+): Promise<void> {
+	try {
+		if (account.providerId.trim().toLowerCase() !== "slack") return;
+		if (!account.accessToken) return;
+
+		const resolved = await deps.resolveTenantMember(account.userId);
+		if (!resolved) {
+			log.debug(
+				{ userId: account.userId },
+				"slack-identity: no tenant $member yet — skipping slack_user_id write",
+			);
+			return;
+		}
+
+		const cfgs = await deps.getEnabledLoginProviderConfigs(
+			resolved.tenantOrganizationId,
+		);
+		const slackCfg = cfgs.find((c) => c.provider.toLowerCase() === "slack");
+
+		const { raw } = await deps.fetchUserInfoWithRaw({
+			provider: "slack",
+			accessToken: account.accessToken,
+			userinfoUrl: slackCfg?.userinfoUrl,
+		});
+
+		const teamId = raw?.["https://slack.com/team_id"] as
+			| string
+			| null
+			| undefined;
+		const bareUser = (account.accountId ??
+			raw?.["https://slack.com/user_id"] ??
+			raw?.sub) as string | null | undefined;
+
+		// null = missing team id or malformed → NEVER write a bare, un-scoped id
+		// (two workspaces can share a `U…`, so a bare id would bleed across orgs).
+		const combined = normalizeSlackUserId(teamId, bareUser);
+		if (!combined) {
+			log.debug(
+				{ userId: account.userId },
+				"slack-identity: missing team_id or user id — skipping slack_user_id write",
+			);
+			return;
+		}
+
+		await writeIdentities(
+			getDb(),
+			resolved.tenantOrganizationId,
+			resolved.memberEntityId,
+			"auth:signup",
+			[{ namespace: "slack_user_id", identifier: combined }],
+		);
+		log.debug(
+			{ userId: account.userId, organizationId: resolved.tenantOrganizationId },
+			"slack-identity: wrote slack_user_id onto $member",
+		);
+	} catch (err) {
+		log.error(
+			{ err, userId: account.userId, providerId: account.providerId },
+			"slack-identity: failed to persist slack_user_id on login",
+		);
+	}
 }

--- a/packages/server/src/identity/auth-hook.ts
+++ b/packages/server/src/identity/auth-hook.ts
@@ -58,7 +58,7 @@ function markIngested(account: AuthAccountSummary): void {
 	recentIngest.set(account.id, { scope: account.scope ?? "", at: Date.now() });
 }
 
-interface ResolvedTenantMember {
+export interface ResolvedTenantMember {
 	tenantOrganizationId: string;
 	memberEntityId: number;
 }
@@ -68,7 +68,7 @@ interface ResolvedTenantMember {
  * personal-org provisioning hasn't yet completed for this user — ingest
  * will be retried on the next account refresh.
  */
-async function resolveTenantMember(
+export async function resolveTenantMember(
 	userId: string,
 ): Promise<ResolvedTenantMember | null> {
 	const sql = getDb();


### PR DESCRIPTION
## What

When a user signs in with Slack, write their team-scoped `slack_user_id` (`T:U`) onto their `$member` entity, sourced `auth:signup`, idempotent. This makes the ACL Slack channel-graph (`buildSlackChannelGraph`) collapse the workspace member onto the existing `$member` instead of forking a new `person` — both sides now resolve on the same canonical `slack_user_id`. Before this, sign-in wrote only `auth_user_id` + `email`.

## How the slack_user_id is sourced (id_token primary, userinfo fallback)

BetterAuth already stores the OIDC `id_token` on the account row at the login code exchange (`createAccount({ ..., idToken })` / `updateAccount({ ..., idToken })`), and Slack's id_token payload carries both `https://slack.com/team_id` and `https://slack.com/user_id`. So:

- **PRIMARY**: decode the stored `account.idToken` (dependency-free base64url JWT-claims decode — no signature verification; this is our own server-stored token from a TLS code exchange, same trust level as the access token we already store/use, and mirrors better-auth's own `decodeJwt`). Read `team_id` + (`accountId` ?? `user_id` ?? `sub`). No network, no DB read.
- **FALLBACK** (only when there's no id_token, or it yields no `team_id`): the original path — `getEnabledLoginProviderConfigs` → slack `userinfoUrl` → `fetchUserInfoWithRaw` → read the same claims. Kept behind the injected `deps` seam so it stays testable.

This removes a redundant 2nd HTTP round-trip + a `getEnabledLoginProviderConfigs` DB read on the common path; the id_token already has the data from the same login exchange.

A `null` from `normalizeSlackUserId(teamId, bareUser)` (missing team / malformed) means **no write** — never a bare, un-scoped id. The whole body is fire-and-forget (logs which path produced the id; never throws into the auth hook).

### Wiring
- `resolveTenantMember` + `ResolvedTenantMember` exported from `identity/auth-hook.ts` (no SQL duplicated). No runtime cycle: auth-hook's dep graph never reaches `subject-identities`, and `config.ts`'s only `../index` import is type-only.
- `persistLoginSlackIdentity` lives in `auth/subject-identities.ts`, reusing the private idempotent `writeIdentities`. Optional injected `deps` param (network reads + `resolveTenantMember`) — the durable alternative to `vi.mock` under the suite's `isolate: false`.
- Both `account.create.after` and `account.update.after` summaries now carry `accountId` + `idToken`, and each fires `void persistLoginSlackIdentity(accountSummary)` after the existing ingest.

## Tests (red → green, real DB)

`packages/server`, against a brew-Postgres test DB.

New id_token case — RED (id_token-primary block disabled):
```
 × PRIMARY: decodes the stored id_token and writes ... with NO network fetch  → expected true to be false
 × collapses the workspace member onto the existing $member, never forking a person  → expected [ 9 ] to include 7
 ✓ FALLBACK: no id_token → fetches userinfo and writes ...
 ✓ FALLBACK: a malformed id_token falls back to the userinfo fetch
 ✓ is idempotent / never writes a bare id / non-slack no-op
```
GREEN (restored):
```
 Test Files  2 passed (2)
      Tests  7 passed (7)
```

- Unit `persist-login-slack-identity.test.ts`: id_token PRIMARY writes `(slack_user_id,'T1:U1')` and asserts the injected `fetchUserInfoWithRaw` / `getEnabledLoginProviderConfigs` were NOT called; userinfo FALLBACK write; malformed id_token → falls back to fetch; idempotency; missing-team guard; non-slack no-op.
- Integration `signin-slack-identity-collapse.test.ts`: provisions a `$member` with only `auth_user_id`, runs `persistLoginSlackIdentity` via the PRIMARY id_token path with the network deps stubbed to **throw** (proving no network needed), then `buildSlackChannelGraph`; asserts the member edge lands on the existing `$member` (not a new `person`) and exactly one entity carries `T01ACME:U01ALICE` and it is the `$member`.

## Diff

```
 .../authz/signin-slack-identity-collapse.test.ts   | 160 ++++++++++++
 .../__tests__/persist-login-slack-identity.test.ts | 288 +++++++++++++++++++++
 packages/server/src/auth/index.tsx                 |  20 +-
 packages/server/src/auth/subject-identities.ts     | 170 ++++++++++++
 packages/server/src/identity/auth-hook.ts          |   4 +-
 5 files changed, 639 insertions(+), 3 deletions(-)
```

New identity written: namespace `slack_user_id`, source `auth:signup`, on the `$member`. No migration. No new runtime dependency (the JWT decode is `Buffer.from(..., 'base64url')` + `JSON.parse` — jose is only a transitive dep and is not used).
