### PR TITLE
fix(server): use catalog inference provider keys

### DIFF
--- a/packages/server/src/gateway/__tests__/inference-url-invariant.test.ts
+++ b/packages/server/src/gateway/__tests__/inference-url-invariant.test.ts
@@ -36,8 +36,17 @@ describe("resolveUrlInvariant", () => {
     expect(v.kind).toBe("no-custom-upstream");
   });
 
-  test("text block without base_url ⇒ no-custom-upstream", async () => {
+  test("text block without base_url uses its org credential with the catalog upstream", async () => {
     configResult = { apiKey: "org-key", custom: false };
+    const v = await resolveUrlInvariant("openai", "org-1");
+    expect(v.kind).toBe("org-credential");
+    if (v.kind === "org-credential") {
+      expect(v.credential).toBe("org-key");
+    }
+  });
+
+  test("text block without base_url and without a key falls through safely", async () => {
+    configResult = { custom: false };
     const v = await resolveUrlInvariant("openai", "org-1");
     expect(v.kind).toBe("no-custom-upstream");
   });

--- a/packages/server/src/gateway/__tests__/secret-proxy-org-upstream.test.ts
+++ b/packages/server/src/gateway/__tests__/secret-proxy-org-upstream.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SecretStore } from "../secrets/index.js";
 
 /**
@@ -14,6 +14,12 @@ import type { SecretStore } from "../secrets/index.js";
  * exercises the full secret-proxy egress path.
  */
 
+let inferenceConfig: {
+  baseUrl?: string;
+  apiKey?: string;
+  custom: boolean;
+};
+
 // Custom upstream + usable org key ⇒ resolveUrlInvariant returns org-only.
 // Spread the real module so secret-proxy's other imports from it (e.g.
 // readOrgSharedProviderApiKey) still resolve; override only the resolver.
@@ -22,11 +28,7 @@ const realProviderSecrets = await import(
 );
 mock.module("../../lobu/stores/provider-secrets.js", () => ({
   ...realProviderSecrets,
-  resolveInferenceProviderConfig: async () => ({
-    baseUrl: "https://myzai.example.com/v1",
-    apiKey: "org-myzai-key",
-    custom: true,
-  }),
+  resolveInferenceProviderConfig: async () => inferenceConfig,
 }));
 
 // Import AFTER the mock so secret-proxy's transitive import of the invariant
@@ -34,6 +36,14 @@ mock.module("../../lobu/stores/provider-secrets.js", () => ({
 const { SecretProxy } = await import("../proxy/secret-proxy.js");
 
 describe("SecretProxy — org custom-upstream slug routing (URL invariant)", () => {
+  beforeEach(() => {
+    inferenceConfig = {
+      baseUrl: "https://myzai.example.com/v1",
+      apiKey: "org-myzai-key",
+      custom: true,
+    };
+  });
+
   test("registered org slug routes to the row base_url with the org key", async () => {
     const proxy = new SecretProxy(
       { defaultUpstreamUrl: "https://default.example.com" },
@@ -90,6 +100,62 @@ describe("SecretProxy — org custom-upstream slug routing (URL invariant)", () 
       );
       // Authenticated with the org row's key (Bearer for openai-compat).
       expect(capturedAuth).toBe("Bearer org-myzai-key");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("catalog upstream uses the inference-provider row key", async () => {
+    inferenceConfig = {
+      apiKey: "org-zai-key",
+      custom: false,
+    };
+    const proxy = new SecretProxy(
+      { defaultUpstreamUrl: "https://default.example.com" },
+      { get: async () => null } satisfies SecretStore
+    );
+    proxy.registerUpstream(
+      { slug: "z-ai", upstreamBaseUrl: "https://api.z.ai/api/paas/v4" },
+      "z-ai"
+    );
+    proxy.setAuthProfilesManager({
+      getBestProfile: async () => {
+        throw new Error("profile lookup must not run when the org row has a key");
+      },
+      ensureFreshCredential: async () => undefined,
+    } as never);
+    proxy.setAgentOrgResolver(async () => "org-1");
+
+    let capturedUrl: string | null = null;
+    let capturedAuth: string | null = null;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (input, init) => {
+      capturedUrl = typeof input === "string" ? input : String(input);
+      capturedAuth =
+        (init?.headers as Record<string, string>)?.authorization ?? null;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    try {
+      const res = await proxy
+        .getApp()
+        .request("/api/proxy/z-ai/a/agent-1/chat/completions", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer worker-token-test",
+          },
+          body: JSON.stringify({ model: "glm-5.2", prompt: "hi" }),
+        });
+
+      expect(res.status).toBe(200);
+      expect(capturedUrl).toBe(
+        "https://api.z.ai/api/paas/v4/chat/completions"
+      );
+      expect(capturedAuth).toBe("Bearer org-zai-key");
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
@@ -9,7 +9,7 @@ const TEST_ENCRYPTION_KEY = Buffer.from(
 let mockOrgId: string | null = null;
 let orgSharedSecretRows: Array<{ ciphertext: string }> = [];
 let inferenceProviderRows: Array<{
-  block: { base_url?: string } | null;
+  block: { base_url?: string; model?: string } | null;
   ciphertext: string | null;
 }> = [];
 
@@ -50,6 +50,7 @@ function makeModule(hasProfile: boolean) {
     sdkCompat: "openai",
     authProfilesManager: {
       hasProviderProfiles: async () => hasProfile,
+      getBestProfile: async () => null,
     } as any,
   });
 }
@@ -106,6 +107,23 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
     expect(
       await mod.hasCredentials("agent-1", { organizationId: "org-1" })
     ).toBe(true);
+  });
+
+  test("uses the org inference-provider key with the catalog upstream", async () => {
+    mockOrgId = "org-1";
+    inferenceProviderRows = [
+      {
+        block: { model: "glm-5.2" },
+        ciphertext: encrypt("zai-inference-provider-key"),
+      },
+    ];
+
+    const mod = makeModule(false);
+    const context = { organizationId: "org-1" };
+    expect(await mod.hasCredentials("agent-1", context)).toBe(true);
+    expect(await mod.buildEnvVars("agent-1", {}, context)).toEqual({
+      Z_AI_API_KEY: "zai-inference-provider-key",
+    });
   });
 
   test("returns false when a custom upstream has no usable org key, even with a profile", async () => {

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -170,18 +170,24 @@ export abstract class BaseProviderModule
     context?: ProviderCredentialContext
   ): Promise<boolean> {
     // Keep this availability check aligned with resolveCredential(). An org
-    // inference-provider row can own both a custom upstream and its key; that
-    // key is intentionally absent from per-agent auth profiles and the legacy
-    // org-shared provider secret. Treat it as available so proxy-mode workers
-    // receive an opaque credential placeholder and can reach the gateway,
-    // where the URL invariant resolves the real key at egress. Conversely, a
-    // custom upstream with an unavailable key must fail closed even when a
-    // profile exists, because that profile is not consented for the custom URL.
+    // inference-provider row owns its key whether it uses the catalog URL or a
+    // custom upstream; that key is intentionally absent from per-agent auth
+    // profiles and the legacy org-shared provider secret. Treat it as available
+    // so proxy-mode workers receive an opaque credential placeholder and can
+    // reach the gateway, where the invariant resolves the real key at egress.
+    // Conversely, a custom upstream with an unavailable key must fail closed
+    // even when a profile exists, because that profile is not consented for the
+    // custom URL.
     const invariant = await resolveUrlInvariant(
       this.providerId,
       resolveOrgId(context?.organizationId) ?? undefined
     );
-    if (invariant.kind === "org-only") return true;
+    if (
+      invariant.kind === "org-only" ||
+      invariant.kind === "org-credential"
+    ) {
+      return true;
+    }
     if (invariant.kind === "org-only-unavailable") return false;
 
     const hasProfile = await this.authProfilesManager.hasProviderProfiles(
@@ -285,7 +291,10 @@ export abstract class BaseProviderModule
       this.providerId,
       resolveOrgId(context?.organizationId) ?? undefined
     );
-    if (invariant.kind === "org-only") {
+    if (
+      invariant.kind === "org-only" ||
+      invariant.kind === "org-credential"
+    ) {
       return { credential: invariant.credential, source: "org" };
     }
     if (invariant.kind === "org-only-unavailable") {

--- a/packages/server/src/gateway/auth/inference-invariant.ts
+++ b/packages/server/src/gateway/auth/inference-invariant.ts
@@ -15,8 +15,9 @@ const logger = createLogger("inference-invariant");
  * NEVER travel to a tenant-defined URL (credential exfiltration).
  *
  * So: custom upstream present ⇒ org-row-key-ONLY (skip profile, skip env).
- * No custom upstream ⇒ the caller walks its normal profile→org→env chain
- * against the static providers.json URL (unchanged).
+ * A row using the static catalog upstream still owns a valid org credential;
+ * use it before the legacy profile→org→env chain. If that row has no usable
+ * key, the static URL remains safe for the normal fallback chain.
  *
  * The row is read ONCE per call — base_url presence and the key come from the
  * same read — so there is no window to flip the base_url between the gate and
@@ -27,8 +28,10 @@ const logger = createLogger("inference-invariant");
  * So the invariant here keys on `capabilities.text.base_url`.
  */
 export type InvariantVerdict =
-  /** No custom upstream for this provider/org — caller walks its normal chain. */
+  /** No inference-provider key/upstream override — caller walks its normal chain. */
   | { kind: "no-custom-upstream" }
+  /** Org-row key for the static catalog upstream. */
+  | { kind: "org-credential"; credential: string }
   /**
    * Custom upstream + usable org key. The caller MUST use this key and nothing
    * else, AND route to `baseUrl` (the tenant-defined URL) — never the static
@@ -56,10 +59,19 @@ export async function resolveUrlInvariant(
     providerSlug,
     "text"
   );
-  if (!config?.custom || !config.baseUrl) {
-    // No custom text upstream — the request goes to the static providers.json
-    // URL, so the normal profile→org→env chain is safe.
+  if (!config) {
     return { kind: "no-custom-upstream" };
+  }
+
+  if (!config.custom || !config.baseUrl) {
+    // The org can store a key while keeping the catalog provider's static URL
+    // (the common setup for providers such as Z.AI). That row key is still the
+    // org's configured credential and must not be ignored. A missing key may
+    // safely fall through because the destination remains the trusted catalog
+    // URL rather than a tenant-defined upstream.
+    return config.apiKey
+      ? { kind: "org-credential", credential: config.apiKey }
+      : { kind: "no-custom-upstream" };
   }
 
   if (!config.apiKey) {

--- a/packages/server/src/gateway/proxy/secret-proxy.ts
+++ b/packages/server/src/gateway/proxy/secret-proxy.ts
@@ -883,6 +883,9 @@ export class SecretProxy {
           resolvedCredential = { value: invariant.credential, kind: "api-key" };
           // Route to the tenant-defined URL from the SAME row read as the key.
           resolvedUpstreamBaseUrl = invariant.baseUrl;
+        } else if (invariant.kind === "org-credential") {
+          // The org row owns the credential but keeps the trusted catalog URL.
+          resolvedCredential = { value: invariant.credential, kind: "api-key" };
         } else if (invariant.kind === "org-only-unavailable") {
           // Custom upstream but no usable org key: fail CLOSED, never fall
           // through to a profile/env key bound for a tenant URL.


### PR DESCRIPTION
## What changed

- Treat an org inference-provider key as available when the provider keeps its catalog upstream URL.
- Inject the opaque worker placeholder and resolve the org-row key at proxy egress.
- Preserve the existing custom-upstream security invariant: a custom URL with a missing key still fails closed.

## Root cause

Buremba had an active `z-ai` inference-provider row with a valid key and `glm-5.2`, but no custom `base_url`. The resolver only consumed inference-provider keys for custom upstreams, so worker setup omitted `Z_AI_API_KEY` and run 527177 failed before contacting Z.AI.

## Reproducer

Red: the new catalog-upstream regression test returned `hasCredentials === false` before the fix. Production watcher run 527177 failed with `connect zai` despite the active org provider row.

Green: credential availability, worker env injection, and proxy egress tests now confirm the key reaches `https://api.z.ai/api/paas/v4` while remaining hidden from the worker.

## Validation

- `bun test packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts`
- `bun test packages/server/src/gateway/__tests__/inference-url-invariant.test.ts`
- `bun test packages/server/src/gateway/__tests__/secret-proxy-org-upstream.test.ts`
- `bun run typecheck`
- `make build-packages`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785853620&installation_id=136316292&pr_number=1741&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1741&signature=b096cfe0e5612eae0d95aad7da161aa54bc242e45a74181d3c6ce936c2eff449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Requests can now use an organization’s available API key even when no custom upstream is configured.
  * Added support for routing certain catalog-based requests through the trusted upstream while still sending the organization’s credential.

* **Bug Fixes**
  * Fixed a fail-closed case so requests without a usable organization key no longer fall back unexpectedly.
  * Improved credential handling for proxy requests using catalog-style upstream settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->