### PR TITLE
feat(server): watcher event filter + owletto memory/events drill-downs

### DIFF
--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -280,6 +280,9 @@ async function getContentImpl(
         ...(args.engagement_min !== undefined && { engagement_min: args.engagement_min }),
         ...(args.engagement_max !== undefined && { engagement_max: args.engagement_max }),
         ...(args.window_id !== undefined && { window_id: args.window_id }),
+        ...(args.analyzed_by_watcher_id !== undefined && {
+          analyzed_by_watcher_id: args.analyzed_by_watcher_id,
+        }),
         ...(args.exclude_watcher_id !== undefined && {
           exclude_watcher_id: args.exclude_watcher_id,
         }),
@@ -311,8 +314,10 @@ async function getContentImpl(
         connection_ids: effectiveConnectionIds,
         feed_ids: args.feed_ids,
         run_ids: args.run_ids,
+        ...(args.agent_id && { agent_id: args.agent_id }),
         visibility_scope: visibilityScope,
         window_id: args.window_id,
+        analyzed_by_watcher_id: args.analyzed_by_watcher_id,
         exclude_watcher_id: args.exclude_watcher_id,
         platform: effectivePlatform,
         since: args.since,

--- a/packages/server/src/tools/get_content/query.ts
+++ b/packages/server/src/tools/get_content/query.ts
@@ -357,6 +357,13 @@ export async function fetchIncludeSuperseded(opts: {
     queryParams.push(args.window_id);
     paramIndex += 1;
   }
+  if (args.analyzed_by_watcher_id !== undefined) {
+    conditions.push(
+      `EXISTS (SELECT 1 FROM watcher_window_events iwf WHERE iwf.event_id = e.id AND iwf.watcher_id = $${paramIndex})`
+    );
+    queryParams.push(args.analyzed_by_watcher_id);
+    paramIndex += 1;
+  }
   if (args.exclude_watcher_id !== undefined) {
     conditions.push(
       `NOT EXISTS (SELECT 1 FROM watcher_window_events exc_iwe WHERE exc_iwe.event_id = e.id AND exc_iwe.watcher_id = $${paramIndex})`
@@ -372,6 +379,11 @@ export async function fetchIncludeSuperseded(opts: {
   if (args.engagement_max !== undefined) {
     conditions.push(`e.score <= $${paramIndex}`);
     queryParams.push(args.engagement_max);
+    paramIndex += 1;
+  }
+  if (args.agent_id) {
+    conditions.push(`e.metadata->>'agent_id' = $${paramIndex}`);
+    queryParams.push(args.agent_id);
     paramIndex += 1;
   }
   if (args.semantic_type) {
@@ -519,6 +531,22 @@ export async function fetchClassificationStats(opts: {
     windowJoinSql = `JOIN watcher_window_events iwf ON iwf.event_id = f.id AND iwf.window_id = $${paramIndex}`;
     params.push(args.window_id);
     paramIndex++;
+  }
+  if (args.analyzed_by_watcher_id !== undefined) {
+    conditions.push(
+      `EXISTS (SELECT 1 FROM watcher_window_events iwf WHERE iwf.event_id = f.id AND iwf.watcher_id = $${paramIndex++})`
+    );
+    params.push(args.analyzed_by_watcher_id);
+  }
+  if (args.exclude_watcher_id !== undefined) {
+    conditions.push(
+      `NOT EXISTS (SELECT 1 FROM watcher_window_events exc_iwe WHERE exc_iwe.event_id = f.id AND exc_iwe.watcher_id = $${paramIndex++})`
+    );
+    params.push(args.exclude_watcher_id);
+  }
+  if (args.agent_id) {
+    conditions.push(`f.metadata->>'agent_id' = $${paramIndex++}`);
+    params.push(args.agent_id);
   }
 
   // Visibility: events from connections the caller can't see must not

--- a/packages/server/src/tools/get_content/schema.ts
+++ b/packages/server/src/tools/get_content/schema.ts
@@ -48,6 +48,12 @@ export const GetContentSchema = Type.Object({
       description: 'Run IDs to filter by (events.run_id — the run that produced the event)',
     })
   ),
+  agent_id: Type.Optional(
+    Type.String({
+      description:
+        'Limit results to memory written by this agent. Filters events where metadata.agent_id matches.',
+    })
+  ),
   platforms: Type.Optional(
     Type.Array(Type.String(), {
       description: 'Platform types to filter by (reddit, trustpilot, etc.)',
@@ -56,6 +62,12 @@ export const GetContentSchema = Type.Object({
   window_id: Type.Optional(
     Type.Number({
       description: 'Watcher window ID to filter by (shows only content analyzed in this window)',
+    })
+  ),
+  analyzed_by_watcher_id: Type.Optional(
+    Type.Number({
+      description:
+        'Limit results to events this watcher has analyzed (any window). Distinct from watcher_id, which enters watcher read mode.',
     })
   ),
   since: Type.Optional(

--- a/packages/server/src/utils/content-search/list-path.ts
+++ b/packages/server/src/utils/content-search/list-path.ts
@@ -297,6 +297,12 @@ export async function listContentInternal(
         `EXISTS (SELECT 1 FROM watcher_window_events iwf WHERE iwf.event_id = f.id AND iwf.window_id = $${baseParams.length})`
       );
     }
+    if (options.analyzed_by_watcher_id != null) {
+      baseParams.push(options.analyzed_by_watcher_id);
+      baseConditions.push(
+        `EXISTS (SELECT 1 FROM watcher_window_events iwf WHERE iwf.event_id = f.id AND iwf.watcher_id = $${baseParams.length})`
+      );
+    }
     if (options.engagement_min != null) {
       baseParams.push(options.engagement_min);
       baseConditions.push(`f.score >= $${baseParams.length}`);

--- a/packages/server/src/utils/content-search/types.ts
+++ b/packages/server/src/utils/content-search/types.ts
@@ -26,6 +26,8 @@ export interface ContentSearchOptions {
    */
   visibility_scope?: { organizationId: string; userId: string | null };
   window_id?: number; // Filter by watcher window ID
+  /** Events linked in any window for this watcher (`watcher_window_events`). */
+  analyzed_by_watcher_id?: number;
   exclude_watcher_id?: number; // Exclude content already in any window for this watcher
   platform?: string;
   since?: string; // ISO date or relative ("7d", "30d")


### PR DESCRIPTION
## Summary
- Add `analyzed_by_watcher_id` to `get_content` so Events can scope to a watcher window linkage
- Bump owletto to the matching memory/events UI work (agent rail, behavior drill-downs, filter banners)

Depends on: https://github.com/lobu-ai/owletto/pull/458

## Test plan
- [x] `bun run typecheck`
- [x] `make build-packages`
- [ ] Manual: drill from agent watch behavior → Events shows watcher-scoped results

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785945801&installation_id=136316292&pr_number=1768&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1768&signature=d6502038610a7f1c2a2621c14508b00f47e4905f89313de1cb4f0e25ce6584d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new optional filters to narrow content by `agent_id` and by `analyzed_by_watcher_id` (events linked to a specified watcher across any window).
  * Updated content retrieval and search/list results to honor these filters.

* **Bug Fixes**
  * Improved consistency so watcher-analysis and agent filters are applied uniformly across different ranking and search paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->