### PR TITLE
feat(slack): marketplace / Slack-initiated install → pending claim flow

### DIFF
--- a/db/migrations/20260701120000_app_installations_pending_orgless.sql
+++ b/db/migrations/20260701120000_app_installations_pending_orgless.sql
@@ -1,0 +1,36 @@
+-- migrate:up
+
+-- Marketplace / Slack-initiated installs arrive with a bot token but no Lobu org
+-- (the installer hasn't identified themselves in Lobu yet). Park them as an
+-- unclaimed `pending` app_installations row — org-less — until an admin claims
+-- the workspace by signing in with Slack. Routing already ignores non-`active`
+-- rows (`resolveActiveByTenant` filters status='active'; the active-tenant unique
+-- index is partial on active), so a pending row is inert until claimed.
+--
+-- The only blocker to reusing app_installations for this was organization_id
+-- NOT NULL. Relax it, but keep the invariant explicit: org may be null ONLY while
+-- the row is pending. On claim, the org is set and status flips to active.
+
+ALTER TABLE public.app_installations
+    ALTER COLUMN organization_id DROP NOT NULL;
+
+-- NOT VALID first so we don't take an ACCESS EXCLUSIVE full-table scan lock;
+-- VALIDATE separately takes only a lighter SHARE UPDATE EXCLUSIVE lock.
+ALTER TABLE public.app_installations
+    ADD CONSTRAINT app_installations_org_or_pending
+    CHECK (organization_id IS NOT NULL OR status = 'pending') NOT VALID;
+
+ALTER TABLE public.app_installations
+    VALIDATE CONSTRAINT app_installations_org_or_pending;
+
+-- migrate:down
+
+ALTER TABLE public.app_installations
+    DROP CONSTRAINT IF EXISTS app_installations_org_or_pending;
+
+-- Backfill guard: DROP NOT NULL is only reversible if no null orgs remain.
+-- Pending/unclaimed rows must be cleared before reverting (they have null org).
+DELETE FROM public.app_installations WHERE organization_id IS NULL;
+
+ALTER TABLE public.app_installations
+    ALTER COLUMN organization_id SET NOT NULL;

--- a/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
@@ -161,6 +161,10 @@ function buildRouter(
 	const deps: AppInstallRouterDeps = {
 		installationStore: createPostgresAppInstallationStore(),
 		resolveInstallOrgId: async () => installOrgId,
+		// The completing user is a member of the org they resolve to; the CSRF
+		// fixation test drives a state org ≠ installOrgId → not a member → reject.
+		verifyInstallOrgAccess: async (_c, organizationId) =>
+			organizationId === installOrgId,
 		getPublicGatewayUrl: () =>
 			opts.publicGatewayUrl === undefined
 				? PUBLIC_GATEWAY_URL

--- a/packages/server/src/__tests__/integration/connectors/install-org-explicit.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/install-org-explicit.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Install-flow org resolution — the connection lands in the org the user was
+ * VIEWING (threaded as `?org=<slug>`), authorized by membership, NOT the
+ * session's ambient active org.
+ *
+ * Regression: the connectors UI showed org A while the session's active org was
+ * B, so `resolveInstallOrgId` (session-only) bound the install to B and the
+ * connection was created in the wrong tenant. These tests prove the explicit
+ * `?org=` target wins over the ambient session org, that a non-member request is
+ * rejected (no silent fallback), and that completion authorization is by
+ * membership (`verifyInstallOrgAccess`).
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import {
+	resolveInstallOrgId,
+	verifyInstallOrgAccess,
+} from "../../../gateway/routes/public/install-org";
+import { initWorkspaceProvider } from "../../../workspace";
+import {
+	addUserToOrganization,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+/**
+ * Build a tiny app that runs the REAL install-org resolvers under a stubbed auth
+ * context — `user` + session `organizationId` mimic what `createLobuAuthBridge`
+ * stamps. `GET /resolve?org=…&verify=…` returns `{ org, access }` so a single
+ * request exercises both `resolveInstallOrgId` and `verifyInstallOrgAccess`
+ * against the real DB.
+ */
+function buildApp(session: { userId: string | null; activeOrg: string | null }) {
+	const app = new Hono();
+	app.use("*", async (c, next) => {
+		c.set("user" as never, session.userId ? { id: session.userId } : null);
+		if (session.activeOrg) c.set("organizationId" as never, session.activeOrg);
+		await next();
+	});
+	app.get("/resolve", async (c) => {
+		const org = await resolveInstallOrgId(c);
+		const verifyTarget = c.req.query("verify");
+		const access = verifyTarget
+			? await verifyInstallOrgAccess(c, verifyTarget)
+			: null;
+		return c.json({ org, access });
+	});
+	return app;
+}
+
+beforeAll(async () => {
+	await initWorkspaceProvider();
+});
+
+describe("install-flow org resolution (?org= explicit target)", () => {
+	it("honors ?org=<slug> over the ambient session org when the user is a member", async () => {
+		const viewedOrg = await createTestOrganization({ name: "Viewed Org" });
+		const ambientOrg = await createTestOrganization({
+			name: "Ambient Session Org",
+		});
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, viewedOrg.id);
+		await addUserToOrganization(user.id, ambientOrg.id);
+
+		// Session's active org is the AMBIENT org (the bug: it drifts from the UI).
+		const app = buildApp({ userId: user.id, activeOrg: ambientOrg.id });
+		const res = await app.request(`/resolve?org=${viewedOrg.slug}`);
+		const body = (await res.json()) as { org: string | null };
+
+		// Explicit ?org= wins — the connection lands in the VIEWED org, not ambient.
+		expect(body.org).toBe(viewedOrg.id);
+	});
+
+	it("rejects ?org=<slug> when the user is NOT a member (no silent fallback)", async () => {
+		const foreignOrg = await createTestOrganization({ name: "Foreign Org" });
+		const homeOrg = await createTestOrganization({ name: "Home Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, homeOrg.id);
+
+		const app = buildApp({ userId: user.id, activeOrg: homeOrg.id });
+		const res = await app.request(`/resolve?org=${foreignOrg.slug}`);
+		const body = (await res.json()) as { org: string | null };
+
+		// Not a member of the requested org → null (the route rejects). It must NOT
+		// silently retarget to the session's home org.
+		expect(body.org).toBeNull();
+	});
+
+	it("falls back to the session org when no ?org= is provided", async () => {
+		const org = await createTestOrganization({ name: "Session Only Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id);
+
+		const app = buildApp({ userId: user.id, activeOrg: org.id });
+		const res = await app.request(`/resolve`);
+		const body = (await res.json()) as { org: string | null };
+
+		expect(body.org).toBe(org.id);
+	});
+
+	it("verifyInstallOrgAccess is true for a member and false for a non-member", async () => {
+		const org = await createTestOrganization({ name: "Access Org" });
+		const member = await createTestUser();
+		const outsider = await createTestUser();
+		await addUserToOrganization(member.id, org.id);
+
+		const memberApp = buildApp({ userId: member.id, activeOrg: org.id });
+		const memberRes = await memberApp.request(`/resolve?verify=${org.id}`);
+		expect(((await memberRes.json()) as { access: boolean }).access).toBe(true);
+
+		const outsiderApp = buildApp({ userId: outsider.id, activeOrg: null });
+		const outsiderRes = await outsiderApp.request(`/resolve?verify=${org.id}`);
+		expect(((await outsiderRes.json()) as { access: boolean }).access).toBe(
+			false,
+		);
+	});
+});

--- a/packages/server/src/gateway/__tests__/slack-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim.test.ts
@@ -30,7 +30,6 @@ function pendingInstall(
     installerUserId: "U-INSTALLER",
     botToken: "xoxb-workspace-token",
     isEnterpriseInstall: false,
-    claimTokenHash: null,
     ...overrides,
   };
 }

--- a/packages/server/src/gateway/__tests__/slack-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Phase 3 of the Slack marketplace "claim" flow: `claimSlackWorkspace` binds a
+ * parked (pending) install to the claiming user's org, but only after proving
+ * the caller holds the single-use token, signed in with Slack for the workspace,
+ * and is a workspace admin/owner.
+ *
+ * Pure unit test — `claimSlackWorkspace` takes every dependency by injection, so
+ * no DB / HTTP / server boot is needed. We assert the guard ordering and, on the
+ * happy path, that the bind (`claim`) runs with the resolved org.
+ */
+
+import { createHash } from "node:crypto";
+import { describe, expect, mock, test } from "bun:test";
+import type { SlackPendingInstall } from "../../lobu/stores/slack-installations.js";
+import {
+  claimSlackWorkspace,
+  type SlackClaimDeps,
+} from "../connections/slack-claim.js";
+
+const TEAM = "T-CLAIM";
+const REAL_TOKEN = "claim-token-abc";
+const REAL_TOKEN_HASH = createHash("sha256").update(REAL_TOKEN).digest("hex");
+
+function pendingInstall(
+  overrides: Partial<SlackPendingInstall> = {},
+): SlackPendingInstall {
+  return {
+    id: "1",
+    teamId: TEAM,
+    teamName: "Acme",
+    botUserId: "B123",
+    installerUserId: "U-INSTALLER",
+    botToken: "xoxb-workspace-token",
+    isEnterpriseInstall: false,
+    claimTokenHash: REAL_TOKEN_HASH,
+    ...overrides,
+  };
+}
+
+/** Deps that reach the happy path; individual tests override single fields. */
+function makeDeps(overrides: Partial<SlackClaimDeps> = {}): {
+  deps: SlackClaimDeps;
+  claim: ReturnType<typeof mock>;
+} {
+  const claim = mock(async () => ({ installationId: "slackinst-bound" }));
+  const deps: SlackClaimDeps = {
+    resolvePending: mock(async () => pendingInstall()),
+    resolveClaimerSlackId: mock(async () => "U-ADMIN"),
+    usersInfo: mock(async () => ({ isAdmin: true, isOwner: false })),
+    resolveDefaultOrgId: mock(async () => "org-1"),
+    claim,
+    resolveOrgSlug: mock(async () => "acme"),
+    ...overrides,
+  };
+  return { deps, claim };
+}
+
+const input = { userId: "user-1", team: TEAM, token: REAL_TOKEN };
+
+describe("claimSlackWorkspace", () => {
+  test("binds the workspace on the happy path (admin + valid token)", async () => {
+    const { deps, claim } = makeDeps();
+    const result = await claimSlackWorkspace(deps, input);
+
+    expect(result).toEqual({
+      status: "ok",
+      orgSlug: "acme",
+      installationId: "slackinst-bound",
+    });
+    // Bound into the resolved org with the pending row's decrypted token.
+    expect(claim).toHaveBeenCalledTimes(1);
+    const [boundPending, boundOrg] = claim.mock.calls[0]!;
+    expect((boundPending as SlackPendingInstall).teamId).toBe(TEAM);
+    expect(boundOrg).toBe("org-1");
+  });
+
+  test("owner (not admin) is also allowed to claim", async () => {
+    const { deps } = makeDeps({
+      usersInfo: mock(async () => ({ isAdmin: false, isOwner: true })),
+    });
+    const result = await claimSlackWorkspace(deps, input);
+    expect(result.status).toBe("ok");
+  });
+
+  test("rejects a wrong claim token and never binds", async () => {
+    const { deps, claim } = makeDeps();
+    const result = await claimSlackWorkspace(deps, {
+      ...input,
+      token: "not-the-token",
+    });
+    expect(result).toEqual({ status: "invalid_token" });
+    expect(claim).not.toHaveBeenCalled();
+  });
+
+  test("rejects when the pending row carries no claim hash", async () => {
+    const { deps, claim } = makeDeps({
+      resolvePending: mock(async () =>
+        pendingInstall({ claimTokenHash: null }),
+      ),
+    });
+    const result = await claimSlackWorkspace(deps, input);
+    expect(result).toEqual({ status: "invalid_token" });
+    expect(claim).not.toHaveBeenCalled();
+  });
+
+  test("rejects a non-admin, non-owner and never binds", async () => {
+    const { deps, claim } = makeDeps({
+      usersInfo: mock(async () => ({ isAdmin: false, isOwner: false })),
+    });
+    const result = await claimSlackWorkspace(deps, input);
+    expect(result).toEqual({ status: "not_admin" });
+    expect(claim).not.toHaveBeenCalled();
+  });
+
+  test("requires Slack sign-in for the workspace before the admin check", async () => {
+    const usersInfo = mock(async () => ({ isAdmin: true, isOwner: true }));
+    const { deps, claim } = makeDeps({
+      resolveClaimerSlackId: mock(async () => null),
+      usersInfo,
+    });
+    const result = await claimSlackWorkspace(deps, input);
+    expect(result).toEqual({ status: "slack_signin_required" });
+    // Short-circuits before ever calling Slack or binding.
+    expect(usersInfo).not.toHaveBeenCalled();
+    expect(claim).not.toHaveBeenCalled();
+  });
+
+  test("404s when there is no pending install for the team", async () => {
+    const { deps } = makeDeps({ resolvePending: mock(async () => null) });
+    const result = await claimSlackWorkspace(deps, input);
+    expect(result).toEqual({ status: "no_pending_install" });
+  });
+
+  test("409s when the user has no default org", async () => {
+    const { deps, claim } = makeDeps({
+      resolveDefaultOrgId: mock(async () => null),
+    });
+    const result = await claimSlackWorkspace(deps, input);
+    expect(result).toEqual({ status: "no_org" });
+    expect(claim).not.toHaveBeenCalled();
+  });
+
+  test("401s an unauthenticated caller before any work", async () => {
+    const { deps } = makeDeps();
+    const resolvePending = deps.resolvePending as ReturnType<typeof mock>;
+    const result = await claimSlackWorkspace(deps, { ...input, userId: null });
+    expect(result).toEqual({ status: "unauthenticated" });
+    expect(resolvePending).not.toHaveBeenCalled();
+  });
+
+  test("400s a missing team or token", async () => {
+    const { deps } = makeDeps();
+    expect(
+      (await claimSlackWorkspace(deps, { ...input, team: "" })).status,
+    ).toBe("invalid_request");
+    expect(
+      (await claimSlackWorkspace(deps, { ...input, token: "" })).status,
+    ).toBe("invalid_request");
+  });
+
+  test("maps an unexpected bind failure to claim_failed", async () => {
+    const { deps } = makeDeps({
+      claim: mock(async () => {
+        throw new Error("secret store unavailable");
+      }),
+    });
+    const result = await claimSlackWorkspace(deps, input);
+    expect(result).toEqual({
+      status: "claim_failed",
+      message: "secret store unavailable",
+    });
+  });
+});

--- a/packages/server/src/gateway/__tests__/slack-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim.test.ts
@@ -1,15 +1,15 @@
 /**
- * Phase 3 of the Slack marketplace "claim" flow: `claimSlackWorkspace` binds a
- * parked (pending) install to the claiming user's org, but only after proving
- * the caller holds the single-use token, signed in with Slack for the workspace,
- * and is a workspace admin/owner.
+ * The Slack marketplace "claim" flow: `claimSlackWorkspace` binds a parked
+ * (pending) install to the claiming user's org. Authority is the Slack
+ * workspace-admin check — the caller must have signed in with Slack for the
+ * workspace and be an admin/owner. There is NO secret link token; a signed-in
+ * admin can always connect a pending install for their team.
  *
  * Pure unit test — `claimSlackWorkspace` takes every dependency by injection, so
  * no DB / HTTP / server boot is needed. We assert the guard ordering and, on the
  * happy path, that the bind (`claim`) runs with the resolved org.
  */
 
-import { createHash } from "node:crypto";
 import { describe, expect, mock, test } from "bun:test";
 import type { SlackPendingInstall } from "../../lobu/stores/slack-installations.js";
 import {
@@ -18,8 +18,6 @@ import {
 } from "../connections/slack-claim.js";
 
 const TEAM = "T-CLAIM";
-const REAL_TOKEN = "claim-token-abc";
-const REAL_TOKEN_HASH = createHash("sha256").update(REAL_TOKEN).digest("hex");
 
 function pendingInstall(
   overrides: Partial<SlackPendingInstall> = {},
@@ -32,7 +30,7 @@ function pendingInstall(
     installerUserId: "U-INSTALLER",
     botToken: "xoxb-workspace-token",
     isEnterpriseInstall: false,
-    claimTokenHash: REAL_TOKEN_HASH,
+    claimTokenHash: null,
     ...overrides,
   };
 }
@@ -45,8 +43,13 @@ function makeDeps(overrides: Partial<SlackClaimDeps> = {}): {
   const claim = mock(async () => ({ installationId: "slackinst-bound" }));
   const deps: SlackClaimDeps = {
     resolvePending: mock(async () => pendingInstall()),
+    resolveActiveOrgSlug: mock(async () => null),
     resolveClaimerSlackId: mock(async () => "U-ADMIN"),
     usersInfo: mock(async () => ({ isAdmin: true, isOwner: false })),
+    resolveMemberOrgs: mock(async () => [
+      { id: "org-1", slug: "acme", name: "Acme" },
+    ]),
+    resolveOrgIfMember: mock(async () => "org-1"),
     resolveDefaultOrgId: mock(async () => "org-1"),
     claim,
     resolveOrgSlug: mock(async () => "acme"),
@@ -55,10 +58,10 @@ function makeDeps(overrides: Partial<SlackClaimDeps> = {}): {
   return { deps, claim };
 }
 
-const input = { userId: "user-1", team: TEAM, token: REAL_TOKEN };
+const input = { userId: "user-1", team: TEAM };
 
 describe("claimSlackWorkspace", () => {
-  test("binds the workspace on the happy path (admin + valid token)", async () => {
+  test("binds the workspace on the happy path (signed-in admin)", async () => {
     const { deps, claim } = makeDeps();
     const result = await claimSlackWorkspace(deps, input);
 
@@ -82,24 +85,32 @@ describe("claimSlackWorkspace", () => {
     expect(result.status).toBe("ok");
   });
 
-  test("rejects a wrong claim token and never binds", async () => {
-    const { deps, claim } = makeDeps();
+  test("binds into the explicitly chosen org (membership-verified)", async () => {
+    const { deps, claim } = makeDeps({
+      resolveOrgIfMember: mock(async () => "org-2"),
+      resolveOrgSlug: mock(async () => "other-org"),
+    });
     const result = await claimSlackWorkspace(deps, {
       ...input,
-      token: "not-the-token",
+      organizationId: "other-org",
     });
-    expect(result).toEqual({ status: "invalid_token" });
-    expect(claim).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "ok",
+      orgSlug: "other-org",
+      installationId: "slackinst-bound",
+    });
+    expect(claim.mock.calls[0]![1]).toBe("org-2");
   });
 
-  test("rejects when the pending row carries no claim hash", async () => {
+  test("rejects binding into an org the user is not a member of", async () => {
     const { deps, claim } = makeDeps({
-      resolvePending: mock(async () =>
-        pendingInstall({ claimTokenHash: null }),
-      ),
+      resolveOrgIfMember: mock(async () => null),
     });
-    const result = await claimSlackWorkspace(deps, input);
-    expect(result).toEqual({ status: "invalid_token" });
+    const result = await claimSlackWorkspace(deps, {
+      ...input,
+      organizationId: "not-mine",
+    });
+    expect(result).toEqual({ status: "not_member_of_org" });
     expect(claim).not.toHaveBeenCalled();
   });
 
@@ -125,8 +136,26 @@ describe("claimSlackWorkspace", () => {
     expect(claim).not.toHaveBeenCalled();
   });
 
-  test("404s when there is no pending install for the team", async () => {
-    const { deps } = makeDeps({ resolvePending: mock(async () => null) });
+  test("already-connected workspace is an idempotent success", async () => {
+    const { deps, claim } = makeDeps({
+      resolvePending: mock(async () => null),
+      resolveActiveOrgSlug: mock(async () => "acme"),
+    });
+    const result = await claimSlackWorkspace(deps, input);
+    expect(result).toEqual({
+      status: "ok",
+      orgSlug: "acme",
+      installationId: "",
+      alreadyConnected: true,
+    });
+    expect(claim).not.toHaveBeenCalled();
+  });
+
+  test("404s when the workspace has no install at all", async () => {
+    const { deps } = makeDeps({
+      resolvePending: mock(async () => null),
+      resolveActiveOrgSlug: mock(async () => null),
+    });
     const result = await claimSlackWorkspace(deps, input);
     expect(result).toEqual({ status: "no_pending_install" });
   });
@@ -148,13 +177,10 @@ describe("claimSlackWorkspace", () => {
     expect(resolvePending).not.toHaveBeenCalled();
   });
 
-  test("400s a missing team or token", async () => {
+  test("400s a missing team", async () => {
     const { deps } = makeDeps();
     expect(
       (await claimSlackWorkspace(deps, { ...input, team: "" })).status,
-    ).toBe("invalid_request");
-    expect(
-      (await claimSlackWorkspace(deps, { ...input, token: "" })).status,
     ).toBe("invalid_request");
   });
 

--- a/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Phase 2 of the Slack marketplace "claim" flow: after a Slack-initiated
+ * (marketplace) install is parked as a pending, unclaimed row,
+ * `completeSlackPendingInstall` DMs the INSTALLER a single-use claim link.
+ *
+ * This unit test stubs the Slack Web API (no HTTP), the pending-install store
+ * (no DB), and the hosted-app credentials so the DM behaviour is exercised in
+ * isolation. It proves: (1) with an installer id, `openDm` + `postMessage` are
+ * called and the posted text carries the claim URL with the team + a token whose
+ * sha256 matches the hash persisted on the pending row; (2) with a null
+ * installer, no DM is sent and no claim hash is stored — the row is still parked.
+ */
+
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { __resetPublicOriginCachesForTests } from "../../utils/public-origin.js";
+
+// --- Stub the pending-install store: capture inputs, never touch Postgres. ---
+const writeCalls: Array<Record<string, unknown>> = [];
+mock.module("../../lobu/stores/slack-installations.js", () => ({
+  writeSlackPendingInstall: mock(async (input: Record<string, unknown>) => {
+    writeCalls.push(input);
+    return { id: "1" };
+  }),
+  // Also imported by the coordinator module (webhook routing); unused here.
+  getSlackInstallByTeamId: mock(async () => null),
+  upsertSlackInstallByTeam: mock(async () => ({ id: "slackinst-x" })),
+}));
+
+// --- Hosted app credentials are configured (so the exchange path runs). ---
+mock.module("../installation/app-install-credentials.js", () => ({
+  getPrimedBundledMethod: () => ({}),
+  resolveAppInstallCredentials: () => ({
+    clientId: "client-id",
+    clientSecret: "client-secret",
+  }),
+}));
+
+// --- Stub the Slack Web API surface the coordinator uses. ---
+const exchangeOAuthCode = mock(
+  async (): Promise<{
+    botToken: string;
+    teamId: string;
+    teamName: string | null;
+    botUserId: string | null;
+    authedUserId: string | null;
+    isEnterpriseInstall: boolean;
+  }> => ({
+    botToken: "xoxb-installer-token",
+    teamId: "T-CLAIM",
+    teamName: "Acme",
+    botUserId: "B123",
+    authedUserId: "U-INSTALLER",
+    isEnterpriseInstall: false,
+  }),
+);
+const openDm = mock(async () => "D-INSTALLER");
+const postMessage = mock(async () => undefined);
+mock.module("../connections/slack-web.js", () => ({
+  createSlackWebApi: () => ({ exchangeOAuthCode, openDm, postMessage }),
+}));
+
+async function loadCoordinator() {
+  const mod = await import("../connections/slack-connection-coordinator.js");
+  return mod.completeSlackPendingInstall;
+}
+
+function callbackRequest(): Request {
+  return new Request(
+    "https://gateway.example.com/slack/oauth_callback?code=the-code",
+    { method: "GET" },
+  );
+}
+
+describe("completeSlackPendingInstall — installer claim DM", () => {
+  let savedWebUrl: string | undefined;
+
+  beforeEach(() => {
+    writeCalls.length = 0;
+    exchangeOAuthCode.mockClear();
+    openDm.mockClear();
+    postMessage.mockClear();
+    savedWebUrl = process.env.PUBLIC_WEB_URL;
+    process.env.PUBLIC_WEB_URL = "https://app.lobu.ai";
+    __resetPublicOriginCachesForTests();
+  });
+
+  afterEach(() => {
+    if (savedWebUrl === undefined) delete process.env.PUBLIC_WEB_URL;
+    else process.env.PUBLIC_WEB_URL = savedWebUrl;
+    __resetPublicOriginCachesForTests();
+  });
+
+  test("DMs the installer a claim link carrying the team + token, and stores only the hash", async () => {
+    const completeSlackPendingInstall = await loadCoordinator();
+
+    const result = await completeSlackPendingInstall(
+      callbackRequest(),
+      "https://gateway.example.com/slack/oauth_callback",
+    );
+
+    expect(result).toEqual({
+      teamId: "T-CLAIM",
+      teamName: "Acme",
+      installerUserId: "U-INSTALLER",
+    });
+
+    // The DM is opened with the installer and the message is posted into it.
+    expect(openDm).toHaveBeenCalledTimes(1);
+    expect(openDm).toHaveBeenCalledWith("xoxb-installer-token", "U-INSTALLER");
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    const [botToken, channel, text] = postMessage.mock.calls[0] as [
+      string,
+      string,
+      string,
+    ];
+    expect(botToken).toBe("xoxb-installer-token");
+    expect(channel).toBe("D-INSTALLER");
+
+    // The posted text embeds the claim URL with the team id and a token.
+    const match = text.match(
+      /https:\/\/app\.lobu\.ai\/slack\/claim\?team=([^&\s]+)&t=([^\s]+)/,
+    );
+    expect(match).not.toBeNull();
+    const [, teamParam, tokenParam] = match as RegExpMatchArray;
+    expect(decodeURIComponent(teamParam)).toBe("T-CLAIM");
+    expect(tokenParam.length).toBeGreaterThan(0);
+
+    // Only the sha256 hash of the token is persisted on the pending row — never
+    // the plaintext token itself.
+    expect(writeCalls).toHaveLength(1);
+    const parked = writeCalls[0]!;
+    expect(parked.installerUserId).toBe("U-INSTALLER");
+    const expectedHash = createHash("sha256")
+      .update(tokenParam)
+      .digest("hex");
+    expect(parked.claimTokenHash).toBe(expectedHash);
+    expect(JSON.stringify(parked)).not.toContain(tokenParam);
+  });
+
+  test("skips the DM when there is no installer, but still parks the pending row", async () => {
+    exchangeOAuthCode.mockResolvedValueOnce({
+      botToken: "xoxb-installer-token",
+      teamId: "T-NOINSTALLER",
+      teamName: null,
+      botUserId: null,
+      authedUserId: null,
+      isEnterpriseInstall: false,
+    });
+    const completeSlackPendingInstall = await loadCoordinator();
+
+    const result = await completeSlackPendingInstall(
+      callbackRequest(),
+      "https://gateway.example.com/slack/oauth_callback",
+    );
+
+    expect(result).toEqual({
+      teamId: "T-NOINSTALLER",
+      teamName: null,
+      installerUserId: null,
+    });
+    // No DM without an installer to send it to.
+    expect(openDm).not.toHaveBeenCalled();
+    expect(postMessage).not.toHaveBeenCalled();
+    // The row is still parked, with no claim token minted.
+    expect(writeCalls).toHaveLength(1);
+    expect(writeCalls[0]!.installerUserId).toBeNull();
+    expect(writeCalls[0]!.claimTokenHash).toBeNull();
+  });
+});

--- a/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
@@ -1,17 +1,16 @@
 /**
  * Phase 2 of the Slack marketplace "claim" flow: after a Slack-initiated
  * (marketplace) install is parked as a pending, unclaimed row,
- * `completeSlackPendingInstall` DMs the INSTALLER a single-use claim link.
+ * `completeSlackPendingInstall` DMs the INSTALLER their connect link.
  *
  * This unit test stubs the Slack Web API (no HTTP), the pending-install store
  * (no DB), and the hosted-app credentials so the DM behaviour is exercised in
  * isolation. It proves: (1) with an installer id, `openDm` + `postMessage` are
- * called and the posted text carries the claim URL with the team + a token whose
- * sha256 matches the hash persisted on the pending row; (2) with a null
- * installer, no DM is sent and no claim hash is stored — the row is still parked.
+ * called and the posted text carries the connect URL with the team id (no secret
+ * token — authority is the Slack workspace-admin check at claim time); (2) with a
+ * null installer, no DM is sent — the row is still parked.
  */
 
-import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { __resetPublicOriginCachesForTests } from "../../utils/public-origin.js";
 
@@ -24,6 +23,7 @@ mock.module("../../lobu/stores/slack-installations.js", () => ({
   }),
   // Also imported by the coordinator module (webhook routing); unused here.
   getSlackInstallByTeamId: mock(async () => null),
+  resolveSlackPendingByTenant: mock(async () => null),
   upsertSlackInstallByTeam: mock(async () => ({ id: "slackinst-x" })),
 }));
 
@@ -91,7 +91,7 @@ describe("completeSlackPendingInstall — installer claim DM", () => {
     __resetPublicOriginCachesForTests();
   });
 
-  test("DMs the installer a claim link carrying the team + token, and stores only the hash", async () => {
+  test("DMs the installer a connect link with the team id (no secret token)", async () => {
     const completeSlackPendingInstall = await loadCoordinator();
 
     const result = await completeSlackPendingInstall(
@@ -117,25 +117,20 @@ describe("completeSlackPendingInstall — installer claim DM", () => {
     expect(botToken).toBe("xoxb-installer-token");
     expect(channel).toBe("D-INSTALLER");
 
-    // The posted text embeds the claim URL with the team id and a token.
+    // The posted text embeds the connect URL with the team id — no secret token
+    // (authority is the Slack workspace-admin check at claim time).
     const match = text.match(
-      /https:\/\/app\.lobu\.ai\/slack\/claim\?team=([^&\s]+)&t=([^\s]+)/,
+      /https:\/\/app\.lobu\.ai\/slack\/claim\?team=([^&\s]+)/,
     );
     expect(match).not.toBeNull();
-    const [, teamParam, tokenParam] = match as RegExpMatchArray;
+    const [, teamParam] = match as RegExpMatchArray;
     expect(decodeURIComponent(teamParam)).toBe("T-CLAIM");
-    expect(tokenParam.length).toBeGreaterThan(0);
+    expect(text).not.toContain("&t=");
 
-    // Only the sha256 hash of the token is persisted on the pending row — never
-    // the plaintext token itself.
+    // The pending row is parked with the installer id and no token material.
     expect(writeCalls).toHaveLength(1);
     const parked = writeCalls[0]!;
     expect(parked.installerUserId).toBe("U-INSTALLER");
-    const expectedHash = createHash("sha256")
-      .update(tokenParam)
-      .digest("hex");
-    expect(parked.claimTokenHash).toBe(expectedHash);
-    expect(JSON.stringify(parked)).not.toContain(tokenParam);
   });
 
   test("skips the DM when there is no installer, but still parks the pending row", async () => {
@@ -162,9 +157,8 @@ describe("completeSlackPendingInstall — installer claim DM", () => {
     // No DM without an installer to send it to.
     expect(openDm).not.toHaveBeenCalled();
     expect(postMessage).not.toHaveBeenCalled();
-    // The row is still parked, with no claim token minted.
+    // The row is still parked (no installer to DM).
     expect(writeCalls).toHaveLength(1);
     expect(writeCalls[0]!.installerUserId).toBeNull();
-    expect(writeCalls[0]!.claimTokenHash).toBeNull();
   });
 });

--- a/packages/server/src/gateway/__tests__/slack-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-routes.test.ts
@@ -121,6 +121,12 @@ describe("slack OAuth install routes", () => {
         const fromCtx = c.get("organizationId" as never) as string | null | undefined;
         return typeof fromCtx === "string" && fromCtx.length > 0 ? fromCtx : null;
       },
+      // Membership stand-in: the completing user is a member of the target org
+      // iff their session-context org equals it. Drives the cross-org 403 test.
+      verifyInstallOrgAccess: async (c, organizationId) => {
+        const fromCtx = c.get("organizationId" as never) as string | null | undefined;
+        return typeof fromCtx === "string" && fromCtx === organizationId;
+      },
       getPublicGatewayUrl: () => "https://gateway.example.com",
       // The generic engine mounts /slack/install + /slack/oauth_callback from
       // this declared oauth-code-exchange integration; completion is dispatched

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -27,6 +27,7 @@ import { registerAutoOpenApiRoutes } from "../routes/openapi-auto.js";
 import { createAgentApi } from "../routes/public/agent.js";
 import { createAgentConfigRoutes } from "../routes/public/agent-config.js";
 import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
+import { completeSlackPendingInstall } from "../connections/slack-connection-coordinator.js";
 import { createAgentRoutes } from "../routes/public/agents.js";
 import {
   createInstallRoutes,
@@ -778,6 +779,12 @@ export function createGatewayApp(
             redirectUri,
             orgId,
           ),
+        // Marketplace / Slack-initiated installs (code, no Lobu state) → park as
+        // pending, unclaimed. Slack-only today; other providers dispatch here later.
+        completeChatPendingInstall: (provider, req, redirectUri) =>
+          provider === "slack"
+            ? completeSlackPendingInstall(req, redirectUri)
+            : Promise.resolve(null),
       }),
     );
     app.route(

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -45,7 +45,10 @@ import {
   createConnectionWebhookRoutes,
 } from "../routes/public/connections.js";
 import { createPublicFileRoutes } from "../routes/public/files.js";
-import { resolveInstallOrgId } from "../routes/public/install-org.js";
+import {
+  resolveInstallOrgId,
+  verifyInstallOrgAccess,
+} from "../routes/public/install-org.js";
 import { createLandingRoutes } from "../routes/public/landing.js";
 import {
   type AuthProvider,
@@ -760,6 +763,7 @@ export function createGatewayApp(
       createInstallRoutes({
         installationStore: createPostgresAppInstallationStore(),
         resolveInstallOrgId,
+        verifyInstallOrgAccess,
         getPublicGatewayUrl: () => coreServices.getPublicGatewayUrl(),
         integrations: (bundledIntegrationConnectors ?? []).map((integration) => ({
           connectorKey: integration.connectorKey,

--- a/packages/server/src/gateway/connections/__tests__/slack-unclaimed-reply.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-unclaimed-reply.test.ts
@@ -1,0 +1,122 @@
+/**
+ * `parseSlackUserMessageEvent` decides which incoming Slack webhook bodies are a
+ * real user @mention or DM that the unclaimed-workspace path should reply to.
+ * It must reply to app_mentions and direct messages, and stay silent for the
+ * bot's own messages, edits/subtypes, channel chatter, challenges, and
+ * non-event (slash/interactivity) payloads — otherwise the connect-link reply
+ * would spam or loop.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parseSlackUserMessageEvent } from "../slack-connection-coordinator.js";
+
+const JSON_CT = "application/json";
+
+function eventBody(event: Record<string, unknown>): string {
+  return JSON.stringify({ type: "event_callback", team_id: "T1", event });
+}
+
+describe("parseSlackUserMessageEvent", () => {
+  test("replies to an app_mention", () => {
+    const body = eventBody({
+      type: "app_mention",
+      channel: "C1",
+      user: "U1",
+      text: "<@B> hi",
+    });
+    expect(parseSlackUserMessageEvent(body, JSON_CT)).toEqual({
+      channel: "C1",
+      user: "U1",
+    });
+  });
+
+  test("replies to a direct message (channel_type im)", () => {
+    const body = eventBody({
+      type: "message",
+      channel: "D1",
+      channel_type: "im",
+      user: "U1",
+      text: "hey",
+    });
+    expect(parseSlackUserMessageEvent(body, JSON_CT)).toEqual({
+      channel: "D1",
+      user: "U1",
+    });
+  });
+
+  test("ignores a plain channel message (not a mention, not a DM)", () => {
+    const body = eventBody({
+      type: "message",
+      channel: "C1",
+      channel_type: "channel",
+      user: "U1",
+      text: "chatter",
+    });
+    expect(parseSlackUserMessageEvent(body, JSON_CT)).toBeNull();
+  });
+
+  test("ignores the bot's own message (bot_id present)", () => {
+    const body = eventBody({
+      type: "message",
+      channel: "D1",
+      channel_type: "im",
+      user: "U1",
+      bot_id: "B999",
+      text: "my own reply",
+    });
+    expect(parseSlackUserMessageEvent(body, JSON_CT)).toBeNull();
+  });
+
+  test("ignores a message edit/subtype in a DM", () => {
+    const body = eventBody({
+      type: "message",
+      channel: "D1",
+      channel_type: "im",
+      user: "U1",
+      subtype: "message_changed",
+      text: "edited",
+    });
+    expect(parseSlackUserMessageEvent(body, JSON_CT)).toBeNull();
+  });
+
+  test("ignores an event missing channel or user", () => {
+    expect(
+      parseSlackUserMessageEvent(
+        eventBody({ type: "app_mention", user: "U1" }),
+        JSON_CT,
+      ),
+    ).toBeNull();
+    expect(
+      parseSlackUserMessageEvent(
+        eventBody({ type: "app_mention", channel: "C1" }),
+        JSON_CT,
+      ),
+    ).toBeNull();
+  });
+
+  test("ignores a url_verification challenge", () => {
+    const body = JSON.stringify({ type: "url_verification", challenge: "x" });
+    expect(parseSlackUserMessageEvent(body, JSON_CT)).toBeNull();
+  });
+
+  test("ignores a non-event_callback envelope", () => {
+    const body = JSON.stringify({
+      type: "something_else",
+      event: { type: "app_mention", channel: "C1", user: "U1" },
+    });
+    expect(parseSlackUserMessageEvent(body, JSON_CT)).toBeNull();
+  });
+
+  test("ignores form-encoded (slash/interactivity) bodies", () => {
+    expect(
+      parseSlackUserMessageEvent(
+        "payload=%7B%7D",
+        "application/x-www-form-urlencoded",
+      ),
+    ).toBeNull();
+  });
+
+  test("ignores non-JSON bodies", () => {
+    expect(parseSlackUserMessageEvent("not json", JSON_CT)).toBeNull();
+  });
+});

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -1,0 +1,94 @@
+import { createHash } from "node:crypto";
+import type { SlackPendingInstall } from "../../lobu/stores/slack-installations.js";
+import type { SlackWebApi } from "./slack-web.js";
+
+/**
+ * The marketplace-claim decision, factored out of the HTTP route so it is
+ * unit-testable without booting the server. A Slack-initiated (marketplace)
+ * install lands as an org-less `pending` row (see `writeSlackPendingInstall`);
+ * this binds it to the claiming user's org once they prove they (a) hold the
+ * single-use claim token, (b) signed in with Slack for the workspace, and (c)
+ * are a workspace admin/owner. Every dependency is injected so the route can
+ * wire the real stores and tests can stub them; nothing here touches HTTP,
+ * Postgres, or the network directly.
+ */
+
+/** Discriminated outcome — the route maps each `status` to an HTTP code. */
+export type SlackClaimResult =
+  | { status: "ok"; orgSlug: string | null; installationId: string }
+  | { status: "unauthenticated" }
+  | { status: "invalid_request" }
+  | { status: "no_pending_install" }
+  | { status: "invalid_token" }
+  | { status: "slack_signin_required" }
+  | { status: "not_admin" }
+  | { status: "no_org" }
+  | { status: "claim_failed"; message: string };
+
+export interface SlackClaimDeps {
+  /** The parked pending install for a workspace, or null if none. */
+  resolvePending(team: string): Promise<SlackPendingInstall | null>;
+  /**
+   * The claiming user's bare `U…` Slack id for this workspace (from their
+   * team-scoped `slack_user_id` identity), or null if they never signed in with
+   * Slack for it.
+   */
+  resolveClaimerSlackId(userId: string, team: string): Promise<string | null>;
+  /** `users.info` admin/owner flags for the claimer. */
+  usersInfo: SlackWebApi["usersInfo"];
+  /** The claiming user's default org to bind into, or null if they have none. */
+  resolveDefaultOrgId(userId: string): Promise<string | null>;
+  /** Bind: persist the token + create the active install, returning its id. */
+  claim(
+    pending: SlackPendingInstall,
+    organizationId: string,
+  ): Promise<{ installationId: string }>;
+  /** The org's URL slug (for the success redirect), or null. */
+  resolveOrgSlug(organizationId: string): Promise<string | null>;
+}
+
+export async function claimSlackWorkspace(
+  deps: SlackClaimDeps,
+  input: { userId: string | null; team: string; token: string },
+): Promise<SlackClaimResult> {
+  if (!input.userId) return { status: "unauthenticated" };
+  if (!input.team || !input.token) return { status: "invalid_request" };
+
+  try {
+    const pending = await deps.resolvePending(input.team);
+    if (!pending) return { status: "no_pending_install" };
+
+    // Validate the presented token against the stored sha256 hash. A null hash
+    // (no claim link was ever minted) is unclaimable via this path.
+    const presentedHash = createHash("sha256")
+      .update(input.token)
+      .digest("hex");
+    if (!pending.claimTokenHash || presentedHash !== pending.claimTokenHash) {
+      return { status: "invalid_token" };
+    }
+
+    // The claimer must have signed in with Slack for THIS workspace, so we hold
+    // their team-scoped slack_user_id — the UI prompts sign-in on this code.
+    const bareUserId = await deps.resolveClaimerSlackId(
+      input.userId,
+      input.team,
+    );
+    if (!bareUserId) return { status: "slack_signin_required" };
+
+    // …and be a workspace admin/owner to bind the whole workspace.
+    const info = await deps.usersInfo(pending.botToken, bareUserId);
+    if (!info.isAdmin && !info.isOwner) return { status: "not_admin" };
+
+    const organizationId = await deps.resolveDefaultOrgId(input.userId);
+    if (!organizationId) return { status: "no_org" };
+
+    const { installationId } = await deps.claim(pending, organizationId);
+    const orgSlug = await deps.resolveOrgSlug(organizationId);
+    return { status: "ok", orgSlug, installationId };
+  } catch (err) {
+    return {
+      status: "claim_failed",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -11,19 +11,48 @@ import type { SlackWebApi } from "./slack-web.js";
  * are a workspace admin/owner. Every dependency is injected so the route can
  * wire the real stores and tests can stub them; nothing here touches HTTP,
  * Postgres, or the network directly.
+ *
+ * Split into two phases so the UI can CONFIRM the destination org before
+ * binding: `resolveSlackClaimContext` runs the authorization guards and returns
+ * the workspace + the claimer's eligible orgs (no write); `claimSlackWorkspace`
+ * re-runs the guards and binds to the org the user explicitly chose. Binding a
+ * whole workspace's data to an org is a decision, so it is never implicit.
  */
 
-/** Discriminated outcome — the route maps each `status` to an HTTP code. */
-export type SlackClaimResult =
-  | { status: "ok"; orgSlug: string | null; installationId: string }
+/** Shared authorization error statuses (each maps to an HTTP code in the route). */
+export type SlackClaimError =
   | { status: "unauthenticated" }
   | { status: "invalid_request" }
   | { status: "no_pending_install" }
   | { status: "invalid_token" }
   | { status: "slack_signin_required" }
   | { status: "not_admin" }
+  | { status: "not_member_of_org" }
   | { status: "no_org" }
   | { status: "claim_failed"; message: string };
+
+/** Terminal outcome of the bind (`claimSlackWorkspace`). */
+export type SlackClaimResult =
+  | { status: "ok"; orgSlug: string | null; installationId: string }
+  | SlackClaimError;
+
+/** A Lobu org the claimer may bind the workspace into. */
+export interface ClaimEligibleOrg {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+/** Confirmation context for the UI (`resolveSlackClaimContext`). */
+export type SlackClaimContext =
+  | {
+      status: "ready";
+      /** Human-readable workspace name for the confirm copy. */
+      workspaceName: string | null;
+      /** Orgs the claimer belongs to (the destination picker). */
+      orgs: ClaimEligibleOrg[];
+    }
+  | SlackClaimError;
 
 export interface SlackClaimDeps {
   /** The parked pending install for a workspace, or null if none. */
@@ -36,7 +65,15 @@ export interface SlackClaimDeps {
   resolveClaimerSlackId(userId: string, team: string): Promise<string | null>;
   /** `users.info` admin/owner flags for the claimer. */
   usersInfo: SlackWebApi["usersInfo"];
-  /** The claiming user's default org to bind into, or null if they have none. */
+  /** The orgs the claimer is a member of (the destination picker). */
+  resolveMemberOrgs(userId: string): Promise<ClaimEligibleOrg[]>;
+  /**
+   * Resolve an explicitly chosen org (slug or id) to its id IFF the user is a
+   * member, else null. Guards the confirm step so a user can only bind into an
+   * org they belong to.
+   */
+  resolveOrgIfMember(userId: string, orgSlugOrId: string): Promise<string | null>;
+  /** The claiming user's default org, when they didn't pick one explicitly. */
   resolveDefaultOrgId(userId: string): Promise<string | null>;
   /** Bind: persist the token + create the active install, returning its id. */
   claim(
@@ -47,42 +84,97 @@ export interface SlackClaimDeps {
   resolveOrgSlug(organizationId: string): Promise<string | null>;
 }
 
-export async function claimSlackWorkspace(
+/**
+ * Run the claim authorization guards (token hash → Slack sign-in → workspace
+ * admin) WITHOUT binding. Returns the pending install on success so callers can
+ * bind or preview.
+ */
+async function authorizeClaim(
   deps: SlackClaimDeps,
   input: { userId: string | null; team: string; token: string },
-): Promise<SlackClaimResult> {
+): Promise<{ status: "ready"; pending: SlackPendingInstall } | SlackClaimError> {
   if (!input.userId) return { status: "unauthenticated" };
   if (!input.team || !input.token) return { status: "invalid_request" };
 
+  const pending = await deps.resolvePending(input.team);
+  if (!pending) return { status: "no_pending_install" };
+
+  // Validate the presented token against the stored sha256 hash. A null hash
+  // (no claim link was ever minted) is unclaimable via this path.
+  const presentedHash = createHash("sha256").update(input.token).digest("hex");
+  if (!pending.claimTokenHash || presentedHash !== pending.claimTokenHash) {
+    return { status: "invalid_token" };
+  }
+
+  // The claimer must have signed in with Slack for THIS workspace, so we hold
+  // their team-scoped slack_user_id — the UI prompts sign-in on this code.
+  const bareUserId = await deps.resolveClaimerSlackId(input.userId, input.team);
+  if (!bareUserId) return { status: "slack_signin_required" };
+
+  // …and be a workspace admin/owner to bind the whole workspace.
+  const info = await deps.usersInfo(pending.botToken, bareUserId);
+  if (!info.isAdmin && !info.isOwner) return { status: "not_admin" };
+
+  return { status: "ready", pending };
+}
+
+/**
+ * Confirmation context: run the guards and return the workspace name + the
+ * claimer's eligible orgs, so the UI can show "Connect <workspace> to <org>"
+ * before any write. No mutation.
+ */
+export async function resolveSlackClaimContext(
+  deps: SlackClaimDeps,
+  input: { userId: string | null; team: string; token: string },
+): Promise<SlackClaimContext> {
   try {
-    const pending = await deps.resolvePending(input.team);
-    if (!pending) return { status: "no_pending_install" };
+    const authz = await authorizeClaim(deps, input);
+    if (authz.status !== "ready") return authz;
+    const orgs = await deps.resolveMemberOrgs(input.userId as string);
+    if (orgs.length === 0) return { status: "no_org" };
+    return { status: "ready", workspaceName: authz.pending.teamName, orgs };
+  } catch (err) {
+    return {
+      status: "claim_failed",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
 
-    // Validate the presented token against the stored sha256 hash. A null hash
-    // (no claim link was ever minted) is unclaimable via this path.
-    const presentedHash = createHash("sha256")
-      .update(input.token)
-      .digest("hex");
-    if (!pending.claimTokenHash || presentedHash !== pending.claimTokenHash) {
-      return { status: "invalid_token" };
+/**
+ * Bind the pending workspace into the org the user CONFIRMED. `organizationId`
+ * (slug or id) is required from the confirm step; it is membership-verified. When
+ * omitted (programmatic callers), falls back to the user's default org.
+ */
+export async function claimSlackWorkspace(
+  deps: SlackClaimDeps,
+  input: {
+    userId: string | null;
+    team: string;
+    token: string;
+    organizationId?: string;
+  },
+): Promise<SlackClaimResult> {
+  try {
+    const authz = await authorizeClaim(deps, input);
+    if (authz.status !== "ready") return authz;
+
+    // Resolve the destination org: the explicitly chosen one (membership-checked)
+    // or the user's default. Binding a workspace is never implicit — the UI sends
+    // the confirmed org here.
+    let organizationId: string | null;
+    if (input.organizationId) {
+      organizationId = await deps.resolveOrgIfMember(
+        input.userId as string,
+        input.organizationId,
+      );
+      if (!organizationId) return { status: "not_member_of_org" };
+    } else {
+      organizationId = await deps.resolveDefaultOrgId(input.userId as string);
     }
-
-    // The claimer must have signed in with Slack for THIS workspace, so we hold
-    // their team-scoped slack_user_id — the UI prompts sign-in on this code.
-    const bareUserId = await deps.resolveClaimerSlackId(
-      input.userId,
-      input.team,
-    );
-    if (!bareUserId) return { status: "slack_signin_required" };
-
-    // …and be a workspace admin/owner to bind the whole workspace.
-    const info = await deps.usersInfo(pending.botToken, bareUserId);
-    if (!info.isAdmin && !info.isOwner) return { status: "not_admin" };
-
-    const organizationId = await deps.resolveDefaultOrgId(input.userId);
     if (!organizationId) return { status: "no_org" };
 
-    const { installationId } = await deps.claim(pending, organizationId);
+    const { installationId } = await deps.claim(authz.pending, organizationId);
     const orgSlug = await deps.resolveOrgSlug(organizationId);
     return { status: "ok", orgSlug, installationId };
   } catch (err) {

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import type { SlackPendingInstall } from "../../lobu/stores/slack-installations.js";
 import type { SlackWebApi } from "./slack-web.js";
 
@@ -6,17 +5,17 @@ import type { SlackWebApi } from "./slack-web.js";
  * The marketplace-claim decision, factored out of the HTTP route so it is
  * unit-testable without booting the server. A Slack-initiated (marketplace)
  * install lands as an org-less `pending` row (see `writeSlackPendingInstall`);
- * this binds it to the claiming user's org once they prove they (a) hold the
- * single-use claim token, (b) signed in with Slack for the workspace, and (c)
- * are a workspace admin/owner. Every dependency is injected so the route can
- * wire the real stores and tests can stub them; nothing here touches HTTP,
- * Postgres, or the network directly.
+ * this binds it to the claiming user's org once they prove they (a) signed in
+ * with Slack for the workspace and (b) are a workspace admin/owner.
  *
- * Split into two phases so the UI can CONFIRM the destination org before
- * binding: `resolveSlackClaimContext` runs the authorization guards and returns
- * the workspace + the claimer's eligible orgs (no write); `claimSlackWorkspace`
- * re-runs the guards and binds to the org the user explicitly chose. Binding a
- * whole workspace's data to an org is a decision, so it is never implicit.
+ * Authority is the Slack workspace-admin check — NOT a secret link token. The
+ * install DM carries a convenience deep-link, but a signed-in admin of the
+ * workspace can always connect a pending install for their team; a missing,
+ * stale, or already-used link never blocks them. Split into two phases so the
+ * UI can CONFIRM the destination org before binding: `resolveSlackClaimContext`
+ * runs the guards + returns the workspace and eligible orgs (no write);
+ * `claimSlackWorkspace` binds to the org the user chose. Every dependency is
+ * injected so the route can wire real stores and tests can stub them.
  */
 
 /** Shared authorization error statuses (each maps to an HTTP code in the route). */
@@ -24,7 +23,6 @@ export type SlackClaimError =
   | { status: "unauthenticated" }
   | { status: "invalid_request" }
   | { status: "no_pending_install" }
-  | { status: "invalid_token" }
   | { status: "slack_signin_required" }
   | { status: "not_admin" }
   | { status: "not_member_of_org" }
@@ -33,7 +31,13 @@ export type SlackClaimError =
 
 /** Terminal outcome of the bind (`claimSlackWorkspace`). */
 export type SlackClaimResult =
-  | { status: "ok"; orgSlug: string | null; installationId: string }
+  | {
+      status: "ok";
+      orgSlug: string | null;
+      installationId: string;
+      /** True when the workspace was already connected (idempotent no-op). */
+      alreadyConnected?: boolean;
+    }
   | SlackClaimError;
 
 /** A Lobu org the claimer may bind the workspace into. */
@@ -52,15 +56,23 @@ export type SlackClaimContext =
       /** Orgs the claimer belongs to (the destination picker). */
       orgs: ClaimEligibleOrg[];
     }
+  | {
+      // The workspace is already connected — the UI links to it instead of
+      // showing a scary "not found" error for a re-visited/spent link.
+      status: "already_connected";
+      orgSlug: string | null;
+    }
   | SlackClaimError;
 
 export interface SlackClaimDeps {
   /** The parked pending install for a workspace, or null if none. */
   resolvePending(team: string): Promise<SlackPendingInstall | null>;
+  /** The org slug the workspace is ALREADY connected to (active install), or null. */
+  resolveActiveOrgSlug(team: string): Promise<string | null>;
   /**
    * The claiming user's bare `U…` Slack id for this workspace (from their
    * team-scoped `slack_user_id` identity), or null if they never signed in with
-   * Slack for it.
+   * Slack for it. Doubles as the workspace-membership proof.
    */
   resolveClaimerSlackId(userId: string, team: string): Promise<string | null>;
   /** `users.info` admin/owner flags for the claimer. */
@@ -85,54 +97,58 @@ export interface SlackClaimDeps {
 }
 
 /**
- * Run the claim authorization guards (token hash → Slack sign-in → workspace
- * admin) WITHOUT binding. Returns the pending install on success so callers can
- * bind or preview.
+ * Run the claim authorization guards WITHOUT binding. Authority is the Slack
+ * workspace-admin check: the caller must have signed in with Slack for the team
+ * (membership) and be an admin/owner. Returns the pending install on success, a
+ * distinct `already_connected` when the workspace is already bound, or an error.
  */
-async function authorizeClaim(
+async function resolveClaimTarget(
   deps: SlackClaimDeps,
-  input: { userId: string | null; team: string; token: string },
-): Promise<{ status: "ready"; pending: SlackPendingInstall } | SlackClaimError> {
+  input: { userId: string | null; team: string },
+): Promise<
+  | { status: "ready"; pending: SlackPendingInstall }
+  | { status: "already_connected"; orgSlug: string | null }
+  | SlackClaimError
+> {
   if (!input.userId) return { status: "unauthenticated" };
-  if (!input.team || !input.token) return { status: "invalid_request" };
+  if (!input.team) return { status: "invalid_request" };
 
-  const pending = await deps.resolvePending(input.team);
-  if (!pending) return { status: "no_pending_install" };
-
-  // Validate the presented token against the stored sha256 hash. A null hash
-  // (no claim link was ever minted) is unclaimable via this path.
-  const presentedHash = createHash("sha256").update(input.token).digest("hex");
-  if (!pending.claimTokenHash || presentedHash !== pending.claimTokenHash) {
-    return { status: "invalid_token" };
-  }
-
-  // The claimer must have signed in with Slack for THIS workspace, so we hold
-  // their team-scoped slack_user_id — the UI prompts sign-in on this code.
+  // The claimer must have signed in with Slack for THIS workspace — that both
+  // proves workspace membership and gives us their `U…` id for the admin check.
   const bareUserId = await deps.resolveClaimerSlackId(input.userId, input.team);
   if (!bareUserId) return { status: "slack_signin_required" };
 
-  // …and be a workspace admin/owner to bind the whole workspace.
-  const info = await deps.usersInfo(pending.botToken, bareUserId);
-  if (!info.isAdmin && !info.isOwner) return { status: "not_admin" };
+  const pending = await deps.resolvePending(input.team);
+  if (pending) {
+    // Must be a workspace admin/owner to bind the whole workspace.
+    const info = await deps.usersInfo(pending.botToken, bareUserId);
+    if (!info.isAdmin && !info.isOwner) return { status: "not_admin" };
+    return { status: "ready", pending };
+  }
 
-  return { status: "ready", pending };
+  // No pending install: either it's already connected (a re-visited/spent link),
+  // or Lobu was never installed into this workspace.
+  const orgSlug = await deps.resolveActiveOrgSlug(input.team);
+  if (orgSlug) return { status: "already_connected", orgSlug };
+  return { status: "no_pending_install" };
 }
 
 /**
  * Confirmation context: run the guards and return the workspace name + the
  * claimer's eligible orgs, so the UI can show "Connect <workspace> to <org>"
- * before any write. No mutation.
+ * before any write. Surfaces `already_connected` for a workspace that's already
+ * bound. No mutation.
  */
 export async function resolveSlackClaimContext(
   deps: SlackClaimDeps,
-  input: { userId: string | null; team: string; token: string },
+  input: { userId: string | null; team: string },
 ): Promise<SlackClaimContext> {
   try {
-    const authz = await authorizeClaim(deps, input);
-    if (authz.status !== "ready") return authz;
+    const target = await resolveClaimTarget(deps, input);
+    if (target.status !== "ready") return target;
     const orgs = await deps.resolveMemberOrgs(input.userId as string);
     if (orgs.length === 0) return { status: "no_org" };
-    return { status: "ready", workspaceName: authz.pending.teamName, orgs };
+    return { status: "ready", workspaceName: target.pending.teamName, orgs };
   } catch (err) {
     return {
       status: "claim_failed",
@@ -144,20 +160,29 @@ export async function resolveSlackClaimContext(
 /**
  * Bind the pending workspace into the org the user CONFIRMED. `organizationId`
  * (slug or id) is required from the confirm step; it is membership-verified. When
- * omitted (programmatic callers), falls back to the user's default org.
+ * omitted (programmatic callers), falls back to the user's default org. An
+ * already-connected workspace resolves to an idempotent success pointing at its
+ * existing org.
  */
 export async function claimSlackWorkspace(
   deps: SlackClaimDeps,
   input: {
     userId: string | null;
     team: string;
-    token: string;
     organizationId?: string;
   },
 ): Promise<SlackClaimResult> {
   try {
-    const authz = await authorizeClaim(deps, input);
-    if (authz.status !== "ready") return authz;
+    const target = await resolveClaimTarget(deps, input);
+    if (target.status === "already_connected") {
+      return {
+        status: "ok",
+        orgSlug: target.orgSlug,
+        installationId: "",
+        alreadyConnected: true,
+      };
+    }
+    if (target.status !== "ready") return target;
 
     // Resolve the destination org: the explicitly chosen one (membership-checked)
     // or the user's default. Binding a workspace is never implicit — the UI sends
@@ -174,7 +199,7 @@ export async function claimSlackWorkspace(
     }
     if (!organizationId) return { status: "no_org" };
 
-    const { installationId } = await deps.claim(authz.pending, organizationId);
+    const { installationId } = await deps.claim(target.pending, organizationId);
     const orgSlug = await deps.resolveOrgSlug(organizationId);
     return { status: "ok", orgSlug, installationId };
   } catch (err) {

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -4,7 +4,9 @@ import type { AppInstallationStore } from "../../lobu/stores/app-installation-st
 import {
   getSlackInstallByTeamId,
   upsertSlackInstallByTeam,
+  writeSlackPendingInstall,
 } from "../../lobu/stores/slack-installations.js";
+import { createSlackWebApi } from "./slack-web.js";
 import type { WritableSecretStore } from "../secrets/index.js";
 import {
   getPrimedBundledMethod,
@@ -18,6 +20,64 @@ import {
 } from "./slack-platform-bridge.js";
 
 const logger = createLogger("slack-connection-coordinator");
+
+/**
+ * Complete a Slack-initiated (marketplace) install: the callback got a `code`
+ * but no Lobu-minted state, so there's no org to bind to. Exchange the code for
+ * the bot token + installer identity via `oauth.v2.access`, and park it as an
+ * UNCLAIMED `pending` install (org-less). The installer later claims the
+ * workspace by signing in with Slack. Returns the parked install's identity, or
+ * `null` when the hosted app credentials aren't configured (so the caller can
+ * fall through to the normal invalid-state rejection).
+ */
+export async function completeSlackPendingInstall(
+  request: Request,
+  redirectUri: string,
+): Promise<{
+  teamId: string;
+  teamName: string | null;
+  installerUserId: string | null;
+} | null> {
+  const method = getPrimedBundledMethod("slack", "slack");
+  const creds = method ? resolveAppInstallCredentials(method) : null;
+  if (!creds?.clientId || !creds?.clientSecret) {
+    logger.warn(
+      "Slack pending-install: hosted app credentials not configured; cannot exchange code",
+    );
+    return null;
+  }
+  const code = new URL(request.url).searchParams.get("code");
+  if (!code) return null;
+
+  const web = createSlackWebApi();
+  const result = await web.exchangeOAuthCode({
+    clientId: creds.clientId,
+    clientSecret: creds.clientSecret,
+    code,
+    redirectUri,
+  });
+  await writeSlackPendingInstall({
+    teamId: result.teamId,
+    teamName: result.teamName,
+    botUserId: result.botUserId,
+    botToken: result.botToken,
+    installerUserId: result.authedUserId,
+    isEnterpriseInstall: result.isEnterpriseInstall,
+  });
+  logger.info(
+    {
+      teamId: result.teamId,
+      installerUserId: result.authedUserId,
+      enterprise: result.isEnterpriseInstall,
+    },
+    "Slack pending-install parked (unclaimed) — awaiting claim",
+  );
+  return {
+    teamId: result.teamId,
+    teamName: result.teamName,
+    installerUserId: result.authedUserId,
+  };
+}
 
 type SlackInstallation = {
   botToken: string;

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -4,6 +4,7 @@ import { Chat } from "chat";
 import type { AppInstallationStore } from "../../lobu/stores/app-installation-store.js";
 import {
   getSlackInstallByTeamId,
+  resolveSlackPendingByTenant,
   upsertSlackInstallByTeam,
   writeSlackPendingInstall,
 } from "../../lobu/stores/slack-installations.js";
@@ -144,6 +145,47 @@ async function dmSlackClaimLink(
       "Slack pending-install: failed to DM the installer their claim link",
     );
   }
+}
+
+/**
+ * Parse an Events API webhook body into a user-facing message we should reply
+ * to when the workspace is unclaimed: an `app_mention`, or a direct message
+ * (`message` with channel_type `im`). Returns null for everything else — the
+ * bot's own messages, message edits/subtypes, channel chatter, url_verification
+ * challenges, or non-JSON (interactivity/slash) payloads.
+ */
+function parseSlackUserMessageEvent(
+  body: string,
+  contentType: string,
+): { channel: string; user: string } | null {
+  // Events API always posts application/json; form bodies are slash/interactivity.
+  if (contentType.includes("application/x-www-form-urlencoded")) return null;
+  let payload: {
+    type?: string;
+    event?: {
+      type?: string;
+      channel?: string;
+      user?: string;
+      bot_id?: string;
+      subtype?: string;
+      channel_type?: string;
+    };
+  };
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (payload.type !== "event_callback") return null;
+  const event = payload.event;
+  if (!event || !event.channel || !event.user || event.bot_id) return null;
+  const isMention = event.type === "app_mention";
+  const isDirectMessage =
+    event.type === "message" &&
+    event.channel_type === "im" &&
+    !event.subtype;
+  if (!isMention && !isDirectMessage) return null;
+  return { channel: event.channel, user: event.user };
 }
 
 type SlackInstallation = {
@@ -409,6 +451,20 @@ export class SlackConnectionCoordinator {
         }
         return response;
       }
+
+      // 3) A workspace that installed Lobu but hasn't been CLAIMED into a Lobu
+      //    org yet (a `pending` install). Don't silently drop their messages —
+      //    reply with the connect link so a workspace admin can finish setup.
+      const pending = await resolveSlackPendingByTenant(teamId);
+      if (pending) {
+        return await this.replyUnclaimedWorkspace(
+          pending.botToken,
+          teamId,
+          body,
+          contentType,
+          request.headers.get("x-slack-retry-num") !== null,
+        );
+      }
     }
 
     const fallbackConnection = await this.getDefaultConnection();
@@ -498,6 +554,38 @@ export class SlackConnectionCoordinator {
       ...(installationKeyPrefix ? { installationKeyPrefix } : {}),
       ...(userName ? { userName } : {}),
     };
+  }
+
+  /**
+   * Reply to a user in an unclaimed workspace with the connect link, using the
+   * pending install's bot token. Only responds to a real @mention or DM — never
+   * to challenges, retries, or the bot's own messages — and always acks 200 so
+   * Slack doesn't retry (and so we never double-post).
+   */
+  private async replyUnclaimedWorkspace(
+    botToken: string,
+    teamId: string,
+    body: string,
+    contentType: string,
+    isRetry: boolean,
+  ): Promise<Response> {
+    const ack = new Response("", { status: 200 });
+    if (isRetry) return ack;
+    const event = parseSlackUserMessageEvent(body, contentType);
+    if (!event) return ack;
+    const webBase = getConfiguredPublicOrigin()?.replace(/\/+$/, "");
+    if (!webBase) return ack;
+    const claimUrl = `${webBase}/slack/claim?team=${encodeURIComponent(teamId)}`;
+    const text = `👋 This Slack workspace isn't connected to Lobu yet. A workspace admin can connect it here: ${claimUrl}`;
+    try {
+      await createSlackWebApi().postMessage(botToken, event.channel, text);
+    } catch (error) {
+      logger.warn(
+        { teamId, error: String(error) },
+        "Slack unclaimed-workspace connect reply failed",
+      );
+    }
+    return ack;
   }
 
   extractTeamId(body: string, contentType: string): string | null {

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -1,3 +1,4 @@
+import { createHash, randomUUID } from "node:crypto";
 import { createLogger } from "@lobu/core";
 import { Chat } from "chat";
 import type { AppInstallationStore } from "../../lobu/stores/app-installation-store.js";
@@ -6,7 +7,8 @@ import {
   upsertSlackInstallByTeam,
   writeSlackPendingInstall,
 } from "../../lobu/stores/slack-installations.js";
-import { createSlackWebApi } from "./slack-web.js";
+import { getConfiguredPublicOrigin } from "../../utils/public-origin.js";
+import { createSlackWebApi, type SlackWebApi } from "./slack-web.js";
 import type { WritableSecretStore } from "../secrets/index.js";
 import {
   getPrimedBundledMethod,
@@ -56,6 +58,16 @@ export async function completeSlackPendingInstall(
     code,
     redirectUri,
   });
+
+  // Mint a single-use claim token ONLY when there's an installer to DM it to. We
+  // persist only its sha256 hash on the pending row — the plaintext lives solely
+  // in the DM'd claim link, so a leaked pending row can't be replayed to claim
+  // the workspace.
+  const claimToken = result.authedUserId ? randomUUID() : null;
+  const claimTokenHash = claimToken
+    ? createHash("sha256").update(claimToken).digest("hex")
+    : null;
+
   await writeSlackPendingInstall({
     teamId: result.teamId,
     teamName: result.teamName,
@@ -63,6 +75,7 @@ export async function completeSlackPendingInstall(
     botToken: result.botToken,
     installerUserId: result.authedUserId,
     isEnterpriseInstall: result.isEnterpriseInstall,
+    claimTokenHash,
   });
   logger.info(
     {
@@ -72,11 +85,65 @@ export async function completeSlackPendingInstall(
     },
     "Slack pending-install parked (unclaimed) — awaiting claim",
   );
+
+  // Best-effort: DM the installer their claim link. The pending row is already
+  // parked; a DM failure (installer un-DMable, un-configured web base, …) must
+  // never fail the install — the workspace can still be claimed via the app.
+  if (result.authedUserId && claimToken) {
+    await dmSlackClaimLink(
+      web,
+      result.botToken,
+      result.authedUserId,
+      result.teamId,
+      claimToken,
+    );
+  } else {
+    logger.info(
+      { teamId: result.teamId },
+      "Slack pending-install: no installer id — skipping claim DM",
+    );
+  }
+
   return {
     teamId: result.teamId,
     teamName: result.teamName,
     installerUserId: result.authedUserId,
   };
+}
+
+/**
+ * DM the installer a single-use claim link so they can connect the freshly
+ * parked (pending) workspace to their Lobu account. Best-effort: any failure is
+ * logged and swallowed — the install stays parked and claimable via the app.
+ */
+async function dmSlackClaimLink(
+  web: SlackWebApi,
+  botToken: string,
+  installerUserId: string,
+  teamId: string,
+  claimToken: string,
+): Promise<void> {
+  const webBase = getConfiguredPublicOrigin()?.replace(/\/+$/, "");
+  if (!webBase) {
+    logger.warn(
+      { teamId, installerUserId },
+      "Slack pending-install: no public web base configured — skipping claim DM",
+    );
+    return;
+  }
+  const claimUrl = `${webBase}/slack/claim?team=${encodeURIComponent(
+    teamId,
+  )}&t=${claimToken}`;
+  const text = `👋 Thanks for adding Lobu to your workspace! Connect it to your Lobu account to finish setup: ${claimUrl}`;
+  try {
+    const dm = await web.openDm(botToken, installerUserId);
+    await web.postMessage(botToken, dm, text);
+  } catch (error) {
+    logger.warn(
+      { teamId, installerUserId, error: String(error) },
+      "Slack pending-install: failed to DM the installer their claim link",
+    );
+  }
 }
 
 type SlackInstallation = {

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -154,7 +154,7 @@ async function dmSlackClaimLink(
  * bot's own messages, message edits/subtypes, channel chatter, url_verification
  * challenges, or non-JSON (interactivity/slash) payloads.
  */
-function parseSlackUserMessageEvent(
+export function parseSlackUserMessageEvent(
   body: string,
   contentType: string,
 ): { channel: string; user: string } | null {

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -1,4 +1,3 @@
-import { createHash, randomUUID } from "node:crypto";
 import { createLogger } from "@lobu/core";
 import { Chat } from "chat";
 import type { AppInstallationStore } from "../../lobu/stores/app-installation-store.js";
@@ -60,15 +59,6 @@ export async function completeSlackPendingInstall(
     redirectUri,
   });
 
-  // Mint a single-use claim token ONLY when there's an installer to DM it to. We
-  // persist only its sha256 hash on the pending row — the plaintext lives solely
-  // in the DM'd claim link, so a leaked pending row can't be replayed to claim
-  // the workspace.
-  const claimToken = result.authedUserId ? randomUUID() : null;
-  const claimTokenHash = claimToken
-    ? createHash("sha256").update(claimToken).digest("hex")
-    : null;
-
   await writeSlackPendingInstall({
     teamId: result.teamId,
     teamName: result.teamName,
@@ -76,7 +66,6 @@ export async function completeSlackPendingInstall(
     botToken: result.botToken,
     installerUserId: result.authedUserId,
     isEnterpriseInstall: result.isEnterpriseInstall,
-    claimTokenHash,
   });
   logger.info(
     {
@@ -87,21 +76,15 @@ export async function completeSlackPendingInstall(
     "Slack pending-install parked (unclaimed) — awaiting claim",
   );
 
-  // Best-effort: DM the installer their claim link. The pending row is already
+  // Best-effort: DM the installer their connect link. The pending row is already
   // parked; a DM failure (installer un-DMable, un-configured web base, …) must
-  // never fail the install — the workspace can still be claimed via the app.
-  if (result.authedUserId && claimToken) {
-    await dmSlackClaimLink(
-      web,
-      result.botToken,
-      result.authedUserId,
-      result.teamId,
-      claimToken,
-    );
+  // never fail the install — the workspace can still be connected via the app.
+  if (result.authedUserId) {
+    await dmSlackClaimLink(web, result.botToken, result.authedUserId, result.teamId);
   } else {
     logger.info(
       { teamId: result.teamId },
-      "Slack pending-install: no installer id — skipping claim DM",
+      "Slack pending-install: no installer id — skipping connect DM",
     );
   }
 
@@ -122,19 +105,16 @@ async function dmSlackClaimLink(
   botToken: string,
   installerUserId: string,
   teamId: string,
-  claimToken: string,
 ): Promise<void> {
   const webBase = getConfiguredPublicOrigin()?.replace(/\/+$/, "");
   if (!webBase) {
     logger.warn(
       { teamId, installerUserId },
-      "Slack pending-install: no public web base configured — skipping claim DM",
+      "Slack pending-install: no public web base configured — skipping connect DM",
     );
     return;
   }
-  const claimUrl = `${webBase}/slack/claim?team=${encodeURIComponent(
-    teamId,
-  )}&t=${claimToken}`;
+  const claimUrl = `${webBase}/slack/claim?team=${encodeURIComponent(teamId)}`;
   const text = `👋 Thanks for adding Lobu to your workspace! Connect it to your Lobu account to finish setup: ${claimUrl}`;
   try {
     const dm = await web.openDm(botToken, installerUserId);

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -44,6 +44,15 @@ export interface SlackWebApi {
     userId: string
   ): Promise<{ isAdmin: boolean; isOwner: boolean }>;
   /**
+   * `auth.revoke` — invalidate a bot token so an abandoned install can't leave a
+   * live credential lying around. Best-effort by contract: an already-invalid or
+   * unknown token yields a Slack-level error (`invalid_auth`, `token_revoked`)
+   * which this throws on, and the caller treats any throw as "already gone" and
+   * continues. Resolves to Slack's `revoked` flag on success. Used by the
+   * expired-pending-install reaper.
+   */
+  revokeToken(botToken: string): Promise<boolean>;
+  /**
    * `oauth.v2.access` — exchange an OAuth `code` for the workspace bot token +
    * tenant/installer identity. Unlike the other methods this authenticates with
    * the app's client id/secret (not a bot token), so it lives outside
@@ -164,6 +173,10 @@ export function createSlackWebApi(): SlackWebApi {
         isAdmin: user?.is_admin === true,
         isOwner: user?.is_owner === true,
       };
+    },
+    async revokeToken(botToken) {
+      const json = await slackPost(botToken, "auth.revoke", {});
+      return json.revoked === true;
     },
     async exchangeOAuthCode({ clientId, clientSecret, code, redirectUri }) {
       const form = new URLSearchParams({

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -34,6 +34,16 @@ export interface SlackWebApi {
     channelId: string
   ): Promise<{ name: string | null; isPrivate: boolean }>;
   /**
+   * `users.info` → the workspace-admin flags for one user. Used by the
+   * marketplace-claim flow to verify the claiming user is a workspace admin or
+   * owner before binding the pending install to their org. Throws on a
+   * Slack-level error (the caller treats a throw as a failed claim).
+   */
+  usersInfo(
+    botToken: string,
+    userId: string
+  ): Promise<{ isAdmin: boolean; isOwner: boolean }>;
+  /**
    * `oauth.v2.access` — exchange an OAuth `code` for the workspace bot token +
    * tenant/installer identity. Unlike the other methods this authenticates with
    * the app's client id/secret (not a bot token), so it lives outside
@@ -143,6 +153,16 @@ export function createSlackWebApi(): SlackWebApi {
       return {
         name: typeof ch?.name === "string" ? ch.name : null,
         isPrivate: ch?.is_private === true,
+      };
+    },
+    async usersInfo(botToken, userId) {
+      const json = await slackPost(botToken, "users.info", { user: userId });
+      const user = json.user as
+        | { is_admin?: boolean; is_owner?: boolean }
+        | undefined;
+      return {
+        isAdmin: user?.is_admin === true,
+        isOwner: user?.is_owner === true,
       };
     },
     async exchangeOAuthCode({ clientId, clientSecret, code, redirectUri }) {

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -33,6 +33,28 @@ export interface SlackWebApi {
     botToken: string,
     channelId: string
   ): Promise<{ name: string | null; isPrivate: boolean }>;
+  /**
+   * `oauth.v2.access` — exchange an OAuth `code` for the workspace bot token +
+   * tenant/installer identity. Unlike the other methods this authenticates with
+   * the app's client id/secret (not a bot token), so it lives outside
+   * {@link slackPost}. Used by the marketplace / Slack-initiated install path,
+   * which lands at the callback with a `code` but no Lobu-minted state — we need
+   * the raw response (`authed_user`, `team`, `bot_user_id`) to park a pending
+   * install and DM the installer to claim it.
+   */
+  exchangeOAuthCode(params: {
+    clientId: string;
+    clientSecret: string;
+    code: string;
+    redirectUri: string;
+  }): Promise<{
+    botToken: string;
+    teamId: string;
+    teamName: string | null;
+    botUserId: string | null;
+    authedUserId: string | null;
+    isEnterpriseInstall: boolean;
+  }>;
 }
 
 async function slackPost(
@@ -121,6 +143,47 @@ export function createSlackWebApi(): SlackWebApi {
       return {
         name: typeof ch?.name === "string" ? ch.name : null,
         isPrivate: ch?.is_private === true,
+      };
+    },
+    async exchangeOAuthCode({ clientId, clientSecret, code, redirectUri }) {
+      const form = new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        redirect_uri: redirectUri,
+      });
+      const res = await fetch("https://slack.com/api/oauth.v2.access", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+        },
+        body: form.toString(),
+      });
+      const json = (await res.json()) as Record<string, unknown>;
+      if (json.ok !== true) {
+        throw new Error(
+          `Slack oauth.v2.access failed: ${String(json.error ?? res.status)}`
+        );
+      }
+      const team = json.team as { id?: string; name?: string } | undefined;
+      const authedUser = json.authed_user as { id?: string } | undefined;
+      const botToken = json.access_token;
+      const teamId = team?.id;
+      if (typeof botToken !== "string" || !botToken) {
+        throw new Error("Slack oauth.v2.access returned no access_token");
+      }
+      if (typeof teamId !== "string" || !teamId) {
+        throw new Error("Slack oauth.v2.access returned no team id");
+      }
+      return {
+        botToken,
+        teamId,
+        teamName: typeof team?.name === "string" ? team.name : null,
+        botUserId:
+          typeof json.bot_user_id === "string" ? json.bot_user_id : null,
+        authedUserId:
+          typeof authedUser?.id === "string" ? authedUser.id : null,
+        isEnterpriseInstall: json.is_enterprise_install === true,
       };
     },
   };

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -42,6 +42,7 @@ import {
 } from "@lobu/core";
 import type { ConnectorAuthAppInstallation } from "@lobu/connector-sdk";
 import { getDb } from "../../../db/client.js";
+import { getConfiguredPublicOrigin } from "../../../utils/public-origin.js";
 import {
 	ConnectionSlugConflictError,
 	insertConnectionWithSlug,
@@ -876,6 +877,17 @@ export interface AppInstallRouterDeps {
 	/** Resolve the active org for the request (session-bound + single-tenant). */
 	resolveInstallOrgId(c: import("hono").Context): Promise<string | null>;
 	/**
+	 * Authorize install COMPLETION against the org the install was started for
+	 * (carried in the signed state): true iff the completing request's user is a
+	 * member of `organizationId` (self-host: iff it is the sole tenant). Replaces
+	 * the fragile "callback active-org === state org" comparison, which rejected
+	 * legitimate installs whenever the active org drifted from the UI-selected org.
+	 */
+	verifyInstallOrgAccess(
+		c: import("hono").Context,
+		organizationId: string,
+	): Promise<boolean>;
+	/**
 	 * The public gateway base URL (e.g. `https://app.lobu.ai`) used to build the
 	 * OAuth `redirect_uri`, which must equal the App's registered Callback URL.
 	 * Undefined falls back to the request origin (self-host single-origin).
@@ -1370,17 +1382,22 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 		// send the genuine github.com/apps/<slug>/installations/new?state=S to a
 		// victim, the victim installs the App on THEIR org V and passes the ownership
 		// check (they own V) — and V's installation lands in the attacker's org A.
-		// Require the completing session's org to equal the state's org (mirrors
-		// slack.ts). The legit admin completes in the same session (A === A).
-		const callbackOrgId = await deps.resolveInstallOrgId(c);
-		if (!callbackOrgId || callbackOrgId !== installState.organizationId) {
+		// Require the completing session's USER to be a member of the state's org.
+		// Membership — not "ambient active org === state org" — is the real
+		// authorization: it still blocks the CSRF (a victim who doesn't belong to
+		// the attacker's org A can't complete an A-bound link) while allowing a
+		// legit admin whose active org drifted from the org they launched from.
+		const callbackAuthorized = await deps.verifyInstallOrgAccess(
+			c,
+			installState.organizationId,
+		);
+		if (!callbackAuthorized) {
 			logger.warn(
 				{
 					state_org: installState.organizationId,
-					callback_org: callbackOrgId ?? null,
 					installation_id: installationIdRaw,
 				},
-				"Rejecting GitHub install callback: completing session org does not match install state",
+				"Rejecting GitHub install callback: completing user is not a member of install state's org",
 			);
 			return c.html(
 				renderOAuthErrorPage(
@@ -1390,7 +1407,7 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				403,
 			);
 		}
-		// Bind to the org encoded in the verified state (== callbackOrgId).
+		// Bind to the org encoded in the verified state (membership-authorized above).
 		const orgId = installState.organizationId;
 
 		// Resolve App credentials from THIS org's connector declaration — only now,
@@ -1758,6 +1775,10 @@ function mountOAuthCodeExchangeRoutes(
 		provider: string;
 		authorizeUrl: string;
 		resolveInstallOrgId(c: import("hono").Context): Promise<string | null>;
+		verifyInstallOrgAccess(
+			c: import("hono").Context,
+			organizationId: string,
+		): Promise<boolean>;
 		getPublicGatewayUrl?(): string | undefined;
 		complete: CompleteOAuthInstall;
 	},
@@ -1858,17 +1879,23 @@ function mountOAuthCodeExchangeRoutes(
 			);
 		}
 
-		// Reject the callback if the session that's completing the install belongs
-		// to a different org than the one that started it.
-		const callbackOrgId = await params.resolveInstallOrgId(c);
-		if (!callbackOrgId || callbackOrgId !== oauthState.organizationId) {
+		// Reject the callback unless the completing session's USER is a member of
+		// the org the install was started for. Membership authorizes completion —
+		// not "ambient active org === state org", which rejected legitimate installs
+		// whenever the active org drifted from the UI-selected org threaded via
+		// `?org=`. The CSRF guarantee holds: a user not in the state's org can't
+		// complete its link.
+		const callbackAuthorized = await params.verifyInstallOrgAccess(
+			c,
+			oauthState.organizationId,
+		);
+		if (!callbackAuthorized) {
 			oauthInstallLogger.warn(
 				{
 					provider,
 					stateOrg: oauthState.organizationId,
-					callbackOrg: callbackOrgId ?? null,
 				},
-				"Rejecting OAuth install callback: session org does not match install state",
+				"Rejecting OAuth install callback: completing user is not a member of install state's org",
 			);
 			return c.html(
 				renderOAuthErrorPage(
@@ -1903,7 +1930,19 @@ function mountOAuthCodeExchangeRoutes(
 			// a "Connect my DM" action, replacing the legacy "run /lobu link <code>"
 			// page. Falls back to the success page when the web origin or org slug
 			// can't be resolved (e.g. a headless/self-host install with no slug).
-			const webBase = params.getPublicGatewayUrl?.()?.replace(/\/+$/, "");
+			//
+			// Use the WEB origin (app.lobu.ai), NOT the gateway base
+			// (getPublicGatewayUrl → app.lobu.ai/lobu): web-app routes live at
+			// `<origin>/<orgSlug>/agents`, so a `/lobu`-prefixed base yields
+			// `/lobu/<slug>/agents`, which the SPA can't resolve ("Not Found").
+			// Fall back to stripping a trailing `/lobu` off the gateway base when
+			// the origin env isn't set (single-origin self-host).
+			const webBase =
+				getConfiguredPublicOrigin()?.replace(/\/+$/, "") ??
+				params
+					.getPublicGatewayUrl?.()
+					?.replace(/\/+$/, "")
+					.replace(/\/lobu$/, "");
 			let orgSlug: string | null = null;
 			try {
 				const rows = (await getDb()`
@@ -1975,6 +2014,11 @@ export interface InstallEngineDeps {
 	installationStore: AppInstallationStore;
 	/** Resolve the active org for the request (session-bound + single-tenant). */
 	resolveInstallOrgId(c: import("hono").Context): Promise<string | null>;
+	/** Authorize install completion by membership in the state's org. */
+	verifyInstallOrgAccess(
+		c: import("hono").Context,
+		organizationId: string,
+	): Promise<boolean>;
 	/** The public gateway base URL used to build OAuth `redirect_uri`s. */
 	getPublicGatewayUrl?(): string | undefined;
 	/** The bundled integration connectors to mount install routes for. */
@@ -2009,6 +2053,7 @@ export function createInstallRoutes(deps: InstallEngineDeps): Hono {
 				createAppInstallRoutes({
 					installationStore: deps.installationStore,
 					resolveInstallOrgId: deps.resolveInstallOrgId,
+					verifyInstallOrgAccess: deps.verifyInstallOrgAccess,
 					getPublicGatewayUrl: deps.getPublicGatewayUrl,
 				}),
 			);
@@ -2040,6 +2085,7 @@ export function createInstallRoutes(deps: InstallEngineDeps): Hono {
 			provider: integration.provider,
 			authorizeUrl,
 			resolveInstallOrgId: deps.resolveInstallOrgId,
+			verifyInstallOrgAccess: deps.verifyInstallOrgAccess,
 			getPublicGatewayUrl: deps.getPublicGatewayUrl,
 			complete: deps.completeChatInstall,
 		});

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -1762,6 +1762,22 @@ type CompleteOAuthInstall = (
 ) => Promise<{ teamId: string; teamName?: string; installationId: string }>;
 
 /**
+ * Complete a Slack-INITIATED (marketplace) install that arrives with a `code`
+ * but no Lobu-minted state: park it as a pending, unclaimed install (org-less)
+ * and return its identity so the callback can prompt the user to claim it.
+ * Returns `null` when it can't run (hosted creds unset) → caller falls through.
+ */
+type CompletePendingOAuthInstall = (
+	provider: string,
+	request: Request,
+	redirectUri: string,
+) => Promise<{
+	teamId: string;
+	teamName: string | null;
+	installerUserId: string | null;
+} | null>;
+
+/**
  * Mount the start + callback routes for ONE oauth-code-exchange connector onto
  * `router`, at the connector's `/{provider}/install` + `/{provider}/oauth_callback`
  * paths. `authorizeUrl` is the provider's declared OAuth authorize endpoint; the
@@ -1781,6 +1797,7 @@ function mountOAuthCodeExchangeRoutes(
 		): Promise<boolean>;
 		getPublicGatewayUrl?(): string | undefined;
 		complete: CompleteOAuthInstall;
+		completePendingInstall?: CompletePendingOAuthInstall;
 	},
 ): void {
 	const { connectorKey, provider, authorizeUrl } = params;
@@ -1855,11 +1872,11 @@ function mountOAuthCodeExchangeRoutes(
 	router.get(`/${provider}/oauth_callback`, async (c) => {
 		const state = c.req.query("state");
 		const code = c.req.query("code");
-		if (!state || !code) {
+		if (!code) {
 			return c.html(
 				renderOAuthErrorPage(
 					"invalid_request",
-					`The ${display} OAuth callback is missing the required state or code parameter.`,
+					`The ${display} OAuth callback is missing the required code parameter.`,
 				),
 				400,
 			);
@@ -1868,8 +1885,57 @@ function mountOAuthCodeExchangeRoutes(
 		const stateStore = oauthInstallStateStore(provider);
 		// Peek (non-destructive) before validating side-channel context so a
 		// cross-org or unauthenticated hit doesn't burn the install link.
-		const oauthState = await stateStore.peek(state);
+		const oauthState = state ? await stateStore.peek(state) : null;
 		if (!oauthState) {
+			// No Lobu-minted state → this is a Slack-INITIATED install (marketplace /
+			// "Add to Slack"), NOT one we started, so there's no org to bind to. Park
+			// it as a pending, unclaimed install and tell the user to finish by
+			// claiming it (the installer gets DMed the claim link). Only fall through
+			// to the invalid-state error when there's no pending handler or it can't
+			// run (e.g. hosted app creds unset).
+			if (params.completePendingInstall) {
+				try {
+					const pendingRedirectUri = resolveOAuthInstallCallbackUrl(
+						params.getPublicGatewayUrl?.(),
+						c.req.url,
+						provider,
+					);
+					const pending = await params.completePendingInstall(
+						provider,
+						c.req.raw,
+						pendingRedirectUri,
+					);
+					if (pending) {
+						return c.html(
+							renderOAuthSuccessPage(
+								pending.teamName || pending.teamId,
+								undefined,
+								{
+									title: `${display} added`,
+									description:
+										"Almost done — check your Slack DMs to connect this workspace to your Lobu account.",
+									details:
+										"We sent the person who installed the app a link to finish setup.",
+								},
+							),
+						);
+					}
+				} catch (error) {
+					oauthInstallLogger.error(
+						{ provider, error: String(error) },
+						"Slack-initiated (marketplace) install failed to park as pending",
+					);
+					return c.html(
+						renderOAuthErrorPage(
+							`${provider}_install_failed`,
+							error instanceof Error
+								? error.message
+								: `${display} install failed.`,
+						),
+						500,
+					);
+				}
+			}
 			return c.html(
 				renderOAuthErrorPage(
 					"invalid_state",
@@ -1906,8 +1972,10 @@ function mountOAuthCodeExchangeRoutes(
 			);
 		}
 
-		// Org check passed — atomically consume the nonce so the link can't be replayed.
-		const consumed = await stateStore.consume(state);
+		// Org check passed — atomically consume the nonce so the link can't be
+		// replayed. `oauthState` being truthy means `state` was a non-empty string
+		// (peek only ran when it was present), so the assertion is sound.
+		const consumed = await stateStore.consume(state as string);
 		if (!consumed) {
 			return c.html(
 				renderOAuthErrorPage(
@@ -2030,6 +2098,12 @@ export interface InstallEngineDeps {
 	 * registered; omit on deployments with none.
 	 */
 	completeChatInstall?: CompleteOAuthInstall;
+	/**
+	 * Park a Slack-initiated (marketplace) install — a callback with a `code` but
+	 * no Lobu-minted state — as a pending, unclaimed install. Omit on deployments
+	 * that don't support marketplace/Slack-side installs.
+	 */
+	completeChatPendingInstall?: CompletePendingOAuthInstall;
 }
 
 /**
@@ -2088,6 +2162,7 @@ export function createInstallRoutes(deps: InstallEngineDeps): Hono {
 			verifyInstallOrgAccess: deps.verifyInstallOrgAccess,
 			getPublicGatewayUrl: deps.getPublicGatewayUrl,
 			complete: deps.completeChatInstall,
+			completePendingInstall: deps.completeChatPendingInstall,
 		});
 	}
 

--- a/packages/server/src/gateway/routes/public/install-org.ts
+++ b/packages/server/src/gateway/routes/public/install-org.ts
@@ -1,8 +1,18 @@
 import { createLogger } from "@lobu/core";
 import type { Context } from "hono";
 import { getDb } from "../../../db/client.js";
+import {
+  getCachedMembershipRole,
+  getCachedOrgBySlug,
+} from "../../../workspace/multi-tenant.js";
 
 const logger = createLogger("install-org");
+
+/** The authenticated user id stamped onto the request by `createLobuAuthBridge`. */
+function readUserId(c: Context): string | null {
+  const user = c.get("user" as never) as { id?: string } | null | undefined;
+  return typeof user?.id === "string" && user.id.length > 0 ? user.id : null;
+}
 
 /**
  * Resolve the active organization id for the current request.
@@ -66,15 +76,99 @@ async function resolveSingleTenantOrgId(): Promise<string | null> {
 }
 
 /**
- * Resolve the install-flow org for the current request: session-bound first,
- * then the self-host single-tenant fallback. Returns `null` only when
- * neither path yields a definite org — at which point the route must reject.
+ * Resolve an EXPLICIT install target org supplied by the UI (`?org=<slug|id>`),
+ * authorized by membership. This is the org the user was actually viewing when
+ * they clicked "Install" — the single source of truth for where the connection
+ * is created. It intentionally does NOT fall back to the ambient "active org":
+ * that silently drifts from the UI selection (the connectors page can show org A
+ * while the session's active org is B), which lands installs in the wrong tenant.
+ *
+ * Returns the resolved org id only when the request's user is a member of it.
+ * On self-host (no authenticated user) the requested org is honored only when it
+ * is the sole tenant. Returns `null` otherwise — the caller MUST reject rather
+ * than silently retarget.
+ */
+async function resolveRequestedOrgId(
+  c: Context,
+  requested: string
+): Promise<string | null> {
+  // The UI passes the org slug from its route; fall back to treating the value
+  // as a raw org id when it doesn't resolve as a slug. Membership gates both.
+  let orgId: string | null = null;
+  try {
+    const bySlug = await getCachedOrgBySlug(requested);
+    orgId = bySlug?.id ?? null;
+  } catch (err) {
+    logger.warn(
+      { err: String(err), requested },
+      "Requested-org slug lookup failed"
+    );
+  }
+  if (!orgId) orgId = requested;
+
+  const userId = readUserId(c);
+  if (userId) {
+    const role = await getCachedMembershipRole(orgId, userId);
+    if (role) return orgId;
+    logger.warn(
+      { requested, orgId },
+      "Rejecting explicit install org: user is not a member"
+    );
+    return null;
+  }
+
+  // No authenticated user (self-host): only honor the requested org when it is
+  // the single tenant, so a stray ?org= can't select a foreign tenant.
+  const single = await resolveSingleTenantOrgId();
+  return single !== null && single === orgId ? orgId : null;
+}
+
+/**
+ * Resolve the install-flow org for the current request.
+ *
+ * Precedence:
+ *   1. Explicit `?org=<slug|id>` from the install link — the org the user chose
+ *      in the UI, authorized by membership ({@link resolveRequestedOrgId}). When
+ *      present but unauthorized/unknown, returns `null` so the route rejects
+ *      rather than silently falling back to a different org.
+ *   2. The session-bound active org (legacy links, CLI).
+ *   3. The self-host single-tenant fallback.
  *
  * Shared by every app-installation flow (the generic install engine in
  * `app-install.ts`), so it lives here rather than in any one provider's module.
  */
 export async function resolveInstallOrgId(c: Context): Promise<string | null> {
+  const requested = c.req.query("org")?.trim();
+  if (requested) {
+    return resolveRequestedOrgId(c, requested);
+  }
   const sessionOrgId = readSessionOrgId(c);
   if (sessionOrgId) return sessionOrgId;
   return resolveSingleTenantOrgId();
+}
+
+/**
+ * Authorize install-flow COMPLETION against the org the install was started for
+ * (carried in the signed OAuth state). Used by the callback instead of
+ * re-deriving the ambient active org and comparing it to the state's org: that
+ * comparison rejects a legitimate install whenever the user's active org drifted
+ * from the org they launched the install from (the UI-selected org threaded via
+ * `?org=`). Membership is the real authorization — the state org was already
+ * membership-checked at start, so the callback just re-confirms the completing
+ * user still belongs to it.
+ *
+ * On self-host (no authenticated user) the org is authorized only when it is the
+ * sole tenant.
+ */
+export async function verifyInstallOrgAccess(
+  c: Context,
+  organizationId: string
+): Promise<boolean> {
+  const userId = readUserId(c);
+  if (userId) {
+    const role = await getCachedMembershipRole(organizationId, userId);
+    return role !== null;
+  }
+  const single = await resolveSingleTenantOrgId();
+  return single !== null && single === organizationId;
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -33,7 +33,12 @@ import { getDb } from "./db/client";
 import * as invalidationEmitter from "./events/emitter";
 import { streamInvalidationEvents } from "./events/sse";
 import { invalidationSseAuth } from "./events/sse-invalidation-auth";
-import { claimSlackWorkspace } from "./gateway/connections/slack-claim";
+import {
+	type ClaimEligibleOrg,
+	type SlackClaimDeps,
+	claimSlackWorkspace,
+	resolveSlackClaimContext,
+} from "./gateway/connections/slack-claim";
 import { createSlackWebApi } from "./gateway/connections/slack-web";
 import {
 	getMaxReservedLocks,
@@ -1458,79 +1463,141 @@ async function resolveClaimingUserSlackId(
  * Registered before the `/api/:orgSlug/:toolName` proxy so `slack`/`claim`
  * doesn't get swallowed as an org tool call.
  */
-app.post("/api/slack/claim", async (c) => {
-	// The main app doesn't run the Lobu auth bridge, so resolve the session here
-	// (same pattern as /api/:orgSlug/join). Cookie or Better-Auth bearer.
-	let userId: string | null = null;
+// The main app doesn't run the Lobu auth bridge, so resolve the session here
+// (same pattern as /api/:orgSlug/join). Cookie or Better-Auth bearer.
+async function resolveClaimSessionUser(env: Env, req: Request): Promise<string | null> {
 	try {
-		const auth = await createAuth(c.env);
-		const session = await auth.api.getSession({ headers: c.req.raw.headers });
-		userId = session?.user?.id ?? null;
+		const auth = await createAuth(env);
+		const session = await auth.api.getSession({ headers: req.headers });
+		return session?.user?.id ?? null;
 	} catch {
-		userId = null;
+		return null;
 	}
+}
 
-	let body: { team?: unknown; token?: unknown };
+// Wire the real stores/APIs behind the injectable SlackClaimDeps (shared by the
+// context + claim routes).
+function slackClaimDeps(): SlackClaimDeps {
+	return {
+		resolvePending: (t) => resolveSlackPendingByTenant(t),
+		resolveClaimerSlackId: resolveClaimingUserSlackId,
+		usersInfo: (botToken, uid) => createSlackWebApi().usersInfo(botToken, uid),
+		resolveMemberOrgs: async (userId) =>
+			(await getDb()`
+				SELECT o.id, o.slug, o.name
+				FROM "member" m JOIN "organization" o ON o.id = m."organizationId"
+				WHERE m."userId" = ${userId}
+				ORDER BY o.name
+			`) as ClaimEligibleOrg[],
+		resolveOrgIfMember: async (userId, orgSlugOrId) => {
+			const rows = (await getDb()`
+				SELECT o.id
+				FROM "organization" o
+				JOIN "member" m ON m."organizationId" = o.id AND m."userId" = ${userId}
+				WHERE o.slug = ${orgSlugOrId} OR o.id = ${orgSlugOrId}
+				LIMIT 1
+			`) as Array<{ id: string }>;
+			return rows[0]?.id ?? null;
+		},
+		resolveDefaultOrgId: (uid) => resolveDefaultOrgId(uid),
+		claim: (pending, organizationId) => {
+			const core = getLobuCoreServices();
+			if (!core) throw new Error("Lobu core services unavailable");
+			return claimSlackPendingInstall(
+				core.getAppInstallationStore(),
+				core.getSecretStore(),
+				pending,
+				organizationId,
+			);
+		},
+		resolveOrgSlug: async (organizationId) => {
+			const orgRows = (await getDb()`
+				SELECT slug FROM "organization" WHERE id = ${organizationId} LIMIT 1
+			`) as Array<{ slug: string }>;
+			return orgRows[0]?.slug ?? null;
+		},
+	};
+}
+
+/** Map a claim/context status to its HTTP code (shared by both routes). */
+function slackClaimHttpStatus(status: string): 400 | 401 | 403 | 404 | 409 | 500 {
+	switch (status) {
+		case "unauthenticated":
+			return 401;
+		case "invalid_request":
+			return 400;
+		case "no_pending_install":
+			return 404;
+		case "invalid_token":
+		case "slack_signin_required":
+		case "not_admin":
+		case "not_member_of_org":
+			return 403;
+		case "no_org":
+			return 409;
+		default:
+			return 500;
+	}
+}
+
+// GET /api/slack/claim/context — the confirm step's data. Runs the guards (token
+// + Slack-admin) with NO write and returns the workspace name + the claimer's
+// orgs, so /slack/claim can render "Connect <workspace> to <org>" before binding.
+app.get("/api/slack/claim/context", async (c) => {
+	const userId = await resolveClaimSessionUser(c.env, c.req.raw);
+	const team = (c.req.query("team") ?? "").trim();
+	const token = c.req.query("t") ?? "";
+	const ctx = await resolveSlackClaimContext(slackClaimDeps(), {
+		userId,
+		team,
+		token,
+	});
+	if (ctx.status === "ready") {
+		return c.json({ ok: true, workspaceName: ctx.workspaceName, orgs: ctx.orgs });
+	}
+	return c.json({ error: ctx.status }, slackClaimHttpStatus(ctx.status));
+});
+
+app.post("/api/slack/claim", async (c) => {
+	const userId = await resolveClaimSessionUser(c.env, c.req.raw);
+
+	let body: { team?: unknown; token?: unknown; org?: unknown };
 	try {
-		body = (await c.req.json()) as { team?: unknown; token?: unknown };
+		body = (await c.req.json()) as {
+			team?: unknown;
+			token?: unknown;
+			org?: unknown;
+		};
 	} catch {
 		body = {};
 	}
 	const team = typeof body.team === "string" ? body.team.trim() : "";
 	const token = typeof body.token === "string" ? body.token : "";
+	// The org the user CONFIRMED on the /slack/claim page (slug or id). Optional
+	// for programmatic callers, who then fall back to the default org.
+	const organizationId =
+		typeof body.org === "string" && body.org.trim() ? body.org.trim() : undefined;
 
 	// All branching lives in the injectable `claimSlackWorkspace` so it stays
 	// unit-testable; the route only wires real deps + maps outcomes to HTTP.
-	const result = await claimSlackWorkspace(
-		{
-			resolvePending: (t) => resolveSlackPendingByTenant(t),
-			resolveClaimerSlackId: resolveClaimingUserSlackId,
-			usersInfo: (botToken, uid) => createSlackWebApi().usersInfo(botToken, uid),
-			resolveDefaultOrgId: (uid) => resolveDefaultOrgId(uid),
-			claim: (pending, organizationId) => {
-				const core = getLobuCoreServices();
-				if (!core) throw new Error("Lobu core services unavailable");
-				return claimSlackPendingInstall(
-					core.getAppInstallationStore(),
-					core.getSecretStore(),
-					pending,
-					organizationId,
-				);
-			},
-			resolveOrgSlug: async (organizationId) => {
-				const orgRows = (await getDb()`
-					SELECT slug FROM "organization" WHERE id = ${organizationId} LIMIT 1
-				`) as Array<{ slug: string }>;
-				return orgRows[0]?.slug ?? null;
-			},
-		},
-		{ userId, team, token },
-	);
+	const result = await claimSlackWorkspace(slackClaimDeps(), {
+		userId,
+		team,
+		token,
+		organizationId,
+	});
 
-	switch (result.status) {
-		case "ok":
-			return c.json({ ok: true, orgSlug: result.orgSlug, provider: "slack" });
-		case "unauthenticated":
-			return c.json({ error: "unauthenticated" }, 401);
-		case "invalid_request":
-			return c.json({ error: "invalid_request" }, 400);
-		case "no_pending_install":
-			return c.json({ error: "no_pending_install" }, 404);
-		case "invalid_token":
-			return c.json({ error: "invalid_token" }, 403);
-		case "slack_signin_required":
-			return c.json({ error: "slack_signin_required" }, 403);
-		case "not_admin":
-			return c.json({ error: "not_admin" }, 403);
-		case "no_org":
-			return c.json({ error: "no_org" }, 409);
-		case "claim_failed":
-			logger.error(
-				{ team, err: result.message },
-				"Slack workspace claim failed",
-			);
-			return c.json({ error: "claim_failed", message: result.message }, 500);
+	if (result.status === "ok") {
+		return c.json({ ok: true, orgSlug: result.orgSlug, provider: "slack" });
 	}
+	if (result.status === "claim_failed") {
+		logger.error({ team, err: result.message }, "Slack workspace claim failed");
+		return c.json(
+			{ error: "claim_failed", message: result.message },
+			500,
+		);
+	}
+	return c.json({ error: result.status }, slackClaimHttpStatus(result.status));
 });
 
 /**
@@ -1562,6 +1629,7 @@ app.get("/slack/claim", (c) => {
   var p=new URLSearchParams(location.search),team=p.get("team"),token=p.get("t");
   var statusEl=document.getElementById("status"),actionEl=document.getElementById("action");
   function setStatus(m){statusEl.textContent=m}
+  function esc(s){var d=document.createElement("div");d.textContent=s==null?"":String(s);return d.innerHTML}
   function showSignIn(){
     actionEl.innerHTML='<button id="si">Sign in with Slack</button>';
     document.getElementById("si").onclick=signIn;
@@ -1572,20 +1640,49 @@ app.get("/slack/claim", (c) => {
     var d=await r.json().catch(function(){return{}});
     if(d.url){location.href=d.url}else{setStatus("Could not start Slack sign-in.")}
   }
-  async function claim(){
-    if(!team||!token){setStatus("This claim link is missing its parameters.");return}
-    setStatus("Connecting your workspace…");
-    var r=await fetch("/api/slack/claim",{method:"POST",headers:{"content-type":"application/json"},credentials:"include",body:JSON.stringify({team:team,token:token})});
-    var d=await r.json().catch(function(){return{}});
-    if(d.ok){setStatus("Connected! Redirecting…");location.href=d.orgSlug?"/"+d.orgSlug+"/agents?connected=slack":"/";return}
-    if(d.error==="unauthenticated"||d.error==="slack_signin_required"){setStatus("Sign in with Slack to verify you are an admin of this workspace.");showSignIn();return}
-    if(d.error==="not_admin"){setStatus("You must be a workspace admin or owner to connect this workspace.");return}
-    if(d.error==="invalid_token"){setStatus("This claim link is invalid or has already been used.");return}
-    if(d.error==="no_pending_install"){setStatus("This workspace install was not found — it may have expired or already been connected.");return}
-    if(d.error==="no_org"){setStatus("Your account has no organization to connect this workspace to.");return}
+  function handleError(err){
+    if(err==="unauthenticated"||err==="slack_signin_required"){setStatus("Sign in with Slack to verify you are an admin of this workspace.");showSignIn();return}
+    if(err==="not_admin"){setStatus("You must be a workspace admin or owner to connect this workspace.");return}
+    if(err==="not_member_of_org"){setStatus("You are not a member of the selected organization.");return}
+    if(err==="invalid_token"){setStatus("This claim link is invalid or has already been used.");return}
+    if(err==="no_pending_install"){setStatus("This workspace install was not found — it may have expired or already been connected.");return}
+    if(err==="no_org"){setStatus("Your account has no Lobu organization to connect this workspace to.");return}
     setStatus("Something went wrong connecting this workspace.");
   }
-  claim();
+  // CONFIRM step: user explicitly accepts connecting the workspace to a chosen org.
+  function showConfirm(workspaceName, orgs){
+    var name=workspaceName||"this Slack workspace";
+    setStatus("You're an admin of "+name+". Choose the Lobu organization to connect it to:");
+    var picker;
+    if(orgs.length>1){
+      picker='<select id="org" style="width:100%;padding:10px;border:1px solid #d0d5dd;border-radius:8px;font-size:15px;margin:6px 0 16px">'+
+        orgs.map(function(o){return '<option value="'+esc(o.slug)+'">'+esc(o.name)+'</option>'}).join('')+'</select>';
+    } else {
+      picker='<div style="margin:6px 0 16px;font-weight:600">'+esc(orgs[0].name)+'</div>';
+    }
+    actionEl.innerHTML=picker+'<button id="connect">Connect '+esc(name)+'</button>';
+    document.getElementById("connect").onclick=function(){
+      var org=orgs.length>1?document.getElementById("org").value:orgs[0].slug;
+      doClaim(org);
+    };
+  }
+  async function doClaim(org){
+    actionEl.innerHTML="";
+    setStatus("Connecting "+ (org||"") +"…");
+    var r=await fetch("/api/slack/claim",{method:"POST",headers:{"content-type":"application/json"},credentials:"include",body:JSON.stringify({team:team,token:token,org:org})});
+    var d=await r.json().catch(function(){return{}});
+    if(d.ok){setStatus("Connected! Redirecting…");location.href=d.orgSlug?"/"+d.orgSlug+"/agents?connected=slack":"/";return}
+    handleError(d.error);
+  }
+  async function loadContext(){
+    if(!team||!token){setStatus("This claim link is missing its parameters.");return}
+    setStatus("Checking your access…");
+    var r=await fetch("/api/slack/claim/context?team="+encodeURIComponent(team)+"&t="+encodeURIComponent(token),{credentials:"include"});
+    var d=await r.json().catch(function(){return{}});
+    if(d.ok){showConfirm(d.workspaceName,d.orgs||[]);return}
+    handleError(d.error);
+  }
+  loadContext();
 </script>
 </body></html>`;
 	return c.html(html);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1534,6 +1534,64 @@ app.post("/api/slack/claim", async (c) => {
 });
 
 /**
+ * GET /slack/claim — the page the marketplace-install claim DM links to. A thin
+ * shell: it POSTs to /api/slack/claim (above) with the team + single-use token,
+ * and on `slack_signin_required` walks the user through Sign in with Slack (so we
+ * can verify they are a workspace admin) before retrying. Server-rendered so the
+ * whole marketplace flow stays provider-generic and needs no SPA route.
+ */
+app.get("/slack/claim", (c) => {
+	const html = `<!doctype html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Connect Slack to Lobu</title>
+<style>
+  body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#0b1220;color:#e6e9ef;font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}
+  .card{background:#fff;color:#0b1220;max-width:420px;width:90%;padding:40px 32px;border-radius:14px;text-align:center;box-shadow:0 10px 40px rgba(0,0,0,.35)}
+  h1{font-size:20px;margin:16px 0 8px}
+  #status{color:#4b5565;margin:8px 0 20px}
+  button{background:#611f69;color:#fff;border:0;border-radius:8px;padding:12px 18px;font-size:15px;font-weight:600;cursor:pointer}
+  button:hover{opacity:.92}
+</style></head>
+<body><div class="card">
+  <div style="font-size:40px">🔗</div>
+  <h1>Connect this Slack workspace to Lobu</h1>
+  <div id="status">Connecting your workspace…</div>
+  <div id="action"></div>
+</div>
+<script>
+  var p=new URLSearchParams(location.search),team=p.get("team"),token=p.get("t");
+  var statusEl=document.getElementById("status"),actionEl=document.getElementById("action");
+  function setStatus(m){statusEl.textContent=m}
+  function showSignIn(){
+    actionEl.innerHTML='<button id="si">Sign in with Slack</button>';
+    document.getElementById("si").onclick=signIn;
+  }
+  async function signIn(){
+    setStatus("Redirecting to Slack…");
+    var r=await fetch("/api/auth/sign-in/social",{method:"POST",headers:{"content-type":"application/json"},credentials:"include",body:JSON.stringify({provider:"slack",callbackURL:location.href})});
+    var d=await r.json().catch(function(){return{}});
+    if(d.url){location.href=d.url}else{setStatus("Could not start Slack sign-in.")}
+  }
+  async function claim(){
+    if(!team||!token){setStatus("This claim link is missing its parameters.");return}
+    setStatus("Connecting your workspace…");
+    var r=await fetch("/api/slack/claim",{method:"POST",headers:{"content-type":"application/json"},credentials:"include",body:JSON.stringify({team:team,token:token})});
+    var d=await r.json().catch(function(){return{}});
+    if(d.ok){setStatus("Connected! Redirecting…");location.href=d.orgSlug?"/"+d.orgSlug+"/agents?connected=slack":"/";return}
+    if(d.error==="unauthenticated"||d.error==="slack_signin_required"){setStatus("Sign in with Slack to verify you are an admin of this workspace.");showSignIn();return}
+    if(d.error==="not_admin"){setStatus("You must be a workspace admin or owner to connect this workspace.");return}
+    if(d.error==="invalid_token"){setStatus("This claim link is invalid or has already been used.");return}
+    if(d.error==="no_pending_install"){setStatus("This workspace install was not found — it may have expired or already been connected.");return}
+    if(d.error==="no_org"){setStatus("Your account has no organization to connect this workspace to.");return}
+    setStatus("Something went wrong connecting this workspace.");
+  }
+  claim();
+</script>
+</body></html>`;
+	return c.html(html);
+});
+
+/**
  * GET /api/:orgSlug/tools
  * List admin REST tools available to the caller. Companion to the POST
  * proxy below — gives CLI/web callers a discovery surface without spinning

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1480,6 +1480,18 @@ async function resolveClaimSessionUser(env: Env, req: Request): Promise<string |
 function slackClaimDeps(): SlackClaimDeps {
 	return {
 		resolvePending: (t) => resolveSlackPendingByTenant(t),
+		resolveActiveOrgSlug: async (team) => {
+			const rows = (await getDb()`
+				SELECT o.slug
+				FROM app_installations ai
+				JOIN "organization" o ON o.id = ai.organization_id
+				WHERE ai.provider = 'slack'
+					AND ai.external_tenant_id = ${team}
+					AND ai.status = 'active'
+				LIMIT 1
+			`) as Array<{ slug: string }>;
+			return rows[0]?.slug ?? null;
+		},
 		resolveClaimerSlackId: resolveClaimingUserSlackId,
 		usersInfo: (botToken, uid) => createSlackWebApi().usersInfo(botToken, uid),
 		resolveMemberOrgs: async (userId) =>
@@ -1528,7 +1540,6 @@ function slackClaimHttpStatus(status: string): 400 | 401 | 403 | 404 | 409 | 500
 			return 400;
 		case "no_pending_install":
 			return 404;
-		case "invalid_token":
 		case "slack_signin_required":
 		case "not_admin":
 		case "not_member_of_org":
@@ -1540,20 +1551,23 @@ function slackClaimHttpStatus(status: string): 400 | 401 | 403 | 404 | 409 | 500
 	}
 }
 
-// GET /api/slack/claim/context — the confirm step's data. Runs the guards (token
-// + Slack-admin) with NO write and returns the workspace name + the claimer's
-// orgs, so /slack/claim can render "Connect <workspace> to <org>" before binding.
+// GET /api/slack/claim/context — the confirm step's data. Runs the guards
+// (Slack workspace-admin) with NO write and returns the workspace name + the
+// claimer's orgs, so /slack/claim can render "Connect <workspace> to <org>"
+// before binding. Surfaces `already_connected` for a workspace already bound, so
+// the UI links to it instead of erroring on a re-visited/spent link.
 app.get("/api/slack/claim/context", async (c) => {
 	const userId = await resolveClaimSessionUser(c.env, c.req.raw);
 	const team = (c.req.query("team") ?? "").trim();
-	const token = c.req.query("t") ?? "";
 	const ctx = await resolveSlackClaimContext(slackClaimDeps(), {
 		userId,
 		team,
-		token,
 	});
 	if (ctx.status === "ready") {
 		return c.json({ ok: true, workspaceName: ctx.workspaceName, orgs: ctx.orgs });
+	}
+	if (ctx.status === "already_connected") {
+		return c.json({ ok: true, alreadyConnected: true, orgSlug: ctx.orgSlug });
 	}
 	return c.json({ error: ctx.status }, slackClaimHttpStatus(ctx.status));
 });
@@ -1561,18 +1575,16 @@ app.get("/api/slack/claim/context", async (c) => {
 app.post("/api/slack/claim", async (c) => {
 	const userId = await resolveClaimSessionUser(c.env, c.req.raw);
 
-	let body: { team?: unknown; token?: unknown; org?: unknown };
+	let body: { team?: unknown; org?: unknown };
 	try {
 		body = (await c.req.json()) as {
 			team?: unknown;
-			token?: unknown;
 			org?: unknown;
 		};
 	} catch {
 		body = {};
 	}
 	const team = typeof body.team === "string" ? body.team.trim() : "";
-	const token = typeof body.token === "string" ? body.token : "";
 	// The org the user CONFIRMED on the /slack/claim page (slug or id). Optional
 	// for programmatic callers, who then fall back to the default org.
 	const organizationId =
@@ -1583,12 +1595,16 @@ app.post("/api/slack/claim", async (c) => {
 	const result = await claimSlackWorkspace(slackClaimDeps(), {
 		userId,
 		team,
-		token,
 		organizationId,
 	});
 
 	if (result.status === "ok") {
-		return c.json({ ok: true, orgSlug: result.orgSlug, provider: "slack" });
+		return c.json({
+			ok: true,
+			orgSlug: result.orgSlug,
+			provider: "slack",
+			alreadyConnected: result.alreadyConnected ?? false,
+		});
 	}
 	if (result.status === "claim_failed") {
 		logger.error({ team, err: result.message }, "Slack workspace claim failed");
@@ -1598,94 +1614,6 @@ app.post("/api/slack/claim", async (c) => {
 		);
 	}
 	return c.json({ error: result.status }, slackClaimHttpStatus(result.status));
-});
-
-/**
- * GET /slack/claim — the page the marketplace-install claim DM links to. A thin
- * shell: it POSTs to /api/slack/claim (above) with the team + single-use token,
- * and on `slack_signin_required` walks the user through Sign in with Slack (so we
- * can verify they are a workspace admin) before retrying. Server-rendered so the
- * whole marketplace flow stays provider-generic and needs no SPA route.
- */
-app.get("/slack/claim", (c) => {
-	const html = `<!doctype html>
-<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Connect Slack to Lobu</title>
-<style>
-  body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#0b1220;color:#e6e9ef;font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}
-  .card{background:#fff;color:#0b1220;max-width:420px;width:90%;padding:40px 32px;border-radius:14px;text-align:center;box-shadow:0 10px 40px rgba(0,0,0,.35)}
-  h1{font-size:20px;margin:16px 0 8px}
-  #status{color:#4b5565;margin:8px 0 20px}
-  button{background:#611f69;color:#fff;border:0;border-radius:8px;padding:12px 18px;font-size:15px;font-weight:600;cursor:pointer}
-  button:hover{opacity:.92}
-</style></head>
-<body><div class="card">
-  <div style="font-size:40px">🔗</div>
-  <h1>Connect this Slack workspace to Lobu</h1>
-  <div id="status">Connecting your workspace…</div>
-  <div id="action"></div>
-</div>
-<script>
-  var p=new URLSearchParams(location.search),team=p.get("team"),token=p.get("t");
-  var statusEl=document.getElementById("status"),actionEl=document.getElementById("action");
-  function setStatus(m){statusEl.textContent=m}
-  function esc(s){var d=document.createElement("div");d.textContent=s==null?"":String(s);return d.innerHTML}
-  function showSignIn(){
-    actionEl.innerHTML='<button id="si">Sign in with Slack</button>';
-    document.getElementById("si").onclick=signIn;
-  }
-  async function signIn(){
-    setStatus("Redirecting to Slack…");
-    var r=await fetch("/api/auth/sign-in/social",{method:"POST",headers:{"content-type":"application/json"},credentials:"include",body:JSON.stringify({provider:"slack",callbackURL:location.href})});
-    var d=await r.json().catch(function(){return{}});
-    if(d.url){location.href=d.url}else{setStatus("Could not start Slack sign-in.")}
-  }
-  function handleError(err){
-    if(err==="unauthenticated"||err==="slack_signin_required"){setStatus("Sign in with Slack to verify you are an admin of this workspace.");showSignIn();return}
-    if(err==="not_admin"){setStatus("You must be a workspace admin or owner to connect this workspace.");return}
-    if(err==="not_member_of_org"){setStatus("You are not a member of the selected organization.");return}
-    if(err==="invalid_token"){setStatus("This claim link is invalid or has already been used.");return}
-    if(err==="no_pending_install"){setStatus("This workspace install was not found — it may have expired or already been connected.");return}
-    if(err==="no_org"){setStatus("Your account has no Lobu organization to connect this workspace to.");return}
-    setStatus("Something went wrong connecting this workspace.");
-  }
-  // CONFIRM step: user explicitly accepts connecting the workspace to a chosen org.
-  function showConfirm(workspaceName, orgs){
-    var name=workspaceName||"this Slack workspace";
-    setStatus("You're an admin of "+name+". Choose the Lobu organization to connect it to:");
-    var picker;
-    if(orgs.length>1){
-      picker='<select id="org" style="width:100%;padding:10px;border:1px solid #d0d5dd;border-radius:8px;font-size:15px;margin:6px 0 16px">'+
-        orgs.map(function(o){return '<option value="'+esc(o.slug)+'">'+esc(o.name)+'</option>'}).join('')+'</select>';
-    } else {
-      picker='<div style="margin:6px 0 16px;font-weight:600">'+esc(orgs[0].name)+'</div>';
-    }
-    actionEl.innerHTML=picker+'<button id="connect">Connect '+esc(name)+'</button>';
-    document.getElementById("connect").onclick=function(){
-      var org=orgs.length>1?document.getElementById("org").value:orgs[0].slug;
-      doClaim(org);
-    };
-  }
-  async function doClaim(org){
-    actionEl.innerHTML="";
-    setStatus("Connecting "+ (org||"") +"…");
-    var r=await fetch("/api/slack/claim",{method:"POST",headers:{"content-type":"application/json"},credentials:"include",body:JSON.stringify({team:team,token:token,org:org})});
-    var d=await r.json().catch(function(){return{}});
-    if(d.ok){setStatus("Connected! Redirecting…");location.href=d.orgSlug?"/"+d.orgSlug+"/agents?connected=slack":"/";return}
-    handleError(d.error);
-  }
-  async function loadContext(){
-    if(!team||!token){setStatus("This claim link is missing its parameters.");return}
-    setStatus("Checking your access…");
-    var r=await fetch("/api/slack/claim/context?team="+encodeURIComponent(team)+"&t="+encodeURIComponent(token),{credentials:"include"});
-    var d=await r.json().catch(function(){return{}});
-    if(d.ok){showConfirm(d.workspaceName,d.orgs||[]);return}
-    handleError(d.error);
-  }
-  loadContext();
-</script>
-</body></html>`;
-	return c.html(html);
 });
 
 /**

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -33,6 +33,8 @@ import { getDb } from "./db/client";
 import * as invalidationEmitter from "./events/emitter";
 import { streamInvalidationEvents } from "./events/sse";
 import { invalidationSseAuth } from "./events/sse-invalidation-auth";
+import { claimSlackWorkspace } from "./gateway/connections/slack-claim";
+import { createSlackWebApi } from "./gateway/connections/slack-web";
 import {
 	getMaxReservedLocks,
 	getReservedLockCount,
@@ -42,7 +44,15 @@ import { isShuttingDown } from "./lifecycle-state";
 import { agentRoutes } from "./lobu/agent-routes";
 import { environmentRoutes } from "./lobu/environment-routes";
 import { clientRoutes, platformSchemaRoutes } from "./lobu/client-routes";
-import { isLobuGatewayRunning } from "./lobu/gateway";
+import {
+	getLobuCoreServices,
+	isLobuGatewayRunning,
+	resolveDefaultOrgId,
+} from "./lobu/gateway";
+import {
+	claimSlackPendingInstall,
+	resolveSlackPendingByTenant,
+} from "./lobu/stores/slack-installations";
 import { handleMcp } from "./mcp-handler";
 import {
 	restDeleteNotification,
@@ -1394,6 +1404,133 @@ app.post("/api/:orgSlug/join", async (c) => {
 		organizationId: result.organizationId,
 		role: result.role,
 	});
+});
+
+/**
+ * Resolve the signed-in user's team-scoped `slack_user_id` (`T…:U…`) for a Slack
+ * workspace, returning the bare `U…` id or null when they never signed in with
+ * Slack for that team. Reuses the canonical `entity_identities` shape the authz
+ * layer writes on Slack sign-in (namespace `slack_user_id`, identifier stored
+ * uppercased as `T…:U…` on the user's `$member`), joined to the user's memberships
+ * via the guarded `auth_user_id`/`auth:signup` claim so a user-supplied identity
+ * row can't hijack the lookup. Org-agnostic (the identity may live in any org the
+ * user belongs to), so it runs BEFORE we resolve the org to bind into.
+ */
+async function resolveClaimingUserSlackId(
+	userId: string,
+	teamId: string,
+): Promise<string | null> {
+	const sql = getDb();
+	const rows = (await sql`
+		SELECT DISTINCT ei.identifier
+		FROM "member" m
+		JOIN entity_identities auth_ei
+		  ON auth_ei.organization_id = m."organizationId"
+		 AND auth_ei.namespace = 'auth_user_id'
+		 AND auth_ei.identifier = m."userId"
+		 AND auth_ei.source_connector = 'auth:signup'
+		 AND auth_ei.deleted_at IS NULL
+		JOIN entity_identities ei
+		  ON ei.organization_id = auth_ei.organization_id
+		 AND ei.entity_id = auth_ei.entity_id
+		 AND ei.namespace = 'slack_user_id'
+		 AND ei.deleted_at IS NULL
+		WHERE m."userId" = ${userId}
+	`) as Array<{ identifier: string }>;
+	const teamPrefix = `${teamId.toUpperCase()}:`;
+	const combined = rows
+		.map((r) => String(r.identifier))
+		.find((id) => id.startsWith(teamPrefix));
+	return combined ? combined.slice(teamPrefix.length) : null;
+}
+
+/**
+ * POST /api/slack/claim — claim a marketplace / Slack-initiated (pending) Slack
+ * workspace into the signed-in user's org.
+ *
+ * Body: `{ team: string, token: string }` — the workspace id and the single-use
+ * claim token from the installer's DM'd link. Binds the parked pending install
+ * (see `writeSlackPendingInstall`) to the user's default org after proving the
+ * caller (a) holds the single-use token, (b) signed in with Slack for this
+ * workspace, and (c) is a workspace admin/owner. Neither the bot token nor the
+ * plaintext claim token is ever logged or returned.
+ *
+ * Registered before the `/api/:orgSlug/:toolName` proxy so `slack`/`claim`
+ * doesn't get swallowed as an org tool call.
+ */
+app.post("/api/slack/claim", async (c) => {
+	// The main app doesn't run the Lobu auth bridge, so resolve the session here
+	// (same pattern as /api/:orgSlug/join). Cookie or Better-Auth bearer.
+	let userId: string | null = null;
+	try {
+		const auth = await createAuth(c.env);
+		const session = await auth.api.getSession({ headers: c.req.raw.headers });
+		userId = session?.user?.id ?? null;
+	} catch {
+		userId = null;
+	}
+
+	let body: { team?: unknown; token?: unknown };
+	try {
+		body = (await c.req.json()) as { team?: unknown; token?: unknown };
+	} catch {
+		body = {};
+	}
+	const team = typeof body.team === "string" ? body.team.trim() : "";
+	const token = typeof body.token === "string" ? body.token : "";
+
+	// All branching lives in the injectable `claimSlackWorkspace` so it stays
+	// unit-testable; the route only wires real deps + maps outcomes to HTTP.
+	const result = await claimSlackWorkspace(
+		{
+			resolvePending: (t) => resolveSlackPendingByTenant(t),
+			resolveClaimerSlackId: resolveClaimingUserSlackId,
+			usersInfo: (botToken, uid) => createSlackWebApi().usersInfo(botToken, uid),
+			resolveDefaultOrgId: (uid) => resolveDefaultOrgId(uid),
+			claim: (pending, organizationId) => {
+				const core = getLobuCoreServices();
+				if (!core) throw new Error("Lobu core services unavailable");
+				return claimSlackPendingInstall(
+					core.getAppInstallationStore(),
+					core.getSecretStore(),
+					pending,
+					organizationId,
+				);
+			},
+			resolveOrgSlug: async (organizationId) => {
+				const orgRows = (await getDb()`
+					SELECT slug FROM "organization" WHERE id = ${organizationId} LIMIT 1
+				`) as Array<{ slug: string }>;
+				return orgRows[0]?.slug ?? null;
+			},
+		},
+		{ userId, team, token },
+	);
+
+	switch (result.status) {
+		case "ok":
+			return c.json({ ok: true, orgSlug: result.orgSlug, provider: "slack" });
+		case "unauthenticated":
+			return c.json({ error: "unauthenticated" }, 401);
+		case "invalid_request":
+			return c.json({ error: "invalid_request" }, 400);
+		case "no_pending_install":
+			return c.json({ error: "no_pending_install" }, 404);
+		case "invalid_token":
+			return c.json({ error: "invalid_token" }, 403);
+		case "slack_signin_required":
+			return c.json({ error: "slack_signin_required" }, 403);
+		case "not_admin":
+			return c.json({ error: "not_admin" }, 403);
+		case "no_org":
+			return c.json({ error: "no_org" }, 409);
+		case "claim_failed":
+			logger.error(
+				{ team, err: result.message },
+				"Slack workspace claim failed",
+			);
+			return c.json({ error: "claim_failed", message: result.message }, 500);
+	}
 });
 
 /**

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -55,7 +55,9 @@ const defaultOrgCache = new Map<
 	{ orgId: string | null; expiresAt: number }
 >();
 
-async function resolveDefaultOrgId(userId: string): Promise<string | null> {
+export async function resolveDefaultOrgId(
+	userId: string,
+): Promise<string | null> {
 	const cached = defaultOrgCache.get(userId);
 	if (cached && cached.expiresAt > Date.now()) return cached.orgId;
 

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { createLogger } from "@lobu/core";
+import { createLogger, decrypt, encrypt } from "@lobu/core";
 import type { StoredConnection } from "@lobu/core";
 import { getDb } from "../../db/client.js";
 import type { WritableSecretStore } from "../../gateway/secrets/index.js";
@@ -361,4 +361,114 @@ export async function deleteSlackInstall(
   } else {
     await purge();
   }
+}
+
+// ---------------------------------------------------------------------------
+// Marketplace / Slack-initiated installs — the UNCLAIMED (pending) path.
+//
+// These arrive at the callback with a bot token but no Lobu org. Park them as a
+// `pending`, org-less `app_installations` row until an admin claims the
+// workspace by signing in with Slack. The org-scoped secret store can't hold an
+// org-less token, so the bot token is stored ENCRYPTED in metadata (same
+// ENCRYPTION_KEY as the secret store); on claim it's decrypted and re-persisted
+// via {@link upsertSlackInstallByTeam}. Routing ignores non-active rows, so the
+// bot is inert until claimed.
+// ---------------------------------------------------------------------------
+
+export interface SlackPendingInstallInput {
+  teamId: string;
+  teamName: string | null;
+  botUserId: string | null;
+  /** Plaintext bot token — stored encrypted, never in the clear. */
+  botToken: string;
+  /** The Slack user who clicked Allow (`authed_user.id`); the DM/claim target. */
+  installerUserId: string | null;
+  isEnterpriseInstall: boolean;
+}
+
+export interface SlackPendingInstall {
+  id: string;
+  teamId: string;
+  teamName: string | null;
+  botUserId: string | null;
+  installerUserId: string | null;
+  /** Decrypted bot token. */
+  botToken: string;
+  isEnterpriseInstall: boolean;
+}
+
+/** Park (or refresh) the single pending install for a Slack workspace. */
+export async function writeSlackPendingInstall(
+  install: SlackPendingInstallInput
+): Promise<{ id: string }> {
+  const sql = getDb();
+  const metadata = {
+    team_name: install.teamName,
+    bot_user_id: install.botUserId,
+    installer_user_id: install.installerUserId,
+    is_enterprise_install: install.isEnterpriseInstall,
+    bot_token_enc: encrypt(install.botToken),
+  };
+  // Refresh: at most one pending row per team (a re-install replaces it).
+  await sql`
+    DELETE FROM app_installations
+    WHERE provider = ${SLACK_PROVIDER}
+      AND provider_app_id = ${SLACK_PROVIDER_APP_ID}
+      AND external_tenant_id = ${install.teamId}
+      AND status = 'pending'
+  `;
+  const rows = (await sql`
+    INSERT INTO app_installations
+      (organization_id, provider, provider_instance, provider_app_id,
+       external_tenant_id, status, metadata)
+    VALUES
+      (NULL, ${SLACK_PROVIDER}, ${SLACK_PROVIDER_INSTANCE},
+       ${SLACK_PROVIDER_APP_ID}, ${install.teamId}, 'pending',
+       ${sql.json(metadata)})
+    RETURNING id
+  `) as Array<{ id: number | string }>;
+  return { id: String(rows[0]!.id) };
+}
+
+/** Resolve the pending (unclaimed) install for a Slack workspace, if any. */
+export async function resolveSlackPendingByTenant(
+  teamId: string
+): Promise<SlackPendingInstall | null> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT id, external_tenant_id, metadata
+    FROM app_installations
+    WHERE provider = ${SLACK_PROVIDER}
+      AND provider_app_id = ${SLACK_PROVIDER_APP_ID}
+      AND external_tenant_id = ${teamId}
+      AND status = 'pending'
+    ORDER BY created_at DESC
+    LIMIT 1
+  `) as Array<{
+    id: number | string;
+    external_tenant_id: string;
+    metadata: Record<string, unknown>;
+  }>;
+  const row = rows[0];
+  if (!row) return null;
+  const enc = row.metadata.bot_token_enc;
+  if (typeof enc !== "string" || !enc) return null;
+  return {
+    id: String(row.id),
+    teamId: row.external_tenant_id,
+    teamName:
+      typeof row.metadata.team_name === "string"
+        ? row.metadata.team_name
+        : null,
+    botUserId:
+      typeof row.metadata.bot_user_id === "string"
+        ? row.metadata.bot_user_id
+        : null,
+    installerUserId:
+      typeof row.metadata.installer_user_id === "string"
+        ? row.metadata.installer_user_id
+        : null,
+    botToken: decrypt(enc),
+    isEnterpriseInstall: row.metadata.is_enterprise_install === true,
+  };
 }

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -402,6 +402,12 @@ export interface SlackPendingInstall {
   /** Decrypted bot token. */
   botToken: string;
   isEnterpriseInstall: boolean;
+  /**
+   * `sha256(claimToken)` (hex) of the single-use token DMed to the installer,
+   * or null when no claim link was minted (no installer to DM). The claim route
+   * validates the presented token against this hash before binding.
+   */
+  claimTokenHash: string | null;
 }
 
 /** Park (or refresh) the single pending install for a Slack workspace. */
@@ -478,5 +484,51 @@ export async function resolveSlackPendingByTenant(
         : null,
     botToken: decrypt(enc),
     isEnterpriseInstall: row.metadata.is_enterprise_install === true,
+    claimTokenHash:
+      typeof row.metadata.claim_token_hash === "string"
+        ? row.metadata.claim_token_hash
+        : null,
   };
+}
+
+/**
+ * Claim a pending (unclaimed) Slack workspace into an org: BIND the install
+ * (persist the bot token to the org-scoped secret store + create the active,
+ * org-owned `app_installations` + `connections` rows via
+ * {@link upsertSlackInstallByTeam}), then DELETE the org-less pending row so the
+ * workspace can't be double-claimed. Caller is responsible for authorizing the
+ * claim (token-hash match + workspace-admin check) BEFORE invoking this.
+ *
+ * The bind commits first; the pending delete is a best-effort follow-up on the
+ * same team so a crash between them leaves the workspace claimed (active row
+ * wins routing) with a harmless leftover pending row that the next claim
+ * replaces. Returns the stable `slackinst-<uuid>` install id.
+ */
+export async function claimSlackPendingInstall(
+  store: AppInstallationStore,
+  secretStore: WritableSecretStore,
+  pending: SlackPendingInstall,
+  organizationId: string
+): Promise<{ installationId: string }> {
+  const row = await upsertSlackInstallByTeam(
+    store,
+    secretStore,
+    organizationId,
+    pending.teamId,
+    {
+      teamName: pending.teamName ?? undefined,
+      botUserId: pending.botUserId ?? undefined,
+      botToken: pending.botToken,
+    }
+  );
+  // Retire the org-less pending row now that an active, org-owned install owns
+  // the workspace. Team-scoped: at most one pending row per team.
+  await getDb()`
+    DELETE FROM app_installations
+    WHERE provider = ${SLACK_PROVIDER}
+      AND provider_app_id = ${SLACK_PROVIDER_APP_ID}
+      AND external_tenant_id = ${pending.teamId}
+      AND status = 'pending'
+  `;
+  return { installationId: row.id };
 }

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -384,6 +384,13 @@ export interface SlackPendingInstallInput {
   /** The Slack user who clicked Allow (`authed_user.id`); the DM/claim target. */
   installerUserId: string | null;
   isEnterpriseInstall: boolean;
+  /**
+   * `sha256(claimToken)` (hex) of the single-use token DMed to the installer.
+   * Only the HASH is persisted — the plaintext token exists solely in the claim
+   * link, so a leaked pending row can't be replayed to claim the workspace. Null
+   * when there is no installer to DM (no claim link was minted).
+   */
+  claimTokenHash: string | null;
 }
 
 export interface SlackPendingInstall {
@@ -408,6 +415,7 @@ export async function writeSlackPendingInstall(
     installer_user_id: install.installerUserId,
     is_enterprise_install: install.isEnterpriseInstall,
     bot_token_enc: encrypt(install.botToken),
+    claim_token_hash: install.claimTokenHash,
   };
   // Refresh: at most one pending row per team (a re-install replaces it).
   await sql`

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -384,13 +384,6 @@ export interface SlackPendingInstallInput {
   /** The Slack user who clicked Allow (`authed_user.id`); the DM/claim target. */
   installerUserId: string | null;
   isEnterpriseInstall: boolean;
-  /**
-   * `sha256(claimToken)` (hex) of the single-use token DMed to the installer.
-   * Only the HASH is persisted — the plaintext token exists solely in the claim
-   * link, so a leaked pending row can't be replayed to claim the workspace. Null
-   * when there is no installer to DM (no claim link was minted).
-   */
-  claimTokenHash: string | null;
 }
 
 export interface SlackPendingInstall {
@@ -402,12 +395,6 @@ export interface SlackPendingInstall {
   /** Decrypted bot token. */
   botToken: string;
   isEnterpriseInstall: boolean;
-  /**
-   * `sha256(claimToken)` (hex) of the single-use token DMed to the installer,
-   * or null when no claim link was minted (no installer to DM). The claim route
-   * validates the presented token against this hash before binding.
-   */
-  claimTokenHash: string | null;
 }
 
 /** Park (or refresh) the single pending install for a Slack workspace. */
@@ -421,7 +408,6 @@ export async function writeSlackPendingInstall(
     installer_user_id: install.installerUserId,
     is_enterprise_install: install.isEnterpriseInstall,
     bot_token_enc: encrypt(install.botToken),
-    claim_token_hash: install.claimTokenHash,
   };
   // Refresh: at most one pending row per team (a re-install replaces it).
   await sql`
@@ -484,10 +470,6 @@ export async function resolveSlackPendingByTenant(
         : null,
     botToken: decrypt(enc),
     isEnterpriseInstall: row.metadata.is_enterprise_install === true,
-    claimTokenHash:
-      typeof row.metadata.claim_token_hash === "string"
-        ? row.metadata.claim_token_hash
-        : null,
   };
 }
 

--- a/packages/server/src/scheduled/__tests__/reap-expired-pending-installs.test.ts
+++ b/packages/server/src/scheduled/__tests__/reap-expired-pending-installs.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Integration test for the expired unclaimed-Slack-install reaper. Seeds
+ * org-less `pending` app_installations rows (marketplace / "Add to Slack"
+ * installs nobody claimed) plus an active install, and asserts the reaper only
+ * deletes pending rows past the TTL — attempting a best-effort token revoke on
+ * each — while leaving fresh pending rows and active/claimed installs untouched.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { encrypt } from '@lobu/core';
+import { getDb } from '../../db/client';
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from '../../gateway/__tests__/helpers/db-setup';
+import type { SlackWebApi } from '../../gateway/connections/slack-web';
+import { reapExpiredPendingSlackInstalls } from '../reap-expired-pending-installs';
+
+const ORG_ID = 'pending-install-reaper-org';
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+});
+
+beforeEach(async () => {
+  await resetTestDatabase();
+  const sql = getDb();
+  await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${ORG_ID}, ${ORG_ID}, ${ORG_ID})
+    ON CONFLICT (id) DO NOTHING
+  `;
+});
+
+/** Every method throws except revokeToken — the reaper only calls revokeToken. */
+function fakeSlackApi(): SlackWebApi & { revoked: string[] } {
+  const revoked: string[] = [];
+  return {
+    revoked,
+    async revokeToken(botToken: string) {
+      revoked.push(botToken);
+      return true;
+    },
+    openDm() {
+      throw new Error('not used');
+    },
+    postMessage() {
+      throw new Error('not used');
+    },
+    conversationMembers() {
+      throw new Error('not used');
+    },
+    conversationInfo() {
+      throw new Error('not used');
+    },
+    exchangeOAuthCode() {
+      throw new Error('not used');
+    },
+  };
+}
+
+/** Seed an org-less pending Slack install with a given age + bot token. */
+async function seedPending(
+  teamId: string,
+  ageDays: number,
+  botToken: string,
+): Promise<void> {
+  const sql = getDb();
+  await sql.unsafe(
+    `INSERT INTO app_installations
+       (organization_id, provider, provider_instance, provider_app_id,
+        external_tenant_id, status, metadata, created_at, updated_at)
+     VALUES
+       (NULL, 'slack', 'cloud', 'cloud', $1, 'pending', $2::jsonb,
+        now() - ($3::int * interval '1 day'), now())`,
+    [teamId, JSON.stringify({ bot_token_enc: encrypt(botToken) }), ageDays],
+  );
+}
+
+async function pendingTeamIds(): Promise<string[]> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT external_tenant_id FROM app_installations
+    WHERE provider = 'slack' AND status = 'pending'
+    ORDER BY external_tenant_id
+  `) as unknown as Array<{ external_tenant_id: string }>;
+  return rows.map((r) => r.external_tenant_id);
+}
+
+describe('reapExpiredPendingSlackInstalls', () => {
+  test('deletes only pending rows past the TTL, revoking their tokens; leaves fresh + active alone', async () => {
+    // 1. Stale pending (10 days old, TTL 7) — reaped + revoked.
+    await seedPending('T-STALE', 10, 'xoxb-stale-token');
+    // 2. Fresh pending (1 day old) — left alone.
+    await seedPending('T-FRESH', 1, 'xoxb-fresh-token');
+    // 3. Active install, org-bound, older than the TTL — must NEVER be touched.
+    const sql = getDb();
+    await sql.unsafe(
+      `INSERT INTO app_installations
+         (organization_id, provider, provider_instance, provider_app_id,
+          external_tenant_id, status, metadata, created_at, updated_at)
+       VALUES
+         ($1, 'slack', 'cloud', 'cloud', 'T-ACTIVE', 'active', '{}'::jsonb,
+          now() - interval '30 days', now())`,
+      [ORG_ID],
+    );
+
+    const slack = fakeSlackApi();
+    const result = await reapExpiredPendingSlackInstalls(7, slack);
+
+    // Only the stale pending row was reaped.
+    expect(result.expired).toBe(1);
+    // Its token was decrypted + revoked (never the fresh one).
+    expect(slack.revoked).toEqual(['xoxb-stale-token']);
+
+    // Fresh pending survives; the active install is fully intact.
+    expect(await pendingTeamIds()).toEqual(['T-FRESH']);
+    const active = (await sql`
+      SELECT status FROM app_installations WHERE external_tenant_id = 'T-ACTIVE'
+    `) as unknown as Array<{ status: string }>;
+    expect(active[0]?.status).toBe('active');
+  });
+
+  test('never touches another provider even when its row is old + pending-like', async () => {
+    // A different provider's row that happens to be old must be out of scope.
+    const sql = getDb();
+    await sql.unsafe(
+      `INSERT INTO app_installations
+         (organization_id, provider, provider_instance, provider_app_id,
+          external_tenant_id, status, metadata, created_at, updated_at)
+       VALUES
+         (NULL, 'github', 'cloud', 'cloud', 'gh-old', 'pending', '{}'::jsonb,
+          now() - interval '90 days', now())`,
+    );
+
+    const slack = fakeSlackApi();
+    const result = await reapExpiredPendingSlackInstalls(7, slack);
+
+    expect(result.expired).toBe(0);
+    expect(slack.revoked).toEqual([]);
+    const gh = (await sql`
+      SELECT id FROM app_installations WHERE provider = 'github'
+    `) as unknown as Array<{ id: string }>;
+    expect(gh.length).toBe(1);
+  });
+
+  test('a failed revoke does not block the delete (best-effort)', async () => {
+    await seedPending('T-STALE', 10, 'xoxb-stale-token');
+
+    const throwingApi: SlackWebApi = {
+      async revokeToken() {
+        throw new Error('token_revoked');
+      },
+      openDm() {
+        throw new Error('not used');
+      },
+      postMessage() {
+        throw new Error('not used');
+      },
+      conversationMembers() {
+        throw new Error('not used');
+      },
+      conversationInfo() {
+        throw new Error('not used');
+      },
+      exchangeOAuthCode() {
+        throw new Error('not used');
+      },
+    };
+
+    const result = await reapExpiredPendingSlackInstalls(7, throwingApi);
+    expect(result.expired).toBe(1);
+    expect(await pendingTeamIds()).toEqual([]);
+  });
+});

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -26,6 +26,7 @@ import {
 import { TaskScheduler } from './task-scheduler';
 import { triggerEmbedBackfill } from './trigger-embed-backfill';
 import { runReapStaleDeviceWorkers } from './reap-stale-device-workers';
+import { runReapExpiredPendingSlackInstalls } from './reap-expired-pending-installs';
 import { getDb, pgTextArray } from '../db/client';
 import { createNotificationForUsers } from '../notifications/service';
 import {
@@ -258,6 +259,21 @@ function registerMaintenanceTasks(
       await runReapStaleDeviceWorkers();
     },
     { cron: '0 3 * * *' },
+  );
+
+  // Expired unclaimed-Slack-install reaper — deletes org-less `pending`
+  // app_installations rows older than 7 days (a marketplace / "Add to Slack"
+  // install the installer never claimed) after best-effort revoking the bot
+  // token, so an abandoned workspace doesn't leave a live credential lying
+  // around. Tightly scoped to pending slack rows; never touches active/claimed
+  // installs. Single-claimant per tick; pure Postgres (multi-replica safe).
+  // Daily, off-peak, distinct minute from the device-worker reaper.
+  scheduler.register(
+    'reap-expired-pending-installs',
+    async () => {
+      await runReapExpiredPendingSlackInstalls();
+    },
+    { cron: '17 3 * * *' },
   );
 
   // Watcher automation: reconcile in-flight runs, materialize newly-due runs,

--- a/packages/server/src/scheduled/reap-expired-pending-installs.ts
+++ b/packages/server/src/scheduled/reap-expired-pending-installs.ts
@@ -1,0 +1,94 @@
+/**
+ * Expired unclaimed-Slack-install reaper.
+ *
+ * A Slack-initiated install (marketplace / raw "Add to Slack") lands at the
+ * OAuth callback with a bot token but no Lobu org, so it's parked as an org-less
+ * `pending` `app_installations` row and the installer is DMed a single-use claim
+ * link (Phases 1-3 on this branch). If nobody ever claims it, that row keeps a
+ * live bot token encrypted in its metadata forever. This reaper reaps pending
+ * rows older than a TTL (default 7 days): best-effort `auth.revoke` of the bot
+ * token so an abandoned workspace's credential is invalidated, then delete the
+ * row.
+ *
+ * Scope is deliberately tight — provider='slack', provider_app_id='cloud',
+ * status='pending' — so an active install (or any other provider's row) is NEVER
+ * touched. The DELETE re-asserts every one of those predicates so a row claimed
+ * (status flipped to 'active' + org bound) between scan and delete is left alone.
+ *
+ * Single-claimant per tick via the runs-queue (like the other scheduled jobs);
+ * pure Postgres, so it's correct under N>1 app replicas. The DELETE is the
+ * authoritative claim: revocation runs only over the rows THIS caller actually
+ * removed (RETURNING), so two overlapping runners never both revoke the same
+ * token, and the token never outlives its row.
+ */
+
+import { decrypt } from '@lobu/core';
+import {
+  createSlackWebApi,
+  type SlackWebApi,
+} from '../gateway/connections/slack-web';
+import { getDb } from '../db/client';
+import logger from '../utils/logger';
+
+const SLACK_PROVIDER = 'slack';
+const SLACK_PROVIDER_APP_ID = 'cloud';
+
+export async function reapExpiredPendingSlackInstalls(
+  ttlDays = 7,
+  slackApi: SlackWebApi = createSlackWebApi(),
+): Promise<{ expired: number }> {
+  const sql = getDb();
+
+  // Authoritative claim + reap in one statement: delete every pending Slack row
+  // past the TTL and return its encrypted token so we can revoke only the rows
+  // we actually removed. The inner SELECT bounds the batch (pending installs are
+  // rare, but keep it finite) and orders oldest-first; the DELETE re-asserts the
+  // full pending/slack/cloud predicate so a just-claimed row (now active + org
+  // bound) is excluded.
+  const deleted = (await sql`
+    DELETE FROM app_installations
+    WHERE id IN (
+      SELECT id FROM app_installations
+      WHERE provider = ${SLACK_PROVIDER}
+        AND provider_app_id = ${SLACK_PROVIDER_APP_ID}
+        AND status = 'pending'
+        AND created_at < now() - (${ttlDays}::int * interval '1 day')
+      ORDER BY created_at ASC
+      LIMIT 500
+    )
+      AND provider = ${SLACK_PROVIDER}
+      AND provider_app_id = ${SLACK_PROVIDER_APP_ID}
+      AND status = 'pending'
+    RETURNING external_tenant_id, metadata
+  `) as unknown as Array<{
+    external_tenant_id: string;
+    metadata: Record<string, unknown>;
+  }>;
+
+  // Best-effort token revocation — the row is already gone, so a revoke failure
+  // (already-invalid token, Slack outage, missing/undecryptable ciphertext) is
+  // logged and swallowed. Never log the token itself.
+  for (const row of deleted) {
+    const enc = row.metadata.bot_token_enc;
+    if (typeof enc !== 'string' || !enc) continue;
+    try {
+      const botToken = decrypt(enc);
+      await slackApi.revokeToken(botToken);
+    } catch (error) {
+      logger.warn(
+        { teamId: row.external_tenant_id, error: String(error) },
+        '[task] reap-expired-pending-installs: bot-token revoke failed (best-effort)',
+      );
+    }
+  }
+
+  return { expired: deleted.length };
+}
+
+/** Scheduled-task wrapper: run the reaper and log a summary. */
+export async function runReapExpiredPendingSlackInstalls(): Promise<void> {
+  const result = await reapExpiredPendingSlackInstalls();
+  if (result.expired > 0) {
+    logger.info({ ...result }, '[task] reap-expired-pending-installs completed');
+  }
+}


### PR DESCRIPTION
## What & why
A Slack-initiated install (Slack App Directory / raw 'Add to Slack') lands at the OAuth callback with a `code` but **no Lobu-minted state**, so there's no org to bind to — today it 400s. This adds an install-first, claim-after flow: park the install as **unclaimed**, then let a workspace admin claim it by signing in with Slack.

Stacked on #1659 (`?org=` fix) because both touch `app-install.ts`; retarget to `main` after #1659 merges.

## Design (no new table)
Reuses `app_installations` (the existing 'app installed into tenant' record). Only change: `organization_id` relaxed to nullable, gated by `CHECK (organization_id IS NOT NULL OR status='pending')`. Routing already ignores non-`active` rows, so a pending row is **inert** until claimed. Bot token stored **encrypted in metadata** (the org-scoped secret store can't hold an org-less token); re-persisted to the secret store on claim.

## Phases
- ✅ **Phase 1 (this commit) — capture.** No-state callback branch → `oauth.v2.access` exchange (captures bot token + team + `authed_user`) → pending org-less row → claim landing page. **Verified live** on QAPeer: stateless install → pending row (org NULL, installer captured, token encrypted).
- ⏳ Phase 2 — bot DMs the installer a claim link.
- ⏳ Phase 3 — `/slack/claim`: Sign in with Slack → `users.info` admin-verify → resolve org → flip pending→active.
- ⏳ Phase 4 — expiry job for unclaimed rows.

Do not merge until the full loop (install → DM → claim → active) is verified end-to-end. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785513647&installation_id=136316292&pr_number=1663&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1663&signature=c7428fbadb33d9d651c0c15de8be96ca8b106ad8035eed9c8b65947ebca3d2c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->