### PR TITLE
fix(ci): sdk-e2e read_feed action + cross-platform security guard

### DIFF
--- a/scripts/check-security-patterns.sh
+++ b/scripts/check-security-patterns.sh
@@ -56,10 +56,8 @@ echo "[check-security-patterns] scanning…"
 echo "  -> window.confirm / window.alert / window.prompt"
 HITS=$(
   git grep -nE 'window\.(confirm|alert|prompt)\(' -- \
-    'packages/owletto/*.ts' 'packages/owletto/*.tsx' \
-    'packages/owletto/**/*.ts' 'packages/owletto/**/*.tsx' \
-    'packages/landing/**/*.ts' 'packages/landing/**/*.tsx' \
-    2>/dev/null | filter_allowlist
+    'packages/owletto/' 'packages/landing/' \
+    2>/dev/null | grep -E '\.tsx?:' | filter_allowlist
 )
 if [ -n "$HITS" ]; then
   echo "::error::Banned modal confirmation primitives:"
@@ -71,11 +69,16 @@ fi
 # Matches:   "SELECT ..." + foo    OR    + "...WHERE..."
 # Allows the postgres.js tagged-template + `.unsafe(query, params)` shapes
 # (those are parameterized and safe).
+# NOTE: no `\b` word-boundary in the pattern — git's -E engine interprets `\b`
+# differently across builds (macOS-bundled git silently drops the match; Linux
+# CI git keeps it), which used to make this check pass locally but fail in CI.
+# The `["`][^"`]*` string-literal anchors already scope the match tightly.
 echo "  -> SQL string-concat onto literal fragments"
 HITS=$(
-  git grep -nE '["`][^"`]*\bSELECT\b[^"`]*["`][[:space:]]*\+|\+[[:space:]]*["`][^"`]*\bWHERE\b' -- \
-    'packages/**/*.ts' \
+  git grep -nE '["`][^"`]*SELECT[^"`]*["`][[:space:]]*\+|\+[[:space:]]*["`][^"`]*WHERE' -- \
+    'packages/' \
     2>/dev/null \
+    | grep -E '\.tsx?:' \
     | grep -v '/__tests__/' \
     | grep -v '/dist/' \
     | filter_allowlist
@@ -93,8 +96,8 @@ fi
 echo "  -> loose Nix charset regex in orchestration/"
 HITS=$(
   git grep -nE '\[A-Za-z0-9\\?\._-\]\+' -- \
-    'packages/server/src/gateway/orchestration/**/*.ts' \
-    2>/dev/null | filter_allowlist
+    'packages/server/src/gateway/orchestration/' \
+    2>/dev/null | grep -E '\.tsx?:' | filter_allowlist
 )
 if [ -n "$HITS" ]; then
   echo "::error::Loose Nix package charset re-introduced — use isValidNixAttrRef() instead:"

--- a/scripts/sdk-e2e.sh
+++ b/scripts/sdk-e2e.sh
@@ -355,12 +355,12 @@ echo "✓ apply created the pulse feed (id=$FEED_ID)"
 
 api manage_feeds "{\"action\":\"trigger_feed\",\"feed_id\":$FEED_ID}" > "$RUN_DIR/trigger-feed.json" || { cat "$RUN_DIR/trigger-feed.json" >&2; fail "trigger_feed failed"; }
 
-# Poll get_feed until the most recent sync run reaches a terminal state. Parse
+# Poll read_feed until the most recent sync run reaches a terminal state. Parse
 # status/items with separate guarded node calls (process substitution + `read`
 # trips `set -e` on a newline-less EOF), so the loop survives transient misses.
 SYNC_OK=""; RUN_ITEMS=0
 for _ in $(seq 1 90); do
-  api manage_feeds "{\"action\":\"get_feed\",\"feed_id\":$FEED_ID}" > "$RUN_DIR/get-feed.json" 2>/dev/null || { sleep 1; continue; }
+  api manage_feeds "{\"action\":\"read_feed\",\"feed_id\":$FEED_ID}" > "$RUN_DIR/get-feed.json" 2>/dev/null || { sleep 1; continue; }
   RUN_STATUS="$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{let j;try{j=JSON.parse(s)}catch{process.stdout.write("none");return}const r=(j.recent_runs||[])[0]||{};process.stdout.write(String(r.status||"none"))})' < "$RUN_DIR/get-feed.json" || echo none)"
   RUN_ITEMS="$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{let j;try{j=JSON.parse(s)}catch{process.stdout.write("0");return}const r=(j.recent_runs||[])[0]||{};process.stdout.write(String(r.items_collected??0))})' < "$RUN_DIR/get-feed.json" || echo 0)"
   case "$RUN_STATUS" in


### PR DESCRIPTION
Fixes the two chronically-red CI checks flagged as next-actions after #1670: **sdk-e2e** and hardening the **Static security guards** glob.

## sdk-e2e — real bug, not a flake

The job polled `manage_feeds` with a `"get_feed"` action that **does not exist** — the valid action that returns `recent_runs` is `read_feed` (`get_feed` was never in `tool-access.ts`'s allowlist either). So every poll returned HTTP 400, the run status was never read, and the job always died with `connector sync run did not complete within timeout` after 90s.

Evidence from the last main run (`856059139`): reqId 113–145 on `/api/local-install/manage_feeds` all `status:400`, then the timeout.

Fix: rename the poll call `get_feed` → `read_feed`. The existing `recent_runs` / `items_collected` parsing already matches `read_feed`'s response shape (it's what the polling code was written for), so this is a one-token contract fix.

## Static security guards — cross-platform determinism

Two issues, both making violations invisible locally and only catchable in CI:

1. **`\b` word-boundary.** git's `-E` engine interprets `\b` differently between the macOS-bundled git (2.50.1 — silently matches nothing) and Linux CI git (matches). The SQL-concat check therefore found **0 hits locally but real hits in CI**, which is exactly how the `execute-data-sources.ts:675` violation slipped past pre-commit and only went red after push (#1670). Dropped `\b`; the `["`][^"`]*` string-literal anchors already scope the match tightly.

2. **Version-dependent `packages/**/*.ts` globs.** git's `**` depth handling varies by version. Replaced with a plain recursive dir pathspec (`packages/`) + a `.tsx?` filter — which also covers 34 nested files the old glob was silently missing.

After both changes the guard reproduces CI locally: 13 raw SQL-concat hits surfaced (was 0), all allowlisted → **0 net violations, exit 0**.

## Verification
- `bash scripts/check-security-patterns.sh` → clean (exit 0); confirmed it now surfaces `execute-data-sources.ts:675` locally (previously masked by `\b`) and the annotation filters it.
- Confirmed all 13 raw hits are within `// security-allowed:` windows (no genuine unannotated concat unmasked).
- `read_feed` confirmed as the valid action + present in `tool-access.ts` allowlist; `get_feed` absent from both the tool schema and the allowlist.
- Pre-commit (biome + tsc) passed.

Scripts-only change; no `packages/*/src` touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785525454&installation_id=136316292&pr_number=1671&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1671&signature=30f12c25f890806a69dd1bab8fe037e4c386dd78f3ef4cbf51ce5e0f6a543839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->