### PR TITLE
fix(slack): post model routing fallback as text

### DIFF
--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -562,6 +562,7 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
       tryHandleSlashText?: (...args: any[]) => Promise<boolean>;
       tryHandle?: (...args: any[]) => Promise<boolean>;
     };
+    providerCatalog?: unknown;
   }) {
     const state = new InMemoryStateAdapter();
     const conversationState = new ConversationStateStore(state);
@@ -596,6 +597,7 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
       getAgentSettingsStore: () => undefined,
       getDeclaredAgentRegistry: () => undefined,
       getQueueProducer: () => ({ enqueueMessage }),
+      getProviderCatalogService: () => opts.providerCatalog,
     } as any;
     const manager = {
       has: () => true,
@@ -659,6 +661,31 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
     expect(thread.post).toHaveBeenCalledTimes(1);
     expect(String(thread.post.mock.calls[0]?.[0])).toContain("/lobu link");
     expect(enqueueMessage).not.toHaveBeenCalled();
+  });
+
+  test("unroutable model provider posts a plain Slack text fallback and skips enqueue", async () => {
+    const providerCatalog = {
+      getInstalledModules: mock(async () => []),
+      findProviderForModel: mock(async () => null),
+    };
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      binding: {
+        agentId: "lobu-builder",
+        organizationId: "org-bound",
+        model: "z-ai/glm-5.2",
+      },
+      providerCatalog,
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(thread, makeMessage(), "mention");
+
+    expect(enqueueMessage).not.toHaveBeenCalled();
+    expect(thread.post).toHaveBeenCalledTimes(1);
+    const posted = thread.post.mock.calls[0]?.[0];
+    expect(typeof posted).toBe("string");
+    expect(posted).toContain("selected model (z-ai/glm-5.2)");
+    expect(posted).toContain("/api/proxy/z-ai/a/lobu-builder");
   });
 
   test("cross-org: routes the worker turn under the BOUND agent's org, not the connection's", async () => {

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -953,7 +953,7 @@ export class MessageHandlerBridge {
           { traceId, agentId, organizationId, model: agentOptions.model },
           "Rejecting inbound message before enqueue because model provider is not routable"
         );
-        await thread.post({ text: modelProviderError });
+        await thread.post(modelProviderError);
         return;
       }
 


### PR DESCRIPTION
## Summary
- post the unroutable-model friendly fallback as plain text through Chat SDK
- add regression coverage that the Slack fallback is a string and enqueue is skipped

## Test
- bun test packages/server/src/gateway/__tests__/message-handler-bridge.test.ts

## Production evidence
Logs showed the new guard rejecting the message before enqueue, but `thread.post({ text })` reached Slack as a payload with no top-level text and failed with `no_text`. Passing a string makes Chat SDK/Slack emit `chat.postMessage({ text })`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785939667&installation_id=136316292&pr_number=1765&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1765&signature=7a2fd2d52d884e558a57926b272aac90e22e0428c1171a7aeb5a7b724f87a216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack fallback behavior when a selected model can’t be routed: users now see a clear plain-text error message in the thread, including the chosen model and proxy link.
  * Prevented unnecessary processing for unroutable messages, so invalid model/provider selections no longer enqueue a worker turn.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->