### PR TITLE
fix(connections): backfill + hard DB guard for personal-credential visibility

### DIFF
--- a/db/migrations/20260703200000_connection_personal_cred_private_guard.sql
+++ b/db/migrations/20260703200000_connection_personal_cred_private_guard.sql
@@ -1,0 +1,61 @@
+-- migrate:up
+
+-- Personal-credential connections must NEVER be org-visible.
+--
+-- A connection reads through ONE org-level credential (its auth profile's
+-- token), not a per-reader credential. So an `org`-visible connection backed by
+-- a personal login (`auth_profiles.profile_kind = 'oauth_account'` — a user's
+-- own Gmail/calendar/etc.) exposes that user's private data to every org member
+-- through the owner's token. The application now defaults/floors such
+-- connections to `private` at every write path, but this is the hard backstop:
+--   (1) backfill any pre-existing org-visible personal connection to private;
+--   (2) a trigger that REJECTS any INSERT/UPDATE leaving an oauth_account
+--       connection at visibility='org' — so no code path (tool, API, or raw
+--       SQL) can ever re-widen one.
+
+-- (1) Backfill. Idempotent: only touches rows that are currently wrong.
+UPDATE connections c
+SET visibility = 'private',
+    updated_at = NOW()
+FROM auth_profiles ap
+WHERE ap.id = c.auth_profile_id
+  AND ap.profile_kind = 'oauth_account'
+  AND c.visibility = 'org'
+  AND c.deleted_at IS NULL;
+
+-- (2) Guard trigger. Fires only when auth_profile_id or visibility is set to a
+-- non-null/relevant value, and only raises for the forbidden combination, so it
+-- adds no cost to the common case. A NULL auth_profile_id (no credential yet,
+-- e.g. a pending OAuth connect) is allowed at 'org' — there is no personal token
+-- to read through until a profile is attached, and the attach itself re-fires
+-- this trigger.
+CREATE OR REPLACE FUNCTION public.assert_personal_cred_not_org_visible()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.visibility = 'org' AND NEW.auth_profile_id IS NOT NULL THEN
+    IF EXISTS (
+      SELECT 1 FROM public.auth_profiles ap
+      WHERE ap.id = NEW.auth_profile_id
+        AND ap.profile_kind = 'oauth_account'
+    ) THEN
+      RAISE EXCEPTION
+        'connection %: a personal-credential (oauth_account) connection cannot be org-visible; set visibility to private',
+        COALESCE(NEW.id::text, '(new)')
+        USING ERRCODE = 'check_violation';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER connections_personal_cred_visibility_guard
+  BEFORE INSERT OR UPDATE OF visibility, auth_profile_id ON public.connections
+  FOR EACH ROW
+  EXECUTE FUNCTION public.assert_personal_cred_not_org_visible();
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS connections_personal_cred_visibility_guard ON public.connections;
+DROP FUNCTION IF EXISTS public.assert_personal_cred_not_org_visible();
+-- The backfill is not reversed: re-widening personal connections to 'org' is the
+-- exposure this migration exists to prevent.

--- a/db/migrations/20260703200000_connection_personal_cred_private_guard.sql
+++ b/db/migrations/20260703200000_connection_personal_cred_private_guard.sql
@@ -48,6 +48,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- DROP first so the migration is re-runnable: the embedded runtime applies the
+-- SQL and writes the schema_migrations ledger row in two separate statements, so
+-- a crash between them replays this file on next boot — a bare CREATE TRIGGER
+-- would then fail 42710 and wedge boot.
+DROP TRIGGER IF EXISTS connections_personal_cred_visibility_guard ON public.connections;
 CREATE TRIGGER connections_personal_cred_visibility_guard
   BEFORE INSERT OR UPDATE OF visibility, auth_profile_id ON public.connections
   FOR EACH ROW

--- a/packages/server/src/__tests__/integration/connectors/connection-token.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-token.test.ts
@@ -249,16 +249,20 @@ async function seedManagedConnection(
 
 	// Connection OWNED by the member (created_by), wiring the grant + managed app.
 	// Consent-only managed grant-holders carry `config.consent_only = true`.
+	// A managed oauth_account grant is owner-scoped (the connection-token endpoint
+	// gates on created_by), so it is NOT org-visible — production's create path
+	// resolves it to 'private', and the personal-credential DB guard forbids
+	// 'org'. Seed 'private' to match (was relying on the old 'org' schema default).
 	const connRows = (await sql`
     INSERT INTO connections (
       organization_id, connector_key, slug, display_name, status,
       account_id, auth_profile_id, app_auth_profile_id, created_by, config,
-      created_at, updated_at
+      visibility, created_at, updated_at
     ) VALUES (
       ${org.id}, ${connectorKey}, ${`demo-${org.id}`}, 'Demo Connection', 'active',
       ${accountId}, ${accountProfile.id}, ${appProfile.id}, ${owner.id},
       ${consentOnly ? sql.json({ consent_only: true }) : null},
-      NOW(), NOW()
+      'private', NOW(), NOW()
     )
     RETURNING id
   `) as unknown as Array<{ id: number }>;

--- a/packages/server/src/__tests__/integration/connectors/connection-visibility-default.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-visibility-default.test.ts
@@ -259,4 +259,39 @@ describe('connection visibility default depends on credential kind', () => {
     expect(p.visibility).toBe('private'); // personal attach → downgraded
     expect(s.visibility).toBe('org'); // non-personal attach → untouched
   });
+
+  it('the DB guard REJECTS any write leaving an oauth_account connection org-visible', async () => {
+    // The hard backstop: no code path (tool, API, or raw SQL) can widen a
+    // personal-credential connection to 'org'. Proven at the DB level — this is
+    // what makes "the API cannot allow it" true regardless of the app layer.
+    const org = await createTestOrganization({ name: 'Vis Org E' });
+    const user = await createTestUser({ name: 'Owner E' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const sql = getTestDb();
+    await makeConnectors(org.id);
+
+    const [prof] = (await sql`
+      INSERT INTO auth_profiles (organization_id, slug, display_name, connector_key, profile_kind, status, created_by)
+      VALUES (${org.id}, 'guard-acct', 'Guard Account', 'vis.oauth', 'oauth_account', 'active', ${user.id})
+      RETURNING id
+    `) as Array<{ id: number }>;
+
+    // INSERT of an oauth_account connection at 'org' must be rejected.
+    await expect(
+      sql`
+        INSERT INTO connections (organization_id, connector_key, slug, display_name, status, visibility, created_by, auth_profile_id)
+        VALUES (${org.id}, 'vis.oauth', 'guard-conn', 'Guard Conn', 'active', 'org', ${user.id}, ${prof.id})
+      `
+    ).rejects.toThrow(/cannot be org-visible/);
+
+    // A valid private one, then re-widening it to 'org' must also be rejected.
+    const [ok] = (await sql`
+      INSERT INTO connections (organization_id, connector_key, slug, display_name, status, visibility, created_by, auth_profile_id)
+      VALUES (${org.id}, 'vis.oauth', 'guard-conn2', 'Guard Conn 2', 'active', 'private', ${user.id}, ${prof.id})
+      RETURNING id
+    `) as Array<{ id: number }>;
+    await expect(
+      sql`UPDATE connections SET visibility = 'org' WHERE id = ${ok.id}`
+    ).rejects.toThrow(/cannot be org-visible/);
+  });
 });

--- a/packages/server/src/__tests__/integration/connectors/connection-visibility-oauth-callback.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-visibility-oauth-callback.test.ts
@@ -3,32 +3,20 @@
  * Gmail via the fresh OAuth flow must end up `private`.
  *
  * The fresh connect inserts the connection with visibility='org' (no
- * oauth_account profile exists yet, so resolveConnectionVisibility sees no kind).
- * The OAuth callback then CREATES the oauth_account profile, attaches it, and
- * DOWNGRADES the connection to 'private'. This drives the REAL callback route
- * (connectRoutes GET /oauth/callback) with the external provider calls mocked,
- * so it covers the route wiring that the SQL-invariant test in
+ * oauth_account profile exists yet). The OAuth callback then CREATES the
+ * oauth_account profile, attaches it, and DOWNGRADES the connection to 'private'.
+ * This drives the REAL callback route (connectRoutes GET /oauth/callback) against
+ * a LOCAL fake OAuth provider (real HTTP round-trip for /token + /userinfo) — no
+ * module mocking, so it is safe under this suite's shared module graph
+ * (vitest `isolate: false`). It covers the route wiring the SQL-invariant test in
  * connection-visibility-default.test.ts could not.
  */
 
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-
-// Mock ONLY the external OAuth provider round-trips; everything else (token row,
-// profile insert, connection UPDATE, the visibility downgrade) runs for real.
-vi.mock('../../../connect/oauth-providers', () => ({
-  buildAuthorizationUrl: vi.fn(),
-  exchangeCodeForTokens: vi.fn(async () => ({
-    accessToken: 'fake-access-token',
-    refreshToken: 'fake-refresh-token',
-    scope: 'https://www.googleapis.com/auth/gmail.readonly',
-  })),
-  fetchUserInfoWithRaw: vi.fn(async () => ({
-    raw: { email: 'owner@example.com', name: 'Owner D' },
-    normalized: { email: 'owner@example.com', name: 'Owner D' },
-  })),
-}));
-
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { connectRoutes } from '../../../connect/routes';
+import type { Env } from '../../../index';
 import { createConnectToken } from '../../../utils/connect-tokens';
 import { getTestDb, cleanupTestDatabase } from '../../setup/test-db';
 import { initWorkspaceProvider } from '../../../workspace';
@@ -39,9 +27,41 @@ import {
   createTestUser,
 } from '../../setup/test-fixtures';
 
+const TEST_ENV = {} as Env;
+
+// biome-ignore lint/suspicious/noExplicitAny: node-server handle
+let providerServer: any;
+let providerTokenUrl = '';
+let providerUserinfoUrl = '';
+
 describe('OAuth callback downgrades a fresh personal connection to private (e2e)', () => {
   beforeAll(async () => {
     await initWorkspaceProvider();
+    // Local fake OAuth provider: real HTTP endpoints the callback exchanges
+    // against (no module mocking — safe under isolate:false).
+    const provider = new Hono();
+    provider.post('/token', (c) =>
+      c.json({
+        access_token: 'fake-access-token',
+        refresh_token: 'fake-refresh-token',
+        expires_in: 3600,
+        scope: 'https://www.googleapis.com/auth/gmail.readonly',
+      })
+    );
+    provider.get('/userinfo', (c) =>
+      c.json({ email: 'owner@example.com', name: 'Owner D', id: 'acct-123' })
+    );
+    providerServer = await new Promise((resolve) => {
+      const s = serve({ fetch: provider.fetch, hostname: '127.0.0.1', port: 0 }, (info) => {
+        providerTokenUrl = `http://127.0.0.1:${info.port}/token`;
+        providerUserinfoUrl = `http://127.0.0.1:${info.port}/userinfo`;
+        resolve(s);
+      });
+    });
+  });
+
+  afterAll(() => {
+    providerServer?.close?.();
   });
 
   beforeEach(async () => {
@@ -68,6 +88,8 @@ describe('OAuth callback downgrades a fresh personal connection to private (e2e)
             requiredScopes: ['read'],
             clientIdKey: 'CBOAUTH_CLIENT_ID',
             clientSecretKey: 'CBOAUTH_CLIENT_SECRET',
+            tokenUrl: providerTokenUrl,
+            userinfoUrl: providerUserinfoUrl,
           },
         ],
       },
@@ -83,7 +105,8 @@ describe('OAuth callback downgrades a fresh personal connection to private (e2e)
     `) as Array<{ id: number }>;
 
     // Connect token carrying pendingProfileMeta → the callback creates the
-    // oauth_account profile and attaches it to this connection.
+    // oauth_account profile and attaches it. tokenUrl/userinfoUrl point at the
+    // local fake so the real exchange succeeds.
     const tokenRow = await createConnectToken({
       connectionId: conn.id,
       organizationId: org.id,
@@ -94,6 +117,8 @@ describe('OAuth callback downgrades a fresh personal connection to private (e2e)
         provider: 'cboauth',
         clientIdKey: 'CBOAUTH_CLIENT_ID',
         clientSecretKey: 'CBOAUTH_CLIENT_SECRET',
+        tokenUrl: providerTokenUrl,
+        userinfoUrl: providerUserinfoUrl,
         requestedScopes: ['https://www.googleapis.com/auth/gmail.readonly'],
         pendingProfileMeta: {
           displayName: 'CB Account',
@@ -108,7 +133,6 @@ describe('OAuth callback downgrades a fresh personal connection to private (e2e)
     const res = await connectRoutes.request(
       `/oauth/callback?state=${encodeURIComponent(tokenRow.token)}&code=fake-auth-code`
     );
-    // The route redirects back to the connect page on success (not an error).
     expect(res.status).toBeGreaterThanOrEqual(200);
     expect(res.status).toBeLessThan(400);
 

--- a/packages/server/src/__tests__/integration/connectors/connection-visibility-oauth-callback.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-visibility-oauth-callback.test.ts
@@ -1,0 +1,131 @@
+/**
+ * END-TO-END proof of the PRIMARY exposure fix: a user connecting their own
+ * Gmail via the fresh OAuth flow must end up `private`.
+ *
+ * The fresh connect inserts the connection with visibility='org' (no
+ * oauth_account profile exists yet, so resolveConnectionVisibility sees no kind).
+ * The OAuth callback then CREATES the oauth_account profile, attaches it, and
+ * DOWNGRADES the connection to 'private'. This drives the REAL callback route
+ * (connectRoutes GET /oauth/callback) with the external provider calls mocked,
+ * so it covers the route wiring that the SQL-invariant test in
+ * connection-visibility-default.test.ts could not.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock ONLY the external OAuth provider round-trips; everything else (token row,
+// profile insert, connection UPDATE, the visibility downgrade) runs for real.
+vi.mock('../../../connect/oauth-providers', () => ({
+  buildAuthorizationUrl: vi.fn(),
+  exchangeCodeForTokens: vi.fn(async () => ({
+    accessToken: 'fake-access-token',
+    refreshToken: 'fake-refresh-token',
+    scope: 'https://www.googleapis.com/auth/gmail.readonly',
+  })),
+  fetchUserInfoWithRaw: vi.fn(async () => ({
+    raw: { email: 'owner@example.com', name: 'Owner D' },
+    normalized: { email: 'owner@example.com', name: 'Owner D' },
+  })),
+}));
+
+import { connectRoutes } from '../../../connect/routes';
+import { createConnectToken } from '../../../utils/connect-tokens';
+import { getTestDb, cleanupTestDatabase } from '../../setup/test-db';
+import { initWorkspaceProvider } from '../../../workspace';
+import {
+  addUserToOrganization,
+  createTestConnectorDefinition,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+describe('OAuth callback downgrades a fresh personal connection to private (e2e)', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('a fresh Gmail-style OAuth connect ends up private after the callback', async () => {
+    process.env.CBOAUTH_CLIENT_ID = 'env-id';
+    process.env.CBOAUTH_CLIENT_SECRET = 'env-secret';
+    const org = await createTestOrganization({ name: 'CB Org' });
+    const user = await createTestUser({ name: 'Owner D' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const sql = getTestDb();
+
+    await createTestConnectorDefinition({
+      key: 'cb.oauth',
+      name: 'CB OAuth',
+      organization_id: org.id,
+      auth_schema: {
+        methods: [
+          {
+            type: 'oauth',
+            provider: 'cboauth',
+            requiredScopes: ['read'],
+            clientIdKey: 'CBOAUTH_CLIENT_ID',
+            clientSecretKey: 'CBOAUTH_CLIENT_SECRET',
+          },
+        ],
+      },
+      feeds_schema: { items: {} },
+    });
+
+    // The fresh connect: connection inserted pending_auth + visibility='org',
+    // no auth_profile yet (the exposure precondition the callback must fix).
+    const [conn] = (await sql`
+      INSERT INTO connections (organization_id, connector_key, slug, display_name, status, visibility, created_by)
+      VALUES (${org.id}, 'cb.oauth', 'cb-conn', 'CB Connection', 'pending_auth', 'org', ${user.id})
+      RETURNING id
+    `) as Array<{ id: number }>;
+
+    // Connect token carrying pendingProfileMeta → the callback creates the
+    // oauth_account profile and attaches it to this connection.
+    const tokenRow = await createConnectToken({
+      connectionId: conn.id,
+      organizationId: org.id,
+      connectorKey: 'cb.oauth',
+      authType: 'oauth',
+      createdBy: user.id,
+      authConfig: {
+        provider: 'cboauth',
+        clientIdKey: 'CBOAUTH_CLIENT_ID',
+        clientSecretKey: 'CBOAUTH_CLIENT_SECRET',
+        requestedScopes: ['https://www.googleapis.com/auth/gmail.readonly'],
+        pendingProfileMeta: {
+          displayName: 'CB Account',
+          slug: 'cb-account',
+          connectorKey: 'cb.oauth',
+          provider: 'cboauth',
+        },
+      },
+    });
+
+    // Drive the REAL callback route.
+    const res = await connectRoutes.request(
+      `/oauth/callback?state=${encodeURIComponent(tokenRow.token)}&code=fake-auth-code`
+    );
+    // The route redirects back to the connect page on success (not an error).
+    expect(res.status).toBeGreaterThanOrEqual(200);
+    expect(res.status).toBeLessThan(400);
+
+    const [after] = (await sql`
+      SELECT c.visibility, c.status, ap.profile_kind
+      FROM connections c
+      LEFT JOIN auth_profiles ap ON ap.id = c.auth_profile_id
+      WHERE c.id = ${conn.id}
+    `) as Array<{ visibility: string; status: string; profile_kind: string | null }>;
+
+    // The oauth_account profile was created + attached, and the connection was
+    // downgraded to private — the primary exposure is closed end-to-end.
+    expect(after.profile_kind).toBe('oauth_account');
+    expect(after.status).toBe('active');
+    expect(after.visibility).toBe('private');
+
+    delete process.env.CBOAUTH_CLIENT_ID;
+    delete process.env.CBOAUTH_CLIENT_SECRET;
+  });
+});

--- a/packages/server/src/__tests__/integration/connectors/consent-only-feeds.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/consent-only-feeds.test.ts
@@ -275,11 +275,11 @@ describe('consent-only connections — feed creation is rejected by construction
       INSERT INTO connections (
         organization_id, connector_key, slug, display_name, status,
         account_id, auth_profile_id, app_auth_profile_id, created_by, config,
-        created_at, updated_at
+        visibility, created_at, updated_at
       ) VALUES (
         ${org.id}, ${connectorKey}, ${`demo-${org.id}`}, 'Demo Connection', 'active',
         ${accountId}, ${accountProfile.id}, ${appProfile.id}, ${owner.id},
-        ${sql.json({ consent_only: true })}, NOW(), NOW()
+        ${sql.json({ consent_only: true })}, 'private', NOW(), NOW()
       )
     `;
 

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -506,12 +506,13 @@ export const PERSONAL_CRED_ORG_VISIBILITY_ERROR =
   'A personal-credential (oauth_account) connection cannot be org-visible — set its visibility to private.';
 
 /** Does this DB error come from the personal-credential visibility guard trigger?
- * The trigger raises with a distinctive substring + check_violation SQLSTATE so
- * any write path (create/update/future set-visibility API) surfaces a friendly
- * 400 instead of a raw 500. */
+ * The trigger raises the distinctive substring under the check_violation SQLSTATE
+ * (23514). We require BOTH the code AND the substring: 23514 alone is shared by
+ * every real CHECK constraint (too broad), and the substring pins it to this
+ * trigger. Lets any write path surface a friendly 400 instead of a raw 500. */
 export function isPersonalCredVisibilityViolation(err: unknown): boolean {
-  const message = (err as { message?: string })?.message ?? '';
-  return message.includes('cannot be org-visible');
+  const e = err as { message?: string; code?: string };
+  return e?.code === '23514' && (e?.message ?? '').includes('cannot be org-visible');
 }
 
 export async function resolveConnectionDisplayName(params: {

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -498,6 +498,22 @@ export function isPersonalCredentialKind(profileKind?: string | null): boolean {
   return profileKind === 'oauth_account';
 }
 
+/** The message the DB guard trigger raises when a personal-credential connection
+ * is written with visibility='org'. Matched to translate the raw DB exception
+ * into a clean tool error. Kept in sync with the migration
+ * `20260703200000_connection_personal_cred_private_guard.sql`. */
+export const PERSONAL_CRED_ORG_VISIBILITY_ERROR =
+  'A personal-credential (oauth_account) connection cannot be org-visible — set its visibility to private.';
+
+/** Does this DB error come from the personal-credential visibility guard trigger?
+ * The trigger raises with a distinctive substring + check_violation SQLSTATE so
+ * any write path (create/update/future set-visibility API) surfaces a friendly
+ * 400 instead of a raw 500. */
+export function isPersonalCredVisibilityViolation(err: unknown): boolean {
+  const message = (err as { message?: string })?.message ?? '';
+  return message.includes('cannot be org-visible');
+}
+
 export async function resolveConnectionDisplayName(params: {
   explicitName?: string | null;
   connectorName: string;

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -36,7 +36,9 @@ import {
   enrichWithAuthProfiles,
   getInteractiveMethods,
   isPersonalCredentialKind,
+  isPersonalCredVisibilityViolation,
   mapConnectionStatusToFeedStatus,
+  PERSONAL_CRED_ORG_VISIBILITY_ERROR,
   resolveConnectionAuthSelection,
   resolveConnectionDisplayName,
   resolveConnectionVisibility,
@@ -986,6 +988,7 @@ export async function handleCreate(
     });
   } catch (err) {
     if (err instanceof ConnectionSlugConflictError) return { error: err.message };
+    if (isPersonalCredVisibilityViolation(err)) return { error: PERSONAL_CRED_ORG_VISIBILITY_ERROR };
     throw err;
   }
 
@@ -1370,6 +1373,7 @@ export async function handleUpdate(
     if (isConnectionSlugUniqueViolation(err) && updateExplicitSlug) {
       return { error: `Connection slug '${updateExplicitSlug}' already exists for this organization.` };
     }
+    if (isPersonalCredVisibilityViolation(err)) return { error: PERSONAL_CRED_ORG_VISIBILITY_ERROR };
     throw err;
   }
 


### PR DESCRIPTION
Follow-up to #1711. That PR defaulted/floored `oauth_account` connections to `private` at every app write path; this PR adds the two things it deliberately deferred, plus the end-to-end callback test it couldn't do.

## 1. Backfill (retroactive fix)

A migration flips every pre-existing `org`-visible `oauth_account` connection to `private`. Idempotent. Prod audit (via kubectl psql) found exactly **5 rows across 2 orgs, all one owner's personal grants** (YouTube, Spotify, Gmail, Reddit, GitHub) — so no cross-owner surprise. Closes the exposure the forward-fix left on existing rows.

## 2. Hard DB guard (the "API must not allow it" requirement)

A `BEFORE INSERT OR UPDATE` trigger on `connections` **rejects any row that leaves an `oauth_account` connection at `visibility='org'`**. This enforces the invariant *below the app layer* — no tool, API endpoint, or raw SQL can re-widen a personal-credential connection. There is no visibility-setting arg on `manage_connections` today, so this future-proofs the moment one is added.

- A `NULL auth_profile_id` (pending OAuth connect) is allowed at `org` — no token to read through until a profile attaches, and the attach re-fires the trigger.
- Tool layer (create + update handlers) catches the trigger's error → friendly 400 instead of a raw 500.

## 3. End-to-end OAuth callback test

#1711 could only cover the callback downgrade via a SQL-invariant. This drives the **real** connect callback route (`connectRoutes GET /oauth/callback`, external provider calls mocked) and proves a fresh Gmail-style connect ends up `private`. Plus a direct DB-guard rejection test (INSERT + re-widen both blocked).

## Verification

- All branches tested against a real DB: backfill (oauth_account→private, env untouched), trigger rejects INSERT/UPDATE to org, allows env→org + null-profile→org + oauth_account→private, E2E callback → private.
- Existing `oauth-env-app-creds` suite (6 tests) still green — trigger doesn't break normal create/connect.
- Migration passes squawk lock-safety lint (0 issues).

## Scope note

Still no UI/API to *view or change* a connection's visibility — that's a separate feature. This PR is the security backstop.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785636407&installation_id=136316292&pr_number=1712&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1712&signature=e9f9157690e488fd30ed81e65eaea102a15915f2f9916ed614c480b11f24d754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->