### PR TITLE
fix(providers): authenticate proxy calls with worker token

### DIFF
--- a/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
@@ -140,6 +140,19 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
     ).toBe(false);
   });
 
+  test("credential placeholder uses signed worker token when available", async () => {
+    const mod = makeModule(false);
+
+    expect(
+      await Promise.resolve(
+        mod.buildCredentialPlaceholder("agent-1", { workerToken: "worker-jwt" })
+      )
+    ).toBe("worker-jwt");
+    expect(await Promise.resolve(mod.buildCredentialPlaceholder("agent-1"))).toBe(
+      "lobu-proxy"
+    );
+  });
+
   test("proxy base URL carries org scope when credential context has organizationId", () => {
     const mod = makeModule(false);
 

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -376,12 +376,16 @@ export abstract class BaseProviderModule
     return resolved?.credential ?? null;
   }
 
-  /** Build a structured placeholder for proxy mode (default: "lobu-proxy"). */
+  /**
+   * Build the proxy-mode credential placeholder. When available, use the signed
+   * worker token so the egress proxy can bind the request to the worker's
+   * agent/org claims instead of resolving org context from a per-org agent id.
+   */
   buildCredentialPlaceholder(
     _agentId: string,
-    _context?: ProviderCredentialContext
+    context?: ProviderCredentialContext
   ): Promise<string> | string {
-    return "lobu-proxy";
+    return context?.workerToken || "lobu-proxy";
   }
 
   /** Override in subclasses to add provider-specific routes. */

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -918,7 +918,11 @@ export class WorkerGateway {
       ) {
         const credVar = provider.getCredentialEnvVarName();
         const placeholder = provider.buildCredentialPlaceholder
-          ? await provider.buildCredentialPlaceholder(agentId, { workerToken })
+          ? await provider.buildCredentialPlaceholder(agentId, {
+              organizationId,
+              userId,
+              workerToken,
+            })
           : "lobu-proxy";
         credentialPlaceholders[credVar] = placeholder;
       }


### PR DESCRIPTION
## Summary\n- use the signed worker token as the default provider proxy credential placeholder when available\n- pass org/user context into placeholder construction from worker session context\n- add regression coverage for worker-token placeholders\n\n## Validation\n- bun test packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts packages/server/src/gateway/__tests__/secret-proxy.test.ts --timeout 15000\n- make build-packages

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785960718&installation_id=136316292&pr_number=1773&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1773&signature=99da79acedb977aec897fd4a89370038a7585df957f8c1d7a9bfc35c8a1c1ee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential placeholder resolution so proxy-mode values now use the worker token when available, instead of always falling back to the default.
  * Gateway credential handling now carries additional context, helping produce the correct placeholder values during request setup.
* **Tests**
  * Added coverage for placeholder behavior with and without a worker token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->