### PR TITLE
fix(connections): default personal-credential connections to private visibility

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/connection-visibility-default.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-visibility-default.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Default `connections.visibility` must depend on the CREDENTIAL kind, not just
+ * the creator's role.
+ *
+ * A connection reads through ONE org-level credential (its auth profile's token),
+ * so an `org`-visible connection lets every org member read live through the
+ * owner's token. For a personal login (`profile_kind='oauth_account'` — a user's
+ * own Gmail etc.) that means org-visible = the owner's private inbox exposed to
+ * the whole org. So a personal-credential connection must default to `private`
+ * EVEN when an admin/owner creates it — the credential being personal outranks
+ * the role. Every other credential kind (env/oauth_app/service account) backs a
+ * genuinely shared source and keeps the role-based default (owner → `org`).
+ *
+ * Red→green: before the fix, resolveConnectionVisibility branched on role alone,
+ * so an OWNER's oauth_account connection defaulted `org` — the exposure bug.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import type { ToolContext } from '../../../tools/registry';
+import { manageAuthProfiles } from '../../../tools/admin/manage_auth_profiles';
+import { manageConnections } from '../../../tools/admin/manage_connections';
+import { getTestDb, cleanupTestDatabase } from '../../setup/test-db';
+import { initWorkspaceProvider } from '../../../workspace';
+import {
+  addUserToOrganization,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const TEST_ENV = {} as Env;
+
+function ownerCtx(organizationId: string, userId: string): ToolContext {
+  return {
+    organizationId,
+    userId,
+    memberRole: 'owner',
+    agentId: null,
+    isAuthenticated: true,
+    clientId: null,
+    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
+    tokenType: 'oauth',
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  } as ToolContext;
+}
+
+async function makeConnectors(orgId: string) {
+  // A personal-login (oauth_account) connector.
+  await createTestConnectorDefinition({
+    key: 'vis.oauth',
+    name: 'Vis OAuth',
+    organization_id: orgId,
+    auth_schema: {
+      methods: [
+        {
+          type: 'oauth',
+          provider: 'visoauth',
+          requiredScopes: ['read'],
+          clientIdKey: 'VISOAUTH_CLIENT_ID',
+          clientSecretKey: 'VISOAUTH_CLIENT_SECRET',
+        },
+      ],
+    },
+    feeds_schema: { items: {} },
+  });
+  // A no-auth connector (a genuinely shared source: no personal credential).
+  await createTestConnectorDefinition({
+    key: 'vis.noauth',
+    name: 'Vis NoAuth',
+    organization_id: orgId,
+    feeds_schema: { items: {} },
+  });
+}
+
+describe('connection visibility default depends on credential kind', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it("an OWNER's oauth_account (personal-login) connection defaults to PRIVATE", async () => {
+    process.env.VISOAUTH_CLIENT_ID = 'env-id';
+    process.env.VISOAUTH_CLIENT_SECRET = 'env-secret';
+    const org = await createTestOrganization({ name: 'Vis Org A' });
+    const user = await createTestUser({ name: 'Owner A' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const ctx = ownerCtx(org.id, user.id);
+    await makeConnectors(org.id);
+
+    await manageAuthProfiles(
+      {
+        action: 'create_auth_profile',
+        connector_key: 'vis.oauth',
+        profile_kind: 'oauth_account',
+        display_name: 'Vis Account',
+        slug: 'vis-account',
+      },
+      TEST_ENV,
+      ctx
+    );
+
+    const res = await manageConnections(
+      {
+        action: 'create',
+        connector_key: 'vis.oauth',
+        slug: 'vis-oauth-conn',
+        display_name: 'Vis OAuth Connection',
+        auth_profile_slug: 'vis-account',
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in res).toBe(false);
+    const connectionId = 'connection' in res ? (res.connection as { id: number }).id : 0;
+    expect(connectionId).toBeGreaterThan(0);
+
+    const sql = getTestDb();
+    const [row] = (await sql`
+      SELECT visibility FROM connections WHERE id = ${connectionId}
+    `) as Array<{ visibility: string }>;
+    // The fix: personal creds → private even for an owner.
+    expect(row.visibility).toBe('private');
+
+    delete process.env.VISOAUTH_CLIENT_ID;
+    delete process.env.VISOAUTH_CLIENT_SECRET;
+  });
+
+  it("an OWNER's non-personal (no auth_profile) connection still defaults to ORG", async () => {
+    const org = await createTestOrganization({ name: 'Vis Org B' });
+    const user = await createTestUser({ name: 'Owner B' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const ctx = ownerCtx(org.id, user.id);
+    await makeConnectors(org.id);
+
+    const res = await manageConnections(
+      {
+        action: 'create',
+        connector_key: 'vis.noauth',
+        slug: 'vis-noauth-conn',
+        display_name: 'Vis NoAuth Connection',
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in res).toBe(false);
+    const connectionId = 'connection' in res ? (res.connection as { id: number }).id : 0;
+    expect(connectionId).toBeGreaterThan(0);
+
+    const sql = getTestDb();
+    const [row] = (await sql`
+      SELECT visibility FROM connections WHERE id = ${connectionId}
+    `) as Array<{ visibility: string }>;
+    // No personal credential → role default preserved (owner → org).
+    expect(row.visibility).toBe('org');
+  });
+});

--- a/packages/server/src/__tests__/integration/connectors/connection-visibility-default.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-visibility-default.test.ts
@@ -158,4 +158,105 @@ describe('connection visibility default depends on credential kind', () => {
     // No personal credential → role default preserved (owner → org).
     expect(row.visibility).toBe('org');
   });
+
+  it('re-pointing an ORG connection onto an oauth_account profile DOWNGRADES it to private', async () => {
+    process.env.VISOAUTH_CLIENT_ID = 'env-id';
+    process.env.VISOAUTH_CLIENT_SECRET = 'env-secret';
+    const org = await createTestOrganization({ name: 'Vis Org C' });
+    const user = await createTestUser({ name: 'Owner C' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const ctx = ownerCtx(org.id, user.id);
+    await makeConnectors(org.id);
+    const sql = getTestDb();
+
+    // Seed an ORG-visible connection on the oauth connector directly (bypassing
+    // the create path, which would now default a personal-cred connection to
+    // private — here we're testing the UPDATE re-point, and need a pre-existing
+    // 'org' row to prove the downgrade). No auth profile yet.
+    const [seed] = (await sql`
+      INSERT INTO connections (organization_id, connector_key, slug, display_name, status, visibility, created_by)
+      VALUES (${org.id}, 'vis.oauth', 'vis-rebind-conn', 'Vis Rebind Connection', 'active', 'org', ${user.id})
+      RETURNING id
+    `) as Array<{ id: number }>;
+    const connectionId = seed.id;
+    const [before] = (await sql`
+      SELECT visibility FROM connections WHERE id = ${connectionId}
+    `) as Array<{ visibility: string }>;
+    expect(before.visibility).toBe('org');
+
+    // Create a personal oauth_account profile on the SAME oauth connector, then
+    // rebind this connection onto it.
+    await manageAuthProfiles(
+      {
+        action: 'create_auth_profile',
+        connector_key: 'vis.oauth',
+        profile_kind: 'oauth_account',
+        display_name: 'Rebind Account',
+        slug: 'rebind-account',
+      },
+      TEST_ENV,
+      ctx
+    );
+    const updated = await manageConnections(
+      {
+        action: 'update',
+        connection_id: connectionId,
+        auth_profile_slug: 'rebind-account',
+      },
+      TEST_ENV,
+      ctx
+    );
+    expect('error' in updated).toBe(false);
+
+    const [after] = (await sql`
+      SELECT visibility, auth_profile_id FROM connections WHERE id = ${connectionId}
+    `) as Array<{ visibility: string; auth_profile_id: number | null }>;
+    expect(after.auth_profile_id).not.toBeNull();
+    // The fix: rebinding onto personal creds floors visibility to private.
+    expect(after.visibility).toBe('private');
+
+    delete process.env.VISOAUTH_CLIENT_ID;
+    delete process.env.VISOAUTH_CLIENT_SECRET;
+  });
+
+  it('the OAuth-callback downgrade SQL flips org→private only when the attached profile is personal', async () => {
+    // The GET /:token/oauth/callback route attaches the freshly-created
+    // oauth_account profile and runs this exact CASE. The route wiring is not
+    // unit-testable without full connect-token + provider scaffolding, so this
+    // pins the mechanism it depends on: downgrade org→private for a personal
+    // attach, leave a non-personal attach untouched. Mirrors connect/routes.ts.
+    const org = await createTestOrganization({ name: 'Vis Org D' });
+    const user = await createTestUser({ name: 'Owner D' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const sql = getTestDb();
+    await makeConnectors(org.id);
+
+    const mkConn = async (slug: string) => {
+      const [r] = (await sql`
+        INSERT INTO connections (organization_id, connector_key, slug, display_name, status, visibility, created_by)
+        VALUES (${org.id}, 'vis.oauth', ${slug}, ${slug}, 'pending_auth', 'org', ${user.id})
+        RETURNING id
+      `) as Array<{ id: number }>;
+      return r.id;
+    };
+    const personalId = await mkConn('cb-personal');
+    const sharedId = await mkConn('cb-shared');
+
+    const downgrade = (forcePrivate: boolean, id: number) => sql`
+      UPDATE connections
+      SET visibility = CASE WHEN ${forcePrivate} THEN 'private' ELSE visibility END
+      WHERE id = ${id}
+    `;
+    await downgrade(true, personalId); // attached profile kind was oauth_account
+    await downgrade(false, sharedId); // attached profile kind was not personal
+
+    const [p] = (await sql`
+      SELECT visibility FROM connections WHERE id = ${personalId}
+    `) as Array<{ visibility: string }>;
+    const [s] = (await sql`
+      SELECT visibility FROM connections WHERE id = ${sharedId}
+    `) as Array<{ visibility: string }>;
+    expect(p.visibility).toBe('private'); // personal attach → downgraded
+    expect(s.visibility).toBe('org'); // non-personal attach → untouched
+  });
 });

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -33,7 +33,10 @@ import {
 import { type ConnectTokenRow, resolveConnectToken } from '../utils/connect-tokens';
 import logger from '../utils/logger';
 import { syncOAuthConnectionsForAuthProfile } from '../utils/oauth-connection-state';
-import { resolveOAuthAppClientCredentials } from '../tools/admin/helpers/connection-helpers';
+import {
+  isPersonalCredentialKind,
+  resolveOAuthAppClientCredentials,
+} from '../tools/admin/helpers/connection-helpers';
 import { registerConnectorWebhook } from './webhook-registration';
 import { mergeOAuthScopeAuthData, normalizeScopeList } from '../auth/oauth/scopes';
 import { createSyncRun } from '../runs/queue-service';
@@ -852,11 +855,30 @@ async function handleOAuthCallback(
     }
 
     if (tokenRow.connection_id) {
+      // This callback attaches a PERSONAL oauth_account grant (the else branch
+      // above hard-codes profile_kind='oauth_account'; the if branch reuses a
+      // profile this same OAuth-account flow created). The connection may have
+      // been inserted with visibility='org' because the account profile did not
+      // exist at connect time (resolveConnectionVisibility saw no kind). Now that
+      // it is personal-credential-backed, DOWNGRADE it to 'private' — an org read
+      // through the connection uses this user's token. Downgrade-only: we never
+      // widen a connection here, and 'private' is the floor for personal creds.
+      const attachedKind = authProfileId
+        ? (
+            (await tx`
+              SELECT profile_kind FROM auth_profiles
+              WHERE id = ${authProfileId} AND organization_id = ${tokenRow.organization_id}
+              LIMIT 1
+            `) as Array<{ profile_kind: string }>
+          )[0]?.profile_kind
+        : undefined;
+      const forcePrivate = isPersonalCredentialKind(attachedKind);
       await tx`
         UPDATE connections
         SET account_id = ${resolvedAccountId},
             auth_profile_id = COALESCE(${authProfileId ?? null}, auth_profile_id),
             status = 'active',
+            visibility = CASE WHEN ${forcePrivate} THEN 'private' ELSE visibility END,
             display_name = COALESCE(display_name, ${displayNameOverride}),
             updated_at = NOW()
         WHERE id = ${tokenRow.connection_id}

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -451,10 +451,29 @@ export async function buildViewUrl(
   return buildConnectionsUrl(ownerSlug, baseUrl, connectorKey);
 }
 
+/**
+ * Default visibility for a newly created connection.
+ *
+ * A connection reads through ONE org-level credential (its auth profile's
+ * token), not a per-reader credential — so an `org`-visible connection lets
+ * EVERY org member read live through the connection owner's token. For a
+ * personal login (`profile_kind === 'oauth_account'` — a user's own Gmail /
+ * calendar / etc.) that means org-visible = the owner's private inbox exposed to
+ * the whole org. So a personal-credential connection defaults to `private`
+ * regardless of the creator's role — the credential being personal is a stronger
+ * fact than "an admin made it". Every other credential kind (env secrets,
+ * oauth_app client creds, service accounts, browser sessions) backs a genuinely
+ * shared source, so it keeps the role-based default (admins/owners → `org`,
+ * members → `private`).
+ */
 export async function resolveConnectionVisibility(
   organizationId: string,
-  userId?: string | null
+  userId?: string | null,
+  profileKind?: string | null
 ): Promise<'org' | 'private'> {
+  // Personal login → private, whatever the role. Checked BEFORE the role gate so
+  // an admin attaching their own Gmail still defaults private.
+  if (profileKind === 'oauth_account') return 'private';
   if (!userId) return 'org';
   const sql = getDb();
   const role = await getWorkspaceRole(sql, organizationId, userId);

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -473,11 +473,29 @@ export async function resolveConnectionVisibility(
 ): Promise<'org' | 'private'> {
   // Personal login → private, whatever the role. Checked BEFORE the role gate so
   // an admin attaching their own Gmail still defaults private.
-  if (profileKind === 'oauth_account') return 'private';
+  if (isPersonalCredentialKind(profileKind)) return 'private';
   if (!userId) return 'org';
   const sql = getDb();
   const role = await getWorkspaceRole(sql, organizationId, userId);
   return isAdminOrOwnerRole(role) ? 'org' : 'private';
+}
+
+/**
+ * Is this auth-profile kind a PERSONAL credential — a single user's own login
+ * whose token is not something the whole org should read through? Today only
+ * `oauth_account` (a user's own Gmail/calendar/etc. grant). Every other kind
+ * (env secrets, oauth_app client creds, service accounts, browser sessions)
+ * backs a genuinely shared source.
+ *
+ * A connection reads through ONE org-level credential, so an `org`-visible
+ * connection on a personal credential exposes that user's private data to every
+ * org member. This predicate is the single source of truth for "personal
+ * credential ⇒ must default private", used at create AND at every later point a
+ * connection can become personal-credential-backed (OAuth callback attach,
+ * update re-point).
+ */
+export function isPersonalCredentialKind(profileKind?: string | null): boolean {
+  return profileKind === 'oauth_account';
 }
 
 export async function resolveConnectionDisplayName(params: {

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -265,7 +265,11 @@ export async function handleConnect(
       : null,
   });
 
-  const connectVisibility = await resolveConnectionVisibility(organizationId, userId);
+  const connectVisibility = await resolveConnectionVisibility(
+    organizationId,
+    userId,
+    authSelection?.authProfile?.profile_kind
+  );
   const connectorFeedsSchema = (connector.feeds_schema ?? null) as Record<
     string,
     FeedDefinition

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -808,7 +808,11 @@ export async function handleCreate(
       : null,
   });
 
-  const visibility = await resolveConnectionVisibility(organizationId, effectiveCreatedBy);
+  const visibility = await resolveConnectionVisibility(
+    organizationId,
+    effectiveCreatedBy,
+    authSelection?.authProfile?.profile_kind
+  );
   const connectorFeedsSchema = (connector.feeds_schema ?? null) as Record<
     string,
     FeedDefinition

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -35,6 +35,7 @@ import {
   ensureEnvBackedOAuthAppProfile,
   enrichWithAuthProfiles,
   getInteractiveMethods,
+  isPersonalCredentialKind,
   mapConnectionStatusToFeedStatus,
   resolveConnectionAuthSelection,
   resolveConnectionDisplayName,
@@ -1198,6 +1199,13 @@ export async function handleUpdate(
   const nextAuthProfileId = hasAuthProfileArg
     ? (authSelection.authProfile?.id ?? null)
     : existing.auth_profile_id;
+  // Re-pointing a connection onto a PERSONAL credential (oauth_account) must
+  // floor its visibility to 'private' — otherwise an existing 'org' connection
+  // rebound onto a user's own Gmail would expose that inbox org-wide through the
+  // owner's token. Downgrade-only: we never widen here (the CASE keeps the
+  // current visibility when the new profile is not personal).
+  const rebindToPersonalCred =
+    hasAuthProfileArg && isPersonalCredentialKind(authSelection.authProfile?.profile_kind);
   const nextAppAuthProfileId = hasAppAuthProfileArg
     ? (authSelection.appAuthProfile?.id ?? null)
     : existing.app_auth_profile_id;
@@ -1347,6 +1355,7 @@ export async function handleUpdate(
           status = COALESCE(${effectiveStatus}, status),
           auth_profile_id = ${nextAuthProfileId},
           app_auth_profile_id = ${nextAppAuthProfileId},
+          visibility = CASE WHEN ${rebindToPersonalCred} THEN 'private' ELSE visibility END,
           entity_ids = COALESCE(${entityIdsValue}::bigint[], entity_ids),
           config = ${
             replaceConfig


### PR DESCRIPTION
## The bug

`connections.visibility` defaults to `'org'` (schema default), and the create-time resolver (`resolveConnectionVisibility`) branched on the creator's **role only** — admins/owners → `org`.

But a connection reads through **one org-level credential** (its auth profile's token), not a per-reader credential. So an `org`-visible connection lets *every org member read live through the connection owner's token*. For a personal login (auth profile `profile_kind='oauth_account'` — a user's own Gmail / calendar / LinkedIn), org-visible means **the owner's private inbox is exposed to the whole org**. An owner attaching their own Gmail silently shared it org-wide.

Found while doing a live virtual-feed read of a personal Gmail — the feed (and `search_memory` recall over it) surfaced the owner's real inbox under org visibility.

## The fix

`resolveConnectionVisibility` now takes the auth profile's `profile_kind` and returns `'private'` for `oauth_account` **before** the role gate — so personal creds default private *regardless of role* (an admin's own Gmail still defaults private; the credential being personal outranks "an admin made it"). Every other kind (`env` / `oauth_app` / service account / `browser_session`) backs a genuinely shared source and keeps the role-based default (owner → `org`).

Both user-facing create paths pass the kind:
- `manage_connections action:'create'` (crud.ts)
- `manage_connections action:'connect'` (connect.ts)

The 3 system insert paths are unchanged (chat/social-login projection → `'org'`, device-reconcile → already `'private'`, GitHub-App-install webhook → schema default). They don't carry a personal auth profile.

## Red→green

Integration test (`connection-visibility-default.test.ts`), real handler + real DB:
- **red:** with the fix disabled, an owner's `oauth_account` connection defaults `'org'` — `expected 'org' to be 'private'`.
- **green:** with the fix, it defaults `'private'`; an owner's no-auth connection still defaults `'org'` (role path preserved).

## Scope note — forward-fix only

Existing `org`-visible personal connections are **not** retroactively privatized. A blind prod visibility flip could surprise an org that intentionally shared a personal connection. Retroactive handling (and a UI/API to view+change connection visibility — there is none today) is worth a separate, deliberate change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785634637&installation_id=136316292&pr_number=1711&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1711&signature=b91c32dde76d15d6a50979dacb3cfc4eafe9a9e286e3de6e92e84b95f04332be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->