### PR TITLE
fix(connections): resolve typecheck errors in #1714 channels consolidation

### DIFF
--- a/packages/server/src/gateway/channels/binding-service.ts
+++ b/packages/server/src/gateway/channels/binding-service.ts
@@ -90,7 +90,7 @@ export class ChannelBindingService {
     agentId: string,
     platform: string,
     channelId: string,
-    teamId?: string,
+    teamId: string | undefined,
 		options: {
 			configuredBy?: string;
 			wasAdmin?: boolean;

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -9,7 +9,7 @@ import { PlatformAdapterConfigSchema } from "../routes/schemas/platform-config.j
 import { isAdapterlessPlatform } from "./chat-instance-manager.js";
 import { getPlatformDescriptor } from "./platforms/index.js";
 import { createSlackWebApi } from "./slack-web.js";
-import type { PlatformAdapterConfig } from "./types.js";
+import { isSlackConfig, type PlatformAdapterConfig } from "./types.js";
 
 const CHAT_LOCK_NAMESPACE = 0x63686174; // "chat"
 
@@ -124,15 +124,17 @@ function parseConfig(
 		);
 	}
 	validateRequiredCredentials(platform, parsed.data);
-	return parsed.data;
+	// The Zod discriminated union and the hand-written `PlatformAdapterConfig`
+	// union are member-for-member equivalent; TS treats the inferred schema type
+	// as distinct only because of declaration order / optional-field variance.
+	return parsed.data as PlatformAdapterConfig;
 }
 
 async function validateProviderIdentity(
-	platform: string,
 	config: PlatformAdapterConfig,
 ): Promise<Record<string, unknown>> {
 	const metadata: Record<string, unknown> = {};
-	if (platform === "slack") {
+	if (isSlackConfig(config)) {
 		const botToken = config.botToken;
 		if (!botToken) throw new Error("Slack bot token is required");
 		const identity = await createSlackWebApi().authTest(botToken);
@@ -193,10 +195,7 @@ export async function upsertByoChatConnection(
 		const settings = { allowGroups: true, ...(input.settings ?? {}) };
 		const existing = existingRows[0];
 		if (!existing) {
-			const providerMetadata = await validateProviderIdentity(
-				input.platform,
-				config,
-			);
+			const providerMetadata = await validateProviderIdentity(config);
 			await orgContext.run({ organizationId: input.organizationId }, () =>
 				manager.addConnection(
 					input.platform,
@@ -264,7 +263,7 @@ export async function upsertByoChatConnection(
 
 		const providerMetadata = matches
 			? {}
-			: await validateProviderIdentity(input.platform, config);
+			: await validateProviderIdentity(config);
 		await orgContext.run({ organizationId: input.organizationId }, () =>
 			manager.updateConnection(input.stableId, {
 				agentId: agentId ?? null,
@@ -321,10 +320,7 @@ export async function updateChatConnection(input: {
 		} as PlatformAdapterConfig;
 		const resolved = await manager.resolveConnectionConfig(runtimeId, merged);
 		const config = parseConfig(row.connector_key, resolved);
-		const providerMetadata = await validateProviderIdentity(
-			row.connector_key,
-			config,
-		);
+		const providerMetadata = await validateProviderIdentity(config);
 		await orgContext.run({ organizationId: input.organizationId }, () =>
 			manager.updateConnection(runtimeId, {
 				config,

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -821,9 +821,14 @@ export class ChatInstanceManager {
 		for (const key of stamped) {
 			if (!(key in config)) delete comparable[key];
 		}
+		// `configsEqual` only reads keys; widen the typed union/interface args to
+		// the plain record shape it compares over.
 		return (
-			configsEqual(comparable, config) &&
-			configsEqual(connection.settings ?? {}, settings) &&
+			configsEqual(comparable, config as Record<string, unknown>) &&
+			configsEqual(
+				(connection.settings ?? {}) as Record<string, unknown>,
+				settings as Record<string, unknown>,
+			) &&
 			(connection.agentId ?? undefined) === (agentId ?? undefined)
 		);
 	}

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -640,7 +640,7 @@ export async function handleCreate(
 				{ action: "get", connection_id: created.connectionId },
 				ctx,
 			);
-			if ("error" in read) return read;
+			if ("error" in read || read.action !== "get") return read;
 			return {
 				action: "create",
 				connection: read.connection,
@@ -1167,7 +1167,7 @@ export async function handleApplyChatConnection(
 			{ action: "get", connection_id: result.connectionId },
 			ctx,
 		);
-		if ("error" in read) return read;
+		if ("error" in read || read.action !== "get") return read;
 		return {
 			action: "apply_chat_connection",
 			connection: read.connection,
@@ -1258,7 +1258,7 @@ export async function handleUpdate(
 				{ action: "get", connection_id: args.connection_id },
 				ctx,
 			);
-			if ("error" in read) return read;
+			if ("error" in read || read.action !== "get") return read;
 			return { action: "update", connection: read.connection };
 		} catch (error) {
 			return { error: getErrorMessage(error) };


### PR DESCRIPTION
The channels→connections consolidation (#1714, `d9cd0d151`) merged with a **red typecheck on main** — CI's typecheck job reports 8 errors across 4 files. This fixes them (type-safety only, no behavior change).

## Errors fixed (from the #1714 CI typecheck run)
- `binding-service.ts:94` — TS1016 required param after optional: `teamId?: string` → `teamId: string | undefined` (all callers already pass it).
- `chat-connection-service.ts:127,136` — `botToken` on the `PlatformAdapterConfig` union: narrow via the existing `isSlackConfig` guard; `parseConfig` returns the (member-for-member equivalent) hand-written union via an explicit cast. Dropped the now-unused `platform` param from `validateProviderIdentity` + its 3 callers.
- `chat-instance-manager.ts:825-826` — widen the typed union/interface args to the `Record<string, unknown>` shape `configsEqual` compares over.
- `manage_connections/crud.ts:646,1173,1262` — narrow `handleGet`'s wide result union on `action === "get"` before reading `.connection` (3 sites).

## Verification
CI typecheck is the authoritative gate (local `make typecheck` mis-resolves `@lobu/core` `.d.ts` due to workspace build-graph state). Letting CI confirm.

Unblocks the gate for org-OAuth PR #1715 (and anything else branched off #1714).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785692792&installation_id=136316292&pr_number=1716&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1716&signature=eaf70e12556b95ed0509c0c0c5f50ce97b6fa6b883dccf04a010d198063ca6b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->