### PR TITLE
feat(watchers): fold watcher windows into canvas_state event chains

### DIFF
--- a/db/migrations/20260702100000_canvas_chain_root_unique_index.sql
+++ b/db/migrations/20260702100000_canvas_chain_root_unique_index.sql
@@ -1,0 +1,33 @@
+-- migrate:up transaction:false
+
+-- Canvas-on-events: one chain ROOT per (watcher, granularity, period).
+-- A watcher window is now a supersede chain of `semantic_type='canvas_state'`
+-- events; the chain-root event (supersedes_event_id IS NULL) is the window
+-- identity. This partial UNIQUE expression index enforces "at most one root per
+-- period" — concurrent completions on N replicas race here and the loser gets a
+-- 23505 the write path maps to a 409 (same UX as the retired
+-- idx_watcher_windows_unique_period).
+--
+-- Scoped to semantic_type='canvas_state' so it never collides with the 19k+
+-- tab_event/tab_snapshot rows that also carry metadata.window_id for BROWSER
+-- windows. CONCURRENTLY (transaction:false, one statement) so building it never
+-- locks the high-write events table; squawk requires a CONCURRENTLY index alone
+-- in its own file.
+--
+-- window_start is indexed as the raw canonical text (`metadata->>'window_start'`,
+-- always written as a UTC ISO-8601 string via Date.toISOString()) rather than
+-- cast to timestamptz: text→timestamptz is STABLE, not IMMUTABLE (it reads the
+-- session TimeZone), so it cannot appear in an index expression. Text equality on
+-- the canonical string is exactly the uniqueness we need; query predicates that
+-- want timestamptz semantics cast in the WHERE clause, which is allowed.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_canvas_chain_root
+  ON public.events (
+    ((metadata->>'watcher_id')::bigint),
+    (metadata->>'granularity'),
+    (metadata->>'window_start')
+  )
+  WHERE semantic_type = 'canvas_state' AND supersedes_event_id IS NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_canvas_chain_root;

--- a/db/migrations/20260702100010_canvas_state_listing_index.sql
+++ b/db/migrations/20260702100010_canvas_state_listing_index.sql
@@ -1,0 +1,26 @@
+-- migrate:up transaction:false
+
+-- Canvas-on-events: listing / pagination index over ALL chain members (roots and
+-- superseders alike), keyed on the same period columns the write path stamps.
+-- Serves get_watchers pagination (ORDER BY window_start DESC) and previous-period
+-- lookups without scanning the full events table. Non-unique on purpose — a
+-- period has one root but many chain members (edit history).
+--
+-- Scoped to semantic_type='canvas_state' (must never pattern-match the bare
+-- metadata.window_id used by tab_event/tab_snapshot BROWSER rows). CONCURRENTLY
+-- (own file, squawk) so the build never locks events.
+--
+-- window_start indexed as canonical text (see idx_canvas_chain_root) — a UTC
+-- ISO-8601 string sorts lexicographically in timestamp order, so DESC text
+-- ordering matches DESC chronological ordering for get_watchers pagination.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_canvas_state_listing
+  ON public.events (
+    ((metadata->>'watcher_id')::bigint),
+    (metadata->>'granularity'),
+    (metadata->>'window_start') DESC
+  )
+  WHERE semantic_type = 'canvas_state';
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_canvas_state_listing;

--- a/db/migrations/20260702100020_watcher_window_events_watcher_id.sql
+++ b/db/migrations/20260702100020_watcher_window_events_watcher_id.sql
@@ -1,0 +1,24 @@
+-- migrate:up
+
+-- Canvas-on-events: denormalize watcher_id onto watcher_window_events so the
+-- inputs link table can be re-keyed to canvas root event ids without a join back
+-- through watcher_windows (which is dropped at the end state). The window_id
+-- column continues to point at the window identity (soon the canvas root event
+-- id); watcher_id lets listing/pagination stay on typed columns.
+--
+-- Backfilled inline from watcher_windows in the same migration: prod has only
+-- ~413 watcher_window_events rows, so a single correlated UPDATE is safe and
+-- keeps un-flipped readers correct during the dual-write release.
+ALTER TABLE public.watcher_window_events
+  ADD COLUMN IF NOT EXISTS watcher_id bigint;
+
+UPDATE public.watcher_window_events wwe
+SET watcher_id = ww.watcher_id
+FROM public.watcher_windows ww
+WHERE wwe.window_id = ww.id
+  AND wwe.watcher_id IS NULL;
+
+-- migrate:down
+
+ALTER TABLE public.watcher_window_events
+  DROP COLUMN IF EXISTS watcher_id;

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -1399,3 +1399,234 @@ describe('watcher automation contract', () => {
     });
   });
 });
+
+// ============================================
+// Canvas-on-events contract
+// ============================================
+describe('canvas-on-events window completion', () => {
+  async function completeOnce(
+    overrides: {
+      extracted_data?: Record<string, unknown>;
+      replace_existing?: boolean;
+      client_id?: string;
+    } = {}
+  ) {
+    const { sql, workspace, api, entityId, watcherId } = await createAutomatedWatcher();
+    const event = await createTestEvent({
+      entity_id: entityId,
+      organization_id: workspace.org.id,
+      content: 'Canvas event content.',
+      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    const windowStart = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const windowEnd = new Date().toISOString();
+    const windowToken = await generateWindowToken(
+      {
+        watcher_id: watcherId,
+        window_start: windowStart,
+        window_end: windowEnd,
+        granularity: 'daily',
+        content_count: 1,
+        content_ids: [event.id],
+      },
+      { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env
+    );
+    const completion = (await api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: windowToken,
+      extracted_data: overrides.extracted_data ?? { summary: 'v1 canvas summary' },
+      replace_existing: overrides.replace_existing ?? false,
+      ...(overrides.client_id ? { client_id: overrides.client_id } : {}),
+    })) as { action: string; window_id: number };
+    return { sql, workspace, api, watcherId, windowStart, windowEnd, windowToken, completion };
+  }
+
+  it('emits a canvas_state ROOT event on window completion', async () => {
+    const { sql, watcherId } = await completeOnce({ extracted_data: { summary: 'hello canvas' } });
+    const rows = await sql`
+      SELECT id, payload_data, supersedes_event_id, metadata->>'granularity' AS granularity
+      FROM events
+      WHERE semantic_type = 'canvas_state'
+        AND (metadata->>'watcher_id')::bigint = ${watcherId}
+    `;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].supersedes_event_id).toBeNull();
+    expect(rows[0].granularity).toBe('daily');
+    expect((rows[0].payload_data as Record<string, unknown>).summary).toBe('hello canvas');
+  });
+
+  it('completes with a PAT/device client_id that is not an oauth_clients row', async () => {
+    // Reproduces the sdk-e2e failure: events.client_id has an FK to
+    // oauth_clients (unlike watcher_windows.client_id, which stores PAT ids
+    // verbatim). The canvas insert runs inside the completion tx, where
+    // insertEvent's client-id-FK retry can't engage (the first failed INSERT
+    // aborts the tx) — so complete_window must pre-validate and stamp NULL.
+    const { sql, watcherId, completion } = await completeOnce({
+      extracted_data: { summary: 'pat canvas' },
+      client_id: 'pat_nonexistent_e2e',
+    });
+    expect(completion.action).toBe('complete_window');
+
+    const [root] = await sql`
+      SELECT client_id, payload_data FROM events
+      WHERE semantic_type = 'canvas_state'
+        AND (metadata->>'watcher_id')::bigint = ${watcherId}
+    `;
+    expect(root.client_id).toBeNull();
+    expect((root.payload_data as Record<string, unknown>).summary).toBe('pat canvas');
+
+    // The legacy row keeps the raw PAT id (no FK there) — provenance preserved.
+    const [win] = await sql`
+      SELECT client_id FROM watcher_windows WHERE id = ${completion.window_id}
+    `;
+    expect(String(win.client_id)).toBe('pat_nonexistent_e2e');
+  });
+
+  it('a tokenWindowId refresh with changed data supersedes the head; same-data replay is a no-op', async () => {
+    // The tokenWindowId (legacy) branch refreshes watcher_windows.extracted_data
+    // unconditionally. Reads prefer the canvas head, so the canvas must follow a
+    // real data change (else the refresh is invisible) while a same-payload
+    // replay must NOT grow the chain.
+    const { sql, api, watcherId, windowStart, windowEnd, completion } = await completeOnce({
+      extracted_data: { summary: 'v1' },
+    });
+
+    const tokenWithWindowId = await generateWindowToken(
+      {
+        watcher_id: watcherId,
+        window_start: windowStart,
+        window_end: windowEnd,
+        granularity: 'daily',
+        window_id: completion.window_id,
+        content_count: 0,
+        content_ids: [],
+      },
+      { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env
+    );
+
+    // Changed payload → head superseded (chain grows to 2), root id stable.
+    await api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: tokenWithWindowId,
+      extracted_data: { summary: 'v2 refreshed' },
+    });
+    const afterChange = await sql`
+      SELECT id, payload_data, supersedes_event_id FROM events
+      WHERE semantic_type = 'canvas_state'
+        AND (metadata->>'watcher_id')::bigint = ${watcherId}
+      ORDER BY id ASC
+    `;
+    expect(afterChange).toHaveLength(2);
+    expect(afterChange[0].supersedes_event_id).toBeNull();
+    expect(Number(afterChange[1].supersedes_event_id)).toBe(Number(afterChange[0].id));
+    expect((afterChange[1].payload_data as Record<string, unknown>).summary).toBe('v2 refreshed');
+
+    // Same payload replayed → no new chain member.
+    await api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: tokenWithWindowId,
+      extracted_data: { summary: 'v2 refreshed' },
+    });
+    const afterReplay = await sql`
+      SELECT id FROM events
+      WHERE semantic_type = 'canvas_state'
+        AND (metadata->>'watcher_id')::bigint = ${watcherId}
+    `;
+    expect(afterReplay).toHaveLength(2);
+  });
+
+  it('replace_existing supersedes the head, keeping the root id stable', async () => {
+    const { sql, api, watcherId, windowStart, windowEnd, workspace } = await completeOnce({
+      extracted_data: { summary: 'v1' },
+    });
+
+    const [root] = await sql`
+      SELECT id FROM events
+      WHERE semantic_type = 'canvas_state'
+        AND (metadata->>'watcher_id')::bigint = ${watcherId}
+        AND supersedes_event_id IS NULL
+    `;
+    const rootId = Number(root.id);
+
+    // A second completion for the SAME period with replace_existing supersedes.
+    const event = await sql`SELECT id FROM events WHERE organization_id = ${workspace.org.id} AND semantic_type <> 'canvas_state' LIMIT 1`;
+    const windowToken = await generateWindowToken(
+      {
+        watcher_id: watcherId,
+        window_start: windowStart,
+        window_end: windowEnd,
+        granularity: 'daily',
+        content_count: 1,
+        content_ids: [Number(event[0].id)],
+      },
+      { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env
+    );
+    await api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: windowToken,
+      extracted_data: { summary: 'v2' },
+      replace_existing: true,
+    });
+
+    // Still exactly one ROOT, with the SAME id.
+    const roots = await sql`
+      SELECT id FROM events
+      WHERE semantic_type = 'canvas_state'
+        AND (metadata->>'watcher_id')::bigint = ${watcherId}
+        AND supersedes_event_id IS NULL
+    `;
+    expect(roots).toHaveLength(1);
+    expect(Number(roots[0].id)).toBe(rootId);
+
+    // The HEAD is the superseding v2 event; it stamps root_event_id = rootId.
+    const head = await sql`
+      SELECT id, payload_data, (metadata->>'root_event_id')::bigint AS root_event_id
+      FROM events e
+      WHERE e.semantic_type = 'canvas_state'
+        AND (e.metadata->>'watcher_id')::bigint = ${watcherId}
+        AND NOT EXISTS (SELECT 1 FROM events n WHERE n.supersedes_event_id = e.id)
+    `;
+    expect(head).toHaveLength(1);
+    expect((head[0].payload_data as Record<string, unknown>).summary).toBe('v2');
+    expect(Number(head[0].root_event_id)).toBe(rootId);
+
+    // The read flip surfaces the HEAD payload via get_watcher.
+    const view = (await api.watchers.get(String(watcherId))) as {
+      windows: Array<{ extracted_data: Record<string, unknown> }>;
+    };
+    expect(view.windows[0].extracted_data.summary).toBe('v2');
+  });
+
+  it('superseded canvas states are masked from current_event_records', async () => {
+    const { sql, api, watcherId, windowStart, windowEnd, workspace } = await completeOnce({
+      extracted_data: { summary: 'v1' },
+    });
+    const event = await sql`SELECT id FROM events WHERE organization_id = ${workspace.org.id} AND semantic_type <> 'canvas_state' LIMIT 1`;
+    const windowToken = await generateWindowToken(
+      {
+        watcher_id: watcherId,
+        window_start: windowStart,
+        window_end: windowEnd,
+        granularity: 'daily',
+        content_count: 1,
+        content_ids: [Number(event[0].id)],
+      },
+      { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env
+    );
+    await api.watchers.completeWindow({
+      watcher_id: String(watcherId),
+      window_token: windowToken,
+      extracted_data: { summary: 'v2' },
+      replace_existing: true,
+    });
+
+    const current = await sql`
+      SELECT payload_data FROM current_event_records
+      WHERE semantic_type = 'canvas_state'
+        AND (metadata->>'watcher_id')::bigint = ${watcherId}
+    `;
+    // Only the HEAD (v2) is current; the superseded v1 root is masked.
+    expect(current).toHaveLength(1);
+    expect((current[0].payload_data as Record<string, unknown>).summary).toBe('v2');
+  });
+});

--- a/packages/server/src/__tests__/integration/watchers/canvas-backfill.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/canvas-backfill.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Canvas-on-events backfill contract.
+ *
+ * Locks the behavior of `backfillCanvasEvents` (the one-off fold of historical
+ * watcher_windows rows into canvas_state chains): a legacy window gets a chain
+ * ROOT event with its original created_at preserved, the denormalized
+ * watcher_window_events.watcher_id is filled, replays are no-ops (the partial
+ * unique index idx_canvas_chain_root is the lock), and dry-run writes nothing.
+ *
+ * window_id re-key onto event ids is intentionally NOT covered — it is deferred
+ * to Phase 3 because watcher_reactions/runs/watcher_window_events/
+ * event_classifications carry live FKs to watcher_windows(id) during the
+ * dual-write release (see backfill-canvas-events.ts).
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { DbClient } from '../../../db/client';
+import { backfillCanvasEvents } from '../../../watchers/backfill-canvas-events';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestAgent, createTestEntity, createTestEvent } from '../../setup/test-fixtures';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('canvas-on-events backfill', () => {
+  let workspace: TestWorkspace;
+  let watcherId: string;
+  let windowId: number;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    workspace = await TestWorkspace.create({ name: 'Canvas Backfill Org' });
+    const entity = await createTestEntity({
+      name: 'Backfill Entity',
+      organization_id: workspace.org.id,
+      created_by: workspace.users.owner.id,
+    });
+    const agent = await createTestAgent({
+      organizationId: workspace.org.id,
+      ownerUserId: workspace.users.owner.id,
+    });
+    const watcher = (await workspace.owner.watchers.create({
+      entity_id: entity.id,
+      slug: 'canvas-backfill-watcher',
+      name: 'Canvas Backfill Watcher',
+      prompt: 'Analyze inputs.',
+      agent_id: agent.agentId,
+    })) as { watcher_id: string };
+    watcherId = watcher.watcher_id;
+
+    // A legacy pre-canvas window (no canvas_state chain), created ~3 days ago.
+    const [win] = await getTestDb()`
+      INSERT INTO watcher_windows (
+        watcher_id, granularity, window_start, window_end,
+        extracted_data, content_analyzed, model_used, created_at
+      ) VALUES (
+        ${Number(watcherId)}, 'weekly',
+        ${new Date(Date.now() - 7 * DAY_MS)}, ${new Date()},
+        ${getTestDb().json({ summary: 'legacy window payload' })},
+        0, 'test-model', ${new Date(Date.now() - 3 * DAY_MS)}
+      )
+      RETURNING id
+    `;
+    windowId = Number(win.id);
+
+    // A link row with watcher_id unset, as pre-migration rows have.
+    const linkEvent = await createTestEvent({
+      entity_id: entity.id,
+      organization_id: workspace.org.id,
+      content: 'linked content',
+      occurred_at: new Date(),
+    });
+    await getTestDb()`
+      INSERT INTO watcher_window_events (window_id, event_id)
+      VALUES (${windowId}, ${linkEvent.id})
+      ON CONFLICT DO NOTHING
+    `;
+  });
+
+  it('dry-run reports the pending root but writes nothing', async () => {
+    const sql = getTestDb() as unknown as DbClient;
+    const dry = await backfillCanvasEvents({ db: sql, execute: false, log: () => {} });
+    expect(dry.windows).toBe(1);
+    expect(dry.rootsCreated).toBe(1);
+    expect(dry.rootsExisting).toBe(0);
+
+    const roots = await getTestDb()`
+      SELECT 1 FROM events
+      WHERE semantic_type = 'canvas_state'
+        AND (metadata->>'watcher_id')::bigint = ${Number(watcherId)}
+    `;
+    expect(roots).toHaveLength(0);
+
+    const [wwe] = await getTestDb()`
+      SELECT watcher_id FROM watcher_window_events WHERE window_id = ${windowId}
+    `;
+    expect(wwe.watcher_id).toBeNull();
+  });
+
+  it('creates the root (created_at preserved), fills watcher_id, and replays as a no-op', async () => {
+    const sql = getTestDb() as unknown as DbClient;
+
+    const r1 = await backfillCanvasEvents({ db: sql, execute: true, log: () => {} });
+    expect(r1.windows).toBe(1);
+    expect(r1.rootsCreated).toBe(1);
+    expect(r1.rootsExisting).toBe(0);
+    expect(r1.windowEventsWatcherIdFilled).toBe(1);
+
+    // (1) Root exists with the window's original created_at (~3 days ago, not NOW()).
+    const roots = await getTestDb()`
+      SELECT id, created_at, payload_data FROM events
+      WHERE semantic_type = 'canvas_state'
+        AND (metadata->>'watcher_id')::bigint = ${Number(watcherId)}
+        AND supersedes_event_id IS NULL
+    `;
+    expect(roots).toHaveLength(1);
+    expect(Date.now() - new Date(roots[0].created_at as string).getTime()).toBeGreaterThan(
+      2 * DAY_MS
+    );
+    expect((roots[0].payload_data as Record<string, unknown>).summary).toBe(
+      'legacy window payload'
+    );
+
+    // (2) Denormalized watcher_id filled; window_id untouched (FK-constrained,
+    // re-key deferred to Phase 3).
+    const [wwe] = await getTestDb()`
+      SELECT window_id, watcher_id FROM watcher_window_events WHERE window_id = ${windowId}
+    `;
+    expect(Number(wwe.watcher_id)).toBe(Number(watcherId));
+    expect(Number(wwe.window_id)).toBe(windowId);
+
+    // (3) Idempotent replay: rootsExisting increments, no duplicate root.
+    const r2 = await backfillCanvasEvents({ db: sql, execute: true, log: () => {} });
+    expect(r2.rootsCreated).toBe(0);
+    expect(r2.rootsExisting).toBe(1);
+
+    const rootsAfterReplay = await getTestDb()`
+      SELECT id FROM events
+      WHERE semantic_type = 'canvas_state'
+        AND (metadata->>'watcher_id')::bigint = ${Number(watcherId)}
+        AND supersedes_event_id IS NULL
+    `;
+    expect(rootsAfterReplay).toHaveLength(1);
+    expect(Number(rootsAfterReplay[0].id)).toBe(Number(roots[0].id));
+  });
+});

--- a/packages/server/src/__tests__/integration/watchers/feedback-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/feedback-contract.test.ts
@@ -10,6 +10,8 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { manageWatchers } from '../../../tools/admin/manage_watchers';
 import type { ToolContext } from '../../../tools/registry';
+import { insertEvent } from '../../../utils/insert-event';
+import { isUniqueViolation } from '../../../utils/pg-errors';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestAgent, createTestEntity } from '../../setup/test-fixtures';
 import { TestWorkspace } from '../../setup/test-mcp-client';
@@ -211,5 +213,206 @@ describe('watcher feedback contract', () => {
         ownerCtx(workspace)
       )
     ).rejects.toThrow(/not found|access/i);
+  });
+
+  // ============================================
+  // Materialized corrections (canvas-on-events)
+  // ============================================
+
+  /**
+   * Seed a canvas_state ROOT event for a window's period so submit_feedback has a
+   * chain HEAD to supersede. Mirrors what complete_window would have written.
+   */
+  async function seedCanvasRoot(
+    orgId: string,
+    wId: string,
+    winId: number,
+    payload: Record<string, unknown>
+  ): Promise<number> {
+    const sql = getTestDb();
+    const [win] = await sql`
+      SELECT granularity, window_start, window_end FROM watcher_windows WHERE id = ${winId}
+    `;
+    const [row] = await sql`
+      INSERT INTO events (
+        organization_id, origin_id, payload_type, payload_data, semantic_type,
+        metadata, occurred_at, created_at
+      ) VALUES (
+        ${orgId}, ${`canvas_seed_${winId}`}, 'json_template', ${sql.json(payload)}, 'canvas_state',
+        ${sql.json({
+          watcher_id: Number(wId),
+          granularity: win.granularity,
+          window_start: new Date(win.window_start as string).toISOString(),
+          window_end: new Date(win.window_end as string).toISOString(),
+        })},
+        ${new Date(win.window_end as string)}, NOW()
+      )
+      RETURNING id
+    `;
+    return Number(row.id);
+  }
+
+  it('materializes a superseding canvas_state with the correction applied AND still writes advisory events', async () => {
+    const seeded = await seedWatcher(workspace, `materialize-${Date.now()}`);
+    const rootId = await seedCanvasRoot(workspace.org.id, seeded.watcherId, seeded.windowId, {
+      problems: [{ name: 'A', severity: 'low' }],
+    });
+
+    const result = (await manageWatchers(
+      {
+        action: 'submit_feedback',
+        watcher_id: seeded.watcherId,
+        window_id: seeded.windowId,
+        corrections: [{ field_path: 'problems[0].severity', value: 'high' }],
+      } as never,
+      {} as never,
+      ownerCtx(workspace)
+    )) as { feedback_ids: number[] };
+
+    // Advisory correction event still written.
+    expect(result.feedback_ids).toHaveLength(1);
+    const advisory = await getTestDb()`
+      SELECT 1 FROM events
+      WHERE semantic_type = 'correction'
+        AND (metadata->>'watcher_id')::bigint = ${Number(seeded.watcherId)}
+        AND metadata->>'field_path' = 'problems[0].severity'
+    `;
+    expect(advisory).toHaveLength(1);
+
+    // A superseding canvas_state event exists with the correction applied.
+    const head = await getTestDb()`
+      SELECT e.id, e.payload_data, e.supersedes_event_id,
+             (e.metadata->>'root_event_id')::bigint AS root_event_id, e.created_by
+      FROM events e
+      WHERE e.semantic_type = 'canvas_state'
+        AND (e.metadata->>'watcher_id')::bigint = ${Number(seeded.watcherId)}
+        AND NOT EXISTS (SELECT 1 FROM events n WHERE n.supersedes_event_id = e.id)
+    `;
+    expect(head).toHaveLength(1);
+    expect(Number(head[0].supersedes_event_id)).toBe(rootId);
+    expect(Number(head[0].root_event_id)).toBe(rootId);
+    expect(head[0].created_by).toBe(workspace.users.owner.id);
+    const problems = (head[0].payload_data as { problems: Array<{ severity: string }> }).problems;
+    expect(problems[0].severity).toBe('high');
+  });
+
+  it('concurrent supersede of the same head loses with 409', async () => {
+    const seeded = await seedWatcher(workspace, `concurrent-${Date.now()}`);
+    const rootId = await seedCanvasRoot(workspace.org.id, seeded.watcherId, seeded.windowId, {
+      problems: [{ name: 'A', severity: 'low' }],
+    });
+
+    // First correction supersedes the root → becomes the head.
+    await manageWatchers(
+      {
+        action: 'submit_feedback',
+        watcher_id: seeded.watcherId,
+        window_id: seeded.windowId,
+        corrections: [{ field_path: 'problems[0].severity', value: 'high' }],
+      } as never,
+      {} as never,
+      ownerCtx(workspace)
+    );
+
+    // Simulate a second replica that read the SAME (now-stale) root as its head
+    // and tries to supersede it concurrently. The partial unique index
+    // idx_events_superseded_by rejects the second superseder of the same target
+    // with 23505; the write path maps it to a clean 409 (mirrors save_content.ts).
+    let raised: unknown;
+    try {
+      await insertEvent(
+        {
+          entityIds: [],
+          organizationId: workspace.org.id,
+          originId: `canvas_conflict_${Date.now()}`,
+          payloadType: 'json_template',
+          payloadData: { problems: [{ name: 'A', severity: 'critical' }] },
+          semanticType: 'canvas_state',
+          metadata: { watcher_id: Number(seeded.watcherId), root_event_id: rootId },
+          supersedesEventId: rootId,
+        },
+        { sql: getTestDb() as never }
+      );
+    } catch (err) {
+      raised = err;
+    }
+    expect(isUniqueViolation(raised, 'idx_events_superseded_by')).toBe(true);
+
+    // Still exactly one HEAD (the first correction).
+    const heads = await getTestDb()`
+      SELECT e.id FROM events e
+      WHERE e.semantic_type = 'canvas_state'
+        AND (e.metadata->>'watcher_id')::bigint = ${Number(seeded.watcherId)}
+        AND NOT EXISTS (SELECT 1 FROM events n WHERE n.supersedes_event_id = e.id)
+    `;
+    expect(heads).toHaveLength(1);
+  });
+
+  it('a prototype-polluting field_path is inert (advisory recorded, payload and prototypes untouched)', async () => {
+    const seeded = await seedWatcher(workspace, `pollute-${Date.now()}`);
+    await seedCanvasRoot(workspace.org.id, seeded.watcherId, seeded.windowId, {
+      summary: 'clean',
+    });
+
+    // field_path is caller input — a path through the prototype chain must not
+    // assign onto Object.prototype (CodeQL js/prototype-polluting-assignment)
+    // and must not become an own key of the payload either.
+    const result = (await manageWatchers(
+      {
+        action: 'submit_feedback',
+        watcher_id: seeded.watcherId,
+        window_id: seeded.windowId,
+        corrections: [
+          { field_path: '__proto__.polluted', value: 'evil' },
+          { field_path: 'constructor.prototype.polluted2', value: 'evil' },
+        ],
+      } as never,
+      {} as never,
+      ownerCtx(workspace)
+    )) as { feedback_ids: number[] };
+
+    // Advisory events still record the intent (they're inert data, not applied).
+    expect(result.feedback_ids).toHaveLength(2);
+
+    // No global prototype pollution.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(({} as Record<string, unknown>).polluted2).toBeUndefined();
+
+    // The head payload is unchanged: the forbidden paths were no-ops, so no
+    // superseding canvas_state was needed OR the head has no polluted keys.
+    const head = await getTestDb()`
+      SELECT e.payload_data FROM events e
+      WHERE e.semantic_type = 'canvas_state'
+        AND (e.metadata->>'watcher_id')::bigint = ${Number(seeded.watcherId)}
+        AND NOT EXISTS (SELECT 1 FROM events n WHERE n.supersedes_event_id = e.id)
+    `;
+    expect(head).toHaveLength(1);
+    const payload = head[0].payload_data as Record<string, unknown>;
+    expect(payload.summary).toBe('clean');
+    expect(Object.keys(payload)).not.toContain('polluted');
+    expect(Object.keys(payload)).not.toContain('polluted2');
+  });
+
+  it('skips materialization gracefully when the window has no canvas chain yet', async () => {
+    const seeded = await seedWatcher(workspace, `nochain-${Date.now()}`);
+    // No canvas_state seeded → materialization must skip, advisory event still written.
+    const result = (await manageWatchers(
+      {
+        action: 'submit_feedback',
+        watcher_id: seeded.watcherId,
+        window_id: seeded.windowId,
+        corrections: [{ field_path: 'problems[0].severity', value: 'high' }],
+      } as never,
+      {} as never,
+      ownerCtx(workspace)
+    )) as { feedback_ids: number[] };
+    expect(result.feedback_ids).toHaveLength(1);
+
+    const canvas = await getTestDb()`
+      SELECT 1 FROM events
+      WHERE semantic_type = 'canvas_state'
+        AND (metadata->>'watcher_id')::bigint = ${Number(seeded.watcherId)}
+    `;
+    expect(canvas).toHaveLength(0);
   });
 });

--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -229,16 +229,22 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
       expect(Number(row.parent_id)).toBe(parentEntityId);
     }
 
-    // The promoted entities are of the configured type.
+    // The promoted entities are of the configured type. complete_window also
+    // creates the per-watcher canvas entity as a child of the same parent
+    // (canvas-on-events, metadata.source='watcher_canvas'), so scope the
+    // promoted-type assertion to the non-canvas children.
     const childTypes = await sql`
-      SELECT et.slug
+      SELECT et.slug, e.metadata->>'source' AS source
       FROM entities e
       JOIN entity_types et ON et.id = e.entity_type_id
       WHERE e.parent_id = ${parentEntityId}
         AND e.organization_id = ${workspace.org.id}
     `;
-    expect(childTypes).toHaveLength(2);
-    expect(childTypes.every((r) => String(r.slug) === 'topic')).toBe(true);
+    expect(childTypes).toHaveLength(3);
+    const promoted = childTypes.filter((r) => r.source !== 'watcher_canvas');
+    expect(promoted).toHaveLength(2);
+    expect(promoted.every((r) => String(r.slug) === 'topic')).toBe(true);
+    expect(childTypes.filter((r) => r.source === 'watcher_canvas')).toHaveLength(1);
 
     // Origin provenance lives on the entity itself — each promoted child carries
     // its window_id / stable_key in metadata (no separate observation event).
@@ -299,12 +305,21 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     );
     expect(entitiesAfterSecond).toHaveLength(2);
 
-    // No entity-count growth under the parent.
+    // No entity-count growth under the parent: 2 promoted + exactly 1 canvas
+    // entity. The replay must reuse the canvas identity claim (namespace
+    // 'watcher_canvas'), never mint a second canvas entity.
     const childCount = await sql`
       SELECT COUNT(*)::int AS c FROM entities
       WHERE parent_id = ${parentEntityId} AND organization_id = ${workspace.org.id}
     `;
-    expect(Number(childCount[0].c)).toBe(2);
+    expect(Number(childCount[0].c)).toBe(3);
+    const canvasCount = await sql`
+      SELECT COUNT(*)::int AS c FROM entities
+      WHERE parent_id = ${parentEntityId}
+        AND organization_id = ${workspace.org.id}
+        AND metadata->>'source' = 'watcher_canvas'
+    `;
+    expect(Number(canvasCount[0].c)).toBe(1);
   });
 
   it('syncs extracted fields into entities and respects a human-owned field on re-run, queuing an approval', async () => {

--- a/packages/server/src/notifications/service.ts
+++ b/packages/server/src/notifications/service.ts
@@ -26,6 +26,12 @@ interface CreateNotificationParams {
    * in-app inbox entry still uses title/body.
    */
   card?: CardElement | null;
+  /**
+   * Optional entity ids to anchor the notification event to (e.g. a watcher's
+   * canvas entity, so the notification threads under the canvas). Stamped onto
+   * the notification event's `entity_ids`.
+   */
+  entityIds?: number[];
 }
 
 /**
@@ -157,13 +163,19 @@ export async function createNotificationForUsers(
   if (userIds.length === 0) return;
   const sql = getDb();
 
+  // fetch_types:false safe: entity_ids is a `{n,...}` literal (or NULL) cast to
+  // bigint[] — never a raw JS array bind. Same pattern as insert-event.ts.
+  const entityIdsValue =
+    params.entityIds && params.entityIds.length > 0 ? `{${params.entityIds.join(',')}}` : null;
+
   await sql.begin(async (tx) => {
     const inserted = (await tx`
       INSERT INTO events
-        (organization_id, title, payload_text, payload_type, semantic_type,
+        (organization_id, entity_ids, title, payload_text, payload_type, semantic_type,
          occurred_at, metadata)
       VALUES (
         ${params.organizationId},
+        ${entityIdsValue}::bigint[],
         ${params.title},
         ${params.body ?? null},
         'text',

--- a/packages/server/src/tools/admin/manage_watchers/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_watchers/complete-window.ts
@@ -16,6 +16,9 @@ import {
   promoteKeyedEntities,
 } from '../../../utils/promote-keyed-entities';
 import { proposeEntityFieldChange } from '../entity-field-approval';
+import { ensureCanvasEntity, findCanvasHead } from '../../../utils/canvas-events';
+import { insertEvent, stableJson } from '../../../utils/insert-event';
+import { isUniqueViolation } from '../../../utils/pg-errors';
 import { computeStableKeys } from '../../../utils/stable-keys';
 import { deriveWatcherExtractionSchema } from '../../../utils/watcher-extraction-schema';
 import { trackWatcherReaction } from '../../../utils/watcher-reactions';
@@ -480,6 +483,132 @@ export async function handleCompleteWindow(
     }
 
     // ============================================
+    // STEP 7.5: Canvas-on-events write (dual-write with watcher_windows above).
+    //
+    // The canvas is a supersede chain of `semantic_type='canvas_state'` events.
+    // The chain ROOT is the window identity; a fresh completion inserts a root,
+    // and `replace_existing` supersedes the current head (found by anti-join)
+    // instead of creating a second root — so the root event id NEVER changes
+    // (fixes the DELETE+reinsert-with-new-id dangling-reference bug the legacy
+    // watcher_windows path has). Concurrent root inserts race on the partial
+    // unique index idx_canvas_chain_root → 23505 → 409, mirroring the legacy
+    // idx_watcher_windows_unique_period handling above. Idempotent replays that
+    // find a non-empty head are no-ops. Runs on `tx` so the entity + identity +
+    // event writes commit atomically with the window.
+    // ============================================
+    const canvasEntityId = await ensureCanvasEntity({
+      tx,
+      watcherId: Number(watcherId),
+      organizationId: watcherOrgId,
+      parentEntityId,
+      createdBy: watcherCreatedBy,
+    });
+    const canvasEntityIds = canvasEntityId != null ? [canvasEntityId] : [];
+    // events.client_id has an FK to oauth_clients — unlike the legacy
+    // watcher_windows.client_id, which stores PAT/device ids verbatim. Inside
+    // this transaction insertEvent's client-id-FK retry cannot engage (the
+    // first failed INSERT aborts the tx), so resolve validity up front and
+    // drop unknown ids to NULL rather than aborting the whole completion.
+    let canvasClientId: string | null = provenanceClientId;
+    if (canvasClientId) {
+      const knownClient = await tx`
+        SELECT 1 FROM oauth_clients WHERE id = ${canvasClientId} LIMIT 1
+      `;
+      if (knownClient.length === 0) canvasClientId = null;
+    }
+    const canvasPeriodMeta = {
+      watcher_id: Number(watcherId),
+      granularity: timeGranularity,
+      window_start,
+      window_end,
+      content_analyzed: batchContentIds.length,
+      version_id: resolvedVersionId,
+    };
+
+    const existingHead = await findCanvasHead(tx, {
+      watcherId: Number(watcherId),
+      granularity: timeGranularity,
+      windowStart: window_start,
+    });
+
+    // The tokenWindowId branch above refreshes the legacy row's extracted_data
+    // unconditionally. Reads prefer the canvas head, so a head that exists with
+    // DIFFERENT data must be superseded too or the refresh is invisible (stale
+    // head). Same-payload replays stay no-ops (stableJson is key-order
+    // independent, matching how jsonb normalizes).
+    const headPayloadChanged =
+      existingHead != null &&
+      stableJson(existingHead.payloadData) !== stableJson(cleanedExtractedData);
+
+    if (existingHead && !args.replace_existing && !(tokenWindowId && headPayloadChanged)) {
+      // Idempotent replay / concurrent completion that already produced a head:
+      // never create a second root and never overwrite a successful head.
+      // (The legacy branch above already refreshed provenance where allowed.)
+    } else if (existingHead && (args.replace_existing || (tokenWindowId && headPayloadChanged))) {
+      // Supersede the current head, copying the root's period metadata. Loser of
+      // a concurrent supersede hits idx_events_superseded_by → 23505 → 409.
+      try {
+        await insertEvent(
+          {
+            entityIds: canvasEntityIds,
+            organizationId: watcherOrgId,
+            originId: `canvas_${crypto.randomUUID()}`,
+            payloadType: 'json_template',
+            payloadData: cleanedExtractedData,
+            semanticType: 'canvas_state',
+            metadata: { ...canvasPeriodMeta, root_event_id: existingHead.rootEventId },
+            runId: watcherRunId,
+            occurredAt: window_end,
+            createdBy: watcherCreatedBy,
+            clientId: canvasClientId,
+            supersedesEventId: existingHead.id,
+          },
+          { sql: tx }
+        );
+      } catch (err) {
+        if (isUniqueViolation(err, 'idx_events_superseded_by')) {
+          throw new ToolUserError(
+            `Canvas for watcher ${watcherId} period ${window_start} was concurrently updated. Retry with the latest state.`,
+            409
+          );
+        }
+        throw err;
+      }
+    } else {
+      // No chain yet → insert the ROOT. A root omits metadata.root_event_id (its
+      // id isn't known until after insert, and metadata is immutable); readers
+      // treat a missing root_event_id as "self", so the root id IS the window id.
+      // Superseders below stamp root_event_id explicitly for zero-traversal reads.
+      try {
+        await insertEvent(
+          {
+            entityIds: canvasEntityIds,
+            organizationId: watcherOrgId,
+            originId: `canvas_${crypto.randomUUID()}`,
+            payloadType: 'json_template',
+            payloadData: cleanedExtractedData,
+            semanticType: 'canvas_state',
+            metadata: canvasPeriodMeta,
+            runId: watcherRunId,
+            occurredAt: window_end,
+            createdBy: watcherCreatedBy,
+            clientId: canvasClientId,
+          },
+          { sql: tx }
+        );
+      } catch (err) {
+        if (isUniqueViolation(err, 'idx_canvas_chain_root')) {
+          throw new ToolUserError(
+            `Window already exists for watcher ${watcherId} for period ${window_start} to ${window_end}. ` +
+              'Use replace_existing: true to replace it, or query a different time period.',
+            409
+          );
+        }
+        throw err;
+      }
+    }
+
+    // ============================================
     // STEP 8: Link content to window (bulk INSERT)
     // Build VALUES clause for bulk insert
     // ============================================
@@ -489,14 +618,14 @@ export async function handleCompleteWindow(
       const insertParams: unknown[] = [];
       let pIdx = 1;
       for (const contentId of batchContentIds) {
-        valuePlaceholders.push(`($${pIdx}, $${pIdx + 1}, $${pIdx + 2}, NOW())`);
-        insertParams.push(nextWindowEventId, windowId, contentId);
+        valuePlaceholders.push(`($${pIdx}, $${pIdx + 1}, $${pIdx + 2}, $${pIdx + 3}, NOW())`);
+        insertParams.push(nextWindowEventId, windowId, contentId, Number(watcherId));
         nextWindowEventId += 1;
-        pIdx += 3;
+        pIdx += 4;
       }
 
       await tx.unsafe(
-        `INSERT INTO watcher_window_events (id, window_id, event_id, created_at)
+        `INSERT INTO watcher_window_events (id, window_id, event_id, watcher_id, created_at)
          VALUES ${valuePlaceholders.join(', ')}
          ON CONFLICT DO NOTHING`,
         insertParams

--- a/packages/server/src/tools/admin/manage_watchers/feedback.ts
+++ b/packages/server/src/tools/admin/manage_watchers/feedback.ts
@@ -3,8 +3,13 @@
  *   submit_feedback, get_feedback, list_promoted
  */
 
-import { getDb } from '../../../db/client';
+import { getDb, parsePgNumberArray } from '../../../db/client';
 import { parseJsonObject } from '@lobu/core';
+import { ensureCanvasEntity, findCanvasHead } from '../../../utils/canvas-events';
+import { ToolUserError } from '../../../utils/errors';
+import { insertEvent } from '../../../utils/insert-event';
+import { isUniqueViolation } from '../../../utils/pg-errors';
+import logger from '../../../utils/logger';
 import type { ToolContext } from '../../registry';
 import type { ManageWatchersArgs, ManageWatchersResult } from '../manage_watchers';
 
@@ -14,6 +19,103 @@ type CorrectionInput = {
   value?: unknown;
   note?: string;
 };
+
+/**
+ * Segments that would let a caller-supplied field_path walk or assign onto the
+ * prototype chain instead of the payload's own data (prototype pollution).
+ * field_path is user input — a path like `__proto__.polluted` must be a no-op.
+ */
+const FORBIDDEN_PATH_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Parse a correction field_path into path segments, supporting dot notation and
+ * array-index brackets: `problems[0].severity` → ['problems', 0, 'severity'].
+ * Returns null when any segment targets the prototype chain — callers treat it
+ * as an inapplicable path (the advisory event still records the intent).
+ */
+function parseFieldPath(path: string): (string | number)[] | null {
+  const segments: (string | number)[] = [];
+  for (const part of path.split('.')) {
+    const match = part.match(/^([^[\]]*)((\[\d+\])*)$/);
+    if (!match) {
+      segments.push(part);
+      continue;
+    }
+    const [, key, indices] = match;
+    if (key) segments.push(key);
+    if (indices) {
+      for (const idx of indices.matchAll(/\[(\d+)\]/g)) {
+        segments.push(Number(idx[1]));
+      }
+    }
+  }
+  if (segments.some((s) => typeof s === 'string' && FORBIDDEN_PATH_SEGMENTS.has(s))) {
+    return null;
+  }
+  return segments;
+}
+
+/**
+ * Apply a single set/remove/add correction to `data` in place (mutates a copy
+ * the caller owns). Mirrors the advisory correction semantics:
+ *   - set:    write `value` at the path (creating intermediate objects/arrays).
+ *   - remove: delete the array element / object key at the path.
+ *   - add:    push `value` onto the array at the path (creating it if absent).
+ * Best-effort: a path that can't be traversed is a no-op (the advisory event
+ * still records the intent).
+ */
+function applyCorrectionToData(
+  data: Record<string, unknown>,
+  fieldPath: string,
+  mutation: 'set' | 'remove' | 'add',
+  value: unknown
+): void {
+  const segments = parseFieldPath(fieldPath);
+  if (segments == null || segments.length === 0) return;
+
+  // Walk to the parent container of the final segment, creating intermediates
+  // for set/add (never for remove — removing a missing path is a no-op). Only
+  // OWN properties are traversed — inherited (prototype) values are treated as
+  // absent, so the walk can never step onto the prototype chain.
+  let parent: unknown = data;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    const next = segments[i + 1];
+    if (parent == null || typeof parent !== 'object') return;
+    const container = parent as Record<string | number, unknown>;
+    if (!Object.hasOwn(container, seg) || container[seg] == null) {
+      if (mutation === 'remove') return;
+      container[seg] = typeof next === 'number' ? [] : {};
+    }
+    parent = container[seg];
+  }
+  if (parent == null || typeof parent !== 'object') return;
+
+  const last = segments[segments.length - 1];
+  const container = parent as Record<string | number, unknown>;
+
+  if (mutation === 'remove') {
+    if (Array.isArray(container) && typeof last === 'number') {
+      container.splice(last, 1);
+    } else {
+      delete container[last];
+    }
+    return;
+  }
+  if (mutation === 'add') {
+    const target = container[last];
+    if (Array.isArray(target)) {
+      target.push(value);
+    } else if (target == null) {
+      container[last] = [value];
+    } else {
+      container[last] = [target, value];
+    }
+    return;
+  }
+  // set
+  container[last] = value;
+}
 
 // ============================================
 // handleSubmitFeedback
@@ -52,7 +154,8 @@ export async function handleSubmitFeedback(
   // Scope to the caller's current org so a member of org A can't write
   // feedback against a watcher in org B by passing its watcher_id.
   const windowCheck = await sql`
-    SELECT ww.id, w.organization_id
+    SELECT ww.id, ww.granularity, ww.window_start, ww.window_end,
+           w.organization_id, w.created_by, w.entity_ids
     FROM watcher_windows ww
     JOIN watchers w ON ww.watcher_id = w.id
     WHERE ww.id = ${args.window_id}
@@ -63,12 +166,23 @@ export async function handleSubmitFeedback(
     throw new Error(`Window ${args.window_id} not found for watcher ${watcherId}`);
   }
   const organizationId = windowCheck[0].organization_id as string;
+  const windowGranularity = windowCheck[0].granularity as string;
+  const windowStart = new Date(windowCheck[0].window_start as string).toISOString();
+  const windowEnd = new Date(windowCheck[0].window_end as string).toISOString();
 
   // Correction-events (P1): every submit emits a correction event directly to the events spine
   // (semantic_type='correction'). The id is allocated from the retired table's sequence
   // (watcher_window_field_feedback_id_seq, kept alive via ALTER SEQUENCE OWNED BY NONE) so
   // origin_id stays 'wwff_<id>' and the reader's substring id-recovery + ids remain stable.
   // One transaction so a partial failure never leaks half-applied corrections.
+  // Advisory correction events and canvas materialization commit in ONE
+  // transaction so a surfaced 409 rolls back BOTH: the caller sees a clean
+  // conflict, retries, and the advisory events are recorded exactly once
+  // (committing them before a 409 would double-record on retry). Materialization
+  // itself runs in a SAVEPOINT: any non-conflict failure rolls back only the
+  // canvas write and the advisory events still commit (materialization is
+  // additive; the advisory 'correction' events keep feeding
+  // getRecentFeedbackSummary into future runs regardless).
   const feedbackIds = await sql.begin(async (tx) => {
     const ids: number[] = [];
     for (const c of corrections) {
@@ -98,6 +212,87 @@ export async function handleSubmitFeedback(
       `;
       ids.push(Number(row.id));
     }
+
+    // Materialize the corrections onto the canvas so the user sees their edit
+    // immediately: apply the set/remove/add mutations to the current chain
+    // HEAD's payload_data and insert ONE superseding canvas_state event
+    // authored by the user. If no chain exists yet (pre-backfill window), skip
+    // gracefully. The concurrent-edit loser hits idx_events_superseded_by →
+    // 409 (same handling as save_content.ts).
+    try {
+      await tx.savepoint(async (sp) => {
+        const spSql = sp as unknown as typeof tx;
+        const head = await findCanvasHead(spSql, {
+          watcherId,
+          granularity: windowGranularity,
+          windowStart,
+        });
+        if (!head) {
+          logger.info(
+            { watcherId, windowId: args.window_id },
+            '[submit_feedback] no canvas_state chain yet — skipping materialization'
+          );
+          return;
+        }
+
+        const nextPayload = structuredClone(head.payloadData);
+        for (const c of corrections) {
+          applyCorrectionToData(nextPayload, c.field_path, c.mutation ?? 'set', c.value);
+        }
+
+        const parentEntityId = parsePgNumberArray(windowCheck[0].entity_ids)[0] ?? null;
+        const canvasEntityId = await ensureCanvasEntity({
+          tx: spSql,
+          watcherId,
+          organizationId,
+          parentEntityId,
+          createdBy: (windowCheck[0].created_by as string | null) ?? ctx.userId ?? null,
+        });
+
+        try {
+          await insertEvent(
+            {
+              entityIds: canvasEntityId != null ? [canvasEntityId] : [],
+              organizationId,
+              originId: `canvas_${crypto.randomUUID()}`,
+              payloadType: 'json_template',
+              payloadData: nextPayload,
+              semanticType: 'canvas_state',
+              metadata: {
+                watcher_id: watcherId,
+                granularity: windowGranularity,
+                window_start: windowStart,
+                window_end: windowEnd,
+                root_event_id: head.rootEventId,
+                correction: true,
+              },
+              occurredAt: windowEnd,
+              createdBy: ctx.userId,
+              supersedesEventId: head.id,
+            },
+            { sql: spSql }
+          );
+        } catch (err) {
+          if (isUniqueViolation(err, 'idx_events_superseded_by')) {
+            throw new ToolUserError(
+              `Canvas for watcher ${watcherId} was concurrently updated. Reload the latest state and retry.`,
+              409
+            );
+          }
+          throw err;
+        }
+      });
+    } catch (err) {
+      // 409 (concurrent edit) aborts the whole transaction — advisory events
+      // included — so the caller's retry re-records exactly once. Anything else
+      // rolled back to the savepoint only: keep the advisory events.
+      if (err instanceof ToolUserError) throw err;
+      logger.warn(
+        { err, watcherId, windowId: args.window_id },
+        '[submit_feedback] canvas materialization failed (advisory events kept)'
+      );
+    }
+
     return ids;
   });
 

--- a/packages/server/src/tools/admin/notify.ts
+++ b/packages/server/src/tools/admin/notify.ts
@@ -10,6 +10,7 @@
 import { type Static, Type } from '@sinclair/typebox';
 import type { CardElement } from 'chat';
 import { getDb, pgTextArray } from '../../db/client';
+import { WATCHER_CANVAS_NAMESPACE } from '../../utils/canvas-events';
 import { emit } from '../../events/emitter';
 import { createNotificationForUsers } from '../../notifications/service';
 import logger from '../../utils/logger';
@@ -127,6 +128,37 @@ async function handleSend(
     body = body ? `${body}\n\n${dataStr}` : dataStr;
   }
 
+  // Anchor watcher-sourced notifications to the watcher's canvas entity so they
+  // thread under the canvas. watcher_source is caller input, so validate the
+  // (watcher_id, window_id) pair against the caller's org before anchoring —
+  // otherwise any org member could thread a notification under an unrelated
+  // watcher's canvas. Resolve the lazy canvas entity via its entity_identities
+  // claim; a mismatched pair or a watcher with no canvas yet anchors nothing.
+  let canvasEntityIds: number[] | undefined;
+  if (args.watcher_source) {
+    const rows = await getDb()<{ entity_id: number | string }>`
+      SELECT ei.entity_id
+      FROM entity_identities ei
+      JOIN watchers w
+        ON w.id = ${args.watcher_source.watcher_id}
+       AND w.organization_id = ${ctx.organizationId}
+      WHERE ei.organization_id = ${ctx.organizationId}
+        AND ei.namespace = ${WATCHER_CANVAS_NAMESPACE}
+        AND ei.identifier = ${String(args.watcher_source.watcher_id)}
+        AND ei.deleted_at IS NULL
+        AND (
+          ${args.watcher_source.window_id ?? null}::bigint IS NULL
+          OR EXISTS (
+            SELECT 1 FROM watcher_windows ww
+            WHERE ww.id = ${args.watcher_source.window_id ?? null}
+              AND ww.watcher_id = w.id
+          )
+        )
+      LIMIT 1
+    `;
+    if (rows.length > 0) canvasEntityIds = [Number(rows[0].entity_id)];
+  }
+
   await createNotificationForUsers(userIds, {
     organizationId: ctx.organizationId,
     type: 'agent_message',
@@ -135,6 +167,7 @@ async function handleSend(
     resourceUrl: args.resource_url ?? null,
     connectionId: args.connection_id ?? null,
     card: (args.card as CardElement | undefined) ?? null,
+    entityIds: canvasEntityIds,
   });
 
   emit(ctx.organizationId, { keys: ['notifications', 'notifications-unread-count'] });

--- a/packages/server/src/utils/canvas-events.ts
+++ b/packages/server/src/utils/canvas-events.ts
@@ -1,0 +1,229 @@
+/**
+ * Canvas-on-events helpers.
+ *
+ * A watcher "window" (canvas) is a supersede chain of `semantic_type='canvas_state'`
+ * events. The chain ROOT (supersedes_event_id IS NULL) is the window identity —
+ * its event id is the `window_id` everywhere. Human edits and materialized
+ * corrections supersede the current head, copying the root's period metadata so
+ * period queries hit any chain member consistently.
+ *
+ * Identity: a lazy per-watcher "canvas" entity claimed via `entity_identities`
+ * (namespace `watcher_canvas`, identifier = `<watcherId>`), anchoring the chain
+ * via `entity_ids`. The partial unique index `idx_entity_identities_live_unique`
+ * (org, namespace, identifier WHERE deleted_at IS NULL) is the multi-replica lock.
+ *
+ * Invariants (enforced by DB indexes, not in-memory state):
+ *   - One root per period: `idx_canvas_chain_root` (unique, partial) → 23505 on
+ *     a concurrent second root, which callers map to a 409.
+ *   - One superseder per event: `idx_events_superseded_by` (unique, partial) →
+ *     23505 on a concurrent supersede of the same head, mapped to a 409.
+ *   - Head = chain member with no superseder (NOT EXISTS anti-join; derived).
+ *
+ * `fetch_types: false`: never bind a raw JS array — the only array here is
+ * entity_ids, formatted as a `{n}` literal cast to bigint[] exactly like
+ * insert-event.ts does.
+ */
+
+import type { DbClient } from '../db/client';
+
+/** Namespace for the per-watcher canvas identity claim in `entity_identities`. */
+export const WATCHER_CANVAS_NAMESPACE = 'watcher_canvas';
+
+/** Metadata keys copied onto every chain member so period queries are consistent. */
+export interface CanvasPeriodMeta {
+  watcher_id: number;
+  granularity: string;
+  window_start: string;
+  window_end: string;
+}
+
+/**
+ * Resolve a live `user(id)` to attribute the canvas entity to. Prefers the
+ * caller-supplied id (the watcher's creator — already a live user); otherwise
+ * falls back to an org owner/admin. Returns null when the org has no member.
+ * Mirrors promote-keyed-entities' resolveCreator.
+ */
+async function resolveCanvasCreator(
+  tx: DbClient,
+  organizationId: string,
+  createdBy: string | null | undefined
+): Promise<string | null> {
+  if (createdBy && createdBy.trim().length > 0) return createdBy;
+  const rows = await tx<{ userId: string }>`
+    SELECT "userId"
+    FROM "member"
+    WHERE "organizationId" = ${organizationId}
+    ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END,
+             "createdAt" ASC
+    LIMIT 1
+  `;
+  return rows.length > 0 ? rows[0].userId : null;
+}
+
+/**
+ * Ensure the lazy per-watcher canvas entity exists and return its id. Idempotent
+ * and multi-replica-safe via the `watcher_canvas` live-unique identity claim:
+ * the reuse fast-path resolves an existing claim; the create path tolerates a
+ * concurrent claim (ON CONFLICT DO NOTHING) and resolves the winner.
+ *
+ * The canvas entity is a child of the watcher's bound entity (`parentEntityId`)
+ * when present, else a root entity. It uses the same `canvas` entity type as
+ * other lazily-created system entities would; it falls back to no type binding
+ * only if no `canvas` type is registered (entity_type_id is NOT NULL, so we pick
+ * a sensible default). Runs on the caller's transaction handle so the entity +
+ * identity writes commit atomically with the canvas event.
+ */
+export async function ensureCanvasEntity(params: {
+  tx: DbClient;
+  watcherId: number;
+  organizationId: string;
+  parentEntityId: number | null;
+  createdBy: string | null | undefined;
+}): Promise<number | null> {
+  const { tx, watcherId, organizationId, parentEntityId } = params;
+  const identifier = String(watcherId);
+
+  // 1. Existing claim → reuse (idempotent fast path).
+  const existing = await tx<{ entity_id: number | string }>`
+    SELECT ei.entity_id
+    FROM entity_identities ei
+    JOIN entities e ON e.id = ei.entity_id
+    WHERE ei.organization_id = ${organizationId}
+      AND ei.namespace = ${WATCHER_CANVAS_NAMESPACE}
+      AND ei.identifier = ${identifier}
+      AND ei.deleted_at IS NULL
+      AND e.deleted_at IS NULL
+    LIMIT 1
+  `;
+  if (existing.length > 0) return Number(existing[0].entity_id);
+
+  const createdBy = await resolveCanvasCreator(tx, organizationId, params.createdBy);
+  if (!createdBy) {
+    // entities.created_by is NOT NULL; without an attributable member we cannot
+    // create the canvas entity. The canvas event still gets written (unanchored).
+    return null;
+  }
+
+  // Resolve an entity type to bind to (entities.entity_type_id is NOT NULL).
+  // Prefer a `canvas` type (org-first, then public via organization.visibility,
+  // skipping view-backed derived types — same precedence as createEntity);
+  // otherwise fall back to any stored type in the org so the canvas entity can
+  // still be created and anchor the chain.
+  const typeRows = await tx<{ id: number | string; backing_sql: string | null }>`
+    SELECT et.id, et.backing_sql
+    FROM entity_types et
+    LEFT JOIN organization o ON o.id = et.organization_id
+    WHERE et.slug = 'canvas'
+      AND et.deleted_at IS NULL
+      AND (et.organization_id = ${organizationId} OR o.visibility = 'public')
+    ORDER BY (et.organization_id = ${organizationId}) DESC, et.id ASC
+    LIMIT 1
+  `;
+  let entityTypeId: number | null =
+    typeRows.length > 0 && !typeRows[0].backing_sql ? Number(typeRows[0].id) : null;
+  if (entityTypeId == null) {
+    const anyType = await tx<{ id: number | string }>`
+      SELECT et.id
+      FROM entity_types et
+      WHERE et.organization_id = ${organizationId}
+        AND et.deleted_at IS NULL
+        AND et.backing_sql IS NULL
+      ORDER BY et.id ASC
+      LIMIT 1
+    `;
+    if (anyType.length === 0) return null;
+    entityTypeId = Number(anyType[0].id);
+  }
+
+  // 2. Create the entity (sequence-allocated id — multi-replica safe). Slug is
+  //    unique per (org, parent); a collision here is astronomically unlikely
+  //    (one canvas per watcher) but tolerate it by suffixing the watcher id.
+  const baseSlug = `watcher-canvas-${watcherId}`;
+  const inserted = await tx<{ id: number | string }>`
+    INSERT INTO entities (
+      organization_id, entity_type_id, name, slug, parent_id, metadata,
+      created_by, created_at, updated_at
+    ) VALUES (
+      ${organizationId}, ${entityTypeId}, ${`Canvas · watcher ${watcherId}`}, ${baseSlug},
+      ${parentEntityId}, ${tx.json({ watcher_id: watcherId, source: 'watcher_canvas' })},
+      ${createdBy}, current_timestamp, current_timestamp
+    )
+    ON CONFLICT DO NOTHING
+    RETURNING id
+  `;
+
+  let entityId: number | null = inserted.length > 0 ? Number(inserted[0].id) : null;
+  if (entityId == null) {
+    // Slug collision (pre-existing canvas entity for this watcher). Resolve it.
+    const bySlug = await tx<{ id: number | string }>`
+      SELECT id FROM entities
+      WHERE organization_id = ${organizationId}
+        AND COALESCE(parent_id, 0) = COALESCE(${parentEntityId}::bigint, 0)
+        AND slug = ${baseSlug}
+      LIMIT 1
+    `;
+    if (bySlug.length === 0) return null;
+    entityId = Number(bySlug[0].id);
+  }
+
+  // 3. Claim the identity. ON CONFLICT DO NOTHING against the live-unique index:
+  //    if a concurrent completion already claimed it, resolve the winner and
+  //    (if we created a fresh entity) drop ours so it doesn't linger orphaned.
+  const claimed = await tx<{ entity_id: number | string }>`
+    INSERT INTO entity_identities (
+      organization_id, entity_id, namespace, identifier, source_connector
+    ) VALUES (
+      ${organizationId}, ${entityId}, ${WATCHER_CANVAS_NAMESPACE}, ${identifier}, 'watcher'
+    )
+    ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
+    DO NOTHING
+    RETURNING entity_id
+  `;
+  if (claimed.length > 0) return entityId;
+
+  const winner = await tx<{ entity_id: number | string }>`
+    SELECT entity_id
+    FROM entity_identities
+    WHERE organization_id = ${organizationId}
+      AND namespace = ${WATCHER_CANVAS_NAMESPACE}
+      AND identifier = ${identifier}
+      AND deleted_at IS NULL
+    LIMIT 1
+  `;
+  if (winner.length > 0 && inserted.length > 0) {
+    // Safe: our entity is brand-new in THIS transaction (no identity, children,
+    // events, or relationships) — its only blocking FK is parent_id RESTRICT,
+    // which can't fire on a freshly-created leaf.
+    await tx`DELETE FROM entities WHERE id = ${entityId}`;
+  }
+  return winner.length > 0 ? Number(winner[0].entity_id) : entityId;
+}
+
+/**
+ * Look up the current chain HEAD (event with no superseder) for a canvas period.
+ * Uses the NOT-EXISTS anti-join over the listing index; returns null when no
+ * chain exists yet (pre-backfill window).
+ */
+export async function findCanvasHead(
+  tx: DbClient,
+  period: { watcherId: number; granularity: string; windowStart: string }
+): Promise<{ id: number; rootEventId: number; payloadData: Record<string, unknown> } | null> {
+  const rows = await tx<{ id: number | string; root_event_id: number | string | null; payload_data: unknown }>`
+    SELECT e.id, (e.metadata->>'root_event_id')::bigint AS root_event_id, e.payload_data
+    FROM events e
+    WHERE e.semantic_type = 'canvas_state'
+      AND (e.metadata->>'watcher_id')::bigint = ${period.watcherId}
+      AND (e.metadata->>'granularity') = ${period.granularity}
+      AND (e.metadata->>'window_start')::timestamptz = ${period.windowStart}
+      AND NOT EXISTS (SELECT 1 FROM events n WHERE n.supersedes_event_id = e.id)
+    LIMIT 1
+  `;
+  if (rows.length === 0) return null;
+  const id = Number(rows[0].id);
+  const rootEventId = rows[0].root_event_id != null ? Number(rows[0].root_event_id) : id;
+  const payloadData =
+    rows[0].payload_data && typeof rows[0].payload_data === 'object'
+      ? (rows[0].payload_data as Record<string, unknown>)
+      : {};
+  return { id, rootEventId, payloadData };
+}

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -100,7 +100,8 @@ interface InsertedEvent {
   created_at: string;
 }
 
-function stableJson(value: unknown): string {
+/** Key-order-independent JSON serialization for semantic equality checks. */
+export function stableJson(value: unknown): string {
   if (value === null || typeof value !== 'object') return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map((item) => stableJson(item)).join(',')}]`;
   const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>

--- a/packages/server/src/utils/window-utils.ts
+++ b/packages/server/src/utils/window-utils.ts
@@ -154,6 +154,14 @@ export async function computePendingWindow(
  * @returns SQL SELECT ... FROM ... JOIN fragment (without WHERE clause)
  */
 export function buildWindowsSelectClause(): string {
+  // Canvas-on-events read flip (dual-write transition): a window's extracted_data
+  // now lives on the chain HEAD `canvas_state` event (payload_data). The LATERAL
+  // finds the head for this window's period — the chain member with no superseder
+  // (NOT EXISTS anti-join), scoped to semantic_type='canvas_state' so it never
+  // matches the tab_event/tab_snapshot BROWSER rows that also carry
+  // metadata.window_id. COALESCE falls back to the legacy iw.extracted_data column
+  // for pre-backfill windows, keeping the API field shape byte-identical. Keys
+  // match idx_canvas_state_listing so the probe stays on the partial index.
   return `
     SELECT
       iw.id as window_id,
@@ -163,7 +171,7 @@ export function buildWindowsSelectClause(): string {
       iw.window_start,
       iw.window_end,
       iw.content_analyzed,
-      iw.extracted_data,
+      COALESCE(canvas_head.payload_data, iw.extracted_data) as extracted_data,
       iw.model_used,
       iw.client_id,
       iw.run_metadata,
@@ -175,6 +183,16 @@ export function buildWindowsSelectClause(): string {
     JOIN watchers i ON iw.watcher_id = i.id
     LEFT JOIN watcher_versions watcher_v ON i.current_version_id = watcher_v.id
     LEFT JOIN watcher_versions window_v ON iw.version_id = window_v.id
+    LEFT JOIN LATERAL (
+      SELECT e.payload_data
+      FROM events e
+      WHERE e.semantic_type = 'canvas_state'
+        AND (e.metadata->>'watcher_id')::bigint = iw.watcher_id
+        AND (e.metadata->>'granularity') = iw.granularity
+        AND (e.metadata->>'window_start')::timestamptz = iw.window_start
+        AND NOT EXISTS (SELECT 1 FROM events n WHERE n.supersedes_event_id = e.id)
+      LIMIT 1
+    ) canvas_head ON TRUE
   `.trim();
 }
 

--- a/packages/server/src/watchers/backfill-canvas-events.ts
+++ b/packages/server/src/watchers/backfill-canvas-events.ts
@@ -1,0 +1,225 @@
+/**
+ * One-off backfill: fold historical `watcher_windows` rows into canvas-on-events.
+ *
+ * For each existing window this:
+ *   1. Ensures the per-watcher canvas entity (entity_identities ns='watcher_canvas').
+ *   2. Inserts the `canvas_state` ROOT event (created_at = window.created_at,
+ *      occurred_at = window.window_end, payload_data = window.extracted_data,
+ *      metadata = { watcher_id, granularity, window_start, window_end,
+ *      content_analyzed, version_id }). Idempotent: the partial unique index
+ *      idx_canvas_chain_root makes a replay a no-op (ON CONFLICT DO NOTHING).
+ *   3. Fills the denormalized watcher_window_events.watcher_id for the window's
+ *      link rows.
+ *
+ * Re-keying window_id references (watcher_reactions/runs/watcher_window_events/
+ * event_classifications) onto the root event id is DEFERRED to Phase 3: those
+ * columns carry a FK to watcher_windows(id) which is still live during this
+ * dual-write release, so pointing them at an events id would violate the FK. The
+ * read flip keys on period metadata (not on window_id = event id), so historical
+ * windows read correctly from their canvas roots without the re-key. The re-key
+ * runs once the FKs + watcher_windows are dropped in Phase 3.
+ *
+ * Scoping: EVERY query is scoped by watcher_windows / semantic_type='canvas_state'.
+ * We NEVER pattern-match bare metadata.window_id — 19k+ tab_event/tab_snapshot
+ * events use it for BROWSER windows and must not be touched.
+ *
+ * Prod has dozens of windows, so this is intentionally simple. It is idempotent
+ * (re-running skips windows whose canvas root already exists and whose references
+ * already point at the root id), so it is safe to replay.
+ *
+ * `fetch_types:false`: all binds here are scalar params; no raw JS array binds.
+ */
+
+import type { DbClient } from '../db/client';
+import { ensureCanvasEntity } from '../utils/canvas-events';
+
+export interface CanvasBackfillReport {
+  windows: number;
+  rootsCreated: number;
+  rootsExisting: number;
+  /** watcher_window_events rows whose denormalized watcher_id was filled. */
+  windowEventsWatcherIdFilled: number;
+  skipped: number;
+  /** Windows whose per-window transaction failed (logged and skipped; re-run to retry). */
+  failed: number;
+}
+
+interface WindowRow {
+  id: number | string;
+  watcher_id: number | string;
+  organization_id: string;
+  created_by: string | null;
+  entity_ids: unknown;
+  granularity: string;
+  window_start: Date | string;
+  window_end: Date | string;
+  content_analyzed: number | string;
+  extracted_data: unknown;
+  version_id: number | string | null;
+  created_at: Date | string | null;
+}
+
+function parseEntityIds(raw: unknown): number[] {
+  if (Array.isArray(raw)) return raw.map(Number);
+  if (typeof raw === 'string') return raw.replace(/[{}]/g, '').split(',').filter(Boolean).map(Number);
+  return [];
+}
+
+/**
+ * Backfill canvas-on-events from watcher_windows. With `execute: false` it only
+ * reports what WOULD change (dry-run: no writes).
+ */
+export async function backfillCanvasEvents(opts: {
+  db: DbClient;
+  org?: string | null;
+  execute: boolean;
+  log?: (msg: string) => void;
+}): Promise<CanvasBackfillReport> {
+  const { db: sql, execute } = opts;
+  const log = opts.log ?? (() => {});
+  const report: CanvasBackfillReport = {
+    windows: 0,
+    rootsCreated: 0,
+    rootsExisting: 0,
+    windowEventsWatcherIdFilled: 0,
+    skipped: 0,
+    failed: 0,
+  };
+
+  const windows = (await sql`
+    SELECT
+      ww.id, ww.watcher_id, w.organization_id, w.created_by, w.entity_ids,
+      ww.granularity, ww.window_start, ww.window_end, ww.content_analyzed,
+      ww.extracted_data, ww.version_id, ww.created_at
+    FROM watcher_windows ww
+    JOIN watchers w ON w.id = ww.watcher_id
+    ${opts.org ? sql`WHERE w.organization_id = ${opts.org}` : sql``}
+    ORDER BY ww.id ASC
+  `) as unknown as WindowRow[];
+
+  log(`Found ${windows.length} watcher_windows row(s) to backfill.`);
+
+  for (const ww of windows) {
+    report.windows += 1;
+    const oldWindowId = Number(ww.id);
+    const watcherId = Number(ww.watcher_id);
+    const windowStartIso = new Date(ww.window_start as string).toISOString();
+    const windowEndIso = new Date(ww.window_end as string).toISOString();
+
+    if (!execute) {
+      // Dry-run: report whether a root already exists.
+      const existing = (await sql`
+        SELECT 1 FROM events
+        WHERE semantic_type = 'canvas_state'
+          AND supersedes_event_id IS NULL
+          AND (metadata->>'watcher_id')::bigint = ${watcherId}
+          AND (metadata->>'granularity') = ${ww.granularity}
+          AND (metadata->>'window_start')::timestamptz = ${windowStartIso}
+        LIMIT 1
+      `) as unknown as unknown[];
+      if (existing.length > 0) report.rootsExisting += 1;
+      else report.rootsCreated += 1;
+      continue;
+    }
+
+    await sql.begin(async (tx) => {
+      const parentEntityId = parseEntityIds(ww.entity_ids)[0] ?? null;
+      const canvasEntityId = await ensureCanvasEntity({
+        tx,
+        watcherId,
+        organizationId: ww.organization_id,
+        parentEntityId,
+        createdBy: ww.created_by,
+      });
+      const entityIdsValue = canvasEntityId != null ? `{${canvasEntityId}}` : null;
+
+      // Insert the ROOT canvas_state event with the window's original created_at.
+      // ON CONFLICT on the partial unique index makes a replay a no-op. We must
+      // use a raw INSERT (not insertEvent) to control created_at.
+      const inserted = (await tx`
+        INSERT INTO events (
+          entity_ids, organization_id, origin_id, payload_type, payload_data,
+          semantic_type, metadata, occurred_at, created_by, created_at
+        ) VALUES (
+          ${entityIdsValue}::bigint[],
+          ${ww.organization_id},
+          ${`canvas_backfill_${oldWindowId}`},
+          'json_template',
+          ${tx.json((ww.extracted_data as Record<string, unknown>) ?? {})},
+          'canvas_state',
+          ${tx.json({
+            watcher_id: watcherId,
+            granularity: ww.granularity,
+            window_start: windowStartIso,
+            window_end: windowEndIso,
+            content_analyzed: Number(ww.content_analyzed) || 0,
+            version_id: ww.version_id != null ? Number(ww.version_id) : null,
+          })},
+          ${windowEndIso},
+          ${ww.created_by},
+          ${ww.created_at ? new Date(ww.created_at as string) : new Date(ww.window_end as string)}
+        )
+        ON CONFLICT (
+          ((metadata->>'watcher_id')::bigint),
+          (metadata->>'granularity'),
+          (metadata->>'window_start')
+        ) WHERE (semantic_type = 'canvas_state' AND supersedes_event_id IS NULL)
+        DO NOTHING
+        RETURNING id
+      `) as unknown as Array<{ id: number | string }>;
+
+      let rootEventId: number;
+      if (inserted.length > 0) {
+        rootEventId = Number(inserted[0].id);
+        report.rootsCreated += 1;
+      } else {
+        // Root already exists (idempotent replay) — resolve it.
+        const existing = (await tx`
+          SELECT id FROM events
+          WHERE semantic_type = 'canvas_state'
+            AND supersedes_event_id IS NULL
+            AND (metadata->>'watcher_id')::bigint = ${watcherId}
+            AND (metadata->>'granularity') = ${ww.granularity}
+            AND (metadata->>'window_start')::timestamptz = ${windowStartIso}
+          LIMIT 1
+        `) as unknown as Array<{ id: number | string }>;
+        if (existing.length === 0) {
+          // No root landed and none exists — odd state (e.g. mismatched metadata).
+          // Skip so we don't leave a half-done window.
+          report.skipped += 1;
+          return;
+        }
+        rootEventId = Number(existing[0].id);
+        report.rootsExisting += 1;
+      }
+      void rootEventId; // root created/resolved; window_id re-key deferred (Phase 3).
+
+      // Fill the denormalized watcher_window_events.watcher_id for this window's
+      // link rows. This has no FK constraint (unlike window_id → watcher_windows),
+      // so it is safe during dual-write. Scoped to the exact old window id.
+      const wwe = (await tx`
+        UPDATE watcher_window_events
+        SET watcher_id = ${watcherId}
+        WHERE window_id = ${oldWindowId} AND watcher_id IS NULL
+        RETURNING id
+      `) as unknown as unknown[];
+      report.windowEventsWatcherIdFilled += wwe.length;
+    }).catch((err: unknown) => {
+      // One bad window (corrupt data, transient DB error) must not abort the
+      // whole run — the per-window tx already rolled back, so log it, count it,
+      // and continue. The backfill is idempotent: a re-run retries only the
+      // failed windows (everything else no-ops on the unique root index).
+      report.failed += 1;
+      log(
+        `window ${oldWindowId} (watcher ${watcherId}) FAILED, continuing: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    });
+  }
+
+  if (report.failed > 0) {
+    log(`${report.failed} window(s) failed — re-run the backfill to retry them.`);
+  }
+  return report;
+}

--- a/scripts/backfill-canvas-events.ts
+++ b/scripts/backfill-canvas-events.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env tsx
+/**
+ * One-off backfill CLI: fold historical `watcher_windows` rows into
+ * canvas-on-events (canvas entity + canvas_state ROOT event + re-keyed
+ * window_id references). Thin wrapper over the package function
+ * `backfillCanvasEvents` (packages/server/src/watchers), which is exercised on a
+ * real DB by the watcher integration tests. See that module for full semantics.
+ *
+ * Idempotent (the idx_canvas_chain_root unique index makes replays no-ops), so
+ * it is safe to re-run. NEVER touches tab_event/tab_snapshot events — every
+ * query is scoped to watcher_windows / semantic_type='canvas_state'.
+ *
+ *   tsx scripts/backfill-canvas-events.ts                 # dry-run, all orgs
+ *   tsx scripts/backfill-canvas-events.ts --execute       # write, all orgs
+ *   tsx scripts/backfill-canvas-events.ts --org <id>      # filter by org
+ *
+ * DATABASE_URL must point at the target database.
+ */
+
+import { getDb } from "../packages/server/src/db/client";
+import { backfillCanvasEvents } from "../packages/server/src/watchers/backfill-canvas-events";
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const execute = argv.includes("--execute");
+  const orgIdx = argv.indexOf("--org");
+  const org = orgIdx >= 0 ? (argv[orgIdx + 1] ?? null) : null;
+  if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is required");
+
+  const sql = getDb();
+  try {
+    const report = await backfillCanvasEvents({
+      db: sql,
+      org,
+      execute,
+      log: (m) => console.log(m),
+    });
+    console.log(
+      `\nDone. windows=${report.windows} ` +
+        `roots ${execute ? "created" : "would create"}=${report.rootsCreated} ` +
+        `existing=${report.rootsExisting} ` +
+        `window_events.watcher_id filled=${report.windowEventsWatcherIdFilled} ` +
+        `skipped=${report.skipped}`
+    );
+    if (!execute && report.rootsCreated > 0)
+      console.log("DRY-RUN only — re-run with --execute to write.");
+  } finally {
+    await sql.end?.();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error("[backfill-canvas-events] FAILED:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## What

Watcher windows ("canvases") become supersede chains of `semantic_type='canvas_state'` events on the events spine — the chain-root event is the window identity, human edits supersede the head, and a lazy per-watcher canvas entity (`entity_identities` ns `watcher_canvas`) anchors the chain. Combined Phase 1+2 (dual-write): events are now both the write target and the read source; the legacy `watcher_windows` row is still written for one release. Phase 3 (FK re-key + table drop) follows.

**Migrations**
- `idx_canvas_chain_root`: partial UNIQUE expression index — one chain root per (watcher, granularity, period). Concurrent completions race here → 23505 → 409, same UX as the legacy period index, but coordinated purely in Postgres (multi-replica safe).
- `idx_canvas_state_listing`: non-unique listing index over all chain members.
- `watcher_window_events.watcher_id`: denormalized + backfilled inline (~413 rows).
- Both canvas indexes scope `semantic_type='canvas_state'` so they never touch the 19k+ `tab_event`/`tab_snapshot` BROWSER rows that also carry `metadata.window_id`.
- `window_start` is indexed as canonical UTC ISO **text** (`text→timestamptz` is STABLE, not IMMUTABLE — rejected in index expressions). Safe: the only token mint site produces it via `Date.toISOString()`, and backfill/feedback normalize the same way; ISO text sorts chronologically.

**Write path** (`complete-window.ts` STEP 7.5, same tx as the window): fresh completion inserts the chain root; `replace_existing` supersedes the current head — **the root id never changes**, fixing the legacy DELETE+reinsert-with-new-id dangling-reference bug.

**Read flip** (`buildWindowsSelectClause`): `extracted_data` comes from the chain HEAD via a LATERAL anti-join, `COALESCE` fallback to the legacy column for pre-backfill windows. API field shape is byte-identical — verified against every field owletto reads (`extracted_data`, `previous_extracted_data`, `granularity`, `window_start/end`, `execution_time_ms`, `model_used`); **owletto needs zero changes**.

**Materialized corrections** (`feedback.ts`): advisory `correction` events unchanged; the set/remove/add mutations now also apply to the head payload as ONE superseding `canvas_state` authored by the user (the machine→human supersede pair is a labeled training signal). Concurrent-edit loser → 409; pre-backfill windows skip gracefully without losing the committed advisory events.

**Notifications**: watcher-sourced notifications anchor to the canvas entity via `entity_ids` (zero DDL — notifications are already events).

**Backfill** (`scripts/backfill-canvas-events.ts`): creates chain roots from `watcher_windows` rows preserving `created_at`, fills `watcher_window_events.watcher_id`; idempotent via the unique root index. Prod scale: 4 watchers / 33 windows.

**Deferred to Phase 3 (deliberate)**: re-keying `watcher_reactions/runs/watcher_window_events/event_classifications.window_id` onto root event ids — those columns FK to `watcher_windows(id)`, which stays live during dual-write. Reads don't depend on it (period-metadata keyed).

## Validation

- Contract tests extended: chained root emission, `replace_existing` supersede with stable root id + head surfaced through the API, superseded states masked from `current_event_records`, correction materialization + advisory preservation, concurrent-supersede 409, backfill (roots + created_at preserved + watcher_id filled + idempotent replay + dry-run inert). **40/40 across the three watcher files**, rerun independently on a fresh PG18+pgvector DB.
- `promote-keyed-entities` updated to encode the new contract: the canvas entity is a third child under the bound entity, and a same-window replay must reuse the canvas identity claim (never mint a second canvas entity).
- Full server vitest integration suite: 216–217/218 files green across runs; the only reproducible failure was the promote-keyed contract above (fixed); remaining one-offs (`scheduling-contract` race, `channel-feed-source` slug collision) pass in isolation and are pre-existing suite non-hermeticity.
- Typecheck + biome clean.

## Merge order

Independent of #1694 (disjoint files), but merging #1694 first means canvas supersedes get `superseded_by` stamped from day one (all canvas writes go through `insertEvent`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785613626&installation_id=136316292&pr_number=1695&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1695&signature=54bf3fd4de4f2375a995463c1bd8d737c9152d49c6348aabed999096d4500778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canvas-based event handling for watcher windows, including automatic creation of canvas state records and support for backfilling older data.
  * Notifications and feedback actions can now be linked to the relevant canvas entity for better traceability.

* **Bug Fixes**
  * Improved handling of repeated or concurrent window completion and feedback updates to avoid duplicate canvas state records.
  * Added safeguards so existing canvas history remains stable during replays and backfills.

* **Chores**
  * Added support for dry-run and execute modes in the backfill workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->