### PR TITLE
fix(watchers): idempotent schedule advance, save_memory occurred_at default, provenance-key metadata round-trip

### DIFF
--- a/packages/server/src/__tests__/integration/entity-schema/metadata-provenance-keys.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/metadata-provenance-keys.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Watcher-promotion provenance keys must survive metadata round-trips.
+ *
+ * `promote-keyed-entities.ts` stamps `watcher_id` / `stable_key` / `window_id`
+ * (plus `source`) onto a promoted entity's metadata via raw SQL — outside
+ * schema validation. Under an `additionalProperties: false` entity-type schema
+ * that meant a promoted entity's metadata could never be written back through
+ * `entities.update`: reading the metadata, editing one domain field, and
+ * saving rejected with "unknown property 'window_id'". Validation now exempts
+ * exactly those platform keys; everything else stays schema-enforced.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import { TestApiClient } from '../../setup/test-mcp-client';
+
+describe('entity metadata validation > watcher provenance keys', () => {
+  let owner: TestApiClient;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const org = await createTestOrganization({ name: 'Provenance Keys Org' });
+    const user = await createTestUser({ email: 'provenance-keys@test.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    owner = await TestApiClient.for({
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+    });
+
+    await owner.entity_schema.createType({
+      slug: 'strict-task',
+      name: 'Strict Task',
+      metadata_schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          action: { type: 'string' },
+          status: { type: 'string', enum: ['backlog', 'active', 'done'] },
+          source: { type: 'string' },
+        },
+      },
+    } as never);
+  });
+
+  it('accepts watcher_id/stable_key/window_id on update under additionalProperties: false', async () => {
+    const created = (await owner.entities.create({
+      type: 'strict-task',
+      name: 'Promoted task round-trip',
+      metadata: { action: 'Ship the fix', status: 'backlog' },
+    })) as { entity: { id: number } };
+
+    // The exact write a client makes after reading a promoted entity's
+    // metadata (provenance keys included) and editing one domain field.
+    await owner.entities.update({
+      entity_id: created.entity.id,
+      metadata: {
+        action: 'Ship the fix',
+        status: 'done',
+        source: 'watcher_promotion',
+        watcher_id: 5,
+        stable_key: 'ship-the-fix',
+        window_id: 4288453,
+      },
+    });
+
+    const got = (await owner.entities.get(created.entity.id)) as {
+      entity?: { metadata?: Record<string, unknown> };
+    };
+    expect(got.entity?.metadata?.status).toBe('done');
+    expect(got.entity?.metadata?.window_id).toBe(4288453);
+  });
+
+  it('still rejects genuinely unknown metadata keys', async () => {
+    const created = (await owner.entities.create({
+      type: 'strict-task',
+      name: 'Strictness control',
+      metadata: { action: 'Stay strict', status: 'backlog' },
+    })) as { entity: { id: number } };
+
+    const err = await owner.entities
+      .update({
+        entity_id: created.entity.id,
+        metadata: { action: 'Stay strict', bogus_field: true },
+      })
+      .then(() => null)
+      .catch((e: unknown) => e as Error);
+    expect(err).not.toBeNull();
+    expect(err?.message).toContain("unknown property 'bogus_field'");
+  });
+});

--- a/packages/server/src/__tests__/integration/events/save-content-occurred-at.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-occurred-at.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Integration test: save_content (save_memory / client.knowledge.save) stamps
+ * `occurred_at` when the caller omits it.
+ *
+ * The tool schema has always promised "Defaults to now if omitted", but the
+ * implementation passed NULL through to insertEvent. A NULL occurred_at makes
+ * the event invisible to every watcher window (window content is an events CTE
+ * filtered on occurred_at within [window_start, window_end)), so agent-saved
+ * knowledge silently never reached watchers.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { ToolContext } from '../../../tools/registry';
+import { saveContent } from '../../../tools/save_content';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestEntity,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+describe('saveContent > occurred_at default', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let entityId: number;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Occurred At Org' });
+    user = await createTestUser({ email: 'occurred-at@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const entity = await createTestEntity({
+      name: 'Occurred At Entity',
+      organization_id: org.id,
+    });
+    entityId = entity.id;
+  });
+
+  function ctx(): ToolContext {
+    return {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:write'],
+      sourceContext: null,
+    } as ToolContext;
+  }
+
+  it('defaults occurred_at to now when omitted', async () => {
+    const before = Date.now();
+    const result = (await saveContent(
+      {
+        entity_ids: [entityId],
+        content: 'A note saved without an explicit occurred_at.',
+        semantic_type: 'note',
+        metadata: {},
+      } as never,
+      {} as never,
+      ctx()
+    )) as { id: number };
+
+    const sql = getTestDb();
+    const [row] = await sql`
+      SELECT occurred_at FROM events WHERE id = ${result.id}
+    `;
+    expect(row.occurred_at).not.toBeNull();
+    const occurredMs = new Date(row.occurred_at as string).getTime();
+    expect(occurredMs).toBeGreaterThanOrEqual(before - 1000);
+    expect(occurredMs).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+
+  it('preserves an explicit occurred_at', async () => {
+    const explicit = '2026-01-02T03:04:05.000Z';
+    const result = (await saveContent(
+      {
+        entity_ids: [entityId],
+        content: 'A note with an explicit occurred_at.',
+        semantic_type: 'note',
+        occurred_at: explicit,
+        metadata: {},
+      } as never,
+      {} as never,
+      ctx()
+    )) as { id: number };
+
+    const sql = getTestDb();
+    const [row] = await sql`
+      SELECT occurred_at FROM events WHERE id = ${result.id}
+    `;
+    expect(new Date(row.occurred_at as string).toISOString()).toBe(explicit);
+  });
+});

--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -19,7 +19,9 @@ import type { Env } from "../../../index";
 import { createWatcherRun } from "../../../runs/queue-service";
 import { generateWindowToken } from "../../../utils/jwt";
 import { computePendingWindow } from "../../../utils/window-utils";
+import { nextRunAt } from "../../../utils/cron";
 import {
+	advanceWatcherSchedule,
 	dispatchPendingWatcherRuns,
 	materializeDueWatcherRuns,
 	reconcileWatcherRuns,
@@ -1988,6 +1990,32 @@ describe("canvas-on-events window completion", () => {
 		expect(current).toHaveLength(1);
 		expect((current[0].payload_data as Record<string, unknown>).summary).toBe(
 			"v2",
+		);
+	});
+
+	// Manual triggers complete through the same advanceWatcherSchedule as
+	// scheduled runs, but with next_run_at already sitting on the upcoming cron
+	// tick. Advancing from max(now, next_run_at) compounded that: every manual
+	// run's completion pushed the schedule one more tick out, so N manual runs
+	// silently skipped N cron slots. The advance must converge on the next tick
+	// after now, no matter how many completions land while the schedule is
+	// already current.
+	it("advanceWatcherSchedule is idempotent when next_run_at is already the upcoming tick", async () => {
+		const { sql, dbClient, watcherId } = await createAutomatedWatcher();
+
+		const upcomingTick = nextRunAt("0 9 * * *", new Date());
+		await sql`
+      UPDATE watchers SET next_run_at = ${upcomingTick}::timestamptz
+      WHERE id = ${watcherId}
+    `;
+
+		await advanceWatcherSchedule(dbClient, watcherId);
+		await advanceWatcherSchedule(dbClient, watcherId);
+
+		const [after] =
+			await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
+		expect(new Date(after.next_run_at as string).getTime()).toBe(
+			new Date(upcomingTick).getTime(),
 		);
 	});
 });

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -343,7 +343,10 @@ async function saveContentImpl(
       attachments: args.attachments,
       authorName: args.author,
       sourceUrl: args.source_url ?? null,
-      occurredAt: args.occurred_at ?? null,
+      // The schema promises "Defaults to now if omitted" — honor it. A NULL
+      // occurred_at makes the event invisible to watcher windows (window
+      // content filters on occurred_at within [window_start, window_end)).
+      occurredAt: args.occurred_at ?? new Date().toISOString(),
       semanticType,
       metadata: args.metadata,
       createdBy: ctx.userId,

--- a/packages/server/src/utils/schema-validation.ts
+++ b/packages/server/src/utils/schema-validation.ts
@@ -60,6 +60,25 @@ async function getEntityTypeSchema(
 // ============================================
 
 /**
+ * Metadata keys stamped by watcher promotion (`promote-keyed-entities.ts`):
+ * platform provenance, not part of any entity-type schema. Excluded from
+ * validation so a promoted entity's metadata round-trips — read it, edit a
+ * domain field, write it back — under an `additionalProperties: false`
+ * schema. `source` is deliberately NOT here: it is a plausible domain field,
+ * so it stays subject to the type's schema.
+ */
+const WATCHER_PROVENANCE_KEYS = ['watcher_id', 'stable_key', 'window_id'];
+
+function withoutWatcherProvenanceKeys(
+  metadata: Record<string, unknown>
+): Record<string, unknown> {
+  if (!WATCHER_PROVENANCE_KEYS.some((key) => key in metadata)) return metadata;
+  return Object.fromEntries(
+    Object.entries(metadata).filter(([key]) => !WATCHER_PROVENANCE_KEYS.includes(key))
+  );
+}
+
+/**
  * Validate entity metadata against the entity type's JSON schema.
  *
  * Returns { valid: true } if:
@@ -101,10 +120,22 @@ export async function validateEntityMetadata(
     return { valid: true };
   }
 
-  // Validate metadata against schema
+  // Validate metadata against schema, ignoring platform provenance keys —
+  // they are stamped by watcher promotion outside this validator and would
+  // otherwise fail every round-trip under additionalProperties: false.
   const ajv = getAjv();
   const validate = ajv.compile(schema);
-  const isValid = validate(metadata);
+  const candidate = withoutWatcherProvenanceKeys(metadata);
+  const isValid = validate(candidate);
+  if (candidate !== metadata) {
+    // The AJV singleton runs with coerceTypes, mutating the validated object
+    // in place — callers persist those coercions. When we validated a stripped
+    // copy, propagate its top-level coercions back (nested objects are shared
+    // by reference, so deeper coercions already landed).
+    for (const [key, value] of Object.entries(candidate)) {
+      metadata[key] = value;
+    }
+  }
 
   if (isValid) {
     return { valid: true };

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -260,10 +260,17 @@ async function markWatcherRunFailedIdempotent(
 }
 
 /**
- * Move a watcher's `next_run_at` forward by one cron tick. Reused by:
+ * Move a watcher's `next_run_at` forward to the next cron tick after now.
+ * Reused by:
  *   - terminal-failure paths in this module (broken watcher shouldn't re-fire each minute)
  *   - client.watchers.completeWindow on successful completion
  *   - the device-side `/api/workers/me/runs/:id/complete-watcher` endpoint
+ *
+ * Idempotent: the target is always `nextRunAt(schedule, now)`, so duplicate
+ * completions and manually-triggered runs converge to the same upcoming tick.
+ * (Basing it on `max(now, next_run_at)` instead compounded the schedule: each
+ * manual trigger's completion pushed an already-future `next_run_at` one more
+ * tick out, so N manual runs silently skipped N cron slots.)
  *
  * Pass either the singleton `sql` client or a transaction handle from
  * `sql.begin(...)` to advance inside the caller's transaction. Schedule-less
@@ -277,20 +284,16 @@ export async function advanceWatcherSchedule(
 	if (watcherId === undefined || watcherId === null) return;
 	try {
 		const rows = await sql`
-      SELECT schedule, next_run_at
+      SELECT schedule
       FROM watchers
       WHERE id = ${watcherId}
       LIMIT 1
     `;
 		const schedule = (rows[0]?.schedule as string | null) ?? null;
 		if (!schedule) return;
-		const currentNextRunAt = (rows[0]?.next_run_at as string | null) ?? null;
-		const base = currentNextRunAt
-			? new Date(Math.max(Date.now(), new Date(currentNextRunAt).getTime()))
-			: new Date();
 		await sql`
       UPDATE watchers
-      SET next_run_at = ${nextRunAt(schedule, base)}::timestamptz,
+      SET next_run_at = ${nextRunAt(schedule, new Date())}::timestamptz,
           updated_at = NOW()
       WHERE id = ${watcherId}
     `;


### PR DESCRIPTION
Three watcher-platform bugs found while auditing the buremba org's Hourly Task Collaborator (watcher 5).

## 1. Manual triggers compounded `next_run_at`
`advanceWatcherSchedule` based the next slot on `max(now, next_run_at)`. When a manually-triggered run completed, `next_run_at` was already in the future, so each completion pushed it one more cron tick out — N manual runs silently skipped N scheduled slots (observed live: 4 triggers pushed an hourly watcher from 04:00Z to 08:00Z). The advance now targets `nextRunAt(schedule, now)`, which is idempotent: manual triggers, duplicate completions, and retries all converge on the same upcoming tick, and already-drifted watchers self-heal on their next completion.

## 2. `save_memory` left `occurred_at` NULL
The tool schema has always documented "Defaults to now if omitted", but the implementation passed NULL through to `insertEvent`. Watcher window content is filtered on `occurred_at` within the window, so agent-saved knowledge was invisible to every watcher. The default now matches the documented contract (applied at the tool layer; `insertEvent` is untouched for connector callers).

## 3. Promoted entities' metadata couldn't round-trip
Watcher promotion stamps `watcher_id` / `stable_key` / `window_id` onto entity metadata via raw SQL, outside schema validation. Under an `additionalProperties: false` entity-type schema, any subsequent `entities.update` that wrote the metadata back failed with `unknown property 'watcher_id'`. Validation now exempts exactly those platform provenance keys (`source` intentionally stays schema-enforced — it's a plausible domain field). Top-level AJV type coercions are propagated back so `coerceTypes` behavior is unchanged.

## Red → green
Reproducers, each verified failing against `origin/main` source and passing with the fix:
- `automation-contract.test.ts` — "advanceWatcherSchedule is idempotent when next_run_at is already the upcoming tick": red lands exactly two daily ticks ahead (`expected 1783497600000 to be 1783324800000`).
- `save-content-occurred-at.test.ts` — red: `occurred_at` NULL; also pins that an explicit `occurred_at` is preserved.
- `metadata-provenance-keys.test.ts` — red: `Metadata validation failed: root: unknown property 'watcher_id'`; control test pins that genuinely unknown keys are still rejected.

## Review gate
`make review`: typecheck ✅, vitest integration 1874/1874 ✅. The bun gateway-suite failures (SlackConnectionCoordinator, app-installation star delivery, agent-history routes) reproduce identically with this diff reverted to origin/main — pre-existing/env, zero delta from this change. The unit-suite failure was a stale `connector-sdk/dist` (green after rebuild).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785901959&installation_id=136316292&pr_number=1757&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1757&signature=9ccab37ae999d9985a760153ca2f17ec69958c4235089e097eca8f971dae7be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event timestamps now default to the current time when omitted, instead of being left blank.
  * Watcher scheduling is now more consistent and idempotent, helping prevent duplicate or unexpected next-run updates.
  * Metadata updates now accept watcher-related provenance fields while still rejecting truly unknown fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->