### PR TITLE
feat(watchers): streaming channel feed as a membership-gated @feed source

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/channel-feed-source.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/channel-feed-source.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Streaming (chat-channel) feed as a watcher @feed source — the membership-gated
+ * read of `channel_messages`.
+ *
+ * A streaming @feed compiles to a read over `channel_messages` (not `events`),
+ * and that read is gated per-channel by `compileChannelMessagesVisibility`:
+ *
+ *   1. On a NON-enforced connection, a headless watcher run (null principal)
+ *      reads the transcript — org-open channels are usable as sources.
+ *   2. On an ACL-enforced connection, a headless run reads NOTHING — enforced
+ *      channel content never reaches the shared recap. THE security property.
+ *   3. On an ACL-enforced connection, a member (auth $member with a `member_of`
+ *      edge to the channel) DOES read it — the gate is membership, not blanket
+ *      denial.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getTestDb } from "../../setup/test-db";
+import { createTestConnection } from "../../setup/test-fixtures";
+import { TestWorkspace } from "../../setup/test-mcp-client";
+import { buildSlackChannelGraph } from "../../../authz/slack-channel-graph";
+import { ensureStreamingChannelFeed } from "../../../gateway/channels/channel-feed";
+import { slugToRuntimeConnectionId } from "../../../lobu/stores/connections-projection";
+import { normalizeWatcherSources } from "../../../watchers/source-refs";
+import { executeDataSources } from "../../../utils/execute-data-sources";
+import { ensureMemberEntity } from "../../../utils/member-entity";
+import type { DbClient } from "../../../db/client";
+
+const TEAM_ID = "TACME";
+const CHANNEL = "C900";
+const FEED_KEY = `slack:${CHANNEL}`;
+
+describe("streaming feed as a watcher @feed source", () => {
+  let workspace: TestWorkspace;
+  let orgId: string;
+
+  beforeAll(async () => {
+    workspace = await TestWorkspace.create({ name: "Channel Feed Source Org" });
+    orgId = workspace.org.id;
+  });
+
+  beforeEach(async () => {
+    const sql = getTestDb();
+    await sql`DELETE FROM channel_messages WHERE organization_id = ${orgId}`;
+    await sql`DELETE FROM authz_source_acl_state WHERE organization_id = ${orgId}`;
+    await sql`DELETE FROM entity_relationships WHERE organization_id = ${orgId}`;
+    await sql`DELETE FROM entity_identities WHERE organization_id = ${orgId}`;
+    await sql`DELETE FROM feeds WHERE organization_id = ${orgId}`;
+    await sql`DELETE FROM connections WHERE organization_id = ${orgId}`;
+    // Keep the workspace's own $member/entities intact; only clear source state.
+    await sql`
+      DELETE FROM entities
+      WHERE organization_id = ${orgId}
+        AND (metadata->>'source' = 'watcher_promotion' OR entity_type_id IN (
+          SELECT id FROM entity_types WHERE organization_id = ${orgId} AND slug IN ('channel', '$member')
+        ))
+    `;
+  });
+
+  /** A chat (slack, managed) connection carrying the team id. Returns the id, the
+   *  slug, and the runtime id that channel_messages + the ACL state key on. */
+  async function makeChatConnection() {
+    const conn = await createTestConnection({
+      organization_id: orgId,
+      connector_key: "slack",
+      display_name: "Org Slack",
+      createDefaultFeed: false,
+    });
+    const sql = getTestDb();
+    const [row] = await sql`
+      UPDATE connections
+      SET credential_mode = 'managed', external_tenant_id = ${TEAM_ID}
+      WHERE id = ${conn.id}
+      RETURNING slug
+    `;
+    const slug = String(row.slug);
+    return { id: conn.id, slug, runtimeId: slugToRuntimeConnectionId(slug) };
+  }
+
+  async function seedTranscript(runtimeId: string) {
+    const sql = getTestDb();
+    for (const [i, [author, text]] of (
+      [
+        ["Alice", "channel secret one"],
+        ["Bob", "channel secret two"],
+      ] as Array<[string, string]>
+    ).entries()) {
+      await sql`
+        INSERT INTO channel_messages (
+          organization_id, connection_id, platform, channel_id,
+          platform_message_id, author_name, is_bot, text, occurred_at
+        ) VALUES (
+          ${orgId}, ${runtimeId}, 'slack', ${CHANNEL},
+          ${`m${i}`}, ${author}, false, ${text},
+          ${new Date(Date.now() + i * 1000)}
+        )
+      `;
+    }
+  }
+
+  /** Compile @feed:<key> to its channel_messages query and run it as the given
+   *  reader — exactly the watcher read path (normalize → executeDataSources). */
+  async function readAsWatcherSource(userId: string | null): Promise<unknown[]> {
+    const sql = getTestDb();
+    const normalized = await normalizeWatcherSources(sql as unknown as DbClient, orgId, [
+      { name: "chat", query: `@feed:${FEED_KEY}` },
+    ]);
+    expect(normalized[0].query).toContain("channel_messages");
+    const out = await executeDataSources(
+      [{ name: "chat", query: normalized[0].query }],
+      { organizationId: orgId, userId },
+      sql as unknown as DbClient
+    );
+    return out.chat ?? [];
+  }
+
+  it("a headless watcher reads a NON-enforced channel's transcript", async () => {
+    const conn = await makeChatConnection();
+    await ensureStreamingChannelFeed({
+      connectionId: conn.id,
+      organizationId: orgId,
+      channelKey: FEED_KEY,
+    });
+    await seedTranscript(conn.runtimeId);
+
+    // No ACL graph → connection not enforced → headless (null principal) reads it.
+    const rows = (await readAsWatcherSource(null)) as Array<{ text: string }>;
+    expect(rows.length).toBe(2);
+    expect(rows.map((r) => r.text).sort()).toEqual([
+      "channel secret one",
+      "channel secret two",
+    ]);
+  });
+
+  it("a headless watcher reads NOTHING from an ACL-enforced channel (no leak)", async () => {
+    const conn = await makeChatConnection();
+    await ensureStreamingChannelFeed({
+      connectionId: conn.id,
+      organizationId: orgId,
+      channelKey: FEED_KEY,
+    });
+    await seedTranscript(conn.runtimeId);
+
+    // Materialize the membership graph → marks the connection ACL-enforced.
+    await buildSlackChannelGraph({
+      organizationId: orgId,
+      connectionId: conn.runtimeId,
+      teamId: TEAM_ID,
+      channels: [{ channelId: CHANNEL, name: "general", memberSlackUserIds: ["UMEMBER"] }],
+    });
+
+    // Headless run has no $member → fails closed on the enforced channel.
+    const rows = await readAsWatcherSource(null);
+    expect(rows.length).toBe(0);
+  });
+
+  it("a channel MEMBER reads the enforced channel (gate is membership, not denial)", async () => {
+    const conn = await makeChatConnection();
+    await ensureStreamingChannelFeed({
+      connectionId: conn.id,
+      organizationId: orgId,
+      channelKey: FEED_KEY,
+    });
+    await seedTranscript(conn.runtimeId);
+
+    const graph = await buildSlackChannelGraph({
+      organizationId: orgId,
+      connectionId: conn.runtimeId,
+      teamId: TEAM_ID,
+      channels: [{ channelId: CHANNEL, name: "general", memberSlackUserIds: [] }],
+    });
+    const channelEntityId = graph.channelEntityIds[CHANNEL];
+    expect(typeof channelEntityId).toBe("number");
+
+    // Provision the reader's $member (writes the auth_user_id/auth:signup identity
+    // the gate resolves), then give it a member_of edge to the channel entity —
+    // the same shape the live ACL sync would produce for a channel member.
+    const readerUserId = workspace.users.owner.id;
+    await ensureMemberEntity({
+      organizationId: orgId,
+      userId: readerUserId,
+      name: "Reader",
+      email: `reader-${readerUserId}@example.com`,
+    });
+    const sql = getTestDb();
+    const [member] = await sql`
+      SELECT e.id
+      FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id AND et.slug = '$member'
+      JOIN entity_identities ei ON ei.entity_id = e.id
+        AND ei.namespace = 'auth_user_id' AND ei.identifier = ${readerUserId}
+        AND ei.source_connector = 'auth:signup'
+      WHERE e.organization_id = ${orgId} AND e.deleted_at IS NULL
+      LIMIT 1
+    `;
+    const [mot] = await sql`
+      SELECT id FROM entity_relationship_types
+      WHERE organization_id = ${orgId} AND slug = 'member_of' AND status = 'active'
+      LIMIT 1
+    `;
+    await sql`
+      INSERT INTO entity_relationships (
+        organization_id, from_entity_id, to_entity_id, relationship_type_id, created_at, updated_at
+      ) VALUES (
+        ${orgId}, ${member.id}, ${channelEntityId}, ${mot.id}, NOW(), NOW()
+      )
+    `;
+
+    const rows = (await readAsWatcherSource(readerUserId)) as Array<{ text: string }>;
+    expect(rows.length).toBe(2);
+    expect(rows.map((r) => r.text).sort()).toEqual([
+      "channel secret one",
+      "channel secret two",
+    ]);
+  });
+});

--- a/packages/server/src/__tests__/integration/watchers/channel-feed-source.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/channel-feed-source.test.ts
@@ -114,6 +114,26 @@ describe("streaming feed as a watcher @feed source", () => {
     return out.chat ?? [];
   }
 
+  it("a streaming @feed compiles to kind 'channel' (prompt context, not event-signed)", async () => {
+    // Regression for the complete_window FK: a channel source's rows carry
+    // channel_messages.id, which is NOT an events.id. If the source were kind
+    // 'event' its ids would be signed into the window_token content_ids and
+    // complete_window would insert them into watcher_window_events.event_id (FK
+    // to events) → break. kind 'channel' keeps them out of eventSourceNames.
+    const conn = await makeChatConnection();
+    await ensureStreamingChannelFeed({
+      connectionId: conn.id,
+      organizationId: orgId,
+      channelKey: FEED_KEY,
+    });
+    const sql = getTestDb();
+    const normalized = await normalizeWatcherSources(sql as unknown as DbClient, orgId, [
+      { name: "chat", query: `@feed:${FEED_KEY}` },
+    ]);
+    expect(normalized[0].kind).toBe("channel");
+    expect(normalized[0].query).toContain("channel_messages");
+  });
+
   it("a headless watcher reads a NON-enforced channel's transcript", async () => {
     const conn = await makeChatConnection();
     await ensureStreamingChannelFeed({

--- a/packages/server/src/__tests__/integration/watchers/channel-feed-source.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/channel-feed-source.test.ts
@@ -174,6 +174,30 @@ describe("streaming feed as a watcher @feed source", () => {
     expect(rows.length).toBe(0);
   });
 
+  it("reads NOTHING from a connection whose ACL snapshot went STALE (fail closed)", async () => {
+    const conn = await makeChatConnection();
+    await ensureStreamingChannelFeed({
+      connectionId: conn.id,
+      organizationId: orgId,
+      channelKey: FEED_KEY,
+    });
+    await seedTranscript(conn.runtimeId);
+
+    // The connection WAS onboarded into authz (acl row exists) but its snapshot
+    // aged out beyond the freshness window — full+fresh yet last_synced_at old, so
+    // it is NOT in the fresh-enforced set. A bare `NOT IN (enforced)` would leak
+    // it; the gate must fail closed because a row exists.
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO authz_source_acl_state
+        (organization_id, connection_id, acl_support, freshness_state, last_synced_at, created_at, updated_at)
+      VALUES (${orgId}, ${conn.runtimeId}, 'full', 'fresh', now() - interval '2 hours', now(), now())
+    `;
+
+    const rows = await readAsWatcherSource(null);
+    expect(rows.length).toBe(0);
+  });
+
   it("a channel MEMBER reads the enforced channel (gate is membership, not denial)", async () => {
     const conn = await makeChatConnection();
     await ensureStreamingChannelFeed({

--- a/packages/server/src/__tests__/integration/watchers/channel-feed-source.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/channel-feed-source.test.ts
@@ -100,7 +100,10 @@ describe("streaming feed as a watcher @feed source", () => {
 
   /** Compile @feed:<key> to its channel_messages query and run it as the given
    *  reader — exactly the watcher read path (normalize → executeDataSources). */
-  async function readAsWatcherSource(userId: string | null): Promise<unknown[]> {
+  async function readAsWatcherSource(
+    opts: string | null | { userId?: string | null; windowStart?: string; windowEnd?: string }
+  ): Promise<unknown[]> {
+    const o = typeof opts === "object" && opts !== null ? opts : { userId: opts };
     const sql = getTestDb();
     const normalized = await normalizeWatcherSources(sql as unknown as DbClient, orgId, [
       { name: "chat", query: `@feed:${FEED_KEY}` },
@@ -108,7 +111,12 @@ describe("streaming feed as a watcher @feed source", () => {
     expect(normalized[0].query).toContain("channel_messages");
     const out = await executeDataSources(
       [{ name: "chat", query: normalized[0].query }],
-      { organizationId: orgId, userId },
+      {
+        organizationId: orgId,
+        userId: o.userId ?? null,
+        windowStart: o.windowStart,
+        windowEnd: o.windowEnd,
+      },
       sql as unknown as DbClient
     );
     return out.chat ?? [];
@@ -256,5 +264,69 @@ describe("streaming feed as a watcher @feed source", () => {
       "channel secret one",
       "channel secret two",
     ]);
+  });
+
+  it("does not expose a PRIVATE connection's channel to a headless watcher (connection visibility)", async () => {
+    // A private chat connection: visible only to its creator, even though its
+    // channel isn't ACL-enforced. The membership gate alone (not-graphed →
+    // passthrough) would leak it to a headless watcher; connection visibility
+    // must also apply.
+    const priv = await createTestConnection({
+      organization_id: orgId,
+      connector_key: "slack",
+      display_name: "Private Slack",
+      visibility: "private",
+      created_by: workspace.users.owner.id,
+      createDefaultFeed: false,
+    });
+    const sql = getTestDb();
+    await sql`
+      UPDATE connections SET credential_mode = 'managed', external_tenant_id = ${TEAM_ID}
+      WHERE id = ${priv.id}
+    `;
+    const [row] = await sql`SELECT slug FROM connections WHERE id = ${priv.id}`;
+    const runtimeId = slugToRuntimeConnectionId(String(row.slug));
+    await ensureStreamingChannelFeed({
+      connectionId: priv.id,
+      organizationId: orgId,
+      channelKey: FEED_KEY,
+    });
+    await seedTranscript(runtimeId);
+
+    // Headless (null principal) → private connection hidden → nothing.
+    expect((await readAsWatcherSource({ userId: null })).length).toBe(0);
+    // The creator can read it.
+    expect(
+      (await readAsWatcherSource({ userId: workspace.users.owner.id })).length
+    ).toBe(2);
+  });
+
+  it("a channel @feed source respects the watcher window bounds", async () => {
+    const conn = await makeChatConnection();
+    await ensureStreamingChannelFeed({
+      connectionId: conn.id,
+      organizationId: orgId,
+      channelKey: FEED_KEY,
+    });
+    const sql = getTestDb();
+    // One message inside the window, one well before it.
+    await sql`
+      INSERT INTO channel_messages (
+        organization_id, connection_id, platform, channel_id,
+        platform_message_id, author_name, is_bot, text, occurred_at
+      ) VALUES
+        (${orgId}, ${conn.runtimeId}, 'slack', ${CHANNEL}, 'w-in', 'A', false, 'inside window', NOW()),
+        (${orgId}, ${conn.runtimeId}, 'slack', ${CHANNEL}, 'w-out', 'B', false, 'before window', NOW() - interval '2 days')
+    `;
+
+    const windowStart = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const windowEnd = new Date(Date.now() + 60 * 1000).toISOString();
+    const rows = (await readAsWatcherSource({
+      userId: null,
+      windowStart,
+      windowEnd,
+    })) as Array<{ text: string }>;
+    expect(rows.length).toBe(1);
+    expect(rows[0].text).toBe("inside window");
   });
 });

--- a/packages/server/src/__tests__/integration/watchers/source-id-and-cross-org.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/source-id-and-cross-org.test.ts
@@ -229,9 +229,10 @@ describe("manage_watchers source-id + cross-org guards", () => {
 		).rejects.toThrow(/nonexistent-typo/i);
 	});
 
-	it("rejects create when an @feed ref points at a streaming (channel) feed", async () => {
-		// A streaming/channel feed's rows live in channel_messages, not events, so
-		// an @feed source over it would validate then read empty. Reject it loudly.
+	it("accepts an @feed ref that points at a streaming (channel) feed", async () => {
+		// A streaming/channel feed compiles to a membership-gated read over
+		// channel_messages (compileChannelMessagesVisibility), so it IS a valid
+		// @feed source — the gate keeps enforced-channel content from leaking.
 		const sql = getTestDb();
 		const connection = await createTestConnection({
 			organization_id: ownerOrgId,
@@ -244,16 +245,15 @@ describe("manage_watchers source-id + cross-org guards", () => {
 			VALUES (${ownerOrgId}, ${connection.id}, 'slack:C123', 'general', 'active', 'streaming', false, ${sql.json({ store: "channel_messages" })}::jsonb)
 		`;
 
-		await expect(
-			owner.watchers.create({
-				entity_id: inOrgEntityId,
-				slug: "streaming-feed-src",
-				name: "Streaming Feed Src",
-				prompt: "Track stuff.",
-				agent_id: agentId,
-				sources: [{ name: "content", query: "@feed:slack:C123" }],
-			}),
-		).rejects.toThrow(/streaming feed|collected/i);
+		const created = (await owner.watchers.create({
+			entity_id: inOrgEntityId,
+			slug: "streaming-feed-src",
+			name: "Streaming Feed Src",
+			prompt: "Track stuff.",
+			agent_id: agentId,
+			sources: [{ name: "content", query: "@feed:slack:C123" }],
+		})) as { watcher_id: string };
+		expect(created.watcher_id).toBeTruthy();
 	});
 
 	it("rejects create when an @entity ref is not a type in the org", async () => {

--- a/packages/server/src/authz/channel-messages-visibility.ts
+++ b/packages/server/src/authz/channel-messages-visibility.ts
@@ -4,20 +4,23 @@
  * fragment so raw-SQL callers (watcher @feed sources, query_sql) read chat
  * transcripts with the same fail-closed membership contract.
  *
- * Rule (mirrors `compileResourceVisibility`, but keyed on the channel identity
- * rather than `events.entity_ids`, because `channel_messages` carries no
- * entity_ids):
- *   - a row on a connection that is NOT ACL-enforced is unconstrained (legacy
- *     fence / org-open — the same passthrough the whole authz program uses for
- *     not-graphed connections);
- *   - a row on an ACL-enforced connection is visible ONLY when the requester is
+ * Rule (keyed on the channel identity rather than `events.entity_ids`, because
+ * `channel_messages` carries no entity_ids), matching `getConnectionEnforcement`'s
+ * three states:
+ *   - `not-graphed` (NO acl state row for the connection) → unconstrained (legacy
+ *     fence / org-open — the passthrough the whole authz program uses);
+ *   - `enforced` (acl row is full + fresh) → visible ONLY when the requester is
  *     `member_of` the `channel` entity keyed `slack_channel_id = UPPER(team:chan)`,
- *     where the team is resolved from the row's connection.
+ *     where the team is resolved from the row's connection;
+ *   - `stale` / partial / failed (acl row EXISTS but isn't fresh-enforcing) →
+ *     fails CLOSED (neither branch matches). A bare `NOT IN (enforced)` would
+ *     instead leak a channel whose ACL snapshot merely aged out.
  *
- * Fail-closed: a headless/null principal, or an enforced channel the requester
- * doesn't belong to, sees nothing. This is what makes a (headless) watcher run
- * safe to read a streaming @feed — it reads only non-enforced channels; enforced
- * ones return zero rows, so their content never reaches the shared recap.
+ * Fail-closed: a headless/null principal, an enforced channel the requester
+ * doesn't belong to, or a stale-ACL connection all see nothing. This is what
+ * makes a (headless) watcher run safe to read a streaming @feed — it reads only
+ * not-graphed channels; enforced/stale ones return zero rows, so their content
+ * never reaches the shared recap.
  *
  * Requester resolution is the auth-signup `$member` claim only (same as
  * `compileResourceVisibility`) — the recap/query_sql reader is a web/app user, not
@@ -48,50 +51,65 @@ export function compileChannelMessagesVisibility(
   const orgParam = `$${baseParamIndex}::text`;
   const userParam = `$${baseParamIndex + 1}::text`;
 
+  // Fail-closed on stale: a connection is visible ONLY when it has NO acl state
+  // row at all (never onboarded → legacy fence, org-visible) OR it is
+  // full+fresh-enforced AND the requester is a channel member. A connection whose
+  // acl row EXISTS but isn't currently fresh-enforcing (stale / partial / failed)
+  // matches neither branch → its transcripts are dropped. This mirrors
+  // getConnectionEnforcement's `not-graphed` (passthrough) vs `stale` (fail
+  // closed) split — NOT a bare `NOT IN (enforced)`, which would leak a channel
+  // whose ACL snapshot merely aged out.
   const sql = `AND (
-      ${tableAlias}.connection_id NOT IN (${enforcedConnectionsSelectSql(orgParam)})
-      OR EXISTS (
-        SELECT 1
-        FROM public.connections conn
-        JOIN public.entity_identities cei
-          ON cei.organization_id = ${orgParam}
-         AND cei.namespace = 'slack_channel_id'
-         AND cei.deleted_at IS NULL
-         AND cei.identifier = UPPER(
-           COALESCE(
-             ${tableAlias}.team_id,
-             conn.external_tenant_id,
-             conn.config->'chatMetadata'->>'teamId'
-           ) || ':' || ${tableAlias}.channel_id
-         )
-        JOIN public.entity_relationships rr
-          ON rr.organization_id = ${orgParam}
-         AND rr.to_entity_id = cei.entity_id
-         AND rr.deleted_at IS NULL
-        JOIN public.entity_relationship_types rt
-          ON rt.id = rr.relationship_type_id
-         AND rt.organization_id = rr.organization_id
-         AND rt.slug = 'member_of'
-        WHERE conn.organization_id = ${orgParam}
-          AND conn.slug IN (${tableAlias}.connection_id, 'agentconn-' || ${tableAlias}.connection_id)
-          AND rr.from_entity_id = (
-            SELECT mei.entity_id
-            FROM public.entity_identities mei
-            JOIN public.entities me
-              ON me.id = mei.entity_id
-             AND me.organization_id = mei.organization_id
-             AND me.deleted_at IS NULL
-            JOIN public.entity_types met
-              ON met.id = me.entity_type_id
-             AND met.organization_id = me.organization_id
-             AND met.slug = '$member'
-            WHERE mei.organization_id = ${orgParam}
-              AND mei.namespace = 'auth_user_id'
-              AND mei.identifier = ${userParam}
-              AND mei.source_connector = 'auth:signup'
-              AND mei.deleted_at IS NULL
-            LIMIT 1
-          )
+      NOT EXISTS (
+        SELECT 1 FROM public.authz_source_acl_state a
+        WHERE a.organization_id = ${orgParam}
+          AND a.connection_id = ${tableAlias}.connection_id
+      )
+      OR (
+        ${tableAlias}.connection_id IN (${enforcedConnectionsSelectSql(orgParam)})
+        AND EXISTS (
+          SELECT 1
+          FROM public.connections conn
+          JOIN public.entity_identities cei
+            ON cei.organization_id = ${orgParam}
+           AND cei.namespace = 'slack_channel_id'
+           AND cei.deleted_at IS NULL
+           AND cei.identifier = UPPER(
+             COALESCE(
+               ${tableAlias}.team_id,
+               conn.external_tenant_id,
+               conn.config->'chatMetadata'->>'teamId'
+             ) || ':' || ${tableAlias}.channel_id
+           )
+          JOIN public.entity_relationships rr
+            ON rr.organization_id = ${orgParam}
+           AND rr.to_entity_id = cei.entity_id
+           AND rr.deleted_at IS NULL
+          JOIN public.entity_relationship_types rt
+            ON rt.id = rr.relationship_type_id
+           AND rt.organization_id = rr.organization_id
+           AND rt.slug = 'member_of'
+          WHERE conn.organization_id = ${orgParam}
+            AND conn.slug IN (${tableAlias}.connection_id, 'agentconn-' || ${tableAlias}.connection_id)
+            AND rr.from_entity_id = (
+              SELECT mei.entity_id
+              FROM public.entity_identities mei
+              JOIN public.entities me
+                ON me.id = mei.entity_id
+               AND me.organization_id = mei.organization_id
+               AND me.deleted_at IS NULL
+              JOIN public.entity_types met
+                ON met.id = me.entity_type_id
+               AND met.organization_id = me.organization_id
+               AND met.slug = '$member'
+              WHERE mei.organization_id = ${orgParam}
+                AND mei.namespace = 'auth_user_id'
+                AND mei.identifier = ${userParam}
+                AND mei.source_connector = 'auth:signup'
+                AND mei.deleted_at IS NULL
+              LIMIT 1
+            )
+        )
       )
     )`;
   return { sql, params: [scope.organizationId, scope.principal] };

--- a/packages/server/src/authz/channel-messages-visibility.ts
+++ b/packages/server/src/authz/channel-messages-visibility.ts
@@ -1,0 +1,98 @@
+/**
+ * Channel-membership gate for the `channel_messages` read seam — the SQL analog
+ * of `./channel-visibility`'s `filterChannelsForRequester`, expressed as a WHERE
+ * fragment so raw-SQL callers (watcher @feed sources, query_sql) read chat
+ * transcripts with the same fail-closed membership contract.
+ *
+ * Rule (mirrors `compileResourceVisibility`, but keyed on the channel identity
+ * rather than `events.entity_ids`, because `channel_messages` carries no
+ * entity_ids):
+ *   - a row on a connection that is NOT ACL-enforced is unconstrained (legacy
+ *     fence / org-open — the same passthrough the whole authz program uses for
+ *     not-graphed connections);
+ *   - a row on an ACL-enforced connection is visible ONLY when the requester is
+ *     `member_of` the `channel` entity keyed `slack_channel_id = UPPER(team:chan)`,
+ *     where the team is resolved from the row's connection.
+ *
+ * Fail-closed: a headless/null principal, or an enforced channel the requester
+ * doesn't belong to, sees nothing. This is what makes a (headless) watcher run
+ * safe to read a streaming @feed — it reads only non-enforced channels; enforced
+ * ones return zero rows, so their content never reaches the shared recap.
+ *
+ * Requester resolution is the auth-signup `$member` claim only (same as
+ * `compileResourceVisibility`) — the recap/query_sql reader is a web/app user, not
+ * an in-Slack author, so the `slack_user_id` fallback isn't needed on this seam.
+ */
+
+import { enforcedConnectionsSelectSql } from './acl-state.js';
+import type { AuthzScope } from './scope.js';
+
+/**
+ * Predicate for a `channel_messages` table (alias has `connection_id` [text
+ * runtime id], `channel_id` [bare], `organization_id`). Binds two params from
+ * `baseParamIndex`: the org id and the principal. Returns an `AND (...)` fragment
+ * (no leading space).
+ *
+ * `channel_messages.connection_id` and `authz_source_acl_state.connection_id` are
+ * BOTH the runtime connection id (see `slack-acl-sync`/`persistChannelMessage`),
+ * so the enforced-set membership check compares like-for-like. The channel entity
+ * is team-scoped (`T:C`), so the team is resolved from the row's connection
+ * (`external_tenant_id` / `config.chatMetadata.teamId`), matched by slug via both
+ * the BYO (`agentconn-<id>`) and slack-install (`<id>`) namespaces.
+ */
+export function compileChannelMessagesVisibility(
+  scope: AuthzScope,
+  baseParamIndex: number,
+  tableAlias: string,
+): { sql: string; params: Array<string | null> } {
+  const orgParam = `$${baseParamIndex}::text`;
+  const userParam = `$${baseParamIndex + 1}::text`;
+
+  const sql = `AND (
+      ${tableAlias}.connection_id NOT IN (${enforcedConnectionsSelectSql(orgParam)})
+      OR EXISTS (
+        SELECT 1
+        FROM public.connections conn
+        JOIN public.entity_identities cei
+          ON cei.organization_id = ${orgParam}
+         AND cei.namespace = 'slack_channel_id'
+         AND cei.deleted_at IS NULL
+         AND cei.identifier = UPPER(
+           COALESCE(
+             ${tableAlias}.team_id,
+             conn.external_tenant_id,
+             conn.config->'chatMetadata'->>'teamId'
+           ) || ':' || ${tableAlias}.channel_id
+         )
+        JOIN public.entity_relationships rr
+          ON rr.organization_id = ${orgParam}
+         AND rr.to_entity_id = cei.entity_id
+         AND rr.deleted_at IS NULL
+        JOIN public.entity_relationship_types rt
+          ON rt.id = rr.relationship_type_id
+         AND rt.organization_id = rr.organization_id
+         AND rt.slug = 'member_of'
+        WHERE conn.organization_id = ${orgParam}
+          AND conn.slug IN (${tableAlias}.connection_id, 'agentconn-' || ${tableAlias}.connection_id)
+          AND rr.from_entity_id = (
+            SELECT mei.entity_id
+            FROM public.entity_identities mei
+            JOIN public.entities me
+              ON me.id = mei.entity_id
+             AND me.organization_id = mei.organization_id
+             AND me.deleted_at IS NULL
+            JOIN public.entity_types met
+              ON met.id = me.entity_type_id
+             AND met.organization_id = me.organization_id
+             AND met.slug = '$member'
+            WHERE mei.organization_id = ${orgParam}
+              AND mei.namespace = 'auth_user_id'
+              AND mei.identifier = ${userParam}
+              AND mei.source_connector = 'auth:signup'
+              AND mei.deleted_at IS NULL
+            LIMIT 1
+          )
+      )
+    )`;
+  return { sql, params: [scope.organizationId, scope.principal] };
+}

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -22,6 +22,7 @@ import {
   compileConnectionFkVisibility,
   compileConnectionRowVisibility,
 } from '../authz/connection-visibility';
+import { compileChannelMessagesVisibility } from '../authz/channel-messages-visibility';
 import { compileResourceVisibility } from '../authz/resource-visibility';
 import type { AuthzScope } from '../authz/scope';
 import {
@@ -429,6 +430,18 @@ export function buildScopedQuery(
     return ` ${vis.sql}`;
   };
 
+  // Per-channel membership gate for the `channel_messages` table (alias has
+  // `connection_id` + `channel_id`): on an ACL-enforced Slack connection, restrict
+  // to channels the requester is `member_of`. A headless/null principal sees only
+  // non-enforced channels — this is what keeps a watcher's streaming @feed source
+  // from leaking enforced-channel content into the shared recap.
+  const channelMessagesVisibility = (alias: string): string => {
+    const vis = compileChannelMessagesVisibility(scope, idx + 1, alias);
+    params.push(...vis.params);
+    idx += vis.params.length;
+    return ` ${vis.sql}`;
+  };
+
   // For the `connections` table itself: the row is visible when org-shared or
   // owned by the requesting user (mirrors manage_connections CRUD).
   const connectionRowVisibility = (alias: string): string => {
@@ -637,6 +650,17 @@ export function buildScopedQuery(
       ctes.push(
         `"${safeName}" AS (SELECT ${sel(table, 'fd')} FROM public.feeds fd WHERE fd.organization_id = ${orgP}` +
           eventConnVisibility('fd') +
+          ')'
+      );
+    } else if (table === 'channel_messages') {
+      // Chat transcript rows. `text` is verbatim channel content, so the CTE
+      // applies the per-channel membership gate: org-scope AND (connection not
+      // ACL-enforced OR requester member_of the channel). A headless reader
+      // (null principal) therefore reads only non-enforced channels.
+      // security-allowed: see block comment above the for-loop
+      ctes.push(
+        `"${safeName}" AS (SELECT ${sel(table, 'cm')} FROM public.channel_messages cm WHERE cm.organization_id = ${orgP}` +
+          channelMessagesVisibility('cm') +
           ')'
       );
     } else if (table === 'connector_definitions') {

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -654,15 +654,39 @@ export function buildScopedQuery(
       );
     } else if (table === 'channel_messages') {
       // Chat transcript rows. `text` is verbatim channel content, so the CTE
-      // applies the per-channel membership gate: org-scope AND (connection not
-      // ACL-enforced OR requester member_of the channel). A headless reader
-      // (null principal) therefore reads only non-enforced channels.
+      // stacks the SAME gates the events CTE applies, adapted to channel_messages:
+      //   1. connection visibility — a PRIVATE connection's transcript is visible
+      //      only to its creator (org-visible connections to everyone). Resolved
+      //      by slug because channel_messages.connection_id is the runtime id, not
+      //      connections.id. A null principal (headless watcher) → org-only.
+      //   2. time window (incremental mode) — only rows inside the watcher window,
+      //      so a channel @feed reads its window, not the whole history.
+      //   3. per-channel membership (channelMessagesVisibility) — ACL-enforced
+      //      channels require member_of; stale/enforced fail closed.
       // security-allowed: see block comment above the for-loop
-      ctes.push(
-        `"${safeName}" AS (SELECT ${sel(table, 'cm')} FROM public.channel_messages cm WHERE cm.organization_id = ${orgP}` +
-          channelMessagesVisibility('cm') +
-          ')'
-      );
+      let cmCte =
+        `"${safeName}" AS (SELECT ${sel(table, 'cm')} FROM public.channel_messages cm ` +
+        `WHERE cm.organization_id = ${orgP}`;
+      idx++;
+      params.push(scope.principal);
+      const cmPrincipal = `$${idx}::text`;
+      cmCte +=
+        ` AND EXISTS (SELECT 1 FROM public.connections cc ` +
+        `WHERE cc.organization_id = ${orgP} AND cc.deleted_at IS NULL ` +
+        `AND cc.slug IN (cm.connection_id, 'agentconn-' || cm.connection_id) ` +
+        `AND (cc.visibility = 'org' OR cc.created_by = ${cmPrincipal}))`;
+      if (context.windowStart && context.windowEnd) {
+        idx++;
+        params.push(context.windowStart);
+        const cmWindowStart = `$${idx}`;
+        idx++;
+        params.push(context.windowEnd);
+        const cmWindowEnd = `$${idx}`;
+        cmCte += ` AND cm.occurred_at >= ${cmWindowStart}::timestamptz AND cm.occurred_at < ${cmWindowEnd}::timestamptz`;
+      }
+      cmCte += channelMessagesVisibility('cm');
+      cmCte += ')';
+      ctes.push(cmCte);
     } else if (table === 'connector_definitions') {
       ctes.push(
         `"${safeName}" AS (SELECT ${sel(table)} FROM public.connector_definitions WHERE organization_id = ${orgP})`

--- a/packages/server/src/utils/table-schema.ts
+++ b/packages/server/src/utils/table-schema.ts
@@ -312,6 +312,32 @@ export const QUERYABLE_SCHEMA = {
         'kind'
       ),
     },
+    // channel_messages — chat-channel transcripts (streaming feeds). Content is
+    // membership-gated per row by the channel_messages CTE in execute-data-sources
+    // (compileChannelMessagesVisibility): a row on an ACL-enforced Slack
+    // connection is visible only to a channel member; a headless reader (null
+    // principal) sees only non-enforced channels. Without that gate this table is
+    // NOT safe to expose, which is why it was previously absent from the allowlist.
+    {
+      name: 'channel_messages',
+      columns: cols(
+        'id',
+        'organization_id',
+        'connection_id',
+        'platform',
+        'channel_id',
+        'thread_id',
+        'platform_message_id',
+        'author_id',
+        'author_name',
+        'author_entity_id',
+        'team_id',
+        'is_bot',
+        'text',
+        'occurred_at',
+        'created_at'
+      ),
+    },
     // connector_definitions (excludes: large *_config JSONB blobs)
     {
       name: 'connector_definitions',

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -1,4 +1,5 @@
 import type { DbClient } from '../db/client';
+import { slugToRuntimeConnectionId } from '../lobu/stores/connections-projection';
 import type { WatcherSource } from '../types/watchers';
 
 export type WatcherSourceKind = 'event' | 'entity' | 'metric';
@@ -117,40 +118,76 @@ function numericRef(value: string): number | null {
   return Number.isSafeInteger(n) && n > 0 ? n : null;
 }
 
-async function resolveFeedIds(sql: DbClient, organizationId: string, value: string): Promise<number[]> {
+interface ResolvedFeed {
+  id: number;
+  kind: string;
+  /** `connections.slug` of the feed's connection (for the channel-messages path). */
+  connectionSlug: string;
+  feedKey: string;
+}
+
+async function resolveFeeds(
+  sql: DbClient,
+  organizationId: string,
+  value: string
+): Promise<ResolvedFeed[]> {
   const id = numericRef(value);
-  const rows = await sql<{ id: number | string; kind: string | null }>`
-    SELECT id, kind
-    FROM feeds
-    WHERE organization_id = ${organizationId}
-      AND deleted_at IS NULL
+  const rows = await sql<{
+    id: number | string;
+    kind: string | null;
+    feed_key: string;
+    connection_slug: string;
+  }>`
+    SELECT f.id, f.kind, f.feed_key, c.slug AS connection_slug
+    FROM feeds f
+    JOIN connections c ON c.id = f.connection_id
+    WHERE f.organization_id = ${organizationId}
+      AND f.deleted_at IS NULL
+      AND c.deleted_at IS NULL
       AND (
-        ${id}::bigint IS NOT NULL AND id = ${id}::bigint
-        OR feed_key = ${value}
-        OR display_name = ${value}
+        ${id}::bigint IS NOT NULL AND f.id = ${id}::bigint
+        OR f.feed_key = ${value}
+        OR f.display_name = ${value}
       )
-    ORDER BY id
+    ORDER BY f.id
     LIMIT 100
   `;
-  // `@feed` sources compile to a SELECT over `events`, so only events-backed
-  // (`collected`) feeds can back one. A `streaming` feed's rows live in
-  // `channel_messages` and a `virtual` feed is an external live query — either
-  // would validate here and then read empty. Reject them with a clear error
-  // (loud, not silent) rather than compiling to a query that returns nothing.
-  const collected = rows.filter((r) => (r.kind ?? 'collected') === 'collected');
-  const ids = collected
-    .map((r) => Number(r.id))
-    .filter((n) => Number.isSafeInteger(n) && n > 0);
-  if (ids.length === 0) {
-    const other = rows.find((r) => (r.kind ?? 'collected') !== 'collected');
-    if (other) {
-      throw new Error(
-        `@feed:${value} is a ${other.kind} feed; only collected (events-backed) feeds can be an @feed source`
-      );
-    }
-    throw new Error(`@feed:${value} did not match any feed`);
-  }
-  return ids;
+  return rows
+    .map((r) => ({
+      id: Number(r.id),
+      kind: r.kind ?? 'collected',
+      connectionSlug: String(r.connection_slug),
+      feedKey: String(r.feed_key),
+    }))
+    .filter((r) => Number.isSafeInteger(r.id) && r.id > 0);
+}
+
+/** Strip a `platform:` prefix off a streaming feed_key to the bare channel id
+ *  that `channel_messages.channel_id` stores (mirror of read_feed). */
+function bareChannelId(feedKey: string): string {
+  return feedKey.includes(':') ? feedKey.slice(feedKey.indexOf(':') + 1) : feedKey;
+}
+
+/** Compile a set of streaming (chat-channel) feeds to a read over
+ *  `channel_messages`. The rows are membership-gated by the channel_messages CTE
+ *  in execute-data-sources — a headless watcher run reads only non-enforced
+ *  channels, so enforced-channel content never reaches the shared recap. */
+function channelMessagesSelect(feeds: ResolvedFeed[]): string {
+  const tuples = feeds
+    .map(
+      (f) =>
+        `(${sqlString(slugToRuntimeConnectionId(f.connectionSlug))}, ${sqlString(
+          bareChannelId(f.feedKey)
+        )})`
+    )
+    .join(', ');
+  return (
+    'SELECT id, organization_id, connection_id, platform, channel_id, thread_id, ' +
+    'platform_message_id, author_id, author_name, author_entity_id, is_bot, text, ' +
+    'occurred_at, created_at ' +
+    `FROM channel_messages WHERE (connection_id, channel_id) IN (${tuples}) ` +
+    'ORDER BY occurred_at DESC'
+  );
 }
 
 async function resolveConnectionId(
@@ -184,8 +221,29 @@ async function compileRefToQuery(
 ): Promise<string | null> {
   switch (ref.type) {
     case 'feed': {
-      const ids = await resolveFeedIds(sql, organizationId, ref.value);
-      return eventSelect(`feed_id IN (${ids.join(',')})`);
+      const feeds = await resolveFeeds(sql, organizationId, ref.value);
+      if (feeds.length === 0) throw new Error(`@feed:${ref.value} did not match any feed`);
+      const collected = feeds.filter((f) => f.kind === 'collected');
+      const streaming = feeds.filter((f) => f.kind === 'streaming');
+      // A `virtual` feed is an external live query with no stored rows — it has no
+      // read seam here, so reject it (loud) rather than compile to empty.
+      const other = feeds.find((f) => f.kind !== 'collected' && f.kind !== 'streaming');
+      if (collected.length === 0 && streaming.length === 0 && other) {
+        throw new Error(
+          `@feed:${ref.value} is a ${other.kind} feed; only collected or streaming feeds can be an @feed source`
+        );
+      }
+      // Don't mix data planes in one source — a collected feed reads `events`, a
+      // streaming feed reads `channel_messages`; a single SELECT can't span both.
+      if (collected.length > 0 && streaming.length > 0) {
+        throw new Error(
+          `@feed:${ref.value} matched both collected and streaming feeds; reference one kind`
+        );
+      }
+      if (streaming.length > 0) {
+        return channelMessagesSelect(streaming);
+      }
+      return eventSelect(`feed_id IN (${collected.map((f) => f.id).join(',')})`);
     }
     case 'connection': {
       const id = await resolveConnectionId(sql, organizationId, ref.value);

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -2,7 +2,11 @@ import type { DbClient } from '../db/client';
 import { slugToRuntimeConnectionId } from '../lobu/stores/connections-projection';
 import type { WatcherSource } from '../types/watchers';
 
-export type WatcherSourceKind = 'event' | 'entity' | 'metric';
+// 'channel' is a chat-transcript source (streaming feed → channel_messages). It
+// is prompt CONTEXT, not events: its rows must never be signed as event
+// content_ids (channel_messages.id is not an events.id — complete_window links
+// content_ids into watcher_window_events.event_id, an FK to events).
+export type WatcherSourceKind = 'event' | 'entity' | 'metric' | 'channel';
 
 export type WatcherSourceRef =
   | { type: 'feed'; value: string }
@@ -218,7 +222,7 @@ async function compileRefToQuery(
   sql: DbClient,
   organizationId: string,
   ref: WatcherSourceRef
-): Promise<string | null> {
+): Promise<{ query: string | null; kind: WatcherSourceKind }> {
   switch (ref.type) {
     case 'feed': {
       const feeds = await resolveFeeds(sql, organizationId, ref.value);
@@ -241,43 +245,52 @@ async function compileRefToQuery(
         );
       }
       if (streaming.length > 0) {
-        return channelMessagesSelect(streaming);
+        // 'channel' kind → prompt context only, NOT event-id-signed (see the type).
+        return { query: channelMessagesSelect(streaming), kind: 'channel' };
       }
-      return eventSelect(`feed_id IN (${collected.map((f) => f.id).join(',')})`);
+      return {
+        query: eventSelect(`feed_id IN (${collected.map((f) => f.id).join(',')})`),
+        kind: 'event',
+      };
     }
     case 'connection': {
       const id = await resolveConnectionId(sql, organizationId, ref.value);
-      return eventSelect(`connection_id = ${id}`);
+      return { query: eventSelect(`connection_id = ${id}`), kind: 'event' };
     }
     case 'connector': {
       if (!SAFE_CONNECTOR_RE.test(ref.value)) {
         throw new Error('@connector refs must be plain connector keys');
       }
-      return eventSelect(`connector_key = ${sqlString(ref.value)}`);
+      return { query: eventSelect(`connector_key = ${sqlString(ref.value)}`), kind: 'event' };
     }
     case 'channel': {
       const raw = ref.value.startsWith('#') ? ref.value.slice(1) : ref.value;
       const channel = sqlString(raw);
       const hashChannel = sqlString(`#${raw}`);
-      return eventSelect(
-        [
-          `metadata->>'channel' IN (${channel}, ${hashChannel})`,
-          `metadata->>'channel_name' IN (${channel}, ${hashChannel})`,
-          `metadata->>'channel_id' = ${raw ? channel : "''"}`,
-          `payload_data->>'channel' IN (${channel}, ${hashChannel})`,
-          `payload_data->>'channel_name' IN (${channel}, ${hashChannel})`,
-          `payload_data->>'channel_id' = ${raw ? channel : "''"}`,
-        ].join(' OR ')
-      );
+      return {
+        query: eventSelect(
+          [
+            `metadata->>'channel' IN (${channel}, ${hashChannel})`,
+            `metadata->>'channel_name' IN (${channel}, ${hashChannel})`,
+            `metadata->>'channel_id' = ${raw ? channel : "''"}`,
+            `payload_data->>'channel' IN (${channel}, ${hashChannel})`,
+            `payload_data->>'channel_name' IN (${channel}, ${hashChannel})`,
+            `payload_data->>'channel_id' = ${raw ? channel : "''"}`,
+          ].join(' OR ')
+        ),
+        kind: 'event',
+      };
     }
     case 'entity':
-      return (
-        'SELECT id, entity_type, entity_type_id, parent_id, name, slug, metadata, created_at, updated_at ' +
-        `FROM entities WHERE entity_type = ${sqlString(ref.value)} AND deleted_at IS NULL ` +
-        'ORDER BY updated_at DESC'
-      );
+      return {
+        query:
+          'SELECT id, entity_type, entity_type_id, parent_id, name, slug, metadata, created_at, updated_at ' +
+          `FROM entities WHERE entity_type = ${sqlString(ref.value)} AND deleted_at IS NULL ` +
+          'ORDER BY updated_at DESC',
+        kind: 'entity',
+      };
     case 'metric':
-      return null;
+      return { query: null, kind: 'metric' };
   }
 }
 
@@ -374,8 +387,7 @@ export async function normalizeWatcherSources(
       normalized.push({ ...source, kind: 'event' });
       continue;
     }
-    const kind = watcherSourceKindForRef(ref);
-    const query = await compileRefToQuery(sql, organizationId, ref);
+    const { query, kind } = await compileRefToQuery(sql, organizationId, ref);
     normalized.push({
       name: source.name,
       query: query ?? source.query,


### PR DESCRIPTION
The third watcher follow-up: let a streaming (chat-channel) feed be a watcher `@feed` source, reading the channel transcript from `channel_messages` instead of `events`.

## Why this was previously rejected — and the leak it would have caused
`source-refs.ts` rejected streaming feeds because the source compiler only reads `events`. Naively compiling to `channel_messages` would **leak channel content**: watcher runs are headless (null principal) and the recap (`watcher_windows.extracted_data`) is read **org-only**, so summarized content from a Slack channel would reach every org member regardless of channel membership.

## Made safe — gate the read per row
- **`compileChannelMessagesVisibility`** (new, `authz/channel-messages-visibility.ts`) — the SQL analog of `filterChannelsForRequester`. A row on a **not-enforced** connection is unconstrained (the same legacy/org-open passthrough the whole authz program uses); a row on an **ACL-enforced** Slack connection is visible only when the requester is `member_of` the channel entity (`slack_channel_id = UPPER(team:channel)`, team from `channel_messages.team_id` or its connection). **Fail-closed**: a headless/null principal reads only non-enforced channels, so enforced-channel content never reaches the shared recap. This is Option 1 — enforced channels simply read empty at ingest, so there's nothing to leak.
- **`channel_messages` added to the queryable schema** with that gate wired into its CTE in `execute-data-sources` (it was deliberately *off* the allowlist until it had a gate). `query_sql` inherits the same membership gate for free.
- **`source-refs`** — a streaming `@feed` compiles to a `channel_messages` read over its `(connection_id, channel_id)` pairs; collected feeds still read `events`; mixing planes in one source, or a `virtual` feed, is rejected loudly.

Key-space alignment verified: `channel_messages.connection_id` and `authz_source_acl_state.connection_id` are both the runtime connection id (`persistChannelMessage` / `slack-acl-sync`), so the enforced-set check compares like-for-like.

## E2E (`channel-feed-source.test.ts`) — each verified load-bearing
The leak case was confirmed to go **red** when the CTE gate is removed (the headless watcher reads the enforced channel's 2 secret messages):

- headless watcher reads a **non-enforced** channel's transcript;
- headless watcher reads **NOTHING** from an **ACL-enforced** channel (no leak);
- a channel **member** reads the enforced channel (the gate is membership, not blanket denial).

`source-id-and-cross-org` updated: a streaming `@feed` is now **accepted** at create. `table-schema` drift-detection green (`channel_messages` fully listed). Existing query-engine + authz-gate suites unaffected (query-tool, datasource-column-masking, authz-e2e-demo, per-user-connection-visibility all green). `tsc` + biome clean.

## Follow-up (Option 2, deliberately deferred)
Enforced channels read *empty* rather than per-viewer content. Making the recap itself per-viewer (link windows to the channel resource entity + gate the `watcher_windows` read by `member_of`) is a larger re-architecture — the recap becomes per-viewer and summaries blend sources — tracked as the scalable next step.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785512027&installation_id=136316292&pr_number=1662&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1662&signature=4497ff4fbebc2bbac71f0d51aa56afc01e7b8c549185f0e4b62d76e9dc4d040e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `@feed` references now support streaming chat-channel feeds, enabling watcher reads from channel message transcripts.
  * Transcript visibility is now gated by channel membership when ACL enforcement is enabled.
* **Bug Fixes**
  * Headless/unenforced connections correctly return channel messages.
  * ACL-enforced channels hide transcripts unless the reader is a channel member; stale ACL snapshots fail closed.
  * Streaming `@feed` refs are now accepted and compiled to the correct transcript source.
* **Tests**
  * Added integration coverage for streaming feed compilation and ACL/membership visibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->