### PR TITLE
feat(dev): Herdr task workspaces and dev app URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 help:
 	@echo "Available commands:"
 	@echo "  make setup                                 - Setup development environment (run once)"
-	@echo "  make dev [NAME=<x>] [FROM=<db>]            - Local dev against the shared brew Postgres@18, one database per branch (NAME defaults to the branch; FROM=<db> forks a dataset)"
+	@echo "  make dev [NAME=<x>] [FROM=<db>] [OPEN=1]   - Local dev (brew Postgres@18); prints App URL; OPEN=1 opens it in the system browser after boot"
 	@echo "  make dev-embedded                          - Dev against the zero-dependency embedded per-worktree Postgres (the lobu run / CI runtime); == LOBU_EMBEDDED=1 make dev"
 	@echo "  make build-packages                        - Build all TypeScript packages"
 	@echo "  make test                                  - Run test bot"
@@ -19,7 +19,7 @@ help:
 	@echo "  make dev-recover [RESTART=1]               - Free this checkout's dev ports + clean workers; RESTART=1 also boots make dev"
 	@echo "  make clean-test-pg                         - Reap orphaned lobu-test-pg embedded-Postgres clusters (frees macOS shm slots)"
 	@echo "  make typecheck                             - Strict typecheck (same as Dockerfile) for server + owletto"
-	@echo "  make task-setup NAME=<name> [CONTEXT=1]    - Create a paired worktree at .claude/worktrees/<name> (lobu + submodule on real branch, .env copied, ports auto-assigned; CONTEXT=1 registers a Lobu CLI context for the Mac menubar)"
+	@echo "  make task-setup NAME=<name> [CONTEXT=1]    - Create a paired worktree at .claude/worktrees/<name> (lobu + submodule, .env/ports; opens a Herdr workspace when herdr is on PATH; HERDR=0 to skip; CONTEXT=1 registers Lobu CLI context)"
 	@echo "  make task-clean NAME=<name> [FORCE=1]      - Remove the worktree, both branches, and the Lobu context (refuses if there's uncommitted/unpushed work unless FORCE=1)"
 	@echo "  make e2e-browser [RESTART=1]               - Launch/reuse the stable 'owletto' Chrome harness (extension from this worktree) for Chrome e2e"
 	@echo "  make bump SUBMODULE=<path> [TARGET=<ref>]  - Lightweight worktree + commit + PR for a trivial submodule pointer bump (skips bun install, .env, ports)"

--- a/scripts/dev-native.sh
+++ b/scripts/dev-native.sh
@@ -127,6 +127,9 @@ export LOBU_WORKSPACE_ROOT="${LOBU_WORKSPACE_ROOT:-$REPO_ROOT/workspaces}"
 
 mkdir -p "$LOBU_WORKSPACE_ROOT"
 
+# shellcheck source=scripts/lib/dev-app-url.sh
+. "$REPO_ROOT/scripts/lib/dev-app-url.sh"
+
 # --- Run -------------------------------------------------------------------
 
 # Backend is selected by the DATABASE_URL *scheme*, not its mere presence: only
@@ -158,9 +161,13 @@ if [ "$_LOBU_EMBEDDED" = 1 ]; then
   mkdir -p "$DEV_DATA_ROOT"
   echo "→ embedded Postgres   cluster: $DEV_DATA_ROOT/.lobu/pgdata"
   echo "→ server on http://${HOST}:${PORT}   (Vite HMR in-process)"
+  lobu_dev_print_app_url
   echo "→ first run seeds a web login: dev@lobu.local / lobudev123   (org 'dev')"
   echo "→ then run \`lobu apply\` from a project dir to sync its lobu.config.ts"
   echo ""
+  if [[ "${OPEN:-}" == "1" || "${OPEN:-}" == "true" ]]; then
+    lobu_dev_schedule_open
+  fi
   exec bun run --filter '@lobu/server' dev:local
 fi
 
@@ -189,6 +196,10 @@ echo "→ external Postgres (sslmode=${PGSSLMODE})"
 echo "→ server on http://${HOST}:${PORT}"
 echo "→ embedded gateway proxy on :${WORKER_PROXY_PORT}"
 echo "→ Vite HMR in-process (same port)"
+lobu_dev_print_app_url
 echo ""
+if [[ "${OPEN:-}" == "1" || "${OPEN:-}" == "true" ]]; then
+  lobu_dev_schedule_open
+fi
 
 exec bun run --filter '@lobu/server' dev

--- a/scripts/lib/dev-app-url.sh
+++ b/scripts/lib/dev-app-url.sh
@@ -1,0 +1,35 @@
+# dev-app-url.sh — local dev UI URL (PUBLIC_GATEWAY_URL) for logs and OPEN=1.
+# Sourced after .env / .env.local are loaded; REPO_ROOT must be set.
+
+lobu_dev_app_url() {
+  if [[ -n "${PUBLIC_GATEWAY_URL:-}" ]]; then
+    printf '%s' "$PUBLIC_GATEWAY_URL"
+    return 0
+  fi
+  local host="${HOST:-127.0.0.1}"
+  local port="${PORT:-8787}"
+  printf 'http://%s:%s/lobu' "$host" "$port"
+}
+
+lobu_dev_print_app_url() {
+  local url
+  url="$(lobu_dev_app_url)"
+  echo "→ App (browser):  $url"
+  echo "   OPEN=1 make dev — open in the default browser once the server is up"
+}
+
+lobu_dev_schedule_open() {
+  local url delay
+  url="$(lobu_dev_app_url)"
+  delay="${LOBU_OPEN_DELAY:-5}"
+  (
+    sleep "$delay"
+    if command -v open >/dev/null 2>&1; then
+      open "$url" >/dev/null 2>&1 || true
+    elif command -v xdg-open >/dev/null 2>&1; then
+      xdg-open "$url" >/dev/null 2>&1 || true
+    else
+      echo "→ OPEN=1: no open/xdg-open; visit $url" >&2
+    fi
+  ) &
+}

--- a/scripts/lib/herdr-task.sh
+++ b/scripts/lib/herdr-task.sh
@@ -1,0 +1,42 @@
+# herdr-task.sh — optional Herdr workspace wiring for task worktrees.
+# Sourced by task-setup.sh / task-clean.sh. Set HERDR=0 to skip.
+
+herdr_task_enabled() {
+  [[ "${HERDR:-1}" != "0" ]] && command -v herdr >/dev/null 2>&1
+}
+
+# Open (or attach) an existing git worktree as a Herdr workspace. Prints workspace_id on stdout.
+herdr_task_open() {
+  local repo="$1" worktree_path="$2" label="$3"
+  local json ws
+  herdr_task_enabled || return 1
+  json="$(herdr worktree open --cwd "$repo" --path "$worktree_path" --label "$label" --no-focus --json 2>/dev/null)" || return 1
+  ws="$(printf '%s' "$json" | python3 -c 'import sys,json
+d=json.load(sys.stdin)
+print(d.get("result",{}).get("workspace",{}).get("workspace_id",""))' 2>/dev/null)" || return 1
+  [[ -n "$ws" ]] || return 1
+  herdr workspace rename "$ws" "$label" >/dev/null 2>&1 || true
+  printf '%s' "$ws"
+}
+
+# Close the Herdr workspace tied to a worktree path, if any.
+herdr_task_close() {
+  local worktree_path="$1"
+  local json ws
+  herdr_task_enabled || return 1
+  json="$(herdr workspace list --json 2>/dev/null)" || return 1
+  ws="$(printf '%s' "$json" | WORKTREE_PATH="$worktree_path" python3 -c 'import os,sys,json
+path=os.environ["WORKTREE_PATH"]
+d=json.load(sys.stdin)
+for w in d.get("result",{}).get("workspaces",[]):
+  wt=w.get("worktree") or {}
+  if wt.get("checkout_path")==path:
+    print(w.get("workspace_id") or "")
+    break
+' 2>/dev/null)" || return 1
+  [[ -n "$ws" ]] || return 1
+  herdr worktree remove --workspace "$ws" >/dev/null 2>&1 || \
+    herdr worktree remove --workspace "$ws" --force >/dev/null 2>&1 || \
+    herdr workspace close "$ws" >/dev/null 2>&1 || return 1
+  return 0
+}

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -113,7 +113,18 @@ if [[ $force -eq 0 ]]; then
 fi
 
 echo "→ removing worktree $worktree_dir"
-git -C "$repo" worktree remove "$worktree_dir" --force
+if git -C "$repo" worktree list --porcelain 2>/dev/null | grep -qF "worktree $worktree_dir"; then
+  git -C "$repo" worktree remove "$worktree_dir" --force
+else
+  echo "→ worktree path already gone from git (e.g. closed via Herdr)"
+  rm -rf "$worktree_dir" 2>/dev/null || true
+fi
+
+# shellcheck source=scripts/lib/herdr-task.sh
+. "$script_dir/lib/herdr-task.sh"
+if herdr_task_close "$worktree_dir"; then
+  echo "→ closed Herdr workspace for $worktree_dir"
+fi
 
 # Returns 0 if branch <b> in <gitdir> carries no local-only commits (its tip is
 # reachable from origin/main, or equals its pushed remote ref). Used to protect

--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -12,7 +12,8 @@
 #   <name>  kebab-case task slug (e.g. fix-sse-leak)
 #
 # Companion: `make task-clean NAME=<name> [FORCE=1]` removes the worktree,
-# its branches in both repos, and the Lobu CLI context.
+# its branches in both repos, the Lobu CLI context, and the Herdr workspace
+# (when `herdr` is on PATH; set HERDR=0 to skip).
 #
 # Behavior (idempotent — re-running on an existing worktree refreshes .env
 # and .env.local only):
@@ -220,6 +221,17 @@ else
   echo "→ skipped Lobu context registration (pass CONTEXT=1 or --context to register)"
 fi
 
+# shellcheck source=scripts/lib/herdr-task.sh
+. "$script_dir/lib/herdr-task.sh"
+herdr_ws=""
+if herdr_ws="$(herdr_task_open "$repo" "$worktree_dir" "$name")"; then
+  echo "→ opened Herdr workspace '$herdr_ws' (label: $name)"
+else
+  if herdr_task_enabled; then
+    echo "warning: Herdr is installed but worktree open failed (run manually: herdr worktree open --cwd $repo --path $worktree_dir --label $name)" >&2
+  fi
+fi
+
 cat <<EOF
 
 ✓ Worktree ready: $worktree_dir
@@ -228,6 +240,10 @@ cat <<EOF
   owletto branch:    $branch (real named branch, not detached HEAD)
   PORT:              $port
   WORKER_PROXY_PORT: $proxy
+  App (browser):     http://127.0.0.1:$port/lobu
+
+  make dev              # in this worktree (or Herdr pane)
+  OPEN=1 make dev       # same, opens the app URL in your browser after ~5s
 
 When pushing owletto changes:
   1. Push owletto FIRST so the SHA is reachable on origin:
@@ -238,5 +254,5 @@ When pushing owletto changes:
        git -C $worktree_dir push -u origin $branch
 
 Launch via the task-start shell function (recommended; see script header),
-or manually: cd $worktree_dir && claude
+or manually: cd $worktree_dir && claude$(if [[ -n "${herdr_ws:-}" ]]; then printf '\n\nHerdr: herdr workspace focus %s  (pane cwd is already this worktree)' "$herdr_ws"; fi)
 EOF


### PR DESCRIPTION
## Summary
- `make task-setup` opens a Herdr workspace for the new worktree (label = task name) when `herdr` is installed; `HERDR=0` to skip.
- `make task-clean` removes the git worktree first, then closes the matching Herdr workspace.
- `make dev` prints **App (browser)** URL from `PUBLIC_GATEWAY_URL`; `OPEN=1 make dev` opens it in the system browser after ~5s (`LOBU_OPEN_DELAY`).

## Test plan
- [x] `make task-setup` / `make task-clean` smoke (Herdr workspace open/close)
- [ ] `OPEN=1 make dev` in a task worktree (manual)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785858812&installation_id=136316292&pr_number=1742&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1742&signature=f5af85ef4dd7a3464e039ffd19d41c6a75dd3a6461a7ddb474b0a1de186e139b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `make dev` now shows the app URL and can open it automatically when `OPEN=1`.
  * Task setup/cleanup can optionally manage workspaces in supported environments, including clearer success/fallback behavior.

* **Bug Fixes**
  * Task worktree cleanup is more reliable for both registered and unregistered worktrees.
  * Development scripts now consistently print the app URL across execution paths.

* **Documentation**
  * Updated `make help` and task setup/usage text to reflect the improved URL and workspace workflow.
  
* **Chores**
  * Updated the `packages/owletto` subproject reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->