### PR TITLE
feat(watchers): per-item recap feedback loop on the entity field-ownership plane

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -499,6 +499,155 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     expect(resolved.approval_status).toBe('approved');
   });
 
+  it('list_promoted returns the watcher promoted entities with field ownership + provenance', async () => {
+    const ctx = await setupKeyedWatcher();
+    const { sql, workspace, watcherId } = ctx;
+
+    await createTestEvent({
+      entity_id: ctx.parentEntityId,
+      organization_id: workspace.org.id,
+      content: 'Users report the app crashing and loading slowly.',
+      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    const runId = await queueRunningRun(ctx);
+    const token = await readWindowToken(ctx);
+    const windowId = await ctx.api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: token,
+      run_metadata: { watcher_run_id: runId },
+      extracted_data: {
+        problems: [
+          { category: 'Stability', name: 'App Crashes', severity: 'low' },
+          { category: 'Performance', name: 'Slow Loading', severity: 'low' },
+        ],
+      },
+    });
+
+    // A human owns `severity` on one of the two promoted entities.
+    const appCrashesId = `${watcherId}::stability::app-crashes`;
+    const [created] = await sql`
+      SELECT e.id FROM entities e JOIN entity_identities ei ON ei.entity_id = e.id
+      WHERE ei.namespace = 'watcher_key' AND ei.identifier = ${appCrashesId}
+    `;
+    const entityId = Number(created.id);
+    await workspace.owner.entities.update({
+      entity_id: entityId,
+      metadata: { severity: 'high' },
+      field_note: 'confirmed critical with eng',
+    });
+
+    const res = (await workspace.owner.watchers.manage({
+      action: 'list_promoted',
+      watcher_id: String(watcherId),
+    })) as {
+      action: string;
+      entities: Array<{
+        id: number;
+        name: string;
+        entity_type: string;
+        metadata: Record<string, unknown>;
+        field_controls: Record<string, { set_by?: string; note?: string }>;
+        window_id: number | null;
+        stable_key: string | null;
+      }>;
+    };
+
+    expect(res.action).toBe('list_promoted');
+    expect(res.entities.length).toBe(2);
+    const appCrashes = res.entities.find((e) => e.stable_key === 'stability::app-crashes');
+    const slowLoading = res.entities.find((e) => e.stable_key === 'performance::slow-loading');
+    expect(appCrashes).toBeDefined();
+    expect(slowLoading).toBeDefined();
+
+    // The owned entity carries its human ownership marker + the corrected value…
+    expect(appCrashes?.id).toBe(entityId);
+    expect(appCrashes?.entity_type).toBe('topic');
+    expect(appCrashes?.metadata.severity).toBe('high');
+    expect(appCrashes?.field_controls.severity?.set_by).toBe(workspace.users.owner.id);
+    expect(appCrashes?.window_id).toBe((windowId as { window_id: number }).window_id);
+    // …while the untouched entity has no owned fields.
+    expect(slowLoading?.field_controls).toEqual({});
+  });
+
+  it('approve (affirm_fields) locks a value as-is so a later watcher change is blocked', async () => {
+    const ctx = await setupKeyedWatcher();
+    const { sql, workspace, watcherId } = ctx;
+
+    await createTestEvent({
+      entity_id: ctx.parentEntityId,
+      organization_id: workspace.org.id,
+      content: 'Users report the app crashing and loading slowly.',
+      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    const runId = await queueRunningRun(ctx);
+    const token = await readWindowToken(ctx);
+
+    // Run 1 seeds `severity: 'low'` (watcher-owned, no field_controls yet).
+    await ctx.api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: token,
+      run_metadata: { watcher_run_id: runId },
+      extracted_data: {
+        problems: [
+          { category: 'Stability', name: 'App Crashes', severity: 'low' },
+          { category: 'Performance', name: 'Slow Loading', severity: 'low' },
+        ],
+      },
+    });
+    const appCrashesId = `${watcherId}::stability::app-crashes`;
+    const [created] = await sql`
+      SELECT e.id FROM entities e JOIN entity_identities ei ON ei.entity_id = e.id
+      WHERE ei.namespace = 'watcher_key' AND ei.identifier = ${appCrashesId}
+    `;
+    const entityId = Number(created.id);
+
+    // The human APPROVES the current value as-is (no value change) — the recap's
+    // "approve" affordance. This must claim ownership (not the pre-fix no-op).
+    await workspace.owner.entities.update({
+      entity_id: entityId,
+      affirm_fields: ['severity'],
+      field_note: 'looks right',
+    });
+    const [afterApprove] = await sql`
+      SELECT metadata, field_controls FROM entities WHERE id = ${entityId}
+    `;
+    expect((afterApprove.metadata as Record<string, unknown>).severity).toBe('low'); // unchanged
+    const sevControl = (
+      afterApprove.field_controls as Record<string, { set_by?: string; note?: string }>
+    ).severity;
+    expect(sevControl?.set_by).toBe(workspace.users.owner.id); // now human-owned
+    expect(sevControl?.note).toBe('looks right');
+
+    // Run 2 proposes a different severity for the SAME key. Because the human
+    // affirmed the field, the watcher must be BLOCKED and queue an approval —
+    // proving the affirm actually locked the value.
+    await ctx.api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: token,
+      run_metadata: { watcher_run_id: runId },
+      extracted_data: {
+        problems: [
+          { category: 'Stability', name: 'App Crashes', severity: 'critical' },
+          { category: 'Performance', name: 'Slow Loading', severity: 'low' },
+        ],
+      },
+    });
+
+    const [afterRerun] = await sql`SELECT metadata FROM entities WHERE id = ${entityId}`;
+    expect((afterRerun.metadata as Record<string, unknown>).severity).toBe('low'); // affirm held
+
+    const pending = await sql`
+      SELECT action_input FROM runs
+      WHERE organization_id = ${workspace.org.id}
+        AND action_key = 'entity_field_change'
+        AND approval_status = 'pending'
+    `;
+    expect(pending.length).toBe(1);
+    const proposal = pending[0].action_input as { entity_id: number; fields: Record<string, unknown> };
+    expect(proposal.entity_id).toBe(entityId);
+    expect(proposal.fields.severity).toBe('critical');
+  });
+
   it('disambiguates a slug that collides with a pre-existing sibling — window is NOT poison-pilled', async () => {
     const ctx = await setupKeyedWatcher();
     const { sql, workspace, parentEntityId } = ctx;

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -137,6 +137,14 @@ export const ManageEntitySchema = Type.Object({
     })
   ),
 
+  // Approve/affirm: claim ownership of a field's current value without changing it
+  affirm_fields: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        "[update] Metadata field names whose CURRENT value the human approves as-is. No value change, but each is marked human-owned so a watcher can't later overwrite it without an approval. The 'approve' half of the recap feedback loop.",
+    })
+  ),
+
   // List/pagination
   search: Type.Optional(Type.String({ description: '[list] Search by name' })),
   limit: Type.Optional(
@@ -597,6 +605,9 @@ async function handleUpdate(
   // Human-correction note: annotates the field_controls marker for the fields
   // this edit claims (why the human set/overrode the value).
   if (args.field_note !== undefined) updateData.field_note = args.field_note;
+
+  // Approve/affirm: claim ownership of these fields' current values as-is.
+  if (args.affirm_fields !== undefined) updateData.affirm_fields = args.affirm_fields;
 
   const updatedEntity = await updateEntity(entityId, updateData, env, ctx);
   const entityDetails = (await getEntity(updatedEntity.id, env, ctx)) ?? updatedEntity;

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -40,7 +40,11 @@ import { handleCreate, handleUpdate, handleDelete, handleCreateFromVersion } fro
 import { handleCreateVersion, handleGetVersions, handleGetVersionDetails } from './manage_watchers/version-actions';
 import { handleCompleteWindow } from './manage_watchers/complete-window';
 import { handleTrigger, handleSetReactionScript } from './manage_watchers/trigger';
-import { handleSubmitFeedback, handleGetFeedback } from './manage_watchers/feedback';
+import {
+  handleSubmitFeedback,
+  handleGetFeedback,
+  handleListPromoted,
+} from './manage_watchers/feedback';
 import { handleGetComponentReference } from './manage_watchers/reference';
 import { handleList, type ListWatchersArgs, type ListWatchersResult } from './manage_watchers/list';
 
@@ -73,6 +77,7 @@ export const ManageWatchersSchema = Type.Object({
       Type.Literal('get_component_reference'),
       Type.Literal('submit_feedback'),
       Type.Literal('get_feedback'),
+      Type.Literal('list_promoted'),
       Type.Literal('create_from_version'),
     ],
     { description: 'Action to perform' }
@@ -410,6 +415,19 @@ export type ManageWatchersResult =
       }>;
     }
   | {
+      action: 'list_promoted';
+      watcher_id: string;
+      entities: Array<{
+        id: number;
+        name: string;
+        entity_type: string;
+        metadata: Record<string, unknown>;
+        field_controls: Record<string, unknown>;
+        window_id: number | null;
+        stable_key: string | null;
+      }>;
+    }
+  | {
       action: 'create_from_version';
       created: Array<{ watcher_id: string; entity_id: number; name: string }>;
     };
@@ -502,6 +520,8 @@ async function manageWatchersImpl(
     await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'write');
   } else if (args.action === 'get_feedback' && args.watcher_id) {
     await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'read');
+  } else if (args.action === 'list_promoted' && args.watcher_id) {
+    await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'read');
   } else if (args.action === 'get_versions' && args.watcher_id) {
     await requireWatcherAccess(pgSql, [args.watcher_id], ctx, 'read');
   } else if (args.action === 'get_version_details' && args.watcher_id) {
@@ -530,6 +550,7 @@ const runManageWatchers = defineFlatActionTool<ManageWatchersArgs, ManageWatcher
     get_component_reference: flatAction(() => Promise.resolve(handleGetComponentReference())),
     submit_feedback: flatAction(handleSubmitFeedback),
     get_feedback: flatAction(handleGetFeedback),
+    list_promoted: flatAction(handleListPromoted),
     create_from_version: flatAction((args, ctx, env) => handleCreateFromVersion(args, env, ctx)),
   }
 );

--- a/packages/server/src/tools/admin/manage_watchers/feedback.ts
+++ b/packages/server/src/tools/admin/manage_watchers/feedback.ts
@@ -1,9 +1,10 @@
 /**
  * Feedback action handlers for manage_watchers:
- *   submit_feedback, get_feedback
+ *   submit_feedback, get_feedback, list_promoted
  */
 
 import { getDb } from '../../../db/client';
+import { parseJsonObject } from '@lobu/core';
 import type { ToolContext } from '../../registry';
 import type { ManageWatchersArgs, ManageWatchersResult } from '../manage_watchers';
 
@@ -173,5 +174,64 @@ export async function handleGetFeedback(
       window_start: row.window_start ? (row.window_start as Date).toISOString() : undefined,
       window_end: row.window_end ? (row.window_end as Date).toISOString() : undefined,
     })),
+  };
+}
+
+// ============================================
+// handleListPromoted
+// ============================================
+
+/**
+ * List the entities a watcher promoted (its keyed children). These are the
+ * durable, per-item correctable units of the recap: each row carries the
+ * entity's metadata (the extracted field values) plus `field_controls` (which
+ * fields a human already owns), so the recap can render approve/correct
+ * affordances keyed on (entity_id, field). Promoted children stamp
+ * `metadata.watcher_id` / `source='watcher_promotion'` at promotion time.
+ *
+ * Org-scoped so a member of org A can't enumerate org B's promoted entities by
+ * passing a watcher_id (auth also gates on requireWatcherAccess 'read').
+ */
+export async function handleListPromoted(
+  args: ManageWatchersArgs,
+  ctx: ToolContext
+): Promise<ManageWatchersResult> {
+  if (!args.watcher_id) throw new Error('watcher_id is required');
+
+  const sql = getDb();
+  const watcherId = String(Number(args.watcher_id));
+  const limit = args.limit ?? 200;
+
+  const rows = await sql`
+    SELECT e.id, e.name, et.slug AS entity_type, e.metadata, e.field_controls
+    FROM entities e
+    JOIN entity_types et ON et.id = e.entity_type_id
+    WHERE e.organization_id = ${ctx.organizationId}
+      AND e.deleted_at IS NULL
+      AND e.metadata->>'source' = 'watcher_promotion'
+      AND e.metadata->>'watcher_id' = ${watcherId}
+    ORDER BY e.name
+    LIMIT ${limit}
+  `;
+
+  return {
+    action: 'list_promoted',
+    watcher_id: args.watcher_id,
+    entities: rows.map((row) => {
+      const metadata = parseJsonObject(row.metadata);
+      const fieldControls = parseJsonObject(row.field_controls);
+      const windowIdRaw = metadata.window_id;
+      const stableKeyRaw = metadata.stable_key;
+      return {
+        id: Number(row.id),
+        name: row.name as string,
+        entity_type: row.entity_type as string,
+        metadata,
+        field_controls: fieldControls,
+        window_id:
+          windowIdRaw == null || windowIdRaw === '' ? null : Number(windowIdRaw),
+        stable_key: stableKeyRaw == null ? null : String(stableKeyRaw),
+      };
+    }),
   };
 }

--- a/packages/server/src/utils/__tests__/entity-field-merge.test.ts
+++ b/packages/server/src/utils/__tests__/entity-field-merge.test.ts
@@ -132,4 +132,75 @@ describe('computeFieldMerge', () => {
     expect(r.stale).toEqual({});
     expect(r.nextMetadata.status).toBe('critical');
   });
+
+  it('approve: affirming an unchanged value claims ownership (NOT a no-op)', () => {
+    const r = computeFieldMerge({
+      metadata: { severity: 'high', title: 'Outage' },
+      controls: {},
+      fields: {}, // no value change
+      source: 'human',
+      actorId: 'usr_1',
+      note: 'confirmed by on-call',
+      nowIso: NOW,
+      affirm: ['severity'],
+    });
+    expect(r.changed).toBe(true); // ownership changed even though metadata didn't
+    expect(r.applied).toEqual({});
+    expect(r.affirmed).toEqual(['severity']);
+    expect(r.nextMetadata).toEqual({ severity: 'high', title: 'Outage' }); // value untouched
+    expect(r.nextControls.severity).toEqual({
+      note: 'confirmed by on-call',
+      set_by: 'usr_1',
+      set_at: NOW,
+    });
+    expect(r.nextControls.title).toBeUndefined(); // only the affirmed field is claimed
+  });
+
+  it('approve: a field being SET is not double-counted as affirmed', () => {
+    const r = computeFieldMerge({
+      metadata: { severity: 'low' },
+      controls: {},
+      fields: { severity: 'high' }, // correction
+      source: 'human',
+      actorId: 'usr_1',
+      note: null,
+      nowIso: NOW,
+      affirm: ['severity'], // also listed to affirm — the set already claims it
+    });
+    expect(r.applied).toEqual({ severity: { old: 'low', new: 'high' } });
+    expect(r.affirmed).toEqual([]); // the set won; no separate affirm
+    expect(r.nextControls.severity).toEqual({ note: null, set_by: 'usr_1', set_at: NOW });
+  });
+
+  it('approve: affirming a field absent from metadata is ignored', () => {
+    const r = computeFieldMerge({
+      metadata: { severity: 'high' },
+      controls: {},
+      fields: {},
+      source: 'human',
+      actorId: 'usr_1',
+      note: null,
+      nowIso: NOW,
+      affirm: ['nonexistent'],
+    });
+    expect(r.changed).toBe(false);
+    expect(r.affirmed).toEqual([]);
+    expect(r.nextControls).toEqual({});
+  });
+
+  it('approve: a watcher cannot affirm (only humans claim ownership)', () => {
+    const r = computeFieldMerge({
+      metadata: { severity: 'high' },
+      controls: {},
+      fields: {},
+      source: 'watcher',
+      actorId: null,
+      note: null,
+      nowIso: NOW,
+      affirm: ['severity'],
+    });
+    expect(r.changed).toBe(false);
+    expect(r.affirmed).toEqual([]);
+    expect(r.nextControls).toEqual({});
+  });
 });

--- a/packages/server/src/utils/entity-field-merge.ts
+++ b/packages/server/src/utils/entity-field-merge.ts
@@ -48,6 +48,9 @@ export interface FieldMergeResult {
   /** Fields skipped because the live value drifted from the proposal's snapshot
    *  (a human re-edited the field after the proposal was queued). NOT written. */
   stale: Record<string, StaleChange>;
+  /** Fields whose CURRENT value a human affirmed — value unchanged, but ownership
+   *  is now claimed so a watcher can't silently overwrite it. */
+  affirmed: string[];
   nextMetadata: Record<string, unknown>;
   nextControls: Record<string, FieldControl>;
   changed: boolean;
@@ -86,13 +89,21 @@ export function computeFieldMerge(args: {
    *  A drifted field is skipped (`stale`) so a stale approval can't clobber a value
    *  the human moved after the proposal was queued. */
   expectedCurrent?: Record<string, unknown> | null;
+  /** Fields (source='human' only) whose CURRENT value the human approves as-is:
+   *  no value change, but ownership is claimed so a watcher can't later overwrite
+   *  it without an approval. This is the "approve" half of the per-item recap
+   *  feedback loop — affirming a value is NOT a no-op the way re-setting an
+   *  unchanged value is. */
+  affirm?: string[];
 }): FieldMergeResult {
-  const { metadata, controls, fields, source, actorId, note, nowIso, expectedCurrent } = args;
+  const { metadata, controls, fields, source, actorId, note, nowIso, expectedCurrent, affirm } =
+    args;
   const nextMetadata: Record<string, unknown> = { ...metadata };
   const nextControls: Record<string, FieldControl> = { ...controls };
   const applied: Record<string, AppliedChange> = {};
   const blocked: Record<string, BlockedChange> = {};
   const stale: Record<string, StaleChange> = {};
+  const affirmed: string[] = [];
 
   for (const [field, value] of Object.entries(fields)) {
     const current = metadata[field];
@@ -125,13 +136,27 @@ export function computeFieldMerge(args: {
     }
   }
 
+  // Approve/affirm: claim ownership of a field's current value without changing
+  // it. Only humans can affirm; a field already written above is skipped (the
+  // set already claimed it). Marking an owned-but-unchanged field is idempotent
+  // (it refreshes set_by/set_at/note), so re-approving is safe.
+  if (source === 'human' && affirm) {
+    for (const field of affirm) {
+      if (Object.hasOwn(applied, field)) continue;
+      if (!Object.hasOwn(metadata, field)) continue;
+      nextControls[field] = { note, set_by: actorId, set_at: nowIso };
+      affirmed.push(field);
+    }
+  }
+
   return {
     applied,
     blocked,
     stale,
+    affirmed,
     nextMetadata,
     nextControls,
-    changed: Object.keys(applied).length > 0,
+    changed: Object.keys(applied).length > 0 || affirmed.length > 0,
   };
 }
 
@@ -150,6 +175,9 @@ export async function mergeEntityFields(params: {
   note?: string | null;
   /** Snapshot the proposal was built on (deferred-apply staleness guard). */
   expectedCurrent?: Record<string, unknown> | null;
+  /** Fields (human source) whose current value is approved as-is, claiming
+   *  ownership without a value change. */
+  affirm?: string[];
 }): Promise<FieldMergeResult> {
   const { tx, entityId, fields, source, actorId } = params;
 
@@ -174,6 +202,7 @@ export async function mergeEntityFields(params: {
     note: params.note ?? null,
     nowIso: new Date().toISOString(),
     expectedCurrent: params.expectedCurrent ?? null,
+    affirm: params.affirm,
   });
 
   if (merge.changed) {

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -105,6 +105,12 @@ export interface EntityData {
   // the UI) can show WHY the value was set. Ignored for agent/system writes.
   field_note?: string | null;
 
+  // Approve/affirm: field names whose CURRENT value the human endorses as-is.
+  // No value change, but ownership is claimed so a watcher can't later overwrite
+  // them without an approval. This is the "approve" half of the recap feedback
+  // loop; "correct" is a normal metadata update. Ignored for agent/system writes.
+  affirm_fields?: string[] | null;
+
   // Convenience fields - will be merged into metadata
   domain?: string | null;
   category?: string | null;
@@ -370,6 +376,7 @@ export async function updateEntity(
 
   const metadataUpdates = mergeConvenienceFields(data, data.metadata ?? {}, 'update');
   const hasMetadataUpdates = Object.keys(metadataUpdates).length > 0;
+  const affirmFields = Array.isArray(data.affirm_fields) ? data.affirm_fields : [];
 
   const hasContent = data.content !== undefined;
   const contentValue = data.content?.trim() || null;
@@ -381,6 +388,9 @@ export async function updateEntity(
   // the existing plain-merge behavior; watcher ownership-aware writes go through
   // mergeEntityFields at the promotion call site.
   const isHumanEdit = !!ctx.userId && !ctx.agentId;
+  // An affirm-only edit (approve a value as-is) has no metadata delta but still
+  // must run the merge so it can claim field ownership.
+  const hasAffirm = isHumanEdit && affirmFields.length > 0;
 
   // Lock the entity row, merge metadata, and write in ONE transaction: concurrent
   // updates to the same entity serialize on the row lock, fixing the pre-existing
@@ -397,7 +407,7 @@ export async function updateEntity(
 
     let mergedMetadata: Record<string, unknown> | null = null;
     let mergedControls: Record<string, unknown> | null = null;
-    if (hasMetadataUpdates) {
+    if (hasMetadataUpdates || hasAffirm) {
       const existing = (
         typeof current[0].metadata === 'string'
           ? JSON.parse(current[0].metadata as string)
@@ -417,6 +427,7 @@ export async function updateEntity(
           actorId: ctx.userId,
           note: data.field_note ?? null,
           nowIso: new Date().toISOString(),
+          affirm: affirmFields,
         });
         mergedMetadata = merge.nextMetadata;
         mergedControls = merge.nextControls;


### PR DESCRIPTION
The deferred centerpiece from #1655's review: make each watcher recap item approve/correctable, wired to the entity field-ownership write path (`entities.field_controls`).

## The design problem
The recap renders `mergeWindows(windows)` — a single merged JSON blob where each item is only a positional path (`problems[2].severity`), with no link to a durable entity. The field-ownership plane keys on `(entity_id, field)`. So corrections had nowhere to land.

**Resolution:** render the watcher's PROMOTED entities (keyed children — each already a real `entities` row with `field_controls` + a stable key), so every item carries `entity_id + field` natively.

## Backend (this repo)
- **`manage_watchers.list_promoted`** — lists a watcher's promoted entities with metadata + `field_controls` + window/stable-key provenance (org-scoped, `requireWatcherAccess 'read'`). The recap's data source.
- **"approve" write** — `computeFieldMerge` / `mergeEntityFields` / `updateEntity` gain an `affirm` path: a human claims ownership of a field's CURRENT value without changing it. Previously re-setting an unchanged value was a no-op (`if (sameValue) continue`), so there was no way to *lock* a correct value against future watcher overwrites. Exposed via `manage_entity.update` `affirm_fields`. ("Correct" already worked via a normal `source:'human'` metadata update.)

## Tests
- `entity-field-merge.test.ts` (+4): affirm claims ownership on an unchanged value; a set subsumes affirm; affirm ignores an absent field; a watcher can't affirm. (12/12 pass.)
- `promote-keyed-entities.test.ts` (+2): `list_promoted` returns promoted entities with ownership + provenance; **approve (`affirm_fields`) locks a value so a later watcher change is BLOCKED and queued as an approval** — end-to-end proof the affirm actually protects the field. (7/7 pass.)

```
entity-field-merge.test.ts        12 passed
promote-keyed-entities.test.ts     7 passed
```
`tsc --noEmit` clean; biome clean.

## Frontend
owletto PR: lobu-ai/owletto#408 (pointer bumped to `37cf13f`). Promoted-entities recap cards with inline correct (`EditablePrimitive`) + approve (`Check`, disabled once owned) + "You own this" badge; optimistic. Non-keyed watchers keep the merged recap unchanged.

Merge owletto#408 first, then this repoints the submodule to its squash SHA.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785509887&installation_id=136316292&pr_number=1661&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1661&signature=009dd09799417c5f3a3c85e522f9a0be9c05fdcee5ebe16b5fd3aef3e655f459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->