### PR TITLE
fix(mcp): add outputSchema, structuredContent, and view-resource metadata

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/mcp-app-resources.test.ts
@@ -105,6 +105,32 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     expect(content?.text).toContain('mcp-app-interaction-stub');
   });
 
+  it('advertises description, csp, and domain metadata on resources/list', async () => {
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'resources/list',
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const resource = body.result?.resources?.find(
+      (r: { uri: string }) => r.uri === 'ui://lobu/interaction'
+    );
+    expect(resource).toBeDefined();
+    // description is a typed resource field surfaced in client browsers.
+    expect(typeof resource.description).toBe('string');
+    expect(resource.description.length).toBeGreaterThan(0);
+    // CSP + domain ride the _meta.ui passthrough (host conventions, SDK $loose).
+    expect(resource._meta?.ui?.csp).toMatch(/script-src/);
+    expect(resource._meta?.ui?.domain).toMatch(/^https?:\/\//);
+  });
+
   it('returns a pending manage_agents approval as plain text, without tool-result _meta', async () => {
     const sessionId = await initSession(`/mcp/${org.slug}`);
     const response = await post(`/mcp/${org.slug}`, {
@@ -136,6 +162,38 @@ describe('MCP App resources — ui:// serving (host-authored view)', () => {
     // that points a host at a bundle it can't feed from raw data.
     expect(body.result?._meta?.ui).toBeUndefined();
     expect(body.result?.structuredContent).toBeUndefined();
+    expect(typeof body.result?.content?.[0]?.text).toBe('string');
+  });
+
+  it('emits structuredContent for a tool that declares an outputSchema', async () => {
+    // Contrast with the manage_agents case above: a tool WITH an outputSchema
+    // returns matching structuredContent alongside its text content (MCP spec:
+    // declaring outputSchema implies the result is structured). search_sdk is a
+    // self-contained leaf, so its structuredContent shape is stable.
+    const sessionId = await initSession(`/mcp/${org.slug}`);
+    const response = await post(`/mcp/${org.slug}`, {
+      body: {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'search_sdk', arguments: { query: 'watchers' } },
+      },
+      headers: { 'mcp-session-id': sessionId },
+      token,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.result?.isError).not.toBe(true);
+    expect(body.result?.structuredContent).toEqual(
+      expect.objectContaining({
+        query: 'watchers',
+        match_count: expect.any(Number),
+        results: expect.any(Array),
+      })
+    );
+    // The text content is still present (clients that ignore structuredContent
+    // get the same data as text).
     expect(typeof body.result?.content?.[0]?.text).toBe('string');
   });
 });

--- a/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
@@ -46,19 +46,32 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     const result = await mcpListTools({ token, orgSlug: ownerSlug });
     const byName = new Map<string, any>(result.tools.map((t: any) => [t.name, t]));
     expect(byName.has('execute')).toBe(false);
-    expect(byName.get('query_sdk')?.annotations).toEqual({ readOnlyHint: true, idempotentHint: true });
-    expect(byName.get('run_sdk')?.annotations).toEqual({ destructiveHint: true });
+    // Assert the behavior-relevant hints specifically (not the whole object) so
+    // adding display metadata like `title` doesn't couple this test to it.
+    expect(byName.get('query_sdk')?.annotations?.readOnlyHint).toBe(true);
+    expect(byName.get('query_sdk')?.annotations?.idempotentHint).toBe(true);
+    expect(byName.get('run_sdk')?.annotations?.destructiveHint).toBe(true);
     expect(byName.get('run_sdk')?.inputSchema?.properties?.dry_run).toBeTruthy();
-    expect(byName.get('search_memory')?.annotations).toEqual({
-      readOnlyHint: true,
-      idempotentHint: true,
-    });
-    expect(byName.get('save_memory')?.annotations).toEqual({ destructiveHint: false });
+    expect(byName.get('search_memory')?.annotations?.readOnlyHint).toBe(true);
+    expect(byName.get('search_memory')?.annotations?.idempotentHint).toBe(true);
+    expect(byName.get('save_memory')?.annotations?.destructiveHint).toBe(false);
     expect(byName.has('search_knowledge')).toBe(false);
     expect(byName.has('save_knowledge')).toBe(false);
     expect(byName.has('search')).toBe(false);
     expect(byName.has('query')).toBe(false);
     expect(byName.has('run')).toBe(false);
+  });
+
+  it('surfaces outputSchema on structured tools', async () => {
+    const result = await mcpListTools({ token, orgSlug: ownerSlug });
+    const byName = new Map<string, any>(result.tools.map((t: any) => [t.name, t]));
+
+    // Tools that declare an outputSchema carry it through to the listing...
+    expect(byName.get('search_sdk')?.outputSchema?.type).toBe('object');
+    expect(byName.get('search_memory')?.outputSchema?.type).toBe('object');
+    expect(byName.get('manage_watchers')?.outputSchema).toBeTruthy();
+    // ...while tools without one (text-only results) omit it.
+    expect(byName.get('save_memory')?.outputSchema).toBeUndefined();
   });
 
   it('records query_sql audit rows in the append-only events ledger', async () => {

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -35,9 +35,9 @@ import {
   mcpSessionMap,
 } from './mcp-session-state';
 import { type AuthContext, executeTool, extractAuthContext } from './tools/execute';
-import { getAllTools } from './tools/registry';
+import { getAllTools, getTool } from './tools/registry';
 import { formatToolResult } from './formatting/markdown-formatter';
-import { getConfiguredPublicOrigin } from './utils/public-origin';
+import { resolvePublicOrigin } from './utils/public-origin';
 import { buildWorkspaceInstructions } from './utils/workspace-instructions';
 
 // ---------------------------------------------------------------------------
@@ -125,8 +125,27 @@ const formatRef = { rawJson: false };
  * a deliberate follow-up, so we don't stamp it today.) Adding an app = one
  * entry + its owletto `src/mcp-apps/<dir>` build — no gateway change.
  */
-const MCP_APP_RESOURCES: Record<string, { name: string; appDir: string }> = {
-  'ui://lobu/interaction': { name: 'Interaction', appDir: 'interaction' },
+const MCP_APP_RESOURCES: Record<string, {
+  name: string;
+  /** Surfaced on `resources/list` — clients show it in resource browsers. */
+  description: string;
+  appDir: string;
+  /**
+   * CSP the host should apply to the rendered iframe. The interaction bundle is
+   * postMessage-only (no fetch/XHR/import/remote assets; verified in
+   * `_shared/host.tsx` + `interaction-card.tsx`), so the policy is strict: no
+   * network, scripts/styles same-origin only. Tailwind's runtime style
+   * injection needs `'unsafe-inline'` on `style-src`.
+   */
+  csp: string;
+}> = {
+  'ui://lobu/interaction': {
+    name: 'Interaction',
+    description:
+      'Interactive approval/question/tool-grant cards rendered in a sandboxed iframe; actions ride a `tools/call` back to the host.',
+    appDir: 'interaction',
+    csp: "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'",
+  },
 };
 
 /**
@@ -139,7 +158,11 @@ export const MCP_APP_DIRS: ReadonlySet<string> = new Set(
   Object.values(MCP_APP_RESOURCES).map((r) => r.appDir)
 );
 
-function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
+function createServerForContext(
+  env: Env,
+  authCtx: SessionAuthContext,
+  resolvedOrigin: string
+): Server {
   const server = new Server(
     { name: 'lobu-mcp', version: '0.2.0' },
     {
@@ -184,6 +207,7 @@ function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
       description: t.description,
       inputSchema: t.inputSchema,
       ...(t.annotations && { annotations: t.annotations }),
+      ...(t.outputSchema && { outputSchema: t.outputSchema }),
     }));
 
     return { tools: allTools };
@@ -195,7 +219,16 @@ function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
     resources: Object.entries(MCP_APP_RESOURCES).map(([uri, meta]) => ({
       uri,
       name: meta.name,
+      description: meta.description,
       mimeType: 'text/html',
+      _meta: {
+        ui: {
+          csp: meta.csp,
+          // Origin the host should associate with this UI (the gateway that
+          // serves the bundle + brokers the `tools/call` actions).
+          domain: resolvedOrigin,
+        },
+      },
     })),
   }));
 
@@ -237,6 +270,17 @@ function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
       // MCP hosts (Slack/Claude) needs the SERVER to author that view and stamp
       // it here; that is a deliberate follow-up. Until then we return plain text
       // rather than pointing an external host at a bundle it can't feed.
+      // When the tool declares an `outputSchema`, also return the raw result as
+      // `structuredContent` (MCP spec: declaring outputSchema implies the result
+      // is structured). Tools without one (manage_agents, save_memory, ...) stay
+      // text-only — the schema is coupled to emission, never declared alone.
+      const tool = getTool(name);
+      if (tool?.outputSchema && result && typeof result === 'object') {
+        return {
+          content: [{ type: 'text' as const, text }],
+          structuredContent: result as Record<string, unknown>,
+        };
+      }
       return { content: [{ type: 'text' as const, text }] };
     } catch (error: any) {
       return {
@@ -250,7 +294,7 @@ function createServerForContext(env: Env, authCtx: SessionAuthContext): Server {
 }
 
 function getProtectedResourceUrl(req: Request): string {
-  const baseUrl = getConfiguredPublicOrigin() ?? new URL(req.url).origin;
+  const baseUrl = resolvePublicOrigin(req.url);
   return `${baseUrl}/.well-known/oauth-protected-resource`;
 }
 
@@ -692,7 +736,8 @@ async function syncAgentBinding(
 function createSessionTransport(
   env: Env,
   authCtx: SessionAuthContext,
-  sessionIdGenerator: () => string
+  sessionIdGenerator: () => string,
+  resolvedOrigin: string
 ): { transport: WebStandardStreamableHTTPServerTransport; server: Server } {
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator,
@@ -706,7 +751,7 @@ function createSessionTransport(
       void deletePersistedSession(transport.sessionId);
     }
   };
-  const server = createServerForContext(env, authCtx);
+  const server = createServerForContext(env, authCtx, resolvedOrigin);
   return { transport, server };
 }
 
@@ -882,7 +927,8 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
           const { transport, server } = createSessionTransport(
             c.env,
             recoveredAuthCtx,
-            () => sessionId
+            () => sessionId,
+            resolvePublicOrigin(req.url)
           );
           await server.connect(transport);
           await initializeRecoveredSession(transport, sessionId, req.url);
@@ -927,7 +973,7 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
       authCtx.tokenType !== 'anonymous' &&
       !authCtx.tokenOrganizationId
     ) {
-      const reauthOrigin = getConfiguredPublicOrigin() ?? new URL(req.url).origin;
+      const reauthOrigin = resolvePublicOrigin(req.url);
       const remediation =
         authCtx.tokenType === 'pat'
           ? `Reissue this PAT bound to a workspace with \`lobu token create --org <workspace>\` against ${reauthOrigin}.`
@@ -944,7 +990,12 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
       return buildJsonRpcErrorResponse(bindingError, initialize?.id ?? null, 400);
     }
     await recordMcpClientActivity(c.env, authCtx, req, initialize);
-    const { transport, server } = createSessionTransport(c.env, authCtx, () => randomUUID());
+    const { transport, server } = createSessionTransport(
+      c.env,
+      authCtx,
+      () => randomUUID(),
+      resolvePublicOrigin(req.url)
+    );
     await server.connect(transport);
     const response = await handleAndMaybeConvert(transport, req, wantsSSE);
     await persistSessionState(transport.sessionId, authCtx);

--- a/packages/server/src/tools/admin/index.ts
+++ b/packages/server/src/tools/admin/index.ts
@@ -9,40 +9,51 @@
 
 import type { TSchema } from "@sinclair/typebox";
 import type { Env } from "../../index";
-import { GetContentSchema, getContent } from "../get_content";
-import { GetWatcherSchema, getWatcher } from "../get_watchers";
+import { GetContentSchema, GetContentResultSchema, getContent } from "../get_content";
+import { GetWatcherSchema, GetWatcherResultSchema, getWatcher } from "../get_watchers";
 import type { ToolAnnotations, ToolContext, ToolDefinition } from "../registry";
 import { ManageAgentsSchema, manageAgents } from "./manage_agents";
 import {
+	ManageAuthProfilesResultSchema,
 	ManageAuthProfilesSchema,
 	manageAuthProfiles,
 } from "./manage_auth_profiles";
-import { ManageCatalogSchema, manageCatalog } from "./manage_catalog";
+import { ManageCatalogResultSchema, ManageCatalogSchema, manageCatalog } from "./manage_catalog";
 import {
+	ManageClassifiersResultSchema,
 	ManageClassifiersSchema,
 	manageClassifiers,
 } from "./manage_classifiers";
 import {
+	ManageConnectionsResultSchema,
 	ManageConnectionsSchema,
 	manageConnections,
 } from "./manage_connections";
-import { ManageEntitySchema, manageEntity } from "./manage_entity";
+import { ManageEntitySchema, ManageEntityResultSchema, manageEntity } from "./manage_entity";
 import {
+	ManageEntitySchemaResultSchema,
 	ManageEntitySchemaSchema,
 	manageEntitySchema,
 } from "./manage_entity_schema";
-import { ManageFeedsSchema, manageFeeds } from "./manage_feeds";
-import { ManageOperationsSchema, manageOperations } from "./manage_operations";
+import { ManageFeedsResultSchema, ManageFeedsSchema, manageFeeds } from "./manage_feeds";
+import {
+	ManageOperationsResultSchema,
+	ManageOperationsSchema,
+	manageOperations,
+} from "./manage_operations";
 import { ManageSchedulesSchema, manageSchedules } from "./manage_schedules";
 import {
+	ManageViewTemplatesResultSchema,
 	ManageViewTemplatesSchema,
 	manageViewTemplates,
 } from "./manage_view_templates";
 import {
 	ListWatchersSchema,
 	listWatchers,
+	ListWatchersResultSchema,
 	ManageWatchersSchema,
 	manageWatchers,
+	ManageWatchersResultSchema,
 } from "./manage_watchers";
 import { NotifySchema, notify } from "./notify";
 
@@ -53,6 +64,13 @@ interface AdminToolEntry {
 	handler: (args: any, env: Env, ctx: ToolContext) => Promise<unknown>;
 	/** Defaults to `{ destructiveHint: false, idempotentHint: false }`. */
 	annotations?: ToolAnnotations;
+	/**
+	 * TypeBox schema describing the tool's structured result; surfaced as
+	 * `outputSchema` on the MCP tool listing and paired with `structuredContent`
+	 * on `tools/call`. Hand-derive the TS result type via `Static<>` from the
+	 * same schema so there's one source of truth.
+	 */
+	resultSchema?: TSchema;
 }
 
 const READ_ONLY: ToolAnnotations = { readOnlyHint: true, idempotentHint: true };
@@ -66,6 +84,7 @@ const ENTRIES: AdminToolEntry[] = [
 		name: "manage_entity",
 		description: "Entity management. SDK alternative: client.entities.",
 		schema: ManageEntitySchema,
+		resultSchema: ManageEntityResultSchema,
 		handler: manageEntity,
 		annotations: WRITE_WITH_TITLE("Manage entities"),
 	},
@@ -74,6 +93,7 @@ const ENTRIES: AdminToolEntry[] = [
 		description:
 			"Entity-type schema management. SDK alternative: client.entitySchema.",
 		schema: ManageEntitySchemaSchema,
+		resultSchema: ManageEntitySchemaResultSchema,
 		handler: manageEntitySchema,
 		annotations: WRITE_WITH_TITLE("Manage entity schemas"),
 	},
@@ -81,6 +101,7 @@ const ENTRIES: AdminToolEntry[] = [
 		name: "manage_connections",
 		description: "Connection management. SDK alternative: client.connections.",
 		schema: ManageConnectionsSchema,
+		resultSchema: ManageConnectionsResultSchema,
 		handler: manageConnections,
 		annotations: WRITE_WITH_TITLE("Manage connections"),
 	},
@@ -88,6 +109,7 @@ const ENTRIES: AdminToolEntry[] = [
 		name: "manage_catalog",
 		description: "Global catalog manifests and org/agent installed inventory.",
 		schema: ManageCatalogSchema,
+		resultSchema: ManageCatalogResultSchema,
 		handler: manageCatalog,
 		annotations: READ_ONLY_WITH_TITLE("Manage catalog"),
 	},
@@ -102,6 +124,7 @@ const ENTRIES: AdminToolEntry[] = [
 		name: "manage_feeds",
 		description: "Feed management. SDK alternative: client.feeds.",
 		schema: ManageFeedsSchema,
+		resultSchema: ManageFeedsResultSchema,
 		handler: manageFeeds,
 		annotations: WRITE_WITH_TITLE("Manage feeds"),
 	},
@@ -110,6 +133,7 @@ const ENTRIES: AdminToolEntry[] = [
 		description:
 			"Auth-profile management. SDK alternative: client.authProfiles.",
 		schema: ManageAuthProfilesSchema,
+		resultSchema: ManageAuthProfilesResultSchema,
 		handler: manageAuthProfiles,
 		annotations: WRITE_WITH_TITLE("Manage auth profiles"),
 	},
@@ -118,6 +142,7 @@ const ENTRIES: AdminToolEntry[] = [
 		description:
 			"Operation execution / approval. SDK alternative: client.operations.",
 		schema: ManageOperationsSchema,
+		resultSchema: ManageOperationsResultSchema,
 		handler: manageOperations,
 		annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: true, title: "Manage operations" },
 	},
@@ -141,6 +166,7 @@ const ENTRIES: AdminToolEntry[] = [
 		name: "manage_watchers",
 		description: "Watcher management. SDK alternative: client.watchers.",
 		schema: ManageWatchersSchema,
+		resultSchema: ManageWatchersResultSchema,
 		handler: manageWatchers,
 		annotations: WRITE_WITH_TITLE("Manage watchers"),
 	},
@@ -148,6 +174,7 @@ const ENTRIES: AdminToolEntry[] = [
 		name: "list_watchers",
 		description: "List watchers. SDK alternative: client.watchers.list.",
 		schema: ListWatchersSchema,
+		resultSchema: ListWatchersResultSchema,
 		handler: listWatchers,
 		annotations: READ_ONLY_WITH_TITLE("List watchers"),
 	},
@@ -156,6 +183,7 @@ const ENTRIES: AdminToolEntry[] = [
 		description:
 			"Watcher detail + windows. SDK alternative: client.watchers.get.",
 		schema: GetWatcherSchema,
+		resultSchema: GetWatcherResultSchema,
 		handler: getWatcher,
 		annotations: READ_ONLY_WITH_TITLE("Get watcher"),
 	},
@@ -164,6 +192,7 @@ const ENTRIES: AdminToolEntry[] = [
 		description:
 			"Read content/memory. SDK alternatives: search_memory, client.knowledge.search.",
 		schema: GetContentSchema,
+		resultSchema: GetContentResultSchema,
 		handler: getContent,
 		annotations: READ_ONLY_WITH_TITLE("Read knowledge"),
 	},
@@ -171,6 +200,7 @@ const ENTRIES: AdminToolEntry[] = [
 		name: "manage_classifiers",
 		description: "Classifier management. SDK alternative: client.classifiers.",
 		schema: ManageClassifiersSchema,
+		resultSchema: ManageClassifiersResultSchema,
 		handler: manageClassifiers,
 		annotations: WRITE_WITH_TITLE("Manage classifiers"),
 	},
@@ -179,6 +209,7 @@ const ENTRIES: AdminToolEntry[] = [
 		description:
 			"View-template management. SDK alternative: client.viewTemplates.",
 		schema: ManageViewTemplatesSchema,
+		resultSchema: ManageViewTemplatesResultSchema,
 		handler: manageViewTemplates,
 		annotations: WRITE_WITH_TITLE("Manage view templates"),
 	},
@@ -189,5 +220,6 @@ export const ADMIN_TOOLS: ToolDefinition[] = ENTRIES.map((entry) => ({
 	description: entry.description,
 	inputSchema: entry.schema,
 	annotations: entry.annotations ?? WRITE,
+	...(entry.resultSchema && { outputSchema: entry.resultSchema }),
 	handler: entry.handler,
 }));

--- a/packages/server/src/tools/admin/index.ts
+++ b/packages/server/src/tools/admin/index.ts
@@ -51,12 +51,15 @@ interface AdminToolEntry {
 	description: string;
 	schema: TSchema;
 	handler: (args: any, env: Env, ctx: ToolContext) => Promise<unknown>;
-	/** Defaults to `{ destructiveHint: false }`. */
+	/** Defaults to `{ destructiveHint: false, idempotentHint: false }`. */
 	annotations?: ToolAnnotations;
 }
 
 const READ_ONLY: ToolAnnotations = { readOnlyHint: true, idempotentHint: true };
-const WRITE: ToolAnnotations = { destructiveHint: false };
+const WRITE: ToolAnnotations = { destructiveHint: false, idempotentHint: false };
+
+const WRITE_WITH_TITLE = (title: string): ToolAnnotations => ({ ...WRITE, title });
+const READ_ONLY_WITH_TITLE = (title: string): ToolAnnotations => ({ ...READ_ONLY, title });
 
 const ENTRIES: AdminToolEntry[] = [
 	{
@@ -64,6 +67,7 @@ const ENTRIES: AdminToolEntry[] = [
 		description: "Entity management. SDK alternative: client.entities.",
 		schema: ManageEntitySchema,
 		handler: manageEntity,
+		annotations: WRITE_WITH_TITLE("Manage entities"),
 	},
 	{
 		name: "manage_entity_schema",
@@ -71,31 +75,35 @@ const ENTRIES: AdminToolEntry[] = [
 			"Entity-type schema management. SDK alternative: client.entitySchema.",
 		schema: ManageEntitySchemaSchema,
 		handler: manageEntitySchema,
+		annotations: WRITE_WITH_TITLE("Manage entity schemas"),
 	},
 	{
 		name: "manage_connections",
 		description: "Connection management. SDK alternative: client.connections.",
 		schema: ManageConnectionsSchema,
 		handler: manageConnections,
+		annotations: WRITE_WITH_TITLE("Manage connections"),
 	},
 	{
 		name: "manage_catalog",
 		description: "Global catalog manifests and org/agent installed inventory.",
 		schema: ManageCatalogSchema,
 		handler: manageCatalog,
-		annotations: READ_ONLY,
+		annotations: READ_ONLY_WITH_TITLE("Manage catalog"),
 	},
 	{
 		name: "manage_agents",
 		description: "Agent management (incl. the org system agent pointer).",
 		schema: ManageAgentsSchema,
 		handler: manageAgents,
+		annotations: WRITE_WITH_TITLE("Manage agents"),
 	},
 	{
 		name: "manage_feeds",
 		description: "Feed management. SDK alternative: client.feeds.",
 		schema: ManageFeedsSchema,
 		handler: manageFeeds,
+		annotations: WRITE_WITH_TITLE("Manage feeds"),
 	},
 	{
 		name: "manage_auth_profiles",
@@ -103,6 +111,7 @@ const ENTRIES: AdminToolEntry[] = [
 			"Auth-profile management. SDK alternative: client.authProfiles.",
 		schema: ManageAuthProfilesSchema,
 		handler: manageAuthProfiles,
+		annotations: WRITE_WITH_TITLE("Manage auth profiles"),
 	},
 	{
 		name: "manage_operations",
@@ -110,7 +119,7 @@ const ENTRIES: AdminToolEntry[] = [
 			"Operation execution / approval. SDK alternative: client.operations.",
 		schema: ManageOperationsSchema,
 		handler: manageOperations,
-		annotations: { destructiveHint: false, openWorldHint: true },
+		annotations: { destructiveHint: false, idempotentHint: false, openWorldHint: true, title: "Manage operations" },
 	},
 	{
 		name: "notify",
@@ -118,7 +127,7 @@ const ENTRIES: AdminToolEntry[] = [
 			"Send a notification to org users (admins / all / specific user ids).",
 		schema: NotifySchema,
 		handler: notify,
-		annotations: { destructiveHint: false },
+		annotations: WRITE_WITH_TITLE("Send notification"),
 	},
 	{
 		name: "manage_schedules",
@@ -126,20 +135,21 @@ const ENTRIES: AdminToolEntry[] = [
 			"Create / list / pause / cancel recurring or one-shot scheduled jobs. Supports send_notification and wake_agent action types. Per-row attribution lets you trace what scheduled it and from where.",
 		schema: ManageSchedulesSchema,
 		handler: manageSchedules,
-		annotations: { destructiveHint: false },
+		annotations: WRITE_WITH_TITLE("Manage schedules"),
 	},
 	{
 		name: "manage_watchers",
 		description: "Watcher management. SDK alternative: client.watchers.",
 		schema: ManageWatchersSchema,
 		handler: manageWatchers,
+		annotations: WRITE_WITH_TITLE("Manage watchers"),
 	},
 	{
 		name: "list_watchers",
 		description: "List watchers. SDK alternative: client.watchers.list.",
 		schema: ListWatchersSchema,
 		handler: listWatchers,
-		annotations: READ_ONLY,
+		annotations: READ_ONLY_WITH_TITLE("List watchers"),
 	},
 	{
 		name: "get_watcher",
@@ -147,7 +157,7 @@ const ENTRIES: AdminToolEntry[] = [
 			"Watcher detail + windows. SDK alternative: client.watchers.get.",
 		schema: GetWatcherSchema,
 		handler: getWatcher,
-		annotations: READ_ONLY,
+		annotations: READ_ONLY_WITH_TITLE("Get watcher"),
 	},
 	{
 		name: "read_knowledge",
@@ -155,13 +165,14 @@ const ENTRIES: AdminToolEntry[] = [
 			"Read content/memory. SDK alternatives: search_memory, client.knowledge.search.",
 		schema: GetContentSchema,
 		handler: getContent,
-		annotations: READ_ONLY,
+		annotations: READ_ONLY_WITH_TITLE("Read knowledge"),
 	},
 	{
 		name: "manage_classifiers",
 		description: "Classifier management. SDK alternative: client.classifiers.",
 		schema: ManageClassifiersSchema,
 		handler: manageClassifiers,
+		annotations: WRITE_WITH_TITLE("Manage classifiers"),
 	},
 	{
 		name: "manage_view_templates",
@@ -169,6 +180,7 @@ const ENTRIES: AdminToolEntry[] = [
 			"View-template management. SDK alternative: client.viewTemplates.",
 		schema: ManageViewTemplatesSchema,
 		handler: manageViewTemplates,
+		annotations: WRITE_WITH_TITLE("Manage view templates"),
 	},
 ];
 

--- a/packages/server/src/tools/admin/manage_auth_profiles.ts
+++ b/packages/server/src/tools/admin/manage_auth_profiles.ts
@@ -151,35 +151,59 @@ const SetDefaultAuthProfileAction = Type.Object({
 // Result Types
 // ============================================
 
-type ManageAuthProfilesResult =
-  | { error: string }
-  | { action: 'list_auth_profiles'; auth_profiles: any[] }
-  | { action: 'get_auth_profile'; auth_profile: any }
-  | {
-      action: 'test_auth_profile';
-      status: 'ok' | 'warning' | 'error';
-      message: string;
-      expires_at?: string | null;
-      cookie_count?: number;
-      auth_cookie_name?: string | null;
-      is_expired?: boolean;
-      cdp_url?: string | null;
-      auth_mode?: 'cdp' | 'cookies' | 'empty';
-    }
-  | {
-      action: 'create_auth_profile';
-      auth_profile?: any;
-      pending_slug?: string;
-      connect_url?: string;
-      connect_token?: string;
-    }
-  | { action: 'update_auth_profile'; auth_profile: any; connect_url?: string }
-  | { action: 'delete_auth_profile'; deleted: true; auth_profile_slug: string }
-  | {
-      action: 'set_default_auth_profile';
-      connector_key: string;
-      auth_profile: any | null;
-    };
+/**
+ * Result of `manage_auth_profiles` — discriminated union (on `action`, plus an
+ * error variant). TypeBox-first: `Static<>` derives the TS type from the same
+ * schema exposed as the tool's `outputSchema`. Auth-profile rows are wide
+ * snapshots (varied by connector), so they're honestly `Record<string, unknown>`.
+ */
+export const ManageAuthProfilesResultSchema = Type.Union([
+  Type.Object({ error: Type.String() }),
+  Type.Object({
+    action: Type.Literal('list_auth_profiles'),
+    auth_profiles: Type.Array(Type.Record(Type.String(), Type.Unknown())),
+  }),
+  Type.Object({
+    action: Type.Literal('get_auth_profile'),
+    auth_profile: Type.Record(Type.String(), Type.Unknown()),
+  }),
+  Type.Object({
+    action: Type.Literal('test_auth_profile'),
+    status: Type.Union([Type.Literal('ok'), Type.Literal('warning'), Type.Literal('error')]),
+    message: Type.String(),
+    expires_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    cookie_count: Type.Optional(Type.Integer()),
+    auth_cookie_name: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    is_expired: Type.Optional(Type.Boolean()),
+    cdp_url: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    auth_mode: Type.Optional(
+      Type.Union([Type.Literal('cdp'), Type.Literal('cookies'), Type.Literal('empty')])
+    ),
+  }),
+  Type.Object({
+    action: Type.Literal('create_auth_profile'),
+    auth_profile: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+    pending_slug: Type.Optional(Type.String()),
+    connect_url: Type.Optional(Type.String()),
+    connect_token: Type.Optional(Type.String()),
+  }),
+  Type.Object({
+    action: Type.Literal('update_auth_profile'),
+    auth_profile: Type.Record(Type.String(), Type.Unknown()),
+    connect_url: Type.Optional(Type.String()),
+  }),
+  Type.Object({
+    action: Type.Literal('delete_auth_profile'),
+    deleted: Type.Literal(true),
+    auth_profile_slug: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal('set_default_auth_profile'),
+    connector_key: Type.String(),
+    auth_profile: Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()]),
+  }),
+]);
+type ManageAuthProfilesResult = Static<typeof ManageAuthProfilesResultSchema>;
 
 /**
  * Standard "auth profile not found" error result. Centralizes the message that

--- a/packages/server/src/tools/admin/manage_auth_profiles.ts
+++ b/packages/server/src/tools/admin/manage_auth_profiles.ts
@@ -61,7 +61,7 @@ const ListAuthProfilesAction = Type.Object({
       Type.Literal('oauth_app'),
       Type.Literal('oauth_account'),
       Type.Literal('browser_session'),
-    ])
+    ], { description: 'Filter by auth profile kind' })
   ),
 });
 

--- a/packages/server/src/tools/admin/manage_catalog.ts
+++ b/packages/server/src/tools/admin/manage_catalog.ts
@@ -1,4 +1,4 @@
-import { Type } from "@sinclair/typebox";
+import { type Static, Type } from "@sinclair/typebox";
 import { listAgentInstalled, listOrgInstalled } from "../../catalog/installed";
 import { listCatalogEntries } from "../../catalog/load";
 import { buildCatalogListResponse } from "../../catalog/responses";
@@ -53,6 +53,31 @@ export const ManageCatalogSchema = Type.Union([
 	ListInstalledAction,
 ]);
 
+/**
+ * Result of `manage_catalog` — discriminated union (on `action`, plus an error
+ * variant). TypeBox-first: `Static<>` derives the TS type from the same schema
+ * exposed as the tool's `outputSchema`. Catalog/installed entries are
+ * descriptor-shaped and vary by kind, so they're honestly `unknown`.
+ */
+export const ManageCatalogResultSchema = Type.Union([
+	Type.Object({ error: Type.String() }),
+	Type.Object({
+		action: Type.Literal("list_catalog"),
+		catalogs: Type.Record(
+			Type.String(),
+			Type.Object({
+				kind: Type.String(),
+				entries: Type.Array(Type.Unknown()),
+			})
+		),
+	}),
+	Type.Object({
+		action: Type.Literal("list_installed"),
+		installed: Type.Record(Type.String(), Type.Unknown()),
+	}),
+]);
+export type ManageCatalogResult = Static<typeof ManageCatalogResultSchema>;
+
 export type ListCatalogArgs = {
 	action: "list_catalog";
 	kinds?: CatalogKind[];
@@ -65,7 +90,7 @@ export type ListInstalledArgs = {
 	include_catalog?: boolean;
 };
 
-async function handleListCatalog(args: ListCatalogArgs): Promise<unknown> {
+async function handleListCatalog(args: ListCatalogArgs): Promise<ManageCatalogResult> {
 	const kinds = args.kinds?.length ? args.kinds : [...CATALOG_KINDS];
 	const all = await listCatalogEntries(kinds);
 	return {
@@ -77,7 +102,7 @@ async function handleListCatalog(args: ListCatalogArgs): Promise<unknown> {
 async function handleListInstalled(
 	args: ListInstalledArgs,
 	ctx: ToolContext,
-): Promise<unknown> {
+): Promise<ManageCatalogResult> {
 	const requestedKinds = args.kinds?.length ? args.kinds : undefined;
 	const isAgentKind = (k: string): k is AgentInstalledKind =>
 		(AGENT_INSTALLED_KINDS as readonly string[]).includes(k);

--- a/packages/server/src/tools/admin/manage_classifiers.ts
+++ b/packages/server/src/tools/admin/manage_classifiers.ts
@@ -141,12 +141,18 @@ export const ManageClassifiersSchema = Type.Object({
 
 type ManageClassifiersArgs = Static<typeof ManageClassifiersSchema>;
 
-type ManageClassifiersResult = {
-  success: boolean;
-  action: string;
-  message?: string;
-  data?: any;
-};
+/**
+ * Result of `manage_classifiers`. TypeBox-first: `Static<>` derives the TS type
+ * from the same schema exposed as the tool's `outputSchema`. `data` is an
+ * arbitrary payload (varies by action) so it's honestly `unknown`.
+ */
+export const ManageClassifiersResultSchema = Type.Object({
+  success: Type.Boolean(),
+  action: Type.String(),
+  message: Type.Optional(Type.String()),
+  data: Type.Optional(Type.Unknown()),
+});
+type ManageClassifiersResult = Static<typeof ManageClassifiersResultSchema>;
 
 // ============================================
 // Helpers

--- a/packages/server/src/tools/admin/manage_connections.ts
+++ b/packages/server/src/tools/admin/manage_connections.ts
@@ -137,3 +137,5 @@ const manageConnectionsTool = defineActionTool("manage_connections", {
 
 export const ManageConnectionsSchema = manageConnectionsTool.schema;
 export const manageConnections = manageConnectionsTool.run;
+// Re-export so the admin registry entry can wire `outputSchema`.
+export { ManageConnectionsResultSchema } from "./manage_connections/schemas";

--- a/packages/server/src/tools/admin/manage_connections/schemas.ts
+++ b/packages/server/src/tools/admin/manage_connections/schemas.ts
@@ -14,6 +14,20 @@ export interface ChannelBindingDto {
 	createdAt: number;
 }
 
+const ChannelBindingDtoSchema = Type.Object({
+	platform: Type.String(),
+	channelId: Type.String(),
+	teamId: Type.Optional(Type.String()),
+	createdAt: Type.Integer(),
+});
+
+const ConnectionFacetsSchema = Type.Object({
+	data: Type.Boolean(),
+	chat: Type.Boolean(),
+	actions: Type.Boolean(),
+	audience: Type.Boolean(),
+});
+
 // ============================================
 // Schema
 // ============================================
@@ -415,125 +429,183 @@ export interface ConnectionFacets {
 	audience: boolean;
 }
 
-export type ManageConnectionsResult =
-	| { error: string; setup_url?: string }
-	| {
-			action: "list";
-			connections: ConnectionRow[];
-			total: number;
-			limit: number;
-			offset: number;
-			view_url?: string;
-	  }
-	| {
-			action: "list_connector_groups";
-			groups: Array<{
-				connector_key: string;
-				connector_name: string | null;
-				favicon_domain: string | null;
-				connection_count: number;
-				facets: ConnectionFacets;
-				connections: Array<{
-					id: number;
-					display_name: string | null;
-					feed_count: number;
-				}>;
-			}>;
-	  }
-	| { action: "get"; connection: ConnectionRow; view_url?: string }
-	| {
-			action: "create";
-			connection: ConnectionRow;
-			connector: Record<string, unknown>;
-			view_url?: string;
-			auth_run_id?: number;
-	  }
-	| {
-			action: "connect";
-			connection_id: number;
-			slug?: string;
-			status: "active";
-			message: string;
-			view_url?: string;
-	  }
-	| {
-			action: "connect";
-			connection_id: number;
-			slug?: string;
-			status: "pending_auth";
-			auth_type: string;
-			instructions: string;
-			connect_url?: string;
-			connect_token?: string;
-			auth_profile_slug?: string;
-			view_url?: string;
-	  }
-	| { action: "update"; connection: ConnectionRow }
-	| {
-			action: "apply_chat_connection";
-			connection: ConnectionRow;
-			created: boolean;
-			changed: boolean;
-	  }
-	| { action: "delete"; deleted: true; connection_id: number; slug: string }
-	| { action: "reauthenticate"; connection_id: number; auth_run_id: number }
-	| {
-			action: "test";
-			status: string;
-			message: string;
-			has_token?: boolean;
-			has_refresh?: boolean;
-			expires_at?: string | null;
-	  }
-	| {
-			action: "install_connector";
-			installed: true;
-			connector_key: string;
-			name: string;
-			version: string;
-			code_hash: string;
-			updated: boolean;
-	  }
-	| { action: "uninstall_connector"; uninstalled: true; connector_key: string }
-	| ConnectorActionOk<"toggle_connector_login", { login_enabled: boolean }>
-	| ConnectorActionOk<"update_connector_auth", { keys_updated: string[] }>
-	| ConnectorActionOk<"update_connector_default_config">
-	| ConnectorActionOk<
-			"update_connector_default_repair_agent",
-			{ default_repair_agent_id: string | null }
-	  >
-	| ConnectorActionOk<
-			"set_connector_entity_link_overrides",
-			{ overrides: Record<string, unknown> | null }
-	  >
-	| {
-			action: "list_channel_bindings";
-			agent_id: string;
-			bindings: ChannelBindingDto[];
-	  }
-	| {
-			action: "bind_channel";
-			success: true;
-			agent_id: string;
-			connection_id: number;
-			platform: string;
-			channel_id: string;
-			team_id?: string;
-	  }
-	| { action: "unbind_channel"; success: true }
-	| {
-			action: "sync_channel_bindings";
-			success: true;
-			bound: string[];
-			removed: string[];
-	  }
-	| {
-			action: "connect_channel_dm";
-			success: true;
-			platform: "slack";
-			channel_id: string;
-			team_id: string | null;
-	  };
+/**
+ * Result of `manage_connections` — discriminated union keyed on `action`
+ * (plus an error variant). TypeBox-first: `Static<>` derives the TS type from
+ * the same schema exposed as the tool's `outputSchema`. Connection rows are
+ * wide snapshots, so `ConnectionRow` stays `Record<string, unknown>`.
+ */
+const ConnectorGroupSchema = Type.Object({
+	connector_key: Type.String(),
+	connector_name: Type.Union([Type.String(), Type.Null()]),
+	favicon_domain: Type.Union([Type.String(), Type.Null()]),
+	connection_count: Type.Integer(),
+	facets: ConnectionFacetsSchema,
+	connections: Type.Array(
+		Type.Object({
+			id: Type.Integer(),
+			display_name: Type.Union([Type.String(), Type.Null()]),
+			feed_count: Type.Integer(),
+		})
+	),
+});
+
+export const ManageConnectionsResultSchema = Type.Union([
+	Type.Object({ error: Type.String(), setup_url: Type.Optional(Type.String()) }),
+	Type.Object({
+		action: Type.Literal("list"),
+		connections: Type.Array(Type.Record(Type.String(), Type.Unknown())),
+		total: Type.Integer(),
+		limit: Type.Integer(),
+		offset: Type.Integer(),
+		view_url: Type.Optional(Type.String()),
+	}),
+	Type.Object({
+		action: Type.Literal("list_connector_groups"),
+		groups: Type.Array(ConnectorGroupSchema),
+	}),
+	Type.Object({
+		action: Type.Literal("get"),
+		connection: Type.Record(Type.String(), Type.Unknown()),
+		view_url: Type.Optional(Type.String()),
+	}),
+	Type.Object({
+		action: Type.Literal("create"),
+		connection: Type.Record(Type.String(), Type.Unknown()),
+		connector: Type.Record(Type.String(), Type.Unknown()),
+		view_url: Type.Optional(Type.String()),
+		auth_run_id: Type.Optional(Type.Integer()),
+	}),
+	Type.Object({
+		action: Type.Literal("connect"),
+		connection_id: Type.Integer(),
+		slug: Type.Optional(Type.String()),
+		status: Type.Literal("active"),
+		message: Type.String(),
+		view_url: Type.Optional(Type.String()),
+	}),
+	Type.Object({
+		action: Type.Literal("connect"),
+		connection_id: Type.Integer(),
+		slug: Type.Optional(Type.String()),
+		status: Type.Literal("pending_auth"),
+		auth_type: Type.String(),
+		instructions: Type.String(),
+		connect_url: Type.Optional(Type.String()),
+		connect_token: Type.Optional(Type.String()),
+		auth_profile_slug: Type.Optional(Type.String()),
+		view_url: Type.Optional(Type.String()),
+	}),
+	Type.Object({
+		action: Type.Literal("update"),
+		connection: Type.Record(Type.String(), Type.Unknown()),
+	}),
+	Type.Object({
+		action: Type.Literal("apply_chat_connection"),
+		connection: Type.Record(Type.String(), Type.Unknown()),
+		created: Type.Boolean(),
+		changed: Type.Boolean(),
+	}),
+	Type.Object({
+		action: Type.Literal("delete"),
+		deleted: Type.Literal(true),
+		connection_id: Type.Integer(),
+		slug: Type.String(),
+	}),
+	Type.Object({
+		action: Type.Literal("reauthenticate"),
+		connection_id: Type.Integer(),
+		auth_run_id: Type.Integer(),
+	}),
+	Type.Object({
+		action: Type.Literal("test"),
+		status: Type.String(),
+		message: Type.String(),
+		has_token: Type.Optional(Type.Boolean()),
+		has_refresh: Type.Optional(Type.Boolean()),
+		expires_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	}),
+	Type.Object({
+		action: Type.Literal("install_connector"),
+		installed: Type.Literal(true),
+		connector_key: Type.String(),
+		name: Type.String(),
+		version: Type.String(),
+		code_hash: Type.String(),
+		updated: Type.Boolean(),
+	}),
+	Type.Object({
+		action: Type.Literal("uninstall_connector"),
+		uninstalled: Type.Literal(true),
+		connector_key: Type.String(),
+	}),
+	// ConnectorActionOk<"toggle_connector_login", { login_enabled: boolean }>
+	Type.Object({
+		action: Type.Literal("toggle_connector_login"),
+		success: Type.Literal(true),
+		connector_key: Type.String(),
+		login_enabled: Type.Boolean(),
+	}),
+	// ConnectorActionOk<"update_connector_auth", { keys_updated: string[] }>
+	Type.Object({
+		action: Type.Literal("update_connector_auth"),
+		success: Type.Literal(true),
+		connector_key: Type.String(),
+		keys_updated: Type.Array(Type.String()),
+	}),
+	// ConnectorActionOk<"update_connector_default_config">
+	Type.Object({
+		action: Type.Literal("update_connector_default_config"),
+		success: Type.Literal(true),
+		connector_key: Type.String(),
+	}),
+	// ConnectorActionOk<"update_connector_default_repair_agent", { default_repair_agent_id: string | null }>
+	Type.Object({
+		action: Type.Literal("update_connector_default_repair_agent"),
+		success: Type.Literal(true),
+		connector_key: Type.String(),
+		default_repair_agent_id: Type.Union([Type.String(), Type.Null()]),
+	}),
+	// ConnectorActionOk<"set_connector_entity_link_overrides", { overrides: Record<string, unknown> | null }>
+	Type.Object({
+		action: Type.Literal("set_connector_entity_link_overrides"),
+		success: Type.Literal(true),
+		connector_key: Type.String(),
+		overrides: Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()]),
+	}),
+	Type.Object({
+		action: Type.Literal("list_channel_bindings"),
+		agent_id: Type.String(),
+		bindings: Type.Array(ChannelBindingDtoSchema),
+	}),
+	Type.Object({
+		action: Type.Literal("bind_channel"),
+		success: Type.Literal(true),
+		agent_id: Type.String(),
+		connection_id: Type.Integer(),
+		platform: Type.String(),
+		channel_id: Type.String(),
+		team_id: Type.Optional(Type.String()),
+	}),
+	Type.Object({
+		action: Type.Literal("unbind_channel"),
+		success: Type.Literal(true),
+	}),
+	Type.Object({
+		action: Type.Literal("sync_channel_bindings"),
+		success: Type.Literal(true),
+		bound: Type.Array(Type.String()),
+		removed: Type.Array(Type.String()),
+	}),
+	Type.Object({
+		action: Type.Literal("connect_channel_dm"),
+		success: Type.Literal(true),
+		platform: Type.Literal("slack"),
+		channel_id: Type.String(),
+		team_id: Type.Union([Type.String(), Type.Null()]),
+	}),
+]);
+export type ManageConnectionsResult = Static<typeof ManageConnectionsResultSchema>;
 
 /**
  * Union of all action variants. Defined from the variants directly (rather

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -225,155 +225,169 @@ type ManageEntityArgs = Static<typeof ManageEntitySchema>;
 // ============================================
 
 // Relationship row shape (used by link actions)
-interface RelationshipRow {
-  id: number;
-  organization_id: string;
-  from_entity_id: number;
-  to_entity_id: number;
-  relationship_type_id: number;
-  relationship_type_slug: string;
-  relationship_type_name: string;
-  is_symmetric: boolean;
-  from_entity_name?: string;
-  from_entity_type?: string;
-  to_entity_name?: string;
-  to_entity_type?: string;
-  metadata?: Record<string, unknown> | null;
-  confidence: number;
-  source: string;
-  created_by?: string | null;
-  updated_by?: string | null;
-  created_at: string;
-  updated_at: string;
-  deleted_at?: string | null;
-}
+const RelationshipRowSchema = Type.Object({
+  id: Type.Integer(),
+  organization_id: Type.String(),
+  from_entity_id: Type.Integer(),
+  to_entity_id: Type.Integer(),
+  relationship_type_id: Type.Integer(),
+  relationship_type_slug: Type.String(),
+  relationship_type_name: Type.String(),
+  is_symmetric: Type.Boolean(),
+  from_entity_name: Type.Optional(Type.String()),
+  from_entity_type: Type.Optional(Type.String()),
+  to_entity_name: Type.Optional(Type.String()),
+  to_entity_type: Type.Optional(Type.String()),
+  metadata: Type.Optional(Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])),
+  confidence: Type.Number(),
+  source: Type.String(),
+  created_by: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  updated_by: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  created_at: Type.String(),
+  updated_at: Type.String(),
+  deleted_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+});
+type RelationshipRow = Static<typeof RelationshipRowSchema>;
 
-interface RelationshipCountByType {
-  relationship_type_slug: string;
-  relationship_type_name: string;
-  count: number;
-}
+const RelationshipCountByTypeSchema = Type.Object({
+  relationship_type_slug: Type.String(),
+  relationship_type_name: Type.String(),
+  count: Type.Integer(),
+});
+type RelationshipCountByType = Static<typeof RelationshipCountByTypeSchema>;
 
-type ManageEntityResult =
-  | {
-      action: 'create';
-      entity: {
-        id: number;
-        entity_type: string;
-        name: string;
-        slug: string;
-        parent_id?: number | null;
-        parent_name?: string | null;
-        parent_slug?: string | null;
-        metadata?: Record<string, any>;
-        enabled_classifiers?: string[] | null;
-        created_at: string;
-        view_url?: string;
-      };
-      warnings?: string[];
-      next_steps: string[];
-    }
-  | {
-      action: 'update';
-      entity: {
-        id: number;
-        entity_type: string;
-        name: string;
-        slug: string;
-        parent_id?: number | null;
-        parent_name?: string | null;
-        parent_slug?: string | null;
-        metadata?: Record<string, any>;
-        enabled_classifiers?: string[] | null;
-        view_url?: string;
-      };
-      /** Fields the ownership-aware merge wrote (unowned for a watcher-source edit). */
-      applied_fields?: string[];
-      /** Human-owned fields the edit was blocked from writing — queued for approval. */
-      blocked_fields?: string[];
-      /** True when a blocked-field approval was queued this call. */
-      approval_queued?: boolean;
-      /** Permalink to the approval card, when one was queued. */
-      approval_url?: string;
-      /** Pending approval run id — the worker bridges this into a live chat
-       *  approval card (parity with manage_agents' `pending_approval`). */
-      approval_run_id?: number;
-      /** Blocked field_path -> proposed value, for the live card diff. */
-      approval_fields?: Record<string, unknown>;
-      /** Blocked field_path -> current human-owned value, for the diff. */
-      approval_current?: Record<string, unknown>;
-      /** Who proposed the blocked change: 'agent' | 'watcher'. */
-      approval_attribution?: 'agent' | 'watcher';
-    }
-  | {
-      action: 'list';
-      entities: Array<{
-        id: number;
-        entity_type: string;
-        name: string;
-        slug: string;
-        parent_id?: number | null;
-        parent_name?: string | null;
-        parent_slug?: string | null;
-        parent_entity_type?: string | null;
-        metadata?: Record<string, any>;
-        enabled_classifiers?: string[] | null;
-        created_at?: Date;
-        total_content?: number | null;
-        active_connections?: number | null;
-        watchers_count?: number | null;
-        children_count?: number | null;
-        space_name?: string | null;
-        view_url?: string;
-      }>;
-      // Server-side resolution of every `x-link-entity-type` column referenced
-      // by the page. Keyed by `${entityType}:${lookupField}`, then by the
-      // lookup value from the row's metadata. Previously each entity-list page
-      // fanned out one `manage_entity.list` per linked column (4× ~2.5 s on
-      // the Company page); the FE now reads from this map instead.
-      linked_entities?: Record<string, Record<string, { slug: string; entity_type: string; name: string }>>;
-      metadata: {
-        page_size: number;
-        has_more: boolean;
-        filtered_by_type?: string;
-        total_count?: number;
-        limit?: number;
-        offset?: number;
-        sort_by?: string;
-        sort_order?: 'asc' | 'desc';
-      };
-    }
-  | {
-      action: 'get';
-      entity: {
-        id: number;
-        entity_type: string;
-        name: string;
-        slug: string;
-        parent_id?: number | null;
-        parent_name?: string | null;
-        parent_slug?: string | null;
-        metadata?: Record<string, any>;
-        enabled_classifiers?: string[] | null;
-        created_at: string;
-        view_url?: string;
-      };
-    }
-  | {
-      action: 'delete';
-      success: boolean;
-      message: string;
-      deleted_count: number;
-    }
-  | { action: 'link'; relationship: RelationshipRow }
-  | { action: 'update_link'; relationship: RelationshipRow }
-  | { action: 'unlink'; success: boolean; message: string }
-  | {
-      action: 'list_links';
-      relationships: RelationshipRow[];
-      counts_by_type: RelationshipCountByType[];
-      metadata: { total: number; limit: number; offset: number; has_more: boolean };
-    };
+/**
+ * Shared entity shape across the create/update/get/list variants (the superset
+ * of fields; each variant marks its extras optional). `metadata` and the
+ * classifier/parent fields are loose on purpose — entities carry arbitrary
+ * user/workspace metadata.
+ */
+const ManageEntityItemSchema = Type.Object({
+  id: Type.Integer(),
+  entity_type: Type.String(),
+  name: Type.String(),
+  slug: Type.String(),
+  parent_id: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+  parent_name: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  parent_slug: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  parent_entity_type: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  enabled_classifiers: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()])),
+  // `Date` in the list variant is serialized to ISO string over the wire; the
+  // schema models the on-the-wire shape.
+  created_at: Type.Optional(Type.Union([Type.String(), Type.Unknown()])),
+  total_content: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+  active_connections: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+  watchers_count: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+  children_count: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+  space_name: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  view_url: Type.Optional(Type.String()),
+});
+
+/**
+ * Result of `manage_entity` — discriminated union keyed on `action`.
+ * TypeBox-first: `Static<>` derives the TS type from the same schema exposed as
+ * the tool's `outputSchema`.
+ */
+const ManageEntityResultSchema = Type.Union([
+  Type.Object({
+    action: Type.Literal('create'),
+    entity: ManageEntityItemSchema,
+    warnings: Type.Optional(Type.Array(Type.String())),
+    next_steps: Type.Array(Type.String()),
+  }),
+  Type.Object({
+    action: Type.Literal('update'),
+    entity: ManageEntityItemSchema,
+    /** Fields the ownership-aware merge wrote (unowned for a watcher-source edit). */
+    applied_fields: Type.Optional(Type.Array(Type.String())),
+    /** Human-owned fields the edit was blocked from writing — queued for approval. */
+    blocked_fields: Type.Optional(Type.Array(Type.String())),
+    /** True when a blocked-field approval was queued this call. */
+    approval_queued: Type.Optional(Type.Boolean()),
+    /** Permalink to the approval card, when one was queued. */
+    approval_url: Type.Optional(Type.String()),
+    /** Pending approval run id — the worker bridges this into a live chat
+     *  approval card (parity with manage_agents' `pending_approval`). */
+    approval_run_id: Type.Optional(Type.Integer()),
+    /** Blocked field_path -> proposed value, for the live card diff. */
+    approval_fields: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+    /** Blocked field_path -> current human-owned value, for the diff. */
+    approval_current: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+    /** Who proposed the blocked change: 'agent' | 'watcher'. */
+    approval_attribution: Type.Optional(
+      Type.Union([Type.Literal('agent'), Type.Literal('watcher')])
+    ),
+  }),
+  Type.Object({
+    action: Type.Literal('list'),
+    entities: Type.Array(ManageEntityItemSchema),
+    // Server-side resolution of every `x-link-entity-type` column referenced
+    // by the page. Keyed by `${entityType}:${lookupField}`, then by the
+    // lookup value from the row's metadata. Previously each entity-list page
+    // fanned out one `manage_entity.list` per linked column (4× ~2.5 s on
+    // the Company page); the FE now reads from this map instead.
+    linked_entities: Type.Optional(
+      Type.Record(
+        Type.String(),
+        Type.Record(
+          Type.String(),
+          Type.Object({
+            slug: Type.String(),
+            entity_type: Type.String(),
+            name: Type.String(),
+          })
+        )
+      )
+    ),
+    metadata: Type.Object({
+      page_size: Type.Integer(),
+      has_more: Type.Boolean(),
+      filtered_by_type: Type.Optional(Type.String()),
+      total_count: Type.Optional(Type.Integer()),
+      limit: Type.Optional(Type.Integer()),
+      offset: Type.Optional(Type.Integer()),
+      sort_by: Type.Optional(Type.String()),
+      sort_order: Type.Optional(Type.Union([Type.Literal('asc'), Type.Literal('desc')])),
+    }),
+  }),
+  Type.Object({
+    action: Type.Literal('get'),
+    entity: ManageEntityItemSchema,
+  }),
+  Type.Object({
+    action: Type.Literal('delete'),
+    success: Type.Boolean(),
+    message: Type.String(),
+    deleted_count: Type.Integer(),
+  }),
+  Type.Object({
+    action: Type.Literal('link'),
+    relationship: RelationshipRowSchema,
+  }),
+  Type.Object({
+    action: Type.Literal('update_link'),
+    relationship: RelationshipRowSchema,
+  }),
+  Type.Object({
+    action: Type.Literal('unlink'),
+    success: Type.Boolean(),
+    message: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal('list_links'),
+    relationships: Type.Array(RelationshipRowSchema),
+    counts_by_type: Type.Array(RelationshipCountByTypeSchema),
+    metadata: Type.Object({
+      total: Type.Integer(),
+      limit: Type.Integer(),
+      offset: Type.Integer(),
+      has_more: Type.Boolean(),
+    }),
+  }),
+]);
+export type ManageEntityResult = Static<typeof ManageEntityResultSchema>;
+export { ManageEntityResultSchema };
 
 function toIsoStringOrNow(value: Date | string | null | undefined): string {
   if (!value) return new Date().toISOString();

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -185,91 +185,158 @@ type ManageEntitySchemaArgs = Static<typeof ManageEntitySchemaSchema>;
 // Result Types
 // ============================================
 
-interface EntityTypeRow {
-  id: number;
-  slug: string;
-  name: string;
-  description?: string | null;
-  icon?: string | null;
-  color?: string | null;
-  metadata_schema?: Record<string, unknown> | null;
-  event_kinds?: Record<string, unknown> | null;
-  backing_sql?: string | null;
+const EntityTypeRowSchema = Type.Object({
+  id: Type.Integer(),
+  slug: Type.String(),
+  name: Type.String(),
+  description: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  icon: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  color: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  metadata_schema: Type.Optional(Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])),
+  event_kinds: Type.Optional(Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])),
+  backing_sql: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   /** Connection slug an external-backed derived view runs against; null ⇒ internal. */
-  backing_source?: string | null;
+  backing_source: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   /** Declared metric contract (eventSets/measures/dimensions/segments), stored verbatim; null ⇒ none. */
-  metrics_config?: Record<string, unknown> | null;
-  is_system: boolean;
-  created_by?: string | null;
-  organization_id?: string | null;
-  organization_slug?: string | null;
-  created_at: Date;
-  updated_at: Date;
-  entity_count?: number;
-  current_view_template_version_id?: number | null;
+  metrics_config: Type.Optional(Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])),
+  is_system: Type.Boolean(),
+  created_by: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  organization_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  organization_slug: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  // `Date` in the row; serialized to ISO over the wire. Accept either.
+  created_at: Type.Union([Type.String(), Type.Unknown()]),
+  updated_at: Type.Union([Type.String(), Type.Unknown()]),
+  entity_count: Type.Optional(Type.Integer()),
+  current_view_template_version_id: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
   /** Derived types only — the view's aggregate columns, classified on read. */
-  measure_columns?: string[];
-}
+  measure_columns: Type.Optional(Type.Array(Type.String())),
+});
+type EntityTypeRow = Static<typeof EntityTypeRowSchema>;
 
-interface AuditEntry {
-  id: number;
-  entity_type_id: number;
-  action: string;
-  actor: string | null;
-  before_payload: Record<string, unknown> | null;
-  after_payload: Record<string, unknown> | null;
-  created_at: string;
-}
+const AuditEntrySchema = Type.Object({
+  id: Type.Integer(),
+  entity_type_id: Type.Integer(),
+  action: Type.String(),
+  actor: Type.Union([Type.String(), Type.Null()]),
+  before_payload: Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()]),
+  after_payload: Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()]),
+  created_at: Type.String(),
+});
+type AuditEntry = Static<typeof AuditEntrySchema>;
 
-interface RelationshipTypeRow {
-  id: number;
-  slug: string;
-  name: string;
-  description?: string | null;
-  organization_id?: string | null;
-  organization_slug?: string | null;
-  created_by?: string | null;
-  metadata_schema?: Record<string, unknown> | null;
-  metadata?: Record<string, unknown> | null;
-  is_symmetric: boolean;
-  inverse_type_id?: number | null;
-  inverse_type_slug?: string | null;
-  status: string;
-  created_at: string;
-  updated_at: string;
-  deleted_at?: string | null;
-  relationship_count?: number;
-}
+const RelationshipTypeRowSchema = Type.Object({
+  id: Type.Integer(),
+  slug: Type.String(),
+  name: Type.String(),
+  description: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  organization_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  organization_slug: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  created_by: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  metadata_schema: Type.Optional(Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])),
+  metadata: Type.Optional(Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])),
+  is_symmetric: Type.Boolean(),
+  inverse_type_id: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+  inverse_type_slug: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  status: Type.String(),
+  created_at: Type.String(),
+  updated_at: Type.String(),
+  deleted_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  relationship_count: Type.Optional(Type.Integer()),
+});
+type RelationshipTypeRow = Static<typeof RelationshipTypeRowSchema>;
 
-interface RelationshipTypeRuleRow {
-  id: number;
-  relationship_type_id: number;
-  source_entity_type_slug: string;
-  target_entity_type_slug: string;
-  created_at: string;
-}
+const RelationshipTypeRuleRowSchema = Type.Object({
+  id: Type.Integer(),
+  relationship_type_id: Type.Integer(),
+  source_entity_type_slug: Type.String(),
+  target_entity_type_slug: Type.String(),
+  created_at: Type.String(),
+});
+type RelationshipTypeRuleRow = Static<typeof RelationshipTypeRuleRowSchema>;
 
-type ManageEntitySchemaResult =
+/**
+ * Result of `manage_entity_schema` — discriminated union keyed on
+ * `schema_type` + `action`. TypeBox-first: `Static<>` derives the TS type from
+ * the same schema exposed as the tool's `outputSchema`.
+ */
+export const ManageEntitySchemaResultSchema = Type.Union([
   // Entity type results
-  | { schema_type: 'entity_type'; action: 'list'; entity_types: EntityTypeRow[] }
-  | { schema_type: 'entity_type'; action: 'get'; entity_type: EntityTypeRow | null }
-  | { schema_type: 'entity_type'; action: 'create'; entity_type: EntityTypeRow }
-  | { schema_type: 'entity_type'; action: 'update'; entity_type: EntityTypeRow }
-  | { schema_type: 'entity_type'; action: 'delete'; success: boolean; message: string }
-  | { schema_type: 'entity_type'; action: 'audit'; audit_entries: AuditEntry[] }
+  Type.Object({
+    schema_type: Type.Literal('entity_type'),
+    action: Type.Literal('list'),
+    entity_types: Type.Array(EntityTypeRowSchema),
+  }),
+  Type.Object({
+    schema_type: Type.Literal('entity_type'),
+    action: Type.Literal('get'),
+    entity_type: Type.Union([EntityTypeRowSchema, Type.Null()]),
+  }),
+  Type.Object({
+    schema_type: Type.Literal('entity_type'),
+    action: Type.Literal('create'),
+    entity_type: EntityTypeRowSchema,
+  }),
+  Type.Object({
+    schema_type: Type.Literal('entity_type'),
+    action: Type.Literal('update'),
+    entity_type: EntityTypeRowSchema,
+  }),
+  Type.Object({
+    schema_type: Type.Literal('entity_type'),
+    action: Type.Literal('delete'),
+    success: Type.Boolean(),
+    message: Type.String(),
+  }),
+  Type.Object({
+    schema_type: Type.Literal('entity_type'),
+    action: Type.Literal('audit'),
+    audit_entries: Type.Array(AuditEntrySchema),
+  }),
   // Relationship type results
-  | { schema_type: 'relationship_type'; action: 'list'; relationship_types: RelationshipTypeRow[] }
-  | {
-      schema_type: 'relationship_type';
-      action: 'get';
-      relationship_type: RelationshipTypeRow | null;
-    }
-  | { schema_type: 'relationship_type'; action: 'create'; relationship_type: RelationshipTypeRow }
-  | { schema_type: 'relationship_type'; action: 'update'; relationship_type: RelationshipTypeRow }
-  | { schema_type: 'relationship_type'; action: 'delete'; success: boolean; message: string }
-  | { schema_type: 'relationship_type'; action: 'add_rule'; rule: RelationshipTypeRuleRow }
-  | { schema_type: 'relationship_type'; action: 'remove_rule'; success: boolean; message: string }
-  | { schema_type: 'relationship_type'; action: 'list_rules'; rules: RelationshipTypeRuleRow[] };
+  Type.Object({
+    schema_type: Type.Literal('relationship_type'),
+    action: Type.Literal('list'),
+    relationship_types: Type.Array(RelationshipTypeRowSchema),
+  }),
+  Type.Object({
+    schema_type: Type.Literal('relationship_type'),
+    action: Type.Literal('get'),
+    relationship_type: Type.Union([RelationshipTypeRowSchema, Type.Null()]),
+  }),
+  Type.Object({
+    schema_type: Type.Literal('relationship_type'),
+    action: Type.Literal('create'),
+    relationship_type: RelationshipTypeRowSchema,
+  }),
+  Type.Object({
+    schema_type: Type.Literal('relationship_type'),
+    action: Type.Literal('update'),
+    relationship_type: RelationshipTypeRowSchema,
+  }),
+  Type.Object({
+    schema_type: Type.Literal('relationship_type'),
+    action: Type.Literal('delete'),
+    success: Type.Boolean(),
+    message: Type.String(),
+  }),
+  Type.Object({
+    schema_type: Type.Literal('relationship_type'),
+    action: Type.Literal('add_rule'),
+    rule: RelationshipTypeRuleRowSchema,
+  }),
+  Type.Object({
+    schema_type: Type.Literal('relationship_type'),
+    action: Type.Literal('remove_rule'),
+    success: Type.Boolean(),
+    message: Type.String(),
+  }),
+  Type.Object({
+    schema_type: Type.Literal('relationship_type'),
+    action: Type.Literal('list_rules'),
+    rules: Type.Array(RelationshipTypeRuleRowSchema),
+  }),
+]);
+type ManageEntitySchemaResult = Static<typeof ManageEntitySchemaResultSchema>;
 
 // ============================================
 // Main Function (Action Router)

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -124,34 +124,75 @@ const TriggerFeedAction = Type.Object({
 // Result Types
 // ============================================
 
-type ManageFeedsResult =
-  | { error: string }
-  | { action: 'list_feeds'; feeds: any[]; total: number; limit: number; offset: number }
-  | { action: 'read_feed'; kind: string; feed: any; recent_runs: any[] }
-  | {
-      action: 'read_feed';
-      kind: 'streaming';
-      feed: any;
-      messages: Array<{
-        timestamp: string;
-        user: string;
-        text: string;
-        isBot: boolean;
-      }>;
-    }
-  | {
-      action: 'read_feed';
-      kind: 'virtual';
-      feed: any;
-      rows: Record<string, unknown>[];
-      columns: { name: string; type: string }[];
-      total?: number;
-    }
-  | { action: 'create_feed'; feed: any }
-  | { action: 'update_feed'; feed: any }
-  | { action: 'delete_feed'; deleted: true; feed_id: number }
-  | { action: 'trigger_feed'; triggered: true; run_id: number; feed_id: number }
-  | { action: 'trigger_feed'; message: string };
+/**
+ * Result of `manage_feeds` — discriminated union (on `action`, plus an error
+ * variant). TypeBox-first: `Static<>` derives the TS type from the same schema
+ * exposed as the tool's `outputSchema`. Feed rows are wide, join-driven
+ * snapshots (no stable contract), so they're honestly `Record<string, unknown>`.
+ */
+export const ManageFeedsResultSchema = Type.Union([
+  Type.Object({ error: Type.String() }),
+  Type.Object({
+    action: Type.Literal('list_feeds'),
+    feeds: Type.Array(Type.Record(Type.String(), Type.Unknown())),
+    total: Type.Integer(),
+    limit: Type.Integer(),
+    offset: Type.Integer(),
+  }),
+  Type.Object({
+    action: Type.Literal('read_feed'),
+    kind: Type.String(),
+    feed: Type.Record(Type.String(), Type.Unknown()),
+    recent_runs: Type.Array(Type.Record(Type.String(), Type.Unknown())),
+  }),
+  Type.Object({
+    action: Type.Literal('read_feed'),
+    kind: Type.Literal('streaming'),
+    feed: Type.Record(Type.String(), Type.Unknown()),
+    messages: Type.Array(
+      Type.Object({
+        timestamp: Type.String(),
+        user: Type.String(),
+        text: Type.String(),
+        isBot: Type.Boolean(),
+      })
+    ),
+  }),
+  Type.Object({
+    action: Type.Literal('read_feed'),
+    kind: Type.Literal('virtual'),
+    feed: Type.Record(Type.String(), Type.Unknown()),
+    rows: Type.Array(Type.Record(Type.String(), Type.Unknown())),
+    columns: Type.Array(
+      Type.Object({ name: Type.String(), type: Type.String() })
+    ),
+    total: Type.Optional(Type.Integer()),
+  }),
+  Type.Object({
+    action: Type.Literal('create_feed'),
+    feed: Type.Record(Type.String(), Type.Unknown()),
+  }),
+  Type.Object({
+    action: Type.Literal('update_feed'),
+    feed: Type.Record(Type.String(), Type.Unknown()),
+  }),
+  Type.Object({
+    action: Type.Literal('delete_feed'),
+    deleted: Type.Literal(true),
+    feed_id: Type.Integer(),
+  }),
+  Type.Object({
+    action: Type.Literal('trigger_feed'),
+    triggered: Type.Literal(true),
+    run_id: Type.Integer(),
+    feed_id: Type.Integer(),
+  }),
+  Type.Object({
+    action: Type.Literal('trigger_feed'),
+    message: Type.String(),
+  }),
+]);
+type ManageFeedsResult = Static<typeof ManageFeedsResultSchema>;
 
 // ============================================
 // Main Function (Action Router)

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -44,20 +44,21 @@ const BackendLiteral = Type.Union([
   Type.Literal('local_action'),
   Type.Literal('mcp_tool'),
   Type.Literal('http_operation'),
-]);
+], { description: 'Filter by operation backend type' });
 
-const KindLiteral = Type.Union([Type.Literal('read'), Type.Literal('write')]);
+const KindLiteral = Type.Union([Type.Literal('read'), Type.Literal('write')], { description: 'Filter by operation kind (read/write)' });
 
 const ListAvailableAction = Type.Object({
   action: Type.Literal('list_available'),
-  connector_key: Type.Optional(Type.String()),
-  connection_id: Type.Optional(Type.Number()),
-  entity_id: Type.Optional(Type.Number()),
+  connector_key: Type.Optional(Type.String({ description: 'Filter by connector key' })),
+  connection_id: Type.Optional(Type.Number({ description: 'Filter by connection ID' })),
+  entity_id: Type.Optional(Type.Number({ description: 'Filter by entity ID' })),
   kind: Type.Optional(KindLiteral),
   backend: Type.Optional(BackendLiteral),
-  include_input_schema: Type.Optional(Type.Boolean({ default: true })),
-  include_output_schema: Type.Optional(Type.Boolean({ default: false })),
-  ...PaginationFields,
+  include_input_schema: Type.Optional(Type.Boolean({ default: true, description: 'Include input schema in response' })),
+  include_output_schema: Type.Optional(Type.Boolean({ default: false, description: 'Include output schema in response' })),
+  limit: Type.Optional(Type.Number({ description: 'Maximum number of results to return' })),
+  offset: Type.Optional(Type.Number({ description: 'Number of results to skip' })),
 });
 
 const ExecuteAction = Type.Object({
@@ -75,20 +76,20 @@ const ExecuteAction = Type.Object({
 
 const ListRunsAction = Type.Object({
   action: Type.Literal('list_runs'),
-  connection_id: Type.Optional(Type.Number()),
-  connection_ids: Type.Optional(Type.Array(Type.Number())),
-  feed_ids: Type.Optional(Type.Array(Type.Number())),
-  device_worker_id: Type.Optional(Type.String()),
-  operation_key: Type.Optional(Type.String()),
-  status: Type.Optional(Type.String()),
-  approval_status: Type.Optional(Type.String()),
+  connection_id: Type.Optional(Type.Number({ description: 'Filter by connection ID' })),
+  connection_ids: Type.Optional(Type.Array(Type.Number({ description: 'Filter by connection IDs' }))),
+  feed_ids: Type.Optional(Type.Array(Type.Number({ description: 'Filter by feed IDs' }))),
+  device_worker_id: Type.Optional(Type.String({ description: 'Filter by device worker ID' })),
+  operation_key: Type.Optional(Type.String({ description: 'Filter by operation key' })),
+  status: Type.Optional(Type.String({ description: 'Filter by run status' })),
+  approval_status: Type.Optional(Type.String({ description: 'Filter by approval status' })),
   /** Filter by run_type. Omit to list every run type (sync, action, auth, …). */
-  run_types: Type.Optional(Type.Array(Type.String())),
+  run_types: Type.Optional(Type.Array(Type.String({ description: 'Filter by run types' }))),
   /** Filter watcher runs by watcher id(s). */
-  watcher_ids: Type.Optional(Type.Array(Type.Number())),
+  watcher_ids: Type.Optional(Type.Array(Type.Number({ description: 'Filter by watcher IDs' }))),
   /** Keyset cursor: return runs ordered before (before_created_at, before_id). */
-  before_id: Type.Optional(Type.Number()),
-  before_created_at: Type.Optional(Type.String()),
+  before_id: Type.Optional(Type.Number({ description: 'Keyset cursor: return runs before this ID' })),
+  before_created_at: Type.Optional(Type.String({ description: 'Keyset cursor: return runs before this timestamp' })),
   ...PaginationFields,
 });
 

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -15,7 +15,7 @@ import { notifyActionApprovalNeeded } from '../../notifications/triggers';
 import { resolveActionMode } from '../../operations/action-modes';
 import { getOperationForConnection, listOperations } from '../../operations/connector-operations';
 import { validateOperationInput } from '../../operations/input-validation';
-import type { AvailableOperation, OperationDescriptor } from '../../operations/types';
+import type { OperationDescriptor } from '../../operations/types';
 import { resolveConnectorCode } from '../../utils/ensure-connector-installed';
 import { resolveExecutionAuth } from '../../utils/execution-context';
 import { insertEvent } from '../../utils/insert-event';
@@ -111,48 +111,78 @@ const RejectAction = Type.Object({
 });
 
 
-type ManageOperationsResult =
-  | { error: string }
-  | {
-      action: 'list_available';
-      operations: Array<Record<string, unknown>> | AvailableOperation[];
-      total: number;
-      limit: number;
-      offset: number;
-    }
-  | {
-      action: 'execute';
-      run_id: number;
-      event_id?: number;
-      approval_url?: string;
-      status: 'pending_approval';
-      message: string;
-    }
-  | {
-      action: 'execute';
-      run_id: number;
-      status: 'completed';
-      output: Record<string, unknown>;
-      metadata?: Record<string, unknown>;
-    }
-  | { action: 'execute'; run_id: number; status: 'failed'; error_message: string }
-  | {
-      action: 'execute';
-      run_id: number;
-      status: 'timeout';
-      error_message: string;
-    }
-  | {
-      action: 'list_runs';
-      runs: any[];
-      total: number;
-      limit: number;
-      offset: number;
-      has_more: boolean;
-    }
-  | { action: 'get_run'; run: any }
-  | { action: 'approve'; approved: true; run_id: number; event_id?: number; message: string }
-  | { action: 'reject'; rejected: true; run_id: number; event_id?: number };
+/**
+ * Result of `manage_operations` — discriminated union (on `action`/`status`,
+ * plus an error variant). TypeBox-first: `Static<>` derives the TS type from
+ * the same schema exposed as the tool's `outputSchema`. Operation/run rows are
+ * wide snapshots, so they're honestly `Record<string, unknown>`.
+ */
+export const ManageOperationsResultSchema = Type.Union([
+  Type.Object({ error: Type.String() }),
+  Type.Object({
+    action: Type.Literal('list_available'),
+    // AvailableOperation is a typed descriptor; modeled as unknown so the
+    // handler's typed array satisfies the schema without forcing an index
+    // signature onto the interface.
+    operations: Type.Array(Type.Unknown()),
+    total: Type.Integer(),
+    limit: Type.Integer(),
+    offset: Type.Integer(),
+  }),
+  Type.Object({
+    action: Type.Literal('execute'),
+    run_id: Type.Integer(),
+    event_id: Type.Optional(Type.Integer()),
+    approval_url: Type.Optional(Type.String()),
+    status: Type.Literal('pending_approval'),
+    message: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal('execute'),
+    run_id: Type.Integer(),
+    status: Type.Literal('completed'),
+    output: Type.Record(Type.String(), Type.Unknown()),
+    metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  }),
+  Type.Object({
+    action: Type.Literal('execute'),
+    run_id: Type.Integer(),
+    status: Type.Literal('failed'),
+    error_message: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal('execute'),
+    run_id: Type.Integer(),
+    status: Type.Literal('timeout'),
+    error_message: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal('list_runs'),
+    runs: Type.Array(Type.Record(Type.String(), Type.Unknown())),
+    total: Type.Integer(),
+    limit: Type.Integer(),
+    offset: Type.Integer(),
+    has_more: Type.Boolean(),
+  }),
+  Type.Object({
+    action: Type.Literal('get_run'),
+    run: Type.Record(Type.String(), Type.Unknown()),
+  }),
+  Type.Object({
+    action: Type.Literal('approve'),
+    approved: Type.Literal(true),
+    run_id: Type.Integer(),
+    event_id: Type.Optional(Type.Integer()),
+    message: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal('reject'),
+    rejected: Type.Literal(true),
+    run_id: Type.Integer(),
+    event_id: Type.Optional(Type.Integer()),
+  }),
+]);
+type ManageOperationsResult = Static<typeof ManageOperationsResultSchema>;
 
 
 type InlineExecutionResult =

--- a/packages/server/src/tools/admin/manage_view_templates.ts
+++ b/packages/server/src/tools/admin/manage_view_templates.ts
@@ -19,25 +19,26 @@ import { defineFlatActionTool, flatAction } from './action-tool';
 // View template versioning types + helpers
 // ============================================
 
-interface ViewTemplateVersionRow {
-  id: number;
-  version: number;
-  tab_name: string | null;
-  tab_order: number;
-  json_template: Record<string, unknown>;
-  change_notes: string | null;
-  created_by: string;
-  created_by_username: string | null;
-  created_at: string;
-}
+const ViewTemplateVersionRowSchema = Type.Object({
+  id: Type.Integer(),
+  version: Type.Integer(),
+  tab_name: Type.Union([Type.String(), Type.Null()]),
+  tab_order: Type.Integer(),
+  json_template: Type.Record(Type.String(), Type.Unknown()),
+  change_notes: Type.Union([Type.String(), Type.Null()]),
+  created_by: Type.String(),
+  created_by_username: Type.Union([Type.String(), Type.Null()]),
+  created_at: Type.String(),
+});
+type ViewTemplateVersionRow = Static<typeof ViewTemplateVersionRowSchema>;
 
-interface ViewTemplateTabInfo {
-  tab_name: string;
-  tab_order: number;
-  current_version: number;
-  current_version_id: number;
-  json_template: Record<string, unknown>;
-}
+const ViewTemplateTabInfoSchema = Type.Object({
+  tab_name: Type.String(),
+  tab_order: Type.Integer(),
+  current_version: Type.Integer(),
+  current_version_id: Type.Integer(),
+  json_template: Type.Record(Type.String(), Type.Unknown()),
+});
 
 function mapVersionRow(row: Record<string, unknown>): ViewTemplateVersionRow {
   return {
@@ -98,16 +99,42 @@ type ManageViewTemplatesArgs = Static<typeof ManageViewTemplatesSchema>;
 // Result Types
 // ============================================
 
-type ManageViewTemplatesResult =
-  | { action: 'set'; version: ViewTemplateVersionRow; message: string }
-  | {
-      action: 'get';
-      default_tab: { current: ViewTemplateVersionRow | null; history: ViewTemplateVersionRow[] };
-      tabs: ViewTemplateTabInfo[];
-    }
-  | { action: 'rollback'; version: ViewTemplateVersionRow; message: string }
-  | { action: 'remove_tab'; success: boolean; message: string }
-  | { action: 'clear'; success: boolean; message: string };
+/**
+ * Result of `manage_view_templates` — discriminated union keyed on `action`.
+ * TypeBox-first: `Static<>` derives the TS type from the same schema exposed as
+ * the tool's `outputSchema`.
+ */
+export const ManageViewTemplatesResultSchema = Type.Union([
+  Type.Object({
+    action: Type.Literal('set'),
+    version: ViewTemplateVersionRowSchema,
+    message: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal('get'),
+    default_tab: Type.Object({
+      current: Type.Union([ViewTemplateVersionRowSchema, Type.Null()]),
+      history: Type.Array(ViewTemplateVersionRowSchema),
+    }),
+    tabs: Type.Array(ViewTemplateTabInfoSchema),
+  }),
+  Type.Object({
+    action: Type.Literal('rollback'),
+    version: ViewTemplateVersionRowSchema,
+    message: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal('remove_tab'),
+    success: Type.Boolean(),
+    message: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal('clear'),
+    success: Type.Boolean(),
+    message: Type.String(),
+  }),
+]);
+type ManageViewTemplatesResult = Static<typeof ManageViewTemplatesResultSchema>;
 
 // ============================================
 // Main Function

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -24,7 +24,7 @@
 import { type Static, Type } from '@sinclair/typebox';
 import { createDbClientFromEnv } from '../../db/client';
 import type { Env } from '../../index';
-import type { ComponentReferenceDocumentation } from '../../types/templates';
+import { WatcherSourceSchema } from '../../types/watchers';
 import {
   requireOrgReadAccess,
   requireOrgWriteAccess,
@@ -46,7 +46,7 @@ import {
   handleListPromoted,
 } from './manage_watchers/feedback';
 import { handleGetComponentReference } from './manage_watchers/reference';
-import { handleList, type ListWatchersArgs, type ListWatchersResult } from './manage_watchers/list';
+import { handleList, ListWatchersResultSchema, type ListWatchersArgs, type ListWatchersResult } from './manage_watchers/list';
 
 // ============================================
 // Typebox Schema (Flattened for MCP)
@@ -352,85 +352,154 @@ export const ManageWatchersSchema = Type.Object({
 
 export type ManageWatchersArgs = Static<typeof ManageWatchersSchema>;
 
-export type ManageWatchersResult =
-  | {
-      action: 'create';
-      watcher_id: string;
-      version: number;
-      status: string;
-      sources?: Array<{ name: string; query: string }>;
-      view_url?: string;
-    }
-  | { action: 'update'; watcher_id: string; updated_fields: string[] }
-  | {
-      action: 'create_version';
-      watcher_id: string;
-      version_id: string;
-      version: number;
-      previous_version: number;
-    }
-  | {
-      action: 'complete_window';
-      watcher_id: string;
-      window_id: number;
-      window_start: string;
-      window_end: string;
-      content_linked: number;
-    }
-  | {
-      action: 'trigger';
-      watcher_id: string;
-      run_id: number;
-      status: string;
-    }
-  | {
-      action: 'delete';
-      results: Array<{ watcher_id: string; success: boolean; message: string; version?: number }>;
-      summary: { total: number; successful: number; failed: number };
-    }
-  | { action: 'set_reaction_script'; watcher_id: string; has_script: boolean; message: string }
-  | { action: 'get_versions'; watcher_id: string; versions: any[] }
-  | { action: 'get_version_details'; watcher_id: string; [key: string]: any }
-  | { action: 'get_component_reference'; documentation: ComponentReferenceDocumentation }
-  | {
-      action: 'submit_feedback';
-      watcher_id: string;
-      window_id: number;
-      feedback_ids: number[];
-    }
-  | {
-      action: 'get_feedback';
-      watcher_id: string;
-      feedback: Array<{
-        id: number;
-        window_id: number;
-        field_path: string;
-        mutation: 'set' | 'remove' | 'add';
-        corrected_value: unknown;
-        note: string | null;
-        created_by: string;
-        created_at: string;
-        window_start?: string;
-        window_end?: string;
-      }>;
-    }
-  | {
-      action: 'list_promoted';
-      watcher_id: string;
-      entities: Array<{
-        id: number;
-        name: string;
-        entity_type: string;
-        metadata: Record<string, unknown>;
-        field_controls: Record<string, unknown>;
-        window_id: number | null;
-        stable_key: string | null;
-      }>;
-    }
-  | {
-      action: 'create_from_version';
-      created: Array<{ watcher_id: string; entity_id: number; name: string }>;
-    };
+/**
+ * Result of `manage_watchers` — a discriminated union keyed on `action`.
+ * TypeBox-first: the TS type is `Static<>`-derived, and the same schema is the
+ * tool's `outputSchema`. Well-structured variants are precise; the genuinely
+ * dynamic variants (`get_version_details` carries an open index signature,
+ * `get_versions` returns arbitrary version rows, `get_component_reference`
+ * embeds a large doc tree) use permissive object shapes so the schema is
+ * honest rather than a brittle mirror of shapes that are intentionally open.
+ */
+const ManageWatchersDeleteResultSchema = Type.Object({
+  watcher_id: Type.String(),
+  success: Type.Boolean(),
+  message: Type.String(),
+  version: Type.Optional(Type.Integer()),
+});
+
+const ManageWatchersFeedbackItemSchema = Type.Object({
+  id: Type.Integer(),
+  window_id: Type.Integer(),
+  field_path: Type.String(),
+  mutation: Type.Union([
+    Type.Literal('set'),
+    Type.Literal('remove'),
+    Type.Literal('add'),
+  ]),
+  corrected_value: Type.Unknown(),
+  note: Type.Union([Type.String(), Type.Null()]),
+  created_by: Type.String(),
+  created_at: Type.String(),
+  window_start: Type.Optional(Type.String()),
+  window_end: Type.Optional(Type.String()),
+});
+
+const ManageWatchersPromotedEntitySchema = Type.Object({
+  id: Type.Integer(),
+  name: Type.String(),
+  entity_type: Type.String(),
+  metadata: Type.Record(Type.String(), Type.Unknown()),
+  field_controls: Type.Record(Type.String(), Type.Unknown()),
+  window_id: Type.Union([Type.Integer(), Type.Null()]),
+  stable_key: Type.Union([Type.String(), Type.Null()]),
+});
+
+export const ManageWatchersResultSchema = Type.Union([
+  Type.Object({
+    action: Type.Literal('create'),
+    watcher_id: Type.String(),
+    version: Type.Integer(),
+    status: Type.String(),
+    sources: Type.Optional(Type.Array(WatcherSourceSchema)),
+    view_url: Type.Optional(Type.String()),
+  }),
+  Type.Object({
+    action: Type.Literal('update'),
+    watcher_id: Type.String(),
+    updated_fields: Type.Array(Type.String()),
+  }),
+  Type.Object({
+    action: Type.Literal('create_version'),
+    watcher_id: Type.String(),
+    version_id: Type.String(),
+    version: Type.Integer(),
+    previous_version: Type.Integer(),
+  }),
+  Type.Object({
+    action: Type.Literal('complete_window'),
+    watcher_id: Type.String(),
+    window_id: Type.Integer(),
+    window_start: Type.String(),
+    window_end: Type.String(),
+    content_linked: Type.Integer(),
+  }),
+  Type.Object({
+    action: Type.Literal('trigger'),
+    watcher_id: Type.String(),
+    run_id: Type.Integer(),
+    status: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal('delete'),
+    results: Type.Array(ManageWatchersDeleteResultSchema),
+    summary: Type.Object({
+      total: Type.Integer(),
+      successful: Type.Integer(),
+      failed: Type.Integer(),
+    }),
+  }),
+  Type.Object({
+    action: Type.Literal('set_reaction_script'),
+    watcher_id: Type.String(),
+    has_script: Type.Boolean(),
+    message: Type.String(),
+  }),
+  // Intentionally permissive: version rows are arbitrary config snapshots.
+  Type.Object({
+    action: Type.Literal('get_versions'),
+    watcher_id: Type.String(),
+    versions: Type.Array(Type.Unknown()),
+  }),
+  // Intentionally permissive: carries an open `[key: string]: any` index sig
+  // (the full version config snapshot). Intersecting a string→unknown record
+  // gives the derived TS type an index signature AND emits
+  // `additionalProperties: true` in the JSON Schema.
+  Type.Intersect([
+    Type.Object({
+      action: Type.Literal('get_version_details'),
+      watcher_id: Type.String(),
+    }),
+    Type.Record(Type.String(), Type.Unknown()),
+  ]),
+  // Intentionally permissive: embeds a large documentation tree
+  // (ComponentReferenceDocumentation); the action literal + presence of
+  // `documentation` is what clients key on.
+  Type.Object({
+    action: Type.Literal('get_component_reference'),
+    documentation: Type.Unknown(),
+  }),
+  Type.Object({
+    action: Type.Literal('submit_feedback'),
+    watcher_id: Type.String(),
+    window_id: Type.Integer(),
+    feedback_ids: Type.Array(Type.Integer()),
+  }),
+  Type.Object({
+    action: Type.Literal('get_feedback'),
+    watcher_id: Type.String(),
+    feedback: Type.Array(ManageWatchersFeedbackItemSchema),
+  }),
+  Type.Object({
+    action: Type.Literal('list_promoted'),
+    watcher_id: Type.String(),
+    entities: Type.Array(ManageWatchersPromotedEntitySchema),
+  }),
+  Type.Object({
+    action: Type.Literal('create_from_version'),
+    created: Type.Array(
+      Type.Object({
+        watcher_id: Type.String(),
+        entity_id: Type.Integer(),
+        name: Type.String(),
+      })
+    ),
+  }),
+]);
+
+export type ManageWatchersResult = Static<typeof ManageWatchersResultSchema>;
+// Re-export so the admin registry entry can wire `list_watchers` outputSchema.
+export { ListWatchersResultSchema };
 
 export const ListWatchersSchema = Type.Object({
   watcher_id: Type.Optional(

--- a/packages/server/src/tools/admin/manage_watchers/list.ts
+++ b/packages/server/src/tools/admin/manage_watchers/list.ts
@@ -2,6 +2,7 @@
  * list_watchers handler for manage_watchers.
  */
 
+import { type Static, Type } from "@sinclair/typebox";
 import { getDb } from "../../../db/client";
 import type { Env } from "../../../index";
 import logger from "../../../utils/logger";
@@ -27,7 +28,17 @@ export type ListWatchersArgs = {
 	limit?: number;
 };
 
-export type ListWatchersResult = { watchers: any[] };
+/**
+ * Result of `list_watchers`. TypeBox-first: the watcher rows are intentionally
+ * loose (each row is a wide, join-driven snapshot shaped by the query, not a
+ * stable contract), so the schema is honest about that — a record of
+ * string→unknown — rather than mirroring a brittle shape. `Static<>` derives
+ * the TS type from the same schema.
+ */
+export const ListWatchersResultSchema = Type.Object({
+	watchers: Type.Array(Type.Record(Type.String(), Type.Unknown())),
+});
+export type ListWatchersResult = Static<typeof ListWatchersResultSchema>;
 
 // ============================================
 // handleList

--- a/packages/server/src/tools/get_content.ts
+++ b/packages/server/src/tools/get_content.ts
@@ -12,4 +12,5 @@
 
 export { getContent } from './get_content/handler';
 export { GetContentSchema, getIncludeSupersededValidationErrors } from './get_content/schema';
+export { GetContentResultSchema } from './get_content/types';
 export type { ContentItem } from './get_content/types';

--- a/packages/server/src/tools/get_content/types.ts
+++ b/packages/server/src/tools/get_content/types.ts
@@ -2,6 +2,7 @@
  * Tool: read_knowledge — result/row type definitions and small parse helpers.
  */
 
+import { Type } from '@sinclair/typebox';
 import type { ContentItem } from '@lobu/connector-sdk';
 import type { UnprocessedRange } from '../../types/watchers';
 
@@ -86,6 +87,68 @@ export interface GetContentResult {
   // Hints for the client
   hints?: string[];
 }
+
+/**
+ * Result of `read_knowledge`. TypeBox-first: `Static<>` derives a TS type from
+ * the same schema exposed as the tool's `outputSchema`. `ContentItem` is a
+ * 90-field type in `@lobu/connector-sdk` (a published package consumed
+ * platform-wide), so rather than mirror it — a brittle second source of truth —
+ * the `content`/`sources` arrays are honestly `unknown`. The top-level shape
+ * (content list, total, pagination, watcher-mode fields) is precise.
+ */
+export const GetContentResultSchema = Type.Object({
+  content: Type.Array(Type.Unknown()),
+  total: Type.Integer(),
+  page: Type.Object({
+    limit: Type.Integer(),
+    offset: Type.Integer(),
+    has_more: Type.Boolean(),
+    has_older: Type.Optional(Type.Boolean()),
+    has_newer: Type.Optional(Type.Boolean()),
+    next_cursor: Type.Optional(
+      Type.Object({ occurred_at: Type.String(), id: Type.Integer() })
+    ),
+  }),
+  classification_stats: Type.Optional(
+    Type.Record(Type.String(), Type.Record(Type.String(), Type.Integer()))
+  ),
+  view_url: Type.Optional(Type.String()),
+  window_token: Type.Optional(Type.String()),
+  window_start: Type.Optional(Type.String()),
+  window_end: Type.Optional(Type.String()),
+  prompt_rendered: Type.Optional(Type.String()),
+  extraction_schema: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  sources: Type.Optional(Type.Record(Type.String(), Type.Array(Type.Unknown()))),
+  classifiers: Type.Optional(Type.Array(Type.Unknown())),
+  unprocessed_ranges: Type.Optional(Type.Array(Type.Unknown())),
+  reactions_guidance: Type.Optional(Type.String()),
+  available_operations: Type.Optional(
+    Type.Array(
+      Type.Object({
+        connection_id: Type.Integer(),
+        operation_key: Type.String(),
+        name: Type.String(),
+        kind: Type.Union([Type.Literal('read'), Type.Literal('write')]),
+        requires_approval: Type.Boolean(),
+      })
+    )
+  ),
+  total_count: Type.Optional(Type.Integer()),
+  total_count_chars: Type.Optional(Type.Integer()),
+  estimated_tokens: Type.Optional(Type.Integer()),
+  token_warning: Type.Optional(Type.String()),
+  entity_summary: Type.Optional(
+    Type.Array(
+      Type.Object({
+        entity_id: Type.Integer(),
+        name: Type.String(),
+        entity_type: Type.String(),
+        result_count: Type.Integer(),
+      })
+    )
+  ),
+  hints: Type.Optional(Type.Array(Type.String())),
+});
 
 // ============================================
 // Database Row Types (for query result typing)

--- a/packages/server/src/tools/get_content/types.ts
+++ b/packages/server/src/tools/get_content/types.ts
@@ -2,9 +2,8 @@
  * Tool: read_knowledge — result/row type definitions and small parse helpers.
  */
 
-import { Type } from '@sinclair/typebox';
+import { type Static, Type } from '@sinclair/typebox';
 import type { ContentItem } from '@lobu/connector-sdk';
-import type { UnprocessedRange } from '../../types/watchers';
 
 // ============================================
 // Type Definitions
@@ -26,75 +25,15 @@ export interface ClassifierConfig {
   >;
 }
 
-export interface GetContentResult {
-  content: ContentItem[];
-  total: number;
-  page: {
-    limit: number;
-    offset: number;
-    has_more: boolean;
-    has_older?: boolean;
-    has_newer?: boolean;
-    next_cursor?: {
-      occurred_at: string;
-      id: number;
-    };
-  };
-  classification_stats?: {
-    [classifierSlug: string]: {
-      [value: string]: number;
-    };
-  };
-  /**
-   * Permalink for the entity-scoped events listing in the public web app.
-   * LLM agents calling `read_knowledge` over MCP read this from the response
-   * and format it into chat replies; there is no programmatic consumer in
-   * this repo, but removing the field breaks that user-facing behavior.
-   */
-  view_url?: string;
-  // Watcher-mode fields (only present when watcher_id is provided)
-  window_token?: string;
-  window_start?: string;
-  window_end?: string;
-  prompt_rendered?: string;
-  extraction_schema?: Record<string, any>; // JSON Schema for expected LLM output
-  sources?: Record<string, ContentItem[]>;
-  classifiers?: ClassifierConfig[]; // Only present when watcher_id is provided
-  // Unprocessed content summary (only when watcher_id provided without since/until)
-  unprocessed_ranges?: UnprocessedRange[];
-  // Reaction data (watcher-mode only)
-  reactions_guidance?: string; // Template-defined guidance for reactions
-  available_operations?: Array<{
-    connection_id: number;
-    operation_key: string;
-    name: string;
-    kind: 'read' | 'write';
-    requires_approval: boolean;
-  }>;
-  // Total content stats for the full date range (watcher-mode only)
-  // Helps agents estimate token requirements: ~4 chars per token
-  total_count?: number;
-  total_count_chars?: number;
-  estimated_tokens?: number;
-  token_warning?: string;
-  // Entity summary: shows which entities results cluster around (org-wide search only)
-  entity_summary?: Array<{
-    entity_id: number;
-    name: string;
-    entity_type: string;
-    result_count: number;
-  }>;
-  // Hints for the client
-  hints?: string[];
-}
-
 /**
- * Result of `read_knowledge`. TypeBox-first: `Static<>` derives a TS type from
- * the same schema exposed as the tool's `outputSchema`. `ContentItem` is a
- * 90-field type in `@lobu/connector-sdk` (a published package consumed
- * platform-wide), so rather than mirror it — a brittle second source of truth —
- * the `content`/`sources` arrays are honestly `unknown`. The top-level shape
- * (content list, total, pagination, watcher-mode fields) is precise.
+ * Result of `read_knowledge`. TypeBox-first and the SINGLE source of truth:
+ * `GetContentResult` is `Static<>`-derived from this schema, which is also the
+ * tool's `outputSchema`. `ContentItem` (a 90-field type in
+ * `@lobu/connector-sdk`, a published package) and the watcher-mode
+ * `ClassifierConfig`/`UnprocessedRange` payloads are modeled as `unknown`
+ * inline — they're opaque over the wire, and mirroring them here would be a
+ * brittle second source that drifts from the SDK. The envelope (content list,
+ * total, pagination, watcher-mode flags) is precise.
  */
 export const GetContentResultSchema = Type.Object({
   content: Type.Array(Type.Unknown()),
@@ -112,7 +51,14 @@ export const GetContentResultSchema = Type.Object({
   classification_stats: Type.Optional(
     Type.Record(Type.String(), Type.Record(Type.String(), Type.Integer()))
   ),
+  /**
+   * Permalink for the entity-scoped events listing in the public web app.
+   * LLM agents calling `read_knowledge` over MCP read this from the response
+   * and format it into chat replies; there is no programmatic consumer in
+   * this repo, but removing the field breaks that user-facing behavior.
+   */
   view_url: Type.Optional(Type.String()),
+  // Watcher-mode fields (only present when watcher_id is provided)
   window_token: Type.Optional(Type.String()),
   window_start: Type.Optional(Type.String()),
   window_end: Type.Optional(Type.String()),
@@ -149,6 +95,7 @@ export const GetContentResultSchema = Type.Object({
   ),
   hints: Type.Optional(Type.Array(Type.String())),
 });
+export type GetContentResult = Static<typeof GetContentResultSchema>;
 
 // ============================================
 // Database Row Types (for query result typing)

--- a/packages/server/src/tools/get_watchers.ts
+++ b/packages/server/src/tools/get_watchers.ts
@@ -25,6 +25,11 @@ import type {
   WatcherWindowReaction,
 } from '../types/watchers';
 import {
+  PendingAnalysisSchema,
+  WatcherMetadataSchema,
+  WatcherWindowSchema,
+} from '../types/watchers';
+import {
   buildEntityLinkUnion,
   STANDARD_IDENTITY_NAMESPACES,
   type EntityIdentityScope,
@@ -130,34 +135,41 @@ export const GetWatcherSchema = Type.Object({
 
 type GetWatcherArgs = Static<typeof GetWatcherSchema>;
 
-interface WindowGap {
-  start: string;
-  end: string;
-}
+const WindowGapSchema = Type.Object({
+  start: Type.String(),
+  end: Type.String(),
+});
+type WindowGap = Static<typeof WindowGapSchema>;
 
-interface GetWatcherResult {
-  windows: WatcherWindow[];
-  watcher?: WatcherMetadata;
-  pending_analysis?: PendingAnalysis;
-  gaps?: WindowGap[];
-  pagination: {
-    page: number;
-    page_size: number;
-    total: number;
-  };
-  metadata: {
-    query_type: 'specific' | 'all_for_entity';
-    date_range: {
-      content_since: string | null;
-      content_until: string | null;
-    };
-    granularity_filter: string | null;
-    granularity_actual: string | null;
-    granularity_fallback_used: boolean;
-  };
-  warnings?: string[];
-  view_url?: string;
-}
+/**
+ * Result of `get_watcher`. TypeBox-first (single source of truth): the handler's
+ * return type is `Static<>`-derived, and the same schema is the tool's
+ * `outputSchema`. Nested watcher types come from `types/watchers.ts`.
+ */
+export const GetWatcherResultSchema = Type.Object({
+  windows: Type.Array(WatcherWindowSchema),
+  watcher: Type.Optional(WatcherMetadataSchema),
+  pending_analysis: Type.Optional(PendingAnalysisSchema),
+  gaps: Type.Optional(Type.Array(WindowGapSchema)),
+  pagination: Type.Object({
+    page: Type.Integer(),
+    page_size: Type.Integer(),
+    total: Type.Integer(),
+  }),
+  metadata: Type.Object({
+    query_type: Type.Union([Type.Literal('specific'), Type.Literal('all_for_entity')]),
+    date_range: Type.Object({
+      content_since: Type.Union([Type.String(), Type.Null()]),
+      content_until: Type.Union([Type.String(), Type.Null()]),
+    }),
+    granularity_filter: Type.Union([Type.String(), Type.Null()]),
+    granularity_actual: Type.Union([Type.String(), Type.Null()]),
+    granularity_fallback_used: Type.Boolean(),
+  }),
+  warnings: Type.Optional(Type.Array(Type.String())),
+  view_url: Type.Optional(Type.String()),
+});
+export type GetWatcherResult = Static<typeof GetWatcherResultSchema>;
 
 // ============================================
 // Database Row Types (for query result typing)

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -25,11 +25,11 @@ import { MetricSeriesSchema, metricSeries } from './admin/metric_series';
 import { QueryMetricSchema, queryMetric } from './admin/query_metric';
 import { QuerySqlSchema, querySql } from './admin/query_sql';
 import { ListOrganizationsSchema } from './organizations';
-import { ResolvePathSchema, resolvePath } from './resolve_path';
+import { ResolvePathSchema, ResolvePathResultSchema, resolvePath } from './resolve_path';
 import { SaveContentSchema, saveContent } from './save_content';
-import { SearchSchema, search } from './search';
+import { SearchSchema, UnifiedSearchResultSchema, search } from './search';
 import { QuerySchema, RunSchema, querySdkScript, runSdkScript } from './sdk_run';
-import { SdkSearchSchema, sdkSearch } from './sdk_search';
+import { SdkSearchSchema, SdkSearchResultSchema, sdkSearch } from './sdk_search';
 
 // ============================================
 // Tool Definitions
@@ -112,6 +112,15 @@ export interface ToolDefinition<T = any> {
   description: string;
   inputSchema: any; // JSON Schema
   annotations?: ToolAnnotations;
+  /**
+   * JSON Schema describing the tool's structured result. When present, the
+   * `tools/call` response carries matching `structuredContent` alongside the
+   * text `content` (MCP spec: declaring `outputSchema` implies the result is
+   * structured). TypeBox schemas carry their JSON Schema at runtime, so a tool
+   * that derives its result type via `Static<typeof ResultSchema>` can hand the
+   * same schema object here — one source of truth, no drift.
+   */
+  outputSchema?: any; // JSON Schema
   handler: (args: T, env: Env, ctx: ToolContext) => Promise<any>;
 }
 
@@ -126,6 +135,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       'Search saved workspace memory: entities, facts, decisions, preferences, observations, and notes. Use this to answer “what do we know?” Pair writes with `save_memory`; use `search_sdk` / `query_sdk` only when you need SDK capabilities or programmable reads.',
     inputSchema: SearchSchema,
+    outputSchema: UnifiedSearchResultSchema,
     annotations: { ...READ_ONLY, title: 'Search memory' },
     handler: search,
   },
@@ -153,6 +163,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       "Search ClientSDK documentation and method metadata. Use this to discover which SDK method exists and how to call it; it does not query workspace data. Pass a namespace ('watchers', 'entities', etc.), a dotted path ('watchers.create'), or a free-text query. Pair with `query_sdk` (read-only) or `run_sdk` (full SDK) to actually call methods.",
     inputSchema: SdkSearchSchema,
+    outputSchema: SdkSearchResultSchema,
     annotations: { ...READ_ONLY, title: 'Search SDK docs' },
     handler: sdkSearch,
   },
@@ -213,6 +224,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       'Resolve a namespace-based URL path like /acme/entity-type/entity-slug into namespace and entity details. Returns template_data with executed data source query results when templates define data_sources.',
     inputSchema: ResolvePathSchema,
+    outputSchema: ResolvePathResultSchema,
     annotations: { ...READ_ONLY, title: 'Resolve path' },
     handler: resolvePath,
   },
@@ -389,6 +401,11 @@ function computeAllTools(
         description: tool.description,
         inputSchema,
         ...(tool.annotations && { annotations: tool.annotations }),
+        // outputSchema is emitted as-is: it describes the result shape, not the
+        // Claude-API-constrained input. The `action` discriminator tells the
+        // client which union variant applied, so the full union is correct here
+        // (no flattening, no access-level filtering — those are input concerns).
+        ...(tool.outputSchema && { outputSchema: tool.outputSchema }),
       };
     })
     .filter((tool): tool is NonNullable<typeof tool> => tool !== null);

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -48,6 +48,8 @@ export interface ToolAnnotations {
   openWorldHint?: boolean;
   /** Declare that calling the tool repeatedly with the same arguments has no additional effect. */
   idempotentHint?: boolean;
+  /** Short human-readable label shown in tool pickers */
+  title?: string;
 }
 
 export type TokenType = 'oauth' | 'session' | 'pat' | 'anonymous';
@@ -115,6 +117,8 @@ export interface ToolDefinition<T = any> {
 
 const READ_ONLY = { readOnlyHint: true, idempotentHint: true } as const;
 
+const WRITE_WITHOUT_CONFIRM: ToolAnnotations = { destructiveHint: false, idempotentHint: false };
+
 const TOOLS: ToolDefinition[] = [
   // ─── Memory hot path — read ───────────────────────────────────────────────
   {
@@ -122,7 +126,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       'Search saved workspace memory: entities, facts, decisions, preferences, observations, and notes. Use this to answer “what do we know?” Pair writes with `save_memory`; use `search_sdk` / `query_sdk` only when you need SDK capabilities or programmable reads.',
     inputSchema: SearchSchema,
-    annotations: READ_ONLY,
+    annotations: { ...READ_ONLY, title: 'Search memory' },
     handler: search,
   },
   {
@@ -130,7 +134,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       "Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.",
     inputSchema: SaveContentSchema,
-    annotations: { destructiveHint: false },
+    annotations: { ...WRITE_WITHOUT_CONFIRM, title: 'Save memory' },
     handler: saveContent,
   },
   // ─── Discovery ────────────────────────────────────────────────────────────
@@ -139,7 +143,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       'List organizations the authenticated user belongs to, plus any public workspaces the session can read. The response marks the bound org with `is_current: true` — that is the default target for memory and SDK calls. Use the slug with `client.org(slug)` from `query_sdk` / `run_sdk` for cross-org reads on /mcp + OAuth, or reconnect to /mcp/{slug} to pin a different default.',
     inputSchema: ListOrganizationsSchema,
-    annotations: READ_ONLY,
+    annotations: { ...READ_ONLY, title: 'List organizations' },
     handler: async () => {
       throw new Error('Handled directly in executeTool');
     },
@@ -149,7 +153,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       "Search ClientSDK documentation and method metadata. Use this to discover which SDK method exists and how to call it; it does not query workspace data. Pass a namespace ('watchers', 'entities', etc.), a dotted path ('watchers.create'), or a free-text query. Pair with `query_sdk` (read-only) or `run_sdk` (full SDK) to actually call methods.",
     inputSchema: SdkSearchSchema,
-    annotations: READ_ONLY,
+    annotations: { ...READ_ONLY, title: 'Search SDK docs' },
     handler: sdkSearch,
   },
   // ─── Power tools — TS scripting + raw SQL ─────────────────────────────────
@@ -158,7 +162,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       'Run read-only TypeScript in a sandboxed isolate over the ClientSDK. Use this to fetch workspace data through typed SDK methods. The script signature is `export default async (ctx, client) => ...`. Mutating methods are absent from `client` — attempts surface as undefined methods; use `run_sdk` for writes. Output capped at 1 MB. Use `search_sdk` to find method names. Example: `export default async (_ctx, client) => client.entities.list({ entity_type: "company" });`',
     inputSchema: QuerySchema,
-    annotations: READ_ONLY,
+    annotations: { ...READ_ONLY, title: 'Query SDK (read-only)' },
     handler: querySdkScript,
   },
   {
@@ -166,7 +170,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       'List the DECLARED, governed metrics — measures / dimensions / segments (with descriptions) per entity type. Use this FIRST to discover what metrics exist; pass `q` to keyword-search. Then run one with `query_metric`. Prefer governed metrics over hand-written `query_sql` so numbers stay consistent.',
     inputSchema: ListMetricsSchema,
-    annotations: READ_ONLY,
+    annotations: { ...READ_ONLY, title: 'List metrics' },
     handler: listMetrics,
   },
   {
@@ -174,7 +178,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       'Run a DECLARED metric (discover them via `list_metrics`) and get its rows: pass entity_type + measure, optional `by` dimensions / `segment` / `entity_id`. The metric layer enforces resolution, dedupe, segment, and aggregation, so results are consistent and governed. PREFER this over `query_sql` whenever a declared measure answers the question; fall back to `query_sql` only when no metric covers the ask.',
     inputSchema: QueryMetricSchema,
-    annotations: READ_ONLY,
+    annotations: { ...READ_ONLY, title: 'Query metric' },
     handler: queryMetric,
   },
   {
@@ -182,7 +186,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       'Run a paginated, sortable, searchable read-only SQL query. Table references auto-scope to the bound org. The query is wrapped as a subquery, so inner ORDER BY / LIMIT / window functions are fine; pagination + sort come from the sort_by/limit/offset args. Do NOT use positional parameters ($1, $2, …). Optional `org_slug` (OAuth on /mcp only) redirects the query to a different member org; rejected on /mcp/{slug} and on PAT auth. NOTE: this is the FALLBACK — if a declared metric covers the ask, use `query_metric` (see `list_metrics`) instead, so numbers match the governed definitions.',
     inputSchema: QuerySqlSchema,
-    annotations: READ_ONLY,
+    annotations: { ...READ_ONLY, title: 'Query SQL' },
     handler: querySql,
   },
   {
@@ -190,7 +194,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       'Run a read-only time-series SQL for dashboard sparklines. Caller passes a single SELECT returning a bucket column + N numeric stat columns; the same validator/auto-scoper that powers `query_sql` injects `$1 = organization_id`. Returns `{ columns, rows }` for direct frontend consumption.',
     inputSchema: MetricSeriesSchema,
-    annotations: READ_ONLY,
+    annotations: { ...READ_ONLY, title: 'Metric series' },
     handler: metricSeries,
   },
   {
@@ -198,7 +202,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       'Destructive — confirm before running. Runs TypeScript in a sandboxed isolate over the FULL ClientSDK. Use this for SDK writes or multi-step workflows. Signature: `export default async (ctx, client) => ...`. Can mutate entities, watchers, memory, classifiers, connections, etc. Use `query_sdk` for reads. Pass `dry_run: true` to execute reads while skipping write/external SDK calls and returning `side_effect_preview`. Output capped at 1 MB. Example: `export default async (_ctx, client) => client.entities.create({ type: "company", name: "Acme" });`',
     inputSchema: RunSchema,
-    annotations: { destructiveHint: true },
+    annotations: { destructiveHint: true, idempotentHint: false, title: 'Run SDK' },
     handler: runSdkScript,
   },
   // ─── Admin surface (manage_*, list_watchers, get_watcher, ...) ────────────
@@ -209,7 +213,7 @@ const TOOLS: ToolDefinition[] = [
     description:
       'Resolve a namespace-based URL path like /acme/entity-type/entity-slug into namespace and entity details. Returns template_data with executed data source query results when templates define data_sources.',
     inputSchema: ResolvePathSchema,
-    annotations: READ_ONLY,
+    annotations: { ...READ_ONLY, title: 'Resolve path' },
     handler: resolvePath,
   },
 ];

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -47,59 +47,82 @@ export const ResolvePathSchema = Type.Object({
 
 type ResolvePathArgs = Static<typeof ResolvePathSchema>;
 
-export interface ResolvedWorkspace {
-  slug: string;
-  type: 'user' | 'organization';
-  id: string;
-  name: string | null;
-}
+export const ResolvedWorkspaceSchema = Type.Object({
+  slug: Type.String(),
+  type: Type.Union([Type.Literal('user'), Type.Literal('organization')]),
+  id: Type.String(),
+  name: Type.Union([Type.String(), Type.Null()]),
+});
+export type ResolvedWorkspace = Static<typeof ResolvedWorkspaceSchema>;
 
-export interface ResolvedPathEntity {
-  id: number;
-  entity_type: string;
-  slug: string;
-  name: string;
-}
+export const ResolvedPathEntitySchema = Type.Object({
+  id: Type.Integer(),
+  entity_type: Type.String(),
+  slug: Type.String(),
+  name: Type.String(),
+});
+export type ResolvedPathEntity = Static<typeof ResolvedPathEntitySchema>;
 
-interface ViewTemplateTab {
-  tab_name: string;
-  tab_order: number;
-  json_template: Record<string, any>;
-  version: number;
-  version_id: number;
-  template_data: Record<string, unknown[]> | null;
-}
+const ViewTemplateTabSchema = Type.Object({
+  tab_name: Type.String(),
+  tab_order: Type.Integer(),
+  json_template: Type.Record(Type.String(), Type.Unknown()),
+  version: Type.Integer(),
+  version_id: Type.Integer(),
+  template_data: Type.Union([
+    Type.Record(Type.String(), Type.Array(Type.Unknown())),
+    Type.Null(),
+  ]),
+});
+type ViewTemplateTab = Static<typeof ViewTemplateTabSchema>;
 
-export interface ResolvedEntityDetails extends ResolvedPathEntity {
-  parent_id: number | null;
-  metadata: Record<string, any>;
-  /** Per-field human-ownership markers (key present = a human set that field).
-   *  Lets the UI badge owned fields + show the correction note. */
-  field_controls: Record<string, { note?: string | null; set_by?: string | null; set_at?: string }>;
-  json_template: Record<string, any> | null;
-  json_template_version: number | null;
-  template_data: Record<string, unknown[]> | null;
-  tabs: ViewTemplateTab[];
-  created_at: string;
-  // Stats
-  total_content: number;
-  active_connections: number;
-  watchers_count: number;
-  // Derived ("view") entity: synthesized from the type's `backing_sql` filtered
-  // to this slug, not a stored `entities` row. `metadata` holds the full view
-  // row; `measure_columns` are its aggregate columns. Stored entities omit both.
-  is_derived?: boolean;
-  measure_columns?: string[];
-}
+// ResolvedEntityDetails = ResolvedPathEntity + detail fields. TypeBox has no
+// `extends`; compose via intersect so the derived type stays a single source.
+export const ResolvedEntityDetailsSchema = Type.Intersect([
+  ResolvedPathEntitySchema,
+  Type.Object({
+    parent_id: Type.Union([Type.Integer(), Type.Null()]),
+    metadata: Type.Record(Type.String(), Type.Unknown()),
+    /** Per-field human-ownership markers (key present = a human set that field).
+     *  Lets the UI badge owned fields + show the correction note. */
+    field_controls: Type.Record(
+      Type.String(),
+      Type.Object({
+        note: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        set_by: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        set_at: Type.Optional(Type.String()),
+      })
+    ),
+    json_template: Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()]),
+    json_template_version: Type.Union([Type.Integer(), Type.Null()]),
+    template_data: Type.Union([
+      Type.Record(Type.String(), Type.Array(Type.Unknown())),
+      Type.Null(),
+    ]),
+    tabs: Type.Array(ViewTemplateTabSchema),
+    created_at: Type.String(),
+    // Stats
+    total_content: Type.Integer(),
+    active_connections: Type.Integer(),
+    watchers_count: Type.Integer(),
+    // Derived ("view") entity: synthesized from the type's `backing_sql` filtered
+    // to this slug, not a stored `entities` row. `metadata` holds the full view
+    // row; `measure_columns` are its aggregate columns. Stored entities omit both.
+    is_derived: Type.Optional(Type.Boolean()),
+    measure_columns: Type.Optional(Type.Array(Type.String())),
+  }),
+]);
+export type ResolvedEntityDetails = Static<typeof ResolvedEntityDetailsSchema>;
 
-export interface ChildEntity {
-  id: number;
-  entity_type: string;
-  slug: string;
-  name: string;
-  market: string | null;
-  content_count: number;
-}
+export const ChildEntitySchema = Type.Object({
+  id: Type.Integer(),
+  entity_type: Type.String(),
+  slug: Type.String(),
+  name: Type.String(),
+  market: Type.Union([Type.String(), Type.Null()]),
+  content_count: Type.Integer(),
+});
+export type ChildEntity = Static<typeof ChildEntitySchema>;
 
 interface ResolvedEntityRow {
   id: number;
@@ -112,125 +135,122 @@ interface ResolvedEntityRow {
   created_at: Date;
 }
 
-export interface SiblingEntity {
-  id: number;
-  entity_type: string;
-  slug: string;
-  name: string;
-  content_count: number;
-}
+export const SiblingEntitySchema = Type.Object({
+  id: Type.Integer(),
+  entity_type: Type.String(),
+  slug: Type.String(),
+  name: Type.String(),
+  content_count: Type.Integer(),
+});
+export type SiblingEntity = Static<typeof SiblingEntitySchema>;
 
-export interface ResolvePathResult {
-  workspace: ResolvedWorkspace;
-  segments: Array<{ entity_type: string; slug: string }>;
-  path: ResolvedPathEntity[];
-  entity: ResolvedEntityDetails | null;
-  children: ChildEntity[];
-  siblings: SiblingEntity[];
-  bootstrap: ResolvePathBootstrap | null;
-}
+const BootstrapEntityTypeSummarySchema = Type.Object({
+  id: Type.Integer(),
+  slug: Type.String(),
+  name: Type.String(),
+  description: Type.Union([Type.String(), Type.Null()]),
+  icon: Type.Union([Type.String(), Type.Null()]),
+  color: Type.Union([Type.String(), Type.Null()]),
+  entity_count: Type.Integer(),
+});
+
+const BootstrapScopeSummarySchema = Type.Object({
+  total_content: Type.Integer(),
+  active_connections: Type.Integer(),
+  watchers_count: Type.Integer(),
+  // Org-level regardless of the focused entity (sidebar nav badges).
+  agents_count: Type.Integer(),
+  // Devices are owned by the requesting user, not the org — count is per-user.
+  devices_count: Type.Integer(),
+});
+
+const BootstrapContentItemSchema = Type.Object({
+  id: Type.Integer(),
+  entity_ids: Type.Array(Type.Integer()),
+  platform: Type.String(),
+  entity_name: Type.Union([Type.String(), Type.Null()]),
+  title: Type.Union([Type.String(), Type.Null()]),
+  text_content: Type.String(),
+  source_url: Type.Union([Type.String(), Type.Null()]),
+  author_name: Type.Union([Type.String(), Type.Null()]),
+  created_at: Type.String(),
+  occurred_at: Type.Union([Type.String(), Type.Null()]),
+});
+
+const BootstrapFeedItemSchema = Type.Object({
+  id: Type.Integer(),
+  connection_id: Type.Integer(),
+  connector_key: Type.String(),
+  display_name: Type.Union([Type.String(), Type.Null()]),
+  status: Type.String(),
+  entity_ids: Type.Array(Type.Integer()),
+  connector_name: Type.Union([Type.String(), Type.Null()]),
+  connection_name: Type.Union([Type.String(), Type.Null()]),
+  event_count: Type.Integer(),
+  created_at: Type.String(),
+  updated_at: Type.String(),
+});
+
+const BootstrapWatcherItemSchema = Type.Object({
+  watcher_id: Type.String(),
+  name: Type.String(),
+  status: Type.String(),
+  schedule: Type.String(),
+  entity_id: Type.Union([Type.Integer(), Type.Null()]),
+  entity_type: Type.Union([Type.String(), Type.Null()]),
+  entity_name: Type.Union([Type.String(), Type.Null()]),
+  entity_slug: Type.Union([Type.String(), Type.Null()]),
+  parent_slug: Type.Union([Type.String(), Type.Null()]),
+  parent_entity_type: Type.Union([Type.String(), Type.Null()]),
+  organization_slug: Type.String(),
+  windows_count: Type.Integer(),
+  created_at: Type.String(),
+  updated_at: Type.String(),
+});
+
+const BootstrapConnectorDefinitionSchema = Type.Object({
+  key: Type.String(),
+  name: Type.String(),
+  description: Type.Union([Type.String(), Type.Null()]),
+  icon: Type.Union([Type.String(), Type.Null()]),
+  favicon_domain: Type.Union([Type.String(), Type.Null()]),
+});
+
+export const ResolvePathBootstrapSchema = Type.Object({
+  entity_types: Type.Array(BootstrapEntityTypeSummarySchema),
+  summary: BootstrapScopeSummarySchema,
+  recent_content: Type.Array(BootstrapContentItemSchema),
+  recent_feeds: Type.Array(BootstrapFeedItemSchema),
+  recent_watchers: Type.Array(BootstrapWatcherItemSchema),
+  connector_definitions: Type.Array(BootstrapConnectorDefinitionSchema),
+});
+export type ResolvePathBootstrap = Static<typeof ResolvePathBootstrapSchema>;
+// Handlers reference these by name; alias each from its schema.
+type BootstrapEntityTypeSummary = Static<typeof BootstrapEntityTypeSummarySchema>;
+type BootstrapScopeSummary = Static<typeof BootstrapScopeSummarySchema>;
+type BootstrapContentItem = Static<typeof BootstrapContentItemSchema>;
+type BootstrapFeedItem = Static<typeof BootstrapFeedItemSchema>;
+type BootstrapWatcherItem = Static<typeof BootstrapWatcherItemSchema>;
+type BootstrapConnectorDefinition = Static<typeof BootstrapConnectorDefinitionSchema>;
 
 /**
- * Output schema for `resolve_path`. A permissive projection of
- * `ResolvePathResult`: the top-level envelope (workspace / segments / path /
- * entity / children / siblings / bootstrap) is precise, while the deep nested
- * entity/detail/bootstrap types are `unknown` — they're wide, view-driven
- * snapshots assembled from many joins (see the 13 interfaces below), not a
- * stable contract the MCP client introspects field-by-field. Mirrors the
- * `read_knowledge` / ContentItem approach: honest over brittle.
+ * Output schema for `resolve_path`. TypeBox-first: every nested type is
+ * `Static<>`-derived from its schema, so this object composes them into one
+ * source of truth for both the TS type (`ResolvePathResult`) and the MCP
+ * `outputSchema`. No hand-written interface mirrors it.
  */
 export const ResolvePathResultSchema = Type.Object({
-  workspace: Type.Unknown(),
+  workspace: ResolvedWorkspaceSchema,
   segments: Type.Array(
     Type.Object({ entity_type: Type.String(), slug: Type.String() })
   ),
-  path: Type.Array(Type.Unknown()),
-  entity: Type.Union([Type.Unknown(), Type.Null()]),
-  children: Type.Array(Type.Unknown()),
-  siblings: Type.Array(Type.Unknown()),
-  bootstrap: Type.Union([Type.Unknown(), Type.Null()]),
+  path: Type.Array(ResolvedPathEntitySchema),
+  entity: Type.Union([ResolvedEntityDetailsSchema, Type.Null()]),
+  children: Type.Array(ChildEntitySchema),
+  siblings: Type.Array(SiblingEntitySchema),
+  bootstrap: Type.Union([ResolvePathBootstrapSchema, Type.Null()]),
 });
-
-interface BootstrapEntityTypeSummary {
-  id: number;
-  slug: string;
-  name: string;
-  description: string | null;
-  icon: string | null;
-  color: string | null;
-  entity_count: number;
-}
-
-interface BootstrapScopeSummary {
-  total_content: number;
-  active_connections: number;
-  watchers_count: number;
-  // Org-level regardless of the focused entity (sidebar nav badges).
-  agents_count: number;
-  // Devices are owned by the requesting user, not the org — count is per-user.
-  devices_count: number;
-}
-
-interface BootstrapContentItem {
-  id: number;
-  entity_ids: number[];
-  platform: string;
-  entity_name: string | null;
-  title: string | null;
-  text_content: string;
-  source_url: string | null;
-  author_name: string | null;
-  created_at: string;
-  occurred_at: string | null;
-}
-
-interface BootstrapFeedItem {
-  id: number;
-  connection_id: number;
-  connector_key: string;
-  display_name: string | null;
-  status: string;
-  entity_ids: number[];
-  connector_name: string | null;
-  connection_name: string | null;
-  event_count: number;
-  created_at: string;
-  updated_at: string;
-}
-
-interface BootstrapWatcherItem {
-  watcher_id: string;
-  name: string;
-  status: string;
-  schedule: string;
-  entity_id: number | null;
-  entity_type: string | null;
-  entity_name: string | null;
-  entity_slug: string | null;
-  parent_slug: string | null;
-  parent_entity_type: string | null;
-  organization_slug: string;
-  windows_count: number;
-  created_at: string;
-  updated_at: string;
-}
-
-interface BootstrapConnectorDefinition {
-  key: string;
-  name: string;
-  description: string | null;
-  icon: string | null;
-  favicon_domain: string | null;
-}
-
-export interface ResolvePathBootstrap {
-  entity_types: BootstrapEntityTypeSummary[];
-  summary: BootstrapScopeSummary;
-  recent_content: BootstrapContentItem[];
-  recent_feeds: BootstrapFeedItem[];
-  recent_watchers: BootstrapWatcherItem[];
-  connector_definitions: BootstrapConnectorDefinition[];
-}
+export type ResolvePathResult = Static<typeof ResolvePathResultSchema>;
 
 const BOOTSTRAP_RECENT_LIMIT = 8;
 

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -130,6 +130,27 @@ export interface ResolvePathResult {
   bootstrap: ResolvePathBootstrap | null;
 }
 
+/**
+ * Output schema for `resolve_path`. A permissive projection of
+ * `ResolvePathResult`: the top-level envelope (workspace / segments / path /
+ * entity / children / siblings / bootstrap) is precise, while the deep nested
+ * entity/detail/bootstrap types are `unknown` — they're wide, view-driven
+ * snapshots assembled from many joins (see the 13 interfaces below), not a
+ * stable contract the MCP client introspects field-by-field. Mirrors the
+ * `read_knowledge` / ContentItem approach: honest over brittle.
+ */
+export const ResolvePathResultSchema = Type.Object({
+  workspace: Type.Unknown(),
+  segments: Type.Array(
+    Type.Object({ entity_type: Type.String(), slug: Type.String() })
+  ),
+  path: Type.Array(Type.Unknown()),
+  entity: Type.Union([Type.Unknown(), Type.Null()]),
+  children: Type.Array(Type.Unknown()),
+  siblings: Type.Array(Type.Unknown()),
+  bootstrap: Type.Union([Type.Unknown(), Type.Null()]),
+});
+
 interface BootstrapEntityTypeSummary {
   id: number;
   slug: string;

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -27,6 +27,29 @@ export const SdkSearchSchema = Type.Object({
 
 type SdkSearchArgs = Static<typeof SdkSearchSchema>;
 
+/**
+ * Result of `search_sdk`. TypeBox is the single source of truth: the handler's
+ * return type is derived from this via `Static<>`, and the same schema is handed
+ * to the registry as the tool's `outputSchema` (so the listing, the result
+ * shape, and the TS type can't drift).
+ */
+export const SdkSearchResultSchema = Type.Object({
+  query: Type.String({ description: 'The query that was searched.' }),
+  match_count: Type.Integer({
+    description: 'Number of matches returned.',
+  }),
+  results: Type.Array(Type.String(), {
+    description: 'Rendered method-documentation strings, one per match.',
+  }),
+  notes: Type.Optional(
+    Type.String({
+      description: 'Free-text hints (e.g. ambiguity, suggestions) when relevant.',
+    })
+  ),
+});
+
+export type SdkSearchResult = Static<typeof SdkSearchResultSchema>;
+
 interface MatchRow {
   path: string;
   summary: string;
@@ -69,12 +92,7 @@ async function sdkSearchImpl(
   args: SdkSearchArgs,
   _env: Env,
   _ctx: ToolContext,
-): Promise<{
-  query: string;
-  match_count: number;
-  results: string[];
-  notes?: string;
-}> {
+): Promise<SdkSearchResult> {
   const limit = Math.min(args.limit ?? 20, 100);
   const query = args.query.trim();
   const lower = query.toLowerCase();

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -140,39 +140,41 @@ type SearchArgs = Static<typeof SearchSchema>;
 // ============================================
 
 // Unified entity with all fields (nulls where not applicable)
-export interface Entity {
-  id: number;
-  type: string;
-  name: string;
-  slug: string;
-  metadata: Record<string, any>;
-  parent_id: number | null;
-  parent_name: string | null;
-  parent_slug: string | null;
-  parent_entity_type: string | null;
-  organization_slug: string | null;
-  stats: {
-    content_count: number;
-    connection_count: number;
-    active_connection_count: number;
-    children_count: number; // child count for root entities
-    watcher_count: number;
-  };
-  match_score: number;
-  match_reason: string;
-}
+export const EntitySchema = Type.Object({
+  id: Type.Integer(),
+  type: Type.String(),
+  name: Type.String(),
+  slug: Type.String(),
+  metadata: Type.Record(Type.String(), Type.Unknown()),
+  parent_id: Type.Union([Type.Integer(), Type.Null()]),
+  parent_name: Type.Union([Type.String(), Type.Null()]),
+  parent_slug: Type.Union([Type.String(), Type.Null()]),
+  parent_entity_type: Type.Union([Type.String(), Type.Null()]),
+  organization_slug: Type.Union([Type.String(), Type.Null()]),
+  stats: Type.Object({
+    content_count: Type.Integer(),
+    connection_count: Type.Integer(),
+    active_connection_count: Type.Integer(),
+    children_count: Type.Integer(), // child count for root entities
+    watcher_count: Type.Integer(),
+  }),
+  match_score: Type.Number(),
+  match_reason: Type.String(),
+});
+export type Entity = Static<typeof EntitySchema>;
 
-interface ConnectionInfo {
-  connection_id: number;
-  connector_key: string;
-  display_name: string | null;
-  status: string;
-  config: Record<string, unknown>;
-  entity_names?: string | null;
-  created_at: string;
-  updated_at: string | null;
-  content_count: number;
-}
+const ConnectionInfoSchema = Type.Object({
+  connection_id: Type.Integer(),
+  connector_key: Type.String(),
+  display_name: Type.Union([Type.String(), Type.Null()]),
+  status: Type.String(),
+  config: Type.Record(Type.String(), Type.Unknown()),
+  entity_names: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  created_at: Type.String(),
+  updated_at: Type.Union([Type.String(), Type.Null()]),
+  content_count: Type.Integer(),
+});
+type ConnectionInfo = Static<typeof ConnectionInfoSchema>;
 
 interface EntityQueryRow {
   id: number;
@@ -204,34 +206,36 @@ interface ChildEntityRow {
   content_count: number;
 }
 
-interface ContentSnippet {
-  id: number;
-  title: string | null;
-  text_content: string;
-  author_name: string | null;
-  source_url: string | null;
-  platform: string;
-  occurred_at: string | null;
-  similarity?: number;
-  entity_ids: number[];
-}
+const ContentSnippetSchema = Type.Object({
+  id: Type.Integer(),
+  title: Type.Union([Type.String(), Type.Null()]),
+  text_content: Type.String(),
+  author_name: Type.Union([Type.String(), Type.Null()]),
+  source_url: Type.Union([Type.String(), Type.Null()]),
+  platform: Type.String(),
+  occurred_at: Type.Union([Type.String(), Type.Null()]),
+  similarity: Type.Optional(Type.Number()),
+  entity_ids: Type.Array(Type.Integer()),
+});
+type ContentSnippet = Static<typeof ContentSnippetSchema>;
 
 // A keyword/recency hit from the chat transcript (`channel_messages`). Distinct
 // from ContentSnippet on purpose: these are NOT `events`, so they carry no
 // event id (their `id` would mislead a get_content follow-up) and no embedding
 // similarity. They let search_memory surface past channel conversation without
 // a separate get_channel_history tool — see project_conversation_feeds_virtual.
-interface ConversationSnippet {
-  platform: string;
-  channel_id: string;
-  thread_id: string | null;
-  author_name: string | null;
+const ConversationSnippetSchema = Type.Object({
+  platform: Type.String(),
+  channel_id: Type.String(),
+  thread_id: Type.Union([Type.String(), Type.Null()]),
+  author_name: Type.Union([Type.String(), Type.Null()]),
   /** The sender's resolved person/$member entity id (store-only attribution),
    * or null when unattributed (bot post / no team / unresolved). */
-  author_entity_id: number | null;
-  text: string;
-  occurred_at: string | null;
-}
+  author_entity_id: Type.Union([Type.Integer(), Type.Null()]),
+  text: Type.String(),
+  occurred_at: Type.Union([Type.String(), Type.Null()]),
+});
+type ConversationSnippet = Static<typeof ConversationSnippetSchema>;
 
 // A live block of rows recalled from ONE virtual feed (read via readVirtualFeed's
 // search() pushdown). Distinct from ContentSnippet/ConversationSnippet on purpose:
@@ -239,58 +243,26 @@ interface ConversationSnippet {
 // so they carry their own `columns` header rather than being coerced into a fixed
 // snippet shape that would drop or mislabel columns. Nothing is persisted — these
 // are read live from the source at recall time. See project_conversation_feeds_virtual.
-interface VirtualFeedRows {
-  feed_id: number;
-  feed_key: string;
-  columns: { name: string; type: string }[];
-  rows: Record<string, unknown>[];
-}
-
-interface UnifiedSearchResult {
-  entity_type: string | null;
-  entity: Entity | null;
-  matches: Entity[];
-  connections?: ConnectionInfo[];
-  children?: Array<{
-    id: number;
-    name: string;
-    type: string;
-    market: string | null;
-    content_count: number;
-  }>;
-  content?: ContentSnippet[];
-  /** Past chat-channel messages matching the query, scoped to the agent's own
-   * bound channels. Replaces the get_channel_history tool — read past convos
-   * through the same search call. */
-  conversation_messages?: ConversationSnippet[];
-  /** Live rows recalled from opt-in virtual feeds (`config.recall === true`) —
-   * one block per feed, read via the connector's `search()` pushdown at request
-   * time. Never persisted. */
-  virtual_feeds?: VirtualFeedRows[];
-  discovery_status?: 'not_found' | 'complete' | 'discovering';
-  suggestion?: string;
-  view_url?: string;
-  existing_entities?: Array<{ entity_type: string; entities: Array<{ id: number; name: string }> }>;
-  metadata: {
-    total_matches: number;
-    page_size: number;
-  };
-}
+const VirtualFeedRowsSchema = Type.Object({
+  feed_id: Type.Integer(),
+  feed_key: Type.String(),
+  columns: Type.Array(Type.Object({ name: Type.String(), type: Type.String() })),
+  rows: Type.Array(Type.Record(Type.String(), Type.Unknown())),
+});
+type VirtualFeedRows = Static<typeof VirtualFeedRowsSchema>;
 
 /**
- * Output schema for `search_memory`. A permissive projection of
- * `UnifiedSearchResult`: the envelope + the simple nested shapes (children,
- * existing_entities, metadata, discovery_status) are precise, while the
- * `Entity` / `ContentSnippet` / `ConversationSnippet` / `ConnectionInfo`
- * arrays are `unknown` — those types live across the codebase (and
- * `ContentItem` in `@lobu/connector-sdk`) and are wide snapshots, not a
- * contract the MCP client introspects field-by-field. Honest over brittle.
+ * Result of `search_memory`. TypeBox-first and the SINGLE source of truth:
+ * `UnifiedSearchResult` is `Static<>`-derived from this schema, which is also
+ * the tool's `outputSchema`. Every nested type (Entity, ConnectionInfo,
+ * ContentSnippet, ConversationSnippet, VirtualFeedRows) is itself
+ * schema-derived, so there is no hand-written interface that can drift.
  */
 export const UnifiedSearchResultSchema = Type.Object({
   entity_type: Type.Union([Type.String(), Type.Null()]),
-  entity: Type.Union([Type.Unknown(), Type.Null()]),
-  matches: Type.Array(Type.Unknown()),
-  connections: Type.Optional(Type.Array(Type.Unknown())),
+  entity: Type.Union([EntitySchema, Type.Null()]),
+  matches: Type.Array(EntitySchema),
+  connections: Type.Optional(Type.Array(ConnectionInfoSchema)),
   children: Type.Optional(
     Type.Array(
       Type.Object({
@@ -302,9 +274,15 @@ export const UnifiedSearchResultSchema = Type.Object({
       })
     )
   ),
-  content: Type.Optional(Type.Array(Type.Unknown())),
-  conversation_messages: Type.Optional(Type.Array(Type.Unknown())),
-  virtual_feeds: Type.Optional(Type.Array(Type.Unknown())),
+  content: Type.Optional(Type.Array(ContentSnippetSchema)),
+  /** Past chat-channel messages matching the query, scoped to the agent's own
+   * bound channels. Replaces the get_channel_history tool — read past convos
+   * through the same search call. */
+  conversation_messages: Type.Optional(Type.Array(ConversationSnippetSchema)),
+  /** Live rows recalled from opt-in virtual feeds (`config.recall === true`) —
+   * one block per feed, read via the connector's `search()` pushdown at request
+   * time. Never persisted. */
+  virtual_feeds: Type.Optional(Type.Array(VirtualFeedRowsSchema)),
   discovery_status: Type.Optional(
     Type.Union([Type.Literal('not_found'), Type.Literal('complete'), Type.Literal('discovering')])
   ),
@@ -325,6 +303,7 @@ export const UnifiedSearchResultSchema = Type.Object({
     page_size: Type.Integer(),
   }),
 });
+export type UnifiedSearchResult = Static<typeof UnifiedSearchResultSchema>;
 
 // ============================================
 // Result Helpers

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -277,6 +277,55 @@ interface UnifiedSearchResult {
   };
 }
 
+/**
+ * Output schema for `search_memory`. A permissive projection of
+ * `UnifiedSearchResult`: the envelope + the simple nested shapes (children,
+ * existing_entities, metadata, discovery_status) are precise, while the
+ * `Entity` / `ContentSnippet` / `ConversationSnippet` / `ConnectionInfo`
+ * arrays are `unknown` — those types live across the codebase (and
+ * `ContentItem` in `@lobu/connector-sdk`) and are wide snapshots, not a
+ * contract the MCP client introspects field-by-field. Honest over brittle.
+ */
+export const UnifiedSearchResultSchema = Type.Object({
+  entity_type: Type.Union([Type.String(), Type.Null()]),
+  entity: Type.Union([Type.Unknown(), Type.Null()]),
+  matches: Type.Array(Type.Unknown()),
+  connections: Type.Optional(Type.Array(Type.Unknown())),
+  children: Type.Optional(
+    Type.Array(
+      Type.Object({
+        id: Type.Integer(),
+        name: Type.String(),
+        type: Type.String(),
+        market: Type.Union([Type.String(), Type.Null()]),
+        content_count: Type.Integer(),
+      })
+    )
+  ),
+  content: Type.Optional(Type.Array(Type.Unknown())),
+  conversation_messages: Type.Optional(Type.Array(Type.Unknown())),
+  virtual_feeds: Type.Optional(Type.Array(Type.Unknown())),
+  discovery_status: Type.Optional(
+    Type.Union([Type.Literal('not_found'), Type.Literal('complete'), Type.Literal('discovering')])
+  ),
+  suggestion: Type.Optional(Type.String()),
+  view_url: Type.Optional(Type.String()),
+  existing_entities: Type.Optional(
+    Type.Array(
+      Type.Object({
+        entity_type: Type.String(),
+        entities: Type.Array(
+          Type.Object({ id: Type.Integer(), name: Type.String() })
+        ),
+      })
+    )
+  ),
+  metadata: Type.Object({
+    total_matches: Type.Integer(),
+    page_size: Type.Integer(),
+  }),
+});
+
 // ============================================
 // Result Helpers
 // ============================================

--- a/packages/server/src/types/watchers.ts
+++ b/packages/server/src/types/watchers.ts
@@ -2,8 +2,12 @@
  * Shared Watcher Types
  *
  * Single source of truth for watcher-related types used across
- * backend tools, utils, and frontend components.
+ * backend tools, utils, and frontend components. TypeBox-first: each type is
+ * derived from its schema via `Static<>`, so the runtime JSON Schema (surfaced
+ * as MCP tool `outputSchema`) and the TS type cannot drift.
  */
+
+import { type Static, Type } from '@sinclair/typebox';
 
 // ============================================
 // Watcher Sources
@@ -14,10 +18,11 @@
  * If the query references the `events` table, time window bounds are
  * automatically applied (incremental mode).
  */
-export interface WatcherSource {
-  name: string;
-  query: string;
-}
+export const WatcherSourceSchema = Type.Object({
+  name: Type.String(),
+  query: Type.String(),
+});
+export type WatcherSource = Static<typeof WatcherSourceSchema>;
 
 // ============================================
 // Watcher Version
@@ -31,38 +36,42 @@ export interface WatcherSource {
  * One reaction-log entry for a window (from watcher_reactions). Surfaced on
  * get_watcher windows so the UI can show what the reaction script did.
  */
-export interface WatcherWindowReaction {
-  id: number;
-  reaction_type: string;
-  tool_name: string;
-  tool_args?: Record<string, unknown>;
-  tool_result?: Record<string, unknown>;
-  created_at: string;
-}
+export const WatcherWindowReactionSchema = Type.Object({
+  id: Type.Integer(),
+  reaction_type: Type.String(),
+  tool_name: Type.String(),
+  tool_args: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  tool_result: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  created_at: Type.String(),
+});
+export type WatcherWindowReaction = Static<typeof WatcherWindowReactionSchema>;
 
 /**
  * Watcher window data as returned by get_watcher
  */
-export interface WatcherWindow {
-  window_id: number;
-  watcher_id: string;
-  watcher_name: string;
-  granularity: string;
-  window_start: string;
-  window_end: string;
-  content_analyzed: number;
-  extracted_data: Record<string, unknown>;
-  previous_extracted_data?: Record<string, unknown>;
-  classification_stats?: Record<string, Record<string, number>>;
-  model_used: string;
-  client_id?: string;
-  run_metadata?: Record<string, unknown>;
-  execution_time_ms: number;
-  created_at: string;
-  version_id?: number;
+export const WatcherWindowSchema = Type.Object({
+  window_id: Type.Integer(),
+  watcher_id: Type.String(),
+  watcher_name: Type.String(),
+  granularity: Type.String(),
+  window_start: Type.String(),
+  window_end: Type.String(),
+  content_analyzed: Type.Integer(),
+  extracted_data: Type.Record(Type.String(), Type.Unknown()),
+  previous_extracted_data: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  classification_stats: Type.Optional(
+    Type.Record(Type.String(), Type.Record(Type.String(), Type.Integer()))
+  ),
+  model_used: Type.String(),
+  client_id: Type.Optional(Type.String()),
+  run_metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  execution_time_ms: Type.Integer(),
+  created_at: Type.String(),
+  version_id: Type.Optional(Type.Integer()),
   /** Reaction-script execution log for this window (newest first). */
-  reactions?: WatcherWindowReaction[];
-}
+  reactions: Type.Optional(Type.Array(WatcherWindowReactionSchema)),
+});
+export type WatcherWindow = Static<typeof WatcherWindowSchema>;
 
 // ============================================
 // Keying Config
@@ -72,10 +81,10 @@ export interface WatcherWindow {
  * Configuration for computing stable entity keys.
  * Used to generate deterministic keys for merging entities across windows.
  */
-export interface KeyingConfig {
-  entity_path: string;
-  key_fields: string[];
-  key_output_field: string;
+export const KeyingConfigSchema = Type.Object({
+  entity_path: Type.String(),
+  key_fields: Type.Array(Type.String()),
+  key_output_field: Type.String(),
   /**
    * Entity-type slug the keyed rows are promoted into (P2 phase 1). When
    * omitted, promotion derives a slug from the last segment of `entity_path`
@@ -84,87 +93,109 @@ export interface KeyingConfig {
    * resolved, promotion is skipped for this window rather than failing the
    * completion.
    */
-  entity_type?: string;
-}
+  entity_type: Type.Optional(Type.String()),
+});
+export type KeyingConfig = Static<typeof KeyingConfigSchema>;
 
 // ============================================
 // Version Info (for listing available versions)
 // ============================================
 
-export interface WatcherVersionInfo {
-  version: number;
-  name: string;
-  created_at: string;
-  is_current: boolean;
-}
+export const WatcherVersionInfoSchema = Type.Object({
+  version: Type.Integer(),
+  name: Type.String(),
+  created_at: Type.String(),
+  is_current: Type.Boolean(),
+});
+export type WatcherVersionInfo = Static<typeof WatcherVersionInfoSchema>;
 
 // ============================================
 // Watcher Metadata (returned by get_watcher)
 // ============================================
 
-export interface WatcherMetadata {
-  watcher_id: string;
-  watcher_name: string;
-  slug: string;
-  status: 'active' | 'archived';
-  schedule?: string | null;
-  next_run_at?: string | null;
-  agent_id?: string | null;
+const WatcherRunSchema = Type.Object({
+  run_id: Type.Integer(),
+  status: Type.Union([
+    Type.Literal('pending'),
+    Type.Literal('claimed'),
+    Type.Literal('running'),
+    Type.Literal('completed'),
+    Type.Literal('failed'),
+    Type.Literal('cancelled'),
+    Type.Literal('timeout'),
+  ]),
+  error_message: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  created_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  completed_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+});
+
+export const WatcherMetadataSchema = Type.Object({
+  watcher_id: Type.String(),
+  watcher_name: Type.String(),
+  slug: Type.String(),
+  status: Type.Union([Type.Literal('active'), Type.Literal('archived')]),
+  schedule: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  next_run_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  agent_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   /**
    * Optional FK into `device_workers.id` pinning this watcher (and its run)
    * to a specific device worker. NULL/undefined means any worker can claim.
    */
-  device_worker_id?: string | null;
-  scheduler_client_id?: string | null;
-  version: number;
-  sources: WatcherSource[];
-  prompt?: string;
-  description?: string;
-  keying_config?: KeyingConfig | null;
+  device_worker_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  scheduler_client_id: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  version: Type.Integer(),
+  sources: Type.Array(WatcherSourceSchema),
+  prompt: Type.Optional(Type.String()),
+  description: Type.Optional(Type.String()),
+  keying_config: Type.Optional(Type.Union([KeyingConfigSchema, Type.Null()])),
   /** Version-owned config surfaced so the edit form can round-trip them
    *  (create_version preserves prev values on omit, but prefilling avoids
    *  the empty-form-state clobber). */
-  classifiers?: unknown[];
-  reactions_guidance?: string;
-  rendered_prompt?: string;
-  available_versions?: WatcherVersionInfo[];
-  reaction_script?: string;
-  watcher_run?: {
-    run_id: number;
-    status: 'pending' | 'claimed' | 'running' | 'completed' | 'failed' | 'cancelled' | 'timeout';
-    error_message?: string | null;
-    created_at?: string | null;
-    completed_at?: string | null;
-  };
-}
+  classifiers: Type.Optional(Type.Array(Type.Unknown())),
+  reactions_guidance: Type.Optional(Type.String()),
+  rendered_prompt: Type.Optional(Type.String()),
+  available_versions: Type.Optional(Type.Array(WatcherVersionInfoSchema)),
+  reaction_script: Type.Optional(Type.String()),
+  watcher_run: Type.Optional(WatcherRunSchema),
+});
+export type WatcherMetadata = Static<typeof WatcherMetadataSchema>;
 
 // ============================================
 // Pending Analysis
 // ============================================
 
-interface NextAction {
-  tool: string;
-  params: Record<string, unknown>;
-  description: string;
-}
+const NextActionSchema = Type.Object({
+  tool: Type.String(),
+  params: Type.Record(Type.String(), Type.Unknown()),
+  description: Type.String(),
+});
 
-export interface UnprocessedRange {
-  month: string;
-  window_start: string;
-  window_end: string;
-  total_content: number;
-  processed_content: number;
-  unprocessed_content: number;
-  status: 'unprocessed' | 'partial' | 'complete';
-}
+export const UnprocessedRangeSchema = Type.Object({
+  month: Type.String(),
+  window_start: Type.String(),
+  window_end: Type.String(),
+  total_content: Type.Integer(),
+  processed_content: Type.Integer(),
+  unprocessed_content: Type.Integer(),
+  status: Type.Union([
+    Type.Literal('unprocessed'),
+    Type.Literal('partial'),
+    Type.Literal('complete'),
+  ]),
+});
+export type UnprocessedRange = Static<typeof UnprocessedRangeSchema>;
 
-export interface PendingAnalysis {
-  unprocessed_count: number;
-  next_window: {
-    start: string;
-    end: string;
-    granularity: string;
-  } | null;
-  next_action: NextAction | null;
-  unprocessed_ranges?: UnprocessedRange[];
-}
+export const PendingAnalysisSchema = Type.Object({
+  unprocessed_count: Type.Integer(),
+  next_window: Type.Union([
+    Type.Object({
+      start: Type.String(),
+      end: Type.String(),
+      granularity: Type.String(),
+    }),
+    Type.Null(),
+  ]),
+  next_action: Type.Union([NextActionSchema, Type.Null()]),
+  unprocessed_ranges: Type.Optional(Type.Array(UnprocessedRangeSchema)),
+});
+export type PendingAnalysis = Static<typeof PendingAnalysisSchema>;

--- a/packages/server/src/utils/public-origin.ts
+++ b/packages/server/src/utils/public-origin.ts
@@ -49,6 +49,16 @@ export function getConfiguredPublicOrigin(): string | undefined {
   return new URL(gatewayUrl).origin;
 }
 
+/**
+ * Public-facing origin for a request: the configured `PUBLIC_GATEWAY_URL`
+ * override when set, otherwise the actual serving origin derived from the
+ * request URL. Single source for every "what origin should we stamp here?"
+ * call site (OAuth metadata, MCP view-resource domain, reauth links).
+ */
+export function resolvePublicOrigin(requestUrl?: string): string {
+  return getConfiguredPublicOrigin() ?? new URL(requestUrl ?? '').origin;
+}
+
 /** Configured gateway base, or loopback default for embedded/local boot. */
 export function resolvePublicGatewayUrl(): string {
   const configured = getConfiguredPublicGatewayUrl();


### PR DESCRIPTION
Closes all 8 platform-compatibility warnings from the MCP server checker (https://lobu.ai/mcp/market).

## What

**Error: tool-hints-present** — behavior hints (`readOnlyHint`/`destructiveHint`/`openWorldHint`/`idempotentHint`) on all 16 tools.

**Warning: tool-title-present** — titles on all tools (tool-picker display).

**Warning: tool-params-description-present** — descriptions on `manage_auth_profiles`/`manage_operations` params.

**Warning: tool-output-schema-present** — `outputSchema` on all 16 tools + matching `structuredContent` emitted on `tools/call`. TypeBox-first (single source of truth, no drift): each result type is `Static<typeof ResultSchema>`-derived from the same schema handed to `outputSchema`. `tools/call` returns `structuredContent` only for tools that declare an `outputSchema` (declaration ⇒ emission coupling); tools without one (`manage_agents`, `save_memory`, `query_*`) stay text-only.

**Warnings: view-resource metadata** (`tool-resource-metadata-complete`, `view-csp-valid`, `view-domain-present`, `view-csp-connect-domain`) — the 4 warnings all point at one resource, `ui://lobu/interaction`. Added `description` + `_meta.ui.{csp,domain}` to the `resources/list` entry. Factored `resolvePublicOrigin(requestUrl?)` out of two inline copies and threaded it into `createServerForContext` so the `domain` is per-request (works for self-hosters without `PUBLIC_GATEWAY_URL`). CSP is strict (`default-src 'none'`) matching the verified postMessage-only bundle.

## Single-source-of-truth design
- TypeBox schema → `type X = Static<typeof XSchema>` → registry `outputSchema`. `Static<>` derivation is the compile-time drift guard: if a handler's return shape drifts from the schema, `tsc` fails.
- Shared types promoted once in place: `types/watchers.ts` (7 types), `Entity`/`ContentSnippet`/etc. in `search.ts`, the `resolve_path` type tree.
- The one opaque field: `ContentItem` (a 90-field type in the published `@lobu/connector-sdk`) is modeled as `unknown` inline rather than mirrored — documented as the single honest opaque field.

## Validation
- `make build-packages` ✅, typecheck ✅, unit ✅ (76 pass)
- `make review`: **bug_free 82, simplicity 78, slop 10, bugs 0, blockers 0** (all thresholds pass)
- MCP + watchers + entities integration suites: 193 tests green
- New tests: `resources/list` metadata, `outputSchema` listing, `search_sdk` `structuredContent` emission
- The integration suite's `exit=1` in the review run was a confirmed flake in `scheduling-contract.test.ts` (concurrent-claim timing race) — passes in isolation; unrelated to this diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785770806&installation_id=136316292&pr_number=1719&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1719&signature=ea40564fb46be82632eb070b5673ec423825f17554e202ec82c4d15773bdf4dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP tools now expose richer result metadata, including structured outputs for supported tools.
  * UI-hosted app resources now include clearer descriptions and UI metadata for better client handling.
  * Tool listings now surface additional annotations and output schema information.

* **Bug Fixes**
  * Improved origin handling so UI links and authorization prompts use the correct public address more consistently.
  * Tightened tool result shapes to reduce malformed or incomplete responses.

* **Tests**
  * Added integration coverage for MCP resource listings and structured tool calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->