### PR TITLE
feat(device): force personal-org binding for device clients

### DIFF
--- a/packages/cli/src/commands/__tests__/whoami.test.ts
+++ b/packages/cli/src/commands/__tests__/whoami.test.ts
@@ -112,6 +112,51 @@ describe("whoamiCommand --json", () => {
     expect(result.loggedIn).toBe(true);
   });
 
+  test("emits personalOrgSlug from the personal-flagged org", async () => {
+    spyOn(internal, "refreshCredentials").mockResolvedValue({
+      accessToken: "token",
+      oauth: {
+        clientId: "client-id",
+        tokenEndpoint: "https://issuer.example.com/token",
+      },
+    });
+    spyOn(internal, "getAgentApiToken").mockResolvedValue("token");
+    // The active org is a team org, but the personal one is buremba — the
+    // device client must target the personal org regardless of `orgSlug`.
+    spyOn(internal, "listOrganizations").mockResolvedValue([
+      { slug: "lobu-team", name: "Lobu Team" },
+      { slug: "buremba", name: "buremba", personal: true },
+    ]);
+    spyOn(internal, "getActiveOrg").mockResolvedValue("lobu-team");
+
+    await whoamiCommand({ json: true });
+
+    const result = parseJsonOutput();
+    expect(result.orgSlug).toBe("lobu-team");
+    expect(result.personalOrgSlug).toBe("buremba");
+  });
+
+  test("emits personalOrgSlug=undefined when no org is marked personal", async () => {
+    spyOn(internal, "refreshCredentials").mockResolvedValue({
+      accessToken: "token",
+      oauth: {
+        clientId: "client-id",
+        tokenEndpoint: "https://issuer.example.com/token",
+      },
+    });
+    spyOn(internal, "getAgentApiToken").mockResolvedValue("token");
+    spyOn(internal, "listOrganizations").mockResolvedValue([
+      { slug: "acme", name: "Acme" },
+    ]);
+    spyOn(internal, "getActiveOrg").mockResolvedValue("acme");
+
+    await whoamiCommand({ json: true });
+
+    const result = parseJsonOutput();
+    expect(result.personalOrgSlug).toBeUndefined();
+    expect(result.orgSlug).toBe("acme");
+  });
+
   test("falls back to accessToken when getAgentApiToken fails", async () => {
     spyOn(internal, "refreshCredentials").mockResolvedValue({
       accessToken: "fallback-token",

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -36,6 +36,12 @@ interface WhoamiJson {
   expiresAt?: number;
   /** Active org slug bound to this context, when set. */
   orgSlug?: string;
+  /**
+   * The user's personal-org slug. Device clients (Owletto Mac + Chrome) bind
+   * here regardless of `orgSlug` (the active/CLI-selected org) — personal
+   * device data always lands in the private workspace.
+   */
+  personalOrgSlug?: string;
   organizations: Array<{ slug: string; name?: string }>;
 }
 
@@ -120,10 +126,11 @@ async function emitJson(
   const effective = creds ?? (await loadCredentials(target.name));
 
   let organizations: Array<{ slug: string; name?: string }> = [];
+  let personalOrgSlug: string | undefined;
   try {
-    organizations = (await listOrganizations({ context: target.name })).map(
-      (org) => ({ slug: org.slug, name: org.name })
-    );
+    const full = await listOrganizations({ context: target.name });
+    organizations = full.map((org) => ({ slug: org.slug, name: org.name }));
+    personalOrgSlug = full.find((org) => org.personal)?.slug;
   } catch {
     organizations = [];
   }
@@ -142,6 +149,7 @@ async function emitJson(
     workerToken: workerToken ?? effective?.accessToken,
     expiresAt: effective?.expiresAt,
     orgSlug,
+    personalOrgSlug,
     organizations,
   };
 

--- a/packages/cli/src/internal/api-client.ts
+++ b/packages/cli/src/internal/api-client.ts
@@ -27,6 +27,8 @@ interface ResolvedApiClient {
 interface OrganizationInfo {
   slug: string;
   name?: string;
+  /** True for the user's personal org (server marks it via `personal_org_slug`). */
+  personal?: boolean;
 }
 
 /** HTTP verbs the CLI's REST clients issue. */
@@ -289,15 +291,23 @@ async function getOrganizationsFromUserInfo(
   > | null;
   if (!data) return [];
   const orgs = Array.isArray(data.organizations) ? data.organizations : [];
+  // The server exposes the personal-org slug both top-level and per-entry; use
+  // whichever is present so device clients (Owletto Mac/Chrome) can target the
+  // personal workspace regardless of the active org.
+  const personalSlug =
+    typeof data.personal_org_slug === "string" ? data.personal_org_slug : "";
   const result: OrganizationInfo[] = [];
   for (const entry of orgs) {
     if (!entry || typeof entry !== "object") continue;
     const value = entry as Record<string, unknown>;
     const slug = typeof value.slug === "string" ? value.slug : "";
     if (!slug) continue;
+    const isPersonal =
+      value.personal === true || (personalSlug !== "" && slug === personalSlug);
     result.push({
       slug,
       ...(typeof value.name === "string" ? { name: value.name } : {}),
+      ...(isPersonal ? { personal: true } : {}),
     });
   }
   return result;

--- a/packages/server/src/__tests__/integration/oauth/device-worker-personal-org.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/device-worker-personal-org.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Device clients (Owletto Mac app, Chrome extension, local `lobu run` worker)
+ * ALWAYS bind to the user's personal org — never the active/selected org and
+ * never the `resource` slug the client passes. Personal device data belongs in
+ * the private workspace; team orgs reach a device by pinning a watcher /
+ * connection to it (resolveDeviceClaimableOrgs), not by re-binding the token.
+ *
+ * These tests pin that invariant on the two server surfaces a device client
+ * touches:
+ *   - the device-code grant (`/oauth/device/approve` + `/oauth/token`): the
+ *     resulting access token's `organization_id` MUST be the personal org,
+ *     even when the client requested a team-org `resource` and the user is a
+ *     multi-org member.
+ *   - `/oauth/userinfo`: exposes `personal_org_slug` and marks the personal
+ *     org with `personal: true`, so the Owletto menu bar can target it
+ *     directly.
+ */
+
+import { Hono } from 'hono';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { oauthRoutes } from '../../../auth/oauth/routes';
+import { hashToken } from '../../../auth/oauth/utils';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestSession,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const TEST_ENV = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+  JWT_SECRET: 'test-jwt-secret-for-testing-only',
+  BETTER_AUTH_SECRET: 'test-auth-secret-for-testing-only',
+  RATE_LIMIT_ENABLED: 'false',
+} as unknown as Env;
+
+const ORIGIN = 'http://localhost';
+
+function buildApp(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+  app.route('/', oauthRoutes);
+  return app;
+}
+
+function call(
+  app: Hono<{ Bindings: Env }>,
+  method: string,
+  path: string,
+  opts?: { body?: unknown; headers?: Record<string, string> }
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Origin: ORIGIN,
+    ...opts?.headers,
+  };
+  return app.fetch(
+    new Request(`${ORIGIN}${path}`, {
+      method,
+      headers,
+      ...(opts?.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+    }),
+    TEST_ENV
+  );
+}
+
+async function markPersonalOrg(orgId: string, userId: string): Promise<void> {
+  const sql = getTestDb();
+  // Match personal-org-provisioning.ts: store the marker as plain JSON text
+  // (the column is `text`; the read path casts with `(metadata::jsonb)->>`).
+  const metadata = JSON.stringify({ personal_org_for_user_id: userId });
+  await sql`
+    UPDATE "organization"
+    SET metadata = ${metadata}
+    WHERE id = ${orgId}
+  `;
+}
+
+beforeAll(async () => {
+  await initWorkspaceProvider();
+});
+
+afterAll(async () => {
+  // nothing to tear down — app is in-process
+});
+
+describe('device-worker grant always binds to the personal org', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('binds the access token to the personal org, ignoring a team-org resource + active org', async () => {
+    const app = buildApp();
+    const sql = getTestDb();
+
+    // A user who belongs to TWO orgs: their personal one + a team org.
+    const personalOrg = await createTestOrganization({ name: 'Personal' });
+    const teamOrg = await createTestOrganization({ name: 'Team Workspace' });
+    const user = await createTestUser({ name: 'Device User' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+    await addUserToOrganization(user.id, teamOrg.id, 'owner');
+    const session = await createTestSession(user.id);
+
+    // Register a device-code client (the CLI / Mac app's DCR step).
+    const reg = await call(app, 'POST', '/oauth/register', {
+      body: {
+        client_name: 'Owletto Mac test',
+        grant_types: ['urn:ietf:params:oauth:grant-type:device_code', 'refresh_token'],
+        token_endpoint_auth_method: 'none',
+      },
+    });
+    expect(reg.status).toBe(201);
+    const client = (await reg.json()) as { client_id: string };
+
+    // The client requests device_worker:run AND points `resource` at the TEAM
+    // org — exactly the lure that used to land devices in the wrong workspace.
+    const deviceAuth = await call(app, 'POST', '/oauth/device_authorization', {
+      body: {
+        client_id: client.client_id,
+        scope: 'device_worker:run mcp:read mcp:write mcp:admin profile:read connections:token',
+        resource: `${ORIGIN}/mcp/${teamOrg.slug}`,
+      },
+    });
+    expect(deviceAuth.status).toBe(200);
+    const da = (await deviceAuth.json()) as { device_code: string; user_code: string };
+
+    // Approve — note NO organization_id is sent. The handler must force the
+    // personal org; it must NOT bounce with org_selection_required.
+    const approve = await call(app, 'POST', '/oauth/device/approve', {
+      body: { user_code: da.user_code, approved: true },
+      headers: { Cookie: session.cookieHeader },
+    });
+    expect(approve.status).toBe(200);
+
+    const tokenRes = await call(app, 'POST', '/oauth/token', {
+      body: {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: da.device_code,
+        client_id: client.client_id,
+      },
+    });
+    expect(tokenRes.status).toBe(200);
+    const tokens = (await tokenRes.json()) as { access_token: string };
+
+    // The persisted access token is bound to the PERSONAL org, not the team org
+    // the resource pointed at.
+    const rows = (await sql`
+      SELECT organization_id FROM oauth_tokens
+      WHERE token_hash = ${hashToken(tokens.access_token)}
+        AND token_type = 'access'
+      LIMIT 1
+    `) as unknown as Array<{ organization_id: string | null }>;
+    expect(rows.length).toBe(1);
+    expect(rows[0].organization_id).toBe(personalOrg.id);
+    expect(rows[0].organization_id).not.toBe(teamOrg.id);
+  });
+
+  it('exposes personal_org_slug and marks the personal org on /oauth/userinfo', async () => {
+    const app = buildApp();
+    const sql = getTestDb();
+
+    const personalOrg = await createTestOrganization({ name: 'Personal UserInfo' });
+    const teamOrg = await createTestOrganization({ name: 'Team UserInfo' });
+    const user = await createTestUser({ name: 'Info User' });
+    await markPersonalOrg(personalOrg.id, user.id);
+    await addUserToOrganization(user.id, personalOrg.id, 'owner');
+    await addUserToOrganization(user.id, teamOrg.id, 'member');
+    const session = await createTestSession(user.id);
+
+    const reg = await call(app, 'POST', '/oauth/register', {
+      body: {
+        client_name: 'Owletto Mac userinfo',
+        grant_types: ['urn:ietf:params:oauth:grant-type:device_code', 'refresh_token'],
+        token_endpoint_auth_method: 'none',
+      },
+    });
+    const client = (await reg.json()) as { client_id: string };
+
+    const deviceAuth = await call(app, 'POST', '/oauth/device_authorization', {
+      body: {
+        client_id: client.client_id,
+        scope: 'device_worker:run mcp:read profile:read',
+      },
+    });
+    const da = (await deviceAuth.json()) as { device_code: string; user_code: string };
+
+    const approve = await call(app, 'POST', '/oauth/device/approve', {
+      body: { user_code: da.user_code, approved: true },
+      headers: { Cookie: session.cookieHeader },
+    });
+    expect(approve.status).toBe(200);
+
+    const tokenRes = await call(app, 'POST', '/oauth/token', {
+      body: {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: da.device_code,
+        client_id: client.client_id,
+      },
+    });
+    const tokens = (await tokenRes.json()) as { access_token: string };
+
+    const infoRes = await call(app, 'GET', '/oauth/userinfo', {
+      headers: { Authorization: `Bearer ${tokens.access_token}` },
+    });
+    expect(infoRes.status).toBe(200);
+    const info = (await infoRes.json()) as {
+      personal_org_slug: string | null;
+      organization_slug: string | null;
+      organizations: { slug: string; personal?: boolean }[];
+    };
+
+    expect(info.personal_org_slug).toBe(personalOrg.slug);
+    const personalEntry = info.organizations.find((o) => o.slug === personalOrg.slug);
+    expect(personalEntry?.personal).toBe(true);
+    // No other org is marked personal.
+    expect(info.organizations.filter((o) => o.personal).length).toBe(1);
+  });
+
+  it('refuses a device-worker grant when the user has no personal org', async () => {
+    const app = buildApp();
+
+    // User with ONLY a team org (no personal-org marker anywhere).
+    const teamOrg = await createTestOrganization({ name: 'Lonely Team' });
+    const user = await createTestUser({ name: 'No Personal' });
+    await addUserToOrganization(user.id, teamOrg.id, 'owner');
+    const session = await createTestSession(user.id);
+
+    const reg = await call(app, 'POST', '/oauth/register', {
+      body: {
+        client_name: 'Owletto no-personal',
+        grant_types: ['urn:ietf:params:oauth:grant-type:device_code', 'refresh_token'],
+        token_endpoint_auth_method: 'none',
+      },
+    });
+    const client = (await reg.json()) as { client_id: string };
+
+    const deviceAuth = await call(app, 'POST', '/oauth/device_authorization', {
+      body: {
+        client_id: client.client_id,
+        scope: 'device_worker:run mcp:read profile:read',
+      },
+    });
+    const da = (await deviceAuth.json()) as { user_code: string };
+
+    const approve = await call(app, 'POST', '/oauth/device/approve', {
+      body: { user_code: da.user_code, approved: true },
+      headers: { Cookie: session.cookieHeader },
+    });
+    // No personal org to bind to → the device can't be paired.
+    expect(approve.status).toBe(403);
+  });
+});

--- a/packages/server/src/auth/oauth/provider.ts
+++ b/packages/server/src/auth/oauth/provider.ts
@@ -414,10 +414,20 @@ export class OAuthProvider {
     name: string | null;
     picture: string | null;
     organization_slug: string | null;
+    /**
+     * The user's personal-org slug (the org marked
+     * `metadata.personal_org_for_user_id`). Device clients (Owletto Mac +
+     * Chrome) bind here regardless of the active/selected org, so the menubar
+     * and device-data uploads always land in the user's private workspace.
+     * Null only when provisioning hasn't completed.
+     */
+    personal_org_slug: string | null;
     organizations: {
       id: string;
       slug: string;
       name: string;
+      /** True for the user's personal org (matches {@link personal_org_slug}). */
+      personal: boolean;
     }[];
   } | null> {
     const authInfo = await this.verifyAccessToken(token);
@@ -433,11 +443,18 @@ export class OAuthProvider {
 
     if (result.length === 0) return null;
 
-    // Return the token-bound org (if any) and the full list of orgs. For
-    // tokens with no org binding — e.g. `device_worker:run` issued via the
-    // device-flow consent, which skips org resolution — fall back to the
-    // user's personal org, matching where the worker upload path actually
-    // delivers data (see worker-api.ts:184).
+    // Resolve the user's personal org once. Two consumers need it:
+    //   - `organization_slug` falls back to it for tokens with no org binding
+    //     (e.g. `device_worker:run` issued via the device-flow consent, which
+    //     historically skipped org resolution) — matching where the worker
+    //     upload path actually delivers data (see worker-api.ts:184).
+    //   - `personal_org_slug` is exposed so device clients (Owletto Mac +
+    //     Chrome) can target the personal workspace directly, independent of
+    //     whatever org the token is bound to or the CLI has selected as active.
+    const personalOrg = await findExistingPersonalOrg(authInfo.userId, this.sql);
+
+    // Return the token-bound org (if any). For tokens with no org binding, fall
+    // back to the personal org.
     let organizationSlug: string | null = null;
     if (authInfo.organizationId) {
       const orgResult = await this.sql`
@@ -445,10 +462,6 @@ export class OAuthProvider {
       `;
       organizationSlug = (orgResult[0]?.slug as string) ?? null;
     } else {
-      const personalOrg = await findExistingPersonalOrg(
-        authInfo.userId,
-        this.sql
-      );
       organizationSlug = personalOrg?.slug ?? null;
     }
 
@@ -466,16 +479,19 @@ export class OAuthProvider {
       name: string | null;
       image: string | null;
     };
+    const personalOrgId = personalOrg?.id ?? null;
     return {
       sub: user.id,
       email: user.email,
       name: user.name,
       picture: user.image,
       organization_slug: organizationSlug,
+      personal_org_slug: personalOrg?.slug ?? null,
       organizations: orgs.map((o) => ({
         id: o.id as string,
         slug: o.slug as string,
         name: o.name as string,
+        personal: personalOrgId !== null && o.id === personalOrgId,
       })),
     };
   }

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -585,6 +585,24 @@ oauthRoutes.post('/oauth/authorize/consent', requireAuth, async (c) => {
 
   const consentHasMcpScopes = hasMcpScopes(body.scope);
 
+  // `device_worker:run` is device-code-only — it mints a personal-device
+  // credential that the Owletto Mac app / Chrome extension / local runner
+  // authenticate `/api/workers/*` with, and device tokens are force-bound to
+  // the personal org in the device/approve handler below. Letting it slip in
+  // via the authorization-code consent path would bypass that invariant and
+  // bind a team-org token a device client could mistake for its identity.
+  // Third-party MCP clients (the only consent-path users) never need it.
+  const requestedConsentScopes = (body.scope ?? '').split(/\s+/).filter(Boolean);
+  if (requestedConsentScopes.includes('device_worker:run')) {
+    return c.json(
+      createOAuthError(
+        'invalid_scope',
+        '`device_worker:run` is only available via the device-authorization flow'
+      ),
+      400
+    );
+  }
+
   // User denied consent
   if (!body.approved) {
     const redirectUrl = new URL(body.redirect_uri);
@@ -931,6 +949,16 @@ oauthRoutes.post('/oauth/device/approve', requireAuth, async (c) => {
       WHERE "organizationId" = ${personalOrg.id} AND "userId" = ${user.id}
       LIMIT 1
     `) as unknown as Array<{ role: string | null }>;
+    if (memberRow.length === 0) {
+      // The personal-org marker exists but the user isn't a member (legacy /
+      // partially-migrated data). Mirrors resolveOrganizationForGrant's
+      // membership gate so we never bind a token to an org the user can't act
+      // on.
+      return c.json(
+        createOAuthError('access_denied', 'Not a member of the personal organization'),
+        403
+      );
+    }
     const memberRole = memberRow[0]?.role ?? null;
     organizationId = personalOrg.id;
     scopeOverride = filterScopeByRole(deviceCode.scope, memberRole);

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -902,10 +902,48 @@ oauthRoutes.post('/oauth/device/approve', requireAuth, async (c) => {
   }
 
   const deviceHasMcpScopes = hasMcpScopes(deviceCode.scope);
+  const requestedScopes = (deviceCode.scope ?? '').split(/\s+/).filter(Boolean);
+  // `device_worker:run` tokens drive personal devices — the Owletto Mac app,
+  // the Chrome extension, and the local `lobu run` worker. Device data
+  // (WhatsApp, Photos, browser context, …) always belongs in the user's
+  // personal org; team orgs reach a device by pinning a watcher/connection
+  // (see resolveDeviceClaimableOrgs), not by re-binding the device token.
+  // So a device-worker grant is FORCE-bound to the personal org, ignoring
+  // the resource slug, the active org, and the consent picker.
+  const isDeviceWorkerGrant = requestedScopes.includes('device_worker:run');
   let organizationId: string | null = null;
   let scopeOverride: string | null | undefined;
 
-  if (deviceHasMcpScopes) {
+  if (isDeviceWorkerGrant) {
+    const sql = createDbClientFromEnv(c.env);
+    const personalOrg = await findExistingPersonalOrg(user.id, sql);
+    if (!personalOrg) {
+      return c.json(
+        createOAuthError(
+          'access_denied',
+          'No personal organization is provisioned for this account; cannot bind a device token.'
+        ),
+        403
+      );
+    }
+    const memberRow = (await sql`
+      SELECT role FROM "member"
+      WHERE "organizationId" = ${personalOrg.id} AND "userId" = ${user.id}
+      LIMIT 1
+    `) as unknown as Array<{ role: string | null }>;
+    const memberRole = memberRow[0]?.role ?? null;
+    organizationId = personalOrg.id;
+    scopeOverride = filterScopeByRole(deviceCode.scope, memberRole);
+    if (scopeOverride === null) {
+      return c.json(
+        createOAuthError(
+          'invalid_scope',
+          'Your role is not authorized for any of the requested scopes'
+        ),
+        400
+      );
+    }
+  } else if (deviceHasMcpScopes) {
     const sql = createDbClientFromEnv(c.env);
     const orgResult = await resolveOrganizationForGrant({
       sql,

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -199,15 +199,26 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
 
   try {
     const sql = getDb();
-    // Same org-resolution rule as /api/workers/poll: prefer the calling
-    // token's org, fall back to the user's personal org.
+    // Device clients (Owletto Chrome extension via the Mac bridge) ALWAYS bind
+    // to the user's personal org — never the calling token's org. Personal
+    // device data (browser context, auted captures, …) belongs in the user's
+    // private workspace; a team org reaches the device by pinning a watcher /
+    // connection to it (see resolveDeviceClaimableOrgs), not by re-binding the
+    // device token. Ignoring `c.var.organizationId` here is what makes a Mac
+    // app whose own token is bound to a team org still land Chrome's data in
+    // the personal org.
     const orgRows = (await sql`
       SELECT id FROM organization
       WHERE (metadata::jsonb)->>'personal_org_for_user_id' = ${userId}
       LIMIT 1
     `) as unknown as Array<{ id: string }>;
-    const organizationId =
-      (c.var.organizationId as string | null | undefined) ?? orgRows[0]?.id ?? null;
+    const organizationId: string | null = orgRows[0]?.id ?? null;
+    if (!organizationId) {
+      return c.json(
+        { error: 'personal_org_missing', error_description: 'User has no personal org to bind the device to.' },
+        403
+      );
+    }
 
     // Identity reuse: when the sibling forwards its existing worker_id AND it
     // already belongs to this user as a chrome-extension device, keep that

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -13,6 +13,7 @@
 import { isKnownPlatform } from '@lobu/core';
 import type { Context } from 'hono';
 import { createAuth } from '../auth';
+import { findExistingPersonalOrg } from '../auth/personal-org-provisioning';
 import { PersonalAccessTokenService } from '../auth/tokens';
 import { getDb, pgBigintArray } from '../db/client';
 import type { Env } from '../index';
@@ -201,18 +202,14 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
     const sql = getDb();
     // Device clients (Owletto Chrome extension via the Mac bridge) ALWAYS bind
     // to the user's personal org — never the calling token's org. Personal
-    // device data (browser context, auted captures, …) belongs in the user's
+    // device data (browser context, captured pages, …) belongs in the user's
     // private workspace; a team org reaches the device by pinning a watcher /
     // connection to it (see resolveDeviceClaimableOrgs), not by re-binding the
     // device token. Ignoring `c.var.organizationId` here is what makes a Mac
     // app whose own token is bound to a team org still land Chrome's data in
     // the personal org.
-    const orgRows = (await sql`
-      SELECT id FROM organization
-      WHERE (metadata::jsonb)->>'personal_org_for_user_id' = ${userId}
-      LIMIT 1
-    `) as unknown as Array<{ id: string }>;
-    const organizationId: string | null = orgRows[0]?.id ?? null;
+    const personalOrg = await findExistingPersonalOrg(userId, sql);
+    const organizationId: string | null = personalOrg?.id ?? null;
     if (!organizationId) {
       return c.json(
         { error: 'personal_org_missing', error_description: 'User has no personal org to bind the device to.' },

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -10,6 +10,7 @@
  */
 
 import { getDb, pgTextArray } from '../db/client';
+import { findExistingPersonalOrg } from '../auth/personal-org-provisioning';
 import {
   type BundledDeviceConnector,
   bundledConnectorSourcePath,
@@ -337,20 +338,37 @@ export async function reconcileDeviceCapabilities(userId: string): Promise<void>
   }
   if (deviceConnectors.length === 0) return;
 
-  // deviceId → { capabilities it advertises, org it's attached to } (fresh
-  // devices only). A device connector is wired into the device's org; a user
-  // with devices in two orgs auto-wires the connector into each.
-  const deviceCaps = new Map<string, { caps: Set<string>; orgId: string | null }>();
+  // Device data ALWAYS lands in the user's personal org — device tokens are
+  // force-bound there (see oauth/device/approve + mint-child-token), and a
+  // team org reaches a device by pinning a watcher/connection to it
+  // (resolveDeviceClaimableOrgs), not by re-binding the device. So auto-wire
+  // targets the personal org regardless of where a legacy device_workers row
+  // is still homed (older pairings may still carry a team org_id; they
+  // converge here on the next poll).
+  const personalOrg = await findExistingPersonalOrg(userId, sql);
+  if (!personalOrg) {
+    // No personal org → nothing to auto-wire. Don't touch team-org connectors
+    // a user may have created manually; those survive on their own pins.
+    return;
+  }
+  const personalOrgId = personalOrg.id;
+
+  // deviceId → capabilities it advertises (fresh devices only). We no longer
+  // partition by the device's stored org_id: under the personal-org
+  // invariant every device serves the personal workspace, so the fleet's
+  // combined capabilities decide what gets wired, irrespective of legacy
+  // per-device home rows.
+  const deviceCaps = new Map<string, Set<string>>();
   try {
     const rows = (await sql`
-      SELECT id, capabilities, organization_id
+      SELECT id, capabilities
       FROM device_workers
       WHERE user_id = ${userId}
         AND last_seen_at > now() - ${DEVICE_WORKER_FRESH_INTERVAL}::interval
-    `) as unknown as Array<{ id: string; capabilities: unknown; organization_id: string | null }>;
+    `) as unknown as Array<{ id: string; capabilities: unknown }>;
     for (const r of rows) {
       const caps = Array.isArray(r.capabilities) ? (r.capabilities as string[]) : [];
-      deviceCaps.set(r.id, { caps: new Set(caps), orgId: r.organization_id });
+      deviceCaps.set(r.id, new Set(caps));
     }
   } catch (err) {
     logger.warn(
@@ -359,26 +377,18 @@ export async function reconcileDeviceCapabilities(userId: string): Promise<void>
     );
     return;
   }
-
-  const orgsWithDevices = [
-    ...new Set(
-      [...deviceCaps.values()].map((d) => d.orgId).filter((o): o is string => Boolean(o))
-    ),
-  ];
-  if (orgsWithDevices.length === 0) return;
-  const devicesWithCapabilityInOrg = (capability: string, orgId: string): string[] =>
-    [...deviceCaps.entries()]
-      .filter(([, d]) => d.orgId === orgId && d.caps.has(capability))
+  if (deviceCaps.size === 0) return;
+  const devicesWithCapability = (capability: string): string[] =>
+    [...deviceCaps.entries()].
+      filter(([, caps]) => caps.has(capability))
       .map(([id]) => id);
 
   await Promise.allSettled(
-    deviceConnectors.flatMap((dc) =>
-      orgsWithDevices.map((orgId) => {
-        const matchingDeviceIds = devicesWithCapabilityInOrg(dc.requiredCapability, orgId);
-        return matchingDeviceIds.length > 0
-          ? ensureDeviceConnectorWired(userId, orgId, dc.key, dc.feedKeys, matchingDeviceIds)
-          : pauseStaleDeviceFeeds(userId, orgId, dc.key);
-      })
-    )
+    deviceConnectors.map((dc) => {
+      const matchingDeviceIds = devicesWithCapability(dc.requiredCapability);
+      return matchingDeviceIds.length > 0
+        ? ensureDeviceConnectorWired(userId, personalOrgId, dc.key, dc.feedKeys, matchingDeviceIds)
+        : pauseStaleDeviceFeeds(userId, personalOrgId, dc.key);
+    })
   );
 }


### PR DESCRIPTION
## Summary
Device clients (Owletto Mac app, Chrome extension, local `lobu run` worker) now **always** bind to the user's personal org, regardless of the active/selected org or any `resource` slug. Personal device data belongs in the private workspace; team orgs reach a device by **pinning** a watcher/connection to it (`resolveDeviceClaimableOrgs`), not by re-binding the device token.

This was the root cause of the "connected to lobu team" bug: the Mac menu bar read the CLI's active org (`whoami.orgSlug`) for its label and every `/api/<slug>/...` call, so a multi-org user with a team active org had WhatsApp/Photos/runs routed to the team workspace.

### Server
- `/oauth/userinfo`: expose `personal_org_slug` + mark the personal org with `personal: true`.
- `/oauth/device/approve`: a `device_worker:run` grant is **force-bound** to the personal org (resource slug, active org, and the consent picker are ignored). Pure-MCP device flows keep the multi-org picker.
- `/api/me/devices/mint-child-token`: the Chrome child token is always bound to the personal org; the caller token's org is no longer inherited.

### CLI
- `whoami --json` emits `personalOrgSlug`, resolved from the personal-flagged org in userinfo.

## Why this is safe for the CLI
Org-scoped REST routes (`/api/:orgSlug/...`) authorize via **path-slug + membership**, not the token's bound org, so forcing the CLI's device-flow token to the personal org does **not** regress CLI operations on team orgs. The token's org only sets the worker-poll base scope (personal + bound org) and the default tenant context.

## Validation
- `make build-packages` ✅
- `bun run typecheck` ✅
- New: `oauth/device-worker-personal-org.test.ts` — device grant forces personal org (ignoring team resource), userinfo exposes `personal_org_slug`+flags the org, no-personal-org → 403 (3 tests) ✅
- Existing: `oauth/login-connections-token-scope.test.ts` + `oauth/`, `auth/`, `workers/`, unit suites (99 tests) ✅
- CLI: `whoami.test.ts` incl. new `personalOrgSlug` cases (7 tests) ✅
- Mac app: `xcodebuild` ✅ (paired owletto PR #437)

## Paired PRs
- owletto: https://github.com/lobu-ai/owletto/pull/437 (merge first — this PR bumps the submodule pointer)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785786302&installation_id=136316292&pr_number=1728&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1728&signature=ac751e1ef54d39e9b18cc3a79f5f0bc60ffb92a78e5576ddc660ae748e2610b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->