### PR TITLE
feat(server): query_sql virtual-feed coverage hints + manage_feeds read_feeds batch

### DIFF
--- a/docs/database-connectors.md
+++ b/docs/database-connectors.md
@@ -15,11 +15,22 @@ gateway never opens an external pool.
   source and returns rows, persisting nothing. The platform reaches it through one
   primitive: `runConnectorQuery` (`packages/server/src/lib/connector-pushdown.ts`),
   which invokes the connector in the worker `query` run-mode (the same inline-run
-  path as `operations.execute`).
+  path as `operations.execute`). Virtual feeds use the same connector pushdown via
+  `readVirtualFeed`: a stored feed query is read live and still persists nothing.
 - **`query_sql({ connection })`** is the single door: with a `connection` slug it
   pushes the SQL down via `runConnectorQuery` (internal org-scoping skipped — it's
   the org's own DB); without, it runs the internal org-scoped path. There is no
   separate `query_entity_type` tool.
+- **`query_sql({ feed })`** reads one virtual feed live by numeric feed id or
+  `"connection_slug/feed_key"`. The feed's stored `config.query` is the source
+  query; caller `sql` is ignored. `search_term` narrows through the connector
+  `search()` pushdown when available.
+- **`SELECT FROM events` is persisted-only.** It reads synced/materialized content,
+  not live virtual feeds. When the internal SQL references `events`, `query_sql`
+  best-effort returns `coverage.source = 'persisted_events_only'` with up to five
+  visibility-fenced `suggested_virtual_feeds`, `more_available`, and a ready
+  `query_sdk` example using `client.feeds.readMany`. Coverage lookup failures log
+  and omit the block; they never fail the SQL query.
 - **Derived entity** — `defineEntityType({ backing: { sql, connection? } })`. With
   `connection`, the read is `get_type → query_sql({ sql: backing_sql, connection })`
   → pushdown. Without, it's the shipped internal view over `events`/`entities`.
@@ -27,10 +38,29 @@ gateway never opens an external pool.
 Single-database only: every query targets one database; no cross-source joins
 (that's a later DuckDB-class engine).
 
-Slice 2 (next): **virtual feeds** (a `virtual` feed flag → live reads, no events)
-and **federated search** (a connector `search()` the platform fans out to and
-merges with the vector index). Only the `query()` live-read primitive is in place
-today; the `virtual` feed flag, `search()`, and the fan-out are the remaining work.
+Slice 2 (shipped): **virtual feeds** (`feeds.kind = 'virtual'` / legacy
+`virtual = true` → live reads, no events) and connector `search()` for live recall.
+What is still not built is transparent SQL federation or server-side cross-source
+fan-out for `events` queries. Agents decompose explicitly: use `query_sql` for
+persisted rows, then read suggested live feeds in parallel with `query_sdk` or
+`manage_feeds`.
+
+## Agent-facing live feed reads
+
+Agents can batch live feed reads through `manage_feeds({ action: 'read_feeds' })`
+or the read-only SDK method:
+
+```ts
+export default async (_ctx, client) => {
+  return client.feeds.readMany({ feed_ids: [123, 456], limit: 25 });
+};
+```
+
+`readMany` reads up to 10 feeds in parallel. Each feed returns independently as
+`{ ok: true, result }` or `{ ok: false, error }`, so a missing or visibility-fenced
+feed does not fail the whole batch. The per-feed response timeout defaults to 10s
+and clamps at 30s; it bounds the batch response, not necessarily the underlying
+connector work.
 
 ## SSRF / egress trust model
 

--- a/docs/plans/feeds-and-connections-model.md
+++ b/docs/plans/feeds-and-connections-model.md
@@ -12,7 +12,7 @@ same registry — today they live in separate code paths. Reviewed with an exter
 model (Q: collapse the axes? → "keep them orthogonal").
 
 **Related docs (authoritative for the kinds/lenses below):**
-[`docs/database-connectors.md`](./database-connectors.md) — the PostgreSQL
+[`docs/database-connectors.md`](../database-connectors.md) — the PostgreSQL
 connector, live-read `query()`, connection-backed entities, and the `virtual`
 feed-flag roadmap. [`docs/define-metric-design.md`](../define-metric-design.md) —
 the entity-bound metric lens. This doc is the *cross-cutting* model that ties the
@@ -38,7 +38,7 @@ bytes live" and "how the caller wants to read them" are different concerns.
 | kind | backing | status |
 | --- | --- | --- |
 | `chat-channel` | local transcript table `channel_messages` (live conversation) | exists |
-| `virtual-live-dataset` | external source queried **live**, nothing copied locally — PostgreSQL connector (`packages/connectors/src/postgres.ts`) `query()` live-read + `QueryContext` (`connector-types.ts:842`). **Live-read infra + connection-backed live entities ship** (#1182), metrics run live against them; the user-facing `virtual` **feed flag** (+ `search()` + fan-out) is **Slice 2 / next** — see `database-connectors.md`. | **partial** |
+| `virtual-live-dataset` | external source queried **live**, nothing copied locally — PostgreSQL connector (`packages/connectors/src/postgres.ts`) `query()` live-read + `search()` recall pushdown. User-configured live feeds are `feeds.kind = 'virtual'` (`virtual` boolean retained as a transitional compatibility flag). | exists |
 | `collected` | sync materializes rows into `events` (the classic data feed = real row in `feeds`) | exists |
 
 ### Axis 2 — Read lens (how you query)
@@ -121,3 +121,9 @@ it (e.g. a new lens that must share the source-adapter layer), per the "design
 the seam, not the framework" discipline. The recall registry was shaped as the
 tuple `(source, lens)` precisely so that fold is additive when it lands: a metric
 reader is just another `FeedReader<S, 'metric', …>` registered by tuple key.
+
+`query_sql` coverage hints do **not** mean the raw-sql lens now federates virtual
+feeds. They are advisory metadata: an `events` SQL result can say "these live
+virtual feeds are accessible but missing from persisted events" and provide a
+`client.feeds.readMany` example. The live reads still happen explicitly through
+feed addressing or the batch feed-read API.

--- a/docs/plans/virtual-feed-flag-slice2.md
+++ b/docs/plans/virtual-feed-flag-slice2.md
@@ -5,6 +5,11 @@ Status: implemented (this PR). Conflict-safe slice of the larger "Conversation f
 that lets a feed be *read live* instead of synced; the FeedReader registry + feed
 enumeration that consume it land in a sibling stream (Stream A, owned separately).
 
+Follow-up shipped: `query_sql` now warns that `events` queries are persisted-only
+and suggests accessible live virtual feeds; `manage_feeds.read_feeds` /
+`client.feeds.readMany` batch those live reads with per-feed partial failures.
+See `docs/database-connectors.md` for the current agent-facing contract.
+
 ## Goal
 
 Make a feed *declarable as virtual*: read LIVE against its source at request time via

--- a/packages/server/src/__tests__/integration/connectors/virtual-feed-surfaces.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/virtual-feed-surfaces.test.ts
@@ -24,6 +24,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { AuthzScope } from '../../../authz/scope';
 import type { Env } from '../../../index';
+import { manageFeeds } from '../../../tools/admin/manage_feeds';
 import { querySql } from '../../../tools/admin/query_sql';
 import type { ToolContext } from '../../../tools/registry';
 import { gatherRecall, type RecallContext } from '../../../tools/search';
@@ -57,6 +58,7 @@ describe('virtual feed surfaces (recall + query_sql)', () => {
     tokenType: 'oauth',
     scopedToOrg: false,
     allowCrossOrg: false,
+    scopes: ['mcp:read'],
   });
 
   const recallCtx = (query: string): RecallContext => ({
@@ -114,24 +116,24 @@ describe('virtual feed surfaces (recall + query_sql)', () => {
     const orgConnId = Number((orgConn as { id: number }).id);
 
     const [recallFeed] = await db`
-      INSERT INTO feeds (organization_id, connection_id, feed_key, status, virtual, config, created_at, updated_at)
-      VALUES (${orgId}, ${orgConnId}, 'inbox', 'active', true,
+      INSERT INTO feeds (organization_id, connection_id, feed_key, status, kind, virtual, config, created_at, updated_at)
+      VALUES (${orgId}, ${orgConnId}, 'inbox', 'active', 'virtual', true,
         ${db.json({ query: VFEED_SQL, primary_key: 'id', cursor_column: 'id', recall: true })}, NOW(), NOW())
       RETURNING id
     `;
     recallFeedId = Number((recallFeed as { id: number }).id);
 
     const [plainFeed] = await db`
-      INSERT INTO feeds (organization_id, connection_id, feed_key, status, virtual, config, created_at, updated_at)
-      VALUES (${orgId}, ${orgConnId}, 'plain', 'active', true,
+      INSERT INTO feeds (organization_id, connection_id, feed_key, status, kind, virtual, config, created_at, updated_at)
+      VALUES (${orgId}, ${orgConnId}, 'plain', 'active', 'virtual', true,
         ${db.json({ query: VFEED_SQL, primary_key: 'id', cursor_column: 'id' })}, NOW(), NOW())
       RETURNING id
     `;
     plainFeedId = Number((plainFeed as { id: number }).id);
 
     const [normalFeed] = await db`
-      INSERT INTO feeds (organization_id, connection_id, feed_key, status, virtual, config, created_at, updated_at)
-      VALUES (${orgId}, ${orgConnId}, 'synced', 'active', false,
+      INSERT INTO feeds (organization_id, connection_id, feed_key, status, kind, virtual, config, created_at, updated_at)
+      VALUES (${orgId}, ${orgConnId}, 'synced', 'active', 'collected', false,
         ${db.json({ query: VFEED_SQL, primary_key: 'id', cursor_column: 'id' })}, NOW(), NOW())
       RETURNING id
     `;
@@ -148,8 +150,8 @@ describe('virtual feed surfaces (recall + query_sql)', () => {
     `;
     const privConnId = Number((privConn as { id: number }).id);
     const [privRecallFeed] = await db`
-      INSERT INTO feeds (organization_id, connection_id, feed_key, status, virtual, config, created_at, updated_at)
-      VALUES (${orgId}, ${privConnId}, 'priv-inbox', 'active', true,
+      INSERT INTO feeds (organization_id, connection_id, feed_key, status, kind, virtual, config, created_at, updated_at)
+      VALUES (${orgId}, ${privConnId}, 'priv-inbox', 'active', 'virtual', true,
         ${db.json({ query: VFEED_SQL, primary_key: 'id', cursor_column: 'id', recall: true })}, NOW(), NOW())
       RETURNING id
     `;
@@ -210,6 +212,26 @@ describe('virtual feed surfaces (recall + query_sql)', () => {
     expect(res.rows.map((r) => r.name).sort()).toEqual(['apple', 'apricot', 'banana']);
   }, 60_000);
 
+  it('(2) query_sql warns that events SQL omits accessible virtual feeds', async () => {
+    const ownerRes = await querySql({ sql: 'SELECT id FROM events LIMIT 1' }, {}, ownerCtx);
+    expect(ownerRes.error).toBeUndefined();
+    expect(ownerRes.coverage?.source).toBe('persisted_events_only');
+    expect(ownerRes.coverage?.suggested_virtual_feeds.map((f) => f.feed).sort()).toEqual([
+      'vfsurf-org-db/inbox',
+      'vfsurf-org-db/plain',
+      'vfsurf-priv-db/priv-inbox',
+    ]);
+    expect(ownerRes.coverage?.suggested_execution.example).toContain(
+      'client.feeds.readMany'
+    );
+
+    const memberRes = await querySql({ sql: 'SELECT id FROM events LIMIT 1' }, {}, memberCtx());
+    expect(memberRes.coverage?.suggested_virtual_feeds.map((f) => f.feed).sort()).toEqual([
+      'vfsurf-org-db/inbox',
+      'vfsurf-org-db/plain',
+    ]);
+  }, 60_000);
+
   it('(2) query_sql addresses a virtual feed by "connection_slug/feed_key"', async () => {
     const res = await querySql({ feed: 'vfsurf-org-db/inbox', limit: 10 }, {}, ownerCtx);
     expect(res.error).toBeUndefined();
@@ -246,5 +268,59 @@ describe('virtual feed surfaces (recall + query_sql)', () => {
     const ok = await querySql({ feed: String(privRecallFeedId) }, {}, ownerCtx);
     expect(ok.error).toBeUndefined();
     expect(ok.rows.length).toBe(3);
+  }, 60_000);
+
+  // ---- (3) manage_feeds read_feeds ---------------------------------------
+
+  it('(3) read_feeds returns per-feed successes and failures', async () => {
+    const res = (await manageFeeds(
+      {
+        action: 'read_feeds',
+        feed_ids: [recallFeedId, 999_999_999],
+        limit: 2,
+      },
+      {},
+      ownerCtx
+    )) as {
+      action: 'read_feeds';
+      failures: number;
+      results: Array<{
+        feed_id: number;
+        ok: boolean;
+        result?: any;
+        error?: string;
+      }>;
+    };
+
+    expect(res.action).toBe('read_feeds');
+    expect(res.failures).toBe(1);
+    const ok = res.results.find((r) => r.feed_id === recallFeedId);
+    expect(ok?.ok).toBe(true);
+    expect(ok?.result?.kind).toBe('virtual');
+    expect(ok?.result?.rows).toHaveLength(2);
+    const missing = res.results.find((r) => r.feed_id === 999_999_999);
+    expect(missing).toMatchObject({ ok: false, error: 'Feed not found' });
+  }, 60_000);
+
+  it('(3) read_feeds preserves per-feed visibility failures', async () => {
+    const res = (await manageFeeds(
+      {
+        action: 'read_feeds',
+        feed_ids: [recallFeedId, privRecallFeedId],
+        limit: 2,
+      },
+      {},
+      memberCtx()
+    )) as {
+      failures: number;
+      results: Array<{ feed_id: number; ok: boolean; error?: string }>;
+    };
+
+    expect(res.failures).toBe(1);
+    expect(res.results.find((r) => r.feed_id === recallFeedId)?.ok).toBe(true);
+    expect(res.results.find((r) => r.feed_id === privRecallFeedId)).toMatchObject({
+      ok: false,
+      error: 'Feed not found',
+    });
   }, 60_000);
 });

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -682,7 +682,7 @@ manage_entity_schema: list=read+public get=read+public create=admin update=admin
 manage_connections: list_connector_groups=read+public list=read+public get=read+public create=write connect=admin update=write apply_chat_connection=admin delete=admin reauthenticate=write test=admin install_connector=admin uninstall_connector=admin toggle_connector_login=admin update_connector_auth=admin update_connector_default_config=admin update_connector_default_repair_agent=admin set_connector_entity_link_overrides=admin list_channel_bindings=read+public bind_channel=admin unbind_channel=admin sync_channel_bindings=admin connect_channel_dm=admin ?=read
 manage_catalog: list_catalog=read+public list_installed=read+public ?=read
 manage_agents: list=admin get=admin create=admin update=admin delete=admin set_system_agent=admin ?=read
-manage_feeds: list_feeds=read+public read_feed=read+public create_feed=admin update_feed=admin delete_feed=admin trigger_feed=admin ?=read
+manage_feeds: list_feeds=read+public read_feed=read+public read_feeds=read+public create_feed=admin update_feed=admin delete_feed=admin trigger_feed=admin ?=read
 manage_auth_profiles: list_auth_profiles=read+public get_auth_profile=admin test_auth_profile=admin create_auth_profile=write update_auth_profile=write delete_auth_profile=admin set_default_auth_profile=admin ?=read
 manage_operations: list_available=read+public execute=admin list_runs=read+public get_run=read+public approve=admin reject=admin ?=read
 notify: send=admin ?=admin

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -143,7 +143,7 @@ const PUBLIC_READ_ACTIONS: Record<string, Set<string> | null> = {
 		"list_channel_bindings",
 	]),
 	manage_catalog: new Set(["list_catalog", "list_installed"]),
-	manage_feeds: new Set(["list_feeds", "read_feed"]),
+	manage_feeds: new Set(["list_feeds", "read_feed", "read_feeds"]),
 	manage_auth_profiles: new Set(["list_auth_profiles"]),
 	manage_operations: new Set(["list_available", "list_runs", "get_run"]),
 	manage_watchers: new Set([

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -514,6 +514,11 @@ export default async (_ctx, client) => {
 	},
 	"feeds.list": { summary: "List data-sync feeds.", access: "read" },
 	"feeds.get": { summary: "Get a feed by id.", access: "read" },
+	"feeds.readMany": {
+		summary:
+			"Read several feeds in parallel with per-feed successes/failures. Useful for live virtual feeds suggested by query_sql coverage hints.",
+		access: "read",
+	},
 	"feeds.create": {
 		summary: "Create a data-sync feed for a connection.",
 		access: "write",

--- a/packages/server/src/sandbox/namespaces/feeds.ts
+++ b/packages/server/src/sandbox/namespaces/feeds.ts
@@ -23,6 +23,11 @@ export interface FeedsNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
 	list(input?: { connection_id?: number; feed_ids?: number[] }): Promise<unknown>;
 	get(feed_id: number): Promise<unknown>;
+	readMany(input: {
+		feed_ids: number[];
+		limit?: number;
+		timeout_ms?: number;
+	}): Promise<unknown>;
 	create(input: FeedsCreateInput): Promise<unknown>;
 	update(input: {
 		feed_id: number;
@@ -46,6 +51,7 @@ export function buildFeedsNamespace(
 		manage,
 		list: (input) => action("list_feeds", input),
 		get: (feed_id) => action("read_feed", { feed_id }),
+		readMany: (input) => action("read_feeds", input),
 		create: (input) => action("create_feed", input),
 		update: (input) => action("update_feed", input),
 		delete: (feed_id) => action("delete_feed", { feed_id }),

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -9,6 +9,7 @@
  *   returns its metadata + recent sync runs; a virtual feed returns LIVE rows
  *   via the connector query()/search() pushdown (never synced); a streaming
  *   (chat-channel) feed returns its live transcript from channel_messages.
+ * - read_feeds: Read several feeds in parallel with per-feed failures.
  * - create_feed: Create a new feed for a connection
  * - update_feed: Update feed settings
  * - delete_feed: Delete a feed
@@ -68,6 +69,30 @@ const ReadFeedAction = Type.Object({
   feed_id: Type.Number({ description: 'Feed ID' }),
   limit: Type.Optional(
     Type.Number({ description: 'Max transcript messages for a streaming feed (default 50)' })
+  ),
+});
+
+const ReadFeedsAction = Type.Object({
+  action: Type.Literal('read_feeds', {
+    description:
+      'Read several feeds in parallel. Each feed returns independently as { ok, result } or { ok:false, error }.',
+  }),
+  feed_ids: Type.Array(Type.Integer({ minimum: 1 }), {
+    minItems: 1,
+    maxItems: 10,
+    description: 'Feed IDs to read in parallel (max 10).',
+  }),
+  limit: Type.Optional(
+    Type.Number({
+      description: 'Per-feed row/message limit for live feed kinds (default 50)',
+    })
+  ),
+  timeout_ms: Type.Optional(
+    Type.Number({
+      description: 'Per-feed timeout in milliseconds (default 10000, max 30000).',
+      minimum: 1000,
+      maximum: 30000,
+    })
   ),
 });
 
@@ -182,6 +207,19 @@ export const ManageFeedsResultSchema = Type.Union([
     total: Type.Optional(Type.Integer()),
   }),
   Type.Object({
+    action: Type.Literal('read_feeds'),
+    results: Type.Array(
+      Type.Object({
+        feed_id: Type.Integer(),
+        ok: Type.Boolean(),
+        result: Type.Optional(Type.Unknown()),
+        error: Type.Optional(Type.String()),
+      })
+    ),
+    failures: Type.Integer(),
+    timeout_ms: Type.Integer(),
+  }),
+  Type.Object({
     action: Type.Literal('create_feed'),
     feed: Type.Record(Type.String(), Type.Unknown()),
   }),
@@ -207,6 +245,9 @@ export const ManageFeedsResultSchema = Type.Union([
 ]);
 type ManageFeedsResult = Static<typeof ManageFeedsResultSchema>;
 
+const DEFAULT_BATCH_READ_TIMEOUT_MS = 10_000;
+const MAX_BATCH_READ_TIMEOUT_MS = 30_000;
+
 // ============================================
 // Main Function (Action Router)
 // ============================================
@@ -214,6 +255,7 @@ type ManageFeedsResult = Static<typeof ManageFeedsResultSchema>;
 const manageFeedsTool = defineActionTool('manage_feeds', {
   list_feeds: action(ListFeedsAction, handleListFeeds),
   read_feed: action(ReadFeedAction, handleReadFeed),
+  read_feeds: action(ReadFeedsAction, handleReadFeeds),
   create_feed: action(CreateFeedAction, handleCreateFeed),
   update_feed: action(UpdateFeedAction, handleUpdateFeed),
   delete_feed: action(DeleteFeedAction, handleDeleteFeed),
@@ -442,6 +484,57 @@ async function handleReadFeed(
   `;
 
   return { action: 'read_feed', kind: String(feed.kind), feed, recent_runs: runs };
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+async function handleReadFeeds(
+  args: Static<typeof ReadFeedsAction>,
+  ctx: ToolContext
+): Promise<ManageFeedsResult> {
+  const rawTimeoutMs = Number(args.timeout_ms ?? DEFAULT_BATCH_READ_TIMEOUT_MS);
+  const timeoutMs = Number.isFinite(rawTimeoutMs)
+    ? Math.max(1000, Math.min(MAX_BATCH_READ_TIMEOUT_MS, Math.trunc(rawTimeoutMs)))
+    : DEFAULT_BATCH_READ_TIMEOUT_MS;
+  const feedIds = [...new Set(args.feed_ids.map((id) => Number(id)))].slice(0, 10);
+  const results = await Promise.all(
+    feedIds.map(async (feedId) => {
+      try {
+        const result = await withTimeout(
+          handleReadFeed({ action: 'read_feed', feed_id: feedId, limit: args.limit }, ctx),
+          timeoutMs,
+          `read_feed ${feedId} timed out after ${timeoutMs}ms`
+        );
+        if ('error' in result) {
+          return { feed_id: feedId, ok: false, error: result.error };
+        }
+        return { feed_id: feedId, ok: true, result };
+      } catch (err) {
+        return { feed_id: feedId, ok: false, error: getErrorMessage(err) };
+      }
+    })
+  );
+
+  return {
+    action: 'read_feeds',
+    results,
+    failures: results.filter((r) => !r.ok).length,
+    timeout_ms: timeoutMs,
+  };
 }
 
 async function handleCreateFeed(

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -27,7 +27,7 @@ export const QuerySqlSchema = Type.Object({
   sql: Type.Optional(
     Type.String({
       description:
-        'Base SELECT query. Required unless `feed` is set (a virtual feed runs its OWN stored query, so `sql` is ignored there). Table references are auto-scoped to your organization. It is wrapped as a subquery, so ORDER BY / LIMIT / window functions inside it are fine; pagination + sort are added on the outside via sort_by/limit/offset.',
+        'Base SELECT query. Required unless `feed` is set. Table references are auto-scoped to your organization. `SELECT FROM events` reads persisted/synced content only; virtual feeds are live-only and are not included. It is wrapped as a subquery, so ORDER BY / LIMIT / window functions inside it are fine; pagination + sort are added on the outside via sort_by/limit/offset.',
     })
   ),
   connection: Type.Optional(
@@ -115,8 +115,35 @@ interface QuerySqlResult {
   total_count: number;
   has_more: boolean;
   execution_time_ms: number;
+  coverage?: QuerySqlCoverage;
   error?: string;
 }
+
+interface SuggestedVirtualFeed {
+  feed_id: number;
+  feed: string;
+  connection_slug: string;
+  feed_key: string;
+  display_name: string | null;
+  connector_key: string;
+  suggested_limit: number;
+}
+
+interface QuerySqlCoverage {
+  source: 'persisted_events_only';
+  warning: string;
+  suggested_virtual_feeds: SuggestedVirtualFeed[];
+  more_available: boolean;
+  suggested_execution: {
+    tool: 'query_sdk';
+    method: 'client.feeds.readMany';
+    latency_note: string;
+    example: string;
+  };
+}
+
+const MAX_SUGGESTED_VIRTUAL_FEEDS = 5;
+const VIRTUAL_FEED_SUGGESTED_LIMIT = 25;
 
 /**
  * Coerce + clamp the page bounds. TypeBox schemas aren't runtime-validated in
@@ -189,6 +216,81 @@ function errorResult(message: string, startTime: number): QuerySqlResult {
     execution_time_ms: Date.now() - startTime,
     error: message,
   };
+}
+
+function querySdkExample(feeds: SuggestedVirtualFeed[]): string {
+  const ids = feeds.map((feed) => feed.feed_id).join(', ');
+  // Keep this shape in sync with FeedsNamespace.readMany.
+  return `export default async (_ctx, client) => {
+  return client.feeds.readMany({ feed_ids: [${ids}], limit: ${VIRTUAL_FEED_SUGGESTED_LIMIT} });
+};`;
+}
+
+async function virtualFeedCoverageForEventsQuery(
+  tableRefs: string[],
+  scope: AuthzScope
+): Promise<QuerySqlCoverage | undefined> {
+  if (!tableRefs.includes('events')) return undefined;
+
+  try {
+    const sql = getDb();
+    const vis = compileConnectionRowVisibility(scope, 2, 'c');
+    const rows = (await sql.unsafe(
+      `SELECT
+         f.id AS feed_id,
+         f.feed_key,
+         f.display_name,
+         c.slug AS connection_slug,
+         c.connector_key
+       FROM feeds f
+       JOIN connections c ON c.id = f.connection_id
+       WHERE f.organization_id = $1
+         AND f.deleted_at IS NULL
+         AND c.deleted_at IS NULL
+         AND f.status = 'active'
+         AND c.status = 'active'
+         AND (f.kind = 'virtual' OR f.virtual IS TRUE)
+         ${vis.sql}
+       ORDER BY f.id ASC
+       LIMIT ${MAX_SUGGESTED_VIRTUAL_FEEDS + 1}`,
+      [scope.organizationId, ...vis.params],
+    )) as unknown as Array<{
+      feed_id: number;
+      feed_key: string;
+      display_name: string | null;
+      connection_slug: string;
+      connector_key: string;
+    }>;
+
+    if (rows.length === 0) return undefined;
+    const suggested = rows.slice(0, MAX_SUGGESTED_VIRTUAL_FEEDS).map((row) => ({
+      feed_id: Number(row.feed_id),
+      feed: `${row.connection_slug}/${row.feed_key}`,
+      connection_slug: row.connection_slug,
+      feed_key: row.feed_key,
+      display_name: row.display_name,
+      connector_key: row.connector_key,
+      suggested_limit: VIRTUAL_FEED_SUGGESTED_LIMIT,
+    }));
+
+    return {
+      source: 'persisted_events_only',
+      warning:
+        'SELECT FROM events reads persisted/synced content only. Virtual feeds are live-only and are not included.',
+      suggested_virtual_feeds: suggested,
+      more_available: rows.length > MAX_SUGGESTED_VIRTUAL_FEEDS,
+      suggested_execution: {
+        tool: 'query_sdk',
+        method: 'client.feeds.readMany',
+        latency_note:
+          'Live feed reads are network-bound; run independent feeds in parallel and keep per-feed limits small.',
+        example: querySdkExample(suggested),
+      },
+    };
+  } catch (err) {
+    logger.warn({ err }, 'query_sql virtual feed coverage lookup failed');
+    return undefined;
+  }
 }
 
 export const querySql = withValidatedArgs('query_sql', QuerySqlSchema, querySqlImpl);
@@ -362,6 +464,7 @@ export async function querySqlImpl(
   // Validate, parse, and org-scope the query
   let scopedSql: string;
   let params: unknown[];
+  let tableRefs: string[];
   try {
     const scoped = validateAndScopeQuery(baseSql, targetOrgId, {
       safeColumns: SAFE_COLUMN_DEFS,
@@ -373,6 +476,7 @@ export async function querySqlImpl(
     });
     scopedSql = scoped.sql;
     params = scoped.params;
+    tableRefs = scoped.tableRefs;
   } catch (err) {
     return errorResult(getErrorMessage(err), startTime);
   }
@@ -433,6 +537,10 @@ export async function querySqlImpl(
       total_count: totalCount,
       has_more: offset + limit < totalCount,
       execution_time_ms: Date.now() - startTime,
+      coverage: await virtualFeedCoverageForEventsQuery(
+        tableRefs,
+        authzScopeFromToolContext({ organizationId: targetOrgId, userId: ctx.userId }),
+      ),
     };
   } catch (error) {
     const msg = getErrorMessage(error);

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -184,7 +184,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'query_sql',
     description:
-      'Run a paginated, sortable, searchable read-only SQL query (member-safe). Table references auto-scope to the bound org. Supports connection pushdown and virtual feeds. Prefer client.metrics.query for declared measures; use client.query in query_sdk for simple one-shot SQL. Do NOT use positional parameters ($1, $2, …). Optional `org_slug` (OAuth on /mcp only) redirects to another member org.',
+      'Run a paginated, sortable, searchable read-only SQL query (member-safe). Table references auto-scope to the bound org. SELECT FROM events reads persisted/synced content only; virtual feeds are live-only and must be read explicitly with feed or via query_sdk client.feeds.readMany. Results may include coverage.suggested_virtual_feeds. Prefer client.metrics.query for declared measures; use client.query in query_sdk for simple one-shot SQL. Do NOT use positional parameters ($1, $2, …). Optional `org_slug` (OAuth on /mcp only) redirects to another member org.',
     inputSchema: QuerySqlSchema,
     annotations: { ...READ_ONLY, title: 'Query SQL' },
     handler: querySql,
@@ -533,4 +533,3 @@ function computeListedTools(
     })
     .filter((tool): tool is NonNullable<typeof tool> => tool !== null);
 }
-

--- a/packages/server/src/utils/execute-data-sources.ts
+++ b/packages/server/src/utils/execute-data-sources.ts
@@ -326,7 +326,7 @@ export function validateAndScopeQuery(
      */
     userId?: string | null;
   }
-): { sql: string; params: unknown[] } {
+): { sql: string; params: unknown[]; tableRefs: string[] } {
   const trimmed = rawSql.trim();
   if (!trimmed) {
     throw new Error('SQL query is required');
@@ -365,12 +365,15 @@ export function validateAndScopeQuery(
     }
   }
 
-  return buildScopedQuery(
-    trimmed,
+  return {
+    ...buildScopedQuery(
+      trimmed,
+      tableRefs,
+      { organizationId, userId: options?.userId ?? null },
+      options
+    ),
     tableRefs,
-    { organizationId, userId: options?.userId ?? null },
-    options
-  );
+  };
 }
 
 // ============================================


### PR DESCRIPTION
## What

- **`query_sql` coverage hints:** when the internal SQL references `events`, the result attaches an advisory `coverage` block (`source: 'persisted_events_only'`) listing up to 5 visibility-fenced `suggested_virtual_feeds`, a `more_available` flag, and a ready `client.feeds.readMany` example. Lookup failures log and omit the block — they never fail the SQL query. `events` reads remain persisted-only; this is explicit agent decomposition, not hidden SQL federation.
- **`manage_feeds.read_feeds`:** batch-read up to 10 feeds in parallel with per-feed `{ ok, result } | { ok:false, error }` results (a missing or visibility-fenced feed doesn't fail the batch). Per-feed timeout defaults 10s, clamps at 30s. Exposed read-only in the sandbox SDK as `client.feeds.readMany`; delegates to `handleReadFeed`, so it inherits the connection-visibility gate and channel ACL fencing.
- `validateAndScopeQuery` additionally returns `tableRefs` (additive; all callers destructure).
- Docs: `database-connectors.md` Slice-2 status updated to shipped; feeds/connections-model + slice-2 plan clarified around the coverage-hint contract.

## Validation

- `vitest run src/__tests__/integration/connectors/virtual-feed-surfaces.test.ts` — 15/15 pass against ephemeral embedded Postgres, including 3 new tests: coverage hints with owner-vs-member fencing, batch partial failures, per-feed visibility failures.
- `query_sql.test.ts`, `method-metadata.test.ts`, `tool-access.test.ts` unit suites pass; `tsc --noEmit` clean (pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785875976&installation_id=136316292&pr_number=1745&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1745&signature=2f02d9d8b6c29f8e5354a0778cf65154859a6755398a3f83eccd45a23783ef4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->