### PR TITLE
fix(authz): resource events gate fails closed on stale ACL state

### DIFF
--- a/packages/server/src/__tests__/integration/events/resource-gate-stale-acl.test.ts
+++ b/packages/server/src/__tests__/integration/events/resource-gate-stale-acl.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Resource visibility gate — STALE-ACL fail-closed (the events counterpart to
+ * slack-channel-visibility.test.ts's "fails closed when the graph ages past the
+ * freshness window").
+ *
+ * The generic resource gate (`authz/resource-visibility`) gates connector-sourced
+ * `events` (GitHub repos, …) by resource membership, but ONLY when the connection
+ * is currently ACL-enforced (full+fresh+in-window). The latent bug this test pins:
+ * a connection whose `authz_source_acl_state` row EXISTS but is no longer enforcing
+ * (aged past the freshness window / marked failed / partial) must FAIL CLOSED —
+ * its resource-linked events must NOT reach a non-member. Before the fix the gate
+ * used a bare `NOT IN (enforced)` passthrough, so a stale connection's events
+ * leaked to non-members; this reproduces that (goes red without the fix) and the
+ * three-state split makes it green.
+ *
+ * Uses explicit embeddings + query_embedding so the recall candidate path is
+ * deterministic without a live embedding service (mirrors github-repo-visibility).
+ */
+
+import { normalizeGithubRepoFullName } from '@lobu/connector-sdk';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { buildGithubRepoGraph } from '../../../authz/github-repo-graph';
+import type { ToolContext } from '../../../tools/registry';
+import { search } from '../../../tools/search';
+import { clearEntityLinkRulesCache } from '../../../utils/entity-link-upsert';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestEntity,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const EMBEDDING_DIM = 768;
+function axisVec(axis: number): number[] {
+  const v = new Array(EMBEDDING_DIM).fill(0);
+  v[axis] = 1;
+  return v;
+}
+
+function ctxFor(orgId: string, userId: string | null): ToolContext {
+  return {
+    organizationId: orgId,
+    userId,
+    memberRole: userId ? 'owner' : null,
+    isAuthenticated: !!userId,
+    tokenType: userId ? 'oauth' : 'anonymous',
+    scopedToOrg: !userId,
+    allowCrossOrg: !!userId,
+    scopes: userId ? ['mcp:read'] : undefined,
+  } as ToolContext;
+}
+
+/** A signed-in member who has also linked GitHub (auth_user_id + github_user_id). */
+async function seedSignedInMember(opts: {
+  orgId: string;
+  userId: string;
+  name: string;
+  githubUserId: string;
+}): Promise<number> {
+  const sql = getTestDb();
+  const entity = await createTestEntity({
+    name: opts.name,
+    entity_type: '$member',
+    organization_id: opts.orgId,
+    created_by: opts.userId,
+  });
+  await sql`
+    INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+    VALUES
+      (${opts.orgId}, ${entity.id}, 'auth_user_id', ${opts.userId}, 'auth:signup'),
+      (${opts.orgId}, ${entity.id}, 'github_user_id', ${opts.githubUserId}, 'connector:github')
+  `;
+  return entity.id;
+}
+
+async function recallContentIds(ctx: ToolContext): Promise<Set<number>> {
+  const result = await search(
+    {
+      query: 'github-recall-probe',
+      query_embedding: axisVec(0),
+      include_content: true,
+      content_limit: 50,
+    } as never,
+    {} as never,
+    ctx,
+  );
+  return new Set((result.content ?? []).map((c) => c.id));
+}
+
+describe('resource visibility gate — stale ACL fails closed (e2e via search_memory)', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    clearEntityLinkRulesCache();
+  });
+
+  /**
+   * Set up an org with a GitHub connection whose ACL graph is materialized:
+   * Alice (collaborator 101) is a member of repo-a only; Bob (102) of repo-b.
+   * One org-visible event per repo. Returns the ids so tests can assert recall.
+   */
+  async function setupEnforcedWorkspace() {
+    const org = await createTestOrganization({ name: 'Acme Stale' });
+    const alice = await createTestUser({ name: 'Alice', email: 'alice-stale@example.com' });
+    await addUserToOrganization(alice.id, org.id, 'owner');
+
+    const conn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      visibility: 'org',
+      createDefaultFeed: false,
+    });
+
+    await seedSignedInMember({ orgId: org.id, userId: alice.id, name: 'Alice', githubUserId: '101' });
+
+    const graph = await buildGithubRepoGraph({
+      organizationId: org.id,
+      connectionId: String(conn.id),
+      repos: [
+        { fullName: 'acme/repo-a', collaborators: [{ login: 'alice', id: 101 }] },
+        { fullName: 'acme/repo-b', collaborators: [{ login: 'bob', id: 102 }] },
+      ],
+    });
+    const repoAId = graph.resourceEntityIds[normalizeGithubRepoFullName('acme/repo-a') as string];
+    const repoBId = graph.resourceEntityIds[normalizeGithubRepoFullName('acme/repo-b') as string];
+
+    const eventA = await createTestEvent({
+      organization_id: org.id,
+      connection_id: conn.id,
+      connector_key: 'github',
+      content: 'repo A issue: quarterly metrics dashboard',
+      entity_ids: [repoAId],
+      embedding: axisVec(0),
+    });
+    const eventB = await createTestEvent({
+      organization_id: org.id,
+      connection_id: conn.id,
+      connector_key: 'github',
+      content: 'repo B issue: confidential quarterly metrics',
+      entity_ids: [repoBId],
+      embedding: axisVec(0),
+    });
+
+    return { org, alice, conn, eventAId: eventA.id, eventBId: eventB.id };
+  }
+
+  it('fails closed when the graph ages past the freshness window (a non-member sees NONE, not both)', async () => {
+    const { org, conn, eventAId, eventBId } = await setupEnforcedWorkspace();
+
+    // Sanity: while FRESH, a non-member (no $member) sees nothing of the enforced
+    // connection — the enforced membership branch requires a resolved member.
+    const freshIntruder = await recallContentIds(ctxFor(org.id, 'intruder-user-id'));
+    expect(freshIntruder.has(eventAId)).toBe(false);
+    expect(freshIntruder.has(eventBId)).toBe(false);
+
+    // The sync stops: age this connection's ACL row past the 60-min window. The
+    // row STILL EXISTS — so the connection must NOT fall back to the legacy fence
+    // (which would re-expose both org-visible events); it must FAIL CLOSED.
+    // Pre-fix, the bare `NOT IN (enforced)` passthrough made both events visible
+    // to the non-member here → this assertion went red (leak).
+    const sql = getTestDb();
+    await sql`
+      UPDATE authz_source_acl_state
+      SET last_synced_at = current_timestamp - interval '90 minutes'
+      WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+    `;
+
+    const staleIntruder = await recallContentIds(ctxFor(org.id, 'intruder-user-id'));
+    expect(staleIntruder.has(eventAId)).toBe(false);
+    expect(staleIntruder.has(eventBId)).toBe(false);
+  });
+
+  it('fails closed even for a genuine member once the graph is stale (no stale-membership re-exposure)', async () => {
+    const { org, alice, conn, eventAId, eventBId } = await setupEnforcedWorkspace();
+
+    // FRESH: Alice (member of repo-a) recalls repo-a only.
+    const fresh = await recallContentIds(ctxFor(org.id, alice.id));
+    expect(fresh.has(eventAId)).toBe(true);
+    expect(fresh.has(eventBId)).toBe(false);
+
+    // Mark the connection's ACL row failed (stale, not aged) — same fail-closed
+    // requirement: an onboarded connection that is not currently enforcing serves
+    // NOTHING rather than falling back to the legacy fence and re-exposing repo-b.
+    const sql = getTestDb();
+    await sql`
+      UPDATE authz_source_acl_state
+      SET freshness_state = 'failed', updated_at = current_timestamp
+      WHERE organization_id = ${org.id} AND connection_id = ${String(conn.id)}
+    `;
+
+    const stale = await recallContentIds(ctxFor(org.id, alice.id));
+    expect(stale.has(eventAId)).toBe(false);
+    expect(stale.has(eventBId)).toBe(false);
+  });
+
+  it('no regression: WITHOUT any ACL row the connection stays on the legacy fence (both visible)', async () => {
+    const { org, alice, eventAId, eventBId } = await setupEnforcedWorkspace();
+
+    // Drop the ACL state entirely → never-graphed → the resource gate is inert and
+    // both org-visible events recall (the not-graphed passthrough, unchanged).
+    const sql = getTestDb();
+    await sql`DELETE FROM authz_source_acl_state WHERE organization_id = ${org.id}`;
+
+    const ids = await recallContentIds(ctxFor(org.id, alice.id));
+    expect(ids.has(eventAId)).toBe(true);
+    expect(ids.has(eventBId)).toBe(true);
+  });
+});

--- a/packages/server/src/authz/acl-state.ts
+++ b/packages/server/src/authz/acl-state.ts
@@ -35,6 +35,20 @@ export function enforcedConnectionsSelectSql(orgParam: string): string {
 }
 
 /**
+ * SQL subquery (no leading/trailing space) selecting the `connection_id`s that
+ * have ANY `authz_source_acl_state` row — i.e. every connection ONBOARDED into
+ * authz, regardless of whether it is currently enforcing. The complement
+ * (`NOT IN` this set) is the "never graphed → legacy fence" case; a connection
+ * that IS in this set but NOT in {@link enforcedConnectionsSelectSql} is
+ * onboarded-but-stale and must fail closed. `orgParam` is an already-bound
+ * `$N::text` placeholder. Returns the bare `SELECT …` (caller wraps in IN/NOT IN).
+ */
+export function aclStateExistsSelectSql(orgParam: string): string {
+  return `SELECT connection_id FROM public.authz_source_acl_state
+    WHERE organization_id = ${orgParam}`;
+}
+
+/**
  * Per-connection enforcement state, the single shape BOTH the gate
  * (`./channel-visibility`) and the audience read (`./audience`) project from the
  * `authz_source_acl_state` row:

--- a/packages/server/src/authz/resource-visibility.ts
+++ b/packages/server/src/authz/resource-visibility.ts
@@ -4,25 +4,36 @@
  * `./channel-visibility` gates Slack chat by channel membership, but at the
  * `events` read seam and for ANY resource type at once.
  *
- * Rule, composed AFTER the per-connection visibility gate (they AND together):
- *   - an event on a connection that is NOT ACL-enforced is unconstrained here
- *     (the per-connection gate already decided it);
- *   - an event on an ACL-enforced connection is visible ONLY when the requester
- *     is `member_of` one of the RESOURCE entities the event is linked to
- *     (`events.entity_ids`), where "resource" = an entity whose type is a
- *     registered ACL resource (`RESOURCE_TYPE_SLUGS`: repo, channel, …). This is
- *     deliberately scoped to resource types so the coarse person→`company` (org)
- *     `member_of` edge never satisfies it — org membership must NOT grant
- *     repo-level read.
+ * Rule, composed AFTER the per-connection visibility gate (they AND together),
+ * mirroring the three-state enforcement split `getConnectionEnforcement` /
+ * `./channel-visibility` apply so the two gates can never drift:
+ *   - an event on a connection that was NEVER graphed (no `authz_source_acl_state`
+ *     row) is unconstrained here — the per-connection gate already decided it and
+ *     an absent graph must never silently hide data;
+ *   - an event on an ENFORCED connection (`acl_support='full'`,
+ *     `freshness_state='fresh'`, synced within the freshness window) is visible
+ *     ONLY when the requester is `member_of` one of the RESOURCE entities the
+ *     event is linked to (`events.entity_ids`), where "resource" = an entity whose
+ *     type is a registered ACL resource (`RESOURCE_TYPE_SLUGS`: repo, channel, …).
+ *     This is deliberately scoped to resource types so the coarse person→`company`
+ *     (org) `member_of` edge never satisfies it — org membership must NOT grant
+ *     repo-level read;
+ *   - an event on an onboarded-but-STALE connection (a row exists but is
+ *     partial/failed/stale/aged-out — i.e. NOT in the enforced set) FAILS CLOSED:
+ *     neither the not-graphed passthrough nor the enforced membership branch
+ *     matches, so its resource-linked events are dropped rather than served on
+ *     stale membership. Once a connection is graphed, it never falls back to the
+ *     legacy per-connection fence — a stalled sync hides data, it does not leak it.
  *
- * Fail-closed: a headless/null principal, or an enforced-connection event linked
- * to no resource the requester belongs to, is dropped. Generic across sources —
- * GitHub repos and Linear teams gate identically; a new source needs only a
- * registry entry (`./sources`) plus its connector stamping the resource identity
- * on its events so they link to the resource entity.
+ * Fail-closed: a headless/null principal, an enforced-connection event linked to
+ * no resource the requester belongs to, or any event on a stale connection is
+ * dropped. Generic across sources — GitHub repos and Linear teams gate
+ * identically; a new source needs only a registry entry (`./sources`) plus its
+ * connector stamping the resource identity on its events so they link to the
+ * resource entity.
  */
 
-import { enforcedConnectionsSelectSql } from './acl-state.js';
+import { aclStateExistsSelectSql, enforcedConnectionsSelectSql } from './acl-state.js';
 import type { AuthzScope } from './scope.js';
 import { RESOURCE_TYPE_SLUGS } from './sources.js';
 
@@ -51,13 +62,25 @@ export function compileResourceVisibility(
     return { sql: '', params: [] };
   }
 
-  // `events.connection_id` is bigint, but `authz_source_acl_state.connection_id`
-  // is text (it also keys text `agent_connections.id` for Slack). Cast to text so
-  // the comparison is well-typed across both connection-id spaces.
+  // `events.connection_id` is the bigint `connections.id`, but
+  // `authz_source_acl_state.connection_id` is text — the ACL sync stamps it as
+  // `String(connections.id)` (see `github-acl-sync` → `buildAccessGraph`). Cast
+  // `events.connection_id::text` so BOTH the "is this connection graphed?" check
+  // and the "is it enforced?" check compare on the SAME key.
+  //
+  // Three-state split (mirrors `getConnectionEnforcement`), NOT a bare
+  // `NOT IN (enforced)`:
+  //   1. no ACL row for the connection → passthrough (never graphed → legacy fence);
+  //   2. row is enforced (in the fresh-enforced set) → require the member_of EXISTS;
+  //   3. row exists but is NOT enforced (stale/partial/failed/aged-out) → neither
+  //      branch matches → FAIL CLOSED. A bare `NOT IN (enforced)` would make (3)
+  //      true and leak stale-connection events to non-members — the hole this fix
+  //      closes, matching the channel gate.
   const sql = `AND (
       ${tableAlias}.connection_id IS NULL
-      OR ${tableAlias}.connection_id::text NOT IN (${enforcedConnectionsSelectSql(orgParam)})
-      OR EXISTS (
+      OR ${tableAlias}.connection_id::text NOT IN (${aclStateExistsSelectSql(orgParam)})
+      OR (${tableAlias}.connection_id::text IN (${enforcedConnectionsSelectSql(orgParam)})
+      AND EXISTS (
         SELECT 1
         FROM public.entity_relationships rr
         JOIN public.entity_relationship_types rt
@@ -93,7 +116,7 @@ export function compileResourceVisibility(
               AND mei.deleted_at IS NULL
             LIMIT 1
           )
-      )
+      ))
     )`;
   return { sql, params: [scope.organizationId, scope.principal] };
 }


### PR DESCRIPTION
## What

The generic resource-visibility gate (`packages/server/src/authz/resource-visibility.ts`) that gates connector-sourced `events` (GitHub repos, Linear teams, …) by resource membership had the identical stale-ACL fail-open that pi caught in the `channel_messages` gate (#1660–#1662). This mirrors that fix for `events`.

## The bug

The gate used a bare passthrough:

```sql
connection_id::text NOT IN (enforcedConnectionsSelectSql)  OR EXISTS(member_of…)
```

`enforcedConnectionsSelectSql` returns only connections that are `acl_support='full'` AND `freshness_state='fresh'` AND synced within `ACL_STALE_AFTER_MINUTES`. A connection whose `authz_source_acl_state` row **exists but isn't fresh-enforcing** (stale / partial / failed / aged out) is not in that set, so `NOT IN (enforced)` is **true** → its resource-linked events pass through to non-members. It should fail closed once a row exists.

## The fix

Three-state split, mirroring `getConnectionEnforcement` and the channel gates:

```sql
connection_id IS NULL
OR connection_id::text NOT IN (aclStateExistsSelectSql)          -- never graphed → passthrough
OR ( connection_id::text IN (enforcedConnectionsSelectSql)       -- enforced → require membership
     AND EXISTS(member_of…) )
-- row exists but NOT enforced → neither branch matches → FAIL CLOSED
```

- New `aclStateExistsSelectSql(orgParam)` in `acl-state.ts` selects every `connection_id` with *any* ACL row for the org, so the passthrough keys on **"onboarded?"** while the membership branch keys on **"enforced?"**.
- Once a connection is graphed it never falls back to the legacy per-connection fence — a stalled sync **hides** data, it does not leak it.

## Key-space alignment (the crux)

`events.connection_id` is `bigint` (FK → `connections.id`); `authz_source_acl_state.connection_id` is `text` = `String(connections.id)` — the GitHub ACL sync passes `id::text` from `connections` through `buildAccessGraph` → `markAclEnforced`. So `events.connection_id::text` matches on the **same key** for both the new "graphed?" `NOT IN` check and the existing "enforced?" `IN` check. Verified against `00000000000000_baseline.sql` + `20260628000000_authz_source_acl_state.sql`. The existing `::text` cast was already correct and the enforced-check does fire for GitHub — no resolve-by-slug indirection needed (unlike the channel gate, whose connections are keyed by runtime id/slug in a different table).

Note: requester resolution stays auth-signup `$member` only — same as the sibling `compileChannelMessagesVisibility`, which documents that these SQL read seams serve web/app users (not in-Slack/in-GitHub authors), so a `slack_user_id`/`github_user_id` fallback is not applicable on this seam.

## Test (red → green)

New `packages/server/src/__tests__/integration/events/resource-gate-stale-acl.test.ts`, e2e through `search_memory`:

1. **aged-out** enforced connection → a non-member sees NONE (not both events).
2. **failed-state** enforced connection → a *genuine member* sees NONE either (no stale-membership re-exposure).
3. **no ACL row** → passthrough unchanged (legacy fence; both org-visible events recall).

Verified red without the fix (assertions 1 & 2 failed: `expected true to be false` — events leaked); green with it.

## Verification

- `make review`: typecheck 0, unit 0; integration **211 files / 1662 passed / 0 failed** (final log tally), including the new test + `authz-e2e-demo`, `per-user-connection-visibility`, `github-repo-visibility`, `slack-channel-visibility`.
- pi verdict: **bug_free 76, simplicity 78, slop 0, bugs 0, 0 blockers**, `tests_adequate: true`.
- Multi-replica safe: pure SQL read gate over Postgres state; no pod-local state.

Not live-verified (standing caveat, same as the existing GitHub gate): a real GitHub App install populating `authz_source_acl_state` in prod. The change is strictly fail-closed, so a mis-sync can only under-expose.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785522060&installation_id=136316292&pr_number=1668&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1668&signature=f22893e0ae09ae57d544585f40e6e6836e400a3548eeeafec9995bba3d0391c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource visibility for GitHub connector events so stale, failed, or aged-out ACL states no longer fall back to broader event access.
  * Ensured member-only event visibility is enforced consistently, while connections with no ACL record still behave as before.
  * Improved consistency in event access checks across different connection ID formats.

* **Tests**
  * Added integration coverage for stale ACL, failed ACL, and no-ACL scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->