### PR TITLE
Fix app-pod CPU throttle + OOM: cap worker heap, bump mem, add eventloop/RSS metrics

### DIFF
--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -35,7 +35,13 @@ app:
       memory: 512Mi
     limits:
       cpu: 3000m
-      memory: 2Gi
+      # Prod pods OOM-killed (exit 137) at a 2Gi limit — repeatedly. The parent
+      # Node heap is only ~300MB; the rest of RSS is the in-pod agent-worker
+      # child subprocesses, whose memory counts toward this pod cgroup. Per-child
+      # heap is now capped (LOBU_WORKER_MAX_OLD_SPACE_MB), but the pod still needs
+      # room for several concurrent workers + parent + proxies. 4Gi matches the
+      # connector worker, which does comparable per-run work.
+      memory: 4Gi
 
   # Non-secret environment variables
   env:

--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -26,11 +26,16 @@ app:
 
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
+      # The app pod embeds the orchestrator AND spawns agent-worker subprocesses
+      # in-pod, so this container does far more than serve HTTP — yet it was
+      # capped at 1 core (the connector worker, which does comparable work, gets
+      # 2-4). Under-resourced regardless of the exact stall mechanism; give the
+      # event loop real headroom. Request stays modest so it isn't over-reserved.
+      cpu: 500m
+      memory: 512Mi
     limits:
-      cpu: 1000m
-      memory: 1Gi
+      cpu: 3000m
+      memory: 2Gi
 
   # Non-secret environment variables
   env:

--- a/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
+++ b/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
@@ -188,7 +188,10 @@ describe("DeploymentManager", () => {
         ? process.execPath
         : "node";
       expect(mockSpawn.mock.calls.at(-1)?.[0]).toBe(expectedNode);
+      // The compiled (Node) worker is spawned with a V8 heap cap so a runaway
+      // turn OOMs itself instead of the whole pod (buildWorkerInvocation).
       expect(mockSpawn.mock.calls.at(-1)?.[1]).toEqual([
+        "--max-old-space-size=512",
         "/test/packages/agent-worker/dist/index.js",
       ]);
     });

--- a/packages/server/src/gateway/metrics/prometheus.ts
+++ b/packages/server/src/gateway/metrics/prometheus.ts
@@ -3,9 +3,20 @@
  * Exposes basic gateway metrics in Prometheus text format
  */
 
+import { monitorEventLoopDelay } from "node:perf_hooks";
 import { createLogger } from "@lobu/core";
 
 const logger = createLogger("metrics");
+
+// Event-loop delay histogram, sampled continuously. Exposed as a Prometheus
+// gauge at scrape time so the "worker stopped responding" freeze — a total
+// event-loop stall — shows up on Grafana as a lag spike, instead of only being
+// reconstructable from ping-log gaps after the fact. `instrument.ts` runs a
+// separate monitor that fires a Sentry event on a hard stall; this one feeds the
+// metrics scrape. Zero deps (native perf_hooks). We read `.max` since the last
+// scrape and then reset, so each scrape window reports its own peak lag.
+const eventLoopDelay = monitorEventLoopDelay({ resolution: 20 });
+eventLoopDelay.enable();
 
 interface MetricValue {
   value: number;
@@ -233,6 +244,28 @@ export function getMetricsText(): string {
   );
   lines.push("# TYPE nodejs_external_memory_bytes gauge");
   lines.push(`nodejs_external_memory_bytes ${memUsage.external}`);
+
+  // Resident set size: the whole process's memory. On the app pod this runs far
+  // above heapUsed because agent-worker child subprocesses' memory counts toward
+  // the pod cgroup — the gap between RSS and heap is what OOM-kills the pod.
+  lines.push("# HELP nodejs_rss_bytes Node.js resident set size in bytes");
+  lines.push("# TYPE nodejs_rss_bytes gauge");
+  lines.push(`nodejs_rss_bytes ${memUsage.rss}`);
+
+  // Event-loop lag. `.max` (ns → seconds) is the worst stall since the last
+  // scrape; `.mean` is the baseline. A total freeze surfaces here as a max close
+  // to the scrape interval. Reset after reading so each window reports its peak.
+  lines.push(
+    "# HELP nodejs_eventloop_lag_seconds Event loop delay since last scrape"
+  );
+  lines.push("# TYPE nodejs_eventloop_lag_seconds gauge");
+  // `.mean` is NaN on an empty histogram (no samples since the last reset, e.g. a
+  // scrape immediately after startup). Fall back to 0 so the series stays numeric.
+  const lagMax = Number.isFinite(eventLoopDelay.max) ? eventLoopDelay.max : 0;
+  const lagMean = Number.isFinite(eventLoopDelay.mean) ? eventLoopDelay.mean : 0;
+  lines.push(`nodejs_eventloop_lag_seconds{quantile="max"} ${lagMax / 1e9}`);
+  lines.push(`nodejs_eventloop_lag_seconds{quantile="mean"} ${lagMean / 1e9}`);
+  eventLoopDelay.reset();
 
   return `${lines.join("\n")}\n`;
 }

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -550,12 +550,36 @@ function buildWorkerInvocation(entryPoint: string): {
   command: string;
   args: string[];
 } {
+  // Cap each worker child's V8 heap so one runaway turn (a huge transcript,
+  // pathological allocation) OOMs *itself* with a clean V8 error, instead of
+  // ballooning the process RSS until the pod's cgroup memory limit trips and the
+  // kernel OOM-kills the whole app pod — taking every other in-flight turn with
+  // it. N uncapped children sharing the pod ceiling is how the pod OOM-kills
+  // today; a per-child cap contains the blast radius to the offending turn.
+  // Env-tunable; default sized so a few concurrent workers fit under the pod
+  // limit with headroom for the parent + proxies.
+  const maxOldSpaceMb = Number.parseInt(
+    process.env.LOBU_WORKER_MAX_OLD_SPACE_MB || "512",
+    10
+  );
   const ext = path.extname(entryPoint);
   if (ext === ".js" || ext === ".cjs" || ext === ".mjs") {
-    return { command: getNodeExecutable(), args: [entryPoint] };
+    // Prod path: agent-worker ships as dist/index.js, run under Node, where
+    // --max-old-space-size caps the V8 old-space (a hard, effective heap limit).
+    return {
+      command: getNodeExecutable(),
+      args: [`--max-old-space-size=${maxOldSpaceMb}`, entryPoint],
+    };
   }
 
-  return { command: getBunExecutable(), args: ["run", entryPoint] };
+  // Dev path: a .ts entrypoint runs under Bun (JavaScriptCore, not V8), which
+  // ignores --max-old-space-size. Bun's memory knob is --smol; it trades CPU for
+  // a smaller footprint rather than enforcing a hard ceiling, but it's the
+  // closest available lever and keeps dev behaviour honest (no no-op V8 flag).
+  return {
+    command: getBunExecutable(),
+    args: ["--smol", "run", entryPoint],
+  };
 }
 
 function buildShellCommand(command: string, args: string[]): string {

--- a/packages/server/src/instrument.ts
+++ b/packages/server/src/instrument.ts
@@ -11,6 +11,7 @@
 
 import dotenv from 'dotenv';
 import * as Sentry from '@sentry/node';
+import { monitorEventLoopDelay } from 'node:perf_hooks';
 
 // .env is the single source of truth for secrets. This module reads SENTRY_DSN
 // (and ENVIRONMENT / SENTRY_RELEASE) at load time and is imported before any
@@ -55,4 +56,50 @@ if (dsn) {
     // LOBU-36.)
     integrations: (defaults) => defaults.filter((i) => i.name !== 'NodeSystemError'),
   });
+}
+
+// ── Event-loop stall detector ────────────────────────────────────────────────
+// The "worker stopped responding" incident was a ~70s event-loop freeze that we
+// could only reverse-engineer from gaps in the ping/`/health` logs — there was
+// no instrumentation to TAG the stall with its real duration or cause. This
+// closes that gap: a native perf_hooks delay monitor whose `max` we sample
+// periodically. A hard synchronous block stops the sampling timer too, so the
+// tick that fires AFTER the block sees the accumulated `max` — that's the stall
+// duration. On a stall past the threshold we log loudly and (if Sentry is
+// configured) capture a tagged message so the next freeze names itself instead
+// of being reconstructed from ping gaps. Zero new deps; the timer is unref'd so
+// it never keeps the process alive.
+{
+  const thresholdMs = Number.parseInt(
+    process.env.LOBU_EVENT_LOOP_STALL_MS || '2000',
+    10
+  );
+  const h = monitorEventLoopDelay({ resolution: 20 });
+  h.enable();
+  const timer = setInterval(() => {
+    const maxMs = h.max / 1e6; // nanoseconds → ms
+    if (maxMs >= thresholdMs) {
+      const rounded = Math.round(maxMs);
+      // Loud log so it's visible in pod logs even without Sentry.
+      console.error(
+        `[event-loop] STALL detected: loop blocked ~${rounded}ms ` +
+          `(threshold ${thresholdMs}ms). The loop could not run timers/IO for ` +
+          `this long — a synchronous block, GC pause, or CPU starvation.`
+      );
+      if (dsn) {
+        Sentry.captureMessage(`Event loop stalled ~${rounded}ms`, {
+          level: 'warning',
+          tags: { subsystem: 'event-loop', stall: 'true' },
+          extra: {
+            stallMs: rounded,
+            thresholdMs,
+            p99Ms: Math.round(h.percentile(99) / 1e6),
+            meanMs: Math.round(h.mean / 1e6),
+          },
+        });
+      }
+    }
+    h.reset(); // reset the window so each tick reports only the latest interval
+  }, 1000);
+  timer.unref();
 }


### PR DESCRIPTION
## What & why

The `lobu-builder` (z-ai/glm-5.2) Slack incident — "The worker handling your request stopped responding" — was a **dual resource failure on the app pod**, and this time I confirmed it in **Prometheus/Grafana** (kube-prometheus-stack + Loki have been running 182 days, 30-day retention) instead of reverse-engineering it from ping-log gaps. At the incident window the app pod showed:

- **CPU throttle ratio → 0.998** (99.8% of scheduler periods throttled — near-total starvation)
- **working-set memory pinned at the 2Gi limit**, and the pod **OOMKilled (exit 137)**
- a **gap in `nodejs_heap_size_bytes` scrapes** (~3.5 min) — the freeze itself, visible as missing samples
- **restart counter ticking** at the liveness kill

Two app pods **OOMKilled again while I was investigating** — this is live, not just the old incident.

**Root cause (updated):** each agent turn spawns an **uncapped `node` child in-pod**; the parent Node heap is only ~300MB, so the ~1.7GB gap up to the 2Gi ceiling is the **child subprocesses**, whose memory counts toward the pod cgroup. N uncapped inference children share one pod's CPU *and* memory → CPU throttle + cgroup OOM. A near-OOM Node also does long stop-the-world GC pauses — a plausible mechanism for the total event-loop freeze.

## Changes

1. **`deployment-manager.ts` — cap each worker child's V8 heap.** `--max-old-space-size` (env `LOBU_WORKER_MAX_OLD_SPACE_MB`, default 512) so a runaway turn OOMs *itself* with a clean error instead of cgroup-killing the whole pod and every other in-flight turn. Prod worker is `dist/index.js` (Node → real cap); the dev `.ts` path runs under Bun, which ignores the V8 flag, so it gets `--smol`. Covered by the existing spawn-args test (updated).
2. **`values.yaml` — app memory 2Gi → 4Gi** (2Gi is proven insufficient — actively OOMKilling), matching the connector worker. CPU 1→3 stays.
3. **`prometheus.ts` — `nodejs_eventloop_lag_seconds` (max/mean) + `nodejs_rss_bytes`.** So the freeze and the parent-vs-child memory gap show up on the existing Grafana dashboards, not only in Sentry. Native `perf_hooks`, zero new deps, NaN-guarded for the empty-histogram startup scrape.
4. **`instrument.ts` — event-loop stall detector** (from the first commit): logs + tagged Sentry event on a hard stall past `LOBU_EVENT_LOOP_STALL_MS` (default 2000ms).

## Deliberately NOT here
- **`@sentry/profiling-node` (CPU flamegraphs)** — it's a **native module** (separate package, not installed); too heavy to add on impulse. The RSS + eventloop-lag gauges cover the "why" (throttle + memory attribution) without a native dep. Revisit if the gauges + Sentry stall events still don't pin the exact allocator.
- The **ingress/runner pod split** — parked; premised on CPU isolation that the child-cap + mem bump address more cheaply.

## Verification
- `tsc --noEmit`: 0 errors repo-wide
- unit + deployment tests: **453 pass / 0 fail** (the spawn-args test caught the flag change → updated → green: red→fix→green)
- helm renders app deployment at `cpu: 3000m` / `memory: 4Gi`
- metrics exporter smoke-tested: emits `nodejs_eventloop_lag_seconds` + `nodejs_rss_bytes`, no NaN
- Note: `make review`'s `pi` LLM step 429'd on an external Codex free-plan cap — not a verdict on the diff.

## Follow-ups (post-merge)
- Add **PrometheusRule alerts** for app-pod OOMKill + sustained throttle-ratio > 0.5 (currently no app-resource alerts — that's why a pod OOMing twice/hour went unnoticed).
- After deploy: confirm on Grafana that `nodejs_eventloop_lag_seconds` spikes are gone and OOMKills stop; confirm a runaway turn now self-OOMs (clean error) rather than killing the pod.
