### PR TITLE
fix(server): wire Mac computer_use device actions end-to-end

### DIFF
--- a/packages/server/src/__tests__/integration/mac-computer-use-action-poll.test.ts
+++ b/packages/server/src/__tests__/integration/mac-computer-use-action-poll.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Mac bridge action runs: poll must surface the operation under both
+ * `action_key` (chrome convention) and `operation_key` (Mac/iOS decode name).
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { generateSecureToken } from '../../auth/oauth/utils';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { post } from '../setup/test-helpers';
+
+const CONNECTOR_KEY = 'apple.computer_use';
+const OPERATION_KEY = 'permissions';
+
+function loadComputerUseManifest(): Record<string, unknown> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const path = resolve(
+    here,
+    '../../../../owletto/apps/mac/Owletto/ConnectorManifests/apple_computer_use.json',
+  );
+  return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+}
+
+async function seedDeviceOwner() {
+  const sql = getTestDb();
+  const userId = `user_${generateSecureToken(4)}`;
+  const orgId = `org-mac-cu-${generateSecureToken(4)}`;
+  const workerId = `mac-${generateSecureToken(6)}`;
+  await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${userId}, 'Mac CU Owner', ${`${userId}@test.local`}, true, NOW(), NOW())
+  `;
+  await sql`
+    INSERT INTO "organization" (id, name, slug, visibility, metadata, "createdAt")
+    VALUES (
+      ${orgId}, 'Mac CU Org', ${orgId}, 'private',
+      ${sql.json({ personal_org_for_user_id: userId })}, NOW()
+    )
+  `;
+  await sql`
+    INSERT INTO member (id, "organizationId", "userId", role, "createdAt")
+    VALUES (${`mem_${generateSecureToken(4)}`}, ${orgId}, ${userId}, 'owner', NOW())
+  `;
+  const deviceRows = (await sql`
+    INSERT INTO device_workers (user_id, worker_id, platform, app_version, capabilities, label, organization_id)
+    VALUES (${userId}, ${workerId}, 'macos', '0.1.0', ${sql.json(['computer_use'])}, 'Test Mac', ${orgId})
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  return { userId, orgId, workerId, deviceWorkerId: deviceRows[0].id };
+}
+
+async function pollMac(
+  workerId: string,
+  capabilities: Record<string, boolean>,
+  connectorManifests: unknown[],
+) {
+  return post('/api/workers/poll', {
+    body: {
+      worker_id: workerId,
+      platform: 'macos',
+      app_version: '0.1.0',
+      label: 'Test Mac',
+      capabilities,
+      connector_manifests: connectorManifests,
+    },
+  });
+}
+
+describe('mac computer_use action poll', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.LOBU_CLOUD_MODE;
+    delete process.env.WORKER_API_TOKEN;
+  });
+  afterEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('claims a pinned action run and returns operation_key alongside action_key', async () => {
+    const { orgId, workerId, deviceWorkerId } = await seedDeviceOwner();
+    const manifest = loadComputerUseManifest();
+
+    const install = await pollMac(workerId, { computer_use: true }, []);
+    expect(install.status).toBe(200);
+
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO connector_definitions (
+        key, name, organization_id, version, status, runtime, required_capability, feeds_schema
+      ) VALUES (
+        ${CONNECTOR_KEY}, 'Mac Computer Use', ${orgId}, '0.1.0', 'active',
+        ${sql.json({ platforms: ['macos'] })}, 'computer_use', ${sql.json({})}
+      )
+      ON CONFLICT DO NOTHING
+    `;
+    const connInserted = (await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status,
+        created_by, visibility, device_worker_id, created_at, updated_at
+      ) VALUES (
+        ${orgId}, ${CONNECTOR_KEY}, 'mac-computer-use', 'Mac Computer Use', 'active',
+        (SELECT "userId" FROM member WHERE "organizationId" = ${orgId} LIMIT 1),
+        'private', ${deviceWorkerId}::uuid, NOW(), NOW()
+      )
+      RETURNING id, device_worker_id
+    `) as unknown as Array<{ id: number; device_worker_id: string }>;
+    expect(connInserted[0]?.id).toBeTruthy();
+    expect(connInserted[0]?.device_worker_id).toBe(deviceWorkerId);
+
+    const inserted = (await sql`
+      INSERT INTO runs (
+        organization_id, run_type, connection_id, connector_key, connector_version,
+        action_key, action_input, approval_status, status, created_at
+      ) VALUES (
+        ${orgId}, 'action', ${connInserted[0].id}, ${CONNECTOR_KEY}, '0.1.0',
+        ${OPERATION_KEY}, ${sql.json({})}, 'auto', 'pending', current_timestamp
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+    const runId = Number(inserted[0].id);
+
+    const claim = await pollMac(workerId, { computer_use: true }, []);
+    expect(claim.status).toBe(200);
+    const body = (await claim.json()) as Record<string, unknown>;
+
+    expect(body.run_id).toBe(runId);
+    expect(body.run_type).toBe('action');
+    expect(body.connector_key).toBe(CONNECTOR_KEY);
+    expect(body.action_key).toBe(OPERATION_KEY);
+    expect(body.operation_key).toBe(OPERATION_KEY);
+    expect(body.compiled_code).toBeUndefined();
+  });
+});

--- a/packages/server/src/__tests__/integration/mac-computer-use-action-poll.test.ts
+++ b/packages/server/src/__tests__/integration/mac-computer-use-action-poll.test.ts
@@ -81,47 +81,33 @@ describe('mac computer_use action poll', () => {
   it('claims a pinned action run and returns operation_key alongside action_key', async () => {
     const { orgId, workerId, deviceWorkerId } = await seedDeviceOwner();
     const manifest = loadComputerUseManifest();
+    const connectorManifests = [manifest];
 
-    const install = await pollMac(workerId, { computer_use: true }, []);
+    const install = await pollMac(workerId, { computer_use: true }, connectorManifests);
     expect(install.status).toBe(200);
 
     const sql = getTestDb();
-    await sql`
-      INSERT INTO connector_definitions (
-        key, name, organization_id, version, status, runtime, required_capability, feeds_schema
-      ) VALUES (
-        ${CONNECTOR_KEY}, 'Mac Computer Use', ${orgId}, '0.1.0', 'active',
-        ${sql.json({ platforms: ['macos'] })}, 'computer_use', ${sql.json({})}
-      )
-      ON CONFLICT DO NOTHING
-    `;
-    const connInserted = (await sql`
-      INSERT INTO connections (
-        organization_id, connector_key, slug, display_name, status,
-        created_by, visibility, device_worker_id, created_at, updated_at
-      ) VALUES (
-        ${orgId}, ${CONNECTOR_KEY}, 'mac-computer-use', 'Mac Computer Use', 'active',
-        (SELECT "userId" FROM member WHERE "organizationId" = ${orgId} LIMIT 1),
-        'private', ${deviceWorkerId}::uuid, NOW(), NOW()
-      )
-      RETURNING id, device_worker_id
+    const connRows = (await sql`
+      SELECT id, device_worker_id FROM connections
+      WHERE organization_id = ${orgId} AND connector_key = ${CONNECTOR_KEY}
+      LIMIT 1
     `) as unknown as Array<{ id: number; device_worker_id: string }>;
-    expect(connInserted[0]?.id).toBeTruthy();
-    expect(connInserted[0]?.device_worker_id).toBe(deviceWorkerId);
+    expect(connRows[0]?.id).toBeTruthy();
+    expect(connRows[0]?.device_worker_id).toBe(deviceWorkerId);
 
     const inserted = (await sql`
       INSERT INTO runs (
         organization_id, run_type, connection_id, connector_key, connector_version,
         action_key, action_input, approval_status, status, created_at
       ) VALUES (
-        ${orgId}, 'action', ${connInserted[0].id}, ${CONNECTOR_KEY}, '0.1.0',
+        ${orgId}, 'action', ${connRows[0].id}, ${CONNECTOR_KEY}, '0.1.0',
         ${OPERATION_KEY}, ${sql.json({})}, 'auto', 'pending', current_timestamp
       )
       RETURNING id
     `) as unknown as Array<{ id: number }>;
     const runId = Number(inserted[0].id);
 
-    const claim = await pollMac(workerId, { computer_use: true }, []);
+    const claim = await pollMac(workerId, { computer_use: true }, connectorManifests);
     expect(claim.status).toBe(200);
     const body = (await claim.json()) as Record<string, unknown>;
 

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -91,7 +91,7 @@ const DEFAULT_LIMITS: Required<RunLimits> = {
 	outputBytes: 1_048_576,
 };
 /** Device action waits allow 60s queue + 95s post-claim; sandbox must outlive that. */
-const MAX_SCRIPT_TIMEOUT_MS = 180_000;
+export const MAX_SCRIPT_TIMEOUT_MS = 180_000;
 const MAX_TRACE_ARGS_BYTES = 8192;
 const SENSITIVE_TRACE_KEY =
 	/(api[_-]?key|apikey|auth[_-]?data|auth[_-]?values|authorization|cookie|credential|password|private[_-]?key|secret|token)/i;

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -1,7 +1,8 @@
 /**
  * Compiles a TypeScript user-script via esbuild, runs it in a V8 isolate, and
  * bridges SDK calls back to the host. Caps: 1 MB output, 200 SDK calls,
- * 60s wall-clock. `client.org()` is stateless — each guest call carries
+ * 180s wall-clock max (device-bound operations may wait up to ~155s).
+ * `client.org()` is stateless — each guest call carries
  * `orgPath` so the host re-walks org swaps without holding refs.
  */
 
@@ -89,6 +90,8 @@ const DEFAULT_LIMITS: Required<RunLimits> = {
 	sdkCallQuota: 200,
 	outputBytes: 1_048_576,
 };
+/** Device action waits allow 60s queue + 95s post-claim; sandbox must outlive that. */
+const MAX_SCRIPT_TIMEOUT_MS = 180_000;
 const MAX_TRACE_ARGS_BYTES = 8192;
 const SENSITIVE_TRACE_KEY =
 	/(api[_-]?key|apikey|auth[_-]?data|auth[_-]?values|authorization|cookie|credential|password|private[_-]?key|secret|token)/i;
@@ -139,7 +142,7 @@ function clampLimits(limits?: RunLimits): Required<RunLimits> {
 			limits?.timeoutMs,
 			DEFAULT_LIMITS.timeoutMs,
 			1,
-			DEFAULT_LIMITS.timeoutMs,
+			MAX_SCRIPT_TIMEOUT_MS,
 		),
 		sdkCallQuota: clampNumber(
 			limits?.sdkCallQuota,

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -15,9 +15,10 @@ const SCRIPT_FIELDS = {
   }),
   timeout_ms: Type.Optional(
     Type.Number({
-      description: "Wall-clock budget. Default 60000 (max 60000).",
+      description:
+        "Wall-clock budget. Default 60000 (max 180000 — device-bound operations may wait ~155s).",
       minimum: 100,
-      maximum: 60_000,
+      maximum: 180_000,
     }),
   ),
 };

--- a/packages/server/src/tools/sdk_run.ts
+++ b/packages/server/src/tools/sdk_run.ts
@@ -2,7 +2,7 @@ import { type Static, Type } from "@sinclair/typebox";
 import { resolveMaxAccessLevel } from "../auth/tool-access";
 import type { Env } from "../index";
 import { buildClientSDK, type SDKMode } from "../sandbox/client-sdk";
-import { runScript } from "../sandbox/run-script";
+import { MAX_SCRIPT_TIMEOUT_MS, runScript } from "../sandbox/run-script";
 import type { ToolContext } from "./registry";
 import { withValidatedArgs } from "./validate-args";
 
@@ -18,7 +18,7 @@ const SCRIPT_FIELDS = {
       description:
         "Wall-clock budget. Default 60000 (max 180000 — device-bound operations may wait ~155s).",
       minimum: 100,
-      maximum: 180_000,
+      maximum: MAX_SCRIPT_TIMEOUT_MS,
     }),
   ),
 };

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -320,12 +320,19 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
       );
     }
     if (!deviceWorkerId) {
-      const existing = (await sql`
-        SELECT id FROM device_workers
-        WHERE user_id = ${registrationUserId} AND worker_id = ${worker_id}
-        LIMIT 1
-      `) as unknown as Array<{ id: string }>;
-      deviceWorkerId = existing[0]?.id ?? null;
+      try {
+        const existing = (await sql`
+          SELECT id FROM device_workers
+          WHERE user_id = ${registrationUserId} AND worker_id = ${worker_id}
+          LIMIT 1
+        `) as unknown as Array<{ id: string }>;
+        deviceWorkerId = existing[0]?.id ?? null;
+      } catch (err) {
+        logger.error(
+          { worker_id, err: errorMessage(err) },
+          '[pollWorkerJob] deviceWorkerId fallback lookup failed (non-fatal)'
+        );
+      }
     }
   }
 

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -319,6 +319,14 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         '[pollWorkerJob] device_workers upsert failed (non-fatal)'
       );
     }
+    if (!deviceWorkerId) {
+      const existing = (await sql`
+        SELECT id FROM device_workers
+        WHERE user_id = ${registrationUserId} AND worker_id = ${worker_id}
+        LIMIT 1
+      `) as unknown as Array<{ id: string }>;
+      deviceWorkerId = existing[0]?.id ?? null;
+    }
   }
 
   // User-scoped workers (e.g. Lobu for Mac) can only claim runs in the
@@ -805,6 +813,8 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     compiled_code: compiledCode,
     session_state: sessionState ?? undefined,
     action_key: row.action_key ?? undefined,
+    // Mac/iOS bridge decodes `operation_key`; chrome uses `action_key` directly.
+    operation_key: row.action_key ?? undefined,
     action_input: (row as any).approved_input ?? row.action_input ?? undefined,
     auth_profile_id: deliverConnectionAuth ? (row.run_auth_profile_id ?? undefined) : undefined,
     previous_credentials: deliverConnectionAuth ? (row.auth_profile_auth_data ?? undefined) : undefined,


### PR DESCRIPTION
## Problem
`lobu memory exec` + `operations.execute` for `apple.computer_use` timed out on prod: action runs stayed `pending` for 60s and never reached the Mac.

## Root causes fixed
1. **Poll wire format** — server returned `action_key` only; Mac `WorkerJob` expected `operation_key`. Poll now emits both; Mac decodes `action_key` as fallback.
2. **deviceWorkerId fallback** — if `device_workers` upsert fails, poll now re-reads the existing row so pinned action runs remain claimable.
3. **Sandbox timeout** — `run_sdk` cap raised from 60s to 180s so device-bound operations can outlive the gateway wait budget.

## Tests
- `mac-computer-use-action-poll.test.ts` — pinned action run claimed, `operation_key` returned
- `device-action-wait.test.ts` — existing suite still green

## Owletto
Submodule bumped to `de6b1baf` (`feat/fix-computer-use-exec` on owletto) for the Mac decode fix.

## Verification after deploy
\`\`\`bash
lobu memory exec 'export default async (_ctx, client) => {
  const cu = (await client.connections.list()).connections
    .find(c => c.connector_key === "apple.computer_use");
  return await client.operations.execute({
    connection_id: cu.id, operation_key: "permissions", input: {},
  });
}'
\`\`\`
Expect `completed` in <15s (not 60s timeout).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785885420&installation_id=136316292&pr_number=1750&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1750&signature=7fa443bb167e9fd32b954ef9dcfa84d0242b92b7abd31b6dfbe10dc7a60d1dbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for Mac device workflows in polling responses, including more consistent operation details for action runs.

* **Bug Fixes**
  * Fixed cases where worker polling could miss device identification during registration, improving reliability for existing device connections.
  * Increased allowed script and tool timeouts, giving long-running jobs more time to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->