### PR TITLE
fix(entities): enforce field ownership on agent manage_entity writes

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/ownership-gate.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/ownership-gate.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Ownership gate on direct agent entity writes.
+ *
+ * The human<->agent feedback loop protects human-owned entity fields via
+ * `entities.field_controls` on the watcher PROMOTION path, but the direct
+ * `manage_entity` update path used to do a plain merge that silently clobbered
+ * human-owned fields. After the fix, EVERY non-human `manage_entity update`
+ * runs an ownership-aware `source:'watcher'` merge: unowned fields write
+ * normally, owned fields are BLOCKED and queued as a human approval, and the
+ * tool result reports what happened so the agent can tell the user.
+ *
+ * These contracts pin that behavior end-to-end through `executeTool` (the real
+ * access-controlled path) so the post-commit approval proposal is exercised.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import type { AuthContext } from '../../../tools/execute';
+import { executeTool } from '../../../tools/execute';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  createCanvasWindow,
+  createTestAgent,
+  createTestEntity,
+} from '../../setup/test-fixtures';
+import { TestWorkspace } from '../../setup/test-mcp-client';
+
+const TEST_ENV: Env = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+  JWT_SECRET: 'test-jwt-secret-for-testing-only',
+  BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
+};
+
+/** Owner web-session auth context (a real human — claims field ownership). */
+function humanCtx(orgId: string, userId: string): AuthContext {
+  return {
+    organizationId: orgId,
+    tokenOrganizationId: orgId,
+    userId,
+    memberRole: 'owner',
+    agentId: null,
+    requestedAgentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    tokenType: 'oauth',
+    requestUrl: `http://localhost/api/${orgId}`,
+    baseUrl: '',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  };
+}
+
+/** Agent auth context — same org/user but attributed to an agent run. */
+function agentCtx(orgId: string, userId: string, agentId = 'test-agent-1'): AuthContext {
+  return { ...humanCtx(orgId, userId), agentId, requestedAgentId: agentId };
+}
+
+async function manageEntityUpdate(
+  ctx: AuthContext,
+  entityId: number,
+  metadata: Record<string, unknown>,
+  opts?: { affirm_fields?: string[]; watcher_source?: { watcher_id: number; window_id: number } }
+) {
+  return executeTool(
+    'manage_entity',
+    {
+      action: 'update',
+      entity_id: entityId,
+      metadata,
+      ...(opts?.affirm_fields ? { affirm_fields: opts.affirm_fields } : {}),
+      ...(opts?.watcher_source ? { watcher_source: opts.watcher_source } : {}),
+    },
+    TEST_ENV,
+    ctx
+  ) as Promise<{
+    action: 'update';
+    applied_fields?: string[];
+    blocked_fields?: string[];
+    approval_queued?: boolean;
+    approval_url?: string;
+  }>;
+}
+
+/** Seed a watcher + canvas window (real FKs for watcher_source / reactions). */
+async function seedWatcherAndWindow(workspace: TestWorkspace, suffix: string) {
+  const entity = await createTestEntity({
+    name: `Gate Reaction Entity ${suffix}`,
+    organization_id: workspace.org.id,
+    created_by: workspace.users.owner.id,
+  });
+  const agent = await createTestAgent({
+    organizationId: workspace.org.id,
+    ownerUserId: workspace.users.owner.id,
+  });
+  const watcher = (await workspace.owner.watchers.create({
+    entity_id: entity.id,
+    slug: `gate-watcher-${suffix}`,
+    name: `Gate Watcher ${suffix}`,
+    prompt: 'Analyze inputs.',
+    agent_id: agent.agentId,
+  })) as { watcher_id: string };
+  const windowId = await createCanvasWindow({
+    watcherId: Number(watcher.watcher_id),
+    organizationId: workspace.org.id,
+    granularity: 'weekly',
+    windowStart: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+    windowEnd: new Date(),
+    extractedData: { problems: [] },
+    createdBy: workspace.users.owner.id,
+    entityIds: [entity.id],
+  });
+  return { entity, watcherId: Number(watcher.watcher_id), windowId };
+}
+
+describe('ownership gate on agent entity writes', () => {
+  let workspace: TestWorkspace;
+  let entity: { id: number };
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    workspace = await TestWorkspace.create({ name: 'Ownership Gate Org' });
+    const created = await createTestEntity({
+      name: 'Gate Target Entity',
+      organization_id: workspace.org.id,
+      created_by: workspace.users.owner.id,
+    });
+    entity = { id: created.id };
+  });
+
+  it('blocks an agent overwrite of a human-owned field and queues an approval', async () => {
+    const org = workspace.org.id;
+    const user = workspace.users.owner.id;
+
+    // Human claims ownership of `severity` by setting it.
+    await manageEntityUpdate(humanCtx(org, user), entity.id, { severity: 'high' });
+
+    // Agent tries to overwrite the owned field AND write a fresh unowned field.
+    const result = await manageEntityUpdate(agentCtx(org, user), entity.id, {
+      severity: 'critical',
+      notes: 'agent-added',
+    });
+
+    // Owned field UNCHANGED — the agent did not clobber it.
+    const [row] = await getTestDb()`
+      SELECT metadata, field_controls FROM entities WHERE id = ${entity.id}
+    `;
+    const metadata = row.metadata as Record<string, unknown>;
+    const controls = row.field_controls as Record<string, unknown>;
+    expect(metadata.severity).toBe('high');
+    expect(controls.severity).toBeTruthy();
+
+    // Unowned field wrote through.
+    expect(metadata.notes).toBe('agent-added');
+
+    // A pending approval run + interaction event exist for the blocked field.
+    const [run] = await getTestDb()`
+      SELECT id, action_input FROM runs
+      WHERE organization_id = ${org}
+        AND run_type = 'internal'
+        AND action_key = 'entity_field_change'
+        AND approval_status = 'pending'
+        AND status = 'pending'
+    `;
+    expect(run).toBeTruthy();
+    const proposal = run.action_input as {
+      entity_id: number;
+      fields: Record<string, unknown>;
+    };
+    expect(Number(proposal.entity_id)).toBe(entity.id);
+    expect(proposal.fields.severity).toBe('critical');
+
+    const [event] = await getTestDb()`
+      SELECT interaction_status FROM events
+      WHERE run_id = ${run.id} AND interaction_type = 'approval'
+    `;
+    expect(event?.interaction_status).toBe('pending');
+
+    // The tool result told the agent what happened.
+    expect(result.blocked_fields).toContain('severity');
+    expect(result.applied_fields).toContain('notes');
+    expect(result.approval_queued).toBe(true);
+  });
+
+  it('writes unowned fields without producing an approval', async () => {
+    const org = workspace.org.id;
+    const user = workspace.users.owner.id;
+
+    const result = await manageEntityUpdate(agentCtx(org, user), entity.id, {
+      domain: 'agent-set.example',
+      category: 'SaaS',
+    });
+
+    const [row] = await getTestDb()`SELECT metadata FROM entities WHERE id = ${entity.id}`;
+    const metadata = row.metadata as Record<string, unknown>;
+    expect(metadata.domain).toBe('agent-set.example');
+    expect(metadata.category).toBe('SaaS');
+
+    expect(result.applied_fields).toEqual(expect.arrayContaining(['domain', 'category']));
+    expect(result.blocked_fields ?? []).toEqual([]);
+
+    const approvals = await getTestDb()`
+      SELECT id FROM runs
+      WHERE organization_id = ${org}
+        AND run_type = 'internal'
+        AND action_key = 'entity_field_change'
+        AND approval_status = 'pending'
+    `;
+    expect(approvals).toHaveLength(0);
+    expect(result.approval_queued).toBeFalsy();
+  });
+
+  it('attributes the proposal to the watcher on the reaction path', async () => {
+    const org = workspace.org.id;
+    const user = workspace.users.owner.id;
+    const { entity: reactionEntity, watcherId, windowId } = await seedWatcherAndWindow(
+      workspace,
+      'reaction'
+    );
+
+    // Human owns the field first.
+    await manageEntityUpdate(humanCtx(org, user), reactionEntity.id, { severity: 'high' });
+
+    // Agent mutation attributed to a watcher reaction.
+    await manageEntityUpdate(agentCtx(org, user), reactionEntity.id, { severity: 'critical' }, {
+      watcher_source: { watcher_id: watcherId, window_id: windowId },
+    });
+
+    const [row] = await getTestDb()`SELECT metadata FROM entities WHERE id = ${reactionEntity.id}`;
+    expect((row.metadata as Record<string, unknown>).severity).toBe('high');
+
+    const [run] = await getTestDb()`
+      SELECT action_input FROM runs
+      WHERE organization_id = ${org}
+        AND run_type = 'internal'
+        AND action_key = 'entity_field_change'
+        AND approval_status = 'pending'
+    `;
+    expect(run).toBeTruthy();
+    expect(Number((run.action_input as { watcher_id: number }).watcher_id)).toBe(watcherId);
+  });
+
+  it('collapses an identical repeated agent edit into a single pending approval', async () => {
+    const org = workspace.org.id;
+    const user = workspace.users.owner.id;
+
+    await manageEntityUpdate(humanCtx(org, user), entity.id, { severity: 'high' });
+
+    await manageEntityUpdate(agentCtx(org, user), entity.id, { severity: 'critical' });
+    await manageEntityUpdate(agentCtx(org, user), entity.id, { severity: 'critical' });
+
+    const pending = await getTestDb()`
+      SELECT id FROM runs
+      WHERE organization_id = ${org}
+        AND run_type = 'internal'
+        AND action_key = 'entity_field_change'
+        AND approval_status = 'pending'
+    `;
+    expect(pending).toHaveLength(1);
+  });
+
+  it('applies the field change when the queued proposal is approved', async () => {
+    const org = workspace.org.id;
+    const user = workspace.users.owner.id;
+
+    await manageEntityUpdate(humanCtx(org, user), entity.id, { severity: 'high' });
+    await manageEntityUpdate(agentCtx(org, user), entity.id, { severity: 'critical' });
+
+    const [pending] = await getTestDb()`
+      SELECT id FROM runs
+      WHERE organization_id = ${org}
+        AND run_type = 'internal'
+        AND action_key = 'entity_field_change'
+        AND approval_status = 'pending'
+    `;
+    expect(pending).toBeTruthy();
+
+    const approveRes = (await executeTool(
+      'manage_operations',
+      { action: 'approve', run_id: Number(pending.id) },
+      TEST_ENV,
+      humanCtx(org, user)
+    )) as { approved?: boolean };
+    expect(approveRes.approved).toBe(true);
+
+    const [applied] = await getTestDb()`
+      SELECT metadata, field_controls FROM entities WHERE id = ${entity.id}
+    `;
+    expect((applied.metadata as Record<string, unknown>).severity).toBe('critical');
+    // Still human-owned — an approved value remains protected.
+    expect((applied.field_controls as Record<string, unknown>).severity).toBeTruthy();
+  });
+
+  it('rejects affirm_fields from an agent context (an agent cannot claim ownership)', async () => {
+    const org = workspace.org.id;
+    const user = workspace.users.owner.id;
+
+    await expect(
+      manageEntityUpdate(agentCtx(org, user), entity.id, {}, { affirm_fields: ['severity'] })
+    ).rejects.toThrow(/affirm_fields/);
+  });
+});

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -27,11 +27,13 @@ export const ENTITY_FIELD_CHANGE_ACTION_KEY = 'entity_field_change';
 /** Proposed field changes held in runs.action_input for a field-change gate run. */
 export interface EntityFieldChangeProposal {
   entity_id: number;
-  /** field_path -> proposed value (what the watcher wanted to write). */
+  /** field_path -> proposed value (what the watcher/agent wanted to write). */
   fields: Record<string, unknown>;
   /** field_path -> current human-owned value (for the diff card). */
   current?: Record<string, unknown>;
   watcher_id?: number | null;
+  /** Who proposed the change — drives the card label/author. Defaults to 'watcher'. */
+  attribution?: 'watcher' | 'agent';
   reason?: string | null;
 }
 
@@ -86,13 +88,15 @@ export async function proposeEntityFieldChange(
   const runId = Number((inserted[0] as { id: unknown }).id);
 
   const fieldList = Object.keys(proposal.fields).join(', ');
-  const label = `Watcher proposes changing ${fieldList}`;
+  const attribution = proposal.attribution ?? 'watcher';
+  const actorNoun = attribution === 'agent' ? 'An agent' : 'A watcher';
+  const label = `${actorNoun} proposes changing ${fieldList}`;
   const event = await insertEvent({
     entityIds: [proposal.entity_id],
     organizationId: ctx.organizationId,
     originId: `run_${runId}_pending`,
     title: `${label} — pending approval`,
-    content: proposal.reason ?? `A watcher proposed updating ${fieldList} on this entity.`,
+    content: proposal.reason ?? `${actorNoun} proposed updating ${fieldList} on this entity.`,
     semanticType: 'operation',
     runId,
     interactionType: 'approval',
@@ -105,11 +109,12 @@ export async function proposeEntityFieldChange(
       fields: proposal.fields,
       current: proposal.current ?? null,
       watcher_id: proposal.watcher_id ?? null,
+      attribution,
       reason: proposal.reason ?? null,
       status: 'pending_approval',
       run_id: runId,
     },
-    authorName: 'watcher',
+    authorName: attribution,
   });
   const eventId = Number(event.id);
 

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -46,6 +46,7 @@ import { buildEntityUrl } from '../../utils/url-builder';
 import { trackWatcherReaction } from '../../utils/watcher-reactions';
 import { isAdminOrOwnerRole } from '../access-control';
 import { MEMBER_ENTITY_TYPE_SLUG } from '../constants';
+import { proposeEntityFieldChange } from './entity-field-approval';
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
 import { buildEntityViewUrl, getOrgUrlContext, toEntityInfo } from '../view-urls';
@@ -286,6 +287,14 @@ type ManageEntityResult =
         enabled_classifiers?: string[] | null;
         view_url?: string;
       };
+      /** Fields the ownership-aware merge wrote (unowned for a watcher-source edit). */
+      applied_fields?: string[];
+      /** Human-owned fields the edit was blocked from writing — queued for approval. */
+      blocked_fields?: string[];
+      /** True when a blocked-field approval was queued this call. */
+      approval_queued?: boolean;
+      /** Permalink to the approval card, when one was queued. */
+      approval_url?: string;
     }
   | {
       action: 'list';
@@ -669,6 +678,31 @@ async function handleUpdate(
 
   const viewUrl = await buildEntityViewUrl(ctx, entityDetails);
 
+  // Post-commit: any blocked (human-owned) fields become a single durable
+  // approval card. Done AFTER the entity tx + change event so the approval
+  // (run + event + notification) is never rolled back with the edit — same
+  // rule as complete_window's blockedProposals.
+  const blocked = updatedEntity.fieldMerge?.blocked ?? {};
+  const blockedPaths = Object.keys(blocked);
+  let approvalQueued = false;
+  let approvalUrl: string | undefined;
+  if (blockedPaths.length > 0) {
+    const fields = Object.fromEntries(blockedPaths.map((p) => [p, blocked[p].proposed]));
+    const current = Object.fromEntries(blockedPaths.map((p) => [p, blocked[p].current]));
+    const res = await proposeEntityFieldChange(ctx, {
+      entity_id: entityId,
+      fields,
+      current,
+      watcher_id: args.watcher_source?.watcher_id ?? null,
+      attribution: args.watcher_source ? 'watcher' : 'agent',
+      reason: args.watcher_source
+        ? `A watcher proposes updating ${blockedPaths.join(', ')} on this entity.`
+        : `An agent proposes updating ${blockedPaths.join(', ')} on this entity.`,
+    });
+    approvalQueued = true;
+    approvalUrl = res.approvalUrl;
+  }
+
   return {
     action: 'update',
     entity: {
@@ -683,6 +717,10 @@ async function handleUpdate(
       enabled_classifiers: entityDetails.enabled_classifiers,
       view_url: viewUrl,
     },
+    applied_fields: updatedEntity.fieldMerge?.applied,
+    blocked_fields: blockedPaths.length > 0 ? blockedPaths : undefined,
+    approval_queued: approvalQueued || undefined,
+    approval_url: approvalUrl,
   };
 }
 

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -126,7 +126,7 @@ export const ManageEntitySchema = Type.Object({
   metadata: Type.Optional(
     Type.Record(Type.String(), Type.Unknown(), {
       description:
-        "[create/update/link/update_link] Custom metadata object. For entities: validated against the entity type's JSON schema. For links: relationship metadata.",
+        "[create/update/link/update_link] Custom metadata object. For entities: validated against the entity type's JSON schema. For links: relationship metadata. On update, fields a human owns are NOT overwritten — they are queued for the human's approval and reported in the result's `blocked_fields`/`approval_queued`; tell the user you PROPOSED those changes rather than claiming you set them. Unowned fields in the same call apply directly (`applied_fields`).",
     })
   ),
 

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -141,6 +141,16 @@ export interface CreatedEntity {
   warnings?: string[];
 }
 
+/**
+ * Outcome of the ownership-aware merge in `updateEntity`, threaded out so the
+ * caller can queue an approval for blocked (human-owned) fields. Kept off the
+ * shared `CreatedEntity` interface — only `updateEntity`'s return carries it.
+ */
+export interface FieldMergeInfo {
+  applied: string[];
+  blocked: Record<string, { current: unknown; proposed: unknown }>;
+}
+
 // ============================================
 // Validation Helpers
 // ============================================
@@ -359,7 +369,7 @@ export async function updateEntity(
   data: Partial<EntityData>,
   env: Env,
   ctx: ToolContext
-): Promise<CreatedEntity> {
+): Promise<CreatedEntity & { fieldMerge?: FieldMergeInfo }> {
   const pgSql = createDbClientFromEnv(env);
   const sql = getDb();
 
@@ -378,19 +388,31 @@ export async function updateEntity(
   const hasMetadataUpdates = Object.keys(metadataUpdates).length > 0;
   const affirmFields = Array.isArray(data.affirm_fields) ? data.affirm_fields : [];
 
+  // A genuine human edit (a real user, not an agent run) claims per-field
+  // ownership so a watcher can't later overwrite it without an approval. Every
+  // non-human write (chat agent or watcher reaction via manage_entity) is an
+  // ownership-aware watcher-source merge: unowned fields write, owned fields
+  // are blocked and surfaced to the caller for an approval. There is no
+  // plain-merge branch — the only caller is agent-attributed.
+  const isHumanEdit = !!ctx.userId && !ctx.agentId;
+  // affirm_fields claims ownership, which only a human may do. An agent must
+  // never silently claim a field — reject before touching the transaction.
+  if (!isHumanEdit && affirmFields.length > 0) {
+    throw new Error('affirm_fields is only allowed for human edits');
+  }
+
   const hasContent = data.content !== undefined;
   const contentValue = data.content?.trim() || null;
   const hasEmbedding = data.embedding !== undefined;
   const embeddingLiteral = toVectorLiteral(data.embedding);
 
-  // A genuine human edit (a real user, not an agent run) claims per-field ownership
-  // so a watcher can't later overwrite it without an approval. Agent/system writes keep
-  // the existing plain-merge behavior; watcher ownership-aware writes go through
-  // mergeEntityFields at the promotion call site.
-  const isHumanEdit = !!ctx.userId && !ctx.agentId;
   // An affirm-only edit (approve a value as-is) has no metadata delta but still
   // must run the merge so it can claim field ownership.
   const hasAffirm = isHumanEdit && affirmFields.length > 0;
+
+  // Outcome of the ownership-aware merge, threaded out so the caller can queue
+  // an approval for blocked (human-owned) fields AFTER the tx commits.
+  let fieldMerge: FieldMergeInfo | undefined;
 
   // Lock the entity row, merge metadata, and write in ONE transaction: concurrent
   // updates to the same entity serialize on the row lock, fixing the pre-existing
@@ -413,27 +435,31 @@ export async function updateEntity(
           ? JSON.parse(current[0].metadata as string)
           : (current[0].metadata ?? {})
       ) as Record<string, unknown>;
-      if (isHumanEdit) {
-        const existingControls = (
-          typeof current[0].field_controls === 'string'
-            ? JSON.parse(current[0].field_controls as string)
-            : (current[0].field_controls ?? {})
-        ) as Record<string, FieldControl>;
-        const merge = computeFieldMerge({
-          metadata: existing,
-          controls: existingControls,
-          fields: metadataUpdates,
-          source: 'human',
-          actorId: ctx.userId,
-          note: data.field_note ?? null,
-          nowIso: new Date().toISOString(),
-          affirm: affirmFields,
-        });
-        mergedMetadata = merge.nextMetadata;
-        mergedControls = merge.nextControls;
-      } else {
-        mergedMetadata = { ...existing, ...metadataUpdates };
-      }
+      const existingControls = (
+        typeof current[0].field_controls === 'string'
+          ? JSON.parse(current[0].field_controls as string)
+          : (current[0].field_controls ?? {})
+      ) as Record<string, FieldControl>;
+      const merge = computeFieldMerge({
+        metadata: existing,
+        controls: existingControls,
+        fields: metadataUpdates,
+        source: isHumanEdit ? 'human' : 'watcher',
+        actorId: isHumanEdit ? ctx.userId : (ctx.agentId ?? ctx.clientId ?? null),
+        note: isHumanEdit ? (data.field_note ?? null) : null,
+        nowIso: new Date().toISOString(),
+        affirm: isHumanEdit ? affirmFields : undefined,
+      });
+      mergedMetadata = merge.nextMetadata;
+      // A human edit claims ownership of the fields it sets; a watcher-source
+      // merge never claims ownership, so leave field_controls untouched.
+      mergedControls = isHumanEdit ? merge.nextControls : null;
+      fieldMerge = {
+        applied: Object.keys(merge.applied),
+        blocked: Object.fromEntries(
+          Object.entries(merge.blocked).map(([p, v]) => [p, { current: v.current, proposed: v.proposed }])
+        ),
+      };
     }
 
     await tx`
@@ -460,7 +486,7 @@ export async function updateEntity(
     if (sel.length === 0) {
       throw new Error(`Entity ${entityId} not found`);
     }
-    return sel[0];
+    return { ...sel[0], fieldMerge } as CreatedEntity & { fieldMerge?: FieldMergeInfo };
   });
 
   return result;


### PR DESCRIPTION
## Problem

The human↔agent feedback loop protects human-set entity fields via per-field ownership (`entities.field_controls`), but only on the **watcher promotion** path (`mergeEntityFields(source='watcher')`). The direct **`manage_entity` update** path — used by chat agents with the `manage_entity` tool **and** by watcher reactions (`reaction-executor` → `manage_entity` with `watcher_source`) — took a plain merge:

```ts
const isHumanEdit = !!ctx.userId && !ctx.agentId;
if (isHumanEdit) { /* ownership-aware */ }
else { mergedMetadata = { ...existing, ...metadataUpdates }; } // clobbers field_controls
```

So any agent context **silently overwrote human-owned fields** — no block, no approval, and the agent believed the write succeeded. This was the last gap in the feedback loop shipped with the canvas-on-events program (#1694→#1704): it was a documented scope cut ("Agent/system writes keep the existing plain-merge behavior").

## Fix

`updateEntity` now runs an ownership-aware `computeFieldMerge({ source: 'watcher' })` for **every** non-human edit, inside the existing `FOR UPDATE` single-tx:
- unowned fields write normally;
- human-owned fields are **blocked** (`field_controls` left untouched) and threaded out to the caller.

`manage_entity` then queues **one** `proposeEntityFieldChange` per entity for the blocked fields **after the tx commits** (approvals never ride the entity tx — same rule as complete-window's `blockedProposals`), attributed to the watcher (`watcher_source`) or the agent, and surfaces the outcome in the tool result (`applied_fields` / `blocked_fields` / `approval_queued` / `approval_url`) so the agent can tell the user "I proposed X for your approval" instead of believing it wrote X.

- `affirm_fields` is **rejected for non-human callers** (an agent must never claim ownership).
- `proposeEntityFieldChange` gains an optional `attribution: 'watcher' | 'agent'` (defaults `'watcher'`) so an agent-attributed card reads "An agent proposes…"; the existing complete-window caller is unchanged.
- No bypass flag, no compat shim — the plain-merge branch is removed entirely.

After this fix, every agent write path either applies to unowned fields or produces a human approval; **a human-owned value can only ever change by human action.**

## Scope audit

`updateEntity` has exactly one caller (`manage_entity`). Other `UPDATE entities` writers were audited and don't touch the protected free-form `metadata`/`field_controls`: `classifier-extraction` writes `attribute_values`/`enabled_classifiers`; `member-entity`/`entity-link-upsert`/`access-graph` are structural. The watcher promotion path already goes through `mergeEntityFields`. So `manage_entity → updateEntity` was the only unguarded agent metadata path.

## Tests (red → green)

New: `packages/server/src/__tests__/integration/watchers/ownership-gate.test.ts` — 6 integration tests driving the **real** `executeTool('manage_entity', …)` path (access control + the post-commit propose), plus the approve round-trip via `executeTool('manage_operations', {action:'approve'})`.

**RED** (source reverted to pre-fix, test unchanged):
```
× blocks an agent overwrite of a human-owned field and queues an approval
  → expected 'critical' to be 'high'            (severity got clobbered — the bug)
× writes unowned fields without producing an approval
  → expected undefined to deeply equal ArrayContaining ["domain","category"]
× attributes the proposal to the watcher on the reaction path
  → expected 'critical' to be 'high'
× collapses an identical repeated agent edit into a single pending approval
  → expected [] to have a length of 1 but got +0
× applies the field change when the queued proposal is approved
  → expected undefined to be truthy
× rejects affirm_fields from an agent context
  → resolved "{ action: 'update', … }" instead of rejecting
Tests  6 failed (6)
```

**GREEN** (after fix):
```
✓ src/__tests__/integration/watchers/ownership-gate.test.ts (6 tests)
  ✓ blocks an agent overwrite of a human-owned field and queues an approval
  ✓ writes unowned fields without producing an approval
  ✓ attributes the proposal to the watcher on the reaction path
  ✓ collapses an identical repeated agent edit into a single pending approval
  ✓ applies the field change when the queued proposal is approved
  ✓ rejects affirm_fields from an agent context (an agent cannot claim ownership)
Tests  6 passed (6)
```

No regression: `promote-keyed-entities.test.ts` (7) + `feedback-contract.test.ts` (8) = **15/15** green (the `proposeEntityFieldChange` label generalization is backward-compatible). `packages/server` typecheck clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785626839&installation_id=136316292&pr_number=1705&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1705&signature=9925177d441d5bde704c17642f62238d391313db37b0bccde7344765360002c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->