### PR TITLE
chore(ci): fix chronically-red format-lint and static-security guards

### DIFF
--- a/config/biome.config.json
+++ b/config/biome.config.json
@@ -38,7 +38,8 @@
       "!**/scripts/lobu/**",
       "!**/benchmarks/**",
       "!**/skills/**",
-      "!**/packages/landing/public/**"
+      "!**/packages/landing/public/**",
+      "!**/docs/plans/**/*.html"
     ]
   },
   "formatter": {

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -670,6 +670,7 @@ export function buildScopedQuery(
       idx++;
       params.push(scope.principal);
       const cmPrincipal = `$${idx}::text`;
+      // security-allowed: see block comment above the for-loop
       cmCte +=
         ` AND EXISTS (SELECT 1 FROM public.connections cc ` +
         `WHERE cc.organization_id = ${orgP} AND cc.deleted_at IS NULL ` +


### PR DESCRIPTION
## Why

Two CI checks have been **red on every recent PR** regardless of the diff (e.g. #1662, #1668) — they're inherited from `main`, so they mask real failures and force every merge to `--admin` past them. This clears both.

## 1. `format-lint` (biome **lint** step)

The failing step was `bun run lint`, not `format:check`. `docs/plans/agent-model-mockups/behaviors-surfaces-runs.html` (added in #1665) trips `lint/a11y/useButtonType` — **20 violations**, all `<button>` without an explicit `type`.

These are static design **mockups**, not shipped source. Fix: exclude `docs/plans/**/*.html` from biome, consistent with the config already excluding `og-assets`, `dist`, `*.css`, `packages/landing/public`, and other non-source artifacts.

- `origin/main`'s `config/biome.config.json` was already format-clean; the only config change is the one added exclude line.
- After the exclude: `bun run lint` → 0, `bun run format:check` → 0.

## 2. `Static security guards` (`scripts/check-security-patterns.sh`)

The SQL string-concat guard flagged the `channel_messages` CTE's `cmCte +=` append in `execute-data-sources.ts:~674`. Its `security-allowed:` annotation sat **8 lines above** the append — outside the guard's 3-line lookback window (`filter_allowlist` checks `line-3 .. line`).

Why it only failed in CI: the guard greps `git grep -- 'packages/**/*.ts'`, and git's `**` pathspec expansion is version-dependent — CI's git matched the deeply-nested file (catching the append), local macOS git didn't. So the latent gap only surfaced in CI.

Fix: add the `security-allowed:` annotation **directly above** the `cmCte +=` append (comment-only). The CTE builds over `QUERYABLE_TABLE_NAMES`-whitelisted names, exactly as the existing block comment documents — this is a safe, parameterized builder, not an injection.

## Verification

- `bash scripts/check-security-patterns.sh` → OK (guard passes; verified the annotation covers the CI-seen hit line via `filter_allowlist` simulation).
- `bun run format:check` → 0, `bun run lint` → 0.
- `tsc --noEmit` (packages/server) → clean.
- No behavior change: the `execute-data-sources.ts` diff is a single comment line; the config diff is one exclude entry.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785523738&installation_id=136316292&pr_number=1670&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1670&signature=bdf69c6bb871422fca6836eb465d2ba7728e33ca220d9f12efa012115ad803d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->