### PR TITLE
feat(chrome): reduce orphan tab lifetime via run-scoped ownership

### DIFF
--- a/packages/connector-sdk/src/extension-network.ts
+++ b/packages/connector-sdk/src/extension-network.ts
@@ -328,7 +328,10 @@ async function safeCloseTab(dispatcher: ChromeActionDispatcher, tabId: number) {
     // of where it ended up), so we don't need to forward the allowlist here.
     await dispatcher.dispatch('close_tab', { tab_id: tabId });
   } catch (err) {
-    sdkLogger.warn({ err, tabId }, '[ExtensionNetwork] close_tab failed (already gone?)');
+    sdkLogger.warn(
+      { err, tabId, reason: err instanceof Error ? err.message : String(err) },
+      '[ExtensionNetwork] close_tab failed'
+    );
   }
 }
 

--- a/packages/server/src/worker-api/dispatch-chrome-action.ts
+++ b/packages/server/src/worker-api/dispatch-chrome-action.ts
@@ -142,6 +142,17 @@ export async function dispatchChromeActionToExtension(params: {
     };
   }
 
+  // Stamp holder_run_id on every chrome action so the extension can scope
+  // scratch-tab ownership/cleanup to the parent sync run.
+  const operationInput: Record<string, unknown> = { ...(actionInput ?? {}) };
+  if (
+    parentRunId != null &&
+    operationInput.holder_run_id == null &&
+    operationInput.parent_run_id == null
+  ) {
+    operationInput.holder_run_id = parentRunId;
+  }
+
   // (2) Insert a device-bound chrome connector action run.
   let runId: number;
   try {
@@ -150,7 +161,7 @@ export async function dispatchChromeActionToExtension(params: {
       connectionId: chromeConnection.connectionId,
       connectorKey: 'chrome',
       operationKey: actionKey,
-      operationInput: actionInput ?? {},
+      operationInput,
       approvalMode: 'device',
       requireCompiledCode: false,
     });

--- a/scripts/e2e-chrome-tab-cleanup.sh
+++ b/scripts/e2e-chrome-tab-cleanup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# E2E verification for chrome tab cleanup (PR1-lite).
+# Runs automated tests + gateway health + optional live extension check.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+port=8787
+if [[ -f .env.local ]]; then
+  p="$(awk -F= '/^PORT=/{print $2; exit}' .env.local | tr -d '[:space:]')"
+  [[ -n "$p" ]] && port="$p"
+fi
+url="http://127.0.0.1:${port}"
+
+echo "==> [1/4] Owletto chrome unit tests"
+(cd packages/owletto/apps/chrome && bun test tools.test.js)
+
+echo "==> [2/4] Connector SDK extension-network tests"
+bun test packages/connector-sdk/src/__tests__/extension-network.test.ts
+
+echo "==> [3/4] Gateway health (${url})"
+curl -sf "${url}/api/health" | head -c 200
+echo ""
+
+db_url=""
+if [[ -f .env.local ]]; then
+  db_url="$(awk -F= '/^DATABASE_URL=/{print $2; exit}' .env.local | tr -d '[:space:]')"
+fi
+if [[ -z "$db_url" && -f .env ]]; then
+  db_url="$(awk -F= '/^DATABASE_URL=/{print $2; exit}' .env | tr -d '[:space:]')"
+fi
+if [[ -z "$db_url" ]]; then
+  # make dev prints DATABASE_URL from dev-db.sh; derive the same name here.
+  db_url="$(NAME="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo dev)" \
+    PGHOST="${PGHOST:-localhost}" PGPORT="${PGPORT:-5418}" PGUSER="${PGUSER:-$USER}" \
+    bash -c 'source scripts/lib/db-name.sh 2>/dev/null; echo "postgres://${PGUSER}@${PGHOST}:${PGPORT}/$(lobu_db_name "${NAME:-dev}")"')"
+fi
+
+echo "==> [4/4] Extension pairing status"
+if [[ -n "$db_url" ]]; then
+  online="$(psql "$db_url" -tAc \
+    "SELECT COUNT(*) FROM device_workers WHERE platform='chrome-extension' AND last_seen_at > now() - interval '20 minutes'" 2>/dev/null || echo 0)"
+  if [[ "${online:-0}" -gt 0 ]]; then
+    echo "    extension online (${online} worker(s)) — live chrome ops available"
+    echo "    run: lobu memory run run_sdk with operations.execute on chrome connection"
+  else
+    echo "    no online chrome-extension in this DB"
+    echo "    pair: make e2e-browser RESTART=1"
+    echo "          set extension Server URL to ${url} in sidepanel, then sign in"
+  fi
+else
+  echo "    DATABASE_URL not found — skip DB pairing check"
+fi
+
+echo ""
+echo "OK automated e2e checks passed"


### PR DESCRIPTION
## Problem

Overlapping Chrome connector syncs on the same `device_worker_id` each open a tab. When a worker is SIGKILL'd, the extension's `finally` never runs so `close_tab` is skipped. With a 30m tab TTL and 10m reaper alarm, orphans accumulate (e.g. dozens of Revolut tabs).

## Solution (PR1-lite)

**Extension (owletto `9895be3`):**
- Tag owned tabs with `holder_run_id`; reuse tabs within the same holder
- `disposeOwnedTabsForHolder` on 90s run timeout
- Tab TTL: 30m → **5m**; reaper alarm: 10m → **1m**
- Startup `reapStaleTabs` on service-worker wake
- Holder-scoped `close_tab` gate

**Gateway:**
- Stamp `holder_run_id = parentRunId` in `dispatch-chrome-action.ts` so extension can correlate tabs to the parent sync run

**SDK:**
- Log `close_tab` failure reason in `safeCloseTab`

**Smoke script:** `scripts/e2e-chrome-tab-cleanup.sh`

Net ~144 lines core + e2e script. Deferred: Postgres `chrome_browser_claims` lease (overkill for personal-agent scope).

## Owletto

Submodule bumped to `9895be3` on branch `feat/chrome-tab-cleanup`. Companion PR: https://github.com/lobu-ai/owletto/compare/feat/chrome-tab-cleanup

## Validation

- `make review`: typecheck ✅ unit ✅ integration ⚠️ (1 flaky failure in unrelated `app-installation` e2e; pi reran narrow test — passed)
- Pi verdict: **bug_free 76**, simplicity 73, slop 10, **0 bugs / 0 blockers**
- Owletto `tools.test.js`: 39 pass
- SDK `extension-network.test.ts`: 6 pass
- `./scripts/e2e-chrome-tab-cleanup.sh`: pass
- Prod smoke (connection #369): navigate + close_tab succeeded; new extension build not yet loaded on prod Chrome (Web Store build still active)

## Risk

High behavior-change surface (extension tab lifecycle). Mitigated by faster reaper + holder-scoped dispose; no gateway lease semantics changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785449020&installation_id=136316292&pr_number=1649&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1649&signature=f565e07164262063728ad78b9cc39f3975d74be80f84388f7a6764c863997562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->