### PR TITLE
feat(entities): post the entity_field_change approval card end-to-end

### DIFF
--- a/packages/agent-worker/src/__tests__/custom-tools.test.ts
+++ b/packages/agent-worker/src/__tests__/custom-tools.test.ts
@@ -200,6 +200,96 @@ describe("maybePostApprovalCard (builder gate)", () => {
     expect(posts).toHaveLength(0);
   });
 
+  test("posts an entity_field_change card for a manage_entity approval_queued result", async () => {
+    const posts: Array<{ url: string; body: any }> = [];
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        posts.push({
+          url,
+          body: init?.body ? JSON.parse(String(init.body)) : null,
+        });
+        return Response.json({ id: "appr-2" });
+      }
+    ) as unknown as typeof fetch;
+
+    const resultText = JSON.stringify({
+      action: "update",
+      entity: { id: 7, name: "Acme" },
+      applied_fields: ["metadata.website"],
+      blocked_fields: ["metadata.tier"],
+      approval_queued: true,
+      approval_run_id: 42,
+      approval_fields: { "metadata.tier": "enterprise" },
+      approval_current: { "metadata.tier": "free" },
+      approval_attribution: "agent",
+    });
+
+    const posted = await maybePostApprovalCard(gw, "manage_entity", resultText);
+
+    expect(posted).toBe(true);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]!.url).toEndWith("/internal/interactions/create");
+    // `fields` (non-empty) is what the SPA routes on for the entity-field card.
+    expect(posts[0]!.body).toMatchObject({
+      interactionType: "tool_approval",
+      runId: 42,
+      action: "change",
+      fields: { "metadata.tier": "enterprise" },
+      current: { "metadata.tier": "free" },
+      attribution: "agent",
+    });
+    // manage_entity does not carry the manage_agents `proposal` shape.
+    expect(posts[0]!.body.proposal).toBeUndefined();
+  });
+
+  test("carries watcher attribution when a manage_entity update was watcher-sourced", async () => {
+    const posts: Array<{ body: any }> = [];
+    globalThis.fetch = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        posts.push({ body: init?.body ? JSON.parse(String(init.body)) : null });
+        return Response.json({ id: "appr-3" });
+      }
+    ) as unknown as typeof fetch;
+
+    const posted = await maybePostApprovalCard(
+      gw,
+      "manage_entity",
+      JSON.stringify({
+        action: "update",
+        approval_queued: true,
+        approval_run_id: 43,
+        approval_fields: { "metadata.stage": "won" },
+        approval_current: { "metadata.stage": "lead" },
+        approval_attribution: "watcher",
+      })
+    );
+
+    expect(posted).toBe(true);
+    expect(posts[0]!.body.attribution).toBe("watcher");
+  });
+
+  test("does nothing for a manage_entity update with no blocked fields", async () => {
+    const posts: string[] = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      posts.push(String(input));
+      return Response.json({});
+    }) as unknown as typeof fetch;
+
+    const posted = await maybePostApprovalCard(
+      gw,
+      "manage_entity",
+      JSON.stringify({
+        action: "update",
+        entity: { id: 7 },
+        applied_fields: ["metadata.website"],
+      })
+    );
+
+    expect(posted).toBe(false);
+    expect(posts).toHaveLength(0);
+  });
+
   test("does nothing for a different tool", async () => {
     const posts: string[] = [];
     globalThis.fetch = mock(async (input: RequestInfo | URL) => {

--- a/packages/agent-worker/src/shared/tool-implementations.ts
+++ b/packages/agent-worker/src/shared/tool-implementations.ts
@@ -1154,15 +1154,25 @@ const TOOLS_REQUESTING_JSON_FORMAT = new Set([
   // not formatted markdown, to forward an approval card into the chat (see
   // maybePostApprovalCard / createMcpToolDefinitions).
   "manage_agents",
+  // manage_entity's update path queues a human-owned-field change for approval
+  // (approval_queued + approval_run_id + approval_fields/current). Same reason:
+  // we need the JSON to forward the entity_field_change approval card.
+  "manage_entity",
 ]);
 
 /**
- * Builder-gate bridge: when a manage_agents write returns a
- * `pending_approval` result, post a durable approval card into the chat so the
- * SPA renders the interactive Approve/Reject diff. Fire-and-forget — a failed
- * post never breaks the tool call (the agent still narrates the result, and the
- * events-tab approval card remains the fallback). Returns true when a card was
- * posted (caller logs at debug only).
+ * Approval-gate bridge: when a gated write returns a pending-approval result,
+ * post a durable approval card into the chat so the SPA renders the interactive
+ * Approve/Reject diff. Handles two producers:
+ *   - manage_agents write gate → `{ status: 'pending_approval', run_id,
+ *     action, proposal, current }` (the builder agent's create/update/delete).
+ *   - manage_entity update gate → `{ approval_queued: true, approval_run_id,
+ *     approval_fields, approval_current, approval_attribution }` (a human-owned
+ *     entity field the agent proposed changing).
+ *
+ * Fire-and-forget — a failed post never breaks the tool call (the agent still
+ * narrates the result, and the events-tab approval card remains the fallback).
+ * Returns true when a card was posted (caller logs at debug only).
  *
  * The card rides the SAME owner-gated thread_response delivery as ask_user:
  * POST /internal/interactions/create → InteractionService → API platform →
@@ -1173,25 +1183,8 @@ export async function maybePostApprovalCard(
   toolName: string,
   rawResultText: string
 ): Promise<boolean> {
-  if (toolName !== "manage_agents") return false;
-  let parsed: {
-    status?: unknown;
-    run_id?: unknown;
-    action?: unknown;
-    proposal?: unknown;
-    current?: unknown;
-  };
-  try {
-    parsed = JSON.parse(rawResultText);
-  } catch {
-    return false;
-  }
-  if (
-    parsed.status !== "pending_approval" ||
-    typeof parsed.run_id !== "number"
-  ) {
-    return false;
-  }
+  const body = buildApprovalCardBody(toolName, rawResultText);
+  if (!body) return false;
 
   // Fire-and-forget: a failed post must never break the tool call (the agent
   // still narrates the result, and the events-tab approval card is the
@@ -1201,27 +1194,74 @@ export async function maybePostApprovalCard(
     ({ error } = await gatewayFetch<{ id: string }>(
       gw,
       "/internal/interactions/create",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          interactionType: "tool_approval",
-          runId: parsed.run_id,
-          action: typeof parsed.action === "string" ? parsed.action : "change",
-          proposal: parsed.proposal ?? null,
-          current: parsed.current ?? null,
-        }),
-      },
+      { method: "POST", body: JSON.stringify(body) },
       "Failed to post approval card"
     ));
   } catch {
-    logger.warn("manage_agents approval card post threw");
+    logger.warn(`${toolName} approval card post threw`);
     return false;
   }
   if (error) {
-    logger.warn("manage_agents approval card post failed");
+    logger.warn(`${toolName} approval card post failed`);
     return false;
   }
   return true;
+}
+
+/**
+ * Parse a gated tool result into the /internal/interactions/create body, or
+ * null when the result is not a pending approval. entity_field_change carries
+ * `fields`/`attribution` (the human-owned-field diff); manage_agents carries
+ * `proposal` (the agent row diff). Both share the `tool_approval` transport.
+ */
+function buildApprovalCardBody(
+  toolName: string,
+  rawResultText: string
+): Record<string, unknown> | null {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(rawResultText);
+  } catch {
+    return null;
+  }
+
+  if (toolName === "manage_agents") {
+    if (
+      parsed.status !== "pending_approval" ||
+      typeof parsed.run_id !== "number"
+    ) {
+      return null;
+    }
+    return {
+      interactionType: "tool_approval",
+      runId: parsed.run_id,
+      action: typeof parsed.action === "string" ? parsed.action : "change",
+      proposal: parsed.proposal ?? null,
+      current: parsed.current ?? null,
+    };
+  }
+
+  if (toolName === "manage_entity") {
+    if (
+      parsed.approval_queued !== true ||
+      typeof parsed.approval_run_id !== "number"
+    ) {
+      return null;
+    }
+    return {
+      interactionType: "tool_approval",
+      runId: parsed.approval_run_id,
+      action: "change",
+      // entity_field_change diff: field_path -> proposed / current. The SPA
+      // routes on `fields` (non-empty) to the entity-field-change card.
+      fields: parsed.approval_fields ?? null,
+      current: parsed.approval_current ?? null,
+      attribution:
+        parsed.approval_attribution === "watcher" ? "watcher" : "agent",
+    };
+  }
+
+  return null;
 }
 
 export async function callMcpTool(

--- a/packages/server/src/__tests__/integration/watchers/ownership-gate.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/ownership-gate.test.ts
@@ -80,6 +80,10 @@ async function manageEntityUpdate(
     blocked_fields?: string[];
     approval_queued?: boolean;
     approval_url?: string;
+    approval_run_id?: number;
+    approval_fields?: Record<string, unknown>;
+    approval_current?: Record<string, unknown>;
+    approval_attribution?: 'agent' | 'watcher';
   }>;
 }
 
@@ -181,6 +185,13 @@ describe('ownership gate on agent entity writes', () => {
     expect(result.blocked_fields).toContain('severity');
     expect(result.applied_fields).toContain('notes');
     expect(result.approval_queued).toBe(true);
+
+    // The result carries the bridge fields the worker forwards into a live
+    // chat approval card (parity with manage_agents' pending_approval).
+    expect(result.approval_run_id).toBe(Number(run.id));
+    expect(result.approval_fields?.severity).toBe('critical');
+    expect(result.approval_current?.severity).toBe('high');
+    expect(result.approval_attribution).toBe('agent');
   });
 
   it('writes unowned fields without producing an approval', async () => {
@@ -223,9 +234,12 @@ describe('ownership gate on agent entity writes', () => {
     await manageEntityUpdate(humanCtx(org, user), reactionEntity.id, { severity: 'high' });
 
     // Agent mutation attributed to a watcher reaction.
-    await manageEntityUpdate(agentCtx(org, user), reactionEntity.id, { severity: 'critical' }, {
-      watcher_source: { watcher_id: watcherId, window_id: windowId },
-    });
+    const result = await manageEntityUpdate(
+      agentCtx(org, user),
+      reactionEntity.id,
+      { severity: 'critical' },
+      { watcher_source: { watcher_id: watcherId, window_id: windowId } }
+    );
 
     const [row] = await getTestDb()`SELECT metadata FROM entities WHERE id = ${reactionEntity.id}`;
     expect((row.metadata as Record<string, unknown>).severity).toBe('high');
@@ -239,6 +253,10 @@ describe('ownership gate on agent entity writes', () => {
     `;
     expect(run).toBeTruthy();
     expect(Number((run.action_input as { watcher_id: number }).watcher_id)).toBe(watcherId);
+
+    // The card attribution flows through as 'watcher' so the SPA labels it
+    // "A watcher proposes…" instead of "An agent proposes…".
+    expect(result.approval_attribution).toBe('watcher');
   });
 
   it('collapses an identical repeated agent edit into a single pending approval', async () => {

--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -182,6 +182,87 @@ describe("agent history routes", () => {
 		expect(card?.current).toMatchObject({ id: "weekly-digest" });
 	});
 
+	test("replays a pending entity_field_change approval with fields + attribution", async () => {
+		setAuthProvider(() => ({
+			userId: USER_ID,
+			platform: "external",
+			exp: Date.now() + 60_000,
+		}));
+
+		const agentId = "agent-1";
+		const threadId = "thread-efc";
+		const conversationId = buildApiConversationId({
+			agentId,
+			userId: USER_ID,
+			organizationId: ORG_ID,
+			threadId,
+		});
+
+		// An agent proposed changing a human-owned field; the worker stamped the
+		// conversationId (via /internal/interactions/create) so it replays. The
+		// entity_field_change card routes on `fields`, not `proposal`.
+		const runId = await insertRun({
+			organizationId: ORG_ID,
+			agentId,
+			conversationId,
+			runType: "internal",
+			status: "pending",
+		});
+		const fields = { "metadata.tier": "enterprise" };
+		const current = { "metadata.tier": "free" };
+		await orgContext.run({ organizationId: ORG_ID }, () =>
+			insertEvent({
+				entityIds: [],
+				organizationId: ORG_ID,
+				originId: `run_${runId}_pending`,
+				title: "An agent proposes changing metadata.tier — pending approval",
+				content: "An agent proposed updating metadata.tier on this entity.",
+				semanticType: "operation",
+				runId,
+				interactionType: "approval",
+				interactionStatus: "pending",
+				interactionInput: { entity_id: 7, fields, current },
+				metadata: {
+					conversationId,
+					tool: "entity_field_change",
+					action_key: "entity_field_change",
+					entity_id: 7,
+					fields,
+					current,
+					attribution: "agent",
+					status: "pending_approval",
+					run_id: runId,
+				},
+			}),
+		);
+
+		const res = await orgContext.run({ organizationId: ORG_ID }, () =>
+			createApp().request(
+				`/api/v1/agents/${agentId}/history/threads/${threadId}/messages`,
+				{ method: "GET", headers: { host: "localhost" } },
+			),
+		);
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			interactions?: Array<{
+				type: string;
+				runId: number;
+				fields: Record<string, unknown> | null;
+				current: Record<string, unknown> | null;
+				attribution: string | null;
+			}>;
+		};
+		expect(body.interactions).toHaveLength(1);
+		const card = body.interactions?.[0];
+		expect(card?.type).toBe("tool-approval");
+		expect(card?.runId).toBe(runId);
+		// The SPA routes on `fields` (non-empty) to the entity-field-change card.
+		expect(card?.fields).toMatchObject({ "metadata.tier": "enterprise" });
+		expect(card?.current).toMatchObject({ "metadata.tier": "free" });
+		expect(card?.attribution).toBe("agent");
+	});
+
 	test("rejects sessions that do not own the requested agent", async () => {
 		setAuthProvider(() => ({
 			userId: "u2",

--- a/packages/server/src/gateway/api/platform.ts
+++ b/packages/server/src/gateway/api/platform.ts
@@ -111,7 +111,12 @@ export class ApiPlatform implements PlatformAdapter {
         action: event.cardAction,
         proposal: event.proposal ?? null,
         current: event.current ?? null,
-        toolName: "manage_agents",
+        // entity_field_change carries a human-owned-field diff + attribution;
+        // the SPA routes on `fields` (non-empty) to the entity-field-change
+        // card. manage_agents leaves these null and renders its agent-row diff.
+        fields: event.fields ?? null,
+        attribution: event.attribution ?? null,
+        toolName: event.fields ? "manage_entity" : "manage_agents",
       });
     });
 

--- a/packages/server/src/gateway/interactions.ts
+++ b/packages/server/src/gateway/interactions.ts
@@ -119,10 +119,15 @@ export interface PostedDurableApproval extends BaseMessage {
   runId: number;
   /** create | update | delete. */
   cardAction: string;
-  /** Proposed field values + the agent id. */
+  /** Proposed field values + the agent id (manage_agents). Null for entity_field_change. */
   proposal: Record<string, unknown> | null;
   /** Current agent row (null for create), for the proposed-vs-current diff. */
   current: Record<string, unknown> | null;
+  /** entity_field_change diff: field_path -> proposed value. Null for manage_agents.
+   *  The SPA routes on this (non-empty) to the entity-field-change card. */
+  fields: Record<string, unknown> | null;
+  /** Who proposed the entity_field_change: 'agent' | 'watcher'. Null for manage_agents. */
+  attribution: string | null;
   /** Headless-origin marker (parity with PostedQuestion/PostedToolApproval). */
   source?: string;
 }
@@ -259,7 +264,9 @@ export class InteractionService extends EventEmitter {
     cardAction: string,
     proposal: Record<string, unknown> | null,
     current: Record<string, unknown> | null,
-    source?: string
+    source?: string,
+    fields: Record<string, unknown> | null = null,
+    attribution: string | null = null
   ): Promise<PostedDurableApproval> {
     assertRoutableInteraction(connectionId, platform, "approval card");
     if (this.beforeCreateHook) {
@@ -278,6 +285,8 @@ export class InteractionService extends EventEmitter {
       cardAction,
       proposal,
       current,
+      fields,
+      attribution,
       source,
     };
 

--- a/packages/server/src/gateway/routes/internal/interactions.ts
+++ b/packages/server/src/gateway/routes/internal/interactions.ts
@@ -87,7 +87,11 @@ export function createInteractionRoutes(
             typeof body.action === "string" ? body.action : "change",
             (body.proposal ?? null) as Record<string, unknown> | null,
             (body.current ?? null) as Record<string, unknown> | null,
-            source
+            source,
+            // entity_field_change (manage_entity) carries a human-owned-field
+            // diff + who proposed it; manage_agents leaves these null.
+            (body.fields ?? null) as Record<string, unknown> | null,
+            typeof body.attribution === "string" ? body.attribution : null
           );
           // The live approval card is a one-shot SSE push, and the transcript
           // doesn't carry interaction parts — so on reload the card is lost.

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -409,6 +409,8 @@ export function createAgentHistoryRoutes(deps: {
 			action: string | null;
 			proposal: Record<string, unknown> | null;
 			current: Record<string, unknown> | null;
+			fields: Record<string, unknown> | null;
+			attribution: string | null;
 		}> = [];
 		if (scope.organizationId) {
 			const conversationId = buildApiConversationId({
@@ -422,11 +424,18 @@ export function createAgentHistoryRoutes(deps: {
 				action: string | null;
 				proposal: Record<string, unknown> | null;
 				current: Record<string, unknown> | null;
+				fields: Record<string, unknown> | null;
+				attribution: string | null;
 			}>`
 				SELECT run_id,
 				       metadata->>'action' AS action,
 				       metadata->'proposal' AS proposal,
-				       metadata->'current' AS current
+				       metadata->'current' AS current,
+				       -- entity_field_change (manage_entity) carries the
+				       -- human-owned-field diff + attribution; manage_agents
+				       -- leaves these null and replays its agent-row proposal.
+				       metadata->'fields' AS fields,
+				       metadata->>'attribution' AS attribution
 				FROM current_event_records
 				WHERE organization_id = ${scope.organizationId}
 				  AND interaction_type = 'approval'
@@ -440,6 +449,8 @@ export function createAgentHistoryRoutes(deps: {
 				action: r.action,
 				proposal: r.proposal ?? null,
 				current: r.current ?? null,
+				fields: r.fields ?? null,
+				attribution: r.attribution ?? null,
 			}));
 		}
 		return c.json({ ...data, interactions });

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -295,6 +295,15 @@ type ManageEntityResult =
       approval_queued?: boolean;
       /** Permalink to the approval card, when one was queued. */
       approval_url?: string;
+      /** Pending approval run id — the worker bridges this into a live chat
+       *  approval card (parity with manage_agents' `pending_approval`). */
+      approval_run_id?: number;
+      /** Blocked field_path -> proposed value, for the live card diff. */
+      approval_fields?: Record<string, unknown>;
+      /** Blocked field_path -> current human-owned value, for the diff. */
+      approval_current?: Record<string, unknown>;
+      /** Who proposed the blocked change: 'agent' | 'watcher'. */
+      approval_attribution?: 'agent' | 'watcher';
     }
   | {
       action: 'list';
@@ -686,6 +695,10 @@ async function handleUpdate(
   const blockedPaths = Object.keys(blocked);
   let approvalQueued = false;
   let approvalUrl: string | undefined;
+  let approvalRunId: number | undefined;
+  let approvalFields: Record<string, unknown> | undefined;
+  let approvalCurrent: Record<string, unknown> | undefined;
+  const approvalAttribution: 'agent' | 'watcher' = args.watcher_source ? 'watcher' : 'agent';
   if (blockedPaths.length > 0) {
     const fields = Object.fromEntries(blockedPaths.map((p) => [p, blocked[p].proposed]));
     const current = Object.fromEntries(blockedPaths.map((p) => [p, blocked[p].current]));
@@ -694,13 +707,16 @@ async function handleUpdate(
       fields,
       current,
       watcher_id: args.watcher_source?.watcher_id ?? null,
-      attribution: args.watcher_source ? 'watcher' : 'agent',
+      attribution: approvalAttribution,
       reason: args.watcher_source
         ? `A watcher proposes updating ${blockedPaths.join(', ')} on this entity.`
         : `An agent proposes updating ${blockedPaths.join(', ')} on this entity.`,
     });
     approvalQueued = true;
     approvalUrl = res.approvalUrl;
+    approvalRunId = res.runId;
+    approvalFields = fields;
+    approvalCurrent = current;
   }
 
   return {
@@ -721,6 +737,10 @@ async function handleUpdate(
     blocked_fields: blockedPaths.length > 0 ? blockedPaths : undefined,
     approval_queued: approvalQueued || undefined,
     approval_url: approvalUrl,
+    approval_run_id: approvalRunId,
+    approval_fields: approvalFields,
+    approval_current: approvalCurrent,
+    approval_attribution: approvalQueued ? approvalAttribution : undefined,
   };
 }
 


### PR DESCRIPTION
## What

Completes the entity_field_change approval feature by wiring the **server** to post the in-chat Approve/Reject card end-to-end.

Background: the ownership-gate fix (#1705) blocks an agent/watcher write to a **human-owned** entity field and queues a durable approval, but only surfaced it as a notification + events-tab card. The owletto diff card (owletto#427) was merged as client-side scaffolding with nothing feeding it `fields`/`attribution`. This PR closes that gap: a chat agent's `manage_entity` proposal now renders as the interactive card, live and replayed on reload — reusing the exact `manage_agents` builder-gate transport (owner-gated `thread_response` queue + history replay), so it's multi-replica safe by construction.

## Changes (server + agent-worker only — owletto client half already merged)

- **`manage_entity` update result** carries `approval_run_id` / `approval_fields` / `approval_current` / `approval_attribution` so the worker can bridge a live card (parity with `manage_agents`' `pending_approval`).
- **`maybePostApprovalCard`** (worker) now handles `manage_entity`, forwarding `fields`/`current`/`attribution` as a `tool_approval` interaction. The SPA routes on non-empty `fields` to the entity-field-change card. `manage_entity` joins `TOOLS_REQUESTING_JSON_FORMAT`.
- **`postDurableApprovalCard`** + the durable-card SSE payload (`platform.ts`) thread `fields`/`attribution`. The internal route's existing `conversationId` stamp already matches the entity_field_change event, so history replays it.
- **`agent-history`** replay selects `metadata.fields` / `metadata.attribution`.

Watcher-reaction proposals (headless `complete_window` path — no conversationId, no chat thread) stay **notification-only by design**; unchanged.

## Test evidence (red → green)

Every surface has a reproducer proven to fail on `origin/main` and pass with the fix (source reverted via `/tmp` copy + `git checkout HEAD --`, not `git stash`):

| Surface | Test | RED (reverted) | GREEN |
|---|---|---|---|
| Worker bridge | `custom-tools.test.ts` (agent + watcher attribution) | 2 fail | 10 pass |
| `manage_entity` result bridge | `ownership-gate.test.ts` (`approval_run_id`/`fields`/`attribution`) | 2 fail | 6 pass |
| History replay | `agent-history-routes.test.ts` (entity_field_change `fields`/`attribution`) | 1 fail | 6 pass |

`bun run typecheck` clean. `make build-packages` (incl. owletto vite) clean.

## Multi-replica

Live push rides the same owner-gated `thread_response` queue as `manage_agents` (proven cross-replica). History replay reads `current_event_records` (pod-independent). No new in-memory cross-pod state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785631676&installation_id=136316292&pr_number=1708&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1708&signature=eea3ebead8685e3f6dd03bd54c992f6546176108f6e72752c110791bd2866e46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval cards now support entity field changes, showing the proposed fields, current values, and whether the change came from an agent or watcher.
  * Agent history now replays these approval details so pending approvals appear consistently across views.

* **Bug Fixes**
  * Blocked entity updates now return approval metadata only when an approval is actually queued.
  * Watcher-originated changes keep their attribution in approval cards and history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->