### PR TITLE
fix(authz): self-heal teamId on BYO Slack connections via auth.test

### DIFF
--- a/packages/server/src/__tests__/integration/authz/slack-byo-bot-identity.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-byo-bot-identity.test.ts
@@ -3,11 +3,14 @@
  * ACL sync. Covers the gap that left BYO Slack connections ungraphed: an active
  * connection with real bindings but NO OAuth app-installation must resolve its
  * bot identity from the connection's OWN config, not fail closed. Also proves
- * the install path still wins when an install exists.
+ * the install path still wins when an install exists, and that a teamId-less BYO
+ * connection self-heals its team via `auth.test` (the real prod case: a BYO
+ * connection created without an OAuth install never persists a teamId).
  */
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import { resolveSlackBotIdentity } from '../../../authz/slack-acl-sync';
+import { getDb } from '../../../db/client';
 import { cleanupTestDatabase } from '../../setup/test-db';
 import {
   createTestOrganization,
@@ -26,6 +29,19 @@ const secretStore = {
 const emptyInstallStore = {
   resolveActiveByTenant: async () => null,
 } as unknown as Parameters<typeof resolveSlackBotIdentity>[0]['installStore'];
+
+// Slack Web stub. `authTest` is only reached on the self-heal path (a BYO
+// connection with no stored teamId); the default throws so any UNEXPECTED
+// auth.test call surfaces as a test failure. Individual tests override it.
+function makeSlackWeb(authTest?: (token: string) => Promise<{ teamId: string }>) {
+  return {
+    authTest:
+      authTest ??
+      (async () => {
+        throw new Error('auth.test should not be called on the fast path');
+      }),
+  } as unknown as Parameters<typeof resolveSlackBotIdentity>[0]['slackWeb'];
+}
 
 const TEAM = 'T0BYOTEAM';
 
@@ -50,7 +66,7 @@ describe('resolveSlackBotIdentity — BYO fallback', () => {
     });
 
     const identity = await resolveSlackBotIdentity(
-      { installStore: emptyInstallStore, secretStore },
+      { installStore: emptyInstallStore, secretStore, slackWeb: makeSlackWeb() },
       { organizationId: orgId, teamId: TEAM, connectionId: 'conn-byo' },
     );
 
@@ -69,7 +85,7 @@ describe('resolveSlackBotIdentity — BYO fallback', () => {
     });
 
     const identity = await resolveSlackBotIdentity(
-      { installStore: emptyInstallStore, secretStore },
+      { installStore: emptyInstallStore, secretStore, slackWeb: makeSlackWeb() },
       { organizationId: orgId, teamId: TEAM, connectionId: 'conn-notoken' },
     );
 
@@ -89,18 +105,19 @@ describe('resolveSlackBotIdentity — BYO fallback', () => {
 
     const other = await createTestOrganization();
     const identity = await resolveSlackBotIdentity(
-      { installStore: emptyInstallStore, secretStore },
+      { installStore: emptyInstallStore, secretStore, slackWeb: makeSlackWeb() },
       { organizationId: other.id, teamId: TEAM, connectionId: 'conn-byo' },
     );
 
     expect(identity).toBeNull();
   });
 
-  it('does NOT hand back a BYO token for a team the connection does not belong to', async () => {
-    // The connection is team T0BYOTEAM; asking to graph a DIFFERENT team must
-    // resolve null (fail-closed), never this connection's own token — otherwise
-    // Slack channel_not_found on the foreign team + the empty-member reconcile
-    // would wipe live edges the foreign team's real connection maintains.
+  it('does NOT hand back a BYO token for a team the connection already belongs to a DIFFERENT team', async () => {
+    // The connection carries stored team T0BYOTEAM; asking to graph a DIFFERENT
+    // team must resolve null (fail-closed) via the stored-team guard, never this
+    // connection's own token — otherwise Slack channel_not_found on the foreign
+    // team + the empty-member reconcile would wipe live edges the foreign team's
+    // real connection maintains. No auth.test needed (stored team suffices).
     await insertChatConnectionRow({
       id: 'conn-byo',
       organizationId: orgId,
@@ -112,8 +129,104 @@ describe('resolveSlackBotIdentity — BYO fallback', () => {
     });
 
     const identity = await resolveSlackBotIdentity(
-      { installStore: emptyInstallStore, secretStore },
+      { installStore: emptyInstallStore, secretStore, slackWeb: makeSlackWeb() },
       { organizationId: orgId, teamId: 'T0OTHERTEAM', connectionId: 'conn-byo' },
+    );
+
+    expect(identity).toBeNull();
+  });
+
+  it('self-heals a teamId-less BYO connection: auth.test confirms the team, backfills it, returns the token', async () => {
+    // The REAL prod case: a BYO connection created without an OAuth install never
+    // persists a teamId (external_tenant_id NULL, no config.chatMetadata.teamId).
+    // The resolver must confirm the token's team live and backfill it.
+    await insertChatConnectionRow({
+      id: 'conn-noteam',
+      organizationId: orgId,
+      platform: 'slack',
+      status: 'active',
+      credentialMode: 'byo',
+      config: { botToken: 'xoxb-byo-token' },
+      metadata: { botUserId: 'U0BYOBOT' }, // NO teamId
+    });
+
+    let authCalls = 0;
+    const slackWeb = makeSlackWeb(async (token) => {
+      authCalls += 1;
+      expect(token).toBe('xoxb-byo-token');
+      return { teamId: TEAM };
+    });
+
+    const identity = await resolveSlackBotIdentity(
+      { installStore: emptyInstallStore, secretStore, slackWeb },
+      { organizationId: orgId, teamId: TEAM, connectionId: 'conn-noteam' },
+    );
+
+    expect(identity).toEqual({ token: 'xoxb-byo-token', botUserId: 'U0BYOBOT' });
+    expect(authCalls).toBe(1);
+
+    // Backfilled: external_tenant_id now carries the confirmed team, so the NEXT
+    // resolve takes the fast path (no auth.test round-trip).
+    const [row] = await getDb()<{ external_tenant_id: string | null }>`
+      SELECT external_tenant_id FROM connections WHERE slug = 'agentconn-conn-noteam'
+    `;
+    expect(row?.external_tenant_id).toBe(TEAM);
+
+    const second = await resolveSlackBotIdentity(
+      { installStore: emptyInstallStore, secretStore, slackWeb },
+      { organizationId: orgId, teamId: TEAM, connectionId: 'conn-noteam' },
+    );
+    expect(second).toEqual({ token: 'xoxb-byo-token', botUserId: 'U0BYOBOT' });
+    expect(authCalls).toBe(1); // fast path — no second auth.test
+  });
+
+  it('fails closed when auth.test reports the token belongs to a DIFFERENT team', async () => {
+    // A teamId-less BYO connection whose token actually belongs to another
+    // workspace must NOT graph the requested team (would wipe that team's edges).
+    await insertChatConnectionRow({
+      id: 'conn-noteam',
+      organizationId: orgId,
+      platform: 'slack',
+      status: 'active',
+      credentialMode: 'byo',
+      config: { botToken: 'xoxb-byo-token' },
+      metadata: { botUserId: 'U0BYOBOT' }, // NO teamId
+    });
+
+    const slackWeb = makeSlackWeb(async () => ({ teamId: 'T0SOMEOTHER' }));
+
+    const identity = await resolveSlackBotIdentity(
+      { installStore: emptyInstallStore, secretStore, slackWeb },
+      { organizationId: orgId, teamId: TEAM, connectionId: 'conn-noteam' },
+    );
+
+    expect(identity).toBeNull();
+
+    // Not backfilled with the requested (wrong) team.
+    const [row] = await getDb()<{ external_tenant_id: string | null }>`
+      SELECT external_tenant_id FROM connections WHERE slug = 'agentconn-conn-noteam'
+    `;
+    expect(row?.external_tenant_id).toBeNull();
+  });
+
+  it('fails closed when auth.test throws (dead/invalid token)', async () => {
+    await insertChatConnectionRow({
+      id: 'conn-noteam',
+      organizationId: orgId,
+      platform: 'slack',
+      status: 'active',
+      credentialMode: 'byo',
+      config: { botToken: 'xoxb-byo-token' },
+      metadata: { botUserId: 'U0BYOBOT' }, // NO teamId
+    });
+
+    const slackWeb = makeSlackWeb(async () => {
+      throw new Error('Slack auth.test failed: invalid_auth');
+    });
+
+    const identity = await resolveSlackBotIdentity(
+      { installStore: emptyInstallStore, secretStore, slackWeb },
+      { organizationId: orgId, teamId: TEAM, connectionId: 'conn-noteam' },
     );
 
     expect(identity).toBeNull();
@@ -148,7 +261,7 @@ describe('resolveSlackBotIdentity — BYO fallback', () => {
     });
 
     const identity = await resolveSlackBotIdentity(
-      { installStore, secretStore },
+      { installStore, secretStore, slackWeb: makeSlackWeb() },
       { organizationId: orgId, teamId: TEAM, connectionId: 'conn-byo' },
     );
 

--- a/packages/server/src/__tests__/integration/authz/slack-byo-bot-identity.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-byo-bot-identity.test.ts
@@ -180,9 +180,11 @@ describe('resolveSlackBotIdentity — BYO fallback', () => {
     expect(authCalls).toBe(1); // fast path — no second auth.test
   });
 
-  it('fails closed when auth.test reports the token belongs to a DIFFERENT team', async () => {
+  it('fails closed for the requested team but backfills the REAL team when auth.test disagrees', async () => {
     // A teamId-less BYO connection whose token actually belongs to another
     // workspace must NOT graph the requested team (would wipe that team's edges).
+    // But it SHOULD record the token's real team so it stops re-hitting auth.test
+    // every tick and takes the foreign-team fast-fail path thereafter.
     await insertChatConnectionRow({
       id: 'conn-noteam',
       organizationId: orgId,
@@ -193,7 +195,11 @@ describe('resolveSlackBotIdentity — BYO fallback', () => {
       metadata: { botUserId: 'U0BYOBOT' }, // NO teamId
     });
 
-    const slackWeb = makeSlackWeb(async () => ({ teamId: 'T0SOMEOTHER' }));
+    let authCalls = 0;
+    const slackWeb = makeSlackWeb(async () => {
+      authCalls += 1;
+      return { teamId: 'T0SOMEOTHER' };
+    });
 
     const identity = await resolveSlackBotIdentity(
       { installStore: emptyInstallStore, secretStore, slackWeb },
@@ -202,11 +208,20 @@ describe('resolveSlackBotIdentity — BYO fallback', () => {
 
     expect(identity).toBeNull();
 
-    // Not backfilled with the requested (wrong) team.
+    // Backfilled with the token's REAL team (not the requested one).
     const [row] = await getDb()<{ external_tenant_id: string | null }>`
       SELECT external_tenant_id FROM connections WHERE slug = 'agentconn-conn-noteam'
     `;
-    expect(row?.external_tenant_id).toBeNull();
+    expect(row?.external_tenant_id).toBe('T0SOMEOTHER');
+
+    // A subsequent resolve for the requested team takes the foreign-team fast-fail
+    // path — no second auth.test round-trip.
+    const second = await resolveSlackBotIdentity(
+      { installStore: emptyInstallStore, secretStore, slackWeb },
+      { organizationId: orgId, teamId: TEAM, connectionId: 'conn-noteam' },
+    );
+    expect(second).toBeNull();
+    expect(authCalls).toBe(1);
   });
 
   it('fails closed when auth.test throws (dead/invalid token)', async () => {

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -254,10 +254,11 @@ export async function resolveSlackBotIdentity(
   deps: {
     installStore: ReturnType<CoreServices['getAppInstallationStore']>;
     secretStore: ReturnType<CoreServices['getSecretStore']>;
+    slackWeb: SlackWebApi;
   },
   params: { organizationId: string; teamId: string; connectionId: string },
 ): Promise<{ token: string; botUserId: string | null } | null> {
-  const { installStore, secretStore } = deps;
+  const { installStore, secretStore, slackWeb } = deps;
   const { organizationId, teamId, connectionId } = params;
 
   // Primary: the workspace OAuth app-installation (the hosted/managed path).
@@ -273,6 +274,12 @@ export async function resolveSlackBotIdentity(
   // Fallback: a BYO Slack connection has no install row — its bot token + user
   // id live on the connection's own config. The token is a `secret://` ref,
   // resolved under the connection's org exactly like the install path.
+  //
+  // We fetch by (slug, org) only and check the team OURSELVES rather than in the
+  // predicate: a BYO connection created without an OAuth install NEVER persists a
+  // teamId (see slack-connection-coordinator: "created without an OAuth install
+  // never gets a metadata.teamId"), so a `= ${teamId}` predicate would drop it
+  // entirely and the sync would fail closed forever. Instead we self-heal.
   const sql = getDb();
   const [conn] = await sql<{
     organization_id: string;
@@ -280,30 +287,68 @@ export async function resolveSlackBotIdentity(
     // OAuth-install writer's shape); COALESCE the chatMetadata nesting too.
     bot_token_ref: string | null;
     bot_user_id: string | null;
+    // The team this connection is already known to belong to, if any.
+    stored_team_id: string | null;
   }>`
 		SELECT organization_id,
 		       COALESCE(config->>'botToken', config->'chatMetadata'->>'botToken') AS bot_token_ref,
-		       config->'chatMetadata'->>'botUserId' AS bot_user_id
+		       config->'chatMetadata'->>'botUserId' AS bot_user_id,
+		       COALESCE(external_tenant_id, config->'chatMetadata'->>'teamId') AS stored_team_id
 		FROM connections
 		WHERE slug = ${runtimeConnectionIdToSlug(connectionId)}
 		  AND organization_id = ${organizationId}
 		  AND connector_key = 'slack'
 		  AND status = 'active'
 		  AND deleted_at IS NULL
-		  -- The connection must actually BELONG to the team we're graphing.
-		  -- Without this, a connection whose bindings span a foreign team (or the
-		  -- teamId-null preview case) would hand back its OWN token for a team it
-		  -- doesn't own; Slack answers channel_not_found for every foreign channel
-		  -- and the empty-member reconcile would then wipe live edges the team's
-		  -- REAL connection maintains. Same team expression the tick scopes with.
-		  AND COALESCE(external_tenant_id, config->'chatMetadata'->>'teamId') = ${teamId}
 		LIMIT 1
 	`;
   if (!conn?.bot_token_ref) return null;
+
+  // Guard the FOREIGN-team case: a connection that already carries a DIFFERENT
+  // team id must NOT hand back its token for the team we're graphing. Without
+  // this, its token would answer channel_not_found for every foreign channel and
+  // the empty-member reconcile would wipe live edges the team's REAL connection
+  // maintains. A matching stored team is the fast path (no Slack round-trip).
+  if (conn.stored_team_id && conn.stored_team_id !== teamId) return null;
+
   const token = await orgContext.run({ organizationId: conn.organization_id }, () =>
     resolveSecretValue(secretStore, conn.bot_token_ref as string),
   );
   if (!token) return null;
+
+  // Self-heal the teamId-less BYO connection: confirm the token's REAL team from
+  // Slack before graphing (a stronger guard than a stored string — it verifies
+  // the LIVE credential owns this team), then backfill it onto the row so future
+  // ticks take the fast path above and the connection is team-scoped everywhere.
+  if (!conn.stored_team_id) {
+    let realTeamId: string;
+    try {
+      ({ teamId: realTeamId } = await slackWeb.authTest(token));
+    } catch (error) {
+      // A dead/invalid token can't be identified — fail closed for THIS team
+      // (leave the connection ungraphed rather than risk wiping a foreign
+      // team's edges). Transient failures retry on the next tick.
+      logger.warn(
+        { connectionId, teamId, error: String(error) },
+        'Slack auth.test failed resolving BYO connection team; skipping',
+      );
+      return null;
+    }
+    if (realTeamId !== teamId) return null;
+    await sql`
+			UPDATE connections
+			SET external_tenant_id = ${teamId}
+			WHERE slug = ${runtimeConnectionIdToSlug(connectionId)}
+			  AND organization_id = ${organizationId}
+			  AND connector_key = 'slack'
+			  AND external_tenant_id IS NULL
+		`;
+    logger.info(
+      { connectionId, teamId },
+      'Backfilled teamId onto BYO Slack connection from auth.test',
+    );
+  }
+
   return { token, botUserId: conn.bot_user_id };
 }
 
@@ -343,7 +388,7 @@ export async function runSlackAclSyncTick(coreServices: CoreServices): Promise<v
   const deps: SlackAclSyncDeps = {
     slackWeb,
     resolveBotIdentity: (params) =>
-      resolveSlackBotIdentity({ installStore, secretStore }, params),
+      resolveSlackBotIdentity({ installStore, secretStore, slackWeb }, params),
   };
 
   let ok = 0;

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -317,9 +317,12 @@ export async function resolveSlackBotIdentity(
   if (!token) return null;
 
   // Self-heal the teamId-less BYO connection: confirm the token's REAL team from
-  // Slack before graphing (a stronger guard than a stored string — it verifies
-  // the LIVE credential owns this team), then backfill it onto the row so future
-  // ticks take the fast path above and the connection is team-scoped everywhere.
+  // Slack (a stronger guard than a stored string — it verifies the LIVE
+  // credential's team), then backfill THAT team onto the row so future ticks take
+  // the fast/foreign-team paths above without another auth.test. We backfill the
+  // real team even when it isn't the one we were asked to graph: otherwise a
+  // connection reached first for a foreign binding would re-hit auth.test every
+  // tick forever. Graphing itself still requires the real team to match.
   if (!conn.stored_team_id) {
     let realTeamId: string;
     try {
@@ -334,19 +337,21 @@ export async function resolveSlackBotIdentity(
       );
       return null;
     }
-    if (realTeamId !== teamId) return null;
     await sql`
 			UPDATE connections
-			SET external_tenant_id = ${teamId}
+			SET external_tenant_id = ${realTeamId}
 			WHERE slug = ${runtimeConnectionIdToSlug(connectionId)}
 			  AND organization_id = ${organizationId}
 			  AND connector_key = 'slack'
 			  AND external_tenant_id IS NULL
 		`;
     logger.info(
-      { connectionId, teamId },
+      { connectionId, teamId: realTeamId },
       'Backfilled teamId onto BYO Slack connection from auth.test',
     );
+    // Only hand back the token when the confirmed team is the one being graphed;
+    // a token for a different workspace must not touch this team's edges.
+    if (realTeamId !== teamId) return null;
   }
 
   return { token, botUserId: conn.bot_user_id };

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -53,6 +53,15 @@ export interface SlackWebApi {
    */
   revokeToken(botToken: string): Promise<boolean>;
   /**
+   * `auth.test` — identify the workspace a bot token belongs to. Returns the
+   * `T…` team id. Used by the ACL sync to self-heal a BYO connection that was
+   * created without an OAuth install (so it never persisted a `teamId`): we
+   * resolve the token's REAL team from Slack, verify it matches the channel
+   * binding's team before graphing, and backfill it onto the connection row.
+   * Throws on a Slack-level error (an invalid/revoked token yields `invalid_auth`).
+   */
+  authTest(botToken: string): Promise<{ teamId: string }>;
+  /**
    * `oauth.v2.access` — exchange an OAuth `code` for the workspace bot token +
    * tenant/installer identity. Unlike the other methods this authenticates with
    * the app's client id/secret (not a bot token), so it lives outside
@@ -177,6 +186,14 @@ export function createSlackWebApi(): SlackWebApi {
     async revokeToken(botToken) {
       const json = await slackPost(botToken, "auth.revoke", {});
       return json.revoked === true;
+    },
+    async authTest(botToken) {
+      const json = await slackPost(botToken, "auth.test", {});
+      const teamId = json.team_id;
+      if (typeof teamId !== "string" || !teamId) {
+        throw new Error("Slack auth.test returned no team_id");
+      }
+      return { teamId };
     },
     async exchangeOAuthCode({ clientId, clientSecret, code, redirectUri }) {
       const form = new URLSearchParams({


### PR DESCRIPTION
## Problem (found via prod e2e of #1683)

#1683 was supposed to graph BYO Slack connections, but it doesn't fix the real org (org_lobucrm). Verified live in prod:

- Baseline: **0 graphed channels** for org_lobucrm.
- BYO connection #390 (\`agentconn-cfa916c95eb64939\`) has **no teamId stored anywhere**: \`external_tenant_id\` NULL, no \`config.chatMetadata.teamId\` (only botUserId/botUsername).
- #1683's \`resolveSlackBotIdentity\` BYO fallback scoped on \`COALESCE(external_tenant_id, chatMetadata.teamId) = teamId\` → **0 rows** → sync throws "No bot token for team T09513HDQ77" → fails closed → 0 channels graphed.

Root cause: a BYO connection created **without an OAuth install never persists a teamId** (documented in slack-connection-coordinator). The teamId predicate #1683 added (correct for the foreign-team guard) drops these connections entirely.

## Fix

Resolve the connection by (slug, org) and check the team ourselves:
- **matching stored team** → fast path, no Slack round-trip
- **different stored team** → null (keeps #1683's foreign-team fail-closed guard)
- **no stored team** → \`auth.test\` the token, verify its REAL team == the binding's team (stronger than a stored string — it checks the live credential), then backfill \`external_tenant_id\` so future ticks take the fast path.

Adds \`SlackWebApi.authTest\`. Fails closed if \`auth.test\` throws (dead token) or reports a different team.

## E2E (red → green)

Integration test \`slack-byo-bot-identity.test.ts\` (8 tests, all green):
- self-heal: teamId-less BYO conn → auth.test confirms team → returns token → **backfills external_tenant_id** → second resolve takes fast path (no 2nd auth.test)
- fails closed when auth.test reports a different team (no backfill)
- fails closed when auth.test throws (dead token)
- existing fast-path / cross-org / foreign-team / install-wins cases preserved

Prod backfill of #390 + full sync verification to follow after this deploys.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785552471&installation_id=136316292&pr_number=1686&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1686&signature=6ff313b68f1c5d7b7bcaba62defff5c2b0761060c73922a92647b0541646b267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->