### PR TITLE
fix(connections): reject unroutable model before enqueue

### DIFF
--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -52,6 +52,92 @@ function sanitizeRefLabel(name: string): string {
   return name.replace(/[[\]()\r\n]+/g, " ").replace(/\s+/g, " ").trim() || "file";
 }
 
+function parseProviderFromModelRef(modelRef: string): string | null {
+  const trimmed = modelRef.trim();
+  if (!trimmed || trimmed === "auto") return null;
+  const slash = trimmed.indexOf("/");
+  if (slash <= 0) return null;
+  return trimmed.slice(0, slash);
+}
+
+function expectedProxyUrlFor(params: {
+  publicGatewayUrl: string;
+  providerId: string;
+  agentId: string;
+}): string {
+  const base = params.publicGatewayUrl.replace(/\/$/, "");
+  const origin = base.endsWith("/lobu") ? base.slice(0, -"/lobu".length) : base;
+  return `${origin}/api/proxy/${params.providerId}/a/${encodeURIComponent(params.agentId)}`;
+}
+
+async function validateMessageModelProvider(params: {
+  services: CoreServices;
+  agentId: string;
+  organizationId?: string;
+  userId: string;
+  modelRef?: unknown;
+}): Promise<string | null> {
+  if (typeof params.modelRef !== "string") return null;
+  const modelRef = params.modelRef.trim();
+  const providerId = parseProviderFromModelRef(modelRef);
+  if (!providerId) return null;
+
+  const catalog = params.services.getProviderCatalogService?.();
+  if (!catalog || !params.organizationId) return null;
+
+  const providers = await catalog.getInstalledModules(
+    params.agentId,
+    params.organizationId
+  );
+  const provider = await catalog.findProviderForModel(modelRef, providers);
+  const expectedProxyUrl = expectedProxyUrlFor({
+    publicGatewayUrl: params.services.getPublicGatewayUrl(),
+    providerId,
+    agentId: params.agentId,
+  });
+
+  if (!provider) {
+    return (
+      `I can't run this yet: the selected model (${modelRef}) uses provider "${providerId}", ` +
+      `but that provider is not connected to this agent. Ask an admin to open this agent's Settings → Providers, ` +
+      `connect "${providerId}", and try again. Expected gateway proxy URL after setup: ${expectedProxyUrl}`
+    );
+  }
+
+  const hasCredentials =
+    provider.hasSystemKey() ||
+    (await provider.hasCredentials(params.agentId, {
+      organizationId: params.organizationId,
+      userId: params.userId,
+    }));
+  if (!hasCredentials) {
+    return (
+      `I can't run this yet: the selected model (${modelRef}) uses provider "${provider.providerId}", ` +
+      `but Lobu has no credentials for that provider. Ask an admin to connect or add credentials for ` +
+      `"${provider.providerId}" in this agent's Settings → Providers, then try again. ` +
+      `Expected gateway proxy URL after setup: ${expectedProxyUrl}`
+    );
+  }
+
+  const proxyBaseUrl = expectedProxyUrl.replace(
+    new RegExp(`/${providerId}/a/${encodeURIComponent(params.agentId)}$`),
+    ""
+  );
+  const mappings = provider.getProxyBaseUrlMappings(proxyBaseUrl, params.agentId, {
+    organizationId: params.organizationId,
+    userId: params.userId,
+  });
+  if (Object.keys(mappings).length === 0) {
+    return (
+      `I can't run this yet: the selected model (${modelRef}) uses provider "${provider.providerId}", ` +
+      `but Lobu could not build a gateway route for it. Ask an admin to reconnect the provider or redeploy the gateway. ` +
+      `Expected gateway proxy URL: ${expectedProxyUrl}`
+    );
+  }
+
+  return null;
+}
+
 /**
  * Append a tokenless artifact-route reference (`[name](/api/v1/files/:id)`) for
  * each non-image attachment to the user's message text, so non-image uploads
@@ -854,6 +940,22 @@ export class MessageHandlerBridge {
         agentSettingsStore,
         organizationId
       );
+
+      const modelProviderError = await validateMessageModelProvider({
+        services: this.services,
+        agentId,
+        organizationId,
+        userId,
+        modelRef: agentOptions.model,
+      });
+      if (modelProviderError) {
+        logger.warn(
+          { traceId, agentId, organizationId, model: agentOptions.model },
+          "Rejecting inbound message before enqueue because model provider is not routable"
+        );
+        await thread.post({ text: modelProviderError });
+        return;
+      }
 
       const payload = buildMessagePayload({
         platform,

--- a/packages/server/src/gateway/platform.ts
+++ b/packages/server/src/gateway/platform.ts
@@ -9,6 +9,7 @@ import type { AgentMetadataStore } from "./auth/agent-metadata-store.js";
 import type { McpConfigService } from "./auth/mcp/config-service.js";
 import type { McpProxy } from "./auth/mcp/proxy.js";
 import type { ProviderOAuthStateStore } from "./auth/oauth/state-store.js";
+import type { ProviderCatalogService } from "./auth/provider-catalog.js";
 import type { AgentSettingsStore } from "./auth/settings/agent-settings-store.js";
 import type { ModelPreferenceStore } from "./auth/settings/model-preference-store.js";
 import type { UserAgentsStore } from "./auth/user-agents-store.js";
@@ -66,6 +67,7 @@ export interface CoreServices {
   getDeclaredAgentRegistry(): DeclaredAgentRegistry | undefined;
   getConnectionStore(): AgentConnectionStore | undefined;
   getAppInstallationStore(): AppInstallationStore;
+  getProviderCatalogService?(): ProviderCatalogService;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- validate effective model provider routing in inbound chat before enqueueing a run
- reply directly in-thread with a user-friendly setup message when the selected model's provider is not connected/credentialed/routable
- include expected gateway proxy URL in the message so operators can verify provider routing

## Validation
- make build-packages
- pre-commit typecheck

## Context
The previous fix improved save-time validation and worker fallback errors, but existing bad configs could still enqueue a run and leave the chat at Processing until the new worker code ran. This handles already-saved bad configs at the message boundary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785937312&installation_id=136316292&pr_number=1762&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1762&signature=4c56fa851654729be4417911cc445e78a11dc6c7d910e08631f490fd0894d2be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->