### PR TITLE
fix(authz): graph BYO Slack connections + reconcile stale channel bindings

### DIFF
--- a/packages/server/src/__tests__/integration/authz/slack-byo-bot-identity.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-byo-bot-identity.test.ts
@@ -1,0 +1,157 @@
+/**
+ * `resolveSlackBotIdentity` — the bot-token/user-id resolution that backs Slack
+ * ACL sync. Covers the gap that left BYO Slack connections ungraphed: an active
+ * connection with real bindings but NO OAuth app-installation must resolve its
+ * bot identity from the connection's OWN config, not fail closed. Also proves
+ * the install path still wins when an install exists.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { resolveSlackBotIdentity } from '../../../authz/slack-acl-sync';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  createTestOrganization,
+  insertChatConnectionRow,
+} from '../../setup/test-fixtures';
+
+// A no-op secret store: our test tokens are plaintext (not `secret://` refs), so
+// resolveSecretValue returns them verbatim without ever calling `.get`.
+const secretStore = {
+  get: async () => undefined,
+} as unknown as Parameters<typeof resolveSlackBotIdentity>[0]['secretStore'];
+
+// Install store that reports NO install for any team — forces the BYO fallback.
+// `getSlackInstallByTeamId` calls `resolveActiveByTenant`; returning null there
+// is the "no install" signal.
+const emptyInstallStore = {
+  resolveActiveByTenant: async () => null,
+} as unknown as Parameters<typeof resolveSlackBotIdentity>[0]['installStore'];
+
+const TEAM = 'T0BYOTEAM';
+
+describe('resolveSlackBotIdentity — BYO fallback', () => {
+  let orgId: string;
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization();
+    orgId = org.id;
+  });
+
+  it('falls back to the connection\'s own bot token + user id when there is no install', async () => {
+    await insertChatConnectionRow({
+      id: 'conn-byo',
+      organizationId: orgId,
+      platform: 'slack',
+      status: 'active',
+      credentialMode: 'byo',
+      config: { botToken: 'xoxb-byo-token' },
+      metadata: { teamId: TEAM, botUserId: 'U0BYOBOT' },
+    });
+
+    const identity = await resolveSlackBotIdentity(
+      { installStore: emptyInstallStore, secretStore },
+      { organizationId: orgId, teamId: TEAM, connectionId: 'conn-byo' },
+    );
+
+    expect(identity).toEqual({ token: 'xoxb-byo-token', botUserId: 'U0BYOBOT' });
+  });
+
+  it('returns null when neither an install nor a BYO token exists (fails closed)', async () => {
+    await insertChatConnectionRow({
+      id: 'conn-notoken',
+      organizationId: orgId,
+      platform: 'slack',
+      status: 'active',
+      credentialMode: 'byo',
+      config: {}, // no botToken
+      metadata: { teamId: TEAM },
+    });
+
+    const identity = await resolveSlackBotIdentity(
+      { installStore: emptyInstallStore, secretStore },
+      { organizationId: orgId, teamId: TEAM, connectionId: 'conn-notoken' },
+    );
+
+    expect(identity).toBeNull();
+  });
+
+  it('does not resolve a BYO token across orgs (org-scoped lookup)', async () => {
+    await insertChatConnectionRow({
+      id: 'conn-byo',
+      organizationId: orgId,
+      platform: 'slack',
+      status: 'active',
+      credentialMode: 'byo',
+      config: { botToken: 'xoxb-byo-token' },
+      metadata: { teamId: TEAM, botUserId: 'U0BYOBOT' },
+    });
+
+    const other = await createTestOrganization();
+    const identity = await resolveSlackBotIdentity(
+      { installStore: emptyInstallStore, secretStore },
+      { organizationId: other.id, teamId: TEAM, connectionId: 'conn-byo' },
+    );
+
+    expect(identity).toBeNull();
+  });
+
+  it('does NOT hand back a BYO token for a team the connection does not belong to', async () => {
+    // The connection is team T0BYOTEAM; asking to graph a DIFFERENT team must
+    // resolve null (fail-closed), never this connection's own token — otherwise
+    // Slack channel_not_found on the foreign team + the empty-member reconcile
+    // would wipe live edges the foreign team's real connection maintains.
+    await insertChatConnectionRow({
+      id: 'conn-byo',
+      organizationId: orgId,
+      platform: 'slack',
+      status: 'active',
+      credentialMode: 'byo',
+      config: { botToken: 'xoxb-byo-token' },
+      metadata: { teamId: TEAM, botUserId: 'U0BYOBOT' },
+    });
+
+    const identity = await resolveSlackBotIdentity(
+      { installStore: emptyInstallStore, secretStore },
+      { organizationId: orgId, teamId: 'T0OTHERTEAM', connectionId: 'conn-byo' },
+    );
+
+    expect(identity).toBeNull();
+  });
+
+  it('prefers the install path when an active install exists', async () => {
+    // Shape it as an AppInstallationRow — toSlackRow reads metadata.external_id,
+    // metadata.bot_user_id, metadata.config, externalTenantId, status.
+    const installStore = {
+      resolveActiveByTenant: async () => ({
+        organizationId: orgId,
+        externalTenantId: TEAM,
+        status: 'active',
+        createdAt: 0,
+        updatedAt: 0,
+        metadata: {
+          external_id: 'slackinst-abc',
+          bot_user_id: 'U0INSTALLBOT',
+          config: { botToken: 'xoxb-install-token' },
+        },
+      }),
+    } as unknown as Parameters<typeof resolveSlackBotIdentity>[0]['installStore'];
+
+    await insertChatConnectionRow({
+      id: 'conn-byo',
+      organizationId: orgId,
+      platform: 'slack',
+      status: 'active',
+      credentialMode: 'byo',
+      config: { botToken: 'xoxb-byo-token' },
+      metadata: { teamId: TEAM, botUserId: 'U0BYOBOT' },
+    });
+
+    const identity = await resolveSlackBotIdentity(
+      { installStore, secretStore },
+      { organizationId: orgId, teamId: TEAM, connectionId: 'conn-byo' },
+    );
+
+    expect(identity).toEqual({ token: 'xoxb-install-token', botUserId: 'U0INSTALLBOT' });
+  });
+});

--- a/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
@@ -388,6 +388,73 @@ describe('slack channel visibility gate (e2e via search_memory)', () => {
     expect(channels).not.toContain('C01SEC');
   });
 
+  it('reconciles a STALE channel to no members (revokes recall) while still graphing the readable ones', async () => {
+    const { org, alice, agent } = await setupWorkspace();
+
+    // Round 1: BOTH channels readable, Alice is a member of BOTH. She can recall
+    // #eng and #secret.
+    const round1 = await syncSlackConnectionAcl(
+      {
+        slackWeb: {
+          conversationMembers: async () => ['U01ALICE'],
+        },
+        resolveBotIdentity: async () => ({ token: 'xoxb-test-token', botUserId: null }),
+      },
+      { connectionId: CONN, organizationId: org.id },
+    );
+    expect(round1.ok).toBe(true);
+    const recalled1 = (
+      await searchAs(org.id, alice.id, agent.agentId)
+    ).conversation_messages?.map((m) => m.channel_id);
+    expect(recalled1).toContain('C01ENG');
+    expect(recalled1).toContain('C01SEC');
+
+    // Round 2: the bot is kicked from #secret (channel_not_found). #eng stays
+    // readable. The connection must NOT fail-close (pre-fix it did, 0 graphed),
+    // AND #secret's stale member_of edges must be reconciled away — otherwise
+    // Alice keeps recalling a channel the bot can no longer see (fail-OPEN).
+    const round2 = await syncSlackConnectionAcl(
+      {
+        slackWeb: {
+          conversationMembers: async (_t, channelId) => {
+            if (channelId === 'C01SEC') {
+              throw new Error('Slack conversations.members failed: channel_not_found');
+            }
+            return ['U01ALICE'];
+          },
+        },
+        resolveBotIdentity: async () => ({ token: 'xoxb-test-token', botUserId: null }),
+      },
+      { connectionId: CONN, organizationId: org.id },
+    );
+    expect(round2.ok).toBe(true);
+
+    const recalled2 = (
+      await searchAs(org.id, alice.id, agent.agentId)
+    ).conversation_messages?.map((m) => m.channel_id);
+    expect(recalled2).toContain('C01ENG'); // still readable → still recalled
+    expect(recalled2).not.toContain('C01SEC'); // kicked → recall revoked
+  });
+
+  it('still FAILS CLOSED on a systemic Slack error (not a stale-channel error)', async () => {
+    const { org } = await setupWorkspace();
+    // A rate-limit / auth error is systemic — it must propagate and fail the
+    // connection closed, not be swallowed like a stale-channel error.
+    const result = await syncSlackConnectionAcl(
+      {
+        slackWeb: {
+          conversationMembers: async () => {
+            throw new Error('Slack conversations.members failed: ratelimited');
+          },
+        },
+        resolveBotIdentity: async () => ({ token: 'xoxb-test-token', botUserId: null }),
+      },
+      { connectionId: CONN, organizationId: org.id },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.channelsSynced).toBe(0);
+  });
+
   it('production sync FAILS CLOSED for an already-graphed connection when Slack fetch throws', async () => {
     const { org, alice, agent } = await setupWorkspace();
     // First a good sync so the connection has a materialized (enforced) graph.

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -47,16 +47,26 @@ export interface SlackAclSyncDeps {
   slackWeb: Pick<SlackWebApi, 'conversationMembers' | 'conversationInfo'>;
   /**
    * Resolve the bot IDENTITY for a workspace — its token plus the bot's own
-   * Slack user id — from the app installation, or null if none is available (no
-   * active install / unresolvable secret), which is treated fail-closed. The bot
-   * id is sourced from the install (stamped at install time), NOT from the
-   * connection metadata, whose `botUserId` is only backfilled lazily at adapter
-   * init: in the window before the adapter first runs it is null, which would let
-   * the bot slip into the `member_of` graph and the audience.
+   * Slack user id — or null if none is available (no active install AND no BYO
+   * token / unresolvable secret), which is treated fail-closed. The OAuth-install
+   * path sources the bot id from the install (stamped at install time). The BYO
+   * fallback sources it from the connection's `chatMetadata.botUserId`, which is
+   * backfilled lazily at adapter init: if it is still null (pre-first-run window)
+   * the bot is NOT filtered out and can transiently gain a `member_of` edge —
+   * self-healing on the next sync once the id backfills (a bot id maps to no
+   * human requester, so this is audience inflation, never access leakage).
    */
   resolveBotIdentity: (params: {
     organizationId: string;
     teamId: string;
+    /**
+     * The connection being synced. Lets the resolver fall back to the
+     * connection's own BYO bot credentials when the team has no OAuth
+     * app-installation — otherwise a BYO Slack connection (active bot, real
+     * bindings, no install row) never gets ACL-graphed and its channel memory
+     * silently degrades to org scope.
+     */
+    connectionId: string;
   }) => Promise<{ token: string; botUserId: string | null } | null>;
 }
 
@@ -143,17 +153,45 @@ export async function syncSlackConnectionAcl(
   let channelsSynced = 0;
   try {
     for (const [teamId, channelIds] of byTeam) {
-      const identity = await deps.resolveBotIdentity({ organizationId, teamId });
+      const identity = await deps.resolveBotIdentity({ organizationId, teamId, connectionId });
       if (!identity) {
         throw new Error(`No bot token for team ${teamId}`);
       }
       const { token, botUserId } = identity;
       const channels: SlackChannelInput[] = [];
       for (const channelId of channelIds) {
-        const rawMembers = await deps.slackWeb.conversationMembers(
-          token,
-          channelId,
-        );
+        // Per-channel tolerance for a STALE binding: if the bot was kicked, the
+        // channel was archived/deleted, or it's simply not in it, Slack throws
+        // `channel_not_found` / `not_in_channel` / `is_archived`. That channel
+        // has no readable audience — DROP it from the graph and keep going;
+        // fail-closing the whole connection over one dead binding would ungraph
+        // every OTHER (readable) channel too. Systemic errors (auth, rate limit)
+        // still propagate to the outer catch and fail the connection closed.
+        let rawMembers: string[];
+        try {
+          rawMembers = await deps.slackWeb.conversationMembers(token, channelId);
+        } catch (error) {
+          const msg = String(error);
+          if (
+            /channel_not_found|not_in_channel|is_archived|method_not_supported_for_channel_type/.test(
+              msg,
+            )
+          ) {
+            // Definitively unreadable (bot kicked / channel archived/gone),
+            // NOT transient. Push it with an EMPTY member set so graph
+            // reconciliation soft-deletes its stale `member_of` edges (revokes
+            // recall) — skipping would leave them alive (fail-OPEN). Transient
+            // errors (ratelimit/auth) fall through to `throw` → whole connection
+            // fails closed, so we never wipe edges on a flaky fetch.
+            logger.warn(
+              { organization_id: organizationId, channel_id: channelId, error: msg },
+              'Slack conversations.members: channel unreadable (stale binding) — reconciling to no members',
+            );
+            channels.push({ channelId, memberSlackUserIds: [] });
+            continue;
+          }
+          throw error;
+        }
         // The bot is itself a member of every channel it's in, so
         // `conversations.members` includes it. Drop it: a bot is not an audience
         // and must never gain a `member_of` edge (it would inflate "who can
@@ -204,6 +242,72 @@ export async function syncSlackConnectionAcl(
 }
 
 /**
+ * Resolve the bot token + user id for one Slack connection's ACL sync. Prefers
+ * the workspace OAuth app-installation (hosted/managed path); falls back to the
+ * connection's OWN bot credentials for a BYO Slack connection that has no
+ * install row. Exported so both branches are unit-testable — the BYO fallback
+ * is what lets an active-but-BYO connection (real bindings, no install) actually
+ * graph instead of failing closed and silently degrading channel memory to org
+ * scope.
+ */
+export async function resolveSlackBotIdentity(
+  deps: {
+    installStore: ReturnType<CoreServices['getAppInstallationStore']>;
+    secretStore: ReturnType<CoreServices['getSecretStore']>;
+  },
+  params: { organizationId: string; teamId: string; connectionId: string },
+): Promise<{ token: string; botUserId: string | null } | null> {
+  const { installStore, secretStore } = deps;
+  const { organizationId, teamId, connectionId } = params;
+
+  // Primary: the workspace OAuth app-installation (the hosted/managed path).
+  const install = await getSlackInstallByTeamId(installStore, teamId);
+  if (install && install.status === 'active') {
+    const tokenRef = (install.config as { botToken?: string }).botToken;
+    const token = await orgContext.run({ organizationId: install.organizationId }, () =>
+      resolveSecretValue(secretStore, tokenRef),
+    );
+    if (token) return { token, botUserId: install.botUserId ?? null };
+  }
+
+  // Fallback: a BYO Slack connection has no install row — its bot token + user
+  // id live on the connection's own config. The token is a `secret://` ref,
+  // resolved under the connection's org exactly like the install path.
+  const sql = getDb();
+  const [conn] = await sql<{
+    organization_id: string;
+    // Slack connection config stores botToken at the top level (the
+    // OAuth-install writer's shape); COALESCE the chatMetadata nesting too.
+    bot_token_ref: string | null;
+    bot_user_id: string | null;
+  }>`
+		SELECT organization_id,
+		       COALESCE(config->>'botToken', config->'chatMetadata'->>'botToken') AS bot_token_ref,
+		       config->'chatMetadata'->>'botUserId' AS bot_user_id
+		FROM connections
+		WHERE slug = ${runtimeConnectionIdToSlug(connectionId)}
+		  AND organization_id = ${organizationId}
+		  AND connector_key = 'slack'
+		  AND status = 'active'
+		  AND deleted_at IS NULL
+		  -- The connection must actually BELONG to the team we're graphing.
+		  -- Without this, a connection whose bindings span a foreign team (or the
+		  -- teamId-null preview case) would hand back its OWN token for a team it
+		  -- doesn't own; Slack answers channel_not_found for every foreign channel
+		  -- and the empty-member reconcile would then wipe live edges the team's
+		  -- REAL connection maintains. Same team expression the tick scopes with.
+		  AND COALESCE(external_tenant_id, config->'chatMetadata'->>'teamId') = ${teamId}
+		LIMIT 1
+	`;
+  if (!conn?.bot_token_ref) return null;
+  const token = await orgContext.run({ organizationId: conn.organization_id }, () =>
+    resolveSecretValue(secretStore, conn.bot_token_ref as string),
+  );
+  if (!token) return null;
+  return { token, botUserId: conn.bot_user_id };
+}
+
+/**
  * The periodic production caller (registered in `scheduled/jobs.ts`). Re-syncs
  * every active Slack connection's channel-membership graph so joins/leaves
  * converge within the tick cadence and the gate's freshness window keeps a
@@ -211,9 +315,10 @@ export async function syncSlackConnectionAcl(
  * runs-queue claim), iterating connections sequentially — membership sync is not
  * latency-critical.
  *
- * Token resolution keys on the workspace install (`getSlackInstallByTeamId`), so
- * it covers the prod OAuth-install path; a connection whose team has no active
- * install is skipped (its sync throws → fail-closed via {@link syncSlackConnectionAcl}).
+ * Token resolution ({@link resolveSlackBotIdentity}) prefers the workspace OAuth
+ * install and falls back to the connection's own BYO bot credentials, so both
+ * managed and BYO Slack connections graph. A connection with neither still
+ * fails closed via {@link syncSlackConnectionAcl}.
  */
 export async function runSlackAclSyncTick(coreServices: CoreServices): Promise<void> {
   const sql = getDb();
@@ -237,16 +342,8 @@ export async function runSlackAclSyncTick(coreServices: CoreServices): Promise<v
 
   const deps: SlackAclSyncDeps = {
     slackWeb,
-    resolveBotIdentity: async ({ teamId }) => {
-      const install = await getSlackInstallByTeamId(installStore, teamId);
-      if (!install || install.status !== 'active') return null;
-      const tokenRef = (install.config as { botToken?: string }).botToken;
-      const token = await orgContext.run({ organizationId: install.organizationId }, () =>
-        resolveSecretValue(secretStore, tokenRef),
-      );
-      if (!token) return null;
-      return { token, botUserId: install.botUserId ?? null };
-    },
+    resolveBotIdentity: (params) =>
+      resolveSlackBotIdentity({ installStore, secretStore }, params),
   };
 
   let ok = 0;


### PR DESCRIPTION
## What

Fixes Slack ACL channel-graphing so a BYO (bring-your-own bot token) Slack connection actually gets its channel-membership graph built. That graph (`entity_identities` namespace `slack_channel_id` + `member_of` edges via `buildAccessGraph`) is what the resource-visibility gate reads to decide who can recall a channel's memory. Three fixes, all in `packages/server/src/authz/slack-acl-sync.ts`.

### 1. BYO bot-identity fallback
`resolveSlackBotIdentity` (newly extracted + exported) previously resolved the bot token ONLY via the OAuth app-installation. Now, when the team has no active install, it falls back to the connection's own `config.botToken` (a `secret://` ref) + `config.chatMetadata.botUserId`, org-scoped **and team-scoped**. Install still wins when present. The team-scope predicate (`COALESCE(external_tenant_id, config->'chatMetadata'->>'teamId') = ${teamId}`) prevents handing back a foreign-workspace token for a team the connection doesn't own — which would otherwise cause every channel to answer `channel_not_found` and trip the empty-member reconcile (fix 3) into wiping the real connection's live edges.

### 2. Stale-channel fail-CLOSED per channel
The per-channel `conversations.members` call was awaited with no try/catch, so one stale binding (bot kicked / channel archived → `channel_not_found`/`not_in_channel`/`is_archived`) threw and fail-closed the WHOLE connection (0 channels graphed). Now definitively-unreadable channels are handled per-channel; transient errors (rate limit, auth) still `throw` → whole connection fails closed.

### 3. Stale-channel does NOT fail-OPEN
A stale channel is pushed with `memberSlackUserIds: []` so `buildAccessGraph` reconciles (soft-deletes) its existing `member_of` edges — revoking recall — instead of skipping it (which would leave stale edges alive = a member keeps recalling a channel the bot can no longer see).

## Red -> green (E2E)

Integration tests against real Postgres, `packages/server/src/__tests__/integration/authz/`:

- `slack-channel-visibility.test.ts` — round 1 both channels readable + Alice recalls both; round 2 bot kicked from `#secret` (`channel_not_found`) -> connection stays `ok`, `#eng` still recalled, `#secret` recall **revoked**. Plus a systemic-error case (`ratelimited`) that must fail the whole connection closed.
- `slack-byo-bot-identity.test.ts` — BYO fallback resolves own token; returns null with no token; org-scoped (no cross-tenant read); **team-scoped** (wrong team -> null, so no foreign-token wipe); install path wins when present.

18/18 pass. `make build-packages` (typecheck) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785551108&installation_id=136316292&pr_number=1683&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1683&signature=f08b07263761a4969044673f905bfbd6a8a34d5235a6bb12af4a59c549ebf124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack connections now support graphing for both managed and BYO bot-identity setups.
  * Bot identity resolution can use a connection’s own stored bot token when no workspace install is available.

* **Bug Fixes**
  * Stale or no-longer-readable Slack channels are now handled more gracefully during sync, without failing the entire connection.
  * Syncs now distinguish between recoverable channel issues and broader Slack/API failures, improving reliability and status reporting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->