### PR TITLE
fix(watchers): align device CLI completion with query_sdk/run_sdk

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -7,34 +7,34 @@
  * a running queued run.
  */
 
-import { randomUUID } from 'node:crypto';
-import { inferWatcherGranularityFromSchedule } from '@lobu/connector-sdk';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { ApiResponseRenderer } from '../../../gateway/api/response-renderer';
-import { UnifiedThreadResponseConsumer } from '../../../gateway/platform/unified-thread-consumer';
-import type { DbClient } from '../../../db/client';
-import { getDb } from '../../../db/client';
-import type { Env } from '../../../index';
-import { generateWindowToken } from '../../../utils/jwt';
-import { createWatcherRun } from '../../../runs/queue-service';
-import { computePendingWindow } from '../../../utils/window-utils';
+import { randomUUID } from "node:crypto";
+import { inferWatcherGranularityFromSchedule } from "@lobu/connector-sdk";
+import { beforeEach, describe, expect, it } from "vitest";
+import { generateSecureToken, hashToken } from "../../../auth/oauth/utils";
+import type { DbClient } from "../../../db/client";
+import { getDb } from "../../../db/client";
+import { ApiResponseRenderer } from "../../../gateway/api/response-renderer";
+import { UnifiedThreadResponseConsumer } from "../../../gateway/platform/unified-thread-consumer";
+import type { Env } from "../../../index";
+import { createWatcherRun } from "../../../runs/queue-service";
+import { generateWindowToken } from "../../../utils/jwt";
+import { computePendingWindow } from "../../../utils/window-utils";
 import {
-  dispatchPendingWatcherRuns,
-  materializeDueWatcherRuns,
-  reconcileWatcherRuns,
-  runWatcherAutomationTick,
-  sweepStaleWatcherRuns,
-} from '../../../watchers/automation';
-import { generateSecureToken, hashToken } from '../../../auth/oauth/utils';
-import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+	dispatchPendingWatcherRuns,
+	materializeDueWatcherRuns,
+	reconcileWatcherRuns,
+	runWatcherAutomationTick,
+	sweepStaleWatcherRuns,
+} from "../../../watchers/automation";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
-  createCanvasWindow,
-  createTestAgent,
-  createTestEntity,
-  createTestEvent,
-} from '../../setup/test-fixtures';
-import { post } from '../../setup/test-helpers';
-import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
+	createCanvasWindow,
+	createTestAgent,
+	createTestEntity,
+	createTestEvent,
+} from "../../setup/test-fixtures";
+import { post } from "../../setup/test-helpers";
+import { TestApiClient, TestWorkspace } from "../../setup/test-mcp-client";
 
 /**
  * Mint a PAT bound to a specific device worker_id and `device_worker:run`
@@ -42,16 +42,16 @@ import { TestApiClient, TestWorkspace } from '../../setup/test-mcp-client';
  * can pre-set the binding without going through the route.
  */
 async function createWorkerBoundPat(
-  userId: string,
-  organizationId: string,
-  workerId: string,
-  scope = 'device_worker:run'
+	userId: string,
+	organizationId: string,
+	workerId: string,
+	scope = "device_worker:run",
 ): Promise<{ token: string }> {
-  const sql = getTestDb();
-  const token = `owl_pat_${generateSecureToken(24)}`;
-  const tokenHash = hashToken(token);
-  const tokenPrefix = token.substring(0, 12);
-  await sql`
+	const sql = getTestDb();
+	const token = `owl_pat_${generateSecureToken(24)}`;
+	const tokenHash = hashToken(token);
+	const tokenPrefix = token.substring(0, 12);
+	await sql`
     INSERT INTO personal_access_tokens (
       token_hash, token_prefix, user_id, organization_id, name, scope, worker_id,
       created_at, updated_at
@@ -61,425 +61,471 @@ async function createWorkerBoundPat(
       NOW(), NOW()
     )
   `;
-  return { token };
+	return { token };
 }
 
 async function createAutomatedWatcher() {
-  const sql = getTestDb();
-  const dbClient = sql as unknown as DbClient;
-  const workspace = await TestWorkspace.create({ name: 'Watcher Automation Contract Org' });
+	const sql = getTestDb();
+	const dbClient = sql as unknown as DbClient;
+	const workspace = await TestWorkspace.create({
+		name: "Watcher Automation Contract Org",
+	});
 
-  const entity = await createTestEntity({
-    name: 'Automation Entity',
-    organization_id: workspace.org.id,
-    created_by: workspace.users.owner.id,
-  });
+	const entity = await createTestEntity({
+		name: "Automation Entity",
+		organization_id: workspace.org.id,
+		created_by: workspace.users.owner.id,
+	});
 
-  const agent = await createTestAgent({
-    organizationId: workspace.org.id,
-    ownerUserId: workspace.users.owner.id,
-    agentId: 'watcher-agent',
-    name: 'Watcher Agent',
-  });
+	const agent = await createTestAgent({
+		organizationId: workspace.org.id,
+		ownerUserId: workspace.users.owner.id,
+		agentId: "watcher-agent",
+		name: "Watcher Agent",
+	});
 
-  const watcher = (await workspace.owner.watchers.create({
-    entity_id: entity.id,
-    slug: 'automation-watcher',
-    name: 'Automation Watcher',
-    prompt: 'Summarize content for {{entities}}.',
-    schedule: '0 9 * * *',
-    agent_id: agent.agentId,
-  })) as { watcher_id: string };
-  const watcherId = Number(watcher.watcher_id);
+	const watcher = (await workspace.owner.watchers.create({
+		entity_id: entity.id,
+		slug: "automation-watcher",
+		name: "Automation Watcher",
+		prompt: "Summarize content for {{entities}}.",
+		schedule: "0 9 * * *",
+		agent_id: agent.agentId,
+	})) as { watcher_id: string };
+	const watcherId = Number(watcher.watcher_id);
 
-  await sql`
+	await sql`
     UPDATE watchers
     SET next_run_at = NOW() - INTERVAL '10 minutes'
     WHERE id = ${watcherId}
   `;
 
-  const api = await TestApiClient.for({
-    organizationId: workspace.org.id,
-    userId: workspace.users.owner.id,
-    memberRole: 'owner',
-  });
+	const api = await TestApiClient.for({
+		organizationId: workspace.org.id,
+		userId: workspace.users.owner.id,
+		memberRole: "owner",
+	});
 
-  return { sql, dbClient, workspace, api, entityId: entity.id, agent, watcherId };
+	return {
+		sql,
+		dbClient,
+		workspace,
+		api,
+		entityId: entity.id,
+		agent,
+		watcherId,
+	};
 }
 
-describe('watcher automation contract', () => {
-  beforeEach(async () => {
-    await cleanupTestDatabase();
-  });
+describe("watcher automation contract", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+	});
 
-  it('materializes one scheduled watcher run and dedupes concurrent ticks', async () => {
-    const { sql, watcherId, agent, workspace } = await createAutomatedWatcher();
+	it("materializes one scheduled watcher run and dedupes concurrent ticks", async () => {
+		const { sql, watcherId, agent, workspace } = await createAutomatedWatcher();
 
-    const [resultA, resultB] = await Promise.all([
-      materializeDueWatcherRuns({} as Env),
-      materializeDueWatcherRuns({} as Env),
-    ]);
+		const [resultA, resultB] = await Promise.all([
+			materializeDueWatcherRuns({} as Env),
+			materializeDueWatcherRuns({} as Env),
+		]);
 
-    expect(resultA.runsCreated + resultB.runsCreated).toBe(1);
+		expect(resultA.runsCreated + resultB.runsCreated).toBe(1);
 
-    const runs = await sql`
+		const runs = await sql`
       SELECT status, approved_input
       FROM runs
       WHERE watcher_id = ${watcherId}
         AND run_type = 'watcher'
         AND organization_id = ${workspace.org.id}
     `;
-    expect(runs).toHaveLength(1);
-    expect(String(runs[0].status)).toBe('pending');
+		expect(runs).toHaveLength(1);
+		expect(String(runs[0].status)).toBe("pending");
 
-    const payload = runs[0].approved_input as Record<string, unknown>;
-    expect(Number(payload.watcher_id)).toBe(watcherId);
-    expect(payload.agent_id).toBe(agent.agentId);
-    expect(payload.dispatch_source).toBe('scheduled');
-  });
+		const payload = runs[0].approved_input as Record<string, unknown>;
+		expect(Number(payload.watcher_id)).toBe(watcherId);
+		expect(payload.agent_id).toBe(agent.agentId);
+		expect(payload.dispatch_source).toBe("scheduled");
+	});
 
-  it('reconciles a queued watcher run when a correlated window already exists', async () => {
-    const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
+	it("reconciles a queued watcher run when a correlated window already exists", async () => {
+		const { sql, dbClient, workspace, watcherId, agent } =
+			await createAutomatedWatcher();
 
-    const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-    const { windowStart, windowEnd } = await computePendingWindow(dbClient, watcherId, granularity);
-    const queued = await createWatcherRun({
-      organizationId: workspace.org.id,
-      watcherId,
-      agentId: agent.agentId,
-      windowStart: windowStart.toISOString(),
-      windowEnd: windowEnd.toISOString(),
-      dispatchSource: 'scheduled',
-    });
+		const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+		const { windowStart, windowEnd } = await computePendingWindow(
+			dbClient,
+			watcherId,
+			granularity,
+		);
+		const queued = await createWatcherRun({
+			organizationId: workspace.org.id,
+			watcherId,
+			agentId: agent.agentId,
+			windowStart: windowStart.toISOString(),
+			windowEnd: windowEnd.toISOString(),
+			dispatchSource: "scheduled",
+		});
 
-    // Canvas-on-events: the correlated window is a canvas_state chain root
-    // stamped with this run_id — what the reconciler joins runs to.
-    const windowRootId = await createCanvasWindow({
-      watcherId,
-      organizationId: workspace.org.id,
-      granularity: 'daily',
-      windowStart,
-      windowEnd,
-      extractedData: { summary: 'External completion' },
-      contentAnalyzed: 1,
-      runId: queued.runId,
-      modelUsed: 'external-client',
-      runMetadata: { source: 'external', watcher_run_id: queued.runId },
-    });
+		// Canvas-on-events: the correlated window is a canvas_state chain root
+		// stamped with this run_id — what the reconciler joins runs to.
+		const windowRootId = await createCanvasWindow({
+			watcherId,
+			organizationId: workspace.org.id,
+			granularity: "daily",
+			windowStart,
+			windowEnd,
+			extractedData: { summary: "External completion" },
+			contentAnalyzed: 1,
+			runId: queued.runId,
+			modelUsed: "external-client",
+			runMetadata: { source: "external", watcher_run_id: queued.runId },
+		});
 
-    const result = await dispatchPendingWatcherRuns({} as Env, {
-      db: dbClient,
-      runIds: [queued.runId],
-    });
-    const [run] = await sql`
+		const result = await dispatchPendingWatcherRuns({} as Env, {
+			db: dbClient,
+			runIds: [queued.runId],
+		});
+		const [run] = await sql`
       SELECT status, window_id
       FROM runs
       WHERE id = ${queued.runId}
     `;
 
-    expect(result.reconciled).toBe(1);
-    expect(String(run.status)).toBe('completed');
-    expect(Number(run.window_id)).toBe(windowRootId);
-  });
+		expect(result.reconciled).toBe(1);
+		expect(String(run.status)).toBe("completed");
+		expect(Number(run.window_id)).toBe(windowRootId);
+	});
 
-  it('completes a queued watcher run from complete_window provenance', async () => {
-    const { sql, dbClient, workspace, api, entityId, watcherId, agent } = await createAutomatedWatcher();
+	it("completes a queued watcher run from complete_window provenance", async () => {
+		const { sql, dbClient, workspace, api, entityId, watcherId, agent } =
+			await createAutomatedWatcher();
 
-    await createTestEvent({
-      entity_id: entityId,
-      organization_id: workspace.org.id,
-      content: 'Customer feedback that should be summarized.',
-      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
-    });
+		await createTestEvent({
+			entity_id: entityId,
+			organization_id: workspace.org.id,
+			content: "Customer feedback that should be summarized.",
+			occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+		});
 
-    const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-    const { windowStart, windowEnd } = await computePendingWindow(dbClient, watcherId, granularity);
-    const queued = await createWatcherRun({
-      organizationId: workspace.org.id,
-      watcherId,
-      agentId: agent.agentId,
-      windowStart: windowStart.toISOString(),
-      windowEnd: windowEnd.toISOString(),
-      dispatchSource: 'scheduled',
-    });
+		const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+		const { windowStart, windowEnd } = await computePendingWindow(
+			dbClient,
+			watcherId,
+			granularity,
+		);
+		const queued = await createWatcherRun({
+			organizationId: workspace.org.id,
+			watcherId,
+			agentId: agent.agentId,
+			windowStart: windowStart.toISOString(),
+			windowEnd: windowEnd.toISOString(),
+			dispatchSource: "scheduled",
+		});
 
-    await sql`
+		await sql`
       UPDATE runs
       SET status = 'running', claimed_at = NOW(), claimed_by = ${`lobu:${agent.agentId}`}
       WHERE id = ${queued.runId}
     `;
 
-    const content = (await api.knowledge.read({ watcher_id: watcherId })) as {
-      window_token: string;
-      window_start: string;
-      window_end: string;
-    };
-    expect(content.window_start).toBe(windowStart.toISOString());
-    expect(content.window_end).toBe(windowEnd.toISOString());
+		const content = (await api.knowledge.read({ watcher_id: watcherId })) as {
+			window_token: string;
+			window_start: string;
+			window_end: string;
+		};
+		expect(content.window_start).toBe(windowStart.toISOString());
+		expect(content.window_end).toBe(windowEnd.toISOString());
 
-    const completion = (await api.watchers.completeWindow({
-      watcher_id: String(watcherId),
-      window_token: content.window_token,
-      extracted_data: { summary: 'Automated watcher summary' },
-      run_metadata: {
-        executor: 'lobu-agent',
-        agent_id: agent.agentId,
-        watcher_run_id: queued.runId,
-        dispatch_source: 'scheduled',
-      },
-    })) as { action: string; window_id: number };
+		const completion = (await api.watchers.completeWindow({
+			watcher_id: String(watcherId),
+			window_token: content.window_token,
+			extracted_data: { summary: "Automated watcher summary" },
+			run_metadata: {
+				executor: "lobu-agent",
+				agent_id: agent.agentId,
+				watcher_run_id: queued.runId,
+				dispatch_source: "scheduled",
+			},
+		})) as { action: string; window_id: number };
 
-    const [run] = await sql`
+		const [run] = await sql`
       SELECT status, window_id
       FROM runs
       WHERE id = ${queued.runId}
     `;
 
-    expect(completion.action).toBe('complete_window');
-    expect(String(run.status)).toBe('completed');
-    expect(Number(run.window_id)).toBe(completion.window_id);
-  });
+		expect(completion.action).toBe("complete_window");
+		expect(String(run.status)).toBe("completed");
+		expect(Number(run.window_id)).toBe(completion.window_id);
+	});
 
-  it('skips watcher runs pinned to a device worker (#802)', async () => {
-    const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
+	it("skips watcher runs pinned to a device worker (#802)", async () => {
+		const { sql, dbClient, workspace, watcherId, agent } =
+			await createAutomatedWatcher();
 
-    const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-    const { windowStart, windowEnd } = await computePendingWindow(dbClient, watcherId, granularity);
-    const queued = await createWatcherRun({
-      organizationId: workspace.org.id,
-      watcherId,
-      agentId: agent.agentId,
-      windowStart: windowStart.toISOString(),
-      windowEnd: windowEnd.toISOString(),
-      dispatchSource: 'scheduled',
-    });
+		const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+		const { windowStart, windowEnd } = await computePendingWindow(
+			dbClient,
+			watcherId,
+			granularity,
+		);
+		const queued = await createWatcherRun({
+			organizationId: workspace.org.id,
+			watcherId,
+			agentId: agent.agentId,
+			windowStart: windowStart.toISOString(),
+			windowEnd: windowEnd.toISOString(),
+			dispatchSource: "scheduled",
+		});
 
-    // Pin the run to a device worker — the dispatcher in #798 will set this
-    // when the watcher is bound to a Mac/CLI device. Until that lands the
-    // server-side claim path must already refuse to grab the row.
-    await sql`
+		// Pin the run to a device worker — the dispatcher in #798 will set this
+		// when the watcher is bound to a Mac/CLI device. Until that lands the
+		// server-side claim path must already refuse to grab the row.
+		await sql`
       UPDATE runs
-      SET approved_input = approved_input || ${sql.json({ device_worker_id: 'mac-device-abc' })}
+      SET approved_input = approved_input || ${sql.json({ device_worker_id: "mac-device-abc" })}
       WHERE id = ${queued.runId}
     `;
 
-    const result = await dispatchPendingWatcherRuns({} as Env, { db: dbClient });
+		const result = await dispatchPendingWatcherRuns({} as Env, {
+			db: dbClient,
+		});
 
-    expect(result.claimed).toBe(0);
-    expect(result.dispatched).toBe(0);
+		expect(result.claimed).toBe(0);
+		expect(result.dispatched).toBe(0);
 
-    const [run] = await sql`
+		const [run] = await sql`
       SELECT status, claimed_by, claimed_at
       FROM runs
       WHERE id = ${queued.runId}
     `;
-    expect(String(run.status)).toBe('pending');
-    expect(run.claimed_by).toBeNull();
-    expect(run.claimed_at).toBeNull();
+		expect(String(run.status)).toBe("pending");
+		expect(run.claimed_by).toBeNull();
+		expect(run.claimed_at).toBeNull();
 
-    // Explicit runIds path must also refuse to claim — the dispatcher's
-    // queueAndDispatchWatcherRun helper hits this branch when a watcher run
-    // is manually triggered.
-    const targeted = await dispatchPendingWatcherRuns({} as Env, {
-      db: dbClient,
-      runIds: [queued.runId],
-    });
-    expect(targeted.claimed).toBe(0);
+		// Explicit runIds path must also refuse to claim — the dispatcher's
+		// queueAndDispatchWatcherRun helper hits this branch when a watcher run
+		// is manually triggered.
+		const targeted = await dispatchPendingWatcherRuns({} as Env, {
+			db: dbClient,
+			runIds: [queued.runId],
+		});
+		expect(targeted.claimed).toBe(0);
 
-    const [stillPending] = await sql`
+		const [stillPending] = await sql`
       SELECT status FROM runs WHERE id = ${queued.runId}
     `;
-    expect(String(stillPending.status)).toBe('pending');
-  });
+		expect(String(stillPending.status)).toBe("pending");
+	});
 
-  it('paginates watcher reads by cursor and completes from multiple page tokens', async () => {
-    const { sql, workspace, api, entityId, watcherId } = await createAutomatedWatcher();
+	it("paginates watcher reads by cursor and completes from multiple page tokens", async () => {
+		const { sql, workspace, api, entityId, watcherId } =
+			await createAutomatedWatcher();
 
-    const base = Date.UTC(2026, 0, 2, 12, 0, 0);
-    const events = [];
-    for (let i = 0; i < 5; i++) {
-      events.push(
-        await createTestEvent({
-          entity_id: entityId,
-          organization_id: workspace.org.id,
-          title: `Paginated event ${i}`,
-          content: `Paginated watcher content ${i}`,
-          occurred_at: new Date(base - i * 60_000),
-        })
-      );
-    }
+		const base = Date.UTC(2026, 0, 2, 12, 0, 0);
+		const events = [];
+		for (let i = 0; i < 5; i++) {
+			events.push(
+				await createTestEvent({
+					entity_id: entityId,
+					organization_id: workspace.org.id,
+					title: `Paginated event ${i}`,
+					content: `Paginated watcher content ${i}`,
+					occurred_at: new Date(base - i * 60_000),
+				}),
+			);
+		}
 
-    const page1 = (await api.knowledge.read({
-      watcher_id: watcherId,
-      since: '2026-01-02',
-      until: '2026-01-02',
-      limit: 2,
-    })) as {
-      content: Array<{ id: number; occurred_at: string }>;
-      window_token: string;
-      page: { has_more: boolean; next_cursor?: { occurred_at: string; id: number } };
-    };
+		const page1 = (await api.knowledge.read({
+			watcher_id: watcherId,
+			since: "2026-01-02",
+			until: "2026-01-02",
+			limit: 2,
+		})) as {
+			content: Array<{ id: number; occurred_at: string }>;
+			window_token: string;
+			page: {
+				has_more: boolean;
+				next_cursor?: { occurred_at: string; id: number };
+			};
+		};
 
-    expect(page1.content.map((item) => item.id)).toEqual([events[0].id, events[1].id]);
-    expect(page1.page.has_more).toBe(true);
-    expect(page1.page.next_cursor).toBeDefined();
+		expect(page1.content.map((item) => item.id)).toEqual([
+			events[0].id,
+			events[1].id,
+		]);
+		expect(page1.page.has_more).toBe(true);
+		expect(page1.page.next_cursor).toBeDefined();
 
-    const page2 = (await api.knowledge.read({
-      watcher_id: watcherId,
-      since: '2026-01-02',
-      until: '2026-01-02',
-      limit: 2,
-      before_occurred_at: page1.page.next_cursor!.occurred_at,
-      before_id: page1.page.next_cursor!.id,
-    })) as {
-      content: Array<{ id: number }>;
-      window_token: string;
-      page: { has_more: boolean; next_cursor?: { occurred_at: string; id: number } };
-    };
+		const page2 = (await api.knowledge.read({
+			watcher_id: watcherId,
+			since: "2026-01-02",
+			until: "2026-01-02",
+			limit: 2,
+			before_occurred_at: page1.page.next_cursor!.occurred_at,
+			before_id: page1.page.next_cursor!.id,
+		})) as {
+			content: Array<{ id: number }>;
+			window_token: string;
+			page: {
+				has_more: boolean;
+				next_cursor?: { occurred_at: string; id: number };
+			};
+		};
 
-    expect(page2.content.map((item) => item.id)).toEqual([events[2].id, events[3].id]);
-    expect(page2.page.has_more).toBe(true);
+		expect(page2.content.map((item) => item.id)).toEqual([
+			events[2].id,
+			events[3].id,
+		]);
+		expect(page2.page.has_more).toBe(true);
 
-    const completion = (await api.watchers.completeWindow({
-      watcher_id: String(watcherId),
-      window_tokens: [page1.window_token, page2.window_token],
-      extracted_data: { summary: 'Summary across two pages' },
-    })) as { action: string; window_id: number; content_linked: number };
+		const completion = (await api.watchers.completeWindow({
+			watcher_id: String(watcherId),
+			window_tokens: [page1.window_token, page2.window_token],
+			extracted_data: { summary: "Summary across two pages" },
+		})) as { action: string; window_id: number; content_linked: number };
 
-    const links = await sql`
+		const links = await sql`
       SELECT event_id
       FROM watcher_window_events
       WHERE window_id = ${completion.window_id}
       ORDER BY event_id
     `;
 
-    expect(completion.action).toBe('complete_window');
-    expect(completion.content_linked).toBe(4);
-    expect(links.map((row) => Number(row.event_id)).sort((a, b) => a - b)).toEqual(
-      [events[0].id, events[1].id, events[2].id, events[3].id].sort((a, b) => a - b)
-    );
-  });
+		expect(completion.action).toBe("complete_window");
+		expect(completion.content_linked).toBe(4);
+		expect(
+			links.map((row) => Number(row.event_id)).sort((a, b) => a - b),
+		).toEqual(
+			[events[0].id, events[1].id, events[2].id, events[3].id].sort(
+				(a, b) => a - b,
+			),
+		);
+	});
 
-  it('links the exact signed content IDs without re-running watcher sources', async () => {
-    const { sql, workspace, api, entityId, watcherId } = await createAutomatedWatcher();
+	it("links the exact signed content IDs without re-running watcher sources", async () => {
+		const { sql, workspace, api, entityId, watcherId } =
+			await createAutomatedWatcher();
 
-    const event = await createTestEvent({
-      entity_id: entityId,
-      organization_id: workspace.org.id,
-      content: 'Content returned to the watcher worker.',
-      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
-    });
-    const windowStart = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
-    const windowEnd = new Date().toISOString();
+		const event = await createTestEvent({
+			entity_id: entityId,
+			organization_id: workspace.org.id,
+			content: "Content returned to the watcher worker.",
+			occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+		});
+		const windowStart = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+		const windowEnd = new Date().toISOString();
 
-    const windowToken = await generateWindowToken(
-      {
-        watcher_id: watcherId,
-        window_start: windowStart,
-        window_end: windowEnd,
-        granularity: 'daily',
-        content_count: 1,
-        content_ids: [event.id],
-      },
-      { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env
-    );
+		const windowToken = await generateWindowToken(
+			{
+				watcher_id: watcherId,
+				window_start: windowStart,
+				window_end: windowEnd,
+				granularity: "daily",
+				content_count: 1,
+				content_ids: [event.id],
+			},
+			{ JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env,
+		);
 
-    const completion = (await api.watchers.completeWindow({
-      watcher_id: String(watcherId),
-      window_token: windowToken,
-      extracted_data: { summary: 'Summary from exact content IDs' },
-    })) as { action: string; window_id: number; content_linked: number };
+		const completion = (await api.watchers.completeWindow({
+			watcher_id: String(watcherId),
+			window_token: windowToken,
+			extracted_data: { summary: "Summary from exact content IDs" },
+		})) as { action: string; window_id: number; content_linked: number };
 
-    // Canvas-on-events: window_id is the canvas ROOT event id; content_analyzed
-    // lives in the chain member's metadata. Content links are keyed to the root
-    // event id (re-keyed window_id).
-    const [window] = await sql`
+		// Canvas-on-events: window_id is the canvas ROOT event id; content_analyzed
+		// lives in the chain member's metadata. Content links are keyed to the root
+		// event id (re-keyed window_id).
+		const [window] = await sql`
       SELECT (metadata->>'content_analyzed')::int AS content_analyzed
       FROM events
       WHERE id = ${completion.window_id}
         AND semantic_type = 'canvas_state'
     `;
-    const links = await sql`
+		const links = await sql`
       SELECT event_id
       FROM watcher_window_events
       WHERE window_id = ${completion.window_id}
     `;
 
-    expect(completion.action).toBe('complete_window');
-    expect(completion.content_linked).toBe(1);
-    expect(Number(window.content_analyzed)).toBe(1);
-    expect(links.map((row) => Number(row.event_id))).toEqual([event.id]);
-  });
+		expect(completion.action).toBe("complete_window");
+		expect(completion.content_linked).toBe(1);
+		expect(Number(window.content_analyzed)).toBe(1);
+		expect(links.map((row) => Number(row.event_id))).toEqual([event.id]);
+	});
 
-  // #798 — device-pinned watcher execution end-to-end:
-  //
-  //   watcher.device_worker_id set
-  //     → materializeDueWatcherRuns persists the pin into approved_input
-  //     → server-side dispatcher refuses to claim (#802 covers this; checked
-  //       above by the "skips watcher runs pinned to a device worker" test)
-  //     → device posts to /api/workers/me/runs/:id/complete-watcher
-  //         which writes the watcher_windows row + advances last_fired_at.
-  describe('device-pinned execution (#798)', () => {
-    it('persists watchers.device_worker_id and agent_kind into approved_input on materialization', async () => {
-      const { sql, watcherId } = await createAutomatedWatcher();
+	// #798 — device-pinned watcher execution end-to-end:
+	//
+	//   watcher.device_worker_id set
+	//     → materializeDueWatcherRuns persists the pin into approved_input
+	//     → server-side dispatcher refuses to claim (#802 covers this; checked
+	//       above by the "skips watcher runs pinned to a device worker" test)
+	//     → device posts to /api/workers/me/runs/:id/complete-watcher
+	//         which writes the watcher_windows row + advances last_fired_at.
+	describe("device-pinned execution (#798)", () => {
+		it("persists watchers.device_worker_id and agent_kind into approved_input on materialization", async () => {
+			const { sql, watcherId } = await createAutomatedWatcher();
 
-      // Register a device worker to anchor the foreign key.
-      const [device] = await sql`
+			// Register a device worker to anchor the foreign key.
+			const [device] = await sql`
         INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label)
         VALUES ('user-watcher-pin', 'device-pin-1', 'macos', ${sql.json({})}, 'My Mac')
         RETURNING id
       `;
-      const deviceWorkerId = String((device as { id: unknown }).id);
+			const deviceWorkerId = String((device as { id: unknown }).id);
 
-      await sql`
+			await sql`
         UPDATE watchers
         SET device_worker_id = ${deviceWorkerId}::uuid,
             agent_kind = 'claude-code'
         WHERE id = ${watcherId}
       `;
 
-      const result = await materializeDueWatcherRuns({} as Env);
-      expect(result.runsCreated).toBe(1);
+			const result = await materializeDueWatcherRuns({} as Env);
+			expect(result.runsCreated).toBe(1);
 
-      const [run] = await sql`
+			const [run] = await sql`
         SELECT approved_input
         FROM runs
         WHERE watcher_id = ${watcherId}
           AND run_type = 'watcher'
       `;
-      const payload = run.approved_input as Record<string, unknown>;
-      expect(payload.device_worker_id).toBe(deviceWorkerId);
-      expect(payload.agent_kind).toBe('claude-code');
-    });
+			const payload = run.approved_input as Record<string, unknown>;
+			expect(payload.device_worker_id).toBe(deviceWorkerId);
+			expect(payload.agent_kind).toBe("claude-code");
+		});
 
-    // The device contract: the CLI agent completes the run itself over MCP
-    // (read_knowledge → complete_window) — the same pipeline as server-side
-    // watcher agents. The dispatcher's POST is only an exit report that
-    // stamps device provenance on the already-completed run.
-    it('exit report acks an MCP-completed run and stamps device provenance', async () => {
-      const { sql, dbClient, workspace, api, watcherId, agent } = await createAutomatedWatcher();
-      const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-      const { windowStart, windowEnd } = await computePendingWindow(
-        dbClient,
-        watcherId,
-        granularity
-      );
+		// The device contract: the CLI agent completes the run itself over MCP
+		// (query_sdk → completeWindow) — the same pipeline as server-side
+		// watcher agents. The dispatcher's POST is only an exit report that
+		// stamps device provenance on the already-completed run.
+		it("exit report acks an MCP-completed run and stamps device provenance", async () => {
+			const { sql, dbClient, workspace, api, watcherId, agent } =
+				await createAutomatedWatcher();
+			const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity,
+			);
 
-      const queued = await createWatcherRun({
-        organizationId: workspace.org.id,
-        watcherId,
-        agentId: agent.agentId,
-        windowStart: windowStart.toISOString(),
-        windowEnd: windowEnd.toISOString(),
-        dispatchSource: 'scheduled',
-        deviceWorkerId: '11111111-1111-1111-1111-111111111111',
-        agentKind: 'claude-code',
-      });
+			const queued = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+				deviceWorkerId: "11111111-1111-1111-1111-111111111111",
+				agentKind: "claude-code",
+			});
 
-      // Move the run into `running` claimed by a specific worker — the device
-      // path normally claims via /api/workers/poll; we shortcut here.
-      const workerId = 'mac-device-cli-test';
-      await sql`
+			// Move the run into `running` claimed by a specific worker — the device
+			// path normally claims via /api/workers/poll; we shortcut here.
+			const workerId = "mac-device-cli-test";
+			await sql`
         UPDATE runs
         SET status = 'running',
             claimed_at = NOW(),
@@ -487,367 +533,414 @@ describe('watcher automation contract', () => {
         WHERE id = ${queued.runId}
       `;
 
-      // The spawned CLI agent completes over MCP, exactly like a server
-      // agent: read_knowledge → window_token → complete_window.
-      const content = (await api.knowledge.read({ watcher_id: watcherId })) as {
-        window_token: string;
-      };
-      const completion = (await api.watchers.completeWindow({
-        watcher_id: String(watcherId),
-        window_token: content.window_token,
-        extracted_data: { summary: 'Looked at 5 events, no anomalies.' },
-        model: 'device-cli:claude-code',
-        run_metadata: {
-          source: 'device_worker',
-          agent_kind: 'claude-code',
-          watcher_run_id: queued.runId,
-        },
-      })) as { window_id: number };
+			// The spawned CLI agent completes over MCP, exactly like a server
+			// agent: query_sdk → window_token → run_sdk (completeWindow).
+			const content = (await api.knowledge.read({ watcher_id: watcherId })) as {
+				window_token: string;
+			};
+			const completion = (await api.watchers.completeWindow({
+				watcher_id: String(watcherId),
+				window_token: content.window_token,
+				extracted_data: { summary: "Looked at 5 events, no anomalies." },
+				model: "device-cli:claude-code",
+				run_metadata: {
+					source: "device_worker",
+					agent_kind: "claude-code",
+					watcher_run_id: queued.runId,
+				},
+			})) as { window_id: number };
 
-      // The subprocess exits; the dispatcher posts the exit report.
-      const response = await post(
-        `/api/workers/me/runs/${queued.runId}/complete-watcher`,
-        {
-          body: {
-            worker_id: workerId,
-            output: 'Done — completed via complete_window.',
-            duration_ms: 1234,
-            exit_code: 0,
-            exit_reason: 'ok',
-          },
-        }
-      );
-      expect(response.status).toBe(200);
-      const json = (await response.json()) as { ok: boolean; status: string; window_id?: number };
-      expect(json.ok).toBe(true);
-      expect(json.status).toBe('completed');
-      expect(Number(json.window_id)).toBe(completion.window_id);
+			// The subprocess exits; the dispatcher posts the exit report.
+			const response = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-watcher`,
+				{
+					body: {
+						worker_id: workerId,
+						output: "Done — completed via complete_window.",
+						duration_ms: 1234,
+						exit_code: 0,
+						exit_reason: "ok",
+					},
+				},
+			);
+			expect(response.status).toBe(200);
+			const json = (await response.json()) as {
+				ok: boolean;
+				status: string;
+				window_id?: number;
+			};
+			expect(json.ok).toBe(true);
+			expect(json.status).toBe("completed");
+			expect(Number(json.window_id)).toBe(completion.window_id);
 
-      const [run] = await sql`
+			const [run] = await sql`
         SELECT status, completed_at, window_id, exit_code, exit_reason
         FROM runs
         WHERE id = ${queued.runId}
       `;
-      expect(String(run.status)).toBe('completed');
-      expect(run.completed_at).not.toBeNull();
-      expect(Number(run.window_id)).toBe(completion.window_id);
-      expect(Number(run.exit_code)).toBe(0);
-      expect(String(run.exit_reason)).toBe('ok');
+			expect(String(run.status)).toBe("completed");
+			expect(run.completed_at).not.toBeNull();
+			expect(Number(run.window_id)).toBe(completion.window_id);
+			expect(Number(run.exit_code)).toBe(0);
+			expect(String(run.exit_reason)).toBe("ok");
 
-      // Canvas-on-events: extracted_data lives on the chain HEAD event
-      // (window_id = canvas root id); provenance (model_used + execution time)
-      // now lives on the RUN row, stamped by the exit report.
-      const [window] = await sql`
+			// Canvas-on-events: extracted_data lives on the chain HEAD event
+			// (window_id = canvas root id); provenance (model_used + execution time)
+			// now lives on the RUN row, stamped by the exit report.
+			const [window] = await sql`
         SELECT payload_data AS extracted_data
         FROM events
         WHERE id = ${run.window_id}
           AND semantic_type = 'canvas_state'
       `;
-      const [runProvenance] = await sql`
+			const [runProvenance] = await sql`
         SELECT model_used, (run_metadata->>'execution_time_ms')::int AS execution_time_ms
         FROM runs
         WHERE id = ${queued.runId}
       `;
-      expect(window.extracted_data as Record<string, unknown>).toEqual({
-        summary: 'Looked at 5 events, no anomalies.',
-      });
-      expect(Number(runProvenance.execution_time_ms)).toBe(1234);
-      expect(String(runProvenance.model_used)).toBe('device-cli:claude-code');
+			expect(window.extracted_data as Record<string, unknown>).toEqual({
+				summary: "Looked at 5 events, no anomalies.",
+			});
+			expect(Number(runProvenance.execution_time_ms)).toBe(1234);
+			expect(String(runProvenance.model_used)).toBe("device-cli:claude-code");
 
-      const [watcher] = await sql`
+			const [watcher] = await sql`
         SELECT last_fired_at
         FROM watchers
         WHERE id = ${watcherId}
       `;
-      expect(watcher.last_fired_at).not.toBeNull();
+			expect(watcher.last_fired_at).not.toBeNull();
 
-      // A duplicate exit report acks idempotently without re-stamping.
-      const dup = await post(`/api/workers/me/runs/${queued.runId}/complete-watcher`, {
-        body: { worker_id: workerId, output: 'dup', duration_ms: 9, exit_code: 0 },
-      });
-      expect(dup.status).toBe(200);
-      const dupJson = (await dup.json()) as { status: string; idempotent?: boolean };
-      expect(dupJson.status).toBe('completed');
-      expect(dupJson.idempotent).toBe(true);
-      const [runAfterDup] = await sql`
+			// A duplicate exit report acks idempotently without re-stamping.
+			const dup = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-watcher`,
+				{
+					body: {
+						worker_id: workerId,
+						output: "dup",
+						duration_ms: 9,
+						exit_code: 0,
+					},
+				},
+			);
+			expect(dup.status).toBe(200);
+			const dupJson = (await dup.json()) as {
+				status: string;
+				idempotent?: boolean;
+			};
+			expect(dupJson.status).toBe("completed");
+			expect(dupJson.idempotent).toBe(true);
+			const [runAfterDup] = await sql`
         SELECT (run_metadata->>'execution_time_ms')::int AS execution_time_ms
         FROM runs WHERE id = ${queued.runId}
       `;
-      expect(Number(runAfterDup.execution_time_ms)).toBe(1234);
-    });
+			expect(Number(runAfterDup.execution_time_ms)).toBe(1234);
+		});
 
-    it('exit report without duration_ms preserves run_metadata (jsonb_set strictness)', async () => {
-      // jsonb_set is STRICT: stamping execution_time_ms with a NULL duration
-      // (device report omits duration_ms, none recorded) must NOT null out the
-      // run_metadata that complete_window already wrote.
-      const { sql, dbClient, workspace, api, watcherId, agent } = await createAutomatedWatcher();
-      const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-      const { windowStart, windowEnd } = await computePendingWindow(
-        dbClient,
-        watcherId,
-        granularity
-      );
-      const queued = await createWatcherRun({
-        organizationId: workspace.org.id,
-        watcherId,
-        agentId: agent.agentId,
-        windowStart: windowStart.toISOString(),
-        windowEnd: windowEnd.toISOString(),
-        dispatchSource: 'scheduled',
-        deviceWorkerId: '11111111-1111-1111-1111-111111111111',
-        agentKind: 'claude-code',
-      });
-      const workerId = 'mac-device-cli-test-nodur';
-      await sql`
+		it("exit report without duration_ms preserves run_metadata (jsonb_set strictness)", async () => {
+			// jsonb_set is STRICT: stamping execution_time_ms with a NULL duration
+			// (device report omits duration_ms, none recorded) must NOT null out the
+			// run_metadata that complete_window already wrote.
+			const { sql, dbClient, workspace, api, watcherId, agent } =
+				await createAutomatedWatcher();
+			const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity,
+			);
+			const queued = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+				deviceWorkerId: "11111111-1111-1111-1111-111111111111",
+				agentKind: "claude-code",
+			});
+			const workerId = "mac-device-cli-test-nodur";
+			await sql`
         UPDATE runs
         SET status = 'running', claimed_at = NOW(), claimed_by = ${workerId}
         WHERE id = ${queued.runId}
       `;
-      const content = (await api.knowledge.read({ watcher_id: watcherId })) as {
-        window_token: string;
-      };
-      await api.watchers.completeWindow({
-        watcher_id: String(watcherId),
-        window_token: content.window_token,
-        extracted_data: { summary: 'No-duration exit report case.' },
-        run_metadata: {
-          source: 'device_worker',
-          agent_kind: 'claude-code',
-          watcher_run_id: queued.runId,
-        },
-      });
+			const content = (await api.knowledge.read({ watcher_id: watcherId })) as {
+				window_token: string;
+			};
+			await api.watchers.completeWindow({
+				watcher_id: String(watcherId),
+				window_token: content.window_token,
+				extracted_data: { summary: "No-duration exit report case." },
+				run_metadata: {
+					source: "device_worker",
+					agent_kind: "claude-code",
+					watcher_run_id: queued.runId,
+				},
+			});
 
-      // Exit report with NO duration_ms.
-      const response = await post(`/api/workers/me/runs/${queued.runId}/complete-watcher`, {
-        body: { worker_id: workerId, output: 'done', exit_code: 0, exit_reason: 'ok' },
-      });
-      expect(response.status).toBe(200);
+			// Exit report with NO duration_ms.
+			const response = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-watcher`,
+				{
+					body: {
+						worker_id: workerId,
+						output: "done",
+						exit_code: 0,
+						exit_reason: "ok",
+					},
+				},
+			);
+			expect(response.status).toBe(200);
 
-      const [run] = await sql`
+			const [run] = await sql`
         SELECT run_metadata, model_used FROM runs WHERE id = ${queued.runId}
       `;
-      const meta = run.run_metadata as Record<string, unknown> | null;
-      expect(meta).not.toBeNull();
-      expect(meta?.source).toBe('device_worker');
-      expect(meta?.agent_kind).toBe('claude-code');
-      expect(String(run.model_used)).toBe('device-cli:claude-code');
-    });
+			const meta = run.run_metadata as Record<string, unknown> | null;
+			expect(meta).not.toBeNull();
+			expect(meta?.source).toBe("device_worker");
+			expect(meta?.agent_kind).toBe("claude-code");
+			expect(String(run.model_used)).toBe("device-cli:claude-code");
+		});
 
-    // Content-less windows (device runs fetch their own context; nothing is
-    // linked server-side) still fire the reaction script — the signal is the
-    // extracted_data itself. The reaction log is surfaced on the window via
-    // get_watcher so the UI can show what the script did.
-    it('fires the reaction script for a content-less window and surfaces the log', async () => {
-      const { sql, dbClient, workspace, api, watcherId, agent } = await createAutomatedWatcher();
-      await api.watchers.setReactionScript({
-        watcher_id: String(watcherId),
-        reaction_script: 'export default async function reaction() { return; }',
-      });
+		// Content-less windows (device runs fetch their own context; nothing is
+		// linked server-side) still fire the reaction script — the signal is the
+		// extracted_data itself. The reaction log is surfaced on the window via
+		// get_watcher so the UI can show what the script did.
+		it("fires the reaction script for a content-less window and surfaces the log", async () => {
+			const { sql, dbClient, workspace, api, watcherId, agent } =
+				await createAutomatedWatcher();
+			await api.watchers.setReactionScript({
+				watcher_id: String(watcherId),
+				reaction_script: "export default async function reaction() { return; }",
+			});
 
-      const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-      const { windowStart, windowEnd } = await computePendingWindow(
-        dbClient,
-        watcherId,
-        granularity
-      );
-      const queued = await createWatcherRun({
-        organizationId: workspace.org.id,
-        watcherId,
-        agentId: agent.agentId,
-        windowStart: windowStart.toISOString(),
-        windowEnd: windowEnd.toISOString(),
-        dispatchSource: 'scheduled',
-        deviceWorkerId: '88888888-8888-8888-8888-888888888888',
-        agentKind: 'claude-code',
-      });
-      await sql`
+			const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity,
+			);
+			const queued = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+				deviceWorkerId: "88888888-8888-8888-8888-888888888888",
+				agentKind: "claude-code",
+			});
+			await sql`
         UPDATE runs
         SET status = 'running', claimed_at = NOW(), claimed_by = 'mac-device-reaction-test'
         WHERE id = ${queued.runId}
       `;
 
-      const content = (await api.knowledge.read({ watcher_id: watcherId })) as {
-        window_token: string;
-      };
-      const completion = (await api.watchers.completeWindow({
-        watcher_id: String(watcherId),
-        window_token: content.window_token,
-        extracted_data: { summary: 'Device-run result, no server content.' },
-        run_metadata: { source: 'device_worker', watcher_run_id: queued.runId },
-      })) as { window_id: number; content_linked: number; reaction_status: string };
+			const content = (await api.knowledge.read({ watcher_id: watcherId })) as {
+				window_token: string;
+			};
+			const completion = (await api.watchers.completeWindow({
+				watcher_id: String(watcherId),
+				window_token: content.window_token,
+				extracted_data: { summary: "Device-run result, no server content." },
+				run_metadata: { source: "device_worker", watcher_run_id: queued.runId },
+			})) as {
+				window_id: number;
+				content_linked: number;
+				reaction_status: string;
+			};
 
-      // Zero content linked, yet the reaction FIRED (window_created gate).
-      // This test pins the gate + the log surface, not the sandbox itself:
-      // runtimes without an isolated-vm build report 'failed' (the sandbox
-      // suite covers executor health), so assert "attempted", never
-      // 'skipped' — the pre-fix behavior this test exists to prevent.
-      expect(completion.content_linked).toBe(0);
-      expect(completion.reaction_status).not.toBe('skipped');
+			// Zero content linked, yet the reaction FIRED (window_created gate).
+			// This test pins the gate + the log surface, not the sandbox itself:
+			// runtimes without an isolated-vm build report 'failed' (the sandbox
+			// suite covers executor health), so assert "attempted", never
+			// 'skipped' — the pre-fix behavior this test exists to prevent.
+			expect(completion.content_linked).toBe(0);
+			expect(completion.reaction_status).not.toBe("skipped");
 
-      const reactionRows = await sql`
+			const reactionRows = await sql`
         SELECT reaction_type, tool_name FROM watcher_reactions
         WHERE window_id = ${completion.window_id}
       `;
-      expect(reactionRows.length).toBeGreaterThan(0);
-      expect(String(reactionRows[0].reaction_type)).toBe('script_execution');
+			expect(reactionRows.length).toBeGreaterThan(0);
+			expect(String(reactionRows[0].reaction_type)).toBe("script_execution");
 
-      // The window surfaces its reaction log through get_watcher.
-      const detail = (await api.watchers.get(String(watcherId))) as {
-        windows: Array<{ window_id: number; reactions?: Array<{ tool_name: string }> }>;
-      };
-      const window = detail.windows.find((w) => w.window_id === completion.window_id);
-      expect(window).toBeDefined();
-      expect(window?.reactions?.length ?? 0).toBeGreaterThan(0);
-      expect(window?.reactions?.[0].tool_name).toBe('reaction_executor');
-    });
+			// The window surfaces its reaction log through get_watcher.
+			const detail = (await api.watchers.get(String(watcherId))) as {
+				windows: Array<{
+					window_id: number;
+					reactions?: Array<{ tool_name: string }>;
+				}>;
+			};
+			const window = detail.windows.find(
+				(w) => w.window_id === completion.window_id,
+			);
+			expect(window).toBeDefined();
+			expect(window?.reactions?.length ?? 0).toBeGreaterThan(0);
+			expect(window?.reactions?.[0].tool_name).toBe("reaction_executor");
+		});
 
-    // Canvas-on-events: replace_existing supersedes the head instead of
-    // deleting+recreating the window row, so window_created is false — the
-    // head_superseded gate must fire reactions for a zero-content replace
-    // (legacy parity: the recreate set window_created=true and reactions ran).
-    it('fires the reaction script on a zero-content replace_existing (head_superseded gate)', async () => {
-      const { api, watcherId } = await createAutomatedWatcher();
-      await api.watchers.setReactionScript({
-        watcher_id: String(watcherId),
-        reaction_script: 'export default async function reaction() { return; }',
-      });
-      const windowStart = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
-      const windowEnd = new Date().toISOString();
-      const env = { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env;
-      const mint = () =>
-        generateWindowToken(
-          {
-            watcher_id: watcherId,
-            window_start: windowStart,
-            window_end: windowEnd,
-            granularity: 'daily',
-            content_count: 0,
-            content_ids: [],
-          },
-          env
-        );
+		// Canvas-on-events: replace_existing supersedes the head instead of
+		// deleting+recreating the window row, so window_created is false — the
+		// head_superseded gate must fire reactions for a zero-content replace
+		// (legacy parity: the recreate set window_created=true and reactions ran).
+		it("fires the reaction script on a zero-content replace_existing (head_superseded gate)", async () => {
+			const { api, watcherId } = await createAutomatedWatcher();
+			await api.watchers.setReactionScript({
+				watcher_id: String(watcherId),
+				reaction_script: "export default async function reaction() { return; }",
+			});
+			const windowStart = new Date(
+				Date.now() - 2 * 60 * 60 * 1000,
+			).toISOString();
+			const windowEnd = new Date().toISOString();
+			const env = { JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env;
+			const mint = () =>
+				generateWindowToken(
+					{
+						watcher_id: watcherId,
+						window_start: windowStart,
+						window_end: windowEnd,
+						granularity: "daily",
+						content_count: 0,
+						content_ids: [],
+					},
+					env,
+				);
 
-      const first = (await api.watchers.completeWindow({
-        watcher_id: String(watcherId),
-        window_token: await mint(),
-        extracted_data: { summary: 'v1' },
-      })) as { window_id: number };
+			const first = (await api.watchers.completeWindow({
+				watcher_id: String(watcherId),
+				window_token: await mint(),
+				extracted_data: { summary: "v1" },
+			})) as { window_id: number };
 
-      const replaced = (await api.watchers.completeWindow({
-        watcher_id: String(watcherId),
-        window_token: await mint(),
-        extracted_data: { summary: 'v2 re-analysis' },
-        replace_existing: true,
-      })) as {
-        window_id: number;
-        window_created: boolean;
-        head_superseded: boolean;
-        content_linked: number;
-        reaction_status: string;
-      };
+			const replaced = (await api.watchers.completeWindow({
+				watcher_id: String(watcherId),
+				window_token: await mint(),
+				extracted_data: { summary: "v2 re-analysis" },
+				replace_existing: true,
+			})) as {
+				window_id: number;
+				window_created: boolean;
+				head_superseded: boolean;
+				content_linked: number;
+				reaction_status: string;
+			};
 
-      // Same root identity, no new window, no content — yet the canvas CHANGED,
-      // so the reaction must be attempted (never 'skipped'; 'failed' is fine on
-      // runtimes without an isolated-vm build, as in the content-less test).
-      expect(replaced.window_id).toBe(first.window_id);
-      expect(replaced.window_created).toBe(false);
-      expect(replaced.head_superseded).toBe(true);
-      expect(replaced.content_linked).toBe(0);
-      expect(replaced.reaction_status).not.toBe('skipped');
-    });
+			// Same root identity, no new window, no content — yet the canvas CHANGED,
+			// so the reaction must be attempted (never 'skipped'; 'failed' is fine on
+			// runtimes without an isolated-vm build, as in the content-less test).
+			expect(replaced.window_id).toBe(first.window_id);
+			expect(replaced.window_created).toBe(false);
+			expect(replaced.head_superseded).toBe(true);
+			expect(replaced.content_linked).toBe(0);
+			expect(replaced.reaction_status).not.toBe("skipped");
+		});
 
-    // Fail closed: the agent exiting cleanly WITHOUT calling complete_window
-    // means no real work was recorded — the run must fail (and the schedule
-    // advance), mirroring the server-side dispatch guard. This is exactly
-    // the failure mode that masked the broken Reddit watcher for a week.
-    it('fails the run when the agent exits without calling complete_window', async () => {
-      const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
-      const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-      const { windowStart, windowEnd } = await computePendingWindow(
-        dbClient,
-        watcherId,
-        granularity
-      );
-      const queued = await createWatcherRun({
-        organizationId: workspace.org.id,
-        watcherId,
-        agentId: agent.agentId,
-        windowStart: windowStart.toISOString(),
-        windowEnd: windowEnd.toISOString(),
-        dispatchSource: 'scheduled',
-        deviceWorkerId: '55555555-5555-5555-5555-555555555555',
-        agentKind: 'claude-code',
-      });
-      const workerId = 'mac-device-nocomplete-test';
-      await sql`
+		// Fail closed: the agent exiting cleanly WITHOUT calling complete_window
+		// means no real work was recorded — the run must fail (and the schedule
+		// advance), mirroring the server-side dispatch guard. This is exactly
+		// the failure mode that masked the broken Reddit watcher for a week.
+		it("fails the run when the agent exits without calling complete_window", async () => {
+			const { sql, dbClient, workspace, watcherId, agent } =
+				await createAutomatedWatcher();
+			const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity,
+			);
+			const queued = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+				deviceWorkerId: "55555555-5555-5555-5555-555555555555",
+				agentKind: "claude-code",
+			});
+			const workerId = "mac-device-nocomplete-test";
+			await sql`
         UPDATE runs
         SET status = 'running', claimed_at = NOW(), claimed_by = ${workerId}
         WHERE id = ${queued.runId}
       `;
 
-      const [before] = await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
-      const beforeNextRun = before.next_run_at as Date | string | null;
+			const [before] =
+				await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
+			const beforeNextRun = before.next_run_at as Date | string | null;
 
-      const response = await post(
-        `/api/workers/me/runs/${queued.runId}/complete-watcher`,
-        {
-          body: {
-            worker_id: workerId,
-            output: 'I looked at everything and it seems fine, nothing to report.',
-            duration_ms: 50,
-            exit_code: 0,
-            exit_reason: 'ok',
-          },
-        }
-      );
-      expect(response.status).toBe(200);
-      const json = (await response.json()) as { ok: boolean; status: string; error?: string };
-      expect(json.status).toBe('failed');
-      expect(String(json.error)).toMatch(/complete_window/);
+			const response = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-watcher`,
+				{
+					body: {
+						worker_id: workerId,
+						output:
+							"I looked at everything and it seems fine, nothing to report.",
+						duration_ms: 50,
+						exit_code: 0,
+						exit_reason: "ok",
+					},
+				},
+			);
+			expect(response.status).toBe(200);
+			const json = (await response.json()) as {
+				ok: boolean;
+				status: string;
+				error?: string;
+			};
+			expect(json.status).toBe("failed");
+			expect(String(json.error)).toMatch(/completeWindow/);
 
-      const [run] = await sql`
+			const [run] = await sql`
         SELECT status, error_message, window_id, output_tail FROM runs WHERE id = ${queued.runId}
       `;
-      expect(String(run.status)).toBe('failed');
-      expect(String(run.error_message)).toMatch(/complete_window/);
-      expect(run.window_id).toBeNull();
-      // The stdout tail is stashed for diagnosis.
-      expect(String(run.output_tail)).toContain('nothing to report');
+			expect(String(run.status)).toBe("failed");
+			expect(String(run.error_message)).toMatch(/completeWindow/);
+			expect(run.window_id).toBeNull();
+			// The stdout tail is stashed for diagnosis.
+			expect(String(run.output_tail)).toContain("nothing to report");
 
-      const windows = await sql`
+			const windows = await sql`
         SELECT id FROM events WHERE run_id = ${queued.runId} AND semantic_type = 'canvas_state'
       `;
-      expect(windows).toHaveLength(0);
+			expect(windows).toHaveLength(0);
 
-      // Schedule must still advance so the watcher doesn't re-fire forever.
-      const [after] = await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
-      const beforeMs = beforeNextRun ? new Date(beforeNextRun).getTime() : 0;
-      const afterMs = after.next_run_at ? new Date(after.next_run_at as string).getTime() : 0;
-      expect(afterMs).toBeGreaterThan(beforeMs);
-    });
+			// Schedule must still advance so the watcher doesn't re-fire forever.
+			const [after] =
+				await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
+			const beforeMs = beforeNextRun ? new Date(beforeNextRun).getTime() : 0;
+			const afterMs = after.next_run_at
+				? new Date(after.next_run_at as string).getTime()
+				: 0;
+			expect(afterMs).toBeGreaterThan(beforeMs);
+		});
 
-    it('complete-watcher endpoint marks the run failed when error is supplied', async () => {
-      const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
-      const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-      const { windowStart, windowEnd } = await computePendingWindow(
-        dbClient,
-        watcherId,
-        granularity
-      );
+		it("complete-watcher endpoint marks the run failed when error is supplied", async () => {
+			const { sql, dbClient, workspace, watcherId, agent } =
+				await createAutomatedWatcher();
+			const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity,
+			);
 
-      const queued = await createWatcherRun({
-        organizationId: workspace.org.id,
-        watcherId,
-        agentId: agent.agentId,
-        windowStart: windowStart.toISOString(),
-        windowEnd: windowEnd.toISOString(),
-        dispatchSource: 'scheduled',
-        deviceWorkerId: '11111111-1111-1111-1111-111111111111',
-        agentKind: 'claude-code',
-      });
+			const queued = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+				deviceWorkerId: "11111111-1111-1111-1111-111111111111",
+				agentKind: "claude-code",
+			});
 
-      const workerId = 'mac-device-cli-fail';
-      await sql`
+			const workerId = "mac-device-cli-fail";
+			await sql`
         UPDATE runs
         SET status = 'running',
             claimed_at = NOW(),
@@ -855,389 +948,424 @@ describe('watcher automation contract', () => {
         WHERE id = ${queued.runId}
       `;
 
-      const response = await post(
-        `/api/workers/me/runs/${queued.runId}/complete-watcher`,
-        {
-          body: {
-            worker_id: workerId,
-            error: 'claude binary not found',
-            duration_ms: 12,
-            exit_reason: 'crash',
-            exit_code: 127,
-          },
-        }
-      );
-      expect(response.status).toBe(200);
-      const json = (await response.json()) as { ok: boolean; status: string };
-      expect(json.status).toBe('failed');
+			const response = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-watcher`,
+				{
+					body: {
+						worker_id: workerId,
+						error: "claude binary not found",
+						duration_ms: 12,
+						exit_reason: "crash",
+						exit_code: 127,
+					},
+				},
+			);
+			expect(response.status).toBe(200);
+			const json = (await response.json()) as { ok: boolean; status: string };
+			expect(json.status).toBe("failed");
 
-      const [run] = await sql`
+			const [run] = await sql`
         SELECT status, error_message, window_id, exit_code, exit_reason
         FROM runs
         WHERE id = ${queued.runId}
       `;
-      expect(String(run.status)).toBe('failed');
-      expect(String(run.error_message)).toBe('claude binary not found');
-      // No watcher_windows row on failure.
-      expect(run.window_id).toBeNull();
-      expect(Number(run.exit_code)).toBe(127);
-      expect(String(run.exit_reason)).toBe('crash');
+			expect(String(run.status)).toBe("failed");
+			expect(String(run.error_message)).toBe("claude binary not found");
+			// No watcher_windows row on failure.
+			expect(run.window_id).toBeNull();
+			expect(Number(run.exit_code)).toBe(127);
+			expect(String(run.exit_reason)).toBe("crash");
 
-      const windows = await sql`
+			const windows = await sql`
         SELECT id FROM events WHERE run_id = ${queued.runId} AND semantic_type = 'canvas_state'
       `;
-      expect(windows).toHaveLength(0);
-    });
+			expect(windows).toHaveLength(0);
+		});
 
-    it('complete-watcher endpoint refuses non-watcher run types', async () => {
-      const sql = getTestDb();
-      const { workspace } = await createAutomatedWatcher();
+		it("complete-watcher endpoint refuses non-watcher run types", async () => {
+			const sql = getTestDb();
+			const { workspace } = await createAutomatedWatcher();
 
-      const [authRun] = await sql`
+			const [authRun] = await sql`
         INSERT INTO runs (organization_id, run_type, approval_status, status, created_at)
         VALUES (${workspace.org.id}, 'sync', 'auto', 'running', current_timestamp)
         RETURNING id
       `;
-      const runId = Number((authRun as { id: unknown }).id);
+			const runId = Number((authRun as { id: unknown }).id);
 
-      const response = await post(
-        `/api/workers/me/runs/${runId}/complete-watcher`,
-        {
-          body: { worker_id: 'any', output: '', duration_ms: 1 },
-        }
-      );
-      expect(response.status).toBe(409);
-      const body = (await response.json()) as { error: string };
-      expect(body.error).toMatch(/watcher/i);
-    });
+			const response = await post(
+				`/api/workers/me/runs/${runId}/complete-watcher`,
+				{
+					body: { worker_id: "any", output: "", duration_ms: 1 },
+				},
+			);
+			expect(response.status).toBe(409);
+			const body = (await response.json()) as { error: string };
+			expect(body.error).toMatch(/watcher/i);
+		});
 
-    it('complete-watcher endpoint returns 404 for an unknown run id', async () => {
-      const response = await post(
-        '/api/workers/me/runs/999999999/complete-watcher',
-        {
-          body: { worker_id: 'any', output: '', duration_ms: 1 },
-        }
-      );
-      expect(response.status).toBe(404);
-    });
+		it("complete-watcher endpoint returns 404 for an unknown run id", async () => {
+			const response = await post(
+				"/api/workers/me/runs/999999999/complete-watcher",
+				{
+					body: { worker_id: "any", output: "", duration_ms: 1 },
+				},
+			);
+			expect(response.status).toBe(404);
+		});
 
-    // Pi review #1: schedule must advance on every terminal exit report or
-    // the scheduler re-fires the watcher every tick forever. This run never
-    // calls complete_window, so the report fails it — next_run_at must
-    // still move.
-    it('advances watchers.next_run_at on a terminal exit report', async () => {
-      const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
-      const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-      const { windowStart, windowEnd } = await computePendingWindow(
-        dbClient,
-        watcherId,
-        granularity
-      );
+		// Pi review #1: schedule must advance on every terminal exit report or
+		// the scheduler re-fires the watcher every tick forever. This run never
+		// calls complete_window, so the report fails it — next_run_at must
+		// still move.
+		it("advances watchers.next_run_at on a terminal exit report", async () => {
+			const { sql, dbClient, workspace, watcherId, agent } =
+				await createAutomatedWatcher();
+			const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity,
+			);
 
-      const [before] = await sql`
+			const [before] = await sql`
         SELECT next_run_at FROM watchers WHERE id = ${watcherId}
       `;
-      const beforeNextRun = before.next_run_at as Date | string | null;
+			const beforeNextRun = before.next_run_at as Date | string | null;
 
-      const queued = await createWatcherRun({
-        organizationId: workspace.org.id,
-        watcherId,
-        agentId: agent.agentId,
-        windowStart: windowStart.toISOString(),
-        windowEnd: windowEnd.toISOString(),
-        dispatchSource: 'scheduled',
-        deviceWorkerId: '22222222-2222-2222-2222-222222222222',
-        agentKind: 'claude-code',
-      });
+			const queued = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+				deviceWorkerId: "22222222-2222-2222-2222-222222222222",
+				agentKind: "claude-code",
+			});
 
-      const workerId = 'mac-device-advance-test';
-      await sql`
+			const workerId = "mac-device-advance-test";
+			await sql`
         UPDATE runs
         SET status = 'running', claimed_at = NOW(), claimed_by = ${workerId}
         WHERE id = ${queued.runId}
       `;
 
-      const response = await post(
-        `/api/workers/me/runs/${queued.runId}/complete-watcher`,
-        {
-          body: { worker_id: workerId, output: 'agent exited without completing', duration_ms: 5 },
-        }
-      );
-      expect(response.status).toBe(200);
+			const response = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-watcher`,
+				{
+					body: {
+						worker_id: workerId,
+						output: "agent exited without completing",
+						duration_ms: 5,
+					},
+				},
+			);
+			expect(response.status).toBe(200);
 
-      const [after] = await sql`
+			const [after] = await sql`
         SELECT next_run_at FROM watchers WHERE id = ${watcherId}
       `;
-      const afterNextRun = after.next_run_at as Date | string | null;
-      expect(afterNextRun).not.toBeNull();
-      // The cron is `0 9 * * *` (daily 9am); the new tick must be strictly in
-      // the future relative to the pre-completion value (which was forced
-      // 10min in the past by createAutomatedWatcher).
-      const beforeMs = beforeNextRun ? new Date(beforeNextRun).getTime() : 0;
-      const afterMs = new Date(afterNextRun as string | Date).getTime();
-      expect(afterMs).toBeGreaterThan(beforeMs);
-      // And strictly in the future relative to "now".
-      expect(afterMs).toBeGreaterThan(Date.now() - 1000);
-    });
+			const afterNextRun = after.next_run_at as Date | string | null;
+			expect(afterNextRun).not.toBeNull();
+			// The cron is `0 9 * * *` (daily 9am); the new tick must be strictly in
+			// the future relative to the pre-completion value (which was forced
+			// 10min in the past by createAutomatedWatcher).
+			const beforeMs = beforeNextRun ? new Date(beforeNextRun).getTime() : 0;
+			const afterMs = new Date(afterNextRun as string | Date).getTime();
+			expect(afterMs).toBeGreaterThan(beforeMs);
+			// And strictly in the future relative to "now".
+			expect(afterMs).toBeGreaterThan(Date.now() - 1000);
+		});
 
-    // Pi review #3: a second concurrent completion must be idempotent — no
-    // duplicate watcher_windows row, no 500, status reflects the winner.
-    // Duplicate exit reports on a FAILED run must be idempotent: the second
-    // report acks without re-failing or double-advancing the schedule
-    // (failRun's RETURNING guard).
-    it('treats a duplicate exit report as idempotent (no double schedule advance)', async () => {
-      const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
-      const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-      const { windowStart, windowEnd } = await computePendingWindow(
-        dbClient,
-        watcherId,
-        granularity
-      );
+		// Pi review #3: a second concurrent completion must be idempotent — no
+		// duplicate watcher_windows row, no 500, status reflects the winner.
+		// Duplicate exit reports on a FAILED run must be idempotent: the second
+		// report acks without re-failing or double-advancing the schedule
+		// (failRun's RETURNING guard).
+		it("treats a duplicate exit report as idempotent (no double schedule advance)", async () => {
+			const { sql, dbClient, workspace, watcherId, agent } =
+				await createAutomatedWatcher();
+			const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity,
+			);
 
-      const queued = await createWatcherRun({
-        organizationId: workspace.org.id,
-        watcherId,
-        agentId: agent.agentId,
-        windowStart: windowStart.toISOString(),
-        windowEnd: windowEnd.toISOString(),
-        dispatchSource: 'scheduled',
-        deviceWorkerId: '33333333-3333-3333-3333-333333333333',
-        agentKind: 'claude-code',
-      });
+			const queued = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+				deviceWorkerId: "33333333-3333-3333-3333-333333333333",
+				agentKind: "claude-code",
+			});
 
-      const workerId = 'mac-device-idem-test';
-      await sql`
+			const workerId = "mac-device-idem-test";
+			await sql`
         UPDATE runs
         SET status = 'running', claimed_at = NOW(), claimed_by = ${workerId}
         WHERE id = ${queued.runId}
       `;
 
-      // First report fails the run (no complete_window happened).
-      const first = await post(`/api/workers/me/runs/${queued.runId}/complete-watcher`, {
-        body: { worker_id: workerId, output: 'first exit', duration_ms: 11 },
-      });
-      expect(first.status).toBe(200);
-      expect(((await first.json()) as { status: string }).status).toBe('failed');
+			// First report fails the run (no complete_window happened).
+			const first = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-watcher`,
+				{
+					body: { worker_id: workerId, output: "first exit", duration_ms: 11 },
+				},
+			);
+			expect(first.status).toBe(200);
+			expect(((await first.json()) as { status: string }).status).toBe(
+				"failed",
+			);
 
-      const [afterFirst] = await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
-      const advancedOnce = new Date(afterFirst.next_run_at as string).getTime();
+			const [afterFirst] =
+				await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
+			const advancedOnce = new Date(afterFirst.next_run_at as string).getTime();
 
-      // Second report acks the terminal state; no extra side effects.
-      const second = await post(`/api/workers/me/runs/${queued.runId}/complete-watcher`, {
-        body: { worker_id: workerId, output: 'second exit', duration_ms: 12 },
-      });
-      expect(second.status).toBe(200);
-      const secondJson = (await second.json()) as { status: string; idempotent?: boolean };
-      expect(secondJson.status).toBe('failed');
-      expect(secondJson.idempotent).toBe(true);
+			// Second report acks the terminal state; no extra side effects.
+			const second = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-watcher`,
+				{
+					body: { worker_id: workerId, output: "second exit", duration_ms: 12 },
+				},
+			);
+			expect(second.status).toBe(200);
+			const secondJson = (await second.json()) as {
+				status: string;
+				idempotent?: boolean;
+			};
+			expect(secondJson.status).toBe("failed");
+			expect(secondJson.idempotent).toBe(true);
 
-      const [afterSecond] = await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
-      expect(new Date(afterSecond.next_run_at as string).getTime()).toBe(advancedOnce);
+			const [afterSecond] =
+				await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
+			expect(new Date(afterSecond.next_run_at as string).getTime()).toBe(
+				advancedOnce,
+			);
 
-      const windowsForRun = await sql`
+			const windowsForRun = await sql`
         SELECT id FROM events WHERE run_id = ${queued.runId} AND semantic_type = 'canvas_state'
       `;
-      expect(windowsForRun).toHaveLength(0);
-    });
+			expect(windowsForRun).toHaveLength(0);
+		});
 
-    // Pi review round-2 #A: device spoof — a same-user token bound to worker
-    // A cannot complete a run pinned to worker B by lying in body.worker_id.
-    // Previously the binding check was `(user_id, body.worker_id)`, which a
-    // same-user attacker could satisfy by registering worker B and POSTing
-    // worker B's id. The fix anchors on the OAuth-token-bound workerId.
-    it('rejects device spoof — token bound to worker A cannot complete worker B run', async () => {
-      const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
+		// Pi review round-2 #A: device spoof — a same-user token bound to worker
+		// A cannot complete a run pinned to worker B by lying in body.worker_id.
+		// Previously the binding check was `(user_id, body.worker_id)`, which a
+		// same-user attacker could satisfy by registering worker B and POSTing
+		// worker B's id. The fix anchors on the OAuth-token-bound workerId.
+		it("rejects device spoof — token bound to worker A cannot complete worker B run", async () => {
+			const { sql, dbClient, workspace, watcherId, agent } =
+				await createAutomatedWatcher();
 
-      // Two registered device workers under the SAME user.
-      const ownerUserId = workspace.users.owner.id;
-      const [deviceA] = await sql`
+			// Two registered device workers under the SAME user.
+			const ownerUserId = workspace.users.owner.id;
+			const [deviceA] = await sql`
         INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label)
         VALUES (${ownerUserId}, 'worker-A', 'macos', ${sql.json({})}, 'Mac A')
         RETURNING id
       `;
-      const [deviceB] = await sql`
+			const [deviceB] = await sql`
         INSERT INTO device_workers (user_id, worker_id, platform, capabilities, label)
         VALUES (${ownerUserId}, 'worker-B', 'macos', ${sql.json({})}, 'Mac B')
         RETURNING id
       `;
-      const deviceBId = String((deviceB as { id: unknown }).id);
-      // deviceA.id is referenced via the bound PAT — no further use here.
-      void deviceA;
+			const deviceBId = String((deviceB as { id: unknown }).id);
+			// deviceA.id is referenced via the bound PAT — no further use here.
+			void deviceA;
 
-      // Token bound to worker A.
-      const { token: patForA } = await createWorkerBoundPat(
-        ownerUserId,
-        workspace.org.id,
-        'worker-A'
-      );
+			// Token bound to worker A.
+			const { token: patForA } = await createWorkerBoundPat(
+				ownerUserId,
+				workspace.org.id,
+				"worker-A",
+			);
 
-      // Watcher run pinned to worker B (via approved_input.device_worker_id).
-      const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-      const { windowStart, windowEnd } = await computePendingWindow(
-        dbClient,
-        watcherId,
-        granularity
-      );
-      const queued = await createWatcherRun({
-        organizationId: workspace.org.id,
-        watcherId,
-        agentId: agent.agentId,
-        windowStart: windowStart.toISOString(),
-        windowEnd: windowEnd.toISOString(),
-        dispatchSource: 'scheduled',
-        deviceWorkerId: deviceBId,
-        agentKind: 'claude-code',
-      });
-      // Claim the run as worker B so `authorizeRunForWorker` passes its
-      // claimed_by check when the body posts worker_id=worker-B. The new
-      // bound-workerId check (Fix A) is what should fire instead.
-      await sql`
+			// Watcher run pinned to worker B (via approved_input.device_worker_id).
+			const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity,
+			);
+			const queued = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+				deviceWorkerId: deviceBId,
+				agentKind: "claude-code",
+			});
+			// Claim the run as worker B so `authorizeRunForWorker` passes its
+			// claimed_by check when the body posts worker_id=worker-B. The new
+			// bound-workerId check (Fix A) is what should fire instead.
+			await sql`
         UPDATE runs
         SET status = 'running', claimed_at = NOW(), claimed_by = 'worker-B'
         WHERE id = ${queued.runId}
       `;
 
-      const response = await post(
-        `/api/workers/me/runs/${queued.runId}/complete-watcher`,
-        {
-          token: patForA,
-          body: { worker_id: 'worker-B', output: 'spoofed', duration_ms: 1 },
-        }
-      );
-      expect(response.status).toBe(403);
-      const body = (await response.json()) as { error: string };
-      expect(body.error).toMatch(/worker_id_mismatch|Forbidden/);
+			const response = await post(
+				`/api/workers/me/runs/${queued.runId}/complete-watcher`,
+				{
+					token: patForA,
+					body: { worker_id: "worker-B", output: "spoofed", duration_ms: 1 },
+				},
+			);
+			expect(response.status).toBe(403);
+			const body = (await response.json()) as { error: string };
+			expect(body.error).toMatch(/worker_id_mismatch|Forbidden/);
 
-      // Run must still be 'running' — nothing was completed.
-      const [run] = await sql`
+			// Run must still be 'running' — nothing was completed.
+			const [run] = await sql`
         SELECT status, window_id FROM runs WHERE id = ${queued.runId}
       `;
-      expect(String(run.status)).toBe('running');
-      expect(run.window_id).toBeNull();
-      // No watcher_windows row was created.
-      const windows = await sql`
+			expect(String(run.status)).toBe("running");
+			expect(run.window_id).toBeNull();
+			// No watcher_windows row was created.
+			const windows = await sql`
         SELECT id FROM events WHERE run_id = ${queued.runId} AND semantic_type = 'canvas_state'
       `;
-      expect(windows).toHaveLength(0);
-    });
+			expect(windows).toHaveLength(0);
+		});
+	});
 
-  });
-
-  // Regression: an active watcher run carrying a `dispatched_message_id` must
-  // not crash reconciliation. The dispatched-id containment query bound the JS
-  // array straight into `= ANY(${ids})`. The production pool (db/client.ts) runs
-  // with `fetch_types: false`, so postgres.js can't infer the array element type
-  // and ships the lone element as a scalar — PG then throws
-  // `malformed array literal: "<uuid>"`. Because `watcher-automation` (every
-  // tick) AND `check-stalled-executions` both call reconcileWatcherRuns, a single
-  // such run wedged BOTH jobs — watchers stopped firing in prod for 12 days (run
-  // 146501 stuck `running` since 2026-05-13, which also blocked the reaper that
-  // would have cleared it). Fix: bind via pgTextArray(...)::text[], the same
-  // explicit-literal idiom every other ANY() in this file already uses.
-  //
-  // NOTE: this MUST exercise getDb() (the prod pool with fetch_types:false), not
-  // the test-harness client — the latter fetches types and silently masks the
-  // bug. Both clients point at the same DATABASE_URL test database here.
-  describe('headless terminal delivery resolves watcher runs on first claim (no SSE owner)', () => {
-    // Regression for the owner-gate false-negative: watcher dispatch never
-    // opens an SSE connection on any pod, so terminal thread_response rows
-    // used to throw "not owned by this gateway instance" on EVERY claim,
-    // exhaust 30 retries, dead-letter, and skip resolveWatcherRunsByMessageIds
-    // entirely — completions deferred to reconcile, failures to the 2h sweep.
-    // These contracts drive the REAL consumer + ApiResponseRenderer against
-    // the test DB with hasActiveConnection=false everywhere.
-    async function makeRunningWatcherRun(messageId: string) {
-      const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
-      const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-      const { windowStart, windowEnd } = await computePendingWindow(dbClient, watcherId, granularity);
-      const queued = await createWatcherRun({
-        organizationId: workspace.org.id,
-        watcherId,
-        agentId: agent.agentId,
-        windowStart: windowStart.toISOString(),
-        windowEnd: windowEnd.toISOString(),
-        dispatchSource: 'scheduled',
-      });
-      await sql`
+	// Regression: an active watcher run carrying a `dispatched_message_id` must
+	// not crash reconciliation. The dispatched-id containment query bound the JS
+	// array straight into `= ANY(${ids})`. The production pool (db/client.ts) runs
+	// with `fetch_types: false`, so postgres.js can't infer the array element type
+	// and ships the lone element as a scalar — PG then throws
+	// `malformed array literal: "<uuid>"`. Because `watcher-automation` (every
+	// tick) AND `check-stalled-executions` both call reconcileWatcherRuns, a single
+	// such run wedged BOTH jobs — watchers stopped firing in prod for 12 days (run
+	// 146501 stuck `running` since 2026-05-13, which also blocked the reaper that
+	// would have cleared it). Fix: bind via pgTextArray(...)::text[], the same
+	// explicit-literal idiom every other ANY() in this file already uses.
+	//
+	// NOTE: this MUST exercise getDb() (the prod pool with fetch_types:false), not
+	// the test-harness client — the latter fetches types and silently masks the
+	// bug. Both clients point at the same DATABASE_URL test database here.
+	describe("headless terminal delivery resolves watcher runs on first claim (no SSE owner)", () => {
+		// Regression for the owner-gate false-negative: watcher dispatch never
+		// opens an SSE connection on any pod, so terminal thread_response rows
+		// used to throw "not owned by this gateway instance" on EVERY claim,
+		// exhaust 30 retries, dead-letter, and skip resolveWatcherRunsByMessageIds
+		// entirely — completions deferred to reconcile, failures to the 2h sweep.
+		// These contracts drive the REAL consumer + ApiResponseRenderer against
+		// the test DB with hasActiveConnection=false everywhere.
+		async function makeRunningWatcherRun(messageId: string) {
+			const { sql, dbClient, workspace, watcherId, agent } =
+				await createAutomatedWatcher();
+			const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity,
+			);
+			const queued = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+			});
+			await sql`
         UPDATE runs
         SET status = 'running', claimed_at = NOW(),
             claimed_by = ${`lobu:${agent.agentId}`},
             dispatched_message_id = ${messageId}
         WHERE id = ${queued.runId}
       `;
-      return { sql, workspace, watcherId, runId: queued.runId, windowStart, windowEnd };
-    }
+			return {
+				sql,
+				workspace,
+				watcherId,
+				runId: queued.runId,
+				windowStart,
+				windowEnd,
+			};
+		}
 
-    function makeHeadlessConsumer() {
-      const renderer = new ApiResponseRenderer({
-        broadcast: () => undefined,
-      } as never);
-      const platformRegistry = { get: () => ({ getResponseRenderer: () => renderer }) };
-      const sseManager = {
-        broadcast: () => undefined,
-        // No pod anywhere holds an SSE connection for a headless session.
-        hasActiveConnection: () => false,
-      };
-      const queueStub = {
-        start: async () => undefined,
-        stop: async () => undefined,
-        createQueue: async () => undefined,
-        work: async () => undefined,
-      };
-      return new UnifiedThreadResponseConsumer(
-        queueStub as never,
-        platformRegistry as never,
-        sseManager as never
-      );
-    }
+		function makeHeadlessConsumer() {
+			const renderer = new ApiResponseRenderer({
+				broadcast: () => undefined,
+			} as never);
+			const platformRegistry = {
+				get: () => ({ getResponseRenderer: () => renderer }),
+			};
+			const sseManager = {
+				broadcast: () => undefined,
+				// No pod anywhere holds an SSE connection for a headless session.
+				hasActiveConnection: () => false,
+			};
+			const queueStub = {
+				start: async () => undefined,
+				stop: async () => undefined,
+				createQueue: async () => undefined,
+				work: async () => undefined,
+			};
+			return new UnifiedThreadResponseConsumer(
+				queueStub as never,
+				platformRegistry as never,
+				sseManager as never,
+			);
+		}
 
-    // Worker terminal rows carry teamId "api" (no platform field) and echo the
-    // dispatch-time platformMetadata.source stamped by routes/public/agent.ts
-    // from the session intent.
-    function terminalPayload(messageId: string, runId: number, error?: string) {
-      return {
-        messageId,
-        channelId: `api_watcher_${runId}`,
-        conversationId: `api_watcher_${runId}`,
-        userId: `watcher-${runId}`,
-        teamId: 'api',
-        timestamp: Date.now(),
-        ...(error ? { error } : { processedMessageIds: [messageId] }),
-        platformMetadata: { source: 'watcher-run' },
-      };
-    }
+		// Worker terminal rows carry teamId "api" (no platform field) and echo the
+		// dispatch-time platformMetadata.source stamped by routes/public/agent.ts
+		// from the session intent.
+		function terminalPayload(messageId: string, runId: number, error?: string) {
+			return {
+				messageId,
+				channelId: `api_watcher_${runId}`,
+				conversationId: `api_watcher_${runId}`,
+				userId: `watcher-${runId}`,
+				teamId: "api",
+				timestamp: Date.now(),
+				...(error ? { error } : { processedMessageIds: [messageId] }),
+				platformMetadata: { source: "watcher-run" },
+			};
+		}
 
-    it('re-dispatches for a finalize nudge when the reply produced no window (first miss)', async () => {
-      // Soft miss: the agent replied but skipped complete_window. Instead of
-      // failing closed on the first miss, the run is re-dispatched (pending)
-      // for one more bounded attempt — finalize_nudge_count records it.
-      const messageId = randomUUID();
-      const { sql, runId } = await makeRunningWatcherRun(messageId);
+		it("re-dispatches for a finalize nudge when the reply produced no window (first miss)", async () => {
+			// Soft miss: the agent replied but skipped complete_window. Instead of
+			// failing closed on the first miss, the run is re-dispatched (pending)
+			// for one more bounded attempt — finalize_nudge_count records it.
+			const messageId = randomUUID();
+			const { sql, runId } = await makeRunningWatcherRun(messageId);
 
-      await makeHeadlessConsumer().handleThreadResponse({
-        id: 'job-headless-1',
-        data: terminalPayload(messageId, runId),
-      } as never);
+			await makeHeadlessConsumer().handleThreadResponse({
+				id: "job-headless-1",
+				data: terminalPayload(messageId, runId),
+			} as never);
 
-      const [run] = await sql`
+			const [run] = await sql`
         SELECT status, error_message, approved_input FROM runs WHERE id = ${runId}
       `;
-      expect(String(run.status)).toBe('pending');
-      expect(run.error_message).toBeNull();
-      expect(
-        Number(
-          (run.approved_input as { finalize_nudge_count?: unknown })
-            .finalize_nudge_count
-        )
-      ).toBe(1);
-    });
+			expect(String(run.status)).toBe("pending");
+			expect(run.error_message).toBeNull();
+			expect(
+				Number(
+					(run.approved_input as { finalize_nudge_count?: unknown })
+						.finalize_nudge_count,
+				),
+			).toBe(1);
+		});
 
-    it('fails the run when the finalize-nudge budget is exhausted (fail-closed guard)', async () => {
-      const messageId = randomUUID();
-      const { sql, runId } = await makeRunningWatcherRun(messageId);
-      // Pre-exhaust the budget so the miss is terminal regardless of the
-      // configured nudge count.
-      await sql`
+		it("fails the run when the finalize-nudge budget is exhausted (fail-closed guard)", async () => {
+			const messageId = randomUUID();
+			const { sql, runId } = await makeRunningWatcherRun(messageId);
+			// Pre-exhaust the budget so the miss is terminal regardless of the
+			// configured nudge count.
+			await sql`
         UPDATE runs
         SET approved_input = jsonb_set(
           COALESCE(approved_input, '{}'::jsonb),
@@ -1247,103 +1375,111 @@ describe('watcher automation contract', () => {
         WHERE id = ${runId}
       `;
 
-      await makeHeadlessConsumer().handleThreadResponse({
-        id: 'job-headless-1b',
-        data: terminalPayload(messageId, runId),
-      } as never);
+			await makeHeadlessConsumer().handleThreadResponse({
+				id: "job-headless-1b",
+				data: terminalPayload(messageId, runId),
+			} as never);
 
-      const [run] = await sql`SELECT status, error_message FROM runs WHERE id = ${runId}`;
-      expect(String(run.status)).toBe('failed');
-      expect(String(run.error_message)).toContain('complete_window');
-    });
+			const [run] =
+				await sql`SELECT status, error_message FROM runs WHERE id = ${runId}`;
+			expect(String(run.status)).toBe("failed");
+			expect(String(run.error_message)).toContain("completeWindow");
+		});
 
-    it('respects a per-watcher finalize_nudges=0 override (fails immediately, no re-dispatch)', async () => {
-      // The per-watcher budget (execution_config.finalize_nudges) overrides the
-      // global default. 0 = no nudge → the first miss fails immediately, the
-      // opposite of the default behavior, proving the override is read.
-      const messageId = randomUUID();
-      const { sql, runId, watcherId } = await makeRunningWatcherRun(messageId);
-      await sql`
+		it("respects a per-watcher finalize_nudges=0 override (fails immediately, no re-dispatch)", async () => {
+			// The per-watcher budget (execution_config.finalize_nudges) overrides the
+			// global default. 0 = no nudge → the first miss fails immediately, the
+			// opposite of the default behavior, proving the override is read.
+			const messageId = randomUUID();
+			const { sql, runId, watcherId } = await makeRunningWatcherRun(messageId);
+			await sql`
         UPDATE watchers
         SET execution_config = '{"finalize_nudges": 0}'::jsonb
         WHERE id = ${watcherId}
       `;
 
-      await makeHeadlessConsumer().handleThreadResponse({
-        id: 'job-headless-nudge0',
-        data: terminalPayload(messageId, runId),
-      } as never);
+			await makeHeadlessConsumer().handleThreadResponse({
+				id: "job-headless-nudge0",
+				data: terminalPayload(messageId, runId),
+			} as never);
 
-      const [run] = await sql`
+			const [run] = await sql`
         SELECT status, error_message FROM runs WHERE id = ${runId}
       `;
-      expect(String(run.status)).toBe('failed');
-      expect(String(run.error_message)).toContain('complete_window');
-    });
+			expect(String(run.status)).toBe("failed");
+			expect(String(run.error_message)).toContain("completeWindow");
+		});
 
-    it('completes the run immediately when a window exists', async () => {
-      const messageId = randomUUID();
-      const { sql, workspace, runId, watcherId, windowStart, windowEnd } =
-        await makeRunningWatcherRun(messageId);
-      // Canvas-on-events: the "window" is a canvas_state chain root stamped with
-      // this run_id (what findWindowIdForRun keys on).
-      const windowRootId = await createCanvasWindow({
-        watcherId,
-        organizationId: workspace.org.id,
-        granularity: 'daily',
-        windowStart,
-        windowEnd,
-        extractedData: { summary: 'done' },
-        contentAnalyzed: 1,
-        runId,
-        modelUsed: 'test-model',
-        runMetadata: { watcher_run_id: runId },
-      });
-      const window = { id: windowRootId };
+		it("completes the run immediately when a window exists", async () => {
+			const messageId = randomUUID();
+			const { sql, workspace, runId, watcherId, windowStart, windowEnd } =
+				await makeRunningWatcherRun(messageId);
+			// Canvas-on-events: the "window" is a canvas_state chain root stamped with
+			// this run_id (what findWindowIdForRun keys on).
+			const windowRootId = await createCanvasWindow({
+				watcherId,
+				organizationId: workspace.org.id,
+				granularity: "daily",
+				windowStart,
+				windowEnd,
+				extractedData: { summary: "done" },
+				contentAnalyzed: 1,
+				runId,
+				modelUsed: "test-model",
+				runMetadata: { watcher_run_id: runId },
+			});
+			const window = { id: windowRootId };
 
-      await makeHeadlessConsumer().handleThreadResponse({
-        id: 'job-headless-2',
-        data: terminalPayload(messageId, runId),
-      } as never);
+			await makeHeadlessConsumer().handleThreadResponse({
+				id: "job-headless-2",
+				data: terminalPayload(messageId, runId),
+			} as never);
 
-      const [run] = await sql`SELECT status, window_id FROM runs WHERE id = ${runId}`;
-      expect(String(run.status)).toBe('completed');
-      expect(Number(run.window_id)).toBe(Number(window.id));
-    });
+			const [run] =
+				await sql`SELECT status, window_id FROM runs WHERE id = ${runId}`;
+			expect(String(run.status)).toBe("completed");
+			expect(Number(run.window_id)).toBe(Number(window.id));
+		});
 
-    it('fails the run immediately on a worker error row (was: 2h stale sweep)', async () => {
-      const messageId = randomUUID();
-      const { sql, runId } = await makeRunningWatcherRun(messageId);
+		it("fails the run immediately on a worker error row (was: 2h stale sweep)", async () => {
+			const messageId = randomUUID();
+			const { sql, runId } = await makeRunningWatcherRun(messageId);
 
-      await makeHeadlessConsumer().handleThreadResponse({
-        id: 'job-headless-3',
-        data: terminalPayload(messageId, runId, 'worker exited 1'),
-      } as never);
+			await makeHeadlessConsumer().handleThreadResponse({
+				id: "job-headless-3",
+				data: terminalPayload(messageId, runId, "worker exited 1"),
+			} as never);
 
-      const [run] = await sql`SELECT status, error_message FROM runs WHERE id = ${runId}`;
-      expect(String(run.status)).toBe('failed');
-      expect(String(run.error_message)).toBe('worker exited 1');
-    });
-  });
+			const [run] =
+				await sql`SELECT status, error_message FROM runs WHERE id = ${runId}`;
+			expect(String(run.status)).toBe("failed");
+			expect(String(run.error_message)).toBe("worker exited 1");
+		});
+	});
 
-  it('reconciles without crashing when an active run carries a dispatched_message_id', async () => {
-    const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
-    const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-    const { windowStart, windowEnd } = await computePendingWindow(dbClient, watcherId, granularity);
-    const queued = await createWatcherRun({
-      organizationId: workspace.org.id,
-      watcherId,
-      agentId: agent.agentId,
-      windowStart: windowStart.toISOString(),
-      windowEnd: windowEnd.toISOString(),
-      dispatchSource: 'scheduled',
-    });
+	it("reconciles without crashing when an active run carries a dispatched_message_id", async () => {
+		const { sql, dbClient, workspace, watcherId, agent } =
+			await createAutomatedWatcher();
+		const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+		const { windowStart, windowEnd } = await computePendingWindow(
+			dbClient,
+			watcherId,
+			granularity,
+		);
+		const queued = await createWatcherRun({
+			organizationId: workspace.org.id,
+			watcherId,
+			agentId: agent.agentId,
+			windowStart: windowStart.toISOString(),
+			windowEnd: windowEnd.toISOString(),
+			dispatchSource: "scheduled",
+		});
 
-    // Move the run to an active state with a dispatched_message_id and NO
-    // watcher_windows row — mirrors prod's stuck run 146501 exactly, so the
-    // first reconcile query is a no-op and execution reaches the buggy
-    // dispatched-id containment query.
-    await sql`
+		// Move the run to an active state with a dispatched_message_id and NO
+		// watcher_windows row — mirrors prod's stuck run 146501 exactly, so the
+		// first reconcile query is a no-op and execution reaches the buggy
+		// dispatched-id containment query.
+		await sql`
       UPDATE runs
       SET status = 'running',
           claimed_at = NOW(),
@@ -1352,123 +1488,129 @@ describe('watcher automation contract', () => {
       WHERE id = ${queued.runId}
     `;
 
-    // Pre-fix this rejects with `malformed array literal`; post-fix it resolves.
-    const result = await reconcileWatcherRuns(getDb());
-    expect(result.reconciled).toBe(0);
-  });
+		// Pre-fix this rejects with `malformed array literal`; post-fix it resolves.
+		const result = await reconcileWatcherRuns(getDb());
+		expect(result.reconciled).toBe(0);
+	});
 
-  describe('watcher-automation tick orchestration', () => {
-    // End-to-end regression for the 12-day outage: a stuck active run carrying a
-    // dispatched_message_id used to make reconcile throw `malformed array literal`,
-    // which (pre phase-isolation) aborted materialize + dispatch every tick. The
-    // tick must now (a) not surface a reconcile error and (b) still materialize a
-    // separate due watcher.
-    it('survives a wedging in-flight run and still materializes other due watchers', async () => {
-      const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
+	describe("watcher-automation tick orchestration", () => {
+		// End-to-end regression for the 12-day outage: a stuck active run carrying a
+		// dispatched_message_id used to make reconcile throw `malformed array literal`,
+		// which (pre phase-isolation) aborted materialize + dispatch every tick. The
+		// tick must now (a) not surface a reconcile error and (b) still materialize a
+		// separate due watcher.
+		it("survives a wedging in-flight run and still materializes other due watchers", async () => {
+			const { sql, dbClient, workspace, watcherId, agent } =
+				await createAutomatedWatcher();
 
-      // Watcher A: a stuck active run with a dispatched_message_id and no window —
-      // the exact shape of prod run 146501 that wedged reconcile.
-      const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-      const { windowStart, windowEnd } = await computePendingWindow(dbClient, watcherId, granularity);
-      const stuck = await createWatcherRun({
-        organizationId: workspace.org.id,
-        watcherId,
-        agentId: agent.agentId,
-        windowStart: windowStart.toISOString(),
-        windowEnd: windowEnd.toISOString(),
-        dispatchSource: 'scheduled',
-      });
-      await sql`
+			// Watcher A: a stuck active run with a dispatched_message_id and no window —
+			// the exact shape of prod run 146501 that wedged reconcile.
+			const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity,
+			);
+			const stuck = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+			});
+			await sql`
         UPDATE runs
         SET status = 'running', claimed_at = NOW(), claimed_by = ${`lobu:${agent.agentId}`},
             dispatched_message_id = 'f7623d32-b589-4085-9504-edbf30925961'
         WHERE id = ${stuck.runId}
       `;
 
-      // Watcher B: due, no active run, valid agent → must materialize this tick.
-      const entityB = await createTestEntity({
-        name: 'Tick Entity B',
-        organization_id: workspace.org.id,
-        created_by: workspace.users.owner.id,
-      });
-      const watcherB = (await workspace.owner.watchers.create({
-        entity_id: entityB.id,
-        slug: 'tick-watcher-b',
-        name: 'Tick Watcher B',
-        prompt: 'Summarize content for {{entities}}.',
-        schedule: '0 9 * * *',
-        agent_id: agent.agentId,
-      })) as { watcher_id: string };
-      const watcherBId = Number(watcherB.watcher_id);
-      await sql`UPDATE watchers SET next_run_at = NOW() - INTERVAL '10 minutes' WHERE id = ${watcherBId}`;
+			// Watcher B: due, no active run, valid agent → must materialize this tick.
+			const entityB = await createTestEntity({
+				name: "Tick Entity B",
+				organization_id: workspace.org.id,
+				created_by: workspace.users.owner.id,
+			});
+			const watcherB = (await workspace.owner.watchers.create({
+				entity_id: entityB.id,
+				slug: "tick-watcher-b",
+				name: "Tick Watcher B",
+				prompt: "Summarize content for {{entities}}.",
+				schedule: "0 9 * * *",
+				agent_id: agent.agentId,
+			})) as { watcher_id: string };
+			const watcherBId = Number(watcherB.watcher_id);
+			await sql`UPDATE watchers SET next_run_at = NOW() - INTERVAL '10 minutes' WHERE id = ${watcherBId}`;
 
-      const result = await runWatcherAutomationTick({} as Env);
+			const result = await runWatcherAutomationTick({} as Env);
 
-      // No phase threw — the bind fix means reconcile handles the dispatched-id
-      // array, and isolation means a phase failure wouldn't starve the rest.
-      expect(result.errors).toEqual([]);
-      // Watcher B materialized despite watcher A's stuck run.
-      expect(result.runsCreated).toBeGreaterThanOrEqual(1);
-      const [runB] = await sql`
+			// No phase threw — the bind fix means reconcile handles the dispatched-id
+			// array, and isolation means a phase failure wouldn't starve the rest.
+			expect(result.errors).toEqual([]);
+			// Watcher B materialized despite watcher A's stuck run.
+			expect(result.runsCreated).toBeGreaterThanOrEqual(1);
+			const [runB] = await sql`
         SELECT status FROM runs
         WHERE watcher_id = ${watcherBId} AND run_type = 'watcher'
       `;
-      expect(runB).toBeDefined();
-    });
+			expect(runB).toBeDefined();
+		});
 
-    // Item 1: a watcher whose assigned agent no longer exists (and isn't device
-    // pinned) must NOT be scheduled — no doomed run per tick — and be counted as
-    // unrunnable for visibility. Mirrors prod orgs lobu-crm / lobu-team.
-    it('does not schedule a watcher whose agent does not exist; counts it unrunnable', async () => {
-      const { sql, watcherId } = await createAutomatedWatcher();
+		// Item 1: a watcher whose assigned agent no longer exists (and isn't device
+		// pinned) must NOT be scheduled — no doomed run per tick — and be counted as
+		// unrunnable for visibility. Mirrors prod orgs lobu-crm / lobu-team.
+		it("does not schedule a watcher whose agent does not exist; counts it unrunnable", async () => {
+			const { sql, watcherId } = await createAutomatedWatcher();
 
-      // Point the watcher at a non-existent agent, no device pin, due now.
-      await sql`
+			// Point the watcher at a non-existent agent, no device pin, due now.
+			await sql`
         UPDATE watchers
         SET agent_id = 'ghost-agent-deleted', device_worker_id = NULL,
             next_run_at = NOW() - INTERVAL '10 minutes'
         WHERE id = ${watcherId}
       `;
 
-      const result = await materializeDueWatcherRuns({} as Env);
+			const result = await materializeDueWatcherRuns({} as Env);
 
-      expect(result.runsCreated).toBe(0);
-      expect(result.unrunnable).toBeGreaterThanOrEqual(1);
-      const runs = await sql`
+			expect(result.runsCreated).toBe(0);
+			expect(result.unrunnable).toBeGreaterThanOrEqual(1);
+			const runs = await sql`
         SELECT id FROM runs WHERE watcher_id = ${watcherId} AND run_type = 'watcher'
       `;
-      expect(runs).toHaveLength(0);
-    });
-  });
+			expect(runs).toHaveLength(0);
+		});
+	});
 
-  describe('sweepStaleWatcherRuns liveness reaping', () => {
-    // Seed a `running` watcher run with controlled claim/heartbeat ages.
-    // Omitting `heartbeatAgo` mirrors a client that never heartbeats — the
-    // claim sets last_heartbeat_at == claimed_at, so the row must fall to the
-    // coarse 2h path, never the fast heartbeat path.
-    async function seedRunningWatcherRun(opts: {
-      claimedAgo: string;
-      heartbeatAgo?: string;
-    }) {
-      const { sql, dbClient, workspace, watcherId, agent } = await createAutomatedWatcher();
-      const granularity = inferWatcherGranularityFromSchedule('0 9 * * *');
-      const { windowStart, windowEnd } = await computePendingWindow(
-        dbClient,
-        watcherId,
-        granularity
-      );
-      const queued = await createWatcherRun({
-        organizationId: workspace.org.id,
-        watcherId,
-        agentId: agent.agentId,
-        windowStart: windowStart.toISOString(),
-        windowEnd: windowEnd.toISOString(),
-        dispatchSource: 'scheduled',
-        deviceWorkerId: '11111111-1111-1111-1111-111111111111',
-        agentKind: 'claude-code',
-      });
-      const heartbeatAgo = opts.heartbeatAgo ?? opts.claimedAgo;
-      await sql`
+	describe("sweepStaleWatcherRuns liveness reaping", () => {
+		// Seed a `running` watcher run with controlled claim/heartbeat ages.
+		// Omitting `heartbeatAgo` mirrors a client that never heartbeats — the
+		// claim sets last_heartbeat_at == claimed_at, so the row must fall to the
+		// coarse 2h path, never the fast heartbeat path.
+		async function seedRunningWatcherRun(opts: {
+			claimedAgo: string;
+			heartbeatAgo?: string;
+		}) {
+			const { sql, dbClient, workspace, watcherId, agent } =
+				await createAutomatedWatcher();
+			const granularity = inferWatcherGranularityFromSchedule("0 9 * * *");
+			const { windowStart, windowEnd } = await computePendingWindow(
+				dbClient,
+				watcherId,
+				granularity,
+			);
+			const queued = await createWatcherRun({
+				organizationId: workspace.org.id,
+				watcherId,
+				agentId: agent.agentId,
+				windowStart: windowStart.toISOString(),
+				windowEnd: windowEnd.toISOString(),
+				dispatchSource: "scheduled",
+				deviceWorkerId: "11111111-1111-1111-1111-111111111111",
+				agentKind: "claude-code",
+			});
+			const heartbeatAgo = opts.heartbeatAgo ?? opts.claimedAgo;
+			await sql`
         UPDATE runs
         SET status = 'running',
             claimed_by = 'mac-sweep-test',
@@ -1476,340 +1618,376 @@ describe('watcher automation contract', () => {
             last_heartbeat_at = NOW() - ${heartbeatAgo}::interval
         WHERE id = ${queued.runId}
       `;
-      return { sql, runId: queued.runId };
-    }
+			return { sql, runId: queued.runId };
+		}
 
-    it('reaps a heartbeating run that went silent past the heartbeat window', async () => {
-      // Beat once after claim (10m ago > claim 1h ago), then silent >3min.
-      const { sql, runId } = await seedRunningWatcherRun({
-        claimedAgo: '1 hour',
-        heartbeatAgo: '10 minutes',
-      });
-      const { timedOut } = await sweepStaleWatcherRuns(sql);
-      expect(timedOut).toBeGreaterThanOrEqual(1);
-      const [row] = await sql`SELECT status, error_message FROM runs WHERE id = ${runId}`;
-      expect(String(row.status)).toBe('timeout');
-      expect(String(row.error_message ?? '')).toMatch(/heartbeat went silent/i);
-    });
+		it("reaps a heartbeating run that went silent past the heartbeat window", async () => {
+			// Beat once after claim (10m ago > claim 1h ago), then silent >3min.
+			const { sql, runId } = await seedRunningWatcherRun({
+				claimedAgo: "1 hour",
+				heartbeatAgo: "10 minutes",
+			});
+			const { timedOut } = await sweepStaleWatcherRuns(sql);
+			expect(timedOut).toBeGreaterThanOrEqual(1);
+			const [row] =
+				await sql`SELECT status, error_message FROM runs WHERE id = ${runId}`;
+			expect(String(row.status)).toBe("timeout");
+			expect(String(row.error_message ?? "")).toMatch(/heartbeat went silent/i);
+		});
 
-    it('leaves a run with a fresh heartbeat running', async () => {
-      const { sql, runId } = await seedRunningWatcherRun({
-        claimedAgo: '1 hour',
-        heartbeatAgo: '30 seconds',
-      });
-      await sweepStaleWatcherRuns(sql);
-      const [row] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
-      expect(String(row.status)).toBe('running');
-    });
+		it("leaves a run with a fresh heartbeat running", async () => {
+			const { sql, runId } = await seedRunningWatcherRun({
+				claimedAgo: "1 hour",
+				heartbeatAgo: "30 seconds",
+			});
+			await sweepStaleWatcherRuns(sql);
+			const [row] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+			expect(String(row.status)).toBe("running");
+		});
 
-    it('does not coarse-reap a live heartbeating run older than the 2h TTL', async () => {
-      // Claimed 3h ago but heartbeating fresh (30s) → still alive. The coarse
-      // 2h backstop must NOT touch it; only the (un-lapsed) fast path governs
-      // a heartbeating run. Guards against killing a legitimately long turn.
-      const { sql, runId } = await seedRunningWatcherRun({
-        claimedAgo: '3 hours',
-        heartbeatAgo: '30 seconds',
-      });
-      await sweepStaleWatcherRuns(sql);
-      const [row] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
-      expect(String(row.status)).toBe('running');
-    });
+		it("does not coarse-reap a live heartbeating run older than the 2h TTL", async () => {
+			// Claimed 3h ago but heartbeating fresh (30s) → still alive. The coarse
+			// 2h backstop must NOT touch it; only the (un-lapsed) fast path governs
+			// a heartbeating run. Guards against killing a legitimately long turn.
+			const { sql, runId } = await seedRunningWatcherRun({
+				claimedAgo: "3 hours",
+				heartbeatAgo: "30 seconds",
+			});
+			await sweepStaleWatcherRuns(sql);
+			const [row] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+			expect(String(row.status)).toBe("running");
+		});
 
-    it('does not fast-reap a recent run that never heartbeats', async () => {
-      // last_heartbeat_at == claimed_at (no beat) + only 30m old → the fast
-      // path must NOT fire; it stays running until the 2h coarse backstop.
-      // Backward-compat guard for clients that do not heartbeat.
-      const { sql, runId } = await seedRunningWatcherRun({ claimedAgo: '30 minutes' });
-      await sweepStaleWatcherRuns(sql);
-      const [row] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
-      expect(String(row.status)).toBe('running');
-    });
+		it("does not fast-reap a recent run that never heartbeats", async () => {
+			// last_heartbeat_at == claimed_at (no beat) + only 30m old → the fast
+			// path must NOT fire; it stays running until the 2h coarse backstop.
+			// Backward-compat guard for clients that do not heartbeat.
+			const { sql, runId } = await seedRunningWatcherRun({
+				claimedAgo: "30 minutes",
+			});
+			await sweepStaleWatcherRuns(sql);
+			const [row] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+			expect(String(row.status)).toBe("running");
+		});
 
-    it('reaps a non-heartbeating run via the coarse 2h backstop', async () => {
-      const { sql, runId } = await seedRunningWatcherRun({ claimedAgo: '3 hours' });
-      const { timedOut } = await sweepStaleWatcherRuns(sql);
-      expect(timedOut).toBeGreaterThanOrEqual(1);
-      const [row] = await sql`SELECT status, error_message FROM runs WHERE id = ${runId}`;
-      expect(String(row.status)).toBe('timeout');
-      expect(String(row.error_message ?? '')).toMatch(/2 hours/i);
-    });
-  });
+		it("reaps a non-heartbeating run via the coarse 2h backstop", async () => {
+			const { sql, runId } = await seedRunningWatcherRun({
+				claimedAgo: "3 hours",
+			});
+			const { timedOut } = await sweepStaleWatcherRuns(sql);
+			expect(timedOut).toBeGreaterThanOrEqual(1);
+			const [row] =
+				await sql`SELECT status, error_message FROM runs WHERE id = ${runId}`;
+			expect(String(row.status)).toBe("timeout");
+			expect(String(row.error_message ?? "")).toMatch(/2 hours/i);
+		});
+	});
 });
 
 // ============================================
 // Canvas-on-events contract
 // ============================================
-describe('canvas-on-events window completion', () => {
-  async function completeOnce(
-    overrides: {
-      extracted_data?: Record<string, unknown>;
-      replace_existing?: boolean;
-      client_id?: string;
-    } = {}
-  ) {
-    const { sql, workspace, api, entityId, watcherId } = await createAutomatedWatcher();
-    const event = await createTestEvent({
-      entity_id: entityId,
-      organization_id: workspace.org.id,
-      content: 'Canvas event content.',
-      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
-    });
-    const windowStart = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
-    const windowEnd = new Date().toISOString();
-    const windowToken = await generateWindowToken(
-      {
-        watcher_id: watcherId,
-        window_start: windowStart,
-        window_end: windowEnd,
-        granularity: 'daily',
-        content_count: 1,
-        content_ids: [event.id],
-      },
-      { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env
-    );
-    const completion = (await api.watchers.completeWindow({
-      watcher_id: String(watcherId),
-      window_token: windowToken,
-      extracted_data: overrides.extracted_data ?? { summary: 'v1 canvas summary' },
-      replace_existing: overrides.replace_existing ?? false,
-      ...(overrides.client_id ? { client_id: overrides.client_id } : {}),
-    })) as { action: string; window_id: number };
-    return { sql, workspace, api, watcherId, windowStart, windowEnd, windowToken, completion };
-  }
+describe("canvas-on-events window completion", () => {
+	async function completeOnce(
+		overrides: {
+			extracted_data?: Record<string, unknown>;
+			replace_existing?: boolean;
+			client_id?: string;
+		} = {},
+	) {
+		const { sql, workspace, api, entityId, watcherId } =
+			await createAutomatedWatcher();
+		const event = await createTestEvent({
+			entity_id: entityId,
+			organization_id: workspace.org.id,
+			content: "Canvas event content.",
+			occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+		});
+		const windowStart = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+		const windowEnd = new Date().toISOString();
+		const windowToken = await generateWindowToken(
+			{
+				watcher_id: watcherId,
+				window_start: windowStart,
+				window_end: windowEnd,
+				granularity: "daily",
+				content_count: 1,
+				content_ids: [event.id],
+			},
+			{ JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env,
+		);
+		const completion = (await api.watchers.completeWindow({
+			watcher_id: String(watcherId),
+			window_token: windowToken,
+			extracted_data: overrides.extracted_data ?? {
+				summary: "v1 canvas summary",
+			},
+			replace_existing: overrides.replace_existing ?? false,
+			...(overrides.client_id ? { client_id: overrides.client_id } : {}),
+		})) as { action: string; window_id: number };
+		return {
+			sql,
+			workspace,
+			api,
+			watcherId,
+			windowStart,
+			windowEnd,
+			windowToken,
+			completion,
+		};
+	}
 
-  it('emits a canvas_state ROOT event on window completion', async () => {
-    const { sql, watcherId } = await completeOnce({ extracted_data: { summary: 'hello canvas' } });
-    const rows = await sql`
+	it("emits a canvas_state ROOT event on window completion", async () => {
+		const { sql, watcherId } = await completeOnce({
+			extracted_data: { summary: "hello canvas" },
+		});
+		const rows = await sql`
       SELECT id, payload_data, supersedes_event_id, metadata->>'granularity' AS granularity
       FROM events
       WHERE semantic_type = 'canvas_state'
         AND (metadata->>'watcher_id')::bigint = ${watcherId}
     `;
-    expect(rows).toHaveLength(1);
-    expect(rows[0].supersedes_event_id).toBeNull();
-    expect(rows[0].granularity).toBe('daily');
-    expect((rows[0].payload_data as Record<string, unknown>).summary).toBe('hello canvas');
-  });
+		expect(rows).toHaveLength(1);
+		expect(rows[0].supersedes_event_id).toBeNull();
+		expect(rows[0].granularity).toBe("daily");
+		expect((rows[0].payload_data as Record<string, unknown>).summary).toBe(
+			"hello canvas",
+		);
+	});
 
-  it('completes with a PAT/device client_id that is not an oauth_clients row', async () => {
-    // Reproduces the sdk-e2e failure: events.client_id has an FK to
-    // oauth_clients (unlike watcher_windows.client_id, which stores PAT ids
-    // verbatim). The canvas insert runs inside the completion tx, where
-    // insertEvent's client-id-FK retry can't engage (the first failed INSERT
-    // aborts the tx) — so complete_window must pre-validate and stamp NULL.
-    const { sql, watcherId, completion } = await completeOnce({
-      extracted_data: { summary: 'pat canvas' },
-      client_id: 'pat_nonexistent_e2e',
-    });
-    expect(completion.action).toBe('complete_window');
+	it("completes with a PAT/device client_id that is not an oauth_clients row", async () => {
+		// Reproduces the sdk-e2e failure: events.client_id has an FK to
+		// oauth_clients (unlike watcher_windows.client_id, which stores PAT ids
+		// verbatim). The canvas insert runs inside the completion tx, where
+		// insertEvent's client-id-FK retry can't engage (the first failed INSERT
+		// aborts the tx) — so complete_window must pre-validate and stamp NULL.
+		const { sql, watcherId, completion } = await completeOnce({
+			extracted_data: { summary: "pat canvas" },
+			client_id: "pat_nonexistent_e2e",
+		});
+		expect(completion.action).toBe("complete_window");
 
-    const [root] = await sql`
+		const [root] = await sql`
       SELECT id, client_id, payload_data FROM events
       WHERE semantic_type = 'canvas_state'
         AND (metadata->>'watcher_id')::bigint = ${watcherId}
     `;
-    expect(root.client_id).toBeNull();
-    expect((root.payload_data as Record<string, unknown>).summary).toBe('pat canvas');
-    // The canvas root IS the window (window_id = root event id).
-    expect(Number(root.id)).toBe(completion.window_id);
-  });
+		expect(root.client_id).toBeNull();
+		expect((root.payload_data as Record<string, unknown>).summary).toBe(
+			"pat canvas",
+		);
+		// The canvas root IS the window (window_id = root event id).
+		expect(Number(root.id)).toBe(completion.window_id);
+	});
 
-  it('a same-period completion without replace_existing is an idempotent no-op', async () => {
-    // Retrying a period never grows the chain or overwrites a successful head —
-    // even with different data. A genuine re-analysis must state
-    // replace_existing explicitly.
-    const { sql, api, watcherId, windowStart, windowEnd, completion } = await completeOnce({
-      extracted_data: { summary: 'v1' },
-    });
+	it("a same-period completion without replace_existing is an idempotent no-op", async () => {
+		// Retrying a period never grows the chain or overwrites a successful head —
+		// even with different data. A genuine re-analysis must state
+		// replace_existing explicitly.
+		const { sql, api, watcherId, windowStart, windowEnd, completion } =
+			await completeOnce({
+				extracted_data: { summary: "v1" },
+			});
 
-    const retryToken = await generateWindowToken(
-      {
-        watcher_id: watcherId,
-        window_start: windowStart,
-        window_end: windowEnd,
-        granularity: 'daily',
-        content_count: 0,
-        content_ids: [],
-      },
-      { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env
-    );
-    const retry = (await api.watchers.completeWindow({
-      watcher_id: String(watcherId),
-      window_token: retryToken,
-      extracted_data: { summary: 'v2 changed but not a replace' },
-    })) as { window_id: number; window_created: boolean };
+		const retryToken = await generateWindowToken(
+			{
+				watcher_id: watcherId,
+				window_start: windowStart,
+				window_end: windowEnd,
+				granularity: "daily",
+				content_count: 0,
+				content_ids: [],
+			},
+			{ JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env,
+		);
+		const retry = (await api.watchers.completeWindow({
+			watcher_id: String(watcherId),
+			window_token: retryToken,
+			extracted_data: { summary: "v2 changed but not a replace" },
+		})) as { window_id: number; window_created: boolean };
 
-    // Same window identity returned; chain unchanged; head still v1.
-    expect(retry.window_id).toBe(completion.window_id);
-    expect(retry.window_created).toBe(false);
-    const chain = await sql`
+		// Same window identity returned; chain unchanged; head still v1.
+		expect(retry.window_id).toBe(completion.window_id);
+		expect(retry.window_created).toBe(false);
+		const chain = await sql`
       SELECT payload_data FROM events
       WHERE semantic_type = 'canvas_state'
         AND (metadata->>'watcher_id')::bigint = ${watcherId}
     `;
-    expect(chain).toHaveLength(1);
-    expect((chain[0].payload_data as Record<string, unknown>).summary).toBe('v1');
-  });
+		expect(chain).toHaveLength(1);
+		expect((chain[0].payload_data as Record<string, unknown>).summary).toBe(
+			"v1",
+		);
+	});
 
-  it('replace_existing supersedes the head, keeping the root id stable', async () => {
-    const { sql, api, watcherId, windowStart, windowEnd, workspace } = await completeOnce({
-      extracted_data: { summary: 'v1' },
-    });
+	it("replace_existing supersedes the head, keeping the root id stable", async () => {
+		const { sql, api, watcherId, windowStart, windowEnd, workspace } =
+			await completeOnce({
+				extracted_data: { summary: "v1" },
+			});
 
-    const [root] = await sql`
+		const [root] = await sql`
       SELECT id FROM events
       WHERE semantic_type = 'canvas_state'
         AND (metadata->>'watcher_id')::bigint = ${watcherId}
         AND supersedes_event_id IS NULL
     `;
-    const rootId = Number(root.id);
+		const rootId = Number(root.id);
 
-    // A second completion for the SAME period with replace_existing supersedes.
-    const event = await sql`SELECT id FROM events WHERE organization_id = ${workspace.org.id} AND semantic_type <> 'canvas_state' LIMIT 1`;
-    const windowToken = await generateWindowToken(
-      {
-        watcher_id: watcherId,
-        window_start: windowStart,
-        window_end: windowEnd,
-        granularity: 'daily',
-        content_count: 1,
-        content_ids: [Number(event[0].id)],
-      },
-      { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env
-    );
-    await api.watchers.completeWindow({
-      watcher_id: String(watcherId),
-      window_token: windowToken,
-      extracted_data: { summary: 'v2' },
-      replace_existing: true,
-    });
+		// A second completion for the SAME period with replace_existing supersedes.
+		const event =
+			await sql`SELECT id FROM events WHERE organization_id = ${workspace.org.id} AND semantic_type <> 'canvas_state' LIMIT 1`;
+		const windowToken = await generateWindowToken(
+			{
+				watcher_id: watcherId,
+				window_start: windowStart,
+				window_end: windowEnd,
+				granularity: "daily",
+				content_count: 1,
+				content_ids: [Number(event[0].id)],
+			},
+			{ JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env,
+		);
+		await api.watchers.completeWindow({
+			watcher_id: String(watcherId),
+			window_token: windowToken,
+			extracted_data: { summary: "v2" },
+			replace_existing: true,
+		});
 
-    // Still exactly one ROOT, with the SAME id.
-    const roots = await sql`
+		// Still exactly one ROOT, with the SAME id.
+		const roots = await sql`
       SELECT id FROM events
       WHERE semantic_type = 'canvas_state'
         AND (metadata->>'watcher_id')::bigint = ${watcherId}
         AND supersedes_event_id IS NULL
     `;
-    expect(roots).toHaveLength(1);
-    expect(Number(roots[0].id)).toBe(rootId);
+		expect(roots).toHaveLength(1);
+		expect(Number(roots[0].id)).toBe(rootId);
 
-    // The HEAD is the superseding v2 event; it stamps root_event_id = rootId.
-    const head = await sql`
+		// The HEAD is the superseding v2 event; it stamps root_event_id = rootId.
+		const head = await sql`
       SELECT id, payload_data, (metadata->>'root_event_id')::bigint AS root_event_id
       FROM events e
       WHERE e.semantic_type = 'canvas_state'
         AND (e.metadata->>'watcher_id')::bigint = ${watcherId}
         AND NOT EXISTS (SELECT 1 FROM events n WHERE n.supersedes_event_id = e.id)
     `;
-    expect(head).toHaveLength(1);
-    expect((head[0].payload_data as Record<string, unknown>).summary).toBe('v2');
-    expect(Number(head[0].root_event_id)).toBe(rootId);
+		expect(head).toHaveLength(1);
+		expect((head[0].payload_data as Record<string, unknown>).summary).toBe(
+			"v2",
+		);
+		expect(Number(head[0].root_event_id)).toBe(rootId);
 
-    // The read flip surfaces the HEAD payload via get_watcher.
-    const view = (await api.watchers.get(String(watcherId))) as {
-      windows: Array<{ extracted_data: Record<string, unknown> }>;
-    };
-    expect(view.windows[0].extracted_data.summary).toBe('v2');
-  });
+		// The read flip surfaces the HEAD payload via get_watcher.
+		const view = (await api.watchers.get(String(watcherId))) as {
+			windows: Array<{ extracted_data: Record<string, unknown> }>;
+		};
+		expect(view.windows[0].extracted_data.summary).toBe("v2");
+	});
 
-  it('replace_existing re-links exactly the new content set (no stale links)', async () => {
-    // The root id is stable across a replace, so STEP 8's ON CONFLICT DO
-    // NOTHING alone would UNION old+new links. An explicit replace states
-    // "this analysis covers THIS content set" — legacy parity (the old path
-    // deleted the window row and its links) requires the old links to go.
-    const { sql, workspace, api, entityId, watcherId } = await createAutomatedWatcher();
-    const eventA = await createTestEvent({
-      entity_id: entityId,
-      organization_id: workspace.org.id,
-      content: 'Replace-links content A.',
-      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
-    });
-    const eventB = await createTestEvent({
-      entity_id: entityId,
-      organization_id: workspace.org.id,
-      content: 'Replace-links content B.',
-      occurred_at: new Date(Date.now() - 30 * 60 * 1000),
-    });
-    const windowStart = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
-    const windowEnd = new Date().toISOString();
-    const env = { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env;
+	it("replace_existing re-links exactly the new content set (no stale links)", async () => {
+		// The root id is stable across a replace, so STEP 8's ON CONFLICT DO
+		// NOTHING alone would UNION old+new links. An explicit replace states
+		// "this analysis covers THIS content set" — legacy parity (the old path
+		// deleted the window row and its links) requires the old links to go.
+		const { sql, workspace, api, entityId, watcherId } =
+			await createAutomatedWatcher();
+		const eventA = await createTestEvent({
+			entity_id: entityId,
+			organization_id: workspace.org.id,
+			content: "Replace-links content A.",
+			occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+		});
+		const eventB = await createTestEvent({
+			entity_id: entityId,
+			organization_id: workspace.org.id,
+			content: "Replace-links content B.",
+			occurred_at: new Date(Date.now() - 30 * 60 * 1000),
+		});
+		const windowStart = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+		const windowEnd = new Date().toISOString();
+		const env = { JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env;
 
-    const tokenA = await generateWindowToken(
-      {
-        watcher_id: watcherId,
-        window_start: windowStart,
-        window_end: windowEnd,
-        granularity: 'daily',
-        content_count: 1,
-        content_ids: [eventA.id],
-      },
-      env
-    );
-    const first = (await api.watchers.completeWindow({
-      watcher_id: String(watcherId),
-      window_token: tokenA,
-      extracted_data: { summary: 'v1 over A' },
-    })) as { window_id: number };
+		const tokenA = await generateWindowToken(
+			{
+				watcher_id: watcherId,
+				window_start: windowStart,
+				window_end: windowEnd,
+				granularity: "daily",
+				content_count: 1,
+				content_ids: [eventA.id],
+			},
+			env,
+		);
+		const first = (await api.watchers.completeWindow({
+			watcher_id: String(watcherId),
+			window_token: tokenA,
+			extracted_data: { summary: "v1 over A" },
+		})) as { window_id: number };
 
-    const tokenB = await generateWindowToken(
-      {
-        watcher_id: watcherId,
-        window_start: windowStart,
-        window_end: windowEnd,
-        granularity: 'daily',
-        content_count: 1,
-        content_ids: [eventB.id],
-      },
-      env
-    );
-    const second = (await api.watchers.completeWindow({
-      watcher_id: String(watcherId),
-      window_token: tokenB,
-      extracted_data: { summary: 'v2 over B' },
-      replace_existing: true,
-    })) as { window_id: number };
+		const tokenB = await generateWindowToken(
+			{
+				watcher_id: watcherId,
+				window_start: windowStart,
+				window_end: windowEnd,
+				granularity: "daily",
+				content_count: 1,
+				content_ids: [eventB.id],
+			},
+			env,
+		);
+		const second = (await api.watchers.completeWindow({
+			watcher_id: String(watcherId),
+			window_token: tokenB,
+			extracted_data: { summary: "v2 over B" },
+			replace_existing: true,
+		})) as { window_id: number };
 
-    // Same window identity (the canvas root), but the links are exactly the
-    // replace's content set — eventA's stale link is gone.
-    expect(second.window_id).toBe(first.window_id);
-    const links = await sql`
+		// Same window identity (the canvas root), but the links are exactly the
+		// replace's content set — eventA's stale link is gone.
+		expect(second.window_id).toBe(first.window_id);
+		const links = await sql`
       SELECT event_id FROM watcher_window_events WHERE window_id = ${first.window_id}
     `;
-    expect(links).toHaveLength(1);
-    expect(Number(links[0].event_id)).toBe(Number(eventB.id));
-  });
+		expect(links).toHaveLength(1);
+		expect(Number(links[0].event_id)).toBe(Number(eventB.id));
+	});
 
-  it('superseded canvas states are masked from current_event_records', async () => {
-    const { sql, api, watcherId, windowStart, windowEnd, workspace } = await completeOnce({
-      extracted_data: { summary: 'v1' },
-    });
-    const event = await sql`SELECT id FROM events WHERE organization_id = ${workspace.org.id} AND semantic_type <> 'canvas_state' LIMIT 1`;
-    const windowToken = await generateWindowToken(
-      {
-        watcher_id: watcherId,
-        window_start: windowStart,
-        window_end: windowEnd,
-        granularity: 'daily',
-        content_count: 1,
-        content_ids: [Number(event[0].id)],
-      },
-      { JWT_SECRET: 'test-jwt-secret-for-testing-only' } as Env
-    );
-    await api.watchers.completeWindow({
-      watcher_id: String(watcherId),
-      window_token: windowToken,
-      extracted_data: { summary: 'v2' },
-      replace_existing: true,
-    });
+	it("superseded canvas states are masked from current_event_records", async () => {
+		const { sql, api, watcherId, windowStart, windowEnd, workspace } =
+			await completeOnce({
+				extracted_data: { summary: "v1" },
+			});
+		const event =
+			await sql`SELECT id FROM events WHERE organization_id = ${workspace.org.id} AND semantic_type <> 'canvas_state' LIMIT 1`;
+		const windowToken = await generateWindowToken(
+			{
+				watcher_id: watcherId,
+				window_start: windowStart,
+				window_end: windowEnd,
+				granularity: "daily",
+				content_count: 1,
+				content_ids: [Number(event[0].id)],
+			},
+			{ JWT_SECRET: "test-jwt-secret-for-testing-only" } as Env,
+		);
+		await api.watchers.completeWindow({
+			watcher_id: String(watcherId),
+			window_token: windowToken,
+			extracted_data: { summary: "v2" },
+			replace_existing: true,
+		});
 
-    const current = await sql`
+		const current = await sql`
       SELECT payload_data FROM current_event_records
       WHERE semantic_type = 'canvas_state'
         AND (metadata->>'watcher_id')::bigint = ${watcherId}
     `;
-    // Only the HEAD (v2) is current; the superseded v1 root is masked.
-    expect(current).toHaveLength(1);
-    expect((current[0].payload_data as Record<string, unknown>).summary).toBe('v2');
-  });
+		// Only the HEAD (v2) is current; the superseded v1 root is masked.
+		expect(current).toHaveLength(1);
+		expect((current[0].payload_data as Record<string, unknown>).summary).toBe(
+			"v2",
+		);
+	});
 });

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -1,93 +1,98 @@
-import { randomUUID } from 'node:crypto';
-import { generateWorkerToken } from '@lobu/core';
-import { inferWatcherGranularityFromSchedule } from '@lobu/connector-sdk';
-import { intervals } from '../config/intervals';
-import type { DbClient } from '../db/client';
-import { getDb, pgTextArray } from '../db/client';
-import { materializeDueItems } from '../scheduled/due-materializer';
-import { markStaleRunsAsTimeout } from '../scheduled/stale-run-sweeper';
-import { incrementCounter, setGauge } from '../gateway/metrics/prometheus';
-import type { Env } from '../index';
-import { getInternalGatewayUrl } from '../gateway/config/index';
-import { isLobuGatewayRunning } from '../lobu/gateway';
-import { getLobuServiceToken } from '../lobu/service-token';
-import logger from '../utils/logger';
-import { createWatcherRun, type WatcherRunPayload } from '../runs/queue-service';
-import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
-import { computePendingWindow } from '../utils/window-utils';
+import { randomUUID } from "node:crypto";
+import { inferWatcherGranularityFromSchedule } from "@lobu/connector-sdk";
+import { generateWorkerToken, getErrorMessage } from "@lobu/core";
+import { intervals } from "../config/intervals";
+import type { DbClient } from "../db/client";
+import { getDb, pgTextArray } from "../db/client";
+import { getInternalGatewayUrl } from "../gateway/config/index";
+import { incrementCounter, setGauge } from "../gateway/metrics/prometheus";
+import type { Env } from "../index";
+import { isLobuGatewayRunning } from "../lobu/gateway";
+import { getLobuServiceToken } from "../lobu/service-token";
 import {
-  findWindowIdForRun,
-  markWatcherRunCompleted,
-  resolveWatcherRunsByMessageIds,
-} from './run-completion';
-import { nextRunAt } from '../utils/cron';
-import { getErrorMessage } from "@lobu/core";
+	createWatcherRun,
+	type WatcherRunPayload,
+} from "../runs/queue-service";
+import { materializeDueItems } from "../scheduled/due-materializer";
+import { markStaleRunsAsTimeout } from "../scheduled/stale-run-sweeper";
+import { nextRunAt } from "../utils/cron";
+import logger from "../utils/logger";
+import { ACTIVE_RUN_STATUSES, runStatusLiteral } from "../utils/run-statuses";
+import { computePendingWindow } from "../utils/window-utils";
+import {
+	findWindowIdForRun,
+	markWatcherRunCompleted,
+	resolveWatcherRunsByMessageIds,
+} from "./run-completion";
 
 type WatcherRunStatus =
-  | 'pending'
-  | 'claimed'
-  | 'running'
-  | 'completed'
-  | 'failed'
-  | 'cancelled'
-  | 'timeout';
+	| "pending"
+	| "claimed"
+	| "running"
+	| "completed"
+	| "failed"
+	| "cancelled"
+	| "timeout";
 
 interface DueWatcherRow {
-  id: number;
-  organization_id: string;
-  agent_id: string;
-  schedule: string | null;
-  status?: string;
-  /** Watcher is pinned to a user-owned device worker (e.g. Lobu Mac app). */
-  device_worker_id?: string | null;
-  /** Preferred local agent kind on the pinned device (e.g. 'claude-code'). */
-  agent_kind?: string | null;
+	id: number;
+	organization_id: string;
+	agent_id: string;
+	schedule: string | null;
+	status?: string;
+	/** Watcher is pinned to a user-owned device worker (e.g. Lobu Mac app). */
+	device_worker_id?: string | null;
+	/** Preferred local agent kind on the pinned device (e.g. 'claude-code'). */
+	agent_kind?: string | null;
 }
 
 interface ClaimedWatcherRunRow {
-  id: number;
-  organization_id: string;
-  watcher_id: number;
-  approved_input: unknown;
+	id: number;
+	organization_id: string;
+	watcher_id: number;
+	approved_input: unknown;
 }
 
 interface ActiveWatcherRunInfo {
-  run_id: number;
-  watcher_id: number;
-  status: WatcherRunStatus;
-  error_message: string | null;
+	run_id: number;
+	watcher_id: number;
+	status: WatcherRunStatus;
+	error_message: string | null;
 }
 
 interface MaterializeDueWatcherRunsResult {
-  dueWatchers: number;
-  runsCreated: number;
-  skipped: number;
-  /** Due active watchers NOT scheduled because they have no runnable executor
-   *  (no device pin AND no matching agents row). Surfaced so a misconfigured
-   *  watcher whose agent was deleted is visible in the tick summary instead of
-   *  silently never running. */
-  unrunnable: number;
+	dueWatchers: number;
+	runsCreated: number;
+	skipped: number;
+	/** Due active watchers NOT scheduled because they have no runnable executor
+	 *  (no device pin AND no matching agents row). Surfaced so a misconfigured
+	 *  watcher whose agent was deleted is visible in the tick summary instead of
+	 *  silently never running. */
+	unrunnable: number;
 }
 
 interface DispatchWatcherRunsResult {
-  claimed: number;
-  dispatched: number;
-  reconciled: number;
-  failed: number;
+	claimed: number;
+	dispatched: number;
+	reconciled: number;
+	failed: number;
 }
 
 interface ReconcileWatcherRunsResult {
-  reconciled: number;
+	reconciled: number;
 }
 
 interface QueueWatcherRunResult {
-  runId: number;
-  status: string;
-  created: boolean;
+	runId: number;
+	status: string;
+	created: boolean;
 }
 
-export function buildLatestWatcherRunJoinSql(watcherAlias = 'i', runAlias = 'wr'): string {
-  return `
+export function buildLatestWatcherRunJoinSql(
+	watcherAlias = "i",
+	runAlias = "wr",
+): string {
+	return `
     LEFT JOIN LATERAL (
       SELECT r.id, r.status, r.error_message, r.created_at, r.completed_at
       FROM runs r
@@ -101,66 +106,73 @@ export function buildLatestWatcherRunJoinSql(watcherAlias = 'i', runAlias = 'wr'
   `.trim();
 }
 
-export function parseWatcherRunPayload(value: unknown): WatcherRunPayload | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+export function parseWatcherRunPayload(
+	value: unknown,
+): WatcherRunPayload | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
 
-  const payload = value as Record<string, unknown>;
-  const watcherId = Number(payload.watcher_id);
-  const agentId = typeof payload.agent_id === 'string' ? payload.agent_id.trim() : '';
-  const windowStart = typeof payload.window_start === 'string' ? payload.window_start.trim() : '';
-  const windowEnd = typeof payload.window_end === 'string' ? payload.window_end.trim() : '';
-  const dispatchSource = payload.dispatch_source;
+	const payload = value as Record<string, unknown>;
+	const watcherId = Number(payload.watcher_id);
+	const agentId =
+		typeof payload.agent_id === "string" ? payload.agent_id.trim() : "";
+	const windowStart =
+		typeof payload.window_start === "string" ? payload.window_start.trim() : "";
+	const windowEnd =
+		typeof payload.window_end === "string" ? payload.window_end.trim() : "";
+	const dispatchSource = payload.dispatch_source;
 
-  if (
-    !Number.isFinite(watcherId) ||
-    !agentId ||
-    !windowStart ||
-    !windowEnd ||
-    (dispatchSource !== 'scheduled' && dispatchSource !== 'manual')
-  ) {
-    return null;
-  }
+	if (
+		!Number.isFinite(watcherId) ||
+		!agentId ||
+		!windowStart ||
+		!windowEnd ||
+		(dispatchSource !== "scheduled" && dispatchSource !== "manual")
+	) {
+		return null;
+	}
 
-  // version_id was added when the watcher group-edit refactor introduced
-  // a per-run version snapshot. Older runs (queued before the change) have
-  // no version_id in approved_input — coerce to null and the agent loop
-  // falls back to current_version_id, matching pre-refactor behavior.
-  const rawVersionId = payload.version_id;
-  const versionId =
-    typeof rawVersionId === 'number' && Number.isFinite(rawVersionId)
-      ? rawVersionId
-      : typeof rawVersionId === 'string' && rawVersionId.trim() !== ''
-        ? Number(rawVersionId)
-        : null;
+	// version_id was added when the watcher group-edit refactor introduced
+	// a per-run version snapshot. Older runs (queued before the change) have
+	// no version_id in approved_input — coerce to null and the agent loop
+	// falls back to current_version_id, matching pre-refactor behavior.
+	const rawVersionId = payload.version_id;
+	const versionId =
+		typeof rawVersionId === "number" && Number.isFinite(rawVersionId)
+			? rawVersionId
+			: typeof rawVersionId === "string" && rawVersionId.trim() !== ""
+				? Number(rawVersionId)
+				: null;
 
-  const rawDeviceWorkerId = payload.device_worker_id;
-  const deviceWorkerId =
-    typeof rawDeviceWorkerId === 'string' && rawDeviceWorkerId.trim() !== ''
-      ? rawDeviceWorkerId.trim()
-      : null;
-  const rawAgentKind = payload.agent_kind;
-  const agentKind =
-    typeof rawAgentKind === 'string' && rawAgentKind.trim() !== ''
-      ? rawAgentKind.trim()
-      : null;
+	const rawDeviceWorkerId = payload.device_worker_id;
+	const deviceWorkerId =
+		typeof rawDeviceWorkerId === "string" && rawDeviceWorkerId.trim() !== ""
+			? rawDeviceWorkerId.trim()
+			: null;
+	const rawAgentKind = payload.agent_kind;
+	const agentKind =
+		typeof rawAgentKind === "string" && rawAgentKind.trim() !== ""
+			? rawAgentKind.trim()
+			: null;
 
-  return {
-    watcher_id: watcherId,
-    agent_id: agentId,
-    window_start: windowStart,
-    window_end: windowEnd,
-    dispatch_source: dispatchSource,
-    version_id: Number.isFinite(versionId as number) ? (versionId as number) : null,
-    device_worker_id: deviceWorkerId,
-    agent_kind: agentKind,
-  };
+	return {
+		watcher_id: watcherId,
+		agent_id: agentId,
+		window_start: windowStart,
+		window_end: windowEnd,
+		dispatch_source: dispatchSource,
+		version_id: Number.isFinite(versionId as number)
+			? (versionId as number)
+			: null,
+		device_worker_id: deviceWorkerId,
+		agent_kind: agentKind,
+	};
 }
 
 async function loadWatcherForAutomation(
-  sql: DbClient,
-  watcherId: number
+	sql: DbClient,
+	watcherId: number,
 ): Promise<DueWatcherRow | null> {
-  const rows = await sql<DueWatcherRow>`
+	const rows = await sql<DueWatcherRow>`
     SELECT id, organization_id, agent_id, schedule, status,
            device_worker_id::text AS device_worker_id, agent_kind
     FROM watchers
@@ -168,63 +180,67 @@ async function loadWatcherForAutomation(
     LIMIT 1
   `;
 
-  return rows[0] ?? null;
+	return rows[0] ?? null;
 }
 
 async function enqueueWatcherRunForRecord(
-  sql: DbClient,
-  watcher: DueWatcherRow,
-  dispatchSource: WatcherRunPayload['dispatch_source']
+	sql: DbClient,
+	watcher: DueWatcherRow,
+	dispatchSource: WatcherRunPayload["dispatch_source"],
 ): Promise<QueueWatcherRunResult> {
-  if ((watcher.status ?? 'active') !== 'active') {
-    throw new Error(`Watcher ${watcher.id} is not active.`);
-  }
+	if ((watcher.status ?? "active") !== "active") {
+		throw new Error(`Watcher ${watcher.id} is not active.`);
+	}
 
-  if (!watcher.agent_id) {
-    throw new Error(`Watcher ${watcher.id} is not assigned to a Lobu agent.`);
-  }
+	if (!watcher.agent_id) {
+		throw new Error(`Watcher ${watcher.id} is not assigned to a Lobu agent.`);
+	}
 
-  const granularity = inferWatcherGranularityFromSchedule(watcher.schedule);
-  const { windowStart, windowEnd } = await computePendingWindow(sql, watcher.id, granularity);
+	const granularity = inferWatcherGranularityFromSchedule(watcher.schedule);
+	const { windowStart, windowEnd } = await computePendingWindow(
+		sql,
+		watcher.id,
+		granularity,
+	);
 
-  const queued = await createWatcherRun(
-    {
-      organizationId: watcher.organization_id,
-      watcherId: watcher.id,
-      agentId: watcher.agent_id,
-      windowStart: windowStart.toISOString(),
-      windowEnd: windowEnd.toISOString(),
-      dispatchSource,
-      deviceWorkerId: watcher.device_worker_id ?? null,
-      agentKind: watcher.agent_kind ?? null,
-    },
-    sql
-  );
+	const queued = await createWatcherRun(
+		{
+			organizationId: watcher.organization_id,
+			watcherId: watcher.id,
+			agentId: watcher.agent_id,
+			windowStart: windowStart.toISOString(),
+			windowEnd: windowEnd.toISOString(),
+			dispatchSource,
+			deviceWorkerId: watcher.device_worker_id ?? null,
+			agentKind: watcher.agent_kind ?? null,
+		},
+		sql,
+	);
 
-  return queued;
+	return queued;
 }
 
 export async function enqueueWatcherRunForWatcher(
-  watcherId: number,
-  dispatchSource: WatcherRunPayload['dispatch_source'],
-  db?: DbClient
+	watcherId: number,
+	dispatchSource: WatcherRunPayload["dispatch_source"],
+	db?: DbClient,
 ): Promise<QueueWatcherRunResult> {
-  const sql = db ?? getDb();
-  const watcher = await loadWatcherForAutomation(sql, watcherId);
+	const sql = db ?? getDb();
+	const watcher = await loadWatcherForAutomation(sql, watcherId);
 
-  if (!watcher) {
-    throw new Error(`Watcher ${watcherId} not found.`);
-  }
+	if (!watcher) {
+		throw new Error(`Watcher ${watcherId} not found.`);
+	}
 
-  return enqueueWatcherRunForRecord(sql, watcher, dispatchSource);
+	return enqueueWatcherRunForRecord(sql, watcher, dispatchSource);
 }
 
 async function markWatcherRunFailedIdempotent(
-  sql: DbClient,
-  runId: number,
-  message: string
+	sql: DbClient,
+	runId: number,
+	message: string,
 ): Promise<void> {
-  const failedRows = await sql`
+	const failedRows = await sql`
     UPDATE runs
     SET status = 'failed',
         completed_at = current_timestamp,
@@ -233,17 +249,20 @@ async function markWatcherRunFailedIdempotent(
       AND status IN ('running', 'claimed', 'pending')
     RETURNING watcher_id
   `;
-  // Advance next_run_at on terminal failure too — otherwise a permanently
-  // broken watcher re-materializes + re-dispatches a fresh agent run every
-  // single minute forever (token/worker burn). Mirrors the feeds model: a
-  // failed run still moves the schedule forward by its normal cadence.
-  await advanceWatcherSchedule(sql, failedRows[0]?.watcher_id as number | undefined);
+	// Advance next_run_at on terminal failure too — otherwise a permanently
+	// broken watcher re-materializes + re-dispatches a fresh agent run every
+	// single minute forever (token/worker burn). Mirrors the feeds model: a
+	// failed run still moves the schedule forward by its normal cadence.
+	await advanceWatcherSchedule(
+		sql,
+		failedRows[0]?.watcher_id as number | undefined,
+	);
 }
 
 /**
  * Move a watcher's `next_run_at` forward by one cron tick. Reused by:
  *   - terminal-failure paths in this module (broken watcher shouldn't re-fire each minute)
- *   - manage_watchers(action="complete_window") on successful completion
+ *   - client.watchers.completeWindow on successful completion
  *   - the device-side `/api/workers/me/runs/:id/complete-watcher` endpoint
  *
  * Pass either the singleton `sql` client or a transaction handle from
@@ -252,40 +271,40 @@ async function markWatcherRunFailedIdempotent(
  * a missed schedule tick is preferable to failing the surrounding write.
  */
 export async function advanceWatcherSchedule(
-  sql: DbClient,
-  watcherId: number | undefined
+	sql: DbClient,
+	watcherId: number | undefined,
 ): Promise<void> {
-  if (watcherId === undefined || watcherId === null) return;
-  try {
-    const rows = await sql`
+	if (watcherId === undefined || watcherId === null) return;
+	try {
+		const rows = await sql`
       SELECT schedule, next_run_at
       FROM watchers
       WHERE id = ${watcherId}
       LIMIT 1
     `;
-    const schedule = (rows[0]?.schedule as string | null) ?? null;
-    if (!schedule) return;
-    const currentNextRunAt = (rows[0]?.next_run_at as string | null) ?? null;
-    const base = currentNextRunAt
-      ? new Date(Math.max(Date.now(), new Date(currentNextRunAt).getTime()))
-      : new Date();
-    await sql`
+		const schedule = (rows[0]?.schedule as string | null) ?? null;
+		if (!schedule) return;
+		const currentNextRunAt = (rows[0]?.next_run_at as string | null) ?? null;
+		const base = currentNextRunAt
+			? new Date(Math.max(Date.now(), new Date(currentNextRunAt).getTime()))
+			: new Date();
+		await sql`
       UPDATE watchers
       SET next_run_at = ${nextRunAt(schedule, base)}::timestamptz,
           updated_at = NOW()
       WHERE id = ${watcherId}
     `;
-  } catch (err) {
-    logger.warn(`[watchers] failed to advance next_run_at: ${err}`);
-  }
+	} catch (err) {
+		logger.warn(`[watchers] failed to advance next_run_at: ${err}`);
+	}
 }
 
 export async function getWatcherRunInfo(
-  runId: number,
-  db?: DbClient
+	runId: number,
+	db?: DbClient,
 ): Promise<ActiveWatcherRunInfo | null> {
-  const sql = db ?? getDb();
-  const rows = await sql`
+	const sql = db ?? getDb();
+	const rows = await sql`
     SELECT id as run_id, watcher_id, status, error_message
     FROM runs
     WHERE id = ${runId}
@@ -293,30 +312,32 @@ export async function getWatcherRunInfo(
     LIMIT 1
   `;
 
-  if (rows.length === 0) return null;
+	if (rows.length === 0) return null;
 
-  return {
-    run_id: Number((rows[0] as { run_id: unknown }).run_id),
-    watcher_id: Number((rows[0] as { watcher_id: unknown }).watcher_id),
-    status: String((rows[0] as { status: unknown }).status) as WatcherRunStatus,
-    error_message:
-      typeof (rows[0] as { error_message: unknown }).error_message === 'string'
-        ? String((rows[0] as { error_message: unknown }).error_message)
-        : null,
-  };
+	return {
+		run_id: Number((rows[0] as { run_id: unknown }).run_id),
+		watcher_id: Number((rows[0] as { watcher_id: unknown }).watcher_id),
+		status: String((rows[0] as { status: unknown }).status) as WatcherRunStatus,
+		error_message:
+			typeof (rows[0] as { error_message: unknown }).error_message === "string"
+				? String((rows[0] as { error_message: unknown }).error_message)
+				: null,
+	};
 }
 
-export async function reconcileWatcherRuns(db?: DbClient): Promise<ReconcileWatcherRunsResult> {
-  const sql = db ?? getDb();
-  // Canvas-on-events: an active run that already produced a canvas window (the
-  // completion committed the canvas_state event but the run status update didn't
-  // stick) is reconciled to 'completed'. A fresh completion stamps its run_id on
-  // the chain ROOT; a replace_existing completion stamps the superseding HEAD —
-  // so join runs → ANY canvas member on run_id and resolve the window identity
-  // via metadata.root_event_id (a root omits it → its own id). Scoped to
-  // canvas_state so it never matches tab_event/tab_snapshot BROWSER rows
-  // carrying run_id.
-  const rows = await sql`
+export async function reconcileWatcherRuns(
+	db?: DbClient,
+): Promise<ReconcileWatcherRunsResult> {
+	const sql = db ?? getDb();
+	// Canvas-on-events: an active run that already produced a canvas window (the
+	// completion committed the canvas_state event but the run status update didn't
+	// stick) is reconciled to 'completed'. A fresh completion stamps its run_id on
+	// the chain ROOT; a replace_existing completion stamps the superseding HEAD —
+	// so join runs → ANY canvas member on run_id and resolve the window identity
+	// via metadata.root_event_id (a root omits it → its own id). Scoped to
+	// canvas_state so it never matches tab_event/tab_snapshot BROWSER rows
+	// carrying run_id.
+	const rows = await sql`
     SELECT r.id, COALESCE((ww.metadata->>'root_event_id')::bigint, ww.id) AS window_id
     FROM runs r
     JOIN events ww
@@ -328,21 +349,21 @@ export async function reconcileWatcherRuns(db?: DbClient): Promise<ReconcileWatc
     LIMIT 100
   `;
 
-  let reconciled = 0;
+	let reconciled = 0;
 
-  for (const row of rows) {
-    const runId = Number((row as { id: unknown }).id);
-    const windowId = Number((row as { window_id: unknown }).window_id);
+	for (const row of rows) {
+		const runId = Number((row as { id: unknown }).id);
+		const windowId = Number((row as { window_id: unknown }).window_id);
 
-    await markWatcherRunCompleted(sql, runId, windowId);
-    reconciled++;
-  }
+		await markWatcherRunCompleted(sql, runId, windowId);
+		reconciled++;
+	}
 
-  // Find the (small) set of active watcher runs awaiting a dispatched
-  // message. If there are none — the common steady state — skip the heavy
-  // `chat_message` scan entirely instead of materializing every completed
-  // thread-response run ever.
-  const pendingDispatchRows = await sql`
+	// Find the (small) set of active watcher runs awaiting a dispatched
+	// message. If there are none — the common steady state — skip the heavy
+	// `chat_message` scan entirely instead of materializing every completed
+	// thread-response run ever.
+	const pendingDispatchRows = await sql`
     SELECT DISTINCT r.dispatched_message_id
     FROM runs r
     WHERE r.run_type = 'watcher'
@@ -350,18 +371,23 @@ export async function reconcileWatcherRuns(db?: DbClient): Promise<ReconcileWatc
       AND r.dispatched_message_id IS NOT NULL
     LIMIT 200
   `;
-  const pendingDispatchIds = pendingDispatchRows
-    .map((row) => (row as { dispatched_message_id?: unknown }).dispatched_message_id)
-    .filter((value): value is string => typeof value === 'string' && value.length > 0);
+	const pendingDispatchIds = pendingDispatchRows
+		.map(
+			(row) =>
+				(row as { dispatched_message_id?: unknown }).dispatched_message_id,
+		)
+		.filter(
+			(value): value is string => typeof value === "string" && value.length > 0,
+		);
 
-  if (pendingDispatchIds.length === 0) {
-    return { reconciled };
-  }
+	if (pendingDispatchIds.length === 0) {
+		return { reconciled };
+	}
 
-  // Drive the containment join from the small side (the pending dispatch ids)
-  // and bound the `chat_message` scan to recent completions — anything older
-  // is already handled by `sweepStaleWatcherRuns`.
-  const terminalRows = await sql`
+	// Drive the containment join from the small side (the pending dispatch ids)
+	// and bound the `chat_message` scan to recent completions — anything older
+	// is already handled by `sweepStaleWatcherRuns`.
+	const terminalRows = await sql`
     WITH response_payloads AS (
       SELECT
         CASE
@@ -387,16 +413,25 @@ export async function reconcileWatcherRuns(db?: DbClient): Promise<ReconcileWatc
     LIMIT 100
   `;
 
-  const completedMessageIds = terminalRows
-    .map((row) => (row as { dispatched_message_id?: unknown }).dispatched_message_id)
-    .filter((value): value is string => typeof value === 'string' && value.length > 0);
+	const completedMessageIds = terminalRows
+		.map(
+			(row) =>
+				(row as { dispatched_message_id?: unknown }).dispatched_message_id,
+		)
+		.filter(
+			(value): value is string => typeof value === "string" && value.length > 0,
+		);
 
-  if (completedMessageIds.length > 0) {
-    await resolveWatcherRunsByMessageIds(completedMessageIds, { ok: true }, sql);
-    reconciled += completedMessageIds.length;
-  }
+	if (completedMessageIds.length > 0) {
+		await resolveWatcherRunsByMessageIds(
+			completedMessageIds,
+			{ ok: true },
+			sql,
+		);
+		reconciled += completedMessageIds.length;
+	}
 
-  return { reconciled };
+	return { reconciled };
 }
 
 /**
@@ -432,23 +467,23 @@ export async function reconcileWatcherRuns(db?: DbClient): Promise<ReconcileWatc
  * (WATCHER_RUN_STALE_INTERVAL / WATCHER_RUN_HEARTBEAT_STALE_INTERVAL).
  */
 export async function sweepStaleWatcherRuns(
-  db?: DbClient
+	db?: DbClient,
 ): Promise<{ timedOut: number }> {
-  const sql = db ?? getDb();
-  const heartbeatStaleInterval = intervals.watcherRunHeartbeatStaleInterval;
-  const coarseStaleInterval = intervals.watcherRunStaleInterval;
-  const timedOut = await markStaleRunsAsTimeout(sql, {
-    runTypes: ['watcher'],
-    heartbeatSemantics: 'beat-after-claim',
-    heartbeatStaleInterval,
-    coarseStaleInterval,
-    heartbeatErrorMessage: `Watcher run heartbeat went silent for over ${heartbeatStaleInterval} — the executor crashed or was abandoned`,
-    coarseErrorMessage: `Watcher run exceeded ${coarseStaleInterval} without reaching terminal state`,
-  });
-  if (timedOut > 0) {
-    logger.warn({ timedOut }, '[watchers] Swept stale watcher runs');
-  }
-  return { timedOut };
+	const sql = db ?? getDb();
+	const heartbeatStaleInterval = intervals.watcherRunHeartbeatStaleInterval;
+	const coarseStaleInterval = intervals.watcherRunStaleInterval;
+	const timedOut = await markStaleRunsAsTimeout(sql, {
+		runTypes: ["watcher"],
+		heartbeatSemantics: "beat-after-claim",
+		heartbeatStaleInterval,
+		coarseStaleInterval,
+		heartbeatErrorMessage: `Watcher run heartbeat went silent for over ${heartbeatStaleInterval} — the executor crashed or was abandoned`,
+		coarseErrorMessage: `Watcher run exceeded ${coarseStaleInterval} without reaching terminal state`,
+	});
+	if (timedOut > 0) {
+		logger.warn({ timedOut }, "[watchers] Swept stale watcher runs");
+	}
+	return { timedOut };
 }
 
 /**
@@ -475,10 +510,10 @@ export async function sweepStaleWatcherRuns(
  * (WATCHER_ORPHANED_CLAIM_THRESHOLD, default 5 minutes).
  */
 async function resetOrphanedWatcherRuns(
-  db?: DbClient
+	db?: DbClient,
 ): Promise<{ reset: number }> {
-  const sql = db ?? getDb();
-  const result = await sql`
+	const sql = db ?? getDb();
+	const result = await sql`
     UPDATE runs
     SET status = 'pending',
         claimed_by = NULL,
@@ -491,33 +526,33 @@ async function resetOrphanedWatcherRuns(
       AND claimed_at < now() - ${intervals.watcherOrphanedClaimThreshold}::interval
       AND COALESCE(approved_input->>'dispatch_source', 'scheduled') = 'scheduled'
   `;
-  const reset = Number(result.count ?? 0);
-  if (reset > 0) {
-    logger.info({ reset }, '[watchers] Reset orphaned watcher runs');
-  }
-  return { reset };
+	const reset = Number(result.count ?? 0);
+	if (reset > 0) {
+		logger.info({ reset }, "[watchers] Reset orphaned watcher runs");
+	}
+	return { reset };
 }
 
 export async function materializeDueWatcherRuns(
-  _env: Env,
-  db?: DbClient
+	_env: Env,
+	db?: DbClient,
 ): Promise<MaterializeDueWatcherRunsResult> {
-  const sql = db ?? getDb();
+	const sql = db ?? getDb();
 
-  let unrunnable = 0;
+	let unrunnable = 0;
 
-  const counts = await materializeDueItems<DueWatcherRow>({
-    label: 'watcher-automation',
-    fetchDue: async () => {
-      // Only schedule watchers we can actually execute: either device-pinned (an
-      // external/device worker claims it via the poll lane — no cloud agent row
-      // needed) OR the assigned agent still exists in the org. A watcher whose
-      // `agents` row was deleted is otherwise materialized every cron tick and fails
-      // at dispatch ("Assigned agent ... does not exist"). Skipping at the source is
-      // self-healing: it resumes automatically if the agent is recreated. The
-      // dispatch-time `ensureWatcherAgentExists` check stays as a delete-after-select
-      // backstop.
-      const dueWatchers = await sql<DueWatcherRow>`
+	const counts = await materializeDueItems<DueWatcherRow>({
+		label: "watcher-automation",
+		fetchDue: async () => {
+			// Only schedule watchers we can actually execute: either device-pinned (an
+			// external/device worker claims it via the poll lane — no cloud agent row
+			// needed) OR the assigned agent still exists in the org. A watcher whose
+			// `agents` row was deleted is otherwise materialized every cron tick and fails
+			// at dispatch ("Assigned agent ... does not exist"). Skipping at the source is
+			// self-healing: it resumes automatically if the agent is recreated. The
+			// dispatch-time `ensureWatcherAgentExists` check stays as a delete-after-select
+			// backstop.
+			const dueWatchers = await sql<DueWatcherRow>`
         SELECT w.id, w.organization_id, w.agent_id, w.schedule,
                w.device_worker_id::text AS device_worker_id, w.agent_kind
         FROM watchers w
@@ -546,11 +581,11 @@ export async function materializeDueWatcherRuns(
         LIMIT 100
       `;
 
-      // Count (cheap, tiny table) due active watchers that this tick filtered out
-      // SOLELY for lacking a runnable executor — for visibility in the tick summary.
-      // Mirrors the dueWatchers predicate (incl. the no-active-run clause) so a ghost
-      // watcher that already has an in-flight run isn't double-counted here.
-      const [unrunnableRow] = await sql<{ count: number }>`
+			// Count (cheap, tiny table) due active watchers that this tick filtered out
+			// SOLELY for lacking a runnable executor — for visibility in the tick summary.
+			// Mirrors the dueWatchers predicate (incl. the no-active-run clause) so a ghost
+			// watcher that already has an in-flight run isn't double-counted here.
+			const [unrunnableRow] = await sql<{ count: number }>`
         SELECT count(*)::int AS count
         FROM watchers w
         WHERE w.status = 'active'
@@ -570,46 +605,50 @@ export async function materializeDueWatcherRuns(
               AND r.status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
           )
       `;
-      unrunnable = unrunnableRow?.count ?? 0;
+			unrunnable = unrunnableRow?.count ?? 0;
 
-      return dueWatchers;
-    },
-    createRun: async (watcher) => {
-      const result = await enqueueWatcherRunForRecord(sql, watcher, 'scheduled');
-      return result.created ? 'created' : 'skipped';
-    },
-    onError: async (watcher, error) => {
-      logger.error(
-        { error, watcherId: watcher.id },
-        '[watcher-automation] Failed to materialize due watcher run'
-      );
-      // Don't leave next_run_at in the past — that would re-select this watcher
-      // on every 60s tick. Push it forward per the watcher's cron schedule.
-      await advanceWatcherSchedule(sql, watcher.id);
-    },
-  });
+			return dueWatchers;
+		},
+		createRun: async (watcher) => {
+			const result = await enqueueWatcherRunForRecord(
+				sql,
+				watcher,
+				"scheduled",
+			);
+			return result.created ? "created" : "skipped";
+		},
+		onError: async (watcher, error) => {
+			logger.error(
+				{ error, watcherId: watcher.id },
+				"[watcher-automation] Failed to materialize due watcher run",
+			);
+			// Don't leave next_run_at in the past — that would re-select this watcher
+			// on every 60s tick. Push it forward per the watcher's cron schedule.
+			await advanceWatcherSchedule(sql, watcher.id);
+		},
+	});
 
-  return {
-    dueWatchers: counts.due,
-    runsCreated: counts.runsCreated,
-    skipped: counts.skipped,
-    unrunnable,
-  };
+	return {
+		dueWatchers: counts.due,
+		runsCreated: counts.runsCreated,
+		skipped: counts.skipped,
+		unrunnable,
+	};
 }
 
 interface WatcherAutomationTickResult {
-  reset: number | null;
-  reconciled: number | null;
-  dueWatchers: number | null;
-  runsCreated: number | null;
-  skipped: number | null;
-  unrunnable: number | null;
-  claimed: number | null;
-  dispatched: number | null;
-  dispatchReconciled: number | null;
-  failed: number | null;
-  /** Phases that threw this tick (empty on a clean tick). */
-  errors: string[];
+	reset: number | null;
+	reconciled: number | null;
+	dueWatchers: number | null;
+	runsCreated: number | null;
+	skipped: number | null;
+	unrunnable: number | null;
+	claimed: number | null;
+	dispatched: number | null;
+	dispatchReconciled: number | null;
+	failed: number | null;
+	/** Phases that threw this tick (empty on a clean tick). */
+	errors: string[];
 }
 
 /**
@@ -622,116 +661,139 @@ interface WatcherAutomationTickResult {
  * Extracted from the scheduler registration so the orchestration is unit/integration
  * testable without standing up the full TaskScheduler.
  */
-export async function runWatcherAutomationTick(env: Env): Promise<WatcherAutomationTickResult> {
-  const errors: string[] = [];
-  const phase = async <T>(name: string, fn: () => Promise<T>): Promise<T | null> => {
-    try {
-      return await fn();
-    } catch (err) {
-      errors.push(name);
-      logger.error({ err, phase: name }, '[watcher-automation] phase failed');
-      return null;
-    }
-  };
+export async function runWatcherAutomationTick(
+	env: Env,
+): Promise<WatcherAutomationTickResult> {
+	const errors: string[] = [];
+	const phase = async <T>(
+		name: string,
+		fn: () => Promise<T>,
+	): Promise<T | null> => {
+		try {
+			return await fn();
+		} catch (err) {
+			errors.push(name);
+			logger.error({ err, phase: name }, "[watcher-automation] phase failed");
+			return null;
+		}
+	};
 
-  const reset = await phase('reset', () => resetOrphanedWatcherRuns());
-  const reconciliation = await phase('reconcile', () => reconcileWatcherRuns());
-  const materialize = await phase('materialize', () => materializeDueWatcherRuns(env));
-  const dispatch = await phase('dispatch', () => dispatchPendingWatcherRuns(env));
+	const reset = await phase("reset", () => resetOrphanedWatcherRuns());
+	const reconciliation = await phase("reconcile", () => reconcileWatcherRuns());
+	const materialize = await phase("materialize", () =>
+		materializeDueWatcherRuns(env),
+	);
+	const dispatch = await phase("dispatch", () =>
+		dispatchPendingWatcherRuns(env),
+	);
 
-  // Emit health metrics. The scheduler-level success/error counter can't see
-  // these because this tick swallows phase errors (returns them in `errors`),
-  // so surface phase failures + materialization health explicitly for alerting.
-  for (const failedPhase of errors) {
-    incrementCounter('lobu_watcher_automation_phase_failures_total', { phase: failedPhase });
-  }
-  if (materialize?.runsCreated) {
-    incrementCounter('lobu_watcher_runs_created_total', {}, materialize.runsCreated);
-  }
-  if (materialize) {
-    setGauge('lobu_watchers_unrunnable', materialize.unrunnable);
-  }
+	// Emit health metrics. The scheduler-level success/error counter can't see
+	// these because this tick swallows phase errors (returns them in `errors`),
+	// so surface phase failures + materialization health explicitly for alerting.
+	for (const failedPhase of errors) {
+		incrementCounter("lobu_watcher_automation_phase_failures_total", {
+			phase: failedPhase,
+		});
+	}
+	if (materialize?.runsCreated) {
+		incrementCounter(
+			"lobu_watcher_runs_created_total",
+			{},
+			materialize.runsCreated,
+		);
+	}
+	if (materialize) {
+		setGauge("lobu_watchers_unrunnable", materialize.unrunnable);
+	}
 
-  return {
-    reset: reset?.reset ?? null,
-    reconciled: reconciliation?.reconciled ?? null,
-    dueWatchers: materialize?.dueWatchers ?? null,
-    runsCreated: materialize?.runsCreated ?? null,
-    skipped: materialize?.skipped ?? null,
-    unrunnable: materialize?.unrunnable ?? null,
-    claimed: dispatch?.claimed ?? null,
-    dispatched: dispatch?.dispatched ?? null,
-    dispatchReconciled: dispatch?.reconciled ?? null,
-    failed: dispatch?.failed ?? null,
-    errors,
-  };
+	return {
+		reset: reset?.reset ?? null,
+		reconciled: reconciliation?.reconciled ?? null,
+		dueWatchers: materialize?.dueWatchers ?? null,
+		runsCreated: materialize?.runsCreated ?? null,
+		skipped: materialize?.skipped ?? null,
+		unrunnable: materialize?.unrunnable ?? null,
+		claimed: dispatch?.claimed ?? null,
+		dispatched: dispatch?.dispatched ?? null,
+		dispatchReconciled: dispatch?.reconciled ?? null,
+		failed: dispatch?.failed ?? null,
+		errors,
+	};
 }
 
 function buildDispatchMessage(params: {
-  watcherId: number;
-  runId: number;
-  agentId: string;
-  sessionAgentId: string;
-  payload: WatcherRunPayload;
+	watcherId: number;
+	runId: number;
+	agentId: string;
+	sessionAgentId: string;
+	payload: WatcherRunPayload;
 }): string {
-  const readKnowledgeSince = new Date(params.payload.window_start).toISOString().split('T')[0];
-  const readKnowledgeUntil = new Date(new Date(params.payload.window_end).getTime() - 1)
-    .toISOString()
-    .split('T')[0];
+	const readKnowledgeSince = new Date(params.payload.window_start)
+		.toISOString()
+		.split("T")[0];
+	const readKnowledgeUntil = new Date(
+		new Date(params.payload.window_end).getTime() - 1,
+	)
+		.toISOString()
+		.split("T")[0];
 
-  return [
-    'Run this watcher now using the lobu-memory MCP tools.',
-    '',
-    `Watcher ID: ${params.watcherId}`,
-    `Watcher run ID: ${params.runId}`,
-    `Assigned agent ID: ${params.agentId}`,
-    `Session agent ID: ${params.sessionAgentId}`,
-    `Queued window start: ${params.payload.window_start}`,
-    `Queued window end: ${params.payload.window_end}`,
-    `Dispatch source: ${params.payload.dispatch_source}`,
-    ...(params.payload.version_id != null
-      ? [`Pinned template version id: ${params.payload.version_id}`]
-      : []),
-    '',
-    'Required steps:',
-    `1. Call query_sdk with a script that runs client.knowledge.read({ watcher_id: ${params.watcherId}, since: "${readKnowledgeSince}", until: "${readKnowledgeUntil}"${params.payload.version_id != null ? `, template_version_id: ${params.payload.version_id}` : ''} }).`,
-    '2. Analyze the returned content using prompt_rendered and extraction_schema.',
-    `3. Call run_sdk with a script that runs client.watchers.completeWindow({ window_token, extracted_data, watcher_run_id: ${params.runId}${params.payload.version_id != null ? `, template_version_id: ${params.payload.version_id}` : ''} }) using the window_token from step 1.`,
-    '4. Include this run_metadata object in complete_window exactly, and add any extra provider/job fields you know:',
-    JSON.stringify(
-      {
-        executor: 'lobu-agent',
-        agent_id: params.agentId,
-        watcher_run_id: params.runId,
-        dispatch_source: params.payload.dispatch_source,
-        session_agent_id: params.sessionAgentId,
-      },
-      null,
-      2
-    ),
-    '',
-    'If there is no content, do not fabricate results.',
-  ].join('\n');
+	return [
+		"Run this watcher now using the lobu-memory MCP tools.",
+		"",
+		`Watcher ID: ${params.watcherId}`,
+		`Watcher run ID: ${params.runId}`,
+		`Assigned agent ID: ${params.agentId}`,
+		`Session agent ID: ${params.sessionAgentId}`,
+		`Queued window start: ${params.payload.window_start}`,
+		`Queued window end: ${params.payload.window_end}`,
+		`Dispatch source: ${params.payload.dispatch_source}`,
+		...(params.payload.version_id != null
+			? [`Pinned template version id: ${params.payload.version_id}`]
+			: []),
+		"",
+		"Required steps:",
+		`1. Call query_sdk with a script that runs client.knowledge.read({ watcher_id: ${params.watcherId}, since: "${readKnowledgeSince}", until: "${readKnowledgeUntil}"${params.payload.version_id != null ? `, template_version_id: ${params.payload.version_id}` : ""} }).`,
+		"2. Analyze the returned content using prompt_rendered and extraction_schema.",
+		`3. Call run_sdk with a script that runs client.watchers.completeWindow({ window_token, extracted_data, watcher_run_id: ${params.runId}${params.payload.version_id != null ? `, template_version_id: ${params.payload.version_id}` : ""} }) using the window_token from step 1.`,
+		"4. Include this run_metadata object in complete_window exactly, and add any extra provider/job fields you know:",
+		JSON.stringify(
+			{
+				executor: "lobu-agent",
+				agent_id: params.agentId,
+				watcher_run_id: params.runId,
+				dispatch_source: params.payload.dispatch_source,
+				session_agent_id: params.sessionAgentId,
+			},
+			null,
+			2,
+		),
+		"",
+		"If there is no content, do not fabricate results.",
+	].join("\n");
 }
 
-async function failWatcherRun(sql: DbClient, runId: number, message: string): Promise<void> {
-  await markWatcherRunFailedIdempotent(sql, runId, message);
+async function failWatcherRun(
+	sql: DbClient,
+	runId: number,
+	message: string,
+): Promise<void> {
+	await markWatcherRunFailedIdempotent(sql, runId, message);
 }
 
 async function claimWatcherRun(
-  sql: DbClient,
-  runId?: number
+	sql: DbClient,
+	runId?: number,
 ): Promise<ClaimedWatcherRunRow | null> {
-  return sql.begin(async (tx) => {
-    const specificRunClause = runId ? tx`AND r.id = ${runId}` : tx``;
-    // Skip runs pinned to a device worker (#802): the user's Mac (or other
-    // device) will claim these via /api/workers/poll. Without this filter the
-    // server-side dispatcher races the device worker for the same row — the
-    // exact failure mode that caused the watcher-run silent-success bug.
-    // The pin currently lives in approved_input JSONB (issue #799 will add a
-    // proper column); both shapes are guarded here so the filter survives
-    // either schema.
-    const claimed = await tx`
+	return sql.begin(async (tx) => {
+		const specificRunClause = runId ? tx`AND r.id = ${runId}` : tx``;
+		// Skip runs pinned to a device worker (#802): the user's Mac (or other
+		// device) will claim these via /api/workers/poll. Without this filter the
+		// server-side dispatcher races the device worker for the same row — the
+		// exact failure mode that caused the watcher-run silent-success bug.
+		// The pin currently lives in approved_input JSONB (issue #799 will add a
+		// proper column); both shapes are guarded here so the filter survives
+		// either schema.
+		const claimed = await tx`
       WITH next_run AS (
         SELECT r.id
         FROM runs r
@@ -755,15 +817,18 @@ async function claimWatcherRun(
       RETURNING r.id, r.organization_id, r.watcher_id, r.approved_input
     `;
 
-    if (claimed.length === 0) return null;
+		if (claimed.length === 0) return null;
 
-    return {
-      id: Number((claimed[0] as { id: unknown }).id),
-      organization_id: String((claimed[0] as { organization_id: unknown }).organization_id),
-      watcher_id: Number((claimed[0] as { watcher_id: unknown }).watcher_id),
-      approved_input: (claimed[0] as { approved_input: unknown }).approved_input,
-    };
-  });
+		return {
+			id: Number((claimed[0] as { id: unknown }).id),
+			organization_id: String(
+				(claimed[0] as { organization_id: unknown }).organization_id,
+			),
+			watcher_id: Number((claimed[0] as { watcher_id: unknown }).watcher_id),
+			approved_input: (claimed[0] as { approved_input: unknown })
+				.approved_input,
+		};
+	});
 }
 
 /**
@@ -775,25 +840,25 @@ async function claimWatcherRun(
  * caller falls through to the agent/org default.
  */
 async function getWatcherModelOverride(
-  sql: DbClient,
-  watcherId: number
+	sql: DbClient,
+	watcherId: number,
 ): Promise<string | undefined> {
-  const rows = await sql`
+	const rows = await sql`
     SELECT execution_config->>'model' AS model
     FROM watchers
     WHERE id = ${watcherId}
     LIMIT 1
   `;
-  const model = rows[0]?.model as string | null | undefined;
-  return typeof model === 'string' && model.trim() ? model.trim() : undefined;
+	const model = rows[0]?.model as string | null | undefined;
+	return typeof model === "string" && model.trim() ? model.trim() : undefined;
 }
 
 async function ensureWatcherAgentExists(
-  sql: DbClient,
-  organizationId: string,
-  agentId: string
+	sql: DbClient,
+	organizationId: string,
+	agentId: string,
 ): Promise<boolean> {
-  const rows = await sql`
+	const rows = await sql`
     SELECT 1
     FROM agents
     WHERE id = ${agentId}
@@ -801,166 +866,197 @@ async function ensureWatcherAgentExists(
     LIMIT 1
   `;
 
-  return rows.length > 0;
+	return rows.length > 0;
 }
 
-const LOBU_MEMORY_MCP_ID = 'lobu-memory';
+const LOBU_MEMORY_MCP_ID = "lobu-memory";
 // Watcher agents reach knowledge reads + complete_window via query_sdk / run_sdk
 // now that flat admin tools are omitted from MCP tools/list.
-const WATCHER_REQUIRED_TOOLS = ['query_sdk', 'run_sdk'];
+const WATCHER_REQUIRED_TOOLS = ["query_sdk", "run_sdk"];
 
 async function preflightWatcherMemoryTools(params: {
-  organizationId: string;
-  agentId: string;
-  runId: number;
+	organizationId: string;
+	agentId: string;
+	runId: number;
 }): Promise<{ ok: true } | { ok: false; error: string }> {
-  const conversationId = `${params.agentId}_watcher_${params.runId}_preflight`;
-  const token = generateWorkerToken(params.agentId, conversationId, `watcher-${params.runId}`, {
-    channelId: `api_watcher_${params.runId}`,
-    agentId: params.agentId,
-    organizationId: params.organizationId,
-    platform: 'api',
-    sessionKey: `watcher_${params.runId}`,
-  });
-  const url = `${getInternalGatewayUrl()}/mcp/${LOBU_MEMORY_MCP_ID}/tools`;
+	const conversationId = `${params.agentId}_watcher_${params.runId}_preflight`;
+	const token = generateWorkerToken(
+		params.agentId,
+		conversationId,
+		`watcher-${params.runId}`,
+		{
+			channelId: `api_watcher_${params.runId}`,
+			agentId: params.agentId,
+			organizationId: params.organizationId,
+			platform: "api",
+			sessionKey: `watcher_${params.runId}`,
+		},
+	);
+	const url = `${getInternalGatewayUrl()}/mcp/${LOBU_MEMORY_MCP_ID}/tools`;
 
-  try {
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    const body = (await response.json().catch(() => null)) as
-      | { tools?: Array<{ name?: unknown }>; error?: unknown }
-      | null;
+	try {
+		const response = await fetch(url, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		const body = (await response.json().catch(() => null)) as {
+			tools?: Array<{ name?: unknown }>;
+			error?: unknown;
+		} | null;
 
-    if (!response.ok) {
-      const detail = typeof body?.error === 'string' ? body.error : response.statusText;
-      return {
-        ok: false,
-        error: `${LOBU_MEMORY_MCP_ID} tools preflight failed (${response.status}): ${detail}`,
-      };
-    }
+		if (!response.ok) {
+			const detail =
+				typeof body?.error === "string" ? body.error : response.statusText;
+			return {
+				ok: false,
+				error: `${LOBU_MEMORY_MCP_ID} tools preflight failed (${response.status}): ${detail}`,
+			};
+		}
 
-    const toolNames = new Set(
-      (body?.tools ?? [])
-        .map((tool) => (typeof tool.name === 'string' ? tool.name : ''))
-        .filter(Boolean)
-    );
-    const missing = WATCHER_REQUIRED_TOOLS.filter((name) => !toolNames.has(name));
-    if (missing.length > 0) {
-      return {
-        ok: false,
-        error: `${LOBU_MEMORY_MCP_ID} tools preflight failed: missing ${missing.join(', ')}`,
-      };
-    }
+		const toolNames = new Set(
+			(body?.tools ?? [])
+				.map((tool) => (typeof tool.name === "string" ? tool.name : ""))
+				.filter(Boolean),
+		);
+		const missing = WATCHER_REQUIRED_TOOLS.filter(
+			(name) => !toolNames.has(name),
+		);
+		if (missing.length > 0) {
+			return {
+				ok: false,
+				error: `${LOBU_MEMORY_MCP_ID} tools preflight failed: missing ${missing.join(", ")}`,
+			};
+		}
 
-    return { ok: true };
-  } catch (error) {
-    return {
-      ok: false,
-      error: `${LOBU_MEMORY_MCP_ID} tools preflight failed: ${getErrorMessage(error)}`,
-    };
-  }
+		return { ok: true };
+	} catch (error) {
+		return {
+			ok: false,
+			error: `${LOBU_MEMORY_MCP_ID} tools preflight failed: ${getErrorMessage(error)}`,
+		};
+	}
 }
 
 async function dispatchWatcherRun(
-  sql: DbClient,
-  run: ClaimedWatcherRunRow
-): Promise<'reconciled' | 'dispatched' | 'failed'> {
-  const payload = parseWatcherRunPayload(run.approved_input);
-  if (!payload) {
-    await failWatcherRun(sql, run.id, 'Watcher run is missing a valid dispatch payload.');
-    return 'failed';
-  }
+	sql: DbClient,
+	run: ClaimedWatcherRunRow,
+): Promise<"reconciled" | "dispatched" | "failed"> {
+	const payload = parseWatcherRunPayload(run.approved_input);
+	if (!payload) {
+		await failWatcherRun(
+			sql,
+			run.id,
+			"Watcher run is missing a valid dispatch payload.",
+		);
+		return "failed";
+	}
 
-  // Already-produced window for this exact run (e.g. retry after crash).
-  const existingWindowId = await findWindowIdForRun(sql, run.id);
-  if (existingWindowId) {
-    await markWatcherRunCompleted(sql, run.id, existingWindowId);
-    return 'reconciled';
-  }
+	// Already-produced window for this exact run (e.g. retry after crash).
+	const existingWindowId = await findWindowIdForRun(sql, run.id);
+	if (existingWindowId) {
+		await markWatcherRunCompleted(sql, run.id, existingWindowId);
+		return "reconciled";
+	}
 
-  if (!(await ensureWatcherAgentExists(sql, run.organization_id, payload.agent_id))) {
-    await failWatcherRun(
-      sql,
-      run.id,
-      `Assigned agent "${payload.agent_id}" does not exist in this organization.`
-    );
-    return 'failed';
-  }
+	if (
+		!(await ensureWatcherAgentExists(
+			sql,
+			run.organization_id,
+			payload.agent_id,
+		))
+	) {
+		await failWatcherRun(
+			sql,
+			run.id,
+			`Assigned agent "${payload.agent_id}" does not exist in this organization.`,
+		);
+		return "failed";
+	}
 
-  if (!isLobuGatewayRunning()) {
-    await failWatcherRun(sql, run.id, 'Embedded Lobu is not available.');
-    return 'failed';
-  }
+	if (!isLobuGatewayRunning()) {
+		await failWatcherRun(sql, run.id, "Embedded Lobu is not available.");
+		return "failed";
+	}
 
-  const serviceToken = await getLobuServiceToken(run.organization_id);
-  if (!serviceToken) {
-    await failWatcherRun(sql, run.id, 'Failed to generate an embedded Lobu service token.');
-    return 'failed';
-  }
+	const serviceToken = await getLobuServiceToken(run.organization_id);
+	if (!serviceToken) {
+		await failWatcherRun(
+			sql,
+			run.id,
+			"Failed to generate an embedded Lobu service token.",
+		);
+		return "failed";
+	}
 
-  const preflight = await preflightWatcherMemoryTools({
-    organizationId: run.organization_id,
-    agentId: payload.agent_id,
-    runId: run.id,
-  });
-  if (!preflight.ok) {
-    await failWatcherRun(sql, run.id, preflight.error);
-    return 'failed';
-  }
+	const preflight = await preflightWatcherMemoryTools({
+		organizationId: run.organization_id,
+		agentId: payload.agent_id,
+		runId: run.id,
+	});
+	if (!preflight.ok) {
+		await failWatcherRun(sql, run.id, preflight.error);
+		return "failed";
+	}
 
-  // Per-watcher model override lives in watchers.execution_config.model (a
-  // `provider/model` ref or "auto"). When set it rides the dispatch message so
-  // agent.ts reads it into baseOptions.model and it wins the layered fallback
-  // (behavior → agent → org default); when absent the agent/org default resolves.
-  const watcherModel = await getWatcherModelOverride(sql, run.watcher_id);
+	// Per-watcher model override lives in watchers.execution_config.model (a
+	// `provider/model` ref or "auto"). When set it rides the dispatch message so
+	// agent.ts reads it into baseOptions.model and it wins the layered fallback
+	// (behavior → agent → org default); when absent the agent/org default resolves.
+	const watcherModel = await getWatcherModelOverride(sql, run.watcher_id);
 
-  const baseUrl = `${getInternalGatewayUrl()}/api/v1/agents`;
-  const headers = {
-    Authorization: `Bearer ${serviceToken}`,
-    'Content-Type': 'application/json',
-  };
-  const messageId = randomUUID();
+	const baseUrl = `${getInternalGatewayUrl()}/api/v1/agents`;
+	const headers = {
+		Authorization: `Bearer ${serviceToken}`,
+		"Content-Type": "application/json",
+	};
+	const messageId = randomUUID();
 
-  try {
-    const sessionResponse = await fetch(baseUrl, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        agentId: payload.agent_id,
-        userId: `watcher-${run.id}`,
-        thread: `watcher-${run.id}`,
-        forceNew: true,
-        dryRun: false,
-        intent: { kind: 'watcher_run', runId: run.id, watcherId: run.watcher_id },
-      }),
-    });
+	try {
+		const sessionResponse = await fetch(baseUrl, {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				agentId: payload.agent_id,
+				userId: `watcher-${run.id}`,
+				thread: `watcher-${run.id}`,
+				forceNew: true,
+				dryRun: false,
+				intent: {
+					kind: "watcher_run",
+					runId: run.id,
+					watcherId: run.watcher_id,
+				},
+			}),
+		});
 
-    if (!sessionResponse.ok) {
-      const body = await sessionResponse.text();
-      await failWatcherRun(
-        sql,
-        run.id,
-        `Failed to create or resume Lobu agent session (${sessionResponse.status}): ${body || 'unknown error'}`
-      );
-      return 'failed';
-    }
+		if (!sessionResponse.ok) {
+			const body = await sessionResponse.text();
+			await failWatcherRun(
+				sql,
+				run.id,
+				`Failed to create or resume Lobu agent session (${sessionResponse.status}): ${body || "unknown error"}`,
+			);
+			return "failed";
+		}
 
-    const sessionBody = (await sessionResponse.json()) as {
-      agentId?: string;
-      messagesUrl?: string;
-    };
-    const sessionAgentId = sessionBody.agentId?.trim();
-    const messagesUrl = sessionBody.messagesUrl?.trim();
+		const sessionBody = (await sessionResponse.json()) as {
+			agentId?: string;
+			messagesUrl?: string;
+		};
+		const sessionAgentId = sessionBody.agentId?.trim();
+		const messagesUrl = sessionBody.messagesUrl?.trim();
 
-    if (!sessionAgentId || !messagesUrl) {
-      await failWatcherRun(sql, run.id, 'Embedded Lobu returned an incomplete agent session.');
-      return 'failed';
-    }
+		if (!sessionAgentId || !messagesUrl) {
+			await failWatcherRun(
+				sql,
+				run.id,
+				"Embedded Lobu returned an incomplete agent session.",
+			);
+			return "failed";
+		}
 
-    // Mark the run 'running' with a durable message correlation BEFORE posting,
-    // so a late completion event arriving mid-POST has somewhere to land.
-    await sql`
+		// Mark the run 'running' with a durable message correlation BEFORE posting,
+		// so a late completion event arriving mid-POST has somewhere to land.
+		await sql`
       UPDATE runs
       SET status = 'running',
           claimed_by = ${`lobu:${payload.agent_id}`},
@@ -969,104 +1065,114 @@ async function dispatchWatcherRun(
       WHERE id = ${run.id}
     `;
 
-    const messageResponse = await fetch(messagesUrl, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        messageId,
-        ...(watcherModel ? { model: watcherModel } : {}),
-        content: buildDispatchMessage({
-          watcherId: run.watcher_id,
-          runId: run.id,
-          agentId: payload.agent_id,
-          sessionAgentId,
-          payload,
-        }),
-      }),
-    });
+		const messageResponse = await fetch(messagesUrl, {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				messageId,
+				...(watcherModel ? { model: watcherModel } : {}),
+				content: buildDispatchMessage({
+					watcherId: run.watcher_id,
+					runId: run.id,
+					agentId: payload.agent_id,
+					sessionAgentId,
+					payload,
+				}),
+			}),
+		});
 
-    if (!messageResponse.ok) {
-      const body = await messageResponse.text();
-      await failWatcherRun(
-        sql,
-        run.id,
-        `Failed to enqueue Lobu watcher message (${messageResponse.status}): ${body || 'unknown error'}`
-      );
-      return 'failed';
-    }
+		if (!messageResponse.ok) {
+			const body = await messageResponse.text();
+			await failWatcherRun(
+				sql,
+				run.id,
+				`Failed to enqueue Lobu watcher message (${messageResponse.status}): ${body || "unknown error"}`,
+			);
+			return "failed";
+		}
 
-    return 'dispatched';
-  } catch (error) {
-    await failWatcherRun(
-      sql,
-      run.id,
-      error instanceof Error ? error.message : 'Unexpected Lobu dispatch failure.'
-    );
-    return 'failed';
-  }
+		return "dispatched";
+	} catch (error) {
+		await failWatcherRun(
+			sql,
+			run.id,
+			error instanceof Error
+				? error.message
+				: "Unexpected Lobu dispatch failure.",
+		);
+		return "failed";
+	}
 }
 
 export async function dispatchPendingWatcherRuns(
-  _env: Env,
-  options?: { db?: DbClient; runIds?: number[] }
+	_env: Env,
+	options?: { db?: DbClient; runIds?: number[] },
 ): Promise<DispatchWatcherRunsResult> {
-  const sql = options?.db ?? getDb();
-  const requestedRunIds = options?.runIds?.filter((value) => Number.isFinite(value)) ?? [];
+	const sql = options?.db ?? getDb();
+	const requestedRunIds =
+		options?.runIds?.filter((value) => Number.isFinite(value)) ?? [];
 
-  let claimed = 0;
-  let dispatched = 0;
-  let reconciled = 0;
-  let failed = 0;
+	let claimed = 0;
+	let dispatched = 0;
+	let reconciled = 0;
+	let failed = 0;
 
-  if (requestedRunIds.length > 0) {
-    for (const runId of requestedRunIds) {
-      const run = await claimWatcherRun(sql, runId);
-      if (!run) continue;
+	if (requestedRunIds.length > 0) {
+		for (const runId of requestedRunIds) {
+			const run = await claimWatcherRun(sql, runId);
+			if (!run) continue;
 
-      claimed++;
-      const outcome = await dispatchWatcherRun(sql, run);
-      if (outcome === 'dispatched') dispatched++;
-      if (outcome === 'reconciled') reconciled++;
-      if (outcome === 'failed') failed++;
-    }
+			claimed++;
+			const outcome = await dispatchWatcherRun(sql, run);
+			if (outcome === "dispatched") dispatched++;
+			if (outcome === "reconciled") reconciled++;
+			if (outcome === "failed") failed++;
+		}
 
-    return { claimed, dispatched, reconciled, failed };
-  }
+		return { claimed, dispatched, reconciled, failed };
+	}
 
-  while (claimed < 100) {
-    const run = await claimWatcherRun(sql);
-    if (!run) break;
+	while (claimed < 100) {
+		const run = await claimWatcherRun(sql);
+		if (!run) break;
 
-    claimed++;
-    const outcome = await dispatchWatcherRun(sql, run);
-    if (outcome === 'dispatched') dispatched++;
-    if (outcome === 'reconciled') reconciled++;
-    if (outcome === 'failed') failed++;
-  }
+		claimed++;
+		const outcome = await dispatchWatcherRun(sql, run);
+		if (outcome === "dispatched") dispatched++;
+		if (outcome === "reconciled") reconciled++;
+		if (outcome === "failed") failed++;
+	}
 
-  return { claimed, dispatched, reconciled, failed };
+	return { claimed, dispatched, reconciled, failed };
 }
 
 export async function queueAndDispatchWatcherRun(
-  watcherId: number,
-  dispatchSource: WatcherRunPayload['dispatch_source'],
-  env: Env,
-  db?: DbClient
+	watcherId: number,
+	dispatchSource: WatcherRunPayload["dispatch_source"],
+	env: Env,
+	db?: DbClient,
 ): Promise<{
-  runId: number;
-  status: string;
-  created: boolean;
-  dispatch: DispatchWatcherRunsResult;
+	runId: number;
+	status: string;
+	created: boolean;
+	dispatch: DispatchWatcherRunsResult;
 }> {
-  const sql = db ?? getDb();
-  const queued = await enqueueWatcherRunForWatcher(watcherId, dispatchSource, sql);
-  const dispatch = await dispatchPendingWatcherRuns(env, { db: sql, runIds: [queued.runId] });
-  const runInfo = await getWatcherRunInfo(queued.runId, sql);
+	const sql = db ?? getDb();
+	const queued = await enqueueWatcherRunForWatcher(
+		watcherId,
+		dispatchSource,
+		sql,
+	);
+	const dispatch = await dispatchPendingWatcherRuns(env, {
+		db: sql,
+		runIds: [queued.runId],
+	});
+	const runInfo = await getWatcherRunInfo(queued.runId, sql);
 
-  return {
-    runId: queued.runId,
-    status: runInfo?.status ?? queued.status,
-    created: queued.created,
-    dispatch,
-  };
+	return {
+		runId: queued.runId,
+		status: runInfo?.status ?? queued.status,
+		created: queued.created,
+		dispatch,
+	};
 }

--- a/packages/server/src/watchers/run-completion.ts
+++ b/packages/server/src/watchers/run-completion.ts
@@ -1,7 +1,7 @@
-import type { DbClient } from '../db/client';
-import { getDb, pgTextArray } from '../db/client';
-import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../utils/run-statuses';
-import logger from '../utils/logger';
+import type { DbClient } from "../db/client";
+import { getDb, pgTextArray } from "../db/client";
+import logger from "../utils/logger";
+import { ACTIVE_RUN_STATUSES, runStatusLiteral } from "../utils/run-statuses";
 
 type WatcherTerminalResult = { ok: true } | { ok: false; error: string };
 
@@ -22,10 +22,10 @@ type WatcherTerminalResult = { ok: true } | { ok: false; error: string };
  * the remaining follow-up (the CLI doesn't expose execution_config yet).
  */
 const MAX_FINALIZE_NUDGES: number = (() => {
-  const raw = process.env.LOBU_WATCHER_FINALIZE_NUDGES;
-  if (raw === undefined) return 1;
-  const n = Number(raw);
-  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 1;
+	const raw = process.env.LOBU_WATCHER_FINALIZE_NUDGES;
+	if (raw === undefined) return 1;
+	const n = Number(raw);
+	return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 1;
 })();
 
 /**
@@ -34,24 +34,27 @@ const MAX_FINALIZE_NUDGES: number = (() => {
  * Clamped defensively in case a raw DB value sits outside the schema's range.
  */
 function resolveFinalizeNudgeBudget(
-  executionConfig: Record<string, unknown> | null | undefined
+	executionConfig: Record<string, unknown> | null | undefined,
 ): number {
-  const override = executionConfig?.finalize_nudges;
-  if (typeof override === 'number' && Number.isFinite(override)) {
-    return Math.min(5, Math.max(0, Math.floor(override)));
-  }
-  return MAX_FINALIZE_NUDGES;
+	const override = executionConfig?.finalize_nudges;
+	if (typeof override === "number" && Number.isFinite(override)) {
+		return Math.min(5, Math.max(0, Math.floor(override)));
+	}
+	return MAX_FINALIZE_NUDGES;
 }
 
-export async function findWindowIdForRun(sql: DbClient, runId: number): Promise<number | null> {
-  // Canvas-on-events: a run produced a window iff a canvas chain member carries
-  // this run_id (stamped atomically inside complete_window's tx). A fresh
-  // completion stamps the ROOT; a replace_existing completion stamps the
-  // superseding HEAD — so match ANY member and resolve the window identity via
-  // metadata.root_event_id (a root omits it → its own id). Scoped to
-  // canvas_state so it never matches tab_event/tab_snapshot BROWSER rows that
-  // also carry run_id.
-  const rows = await sql`
+export async function findWindowIdForRun(
+	sql: DbClient,
+	runId: number,
+): Promise<number | null> {
+	// Canvas-on-events: a run produced a window iff a canvas chain member carries
+	// this run_id (stamped atomically inside complete_window's tx). A fresh
+	// completion stamps the ROOT; a replace_existing completion stamps the
+	// superseding HEAD — so match ANY member and resolve the window identity via
+	// metadata.root_event_id (a root omits it → its own id). Scoped to
+	// canvas_state so it never matches tab_event/tab_snapshot BROWSER rows that
+	// also carry run_id.
+	const rows = await sql`
     SELECT COALESCE((metadata->>'root_event_id')::bigint, id) AS id
     FROM events
     WHERE run_id = ${runId}
@@ -60,15 +63,15 @@ export async function findWindowIdForRun(sql: DbClient, runId: number): Promise<
     LIMIT 1
   `;
 
-  return rows.length > 0 ? Number((rows[0] as { id: unknown }).id) : null;
+	return rows.length > 0 ? Number((rows[0] as { id: unknown }).id) : null;
 }
 
 export async function markWatcherRunCompleted(
-  sql: DbClient,
-  runId: number,
-  windowId: number | null
+	sql: DbClient,
+	runId: number,
+	windowId: number | null,
 ): Promise<void> {
-  await sql`
+	await sql`
     UPDATE runs
     SET status = 'completed',
         window_id = ${windowId},
@@ -80,11 +83,11 @@ export async function markWatcherRunCompleted(
 }
 
 async function markWatcherRunFailed(
-  sql: DbClient,
-  runId: number,
-  message: string
+	sql: DbClient,
+	runId: number,
+	message: string,
 ): Promise<void> {
-  await sql`
+	await sql`
     UPDATE runs
     SET status = 'failed',
         completed_at = current_timestamp,
@@ -103,11 +106,11 @@ async function markWatcherRunFailed(
  * guarded so it can't resurrect an already-terminal run (replica-safe).
  */
 async function requeueWatcherRunForFinalizeNudge(
-  sql: DbClient,
-  runId: number,
-  nextNudgeCount: number
+	sql: DbClient,
+	runId: number,
+	nextNudgeCount: number,
 ): Promise<void> {
-  await sql`
+	await sql`
     UPDATE runs
     SET status = 'pending',
         claimed_by = NULL,
@@ -125,15 +128,15 @@ async function requeueWatcherRunForFinalizeNudge(
 }
 
 export async function resolveWatcherRunsByMessageIds(
-  messageIds: Iterable<string>,
-  result: WatcherTerminalResult,
-  db?: DbClient
+	messageIds: Iterable<string>,
+	result: WatcherTerminalResult,
+	db?: DbClient,
 ): Promise<{ resolved: number }> {
-  const ids = Array.from(new Set(Array.from(messageIds).filter(Boolean)));
-  if (ids.length === 0) return { resolved: 0 };
+	const ids = Array.from(new Set(Array.from(messageIds).filter(Boolean)));
+	if (ids.length === 0) return { resolved: 0 };
 
-  const sql = db ?? getDb();
-  const rows = await sql`
+	const sql = db ?? getDb();
+	const rows = await sql`
     SELECT r.id, r.approved_input, w.execution_config
     FROM runs r
     LEFT JOIN watchers w ON w.id = r.watcher_id
@@ -142,55 +145,57 @@ export async function resolveWatcherRunsByMessageIds(
       AND r.status = ANY(${runStatusLiteral(ACTIVE_RUN_STATUSES)}::text[])
   `;
 
-  let resolved = 0;
-  for (const row of rows) {
-    const typedRow = row as {
-      id: unknown;
-      approved_input: Record<string, unknown> | null;
-      execution_config: Record<string, unknown> | null;
-    };
-    const runId = Number(typedRow.id);
-    if (!Number.isFinite(runId)) continue;
+	let resolved = 0;
+	for (const row of rows) {
+		const typedRow = row as {
+			id: unknown;
+			approved_input: Record<string, unknown> | null;
+			execution_config: Record<string, unknown> | null;
+		};
+		const runId = Number(typedRow.id);
+		if (!Number.isFinite(runId)) continue;
 
-    if (!result.ok) {
-      await markWatcherRunFailed(sql, runId, result.error);
-      resolved++;
-      continue;
-    }
+		if (!result.ok) {
+			await markWatcherRunFailed(sql, runId, result.error);
+			resolved++;
+			continue;
+		}
 
-    const windowId = await findWindowIdForRun(sql, runId);
-    if (windowId === null) {
-      // The agent replied but never called complete_window — a soft, usually
-      // non-deterministic miss. Re-dispatch for one more turn (bounded by
-      // finalize_nudge_count) before giving up. The budget is per-watcher
-      // (execution_config.finalize_nudges) with a global fallback.
-      const budget = resolveFinalizeNudgeBudget(typedRow.execution_config);
-      const nudgeCount = Number(typedRow.approved_input?.finalize_nudge_count ?? 0);
-      if (Number.isFinite(nudgeCount) && nudgeCount < budget) {
-        await requeueWatcherRunForFinalizeNudge(sql, runId, nudgeCount + 1);
-        logger.info(
-          { run_id: runId, attempt: nudgeCount + 1, max: budget },
-          '[watchers] Agent finished without complete_window — re-dispatching for finalize nudge'
-        );
-        resolved++;
-        continue;
-      }
+		const windowId = await findWindowIdForRun(sql, runId);
+		if (windowId === null) {
+			// The agent replied but never called complete_window — a soft, usually
+			// non-deterministic miss. Re-dispatch for one more turn (bounded by
+			// finalize_nudge_count) before giving up. The budget is per-watcher
+			// (execution_config.finalize_nudges) with a global fallback.
+			const budget = resolveFinalizeNudgeBudget(typedRow.execution_config);
+			const nudgeCount = Number(
+				typedRow.approved_input?.finalize_nudge_count ?? 0,
+			);
+			if (Number.isFinite(nudgeCount) && nudgeCount < budget) {
+				await requeueWatcherRunForFinalizeNudge(sql, runId, nudgeCount + 1);
+				logger.info(
+					{ run_id: runId, attempt: nudgeCount + 1, max: budget },
+					"[watchers] Agent finished without complete_window — re-dispatching for finalize nudge",
+				);
+				resolved++;
+				continue;
+			}
 
-      await markWatcherRunFailed(
-        sql,
-        runId,
-        'Agent reply finished without calling manage_watchers(action="complete_window")' +
-          (budget > 0 ? ` after ${budget + 1} attempt(s)` : '') +
-          '. Check that the assigned agent has the lobu-memory MCP attached and that query_sdk / ' +
-          'run_sdk tools are approved for it.'
-      );
-      resolved++;
-      continue;
-    }
+			await markWatcherRunFailed(
+				sql,
+				runId,
+				"Agent reply finished without calling run_sdk (client.watchers.completeWindow)" +
+					(budget > 0 ? ` after ${budget + 1} attempt(s)` : "") +
+					". Check that the assigned agent has the lobu-memory MCP attached and that query_sdk / " +
+					"run_sdk tools are approved for it.",
+			);
+			resolved++;
+			continue;
+		}
 
-    await markWatcherRunCompleted(sql, runId, windowId);
-    resolved++;
-  }
+		await markWatcherRunCompleted(sql, runId, windowId);
+		resolved++;
+	}
 
-  return { resolved };
+	return { resolved };
 }

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -7,35 +7,35 @@
  * poll-auth-signal.
  */
 
-import type { Context } from 'hono';
-import { getDb, parsePgNumberArray } from '../db/client';
-import { emit } from '../events/emitter';
-import type { Env } from '../index';
-import { notifyBrowserAuthExpired } from '../notifications/triggers';
-import { supersedeActionEvent } from '../tools/admin/manage_operations';
+import type { Context } from "hono";
 import {
-  getAuthProfileById,
-  getBrowserSessionReadiness,
-} from '../utils/auth-profiles';
+	maybeCloseRepairThread,
+	maybeOpenOrAppendRepairThread,
+} from "../connectors/repair-agent";
+import { getDb, parsePgNumberArray } from "../db/client";
+import { emit } from "../events/emitter";
+import { parseJsonBody } from "../gateway/routes/shared/helpers";
+import type { Env } from "../index";
+import { notifyBrowserAuthExpired } from "../notifications/triggers";
+import { supersedeActionEvent } from "../tools/admin/manage_operations";
 import {
-  maybeCloseRepairThread,
-  maybeOpenOrAppendRepairThread,
-} from '../connectors/repair-agent';
-import { autoLinkEvent } from '../utils/auto-linker';
-import { nextRunAt as nextRunAtFromCron } from '../utils/cron';
-import { advanceWatcherSchedule } from '../watchers/automation';
-import { applyEntityLinks } from '../utils/entity-link-upsert';
-import { errorMessage } from '../utils/errors';
-import { validateConnectorEventSemanticType } from '../utils/event-kind-validation';
+	getAuthProfileById,
+	getBrowserSessionReadiness,
+} from "../utils/auth-profiles";
+import { autoLinkEvent } from "../utils/auto-linker";
+import { nextRunAt as nextRunAtFromCron } from "../utils/cron";
+import { needsEmbeddingSql } from "../utils/embeddings";
+import { applyEntityLinks } from "../utils/entity-link-upsert";
+import { errorMessage } from "../utils/errors";
+import { validateConnectorEventSemanticType } from "../utils/event-kind-validation";
 import {
-  materializeInlineAttachments,
-  triggerAudioTranscriptions,
-} from '../utils/inline-attachments';
-import { needsEmbeddingSql } from '../utils/embeddings';
-import { insertEvent, recordLifecycleEvent } from '../utils/insert-event';
-import logger from '../utils/logger';
-import { authorizeRunForWorker } from './shared';
-import { parseJsonBody } from '../gateway/routes/shared/helpers';
+	materializeInlineAttachments,
+	triggerAudioTranscriptions,
+} from "../utils/inline-attachments";
+import { insertEvent, recordLifecycleEvent } from "../utils/insert-event";
+import logger from "../utils/logger";
+import { advanceWatcherSchedule } from "../watchers/automation";
+import { authorizeRunForWorker } from "./shared";
 
 type DbClient = ReturnType<typeof getDb>;
 type SqlFragment = ReturnType<DbClient>;
@@ -53,19 +53,19 @@ type SqlFragment = ReturnType<DbClient>;
  * handler's RETURNING column list. Both are nested `sql` fragments.
  */
 async function finalizeRun(
-  sql: DbClient,
-  params: {
-    runId: number;
-    workerId: string;
-    status: 'completed' | 'failed';
-    extraSet?: SqlFragment;
-    returning?: SqlFragment;
-  }
+	sql: DbClient,
+	params: {
+		runId: number;
+		workerId: string;
+		status: "completed" | "failed";
+		extraSet?: SqlFragment;
+		returning?: SqlFragment;
+	},
 ): Promise<Array<Record<string, unknown>>> {
-  const status = params.status;
-  const extra = params.extraSet ?? sql``;
-  const returning = params.returning ?? sql`id`;
-  return (await sql`
+	const status = params.status;
+	const extra = params.extraSet ?? sql``;
+	const returning = params.returning ?? sql`id`;
+	return (await sql`
     UPDATE runs
     SET status = ${status},
         completed_at = current_timestamp${extra}
@@ -82,11 +82,14 @@ async function finalizeRun(
  * resume with `next_run_at` seeded. Shared by the auth completion path.
  */
 async function reactivateProfileCascade(
-  sql: DbClient,
-  authProfileId: number,
-  authData: { credentials: Record<string, unknown>; metadata: Record<string, unknown> }
+	sql: DbClient,
+	authProfileId: number,
+	authData: {
+		credentials: Record<string, unknown>;
+		metadata: Record<string, unknown>;
+	},
 ): Promise<void> {
-  await sql`
+	await sql`
     UPDATE auth_profiles
     SET auth_data = ${sql.json(authData.credentials)},
         metadata = ${sql.json(authData.metadata)},
@@ -94,13 +97,13 @@ async function reactivateProfileCascade(
         updated_at = current_timestamp
     WHERE id = ${authProfileId}
   `;
-  await sql`
+	await sql`
     UPDATE connections
     SET status = 'active', updated_at = current_timestamp
     WHERE auth_profile_id = ${authProfileId}
       AND status = 'pending_auth'
   `;
-  await sql`
+	await sql`
     UPDATE feeds f
     SET status = 'active',
         next_run_at = COALESCE(f.next_run_at, NOW()),
@@ -118,29 +121,29 @@ async function reactivateProfileCascade(
  * Worker sends periodic heartbeat to indicate it's still processing.
  */
 export async function heartbeat(c: Context<{ Bindings: Env }>) {
-  try {
-    const { run_id, worker_id, progress } = await c.req.json<{
-      run_id: number;
-      worker_id: string;
-      progress?: { items_collected_so_far?: number };
-    }>();
+	try {
+		const { run_id, worker_id, progress } = await c.req.json<{
+			run_id: number;
+			worker_id: string;
+			progress?: { items_collected_so_far?: number };
+		}>();
 
-    const denied = await authorizeRunForWorker(c, run_id, worker_id);
-    if (denied) return denied;
+		const denied = await authorizeRunForWorker(c, run_id, worker_id);
+		if (denied) return denied;
 
-    const sql = getDb();
+		const sql = getDb();
 
-    await sql`
+		await sql`
       UPDATE runs
       SET last_heartbeat_at = current_timestamp,
           items_collected = COALESCE(${progress?.items_collected_so_far ?? null}, items_collected)
       WHERE id = ${run_id}
     `;
 
-    return c.json({ continue: true });
-  } catch (err: unknown) {
-    return c.json({ error: errorMessage(err) }, 500);
-  }
+		return c.json({ continue: true });
+	} catch (err: unknown) {
+		return c.json({ error: errorMessage(err) }, 500);
+	}
 }
 
 /**
@@ -149,205 +152,223 @@ export async function heartbeat(c: Context<{ Bindings: Env }>) {
  * Worker streams content batch for a sync run.
  */
 export async function streamContent(c: Context<{ Bindings: Env }>) {
-  try {
-    const batch = await c.req.json<{
-      type: 'batch';
-      run_id: number;
-      worker_id?: string;
-      items: Array<{
-        id: string;
-        title?: string;
-        payload_type?: 'text' | 'markdown' | 'json_template' | 'media' | 'empty';
-        payload_text: string;
-        payload_data?: Record<string, unknown>;
-        payload_template?: Record<string, unknown> | null;
-        attachments?: unknown[];
-        author_name?: string;
-        occurred_at: string;
-        source_url?: string;
-        score?: number;
-        metadata?: Record<string, unknown>;
-        origin_parent_id?: string;
-        origin_type?: string;
-        embedding?: number[];
-        embedding_model?: string;
-        semantic_type?: string;
-      }>;
-      checkpoint?: Record<string, unknown>;
-    }>();
+	try {
+		const batch = await c.req.json<{
+			type: "batch";
+			run_id: number;
+			worker_id?: string;
+			items: Array<{
+				id: string;
+				title?: string;
+				payload_type?:
+					| "text"
+					| "markdown"
+					| "json_template"
+					| "media"
+					| "empty";
+				payload_text: string;
+				payload_data?: Record<string, unknown>;
+				payload_template?: Record<string, unknown> | null;
+				attachments?: unknown[];
+				author_name?: string;
+				occurred_at: string;
+				source_url?: string;
+				score?: number;
+				metadata?: Record<string, unknown>;
+				origin_parent_id?: string;
+				origin_type?: string;
+				embedding?: number[];
+				embedding_model?: string;
+				semantic_type?: string;
+			}>;
+			checkpoint?: Record<string, unknown>;
+		}>();
 
-    const denied = await authorizeRunForWorker(c, batch.run_id, batch.worker_id);
-    if (denied) return denied;
+		const denied = await authorizeRunForWorker(
+			c,
+			batch.run_id,
+			batch.worker_id,
+		);
+		if (denied) return denied;
 
-    const sql = getDb();
+		const sql = getDb();
 
-    // Look up run details for event columns
-    const runRows = (await sql`
+		// Look up run details for event columns
+		const runRows = (await sql`
     SELECT r.feed_id, r.connection_id, r.connector_key, r.organization_id,
            f.feed_key, f.entity_ids
     FROM runs r
     LEFT JOIN feeds f ON f.id = r.feed_id
     WHERE r.id = ${batch.run_id}
   `) as unknown as Array<{
-      feed_id: number | null;
-      connection_id: number | null;
-      connector_key: string;
-      organization_id: string;
-      feed_key: string | null;
-      entity_ids: number[] | null;
-    }>;
+			feed_id: number | null;
+			connection_id: number | null;
+			connector_key: string;
+			organization_id: string;
+			feed_key: string | null;
+			entity_ids: number[] | null;
+		}>;
 
-    if (runRows.length === 0) {
-      return c.json({ error: 'Run not found' }, 404);
-    }
+		if (runRows.length === 0) {
+			return c.json({ error: "Run not found" }, 404);
+		}
 
-    const run = runRows[0];
-    const entityIds = parsePgNumberArray(run.entity_ids);
+		const run = runRows[0];
+		const entityIds = parsePgNumberArray(run.entity_ids);
 
-    // Connector-emitted inline attachments (e.g. whatsapp.local voice notes)
-    // come over the wire as base64 in `attachment.data`. Materialize each into
-    // the ArtifactStore before the row hits events.attachments — the events
-    // table is not a binary store. Audio attachments are queued for async
-    // transcription after insert.
-    const { items: materializedItems, pendingTranscriptions } =
-      await materializeInlineAttachments(batch.items);
-    batch.items = materializedItems as typeof batch.items;
+		// Connector-emitted inline attachments (e.g. whatsapp.local voice notes)
+		// come over the wire as base64 in `attachment.data`. Materialize each into
+		// the ArtifactStore before the row hits events.attachments — the events
+		// table is not a binary store. Audio attachments are queued for async
+		// transcription after insert.
+		const { items: materializedItems, pendingTranscriptions } =
+			await materializeInlineAttachments(batch.items);
+		batch.items = materializedItems as typeof batch.items;
 
-    // Auto-create dimension entities declared via eventKinds[kind].entityLinks
-    // before inserting events. One query per (entityType, matchField) per
-    // batch — cheap compared to the per-event inserts that follow.
-    await applyEntityLinks({
-      connectorKey: run.connector_key,
-      feedKey: run.feed_key,
-      orgId: run.organization_id,
-      items: batch.items,
-    });
+		// Auto-create dimension entities declared via eventKinds[kind].entityLinks
+		// before inserting events. One query per (entityType, matchField) per
+		// batch — cheap compared to the per-event inserts that follow.
+		await applyEntityLinks({
+			connectorKey: run.connector_key,
+			feedKey: run.feed_key,
+			orgId: run.organization_id,
+			items: batch.items,
+		});
 
-    let totalItems = 0;
-    const rejectedItems: Array<{ id: string; semantic_type?: string; errors: string[] }> = [];
+		let totalItems = 0;
+		const rejectedItems: Array<{
+			id: string;
+			semantic_type?: string;
+			errors: string[];
+		}> = [];
 
-    for (const item of batch.items) {
-      try {
-        const itemOriginType = item.origin_type ?? null;
-        const itemSemanticType = item.semantic_type ?? itemOriginType ?? 'content';
-        const validationType = itemOriginType ?? itemSemanticType;
+		for (const item of batch.items) {
+			try {
+				const itemOriginType = item.origin_type ?? null;
+				const itemSemanticType =
+					item.semantic_type ?? itemOriginType ?? "content";
+				const validationType = itemOriginType ?? itemSemanticType;
 
-        // Validate connector-declared type against the feed's eventKinds schema.
-        if (validationType && run.feed_key) {
-          const kindResult = await validateConnectorEventSemanticType(
-            validationType,
-            item.metadata as Record<string, unknown> | undefined,
-            run.connector_key,
-            run.feed_key,
-            run.organization_id
-          );
-          if (!kindResult.valid) {
-            logger.warn(
-              {
-                run_id: batch.run_id,
-                item_id: item.id,
-                semantic_type: validationType,
-                errors: kindResult.errors,
-              },
-              'Connector event semantic type validation failed — rejecting event'
-            );
-            rejectedItems.push({
-              id: item.id,
-              semantic_type: validationType,
-              errors: kindResult.errors,
-            });
-            continue;
-          }
-        }
+				// Validate connector-declared type against the feed's eventKinds schema.
+				if (validationType && run.feed_key) {
+					const kindResult = await validateConnectorEventSemanticType(
+						validationType,
+						item.metadata as Record<string, unknown> | undefined,
+						run.connector_key,
+						run.feed_key,
+						run.organization_id,
+					);
+					if (!kindResult.valid) {
+						logger.warn(
+							{
+								run_id: batch.run_id,
+								item_id: item.id,
+								semantic_type: validationType,
+								errors: kindResult.errors,
+							},
+							"Connector event semantic type validation failed — rejecting event",
+						);
+						rejectedItems.push({
+							id: item.id,
+							semantic_type: validationType,
+							errors: kindResult.errors,
+						});
+						continue;
+					}
+				}
 
-        // Skip events with no content — connectors must provide text
-        if (!item.payload_text && !item.title) {
-          logger.warn(
-            { run_id: batch.run_id, item_id: item.id, connector: run.connector_key },
-            '[stream] Skipping event with empty payload_text and title'
-          );
-          continue;
-        }
+				// Skip events with no content — connectors must provide text
+				if (!item.payload_text && !item.title) {
+					logger.warn(
+						{
+							run_id: batch.run_id,
+							item_id: item.id,
+							connector: run.connector_key,
+						},
+						"[stream] Skipping event with empty payload_text and title",
+					);
+					continue;
+				}
 
-        const inserted = await insertEvent(
-          {
-            entityIds: entityIds,
-            organizationId: run.organization_id,
-            originId: item.id,
-            title: item.title,
-            payloadType: item.payload_type,
-            content: item.payload_text,
-            payloadData: item.payload_data,
-            payloadTemplate: item.payload_template,
-            attachments: item.attachments,
-            authorName: item.author_name,
-            sourceUrl: item.source_url,
-            occurredAt: item.occurred_at,
-            score: item.score,
-            embedding: item.embedding,
-            embeddingModel: item.embedding_model,
-            metadata: item.metadata as Record<string, unknown> | undefined,
-            semanticType: itemSemanticType,
-            originType: itemOriginType,
-            connectorKey: run.connector_key,
-            connectionId: run.connection_id,
-            feedKey: run.feed_key,
-            feedId: run.feed_id,
-            runId: batch.run_id,
-            parentOriginId: item.origin_parent_id,
-          },
-          { onConflictUpdate: true }
-        );
-        if (inserted) {
-          totalItems++;
-          if (entityIds.length > 0) {
-            autoLinkEvent({
-              eventId: Number(inserted.id),
-              entityIds,
-              content: item.payload_text,
-              title: item.title,
-              organizationId: run.organization_id,
-            }).catch(() => {});
-          }
-        }
-      } catch (err) {
-        console.error('[stream] Insert failed for item', item.id, ':', err);
-        throw err;
-      }
-    }
+				const inserted = await insertEvent(
+					{
+						entityIds: entityIds,
+						organizationId: run.organization_id,
+						originId: item.id,
+						title: item.title,
+						payloadType: item.payload_type,
+						content: item.payload_text,
+						payloadData: item.payload_data,
+						payloadTemplate: item.payload_template,
+						attachments: item.attachments,
+						authorName: item.author_name,
+						sourceUrl: item.source_url,
+						occurredAt: item.occurred_at,
+						score: item.score,
+						embedding: item.embedding,
+						embeddingModel: item.embedding_model,
+						metadata: item.metadata as Record<string, unknown> | undefined,
+						semanticType: itemSemanticType,
+						originType: itemOriginType,
+						connectorKey: run.connector_key,
+						connectionId: run.connection_id,
+						feedKey: run.feed_key,
+						feedId: run.feed_id,
+						runId: batch.run_id,
+						parentOriginId: item.origin_parent_id,
+					},
+					{ onConflictUpdate: true },
+				);
+				if (inserted) {
+					totalItems++;
+					if (entityIds.length > 0) {
+						autoLinkEvent({
+							eventId: Number(inserted.id),
+							entityIds,
+							content: item.payload_text,
+							title: item.title,
+							organizationId: run.organization_id,
+						}).catch(() => {});
+					}
+				}
+			} catch (err) {
+				console.error("[stream] Insert failed for item", item.id, ":", err);
+				throw err;
+			}
+		}
 
-    // Kick off background transcription for any audio attachments
-    // materialized above. Runs detached — never blocks the stream-batch ack.
-    triggerAudioTranscriptions(run.organization_id, pendingTranscriptions);
+		// Kick off background transcription for any audio attachments
+		// materialized above. Runs detached — never blocks the stream-batch ack.
+		triggerAudioTranscriptions(run.organization_id, pendingTranscriptions);
 
-    // Update feed + run checkpoint if provided (so mid-run state like QR codes
-    // surface in UI via recent_runs[0].checkpoint before the run completes).
-    if (batch.checkpoint) {
-      if (run.feed_id) {
-        await sql`
+		// Update feed + run checkpoint if provided (so mid-run state like QR codes
+		// surface in UI via recent_runs[0].checkpoint before the run completes).
+		if (batch.checkpoint) {
+			if (run.feed_id) {
+				await sql`
       UPDATE feeds
       SET checkpoint = ${sql.json(batch.checkpoint)},
           updated_at = current_timestamp
       WHERE id = ${run.feed_id}
     `;
-      }
-      await sql`
+			}
+			await sql`
       UPDATE runs
       SET checkpoint = ${sql.json(batch.checkpoint)}
       WHERE id = ${batch.run_id}
     `;
-    }
+		}
 
-    return c.json({
-      batches_received: 1,
-      total_items: totalItems,
-      ...(rejectedItems.length > 0 && { rejected_items: rejectedItems }),
-    });
-  } catch (err: unknown) {
-    const stack = err instanceof Error ? err.stack : undefined;
-    console.error('[stream] Error:', errorMessage(err), stack);
-    return c.json({ error: errorMessage(err), stack }, 500);
-  }
+		return c.json({
+			batches_received: 1,
+			total_items: totalItems,
+			...(rejectedItems.length > 0 && { rejected_items: rejectedItems }),
+		});
+	} catch (err: unknown) {
+		const stack = err instanceof Error ? err.stack : undefined;
+		console.error("[stream] Error:", errorMessage(err), stack);
+		return c.json({ error: errorMessage(err), stack }, 500);
+	}
 }
 
 /**
@@ -356,42 +377,42 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
  * Worker signals sync run completion (success or failure).
  */
 export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
-  try {
-    const req = await c.req.json<{
-      run_id: number;
-      worker_id: string;
-      status: 'success' | 'failed';
-      items_collected?: number;
-      error_message?: string;
-      checkpoint?: Record<string, unknown>;
-      auth_update?: Record<string, unknown>;
-      // Diagnostic fields from the subprocess executor (failed-run path only).
-      // The worker redacts output_tail before sending; backend stores as-is.
-      output_tail?: string;
-      exit_code?: number | null;
-      exit_signal?: string | null;
-      exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
-    }>();
+	try {
+		const req = await c.req.json<{
+			run_id: number;
+			worker_id: string;
+			status: "success" | "failed";
+			items_collected?: number;
+			error_message?: string;
+			checkpoint?: Record<string, unknown>;
+			auth_update?: Record<string, unknown>;
+			// Diagnostic fields from the subprocess executor (failed-run path only).
+			// The worker redacts output_tail before sending; backend stores as-is.
+			output_tail?: string;
+			exit_code?: number | null;
+			exit_signal?: string | null;
+			exit_reason?: "ok" | "error_message" | "timeout" | "oom" | "crash";
+		}>();
 
-    const denied = await authorizeRunForWorker(c, req.run_id, req.worker_id);
-    if (denied) return denied;
+		const denied = await authorizeRunForWorker(c, req.run_id, req.worker_id);
+		if (denied) return denied;
 
-    const sql = getDb();
+		const sql = getDb();
 
-    // Atomic terminal-state transition with the shared F2 guard (see
-    // finalizeRun). A no-op (0 rows) means the run was already finalized by
-    // another path (e.g. the gateway reaped it on timeout and the worker is
-    // reporting in late) or this worker isn't the claimant — without it a late
-    // completion resurrects a reaped run and the feed/auth bookkeeping below
-    // double-applies (consecutive_failures, items_collected, next_run_at,
-    // auth_data). The failed path also stamps exit diagnostics.
-    const updatedRuns = (await finalizeRun(sql, {
-      runId: req.run_id,
-      workerId: req.worker_id,
-      status: req.status === 'failed' ? 'failed' : 'completed',
-      extraSet:
-        req.status === 'failed'
-          ? sql`,
+		// Atomic terminal-state transition with the shared F2 guard (see
+		// finalizeRun). A no-op (0 rows) means the run was already finalized by
+		// another path (e.g. the gateway reaped it on timeout and the worker is
+		// reporting in late) or this worker isn't the claimant — without it a late
+		// completion resurrects a reaped run and the feed/auth bookkeeping below
+		// double-applies (consecutive_failures, items_collected, next_run_at,
+		// auth_data). The failed path also stamps exit diagnostics.
+		const updatedRuns = (await finalizeRun(sql, {
+			runId: req.run_id,
+			workerId: req.worker_id,
+			status: req.status === "failed" ? "failed" : "completed",
+			extraSet:
+				req.status === "failed"
+					? sql`,
           items_collected = ${req.items_collected ?? 0},
           error_message = ${req.error_message ?? null},
           checkpoint = COALESCE(${req.checkpoint ? sql.json(req.checkpoint) : null}, checkpoint),
@@ -399,38 +420,45 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
           exit_code = ${req.exit_code ?? null},
           exit_signal = ${req.exit_signal ?? null},
           exit_reason = ${req.exit_reason ?? null}`
-          : sql`,
+					: sql`,
           items_collected = ${req.items_collected ?? 0},
           error_message = ${req.error_message ?? null},
           checkpoint = COALESCE(${req.checkpoint ? sql.json(req.checkpoint) : null}, checkpoint)`,
-      returning: sql`feed_id, connection_id`,
-    })) as unknown as Array<{ feed_id: number | null; connection_id: number | null }>;
+			returning: sql`feed_id, connection_id`,
+		})) as unknown as Array<{
+			feed_id: number | null;
+			connection_id: number | null;
+		}>;
 
-    if (updatedRuns.length === 0) {
-      // The run was already finalized (timeout race) or this worker isn't the
-      // claimant. Skip all feed/auth bookkeeping and return an idempotent
-      // already-finalized response.
-      logger.info(
-        { run_id: req.run_id, worker_id: req.worker_id, claimed_status: req.status },
-        '[completeWorkerJob] no-op: run already in terminal state (likely gateway timeout)'
-      );
-      return c.json({ success: false, reason: 'already_finalized' });
-    }
+		if (updatedRuns.length === 0) {
+			// The run was already finalized (timeout race) or this worker isn't the
+			// claimant. Skip all feed/auth bookkeeping and return an idempotent
+			// already-finalized response.
+			logger.info(
+				{
+					run_id: req.run_id,
+					worker_id: req.worker_id,
+					claimed_status: req.status,
+				},
+				"[completeWorkerJob] no-op: run already in terminal state (likely gateway timeout)",
+			);
+			return c.json({ success: false, reason: "already_finalized" });
+		}
 
-    // Update the feed's sync state
-    const runRows = updatedRuns;
-    const feedId = runRows[0]?.feed_id;
+		// Update the feed's sync state
+		const runRows = updatedRuns;
+		const feedId = runRows[0]?.feed_id;
 
-    if (feedId) {
-      const feedRows = (await sql`
+		if (feedId) {
+			const feedRows = (await sql`
       SELECT schedule FROM feeds WHERE id = ${feedId}
     `) as unknown as Array<{ schedule: string | null }>;
 
-      const schedule = feedRows[0]?.schedule ?? '0 */6 * * *';
-      const nextRun = nextRunAtFromCron(schedule);
-      const isSuccess = req.status === 'success';
+			const schedule = feedRows[0]?.schedule ?? "0 */6 * * *";
+			const nextRun = nextRunAtFromCron(schedule);
+			const isSuccess = req.status === "success";
 
-      await sql`
+			await sql`
         UPDATE feeds
         SET last_sync_at = current_timestamp,
             last_sync_status = ${req.status},
@@ -444,61 +472,67 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
         WHERE id = ${feedId}
       `;
 
-      // Repair-agent trigger: open / append / close threads based on the
-      // updated streak state. Fire-and-forget — all errors are swallowed
-      // inside the helper, the inner UPDATEs use atomic claims so concurrent
-      // invocations are safe, and the worker-completion ACK should not wait on
-      // repair-thread bookkeeping. (If the process dies mid-check the next
-      // failure re-triggers it.)
-      if (isSuccess) {
-        void maybeCloseRepairThread(feedId, req.run_id).catch((err) => {
-          logger.warn(
-            { feed_id: feedId, error: errorMessage(err) },
-            '[completeWorkerJob] maybeCloseRepairThread threw'
-          );
-        });
-      } else {
-        void maybeOpenOrAppendRepairThread(feedId, req.run_id).catch((err) => {
-          logger.warn(
-            { feed_id: feedId, error: errorMessage(err) },
-            '[completeWorkerJob] maybeOpenOrAppendRepairThread threw'
-          );
-        });
-      }
-    }
+			// Repair-agent trigger: open / append / close threads based on the
+			// updated streak state. Fire-and-forget — all errors are swallowed
+			// inside the helper, the inner UPDATEs use atomic claims so concurrent
+			// invocations are safe, and the worker-completion ACK should not wait on
+			// repair-thread bookkeeping. (If the process dies mid-check the next
+			// failure re-triggers it.)
+			if (isSuccess) {
+				void maybeCloseRepairThread(feedId, req.run_id).catch((err) => {
+					logger.warn(
+						{ feed_id: feedId, error: errorMessage(err) },
+						"[completeWorkerJob] maybeCloseRepairThread threw",
+					);
+				});
+			} else {
+				void maybeOpenOrAppendRepairThread(feedId, req.run_id).catch((err) => {
+					logger.warn(
+						{ feed_id: feedId, error: errorMessage(err) },
+						"[completeWorkerJob] maybeOpenOrAppendRepairThread threw",
+					);
+				});
+			}
+		}
 
-    // Persist refreshed browser auth data on the auth profile
-    const connectionId = runRows[0]?.connection_id;
-    if (req.status === 'success' && req.auth_update && connectionId) {
-      const connectionRows = (await sql`
+		// Persist refreshed browser auth data on the auth profile
+		const connectionId = runRows[0]?.connection_id;
+		if (req.status === "success" && req.auth_update && connectionId) {
+			const connectionRows = (await sql`
         SELECT c.organization_id, c.connector_key, c.auth_profile_id
         FROM connections c
         WHERE c.id = ${connectionId}
         LIMIT 1
       `) as Array<{
-        organization_id: string;
-        connector_key: string;
-        auth_profile_id: number | null;
-      }>;
+				organization_id: string;
+				connector_key: string;
+				auth_profile_id: number | null;
+			}>;
 
-      const connection = connectionRows[0];
-      const authProfile =
-        connection?.auth_profile_id != null
-          ? await getAuthProfileById(connection.organization_id, connection.auth_profile_id)
-          : null;
+			const connection = connectionRows[0];
+			const authProfile =
+				connection?.auth_profile_id != null
+					? await getAuthProfileById(
+							connection.organization_id,
+							connection.auth_profile_id,
+						)
+					: null;
 
-      if (authProfile?.profile_kind === 'browser_session') {
-        const nextAuthData = {
-          ...(authProfile.auth_data ?? {}),
-          ...req.auth_update,
-        };
-        const nextStatus = (
-          await getBrowserSessionReadiness(nextAuthData, connection.connector_key)
-        ).usable
-          ? 'active'
-          : 'pending_auth';
+			if (authProfile?.profile_kind === "browser_session") {
+				const nextAuthData = {
+					...(authProfile.auth_data ?? {}),
+					...req.auth_update,
+				};
+				const nextStatus = (
+					await getBrowserSessionReadiness(
+						nextAuthData,
+						connection.connector_key,
+					)
+				).usable
+					? "active"
+					: "pending_auth";
 
-        await sql`
+				await sql`
           UPDATE auth_profiles
           SET auth_data = ${sql.json(nextAuthData)},
               status = ${nextStatus},
@@ -506,43 +540,47 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
           WHERE id = ${authProfile.id}
         `;
 
-        await sql`
+				await sql`
           UPDATE connections
-          SET status = ${nextStatus === 'active' ? 'active' : 'pending_auth'},
+          SET status = ${nextStatus === "active" ? "active" : "pending_auth"},
               updated_at = current_timestamp
           WHERE auth_profile_id = ${authProfile.id}
         `;
 
-        await sql`
+				await sql`
           UPDATE feeds f
-          SET status = ${nextStatus === 'active' ? 'active' : 'paused'},
+          SET status = ${nextStatus === "active" ? "active" : "paused"},
               next_run_at = ${
-                nextStatus === 'active' ? sql`COALESCE(f.next_run_at, NOW())` : sql`NULL`
-              },
+								nextStatus === "active"
+									? sql`COALESCE(f.next_run_at, NOW())`
+									: sql`NULL`
+							},
               updated_at = current_timestamp
           FROM connections c
           WHERE f.connection_id = c.id
             AND c.auth_profile_id = ${authProfile.id}
         `;
 
-        if (nextStatus === 'pending_auth') {
-          notifyBrowserAuthExpired({
-            orgId: connection.organization_id,
-            connectionId,
-            connectorKey: connection.connector_key,
-            authProfileSlug: authProfile.slug,
-          }).catch(() => {});
-        }
-      } else if (authProfile?.profile_kind === 'interactive') {
-        // Interactive profiles (e.g. WhatsApp/Baileys) manage their own session
-        // tokens. Merge the connector's auth_update into auth_data. A sentinel
-        // { creds: null } wipes the profile and forces re-pair.
-        const update = (req.auth_update ?? {}) as Record<string, unknown>;
-        const wiped = update.creds === null;
-        const nextAuthData = wiped ? {} : { ...(authProfile.auth_data ?? {}), ...update };
-        const nextStatus = wiped ? 'pending_auth' : 'active';
+				if (nextStatus === "pending_auth") {
+					notifyBrowserAuthExpired({
+						orgId: connection.organization_id,
+						connectionId,
+						connectorKey: connection.connector_key,
+						authProfileSlug: authProfile.slug,
+					}).catch(() => {});
+				}
+			} else if (authProfile?.profile_kind === "interactive") {
+				// Interactive profiles (e.g. WhatsApp/Baileys) manage their own session
+				// tokens. Merge the connector's auth_update into auth_data. A sentinel
+				// { creds: null } wipes the profile and forces re-pair.
+				const update = (req.auth_update ?? {}) as Record<string, unknown>;
+				const wiped = update.creds === null;
+				const nextAuthData = wiped
+					? {}
+					: { ...(authProfile.auth_data ?? {}), ...update };
+				const nextStatus = wiped ? "pending_auth" : "active";
 
-        await sql`
+				await sql`
           UPDATE auth_profiles
           SET auth_data = ${sql.json(nextAuthData)},
               status = ${nextStatus},
@@ -550,30 +588,30 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
           WHERE id = ${authProfile.id}
         `;
 
-        if (wiped) {
-          await sql`
+				if (wiped) {
+					await sql`
             UPDATE connections
             SET status = 'pending_auth',
                 updated_at = current_timestamp
             WHERE auth_profile_id = ${authProfile.id}
           `;
-          await sql`
+					await sql`
             UPDATE feeds f
             SET status = 'paused', next_run_at = NULL, updated_at = current_timestamp
             FROM connections c
             WHERE f.connection_id = c.id AND c.auth_profile_id = ${authProfile.id}
           `;
-        }
-      }
-    }
+				}
+			}
+		}
 
-    logger.info({ run_id: req.run_id, status: req.status }, 'Run completed');
+		logger.info({ run_id: req.run_id, status: req.status }, "Run completed");
 
-    return c.json({ success: true });
-  } catch (err: unknown) {
-    logger.error({ error: errorMessage(err) }, '[completeWorkerJob] Error');
-    return c.json({ error: errorMessage(err) }, 500);
-  }
+		return c.json({ success: true });
+	} catch (err: unknown) {
+		logger.error({ error: errorMessage(err) }, "[completeWorkerJob] Error");
+		return c.json({ error: errorMessage(err) }, 500);
+	}
 }
 
 /**
@@ -584,8 +622,8 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
  * `WatcherDispatcher` posts here once the subprocess exits.
  *
  * The CLI agent completes the run itself, over MCP, exactly like a
- * server-side watcher agent: `read_knowledge({watcher_id})` → window_token
- * → `manage_watchers({action: "complete_window", extracted_data})`. The
+ * server-side watcher agent: `query_sdk` (`client.knowledge.read`) →
+ * window_token → `run_sdk` (`client.watchers.completeWindow`). The
  * dispatcher wires the gateway MCP server into the spawned CLI
  * (--mcp-config) and the prompt carries the completion instructions. This
  * endpoint therefore only records process exit metadata:
@@ -602,168 +640,186 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
  * /api/workers/complete (status='running' AND claimed_by === worker_id).
  */
 export async function completeWatcherRun(c: Context<{ Bindings: Env }>) {
-  const runIdParam = c.req.param('runId');
-  if (!runIdParam) {
-    return c.json({ error: 'runId is required' }, 400);
-  }
-  const runId = Number(runIdParam);
-  if (!Number.isFinite(runId) || runId <= 0) {
-    return c.json({ error: 'Invalid runId' }, 400);
-  }
+	const runIdParam = c.req.param("runId");
+	if (!runIdParam) {
+		return c.json({ error: "runId is required" }, 400);
+	}
+	const runId = Number(runIdParam);
+	if (!Number.isFinite(runId) || runId <= 0) {
+		return c.json({ error: "Invalid runId" }, 400);
+	}
 
-  const body = await parseJsonBody<{
-    worker_id: string;
-    output?: string;
-    error?: string;
-    duration_ms?: number;
-    exit_code?: number | null;
-    exit_signal?: string | null;
-    exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
-  }>(c, 'Invalid or missing JSON body');
-  if (body instanceof Response) return body;
+	const body = await parseJsonBody<{
+		worker_id: string;
+		output?: string;
+		error?: string;
+		duration_ms?: number;
+		exit_code?: number | null;
+		exit_signal?: string | null;
+		exit_reason?: "ok" | "error_message" | "timeout" | "oom" | "crash";
+	}>(c, "Invalid or missing JSON body");
+	if (body instanceof Response) return body;
 
-  // allowTerminal: when the CLI agent already completed the run via MCP
-  // complete_window, the exit report arrives against a terminal run — that's
-  // the happy path. Ownership (scope + claimed_by) is still enforced.
-  const denied = await authorizeRunForWorker(c, runId, body.worker_id, { allowTerminal: true });
-  if (denied) return denied;
+	// allowTerminal: when the CLI agent already completed the run via MCP
+	// complete_window, the exit report arrives against a terminal run — that's
+	// the happy path. Ownership (scope + claimed_by) is still enforced.
+	const denied = await authorizeRunForWorker(c, runId, body.worker_id, {
+		allowTerminal: true,
+	});
+	if (denied) return denied;
 
-  const sql = getDb();
-  // Reload the row now that authorization has cleared. Status drives the
-  // exit-report decision; the authoritative guard against double-writes is
-  // failRun's status-filtered UPDATE, so a stale read can't double-fail —
-  // at worst it reports `idempotent: true` with the loser's view.
-  const runRows = (await sql`
+	const sql = getDb();
+	// Reload the row now that authorization has cleared. Status drives the
+	// exit-report decision; the authoritative guard against double-writes is
+	// failRun's status-filtered UPDATE, so a stale read can't double-fail —
+	// at worst it reports `idempotent: true` with the loser's view.
+	const runRows = (await sql`
     SELECT id, organization_id, watcher_id, approved_input, run_type, claimed_at, status, window_id
     FROM runs
     WHERE id = ${runId}
     LIMIT 1
   `) as unknown as Array<{
-    id: number;
-    organization_id: string;
-    watcher_id: number | null;
-    approved_input: Record<string, unknown> | null;
-    run_type: string;
-    claimed_at: string | Date | null;
-    status: string;
-    window_id: number | null;
-  }>;
-  const run = runRows[0];
-  if (!run) return c.json({ error: 'Run not found' }, 404);
-  if (run.run_type !== 'watcher') {
-    return c.json({ error: 'Not a watcher run' }, 409);
-  }
-  if (run.watcher_id == null) {
-    return c.json({ error: 'Watcher run missing watcher_id' }, 500);
-  }
+		id: number;
+		organization_id: string;
+		watcher_id: number | null;
+		approved_input: Record<string, unknown> | null;
+		run_type: string;
+		claimed_at: string | Date | null;
+		status: string;
+		window_id: number | null;
+	}>;
+	const run = runRows[0];
+	if (!run) return c.json({ error: "Run not found" }, 404);
+	if (run.run_type !== "watcher") {
+		return c.json({ error: "Not a watcher run" }, 409);
+	}
+	if (run.watcher_id == null) {
+		return c.json({ error: "Watcher run missing watcher_id" }, 500);
+	}
 
-  const watcherId = Number(run.watcher_id);
-  const approved = (run.approved_input ?? {}) as Record<string, unknown>;
+	const watcherId = Number(run.watcher_id);
+	const approved = (run.approved_input ?? {}) as Record<string, unknown>;
 
-  // Fix 2 (pi round-2): device-identity binding pinned to the OAuth token, not
-  // the request body.
-  //
-  // The previous version looked up `(workerUserId, body.worker_id)` in
-  // `device_workers`, but `body.worker_id` is client-supplied. A same-user
-  // token could complete as a different registered worker by posting that
-  // worker's id. The fix is the same trick `pollWorkerJob` already uses: if
-  // the token was minted with a `workerId` binding (`device_worker:run`
-  // PATs/OAuth tokens always are), require `body.worker_id === boundWorkerId`
-  // AND, if the run is pinned to a device, the bound worker's
-  // `device_workers.id` matches `approved_input.device_worker_id`.
-  //
-  // For legacy/admin tokens with no `workerId` binding we fall through to the
-  // old user_id+worker_id lookup, but emit a warning so the audit trail can
-  // catch this path if it ever fires in production (Lobu for Mac always
-  // mints worker-bound tokens via /api/me/devices/mint-child-token).
-  if (c.var.workerAuthMode === 'user') {
-    const workerUserId = c.var.workerUserId;
-    const boundWorkerId = c.var.mcpAuthInfo?.workerId ?? null;
-    const pinnedDeviceWorkerId =
-      typeof approved.device_worker_id === 'string' ? approved.device_worker_id : null;
+	// Fix 2 (pi round-2): device-identity binding pinned to the OAuth token, not
+	// the request body.
+	//
+	// The previous version looked up `(workerUserId, body.worker_id)` in
+	// `device_workers`, but `body.worker_id` is client-supplied. A same-user
+	// token could complete as a different registered worker by posting that
+	// worker's id. The fix is the same trick `pollWorkerJob` already uses: if
+	// the token was minted with a `workerId` binding (`device_worker:run`
+	// PATs/OAuth tokens always are), require `body.worker_id === boundWorkerId`
+	// AND, if the run is pinned to a device, the bound worker's
+	// `device_workers.id` matches `approved_input.device_worker_id`.
+	//
+	// For legacy/admin tokens with no `workerId` binding we fall through to the
+	// old user_id+worker_id lookup, but emit a warning so the audit trail can
+	// catch this path if it ever fires in production (Lobu for Mac always
+	// mints worker-bound tokens via /api/me/devices/mint-child-token).
+	if (c.var.workerAuthMode === "user") {
+		const workerUserId = c.var.workerUserId;
+		const boundWorkerId = c.var.mcpAuthInfo?.workerId ?? null;
+		const pinnedDeviceWorkerId =
+			typeof approved.device_worker_id === "string"
+				? approved.device_worker_id
+				: null;
 
-    if (boundWorkerId) {
-      if (boundWorkerId !== body.worker_id) {
-        logger.warn(
-          { run_id: runId, body_worker_id: body.worker_id, bound_worker_id: boundWorkerId },
-          '[completeWatcherRun] body.worker_id != token-bound worker_id — rejecting'
-        );
-        return c.json(
-          {
-            error: 'worker_id_mismatch',
-            error_description: `this token is bound to worker_id '${boundWorkerId}'`,
-          },
-          403
-        );
-      }
-      if (pinnedDeviceWorkerId && workerUserId) {
-        const deviceRows = (await sql`
+		if (boundWorkerId) {
+			if (boundWorkerId !== body.worker_id) {
+				logger.warn(
+					{
+						run_id: runId,
+						body_worker_id: body.worker_id,
+						bound_worker_id: boundWorkerId,
+					},
+					"[completeWatcherRun] body.worker_id != token-bound worker_id — rejecting",
+				);
+				return c.json(
+					{
+						error: "worker_id_mismatch",
+						error_description: `this token is bound to worker_id '${boundWorkerId}'`,
+					},
+					403,
+				);
+			}
+			if (pinnedDeviceWorkerId && workerUserId) {
+				const deviceRows = (await sql`
           SELECT id
           FROM device_workers
           WHERE user_id = ${workerUserId}
             AND worker_id = ${boundWorkerId}
           LIMIT 1
         `) as unknown as Array<{ id: string }>;
-        const callerDeviceWorkerId = deviceRows[0]?.id ?? null;
-        if (!callerDeviceWorkerId || callerDeviceWorkerId !== pinnedDeviceWorkerId) {
-          logger.warn(
-            {
-              run_id: runId,
-              bound_worker_id: boundWorkerId,
-              caller_device: callerDeviceWorkerId,
-              pinned_device: pinnedDeviceWorkerId,
-            },
-            '[completeWatcherRun] device_worker_id mismatch — rejecting'
-          );
-          return c.json({ error: 'Forbidden: device worker mismatch' }, 403);
-        }
-      }
-    } else if (workerUserId && pinnedDeviceWorkerId) {
-      // Legacy/admin path: no worker-bound token. Fall back to the
-      // (user_id, body.worker_id) lookup; this is weaker than the bound path
-      // but still gates on user ownership. Emit a warning so prod telemetry
-      // can flag if any non-Mac caller hits this branch.
-      logger.warn(
-        { run_id: runId, worker_user_id: workerUserId, body_worker_id: body.worker_id },
-        '[completeWatcherRun] no token-bound workerId — falling back to user_id+worker_id check'
-      );
-      const deviceRows = (await sql`
+				const callerDeviceWorkerId = deviceRows[0]?.id ?? null;
+				if (
+					!callerDeviceWorkerId ||
+					callerDeviceWorkerId !== pinnedDeviceWorkerId
+				) {
+					logger.warn(
+						{
+							run_id: runId,
+							bound_worker_id: boundWorkerId,
+							caller_device: callerDeviceWorkerId,
+							pinned_device: pinnedDeviceWorkerId,
+						},
+						"[completeWatcherRun] device_worker_id mismatch — rejecting",
+					);
+					return c.json({ error: "Forbidden: device worker mismatch" }, 403);
+				}
+			}
+		} else if (workerUserId && pinnedDeviceWorkerId) {
+			// Legacy/admin path: no worker-bound token. Fall back to the
+			// (user_id, body.worker_id) lookup; this is weaker than the bound path
+			// but still gates on user ownership. Emit a warning so prod telemetry
+			// can flag if any non-Mac caller hits this branch.
+			logger.warn(
+				{
+					run_id: runId,
+					worker_user_id: workerUserId,
+					body_worker_id: body.worker_id,
+				},
+				"[completeWatcherRun] no token-bound workerId — falling back to user_id+worker_id check",
+			);
+			const deviceRows = (await sql`
         SELECT id
         FROM device_workers
         WHERE user_id = ${workerUserId}
           AND worker_id = ${body.worker_id}
         LIMIT 1
       `) as unknown as Array<{ id: string }>;
-      const callerDeviceWorkerId = deviceRows[0]?.id ?? null;
-      if (!callerDeviceWorkerId || callerDeviceWorkerId !== pinnedDeviceWorkerId) {
-        logger.warn(
-          {
-            run_id: runId,
-            body_worker_id: body.worker_id,
-            caller_device: callerDeviceWorkerId,
-            pinned_device: pinnedDeviceWorkerId,
-          },
-          '[completeWatcherRun] device_worker_id mismatch (legacy path) — rejecting'
-        );
-        return c.json({ error: 'Forbidden: device worker mismatch' }, 403);
-      }
-    }
-  }
+			const callerDeviceWorkerId = deviceRows[0]?.id ?? null;
+			if (
+				!callerDeviceWorkerId ||
+				callerDeviceWorkerId !== pinnedDeviceWorkerId
+			) {
+				logger.warn(
+					{
+						run_id: runId,
+						body_worker_id: body.worker_id,
+						caller_device: callerDeviceWorkerId,
+						pinned_device: pinnedDeviceWorkerId,
+					},
+					"[completeWatcherRun] device_worker_id mismatch (legacy path) — rejecting",
+				);
+				return c.json({ error: "Forbidden: device worker mismatch" }, 403);
+			}
+		}
+	}
 
-  const hasError = typeof body.error === 'string' && body.error.trim() !== '';
-  const output = typeof body.output === 'string' ? body.output : '';
-  const durationMs =
-    typeof body.duration_ms === 'number' && Number.isFinite(body.duration_ms)
-      ? Math.max(0, Math.floor(body.duration_ms))
-      : null;
+	const hasError = typeof body.error === "string" && body.error.trim() !== "";
+	const output = typeof body.output === "string" ? body.output : "";
+	const durationMs =
+		typeof body.duration_ms === "number" && Number.isFinite(body.duration_ms)
+			? Math.max(0, Math.floor(body.duration_ms))
+			: null;
 
-  // Mark the run failed and tick the schedule forward — but only when the
-  // UPDATE actually transitioned the row (RETURNING guard), so a concurrent
-  // duplicate POST can't double-advance `next_run_at` and skip a window.
-  // The stdout tail is stashed for diagnosis (why didn't the agent call
-  // complete_window?); the worker redacts before sending.
-  const failRun = async (reason: string): Promise<boolean> => {
-    const failedRows = (await sql`
+	// Mark the run failed and tick the schedule forward — but only when the
+	// UPDATE actually transitioned the row (RETURNING guard), so a concurrent
+	// duplicate POST can't double-advance `next_run_at` and skip a window.
+	// The stdout tail is stashed for diagnosis (why didn't the agent call
+	// complete_window?); the worker redacts before sending.
+	const failRun = async (reason: string): Promise<boolean> => {
+		const failedRows = (await sql`
       UPDATE runs
       SET status = 'failed',
           completed_at = current_timestamp,
@@ -771,92 +827,105 @@ export async function completeWatcherRun(c: Context<{ Bindings: Env }>) {
           output_tail = ${output ? output.slice(-2000) : null},
           exit_code = ${body.exit_code ?? null},
           exit_signal = ${body.exit_signal ?? null},
-          exit_reason = ${body.exit_reason ?? 'error_message'}
+          exit_reason = ${body.exit_reason ?? "error_message"}
       WHERE id = ${runId}
         AND status = 'running'
       RETURNING id
     `) as unknown as Array<{ id: number }>;
-    if (failedRows.length === 0) return false;
-    await sql`
+		if (failedRows.length === 0) return false;
+		await sql`
       UPDATE watchers
       SET last_fired_at = NOW(), updated_at = NOW()
       WHERE id = ${watcherId}
     `;
-    await advanceWatcherSchedule(sql, watcherId);
-    return true;
-  };
+		await advanceWatcherSchedule(sql, watcherId);
+		return true;
+	};
 
-  const emitCompletionEvent = (outcome: 'completed' | 'failed', detail?: string) => {
-    // Fire-and-forget: a "change" event so the dashboard's metric_series picks
-    // up the device-CLI completion the same way it picks up server-side ones.
-    // LifecycleOp is restricted to created/updated/deleted — we use 'updated'
-    // and put the actual ran/errored detail under `extra`.
-    recordLifecycleEvent({
-      organizationId: run.organization_id,
-      entityType: 'watcher',
-      op: 'updated',
-      entityId: String(watcherId),
-      summary:
-        outcome === 'failed'
-          ? `Watcher run ${runId} failed on device CLI: ${detail ?? 'unknown error'}`
-          : `Watcher run ${runId} completed via device CLI`,
-      extra: {
-        run_id: runId,
-        source: 'device_worker',
-        outcome,
-        duration_ms: durationMs,
-      },
-    });
-  };
+	const emitCompletionEvent = (
+		outcome: "completed" | "failed",
+		detail?: string,
+	) => {
+		// Fire-and-forget: a "change" event so the dashboard's metric_series picks
+		// up the device-CLI completion the same way it picks up server-side ones.
+		// LifecycleOp is restricted to created/updated/deleted — we use 'updated'
+		// and put the actual ran/errored detail under `extra`.
+		recordLifecycleEvent({
+			organizationId: run.organization_id,
+			entityType: "watcher",
+			op: "updated",
+			entityId: String(watcherId),
+			summary:
+				outcome === "failed"
+					? `Watcher run ${runId} failed on device CLI: ${detail ?? "unknown error"}`
+					: `Watcher run ${runId} completed via device CLI`,
+			extra: {
+				run_id: runId,
+				source: "device_worker",
+				outcome,
+				duration_ms: durationMs,
+			},
+		});
+	};
 
-  if (hasError) {
-    const transitioned = await failRun(body.error as string);
-    if (!transitioned) {
-      const finalRows = (await sql`
+	if (hasError) {
+		const transitioned = await failRun(body.error as string);
+		if (!transitioned) {
+			const finalRows = (await sql`
         SELECT status FROM runs WHERE id = ${runId} LIMIT 1
       `) as unknown as Array<{ status: string }>;
-      return c.json({ ok: true, status: finalRows[0]?.status ?? 'failed', idempotent: true });
-    }
-    emitCompletionEvent('failed', body.error);
-    return c.json({ ok: true, status: 'failed' });
-  }
+			return c.json({
+				ok: true,
+				status: finalRows[0]?.status ?? "failed",
+				idempotent: true,
+			});
+		}
+		emitCompletionEvent("failed", body.error);
+		return c.json({ ok: true, status: "failed" });
+	}
 
-  // Clean exit + run already completed: the agent finished the job over MCP
-  // (read_knowledge → complete_window) before the subprocess exited. Stamp
-  // the device-side provenance the pipeline can't know — exit metadata and
-  // the subprocess wall-clock — plus the cooldown bookkeeping. The
-  // `exit_reason IS NULL` filter makes this first-report-only: a duplicate
-  // exit report matches zero rows and acks without re-firing side effects.
-  if (run.status === 'completed') {
-    const stamped = (await sql`
+	// Clean exit + run already completed: the agent finished the job over MCP
+	// (query_sdk → completeWindow) before the subprocess exited. Stamp
+	// the device-side provenance the pipeline can't know — exit metadata and
+	// the subprocess wall-clock — plus the cooldown bookkeeping. The
+	// `exit_reason IS NULL` filter makes this first-report-only: a duplicate
+	// exit report matches zero rows and acks without re-firing side effects.
+	if (run.status === "completed") {
+		const stamped = (await sql`
       UPDATE runs
       SET exit_code = ${body.exit_code ?? null},
           exit_signal = ${body.exit_signal ?? null},
-          exit_reason = ${body.exit_reason ?? 'ok'}
+          exit_reason = ${body.exit_reason ?? "ok"}
       WHERE id = ${runId}
         AND exit_reason IS NULL
       RETURNING id
     `) as unknown as Array<{ id: number }>;
-    if (stamped.length === 0) {
-      return c.json({ ok: true, status: 'completed', window_id: run.window_id, idempotent: true });
-    }
-    if (run.window_id != null) {
-      const agentKind =
-        typeof approved.agent_kind === 'string' && (approved.agent_kind as string).trim()
-          ? (approved.agent_kind as string).trim()
-          : null;
-      // Deterministic provenance from the system of record (the run's pinned
-      // agent_kind): the agent isn't trusted to self-report `model` through
-      // complete_window, so runs it left on the pipeline default get the device
-      // stamp. An explicit model passed by the agent wins. Provenance now lives
-      // on the RUN row (model_used / run_metadata.execution_time_ms), not the
-      // retired watcher_windows table — the canvas is the window projection and
-      // reads pull execution_time_ms from run timestamps / run_metadata.
-      await sql`
+		if (stamped.length === 0) {
+			return c.json({
+				ok: true,
+				status: "completed",
+				window_id: run.window_id,
+				idempotent: true,
+			});
+		}
+		if (run.window_id != null) {
+			const agentKind =
+				typeof approved.agent_kind === "string" &&
+				(approved.agent_kind as string).trim()
+					? (approved.agent_kind as string).trim()
+					: null;
+			// Deterministic provenance from the system of record (the run's pinned
+			// agent_kind): the agent isn't trusted to self-report `model` through
+			// complete_window, so runs it left on the pipeline default get the device
+			// stamp. An explicit model passed by the agent wins. Provenance now lives
+			// on the RUN row (model_used / run_metadata.execution_time_ms), not the
+			// retired watcher_windows table — the canvas is the window projection and
+			// reads pull execution_time_ms from run timestamps / run_metadata.
+			await sql`
         UPDATE runs
         SET model_used = CASE
               WHEN model_used = 'external-client' OR model_used IS NULL
-                THEN ${agentKind ? `device-cli:${agentKind}` : 'device-cli'}
+                THEN ${agentKind ? `device-cli:${agentKind}` : "device-cli"}
               ELSE model_used
             END,
             run_metadata = CASE
@@ -878,35 +947,35 @@ export async function completeWatcherRun(c: Context<{ Bindings: Env }>) {
             END
         WHERE id = ${runId}
       `;
-    }
-    await sql`
+		}
+		await sql`
       UPDATE watchers
       SET last_fired_at = NOW(), updated_at = NOW()
       WHERE id = ${watcherId}
     `;
-    emitCompletionEvent('completed');
-    return c.json({ ok: true, status: 'completed', window_id: run.window_id });
-  }
+		emitCompletionEvent("completed");
+		return c.json({ ok: true, status: "completed", window_id: run.window_id });
+	}
 
-  // Already failed/timed out (a concurrent report, the reconciler, or the
-  // 2h sweep won): idempotent ack, no side effects.
-  if (run.status !== 'running') {
-    return c.json({ ok: true, status: run.status, idempotent: true });
-  }
+	// Already failed/timed out (a concurrent report, the reconciler, or the
+	// 2h sweep won): idempotent ack, no side effects.
+	if (run.status !== "running") {
+		return c.json({ ok: true, status: run.status, idempotent: true });
+	}
 
-  // Clean exit but the run is still `running`: the agent never called
-  // manage_watchers(complete_window). Fail closed — complete_window is the
-  // only signal that real work happened (the same rule the server-side
-  // dispatch guard enforces in automation.ts). The stdout tail lands in
-  // runs.output_tail for diagnosis.
-  const reason =
-    'Device CLI exited without calling manage_watchers(action="complete_window"). ' +
-    'The watcher prompt instructs the agent to complete via the lobu MCP server — check that ' +
-    'the dispatcher passed --mcp-config, the gateway is reachable from the device, and the ' +
-    'device token has mcp:write scope.';
-  await failRun(reason);
-  emitCompletionEvent('failed', reason);
-  return c.json({ ok: true, status: 'failed', error: reason });
+	// Clean exit but the run is still `running`: the agent never called
+	// run_sdk (client.watchers.completeWindow). Fail closed — completeWindow is
+	// the only signal that real work happened (the same rule the server-side
+	// dispatch guard enforces in automation.ts). The stdout tail lands in
+	// runs.output_tail for diagnosis.
+	const reason =
+		"Device CLI exited without calling run_sdk (client.watchers.completeWindow). " +
+		"The watcher prompt instructs the agent to complete via the lobu MCP server — check that " +
+		"the dispatcher passed --mcp-config with query_sdk/run_sdk allowed, the gateway is reachable " +
+		"from the device, and the device token has mcp:write scope.";
+	await failRun(reason);
+	emitCompletionEvent("failed", reason);
+	return c.json({ ok: true, status: "failed", error: reason });
 }
 
 /**
@@ -916,46 +985,46 @@ export async function completeWatcherRun(c: Context<{ Bindings: Env }>) {
  * Returns event IDs and payload_text for the given IDs.
  */
 export async function fetchEventsForEmbedding(c: Context<{ Bindings: Env }>) {
-  try {
-    const { event_ids } = await c.req.json<{ event_ids: number[] }>();
+	try {
+		const { event_ids } = await c.req.json<{ event_ids: number[] }>();
 
-    if (!event_ids || event_ids.length === 0) {
-      return c.json({ events: [] });
-    }
+		if (!event_ids || event_ids.length === 0) {
+			return c.json({ events: [] });
+		}
 
-    const sql = getDb();
+		const sql = getDb();
 
-    // Build safe IN clause
-    const safeIds = event_ids.filter((id) => Number.isInteger(id) && id > 0);
-    if (safeIds.length === 0) {
-      return c.json({ events: [] });
-    }
+		// Build safe IN clause
+		const safeIds = event_ids.filter((id) => Number.isInteger(id) && id > 0);
+		if (safeIds.length === 0) {
+			return c.json({ events: [] });
+		}
 
-    // Return events that need (re)embedding under the configured model. The
-    // shared predicate (NOT EXISTS anti-joins on event_embeddings) is identical
-    // to the backfill discovery rule and, being multi-vector aware, also catches
-    // long events that only have a chunk-0 vector. A correlated anti-join (not a
-    // LEFT JOIN) also avoids fanning out one row per chunk now that an event can
-    // have many embedding rows.
-    const placeholders = safeIds.map((_, i) => `$${i + 1}`).join(',');
-    const rows = await sql.unsafe(
-      `SELECT e.id, e.payload_text, e.title
+		// Return events that need (re)embedding under the configured model. The
+		// shared predicate (NOT EXISTS anti-joins on event_embeddings) is identical
+		// to the backfill discovery rule and, being multi-vector aware, also catches
+		// long events that only have a chunk-0 vector. A correlated anti-join (not a
+		// LEFT JOIN) also avoids fanning out one row per chunk now that an event can
+		// have many embedding rows.
+		const placeholders = safeIds.map((_, i) => `$${i + 1}`).join(",");
+		const rows = await sql.unsafe(
+			`SELECT e.id, e.payload_text, e.title
        FROM events e
        WHERE e.id IN (${placeholders})
-         AND ${needsEmbeddingSql('e')}`,
-      safeIds
-    );
+         AND ${needsEmbeddingSql("e")}`,
+			safeIds,
+		);
 
-    return c.json({
-      events: rows.map((r) => ({
-        id: Number(r.id),
-        content: (r.payload_text as string) ?? '',
-        title: (r.title as string) ?? null,
-      })),
-    });
-  } catch (err: unknown) {
-    return c.json({ error: errorMessage(err) }, 500);
-  }
+		return c.json({
+			events: rows.map((r) => ({
+				id: Number(r.id),
+				content: (r.payload_text as string) ?? "",
+				title: (r.title as string) ?? null,
+			})),
+		});
+	} catch (err: unknown) {
+		return c.json({ error: errorMessage(err) }, 500);
+	}
 }
 
 /**
@@ -965,124 +1034,124 @@ export async function fetchEventsForEmbedding(c: Context<{ Bindings: Env }>) {
  * Used by embed_backfill runs.
  */
 export async function completeEmbeddings(c: Context<{ Bindings: Env }>) {
-  try {
-    const req = await c.req.json<{
-      run_id: number;
-      worker_id: string;
-      embeddings: Array<{
-        event_id: number;
-        chunk_index: number;
-        embedding: number[];
-        embedding_model?: string;
-      }>;
-      error_message?: string;
-    }>();
+	try {
+		const req = await c.req.json<{
+			run_id: number;
+			worker_id: string;
+			embeddings: Array<{
+				event_id: number;
+				chunk_index: number;
+				embedding: number[];
+				embedding_model?: string;
+			}>;
+			error_message?: string;
+		}>();
 
-    // Ownership gate — a worker can only finalize runs it claimed. Mirrors the
-    // other /complete handlers; without it a leaked worker token could mark
-    // arbitrary runs terminal.
-    const denied = await authorizeRunForWorker(c, req.run_id, req.worker_id);
-    if (denied) return denied;
+		// Ownership gate — a worker can only finalize runs it claimed. Mirrors the
+		// other /complete handlers; without it a leaked worker token could mark
+		// arbitrary runs terminal.
+		const denied = await authorizeRunForWorker(c, req.run_id, req.worker_id);
+		if (denied) return denied;
 
-    const sql = getDb();
+		const sql = getDb();
 
-    if (!req.embeddings || req.embeddings.length === 0) {
-      if (req.error_message) {
-        // Guarded terminal transition (the status='running' AND claimed_by guard
-        // inside finalizeRun won't resurrect a reaped run). Ownership is already
-        // enforced by authorizeRunForWorker above.
-        await finalizeRun(sql, {
-          runId: req.run_id,
-          workerId: req.worker_id,
-          status: 'failed',
-          extraSet: sql`,
+		if (!req.embeddings || req.embeddings.length === 0) {
+			if (req.error_message) {
+				// Guarded terminal transition (the status='running' AND claimed_by guard
+				// inside finalizeRun won't resurrect a reaped run). Ownership is already
+				// enforced by authorizeRunForWorker above.
+				await finalizeRun(sql, {
+					runId: req.run_id,
+					workerId: req.worker_id,
+					status: "failed",
+					extraSet: sql`,
               error_message = ${req.error_message}`,
-        });
-        return c.json({ success: false, error: req.error_message }, 400);
-      }
-      // Empty batch means all events already had embeddings — mark completed
-      // (best-effort; the guard makes it a no-op on an already-finalized run).
-      await finalizeRun(sql, {
-        runId: req.run_id,
-        workerId: req.worker_id,
-        status: 'completed',
-      });
-      return c.json({ success: true, updated: 0 });
-    }
+				});
+				return c.json({ success: false, error: req.error_message }, 400);
+			}
+			// Empty batch means all events already had embeddings — mark completed
+			// (best-effort; the guard makes it a no-op on an already-finalized run).
+			await finalizeRun(sql, {
+				runId: req.run_id,
+				workerId: req.worker_id,
+				status: "completed",
+			});
+			return c.json({ success: true, updated: 0 });
+		}
 
-    // Durability first, THEN finalize the run. Each (event, model)'s chunk set is
-    // replaced in its OWN transaction (delete that model's rows, then insert):
-    // per-(event, model) isolation so one bad write can't drop another's and so
-    // old/new models can coexist during a zero-downtime swap. chunk_index
-    // defaults to 0 for an older worker mid-deploy.
-    const byEventModel = new Map<string, typeof req.embeddings>();
-    for (const item of req.embeddings) {
-      if (!item.embedding_model) continue; // unstamped vectors are unusable (search scopes by model)
-      const key = `${item.event_id}\0${item.embedding_model}`;
-      const group = byEventModel.get(key);
-      if (group) group.push(item);
-      else byEventModel.set(key, [item]);
-    }
-    let updated = 0;
-    let failed = 0;
-    for (const [, items] of byEventModel) {
-      const eventId = items[0]!.event_id;
-      const model = items[0]!.embedding_model!;
-      try {
-        await sql.begin(async (tx) => {
-          await tx`DELETE FROM event_embeddings WHERE event_id = ${eventId} AND embedding_model = ${model}`;
-          for (const item of items) {
-            const vectorStr = `[${item.embedding.join(',')}]`;
-            await tx.unsafe(
-              `INSERT INTO event_embeddings (event_id, chunk_index, embedding, embedding_model)
+		// Durability first, THEN finalize the run. Each (event, model)'s chunk set is
+		// replaced in its OWN transaction (delete that model's rows, then insert):
+		// per-(event, model) isolation so one bad write can't drop another's and so
+		// old/new models can coexist during a zero-downtime swap. chunk_index
+		// defaults to 0 for an older worker mid-deploy.
+		const byEventModel = new Map<string, typeof req.embeddings>();
+		for (const item of req.embeddings) {
+			if (!item.embedding_model) continue; // unstamped vectors are unusable (search scopes by model)
+			const key = `${item.event_id}\0${item.embedding_model}`;
+			const group = byEventModel.get(key);
+			if (group) group.push(item);
+			else byEventModel.set(key, [item]);
+		}
+		let updated = 0;
+		let failed = 0;
+		for (const [, items] of byEventModel) {
+			const eventId = items[0]!.event_id;
+			const model = items[0]!.embedding_model!;
+			try {
+				await sql.begin(async (tx) => {
+					await tx`DELETE FROM event_embeddings WHERE event_id = ${eventId} AND embedding_model = ${model}`;
+					for (const item of items) {
+						const vectorStr = `[${item.embedding.join(",")}]`;
+						await tx.unsafe(
+							`INSERT INTO event_embeddings (event_id, chunk_index, embedding, embedding_model)
                VALUES ($1, $2, $3::vector, $4)`,
-              [eventId, item.chunk_index ?? 0, vectorStr, model]
-            );
-          }
-        });
-        updated++;
-      } catch (err) {
-        failed++;
-        logger.error(
-          { event_id: eventId, model, error: err },
-          '[completeEmbeddings] Failed to write embeddings for event (stays stale, will re-queue)'
-        );
-      }
-    }
+							[eventId, item.chunk_index ?? 0, vectorStr, model],
+						);
+					}
+				});
+				updated++;
+			} catch (err) {
+				failed++;
+				logger.error(
+					{ event_id: eventId, model, error: err },
+					"[completeEmbeddings] Failed to write embeddings for event (stays stale, will re-queue)",
+				);
+			}
+		}
 
-    // Finalize AFTER the writes, and only as completed if nothing failed — a
-    // failed write must not be hidden behind a "completed" run; mark the run
-    // failed so the events get re-queued and the failure is visible. Headless
-    // backfills (run_id=-1) make finalizeRun a harmless no-op either way.
-    await finalizeRun(sql, {
-      runId: req.run_id,
-      workerId: req.worker_id,
-      status: failed > 0 ? 'failed' : 'completed',
-      ...(failed > 0
-        ? {
-            extraSet: sql`,
+		// Finalize AFTER the writes, and only as completed if nothing failed — a
+		// failed write must not be hidden behind a "completed" run; mark the run
+		// failed so the events get re-queued and the failure is visible. Headless
+		// backfills (run_id=-1) make finalizeRun a harmless no-op either way.
+		await finalizeRun(sql, {
+			runId: req.run_id,
+			workerId: req.worker_id,
+			status: failed > 0 ? "failed" : "completed",
+			...(failed > 0
+				? {
+						extraSet: sql`,
               error_message = ${`${failed}/${byEventModel.size} event embedding writes failed`}`,
-          }
-        : {}),
-    });
+					}
+				: {}),
+		});
 
-    await sql`
+		await sql`
       UPDATE runs
       SET items_collected = ${updated}
       WHERE id = ${req.run_id}
         AND claimed_by = ${req.worker_id}
     `;
 
-    logger.info(
-      { run_id: req.run_id, total: req.embeddings.length, updated, failed },
-      'Embedding backfill completed'
-    );
+		logger.info(
+			{ run_id: req.run_id, total: req.embeddings.length, updated, failed },
+			"Embedding backfill completed",
+		);
 
-    return c.json({ success: failed === 0, updated, failed });
-  } catch (err: unknown) {
-    logger.error({ error: errorMessage(err) }, '[completeEmbeddings] Error');
-    return c.json({ error: errorMessage(err) }, 500);
-  }
+		return c.json({ success: failed === 0, updated, failed });
+	} catch (err: unknown) {
+		logger.error({ error: errorMessage(err) }, "[completeEmbeddings] Error");
+		return c.json({ error: errorMessage(err) }, 500);
+	}
 }
 
 /**
@@ -1092,26 +1161,26 @@ export async function completeEmbeddings(c: Context<{ Bindings: Env }>) {
  * checkpoint so the UI can render it.
  */
 export async function emitAuthArtifact(c: Context<{ Bindings: Env }>) {
-  try {
-    const { run_id, artifact } = await c.req.json<{
-      run_id: number;
-      worker_id: string;
-      artifact: Record<string, unknown>;
-    }>();
+	try {
+		const { run_id, artifact } = await c.req.json<{
+			run_id: number;
+			worker_id: string;
+			artifact: Record<string, unknown>;
+		}>();
 
-    const sql = getDb();
+		const sql = getDb();
 
-    await sql`
+		await sql`
       UPDATE runs
       SET checkpoint = ${sql.json({ artifact, emitted_at: new Date().toISOString() })},
           last_heartbeat_at = current_timestamp
       WHERE id = ${run_id}
     `;
 
-    return c.json({ success: true });
-  } catch (err: unknown) {
-    return c.json({ error: errorMessage(err) }, 500);
-  }
+		return c.json({ success: true });
+	} catch (err: unknown) {
+		return c.json({ error: errorMessage(err) }, 500);
+	}
 }
 
 /**
@@ -1121,34 +1190,34 @@ export async function emitAuthArtifact(c: Context<{ Bindings: Env }>) {
  * (cleared from the run row) when delivered.
  */
 export async function pollAuthSignal(c: Context<{ Bindings: Env }>) {
-  try {
-    const { run_id, signal_name } = await c.req.json<{
-      run_id: number;
-      worker_id: string;
-      signal_name: string;
-    }>();
+	try {
+		const { run_id, signal_name } = await c.req.json<{
+			run_id: number;
+			worker_id: string;
+			signal_name: string;
+		}>();
 
-    const sql = getDb();
+		const sql = getDb();
 
-    const consumed = await sql.begin(async (tx) => {
-      const rows = (await tx`
+		const consumed = await sql.begin(async (tx) => {
+			const rows = (await tx`
         SELECT auth_signal FROM runs
         WHERE id = ${run_id}
         FOR UPDATE
       `) as Array<{ auth_signal: Record<string, unknown> | null }>;
 
-      const current = rows[0]?.auth_signal ?? null;
-      if (!current) return null;
-      if (current.name !== signal_name) return null;
+			const current = rows[0]?.auth_signal ?? null;
+			if (!current) return null;
+			if (current.name !== signal_name) return null;
 
-      await tx`UPDATE runs SET auth_signal = NULL WHERE id = ${run_id}`;
-      return current.payload ?? {};
-    });
+			await tx`UPDATE runs SET auth_signal = NULL WHERE id = ${run_id}`;
+			return current.payload ?? {};
+		});
 
-    return c.json(consumed ? { signal: consumed } : {});
-  } catch (err: unknown) {
-    return c.json({ error: errorMessage(err) }, 500);
-  }
+		return c.json(consumed ? { signal: consumed } : {});
+	} catch (err: unknown) {
+		return c.json({ error: errorMessage(err) }, 500);
+	}
 }
 
 /**
@@ -1158,92 +1227,102 @@ export async function pollAuthSignal(c: Context<{ Bindings: Env }>) {
  * written to the linked auth_profiles row and the profile moves to 'active'.
  */
 export async function completeAuthRun(c: Context<{ Bindings: Env }>) {
-  try {
-    const req = await c.req.json<{
-      run_id: number;
-      worker_id: string;
-      status: 'success' | 'failed';
-      credentials?: Record<string, unknown>;
-      metadata?: Record<string, unknown>;
-      error_message?: string;
-      // Diagnostic fields from the subprocess executor (failed-run path only).
-      // The worker redacts output_tail before sending; backend stores as-is.
-      output_tail?: string;
-      exit_code?: number | null;
-      exit_signal?: string | null;
-      exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
-    }>();
+	try {
+		const req = await c.req.json<{
+			run_id: number;
+			worker_id: string;
+			status: "success" | "failed";
+			credentials?: Record<string, unknown>;
+			metadata?: Record<string, unknown>;
+			error_message?: string;
+			// Diagnostic fields from the subprocess executor (failed-run path only).
+			// The worker redacts output_tail before sending; backend stores as-is.
+			output_tail?: string;
+			exit_code?: number | null;
+			exit_signal?: string | null;
+			exit_reason?: "ok" | "error_message" | "timeout" | "oom" | "crash";
+		}>();
 
-    // Ownership gate — a worker can only finalize runs it claimed. Mirrors the
-    // other /complete handlers. Without it a leaked worker token could finalize
-    // an arbitrary auth run and inject credentials into the linked auth_profiles
-    // row. authorizeRunForWorker waves through token-auth (non-'user') mode, so
-    // the claimant/status guard inside finalizeRun is what protects that path.
-    const denied = await authorizeRunForWorker(c, req.run_id, req.worker_id);
-    if (denied) return denied;
+		// Ownership gate — a worker can only finalize runs it claimed. Mirrors the
+		// other /complete handlers. Without it a leaked worker token could finalize
+		// an arbitrary auth run and inject credentials into the linked auth_profiles
+		// row. authorizeRunForWorker waves through token-auth (non-'user') mode, so
+		// the claimant/status guard inside finalizeRun is what protects that path.
+		const denied = await authorizeRunForWorker(c, req.run_id, req.worker_id);
+		if (denied) return denied;
 
-    const sql = getDb();
+		const sql = getDb();
 
-    // Atomic terminal transition with the shared F2 guard (see finalizeRun), so
-    // a late/reaped completion is a no-op rather than resurrecting the run and
-    // double-applying the auth_profile/connection/feed side effects below. The
-    // failed path also clears auth_signal and stamps exit diagnostics.
-    const runRows = (await finalizeRun(sql, {
-      runId: req.run_id,
-      workerId: req.worker_id,
-      status: req.status === 'failed' ? 'failed' : 'completed',
-      extraSet:
-        req.status === 'failed'
-          ? sql`,
+		// Atomic terminal transition with the shared F2 guard (see finalizeRun), so
+		// a late/reaped completion is a no-op rather than resurrecting the run and
+		// double-applying the auth_profile/connection/feed side effects below. The
+		// failed path also clears auth_signal and stamps exit diagnostics.
+		const runRows = (await finalizeRun(sql, {
+			runId: req.run_id,
+			workerId: req.worker_id,
+			status: req.status === "failed" ? "failed" : "completed",
+			extraSet:
+				req.status === "failed"
+					? sql`,
           error_message = ${req.error_message ?? null},
           auth_signal = NULL,
           output_tail = ${req.output_tail ?? null},
           exit_code = ${req.exit_code ?? null},
           exit_signal = ${req.exit_signal ?? null},
           exit_reason = ${req.exit_reason ?? null}`
-          : sql`,
+					: sql`,
           error_message = ${req.error_message ?? null},
           auth_signal = NULL`,
-      returning: sql`auth_profile_id, organization_id`,
-    })) as unknown as Array<{ auth_profile_id: number | null; organization_id: string }>;
+			returning: sql`auth_profile_id, organization_id`,
+		})) as unknown as Array<{
+			auth_profile_id: number | null;
+			organization_id: string;
+		}>;
 
-    if (runRows.length === 0) {
-      // Already finalized (timeout race) or not the claimant. Skip all
-      // auth_profile/connection/feed side effects and ack idempotently.
-      logger.info(
-        { run_id: req.run_id, worker_id: req.worker_id, claimed_status: req.status },
-        '[completeAuthRun] no-op: run already in terminal state (likely gateway timeout)'
-      );
-      return c.json({ success: false, reason: 'already_finalized' });
-    }
+		if (runRows.length === 0) {
+			// Already finalized (timeout race) or not the claimant. Skip all
+			// auth_profile/connection/feed side effects and ack idempotently.
+			logger.info(
+				{
+					run_id: req.run_id,
+					worker_id: req.worker_id,
+					claimed_status: req.status,
+				},
+				"[completeAuthRun] no-op: run already in terminal state (likely gateway timeout)",
+			);
+			return c.json({ success: false, reason: "already_finalized" });
+		}
 
-    const authProfileId = runRows[0]?.auth_profile_id ?? null;
-    const organizationId = runRows[0]?.organization_id;
+		const authProfileId = runRows[0]?.auth_profile_id ?? null;
+		const organizationId = runRows[0]?.organization_id;
 
-    if (req.status === 'success' && authProfileId && req.credentials) {
-      await reactivateProfileCascade(sql, authProfileId, {
-        credentials: req.credentials,
-        metadata: req.metadata ?? {},
-      });
+		if (req.status === "success" && authProfileId && req.credentials) {
+			await reactivateProfileCascade(sql, authProfileId, {
+				credentials: req.credentials,
+				metadata: req.metadata ?? {},
+			});
 
-      if (organizationId) {
-        emit(organizationId, { keys: ['connections', 'auth-profiles'] });
-      }
-    } else if (req.status === 'failed' && authProfileId) {
-      await sql`
+			if (organizationId) {
+				emit(organizationId, { keys: ["connections", "auth-profiles"] });
+			}
+		} else if (req.status === "failed" && authProfileId) {
+			await sql`
         UPDATE auth_profiles
         SET status = 'error',
             updated_at = current_timestamp
         WHERE id = ${authProfileId}
       `;
-    }
+		}
 
-    logger.info({ run_id: req.run_id, status: req.status }, 'Auth run completed');
-    return c.json({ success: true });
-  } catch (err: unknown) {
-    logger.error({ error: errorMessage(err) }, '[completeAuthRun] Error');
-    return c.json({ error: errorMessage(err) }, 500);
-  }
+		logger.info(
+			{ run_id: req.run_id, status: req.status },
+			"Auth run completed",
+		);
+		return c.json({ success: true });
+	} catch (err: unknown) {
+		logger.error({ error: errorMessage(err) }, "[completeAuthRun] Error");
+		return c.json({ error: errorMessage(err) }, 500);
+	}
 }
 
 /**
@@ -1252,75 +1331,82 @@ export async function completeAuthRun(c: Context<{ Bindings: Env }>) {
  * Worker signals action run completion (for async high-risk actions).
  */
 export async function completeActionRun(c: Context<{ Bindings: Env }>) {
-  try {
-    const req = await c.req.json<{
-      run_id: number;
-      worker_id: string;
-      status: 'success' | 'failed';
-      action_output?: Record<string, unknown>;
-      error_message?: string;
-    }>();
+	try {
+		const req = await c.req.json<{
+			run_id: number;
+			worker_id: string;
+			status: "success" | "failed";
+			action_output?: Record<string, unknown>;
+			error_message?: string;
+		}>();
 
-    // Same ownership check as the other /complete endpoints — a worker
-    // can only finalize runs it claimed. Without this, a leaked worker
-    // token could overwrite action_output on arbitrary runs.
-    const denied = await authorizeRunForWorker(c, req.run_id, req.worker_id);
-    if (denied) return denied;
+		// Same ownership check as the other /complete endpoints — a worker
+		// can only finalize runs it claimed. Without this, a leaked worker
+		// token could overwrite action_output on arbitrary runs.
+		const denied = await authorizeRunForWorker(c, req.run_id, req.worker_id);
+		if (denied) return denied;
 
-    const sql = getDb();
+		const sql = getDb();
 
-    // Atomic terminal-state transition with the shared F2 guard (see
-    // finalizeRun), so a no-op (0 rows) means the row was already finalized by
-    // another path (e.g. waitForDeviceActionRun timed out and marked it
-    // 'timeout'). Without it a slow worker could overwrite a gateway-side
-    // timeout decision with success — and the caller has already returned
-    // timeout to its caller, so the action would double-finalize.
-    const updatedRuns = await finalizeRun(sql, {
-      runId: req.run_id,
-      workerId: req.worker_id,
-      status: req.status === 'success' ? 'completed' : 'failed',
-      extraSet: sql`,
+		// Atomic terminal-state transition with the shared F2 guard (see
+		// finalizeRun), so a no-op (0 rows) means the row was already finalized by
+		// another path (e.g. waitForDeviceActionRun timed out and marked it
+		// 'timeout'). Without it a slow worker could overwrite a gateway-side
+		// timeout decision with success — and the caller has already returned
+		// timeout to its caller, so the action would double-finalize.
+		const updatedRuns = await finalizeRun(sql, {
+			runId: req.run_id,
+			workerId: req.worker_id,
+			status: req.status === "success" ? "completed" : "failed",
+			extraSet: sql`,
           action_output = ${req.action_output ? sql.json(req.action_output) : null},
           error_message = ${req.error_message ?? null}`,
-      returning: sql`organization_id, action_key`,
-    });
-    if (updatedRuns.length === 0) {
-      // Either the run was already finalized (timeout race) or the
-      // worker isn't the claimant. authorizeRunForWorker already gated
-      // ownership, so this is almost always the timeout race; return
-      // a clear status so the worker's logs are informative.
-      logger.info(
-        { run_id: req.run_id, worker_id: req.worker_id, claimed_status: req.status },
-        '[completeActionRun] no-op: run already in terminal state (likely gateway timeout)'
-      );
-      return c.json({ success: false, reason: 'already_finalized' });
-    }
+			returning: sql`organization_id, action_key`,
+		});
+		if (updatedRuns.length === 0) {
+			// Either the run was already finalized (timeout race) or the
+			// worker isn't the claimant. authorizeRunForWorker already gated
+			// ownership, so this is almost always the timeout race; return
+			// a clear status so the worker's logs are informative.
+			logger.info(
+				{
+					run_id: req.run_id,
+					worker_id: req.worker_id,
+					claimed_status: req.status,
+				},
+				"[completeActionRun] no-op: run already in terminal state (likely gateway timeout)",
+			);
+			return c.json({ success: false, reason: "already_finalized" });
+		}
 
-    const organizationId = (updatedRuns[0] as any)?.organization_id;
-    const actionKey = (updatedRuns[0] as any)?.action_key ?? 'Action';
+		const organizationId = (updatedRuns[0] as any)?.organization_id;
+		const actionKey = (updatedRuns[0] as any)?.action_key ?? "Action";
 
-    if (organizationId) {
-      const newStatus = req.status === 'success' ? 'completed' : 'failed';
-      await supersedeActionEvent(
-        req.run_id,
-        organizationId,
-        newStatus,
-        `${actionKey} — ${newStatus}`,
-        req.status === 'success'
-          ? `Action completed: ${actionKey}`
-          : `Action failed: ${actionKey}${req.error_message ? ` — ${req.error_message}` : ''}`,
-        req.status === 'success'
-          ? { action_output: req.action_output }
-          : { error_message: req.error_message }
-      );
+		if (organizationId) {
+			const newStatus = req.status === "success" ? "completed" : "failed";
+			await supersedeActionEvent(
+				req.run_id,
+				organizationId,
+				newStatus,
+				`${actionKey} — ${newStatus}`,
+				req.status === "success"
+					? `Action completed: ${actionKey}`
+					: `Action failed: ${actionKey}${req.error_message ? ` — ${req.error_message}` : ""}`,
+				req.status === "success"
+					? { action_output: req.action_output }
+					: { error_message: req.error_message },
+			);
 
-      emit(organizationId, { keys: ['contents-filtered', 'notifications'] });
-    }
+			emit(organizationId, { keys: ["contents-filtered", "notifications"] });
+		}
 
-    logger.info({ run_id: req.run_id, status: req.status }, 'Action run completed');
-    return c.json({ success: true });
-  } catch (err: unknown) {
-    logger.error({ error: errorMessage(err) }, '[completeActionRun] Error');
-    return c.json({ error: errorMessage(err) }, 500);
-  }
+		logger.info(
+			{ run_id: req.run_id, status: req.status },
+			"Action run completed",
+		);
+		return c.json({ success: true });
+	} catch (err: unknown) {
+		logger.error({ error: errorMessage(err) }, "[completeActionRun] Error");
+		return c.json({ error: errorMessage(err) }, 500);
+	}
 }


### PR DESCRIPTION
Follow-up to #1733 — fixes remaining agent-facing references to the old flat MCP tools.

## Owletto (Mac app)
- `WatcherDispatcher`: `--allowedTools` now pre-approves `mcp__lobu__query_sdk` and `mcp__lobu__run_sdk`
- Completion contract prompt uses `query_sdk` (`client.knowledge.read`) and `run_sdk` (`client.watchers.completeWindow`)
- `LobuClient` comments updated to match

## Owletto (web)
- Watcher summary copy-agent prompt references `query_sdk` / `run_sdk`
- Stitch test fixture uses `query_sdk` tool name

## Lobu server
- `run-completion.ts` and `run-lifecycle.ts` error messages/comments reference `query_sdk` / `run_sdk` instead of `read_knowledge` / `manage_watchers`
- `automation-contract.test.ts` assertions updated for new error strings

Internal REST dispatch (`read_knowledge`, `manage_watchers`) is unchanged — only MCP `tools/list` and agent-facing strings were slimmed in #1733.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785804244&installation_id=136316292&pr_number=1734&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1734&signature=9baad01eccf7c38175cd814293c398ec8eb8eb0665a5610f5f13110749997180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->