### PR TITLE
refactor(feeds): promote recall registry to the (source, lens) FeedReader tuple

### DIFF
--- a/docs/plans/feeds-and-connections-model.md
+++ b/docs/plans/feeds-and-connections-model.md
@@ -1,12 +1,15 @@
 # Feeds & Connections — the queryable-source model
 
 **Status: PARTLY BUILT.** All three feed kinds already exist in some form (see
-the table). What **this PR** ships is the `recall` lens reading `channel_messages`
-(the `RecallSource[]` registry in `packages/server/src/tools/search.ts`). What is
-**not** built is the unified `FeedReader<S,L>` capability registry that would
-dispatch every `(kind, lens)` through one seam — today the lenses (recall /
-metric / query_sql) and the live-pushdown path live in separate code paths.
-Reviewed with an external model (Q: collapse the axes? → "keep them orthogonal").
+the table). The `recall` lens now dispatches every source (`knowledge` = events,
+`conversation` = channel_messages, `virtual` = live virtual feeds) through the
+tuple-shaped `FeedReader<S, L>` registry (`RECALL_SOURCES` in
+`packages/server/src/tools/search.ts`, reader contract in
+`packages/server/src/lib/feed-reader.ts`) — parameterized by `(sourceKind,
+lensKind)`, gated by `canRead`, no central `switch`. What is **not** yet built is
+folding the OTHER lenses (metric / raw-sql) and the live-pushdown path into that
+same registry — today they live in separate code paths. Reviewed with an external
+model (Q: collapse the axes? → "keep them orthogonal").
 
 **Related docs (authoritative for the kinds/lenses below):**
 [`docs/database-connectors.md`](./database-connectors.md) — the PostgreSQL
@@ -48,54 +51,73 @@ bytes live" and "how the caller wants to read them" are different concerns.
 
 Any lens over any kind. Source kind = where bytes live; lens = read semantics.
 
-## The unifying abstraction (target)
+## The unifying abstraction (realized for recall)
 
 One concept — *a generated query/view parameterized by (source, shape) + lens* —
 realized as a **capability registry keyed by the `(sourceKind, lensKind)`
-tuple**. Not inheritance, not a central `switch`.
+tuple**. Not inheritance, not a central `switch`. The reader contract lives in
+`packages/server/src/lib/feed-reader.ts`:
 
 ```ts
 type SourceKind = 'chat-channel' | 'virtual-live-dataset' | 'collected';
 type LensKind   = 'recall' | 'metric' | 'raw-sql';
 
-interface FeedReader<S extends SourceKind, L extends LensKind> {
+interface FeedReader<S extends SourceKind, L extends LensKind, Ctx, Out> {
   readonly source: S;
   readonly lens: L;
-  canRead(feed: FeedSpec<S, L>): boolean;
-  read(ctx: ReadCtx, feed: FeedSpec<S, L>): Promise<ResultFor<L>>;
+  canRead(ctx: Ctx): boolean;                // decline a ctx you can't serve
+  read(gate: AuthzScope, ctx: Ctx): Promise<Out>;
 }
 ```
 
 - Register concrete `(source, lens)` handlers; dispatch by tuple key.
 - **Missing combinations are explicit unsupported capabilities, not enum holes.**
+- `canRead` lets a reader opt out of a ctx (no query text, wrong signal) so the
+  registry skips it **branch-free** — the guard is on the reader, not a
+  caller-side `if`.
+- The ACL gate (`AuthzScope`) is a required, typed first argument of `read`,
+  threaded by the registry so a call site cannot drop it.
 - Materialization is an implementation detail of the *source adapter*.
 - Adding a new kind (live dataset) or a new lens stays branch-free.
+
+**Realized today for `lens = recall` only** (`RECALL_SOURCES`, three sources
+across all three source kinds). The metric / raw-sql lenses and the live-pushdown
+path have not yet been folded under this registry — see below.
 
 ## What's shipped today — the recall slice
 
 `search.ts` holds a `RecallSource[]` registry: the `lens = recall` row of the
-matrix, varying source.
+matrix, varying source. Each entry is a `FeedReader<SourceKind, 'recall', …>`.
 
-- `knowledge` source → `events` (semantic + keyword, visibility-scoped).
-- `conversation` source → `channel_messages` (keyword + recency, **fenced to the
-  calling agent's bound channels**; all-stop-word prompts fall back to recency).
+- `knowledge` source (`collected`) → `events` (semantic + keyword,
+  visibility-scoped).
+- `conversation` source (`chat-channel`) → `channel_messages` (keyword +
+  recency, **fenced to the calling agent's bound channels**; all-stop-word
+  prompts fall back to recency).
+- `virtual` source (`virtual-live-dataset`) → opt-in virtual feeds read LIVE via
+  `readVirtualFeed` (`config.recall === true`, capped fan-out, connection-visibility
+  gated).
 
-`gatherRecall` runs every source and merges their result facets — no central
-`if/else`, each source contributes only its facet, failures are isolated. This
-is exactly the `FeedReader[]` shape restricted to one lens.
+`gatherRecall` filters by `canRead(ctx)` then runs every remaining source and
+merges their result facets — no central `if/else`, each source contributes only
+its facet, failures are isolated. This is exactly the `FeedReader[]` registry
+restricted to one lens.
 
 `get_channel_history` was **retired** in favour of this: past channel
 conversation is read through `search_memory` (returns `conversation_messages`
 alongside `content`), the same path as all other memory. `read_conversation`
 remains the point-read of a single named conversation.
 
-## Why not generalize to `FeedReader<S,L>` now
+## Why the metric / raw-sql fold is still deferred
 
-All three kinds and all three lenses already exist — but in **separate code
-paths** (recall in `search.ts`; metric + the live-pushdown / virtual-feed read
-via the connector `query()` path; `query_sql` via `QUERYABLE_SCHEMA`). The
-unified `FeedReader<S,L>` registry is a **consolidation target, not a new
-capability**. This PR only touches the recall lens; promoting `RecallSource` →
-`FeedReader` (folding the other lenses + the virtual-feed/live-pushdown path
-under one tuple-dispatched registry) is the follow-up. The current shape was
-chosen so that promotion is additive.
+The recall lens is now on the `FeedReader<S,L>` tuple registry. The other two
+lenses are not: metric runs via the connector `query()` / `metric_series` path,
+`query_sql` via `QUERYABLE_SCHEMA` → `buildScopedQuery` CTEs (plus its own
+virtual-feed / connector-query branches). Folding them under the SAME
+tuple-dispatched registry is a **consolidation of existing capability, not a new
+one** — pure refactor across two working subsystems, with no behavior change and
+real regression surface. It is deferred until a concrete second-lens need forces
+it (e.g. a new lens that must share the source-adapter layer), per the "design
+the seam, not the framework" discipline. The recall registry was shaped as the
+tuple `(source, lens)` precisely so that fold is additive when it lands: a metric
+reader is just another `FeedReader<S, 'metric', …>` registered by tuple key.

--- a/packages/server/src/lib/feed-reader.ts
+++ b/packages/server/src/lib/feed-reader.ts
@@ -1,14 +1,25 @@
 /**
- * FeedReader — the read contract for the recall registry (`RECALL_SOURCES` in
- * search.ts). It is the ONE shape every recall source implements; the registry
- * fans out over readers without branching on kind. (Other feed read seams like
- * `readVirtualFeed`/`runConnectorQuery` take the same `AuthzScope` gate directly
- * but are single functions, not registry members, so they don't implement this.)
+ * FeedReader — the read contract behind the feed registry. A feed is described by
+ * two orthogonal axes (see `docs/plans/feeds-and-connections-model.md`):
+ *   - {@link SourceKind}: WHERE the bytes live (chat transcript / live external
+ *     dataset / collected events).
+ *   - {@link LensKind}: HOW the caller wants to read them (recall / metric /
+ *     raw-sql).
+ * A reader owns exactly one `(source, lens)` tuple and is dispatched by that key,
+ * with no central `switch` over kinds. `canRead` lets a reader decline a ctx it
+ * can't serve (e.g. a keyword-only source with no query text) so the registry
+ * skips it BRANCH-FREE — the caller never special-cases a kind.
+ *
+ * Today the registry is realized for the `recall` lens only (`RECALL_SOURCES` in
+ * search.ts); the metric / raw-sql lenses and the live-pushdown path remain
+ * separate functions. Folding them under one tuple-dispatched registry is the
+ * consolidation target the doc describes — this shape was chosen so that
+ * promotion is additive.
  *
  * The access-graph ACL gate ({@link AuthzScope}) is a REQUIRED, typed argument of
  * `read`, threaded by the registry to every reader — it is never buried in a
  * loose context where a call site could quietly drop it. What the type
- * guarantees: a reader must ACCEPT the gate, and `gatherRecall` cannot invoke a
+ * guarantees: a reader must ACCEPT the gate, and the registry cannot invoke a
  * reader without supplying one. What the type does NOT guarantee: that a reader
  * actually applies the gate to its query predicate — TypeScript can't see inside
  * the body. That last mile is held by the per-source ACL tests (search-channel /
@@ -21,9 +32,28 @@
 
 import type { AuthzScope } from '../authz/scope';
 
-export interface FeedReader<Ctx, Out> {
-  /** Stable identifier for the reader (its recall kind / feed kind). */
-  readonly kind: string;
+/** Axis 1 — where a feed's bytes live. Keep in sync with the model doc's table. */
+export type SourceKind = 'chat-channel' | 'virtual-live-dataset' | 'collected';
+
+/** Axis 2 — how the caller reads a feed. Any lens over any source kind. */
+export type LensKind = 'recall' | 'metric' | 'raw-sql';
+
+export interface FeedReader<
+  S extends SourceKind,
+  L extends LensKind,
+  Ctx,
+  Out,
+> {
+  /** WHERE the bytes live — one of the source-kind axis values. */
+  readonly source: S;
+  /** HOW the caller reads them — one of the lens-kind axis values. */
+  readonly lens: L;
+  /**
+   * Whether this reader can serve `ctx`. Lets the registry skip a reader that
+   * has no work to do (missing query text, wrong signal) WITHOUT the caller
+   * branching on the reader's kind. Return `true` to always attempt `read`.
+   */
+  canRead(ctx: Ctx): boolean;
   /**
    * Run the read under `gate`. The gate is the first argument on purpose: it is
    * the ACL boundary every reader compiles its scoping predicate from, and

--- a/packages/server/src/tools/__tests__/recall-sources.test.ts
+++ b/packages/server/src/tools/__tests__/recall-sources.test.ts
@@ -1,10 +1,12 @@
 /**
- * Generic test of the recall-source registry — the ONE abstraction over the two
+ * Generic test of the recall-source registry — the ONE abstraction over the
  * consolidated recall kinds (`knowledge` = events, `conversation` =
- * channel_messages). Uses fake sources so it asserts the registry CONTRACT
- * (merge, failure isolation, empty omission, unique kinds, GATE forwarding)
- * independent of any one source's behavior. Per-source behavior is covered
- * separately (search-channel-recall.test.ts, search-content-*.test.ts).
+ * channel_messages, `virtual` = live virtual feeds), realized as the
+ * `(source, lens='recall')` row of the FeedReader matrix. Uses fake sources so it
+ * asserts the registry CONTRACT (canRead gating, merge, failure isolation, empty
+ * omission, unique kinds, GATE forwarding) independent of any one source's
+ * behavior. Per-source behavior is covered separately
+ * (search-channel-recall.test.ts, search-content-*.test.ts).
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -23,11 +25,17 @@ const gate: AuthzScope = { organizationId: 'org-1', principal: 'user-1', agentId
 
 const knowledgeHit: RecallSource = {
   kind: 'knowledge',
+  source: 'collected',
+  lens: 'recall',
+  canRead: () => true,
   // biome-ignore lint/suspicious/noExplicitAny: fixture snippet, shape irrelevant
   read: async () => ({ content: [{ id: 1 } as any] }),
 };
 const conversationHit: RecallSource = {
   kind: 'conversation',
+  source: 'chat-channel',
+  lens: 'recall',
+  canRead: () => true,
   // biome-ignore lint/suspicious/noExplicitAny: fixture snippet, shape irrelevant
   read: async () => ({ conversation_messages: [{ text: 'hi' } as any] }),
 };
@@ -42,6 +50,9 @@ describe('recall source registry (generic contract)', () => {
   it('isolates a failing source — the others still contribute', async () => {
     const boom: RecallSource = {
       kind: 'conversation',
+      source: 'chat-channel',
+      lens: 'recall',
+      canRead: () => true,
       read: async () => {
         throw new Error('source blew up');
       },
@@ -52,15 +63,38 @@ describe('recall source registry (generic contract)', () => {
   });
 
   it('omits the facet for a source that returns nothing', async () => {
-    const empty: RecallSource = { kind: 'conversation', read: async () => ({}) };
+    const empty: RecallSource = {
+      kind: 'conversation',
+      source: 'chat-channel',
+      lens: 'recall',
+      canRead: () => true,
+      read: async () => ({}),
+    };
     const merged = await gatherRecall(gate, ctx, [empty]);
     expect(merged).toEqual({});
   });
 
-  it('every registered source owns a distinct kind', () => {
+  it('skips a source whose canRead returns false — read is never called', async () => {
+    const declines: RecallSource = {
+      kind: 'virtual',
+      source: 'virtual-live-dataset',
+      lens: 'recall',
+      canRead: () => false,
+      read: vi.fn(async () => ({ content: [{ id: 99 }] as never })),
+    };
+    const merged = await gatherRecall(gate, ctx, [knowledgeHit, declines]);
+    // knowledgeHit ran; the declining source contributed nothing and its read
+    // was never invoked (branch-free skip, not a wasted call swallowed later).
+    expect(merged.content).toHaveLength(1);
+    expect(declines.read).not.toHaveBeenCalled();
+  });
+
+  it('every registered source owns a distinct kind and the recall lens', () => {
     const kinds = RECALL_SOURCES.map((s) => s.kind);
     expect(new Set(kinds).size).toBe(kinds.length);
     expect(RECALL_SOURCES.length).toBeGreaterThanOrEqual(2);
+    // The registry is the `lens = recall` row of the matrix — every entry agrees.
+    expect(RECALL_SOURCES.every((s) => s.lens === 'recall')).toBe(true);
   });
 });
 
@@ -69,6 +103,9 @@ describe('recall gate is a REQUIRED, typed argument (the contract)', () => {
     const seen: AuthzScope[] = [];
     const spy1: RecallSource = {
       kind: 'knowledge',
+      source: 'collected',
+      lens: 'recall',
+      canRead: () => true,
       read: vi.fn(async (g: AuthzScope) => {
         seen.push(g);
         return {};
@@ -76,6 +113,9 @@ describe('recall gate is a REQUIRED, typed argument (the contract)', () => {
     };
     const spy2: RecallSource = {
       kind: 'conversation',
+      source: 'chat-channel',
+      lens: 'recall',
+      canRead: () => true,
       read: vi.fn(async (g: AuthzScope) => {
         seen.push(g);
         return {};
@@ -91,19 +131,24 @@ describe('recall gate is a REQUIRED, typed argument (the contract)', () => {
 
   it('the registry type CANNOT hold a reader that omits the gate', () => {
     // A reader on the OLD `recall(ctx)` shape (no gate) is structurally
-    // incompatible with FeedReader<RecallContext, …> — the compiler rejects it.
+    // incompatible with FeedReader<…> — the compiler rejects it.
     // @ts-expect-error — `read` MUST accept the AuthzScope gate as its first arg.
     const leaky: RecallSource = {
       kind: 'knowledge',
+      source: 'collected',
+      lens: 'recall',
+      canRead: () => true,
       recall: async (_ctx: RecallContext) => ({}),
     };
     // Sanity: a correctly-typed reader IS assignable.
-    const ok: FeedReader<RecallContext, Record<string, never>> = {
-      kind: 'knowledge',
+    const ok: FeedReader<'collected', 'recall', RecallContext, Record<string, never>> = {
+      source: 'collected',
+      lens: 'recall',
+      canRead: () => true,
       read: async (_gate: AuthzScope, _ctx: RecallContext) => ({}),
     };
     expect(leaky.kind).toBe('knowledge');
-    expect(ok.kind).toBe('knowledge');
+    expect(ok.source).toBe('collected');
   });
   // NOTE: that a reader DENIES a non-member is NOT asserted here — a fake source
   // proves nothing about production enforcement. The real fail-closed regression

--- a/packages/server/src/tools/__tests__/recall-sources.test.ts
+++ b/packages/server/src/tools/__tests__/recall-sources.test.ts
@@ -74,6 +74,25 @@ describe('recall source registry (generic contract)', () => {
     expect(merged).toEqual({});
   });
 
+  it('isolates a source whose canRead THROWS — the others still contribute', async () => {
+    // canRead is part of a reader's surface, so a throwing predicate must be
+    // isolated the same way a throwing read is — it must NOT reject the whole
+    // gather and wipe every source's facet.
+    const throwsInCanRead: RecallSource = {
+      kind: 'conversation',
+      source: 'chat-channel',
+      lens: 'recall',
+      canRead: () => {
+        throw new Error('canRead blew up');
+      },
+      read: vi.fn(async () => ({ conversation_messages: [{ text: 'hi' }] as never })),
+    };
+    const merged = await gatherRecall(gate, ctx, [knowledgeHit, throwsInCanRead]);
+    expect(merged.content).toHaveLength(1); // knowledge survived
+    expect(merged.conversation_messages).toBeUndefined();
+    expect(throwsInCanRead.read).not.toHaveBeenCalled(); // never reached read
+  });
+
   it('skips a source whose canRead returns false — read is never called', async () => {
     const declines: RecallSource = {
       kind: 'virtual',
@@ -95,6 +114,19 @@ describe('recall source registry (generic contract)', () => {
     expect(RECALL_SOURCES.length).toBeGreaterThanOrEqual(2);
     // The registry is the `lens = recall` row of the matrix — every entry agrees.
     expect(RECALL_SOURCES.every((s) => s.lens === 'recall')).toBe(true);
+  });
+
+  it('each production source maps its kind to the right source-kind axis value', () => {
+    // Pins the kind ↔ source correspondence the code documents (the tuple's
+    // `source` is typed as the union, so a wrong pairing would still compile).
+    const expected: Record<string, string> = {
+      knowledge: 'collected',
+      conversation: 'chat-channel',
+      virtual: 'virtual-live-dataset',
+    };
+    for (const s of RECALL_SOURCES) {
+      expect(s.source).toBe(expected[s.kind]);
+    }
   });
 });
 
@@ -129,16 +161,19 @@ describe('recall gate is a REQUIRED, typed argument (the contract)', () => {
     expect(seen).toEqual([gate, gate]);
   });
 
-  it('the registry type CANNOT hold a reader that omits the gate', () => {
-    // A reader on the OLD `recall(ctx)` shape (no gate) is structurally
-    // incompatible with FeedReader<…> — the compiler rejects it.
-    // @ts-expect-error — `read` MUST accept the AuthzScope gate as its first arg.
+  it('the registry type CANNOT hold a reader whose read omits the gate', () => {
+    // A reader whose `read` takes only ctx (the OLD gate-less shape) is
+    // structurally incompatible with FeedReader<…>: RecallContext and AuthzScope
+    // are unrelated, so the first-arg mismatch is what the compiler rejects here
+    // — NOT a missing property. This pins the exact claim (gate-first signature),
+    // so adding fields to the reader shape can't silently satisfy the suppression.
+    // @ts-expect-error — `read`'s first arg MUST be the AuthzScope gate, not ctx.
     const leaky: RecallSource = {
       kind: 'knowledge',
       source: 'collected',
       lens: 'recall',
       canRead: () => true,
-      recall: async (_ctx: RecallContext) => ({}),
+      read: async (_ctx: RecallContext) => ({}),
     };
     // Sanity: a correctly-typed reader IS assignable.
     const ok: FeedReader<'collected', 'recall', RecallContext, Record<string, never>> = {

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -639,24 +639,29 @@ export const RECALL_SOURCES: RecallSource[] = [knowledgeSource, conversationSour
 /** Run every recall reader that CAN serve `ctx` under `gate` and merge their
  * facets into one fragment. A source that returns `false` from `canRead` is
  * skipped BRANCH-FREE — the "needs query text" guard lives on the reader, not in
- * a caller-side type-switch. Readers fail independently — one reader's error
- * never drops another's results. The `sources` param is injectable so the
- * registry can be tested generically. The gate is a required, explicit argument:
- * it is the ACL boundary every reader compiles against, never buried in `ctx`. */
+ * a caller-side type-switch. Readers fail INDEPENDENTLY: BOTH `canRead` and
+ * `read` run inside the per-source isolation boundary, so a throw from either one
+ * drops only that source's facet (logged), never another's. The `sources` param
+ * is injectable so the registry can be tested generically. The gate is a
+ * required, explicit argument: it is the ACL boundary every reader compiles
+ * against, never buried in `ctx`. */
 export async function gatherRecall(
   gate: AuthzScope,
   ctx: RecallContext,
   sources: RecallSource[] = RECALL_SOURCES
 ): Promise<Partial<UnifiedSearchResult>> {
   const fragments = await Promise.all(
-    sources
-      .filter((source) => source.canRead(ctx))
-      .map((source) =>
-        source.read(gate, ctx).catch((err) => {
-          logger.warn(`[search] recall source '${source.kind}' failed: ${getErrorMessage(err)}`);
-          return {} as Partial<UnifiedSearchResult>;
-        })
-      )
+    sources.map(async (source) => {
+      try {
+        // canRead is inside the try so a throwing predicate isolates to this
+        // source (skipped + logged) instead of rejecting the whole gather.
+        if (!source.canRead(ctx)) return {} as Partial<UnifiedSearchResult>;
+        return await source.read(gate, ctx);
+      } catch (err) {
+        logger.warn(`[search] recall source '${source.kind}' failed: ${getErrorMessage(err)}`);
+        return {} as Partial<UnifiedSearchResult>;
+      }
+    })
   );
   return Object.assign({}, ...fragments);
 }

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -13,7 +13,7 @@ import { type AuthzScope, authzScopeFromToolContext } from '../authz/scope';
 import { compileConnectionRowVisibility } from '../authz/connection-visibility';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
-import type { FeedReader } from '../lib/feed-reader';
+import type { FeedReader, SourceKind } from '../lib/feed-reader';
 import { readVirtualFeed } from '../lib/connector-pushdown';
 import { entityLinkMatchSql, searchContentByText } from '../utils/content-search';
 import { resolveBoundChannelRows, stripPlatformPrefix } from '../gateway/channels/bound-channels';
@@ -472,13 +472,22 @@ export interface RecallContext {
 }
 
 /**
- * The consolidated recall types. `knowledge` (the `events` store — where data
- * feeds and promoted memory live), `conversation` (the `channel_messages` chat
- * transcript), and `virtual` (opt-in virtual feeds read LIVE at request time).
- * All read through ONE abstraction — add a type here + a RECALL_SOURCES entry;
- * nothing branches on the kind.
+ * The consolidated recall sources — the `lens = 'recall'` row of the feed matrix
+ * (see `docs/plans/feeds-and-connections-model.md`), one entry per source KIND:
+ * `knowledge` (the `events` store — where data feeds and promoted memory live,
+ * source `collected`), `conversation` (the `channel_messages` chat transcript,
+ * source `chat-channel`), and `virtual` (opt-in virtual feeds read LIVE at
+ * request time, source `virtual-live-dataset`). All read through ONE abstraction
+ * — add a kind here + a RECALL_SOURCES entry; nothing branches on the kind.
  */
 export type RecallKind = 'knowledge' | 'conversation' | 'virtual';
+
+/** Maps each recall source's human label to its {@link SourceKind} axis value. */
+const RECALL_SOURCE_KIND: Record<RecallKind, SourceKind> = {
+  knowledge: 'collected',
+  conversation: 'chat-channel',
+  virtual: 'virtual-live-dataset',
+};
 
 /**
  * Max virtual feeds fanned out on a single recall. Each virtual feed spawns a
@@ -490,21 +499,34 @@ export type RecallKind = 'knowledge' | 'conversation' | 'virtual';
 const MAX_VIRTUAL_RECALL_FEEDS = 5;
 
 /**
- * A recall source is a {@link FeedReader}: it owns exactly one kind and
- * contributes ONLY the result facet it produces (or `{}` when it has none).
- * `gatherRecall` runs them all and merges — there is no central type-switch over
- * kinds. Each reader receives the ACL gate ({@link AuthzScope}) as a REQUIRED,
- * typed argument supplied by `gatherRecall` — never buried in `ctx`, so it can't
- * be dropped at the call site. (The gate enforcing the scope is verified by the
- * per-source ACL tests, not by the type.) Readers fail independently.
+ * A recall source is a {@link FeedReader} on the `(source, lens='recall')` tuple:
+ * it owns exactly one source kind and contributes ONLY the result facet it
+ * produces (or `{}` when it has none). `canRead(ctx)` lets a source decline a ctx
+ * it can't serve (no query text, wrong signal) so `gatherRecall` skips it
+ * BRANCH-FREE — the guard lives on the reader, not in a caller-side `if`. Each
+ * reader receives the ACL gate ({@link AuthzScope}) as a REQUIRED, typed argument
+ * supplied by `gatherRecall` — never buried in `ctx`, so it can't be dropped at
+ * the call site. (The gate enforcing the scope is verified by the per-source ACL
+ * tests, not by the type.) Readers fail independently.
  */
-export type RecallSource = FeedReader<RecallContext, Partial<UnifiedSearchResult>> & {
+export type RecallSource = FeedReader<
+  SourceKind,
+  'recall',
+  RecallContext,
+  Partial<UnifiedSearchResult>
+> & {
+  /** Human label for logs + the result facet it owns; maps to `source` via RECALL_SOURCE_KIND. */
   readonly kind: RecallKind;
 };
 
 /** `knowledge` — semantic/keyword snippets from the `events` store. */
 const knowledgeSource: RecallSource = {
   kind: 'knowledge',
+  source: RECALL_SOURCE_KIND.knowledge,
+  lens: 'recall',
+  // Reads via text OR a precomputed embedding; fetchContentSnippets tolerates a
+  // null query (embedding-only), so there is nothing to decline here.
+  canRead: () => true,
   read: async (gate, ctx) => {
     const content = await fetchContentSnippets(
       gate,
@@ -521,9 +543,14 @@ const knowledgeSource: RecallSource = {
 /** `conversation` — keyword/recency hits from the `channel_messages` transcript. */
 const conversationSource: RecallSource = {
   kind: 'conversation',
+  source: RECALL_SOURCE_KIND.conversation,
+  lens: 'recall',
+  // Keyword match has no embedding path, so a text query is required. (The
+  // calling-agent requirement is gate-dependent and stays in `read`.)
+  canRead: (ctx) => Boolean(ctx.query),
   read: async (gate, ctx) => {
-    // Needs a calling agent (its bindings are the tenant fence, on the gate) and
-    // a text query (keyword match has no embedding path). The requesting user
+    // Needs a calling agent (its bindings are the tenant fence, on the gate).
+    // `canRead` already guaranteed a text query. The requesting user
     // (`gate.principal`) is the per-user side of the gate — see
     // fetchConversationSnippets.
     if (!ctx.query || !gate.agentId) return {};
@@ -545,8 +572,12 @@ const conversationSource: RecallSource = {
  */
 const virtualSource: RecallSource = {
   kind: 'virtual',
+  source: RECALL_SOURCE_KIND.virtual,
+  lens: 'recall',
+  // Recall over a virtual feed is a keyword `search()` — it needs query text.
+  canRead: (ctx) => Boolean(ctx.query),
   read: async (gate, ctx) => {
-    // Recall over a virtual feed is a keyword `search()` — it needs query text.
+    // `canRead` already guaranteed a text query.
     if (!ctx.query) return {};
 
     // Candidate opt-in feeds, gated by the same connection visibility every read
@@ -605,23 +636,27 @@ const virtualSource: RecallSource = {
 
 export const RECALL_SOURCES: RecallSource[] = [knowledgeSource, conversationSource, virtualSource];
 
-/** Run every recall reader under `gate` and merge their facets into one
- * fragment. Readers fail independently — one reader's error never drops
- * another's results. The `sources` param is injectable so the registry can be
- * tested generically. The gate is a required, explicit argument: it is the ACL
- * boundary every reader compiles against, never buried in `ctx`. */
+/** Run every recall reader that CAN serve `ctx` under `gate` and merge their
+ * facets into one fragment. A source that returns `false` from `canRead` is
+ * skipped BRANCH-FREE — the "needs query text" guard lives on the reader, not in
+ * a caller-side type-switch. Readers fail independently — one reader's error
+ * never drops another's results. The `sources` param is injectable so the
+ * registry can be tested generically. The gate is a required, explicit argument:
+ * it is the ACL boundary every reader compiles against, never buried in `ctx`. */
 export async function gatherRecall(
   gate: AuthzScope,
   ctx: RecallContext,
   sources: RecallSource[] = RECALL_SOURCES
 ): Promise<Partial<UnifiedSearchResult>> {
   const fragments = await Promise.all(
-    sources.map((source) =>
-      source.read(gate, ctx).catch((err) => {
-        logger.warn(`[search] recall source '${source.kind}' failed: ${getErrorMessage(err)}`);
-        return {} as Partial<UnifiedSearchResult>;
-      })
-    )
+    sources
+      .filter((source) => source.canRead(ctx))
+      .map((source) =>
+        source.read(gate, ctx).catch((err) => {
+          logger.warn(`[search] recall source '${source.kind}' failed: ${getErrorMessage(err)}`);
+          return {} as Partial<UnifiedSearchResult>;
+        })
+      )
   );
   return Object.assign({}, ...fragments);
 }


### PR DESCRIPTION
## What

Promotes the recall-source registry (`RECALL_SOURCES` in `search.ts`) from the `FeedReader<Ctx, Out>` shape it got in #1707 to the `(sourceKind, lensKind)` **tuple** the feeds model doc specifies. This is the "generalize `RecallSource` → `FeedReader`" follow-up, scoped to the recall lens where it earns its keep.

## Why

The design doc (`docs/plans/feeds-and-connections-model.md`) defines a feed by two orthogonal axes — **source kind** (where the bytes live) × **lens kind** (how you read them) — and a capability registry keyed by the `(source, lens)` tuple. #1707 shipped the recall lens on a registry but parameterized `FeedReader` only by `<Ctx, Out>`. This lands the actual tuple shape so that adding a source or a lens is provably branch-free, and the future fold of the metric/raw-sql lenses is additive.

## Changes

- `lib/feed-reader.ts`: `FeedReader<S extends SourceKind, L extends LensKind, Ctx, Out>` with typed `source` + `lens` + a `canRead(ctx)` predicate. `SourceKind` (`chat-channel | virtual-live-dataset | collected`) and `LensKind` (`recall | metric | raw-sql`) are the shared axis vocabulary.
- `tools/search.ts`: each recall source tagged `source` + `lens:'recall'`; the "needs query text" guards move from inside `read` into `canRead`; `gatherRecall` filters by `canRead` so a source that can't serve the ctx is skipped **branch-free** (instead of being called and returning `{}`).
- `docs/plans/feeds-and-connections-model.md`: marks the recall slice as realized on the tuple registry; records why the metric/raw-sql fold stays deferred (pure consolidation of working subsystems, no new capability — defer until a real second-lens need forces it, per "design the seam, not the framework").

## Behavior

**Unchanged.** A source skipped by `canRead` contributed nothing before either (it returned `{}` after being called). The only observable difference is one fewer no-op call. This is a type/dispatch refactor, not a behavior change.

## Scope decision

Deliberately does NOT fold `metric` + `query_sql` under one tuple registry — that's a large pure-refactor across two working subsystems with real regression surface and zero new capability. Deferred per the design doc's own reasoning; the recall registry is shaped so that fold is additive when a second-lens need forces it.

## Tests

- `recall-sources.test.ts` extended: `canRead=false` source is skipped and its `read` is never called; every registered source agrees on `lens:'recall'`; tuple-shape type-guard test.
- Regression: `search-channel-recall.test.ts` (17), `virtual-feed-surfaces.test.ts` (12), `slack-channel-visibility.test.ts` (ACL fail-closed) all green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785632009&installation_id=136316292&pr_number=1709&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1709&signature=07a84a4cf2832b08a8816ddf4a841bcd654e19c58a7d266cdc64fc85233eed12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->