### PR TITLE
feat(chat): WS-A keystone — Slack senders attributed + managed installs recallable

### DIFF
--- a/db/migrations/20260630130000_channel_messages_attribution.sql
+++ b/db/migrations/20260630130000_channel_messages_attribution.sql
@@ -1,0 +1,37 @@
+-- migrate:up
+
+-- Sender attribution for the durable chat transcript. `author_entity_id` links a
+-- captured message to the person/$member entity that wrote it (resolved at
+-- capture time from the normalized identity index — store-only, NO event, never
+-- embedded), and `team_id` records the workspace the author id is scoped to
+-- (Slack user ids aren't globally unique). Both are additive + nullable so the
+-- column add takes no rewrite and an unattributable message (bot / no team /
+-- unresolved) simply leaves them NULL.
+--
+-- The FK is added NOT VALID then VALIDATEd in a second step so the add never
+-- holds an ACCESS EXCLUSIVE lock while it scans existing rows. ON DELETE SET NULL
+-- so deleting an entity orphans (not deletes) its transcript rows — transcript is
+-- high-volume operational data the entity lifecycle must never cascade into.
+ALTER TABLE public.channel_messages
+  ADD COLUMN IF NOT EXISTS author_entity_id bigint,
+  ADD COLUMN IF NOT EXISTS team_id text;
+
+ALTER TABLE public.channel_messages
+  DROP CONSTRAINT IF EXISTS channel_messages_author_entity_fkey;
+
+ALTER TABLE public.channel_messages
+  ADD CONSTRAINT channel_messages_author_entity_fkey
+  FOREIGN KEY (author_entity_id) REFERENCES public.entities(id) ON DELETE SET NULL
+  NOT VALID;
+
+ALTER TABLE public.channel_messages
+  VALIDATE CONSTRAINT channel_messages_author_entity_fkey;
+
+-- migrate:down
+
+ALTER TABLE public.channel_messages
+  DROP CONSTRAINT IF EXISTS channel_messages_author_entity_fkey;
+
+ALTER TABLE public.channel_messages
+  DROP COLUMN IF EXISTS team_id,
+  DROP COLUMN IF EXISTS author_entity_id;

--- a/db/migrations/20260630130010_channel_messages_author_entity_index.sql
+++ b/db/migrations/20260630130010_channel_messages_author_entity_index.sql
@@ -1,0 +1,15 @@
+-- migrate:up transaction:false
+
+-- Lookup index for per-author transcript queries (e.g. "what did <person> say").
+-- Partial on NOT NULL so the index stays small while most rows (bot posts,
+-- unattributed) carry no author. CONCURRENTLY (transaction:false, one statement)
+-- so building it never locks the high-write channel_messages table. Separate
+-- migration from the column add — squawk requires a CONCURRENTLY index alone in
+-- its own file.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_channel_messages_author_entity
+  ON public.channel_messages (author_entity_id)
+  WHERE author_entity_id IS NOT NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_channel_messages_author_entity;

--- a/docs/plans/chat-feeds/ws-a-implementation.md
+++ b/docs/plans/chat-feeds/ws-a-implementation.md
@@ -1,0 +1,191 @@
+# WS-A (keystone) — implementation plan, verified against current `main` (73e8f387f)
+
+> Branch: `feat/ws-a-slack-ingestion`. Goal: inbound Slack messages become
+> (1) sender-attributed to a person/$member entity and (2) recallable for managed
+> installs. Store-only attribution; NO events emitted; NEVER embed.
+> Scope EXCLUDES `feeds.kind`, channel-as-feed materialization, and the recall
+> re-key — those belong to `feat/feed-consolidation` (WS-D).
+
+## What changed under us since the plan was written (READ FIRST)
+
+1. **#1623 (connections single-table cutover) already fixed the read-orphan.**
+   `resolveBoundChannelRows` (`gateway/channels/bound-channels.ts:46-145`) now reads
+   the unified `connections` table. Branch (A) resolves MANAGED Slack installs via
+   the `b.connection_id = ac.id` link and emits `ac.slug` verbatim — for managed
+   that slug is `slackinst-<uuid>`, which equals `channel_messages.connection_id`
+   (writer: `message-handler-bridge.ts:408` `connectionId: connection.id`). The
+   slug pass-through is confirmed in the test fixture
+   (`__tests__/setup/test-fixtures.ts:223` — `slackinst-` ids stay verbatim, others
+   get `agentconn-`). **So Item 2's UNION-branch-C is NO LONGER NEEDED.** The plan's
+   premise ("`resolveBoundChannelRows` never yields `slackinst-` ids") is stale.
+   → Item 2 becomes: **prove it with a red/green test, don't re-implement.** Caveat
+   to verify (see Item 2): branch (A) only resolves a managed install when its
+   binding is LINKED (`agent_channel_bindings.connection_id` populated); managed
+   `agent_id` is NULL so the tuple fallback can't match. If unlinked managed
+   bindings exist, they stay orphaned — that's a binding-link gap, not a recall gap.
+
+2. **Session B part 2 (#1645) merged** — recall is now a `FeedReader` registry
+   (`lib/feed-reader.ts`, `RECALL_SOURCES` in `tools/search.ts:501`). The ACL gate
+   (`AuthzScope`) is a required typed arg. `fetchConversationSnippets`
+   (`search.ts:361`) still owns the `channel_messages` SELECT and keeps
+   `gate.organizationId` + per-`connection_id` `pairFilter` first-class. Item 3 is a
+   clean, minimal add against this shape — no rebase conflict.
+
+3. **#1646 (stamp `slack_user_id` on Slack sign-in) merged** — a signed-in human's
+   `$member` entity now carries the team-scoped `slack_user_id` (`T:U`). This makes
+   the cross-source collapse LIVE and forces a resolver design decision (Item 1).
+
+## Item 1 — sender attribution (the real keystone work) — TODO
+
+### 1a. Migration `db/migrations/<ts>_channel_messages_attribution.sql`
+`channel_messages` has neither column today (confirmed). `entities_pkey PRIMARY KEY
+(id)` exists (`baseline.sql:2797`), so the FK is valid. Squawk-safe (additive
+nullable + NOT VALID/VALIDATE):
+```sql
+-- migrate:up
+ALTER TABLE public.channel_messages
+  ADD COLUMN IF NOT EXISTS author_entity_id bigint,
+  ADD COLUMN IF NOT EXISTS team_id text;
+ALTER TABLE public.channel_messages DROP CONSTRAINT IF EXISTS channel_messages_author_entity_fkey;
+ALTER TABLE public.channel_messages
+  ADD CONSTRAINT channel_messages_author_entity_fkey
+  FOREIGN KEY (author_entity_id) REFERENCES public.entities(id) ON DELETE SET NULL NOT VALID;
+ALTER TABLE public.channel_messages VALIDATE CONSTRAINT channel_messages_author_entity_fkey;
+-- migrate:down
+ALTER TABLE public.channel_messages DROP CONSTRAINT IF EXISTS channel_messages_author_entity_fkey;
+ALTER TABLE public.channel_messages DROP COLUMN IF EXISTS team_id, DROP COLUMN IF EXISTS author_entity_id;
+```
+The partial index on `author_entity_id` must be a SEPARATE migration with
+`CREATE INDEX CONCURRENTLY` (squawk: index alone in its own file):
+```sql
+-- migrate:up
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_channel_messages_author_entity
+  ON public.channel_messages (author_entity_id) WHERE author_entity_id IS NOT NULL;
+-- migrate:down
+DROP INDEX CONCURRENTLY IF EXISTS idx_channel_messages_author_entity;
+```
+Run the changed migrations through squawk locally (CI `migrations` job gates on it
+and `make review`/pi do NOT — see `reference_squawk_migration_gate`).
+
+### 1b. `resolveChannelMessageSender` in `utils/entity-link-upsert.ts`
+Add an EXPORTED function in this file (the 5 helpers are module-private:
+`lookupMatches:260`, `createEntityWithIdentities:303`, `insertIdentities:404`,
+`ensureAliases:203`, `passesCreateWhen:176`). It produces NO event item, stamps no
+`events.metadata`, never calls `applyEntityLinks`/embedding — mirror the
+hit/miss core of `resolveLinksByKind` (~625-792) using only the primitives.
+
+Identity: `IDENTITY.SLACK_USER_ID` (`@lobu/connector-sdk`, value `'slack_user_id'`),
+value = `normalizeSlackUserId(teamId, authorId)` → `T…:U…` uppercased
+(`connector-sdk/src/identity-normalize.ts:85`). Optional `IDENTITY.EMAIL` secondary
+(degrades to slack_user_id-only when absent). Drop a bare `U…` with no team —
+never store a malformed key.
+
+**KEY DECISION — entityType / `$member` collapse (driven by #1646).**
+`lookupMatches` is scoped to ONE entityType (`search.ts`-style `AND et.slug =
+${entityType}`, line 290). A signed-in human is a `$member` carrying
+`slack_user_id=T:U` (from #1646). To satisfy cross-source collapse (test #4) and
+make attribution + ACL converge on ONE entity, resolve in this order:
+1. `lookupMatches(entityType: '$member', identities: [slack_user_id])` → if hit,
+   return that entity id (the signed-in human). No create.
+2. else `lookupMatches(entityType: 'person', …)` → if hit, return it.
+3. else, gated by `passesCreateWhen({path:'is_bot', equals:false})` AND `teamId`
+   present AND identity normalizes: `createEntityWithIdentities(entityType:
+   'person', …)` + `insertIdentities` + `ensureAliases`. Return the new id.
+Never auto-create a `$member` here (membership provisioning owns that). Bots and
+team-less rows resolve to NULL.
+
+Signature sketch: `resolveChannelMessageSender(sql, { orgId, teamId, authorId,
+authorName, isBot, email? }): Promise<number | null>`.
+
+### 1c. Thread `teamId` through capture — `gateway/connections/channel-transcript.ts`
+- Add `teamId?: string | null` to `PersistChannelMessageParams` (interface ~19-35).
+- In `persistChannelMessage` (~37-68): before/after the INSERT, when
+  `!isBot && teamId && authorId`, call `resolveChannelMessageSender` (best-effort,
+  wrapped so a failure never blocks the turn/ack), then write `team_id` +
+  `author_entity_id` into the INSERT column list/VALUES (~57-65). Keep the
+  `ON CONFLICT … DO NOTHING` dedup. `captureChannelMessage` wrapper (~71-78)
+  unchanged (already fire-and-forget).
+
+### 1d. Wire `teamId` at the writers
+- `message-handler-bridge.ts:408` and `:641` — inbound, non-bot; `teamId` is in
+  scope (used at `:383`,`:391`). **These two drive attribution.**
+- `chat-response-bridge.ts:411` — bot's own reply (`isBot:true`); pass `teamId`
+  via `readPlatformMetadata(...).teamId` for the new column, attribution N/A.
+- `gateway/routes/internal/conversations.ts:206` — bot post (`isBot:true`); `teamId`
+  not in scope → pass null. (NOTE: actual path is `gateway/routes/internal/…`, the
+  original plan's `routes/internal/…` is wrong.)
+
+## Item 2 — managed read-orphan: PROVE, don't re-implement — TODO (E2E hard gate)
+Branch (A) already resolves managed installs (see "What changed" #1). Deliverable:
+a red→green integration test (mirror `tools/__tests__/search-channel-recall.test.ts`
++ the managed-slug fixture `insertChatConnectionRow({ id: 'slackinst-…',
+credentialMode:'managed' })`) that seeds a managed connection + a LINKED
+`agent_channel_bindings` row (`connection_id` set) + a `channel_messages` row with
+`connection_id='slackinst-…'`, then asserts `search_memory` recall returns it and
+attributes the right person, respecting ACL. If it passes on current main with no
+prod change, document "already fixed by #1623, regression test added." If it FAILS
+(e.g. the binding-link path has a gap for managed installs), THAT is the real fix —
+investigate the binding `connection_id` linkage, not a UNION-branch-C re-add.
+
+## Item 3 — surface `author_entity_id` in recall — TODO (minimal)
+`tools/search.ts`, all additive, ACL inputs untouched:
+- `ConversationSnippet` interface (~227): add `author_entity_id: number | null`.
+- `fetchConversationSnippets` SELECT (~397 `SELECT cm.platform, …`): add
+  `cm.author_entity_id`; add it to the row-cast type and the `.map(...)` result.
+- Do NOT touch the WHERE fence (`gate.organizationId` + `pairFilter` on
+  `connection_id`) or the `resolveBoundChannelRows`/`filterChannelsForRequester`
+  ACL path. A test asserts ACL inputs are byte-identical before/after.
+
+## Tests (red→green; from `packages/server`, Node ≥22 or ≥26, reachable DATABASE_URL)
+Mirror `__tests__/integration/conversations/transcript.test.ts` (transcript
+persistence) and `__tests__/integration/authz/slack-channel-visibility.test.ts`
+(seed entity_identities/bindings/channel_messages + authz_source_acl_state aging).
+1. Known `slack_user_id=T1:U1` → `author_entity_id` resolves.
+2. Unknown non-bot → new `person` minted; `is_bot=true` → NULL.
+3. No `team_id` → no write, no malformed key.
+4. **Cross-source collapse** — pre-seeded `$member` with `slack_user_id=T1:U1` →
+   attribution lands on that `$member`, no duplicate person. (Validates the Item-1b
+   `$member`-first lookup against the #1646 model.)
+5. **Managed-install recall (Item 2 E2E gate)** — `slackinst-` connection + linked
+   binding + `channel_messages` row → recall returns it, attributed, ACL-respected.
+6. **ACL isolation / inputs unchanged** — enforced connection + non-member → nothing;
+   member → rows; assert Item 3 didn't change ACL inputs.
+Run: `cd packages/server && npx vitest run <file>`; full gate `make review`.
+
+## Multi-replica / constraints
+- All state PG-mediated: `entity_identities UNIQUE(org,namespace,identifier)` +
+  `ON CONFLICT DO NOTHING` + existing lost-create-race handling
+  (`entity-link-upsert.ts` ~736-764). No in-memory cross-pod state added.
+- Attribution is best-effort/fire-and-forget; resolution failure never blocks a
+  turn or webhook ack.
+- `channel_messages` stays OUT of the embed pipeline (store-only). `events` untouched.
+- No transport changes; Telegram polling single-claimant lease untouched.
+
+## Files
+New: 2 migrations (attribution columns; CONCURRENTLY index);
+`resolveChannelMessageSender` in `utils/entity-link-upsert.ts`; tests above.
+Modify: `gateway/connections/channel-transcript.ts`; `message-handler-bridge.ts`
+(:408,:641); `chat-response-bridge.ts` (:411); `gateway/routes/internal/conversations.ts`
+(:206); `tools/search.ts` (Item 3 only). **No change to `bound-channels.ts`** unless
+test #5 exposes a real binding-link gap.
+
+## Prod reality check (verified 2026-06-30 via Lobu MCP query_sql across all member orgs)
+- **Zero managed (`slackinst-`) installs in prod. Zero `app_installations` rows. Zero
+  `channel_messages` anywhere.** The only Slack connection in any reachable org is ONE
+  BYO connection in `lobu-crm` (`agentconn-cfa916c95eb64939`), and it has no bindings
+  and no messages. So the managed read-orphan is **theoretical for today's data** —
+  the #1623 branch-(A) plumbing is ahead of demand.
+- Consequence for test #5: there is NO real managed dataset to measure linkage on, so
+  the E2E reproducer must **synthesize** the managed scenario (fixtures already support
+  it: `insertChatConnectionRow({ id: 'slackinst-…', credentialMode:'managed' })` +
+  a binding row with `connection_id` set to that connection's id + a `channel_messages`
+  row with `connection_id='slackinst-…'`).
+- The verification question therefore shifts from "is the unify BACKFILL reliable" (no
+  rows to back-fill) to "does the managed-install CREATE path link the binding's
+  `connection_id`". The implementer should read the Slack OAuth install handler
+  (`gateway/routes/public/slack.ts` + `lobu/stores/slack-installations.ts`) and confirm
+  a managed install writes `agent_channel_bindings.connection_id` at bind time (managed
+  `agent_id` is NULL, so the tuple fallback in branch (A) can NEVER match — recall for
+  managed installs depends entirely on the binding being linked). If the install path
+  does NOT set `connection_id`, THAT is the real orphan and the actual fix; surface it
+  in the PR. If it does, test #5 is a green regression test and Item 2 is closed.

--- a/packages/server/src/__tests__/integration/conversations/channel-message-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/conversations/channel-message-attribution.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Store-only sender attribution for the durable chat transcript.
+ *
+ * `persistChannelMessage` resolves a real (non-bot) author to its person/$member
+ * entity and stamps `channel_messages.author_entity_id` — WITHOUT emitting an
+ * event or touching the embed pipeline. Invariants proved here:
+ *   1. a known Slack sender (existing person, slack_user_id=T:U) attributes to it;
+ *   2. an unknown non-bot sender mints a NEW person; a bot post never attributes;
+ *   3. a sender with no team id is never attributed (no malformed, team-less key);
+ *   4. cross-source collapse (#1646): a signed-in human is a $member carrying the
+ *      same slack_user_id, so attribution lands on the $member — no dup person.
+ */
+
+import { normalizeSlackUserId } from '@lobu/connector-sdk';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { persistChannelMessage } from '../../../gateway/connections/channel-transcript';
+import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const TEAM = 'T1ACME';
+
+/** Ensure the org has a `person` entity type so auto-create can resolve it. */
+async function ensurePersonType(orgId: string): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+    VALUES (${orgId}, 'person', 'Person', current_timestamp, current_timestamp)
+    ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+    DO NOTHING
+  `;
+}
+
+async function addIdentity(opts: {
+  orgId: string;
+  entityId: number;
+  namespace: string;
+  identifier: string;
+}): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+    VALUES (${opts.orgId}, ${opts.entityId}, ${opts.namespace}, ${opts.identifier}, 'connector:slack')
+  `;
+}
+
+/** Capture one inbound message and read its attribution back. */
+async function captureAndRead(params: {
+  orgId: string;
+  connectionId: string;
+  channelId: string;
+  authorId: string | null;
+  teamId: string | null;
+  isBot: boolean;
+  text: string;
+}): Promise<number | null> {
+  const sql = getTestDb();
+  await persistChannelMessage({
+    organizationId: params.orgId,
+    connectionId: params.connectionId,
+    platform: 'slack',
+    channelId: params.channelId,
+    platformMessageId: `${params.channelId}-${Math.random().toString(36).slice(2)}`,
+    authorId: params.authorId,
+    authorName: 'Sender',
+    teamId: params.teamId,
+    isBot: params.isBot,
+    text: params.text,
+    occurredAt: new Date(),
+  });
+  const rows = (await sql`
+    SELECT author_entity_id, team_id
+    FROM channel_messages
+    WHERE organization_id = ${params.orgId} AND connection_id = ${params.connectionId}
+    ORDER BY id DESC LIMIT 1
+  `) as Array<{ author_entity_id: number | string | null; team_id: string | null }>;
+  expect(rows).toHaveLength(1);
+  return rows[0].author_entity_id == null ? null : Number(rows[0].author_entity_id);
+}
+
+describe('channel_messages sender attribution', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    clearEntityLinkRulesCache();
+  });
+
+  it('attributes a known Slack sender (existing person, slack_user_id=T:U)', async () => {
+    const org = await createTestOrganization({ name: 'Attr Org' });
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    const person = await createTestEntity({
+      name: 'Alice',
+      entity_type: 'person',
+      organization_id: org.id,
+      created_by: user.id,
+    });
+    const slackId = normalizeSlackUserId(TEAM, 'U1ALICE');
+    await addIdentity({
+      orgId: org.id,
+      entityId: person.id,
+      namespace: 'slack_user_id',
+      identifier: slackId as string,
+    });
+
+    const resolved = await captureAndRead({
+      orgId: org.id,
+      connectionId: 'conn-attr',
+      channelId: 'C1',
+      authorId: 'U1ALICE',
+      teamId: TEAM,
+      isBot: false,
+      text: 'hello from alice',
+    });
+    expect(resolved).toBe(person.id);
+  });
+
+  it('mints a new person for an unknown non-bot sender, and never attributes a bot', async () => {
+    const org = await createTestOrganization({ name: 'Mint Org' });
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, org.id, 'owner');
+    await ensurePersonType(org.id);
+    const sql = getTestDb();
+
+    // Unknown non-bot → a fresh person is minted and attributed.
+    const minted = await captureAndRead({
+      orgId: org.id,
+      connectionId: 'conn-mint',
+      channelId: 'C1',
+      authorId: 'U2BOB',
+      teamId: TEAM,
+      isBot: false,
+      text: 'first message from bob',
+    });
+    expect(minted).not.toBeNull();
+
+    const slackId = normalizeSlackUserId(TEAM, 'U2BOB');
+    const idRows = (await sql`
+      SELECT entity_id FROM entity_identities
+      WHERE organization_id = ${org.id} AND namespace = 'slack_user_id' AND identifier = ${slackId}
+    `) as Array<{ entity_id: number | string }>;
+    expect(idRows).toHaveLength(1);
+    expect(Number(idRows[0].entity_id)).toBe(minted);
+
+    // A bot post is never attributed.
+    const botAttr = await captureAndRead({
+      orgId: org.id,
+      connectionId: 'conn-mint',
+      channelId: 'C1',
+      authorId: 'B1BOT',
+      teamId: TEAM,
+      isBot: true,
+      text: 'beep boop',
+    });
+    expect(botAttr).toBeNull();
+  });
+
+  it('never attributes (or mints a malformed key) when there is no team id', async () => {
+    const org = await createTestOrganization({ name: 'NoTeam Org' });
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, org.id, 'owner');
+    await ensurePersonType(org.id);
+    const sql = getTestDb();
+
+    const resolved = await captureAndRead({
+      orgId: org.id,
+      connectionId: 'conn-noteam',
+      channelId: 'C1',
+      authorId: 'U3CAROL',
+      teamId: null,
+      isBot: false,
+      text: 'no team here',
+    });
+    expect(resolved).toBeNull();
+
+    // No identity row was written for a bare, team-less Slack id.
+    const idRows = (await sql`
+      SELECT 1 FROM entity_identities
+      WHERE organization_id = ${org.id} AND namespace = 'slack_user_id'
+    `) as Array<unknown>;
+    expect(idRows).toHaveLength(0);
+  });
+
+  it('collapses onto a signed-in $member carrying the same slack_user_id (no dup person)', async () => {
+    const org = await createTestOrganization({ name: 'Collapse Org' });
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, org.id, 'owner');
+    await ensurePersonType(org.id);
+    const sql = getTestDb();
+
+    // A signed-in human: $member carrying auth_user_id + the team-scoped slack id.
+    const member = await createTestEntity({
+      name: 'Dave',
+      entity_type: '$member',
+      organization_id: org.id,
+      created_by: user.id,
+    });
+    const slackId = normalizeSlackUserId(TEAM, 'U4DAVE');
+    await addIdentity({
+      orgId: org.id,
+      entityId: member.id,
+      namespace: 'auth_user_id',
+      identifier: user.id,
+    });
+    await addIdentity({
+      orgId: org.id,
+      entityId: member.id,
+      namespace: 'slack_user_id',
+      identifier: slackId as string,
+    });
+
+    const resolved = await captureAndRead({
+      orgId: org.id,
+      connectionId: 'conn-collapse',
+      channelId: 'C1',
+      authorId: 'U4DAVE',
+      teamId: TEAM,
+      isBot: false,
+      text: 'dave in slack',
+    });
+    expect(resolved).toBe(member.id);
+
+    // No person entity was minted for the same identity — attribution and ACL
+    // converge on the single $member.
+    const personRows = (await sql`
+      SELECT e.id FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id AND et.slug = 'person'
+      WHERE e.organization_id = ${org.id} AND e.deleted_at IS NULL
+    `) as Array<unknown>;
+    expect(personRows).toHaveLength(0);
+  });
+});

--- a/packages/server/src/gateway/channels/binding-service.ts
+++ b/packages/server/src/gateway/channels/binding-service.ts
@@ -136,23 +136,67 @@ export class ChannelBindingService {
       // same platform+channel can never collide with — and silently take over —
       // this org's row. `organization_id` is intentionally NOT in the SET list:
       // a binding must never change owners.
+      //
+      // Link `connection_id` to the active chat connection for this (org,
+      // platform, team) at bind time (mirrors the connections-unify backfill's
+      // Step 3, but at runtime so it works for installs created after the
+      // one-shot migration). This is the ONLY thing that makes a MANAGED Slack
+      // install (slackinst- slug, connection agent_id NULL) resolve its channels
+      // in `resolveBoundChannelRows` branch (A): the tuple fallback joins on
+      // `b.agent_id = ac.agent_id`, which can never match a NULL connection
+      // agent_id, so without this link a managed install's transcript is an
+      // unrecallable orphan. COALESCE on conflict keeps an existing link if the
+      // connection isn't resolvable yet (binding created before the install row).
       await sql`
-        INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
-        VALUES (${orgId}, ${agentId}, ${platform}, ${channelId}, ${teamId}, now())
+        INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, connection_id, created_at)
+        VALUES (
+          ${orgId}, ${agentId}, ${platform}, ${channelId}, ${teamId},
+          (
+            SELECT c.id FROM connections c
+            WHERE c.deleted_at IS NULL
+              AND c.status = 'active'
+              AND c.credential_mode IS NOT NULL
+              AND c.organization_id = ${orgId}
+              AND c.connector_key = ${platform}
+              AND c.external_tenant_id = ${teamId}
+            ORDER BY c.updated_at DESC
+            LIMIT 1
+          ),
+          now()
+        )
         ON CONFLICT (organization_id, platform, channel_id, team_id) DO UPDATE SET
           agent_id = EXCLUDED.agent_id,
+          connection_id = COALESCE(EXCLUDED.connection_id, agent_channel_bindings.connection_id),
           created_at = EXCLUDED.created_at
       `;
     } else {
       // For team_id IS NULL the unique constraint above doesn't fire (PG
       // treats NULL as distinct). The companion org-scoped partial unique index
       // (agent_channel_bindings_org_no_team_unique) is what we conflict on.
+      // Tenantless (Telegram, etc.) bindings link to the active chat connection
+      // owned by this agent (mirrors the backfill's tenantless match).
       await sql`
-        INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, created_at)
-        VALUES (${orgId}, ${agentId}, ${platform}, ${channelId}, NULL, now())
+        INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, connection_id, created_at)
+        VALUES (
+          ${orgId}, ${agentId}, ${platform}, ${channelId}, NULL,
+          (
+            SELECT c.id FROM connections c
+            WHERE c.deleted_at IS NULL
+              AND c.status = 'active'
+              AND c.credential_mode IS NOT NULL
+              AND c.organization_id = ${orgId}
+              AND c.connector_key = ${platform}
+              AND c.external_tenant_id IS NULL
+              AND c.agent_id = ${agentId}
+            ORDER BY c.updated_at DESC
+            LIMIT 1
+          ),
+          now()
+        )
         ON CONFLICT (organization_id, platform, channel_id)
           WHERE team_id IS NULL
           DO UPDATE SET agent_id = EXCLUDED.agent_id,
+            connection_id = COALESCE(EXCLUDED.connection_id, agent_channel_bindings.connection_id),
             created_at = EXCLUDED.created_at
       `;
     }

--- a/packages/server/src/gateway/connections/channel-transcript.ts
+++ b/packages/server/src/gateway/connections/channel-transcript.ts
@@ -12,6 +12,7 @@
  */
 import { createLogger } from "@lobu/core";
 import { getDb } from "../../db/client.js";
+import { resolveChannelMessageSender } from "../../utils/entity-link-upsert.js";
 import { stripPlatformPrefix } from "../channels/bound-channels.js";
 
 const logger = createLogger("channel-transcript");
@@ -29,6 +30,10 @@ interface PersistChannelMessageParams {
   platformMessageId: string;
   authorId?: string | null;
   authorName?: string | null;
+  /** Workspace/tenant id the author id is scoped to (Slack team_id). Required to
+   * attribute a sender — Slack user ids aren't globally unique. Null for the
+   * bot's own posts and tenantless platforms. */
+  teamId?: string | null;
   isBot: boolean;
   text: string;
   occurredAt: Date;
@@ -53,15 +58,40 @@ export async function persistChannelMessage(
   // agree on one key (else read_conversation silently returns nothing).
   const channelId = stripPlatformPrefix(params.platform, params.channelId);
   const sql = getDb();
+  const teamId = params.teamId ?? null;
+
+  // Store-only sender attribution: resolve a real (non-bot) author to its
+  // person/$member entity from the normalized identity index. NO event row, no
+  // embedding — channel_messages stays out of the knowledge pipeline. Best-effort
+  // and isolated: a resolution failure must never block transcript capture.
+  let authorEntityId: number | null = null;
+  if (!params.isBot && teamId && params.authorId) {
+    try {
+      authorEntityId = await resolveChannelMessageSender(sql, {
+        orgId: params.organizationId,
+        teamId,
+        authorId: params.authorId,
+        authorName: params.authorName ?? null,
+        isBot: params.isBot,
+      });
+    } catch (err) {
+      logger.warn(
+        { connectionId: params.connectionId, err: String(err) },
+        "sender attribution failed (non-fatal)"
+      );
+    }
+  }
+
   await sql`
     INSERT INTO channel_messages (
       organization_id, connection_id, platform, channel_id, thread_id,
-      platform_message_id, author_id, author_name, is_bot, text, occurred_at
+      platform_message_id, author_id, author_name, team_id, author_entity_id,
+      is_bot, text, occurred_at
     ) VALUES (
       ${params.organizationId}, ${params.connectionId}, ${params.platform},
       ${channelId}, ${params.threadId ?? null}, ${params.platformMessageId},
-      ${params.authorId ?? null}, ${params.authorName ?? null}, ${params.isBot},
-      ${text}, ${params.occurredAt}
+      ${params.authorId ?? null}, ${params.authorName ?? null}, ${teamId},
+      ${authorEntityId}, ${params.isBot}, ${text}, ${params.occurredAt}
     )
     ON CONFLICT (connection_id, channel_id, platform_message_id) DO NOTHING
   `;

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -420,6 +420,7 @@ export class ChatResponseBridge implements ResponseRenderer {
           platformMessageId: `bot:${payload.messageId}`,
           authorId: replyMd.agentId,
           authorName: replyMd.agentId,
+          teamId: replyMd.teamId ?? null,
           isBot: true,
           text: historyText,
           occurredAt: new Date(),

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -412,6 +412,7 @@ export class MessageHandlerBridge {
         platformMessageId: messageId,
         authorId: userId,
         authorName: message.author?.fullName ?? message.author?.userName,
+        teamId: teamId ?? null,
         isBot: message.author?.isMe === true,
         text: typeof message.text === "string" ? message.text : "",
         occurredAt:
@@ -645,6 +646,7 @@ export class MessageHandlerBridge {
                 platformMessageId: prior.id,
                 authorId: prior.author?.userId,
                 authorName: prior.author?.fullName,
+                teamId: teamId ?? null,
                 isBot: prior.author?.isMe === true,
                 text,
                 occurredAt: new Date(sentAt),

--- a/packages/server/src/gateway/routes/internal/conversations.ts
+++ b/packages/server/src/gateway/routes/internal/conversations.ts
@@ -212,6 +212,8 @@ export function createConversationsRoutes(): Hono<WorkerContext> {
           platformMessageId: sent.messageId,
           authorId: worker.agentId,
           authorName: worker.agentId,
+          // Bot's own post — no sender attribution; team_id is not in scope here.
+          teamId: null,
           isBot: true,
           text,
           occurredAt: new Date(),

--- a/packages/server/src/tools/__tests__/search-managed-recall-and-acl.test.ts
+++ b/packages/server/src/tools/__tests__/search-managed-recall-and-acl.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Item 2 (managed read-orphan) + Item 3 (surface author_entity_id) for chat recall.
+ *
+ * Item 2 — a MANAGED Slack install is a `connections` row with `slug=slackinst-…`
+ * and `agent_id NULL`. `resolveBoundChannelRows` branch (A) resolves it ONLY via
+ * the `agent_channel_bindings.connection_id` link — the legacy tuple fallback
+ * joins `b.agent_id = ac.agent_id`, which can never match a NULL connection
+ * agent_id. The one-shot connections-unify backfill links EXISTING bindings, but
+ * a binding created at RUNTIME (post-deploy) gets `connection_id` only because
+ * `ChannelBindingService.createBinding` now links it. These tests prove:
+ *   - an UNLINKED managed binding (connection_id NULL) is an unrecallable orphan
+ *     (the bug, documented as the red);
+ *   - createBinding LINKS connection_id, so the managed install's transcript
+ *     recalls + attributes correctly (the green / fix).
+ *
+ * Item 3 — `author_entity_id` is surfaced in recalled snippets, additively: the
+ * ACL fence (per-user channel visibility) is unchanged — a graphed non-member
+ * still sees nothing, a member sees the channel WITH its author attribution.
+ */
+
+import { normalizeSlackUserId } from '@lobu/connector-sdk';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../__tests__/setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAgent,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+  insertChatConnectionRow,
+} from '../../__tests__/setup/test-fixtures';
+import { buildSlackChannelGraph } from '../../authz/slack-channel-graph';
+import { ChannelBindingService } from '../../gateway/channels/binding-service';
+import { clearEntityLinkRulesCache } from '../../utils/entity-link-upsert';
+import { initWorkspaceProvider } from '../../workspace';
+import { search } from '../search';
+
+const TEAM = 'TMANAGED';
+const MANAGED_CONN = 'slackinst-recall-test';
+
+type SearchCtx = Parameters<typeof search>[2];
+
+async function seedManagedMessage(
+  connectionId: string,
+  channelId: string,
+  text: string
+): Promise<void> {
+  const sql = getTestDb();
+  // channel_messages stores the BARE channel id; the binding stores the
+  // platform-prefixed form (`slack:C…`).
+  const bare = channelId.startsWith('slack:') ? channelId.slice('slack:'.length) : channelId;
+  await sql`
+    INSERT INTO channel_messages (
+      organization_id, connection_id, platform, channel_id,
+      platform_message_id, author_name, is_bot, text, occurred_at
+    )
+    SELECT c.organization_id, ${connectionId}, 'slack', ${bare},
+           ${`${bare}-0`}, 'Alice', false, ${text}, NOW()
+    FROM connections c WHERE c.slug = ${connectionId} LIMIT 1
+  `;
+}
+
+describe('managed-install recall (Item 2) + author attribution surfacing (Item 3)', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    clearEntityLinkRulesCache();
+  });
+
+  async function setupManaged() {
+    const org = await createTestOrganization({ name: 'Managed Co' });
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, org.id, 'owner');
+    // The agent that LINKS the channel (a real, non-null agent) — the managed
+    // connection itself has agent_id NULL.
+    const agent = await createTestAgent({ organizationId: org.id });
+    await insertChatConnectionRow({
+      id: MANAGED_CONN,
+      organizationId: org.id,
+      platform: 'slack',
+      agentId: null,
+      credentialMode: 'managed',
+      status: 'active',
+      metadata: { teamId: TEAM },
+    });
+    await seedManagedMessage(
+      MANAGED_CONN,
+      'slack:CMANAGED',
+      'We discussed the quarterly revenue forecast'
+    );
+    return { org, user, agent };
+  }
+
+  it('RED: an UNLINKED managed binding (connection_id NULL) is an unrecallable orphan', async () => {
+    const { org, user, agent } = await setupManaged();
+    const sql = getTestDb();
+    // Bind WITHOUT the connection_id link (raw insert, the pre-fix shape).
+    await sql`
+      INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id)
+      VALUES (${org.id}, ${agent.agentId}, 'slack', 'slack:CMANAGED', ${TEAM})
+    `;
+
+    const result = await search(
+      { query: 'quarterly revenue', include_content: true },
+      {} as Parameters<typeof search>[1],
+      { organizationId: org.id, userId: user.id, agentId: agent.agentId } as SearchCtx
+    );
+    // The managed connection's agent_id is NULL → the tuple fallback can't match
+    // and there is no connection_id link → branch (A) yields nothing.
+    expect(result.conversation_messages ?? []).toHaveLength(0);
+  });
+
+  it('GREEN: createBinding LINKS connection_id, so the managed install recalls + attributes', async () => {
+    const { org, user, agent } = await setupManaged();
+    const sql = getTestDb();
+
+    // The REAL runtime bind path — links connection_id to the active managed
+    // connection for (org, slack, TEAM).
+    await new ChannelBindingService().createBinding(agent.agentId, 'slack', 'slack:CMANAGED', TEAM, {
+      organizationId: org.id,
+    });
+
+    // The fix's load-bearing assertion: the binding is now linked to the managed
+    // connection (this is what makes branch (A) resolve a NULL-agent install).
+    const [binding] = (await sql`
+      SELECT b.connection_id, c.slug
+      FROM agent_channel_bindings b
+      JOIN connections c ON c.id = b.connection_id
+      WHERE b.organization_id = ${org.id} AND b.channel_id = 'slack:CMANAGED'
+    `) as Array<{ connection_id: number; slug: string }>;
+    expect(binding).toBeDefined();
+    expect(binding.slug).toBe(MANAGED_CONN);
+
+    const result = await search(
+      { query: 'quarterly revenue', include_content: true },
+      {} as Parameters<typeof search>[1],
+      { organizationId: org.id, userId: user.id, agentId: agent.agentId } as SearchCtx
+    );
+    const channels = (result.conversation_messages ?? []).map((m) => m.channel_id);
+    expect(channels).toContain('CMANAGED');
+  });
+
+  it('Item 3: surfaces author_entity_id additively without changing the ACL fence', async () => {
+    const org = await createTestOrganization({ name: 'Attr Recall Co' });
+    const alice = await createTestUser({ name: 'Alice' });
+    await addUserToOrganization(alice.id, org.id, 'owner');
+    const agent = await createTestAgent({ organizationId: org.id });
+    const sql = getTestDb();
+
+    // BYO connection (agent_id set → tuple-resolves) + a graphed workspace.
+    const CONN = 'conn-attr-recall';
+    await insertChatConnectionRow({
+      id: CONN,
+      organizationId: org.id,
+      platform: 'slack',
+      agentId: agent.agentId,
+      status: 'active',
+      metadata: { teamId: TEAM },
+    });
+    await sql`
+      INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+      VALUES (${org.id}, 'person', 'Person', current_timestamp, current_timestamp)
+      ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+      DO NOTHING
+    `;
+
+    // Alice signed in ($member with the team-scoped slack id) — the requester.
+    const aliceMember = await createTestEntity({
+      name: 'Alice',
+      entity_type: '$member',
+      organization_id: org.id,
+      created_by: alice.id,
+    });
+    const aliceSlack = normalizeSlackUserId(TEAM, 'U01ALICE');
+    await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+      VALUES
+        (${org.id}, ${aliceMember.id}, 'auth_user_id', ${alice.id}, 'auth:signup'),
+        (${org.id}, ${aliceMember.id}, 'slack_user_id', ${aliceSlack}, 'connector:slack')
+    `;
+
+    // The author of the recalled message — a person already attributed.
+    const author = await createTestEntity({
+      name: 'Bob',
+      entity_type: 'person',
+      organization_id: org.id,
+      created_by: alice.id,
+    });
+
+    // Bind both channels; Alice is a member of #eng only.
+    for (const ch of ['C01ENG', 'C01SEC']) {
+      await sql`
+        INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id)
+        VALUES (${org.id}, ${agent.agentId}, 'slack', ${`slack:${ch}`}, ${TEAM})
+      `;
+    }
+    await sql`
+      INSERT INTO channel_messages (
+        organization_id, connection_id, platform, channel_id,
+        platform_message_id, author_name, author_entity_id, is_bot, text, occurred_at
+      ) VALUES
+        (${org.id}, ${CONN}, 'slack', 'C01ENG', 'eng-0', 'Bob', ${author.id}, false,
+         'We discussed the quarterly revenue forecast', NOW()),
+        (${org.id}, ${CONN}, 'slack', 'C01SEC', 'sec-0', 'Bob', ${author.id}, false,
+         'Secret: the quarterly revenue numbers are confidential', NOW())
+    `;
+
+    await buildSlackChannelGraph({
+      organizationId: org.id,
+      connectionId: CONN,
+      teamId: TEAM,
+      channels: [
+        { channelId: 'C01ENG', name: 'eng', memberSlackUserIds: ['U01ALICE'] },
+        { channelId: 'C01SEC', name: 'secret', isPrivate: true, memberSlackUserIds: ['U01BOB'] },
+      ],
+    });
+
+    // Member: sees #eng only (ACL fence intact) AND the snippet carries the
+    // surfaced author_entity_id.
+    const asMember = await search(
+      { query: 'quarterly revenue', include_content: true },
+      {} as Parameters<typeof search>[1],
+      { organizationId: org.id, userId: alice.id, agentId: agent.agentId } as SearchCtx
+    );
+    const memberChannels = (asMember.conversation_messages ?? []).map((m) => m.channel_id);
+    expect(memberChannels).toContain('C01ENG');
+    expect(memberChannels).not.toContain('C01SEC');
+    const engSnippet = (asMember.conversation_messages ?? []).find((m) => m.channel_id === 'C01ENG');
+    expect(engSnippet?.author_entity_id).toBe(author.id);
+
+    // Non-member: the graphed connection fails closed (Item 3 didn't widen it).
+    const asIntruder = await search(
+      { query: 'quarterly revenue', include_content: true },
+      {} as Parameters<typeof search>[1],
+      { organizationId: org.id, userId: 'intruder-user-id', agentId: agent.agentId } as SearchCtx
+    );
+    expect(asIntruder.conversation_messages ?? []).toHaveLength(0);
+  });
+});

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -224,6 +224,9 @@ interface ConversationSnippet {
   channel_id: string;
   thread_id: string | null;
   author_name: string | null;
+  /** The sender's resolved person/$member entity id (store-only attribution),
+   * or null when unattributed (bot post / no team / unresolved). */
+  author_entity_id: number | null;
   text: string;
   occurred_at: string | null;
 }
@@ -409,7 +412,8 @@ async function fetchConversationSnippets(
   });
 
   const rows = (await sql`
-    SELECT cm.platform, cm.channel_id, cm.thread_id, cm.author_name, cm.text, cm.occurred_at
+    SELECT cm.platform, cm.channel_id, cm.thread_id, cm.author_name,
+           cm.author_entity_id, cm.text, cm.occurred_at
     FROM channel_messages cm
     WHERE cm.organization_id = ${gate.organizationId}
       AND (${pairFilter})
@@ -421,6 +425,7 @@ async function fetchConversationSnippets(
     channel_id: string;
     thread_id: string | null;
     author_name: string | null;
+    author_entity_id: number | string | null;
     text: string;
     occurred_at: Date | null;
   }>;
@@ -430,6 +435,7 @@ async function fetchConversationSnippets(
     channel_id: r.channel_id,
     thread_id: r.thread_id,
     author_name: r.author_name,
+    author_entity_id: r.author_entity_id == null ? null : Number(r.author_entity_id),
     text: r.text.length > 500 ? `${r.text.slice(0, 500)}...` : r.text,
     occurred_at: r.occurred_at ? new Date(r.occurred_at).toISOString() : null,
   }));

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -22,7 +22,12 @@ import type {
   EntityLinkPredicate,
   EntityLinkRule,
 } from '@lobu/connector-sdk';
-import { normalizeIdentifier } from '@lobu/connector-sdk';
+import {
+  IDENTITY,
+  normalizeEmail,
+  normalizeIdentifier,
+  normalizeSlackUserId,
+} from '@lobu/connector-sdk';
 import { type DbClient, getDb, pgTextArray } from '../db/client';
 import { resolveEntityLinkRules } from './entity-link-validation';
 import logger from './logger';
@@ -793,4 +798,128 @@ async function resolveLinksByKind(
   }
 
   return resolvedByItem;
+}
+
+/**
+ * Resolve the SENDER of a captured chat message to a person/$member entity id —
+ * STORE-ONLY attribution for `channel_messages.author_entity_id`.
+ *
+ * Unlike {@link applyEntityLinks}, this writes NO event row, stamps no
+ * `events.metadata`, and never enters the embed pipeline: it only reads the
+ * normalized identity index and, on a miss, mints a `person` (gated). Transcript
+ * is high-volume operational data, so the caller fire-and-forgets this — a
+ * resolution failure must never block capture or a webhook ack.
+ *
+ * Resolution order (driven by the #1646 cross-source collapse — a signed-in
+ * human is a `$member` carrying the team-scoped `slack_user_id`):
+ *   1. an existing `$member` with this `slack_user_id` (the signed-in human) —
+ *      return it; never create a `$member` here (membership provisioning owns
+ *      that, so attribution and ACL converge on the SAME entity).
+ *   2. else an existing `person` with it — return it.
+ *   3. else mint a `person`, gated on a real (non-bot) human WITH a team id and a
+ *      well-formed identity. Bots, team-less rows, and malformed ids → null.
+ *
+ * Identity is `slack_user_id = normalizeSlackUserId(teamId, authorId)` (`T…:U…`),
+ * with an optional `email` secondary; a bare `U…` with no team is dropped so a
+ * malformed (non-workspace-scoped) key never poisons cross-workspace matching.
+ */
+export async function resolveChannelMessageSender(
+  sql: DbClient,
+  params: {
+    orgId: string;
+    teamId?: string | null;
+    authorId?: string | null;
+    authorName?: string | null;
+    isBot: boolean;
+    email?: string | null;
+  }
+): Promise<number | null> {
+  if (params.isBot) return null;
+
+  const slackId = normalizeSlackUserId(params.teamId, params.authorId);
+  // Drop a bare `U…` with no team — never store a malformed, team-less key.
+  if (!slackId) return null;
+
+  const identities: ExtractedLink['identities'] = [
+    { namespace: IDENTITY.SLACK_USER_ID, identifier: slackId, matchOnly: false, primary: false },
+  ];
+  const email = normalizeEmail(params.email ?? null);
+  if (email) {
+    identities.push({
+      namespace: IDENTITY.EMAIL,
+      identifier: email,
+      matchOnly: false,
+      primary: false,
+    });
+  }
+
+  const firstHit = (matches: Map<string, number>): number | null => {
+    for (const id of identities) {
+      const hit = matches.get(`${id.namespace} ${id.identifier}`);
+      if (hit !== undefined) return hit;
+    }
+    return null;
+  };
+
+  // 1) Signed-in human ($member, carrying slack_user_id from #1646). No create.
+  const memberHit = firstHit(
+    await lookupMatches(sql, {
+      orgId: params.orgId,
+      entityType: '$member',
+      identities: [identities],
+    })
+  );
+  if (memberHit !== null) return memberHit;
+
+  // 2) An existing person.
+  const personHit = firstHit(
+    await lookupMatches(sql, {
+      orgId: params.orgId,
+      entityType: 'person',
+      identities: [identities],
+    })
+  );
+  if (personHit !== null) return personHit;
+
+  // 3) Mint a person — gated on a real human (is_bot=false). isBot is already
+  // rejected above, so this only re-states the contract via the same predicate
+  // primitive the connector autoCreate gate uses.
+  if (
+    !passesCreateWhen({ path: 'is_bot', equals: false }, {
+      is_bot: params.isBot,
+    } as unknown as BatchItem)
+  ) {
+    return null;
+  }
+  const creatorUserId = await resolveOrgCreator(params.orgId);
+  if (!creatorUserId) return null;
+
+  const created = await createEntityWithIdentities(sql, {
+    orgId: params.orgId,
+    connectorKey: 'slack',
+    entityType: 'person',
+    title: params.authorName?.trim() || '',
+    identities,
+    traits: new Map(),
+    creatorUserId,
+  });
+  if (created !== null && created.attached.length > 0) {
+    return created.entityId;
+  }
+  // Lost the identity create-race (a concurrent ingest minted the person first):
+  // drop the identity-less orphan and resolve to the winner instead.
+  if (created !== null) {
+    await sql`
+      DELETE FROM entities
+      WHERE id = ${created.entityId} AND organization_id = ${params.orgId}
+    `;
+    return firstHit(
+      await lookupMatches(sql, {
+        orgId: params.orgId,
+        entityType: 'person',
+        identities: [identities],
+      })
+    );
+  }
+  return null;
 }

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -24,7 +24,6 @@ import type {
 } from '@lobu/connector-sdk';
 import {
   IDENTITY,
-  normalizeEmail,
   normalizeIdentifier,
   normalizeSlackUserId,
 } from '@lobu/connector-sdk';
@@ -819,9 +818,9 @@ async function resolveLinksByKind(
  *   3. else mint a `person`, gated on a real (non-bot) human WITH a team id and a
  *      well-formed identity. Bots, team-less rows, and malformed ids → null.
  *
- * Identity is `slack_user_id = normalizeSlackUserId(teamId, authorId)` (`T…:U…`),
- * with an optional `email` secondary; a bare `U…` with no team is dropped so a
- * malformed (non-workspace-scoped) key never poisons cross-workspace matching.
+ * Identity is `slack_user_id = normalizeSlackUserId(teamId, authorId)` (`T…:U…`);
+ * a bare `U…` with no team is dropped so a malformed (non-workspace-scoped) key
+ * never poisons cross-workspace matching.
  */
 export async function resolveChannelMessageSender(
   sql: DbClient,
@@ -831,7 +830,6 @@ export async function resolveChannelMessageSender(
     authorId?: string | null;
     authorName?: string | null;
     isBot: boolean;
-    email?: string | null;
   }
 ): Promise<number | null> {
   if (params.isBot) return null;
@@ -843,15 +841,6 @@ export async function resolveChannelMessageSender(
   const identities: ExtractedLink['identities'] = [
     { namespace: IDENTITY.SLACK_USER_ID, identifier: slackId, matchOnly: false, primary: false },
   ];
-  const email = normalizeEmail(params.email ?? null);
-  if (email) {
-    identities.push({
-      namespace: IDENTITY.EMAIL,
-      identifier: email,
-      matchOnly: false,
-      primary: false,
-    });
-  }
 
   const firstHit = (matches: Map<string, number>): number | null => {
     for (const id of identities) {
@@ -881,16 +870,8 @@ export async function resolveChannelMessageSender(
   );
   if (personHit !== null) return personHit;
 
-  // 3) Mint a person — gated on a real human (is_bot=false). isBot is already
-  // rejected above, so this only re-states the contract via the same predicate
-  // primitive the connector autoCreate gate uses.
-  if (
-    !passesCreateWhen({ path: 'is_bot', equals: false }, {
-      is_bot: params.isBot,
-    } as unknown as BatchItem)
-  ) {
-    return null;
-  }
+  // 3) Mint a person. Non-bot is already enforced by the early return above, so
+  // the only remaining gate is a real org member to attribute the create to.
   const creatorUserId = await resolveOrgCreator(params.orgId);
   if (!creatorUserId) return null;
 

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -844,7 +844,7 @@ export async function resolveChannelMessageSender(
 
   const firstHit = (matches: Map<string, number>): number | null => {
     for (const id of identities) {
-      const hit = matches.get(`${id.namespace} ${id.identifier}`);
+      const hit = matches.get(`${id.namespace}\u0000${id.identifier}`);
       if (hit !== undefined) return hit;
     }
     return null;


### PR DESCRIPTION
## WS-A keystone — Slack messages become attributed + recallable data

Three items. Store-only attribution (no events, never embedded); recall stays ACL-gated; multi-replica safe (all state PG-mediated).

### Item 1 — sender attribution (commits `b1981c5`)
- Migrations: `channel_messages` gains `author_entity_id bigint` (FK → `entities(id)` `ON DELETE SET NULL`, added `NOT VALID` then `VALIDATE`) + `team_id text`; a separate `CREATE INDEX CONCURRENTLY` (its own `transaction:false` file) for the partial author index.
- New exported `resolveChannelMessageSender` in `utils/entity-link-upsert.ts` reuses the module-private primitives (`lookupMatches`, `createEntityWithIdentities`, `insertIdentities`, `ensureAliases`, `passesCreateWhen`, `resolveOrgCreator`). It emits **no** event, stamps no `events.metadata`, never embeds. Resolution order: `$member` (signed-in human carrying `slack_user_id` from #1646) → `person` → mint a `person` (gated on `is_bot=false` + a team id + a well-formed `normalizeSlackUserId(team,user)`). Bots / team-less / malformed → null; never mints a `$member`.
- `persistChannelMessage` threads `teamId` and resolves best-effort (a failure never blocks capture). The four writers pass `teamId`: the two inbound `message-handler-bridge` sites drive attribution; `chat-response-bridge` passes `replyMd.teamId`; `routes/internal/conversations` is a bot post → null.

### Item 2 — managed read-orphan (commit `f54e93f`) — REAL GAP, fixed
Branch (A) of `resolveBoundChannelRows` resolves a managed install via `b.connection_id = ac.id` (#1623). I verified the install/bind path and found a real runtime gap: **`ChannelBindingService.createBinding` never set `connection_id`** (nor did `postgres-stores.createChannelBinding`, which has no live callers). The connections-unify backfill links only *existing* bindings, one-shot. A managed connection has `agent_id NULL`, so branch (A)'s tuple fallback (`b.agent_id = ac.agent_id`) can never match — recall depends **entirely** on the `connection_id` link. A binding created at runtime (post-deploy) therefore stays an unrecallable orphan.

Fix: `createBinding` now resolves and stamps `connection_id` for the active chat connection of `(org, platform, team)` (mirrors the backfill's Step 3, at runtime), with `COALESCE` on conflict so a rebind re-links without clobbering.

**Red→green reproducer** (`search-managed-recall-and-acl.test.ts`):
- RED documented: a managed install + an UNLINKED binding (raw insert, `connection_id NULL`) → `search_memory` recall returns **0** rows.
- GREEN: bind via the real `createBinding` → the binding is linked to the `slackinst-` connection and recall returns the channel.
- Proven dependent on the fix: reverting the `createBinding` link makes the GREEN test fail (`expected undefined to be defined` on the linked-binding assertion). Captured against the live DB.

### Item 3 — surface `author_entity_id` in recall (commit `3c5631f`)
`tools/search.ts`: added `cm.author_entity_id` to the `fetchConversationSnippets` SELECT, the row cast, the `ConversationSnippet` interface, and the mapped result. The WHERE fence (`gate.organizationId` + per-`connection_id` `pairFilter`) and the `resolveBoundChannelRows`/`filterChannelsForRequester` ACL path are untouched; a test asserts a graphed member sees the attributed snippet while a non-member fails closed.

### Tests (commit `0618b39`) — all green against live Postgres+pgvector
- `channel-message-attribution.test.ts` (4): known sender; mint-on-miss + bot→null; no-team→null/no-malformed-key; `$member` cross-source collapse (no dup person).
- `search-managed-recall-and-acl.test.ts` (3): managed orphan (red) vs linked recall (green, E2E gate); `author_entity_id` surfaced + ACL fence unchanged.
- Regressions confirmed green: `search-channel-recall`, `slack-channel-visibility` (11), `connections-unify-managed-routing`, `transcript`, `entity-link-upsert`, `entity-links-contract`, `connections-unify-resync-drop`.

squawk (CI's pinned `squawk-cli@2.58.0`, same excludes): **0 issues in 2 files**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785442428&installation_id=136316292&pr_number=1648&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1648&signature=66cbfddfd42cf12b19b89940208063ab78b204aea2b14e4e90e4c50e8bfda47e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat transcripts now retain sender attribution for non-bot messages, improving message history context.
  * Search results can now show the sender associated with recalled chat snippets.

* **Bug Fixes**
  * Improved Slack message recall for managed installs, helping previously missing conversations appear correctly.
  * Better linking between workspace-scoped channel bindings and the right active connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->