### PR TITLE
feat(connectors): Gmail virtual feeds, YouTube personal sync + actions

### DIFF
--- a/examples/personal-agent/docs/one-off-context-sources.md
+++ b/examples/personal-agent/docs/one-off-context-sources.md
@@ -1,0 +1,302 @@
+# One-off personal context sources
+
+How to gather **historical, export-only** personal data for a Lobu org running the `personal-agent` example. These complement the live connectors declared in `lobu.config.ts` and any others you add in the dashboard.
+
+Set `org` in `lobu.config.ts` to your workspace slug (the example defaults to `personal-agent`). Connection slugs below use short generic names — change them in config if you run multiple accounts of the same type.
+
+For durable facts, ingest into `learning` entities or `save_memory` — not as file-path references.
+
+## Live connectors
+
+**Declared in `lobu.config.ts`:**
+
+| Connector | Slug | Feeds |
+|-----------|------|-------|
+| Revolut | `revolut` | `transactions` → `asset`, `subscription`, `trip` |
+
+**Commonly added alongside this example** (via dashboard or extended config):
+
+| Connector | Suggested slug | Feeds / notes |
+|-----------|----------------|---------------|
+| LinkedIn | `linkedin` | Home feed, company pages |
+| Spotify | `spotify` | Recently played, playlists, top tracks |
+| WhatsApp | `whatsapp` | Messages (`whatsapp.local` on a paired device) |
+| Gmail | `gmail` | Indexed sync and/or virtual `threads` feed. Optional `config.query` scope; agents pass `query_sql` `search_term` (Gmail connector merges as search syntax). Default: unbounded mailbox |
+| YouTube | `youtube` | `liked_videos`, `playlists` (OAuth). **Watch history** is not in the YouTube API — use Google Takeout |
+| Chrome | `chrome`, `chrome-history`, `chrome-downloads`, `chrome-bookmarks` | Browsing + downloads |
+| Apple Photos / Calendar / Reminders / Screen Time | `apple-photos`, `calendar`, `reminders`, `apple-screen-time` | Device data |
+| Local folder | `local-folder` | Watched directories |
+
+**Trips** are Revolut-derived only (foreign card-spend clusters). Passport, visa, or ILR history belongs in travel **learnings**, not `trip` entities.
+
+---
+
+## YouTube & LinkedIn — live sync vs exports
+
+Both services split into **ongoing live ingest** (connectors) and **one-off archives** (official downloads). Use live for what the API or extension can reach; use exports for deep history the API does not expose.
+
+### YouTube
+
+#### What the live connector covers (OAuth)
+
+The bundled `youtube` connector syncs **indexed** feeds — not virtual. Connect Google in the dashboard, then add feeds:
+
+| Feed | What you get | Auth |
+|------|----------------|------|
+| `liked_videos` | Videos you have liked (indexed sync) | Google OAuth + `youtube.readonly` |
+| `playlists` | Your playlists and (optionally) videos inside each | Same |
+| `videos` | Scheduled ingest of a **fixed** public keyword (`search_query`) | OAuth or `YOUTUBE_API_KEY` |
+
+**On-demand actions** (via `operations.execute` — results are not synced):
+
+| Action | What you get | Auth |
+|--------|----------------|------|
+| `search` | Public YouTube keyword search now | OAuth or API key |
+| `get_video` | One video's metadata (+ optional transcript/comments) | OAuth or API key |
+| `search_liked_videos` | Filter your likes by title/channel | OAuth |
+| `list_playlists` | Your playlist catalog | OAuth |
+| `get_playlist` | Videos in one playlist (+ optional filter) | OAuth |
+
+Use **feeds** for durable memory (`search_memory`); use **actions** when the agent needs a live lookup.
+
+**Setup:**
+
+1. Dashboard → **Connections** → add connector `youtube`, slug e.g. `youtube`.
+2. **Connect** → sign in with Google and grant YouTube read access.
+3. **Feeds** → create `liked_videos` and `playlists` (defaults are fine).
+4. Run sync or wait for the schedule; rows land in `events` and become searchable via `search_memory`.
+
+**Not available live:** watch history. The YouTube Data API has no watch-history endpoint — Google keeps that out of third-party apps.
+
+#### Download watch history (Google Takeout)
+
+For full watch history (including mobile/TV views the Chrome extension would miss):
+
+1. Open https://takeout.google.com (same Google account as YouTube).
+2. **Deselect all**, then enable **YouTube and YouTube Music** only (or include other products if you want a broader archive).
+3. Click **All YouTube data included** → ensure **history** is checked. Optionally include **subscriptions**, **playlists**, **comments** for overlap with live feeds.
+4. Choose **Export once**, **.zip**, and a size that fits your mailbox (large histories split across multiple zips).
+5. Submit → wait for the email (minutes to hours) → download each part and unzip.
+
+**Paths inside the archive** (names vary slightly by export date):
+
+```
+Takeout/
+  YouTube and YouTube Music/
+    history/
+      watch-history.html          # primary watch log (HTML table)
+    playlists/
+      playlists.csv               # optional — overlaps live `playlists` feed
+    subscriptions/
+      subscriptions.csv           # channels you follow
+```
+
+Some exports also ship JSON under `history/` instead of HTML. Lobu has no Takeout parser yet — treat the export as a **one-off backfill**:
+
+- Drop `watch-history.html` (or the whole `Takeout/` folder) into a **local folder** feed (`local.directory` on Lobu for Mac) so the file is ingested as a document, **or**
+- Summarise key facts into **learning** entities / `save_memory` after you skim the export.
+
+**Partial live alternative:** `chrome.history` (Owletto Chrome + `history` permission) captures `youtube.com/watch?v=...` visits from the browser (~90-day backfill + live). Good for forward-looking web viewing; not a full account history.
+
+| Source | Coverage |
+|--------|----------|
+| OAuth `liked_videos` / `playlists` | Likes and curated lists, ongoing |
+| Takeout `watch-history.html` | Full watch log, one-off / periodic re-export |
+| `chrome.history` | Browser watch URLs only, ongoing |
+
+---
+
+### LinkedIn
+
+#### What the live connector covers (Chrome extension)
+
+The example `linkedin` connector (in `linkedin.connector.ts`) scrapes via the **paired Owletto Chrome extension** — you must be signed into linkedin.com in that browser profile.
+
+| Feed | What you get | Requires |
+|------|----------------|----------|
+| `home_feed` | Your personalised feed (`linkedin.com/feed/`) | Extension + LinkedIn session |
+| `company_updates` | Posts from a company page URL in feed config | Extension + `company_url` |
+| `jobs` | Open roles on a company page | Extension + `company_url` |
+
+**Setup:**
+
+1. Pair Owletto for Chrome with your org’s worker.
+2. Sign in to LinkedIn in the extension’s Chrome profile.
+3. Dashboard → **Connections** → add connector `linkedin` (example connector from `lobu apply` / extended config).
+4. Add feed `home_feed` for your timeline; add `company_updates` / `jobs` only if you track specific company pages.
+5. Sync runs on the worker; the extension executes the scrape. New posts accumulate in `events`.
+
+**Not available live:** full connection graph, message archive, complete career CSVs, endorsements, or pre-account history. The extension reads what’s on the pages you scrape today, not LinkedIn’s full account dump.
+
+#### Download your LinkedIn archive (official export)
+
+For career timeline, connections, education, skills, and message history:
+
+1. Open https://www.linkedin.com/mypreferences/d/download-my-data (or **Settings & Privacy** → **Data privacy** → **Get a copy of your data**).
+2. Choose **Download larger data archive** (not the “ready within minutes” lite export) if you want messages and full history.
+3. Confirm the request. LinkedIn emails when the archive is ready — often **24–72 hours**, sometimes longer.
+4. Use the link in the email to download the `.zip` (may be multiple parts).
+
+**Typical contents** (exact filenames can vary):
+
+```
+LinkedIn_Export_<date>.zip
+  Profile.csv                 # headline, location, summary
+  Positions.csv               # job history
+  Education.csv
+  Skills.csv
+  Certifications.csv
+  Connections.csv             # first name, last name, email, company, position, connected on
+  Messages/                   # per-conversation HTML or CSV shards
+  Invitations.csv
+  Endorsements_Received.csv
+  Rich_Attachments/           # media from messages, if included
+```
+
+**Ingest today (no bundled Takeout-style parser):**
+
+| File | Suggested Lobu target |
+|------|------------------------|
+| `Positions.csv` + `Education.csv` | **Career history** learning |
+| `Profile.csv` + `Skills.csv` | Professional identity facts in learnings |
+| `Connections.csv` | Seed `person` entities for close network (not the whole CSV — curate) |
+| `Messages/` | Episodic `save_memory` only for threads not captured elsewhere |
+
+Live `home_feed` keeps your timeline current; the zip **backfills** graph and career data the scraper never sees.
+
+---
+
+## One-off exports
+
+### Google Takeout
+
+| | |
+|---|---|
+| **Download** | https://takeout.google.com |
+| **Pick** | Calendar, Mail, Photos, Chrome, Drive, YouTube, Location History |
+| **Format** | `.zip` shards |
+| **Ingest** | Calendar overlaps `calendar`; Mail overlaps `gmail`; Photos may need a Takeout-specific connector |
+| **YouTube history** | See [YouTube → Download watch history](#download-watch-history-google-takeout) above |
+| **Status** | _Not started_ |
+
+---
+
+### X / Twitter
+
+| | |
+|---|---|
+| **Download** | https://x.com/settings/download_your_data |
+| **Format** | `twitter-YYYY-MM-DD-<hash>.zip` → `data/tweets.js`, DMs, media |
+| **Ingest** | No bundled connector; summarise into learnings or episodic memory |
+| **Status** | _Not started_ |
+
+---
+
+### ChatGPT / OpenAI
+
+| | |
+|---|---|
+| **Download** | ChatGPT → Settings → Data controls → Export data |
+| **Format** | `conversations.json`, `memories.json`, `projects.json`, `users.json` |
+| **Ingest** | Diff `memories.json` + project descriptions into learnings; skip ephemeral devtool threads |
+| **Status** | _Not started_ |
+
+---
+
+### LinkedIn
+
+Full step-by-step: [LinkedIn → Download your archive](#download-your-linkedin-archive-official-export) above.
+
+| | |
+|---|---|
+| **Download** | https://www.linkedin.com/mypreferences/d/download-my-data |
+| **Wait** | Email link, typically 24–72 hours |
+| **Ingest** | Live `home_feed` for ongoing posts; zip backfills career + connections |
+| **Status** | _Not started_ |
+
+---
+
+### WhatsApp
+
+| | |
+|---|---|
+| **Download** | In app: chat → ⋮ → More → Export chat |
+| **Format** | `.zip` with `_chat.txt` + media |
+| **Ingest** | `whatsapp` / `whatsapp.local` is primary; exports for chats outside the paired device |
+| **Status** | _Not started_ |
+
+---
+
+### Passport / ILR / travel evidence
+
+| | |
+|---|---|
+| **Source** | Passport scans, visa spreadsheets, flight logs |
+| **Ingest** | Travel learnings (e.g. **UK travel and absence history**, **International travel profile**) |
+| **Status** | _Not started_ |
+
+---
+
+### Apple / iCloud
+
+| | |
+|---|---|
+| **Download** | https://privacy.apple.com |
+| **Ingest** | Overlaps Apple connectors; use for backfill only |
+
+---
+
+### Meta (Facebook / Instagram)
+
+| | |
+|---|---|
+| **Download** | https://www.facebook.com/dyi |
+| **Status** | _Not started_ |
+
+---
+
+### Spotify
+
+| | |
+|---|---|
+| **Download** | https://www.spotify.com/account/privacy/ |
+| **Ingest** | `spotify` connector is live once connected; export only for offline archive |
+
+---
+
+## Ingestion playbook
+
+Replace `personal-agent` with your org slug if you changed it in `lobu.config.ts`.
+
+```bash
+lobu login
+lobu apply                    # provision org + connectors from lobu.config.ts
+lobu memory org set personal-agent
+
+# Search before writing
+lobu memory run search_memory '{"query":"career linkedin"}' --org personal-agent
+
+# Update a learning
+lobu memory run run_sdk --org personal-agent '{"script":"export default async (_ctx, c) => c.entities.update({ entity_id: <id>, metadata: { ... } })"}'
+
+# Append an episodic note
+lobu memory run save_memory --org personal-agent '{"content":"...","semantic_type":"observation"}'
+```
+
+**Rules:** search first · supersede stale learnings · no file paths in memory · credentials never ingested.
+
+---
+
+## Backfill queue
+
+Track your own progress here (or delete this section once done).
+
+| Priority | Source | Status |
+|----------|--------|--------|
+| P0 | ChatGPT export | _Not started_ |
+| P0 | Passport / ILR travel | _Not started_ |
+| P1 | Twitter archive | _Not started_ |
+| P1 | LinkedIn data zip | _Not started_ |
+| P1 | YouTube Takeout (watch history) | _Not started_ |
+| P2 | Google Takeout (full) | _Not started_ |
+| P3 | WhatsApp exports | _Not started_ |

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -217,7 +217,7 @@ const asset = defineEntityType({
   },
   // Governed spend metrics over the Revolut transaction stream. The eventSet
   // resolves a transaction to an account by matching its `currency` against the
-  // account asset's aliases. The buremba org runs a single consolidated Revolut
+  // account asset's aliases. This example assumes a single consolidated Revolut
   // account, so that one asset is aliased with EVERY currency it transacts in
   // (GBP, USD, EUR, …) and owns all transactions; `currency` is then a
   // dimension, not a separate entity per pocket. Because the measure is
@@ -660,7 +660,7 @@ const learning = defineEntityType({
 // always timed out); 20 scrolls (~55s) reliably completes, and scheduled
 // incremental syncs keep history current from the top each run.
 const revolutConnection = defineConnection({
-  slug: "revolut-buremba",
+  slug: "revolut",
   connector: "revolut",
   name: "Revolut",
   feeds: [{ feed: "transactions", config: { max_scrolls: 20 } }],
@@ -677,8 +677,8 @@ export default defineConfig({
       "./whatsapp.cloud.connector.ts"
     ),
   ],
-  org: "buremba",
-  orgName: "Buremba",
+  org: "personal-agent",
+  orgName: "Personal Agent",
   orgDescription:
     "Personal agent tracking finances, people, companies, subscriptions, trips, and topics.",
   agents: [personalAgent],

--- a/examples/personal-agent/seed-asset-aliases.sql
+++ b/examples/personal-agent/seed-asset-aliases.sql
@@ -11,7 +11,7 @@
 -- transacts in and owns all transactions; `currency` is a metric dimension.
 -- The asset alias array is REPLACED (not appended) so re-running is idempotent.
 --
--- Scope to the buremba org if running against a shared database.
+-- Scope to the org slug from lobu.config.ts when running against a shared database.
 UPDATE entities AS e
 SET metadata = jsonb_set(
   coalesce(e.metadata, '{}'::jsonb),
@@ -31,4 +31,7 @@ WHERE e.entity_type_id = (
     WHERE et.organization_id = e.organization_id AND et.slug = 'asset'
   )
   AND e.name = 'Revolut'
-  AND e.deleted_at IS NULL;
+  AND e.deleted_at IS NULL
+  AND e.organization_id = (
+    SELECT id FROM organizations WHERE slug = 'personal-agent' LIMIT 1
+  );

--- a/packages/connectors/src/README.md
+++ b/packages/connectors/src/README.md
@@ -493,4 +493,4 @@ This means edits to `.ts` files in `connectors/` take effect on the next sync wi
 | `reddit` | oauth/none | posts, comments | - |
 | `rss` | none | articles | - |
 | `x` | browser (CLI) | tweets | - |
-| `youtube` | oauth (Google) | videos & comments | - |
+| `youtube` | oauth (Google) | liked videos, playlists, keyword search (sync) | search, get_video, search_liked_videos, list_playlists, get_playlist |

--- a/packages/connectors/src/__tests__/connector-sdk.mock.ts
+++ b/packages/connectors/src/__tests__/connector-sdk.mock.ts
@@ -76,7 +76,11 @@ export function connectorSdkMock() {
     createHttpClient: () => ({
       json: notUsed('http.json'),
       request: notUsed('http.request'),
+      raw: notUsed('http.raw'),
     }),
+    filterByCheckpoint: <T>(events: T[]) => events,
+    sleep: async () => {},
+    validatePublicUrl: (url: string) => url,
     requireBearerClient: notUsed('requireBearerClient'),
     paginateByCursor,
     paginateByOffset,

--- a/packages/connectors/src/__tests__/connector-sdk.mock.ts
+++ b/packages/connectors/src/__tests__/connector-sdk.mock.ts
@@ -78,7 +78,18 @@ export function connectorSdkMock() {
       request: notUsed('http.request'),
       raw: notUsed('http.raw'),
     }),
-    filterByCheckpoint: <T>(events: T[]) => events,
+    // Faithful copy of connector-sdk checkpoint/timestamp-watermark.ts — must
+    // honor the checkpoint arg; a passthrough stub leaks via Bun's global mock
+    // registry and breaks scraper-utils.test when connector tests run first.
+    filterByCheckpoint: <T extends { occurred_at: Date }>(
+      events: T[],
+      checkpoint: Record<string, unknown> | null
+    ): T[] => {
+      const lastTimestamp = checkpoint?.last_timestamp as string | undefined;
+      if (!lastTimestamp) return events;
+      const cutoff = new Date(lastTimestamp);
+      return events.filter((e) => e.occurred_at >= cutoff);
+    },
     sleep: async () => {},
     validatePublicUrl: (url: string) => url,
     requireBearerClient: notUsed('requireBearerClient'),

--- a/packages/connectors/src/__tests__/youtube.test.ts
+++ b/packages/connectors/src/__tests__/youtube.test.ts
@@ -1,0 +1,316 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
+import { connectorSdkMock } from './connector-sdk.mock';
+
+mock.module('@lobu/connector-sdk', connectorSdkMock);
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let YouTubeConnector: any;
+
+beforeAll(async () => {
+  const mod = await import('../youtube');
+  YouTubeConnector = mod.default;
+});
+
+function fakeHttp(handlers: Record<string, (url: URL) => unknown>) {
+  return {
+    raw: async (url: string) => {
+      const u = new URL(url);
+      const key = u.pathname.split('/').pop() ?? '';
+      const handler = handlers[key];
+      if (!handler) {
+        return {
+          ok: false,
+          status: 404,
+          text: async () => `no handler for ${key}`,
+        } as Response;
+      }
+      const body = handler(u);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => body,
+        text: async () => JSON.stringify(body),
+      } as Response;
+    },
+  };
+}
+
+describe('YouTubeConnector personal feeds', () => {
+  test('liked_videos resolves the Likes playlist and emits liked_video events', async () => {
+    const connector = new YouTubeConnector();
+    connector.http = fakeHttp({
+      channels: () => ({
+        items: [{ contentDetails: { relatedPlaylists: { likes: 'LLlikes' } } }],
+      }),
+      playlistItems: (u) => ({
+        items: [
+          {
+            snippet: {
+              publishedAt: '2026-07-01T10:00:00Z',
+              title: 'Great talk',
+              channelTitle: 'Channel A',
+              playlistId: 'LLlikes',
+              resourceId: { kind: 'youtube#video', videoId: 'vid1' },
+            },
+            contentDetails: { videoId: 'vid1', videoPublishedAt: '2026-06-01T10:00:00Z' },
+          },
+        ],
+      }),
+    });
+
+    const result = await connector.sync({
+      feedKey: 'liked_videos',
+      credentials: { accessToken: 'token' },
+      config: { max_results: 10 },
+      checkpoint: {},
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].origin_type).toBe('liked_video');
+    expect(result.events[0].origin_id).toBe('yt_liked_vid1');
+    expect(result.events[0].title).toBe('Great talk');
+  });
+
+  test('playlists emits playlist and playlist_item events', async () => {
+    const connector = new YouTubeConnector();
+    connector.http = fakeHttp({
+      playlists: () => ({
+        items: [
+          {
+            id: 'PL1',
+            snippet: {
+              title: 'Favourites',
+              description: 'Saved stuff',
+              publishedAt: '2026-01-01T00:00:00Z',
+              channelTitle: 'Me',
+            },
+            contentDetails: { itemCount: 1 },
+          },
+        ],
+      }),
+      playlistItems: (u) => {
+        const playlistId = u.searchParams.get('playlistId');
+        if (playlistId === 'PL1') {
+          return {
+            items: [
+              {
+                snippet: {
+                  publishedAt: '2026-02-01T00:00:00Z',
+                  title: 'Inside item',
+                  channelTitle: 'Channel B',
+                  playlistId: 'PL1',
+                  resourceId: { kind: 'youtube#video', videoId: 'vid2' },
+                },
+                contentDetails: { videoId: 'vid2' },
+              },
+            ],
+          };
+        }
+        return { items: [] };
+      },
+    });
+
+    const result = await connector.sync({
+      feedKey: 'playlists',
+      credentials: { accessToken: 'token' },
+      config: { max_playlists: 5, include_items: true, max_items_per_playlist: 10 },
+      checkpoint: {},
+    });
+
+    expect(result.events).toHaveLength(2);
+    expect(result.events.find((e: { origin_type: string }) => e.origin_type === 'playlist')?.title).toBe(
+      'Favourites'
+    );
+    expect(
+      result.events.find((e: { origin_type: string }) => e.origin_type === 'playlist_item')?.origin_parent_id
+    ).toBe('yt_playlist_PL1');
+  });
+
+  test('liked_videos requires OAuth', async () => {
+    const connector = new YouTubeConnector();
+    await expect(
+      connector.sync({
+        feedKey: 'liked_videos',
+        credentials: {},
+        config: { YOUTUBE_API_KEY: 'key-only' },
+        checkpoint: {},
+      })
+    ).rejects.toThrow(/requires OAuth/i);
+  });
+});
+
+describe('YouTubeConnector actions', () => {
+  test('search returns public video summaries', async () => {
+    const connector = new YouTubeConnector();
+    connector.http = fakeHttp({
+      search: (u) => ({
+        items: [
+          {
+            id: { kind: 'youtube#video', videoId: 'vid9' },
+            snippet: {
+              publishedAt: '2026-07-01T10:00:00Z',
+              channelId: 'ch1',
+              title: 'Public hit',
+              description: 'desc',
+              channelTitle: 'Channel Z',
+            },
+          },
+        ],
+      }),
+      videos: () => ({
+        items: [
+          {
+            id: 'vid9',
+            snippet: {
+              publishedAt: '2026-07-01T10:00:00Z',
+              channelId: 'ch1',
+              title: 'Public hit',
+              description: 'desc',
+              channelTitle: 'Channel Z',
+            },
+            statistics: { viewCount: '100', likeCount: '5', commentCount: '1' },
+            contentDetails: { duration: 'PT5M' },
+          },
+        ],
+      }),
+    });
+
+    const result = await connector.execute({
+      actionKey: 'search',
+      credentials: { accessToken: 'token' },
+      config: {},
+      input: { query: 'public hit', max_results: 5 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output?.videos).toHaveLength(1);
+    expect(result.output?.videos[0].video_id).toBe('vid9');
+    expect(result.output?.videos[0].title).toBe('Public hit');
+  });
+
+  test('search_liked_videos filters by title', async () => {
+    const connector = new YouTubeConnector();
+    connector.http = fakeHttp({
+      channels: () => ({
+        items: [{ contentDetails: { relatedPlaylists: { likes: 'LLlikes' } } }],
+      }),
+      playlistItems: (u) => {
+        if (u.searchParams.get('playlistId') === 'LLlikes') {
+          return {
+            items: [
+              {
+                snippet: {
+                  publishedAt: '2026-07-01T10:00:00Z',
+                  title: 'Immigration podcast',
+                  channelTitle: 'Law Channel',
+                  playlistId: 'LLlikes',
+                  resourceId: { kind: 'youtube#video', videoId: 'a' },
+                },
+                contentDetails: { videoId: 'a' },
+              },
+              {
+                snippet: {
+                  publishedAt: '2026-07-02T10:00:00Z',
+                  title: 'Cooking tips',
+                  channelTitle: 'Food Channel',
+                  playlistId: 'LLlikes',
+                  resourceId: { kind: 'youtube#video', videoId: 'b' },
+                },
+                contentDetails: { videoId: 'b' },
+              },
+            ],
+          };
+        }
+        return { items: [] };
+      },
+    });
+
+    const result = await connector.execute({
+      actionKey: 'search_liked_videos',
+      credentials: { accessToken: 'token' },
+      config: {},
+      input: { query: 'immigration' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output?.videos).toHaveLength(1);
+    expect(result.output?.videos[0].video_id).toBe('a');
+  });
+
+  test('get_video accepts a watch URL', async () => {
+    const connector = new YouTubeConnector();
+    connector.http = fakeHttp({
+      videos: () => ({
+        items: [
+          {
+            id: 'abc12345678',
+            snippet: {
+              publishedAt: '2026-06-01T10:00:00Z',
+              channelId: 'ch',
+              title: 'One video',
+              description: 'body',
+              channelTitle: 'Creator',
+            },
+            statistics: { viewCount: '1', likeCount: '0', commentCount: '0' },
+          },
+        ],
+      }),
+    });
+
+    const result = await connector.execute({
+      actionKey: 'get_video',
+      credentials: { accessToken: 'token' },
+      config: {},
+      input: {
+        video_id: 'https://www.youtube.com/watch?v=abc12345678',
+        include_transcript: false,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output?.video.video_id).toBe('abc12345678');
+  });
+
+  test('list_playlists returns playlist summaries', async () => {
+    const connector = new YouTubeConnector();
+    connector.http = fakeHttp({
+      playlists: () => ({
+        items: [
+          {
+            id: 'PL9',
+            snippet: {
+              title: 'Saved',
+              description: 'My list',
+              publishedAt: '2026-01-01T00:00:00Z',
+              channelTitle: 'Me',
+            },
+            contentDetails: { itemCount: 3 },
+          },
+        ],
+      }),
+    });
+
+    const result = await connector.execute({
+      actionKey: 'list_playlists',
+      credentials: { accessToken: 'token' },
+      config: {},
+      input: {},
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output?.playlists[0].playlist_id).toBe('PL9');
+    expect(result.output?.playlists[0].item_count).toBe(3);
+  });
+
+  test('search_liked_videos requires OAuth', async () => {
+    const connector = new YouTubeConnector();
+    const result = await connector.execute({
+      actionKey: 'search_liked_videos',
+      credentials: {},
+      config: { YOUTUBE_API_KEY: 'key-only' },
+      input: { query: 'test' },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/requires OAuth/i);
+  });
+});

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -479,14 +479,12 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       throw new Error('Gmail virtual-feed reads require Google OAuth credentials.');
     }
 
-    // Gmail's `q` is space-separated = AND. Each term is escaped so a term that
-    // contains Gmail operators/spaces (e.g. `from:a b`) is matched literally as a
-    // quoted phrase rather than reinterpreted as query syntax.
-    const parts = [baseQuery.trim(), ...terms.map((t) => this.escapeGmailTerm(t))].filter(Boolean);
+    // Gmail's `q` is space-separated = AND. Compose the feed's optional scope
+    // (config.query) with the caller's terms as raw Gmail search syntax — each
+    // connector interprets search() terms; we do not escape operators here.
+    // An empty string means no `q` filter — list the authenticated mailbox.
+    const parts = [baseQuery.trim(), ...terms.map((t) => t.trim())].filter(Boolean);
     const q = parts.join(' ');
-    if (!q) {
-      throw new Error('Gmail virtual feed has no `query` in its config and no search terms.');
-    }
 
     // Gmail search has no arbitrary sort — results are always reverse-chronological
     // (newest first). Reject a sort we can't honor rather than silently ignore it.
@@ -511,22 +509,6 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     return { rows, columns: GMAIL_SEARCH_COLUMNS };
   }
 
-  /**
-   * Quote a recall term so Gmail matches it LITERALLY. A bare word passes
-   * through; anything containing whitespace, a quote, or a Gmail query-operator
-   * character (`:` `(` `)` `{` `}`) is wrapped in quotes so it is not reparsed as
-   * query syntax (e.g. `from:alice@example.com` must match the text, not act as a
-   * `from:` operator). Embedded quotes are stripped — Gmail has no escape for a
-   * literal quote inside a phrase.
-   */
-  private escapeGmailTerm(term: string): string {
-    const t = term.trim();
-    if (!t) return '';
-    // Bare token with no whitespace, quotes, or operator characters → pass through.
-    if (!/[\s"():{}]/.test(t)) return t;
-    return `"${t.replace(/"/g, '')}"`;
-  }
-
   private async listMessageIds(
     http: HttpClient,
     q: string,
@@ -538,9 +520,9 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       const remaining = want - out.length;
       if (remaining <= 0) break;
       const params = new URLSearchParams({
-        q,
         maxResults: String(Math.min(100, remaining)),
       });
+      if (q) params.set('q', q);
       if (pageToken) params.set('pageToken', pageToken);
       const res = await http.raw(`${this.BASE_URL}/messages?${params.toString()}`);
       if (!res.ok) {

--- a/packages/connectors/src/youtube.ts
+++ b/packages/connectors/src/youtube.ts
@@ -1,12 +1,24 @@
 /**
  * YouTube Connector (V1 runtime)
  *
- * Fetches video metadata, comments, and transcripts from YouTube search results
- * via the YouTube Data API v3. Transcripts are extracted from YouTube's embedded
- * caption tracks (no third-party packages required).
+ * Feeds (indexed sync → events / search_memory):
+ *  - `liked_videos` — the authenticated user's liked videos (Likes playlist)
+ *  - `playlists` — the user's playlists and their items
+ *  - `videos` — optional scheduled ingest of a fixed public keyword search
+ *
+ * Actions (on-demand via operations.execute — not persisted):
+ *  - `search` — public YouTube keyword search
+ *  - `get_video` — one video's metadata (+ optional transcript/comments)
+ *  - `search_liked_videos` — filter your liked videos by title/channel
+ *  - `list_playlists` — list your playlists
+ *  - `get_playlist` — list videos in a playlist (optional title filter)
+ *
+ * Watch history is NOT exposed by the YouTube Data API; use Google Takeout for that.
  */
 
 import {
+  type ActionContext,
+  type ActionResult,
   type ConnectorDefinition,
   ConnectorRuntime,
   calculateEngagementScore,
@@ -100,9 +112,87 @@ interface YouTubeCommentThreadResponse {
   items: YouTubeCommentThread[];
 }
 
+interface YouTubePlaylistItem {
+  snippet: {
+    publishedAt: string;
+    title: string;
+    channelTitle: string;
+    playlistId: string;
+    resourceId: {
+      kind: string;
+      videoId?: string;
+    };
+  };
+  contentDetails?: {
+    videoId?: string;
+    videoPublishedAt?: string;
+  };
+}
+
+interface YouTubePlaylistItemResponse {
+  nextPageToken?: string;
+  items: YouTubePlaylistItem[];
+}
+
+interface YouTubePlaylist {
+  id: string;
+  snippet: {
+    title: string;
+    description: string;
+    publishedAt: string;
+    channelTitle: string;
+  };
+  contentDetails: {
+    itemCount: number;
+  };
+}
+
+interface YouTubePlaylistResponse {
+  nextPageToken?: string;
+  items: YouTubePlaylist[];
+}
+
+interface YouTubeChannelResponse {
+  items: Array<{
+    contentDetails: {
+      relatedPlaylists: {
+        likes?: string;
+        uploads?: string;
+      };
+    };
+  }>;
+}
+
 interface CaptionTrack {
   baseUrl: string;
   languageCode: string;
+}
+
+type YouTubeAuth = { accessToken?: string; apiKey?: string };
+
+/** Compact video row returned by on-demand actions. */
+interface VideoSummary {
+  video_id: string;
+  title: string;
+  channel_title: string;
+  channel_id?: string;
+  published_at: string;
+  url: string;
+  view_count?: number;
+  like_count?: number;
+  comment_count?: number;
+  description?: string;
+  transcript?: string;
+  duration?: string;
+}
+
+interface PlaylistSummary {
+  playlist_id: string;
+  title: string;
+  description: string;
+  item_count: number;
+  channel_title: string;
+  url: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -122,8 +212,9 @@ export default class YouTubeConnector extends ConnectorRuntime {
   readonly definition: ConnectorDefinition = {
     key: 'youtube',
     name: 'YouTube',
-    description: 'Fetches video metadata, comments, and transcripts from YouTube search results.',
-    version: '1.0.0',
+    description:
+      'Syncs liked videos, playlists, and optional keyword search; on-demand actions for public and library search.',
+    version: '1.2.0',
     faviconDomain: 'youtube.com',
     authSchema: {
       methods: [
@@ -143,11 +234,100 @@ export default class YouTubeConnector extends ConnectorRuntime {
       ],
     },
     feeds: {
+      liked_videos: {
+        key: 'liked_videos',
+        name: 'Liked Videos',
+        requiredScopes: ['https://www.googleapis.com/auth/youtube.readonly'],
+        description:
+          "Videos the authenticated user has liked. Uses the account's Likes playlist.",
+        configSchema: {
+          type: 'object',
+          properties: {
+            max_results: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 5000,
+              default: 500,
+              description: 'Maximum liked videos to fetch per sync.',
+            },
+          },
+        },
+        eventKinds: {
+          liked_video: {
+            description: 'A video the user liked on YouTube',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                video_id: { type: 'string' },
+                channel_title: { type: 'string' },
+                playlist_id: { type: 'string' },
+                video_published_at: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+      playlists: {
+        key: 'playlists',
+        name: 'Playlists',
+        requiredScopes: ['https://www.googleapis.com/auth/youtube.readonly'],
+        description: "The authenticated user's playlists and the videos in each playlist.",
+        configSchema: {
+          type: 'object',
+          properties: {
+            max_playlists: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 500,
+              default: 100,
+              description: 'Maximum playlists to fetch.',
+            },
+            include_items: {
+              type: 'boolean',
+              default: true,
+              description: 'Whether to fetch videos inside each playlist.',
+            },
+            max_items_per_playlist: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 5000,
+              default: 500,
+              description: 'Per-playlist cap on items fetched when include_items is true.',
+            },
+          },
+        },
+        eventKinds: {
+          playlist: {
+            description: 'A YouTube playlist owned by the user',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                item_count: { type: 'number' },
+                channel_title: { type: 'string' },
+              },
+            },
+          },
+          playlist_item: {
+            description: 'A video inside a YouTube playlist',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                playlist_id: { type: 'string' },
+                playlist_title: { type: 'string' },
+                video_id: { type: 'string' },
+                channel_title: { type: 'string' },
+                video_published_at: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
       videos: {
         key: 'videos',
         name: 'Videos',
         requiredScopes: ['https://www.googleapis.com/auth/youtube.readonly'],
-        description: 'Search YouTube for videos and collect metadata, comments, and transcripts.',
+        description:
+          'Scheduled ingest of a fixed public keyword search (metadata, comments, transcripts). For agent-time search use the `search` action instead.',
         configSchema: {
           type: 'object',
           required: ['search_query'],
@@ -155,7 +335,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
             search_query: {
               type: 'string',
               minLength: 1,
-              description: 'Search term to query YouTube.',
+              description: 'Fixed search term synced on each run (e.g. a topic you monitor).',
             },
             max_results: {
               type: 'integer',
@@ -210,6 +390,121 @@ export default class YouTubeConnector extends ConnectorRuntime {
         },
       },
     },
+    actions: {
+      search: {
+        key: 'search',
+        name: 'Search Videos',
+        description: 'Search public YouTube by keyword and return matching videos.',
+        inputSchema: {
+          type: 'object',
+          required: ['query'],
+          properties: {
+            query: {
+              type: 'string',
+              minLength: 1,
+              description: 'YouTube search keywords (public catalog).',
+            },
+            max_results: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 50,
+              description: 'Maximum videos to return (default 10).',
+            },
+            include_transcript: {
+              type: 'boolean',
+              description: 'Fetch captions when available (default false).',
+            },
+          },
+        },
+      },
+      get_video: {
+        key: 'get_video',
+        name: 'Get Video',
+        description: 'Fetch metadata for one YouTube video by id or URL.',
+        inputSchema: {
+          type: 'object',
+          required: ['video_id'],
+          properties: {
+            video_id: {
+              type: 'string',
+              description: 'YouTube video id or watch URL.',
+            },
+            include_transcript: {
+              type: 'boolean',
+              description: 'Fetch captions when available (default true).',
+            },
+            include_comments: {
+              type: 'boolean',
+              description: 'Include top comment threads (default false).',
+            },
+          },
+        },
+      },
+      search_liked_videos: {
+        key: 'search_liked_videos',
+        name: 'Search Liked Videos',
+        description:
+          "Filter the authenticated user's liked videos by title or channel name (substring match).",
+        inputSchema: {
+          type: 'object',
+          required: ['query'],
+          properties: {
+            query: {
+              type: 'string',
+              minLength: 1,
+              description: 'Case-insensitive filter on video title or channel name.',
+            },
+            max_results: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              description: 'Maximum matches to return (default 25).',
+            },
+          },
+        },
+      },
+      list_playlists: {
+        key: 'list_playlists',
+        name: 'List Playlists',
+        description: "List the authenticated user's YouTube playlists.",
+        inputSchema: {
+          type: 'object',
+          properties: {
+            max_results: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              description: 'Maximum playlists to return (default 25).',
+            },
+          },
+        },
+      },
+      get_playlist: {
+        key: 'get_playlist',
+        name: 'Get Playlist',
+        description: 'List videos in one of your playlists, with an optional title filter.',
+        inputSchema: {
+          type: 'object',
+          required: ['playlist_id'],
+          properties: {
+            playlist_id: {
+              type: 'string',
+              description: 'Playlist id or youtube.com/playlist?list= URL.',
+            },
+            query: {
+              type: 'string',
+              description: 'Optional case-insensitive filter on video title or channel.',
+            },
+            max_results: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 100,
+              description: 'Maximum videos to return (default 50).',
+            },
+          },
+        },
+      },
+    },
   };
 
   private readonly BASE_URL = 'https://www.googleapis.com/youtube/v3';
@@ -222,12 +517,286 @@ export default class YouTubeConnector extends ConnectorRuntime {
   // -------------------------------------------------------------------------
 
   async sync(ctx: SyncContext): Promise<SyncResult> {
+    const auth = this.resolveAuth(ctx);
+
+    switch (ctx.feedKey) {
+      case 'liked_videos':
+        return this.syncLikedVideos(ctx, auth);
+      case 'playlists':
+        return this.syncPlaylists(ctx, auth);
+      case 'videos':
+        return this.syncSearchVideos(ctx, auth);
+      default:
+        throw new Error(`Unknown feed: ${ctx.feedKey}`);
+    }
+  }
+
+  private resolveAuth(ctx: SyncContext): YouTubeAuth {
     const accessToken = ctx.credentials?.accessToken as string | undefined;
     const apiKey = (ctx.config.YOUTUBE_API_KEY as string) || undefined;
     if (!accessToken && !apiKey) {
       throw new Error('YouTube requires either OAuth (Google) or a YOUTUBE_API_KEY.');
     }
+    return { accessToken, apiKey };
+  }
 
+  private requireOAuth(auth: YouTubeAuth, feed: string): string {
+    if (!auth.accessToken) {
+      throw new Error(
+        `YouTube feed '${feed}' requires OAuth (youtube.readonly). Connect a Google account.`
+      );
+    }
+    return auth.accessToken;
+  }
+
+  // -------------------------------------------------------------------------
+  // execute (on-demand actions)
+  // -------------------------------------------------------------------------
+
+  async execute(ctx: ActionContext): Promise<ActionResult> {
+    try {
+      const auth = this.resolveAuthFromAction(ctx);
+      switch (ctx.actionKey) {
+        case 'search':
+          return await this.actionSearchPublic(auth, ctx.input);
+        case 'get_video':
+          return await this.actionGetVideo(auth, ctx.input);
+        case 'search_liked_videos':
+          return await this.actionSearchLikedVideos(auth, ctx.input);
+        case 'list_playlists':
+          return await this.actionListPlaylists(auth, ctx.input);
+        case 'get_playlist':
+          return await this.actionGetPlaylist(auth, ctx.input);
+        default:
+          return { success: false, error: `Unknown action: ${ctx.actionKey}` };
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private resolveAuthFromAction(ctx: ActionContext): YouTubeAuth {
+    const accessToken = ctx.credentials?.accessToken as string | undefined;
+    const apiKey = (ctx.config?.YOUTUBE_API_KEY as string) || undefined;
+    if (!accessToken && !apiKey) {
+      throw new Error('YouTube requires either OAuth (Google) or a YOUTUBE_API_KEY.');
+    }
+    return { accessToken, apiKey };
+  }
+
+  private async actionSearchPublic(
+    auth: YouTubeAuth,
+    input: Record<string, unknown>
+  ): Promise<ActionResult> {
+    const query = (input.query as string)?.trim();
+    if (!query) {
+      return { success: false, error: 'query is required.' };
+    }
+    const maxResults = Math.min(Math.max((input.max_results as number) ?? 10, 1), 50);
+    const includeTranscript = (input.include_transcript as boolean) ?? false;
+    const videos = await this.searchPublicVideos(auth, query, maxResults, includeTranscript);
+    return { success: true, output: { videos } };
+  }
+
+  private async actionGetVideo(
+    auth: YouTubeAuth,
+    input: Record<string, unknown>
+  ): Promise<ActionResult> {
+    const videoId = this.parseVideoId(input.video_id as string);
+    if (!videoId) {
+      return { success: false, error: 'video_id is required.' };
+    }
+    const includeTranscript = (input.include_transcript as boolean) ?? true;
+    const includeComments = (input.include_comments as boolean) ?? false;
+    const details = await this.fetchVideoDetails(auth, [videoId]);
+    if (details.length === 0) {
+      return { success: false, error: `Video '${videoId}' not found.` };
+    }
+    const video = await this.videoToSummary(details[0], auth, {
+      includeTranscript,
+      includeComments,
+    });
+    return { success: true, output: { video } };
+  }
+
+  private async actionSearchLikedVideos(
+    auth: YouTubeAuth,
+    input: Record<string, unknown>
+  ): Promise<ActionResult> {
+    this.requireOAuth(auth, 'search_liked_videos');
+    const query = (input.query as string)?.trim();
+    if (!query) {
+      return { success: false, error: 'query is required.' };
+    }
+    const maxResults = Math.min(Math.max((input.max_results as number) ?? 25, 1), 100);
+    const likesPlaylistId = await this.fetchLikesPlaylistId(auth);
+    const videos = await this.searchPlaylistItemsByQuery({
+      auth,
+      playlistId: likesPlaylistId,
+      query,
+      maxResults,
+    });
+    return { success: true, output: { videos } };
+  }
+
+  private async actionListPlaylists(
+    auth: YouTubeAuth,
+    input: Record<string, unknown>
+  ): Promise<ActionResult> {
+    this.requireOAuth(auth, 'list_playlists');
+    const maxResults = Math.min(Math.max((input.max_results as number) ?? 25, 1), 100);
+    const playlists: PlaylistSummary[] = [];
+    const pages = paginateByCursor<YouTubePlaylist, string>(
+      async (cursor) => {
+        const params = new URLSearchParams({
+          part: 'snippet,contentDetails',
+          mine: 'true',
+          maxResults: '50',
+        });
+        if (cursor) params.set('pageToken', cursor);
+        const response = await this.apiGet(`${this.BASE_URL}/playlists?${params.toString()}`, auth);
+        if (!response.ok) {
+          throw new Error(
+            `YouTube Playlists API error (${response.status}): ${await response.text()}`
+          );
+        }
+        const data = (await response.json()) as YouTubePlaylistResponse;
+        return { items: data.items ?? [], nextCursor: data.nextPageToken };
+      },
+      { delayMs: this.RATE_LIMIT_MS }
+    );
+    for await (const batch of pages) {
+      for (const playlist of batch) {
+        if (playlists.length >= maxResults) break;
+        playlists.push(this.playlistToSummary(playlist));
+      }
+      if (playlists.length >= maxResults) break;
+    }
+    return { success: true, output: { playlists } };
+  }
+
+  private async actionGetPlaylist(
+    auth: YouTubeAuth,
+    input: Record<string, unknown>
+  ): Promise<ActionResult> {
+    this.requireOAuth(auth, 'get_playlist');
+    const playlistId = this.parsePlaylistId(input.playlist_id as string);
+    if (!playlistId) {
+      return { success: false, error: 'playlist_id is required.' };
+    }
+    const query = (input.query as string)?.trim();
+    const maxResults = Math.min(Math.max((input.max_results as number) ?? 50, 1), 100);
+    const videos = await this.searchPlaylistItemsByQuery({
+      auth,
+      playlistId,
+      query: query || undefined,
+      maxResults,
+    });
+    return { success: true, output: { playlist_id: playlistId, videos } };
+  }
+
+  // -------------------------------------------------------------------------
+  // Feed: liked_videos
+  // -------------------------------------------------------------------------
+
+  private async syncLikedVideos(ctx: SyncContext, auth: YouTubeAuth): Promise<SyncResult> {
+    this.requireOAuth(auth, 'liked_videos');
+    const maxResults = Math.min(Math.max((ctx.config.max_results as number) ?? 500, 1), 5000);
+    const likesPlaylistId = await this.fetchLikesPlaylistId(auth);
+    const events = await this.collectPlaylistVideoEvents({
+      auth,
+      playlistId: likesPlaylistId,
+      playlistTitle: 'Liked videos',
+      maxResults,
+      originType: 'liked_video',
+      originIdPrefix: 'yt_liked',
+    });
+
+    return this.buildListCheckpointResult(events);
+  }
+
+  // -------------------------------------------------------------------------
+  // Feed: playlists
+  // -------------------------------------------------------------------------
+
+  private async syncPlaylists(ctx: SyncContext, auth: YouTubeAuth): Promise<SyncResult> {
+    this.requireOAuth(auth, 'playlists');
+    const maxPlaylists = Math.min(Math.max((ctx.config.max_playlists as number) ?? 100, 1), 500);
+    const includeItems = (ctx.config.include_items as boolean) ?? true;
+    const maxItemsPerPlaylist = Math.min(
+      Math.max((ctx.config.max_items_per_playlist as number) ?? 500, 1),
+      5000
+    );
+
+    const events: EventEnvelope[] = [];
+    let collectedPlaylists = 0;
+
+    const playlistPages = paginateByCursor<YouTubePlaylist, string>(
+      async (cursor) => {
+        const params = new URLSearchParams({
+          part: 'snippet,contentDetails',
+          mine: 'true',
+          maxResults: '50',
+        });
+        if (cursor) params.set('pageToken', cursor);
+        const response = await this.apiGet(`${this.BASE_URL}/playlists?${params.toString()}`, auth);
+        if (!response.ok) {
+          throw new Error(
+            `YouTube Playlists API error (${response.status}): ${await response.text()}`
+          );
+        }
+        const data = (await response.json()) as YouTubePlaylistResponse;
+        return { items: data.items ?? [], nextCursor: data.nextPageToken };
+      },
+      { delayMs: this.RATE_LIMIT_MS }
+    );
+
+    for await (const playlists of playlistPages) {
+      for (const playlist of playlists) {
+        if (collectedPlaylists >= maxPlaylists) break;
+
+        events.push({
+          origin_id: `yt_playlist_${playlist.id}`,
+          title: playlist.snippet.title,
+          payload_text: (playlist.snippet.description ?? '').trim(),
+          author_name: playlist.snippet.channelTitle,
+          source_url: `https://www.youtube.com/playlist?list=${playlist.id}`,
+          occurred_at: new Date(playlist.snippet.publishedAt),
+          origin_type: 'playlist',
+          metadata: {
+            item_count: playlist.contentDetails.itemCount,
+            channel_title: playlist.snippet.channelTitle,
+          },
+        });
+
+        if (includeItems && playlist.contentDetails.itemCount > 0) {
+          const itemEvents = await this.collectPlaylistVideoEvents({
+            auth,
+            playlistId: playlist.id,
+            playlistTitle: playlist.snippet.title,
+            maxResults: maxItemsPerPlaylist,
+            originType: 'playlist_item',
+            originIdPrefix: `yt_playlist_item_${playlist.id}`,
+          });
+          events.push(...itemEvents);
+        }
+
+        collectedPlaylists += 1;
+      }
+      if (collectedPlaylists >= maxPlaylists) break;
+    }
+
+    return this.buildListCheckpointResult(events);
+  }
+
+  // -------------------------------------------------------------------------
+  // Feed: videos (keyword search)
+  // -------------------------------------------------------------------------
+
+  private async syncSearchVideos(ctx: SyncContext, auth: YouTubeAuth): Promise<SyncResult> {
     const searchQuery = ctx.config.search_query as string;
     if (!searchQuery) {
       throw new Error('search_query is required.');
@@ -241,11 +810,9 @@ export default class YouTubeConnector extends ConnectorRuntime {
     const events: EventEnvelope[] = [];
     const seenIds = new Set<string>();
 
-    const auth = { accessToken, apiKey };
     let pageToken: string | undefined = checkpoint.next_page_token;
     let totalCollected = 0;
 
-    // ----- Search & collect video IDs -----
     const searchPages = paginateByCursor<YouTubeSearchItem, string>(
       async (cursor) => {
         const pageSize = Math.min(50, maxResults - totalCollected);
@@ -268,7 +835,6 @@ export default class YouTubeConnector extends ConnectorRuntime {
     for await (const searchItems of searchPages) {
       if (searchItems.length === 0) break;
 
-      // Collect unique video IDs from this page
       const videoIds: string[] = [];
       for (const item of searchItems) {
         const videoId = item.id.videoId;
@@ -278,21 +844,16 @@ export default class YouTubeConnector extends ConnectorRuntime {
         }
       }
 
-      if (videoIds.length === 0) {
-        continue;
-      }
+      if (videoIds.length === 0) continue;
 
-      // ----- Fetch video details in batches of 50 -----
       const videoDetails = await this.fetchVideoDetails(auth, videoIds);
 
-      // ----- Process each video -----
       for (const video of videoDetails) {
         try {
           const viewCount = parseInt(video.statistics.viewCount ?? '0', 10);
           const likeCount = parseInt(video.statistics.likeCount ?? '0', 10);
           const commentCount = parseInt(video.statistics.commentCount ?? '0', 10);
 
-          // Fetch transcript if enabled
           let transcript: string | null = null;
           if (includeTranscripts) {
             try {
@@ -339,14 +900,13 @@ export default class YouTubeConnector extends ConnectorRuntime {
 
           events.push(videoEvent);
 
-          // ----- Fetch comments if enabled -----
           if (includeComments && commentCount > 0) {
             try {
               const comments = await this.fetchComments(auth, video.id);
               for (const comment of comments) {
                 const commentSnippet = comment.snippet.topLevelComment.snippet;
 
-                const commentEvent: EventEnvelope = {
+                events.push({
                   origin_id: `yt_comment_${comment.snippet.topLevelComment.id}`,
                   payload_text: commentSnippet.textOriginal,
                   author_name: commentSnippet.authorDisplayName,
@@ -359,9 +919,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
                     like_count: commentSnippet.likeCount,
                     reply_count: comment.snippet.totalReplyCount,
                   },
-                };
-
-                events.push(commentEvent);
+                });
               }
             } catch {
               /* comment fetch is best-effort */
@@ -376,12 +934,9 @@ export default class YouTubeConnector extends ConnectorRuntime {
       if (totalCollected >= maxResults) break;
     }
 
-    // Sort events by occurred_at descending
     events.sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime());
 
-    // Update checkpoint
     const latestPublishedAt = events.length > 0 ? events[0].occurred_at.toISOString() : undefined;
-
     const newCheckpoint: YouTubeCheckpoint = {
       last_published_at: latestPublishedAt ?? checkpoint.last_published_at,
       next_page_token: pageToken,
@@ -398,8 +953,297 @@ export default class YouTubeConnector extends ConnectorRuntime {
   }
 
   // -------------------------------------------------------------------------
-  // execute
+  // Shared playlist helpers
   // -------------------------------------------------------------------------
+
+  private async fetchLikesPlaylistId(auth: YouTubeAuth): Promise<string> {
+    const params = new URLSearchParams({
+      part: 'contentDetails',
+      mine: 'true',
+    });
+    const response = await this.apiGet(`${this.BASE_URL}/channels?${params.toString()}`, auth);
+    if (!response.ok) {
+      throw new Error(
+        `YouTube Channels API error (${response.status}): ${await response.text()}`
+      );
+    }
+    const data = (await response.json()) as YouTubeChannelResponse;
+    const likesPlaylistId = data.items?.[0]?.contentDetails?.relatedPlaylists?.likes;
+    if (!likesPlaylistId) {
+      throw new Error(
+        'Could not resolve the Likes playlist for this YouTube account. Ensure the Google account has a YouTube channel.'
+      );
+    }
+    return likesPlaylistId;
+  }
+
+  private async collectPlaylistVideoEvents(params: {
+    auth: YouTubeAuth;
+    playlistId: string;
+    playlistTitle: string;
+    maxResults: number;
+    originType: string;
+    originIdPrefix: string;
+  }): Promise<EventEnvelope[]> {
+    const events: EventEnvelope[] = [];
+    let collected = 0;
+
+    const itemPages = paginateByCursor<YouTubePlaylistItem, string>(
+      async (cursor) => {
+        const listParams = new URLSearchParams({
+          part: 'snippet,contentDetails',
+          playlistId: params.playlistId,
+          maxResults: '50',
+        });
+        if (cursor) listParams.set('pageToken', cursor);
+        const response = await this.apiGet(
+          `${this.BASE_URL}/playlistItems?${listParams.toString()}`,
+          params.auth
+        );
+        if (!response.ok) {
+          throw new Error(
+            `YouTube PlaylistItems API error (${response.status}): ${await response.text()}`
+          );
+        }
+        const data = (await response.json()) as YouTubePlaylistItemResponse;
+        return { items: data.items ?? [], nextCursor: data.nextPageToken };
+      },
+      { delayMs: this.RATE_LIMIT_MS }
+    );
+
+    for await (const items of itemPages) {
+      for (const item of items) {
+        if (collected >= params.maxResults) return events;
+        const videoId =
+          item.snippet.resourceId.videoId ?? item.contentDetails?.videoId ?? null;
+        if (!videoId) continue;
+
+        events.push({
+          origin_id: `${params.originIdPrefix}_${videoId}`,
+          title: item.snippet.title,
+          payload_text: `${item.snippet.title} — ${item.snippet.channelTitle}`,
+          author_name: item.snippet.channelTitle,
+          source_url: `https://www.youtube.com/watch?v=${videoId}`,
+          occurred_at: new Date(item.snippet.publishedAt),
+          origin_type: params.originType,
+          ...(params.originType === 'playlist_item' && {
+            origin_parent_id: `yt_playlist_${params.playlistId}`,
+          }),
+          metadata: {
+            video_id: videoId,
+            channel_title: item.snippet.channelTitle,
+            playlist_id: params.playlistId,
+            ...(params.originType === 'playlist_item' && {
+              playlist_title: params.playlistTitle,
+            }),
+            ...(item.contentDetails?.videoPublishedAt && {
+              video_published_at: item.contentDetails.videoPublishedAt,
+            }),
+          },
+        });
+        collected += 1;
+      }
+      if (collected >= params.maxResults) break;
+    }
+
+    return events;
+  }
+
+  private buildListCheckpointResult(events: EventEnvelope[]): SyncResult {
+    events.sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime());
+    const latest = events.length > 0 ? events[0].occurred_at.toISOString() : undefined;
+    return {
+      events,
+      checkpoint: {
+        last_published_at: latest,
+      } satisfies YouTubeCheckpoint as Record<string, unknown>,
+      metadata: {
+        items_found: events.length,
+      },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Shared search / action helpers
+  // -------------------------------------------------------------------------
+
+  private parseVideoId(raw: string | undefined): string | null {
+    if (!raw) return null;
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    const urlMatch = trimmed.match(
+      /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([A-Za-z0-9_-]{11})/
+    );
+    if (urlMatch) return urlMatch[1];
+    if (/^[A-Za-z0-9_-]{11}$/.test(trimmed)) return trimmed;
+    return null;
+  }
+
+  private parsePlaylistId(raw: string | undefined): string | null {
+    if (!raw) return null;
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    const urlMatch = trimmed.match(/[?&]list=([A-Za-z0-9_-]+)/);
+    if (urlMatch) return urlMatch[1];
+    if (/^[A-Za-z0-9_-]+$/.test(trimmed)) return trimmed;
+    return null;
+  }
+
+  private playlistToSummary(playlist: YouTubePlaylist): PlaylistSummary {
+    return {
+      playlist_id: playlist.id,
+      title: playlist.snippet.title,
+      description: (playlist.snippet.description ?? '').trim(),
+      item_count: playlist.contentDetails.itemCount,
+      channel_title: playlist.snippet.channelTitle,
+      url: `https://www.youtube.com/playlist?list=${playlist.id}`,
+    };
+  }
+
+  private async videoToSummary(
+    video: YouTubeVideoItem,
+    auth: YouTubeAuth,
+    options: { includeTranscript: boolean; includeComments: boolean }
+  ): Promise<VideoSummary & { comments?: Array<{ text: string; author: string; like_count: number }> }> {
+    let transcript: string | undefined;
+    if (options.includeTranscript) {
+      const text = await this.fetchTranscript(video.id);
+      if (text) transcript = text;
+    }
+    const summary: VideoSummary & {
+      comments?: Array<{ text: string; author: string; like_count: number }>;
+    } = {
+      video_id: video.id,
+      title: video.snippet.title,
+      channel_title: video.snippet.channelTitle,
+      channel_id: video.snippet.channelId,
+      published_at: video.snippet.publishedAt,
+      url: `https://www.youtube.com/watch?v=${video.id}`,
+      view_count: parseInt(video.statistics.viewCount ?? '0', 10),
+      like_count: parseInt(video.statistics.likeCount ?? '0', 10),
+      comment_count: parseInt(video.statistics.commentCount ?? '0', 10),
+      description: (video.snippet.description ?? '').trim() || undefined,
+      ...(video.contentDetails?.duration && { duration: video.contentDetails.duration }),
+      ...(transcript && { transcript }),
+    };
+    if (options.includeComments && summary.comment_count && summary.comment_count > 0) {
+      const threads = await this.fetchComments(auth, video.id);
+      summary.comments = threads.map((c) => ({
+        text: c.snippet.topLevelComment.snippet.textOriginal,
+        author: c.snippet.topLevelComment.snippet.authorDisplayName,
+        like_count: c.snippet.topLevelComment.snippet.likeCount,
+      }));
+    }
+    return summary;
+  }
+
+  private matchesLibraryQuery(
+    title: string,
+    channelTitle: string,
+    query: string | undefined
+  ): boolean {
+    if (!query) return true;
+    const needle = query.toLowerCase();
+    return (
+      title.toLowerCase().includes(needle) || channelTitle.toLowerCase().includes(needle)
+    );
+  }
+
+  private playlistItemToSummary(item: YouTubePlaylistItem): VideoSummary | null {
+    const videoId = item.snippet.resourceId.videoId ?? item.contentDetails?.videoId ?? null;
+    if (!videoId) return null;
+    return {
+      video_id: videoId,
+      title: item.snippet.title,
+      channel_title: item.snippet.channelTitle,
+      published_at: item.snippet.publishedAt,
+      url: `https://www.youtube.com/watch?v=${videoId}`,
+    };
+  }
+
+  private async searchPlaylistItemsByQuery(params: {
+    auth: YouTubeAuth;
+    playlistId: string;
+    query?: string;
+    maxResults: number;
+  }): Promise<VideoSummary[]> {
+    const videos: VideoSummary[] = [];
+    const pages = paginateByCursor<YouTubePlaylistItem, string>(
+      async (cursor) => {
+        const listParams = new URLSearchParams({
+          part: 'snippet,contentDetails',
+          playlistId: params.playlistId,
+          maxResults: '50',
+        });
+        if (cursor) listParams.set('pageToken', cursor);
+        const response = await this.apiGet(
+          `${this.BASE_URL}/playlistItems?${listParams.toString()}`,
+          params.auth
+        );
+        if (!response.ok) {
+          throw new Error(
+            `YouTube PlaylistItems API error (${response.status}): ${await response.text()}`
+          );
+        }
+        const data = (await response.json()) as YouTubePlaylistItemResponse;
+        return { items: data.items ?? [], nextCursor: data.nextPageToken };
+      },
+      { delayMs: this.RATE_LIMIT_MS }
+    );
+    for await (const items of pages) {
+      for (const item of items) {
+        if (videos.length >= params.maxResults) return videos;
+        if (
+          !this.matchesLibraryQuery(
+            item.snippet.title,
+            item.snippet.channelTitle,
+            params.query
+          )
+        ) {
+          continue;
+        }
+        const summary = this.playlistItemToSummary(item);
+        if (summary) videos.push(summary);
+      }
+      if (videos.length >= params.maxResults) break;
+    }
+    return videos;
+  }
+
+  private async searchPublicVideos(
+    auth: YouTubeAuth,
+    query: string,
+    maxResults: number,
+    includeTranscript: boolean
+  ): Promise<VideoSummary[]> {
+    const searchUrl = this.buildSearchUrl(query, Math.min(maxResults, 50));
+    const searchResponse = await this.apiGet(searchUrl, auth);
+    if (!searchResponse.ok) {
+      throw new Error(
+        `YouTube Search API error (${searchResponse.status}): ${await searchResponse.text()}`
+      );
+    }
+    const searchData = (await searchResponse.json()) as YouTubeSearchResponse;
+    const videoIds = (searchData.items ?? [])
+      .map((item) => item.id.videoId)
+      .filter((id): id is string => Boolean(id))
+      .slice(0, maxResults);
+    if (videoIds.length === 0) return [];
+
+    const details = await this.fetchVideoDetails(auth, videoIds);
+    const videos: VideoSummary[] = [];
+    for (const video of details) {
+      videos.push(
+        await this.videoToSummary(video, auth, {
+          includeTranscript,
+          includeComments: false,
+        })
+      );
+      if (includeTranscript) await sleep(this.RATE_LIMIT_MS);
+    }
+    return videos;
+  }
+
   // -------------------------------------------------------------------------
   // YouTube API helpers
   // -------------------------------------------------------------------------
@@ -419,12 +1263,11 @@ export default class YouTubeConnector extends ConnectorRuntime {
   }
 
   private async fetchVideoDetails(
-    auth: { accessToken?: string; apiKey?: string },
+    auth: YouTubeAuth,
     videoIds: string[]
   ): Promise<YouTubeVideoItem[]> {
     const results: YouTubeVideoItem[] = [];
 
-    // Batch in groups of 50 (YouTube API limit)
     for (let i = 0; i < videoIds.length; i += 50) {
       const batch = videoIds.slice(i, i + 50);
       const params = new URLSearchParams({
@@ -449,7 +1292,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
   }
 
   private async fetchComments(
-    auth: { accessToken?: string; apiKey?: string },
+    auth: YouTubeAuth,
     videoId: string
   ): Promise<YouTubeCommentThread[]> {
     const allComments: YouTubeCommentThread[] = [];
@@ -472,7 +1315,6 @@ export default class YouTubeConnector extends ConnectorRuntime {
         );
 
         if (!response.ok) {
-          // Comments may be disabled — not a fatal error
           if (response.status === 403) return { items: [], nextCursor: null };
           throw new Error(
             `YouTube Comments API error (${response.status}): ${await response.text()}`
@@ -498,7 +1340,6 @@ export default class YouTubeConnector extends ConnectorRuntime {
 
   private async fetchTranscript(videoId: string): Promise<string | null> {
     try {
-      // Fetch the YouTube watch page HTML
       const watchUrl = `https://www.youtube.com/watch?v=${videoId}`;
       const response = await fetch(watchUrl, {
         headers: {
@@ -511,18 +1352,14 @@ export default class YouTubeConnector extends ConnectorRuntime {
       if (!response.ok) return null;
 
       const html = await response.text();
-
-      // Extract captionTracks from ytInitialPlayerResponse
       const captionTracks = this.extractCaptionTracks(html);
       if (!captionTracks || captionTracks.length === 0) return null;
 
-      // Prefer English, fall back to first available
       const englishTrack = captionTracks.find(
         (t) => t.languageCode === 'en' || t.languageCode.startsWith('en-')
       );
       const track = englishTrack ?? captionTracks[0];
 
-      // Fetch the timedtext XML
       const captionResponse = await fetch(track.baseUrl);
       if (!captionResponse.ok) return null;
 
@@ -534,7 +1371,6 @@ export default class YouTubeConnector extends ConnectorRuntime {
   }
 
   private extractCaptionTracks(html: string): CaptionTrack[] | null {
-    // Look for ytInitialPlayerResponse in the page
     const playerResponseMatch = html.match(/ytInitialPlayerResponse\s*=\s*(\{.+?\});/s);
     if (!playerResponseMatch) return null;
 
@@ -563,15 +1399,12 @@ export default class YouTubeConnector extends ConnectorRuntime {
   }
 
   private parseTimedTextXml(xml: string): string | null {
-    // Extract text from <text> elements in the timedtext XML
-    // Format: <text start="0.0" dur="2.0">caption text here</text>
     const textSegments: string[] = [];
     const textRegex = /<text[^>]*>([\s\S]*?)<\/text>/g;
     let match: RegExpExecArray | null;
 
     while ((match = textRegex.exec(xml)) !== null) {
       let text = match[1];
-      // Decode HTML entities in a single pass so '&amp;lt;' does not become '<'.
       text = text.replace(
         /&(amp|lt|gt|quot|apos|#39|#(\d+));/g,
         (_match, name, numeric) => {
@@ -592,8 +1425,6 @@ export default class YouTubeConnector extends ConnectorRuntime {
           }
         }
       );
-      // Strip any remaining HTML tags (loop to handle nested/broken markup
-      // like '<<script>script>' that a single pass would leave behind).
       let previous: string;
       do {
         previous = text;
@@ -609,15 +1440,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
     return textSegments.join(' ');
   }
 
-  // -------------------------------------------------------------------------
-  // Utilities
-  // -------------------------------------------------------------------------
-
-  /** Fetch a YouTube API URL with auth (OAuth token or API key). */
-  private async apiGet(
-    url: string,
-    auth: { accessToken?: string; apiKey?: string }
-  ): Promise<Response> {
+  private async apiGet(url: string, auth: YouTubeAuth): Promise<Response> {
     const parsedUrl = new URL(url);
     if (auth.apiKey && !auth.accessToken) {
       parsedUrl.searchParams.set('key', auth.apiKey);

--- a/packages/server/src/__tests__/integration/connectors/gmail-virtual-pushdown.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/gmail-virtual-pushdown.test.ts
@@ -174,21 +174,18 @@ describe('Gmail virtual-feed pushdown', () => {
     expect(cap.listQueries).toEqual(['in:inbox report urgent']);
   });
 
-  it('search() quotes a term containing spaces so it matches literally', async () => {
+  it('search() passes terms as raw Gmail syntax (phrases with spaces AND as tokens)', async () => {
     const cap: Capture = { listQueries: [], listMaxResults: [] };
     const c = connectorWith(cap);
     await c.search({ ...CREDS, query: 'in:inbox', terms: ['weekly report'], config: {}, limit: 5 } as never);
-    expect(cap.listQueries).toEqual(['in:inbox "weekly report"']);
+    expect(cap.listQueries).toEqual(['in:inbox weekly report']);
   });
 
-  it('search() quotes an operator-like term so it is matched literally, not reparsed', async () => {
+  it('search() treats operator syntax in terms as Gmail operators', async () => {
     const cap: Capture = { listQueries: [], listMaxResults: [] };
     const c = connectorWith(cap);
-    // A recall term is keyword text, not Gmail query syntax — `from:alice@x.com`
-    // must be a literal phrase, not activate the `from:` operator (operators
-    // belong in the base config.query, not in recall terms).
     await c.search({ ...CREDS, query: 'in:inbox', terms: ['from:alice@x.com'], config: {}, limit: 5 } as never);
-    expect(cap.listQueries).toEqual(['in:inbox "from:alice@x.com"']);
+    expect(cap.listQueries).toEqual(['in:inbox from:alice@x.com']);
   });
 
   it('clamps the limit and passes it as maxResults', async () => {
@@ -238,9 +235,24 @@ describe('Gmail virtual-feed pushdown', () => {
     await expect(c.query({ query: 'in:inbox', config: {} } as never)).rejects.toThrow(/OAuth credentials/i);
   });
 
-  it('throws when there is no q (empty base and no terms)', async () => {
+  it('lists without q when base and terms are empty (unbounded mailbox)', async () => {
     const cap: Capture = { listQueries: [], listMaxResults: [] };
     const c = connectorWith(cap);
-    await expect(c.query({ ...CREDS, query: '', config: {} } as never)).rejects.toThrow(/no `query`|no search terms/i);
+    const res = await c.query({ ...CREDS, query: '', config: {}, limit: 10 } as never);
+    expect(cap.listQueries).toEqual(['']);
+    expect(res.rows.length).toBeGreaterThan(0);
+  });
+
+  it('AND-composes feed scope (config.query) with agent search() terms', async () => {
+    const cap: Capture = { listQueries: [], listMaxResults: [] };
+    const c = connectorWith(cap);
+    await c.search({
+      ...CREDS,
+      query: 'in:all',
+      terms: ['after:2020/01/01 from:linkedin.com'],
+      config: {},
+      limit: 5,
+    } as never);
+    expect(cap.listQueries).toEqual(['in:all after:2020/01/01 from:linkedin.com']);
   });
 });

--- a/packages/server/src/__tests__/integration/connectors/virtual-feed-create.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/virtual-feed-create.test.ts
@@ -2,7 +2,7 @@
  * manage_feeds create_feed — VIRTUAL feed creation (PR #1702).
  *
  * A virtual feed is read LIVE and never synced, so create_feed must:
- *  - require config.query (the pushdown predicate readVirtualFeed reads);
+ *  - allow optional config.query (empty = unbounded for connectors that support it);
  *  - persist kind='virtual', virtual=true, and schedule/next_run_at = NULL;
  *  - NOT validate the (irrelevant) sync schedule — a bad/absent schedule string
  *    must not gate a virtual feed's creation. This is the ordering fix: schedule
@@ -52,15 +52,18 @@ describe('manage_feeds create_feed (virtual)', () => {
     expect(result.feed?.next_run_at).toBeNull();
   });
 
-  it('rejects a virtual feed with no config.query', async () => {
+  it('allows a virtual feed with no config.query (unbounded live read)', async () => {
     const result = (await owner.feeds.create({
       connection_id: connectionId,
       feed_key: 'issues',
       virtual: true,
-    })) as { error?: string; feed?: unknown };
+      config: { recall: true },
+    })) as { error?: string; feed?: { kind: string; virtual: boolean; config?: { recall?: boolean } } };
 
-    expect(result.error).toMatch(/requires config\.query/i);
-    expect(result.feed).toBeUndefined();
+    expect(result.error).toBeUndefined();
+    expect(result.feed?.kind).toBe('virtual');
+    expect(result.feed?.virtual).toBe(true);
+    expect(result.feed?.config?.recall).toBe(true);
   });
 
   it('does NOT validate the sync schedule for a virtual feed (ordering fix)', async () => {

--- a/packages/server/src/lib/connector-pushdown.ts
+++ b/packages/server/src/lib/connector-pushdown.ts
@@ -206,10 +206,7 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
   }
 
   const feedConfig = (feed.config ?? {}) as Record<string, unknown>;
-  const liveQuery = typeof feedConfig.query === 'string' ? feedConfig.query : null;
-  if (!liveQuery) {
-    throw new Error(`virtual feed '${p.feedId}' has no \`query\` in its config`);
-  }
+  const storedQuery = typeof feedConfig.query === 'string' ? feedConfig.query : '';
 
   // Execution-time cloud gate, identical to the slug pushdown above.
   assertConnectorAllowedInCloud(feed.connector_key);
@@ -250,7 +247,7 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
         ? {
             mode: 'search',
             feedKey: feed.feed_key,
-            query: liveQuery,
+            query: storedQuery,
             terms,
             config,
             env: {},
@@ -263,7 +260,7 @@ export async function readVirtualFeed(p: ReadVirtualFeedParams): Promise<ReadVir
         : {
             mode: 'query',
             feedKey: feed.feed_key,
-            query: liveQuery,
+            query: storedQuery,
             config,
             env: {},
             sessionState,

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -115,7 +115,7 @@ const CreateFeedAction = Type.Object({
   virtual: Type.Optional(
     Type.Boolean({
       description:
-        'When true, create a VIRTUAL feed (kind=virtual): read LIVE via the connector query()/search() pushdown at request time, never synced — sync-lifecycle columns stay NULL. Requires config.query (a connector-specific read predicate, e.g. a Gmail search string) and the connector to implement the pushdown.',
+        'When true, create a VIRTUAL feed (kind=virtual): read LIVE via the connector query()/search() pushdown at request time, never synced — sync-lifecycle columns stay NULL. Optional config.query sets a default scope; agents narrow via query_sql search_term (connector interprets it).',
     })
   ),
 });
@@ -593,8 +593,8 @@ async function handleCreateFeed(
   }
 
   // A virtual feed is read LIVE at request time and never synced, so it has no
-  // schedule. It MUST carry config.query (the pushdown predicate readVirtualFeed
-  // reads) — without it the live read would always throw at request time.
+  // schedule. config.query is an optional scope fence; agents can compose further
+  // filters at read time (query_sql feed_query) or pass recall terms.
   const isVirtual = args.virtual === true;
   // Only validate the sync schedule for non-virtual feeds — a virtual feed
   // persists schedule = NULL, so a (possibly defaulted) schedule string must not
@@ -606,15 +606,7 @@ async function handleCreateFeed(
       return { error: scheduleError };
     }
   }
-  if (isVirtual) {
-    const configQuery = args.config?.query;
-    if (typeof configQuery !== 'string' || !configQuery.trim()) {
-      return {
-        error:
-          'A virtual feed requires config.query (a connector-specific read predicate, e.g. a Gmail search string).',
-      };
-    }
-  }
+
   // Don't schedule a first run for a feed whose connection is still pending auth,
   // or for a virtual feed (never synced — schedule is NULL).
   const nextRunAtVal =

--- a/packages/server/src/tools/admin/query_sql.ts
+++ b/packages/server/src/tools/admin/query_sql.ts
@@ -39,7 +39,7 @@ export const QuerySqlSchema = Type.Object({
   feed: Type.Optional(
     Type.String({
       description:
-        'Optional virtual-feed reference (numeric feed id, or "connection_slug/feed_key"). When set, the feed’s STORED query runs LIVE against its source (no `sql` needed — it is ignored); `search_term` narrows via the connector’s search(). Mutually exclusive with `connection`.',
+        'Optional virtual-feed reference (numeric feed id, or "connection_slug/feed_key"). When set, the feed’s STORED config.query runs LIVE against its source (no `sql` needed — it is ignored). `search_term` is forwarded to the connector search() pushdown (each connector interprets it — e.g. Gmail query syntax AND-composed with config.query). Mutually exclusive with `connection`.',
     })
   ),
   org_slug: Type.Optional(
@@ -68,7 +68,10 @@ export const QuerySqlSchema = Type.Object({
     })
   ),
   search_term: Type.Optional(
-    Type.String({ description: 'ILIKE search value (wrapped in %...% automatically).' })
+    Type.String({
+      description:
+        'Internal SQL: ILIKE search value. Virtual feeds: forwarded to connector search() — interpretation is connector-specific (Gmail: search syntax merged with config.query).',
+    })
   ),
   search_columns: Type.Optional(
     Type.Array(Type.String(), {


### PR DESCRIPTION
## Summary

- **Gmail virtual feeds:** `config.query` optional (empty = unbounded mailbox); `search_term` forwarded as raw Gmail `q` syntax
- **Server:** `readVirtualFeed` / `manage_feeds` allow virtual feeds without stored query
- **YouTube 1.2.0:** `liked_videos` + `playlists` sync feeds; on-demand actions (`search`, `get_video`, `search_liked_videos`, `list_playlists`, `get_playlist`)
- **personal-agent example:** `one-off-context-sources.md` (new) with YouTube/LinkedIn download + ingest guide; org slug cleanup

## Post-deploy

- Update buremba Gmail virtual feed 381 if unbounded recall is desired
- Connect YouTube in dashboard for OAuth feeds/actions

## Test plan

- [x] Gmail virtual pushdown unit tests
- [x] YouTube connector unit tests (feeds + actions)
- [ ] `virtual-feed-create` integration (CI / DATABASE_URL)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785892629&installation_id=136316292&pr_number=1753&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1753&signature=1260f0f6f0fc839346b58bbd9a194b0327ec962f5a672be338f81ac0f2742afb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->