### PR TITLE
fix(providers): scope worker agent settings by org

### DIFF
--- a/packages/server/src/gateway/__tests__/agent-settings-store.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-settings-store.test.ts
@@ -27,6 +27,28 @@ describe("AgentSettingsStore", () => {
   }
 
   describe("CRUD basics", () => {
+    test("getSettings uses explicit organization context when agent ids collide", async () => {
+      const otherOrg = `${ORG_ID}-other`;
+      await orgContext.run({ organizationId: ORG_ID }, async () => {
+        await seedAgentRow("shared-agent", { organizationId: ORG_ID });
+        await store.saveSettings("shared-agent", {
+          defaultModel: "openai/gpt-4o-mini",
+        });
+      });
+      await orgContext.run({ organizationId: otherOrg }, async () => {
+        await seedAgentRow("shared-agent", { organizationId: otherOrg });
+        await store.saveSettings("shared-agent", {
+          defaultModel: "z-ai/glm-5.2",
+        });
+      });
+
+      const settings = await store.getSettings("shared-agent", {
+        organizationId: ORG_ID,
+      });
+
+      expect(settings?.defaultModel).toBe("openai/gpt-4o-mini");
+    });
+
     test("saveSettings stores and getSettings retrieves", async () => {
       await withOrg(async () => {
         await seedAgentRow("agent-1", { organizationId: ORG_ID });

--- a/packages/server/src/gateway/auth/settings/agent-settings-store.ts
+++ b/packages/server/src/gateway/auth/settings/agent-settings-store.ts
@@ -5,6 +5,7 @@ import {
   type AuthProfile,
   createLogger,
 } from "@lobu/core";
+import { orgContext } from "../../../lobu/stores/org-context.js";
 import type { DeclaredAgentRegistry } from "../../services/declared-agent-registry.js";
 
 // Re-export so existing imports from this module keep working.
@@ -69,10 +70,18 @@ export class AgentSettingsStore {
     this.declaredAgents = registry;
   }
 
-  async getSettings(agentId: string): Promise<AgentSettings | null> {
+  async getSettings(
+    agentId: string,
+    context?: { organizationId?: string }
+  ): Promise<AgentSettings | null> {
     const declared = this.declaredAgents?.get(agentId);
     if (declared) {
       return declared.settings as AgentSettings;
+    }
+    if (context?.organizationId) {
+      return orgContext.run({ organizationId: context.organizationId }, () =>
+        this.configStore.getSettings(agentId)
+      );
     }
     return this.configStore.getSettings(agentId);
   }

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -595,7 +595,9 @@ export class WorkerGateway {
       // Resolve dynamic provider configuration
       const agentSettings =
         this.agentSettingsStore && agentId
-          ? await this.agentSettingsStore.getSettings(agentId)
+          ? await this.agentSettingsStore.getSettings(agentId, {
+              organizationId: auth.tokenData.organizationId,
+            })
           : null;
       const providerConfig = await this.resolveProviderConfig(
         agentId || "",
@@ -616,7 +618,9 @@ export class WorkerGateway {
       if (this.agentSettingsStore && agentId) {
         try {
           const settings =
-            await this.agentSettingsStore.getSettings(agentId);
+            await this.agentSettingsStore.getSettings(agentId, {
+              organizationId: auth.tokenData.organizationId,
+            });
           const skills = settings?.skillsConfig?.skills || [];
           skillsConfig = skills
             .filter((s) => s.enabled && s.content)
@@ -910,7 +914,7 @@ export class WorkerGateway {
     for (const provider of effectiveProviders) {
       if (
         provider.hasSystemKey() ||
-        (await provider.hasCredentials(agentId, { organizationId }))
+        (await provider.hasCredentials(agentId, { organizationId, userId }))
       ) {
         const credVar = provider.getCredentialEnvVarName();
         const placeholder = provider.buildCredentialPlaceholder


### PR DESCRIPTION
## Summary\n- scope AgentSettingsStore reads with explicit organization context for worker session context\n- pass org-scoped settings into provider config/skills resolution to avoid duplicate agent IDs selecting another org's model\n- keep provider credential checks user/org-aware for proxy placeholders\n\n## Validation\n- bun test packages/server/src/gateway/__tests__/agent-settings-store.test.ts packages/server/src/gateway/__tests__/secret-proxy.test.ts packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts --timeout 15000\n- make build-packages\n- make review (typecheck passed; unit/integration failures were pre-existing/unrelated: stale connector-sdk dist export from identity-pipeline-migration worktree, Slack/app history integration failures)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785959487&installation_id=136316292&pr_number=1772&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1772&signature=cd6f2451e86df006100ea36f179a0c562b0cd280ea7779f76ffe96c00409c956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->