### PR TITLE
fix(agent-worker): route behavior model providers

### DIFF
--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -74,6 +74,44 @@ describe("resolveModelRef", () => {
     expect(result.modelId).toBe("anthropic/claude-sonnet-4");
   });
 
+  test("behavior override switches to another installed provider", () => {
+    const result = resolveModelRef("z-ai/glm-5.2", {
+      defaultModel: "claude/claude-sonnet-4-5",
+      defaultProvider: "anthropic",
+      defaultProviderSlug: "claude",
+      installedProviderRoutes: { claude: "anthropic", "z-ai": "z-ai" },
+      allowInstalledProviderOverride: true,
+    });
+
+    expect(result.provider).toBe("z-ai");
+    expect(result.modelId).toBe("glm-5.2");
+  });
+
+  test("behavior override resolves auto against the selected installed provider", () => {
+    const result = resolveModelRef("z-ai/auto", {
+      defaultModel: "claude/claude-sonnet-4-5",
+      defaultProvider: "anthropic",
+      defaultProviderSlug: "claude",
+      installedProviderRoutes: { claude: "anthropic", "z-ai": "z-ai" },
+      allowInstalledProviderOverride: true,
+    });
+
+    expect(result.provider).toBe("z-ai");
+    expect(result.modelId).toBe(DEFAULT_PROVIDER_MODELS["z-ai"]);
+  });
+
+  test("behavior override routes a Lobu provider ID to its upstream runtime slug", () => {
+    const result = resolveModelRef("claude/claude-sonnet-4-5", {
+      defaultModel: "z-ai/glm-5.2",
+      defaultProvider: "z-ai",
+      installedProviderRoutes: { claude: "anthropic", "z-ai": "z-ai" },
+      allowInstalledProviderOverride: true,
+    });
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.modelId).toBe("claude-sonnet-4-5");
+  });
+
   test("falls back to overrides.defaultModel when rawModelRef is empty", () => {
     const result = resolveModelRef("", {
       defaultModel: "anthropic/claude-sonnet-4-20250514",
@@ -115,6 +153,38 @@ describe("resolveModelRef", () => {
     });
     expect(result.provider).toBe("openrouter");
     expect(result.modelId).toBe("anthropic/claude-sonnet-4");
+  });
+
+  test("installed providers do not reinterpret an OpenRouter vendor namespace", () => {
+    const result = resolveModelRef("anthropic/claude-sonnet-4", {
+      defaultProvider: "openrouter",
+      installedProviderRoutes: { openrouter: "openrouter", "z-ai": "z-ai" },
+    });
+
+    expect(result.provider).toBe("openrouter");
+    expect(result.modelId).toBe("anthropic/claude-sonnet-4");
+  });
+
+  test("base model stays on OpenRouter when its vendor prefix is also an installed provider", () => {
+    const result = resolveModelRef("openai/gpt-4o", {
+      defaultModel: "openai/gpt-4o",
+      defaultProvider: "openrouter",
+      installedProviderRoutes: { openrouter: "openrouter", openai: "openai" },
+    });
+
+    expect(result.provider).toBe("openrouter");
+    expect(result.modelId).toBe("openai/gpt-4o");
+  });
+
+  test("OpenRouter vendor model changes do not switch providers without an explicit behavior signal", () => {
+    const result = resolveModelRef("openai/gpt-4o-mini", {
+      defaultModel: "openai/gpt-4o",
+      defaultProvider: "openrouter",
+      installedProviderRoutes: { openrouter: "openrouter", openai: "openai" },
+    });
+
+    expect(result.provider).toBe("openrouter");
+    expect(result.modelId).toBe("openai/gpt-4o-mini");
   });
 
   test("configured provider: a redundant self-prefix is stripped (z-ai/glm-4.7 → glm-4.7)", () => {

--- a/packages/agent-worker/src/openclaw/model-resolver.ts
+++ b/packages/agent-worker/src/openclaw/model-resolver.ts
@@ -206,6 +206,8 @@ export function resolveModelRef(
     defaultModel?: string;
     defaultProvider?: string;
     defaultProviderSlug?: string;
+    installedProviderRoutes?: Record<string, string>;
+    allowInstalledProviderOverride?: boolean;
   }
 ): {
   provider: string;
@@ -231,6 +233,38 @@ export function resolveModelRef(
       "No model resolved for this run. Set the agent's default model, a " +
         "per-behavior model, or an org default inference provider."
     );
+  }
+
+  // A per-behavior model override can deliberately select another installed
+  // provider (for example, a watcher using z-ai while its base agent uses
+  // Claude). Prefer that explicit provider only when the prefix names a real
+  // installed provider, and route its Lobu ID to the upstream runtime slug
+  // (for example, claude → anthropic). This preserves model namespaces such as
+  // OpenRouter's "anthropic/claude-sonnet-4", where "anthropic" is not a
+  // separately installed provider and the configured OpenRouter route must win.
+  // Switching also requires an explicit behavior-override signal from the
+  // gateway. A slash prefix alone is ambiguous: OpenRouter model namespaces
+  // such as "openai/gpt-4o" must stay on OpenRouter even when standalone OpenAI
+  // is installed alongside it.
+  const explicitParts = normalizedRaw?.split("/").filter(Boolean) ?? [];
+  const explicitProvider = explicitParts[0];
+  if (
+    explicitParts.length >= 2 &&
+    explicitProvider &&
+    overrides?.allowInstalledProviderOverride === true &&
+    overrides?.installedProviderRoutes?.[explicitProvider] &&
+    explicitProvider !== defaultProvider &&
+    explicitProvider !== defaultProviderSlug
+  ) {
+    const routedProvider = overrides.installedProviderRoutes[explicitProvider];
+    let modelId = explicitParts.slice(1).join("/");
+    if (modelId === "auto") {
+      modelId =
+        DEFAULT_PROVIDER_MODELS[explicitProvider] ??
+        DEFAULT_PROVIDER_MODELS[routedProvider] ??
+        modelId;
+    }
+    return { provider: routedProvider, modelId };
   }
 
   // When the agent has an explicitly configured provider, route to it and pass

--- a/packages/agent-worker/src/openclaw/session-context.ts
+++ b/packages/agent-worker/src/openclaw/session-context.ts
@@ -32,6 +32,8 @@ interface ProviderConfig {
   providerBaseUrlMappings?: Record<string, string>;
   /** Dynamic provider metadata from config-driven providers */
   configProviders?: Record<string, ConfigProviderMeta>;
+  /** Installed Lobu provider ID → upstream runtime provider slug. */
+  installedProviderRoutes?: Record<string, string>;
   /** Credential env var placeholders for proxy mode (e.g. Z_AI_API_KEY → "lobu-proxy") */
   credentialPlaceholders?: Record<string, string>;
 }

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -566,6 +566,8 @@ export async function runAISession(
     defaultModel: pc.defaultModel,
     defaultProvider: pc.defaultProvider,
     defaultProviderSlug: pc.defaultProviderSlug,
+    installedProviderRoutes: pc.installedProviderRoutes,
+    allowInstalledProviderOverride: rawOptions.behaviorModelOverride === true,
   });
   // Map gateway slug to model-registry provider name (e.g. "z-ai" → "zai")
   const provider = PROVIDER_REGISTRY_ALIASES[rawProvider] || rawProvider;

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -825,6 +825,7 @@ export class WorkerGateway {
     }>;
     providerBaseUrlMappings?: Record<string, string>;
     configProviders?: Record<string, ConfigProviderMeta>;
+    installedProviderRoutes?: Record<string, string>;
   }> {
     if (!this.providerCatalogService || !agentId) {
       return {};
@@ -922,6 +923,7 @@ export class WorkerGateway {
       cliBackends?: typeof cliBackends;
       providerBaseUrlMappings?: Record<string, string>;
       configProviders?: typeof configProviders;
+      installedProviderRoutes?: Record<string, string>;
       credentialPlaceholders?: Record<string, string>;
     } = {};
 
@@ -960,6 +962,13 @@ export class WorkerGateway {
     if (Object.keys(configProviders).length > 0) {
       result.configProviders = configProviders;
     }
+
+    result.installedProviderRoutes = Object.fromEntries(
+      effectiveProviders.map((provider) => [
+        provider.providerId,
+        provider.getUpstreamConfig?.()?.slug || provider.providerId,
+      ])
+    );
 
     if (Object.keys(credentialPlaceholders).length > 0) {
       result.credentialPlaceholders = credentialPlaceholders;

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1453,6 +1453,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
       const baseOptions: Record<string, any> = {
         provider: session.provider || "claude",
         model: behaviorModel ?? session.model,
+        ...(behaviorModel ? { behaviorModelOverride: true } : {}),
       };
       const agentOptions = await resolveAgentOptions(
         realAgentId,

--- a/packages/server/src/gateway/services/agent-threads.ts
+++ b/packages/server/src/gateway/services/agent-threads.ts
@@ -178,6 +178,7 @@ export async function enqueueAgentMessage(
     agentOptions: {
       provider: session.provider || "claude",
       model: args.model ?? session.model,
+      ...(args.model ? { behaviorModelOverride: true } : {}),
     },
     networkConfig: session.networkConfig,
   });

--- a/packages/server/src/scheduled/__tests__/wake-agent-delivery.test.ts
+++ b/packages/server/src/scheduled/__tests__/wake-agent-delivery.test.ts
@@ -7,6 +7,7 @@ import {
   seedAgentRow,
 } from "../../gateway/__tests__/helpers/db-setup";
 import type { CoreServices } from "../../gateway/services/core-services";
+import { enqueueAgentMessage } from "../../gateway/services/agent-threads";
 import { runtimeConnectionIdToSlug } from "../../lobu/stores/connections-projection";
 import { runWakeAgentTask, type WakeAgentTaskPayload } from "../jobs";
 
@@ -134,7 +135,10 @@ describe("runWakeAgentTask chat delivery dispatch", () => {
     );
 
     expect(enqueued).toHaveLength(1);
-    expect(enqueued[0].agentOptions).toEqual({ model: "openai/gpt-5" });
+    expect(enqueued[0].agentOptions).toEqual({
+      model: "openai/gpt-5",
+      behaviorModelOverride: true,
+    });
   });
 
   test("leaves agentOptions empty when no per-schedule model is set", async () => {
@@ -219,5 +223,41 @@ describe("runWakeAgentTask chat delivery dispatch", () => {
       )
     ).rejects.toThrow("API_PATH_REACHED");
     expect(enqueued).toHaveLength(0);
+  });
+});
+
+test("internal API-thread dispatch marks a supplied model as a behavior override", async () => {
+  const enqueued: MessagePayload[] = [];
+  const deps = {
+    sessionManager: {
+      getSession: async () => ({
+        userId: USER,
+        conversationId: "thread-1",
+        agentId: AGENT,
+        provider: "claude",
+        model: "claude/claude-sonnet-4-5",
+      }),
+      touchSession: async () => {},
+    },
+    queueProducer: {
+      enqueueMessage: async (message: MessagePayload) => {
+        enqueued.push(message);
+        return "queued";
+      },
+    },
+  } as unknown as Parameters<typeof enqueueAgentMessage>[0];
+
+  await enqueueAgentMessage(
+    deps,
+    {
+      threadId: "thread-1",
+      messageText: "wake up",
+      model: "z-ai/glm-5.2",
+    }
+  );
+
+  expect(enqueued[0].agentOptions).toMatchObject({
+    model: "z-ai/glm-5.2",
+    behaviorModelOverride: true,
   });
 });

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -486,7 +486,9 @@ export async function runWakeAgentTask(
           organizationId: orgId,
           source: 'scheduled-job',
         },
-        agentOptions: behaviorModel ? { model: behaviorModel } : {},
+        agentOptions: behaviorModel
+          ? { model: behaviorModel, behaviorModelOverride: true }
+          : {},
       })
     );
     return;


### PR DESCRIPTION
## Summary
- let watcher and schedule model overrides select a different installed inference provider
- route Lobu provider IDs to their upstream runtime slugs, including claude to anthropic
- require an explicit gateway-owned behavior override marker so OpenRouter vendor namespaces are never reinterpreted
- propagate the marker through direct API, chat delivery, and internal scheduled thread dispatch

## Red to green reproducer
Before the fix, resolving z-ai/glm-5.2 for a watcher whose base agent used Anthropic returned provider anthropic with model z-ai/glm-5.2. The focused test failed: expected z-ai, received anthropic.

After the fix, the resolver routes to z-ai with model glm-5.2. Focused validation: 82 tests pass across resolver and scheduled delivery suites.

## Validation
- bun test model-resolver.test.ts model-resolver-harden.test.ts wake-agent-delivery.test.ts: 82 pass, 0 fail
- bun run typecheck: pass
- make build-packages: pass
- make clean-workers: pass
- Claude Opus review: SHIP, no blocking findings; all later automated review findings addressed
- make review: build/typecheck/unit pass; integration repeats seven unrelated existing Slack, GitHub app-install, history fixture, and cleanup timeout failures

## Multi-replica
Provider routes are derived per request from the DB-backed installed provider catalog. No shared in-memory state is introduced.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785815994&installation_id=136316292&pr_number=1738&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1738&signature=2202a3d60598ba29d4e8f2c913729365dcb7c87ca887199494532cb8d7ef6f3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for model override routing across installed providers, including safer handling of provider-prefixed model IDs.
  * Requests can now mark when a model choice is an explicit behavior override, enabling more precise routing.

* **Bug Fixes**
  * Improved model selection so OpenRouter-style provider namespaces continue to resolve correctly unless override behavior is explicitly enabled.
  * Preserved automatic model resolution when switching between installed providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->