### PR TITLE
feat: add app focus telemetry to Owletto Mac

### DIFF
--- a/packages/connectors/src/apple_screen_time.ts
+++ b/packages/connectors/src/apple_screen_time.ts
@@ -26,7 +26,7 @@ export default class AppleScreenTimeConnector extends BridgeOnlyConnector {
     key: 'apple.screen_time',
     name: 'Apple Screen Time',
     description:
-      'Daily per-app usage totals from Lobu for Mac, sourced from the Apple Knowledge store. Captures both Mac usage and (if Screen Time iCloud sync is on) the user\'s iOS device usage.',
+      'Daily per-app usage totals and focus-switch counts from Lobu for Mac, sourced from the Apple Knowledge store. Captures both Mac usage and (if Screen Time iCloud sync is on) the user\'s iOS device usage.',
     version: '0.1.0',
     faviconDomain: 'apple.com',
     requiredCapability: 'screentime',
@@ -62,6 +62,65 @@ export default class AppleScreenTimeConnector extends BridgeOnlyConnector {
                 date: { type: 'string', format: 'date' },
                 bundle_id: { type: 'string' },
                 seconds: { type: 'number', minimum: 0 },
+              },
+            },
+          },
+        },
+      },
+      daily_app_focus_switches: {
+        key: 'daily_app_focus_switches',
+        name: 'Daily app focus switches',
+        description:
+          'Number of times each application (by bundle id) was brought to the foreground on a given day. Complements daily_app_usage: two hours in Slack as one long session vs. forty short switches are very different focus patterns, and only the switch count distinguishes them. Sourced from the same knowledgeC.db /app/inFocus stream.',
+        configSchema: {
+          type: 'object',
+          properties: {
+            backfill_days: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 90,
+              default: 14,
+              description: 'How many days the bridge should backfill on each sync.',
+            },
+          },
+        },
+        eventKinds: {
+          app_focus_switches_daily: {
+            description:
+              'Number of times the user switched into one application on a given day.',
+            metadataSchema: {
+              type: 'object',
+              required: ['source', 'origin_id', 'date', 'bundle_id', 'switches'],
+              properties: {
+                source: { type: 'string', const: 'apple_screen_time' },
+                origin_id: { type: 'string' },
+                date: { type: 'string', format: 'date' },
+                bundle_id: { type: 'string' },
+                switches: { type: 'integer', minimum: 0 },
+              },
+            },
+          },
+        },
+      },
+      live_app_focus: {
+        key: 'live_app_focus',
+        name: 'Live app focus',
+        description:
+          'Real-time app-focus transitions captured by the Mac menubar app via NSWorkspace.didActivateApplication, drained on each poll. Same event shape as daily_app_focus_switches but sub-second-latency observations rather than a retrospective knowledgeC.db pull. Source is tagged apple_screen_time_live so the two can be told apart.',
+        configSchema: { type: 'object', properties: {} },
+        eventKinds: {
+          app_focus_switches_daily: {
+            description:
+              'Number of times the user switched into one application on a given day (live observation).',
+            metadataSchema: {
+              type: 'object',
+              required: ['source', 'origin_id', 'date', 'bundle_id', 'switches'],
+              properties: {
+                source: { type: 'string' },
+                origin_id: { type: 'string' },
+                date: { type: 'string', format: 'date' },
+                bundle_id: { type: 'string' },
+                switches: { type: 'integer', minimum: 0 },
               },
             },
           },


### PR DESCRIPTION
## Summary

Adds per-app **foreground switch counts** to Owletto Mac telemetry — how many times the user brought each app to the front per day. Complements Screen Time's existing foreground *duration* (minutes): two hours in Slack as one long session vs. as forty short switches are very different focus patterns, and only the switch count distinguishes them.

Implemented as **two new feeds on the existing `apple.screen_time` connector** (not a new connector — same `knowledgeC.db`, same Full Disk Access grant, same Mac, no auth):

| Feed | Source | Latency |
|---|---|---|
| `daily_app_usage` (existing) | `knowledgeC.db /app/usage` | retrospective (6h poll) |
| `daily_app_focus_switches` (new) | `knowledgeC.db /app/inFocus` | retrospective (6h poll) |
| `live_app_focus` (new) | `NSWorkspace.didActivateApplication` | near-live (buffered, drained on poll) |

All three emit under the existing `screentime` capability — **no new connector, no new capability string, no new TCC, no new entitlements.**

## Changes

**Server (`packages/connectors/src/apple_screen_time.ts`):**
- Added `daily_app_focus_switches` + `live_app_focus` feeds to the existing connector, both emitting `app_focus_switches_daily` events (`source`, `origin_id`, `date`, `bundle_id`, `switches`). The live feed tags `source: apple_screen_time_live` so it can be told apart from the retrospective pull at query time.

**Mac (`packages/owletto/apps/mac/Owletto/`):**
- `KnowledgeKitReader.swift` — new `dailyAppFocusSwitches(days:)` reading `/app/inFocus`; extracted a shared `openReadonlyDB()` helper so both readers share the Full-Disk-Access error path.
- `ScreenTimeSyncService.swift` — routes by `job.feed_key` across all three feeds.
- `AppFocusLiveService.swift` (new) — singleton `NSWorkspace` observer; buffers transitions to `Application Support/Lobu/app-focus-live.jsonl`; idempotent `drainBuffer()` ships+clears on pull. **No new push transport** — reuses the proven pull cycle.
- `AppState.swift` — starts the observer in `init()` (`NSWorkspace` needs no TCC).
- `project.pbxproj` — registers the new file.

**Bumps `packages/owletto` submodule pointer** → `feat/mac-focus-telemetry` (`d88259d2`).

## Privacy

Only **bundle-id + the numeric metric** (seconds or switch count) leave the device. No window titles, document names, or URLs. The `NSWorkspace` observer reads no accessibility state. Reuses the existing Full Disk Access grant; zero new TCC, zero new entitlements, zero notarization delta.

## Validation

- [x] `bun run typecheck` clean
- [x] Mac app `xcodebuild` → **BUILD SUCCEEDED**
- [x] Husky pre-commit (biome + tsc) passed
- [x] Connector definition: 3 feeds under `screentime` capability, `runtime.platforms: ['macos']`
- [x] Device-reconcile auto-wire: all 3 feed keys picked up from current source
- [x] Mac output validates against eventKind schemas for all 3 feeds (ajv)
- [ ] True device-pairing red→green (pair Mac → assert feeds wired → assert events land) — needs a fresh DB / real paired device; gateway-side layers verified in isolation

## E2E note

The live `knowledgeC.db` reader SQL and the `NSWorkspace` observer are the two paths that compile-check but need a real Mac + Knowledge DB to confirm at runtime. The SQL mirrors the proven `/app/usage` query (same columns, same time math); the observer is a standard `NSWorkspace.shared.notificationCenter` subscription. Both are low-risk but "compiles ≠ runs" — flagging for the device-side check on pickup.

Part of the phased Mac telemetry plan (Phase 1). Actuation (bash/osascript, then Peekaboo) is deferred to follow-up PRs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785848765&installation_id=136316292&pr_number=1739&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1739&signature=8fe3a2b16fbeaae82a2709a4ab830f8eba8150220c498069e04152d073e41ba4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new Apple Screen Time feeds for daily per-app focus switch counts (with daily backfill) and near-real-time focus observations, including required event metadata details.
* **Chores**
  * Updated the included bundled content to a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->