### PR TITLE
fix(mcp): mark destructive admin tools destructiveHint=true

### DIFF
--- a/packages/server/src/tools/admin/index.ts
+++ b/packages/server/src/tools/admin/index.ts
@@ -75,8 +75,13 @@ interface AdminToolEntry {
 
 const READ_ONLY: ToolAnnotations = { readOnlyHint: true, idempotentHint: true };
 const WRITE: ToolAnnotations = { destructiveHint: false, idempotentHint: false };
+// Tools whose action union includes an irreversible action (delete / remove /
+// clear / cancel). MCP hints are per-tool, not per-action, so the conservative
+// correct answer for any tool that can destroy data is destructiveHint: true.
+const DESTRUCTIVE: ToolAnnotations = { destructiveHint: true, idempotentHint: false };
 
 const WRITE_WITH_TITLE = (title: string): ToolAnnotations => ({ ...WRITE, title });
+const DESTRUCTIVE_WITH_TITLE = (title: string): ToolAnnotations => ({ ...DESTRUCTIVE, title });
 const READ_ONLY_WITH_TITLE = (title: string): ToolAnnotations => ({ ...READ_ONLY, title });
 
 const ENTRIES: AdminToolEntry[] = [
@@ -86,7 +91,7 @@ const ENTRIES: AdminToolEntry[] = [
 		schema: ManageEntitySchema,
 		resultSchema: ManageEntityResultSchema,
 		handler: manageEntity,
-		annotations: WRITE_WITH_TITLE("Manage entities"),
+		annotations: DESTRUCTIVE_WITH_TITLE("Manage entities"),
 	},
 	{
 		name: "manage_entity_schema",
@@ -95,7 +100,7 @@ const ENTRIES: AdminToolEntry[] = [
 		schema: ManageEntitySchemaSchema,
 		resultSchema: ManageEntitySchemaResultSchema,
 		handler: manageEntitySchema,
-		annotations: WRITE_WITH_TITLE("Manage entity schemas"),
+		annotations: DESTRUCTIVE_WITH_TITLE("Manage entity schemas"),
 	},
 	{
 		name: "manage_connections",
@@ -103,7 +108,7 @@ const ENTRIES: AdminToolEntry[] = [
 		schema: ManageConnectionsSchema,
 		resultSchema: ManageConnectionsResultSchema,
 		handler: manageConnections,
-		annotations: WRITE_WITH_TITLE("Manage connections"),
+		annotations: DESTRUCTIVE_WITH_TITLE("Manage connections"),
 	},
 	{
 		name: "manage_catalog",
@@ -111,6 +116,10 @@ const ENTRIES: AdminToolEntry[] = [
 		schema: ManageCatalogSchema,
 		resultSchema: ManageCatalogResultSchema,
 		handler: manageCatalog,
+		// Read-only today (only list_catalog / list_installed actions). If a
+		// write action (install / uninstall / purge) is added here, drop
+		// READ_ONLY and pick WRITE or DESTRUCTIVE to match — clients and approval
+		// UIs trust readOnlyHint to skip confirmation.
 		annotations: READ_ONLY_WITH_TITLE("Manage catalog"),
 	},
 	{
@@ -118,7 +127,7 @@ const ENTRIES: AdminToolEntry[] = [
 		description: "Agent management (incl. the org system agent pointer).",
 		schema: ManageAgentsSchema,
 		handler: manageAgents,
-		annotations: WRITE_WITH_TITLE("Manage agents"),
+		annotations: DESTRUCTIVE_WITH_TITLE("Manage agents"),
 	},
 	{
 		name: "manage_feeds",
@@ -126,7 +135,7 @@ const ENTRIES: AdminToolEntry[] = [
 		schema: ManageFeedsSchema,
 		resultSchema: ManageFeedsResultSchema,
 		handler: manageFeeds,
-		annotations: WRITE_WITH_TITLE("Manage feeds"),
+		annotations: DESTRUCTIVE_WITH_TITLE("Manage feeds"),
 	},
 	{
 		name: "manage_auth_profiles",
@@ -135,7 +144,7 @@ const ENTRIES: AdminToolEntry[] = [
 		schema: ManageAuthProfilesSchema,
 		resultSchema: ManageAuthProfilesResultSchema,
 		handler: manageAuthProfiles,
-		annotations: WRITE_WITH_TITLE("Manage auth profiles"),
+		annotations: DESTRUCTIVE_WITH_TITLE("Manage auth profiles"),
 	},
 	{
 		name: "manage_operations",
@@ -160,7 +169,7 @@ const ENTRIES: AdminToolEntry[] = [
 			"Create / list / pause / cancel recurring or one-shot scheduled jobs. Supports send_notification and wake_agent action types. Per-row attribution lets you trace what scheduled it and from where.",
 		schema: ManageSchedulesSchema,
 		handler: manageSchedules,
-		annotations: WRITE_WITH_TITLE("Manage schedules"),
+		annotations: DESTRUCTIVE_WITH_TITLE("Manage schedules"),
 	},
 	{
 		name: "manage_watchers",
@@ -168,7 +177,7 @@ const ENTRIES: AdminToolEntry[] = [
 		schema: ManageWatchersSchema,
 		resultSchema: ManageWatchersResultSchema,
 		handler: manageWatchers,
-		annotations: WRITE_WITH_TITLE("Manage watchers"),
+		annotations: DESTRUCTIVE_WITH_TITLE("Manage watchers"),
 	},
 	{
 		name: "list_watchers",
@@ -202,7 +211,7 @@ const ENTRIES: AdminToolEntry[] = [
 		schema: ManageClassifiersSchema,
 		resultSchema: ManageClassifiersResultSchema,
 		handler: manageClassifiers,
-		annotations: WRITE_WITH_TITLE("Manage classifiers"),
+		annotations: DESTRUCTIVE_WITH_TITLE("Manage classifiers"),
 	},
 	{
 		name: "manage_view_templates",
@@ -211,7 +220,7 @@ const ENTRIES: AdminToolEntry[] = [
 		schema: ManageViewTemplatesSchema,
 		resultSchema: ManageViewTemplatesResultSchema,
 		handler: manageViewTemplates,
-		annotations: WRITE_WITH_TITLE("Manage view templates"),
+		annotations: DESTRUCTIVE_WITH_TITLE("Manage view templates"),
 	},
 ];
 


### PR DESCRIPTION
## What

MCP tool hints are per-tool, not per-action. Every `manage_*` tool whose action union includes an irreversible action (delete / remove / clear / cancel) was stamped `destructiveHint: false`, so spec-compliant hosts would treat e.g. `manage_entity delete` as safe and skip confirmation.

## Change

- Add a `DESTRUCTIVE` annotation constant (`destructiveHint: true`) alongside the existing `READ_ONLY` / `WRITE`.
- Apply `DESTRUCTIVE_WITH_TITLE` to the 10 tools with irreversible actions: `manage_entity`, `manage_entity_schema`, `manage_connections`, `manage_agents`, `manage_feeds`, `manage_auth_profiles`, `manage_schedules` (has `cancel`), `manage_watchers`, `manage_classifiers`, `manage_view_templates` (has `clear`/`remove_tab`).
- Leave alone: `manage_operations` (approve/reject — not destructive), `notify` (fire-and-forget write), `manage_catalog` (genuinely read-only), all read tools.
- Add a guard comment on `manage_catalog` (read-only today) against silently inheriting a future write action.

## Verified live in prod before changing

Captured the live `tools/list` from prod pod `summaries-app-lobu-app` (image `20260704-164212`, SHA \`42bb2a7cf\`):
- 16 tools listed, all with \`outputSchema\` + \`annotations\`
- All write \`manage_*\` tools showed \`destructiveHint: false\` — the bug this PR fixes

## Test plan

- [x] \`tool-access.test.ts\` (67/67) — asserts the access matrix and tool registration, including \`manage_catalog is registered\`
- [x] \`manage_catalog.test.ts\` (3/3)
- [x] Server typecheck clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785781048&installation_id=136316292&pr_number=1725&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1725&signature=b074bbd919abaff32bad5179245a992705512927aeae5ffa5a776c74d55960f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin tool listings now better indicate when actions are destructive.
  * Several management tools now display a destructive warning hint in their metadata, improving clarity before execution.
* **Bug Fixes**
  * Read-only catalog actions continue to appear as non-destructive, keeping tool labels more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->