### PR TITLE
feat(mcp): serve agent-approval as an MCP App + expose builder tools on mcp:admin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -335,6 +335,7 @@
         "tailwindcss": "^4.1.17",
         "typescript": "^5.7.2",
         "vite": "^6.0.0",
+        "vite-plugin-singlefile": "^2.3.3",
         "vitest": "^2.1.8",
       },
     },
@@ -3987,6 +3988,8 @@
     "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vite-plugin-singlefile": ["vite-plugin-singlefile@2.3.3", "", { "dependencies": { "micromatch": "^4.0.8" }, "peerDependencies": { "rollup": "^4.59.0", "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["rollup"] }, "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg=="],
 
     "vite-prerender-plugin": ["vite-prerender-plugin@0.5.13", "", { "dependencies": { "kolorist": "^1.8.0", "magic-string": "0.x >= 0.26.0", "node-html-parser": "^6.1.12", "simple-code-frame": "^1.3.0", "source-map": "^0.7.4", "stack-trace": "^1.0.0-pre2" }, "peerDependencies": { "vite": "5.x || 6.x || 7.x || 8.x" } }, "sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g=="],
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -112,7 +112,7 @@ ARG VITE_ENVIRONMENT=production
 ENV VITE_ENVIRONMENT=$VITE_ENVIRONMENT
 ARG SKIP_WEB_BUILD=false
 RUN if [ "$SKIP_WEB_BUILD" = "false" ] && [ -f packages/owletto/package.json ]; then \
-      cd packages/owletto && bun run build; \
+      cd packages/owletto && bun run build && bun run build:mcp-apps; \
     else \
       mkdir -p /app/packages/owletto/dist; \
     fi

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -1,0 +1,138 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAccessToken,
+  createTestOAuthClient,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+import { post } from '../../setup/test-helpers';
+
+// Marker in the stub bundle so we can assert the served HTML is ours.
+const STUB_HTML =
+  '<!doctype html><html><body data-test="mcp-app-approve-stub">approve</body></html>';
+
+describe('MCP App resources — ui:// serving + _meta on pending approval', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let owner: Awaited<ReturnType<typeof createTestUser>>;
+  let client: Awaited<ReturnType<typeof createTestOAuthClient>>;
+  let token: string;
+  let tmpRoot: string;
+  const prevWebDist = process.env.WEB_DIST_DIR;
+
+  beforeAll(async () => {
+    // Serve a stub bundle from a temp dir so resources/read needs no real owletto
+    // build. The resolver's first candidate is
+    // `join(WEB_DIST_DIR, '..', 'dist-mcp-apps/approval/index.html')`, so point
+    // WEB_DIST_DIR at `<tmp>/dist` and write the stub under `<tmp>/dist-mcp-apps`.
+    // `<tmp>/dist/index.html` deliberately does NOT exist, so the SPA dist
+    // resolver in index.ts skips this WEB_DIST_DIR and is unaffected. Set this
+    // BEFORE any resources/read — the bundle resolver caches misses per process.
+    tmpRoot = mkdtempSync(join(tmpdir(), 'lobu-mcp-app-'));
+    mkdirSync(join(tmpRoot, 'dist-mcp-apps', 'approval'), { recursive: true });
+    writeFileSync(
+      join(tmpRoot, 'dist-mcp-apps', 'approval', 'index.html'),
+      STUB_HTML
+    );
+    process.env.WEB_DIST_DIR = join(tmpRoot, 'dist');
+
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    org = await createTestOrganization({ name: 'MCP App Org', slug: 'mcp-app-org' });
+    owner = await createTestUser({ email: 'mcp-app-owner@test.example.com' });
+    await addUserToOrganization(owner.id, org.id, 'owner');
+    client = await createTestOAuthClient();
+    token = (
+      await createTestAccessToken(owner.id, org.id, client.client_id, {
+        scope: 'mcp:admin mcp:write mcp:read profile:read',
+      })
+    ).token;
+  });
+
+  afterAll(() => {
+    if (prevWebDist === undefined) delete process.env.WEB_DIST_DIR;
+    else process.env.WEB_DIST_DIR = prevWebDist;
+    if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function initSession(path: string): Promise<string> {
+    const initResponse = await post(path, {
+      body: {
+        jsonrpc: '2.0',
+        id: '__test_init__',
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'lobu-test', version: '1.0' },
+        },
+      },
+      token,
+    });
+    const sessionId = initResponse.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+    await post(path, {
+      body: { jsonrpc: '2.0', method: 'notifications/initialized' },
+      headers: { 'mcp-session-id': sessionId! },
+      token,
+    });
+    return sessionId!;
+  }
+
+  it('serves the ui://lobu/approve bundle over resources/read', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'resources/read',
+        params: { uri: 'ui://lobu/approve' },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const content = body.result?.contents?.[0];
+    expect(content?.uri).toBe('ui://lobu/approve');
+    expect(content?.mimeType).toBe('text/html');
+    expect(content?.text).toContain('mcp-app-approve-stub');
+  });
+
+  it('attaches _meta.ui + structuredContent to a pending manage_agents approval', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'manage_agents',
+          arguments: {
+            action: 'create',
+            agent_id: 'mcp-app-approval-agent',
+            name: 'MCP App Approval Agent',
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    // The pending approval carries the MCP App UI pointer + the proposal, so a
+    // host renders the ApprovalCard with the create diff.
+    expect(body.result?._meta?.ui?.resourceUri).toBe('ui://lobu/approve');
+    expect(body.result?.structuredContent?.action).toBe('create');
+    expect(typeof body.result?.structuredContent?.runId).toBe('number');
+    expect(body.result?.structuredContent?.current).toBeNull();
+  });
+});

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -15,7 +15,12 @@ import { randomUUID } from 'node:crypto';
 import { MCP_PROTOCOL_VERSION } from '@lobu/core';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
 import type { Context } from 'hono';
 import { bindRequestAbortToStream, type AbortableStream } from './events/sse-abort-bridge';
 import { OAuthClientsStore } from './auth/oauth/clients';
@@ -23,6 +28,7 @@ import { isPublicReadable } from './auth/tool-access';
 import { createDbClientFromEnv } from './db/client';
 import type { Env } from './index';
 import { agentExistsInOrganization, isValidAgentId, touchAgentLastUsed } from './lobu/stores/postgres-stores';
+import { readMcpAppBundle } from './utils/mcp-app-bundle';
 import { McpSessionStore, type PersistedMcpSession } from './mcp-session-store';
 import {
   clearInMemoryMcpSessionsForTests as clearInMemoryMcpSessionsForTestsShared,
@@ -109,11 +115,23 @@ export async function revokeInMemoryMcpSessionsForClient(
 /** Shared mutable ref so handleMcp can signal the format to tool handlers. */
 const formatRef = { rawJson: false };
 
+/**
+ * MCP Apps UI resources (interactive iframe payloads a host renders in a
+ * sandboxed iframe). Keyed by `ui://` uri → the built bundle's app dir under
+ * owletto's `dist-mcp-apps/`. A tool result that references one of these uris in
+ * `_meta.ui.resourceUri` makes the host fetch + render it (see the pending
+ * `manage_agents` approval below). Adding an app = one entry + its owletto
+ * `src/mcp-apps/<dir>` build — no gateway change.
+ */
+const MCP_APP_RESOURCES: Record<string, { name: string; appDir: string }> = {
+  'ui://lobu/approve': { name: 'Approve agent change', appDir: 'approval' },
+};
+
 function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
   const server = new Server(
     { name: 'lobu-mcp', version: '0.2.0' },
     {
-      capabilities: { tools: {} },
+      capabilities: { tools: {}, resources: {} },
       ...(authCtx.instructions && { instructions: authCtx.instructions }),
     }
   );
@@ -182,6 +200,32 @@ function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
     return { tools: allTools };
   });
 
+  // resources/list — advertise the MCP App UI resources (interactive iframe
+  // surfaces a host renders in place of flat text; see MCP Apps).
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    resources: Object.entries(MCP_APP_RESOURCES).map(([uri, meta]) => ({
+      uri,
+      name: meta.name,
+      mimeType: 'text/html',
+    })),
+  }));
+
+  // resources/read — return the built bundle HTML for a `ui://` app resource.
+  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const uri = request.params.uri;
+    const app = MCP_APP_RESOURCES[uri];
+    if (!app) throw new Error(`Unknown resource: ${uri}`);
+    const html = await readMcpAppBundle(app.appDir);
+    if (html == null) {
+      throw new Error(
+        `MCP App bundle not built for ${uri} (run owletto build:mcp-apps)`
+      );
+    }
+    return {
+      contents: [{ uri, mimeType: 'text/html', text: html }],
+    };
+  });
+
   // tools/call — access control + execution + formatting
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
@@ -197,6 +241,32 @@ function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
       const text = formatRef.rawJson
         ? JSON.stringify(result)
         : formatToolResult(name, result, { includeRawJson: false });
+      // A pending agent-change approval carries an MCP App UI: point the host at
+      // the `ui://lobu/approve` resource and hand it the proposal, so it renders
+      // the same ApprovalCard shown in our chat, with Approve/Reject brokered
+      // back as a `manage_operations` tools/call (host consent-gated).
+      const pending =
+        result != null &&
+        typeof result === 'object' &&
+        (result as { status?: unknown }).status === 'pending_approval';
+      if (pending) {
+        const r = result as {
+          run_id?: number;
+          action?: string | null;
+          proposal?: unknown;
+          current?: unknown;
+        };
+        return {
+          content: [{ type: 'text' as const, text }],
+          _meta: { ui: { resourceUri: 'ui://lobu/approve' } },
+          structuredContent: {
+            runId: r.run_id,
+            action: r.action ?? null,
+            proposal: r.proposal ?? null,
+            current: r.current ?? null,
+          },
+        };
+      }
       return { content: [{ type: 'text' as const, text }] };
     } catch (error: any) {
       return {

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -91,10 +91,23 @@ export function extractAuthContext(c: Context<{ Bindings: Env }>): AuthContext {
     allowCrossOrg: tokenType === 'oauth' && !scopedToOrg,
     allowInternalTools:
       !pathname.startsWith('/mcp') || c.req.header('x-lobu-memory-direct-auth') === '1',
-    // Builder admin-tool grant: carried from the verified worker token through
-    // mcpAuthInfo (see multi-tenant worker direct-auth). Lets the system agent
-    // call its allowlisted internal tools even on the /mcp path.
-    adminTools: mcpAuthInfo?.adminTools ?? null,
+    // Builder admin-tool grant. Verified-worker first:
+    //   1. the verified worker token's per-turn allowlist (the builder/system
+    //      agent run), carried through mcpAuthInfo — its narrow list wins; else
+    //   2. an external MCP caller (Slackbot/Claude/PAT) whose token holds the
+    //      `mcp:admin` scope — surface the builder tools so an approved admin
+    //      can drive agent management + approvals over MCP (e.g. the in-Slack
+    //      "@lobu build an agent" flow and its approval callback).
+    // Check `mcpAuthInfo.scopes` (real grants), NOT `scopes` above: session/
+    // anonymous callers carry the `*` sentinel, which would bypass the scope
+    // check. This only widens visibility/reachability — the owner/admin-role +
+    // `mcp:admin` gate in `enforceRoleScopeAccess` still fires underneath.
+    adminTools:
+      mcpAuthInfo?.adminTools ??
+      (mcpAuthInfo != null &&
+      hasRequiredMcpScope('admin', mcpAuthInfo.scopes ?? [])
+        ? ['manage_agents', 'manage_operations']
+        : null),
   };
 }
 

--- a/packages/server/src/utils/mcp-app-bundle.ts
+++ b/packages/server/src/utils/mcp-app-bundle.ts
@@ -1,0 +1,51 @@
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Locate + read a built MCP App bundle (a self-contained `ui://` iframe payload
+ * produced by owletto's `build:mcp-apps`, e.g.
+ * `packages/owletto/dist-mcp-apps/<appDir>/index.html`).
+ *
+ * Path resolution mirrors `resolveWebDistDirectory` in `index.ts` (the owletto
+ * SPA dist locator): `WEB_DIST_DIR` override first, then `APP_ROOT` and `cwd`
+ * siblings. `WEB_DIST_DIR` points at the owletto `dist` dir, so the MCP bundle
+ * lives one level up under `dist-mcp-apps/`.
+ */
+
+// packages/server dir (mirror of APP_ROOT in index.ts).
+const APP_ROOT = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+function bundleCandidates(appDir: string): string[] {
+  const rel = path.join('dist-mcp-apps', appDir, 'index.html');
+  const webDist = process.env.WEB_DIST_DIR?.trim();
+  return [
+    webDist ? path.join(webDist, '..', rel) : undefined,
+    path.resolve(APP_ROOT, 'packages/owletto', rel),
+    path.resolve(APP_ROOT, '../owletto', rel),
+    path.resolve(process.cwd(), 'packages/owletto', rel),
+    path.resolve(process.cwd(), '../owletto', rel),
+  ].filter((p): p is string => typeof p === 'string');
+}
+
+// Cache the resolved HTML per app dir — the bundle is immutable at runtime, so
+// don't hit disk on every `resources/read`. `null` caches a confirmed miss.
+const bundleCache = new Map<string, string | null>();
+
+/** Read a built MCP App bundle's HTML. Returns null when no build is present. */
+export async function readMcpAppBundle(appDir: string): Promise<string | null> {
+  const cached = bundleCache.get(appDir);
+  if (cached !== undefined) return cached;
+  for (const candidate of bundleCandidates(appDir)) {
+    try {
+      await stat(candidate);
+      const html = await readFile(candidate, 'utf8');
+      bundleCache.set(appDir, html);
+      return html;
+    } catch {
+      // candidate absent — try the next
+    }
+  }
+  bundleCache.set(appDir, null);
+  return null;
+}


### PR DESCRIPTION
Serve the agent-change approval as an MCP App for external hosts (Slackbot, Claude), and surface the builder tools on `mcp:admin`.

- `mcp-handler`: `resources` capability + `resources/list|read` serving `ui://lobu/approve`; `_meta.ui.resourceUri` + `structuredContent` on a pending `manage_agents` approval, so a host renders the same `ApprovalCard` (that renders natively in our chat), with Approve/Reject brokered back as `manage_operations`.
- `utils/mcp-app-bundle`: locate + cache the built bundle (mirrors the SPA dist resolver).
- `execute`: surface `manage_agents`/`manage_operations` on the external MCP for `mcp:admin` tokens — visibility only; the owner/admin + `mcp:admin` gate in `enforceRoleScopeAccess` still fires underneath.
- Docker: build the bundle into the image; bumps owletto pointer.

Gates: build-packages ✓, typecheck ✓, unit ✓, integration tests ✓ (1642 passed).

Depends on lobu-ai/owletto#409 — merge that first, then this pointer bump goes green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785518202&installation_id=136316292&pr_number=1667&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1667&signature=71bd2a5442ab6ffd55265dc89f855c3af285011ddb41b1e864b01b418c24db13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->