### PR TITLE
fix(mcp): validate structuredContent + fix outputSchema drift

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
@@ -69,7 +69,14 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     // Tools that declare an outputSchema carry it through to the listing...
     expect(byName.get('search_sdk')?.outputSchema?.type).toBe('object');
     expect(byName.get('search_memory')?.outputSchema?.type).toBe('object');
-    expect(byName.get('manage_watchers')?.outputSchema).toBeTruthy();
+    // ...including union-result tools: the MCP spec requires outputSchema to be
+    // an OBJECT schema, so even a discriminated `Type.Union` result must carry
+    // top-level `type: "object"` (a bare `anyOf` — TypeBox's default union
+    // serialization — is what a validating host rejects). The variants stay in
+    // `anyOf` so the client can still tell which one applied.
+    const watchersOut = byName.get('manage_watchers')?.outputSchema;
+    expect(watchersOut?.type).toBe('object');
+    expect(Array.isArray(watchersOut?.anyOf)).toBe(true);
     // ...while tools without one (text-only results) omit it.
     expect(byName.get('save_memory')?.outputSchema).toBeUndefined();
   });

--- a/packages/server/src/__tests__/unit/validate-args.test.ts
+++ b/packages/server/src/__tests__/unit/validate-args.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { Type } from "@sinclair/typebox";
 import { getAllTools, getTool } from "../../tools/registry";
-import { validateToolArgs, withValidatedArgs } from "../../tools/validate-args";
+import { validateToolArgs, validateToolResult, withValidatedArgs } from "../../tools/validate-args";
 import { ToolUserError } from "../../utils/errors";
 
 describe("validateToolArgs coercion", () => {
@@ -163,5 +163,57 @@ describe("registry completeness", () => {
       .filter((name) => !exempt.has(name))
       .filter((name) => brandedName(getTool(name)?.handler) !== name);
     expect(unwrapped).toEqual([]);
+  });
+});
+
+describe("validateToolResult (structuredContent emission)", () => {
+  const schema = Type.Object({
+    created_at: Type.String(),
+    count: Type.Integer(),
+    text: Type.String(),
+  });
+
+  it("coerces a Date to an ISO string so a raw SQL row satisfies Type.String()", () => {
+    const when = new Date("2026-07-04T00:00:00.000Z");
+    const out = validateToolResult(schema, { created_at: when, count: 3, text: "hi" }) as Record<
+      string,
+      unknown
+    >;
+    expect(out).not.toBeNull();
+    expect(out.created_at).toBe("2026-07-04T00:00:00.000Z");
+  });
+
+  it("returns null (→ text-only fallback) when the result cannot satisfy the schema", () => {
+    // text_content NULL where the schema demands a non-null string — the exact
+    // drift that used to reach the client as a validation error. Now: no
+    // structuredContent, not a failed call.
+    expect(validateToolResult(schema, { created_at: "x", count: 1, text: null })).toBeNull();
+  });
+
+  it("accepts any variant of a discriminated result union", () => {
+    const union = Type.Union([
+      Type.Object({ status: Type.Literal("completed"), output: Type.Unknown() }),
+      Type.Object({ status: Type.Literal("failed"), error_message: Type.String() }),
+    ]);
+    // A non-object `output` (array) must still validate — manage_operations #9.
+    expect(validateToolResult(union, { status: "completed", output: [1, 2] })).not.toBeNull();
+    expect(validateToolResult(union, { status: "failed", error_message: "boom" })).not.toBeNull();
+  });
+});
+
+describe("registry outputSchema normalization (MCP spec: must be an object schema)", () => {
+  it("stamps type:'object' on union result schemas while keeping the anyOf variants", () => {
+    // The 8 admin tools declare Type.Union result schemas → bare `{ anyOf }`.
+    // A spec-strict host rejects an outputSchema without top-level type:object.
+    const byName = new Map(getAllTools().map((t) => [t.name, t]));
+    const watchers = byName.get("manage_watchers") as { outputSchema?: any } | undefined;
+    expect(watchers?.outputSchema?.type).toBe("object");
+    expect(Array.isArray(watchers?.outputSchema?.anyOf)).toBe(true);
+  });
+
+  it("leaves an already-object result schema (search_memory) untouched", () => {
+    const byName = new Map(getAllTools().map((t) => [t.name, t]));
+    const search = byName.get("search_memory") as { outputSchema?: any } | undefined;
+    expect(search?.outputSchema?.type).toBe("object");
   });
 });

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -36,6 +36,7 @@ import {
 } from './mcp-session-state';
 import { type AuthContext, executeTool, extractAuthContext } from './tools/execute';
 import { getAllTools, getTool } from './tools/registry';
+import { validateToolResult } from './tools/validate-args';
 import { formatToolResult } from './formatting/markdown-formatter';
 import { resolvePublicOrigin } from './utils/public-origin';
 import { buildWorkspaceInstructions } from './utils/workspace-instructions';
@@ -270,16 +271,28 @@ function createServerForContext(
       // MCP hosts (Slack/Claude) needs the SERVER to author that view and stamp
       // it here; that is a deliberate follow-up. Until then we return plain text
       // rather than pointing an external host at a bundle it can't feed.
-      // When the tool declares an `outputSchema`, also return the raw result as
+      // When the tool declares an `outputSchema`, also return the result as
       // `structuredContent` (MCP spec: declaring outputSchema implies the result
-      // is structured). Tools without one (manage_agents, save_memory, ...) stay
-      // text-only — the schema is coupled to emission, never declared alone.
+      // is structured — and a spec-compliant client validates it against the
+      // declared schema). Tools without one (manage_agents, save_memory, ...)
+      // stay text-only — the schema is coupled to emission, never declared alone.
+      //
+      // Validate + coerce the result against the schema before emitting: result
+      // types are hand-authored TypeBox schemas but the values are assembled from
+      // raw SQL rows (Dates where the schema says String, counts as bigint, a
+      // NULL where the schema says non-null). `validateToolResult` coerces the
+      // fixable drift and, on an unfixable mismatch, returns null so we fall back
+      // to text-only rather than shipping structuredContent the client rejects —
+      // a successful tool call must never surface as a validation error.
       const tool = getTool(name);
       if (tool?.outputSchema && result && typeof result === 'object') {
-        return {
-          content: [{ type: 'text' as const, text }],
-          structuredContent: result as Record<string, unknown>,
-        };
+        const structured = validateToolResult(tool.outputSchema, result);
+        if (structured !== null) {
+          return {
+            content: [{ type: 'text' as const, text }],
+            structuredContent: structured as Record<string, unknown>,
+          };
+        }
       }
       return { content: [{ type: 'text' as const, text }] };
     } catch (error: any) {

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -273,9 +273,12 @@ const ManageEntityItemSchema = Type.Object({
   parent_entity_type: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
   enabled_classifiers: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()])),
-  // `Date` in the list variant is serialized to ISO string over the wire; the
-  // schema models the on-the-wire shape.
-  created_at: Type.Optional(Type.Union([Type.String(), Type.Unknown()])),
+  // `created_at` arrives from the row as a `Date`; the structuredContent
+  // validation layer coerces it to an ISO string before the check (Value.Convert
+  // on Type.String() converts Date → ISO), so the schema declares the honest
+  // on-the-wire shape — a string. (The former `Type.Unknown()` union arm made
+  // this field accept ANY value, silently voiding its type.)
+  created_at: Type.Optional(Type.String()),
   total_content: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
   active_connections: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
   watchers_count: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
@@ -857,7 +860,10 @@ async function handleList(
         parent_entity_type: e.parent_entity_type,
         metadata,
         enabled_classifiers: e.enabled_classifiers,
-        created_at: e.created_at,
+        // Row `created_at` is a Date; the schema (and wire shape) is an ISO
+        // string, so convert at the source rather than leaning on the emission
+        // layer's coercion.
+        created_at: toIsoStringOrNow(e.created_at),
         total_content: e.total_content,
         active_connections: e.active_connections,
         watchers_count: e.watchers_count,

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -57,8 +57,10 @@ const ListAvailableAction = Type.Object({
   backend: Type.Optional(BackendLiteral),
   include_input_schema: Type.Optional(Type.Boolean({ default: true, description: 'Include input schema in response' })),
   include_output_schema: Type.Optional(Type.Boolean({ default: false, description: 'Include output schema in response' })),
-  limit: Type.Optional(Type.Number({ description: 'Maximum number of results to return' })),
-  offset: Type.Optional(Type.Number({ description: 'Number of results to skip' })),
+  // Shared with list_runs — same limit/offset defaults + descriptions, and a
+  // future PaginationFields edit reaches both actions instead of silently
+  // skipping this hand-inlined copy.
+  ...PaginationFields,
 });
 
 const ExecuteAction = Type.Object({
@@ -141,7 +143,12 @@ export const ManageOperationsResultSchema = Type.Union([
     action: Type.Literal('execute'),
     run_id: Type.Integer(),
     status: Type.Literal('completed'),
-    output: Type.Record(Type.String(), Type.Unknown()),
+    // A connector/device operation's `action_output` is arbitrary JSON — it can
+    // be an array or a scalar, not just an object. Declaring `output` as an
+    // object-only Record made a non-object body fail structuredContent
+    // validation (no variant matched), turning a SUCCESSFUL run into a client
+    // error. `Type.Unknown()` accepts any JSON shape the run actually produced.
+    output: Type.Unknown(),
     metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
   }),
   Type.Object({
@@ -594,7 +601,9 @@ export async function waitForDeviceActionRun(
   abortSignal?: AbortSignal,
 ): Promise<{
   status: 'completed' | 'failed' | 'timeout';
-  output?: Record<string, unknown>;
+  // `action_output` is arbitrary connector/device JSON — object, array, or
+  // scalar — so the completed output is `unknown`, not an object.
+  output?: unknown;
   error_message?: string;
 }> {
   const sql = getDb();
@@ -612,7 +621,7 @@ export async function waitForDeviceActionRun(
       LIMIT 1
     `) as Array<{
       status: string;
-      action_output: Record<string, unknown> | null;
+      action_output: unknown;
       error_message: string | null;
       claimed_at: Date | string | null;
     }>;
@@ -626,7 +635,7 @@ export async function waitForDeviceActionRun(
     if (row.status === 'completed') {
       return {
         status: 'completed',
-        output: (row.action_output ?? {}) as Record<string, unknown>,
+        output: row.action_output ?? {},
       };
     }
     if (row.status === 'failed' || row.status === 'timeout') {

--- a/packages/server/src/tools/get_watchers.ts
+++ b/packages/server/src/tools/get_watchers.ts
@@ -48,6 +48,7 @@ import { buildWatchersUrl, type EntityInfo, getPublicWebUrl } from '../utils/url
 import {
   buildWindowsCountFromClause,
   buildWindowsSelectClause,
+  ensureIsoString,
   ensureNumber,
   foldUnprocessedRanges,
   parseBigintArray,
@@ -763,9 +764,13 @@ async function getWatcherImpl(
       watcher_id: w.watcher_id,
       watcher_name: w.watcher_name,
       granularity: w.granularity,
-      window_start: w.window_start,
-      window_end: w.window_end,
-      content_analyzed: w.content_analyzed,
+      // window_start/end and created_at come back from postgres.js as Date
+      // objects (raw timestamp columns, no ::text cast), while the outputSchema
+      // declares Type.String(). Coerce to ISO so structuredContent validates;
+      // window_start/end are NOT NULL, created_at falls back to window_end.
+      window_start: ensureIsoString(w.window_start) ?? '',
+      window_end: ensureIsoString(w.window_end) ?? '',
+      content_analyzed: ensureNumber(w.content_analyzed),
       extracted_data: extractedData,
       previous_extracted_data: previousExtractedData,
       classification_stats: stats,
@@ -773,7 +778,7 @@ async function getWatcherImpl(
       client_id: w.client_id ?? undefined,
       run_metadata: w.run_metadata ?? undefined,
       execution_time_ms: w.execution_time_ms ?? 0,
-      created_at: w.created_at ?? w.window_end,
+      created_at: ensureIsoString(w.created_at, w.window_end) ?? '',
       version_id: w.version_id ?? undefined,
       reactions: reactionsMap.get(windowIdNum),
     };

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -281,6 +281,22 @@ function flattenUnionSchema(schema: any): any {
   };
 }
 
+/**
+ * Ensure an outputSchema is advertised as an OBJECT schema, as the MCP spec
+ * requires. TypeBox serializes `Type.Union([Type.Object(...), ...])` to a bare
+ * `{ anyOf: [...] }` with no top-level `type`; a validating host rejects that
+ * (or the paired structuredContent). Unlike inputSchema we do NOT flatten the
+ * union into a single merged object — the discriminated variants are the
+ * correct description of a result — we only add the missing `type: "object"`.
+ * A schema that is already an object (or otherwise typed) is returned as-is.
+ */
+function normalizeOutputSchema(schema: any): any {
+  if (schema && (schema.anyOf || schema.oneOf) && schema.type === undefined) {
+    return { type: 'object' as const, ...schema };
+  }
+  return schema;
+}
+
 function filterSchemaForPublicActions(toolName: string, schema: any): any | null {
   const allowedActions = getPublicReadableActions(toolName);
   if (allowedActions === undefined) return null;
@@ -401,11 +417,14 @@ function computeAllTools(
         description: tool.description,
         inputSchema,
         ...(tool.annotations && { annotations: tool.annotations }),
-        // outputSchema is emitted as-is: it describes the result shape, not the
-        // Claude-API-constrained input. The `action` discriminator tells the
-        // client which union variant applied, so the full union is correct here
-        // (no flattening, no access-level filtering — those are input concerns).
-        ...(tool.outputSchema && { outputSchema: tool.outputSchema }),
+        // outputSchema keeps its discriminated variants (no flattening, no
+        // access-level filtering — those are input concerns) but the MCP spec
+        // requires a tool's outputSchema to be an OBJECT schema. TypeBox
+        // serializes a `Type.Union` of object variants to a bare `{ anyOf: [...] }`
+        // with no top-level `type`, which a validating host rejects. Stamp
+        // `type: "object"` on top so the union is advertised as a valid object
+        // schema while the `anyOf` still tells the client which variant applied.
+        ...(tool.outputSchema && { outputSchema: normalizeOutputSchema(tool.outputSchema) }),
       };
     })
     .filter((tool): tool is NonNullable<typeof tool> => tool !== null);

--- a/packages/server/src/tools/resolve_path.ts
+++ b/packages/server/src/tools/resolve_path.ts
@@ -234,6 +234,25 @@ type BootstrapWatcherItem = Static<typeof BootstrapWatcherItemSchema>;
 type BootstrapConnectorDefinition = Static<typeof BootstrapConnectorDefinitionSchema>;
 
 /**
+ * Coerce a timestamp value from a SQL row to an ISO string, tolerating NULL.
+ * `new Date(String(null)).toISOString()` throws (`new Date('null')` is Invalid
+ * Date → RangeError), and the feed/watcher queries ORDER BY
+ * `COALESCE(updated_at, created_at)` precisely because `updated_at` can be NULL.
+ * `fallback` supplies that same coalesced value so a non-null `updated_at`
+ * column stays a non-null string in the result. If both are absent, returns the
+ * epoch — a valid ISO string keeps the (non-nullable) schema field satisfied
+ * rather than throwing or emitting an invalid `structuredContent`.
+ */
+function toIso(value: unknown, fallback?: unknown): string {
+  for (const candidate of [value, fallback]) {
+    if (candidate == null) continue;
+    const date = new Date(String(candidate));
+    if (!Number.isNaN(date.getTime())) return date.toISOString();
+  }
+  return new Date(0).toISOString();
+}
+
+/**
  * Output schema for `resolve_path`. TypeBox-first: every nested type is
  * `Static<>`-derived from its schema, so this object composes them into one
  * source of truth for both the TS type (`ResolvePathResult`) and the MCP
@@ -1005,8 +1024,8 @@ async function fetchRecentContent(
     payload_template: row.payload_template as Record<string, unknown> | null | undefined,
     source_url: row.source_url ? String(row.source_url) : null,
     author_name: row.author_name ? String(row.author_name) : null,
-    created_at: new Date(String(row.created_at)).toISOString(),
-    occurred_at: row.occurred_at ? new Date(String(row.occurred_at)).toISOString() : null,
+    created_at: toIso(row.created_at),
+    occurred_at: row.occurred_at ? toIso(row.occurred_at) : null,
   }));
 }
 
@@ -1082,8 +1101,8 @@ async function fetchRecentFeeds(
     connector_name: row.connector_name ? String(row.connector_name) : null,
     connection_name: row.connection_name ? String(row.connection_name) : null,
     event_count: Number(row.event_count) || 0,
-    created_at: new Date(String(row.created_at)).toISOString(),
-    updated_at: new Date(String(row.updated_at)).toISOString(),
+    created_at: toIso(row.created_at),
+    updated_at: toIso(row.updated_at, row.created_at),
   }));
 }
 
@@ -1158,8 +1177,8 @@ async function fetchRecentWatchers(
     parent_entity_type: row.parent_entity_type ? String(row.parent_entity_type) : null,
     organization_slug: organizationSlug,
     windows_count: Number(row.windows_count) || 0,
-    created_at: new Date(String(row.created_at)).toISOString(),
-    updated_at: new Date(String(row.updated_at)).toISOString(),
+    created_at: toIso(row.created_at),
+    updated_at: toIso(row.updated_at, row.created_at),
   }));
 }
 

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -364,18 +364,24 @@ async function fetchContentSnippets(
     env
   );
 
-  return result.content.map((c) => ({
-    id: c.id,
-    title: c.title,
-    text_content:
-      c.payload_text.length > 500 ? c.payload_text.slice(0, 500) + '...' : c.payload_text,
-    author_name: c.author_name,
-    source_url: c.source_url,
-    platform: c.platform,
-    occurred_at: c.occurred_at,
-    similarity: c.similarity,
-    entity_ids: Array.isArray(c.entity_ids) ? c.entity_ids.map(Number) : [],
-  }));
+  return result.content.map((c) => {
+    // payload_text is `string | null` (a content row can have no text body).
+    // Coalesce to '' — both to avoid `.length`/`.slice` throwing on null and to
+    // keep the (non-nullable) `text_content` schema field honest: "" is the
+    // correct representation of no text, so structuredContent stays valid.
+    const text = c.payload_text ?? '';
+    return {
+      id: c.id,
+      title: c.title,
+      text_content: text.length > 500 ? text.slice(0, 500) + '...' : text,
+      author_name: c.author_name,
+      source_url: c.source_url,
+      platform: c.platform,
+      occurred_at: c.occurred_at,
+      similarity: c.similarity,
+      entity_ids: Array.isArray(c.entity_ids) ? c.entity_ids.map(Number) : [],
+    };
+  });
 }
 
 // Generic "what did we talk about" recall words carry no signal against a

--- a/packages/server/src/tools/validate-args.ts
+++ b/packages/server/src/tools/validate-args.ts
@@ -158,6 +158,45 @@ export function validateToolArgs(toolName: string, schema: TSchema, args: unknow
   return checkAgainst(toolName, schema, args);
 }
 
+/**
+ * Validate (and coerce) a tool's RESULT against its TypeBox output schema,
+ * for the `structuredContent` emission path (MCP spec: declaring `outputSchema`
+ * means the client validates the returned structured result against it).
+ *
+ * Returns the coerced result to emit as `structuredContent`, or `null` when the
+ * result cannot be made to satisfy the schema — the caller then falls back to
+ * text-only so a schema/runtime drift degrades gracefully instead of turning a
+ * successful tool call into a client-side validation error.
+ *
+ * The result is first JSON-normalized (`JSON.parse(JSON.stringify(...))`): this
+ * is exactly the transform the transport applies before the client sees the
+ * `structuredContent`, so we validate the shape the client will actually
+ * receive — and it is load-bearing, because handler results are assembled from
+ * raw SQL rows where a timestamp column is a `Date` (which `Value.Check` against
+ * `Type.String()` REJECTS, but whose JSON form is the ISO string the schema
+ * wants) and a `bigint` count needs its numeric form. A trailing `Value.Convert`
+ * still catches the residual numeric-string drift.
+ *
+ * Unlike the input side there is no per-variant dispatch: result unions are not
+ * uniformly `action`-keyed (e.g. manage_operations splits `execute` by `status`,
+ * and has an `error`-only variant), and `Value.Check` against a `Type.Union`
+ * already passes when ANY member matches — the exact semantics we want here.
+ */
+export function validateToolResult(schema: TSchema, result: unknown): unknown | null {
+  const validator = compileSchema(schema);
+  let normalized: unknown;
+  try {
+    // Mirror the wire transform: Dates → ISO strings, undefined keys dropped,
+    // non-JSON values surfaced. A result that cannot be serialized cannot be
+    // emitted as structuredContent anyway, so fall back to text-only.
+    normalized = JSON.parse(JSON.stringify(result));
+  } catch {
+    return null;
+  }
+  const coerced = Value.Convert(schema, normalized);
+  return validator.Check(coerced) ? coerced : null;
+}
+
 const VALIDATED_BRAND = Symbol.for('lobu.validated-tool-handler');
 
 interface BrandedHandler {

--- a/packages/server/src/utils/public-origin.ts
+++ b/packages/server/src/utils/public-origin.ts
@@ -54,9 +54,13 @@ export function getConfiguredPublicOrigin(): string | undefined {
  * override when set, otherwise the actual serving origin derived from the
  * request URL. Single source for every "what origin should we stamp here?"
  * call site (OAuth metadata, MCP view-resource domain, reauth links).
+ *
+ * `requestUrl` is required: it is the fallback when no override is configured,
+ * and every caller has a `req.url` to pass. An optional param invited a
+ * `new URL('')` that throws `TypeError: Invalid URL` — a trap, not a default.
  */
-export function resolvePublicOrigin(requestUrl?: string): string {
-  return getConfiguredPublicOrigin() ?? new URL(requestUrl ?? '').origin;
+export function resolvePublicOrigin(requestUrl: string): string {
+  return getConfiguredPublicOrigin() ?? new URL(requestUrl).origin;
 }
 
 /** Configured gateway base, or loopback default for embedded/local boot. */

--- a/packages/server/src/utils/window-utils.ts
+++ b/packages/server/src/utils/window-utils.ts
@@ -218,6 +218,29 @@ export function ensureNumber(value: bigint | number | string | null | undefined)
 }
 
 /**
+ * Safely convert a timestamp value from a SQL row to an ISO string.
+ *
+ * postgres.js returns `timestamp`/`timestamptz` columns as JS `Date` objects
+ * (not strings) unless the projection casts them to text, so a field typed
+ * `string` in the row interface is a `Date` at runtime. Emitting that raw Date
+ * as `structuredContent` fails a `Type.String()` outputSchema check. Normalize
+ * Date | string to ISO here; `fallback` covers a nullable column (e.g. a window
+ * `created_at` that defaults to its `window_end`). Returns null when neither is
+ * a usable timestamp — callers map that to a nullable schema field.
+ */
+export function ensureIsoString(
+  value: Date | string | null | undefined,
+  fallback?: Date | string | null | undefined
+): string | null {
+  for (const candidate of [value, fallback]) {
+    if (candidate == null) continue;
+    const date = candidate instanceof Date ? candidate : new Date(candidate);
+    if (!Number.isNaN(date.getTime())) return date.toISOString();
+  }
+  return null;
+}
+
+/**
  * Parse a PostgreSQL bigint[] column that may come back as a raw string
  * like "{9}" or "{1,2,3}" when fetch_types is disabled.
  * Returns an array of numbers.

--- a/packages/server/src/worker-api/dispatch-chrome-action.ts
+++ b/packages/server/src/worker-api/dispatch-chrome-action.ts
@@ -186,7 +186,16 @@ export async function dispatchChromeActionToExtension(params: {
   );
 
   // (3) Wait for the chrome extension to claim and complete.
-  return waitForDeviceActionRun(runId, organizationId, abortSignal);
+  const result = await waitForDeviceActionRun(runId, organizationId, abortSignal);
+  // `waitForDeviceActionRun` returns `output: unknown` (a device/connector run
+  // can produce any JSON). Chrome actions return object results and this
+  // result's `output` feeds `completeRunInline`, which requires an object, so
+  // narrow here: a non-object output is a protocol violation, floored to `{}`.
+  const output =
+    result.output && typeof result.output === 'object' && !Array.isArray(result.output)
+      ? (result.output as Record<string, unknown>)
+      : undefined;
+  return { ...result, output };
 }
 
 export async function dispatchChromeAction(c: Context<{ Bindings: Env }>) {


### PR DESCRIPTION
Follow-up to #1719. That PR added hand-authored TypeBox outputSchemas and made the MCP handler echo raw tool results as `structuredContent` with no server-side validation. A high-effort review found that any drift between a result schema and the actual runtime shape (a Date where the schema says String, a NULL where it says non-null, an array where it says object) turns a previously-working call into a client-side validation error on spec-compliant hosts — and two sites threw outright. This fixes all of it.

## What changed

- **mcp-handler**: validate + coerce each result against its outputSchema before emitting `structuredContent`; on an unfixable mismatch fall back to text-only so a successful call never surfaces as a client error. `validateToolResult` JSON-normalizes the result first (the exact wire transform), which turns Dates into ISO strings — `Value.Check(Type.String())` rejects a raw Date, so this is load-bearing, not cosmetic.
- **registry**: stamp `type: "object"` on union result schemas. The MCP spec requires outputSchema to be an object schema; TypeBox serializes `Type.Union` to a bare `anyOf`, which a validating host rejects. Variants are kept.
- **resolve_path**: guard NULL `updated_at` (was `new Date('null')` → RangeError), coalescing to `created_at` to match the query's own `ORDER BY COALESCE`.
- **search_memory**: coalesce NULL `text_content` to `""` (was `.length` on null → throw).
- **get_watcher**: coerce Date `window_start`/`window_end`/`created_at` to ISO (raw timestamp columns come back from postgres as Date).
- **manage_operations**: a completed run's `output` is arbitrary JSON (array/scalar possible), not object-only — widen to `Type.Unknown()`; restore the shared `PaginationFields` spread on `list_available`.
- **manage_entity**: drop the `Type.Unknown()` union arm that silently voided `created_at`'s type; convert the Date at the source.
- **public-origin**: make `resolvePublicOrigin(requestUrl)` required — the optional param fell back to `new URL('')`, which throws.
- **tests**: tighten the outputSchema listing assertion so the union-`anyOf` regression is caught in CI; add unit tests for the validate/coerce/fallback path and the registry normalization.

## Verification

- typecheck: clean
- server unit: 374 pass
- server integration (real Postgres): 1806 pass, 0 fail — including the two MCP suites
- One of the new unit tests caught a real bug in the first version of the fix (`Value.Convert` does not coerce Date→string on its own), which is why the JSON-normalize step is there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785774834&installation_id=136316292&pr_number=1721&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1721&signature=5349e20f6c3b8e81bae8c9ada31edfee7568705d7b859257df42054510d6d8e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of tool responses by validating output before sending structured results, with safe fallback to text when data doesn’t match the expected shape.
  * Fixed several timestamp fields so they consistently return valid ISO-formatted strings.
  * Prevented null-related issues in search snippet generation and recent feed formatting.
  * Improved handling of device action outputs so only valid object results are surfaced where expected.
  * Updated tool schema reporting to better match supported result shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->