### PR TITLE
ci: gate connector-sdk and example connector tests in unit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,17 @@ jobs:
         # Neither needs Postgres.
         run: bun test packages/client packages/promptfoo-provider
 
+      - name: connector-sdk (bun:test)
+        # Checkpoint/watermark + url-guards moved here from bundled scraper-utils.
+        run: bun test packages/connector-sdk
+
+      - name: example connectors (bun:test)
+        # Unbundled connectors live under examples/; mock @lobu/connector-sdk
+        # so Playwright/Baileys never load in CI.
+        run: |
+          bun test examples/personal-agent
+          bun test examples/brand-intelligence
+
       - name: Upload coverage
         if: always()
         uses: codecov/codecov-action@v7

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,9 @@ test-unit:
 	@# src/gateway/infrastructure/queue runs in the gateway loop in test-integration (#1238)
 	@bun test packages/connector-worker
 	@bun test packages/client packages/promptfoo-provider
+	@bun test packages/connector-sdk
 	@bun test examples/personal-agent
+	@bun test examples/brand-intelligence
 
 # Integration suite — vitest under Node + bun:test packages that need Postgres.
 # Requires DATABASE_URL pointing at a Postgres with pgvector installed.

--- a/examples/brand-intelligence/gmaps.connector.ts
+++ b/examples/brand-intelligence/gmaps.connector.ts
@@ -10,10 +10,10 @@ import {
   calculateEngagementScore,
   createHttpClient,
   type EventEnvelope,
+  finalizeTimestampSync,
   type SyncContext,
   type SyncResult,
 } from "@lobu/connector-sdk";
-import { finalizeTimestampSync } from "@lobu/connector-sdk";
 
 interface GMapsReview {
   author_name: string;

--- a/scripts/lobu/install-connectors.ts
+++ b/scripts/lobu/install-connectors.ts
@@ -7,8 +7,8 @@
  * null-byte limitation in postgres text columns.
  *
  * Usage:
- *   pnpm tsx --env-file=.env scripts/install-connectors.ts --org buremba --file connectors/whatsapp.ts
- *   pnpm tsx --env-file=.env scripts/install-connectors.ts --org buremba --file connectors/whatsapp.ts --target-entity-type contact
+ *   pnpm tsx --env-file=.env scripts/lobu/install-connectors.ts --org buremba --file examples/personal-agent/spotify.connector.ts
+ *   pnpm tsx --env-file=.env scripts/lobu/install-connectors.ts --org market --file examples/brand-intelligence/website.connector.ts --target-entity-type company
  */
 
 import { basename, resolve } from 'node:path';
@@ -34,7 +34,7 @@ if (values.help || !values.org || !values.file?.length) {
 Install or refresh connector(s) in an organization.
 
 Usage:
-  pnpm tsx --env-file=.env scripts/install-connectors.ts --org <slug> --file <path>...
+  pnpm tsx --env-file=.env scripts/lobu/install-connectors.ts --org <slug> --file <path-to-connector.ts>...
 
 Options:
   --org                      Organization slug (required)


### PR DESCRIPTION
Adds `bun test packages/connector-sdk` and `examples/brand-intelligence` to CI unit job and Makefile. Fixes gmaps duplicate import and stale install-connectors help.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785605557&installation_id=136316292&pr_number=1693&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1693&signature=1d12094a917c26d19ab3a694b3468fb7517a7b8b32d878df5ff9167f86e45d1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->