### PR TITLE
perf(events): denormalize supersession lineage into events.superseded_by

### DIFF
--- a/db/migrations/20260702200000_events_superseded_by.sql
+++ b/db/migrations/20260702200000_events_superseded_by.sql
@@ -1,0 +1,45 @@
+-- migrate:up
+
+-- Denormalize supersession lineage onto the row it supersedes.
+--
+-- Background: `events` is append-only. An edit/delete inserts a NEW row whose
+-- `supersedes_event_id` points back at the row it replaces. The masking view
+-- `current_event_records` today hides replaced rows with a per-row anti-join:
+--   WHERE NOT EXISTS (SELECT 1 FROM events newer WHERE newer.supersedes_event_id = e.id)
+-- In prod ~75% of rows are superseded, so every live-row read scans mostly-dead
+-- rows. This column lets the view flip to a cheap `WHERE superseded_by IS NULL`
+-- predicate backed by a partial index — but ONLY after the backfill lands
+-- (see Stage 2 below).
+--
+-- `superseded_by` holds the id of the row that superseded THIS row (the inverse
+-- edge of `supersedes_event_id`). It is lineage metadata, NOT payload — the
+-- append-only invariant applies to content, and precedent for post-insert
+-- lineage maintenance is `search_tsv`. There is at most one superseder per row
+-- (enforced by the partial unique index `idx_events_superseded_by` on
+-- `supersedes_event_id`), so this is a 1:1 inverse.
+--
+-- Stage 1 (THIS migration): add the column only. No DEFAULT, no NOT NULL, no
+-- FK, no index — a pure catalog change that does NOT rewrite the 2M+ row heap
+-- and does not block writes. A prior inline 1.5M-row UPDATE inside a migration
+-- caused an outage; the historical backfill is deliberately a separate,
+-- batched, out-of-band script (scripts/backfill-superseded-by.ts). New
+-- superseding writes dual-write this column in the same transaction as the
+-- superseding INSERT (packages/server/src/utils/insert-event.ts).
+--
+-- Stage 2 (SEPARATE, LATER — NOT in this repo as a migration): once the
+-- backfill has completed on prod, deploy the view flip + partial index. It is
+-- intentionally NOT committed as a migration file because the migration runner
+-- (embedded-runtime.ts / dbmate) auto-applies every unapplied file in filename
+-- order at boot, which would flip the view BEFORE the backfill finished and
+-- silently un-mask every not-yet-stamped superseded row. The exact Stage 2 SQL
+-- is documented in packages/server/src/events/backfill-superseded-by.ts.
+ALTER TABLE public.events
+    ADD COLUMN IF NOT EXISTS superseded_by bigint;
+
+COMMENT ON COLUMN public.events.superseded_by IS
+    'Denormalized inverse of supersedes_event_id: the id of the event that superseded THIS row (NULL = live). Lineage metadata only (never payload). Stamped in the same tx as the superseding INSERT; historical rows filled by scripts/backfill-superseded-by.ts. The current_event_records view flips to WHERE superseded_by IS NULL only after that backfill completes.';
+
+-- migrate:down
+
+ALTER TABLE public.events
+    DROP COLUMN IF EXISTS superseded_by;

--- a/packages/server/src/__tests__/integration/events/supersession-hidden-not-deleted.test.ts
+++ b/packages/server/src/__tests__/integration/events/supersession-hidden-not-deleted.test.ts
@@ -21,8 +21,10 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
+import { backfillSupersededBy } from '../../../events/backfill-superseded-by';
 import { getContent } from '../../../tools/get_content';
 import type { ToolContext } from '../../../tools/registry';
+import { insertEvent } from '../../../utils/insert-event';
 import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
@@ -158,5 +160,210 @@ describe('supersession > hidden, not deleted', () => {
 
     expect(ids.has(originalId)).toBe(true);
     expect(ids.has(successorId)).toBe(true);
+  });
+});
+
+/**
+ * Denormalized lineage (`events.superseded_by`) coverage.
+ *
+ * Migration 20260702200000 adds `superseded_by` as the inverse edge of
+ * `supersedes_event_id`. New superseding writes dual-write it in the same tx as
+ * the superseding INSERT (utils/insert-event.ts); historical rows are filled by
+ * the batched, resumable backfill (events/backfill-superseded-by.ts). Through
+ * all of this the masking contract above stays intact — the view still hides
+ * superseded rows — so the flip to `WHERE superseded_by IS NULL` (Stage 2) is a
+ * pure performance change, not a behaviour change.
+ */
+describe('supersession > denormalized superseded_by lineage', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let entity: Awaited<ReturnType<typeof createTestEntity>>;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Superseded-By Lineage Org' });
+    entity = await createTestEntity({
+      name: 'Lineage Entity',
+      organization_id: org.id,
+    });
+  });
+
+  it('dual-writes superseded_by on the target in the SAME insertEvent call', async () => {
+    const sql = getTestDb();
+
+    const original = await createTestEvent({
+      organization_id: org.id,
+      entity_id: entity.id,
+      content: 'v1',
+      semantic_type: 'preference',
+    });
+
+    // Before superseding, the target is live: superseded_by IS NULL.
+    const [before] = await sql`
+      SELECT superseded_by FROM events WHERE id = ${original.id}
+    `;
+    expect(before.superseded_by).toBeNull();
+
+    const successor = await insertEvent({
+      entityIds: [entity.id],
+      organizationId: org.id,
+      originId: `dualwrite-${original.id}`,
+      content: 'v2',
+      semanticType: 'preference',
+      supersedesEventId: original.id,
+    });
+
+    // The superseding insert stamped the target's inverse edge atomically.
+    const [after] = await sql`
+      SELECT superseded_by FROM events WHERE id = ${original.id}
+    `;
+    expect(Number(after.superseded_by)).toBe(Number(successor.id));
+
+    // The successor itself is live (nothing supersedes it yet).
+    const [succRow] = await sql`
+      SELECT superseded_by FROM events WHERE id = ${successor.id}
+    `;
+    expect(succRow.superseded_by).toBeNull();
+
+    // Masking is unchanged: original hidden, successor visible.
+    const hidden = await sql`
+      SELECT id FROM current_event_records WHERE id = ${original.id}
+    `;
+    expect(hidden).toHaveLength(0);
+    const visible = await sql`
+      SELECT id FROM current_event_records WHERE id = ${successor.id}
+    `;
+    expect(visible).toHaveLength(1);
+  });
+
+  it('lets a concurrent double-supersede lose cleanly (unique index, one winner)', async () => {
+    const sql = getTestDb();
+
+    const target = await createTestEvent({
+      organization_id: org.id,
+      entity_id: entity.id,
+      content: 'contended',
+      semantic_type: 'preference',
+    });
+
+    // Two supersedes of the SAME target fire concurrently. The partial unique
+    // index idx_events_superseded_by on supersedes_event_id serializes them:
+    // exactly one INSERT wins, the other throws a raw 23505.
+    const results = await Promise.allSettled([
+      insertEvent({
+        entityIds: [entity.id],
+        organizationId: org.id,
+        originId: `race-a-${target.id}`,
+        content: 'winner?',
+        semanticType: 'preference',
+        supersedesEventId: target.id,
+      }),
+      insertEvent({
+        entityIds: [entity.id],
+        organizationId: org.id,
+        originId: `race-b-${target.id}`,
+        content: 'winner?',
+        semanticType: 'preference',
+        supersedesEventId: target.id,
+      }),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+
+    // Exactly one superseder edge exists in the raw table.
+    const superseders = await sql`
+      SELECT id FROM events WHERE supersedes_event_id = ${target.id}
+    `;
+    expect(superseders).toHaveLength(1);
+
+    // The winner's dual-write stamped superseded_by to that single winner.
+    const winnerId = (fulfilled[0] as PromiseFulfilledResult<{ id: number }>).value.id;
+    const [stamped] = await sql`
+      SELECT superseded_by FROM events WHERE id = ${target.id}
+    `;
+    expect(Number(stamped.superseded_by)).toBe(Number(winnerId));
+    expect(Number(superseders[0].id)).toBe(Number(winnerId));
+  });
+
+  it('backfill fills historical edges that predate the dual-write and stays idempotent', async () => {
+    const sql = getTestDb();
+
+    // Simulate a historical (pre-dual-write) supersede: raw INSERT that sets
+    // supersedes_event_id but leaves superseded_by NULL (bypassing insertEvent,
+    // exactly like the older successor inserted in the first describe block).
+    const original = await createTestEvent({
+      organization_id: org.id,
+      entity_id: entity.id,
+      content: 'historical v1',
+      semantic_type: 'preference',
+    });
+    const [succ] = await sql`
+      INSERT INTO events (
+        entity_ids, origin_id, payload_type, payload_text, occurred_at,
+        semantic_type, connector_key, metadata, organization_id,
+        supersedes_event_id, created_at
+      ) VALUES (
+        ${`{${entity.id}}`}::bigint[],
+        ${`historical-supersede-${original.id}`},
+        'text',
+        'historical v2',
+        NOW(),
+        'preference',
+        'test.connector',
+        ${sql.json({})},
+        ${org.id},
+        ${original.id},
+        NOW()
+      )
+      RETURNING id
+    `;
+    const successorId = Number(succ.id);
+
+    // The historical edge is unstamped, but the view already masks it (proves
+    // the flip is a perf-only change: masking works both before AND after the
+    // backfill).
+    const [preBackfill] = await sql`
+      SELECT superseded_by FROM events WHERE id = ${original.id}
+    `;
+    expect(preBackfill.superseded_by).toBeNull();
+    const maskedBefore = await sql`
+      SELECT id FROM current_event_records WHERE id = ${original.id}
+    `;
+    expect(maskedBefore).toHaveLength(0);
+
+    // Dry-run reports the edge without writing.
+    const dry = await backfillSupersededBy({ db: sql, execute: false, sleepMs: 0 });
+    expect(dry.filled).toBeGreaterThanOrEqual(1);
+    const [stillNull] = await sql`
+      SELECT superseded_by FROM events WHERE id = ${original.id}
+    `;
+    expect(stillNull.superseded_by).toBeNull();
+
+    // Execute: the historical edge is now stamped.
+    const run1 = await backfillSupersededBy({ db: sql, execute: true, sleepMs: 0 });
+    expect(run1.filled).toBeGreaterThanOrEqual(1);
+    const [filled] = await sql`
+      SELECT superseded_by FROM events WHERE id = ${original.id}
+    `;
+    expect(Number(filled.superseded_by)).toBe(successorId);
+
+    // Re-run is a no-op (idempotent + resumable): nothing left to fill.
+    const run2 = await backfillSupersededBy({ db: sql, execute: true, sleepMs: 0 });
+    expect(run2.filled).toBe(0);
+
+    // Masking remains correct after the backfill.
+    const maskedAfter = await sql`
+      SELECT id FROM current_event_records WHERE id = ${original.id}
+    `;
+    expect(maskedAfter).toHaveLength(0);
+    const visibleAfter = await sql`
+      SELECT id FROM current_event_records WHERE id = ${successorId}
+    `;
+    expect(visibleAfter).toHaveLength(1);
   });
 });

--- a/packages/server/src/events/backfill-superseded-by.ts
+++ b/packages/server/src/events/backfill-superseded-by.ts
@@ -1,0 +1,171 @@
+/**
+ * One-off backfill: populate `events.superseded_by` from the existing
+ * `supersedes_event_id` edges.
+ *
+ * Context: migration 20260702200000_events_superseded_by adds the column but
+ * does NOT fill it (a prior inline 1.5M-row UPDATE inside a migration caused an
+ * outage). New superseding writes dual-write the column in the same tx as the
+ * superseding INSERT (utils/insert-event.ts). This script fills the historical
+ * rows out of band, in small batches with short sleeps, so it is safe to run
+ * against a live prod database.
+ *
+ * `superseded_by` is the inverse edge of `supersedes_event_id`: for a row R
+ * that was replaced by a newer row N (N.supersedes_event_id = R.id), we set
+ * R.superseded_by = N.id. The partial unique index idx_events_superseded_by
+ * guarantees at most one N per R, so this is an unambiguous 1:1 fill. This is
+ * LINEAGE METADATA ONLY — never payload — so it does not violate the
+ * append-only invariant (precedent: search_tsv is maintained post-insert).
+ *
+ * Idempotent + resumable: every batch only touches rows where
+ * `superseded_by IS NULL`, so re-running after an interrupt (or after the
+ * dual-write has already stamped some rows) simply skips already-filled rows.
+ * Safe under concurrent live writes: the dual-write and this backfill both
+ * guard on `superseded_by IS NULL`, and the unique index serializes supersede
+ * winners, so neither can clobber the other.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * STAGE 2 (view flip + partial index) — deploy ONLY after this backfill has
+ * completed on the target DB. It is deliberately NOT committed as a migration
+ * file: the migration runner (embedded-runtime.ts / dbmate) auto-applies every
+ * unapplied migration in filename order at boot, which would flip the view
+ * BEFORE the backfill finished and un-mask every not-yet-stamped superseded
+ * row. Run this SQL by hand (or add it as a migration in the follow-up PR once
+ * prod is fully backfilled):
+ *
+ *   -- Partial index backing the flipped predicate. Org-scoped chronological
+ *   -- reads (get_content, metrics/compiler.ts rewrites events→
+ *   -- current_event_records, utils/execute-data-sources.ts) filter on
+ *   -- organization_id then order by created_at, so key the live-row index on
+ *   -- (organization_id, created_at) restricted to live rows. CONCURRENTLY so
+ *   -- the build never blocks writes.
+ *   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_live_org_created
+ *       ON public.events (organization_id, created_at)
+ *       WHERE superseded_by IS NULL;
+ *
+ *   -- Flip the view from the per-row anti-join to the cheap partial-index
+ *   -- predicate. Column list MUST match the current definition (see migration
+ *   -- 20260618140000_event_embeddings_contract.sql, which added the
+ *   -- event_embeddings LEFT JOIN). Only the WHERE clause changes.
+ *   CREATE OR REPLACE VIEW public.current_event_records AS
+ *    SELECT e.id, e.organization_id, e.entity_ids, e.origin_id, e.title,
+ *           e.payload_type, e.payload_text, e.payload_data, e.payload_template,
+ *           e.attachments, e.metadata, e.score, emb.embedding, e.author_name,
+ *           e.source_url, e.occurred_at, e.created_at, e.origin_parent_id,
+ *           COALESCE(length(e.payload_text), 0) AS content_length,
+ *           e.search_tsv, e.origin_type, e.connector_key, e.connection_id,
+ *           e.feed_key, e.feed_id, e.run_id, e.semantic_type, e.client_id,
+ *           e.created_by, e.interaction_type, e.interaction_status,
+ *           e.interaction_input_schema, e.interaction_input,
+ *           e.interaction_output, e.interaction_error, e.supersedes_event_id
+ *      FROM (public.events e
+ *        LEFT JOIN public.event_embeddings emb ON ((emb.event_id = e.id)))
+ *     WHERE e.superseded_by IS NULL;
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+import { type DbClient, pgBigintArray } from '../db/client';
+
+export interface BackfillSupersededByOptions {
+  db: DbClient;
+  /** Rows scanned per batch (default 5000). */
+  batchSize?: number;
+  /** Milliseconds to sleep between batches to avoid hammering a live DB (default 200). */
+  sleepMs?: number;
+  /** Dry-run: count what WOULD be filled without writing (default false). */
+  execute?: boolean;
+  log?: (msg: string) => void;
+}
+
+export interface BackfillSupersededByReport {
+  /** Total rows whose `superseded_by` was (or would be) filled. */
+  filled: number;
+  /** Number of batches processed. */
+  batches: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fill `events.superseded_by` for historical superseded rows. Walks the
+ * supersede edges by ascending superseded-row id, so an interrupted run resumes
+ * cleanly (every batch re-filters on `superseded_by IS NULL`).
+ */
+export async function backfillSupersededBy(
+  opts: BackfillSupersededByOptions
+): Promise<BackfillSupersededByReport> {
+  const sql = opts.db;
+  const batchSize = opts.batchSize ?? 5000;
+  const sleepMs = opts.sleepMs ?? 200;
+  // A production backfill must not silently no-op (batchSize 0 makes every
+  // batch empty → reports "done" with nothing filled) or die on LIMIT/negative
+  // sleep — reject bad knobs up front.
+  if (!Number.isInteger(batchSize) || batchSize <= 0) {
+    throw new Error(`batchSize must be a positive integer (got ${String(opts.batchSize)})`);
+  }
+  if (!Number.isFinite(sleepMs) || sleepMs < 0) {
+    throw new Error(`sleepMs must be a non-negative number (got ${String(opts.sleepMs)})`);
+  }
+  const execute = opts.execute ?? false;
+  const log = opts.log ?? (() => {});
+
+  let filled = 0;
+  let batches = 0;
+  // Cursor over the superseded row's id. Only advances past ids we've inspected;
+  // combined with the `superseded_by IS NULL` guard this is resumable and never
+  // reprocesses a filled row.
+  let cursor = 0;
+
+  for (;;) {
+    // A superseded row (e) is one that some newer row (n) points at via
+    // supersedes_event_id and whose superseded_by is not yet stamped. Grab a
+    // batch of such rows past the cursor. `n.id` is the value we will stamp
+    // onto e.superseded_by (the unique index guarantees one n per e).
+    const candidates = (await sql`
+      SELECT e.id AS superseded_id, n.id AS superseder_id
+      FROM events e
+      JOIN events n ON n.supersedes_event_id = e.id
+      WHERE e.superseded_by IS NULL
+        AND e.id > ${cursor}
+      ORDER BY e.id ASC
+      LIMIT ${batchSize}
+    `) as unknown as Array<{ superseded_id: number; superseder_id: number }>;
+
+    if (candidates.length === 0) break;
+
+    batches++;
+    cursor = Number(candidates[candidates.length - 1]!.superseded_id);
+
+    if (execute) {
+      const batchIds = candidates.map((r) => Number(r.superseded_id));
+      // Correlated UPDATE, scoped to this batch's ids. Re-derives the superseder
+      // from the live edge (n.supersedes_event_id) rather than trusting the
+      // read, so a concurrent supersede that landed between the SELECT and here
+      // is reflected. Guarded on `superseded_by IS NULL` so the live dual-write
+      // path (insert-event.ts) always wins a race without being overwritten.
+      const updated = (await sql`
+        UPDATE events e
+        SET superseded_by = n.id
+        FROM events n
+        WHERE n.supersedes_event_id = e.id
+          AND e.superseded_by IS NULL
+          AND e.id = ANY(${pgBigintArray(batchIds)}::bigint[])
+        RETURNING e.id
+      `) as unknown as Array<{ id: number }>;
+      filled += updated.length;
+    } else {
+      filled += candidates.length;
+    }
+
+    log(
+      `batch ${batches}: ${execute ? 'filled' : 'would fill'} ${filled} row(s) ` +
+        `(cursor now at superseded id ${cursor})`
+    );
+
+    if (candidates.length < batchSize) break;
+    if (sleepMs > 0) await sleep(sleepMs);
+  }
+
+  return { filled, batches };
+}

--- a/packages/server/src/utils/__tests__/table-schema.test.ts
+++ b/packages/server/src/utils/__tests__/table-schema.test.ts
@@ -116,7 +116,11 @@ describe('validateTableQuery', () => {
 describe('QUERYABLE_SCHEMA vs database (drift detection)', () => {
   const INTENTIONALLY_OMITTED: Record<string, Set<string>> = {
     entities: new Set(['embedding', 'content_tsv', 'content_hash', 'field_controls']),
-    events: new Set([]),
+    // superseded_by: the query_sql events CTE reads from current_event_records,
+    // which doesn't expose the column — and never usefully can: the Stage-2
+    // flip makes the view `WHERE superseded_by IS NULL`, so through the view
+    // the column is always NULL. Lineage queries belong on the raw table.
+    events: new Set(['superseded_by']),
     connections: new Set(['credentials', 'unhealthy_alerted_at']),
     // Large per-connector JSONB blobs — too big and structure-dependent to expose
     // via raw SQL. Callers should hit the typed connector handler instead.

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -404,6 +404,33 @@ export async function insertEvent(
         `Row was not persisted; check server logs for diagnostic context.`
     );
   }
+
+    // Dual-write the denormalized supersession edge. `events.superseded_by`
+    // holds the inverse of `supersedes_event_id`: we stamp the row we just
+    // replaced with the id of THIS new superseding row so live-row reads can
+    // one day use `WHERE superseded_by IS NULL` instead of the per-row
+    // anti-join in current_event_records. This touches LINEAGE METADATA ONLY,
+    // never payload — the append-only invariant applies to content (precedent:
+    // search_tsv is likewise maintained post-insert). Runs on the SAME `sql`
+    // handle as the INSERT, so when we're inside the dedup advisory-lock tx or
+    // a caller-supplied tx (identity engine) it is atomic with the supersede.
+    //
+    // The `AND superseded_by IS NULL` guard is belt-and-braces: the partial
+    // unique index idx_events_superseded_by already fired a 23505 on the INSERT
+    // above if the target was already superseded, so a 0-row UPDATE here can
+    // only happen if the column was backfilled/stamped by a losing concurrent
+    // writer whose INSERT nonetheless slipped through — in which case leaving
+    // the existing stamp intact is correct (the unique index still guarantees a
+    // single superseder).
+    if (supersedesEventId !== null) {
+      await sql`
+        UPDATE events
+        SET superseded_by = ${inserted.id}
+        WHERE id = ${supersedesEventId}
+          AND superseded_by IS NULL
+      `;
+    }
+
     await upsertEmbedding(inserted.id, params.embedding, params.embeddingModel, sql);
     return inserted;
   };
@@ -427,6 +454,19 @@ export async function insertEvent(
       `;
       return runInsert(tx as unknown as ReturnType<typeof getDb>);
     }) as Promise<InsertedEvent>;
+  }
+
+  // An explicit supersede without a caller-supplied tx must still commit the
+  // superseding INSERT and the superseded_by stamp atomically: as two
+  // autocommit statements, a crash between them would leave the superseded
+  // row's denormalized edge permanently NULL — which, after the Stage-2 view
+  // flip to `WHERE superseded_by IS NULL`, would resurrect it as a live row.
+  // (The dedup path can only derive a supersede when connectionId+originId are
+  // both present, and that case is already inside the advisory-lock tx above.)
+  if (params.supersedesEventId != null && !options?.sql) {
+    return sql.begin(async (tx) =>
+      runInsert(tx as unknown as ReturnType<typeof getDb>)
+    ) as Promise<InsertedEvent>;
   }
 
   return runInsert(sql);

--- a/scripts/backfill-superseded-by.ts
+++ b/scripts/backfill-superseded-by.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env tsx
+/**
+ * One-off backfill CLI: populate `events.superseded_by` from the existing
+ * `supersedes_event_id` edges. Thin wrapper over the package function
+ * `backfillSupersededBy` (packages/server/src/events), which is exercised on a
+ * real DB by its integration test (vitest = the proven isolate runner). See
+ * that module for full semantics and the Stage 2 (view flip) SQL.
+ *
+ * Batched + resumable + idempotent, so it is safe to run against a LIVE prod
+ * database and safe to re-run after an interrupt.
+ *
+ *   tsx scripts/backfill-superseded-by.ts                       # dry-run (count only)
+ *   tsx scripts/backfill-superseded-by.ts --execute             # write
+ *   tsx scripts/backfill-superseded-by.ts --execute --batch 5000 --sleep 200
+ *
+ * DATABASE_URL must point at the target database.
+ */
+
+import { getDb } from "../packages/server/src/db/client";
+import { backfillSupersededBy } from "../packages/server/src/events/backfill-superseded-by";
+
+function numArg(argv: string[], flag: string): number | undefined {
+  const idx = argv.indexOf(flag);
+  if (idx < 0) return undefined;
+  const raw = argv[idx + 1];
+  const n = raw ? Number(raw) : Number.NaN;
+  if (!Number.isFinite(n)) {
+    // A malformed flag silently falling back to the default is dangerous for a
+    // production backfill ("--batch foo" must not mean 5000) — fail fast.
+    throw new Error(
+      `${flag} requires a numeric value (got ${JSON.stringify(raw ?? null)})`
+    );
+  }
+  return n;
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const execute = argv.includes("--execute");
+  const batchSize = numArg(argv, "--batch");
+  const sleepMs = numArg(argv, "--sleep");
+  if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is required");
+
+  const sql = getDb();
+  try {
+    const report = await backfillSupersededBy({
+      db: sql,
+      execute,
+      batchSize,
+      sleepMs,
+      log: (m) => console.log(m),
+    });
+    console.log(
+      `\nDone. ${report.filled} row(s) ${execute ? "filled" : "would fill"} ` +
+        `across ${report.batches} batch(es).`
+    );
+  } finally {
+    await sql.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Denormalizes the supersession inverse edge onto the superseded row so the `current_event_records` masking view can eventually flip from a per-row anti-join to a cheap `WHERE superseded_by IS NULL` partial-index predicate. In prod ~75% of the 2.1M events rows are superseded tombstones — every live-row read today scans mostly-dead rows.

Two-phase and prod-safe (a prior inline 1.5M-row UPDATE inside a migration caused an outage):

- **Migration A (this PR)**: `ADD COLUMN superseded_by bigint` — catalog-only, no default/FK/index/rewrite.
- **Dual-write**: `insertEvent` stamps the superseded row in the SAME transaction as the superseding INSERT. Explicit supersedes without a caller tx are wrapped in `sql.begin` so the INSERT + stamp commit atomically (the dedup path already runs in its advisory-lock tx, and it can only derive a supersede when connection+origin keys exist). Verified this covers every supersede path: the only raw `INSERT INTO events` sites outside `insertEvent` never set `supersedes_event_id`.
- **Backfill**: batched (5k), resumable, idempotent script (`scripts/backfill-superseded-by.ts`) — deliberately NOT inline in the migration. Guarded on `superseded_by IS NULL` both here and in the dual-write, so live writes and the backfill can't clobber each other.
- **Stage 2 (view flip + partial index) is intentionally NOT a migration in this PR**: the runner auto-applies migrations at boot, which would flip the view before prod backfills and un-mask ~1.5M rows. Exact SQL is documented in the backfill module header; ship it as a follow-up after the prod backfill completes.

`superseded_by` is intentionally **not** in `QUERYABLE_SCHEMA`: the events CTE reads from `current_event_records`, which doesn't expose the column — and post-flip never usefully can (every visible row has it NULL). Documented in the drift test's omission list.

## Validation

- `supersession-hidden-not-deleted` extended: dual-write stamps in the same call; concurrent double-supersede → exactly one winner stamped (23505 loser); backfill fills historical raw-inserted edges, dry-run writes nothing, re-run fills 0; view masking identical before/after backfill. 7/7 green on a fresh PG18+pgvector DB.
- Full server vitest integration suite: **217 files / 1706 tests passed**.
- Schema-drift test green (14/14); typecheck + biome clean.
- Known pre-existing failures NOT from this diff (reproduced identically on a control worktree with a disjoint diff): gateway bun suites (Slack coordinator ×3, star delivery, agent-history) and `lobu init` CLI tests (network timeouts).

## Post-merge runbook

1. Run `tsx scripts/backfill-superseded-by.ts --execute` against prod (batched, resumable; safe live).
2. Verify `COUNT(*) WHERE superseded_by IS NULL AND EXISTS(newer)` reaches 0.
3. Follow-up PR: partial index (`CONCURRENTLY`) + view flip using the SQL in the backfill module header; EXPLAIN-verify an org-scoped read picks the index.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785612664&installation_id=136316292&pr_number=1694&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1694&signature=86b81d90ac50379934e6c9474993e580a73b57d3c79c4b05a38b2d41899984ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking an event’s superseding event in a new lineage field.
  * Event creation now keeps this supersession information in sync automatically.
  * Added a backfill option to populate historical lineage data, with dry-run and resumable execution support.

* **Bug Fixes**
  * Supersession updates now commit atomically to reduce race-condition issues.
  * Existing event masking behavior remains unchanged when supersession data is recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->