### PR TITLE
feat(inference): bundled provider catalog on the inference-providers page

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -13,10 +13,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://console.groq.com/keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Groq Console</a>",
           "apiKeyPlaceholder": "gsk_...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text",
-            "stt"
-          ],
+          "modalities": ["text", "stt"],
           "defaultModel": "llama-3.3-70b-versatile",
           "modelsEndpoint": "/models",
           "stt": {
@@ -41,11 +38,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://aistudio.google.com/apikey\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Google AI Studio</a>",
           "apiKeyPlaceholder": "AIza...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text",
-            "image",
-            "tts"
-          ],
+          "modalities": ["text", "image", "tts"],
           "defaultModel": "gemini-2.5-flash"
         }
       ]
@@ -63,9 +56,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://api.together.ai/settings/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Together AI Dashboard</a>",
           "apiKeyPlaceholder": "tok_...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text"
-          ],
+          "modalities": ["text"],
           "defaultModel": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
           "modelsEndpoint": "/models"
         }
@@ -84,9 +75,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://build.nvidia.com/settings/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">NVIDIA Build</a>",
           "apiKeyPlaceholder": "nvapi-...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text"
-          ],
+          "modalities": ["text"],
           "modelsEndpoint": "/models",
           "defaultModel": "nvidia/moonshotai/kimi-k2.6"
         }
@@ -105,9 +94,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://z.ai/manage-apikey/apikey-list\" target=\"_blank\" class=\"text-blue-600 hover:underline\">z.ai</a>",
           "apiKeyPlaceholder": "zai-...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text"
-          ]
+          "modalities": ["text"]
         }
       ]
     },
@@ -124,9 +111,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://elevenlabs.io/app/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">ElevenLabs</a>",
           "apiKeyPlaceholder": "sk_...",
           "sdkCompat": "openai",
-          "modalities": [
-            "tts"
-          ]
+          "modalities": ["tts"]
         }
       ]
     },
@@ -143,9 +128,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://fireworks.ai/account/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Fireworks Dashboard</a>",
           "apiKeyPlaceholder": "fw_...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text"
-          ],
+          "modalities": ["text"],
           "defaultModel": "accounts/fireworks/models/llama-v3p3-70b-instruct",
           "modelsEndpoint": "/models"
         }
@@ -164,9 +147,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://console.mistral.ai/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Mistral Console</a>",
           "apiKeyPlaceholder": "sk-...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text"
-          ],
+          "modalities": ["text"],
           "defaultModel": "mistral-large-latest",
           "modelsEndpoint": "/models"
         }
@@ -185,9 +166,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://platform.deepseek.com/api_keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">DeepSeek Platform</a>",
           "apiKeyPlaceholder": "sk-...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text"
-          ],
+          "modalities": ["text"],
           "defaultModel": "deepseek-v4-flash",
           "modelsEndpoint": "/v1/models"
         }
@@ -206,10 +185,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://openrouter.ai/keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">OpenRouter</a>, or connect via OAuth for per-user billing",
           "apiKeyPlaceholder": "sk-or-...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text",
-            "stt"
-          ],
+          "modalities": ["text", "stt"],
           "defaultModel": "anthropic/claude-sonnet-4",
           "modelsEndpoint": "/models",
           "stt": {
@@ -234,9 +210,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://cloud.cerebras.ai/\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Cerebras Cloud</a>",
           "apiKeyPlaceholder": "csk-...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text"
-          ],
+          "modalities": ["text"],
           "defaultModel": "llama-3.3-70b",
           "modelsEndpoint": "/models"
         }
@@ -255,9 +229,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://opencode.ai/auth\" target=\"_blank\" class=\"text-blue-600 hover:underline\">OpenCode Zen</a>",
           "apiKeyPlaceholder": "zen-...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text"
-          ],
+          "modalities": ["text"],
           "defaultModel": "claude-sonnet-4-6",
           "modelsEndpoint": "/models"
         }
@@ -276,9 +248,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://console.x.ai/\" target=\"_blank\" class=\"text-blue-600 hover:underline\">xAI Console</a>",
           "apiKeyPlaceholder": "xai-...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text"
-          ],
+          "modalities": ["text"],
           "defaultModel": "grok-3",
           "modelsEndpoint": "/models"
         }
@@ -297,9 +267,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://www.perplexity.ai/settings/api\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Perplexity Settings</a>",
           "apiKeyPlaceholder": "pplx-...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text"
-          ],
+          "modalities": ["text"],
           "defaultModel": "sonar",
           "modelsEndpoint": "/v1/models"
         }
@@ -318,9 +286,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://dashboard.cohere.com/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Cohere Dashboard</a>",
           "apiKeyPlaceholder": "co-...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text"
-          ],
+          "modalities": ["text"],
           "defaultModel": "command-r-plus",
           "modelsEndpoint": "/models"
         }
@@ -339,11 +305,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://platform.openai.com/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">OpenAI Dashboard</a>",
           "apiKeyPlaceholder": "sk-...",
           "sdkCompat": "openai",
-          "modalities": [
-            "text",
-            "image",
-            "tts"
-          ],
+          "modalities": ["text", "image", "tts"],
           "defaultModel": "gpt-4o",
           "modelsEndpoint": "/models"
         }

--- a/config/providers.json
+++ b/config/providers.json
@@ -13,6 +13,10 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://console.groq.com/keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Groq Console</a>",
           "apiKeyPlaceholder": "gsk_...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text",
+            "stt"
+          ],
           "defaultModel": "llama-3.3-70b-versatile",
           "modelsEndpoint": "/models",
           "stt": {
@@ -37,6 +41,11 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://aistudio.google.com/apikey\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Google AI Studio</a>",
           "apiKeyPlaceholder": "AIza...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text",
+            "image",
+            "tts"
+          ],
           "defaultModel": "gemini-2.5-flash"
         }
       ]
@@ -54,6 +63,9 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://api.together.ai/settings/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Together AI Dashboard</a>",
           "apiKeyPlaceholder": "tok_...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text"
+          ],
           "defaultModel": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
           "modelsEndpoint": "/models"
         }
@@ -72,6 +84,9 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://build.nvidia.com/settings/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">NVIDIA Build</a>",
           "apiKeyPlaceholder": "nvapi-...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text"
+          ],
           "modelsEndpoint": "/models",
           "defaultModel": "nvidia/moonshotai/kimi-k2.6"
         }
@@ -89,7 +104,10 @@
           "upstreamBaseUrl": "https://api.z.ai/api/coding/paas/v4",
           "apiKeyInstructions": "Get your API key from <a href=\"https://z.ai/manage-apikey/apikey-list\" target=\"_blank\" class=\"text-blue-600 hover:underline\">z.ai</a>",
           "apiKeyPlaceholder": "zai-...",
-          "sdkCompat": "openai"
+          "sdkCompat": "openai",
+          "modalities": [
+            "text"
+          ]
         }
       ]
     },
@@ -105,7 +123,10 @@
           "upstreamBaseUrl": "https://api.elevenlabs.io",
           "apiKeyInstructions": "Get your API key from <a href=\"https://elevenlabs.io/app/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">ElevenLabs</a>",
           "apiKeyPlaceholder": "sk_...",
-          "sdkCompat": "openai"
+          "sdkCompat": "openai",
+          "modalities": [
+            "tts"
+          ]
         }
       ]
     },
@@ -122,6 +143,9 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://fireworks.ai/account/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Fireworks Dashboard</a>",
           "apiKeyPlaceholder": "fw_...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text"
+          ],
           "defaultModel": "accounts/fireworks/models/llama-v3p3-70b-instruct",
           "modelsEndpoint": "/models"
         }
@@ -140,6 +164,9 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://console.mistral.ai/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Mistral Console</a>",
           "apiKeyPlaceholder": "sk-...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text"
+          ],
           "defaultModel": "mistral-large-latest",
           "modelsEndpoint": "/models"
         }
@@ -148,7 +175,7 @@
     {
       "id": "deepseek",
       "name": "DeepSeek",
-      "description": "DeepSeek V4 models — fast and reasoning variants",
+      "description": "DeepSeek V4 models \u2014 fast and reasoning variants",
       "providers": [
         {
           "displayName": "DeepSeek",
@@ -158,6 +185,9 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://platform.deepseek.com/api_keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">DeepSeek Platform</a>",
           "apiKeyPlaceholder": "sk-...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text"
+          ],
           "defaultModel": "deepseek-v4-flash",
           "modelsEndpoint": "/v1/models"
         }
@@ -176,6 +206,10 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://openrouter.ai/keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">OpenRouter</a>, or connect via OAuth for per-user billing",
           "apiKeyPlaceholder": "sk-or-...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text",
+            "stt"
+          ],
           "defaultModel": "anthropic/claude-sonnet-4",
           "modelsEndpoint": "/models",
           "stt": {
@@ -200,6 +234,9 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://cloud.cerebras.ai/\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Cerebras Cloud</a>",
           "apiKeyPlaceholder": "csk-...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text"
+          ],
           "defaultModel": "llama-3.3-70b",
           "modelsEndpoint": "/models"
         }
@@ -218,6 +255,9 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://opencode.ai/auth\" target=\"_blank\" class=\"text-blue-600 hover:underline\">OpenCode Zen</a>",
           "apiKeyPlaceholder": "zen-...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text"
+          ],
           "defaultModel": "claude-sonnet-4-6",
           "modelsEndpoint": "/models"
         }
@@ -236,6 +276,9 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://console.x.ai/\" target=\"_blank\" class=\"text-blue-600 hover:underline\">xAI Console</a>",
           "apiKeyPlaceholder": "xai-...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text"
+          ],
           "defaultModel": "grok-3",
           "modelsEndpoint": "/models"
         }
@@ -254,6 +297,9 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://www.perplexity.ai/settings/api\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Perplexity Settings</a>",
           "apiKeyPlaceholder": "pplx-...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text"
+          ],
           "defaultModel": "sonar",
           "modelsEndpoint": "/v1/models"
         }
@@ -272,6 +318,9 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://dashboard.cohere.com/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Cohere Dashboard</a>",
           "apiKeyPlaceholder": "co-...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text"
+          ],
           "defaultModel": "command-r-plus",
           "modelsEndpoint": "/models"
         }
@@ -290,6 +339,11 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://platform.openai.com/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">OpenAI Dashboard</a>",
           "apiKeyPlaceholder": "sk-...",
           "sdkCompat": "openai",
+          "modalities": [
+            "text",
+            "image",
+            "tts"
+          ],
           "defaultModel": "gpt-4o",
           "modelsEndpoint": "/models"
         }

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -260,6 +260,29 @@ describe("buildDynamicOpenAIModel — never silently route to OpenAI", () => {
     );
   });
 
+  test("uses the passed pi-ai api for non-openai protocols (generic)", () => {
+    const model = buildDynamicOpenAIModel({
+      rawProvider: "my-claude",
+      registryProvider: "anthropic",
+      modelId: "claude-opus-4-8",
+      providerBaseUrl: "http://localhost:8118/api/proxy/my-claude/a/agent-1",
+      api: "anthropic-messages",
+    });
+    expect(model.api).toBe("anthropic-messages");
+    expect(model.provider).toBe("anthropic");
+    expect(model.id).toBe("claude-opus-4-8");
+  });
+
+  test("defaults to openai-completions when no api is passed", () => {
+    const model = buildDynamicOpenAIModel({
+      rawProvider: "groq",
+      registryProvider: "openai",
+      modelId: "llama-3.3-70b",
+      providerBaseUrl: "http://localhost:8118/api/proxy/groq/a/agent-1",
+    });
+    expect(model.api).toBe("openai-completions");
+  });
+
   test("THROWS for a third-party provider with no resolved base URL", () => {
     // Regression for the silent-misroute bug: an unresolved proxy base URL
     // previously fell back to api.openai.com, shipping the request to OpenAI
@@ -283,7 +306,7 @@ describe("buildDynamicOpenAIModel — never silently route to OpenAI", () => {
           modelId: "some-model",
           providerBaseUrl: undefined,
         })
-      ).toThrow(/Refusing to route .* to OpenAI's public endpoint/);
+      ).toThrow(/Refusing to route .* to a public endpoint/);
     }
   });
 

--- a/packages/agent-worker/src/openclaw/model-resolver.ts
+++ b/packages/agent-worker/src/openclaw/model-resolver.ts
@@ -5,7 +5,13 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { type ConfigProviderMeta, createLogger } from "@lobu/core";
+import {
+  type ConfigProviderMeta,
+  createLogger,
+  type PiAiApi,
+  resolveSdkCompat,
+  SDK_COMPAT_PROTOCOLS,
+} from "@lobu/core";
 import { getModel, type Model } from "@mariozechner/pi-ai";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 
@@ -76,6 +82,20 @@ export const PROVIDER_REGISTRY_ALIASES: Record<string, string> = {
 };
 
 /**
+ * Registry alias → pi-ai adapter, derived from the protocol registry. Lets the
+ * model builder pick the right wire adapter for a dynamic model from just the
+ * resolved registry alias. When an alias maps to multiple protocols (e.g.
+ * "openai" ← openai + openai-responses), the first wins — openai-completions,
+ * the correct default for the common OpenAI-compatible case.
+ */
+export const PIAI_API_BY_REGISTRY_ALIAS: Record<string, PiAiApi> =
+  Object.fromEntries(
+    Object.values(SDK_COMPAT_PROTOCOLS)
+      .reverse()
+      .map((p) => [p.registryAlias, p.api])
+  );
+
+/**
  * Register a config-driven provider at runtime.
  * Extends the base URL env, default model, and registry alias maps
  * so resolveModelRef() and the worker can handle the provider.
@@ -95,11 +115,11 @@ export function registerDynamicProvider(
     DEFAULT_PROVIDER_MODELS[id] = config.defaultModel;
   }
 
-  // Map to model registry name: explicit alias, or "openai" for sdkCompat providers
+  // Map to model registry name: explicit alias, else the protocol's registry
+  // alias (e.g. openai-compatible → "openai", anthropic → "anthropic").
   if (!PROVIDER_REGISTRY_ALIASES[id]) {
     const alias =
-      config.registryAlias ||
-      (config.sdkCompat === "openai" ? "openai" : undefined);
+      config.registryAlias || resolveSdkCompat(config.sdkCompat)?.registryAlias;
     if (alias) {
       PROVIDER_REGISTRY_ALIASES[id] = alias;
     }
@@ -112,11 +132,11 @@ export function registerDynamicProvider(
   );
 }
 
-/** Shape of a dynamically-built openai-completions model entry. */
-interface DynamicOpenAIModel {
+/** Shape of a dynamically-built model entry (any pi-ai wire protocol). */
+interface DynamicModel {
   id: string;
   name: string;
-  api: "openai-completions";
+  api: PiAiApi;
   provider: string;
   baseUrl: string;
   reasoning: boolean;
@@ -133,40 +153,43 @@ interface DynamicOpenAIModel {
 }
 
 /**
- * Build a dynamic openai-completions model entry for a config-driven provider
- * whose model isn't in pi-ai's static registry (gemini, nvidia, together-ai,
- * z.ai, …).
+ * Build a dynamic model entry for a config-driven provider whose model isn't in
+ * pi-ai's static registry (gemini, nvidia, together-ai, z.ai, org BYO providers,
+ * …). The `api` selects the pi-ai adapter that speaks the provider's protocol —
+ * defaults to openai-completions for the common OpenAI-compatible case.
  *
  * `rawProvider` is the gateway provider slug; `registryProvider` is the
- * model-registry name it maps to (usually "openai" for sdkCompat providers).
+ * model-registry name it maps to.
  *
  * Reliability invariant: only REAL OpenAI may default to OpenAI's public
  * endpoint. For every other provider an unresolved `providerBaseUrl` means the
- * gateway failed to supply a proxy mapping — routing such a request to
- * api.openai.com would silently mis-deliver it to OpenAI with a model ID it
- * doesn't know, surfacing as a confusing "400 <model> is not a valid model
- * ID". We throw instead so the real cause (no proxy base URL) is visible.
+ * gateway failed to supply a proxy mapping — routing such a request to a public
+ * endpoint would silently mis-deliver it with a model ID that endpoint doesn't
+ * know, surfacing as a confusing "400 <model> is not a valid model ID". We throw
+ * instead so the real cause (no proxy base URL) is visible.
  */
 export function buildDynamicOpenAIModel(args: {
   rawProvider: string;
   registryProvider: string;
   modelId: string;
   providerBaseUrl: string | undefined;
-}): DynamicOpenAIModel {
+  api?: PiAiApi;
+}): DynamicModel {
   const { rawProvider, registryProvider, modelId, providerBaseUrl } = args;
+  const api = args.api ?? "openai-completions";
   const isRealOpenAI = rawProvider === "openai";
   if (!isRealOpenAI && !providerBaseUrl) {
     throw new Error(
       `Could not resolve a base URL for provider "${rawProvider}". ` +
         `The gateway did not supply a proxy mapping for its base-URL env ` +
         `var (${DEFAULT_PROVIDER_BASE_URL_ENV[rawProvider] ?? "unknown"}). ` +
-        `Refusing to route "${modelId}" to OpenAI's public endpoint.`
+        `Refusing to route "${modelId}" to a public endpoint.`
     );
   }
   return {
     id: modelId,
     name: modelId,
-    api: "openai-completions",
+    api,
     provider: registryProvider,
     baseUrl: providerBaseUrl || "https://api.openai.com/v1",
     reasoning: false,

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -42,6 +42,7 @@ import {
   DEFAULT_PROVIDER_BASE_URL_ENV,
   getModelDynamic,
   openOrCreateSessionManager,
+  PIAI_API_BY_REGISTRY_ALIAS,
   PROVIDER_REGISTRY_ALIASES,
   registerDynamicProvider,
   resolveModelRef,
@@ -604,23 +605,14 @@ export async function runAISession(
 
   let baseModel: Model<any> | undefined = getModelDynamic(provider, modelId);
   if (!baseModel) {
-    // For OpenAI-compatible providers (e.g. nvidia, together-ai), create a
-    // dynamic model entry since these models aren't in the static registry.
+    // The model isn't in pi-ai's static registry — build a dynamic entry. Which
+    // path depends on the provider's wire protocol (the registry alias, set from
+    // sdkCompat by registerDynamicProvider): anthropic clones a known Claude
+    // shape (pi-ai's static Anthropic registry lags newest models); every other
+    // protocol builds a generic dynamic model with the matching pi-ai adapter.
     const registryProvider =
       PROVIDER_REGISTRY_ALIASES[rawProvider] || rawProvider;
-    if (registryProvider === "openai" || rawProvider !== provider) {
-      logger.info(
-        `Creating dynamic model entry for ${rawProvider}/${modelId} (openai-compatible)`
-      );
-      // Throws if a non-OpenAI provider's base URL is unresolved, rather
-      // than silently routing to OpenAI's public endpoint.
-      baseModel = buildDynamicOpenAIModel({
-        rawProvider,
-        registryProvider,
-        modelId,
-        providerBaseUrl,
-      });
-    } else if (provider === "anthropic") {
+    if (provider === "anthropic") {
       // The newest Claude models (resolved live from the provider for auto-mode
       // agents) lag pi-ai's static registry. Clone a known Claude model's shape
       // and override the id so the agent still runs — Anthropic / the
@@ -644,6 +636,23 @@ export async function runAISession(
           `Model "${modelId}" not found for provider "${provider}". Check that the model ID is valid and registered in the model registry.`
         );
       }
+    } else if (registryProvider === "openai" || rawProvider !== provider) {
+      // OpenAI-compatible (openai, nvidia, together-ai, z.ai, …) or any org BYO
+      // provider whose slug differs from its registry alias. Resolve the pi-ai
+      // adapter from the provider's protocol; default to openai-completions.
+      const api = PIAI_API_BY_REGISTRY_ALIAS[registryProvider];
+      logger.info(
+        `Creating dynamic model entry for ${rawProvider}/${modelId} (${api ?? "openai-completions"})`
+      );
+      // Throws if a non-OpenAI provider's base URL is unresolved, rather
+      // than silently routing to a public endpoint.
+      baseModel = buildDynamicOpenAIModel({
+        rawProvider,
+        registryProvider,
+        modelId,
+        providerBaseUrl,
+        api,
+      });
     } else {
       throw new Error(
         `Model "${modelId}" not found for provider "${provider}". Check that the model ID is valid and registered in the model registry.`

--- a/packages/core/src/__tests__/sdk-compat.test.ts
+++ b/packages/core/src/__tests__/sdk-compat.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isSdkCompat,
+  resolveSdkCompat,
+  SDK_COMPAT_PROTOCOLS,
+} from "../sdk-compat";
+
+describe("sdk-compat registry", () => {
+  test("openai maps to the openai-completions adapter", () => {
+    const p = resolveSdkCompat("openai");
+    expect(p?.api).toBe("openai-completions");
+    expect(p?.registryAlias).toBe("openai");
+    // OpenAI-compatible keys ride as Bearer (no explicit header).
+    expect(p?.apiKeyHeader).toBeUndefined();
+  });
+
+  test("anthropic maps to anthropic-messages with x-api-key", () => {
+    const p = resolveSdkCompat("anthropic");
+    expect(p?.api).toBe("anthropic-messages");
+    expect(p?.registryAlias).toBe("anthropic");
+    // Anthropic 401s on Bearer — the key must ride in x-api-key.
+    expect(p?.apiKeyHeader).toBe("x-api-key");
+  });
+
+  test("isSdkCompat gates routable protocols", () => {
+    expect(isSdkCompat("openai")).toBe(true);
+    expect(isSdkCompat("anthropic")).toBe(true);
+    expect(isSdkCompat("google")).toBe(true);
+    // Not routable:
+    expect(isSdkCompat(null)).toBe(false);
+    expect(isSdkCompat(undefined)).toBe(false);
+    expect(isSdkCompat("made-up")).toBe(false);
+  });
+
+  test("resolveSdkCompat returns null for unroutable input", () => {
+    expect(resolveSdkCompat(null)).toBeNull();
+    expect(resolveSdkCompat("nope")).toBeNull();
+  });
+
+  test("every protocol declares api, registryAlias, and label", () => {
+    for (const [key, p] of Object.entries(SDK_COMPAT_PROTOCOLS)) {
+      expect(p.api, `${key}.api`).toBeTruthy();
+      expect(p.registryAlias, `${key}.registryAlias`).toBeTruthy();
+      expect(p.label, `${key}.label`).toBeTruthy();
+    }
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,15 @@ export type {
   ConfigProviderMeta,
   ProviderConfigEntry,
 } from "./provider-config-types";
+// Wire-protocol registry (sdkCompat → pi-ai adapter)
+export {
+  isSdkCompat,
+  type PiAiApi,
+  resolveSdkCompat,
+  SDK_COMPAT_PROTOCOLS,
+  type SdkCompat,
+  type SdkCompatProtocol,
+} from "./sdk-compat";
 export * from "./secret-refs";
 // Observability
 export { getSentry, initSentry } from "./sentry";

--- a/packages/core/src/provider-config-types.ts
+++ b/packages/core/src/provider-config-types.ts
@@ -29,8 +29,11 @@ export interface ProviderConfigEntry {
    * Gates which per-modality overrides are offered and (for STT) whether the
    * provider is a transcription candidate at all — an OpenAI-compatible chat
    * provider like Cerebras does NOT do speech-to-text, so it must not be listed
-   * for `stt`. `image`/`tts` remain additionally gated by their service
-   * allowlists; this list is the source of truth for the UI + STT eligibility.
+   * for `stt`. STT is enabled only when this list includes `"stt"` OR an
+   * explicit `stt` block enables it (`enabled !== false`); there is no
+   * "default on for openai-compatible" fallback. `image`/`tts` remain
+   * additionally gated by their service allowlists; this list is the source of
+   * truth for the UI + STT eligibility.
    */
   modalities?: ("text" | "image" | "stt" | "tts")[];
   /** Default model ID when none is configured */

--- a/packages/core/src/provider-config-types.ts
+++ b/packages/core/src/provider-config-types.ts
@@ -18,6 +18,15 @@ export interface ProviderConfigEntry {
   apiKeyPlaceholder: string;
   /** SDK compatibility hint — "openai" means OpenAI-compatible API format */
   sdkCompat?: "openai";
+  /**
+   * Modalities this provider actually serves. Omitted ⇒ text only.
+   * Gates which per-modality overrides are offered and (for STT) whether the
+   * provider is a transcription candidate at all — an OpenAI-compatible chat
+   * provider like Cerebras does NOT do speech-to-text, so it must not be listed
+   * for `stt`. `image`/`tts` remain additionally gated by their service
+   * allowlists; this list is the source of truth for the UI + STT eligibility.
+   */
+  modalities?: ("text" | "image" | "stt" | "tts")[];
   /** Default model ID when none is configured */
   defaultModel?: string;
   /** Relative path to fetch model list (e.g. "/v1/models") */

--- a/packages/core/src/provider-config-types.ts
+++ b/packages/core/src/provider-config-types.ts
@@ -3,6 +3,8 @@
  * Loaded from the bundled provider registry config.
  */
 
+import type { SdkCompat } from "./sdk-compat";
+
 export interface ProviderConfigEntry {
   /** Display name in settings page (e.g. "Groq") */
   displayName: string;
@@ -16,8 +18,12 @@ export interface ProviderConfigEntry {
   apiKeyInstructions: string;
   /** Placeholder text for the API key input */
   apiKeyPlaceholder: string;
-  /** SDK compatibility hint — "openai" means OpenAI-compatible API format */
-  sdkCompat?: "openai";
+  /**
+   * Wire protocol this provider speaks (see SDK_COMPAT_PROTOCOLS). "openai" for
+   * OpenAI-compatible providers; "anthropic"/"google"/etc. for others. Omitted ⇒
+   * not routable as a config-driven model.
+   */
+  sdkCompat?: SdkCompat;
   /**
    * Modalities this provider actually serves. Omitted ⇒ text only.
    * Gates which per-modality overrides are offered and (for STT) whether the
@@ -56,7 +62,7 @@ export interface ProviderConfigEntry {
 
 /** Metadata passed from gateway to worker for config-driven providers. */
 export interface ConfigProviderMeta {
-  sdkCompat?: "openai";
+  sdkCompat?: SdkCompat;
   defaultModel?: string;
   registryAlias?: string;
   baseUrlEnvVar: string;

--- a/packages/core/src/sdk-compat.ts
+++ b/packages/core/src/sdk-compat.ts
@@ -1,0 +1,104 @@
+/**
+ * Wire-protocol registry for config-driven providers.
+ *
+ * `sdkCompat` names the API format a provider speaks. It is a plain metadata
+ * dimension — many providers share one protocol — NOT a per-provider special
+ * case. Every place that used to assume "openai" now consults this table, so
+ * adding a protocol is one row here, not an `if`-chain edit across packages.
+ *
+ * The `api` field is the pi-ai (`@mariozechner/pi-ai`) adapter the worker uses
+ * to actually talk the protocol; `registryAlias` is the model-registry provider
+ * name a dynamic model maps to. The gateway proxy is a transparent byte
+ * forwarder, so the protocol is chosen entirely on the worker side by picking
+ * the right adapter here.
+ */
+
+/** Protocols we can route. Extend by adding a `SDK_COMPAT_PROTOCOLS` row. */
+export type SdkCompat =
+  | "openai"
+  | "openai-responses"
+  | "anthropic"
+  | "google"
+  | "bedrock"
+  | "mistral";
+
+/** pi-ai API adapter names (mirrors pi-ai's `KnownApi`). */
+export type PiAiApi =
+  | "openai-completions"
+  | "openai-responses"
+  | "anthropic-messages"
+  | "google-generative-ai"
+  | "bedrock-converse-stream"
+  | "mistral-conversations";
+
+export interface SdkCompatProtocol {
+  /** The pi-ai adapter that speaks this protocol. */
+  api: PiAiApi;
+  /**
+   * Model-registry provider name a dynamic model maps to. Providers speaking
+   * the same protocol share a registry alias (e.g. all OpenAI-compatible ones
+   * resolve as "openai") unless a provider overrides it via `registryAlias`.
+   */
+  registryAlias: string;
+  /**
+   * How an API-KEY credential is presented to the upstream. "x-api-key" for
+   * Anthropic; "authorization" (Bearer) or omitted for OpenAI-compatible APIs.
+   * The secret proxy applies this at egress for synthesized org providers.
+   */
+  apiKeyHeader?: "authorization" | "x-api-key";
+  /** Human label for logs / UI. */
+  label: string;
+}
+
+/**
+ * The single source of truth mapping a `sdkCompat` to how it routes. Anything
+ * NOT in this map is not-yet-routable (the create gate rejects it).
+ */
+export const SDK_COMPAT_PROTOCOLS: Record<SdkCompat, SdkCompatProtocol> = {
+  openai: {
+    api: "openai-completions",
+    registryAlias: "openai",
+    label: "OpenAI-compatible",
+  },
+  "openai-responses": {
+    api: "openai-responses",
+    registryAlias: "openai",
+    label: "OpenAI Responses",
+  },
+  anthropic: {
+    api: "anthropic-messages",
+    registryAlias: "anthropic",
+    // Anthropic rejects keys sent as Bearer (401) — they ride in x-api-key.
+    apiKeyHeader: "x-api-key",
+    label: "Anthropic Messages",
+  },
+  google: {
+    api: "google-generative-ai",
+    registryAlias: "google",
+    label: "Google Generative AI",
+  },
+  bedrock: {
+    api: "bedrock-converse-stream",
+    registryAlias: "bedrock",
+    label: "Amazon Bedrock",
+  },
+  mistral: {
+    api: "mistral-conversations",
+    registryAlias: "mistral",
+    label: "Mistral",
+  },
+};
+
+/** Is `value` a routable protocol (present in the registry)? */
+export function isSdkCompat(
+  value: string | null | undefined
+): value is SdkCompat {
+  return value != null && value in SDK_COMPAT_PROTOCOLS;
+}
+
+/** Resolve a `sdkCompat` to its protocol row, or null when not routable. */
+export function resolveSdkCompat(
+  value: string | null | undefined
+): SdkCompatProtocol | null {
+  return isSdkCompat(value) ? SDK_COMPAT_PROTOCOLS[value] : null;
+}

--- a/packages/server/src/gateway/__tests__/transcription-service.test.ts
+++ b/packages/server/src/gateway/__tests__/transcription-service.test.ts
@@ -125,7 +125,12 @@ describe("TranscriptionService provider fallback", () => {
     }
   });
 
-  test("uses sdkCompat openai STT by default when stt block is missing", async () => {
+  test("does NOT treat an OpenAI-compatible provider as STT when it declares no stt modality", async () => {
+    // OpenRouter (and Cerebras, z.ai, Mistral, …) speak the OpenAI chat protocol
+    // but have no /audio/transcriptions endpoint. Previously STT defaulted ON for
+    // every openai-compatible provider, so these were wrongly listed as
+    // transcription candidates and 404'd. With no `stt` in modalities and no `stt`
+    // block, the provider must be skipped and fetch never called.
     const authProfilesManager = {
       getBestProfile: mock(async (_agentId: string, providerId: string) => {
         if (providerId === "openrouter") {
@@ -144,6 +149,7 @@ describe("TranscriptionService provider fallback", () => {
         apiKeyInstructions: "x",
         apiKeyPlaceholder: "x",
         sdkCompat: "openai",
+        modalities: ["text"],
       },
     }));
 
@@ -153,14 +159,10 @@ describe("TranscriptionService provider fallback", () => {
     );
 
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      expect(url).toBe("https://openrouter.ai/api/v1/audio/transcriptions");
-      return new Response(JSON.stringify({ text: "default stt works" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    }) as any;
+    const fetchMock = mock(async () => {
+      throw new Error("fetch should not be called for a non-STT provider");
+    });
+    globalThis.fetch = fetchMock as any;
 
     try {
       const result = await service.transcribe(
@@ -168,11 +170,11 @@ describe("TranscriptionService provider fallback", () => {
         "agent-4",
         "audio/ogg"
       );
-      expect("text" in result).toBe(true);
-      if ("text" in result) {
-        expect(result.text).toBe("default stt works");
-        expect(result.provider).toBe("openai");
+      expect("error" in result).toBe(true);
+      if ("error" in result) {
+        expect(result.error).toContain("No transcription provider configured");
       }
+      expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/packages/server/src/gateway/auth/__tests__/build-provider-catalog.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/build-provider-catalog.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { type ModuleInterface, moduleRegistry } from "@lobu/core";
+import type { ProviderConfigEntry } from "@lobu/core";
+import { buildProviderCatalog } from "../provider-catalog.js";
+
+/**
+ * buildProviderCatalog is the single source both the org inference-providers
+ * catalog route and the per-agent agent-config catalog map from. It must:
+ *  - include OAuth modules (Claude/ChatGPT) with their auth metadata, so they
+ *    appear in the "Add provider" catalog;
+ *  - carry sdkCompat so the POST route can gate: only sdkCompat === "openai" is
+ *    addable via API key today (OAuth providers are null ⇒ rejected).
+ *
+ * The registry is a process-global singleton; these tests register minimal fake
+ * modules and clear between cases to stay hermetic.
+ */
+
+function fakeModule(
+  overrides: Partial<Record<string, unknown>> & { providerId: string }
+): ModuleInterface {
+  return {
+    // Registry keys modules by `name` and only stores enabled ones.
+    name: `${overrides.providerId}-provider`,
+    isEnabled: () => true,
+    // Fields buildProviderCatalog reads off the module.
+    providerDisplayName: overrides.providerId,
+    providerIconUrl: "",
+    authType: "api-key",
+    // Marks it as a ModelProviderModule for getModelProviderModules()'s filter.
+    getSecretEnvVarNames: () => [],
+    ...overrides,
+  } as unknown as ModuleInterface;
+}
+
+function clearRegistry(): void {
+  // No public clear(); reset the internal Map between tests.
+  (
+    moduleRegistry as unknown as { modules: Map<string, ModuleInterface> }
+  ).modules = new Map();
+}
+
+describe("buildProviderCatalog", () => {
+  beforeEach(() => clearRegistry());
+
+  test("OAuth modules appear with their auth metadata and null sdkCompat", () => {
+    moduleRegistry.register(
+      fakeModule({
+        providerId: "claude",
+        providerDisplayName: "Claude",
+        authType: "oauth",
+        supportedAuthTypes: ["oauth", "api-key"],
+      })
+    );
+
+    const catalog = buildProviderCatalog();
+    const claude = catalog.find((e) => e.slug === "claude");
+    expect(claude).toBeDefined();
+    expect(claude?.authType).toBe("oauth");
+    expect(claude?.supportedAuthTypes).toEqual(["oauth", "api-key"]);
+    // No providers.json enrichment and no module metadata ⇒ not addable by key.
+    expect(claude?.sdkCompat).toBeNull();
+  });
+
+  test("config enrichment sets sdkCompat/modalities for api-key providers", () => {
+    moduleRegistry.register(
+      fakeModule({ providerId: "groq", providerDisplayName: "Groq" })
+    );
+    const configs: Record<string, ProviderConfigEntry> = {
+      groq: {
+        displayName: "Groq",
+        iconUrl: "https://icon/groq.png",
+        envVarName: "GROQ_API_KEY",
+        upstreamBaseUrl: "https://api.groq.com/openai/v1",
+        apiKeyInstructions: "",
+        apiKeyPlaceholder: "gsk_...",
+        sdkCompat: "openai",
+        modalities: ["text", "stt"],
+        defaultModel: "llama-3.3-70b-versatile",
+      },
+    };
+
+    const catalog = buildProviderCatalog(configs);
+    const groq = catalog.find((e) => e.slug === "groq");
+    expect(groq?.sdkCompat).toBe("openai");
+    expect(groq?.modalities).toEqual(["text", "stt"]);
+    expect(groq?.baseUrl).toBe("https://api.groq.com/openai/v1");
+    expect(groq?.defaultModel).toBe("llama-3.3-70b-versatile");
+  });
+
+  test("supportedAuthTypes defaults to [authType] when absent", () => {
+    moduleRegistry.register(fakeModule({ providerId: "cerebras" }));
+    const catalog = buildProviderCatalog();
+    const cerebras = catalog.find((e) => e.slug === "cerebras");
+    expect(cerebras?.authType).toBe("api-key");
+    expect(cerebras?.supportedAuthTypes).toEqual(["api-key"]);
+    // No config ⇒ text-only default.
+    expect(cerebras?.modalities).toEqual(["text"]);
+  });
+
+  test("catalogVisible === false hides a module", () => {
+    moduleRegistry.register(
+      fakeModule({ providerId: "hidden", catalogVisible: false })
+    );
+    const catalog = buildProviderCatalog();
+    expect(catalog.find((e) => e.slug === "hidden")).toBeUndefined();
+  });
+
+  test("entries are sorted by slug", () => {
+    moduleRegistry.register(fakeModule({ providerId: "zebra" }));
+    moduleRegistry.register(fakeModule({ providerId: "alpha" }));
+    const slugs = buildProviderCatalog().map((e) => e.slug);
+    expect(slugs).toEqual(["alpha", "zebra"]);
+  });
+});

--- a/packages/server/src/gateway/auth/__tests__/build-provider-catalog.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/build-provider-catalog.test.ts
@@ -8,8 +8,9 @@ import { buildProviderCatalog } from "../provider-catalog.js";
  * catalog route and the per-agent agent-config catalog map from. It must:
  *  - include OAuth modules (Claude/ChatGPT) with their auth metadata, so they
  *    appear in the "Add provider" catalog;
- *  - carry sdkCompat so the POST route can gate: only sdkCompat === "openai" is
- *    addable via API key today (OAuth providers are null ⇒ rejected).
+ *  - carry sdkCompat so the POST route can gate on routable protocols via
+ *    isSdkCompat (openai, anthropic, google, …) — not only "openai". OAuth /
+ *    subscription-only providers carry a null sdkCompat ⇒ rejected.
  *
  * The registry is a process-global singleton; these tests register minimal fake
  * modules and clear between cases to stay hermetic.

--- a/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
@@ -1,7 +1,32 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { type ModuleInterface, moduleRegistry } from "@lobu/core";
 import type { InferenceProviderListItem } from "../../../lobu/stores/provider-secrets.js";
 import type { ApiKeyProviderModule } from "../api-key-provider-module.js";
 import { ProviderCatalogService } from "../provider-catalog.js";
+
+/**
+ * Register a fake catalog module so buildProviderCatalog() (called inside
+ * getInstalledModules to map an org row's `kind` → protocol) can resolve it.
+ * Keyed by `name`; the registry only stores enabled modules.
+ */
+function registerFakeModule(providerId: string, sdkCompat: string): void {
+  moduleRegistry.register({
+    name: `${providerId}-provider`,
+    isEnabled: () => true,
+    providerId,
+    providerDisplayName: providerId,
+    providerIconUrl: "",
+    authType: "oauth",
+    sdkCompat,
+    getSecretEnvVarNames: () => [],
+  } as unknown as ModuleInterface);
+}
+
+function clearRegistry(): void {
+  (
+    moduleRegistry as unknown as { modules: Map<string, ModuleInterface> }
+  ).modules = new Map();
+}
 
 /**
  * Org-owned inference-provider slugs (rows in `inference_providers`) must become
@@ -71,6 +96,8 @@ function customUpstreamRow(
 }
 
 describe("ProviderCatalogService.getInstalledModules — org inference providers", () => {
+  afterEach(() => clearRegistry());
+
   test("synthesizes a routable module for a custom-upstream org slug + registers its upstream", async () => {
     const registered: Array<{ slug: string; providerId: string; url: string }> =
       [];
@@ -114,6 +141,26 @@ describe("ProviderCatalogService.getInstalledModules — org inference providers
 
     // Never surfaced in the "Add Provider" catalog.
     expect(mod.catalogVisible).toBe(false);
+  });
+
+  test("an org row whose kind is an anthropic provider routes as anthropic (x-api-key)", async () => {
+    // Claude-like catalog module so kind "claude" resolves to sdkCompat anthropic.
+    registerFakeModule("claude", "anthropic");
+    const catalog = makeCatalog({
+      installedProviderIds: ["my-claude"],
+      orgRows: [customUpstreamRow("my-claude", { kind: "claude" })],
+      registerUpstream: () => {},
+    });
+
+    const modules = await catalog.getInstalledModules("agent-1", "org-1");
+    expect(modules).toHaveLength(1);
+    const mod = modules[0] as ApiKeyProviderModule;
+
+    // Protocol resolved from the row's kind → anthropic, not the default openai.
+    expect(mod.getProviderMetadata()?.sdkCompat).toBe("anthropic");
+    // Anthropic keys must present as x-api-key, not Bearer — the proxy reads
+    // this off the upstream config at egress.
+    expect(mod.getUpstreamConfig()?.apiKeyHeader).toBe("x-api-key");
   });
 
   test("does NOT synthesize when the org row has no custom text base_url", async () => {

--- a/packages/server/src/gateway/auth/api-key-provider-module.ts
+++ b/packages/server/src/gateway/auth/api-key-provider-module.ts
@@ -1,4 +1,4 @@
-import type { ConfigProviderMeta, ModelOption } from "@lobu/core";
+import type { ConfigProviderMeta, ModelOption, SdkCompat } from "@lobu/core";
 import { BaseProviderModule } from "./base-provider-module.js";
 import type { AuthProfilesManager } from "./settings/auth-profiles-manager.js";
 import { fetchModelOptions } from "./utils/fetch-model-options.js";
@@ -19,8 +19,10 @@ interface ApiKeyProviderConfig {
   baseUrlEnvVarName?: string;
   /** Relative path to fetch model list (e.g. "/v1/models"). Enables generic model fetching. */
   modelsEndpoint?: string;
-  /** SDK compatibility — "openai" means OpenAI-compatible format. Also maps OPENAI_BASE_URL in proxy. */
-  sdkCompat?: "openai";
+  /** Wire protocol (see SDK_COMPAT_PROTOCOLS). "openai" also maps OPENAI_BASE_URL in proxy. */
+  sdkCompat?: SdkCompat;
+  /** How the API key is presented upstream ("x-api-key" for Anthropic; Bearer otherwise). */
+  apiKeyHeader?: "authorization" | "x-api-key";
   /** Default model ID when none is configured */
   defaultModel?: string;
   /** Override provider name for model registry lookup */
@@ -59,6 +61,8 @@ export class ApiKeyProviderModule extends BaseProviderModule {
         apiKeyInstructions: config.apiKeyInstructions,
         apiKeyPlaceholder: config.apiKeyPlaceholder,
         catalogVisible: config.catalogVisible,
+        sdkCompat: config.sdkCompat,
+        apiKeyHeader: config.apiKeyHeader,
       },
       config.authProfilesManager
     );

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -1,4 +1,4 @@
-import { createLogger } from "@lobu/core";
+import { createLogger, type SdkCompat } from "@lobu/core";
 import { Hono } from "hono";
 import { resolveOrgId } from "../../lobu/stores/org-context.js";
 import { readOrgSharedProviderApiKey } from "../../lobu/stores/provider-secrets.js";
@@ -68,6 +68,8 @@ interface BaseProviderConfig {
   apiKeyPlaceholder?: string;
   catalogDescription?: string;
   catalogVisible?: boolean;
+  /** Wire protocol this provider speaks (see SDK_COMPAT_PROTOCOLS). */
+  sdkCompat?: SdkCompat;
 }
 
 /**
@@ -96,6 +98,7 @@ export abstract class BaseProviderModule
   apiKeyPlaceholder?: string;
   catalogDescription?: string;
   catalogVisible?: boolean;
+  sdkCompat?: SdkCompat;
 
   protected readonly providerConfig: BaseProviderConfig;
   protected readonly authProfilesManager: AuthProfilesManager;
@@ -119,6 +122,7 @@ export abstract class BaseProviderModule
     this.apiKeyPlaceholder = config.apiKeyPlaceholder;
     this.catalogDescription = config.catalogDescription;
     this.catalogVisible = config.catalogVisible;
+    this.sdkCompat = config.sdkCompat;
 
     this.app = new Hono();
     this.setupRoutes();

--- a/packages/server/src/gateway/auth/claude/oauth-module.ts
+++ b/packages/server/src/gateway/auth/claude/oauth-module.ts
@@ -54,6 +54,9 @@ export class ClaudeOAuthModule extends BaseProviderModule {
           'Enter your <a href="https://console.anthropic.com/settings/keys" target="_blank" class="text-blue-600 underline">Anthropic API key</a>:',
         apiKeyPlaceholder: "sk-ant-...",
         catalogDescription: "Anthropic's Claude AI with OAuth authentication",
+        // Claude speaks the Anthropic Messages protocol, so an org Claude
+        // provider routes via the anthropic-messages adapter.
+        sdkCompat: "anthropic",
       },
       authProfilesManager
     );

--- a/packages/server/src/gateway/auth/provider-catalog.ts
+++ b/packages/server/src/gateway/auth/provider-catalog.ts
@@ -1,4 +1,8 @@
-import { createLogger, type InstalledProvider } from "@lobu/core";
+import {
+  createLogger,
+  type InstalledProvider,
+  type ProviderConfigEntry,
+} from "@lobu/core";
 import type { InferenceProviderListItem } from "../../lobu/stores/provider-secrets.js";
 import {
   getModelProviderModules,
@@ -12,6 +16,113 @@ import type { AuthProfilesManager } from "./settings/auth-profiles-manager.js";
 import { reconcileModelSelectionForInstalledProviders } from "./settings/model-selection.js";
 
 const logger = createLogger("provider-catalog");
+
+/** Auth mechanism a provider supports. */
+export type ProviderAuthType = "oauth" | "device-code" | "api-key";
+
+/**
+ * One provider as seen in the "Add provider" catalog: its identity, auth
+ * options (OAuth sign-in vs API key), wire protocol (`sdkCompat`), and upstream
+ * pre-fill. Built from the module registry so EVERY registered provider appears
+ * — the config-driven api-key ones AND the hardcoded OAuth ones (Claude,
+ * ChatGPT) — not just the providers.json subset.
+ */
+export interface ProviderCatalogEntry {
+  /** Provider id; also the default slug pre-fill. */
+  slug: string;
+  displayName: string;
+  iconUrl: string;
+  authType: ProviderAuthType;
+  supportedAuthTypes: ProviderAuthType[];
+  /**
+   * Wire protocol the provider speaks. "openai" for the config-driven OpenAI-
+   * compatible providers; null when unknown/not-yet-routable (the OAuth
+   * providers — their real protocol is wired in a later phase).
+   */
+  sdkCompat: string | null;
+  /** Upstream base URL pre-fill ("" when the module doesn't expose one). */
+  baseUrl: string;
+  defaultModel: string | null;
+  modelsEndpoint: string | null;
+  apiKeyPlaceholder: string;
+  apiKeyInstructions: string;
+  /** Modalities served; drives which per-modality overrides the UI offers. */
+  modalities: ("text" | "image" | "stt" | "tts")[];
+}
+
+/**
+ * Build the provider catalog from the module registry. This is the single
+ * source of truth both the org inference-providers catalog route and the
+ * per-agent agent-config catalog map from — so Claude/ChatGPT (OAuth modules)
+ * appear everywhere, carrying their auth metadata.
+ *
+ * `configs` (the flattened providers.json map, keyed by providerId) enriches
+ * the config-driven entries with sdkCompat/defaultModel/modelsEndpoint/
+ * modalities. It's optional: callers without a registry handle (agent-config,
+ * which only needs the auth fields) may omit it — those entries then fall back
+ * to the module's own metadata and default to text-only.
+ */
+export function buildProviderCatalog(
+  configs?: Record<string, ProviderConfigEntry>
+): ProviderCatalogEntry[] {
+  const entries: ProviderCatalogEntry[] = [];
+  for (const module of getModelProviderModules()) {
+    if (module.catalogVisible === false) continue;
+    try {
+      const config = configs?.[module.providerId];
+
+      const authType = (module.authType || "oauth") as ProviderAuthType;
+      const supportedAuthTypes =
+        (module.supportedAuthTypes as ProviderAuthType[] | undefined) ?? [
+          authType,
+        ];
+
+      // sdkCompat/defaultModel come from providers.json when we have it, else
+      // from the module's own metadata (config-driven modules expose it).
+      const moduleMeta =
+        module instanceof ApiKeyProviderModule
+          ? module.getProviderMetadata()
+          : null;
+      const sdkCompat =
+        config?.sdkCompat ?? moduleMeta?.sdkCompat ?? null;
+      const defaultModel =
+        config?.defaultModel ?? moduleMeta?.defaultModel ?? null;
+
+      const upstream =
+        module instanceof ApiKeyProviderModule
+          ? module.getUpstreamConfig()
+          : null;
+      const baseUrl = config?.upstreamBaseUrl ?? upstream?.upstreamBaseUrl ?? "";
+
+      entries.push({
+        slug: module.providerId,
+        displayName: config?.displayName || module.providerDisplayName,
+        iconUrl: config?.iconUrl || module.providerIconUrl || "",
+        authType,
+        supportedAuthTypes,
+        sdkCompat,
+        baseUrl,
+        defaultModel,
+        modelsEndpoint: config?.modelsEndpoint ?? null,
+        apiKeyPlaceholder:
+          config?.apiKeyPlaceholder ?? module.apiKeyPlaceholder ?? "",
+        apiKeyInstructions:
+          config?.apiKeyInstructions ?? module.apiKeyInstructions ?? "",
+        modalities: config?.modalities ?? ["text"],
+      });
+    } catch (err) {
+      logger.warn(
+        {
+          providerId: module.providerId,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "[buildProviderCatalog] skipping malformed provider module"
+      );
+    }
+  }
+  entries.sort((a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
+  return entries;
+}
 
 /**
  * Reads an org's inference-provider rows (slug + custom-upstream capabilities).

--- a/packages/server/src/gateway/auth/provider-catalog.ts
+++ b/packages/server/src/gateway/auth/provider-catalog.ts
@@ -1,7 +1,10 @@
 import {
   createLogger,
   type InstalledProvider,
+  isSdkCompat,
   type ProviderConfigEntry,
+  SDK_COMPAT_PROTOCOLS,
+  type SdkCompat,
 } from "@lobu/core";
 import type { InferenceProviderListItem } from "../../lobu/stores/provider-secrets.js";
 import {
@@ -78,13 +81,15 @@ export function buildProviderCatalog(
         ];
 
       // sdkCompat/defaultModel come from providers.json when we have it, else
-      // from the module's own metadata (config-driven modules expose it).
+      // from the module's own metadata (config-driven modules expose it), else
+      // from the module's declared protocol (OAuth modules like Claude set
+      // `sdkCompat` directly since they aren't config-driven).
       const moduleMeta =
         module instanceof ApiKeyProviderModule
           ? module.getProviderMetadata()
           : null;
       const sdkCompat =
-        config?.sdkCompat ?? moduleMeta?.sdkCompat ?? null;
+        config?.sdkCompat ?? moduleMeta?.sdkCompat ?? module.sdkCompat ?? null;
       const defaultModel =
         config?.defaultModel ?? moduleMeta?.defaultModel ?? null;
 
@@ -202,7 +207,8 @@ export class ProviderCatalogService {
    * `capabilities.text.base_url` (nothing to route to).
    */
   private synthesizeOrgProviderModule(
-    row: InferenceProviderListItem
+    row: InferenceProviderListItem,
+    sdkCompat: SdkCompat
   ): ApiKeyProviderModule | null {
     const textUpstream = row.capabilities.text?.base_url;
     if (!textUpstream) return null;
@@ -210,7 +216,12 @@ export class ProviderCatalogService {
     const module = new ApiKeyProviderModule({
       providerId: row.slug,
       slug: row.slug,
-      sdkCompat: "openai",
+      // The protocol comes from the row's catalog `kind` (resolved by the
+      // caller), NOT hardcoded — so an org Claude provider routes as anthropic,
+      // an org OpenAI-compatible one as openai, etc. The protocol also decides
+      // the auth header (Anthropic needs x-api-key, not Bearer).
+      sdkCompat,
+      apiKeyHeader: SDK_COMPAT_PROTOCOLS[sdkCompat].apiKeyHeader,
       upstreamBaseUrl: textUpstream,
       defaultModel: row.capabilities.text?.model,
       envVarName: orgProviderKeyEnvVarName(row.slug),
@@ -274,6 +285,9 @@ export class ProviderCatalogService {
     // providers. Load the org's rows once and index by slug so each unmatched
     // installed slug can be synthesized in install order.
     let orgRowsBySlug: Map<string, InferenceProviderListItem> | undefined;
+    // Protocol per catalog slug, so a synthesized org row routes with the wire
+    // protocol its `kind` declares (openai/anthropic/…), not a hardcoded one.
+    let sdkCompatByKind: Map<string, SdkCompat> | undefined;
     if (
       organizationId &&
       this.listOrgInferenceProviders &&
@@ -281,6 +295,12 @@ export class ProviderCatalogService {
     ) {
       const rows = await this.listOrgInferenceProviders(organizationId);
       orgRowsBySlug = new Map(rows.map((r) => [r.slug, r]));
+      sdkCompatByKind = new Map();
+      for (const entry of buildProviderCatalog()) {
+        if (isSdkCompat(entry.sdkCompat)) {
+          sdkCompatByKind.set(entry.slug, entry.sdkCompat);
+        }
+      }
     }
 
     const resolved: ModelProviderModule[] = [];
@@ -292,7 +312,11 @@ export class ProviderCatalogService {
       }
       const row = orgRowsBySlug?.get(ip.providerId);
       if (row) {
-        const synthesized = this.synthesizeOrgProviderModule(row);
+        // Resolve the row's protocol from its catalog `kind`. Unknown/absent ⇒
+        // default to openai (legacy rows created before kind carried a
+        // protocol, and custom endpoints, are OpenAI-compatible).
+        const sdkCompat = sdkCompatByKind?.get(row.kind) ?? "openai";
+        const synthesized = this.synthesizeOrgProviderModule(row, sdkCompat);
         if (synthesized) resolved.push(synthesized);
       }
     }

--- a/packages/server/src/gateway/modules/module-system.ts
+++ b/packages/server/src/gateway/modules/module-system.ts
@@ -1,4 +1,4 @@
-import type { CliBackendConfig, ModelOption } from "@lobu/core";
+import type { CliBackendConfig, ModelOption, SdkCompat } from "@lobu/core";
 import { type ModuleInterface, moduleRegistry } from "@lobu/core";
 import type { ProviderCredentialContext } from "../embedded.js";
 
@@ -33,6 +33,12 @@ export interface ModelProviderModule extends OrchestratorModule {
   apiKeyPlaceholder?: string;
   catalogDescription?: string;
   catalogVisible?: boolean;
+  /**
+   * Wire protocol this provider speaks (see SDK_COMPAT_PROTOCOLS). Lets the
+   * catalog know a module's protocol uniformly — including OAuth modules like
+   * Claude (anthropic) that aren't config-driven. Omitted ⇒ unknown/openai.
+   */
+  sdkCompat?: SdkCompat;
   getSecretEnvVarNames(): string[];
   getCredentialEnvVarName(): string;
   /**

--- a/packages/server/src/gateway/routes/public/agent-config.ts
+++ b/packages/server/src/gateway/routes/public/agent-config.ts
@@ -7,7 +7,10 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import type { AgentConfigStore, ModelOption, SkillConfig } from "@lobu/core";
 import type { Context } from "hono";
-import type { ProviderCatalogService } from "../../auth/provider-catalog.js";
+import {
+	buildProviderCatalog,
+	type ProviderCatalogService,
+} from "../../auth/provider-catalog.js";
 import { collectProviderModelOptions } from "../../auth/provider-model-options.js";
 
 import type {
@@ -27,10 +30,6 @@ import type { SettingsTokenPayload } from "../../auth/settings/token-service.js"
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
 import type { WorkerConnectionManager } from "../../gateway/connection-manager.js";
 import type { IMessageQueue } from "../../infrastructure/queue/index.js";
-import {
-	getModelProviderModules,
-	type ModelProviderModule,
-} from "../../modules/module-system.js";
 import type { GrantStore } from "../../permissions/grant-store.js";
 import { createTokenVerifier } from "../shared/agent-ownership.js";
 import { errorResponse } from "../shared/helpers.js";
@@ -211,28 +210,19 @@ async function buildResolvedConfigResponse(
 		}
 	}
 
-	const allModules = getModelProviderModules();
-	const allProviderMeta = allModules
-		.filter((module) => module.catalogVisible !== false)
-		.map((module: ModelProviderModule) => ({
-			id: module.providerId,
-			name: module.providerDisplayName,
-			iconUrl: module.providerIconUrl || "",
-			authType: (module.authType || "oauth") as
-				| "oauth"
-				| "device-code"
-				| "api-key",
-			supportedAuthTypes: (module.supportedAuthTypes as (
-				| "oauth"
-				| "device-code"
-				| "api-key"
-			)[]) || [
-				(module.authType || "oauth") as "oauth" | "device-code" | "api-key",
-			],
-			apiKeyInstructions: module.apiKeyInstructions || "",
-			apiKeyPlaceholder: module.apiKeyPlaceholder || "",
-			capabilities: [] as string[],
-		}));
+	// Shared catalog builder (same source as the org inference-providers catalog
+	// route) so Claude/ChatGPT and their auth metadata stay consistent across
+	// both surfaces. agent-config only needs the auth fields, so it maps a subset.
+	const allProviderMeta = buildProviderCatalog().map((entry) => ({
+		id: entry.slug,
+		name: entry.displayName,
+		iconUrl: entry.iconUrl,
+		authType: entry.authType,
+		supportedAuthTypes: entry.supportedAuthTypes,
+		apiKeyInstructions: entry.apiKeyInstructions,
+		apiKeyPlaceholder: entry.apiKeyPlaceholder,
+		capabilities: [] as string[],
+	}));
 
 	const installedIds = (settings?.installedProviders || []).map(
 		(provider) => provider.providerId,

--- a/packages/server/src/gateway/services/transcription-service.ts
+++ b/packages/server/src/gateway/services/transcription-service.ts
@@ -331,7 +331,16 @@ export class TranscriptionService {
     for (const [providerId, entry] of Object.entries(providerConfigs)) {
       const stt = entry.stt;
       const compat = stt?.sdkCompat || entry.sdkCompat;
-      const sttEnabled = stt ? stt.enabled !== false : compat === "openai";
+      // STT is only offered for providers that declare it. Historically this
+      // defaulted ON for every OpenAI-compatible provider, which wrongly listed
+      // text-only chat providers (Cerebras, z.ai, Mistral, …) as transcription
+      // candidates — they have no /audio/transcriptions endpoint and 404. Gate
+      // on the provider's declared modalities; an explicit `stt` block (with
+      // enabled !== false) still counts as declaring STT.
+      const declaresStt =
+        entry.modalities?.includes("stt") ??
+        (stt ? stt.enabled !== false : false);
+      const sttEnabled = stt ? stt.enabled !== false : declaresStt;
       if (!sttEnabled) continue;
 
       if (compat !== "openai") {

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -4,7 +4,7 @@
  * All routes are org-scoped via mcpAuth middleware and orgContext.
  */
 
-import { encrypt, type AuthProfile } from '@lobu/core';
+import { encrypt, isSdkCompat, type AuthProfile } from '@lobu/core';
 import { Hono } from 'hono';
 import { mcpAuth } from '../auth/middleware';
 import { ensureBuilderAgent } from '../auth/builder-provisioning';
@@ -494,19 +494,20 @@ routes.post('/inference-providers', async (c) => {
   const capErr = validateCapabilitiesMap(body.capabilities);
   if (capErr) return c.json({ error: capErr }, 400);
 
-  // Gate: only OpenAI-compatible providers are routable via a pasted API key
-  // today. `kind` is the catalog slug the user picked; look up its wire
-  // protocol and reject non-openai ones (Claude/ChatGPT) — they sign in via
-  // OAuth and their routing is wired in a later phase. Without this, an
-  // api-key Claude row would be created but silently fail to route.
+  // Gate: a provider is addable via a pasted API key only if its wire protocol
+  // is one we can route (present in SDK_COMPAT_PROTOCOLS). `kind` is the catalog
+  // slug the user picked; a known catalog entry whose sdkCompat isn't routable
+  // (e.g. a subscription-only OAuth provider) is rejected so an unroutable row
+  // can't be created. Unknown kinds (custom endpoints) pass — they're treated as
+  // OpenAI-compatible by the synthesize path.
   try {
     const registry = new ProviderRegistryService(resolveProviderRegistryPath());
     const catalog = buildProviderCatalog(await registry.getProviderConfigs());
     const entry = catalog.find((e) => e.slug === kind);
-    if (entry && entry.sdkCompat !== 'openai') {
+    if (entry && !isSdkCompat(entry.sdkCompat)) {
       return c.json(
         {
-          error: `Provider '${kind}' can't be added with an API key yet — only OpenAI-compatible providers are supported for now.`,
+          error: `Provider '${kind}' can't be added with an API key — it signs in instead.`,
         },
         400
       );

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -14,6 +14,7 @@ import {
   createInferenceProvider,
   listInferenceProviders,
   updateInferenceProviderCapabilities,
+  updateInferenceProviderCoreFields,
   rotateInferenceProviderKey,
   softDeleteInferenceProvider,
   validateCapabilityBlock,
@@ -41,6 +42,7 @@ import {
   ProviderRegistryService,
   resolveProviderRegistryPath,
 } from '../gateway/services/provider-registry-service';
+import { buildProviderCatalog } from '../gateway/auth/provider-catalog';
 import logger from '../utils/logger';
 
 const routes = new Hono<{ Bindings: Env }>();
@@ -440,23 +442,9 @@ routes.get('/inference-providers/catalog', async (c) => {
   try {
     const registry = new ProviderRegistryService(resolveProviderRegistryPath());
     const configs = await registry.getProviderConfigs();
-    const catalog = Object.entries(configs)
-      .filter(([, entry]) => entry.catalogVisible !== false)
-      .map(([slug, entry]) => ({
-        slug,
-        displayName: entry.displayName,
-        iconUrl: entry.iconUrl,
-        kind: entry.sdkCompat === 'openai' ? 'openai' : 'anthropic',
-        baseUrl: entry.upstreamBaseUrl,
-        defaultModel: entry.defaultModel ?? null,
-        modelsEndpoint: entry.modelsEndpoint ?? null,
-        apiKeyPlaceholder: entry.apiKeyPlaceholder,
-        apiKeyInstructions: entry.apiKeyInstructions,
-        // Which modalities this provider serves (omitted ⇒ text only). Lets the
-        // UI offer per-modality overrides only where they make sense.
-        modalities: entry.modalities ?? ['text'],
-      }))
-      .sort((a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
+    // Built from the module registry (not just providers.json) so Claude /
+    // ChatGPT (OAuth modules) appear too, each carrying its auth metadata.
+    const catalog = buildProviderCatalog(configs);
     return c.json({ catalog });
   } catch (err) {
     logger.warn(
@@ -506,6 +494,32 @@ routes.post('/inference-providers', async (c) => {
   const capErr = validateCapabilitiesMap(body.capabilities);
   if (capErr) return c.json({ error: capErr }, 400);
 
+  // Gate: only OpenAI-compatible providers are routable via a pasted API key
+  // today. `kind` is the catalog slug the user picked; look up its wire
+  // protocol and reject non-openai ones (Claude/ChatGPT) — they sign in via
+  // OAuth and their routing is wired in a later phase. Without this, an
+  // api-key Claude row would be created but silently fail to route.
+  try {
+    const registry = new ProviderRegistryService(resolveProviderRegistryPath());
+    const catalog = buildProviderCatalog(await registry.getProviderConfigs());
+    const entry = catalog.find((e) => e.slug === kind);
+    if (entry && entry.sdkCompat !== 'openai') {
+      return c.json(
+        {
+          error: `Provider '${kind}' can't be added with an API key yet — only OpenAI-compatible providers are supported for now.`,
+        },
+        400
+      );
+    }
+  } catch (err) {
+    // Fail open on catalog-load errors: don't block creation on a metadata
+    // read. The synthesize path still gates routing downstream.
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      '[inference-providers POST] catalog gate check failed; allowing',
+    );
+  }
+
   const createdBy = c.get('user')?.id ?? null;
 
   const result = await createInferenceProvider({
@@ -539,6 +553,46 @@ routes.post('/inference-providers', async (c) => {
     },
     201
   );
+});
+
+// Edit a provider's core fields. Only displayName is mutable — slug (agents
+// reference it) and kind (catalog linkage) are immutable. Key rotation and
+// per-modality capability edits keep their dedicated routes below; the Edit UI
+// calls whichever it needs.
+routes.put('/inference-providers/:slug', async (c) => {
+  const denied = requireSessionOrAdminPat(c);
+  if (denied) return denied;
+  const orgId = requireOrgId(c);
+  if (typeof orgId !== 'string') return orgId;
+  const { slug } = c.req.param();
+
+  let body: { displayName?: unknown };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'Invalid or missing JSON body' }, 400);
+  }
+
+  // Empty / whitespace-only name means "leave unchanged" (pass undefined).
+  const rawName = typeof body.displayName === 'string' ? body.displayName : '';
+  const displayName = rawName.trim() ? rawName.trim() : undefined;
+
+  const updated = await updateInferenceProviderCoreFields(orgId, slug, {
+    displayName,
+  });
+  if (!updated) return c.json({ error: 'Provider not found' }, 404);
+  return c.json({
+    provider: {
+      id: updated.id,
+      slug: updated.slug,
+      kind: updated.kind,
+      displayName: updated.displayName,
+      capabilities: updated.capabilities,
+      hasCustomUpstream: updated.hasCustomUpstream,
+      status: updated.status,
+      createdAt: updated.createdAt,
+    },
+  });
 });
 
 routes.put('/inference-providers/:slug/capabilities/:modality', async (c) => {

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -550,7 +550,7 @@ routes.put('/inference-providers/:slug/capabilities/:modality', async (c) => {
 
   if (!isInferenceModality(modality)) {
     return c.json(
-      { error: 'modality must be one of: text, image, stt, tts, embedding' },
+      { error: 'modality must be one of: text, image, stt, tts' },
       400
     );
   }

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -452,6 +452,9 @@ routes.get('/inference-providers/catalog', async (c) => {
         modelsEndpoint: entry.modelsEndpoint ?? null,
         apiKeyPlaceholder: entry.apiKeyPlaceholder,
         apiKeyInstructions: entry.apiKeyInstructions,
+        // Which modalities this provider serves (omitted ⇒ text only). Lets the
+        // UI offer per-modality overrides only where they make sense.
+        modalities: entry.modalities ?? ['text'],
       }))
       .sort((a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
     return c.json({ catalog });

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -37,6 +37,11 @@ import {
 } from './stores/postgres-stores';
 import { orgContext } from './stores/org-context';
 import { runtimeConnectionIdToSlug } from './stores/connections-projection';
+import {
+  ProviderRegistryService,
+  resolveProviderRegistryPath,
+} from '../gateway/services/provider-registry-service';
+import logger from '../utils/logger';
 
 const routes = new Hono<{ Bindings: Env }>();
 
@@ -425,6 +430,38 @@ routes.get('/inference-providers', async (c) => {
   if (typeof orgId !== 'string') return orgId;
   const providers = await listInferenceProviders(orgId);
   return c.json({ providers });
+});
+
+// Bundled provider catalog (PUBLIC metadata only — no secrets). Renders the
+// default "Available" add-cards on the inference-providers page; each entry
+// carries enough pre-fill data that adopting a bundled provider needs only an
+// API key. Registered before any `/:agentId` route so the literal path matches.
+routes.get('/inference-providers/catalog', async (c) => {
+  try {
+    const registry = new ProviderRegistryService(resolveProviderRegistryPath());
+    const configs = await registry.getProviderConfigs();
+    const catalog = Object.entries(configs)
+      .filter(([, entry]) => entry.catalogVisible !== false)
+      .map(([slug, entry]) => ({
+        slug,
+        displayName: entry.displayName,
+        iconUrl: entry.iconUrl,
+        kind: entry.sdkCompat === 'openai' ? 'openai' : 'anthropic',
+        baseUrl: entry.upstreamBaseUrl,
+        defaultModel: entry.defaultModel ?? null,
+        modelsEndpoint: entry.modelsEndpoint ?? null,
+        apiKeyPlaceholder: entry.apiKeyPlaceholder,
+        apiKeyInstructions: entry.apiKeyInstructions,
+      }))
+      .sort((a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
+    return c.json({ catalog });
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      '[inference-providers/catalog] failed to load bundled provider catalog',
+    );
+    return c.json({ catalog: [] });
+  }
 });
 
 routes.post('/inference-providers', async (c) => {

--- a/packages/server/src/lobu/stores/__tests__/inference-provider-validator.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/inference-provider-validator.test.ts
@@ -104,7 +104,7 @@ describe('validateCapabilityBlock', () => {
     });
 
     it('accepts an empty block for a known modality', () => {
-      expect(validateCapabilityBlock('embedding', {})).toBeNull();
+      expect(validateCapabilityBlock('text', {})).toBeNull();
     });
 
     it('accepts a full valid block', () => {

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -145,7 +145,7 @@ export function validateCapabilityBlock(
 	block: unknown,
 ): string | null {
 	if (!isInferenceModality(modality)) {
-		return `Unknown modality '${modality}' (expected text|image|stt|tts|embedding)`;
+		return `Unknown modality '${modality}' (expected text|image|stt|tts)`;
 	}
 	if (typeof block !== "object" || block === null || Array.isArray(block)) {
 		return `capabilities.${modality} must be an object`;

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -37,14 +37,13 @@ const logger = createLogger("provider-secrets");
 // soft-delete→recreate never inherits a deleted row's ciphertext (the TOTAL
 // keyref unique index keeps the name reserved even after soft-delete).
 
-export type InferenceModality = "text" | "image" | "stt" | "tts" | "embedding";
+export type InferenceModality = "text" | "image" | "stt" | "tts";
 
 export const INFERENCE_MODALITIES: ReadonlySet<InferenceModality> = new Set([
 	"text",
 	"image",
 	"stt",
 	"tts",
-	"embedding",
 ]);
 
 /** Type guard: is `m` a known inference modality? */

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -483,6 +483,31 @@ export async function updateInferenceProviderCapabilities(
 }
 
 /**
+ * Update a provider's editable core fields. Only `display_name` is editable —
+ * `slug` (agents reference it) and `kind` (catalog linkage) are immutable.
+ * `COALESCE` leaves the column unchanged when `displayName` is null/undefined,
+ * so the route can pass undefined for "no change". Returns the updated row, or
+ * null when no live row exists for the slug.
+ */
+export async function updateInferenceProviderCoreFields(
+	organizationId: string,
+	slug: string,
+	fields: { displayName?: string | null },
+): Promise<InferenceProviderRow | null> {
+	const sql = getDb();
+	const rows = (await sql`
+		UPDATE inference_providers
+		SET display_name = COALESCE(${fields.displayName ?? null}, display_name),
+		    updated_at = now()
+		WHERE organization_id = ${organizationId} AND slug = ${slug}
+		  AND deleted_at IS NULL
+		RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
+		          capabilities, has_custom_upstream, status, created_at
+	`) as RawInferenceProviderRow[];
+	return rows[0] ? mapRow(rows[0]) : null;
+}
+
+/**
  * Rotate a provider's api key: re-encrypt into the SAME api_key_ref name (the
  * ref is immutable). Returns false when no live row exists for the slug.
  */


### PR DESCRIPTION
## What

The org inference-providers page showed only an empty create form when an org had no configured providers — which read as "only OpenAI/Anthropic" (those are the two *kind* options in the create dropdown, not the provider list). This surfaces the bundled providers as adoptable defaults.

## Changes
- **Server** (`agent-routes.ts`): new `GET /inference-providers/catalog` returning the bundled providers from `config/providers.json` as public metadata (slug, displayName, iconUrl, kind, baseUrl, defaultModel, modelsEndpoint, apiKeyPlaceholder, apiKeyInstructions). Filtered to `catalogVisible !== false`, sorted by slug. Fail-soft (`{catalog:[]}` + warn on error, never 500). Registered before the `/:agentId` route so the literal path matches.
- **owletto** submodule bump to e06f663 (lobu-ai/owletto#429): two-section page ("Your providers" + "Available"), adopting a bundled provider pre-fills all fields so only the API key is needed.

## Verification
Ran locally (`make dev`, fresh branch DB) and drove the page in a browser:
- `GET /api/local-install/agents/inference-providers/catalog` → 200 with all 16 providers, correctly mapped/sorted.
- Two-section layout renders; the Available grid shows all 16 bundled providers with Add buttons, including for an org with zero configured providers.
- Clicking Add on Groq opens the create form pre-filled: slug=groq, kind=OpenAI-compatible, display name Groq, key placeholder gsk_...
- Pre-commit `tsc --noEmit` passed.

## Not done / follow-ups
- No unit test for the catalog route yet (owed).
- Keyless "available via system env key" adoption is out of scope (POST requires a key).
- A pre-existing, app-wide dev-layout sidebar overlap is visible in screenshots but is unrelated to this change (present on other pages too).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785633360&installation_id=136316292&pr_number=1710&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1710&signature=1bdf2e702e52d892400506304bc2aa4e909b1b0f2c6180762d646e223532139d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public inference-provider catalog endpoint with capabilities and setup details.
  * Added provider display-name editing for inference providers.
* **Bug Fixes**
  * Improved transcription selection: OpenAI-compatible providers without declared `stt` are no longer treated as transcription providers.
  * Updated provider capability/modalities handling to reflect the supported modality set.
* **Chores**
  * Updated the bundled `owletto` component to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->