### PR TITLE
fix(gateway): org-scope the two deferred worker-path getSettings reads

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -382,6 +382,13 @@ export type LogLevel = "debug" | "info" | "warn" | "error";
 export interface InstructionContext {
   userId: string;
   agentId: string;
+  /**
+   * Owning org of the agent. An agent id can exist in multiple orgs (PK is
+   * `(organization_id, id)`), so instruction providers must scope their
+   * settings reads by org — the worker-dispatch path has no ambient orgContext,
+   * so an unscoped read returns an arbitrary org's row.
+   */
+  organizationId?: string;
   sessionKey: string;
   workingDirectory: string;
   availableProjects?: string[];

--- a/packages/server/src/gateway/__tests__/instruction-service.test.ts
+++ b/packages/server/src/gateway/__tests__/instruction-service.test.ts
@@ -1,10 +1,12 @@
 import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { createPostgresAgentConfigStore } from "../../lobu/stores/postgres-stores.js";
+import { orgContext } from "../../lobu/stores/org-context.js";
 import { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import { InstructionService } from "../services/instruction-service.js";
 import {
   ensureDbForGatewayTests,
   resetTestDatabase,
+  seedAgentRow,
 } from "./helpers/db-setup.js";
 
 describe("InstructionService", () => {
@@ -41,5 +43,37 @@ describe("InstructionService", () => {
     expect(sessionContext.agentInstructions).not.toContain(
       "Do not invent product capabilities"
     );
+  });
+
+  test("resolves agent identity scoped to the caller's org (shared agent id across orgs)", async () => {
+    // The same agent id lives in two orgs with different identities. The worker
+    // path (getSessionContext) has no ambient orgContext, so the instruction
+    // reads MUST scope by context.organizationId — otherwise an unscoped read
+    // returns an arbitrary org's identity and leaks it into the other tenant's
+    // session.
+    await seedAgentRow("lobu-builder", { organizationId: "org-a" });
+    await seedAgentRow("lobu-builder", { organizationId: "org-b" });
+
+    await orgContext.run({ organizationId: "org-a" }, () =>
+      store.saveSettings("lobu-builder", {
+        identityMd: "I am the ORG-A builder.",
+      } as any)
+    );
+    await orgContext.run({ organizationId: "org-b" }, () =>
+      store.saveSettings("lobu-builder", {
+        identityMd: "I am the ORG-B builder.",
+      } as any)
+    );
+
+    const ctxB = await service.getSessionContext("telegram", {
+      agentId: "lobu-builder",
+      organizationId: "org-b",
+      userId: "user-1",
+      workingDirectory: "/workspace/thread-1",
+    } as any);
+
+    // org-b's identity resolved — not org-a's (the unscoped-read bug).
+    expect(ctxB.agentInstructions).toContain("I am the ORG-B builder.");
+    expect(ctxB.agentInstructions).not.toContain("I am the ORG-A builder.");
   });
 });

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -178,7 +178,10 @@ export class ChatResponseBridge implements ResponseRenderer {
   ): Promise<boolean> {
     const agentId = this.resolveAgentId(payload, ctx);
     if (!agentId) return false;
-    return this.outputGuardrail.hasOutputGuardrails(agentId);
+    return this.outputGuardrail.hasOutputGuardrails(
+      agentId,
+      this.resolveOrganizationId(payload, ctx)
+    );
   }
 
   /**

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -518,6 +518,7 @@ export class WorkerGateway {
       const instructionContext: InstructionContext = {
         userId,
         agentId: agentId || "",
+        organizationId: auth.tokenData.organizationId,
         sessionKey: sessionKey || "",
         workingDirectory: "/workspace",
         availableProjects: [],

--- a/packages/server/src/gateway/guardrails/__tests__/output-scan-org-scope.test.ts
+++ b/packages/server/src/gateway/guardrails/__tests__/output-scan-org-scope.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { GuardrailRegistry } from "@lobu/core";
-import { runOutputGuardrailScan } from "../output-scan.js";
+import { OutputGuardrailScanner, runOutputGuardrailScan } from "../output-scan.js";
 import type { AgentSettingsStore } from "../../auth/settings/agent-settings-store.js";
 
 describe("runOutputGuardrailScan org scoping", () => {
@@ -35,6 +35,28 @@ describe("runOutputGuardrailScan org scoping", () => {
         platform: "slack",
       },
     );
+
+    expect(seen).toEqual([
+      { agentId: "lobu-builder", organizationId: "org-b" },
+    ]);
+  });
+
+  test("hasOutputGuardrails passes the caller's org into getSettings", async () => {
+    const seen: Array<{ agentId: string; organizationId?: string }> = [];
+    const settingsStore = {
+      getSettings: async (
+        agentId: string,
+        context?: { organizationId?: string },
+      ) => {
+        seen.push({ agentId, organizationId: context?.organizationId });
+        return { guardrails: [] } as any;
+      },
+    } as unknown as AgentSettingsStore;
+
+    const scanner = new OutputGuardrailScanner();
+    scanner.setGuardrails(new GuardrailRegistry(), settingsStore);
+
+    await scanner.hasOutputGuardrails("lobu-builder", "org-b");
 
     expect(seen).toEqual([
       { agentId: "lobu-builder", organizationId: "org-b" },

--- a/packages/server/src/gateway/guardrails/output-scan.ts
+++ b/packages/server/src/gateway/guardrails/output-scan.ts
@@ -152,11 +152,19 @@ export class OutputGuardrailScanner {
    * guardrails never blocking on infra failure. Resolution rides the
    * AgentSettingsStore's own memoization (the chat bridge resolves per-delta the
    * same way), so no extra cache is kept here (avoids config-edit staleness).
+   * Pass `organizationId` so the read is org-scoped: a shared agent id exists in
+   * multiple orgs and the worker path has no ambient orgContext, so an unscoped
+   * read could resolve another org's guardrail config.
    */
-  async hasOutputGuardrails(agentId: string): Promise<boolean> {
+  async hasOutputGuardrails(
+    agentId: string,
+    organizationId?: string
+  ): Promise<boolean> {
     if (!this.enabled || !agentId) return false;
     try {
-      const settings = await this.settingsStore!.getSettings(agentId);
+      const settings = await this.settingsStore!.getSettings(agentId, {
+        organizationId,
+      });
       const resolved = resolveAgentGuardrails(
         settings ?? { guardrails: [] },
         (settings?.skillsConfig?.skills ?? []).filter((s) => s.enabled),

--- a/packages/server/src/gateway/platform/unified-thread-consumer.ts
+++ b/packages/server/src/gateway/platform/unified-thread-consumer.ts
@@ -448,7 +448,13 @@ export class UnifiedThreadResponseConsumer {
         // event instead (the SPA renders from it). Agents without output
         // guardrails stream normally — `hasOutputGuardrails` returns false.
         if (data.delta) {
-          if (await this.outputGuardrail.hasOutputGuardrails(agentId)) return;
+          if (
+            await this.outputGuardrail.hasOutputGuardrails(
+              agentId,
+              md.organizationId
+            )
+          )
+            return;
         } else if (data.error || data.processedMessageIds?.length) {
           // Terminal row: scan whichever authoritative text the renderer will
           // broadcast — the reply (`finalText`, via handleCompletion) OR the

--- a/packages/server/src/gateway/services/instruction-service.ts
+++ b/packages/server/src/gateway/services/instruction-service.ts
@@ -67,7 +67,8 @@ class SkillsInstructionProvider extends BaseInstructionProvider {
     }> = [];
     try {
       const settings = await this.agentSettingsStore.getSettings(
-        context.agentId
+        context.agentId,
+        { organizationId: context.organizationId }
       );
       const skills = settings?.skillsConfig?.skills || [];
       enabledSkills = skills.filter((s) => s.enabled && s.content);
@@ -275,7 +276,8 @@ export class InstructionService {
     if (this.agentSettingsStore && context.agentId) {
       try {
         const settings = await this.agentSettingsStore.getSettings(
-          context.agentId
+          context.agentId,
+          { organizationId: context.organizationId }
         );
         if (settings) {
           const sections: string[] = [];


### PR DESCRIPTION
Follow-up to #1779, which org-scoped the worker-path `getSettings` callers that resolved the model/provider/guardrail config. Two callers were deferred there because they lacked a route to the org; this closes them.

## The bug (same class as #1779)

`AgentConfigStore.getSettings(agentId)` scopes by ambient `tryGetOrgId()`. The worker-dispatch path runs without ambient orgContext, so an unscoped read falls to an id-only query and returns an **arbitrary** org's row. An agent id like `lobu-builder` exists once per org (PK is `(organization_id, id)`), so the wrong tenant's config can bleed in.

## What this changes

- **`hasOutputGuardrails(agentId, organizationId?)`** — the streaming gate that decides whether to withhold deltas for an agent with output guardrails. Both call sites already hold the org: the unified-thread consumer passes `md.organizationId`; the chat-response bridge passes `resolveOrganizationId(payload, ctx)`. Without this, one tenant's guardrail config could gate another tenant's stream.
- **`InstructionContext.organizationId?`** (new field on the `@lobu/core` type) — set from the worker token at the gateway session-context site, then threaded into the two instruction-service reads (agent identity/soul/user + enabled skills). Without this, a shared agent id could inject the wrong org's IDENTITY.md/SOUL.md into a session.

## Tests (red→green)

- `instruction-service.test.ts`: seeds the **same** agent id in two orgs with distinct `identityMd`, calls `getSessionContext` with `organizationId: org-b`, asserts org-b's identity resolves (not org-a's). Proven red without the fix (returned org-a's identity).
- `output-scan-org-scope.test.ts`: asserts `hasOutputGuardrails` passes the caller's org into `getSettings`. Proven red without the fix (passed `organizationId: undefined`).

## Verification

- `bun run typecheck` clean for `core` + `server` (after `make build-packages` — worktree dist was stale from creation).
- Affected suites green in isolation: guardrails (65), instruction-service, chat-response-bridge + unified-thread-consumer (49).
- `make review` run before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786023310&installation_id=136316292&pr_number=1783&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1783&signature=ed6a8db7b1c07e5f227650bfac0ce7f50e5b4f61db856ff9a6935aca8271ce25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session instruction generation and output-guardrail checks now consistently respect the current organization, ensuring the correct per-org identity and settings are used when agents share the same ID.
  * Streaming delta rendering now accounts for organization-scoped guardrail availability, preventing unintended output in org-specific scenarios.
* **Tests**
  * Added regression coverage to verify organization-specific instruction and output-guardrail behavior, including session context selection and guardrail lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->