### PR TITLE
feat(identity): derive email_domain facts and seed works_at inference

### DIFF
--- a/db/migrations/20260707120000_seed_works_at_email_domain_rule.sql
+++ b/db/migrations/20260707120000_seed_works_at_email_domain_rule.sql
@@ -1,0 +1,128 @@
+-- migrate:up
+
+-- Seed the `works_at` auto_create_when rule on every public catalog org.
+--
+-- The identity engine (packages/server/src/identity/engine.ts) derives a
+-- relationship edge when a person-fact's normalized value equals a catalog
+-- entity's `metadata->>targetField`. This migration wires the canonical
+-- employment inference:
+--
+--   person fact  email_domain = "acme.com"
+--   catalog company  metadata.domain = "acme.com"
+--   ⇒ derive  person --works_at--> company
+--
+-- The `email_domain` fact is derived centrally by the engine from every
+-- `email` fact (see deriveCompanionFacts), so this fires for any connector
+-- that produces an email — not just Google Workspace `hd` sign-ins.
+--
+-- Two things must be true for the engine to act (both seeded here, per
+-- public-catalog org that has a `company` type):
+--   1. `company.domain` is declared `x-identity-namespace: true` in the type's
+--      metadata_schema — engine.ts:findEntitiesByMetadataField refuses to match
+--      an undeclared field.
+--   2. an active `works_at` relationship type carries the compiled rule blob
+--      { autoCreateWhen, ruleVersion, ruleHash } in `metadata`.
+--
+-- ruleHash below is sha256 of the canonicalised rule set, matching
+-- ruleHashFor() in packages/server/src/identity/rules.ts. It is validated at
+-- read time by loadRules(): if this hash ever disagrees with a fresh hash of
+-- the stored rules (e.g. the canonicaliser changes), the engine SKIPS the rule
+-- and logs drift rather than acting on a stale rule — so a mistake here fails
+-- safe (no derivations), never wrong. If the rule set is edited, recompute the
+-- hash with ruleHashFor and reseed.
+--
+-- assuranceRequired = 'oauth_verified': only provider-verified emails derive an
+-- edge. A self-attested or scraped contact email will not create a works_at,
+-- and a personal @gmail.com never matches a company (gmail.com is not a
+-- company domain), so false "works at Google" edges are avoided by design.
+--
+-- matchStrategy = 'unique_only': if two catalog companies share a domain the
+-- engine records a collision event for human resolution instead of guessing.
+
+DO $$
+DECLARE
+  org RECORD;
+  company_type RECORD;
+  schema jsonb;
+  props jsonb;
+  domain_prop jsonb;
+  rule_metadata jsonb;
+BEGIN
+  rule_metadata := jsonb_build_object(
+    'autoCreateWhen', jsonb_build_array(
+      jsonb_build_object(
+        'sourceNamespace', 'email_domain',
+        'targetField', 'domain',
+        'assuranceRequired', 'oauth_verified',
+        'matchStrategy', 'unique_only'
+      )
+    ),
+    'ruleVersion', 1,
+    'ruleHash', 'db3256f51ec866accb213b0167068f2f4df32e55b4bd5eb83067d27a157c7419'
+  );
+
+  FOR org IN
+    SELECT id FROM organization WHERE visibility = 'public'
+  LOOP
+    -- Only orgs that actually model companies get the rule/field.
+    SELECT id, metadata_schema INTO company_type
+    FROM entity_types
+    WHERE organization_id = org.id
+      AND slug = 'company'
+      AND deleted_at IS NULL
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+      CONTINUE;
+    END IF;
+
+    -- 1. Declare company.domain as an identity-matchable field, preserving any
+    --    existing schema/props (idempotent: re-running just re-sets the marker).
+    schema := COALESCE(company_type.metadata_schema, '{"type":"object"}'::jsonb);
+    props := COALESCE(schema -> 'properties', '{}'::jsonb);
+    domain_prop := COALESCE(props -> 'domain', '{"type":"string"}'::jsonb)
+      || '{"x-identity-namespace": true}'::jsonb;
+    props := props || jsonb_build_object('domain', domain_prop);
+    schema := schema || jsonb_build_object('properties', props);
+
+    UPDATE entity_types
+    SET metadata_schema = schema, updated_at = now()
+    WHERE id = company_type.id;
+
+    -- 2. Upsert the works_at type carrying the compiled rule. Idempotent on the
+    --    active (organization_id, slug) unique index; on conflict we refresh the
+    --    rule metadata so a reseed corrects any drift.
+    INSERT INTO entity_relationship_types (
+      organization_id, slug, name, description, is_symmetric, status, metadata,
+      created_at, updated_at
+    ) VALUES (
+      org.id, 'works_at', 'Works at',
+      'Person is employed by / affiliated with a company. Auto-derived when the person''s email domain matches the company''s domain.',
+      false, 'active', rule_metadata, now(), now()
+    )
+    ON CONFLICT (organization_id, slug) WHERE (status = 'active')
+    DO UPDATE SET metadata = EXCLUDED.metadata, updated_at = now();
+  END LOOP;
+END $$;
+
+-- migrate:down
+
+-- Remove the seeded rule; leave the x-identity-namespace marker on
+-- company.domain in place (harmless without a rule, and other rules may rely
+-- on it). Only strip the works_at rule metadata we added.
+DO $$
+DECLARE
+  org RECORD;
+BEGIN
+  FOR org IN
+    SELECT id FROM organization WHERE visibility = 'public'
+  LOOP
+    UPDATE entity_relationship_types
+    SET metadata = metadata - 'autoCreateWhen' - 'ruleVersion' - 'ruleHash',
+        updated_at = now()
+    WHERE organization_id = org.id
+      AND slug = 'works_at'
+      AND status = 'active'
+      AND metadata ->> 'ruleHash' = 'db3256f51ec866accb213b0167068f2f4df32e55b4bd5eb83067d27a157c7419';
+  END LOOP;
+END $$;

--- a/db/migrations/20260707120000_seed_works_at_email_domain_rule.sql
+++ b/db/migrations/20260707120000_seed_works_at_email_domain_rule.sql
@@ -77,21 +77,27 @@ BEGIN
     END IF;
 
     -- 1. Declare company.domain as an identity-matchable field, preserving any
-    --    existing schema/props (idempotent: re-running just re-sets the marker).
+    --    existing schema/props. Only ADD the marker when it is absent — an
+    --    existing x-identity-namespace value (true OR the richer object form the
+    --    engine also accepts) is left untouched, so a reseed never downgrades a
+    --    hand-tuned declaration. Idempotent: with the marker present this is a
+    --    no-op on that key.
     schema := COALESCE(company_type.metadata_schema, '{"type":"object"}'::jsonb);
     props := COALESCE(schema -> 'properties', '{}'::jsonb);
-    domain_prop := COALESCE(props -> 'domain', '{"type":"string"}'::jsonb)
-      || '{"x-identity-namespace": true}'::jsonb;
-    props := props || jsonb_build_object('domain', domain_prop);
-    schema := schema || jsonb_build_object('properties', props);
-
-    UPDATE entity_types
-    SET metadata_schema = schema, updated_at = now()
-    WHERE id = company_type.id;
+    domain_prop := COALESCE(props -> 'domain', '{"type":"string"}'::jsonb);
+    IF NOT (domain_prop ? 'x-identity-namespace') THEN
+      domain_prop := domain_prop || '{"x-identity-namespace": true}'::jsonb;
+      props := props || jsonb_build_object('domain', domain_prop);
+      schema := schema || jsonb_build_object('properties', props);
+      UPDATE entity_types
+      SET metadata_schema = schema, updated_at = now()
+      WHERE id = company_type.id;
+    END IF;
 
     -- 2. Upsert the works_at type carrying the compiled rule. Idempotent on the
-    --    active (organization_id, slug) unique index; on conflict we refresh the
-    --    rule metadata so a reseed corrects any drift.
+    --    active (organization_id, slug) unique index; on conflict we MERGE the
+    --    rule keys into any existing metadata (never clobber other fields on an
+    --    already-defined works_at type) so a reseed corrects drift in place.
     INSERT INTO entity_relationship_types (
       organization_id, slug, name, description, is_symmetric, status, metadata,
       created_at, updated_at
@@ -101,7 +107,9 @@ BEGIN
       false, 'active', rule_metadata, now(), now()
     )
     ON CONFLICT (organization_id, slug) WHERE (status = 'active')
-    DO UPDATE SET metadata = EXCLUDED.metadata, updated_at = now();
+    DO UPDATE SET
+      metadata = COALESCE(entity_relationship_types.metadata, '{}'::jsonb) || rule_metadata,
+      updated_at = now();
   END LOOP;
 END $$;
 

--- a/packages/connector-sdk/src/__tests__/identity-namespaces.test.ts
+++ b/packages/connector-sdk/src/__tests__/identity-namespaces.test.ts
@@ -43,4 +43,34 @@ describe('identity namespace registry', () => {
     expect(normalizeIdentifier(IDENTITY.GITHUB_LOGIN, ' Lobu-AI ')).toBe('Lobu-AI');
     expect(normalizeIdentifier(IDENTITY.SLACK_USER_ID, 't1:u2')).toBe('t1:u2');
   });
+
+  it('registers email_domain as a derived, non-recall, non-unique person namespace', () => {
+    expect(getIdentityNamespaceDefinition(IDENTITY.EMAIL_DOMAIN)).toMatchObject({
+      subjectKind: 'person',
+      normalizer: 'email_domain',
+      eventRecallIndexed: false,
+      uniquePerOrg: false,
+    });
+    // Not a recall key — it exists only to power domain-keyed derivation rules.
+    expect(isEventRecallIdentityNamespace(IDENTITY.EMAIL_DOMAIN)).toBe(false);
+    expect(EVENT_RECALL_IDENTITY_NAMESPACES).not.toContain(IDENTITY.EMAIL_DOMAIN);
+  });
+
+  it('normalizes email_domain from a full email or a bare domain, rejecting junk', () => {
+    // Full email → lowercased domain part.
+    expect(normalizeIdentifier(IDENTITY.EMAIL_DOMAIN, 'Alice@Anthropic.com')).toBe(
+      'anthropic.com'
+    );
+    expect(normalizeIdentifier(IDENTITY.EMAIL_DOMAIN, '  dev@ACME.CO.UK  ')).toBe(
+      'acme.co.uk'
+    );
+    // Bare domain passes through normalized.
+    expect(normalizeIdentifier(IDENTITY.EMAIL_DOMAIN, 'Example.COM')).toBe(
+      'example.com'
+    );
+    // Junk → null (no dot, empty, malformed).
+    expect(normalizeIdentifier(IDENTITY.EMAIL_DOMAIN, 'notadomain')).toBeNull();
+    expect(normalizeIdentifier(IDENTITY.EMAIL_DOMAIN, 'a@b@c.com')).toBeNull();
+    expect(normalizeIdentifier(IDENTITY.EMAIL_DOMAIN, '')).toBeNull();
+  });
 });

--- a/packages/connector-sdk/src/identity-namespaces.ts
+++ b/packages/connector-sdk/src/identity-namespaces.ts
@@ -9,6 +9,7 @@
 
 export type IdentityNormalizerKind =
   | 'email'
+  | 'email_domain'
   | 'phone'
   | 'wa_jid'
   | 'slack_user_id'
@@ -40,6 +41,7 @@ export const IDENTITY = {
   WA_JID: 'wa_jid',
   SLACK_USER_ID: 'slack_user_id',
   SLACK_CHANNEL_ID: 'slack_channel_id',
+  EMAIL_DOMAIN: 'email_domain',
   GITHUB_LOGIN: 'github_login',
   GITHUB_USER_ID: 'github_user_id',
   GITHUB_REPO_ID: 'github_repo_id',
@@ -59,6 +61,15 @@ export const IDENTITY_NAMESPACE_REGISTRY = [
     normalizer: 'email',
     eventRecallIndexed: true,
     uniquePerOrg: true,
+  },
+  {
+    namespace: IDENTITY.EMAIL_DOMAIN,
+    subjectKind: 'person',
+    normalizer: 'email_domain',
+    eventRecallIndexed: false,
+    uniquePerOrg: false,
+    notes:
+      "Derived from the person's email fact (the part after @); the engine emits it, connectors never supply it directly. Many people share a domain (not unique-per-org) and it isn't a recall key — its sole job is powering domain-keyed auto_create_when rules (e.g. works_at → company.domain).",
   },
   {
     namespace: IDENTITY.PHONE,

--- a/packages/connector-sdk/src/identity-normalize.ts
+++ b/packages/connector-sdk/src/identity-normalize.ts
@@ -58,6 +58,31 @@ export function normalizeEmail(raw: string | null | undefined): string | null {
 }
 
 /**
+ * Extract the canonical domain from an email address. Runs the full email
+ * validator first (so a malformed address yields null, never a bogus domain),
+ * then returns the lowercased part after `@`. This is what backs the derived
+ * `email_domain` identity namespace: `alice@Anthropic.com` → `anthropic.com`.
+ *
+ * Accepts either a full email or a bare domain — passing an already-extracted
+ * `anthropic.com` returns it normalized, so the engine can re-run this
+ * defensively over a value that may already be a domain.
+ */
+export function normalizeEmailDomain(raw: string | null | undefined): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed || /\s/.test(trimmed)) return null;
+  const atIndex = trimmed.indexOf('@');
+  if (atIndex === -1) {
+    // Bare domain: must contain a dot and no other @-like junk.
+    if (trimmed.indexOf('.') === -1) return null;
+    return trimmed;
+  }
+  const email = normalizeEmail(trimmed);
+  if (!email) return null;
+  return email.slice(email.indexOf('@') + 1);
+}
+
+/**
  * WhatsApp JIDs carry one of these suffixes:
  *   @s.whatsapp.net   — individual, backed by an e164 phone
  *   @lid              — privacy-protected individual (no phone)
@@ -167,6 +192,8 @@ function applyNormalizer(
       return normalizePhone(raw);
     case 'email':
       return normalizeEmail(raw);
+    case 'email_domain':
+      return normalizeEmailDomain(raw);
     case 'numeric_id':
       return normalizeNumericId(raw);
     case 'x_handle':

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -127,6 +127,7 @@ export {
 import {
   normalizeAuthUserId,
   normalizeEmail,
+  normalizeEmailDomain,
   normalizeNumericId,
   normalizeIdentifier,
   normalizePhone,
@@ -138,6 +139,7 @@ import {
 export {
   normalizeAuthUserId,
   normalizeEmail,
+  normalizeEmailDomain,
   normalizeNumericId,
   normalizeIdentifier,
   normalizePhone,

--- a/packages/server/src/__tests__/integration/identity/engine.test.ts
+++ b/packages/server/src/__tests__/integration/identity/engine.test.ts
@@ -1403,6 +1403,134 @@ describe("identity engine — facts ingestion", () => {
 		expect(rel?.deleted_at).toBeNull();
 	});
 
+	it("EMAIL_DOMAIN: companion takes the STRONGEST assurance at a domain, not input order", async () => {
+		const market = await createPublicCatalog("Market EmailDomainAssurance");
+		const tenant = await createTestOrganization({
+			name: "Tenant EmailDomainAssurance",
+			visibility: "private",
+		});
+		const user = await createTestUser({ email: "weak@acme.com" });
+		await addUserToOrganization(user.id, tenant.id, "owner");
+		const memberEntityId = await createMemberEntity({
+			organizationId: tenant.id,
+			userId: user.id,
+			email: user.email,
+			name: "Weak First",
+		});
+		const company = await createTestEntity({
+			name: "Acme",
+			entity_type: "company",
+			organization_id: market.id,
+			domain: "acme.com",
+			created_by: user.id,
+		});
+		await declareIdentityField(market.id, "company", "domain");
+		clearIdentityFieldCache();
+		const works_at = await createRelationshipTypeWithRules({
+			organizationId: market.id,
+			slug: "works_at",
+			name: "Works at",
+			rules: [
+				{
+					sourceNamespace: "email_domain",
+					targetField: "domain",
+					assuranceRequired: "oauth_verified",
+					matchStrategy: "unique_only",
+				},
+			],
+		});
+
+		// Two emails at the SAME domain: the self_attested one comes FIRST. If the
+		// companion took input order it would be self_attested and fail the rule's
+		// oauth_verified floor. It must instead carry oauth_verified from the
+		// stronger email so the works_at edge still derives.
+		const result = await ingestFacts({
+			tenantOrganizationId: tenant.id,
+			memberEntityId,
+			userId: user.id,
+			accountIdentity: {
+				connectorKey: "google_workspace",
+				providerStableId: "google:sub:assurance",
+				sourceAccountId: "acct_assurance",
+			},
+			facts: [
+				{
+					namespace: "email",
+					identifier: "weak@acme.com",
+					normalizedValue: "weak@acme.com",
+					assurance: "self_attested",
+					providerStableId: "google:sub:assurance",
+					sourceAccountId: "acct_assurance",
+				},
+				{
+					namespace: "email",
+					identifier: "strong@acme.com",
+					normalizedValue: "strong@acme.com",
+					assurance: "oauth_verified",
+					providerStableId: "google:sub:assurance",
+					sourceAccountId: "acct_assurance",
+				},
+			],
+			options: { shadow: false },
+		});
+
+		const factEvents = await Promise.all(
+			result.factEventIds.map((id) => getEvent(id)),
+		);
+		const domainEvent = factEvents.find(
+			(e) => e?.metadata.namespace === "email_domain",
+		);
+		expect(domainEvent?.metadata.normalizedValue).toBe("acme.com");
+		expect(domainEvent?.metadata.assurance).toBe("oauth_verified");
+		expect(result.derivedRelationshipIds).toHaveLength(1);
+		const rel = await getRelationship(result.derivedRelationshipIds[0]);
+		expect(rel?.to_entity_id).toBe(company.id);
+		expect(rel?.relationship_type_id).toBe(works_at.id);
+	});
+
+	it("EMAIL_DOMAIN: a connector-supplied email_domain fact is rejected (capability cap)", async () => {
+		const tenant = await createTestOrganization({
+			name: "Tenant EmailDomainForge",
+			visibility: "private",
+		});
+		const user = await createTestUser({ email: "forge@acme.com" });
+		await addUserToOrganization(user.id, tenant.id, "owner");
+		const memberEntityId = await createMemberEntity({
+			organizationId: tenant.id,
+			userId: user.id,
+			email: user.email,
+			name: "Forger",
+		});
+
+		// A connector must not be able to forge an email_domain fact directly —
+		// only the engine derives it. No connector declares the capability, so the
+		// cap rejects it. This guards the privilege hole of skipping the cap by
+		// namespace instead of by engine-derived identity.
+		await expect(
+			ingestFacts({
+				tenantOrganizationId: tenant.id,
+				memberEntityId,
+				userId: user.id,
+				accountIdentity: {
+					connectorKey: "google_workspace",
+					providerStableId: "google:sub:forge",
+					sourceAccountId: "acct_forge",
+				},
+				facts: [
+					{
+						namespace: "email_domain",
+						identifier: "acme.com",
+						normalizedValue: "acme.com",
+						assurance: "oauth_verified",
+						providerStableId: "google:sub:forge",
+						sourceAccountId: "acct_forge",
+					},
+				],
+				options: { shadow: false },
+			}),
+		).rejects.toThrow(/no registered capability for namespace email_domain/);
+	});
+
 	it("EMAIL_DOMAIN: dropping the email on refresh revokes the derived works_at edge", async () => {
 		const market = await createPublicCatalog("Market EmailDomainRevoke");
 		const tenant = await createTestOrganization({

--- a/packages/server/src/__tests__/integration/identity/engine.test.ts
+++ b/packages/server/src/__tests__/integration/identity/engine.test.ts
@@ -13,19 +13,16 @@
  * tests pre-create the `$member` directly.
  */
 
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
-	clearIdentityFieldCache,
-	ingestFacts,
-} from "../../../identity/engine";
-import { compileRulesMetadata } from "../../../identity/rules";
-import { connectorCapabilityRegistry } from "../../../identity/capability-registry";
-import {
-	IDENTITY_FACT_SEMANTIC_TYPE,
-	CLAIM_COLLISION_SEMANTIC_TYPE,
 	type AutoCreateWhenRule,
+	CLAIM_COLLISION_SEMANTIC_TYPE,
 	type ConnectorFact,
+	IDENTITY_FACT_SEMANTIC_TYPE,
 } from "@lobu/connector-sdk";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { connectorCapabilityRegistry } from "../../../identity/capability-registry";
+import { clearIdentityFieldCache, ingestFacts } from "../../../identity/engine";
+import { compileRulesMetadata } from "../../../identity/rules";
 import { IdentitySchemaError } from "../../../identity/validate";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
@@ -716,7 +713,10 @@ describe("identity engine — facts ingestion", () => {
 				memberEntityId,
 				userId: user.id,
 				accountIdentity,
-				facts: [fact, { ...fact, identifier: "Dupe Fact <dupe-fact@example.com>" }],
+				facts: [
+					fact,
+					{ ...fact, identifier: "Dupe Fact <dupe-fact@example.com>" },
+				],
 			}),
 		).rejects.toThrow(/duplicate fact/);
 	});
@@ -1209,7 +1209,9 @@ describe("identity engine — facts ingestion", () => {
 			accountIdentity,
 			facts: factsBoth,
 		});
-		expect(first.factEventIds).toHaveLength(2);
+		// Two distinct email facts, plus one engine-derived email_domain companion
+		// (both emails share example.com, so the companion dedupes to a single fact).
+		expect(first.factEventIds).toHaveLength(3);
 
 		const second = await ingestFacts({
 			tenantOrganizationId: tenant.id,
@@ -1219,20 +1221,33 @@ describe("identity engine — facts ingestion", () => {
 			facts: [factsBoth[0]],
 		});
 		// The dropped value tombstones; the kept value either no-ops (same
-		// normalizedValue) or supersedes itself.
+		// normalizedValue) or supersedes itself. The shared domain stays live
+		// (one@example.com still yields example.com), so it is not tombstoned.
 		expect(second.supersededEventIds.length).toBeGreaterThanOrEqual(1);
 		const sql = getTestDb();
-		const liveFacts = await sql<{ normalized_value: string }[]>`
+		const liveEmails = await sql<{ normalized_value: string }[]>`
       SELECT metadata->>'normalizedValue' AS normalized_value
       FROM current_event_records
       WHERE semantic_type = ${IDENTITY_FACT_SEMANTIC_TYPE}
         AND connector_key = ${accountIdentity.connectorKey}
         AND metadata->>'providerStableId' = ${accountIdentity.providerStableId}
+        AND metadata->>'namespace' = 'email'
         AND COALESCE(metadata->>'normalizedValue', '') <> ''
     `;
-		expect(liveFacts.map((r) => r.normalized_value)).toEqual([
+		expect(liveEmails.map((r) => r.normalized_value)).toEqual([
 			"one@example.com",
 		]);
+		// The shared email_domain companion survives because one@example.com keeps it live.
+		const liveDomains = await sql<{ normalized_value: string }[]>`
+      SELECT metadata->>'normalizedValue' AS normalized_value
+      FROM current_event_records
+      WHERE semantic_type = ${IDENTITY_FACT_SEMANTIC_TYPE}
+        AND connector_key = ${accountIdentity.connectorKey}
+        AND metadata->>'providerStableId' = ${accountIdentity.providerStableId}
+        AND metadata->>'namespace' = 'email_domain'
+        AND COALESCE(metadata->>'normalizedValue', '') <> ''
+    `;
+		expect(liveDomains.map((r) => r.normalized_value)).toEqual(["example.com"]);
 	});
 
 	it("validTo: an expired fact is persisted but never derives a relationship", async () => {
@@ -1298,5 +1313,172 @@ describe("identity engine — facts ingestion", () => {
 		expect(result.skippedRules.some((s) => s.reason.includes("validTo"))).toBe(
 			true,
 		);
+	});
+
+	// ── email_domain: the engine derives an email_domain companion fact from
+	//    every email fact, so an email alone (no explicit hosted_domain) drives
+	//    works_at via the domain rule. This is the general path that fires for
+	//    any connector emitting email, not just Google Workspace `hd` sign-ins.
+	it("EMAIL_DOMAIN: an email fact alone derives the email_domain companion and a works_at edge", async () => {
+		const market = await createPublicCatalog("Market EmailDomain");
+		const tenant = await createTestOrganization({
+			name: "Tenant EmailDomain",
+			visibility: "private",
+		});
+		const user = await createTestUser({ email: "dev@acme.com" });
+		await addUserToOrganization(user.id, tenant.id, "owner");
+		const memberEntityId = await createMemberEntity({
+			organizationId: tenant.id,
+			userId: user.id,
+			email: user.email,
+			name: "Dev Acme",
+		});
+		const company = await createTestEntity({
+			name: "Acme",
+			entity_type: "company",
+			organization_id: market.id,
+			domain: "acme.com",
+			created_by: user.id,
+		});
+		await declareIdentityField(market.id, "company", "domain");
+		clearIdentityFieldCache();
+		const works_at = await createRelationshipTypeWithRules({
+			organizationId: market.id,
+			slug: "works_at",
+			name: "Works at",
+			rules: [
+				{
+					sourceNamespace: "email_domain",
+					targetField: "domain",
+					assuranceRequired: "oauth_verified",
+					matchStrategy: "unique_only",
+				},
+			],
+		});
+
+		// Only an email fact is emitted — no explicit email_domain/hosted_domain.
+		const emailFact: ConnectorFact = {
+			namespace: "email",
+			identifier: "dev@acme.com",
+			normalizedValue: "dev@acme.com",
+			assurance: "oauth_verified",
+			providerStableId: "google:sub:acme1",
+			sourceAccountId: "acct_emaildomain",
+		};
+
+		const result = await ingestFacts({
+			tenantOrganizationId: tenant.id,
+			memberEntityId,
+			userId: user.id,
+			accountIdentity: {
+				connectorKey: "google_workspace",
+				providerStableId: "google:sub:acme1",
+				sourceAccountId: "acct_emaildomain",
+			},
+			facts: [emailFact],
+			options: { shadow: false },
+		});
+
+		// Two fact events: the email, plus the engine-derived email_domain.
+		expect(result.factEventIds).toHaveLength(2);
+		const factEvents = await Promise.all(
+			result.factEventIds.map((id) => getEvent(id)),
+		);
+		const namespaces = factEvents.map((e) => e?.metadata.namespace).sort();
+		expect(namespaces).toEqual(["email", "email_domain"]);
+		const domainEvent = factEvents.find(
+			(e) => e?.metadata.namespace === "email_domain",
+		);
+		expect(domainEvent?.metadata.normalizedValue).toBe("acme.com");
+		// Companion inherits the source email's assurance (never higher).
+		expect(domainEvent?.metadata.assurance).toBe("oauth_verified");
+
+		// The domain fact matched the catalog company → works_at derived.
+		expect(result.derivedRelationshipIds).toHaveLength(1);
+		expect(result.collisionEventIds).toHaveLength(0);
+		const rel = await getRelationship(result.derivedRelationshipIds[0]);
+		expect(rel?.from_entity_id).toBe(memberEntityId);
+		expect(rel?.to_entity_id).toBe(company.id);
+		expect(rel?.relationship_type_id).toBe(works_at.id);
+		expect(rel?.deleted_at).toBeNull();
+	});
+
+	it("EMAIL_DOMAIN: dropping the email on refresh revokes the derived works_at edge", async () => {
+		const market = await createPublicCatalog("Market EmailDomainRevoke");
+		const tenant = await createTestOrganization({
+			name: "Tenant EmailDomainRevoke",
+			visibility: "private",
+		});
+		const user = await createTestUser({ email: "leaver@acme.com" });
+		await addUserToOrganization(user.id, tenant.id, "owner");
+		const memberEntityId = await createMemberEntity({
+			organizationId: tenant.id,
+			userId: user.id,
+			email: user.email,
+			name: "Leaver Acme",
+		});
+		// The company must exist so the domain match derives an edge; the row id
+		// isn't asserted directly (we assert via the derived relationship).
+		await createTestEntity({
+			name: "Acme",
+			entity_type: "company",
+			organization_id: market.id,
+			domain: "acme.com",
+			created_by: user.id,
+		});
+		await declareIdentityField(market.id, "company", "domain");
+		clearIdentityFieldCache();
+		await createRelationshipTypeWithRules({
+			organizationId: market.id,
+			slug: "works_at",
+			name: "Works at",
+			rules: [
+				{
+					sourceNamespace: "email_domain",
+					targetField: "domain",
+					assuranceRequired: "oauth_verified",
+					matchStrategy: "unique_only",
+				},
+			],
+		});
+
+		const accountIdentity = {
+			connectorKey: "google_workspace",
+			providerStableId: "google:sub:leaver",
+			sourceAccountId: "acct_leaver",
+		};
+		const first = await ingestFacts({
+			tenantOrganizationId: tenant.id,
+			memberEntityId,
+			userId: user.id,
+			accountIdentity,
+			facts: [
+				{
+					namespace: "email",
+					identifier: "leaver@acme.com",
+					normalizedValue: "leaver@acme.com",
+					assurance: "oauth_verified",
+					providerStableId: "google:sub:leaver",
+					sourceAccountId: "acct_leaver",
+				},
+			],
+			options: { shadow: false },
+		});
+		expect(first.derivedRelationshipIds).toHaveLength(1);
+		const relId = first.derivedRelationshipIds[0];
+		expect((await getRelationship(relId))?.deleted_at).toBeNull();
+
+		// Empty batch is authoritative: the email (and its derived email_domain)
+		// are dropped, which must revoke the works_at edge in lockstep.
+		const second = await ingestFacts({
+			tenantOrganizationId: tenant.id,
+			memberEntityId,
+			userId: user.id,
+			accountIdentity,
+			facts: [],
+			options: { shadow: false },
+		});
+		expect(second.revokedRelationshipIds).toContain(relId);
+		expect((await getRelationship(relId))?.deleted_at).not.toBeNull();
 	});
 });

--- a/packages/server/src/identity/engine.ts
+++ b/packages/server/src/identity/engine.ts
@@ -18,23 +18,25 @@
  * real users before flipping derivations on.
  */
 
-import { getDb } from "../db/client";
-import { insertEvent } from "../utils/insert-event";
-import logger from "../utils/logger";
-import { TtlCache } from "../utils/ttl-cache";
+import { IDENTITY, normalizeEmailDomain } from "@lobu/connector-sdk";
 import {
 	type AssuranceLevel,
 	type AutoCreateWhenRule,
+	assuranceMeets,
 	CLAIM_COLLISION_SEMANTIC_TYPE,
 	type ConnectorFact,
 	type DerivedFromProvenance,
 	IDENTITY_FACT_SEMANTIC_TYPE,
-	assuranceMeets,
 } from "@lobu/connector-sdk/identity-types";
-import type { EngineOptions, IngestResult } from "./types";
+import { getDb } from "../db/client";
+import { insertEvent } from "../utils/insert-event";
+import logger from "../utils/logger";
 import { validateTypeRule } from "../utils/relationship-validation";
+import { TtlCache } from "../utils/ttl-cache";
 import { connectorCapabilityRegistry } from "./capability-registry";
 import { withAccountLock } from "./lock";
+import { ruleHashFor } from "./rules";
+import type { EngineOptions, IngestResult } from "./types";
 import {
 	IdentitySchemaError,
 	validateClaimCollisionPayload,
@@ -43,7 +45,6 @@ import {
 	validateFactEventMetadata,
 	validateRelationshipTypeIdentityMetadata,
 } from "./validate";
-import { ruleHashFor } from "./rules";
 
 type Sql = ReturnType<typeof getDb>;
 
@@ -126,6 +127,51 @@ function priorKey(p: { namespace: string; normalizedValue: string }): string {
 	// US (\x1f) delimiter banned by ConnectorFact field charset, so namespace
 	// and normalizedValue can never produce the same join as another pair.
 	return `${p.namespace}${p.normalizedValue}`;
+}
+
+/**
+ * Engine-derived companion facts for a connector batch.
+ *
+ * `email_domain` is a pure function of an `email` fact (the part after `@`),
+ * so the engine derives it centrally rather than asking every connector to
+ * emit it — one authoritative rule, and any connector that produces `email`
+ * gets domain-keyed matching (e.g. works_at → company.domain) for free. The
+ * derived fact inherits the source email's assurance, providerStableId, and
+ * sourceAccountId, so it supersedes/tombstones/revokes in lockstep with the
+ * email: if the email goes away on refresh, so does the domain and any edge
+ * it derived. Because it is engine-authored (not connector-declared) it is
+ * exempt from the per-connector capability cap — its trust is exactly the
+ * already-capped email fact's trust, never more.
+ */
+const ENGINE_DERIVED_NAMESPACES = new Set<string>([IDENTITY.EMAIL_DOMAIN]);
+
+function isEngineDerivedFact(namespace: string): boolean {
+	return ENGINE_DERIVED_NAMESPACES.has(namespace);
+}
+
+function deriveCompanionFacts(facts: ConnectorFact[]): ConnectorFact[] {
+	const derived: ConnectorFact[] = [];
+	const seen = new Set<string>();
+	for (const fact of facts) {
+		if (fact.namespace !== IDENTITY.EMAIL) continue;
+		const domain = normalizeEmailDomain(fact.normalizedValue);
+		if (!domain) continue;
+		const key = `${IDENTITY.EMAIL_DOMAIN}${domain}`;
+		// One domain fact per distinct domain, even if several emails share it.
+		if (seen.has(key)) continue;
+		seen.add(key);
+		derived.push({
+			namespace: IDENTITY.EMAIL_DOMAIN,
+			identifier: domain,
+			normalizedValue: domain,
+			assurance: fact.assurance,
+			providerStableId: fact.providerStableId,
+			sourceAccountId: fact.sourceAccountId,
+			validTo: fact.validTo,
+			notes: `derived from email ${fact.normalizedValue}`,
+		});
+	}
+	return derived;
 }
 
 function isSupersedeUniqueViolation(err: unknown): boolean {
@@ -269,7 +315,9 @@ const IDENTITY_FIELD_CACHE_TTL_MS = (() => {
 	return Number.isFinite(raw) && raw > 0 ? raw : 60_000;
 })();
 
-const identityFieldCache = new TtlCache<Set<string>>(IDENTITY_FIELD_CACHE_TTL_MS);
+const identityFieldCache = new TtlCache<Set<string>>(
+	IDENTITY_FIELD_CACHE_TTL_MS,
+);
 
 /**
  * Drop the in-memory cache. Tests use this to refresh after declaring new
@@ -301,7 +349,7 @@ async function loadIdentityFields(
 						string,
 						{ "x-identity-namespace"?: boolean | Record<string, unknown> }
 					>;
-				}
+			  }
 			| null
 			| undefined;
 		if (!schema || typeof schema !== "object" || !schema.properties) continue;
@@ -501,9 +549,20 @@ async function ingestFactsLocked(params: IngestParams): Promise<IngestResult> {
 		memberEntityId,
 		userId,
 		accountIdentity,
-		facts,
+		facts: connectorFacts,
 	} = params;
 	const shadow = isShadow(params.options);
+
+	// Expand the connector batch with engine-derived companion facts (e.g. an
+	// `email_domain` fact for each `email`). These ride the same persist /
+	// supersede / tombstone / derive machinery as connector facts, so absence
+	// of the source email on a later refresh tombstones the domain too. Derived
+	// facts are appended (never replace connector facts) and are exempt from the
+	// per-connector capability cap below.
+	const facts: ConnectorFact[] = [
+		...connectorFacts,
+		...deriveCompanionFacts(connectorFacts),
+	];
 
 	// 1. Validate every fact up front. All-or-nothing — we do not partially
 	// ingest, since a partial write could leave derivations dangling.
@@ -543,6 +602,11 @@ async function ingestFactsLocked(params: IngestParams): Promise<IngestResult> {
 			);
 		}
 		seenFactKeys.add(key);
+		// Engine-derived companion facts (e.g. email_domain) are authored by the
+		// engine, not the connector, so no connector declares a capability for
+		// them. They inherit the source fact's already-capped assurance, so the
+		// cap is enforced upstream on the email fact — skip the connector cap here.
+		if (isEngineDerivedFact(fact.namespace)) continue;
 		// server-side capability cap: a connector may only emit
 		// (namespace, assurance) pairs it declared in its capability. Anything
 		// outside the declared cap is rejected before any side effect.
@@ -762,7 +826,10 @@ async function ingestFactsLocked(params: IngestParams): Promise<IngestResult> {
 						}
 						if (validMatches.length === 0) continue;
 
-						if (validMatches.length > 1 && rule.matchStrategy === "unique_only") {
+						if (
+							validMatches.length > 1 &&
+							rule.matchStrategy === "unique_only"
+						) {
 							// Surface as a collision event for admin / user resolution.
 							const collisionId = await recordCollision(
 								sql,
@@ -786,7 +853,9 @@ async function ingestFactsLocked(params: IngestParams): Promise<IngestResult> {
 						// unique_only with one match, or all_matches with N → derive each.
 						// (first_match is rejected at the schema layer in @lobu/connector-sdk.)
 						const targets =
-							rule.matchStrategy === "unique_only" ? [validMatches[0]] : validMatches;
+							rule.matchStrategy === "unique_only"
+								? [validMatches[0]]
+								: validMatches;
 						for (const target of targets) {
 							const existing = await findExistingRelationship(
 								sql,

--- a/packages/server/src/identity/engine.ts
+++ b/packages/server/src/identity/engine.ts
@@ -143,35 +143,31 @@ function priorKey(p: { namespace: string; normalizedValue: string }): string {
  * exempt from the per-connector capability cap — its trust is exactly the
  * already-capped email fact's trust, never more.
  */
-const ENGINE_DERIVED_NAMESPACES = new Set<string>([IDENTITY.EMAIL_DOMAIN]);
-
-function isEngineDerivedFact(namespace: string): boolean {
-	return ENGINE_DERIVED_NAMESPACES.has(namespace);
-}
-
 function deriveCompanionFacts(facts: ConnectorFact[]): ConnectorFact[] {
-	const derived: ConnectorFact[] = [];
-	const seen = new Set<string>();
+	// One companion per distinct domain, sourced from the STRONGEST-assurance
+	// email at that domain — not first-input-order. If a person supplies both a
+	// self_attested and an oauth_verified email at acme.com, the companion must
+	// carry oauth_verified so the works_at rule (which requires it) still fires;
+	// input order must not decide that.
+	const byDomain = new Map<string, ConnectorFact>();
 	for (const fact of facts) {
 		if (fact.namespace !== IDENTITY.EMAIL) continue;
 		const domain = normalizeEmailDomain(fact.normalizedValue);
 		if (!domain) continue;
-		const key = `${IDENTITY.EMAIL_DOMAIN}${domain}`;
-		// One domain fact per distinct domain, even if several emails share it.
-		if (seen.has(key)) continue;
-		seen.add(key);
-		derived.push({
-			namespace: IDENTITY.EMAIL_DOMAIN,
-			identifier: domain,
-			normalizedValue: domain,
-			assurance: fact.assurance,
-			providerStableId: fact.providerStableId,
-			sourceAccountId: fact.sourceAccountId,
-			validTo: fact.validTo,
-			notes: `derived from email ${fact.normalizedValue}`,
-		});
+		const prior = byDomain.get(domain);
+		if (prior && assuranceMeets(prior.assurance, fact.assurance)) continue;
+		byDomain.set(domain, fact);
 	}
-	return derived;
+	return Array.from(byDomain, ([domain, source]) => ({
+		namespace: IDENTITY.EMAIL_DOMAIN,
+		identifier: domain,
+		normalizedValue: domain,
+		assurance: source.assurance,
+		providerStableId: source.providerStableId,
+		sourceAccountId: source.sourceAccountId,
+		validTo: source.validTo,
+		notes: `derived from email ${source.normalizedValue}`,
+	}));
 }
 
 function isSupersedeUniqueViolation(err: unknown): boolean {
@@ -557,12 +553,17 @@ async function ingestFactsLocked(params: IngestParams): Promise<IngestResult> {
 	// `email_domain` fact for each `email`). These ride the same persist /
 	// supersede / tombstone / derive machinery as connector facts, so absence
 	// of the source email on a later refresh tombstones the domain too. Derived
-	// facts are appended (never replace connector facts) and are exempt from the
-	// per-connector capability cap below.
-	const facts: ConnectorFact[] = [
-		...connectorFacts,
-		...deriveCompanionFacts(connectorFacts),
-	];
+	// facts are appended (never replace connector facts).
+	//
+	// `engineDerived` holds the exact fact OBJECTS the engine synthesized, so
+	// the capability cap is skipped ONLY for those. A connector that itself
+	// supplies an email_domain fact is NOT in this set and is still subject to
+	// the cap — which no connector declares for email_domain, so a forged
+	// companion is rejected. Keying the exemption on identity (not namespace)
+	// is what closes that privilege hole.
+	const companions = deriveCompanionFacts(connectorFacts);
+	const engineDerived = new Set<ConnectorFact>(companions);
+	const facts: ConnectorFact[] = [...connectorFacts, ...companions];
 
 	// 1. Validate every fact up front. All-or-nothing — we do not partially
 	// ingest, since a partial write could leave derivations dangling.
@@ -605,8 +606,10 @@ async function ingestFactsLocked(params: IngestParams): Promise<IngestResult> {
 		// Engine-derived companion facts (e.g. email_domain) are authored by the
 		// engine, not the connector, so no connector declares a capability for
 		// them. They inherit the source fact's already-capped assurance, so the
-		// cap is enforced upstream on the email fact — skip the connector cap here.
-		if (isEngineDerivedFact(fact.namespace)) continue;
+		// cap is enforced upstream on the email fact — skip the connector cap for
+		// THESE specific objects only. A connector-supplied fact of the same
+		// namespace is not in the set and still faces the cap below.
+		if (engineDerived.has(fact)) continue;
 		// server-side capability cap: a connector may only emit
 		// (namespace, assurance) pairs it declared in its capability. Anything
 		// outside the declared cap is rejected before any side effect.


### PR DESCRIPTION
## What

Wires the **\"an employee's email domain matches a company's domain ⇒ works_at\"** inference into the existing identity engine — generally, not as a one-off. Asked \"can we auto-infer employment from email domains,\" the answer turned out to be: the derivation engine (`packages/server/src/identity/engine.ts`) already does two-entity-type join-on-shared-value with collision handling, provenance, revocation, and idempotency. It just wasn't fed a domain fact or a rule. This adds both.

## The three pieces

1. **`email_domain` identity namespace** — a derived, person-scoped, non-recall namespace (the part after `@`). Registered in `identity-namespaces.ts` with a `normalizeEmailDomain` normalizer.

2. **Central engine derivation** — the engine synthesizes an `email_domain` companion fact from every `email` fact (`deriveCompanionFacts`). So **any connector that emits `email` gets domain-keyed matching for free** — no per-connector change. Companions ride the existing persist / supersede / tombstone / revoke machinery: drop the email on refresh and the domain (and any edge it derived) is revoked in lockstep. They inherit the email's already-capped assurance and are exempt from the per-connector capability cap **by object identity** (a connector-forged `email_domain` fact is still rejected).

3. **Idempotent migration** seeds a `works_at` `auto_create_when` rule (`email_domain → company.domain`, `oauth_verified`, `unique_only`) on every public-catalog org that models companies, and declares `company.domain` as `x-identity-namespace`. `ruleHash` matches `ruleHashFor()`; `loadRules` validates it at read time, so drift fails safe (rule skipped, never wrong).

Matches the engine's **catalog-scoped** design: `works_at` points at the canonical public-catalog company, not a per-tenant duplicate.

## Assurance & safety

- `oauth_verified` floor: only provider-verified emails derive an edge; a personal `@gmail.com` never matches a company, so no false \"works at Google.\"
- `unique_only`: two catalog companies sharing a domain record a collision for human resolution instead of guessing.
- Companion takes the **strongest** assurance among emails at a domain (not input order), so a weak email can't block the rule.

## Tests (red→green, real Postgres)

- email-alone derives the companion + `works_at` edge
- dropping the email revokes the edge in lockstep
- companion takes strongest assurance, not input order
- connector-forged `email_domain` fact is rejected by the cap
- multi-email dedup to one domain
- `normalizeEmailDomain` edge cases

Full identity engine suite green (18/18) against real Postgres. Two review blockers (capability-cap bypass, migration metadata overwrite) found by \`make review\` and fixed in the second commit.

## Follow-up (not in this PR)

Historical backfill — populate catalog company domains, then replay existing `email` facts through \`ingestFacts\` so people ingested before this change get edges. This PR makes **all future ingests** derive the edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786022638&installation_id=136316292&pr_number=1782&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1782&signature=6e3680d07c3337026e439ee1e7c52c3a5760bf23510ab65b4f827b188566a645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->