### PR TITLE
feat(server): generic bind confirmation in chat channels

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/channel-binding-actions.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-binding-actions.test.ts
@@ -9,7 +9,7 @@
  *     `slack:<id>` binding key. The Slack Web API is mocked (no live Slack).
  */
 
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getDb } from "../../../db/client";
 import {
 	persistSecretValue,
@@ -17,6 +17,7 @@ import {
 } from "../../../gateway/secrets";
 import { orgContext } from "../../../lobu/stores/org-context";
 import { PostgresSecretStore } from "../../../lobu/stores/postgres-secret-store";
+import { __setBindChannelNotifyDepsForTests } from "../../../gateway/channels/bind-channel-notify";
 import { __setSlackWebApiForTests } from "../../../tools/admin/manage_connections/handlers/channel-bindings";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
@@ -70,6 +71,47 @@ describe("manage_connections channel-binding actions", () => {
     await sql`DELETE FROM connections WHERE organization_id = ${orgId}`;
     await sql`DELETE FROM app_installations WHERE organization_id = ${orgId}`;
     await sql`DELETE FROM account WHERE "userId" = ${workspace.users.owner.id}`;
+    __setBindChannelNotifyDepsForTests({
+      gatewayRunning: () => false,
+      getManager: () => null,
+    });
+  });
+
+  it("bind_channel schedules a generic channel confirmation when the gateway is up", async () => {
+    const connectionId = await makeManagedSlackConnection({
+      orgId,
+      slug: "slackinst-notify",
+      teamId: TEAM,
+    });
+    const postMessageToChannel = vi.fn(async () => {});
+    __setBindChannelNotifyDepsForTests({
+      gatewayRunning: () => true,
+      getManager: () => ({ postMessageToChannel }),
+    });
+
+    const bound = (await workspace.owner.connections.manage({
+      action: "bind_channel",
+      agent_id: agentId,
+      connection_id: connectionId,
+      channel_id: "slack:C222",
+    })) as { success?: boolean };
+    expect(bound.success).toBe(true);
+    expect(postMessageToChannel).toHaveBeenCalledTimes(1);
+    expect(postMessageToChannel).toHaveBeenCalledWith(
+      "slackinst-notify",
+      "slack:C222",
+      expect.objectContaining({
+        markdown: expect.stringContaining("Linked to"),
+      }),
+    );
+
+    await workspace.owner.connections.manage({
+      action: "bind_channel",
+      agent_id: agentId,
+      connection_id: connectionId,
+      channel_id: "slack:C222",
+    });
+    expect(postMessageToChannel).toHaveBeenCalledTimes(1);
   });
 
   it("bind_channel → list_channel_bindings → unbind_channel round-trips", async () => {

--- a/packages/server/src/gateway/channels/__tests__/bind-channel-notify.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/bind-channel-notify.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import {
+	__setBindChannelNotifyDepsForTests,
+	channelBindConfirmationText,
+	postChannelBindConfirmation,
+} from "../bind-channel-notify";
+
+const defaultDeps = {
+	getManager: () => null,
+	gatewayRunning: () => false,
+};
+
+afterEach(() => {
+	__setBindChannelNotifyDepsForTests(defaultDeps);
+});
+
+describe("channelBindConfirmationText", () => {
+	it("names the agent in the ack", () => {
+		expect(channelBindConfirmationText("Finance Bot")).toBe(
+			"✅ Linked to **Finance Bot**. I'll reply here from now on.",
+		);
+	});
+});
+
+describe("postChannelBindConfirmation", () => {
+	it("skips when the channel was already bound to the same agent", async () => {
+		const postMessageToChannel = mock(async () => {});
+		__setBindChannelNotifyDepsForTests({
+			gatewayRunning: () => true,
+			getManager: () => ({ postMessageToChannel }),
+		});
+
+		await postChannelBindConfirmation({
+			connectionSlug: "slackinst-test",
+			platform: "slack",
+			channelId: "slack:C111",
+			agentId: "agent-a",
+			agentName: "Agent A",
+			previousAgentId: "agent-a",
+		});
+
+		expect(postMessageToChannel).not.toHaveBeenCalled();
+	});
+
+	it("skips when the gateway is not running", async () => {
+		const postMessageToChannel = mock(async () => {});
+		__setBindChannelNotifyDepsForTests({
+			gatewayRunning: () => false,
+			getManager: () => ({ postMessageToChannel }),
+		});
+
+		await postChannelBindConfirmation({
+			connectionSlug: "slackinst-test",
+			platform: "slack",
+			channelId: "slack:C111",
+			agentId: "agent-a",
+			agentName: "Agent A",
+		});
+
+		expect(postMessageToChannel).not.toHaveBeenCalled();
+	});
+
+	it("posts via the chat instance manager on a new bind", async () => {
+		const postMessageToChannel = mock(async () => {});
+		__setBindChannelNotifyDepsForTests({
+			gatewayRunning: () => true,
+			getManager: () => ({ postMessageToChannel }),
+		});
+
+		await postChannelBindConfirmation({
+			connectionSlug: "agentconn-42",
+			platform: "telegram",
+			channelId: "-100123",
+			agentId: "agent-a",
+			agentName: "Finance Bot",
+		});
+
+		expect(postMessageToChannel).toHaveBeenCalledTimes(1);
+		expect(postMessageToChannel).toHaveBeenCalledWith(
+			"42",
+			"telegram:-100123",
+			{
+				markdown:
+					"✅ Linked to **Finance Bot**. I'll reply here from now on.",
+			},
+		);
+	});
+
+	it("still posts when rebinding to a different agent", async () => {
+		const postMessageToChannel = mock(async () => {});
+		__setBindChannelNotifyDepsForTests({
+			gatewayRunning: () => true,
+			getManager: () => ({ postMessageToChannel }),
+		});
+
+		await postChannelBindConfirmation({
+			connectionSlug: "slackinst-test",
+			platform: "slack",
+			channelId: "slack:C111",
+			agentId: "agent-b",
+			agentName: "Agent B",
+			previousAgentId: "agent-a",
+		});
+
+		expect(postMessageToChannel).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/server/src/gateway/channels/__tests__/bind-channel-notify.test.ts
+++ b/packages/server/src/gateway/channels/__tests__/bind-channel-notify.test.ts
@@ -15,9 +15,20 @@ afterEach(() => {
 });
 
 describe("channelBindConfirmationText", () => {
-	it("names the agent in the ack", () => {
+	it("bolds the agent name when no dashboard URL is available", () => {
 		expect(channelBindConfirmationText("Finance Bot")).toBe(
 			"✅ Linked to **Finance Bot**. I'll reply here from now on.",
+		);
+	});
+
+	it("links the agent name to the Behaviors page when a URL is set", () => {
+		expect(
+			channelBindConfirmationText(
+				"Finance Bot",
+				"https://app.lobu.ai/acme/agents/agent-1/behaviors",
+			),
+		).toBe(
+			"✅ Linked to [Finance Bot](https://app.lobu.ai/acme/agents/agent-1/behaviors). I'll reply here from now on.",
 		);
 	});
 });
@@ -73,6 +84,7 @@ describe("postChannelBindConfirmation", () => {
 			channelId: "-100123",
 			agentId: "agent-a",
 			agentName: "Finance Bot",
+			agentUrl: "https://app.lobu.ai/acme/agents/agent-a/behaviors",
 		});
 
 		expect(postMessageToChannel).toHaveBeenCalledTimes(1);
@@ -81,7 +93,7 @@ describe("postChannelBindConfirmation", () => {
 			"telegram:-100123",
 			{
 				markdown:
-					"✅ Linked to **Finance Bot**. I'll reply here from now on.",
+					"✅ Linked to [Finance Bot](https://app.lobu.ai/acme/agents/agent-a/behaviors). I'll reply here from now on.",
 			},
 		);
 	});

--- a/packages/server/src/gateway/channels/bind-channel-notify.ts
+++ b/packages/server/src/gateway/channels/bind-channel-notify.ts
@@ -32,8 +32,22 @@ export function __setBindChannelNotifyDepsForTests(
 	deps = { ...deps, ...next };
 }
 
-export function channelBindConfirmationText(agentName: string): string {
-	return `✅ Linked to **${agentName}**. I'll reply here from now on.`;
+/** Escape chars that would break a markdown `[label](url)` link label. */
+function escapeMarkdownLinkLabel(text: string): string {
+	return text
+		.replace(/\\/g, "\\\\")
+		.replace(/\[/g, "\\[")
+		.replace(/\]/g, "\\]");
+}
+
+export function channelBindConfirmationText(
+	agentName: string,
+	agentUrl?: string,
+): string {
+	const agentRef = agentUrl
+		? `[${escapeMarkdownLinkLabel(agentName)}](${agentUrl})`
+		: `**${agentName}**`;
+	return `✅ Linked to ${agentRef}. I'll reply here from now on.`;
 }
 
 function channelKey(platform: string, channelId: string): string {
@@ -46,6 +60,8 @@ export type PostChannelBindConfirmationParams = {
 	channelId: string;
 	agentId: string;
 	agentName: string;
+	/** Owletto Behaviors page — rendered as the link label when set. */
+	agentUrl?: string;
 	/** When equal to `agentId`, skip — rebinding the same agent (e.g. model tweak). */
 	previousAgentId?: string | null;
 };
@@ -65,6 +81,7 @@ export async function postChannelBindConfirmation(
 		channelId,
 		agentId,
 		agentName,
+		agentUrl,
 		previousAgentId,
 	} = params;
 
@@ -78,7 +95,7 @@ export async function postChannelBindConfirmation(
 
 	try {
 		await manager.postMessageToChannel(runtimeConnectionId, key, {
-			markdown: channelBindConfirmationText(agentName),
+			markdown: channelBindConfirmationText(agentName, agentUrl),
 		});
 	} catch (err) {
 		logger.warn(

--- a/packages/server/src/gateway/channels/bind-channel-notify.ts
+++ b/packages/server/src/gateway/channels/bind-channel-notify.ts
@@ -1,0 +1,101 @@
+import { createLogger } from "@lobu/core";
+import {
+	getChatInstanceManager,
+	isLobuGatewayRunning,
+} from "../../lobu/gateway.js";
+import { slugToRuntimeConnectionId } from "../../lobu/stores/connections-projection.js";
+
+const logger = createLogger("bind-channel-notify");
+
+type ChatInstanceManagerLike = {
+	postMessageToChannel: (
+		connectionId: string,
+		channelKey: string,
+		content: { markdown: string },
+	) => Promise<void>;
+};
+
+type BindChannelNotifyDeps = {
+	getManager: () => ChatInstanceManagerLike | null | undefined;
+	gatewayRunning: () => boolean;
+};
+
+let deps: BindChannelNotifyDeps = {
+	getManager: getChatInstanceManager,
+	gatewayRunning: isLobuGatewayRunning,
+};
+
+/** Test hook: override gateway/manager accessors used by bind confirmation. */
+export function __setBindChannelNotifyDepsForTests(
+	next: Partial<BindChannelNotifyDeps>,
+): void {
+	deps = { ...deps, ...next };
+}
+
+export function channelBindConfirmationText(agentName: string): string {
+	return `✅ Linked to **${agentName}**. I'll reply here from now on.`;
+}
+
+function channelKey(platform: string, channelId: string): string {
+	return channelId.includes(":") ? channelId : `${platform}:${channelId}`;
+}
+
+export type PostChannelBindConfirmationParams = {
+	connectionSlug: string;
+	platform: string;
+	channelId: string;
+	agentId: string;
+	agentName: string;
+	/** When equal to `agentId`, skip — rebinding the same agent (e.g. model tweak). */
+	previousAgentId?: string | null;
+};
+
+/**
+ * Best-effort outbound ack after a single-channel bind. Uses the Chat SDK
+ * adapter path (`ChatInstanceManager.postMessageToChannel`) so every chat
+ * platform shares one code path. The binding is authoritative — delivery
+ * failure is logged and swallowed.
+ */
+export async function postChannelBindConfirmation(
+	params: PostChannelBindConfirmationParams,
+): Promise<void> {
+	const {
+		connectionSlug,
+		platform,
+		channelId,
+		agentId,
+		agentName,
+		previousAgentId,
+	} = params;
+
+	if (previousAgentId === agentId) return;
+	if (!deps.gatewayRunning()) return;
+
+	const manager = deps.getManager();
+	if (!manager?.postMessageToChannel) return;
+	const runtimeConnectionId = slugToRuntimeConnectionId(connectionSlug);
+	const key = channelKey(platform, channelId);
+
+	try {
+		await manager.postMessageToChannel(runtimeConnectionId, key, {
+			markdown: channelBindConfirmationText(agentName),
+		});
+	} catch (err) {
+		logger.warn(
+			{
+				err: String(err),
+				connectionSlug,
+				channelKey: key,
+				agentId,
+			},
+			"bind confirmation post failed (binding still succeeded)",
+		);
+	}
+}
+
+/** Fire-and-forget — tool handlers must not block on chat delivery. */
+export function scheduleChannelBindConfirmation(
+	params: PostChannelBindConfirmationParams,
+): void {
+	void postChannelBindConfirmation(params).catch(() => {});
+}

--- a/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
@@ -34,6 +34,7 @@ import {
 import { orgContext } from "../../../../lobu/stores/org-context";
 import { PostgresSecretStore } from "../../../../lobu/stores/postgres-secret-store";
 import { canonicalSlackChannelId } from "../../../../preview/slack";
+import { getConfiguredPublicOrigin } from "../../../../utils/public-origin";
 import type { ToolContext } from "../../../registry";
 import type { ConnectionsArgs, ManageConnectionsResult } from "../schemas";
 
@@ -66,18 +67,27 @@ async function assertAgentInOrg(
 	return rows.length > 0;
 }
 
-async function resolveAgentName(
+async function resolveAgentBindNotice(
 	organizationId: string,
 	agentId: string,
-): Promise<string> {
+): Promise<{ name: string; url?: string }> {
 	const sql = getDb();
 	const rows = (await sql`
-		SELECT name FROM agents
-		WHERE id = ${agentId} AND organization_id = ${organizationId}
+		SELECT a.name, o.slug AS org_slug
+		FROM agents a
+		JOIN organization o ON o.id = a.organization_id
+		WHERE a.id = ${agentId} AND a.organization_id = ${organizationId}
 		LIMIT 1
-	`) as Array<{ name: string }>;
-	const name = rows[0]?.name?.trim();
-	return name || agentId;
+	`) as Array<{ name: string | null; org_slug: string | null }>;
+	const row = rows[0];
+	const name = row?.name?.trim() || agentId;
+	const origin = getConfiguredPublicOrigin()?.replace(/\/+$/, "");
+	const orgSlug = row?.org_slug?.trim();
+	const url =
+		origin && orgSlug
+			? `${origin}/${orgSlug}/agents/${agentId}/behaviors`
+			: undefined;
+	return { name, url };
 }
 
 /**
@@ -185,12 +195,17 @@ export async function handleBindChannel(
 			model: args.model,
 		},
 	);
+	const agentNotice = await resolveAgentBindNotice(
+		organizationId,
+		args.agent_id,
+	);
 	scheduleChannelBindConfirmation({
 		connectionSlug: connection.slug,
 		platform: connection.connector_key,
 		channelId,
 		agentId: args.agent_id,
-		agentName: await resolveAgentName(organizationId, args.agent_id),
+		agentName: agentNotice.name,
+		agentUrl: agentNotice.url,
 		previousAgentId: existing?.agentId,
 	});
 	logger.info(
@@ -425,12 +440,17 @@ export async function handleConnectChannelDm(
 			connectionId: String(connection.id),
 		},
 	);
+	const agentNotice = await resolveAgentBindNotice(
+		organizationId,
+		args.agent_id,
+	);
 	scheduleChannelBindConfirmation({
 		connectionSlug: connection.slug,
 		platform: "slack",
 		channelId: boundChannelId,
 		agentId: args.agent_id,
-		agentName: await resolveAgentName(organizationId, args.agent_id),
+		agentName: agentNotice.name,
+		agentUrl: agentNotice.url,
 		previousAgentId: existing?.agentId,
 	});
 

--- a/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
@@ -18,6 +18,11 @@
 import { createLogger } from "@lobu/core";
 import { getDb } from "../../../../db/client";
 import { ChannelBindingService } from "../../../../gateway/channels/binding-service";
+import { scheduleChannelBindConfirmation } from "../../../../gateway/channels/bind-channel-notify";
+import {
+	runtimeConnectionIdToSlug,
+	slugToRuntimeConnectionId,
+} from "../../../../lobu/stores/connections-projection";
 import {
 	createSlackWebApi,
 	type SlackWebApi,
@@ -26,7 +31,6 @@ import {
 	resolveSecretValue,
 	SecretStoreRegistry,
 } from "../../../../gateway/secrets";
-import { runtimeConnectionIdToSlug } from "../../../../lobu/stores/connections-projection";
 import { orgContext } from "../../../../lobu/stores/org-context";
 import { PostgresSecretStore } from "../../../../lobu/stores/postgres-secret-store";
 import { canonicalSlackChannelId } from "../../../../preview/slack";
@@ -60,6 +64,20 @@ async function assertAgentInOrg(
 		LIMIT 1
 	`) as Array<unknown>;
 	return rows.length > 0;
+}
+
+async function resolveAgentName(
+	organizationId: string,
+	agentId: string,
+): Promise<string> {
+	const sql = getDb();
+	const rows = (await sql`
+		SELECT name FROM agents
+		WHERE id = ${agentId} AND organization_id = ${organizationId}
+		LIMIT 1
+	`) as Array<{ name: string }>;
+	const name = rows[0]?.name?.trim();
+	return name || agentId;
 }
 
 /**
@@ -130,7 +148,7 @@ export async function handleBindChannel(
 	if (!channelId) return { error: "Invalid channel_id" };
 	const sql = getDb();
 	const connections = (await sql`
-		SELECT id, connector_key, external_tenant_id
+		SELECT id, slug, connector_key, external_tenant_id
 		FROM connections
 		WHERE id = ${args.connection_id}
 			AND organization_id = ${organizationId}
@@ -140,6 +158,7 @@ export async function handleBindChannel(
 		LIMIT 1
 	`) as Array<{
 		id: number;
+		slug: string;
 		connector_key: string;
 		external_tenant_id: string | null;
 	}>;
@@ -148,6 +167,12 @@ export async function handleBindChannel(
 	const teamId = connection.external_tenant_id ?? undefined;
 
 	const svc = new ChannelBindingService();
+	const runtimeConnectionId = slugToRuntimeConnectionId(connection.slug);
+	const existing = await svc.getBindingForConnection(
+		runtimeConnectionId,
+		channelId,
+		organizationId,
+	);
 	await svc.createBinding(
 		args.agent_id,
 		connection.connector_key,
@@ -160,6 +185,14 @@ export async function handleBindChannel(
 			model: args.model,
 		},
 	);
+	scheduleChannelBindConfirmation({
+		connectionSlug: connection.slug,
+		platform: connection.connector_key,
+		channelId,
+		agentId: args.agent_id,
+		agentName: await resolveAgentName(organizationId, args.agent_id),
+		previousAgentId: existing?.agentId,
+	});
 	logger.info(
 		`Bound ${connection.connector_key}/${channelId} → ${args.agent_id}`,
 	);
@@ -323,7 +356,7 @@ export async function handleConnectChannelDm(
 
 	const sql = getDb();
 	const rows = (await sql`
-		SELECT id, connector_key, external_tenant_id, config
+		SELECT id, slug, connector_key, external_tenant_id, config
 		FROM connections
 		WHERE id = ${args.connection_id}
 			AND organization_id = ${organizationId}
@@ -334,6 +367,7 @@ export async function handleConnectChannelDm(
 		LIMIT 1
 	`) as Array<{
 		id: number;
+		slug: string;
 		connector_key: string;
 		external_tenant_id: string | null;
 		config: { botToken?: string } | null;
@@ -372,11 +406,18 @@ export async function handleConnectChannelDm(
 	// Store the binding under the canonical `slack:<id>` channel key — inbound
 	// Slack messages reach the dispatcher already canonicalized, so a raw `D…`
 	// key would never route. (dmChannelId stays raw for the Web API calls.)
+	const boundChannelId = canonicalSlackChannelId(dmChannelId);
 	const svc = new ChannelBindingService();
+	const runtimeConnectionId = slugToRuntimeConnectionId(connection.slug);
+	const existing = await svc.getBindingForConnection(
+		runtimeConnectionId,
+		boundChannelId,
+		organizationId,
+	);
 	await svc.createBinding(
 		args.agent_id,
 		"slack",
-		canonicalSlackChannelId(dmChannelId),
+		boundChannelId,
 		connection.external_tenant_id ?? undefined,
 		{
 			configuredBy: userId ?? undefined,
@@ -384,15 +425,14 @@ export async function handleConnectChannelDm(
 			connectionId: String(connection.id),
 		},
 	);
-
-	// Best-effort welcome — the binding is the contract, not this DM.
-	void slackWebApi
-		.postMessage(
-			botToken,
-			dmChannelId,
-			"✅ Connected. I'm now wired to this DM — ask me anything to get started.",
-		)
-		.catch(() => {});
+	scheduleChannelBindConfirmation({
+		connectionSlug: connection.slug,
+		platform: "slack",
+		channelId: boundChannelId,
+		agentId: args.agent_id,
+		agentName: await resolveAgentName(organizationId, args.agent_id),
+		previousAgentId: existing?.agentId,
+	});
 
 	logger.info(
 		`Connected Slack DM ${dmChannelId} (team ${connection.external_tenant_id ?? "unknown"}) → ${args.agent_id}`,


### PR DESCRIPTION
## Summary

After a dashboard `bind_channel` or `connect_channel_dm`, best-effort post a short confirmation in the bound chat channel via `ChatInstanceManager.postMessageToChannel` (platform-generic — Slack, Telegram, etc.).

- Message: `✅ Linked to [Agent Name]({behaviorsUrl}). I'll reply here from now on.` when `PUBLIC_GATEWAY_URL` is set; bold name fallback otherwise
- Skips when rebinding the same agent (e.g. model-only update)
- Does **not** notify on `sync_channel_bindings` bulk apply
- Replaces the Slack-only `slackWebApi.postMessage` welcome in `connect_channel_dm`

## Test plan

- [x] `bun test src/gateway/channels/__tests__/bind-channel-notify.test.ts`
- [x] `bun run test -- src/__tests__/integration/connectors/channel-binding-actions.test.ts`
- [x] `make review` — typecheck pass; integration 233/233 pass; channel-binding integration green

## Review verdict

`bug_free 62, simplicity 78, slop 5, 0 blockers` — pi flagged unrelated pre-existing unit-suite noise (connector-sdk dist export); no blockers on this diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785937818&installation_id=136316292&pr_number=1763&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1763&signature=f8201bc98c186bd4444d2cb21040073a6bce905b62feba9d8bda036fc41a15f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->