### PR TITLE
feat(mcp-apps): render every interactive interaction through one MCP App host

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -335,6 +335,7 @@
         "tailwindcss": "^4.1.17",
         "typescript": "^5.7.2",
         "vite": "^6.0.0",
+        "vite-plugin-singlefile": "^2.3.3",
         "vitest": "^2.1.8",
       },
     },
@@ -3987,6 +3988,8 @@
     "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vite-plugin-singlefile": ["vite-plugin-singlefile@2.3.3", "", { "dependencies": { "micromatch": "^4.0.8" }, "peerDependencies": { "rollup": "^4.59.0", "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["rollup"] }, "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg=="],
 
     "vite-prerender-plugin": ["vite-prerender-plugin@0.5.13", "", { "dependencies": { "kolorist": "^1.8.0", "magic-string": "0.x >= 0.26.0", "node-html-parser": "^6.1.12", "simple-code-frame": "^1.3.0", "source-map": "^0.7.4", "stack-trace": "^1.0.0-pre2" }, "peerDependencies": { "vite": "5.x || 6.x || 7.x || 8.x" } }, "sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g=="],
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -112,7 +112,7 @@ ARG VITE_ENVIRONMENT=production
 ENV VITE_ENVIRONMENT=$VITE_ENVIRONMENT
 ARG SKIP_WEB_BUILD=false
 RUN if [ "$SKIP_WEB_BUILD" = "false" ] && [ -f packages/owletto/package.json ]; then \
-      cd packages/owletto && bun run build; \
+      cd packages/owletto && bun run build && bun run build:mcp-apps; \
     else \
       mkdir -p /app/packages/owletto/dist; \
     fi

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -15,9 +15,9 @@ import { post } from '../../setup/test-helpers';
 
 // Marker in the stub bundle so we can assert the served HTML is ours.
 const STUB_HTML =
-  '<!doctype html><html><body data-test="mcp-app-approve-stub">approve</body></html>';
+  '<!doctype html><html><body data-test="mcp-app-interaction-stub">interaction</body></html>';
 
-describe('MCP App resources — ui:// serving + _meta on pending approval', () => {
+describe('MCP App resources — ui:// serving (host-authored view)', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
   let owner: Awaited<ReturnType<typeof createTestUser>>;
   let client: Awaited<ReturnType<typeof createTestOAuthClient>>;
@@ -28,15 +28,15 @@ describe('MCP App resources — ui:// serving + _meta on pending approval', () =
   beforeAll(async () => {
     // Serve a stub bundle from a temp dir so resources/read needs no real owletto
     // build. The resolver's first candidate is
-    // `join(WEB_DIST_DIR, '..', 'dist-mcp-apps/approval/index.html')`, so point
+    // `join(WEB_DIST_DIR, '..', 'dist-mcp-apps/interaction/index.html')`, so point
     // WEB_DIST_DIR at `<tmp>/dist` and write the stub under `<tmp>/dist-mcp-apps`.
     // `<tmp>/dist/index.html` deliberately does NOT exist, so the SPA dist
     // resolver in index.ts skips this WEB_DIST_DIR and is unaffected. Set this
     // BEFORE any resources/read — the bundle resolver caches misses per process.
     tmpRoot = mkdtempSync(join(tmpdir(), 'lobu-mcp-app-'));
-    mkdirSync(join(tmpRoot, 'dist-mcp-apps', 'approval'), { recursive: true });
+    mkdirSync(join(tmpRoot, 'dist-mcp-apps', 'interaction'), { recursive: true });
     writeFileSync(
-      join(tmpRoot, 'dist-mcp-apps', 'approval', 'index.html'),
+      join(tmpRoot, 'dist-mcp-apps', 'interaction', 'index.html'),
       STUB_HTML
     );
     process.env.WEB_DIST_DIR = join(tmpRoot, 'dist');
@@ -84,14 +84,14 @@ describe('MCP App resources — ui:// serving + _meta on pending approval', () =
     return sessionId!;
   }
 
-  it('serves the ui://lobu/approve bundle over resources/read', async () => {
+  it('serves the ui://lobu/interaction bundle over resources/read', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
         jsonrpc: '2.0',
         id: 1,
         method: 'resources/read',
-        params: { uri: 'ui://lobu/approve' },
+        params: { uri: 'ui://lobu/interaction' },
       },
       headers: { 'mcp-session-id': sessionId },
       token,
@@ -100,12 +100,12 @@ describe('MCP App resources — ui:// serving + _meta on pending approval', () =
     expect(response.status).toBe(200);
     const body = await response.json();
     const content = body.result?.contents?.[0];
-    expect(content?.uri).toBe('ui://lobu/approve');
+    expect(content?.uri).toBe('ui://lobu/interaction');
     expect(content?.mimeType).toBe('text/html');
-    expect(content?.text).toContain('mcp-app-approve-stub');
+    expect(content?.text).toContain('mcp-app-interaction-stub');
   });
 
-  it('attaches _meta.ui + structuredContent to a pending manage_agents approval', async () => {
+  it('returns a pending manage_agents approval as plain text, without tool-result _meta', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
       body: {
@@ -128,11 +128,14 @@ describe('MCP App resources — ui:// serving + _meta on pending approval', () =
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.result?.isError).not.toBe(true);
-    // The pending approval carries the MCP App UI pointer + the proposal, so a
-    // host renders the ApprovalCard with the create diff.
-    expect(body.result?._meta?.ui?.resourceUri).toBe('ui://lobu/approve');
-    expect(body.result?.structuredContent?.action).toBe('create');
-    expect(typeof body.result?.structuredContent?.runId).toBe('number');
-    expect(body.result?.structuredContent?.current).toBeNull();
+    // The pending approval still returns its text result, but the tool result no
+    // longer carries an MCP App UI pointer: our own SPA builds the interaction
+    // view CLIENT-side from the SSE card payload, and external-host rendering
+    // (which needs the SERVER to author that view) is a deliberate follow-up.
+    // Assert the pointer is absent so we don't silently re-introduce a `_meta`
+    // that points a host at a bundle it can't feed from raw data.
+    expect(body.result?._meta?.ui).toBeUndefined();
+    expect(body.result?.structuredContent).toBeUndefined();
+    expect(typeof body.result?.content?.[0]?.text).toBe('string');
   });
 });

--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -1,0 +1,138 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAccessToken,
+  createTestOAuthClient,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+import { post } from '../../setup/test-helpers';
+
+// Marker in the stub bundle so we can assert the served HTML is ours.
+const STUB_HTML =
+  '<!doctype html><html><body data-test="mcp-app-approve-stub">approve</body></html>';
+
+describe('MCP App resources — ui:// serving + _meta on pending approval', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let owner: Awaited<ReturnType<typeof createTestUser>>;
+  let client: Awaited<ReturnType<typeof createTestOAuthClient>>;
+  let token: string;
+  let tmpRoot: string;
+  const prevWebDist = process.env.WEB_DIST_DIR;
+
+  beforeAll(async () => {
+    // Serve a stub bundle from a temp dir so resources/read needs no real owletto
+    // build. The resolver's first candidate is
+    // `join(WEB_DIST_DIR, '..', 'dist-mcp-apps/approval/index.html')`, so point
+    // WEB_DIST_DIR at `<tmp>/dist` and write the stub under `<tmp>/dist-mcp-apps`.
+    // `<tmp>/dist/index.html` deliberately does NOT exist, so the SPA dist
+    // resolver in index.ts skips this WEB_DIST_DIR and is unaffected. Set this
+    // BEFORE any resources/read — the bundle resolver caches misses per process.
+    tmpRoot = mkdtempSync(join(tmpdir(), 'lobu-mcp-app-'));
+    mkdirSync(join(tmpRoot, 'dist-mcp-apps', 'approval'), { recursive: true });
+    writeFileSync(
+      join(tmpRoot, 'dist-mcp-apps', 'approval', 'index.html'),
+      STUB_HTML
+    );
+    process.env.WEB_DIST_DIR = join(tmpRoot, 'dist');
+
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    org = await createTestOrganization({ name: 'MCP App Org', slug: 'mcp-app-org' });
+    owner = await createTestUser({ email: 'mcp-app-owner@test.example.com' });
+    await addUserToOrganization(owner.id, org.id, 'owner');
+    client = await createTestOAuthClient();
+    token = (
+      await createTestAccessToken(owner.id, org.id, client.client_id, {
+        scope: 'mcp:admin mcp:write mcp:read profile:read',
+      })
+    ).token;
+  });
+
+  afterAll(() => {
+    if (prevWebDist === undefined) delete process.env.WEB_DIST_DIR;
+    else process.env.WEB_DIST_DIR = prevWebDist;
+    if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function initSession(path: string): Promise<string> {
+    const initResponse = await post(path, {
+      body: {
+        jsonrpc: '2.0',
+        id: '__test_init__',
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'lobu-test', version: '1.0' },
+        },
+      },
+      token,
+    });
+    const sessionId = initResponse.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+    await post(path, {
+      body: { jsonrpc: '2.0', method: 'notifications/initialized' },
+      headers: { 'mcp-session-id': sessionId! },
+      token,
+    });
+    return sessionId!;
+  }
+
+  it('serves the ui://lobu/approve bundle over resources/read', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'resources/read',
+        params: { uri: 'ui://lobu/approve' },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const content = body.result?.contents?.[0];
+    expect(content?.uri).toBe('ui://lobu/approve');
+    expect(content?.mimeType).toBe('text/html');
+    expect(content?.text).toContain('mcp-app-approve-stub');
+  });
+
+  it('attaches _meta.ui + structuredContent to a pending manage_agents approval', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'manage_agents',
+          arguments: {
+            action: 'create',
+            agent_id: 'mcp-app-approval-agent',
+            name: 'MCP App Approval Agent',
+          },
+        },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    // The pending approval carries the MCP App UI pointer + the proposal, so a
+    // host renders the ApprovalCard with the create diff.
+    expect(body.result?._meta?.ui?.resourceUri).toBe('ui://lobu/approve');
+    expect(body.result?.structuredContent?.action).toBe('create');
+    expect(typeof body.result?.structuredContent?.runId).toBe('number');
+    expect(body.result?.structuredContent?.current).toBeNull();
+  });
+});

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -218,6 +218,77 @@ describe('extractAuthContext scopes (F8 source side)', () => {
   });
 });
 
+describe('extractAuthContext adminTools — builder-tool grant must only widen', () => {
+  // A non-empty `adminTools` is the LIMIT in checkToolAccess (it overrides
+  // `allowInternalTools`). So the scope-derived builder-tool allowlist may only
+  // be handed to a caller that does NOT already have blanket internal access —
+  // otherwise it NARROWS them (regression: worker direct-auth + admin REST
+  // proxy both carry `mcp:admin` AND `allowInternalTools === true`).
+  function ctxFor(opts: {
+    scopes?: string[];
+    adminTools?: string[] | null;
+    url?: string;
+    directAuth?: boolean;
+  }) {
+    const fake = {
+      req: {
+        url: opts.url ?? 'http://localhost/mcp/acme',
+        param: (_k: string) => undefined,
+        header: (k: string) =>
+          k === 'x-lobu-memory-direct-auth' && opts.directAuth ? '1' : undefined,
+      },
+      var: {
+        mcpAuthInfo: {
+          userId: 'u1',
+          scopes: opts.scopes,
+          adminTools: opts.adminTools ?? null,
+        },
+        mcpIsAuthenticated: true,
+        organizationId: 'org_1',
+      },
+    } as unknown as Parameters<typeof extractAuthContext>[0];
+    return extractAuthContext(fake);
+  }
+
+  it('surfaces the two builder tools to an external /mcp admin caller (widens)', () => {
+    const ctx = ctxFor({ scopes: ['mcp:admin'] });
+    expect(ctx.allowInternalTools).toBe(false);
+    expect(ctx.adminTools).toEqual(['manage_agents', 'manage_operations']);
+  });
+
+  it('does NOT derive an allowlist for a worker direct-auth admin caller (would narrow)', () => {
+    const ctx = ctxFor({
+      scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+      directAuth: true,
+    });
+    expect(ctx.allowInternalTools).toBe(true);
+    expect(ctx.adminTools).toBeNull();
+  });
+
+  it('does NOT derive an allowlist for an admin caller on the REST proxy (would narrow)', () => {
+    const ctx = ctxFor({
+      scopes: ['mcp:admin'],
+      url: 'http://localhost/api/v1/tools/manage_watchers',
+    });
+    expect(ctx.allowInternalTools).toBe(true);
+    expect(ctx.adminTools).toBeNull();
+  });
+
+  it('carries a builder worker per-run allowlist through unchanged', () => {
+    const ctx = ctxFor({
+      scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+      adminTools: ['manage_agents'],
+      directAuth: true,
+    });
+    expect(ctx.adminTools).toEqual(['manage_agents']);
+  });
+
+  it('leaves adminTools null for a non-admin /mcp caller', () => {
+    const ctx = ctxFor({ scopes: ['mcp:read', 'mcp:write'] });
+    expect(ctx.adminTools).toBeNull();
+  });
+});
+
 describe('hasRequiredMcpScope — fail closed on null (F8)', () => {
   // SECURITY INVARIANT: a null/undefined scope set is an under-specified
   // caller, NOT a grant of full access. Before the fix this returned `true`,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -58,7 +58,7 @@ import {
 	claimSlackPendingInstall,
 	resolveSlackPendingByTenant,
 } from "./lobu/stores/slack-installations";
-import { handleMcp } from "./mcp-handler";
+import { handleMcp, MCP_APP_DIRS } from "./mcp-handler";
 import {
 	restDeleteNotification,
 	restGetUnreadCount,
@@ -1707,7 +1707,11 @@ app.all("/mcp/:orgSlug/", handleMcp);
 // tool via the SPA host bridge. The same `readMcpAppBundle` resolver backs the
 // MCP `resources/read` path for external hosts.
 app.get("/mcp-apps/:app/index.html", async (c) => {
-	const html = await readMcpAppBundle(c.req.param("app"));
+	const app_ = c.req.param("app");
+	// Only serve a bundle the MCP App registry declares — never an arbitrary
+	// path param.
+	if (!MCP_APP_DIRS.has(app_)) return c.notFound();
+	const html = await readMcpAppBundle(app_);
 	if (html == null) return c.notFound();
 	c.header("Content-Type", "text/html; charset=utf-8");
 	c.header("Cache-Control", "no-cache");

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1701,11 +1701,11 @@ app.all("/mcp/:orgSlug/", handleMcp);
 
 // MCP App bundle — asset-only static delivery (NOT an approval endpoint). Serves
 // the self-contained `ui://` iframe payload built by owletto `build:mcp-apps`
-// (e.g. dist-mcp-apps/approval/index.html) so our own SPA can host the same
-// approval card external MCP hosts render, in a sandboxed iframe. There is no
-// approval logic here — Approve/Reject rides the existing `manage_operations`
-// tool via the SPA host bridge. The same `readMcpAppBundle` resolver backs the
-// MCP `resources/read` path for external hosts.
+// (dist-mcp-apps/interaction/index.html) so our own SPA can host every
+// interactive interaction (approval, question, tool grant, link) in a sandboxed
+// iframe. There is no action logic here — each action rides an MCP `tools/call`
+// brokered by the SPA host bridge. The same `readMcpAppBundle` resolver backs
+// the MCP `resources/read` path for external hosts.
 app.get("/mcp-apps/:app/index.html", async (c) => {
 	const app_ = c.req.param("app");
 	// Only serve a bundle the MCP App registry declares — never an arbitrary

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -81,6 +81,7 @@ import { entityLinkMatchSql } from "./utils/content-search";
 import { isValidFrameAncestor } from "./utils/csp";
 import { errorMessage } from "./utils/errors";
 import logger from "./utils/logger";
+import { readMcpAppBundle } from "./utils/mcp-app-bundle";
 import { generateOpenAPISpec } from "./utils/openapi-generator";
 import {
 	extractSubdomainOrg,
@@ -1477,6 +1478,21 @@ app.all("/mcp", handleMcp);
 app.all("/mcp/", handleMcp);
 app.all("/mcp/:orgSlug", handleMcp);
 app.all("/mcp/:orgSlug/", handleMcp);
+
+// MCP App bundle — asset-only static delivery (NOT an approval endpoint). Serves
+// the self-contained `ui://` iframe payload built by owletto `build:mcp-apps`
+// (e.g. dist-mcp-apps/approval/index.html) so our own SPA can host the same
+// approval card external MCP hosts render, in a sandboxed iframe. There is no
+// approval logic here — Approve/Reject rides the existing `manage_operations`
+// tool via the SPA host bridge. The same `readMcpAppBundle` resolver backs the
+// MCP `resources/read` path for external hosts.
+app.get("/mcp-apps/:app/index.html", async (c) => {
+	const html = await readMcpAppBundle(c.req.param("app"));
+	if (html == null) return c.notFound();
+	c.header("Content-Type", "text/html; charset=utf-8");
+	c.header("Cache-Control", "no-cache");
+	return c.body(html);
+});
 
 /**
  * Catch-all route

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -15,7 +15,12 @@ import { randomUUID } from 'node:crypto';
 import { MCP_PROTOCOL_VERSION } from '@lobu/core';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
-import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
 import type { Context } from 'hono';
 import { bindRequestAbortToStream, type AbortableStream } from './events/sse-abort-bridge';
 import { OAuthClientsStore } from './auth/oauth/clients';
@@ -23,6 +28,7 @@ import { isPublicReadable } from './auth/tool-access';
 import { createDbClientFromEnv } from './db/client';
 import type { Env } from './index';
 import { agentExistsInOrganization, isValidAgentId, touchAgentLastUsed } from './lobu/stores/postgres-stores';
+import { readMcpAppBundle } from './utils/mcp-app-bundle';
 import { McpSessionStore, type PersistedMcpSession } from './mcp-session-store';
 import {
   clearInMemoryMcpSessionsForTests as clearInMemoryMcpSessionsForTestsShared,
@@ -109,11 +115,23 @@ export async function revokeInMemoryMcpSessionsForClient(
 /** Shared mutable ref so handleMcp can signal the format to tool handlers. */
 const formatRef = { rawJson: false };
 
+/**
+ * MCP Apps UI resources (interactive iframe payloads a host renders in a
+ * sandboxed iframe). Keyed by `ui://` uri → the built bundle's app dir under
+ * owletto's `dist-mcp-apps/`. A tool result that references one of these uris in
+ * `_meta.ui.resourceUri` makes the host fetch + render it (see the pending
+ * `manage_agents` approval below). Adding an app = one entry + its owletto
+ * `src/mcp-apps/<dir>` build — no gateway change.
+ */
+const MCP_APP_RESOURCES: Record<string, { name: string; appDir: string }> = {
+  'ui://lobu/approve': { name: 'Approve agent change', appDir: 'approval' },
+};
+
 function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
   const server = new Server(
     { name: 'lobu-mcp', version: '0.2.0' },
     {
-      capabilities: { tools: {} },
+      capabilities: { tools: {}, resources: {} },
       ...(authCtx.instructions && { instructions: authCtx.instructions }),
     }
   );
@@ -182,6 +200,32 @@ function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
     return { tools: allTools };
   });
 
+  // resources/list — advertise the MCP App UI resources (interactive iframe
+  // surfaces a host renders in place of flat text; see MCP Apps).
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    resources: Object.entries(MCP_APP_RESOURCES).map(([uri, meta]) => ({
+      uri,
+      name: meta.name,
+      mimeType: 'text/html',
+    })),
+  }));
+
+  // resources/read — return the built bundle HTML for a `ui://` app resource.
+  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const uri = request.params.uri;
+    const app = MCP_APP_RESOURCES[uri];
+    if (!app) throw new Error(`Unknown resource: ${uri}`);
+    const html = await readMcpAppBundle(app.appDir);
+    if (html == null) {
+      throw new Error(
+        `MCP App bundle not built for ${uri} (run owletto build:mcp-apps)`
+      );
+    }
+    return {
+      contents: [{ uri, mimeType: 'text/html', text: html }],
+    };
+  });
+
   // tools/call — access control + execution + formatting
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
@@ -197,6 +241,32 @@ function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
       const text = formatRef.rawJson
         ? JSON.stringify(result)
         : formatToolResult(name, result, { includeRawJson: false });
+      // A pending agent-change approval carries an MCP App UI: point the host at
+      // the `ui://lobu/approve` resource and hand it the proposal, so it renders
+      // the same ApprovalCard shown in our chat, with Approve/Reject brokered
+      // back as a `manage_operations` tools/call (host consent-gated).
+      const pending =
+        result != null &&
+        typeof result === 'object' &&
+        (result as { status?: unknown }).status === 'pending_approval';
+      if (pending) {
+        const r = result as {
+          run_id?: number;
+          action?: string | null;
+          proposal?: unknown;
+          current?: unknown;
+        };
+        return {
+          content: [{ type: 'text' as const, text }],
+          _meta: { ui: { resourceUri: 'ui://lobu/approve' } },
+          structuredContent: {
+            runId: r.run_id,
+            action: r.action ?? null,
+            proposal: r.proposal ?? null,
+            current: r.current ?? null,
+          },
+        };
+      }
       return { content: [{ type: 'text' as const, text }] };
     } catch (error: any) {
       return {

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -125,7 +125,20 @@ const formatRef = { rawJson: false };
  */
 const MCP_APP_RESOURCES: Record<string, { name: string; appDir: string }> = {
   'ui://lobu/approve': { name: 'Approve agent change', appDir: 'approval' },
+  'ui://lobu/question': { name: 'Answer question', appDir: 'question' },
+  'ui://lobu/grant': { name: 'Approve tool', appDir: 'grant' },
+  'ui://lobu/link': { name: 'Open link', appDir: 'link-button' },
 };
+
+/**
+ * Built MCP App dirs, derived from the registry above. The asset route
+ * (`/mcp-apps/:app/index.html`) validates its path param against this set so it
+ * only ever serves a registered bundle — an untrusted `:app` can't be used to
+ * probe the filesystem.
+ */
+export const MCP_APP_DIRS: ReadonlySet<string> = new Set(
+  Object.values(MCP_APP_RESOURCES).map((r) => r.appDir)
+);
 
 function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
   const server = new Server(

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -118,10 +118,12 @@ const formatRef = { rawJson: false };
 /**
  * MCP Apps UI resources (interactive iframe payloads a host renders in a
  * sandboxed iframe). Keyed by `ui://` uri → the built bundle's app dir under
- * owletto's `dist-mcp-apps/`. A tool result that references one of these uris in
- * `_meta.ui.resourceUri` makes the host fetch + render it (see the pending
- * `manage_agents` approval below). Adding an app = one entry + its owletto
- * `src/mcp-apps/<dir>` build — no gateway change.
+ * owletto's `dist-mcp-apps/`. Served over `resources/read` + the asset route;
+ * our own SPA fetches the one bundle and streams it a `{title, blocks, actions}`
+ * view it builds CLIENT-side. (Pointing an external MCP host at a bundle via a
+ * tool result's `_meta.ui.resourceUri` needs the SERVER to author that view —
+ * a deliberate follow-up, so we don't stamp it today.) Adding an app = one
+ * entry + its owletto `src/mcp-apps/<dir>` build — no gateway change.
  */
 const MCP_APP_RESOURCES: Record<string, { name: string; appDir: string }> = {
   'ui://lobu/interaction': { name: 'Interaction', appDir: 'interaction' },

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -124,10 +124,7 @@ const formatRef = { rawJson: false };
  * `src/mcp-apps/<dir>` build — no gateway change.
  */
 const MCP_APP_RESOURCES: Record<string, { name: string; appDir: string }> = {
-  'ui://lobu/approve': { name: 'Approve agent change', appDir: 'approval' },
-  'ui://lobu/question': { name: 'Answer question', appDir: 'question' },
-  'ui://lobu/grant': { name: 'Approve tool', appDir: 'grant' },
-  'ui://lobu/link': { name: 'Open link', appDir: 'link-button' },
+  'ui://lobu/interaction': { name: 'Interaction', appDir: 'interaction' },
 };
 
 /**
@@ -254,32 +251,13 @@ function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
       const text = formatRef.rawJson
         ? JSON.stringify(result)
         : formatToolResult(name, result, { includeRawJson: false });
-      // A pending agent-change approval carries an MCP App UI: point the host at
-      // the `ui://lobu/approve` resource and hand it the proposal, so it renders
-      // the same ApprovalCard shown in our chat, with Approve/Reject brokered
-      // back as a `manage_operations` tools/call (host consent-gated).
-      const pending =
-        result != null &&
-        typeof result === 'object' &&
-        (result as { status?: unknown }).status === 'pending_approval';
-      if (pending) {
-        const r = result as {
-          run_id?: number;
-          action?: string | null;
-          proposal?: unknown;
-          current?: unknown;
-        };
-        return {
-          content: [{ type: 'text' as const, text }],
-          _meta: { ui: { resourceUri: 'ui://lobu/approve' } },
-          structuredContent: {
-            runId: r.run_id,
-            action: r.action ?? null,
-            proposal: r.proposal ?? null,
-            current: r.current ?? null,
-          },
-        };
-      }
+      // NOTE: our own SPA renders interactions (incl. the pending agent-change
+      // approval) through the `ui://lobu/interaction` MCP App, but it builds the
+      // `{title, blocks, actions}` view CLIENT-side from the SSE card payload —
+      // it does not consume this tool result's `_meta`. Rendering for EXTERNAL
+      // MCP hosts (Slack/Claude) needs the SERVER to author that view and stamp
+      // it here; that is a deliberate follow-up. Until then we return plain text
+      // rather than pointing an external host at a bundle it can't feed.
       return { content: [{ type: 'text' as const, text }] };
     } catch (error: any) {
       return {

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -62,6 +62,12 @@ export function extractAuthContext(c: Context<{ Bindings: Env }>): AuthContext {
     : c.var.session?.userId ? 'session'
     : 'anonymous';
   const scopedToOrg = !!c.req.param('orgSlug');
+  // Blanket internal-tool access: the REST proxy (non-`/mcp`) and the worker
+  // memory-direct-auth path. Computed here because `adminTools` below must NOT
+  // narrow a caller that already has it (see the note there).
+  const allowInternalTools =
+    !pathname.startsWith('/mcp') ||
+    c.req.header('x-lobu-memory-direct-auth') === '1';
 
   return {
     organizationId: c.var.organizationId,
@@ -89,8 +95,7 @@ export function extractAuthContext(c: Context<{ Bindings: Env }>): AuthContext {
     baseUrl: getConfiguredPublicOrigin() ?? '',
     scopedToOrg,
     allowCrossOrg: tokenType === 'oauth' && !scopedToOrg,
-    allowInternalTools:
-      !pathname.startsWith('/mcp') || c.req.header('x-lobu-memory-direct-auth') === '1',
+    allowInternalTools,
     // Builder admin-tool grant. Verified-worker first:
     //   1. the verified worker token's per-turn allowlist (the builder/system
     //      agent run), carried through mcpAuthInfo — its narrow list wins; else
@@ -100,11 +105,16 @@ export function extractAuthContext(c: Context<{ Bindings: Env }>): AuthContext {
     //      "@lobu build an agent" flow and its approval callback).
     // Check `mcpAuthInfo.scopes` (real grants), NOT `scopes` above: session/
     // anonymous callers carry the `*` sentinel, which would bypass the scope
-    // check. This only widens visibility/reachability — the owner/admin-role +
-    // `mcp:admin` gate in `enforceRoleScopeAccess` still fires underneath.
+    // check. CRITICAL: only derive this list when `allowInternalTools` is FALSE
+    // (the external `/mcp` path). A non-empty allowlist is the LIMIT in
+    // `checkToolAccess`, so deriving it for a caller that ALREADY has blanket
+    // internal-tool access (worker direct-auth, admin REST proxy — both
+    // `allowInternalTools === true`) would NARROW them to just these two tools,
+    // not widen. The owner/admin-role + `mcp:admin` gate still fires underneath.
     adminTools:
       mcpAuthInfo?.adminTools ??
-      (mcpAuthInfo != null &&
+      (!allowInternalTools &&
+      mcpAuthInfo != null &&
       hasRequiredMcpScope('admin', mcpAuthInfo.scopes ?? [])
         ? ['manage_agents', 'manage_operations']
         : null),

--- a/packages/server/src/tools/execute.ts
+++ b/packages/server/src/tools/execute.ts
@@ -91,10 +91,23 @@ export function extractAuthContext(c: Context<{ Bindings: Env }>): AuthContext {
     allowCrossOrg: tokenType === 'oauth' && !scopedToOrg,
     allowInternalTools:
       !pathname.startsWith('/mcp') || c.req.header('x-lobu-memory-direct-auth') === '1',
-    // Builder admin-tool grant: carried from the verified worker token through
-    // mcpAuthInfo (see multi-tenant worker direct-auth). Lets the system agent
-    // call its allowlisted internal tools even on the /mcp path.
-    adminTools: mcpAuthInfo?.adminTools ?? null,
+    // Builder admin-tool grant. Verified-worker first:
+    //   1. the verified worker token's per-turn allowlist (the builder/system
+    //      agent run), carried through mcpAuthInfo — its narrow list wins; else
+    //   2. an external MCP caller (Slackbot/Claude/PAT) whose token holds the
+    //      `mcp:admin` scope — surface the builder tools so an approved admin
+    //      can drive agent management + approvals over MCP (e.g. the in-Slack
+    //      "@lobu build an agent" flow and its approval callback).
+    // Check `mcpAuthInfo.scopes` (real grants), NOT `scopes` above: session/
+    // anonymous callers carry the `*` sentinel, which would bypass the scope
+    // check. This only widens visibility/reachability — the owner/admin-role +
+    // `mcp:admin` gate in `enforceRoleScopeAccess` still fires underneath.
+    adminTools:
+      mcpAuthInfo?.adminTools ??
+      (mcpAuthInfo != null &&
+      hasRequiredMcpScope('admin', mcpAuthInfo.scopes ?? [])
+        ? ['manage_agents', 'manage_operations']
+        : null),
   };
 }
 

--- a/packages/server/src/utils/mcp-app-bundle.ts
+++ b/packages/server/src/utils/mcp-app-bundle.ts
@@ -29,8 +29,12 @@ function bundleCandidates(appDir: string): string[] {
 }
 
 // Cache the resolved HTML per app dir — the bundle is immutable at runtime, so
-// don't hit disk on every `resources/read`. `null` caches a confirmed miss.
-const bundleCache = new Map<string, string | null>();
+// don't hit disk on every `resources/read`. Only successful reads are cached: a
+// miss is NOT memoized, so a bundle built after the first request (e.g. a dev
+// server that hasn't run `build:mcp-apps` yet) recovers on the next request
+// instead of serving 404 until the pod restarts. Every interactive interaction
+// now depends on this one bundle, so a sticky miss would break all of them.
+const bundleCache = new Map<string, string>();
 
 /** Read a built MCP App bundle's HTML. Returns null when no build is present. */
 export async function readMcpAppBundle(appDir: string): Promise<string | null> {
@@ -46,6 +50,5 @@ export async function readMcpAppBundle(appDir: string): Promise<string | null> {
       // candidate absent — try the next
     }
   }
-  bundleCache.set(appDir, null);
   return null;
 }

--- a/packages/server/src/utils/mcp-app-bundle.ts
+++ b/packages/server/src/utils/mcp-app-bundle.ts
@@ -1,0 +1,51 @@
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Locate + read a built MCP App bundle (a self-contained `ui://` iframe payload
+ * produced by owletto's `build:mcp-apps`, e.g.
+ * `packages/owletto/dist-mcp-apps/<appDir>/index.html`).
+ *
+ * Path resolution mirrors `resolveWebDistDirectory` in `index.ts` (the owletto
+ * SPA dist locator): `WEB_DIST_DIR` override first, then `APP_ROOT` and `cwd`
+ * siblings. `WEB_DIST_DIR` points at the owletto `dist` dir, so the MCP bundle
+ * lives one level up under `dist-mcp-apps/`.
+ */
+
+// packages/server dir (mirror of APP_ROOT in index.ts).
+const APP_ROOT = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+function bundleCandidates(appDir: string): string[] {
+  const rel = path.join('dist-mcp-apps', appDir, 'index.html');
+  const webDist = process.env.WEB_DIST_DIR?.trim();
+  return [
+    webDist ? path.join(webDist, '..', rel) : undefined,
+    path.resolve(APP_ROOT, 'packages/owletto', rel),
+    path.resolve(APP_ROOT, '../owletto', rel),
+    path.resolve(process.cwd(), 'packages/owletto', rel),
+    path.resolve(process.cwd(), '../owletto', rel),
+  ].filter((p): p is string => typeof p === 'string');
+}
+
+// Cache the resolved HTML per app dir — the bundle is immutable at runtime, so
+// don't hit disk on every `resources/read`. `null` caches a confirmed miss.
+const bundleCache = new Map<string, string | null>();
+
+/** Read a built MCP App bundle's HTML. Returns null when no build is present. */
+export async function readMcpAppBundle(appDir: string): Promise<string | null> {
+  const cached = bundleCache.get(appDir);
+  if (cached !== undefined) return cached;
+  for (const candidate of bundleCandidates(appDir)) {
+    try {
+      await stat(candidate);
+      const html = await readFile(candidate, 'utf8');
+      bundleCache.set(appDir, html);
+      return html;
+    } catch {
+      // candidate absent — try the next
+    }
+  }
+  bundleCache.set(appDir, null);
+  return null;
+}


### PR DESCRIPTION
## What

Unify the agent create/update/delete approval on the **MCP Apps** path: our own chat becomes just another MCP Apps host that renders the same `ui://lobu/approve` bundle external hosts (Slack, Claude) get — in a sandboxed iframe — instead of carrying a bespoke inline React card.

Supersedes the split-path #1667 (+ owletto #409): those shipped the server-side MCP resource + the bundle but left our own chat on a separate inline `BuilderApprovalCard`. This folds both in and deletes the inline path, so there is **one** rendering path everywhere.

Builds on #1669 (reload-replay): pending approvals are already rehydrated as `tool-approval` parts on history load, so this renders identically after a reload.

## How

**Server**
- `mcp-handler`: advertise + serve `ui://lobu/approve` (`resources/list` + `resources/read` via `readMcpAppBundle`); attach `_meta.ui.resourceUri` + `structuredContent` (`runId/action/proposal/current`) on a `pending_approval` tool result so any host renders it.
- `execute`: surface builder tools (`manage_agents`/`manage_operations`) to an `mcp:admin`-scoped external caller (owner/admin-role gate still fires underneath).
- `readMcpAppBundle` resolver (finds owletto `dist-mcp-apps` next to the SPA dist) + integration test.
- **New asset-only route** `GET /mcp-apps/:app/index.html` serves the self-contained bundle HTML to our SPA iframe. **No approval logic** — Approve/Reject rides the existing `manage_operations` tool via the host bridge. Works in dev + prod (same resolver the MCP `resources/read` path uses).
- Dockerfile builds the bundle (`build:mcp-apps`) into the image.

**owletto** (host-bridge branch)
- Reusable presentational `ApprovalCard` + the `ui://lobu/approve` bundle (`vite-plugin-singlefile` → one 340KB self-contained HTML).
- Replace inline `BuilderApprovalCard` with `McpAppApprovalCard`: embeds the bundle via `sandbox="allow-scripts"` (opaque origin — no cookie/DOM reach) and owns the host bridge — streams the proposal (`ui/render`), sizes the frame to reported height (`ui/resize`), brokers Approve/Reject (`tools/call manage_operations`) through the authenticated mutation hooks. The sandbox never touches the API directly.
- Bundle re-enables its buttons on a brokered-call error (`ui/tool-result` `isError`) instead of freezing.

## Verification

- owletto + server `tsc` clean; biome clean.
- Asset route (curl): `200`, `text/html`, 340KB, `Content-Security-Policy: frame-ancestors 'self' …`, `404` on unknown app.
- MCP `resources/read` + `_meta`-on-pending-approval integration test: **2/2 pass**.
- **Live browser E2E against the real production bundle** (host harness on the SPA origin, real `sandbox="allow-scripts"` iframe):
  - `ui/initialize → ui/render` → card renders the full field-level diff with the SPA's shadcn theme.
  - `ui/resize` → iframe auto-sizes (72→256px).
  - Approve click → `tools/call {name:"manage_operations", arguments:{action:"approve", run_id:4242}}` (exactly what the host bridge maps to `useApproveAgentChange.mutate`).
  - `ui/tool-result` → card resolves to "Approved — update support-triage is being applied.", buttons removed.

## Note
Requires owletto pointer at the host-bridge branch (bumped here). After merge, repoint to owletto main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785529821&installation_id=136316292&pr_number=1674&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1674&signature=2a3f562f2e72a6e49062594ceb71024ed8ad26771778f3aa796d4a8a32d39f9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP resource support for serving built MCP app UI bundles (including listing available resources and reading bundle HTML).
* **Bug Fixes**
  * Improved admin tool access control: admin tools are granted only when the required MCP admin scope is present, using the correct precedence rules.
  * Pending-approval responses no longer include MCP app UI pointer metadata.
* **Tests**
  * Added/updated integration and auth tests to validate MCP app resource serving and the updated pending-approval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update — generic MCP App host (consolidation)

The PR now consolidates **all four** interactive agent interactions onto one generic MCP App iframe host, not just the agent-change approval.

**Before:** only the agent-change approval rendered as an MCP App. The MCP tool grant, `ask_user` question, and link button each rendered as a bespoke inline React card in `agent-thread.tsx`.

**After:** every interactive interaction renders through the same sandboxed iframe host (`sandbox="allow-scripts"`, opaque origin), served the matching `ui://` bundle.

- Extracted the iframe-side MCP Apps protocol (initialize / render / resize / tool-result + theme + height-report burst) into `src/mcp-apps/_shared/host` — a bundle is now just a presentational card wired to a `callTool`.
- Added `question`, `grant`, `link-button` bundles reusing the SPA's presentational cards; all four build via the `MCP_APP`-parameterized vite config.
- Replaced the four inline cards (`QuestionPart` / `LinkButtonPart` / `McpGrantApprovalCard` / `McpAppApprovalCard`) with one generic `McpAppFrame` + `InteractiveToolPart` dispatcher. Net **−171 lines** in `agent-thread.tsx` while adding two interaction types.
- **Security:** the dispatcher pins every sensitive identifier (runId, requestId, approve URL, org slug, link URL) from its **own** copy of the args — the sandbox only ever sends a decision/answer string. For the tool grant it validates the decision against the allowed duration set before making the authenticated REST call, so the opaque-origin iframe can't forge which request it grants (strictly tighter than the previous inline fetch).
- Server: registered the three new `ui://` resources in `MCP_APP_RESOURCES` and gated the `/mcp-apps/:app/index.html` asset route against the registry so it only serves a declared bundle.

**Scope note (durability):** rendering is now uniform. Reload-durability is orthogonal and unchanged — the agent-change approval is still the only interaction replayed on reload (it's a saved event); question / grant / link stay live-only SSE cards, same as before. Making the tool grant reload-durable via the existing `pending-approvals` endpoint is a small follow-up.


---

## Update 2 — collapsed to ONE data-driven bundle

Superseded the four per-type bundles with a **single** `ui://lobu/interaction` bundle + one generic renderer. The bundle renders whatever `{title, blocks, actions}` view the host streams and posts each action back as `tools/call {tool, args}`.

- 4 bundles → **1**; 4 presentational cards → **1** generic `InteractionCard`; no per-type build (`build:mcp-apps` builds one app).
- The host (`agent-thread`) builds the view per interaction + keeps a small tool→handler map for the actions that hit different subsystems (approve mutation / grant REST / question append / link open), still pinning every sensitive id host-side.
- Adding an interaction type is now a new view shape — no new bundle, no new component.
- Server: `MCP_APP_RESOURCES` collapsed to the one resource; the pending-approval tool result no longer stamps `_meta` (external-host rendering needs the server to author the view — a deliberate follow-up).

**Live-verified** (dev server, all four shapes driven through the real bundle): approval diff + Approve/Reject, question options → "Answered: …", grant amber + durations/Deny → "Approved for 24h.", link bare fire-and-forget, and the reject→confirm→resolved two-step. Owletto `tsc`+biome clean, 410/410 tests, bundle builds; server registry gate serves only `interaction` and 404s everything else.


---

## Reviewer note — MCP authz-surface expansion (from the bundled #1667 work)

Independent of the rendering refactor, this branch carries an `execute.ts` change that makes `manage_agents` / `manage_operations` reachable over the **external `/mcp`** transport for a caller holding the `mcp:admin` scope (previously REST/session-only). This is the deliberate "in-Slack build-an-agent + approval callback" path. It is double-gated: `enforceRoleScopeAccess` still requires **both** an owner/admin member role **and** the `mcp:admin` scope, so surfacing the tool does not bypass authz. The fallback only *widens* (it's skipped whenever the caller already has blanket internal access), with red-green unit coverage in `tool-access.test.ts` for both directions. Flagging it so it's not mistaken for an accidental surface change riding a UI PR.
