### PR TITLE
fix(server): recognize org inference credentials

### DIFF
--- a/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
@@ -8,11 +8,16 @@ const TEST_ENCRYPTION_KEY = Buffer.from(
 // Controls what the mocked org context and db return per-test.
 let mockOrgId: string | null = null;
 let orgSharedSecretRows: Array<{ ciphertext: string }> = [];
+let inferenceProviderRows: Array<{
+  block: { base_url?: string } | null;
+  ciphertext: string | null;
+}> = [];
 
 // Mock the org-context AsyncLocalStorage lookup so we can simulate a worker
 // request that does (or doesn't) carry an org.
 mock.module("../../../lobu/stores/org-context.js", () => ({
   tryGetOrgId: () => mockOrgId,
+  resolveOrgId: (explicit?: string | null) => explicit ?? mockOrgId,
   getOrgId: () => {
     if (!mockOrgId) throw new Error("no org");
     return mockOrgId;
@@ -23,7 +28,12 @@ mock.module("../../../lobu/stores/org-context.js", () => ({
 // template (`sql\`SELECT ...\``); a tagged-template call invokes the function
 // with (strings, ...values), so returning the rows array satisfies it.
 mock.module("../../../db/client.js", () => ({
-  getDb: () => () => Promise.resolve(orgSharedSecretRows),
+  getDb: () => (strings: TemplateStringsArray) =>
+    Promise.resolve(
+      strings.join(" ").includes("FROM inference_providers")
+        ? inferenceProviderRows
+        : orgSharedSecretRows
+    ),
 }));
 
 // Import AFTER mocks so the module graph picks them up.
@@ -54,6 +64,7 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
     delete process.env.Z_AI_API_KEY;
     mockOrgId = null;
     orgSharedSecretRows = [];
+    inferenceProviderRows = [];
   });
 
   afterEach(() => {
@@ -80,6 +91,35 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
       await mod.hasCredentials("agent-1", { organizationId: "org-1" })
     ).toBe(true);
     expect(await mod.hasCredentials("agent-1")).toBe(true);
+  });
+
+  test("returns true when the org inference-provider row owns the custom upstream key", async () => {
+    mockOrgId = "org-1";
+    inferenceProviderRows = [
+      {
+        block: { base_url: "https://api.z.ai/api/paas/v4" },
+        ciphertext: encrypt("zai-inference-provider-key"),
+      },
+    ];
+
+    const mod = makeModule(false);
+    expect(
+      await mod.hasCredentials("agent-1", { organizationId: "org-1" })
+    ).toBe(true);
+  });
+
+  test("returns false when a custom upstream has no usable org key, even with a profile", async () => {
+    inferenceProviderRows = [
+      {
+        block: { base_url: "https://custom.example.com/v1" },
+        ciphertext: null,
+      },
+    ];
+
+    const mod = makeModule(true);
+    expect(
+      await mod.hasCredentials("agent-1", { organizationId: "org-1" })
+    ).toBe(false);
   });
 
   test("returns false when neither profile nor org-shared key exists", async () => {

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -169,6 +169,21 @@ export abstract class BaseProviderModule
     agentId: string,
     context?: ProviderCredentialContext
   ): Promise<boolean> {
+    // Keep this availability check aligned with resolveCredential(). An org
+    // inference-provider row can own both a custom upstream and its key; that
+    // key is intentionally absent from per-agent auth profiles and the legacy
+    // org-shared provider secret. Treat it as available so proxy-mode workers
+    // receive an opaque credential placeholder and can reach the gateway,
+    // where the URL invariant resolves the real key at egress. Conversely, a
+    // custom upstream with an unavailable key must fail closed even when a
+    // profile exists, because that profile is not consented for the custom URL.
+    const invariant = await resolveUrlInvariant(
+      this.providerId,
+      resolveOrgId(context?.organizationId) ?? undefined
+    );
+    if (invariant.kind === "org-only") return true;
+    if (invariant.kind === "org-only-unavailable") return false;
+
     const hasProfile = await this.authProfilesManager.hasProviderProfiles(
       agentId,
       this.providerId,


### PR DESCRIPTION
## Summary
- recognize org-owned custom-upstream credentials during provider availability checks
- let proxy-mode workers receive only the opaque placeholder; the gateway still resolves the real key at egress
- preserve fail-closed behavior when a custom upstream key is missing or undecryptable

## Reproducer
- Red: an installed Z.AI behavior override routed to zai but failed before egress with `needs to connect zai` because `hasCredentials()` ignored the org inference-provider row
- Green: regression test proves the org row is available while a missing custom-upstream key remains fail-closed

## Validation
- focused regression: 6 passed
- gateway auth tests: 50 passed
- `bun run typecheck`
- `make build-packages`
- `make review` running against `origin/main`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785851967&installation_id=136316292&pr_number=1740&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1740&signature=41a65cde5d6fc25de8679b1bbed591192c44e6ec61be7e2096281ce6e1bf1fb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->