### PR TITLE
feat(nav): bump owletto to Infrastructure nav + reserve infrastructure segment

### DIFF
--- a/packages/server/src/utils/reserved.ts
+++ b/packages/server/src/utils/reserved.ts
@@ -7,6 +7,7 @@ const OWNER_ROUTE_SEGMENTS = [
   'connectors',
   'devices',
   'environments',
+  'infrastructure',
   'memory',
   'members',
   'settings',


### PR DESCRIPTION
Bumps the owletto submodule to include **lobu-ai/owletto#433** (merged): the Infrastructure nav consolidation — merged Environments + Inference Providers into one **Infrastructure** section with path-based **Runtimes / Models** tabs, promoted the Agents roster in the sidebar, and moved devices to user scope (`/account/devices`).

**Server change:** adds `infrastructure` to `OWNER_ROUTE_SEGMENTS` in `packages/server/src/utils/reserved.ts`, kept in sync with owletto's `src/lib/reserved.ts`, so an org or entity type slugged `infrastructure` can't shadow the new static route.

Submodule pointer → `ca5101c` (reachable on owletto `main`).

Pre-commit: biome + `tsc --noEmit` pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785727353&installation_id=136316292&pr_number=1718&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1718&signature=bf422db530b4fc2a329cac6a1570339777a36f0d78e0c2221693222c32198314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->