### PR TITLE
feat(gateway): replay durable manage_agents approval cards on reload

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -9,6 +9,7 @@ import {
 import { Hono } from "hono";
 import { getDb } from "../../db/client.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
+import { insertEvent } from "../../utils/insert-event.js";
 import { createPostgresAgentConfigStore } from "../../lobu/stores/postgres-stores.js";
 import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
 import { UserAgentsStore } from "../auth/user-agents-store.js";
@@ -99,6 +100,87 @@ describe("agent history routes", () => {
 		);
 		return app;
 	}
+
+	test("replays pending manage_agents approvals as interactions on reload", async () => {
+		setAuthProvider(() => ({
+			userId: USER_ID,
+			platform: "external",
+			exp: Date.now() + 60_000,
+		}));
+
+		const agentId = "agent-1";
+		const threadId = "thread-appr";
+		const conversationId = buildApiConversationId({
+			agentId,
+			userId: USER_ID,
+			organizationId: ORG_ID,
+			threadId,
+		});
+
+		// A pending builder approval, stamped with the conversationId the way the
+		// internal interactions route does, so the history endpoint replays it —
+		// the transcript itself carries no interaction parts.
+		const runId = await insertRun({
+			organizationId: ORG_ID,
+			agentId,
+			conversationId,
+			runType: "internal",
+			status: "pending",
+		});
+		const proposal = {
+			action: "update",
+			agent_id: "weekly-digest",
+			name: "Weekly Digest",
+		};
+		const current = { id: "weekly-digest", name: "Old Name" };
+		await orgContext.run({ organizationId: ORG_ID }, () =>
+			insertEvent({
+				entityIds: [],
+				organizationId: ORG_ID,
+				originId: `run_${runId}_pending`,
+				title: "update weekly-digest — pending approval",
+				content: "Builder requested a change",
+				semanticType: "operation",
+				runId,
+				interactionType: "approval",
+				interactionStatus: "pending",
+				interactionInput: proposal,
+				metadata: {
+					conversationId,
+					action: "update",
+					proposal,
+					current,
+					status: "pending_approval",
+					run_id: runId,
+				},
+			}),
+		);
+
+		const res = await orgContext.run({ organizationId: ORG_ID }, () =>
+			createApp().request(
+				`/api/v1/agents/${agentId}/history/threads/${threadId}/messages`,
+				{ method: "GET", headers: { host: "localhost" } },
+			),
+		);
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			interactions?: Array<{
+				type: string;
+				runId: number;
+				action: string | null;
+				proposal: Record<string, unknown> | null;
+				current: Record<string, unknown> | null;
+			}>;
+		};
+		expect(body.interactions).toHaveLength(1);
+		const card = body.interactions?.[0];
+		expect(card?.type).toBe("tool-approval");
+		expect(card?.runId).toBe(runId);
+		expect(card?.action).toBe("update");
+		expect(card?.proposal).toMatchObject({ agent_id: "weekly-digest" });
+		expect(card?.current).toMatchObject({ id: "weekly-digest" });
+	});
 
 	test("rejects sessions that do not own the requested agent", async () => {
 		setAuthProvider(() => ({

--- a/packages/server/src/gateway/routes/internal/interactions.ts
+++ b/packages/server/src/gateway/routes/internal/interactions.ts
@@ -5,6 +5,7 @@ import {
 	getErrorMessage,
 } from "@lobu/core";
 import { Hono } from "hono";
+import { getDb } from "../../../db/client.js";
 import type { InteractionService } from "../../interactions.js";
 import { errorResponse, getVerifiedWorker } from "../shared/helpers.js";
 import { authenticateWorker } from "./middleware.js";
@@ -88,6 +89,21 @@ export function createInteractionRoutes(
             (body.current ?? null) as Record<string, unknown> | null,
             source
           );
+          // The live approval card is a one-shot SSE push, and the transcript
+          // doesn't carry interaction parts — so on reload the card is lost.
+          // Stamp the conversation onto the durable approval event (manage_agents
+          // created it WITHOUT one — the tool ctx has no conversationId; the
+          // worker does) so the history endpoint can replay it. Routing-metadata
+          // only; `events` is append-only for DELETE, and once the approval is
+          // resolved the superseding event drops it from current_event_records.
+          await getDb()`
+            UPDATE events
+            SET metadata = coalesce(metadata, '{}'::jsonb)
+              || jsonb_build_object('conversationId', ${conversationId}::text)
+            WHERE run_id = ${Number(body.runId)}
+              AND interaction_type = 'approval'
+              AND interaction_status = 'pending'
+          `;
           return c.json({ id: posted.id, status: "posted" });
         }
 

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -12,6 +12,7 @@ import { createLogger, entryToMessage, parseSessionEntries } from "@lobu/core";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { getDb } from "../../../db/client.js";
+import { buildApiConversationId } from "../../services/api-conversation-id.js";
 import type { ArtifactStore } from "../../files/artifact-store.js";
 import { resolveOrgId } from "../../../lobu/stores/org-context.js";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
@@ -395,7 +396,53 @@ export function createAgentHistoryRoutes(deps: {
 					: message,
 			);
 		}
-		return c.json(data);
+
+		// Replay durable interaction cards the transcript doesn't carry (today the
+		// builder's manage_agents write-gate approval). Reconstruct the session
+		// conversationId the worker stamped (same parts), then read the still-
+		// pending approval events. Self-cleaning: a resolved approval is
+		// superseded out of current_event_records. Without this the interactive
+		// approval card is lost on reload — only the model's text + link survive.
+		let interactions: Array<{
+			type: "tool-approval";
+			runId: number;
+			action: string | null;
+			proposal: Record<string, unknown> | null;
+			current: Record<string, unknown> | null;
+		}> = [];
+		if (scope.organizationId) {
+			const conversationId = buildApiConversationId({
+				agentId: scope.agentId,
+				userId: scope.userId,
+				organizationId: scope.organizationId,
+				threadId,
+			});
+			const rows = await getDb()<{
+				run_id: number;
+				action: string | null;
+				proposal: Record<string, unknown> | null;
+				current: Record<string, unknown> | null;
+			}>`
+				SELECT run_id,
+				       metadata->>'action' AS action,
+				       metadata->'proposal' AS proposal,
+				       metadata->'current' AS current
+				FROM current_event_records
+				WHERE organization_id = ${scope.organizationId}
+				  AND interaction_type = 'approval'
+				  AND interaction_status = 'pending'
+				  AND metadata->>'conversationId' = ${conversationId}
+				ORDER BY run_id
+			`;
+			interactions = rows.map((r) => ({
+				type: "tool-approval" as const,
+				runId: Number(r.run_id),
+				action: r.action,
+				proposal: r.proposal ?? null,
+				current: r.current ?? null,
+			}));
+		}
+		return c.json({ ...data, interactions });
 	});
 
 	// Read a PLATFORM conversation (e.g. `slack:{channel}:{ts}`) read-only by its

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -104,7 +104,6 @@ export type ManageAgentsResult =
       action: 'create' | 'update' | 'delete';
       run_id: number;
       event_id?: number;
-      approval_url?: string;
       status: 'pending_approval';
       message: string;
       // The proposed change + current agent row, so the worker can forward an
@@ -487,9 +486,12 @@ async function queueWriteForApproval(
     action: proposal.action,
     run_id: runId,
     event_id: eventId,
-    approval_url: approvalUrl,
     status: 'pending_approval',
-    message: `${label} requires approval. Approve or reject the card to apply it.`,
+    // An interactive approval card (change details + Approve/Reject buttons) is
+    // rendered into the chat from this result — so instruct the model to stay
+    // terse and NOT restate the change or paste a link. Narrating a Markdown
+    // "Approval Link" duplicates the card and leaves a dead link once resolved.
+    message: `${label} is queued for approval. A confirmation card with the change details and Approve/Reject buttons is now shown to the user in the chat — reply with at most one short sentence and do NOT restate the change or include an approval link.`,
     proposal,
     current,
   };


### PR DESCRIPTION
## Problem
The interactive builder-approval card (`BuilderApprovalCard`) was delivered **once** over live SSE, and the chat transcript carries no interaction parts. So on reload — or any missed live delivery — the card vanished, leaving only the model's text response with the approval link. Real gap in prod, not just local.

## Fix
Anchor the card on durable state and re-derive it on load:
- **Stamp `conversationId`** onto the pending approval event (`routes/internal/interactions.ts`, where the worker supplies it — the tool ctx has none). Routing-metadata only; `events` append-only trigger guards DELETE only.
- **History endpoint** (`/threads/:threadId/messages`) reconstructs the session id via `buildApiConversationId` and returns the still-pending approvals from `current_event_records` as `interactions`. Self-cleaning: a resolved approval is superseded out.
- The SPA folds them into the stream on hydrate (paired owletto PR) → the card renders reliably.

## Test
Adds `agent-history-routes.test.ts > replays pending manage_agents approvals…` (green): a stamped pending approval is returned as a `tool-approval` interaction by the history endpoint.

Depends on lobu-ai/owletto#410 — merge that first, then this pointer goes green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785522335&installation_id=136316292&pr_number=1669&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1669&signature=3d4e052f6a6891ca5822c7af372da21d1a117bd1d165daf99a809055890fb8cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pending approval actions now reappear in conversation history as interactive approval cards, including the original proposal and current state.
  * Chat history responses now include related interactions alongside messages when available.

* **Bug Fixes**
  * Approval cards are now preserved more reliably when reloading a thread.
  * Queued approval responses now use clearer, shorter guidance and no longer show an approval link in the text response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->