### PR TITLE
test(server): cover feeds.readMany SDK dispatch in namespace-dispatch suite

### DIFF
--- a/packages/server/src/__tests__/integration/sandbox/namespace-dispatch.test.ts
+++ b/packages/server/src/__tests__/integration/sandbox/namespace-dispatch.test.ts
@@ -85,6 +85,22 @@ describe("ClientSDK namespace dispatch (read paths)", () => {
 		await expect(sdk.feeds.list()).resolves.toBeDefined();
 	});
 
+	it("feeds.readMany dispatches cleanly with per-feed failures", async () => {
+		const out = (await sdk.feeds.readMany({
+			feed_ids: [999_999_999],
+			limit: 1,
+		})) as {
+			action: string;
+			failures: number;
+			results: Array<{ feed_id: number; ok: boolean; error?: string }>;
+		};
+		expect(out).toMatchObject({
+			action: "read_feeds",
+			failures: 1,
+			results: [{ feed_id: 999_999_999, ok: false, error: "Feed not found" }],
+		});
+	});
+
 	it("authProfiles.list dispatches cleanly", async () => {
 		await expect(sdk.authProfiles.list()).resolves.toBeDefined();
 	});


### PR DESCRIPTION
Follow-up to #1745. The namespace-dispatch harness exists to catch field-name drift between SDK wrappers and handler TypeBox schemas, but `feeds.readMany` landed without an entry — the `client.feeds.readMany` → `read_feeds` action mapping was only typechecked, never executed.

Adds a dispatch test asserting the `read_feeds` result shape including per-feed `{ ok:false, error: 'Feed not found' }` partial-failure semantics.

Validation: `vitest run src/__tests__/integration/sandbox/namespace-dispatch.test.ts` — 19/19 pass (embedded Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785876933&installation_id=136316292&pr_number=1747&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1747&signature=9483ec22155fbda37f6311bfeb9ae01004fe8d3d6d7efe84702931e901564a44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->