### PR TITLE
feat(mcp): slim tools/list to six agent tools with aligned SDK discovery

### DIFF
--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -10,7 +10,6 @@
       "lobu_login_check",
       "lobu_search_memory",
       "lobu_save_memory",
-      "lobu_list_organizations",
       "lobu_search_sdk",
       "lobu_query_sdk",
       "lobu_query_sql",

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -38,7 +38,6 @@ const DEFAULT_RECALL_LIMIT = 6;
 export const KNOWN_MCP_TOOL_NAMES = new Set([
   'search_memory',
   'save_memory',
-  'list_organizations',
   'search_sdk',
   'query_sdk',
   'query_sql',

--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -266,10 +266,8 @@ describe('MCP Authentication', () => {
       expect(toolNames).not.toContain('save_memory');
       expect(toolNames).not.toContain('query_sql');
       expect(toolNames).not.toContain('run_sdk');
-      // Uniform surface: manage_entity is listed for anonymous public callers,
-      // filtered down to its public-read actions (pinned by the access-matrix
-      // fixture in auth/__tests__/tool-access.test.ts).
-      expect(toolNames).toContain('manage_entity');
+      // Admin flat tools are not on the MCP list — use search_sdk + query_sdk.
+      expect(toolNames).not.toContain('manage_entity');
     });
 
     it('allows anonymous public-read tool calls on public org MCP routes', async () => {
@@ -369,8 +367,7 @@ describe('MCP Authentication', () => {
       expect(toolNames).not.toContain('save_memory');
       expect(toolNames).not.toContain('query_sql');
       expect(toolNames).not.toContain('run_sdk');
-      // Uniform surface: manage_entity appears with public-read actions only.
-      expect(toolNames).toContain('manage_entity');
+      expect(toolNames).not.toContain('manage_entity');
     });
 
     it('should reject expired OAuth access token', async () => {
@@ -426,14 +423,15 @@ describe('MCP Authentication', () => {
       expect(response.error).toBeUndefined();
     });
 
-    it('exposes list_organizations on unscoped /mcp for authenticated tokens', async () => {
+    it('still dispatches list_organizations by name via tools/call when omitted from tools/list', async () => {
       const { token } = await createTestAccessToken(user.id, org.id, client.client_id);
 
-      const result = await mcpListTools({ token });
-      const toolNames = result.tools.map((tool: any) => tool.name);
+      const listed = await mcpListTools({ token });
+      expect(listed.tools.map((t: any) => t.name)).not.toContain('list_organizations');
 
-      expect(toolNames).toContain('list_organizations');
-      expect(toolNames).not.toContain('switch_organization');
+      const result = await mcpToolsCall<unknown[]>('list_organizations', {}, { token });
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeGreaterThan(0);
     });
 
     it('recovers a stale authenticated MCP session from the persisted session store', async () => {
@@ -677,25 +675,9 @@ describe('MCP Authentication', () => {
       expect(body.error?.message).toContain("Agent 'missing-agent' was not found");
     });
 
-    it('exposes list_organizations on scoped /mcp/:org routes too', async () => {
-      const { token } = await createTestAccessToken(user.id, org.id, client.client_id);
-      const result = await mcpListTools({ token, orgSlug: org.slug });
-      const toolNames = result.tools.map((t) => t.name);
-
-      expect(toolNames).toContain('list_organizations');
-      expect(toolNames).not.toContain('switch_organization');
-    });
   });
 
   describe('Session Cookie Authentication', () => {
-    it('exposes list_organizations on unscoped /mcp for authenticated browser sessions', async () => {
-      const result = await mcpListTools({ cookie: sessionCookie });
-      const toolNames = result.tools.map((t) => t.name);
-
-      expect(toolNames).toContain('list_organizations');
-      expect(toolNames).not.toContain('switch_organization');
-    });
-
     it('allows a signed-in non-member to call public-readable REST tools on a public org', async () => {
       const response = await post(`/api/${publicOrg.slug}/manage_entity`, {
         body: {
@@ -882,31 +864,47 @@ describe('MCP Authentication', () => {
 
   describe('tools/list Response', () => {
     it('should return list of available tools', async () => {
-      const { token } = await createTestAccessToken(user.id, org.id, client.client_id);
+      const { token } = await createTestAccessToken(user.id, org.id, client.client_id, {
+        scope: 'mcp:read mcp:write mcp:admin',
+      });
 
-      const result = await mcpListTools({ token });
+      const result = await mcpListTools({ token, orgSlug: org.slug });
 
       expect(result.tools).toBeInstanceOf(Array);
 
-      // Uniform tool surface: every registered tool is listed for an
-      // authorized member, admin tools included — reach is gated by
-      // per-action tier x role x scope at execute time, not by visibility.
+      // MCP tools/list is the agent surface only — admin flat tools dispatch
+      // via REST and tools/call by name but are not advertised here.
       const toolNames = result.tools.map((t: any) => t.name);
-      expect(toolNames).toContain('search_memory');
-      expect(toolNames).toContain('save_memory');
-      expect(toolNames).toContain('search_sdk');
-      expect(toolNames).toContain('query_sdk');
-      expect(toolNames).toContain('run_sdk');
-      expect(toolNames).toContain('read_knowledge');
-      expect(toolNames).toContain('get_watcher');
-      expect(toolNames).toContain('list_watchers');
-      expect(toolNames).toContain('manage_entity');
-      expect(toolNames).toContain('manage_connections');
-      expect(toolNames).toContain('manage_feeds');
-      expect(toolNames).toContain('manage_auth_profiles');
-      // Never-registered names stay absent.
+      expect(toolNames.sort()).toEqual(
+        [
+          'query_sdk',
+          'query_sql',
+          'run_sdk',
+          'save_memory',
+          'search_memory',
+          'search_sdk',
+        ].sort(),
+      );
+      expect(toolNames).not.toContain('list_organizations');
+      expect(toolNames).not.toContain('list_metrics');
+      expect(toolNames).not.toContain('query_metric');
+      expect(toolNames).not.toContain('metric_series');
+      expect(toolNames).not.toContain('list_watchers');
+      expect(toolNames).not.toContain('manage_entity');
+      expect(toolNames).not.toContain('read_knowledge');
       expect(toolNames).not.toContain('execute');
       expect(toolNames).not.toContain('join_organization');
+    });
+
+    it('still dispatches internal admin tools by name via tools/call (#434)', async () => {
+      const { token } = await createTestAccessToken(user.id, org.id, client.client_id);
+
+      const result = await mcpToolsCall<{ watchers?: unknown[] }>(
+        'list_watchers',
+        { status: 'active' },
+        { token, orgSlug: org.slug },
+      );
+      expect(Array.isArray(result.watchers)).toBe(true);
     });
 
     it('should include tool descriptions', async () => {

--- a/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/query-tool.test.ts
@@ -74,9 +74,8 @@ describe('MCP query_sdk / run_sdk tool surface', () => {
     // top-level `type: "object"` (a bare `anyOf` — TypeBox's default union
     // serialization — is what a validating host rejects). The variants stay in
     // `anyOf` so the client can still tell which one applied.
-    const watchersOut = byName.get('manage_watchers')?.outputSchema;
-    expect(watchersOut?.type).toBe('object');
-    expect(Array.isArray(watchersOut?.anyOf)).toBe(true);
+    const querySdkOut = byName.get('query_sdk')?.outputSchema;
+    expect(querySdkOut?.type).toBe('object');
     // ...while tools without one (text-only results) omit it.
     expect(byName.get('save_memory')?.outputSchema).toBeUndefined();
   });

--- a/packages/server/src/__tests__/integration/sandbox/execute-wire.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/execute-wire.test.ts
@@ -9,6 +9,9 @@
  * matching prebuilds); CI pins Node 22 where the abi127 prebuild ships.
  */
 
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
   addUserToOrganization,
@@ -21,12 +24,18 @@ import { TestApiClient, TestMcpClient } from '../../setup/test-mcp-client';
 import { cleanupTestDatabase } from '../../setup/test-db';
 
 function isolatedVmAvailable(): boolean {
-  // isolated-vm ships prebuilds for abi127 (Node 22) and abi137 (Node 24).
-  // We can't actually try `new Isolate()` to detect — on a wrong ABI it
-  // segfaults, which we can't recover from. So gate on `process.versions.modules`
-  // matching a known-good value. CI pins Node 22 explicitly.
+  // isolated-vm ships prebuilds for abi127 (Node 22), abi137 (Node 24), and
+  // isolated-vm-next for Node 26+. We can't actually try `new Isolate()` to
+  // detect — on a wrong ABI it segfaults. Gate on ABI + the package being on
+  // disk (bun install optional dep).
   const abi = process.versions.modules;
-  return abi === '127' || abi === '137';
+  const abiOk = abi === '127' || abi === '137' || abi === '147';
+  if (!abiOk) return false;
+  const root = fileURLToPath(new URL('../../../../../../', import.meta.url));
+  return (
+    existsSync(join(root, 'node_modules/isolated-vm')) ||
+    existsSync(join(root, 'node_modules/isolated-vm-next'))
+  );
 }
 
 describe('sandbox run (wire)', () => {
@@ -41,7 +50,9 @@ describe('sandbox run (wire)', () => {
     const user = await createTestUser({ email: 'sandbox-wire@test.com' });
     await addUserToOrganization(user.id, org.id, 'owner');
     const oauthClient = await createTestOAuthClient();
-    const oauthResult = await createTestAccessToken(user.id, org.id, oauthClient.client_id);
+    const oauthResult = await createTestAccessToken(user.id, org.id, oauthClient.client_id, {
+      scope: 'mcp:read mcp:write mcp:admin',
+    });
 
     orgSlug = org.slug;
     token = oauthResult.token;
@@ -79,4 +90,97 @@ describe('sandbox run (wire)', () => {
     // We seeded one company; the script should see it.
     expect(json).toContain('"count":1');
   });
+
+  it('query_sdk can list agents via client.agents.list', async (testCtx) => {
+    if (!isolatedAvailable) return testCtx.skip();
+    const client = new TestMcpClient({ token, orgSlug });
+    const result = await client.querySdk<unknown>(
+      `export default async (_ctx, client) => {
+         const out = await client.agents.list();
+         return { action: out.action, n: out.agents?.length ?? 0 };
+       };`
+    );
+    const json = JSON.stringify(result);
+    expect(json).toContain('"action":"list"');
+    expect(json).toMatch(/"n":\d+/);
+  });
+
+  it('query_sdk can list schedules via client.schedules.list', async (testCtx) => {
+    if (!isolatedAvailable) return testCtx.skip();
+    const client = new TestMcpClient({ token, orgSlug });
+    const result = await client.querySdk<unknown>(
+      `export default async (_ctx, client) => {
+         const out = await client.schedules.list();
+         return { hasSchedules: Array.isArray(out.schedules) };
+       };`
+    );
+    expect(JSON.stringify(result)).toContain('"hasSchedules":true');
+  });
+
+  it('run_sdk can list schedules via client.schedules.list', async (testCtx) => {
+    if (!isolatedAvailable) return testCtx.skip();
+    const client = new TestMcpClient({ token, orgSlug });
+    const result = await client.runSdk<unknown>(
+      `export default async (_ctx, client) => {
+         const out = await client.schedules.list();
+         return { hasSchedules: Array.isArray(out.schedules) };
+       };`
+    );
+    expect(JSON.stringify(result)).toContain('"hasSchedules":true');
+  });
+
+  it('query_sdk can list watchers via client.watchers.list (replaces list_watchers)', async (testCtx) => {
+    if (!isolatedAvailable) return testCtx.skip();
+    const client = new TestMcpClient({ token, orgSlug });
+    const result = await client.querySdk<unknown>(
+      `export default async (_ctx, client) => {
+         const out = await client.watchers.list({ status: 'active' });
+         return { hasWatchers: Array.isArray(out.watchers) };
+       };`
+    );
+    expect(JSON.stringify(result)).toContain('"hasWatchers":true');
+  });
+
+  it('run_sdk can create an agent via client.agents.create', async (testCtx) => {
+    if (!isolatedAvailable) return testCtx.skip();
+    const client = new TestMcpClient({ token, orgSlug });
+    const result = await client.runSdk<unknown>(
+      `export default async (_ctx, client) => {
+         const out = await client.agents.create({
+           agent_id: 'wire-test-agent',
+           name: 'Wire Test Agent',
+         });
+         return out;
+       };`,
+      { timeout_ms: 15_000 }
+    );
+    expect(JSON.stringify(result)).toContain('"action":"create"');
+  });
+
+  it('query_sdk can list metrics via client.metrics.list', async (testCtx) => {
+    if (!isolatedAvailable) return testCtx.skip();
+    const client = new TestMcpClient({ token, orgSlug });
+    const result = await client.querySdk<unknown>(
+      `export default async (_ctx, client) => {
+         const out = await client.metrics.list();
+         return { hasCatalog: Array.isArray(out.entity_types) };
+       };`
+    );
+    expect(JSON.stringify(result)).toContain('"hasCatalog":true');
+  });
+
+  it('run_sdk can list agents via client.agents.list', async (testCtx) => {
+    if (!isolatedAvailable) return testCtx.skip();
+    const client = new TestMcpClient({ token, orgSlug });
+    const result = await client.runSdk<unknown>(
+      `export default async (_ctx, client) => {
+         const out = await client.agents.list();
+         return { action: out.action, n: out.agents?.length ?? 0 };
+       };`
+    );
+    const json = JSON.stringify(result);
+    expect(json).toContain('"action":"list"');
+    expect(json).toMatch(/"n":\d+/);
+  });
+
 });

--- a/packages/server/src/__tests__/integration/sandbox/execute-wire.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/execute-wire.test.ts
@@ -91,32 +91,6 @@ describe('sandbox run (wire)', () => {
     expect(json).toContain('"count":1');
   });
 
-  it('query_sdk can list agents via client.agents.list', async (testCtx) => {
-    if (!isolatedAvailable) return testCtx.skip();
-    const client = new TestMcpClient({ token, orgSlug });
-    const result = await client.querySdk<unknown>(
-      `export default async (_ctx, client) => {
-         const out = await client.agents.list();
-         return { action: out.action, n: out.agents?.length ?? 0 };
-       };`
-    );
-    const json = JSON.stringify(result);
-    expect(json).toContain('"action":"list"');
-    expect(json).toMatch(/"n":\d+/);
-  });
-
-  it('query_sdk can list schedules via client.schedules.list', async (testCtx) => {
-    if (!isolatedAvailable) return testCtx.skip();
-    const client = new TestMcpClient({ token, orgSlug });
-    const result = await client.querySdk<unknown>(
-      `export default async (_ctx, client) => {
-         const out = await client.schedules.list();
-         return { hasSchedules: Array.isArray(out.schedules) };
-       };`
-    );
-    expect(JSON.stringify(result)).toContain('"hasSchedules":true');
-  });
-
   it('run_sdk can list schedules via client.schedules.list', async (testCtx) => {
     if (!isolatedAvailable) return testCtx.skip();
     const client = new TestMcpClient({ token, orgSlug });

--- a/packages/server/src/__tests__/integration/sandbox/namespace-dispatch.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/namespace-dispatch.test.ts
@@ -97,6 +97,16 @@ describe("ClientSDK namespace dispatch (read paths)", () => {
 	// above; operations.listRuns result-shape is covered by the operations
 	// suite, not duplicated here.
 
+	it("agents.list dispatches cleanly", async () => {
+		const out = await sdk.agents.list();
+		expect(out).toMatchObject({ action: "list", agents: expect.any(Array) });
+	});
+
+	it("schedules.list dispatches cleanly", async () => {
+		const out = await sdk.schedules.list();
+		expect(out).toMatchObject({ schedules: expect.any(Array) });
+	});
+
 	it("watchers.list dispatches cleanly", async () => {
 		await expect(sdk.watchers.list()).resolves.toBeDefined();
 	});
@@ -113,6 +123,11 @@ describe("ClientSDK namespace dispatch (read paths)", () => {
 	it("organizations.current returns the session org", async () => {
 		const current = await sdk.organizations.current();
 		expect(current.slug).toBe("dispatch-sdk");
+	});
+
+	it("metrics.list dispatches cleanly", async () => {
+		const out = await sdk.metrics.list();
+		expect(out).toMatchObject({ entity_types: expect.any(Array) });
 	});
 
 	it("knowledge.search dispatches cleanly", async () => {

--- a/packages/server/src/__tests__/setup/test-helpers.ts
+++ b/packages/server/src/__tests__/setup/test-helpers.ts
@@ -263,11 +263,8 @@ export async function mcpRequest<T = any>(
 /**
  * Make an MCP tools/call request with JSON format for raw results.
  *
- * After PR-2 the legacy `manage_*`/`list_watchers`/`get_watcher`/
- * `read_knowledge` tools are gone from the MCP surface. Historical tests
- * that call those names still go through this function and will get
- * `Tool not found` — those tests are tracked for migration to either
- * direct handler imports or `executeScript` script form.
+ * Admin flat tools are omitted from MCP `tools/list` but remain dispatchable
+ * by name here and via REST. Prefer `query_sdk` / `run_sdk` for new agent tests.
  */
 export async function mcpToolsCall<T = any>(
   toolName: string,

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -65,7 +65,7 @@ describe("method-metadata", () => {
   });
 
   it("has valid access levels on every entry", () => {
-    const valid: MethodAccess[] = ["read", "write", "external"];
+    const valid: MethodAccess[] = ["read", "write", "external", "admin"];
     for (const [path, meta] of Object.entries(METHOD_METADATA)) {
       expect(valid).toContain(meta.access);
       expect(meta.summary.length).toBeGreaterThan(0);

--- a/packages/server/src/__tests__/unit/sandbox/read-only.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/read-only.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
+import type { ToolAccessLevel } from "../../../auth/tool-access";
 import {
   buildClientSDK,
   enumerateSDKManifest,
 } from "../../../sandbox/client-sdk";
 import { METHOD_METADATA } from "../../../sandbox/method-metadata";
+import { sdkMethodVisible } from "../../../sandbox/sdk-method-access";
 import { baseCtx, expectReturnValue, runOrSkip, stubSDK } from "./_helpers";
 
 const stubEntitiesList = stubSDK({
@@ -12,16 +14,18 @@ const stubEntitiesList = stubSDK({
 
 describe("enumerateSDKManifest", () => {
   it("read mode mirrors METHOD_METADATA access classification", () => {
-    const read = enumerateSDKManifest("read");
-    const full = enumerateSDKManifest("full");
+    const callerMax: ToolAccessLevel = "admin";
+    const read = enumerateSDKManifest("read", { maxAccessLevel: callerMax });
+    const full = enumerateSDKManifest("full", { maxAccessLevel: callerMax });
     for (const [path, meta] of Object.entries(METHOD_METADATA)) {
       const dot = path.indexOf(".");
       if (dot === -1) continue;
       const ns = path.slice(0, dot);
       const method = path.slice(dot + 1);
-      expect(full.byNamespace[ns]).toContain(method);
+      const inFull = full.byNamespace[ns]?.includes(method) ?? false;
+      expect(inFull).toBe(sdkMethodVisible(meta.access, callerMax, "full"));
       const inRead = read.byNamespace[ns]?.includes(method) ?? false;
-      expect(inRead).toBe(meta.access === "read");
+      expect(inRead).toBe(sdkMethodVisible(meta.access, callerMax, "read"));
     }
   });
 

--- a/packages/server/src/__tests__/unit/sandbox/sdk-method-access.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-method-access.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { sdkMethodVisible } from "../../../sandbox/sdk-method-access";
+
+describe("sdkMethodVisible", () => {
+	it("read mode exposes only read-tier methods", () => {
+		expect(sdkMethodVisible("read", "read", "read")).toBe(true);
+		expect(sdkMethodVisible("write", "admin", "read")).toBe(false);
+		expect(sdkMethodVisible("admin", "admin", "read")).toBe(false);
+	});
+
+	it("full mode exposes read methods to every caller", () => {
+		expect(sdkMethodVisible("read", "read", "full")).toBe(true);
+		expect(sdkMethodVisible("read", "write", "full")).toBe(true);
+		expect(sdkMethodVisible("read", "admin", "full")).toBe(true);
+	});
+
+	it("full mode exposes write methods to write and admin tiers", () => {
+		expect(sdkMethodVisible("write", "read", "full")).toBe(false);
+		expect(sdkMethodVisible("write", "write", "full")).toBe(true);
+		expect(sdkMethodVisible("write", "admin", "full")).toBe(true);
+	});
+
+	it("full mode exposes admin methods only to admin tier", () => {
+		expect(sdkMethodVisible("admin", "read", "full")).toBe(false);
+		expect(sdkMethodVisible("admin", "write", "full")).toBe(false);
+		expect(sdkMethodVisible("admin", "admin", "full")).toBe(true);
+	});
+
+	it("full mode treats external like write", () => {
+		expect(sdkMethodVisible("external", "read", "full")).toBe(false);
+		expect(sdkMethodVisible("external", "write", "full")).toBe(true);
+		expect(sdkMethodVisible("external", "admin", "full")).toBe(true);
+	});
+});

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -1,56 +1,98 @@
 import { describe, expect, it } from "bun:test";
+import type { ToolContext } from "../../../tools/registry";
 import { sdkSearch } from "../../../tools/sdk_search";
 
 const stubEnv = {} as never;
-const stubCtx = {} as never;
+
+const readCtx: ToolContext = {
+	organizationId: "org",
+	userId: "user",
+	memberRole: "member",
+	isAuthenticated: true,
+	tokenType: "oauth",
+	scopes: ["mcp:read"],
+	scopedToOrg: true,
+	allowCrossOrg: false,
+};
+
+const writeCtx: ToolContext = {
+	...readCtx,
+	scopes: ["mcp:read", "mcp:write"],
+};
+
+const adminCtx: ToolContext = {
+	...readCtx,
+	memberRole: "owner",
+	scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+};
 
 describe("sdkSearch", () => {
-  it("returns drill-down for an exact path", async () => {
-    const result = await sdkSearch(
-      { query: "watchers.list" },
-      stubEnv,
-      stubCtx,
-    );
-    expect(result.match_count).toBe(1);
-    expect(result.results[0]).toContain("watchers.list");
-    expect(result.results[0]).toContain("access:");
-  });
+	it("returns drill-down for an exact path", async () => {
+		const result = await sdkSearch(
+			{ query: "watchers.list" },
+			stubEnv,
+			readCtx,
+		);
+		expect(result.match_count).toBe(1);
+		expect(result.results[0]).toContain("watchers.list");
+		expect(result.results[0]).toContain("access:");
+	});
 
-  it("returns namespace listing for a top-level namespace", async () => {
-    const result = await sdkSearch({ query: "watchers" }, stubEnv, stubCtx);
-    expect(result.match_count).toBeGreaterThan(2);
-    const joined = result.results.join("\n");
-    expect(joined).toContain("watchers.list");
-    expect(joined).toContain("watchers.create");
-  });
+	it("returns namespace listing for a top-level namespace at write tier", async () => {
+		const result = await sdkSearch({ query: "watchers" }, stubEnv, writeCtx);
+		expect(result.match_count).toBeGreaterThan(2);
+		const joined = result.results.join("\n");
+		expect(joined).toContain("watchers.list");
+		expect(joined).toContain("watchers.create");
+	});
 
-  it("substring-matches across paths and summaries", async () => {
-    const result = await sdkSearch(
-      { query: "extraction" },
-      stubEnv,
-      stubCtx,
-    );
-    // "extraction" appears in watchers.create's summary (entity-type derive).
-    expect(result.match_count).toBeGreaterThan(0);
-  });
+	it("read mode hides write methods from namespace listing", async () => {
+		const result = await sdkSearch(
+			{ query: "watchers", mode: "read" },
+			stubEnv,
+			writeCtx,
+		);
+		const joined = result.results.join("\n");
+		expect(joined).toContain("watchers.list");
+		expect(joined).not.toContain("watchers.create");
+		expect(result.notes).toContain("query_sdk-safe");
+	});
 
-  it("returns empty + helpful note for unknown queries", async () => {
-    const result = await sdkSearch(
-      { query: "definitelyNotAMethod" },
-      stubEnv,
-      stubCtx,
-    );
-    expect(result.match_count).toBe(0);
-    expect(result.notes).toBeDefined();
-  });
+	it("hides admin methods from write-tier callers", async () => {
+		const result = await sdkSearch({ query: "agents.list" }, stubEnv, writeCtx);
+		expect(result.match_count).toBe(0);
+		expect(result.notes).toContain("mcp:admin");
+	});
 
-  it("respects the limit parameter", async () => {
-    const result = await sdkSearch(
-      { query: "watchers", limit: 2 },
-      stubEnv,
-      stubCtx,
-    );
-    expect(result.results.length).toBeLessThanOrEqual(2);
-    expect(result.notes).toContain("more matches");
-  });
+	it("shows admin methods to admin-tier callers", async () => {
+		const result = await sdkSearch({ query: "agents.list" }, stubEnv, adminCtx);
+		expect(result.match_count).toBe(1);
+		expect(result.results[0]).toContain("agents.list");
+	});
+
+	it("substring-matches across paths and summaries", async () => {
+		const result = await sdkSearch({ query: "extraction" }, stubEnv, writeCtx);
+		// "extraction" appears in watchers.create's summary (entity-type derive).
+		expect(result.match_count).toBeGreaterThan(0);
+	});
+
+	it("returns empty + helpful note for unknown queries", async () => {
+		const result = await sdkSearch(
+			{ query: "definitelyNotAMethod" },
+			stubEnv,
+			readCtx,
+		);
+		expect(result.match_count).toBe(0);
+		expect(result.notes).toBeDefined();
+	});
+
+	it("respects the limit parameter", async () => {
+		const result = await sdkSearch(
+			{ query: "watchers", limit: 2 },
+			stubEnv,
+			writeCtx,
+		);
+		expect(result.results.length).toBeLessThanOrEqual(2);
+		expect(result.notes).toContain("more matches");
+	});
 });

--- a/packages/server/src/__tests__/unit/tool-registry-split.test.ts
+++ b/packages/server/src/__tests__/unit/tool-registry-split.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "bun:test";
+import { buildClientSDK } from "../../sandbox/client-sdk";
+import type { Env } from "../../index";
+import type { ToolContext } from "../../tools/registry";
+import { ADMIN_TOOLS } from "../../tools/admin";
+import { METHOD_METADATA } from "../../sandbox/method-metadata";
+import {
+	AGENT_TOOL_NAMES,
+	getAllTools,
+	getMcpTools,
+	getTool,
+	isInternalDispatchTool,
+} from "../../tools/registry";
+
+/** Agent MCP flat tools (excluding meta scripting/discovery) → SDK dotted path. */
+const AGENT_FLAT_TOOL_SDK_PATH: Record<string, string> = {
+	query_sql: "query",
+	search_memory: "knowledge.search",
+	save_memory: "knowledge.save",
+};
+
+/** Internal dispatch flat tools omitted from MCP list → SDK dotted path. */
+const INTERNAL_FLAT_TOOL_SDK_PATH: Record<string, string> = {
+	list_metrics: "metrics.list",
+	query_metric: "metrics.query",
+	metric_series: "metrics.series",
+	list_organizations: "organizations.list",
+};
+
+/** Every internal admin tool must be reachable via run_sdk/query_sdk. */
+const ADMIN_TOOL_SDK_NAMESPACE: Record<string, keyof ReturnType<typeof buildClientSDK>> = {
+	manage_entity: "entities",
+	manage_entity_schema: "entitySchema",
+	manage_connections: "connections",
+	manage_catalog: "catalog",
+	manage_agents: "agents",
+	manage_feeds: "feeds",
+	manage_auth_profiles: "authProfiles",
+	manage_operations: "operations",
+	notify: "notifications",
+	manage_schedules: "schedules",
+	manage_watchers: "watchers",
+	list_watchers: "watchers",
+	get_watcher: "watchers",
+	read_knowledge: "knowledge",
+	manage_classifiers: "classifiers",
+	manage_view_templates: "viewTemplates",
+};
+
+const testEnv = { ENVIRONMENT: "test" } as Env;
+const testCtx: ToolContext = {
+	organizationId: "test-org",
+	userId: "test-user",
+	memberRole: "owner",
+	isAuthenticated: true,
+	tokenType: "oauth",
+	scopedToOrg: false,
+	allowCrossOrg: true,
+};
+
+describe("tool registry split", () => {
+	it("advertises the agent MCP surface via getMcpTools", () => {
+		const names = getMcpTools().map((t) => t.name).sort();
+		expect(names).toEqual(
+			[
+				"query_sdk",
+				"query_sql",
+				"run_sdk",
+				"save_memory",
+				"search_memory",
+				"search_sdk",
+			].sort(),
+		);
+		expect(AGENT_TOOL_NAMES.size).toBe(6);
+	});
+
+	it("maps internal flat tools to ClientSDK methods for run_sdk/query_sdk parity", () => {
+		const { namespaceMethods, topLevelMethods } = (() => {
+			const sdk = buildClientSDK(testCtx, testEnv);
+			const namespaceMethods: string[] = [];
+			const topLevelMethods: string[] = [];
+			for (const [name, value] of Object.entries(sdk)) {
+				if (typeof value === "function") {
+					topLevelMethods.push(name);
+					continue;
+				}
+				if (!value || typeof value !== "object") continue;
+				for (const method of Object.keys(value)) {
+					namespaceMethods.push(`${name}.${method}`);
+				}
+			}
+			return { namespaceMethods, topLevelMethods };
+		})();
+		const runtime = new Set([...namespaceMethods, ...topLevelMethods]);
+
+		for (const [toolName, sdkPath] of Object.entries(INTERNAL_FLAT_TOOL_SDK_PATH)) {
+			expect(getTool(toolName), `${toolName} must stay dispatchable`).toBeDefined();
+			expect(isInternalDispatchTool(toolName), `${toolName} should be internal`).toBe(
+				true,
+			);
+			expect(
+				METHOD_METADATA[sdkPath],
+				`${toolName} → ${sdkPath} missing METHOD_METADATA`,
+			).toBeDefined();
+			expect(runtime.has(sdkPath), `${sdkPath} not on ClientSDK`).toBe(true);
+		}
+	});
+
+	it("maps agent flat tools to ClientSDK methods for run_sdk/query_sdk parity", () => {
+		const { namespaceMethods, topLevelMethods } = (() => {
+			const sdk = buildClientSDK(testCtx, testEnv);
+			const namespaceMethods: string[] = [];
+			const topLevelMethods: string[] = [];
+			for (const [name, value] of Object.entries(sdk)) {
+				if (typeof value === "function") {
+					topLevelMethods.push(name);
+					continue;
+				}
+				if (!value || typeof value !== "object") continue;
+				for (const method of Object.keys(value)) {
+					namespaceMethods.push(`${name}.${method}`);
+				}
+			}
+			return { namespaceMethods, topLevelMethods };
+		})();
+		const runtime = new Set([...namespaceMethods, ...topLevelMethods]);
+
+		for (const [toolName, sdkPath] of Object.entries(AGENT_FLAT_TOOL_SDK_PATH)) {
+			expect(AGENT_TOOL_NAMES.has(toolName), `${toolName} should be an agent tool`).toBe(
+				true,
+			);
+			expect(
+				METHOD_METADATA[sdkPath],
+				`${toolName} → ${sdkPath} missing METHOD_METADATA`,
+			).toBeDefined();
+			const [ns, method] = sdkPath.includes(".")
+				? sdkPath.split(".")
+				: [null, sdkPath];
+			if (ns) {
+				expect(namespaceMethods, `${toolName} → ${sdkPath}`).toContain(sdkPath);
+			} else {
+				expect(topLevelMethods, `${toolName} → ${sdkPath}`).toContain(method);
+			}
+			expect(runtime.has(sdkPath), `${sdkPath} not on ClientSDK`).toBe(true);
+		}
+	});
+
+	it("maps every admin tool to a ClientSDK namespace for run_sdk coverage", () => {
+		const sdk = buildClientSDK(testCtx, testEnv);
+		for (const tool of ADMIN_TOOLS) {
+			const ns = ADMIN_TOOL_SDK_NAMESPACE[tool.name];
+			expect(ns, `${tool.name} missing SDK namespace mapping`).toBeDefined();
+			expect(sdk[ns!], `${tool.name} → client.${String(ns)} not on ClientSDK`).toBeDefined();
+		}
+		expect(Object.keys(ADMIN_TOOL_SDK_NAMESPACE).sort()).toEqual(
+			ADMIN_TOOLS.map((t) => t.name).sort(),
+		);
+	});
+
+	it("keeps internal admin tools dispatchable and marks them internal on REST list", () => {
+		expect(getTool("list_watchers")).toBeDefined();
+		expect(getTool("manage_entity")).toBeDefined();
+		expect(isInternalDispatchTool("list_watchers")).toBe(true);
+		expect(isInternalDispatchTool("run_sdk")).toBe(false);
+
+		const rest = getAllTools();
+		expect(rest.length).toBeGreaterThan(getMcpTools().length);
+		const internal = rest.filter((t) => "internal" in t && t.internal);
+		expect(internal.map((t) => t.name)).toContain("manage_watchers");
+		expect(internal.map((t) => t.name)).not.toContain("run_sdk");
+	});
+});

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -673,13 +673,9 @@ describe('first-party tool-name coverage', () => {
 const ACCESS_SURFACE = `
 search_memory: read+public ?=read+public
 save_memory: write ?=write
-list_organizations: read ?=read
 search_sdk: read+public ?=read+public
 query_sdk: read ?=read
-list_metrics: read ?=read
-query_metric: read ?=read
 query_sql: read ?=read
-metric_series: read ?=read
 run_sdk: write ?=write
 manage_entity: create=write update=write list=read+public get=read+public delete=admin link=write unlink=write update_link=write list_links=read+public ?=read
 manage_entity_schema: list=read+public get=read+public create=admin update=admin delete=admin audit=read+public add_rule=admin remove_rule=admin list_rules=read+public ?=read
@@ -697,6 +693,10 @@ get_watcher: read+public ?=read+public
 read_knowledge: read+public ?=read+public
 manage_classifiers: create=admin list=read+public generate_embeddings=admin delete=admin classify=admin ?=read
 manage_view_templates: set=admin get=read+public rollback=admin remove_tab=admin clear=admin ?=read
+list_organizations: read ?=read
+list_metrics: read ?=read
+query_metric: read ?=read
+metric_series: read ?=read
 resolve_path: read+public ?=read+public
 `.trim();
 

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -36,7 +36,7 @@ import {
   mcpSessionMap,
 } from './mcp-session-state';
 import { type AuthContext, executeTool, extractAuthContext } from './tools/execute';
-import { getAllTools, getTool } from './tools/registry';
+import { getMcpTools, getTool } from './tools/registry';
 import { validateToolResult } from './tools/validate-args';
 import { formatToolResult } from './formatting/markdown-formatter';
 import { resolvePublicOrigin } from './utils/public-origin';
@@ -194,38 +194,16 @@ function createServerForContext(
     }
   );
 
-  // tools/list — return our TypeBox JSON Schemas
-  // Read auth state dynamically so the list updates after auth upgrades.
-  // Every registered tool is listed uniformly; the caller's access level
-  // (role × scope) and public-workspace readability are the only filters.
+  // tools/list — agent-facing surface only (memory + SDK scripting + SQL/metrics).
+  // Admin flat tools stay dispatchable via tools/call and REST but are omitted
+  // here so agents compose through query_sdk / run_sdk instead.
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    const adminAllowlist = authCtx.adminTools ?? null;
-    const hasAdminAllowlist = !!adminAllowlist && adminAllowlist.length > 0;
     const publicOnly = !!authCtx.organizationId && !authCtx.memberRole;
     const maxAccessLevel = resolveMaxAccessLevel(authCtx.memberRole, authCtx.scopes);
-    const staticTools = getAllTools({
+    const allTools = getMcpTools({
       publicOnly,
       maxAccessLevel,
-    });
-    // System-agent (builder) run: the per-turn allowlist LIMITS which tools may
-    // exercise admin-tier actions (see checkToolAccess). Mirror that here so
-    // the listing matches the execute gate: non-allowlisted tools are shown at
-    // write-tier (their admin-only action variants filtered out; tools with
-    // nothing left below admin disappear).
-    let visibleTools = staticTools;
-    if (hasAdminAllowlist && maxAccessLevel === 'admin') {
-      const allowed = new Set(adminAllowlist);
-      const writeTier = new Map(
-        getAllTools({ publicOnly, maxAccessLevel: 'write' }).map((t) => [
-          t.name,
-          t,
-        ])
-      );
-      visibleTools = staticTools
-        .map((t) => (allowed.has(t.name) ? t : writeTier.get(t.name)))
-        .filter((t): t is NonNullable<typeof t> => t !== undefined);
-    }
-    const allTools = visibleTools.map((t) => ({
+    }).map((t) => ({
       name: t.name,
       description: t.description,
       inputSchema: t.inputSchema,

--- a/packages/server/src/sandbox/client-sdk.ts
+++ b/packages/server/src/sandbox/client-sdk.ts
@@ -4,9 +4,9 @@
  * `allowCrossOrg: false` makes `client.org(...)` throw `CrossOrgAccessDenied`.
  */
 
-import { hasRequiredMcpScope } from "../auth/tool-access";
 import type { Env } from "../index";
-import { isSystemContext } from "../tools/access-control";
+import { isAdminOrOwnerRole, isSystemContext } from "../tools/access-control";
+import { ADMIN_ONLY_QUERYABLE_TABLES, SAFE_COLUMN_DEFS } from "../utils/table-schema";
 import type { ToolContext } from "../tools/registry";
 import { raceAbort } from "../utils/race-abort";
 import {
@@ -20,6 +20,7 @@ import type { SDKMode } from "./sdk-manifest";
 export { enumerateSDKManifest, type SDKMode } from "./sdk-manifest";
 
 import {
+	buildAgentsNamespace,
 	buildAuthProfilesNamespace,
 	buildCatalogNamespace,
 	buildClassifiersNamespace,
@@ -28,12 +29,15 @@ import {
 	buildEntitySchemaNamespace,
 	buildFeedsNamespace,
 	buildKnowledgeNamespace,
+	buildMetricsNamespace,
 	buildNotificationsNamespace,
 	buildOperationsNamespace,
 	buildOrganizationsNamespace,
+	buildSchedulesNamespace,
 	buildViewTemplatesNamespace,
 	buildWatchersNamespace,
 } from "./namespaces";
+import type { AgentsNamespace } from "./namespaces/agents";
 import type { AuthProfilesNamespace } from "./namespaces/auth-profiles";
 import type { CatalogNamespace } from "./namespaces/catalog";
 import type { ClassifiersNamespace } from "./namespaces/classifiers";
@@ -42,13 +46,16 @@ import type { EntitiesNamespace } from "./namespaces/entities";
 import type { EntitySchemaNamespace } from "./namespaces/entity-schema";
 import type { FeedsNamespace } from "./namespaces/feeds";
 import type { KnowledgeNamespace } from "./namespaces/knowledge";
+import type { MetricsNamespace } from "./namespaces/metrics";
 import type { NotificationsNamespace } from "./namespaces/notifications";
 import type { OperationsNamespace } from "./namespaces/operations";
 import type { OrganizationsNamespace } from "./namespaces/organizations";
 import type { ViewTemplatesNamespace } from "./namespaces/view-templates";
+import type { SchedulesNamespace } from "./namespaces/schedules";
 import type { WatchersNamespace } from "./namespaces/watchers";
 
 export interface ClientSDK {
+	agents: AgentsNamespace;
 	entities: EntitiesNamespace;
 	entitySchema: EntitySchemaNamespace;
 	catalog: CatalogNamespace;
@@ -60,8 +67,10 @@ export interface ClientSDK {
 	classifiers: ClassifiersNamespace;
 	viewTemplates: ViewTemplatesNamespace;
 	knowledge: KnowledgeNamespace;
+	metrics: MetricsNamespace;
 	notifications: NotificationsNamespace;
 	organizations: OrganizationsNamespace;
+	schedules: SchedulesNamespace;
 
 	org(slugOrId: string): Promise<ClientSDK>;
 	query(sql: string): Promise<unknown[]>;
@@ -162,6 +171,7 @@ export function buildClientSDK(
 	ctx = ctxWithSignal;
 
 	const namespaces = {
+		agents: buildAgentsNamespace(ctx, env),
 		entities: buildEntitiesNamespace(ctx, env),
 		entitySchema: buildEntitySchemaNamespace(ctx, env),
 		catalog: buildCatalogNamespace(ctx, env),
@@ -173,8 +183,10 @@ export function buildClientSDK(
 		classifiers: buildClassifiersNamespace(ctx, env),
 		viewTemplates: buildViewTemplatesNamespace(ctx, env),
 		knowledge: buildKnowledgeNamespace(ctx, env),
+		metrics: buildMetricsNamespace(ctx, env),
 		notifications: buildNotificationsNamespace(ctx, env),
 		organizations: buildOrganizationsNamespace(ctx),
+		schedules: buildSchedulesNamespace(ctx, env),
 	};
 
 	if (mode === "read") {
@@ -209,26 +221,19 @@ export function buildClientSDK(
 		},
 
 		async query(querySql) {
-			// The SQL allowlist exposes audit/event tables — admin/owner only for
-			// user sessions; system contexts (watcher reactions) bypass this gate.
-			if (!isSystemContext(ctx)) {
-				if (ctx.memberRole !== "owner" && ctx.memberRole !== "admin") {
-					throw new AccessDeniedError(
-						"client.query requires admin or owner access in the current organization.",
-					);
-				}
-				if (!hasRequiredMcpScope("admin", ctx.scopes)) {
-					throw new AccessDeniedError(
-						"client.query requires an MCP session with admin access.",
-					);
-				}
-			}
+			// Read-tier parity with `query_sql` / `metric_series`: members may query
+			// operational tables; auth/identity tables stay admin-only per-query.
+			const isAdmin = isAdminOrOwnerRole(ctx.memberRole);
 			const [{ getDb }, { validateAndScopeQuery }] = await Promise.all([
 				import("../db/client"),
 				import("../utils/execute-data-sources"),
 			]);
 			const scoped = validateAndScopeQuery(querySql, ctx.organizationId, {
 				userId: ctx.userId,
+				safeColumns: isSystemContext(ctx) ? undefined : SAFE_COLUMN_DEFS,
+				restrictedTables: isSystemContext(ctx) || isAdmin
+					? undefined
+					: ADMIN_ONLY_QUERYABLE_TABLES,
 			});
 			const rows = await raceAbort(
 				getDb().begin(async (tx) => {

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -3,7 +3,7 @@
  * tool, the read-only SDK filter (`access`), and the BANNED_PATHS guard.
  */
 
-export type MethodAccess = "read" | "write" | "external";
+export type MethodAccess = "read" | "write" | "external" | "admin";
 
 export interface MethodMetadata {
 	summary: string;
@@ -210,6 +210,76 @@ export default async (_ctx, client) => {
   });
   return result;
 };`,
+	},
+
+	// agents
+	"agents.manage": {
+		summary: "Raw manage_agents action wrapper. Prefer named methods.",
+		access: "admin",
+	},
+	"agents.list": {
+		summary: "List agents in the org (marks the system agent). Requires admin.",
+		access: "admin",
+		example: "const { agents } = await client.agents.list();",
+	},
+	"agents.get": {
+		summary: "Fetch one agent by id. Requires admin.",
+		access: "admin",
+		example: "const { agent } = await client.agents.get('builder');",
+	},
+	"agents.create": {
+		summary:
+			"Create an agent (queued for approval when invoked by the builder agent). Requires admin.",
+		access: "admin",
+		example:
+			"await client.agents.create({ agent_id: 'researcher', name: 'Researcher' });",
+	},
+	"agents.update": {
+		summary: "Update agent fields (may queue for approval). Requires admin.",
+		access: "admin",
+	},
+	"agents.delete": {
+		summary: "Delete an agent (may queue for approval). Requires admin.",
+		access: "admin",
+	},
+	"agents.setSystemAgent": {
+		summary: "Point organization.system_agent_id at an agent. Requires admin.",
+		access: "admin",
+		example: "await client.agents.setSystemAgent('builder');",
+	},
+
+	// schedules
+	"schedules.manage": {
+		summary: "Raw manage_schedules action wrapper. Prefer named methods.",
+		access: "admin",
+	},
+	"schedules.list": {
+		summary: "List scheduled jobs with optional filters. Requires admin.",
+		access: "admin",
+		example:
+			"const { schedules } = await client.schedules.list({ agent_id: 'builder' });",
+	},
+	"schedules.create": {
+		summary:
+			"Create a one-shot or recurring schedule (send_notification or wake_agent). Requires admin.",
+		access: "admin",
+		example: `await client.schedules.create({
+  description: 'Follow up in 1h',
+  run_at: '2026-07-05T12:00:00Z',
+  payload: { type: 'wake_agent', agent_id: 'builder', prompt: 'Check inbox' },
+});`,
+	},
+	"schedules.update": {
+		summary: "Patch a schedule (next run, cron, wake_agent prompt). Requires admin.",
+		access: "admin",
+	},
+	"schedules.pause": {
+		summary: "Pause or resume a schedule. Requires admin.",
+		access: "admin",
+	},
+	"schedules.cancel": {
+		summary: "Permanently delete a schedule. Requires admin.",
+		access: "admin",
 	},
 
 	// notifications
@@ -541,14 +611,49 @@ export default async (_ctx, client) => {
 		access: "write",
 	},
 
+	// metrics — governed measures (prefer over client.query / query_sql)
+	"metrics.list": {
+		summary:
+			"List declared metrics per entity type: measures, dimensions, and segments with descriptions. Keyword-search with `q`. Pair with `metrics.query`.",
+		access: "read",
+		example: "const { entity_types } = await client.metrics.list({ q: 'spend' });",
+		usageExample: `// Discover governed measures before running one.
+export default async (_ctx, client) => {
+  const { entity_types } = await client.metrics.list({ entity_type: 'company' });
+  return { types: entity_types.map((t) => t.entity_type) };
+};`,
+	},
+	"metrics.query": {
+		summary:
+			"Run a declared measure for an entity type. Pass entity_type + measure; optional by, segment, entity_id. Prefer this over client.query when a measure exists.",
+		access: "read",
+		example:
+			"await client.metrics.query({ entity_type: 'company', measure: 'spend', by: ['month'] });",
+		usageExample: `export default async (_ctx, client) => {
+  const { rows, row_count } = await client.metrics.query({
+    entity_type: 'company',
+    measure: 'spend',
+    by: ['month'],
+  });
+  return { row_count, sample: rows[0] };
+};`,
+	},
+	"metrics.series": {
+		summary:
+			"Run read-only time-bucketed SQL for sparklines. Returns { columns, rows } tabular output. Member-safe column allowlist; 5s timeout, 2000-row cap.",
+		access: "read",
+		example:
+			'await client.metrics.series({ sql: "SELECT date_trunc(\\\'day\\\', created_at) AS bucket, COUNT(*)::int AS n FROM events GROUP BY 1 ORDER BY 1" });',
+	},
+
 	// top-level
 	query: {
 		summary:
-			"Run a read-only SQL query against the organization-scoped virtual tables. No positional parameters — use Handlebars {{query.name}} substitutions inside the SQL when you need values.",
+			"Run a simple read-only SQL string scoped to the org (member-safe column allowlist). For pagination, connection pushdown, or virtual feeds use the `query_sql` MCP tool instead. Prefer `client.metrics.query` for declared measures.",
 		access: "read",
 		example:
-			"const rows = await client.query(\"SELECT id, name FROM entities WHERE entity_type = 'company'\");",
-		usageExample: `// Run a one-off SQL read scoped to the bound organization.
+			"const rows = await client.query(\"SELECT id, name FROM entities WHERE entity_type = 'company' LIMIT 10\");",
+		usageExample: `// Simple SQL read — use query_sql for pagination/feeds.
 export default async (_ctx, client) => {
   return client.query("SELECT id, name FROM entities WHERE entity_type = 'company' LIMIT 10");
 };`,

--- a/packages/server/src/sandbox/namespaces/agents.ts
+++ b/packages/server/src/sandbox/namespaces/agents.ts
@@ -1,0 +1,50 @@
+/**
+ * ClientSDK `agents` namespace. Thin wrapper over `manageAgents`.
+ */
+
+import type { Env } from "../../index";
+import { manageAgents } from "../../tools/admin/manage_agents";
+import type { ToolContext } from "../../tools/registry";
+import { createActionCaller } from "./action-call";
+
+export interface AgentsCreateInput {
+	agent_id: string;
+	name?: string;
+	description?: string;
+	identity_md?: string;
+}
+
+export interface AgentsUpdateInput {
+	agent_id: string;
+	name?: string;
+	description?: string;
+	identity_md?: string;
+}
+
+export interface AgentsNamespace {
+	manage(input: Record<string, unknown>): Promise<unknown>;
+	list(): Promise<unknown>;
+	get(agent_id: string): Promise<unknown>;
+	create(input: AgentsCreateInput): Promise<unknown>;
+	update(input: AgentsUpdateInput): Promise<unknown>;
+	delete(agent_id: string): Promise<unknown>;
+	setSystemAgent(agent_id: string): Promise<unknown>;
+}
+
+export function buildAgentsNamespace(
+	ctx: ToolContext,
+	env: Env,
+): AgentsNamespace {
+	const { manage, action } = createActionCaller(manageAgents, env, ctx);
+
+	return {
+		manage,
+		list: () => action("list", {}),
+		get: (agent_id) => action("get", { agent_id }),
+		create: (input) => action("create", input),
+		update: (input) => action("update", input),
+		delete: (agent_id) => action("delete", { agent_id }),
+		setSystemAgent: (agent_id) =>
+			action("set_system_agent", { agent_id }),
+	};
+}

--- a/packages/server/src/sandbox/namespaces/index.ts
+++ b/packages/server/src/sandbox/namespaces/index.ts
@@ -2,6 +2,7 @@
  * Re-exports for the per-namespace SDK builders.
  */
 
+export { buildAgentsNamespace } from "./agents";
 export { buildAuthProfilesNamespace } from "./auth-profiles";
 export { buildCatalogNamespace } from "./catalog";
 export { buildClassifiersNamespace } from "./classifiers";
@@ -10,8 +11,10 @@ export { buildEntitiesNamespace } from "./entities";
 export { buildEntitySchemaNamespace } from "./entity-schema";
 export { buildFeedsNamespace } from "./feeds";
 export { buildKnowledgeNamespace } from "./knowledge";
+export { buildMetricsNamespace } from "./metrics";
 export { buildNotificationsNamespace } from "./notifications";
 export { buildOperationsNamespace } from "./operations";
 export { buildOrganizationsNamespace } from "./organizations";
+export { buildSchedulesNamespace } from "./schedules";
 export { buildViewTemplatesNamespace } from "./view-templates";
 export { buildWatchersNamespace } from "./watchers";

--- a/packages/server/src/sandbox/namespaces/metrics.ts
+++ b/packages/server/src/sandbox/namespaces/metrics.ts
@@ -1,0 +1,41 @@
+/**
+ * ClientSDK `metrics` namespace. Thin wrapper over the metric MCP tools
+ * (`list_metrics`, `query_metric`, `metric_series`).
+ */
+
+import type { Static } from "@sinclair/typebox";
+import type { Env } from "../../index";
+import {
+	ListMetricsSchema,
+	listMetrics,
+} from "../../tools/admin/list_metrics";
+import {
+	MetricSeriesSchema,
+	metricSeries,
+} from "../../tools/admin/metric_series";
+import {
+	QueryMetricSchema,
+	queryMetric,
+} from "../../tools/admin/query_metric";
+import type { ToolContext } from "../../tools/registry";
+
+export type MetricsListInput = Static<typeof ListMetricsSchema>;
+export type MetricsQueryInput = Static<typeof QueryMetricSchema>;
+export type MetricsSeriesInput = Static<typeof MetricSeriesSchema>;
+
+export interface MetricsNamespace {
+	list(input?: MetricsListInput): Promise<unknown>;
+	query(input: MetricsQueryInput): Promise<unknown>;
+	series(input: MetricsSeriesInput): Promise<unknown>;
+}
+
+export function buildMetricsNamespace(
+	ctx: ToolContext,
+	env: Env,
+): MetricsNamespace {
+	return {
+		list: (input) => listMetrics(input ?? {}, env, ctx),
+		query: (input) => queryMetric(input, env, ctx),
+		series: (input) => metricSeries(input, env, ctx),
+	};
+}

--- a/packages/server/src/sandbox/namespaces/schedules.ts
+++ b/packages/server/src/sandbox/namespaces/schedules.ts
@@ -1,0 +1,59 @@
+/**
+ * ClientSDK `schedules` namespace. Thin wrapper over `manageSchedules`.
+ */
+
+import type { Env } from "../../index";
+import { manageSchedules } from "../../tools/admin/manage_schedules";
+import type { ToolContext } from "../../tools/registry";
+import { createActionCaller } from "./action-call";
+
+export interface SchedulesListInput {
+	agent_id?: string;
+	user_id?: string;
+	action_type?: string;
+	include_paused?: boolean;
+}
+
+export interface SchedulesCreateInput {
+	description: string;
+	run_at: string;
+	cron?: string;
+	payload: Record<string, unknown>;
+	source_run_id?: number;
+	source_event_id?: number;
+	source_thread_id?: string;
+}
+
+export interface SchedulesUpdateInput {
+	id: string;
+	description?: string;
+	run_at?: string;
+	cron?: string | null;
+	prompt?: string;
+	model?: string;
+}
+
+export interface SchedulesNamespace {
+	manage(input: Record<string, unknown>): Promise<unknown>;
+	list(input?: SchedulesListInput): Promise<unknown>;
+	create(input: SchedulesCreateInput): Promise<unknown>;
+	update(input: SchedulesUpdateInput): Promise<unknown>;
+	pause(input: { id: string; paused?: boolean }): Promise<unknown>;
+	cancel(id: string): Promise<unknown>;
+}
+
+export function buildSchedulesNamespace(
+	ctx: ToolContext,
+	env: Env,
+): SchedulesNamespace {
+	const { manage, action } = createActionCaller(manageSchedules, env, ctx);
+
+	return {
+		manage,
+		list: (input) => action("list", input ?? {}),
+		create: (input) => action("create", input),
+		update: (input) => action("update", input),
+		pause: (input) => action("pause", input),
+		cancel: (id) => action("cancel", { id }),
+	};
+}

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -7,6 +7,7 @@
 
 import type { ClientSDK } from "./client-sdk";
 import { METHOD_METADATA, type MethodAccess } from "./method-metadata";
+import type { ToolAccessLevel } from "../auth/tool-access";
 import { enumerateSDKManifest, type SDKMode } from "./sdk-manifest";
 
 export interface RunLimits {
@@ -35,6 +36,8 @@ export interface RunScriptOptions {
 	sdkMode?: SDKMode;
 	/** Whether `client.org` is reachable inside the guest. Defaults to false. */
 	allowCrossOrg?: boolean;
+	/** Caller access tier — filters the dispatch manifest (defaults to read). */
+	maxAccessLevel?: ToolAccessLevel;
 	limits?: RunLimits;
 	/** Forwarded to the script entry point after `(ctx, client)`. */
 	extraArgs?: unknown[];
@@ -337,7 +340,10 @@ export async function runScript(
 	const limits = clampLimits(options.limits);
 	const sdkMode: SDKMode = options.sdkMode ?? "full";
 	const allowCrossOrg = options.allowCrossOrg ?? false;
-	const manifest = enumerateSDKManifest(sdkMode, { allowCrossOrg });
+	const manifest = enumerateSDKManifest(sdkMode, {
+		allowCrossOrg,
+		maxAccessLevel: options.maxAccessLevel,
+	});
 
 	// Host-side mirror of the manifest's dispatchable paths. `__sdk_dispatch` is a
 	// guest-visible global, so a malicious script can call it with an un-manifested

--- a/packages/server/src/sandbox/sdk-manifest.ts
+++ b/packages/server/src/sandbox/sdk-manifest.ts
@@ -4,7 +4,12 @@
  * runtime — the run-script-runtime.test.ts CI guard depends on this.
  */
 
+import {
+	resolveMaxAccessLevel,
+	type ToolAccessLevel,
+} from "../auth/tool-access";
 import { METHOD_METADATA } from "./method-metadata";
+import { sdkMethodVisible } from "./sdk-method-access";
 
 export type SDKMode = "read" | "full";
 
@@ -13,20 +18,24 @@ type SDKManifest = {
 	byNamespace: Record<string, string[]>;
 };
 
-// METHOD_METADATA is a static module constant, so there are only four distinct
-// manifests (mode × allowCrossOrg). Memoize them so each sandbox call is a Map
-// lookup instead of a ~545-entry walk + allocations.
 const manifestCache = new Map<string, SDKManifest>();
 
-function buildSDKManifest(mode: SDKMode, allowCrossOrg: boolean): SDKManifest {
-	const topLevel = ["query", "log"];
-	if (allowCrossOrg) topLevel.unshift("org");
+function buildSDKManifest(
+	mode: SDKMode,
+	allowCrossOrg: boolean,
+	callerMax: ToolAccessLevel,
+): SDKManifest {
+	const topLevel: string[] = [];
+	if (sdkMethodVisible("read", callerMax, mode)) {
+		if (allowCrossOrg) topLevel.push("org");
+		topLevel.push("query", "log");
+	}
 
 	const byNamespace: Record<string, string[]> = {};
 	for (const [path, meta] of Object.entries(METHOD_METADATA)) {
 		const dot = path.indexOf(".");
 		if (dot === -1) continue;
-		if (mode === "read" && meta.access !== "read") continue;
+		if (!sdkMethodVisible(meta.access, callerMax, mode)) continue;
 		const ns = path.slice(0, dot);
 		(byNamespace[ns] ??= []).push(path.slice(dot + 1));
 	}
@@ -35,13 +44,15 @@ function buildSDKManifest(mode: SDKMode, allowCrossOrg: boolean): SDKManifest {
 
 export function enumerateSDKManifest(
 	mode: SDKMode,
-	options?: { allowCrossOrg?: boolean },
+	options?: { allowCrossOrg?: boolean; maxAccessLevel?: ToolAccessLevel },
 ): SDKManifest {
 	const allowCrossOrg = options?.allowCrossOrg !== false;
-	const key = `${mode}:${allowCrossOrg ? "1" : "0"}`;
+	const callerMax =
+		options?.maxAccessLevel ?? resolveMaxAccessLevel(null, null);
+	const key = `${mode}:${allowCrossOrg ? "1" : "0"}:${callerMax}`;
 	let manifest = manifestCache.get(key);
 	if (!manifest) {
-		manifest = buildSDKManifest(mode, allowCrossOrg);
+		manifest = buildSDKManifest(mode, allowCrossOrg, callerMax);
 		manifestCache.set(key, manifest);
 	}
 	return manifest;

--- a/packages/server/src/sandbox/sdk-manifest.ts
+++ b/packages/server/src/sandbox/sdk-manifest.ts
@@ -4,10 +4,7 @@
  * runtime — the run-script-runtime.test.ts CI guard depends on this.
  */
 
-import {
-	resolveMaxAccessLevel,
-	type ToolAccessLevel,
-} from "../auth/tool-access";
+import type { ToolAccessLevel } from "../auth/tool-access";
 import { METHOD_METADATA } from "./method-metadata";
 import { sdkMethodVisible } from "./sdk-method-access";
 
@@ -47,8 +44,11 @@ export function enumerateSDKManifest(
 	options?: { allowCrossOrg?: boolean; maxAccessLevel?: ToolAccessLevel },
 ): SDKManifest {
 	const allowCrossOrg = options?.allowCrossOrg !== false;
+	// Callers that omit maxAccessLevel (reaction scripts, tests) expect the
+	// historical full manifest. MCP entry points pass the caller tier explicitly.
 	const callerMax =
-		options?.maxAccessLevel ?? resolveMaxAccessLevel(null, null);
+		options?.maxAccessLevel ??
+		(mode === "read" ? "read" : "admin");
 	const key = `${mode}:${allowCrossOrg ? "1" : "0"}:${callerMax}`;
 	let manifest = manifestCache.get(key);
 	if (!manifest) {

--- a/packages/server/src/sandbox/sdk-method-access.ts
+++ b/packages/server/src/sandbox/sdk-method-access.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared visibility rules for SDK method discovery (`search_sdk`) and the
+ * sandbox manifest (`query_sdk` / `run_sdk`). Keeps catalog, manifest, and
+ * runtime policy aligned on what a caller can actually invoke.
+ */
+
+import type { ToolAccessLevel } from "../auth/tool-access";
+import type { MethodAccess } from "./method-metadata";
+
+export type SdkDiscoveryMode = "read" | "full";
+
+/** Whether a method should appear for this caller + discovery mode. */
+export function sdkMethodVisible(
+	methodAccess: MethodAccess,
+	callerMax: ToolAccessLevel,
+	mode: SdkDiscoveryMode,
+): boolean {
+	if (mode === "read") return methodAccess === "read";
+	if (methodAccess === "read") return true;
+	if (methodAccess === "admin") return callerMax === "admin";
+	// write | external — member write tier or admin/owner
+	return callerMax === "write" || callerMax === "admin";
+}

--- a/packages/server/src/tools/admin/index.ts
+++ b/packages/server/src/tools/admin/index.ts
@@ -1,10 +1,10 @@
 /**
  * Admin tool surface (manage_*, watcher reads, knowledge reads, notify).
  *
- * Exposed uniformly on every surface — MCP `tools/list`, the REST proxy
- * (`POST /api/:orgSlug/:toolName`), the ClientSDK namespaces, and the CLI.
- * There is no visibility flag: reach is decided purely by per-action access
- * tier x member role x `mcp:*` scope (see `auth/tool-access.ts`).
+ * REST + MCP `tools/call` dispatch surface (`POST /api/:orgSlug/:toolName`).
+ * Omitted from MCP `tools/list` — agents reach these via `query_sdk` / `run_sdk`
+ * and the ClientSDK namespaces. Per-action access tier x member role x `mcp:*`
+ * scope still governs execution (`auth/tool-access.ts`).
  */
 
 import type { TSchema } from "@sinclair/typebox";
@@ -126,7 +126,8 @@ const ENTRIES: AdminToolEntry[] = [
 	},
 	{
 		name: "manage_agents",
-		description: "Agent management (incl. the org system agent pointer).",
+		description:
+			"Agent management (incl. the org system agent pointer). SDK alternative: client.agents.",
 		schema: ManageAgentsSchema,
 		handler: manageAgents,
 		annotations: DESTRUCTIVE_WITH_TITLE("Manage agents"),
@@ -168,7 +169,7 @@ const ENTRIES: AdminToolEntry[] = [
 	{
 		name: "manage_schedules",
 		description:
-			"Create / list / pause / cancel recurring or one-shot scheduled jobs. Supports send_notification and wake_agent action types. Per-row attribution lets you trace what scheduled it and from where.",
+			"Create / list / pause / cancel recurring or one-shot scheduled jobs. Supports send_notification and wake_agent action types. Per-row attribution lets you trace what scheduled it and from where. SDK alternative: client.schedules.",
 		schema: ManageSchedulesSchema,
 		handler: manageSchedules,
 		annotations: DESTRUCTIVE_WITH_TITLE("Manage schedules"),

--- a/packages/server/src/tools/admin/metric_series.ts
+++ b/packages/server/src/tools/admin/metric_series.ts
@@ -14,9 +14,9 @@
  *   - server-injected `$1`: caller can't choose which org to query
  *   - statement timeout: 5s, enforced via SET LOCAL inside a transaction
  *   - hard row cap: queries returning more than MAX_ROWS rows are rejected
- *   - `internal: true`: hidden from external MCP clients (REST/session only)
  *
- * Returns `{ columns: string[], rows: unknown[][] }`.
+ * Returns `{ columns: string[], rows: unknown[][] }`. Also exposed as
+ * `client.metrics.series` in the ClientSDK and on the MCP agent surface.
  */
 
 import { type Static, Type } from '@sinclair/typebox';

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -136,7 +136,8 @@ const READ_ONLY = { readOnlyHint: true, idempotentHint: true } as const;
 
 const WRITE_WITHOUT_CONFIRM: ToolAnnotations = { destructiveHint: false, idempotentHint: false };
 
-const TOOLS: ToolDefinition[] = [
+/** Tools advertised on MCP `tools/list` and external OpenAPI. */
+const AGENT_TOOLS: ToolDefinition[] = [
   // ─── Memory hot path — read ───────────────────────────────────────────────
   {
     name: 'search_memory',
@@ -159,21 +160,10 @@ const TOOLS: ToolDefinition[] = [
     annotations: { ...WRITE_WITHOUT_CONFIRM, title: 'Save memory' },
     handler: saveContent,
   },
-  // ─── Discovery ────────────────────────────────────────────────────────────
-  {
-    name: 'list_organizations',
-    description:
-      'List organizations the authenticated user belongs to, plus any public workspaces the session can read. The response marks the bound org with `is_current: true` — that is the default target for memory and SDK calls. Use the slug with `client.org(slug)` from `query_sdk` / `run_sdk` for cross-org reads on /mcp + OAuth, or reconnect to /mcp/{slug} to pin a different default.',
-    inputSchema: ListOrganizationsSchema,
-    annotations: { ...READ_ONLY, title: 'List organizations' },
-    handler: async () => {
-      throw new Error('Handled directly in executeTool');
-    },
-  },
   {
     name: 'search_sdk',
     description:
-      "Search ClientSDK documentation and method metadata. Use this to discover which SDK method exists and how to call it; it does not query workspace data. Pass a namespace ('watchers', 'entities', etc.), a dotted path ('watchers.create'), or a free-text query. Pair with `query_sdk` (read-only) or `run_sdk` (full SDK) to actually call methods.",
+      "Search ClientSDK documentation and method metadata. Results are filtered to what you can call: pass mode='read' for query_sdk-safe methods, or omit mode for your full run_sdk tier (write/admin methods appear only when your role and scopes allow). Does not query workspace data — pair with `query_sdk` or `run_sdk` to execute. For flat SQL with pagination/feeds use `query_sql`; for governed metrics use client.metrics.* via query_sdk.",
     inputSchema: SdkSearchSchema,
     outputSchema: SdkSearchResultSchema,
     annotations: { ...READ_ONLY, title: 'Search SDK docs' },
@@ -190,36 +180,12 @@ const TOOLS: ToolDefinition[] = [
     handler: querySdkScript,
   },
   {
-    name: 'list_metrics',
-    description:
-      'List the DECLARED, governed metrics — measures / dimensions / segments (with descriptions) per entity type. Use this FIRST to discover what metrics exist; pass `q` to keyword-search. Then run one with `query_metric`. Prefer governed metrics over hand-written `query_sql` so numbers stay consistent.',
-    inputSchema: ListMetricsSchema,
-    annotations: { ...READ_ONLY, title: 'List metrics' },
-    handler: listMetrics,
-  },
-  {
-    name: 'query_metric',
-    description:
-      'Run a DECLARED metric (discover them via `list_metrics`) and get its rows: pass entity_type + measure, optional `by` dimensions / `segment` / `entity_id`. The metric layer enforces resolution, dedupe, segment, and aggregation, so results are consistent and governed. PREFER this over `query_sql` whenever a declared measure answers the question; fall back to `query_sql` only when no metric covers the ask.',
-    inputSchema: QueryMetricSchema,
-    annotations: { ...READ_ONLY, title: 'Query metric' },
-    handler: queryMetric,
-  },
-  {
     name: 'query_sql',
     description:
-      'Run a paginated, sortable, searchable read-only SQL query. Table references auto-scope to the bound org. The query is wrapped as a subquery, so inner ORDER BY / LIMIT / window functions are fine; pagination + sort come from the sort_by/limit/offset args. Do NOT use positional parameters ($1, $2, …). Optional `org_slug` (OAuth on /mcp only) redirects the query to a different member org; rejected on /mcp/{slug} and on PAT auth. NOTE: this is the FALLBACK — if a declared metric covers the ask, use `query_metric` (see `list_metrics`) instead, so numbers match the governed definitions.',
+      'Run a paginated, sortable, searchable read-only SQL query (member-safe). Table references auto-scope to the bound org. Supports connection pushdown and virtual feeds. Prefer client.metrics.query for declared measures; use client.query in query_sdk for simple one-shot SQL. Do NOT use positional parameters ($1, $2, …). Optional `org_slug` (OAuth on /mcp only) redirects to another member org.',
     inputSchema: QuerySqlSchema,
     annotations: { ...READ_ONLY, title: 'Query SQL' },
     handler: querySql,
-  },
-  {
-    name: 'metric_series',
-    description:
-      'Run a read-only time-series SQL for dashboard sparklines. Caller passes a single SELECT returning a bucket column + N numeric stat columns; the same validator/auto-scoper that powers `query_sql` injects `$1 = organization_id`. Returns `{ columns, rows }` for direct frontend consumption.',
-    inputSchema: MetricSeriesSchema,
-    annotations: { ...READ_ONLY, title: 'Metric series' },
-    handler: metricSeries,
   },
   {
     name: 'run_sdk',
@@ -230,9 +196,49 @@ const TOOLS: ToolDefinition[] = [
     annotations: { destructiveHint: true, idempotentHint: false, title: 'Run SDK' },
     handler: runSdkScript,
   },
-  // ─── Admin surface (manage_*, list_watchers, get_watcher, ...) ────────────
+];
+
+/**
+ * Admin + first-party REST dispatch tools. Callable via `POST /api/:org/:toolName`
+ * and MCP `tools/call` by name, but omitted from MCP `tools/list` — agents use
+ * `search_sdk` → `query_sdk` / `run_sdk` instead.
+ */
+const INTERNAL_DISPATCH_TOOLS: ToolDefinition[] = [
   ...ADMIN_TOOLS,
-  // ─── Path resolution (frontend internal) ──────────────────────────────────
+  {
+    name: 'list_organizations',
+    description:
+      'List organizations the authenticated user belongs to, plus any public workspaces the session can read. SDK alternative: client.organizations.list via `query_sdk` / `run_sdk`.',
+    inputSchema: ListOrganizationsSchema,
+    annotations: { ...READ_ONLY, title: 'List organizations' },
+    handler: async () => {
+      throw new Error('Handled directly in executeTool');
+    },
+  },
+  {
+    name: 'list_metrics',
+    description:
+      'List declared governed metrics per entity type. SDK alternative: client.metrics.list.',
+    inputSchema: ListMetricsSchema,
+    annotations: { ...READ_ONLY, title: 'List metrics' },
+    handler: listMetrics,
+  },
+  {
+    name: 'query_metric',
+    description:
+      'Run a declared metric. SDK alternative: client.metrics.query.',
+    inputSchema: QueryMetricSchema,
+    annotations: { ...READ_ONLY, title: 'Query metric' },
+    handler: queryMetric,
+  },
+  {
+    name: 'metric_series',
+    description:
+      'Read-only time-series SQL for dashboard sparklines. SDK alternative: client.metrics.series.',
+    inputSchema: MetricSeriesSchema,
+    annotations: { ...READ_ONLY, title: 'Metric series' },
+    handler: metricSeries,
+  },
   {
     name: 'resolve_path',
     description:
@@ -244,20 +250,36 @@ const TOOLS: ToolDefinition[] = [
   },
 ];
 
+const ALL_DISPATCH_TOOLS: ToolDefinition[] = [
+  ...AGENT_TOOLS,
+  ...INTERNAL_DISPATCH_TOOLS,
+];
+
+export const AGENT_TOOL_NAMES: ReadonlySet<string> = new Set(
+  AGENT_TOOLS.map((tool) => tool.name),
+);
+
+const INTERNAL_TOOL_NAMES: ReadonlySet<string> = new Set(
+  INTERNAL_DISPATCH_TOOLS.map((tool) => tool.name),
+);
+
 // ============================================
 // Helper Functions
 // ============================================
 
-// TOOLS is a module constant with no runtime mutation — index it once.
-const TOOLS_BY_NAME: Map<string, ToolDefinition> = new Map(
-  TOOLS.map((tool) => [tool.name, tool])
+const DISPATCH_BY_NAME: Map<string, ToolDefinition> = new Map(
+  ALL_DISPATCH_TOOLS.map((tool) => [tool.name, tool]),
 );
 
 /**
  * Get tool by name
  */
 export function getTool(name: string): ToolDefinition | undefined {
-  return TOOLS_BY_NAME.get(name);
+  return DISPATCH_BY_NAME.get(name);
+}
+
+export function isInternalDispatchTool(name: string): boolean {
+  return INTERNAL_TOOL_NAMES.has(name);
 }
 
 /**
@@ -415,37 +437,53 @@ function filterSchemaForAccessLevel(
   return null;
 }
 
-// The tool registry + its schemas are static after module load, so the
-// computed tool list depends only on the two options. Memoize per option
-// tuple (a handful of distinct values in practice).
-const allToolsCache = new Map<string, ReturnType<typeof computeAllTools>>();
+// Memoize listed tool shapes per (surface × filter tuple).
+const listedToolsCache = new Map<string, ReturnType<typeof computeListedTools>>();
 
-/**
- * Get all tool definitions for MCP tools/list.
- *
- * Every registered tool is listed on every surface; the only filters are the
- * caller's access level (role × scope) and public-workspace readability.
- */
-export function getAllTools(options?: {
+type ListedToolOptions = {
   publicOnly?: boolean;
   maxAccessLevel?: 'read' | 'write' | 'admin';
-}) {
+};
+
+/**
+ * Agent-facing tools for MCP `tools/list` and external OpenAPI.
+ */
+export function getMcpTools(options?: ListedToolOptions) {
+  return getListedTools(AGENT_TOOLS, options);
+}
+
+/**
+ * All dispatch tools for REST `GET /api/:org/tools` (admin entries carry
+ * `internal: true` for CLI filtering). Execution uses `getTool` across both sets.
+ */
+export function getAllTools(options?: ListedToolOptions) {
+  const listed = getListedTools(ALL_DISPATCH_TOOLS, options);
+  return listed.map((tool) =>
+    INTERNAL_TOOL_NAMES.has(tool.name) ? { ...tool, internal: true as const } : tool,
+  );
+}
+
+function getListedTools(
+  source: ToolDefinition[],
+  options?: ListedToolOptions,
+) {
   const publicOnly = options?.publicOnly ?? false;
   const maxAccessLevel = options?.maxAccessLevel ?? 'admin';
-  const cacheKey = `${publicOnly ? 1 : 0}:${maxAccessLevel}`;
-  let cached = allToolsCache.get(cacheKey);
+  const cacheKey = `${source === AGENT_TOOLS ? 'mcp' : 'all'}:${publicOnly ? 1 : 0}:${maxAccessLevel}`;
+  let cached = listedToolsCache.get(cacheKey);
   if (!cached) {
-    cached = computeAllTools(publicOnly, maxAccessLevel);
-    allToolsCache.set(cacheKey, cached);
+    cached = computeListedTools(source, publicOnly, maxAccessLevel);
+    listedToolsCache.set(cacheKey, cached);
   }
   return cached;
 }
 
-function computeAllTools(
+function computeListedTools(
+  source: ToolDefinition[],
   publicOnly: boolean,
   maxAccessLevel: 'read' | 'write' | 'admin'
 ) {
-  return TOOLS
+  return source
     .filter((tool) => !publicOnly || getPublicReadableActions(tool.name) !== undefined)
     .map((tool) => {
       // Advertise the narrower `publicInputSchema` when a tool declares one;

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -1,4 +1,5 @@
 import { type Static, Type } from "@sinclair/typebox";
+import { resolveMaxAccessLevel } from "../auth/tool-access";
 import type { Env } from "../index";
 import { buildClientSDK, type SDKMode } from "../sandbox/client-sdk";
 import { runScript } from "../sandbox/run-script";
@@ -105,6 +106,7 @@ async function runSandbox(
     sdk: (abortSignal) => buildClientSDK(ctx, env, { mode, allowCrossOrg, abortSignal }),
     sdkMode: mode,
     allowCrossOrg,
+    maxAccessLevel: resolveMaxAccessLevel(ctx.memberRole, ctx.scopes),
     dryRun: mode === "full" && "dry_run" in args && args.dry_run === true,
     context: {
       organization_id: ctx.organizationId,

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -1,191 +1,223 @@
 /**
  * Method discovery for the `ClientSDK`. Match order: exact path drill-down →
  * namespace prefix listing → substring on path + summary. Source of truth is
- * `method-metadata.ts`.
+ * `method-metadata.ts`; visibility matches `query_sdk` / `run_sdk` manifests.
  */
 
 import { type Static, Type } from "@sinclair/typebox";
+import { resolveMaxAccessLevel } from "../auth/tool-access";
 import type { Env } from "../index";
 import { METHOD_METADATA, type MethodMetadata } from "../sandbox/method-metadata";
+import {
+	sdkMethodVisible,
+	type SdkDiscoveryMode,
+} from "../sandbox/sdk-method-access";
 import type { ToolContext } from "./registry";
 import { withValidatedArgs } from "./validate-args";
 
-/**
- * Namespace index derived from the metadata keys at module load — advertised
- * in the query description and the no-match hint so a cold client can
- * enumerate the SDK surface without guessing. Parity with the runtime SDK is
- * guarded by `sandbox/method-metadata.test.ts`, so this list can't drift.
- */
 const NAMESPACES = [
-  ...new Set(
-    Object.keys(METHOD_METADATA)
-      .filter((path) => path.includes("."))
-      .map((path) => path.split(".")[0]),
-  ),
+	...new Set(
+		Object.keys(METHOD_METADATA)
+			.filter((path) => path.includes("."))
+			.map((path) => path.split(".")[0]),
+	),
 ].sort();
 
 export const SdkSearchSchema = Type.Object({
-  query: Type.String({
-    description:
-      `Method-discovery query. Use a namespace name (e.g. 'watchers') for a listing, a dotted path (e.g. 'watchers.create') for a drill-down, or a free-text term to substring-match across paths and summaries. Namespaces: ${NAMESPACES.join(", ")}.`,
-    minLength: 1,
-  }),
-  limit: Type.Optional(
-    Type.Number({
-      description: "Max matches to return. Default 20, max 100.",
-      minimum: 1,
-      maximum: 100,
-    }),
-  ),
+	query: Type.String({
+		description:
+			`Method-discovery query. Use a namespace (e.g. 'watchers'), a dotted path (e.g. 'watchers.create'), or free text. Pass mode='read' for query_sdk-safe methods only; omit mode for your full run_sdk tier. Namespaces: ${NAMESPACES.join(", ")}.`,
+		minLength: 1,
+	}),
+	mode: Type.Optional(
+		Type.Union(
+			[
+				Type.Literal("read", {
+					description: "Only methods callable via query_sdk (read access).",
+				}),
+				Type.Literal("full", {
+					description:
+						"Methods callable via run_sdk at your access tier (default).",
+				}),
+			],
+			{
+				description:
+					"Filter results to match query_sdk ('read') or run_sdk ('full', default).",
+			},
+		),
+	),
+	limit: Type.Optional(
+		Type.Number({
+			description: "Max matches to return. Default 20, max 100.",
+			minimum: 1,
+			maximum: 100,
+		}),
+	),
 });
 
 type SdkSearchArgs = Static<typeof SdkSearchSchema>;
 
-/**
- * Result of `search_sdk`. TypeBox is the single source of truth: the handler's
- * return type is derived from this via `Static<>`, and the same schema is handed
- * to the registry as the tool's `outputSchema` (so the listing, the result
- * shape, and the TS type can't drift).
- */
 export const SdkSearchResultSchema = Type.Object({
-  query: Type.String({ description: 'The query that was searched.' }),
-  match_count: Type.Integer({
-    description: 'Number of matches returned.',
-  }),
-  results: Type.Array(Type.String(), {
-    description: 'Rendered method-documentation strings, one per match.',
-  }),
-  notes: Type.Optional(
-    Type.String({
-      description: 'Free-text hints (e.g. ambiguity, suggestions) when relevant.',
-    })
-  ),
+	query: Type.String({ description: "The query that was searched." }),
+	match_count: Type.Integer({
+		description: "Number of matches returned.",
+	}),
+	results: Type.Array(Type.String(), {
+		description: "Rendered method-documentation strings, one per match.",
+	}),
+	notes: Type.Optional(
+		Type.String({
+			description: "Free-text hints (e.g. ambiguity, suggestions) when relevant.",
+		}),
+	),
 });
 
 export type SdkSearchResult = Static<typeof SdkSearchResultSchema>;
 
-interface MatchRow {
-  path: string;
-  summary: string;
-  access: MethodMetadata["access"];
+function catalogForCaller(
+	ctx: ToolContext,
+	mode: SdkDiscoveryMode,
+): Array<[string, MethodMetadata]> {
+	const callerMax = resolveMaxAccessLevel(ctx.memberRole, ctx.scopes);
+	return Object.entries(METHOD_METADATA).filter(([, meta]) =>
+		sdkMethodVisible(meta.access, callerMax, mode),
+	);
 }
 
-/**
- * Render a one-line method entry for namespace listings.
- */
+function hiddenMethodNote(
+	path: string,
+	meta: MethodMetadata,
+	mode: SdkDiscoveryMode,
+): string {
+	if (mode === "read" && meta.access !== "read") {
+		return `${path} exists but requires run_sdk (access: ${meta.access}). Retry with mode='full' or call via run_sdk.`;
+	}
+	if (meta.access === "admin") {
+		return `${path} requires workspace admin/owner + mcp:admin.`;
+	}
+	return `${path} is not available at your access tier (access: ${meta.access}).`;
+}
+
 function renderListLine(path: string, meta: MethodMetadata): string {
-  return `${path} — ${meta.summary}`;
+	return `${path} — ${meta.summary}`;
 }
 
-/**
- * Render a multi-line drill-down for a single method.
- */
 function renderDrillDown(path: string, meta: MethodMetadata): string {
-  const lines: string[] = [];
-  lines.push(path);
-  lines.push(`  ${meta.summary}`);
-  lines.push(`  access: ${meta.access}${meta.cost ? ` (cost: ${meta.cost})` : ""}`);
-  if (meta.throws && meta.throws.length > 0) {
-    lines.push(`  throws: ${meta.throws.join(", ")}`);
-  }
-  if (meta.example) {
-    lines.push(`  example: ${meta.example}`);
-  }
-  if (meta.usageExample) {
-    lines.push("  usage_example:");
-    for (const exampleLine of meta.usageExample.split("\n")) {
-      lines.push(`    ${exampleLine}`);
-    }
-  }
-  return lines.join("\n");
+	const lines: string[] = [];
+	lines.push(path);
+	lines.push(`  ${meta.summary}`);
+	lines.push(
+		`  access: ${meta.access}${meta.cost ? ` (cost: ${meta.cost})` : ""}`,
+	);
+	if (meta.throws && meta.throws.length > 0) {
+		lines.push(`  throws: ${meta.throws.join(", ")}`);
+	}
+	if (meta.example) {
+		lines.push(`  example: ${meta.example}`);
+	}
+	if (meta.usageExample) {
+		lines.push("  usage_example:");
+		for (const exampleLine of meta.usageExample.split("\n")) {
+			lines.push(`    ${exampleLine}`);
+		}
+	}
+	return lines.join("\n");
 }
 
 export const sdkSearch = withValidatedArgs("search_sdk", SdkSearchSchema, sdkSearchImpl);
 
 async function sdkSearchImpl(
-  args: SdkSearchArgs,
-  _env: Env,
-  _ctx: ToolContext,
+	args: SdkSearchArgs,
+	_env: Env,
+	ctx: ToolContext,
 ): Promise<SdkSearchResult> {
-  const limit = Math.min(args.limit ?? 20, 100);
-  const query = args.query.trim();
-  const lower = query.toLowerCase();
+	const limit = Math.min(args.limit ?? 20, 100);
+	const query = args.query.trim();
+	const lower = query.toLowerCase();
+	const mode: SdkDiscoveryMode = args.mode ?? "full";
+	const catalog = catalogForCaller(ctx, mode);
 
-  const all: Array<[string, MethodMetadata]> = Object.entries(METHOD_METADATA);
+	if (lower in METHOD_METADATA) {
+		const meta = METHOD_METADATA[lower];
+		const callerMax = resolveMaxAccessLevel(ctx.memberRole, ctx.scopes);
+		if (!sdkMethodVisible(meta.access, callerMax, mode)) {
+			return {
+				query,
+				match_count: 0,
+				results: [],
+				notes: hiddenMethodNote(lower, meta, mode),
+			};
+		}
+		return {
+			query,
+			match_count: 1,
+			results: [renderDrillDown(lower, meta)],
+		};
+	}
 
-  // Tier 1: exact path drill-down.
-  if (lower in METHOD_METADATA) {
-    const meta = METHOD_METADATA[lower];
-    return {
-      query,
-      match_count: 1,
-      results: [renderDrillDown(lower, meta)],
-    };
-  }
+	if (lower.indexOf(".") === -1) {
+		const prefix = `${lower}.`;
+		const ns = catalog.filter(([p]) => p.startsWith(prefix));
+		const topLevel = catalog.filter(([p]) => p === lower);
+		const combined = [...topLevel, ...ns];
+		if (combined.length > 0) {
+			return {
+				query,
+				match_count: combined.length,
+				results: combined
+					.slice(0, limit)
+					.map(([p, m]) => renderListLine(p, m)),
+				notes:
+					combined.length > limit
+						? `${combined.length - limit} more matches; raise \`limit\` or refine the query.`
+						: mode === "read"
+							? "Showing query_sdk-safe methods only. Pass mode='full' for write/admin methods."
+							: undefined,
+			};
+		}
+	}
 
-  // Tier 2: namespace prefix listing.
-  if (lower.indexOf(".") === -1) {
-    const prefix = `${lower}.`;
-    const ns = all.filter(([p]) => p.startsWith(prefix));
-    // Top-level methods (no dot) live as bare paths — match those too.
-    const topLevel = all.filter(([p]) => p === lower);
-    const combined = [...topLevel, ...ns];
-    if (combined.length > 0) {
-      return {
-        query,
-        match_count: combined.length,
-        results: combined
-          .slice(0, limit)
-          .map(([p, m]) => renderListLine(p, m)),
-        notes:
-          combined.length > limit
-            ? `${combined.length - limit} more matches; raise \`limit\` or refine the query.`
-            : undefined,
-      };
-    }
-  }
+	const seen = new Set<string>();
+	const matches: Array<[string, MethodMetadata]> = [];
+	for (const [path, meta] of catalog) {
+		if (path.toLowerCase().includes(lower) && !seen.has(path)) {
+			seen.add(path);
+			matches.push([path, meta]);
+		}
+	}
+	for (const [path, meta] of catalog) {
+		if (meta.summary.toLowerCase().includes(lower) && !seen.has(path)) {
+			seen.add(path);
+			matches.push([path, meta]);
+		}
+	}
 
-  // Tier 3: substring on path + summary.
-  const seen = new Set<string>();
-  const matches: MatchRow[] = [];
-  for (const [path, meta] of all) {
-    if (path.toLowerCase().includes(lower)) {
-      if (!seen.has(path)) {
-        seen.add(path);
-        matches.push({ path, summary: meta.summary, access: meta.access });
-      }
-    }
-  }
-  for (const [path, meta] of all) {
-    if (meta.summary.toLowerCase().includes(lower) && !seen.has(path)) {
-      seen.add(path);
-      matches.push({ path, summary: meta.summary, access: meta.access });
-    }
-  }
+	if (matches.length === 0) {
+		const existsButHidden =
+			lower in METHOD_METADATA
+				? hiddenMethodNote(lower, METHOD_METADATA[lower], mode)
+				: undefined;
+		return {
+			query,
+			match_count: 0,
+			results: [],
+			notes:
+				existsButHidden ??
+				`No matches at your access tier. Try a namespace (${NAMESPACES.join(", ")}), mode='read' for query_sdk, or a verb (create, list, search).`,
+		};
+	}
 
-  if (matches.length === 0) {
-    return {
-      query,
-      match_count: 0,
-      results: [],
-      notes: `No matches. Try a namespace (${NAMESPACES.join(", ")}) or a verb (create, list, search).`,
-    };
-  }
-
-  return {
-    query,
-    match_count: matches.length,
-    results: matches
-      .slice(0, limit)
-      .map((m) =>
-        renderListLine(m.path, {
-          summary: m.summary,
-          access: m.access,
-        } as MethodMetadata),
-      ),
-    notes:
-      matches.length > limit
-        ? `${matches.length - limit} more matches; raise \`limit\` or refine the query.`
-        : undefined,
-  };
+	return {
+		query,
+		match_count: matches.length,
+		results: matches
+			.slice(0, limit)
+			.map(([p, m]) => renderListLine(p, m)),
+		notes:
+			matches.length > limit
+				? `${matches.length - limit} more matches; raise \`limit\` or refine the query.`
+				: mode === "read"
+					? "Showing query_sdk-safe methods only. Pass mode='full' for write/admin methods."
+					: undefined,
+	};
 }

--- a/packages/server/src/utils/openapi-generator.ts
+++ b/packages/server/src/utils/openapi-generator.ts
@@ -4,7 +4,7 @@
  * Dynamically generates OpenAPI specification from tool registry TypeBox schemas
  */
 
-import { getAllTools } from '../tools/registry';
+import { getMcpTools } from '../tools/registry';
 
 /**
  * Recursively deep copies schema properties while filtering out hidden ones
@@ -166,7 +166,7 @@ function truncateDescription(text: string, maxLength: number = 300): string {
  * Generates OpenAPI 3.1.0 spec from tool registry
  */
 export function generateOpenAPISpec(serverUrl: string) {
-  const tools = getAllTools();
+  const tools = getMcpTools();
   const paths: Record<string, any> = {};
 
   for (const tool of tools) {

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -154,7 +154,7 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
     sections.push(
       '',
       '### Tool surface',
-      'External MCP tools: `search_memory`, `save_memory`, `list_organizations`, `search_sdk` (SDK method discovery), `query_sdk` (read-only TS over the typed client SDK), `query_sql` (admin/debug read-only SQL), `run_sdk` (full TS — destructive; supports `dry_run: true`).',
+      'External MCP tools: `search_memory`, `save_memory`, `search_sdk` (SDK discovery — pass mode=read for query_sdk methods), `query_sdk` (read-only TS), `query_sql` (paginated SQL for all members), `run_sdk` (full TS writes). Discover SDK methods with `search_sdk`, then call via `query_sdk` / `run_sdk`. Prefer `client.metrics.*` for governed metrics.',
       'For reads beyond search_memory, prefer `query_sdk` with a TS script. For writes (entity CRUD, watchers, classifiers, connections, feeds, view templates, operations), use `run_sdk`. Use `search_sdk` to discover method names.',
       '',
       '### Saving (do this automatically)',

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -679,14 +679,6 @@ function buildDispatchMessage(params: {
     .toISOString()
     .split('T')[0];
 
-  // The version snapshot taken at run-creation time pins this run to a
-  // specific watcher_template_versions row. Pass it to read_knowledge AND
-  // complete_window so a group edit landing mid-run can't make the agent
-  // extract with prompt v1 and have its output validated against schema v2.
-  const versionPin = params.payload.version_id != null
-    ? `, "template_version_id": ${params.payload.version_id}`
-    : '';
-
   return [
     'Run this watcher now using the lobu-memory MCP tools.',
     '',

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -702,9 +702,9 @@ function buildDispatchMessage(params: {
       : []),
     '',
     'Required steps:',
-    `1. Call read_knowledge with {"watcher_id": ${params.watcherId}, "since": "${readKnowledgeSince}", "until": "${readKnowledgeUntil}"${versionPin}}.`,
+    `1. Call query_sdk with a script that runs client.knowledge.read({ watcher_id: ${params.watcherId}, since: "${readKnowledgeSince}", until: "${readKnowledgeUntil}"${params.payload.version_id != null ? `, template_version_id: ${params.payload.version_id}` : ''} }).`,
     '2. Analyze the returned content using prompt_rendered and extraction_schema.',
-    `3. Call manage_watchers(action="complete_window") with the returned window_token, extracted_data, and "watcher_run_id": ${params.runId}${params.payload.version_id != null ? `, including "template_version_id": ${params.payload.version_id}` : ''}.`,
+    `3. Call run_sdk with a script that runs client.watchers.completeWindow({ window_token, extracted_data, watcher_run_id: ${params.runId}${params.payload.version_id != null ? `, template_version_id: ${params.payload.version_id}` : ''} }) using the window_token from step 1.`,
     '4. Include this run_metadata object in complete_window exactly, and add any extra provider/job fields you know:',
     JSON.stringify(
       {
@@ -813,7 +813,9 @@ async function ensureWatcherAgentExists(
 }
 
 const LOBU_MEMORY_MCP_ID = 'lobu-memory';
-const WATCHER_REQUIRED_TOOLS = ['read_knowledge', 'manage_watchers'];
+// Watcher agents reach knowledge reads + complete_window via query_sdk / run_sdk
+// now that flat admin tools are omitted from MCP tools/list.
+const WATCHER_REQUIRED_TOOLS = ['query_sdk', 'run_sdk'];
 
 async function preflightWatcherMemoryTools(params: {
   organizationId: string;

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -181,8 +181,8 @@ export async function resolveWatcherRunsByMessageIds(
         runId,
         'Agent reply finished without calling manage_watchers(action="complete_window")' +
           (budget > 0 ? ` after ${budget + 1} attempt(s)` : '') +
-          '. Check that the assigned agent has the lobu-memory MCP attached and that read_knowledge / ' +
-          'manage_watchers tools are approved for it.'
+          '. Check that the assigned agent has the lobu-memory MCP attached and that query_sdk / ' +
+          'run_sdk tools are approved for it.'
       );
       resolved++;
       continue;


### PR DESCRIPTION
## Summary

- Slim MCP `tools/list` to six agent-facing tools: `search_memory`, `save_memory`, `search_sdk`, `query_sdk`, `query_sql`, `run_sdk`
- Keep admin flat tools (`manage_*`, orgs, metrics, `resolve_path`, etc.) dispatchable via REST/CLI/`tools/call` but hidden from the advertised list
- Add `client.agents.*`, `client.schedules.*`, and `client.metrics.*` SDK namespaces so everything remains reachable via `query_sdk` / `run_sdk`
- Align `client.query` with member-safe `query_sql` scoping (same column allowlist / restricted tables)
- Filter `search_sdk` and sandbox manifests by caller access tier via shared `sdkMethodVisible` — agents only discover methods they can actually invoke
- Update workspace instructions and OpenClaw plugin to match the six-tool surface

## Agent discovery flow

```
search_memory  → memory hot path
search_sdk     → SDK method docs (mode=read for query_sdk tier)
query_sdk      → read-only TS + client.query + client.metrics.*
query_sql      → paginated SQL / feeds / connections (all members)
run_sdk        → writes + admin namespaces
```

## Test plan

- [x] `tool-registry-split.test.ts` — 6 MCP tools, SDK parity mappings
- [x] `sdk-method-access.test.ts` — visibility rules
- [x] `sdk-search.test.ts` — caller-aware filtering
- [x] `method-metadata.test.ts` — metadata/runtime parity
- [x] `manifest-contracts.test.ts` — OpenClaw 6 tools
- [x] `namespace-dispatch.test.ts` — agents/schedules/metrics/query
- [x] MCP auth tests — tool list shape
- [ ] `execute-wire.test.ts` — requires isolated-vm (skipped in this env)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785802347&installation_id=136316292&pr_number=1733&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1733&signature=e33be69c970a6118cdfbe626e258d456c12aa48f5be522c618878b56276759ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SDK namespaces for agents, schedules, and metrics.
  * SDK method discovery now respects access tiers, and OpenAPI generation reflects the agent-facing tool set.
* **Bug Fixes**
  * Tool listing and permissions are aligned: some admin tools remain callable even when not listed.
  * Watcher completion/error guidance updated for the current required SDK tools.
* **Documentation**
  * Updated tool-surface instructions and tool descriptions for search, SQL query, and SDK run.
* **Tests**
  * Expanded/adjusted MCP sandbox and auth integration coverage for the new tool visibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->