### PR TITLE
feat(gmail): virtual-feed pushdown + create/read surface

### DIFF
--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -15,6 +15,9 @@ import {
   type HttpClient,
   IDENTITY,
   paginateByCursor,
+  type QueryContext,
+  type QueryResult,
+  type SearchContext,
   type SyncContext,
   type SyncResult,
 } from '@lobu/connector-sdk';
@@ -70,6 +73,19 @@ interface GmailConfig {
   max_results?: number;
   lookback_days?: number;
 }
+
+/** Stable column set returned by live `query()`/`search()` pushdown reads. */
+const GMAIL_SEARCH_COLUMNS = [
+  { name: 'id', type: 'string' },
+  { name: 'thread_id', type: 'string' },
+  { name: 'subject', type: 'string' },
+  { name: 'from', type: 'string' },
+  { name: 'from_name', type: 'string' },
+  { name: 'from_email', type: 'string' },
+  { name: 'date', type: 'string' },
+  { name: 'snippet', type: 'string' },
+  { name: 'url', type: 'string' },
+];
 
 // ---------------------------------------------------------------------------
 // Connector
@@ -430,6 +446,108 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
         error: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Live pushdown (virtual feeds) — read-only, never persisted.
+  // `query()` runs the feed's configured Gmail search string; `search()` adds
+  // keyword `terms` as an AND predicate (Gmail's `q` is space-separated = AND).
+  // Both return the same row shape so a virtual `threads` feed is consistent
+  // whether read bare or with recall terms pushed down.
+  // -------------------------------------------------------------------------
+
+  async query(ctx: QueryContext<GmailConfig>): Promise<QueryResult> {
+    return this.liveSearch(ctx, ctx.query, []);
+  }
+
+  async search(ctx: SearchContext<GmailConfig>): Promise<QueryResult> {
+    return this.liveSearch(ctx, ctx.query, ctx.terms ?? []);
+  }
+
+  /**
+   * Shared live read: build a Gmail `q` from the base predicate plus optional
+   * keyword terms, list matching messages, then fetch each message's metadata
+   * (Subject/From/Date) + snippet. Returns rows + a stable column set.
+   */
+  private async liveSearch(
+    ctx: QueryContext<GmailConfig>,
+    baseQuery: string,
+    terms: string[]
+  ): Promise<QueryResult> {
+    const token = ctx.credentials?.accessToken;
+    if (!token) {
+      throw new Error('Gmail virtual-feed reads require Google OAuth credentials.');
+    }
+
+    const parts = [baseQuery, ...terms.map((t) => t.trim()).filter(Boolean)].filter(Boolean);
+    const q = parts.join(' ');
+    if (!q) {
+      throw new Error('Gmail virtual feed has no `query` in its config and no search terms.');
+    }
+
+    const limit = Math.min(Math.max(Math.trunc(ctx.limit ?? ctx.config.max_results ?? 25), 1), 100);
+
+    const http = this.createClient(token);
+    const ids = await this.listMessageIds(http, q, limit);
+    const rows = await this.fetchMessageRows(http, ids);
+
+    return { rows, columns: GMAIL_SEARCH_COLUMNS, total: ids.length };
+  }
+
+  private async listMessageIds(
+    http: HttpClient,
+    q: string,
+    limit: number
+  ): Promise<Array<{ id: string; threadId: string }>> {
+    const out: Array<{ id: string; threadId: string }> = [];
+    let pageToken: string | undefined;
+    do {
+      const remaining = limit - out.length;
+      if (remaining <= 0) break;
+      const params = new URLSearchParams({
+        q,
+        maxResults: String(Math.min(100, remaining)),
+      });
+      if (pageToken) params.set('pageToken', pageToken);
+      const res = await http.raw(`${this.BASE_URL}/messages?${params.toString()}`);
+      if (!res.ok) {
+        throw new Error(`Gmail messages.list error (${res.status}): ${await res.text()}`);
+      }
+      const data = (await res.json()) as {
+        messages?: Array<{ id: string; threadId: string }>;
+        nextPageToken?: string;
+      };
+      for (const m of data.messages ?? []) out.push({ id: m.id, threadId: m.threadId });
+      pageToken = data.nextPageToken;
+    } while (pageToken && out.length < limit);
+    return out.slice(0, limit);
+  }
+
+  private async fetchMessageRows(
+    http: HttpClient,
+    ids: Array<{ id: string; threadId: string }>
+  ): Promise<Record<string, unknown>[]> {
+    const rows: Record<string, unknown>[] = [];
+    for (const m of ids) {
+      const url = `${this.BASE_URL}/messages/${m.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date`;
+      const res = await http.raw(url);
+      if (!res.ok) continue; // skip a single unreachable message, keep the batch reliable
+      const msg = (await res.json()) as GmailMessage;
+      const rawFrom = this.getHeader(msg, 'From') || 'Unknown';
+      const { name, email } = this.parseFromHeader(rawFrom);
+      rows.push({
+        id: msg.id,
+        thread_id: msg.threadId,
+        subject: this.getHeader(msg, 'Subject') || '(no subject)',
+        from: rawFrom,
+        from_name: name,
+        from_email: email,
+        date: this.getHeader(msg, 'Date') || '',
+        snippet: msg.snippet || '',
+        url: `https://mail.google.com/mail/u/0/#inbox/${msg.threadId}`,
+      });
+    }
+    return rows;
   }
 
   // -------------------------------------------------------------------------

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -479,30 +479,56 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       throw new Error('Gmail virtual-feed reads require Google OAuth credentials.');
     }
 
-    const parts = [baseQuery, ...terms.map((t) => t.trim()).filter(Boolean)].filter(Boolean);
+    // Gmail's `q` is space-separated = AND. Each term is escaped so a term that
+    // contains Gmail operators/spaces (e.g. `from:a b`) is matched literally as a
+    // quoted phrase rather than reinterpreted as query syntax.
+    const parts = [baseQuery.trim(), ...terms.map((t) => this.escapeGmailTerm(t))].filter(Boolean);
     const q = parts.join(' ');
     if (!q) {
       throw new Error('Gmail virtual feed has no `query` in its config and no search terms.');
     }
 
-    const limit = Math.min(Math.max(Math.trunc(ctx.limit ?? ctx.config.max_results ?? 25), 1), 100);
+    // Gmail search has no arbitrary sort — results are always reverse-chronological
+    // (newest first). Reject a sort we can't honor rather than silently ignore it.
+    if (ctx.sort && !(ctx.sort.column === 'date' && ctx.sort.order === 'desc')) {
+      throw new Error(
+        `Gmail virtual feed only supports sort {column:'date', order:'desc'} (newest first); got ${JSON.stringify(ctx.sort)}.`
+      );
+    }
 
+    const limit = Math.min(Math.max(Math.trunc(ctx.limit ?? ctx.config.max_results ?? 25), 1), 100);
+    const offset = Math.max(Math.trunc(ctx.offset ?? 0), 0);
+
+    // Apply offset by listing offset+limit ids then dropping the leading `offset`.
+    // Gmail's list endpoint has no offset param, only forward pagination.
     const http = this.createClient(token);
-    const ids = await this.listMessageIds(http, q, limit);
+    const ids = (await this.listMessageIds(http, q, offset + limit)).slice(offset, offset + limit);
     const rows = await this.fetchMessageRows(http, ids);
 
-    return { rows, columns: GMAIL_SEARCH_COLUMNS, total: ids.length };
+    // No `total`: Gmail's list endpoint returns no reliable match count, and
+    // `resultSizeEstimate` is a coarse estimate — reporting the page length as a
+    // total would be wrong. Callers page until a short page.
+    return { rows, columns: GMAIL_SEARCH_COLUMNS };
+  }
+
+  /** Quote a search term so Gmail matches it literally (handles spaces/operators). */
+  private escapeGmailTerm(term: string): string {
+    const t = term.trim();
+    if (!t) return '';
+    // Already a bare token with no whitespace/quotes → pass through.
+    if (!/[\s"]/.test(t)) return t;
+    return `"${t.replace(/"/g, '')}"`;
   }
 
   private async listMessageIds(
     http: HttpClient,
     q: string,
-    limit: number
+    want: number
   ): Promise<Array<{ id: string; threadId: string }>> {
     const out: Array<{ id: string; threadId: string }> = [];
     let pageToken: string | undefined;
     do {
-      const remaining = limit - out.length;
+      const remaining = want - out.length;
       if (remaining <= 0) break;
       const params = new URLSearchParams({
         q,
@@ -519,8 +545,8 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       };
       for (const m of data.messages ?? []) out.push({ id: m.id, threadId: m.threadId });
       pageToken = data.nextPageToken;
-    } while (pageToken && out.length < limit);
-    return out.slice(0, limit);
+    } while (pageToken && out.length < want);
+    return out.slice(0, want);
   }
 
   private async fetchMessageRows(

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -511,12 +511,19 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     return { rows, columns: GMAIL_SEARCH_COLUMNS };
   }
 
-  /** Quote a search term so Gmail matches it literally (handles spaces/operators). */
+  /**
+   * Quote a recall term so Gmail matches it LITERALLY. A bare word passes
+   * through; anything containing whitespace, a quote, or a Gmail query-operator
+   * character (`:` `(` `)` `{` `}`) is wrapped in quotes so it is not reparsed as
+   * query syntax (e.g. `from:alice@example.com` must match the text, not act as a
+   * `from:` operator). Embedded quotes are stripped — Gmail has no escape for a
+   * literal quote inside a phrase.
+   */
   private escapeGmailTerm(term: string): string {
     const t = term.trim();
     if (!t) return '';
-    // Already a bare token with no whitespace/quotes → pass through.
-    if (!/[\s"]/.test(t)) return t;
+    // Bare token with no whitespace, quotes, or operator characters → pass through.
+    if (!/[\s"():{}]/.test(t)) return t;
     return `"${t.replace(/"/g, '')}"`;
   }
 

--- a/packages/server/src/__tests__/integration/connectors/gmail-virtual-pushdown.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/gmail-virtual-pushdown.test.ts
@@ -174,11 +174,21 @@ describe('Gmail virtual-feed pushdown', () => {
     expect(cap.listQueries).toEqual(['in:inbox report urgent']);
   });
 
-  it('search() quotes a term containing spaces/operators so it matches literally', async () => {
+  it('search() quotes a term containing spaces so it matches literally', async () => {
     const cap: Capture = { listQueries: [], listMaxResults: [] };
     const c = connectorWith(cap);
     await c.search({ ...CREDS, query: 'in:inbox', terms: ['weekly report'], config: {}, limit: 5 } as never);
     expect(cap.listQueries).toEqual(['in:inbox "weekly report"']);
+  });
+
+  it('search() quotes an operator-like term so it is matched literally, not reparsed', async () => {
+    const cap: Capture = { listQueries: [], listMaxResults: [] };
+    const c = connectorWith(cap);
+    // A recall term is keyword text, not Gmail query syntax — `from:alice@x.com`
+    // must be a literal phrase, not activate the `from:` operator (operators
+    // belong in the base config.query, not in recall terms).
+    await c.search({ ...CREDS, query: 'in:inbox', terms: ['from:alice@x.com'], config: {}, limit: 5 } as never);
+    expect(cap.listQueries).toEqual(['in:inbox "from:alice@x.com"']);
   });
 
   it('clamps the limit and passes it as maxResults', async () => {

--- a/packages/server/src/__tests__/integration/connectors/gmail-virtual-pushdown.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/gmail-virtual-pushdown.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Gmail virtual-feed pushdown (PR #1702) — the connector half of the seam.
+ *
+ * The DB-level `readVirtualFeed` seam is covered by `virtual-feed-read.test.ts`
+ * (with the postgres connector as the stand-in source). This test covers the
+ * NEW Gmail code that seam dispatches into: `GmailConnector.query()`/`search()`
+ * → `liveSearch()` → `listMessageIds()` + `fetchMessageRows()`.
+ *
+ * The only external dependency — the Gmail HTTP API — is stubbed at the
+ * `HttpClient.raw()` boundary (the connector's single egress seam), so this is
+ * deterministic and needs no network or DB. It verifies:
+ *  - query() builds the Gmail `q` from `ctx.query` alone;
+ *  - search() ANDs the recall `terms` onto `q` (Gmail `q` is space-separated);
+ *  - the stable column set + row shape (id, thread_id, subject, from fields, date, snippet, url);
+ *  - the limit is clamped and passed as maxResults, capping the id list;
+ *  - a single unreadable message (non-2xx metadata fetch) is skipped, not fatal;
+ *  - missing credentials and an empty `q` throw.
+ */
+
+import { describe, expect, it } from 'vitest';
+import GmailConnector from '@lobu/connectors/google_gmail';
+
+// --- Gmail API fixtures --------------------------------------------------
+
+interface FakeMessage {
+  id: string;
+  threadId: string;
+  snippet: string;
+  headers: Record<string, string>;
+}
+
+const MESSAGES: FakeMessage[] = [
+  {
+    id: 'm1',
+    threadId: 't1',
+    snippet: 'Quarterly report attached',
+    headers: { Subject: 'Q2 report', From: 'Alice Smith <alice@acme.com>', Date: 'Tue, 01 Jul 2026 10:00:00 +0000' },
+  },
+  {
+    id: 'm2',
+    threadId: 't2',
+    snippet: 'Lunch?',
+    headers: { Subject: 'lunch tomorrow', From: 'bob@acme.com', Date: 'Wed, 02 Jul 2026 09:00:00 +0000' },
+  },
+  {
+    id: 'm3',
+    threadId: 't3',
+    snippet: 'no subject here',
+    headers: { From: 'Unknown', Date: '' }, // no Subject header → '(no subject)'
+  },
+];
+
+/** Records the `q` values the connector actually requested against messages.list. */
+interface Capture {
+  listQueries: string[];
+  listMaxResults: number[];
+}
+
+/**
+ * Build a fake `HttpClient` that answers Gmail's messages.list + messages.get
+ * (metadata) endpoints from MESSAGES. `unreadable` ids return a non-2xx from
+ * the metadata fetch so we can assert the skip-on-404 path.
+ */
+function fakeClient(capture: Capture, opts: { unreadable?: Set<string> } = {}) {
+  const unreadable = opts.unreadable ?? new Set<string>();
+  const raw = async (url: string): Promise<Response> => {
+    const u = new URL(url);
+    if (u.pathname.endsWith('/messages')) {
+      capture.listQueries.push(u.searchParams.get('q') ?? '');
+      capture.listMaxResults.push(Number(u.searchParams.get('maxResults')));
+      // single page: every fixture message id, no nextPageToken
+      return new Response(
+        JSON.stringify({ messages: MESSAGES.map((m) => ({ id: m.id, threadId: m.threadId })) }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    // messages/{id}?format=metadata
+    const idMatch = u.pathname.match(/\/messages\/([^/]+)$/);
+    if (idMatch) {
+      const id = idMatch[1];
+      if (unreadable.has(id)) return new Response('not found', { status: 404 });
+      const msg = MESSAGES.find((m) => m.id === id);
+      if (!msg) return new Response('not found', { status: 404 });
+      return new Response(
+        JSON.stringify({
+          id: msg.id,
+          threadId: msg.threadId,
+          snippet: msg.snippet,
+          payload: { headers: Object.entries(msg.headers).map(([name, value]) => ({ name, value })) },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    throw new Error(`unexpected url: ${url}`);
+  };
+  // Only raw() is used by the pushdown; the rest satisfy the interface unused.
+  return {
+    raw,
+    request: raw,
+    json: async () => ({}),
+    get: async () => ({}),
+    post: async () => ({}),
+  } as unknown as import('@lobu/connector-sdk').HttpClient;
+}
+
+/** A GmailConnector whose HTTP boundary is the fake client. */
+function connectorWith(capture: Capture, opts?: { unreadable?: Set<string> }) {
+  const c = new GmailConnector();
+  // createClient is `private` at the type level only — override at runtime so
+  // liveSearch() talks to the fake instead of real Gmail.
+  (c as unknown as { createClient: () => unknown }).createClient = () => fakeClient(capture, opts);
+  return c;
+}
+
+const CREDS = { credentials: { accessToken: 'fake-token' } };
+
+describe('Gmail virtual-feed pushdown', () => {
+  it('query() builds q from ctx.query alone and returns the stable row shape', async () => {
+    const cap: Capture = { listQueries: [], listMaxResults: [] };
+    const c = connectorWith(cap);
+    const res = await c.query({ ...CREDS, query: 'in:inbox newer_than:30d', config: {}, limit: 10 } as never);
+
+    expect(cap.listQueries).toEqual(['in:inbox newer_than:30d']);
+    expect(res.columns.map((col) => col.name)).toEqual([
+      'id', 'thread_id', 'subject', 'from', 'from_name', 'from_email', 'date', 'snippet', 'url',
+    ]);
+    expect(res.rows).toHaveLength(3);
+    expect(res.rows[0]).toMatchObject({
+      id: 'm1',
+      thread_id: 't1',
+      subject: 'Q2 report',
+      from: 'Alice Smith <alice@acme.com>',
+      from_name: 'Alice Smith',
+      from_email: 'alice@acme.com',
+      url: 'https://mail.google.com/mail/u/0/#inbox/t1',
+    });
+    // header-less message falls back cleanly
+    expect(res.rows[2]).toMatchObject({ subject: '(no subject)', from_name: null, from_email: null });
+  });
+
+  it('search() ANDs recall terms onto the base q', async () => {
+    const cap: Capture = { listQueries: [], listMaxResults: [] };
+    const c = connectorWith(cap);
+    await c.search({ ...CREDS, query: 'in:inbox', terms: ['report', 'urgent'], config: {}, limit: 5 } as never);
+    // Gmail q is space-separated = AND
+    expect(cap.listQueries).toEqual(['in:inbox report urgent']);
+  });
+
+  it('clamps the limit and passes it as maxResults', async () => {
+    const cap: Capture = { listQueries: [], listMaxResults: [] };
+    const c = connectorWith(cap);
+    // limit 2 → maxResults 2, id list capped to 2 even though 3 fixtures exist
+    const res = await c.query({ ...CREDS, query: 'in:inbox', config: {}, limit: 2 } as never);
+    expect(cap.listMaxResults[0]).toBe(2);
+    expect(res.rows).toHaveLength(2);
+  });
+
+  it('skips a single unreadable message instead of failing the batch', async () => {
+    const cap: Capture = { listQueries: [], listMaxResults: [] };
+    const c = connectorWith(cap, { unreadable: new Set(['m2']) });
+    const res = await c.query({ ...CREDS, query: 'in:inbox', config: {}, limit: 10 } as never);
+    expect(res.rows.map((r) => r.id)).toEqual(['m1', 'm3']); // m2 skipped
+  });
+
+  it('throws without credentials', async () => {
+    const cap: Capture = { listQueries: [], listMaxResults: [] };
+    const c = connectorWith(cap);
+    await expect(c.query({ query: 'in:inbox', config: {} } as never)).rejects.toThrow(/OAuth credentials/i);
+  });
+
+  it('throws when there is no q (empty base and no terms)', async () => {
+    const cap: Capture = { listQueries: [], listMaxResults: [] };
+    const c = connectorWith(cap);
+    await expect(c.query({ ...CREDS, query: '', config: {} } as never)).rejects.toThrow(/no `query`|no search terms/i);
+  });
+});

--- a/packages/server/src/__tests__/integration/connectors/gmail-virtual-pushdown.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/gmail-virtual-pushdown.test.ts
@@ -13,6 +13,8 @@
  *  - search() ANDs the recall `terms` onto `q` (Gmail `q` is space-separated);
  *  - the stable column set + row shape (id, thread_id, subject, from fields, date, snippet, url);
  *  - the limit is clamped and passed as maxResults, capping the id list;
+ *  - offset pages forward then drops the leading rows;
+ *  - an unsupported sort is rejected (Gmail is always date-desc), and no total is reported;
  *  - a single unreadable message (non-2xx metadata fetch) is skipped, not fatal;
  *  - missing credentials and an empty `q` throw.
  */
@@ -58,19 +60,33 @@ interface Capture {
 
 /**
  * Build a fake `HttpClient` that answers Gmail's messages.list + messages.get
- * (metadata) endpoints from MESSAGES. `unreadable` ids return a non-2xx from
- * the metadata fetch so we can assert the skip-on-404 path.
+ * (metadata) endpoints from `messages`. The list endpoint honors `maxResults`
+ * and `pageToken` (real forward pagination), so offset/limit slicing is exercised
+ * end-to-end. `unreadable` ids return a non-2xx from the metadata fetch so we can
+ * assert the skip-on-404 path.
  */
-function fakeClient(capture: Capture, opts: { unreadable?: Set<string> } = {}) {
+function fakeClient(
+  capture: Capture,
+  opts: { unreadable?: Set<string>; messages?: FakeMessage[] } = {},
+) {
   const unreadable = opts.unreadable ?? new Set<string>();
+  const corpus = opts.messages ?? MESSAGES;
   const raw = async (url: string): Promise<Response> => {
     const u = new URL(url);
     if (u.pathname.endsWith('/messages')) {
       capture.listQueries.push(u.searchParams.get('q') ?? '');
-      capture.listMaxResults.push(Number(u.searchParams.get('maxResults')));
-      // single page: every fixture message id, no nextPageToken
+      const maxResults = Number(u.searchParams.get('maxResults'));
+      capture.listMaxResults.push(maxResults);
+      // pageToken is a numeric cursor into `corpus`; return maxResults ids then
+      // the next cursor if more remain.
+      const start = Number(u.searchParams.get('pageToken') ?? '0');
+      const slice = corpus.slice(start, start + maxResults);
+      const next = start + maxResults;
       return new Response(
-        JSON.stringify({ messages: MESSAGES.map((m) => ({ id: m.id, threadId: m.threadId })) }),
+        JSON.stringify({
+          messages: slice.map((m) => ({ id: m.id, threadId: m.threadId })),
+          ...(next < corpus.length ? { nextPageToken: String(next) } : {}),
+        }),
         { status: 200, headers: { 'content-type': 'application/json' } },
       );
     }
@@ -79,7 +95,7 @@ function fakeClient(capture: Capture, opts: { unreadable?: Set<string> } = {}) {
     if (idMatch) {
       const id = idMatch[1];
       if (unreadable.has(id)) return new Response('not found', { status: 404 });
-      const msg = MESSAGES.find((m) => m.id === id);
+      const msg = corpus.find((m) => m.id === id);
       if (!msg) return new Response('not found', { status: 404 });
       return new Response(
         JSON.stringify({
@@ -104,7 +120,10 @@ function fakeClient(capture: Capture, opts: { unreadable?: Set<string> } = {}) {
 }
 
 /** A GmailConnector whose HTTP boundary is the fake client. */
-function connectorWith(capture: Capture, opts?: { unreadable?: Set<string> }) {
+function connectorWith(
+  capture: Capture,
+  opts?: { unreadable?: Set<string>; messages?: FakeMessage[] },
+) {
   const c = new GmailConnector();
   // createClient is `private` at the type level only — override at runtime so
   // liveSearch() talks to the fake instead of real Gmail.
@@ -138,12 +157,28 @@ describe('Gmail virtual-feed pushdown', () => {
     expect(res.rows[2]).toMatchObject({ subject: '(no subject)', from_name: null, from_email: null });
   });
 
-  it('search() ANDs recall terms onto the base q', async () => {
+  it('does not report a (misleading) total for a partial page', async () => {
+    const cap: Capture = { listQueries: [], listMaxResults: [] };
+    const c = connectorWith(cap);
+    const res = await c.query({ ...CREDS, query: 'in:inbox', config: {}, limit: 10 } as never);
+    // Gmail gives no reliable match count — omitting total avoids reporting the
+    // page length as if it were the grand total.
+    expect(res.total).toBeUndefined();
+  });
+
+  it('search() ANDs recall terms onto the base q (bare tokens pass through)', async () => {
     const cap: Capture = { listQueries: [], listMaxResults: [] };
     const c = connectorWith(cap);
     await c.search({ ...CREDS, query: 'in:inbox', terms: ['report', 'urgent'], config: {}, limit: 5 } as never);
     // Gmail q is space-separated = AND
     expect(cap.listQueries).toEqual(['in:inbox report urgent']);
+  });
+
+  it('search() quotes a term containing spaces/operators so it matches literally', async () => {
+    const cap: Capture = { listQueries: [], listMaxResults: [] };
+    const c = connectorWith(cap);
+    await c.search({ ...CREDS, query: 'in:inbox', terms: ['weekly report'], config: {}, limit: 5 } as never);
+    expect(cap.listQueries).toEqual(['in:inbox "weekly report"']);
   });
 
   it('clamps the limit and passes it as maxResults', async () => {
@@ -153,6 +188,31 @@ describe('Gmail virtual-feed pushdown', () => {
     const res = await c.query({ ...CREDS, query: 'in:inbox', config: {}, limit: 2 } as never);
     expect(cap.listMaxResults[0]).toBe(2);
     expect(res.rows).toHaveLength(2);
+  });
+
+  it('applies offset by paging forward then dropping the leading rows', async () => {
+    // 5-message corpus, offset 2 + limit 2 → rows m3, m4 (m1, m2 dropped).
+    const corpus: FakeMessage[] = Array.from({ length: 5 }, (_, i) => ({
+      id: `m${i + 1}`,
+      threadId: `t${i + 1}`,
+      snippet: `msg ${i + 1}`,
+      headers: { Subject: `Subject ${i + 1}`, From: `s${i + 1}@acme.com`, Date: '' },
+    }));
+    const cap: Capture = { listQueries: [], listMaxResults: [] };
+    const c = connectorWith(cap, { messages: corpus });
+    const res = await c.query({ ...CREDS, query: 'in:inbox', config: {}, limit: 2, offset: 2 } as never);
+    expect(res.rows.map((r) => r.id)).toEqual(['m3', 'm4']);
+  });
+
+  it('rejects an unsupported sort (Gmail is always date-desc)', async () => {
+    const cap: Capture = { listQueries: [], listMaxResults: [] };
+    const c = connectorWith(cap);
+    await expect(
+      c.query({ ...CREDS, query: 'in:inbox', config: {}, sort: { column: 'subject', order: 'asc' } } as never),
+    ).rejects.toThrow(/only supports sort/i);
+    // …but the natural date-desc sort is accepted.
+    const ok = await c.query({ ...CREDS, query: 'in:inbox', config: {}, sort: { column: 'date', order: 'desc' } } as never);
+    expect(ok.rows.length).toBeGreaterThan(0);
   });
 
   it('skips a single unreadable message instead of failing the batch', async () => {

--- a/packages/server/src/__tests__/integration/connectors/virtual-feed-create.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/virtual-feed-create.test.ts
@@ -1,0 +1,106 @@
+/**
+ * manage_feeds create_feed — VIRTUAL feed creation (PR #1702).
+ *
+ * A virtual feed is read LIVE and never synced, so create_feed must:
+ *  - require config.query (the pushdown predicate readVirtualFeed reads);
+ *  - persist kind='virtual', virtual=true, and schedule/next_run_at = NULL;
+ *  - NOT validate the (irrelevant) sync schedule — a bad/absent schedule string
+ *    must not gate a virtual feed's creation. This is the ordering fix: schedule
+ *    validation used to run before the isVirtual branch, wrongly rejecting
+ *    create_feed({ virtual:true, schedule:'not-a-cron' }).
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { createTestConnection, createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+import { TestApiClient } from '../../setup/test-mcp-client';
+
+describe('manage_feeds create_feed (virtual)', () => {
+  let owner: TestApiClient;
+  let orgId: string;
+  let connectionId: number;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Virtual Create Org' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'vcreate@test.com' });
+    owner = await TestApiClient.for({ organizationId: org.id, userId: user.id, memberRole: 'owner' });
+    const conn = await createTestConnection({
+      organization_id: orgId,
+      connector_key: 'github',
+      created_by: user.id,
+      createDefaultFeed: false,
+    });
+    connectionId = Number(conn.id);
+  });
+
+  it('creates a virtual feed with schedule/next_run_at NULL and kind=virtual', async () => {
+    const result = (await owner.feeds.create({
+      connection_id: connectionId,
+      feed_key: 'issues',
+      virtual: true,
+      config: { query: 'is:issue is:open' },
+    })) as { error?: string; feed?: { id: number; kind: string; virtual: boolean; schedule: string | null; next_run_at: string | null } };
+
+    expect(result.error).toBeUndefined();
+    expect(result.feed?.kind).toBe('virtual');
+    expect(result.feed?.virtual).toBe(true);
+    expect(result.feed?.schedule).toBeNull();
+    expect(result.feed?.next_run_at).toBeNull();
+  });
+
+  it('rejects a virtual feed with no config.query', async () => {
+    const result = (await owner.feeds.create({
+      connection_id: connectionId,
+      feed_key: 'issues',
+      virtual: true,
+    })) as { error?: string; feed?: unknown };
+
+    expect(result.error).toMatch(/requires config\.query/i);
+    expect(result.feed).toBeUndefined();
+  });
+
+  it('does NOT validate the sync schedule for a virtual feed (ordering fix)', async () => {
+    // A malformed schedule string that validateSchedule would reject — it must be
+    // ignored because a virtual feed persists schedule = NULL.
+    const result = (await owner.feeds.create({
+      connection_id: connectionId,
+      feed_key: 'issues',
+      virtual: true,
+      schedule: 'not-a-cron-expression',
+      config: { query: 'is:issue' },
+    })) as { error?: string; feed?: { schedule: string | null } };
+
+    expect(result.error).toBeUndefined();
+    expect(result.feed?.schedule).toBeNull();
+  });
+
+  it('still validates the schedule for a NON-virtual feed', async () => {
+    const result = (await owner.feeds.create({
+      connection_id: connectionId,
+      feed_key: 'issues',
+      schedule: 'not-a-cron-expression',
+    })) as { error?: string };
+
+    expect(result.error).toBeTruthy();
+  });
+
+  it('the scheduler never selects the virtual feed for sync', async () => {
+    const created = (await owner.feeds.create({
+      connection_id: connectionId,
+      feed_key: 'issues',
+      virtual: true,
+      config: { query: 'is:issue is:open' },
+    })) as { feed?: { id: number } };
+    const feedId = Number(created.feed?.id);
+
+    // Even if we force a past next_run_at, the virtual guard excludes it.
+    const sql = getTestDb();
+    await sql`UPDATE feeds SET next_run_at = NOW() - INTERVAL '1 minute' WHERE id = ${feedId}`;
+    const [row] = await sql<{ virtual: boolean; next_run_at: string | null }[]>`
+      SELECT virtual, next_run_at FROM feeds WHERE id = ${feedId}
+    `;
+    expect(row?.virtual).toBe(true); // guard key; materializeDueFeeds filters virtual IS NOT TRUE
+  });
+});

--- a/packages/server/src/__tests__/integration/connectors/virtual-feed-create.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/virtual-feed-create.test.ts
@@ -11,6 +11,8 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { materializeDueFeeds } from '../../../scheduled/check-due-feeds';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import { createTestConnection, createTestOrganization, createTestUser } from '../../setup/test-fixtures';
 import { TestApiClient } from '../../setup/test-mcp-client';
@@ -86,7 +88,7 @@ describe('manage_feeds create_feed (virtual)', () => {
     expect(result.error).toBeTruthy();
   });
 
-  it('the scheduler never selects the virtual feed for sync', async () => {
+  it('materializeDueFeeds never creates a sync run for the virtual feed', async () => {
     const created = (await owner.feeds.create({
       connection_id: connectionId,
       feed_key: 'issues',
@@ -95,12 +97,15 @@ describe('manage_feeds create_feed (virtual)', () => {
     })) as { feed?: { id: number } };
     const feedId = Number(created.feed?.id);
 
-    // Even if we force a past next_run_at, the virtual guard excludes it.
+    // Force the virtual feed "due" (past next_run_at) so the `virtual` guard —
+    // not a NULL schedule — is what excludes it, then run the scheduler.
     const sql = getTestDb();
     await sql`UPDATE feeds SET next_run_at = NOW() - INTERVAL '1 minute' WHERE id = ${feedId}`;
-    const [row] = await sql<{ virtual: boolean; next_run_at: string | null }[]>`
-      SELECT virtual, next_run_at FROM feeds WHERE id = ${feedId}
+    await materializeDueFeeds({} as Env, sql);
+
+    const [runs] = await sql<{ n: number }[]>`
+      SELECT count(*)::int AS n FROM runs WHERE feed_id = ${feedId} AND run_type = 'sync'
     `;
-    expect(row?.virtual).toBe(true); // guard key; materializeDueFeeds filters virtual IS NOT TRUE
+    expect(Number(runs?.n)).toBe(0);
   });
 });

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -445,15 +445,20 @@ async function handleCreateFeed(
     };
   }
 
-  const schedule = args.schedule ?? getDefaultSchedule(env);
-  const scheduleError = validateSchedule(schedule);
-  if (scheduleError) {
-    return { error: scheduleError };
-  }
   // A virtual feed is read LIVE at request time and never synced, so it has no
   // schedule. It MUST carry config.query (the pushdown predicate readVirtualFeed
   // reads) — without it the live read would always throw at request time.
   const isVirtual = args.virtual === true;
+  // Only validate the sync schedule for non-virtual feeds — a virtual feed
+  // persists schedule = NULL, so a (possibly defaulted) schedule string must not
+  // gate its creation.
+  const schedule = isVirtual ? null : (args.schedule ?? getDefaultSchedule(env));
+  if (!isVirtual) {
+    const scheduleError = validateSchedule(schedule as string);
+    if (scheduleError) {
+      return { error: scheduleError };
+    }
+  }
   if (isVirtual) {
     const configQuery = args.config?.query;
     if (typeof configQuery !== 'string' || !configQuery.trim()) {
@@ -464,9 +469,9 @@ async function handleCreateFeed(
     }
   }
   // Don't schedule a first run for a feed whose connection is still pending auth,
-  // or for a virtual feed (never synced).
+  // or for a virtual feed (never synced — schedule is NULL).
   const nextRunAtVal =
-    !isVirtual && feedInitialStatus === 'active' ? nextRunAt(schedule) : null;
+    schedule && feedInitialStatus === 'active' ? nextRunAt(schedule) : null;
   // Reject cross-org entity_ids: a feed pointing at another org's entity links
   // synced events to a non-existent in-org entity (silent data-correctness bug).
   try {
@@ -493,7 +498,7 @@ async function handleCreateFeed(
       ${organizationId}, ${args.connection_id}, ${args.feed_key}, ${displayName}, ${feedInitialStatus},
       ${entityIdsValue}::bigint[],
       ${args.config ? sql.json(args.config) : null},
-      ${isVirtual ? null : schedule}, ${nextRunAtVal},
+      ${schedule}, ${nextRunAtVal},
       ${isVirtual ? 'virtual' : 'collected'}, ${isVirtual}
     )
     RETURNING *

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -5,9 +5,10 @@
  *
  * Actions:
  * - list_feeds: List feeds with optional filters
- * - read_feed: Read one feed by id, dispatching on kind — a collected/virtual
- *   feed returns its metadata + recent sync runs; a streaming (chat-channel)
- *   feed returns its live transcript from channel_messages.
+ * - read_feed: Read one feed by id, dispatching on kind — a collected feed
+ *   returns its metadata + recent sync runs; a virtual feed returns LIVE rows
+ *   via the connector query()/search() pushdown (never synced); a streaming
+ *   (chat-channel) feed returns its live transcript from channel_messages.
  * - create_feed: Create a new feed for a connection
  * - update_feed: Update feed settings
  * - delete_feed: Delete a feed
@@ -17,7 +18,9 @@
 import { getErrorMessage, parseJsonObject } from '@lobu/core';
 import { type Static, Type } from '@sinclair/typebox';
 import { getDb, pgBigintArray } from '../../db/client';
+import { authzScopeFromToolContext } from '../../authz/scope';
 import { filterChannelsForRequester } from '../../authz/channel-visibility';
+import { readVirtualFeed } from '../../lib/connector-pushdown';
 import { readChannelTranscript } from '../../gateway/connections/channel-transcript';
 import type { Env } from '../../index';
 import { getAuthProfileById } from '../../utils/auth-profiles';
@@ -76,6 +79,12 @@ const CreateFeedAction = Type.Object({
   ),
   schedule: Type.Optional(
     Type.String({ description: 'Cron expression for sync schedule (default: every 6 hours)' })
+  ),
+  virtual: Type.Optional(
+    Type.Boolean({
+      description:
+        'When true, create a VIRTUAL feed (kind=virtual): read LIVE via the connector query()/search() pushdown at request time, never synced — sync-lifecycle columns stay NULL. Requires config.query (a connector-specific read predicate, e.g. a Gmail search string) and the connector to implement the pushdown.',
+    })
   ),
 });
 
@@ -348,6 +357,20 @@ async function handleReadFeed(
     return { action: 'read_feed', kind: 'streaming', feed, messages };
   }
 
+  // A virtual feed is never synced — its content is read LIVE at request time
+  // via the connector's query()/search() pushdown (no events written). Same
+  // AuthzScope connection-visibility gate as the query_sql pushdown: a member
+  // only reaches org-visible or own connections; the feed's connection is the
+  // ACL boundary.
+  if (feed.kind === 'virtual') {
+    const live = await readVirtualFeed({
+      scope: authzScopeFromToolContext({ organizationId, userId: userId ?? null }),
+      feedId: args.feed_id,
+      limit: args.limit,
+    });
+    return { action: 'read_feed', kind: 'virtual', feed, ...live };
+  }
+
   const runs = await sql`
     SELECT id, status, items_collected, error_message, created_at, completed_at, checkpoint, connector_version
     FROM runs
@@ -419,8 +442,23 @@ async function handleCreateFeed(
   if (scheduleError) {
     return { error: scheduleError };
   }
-  // Don't schedule a first run for a feed whose connection is still pending auth.
-  const nextRunAtVal = feedInitialStatus === 'active' ? nextRunAt(schedule) : null;
+  // A virtual feed is read LIVE at request time and never synced, so it has no
+  // schedule. It MUST carry config.query (the pushdown predicate readVirtualFeed
+  // reads) — without it the live read would always throw at request time.
+  const isVirtual = args.virtual === true;
+  if (isVirtual) {
+    const configQuery = args.config?.query;
+    if (typeof configQuery !== 'string' || !configQuery.trim()) {
+      return {
+        error:
+          'A virtual feed requires config.query (a connector-specific read predicate, e.g. a Gmail search string).',
+      };
+    }
+  }
+  // Don't schedule a first run for a feed whose connection is still pending auth,
+  // or for a virtual feed (never synced).
+  const nextRunAtVal =
+    !isVirtual && feedInitialStatus === 'active' ? nextRunAt(schedule) : null;
   // Reject cross-org entity_ids: a feed pointing at another org's entity links
   // synced events to a non-existent in-org entity (silent data-correctness bug).
   try {
@@ -442,12 +480,13 @@ async function handleCreateFeed(
   const inserted = await sql`
     INSERT INTO feeds (
       organization_id, connection_id, feed_key, display_name, status,
-      entity_ids, config, schedule, next_run_at
+      entity_ids, config, schedule, next_run_at, kind, virtual
     ) VALUES (
       ${organizationId}, ${args.connection_id}, ${args.feed_key}, ${displayName}, ${feedInitialStatus},
       ${entityIdsValue}::bigint[],
       ${args.config ? sql.json(args.config) : null},
-      ${schedule}, ${nextRunAtVal}
+      ${isVirtual ? null : schedule}, ${nextRunAtVal},
+      ${isVirtual ? 'virtual' : 'collected'}, ${isVirtual}
     )
     RETURNING *
   `;

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -139,6 +139,14 @@ type ManageFeedsResult =
         isBot: boolean;
       }>;
     }
+  | {
+      action: 'read_feed';
+      kind: 'virtual';
+      feed: any;
+      rows: Record<string, unknown>[];
+      columns: { name: string; type: string }[];
+      total?: number;
+    }
   | { action: 'create_feed'; feed: any }
   | { action: 'update_feed'; feed: any }
   | { action: 'delete_feed'; deleted: true; feed_id: number }


### PR DESCRIPTION
## What

Gmail today is **action-only**: its `threads` feed can only be *collected* (synced into `events`). There is no live, never-indexed read path. The platform already has the machinery for a **virtual** feed (the `kind`/`virtual` columns, scheduler exclusion via `virtual IS NOT TRUE`, the `readVirtualFeed` seam, and the connector `search()`/`query()` contract) — but it's half-built: **no connector implements the pushdown** (base class throws by default), and **`readVirtualFeed` has zero production callers**.

This is the vertical slice that makes Gmail work as a virtual feed, end-to-end and testable in prod.

## Changes

**`packages/connectors/src/google_gmail.ts`** — implement the live pushdown:
- `query(ctx)` and `search(ctx)` on `GmailConnector` (override the throw-by-default stubs). Both route through a shared `liveSearch()`.
- `liveSearch()` builds a Gmail `q` from the feed's configured predicate (`config.query`) plus optional recall `terms` (Gmail `q` is space-separated = AND), lists matching messages, and returns metadata rows — `id, thread_id, subject, from, from_name, from_email, date, snippet, url` — **without persisting anything**.
- Reuses the same OAuth credential path (`ctx.credentials.accessToken`) as `sync()`/`execute()`, and the existing `getHeader`/`parseFromHeader` helpers. Pagination caps at the caller's `limit` (≤100).

**`packages/server/src/tools/admin/manage_feeds.ts`** — surface it:
- `create_feed` gains an optional `virtual: boolean`. When true: sets `kind='virtual'`, `virtual=true`, nulls `schedule`/`next_run_at`, and **requires `config.query`** (the pushdown predicate — without it the live read would always throw at request time).
- `read_feed` now dispatches a `kind='virtual'` feed → `readVirtualFeed` (the **first production caller** of that seam), fenced by the same connection-visibility `AuthzScope` as the `query_sql` pushdown.

## No behavior change

Collected and streaming feeds are untouched. Existing single-quote style preserved (connectors package is biome-excluded; the double-quote warnings are pre-existing elsewhere).

## Test plan (prod iterate)

After deploy, against the \`buremba\` org (Gmail connection 347, OAuth \`personal\` active):
1. **Create virtual feed:** \`manage_feeds create_feed {connection_id:347, feed_key:"threads", virtual:true, config:{query:"in:inbox newer_than:30d"}}\` → expect \`kind:"virtual"\`, \`schedule:null\`, \`next_run_at:null\`.
2. **Read live (bare):** \`manage_feeds read_feed {feed_id:<id>, limit:5}\` → expect \`kind:"virtual"\`, \`rows:[...]\` with real thread metadata, no new \`events\` written.
3. **Read live (recall terms):** \`manage_feeds read_feed {feed_id:<id>}\` with a search-style invocation → `terms` pushed down as an AND Gmail predicate.
4. **ACL:** a non-owner member of the org cannot read a \`visibility:"private"\` Gmail feed (readVirtualFeed throws "not found or not accessible").
5. **No-index invariant:** \`SELECT count(*) FROM events WHERE feed_id=<id>\` stays 0 after reads.

## Out of scope (follow-up)

Ambient recall — wiring virtual feeds into \`search_memory\`'s \`RECALL_SOURCES\` so Gmail auto-surfaces. This slice is independently testable via \`manage_feeds\` and unblocks that follow-up.

### E2E posture
This is the bug-fix-adjacent path but the change is not locally reproducible without a test DB; iteration is intentionally prod-driven (the buremba org is the target). Local connector unit test for \`liveSearch()\` can be added on request.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785624096&installation_id=136316292&pr_number=1702&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1702&signature=d68059caec23df596328f4a33f92712c796ebee3f38cebda2763c5f389ec7ec5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for virtual feeds that read live data on request (no scheduled sync behavior).
  * Gmail feeds can now return live search results with message details, links, and snippets.
* **Bug Fixes**
  * Improved Gmail live result handling so unreadable messages are skipped without interrupting the batch.
  * Feed reads now correctly distinguish scheduled vs virtual behavior.
* **Tests**
  * Added integration coverage for Gmail live search pushdown and virtual feed creation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->