### PR TITLE
chore: fix stale agent_connections/auth_profiles refs after connections-unify

### DIFF
--- a/db/migrations/20260702000000_auth_profiles_table_comment.sql
+++ b/db/migrations/20260702000000_auth_profiles_table_comment.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+
+-- Correct the stale `auth_profiles` table comment. The original (applied in the
+-- baseline migration) described it as "Per-user-per-agent", but the table has
+-- no agent_id/user_id columns: it is org-scoped (`organization_id` NOT NULL)
+-- and reusable. Per-(user, agent) linkage is a separate join table
+-- (`user_auth_profiles`). Comment-only change — no data/schema alteration.
+
+COMMENT ON TABLE public.auth_profiles IS 'Org-scoped reusable auth state for connector- and provider-mediated identities (API keys via profile_kind=env, OAuth tokens, browser sessions). Referenced by connections.auth_profile_id / app_auth_profile_id and by the user_auth_profiles (user_id, agent_id) join table. device_workers binding applies only to browser_session profiles minted via /api/me/devices/mint-child-token.';
+
+-- migrate:down
+
+COMMENT ON TABLE public.auth_profiles IS 'Per-user-per-agent OAuth / auth state for connector-mediated user identities. Holds tokens, refresh tokens, expiry, and the pending-auth workflow state. Bound to a device_workers.worker_id when minted via /api/me/devices/mint-child-token.';

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -287,7 +287,7 @@ function mapAgent(
   const platforms: DesiredPlatform[] = (agent.platforms ?? [])
     // A hosted-bot entry (slack/telegram with no `config`) is reached via the
     // hosted Lobu bot + a `/lobu link` claim, NOT a self-hosted connection. It
-    // must never become a credential-less `agent_connections` row — `lobu run`
+    // must never become a credential-less `connections` chat row — `lobu run`
     // reads it straight from the authored config to mint the link code.
     .filter((p) => !isHostedChatEntry(p))
     .map((p) => ({

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -133,7 +133,7 @@ export interface StoredConnection {
   /**
    * Organization id this connection belongs to. Optional in the type for
    * back-compat with in-memory tests, but required at the storage layer
-   * (`agent_connections.organization_id` is NOT NULL post-Phase-C).
+   * (`connections.organization_id` is NOT NULL post-unify).
    */
   organizationId?: string;
   config: Record<string, any>;

--- a/packages/server/src/connectors/connector-health.ts
+++ b/packages/server/src/connectors/connector-health.ts
@@ -132,8 +132,12 @@ interface UnhealthyRow {
  * The detection query. Read-only. Returns one row per active, non-deleted
  * connection that is past the min-age grace window, with aggregates over its
  * non-deleted feeds, so the JS classifier can decide healthy vs. unhealthy
- * (and which rule tripped). Chat connections live in a separate table
- * (`agent_connections`) and are intentionally NOT scanned here.
+ * (and which rule tripped). NOTE: post-`connections`-unify, chat connections
+ * (slack/telegram) share this SAME `connections` table with connector
+ * connections — they no longer live in a separate table. The query below has
+ * NO connector_key filter, and chat connections own zero feeds, so they would
+ * trip the `zero_feeds` rule and false-positive as unhealthy. Verify whether a
+ * chat-platform exclusion is needed before relying on this scan's output.
  */
 async function loadConnectionHealthRows(
   sql: DbClient,

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -300,7 +300,7 @@ export class SlackConnectionCoordinator {
   /**
    * Persist a per-workspace OAuth install: the workspace's bot token + tenant
    * metadata, keyed on (org, team), as an `app_installations` row (provider=slack).
-   * This is NOT an `agent_connections` row — an installed workspace has no owning agent;
+   * This is NOT a BYO `connections` chat row — an installed workspace has no owning agent;
    * it routes to many agents via `/lobu link` channel bindings. The token goes
    * to the secret store (the store handles that); app-level creds
    * (signingSecret/clientId/clientSecret) stay env-sourced at runtime. Idempotent
@@ -409,7 +409,7 @@ export class SlackConnectionCoordinator {
       }
 
       // 2) An OAuth-installed workspace (the "Add to Slack" path). The install
-      //    is an `app_installations` row (provider=slack), not `agent_connections`;
+      //    is an `app_installations` row (provider=slack), not a BYO `connections` chat row;
       //    the manager hydrates an agentless Slack instance from it (the
       //    `slackinst-` id is namespaced, so `ensureConnectionRunning`/
       //    `forwardWebhook` resolve it via the Slack install projection). Per-message

--- a/packages/server/src/gateway/connections/types.ts
+++ b/packages/server/src/gateway/connections/types.ts
@@ -106,7 +106,7 @@ export interface PlatformConnection {
   agentId?: string;
   /**
    * Organization id this connection belongs to. Mirrors
-   * `agent_connections.organization_id`. Optional in the type for
+   * `connections.organization_id`. Optional in the type for
    * back-compat with in-memory tests; required at the storage layer.
    */
   organizationId?: string;

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -155,8 +155,9 @@ export interface AppWebhookProvider {
 	 *
 	 * This exists for Slack, whose live messaging path does NOT fit the
 	 * resolve-install-then-store model:
-	 *  - Slack's PRIMARY routing target is a BYO `agent_connections` row keyed on
-	 *    team_id — there is NO `app_installations` row for it, so the generic
+	 *  - Slack's PRIMARY routing target is a BYO `connections` row (slug
+	 *    `agentconn-…`) keyed on team_id — there is NO `app_installations` row
+	 *    for it, so the generic
 	 *    `resolveActiveByTenant` would 200-ack the delivery and the live bot would
 	 *    stop receiving events. The precedence (BYO connection → active OAuth
 	 *    install → preview connection → OAuth-fallback chat) and the live forward
@@ -860,11 +861,11 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 
 		// 1b. Providers that own their own routing (Slack) take over here, after
 		//     the edge signing check. They do NOT resolve an `app_installations`
-		//     row — Slack's primary target is a BYO `agent_connections` row that
-		//     has no install row, so the generic resolveActiveByTenant would
-		//     200-ack the live bot's traffic into oblivion. They run their own
-		//     precedence chain and return their own Response; the generic
-		//     install/ingest pipeline below is skipped entirely.
+		//     row — Slack's primary target is a BYO `connections` chat row
+		//     (slug `agentconn-…`) that has no install row, so the generic
+		//     resolveActiveByTenant would 200-ack the live bot's traffic into
+		//     oblivion. They run their own precedence chain and return their own
+		//     Response; the generic install/ingest pipeline below is skipped entirely.
 		if (provider.handleDelivery) {
 			try {
 				return await provider.handleDelivery({

--- a/packages/server/src/gateway/routes/public/connections.ts
+++ b/packages/server/src/gateway/routes/public/connections.ts
@@ -215,7 +215,7 @@ export function createConnectionWebhookRoutes(
       return c.json({ error: "Missing connectionId" }, 400);
     }
 
-    // Resolve the `agent_connections` row (chat platforms + ingest-only webhook
+    // Resolve the `connections` row (chat platforms + ingest-only webhook
     // connections). A miss is NOT necessarily a 404: the id may name a CONNECTOR
     // connection (`connections` table) that registered a provider webhook at
     // connect time — `handleIngestWebhook` bridges to that row. So fall through

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1007,7 +1007,7 @@ routes.post('/:agentId/platforms', async (c) => {
   // No ChatInstanceManager — refuse the write rather than persist
   // plaintext secrets directly. Secret normalization (`secret://` ref
   // indirection) lives on the manager; bypassing it would leak bot
-  // tokens into the agent_connections.config JSON.
+  // tokens into the connections.config JSON.
   return c.json(
     { error: 'platform manager unavailable — retry once startup completes' },
     503
@@ -1200,7 +1200,7 @@ routes.put('/:agentId/platforms/by-stable-id/:stableId', async (c) => {
 
         // No ChatInstanceManager — same reasoning as the POST handler:
         // refuse the write so plaintext secrets aren't persisted into
-        // agent_connections.config bypassing secret-ref normalization.
+        // connections.config bypassing secret-ref normalization.
         return c.json(
           { error: 'platform manager unavailable — retry once startup completes' },
           503
@@ -1268,7 +1268,7 @@ routes.put('/:agentId/platforms/by-stable-id/:stableId', async (c) => {
     }
 
     // No ChatInstanceManager — refuse rather than persist plaintext
-    // secrets directly into agent_connections.config.
+    // secrets directly into connections.config.
     return c.json(
       { error: 'platform manager unavailable — retry once startup completes' },
       503

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -15,7 +15,7 @@ import { MANAGED_CHAT_PLATFORMS_SET } from "./managed-platforms";
 // There is no Slack-Preview-specific schema or transport:
 //   * The link code lives in `oauth_states` (scope `slack-preview-claim`).
 //   * The hosted "Lobu Developer" workspace is just an ordinary Slack
-//     `agent_connections` row (no env var, no relay service).
+//     `connections` row (no env var, no relay service).
 //   * `/lobu link <code>` in that workspace consumes the claim and writes a normal
 //     `agent_channel_bindings` row (platform `slack`) — so inbound messages
 //     route through the exact same Chat SDK adapter path every other platform

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -162,7 +162,7 @@ function registerMaintenanceTasks(
     { cron: '*/5 * * * *' },
   );
 
-  // Connection health — keeps agent_connections.status honest now that boot
+  // Connection health — keeps connections.status honest now that boot
   // no longer warm-starts (and status-marks) every connection on every pod.
   // One claimant per tick validates config rejections + secret-ref
   // resolution; instances themselves hydrate lazily on use.


### PR DESCRIPTION
## What

After the connections-unify migration (`20260630000000_connections_unify_resync_and_drop`) dropped `agent_connections`, several live-code comments still referenced the retired table. This PR corrects those stale pointers to `connections` (the new sole source of truth) and fixes one stale table comment via a proper forward migration.

## Why
Stale `agent_connections` refs (the table no longer exists — dropped by the unify migration) appeared in 10 live-code comments across the gateway/CLI. Kept 2 that are legitimate etymology (`retired ON CONFLICT` SQL arbiter + the live `agentconn-` slug prefix origin).

Also corrected the `auth_profiles` table comment, which claimed **"Per-user-per-agent"** despite the table having **no `agent_id`/`user_id` columns** — it is org-scoped (`organization_id NOT NULL`) and reusable; per-(user,agent) linkage is the separate `user_auth_profiles` join table. Done as a forward migration rather than editing baseline history (baseline migrations are immutable).

## Latent issue flagged (NOT fixed here)
`connector-health.ts` scan has **no `connector_key` filter**. Post-unify, chat connections (slack/telegram) share the same `connections` table with connector connections and own **zero feeds**, so `classify()` Rule B (`zero_feeds`) would flag every active chat connection older than `MIN_CONNECTION_AGE_HOURS` as unhealthy → `logger.error` → Sentry → Slack alert. Left as a NOTE in the comment for a follow-up PR with a reproducer + `connector_key` exclusion.

## Scope
**Comments only** + one comment-only migration. No behavior change, no data/schema alteration.

## Validation
- [x] `bun run typecheck` — clean
- [x] pre-commit (biome + tsc) — passed
- [x] grep sweep confirms no remaining stale `agent_connections` refs in live code (the 2 kept are intentional historical context)

Not a bug fix, so no reproducer required under the E2E gate. Comment-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785594498&installation_id=136316292&pr_number=1690&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1690&signature=17a6e1123cca2e7874a8b08eb2eed8886d0dc6d042af7369bfd6d82d9276db27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified connection and profile wording to reflect the current unified storage model.
  * Updated several inline notes around webhooks, previews, health checks, and Slack flows for consistency.
  * Improved descriptions of how org-scoped records, chat connections, and OAuth-installed workspaces are handled.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->