### PR TITLE
fix(migrations): collision-guard the 3b straggler re-key

### DIFF
--- a/db/migrations/20260703100000_drop_watcher_windows.sql
+++ b/db/migrations/20260703100000_drop_watcher_windows.sql
@@ -98,7 +98,11 @@ WITH root AS (
      AND (ev.metadata->>'window_start') =
          to_char(ww.window_start AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
 )
-UPDATE public.watcher_reactions t SET window_id = r.root_id FROM root r WHERE t.window_id = r.old_id;
+UPDATE public.watcher_reactions t SET window_id = r.root_id FROM root r
+WHERE t.window_id = r.old_id
+  -- collision guard: a window_id that is already a canvas_state event id is
+  -- migrated — never rewrite it, even if a straggler ww.id collides numerically.
+  AND NOT EXISTS (SELECT 1 FROM public.events g WHERE g.id = t.window_id AND g.semantic_type = 'canvas_state');
 
 WITH root AS (
     SELECT ww.id AS old_id, ev.id AS root_id
@@ -111,7 +115,11 @@ WITH root AS (
      AND (ev.metadata->>'window_start') =
          to_char(ww.window_start AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
 )
-UPDATE public.runs t SET window_id = r.root_id FROM root r WHERE t.window_id = r.old_id;
+UPDATE public.runs t SET window_id = r.root_id FROM root r
+WHERE t.window_id = r.old_id
+  -- collision guard: a window_id that is already a canvas_state event id is
+  -- migrated — never rewrite it, even if a straggler ww.id collides numerically.
+  AND NOT EXISTS (SELECT 1 FROM public.events g WHERE g.id = t.window_id AND g.semantic_type = 'canvas_state');
 
 WITH root AS (
     SELECT ww.id AS old_id, ev.id AS root_id
@@ -124,7 +132,11 @@ WITH root AS (
      AND (ev.metadata->>'window_start') =
          to_char(ww.window_start AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
 )
-UPDATE public.watcher_window_events t SET window_id = r.root_id FROM root r WHERE t.window_id = r.old_id;
+UPDATE public.watcher_window_events t SET window_id = r.root_id FROM root r
+WHERE t.window_id = r.old_id
+  -- collision guard: a window_id that is already a canvas_state event id is
+  -- migrated — never rewrite it, even if a straggler ww.id collides numerically.
+  AND NOT EXISTS (SELECT 1 FROM public.events g WHERE g.id = t.window_id AND g.semantic_type = 'canvas_state');
 
 WITH root AS (
     SELECT ww.id AS old_id, ev.id AS root_id
@@ -137,7 +149,11 @@ WITH root AS (
      AND (ev.metadata->>'window_start') =
          to_char(ww.window_start AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
 )
-UPDATE public.event_classifications t SET window_id = r.root_id FROM root r WHERE t.window_id = r.old_id;
+UPDATE public.event_classifications t SET window_id = r.root_id FROM root r
+WHERE t.window_id = r.old_id
+  -- collision guard: a window_id that is already a canvas_state event id is
+  -- migrated — never rewrite it, even if a straggler ww.id collides numerically.
+  AND NOT EXISTS (SELECT 1 FROM public.events g WHERE g.id = t.window_id AND g.semantic_type = 'canvas_state');
 
 WITH root AS (
     SELECT ww.id AS old_id, ev.id AS root_id
@@ -154,7 +170,12 @@ UPDATE public.events e
 SET metadata = jsonb_set(e.metadata, '{window_id}', to_jsonb(r.root_id))
 FROM root r
 WHERE e.semantic_type = 'correction'
-  AND (e.metadata->>'window_id')::bigint = r.old_id;
+  AND (e.metadata->>'window_id')::bigint = r.old_id
+  -- collision guard (see re-keys above).
+  AND NOT EXISTS (
+      SELECT 1 FROM public.events g
+      WHERE g.id = (e.metadata->>'window_id')::bigint
+        AND g.semantic_type = 'canvas_state');
 
 -- (1c) Straggler provenance → run model (3a §d.1–d.3, all guarded/idempotent).
 WITH win AS (

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -614,10 +614,8 @@ export async function deleteEntity(
            OR to_entity_id = ANY(${entityTreeIdsLiteral}::bigint[])
       `;
 
-      // Canvas-on-events: window_id link rows are re-keyed to canvas root event
-      // ids, so key the cleanup on the denormalized watcher_id. (Legacy
-      // watcher_windows rows need no explicit delete — watcher_id CASCADEs when
-      // the watchers rows are hard-deleted below, until 3b drops the table.)
+      // Canvas-on-events: window_id link rows carry canvas root event ids, so
+      // key the cleanup on the denormalized watcher_id.
       await tx`
         DELETE FROM watcher_window_events
         WHERE watcher_id IN (


### PR DESCRIPTION
pi's post-merge verdict on #1703 flagged that the straggler re-key rewrites any `window_id` equal to a live `watcher_windows.id` — on a pathological install (more historical windows than events) a straggler id could collide with a canvas root event id and re-point an already-migrated row.

**Prod is provably unaffected** (max `watcher_windows.id` = 37 vs min canvas root id = 4,153,991, verified pre-apply). This hardens the migration **in place** for installs that haven't applied it: every re-key (4 tables + correction metadata) now refuses to rewrite a `window_id` that is already a `canvas_state` event id. Version-gated — already-applied installs skip the file entirely.

Verification: squawk clean; fresh-DB chain baseline→3b(hardened) green, watcher+corrections suites 112/112.

Also scrubs the stale "until 3b drops the table" comment in entity-management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQzN7gVzLwHunE428cqeuN

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785625117&installation_id=136316292&pr_number=1704&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1704&signature=4f8c2a4e1f238b468ababe0ba2b4535f6d9f64487d6027436baacf4e88ba362e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->