### PR TITLE
perf: cut initial bundle ~75KB gzip, self-host fonts, edge-cache HTML shell

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -360,7 +360,7 @@ async function serveStaticFile(
 	c.header(
 		"Cache-Control",
 		isHtml
-			? "no-cache, no-store, must-revalidate"
+			? "public, max-age=0, s-maxage=60, stale-while-revalidate=300"
 			: "public, max-age=31536000, immutable",
 	);
 	// Hono's Data type expects Uint8Array<ArrayBuffer>; copy into a fresh


### PR DESCRIPTION
## Why
`app.lobu.ai` had slow perceived load: large initial JS bundle (453KB gzip), a render-blocking Google Fonts request, a wasted `/api/auth-config` XHR on every page, and the HTML shell fully bypassing Cloudflare edge cache.

## What changed

### Web (owletto)
1. **Removed `@daveyplate/better-auth-ui` from app shell.** It was eagerly imported in `providers.tsx` (495KB unminified) but only used by `/auth/accept-invitation`. Moved `AuthUIProvider` + CSS into that route (lazy chunk). **main JS gzip: 426KB → 377KB (-11%)**.
2. **Stopped `/api/auth-config` XHR on every page.** `useLocalInstallAutoSignIn` (mounted in `__root`) called `useAuthConfig()` unconditionally. Added `enabled` option; it now only fetches on loopback hosts + non-`/auth/` paths (single-user local installs).
3. **Self-hosted Google Fonts.** Replaced `@import url(fonts.googleapis.com...)` with local woff2 files in `public/fonts/` + `src/fonts.css`. Removes a render-blocking third-party request (~95ms measured in browser trace).

### Server
4. **Edge-cache HTML shell.** Changed `Cache-Control` for static HTML from `no-cache, no-store, must-revalidate` → `public, max-age=0, s-maxage=60, stale-while-revalidate=300`. Browsers still revalidate every navigation (logged-in chrome stays fresh), but Cloudflare can now serve the shell from edge cache instead of hitting the app pod on every page load. Hashed assets stay immutable; API routes unaffected.

### Infra (applied live, outside this PR)
5. **Traefik resource limits.** Added `requests: {cpu: 100m, memory: 128Mi}` + `limits: {cpu: 1, memory: 512Mi}` to the traefik deployment (was best-effort with no resources). Rolled out successfully.

## Test plan
- [x] `bun run test` in owletto — 427 passed (63 files)
- [x] `bun run build` in owletto — builds clean, main chunk 377KB gzip
- [x] `tsc --noEmit` — no new type errors
- [x] `biome check` — clean
- [x] `agent-browser` preview on `vite preview` — login page renders, Manrope font loads from `/fonts/`, no Google Fonts request
- [ ] After deploy: verify `cf-cache-status` for `/` becomes `HIT` or edge-cached

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785596948&installation_id=136316292&pr_number=1691&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1691&signature=e02c37cc2c5f73def7a5d8a4dedee8d35dad74252750cf6e4a11d2d2942c49de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caching behavior for served HTML pages, allowing faster repeat visits while still checking for updates regularly.
  * Kept static asset caching unchanged for non-HTML files, preserving current performance for images, scripts, and styles.
* **Chores**
  * Updated an internal subproject to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->