### PR TITLE
fix(mcp): hide server-internal search_memory args from public schema

### DIFF
--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -27,7 +27,7 @@ import { QuerySqlSchema, querySql } from './admin/query_sql';
 import { ListOrganizationsSchema } from './organizations';
 import { ResolvePathSchema, ResolvePathResultSchema, resolvePath } from './resolve_path';
 import { SaveContentSchema, saveContent } from './save_content';
-import { SearchSchema, UnifiedSearchResultSchema, search } from './search';
+import { PublicSearchSchema, SearchSchema, UnifiedSearchResultSchema, search } from './search';
 import { QuerySchema, RunSchema, querySdkScript, runSdkScript } from './sdk_run';
 import { SdkSearchSchema, SdkSearchResultSchema, sdkSearch } from './sdk_search';
 
@@ -111,6 +111,14 @@ export interface ToolDefinition<T = any> {
   name: string;
   description: string;
   inputSchema: any; // JSON Schema
+  /**
+   * Narrower schema advertised on `tools/list` when the tool accepts fields
+   * that are server-internal (e.g. pre-computed embeddings, identity-bound
+   * filters the server populates from auth context). Validation still runs
+   * against the full `inputSchema`, so internal callers and tests keep working;
+   * only the client-facing listing is narrowed. Falls back to `inputSchema`.
+   */
+  publicInputSchema?: any; // JSON Schema
   annotations?: ToolAnnotations;
   /**
    * JSON Schema describing the tool's structured result. When present, the
@@ -135,6 +143,10 @@ const TOOLS: ToolDefinition[] = [
     description:
       'Search saved workspace memory: entities, facts, decisions, preferences, observations, and notes. Use this to answer “what do we know?” Pair writes with `save_memory`; use `search_sdk` / `query_sdk` only when you need SDK capabilities or programmable reads.',
     inputSchema: SearchSchema,
+    // Advertise the narrower public schema: query_embedding (server pre-compute
+    // optimization) and agent_id (auth-bound) are server-internal, not client
+    // affordances. See search.ts → PublicSearchSchema.
+    publicInputSchema: PublicSearchSchema,
     outputSchema: UnifiedSearchResultSchema,
     annotations: { ...READ_ONLY, title: 'Search memory' },
     handler: search,
@@ -388,7 +400,11 @@ function computeAllTools(
   return TOOLS
     .filter((tool) => !publicOnly || getPublicReadableActions(tool.name) !== undefined)
     .map((tool) => {
-      let inputSchema = tool.inputSchema;
+      // Advertise the narrower `publicInputSchema` when a tool declares one;
+      // validation still runs against the full `inputSchema` so internal
+      // server-supplied fields (e.g. embeddings, auth-bound filters) are
+      // accepted at the handler boundary but never advertised to clients.
+      let inputSchema = tool.publicInputSchema ?? tool.inputSchema;
       const readOnlyHint = tool.annotations?.readOnlyHint === true;
 
       if (publicOnly) {

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -754,8 +754,10 @@ async function searchImpl(
   // The caller's bound agent (from auth context) scopes recall by default; an
   // explicit `agent_id` arg is still honored for server-internal cross-agent
   // recall, but is no longer advertised to clients (see PublicSearchSchema).
-  const agentIdScope =
-    args.agent_id ?? (args.metadata_filter?.agent_id as string | undefined) ?? ctx.agentId ?? undefined;
+  // NOTE: deliberately NOT reading `metadata_filter.agent_id` — `metadata_filter`
+  // is on the public schema, so honoring it would re-expose the very footgun
+  // `PublicSearchSchema` hides.
+  const agentIdScope = args.agent_id ?? ctx.agentId ?? undefined;
   // Channel recall is fenced to the CALLING agent's own bindings (ctx.agentId),
   // never a caller-supplied filter — that's the tenant boundary for transcript
   // rows, which have no agent_id of their own. gatherRecall catches per source.
@@ -1037,10 +1039,13 @@ async function queryEntities(
     }
   }
 
-  // Structured agent_id filter (also accepted under metadata_filter; the
-  // top-level form is the documented contract so agents can't typo the key).
-  const agentIdFilter =
-    args.agent_id ?? (args.metadata_filter?.agent_id as string | undefined);
+  // Structured agent_id filter. The top-level `agent_id` arg is the only
+  // accepted form — it's server-internal (resolved from auth context in
+  // searchImpl, or passed by server-internal callers); it is NOT advertised
+  // on the public schema (see PublicSearchSchema). Do NOT honor
+  // `metadata_filter.agent_id` — `metadata_filter` is public, so honoring it
+  // would re-expose the cross-agent footgun the field split hides.
+  const agentIdFilter = args.agent_id;
   if (agentIdFilter) {
     conditions.push(`e.metadata->>'agent_id' = $${addParam(agentIdFilter)}`);
   }

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -133,6 +133,23 @@ export const SearchSchema = Type.Object({
   ),
 });
 
+/**
+ * Schema advertised on `tools/list`. Drops the server-internal fields that
+ * `SearchSchema` still accepts (so validation passes for internal callers and
+ * tests): `query_embedding` (a pre-computed vector the content-search layer
+ * re-derives itself when absent) and `agent_id` (the caller's bound agent,
+ * resolved from auth context — clients asserting it cross-agent within an org
+ * is a footgun, not an affordance). See `ToolDefinition.publicInputSchema`.
+ */
+const PUBLIC_SEARCH_SCHEMA_INTERNAL_FIELDS = ['query_embedding', 'agent_id'];
+export const PublicSearchSchema = Type.Object(
+  Object.fromEntries(
+    Object.entries(SearchSchema.properties).filter(
+      ([key]) => !PUBLIC_SEARCH_SCHEMA_INTERNAL_FIELDS.includes(key)
+    )
+  )
+);
+
 type SearchArgs = Static<typeof SearchSchema>;
 
 // ============================================
@@ -734,8 +751,11 @@ async function searchImpl(
   // query or a pre-computed embedding — forwarding the embedding lets the
   // content layer skip regenerating it from text.
   const hasContentSignal = Boolean(args.query || args.query_embedding?.length);
+  // The caller's bound agent (from auth context) scopes recall by default; an
+  // explicit `agent_id` arg is still honored for server-internal cross-agent
+  // recall, but is no longer advertised to clients (see PublicSearchSchema).
   const agentIdScope =
-    args.agent_id ?? (args.metadata_filter?.agent_id as string | undefined);
+    args.agent_id ?? (args.metadata_filter?.agent_id as string | undefined) ?? ctx.agentId ?? undefined;
   // Channel recall is fenced to the CALLING agent's own bindings (ctx.agentId),
   // never a caller-supplied filter — that's the tenant boundary for transcript
   // rows, which have no agent_id of their own. gatherRecall catches per source.


### PR DESCRIPTION
## What

\`search_memory\` advertised \`query_embedding\` and \`agent_id\` on \`tools/list\`. Both are server-internal, not client affordances:

- **\`query_embedding\`** — a pre-computed vector the content-search layer re-derives itself when absent. Exposing it lets clients bypass the embedding model (model drift → silent garbage ranking), leaks the vector dimension, and enables crafted-vector probes of semantic ranking.
- **\`agent_id\`** — the caller's bound agent, resolved from auth context. Clients asserting it cross-agent within an org is a footgun, not a feature. \`autoRecall\` (the only real caller) doesn't pass it.

## Change

- Add \`ToolDefinition.publicInputSchema?\` — a narrower schema advertised on \`tools/list\` while validation still runs against the full \`inputSchema\`. Generic mechanism, reusable.
- \`computeAllTools\` (registry listing) prefers \`publicInputSchema ?? inputSchema\`.
- Wire \`search_memory\` to a \`PublicSearchSchema\` (14 fields) that drops the two fields, derived from \`SearchSchema\` (16 fields) without duplicating field definitions.
- Handler now defaults \`agentIdScope\` to \`ctx.agentId\` (auth-resolved bound agent) when no explicit \`agent_id\` is passed — preserves agent-scoping behavior without exposing the field.

## Why a split schema, not just removal

The validation gate (\`withValidatedArgs\`) enforces the advertised schema strictly — removing the fields outright would 400 the integration tests that drive deterministic recall via explicit orthogonal embeddings (\`github-repo-visibility\`, \`resource-gate-stale-acl\`, \`search-content-visibility\`, \`search-content-embedding-only\`). The split keeps the server-internal optimization path working while hiding the fields from clients.

## Test plan

- [x] Runtime check: \`PublicSearchSchema\` has 14 props, neither field present
- [x] Visibility tests (use \`query_embedding\` via internal \`search()\`): 14/14
- [x] \`all-tools-e2e.test.ts\` (asserts every tool lists + round-trips): 29/29
- [x] \`mcp/auth.test.ts\`: 30+ tests
- [x] \`slack-channel-visibility.test.ts\`: 13 tests
- [x] Server typecheck clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785781061&installation_id=136316292&pr_number=1726&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1726&signature=a9d6f6e9cf68b0408677780c04f933cd74831847311c16d3d620b631edc08051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool listings can now publish a client-facing input schema that hides internal-only fields.
  * The search tool’s published schema is now narrower and simpler for clients to use.

* **Bug Fixes**
  * Search requests now default agent scoping to the current authenticated agent when none is provided, improving result isolation.
  * Agent ID filtering for structured entity name search is now read only from the top-level input, not from nested filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->