### PR TITLE
feat(slack): actionable unlinked-channel notice (list agents + Behaviors deep-links + CLI)

### DIFF
--- a/packages/server/src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
+++ b/packages/server/src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
@@ -40,26 +40,44 @@ describe('workspaceUnlinkedNotice', () => {
     expect(await workspaceUnlinkedNotice('telegram', org.id)).toBeNull();
   });
 
-  it('lists agents and deep-links each Behaviors page when the public origin is set', async () => {
+  it('deep-links each agent to the Behaviors "new" step with the channel prefilled', async () => {
     setOrigin('https://app.lobu.ai/lobu');
     const org = await createTestOrganization({ slug: 'acme' });
     await createTestAgent({ organizationId: org.id, agentId: 'planner', name: 'Planner' });
     await createTestAgent({ organizationId: org.id, agentId: 'builder', name: 'Builder' });
 
-    const notice = await workspaceUnlinkedNotice('slack', org.id);
+    const notice = await workspaceUnlinkedNotice('slack', org.id, {
+      channelId: 'slack:C0ABC123',
+      teamId: 'T0TEAM',
+    });
     expect(notice).not.toBeNull();
     const text = notice as string;
 
     // getConfiguredPublicOrigin() returns the URL *origin* (scheme+host), so the
-    // /lobu gateway mount is dropped — the SPA lives at the bare origin. We build
-    // `${origin}/${slug}/agents/${id}/behaviors`.
-    expect(text).toContain('https://app.lobu.ai/acme/agents/planner/behaviors');
-    expect(text).toContain('https://app.lobu.ai/acme/agents/builder/behaviors');
+    // /lobu gateway mount is dropped — the SPA lives at the bare origin. The link
+    // targets the Listen "new" step with the channel prefilled for confirm-bind.
+    // `slack:C…` and `T0TEAM` are URL-encoded in the query string.
+    expect(text).toContain(
+      'https://app.lobu.ai/acme/agents/planner/behaviors/new?listen=slack%3AC0ABC123&platform=slack&team=T0TEAM',
+    );
+    expect(text).toContain(
+      'https://app.lobu.ai/acme/agents/builder/behaviors/new?listen=slack%3AC0ABC123&platform=slack&team=T0TEAM',
+    );
     expect(text).toContain('Planner');
     expect(text).toContain('Builder');
     // The CLI path is always offered too.
     expect(text).toContain('lobu run');
     expect(text).toContain('/lobu link');
+  });
+
+  it('deep-links to the plain Behaviors page when no channel context is given', async () => {
+    setOrigin('https://app.lobu.ai');
+    const org = await createTestOrganization({ slug: 'acme' });
+    await createTestAgent({ organizationId: org.id, agentId: 'planner', name: 'Planner' });
+
+    const text = (await workspaceUnlinkedNotice('slack', org.id)) as string;
+    expect(text).toContain('https://app.lobu.ai/acme/agents/planner/behaviors');
+    expect(text).not.toContain('/behaviors/new?');
   });
 
   it('lists agents by name (no URLs) when the public origin is not configured', async () => {

--- a/packages/server/src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
+++ b/packages/server/src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
@@ -49,6 +49,7 @@ describe('workspaceUnlinkedNotice', () => {
     const notice = await workspaceUnlinkedNotice('slack', org.id, {
       channelId: 'slack:C0ABC123',
       teamId: 'T0TEAM',
+      channelName: 'general',
     });
     expect(notice).not.toBeNull();
     const text = notice as string;
@@ -56,12 +57,12 @@ describe('workspaceUnlinkedNotice', () => {
     // getConfiguredPublicOrigin() returns the URL *origin* (scheme+host), so the
     // /lobu gateway mount is dropped — the SPA lives at the bare origin. The link
     // targets the Listen "new" step with the channel prefilled for confirm-bind.
-    // `slack:C…` and `T0TEAM` are URL-encoded in the query string.
+    // `slack:C…`, `T0TEAM`, and the `#general` label are URL-encoded.
     expect(text).toContain(
-      'https://app.lobu.ai/acme/agents/planner/behaviors/new?listen=slack%3AC0ABC123&platform=slack&team=T0TEAM',
+      'https://app.lobu.ai/acme/agents/planner/behaviors/new?listen=slack%3AC0ABC123&platform=slack&team=T0TEAM&label=%23general',
     );
     expect(text).toContain(
-      'https://app.lobu.ai/acme/agents/builder/behaviors/new?listen=slack%3AC0ABC123&platform=slack&team=T0TEAM',
+      'https://app.lobu.ai/acme/agents/builder/behaviors/new?listen=slack%3AC0ABC123&platform=slack&team=T0TEAM&label=%23general',
     );
     expect(text).toContain('Planner');
     expect(text).toContain('Builder');

--- a/packages/server/src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
+++ b/packages/server/src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
@@ -1,0 +1,93 @@
+/**
+ * `workspaceUnlinkedNotice` — the reply a tenant's own OAuth-installed Slack bot
+ * sends in a channel that isn't bound to an agent yet. It must be actionable:
+ * list the org's agents, deep-link each to its Behaviors page (where a channel
+ * is added as a Listen source), and give the CLI `/lobu link` path. It must
+ * degrade gracefully when the public origin isn't configured or the org has no
+ * agents, and never turn into a dead drop.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { workspaceUnlinkedNotice } from '../../../preview/slack';
+import { __resetPublicOriginCachesForTests } from '../../../utils/public-origin';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import { createTestAgent, createTestOrganization } from '../../setup/test-fixtures';
+
+const ORIGIN_ENV = 'PUBLIC_GATEWAY_URL';
+
+// getConfiguredPublicOrigin() memoizes PUBLIC_GATEWAY_URL on first read, so every
+// case that changes the env must reset the cache to be observed.
+function setOrigin(value: string | undefined) {
+  if (value === undefined) delete process.env[ORIGIN_ENV];
+  else process.env[ORIGIN_ENV] = value;
+  __resetPublicOriginCachesForTests();
+}
+
+describe('workspaceUnlinkedNotice', () => {
+  let savedOrigin: string | undefined;
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    savedOrigin = process.env[ORIGIN_ENV];
+  });
+
+  afterEach(() => {
+    setOrigin(savedOrigin);
+  });
+
+  it('returns null for non-slack platforms', async () => {
+    const org = await createTestOrganization();
+    expect(await workspaceUnlinkedNotice('telegram', org.id)).toBeNull();
+  });
+
+  it('lists agents and deep-links each Behaviors page when the public origin is set', async () => {
+    setOrigin('https://app.lobu.ai/lobu');
+    const org = await createTestOrganization({ slug: 'acme' });
+    await createTestAgent({ organizationId: org.id, agentId: 'planner', name: 'Planner' });
+    await createTestAgent({ organizationId: org.id, agentId: 'builder', name: 'Builder' });
+
+    const notice = await workspaceUnlinkedNotice('slack', org.id);
+    expect(notice).not.toBeNull();
+    const text = notice as string;
+
+    // getConfiguredPublicOrigin() returns the URL *origin* (scheme+host), so the
+    // /lobu gateway mount is dropped — the SPA lives at the bare origin. We build
+    // `${origin}/${slug}/agents/${id}/behaviors`.
+    expect(text).toContain('https://app.lobu.ai/acme/agents/planner/behaviors');
+    expect(text).toContain('https://app.lobu.ai/acme/agents/builder/behaviors');
+    expect(text).toContain('Planner');
+    expect(text).toContain('Builder');
+    // The CLI path is always offered too.
+    expect(text).toContain('lobu run');
+    expect(text).toContain('/lobu link');
+  });
+
+  it('lists agents by name (no URLs) when the public origin is not configured', async () => {
+    setOrigin(undefined);
+    const org = await createTestOrganization({ slug: 'acme' });
+    await createTestAgent({ organizationId: org.id, agentId: 'planner', name: 'Planner' });
+
+    const text = (await workspaceUnlinkedNotice('slack', org.id)) as string;
+    expect(text).toContain('Planner');
+    expect(text).not.toContain('/agents/planner/behaviors');
+    expect(text).toContain('lobu run'); // CLI path still present
+  });
+
+  it('falls back to the CLI-only notice when the org has no agents', async () => {
+    setOrigin('https://app.lobu.ai');
+    const org = await createTestOrganization();
+
+    const text = (await workspaceUnlinkedNotice('slack', org.id)) as string;
+    expect(text).toContain('lobu run');
+    expect(text).toContain('/lobu link');
+    // No agent-list section.
+    expect(text).not.toContain('Behaviors page');
+  });
+
+  it('never throws / dead-drops for an unknown org (returns the CLI-only notice)', async () => {
+    setOrigin('https://app.lobu.ai');
+    const text = (await workspaceUnlinkedNotice('slack', 'org_does_not_exist')) as string;
+    expect(text).not.toBeNull();
+    expect(text).toContain('/lobu link');
+  });
+});

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -30,6 +30,7 @@ import {
 } from '../gateway/channels/bound-channels.js';
 import { createSlackWebApi, type SlackWebApi } from '../gateway/connections/slack-web.js';
 import { resolveSecretValue } from '../gateway/secrets/index.js';
+import type { SecretStore } from '../gateway/secrets/index.js';
 import type { CoreServices } from '../gateway/services/core-services.js';
 import {
   runtimeConnectionIdToSlug,
@@ -253,7 +254,10 @@ export async function syncSlackConnectionAcl(
 export async function resolveSlackBotIdentity(
   deps: {
     installStore: ReturnType<CoreServices['getAppInstallationStore']>;
-    secretStore: ReturnType<CoreServices['getSecretStore']>;
+    // Only the read side (`.get`) is used, via resolveSecretValue — accept the
+    // minimal SecretStore so callers with either the WritableSecretStore
+    // (platform.ts CoreServices) or the SecretStoreRegistry (concrete) type fit.
+    secretStore: SecretStore;
     slackWeb: SlackWebApi;
   },
   params: { organizationId: string; teamId: string; connectionId: string },

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -381,6 +381,7 @@ export class MessageHandlerBridge {
         const notice = await workspaceUnlinkedNotice(
           platform,
           this.connection.organizationId,
+          { channelId, teamId },
         );
         if (notice) {
           logger.info(

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -375,9 +375,13 @@ export class MessageHandlerBridge {
       if (
         !isPreview &&
         platform === "slack" &&
-        this.connection.metadata?.teamId
+        this.connection.metadata?.teamId &&
+        this.connection.organizationId
       ) {
-        const notice = workspaceUnlinkedNotice(platform);
+        const notice = await workspaceUnlinkedNotice(
+          platform,
+          this.connection.organizationId,
+        );
         if (notice) {
           logger.info(
             { platform, channelId, teamId, connectionId: this.connection.id },

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -389,11 +389,12 @@ export class MessageHandlerBridge {
         let channelName: string | undefined;
         if (linkTeamId) {
           try {
+            const slackWeb = createSlackWebApi();
             const identity = await resolveSlackBotIdentity(
               {
                 installStore: this.services.getAppInstallationStore(),
                 secretStore: this.services.getSecretStore(),
-                slackWeb: createSlackWebApi(),
+                slackWeb,
               },
               {
                 organizationId: this.connection.organizationId,
@@ -402,7 +403,7 @@ export class MessageHandlerBridge {
               },
             );
             if (identity?.token) {
-              const info = await createSlackWebApi().conversationInfo(
+              const info = await slackWeb.conversationInfo(
                 identity.token,
                 stripPlatformPrefix(platform, channelId),
               );

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -18,7 +18,10 @@ import {
   resolveAgentId,
   resolveAgentOptions,
 } from "../services/platform-helpers.js";
+import { resolveSlackBotIdentity } from "../../authz/slack-acl-sync.js";
+import { stripPlatformPrefix } from "../channels/bound-channels.js";
 import { captureChannelMessage } from "./channel-transcript.js";
+import { createSlackWebApi } from "./slack-web.js";
 import type { ConversationStateStore } from "./conversation-state-store.js";
 import type { ChatInstanceManager } from "./chat-instance-manager.js";
 import type { PlatformConnection } from "./types.js";
@@ -378,13 +381,47 @@ export class MessageHandlerBridge {
         this.connection.metadata?.teamId &&
         this.connection.organizationId
       ) {
+        const linkTeamId = teamId ?? this.connection.metadata?.teamId;
+        // Best-effort: resolve the channel's friendly name (#general) for the
+        // notice's deep-link label. Uses this connection's own bot token via
+        // conversations.info; any failure (no token, not-in-channel, rate limit)
+        // just drops to the channel id in the UI — never blocks the notice.
+        let channelName: string | undefined;
+        if (linkTeamId) {
+          try {
+            const identity = await resolveSlackBotIdentity(
+              {
+                installStore: this.services.getAppInstallationStore(),
+                secretStore: this.services.getSecretStore(),
+                slackWeb: createSlackWebApi(),
+              },
+              {
+                organizationId: this.connection.organizationId,
+                teamId: linkTeamId,
+                connectionId: this.connection.id,
+              },
+            );
+            if (identity?.token) {
+              const info = await createSlackWebApi().conversationInfo(
+                identity.token,
+                stripPlatformPrefix(platform, channelId),
+              );
+              channelName = info.name ?? undefined;
+            }
+          } catch (err) {
+            logger.debug(
+              { channelId, error: String(err) },
+              "unlinked-notice: channel name lookup failed (using id)"
+            );
+          }
+        }
         const notice = await workspaceUnlinkedNotice(
           platform,
           this.connection.organizationId,
           // Fall back to the connection's stored team when the raw message omits
           // team_id, so the deep-link stays team-scoped (the binding is keyed on
           // team). The connection always carries it — it's the gate above.
-          { channelId, teamId: teamId ?? this.connection.metadata?.teamId },
+          { channelId, teamId: linkTeamId, channelName },
         );
         if (notice) {
           logger.info(

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -381,7 +381,10 @@ export class MessageHandlerBridge {
         const notice = await workspaceUnlinkedNotice(
           platform,
           this.connection.organizationId,
-          { channelId, teamId },
+          // Fall back to the connection's stored team when the raw message omits
+          // team_id, so the deep-link stays team-scoped (the binding is keyed on
+          // team). The connection always carries it — it's the gate above.
+          { channelId, teamId: teamId ?? this.connection.metadata?.teamId },
         );
         if (notice) {
           logger.info(

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -526,6 +526,7 @@ async function listOrgAgentsForNotice(organizationId: string): Promise<{
 export async function workspaceUnlinkedNotice(
 	platform: string,
 	organizationId: string,
+	channel?: { channelId: string; teamId?: string },
 ): Promise<string | null> {
 	if (platform !== "slack") return null;
 
@@ -547,14 +548,25 @@ export async function workspaceUnlinkedNotice(
 	}
 
 	const origin = getConfiguredPublicOrigin()?.replace(/\/+$/, "");
-	// Deep-link each agent to its Behaviors page when we can build a full URL
-	// (need both the public origin and the org slug). The Behaviors → Listen
-	// picker is where a channel is bound to the agent from the UI.
+	// Deep-link each agent to its Behaviors "new" step with THIS channel prefilled,
+	// so the user lands on a one-click confirm-bind (no hunting in the picker,
+	// which only lists channels that already have a streaming feed). `channelId` is
+	// the canonical `slack:C…` form the binding is stored under, passed verbatim so
+	// the confirm binds the exact key the router resolves. Falls back to the plain
+	// Behaviors page when we have no channel context.
 	const canLink = Boolean(origin && orgSlug);
+	const behaviorsUrl = (agentId: string): string => {
+		const base = `${origin}/${orgSlug}/agents/${agentId}/behaviors`;
+		if (!channel?.channelId) return base;
+		const params = new URLSearchParams({
+			listen: channel.channelId,
+			platform: "slack",
+		});
+		if (channel.teamId) params.set("team", channel.teamId);
+		return `${base}/new?${params.toString()}`;
+	};
 	const agentLines = agents.map((a) =>
-		canLink
-			? `   • ${a.name} — ${origin}/${orgSlug}/agents/${a.agentId}/behaviors`
-			: `   • ${a.name}`,
+		canLink ? `   • ${a.name} — ${behaviorsUrl(a.agentId)}` : `   • ${a.name}`,
 	);
 
 	if (agentLines.length > 0) {

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -526,7 +526,7 @@ async function listOrgAgentsForNotice(organizationId: string): Promise<{
 export async function workspaceUnlinkedNotice(
 	platform: string,
 	organizationId: string,
-	channel?: { channelId: string; teamId?: string },
+	channel?: { channelId: string; teamId?: string; channelName?: string },
 ): Promise<string | null> {
 	if (platform !== "slack") return null;
 
@@ -563,6 +563,9 @@ export async function workspaceUnlinkedNotice(
 			platform: "slack",
 		});
 		if (channel.teamId) params.set("team", channel.teamId);
+		// Friendly channel name → the confirm card's label (falls back to the id in
+		// the UI when absent). Prefixed with `#` so it reads as a channel.
+		if (channel.channelName) params.set("label", `#${channel.channelName}`);
 		return `${base}/new?${params.toString()}`;
 	};
 	const agentLines = agents.map((a) =>

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -7,6 +7,7 @@ import type { Env } from "../index";
 import { runtimeConnectionIdToSlug } from "../lobu/stores/connections-projection";
 import { errorMessage } from "../utils/errors";
 import logger from "../utils/logger";
+import { getConfiguredPublicOrigin } from "../utils/public-origin";
 import { requireOrgUser } from "../utils/require-org-user";
 import { MANAGED_CHAT_PLATFORMS_SET } from "./managed-platforms";
 
@@ -487,20 +488,90 @@ export async function previewUnlinkedNotice(
 }
 
 /**
+ * The org's agents + slug for building a link notice. Kept separate from
+ * `listPreviewAgents` (which is preview-connection-scoped and excludes the
+ * owning agent) — an OAuth-installed workspace has no owning agent, so every
+ * agent in the org is a valid link target.
+ */
+async function listOrgAgentsForNotice(organizationId: string): Promise<{
+	orgSlug: string | null;
+	agents: Array<{ agentId: string; name: string }>;
+}> {
+	const sql = getDb();
+	const [orgRow] = await sql<{ slug: string | null }>`
+    SELECT slug FROM organization WHERE id = ${organizationId} LIMIT 1
+  `;
+	const rows = await sql<{ id: string; name: string | null }>`
+    SELECT id, name
+    FROM agents
+    WHERE organization_id = ${organizationId}
+    ORDER BY name NULLS LAST, id
+  `;
+	return {
+		orgSlug: orgRow?.slug ?? null,
+		agents: rows.map((r) => ({ agentId: r.id, name: r.name ?? r.id })),
+	};
+}
+
+/**
  * Reply for a tenant's own OAuth-installed workspace bot (a connection with a
  * `metadata.teamId` but no owning agent) when a non-command message arrives in
  * a channel that isn't bound to one of the tenant's agents yet. Unlike a
  * preview connection there are no demo agents to offer — the tenant links their
- * own agents with `/lobu link <code>`. Returns null for non-Slack platforms
- * (OAuth install is Slack-only today).
+ * own agents. Lists the org's agents and, when the public origin is configured,
+ * deep-links each to its Behaviors page (where a channel is added as a Listen
+ * source); also gives the CLI `lobu run` / `/lobu link <code>` path. Returns
+ * null for non-Slack platforms (OAuth install is Slack-only today).
  */
-export function workspaceUnlinkedNotice(platform: string): string | null {
+export async function workspaceUnlinkedNotice(
+	platform: string,
+	organizationId: string,
+): Promise<string | null> {
 	if (platform !== "slack") return null;
-	return [
-		"👋 Thanks for adding Lobu! This channel isn't linked to one of your agents yet.",
-		"",
-		`Run \`${linkCommand(platform)} <code>\` here with a link code from your Lobu dashboard (or \`lobu run\`) to connect an agent.`,
-	].join("\n");
+
+	const header =
+		"👋 Thanks for adding Lobu! This channel isn't linked to one of your agents yet.";
+	const cliLine = `From the CLI — run \`lobu run\`, then paste the \`${linkCommand(platform)} <code>\` it prints here.`;
+
+	let agents: Array<{ agentId: string; name: string }> = [];
+	let orgSlug: string | null = null;
+	try {
+		({ agents, orgSlug } = await listOrgAgentsForNotice(organizationId));
+	} catch (err) {
+		// Never let a lookup failure turn the notice into a dead drop — fall back
+		// to the CLI-only path below.
+		logger.warn(
+			{ err: errorMessage(err), organizationId },
+			"[slack] workspaceUnlinkedNotice: agent lookup failed",
+		);
+	}
+
+	const origin = getConfiguredPublicOrigin()?.replace(/\/+$/, "");
+	// Deep-link each agent to its Behaviors page when we can build a full URL
+	// (need both the public origin and the org slug). The Behaviors → Listen
+	// picker is where a channel is bound to the agent from the UI.
+	const canLink = Boolean(origin && orgSlug);
+	const agentLines = agents.map((a) =>
+		canLink
+			? `   • ${a.name} — ${origin}/${orgSlug}/agents/${a.agentId}/behaviors`
+			: `   • ${a.name}`,
+	);
+
+	if (agentLines.length > 0) {
+		return [
+			header,
+			"",
+			"Link it to an agent two ways:",
+			canLink
+				? "• In the dashboard — open an agent's Behaviors page and add this channel as a Listen source:"
+				: "• In the dashboard — open an agent's Behaviors page and add this channel as a Listen source. Your agents:",
+			...agentLines,
+			`• ${cliLine}`,
+		].join("\n");
+	}
+
+	// No agents yet (or the lookup failed) — CLI path only.
+	return [header, "", cliLine].join("\n");
 }
 
 /** The Lobu user id a chat-platform user has linked to, or null. */


### PR DESCRIPTION
## Problem

When a tenant's own OAuth-installed Slack bot gets a message in a channel not yet bound to an agent, it replied with a pointer to a "link code from your Lobu dashboard" that **doesn't exist** (only `lobu run` mints link codes), and gave no way to act from where the user is.

Even a naive "open the Behaviors page" deep-link would dead-end: the Behaviors → Listen picker only lists channels that already have a **streaming feed**, and a brand-new channel has none until the first bind.

## Fix (two halves)

**1. Actionable notice** (`packages/server/src/preview/slack.ts`): lists the org's agents and deep-links each to `…/behaviors/new?listen=<channelId>&team=&platform=slack` — carrying THIS channel — plus the CLI path (`lobu run` → `/lobu link <code>`). Degrades gracefully (names-only with no public origin; CLI-only with no agents / on lookup error); never dead-drops. `channelId` is the canonical `slack:C…` form passed verbatim so the confirm binds the exact key the router resolves (and dedups with `/lobu link`).

**2. Confirm-bind on the Listen step** (owletto): `behaviors/new` reads the `listen`/`team`/`platform`/`label` query params and jumps to the Listen step with a one-click **"Link channel"** confirm card above the picker. Binds by channel id/team via the existing `useBindChannel` — **no pre-existing feed required**, so it works for a brand-new channel. Renders before the loading/empty-state returns so it shows even when the workspace has no other streaming feeds. Owletto pointer bumped.

### Example notice (org slug `buremba`)
```
👋 Thanks for adding Lobu! This channel isn't linked to one of your agents yet.

Link it to an agent two ways:
• In the dashboard — open an agent's Behaviors page and add this channel as a Listen source:
   • Builder — https://app.lobu.ai/buremba/agents/lobu-builder/behaviors/new?listen=slack%3AC…&platform=slack&team=T…
   • …
• From the CLI — run `lobu run`, then paste the `/lobu link <code>` it prints here.
```

## Tests
Integration `workspace-unlinked-notice.test.ts` (6, green): deep-links with channel prefilled + URL-encoding; plain link when no channel; names-only when no origin; CLI-only when no agents; no dead-drop for unknown org; null for non-slack. Owletto builds clean (`tsc -b` + vite).

## Cross-repo
owletto branch `feat/slack-unlinked-notice` (SHA d84c7a0) pushed first; lobu submodule pointer bumped to it in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the Slack “workspace unlinked” notice to include agent-specific Behaviors links when public dashboard linking is available.
  * When available, links incorporate channel context; otherwise they fall back to the general Behaviors page.

* **Bug Fixes**
  * The notice now only appears for the correct Slack unlinked scenarios (not during preview).
  * Improved fallback behavior: when org/agent details can’t be resolved, users still get CLI setup instructions, and unknown orgs no longer omit the notice.

* **Tests**
  * Added integration tests covering Slack linked/unlinked, channel vs. no-channel context, and fallback cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->