### PR TITLE
feat(operations): permalink chain resolve + run-aware timeline + approval attribution

### DIFF
--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -1180,6 +1180,11 @@ export interface ContentItem {
   interaction_output?: Record<string, unknown> | null;
   interaction_error?: string | null;
   supersedes_event_id?: number | null;
+  /** The run this event belongs to, when it originated from one (operation
+   *  chains, approval notifications). Lets the client group a run's satellite
+   *  events (the "needs approval" notification) onto the same timeline node as
+   *  its operation chain, and surface a "Run #N" identity. */
+  run_id?: number | null;
   /** Entity display info (only present in some responses) */
   entity_name?: string;
   entity_type?: string;

--- a/packages/server/src/__tests__/integration/events/approval-reviewer-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/events/approval-reviewer-attribution.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Approval reviewer attribution.
+ *
+ * When a human approves or rejects a queued action, the superseding event must
+ * record *who* decided it — both the durable FK (`created_by`) and a
+ * display-ready name in metadata (`reviewed_by_name` / `reviewed_by_id`). And
+ * because a run's later system transitions (the worker reporting 'completed')
+ * re-supersede without an acting user, the reviewer must be *inherited* down the
+ * chain so the completed state still shows who authorized it.
+ *
+ * Contract under test: `supersedeActionEvent(runId, org, status, …, reviewer)`.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getDb } from '../../../db/client';
+import { supersedeActionEvent } from '../../../tools/admin/manage_operations';
+import { insertEvent } from '../../../utils/insert-event';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import { createTestOrganization, createTestUser } from '../../setup/test-fixtures';
+
+async function insertActionRun(organizationId: string): Promise<number> {
+  const sql = getDb();
+  const rows = (await sql`
+    INSERT INTO runs
+      (organization_id, run_type, status, approval_status, action_key, created_at)
+    VALUES
+      (${organizationId}, 'action', 'pending', 'pending', 'screenshot', NOW())
+    RETURNING id
+  `) as Array<{ id: number }>;
+  return rows[0].id;
+}
+
+async function insertPendingApprovalEvent(
+  organizationId: string,
+  runId: number
+): Promise<number> {
+  const inserted = await insertEvent({
+    entityIds: [],
+    organizationId,
+    originId: `run_${runId}_pending`,
+    title: 'screenshot — pending approval',
+    content: 'Agent requested a screenshot.',
+    semanticType: 'operation',
+    connectorKey: 'apple.computer_use',
+    runId,
+    interactionType: 'approval',
+    interactionStatus: 'pending',
+    metadata: { status: 'pending_approval' },
+  });
+  return Number(inserted.id);
+}
+
+async function metadataFor(eventId: number): Promise<{
+  created_by: string | null;
+  metadata: Record<string, unknown>;
+  interaction_status: string | null;
+}> {
+  const rows = (await getDb()`
+    SELECT created_by, metadata, interaction_status FROM events WHERE id = ${eventId}
+  `) as Array<{
+    created_by: string | null;
+    metadata: Record<string, unknown>;
+    interaction_status: string | null;
+  }>;
+  return rows[0];
+}
+
+describe('approval reviewer attribution', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('stamps the reviewer on an approve transition', async () => {
+    const org = await createTestOrganization();
+    const reviewer = await createTestUser({ name: 'Ada Approver' });
+    const runId = await insertActionRun(org.id);
+    await insertPendingApprovalEvent(org.id, runId);
+
+    const approvedId = await supersedeActionEvent(
+      runId,
+      org.id,
+      'confirmed',
+      'screenshot — executing',
+      'Operation confirmed',
+      {},
+      { userId: reviewer.id, name: reviewer.name }
+    );
+    expect(approvedId).toBeDefined();
+
+    const approved = await metadataFor(approvedId!);
+    expect(approved.interaction_status).toBe('approved');
+    expect(approved.created_by).toBe(reviewer.id);
+    expect(approved.metadata.reviewed_by_id).toBe(reviewer.id);
+    expect(approved.metadata.reviewed_by_name).toBe('Ada Approver');
+  });
+
+  it('records the reviewer + reason on a reject transition', async () => {
+    const org = await createTestOrganization();
+    const reviewer = await createTestUser({ name: 'Rex Rejector' });
+    const runId = await insertActionRun(org.id);
+    await insertPendingApprovalEvent(org.id, runId);
+
+    const rejectedId = await supersedeActionEvent(
+      runId,
+      org.id,
+      'rejected',
+      'screenshot — rejected',
+      'Operation rejected',
+      { reason: 'not needed' },
+      { userId: reviewer.id, name: reviewer.name }
+    );
+
+    const rejected = await metadataFor(rejectedId!);
+    expect(rejected.interaction_status).toBe('rejected');
+    expect(rejected.created_by).toBe(reviewer.id);
+    expect(rejected.metadata.reviewed_by_name).toBe('Rex Rejector');
+    expect(rejected.metadata.reason).toBe('not needed');
+  });
+
+  it('inherits the reviewer onto a later system transition (completed)', async () => {
+    const org = await createTestOrganization();
+    const reviewer = await createTestUser({ name: 'Ada Approver' });
+    const runId = await insertActionRun(org.id);
+    await insertPendingApprovalEvent(org.id, runId);
+
+    // Human approves…
+    await supersedeActionEvent(
+      runId,
+      org.id,
+      'confirmed',
+      'screenshot — executing',
+      'Operation confirmed',
+      {},
+      { userId: reviewer.id, name: reviewer.name }
+    );
+
+    // …then the worker reports completion with NO acting user (reviewer=null).
+    const completedId = await supersedeActionEvent(
+      runId,
+      org.id,
+      'completed',
+      'screenshot — completed',
+      'Operation completed',
+      { output: { bytes: 1 } }
+      // no reviewer arg — the worker isn't a user
+    );
+
+    const completed = await metadataFor(completedId!);
+    expect(completed.interaction_status).toBe('completed');
+    // The person who approved still owns the completed state.
+    expect(completed.created_by).toBe(reviewer.id);
+    expect(completed.metadata.reviewed_by_id).toBe(reviewer.id);
+    expect(completed.metadata.reviewed_by_name).toBe('Ada Approver');
+  });
+
+  it('leaves no reviewer when none was ever supplied', async () => {
+    const org = await createTestOrganization();
+    const runId = await insertActionRun(org.id);
+    await insertPendingApprovalEvent(org.id, runId);
+
+    const completedId = await supersedeActionEvent(
+      runId,
+      org.id,
+      'completed',
+      'screenshot — completed',
+      'Operation completed',
+      { output: { bytes: 1 } }
+    );
+
+    const completed = await metadataFor(completedId!);
+    expect(completed.created_by).toBeNull();
+    expect(completed.metadata.reviewed_by_id).toBeUndefined();
+    expect(completed.metadata.reviewed_by_name).toBeUndefined();
+  });
+});

--- a/packages/server/src/__tests__/integration/events/get-content-chain-resolve.test.ts
+++ b/packages/server/src/__tests__/integration/events/get-content-chain-resolve.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Integration test: `content_ids` permalinks resolve the full supersede chain.
+ *
+ * An approval permalink is minted at pending-approval time and carries THAT
+ * event id. When the user approves and the device completes, each transition
+ * INSERTs a new row and stamps `superseded_by` on the prior one, so the pending
+ * id is no longer live and drops out of `current_event_records`. Before the fix
+ * `fetchByContentIds` read the masked view directly, so the frozen permalink id
+ * returned zero rows → the UI's "not found".
+ *
+ * Pinned behavior after the fix (get_content/query.ts):
+ *   - Requesting a superseded id returns its WHOLE lineage (pending → executing
+ *     → completed), not a 404 and not just the head — the caller sees what
+ *     happened.
+ *   - Run/operation chains resolve via the shared `run_id` (the run arm).
+ *   - run_id-less chains (e.g. an edited note) resolve by walking
+ *     `superseded_by` / `supersedes_event_id` (the walk arm).
+ *   - Requesting two ids from the same chain does not double-return it.
+ *
+ * Vitest CI gap note (mirrors neighbors): runs locally / in the CI integration
+ * job against the pgvector DB via DATABASE_URL.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getTestDb } from '../../setup/test-db';
+import { getContent } from '../../../tools/get_content';
+import type { ToolContext } from '../../../tools/registry';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestOrganization,
+  createTestUser,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+/**
+ * Insert one event row directly and (when `supersedesId` is given) stamp the
+ * inverse `superseded_by` edge on the prior row in the SAME lineage — exactly
+ * what insert-event.ts does on a real supersede. Returns the new row id.
+ */
+async function insertChainRow(opts: {
+  organizationId: string;
+  title: string;
+  content: string;
+  runId?: number | null;
+  occurredAt: Date;
+  supersedesId?: number | null;
+}): Promise<number> {
+  const sql = getTestDb();
+  const [row] = await sql`
+    INSERT INTO events (
+      organization_id, origin_id, title, payload_type, payload_text,
+      semantic_type, occurred_at, created_at, run_id, supersedes_event_id
+    ) VALUES (
+      ${opts.organizationId},
+      ${`chain-test-${opts.title}-${opts.occurredAt.getTime()}`},
+      ${opts.title}, 'text', ${opts.content},
+      'content', ${opts.occurredAt}, NOW(),
+      ${opts.runId ?? null},
+      ${opts.supersedesId ?? null}
+    )
+    RETURNING id
+  `;
+  const id = Number((row as { id: unknown }).id);
+  // Stamp the forward edge on the row we just superseded so the masking view
+  // (WHERE superseded_by IS NULL) hides it — reproducing the stale permalink.
+  if (opts.supersedesId != null) {
+    await sql`UPDATE events SET superseded_by = ${id} WHERE id = ${opts.supersedesId}`;
+  }
+  return id;
+}
+
+describe('getContent > content_ids resolves the full supersede chain', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let user: Awaited<ReturnType<typeof createTestUser>>;
+  let ctx: ToolContext;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+
+    org = await createTestOrganization({ name: 'Chain Resolve Org' });
+    user = await createTestUser({ email: 'chain-resolve@example.com' });
+    await addUserToOrganization(user.id, org.id, 'owner');
+
+    ctx = {
+      organizationId: org.id,
+      userId: user.id,
+      memberRole: 'owner',
+      isAuthenticated: true,
+      tokenType: 'oauth',
+      scopedToOrg: false,
+      allowCrossOrg: true,
+      scopes: ['mcp:read'],
+    } as ToolContext;
+  });
+
+  it('run arm: a superseded permalink id returns the whole run chain (pending→executing→completed)', async () => {
+    const sql = getTestDb();
+    const [run] = await sql<{ id: number }[]>`
+      INSERT INTO runs (run_type, status, organization_id)
+      VALUES ('action', 'completed', ${org.id}) RETURNING id`;
+    const runId = Number(run.id);
+
+    const t0 = new Date('2026-07-01T00:00:00Z');
+    const pending = await insertChainRow({
+      organizationId: org.id,
+      title: 'screenshot — pending approval',
+      content: 'pending',
+      runId,
+      occurredAt: t0,
+    });
+    const executing = await insertChainRow({
+      organizationId: org.id,
+      title: 'screenshot — executing',
+      content: 'executing',
+      runId,
+      occurredAt: new Date(t0.getTime() + 1000),
+      supersedesId: pending,
+    });
+    const completed = await insertChainRow({
+      organizationId: org.id,
+      title: 'screenshot — completed',
+      content: 'completed with image',
+      runId,
+      occurredAt: new Date(t0.getTime() + 2000),
+      supersedesId: executing,
+    });
+
+    // The permalink carries the PENDING id, which is now superseded/hidden.
+    const result = await getContent(
+      { content_ids: [pending], limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    const ids = result.content.map((c) => c.id);
+
+    // Whole lineage comes back, chronological, not a 404.
+    expect(ids).toEqual([pending, executing, completed]);
+    // total counts the chain as ONE unit, not three rows.
+    expect(result.total).toBe(1);
+  });
+
+  it('walk arm: a run_id-less superseded id resolves via superseded_by/supersedes_event_id', async () => {
+    const t0 = new Date('2026-07-02T00:00:00Z');
+    const v1 = await insertChainRow({
+      organizationId: org.id,
+      title: 'note v1',
+      content: 'first',
+      runId: null,
+      occurredAt: t0,
+    });
+    const v2 = await insertChainRow({
+      organizationId: org.id,
+      title: 'note v2',
+      content: 'second',
+      runId: null,
+      occurredAt: new Date(t0.getTime() + 1000),
+      supersedesId: v1,
+    });
+
+    // Request the OLD (superseded) id; expect both rows of the walked chain.
+    const result = await getContent(
+      { content_ids: [v1], limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    const ids = result.content.map((c) => c.id).sort((a, b) => a - b);
+    expect(ids).toEqual([v1, v2].sort((a, b) => a - b));
+    expect(result.total).toBe(1);
+  });
+
+  it('walk arm: entering from the HEAD id still returns the full history (backward walk)', async () => {
+    const t0 = new Date('2026-07-04T00:00:00Z');
+    const v1 = await insertChainRow({
+      organizationId: org.id,
+      title: 'doc v1',
+      content: 'first',
+      runId: null,
+      occurredAt: t0,
+    });
+    const v2 = await insertChainRow({
+      organizationId: org.id,
+      title: 'doc v2',
+      content: 'second',
+      runId: null,
+      occurredAt: new Date(t0.getTime() + 1000),
+      supersedesId: v1,
+    });
+    const v3 = await insertChainRow({
+      organizationId: org.id,
+      title: 'doc v3',
+      content: 'third',
+      runId: null,
+      occurredAt: new Date(t0.getTime() + 2000),
+      supersedesId: v2,
+    });
+
+    // Enter from the live HEAD (v3): the caller should still see the superseded
+    // history (v1, v2) via the backward supersedes_event_id walk.
+    const result = await getContent(
+      { content_ids: [v3], limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    const ids = result.content.map((c) => c.id).sort((a, b) => a - b);
+    expect(ids).toEqual([v1, v2, v3].sort((a, b) => a - b));
+    expect(result.total).toBe(1);
+  });
+
+  it('two ids from the same chain do not double-return the lineage', async () => {
+    const sql = getTestDb();
+    const [run] = await sql<{ id: number }[]>`
+      INSERT INTO runs (run_type, status, organization_id)
+      VALUES ('action', 'completed', ${org.id}) RETURNING id`;
+    const runId = Number(run.id);
+
+    const t0 = new Date('2026-07-03T00:00:00Z');
+    const a = await insertChainRow({
+      organizationId: org.id,
+      title: 'op a',
+      content: 'a',
+      runId,
+      occurredAt: t0,
+    });
+    const b = await insertChainRow({
+      organizationId: org.id,
+      title: 'op b',
+      content: 'b',
+      runId,
+      occurredAt: new Date(t0.getTime() + 1000),
+      supersedesId: a,
+    });
+
+    const result = await getContent(
+      { content_ids: [a, b], limit: 100 } as never,
+      {} as never,
+      ctx
+    );
+    const ids = result.content.map((c) => c.id);
+    // Each chain row appears exactly once even though both its ids were asked for.
+    expect(ids.sort((x, y) => x - y)).toEqual([a, b].sort((x, y) => x - y));
+    expect(result.total).toBe(1);
+  });
+});

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -1,5 +1,6 @@
 import { getDb } from '../db/client';
 import { emit } from '../events/emitter';
+import { buildResourcePermalink } from '../utils/url-builder';
 import { createNotificationForUsers } from './service';
 
 /** Notification content minus the org id (the dispatch helpers stamp it). */
@@ -65,12 +66,11 @@ export async function notifyActionApprovalNeeded(params: {
 }): Promise<void> {
   await notifyOrgAdmins(params.orgId, (orgSlug) => {
     const connLabel = params.connectionName ? ` on ${params.connectionName}` : '';
-    const resourceUrl =
-      params.eventId && orgSlug
-        ? `/${orgSlug}/memory?content_ids=${params.eventId}`
-        : orgSlug
-          ? `/${orgSlug}/memory?run_ids=${params.runId}`
-          : undefined;
+    // Run-scoped, via the shared permalink resolver — same reasoning as the
+    // approval_url: the pending event is superseded on approve→complete, but the
+    // run link stays valid across the chain. (baseUrl omitted → relative link,
+    // which the inbox resolves against the current origin.)
+    const resourceUrl = buildResourcePermalink(orgSlug, { kind: 'run', runId: params.runId });
     const urlLine = params.approvalUrl ? `\n\nReview: ${params.approvalUrl}` : '';
     return {
       type: 'action_approval_needed',

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -16,7 +16,7 @@ import { getDb } from '../../db/client';
 import { mergeEntityFields, type FieldMergeResult } from '../../utils/entity-field-merge';
 import { insertEvent } from '../../utils/insert-event';
 import logger from '../../utils/logger';
-import { buildEventPermalink } from '../../utils/url-builder';
+import { buildResourcePermalink } from '../../utils/url-builder';
 import type { ToolContext } from '../registry';
 import { getOrgUrlContext } from '../view-urls';
 import { notifyActionApprovalNeeded } from '../../notifications/triggers';
@@ -119,8 +119,10 @@ export async function proposeEntityFieldChange(
   const eventId = Number(event.id);
 
   const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
-  const approvalUrl =
-    ownerSlug && baseUrl ? buildEventPermalink(ownerSlug, eventId, baseUrl) : undefined;
+  // Run-scoped: the pending event is superseded on approve→complete; a run link
+  // stays valid across the chain. (Read-side content_ids resolution also covers
+  // the event id below, carried for the notification's resourceId.)
+  const approvalUrl = buildResourcePermalink(ownerSlug, { kind: 'run', runId }, baseUrl);
 
   notifyActionApprovalNeeded({
     orgId: ctx.organizationId,

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -30,7 +30,7 @@ import { isValidAgentId } from '../../lobu/stores/postgres-stores';
 import { notifyActionApprovalNeeded } from '../../notifications/triggers';
 import { insertEvent } from '../../utils/insert-event';
 import logger from '../../utils/logger';
-import { buildEventPermalink } from '../../utils/url-builder';
+import { buildResourcePermalink } from '../../utils/url-builder';
 import { ToolUserError } from '../../utils/errors';
 import { requireOrgReadAccess, requireOrgWriteAccess } from '../../utils/organization-access';
 import type { ToolContext } from '../registry';
@@ -398,8 +398,10 @@ async function queueWriteForApproval(
   const eventId = Number(event.id);
 
   const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
-  const approvalUrl =
-    ownerSlug && baseUrl ? buildEventPermalink(ownerSlug, eventId, baseUrl) : undefined;
+  // Run-scoped: the pending event is superseded on approve→complete; a run link
+  // stays valid across the chain. (Read-side content_ids resolution also covers
+  // the event id below, carried for the notification's resourceId.)
+  const approvalUrl = buildResourcePermalink(ownerSlug, { kind: 'run', runId }, baseUrl);
 
   notifyActionApprovalNeeded({
     orgId: ctx.organizationId,

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -33,7 +33,7 @@ import { insertEvent } from '../../utils/insert-event';
 import logger from '../../utils/logger';
 import { createConnectorOperationRun } from '../../runs/queue-service';
 import { dispatchChromeActionToExtension } from '../../worker-api/dispatch-chrome-action';
-import { buildRunPermalink } from '../../utils/url-builder';
+import { buildResourcePermalink } from '../../utils/url-builder';
 import { trackWatcherReaction } from '../../utils/watcher-reactions';
 import type { ToolContext } from '../registry';
 import { getOrgUrlContext } from '../view-urls';
@@ -708,8 +708,7 @@ async function handleExecute(
     // approve→complete and drops out of the live view, but a run_ids permalink
     // reads the whole chain and stays valid across the lifecycle. (The read-side
     // content_ids resolver also covers already-minted event-scoped links.)
-    const approvalUrl =
-      orgSlug && baseUrl ? buildRunPermalink(orgSlug, runId, baseUrl) : undefined;
+    const approvalUrl = buildResourcePermalink(orgSlug, { kind: 'run', runId }, baseUrl);
 
     notifyActionApprovalNeeded({
       orgId: ctx.organizationId,

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -892,13 +892,27 @@ async function handleGetRun(
   return { action: 'get_run', run: rows[0] };
 }
 
+/**
+ * The human who decided an approval. Threaded from the approve/reject handler
+ * (a web session — `ctx.userId` is the acting user) into every event of the
+ * post-decision chain (approved → completed/failed), so each state records who
+ * authorized it. `null` for system-driven supersessions with no acting user
+ * (e.g. a worker completing a device action it was told to run).
+ */
+export interface ApprovalReviewer {
+  userId: string;
+  /** Display name resolved at decision time; falls back to userId when unknown. */
+  name: string | null;
+}
+
 export async function supersedeActionEvent(
   runId: number,
   organizationId: string,
   status: string,
   title: string,
   content: string,
-  extraMetadata: Record<string, unknown> = {}
+  extraMetadata: Record<string, unknown> = {},
+  reviewer: ApprovalReviewer | null = null
 ): Promise<number | undefined> {
   const sql = getDb();
   const originalEvent = await sql`
@@ -913,6 +927,16 @@ export async function supersedeActionEvent(
   if (originalEvent.length === 0) return undefined;
 
   const orig = originalEvent[0] as any;
+  // Carry the reviewer forward. A decision (approve/reject) supplies one; the
+  // later system transitions (completed/failed) don't re-supply it, so inherit
+  // the reviewer already stamped on the prior state — the person who authorized
+  // the run owns its whole outcome in the audit trail.
+  const priorMetadata = (orig.metadata ?? {}) as Record<string, unknown>;
+  const reviewedById =
+    reviewer?.userId ?? (priorMetadata.reviewed_by_id as string | undefined) ?? null;
+  const reviewedByName =
+    reviewer?.name ?? (priorMetadata.reviewed_by_name as string | undefined) ?? null;
+
   const nextEvent = await insertEvent({
     entityIds: Array.isArray(orig.entity_ids) ? orig.entity_ids.map(Number) : [],
     organizationId,
@@ -943,9 +967,14 @@ export async function supersedeActionEvent(
         | undefined) ?? null,
     interactionError: (extraMetadata.error_message as string | undefined) ?? null,
     supersedesEventId: Number(orig.id),
+    // The durable identity (FK → user); set on the first decision event and
+    // preserved down the chain.
+    createdBy: reviewedById,
     metadata: {
-      ...(orig.metadata ?? {}),
+      ...priorMetadata,
       status,
+      ...(reviewedById ? { reviewed_by_id: reviewedById } : {}),
+      ...(reviewedByName ? { reviewed_by_name: reviewedByName } : {}),
       ...(extraMetadata.output ? { action_output: extraMetadata.output } : {}),
       ...(extraMetadata.error_message ? { error_message: extraMetadata.error_message } : {}),
       ...extraMetadata,
@@ -954,6 +983,19 @@ export async function supersedeActionEvent(
   });
 
   return Number(nextEvent.id);
+}
+
+/**
+ * Resolve the acting user's display name for the approval audit trail. Approvals
+ * are web-session only (`ctx.clientId` is rejected upstream), so `ctx.userId` is
+ * always a real human here; we still guard on null for safety.
+ */
+async function resolveReviewer(ctx: ToolContext): Promise<ApprovalReviewer | null> {
+  if (!ctx.userId) return null;
+  const rows = await getDb()<{ name: string | null }>`
+    SELECT name FROM "user" WHERE id = ${ctx.userId} LIMIT 1
+  `;
+  return { userId: ctx.userId, name: rows[0]?.name ?? null };
 }
 
 /**
@@ -1022,13 +1064,15 @@ async function tryApproveManageAgentsRun(
   if (!claimed) return null;
 
   const { proposal, requesterUserId } = claimed;
+  const reviewer = await resolveReviewer(ctx);
   await supersedeActionEvent(
     args.run_id,
     ctx.organizationId,
     'confirmed',
     `manage_agents.${proposal.action} — executing`,
     `Builder action confirmed: ${proposal.action} ${proposal.agent_id}`,
-    {}
+    {},
+    reviewer
   );
 
   try {
@@ -1049,7 +1093,8 @@ async function tryApproveManageAgentsRun(
       'completed',
       `manage_agents.${proposal.action} — completed`,
       `Builder action completed: ${proposal.action} ${proposal.agent_id}`,
-      { output: output as unknown as Record<string, unknown> }
+      { output: output as unknown as Record<string, unknown> },
+      reviewer
     );
     return {
       action: 'approve',
@@ -1070,7 +1115,8 @@ async function tryApproveManageAgentsRun(
       'failed',
       `manage_agents.${proposal.action} — failed`,
       `Builder action failed: ${proposal.action} ${proposal.agent_id} — ${errorMessage}`,
-      { error_message: errorMessage }
+      { error_message: errorMessage },
+      reviewer
     );
     return {
       action: 'approve',
@@ -1135,6 +1181,7 @@ async function tryApproveEntityFieldChangeRun(
   if (!claimed) return null;
   const { proposal } = claimed;
   const fieldList = Object.keys(proposal.fields).join(', ');
+  const reviewer = await resolveReviewer(ctx);
 
   await supersedeActionEvent(
     args.run_id,
@@ -1142,7 +1189,8 @@ async function tryApproveEntityFieldChangeRun(
     'confirmed',
     'entity_field_change — applying',
     `Field change confirmed: ${fieldList}`,
-    {}
+    {},
+    reviewer
   );
 
   try {
@@ -1165,7 +1213,8 @@ async function tryApproveEntityFieldChangeRun(
       'completed',
       allStale ? 'entity_field_change — skipped (stale)' : 'entity_field_change — completed',
       summary,
-      { output: result as unknown as Record<string, unknown> }
+      { output: result as unknown as Record<string, unknown> },
+      reviewer
     );
     return {
       action: 'approve',
@@ -1188,7 +1237,8 @@ async function tryApproveEntityFieldChangeRun(
       'failed',
       'entity_field_change — failed',
       `Field change failed: ${errorMessage}`,
-      { error_message: errorMessage }
+      { error_message: errorMessage },
+      reviewer
     );
     return { error: `Failed to apply field change: ${errorMessage}` };
   }
@@ -1211,13 +1261,15 @@ async function tryRejectEntityFieldChangeRun(
   );
   if (!claimed) return null;
   const fieldList = Object.keys(claimed.proposal.fields).join(', ');
+  const reviewer = await resolveReviewer(ctx);
   const eventId = await supersedeActionEvent(
     args.run_id,
     ctx.organizationId,
     'rejected',
     'entity_field_change — rejected',
     `Field change rejected: ${fieldList}${args.reason ? ` — ${args.reason}` : ''}`,
-    { reason }
+    { reason },
+    reviewer
   );
   return { action: 'reject', rejected: true, run_id: args.run_id, event_id: eventId };
 }
@@ -1305,13 +1357,15 @@ async function handleApprove(
     action_input: Record<string, unknown> | null;
   };
 
+  const reviewer = await resolveReviewer(ctx);
   const eventId = await supersedeActionEvent(
     args.run_id,
     ctx.organizationId,
     'confirmed',
     `${run.action_key} — executing`,
     `Operation confirmed: ${run.action_key} — waiting for execution`,
-    args.input ? { approved_input: args.input } : {}
+    args.input ? { approved_input: args.input } : {},
+    reviewer
   );
 
   if (resolved.operation.backend === 'local_action') {
@@ -1341,7 +1395,8 @@ async function handleApprove(
       'completed',
       `${run.action_key} — completed`,
       `Operation completed: ${run.action_key}`,
-      { output: result.output }
+      { output: result.output },
+      reviewer
     );
     return {
       action: 'approve',
@@ -1358,7 +1413,8 @@ async function handleApprove(
     'failed',
     `${run.action_key} — failed`,
     `Operation failed: ${run.action_key}${result.error_message ? ` — ${result.error_message}` : ''}`,
-    { error_message: result.error_message }
+    { error_message: result.error_message },
+    reviewer
   );
   return {
     action: 'approve',
@@ -1381,6 +1437,7 @@ async function handleReject(
 
   const sql = getDb();
   const reason = args.reason ?? 'Rejected by user';
+  const reviewer = await resolveReviewer(ctx);
 
   // Builder-gate run? Cancel it without touching the agents table.
   const claimedBuilder = await claimManageAgentsRun(
@@ -1396,7 +1453,8 @@ async function handleReject(
       'rejected',
       `manage_agents.${claimedBuilder.proposal.action} — rejected`,
       `Builder action rejected: ${claimedBuilder.proposal.action} ${claimedBuilder.proposal.agent_id}${args.reason ? ` — ${args.reason}` : ''}`,
-      { reason }
+      { reason },
+      reviewer
     );
     return { action: 'reject', rejected: true, run_id: args.run_id, event_id: eventId };
   }
@@ -1425,7 +1483,8 @@ async function handleReject(
     'rejected',
     `${operationKey} — rejected`,
     `Operation rejected: ${operationKey}${args.reason ? ` — ${args.reason}` : ''}`,
-    { reason }
+    { reason },
+    reviewer
   );
 
   return { action: 'reject', rejected: true, run_id: args.run_id, event_id: eventId };

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -33,7 +33,7 @@ import { insertEvent } from '../../utils/insert-event';
 import logger from '../../utils/logger';
 import { createConnectorOperationRun } from '../../runs/queue-service';
 import { dispatchChromeActionToExtension } from '../../worker-api/dispatch-chrome-action';
-import { buildEventPermalink } from '../../utils/url-builder';
+import { buildRunPermalink } from '../../utils/url-builder';
 import { trackWatcherReaction } from '../../utils/watcher-reactions';
 import type { ToolContext } from '../registry';
 import { getOrgUrlContext } from '../view-urls';
@@ -704,8 +704,12 @@ async function handleExecute(
     });
     const eventId = Number(event.id);
     const { ownerSlug: orgSlug, baseUrl } = await getOrgUrlContext(ctx);
+    // Run-scoped, not event-scoped: the pending event is superseded on
+    // approve→complete and drops out of the live view, but a run_ids permalink
+    // reads the whole chain and stays valid across the lifecycle. (The read-side
+    // content_ids resolver also covers already-minted event-scoped links.)
     const approvalUrl =
-      orgSlug && baseUrl ? buildEventPermalink(orgSlug, eventId, baseUrl) : undefined;
+      orgSlug && baseUrl ? buildRunPermalink(orgSlug, runId, baseUrl) : undefined;
 
     notifyActionApprovalNeeded({
       orgId: ctx.organizationId,

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -73,6 +73,7 @@ function buildContentQuery(opts: {
       ${a}.interaction_output,
       ${a}.interaction_error,
       ${a}.supersedes_event_id,
+      ${a}.run_id,
       oc.client_name,
       -- classifications was sourced from latest_event_classifications, a denormalized cache that was
       -- never populated (no writer) — so this field has always been '{}'. Kept empty for response-shape

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -4,7 +4,7 @@
  * stats aggregation).
  */
 
-import { type DbClient, pgTextArray } from '../../db/client';
+import { type DbClient, pgBigintArray, pgTextArray } from '../../db/client';
 import {
   buildConnectionVisibilityClause,
   buildEntityLinkUnion,
@@ -35,12 +35,14 @@ interface ListPageResult {
 function buildContentQuery(opts: {
   table: string;
   alias: string;
+  /** Extra JOIN clause(s) spliced in before the fixed connection/oauth joins. */
+  join?: string;
   where: string;
   orderBy: string;
   limit: number;
   offset: number;
 }): string {
-  const { table, alias: a, where, orderBy, limit, offset } = opts;
+  const { table, alias: a, join = '', where, orderBy, limit, offset } = opts;
   return `
     SELECT
       ${a}.id,
@@ -77,6 +79,7 @@ function buildContentQuery(opts: {
       -- stability now that the dead table is dropped.
       '{}'::jsonb as classifications
     FROM ${table} ${a}
+    ${join}
     LEFT JOIN connections c ON c.id = ${a}.connection_id
     LEFT JOIN oauth_clients oc ON oc.id = ${a}.client_id
     WHERE ${where}
@@ -87,8 +90,68 @@ function buildContentQuery(opts: {
 }
 
 /**
- * Direct query by content IDs — simple and fast. Bypasses other filters
- * except entity_id. Caller dispatches here only when content_ids is non-empty.
+ * Chain-resolution CTE. Expands each requested content id to its full supersede
+ * lineage so a permalink minted at pending-approval time (its id is later
+ * superseded and hidden from `current_event_records`) still resolves — and
+ * shows the whole pending→executing→completed history, not just the head.
+ *
+ * Reads from `events` (not the masked view) because superseded rows are the
+ * whole point. Two arms, UNIONed:
+ *  - run arm: operation/approval chains all share one `run_id`, so a single
+ *    indexed lookup returns pending + executing + completed together.
+ *  - walk arm: seeds with `run_id IS NULL` (e.g. an edited note) have no run to
+ *    key on, so we walk the `superseded_by` / `supersedes_event_id` linked list
+ *    out from the seed in both directions. Bounded (chains are 2–3 hops; the
+ *    forward edge is uniquely indexed), so the recursion terminates cheaply.
+ *
+ * `$1` must be a bigint[] bind param of the requested ids. Emits a CTE named
+ * `resolved_ids(id, chain_key)` — `id` is an event id in a resolved chain and
+ * `chain_key` is a stable per-chain identifier shared by every row of the same
+ * lineage, so the caller can `COUNT(DISTINCT chain_key)` to count chains (an
+ * atomic unit) rather than expanded rows. The caller filters the final read to
+ * `f.id IN (SELECT id FROM resolved_ids)`.
+ */
+const RESOLVED_IDS_CTE = `
+  resolved_ids AS (
+    -- run arm: every row of the seed's run (the common approval/operation case).
+    -- Chain key is the run id, text-prefixed so it can't collide with the walk
+    -- arm's event-id keys.
+    SELECT run_ev.id, 'run:' || seed.run_id AS chain_key
+    FROM events seed
+    JOIN events run_ev ON run_ev.run_id = seed.run_id
+    WHERE seed.id = ANY($1::bigint[]) AND seed.run_id IS NOT NULL
+    UNION
+    -- walk arm: run_id-less chains, transitive closure both directions. Chain
+    -- key is the lineage root (oldest ancestor), which every row in the chain
+    -- shares regardless of which id the caller entered from.
+    SELECT walked.id, 'ev:' || walked.root AS chain_key
+    FROM (
+      WITH RECURSIVE lineage(id, root) AS (
+        -- Seed each run_id-less requested id with its own oldest ancestor as
+        -- the provisional root; MIN() over the component finalizes it below.
+        SELECT s.id, s.id AS root
+        FROM events s
+        WHERE s.id = ANY($1::bigint[]) AND s.run_id IS NULL
+        UNION
+        SELECT nxt.id, LEAST(l.root, nxt.id)
+        FROM lineage l
+        JOIN events cur ON cur.id = l.id
+        JOIN events nxt
+          ON nxt.id = cur.superseded_by        -- forward: newer
+          OR nxt.id = cur.supersedes_event_id  -- backward: older
+      )
+      -- A component can be reached from multiple seeds / hop orders; collapse to
+      -- one row per event with the smallest root so the chain key is stable.
+      SELECT id, MIN(root) AS root FROM lineage GROUP BY id
+    ) walked
+  )
+`;
+
+/**
+ * Direct query by content IDs. Each requested id is expanded to its full
+ * supersede chain (see {@link RESOLVED_IDS_CTE}) so stale permalinks resolve and
+ * the caller sees the pending→completed history. Bypasses other filters except
+ * entity_id. Caller dispatches here only when content_ids is non-empty.
  */
 export async function fetchByContentIds(opts: {
   args: GetContentArgs;
@@ -106,9 +169,11 @@ export async function fetchByContentIds(opts: {
 
   logger.info(`[get_content] Filtering by ${contentIdsArray.length} specific content IDs`);
 
-  // Build parameterized IN clause for content IDs
-  const idPlaceholders = contentIdsArray.map((_, i) => `$${i + 1}`).join(',');
-  const queryParams: Array<string | number | null> = [...contentIdsArray];
+  // $1 is the requested-id array, consumed by RESOLVED_IDS_CTE. All later
+  // filters bind from $2 onward and read the expanded chain set, so org scope,
+  // entity link, and visibility apply to every resolved row, not just the seed.
+  const queryParams: Array<string | number | null> = [pgBigintArray(contentIdsArray)];
+  const idFilter = 'f.id IN (SELECT id FROM resolved_ids)';
 
   queryParams.push(organizationId);
   const orgScope = `AND f.organization_id = $${queryParams.length}::text`;
@@ -140,27 +205,40 @@ export async function fetchByContentIds(opts: {
   });
   queryParams.push(...visibility.params);
 
-  // Query content by IDs with classifications
+  const where = `${idFilter} ${orgScope}${entityFilter} ${visibility.sql}`;
+
+  // Read the full chain from `events` (not the masked view — superseded rows are
+  // what we're here for). The list query JOINs resolved_ids so it can order by
+  // the resolver's stable `chain_key`: lineages never interleave, and within a
+  // chain rows read pending→completed top-to-bottom by occurred_at.
   const result = await sql.unsafe(
-    buildContentQuery({
-      table: 'current_event_records',
+    `
+    WITH ${RESOLVED_IDS_CTE}
+    ${buildContentQuery({
+      table: 'events',
       alias: 'f',
-      where: `f.id IN (${idPlaceholders}) ${orgScope}${entityFilter} ${visibility.sql}`,
-      orderBy: 'f.occurred_at DESC',
+      join: 'JOIN resolved_ids ri ON ri.id = f.id',
+      where,
+      orderBy: 'ri.chain_key ASC, f.occurred_at ASC, f.id ASC',
       limit,
       offset,
-    }),
+    })}
+  `,
     queryParams
   );
 
+  // Count distinct chains via the resolver's stable `chain_key`, not expanded
+  // rows: a chain is an atomic unit and paging must never split it. Joining
+  // resolved_ids also re-applies the same org/entity/visibility WHERE to the
+  // counted set, so it can't drift from the list above.
   const countResult = await sql.unsafe(
     `
-    SELECT COUNT(*) as total
-    FROM current_event_records f
-    WHERE f.id IN (${idPlaceholders})
-      ${orgScope}
-      ${entityFilter}
-      ${visibility.sql}
+    WITH ${RESOLVED_IDS_CTE}
+    SELECT COUNT(DISTINCT ri.chain_key) as total
+    FROM events f
+    JOIN resolved_ids ri ON ri.id = f.id
+    LEFT JOIN connections c ON c.id = f.connection_id
+    WHERE ${where}
   `,
     queryParams
   );

--- a/packages/server/src/tools/get_content/render.ts
+++ b/packages/server/src/tools/get_content/render.ts
@@ -172,6 +172,7 @@ export async function buildContentItems(opts: {
         : undefined,
       interaction_error: f.interaction_error ?? undefined,
       supersedes_event_id: f.supersedes_event_id == null ? null : Number(f.supersedes_event_id),
+      run_id: f.run_id == null ? null : Number(f.run_id),
       parent_context:
         parentContextMap.get(f.origin_parent_id as string) ??
         (f.parent_context as ContentItem['parent_context']) ??

--- a/packages/server/src/tools/get_content/render.ts
+++ b/packages/server/src/tools/get_content/render.ts
@@ -8,7 +8,7 @@ import type { ContentItem } from '@lobu/connector-sdk';
 import { parseJsonObject } from '@lobu/core';
 import { type DbClient, parsePgNumberArray, pgTextArray } from '../../db/client';
 import logger from '../../utils/logger';
-import { buildEventPermalink } from '../../utils/url-builder';
+import { buildResourcePermalink } from '../../utils/url-builder';
 import { resolveEntityRender } from '../../utils/default-entity-template';
 import { resolveEventKindDefinition } from '../../utils/event-kind-validation';
 import type { ContentRow } from './types';
@@ -177,7 +177,7 @@ export async function buildContentItems(opts: {
         (f.parent_context as ContentItem['parent_context']) ??
         null,
       root_context: f.root_context as ContentItem['root_context'],
-      permalink: ownerSlug ? buildEventPermalink(ownerSlug, f.id, baseUrl) : null,
+      permalink: buildResourcePermalink(ownerSlug, { kind: 'event', eventId: f.id }, baseUrl) ?? null,
     };
   });
 

--- a/packages/server/src/tools/get_content/types.ts
+++ b/packages/server/src/tools/get_content/types.ts
@@ -148,6 +148,7 @@ export interface ContentRow {
   interaction_output?: Record<string, unknown> | null;
   interaction_error?: string | null;
   supersedes_event_id?: number | null;
+  run_id?: number | string | null;
   parent_context?: Record<string, unknown> | null;
   root_context?: Record<string, unknown> | null;
   client_name?: string | null;

--- a/packages/server/src/tools/view-urls.ts
+++ b/packages/server/src/tools/view-urls.ts
@@ -8,7 +8,7 @@
 
 import {
   buildEntityUrl,
-  buildEventPermalink,
+  buildResourcePermalink,
   type EntityInfo,
   getOrganizationSlug,
   getPublicWebUrl,
@@ -64,6 +64,5 @@ export async function buildEventViewUrl(
   eventId: number
 ): Promise<string | undefined> {
   const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
-  if (!ownerSlug) return undefined;
-  return buildEventPermalink(ownerSlug, eventId, baseUrl);
+  return buildResourcePermalink(ownerSlug, { kind: 'event', eventId }, baseUrl);
 }

--- a/packages/server/src/utils/__tests__/url-builder.test.ts
+++ b/packages/server/src/utils/__tests__/url-builder.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { buildEntityUrl, buildRunPermalink, getPublicWebUrl } from '../url-builder';
+import { buildEntityUrl, buildResourcePermalink, getPublicWebUrl } from '../url-builder';
 import {
   HOSTED_UI_FALLBACK_ORIGIN,
   __resetPublicOriginCachesForTests,
@@ -88,15 +88,33 @@ describe('buildEntityUrl', () => {
   });
 });
 
-describe('buildRunPermalink', () => {
-  it('scopes the memory permalink to run_ids (survives the supersede chain)', () => {
-    const url = buildRunPermalink('acme', 536620, 'https://app.lobu.com');
-    expect(url).toBe('https://app.lobu.com/acme/memory?run_ids=536620');
+describe('buildResourcePermalink', () => {
+  it('run kind → ?run_ids (survives the supersede chain by construction)', () => {
+    expect(
+      buildResourcePermalink('acme', { kind: 'run', runId: 536620 }, 'https://app.lobu.com')
+    ).toBe('https://app.lobu.com/acme/memory?run_ids=536620');
+  });
+
+  it('event kind → ?content_ids (chain-resolved on read)', () => {
+    expect(
+      buildResourcePermalink('acme', { kind: 'event', eventId: 4309390 }, 'https://app.lobu.com')
+    ).toBe('https://app.lobu.com/acme/memory?content_ids=4309390');
+  });
+
+  it('feed kind → ?feed_ids (all activity in a channel)', () => {
+    expect(
+      buildResourcePermalink('acme', { kind: 'feed', feedId: 42 }, 'https://app.lobu.com')
+    ).toBe('https://app.lobu.com/acme/memory?feed_ids=42');
   });
 
   it('builds a relative URL when no base is provided', () => {
-    expect(buildRunPermalink('acme', 536620, undefined)).toBe(
+    expect(buildResourcePermalink('acme', { kind: 'run', runId: 536620 })).toBe(
       '/acme/memory?run_ids=536620'
     );
+  });
+
+  it('returns undefined when the org slug is missing (no usable link)', () => {
+    expect(buildResourcePermalink(null, { kind: 'run', runId: 1 })).toBeUndefined();
+    expect(buildResourcePermalink(undefined, { kind: 'event', eventId: 1 })).toBeUndefined();
   });
 });

--- a/packages/server/src/utils/__tests__/url-builder.test.ts
+++ b/packages/server/src/utils/__tests__/url-builder.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { buildEntityUrl, getPublicWebUrl } from '../url-builder';
+import { buildEntityUrl, buildRunPermalink, getPublicWebUrl } from '../url-builder';
 import {
   HOSTED_UI_FALLBACK_ORIGIN,
   __resetPublicOriginCachesForTests,
@@ -85,5 +85,18 @@ describe('buildEntityUrl', () => {
       undefined
     );
     expect(url).toBe('/acme/topic/test-topic');
+  });
+});
+
+describe('buildRunPermalink', () => {
+  it('scopes the memory permalink to run_ids (survives the supersede chain)', () => {
+    const url = buildRunPermalink('acme', 536620, 'https://app.lobu.com');
+    expect(url).toBe('https://app.lobu.com/acme/memory?run_ids=536620');
+  });
+
+  it('builds a relative URL when no base is provided', () => {
+    expect(buildRunPermalink('acme', 536620, undefined)).toBe(
+      '/acme/memory?run_ids=536620'
+    );
   });
 });

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -102,6 +102,24 @@ export function buildEventPermalink(ownerSlug: string, eventId: number, baseUrl?
 }
 
 /**
+ * Build permalink URL scoped to a run.
+ * Pattern: /{ownerSlug}/memory?run_ids={runId}
+ *
+ * Prefer this over {@link buildEventPermalink} when the link's identity is the
+ * run, not a single event snapshot — e.g. an operation's approval_url. A run's
+ * events form a supersede chain (pending→executing→completed) that shares one
+ * run_id, and run-scoped reads were never masked by `superseded_by IS NULL`, so
+ * this URL stays valid across the whole lifecycle by construction — no read-side
+ * chain resolution required.
+ */
+export function buildRunPermalink(ownerSlug: string, runId: number, baseUrl?: string): string {
+  return withBaseUrl(
+    normalizeBaseUrl(baseUrl),
+    `/${ownerSlug}/memory?run_ids=${runId}`
+  );
+}
+
+/**
  * Build URL to view entity content
  */
 export function buildContentUrl(

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -91,31 +91,54 @@ export function buildConnectionsUrl(
 }
 
 /**
- * Build permalink URL for a single knowledge item
- * Pattern: /{ownerSlug}/memory?content_ids={eventId}
+ * A slice of the memory/events log to permalink into. One discriminated union
+ * so every caller (approval_url, notification resourceUrl, agent output) picks a
+ * *kind* and the URL shape is decided in exactly one place — no caller
+ * hand-assembles `?content_ids=`/`?run_ids=`/`?feed_ids=` strings.
+ *
+ * Which kind to use:
+ *  - `run`   — the link's identity is one execution (an operation approval, a
+ *    watcher/scheduled run). Survives the supersede chain by construction: a
+ *    run's events share one run_id and run-scoped reads were never masked by
+ *    `superseded_by IS NULL`.
+ *  - `event` — a point in the log (a specific card). Read-side chain resolution
+ *    (get_content) resolves a superseded id to its full lineage, so a frozen
+ *    event permalink still lands even after it's superseded.
+ *  - `feed`  — a channel / conversational stream (all activity in #leads).
  */
-export function buildEventPermalink(ownerSlug: string, eventId: number, baseUrl?: string): string {
-  return withBaseUrl(
-    normalizeBaseUrl(baseUrl),
-    `/${ownerSlug}/memory?content_ids=${eventId}`
-  );
+export type MemoryResource =
+  | { kind: 'run'; runId: number }
+  | { kind: 'event'; eventId: number }
+  | { kind: 'feed'; feedId: number };
+
+/** The `?param=value` query for a {@link MemoryResource}. */
+function memoryResourceQuery(resource: MemoryResource): string {
+  switch (resource.kind) {
+    case 'run':
+      return `run_ids=${resource.runId}`;
+    case 'event':
+      return `content_ids=${resource.eventId}`;
+    case 'feed':
+      return `feed_ids=${resource.feedId}`;
+  }
 }
 
 /**
- * Build permalink URL scoped to a run.
- * Pattern: /{ownerSlug}/memory?run_ids={runId}
+ * Build a permalink into the memory/events log for a {@link MemoryResource}.
+ * Pattern: /{ownerSlug}/memory?{run_ids|content_ids|feed_ids}={id}
  *
- * Prefer this over {@link buildEventPermalink} when the link's identity is the
- * run, not a single event snapshot — e.g. an operation's approval_url. A run's
- * events form a supersede chain (pending→executing→completed) that shares one
- * run_id, and run-scoped reads were never masked by `superseded_by IS NULL`, so
- * this URL stays valid across the whole lifecycle by construction — no read-side
- * chain resolution required.
+ * This is the ONE place a memory permalink is assembled. `ownerSlug` empty →
+ * returns undefined (no org context, can't build a usable link).
  */
-export function buildRunPermalink(ownerSlug: string, runId: number, baseUrl?: string): string {
+export function buildResourcePermalink(
+  ownerSlug: string | null | undefined,
+  resource: MemoryResource,
+  baseUrl?: string
+): string | undefined {
+  if (!ownerSlug) return undefined;
   return withBaseUrl(
     normalizeBaseUrl(baseUrl),
-    `/${ownerSlug}/memory?run_ids=${runId}`
+    `/${ownerSlug}/memory?${memoryResourceQuery(resource)}`
   );
 }
 


### PR DESCRIPTION
## What

Three related changes to the operation-approval permalink + timeline UX:

1. **Permalink chain resolve** (original scope) — `content_ids` resolves to the full supersede chain (pending → executing → completed) so an approval permalink stays valid after the run advances. Run-scoped `approval_url` / notification links via one shared `buildResourcePermalink` resolver.

2. **Run-aware timeline** — collapse a run's supersede chain to its head, then fold same-run *satellite* events (the "needs approval" notification) into that node's history instead of rendering them as duplicate top-level rows. The history expander now shows the run identity ("Run #N · N earlier steps"). Requires exposing `events.run_id` through the content query → `ContentItem.run_id`.

3. **Approval attribution** — stamp *who* decided an approval: `created_by` FK plus `reviewed_by_id` / `reviewed_by_name` in metadata, across every approve/reject path (connector ops, `manage_agents`, `entity_field_change`). The reviewer is inherited down later system transitions (worker-reported completed/failed) so the whole run keeps its approver. Rendered as "Approved by X" / "Rejected by X" + reason on the approval card.

## Tests

- `approval-reviewer-attribution.test.ts` (new, 4 tests) — approve/reject stamp reviewer + reason; completed *inherits* reviewer; no-reviewer stays null. Red→green verified.
- `navigation.test.ts` — added run-fold + run_id-propagation cases (12 total). Red→green verified (disabling the fold fails the dup test).
- Existing green: `get-content-chain-resolve` (4), `agent-history-routes` (6), `events-tab` (17).

## Review note

`make review`'s full gate could not produce a clean pass in this environment for two reasons unrelated to these changes:
- **Cross-worktree contamination** — a parallel worktree (`events-filter-condense`) rebuilding its `connector-sdk/dist` mid-run leaked a half-written module (`validateEntityMetrics` missing) into the shared bun resolution, cascading into module-load + knock-on integration failures.
- **AI-reviewer 429** — the Codex verdict step hit its usage limit.

Every flagged suite passes **in isolation** in this worktree: connector-sdk 146/0, cli 579/0, agent-history-routes 6/0, channel-streaming-feeds 10/10, plus the new suites above. `tsc --noEmit` clean on server + owletto.
