### PR TITLE
perf(events): flip current_event_records to superseded_by predicate (Stage 2)

### DIFF
--- a/db/migrations/20260702300000_events_superseded_by_inline_backfill.sql
+++ b/db/migrations/20260702300000_events_superseded_by_inline_backfill.sql
@@ -1,0 +1,28 @@
+-- migrate:up
+
+-- Stage 2 of the superseded_by rollout (Stage 1 = 20260702200000, which added
+-- the column + the same-transaction dual-write in insert-event.ts). Fill the
+-- denormalized inverse edge for every historical superseded row so the NEXT
+-- migration can flip current_event_records to `WHERE superseded_by IS NULL`.
+--
+-- Inline-UPDATE rationale (vs. the out-of-band-script rule from the classifier
+-- backfill outage): the write below is a single set-based UPDATE that our own
+-- prod does NOT pay — prod is pre-backfilled out of band via
+-- scripts/backfill-superseded-by.ts BEFORE this migration ships, so here it
+-- matches ~0 rows. Fresh installs have empty tables. The only installs that pay
+-- are self-hosted DBs upgrading with pre-existing superseded rows, which are
+-- orders of magnitude below the 1.5M-row scale where an inline UPDATE became an
+-- outage. Idempotent: guarded on `superseded_by IS NULL`, and the partial
+-- unique index idx_events_superseded_by guarantees at most one superseder per
+-- row, so the join is 1:1.
+UPDATE events e
+SET superseded_by = n.id
+FROM events n
+WHERE n.supersedes_event_id = e.id
+  AND e.superseded_by IS NULL;
+
+-- migrate:down
+
+-- The column stays (Stage 1 owns it); clearing the backfilled values restores
+-- the pre-migration state.
+UPDATE events SET superseded_by = NULL WHERE superseded_by IS NOT NULL;

--- a/db/migrations/20260702300010_events_live_partial_index.sql
+++ b/db/migrations/20260702300010_events_live_partial_index.sql
@@ -1,0 +1,22 @@
+-- migrate:up transaction:false
+
+-- Partial index backing the flipped current_event_records predicate
+-- (`WHERE superseded_by IS NULL`, next migration). Org-scoped chronological
+-- reads (get_content, metrics/compiler.ts rewrites events →
+-- current_event_records, utils/execute-data-sources.ts) filter on
+-- organization_id then order by created_at, so key the live-row index on
+-- (organization_id, created_at) restricted to live rows. In prod ~75% of rows
+-- are superseded, so this indexes only the ~25% that reads actually want.
+--
+-- Ordered AFTER the backfill migration on purpose: building it before the
+-- backfill would index the ~1.5M then-unstamped rows only to delete them all
+-- from the index moments later (bloat). CONCURRENTLY (transaction:false, one
+-- statement per squawk) so the build never blocks writes on the high-write
+-- events table.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_live_org_created
+  ON public.events (organization_id, created_at)
+  WHERE superseded_by IS NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_events_live_org_created;

--- a/db/migrations/20260702300020_current_event_records_superseded_by_flip.sql
+++ b/db/migrations/20260702300020_current_event_records_superseded_by_flip.sql
@@ -1,0 +1,100 @@
+-- migrate:up
+
+-- Flip the masking view from the per-row anti-join
+--   WHERE NOT EXISTS (SELECT 1 FROM events newer WHERE newer.supersedes_event_id = e.id)
+-- to the denormalized predicate backed by idx_events_live_org_created. Every
+-- live-row read stops scanning the ~75% superseded tombstones.
+--
+-- Correctness contract (why this is safe NOW and wasn't in Stage 1):
+--   - New superseding writes stamp `superseded_by` in the SAME transaction as
+--     the superseding INSERT (insert-event.ts, since 20260702200000).
+--   - Historical rows were filled by 20260702300000 (and prod out of band
+--     beforehand), so no committed superseded row has a NULL edge.
+--   - The partial unique index idx_events_superseded_by still guarantees at
+--     most one superseder, so the edge can never be ambiguous.
+--
+-- Column list MUST stay identical to the previous definition — the one from
+-- 20260618140000_event_embeddings_contract.sql, which DROPPED the
+-- event_embeddings join (vector callers read event_embeddings directly). Only
+-- the WHERE clause changes, so CREATE OR REPLACE VIEW is valid.
+CREATE OR REPLACE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id
+   FROM public.events e
+  WHERE e.superseded_by IS NULL;
+
+-- migrate:down
+
+CREATE OR REPLACE VIEW public.current_event_records AS
+ SELECT e.id,
+    e.organization_id,
+    e.entity_ids,
+    e.origin_id,
+    e.title,
+    e.payload_type,
+    e.payload_text,
+    e.payload_data,
+    e.payload_template,
+    e.attachments,
+    e.metadata,
+    e.score,
+    e.author_name,
+    e.source_url,
+    e.occurred_at,
+    e.created_at,
+    e.origin_parent_id,
+    COALESCE(length(e.payload_text), 0) AS content_length,
+    e.search_tsv,
+    e.origin_type,
+    e.connector_key,
+    e.connection_id,
+    e.feed_key,
+    e.feed_id,
+    e.run_id,
+    e.semantic_type,
+    e.client_id,
+    e.created_by,
+    e.interaction_type,
+    e.interaction_status,
+    e.interaction_input_schema,
+    e.interaction_input,
+    e.interaction_output,
+    e.interaction_error,
+    e.supersedes_event_id
+   FROM public.events e
+  WHERE NOT (EXISTS ( SELECT 1
+           FROM public.events newer
+          WHERE newer.supersedes_event_id = e.id));

--- a/packages/server/src/__tests__/integration/events/dedup-events.test.ts
+++ b/packages/server/src/__tests__/integration/events/dedup-events.test.ts
@@ -67,7 +67,16 @@ async function insertRow(opts: {
     )
     RETURNING id
   `;
-  return Number(row.id);
+  const id = Number(row.id);
+  // The masking view keys on superseded_by (20260702300020), so raw supersedes
+  // must stamp the inverse edge like insertEvent's same-tx dual-write does.
+  if (opts.supersedesEventId != null) {
+    await sql`
+      UPDATE events SET superseded_by = ${id}
+      WHERE id = ${opts.supersedesEventId} AND superseded_by IS NULL
+    `;
+  }
+  return id;
 }
 
 async function isCurrent(id: number): Promise<boolean> {

--- a/packages/server/src/__tests__/integration/events/supersession-hidden-not-deleted.test.ts
+++ b/packages/server/src/__tests__/integration/events/supersession-hidden-not-deleted.test.ts
@@ -104,6 +104,13 @@ describe('supersession > hidden, not deleted', () => {
       RETURNING id
     `;
     successorId = Number(succ.id);
+    // The masking view now reads `WHERE superseded_by IS NULL`
+    // (20260702300020), so a raw supersede must stamp the inverse edge exactly
+    // like every production write does via insertEvent's same-tx dual-write.
+    await sql`
+      UPDATE events SET superseded_by = ${successorId}
+      WHERE id = ${originalId} AND superseded_by IS NULL
+    `;
   });
 
   it('keeps the superseded original PHYSICALLY present in the raw events table', async () => {
@@ -169,10 +176,10 @@ describe('supersession > hidden, not deleted', () => {
  * Migration 20260702200000 adds `superseded_by` as the inverse edge of
  * `supersedes_event_id`. New superseding writes dual-write it in the same tx as
  * the superseding INSERT (utils/insert-event.ts); historical rows are filled by
- * the batched, resumable backfill (events/backfill-superseded-by.ts). Through
- * all of this the masking contract above stays intact — the view still hides
- * superseded rows — so the flip to `WHERE superseded_by IS NULL` (Stage 2) is a
- * pure performance change, not a behaviour change.
+ * the batched, resumable backfill (events/backfill-superseded-by.ts) and the
+ * inline migration 20260702300000. Since 20260702300020 the masking view reads
+ * `WHERE superseded_by IS NULL` directly — masking DEPENDS on the stamp, which
+ * is why the stamp is transactionally coupled to the supersede everywhere.
  */
 describe('supersession > denormalized superseded_by lineage', () => {
   let org: Awaited<ReturnType<typeof createTestOrganization>>;
@@ -324,17 +331,19 @@ describe('supersession > denormalized superseded_by lineage', () => {
     `;
     const successorId = Number(succ.id);
 
-    // The historical edge is unstamped, but the view already masks it (proves
-    // the flip is a perf-only change: masking works both before AND after the
-    // backfill).
+    // Post-flip (20260702300020) the view keys masking on superseded_by, so an
+    // unstamped edge means the superseded row is still VISIBLE — this is
+    // exactly why the flip migration is ordered AFTER the inline backfill and
+    // why prod is pre-backfilled out of band. The backfill below is what
+    // restores masking for edges that predate the dual-write.
     const [preBackfill] = await sql`
       SELECT superseded_by FROM events WHERE id = ${original.id}
     `;
     expect(preBackfill.superseded_by).toBeNull();
-    const maskedBefore = await sql`
+    const visibleBefore = await sql`
       SELECT id FROM current_event_records WHERE id = ${original.id}
     `;
-    expect(maskedBefore).toHaveLength(0);
+    expect(visibleBefore).toHaveLength(1);
 
     // Dry-run reports the edge without writing.
     const dry = await backfillSupersededBy({ db: sql, execute: false, sleepMs: 0 });

--- a/packages/server/src/events/backfill-superseded-by.ts
+++ b/packages/server/src/events/backfill-superseded-by.ts
@@ -23,44 +23,13 @@
  * guard on `superseded_by IS NULL`, and the unique index serializes supersede
  * winners, so neither can clobber the other.
  *
- * ─────────────────────────────────────────────────────────────────────────────
- * STAGE 2 (view flip + partial index) — deploy ONLY after this backfill has
- * completed on the target DB. It is deliberately NOT committed as a migration
- * file: the migration runner (embedded-runtime.ts / dbmate) auto-applies every
- * unapplied migration in filename order at boot, which would flip the view
- * BEFORE the backfill finished and un-mask every not-yet-stamped superseded
- * row. Run this SQL by hand (or add it as a migration in the follow-up PR once
- * prod is fully backfilled):
- *
- *   -- Partial index backing the flipped predicate. Org-scoped chronological
- *   -- reads (get_content, metrics/compiler.ts rewrites events→
- *   -- current_event_records, utils/execute-data-sources.ts) filter on
- *   -- organization_id then order by created_at, so key the live-row index on
- *   -- (organization_id, created_at) restricted to live rows. CONCURRENTLY so
- *   -- the build never blocks writes.
- *   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_live_org_created
- *       ON public.events (organization_id, created_at)
- *       WHERE superseded_by IS NULL;
- *
- *   -- Flip the view from the per-row anti-join to the cheap partial-index
- *   -- predicate. Column list MUST match the current definition (see migration
- *   -- 20260618140000_event_embeddings_contract.sql, which added the
- *   -- event_embeddings LEFT JOIN). Only the WHERE clause changes.
- *   CREATE OR REPLACE VIEW public.current_event_records AS
- *    SELECT e.id, e.organization_id, e.entity_ids, e.origin_id, e.title,
- *           e.payload_type, e.payload_text, e.payload_data, e.payload_template,
- *           e.attachments, e.metadata, e.score, emb.embedding, e.author_name,
- *           e.source_url, e.occurred_at, e.created_at, e.origin_parent_id,
- *           COALESCE(length(e.payload_text), 0) AS content_length,
- *           e.search_tsv, e.origin_type, e.connector_key, e.connection_id,
- *           e.feed_key, e.feed_id, e.run_id, e.semantic_type, e.client_id,
- *           e.created_by, e.interaction_type, e.interaction_status,
- *           e.interaction_input_schema, e.interaction_input,
- *           e.interaction_output, e.interaction_error, e.supersedes_event_id
- *      FROM (public.events e
- *        LEFT JOIN public.event_embeddings emb ON ((emb.event_id = e.id)))
- *     WHERE e.superseded_by IS NULL;
- * ─────────────────────────────────────────────────────────────────────────────
+ * STAGE 2 IS NOW SHIPPED as migrations 20260702300000 (inline backfill for
+ * small/fresh installs), 20260702300010 (partial index
+ * idx_events_live_org_created), and 20260702300020 (view flip to
+ * `WHERE superseded_by IS NULL`). This script's remaining job is PRE-backfilling
+ * a large live database out of band BEFORE deploying those migrations, so the
+ * inline UPDATE in 20260702300000 matches ~0 rows at boot instead of rewriting
+ * millions of rows during a rolling deploy (prod: ~1.5M superseded rows).
  */
 
 import { type DbClient, pgBigintArray } from '../db/client';


### PR DESCRIPTION
## What

Stage 2 of the `superseded_by` rollout (#1694 was Stage 1: column + same-tx dual-write + out-of-band backfill script). The masking view drops the per-row `NOT EXISTS` anti-join for `WHERE superseded_by IS NULL`, backed by a new partial index — live-row reads stop scanning the ~75% of prod's 2.1M events rows that are superseded tombstones.

Three migrations, ordered deliberately:
1. `20260702300000` — inline set-based backfill. **Prod is pre-backfilled out of band** (1,593,820 rows via the batched script, verified 0 remaining before this merges), so this matches ~0 rows there; fresh installs are empty; only small upgrading self-hosted DBs pay the single UPDATE (rationale + the outage lesson documented in the file).
2. `20260702300010` — `idx_events_live_org_created (organization_id, created_at) WHERE superseded_by IS NULL`, CONCURRENTLY, built *after* the backfill so it never indexes soon-to-be-stamped rows.
3. `20260702300020` — the view flip. Column list matches the live definition exactly; only the WHERE changes.

One correction over the previously documented Stage-2 SQL: the backfill module header claimed the view still had the `event_embeddings` LEFT JOIN — it doesn't (`20260618140000` dropped it). Caught by actually applying the SQL in the test harness; the header is fixed in this PR.

Masking now *depends* on the stamp; the same-transaction dual-write in `insert-event.ts` guarantees it for every supersede path (verified in #1694: `insertEvent` is the only supersede writer). Tests that raw-insert superseding rows now stamp the edge exactly like production writes; the backfill contract test asserts the new semantics (unstamped edge visible until backfilled, masked after).

## Validation

- Full server vitest integration suite against the flipped view: **218/218 files, 1729 passed, 0 failed**.
- `EXPLAIN` on an org-scoped view read: backward index scan on `idx_events_live_org_created`, no anti-join sub-plan.
- Migration applied cleanly by the test runner from empty; migrations-format 172/172.

## Merge gate

Do NOT merge until the prod unstamped-row count is verified 0 (backfill running now; I'll confirm on this PR). Merging early would un-mask any not-yet-stamped superseded rows the moment the view flips at boot.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785616763&installation_id=136316292&pr_number=1697&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1697&signature=40c762dedc2e134a693592e782673beb9fb280171a6ccaaa6a06591556b8908f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event records now use a faster “live events” path, improving read performance for current items.
  * Historical supersession data is now backfilled so older records are shown consistently.

* **Bug Fixes**
  * Fixed cases where superseded events could appear or disappear incorrectly in the current events view.
  * Improved consistency between event updates and what users see immediately afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->