### PR TITLE
feat(feeds): surface virtual feeds in search_memory recall + query_sql

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/virtual-feed-surfaces.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/virtual-feed-surfaces.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Virtual feeds surfaced EVERYWHERE (follow-up to #1702) — two seams, one file:
+ *
+ *  (1) search_memory recall: the `virtualSource` in RECALL_SOURCES runs a virtual
+ *      feed's search() LIVE and returns a `virtual_feeds` facet — but ONLY for
+ *      feeds that opt in via `config.recall === true`, capped + logged, ACL-fenced,
+ *      failing independently. A feed without the flag stays invisible to recall.
+ *
+ *  (2) query_sql({ feed }): a virtual feed's STORED query runs LIVE, addressable
+ *      by numeric id OR "connection_slug/feed_key". `search_term` narrows via the
+ *      connector's search(); `feed`+`connection` together is rejected; the same
+ *      AuthzScope visibility fence applies; a non-virtual feed ref is refused.
+ *
+ * Reuses the #1702 pattern: the "external" connection points back at the test DB,
+ * so the postgres connector reads a throwaway table as if it were an external
+ * source — a real end-to-end pushdown (subprocess compile + fork + live query),
+ * no mocking.
+ *
+ * Red→green: without `virtualSource` in RECALL_SOURCES, (1) returns no
+ * virtual_feeds facet; without the `feed` branch in query_sql, (2) can't address
+ * a feed by id/key.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { AuthzScope } from '../../../authz/scope';
+import type { Env } from '../../../index';
+import { querySql } from '../../../tools/admin/query_sql';
+import type { ToolContext } from '../../../tools/registry';
+import { gatherRecall, type RecallContext } from '../../../tools/search';
+import { createAuthProfile } from '../../../utils/auth-profiles';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+  ownerToolContext,
+} from '../../setup/test-fixtures';
+
+const VFEED_SQL = 'SELECT id, name, amount FROM vfsurf_ext';
+
+describe('virtual feed surfaces (recall + query_sql)', () => {
+  let orgId: string;
+  let ownerId: string;
+  let ownerCtx: ToolContext;
+  let recallFeedId: number; // opt-in virtual feed (config.recall=true)
+  let plainFeedId: number; // virtual feed WITHOUT the recall flag
+  let privRecallFeedId: number; // opt-in but on a PRIVATE connection (owner-only)
+  let nonVirtualFeedId: number;
+
+  const ownerScope = (): AuthzScope => ({ organizationId: orgId, principal: ownerId });
+  const memberScope = (): AuthzScope => ({ organizationId: orgId, principal: 'member-x' });
+  const memberCtx = (): ToolContext => ({
+    organizationId: orgId,
+    userId: 'member-x',
+    memberRole: 'member',
+    isAuthenticated: true,
+    tokenType: 'oauth',
+    scopedToOrg: false,
+    allowCrossOrg: false,
+  });
+
+  const recallCtx = (query: string): RecallContext => ({
+    query,
+    contentAgentId: undefined,
+    contentLimit: 10,
+    env: {} as Env,
+  });
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'VFeedSurfaces' });
+    orgId = org.id;
+    const user = await createTestUser({ email: 'vfsurf@test.com' });
+    ownerId = user.id;
+    await addUserToOrganization(user.id, org.id, 'owner');
+    ownerCtx = ownerToolContext(orgId, user.id);
+
+    const db = getTestDb();
+    await db`DROP TABLE IF EXISTS vfsurf_ext`;
+    await db`CREATE TABLE vfsurf_ext (id bigserial primary key, name text, amount numeric)`;
+    await db`INSERT INTO vfsurf_ext (name, amount) VALUES ('apple', 10), ('banana', 5), ('apricot', 7)`;
+
+    const profile = await createAuthProfile({
+      organizationId: orgId,
+      connectorKey: 'postgres',
+      displayName: 'ext db',
+      profileKind: 'env',
+      authData: { DATABASE_URL: process.env.DATABASE_URL as string },
+    });
+
+    // Register the bundled postgres connector for this org (runnable from bundle;
+    // compiled_code NULL → resolveConnectorCode compiles on demand).
+    await db`
+      INSERT INTO connector_definitions
+        (key, name, version, feeds_schema, auth_schema, organization_id, status, created_at, updated_at)
+      VALUES ('postgres', 'PostgreSQL', '1.0.0', ${db.json({})}, ${db.json({})}, ${orgId}, 'active', NOW(), NOW())
+      ON CONFLICT DO NOTHING
+    `;
+    await db`
+      INSERT INTO connector_versions (connector_key, version, compiled_code, source_path, created_at)
+      VALUES ('postgres', '1.0.0', NULL, NULL, NOW())
+      ON CONFLICT DO NOTHING
+    `;
+
+    // Org-visible connection with THREE feeds: an opt-in recall feed, a plain
+    // virtual feed (no recall flag), and a non-virtual control.
+    const [orgConn] = await db`
+      INSERT INTO connections
+        (organization_id, connector_key, slug, display_name, status, auth_profile_id, visibility, created_by, created_at, updated_at)
+      VALUES
+        (${orgId}, 'postgres', 'vfsurf-org-db', 'Org DB', 'active', ${profile.id}, 'org', ${ownerId}, NOW(), NOW())
+      RETURNING id
+    `;
+    const orgConnId = Number((orgConn as { id: number }).id);
+
+    const [recallFeed] = await db`
+      INSERT INTO feeds (organization_id, connection_id, feed_key, status, virtual, config, created_at, updated_at)
+      VALUES (${orgId}, ${orgConnId}, 'inbox', 'active', true,
+        ${db.json({ query: VFEED_SQL, primary_key: 'id', cursor_column: 'id', recall: true })}, NOW(), NOW())
+      RETURNING id
+    `;
+    recallFeedId = Number((recallFeed as { id: number }).id);
+
+    const [plainFeed] = await db`
+      INSERT INTO feeds (organization_id, connection_id, feed_key, status, virtual, config, created_at, updated_at)
+      VALUES (${orgId}, ${orgConnId}, 'plain', 'active', true,
+        ${db.json({ query: VFEED_SQL, primary_key: 'id', cursor_column: 'id' })}, NOW(), NOW())
+      RETURNING id
+    `;
+    plainFeedId = Number((plainFeed as { id: number }).id);
+
+    const [normalFeed] = await db`
+      INSERT INTO feeds (organization_id, connection_id, feed_key, status, virtual, config, created_at, updated_at)
+      VALUES (${orgId}, ${orgConnId}, 'synced', 'active', false,
+        ${db.json({ query: VFEED_SQL, primary_key: 'id', cursor_column: 'id' })}, NOW(), NOW())
+      RETURNING id
+    `;
+    nonVirtualFeedId = Number((normalFeed as { id: number }).id);
+
+    // PRIVATE connection owned by the owner + an opt-in recall feed on it — a
+    // member must NOT see it surfaced in recall or reachable via query_sql.
+    const [privConn] = await db`
+      INSERT INTO connections
+        (organization_id, connector_key, slug, display_name, status, auth_profile_id, visibility, created_by, created_at, updated_at)
+      VALUES
+        (${orgId}, 'postgres', 'vfsurf-priv-db', 'Private DB', 'active', ${profile.id}, 'private', ${ownerId}, NOW(), NOW())
+      RETURNING id
+    `;
+    const privConnId = Number((privConn as { id: number }).id);
+    const [privRecallFeed] = await db`
+      INSERT INTO feeds (organization_id, connection_id, feed_key, status, virtual, config, created_at, updated_at)
+      VALUES (${orgId}, ${privConnId}, 'priv-inbox', 'active', true,
+        ${db.json({ query: VFEED_SQL, primary_key: 'id', cursor_column: 'id', recall: true })}, NOW(), NOW())
+      RETURNING id
+    `;
+    privRecallFeedId = Number((privRecallFeed as { id: number }).id);
+  }, 120_000);
+
+  afterAll(async () => {
+    await getTestDb()`DROP TABLE IF EXISTS vfsurf_ext`;
+  });
+
+  // ---- (1) search_memory recall ------------------------------------------
+
+  it('(1) gatherRecall surfaces an OPT-IN virtual feed as a virtual_feeds facet (live search)', async () => {
+    const res = await gatherRecall(ownerScope(), recallCtx('ap'));
+    expect(res.virtual_feeds).toBeDefined();
+    // Only the org-visible opt-in feed matches for the owner (the private one also
+    // opts in and the owner CAN see it — so expect BOTH the org + private feed).
+    const byKey = new Map((res.virtual_feeds ?? []).map((b) => [b.feed_key, b]));
+    expect(byKey.has('inbox')).toBe(true);
+    // search('ap') → apple + apricot at the source (ILIKE pushdown), banana excluded.
+    const inbox = byKey.get('inbox');
+    expect((inbox?.rows ?? []).map((r) => r.name).sort()).toEqual(['apple', 'apricot']);
+    expect(inbox?.feed_id).toBe(recallFeedId);
+  }, 60_000);
+
+  it('(1) does NOT surface a virtual feed that has not opted in (config.recall unset)', async () => {
+    const res = await gatherRecall(ownerScope(), recallCtx('ap'));
+    const keys = (res.virtual_feeds ?? []).map((b) => b.feed_key);
+    expect(keys).not.toContain('plain'); // plainFeedId is virtual but not recall:true
+  }, 60_000);
+
+  it('(1) fences recall by AuthzScope: a member does not see the owner’s PRIVATE recall feed', async () => {
+    const ownerRes = await gatherRecall(ownerScope(), recallCtx('ap'));
+    const ownerKeys = (ownerRes.virtual_feeds ?? []).map((b) => b.feed_key);
+    expect(ownerKeys).toContain('priv-inbox'); // owner sees it
+
+    const memberRes = await gatherRecall(memberScope(), recallCtx('ap'));
+    const memberKeys = (memberRes.virtual_feeds ?? []).map((b) => b.feed_key);
+    expect(memberKeys).not.toContain('priv-inbox'); // member is fenced out
+    expect(memberKeys).toContain('inbox'); // …but the org-visible one is visible
+  }, 60_000);
+
+  it('(1) omits the facet when the query matches no live rows', async () => {
+    const res = await gatherRecall(ownerScope(), recallCtx('zzz-no-match'));
+    expect(res.virtual_feeds).toBeUndefined();
+  }, 60_000);
+
+  it('(1) omits the facet entirely when there is no query text', async () => {
+    const res = await gatherRecall(ownerScope(), recallCtx(''));
+    expect(res.virtual_feeds).toBeUndefined();
+  }, 60_000);
+
+  // ---- (2) query_sql({ feed }) -------------------------------------------
+
+  it('(2) query_sql addresses a virtual feed by numeric id and runs its STORED query live', async () => {
+    const res = await querySql({ feed: String(recallFeedId), limit: 10 }, {}, ownerCtx);
+    expect(res.error).toBeUndefined();
+    expect(res.rows.map((r) => r.name).sort()).toEqual(['apple', 'apricot', 'banana']);
+  }, 60_000);
+
+  it('(2) query_sql addresses a virtual feed by "connection_slug/feed_key"', async () => {
+    const res = await querySql({ feed: 'vfsurf-org-db/inbox', limit: 10 }, {}, ownerCtx);
+    expect(res.error).toBeUndefined();
+    expect(res.rows.map((r) => r.name).sort()).toEqual(['apple', 'apricot', 'banana']);
+  }, 60_000);
+
+  it('(2) search_term narrows the feed read via the connector search() pushdown', async () => {
+    const res = await querySql({ feed: String(recallFeedId), search_term: 'ap', limit: 10 }, {}, ownerCtx);
+    expect(res.error).toBeUndefined();
+    expect(res.rows.map((r) => r.name).sort()).toEqual(['apple', 'apricot']);
+    expect(res.total_count).toBe(2);
+  }, 60_000);
+
+  it('(2) rejects passing both feed and connection', async () => {
+    const res = await querySql({ feed: String(recallFeedId), connection: 'vfsurf-org-db' }, {}, ownerCtx);
+    expect(res.error).toMatch(/either .*feed.* or .*connection/i);
+  }, 60_000);
+
+  it('(2) refuses to address a NON-virtual feed', async () => {
+    const res = await querySql({ feed: String(nonVirtualFeedId) }, {}, ownerCtx);
+    expect(res.error).toMatch(/not a virtual feed/i);
+  }, 60_000);
+
+  it('(2) errors on an unresolvable feed reference', async () => {
+    const res = await querySql({ feed: 'vfsurf-org-db/nope' }, {}, ownerCtx);
+    expect(res.error).toMatch(/not found or not accessible/i);
+  }, 60_000);
+
+  it('(2) a member cannot reach a feed on another user’s PRIVATE connection', async () => {
+    const res = await querySql({ feed: String(privRecallFeedId) }, {}, memberCtx());
+    expect(res.rows).toHaveLength(0);
+    expect(res.error).toMatch(/not found or not accessible/i);
+    // …and the owner still can.
+    const ok = await querySql({ feed: String(privRecallFeedId) }, {}, ownerCtx);
+    expect(ok.error).toBeUndefined();
+    expect(ok.rows.length).toBe(3);
+  }, 60_000);
+});

--- a/packages/server/src/formatting/__tests__/markdown-formatter.test.ts
+++ b/packages/server/src/formatting/__tests__/markdown-formatter.test.ts
@@ -72,6 +72,34 @@ describe('formatToolResult', () => {
       expect(md).toContain('quarterly revenue forecast');
       expect(md).toContain('Alice');
     });
+
+    it('renders virtual-feed rows as a table and escapes cell delimiters', () => {
+      const result = {
+        entity: null,
+        matches: [],
+        virtual_feeds: [
+          {
+            feed_id: 7,
+            feed_key: 'inbox',
+            columns: [
+              { name: 'subject', type: 'text' },
+              { name: 'from', type: 'text' },
+            ],
+            // A subject with a literal pipe AND a backslash must not break the
+            // table row and must be escaped completely (backslash + pipe).
+            rows: [{ subject: 'a | b \\ c', from: 'alice@x.com' }],
+          },
+        ],
+      };
+      const md = formatToolResult('search_memory', result);
+      expect(md).not.toContain('No Results Found');
+      expect(md).toContain('inbox (live) (1)');
+      expect(md).toContain('| subject | from |');
+      // backslash escaped to `\\`, pipe escaped to `\|` — the raw ` | ` delimiter
+      // never leaks into the cell.
+      expect(md).toContain('a \\| b \\\\ c');
+      expect(md).toContain('alice@x.com');
+    });
   });
 
   describe('query_sql tool', () => {

--- a/packages/server/src/formatting/markdown-formatter.ts
+++ b/packages/server/src/formatting/markdown-formatter.ts
@@ -319,10 +319,11 @@ function formatSearchResult(result: any, options: FormatterOptions): string {
   const { entity, matches, suggestion } = result;
   const hasContent = result.content?.length > 0;
   const hasConversation = result.conversation_messages?.length > 0;
+  const hasVirtual = result.virtual_feeds?.length > 0;
 
   let md: string;
 
-  if (!entity && matches.length === 0 && (hasContent || hasConversation)) {
+  if (!entity && matches.length === 0 && (hasContent || hasConversation || hasVirtual)) {
     // Recall hits with no entity match — don't claim "No Results"; the content
     // and channel-conversation sections appended below carry the answer.
     md = '# 🔍 Search Results\n\n';
@@ -366,7 +367,39 @@ function formatSearchResult(result: any, options: FormatterOptions): string {
   if (hasConversation) {
     md += formatConversationMessages(result.conversation_messages);
   }
+  if (hasVirtual) {
+    md += formatVirtualFeeds(result.virtual_feeds);
+  }
 
+  return md;
+}
+
+/** Render live virtual-feed recall blocks (one per opt-in feed). Rows are
+ * arbitrary connector columns, so each feed prints its own compact table under a
+ * feed-keyed heading — keeps default (non-JSON) MCP clients from seeing "No
+ * Results" when search_memory matched only a live source. */
+function formatVirtualFeeds(feeds: any[]): string {
+  let md = '';
+  for (const feed of feeds) {
+    const cols: { name: string }[] = feed.columns ?? [];
+    const rows: Record<string, unknown>[] = feed.rows ?? [];
+    const heading = feed.feed_key ? `${feed.feed_key} (live)` : 'Live Feed';
+    md += `## ${heading} (${rows.length})\n\n`;
+    if (cols.length === 0 || rows.length === 0) continue;
+    const names = cols.map((c) => c.name);
+    md += `| ${names.join(' | ')} |\n`;
+    md += `| ${names.map(() => '---').join(' | ')} |\n`;
+    for (const row of rows) {
+      const cells = names.map((n) => {
+        const v = row[n];
+        const s = v == null ? '' : String(v);
+        const flat = s.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+        return flat.length > 80 ? `${flat.slice(0, 80)}…` : flat;
+      });
+      md += `| ${cells.join(' | ')} |\n`;
+    }
+    md += '\n';
+  }
   return md;
 }
 

--- a/packages/server/src/formatting/markdown-formatter.ts
+++ b/packages/server/src/formatting/markdown-formatter.ts
@@ -393,7 +393,9 @@ function formatVirtualFeeds(feeds: any[]): string {
       const cells = names.map((n) => {
         const v = row[n];
         const s = v == null ? '' : String(v);
-        const flat = s.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+        // Escape backslash FIRST (so the escaping we add for `|` isn't itself
+        // re-escaped), then the cell delimiter, then flatten newlines.
+        const flat = s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ');
         return flat.length > 80 ? `${flat.slice(0, 80)}…` : flat;
       });
       md += `| ${cells.join(' | ')} |\n`;

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -7,9 +7,10 @@
  */
 
 import { type Static, Type } from '@sinclair/typebox';
-import { authzScopeFromToolContext } from '../../authz/scope';
+import { type AuthzScope, authzScopeFromToolContext } from '../../authz/scope';
+import { compileConnectionRowVisibility } from '../../authz/connection-visibility';
 import { getDb } from '../../db/client';
-import { runConnectorQuery } from '../../lib/connector-pushdown';
+import { readVirtualFeed, runConnectorQuery } from '../../lib/connector-pushdown';
 import { validateAndScopeQuery } from '../../utils/execute-data-sources';
 import logger from '../../utils/logger';
 import { raceAbort } from '../../utils/race-abort';
@@ -22,14 +23,22 @@ import { isAdminOrOwnerRole } from '../access-control';
 import { getErrorMessage } from "@lobu/core";
 
 export const QuerySqlSchema = Type.Object({
-  sql: Type.String({
-    description:
-      'Base SELECT query. Table references are auto-scoped to your organization. It is wrapped as a subquery, so ORDER BY / LIMIT / window functions inside it are fine; pagination + sort are added on the outside via sort_by/limit/offset.',
-  }),
+  sql: Type.Optional(
+    Type.String({
+      description:
+        'Base SELECT query. Required unless `feed` is set (a virtual feed runs its OWN stored query, so `sql` is ignored there). Table references are auto-scoped to your organization. It is wrapped as a subquery, so ORDER BY / LIMIT / window functions inside it are fine; pagination + sort are added on the outside via sort_by/limit/offset.',
+    })
+  ),
   connection: Type.Optional(
     Type.String({
       description:
         'Optional connection slug. When set, `sql` runs LIVE (read-only) against that connection’s external database via its connector (pushdown), and the internal org-scoping is skipped. When unset, the query runs over your org’s internal tables.',
+    })
+  ),
+  feed: Type.Optional(
+    Type.String({
+      description:
+        'Optional virtual-feed reference (numeric feed id, or "connection_slug/feed_key"). When set, the feed’s STORED query runs LIVE against its source (no `sql` needed — it is ignored); `search_term` narrows via the connector’s search(). Mutually exclusive with `connection`.',
     })
   ),
   org_slug: Type.Optional(
@@ -128,6 +137,48 @@ function coercePageBounds(
   };
 }
 
+/**
+ * Resolve a `feed` reference to a numeric virtual-feed id under `scope`. Accepts
+ * a bare numeric id or "connection_slug/feed_key". Applies the SAME
+ * connection-visibility gate every read seam uses, so a member can only address a
+ * feed on an org-visible or self-owned connection. readVirtualFeed re-checks
+ * visibility + asserts virtual=true, so this only needs to disambiguate the ref.
+ */
+async function resolveVirtualFeedId(ref: string, scope: AuthzScope): Promise<number> {
+  const trimmed = ref.trim();
+  if (/^\d+$/.test(trimmed)) return Number(trimmed);
+
+  const slash = trimmed.indexOf('/');
+  if (slash <= 0 || slash === trimmed.length - 1) {
+    throw new Error(
+      `invalid feed reference '${ref}' — use a numeric feed id or "connection_slug/feed_key"`
+    );
+  }
+  const connectionSlug = trimmed.slice(0, slash);
+  const feedKey = trimmed.slice(slash + 1);
+
+  const sql = getDb();
+  // $1 org, $2 slug, $3 feed_key → visibility principal is $4.
+  const vis = compileConnectionRowVisibility(scope, 4, 'c');
+  const rows = (await sql.unsafe(
+    `SELECT f.id
+     FROM feeds f
+     JOIN connections c ON c.id = f.connection_id
+     WHERE f.organization_id = $1
+       AND c.slug = $2
+       AND f.feed_key = $3
+       AND f.deleted_at IS NULL
+       AND c.deleted_at IS NULL
+       ${vis.sql}
+     LIMIT 1`,
+    [scope.organizationId, connectionSlug, feedKey, ...vis.params],
+  )) as unknown as Array<{ id: number }>;
+  if (rows.length === 0) {
+    throw new Error(`virtual feed '${ref}' not found or not accessible`);
+  }
+  return rows[0].id;
+}
+
 function errorResult(message: string, startTime: number): QuerySqlResult {
   return {
     rows: [],
@@ -148,8 +199,10 @@ export async function querySqlImpl(
 ): Promise<QuerySqlResult> {
   const startTime = Date.now();
 
-  const baseSql = args.sql.trim();
-  if (!baseSql) return errorResult('SQL query is required.', startTime);
+  const baseSql = (args.sql ?? '').trim();
+  // `feed` runs a STORED query, so caller `sql` is optional there; every other
+  // path requires it.
+  if (!baseSql && !args.feed) return errorResult('SQL query is required.', startTime);
 
   // The base query is wrapped as `SELECT * FROM (<sql>) _t [ORDER BY …] LIMIT …`,
   // so an ORDER BY / LIMIT / window inside the caller's SQL is valid (it sits in
@@ -220,6 +273,45 @@ export async function querySqlImpl(
       callerIsAdmin = true; // cross-org already required owner/admin in the target
     } else {
       callerIsAdmin = isAdminOrOwnerRole(role);
+    }
+  }
+
+  if (args.feed && args.connection) {
+    return errorResult('Pass either `feed` or `connection`, not both.', startTime);
+  }
+
+  // Virtual-feed pushdown: `feed` names a virtual feed whose STORED query runs
+  // LIVE against its source (caller `sql` is ignored — the query is authored on
+  // the feed). `search_term` narrows via the connector's search(). Same
+  // AuthzScope connection-visibility gate readVirtualFeed re-checks; the feed-ref
+  // resolution below applies it too. This is strictly tighter than the
+  // `connection` pushdown — no arbitrary caller SQL.
+  if (args.feed) {
+    const bounds = coercePageBounds(args);
+    if ('error' in bounds) return errorResult(bounds.error, startTime);
+    const { limit, offset } = bounds;
+    const scope = authzScopeFromToolContext({ organizationId: targetOrgId, userId: ctx.userId });
+    try {
+      const feedId = await resolveVirtualFeedId(args.feed, scope);
+      const r = await readVirtualFeed({
+        scope,
+        feedId,
+        terms: args.search_term ? [args.search_term] : undefined,
+        limit,
+        offset,
+        sort: args.sort_by
+          ? { column: args.sort_by, order: args.sort_order === 'desc' ? 'desc' : 'asc' }
+          : undefined,
+      });
+      return {
+        rows: r.rows,
+        columns: r.columns,
+        total_count: r.total ?? r.rows.length,
+        has_more: r.total !== undefined ? offset + limit < r.total : r.rows.length >= limit,
+        execution_time_ms: Date.now() - startTime,
+      };
+    } catch (err) {
+      return errorResult(getErrorMessage(err), startTime);
     }
   }
 

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -21,6 +21,7 @@ import { withValidatedArgs } from '../validate-args';
 import { SortOrderField } from './schemas/common-fields';
 import { isAdminOrOwnerRole } from '../access-control';
 import { getErrorMessage } from "@lobu/core";
+import { ToolUserError } from '../../utils/errors';
 
 export const QuerySqlSchema = Type.Object({
   sql: Type.Optional(
@@ -201,8 +202,13 @@ export async function querySqlImpl(
 
   const baseSql = (args.sql ?? '').trim();
   // `feed` runs a STORED query, so caller `sql` is optional there; every other
-  // path requires it.
-  if (!baseSql && !args.feed) return errorResult('SQL query is required.', startTime);
+  // path requires it. `sql` is optional at the SCHEMA level (so a feed call needs
+  // no dummy sql), so this presence check moved here from the typebox boundary —
+  // but it stays a hard REJECT (throw), not a structured { error }, preserving the
+  // "missing sql rejects at the tool boundary, naming the field" contract.
+  if (!baseSql && !args.feed) {
+    throw new ToolUserError('query_sql requires `sql` (or a `feed` to read).', 400);
+  }
 
   // The base query is wrapped as `SELECT * FROM (<sql>) _t [ORDER BY …] LIMIT …`,
   // so an ORDER BY / LIMIT / window inside the caller's SQL is valid (it sits in

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -10,9 +10,11 @@
 import { type Static, Type } from '@sinclair/typebox';
 import { hasRequiredMcpScope } from '../auth/tool-access';
 import { type AuthzScope, authzScopeFromToolContext } from '../authz/scope';
+import { compileConnectionRowVisibility } from '../authz/connection-visibility';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
 import type { FeedReader } from '../lib/feed-reader';
+import { readVirtualFeed } from '../lib/connector-pushdown';
 import { entityLinkMatchSql, searchContentByText } from '../utils/content-search';
 import { resolveBoundChannelRows, stripPlatformPrefix } from '../gateway/channels/bound-channels';
 import { filterChannelsForRequester } from '../authz/channel-visibility';
@@ -231,6 +233,19 @@ interface ConversationSnippet {
   occurred_at: string | null;
 }
 
+// A live block of rows recalled from ONE virtual feed (read via readVirtualFeed's
+// search() pushdown). Distinct from ContentSnippet/ConversationSnippet on purpose:
+// virtual rows are arbitrary connector columns (Gmail: id/subject/from/date/…),
+// so they carry their own `columns` header rather than being coerced into a fixed
+// snippet shape that would drop or mislabel columns. Nothing is persisted — these
+// are read live from the source at recall time. See project_conversation_feeds_virtual.
+interface VirtualFeedRows {
+  feed_id: number;
+  feed_key: string;
+  columns: { name: string; type: string }[];
+  rows: Record<string, unknown>[];
+}
+
 interface UnifiedSearchResult {
   entity_type: string | null;
   entity: Entity | null;
@@ -248,6 +263,10 @@ interface UnifiedSearchResult {
    * bound channels. Replaces the get_channel_history tool — read past convos
    * through the same search call. */
   conversation_messages?: ConversationSnippet[];
+  /** Live rows recalled from opt-in virtual feeds (`config.recall === true`) —
+   * one block per feed, read via the connector's `search()` pushdown at request
+   * time. Never persisted. */
+  virtual_feeds?: VirtualFeedRows[];
   discovery_status?: 'not_found' | 'complete' | 'discovering';
   suggestion?: string;
   view_url?: string;
@@ -453,12 +472,22 @@ export interface RecallContext {
 }
 
 /**
- * The consolidated recall types. We landed on TWO: `knowledge` (the `events`
- * store — where data feeds and promoted memory live) and `conversation` (the
- * `channel_messages` chat transcript). Both are read through ONE abstraction.
- * Add a type here + a RECALL_SOURCES entry; nothing branches on the kind.
+ * The consolidated recall types. `knowledge` (the `events` store — where data
+ * feeds and promoted memory live), `conversation` (the `channel_messages` chat
+ * transcript), and `virtual` (opt-in virtual feeds read LIVE at request time).
+ * All read through ONE abstraction — add a type here + a RECALL_SOURCES entry;
+ * nothing branches on the kind.
  */
-export type RecallKind = 'knowledge' | 'conversation';
+export type RecallKind = 'knowledge' | 'conversation' | 'virtual';
+
+/**
+ * Max virtual feeds fanned out on a single recall. Each virtual feed spawns a
+ * connector subprocess + a live external API round-trip, so unlike the
+ * single-query knowledge/conversation sources this one has real per-feed cost.
+ * A org with more opt-in feeds than this gets the first N (by id) and a logged
+ * truncation — never a silent drop.
+ */
+const MAX_VIRTUAL_RECALL_FEEDS = 5;
 
 /**
  * A recall source is a {@link FeedReader}: it owns exactly one kind and
@@ -503,7 +532,78 @@ const conversationSource: RecallSource = {
   },
 };
 
-export const RECALL_SOURCES: RecallSource[] = [knowledgeSource, conversationSource];
+/**
+ * `virtual` — live rows from opt-in virtual feeds. A virtual feed participates
+ * in ambient recall ONLY when its `config.recall === true`; most virtual feeds
+ * exist to be SQL-addressable (query_sql) and must NOT tax every search_memory
+ * call with a live external round-trip. For each opted-in feed we run
+ * `readVirtualFeed` with the query as a recall term (its `search()` pushdown),
+ * fenced by the SAME connection-visibility gate readVirtualFeed re-checks — the
+ * enumeration below applies it too so we never spawn a subprocess for a feed the
+ * caller can't see. Feeds fail INDEPENDENTLY: one feed's live error (expired
+ * token, source down) never drops another's rows.
+ */
+const virtualSource: RecallSource = {
+  kind: 'virtual',
+  read: async (gate, ctx) => {
+    // Recall over a virtual feed is a keyword `search()` — it needs query text.
+    if (!ctx.query) return {};
+
+    // Candidate opt-in feeds, gated by the same connection visibility every read
+    // seam uses. Params: $1 organizationId, $2 principal (compiler). Ordered by
+    // id and capped so an org with many feeds gets a bounded, logged fan-out.
+    const sql = getDb();
+    const vis = compileConnectionRowVisibility(gate, 2, 'c');
+    const feedRows = (await sql.unsafe(
+      `SELECT f.id, f.feed_key
+       FROM feeds f
+       JOIN connections c ON c.id = f.connection_id
+       WHERE f.organization_id = $1
+         AND f.virtual = true
+         AND f.status = 'active'
+         AND f.deleted_at IS NULL
+         AND (f.config->>'recall') = 'true'
+         AND c.deleted_at IS NULL
+         AND c.status = 'active'
+         ${vis.sql}
+       ORDER BY f.id
+       LIMIT ${MAX_VIRTUAL_RECALL_FEEDS + 1}`,
+      [gate.organizationId, ...vis.params],
+    )) as unknown as Array<{ id: number; feed_key: string }>;
+
+    if (feedRows.length === 0) return {};
+    let candidates = feedRows;
+    if (candidates.length > MAX_VIRTUAL_RECALL_FEEDS) {
+      candidates = candidates.slice(0, MAX_VIRTUAL_RECALL_FEEDS);
+      logger.warn(
+        `[search] virtual recall fan-out capped at ${MAX_VIRTUAL_RECALL_FEEDS} feeds ` +
+          `for org ${gate.organizationId}; ${feedRows.length - MAX_VIRTUAL_RECALL_FEEDS}+ opted-in feed(s) skipped`
+      );
+    }
+
+    const blocks = await Promise.all(
+      candidates.map(async (f): Promise<VirtualFeedRows | null> => {
+        try {
+          const live = await readVirtualFeed({
+            scope: gate,
+            feedId: f.id,
+            terms: [ctx.query as string],
+            limit: ctx.contentLimit,
+          });
+          if (live.rows.length === 0) return null;
+          return { feed_id: f.id, feed_key: f.feed_key, columns: live.columns, rows: live.rows };
+        } catch (err) {
+          logger.warn(`[search] virtual feed ${f.id} recall failed: ${getErrorMessage(err)}`);
+          return null;
+        }
+      })
+    );
+    const virtual_feeds = blocks.filter((b): b is VirtualFeedRows => b !== null);
+    return virtual_feeds.length > 0 ? { virtual_feeds } : {};
+  },
+};
+
+export const RECALL_SOURCES: RecallSource[] = [knowledgeSource, conversationSource, virtualSource];
 
 /** Run every recall reader under `gate` and merge their facets into one
  * fragment. Readers fail independently — one reader's error never drops


### PR DESCRIPTION
## What

Follow-up to #1702. Virtual feeds were readable only via `manage_feeds read_feed` — invisible to the two surfaces where an agent actually reaches for data. This wires the **existing** `readVirtualFeed` seam into both, so virtual feeds work in recall and SQL, not just an explicit read.

No new federation infra — `readVirtualFeed` already resolves a feed under the `AuthzScope` connection-visibility gate, runs the connector's `query()`/`search()` in the egress-controlled subprocess, and persists nothing. Both changes are dispatch wiring.

### 1. `search_memory` ambient recall
New opt-in `virtual` `RecallSource` in `RECALL_SOURCES`. A virtual feed joins recall **only when `config.recall === true`** — most virtual feeds exist to be SQL-addressable and must not tax the hot recall path with a live external round-trip per call. When opted in:
- runs the connector `search()` with the query as a recall term;
- ACL-fenced by the same connection-visibility gate (enumeration + `readVirtualFeed` both apply it);
- fan-out capped at `MAX_VIRTUAL_RECALL_FEEDS` (5) with a **logged truncation** (no silent drop);
- feeds fail independently — one feed's live error never drops another's rows.

Rows land in a new `virtual_feeds` facet (arbitrary connector columns → its own `{feed_id, feed_key, columns, rows}` shape, not coerced into `ContentSnippet`), rendered as a compact table by the markdown formatter.

### 2. `query_sql({ feed })`
New `feed` arg (numeric id or `"connection_slug/feed_key"`) runs a virtual feed's **stored** `config.query` live via `readVirtualFeed`. `search_term` → recall terms; `sort`/paging pass through. Strictly tighter than the existing `connection` pushdown — no arbitrary caller SQL. Mutually exclusive with `connection`; `sql` is optional when `feed` is set.

## Testing

`virtual-feed-surfaces.test.ts` — one integration file, both surfaces, **red→green** (8/12 fail without the wiring), driven end-to-end against a real subprocess-compiled `postgres` connector (no mocks):
- recall: opt-in feed surfaces as `virtual_feeds`; a virtual feed **without** `recall:true` stays invisible; ACL fence (member can't see owner's PRIVATE recall feed); facet omitted on no-match / empty query.
- query_sql: address by numeric id **and** `slug/key`; `search_term` narrows via `search()`; `feed`+`connection` rejected; non-virtual feed refused; unresolvable ref errors; member fenced from a PRIVATE-connection feed.

Local gates: typecheck 0, unit 0, integration suite **1792 passed / 0 failed** (223 files). Local pi verdict blocked by an external codex 429 (usage limit, unrelated to the diff) — relying on GitHub's `pi-review` job for the verdict.

## Multi-replica
Both paths are pure per-request reads with all state in Postgres — no pod-local state, runnable on any replica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785630191&installation_id=136316292&pr_number=1707&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1707&signature=57e59e20180469d741267ead6d53773ee559b39d915c8130813cda9d7e02051b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->