### PR TITLE
docs(plans): agent model — Behaviors/Surfaces/Runs + workflow WAIT

### DIFF
--- a/docs/plans/agent-model.md
+++ b/docs/plans/agent-model.md
@@ -1,0 +1,270 @@
+# Agent Model — Behaviors, Surfaces, Workflows
+
+Design of record for consolidating the agent config surface. Supersedes the
+separate "Reach", "Watchers", and "Schedules" tabs. Written after review by
+GPT‑5.5 (xhigh) and Grok, and a use‑case gauntlet.
+
+Status: **model + UX locked; workflow execution has a small new mechanism +
+two safety guarantees (below).**
+
+---
+
+## 1. The mental model — three nouns
+
+An agent is three things a person can hold in their head:
+
+- **Connections** — what it can *see* (sources + feeds).
+- **Behaviors** — what it *does*. Each is one sentence: *"When ⟨X⟩, Ada ⟨Y⟩."*
+- **Surfaces** — durable boards it *maintains* (dashboards, digests, reports).
+
+Plus **Persona** (who it is), **Chat** (ad‑hoc / ambient Q&A), and **Runs** (an
+audit view — secondary, not a headline noun).
+
+Nav: `Chat · Behaviors · Surfaces · Persona · Connections` (+ Skills, Guardrails).
+
+### Why "Behaviors" (not Triggers/Automations/Rules)
+Agent‑native, and it makes *silence* and *quiet watching* read as features, not
+failures ("Ada's behavior is to only speak when she can help"). Works because
+Persona is a separate surface, so "behavior" unambiguously means *actions*, not
+*character*.
+
+---
+
+## 2. Behaviors
+
+One list. Each row is a sentence + a **kind badge**:
+
+- **Listen** — a chat channel. Real‑time. (was Reach)
+- **Watch** — a data feed; new items match a rule, evaluated incrementally. (was Watchers)
+- **Schedule** — a clock / cron. (was Schedules)
+
+The three kinds keep distinct constructors and empty‑states — a subscription, an
+incremental query, and a clock invocation are genuinely different underneath;
+the shared sentence is a *summary*, not a claim they're identical.
+
+### Output = attributes, not a verb‑noun
+There is no "Say/Keep/Do" noun. A behavior's output is expressed as attributes:
+
+- **destination**: `thread | channel | surface | inbox | external | silent`
+- **disposition**: `ephemeral | maintain`
+- **governance**: `auto | needs-approval`
+- **proactivity** (per‑behavior override): `always | on-mention | when-confident | silent`
+
+Use plain words in the UI ("Reply in thread", "Update a board", "Request
+approval"), and structured facets for filtering (kind / output / state).
+
+### Proactivity
+A structured control, not prose. Default lives on **Persona** (Reserved /
+Balanced / Proactive); each behavior can override it. It is the lever that
+decides reply‑vs‑silence and must be per‑context.
+
+---
+
+## 3. Backend mapping (reuse‑heavy)
+
+The consolidation is **~80% frontend** over existing APIs; two runtimes and three
+tables stay.
+
+- **Behaviors** = a read/dispatch view over `agent_channel_bindings` (Listen) +
+  `watchers` (Watch) + `scheduled_jobs` (Schedule). No new source table.
+- **Two runtimes (the event detectors — never the agent's job):**
+  - realtime chat handler → invokes the agent on a message (Listen).
+  - cron due‑scanner → invokes the agent when a Watch/Schedule is due.
+- **Watch is cron‑paced + incremental — near‑real‑time by design.** It ticks on
+  its schedule (not on data arrival); each run only sees new data since the last
+  window (`window_start..window_end`). Near‑real‑time is a *feature*: multiple
+  new items in a window are **batched into one reaction** (5 P0s → one triage
+  post), which is cheaper and less noisy than 5 real‑time firings. Real‑time is
+  reserved for chat (Listen).
+  - **Skip‑if‑empty (opt):** each tick runs the source/filter query bounded to
+    the window; if **no new matching events**, it **skips** — no run, no agent
+    call. Only non‑empty windows spawn the reaction. Falls out of the kind:
+    *Watch* skips‑if‑empty; *Schedule* always runs (a digest fires on a quiet
+    day too). Also keeps **Runs** to real firings, not empty ticks. Backend: a
+    pre‑dispatch `EXISTS` gate in the materialize path + advance the window on a
+    skipped tick. (`@refs` already compile to the query this gate reuses.)
+  - "On arrival" (event‑driven dispatch, sub‑cadence) is **deferred** — we don't
+    need real‑time for data.
+- **Runs / Activity** = `events(semantic_type='notification')` ⋈
+  `notification_targets(event_id, user_id)`. Append stream; exhaust.
+- **Surfaces** = a *keyed* event, updated by **upsert‑via‑supersede**
+  (`supersedes_event_id`; `current_event_records` masks superseded rows).
+  Incremental‑in (window cursor) → upsert‑out (rewrite the board). Distinct from
+  Runs (append). No new table.
+- **Chat replies** = `channel_messages` (the conversation transcript), separate
+  from the events spine.
+
+New backend for the base model: proactive‑chat + first‑class silent outcome on
+the chat handler; approval wiring (mostly exists); webhook→feed (so external
+push sources become queryable events).
+
+---
+
+## 4. Workflows — a Behavior with a multi‑step body
+
+**Option A (locked):** a Workflow is a Behavior whose action is a sequence with
+`WAIT` steps (`do → WAIT → do`). Not a separate builder tab. Simple behaviors
+stay one step; the list shows one sentence with a `workflow` tag and expands to
+the flow.
+
+Internally the body is a **versioned step graph/sequence**, even though the UI
+renders one list item. (Locked invariant — see §6.)
+
+The line where a separate builder is warranted (deferred until it appears):
+branching, loops, parallel waits, reusable subflows, step‑level permissions, or
+nontrivial data mapping between steps.
+
+### WAIT — the one new primitive
+Four conditions, **one mechanism** (suspend → resume on signal):
+
+| condition | resumed by | owner |
+|---|---|---|
+| duration / deadline ("in 20 min") | a clock | **agent self‑schedules** `wake_agent` |
+| count / threshold ("until 5 replies") | an event lands, check count | detector (Watch/ingest) |
+| specific event ("PR merges") | the event lands | detector |
+| a human ("until I approve") | approve clicked (an event) | detector |
+
+**Key unification: approval *is* wait‑for‑human.** The governance
+"needs‑approval" gate and a workflow WAIT are the same mechanism.
+
+### Two resume paths
+- **Time waits** → the agent schedules its own `wake_agent` and ends the turn;
+  the scheduler re‑invokes it with a synthetic prompt. Durability rides
+  `scheduled_jobs` leasing (multi‑replica safe). **Works today** —
+  `manage_schedules(wake_agent)` is a real admin tool, grantable to a worker via
+  the per‑run token (`BUILDER_ADMIN_TOOLS` / `resolveBuilderAdminTools`).
+- **Event waits** → a detector (Watch cron tick / ingest) resumes the **suspended
+  run**, not a fresh behavior. This is the one genuinely‑new mechanism (§5).
+
+### v1 scope (simplification)
+- **Enable** agent self‑wake and watcher‑resume **by default** for workflow
+  agents. The per‑agent / per‑watcher **disable toggles are deferred**.
+- Self‑wake capability should be scoped to *self‑wake* (least privilege), not the
+  full `manage_schedules` admin surface — a follow‑up hardening, not a v1 blocker.
+
+---
+
+## 5. The WAIT resume‑subscription (spec — the one new mechanism)
+
+A time wait already resumes via the scheduler. An **event** wait needs the
+detector to wake the right suspended run. Design:
+
+- When a workflow reaches a WAIT‑for‑event step, it writes a **resume‑subscription**:
+  `{ run_id, step_id, behavior_version, match: <event filter>, deadline, created_at }`.
+  A deadline is always set (even for pure count/event waits) so nothing hangs
+  forever.
+- **Collection** (optional, a property of WAIT, not a separate step): inbound
+  events matching the filter are correlated to the run (`run_id`) and appended to
+  the run's partial state as they arrive.
+- **Resume** happens on whichever fires first:
+  - the detector (Watch tick / ingest) matches a new event against active
+    resume‑subscriptions → wakes `run_id` at `step_id`; or
+  - the deadline `scheduled_jobs` row fires → wakes with whatever was collected.
+- **Claiming**: resuming a run takes an atomic lease (reuse the scheduler's
+  `FOR UPDATE SKIP LOCKED` leasing) so exactly one replica resumes it.
+- **Invariant**: *every WAIT resumes exactly one suspended step, under a durable
+  claim.*
+
+---
+
+## 6. Safety guarantees (NOT toggles — required for correctness)
+
+A capability checkbox enables a feature; these are correctness properties a
+checkbox can't provide:
+
+1. **Idempotency on irreversible terminal actions** — a re‑wake (crash before
+   recording completion, then retry) must not double‑fire "order / pay / send".
+   Require a per‑step idempotency key, or an agent "did I already?" check backed
+   by memory. Model external effects as recorded `effect_started / effect_completed`
+   (outbox‑style).
+2. **Approval binding** — an approval event must bind to
+   `run_id + step_id + behavior_version + approver + expiry` and be single‑use, so
+   a stale approval can't resume the wrong run after an edit or retry.
+3. **Versioned steps** — the run carries the `behavior_version` it started under,
+   so an edit mid‑flight doesn't corrupt an in‑progress run.
+
+---
+
+## 7. Goals
+
+- **Monitoring a goal** ("track MRR toward $50k, show progress, alert on drift")
+  = a **Watch that maintains a progress Surface**. Buildable today with the base
+  model; no new primitive.
+- **Autonomously pursuing a goal** = a planning/agentic loop, not a reactive
+  behavior. **Deferred** — an explicit, separate product bet. Do not smuggle an
+  agentic loop into Behaviors.
+
+---
+
+## 8. Deferred (explicit)
+
+- Per‑agent / per‑watcher **disable** toggles for self‑wake / resume (v1 enables
+  by default).
+- **Branching / parallel** workflow builder (Option B) — only when branching,
+  loops, parallel waits, or subflows appear.
+- **Autonomous goal pursuit**.
+- **Real‑time (event‑driven) Watch dispatch** — Watch stays cron‑paced (~1 min);
+  real‑time is chat‑only.
+- Least‑privilege scoping of the self‑wake capability (hardening follow‑up).
+
+---
+
+## 8b. Surface change summary — API / MCP / backend
+
+**The consolidation itself needs no new MCP tool, no API change, no new engine.**
+The Behaviors / Surfaces / Runs / Persona tabs are a frontend re‑presentation over
+what exists:
+- list = the existing `channel-bindings`, `manage_watchers` (list), and
+  `manage_schedules` (list) APIs, merged client‑side;
+- create/edit = dispatch to the existing `bind_channel` / `manage_watchers` /
+  `manage_schedules` writers;
+- Surfaces/Runs = reads over `events` + `notification_targets`;
+- Watch editor = the existing watcher builder (incl. `@refs` from #1655);
+- self‑wake for workflows = a **capability grant flip** (`manage_schedules` is
+  already grantable via the per‑run token), not a new tool.
+
+So Phase 1 ships with **zero backend / API / MCP change**.
+
+The **new capabilities** each need a small, targeted backend change — none is a
+new MCP tool or a new engine:
+
+| capability | backend change | new MCP tool? |
+|---|---|---|
+| proactive + silent chat | wake agent on non‑mention; first‑class "no reply" (chat handler) | no |
+| skip‑if‑empty | pre‑dispatch `EXISTS` gate in the watcher materialize path | no |
+| webhook → feed | materialize a webhook connection as a feed | no |
+| maintained Surfaces | upsert‑via‑supersede write path | no |
+| proactivity | one structured field (persona default + per‑behavior override) | no |
+| workflow event‑wait | the WAIT resume‑subscription (§5) + event→run correlation | no |
+| workflow safety | idempotency on terminal actions + approval binding (§6) | no |
+
+No new admin/MCP tool is introduced; writes reuse `manage_watchers` /
+`bind_channel` / `manage_schedules`.
+
+## 9. Build phases
+
+1. **Frontend consolidation** — the Behaviors + Surfaces + Runs + Persona tabs
+   over existing APIs (bindings / watchers / schedules / events). No backend.
+2. **Proactive + silent chat** — wake the agent on non‑mention messages in
+   opted‑in channels; make "no reply" a first‑class, logged outcome; inject the
+   proactivity policy into the turn.
+3. **Surfaces** — the upsert‑via‑supersede path for a maintained board.
+4. **Webhook → feed** — external push sources become queryable events.
+5. **Workflows** — enable self‑wake + watcher‑resume; implement the WAIT
+   resume‑subscription (§5) and the safety guarantees (§6).
+6. **(deferred)** disable toggles, branching builder, autonomous goals.
+
+---
+
+## Appendix — decisions & their basis
+
+- Consolidation to `Behaviors` + `Surfaces` + `Runs`: converged across GPT‑5.5,
+  Grok, and the internal gauntlet.
+- Output‑as‑attributes (not Say/Keep/Do): both external reviews flagged the verb
+  taxonomy as leaky.
+- Surfaces first‑class, Runs as exhaust: "feeds are temporal; boards are spatial"
+  (Grok); "activity is exhaust, not something you manage" (GPT‑5.5).
+- Approval = wait‑for‑human: internal, endorsed with the binding caveat (§6.2)
+  from GPT‑5.5.
+- Option A over a workflow builder: GPT‑5.5 ("users should think 'this is a
+  behavior that sometimes pauses'"), with the versioned‑step invariant (§6.3).


### PR DESCRIPTION
Design of record for consolidating the agent config surface (Reach + Watchers + Schedules → Behaviors; Surfaces; Runs). Output as attributes; Persona holds soul + proactivity; Workflows = multi-step Behavior with a WAIT primitive (approval = wait-for-human); Watch is near-real-time with skip-if-empty batching.

Consolidation ships with zero backend/API/MCP change (frontend over existing manage_watchers / bind_channel / manage_schedules + events reads). New capabilities each need a small targeted change — no new MCP tool, no new engine (see §8b).

Reviewed by GPT-5.5 (xhigh) + Grok + a use-case gauntlet. Doc only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785515097&installation_id=136316292&pr_number=1664&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1664&signature=e14012064193e0d9c93641d96cd051097c7712ea6f7562ea36fd832e15be89be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->