### PR TITLE
fix(slack): render agent links as mrkdwn in channel-link notice + confirm-bind card

### DIFF
--- a/packages/server/src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
+++ b/packages/server/src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
@@ -85,6 +85,27 @@ describe("workspaceUnlinkedNotice", () => {
 		expect(text).toContain("/lobu link");
 	});
 
+	it("escapes mrkdwn control chars in the link label so a name can't break the inline link", async () => {
+		setOrigin("https://app.lobu.ai");
+		const org = await createTestOrganization({ slug: "acme" });
+		await createTestAgent({
+			organizationId: org.id,
+			agentId: "odd",
+			name: "A&B <Co>",
+		});
+
+		const text = (await workspaceUnlinkedNotice("slack", org.id, {
+			channelId: "slack:C0ABC123",
+			teamId: "T0TEAM",
+			channelName: "general",
+		})) as string;
+
+		// The label inside `<url|label>` is entity-escaped; the raw name never
+		// reaches Slack, so a `>` can't prematurely close the inline link.
+		expect(text).toContain("|A&amp;B &lt;Co&gt;>");
+		expect(text).not.toContain("|A&B <Co>>");
+	});
+
 	it("deep-links to the plain Behaviors page when no channel context is given", async () => {
 		setOrigin("https://app.lobu.ai");
 		const org = await createTestOrganization({ slug: "acme" });

--- a/packages/server/src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
+++ b/packages/server/src/__tests__/integration/preview/workspace-unlinked-notice.test.ts
@@ -7,106 +7,131 @@
  * agents, and never turn into a dead drop.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { workspaceUnlinkedNotice } from '../../../preview/slack';
-import { __resetPublicOriginCachesForTests } from '../../../utils/public-origin';
-import { cleanupTestDatabase } from '../../setup/test-db';
-import { createTestAgent, createTestOrganization } from '../../setup/test-fixtures';
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { workspaceUnlinkedNotice } from "../../../preview/slack";
+import { __resetPublicOriginCachesForTests } from "../../../utils/public-origin";
+import { cleanupTestDatabase } from "../../setup/test-db";
+import {
+	createTestAgent,
+	createTestOrganization,
+} from "../../setup/test-fixtures";
 
-const ORIGIN_ENV = 'PUBLIC_GATEWAY_URL';
+const ORIGIN_ENV = "PUBLIC_GATEWAY_URL";
 
 // getConfiguredPublicOrigin() memoizes PUBLIC_GATEWAY_URL on first read, so every
 // case that changes the env must reset the cache to be observed.
 function setOrigin(value: string | undefined) {
-  if (value === undefined) delete process.env[ORIGIN_ENV];
-  else process.env[ORIGIN_ENV] = value;
-  __resetPublicOriginCachesForTests();
+	if (value === undefined) delete process.env[ORIGIN_ENV];
+	else process.env[ORIGIN_ENV] = value;
+	__resetPublicOriginCachesForTests();
 }
 
-describe('workspaceUnlinkedNotice', () => {
-  let savedOrigin: string | undefined;
+describe("workspaceUnlinkedNotice", () => {
+	let savedOrigin: string | undefined;
 
-  beforeEach(async () => {
-    await cleanupTestDatabase();
-    savedOrigin = process.env[ORIGIN_ENV];
-  });
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		savedOrigin = process.env[ORIGIN_ENV];
+	});
 
-  afterEach(() => {
-    setOrigin(savedOrigin);
-  });
+	afterEach(() => {
+		setOrigin(savedOrigin);
+	});
 
-  it('returns null for non-slack platforms', async () => {
-    const org = await createTestOrganization();
-    expect(await workspaceUnlinkedNotice('telegram', org.id)).toBeNull();
-  });
+	it("returns null for non-slack platforms", async () => {
+		const org = await createTestOrganization();
+		expect(await workspaceUnlinkedNotice("telegram", org.id)).toBeNull();
+	});
 
-  it('deep-links each agent to the Behaviors "new" step with the channel prefilled', async () => {
-    setOrigin('https://app.lobu.ai/lobu');
-    const org = await createTestOrganization({ slug: 'acme' });
-    await createTestAgent({ organizationId: org.id, agentId: 'planner', name: 'Planner' });
-    await createTestAgent({ organizationId: org.id, agentId: 'builder', name: 'Builder' });
+	it('deep-links each agent to the Behaviors "new" step with the channel prefilled', async () => {
+		setOrigin("https://app.lobu.ai/lobu");
+		const org = await createTestOrganization({ slug: "acme" });
+		await createTestAgent({
+			organizationId: org.id,
+			agentId: "planner",
+			name: "Planner",
+		});
+		await createTestAgent({
+			organizationId: org.id,
+			agentId: "builder",
+			name: "Builder",
+		});
 
-    const notice = await workspaceUnlinkedNotice('slack', org.id, {
-      channelId: 'slack:C0ABC123',
-      teamId: 'T0TEAM',
-      channelName: 'general',
-    });
-    expect(notice).not.toBeNull();
-    const text = notice as string;
+		const notice = await workspaceUnlinkedNotice("slack", org.id, {
+			channelId: "slack:C0ABC123",
+			teamId: "T0TEAM",
+			channelName: "general",
+		});
+		expect(notice).not.toBeNull();
+		const text = notice as string;
 
-    // getConfiguredPublicOrigin() returns the URL *origin* (scheme+host), so the
-    // /lobu gateway mount is dropped — the SPA lives at the bare origin. The link
-    // targets the Listen "new" step with the channel prefilled for confirm-bind.
-    // `slack:C…`, `T0TEAM`, and the `#general` label are URL-encoded.
-    expect(text).toContain(
-      'https://app.lobu.ai/acme/agents/planner/behaviors/new?listen=slack%3AC0ABC123&platform=slack&team=T0TEAM&label=%23general',
-    );
-    expect(text).toContain(
-      'https://app.lobu.ai/acme/agents/builder/behaviors/new?listen=slack%3AC0ABC123&platform=slack&team=T0TEAM&label=%23general',
-    );
-    expect(text).toContain('Planner');
-    expect(text).toContain('Builder');
-    // The CLI path is always offered too.
-    expect(text).toContain('lobu run');
-    expect(text).toContain('/lobu link');
-  });
+		// getConfiguredPublicOrigin() returns the URL *origin* (scheme+host), so the
+		// /lobu gateway mount is dropped — the SPA lives at the bare origin. The link
+		// targets the Listen "new" step with the channel prefilled for confirm-bind.
+		// `slack:C…`, `T0TEAM`, and the `#general` label are URL-encoded. Each agent
+		// is a Slack mrkdwn inline link `<url|Name>` so it renders clickable (the
+		// notice goes out via chat.postMessage text, which Slack reads as mrkdwn;
+		// unfurl_links is off so a bare URL would render as flat text).
+		expect(text).toContain(
+			"<https://app.lobu.ai/acme/agents/planner/behaviors/new?listen=slack%3AC0ABC123&platform=slack&team=T0TEAM&label=%23general|Planner>",
+		);
+		expect(text).toContain(
+			"<https://app.lobu.ai/acme/agents/builder/behaviors/new?listen=slack%3AC0ABC123&platform=slack&team=T0TEAM&label=%23general|Builder>",
+		);
+		expect(text).toContain("Planner");
+		expect(text).toContain("Builder");
+		// The CLI path is always offered too.
+		expect(text).toContain("lobu run");
+		expect(text).toContain("/lobu link");
+	});
 
-  it('deep-links to the plain Behaviors page when no channel context is given', async () => {
-    setOrigin('https://app.lobu.ai');
-    const org = await createTestOrganization({ slug: 'acme' });
-    await createTestAgent({ organizationId: org.id, agentId: 'planner', name: 'Planner' });
+	it("deep-links to the plain Behaviors page when no channel context is given", async () => {
+		setOrigin("https://app.lobu.ai");
+		const org = await createTestOrganization({ slug: "acme" });
+		await createTestAgent({
+			organizationId: org.id,
+			agentId: "planner",
+			name: "Planner",
+		});
 
-    const text = (await workspaceUnlinkedNotice('slack', org.id)) as string;
-    expect(text).toContain('https://app.lobu.ai/acme/agents/planner/behaviors');
-    expect(text).not.toContain('/behaviors/new?');
-  });
+		const text = (await workspaceUnlinkedNotice("slack", org.id)) as string;
+		expect(text).toContain("https://app.lobu.ai/acme/agents/planner/behaviors");
+		expect(text).not.toContain("/behaviors/new?");
+	});
 
-  it('lists agents by name (no URLs) when the public origin is not configured', async () => {
-    setOrigin(undefined);
-    const org = await createTestOrganization({ slug: 'acme' });
-    await createTestAgent({ organizationId: org.id, agentId: 'planner', name: 'Planner' });
+	it("lists agents by name (no URLs) when the public origin is not configured", async () => {
+		setOrigin(undefined);
+		const org = await createTestOrganization({ slug: "acme" });
+		await createTestAgent({
+			organizationId: org.id,
+			agentId: "planner",
+			name: "Planner",
+		});
 
-    const text = (await workspaceUnlinkedNotice('slack', org.id)) as string;
-    expect(text).toContain('Planner');
-    expect(text).not.toContain('/agents/planner/behaviors');
-    expect(text).toContain('lobu run'); // CLI path still present
-  });
+		const text = (await workspaceUnlinkedNotice("slack", org.id)) as string;
+		expect(text).toContain("Planner");
+		expect(text).not.toContain("/agents/planner/behaviors");
+		expect(text).toContain("lobu run"); // CLI path still present
+	});
 
-  it('falls back to the CLI-only notice when the org has no agents', async () => {
-    setOrigin('https://app.lobu.ai');
-    const org = await createTestOrganization();
+	it("falls back to the CLI-only notice when the org has no agents", async () => {
+		setOrigin("https://app.lobu.ai");
+		const org = await createTestOrganization();
 
-    const text = (await workspaceUnlinkedNotice('slack', org.id)) as string;
-    expect(text).toContain('lobu run');
-    expect(text).toContain('/lobu link');
-    // No agent-list section.
-    expect(text).not.toContain('Behaviors page');
-  });
+		const text = (await workspaceUnlinkedNotice("slack", org.id)) as string;
+		expect(text).toContain("lobu run");
+		expect(text).toContain("/lobu link");
+		// No agent-list section.
+		expect(text).not.toContain("Behaviors page");
+	});
 
-  it('never throws / dead-drops for an unknown org (returns the CLI-only notice)', async () => {
-    setOrigin('https://app.lobu.ai');
-    const text = (await workspaceUnlinkedNotice('slack', 'org_does_not_exist')) as string;
-    expect(text).not.toBeNull();
-    expect(text).toContain('/lobu link');
-  });
+	it("never throws / dead-drops for an unknown org (returns the CLI-only notice)", async () => {
+		setOrigin("https://app.lobu.ai");
+		const text = (await workspaceUnlinkedNotice(
+			"slack",
+			"org_does_not_exist",
+		)) as string;
+		expect(text).not.toBeNull();
+		expect(text).toContain("/lobu link");
+	});
 });

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -402,9 +402,7 @@ interface PreviewAgent {
  * owning agent), plus that owning agent's id (excluded from the demo list).
  * Returns null when the connection or its owning agent can't be resolved.
  */
-async function resolvePreviewConnectionOrg(
-	connectionId: string,
-): Promise<{
+async function resolvePreviewConnectionOrg(connectionId: string): Promise<{
 	organizationId: string;
 	owningAgentId: string;
 	connectionDatabaseId: number;
@@ -599,6 +597,20 @@ async function listOrgAgentsForNotice(organizationId: string): Promise<{
  * source); also gives the CLI `lobu run` / `/lobu link <code>` path. Returns
  * null for non-Slack platforms (OAuth install is Slack-only today).
  */
+/**
+ * Escape the Slack mrkdwn chars that break an inline `<url|label>` link label.
+ * Agent names are user-controlled; a `>`, `<`, or `&` in a name would otherwise
+ * terminate/mangle the link (Slack reads `text` as mrkdwn, and `&` is the entity
+ * escape prefix). Mirrors the private `escapeMrkdwn` in slack-platform-bridge.ts;
+ * kept local because preview and gateway/connections are separate modules.
+ */
+function escapeMrkdwnLabel(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;");
+}
+
 export async function workspaceUnlinkedNotice(
 	platform: string,
 	organizationId: string,
@@ -648,9 +660,13 @@ export async function workspaceUnlinkedNotice(
 	// is posted via thread.post(string) → chat.postMessage({ text }), which Slack
 	// always interprets as mrkdwn; with unfurl_links disabled a bare URL renders
 	// as flat text, but `<url|label>` renders as a clickable link. The adapter's
-	// plain-text path only rewrites @mentions, so the `<>` survive intact.
+	// plain-text path only rewrites @mentions, so the `<>` survive intact. The
+	// label is escaped because agent names are user-controlled and a raw `>`/`<`/`&`
+	// would terminate or corrupt the inline link.
 	const agentLines = agents.map((a) =>
-		canLink ? `   • <${behaviorsUrl(a.agentId)}|${a.name}>` : `   • ${a.name}`,
+		canLink
+			? `   • <${behaviorsUrl(a.agentId)}|${escapeMrkdwnLabel(a.name)}>`
+			: `   • ${a.name}`,
 	);
 
 	if (agentLines.length > 0) {

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -644,8 +644,13 @@ export async function workspaceUnlinkedNotice(
 		if (channel.channelName) params.set("label", `#${channel.channelName}`);
 		return `${base}/new?${params.toString()}`;
 	};
+	// Render each agent as a Slack mrkdwn inline link (`<url|label>`). The notice
+	// is posted via thread.post(string) → chat.postMessage({ text }), which Slack
+	// always interprets as mrkdwn; with unfurl_links disabled a bare URL renders
+	// as flat text, but `<url|label>` renders as a clickable link. The adapter's
+	// plain-text path only rewrites @mentions, so the `<>` survive intact.
 	const agentLines = agents.map((a) =>
-		canLink ? `   • ${a.name} — ${behaviorsUrl(a.agentId)}` : `   • ${a.name}`,
+		canLink ? `   • <${behaviorsUrl(a.agentId)}|${a.name}>` : `   • ${a.name}`,
 	);
 
 	if (agentLines.length > 0) {


### PR DESCRIPTION
## Problem

Two bugs in the Slack "link your agent" notice (the reply a tenant's OAuth-installed bot posts when a channel isn't bound to an agent yet):

1. **Raw links.** The notice emitted each agent as bare text (`   • Builder — https://…`). It posts via `thread.post(string)` → `chat.postMessage({ text, unfurl_links: false })`, and with unfurling off a bare URL renders as flat, un-clickable text.
2. **Clicking shows nothing.** The deep link (`behaviors/new?listen=…&platform=…&team=…&label=…`) promised a one-click confirm-bind with the channel prefilled, but the frontend never read those params — it rendered a generic Listen/Watch/Schedule picker unrelated to the channel.

## Fix

**Bug 1 (server, this PR):** `workspaceUnlinkedNotice` now renders each agent as a Slack mrkdwn inline link `<url|Name>`. Slack always interprets `text` as mrkdwn, so `<url|label>` renders clickable regardless of `unfurl_links:false`. The chat-adapter plain-text path only rewrites @mentions — `<>` survive intact. The link label is escaped (`escapeMrkdwnLabel`) so a user-controlled agent name containing `>`/`<`/`&` can't terminate or corrupt the inline link.

**Bug 2 (frontend, owletto #428):** adds `validateSearch` to the `behaviors/new` route and a `<ConfirmBindCard>` that binds the prefilled channel via `useBindChannel`. Reviewed by pi/gpt-5.5 (3 rounds): fixed a channel-steal guard (refuse to bind when the channel's `target_agent_id` is another agent), a cold-load race (`!org` gate), a back-nav regression, and a stale-state sync.

> **Note on the owletto pointer:** the submodule bump lands the merge of owletto **#433** (`ca5101c`, "feat(nav): Infrastructure section") — the current tip of owletto `main` that #428's `fc557f1` merge was already absorbed into. `check-drift` confirms the SHA is reachable from the remote.

## Validation
- Server `tsc` clean; `workspace-unlinked-notice.test.ts` green (7/7) — asserts both the `<https://…|Planner>` form and that `A&B <Co>` is escaped to `A&amp;B &lt;Co&gt;` in the label.
- `make build-packages` + server `typecheck` clean.
- owletto #428 verified end-to-end in the browser (bind, steal-guard, back-nav, already-bound state).
- `make review` build/typecheck/unit/integration all passed locally; CI + CodeRabbit run on the PR.

## Note on bug-1 verification
The mrkdwn rendering happens inside Slack's client, so it can't be screenshotted. Proven by the unit tests (asserting the `<url|Name>` form and label escaping) and the adapter source analysis (plain-text path doesn't escape `<>`).
