### PR TITLE
fix(feeds): thread search_term through read_feeds to virtual-feed search()

### DIFF
--- a/packages/core/src/contracts/tools/manage-feeds.ts
+++ b/packages/core/src/contracts/tools/manage-feeds.ts
@@ -50,6 +50,12 @@ export const ReadFeedAction = Type.Object({
       description: "Max transcript messages for a streaming feed (default 50)",
     })
   ),
+  search_term: Type.Optional(
+    Type.String({
+      description:
+        "For a VIRTUAL feed: term pushed to the connector's search() pushdown (e.g. Gmail query syntax AND-composed with the feed's config.query). Ignored for non-virtual feeds.",
+    })
+  ),
 });
 
 export const ReadFeedsAction = Type.Object({
@@ -66,6 +72,12 @@ export const ReadFeedsAction = Type.Object({
     Type.Number({
       description:
         "Per-feed row/message limit for live feed kinds (default 50)",
+    })
+  ),
+  search_term: Type.Optional(
+    Type.String({
+      description:
+        "For VIRTUAL feeds: term pushed to each connector's search() pushdown (e.g. Gmail query syntax AND-composed with config.query). Applies to every virtual feed in the batch; ignored for non-virtual feeds.",
     })
   ),
   timeout_ms: Type.Optional(

--- a/packages/server/src/__tests__/integration/connectors/virtual-feed-surfaces.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/virtual-feed-surfaces.test.ts
@@ -302,6 +302,40 @@ describe('virtual feed surfaces (recall + query_sql)', () => {
     expect(missing).toMatchObject({ ok: false, error: 'Feed not found' });
   }, 60_000);
 
+  it('(3) read_feeds pushes search_term down to the connector search() (ILIKE at source)', async () => {
+    type ReadFeedsResult = {
+      results: Array<{
+        feed_id: number;
+        ok: boolean;
+        result?: { kind?: string; rows?: Array<{ name: string }> };
+      }>;
+    };
+    const namesOf = (res: ReadFeedsResult) =>
+      (res.results.find((r) => r.feed_id === recallFeedId)?.result?.rows ?? [])
+        .map((r) => r.name)
+        .sort();
+
+    // Without search_term the virtual feed returns all three rows via query().
+    const unscoped = (await manageFeeds(
+      { action: 'read_feeds', feed_ids: [recallFeedId] },
+      {},
+      ownerCtx
+    )) as ReadFeedsResult;
+    expect(namesOf(unscoped)).toEqual(['apple', 'apricot', 'banana']);
+
+    // With search_term the term reaches the connector's search() → ILIKE pushdown,
+    // so 'apple'+'apricot' match 'ap' and 'banana' is excluded AT THE SOURCE.
+    const scoped = (await manageFeeds(
+      { action: 'read_feeds', feed_ids: [recallFeedId], search_term: 'ap' },
+      {},
+      ownerCtx
+    )) as ReadFeedsResult;
+    const okScoped = scoped.results.find((r) => r.feed_id === recallFeedId);
+    expect(okScoped?.ok).toBe(true);
+    expect(okScoped?.result?.kind).toBe('virtual');
+    expect(namesOf(scoped)).toEqual(['apple', 'apricot']);
+  }, 60_000);
+
   it('(3) read_feeds preserves per-feed visibility failures', async () => {
     const res = (await manageFeeds(
       {

--- a/packages/server/src/sandbox/namespaces/feeds.ts
+++ b/packages/server/src/sandbox/namespaces/feeds.ts
@@ -22,11 +22,13 @@ export interface FeedsCreateInput {
 export interface FeedsNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
 	list(input?: { connection_id?: number; feed_ids?: number[] }): Promise<unknown>;
-	get(feed_id: number): Promise<unknown>;
+	get(feed_id: number, opts?: { search_term?: string }): Promise<unknown>;
 	readMany(input: {
 		feed_ids: number[];
 		limit?: number;
 		timeout_ms?: number;
+		/** For VIRTUAL feeds: term pushed to each connector's search() pushdown. */
+		search_term?: string;
 	}): Promise<unknown>;
 	create(input: FeedsCreateInput): Promise<unknown>;
 	update(input: {
@@ -50,7 +52,8 @@ export function buildFeedsNamespace(
 	return {
 		manage,
 		list: (input) => action("list_feeds", input),
-		get: (feed_id) => action("read_feed", { feed_id }),
+		get: (feed_id, opts) =>
+			action("read_feed", { feed_id, search_term: opts?.search_term }),
 		readMany: (input) => action("read_feeds", input),
 		create: (input) => action("create_feed", input),
 		update: (input) => action("update_feed", input),

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -278,6 +278,7 @@ async function handleReadFeed(
       scope: authzScopeFromToolContext({ organizationId, userId: userId ?? null }),
       feedId: args.feed_id,
       limit: args.limit,
+      terms: args.search_term ? [args.search_term] : undefined,
     });
     return { action: 'read_feed', kind: 'virtual', feed, ...live };
   }
@@ -322,7 +323,10 @@ async function handleReadFeeds(
     feedIds.map(async (feedId) => {
       try {
         const result = await withTimeout(
-          handleReadFeed({ action: 'read_feed', feed_id: feedId, limit: args.limit }, ctx),
+          handleReadFeed(
+            { action: 'read_feed', feed_id: feedId, limit: args.limit, search_term: args.search_term },
+            ctx
+          ),
           timeoutMs,
           `read_feed ${feedId} timed out after ${timeoutMs}ms`
         );


### PR DESCRIPTION
## Problem

`client.feeds.readMany` (and the `read_feeds` tool action) **silently dropped** a search term. The `search` param did not exist anywhere on that path — not in the SDK type, the action schema, or the handler — so a virtual-feed read always fell back to the connector's unfiltered `query()` instead of its `search()` pushdown.

This is a **two-path divergence**:
- `query_sql({ feed, search_term })` → forwards `terms` → `readVirtualFeed` runs `mode:'search'` → connector filters at source. **Worked.**
- `client.feeds.readMany({ search })` → param stripped by schema validation → `readVirtualFeed` gets empty `terms` → unfiltered `query()`. **Broken.**

Surfaced while evaluating agent behaviour: an agent correctly scoped a Gmail virtual feed by a person's email via `readMany`, but got back the full unfiltered inbox page.

## Fix

Thread an optional `search_term` through the three layers that were missing it, forwarding it as `terms` into the **existing** `readVirtualFeed`. No new search logic — both paths now converge on the same `readVirtualFeed({ terms }) → connector search()`.

- `ReadFeedAction` / `ReadFeedsAction` (contract) gain optional `search_term`.
- `handleReadFeed`/`handleReadFeeds` forward it as `terms`.
- `feeds` SDK namespace (`readMany`, `get`) accept `search_term`.

Naming matches the working `query_sql` path (`search_term`). In a batch read the term applies to every virtual feed in the batch (ignored for non-virtual feeds).

## Test (red→green)

New integration test against a real Postgres virtual feed: `read_feeds` with `search_term:'ap'` returns only `apple`/`apricot` (filtered at source), vs all three rows without it. Fails on the old code (term dropped → all rows).

## Scope

4 files, +56/-3. Additive only; no behaviour change when `search_term` is omitted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785992079&installation_id=136316292&pr_number=1780&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1780&signature=17e51d986f4590eb7e497ae1fadaa09cc67cfa9956d9419e1f38519ff0b36314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional search-term filtering when reading feeds, including bulk feed reads.
  * Virtual feeds can now return results narrowed by a provided search term.

* **Bug Fixes**
  * Feed reads now consistently apply the same search filtering behavior across single and multiple feed requests.
  * Search filtering is ignored for non-virtual feeds, preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->