### PR TITLE
fix(agent): validate model provider routing

### DIFF
--- a/packages/agent-worker/src/__tests__/error-handler.test.ts
+++ b/packages/agent-worker/src/__tests__/error-handler.test.ts
@@ -93,6 +93,23 @@ describe("handleExecutionError", () => {
     expect(errors).toHaveLength(1);
     expect(errors[0].code).toBe("PROVIDER_UNKNOWN_MODEL");
   });
+
+  test("provider routing failures are explanatory, not crash-branded", async () => {
+    const { transport, deltas, errors } = makeTransport();
+
+    await handleExecutionError(
+      new Error(
+        'The selected model (z-ai/glm-5.2) uses provider "z-ai", but that provider is not connected to this agent.'
+      ),
+      transport
+    );
+
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0].delta).toContain("⚠️ The selected model");
+    expect(deltas[0].delta).not.toContain("Worker crashed");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe("PROVIDER_BASE_URL_UNRESOLVED");
+  });
 });
 
 describe("classifyError", () => {
@@ -138,6 +155,13 @@ describe("classifyError", () => {
     expect(
       classifyError(
         new Error('Could not resolve a base URL for provider "z-ai".')
+      )
+    ).toBe("PROVIDER_BASE_URL_UNRESOLVED");
+    expect(
+      classifyError(
+        new Error(
+          'The selected model (z-ai/glm-5.2) uses provider "z-ai", but that provider is not connected to this agent.'
+        )
       )
     ).toBe("PROVIDER_BASE_URL_UNRESOLVED");
   });

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -364,7 +364,7 @@ describe("buildDynamicOpenAIModel — never silently route to OpenAI", () => {
         modelId: "gemini-2.5-flash",
         providerBaseUrl: undefined,
       })
-    ).toThrow(/Could not resolve a base URL for provider "gemini"/);
+    ).toThrow(/gateway routing URL.*GEMINI_API_BASE_URL/);
   });
 
   test("THROWS for nvidia/together/etc with no base URL (generic, all providers)", () => {
@@ -376,7 +376,7 @@ describe("buildDynamicOpenAIModel — never silently route to OpenAI", () => {
           modelId: "some-model",
           providerBaseUrl: undefined,
         })
-      ).toThrow(/Refusing to route .* to a public endpoint/);
+      ).toThrow(/Connect the provider in the agent's Providers settings/);
     }
   });
 

--- a/packages/agent-worker/src/core/error-handler.ts
+++ b/packages/agent-worker/src/core/error-handler.ts
@@ -14,9 +14,12 @@ interface ExecutionErrorContext {
   runId?: number | string;
 }
 
-function formatErrorMessage(error: unknown): string {
+function formatErrorMessage(error: unknown, code?: string): string {
   if (!(error instanceof Error)) {
     return `💥 Worker crashed: Unknown error`;
+  }
+  if (code === "PROVIDER_BASE_URL_UNRESOLVED") {
+    return `⚠️ ${error.message}`;
   }
   const name = error.constructor.name;
   const isGeneric = name === "Error" || name === "WorkspaceError";
@@ -75,9 +78,14 @@ export function classifyError(error: unknown): string | undefined {
   // upstream surface "<x> is not a valid model"/"unknown model"/"model ... not found".
   if (/not a valid model|unknown model|model .* not found/i.test(message))
     return "PROVIDER_UNKNOWN_MODEL";
-  // model-resolver.ts buildDynamicOpenAIModel throws this when the gateway
-  // failed to supply a proxy base URL for a non-OpenAI provider.
-  if (/Could not resolve a base URL for provider/i.test(message))
+  // model-resolver.ts / session-runner.ts throw this when a non-OpenAI
+  // provider cannot be routed through the Lobu gateway proxy. This is usually a
+  // provider/model configuration issue, not an agent crash.
+  if (
+    /Could not resolve a base URL for provider/i.test(message) ||
+    /provider is not connected to this agent/i.test(message) ||
+    /did not receive the gateway routing URL/i.test(message)
+  )
     return "PROVIDER_BASE_URL_UNRESOLVED";
   return undefined;
 }
@@ -118,7 +126,11 @@ export async function handleExecutionError(
     } else {
       // Unclassified crashes AND PROVIDER_* failures still show the user a
       // crash message; the classification rides along on signalError.
-      await transport.sendStreamDelta(formatErrorMessage(error), true, true);
+      await transport.sendStreamDelta(
+        formatErrorMessage(error, code),
+        true,
+        true
+      );
       await transport.signalError(errorInstance, code);
     }
   } catch (gatewayError) {

--- a/packages/agent-worker/src/openclaw/model-resolver.ts
+++ b/packages/agent-worker/src/openclaw/model-resolver.ts
@@ -180,10 +180,11 @@ export function buildDynamicOpenAIModel(args: {
   const isRealOpenAI = rawProvider === "openai";
   if (!isRealOpenAI && !providerBaseUrl) {
     throw new Error(
-      `Could not resolve a base URL for provider "${rawProvider}". ` +
-        `The gateway did not supply a proxy mapping for its base-URL env ` +
-        `var (${DEFAULT_PROVIDER_BASE_URL_ENV[rawProvider] ?? "unknown"}). ` +
-        `Refusing to route "${modelId}" to a public endpoint.`
+      `The selected model (${rawProvider}/${modelId}) uses provider "${rawProvider}", ` +
+        `but Lobu did not receive the gateway routing URL it needs ` +
+        `(${DEFAULT_PROVIDER_BASE_URL_ENV[rawProvider] ?? "unknown"}). ` +
+        `Connect the provider in the agent's Providers settings, choose a model ` +
+        `from a connected provider, or restart/redeploy the gateway if the provider is already connected.`
     );
   }
   return {

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -605,6 +605,44 @@ export async function runAISession(
     }
   }
 
+  // Fail before pi-ai/model construction with an operator-facing explanation.
+  // A non-OpenAI provider must route through the Lobu gateway proxy; otherwise
+  // the SDK would hit a public endpoint with a tenant/org model id and return a
+  // confusing low-level error. The common real-world cause is a model selected
+  // from a provider that is not installed/connected on the agent.
+  if (!providerBaseUrl && rawProvider !== "openai") {
+    const baseUrlEnvVar = DEFAULT_PROVIDER_BASE_URL_ENV[rawProvider];
+    if (baseUrlEnvVar) {
+      const installedRoutes = pc.installedProviderRoutes ?? {};
+      const installedProviderIds = Object.keys(installedRoutes);
+      const providerIsInstalled =
+        installedRoutes[rawProvider] != null ||
+        Object.values(installedRoutes).includes(rawProvider);
+      const selectedModel = `${rawProvider}/${modelId}`;
+      const dispatcherUrl = process.env.DISPATCHER_URL?.replace(/\/$/, "");
+      const encodedAgentId = encodeURIComponent(agentId || "unknown-agent");
+      const expectedProxyUrl = dispatcherUrl
+        ? `${dispatcherUrl}/api/proxy/${rawProvider}/a/${encodedAgentId}`
+        : `/api/proxy/${rawProvider}/a/${encodedAgentId}`;
+
+      if (installedProviderIds.length === 0 || !providerIsInstalled) {
+        throw new Error(
+          `The selected model (${selectedModel}) uses provider "${rawProvider}", ` +
+            `but that provider is not connected to this agent. Connect "${rawProvider}" ` +
+            `in the agent's Providers settings, or choose a model from a connected provider, then try again. ` +
+            `Expected gateway proxy URL after setup: ${expectedProxyUrl}`
+        );
+      }
+
+      throw new Error(
+        `The selected model (${selectedModel}) uses provider "${rawProvider}", ` +
+          `but Lobu did not receive the gateway routing URL it needs (${baseUrlEnvVar}). ` +
+          `Expected gateway proxy URL: ${expectedProxyUrl}. ` +
+          `Restart the agent worker or redeploy the gateway; if this keeps happening, contact support.`
+      );
+    }
+  }
+
   let baseModel: Model<any> | undefined = getModelDynamic(provider, modelId);
   if (!baseModel) {
     // The model isn't in pi-ai's static registry — build a dynamic entry. Which

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -14,7 +14,10 @@ import {
 	CLAUDE_PROVIDER,
 	type OAuthProviderConfig,
 } from "../gateway/auth/oauth/providers";
-import { buildProviderCatalog } from "../gateway/auth/provider-catalog";
+import {
+	buildProviderCatalog,
+	type ProviderCatalogService,
+} from "../gateway/auth/provider-catalog";
 import { createAuthProfileLabel } from "../gateway/auth/settings/auth-profiles-manager";
 import {
 	ProviderRegistryService,
@@ -69,6 +72,108 @@ function toStringArray(value: unknown): string[] {
 }
 
 const configStore = createPostgresAgentConfigStore();
+
+function buildRequestBaseUrls(c: any, agentId: string, providerId: string) {
+	const url = new URL(c.req.url);
+	const apiIndex = url.pathname.indexOf("/api/");
+	const mountPath = apiIndex >= 0 ? url.pathname.slice(0, apiIndex) : "";
+	const origin = url.origin;
+	const orgSlug = c.req.param("orgSlug") as string | undefined;
+	const encodedAgent = encodeURIComponent(agentId);
+	return {
+		proxyBaseUrl: `${origin}${mountPath}/api/proxy`,
+		expectedProxyUrl: `${origin}${mountPath}/api/proxy/${providerId}/a/${encodedAgent}`,
+		settingsUrl: orgSlug
+			? `${origin}${mountPath}/${encodeURIComponent(orgSlug)}/agents/${encodedAgent}/settings`
+			: `${origin}${mountPath}/agents/${encodedAgent}/settings`,
+	};
+}
+
+function parseProviderFromModelRef(modelRef: string): string | null {
+	const trimmed = modelRef.trim();
+	if (!trimmed || trimmed === "auto") return null;
+	const slash = trimmed.indexOf("/");
+	if (slash <= 0) return null;
+	return trimmed.slice(0, slash);
+}
+
+async function validateModelProviderRoutable(params: {
+	catalog: ProviderCatalogService;
+	agentId: string;
+	modelRef: string;
+	organizationId: string;
+	userId?: string;
+	c: any;
+}): Promise<Record<string, unknown> | null> {
+	const providerId = parseProviderFromModelRef(params.modelRef);
+	if (!providerId) return null;
+
+	const providers = await params.catalog.getInstalledModules(
+		params.agentId,
+		params.organizationId,
+	);
+	const provider = await params.catalog.findProviderForModel(
+		params.modelRef,
+		providers,
+	);
+	const urls = buildRequestBaseUrls(params.c, params.agentId, providerId);
+
+	if (!provider) {
+		return {
+			error: "model_provider_not_connected",
+			error_description:
+				`The selected model (${params.modelRef}) uses provider "${providerId}", but that provider is not connected to this agent. ` +
+				`Open ${urls.settingsUrl}, connect "${providerId}" in Providers, then save again. ` +
+				`Expected gateway proxy URL after setup: ${urls.expectedProxyUrl}`,
+			model: params.modelRef,
+			provider: providerId,
+			settingsUrl: urls.settingsUrl,
+			expectedProxyUrl: urls.expectedProxyUrl,
+		};
+	}
+
+	const hasCredentials =
+		provider.hasSystemKey() ||
+		(await provider.hasCredentials(params.agentId, {
+			organizationId: params.organizationId,
+			userId: params.userId,
+		}));
+	if (!hasCredentials) {
+		return {
+			error: "model_provider_credentials_missing",
+			error_description:
+				`The selected model (${params.modelRef}) uses provider "${provider.providerId}", but Lobu has no credentials for that provider. ` +
+				`Open ${urls.settingsUrl}, connect or add credentials for "${provider.providerId}", then save again. ` +
+				`Expected gateway proxy URL after setup: ${urls.expectedProxyUrl}`,
+			model: params.modelRef,
+			provider: provider.providerId,
+			settingsUrl: urls.settingsUrl,
+			expectedProxyUrl: urls.expectedProxyUrl,
+		};
+	}
+
+	const mappings = provider.getProxyBaseUrlMappings(
+		urls.proxyBaseUrl,
+		params.agentId,
+		{ organizationId: params.organizationId, userId: params.userId },
+	);
+	const expectedProxyUrl = Object.values(mappings)[0] || urls.expectedProxyUrl;
+	if (Object.keys(mappings).length === 0) {
+		return {
+			error: "model_provider_route_missing",
+			error_description:
+				`The selected model (${params.modelRef}) uses provider "${provider.providerId}", but Lobu could not build a gateway route for it. ` +
+				`Open ${urls.settingsUrl} and reconnect the provider, or restart/redeploy the gateway. ` +
+				`Expected gateway proxy URL: ${expectedProxyUrl}`,
+			model: params.modelRef,
+			provider: provider.providerId,
+			settingsUrl: urls.settingsUrl,
+			expectedProxyUrl,
+		};
+	}
+
+	return null;
+}
 
 // ── Route-level middleware ───────────────────────────────────────────────────
 //
@@ -1397,6 +1502,7 @@ routes.patch("/:agentId/config", async (c) => {
   const { authProfiles, ...settingsUpdates } = updates as {
     authProfiles?: AuthProfile[];
   } & Record<string, unknown>;
+
   if (Array.isArray(authProfiles)) {
 		const user = c.get("user");
     if (!user?.id) {
@@ -1424,6 +1530,32 @@ routes.patch("/:agentId/config", async (c) => {
       }
     }
   }
+
+	if (typeof settingsUpdates.defaultModel === "string") {
+		const modelRef = settingsUpdates.defaultModel.trim();
+		if (modelRef) {
+			try {
+				const catalog = getLobuCoreServices()?.getProviderCatalogService?.();
+				const organizationId = c.get("organizationId") as string | undefined;
+				if (catalog && organizationId) {
+					const error = await validateModelProviderRoutable({
+						catalog,
+						agentId,
+						modelRef,
+						organizationId,
+						userId: c.get("user")?.id,
+						c,
+					});
+					if (error) return c.json(error, 400);
+				}
+			} catch (error) {
+				logger.warn(
+					{ agentId, modelRef, error },
+					"Failed to validate model/provider routability before saving agent settings",
+				);
+			}
+		}
+	}
 
   await configStore.updateSettings(agentId, settingsUpdates);
 	// Snapshot the merged settings row as stored (the store merges partial


### PR DESCRIPTION
## Summary
- validate agent default model provider routing on settings save and return actionable 400s with settings/proxy URLs
- make worker-side provider routing failures user-friendly and include expected proxy URLs
- avoid branding provider routing/configuration failures as worker crashes

## Validation
- bun test packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts packages/agent-worker/src/__tests__/model-resolver.test.ts packages/agent-worker/src/__tests__/error-handler.test.ts
- bunx biome check --config-path config/biome.config.json packages/server/src/lobu/agent-routes.ts packages/agent-worker/src/openclaw/session-runner.ts packages/agent-worker/src/openclaw/model-resolver.ts packages/agent-worker/src/core/error-handler.ts packages/agent-worker/src/__tests__/model-resolver.test.ts packages/agent-worker/src/__tests__/error-handler.test.ts
- make build-packages

## E2E
- Started local dev server on http://127.0.0.1:8788/lobu
- Attempted ./scripts/test-bot.sh against local gateway; blocked by QA Slack token invalid_auth, so no end-to-end chat assertion was possible from this environment.

## Notes
- make review was attempted but repo-wide unit phase hung after existing connector-sdk dist export failures (validateEntityMetrics); targeted tests and build passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785935989&installation_id=136316292&pr_number=1760&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1760&signature=de421aca01f2c2383427bd573c48b2147cbb8cfdad2c34f3316dab1834bf66d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer validation when choosing a model for an agent, so incompatible or unconnected providers are flagged before saving.
  * Improved error messages to include actionable next steps and the expected gateway routing details.

* **Bug Fixes**
  * Provider routing issues now show a warning-style message instead of appearing as a crash.
  * Expanded detection of routing and base URL problems so the app reports these issues more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->