### PR TITLE
fix(ci): managed-e2e uses read_feed (same dead get_feed as #1671)

### DIFF
--- a/scripts/managed-e2e.sh
+++ b/scripts/managed-e2e.sh
@@ -355,7 +355,7 @@ api manage_feeds "{\"action\":\"trigger_feed\",\"feed_id\":$FEED_ID}" > "$RUN_DI
 
 SYNC_OK=""; RUN_ITEMS=0; LAST_STATUS=none
 for _ in $(seq 1 90); do
-  api manage_feeds "{\"action\":\"get_feed\",\"feed_id\":$FEED_ID}" > "$RUN_DIR/get-feed.json" 2>/dev/null || { sleep 1; continue; }
+  api manage_feeds "{\"action\":\"read_feed\",\"feed_id\":$FEED_ID}" > "$RUN_DIR/get-feed.json" 2>/dev/null || { sleep 1; continue; }
   RUN_STATUS="$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{let j;try{j=JSON.parse(s)}catch{process.stdout.write("none");return}const r=(j.recent_runs||[])[0]||{};process.stdout.write(String(r.status||"none"))})' < "$RUN_DIR/get-feed.json" || echo none)"
   RUN_ITEMS="$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{let j;try{j=JSON.parse(s)}catch{process.stdout.write("0");return}const r=(j.recent_runs||[])[0]||{};process.stdout.write(String(r.items_collected??0))})' < "$RUN_DIR/get-feed.json" || echo 0)"
   LAST_STATUS="$RUN_STATUS"


### PR DESCRIPTION
Follow-up to #1671. Auditing for other stale `manage_feeds` actions turned up the identical latent bug in `scripts/managed-e2e.sh`.

It polled `manage_feeds` with a `"get_feed"` action that does not exist (not in the tool schema, not in the tool-access allowlist), so every poll returns HTTP 400, the run status is never read, and the loop always times out. The valid action returning `recent_runs` is `read_feed` — which is exactly what the existing `recent_runs` / `items_collected` parsing was written for.

Unlike sdk-e2e, `managed-e2e.sh` is **not wired into any CI workflow** (it's a manually-run managed e2e), so it wasn't chronically red — but it would fail the instant anyone ran it. One-token contract fix.

## Verification
- Confirmed `get_feed` no longer appears anywhere under `scripts/`.
- All action strings in `managed-e2e.sh` now valid (`list_feeds`, `trigger_feed`, `read_feed`).
- `bash -n scripts/managed-e2e.sh` clean; pre-commit (biome + tsc) passed.

Scripts-only change; no `packages/*/src` touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785526164&installation_id=136316292&pr_number=1672&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1672&signature=bbd720264ac0fe0beb52caa5ad9fe02dcd598a057a10756cc2ca4f2a461c991b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->