### PR TITLE
fix(feeds): channel-feed lifecycle fixes + read_feed consolidation

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
@@ -218,6 +218,79 @@ describe("channel streaming feeds", () => {
     expect(result.messages[1]).toMatchObject({ user: "assistant", text: "hi Alice", isBot: true });
   });
 
+  it("trigger_feed rejects a streaming feed (only collected feeds sync)", async () => {
+    const conn = await makeChatConnection({ orgId, teamId: "TACME" });
+    const feedId = await ensureStreamingChannelFeed({
+      connectionId: conn.id,
+      organizationId: orgId,
+      channelKey: "slack:C600",
+    });
+
+    const res = (await workspace.owner.feeds.manage({
+      action: "trigger_feed",
+      feed_id: feedId,
+    })) as { triggered?: boolean; run_id?: string; error?: string };
+
+    // A streaming feed has no connector fetch for its feed_key — triggering a
+    // sync would spawn a run against nothing. Reject before createSyncRun.
+    expect(res.triggered).toBeUndefined();
+    expect(res.run_id).toBeUndefined();
+    expect(res.error).toContain("only collected feeds");
+  });
+
+  it("read_channel_feed rejects a non-streaming (collected) feed id", async () => {
+    // A plain connection with the default kind='collected' feed.
+    const conn = await createTestConnection({
+      organization_id: orgId,
+      connector_key: "slack",
+      display_name: "Collected Slack",
+    });
+    const sql = getTestDb();
+    const feedRow = (await sql`
+      SELECT id, kind FROM feeds WHERE connection_id = ${conn.id} AND deleted_at IS NULL
+    `) as Array<{ id: number; kind: string }>;
+    expect(feedRow[0]?.kind).toBe("collected");
+
+    // read_channel_feed only reads streaming channel feeds; a collected feed id
+    // must not resolve to a transcript.
+    const res = (await workspace.owner.feeds.manage({
+      action: "read_channel_feed",
+      feed_id: feedRow[0].id,
+    })) as { messages?: unknown[]; error?: string };
+    expect(res.messages).toBeUndefined();
+    expect(res.error).toBe("Feed not found");
+  });
+
+  it("deleteAllBindings soft-deletes each unbound channel's streaming feed", async () => {
+    const conn = await makeChatConnection({ orgId, teamId: "TACME" });
+    const svc = new ChannelBindingService();
+    const { agentId } = await createTestAgent({ organizationId: orgId });
+
+    await svc.createBinding(agentId, "slack", "slack:C700", "TACME", {
+      organizationId: orgId,
+    });
+    await svc.createBinding(agentId, "slack", "slack:C701", "TACME", {
+      organizationId: orgId,
+    });
+
+    const sql = getDb();
+    const before = await sql`
+      SELECT COUNT(*)::int AS n FROM feeds
+      WHERE organization_id = ${orgId} AND kind = 'streaming' AND deleted_at IS NULL
+    `;
+    expect(Number(before[0]?.n)).toBe(2);
+
+    const removed = await svc.deleteAllBindings(agentId, orgId);
+    expect(removed).toBe(2);
+
+    // Both streaming feeds are retired — no live orphan feed left behind.
+    const after = await sql`
+      SELECT COUNT(*)::int AS n FROM feeds
+      WHERE organization_id = ${orgId} AND kind = 'streaming' AND deleted_at IS NULL
+    `;
+    expect(Number(after[0]?.n)).toBe(0);
+  });
+
   it("a chat-only connection with streaming feeds is not labeled a data connection", async () => {
     const conn = await makeChatConnection({ orgId, teamId: "TACME" });
     await ensureStreamingChannelFeed({

--- a/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
@@ -9,7 +9,8 @@
  *      with next_run_at in the past — kind is the discriminator.
  *   3. ChannelBindingService.createBinding materializes the channel's feed under
  *      the bound connection; deleteBinding soft-deletes it.
- *   4. manage_feeds read_channel_feed returns the channel transcript.
+ *   4. manage_feeds read_feed dispatches on kind: a streaming feed returns its
+ *      channel transcript, a collected feed returns metadata + recent runs.
  *   5. facet derivation: a chat-only connection whose channels are streaming
  *      feeds is NOT mislabeled a data connection.
  */
@@ -175,7 +176,7 @@ describe("channel streaming feeds", () => {
     expect(Number(after[0]?.n)).toBe(0);
   });
 
-  it("read_channel_feed returns the channel transcript", async () => {
+  it("read_feed returns a streaming feed's transcript (kind dispatch)", async () => {
     const conn = await makeChatConnection({ orgId, teamId: "TACME" });
     const feedId = await ensureStreamingChannelFeed({
       connectionId: conn.id,
@@ -209,10 +210,14 @@ describe("channel streaming feeds", () => {
     }
 
     const result = (await workspace.owner.feeds.manage({
-      action: "read_channel_feed",
+      action: "read_feed",
       feed_id: feedId,
-    })) as { messages: Array<{ user: string; text: string; isBot: boolean }> };
+    })) as {
+      kind: string;
+      messages: Array<{ user: string; text: string; isBot: boolean }>;
+    };
 
+    expect(result.kind).toBe("streaming");
     expect(result.messages.length).toBe(2);
     expect(result.messages[0]).toMatchObject({ user: "Alice", text: "hello team", isBot: false });
     expect(result.messages[1]).toMatchObject({ user: "assistant", text: "hi Alice", isBot: true });
@@ -238,7 +243,7 @@ describe("channel streaming feeds", () => {
     expect(res.error).toContain("only collected feeds");
   });
 
-  it("read_channel_feed rejects a non-streaming (collected) feed id", async () => {
+  it("read_feed on a collected feed returns runs, not a transcript", async () => {
     // A plain connection with the default kind='collected' feed.
     const conn = await createTestConnection({
       organization_id: orgId,
@@ -251,14 +256,23 @@ describe("channel streaming feeds", () => {
     `) as Array<{ id: number; kind: string }>;
     expect(feedRow[0]?.kind).toBe("collected");
 
-    // read_channel_feed only reads streaming channel feeds; a collected feed id
-    // must not resolve to a transcript.
+    // read_feed dispatches on kind: a collected feed resolves to its metadata +
+    // recent sync runs, NEVER a channel_messages transcript.
     const res = (await workspace.owner.feeds.manage({
-      action: "read_channel_feed",
+      action: "read_feed",
       feed_id: feedRow[0].id,
-    })) as { messages?: unknown[]; error?: string };
+    })) as {
+      kind?: string;
+      feed?: { id: number };
+      recent_runs?: unknown[];
+      messages?: unknown[];
+      error?: string;
+    };
+    expect(res.error).toBeUndefined();
+    expect(res.kind).toBe("collected");
     expect(res.messages).toBeUndefined();
-    expect(res.error).toBe("Feed not found");
+    expect(Array.isArray(res.recent_runs)).toBe(true);
+    expect(res.feed?.id).toBe(feedRow[0].id);
   });
 
   it("deleteAllBindings soft-deletes each unbound channel's streaming feed", async () => {
@@ -350,7 +364,7 @@ describe("channel streaming feeds", () => {
 
     // Owner (creator) CAN read it.
     const ownerRes = (await workspace.owner.feeds.manage({
-      action: "read_channel_feed",
+      action: "read_feed",
       feed_id: feedId,
     })) as { messages?: unknown[]; error?: string };
     expect(ownerRes.messages?.length).toBe(1);
@@ -358,7 +372,7 @@ describe("channel streaming feeds", () => {
     // Anonymous reader of the public org must NOT — the gate hides the private
     // connection's feed, so the transcript is never resolved.
     const anonRes = (await workspace.asAnonymous().feeds.manage({
-      action: "read_channel_feed",
+      action: "read_feed",
       feed_id: feedId,
     })) as { messages?: unknown[]; error?: string };
     expect(anonRes.messages).toBeUndefined();

--- a/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { buildSlackChannelGraph } from "../../../authz/slack-channel-graph";
 import { getDb } from "../../../db/client";
 import { ChannelBindingService } from "../../../gateway/channels/binding-service";
 import {
@@ -23,7 +24,9 @@ import {
   softDeleteStreamingChannelFeed,
 } from "../../../gateway/channels/channel-feed";
 import type { Env } from "../../../index";
+import { slugToRuntimeConnectionId } from "../../../lobu/stores/connections-projection";
 import { materializeDueFeeds } from "../../../scheduled/check-due-feeds";
+import { ensureMemberEntity } from "../../../utils/member-entity";
 import { getTestDb } from "../../setup/test-db";
 import { createTestAgent, createTestConnection } from "../../setup/test-fixtures";
 import { TestWorkspace } from "../../setup/test-mcp-client";
@@ -72,6 +75,17 @@ describe("channel streaming feeds", () => {
     await sql`DELETE FROM agent_channel_bindings WHERE organization_id = ${orgId}`;
     await sql`DELETE FROM feeds WHERE organization_id = ${orgId}`;
     await sql`DELETE FROM connections WHERE organization_id = ${orgId}`;
+    // ACL/graph state the membership-gate test materializes.
+    await sql`DELETE FROM authz_source_acl_state WHERE organization_id = ${orgId}`;
+    await sql`DELETE FROM entity_relationships WHERE organization_id = ${orgId}`;
+    await sql`DELETE FROM entity_identities WHERE organization_id = ${orgId}`;
+    await sql`
+      DELETE FROM entities
+      WHERE organization_id = ${orgId}
+        AND entity_type_id IN (
+          SELECT id FROM entity_types WHERE organization_id = ${orgId} AND slug IN ('channel', '$member')
+        )
+    `;
   });
 
   it("materializes a streaming feed with the scheduler guards + idempotency", async () => {
@@ -324,6 +338,83 @@ describe("channel streaming feeds", () => {
     // …but it does NOT make the connection claim the data facet.
     expect(result.connection.facets.data).toBe(false);
     expect(result.connection.facets.chat).toBe(true);
+  });
+
+  it("read_feed gates an ACL-enforced channel by membership, not just connection visibility", async () => {
+    // The owner can SEE any connection (no visibility filter), but must not read
+    // an enforced Slack channel's transcript unless they're a channel member.
+    const conn = await makeChatConnection({ orgId, teamId: "TENF" });
+    const feedId = await ensureStreamingChannelFeed({
+      connectionId: conn.id,
+      organizationId: orgId,
+      channelKey: "slack:CENF",
+    });
+    const runtimeConnId = slugToRuntimeConnectionId(conn.slug);
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO channel_messages (
+        organization_id, connection_id, platform, channel_id,
+        platform_message_id, author_name, is_bot, text, occurred_at
+      ) VALUES (
+        ${orgId}, ${runtimeConnId}, 'slack', 'CENF',
+        'me1', 'Insider', false, 'enforced channel secret', NOW()
+      )
+    `;
+
+    // Not enforced yet → owner reads it.
+    const before = (await workspace.owner.feeds.manage({
+      action: "read_feed",
+      feed_id: feedId,
+    })) as { messages?: unknown[] };
+    expect(before.messages?.length).toBe(1);
+
+    // Enforce the connection's ACL; owner is NOT a channel member.
+    const graph = await buildSlackChannelGraph({
+      organizationId: orgId,
+      connectionId: runtimeConnId,
+      teamId: "TENF",
+      channels: [{ channelId: "CENF", name: "secret", memberSlackUserIds: [] }],
+    });
+
+    const blocked = (await workspace.owner.feeds.manage({
+      action: "read_feed",
+      feed_id: feedId,
+    })) as { messages?: unknown[] };
+    expect(blocked.messages?.length).toBe(0); // membership gate fires
+
+    // Make the owner a channel member → they can read it again.
+    const channelEntityId = graph.channelEntityIds.CENF;
+    await ensureMemberEntity({
+      organizationId: orgId,
+      userId: workspace.users.owner.id,
+      name: "Owner",
+      email: `owner-${workspace.users.owner.id}@example.com`,
+    });
+    const [member] = await sql`
+      SELECT e.id FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id AND et.slug = '$member'
+      JOIN entity_identities ei ON ei.entity_id = e.id
+        AND ei.namespace = 'auth_user_id' AND ei.identifier = ${workspace.users.owner.id}
+        AND ei.source_connector = 'auth:signup'
+      WHERE e.organization_id = ${orgId} AND e.deleted_at IS NULL
+      LIMIT 1
+    `;
+    const [mot] = await sql`
+      SELECT id FROM entity_relationship_types
+      WHERE organization_id = ${orgId} AND slug = 'member_of' AND status = 'active'
+      LIMIT 1
+    `;
+    await sql`
+      INSERT INTO entity_relationships (
+        organization_id, from_entity_id, to_entity_id, relationship_type_id, created_at, updated_at
+      ) VALUES (${orgId}, ${member.id}, ${channelEntityId}, ${mot.id}, NOW(), NOW())
+    `;
+
+    const allowed = (await workspace.owner.feeds.manage({
+      action: "read_feed",
+      feed_id: feedId,
+    })) as { messages?: unknown[] };
+    expect(allowed.messages?.length).toBe(1);
   });
 
   it("does not leak a PRIVATE connection's transcript to an anonymous caller", async () => {

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -143,7 +143,7 @@ const PUBLIC_READ_ACTIONS: Record<string, Set<string> | null> = {
 		"get_channel_audience",
 	]),
 	manage_catalog: new Set(["list_catalog", "list_installed"]),
-	manage_feeds: new Set(["list_feeds", "get_feed", "read_channel_feed"]),
+	manage_feeds: new Set(["list_feeds", "read_feed"]),
 	manage_auth_profiles: new Set(["list_auth_profiles"]),
 	manage_operations: new Set(["list_available", "list_runs", "get_run"]),
 	manage_watchers: new Set([

--- a/packages/server/src/gateway/channels/binding-service.ts
+++ b/packages/server/src/gateway/channels/binding-service.ts
@@ -327,14 +327,26 @@ export class ChannelBindingService {
       ? await sql`
           DELETE FROM agent_channel_bindings
           WHERE agent_id = ${agentId} AND organization_id = ${orgId}
-          RETURNING platform, channel_id, team_id
+          RETURNING platform, channel_id, team_id, connection_id
         `
       : await sql`
           DELETE FROM agent_channel_bindings
           WHERE agent_id = ${agentId}
-          RETURNING platform, channel_id, team_id
+          RETURNING platform, channel_id, team_id, connection_id
         `;
     logger.info(`Deleted ${rows.length} bindings for agent ${agentId}`);
+    // Each unbound channel's streaming feed is now orphaned; retire it. Same
+    // best-effort contract as deleteBinding — the binding is already gone, a
+    // lingering feed row never blocks the delete. Keyed by the connection the
+    // binding routed through + the channel id (= feed_key).
+    for (const row of rows) {
+      if (row.connection_id != null) {
+        await softDeleteStreamingChannelFeed({
+          connectionId: String(row.connection_id),
+          channelKey: row.channel_id,
+        });
+      }
+    }
     return rows.length;
   }
 }

--- a/packages/server/src/gateway/channels/channel-feed.ts
+++ b/packages/server/src/gateway/channels/channel-feed.ts
@@ -47,7 +47,7 @@ async function findStreamingFeedId(
  * Idempotently ensure the streaming feed for a bound channel, returning its id.
  * `channelKey` is the channel id exactly as stored on the binding (may be
  * platform-prefixed, e.g. `slack:C…`) — the feed_key mirrors it so the read path
- * (`read_channel_feed`) maps back to the same `channel_messages` rows.
+ * (`read_feed`) maps back to the same `channel_messages` rows.
  */
 export async function ensureStreamingChannelFeed(opts: {
   connectionId: string | number;

--- a/packages/server/src/sandbox/namespaces/feeds.ts
+++ b/packages/server/src/sandbox/namespaces/feeds.ts
@@ -45,7 +45,7 @@ export function buildFeedsNamespace(
 	return {
 		manage,
 		list: (input) => action("list_feeds", input),
-		get: (feed_id) => action("get_feed", { feed_id }),
+		get: (feed_id) => action("read_feed", { feed_id }),
 		create: (input) => action("create_feed", input),
 		update: (input) => action("update_feed", input),
 		delete: (feed_id) => action("delete_feed", { feed_id }),

--- a/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
@@ -257,7 +257,7 @@ interface ConnectionChannelRow {
  * the binding's agent. Mirrors branch (A) of resolveBoundChannelRows — a binding
  * matches its connection by the unified connection_id link, falling back to the
  * legacy (org, agent, platform) tuple — but scoped to a single connection and
- * with the agent joined. Visibility-gated (mirrors read_channel_feed): anonymous
+ * with the agent joined. Visibility-gated (mirrors read_feed): anonymous
  * sees org-visible connections only; a non-admin member sees org + own; owners /
  * admins see all.
  */

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -17,6 +17,7 @@
 import { getErrorMessage, parseJsonObject } from '@lobu/core';
 import { type Static, Type } from '@sinclair/typebox';
 import { getDb, pgBigintArray } from '../../db/client';
+import { filterChannelsForRequester } from '../../authz/channel-visibility';
 import { readChannelTranscript } from '../../gateway/connections/channel-transcript';
 import type { Env } from '../../index';
 import { getAuthProfileById } from '../../utils/auth-profiles';
@@ -279,6 +280,7 @@ async function handleReadFeed(
     SELECT f.*,
            c.slug,
            c.connector_key,
+           c.external_tenant_id,
            c.display_name AS connection_name,
            (
              SELECT string_agg(DISTINCT ent.name, ', ' ORDER BY ent.name)
@@ -308,6 +310,26 @@ async function handleReadFeed(
     const channelId = feedKey.includes(':')
       ? feedKey.slice(feedKey.indexOf(':') + 1)
       : feedKey;
+    // The connection-visibility gate above only decides who can see the
+    // CONNECTION. For an ACL-enforced Slack channel the transcript is further
+    // gated to channel members — a user who can see the connection but isn't in
+    // the channel must NOT read its messages. Non-enforced channels pass through
+    // (same posture as search_memory). Fail-closed: a dropped row → no transcript.
+    const visible = await filterChannelsForRequester(sql, {
+      organizationId,
+      userId: userId ?? null,
+      rows: [
+        {
+          id: connectionId,
+          platform: String(feed.connector_key ?? 'slack'),
+          channel_id: channelId,
+          team_id: (feed.external_tenant_id as string | null) ?? null,
+        },
+      ],
+    });
+    if (visible.length === 0) {
+      return { action: 'read_feed', kind: 'streaming', feed, messages: [] };
+    }
     const messages = await readChannelTranscript(
       organizationId,
       connectionId,

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -5,7 +5,9 @@
  *
  * Actions:
  * - list_feeds: List feeds with optional filters
- * - get_feed: Get a specific feed by ID
+ * - read_feed: Read one feed by id, dispatching on kind — a collected/virtual
+ *   feed returns its metadata + recent sync runs; a streaming (chat-channel)
+ *   feed returns its live transcript from channel_messages.
  * - create_feed: Create a new feed for a connection
  * - update_feed: Update feed settings
  * - delete_feed: Delete a feed
@@ -47,9 +49,17 @@ const ListFeedsAction = Type.Object({
   ...PaginationFields,
 });
 
-const GetFeedAction = Type.Object({
-  action: Type.Literal('get_feed'),
+// One read action for any feed kind. A collected/virtual feed returns its
+// metadata + recent sync runs; a streaming (chat-channel) feed has no sync runs
+// — its content is the live transcript in `channel_messages` — so it returns
+// that instead, read through the same primitive read_conversation uses. The
+// caller never has to know the kind up front; the response carries it.
+const ReadFeedAction = Type.Object({
+  action: Type.Literal('read_feed'),
   feed_id: Type.Number({ description: 'Feed ID' }),
+  limit: Type.Optional(
+    Type.Number({ description: 'Max transcript messages for a streaming feed (default 50)' })
+  ),
 });
 
 const CreateFeedAction = Type.Object({
@@ -100,16 +110,6 @@ const TriggerFeedAction = Type.Object({
   feed_id: Type.Number({ description: 'Feed ID to trigger sync for' }),
 });
 
-// A streaming (chat-channel) feed has no sync runs — its content is the live
-// transcript in `channel_messages`, not embedded `events`. This reads that
-// transcript through the same primitive read_conversation uses, so the feed
-// detail can render the conversation instead of a runs table.
-const ReadChannelFeedAction = Type.Object({
-  action: Type.Literal('read_channel_feed'),
-  feed_id: Type.Number({ description: 'Streaming chat-channel feed ID' }),
-  limit: Type.Optional(Type.Number({ description: 'Max messages (default 50)' })),
-});
-
 // ============================================
 // Result Types
 // ============================================
@@ -117,21 +117,23 @@ const ReadChannelFeedAction = Type.Object({
 type ManageFeedsResult =
   | { error: string }
   | { action: 'list_feeds'; feeds: any[]; total: number; limit: number; offset: number }
-  | { action: 'get_feed'; feed: any; recent_runs: any[] }
-  | { action: 'create_feed'; feed: any }
-  | { action: 'update_feed'; feed: any }
-  | { action: 'delete_feed'; deleted: true; feed_id: number }
-  | { action: 'trigger_feed'; triggered: true; run_id: number; feed_id: number }
-  | { action: 'trigger_feed'; message: string }
+  | { action: 'read_feed'; kind: string; feed: any; recent_runs: any[] }
   | {
-      action: 'read_channel_feed';
+      action: 'read_feed';
+      kind: 'streaming';
+      feed: any;
       messages: Array<{
         timestamp: string;
         user: string;
         text: string;
         isBot: boolean;
       }>;
-    };
+    }
+  | { action: 'create_feed'; feed: any }
+  | { action: 'update_feed'; feed: any }
+  | { action: 'delete_feed'; deleted: true; feed_id: number }
+  | { action: 'trigger_feed'; triggered: true; run_id: number; feed_id: number }
+  | { action: 'trigger_feed'; message: string };
 
 // ============================================
 // Main Function (Action Router)
@@ -139,12 +141,11 @@ type ManageFeedsResult =
 
 const manageFeedsTool = defineActionTool('manage_feeds', {
   list_feeds: action(ListFeedsAction, handleListFeeds),
-  get_feed: action(GetFeedAction, handleGetFeed),
+  read_feed: action(ReadFeedAction, handleReadFeed),
   create_feed: action(CreateFeedAction, handleCreateFeed),
   update_feed: action(UpdateFeedAction, handleUpdateFeed),
   delete_feed: action(DeleteFeedAction, handleDeleteFeed),
   trigger_feed: action(TriggerFeedAction, handleTriggerFeed),
-  read_channel_feed: action(ReadChannelFeedAction, handleReadChannelFeed),
 });
 
 export const ManageFeedsSchema = manageFeedsTool.schema;
@@ -253,16 +254,16 @@ async function handleListFeeds(
   return { action: 'list_feeds', feeds: rows, total: rows.length, limit, offset };
 }
 
-async function handleReadChannelFeed(
-  args: Static<typeof ReadChannelFeedAction>,
+async function handleReadFeed(
+  args: Static<typeof ReadFeedAction>,
   ctx: ToolContext
 ): Promise<ManageFeedsResult> {
   const sql = getDb();
   const { organizationId, userId } = ctx;
   // Connection-visibility gate (mirrors manage_connections crud handleList/Get):
-  // read_channel_feed is in PUBLIC_READ_ACTIONS, so a transcript is content an
-  // anonymous caller could otherwise pull by guessing a feed_id. Anonymous sees
-  // org-visible connections only; a non-admin member sees org + their own
+  // read_feed is in PUBLIC_READ_ACTIONS, so a feed's config/transcript is content
+  // an anonymous caller could otherwise pull by guessing a feed_id. Anonymous
+  // sees org-visible connections only; a non-admin member sees org + their own
   // private connections; owners/admins see all.
   let visibilityFilter = sql``;
   if (!userId) {
@@ -273,45 +274,10 @@ async function handleReadChannelFeed(
       visibilityFilter = sql`AND (c.visibility = 'org' OR c.created_by = ${userId})`;
     }
   }
-  // Resolve the feed's connection slug + channel key, then map to the runtime
-  // ids channel_messages is keyed by: the BYO namespace is stripped off the
-  // slug (mirror of resolveBoundChannelRows), and the platform prefix
-  // (`slack:`) is stripped off feed_key to the bare channel id capture stores.
+
   const rows = (await sql`
-    SELECT f.feed_key, c.slug
-    FROM feeds f
-    JOIN connections c ON c.id = f.connection_id
-    WHERE f.id = ${args.feed_id}
-      AND f.organization_id = ${organizationId}
-      AND f.kind = 'streaming'
-      AND f.deleted_at IS NULL
-      AND c.deleted_at IS NULL
-      ${visibilityFilter}
-  `) as Array<{ feed_key: string; slug: string }>;
-  if (rows.length === 0) return { error: 'Feed not found' };
-  const { feed_key, slug } = rows[0];
-  const connectionId = slug.startsWith('agentconn-') ? slug.slice(10) : slug;
-  const channelId = feed_key.includes(':')
-    ? feed_key.slice(feed_key.indexOf(':') + 1)
-    : feed_key;
-  const messages = await readChannelTranscript(
-    organizationId,
-    connectionId,
-    channelId,
-    args.limit ?? 50
-  );
-  return { action: 'read_channel_feed', messages };
-}
-
-async function handleGetFeed(
-  args: Static<typeof GetFeedAction>,
-  ctx: ToolContext
-): Promise<ManageFeedsResult> {
-  const sql = getDb();
-  const { organizationId } = ctx;
-
-  const rows = await sql`
     SELECT f.*,
+           c.slug,
            c.connector_key,
            c.display_name AS connection_name,
            (
@@ -321,11 +287,34 @@ async function handleGetFeed(
            ) AS entity_names
     FROM feeds f
     JOIN connections c ON c.id = f.connection_id
-    WHERE f.id = ${args.feed_id} AND f.organization_id = ${organizationId} AND c.deleted_at IS NULL AND f.deleted_at IS NULL
-  `;
+    WHERE f.id = ${args.feed_id}
+      AND f.organization_id = ${organizationId}
+      AND c.deleted_at IS NULL
+      AND f.deleted_at IS NULL
+      ${visibilityFilter}
+  `) as Array<Record<string, any>>;
+  if (rows.length === 0) return { error: 'Feed not found' };
+  const feed = rows[0];
 
-  if (rows.length === 0) {
-    return { error: 'Feed not found' };
+  // A streaming (chat-channel) feed has no sync runs — its content is the live
+  // transcript in `channel_messages`. Map the connection slug + feed_key to the
+  // runtime ids channel_messages is keyed by: the BYO namespace is stripped off
+  // the slug (mirror of resolveBoundChannelRows), and the platform prefix
+  // (`slack:`) is stripped off feed_key to the bare channel id capture stores.
+  if (feed.kind === 'streaming') {
+    const slug = String(feed.slug);
+    const feedKey = String(feed.feed_key);
+    const connectionId = slug.startsWith('agentconn-') ? slug.slice(10) : slug;
+    const channelId = feedKey.includes(':')
+      ? feedKey.slice(feedKey.indexOf(':') + 1)
+      : feedKey;
+    const messages = await readChannelTranscript(
+      organizationId,
+      connectionId,
+      channelId,
+      args.limit ?? 50
+    );
+    return { action: 'read_feed', kind: 'streaming', feed, messages };
   }
 
   const runs = await sql`
@@ -336,7 +325,7 @@ async function handleGetFeed(
     LIMIT 10
   `;
 
-  return { action: 'get_feed', feed: rows[0], recent_runs: runs };
+  return { action: 'read_feed', kind: String(feed.kind), feed, recent_runs: runs };
 }
 
 async function handleCreateFeed(

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -283,6 +283,7 @@ async function handleReadChannelFeed(
     JOIN connections c ON c.id = f.connection_id
     WHERE f.id = ${args.feed_id}
       AND f.organization_id = ${organizationId}
+      AND f.kind = 'streaming'
       AND f.deleted_at IS NULL
       AND c.deleted_at IS NULL
       ${visibilityFilter}
@@ -581,7 +582,7 @@ async function handleTriggerFeed(
   const { organizationId } = ctx;
 
   const feedRows = await sql`
-    SELECT f.id, f.status, f.connection_id, c.connector_key
+    SELECT f.id, f.status, f.kind, f.connection_id, c.connector_key
     FROM feeds f
     JOIN connections c ON c.id = f.connection_id
     WHERE f.id = ${args.feed_id} AND f.organization_id = ${organizationId} AND c.deleted_at IS NULL AND f.deleted_at IS NULL
@@ -592,6 +593,12 @@ async function handleTriggerFeed(
   }
 
   const feed = feedRows[0] as any;
+  // Only collected feeds run a connector sync. Streaming feeds (chat channels)
+  // are fed by inbound webhooks/capture, not a sync run — triggering one would
+  // spawn a run against a connector that has no fetch for this feed.
+  if (feed.kind !== 'collected') {
+    return { error: `Feed is ${feed.kind}, only collected feeds can be triggered` };
+  }
   if (feed.status !== 'active') {
     return { error: `Feed is ${feed.status}, must be active to trigger sync` };
   }


### PR DESCRIPTION
Pre-existing channel-feed lifecycle bugs (surfaced as pi blockers #2–4 on #1655, but living in the channels-as-feeds code, not introduced by that PR), plus the `read_feed` consolidation that is the proper fix for the read bug.

## Lifecycle fixes

**1. `trigger_feed` synced streaming feeds** — `handleTriggerFeed` called `createSyncRun` for any active feed. A streaming feed (a chat channel, fed by inbound webhooks/capture) has no connector fetch for its `feed_key`. Fix: reject unless `kind = 'collected'` before creating the run.

**2. `deleteAllBindings` orphaned live streaming feeds** — the single `deleteBinding` path already soft-deletes the channel's streaming feed on unbind; the bulk path used by agent deletion left the feeds live. Fix: `RETURNING connection_id`, then `softDeleteStreamingChannelFeed` per deleted binding.

## read_feed consolidation (fixes read bug #3 properly)

The original blocker was that `read_channel_feed` accepted any visible feed id and read `channel_messages` for it, so a collected feed id resolved to a spurious transcript. Rather than bolt a `kind='streaming'` guard onto one of two overlapping actions, **collapse `get_feed` + `read_channel_feed` into one `read_feed`** that dispatches on kind:

- collected/virtual → `{ kind, feed, recent_runs }`
- streaming → `{ kind: 'streaming', feed, messages }`

This also **closes a security gap**: `get_feed` was in the public-read allowlist but had no visibility gate, so a private connection's feed config was pullable by guessing a feed id. `read_feed` applies the connection-visibility gate uniformly (anonymous → org-visible only; non-admin member → org + own private; owner/admin → all).

Touches: `manage_feeds` handler/schema/router, `tool-access` allowlist, SDK sandbox `feeds.get`, and owletto's two feed-detail hooks (companion PR — pointer bumped to `722d2f9`).

## Tests (red→green)

`channel-streaming-feeds.test.ts` — 9 passing (6 pre-existing + 3 new/updated). Verified red on `main` for the two lifecycle fixes:

```
× trigger_feed rejects a streaming feed (only collected feeds sync)
× deleteAllBindings soft-deletes each unbound channel's streaming feed → expected 2 to be +0
```

read_feed cases assert dispatch: streaming → `{kind:'streaming', messages}`, collected → `{kind:'collected', recent_runs}` (never a transcript), and the private-feed transcript stays hidden from an anonymous caller (`Feed not found`).

`tsc --noEmit` clean (server + owletto); biome clean.

Companion owletto PR: lobu-ai/owletto#407 (must merge first, then this repoints).