### PR TITLE
feat(watchers): derive watcher sources from prompt @-mention tokens

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent-worker": {
       "name": "@lobu/worker",
-      "version": "13.3.0",
+      "version": "13.4.0",
       "bin": {
         "lobu-worker": "./dist/index.js",
       },
@@ -43,7 +43,7 @@
     },
     "packages/cli": {
       "name": "@lobu/cli",
-      "version": "13.3.0",
+      "version": "13.4.0",
       "bin": {
         "lobu": "bin/lobu.js",
       },
@@ -129,7 +129,7 @@
     },
     "packages/client": {
       "name": "@lobu/client",
-      "version": "13.3.0",
+      "version": "13.4.0",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.99.0",
@@ -138,7 +138,7 @@
     },
     "packages/connector-sdk": {
       "name": "@lobu/connector-sdk",
-      "version": "13.3.0",
+      "version": "13.4.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
         "@sinclair/typebox": "^0.34.41",
@@ -162,7 +162,7 @@
     },
     "packages/connector-worker": {
       "name": "@lobu/connector-worker",
-      "version": "13.3.0",
+      "version": "13.4.0",
       "bin": {
         "connector-worker": "./dist/bin.js",
       },
@@ -197,7 +197,7 @@
     },
     "packages/core": {
       "name": "@lobu/core",
-      "version": "13.3.0",
+      "version": "13.4.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
@@ -215,7 +215,7 @@
     },
     "packages/embeddings": {
       "name": "@lobu/embeddings",
-      "version": "13.3.0",
+      "version": "13.4.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
         "@xenova/transformers": "^2.17.2",
@@ -229,7 +229,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "@lobu/openclaw-plugin",
-      "version": "13.3.0",
+      "version": "13.4.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
       },
@@ -247,7 +247,9 @@
         "@better-auth/passkey": "^1.6.9",
         "@codemirror/autocomplete": "^6.20.0",
         "@codemirror/commands": "^6.10.2",
+        "@codemirror/lang-javascript": "^6",
         "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/lang-sql": "^6",
         "@codemirror/language": "^6.12.2",
         "@codemirror/lint": "^6.9.4",
         "@codemirror/search": "^6.6.0",
@@ -277,6 +279,15 @@
         "@tanstack/react-router": "^1.95.0",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/router-devtools": "^1.95.0",
+        "@tiptap/core": "^3",
+        "@tiptap/extension-document": "^3",
+        "@tiptap/extension-mention": "^3",
+        "@tiptap/extension-paragraph": "^3",
+        "@tiptap/extension-text": "^3",
+        "@tiptap/extensions": "^3",
+        "@tiptap/pm": "^3",
+        "@tiptap/react": "^3",
+        "@tiptap/suggestion": "^3",
         "better-auth": "^1.4.10",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -320,7 +331,7 @@
     },
     "packages/pgvector-embedded": {
       "name": "@lobu/pgvector-embedded",
-      "version": "13.3.0",
+      "version": "13.4.0",
       "devDependencies": {
         "@types/node": "20.19.9",
         "typescript": "^5.7.2",
@@ -328,7 +339,7 @@
     },
     "packages/promptfoo-provider": {
       "name": "@lobu/promptfoo-provider",
-      "version": "13.3.0",
+      "version": "13.4.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.3",
@@ -614,7 +625,11 @@
 
     "@codemirror/commands": ["@codemirror/commands@6.10.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.6.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q=="],
 
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
     "@codemirror/lang-json": ["@codemirror/lang-json@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/json": "^1.0.0" } }, "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ=="],
+
+    "@codemirror/lang-sql": ["@codemirror/lang-sql@6.10.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w=="],
 
     "@codemirror/language": ["@codemirror/language@6.12.3", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
 
@@ -989,6 +1004,8 @@
     "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 
     "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
 
     "@lezer/json": ["@lezer/json@1.0.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ=="],
 
@@ -1736,6 +1753,28 @@
 
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
 
+    "@tiptap/core": ["@tiptap/core@3.27.1", "", { "peerDependencies": { "@tiptap/pm": "3.27.1" } }, "sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ=="],
+
+    "@tiptap/extension-bubble-menu": ["@tiptap/extension-bubble-menu@3.27.1", "", { "dependencies": { "@floating-ui/dom": "^1.0.0" }, "peerDependencies": { "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1" } }, "sha512-j/j8Qp9Z5nViade2m7zjrO/CYH/Ca80Qj7aqo0eUaei6FZQ5izlF9o4XQU5EFMAutV6mwynsPUp8FVo5sCuYfw=="],
+
+    "@tiptap/extension-document": ["@tiptap/extension-document@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-8FbBTkfnRP4iVaoj+2h3iWa+H0eGDD3yTyVCwrmue/sQTkqUNUoSuAZa3GDG4Sd41xdPwTJxl9nUWGgM1qDCnw=="],
+
+    "@tiptap/extension-floating-menu": ["@tiptap/extension-floating-menu@3.27.1", "", { "peerDependencies": { "@floating-ui/dom": "^1.0.0", "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1" } }, "sha512-BmJF1VqB7dSJkgAalrpVFj88WLhxKjcWPuWHOqf2ITrUU2832BhKLXKmxjWUy1gqV8PfNNVWtGfIERy7I0y0+Q=="],
+
+    "@tiptap/extension-mention": ["@tiptap/extension-mention@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1", "@tiptap/suggestion": "3.27.1" } }, "sha512-QfaKdl8PET01JvEFrIjMcOC1iYrBm2tsZEn07J1AaCqClW9iWcg/nCAdkdFhVir1fC54SLuaui43xslBawQRFg=="],
+
+    "@tiptap/extension-paragraph": ["@tiptap/extension-paragraph@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-7K7eo1gruOgAsnbK+GCV23AUVUI0cL1bTig8HaPneoFMVbig7vddk8jNLKBWO8TXVbG7TuHdnDN4F98vdtwh5Q=="],
+
+    "@tiptap/extension-text": ["@tiptap/extension-text@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1" } }, "sha512-6ZwaZwSrDh+KFFv6V1J79oO37yPs7y1bFxvk1/9Ih2rn3Xr5AWz+eMS+n8RpH3djBVVAQpdIAeYQgcn+VCSsTg=="],
+
+    "@tiptap/extensions": ["@tiptap/extensions@3.27.1", "", { "peerDependencies": { "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1" } }, "sha512-1Tdx9faw8k0/83V6X+xCDVhV8yElGt95JxeW3YMkKQJI56QdlPz0xOdJPlMiSGJKinPyVier+x9LJD/YZUZIaw=="],
+
+    "@tiptap/pm": ["@tiptap/pm@3.27.1", "", { "dependencies": { "prosemirror-changeset": "^2.3.0", "prosemirror-commands": "^1.6.2", "prosemirror-dropcursor": "^1.8.1", "prosemirror-gapcursor": "^1.3.2", "prosemirror-history": "^1.4.1", "prosemirror-inputrules": "^1.4.0", "prosemirror-keymap": "^1.2.3", "prosemirror-model": "^1.25.7", "prosemirror-schema-list": "^1.5.0", "prosemirror-state": "^1.4.4", "prosemirror-tables": "^1.8.0", "prosemirror-transform": "^1.12.0", "prosemirror-view": "^1.41.8" } }, "sha512-Ffjx+vimmBU7zH/KrpXzJid3+pziCe/VL2aexSTP63cyQwKQ65LkFkCKaIsSpFdQQuakVZBGWjCA5RoBV852pw=="],
+
+    "@tiptap/react": ["@tiptap/react@3.27.1", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "fast-equals": "^5.3.3", "use-sync-external-store": "^1.4.0" }, "optionalDependencies": { "@tiptap/extension-bubble-menu": "^3.27.1", "@tiptap/extension-floating-menu": "^3.27.1" }, "peerDependencies": { "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1", "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/Wn2fc9zMtX08MXYScDFsm4wJ8lzfhfPEdbtls7WCDlbtrop48PWlkHDBBJrywARfAQTB2mFs9KiFy9yrQm5Lg=="],
+
+    "@tiptap/suggestion": ["@tiptap/suggestion@3.27.1", "", { "peerDependencies": { "@floating-ui/dom": "^1.0.0", "@tiptap/core": "3.27.1", "@tiptap/pm": "3.27.1" } }, "sha512-GNBPRav+lAfXzqmmUAS6ylRAn3G8JfsP6XosjoORxJIQJLx1ktDqwp6tm1Vgz9aGIM2TrBxLS1uBbI1Gb2/1VA=="],
+
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
@@ -1821,6 +1860,8 @@
     "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
 
@@ -2285,6 +2326,8 @@
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
@@ -2920,6 +2963,8 @@
 
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
 
+    "orderedmap": ["orderedmap@2.1.1", "", {}, "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="],
+
     "os-paths": ["os-paths@4.4.0", "", {}, "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg=="],
 
     "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
@@ -3068,6 +3113,32 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
+    "prosemirror-changeset": ["prosemirror-changeset@2.4.1", "", { "dependencies": { "prosemirror-transform": "^1.0.0" } }, "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw=="],
+
+    "prosemirror-commands": ["prosemirror-commands@1.7.1", "", { "dependencies": { "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.10.2" } }, "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w=="],
+
+    "prosemirror-dropcursor": ["prosemirror-dropcursor@1.8.2", "", { "dependencies": { "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0", "prosemirror-view": "^1.1.0" } }, "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw=="],
+
+    "prosemirror-gapcursor": ["prosemirror-gapcursor@1.4.1", "", { "dependencies": { "prosemirror-keymap": "^1.0.0", "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-view": "^1.0.0" } }, "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw=="],
+
+    "prosemirror-history": ["prosemirror-history@1.5.0", "", { "dependencies": { "prosemirror-state": "^1.2.2", "prosemirror-transform": "^1.0.0", "prosemirror-view": "^1.31.0", "rope-sequence": "^1.3.0" } }, "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg=="],
+
+    "prosemirror-inputrules": ["prosemirror-inputrules@1.5.1", "", { "dependencies": { "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.0.0" } }, "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw=="],
+
+    "prosemirror-keymap": ["prosemirror-keymap@1.2.3", "", { "dependencies": { "prosemirror-state": "^1.0.0", "w3c-keyname": "^2.2.0" } }, "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw=="],
+
+    "prosemirror-model": ["prosemirror-model@1.25.9", "", { "dependencies": { "orderedmap": "^2.0.0" } }, "sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA=="],
+
+    "prosemirror-schema-list": ["prosemirror-schema-list@1.5.1", "", { "dependencies": { "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.7.3" } }, "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q=="],
+
+    "prosemirror-state": ["prosemirror-state@1.4.4", "", { "dependencies": { "prosemirror-model": "^1.0.0", "prosemirror-transform": "^1.0.0", "prosemirror-view": "^1.27.0" } }, "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw=="],
+
+    "prosemirror-tables": ["prosemirror-tables@1.8.5", "", { "dependencies": { "prosemirror-keymap": "^1.2.3", "prosemirror-model": "^1.25.4", "prosemirror-state": "^1.4.4", "prosemirror-transform": "^1.10.5", "prosemirror-view": "^1.41.4" } }, "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw=="],
+
+    "prosemirror-transform": ["prosemirror-transform@1.12.0", "", { "dependencies": { "prosemirror-model": "^1.21.0" } }, "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w=="],
+
+    "prosemirror-view": ["prosemirror-view@1.42.0", "", { "dependencies": { "prosemirror-model": "^1.25.8", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-N54DF3OXNWDuP81G1kbfCys8ZzIjuL1VnvJ2mk5STSu/fNxWIcX/EutQLA3s9KR/2wVhgDi4hzBB/1fINVxk0A=="],
+
     "protobufjs": ["protobufjs@7.6.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
@@ -3205,6 +3276,8 @@
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
+
+    "rope-sequence": ["rope-sequence@1.3.4", "", {}, "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="],
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 

--- a/packages/agent-worker/src/openclaw/lobu-refs.test.ts
+++ b/packages/agent-worker/src/openclaw/lobu-refs.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { buildRefContextHint, parseLobuRefs } from "./lobu-refs";
+
+describe("parseLobuRefs", () => {
+  it("parses tokens in order and skips unknown kinds", () => {
+    const text =
+      "check @[entity:42:Spotify](/acme/company/spotify) and @[bogus:9:X](/a) and @[connection:7:Stripe](/acme/connectors/stripe/7)";
+    expect(parseLobuRefs(text)).toEqual([
+      {
+        kind: "entity",
+        id: "42",
+        label: "Spotify",
+        path: "/acme/company/spotify",
+      },
+      {
+        kind: "connection",
+        id: "7",
+        label: "Stripe",
+        path: "/acme/connectors/stripe/7",
+      },
+    ]);
+  });
+
+  it("returns [] for plain text", () => {
+    expect(parseLobuRefs("no refs, just an email a@b.com")).toEqual([]);
+  });
+});
+
+describe("buildRefContextHint", () => {
+  it("is empty when there are no refs", () => {
+    expect(buildRefContextHint("hello world")).toBe("");
+  });
+
+  it("lists each referenced object with kind, label, path", () => {
+    const hint = buildRefContextHint(
+      "see @[entity:42:Spotify](/acme/company/spotify)"
+    );
+    expect(hint).toContain('entity "Spotify" → /acme/company/spotify');
+    expect(hint).toContain("resolve_path");
+  });
+
+  it("surfaces a sql ref's decoded query inline, not its #sql= path", () => {
+    // Encode like owletto's sqlRefPath: percent-escape the sub-delims that
+    // `encodeURIComponent` leaves raw (notably `)`, which closes the token).
+    const query = "SELECT id FROM events WHERE ts > now()";
+    const encoded = encodeURIComponent(query).replace(
+      /[()'!*~]/g,
+      (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+    );
+    const token = `@[sql:recent:Recent](#sql=${encoded})`;
+    const hint = buildRefContextHint(`watch ${token}`);
+    expect(hint).toContain(`sql "Recent": ${query}`);
+    expect(hint).not.toContain("#sql=");
+  });
+});

--- a/packages/agent-worker/src/openclaw/lobu-refs.ts
+++ b/packages/agent-worker/src/openclaw/lobu-refs.ts
@@ -1,0 +1,84 @@
+/**
+ * Worker-side parsing of the inline LobuRef tokens the owletto @-mention
+ * composer serializes into a message. Kept as a small local mirror of the codec
+ * in owletto (`src/lib/references.ts`) because the worker cannot import the
+ * owletto submodule; the wire form is a stable contract between them.
+ *
+ *   @[entity:Spotify](/acme/company/spotify)
+ *
+ * This lightweight pass only turns the tokens into a plain-text context hint
+ * appended before the agent's turn — it does NOT resolve the objects (that
+ * would need gateway access threaded into the plugin hook; a planned
+ * follow-up). The hint tells the agent which objects were referenced and their
+ * paths so it can resolve them with its own tools (e.g. resolve_path).
+ */
+
+export interface ParsedLobuRef {
+  kind: string;
+  id: string;
+  label: string;
+  path: string;
+}
+
+// Token: `@[kind:id:label](path)` — mirrors owletto's serializeRef. This grammar
+// is duplicated (submodule can't be imported) in owletto `lib/references.ts` and
+// server `watchers/source-refs.ts`; keep all three in sync (path group is 0+).
+const REF_TOKEN = /@\[([a-z]+):([^:\]]*):([^\]]*)\]\(([^)\s]*)\)/g;
+
+const KNOWN_KINDS = new Set([
+  "entity",
+  "connection",
+  "connector",
+  "feed",
+  "watcher",
+  "member",
+  "metric",
+  "sql",
+  "event",
+]);
+
+/** A `sql` ref carries its query URL-encoded in `path` behind `#sql=` (it has no
+ *  route). Recover the raw query, or null if the path isn't a SQL payload. */
+const SQL_PATH_PREFIX = "#sql=";
+function sqlQueryFromPath(path: string): string | null {
+  if (!path.startsWith(SQL_PATH_PREFIX)) return null;
+  try {
+    return decodeURIComponent(path.slice(SQL_PATH_PREFIX.length));
+  } catch {
+    return null;
+  }
+}
+
+/** Parse every LobuRef token out of a message body, in order. */
+export function parseLobuRefs(text: string): ParsedLobuRef[] {
+  const out: ParsedLobuRef[] = [];
+  for (const m of text.matchAll(REF_TOKEN)) {
+    const [, kind, id, label, path] = m;
+    if (!kind || !KNOWN_KINDS.has(kind) || !path) continue;
+    out.push({ kind, id: id ?? "", label: (label ?? "").trim(), path });
+  }
+  return out;
+}
+
+/**
+ * Build a short context block naming the referenced objects, or "" when the
+ * message has none. Appended before the user's turn so the agent knows what
+ * `@[...]` tokens point at without the tokens reading as opaque markdown.
+ */
+export function buildRefContextHint(text: string): string {
+  const refs = parseLobuRefs(text);
+  if (refs.length === 0) return "";
+  const lines = refs.map((r) => {
+    // A SQL ref has no route — surface its query inline instead of the opaque
+    // `#sql=…` path so the agent sees the actual SELECT.
+    const sqlQuery = r.kind === "sql" ? sqlQueryFromPath(r.path) : null;
+    if (sqlQuery !== null) return `- sql "${r.label}": ${sqlQuery}`;
+    return `- ${r.kind} "${r.label}" → ${r.path}`;
+  });
+  return [
+    "The user referenced these objects in their message. Use your tools",
+    "(e.g. resolve_path for entities, or the relevant read tool) to load any",
+    "you need before answering:",
+    ...lines,
+  ].join("\n");
+}

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -56,6 +56,7 @@ import {
 } from "./plugin-loader";
 import type { OpenClawProgressProcessor } from "./processor";
 import { activeToolNames } from "./active-tool-names";
+import { buildRefContextHint } from "./lobu-refs";
 import { getOpenClawSessionContext } from "./session-context";
 import {
   buildToolPolicy,
@@ -1502,7 +1503,13 @@ user references earlier discussion or you need prior context.`);
           ).trim()
         : "";
 
-    const effectivePromptText = `${configNotice}${sessionSummary ? `${sessionSummary}\n\n` : ""}${ephemeralContext ? `${ephemeralContext}\n\n` : ""}${prependContexts ? `${prependContexts}\n\n` : ""}${userPrompt}`;
+    // Turn any inline LobuRef tokens (@[kind:label](path)) the composer
+    // serialized into a short "these objects were referenced" hint, so the
+    // agent knows to resolve them with its tools. (Full pre-resolution is a
+    // planned follow-up needing gateway access in the plugin hook.)
+    const refContextHint = buildRefContextHint(userPrompt);
+
+    const effectivePromptText = `${configNotice}${sessionSummary ? `${sessionSummary}\n\n` : ""}${ephemeralContext ? `${ephemeralContext}\n\n` : ""}${prependContexts ? `${prependContexts}\n\n` : ""}${refContextHint ? `${refContextHint}\n\n` : ""}${userPrompt}`;
 
     // Load image attachments for vision-capable models
     const images = await loadImageAttachments();

--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -105,6 +105,109 @@ describe('watcher CRUD', () => {
     expect(got.watcher?.entity_id ?? null).toBeNull();
   });
 
+  it('derives sources[] from @-mention tokens in the prompt (no sources sent)', async () => {
+    // The owletto composer serializes a picked reference into the prompt as an
+    // inline `@[kind:id:label](path)` token and sends ONLY the raw prompt — the
+    // backend derives sources[]. A `sql` token carries its query URL-encoded in
+    // the path (`#sql=…`); we use it here because it resolves without any seeded
+    // feed/connection (a raw-SQL source is a valid custom source).
+    const query = 'SELECT id, payload_text FROM events ORDER BY occurred_at DESC';
+    const sqlPath = `#sql=${encodeURIComponent(query).replace(
+      /[()'!*~]/g,
+      (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+    )}`;
+    const prompt = `Summarize @[sql:recent:Recent events](${sqlPath}) each morning.`;
+
+    const created = (await owner.watchers.create({
+      entity_id: entityId,
+      slug: 'prompt-derived-sources-watcher',
+      name: 'Prompt Derived Sources Watcher',
+      prompt,
+      agent_id: agentId,
+      // NOTE: no `sources` — the backend must derive them from the prompt token.
+    })) as { watcher_id: string };
+
+    const got = (await owner.watchers.get(created.watcher_id)) as {
+      watcher?: { sources?: Array<{ name: string; query: string }> | null };
+    };
+    expect(got.watcher?.sources).toEqual([
+      { name: 'recent_events', query },
+    ]);
+
+    await owner.watchers.delete([created.watcher_id]);
+  });
+
+  it('re-derives sources on a version bump — an edited SQL chip replaces (not strands) the old query', async () => {
+    // Regression: create_version used to UNION prompt-derived sources with the
+    // stored ones, so editing a SQL chip left the OLD query running under the
+    // original name and added the new one under a suffixed name. The prompt must
+    // be the single source of truth: the new prompt's tokens are authoritative.
+    const enc = (q: string) =>
+      `#sql=${encodeURIComponent(q).replace(
+        /[()'!*~]/g,
+        (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+      )}`;
+    const oldQuery = 'SELECT id FROM events WHERE payload_type = \'a\'';
+    const newQuery = 'SELECT id FROM events WHERE payload_type = \'b\'';
+
+    const created = (await owner.watchers.create({
+      entity_id: entityId,
+      slug: 'sql-edit-rederive-watcher',
+      name: 'SQL Edit Rederive Watcher',
+      prompt: `Watch @[sql:recent:Recent](${enc(oldQuery)}).`,
+      agent_id: agentId,
+    })) as { watcher_id: string };
+
+    // Edit the SQL chip: same label/name, new query — a new prompt version.
+    await owner.watchers.createVersion({
+      watcher_id: created.watcher_id,
+      prompt: `Watch @[sql:recent:Recent](${enc(newQuery)}).`,
+      change_notes: 'edit sql',
+    });
+
+    const got = (await owner.watchers.get(created.watcher_id)) as {
+      watcher?: { sources?: Array<{ name: string; query: string }> | null };
+    };
+    // Exactly one source, carrying the NEW query — the old one is gone, not
+    // stranded under `recent`, and there is no `recent_2`.
+    expect(got.watcher?.sources).toEqual([{ name: 'recent', query: newQuery }]);
+
+    await owner.watchers.delete([created.watcher_id]);
+  });
+
+  it('clears sources when an edited prompt removes every @-mention chip', async () => {
+    // Regression: an edited prompt (args.prompt provided) with NO source tokens
+    // must yield an empty sources[] — removing all chips clears sources. It must
+    // NOT fall back to the stored sources (that fallback is only for a bump that
+    // did not touch the prompt, e.g. a schedule-only change).
+    const enc = (q: string) =>
+      `#sql=${encodeURIComponent(q).replace(
+        /[()'!*~]/g,
+        (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+      )}`;
+    const created = (await owner.watchers.create({
+      entity_id: entityId,
+      slug: 'clear-sources-on-edit-watcher',
+      name: 'Clear Sources On Edit Watcher',
+      prompt: `Watch @[sql:recent:Recent](${enc('SELECT id FROM events')}).`,
+      agent_id: agentId,
+    })) as { watcher_id: string };
+
+    // New prompt with the chip removed → sources must become empty.
+    await owner.watchers.createVersion({
+      watcher_id: created.watcher_id,
+      prompt: 'Just watch everything, no specific source.',
+      change_notes: 'remove chip',
+    });
+
+    const got = (await owner.watchers.get(created.watcher_id)) as {
+      watcher?: { sources?: Array<{ name: string; query: string }> | null };
+    };
+    expect(got.watcher?.sources ?? []).toEqual([]);
+
+    await owner.watchers.delete([created.watcher_id]);
+  });
+
   it('round-trips execution_config through create → list → update', async () => {
     const created = (await owner.watchers.create({
       entity_id: entityId,

--- a/packages/server/src/__tests__/unit/watcher-source-refs.test.ts
+++ b/packages/server/src/__tests__/unit/watcher-source-refs.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it } from "bun:test";
 import {
+	extractSourcesFromPromptTokens,
+	mergePromptSources,
 	parseWatcherSourceRef,
 	validateWatcherSourceRef,
 	watcherSourceKindForRef,
 } from "../../watchers/source-refs";
+
+/** Mirror of owletto's sqlRefPath: encode the query, additionally escaping the
+ *  sub-delims encodeURIComponent leaves raw ( ) ' ! * ~ so the token parses. */
+function sqlRefPath(query: string): string {
+	return `#sql=${encodeURIComponent(query).replace(
+		/[()'!*~]/g,
+		(c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+	)}`;
+}
 
 describe("watcher source refs", () => {
 	it("parses event-backed refs", () => {
@@ -53,5 +64,74 @@ describe("watcher source refs", () => {
 		expect(() => validateWatcherSourceRef("x", "@unknown:y")).toThrow(
 			/unsupported/i,
 		);
+	});
+});
+
+describe("extractSourcesFromPromptTokens", () => {
+	it("derives @mode:id sources from feed/connection/connector/metric tokens", () => {
+		const prompt =
+			"summarize @[feed:issues:GitHub Issues](/o/x) and " +
+			"@[connection:7:Slack](/o/y) and @[metric:company.churn:Churn](/o/z)";
+		expect(extractSourcesFromPromptTokens(prompt)).toEqual([
+			{ name: "github_issues", query: "@feed:issues" },
+			{ name: "slack", query: "@connection:7" },
+			{ name: "churn", query: "@metric:company.churn" },
+		]);
+	});
+
+	it("excludes entity tokens (scope, not source)", () => {
+		const prompt =
+			"for @[entity:42:Spotify](/o/company/spotify) watch @[feed:k:Feed](/o/x)";
+		expect(extractSourcesFromPromptTokens(prompt)).toEqual([
+			{ name: "feed", query: "@feed:k" },
+		]);
+	});
+
+	it("recovers a sql token's raw query from its inline #sql= path", () => {
+		const query = "SELECT id FROM events WHERE ts > now() - interval '7 days'";
+		const prompt = `run @[sql:recent:Recent events](${sqlRefPath(query)})`;
+		expect(extractSourcesFromPromptTokens(prompt)).toEqual([
+			{ name: "recent_events", query },
+		]);
+	});
+
+	it("de-dupes by query and makes duplicate names unique", () => {
+		const prompt =
+			"@[feed:k1:Issues](/o/a) @[feed:k1:Issues again](/o/a) " +
+			"@[feed:k2:Issues](/o/b)";
+		const out = extractSourcesFromPromptTokens(prompt);
+		expect(out).toEqual([
+			{ name: "issues", query: "@feed:k1" },
+			{ name: "issues_2", query: "@feed:k2" },
+		]);
+	});
+
+	it("returns [] for a prompt with no source tokens", () => {
+		expect(extractSourcesFromPromptTokens("just plain instructions")).toEqual(
+			[],
+		);
+	});
+});
+
+describe("mergePromptSources", () => {
+	it("keeps explicit sources and appends prompt sources, de-duping by query", () => {
+		const explicit = [{ name: "content", query: "@feed:issues" }];
+		const fromPrompt = [
+			{ name: "issues", query: "@feed:issues" }, // dupe query → dropped
+			{ name: "slack", query: "@connection:7" },
+		];
+		expect(mergePromptSources(explicit, fromPrompt)).toEqual([
+			{ name: "content", query: "@feed:issues" },
+			{ name: "slack", query: "@connection:7" },
+		]);
+	});
+
+	it("suffixes a prompt source whose name collides with an explicit one", () => {
+		const explicit = [{ name: "slack", query: "@feed:a" }];
+		const fromPrompt = [{ name: "slack", query: "@connection:7" }];
+		expect(mergePromptSources(explicit, fromPrompt)).toEqual([
+			{ name: "slack", query: "@feed:a" },
+			{ name: "slack_2", query: "@connection:7" },
+		]);
 	});
 });

--- a/packages/server/src/tools/admin/manage_watchers/crud.ts
+++ b/packages/server/src/tools/admin/manage_watchers/crud.ts
@@ -30,6 +30,10 @@ import {
   type WatcherOperationResult,
 } from './shared';
 import { getErrorMessage } from "@lobu/core";
+import {
+  extractSourcesFromPromptTokens,
+  mergePromptSources,
+} from '../../../watchers/source-refs';
 
 // ============================================
 // handleCreate
@@ -72,10 +76,17 @@ export async function handleCreate(
   const keyingConfig = parseJsonInput<Record<string, unknown>>(args.keying_config, 'keying_config');
   const classifiers = parseJsonInput<unknown[]>(args.classifiers, 'classifiers');
 
-  // Build sources array - use provided sources or create default
+  // Build sources array. Sources are authored two ways and merged here:
+  //   1. `@`-mention tokens in the prompt (the owletto composer's primary path)
+  //      — the backend derives them so the UI sends only the raw prompt.
+  //   2. explicit `args.sources` (API callers / legacy).
+  // If neither yields anything, fall back to a default all-events source.
+  const promptSources = extractSourcesFromPromptTokens(args.prompt);
+  const explicitSources = args.sources ?? [];
+  const merged = mergePromptSources(explicitSources, promptSources);
   const sources: Array<{ name: string; query: string }> =
-    args.sources && args.sources.length > 0
-      ? args.sources
+    merged.length > 0
+      ? merged
       : [{ name: 'content', query: 'SELECT * FROM events ORDER BY occurred_at DESC' }];
 
   // Validate watcher config

--- a/packages/server/src/tools/admin/manage_watchers/version-actions.ts
+++ b/packages/server/src/tools/admin/manage_watchers/version-actions.ts
@@ -7,6 +7,10 @@ import { getDb } from '../../../db/client';
 import { nextRunAt, validateSchedule } from '../../../utils/cron';
 import { resolveUsernames } from '../../../utils/resolve-usernames';
 import { getNextNumericId } from '../helpers/db-helpers';
+import {
+  extractSourcesFromPromptTokens,
+  mergePromptSources,
+} from '../../../watchers/source-refs';
 import type { ToolContext } from '../../registry';
 import type { ManageWatchersArgs, ManageWatchersResult } from '../manage_watchers';
 import {
@@ -75,17 +79,31 @@ export async function handleCreateVersion(
   }
   const prev = prevRows[0] as Record<string, unknown>;
 
+  const promptEdited = args.prompt !== undefined;
   const prompt = args.prompt ?? (prev.prompt as string);
-  // Sources are per-assignment now. When the caller omits args.sources we
-  // keep the seed watcher's existing sources; we deliberately do not fall
-  // back to prev.version_sources from the prior version row, because
-  // version_sources is no longer written and is a vestigial column.
+  // Sources derivation on a version bump. The prompt is the single source of
+  // truth for prompt-derived sources: the current prompt's `@`-mention tokens
+  // are authoritative, so we derive fresh from `prompt` and do NOT union with
+  // the stored sources — otherwise a deleted chip's source would linger forever
+  // and an edited SQL chip would leave its OLD query running under the original
+  // name (union-merge is monotonic; it can only add). We union ONLY explicit
+  // `args.sources` (an API caller that passes sources directly, not the UI which
+  // sends just the prompt).
+  const promptSources = extractSourcesFromPromptTokens(prompt);
+  const explicitSources = args.sources ?? [];
+  const derived = mergePromptSources(explicitSources, promptSources);
+  // When the caller EDITED the prompt, the derived set is authoritative even if
+  // empty — removing every source chip must clear the sources, not silently keep
+  // the stale stored ones. Only fall back to the stored sources for a bump that
+  // did NOT touch the prompt (e.g. a schedule-only change), so a legacy watcher's
+  // sources survive a metadata edit.
   const sources =
-    args.sources ??
-    normalizeStoredJsonField(
-      watcherRows[0].sources,
-      [] as Array<{ name: string; query: string }>
-    );
+    promptEdited || derived.length > 0
+      ? derived
+      : normalizeStoredJsonField(
+          watcherRows[0].sources,
+          [] as Array<{ name: string; query: string }>
+        );
   const keyingConfig =
     parseJsonInput<Record<string, unknown>>(args.keying_config, 'keying_config') ??
     normalizeStoredJsonField(prev.keying_config, undefined as Record<string, unknown> | undefined);

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -99,6 +99,119 @@ export function parseWatcherSourceRef(query: string): WatcherSourceRef | null {
   }
 }
 
+// ── Prompt-token extraction ────────────────────────────────────────────────
+// The owletto composer serializes a picked reference into the watcher prompt as
+// an inline token `@[kind:id:label](path)` (see owletto's src/lib/references.ts,
+// mirrored in agent-worker's lobu-refs.ts). The backend — not the frontend —
+// derives the watcher's `sources[]` from these tokens, so the UI just sends the
+// raw prompt and there is no client/server gap. This is a small local mirror of
+// the codec because the server cannot import the owletto submodule.
+const PROMPT_REF_TOKEN = /@\[([a-z]+):([^:\]]*):([^\]]*)\]\(([^)\s]*)\)/g;
+const SQL_PATH_PREFIX = '#sql=';
+
+/** Which prompt-token kinds become a watcher source, and the `@mode` each uses.
+ *  `entity` scopes the watcher (not a source); `sql` is handled separately (its
+ *  query rides inline in the path). watcher/member/event never become sources. */
+const PROMPT_KIND_TO_MODE: Record<string, string> = {
+  feed: 'feed',
+  connection: 'connection',
+  connector: 'connector',
+  channel: 'channel',
+  metric: 'metric',
+};
+
+/** Slugify a token label into a safe output-field name. */
+function promptSourceSlug(value: string): string {
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_]+/g, '_')
+      .replace(/^_+|_+$/g, '') || 'source'
+  );
+}
+
+/**
+ * Derive watcher `sources[]` from the `@`-mention tokens in a prompt. Each
+ * feed/connection/connector/metric token becomes `{ name, query: '@mode:id' }`;
+ * a `sql` token carries its raw query URL-encoded in the path (`#sql=…`), which
+ * is decoded to the SELECT itself. Entities are excluded (they scope the
+ * watcher). De-dupes by query; names are made unique with a numeric suffix.
+ *
+ * Returns [] for a prompt with no source tokens. Malformed tokens are skipped
+ * rather than thrown — the downstream `assertWatcherSourcesResolve` is what
+ * enforces that every derived source actually resolves against the org.
+ */
+export function extractSourcesFromPromptTokens(prompt: string): WatcherSource[] {
+  const sources: WatcherSource[] = [];
+  const seenQuery = new Set<string>();
+  const usedNames = new Set<string>();
+
+  const push = (label: string, fallback: string, query: string) => {
+    if (seenQuery.has(query)) return;
+    seenQuery.add(query);
+    let name = promptSourceSlug(label || fallback);
+    if (usedNames.has(name)) {
+      let i = 2;
+      while (usedNames.has(`${name}_${i}`)) i += 1;
+      name = `${name}_${i}`;
+    }
+    usedNames.add(name);
+    sources.push({ name, query });
+  };
+
+  for (const m of prompt.matchAll(PROMPT_REF_TOKEN)) {
+    const [, kind, id, label, path] = m;
+    if (!kind) continue;
+    if (kind === 'sql') {
+      if (!path?.startsWith(SQL_PATH_PREFIX)) continue;
+      let query: string;
+      try {
+        query = decodeURIComponent(path.slice(SQL_PATH_PREFIX.length)).trim();
+      } catch {
+        continue;
+      }
+      if (!query) continue;
+      push(label ?? '', 'sql_source', query);
+      continue;
+    }
+    const mode = PROMPT_KIND_TO_MODE[kind];
+    if (!mode) continue;
+    const value = (id ?? '').trim();
+    if (!value) continue;
+    push(label ?? '', value, `@${mode}:${value}`);
+  }
+
+  return sources;
+}
+
+/**
+ * Merge prompt-derived sources into an explicit sources list, de-duping by
+ * query and keeping output-field names unique. Explicit sources win (they keep
+ * their names/order); prompt sources fill in the rest.
+ */
+export function mergePromptSources(
+  explicit: WatcherSource[],
+  fromPrompt: WatcherSource[]
+): WatcherSource[] {
+  const merged = [...explicit];
+  const seenQuery = new Set(explicit.map((s) => s.query.trim()));
+  const usedNames = new Set(explicit.map((s) => s.name));
+  for (const src of fromPrompt) {
+    if (seenQuery.has(src.query.trim())) continue;
+    seenQuery.add(src.query.trim());
+    let name = src.name;
+    if (usedNames.has(name)) {
+      let i = 2;
+      while (usedNames.has(`${name}_${i}`)) i += 1;
+      name = `${name}_${i}`;
+    }
+    usedNames.add(name);
+    merged.push({ name, query: src.query });
+  }
+  return merged;
+}
+
 export function watcherSourceKindForRef(ref: WatcherSourceRef | null): WatcherSourceKind {
   if (!ref) return 'event';
   if (ref.type === 'entity') return 'entity';


### PR DESCRIPTION
Backend half of the reference/@-mention system (owletto UI merged in lobu-ai/owletto#438). The composer sends only the raw prompt (with `@[kind:id:label](path)` tokens); the backend derives watcher `sources[]`, so there's no client/server gap and the same MentionEditor serves both chat and watcher prompts.

## What
- **`extractSourcesFromPromptTokens` + `mergePromptSources`** in `watchers/source-refs.ts` — a server-local mirror of the owletto codec (the submodule can't be imported). feed/connection/connector/metric → `@mode:id`; sql → decoded `#sql=` query; entity is scope, not a source.
- **create**: merge prompt-derived sources with any explicit ones before resolve/validate/insert.
- **create_version**: the prompt is the single source of truth — derive fresh from the (new) prompt rather than union-merging with stored sources, so a deleted chip's source is removed and an edited SQL chip **replaces** (not strands) its old query. Metadata-only bumps keep the stored sources.
- **Worker** `lobu-refs`: surface a SQL ref's decoded query in the context hint; align the mirrored token grammar (path group `0+`) across owletto/worker/server.
- Bump owletto submodule pointer to the merged main SHA.

## Tests
- `watcher-source-refs` unit: extract/merge (11 cases incl. SQL decode, dedup, name-uniquify).
- `watchers-crud` integration (real DB): create derives sources from an `@sql` prompt token; a version bump re-derives — an edited SQL chip replaces the old query with no stale source.

## E2E note
Backend paths are covered by the integration tests. The in-browser interactions (Enter-to-pick, copy/paste, SQL-chip edit) live in the owletto PR and are unit/integration-verified but not yet browser-driven.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785799228&installation_id=136316292&pr_number=1731&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1731&signature=c564c6649908f7715213f73a40abe15f9f2ff694d3275d4c83889d680e12d554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watcher prompts can now automatically derive `sources[]` from inline reference tokens.
  * Agent sessions now include an extra “referenced objects” context hint extracted from those tokens, with SQL shown inline.
* **Bug Fixes**
  * Merging of prompt-derived and explicitly provided sources is more reliable, including consistent name collision handling.
  * Editing prompts (including removing SQL refs) correctly updates or clears derived sources without leaving stale entries.
* **Tests**
  * Added unit and integration coverage for reference parsing, SQL decoding, source extraction/merging, and watcher CRUD/version flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->