### PR TITLE
fix(errors): unified agent-error taxonomy — thin catalog, one classifier, one renderer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,12 @@ jobs:
       - name: SDK lifecycle e2e (apply + prune + real worker turn)
         run: bash scripts/sdk-e2e.sh
 
+      # Failure-path companion: drives a real provider 429 through the worker
+      # and asserts the unified AGENT_ERRORS catalog prose reaches the user with
+      # no raw-429 / "stopped responding" leak. Reuses this job's build.
+      - name: Error-taxonomy e2e (provider 429 → catalog prose)
+        run: bash scripts/sdk-e2e-error.sh
+
   # CLI command-coverage smoke — the hard gate that EVERY `lobu` command runs,
   # not just the SDK lifecycle (sdk-e2e covers that). Boots one `lobu run`
   # (embedded Postgres + a deterministic mock provider, no key) under an isolated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,9 +190,10 @@ jobs:
         run: bash scripts/sdk-e2e.sh
 
       # Failure-path companion: drives a real provider 429 through the worker
-      # and asserts the unified AGENT_ERRORS catalog prose reaches the user with
-      # no raw-429 / "stopped responding" leak. Reuses this job's build.
-      - name: Error-taxonomy e2e (provider 429 → catalog prose)
+      # and asserts the provider's own message reaches the user verbatim (incl.
+      # reset time) with no generic "stopped responding" mask. Reuses this
+      # job's build.
+      - name: Error-taxonomy e2e (provider 429 → verbatim relay)
         run: bash scripts/sdk-e2e-error.sh
 
   # CLI command-coverage smoke — the hard gate that EVERY `lobu` command runs,

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ packages/*/~/
 .lobu/
 .bench-hindsight/
 .sdk-e2e-run/
+.sdk-e2e-error-run/
 .managed-e2e-run/
 .cli-smoke-run/
 .mac-cli-auth-e2e/

--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,14 @@ test-e2e:
 test-e2e-sdk:
 	@./scripts/sdk-e2e.sh
 
+# Error-taxonomy e2e: the failure-path companion to sdk-e2e. Boots `lobu run`
+# with the mock provider in 429 mode and drives a real turn through a spawned
+# worker, asserting the unified AGENT_ERRORS catalog prose reaches the user
+# (provider + reset time) with NO raw-429 or generic "stopped responding" leak.
+# Self-contained, no key. Guards the whole classify→signal→render chain.
+test-e2e-error:
+	@./scripts/sdk-e2e-error.sh
+
 # CLI command-coverage smoke: boots one `lobu run` (embedded Postgres + mock
 # provider) under an isolated HOME and walks EVERY `lobu` command/subcommand
 # once, asserting each runs (or fails gracefully). Self-contained, no key. This

--- a/Makefile
+++ b/Makefile
@@ -196,8 +196,8 @@ test-e2e-sdk:
 
 # Error-taxonomy e2e: the failure-path companion to sdk-e2e. Boots `lobu run`
 # with the mock provider in 429 mode and drives a real turn through a spawned
-# worker, asserting the unified AGENT_ERRORS catalog prose reaches the user
-# (provider + reset time) with NO raw-429 or generic "stopped responding" leak.
+# worker, asserting the provider's own 429 message reaches the user verbatim
+# (incl. the reset time) with NO generic "stopped responding" mask.
 # Self-contained, no key. Guards the whole classify→signal→render chain.
 test-e2e-error:
 	@./scripts/sdk-e2e-error.sh

--- a/packages/agent-worker/src/__tests__/audio-provider-suggestions.test.ts
+++ b/packages/agent-worker/src/__tests__/audio-provider-suggestions.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { classifyAgentError } from "../core/error-handler";
 import { OpenClawWorker } from "../openclaw/worker";
 import {
   fetchAudioProviderSuggestions,
@@ -180,20 +181,16 @@ describe("OpenClawWorker audio permission hint", () => {
   });
 });
 
-describe("OpenClawWorker auth hint messaging", () => {
-  test("routes missing provider auth to admin guidance", async () => {
-    const hint = await (
-      OpenClawWorker.prototype as any
-    ).maybeBuildAuthHintMessage(
-      'Authentication failed for "openai"',
-      "openai",
-      "gpt-4.1",
-      "http://gateway",
-      "token"
+describe("provider auth classification (no bespoke hint round-trip)", () => {
+  test("a raw provider auth error classifies to PROVIDER_AUTH with the provider in context", () => {
+    // The worker no longer rewrites the raw error into an admin-guidance
+    // sentence that the classifier then re-parses. The raw error classifies
+    // directly, and the provider (threaded from the worker's ExecutionError
+    // context) is what the AGENT_ERRORS catalog uses to render
+    // "Your openai provider's credentials are invalid…" + a reconnect CTA.
+    const { code } = classifyAgentError(
+      new Error('Authentication failed for "openai"')
     );
-
-    expect(hint).toContain("gpt-4.1");
-    expect(hint).toContain("admin");
-    expect(hint).toContain("openai");
+    expect(code).toBe("PROVIDER_AUTH");
   });
 });

--- a/packages/agent-worker/src/__tests__/audio-provider-suggestions.test.ts
+++ b/packages/agent-worker/src/__tests__/audio-provider-suggestions.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { classifyAgentError } from "../core/error-handler";
+import { classifyError } from "../core/error-handler";
 import { OpenClawWorker } from "../openclaw/worker";
 import {
   fetchAudioProviderSuggestions,
@@ -182,15 +182,13 @@ describe("OpenClawWorker audio permission hint", () => {
 });
 
 describe("provider auth classification (no bespoke hint round-trip)", () => {
-  test("a raw provider auth error classifies to PROVIDER_AUTH with the provider in context", () => {
+  test("a raw provider auth error classifies to PROVIDER_AUTH", () => {
     // The worker no longer rewrites the raw error into an admin-guidance
     // sentence that the classifier then re-parses. The raw error classifies
-    // directly, and the provider (threaded from the worker's ExecutionError
-    // context) is what the AGENT_ERRORS catalog uses to render
-    // "Your openai provider's credentials are invalid…" + a reconnect CTA.
-    const { code } = classifyAgentError(
-      new Error('Authentication failed for "openai"')
+    // directly to a code; that code selects the reconnect CTA, and the raw
+    // provider message is relayed verbatim as the body.
+    expect(classifyError(new Error('Authentication failed for "openai"'))).toBe(
+      "PROVIDER_AUTH"
     );
-    expect(code).toBe("PROVIDER_AUTH");
   });
 });

--- a/packages/agent-worker/src/__tests__/error-handler.test.ts
+++ b/packages/agent-worker/src/__tests__/error-handler.test.ts
@@ -6,8 +6,12 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { WorkerTransport } from "@lobu/core";
-import { classifyError, handleExecutionError } from "../core/error-handler";
+import type { AgentErrorContext, WorkerTransport } from "@lobu/core";
+import {
+  classifyAgentError,
+  classifyError,
+  handleExecutionError,
+} from "../core/error-handler";
 
 type Recorder = {
   transport: WorkerTransport;
@@ -16,7 +20,11 @@ type Recorder = {
     isFullReplacement?: boolean;
     isFinal?: boolean;
   }>;
-  errors: Array<{ message: string; code?: string }>;
+  errors: Array<{
+    message: string;
+    code?: string;
+    context?: AgentErrorContext;
+  }>;
 };
 
 function makeTransport(): Recorder {
@@ -31,8 +39,12 @@ function makeTransport(): Recorder {
     },
     signalDone: asyncNoop,
     signalCompletion: asyncNoop,
-    async signalError(error, errorCode) {
-      errors.push({ message: error.message, code: errorCode });
+    async signalError(error, errorCode, errorContext) {
+      errors.push({
+        message: error.message,
+        code: errorCode,
+        context: errorContext,
+      });
     },
     sendStatusUpdate: asyncNoop,
     sendCustomEvent: asyncNoop,
@@ -78,7 +90,7 @@ describe("handleExecutionError", () => {
     expect(errors[0].code).toBe("NO_MODEL_CONFIGURED");
   });
 
-  test("PROVIDER_* failures STILL emit a user-facing delta (not silent)", async () => {
+  test("classified PROVIDER_* failures signal code + context, NO worker delta", async () => {
     const { transport, deltas, errors } = makeTransport();
 
     await handleExecutionError(
@@ -86,15 +98,16 @@ describe("handleExecutionError", () => {
       transport
     );
 
-    // Unlike SESSION_TIMEOUT / NO_MODEL_CONFIGURED, a provider failure that
-    // reaches the catch-all must still tell the user something broke.
-    expect(deltas).toHaveLength(1);
-    expect(deltas[0].delta).toContain("💥 Worker crashed");
+    // New contract: the gateway renderer owns the user-facing text (via
+    // AGENT_ERRORS), so the worker must NOT also emit a formatted delta —
+    // that historical double-formatting is exactly what made the same error
+    // render differently across surfaces.
+    expect(deltas).toHaveLength(0);
     expect(errors).toHaveLength(1);
     expect(errors[0].code).toBe("PROVIDER_UNKNOWN_MODEL");
   });
 
-  test("provider routing failures are explanatory, not crash-branded", async () => {
+  test("provider routing failures signal a code, not a crash delta", async () => {
     const { transport, deltas, errors } = makeTransport();
 
     await handleExecutionError(
@@ -104,11 +117,32 @@ describe("handleExecutionError", () => {
       transport
     );
 
-    expect(deltas).toHaveLength(1);
-    expect(deltas[0].delta).toContain("⚠️ The selected model");
-    expect(deltas[0].delta).not.toContain("Worker crashed");
+    expect(deltas).toHaveLength(0);
     expect(errors).toHaveLength(1);
     expect(errors[0].code).toBe("PROVIDER_BASE_URL_UNRESOLVED");
+  });
+
+  test("provider QUOTA (z.ai 429) classifies + threads the reset time", async () => {
+    const { transport, deltas, errors } = makeTransport();
+
+    // The exact prod shape from the app pod logs.
+    await handleExecutionError(
+      new Error(
+        "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47"
+      ),
+      transport,
+      { provider: "z-ai" }
+    );
+
+    // No worker-formatted delta — the renderer builds the CTA'd message.
+    expect(deltas).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe("PROVIDER_QUOTA_EXHAUSTED");
+    // The reset time is parsed out of the raw provider text so the rendered
+    // message can tell the user when it resets — and the worker's provider is
+    // threaded in for "Your z-ai provider…".
+    expect(errors[0].context?.resetAt).toBe("2026-07-10 04:32:47");
+    expect(errors[0].context?.provider).toBe("z-ai");
   });
 });
 
@@ -126,15 +160,6 @@ describe("classifyError", () => {
       classifyError(
         new Error(
           "401 No provider credentials configured. End-user provider setup is not available in chat yet."
-        )
-      )
-    ).toBe("PROVIDER_AUTH");
-    // The admin-facing auth hint that session-runner substitutes for the raw
-    // provider 401 before the worker's capture sees it.
-    expect(
-      classifyError(
-        new Error(
-          "To use gpt-4o, an admin needs to connect openai on the base agent. Ask an admin to configure openai and then try again."
         )
       )
     ).toBe("PROVIDER_AUTH");
@@ -166,6 +191,43 @@ describe("classifyError", () => {
     ).toBe("PROVIDER_BASE_URL_UNRESOLVED");
   });
 
+  test("recognizes provider quota / rate-limit exhaustion", () => {
+    expect(
+      classifyError(
+        new Error(
+          "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47"
+        )
+      )
+    ).toBe("PROVIDER_QUOTA_EXHAUSTED");
+    expect(classifyError(new Error("429 Too Many Requests"))).toBe(
+      "PROVIDER_QUOTA_EXHAUSTED"
+    );
+    expect(classifyError(new Error("rate limit exceeded"))).toBe(
+      "PROVIDER_QUOTA_EXHAUSTED"
+    );
+    expect(classifyError(new Error("RESOURCE_EXHAUSTED: quota"))).toBe(
+      "PROVIDER_QUOTA_EXHAUSTED"
+    );
+  });
+
+  test("classifyAgentError extracts the reset time when present", () => {
+    const { code, context } = classifyAgentError(
+      new Error(
+        "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47"
+      )
+    );
+    expect(code).toBe("PROVIDER_QUOTA_EXHAUSTED");
+    expect(context.resetAt).toBe("2026-07-10 04:32:47");
+  });
+
+  test("quota without a reset time still classifies (no resetAt)", () => {
+    const { code, context } = classifyAgentError(
+      new Error("429 rate limit exceeded")
+    );
+    expect(code).toBe("PROVIDER_QUOTA_EXHAUSTED");
+    expect(context.resetAt).toBeUndefined();
+  });
+
   test("leaves unrelated crashes unclassified", () => {
     expect(classifyError(new Error("kaboom"))).toBeUndefined();
     expect(classifyError("not an error")).toBeUndefined();
@@ -176,5 +238,18 @@ describe("classifyError", () => {
     expect(classifyError(new Error("No model configured"))).toBe(
       "NO_MODEL_CONFIGURED"
     );
+  });
+
+  test("model-resolver's 'No model resolved' now classifies (was unclassified)", () => {
+    // model-resolver.ts throws this when no default/per-behavior/org model is
+    // set. It previously fell through to `undefined` → raw crash delta + dodged
+    // the PROVIDER_* Sentry alert. Now it renders the actionable catalog line.
+    expect(
+      classifyError(
+        new Error(
+          "No model resolved for this run. Set the agent's default model, a per-behavior model, or an org default inference provider."
+        )
+      )
+    ).toBe("NO_MODEL_CONFIGURED");
   });
 });

--- a/packages/agent-worker/src/__tests__/error-handler.test.ts
+++ b/packages/agent-worker/src/__tests__/error-handler.test.ts
@@ -6,12 +6,8 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { AgentErrorContext, WorkerTransport } from "@lobu/core";
-import {
-  classifyAgentError,
-  classifyError,
-  handleExecutionError,
-} from "../core/error-handler";
+import type { WorkerTransport } from "@lobu/core";
+import { classifyError, handleExecutionError } from "../core/error-handler";
 
 type Recorder = {
   transport: WorkerTransport;
@@ -20,11 +16,7 @@ type Recorder = {
     isFullReplacement?: boolean;
     isFinal?: boolean;
   }>;
-  errors: Array<{
-    message: string;
-    code?: string;
-    context?: AgentErrorContext;
-  }>;
+  errors: Array<{ message: string; code?: string }>;
 };
 
 function makeTransport(): Recorder {
@@ -39,12 +31,8 @@ function makeTransport(): Recorder {
     },
     signalDone: asyncNoop,
     signalCompletion: asyncNoop,
-    async signalError(error, errorCode, errorContext) {
-      errors.push({
-        message: error.message,
-        code: errorCode,
-        context: errorContext,
-      });
+    async signalError(error, errorCode) {
+      errors.push({ message: error.message, code: errorCode });
     },
     sendStatusUpdate: asyncNoop,
     sendCustomEvent: asyncNoop,
@@ -122,27 +110,22 @@ describe("handleExecutionError", () => {
     expect(errors[0].code).toBe("PROVIDER_BASE_URL_UNRESOLVED");
   });
 
-  test("provider QUOTA (z.ai 429) classifies + threads the reset time", async () => {
+  test("provider QUOTA (z.ai 429) classifies + relays the raw message verbatim", async () => {
     const { transport, deltas, errors } = makeTransport();
 
     // The exact prod shape from the app pod logs.
-    await handleExecutionError(
-      new Error(
-        "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47"
-      ),
-      transport,
-      { provider: "z-ai" }
-    );
+    const raw =
+      "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47";
+    await handleExecutionError(new Error(raw), transport, { provider: "z-ai" });
 
-    // No worker-formatted delta — the renderer builds the CTA'd message.
+    // No worker-formatted delta — the renderer presents it (raw message body +
+    // the code's CTA link). The raw message reaches the wire UNCHANGED: it
+    // already tells the user when the quota resets, so we relay it verbatim
+    // instead of parsing a reset time out of it.
     expect(deltas).toHaveLength(0);
     expect(errors).toHaveLength(1);
     expect(errors[0].code).toBe("PROVIDER_QUOTA_EXHAUSTED");
-    // The reset time is parsed out of the raw provider text so the rendered
-    // message can tell the user when it resets — and the worker's provider is
-    // threaded in for "Your z-ai provider…".
-    expect(errors[0].context?.resetAt).toBe("2026-07-10 04:32:47");
-    expect(errors[0].context?.provider).toBe("z-ai");
+    expect(errors[0].message).toBe(raw);
   });
 });
 
@@ -208,24 +191,6 @@ describe("classifyError", () => {
     expect(classifyError(new Error("RESOURCE_EXHAUSTED: quota"))).toBe(
       "PROVIDER_QUOTA_EXHAUSTED"
     );
-  });
-
-  test("classifyAgentError extracts the reset time when present", () => {
-    const { code, context } = classifyAgentError(
-      new Error(
-        "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47"
-      )
-    );
-    expect(code).toBe("PROVIDER_QUOTA_EXHAUSTED");
-    expect(context.resetAt).toBe("2026-07-10 04:32:47");
-  });
-
-  test("quota without a reset time still classifies (no resetAt)", () => {
-    const { code, context } = classifyAgentError(
-      new Error("429 rate limit exceeded")
-    );
-    expect(code).toBe("PROVIDER_QUOTA_EXHAUSTED");
-    expect(context.resetAt).toBeUndefined();
   });
 
   test("leaves unrelated crashes unclassified", () => {

--- a/packages/agent-worker/src/core/error-handler.ts
+++ b/packages/agent-worker/src/core/error-handler.ts
@@ -1,4 +1,10 @@
-import { createLogger, getSentry, type WorkerTransport } from "@lobu/core";
+import {
+  type AgentErrorContext,
+  AgentErrorCode,
+  createLogger,
+  getSentry,
+  type WorkerTransport,
+} from "@lobu/core";
 import { getProviderAuthHintFromError } from "../shared/provider-auth-hints";
 
 const logger = createLogger("worker");
@@ -14,12 +20,14 @@ interface ExecutionErrorContext {
   runId?: number | string;
 }
 
-function formatErrorMessage(error: unknown, code?: string): string {
+/**
+ * Format the crash delta for an UNCLASSIFIED failure only. Classified errors
+ * are rendered by the gateway from `AGENT_ERRORS`, not here — see
+ * `handleExecutionError`.
+ */
+function formatErrorMessage(error: unknown): string {
   if (!(error instanceof Error)) {
     return `💥 Worker crashed: Unknown error`;
-  }
-  if (code === "PROVIDER_BASE_URL_UNRESOLVED") {
-    return `⚠️ ${error.message}`;
   }
   const name = error.constructor.name;
   const isGeneric = name === "Error" || name === "WorkspaceError";
@@ -42,22 +50,72 @@ const SESSION_TIMEOUT_MESSAGE = "SESSION_TIMEOUT";
  * dedicated upstream user message. PROVIDER_* codes are NOT in this set — they
  * must still surface a crash delta to the user when they reach the catch-all.
  */
-const SILENT_DELTA_CODES = new Set(["SESSION_TIMEOUT", "NO_MODEL_CONFIGURED"]);
+const SILENT_DELTA_CODES = new Set<string>([
+  AgentErrorCode.SESSION_TIMEOUT,
+  AgentErrorCode.NO_MODEL_CONFIGURED,
+]);
 
-export function classifyError(error: unknown): string | undefined {
-  if (!(error instanceof Error)) return undefined;
+/**
+ * Pull a human reset time out of a provider quota error so the rendered
+ * message can tell the user when they can retry. z.ai's 429 body is
+ * "…Your limit will reset at 2026-07-10 04:32:47". Returns undefined when no
+ * timestamp is present (the message still classifies as quota-exhausted).
+ */
+function extractResetAt(message: string): string | undefined {
+  const m = message.match(
+    /reset(?:s| at| will reset at)?\s+([0-9]{4}-[0-9]{2}-[0-9]{2}[ T][0-9]{2}:[0-9]{2}(?::[0-9]{2})?)/i
+  );
+  return m?.[1];
+}
+
+/**
+ * THE classifier: message → { code, context }. This is the single source of
+ * truth for turning a raw worker/provider failure into a catalog code — every
+ * other layer (worker failure branch, Sentry tagging, the gateway renderers)
+ * consumes this rather than re-implementing its own regex. Adding a failure
+ * mode = one pattern here + one entry in `AGENT_ERRORS`.
+ */
+export function classifyAgentError(error: unknown): {
+  code?: AgentErrorCode;
+  context: AgentErrorContext;
+} {
+  const context: AgentErrorContext = {};
+  if (!(error instanceof Error)) return { context };
   const message = error.message;
-  if (message === SESSION_TIMEOUT_MESSAGE) return "SESSION_TIMEOUT";
+
+  if (message === SESSION_TIMEOUT_MESSAGE)
+    return { code: AgentErrorCode.SESSION_TIMEOUT, context };
+
+  // Provider usage/rate limit. Covers z.ai's "429 Weekly/Monthly Limit
+  // Exhausted", generic rate-limit/quota phrasings, and a bare 429. Placed
+  // before PROVIDER_AUTH because a rate-limited request can also echo auth-ish
+  // words; the quota shape is the more specific, more actionable signal.
+  if (
+    /weekly\/monthly limit exhausted|limit exhausted|rate[-\s]?limit|quota (?:exceeded|exhausted)|too many requests|\b429\b|resource_exhausted/i.test(
+      message
+    )
+  ) {
+    const resetAt = extractResetAt(message);
+    if (resetAt) context.resetAt = resetAt;
+    return { code: AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED, context };
+  }
+
   if (
     message.includes("No model configured") ||
     message.includes("No model selected") ||
+    // model-resolver.ts throws "No model resolved for this run…" when no
+    // default/per-behavior/org model is set. Was previously UNCLASSIFIED — it
+    // dodged the catalog and surfaced as a raw "💥 Worker crashed" instead of
+    // the actionable "connect a provider" guidance.
+    message.includes("No model resolved") ||
     message.includes("No provider specified")
   )
-    return "NO_MODEL_CONFIGURED";
+    return { code: AgentErrorCode.NO_MODEL_CONFIGURED, context };
   // Reuse the canonical provider-auth regex (provider-auth-hints.ts) so the
   // classification matches the same auth-failure strings the worker already
   // detects elsewhere.
-  if (getProviderAuthHintFromError(message)) return "PROVIDER_AUTH";
+  if (getProviderAuthHintFromError(message))
+    return { code: AgentErrorCode.PROVIDER_AUTH, context };
   // The gateway secret-proxy 401s with "No provider credentials configured"
   // (code no_credentials) when every credential tier misses. The live red-test
   // (LOBU-BACKEND-W) landed as `unclassified` because the auth-hint regex
@@ -66,18 +124,11 @@ export function classifyError(error: unknown): string | undefined {
   if (
     /no\s+(provider\s+)?credentials\s+configured|no_credentials/i.test(message)
   )
-    return "PROVIDER_AUTH";
-  // session-runner replaces a raw provider 401 with the admin-facing hint
-  // BEFORE the worker's failure branch captures it (maybeBuildAuthHintMessage),
-  // so the captured message is the hint, not the original "Incorrect API key".
-  // Classify the hint shape too or auth failures stay `unclassified` and dodge
-  // the PROVIDER_* Sentry alert (second live red-test round, LOBU-BACKEND-W).
-  if (/needs to connect .+ on the base agent/i.test(message))
-    return "PROVIDER_AUTH";
+    return { code: AgentErrorCode.PROVIDER_AUTH, context };
   // `worker.ts` throws "Model \"<id>\" not found for provider ..." and pi-ai /
   // upstream surface "<x> is not a valid model"/"unknown model"/"model ... not found".
   if (/not a valid model|unknown model|model .* not found/i.test(message))
-    return "PROVIDER_UNKNOWN_MODEL";
+    return { code: AgentErrorCode.PROVIDER_UNKNOWN_MODEL, context };
   // model-resolver.ts / session-runner.ts throw this when a non-OpenAI
   // provider cannot be routed through the Lobu gateway proxy. This is usually a
   // provider/model configuration issue, not an agent crash.
@@ -86,8 +137,18 @@ export function classifyError(error: unknown): string | undefined {
     /provider is not connected to this agent/i.test(message) ||
     /did not receive the gateway routing URL/i.test(message)
   )
-    return "PROVIDER_BASE_URL_UNRESOLVED";
-  return undefined;
+    return { code: AgentErrorCode.PROVIDER_BASE_URL_UNRESOLVED, context };
+  return { context };
+}
+
+/**
+ * Back-compat thin wrapper returning just the code string. Callers that only
+ * need the classification for Sentry tagging / silent-delta gating use this;
+ * anything that renders a user message should use `classifyAgentError` to also
+ * get the context (resetAt, provider).
+ */
+export function classifyError(error: unknown): string | undefined {
+  return classifyAgentError(error).code;
 }
 
 export async function handleExecutionError(
@@ -97,7 +158,7 @@ export async function handleExecutionError(
 ): Promise<void> {
   logger.error("Worker execution failed:", error);
 
-  const code = classifyError(error);
+  const { code, context } = classifyAgentError(error);
   const errorInstance =
     error instanceof Error ? error : new Error(String(error));
 
@@ -105,7 +166,7 @@ export async function handleExecutionError(
   // the worker was spawned without SENTRY_DSN, so this is a safe no-op in dev /
   // self-host. SESSION_TIMEOUT is retried silently — capturing it would be pure
   // noise — so it's the one classification we skip.
-  if (code !== "SESSION_TIMEOUT") {
+  if (code !== AgentErrorCode.SESSION_TIMEOUT) {
     getSentry()?.captureException(errorInstance, {
       tags: {
         provider: ctx?.provider ?? "unknown",
@@ -118,20 +179,30 @@ export async function handleExecutionError(
     });
   }
 
+  // Thread the worker's provider into the render context when the classifier
+  // didn't already pull one from the message, so the rendered line can say
+  // "Your z-ai provider…" instead of the generic "Your AI provider…".
+  if (!context.provider && ctx?.provider) context.provider = ctx.provider;
+
   try {
     if (code && SILENT_DELTA_CODES.has(code)) {
       // SESSION_TIMEOUT (retried silently) / NO_MODEL_CONFIGURED (dedicated
       // upstream user message): signal for bookkeeping, no user-facing delta.
-      await transport.signalError(errorInstance, code);
+      await transport.signalError(errorInstance, code, context);
+    } else if (code) {
+      // CLASSIFIED failure: the gateway renderer owns the user-facing text +
+      // CTA (via AGENT_ERRORS). The worker must NOT also emit a formatted delta
+      // — doing so is exactly the historical double-formatting that made the
+      // same error render differently across surfaces. Signal code + context
+      // and let one renderer present it.
+      await transport.signalError(errorInstance, code, context);
     } else {
-      // Unclassified crashes AND PROVIDER_* failures still show the user a
-      // crash message; the classification rides along on signalError.
-      await transport.sendStreamDelta(
-        formatErrorMessage(error, code),
-        true,
-        true
-      );
-      await transport.signalError(errorInstance, code);
+      // UNCLASSIFIED crash: no catalog entry to render from, so the worker
+      // still shows its raw crash delta rather than swallowing the failure.
+      // Every time this branch fires it's a signal to add a classifier pattern
+      // + catalog entry.
+      await transport.sendStreamDelta(formatErrorMessage(error), true, true);
+      await transport.signalError(errorInstance, code, context);
     }
   } catch (gatewayError) {
     logger.error("Failed to send error via gateway:", gatewayError);

--- a/packages/agent-worker/src/core/error-handler.ts
+++ b/packages/agent-worker/src/core/error-handler.ts
@@ -1,5 +1,4 @@
 import {
-  type AgentErrorContext,
   AgentErrorCode,
   createLogger,
   getSentry,
@@ -45,46 +44,22 @@ function formatErrorMessage(error: unknown): string {
 const SESSION_TIMEOUT_MESSAGE = "SESSION_TIMEOUT";
 
 /**
- * Classified codes whose user-facing "💥 Worker crashed" delta is intentionally
- * suppressed: SESSION_TIMEOUT is retried silently, and NO_MODEL_CONFIGURED has a
- * dedicated upstream user message. PROVIDER_* codes are NOT in this set — they
- * must still surface a crash delta to the user when they reach the catch-all.
+ * THE classifier: message → catalog code. Single source of truth for turning a
+ * raw worker/provider failure into an `AgentErrorCode` — every other layer (the
+ * worker failure branch, Sentry tagging, the gateway renderers) consumes this
+ * rather than re-implementing its own regex. Adding a failure mode = one pattern
+ * here + one entry in `AGENT_ERRORS`.
+ *
+ * The code selects only the CTA link. The user-facing TEXT for provider errors
+ * is the provider's own message (relayed verbatim); we do NOT parse or reword
+ * it — no reset-time extraction, no provider-label interpolation.
  */
-const SILENT_DELTA_CODES = new Set<string>([
-  AgentErrorCode.SESSION_TIMEOUT,
-  AgentErrorCode.NO_MODEL_CONFIGURED,
-]);
-
-/**
- * Pull a human reset time out of a provider quota error so the rendered
- * message can tell the user when they can retry. z.ai's 429 body is
- * "…Your limit will reset at 2026-07-10 04:32:47". Returns undefined when no
- * timestamp is present (the message still classifies as quota-exhausted).
- */
-function extractResetAt(message: string): string | undefined {
-  const m = message.match(
-    /reset(?:s| at| will reset at)?\s+([0-9]{4}-[0-9]{2}-[0-9]{2}[ T][0-9]{2}:[0-9]{2}(?::[0-9]{2})?)/i
-  );
-  return m?.[1];
-}
-
-/**
- * THE classifier: message → { code, context }. This is the single source of
- * truth for turning a raw worker/provider failure into a catalog code — every
- * other layer (worker failure branch, Sentry tagging, the gateway renderers)
- * consumes this rather than re-implementing its own regex. Adding a failure
- * mode = one pattern here + one entry in `AGENT_ERRORS`.
- */
-export function classifyAgentError(error: unknown): {
-  code?: AgentErrorCode;
-  context: AgentErrorContext;
-} {
-  const context: AgentErrorContext = {};
-  if (!(error instanceof Error)) return { context };
+export function classifyError(error: unknown): AgentErrorCode | undefined {
+  if (!(error instanceof Error)) return undefined;
   const message = error.message;
 
   if (message === SESSION_TIMEOUT_MESSAGE)
-    return { code: AgentErrorCode.SESSION_TIMEOUT, context };
+    return AgentErrorCode.SESSION_TIMEOUT;
 
   // Provider usage/rate limit. Covers z.ai's "429 Weekly/Monthly Limit
   // Exhausted", generic rate-limit/quota phrasings, and a bare 429. Placed
@@ -94,11 +69,8 @@ export function classifyAgentError(error: unknown): {
     /weekly\/monthly limit exhausted|limit exhausted|rate[-\s]?limit|quota (?:exceeded|exhausted)|too many requests|\b429\b|resource_exhausted/i.test(
       message
     )
-  ) {
-    const resetAt = extractResetAt(message);
-    if (resetAt) context.resetAt = resetAt;
-    return { code: AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED, context };
-  }
+  )
+    return AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED;
 
   if (
     message.includes("No model configured") ||
@@ -110,12 +82,12 @@ export function classifyAgentError(error: unknown): {
     message.includes("No model resolved") ||
     message.includes("No provider specified")
   )
-    return { code: AgentErrorCode.NO_MODEL_CONFIGURED, context };
+    return AgentErrorCode.NO_MODEL_CONFIGURED;
   // Reuse the canonical provider-auth regex (provider-auth-hints.ts) so the
   // classification matches the same auth-failure strings the worker already
   // detects elsewhere.
   if (getProviderAuthHintFromError(message))
-    return { code: AgentErrorCode.PROVIDER_AUTH, context };
+    return AgentErrorCode.PROVIDER_AUTH;
   // The gateway secret-proxy 401s with "No provider credentials configured"
   // (code no_credentials) when every credential tier misses. The live red-test
   // (LOBU-BACKEND-W) landed as `unclassified` because the auth-hint regex
@@ -124,11 +96,11 @@ export function classifyAgentError(error: unknown): {
   if (
     /no\s+(provider\s+)?credentials\s+configured|no_credentials/i.test(message)
   )
-    return { code: AgentErrorCode.PROVIDER_AUTH, context };
+    return AgentErrorCode.PROVIDER_AUTH;
   // `worker.ts` throws "Model \"<id>\" not found for provider ..." and pi-ai /
   // upstream surface "<x> is not a valid model"/"unknown model"/"model ... not found".
   if (/not a valid model|unknown model|model .* not found/i.test(message))
-    return { code: AgentErrorCode.PROVIDER_UNKNOWN_MODEL, context };
+    return AgentErrorCode.PROVIDER_UNKNOWN_MODEL;
   // model-resolver.ts / session-runner.ts throw this when a non-OpenAI
   // provider cannot be routed through the Lobu gateway proxy. This is usually a
   // provider/model configuration issue, not an agent crash.
@@ -137,18 +109,8 @@ export function classifyAgentError(error: unknown): {
     /provider is not connected to this agent/i.test(message) ||
     /did not receive the gateway routing URL/i.test(message)
   )
-    return { code: AgentErrorCode.PROVIDER_BASE_URL_UNRESOLVED, context };
-  return { context };
-}
-
-/**
- * Back-compat thin wrapper returning just the code string. Callers that only
- * need the classification for Sentry tagging / silent-delta gating use this;
- * anything that renders a user message should use `classifyAgentError` to also
- * get the context (resetAt, provider).
- */
-export function classifyError(error: unknown): string | undefined {
-  return classifyAgentError(error).code;
+    return AgentErrorCode.PROVIDER_BASE_URL_UNRESOLVED;
+  return undefined;
 }
 
 export async function handleExecutionError(
@@ -158,7 +120,7 @@ export async function handleExecutionError(
 ): Promise<void> {
   logger.error("Worker execution failed:", error);
 
-  const { code, context } = classifyAgentError(error);
+  const code = classifyError(error);
   const errorInstance =
     error instanceof Error ? error : new Error(String(error));
 
@@ -179,31 +141,18 @@ export async function handleExecutionError(
     });
   }
 
-  // Thread the worker's provider into the render context when the classifier
-  // didn't already pull one from the message, so the rendered line can say
-  // "Your z-ai provider…" instead of the generic "Your AI provider…".
-  if (!context.provider && ctx?.provider) context.provider = ctx.provider;
-
   try {
-    if (code && SILENT_DELTA_CODES.has(code)) {
-      // SESSION_TIMEOUT (retried silently) / NO_MODEL_CONFIGURED (dedicated
-      // upstream user message): signal for bookkeeping, no user-facing delta.
-      await transport.signalError(errorInstance, code, context);
-    } else if (code) {
-      // CLASSIFIED failure: the gateway renderer owns the user-facing text +
-      // CTA (via AGENT_ERRORS). The worker must NOT also emit a formatted delta
-      // — doing so is exactly the historical double-formatting that made the
-      // same error render differently across surfaces. Signal code + context
-      // and let one renderer present it.
-      await transport.signalError(errorInstance, code, context);
-    } else {
-      // UNCLASSIFIED crash: no catalog entry to render from, so the worker
-      // still shows its raw crash delta rather than swallowing the failure.
-      // Every time this branch fires it's a signal to add a classifier pattern
-      // + catalog entry.
+    // UNCLASSIFIED crash only: no catalog entry to render from, so the worker
+    // shows its raw crash delta rather than swallowing the failure. Every time
+    // this fires it's a signal to add a classifier pattern + catalog entry.
+    // Any CLASSIFIED failure emits NO delta — the gateway renderer presents it
+    // (provider message as the body + the code's CTA link). Emitting a delta
+    // here too is the historical double-formatting that made the same error
+    // render differently across surfaces.
+    if (!code) {
       await transport.sendStreamDelta(formatErrorMessage(error), true, true);
-      await transport.signalError(errorInstance, code, context);
     }
+    await transport.signalError(errorInstance, code);
   } catch (gatewayError) {
     logger.error("Failed to send error via gateway:", gatewayError);
     throw error;

--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  type AgentErrorContext,
   createLogger,
   retryWithBackoff,
   type WorkerTransport,
@@ -181,16 +180,11 @@ export class HttpWorkerTransport implements WorkerTransport {
     );
   }
 
-  async signalError(
-    error: Error,
-    errorCode?: string,
-    errorContext?: AgentErrorContext
-  ): Promise<void> {
+  async signalError(error: Error, errorCode?: string): Promise<void> {
     await this.sendResponse(
       this.buildBaseResponse({
         error: error.message,
         ...(errorCode && { errorCode }),
-        ...(errorContext && { errorContext }),
       })
     );
   }

--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  type AgentErrorContext,
   createLogger,
   retryWithBackoff,
   type WorkerTransport,
@@ -180,11 +181,16 @@ export class HttpWorkerTransport implements WorkerTransport {
     );
   }
 
-  async signalError(error: Error, errorCode?: string): Promise<void> {
+  async signalError(
+    error: Error,
+    errorCode?: string,
+    errorContext?: AgentErrorContext
+  ): Promise<void> {
     await this.sendResponse(
       this.buildBaseResponse({
         error: error.message,
         ...(errorCode && { errorCode }),
+        ...(errorContext && { errorContext }),
       })
     );
   }

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -1568,10 +1568,9 @@ user references earlier discussion or you need prior context.`);
     const sessionError = progressProcessor.consumeFatalErrorMessage();
     if (sessionError) {
       await emitAgentEnd(sessionError);
-      // Return the RAW provider error. Classification + user-facing rendering
-      // (incl. the provider-connect CTA) happen once downstream via
-      // classifyAgentError + AGENT_ERRORS — no bespoke sentence to rewrite here
-      // (which the classifier then had to regex-parse back into a code).
+      // Return the RAW provider error. It's the user-facing body verbatim; the
+      // only downstream work is `classifyError` → a code that selects the CTA
+      // link (via AGENT_ERRORS). No sentence is rewritten here.
       return buildResult(sessionError);
     }
 
@@ -1590,8 +1589,8 @@ user references earlier discussion or you need prior context.`);
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
     await emitAgentEnd(errorMsg);
-    // Raw error out; downstream classifyAgentError + AGENT_ERRORS own the
-    // user-facing message + CTA (see the sessionError branch above).
+    // Raw error out; downstream `classifyError` picks the code (→ CTA) and the
+    // raw message is the body verbatim (see the sessionError branch above).
     return buildResult(errorMsg);
   } finally {
     if (heartbeatTimer) {

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -430,11 +430,6 @@ interface RunAISessionParams {
     incomingImageCount: number;
     runSilentPrompt: (prompt: string) => Promise<void>;
   }) => Promise<void>;
-  maybeBuildAuthHintMessage: (
-    errorMessage: string,
-    provider: string,
-    modelId: string
-  ) => string;
 }
 
 // ---------------------------------------------------------------------------
@@ -461,7 +456,6 @@ export async function runAISession(
     onModelResolved,
     loadImageAttachments,
     maybeRunPreCompactionMemoryFlush,
-    maybeBuildAuthHintMessage,
   } = params;
 
   let rawOptions: Record<string, unknown>;
@@ -1574,12 +1568,11 @@ user references earlier discussion or you need prior context.`);
     const sessionError = progressProcessor.consumeFatalErrorMessage();
     if (sessionError) {
       await emitAgentEnd(sessionError);
-      const errorWithHint = maybeBuildAuthHintMessage(
-        sessionError,
-        rawProvider,
-        modelId
-      );
-      return buildResult(errorWithHint);
+      // Return the RAW provider error. Classification + user-facing rendering
+      // (incl. the provider-connect CTA) happen once downstream via
+      // classifyAgentError + AGENT_ERRORS — no bespoke sentence to rewrite here
+      // (which the classifier then had to regex-parse back into a code).
+      return buildResult(sessionError);
     }
 
     await emitAgentEnd();
@@ -1597,13 +1590,9 @@ user references earlier discussion or you need prior context.`);
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
     await emitAgentEnd(errorMsg);
-    const errorWithHint = maybeBuildAuthHintMessage(
-      errorMsg,
-      provider,
-      modelId
-    );
-
-    return buildResult(errorWithHint);
+    // Raw error out; downstream classifyAgentError + AGENT_ERRORS own the
+    // user-facing message + CTA (see the sessionError branch above).
+    return buildResult(errorMsg);
   } finally {
     if (heartbeatTimer) {
       clearInterval(heartbeatTimer);

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -5,11 +5,11 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { createLogger, getSentry, type WorkerTransport } from "@lobu/core";
+import { createLogger, type WorkerTransport } from "@lobu/core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import type { SettingsManager } from "@mariozechner/pi-coding-agent";
 import * as Sentry from "@sentry/node";
-import { classifyError, handleExecutionError } from "../core/error-handler";
+import { handleExecutionError } from "../core/error-handler";
 import { listAppDirectories } from "../core/project-scanner";
 import type {
   ProgressUpdate,
@@ -26,7 +26,6 @@ import {
 import { generateCustomInstructions } from "../instructions/builder";
 import { ProjectsInstructionProvider } from "../instructions/providers";
 import { fetchAudioProviderSuggestions } from "../shared/audio-provider-suggestions";
-import { getProviderAuthHintFromError } from "../shared/provider-auth-hints";
 import {
   OpenClawCoreInstructionProvider,
   OpenClawPromptIntentInstructionProvider,
@@ -311,32 +310,24 @@ export class OpenClawWorker implements WorkerExecutor {
           );
           throw new Error("SESSION_TIMEOUT");
         } else {
-          const isAuthError =
-            /no.credentials.configured|no_credentials|invalid.*api.key|incorrect.*api.key|token.*expired/i.test(
-              errorMsg
-            );
-          const userMessage = isAuthError
-            ? "Your AI provider credentials are invalid or expired. End-user provider setup is not available in chat yet. Ask an admin to reconnect the base agent provider."
-            : `❌ Session failed: ${errorMsg}`;
-          await this.workerTransport.sendStreamDelta(userMessage, true, true);
-          // These branches consume the `{success:false}` RESULT from
-          // runAISession — the session failed without throwing, so neither
-          // reaches execute()'s catch / handleExecutionError. Capture here or
-          // the failure is invisible to Sentry. Auth errors are an
-          // admin-config condition (level "warning"); other session failures
-          // are real faults (level "error").
-          this.reportSessionFailureToSentry(
-            errorMsg,
-            isAuthError ? "warning" : "error"
+          // A `{success:false}` RESULT (not a throw) still routes through the
+          // ONE classifier+renderer path so provider quota/auth/etc. get a
+          // catalog code, context, and a rendered CTA — identical to the
+          // thrown-error path in execute()'s catch. This deleted the historical
+          // second classifier here (ad-hoc isAuthError regex + raw
+          // "❌ Session failed: …"), which was a top source of divergent,
+          // link-less error text. handleExecutionError also reports to Sentry,
+          // so no separate reportSessionFailureToSentry call is needed.
+          await handleExecutionError(
+            new Error(errorMsg),
+            this.workerTransport,
+            {
+              provider: this.resolvedProvider,
+              model: this.resolvedModelId,
+              agentId: this.config.agentId,
+              runId: this.config.runId,
+            }
           );
-          if (isAuthError) {
-            await this.workerTransport.signalDone();
-          } else {
-            await this.workerTransport.signalError(
-              new Error(errorMsg),
-              classifyError(new Error(errorMsg))
-            );
-          }
         }
       }
 
@@ -364,30 +355,6 @@ export class OpenClawWorker implements WorkerExecutor {
       // next turn re-adopts a fresh per-run token and re-enables it.
       getWorkerTokenManager().disableAutoRefresh();
     }
-  }
-
-  /**
-   * Report a non-throwing session failure (the `{success:false}` result from
-   * runAISession) to Sentry Issues, tagged with the resolved provider/model so
-   * "openai doesn't work" is triageable. `getSentry()` is DSN-gated, so this is
-   * a safe no-op when the worker was spawned without SENTRY_DSN.
-   */
-  private reportSessionFailureToSentry(
-    errorMsg: string,
-    level: "warning" | "error"
-  ): void {
-    const error = new Error(errorMsg);
-    getSentry()?.captureException(error, {
-      tags: {
-        provider: this.resolvedProvider ?? "unknown",
-        model: this.resolvedModelId ?? "unknown",
-        agent_id: this.config.agentId ?? "unknown",
-        run_id:
-          this.config.runId != null ? String(this.config.runId) : "unknown",
-        classification: classifyError(error) ?? "unclassified",
-      },
-      level,
-    });
   }
 
   async cleanup(): Promise<void> {
@@ -571,8 +538,6 @@ export class OpenClawWorker implements WorkerExecutor {
       loadImageAttachments: () => this.loadImageAttachments(),
       maybeRunPreCompactionMemoryFlush: (p) =>
         this.maybeRunPreCompactionMemoryFlush(p),
-      maybeBuildAuthHintMessage: (msg, provider, modelId) =>
-        this.maybeBuildAuthHintMessage(msg, provider, modelId),
     });
   }
 
@@ -853,19 +818,6 @@ ${fileListing}
         "Session completed successfully - all content already streamed"
       );
     }
-  }
-
-  private maybeBuildAuthHintMessage(
-    errorMessage: string,
-    provider: string,
-    modelId: string
-  ): string {
-    const authHint = getProviderAuthHintFromError(errorMessage, provider);
-    if (!authHint) {
-      return errorMessage;
-    }
-
-    return `To use ${modelId}, an admin needs to connect ${authHint.providerName} on the base agent. Ask an admin to configure ${authHint.providerName} and then try again.`;
   }
 
   private async maybeBuildAudioPermissionHintMessage(

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -201,16 +201,28 @@ export type AgentErrorCtaKind =
   | "provider-connect" // → same settings page, provider-connect intent
   | "none";
 
-export interface AgentErrorContext {
-  /** Provider slug (e.g. "z-ai"), when known — interpolated into the message. */
-  provider?: string;
-  /** Human reset time for quota errors, e.g. "2026-07-10 04:32 UTC". */
-  resetAt?: string;
-}
-
+/**
+ * The spec is deliberately thin. Two families of failure:
+ *
+ *  - PROVIDER errors (quota/auth/unknown-model/routing) carry NO `message`: the
+ *    provider's own error string (relayed verbatim via `payload.error`) is the
+ *    body, because it already says the useful thing — including a reset time
+ *    like "will reset at 2026-07-10". We don't re-derive or reword it; the spec
+ *    only decides the CTA link to append. Zero string parsing.
+ *
+ *  - WORKER / config errors DO carry a `message`: they're synthesized by us (the
+ *    sweep, the deployment manager, the model resolver) so there is no upstream
+ *    provider string to fall back to.
+ *
+ * The renderer picks `spec.message ?? payload.error` and appends the CTA.
+ */
 export interface AgentErrorSpec {
-  /** Build the user-facing sentence (no link — the renderer appends the CTA). */
-  userMessage: (ctx: AgentErrorContext) => string;
+  /**
+   * Fixed user-facing text, ONLY for errors we synthesize (no provider string
+   * exists). Omit for provider errors — the renderer uses the relayed provider
+   * message instead.
+   */
+  message?: string;
   cta: AgentErrorCtaKind;
   /** Label for the CTA button/link. */
   ctaLabel?: string;
@@ -221,58 +233,48 @@ export interface AgentErrorSpec {
   silent?: boolean;
 }
 
-const providerLabel = (ctx: AgentErrorContext): string =>
-  ctx.provider ? `Your ${ctx.provider} provider` : "Your AI provider";
-
 export const AGENT_ERRORS: Record<AgentErrorCode, AgentErrorSpec> = {
+  // Provider errors — no `message`; the provider's own text is the body.
   [AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED]: {
-    userMessage: (ctx) =>
-      `${providerLabel(ctx)}'s usage limit is used up` +
-      (ctx.resetAt ? `. It resets ${ctx.resetAt}.` : "."),
     cta: "agent-settings",
     ctaLabel: "Manage provider",
   },
   [AgentErrorCode.PROVIDER_AUTH]: {
-    userMessage: (ctx) =>
-      `${providerLabel(ctx)}'s credentials are invalid or expired. Reconnect the provider to continue.`,
     cta: "provider-connect",
     ctaLabel: "Reconnect provider",
   },
   [AgentErrorCode.PROVIDER_UNKNOWN_MODEL]: {
-    userMessage: () =>
-      `The selected model isn't valid for this provider. Pick a supported model.`,
     cta: "agent-settings",
     ctaLabel: "Choose model",
   },
   [AgentErrorCode.PROVIDER_BASE_URL_UNRESOLVED]: {
-    userMessage: (ctx) =>
-      `${providerLabel(ctx)} isn't connected to this agent, so its requests can't be routed. Connect it to continue.`,
     cta: "agent-settings",
     ctaLabel: "Connect provider",
   },
+  // Errors we synthesize — carry our own text (no provider string to relay).
   [AgentErrorCode.NO_MODEL_CONFIGURED]: {
-    userMessage: () =>
-      `No model is configured for this agent. Connect a provider to get started.`,
+    message:
+      "No model is configured for this agent. Connect a provider to get started.",
     cta: "agent-settings",
     ctaLabel: "Connect a provider",
   },
   [AgentErrorCode.WORKER_UNRESPONSIVE]: {
-    userMessage: () =>
-      `The agent didn't finish responding in time. This is usually temporary — please try again.`,
+    message:
+      "The agent didn't finish responding in time. This is usually temporary — please try again.",
     cta: "none",
   },
   [AgentErrorCode.WORKER_DIED]: {
-    userMessage: () =>
-      `The agent stopped unexpectedly before it could reply. This is usually temporary — please try again.`,
+    message:
+      "The agent stopped unexpectedly before it could reply. This is usually temporary — please try again.",
     cta: "none",
   },
   [AgentErrorCode.WORKER_STARTUP_FAILED]: {
-    userMessage: () =>
-      `The agent couldn't start, so your request wasn't processed. Please try again in a moment.`,
+    message:
+      "The agent couldn't start, so your request wasn't processed. Please try again in a moment.",
     cta: "none",
   },
   [AgentErrorCode.WORKER_SANDBOX_REQUIRED]: {
-    userMessage: () =>
+    message:
       "LOBU_REQUIRE_WORKER_SANDBOX=1 but the systemd worker sandbox is unavailable on this host " +
       "(no usable `systemd-run --user` manager). Refusing to run an un-sandboxed worker. Provide a " +
       "user-level systemd manager, or unset LOBU_REQUIRE_WORKER_SANDBOX to allow unwrapped workers " +
@@ -280,7 +282,6 @@ export const AGENT_ERRORS: Record<AgentErrorCode, AgentErrorSpec> = {
     cta: "none",
   },
   [AgentErrorCode.SESSION_TIMEOUT]: {
-    userMessage: () => "",
     cta: "none",
     silent: true,
   },

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -135,3 +135,161 @@ export class ConversationOwnedElsewhereError extends BaseError {
 export class ConfigError extends BaseError {
   readonly name = "ConfigError";
 }
+
+/**
+ * The single catalog of user-facing agent-turn failures.
+ *
+ * Historically the same logical failure (e.g. "provider quota exhausted") was
+ * classified and formatted in four independent places — the worker's
+ * `classifyError`, a second ad-hoc regex in `worker.ts`, the Slack
+ * `chat-response-bridge`, and the browser SSE `response-renderer` — plus the
+ * turn-liveness sweep which invented its own string with no code at all. Each
+ * past fix touched one layer while the other three kept diverging, so the same
+ * error rendered differently depending on which layer terminalized first.
+ *
+ * This catalog makes an agent error DATA, resolved once:
+ *   1. `classifyError` (worker) is the ONLY classifier — message → code.
+ *   2. The code rides `signalError`/`ThreadResponsePayload.errorCode` to the
+ *      gateway.
+ *   3. Every renderer (Slack, Telegram, browser SSE) turns the code into
+ *      text + CTA via the shared `renderAgentError`, keyed on this record.
+ *
+ * Adding a new failure mode = one entry here + one `classifyError` pattern.
+ * A raw error reaching a user is a signal to add an entry, not to hand-wire a
+ * new branch in a renderer.
+ */
+export enum AgentErrorCode {
+  /** Provider weekly/monthly/rate limit hit (e.g. z.ai 429 "Limit Exhausted"). */
+  PROVIDER_QUOTA_EXHAUSTED = "PROVIDER_QUOTA_EXHAUSTED",
+  /** Provider credentials missing/invalid/expired. */
+  PROVIDER_AUTH = "PROVIDER_AUTH",
+  /** Model id not valid for the configured provider. */
+  PROVIDER_UNKNOWN_MODEL = "PROVIDER_UNKNOWN_MODEL",
+  /** Provider can't be routed through the gateway proxy (base URL unresolved). */
+  PROVIDER_BASE_URL_UNRESOLVED = "PROVIDER_BASE_URL_UNRESOLVED",
+  /** No model/provider selected for the agent at all. */
+  NO_MODEL_CONFIGURED = "NO_MODEL_CONFIGURED",
+  /**
+   * Turn-liveness sweep terminalized the turn: no worker-driven signal within
+   * the deadline (a worker blocked so long it stopped heartbeating). Carries a
+   * code now so it renders through the same path instead of a hardcoded
+   * "stopped responding" string.
+   */
+  WORKER_UNRESPONSIVE = "WORKER_UNRESPONSIVE",
+  /** Worker process died mid-flight (pod crash/OOM) before it could reply. */
+  WORKER_DIED = "WORKER_DIED",
+  /** Deployment/worker failed to START, so the request never ran. */
+  WORKER_STARTUP_FAILED = "WORKER_STARTUP_FAILED",
+  /**
+   * Operator required the systemd worker sandbox (LOBU_REQUIRE_WORKER_SANDBOX=1)
+   * but it's unavailable — the worker refused to run. An admin-config condition
+   * with remediation steps, not a transient user error.
+   */
+  WORKER_SANDBOX_REQUIRED = "WORKER_SANDBOX_REQUIRED",
+  /** Session exceeded its time budget (exit 124); retried silently. */
+  SESSION_TIMEOUT = "SESSION_TIMEOUT",
+}
+
+/**
+ * What kind of call-to-action link a rendered error should carry. The renderer
+ * resolves each kind to a concrete URL per surface (the resolver knows the org
+ * slug / agent id / public web origin); the catalog stays URL-free so it can
+ * live in `core` with no gateway dependency.
+ */
+export type AgentErrorCtaKind =
+  | "agent-settings" // → <webOrigin>/<slug>/agents/<agentId>
+  | "provider-connect" // → same settings page, provider-connect intent
+  | "none";
+
+export interface AgentErrorContext {
+  /** Provider slug (e.g. "z-ai"), when known — interpolated into the message. */
+  provider?: string;
+  /** Human reset time for quota errors, e.g. "2026-07-10 04:32 UTC". */
+  resetAt?: string;
+}
+
+export interface AgentErrorSpec {
+  /** Build the user-facing sentence (no link — the renderer appends the CTA). */
+  userMessage: (ctx: AgentErrorContext) => string;
+  cta: AgentErrorCtaKind;
+  /** Label for the CTA button/link. */
+  ctaLabel?: string;
+  /**
+   * When true, no user-facing message is emitted (bookkeeping only). Used for
+   * SESSION_TIMEOUT, which the runs queue retries automatically.
+   */
+  silent?: boolean;
+}
+
+const providerLabel = (ctx: AgentErrorContext): string =>
+  ctx.provider ? `Your ${ctx.provider} provider` : "Your AI provider";
+
+export const AGENT_ERRORS: Record<AgentErrorCode, AgentErrorSpec> = {
+  [AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED]: {
+    userMessage: (ctx) =>
+      `${providerLabel(ctx)}'s usage limit is used up` +
+      (ctx.resetAt ? `. It resets ${ctx.resetAt}.` : "."),
+    cta: "agent-settings",
+    ctaLabel: "Manage provider",
+  },
+  [AgentErrorCode.PROVIDER_AUTH]: {
+    userMessage: (ctx) =>
+      `${providerLabel(ctx)}'s credentials are invalid or expired. Reconnect the provider to continue.`,
+    cta: "provider-connect",
+    ctaLabel: "Reconnect provider",
+  },
+  [AgentErrorCode.PROVIDER_UNKNOWN_MODEL]: {
+    userMessage: () =>
+      `The selected model isn't valid for this provider. Pick a supported model.`,
+    cta: "agent-settings",
+    ctaLabel: "Choose model",
+  },
+  [AgentErrorCode.PROVIDER_BASE_URL_UNRESOLVED]: {
+    userMessage: (ctx) =>
+      `${providerLabel(ctx)} isn't connected to this agent, so its requests can't be routed. Connect it to continue.`,
+    cta: "agent-settings",
+    ctaLabel: "Connect provider",
+  },
+  [AgentErrorCode.NO_MODEL_CONFIGURED]: {
+    userMessage: () =>
+      `No model is configured for this agent. Connect a provider to get started.`,
+    cta: "agent-settings",
+    ctaLabel: "Connect a provider",
+  },
+  [AgentErrorCode.WORKER_UNRESPONSIVE]: {
+    userMessage: () =>
+      `The agent didn't finish responding in time. This is usually temporary — please try again.`,
+    cta: "none",
+  },
+  [AgentErrorCode.WORKER_DIED]: {
+    userMessage: () =>
+      `The agent stopped unexpectedly before it could reply. This is usually temporary — please try again.`,
+    cta: "none",
+  },
+  [AgentErrorCode.WORKER_STARTUP_FAILED]: {
+    userMessage: () =>
+      `The agent couldn't start, so your request wasn't processed. Please try again in a moment.`,
+    cta: "none",
+  },
+  [AgentErrorCode.WORKER_SANDBOX_REQUIRED]: {
+    userMessage: () =>
+      "LOBU_REQUIRE_WORKER_SANDBOX=1 but the systemd worker sandbox is unavailable on this host " +
+      "(no usable `systemd-run --user` manager). Refusing to run an un-sandboxed worker. Provide a " +
+      "user-level systemd manager, or unset LOBU_REQUIRE_WORKER_SANDBOX to allow unwrapped workers " +
+      "(the egress proxy still constrains network access).",
+    cta: "none",
+  },
+  [AgentErrorCode.SESSION_TIMEOUT]: {
+    userMessage: () => "",
+    cta: "none",
+    silent: true,
+  },
+};
+
+/** Parse an `AgentErrorCode` from an unknown value (payload/DB boundary). */
+export function toAgentErrorCode(value: unknown): AgentErrorCode | undefined {
+  if (typeof value !== "string") return undefined;
+  return (Object.values(AgentErrorCode) as string[]).includes(value)
+    ? (value as AgentErrorCode)
+    : undefined;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,4 @@
+import type { AgentErrorContext } from "./errors";
 import type { GuardrailStage } from "./guardrails/types";
 import type { SecretRef } from "./secret-refs";
 
@@ -438,6 +439,12 @@ export interface ThreadResponsePayload {
   finalText?: string;
   error?: string;
   errorCode?: string;
+  /**
+   * Structured context for `errorCode`, threaded from the worker's classifier
+   * so a renderer can build the full user message (e.g. the quota reset time)
+   * and CTA. See `AGENT_ERRORS` in ./errors.
+   */
+  errorContext?: AgentErrorContext;
   timestamp: number;
   originalMessageId?: string;
   botResponseId?: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,3 @@
-import type { AgentErrorContext } from "./errors";
 import type { GuardrailStage } from "./guardrails/types";
 import type { SecretRef } from "./secret-refs";
 
@@ -437,14 +436,13 @@ export interface ThreadResponsePayload {
    * drained by a different replica than the one that buffered the deltas.
    */
   finalText?: string;
+  /**
+   * Raw error message. For provider errors this is relayed verbatim as the
+   * user-facing body (the provider's own text already says the useful thing,
+   * e.g. the quota reset time); `errorCode` only selects the CTA link.
+   */
   error?: string;
   errorCode?: string;
-  /**
-   * Structured context for `errorCode`, threaded from the worker's classifier
-   * so a renderer can build the full user message (e.g. the quota reset time)
-   * and CTA. See `AGENT_ERRORS` in ./errors.
-   */
-  errorContext?: AgentErrorContext;
   timestamp: number;
   originalMessageId?: string;
   botResponseId?: string;

--- a/packages/core/src/worker/transport.ts
+++ b/packages/core/src/worker/transport.ts
@@ -4,8 +4,6 @@
  * Current implementation: HTTP.
  */
 
-import type { AgentErrorContext } from "../errors";
-
 /**
  * Transport interface for worker-to-gateway communication
  */
@@ -45,16 +43,12 @@ export interface WorkerTransport {
   /**
    * Signal that an error occurred during processing
    *
-   * @param error - The error that occurred
-   * @param errorCode - Classified `AgentErrorCode` (see @lobu/core errors)
-   * @param errorContext - Structured context (provider, resetAt) the renderer
-   *                       needs to build the full user message + CTA
+   * @param error - The error that occurred. Its message is relayed verbatim as
+   *                the user-facing body for provider errors.
+   * @param errorCode - Classified `AgentErrorCode` (see @lobu/core errors); the
+   *                    renderer uses it only to select the CTA link.
    */
-  signalError(
-    error: Error,
-    errorCode?: string,
-    errorContext?: AgentErrorContext
-  ): Promise<void>;
+  signalError(error: Error, errorCode?: string): Promise<void>;
 
   /**
    * Send a status update to the gateway

--- a/packages/core/src/worker/transport.ts
+++ b/packages/core/src/worker/transport.ts
@@ -4,6 +4,8 @@
  * Current implementation: HTTP.
  */
 
+import type { AgentErrorContext } from "../errors";
+
 /**
  * Transport interface for worker-to-gateway communication
  */
@@ -44,8 +46,15 @@ export interface WorkerTransport {
    * Signal that an error occurred during processing
    *
    * @param error - The error that occurred
+   * @param errorCode - Classified `AgentErrorCode` (see @lobu/core errors)
+   * @param errorContext - Structured context (provider, resetAt) the renderer
+   *                       needs to build the full user message + CTA
    */
-  signalError(error: Error, errorCode?: string): Promise<void>;
+  signalError(
+    error: Error,
+    errorCode?: string,
+    errorContext?: AgentErrorContext
+  ): Promise<void>;
 
   /**
    * Send a status update to the gateway

--- a/packages/server/src/gateway/__tests__/turn-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/turn-liveness.test.ts
@@ -14,6 +14,7 @@ import {
   expect,
   test,
 } from "bun:test";
+import { AgentErrorCode } from "@lobu/core";
 import { getDb } from "../../db/client.js";
 import { RunsQueue } from "../infrastructure/queue/runs-queue.js";
 import {
@@ -86,6 +87,15 @@ async function threadResponseCount(): Promise<number> {
   return Number(rows[0]?.n ?? 0);
 }
 
+/** The `errorCode` on the most recently enqueued terminal error row, if any. */
+async function latestErrorCode(): Promise<string | null> {
+  const rows = await getDb()<{ code: string | null }>`
+    SELECT action_input->>'errorCode' AS code FROM public.runs
+    WHERE queue_name = 'thread_response' AND action_input->>'error' IS NOT NULL
+    ORDER BY id DESC LIMIT 1`;
+  return rows[0]?.code ?? null;
+}
+
 async function expireAllMarkers(): Promise<void> {
   await getDb()`
     UPDATE public.runs SET run_at = now() - interval '1 minute'
@@ -119,23 +129,23 @@ describe("turn-liveness", () => {
     await armTurnTimeout(queue, routing("dep-2", "a"));
     await armTurnTimeout(queue, routing("dep-2", "b"));
 
-    expect(await failTurnsForDeployment("dep-2", "worker died")).toBe(2);
+    expect(await failTurnsForDeployment("dep-2", AgentErrorCode.WORKER_DIED)).toBe(2);
     expect(await markerCount("dep-2")).toBe(0);
     expect(await errorRowCount()).toBe(2);
 
     // Re-running emits nothing (markers already gone) — exactly-once.
-    expect(await failTurnsForDeployment("dep-2", "worker died")).toBe(0);
+    expect(await failTurnsForDeployment("dep-2", AgentErrorCode.WORKER_DIED)).toBe(0);
     expect(await errorRowCount()).toBe(2);
   });
 
   test("failTurnIfPending emits once when the turn is still owed", async () => {
     await armTurnTimeout(queue, routing("dep-3", "m"));
 
-    expect(await failTurnIfPending("dep-3", "m", "startup failed")).toBe(true);
+    expect(await failTurnIfPending("dep-3", "m", AgentErrorCode.WORKER_STARTUP_FAILED)).toBe(true);
     expect(await errorRowCount()).toBe(1);
 
     // Marker is gone — a second call must not double-signal.
-    expect(await failTurnIfPending("dep-3", "m", "startup failed")).toBe(false);
+    expect(await failTurnIfPending("dep-3", "m", AgentErrorCode.WORKER_STARTUP_FAILED)).toBe(false);
     expect(await errorRowCount()).toBe(1);
   });
 
@@ -145,7 +155,7 @@ describe("turn-liveness", () => {
     // commitTerminalReply path.
     await commitTerminalReply("dep-4", ["m"], reply("dep-4", "m"), null);
 
-    expect(await failTurnIfPending("dep-4", "m", "startup failed")).toBe(false);
+    expect(await failTurnIfPending("dep-4", "m", AgentErrorCode.WORKER_STARTUP_FAILED)).toBe(false);
     // commitTerminalReply emitted a (non-error) reply; no error row.
     expect(await errorRowCount()).toBe(0);
   });
@@ -165,7 +175,7 @@ describe("turn-liveness", () => {
     await armTurnTimeout(queue, routing("dep-5b", "m"));
     await expireAllMarkers();
     // Deadline lapsed → sweep emits the terminal error and deletes the marker.
-    expect(await sweepExpiredTurns("worker unresponsive")).toBe(1);
+    expect(await sweepExpiredTurns()).toBe(1);
     expect(await errorRowCount()).toBe(1);
 
     // A worker reply that arrives AFTER the sweep must NOT double-signal: there
@@ -177,15 +187,27 @@ describe("turn-liveness", () => {
     expect(await errorRowCount()).toBe(1);
   });
 
+  test("sweep tags its terminal error WORKER_UNRESPONSIVE so it renders via the catalog", async () => {
+    await armTurnTimeout(queue, routing("dep-code", "m"));
+    await expireAllMarkers();
+
+    expect(await sweepExpiredTurns()).toBe(1);
+    expect(await errorRowCount()).toBe(1);
+    // The whole point: instead of a hardcoded "stopped responding" string with
+    // no code, the sweep now carries a code the gateway renderers turn into a
+    // proper message (and, where resolvable, a CTA).
+    expect(await latestErrorCode()).toBe("WORKER_UNRESPONSIVE");
+  });
+
   test("sweep fails lapsed turns (hung/pod-death) exactly once", async () => {
     await armTurnTimeout(queue, routing("dep-6", "m"));
     await expireAllMarkers();
 
-    expect(await sweepExpiredTurns("worker unresponsive")).toBe(1);
+    expect(await sweepExpiredTurns()).toBe(1);
     expect(await markerCount("dep-6")).toBe(0);
     expect(await errorRowCount()).toBe(1);
 
-    expect(await sweepExpiredTurns("worker unresponsive")).toBe(0);
+    expect(await sweepExpiredTurns()).toBe(0);
     expect(await errorRowCount()).toBe(1);
   });
 
@@ -195,7 +217,7 @@ describe("turn-liveness", () => {
 
     await extendTurnDeadlines("dep-7"); // heartbeat pushes it forward
 
-    expect(await sweepExpiredTurns("worker unresponsive")).toBe(0);
+    expect(await sweepExpiredTurns()).toBe(0);
     expect(await markerCount("dep-7")).toBe(1);
     expect(await errorRowCount()).toBe(0);
   });
@@ -251,7 +273,7 @@ describe("hasLiveTurnForMessage (token-refresh liveness gate)", () => {
     await armTurnTimeout(queue, routing("dep-dead", "m1"));
     expect(await hasLiveTurnForMessage("dep-dead", "m1")).toBe(true);
 
-    await failTurnsForDeployment("dep-dead", "worker died");
+    await failTurnsForDeployment("dep-dead", AgentErrorCode.WORKER_DIED);
     expect(await hasLiveTurnForMessage("dep-dead", "m1")).toBe(false);
   });
 

--- a/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
@@ -24,7 +24,11 @@ import {
   expect,
   test,
 } from "bun:test";
-import { generateWorkerToken, verifyWorkerToken } from "@lobu/core";
+import {
+  AgentErrorCode,
+  generateWorkerToken,
+  verifyWorkerToken,
+} from "@lobu/core";
 import { RunsQueue } from "../infrastructure/queue/runs-queue.js";
 import {
   armTurnTimeout,
@@ -168,7 +172,7 @@ describe("POST /worker/token/refresh", () => {
 
     // The worker dies / replies → marker discharged. Use the fast path to
     // simulate terminalization, then refresh must be denied.
-    await failTurnsForDeployment(DEPLOYMENT, "worker died");
+    await failTurnsForDeployment(DEPLOYMENT, AgentErrorCode.WORKER_DIED);
 
     const res = await postRefresh(original);
     expect(res.status).toBe(403);

--- a/packages/server/src/gateway/api/response-renderer.ts
+++ b/packages/server/src/gateway/api/response-renderer.ts
@@ -112,12 +112,12 @@ export class ApiResponseRenderer implements ResponseRenderer {
       return;
     }
 
-    // Render a coded error through the shared catalog so the browser sees the
-    // same user-facing sentence Slack does (e.g. "Your provider's limit is used
-    // up. It resets …") instead of a raw "429 Weekly/Monthly …". The catalog
-    // text needs no URL, so it's always safe here; the CTA link itself is a
-    // follow-up (this SSE surface lacks the org/agent ids to resolve it — the
-    // structured `errorCode` is forwarded so the frontend can build the button).
+    // Pick the body the same way every surface does: our catalog text for
+    // errors we synthesize (worker/config), else the provider's OWN message
+    // relayed verbatim (it already says the useful thing, e.g. the quota reset
+    // time). The structured `errorCode` is forwarded so the frontend can build
+    // the CTA button (this SSE surface lacks the org/agent ids to resolve the
+    // URL itself).
     const code = toAgentErrorCode(payload.errorCode);
     const spec = code ? AGENT_ERRORS[code] : undefined;
     if (spec?.silent) {
@@ -128,9 +128,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
       });
       return;
     }
-    const errorText = spec
-      ? spec.userMessage(payload.errorContext ?? {})
-      : payload.error;
+    const errorText = spec?.message ?? payload.error;
 
     const errorEvent = {
       type: "error",

--- a/packages/server/src/gateway/api/response-renderer.ts
+++ b/packages/server/src/gateway/api/response-renderer.ts
@@ -5,7 +5,7 @@
  * Broadcasts worker responses to SSE connections for direct API clients
  */
 
-import { createLogger } from "@lobu/core";
+import { AGENT_ERRORS, createLogger, toAgentErrorCode } from "@lobu/core";
 import type { ThreadResponsePayload } from "../infrastructure/queue/types.js";
 import type { ResponseRenderer } from "../platform/response-renderer.js";
 import type { SseManager } from "../services/sse-manager.js";
@@ -112,9 +112,30 @@ export class ApiResponseRenderer implements ResponseRenderer {
       return;
     }
 
+    // Render a coded error through the shared catalog so the browser sees the
+    // same user-facing sentence Slack does (e.g. "Your provider's limit is used
+    // up. It resets …") instead of a raw "429 Weekly/Monthly …". The catalog
+    // text needs no URL, so it's always safe here; the CTA link itself is a
+    // follow-up (this SSE surface lacks the org/agent ids to resolve it — the
+    // structured `errorCode` is forwarded so the frontend can build the button).
+    const code = toAgentErrorCode(payload.errorCode);
+    const spec = code ? AGENT_ERRORS[code] : undefined;
+    if (spec?.silent) {
+      // Silent codes (SESSION_TIMEOUT) are retried and must not surface.
+      await this.resolveWatcherRunsFromPayload(payload, {
+        ok: false,
+        error: "agent error",
+      });
+      return;
+    }
+    const errorText = spec
+      ? spec.userMessage(payload.errorContext ?? {})
+      : payload.error;
+
     const errorEvent = {
       type: "error",
-      error: payload.error,
+      error: errorText,
+      errorCode: code,
       messageId: payload.messageId,
       timestamp: payload.timestamp || Date.now(),
     };
@@ -125,11 +146,11 @@ export class ApiResponseRenderer implements ResponseRenderer {
     this.sseManager.broadcast(sessionId, "error", errorEvent);
     this.sseManager.broadcast(sessionId, "agent-error", errorEvent);
 
-    logger.error(`Broadcast error to session ${sessionId}: ${payload.error}`);
+    logger.error(`Broadcast error to session ${sessionId}: ${errorText}`);
 
     await this.resolveWatcherRunsFromPayload(payload, {
       ok: false,
-      error: typeof payload.error === "string" ? payload.error : "agent error",
+      error: typeof errorText === "string" ? errorText : "agent error",
     });
   }
 

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -561,7 +561,7 @@ export class ChatResponseBridge implements ResponseRenderer {
     if (code) {
       const rendered = await renderAgentError(
         code,
-        payload.errorContext,
+        payload.error,
         () =>
           buildAgentSettingsUrl(
             this.manager.getPublicGatewayUrl(),
@@ -570,8 +570,9 @@ export class ChatResponseBridge implements ResponseRenderer {
           )
       );
       if (rendered.silent) return;
-      // Overwrite the raw error with the catalog message so the guardrail scan
-      // and the plain-text fallback below both operate on the rendered text.
+      // For provider errors `rendered.text` IS the provider's own message (we
+      // relay it verbatim); for our synthesized errors it's the catalog line.
+      // Either way the guardrail scan + plain-text fallback below operate on it.
       payload.error = rendered.text;
       if (rendered.ctaUrl) ctaButton = rendered;
     }

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -14,16 +14,24 @@
 import { unlink } from "node:fs/promises";
 import { resolve } from "node:path";
 import { createLogger, type GuardrailRegistry } from "@lobu/core";
+import { toAgentErrorCode } from "@lobu/core";
 import { Actions, Card, CardText, LinkButton } from "chat";
 import { getDb } from "../../db/client.js";
-import { getOrganizationSlug } from "../../utils/url-builder.js";
+import {
+  buildAgentSettingsUrl,
+  type RenderedAgentError,
+  renderAgentError,
+} from "../../utils/url-builder.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import {
   OutputGuardrailScanner,
   type OutputGuardrailTrip,
 } from "../guardrails/output-scan.js";
 import type { ThreadResponsePayload } from "../infrastructure/queue/index.js";
-import { extractSettingsLinkButtons } from "../platform/link-buttons.js";
+import {
+  extractSettingsLinkButtons,
+  isLocalhostUrl,
+} from "../platform/link-buttons.js";
 import type { ResponseRenderer } from "../platform/response-renderer.js";
 import { captureChannelMessage } from "./channel-transcript.js";
 import type { ChatInstanceManager } from "./chat-instance-manager.js";
@@ -40,31 +48,6 @@ import {
 import { resolveChatTarget } from "./platforms/shared.js";
 
 const logger = createLogger("chat-response-bridge");
-
-/**
- * Build the agent's admin-settings URL — `<publicWebUrl>/<orgSlug>/agents/<agentId>`
- * — for surfacing in user-facing error messages (e.g. NO_MODEL_CONFIGURED tells
- * the user where to connect a provider). Returns null when any required piece
- * is missing; callers fall back to non-linked guidance.
- *
- * `manager.publicGatewayUrl` is the gateway base, which in embedded mode
- * includes the `/lobu` path suffix (the gateway is mounted at `/lobu` under
- * the web app). Admin UI routes live at the web origin (`/<slug>/agents/...`)
- * NOT under `/lobu`, so strip a trailing `/lobu` before composing the link.
- */
-async function buildAgentSettingsUrl(
-  publicGatewayUrl: string | undefined,
-  organizationId: string | undefined,
-  agentId: string | undefined
-): Promise<string | null> {
-  if (!publicGatewayUrl || !organizationId || !agentId) return null;
-  const slug = await getOrganizationSlug(organizationId).catch(() => null);
-  if (!slug) return null;
-  const webOrigin = publicGatewayUrl
-    .replace(/\/+$/, "")
-    .replace(/\/lobu$/, "");
-  return `${webOrigin}/${slug}/agents/${encodeURIComponent(agentId)}`;
-}
 
 /**
  * Construct a minimal Chat SDK `Message`-shaped object from the inbound
@@ -568,18 +551,29 @@ export class ChatResponseBridge implements ResponseRenderer {
       return;
     }
 
-    // For known error codes, render user-facing guidance with a real link
-    // into the admin UI when we can resolve one. The settings page for an
-    // agent is `<publicWebUrl>/<orgSlug>/agents/<agentId>`.
-    if (payload.errorCode === "NO_MODEL_CONFIGURED") {
-      const settingsUrl = await buildAgentSettingsUrl(
-        this.manager.getPublicGatewayUrl(),
-        this.resolveOrganizationId(payload, ctx) ?? undefined,
-        this.resolveAgentId(payload, ctx) ?? undefined
+    // Known error code → render user-facing text + a real CTA link from the
+    // shared catalog (AGENT_ERRORS). This is the ONE place a coded error
+    // becomes Slack/Telegram output; adding a failure mode never touches this
+    // branch, only the catalog. Unknown/empty code falls through to the raw
+    // fallback below.
+    const code = toAgentErrorCode(payload.errorCode);
+    let ctaButton: RenderedAgentError | null = null;
+    if (code) {
+      const rendered = await renderAgentError(
+        code,
+        payload.errorContext,
+        () =>
+          buildAgentSettingsUrl(
+            this.manager.getPublicGatewayUrl(),
+            this.resolveOrganizationId(payload, ctx) ?? undefined,
+            this.resolveAgentId(payload, ctx) ?? undefined
+          )
       );
-      payload.error = settingsUrl
-        ? `No model configured. Connect a provider at ${settingsUrl}`
-        : "No model configured. Ask an admin to connect a provider for the base agent.";
+      if (rendered.silent) return;
+      // Overwrite the raw error with the catalog message so the guardrail scan
+      // and the plain-text fallback below both operate on the rendered text.
+      payload.error = rendered.text;
+      if (rendered.ctaUrl) ctaButton = rendered;
     }
 
     // Scan the error text before surfacing it — a provider/stack-trace error
@@ -596,7 +590,33 @@ export class ChatResponseBridge implements ResponseRenderer {
       return;
     }
 
-    // Fallback: plain text error via Chat SDK
+    // Coded error with a resolved CTA → post a Card with a native link button
+    // (same mechanism the ephemeral settings-link path uses) so the user gets a
+    // clickable action, not a bare URL in prose. Loopback URLs can't be
+    // rendered as inline buttons by some platforms, so fall through to text.
+    if (ctaButton?.ctaUrl && !isLocalhostUrl(ctaButton.ctaUrl)) {
+      const label = ctaButton.ctaLabel ?? "Open settings";
+      const card = Card({
+        children: [
+          CardText(ctaButton.text),
+          Actions([LinkButton({ url: ctaButton.ctaUrl, label })]),
+        ],
+      });
+      await this.postToPayloadTarget(
+        payload,
+        ctx,
+        {
+          card,
+          fallbackText: `${ctaButton.text}\n\n${label}: ${ctaButton.ctaUrl}`,
+        },
+        "Failed to send error card"
+      );
+      return;
+    }
+
+    // Fallback: plain text error via Chat SDK. For a coded error this is the
+    // catalog text (already assigned above); for an unclassified error it's the
+    // raw worker message — a signal to add a catalog entry.
     await this.postToPayloadTarget(
       payload,
       ctx,

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -2190,7 +2190,7 @@ export class DeploymentManager {
       }
       throw new OrchestratorError(
         ErrorCode.DEPLOYMENT_CREATE_FAILED,
-        AGENT_ERRORS[AgentErrorCode.WORKER_SANDBOX_REQUIRED].userMessage({})
+        AGENT_ERRORS[AgentErrorCode.WORKER_SANDBOX_REQUIRED].message ?? ""
       );
     } else if (
       params.allowSystemd &&

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -3,6 +3,8 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import {
+	AGENT_ERRORS,
+	AgentErrorCode,
 	ConversationOwnedElsewhereError,
 	createLogger,
 	ErrorCode,
@@ -43,23 +45,6 @@ import { getInternalGatewayUrl } from "../config/index.js";
 
 const logger = createLogger("orchestrator");
 
-/** Surfaced to the client when a worker dies before producing a reply. */
-const WORKER_DIED_MESSAGE =
-  "The worker handling your request stopped unexpectedly before it could reply. Please retry in a moment.";
-
-/**
- * Surfaced only when the operator REQUIRES the systemd sandbox
- * (LOBU_REQUIRE_WORKER_SANDBOX=1) but it is unavailable on the host. By default
- * workers run unwrapped when no systemd user manager exists — that is exactly
- * how the prod container (which ships no `systemd-run`) runs today, with the
- * egress proxy as the network boundary — so failing closed is opt-in, never
- * the default (defaulting to fail-closed would take prod down instantly).
- */
-const WORKER_SANDBOX_REQUIRED_MESSAGE =
-  "LOBU_REQUIRE_WORKER_SANDBOX=1 but the systemd worker sandbox is unavailable on this host " +
-  "(no usable `systemd-run --user` manager). Refusing to run an un-sandboxed worker. Provide a " +
-  "user-level systemd manager, or unset LOBU_REQUIRE_WORKER_SANDBOX to allow unwrapped workers " +
-  "(the egress proxy still constrains network access).";
 
 /**
  * A `systemd-run --scope` that can't reach the user bus / start the scope
@@ -2195,7 +2180,7 @@ export class DeploymentManager {
         void releaseLockOnce();
         failTurnsForDeployment(
           deploymentName,
-          WORKER_SANDBOX_REQUIRED_MESSAGE
+          AgentErrorCode.WORKER_SANDBOX_REQUIRED
         ).catch((failErr) => {
           logger.error(
             `Failed to fail in-flight turns after refusing un-sandboxed worker ${deploymentName}: ${getErrorMessage(failErr)}`
@@ -2205,7 +2190,7 @@ export class DeploymentManager {
       }
       throw new OrchestratorError(
         ErrorCode.DEPLOYMENT_CREATE_FAILED,
-        WORKER_SANDBOX_REQUIRED_MESSAGE
+        AGENT_ERRORS[AgentErrorCode.WORKER_SANDBOX_REQUIRED].userMessage({})
       );
     } else if (
       params.allowSystemd &&
@@ -2265,7 +2250,7 @@ export class DeploymentManager {
       // in-flight turn(s) were NOT failed and the client may hang until the
       // sweep backstop catches the lapsed marker — log it loudly.
       this.intentionalExits.delete(deploymentName);
-      failTurnsForDeployment(deploymentName, WORKER_DIED_MESSAGE).catch(
+      failTurnsForDeployment(deploymentName, AgentErrorCode.WORKER_DIED).catch(
         (failErr) => {
           logger.error(
             `Failed to fail in-flight turns after spawn error for ${deploymentName} (client may hang until the turn-liveness sweep): ${getErrorMessage(failErr)}`
@@ -2349,7 +2334,7 @@ export class DeploymentManager {
       // Fire-and-forget with a logging .catch — same rationale as the spawn
       // error handler above.
       if (!wasIntentional) {
-        failTurnsForDeployment(deploymentName, WORKER_DIED_MESSAGE).catch(
+        failTurnsForDeployment(deploymentName, AgentErrorCode.WORKER_DIED).catch(
           (failErr) => {
             logger.error(
               `Failed to fail in-flight turns after unexpected exit of ${deploymentName} (client may hang until the turn-liveness sweep): ${getErrorMessage(failErr)}`

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -1,4 +1,5 @@
 import {
+	AgentErrorCode,
 	ConversationOwnedElsewhereError,
 	createChildSpan,
 	createLogger,
@@ -882,17 +883,18 @@ export class MessageConsumer {
         "Deployment creation failed"
       );
 
-      const userMessage =
-        "Worker startup failed and your request could not be processed. Please retry in a moment.";
-
       // Emit the startup-failure notice through the first-writer-wins election
       // (atomic delete-marker + enqueue-error in one tx). This is gated on the
       // marker still being pending: if a still-attached worker raced a real
       // terminal reply (which discharged the marker), this no-ops instead of
-      // double-signalling the client. Routes via `error` (renders end-to-end:
-      // SSE error event + CLI exit 1; platforms post `Error: …`). If the marker
-      // was never armed (arm failed) it also no-ops — logged at arm time.
-      await failTurnIfPending(deploymentName, data.messageId, userMessage);
+      // double-signalling the client. Carries a code so it renders end-to-end
+      // through the AGENT_ERRORS catalog (SSE + CLI + platforms) with one
+      // source of prose. If the marker was never armed it also no-ops.
+      await failTurnIfPending(
+        deploymentName,
+        data.messageId,
+        AgentErrorCode.WORKER_STARTUP_FAILED
+      );
     } catch (trackError) {
       // Don't fail the main flow if tracking fails
       logger.error("Failed to track deployment failure:", trackError);

--- a/packages/server/src/gateway/orchestration/turn-liveness.ts
+++ b/packages/server/src/gateway/orchestration/turn-liveness.ts
@@ -40,6 +40,8 @@
  */
 
 import {
+	AGENT_ERRORS,
+	AgentErrorCode,
 	createLogger,
 	getErrorMessage,
 } from "@lobu/core";
@@ -229,7 +231,7 @@ export async function hasLiveTurnForMessage(
  */
 export async function failTurnsForDeployment(
   deploymentName: string,
-  reason: string
+  code: AgentErrorCode
 ): Promise<number> {
   try {
     const sql = getDb();
@@ -254,7 +256,7 @@ export async function failTurnsForDeployment(
           logger.error("Dropping unroutable turn-timeout marker (fast path)");
           continue;
         }
-        await enqueueTerminalError(tx, routing, reason);
+        await enqueueTerminalError(tx, routing, code);
         emitted += 1;
       }
       return emitted;
@@ -283,7 +285,7 @@ export async function failTurnsForDeployment(
  * outlives the pod that armed it).
  */
 export async function sweepExpiredTurns(
-  reason = "The worker handling your request stopped responding before it could reply. Please retry in a moment."
+  code: AgentErrorCode = AgentErrorCode.WORKER_UNRESPONSIVE
 ): Promise<number> {
   try {
     const sql = getDb();
@@ -314,7 +316,7 @@ export async function sweepExpiredTurns(
           logger.error("Dropping unroutable turn-timeout marker (sweep)");
           continue;
         }
-        await enqueueTerminalError(tx, routing, reason);
+        await enqueueTerminalError(tx, routing, code);
         emitted += 1;
       }
       return emitted;
@@ -364,8 +366,17 @@ async function insertThreadResponseRow(
 
 /** Build the terminal `thread_response{error}` payload for a turn. `platform`
  *  always carries an explicit value (defaults to "api") — gateway routing and
- *  platform isolation require it; never emit `platform: undefined`. */
-function buildTerminalErrorPayload(routing: TurnRouting, reason: string) {
+ *  platform isolation require it; never emit `platform: undefined`.
+ *
+ *  Carries the `AgentErrorCode` so the gateway renderers present it through the
+ *  shared `renderAgentError` catalog like any other agent error. `error` is the
+ *  catalog's own fallback text for that code (for any consumer that reads
+ *  `error` instead of rendering from the code) — NOT a caller-supplied string,
+ *  so there is exactly one place this prose lives: AGENT_ERRORS. */
+function buildTerminalErrorPayload(
+  routing: TurnRouting,
+  code: AgentErrorCode
+) {
   return {
     messageId: routing.messageId,
     channelId: routing.channelId,
@@ -374,7 +385,8 @@ function buildTerminalErrorPayload(routing: TurnRouting, reason: string) {
     teamId: routing.platform ?? "api",
     platform: routing.platform ?? "api",
     platformMetadata: routing.platformMetadata,
-    error: reason,
+    error: AGENT_ERRORS[code].userMessage({}),
+    errorCode: code,
     processedMessageIds: [routing.messageId],
     timestamp: Date.now(),
   };
@@ -384,11 +396,11 @@ function buildTerminalErrorPayload(routing: TurnRouting, reason: string) {
 async function enqueueTerminalError(
   tx: DbClient,
   routing: TurnRouting,
-  reason: string
+  code: AgentErrorCode
 ): Promise<void> {
   await insertThreadResponseRow(
     tx,
-    buildTerminalErrorPayload(routing, reason),
+    buildTerminalErrorPayload(routing, code),
     routing.organizationId ?? null
   );
 }
@@ -407,7 +419,7 @@ async function enqueueTerminalError(
 export async function failTurnIfPending(
   deploymentName: string,
   messageId: string,
-  reason: string
+  code: AgentErrorCode
 ): Promise<boolean> {
   const key = turnMarkerKey(deploymentName, messageId);
   try {
@@ -422,7 +434,7 @@ export async function failTurnIfPending(
       `;
       const routing = rows[0] ? asTurnRouting(rows[0].action_input) : null;
       if (!routing) return false;
-      await enqueueTerminalError(tx, routing, reason);
+      await enqueueTerminalError(tx, routing, code);
       return true;
     });
     if (emitted) await notifyThreadResponse();

--- a/packages/server/src/gateway/orchestration/turn-liveness.ts
+++ b/packages/server/src/gateway/orchestration/turn-liveness.ts
@@ -385,7 +385,9 @@ function buildTerminalErrorPayload(
     teamId: routing.platform ?? "api",
     platform: routing.platform ?? "api",
     platformMetadata: routing.platformMetadata,
-    error: AGENT_ERRORS[code].userMessage({}),
+    // Sweep/dispatch codes are always worker-family, which carry catalog text
+    // (there's no provider message to relay when the worker never replied).
+    error: AGENT_ERRORS[code].message ?? "The agent didn't finish responding.",
     errorCode: code,
     processedMessageIds: [routing.messageId],
     timestamp: Date.now(),

--- a/packages/server/src/gateway/platform/link-buttons.ts
+++ b/packages/server/src/gateway/platform/link-buttons.ts
@@ -13,7 +13,7 @@ const SETTINGS_LINK_RE =
  * Returns true when the URL points to a loopback address that
  * Telegram (and other platforms) reject for inline keyboard buttons.
  */
-function isLocalhostUrl(url: string): boolean {
+export function isLocalhostUrl(url: string): boolean {
   try {
     const u = new URL(url);
     return (

--- a/packages/server/src/utils/__tests__/render-agent-error.test.ts
+++ b/packages/server/src/utils/__tests__/render-agent-error.test.ts
@@ -1,0 +1,86 @@
+/**
+ * renderAgentError is THE renderer every surface (Slack/Telegram bridge,
+ * browser SSE) shares. These tests pin the code → (text, CTA) contract so the
+ * same agent error reads identically everywhere — the thing that was NOT true
+ * while four layers each formatted errors independently.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AgentErrorCode } from "@lobu/core";
+import { renderAgentError } from "../url-builder";
+
+const SETTINGS_URL = "https://app.lobu.ai/acme/agents/agent-1";
+const resolveSettings = async () => SETTINGS_URL;
+const resolveNothing = async () => null;
+
+describe("renderAgentError", () => {
+  test("provider quota renders the reset time + a settings CTA", async () => {
+    const r = await renderAgentError(
+      AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
+      { provider: "z-ai", resetAt: "2026-07-10 04:32 UTC" },
+      resolveSettings
+    );
+    expect(r.text).toContain("z-ai");
+    expect(r.text).toContain("used up");
+    expect(r.text).toContain("2026-07-10 04:32 UTC");
+    expect(r.ctaUrl).toBe(SETTINGS_URL);
+    expect(r.ctaLabel).toBe("Manage provider");
+    expect(r.silent).toBe(false);
+  });
+
+  test("quota without context is still a coherent generic message", async () => {
+    const r = await renderAgentError(
+      AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
+      undefined,
+      resolveSettings
+    );
+    expect(r.text).toContain("Your AI provider");
+    expect(r.text).not.toContain("undefined");
+    expect(r.ctaUrl).toBe(SETTINGS_URL);
+  });
+
+  test("auth failure asks the user to reconnect with a CTA", async () => {
+    const r = await renderAgentError(
+      AgentErrorCode.PROVIDER_AUTH,
+      { provider: "openai" },
+      resolveSettings
+    );
+    expect(r.text.toLowerCase()).toContain("reconnect");
+    expect(r.ctaUrl).toBe(SETTINGS_URL);
+    expect(r.ctaLabel).toBe("Reconnect provider");
+  });
+
+  test("WORKER_UNRESPONSIVE has a message but NO CTA (resolver never called)", async () => {
+    let called = false;
+    const r = await renderAgentError(
+      AgentErrorCode.WORKER_UNRESPONSIVE,
+      undefined,
+      async () => {
+        called = true;
+        return SETTINGS_URL;
+      }
+    );
+    expect(r.text.toLowerCase()).toContain("try again");
+    expect(r.ctaUrl).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  test("SESSION_TIMEOUT is silent", async () => {
+    const r = await renderAgentError(
+      AgentErrorCode.SESSION_TIMEOUT,
+      undefined,
+      resolveSettings
+    );
+    expect(r.silent).toBe(true);
+  });
+
+  test("a CTA code with an unresolvable URL degrades to text-only", async () => {
+    const r = await renderAgentError(
+      AgentErrorCode.NO_MODEL_CONFIGURED,
+      undefined,
+      resolveNothing
+    );
+    expect(r.text).toContain("No model");
+    expect(r.ctaUrl).toBeNull();
+  });
+});

--- a/packages/server/src/utils/__tests__/render-agent-error.test.ts
+++ b/packages/server/src/utils/__tests__/render-agent-error.test.ts
@@ -5,7 +5,7 @@
  * while four layers each formatted errors independently.
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { AgentErrorCode } from "@lobu/core";
 import { renderAgentError } from "../url-builder";
 
@@ -14,58 +14,62 @@ const resolveSettings = async () => SETTINGS_URL;
 const resolveNothing = async () => null;
 
 describe("renderAgentError", () => {
-  test("provider quota renders the reset time + a settings CTA", async () => {
+  it("provider quota RELAYS the provider's own message verbatim + a settings CTA", async () => {
+    // The provider's message already says when the quota resets — we relay it
+    // unchanged (no reset-time parsing, no reword) and only add the CTA link.
+    const raw =
+      "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47";
     const r = await renderAgentError(
       AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
-      { provider: "z-ai", resetAt: "2026-07-10 04:32 UTC" },
+      raw,
       resolveSettings
     );
-    expect(r.text).toContain("z-ai");
-    expect(r.text).toContain("used up");
-    expect(r.text).toContain("2026-07-10 04:32 UTC");
+    expect(r.text).toBe(raw);
     expect(r.ctaUrl).toBe(SETTINGS_URL);
     expect(r.ctaLabel).toBe("Manage provider");
     expect(r.silent).toBe(false);
   });
 
-  test("quota without context is still a coherent generic message", async () => {
+  it("provider error with no relayed message renders empty text but keeps the CTA", async () => {
     const r = await renderAgentError(
       AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
       undefined,
       resolveSettings
     );
-    expect(r.text).toContain("Your AI provider");
-    expect(r.text).not.toContain("undefined");
+    expect(r.text).toBe("");
     expect(r.ctaUrl).toBe(SETTINGS_URL);
   });
 
-  test("auth failure asks the user to reconnect with a CTA", async () => {
+  it("auth failure relays the provider message + a reconnect CTA", async () => {
     const r = await renderAgentError(
       AgentErrorCode.PROVIDER_AUTH,
-      { provider: "openai" },
+      'Authentication failed for "openai"',
       resolveSettings
     );
-    expect(r.text.toLowerCase()).toContain("reconnect");
+    expect(r.text).toBe('Authentication failed for "openai"');
     expect(r.ctaUrl).toBe(SETTINGS_URL);
     expect(r.ctaLabel).toBe("Reconnect provider");
   });
 
-  test("WORKER_UNRESPONSIVE has a message but NO CTA (resolver never called)", async () => {
+  it("WORKER_UNRESPONSIVE uses OUR catalog text (no provider message) and NO CTA", async () => {
     let called = false;
     const r = await renderAgentError(
       AgentErrorCode.WORKER_UNRESPONSIVE,
-      undefined,
+      // Even if a stray message is passed, a synthesized error prefers its own
+      // catalog text.
+      "some raw string",
       async () => {
         called = true;
         return SETTINGS_URL;
       }
     );
     expect(r.text.toLowerCase()).toContain("try again");
+    expect(r.text).not.toBe("some raw string");
     expect(r.ctaUrl).toBeNull();
     expect(called).toBe(false);
   });
 
-  test("SESSION_TIMEOUT is silent", async () => {
+  it("SESSION_TIMEOUT is silent", async () => {
     const r = await renderAgentError(
       AgentErrorCode.SESSION_TIMEOUT,
       undefined,
@@ -74,7 +78,7 @@ describe("renderAgentError", () => {
     expect(r.silent).toBe(true);
   });
 
-  test("a CTA code with an unresolvable URL degrades to text-only", async () => {
+  it("a synthesized CTA code with an unresolvable URL degrades to text-only", async () => {
     const r = await renderAgentError(
       AgentErrorCode.NO_MODEL_CONFIGURED,
       undefined,

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -4,6 +4,11 @@
  * Generates consistent URLs for the frontend application.
  */
 
+import {
+  AGENT_ERRORS,
+  type AgentErrorContext,
+  type AgentErrorCode,
+} from '@lobu/core';
 import { getWorkspaceProvider } from '../workspace';
 import {
   getConfiguredPublicOrigin,
@@ -36,6 +41,71 @@ export async function getOrganizationSlug(
 ): Promise<string | null> {
   if (!organizationId) return null;
   return getWorkspaceProvider().getOrgSlug(organizationId);
+}
+
+/**
+ * Build the agent's admin-settings URL — `<webOrigin>/<orgSlug>/agents/<agentId>`
+ * — the CTA target for provider/model errors (connect a provider, choose a
+ * model, reconnect credentials). Returns null when any required piece is
+ * missing; callers fall back to a non-linked message.
+ *
+ * `publicGatewayUrl` is the gateway base, which in embedded mode carries the
+ * `/lobu` path suffix (the gateway is mounted at `/lobu` under the web app).
+ * Admin UI routes live at the web origin (`/<slug>/agents/...`) NOT under
+ * `/lobu`, so a trailing `/lobu` is stripped before composing the link.
+ */
+export async function buildAgentSettingsUrl(
+  publicGatewayUrl: string | undefined,
+  organizationId: string | undefined,
+  agentId: string | undefined
+): Promise<string | null> {
+  if (!publicGatewayUrl || !organizationId || !agentId) return null;
+  const slug = await getOrganizationSlug(organizationId).catch(() => null);
+  if (!slug) return null;
+  const webOrigin = publicGatewayUrl.replace(/\/+$/, '').replace(/\/lobu$/, '');
+  return `${webOrigin}/${slug}/agents/${encodeURIComponent(agentId)}`;
+}
+
+export interface RenderedAgentError {
+  /** User-facing sentence (no link appended — carry `ctaUrl` separately). */
+  text: string;
+  /** Resolved CTA link, or null when the code has no CTA / it couldn't build. */
+  ctaUrl: string | null;
+  /** Button/link label for `ctaUrl`. */
+  ctaLabel?: string;
+  /** True when this code is intentionally silent (no user message emitted). */
+  silent: boolean;
+}
+
+/**
+ * THE renderer: turn an `AgentErrorCode` (+ its context) into user-facing text
+ * and a resolved CTA link. Every surface — Slack/Telegram bridge, browser SSE —
+ * calls this so the same error reads identically everywhere. The catalog
+ * (`AGENT_ERRORS`) owns the words and the CTA *kind*; this function owns
+ * resolving that kind to a concrete URL (it's the only layer that knows the
+ * org slug / agent id / public origin).
+ *
+ * `resolveSettingsUrl` is injected (not imported) so this stays free of the
+ * per-surface plumbing that knows how to reach `publicGatewayUrl`/org/agent.
+ */
+export async function renderAgentError(
+  code: AgentErrorCode,
+  context: AgentErrorContext | undefined,
+  resolveSettingsUrl: () => Promise<string | null>
+): Promise<RenderedAgentError> {
+  const spec = AGENT_ERRORS[code];
+  const ctx = context ?? {};
+  const text = spec.userMessage(ctx);
+  let ctaUrl: string | null = null;
+  if (spec.cta === 'agent-settings' || spec.cta === 'provider-connect') {
+    ctaUrl = await resolveSettingsUrl().catch(() => null);
+  }
+  return {
+    text,
+    ctaUrl,
+    ctaLabel: spec.ctaLabel,
+    silent: spec.silent ?? false,
+  };
 }
 
 export interface EntityInfo {

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -4,11 +4,7 @@
  * Generates consistent URLs for the frontend application.
  */
 
-import {
-  AGENT_ERRORS,
-  type AgentErrorContext,
-  type AgentErrorCode,
-} from '@lobu/core';
+import { AGENT_ERRORS, type AgentErrorCode } from '@lobu/core';
 import { getWorkspaceProvider } from '../workspace';
 import {
   getConfiguredPublicOrigin,
@@ -67,7 +63,7 @@ export async function buildAgentSettingsUrl(
 }
 
 export interface RenderedAgentError {
-  /** User-facing sentence (no link appended — carry `ctaUrl` separately). */
+  /** User-facing body (no link appended — carry `ctaUrl` separately). */
   text: string;
   /** Resolved CTA link, or null when the code has no CTA / it couldn't build. */
   ctaUrl: string | null;
@@ -78,24 +74,26 @@ export interface RenderedAgentError {
 }
 
 /**
- * THE renderer: turn an `AgentErrorCode` (+ its context) into user-facing text
- * and a resolved CTA link. Every surface — Slack/Telegram bridge, browser SSE —
- * calls this so the same error reads identically everywhere. The catalog
- * (`AGENT_ERRORS`) owns the words and the CTA *kind*; this function owns
- * resolving that kind to a concrete URL (it's the only layer that knows the
- * org slug / agent id / public origin).
+ * THE renderer: turn an `AgentErrorCode` + the raw provider message into the
+ * user-facing body and a resolved CTA link. Every surface — Slack/Telegram
+ * bridge, browser SSE — calls this so the same error reads identically
+ * everywhere.
  *
- * `resolveSettingsUrl` is injected (not imported) so this stays free of the
- * per-surface plumbing that knows how to reach `publicGatewayUrl`/org/agent.
+ * The body is deliberately thin: for provider errors the catalog has no text, so
+ * we relay the provider's OWN message verbatim (it already says the useful thing
+ * — the reset time, the bad model id). For errors we synthesize (worker/config),
+ * the catalog carries the text. The code's only job is to pick the CTA *kind*;
+ * this function resolves that kind to a concrete URL (the only layer that knows
+ * the org slug / agent id / public origin). `resolveSettingsUrl` is injected so
+ * this stays free of the per-surface plumbing.
  */
 export async function renderAgentError(
   code: AgentErrorCode,
-  context: AgentErrorContext | undefined,
+  providerMessage: string | undefined,
   resolveSettingsUrl: () => Promise<string | null>
 ): Promise<RenderedAgentError> {
   const spec = AGENT_ERRORS[code];
-  const ctx = context ?? {};
-  const text = spec.userMessage(ctx);
+  const text = spec.message ?? providerMessage ?? '';
   let ctaUrl: string | null = null;
   if (spec.cta === 'agent-settings' || spec.cta === 'provider-connect') {
     ctaUrl = await resolveSettingsUrl().catch(() => null);

--- a/scripts/sdk-e2e-error.sh
+++ b/scripts/sdk-e2e-error.sh
@@ -3,18 +3,19 @@
 # Error-taxonomy end-to-end gate.
 #
 # The companion to sdk-e2e.sh (happy path). Instead of asserting a successful
-# turn, it drives a real provider FAILURE end to end and asserts the unified
-# AGENT_ERRORS catalog prose reaches the user — proving the whole
-# worker→classifyAgentError→signalError(code,context)→gateway renderer chain,
-# not just that a unit test classifies a string.
+# turn, it drives a real provider FAILURE end to end and asserts the provider's
+# OWN message is relayed to the user verbatim — proving the whole
+# worker→classifyError→signalError(code)→gateway renderer chain, not just that
+# a unit test classifies a string.
 #
 # The mock provider answers /chat/completions with z.ai's exact production 429
 # body ("429 Weekly/Monthly Limit Exhausted. Your limit will reset at …"). A
-# real agent turn is spawned through the worker; the failure must render as:
-#     "Your mock provider's usage limit is used up. It resets 2026-07-10 …."
-# and must NOT surface either the raw "429 Weekly/Monthly Limit Exhausted"
-# (leaked provider text) or the generic "stopped responding" (sweep race
-# terminalization) — the two divergent masks the taxonomy was built to kill.
+# real agent turn is spawned through the worker; the failure must render the
+# provider's message VERBATIM — including the reset time, which rides inside
+# that message for free — and must NOT surface the generic "stopped responding"
+# sweep-race mask the taxonomy was built to kill. (Under the thin design the
+# raw 429 text reaching the user IS the intended body, not a leak — the code
+# only adds a CTA link.)
 #
 # Runs against embedded Postgres + the deterministic mock, so it needs no
 # provider key and is reproducible in CI. Self-contained, same boot flow as

--- a/scripts/sdk-e2e-error.sh
+++ b/scripts/sdk-e2e-error.sh
@@ -118,31 +118,21 @@ echo "✓ lobu run auto-applied the project"
 
 echo "--- chat output ---"; cat "$CHAT_OUT"; echo "-------------------"
 
-# 4a) The rendered catalog prose must reach the user.
-grep -qiF "usage limit is used up" "$CHAT_OUT" \
-  || fail "rendered PROVIDER_QUOTA_EXHAUSTED prose missing (got: $(tr -d '\n' < "$CHAT_OUT" | tail -c 300))"
-# 4b) The reset time parsed out of the raw provider body must be threaded through.
+# 4a) The provider's OWN message is relayed verbatim as the body. This is the
+# thin design: we don't reword the provider's error, we surface it — which also
+# means the reset time it contains reaches the user for free.
+grep -qF "Weekly/Monthly Limit Exhausted" "$CHAT_OUT" \
+  || fail "provider message not relayed to the user (got: $(tr -d '\n' < "$CHAT_OUT" | tail -c 300))"
+# 4b) The reset time (inside the provider's message) reaches the user — that's
+# how the user knows when quota is back, with no parsing on our side.
 grep -qF "2026-07-10 04:32:47" "$CHAT_OUT" \
-  || fail "reset time not threaded into the rendered message"
-# 4c) The provider label must be SPECIFIC (threaded from the worker's resolved
-# provider), not the generic "Your AI provider" fallback. The resolved provider
-# is the wire protocol the route composed to — here the mock registers with
-# sdkCompat "openai", so a real openai-compatible route (z.ai included) surfaces
-# as "openai provider". What we're guarding is that a concrete provider name
-# reached the render context at all, i.e. the fallback did NOT fire.
-grep -qiE "Your [a-z0-9_-]+ provider's usage limit" "$CHAT_OUT" \
-  || fail "provider label not rendered from context"
-if grep -qiF "Your AI provider's usage limit" "$CHAT_OUT"; then
-  fail "generic provider fallback fired — resolved provider was not threaded into the render context"
-fi
+  || fail "reset time (in the provider message) did not reach the user"
 
-# 4d) NEGATIVE assertions — the two masks the taxonomy killed must NOT appear.
-if grep -qiF "Weekly/Monthly Limit Exhausted" "$CHAT_OUT"; then
-  fail "raw provider 429 body leaked to the user (should be catalog prose)"
-fi
+# 4c) NEGATIVE assertion — the generic sweep mask must NOT replace the real
+# provider error (the terminalization race the taxonomy closed).
 if grep -qiE "stopped responding|worker.*(unresponsive|not responding)" "$CHAT_OUT"; then
   fail "generic sweep 'stopped responding' surfaced instead of the real quota error"
 fi
 
-echo "✓ provider 429 rendered as unified catalog prose (code + reset + provider), no raw/generic leak"
+echo "✓ provider 429 relayed verbatim (incl. reset time), classified, no generic-sweep mask"
 echo "🎉 error-taxonomy e2e passed"

--- a/scripts/sdk-e2e-error.sh
+++ b/scripts/sdk-e2e-error.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Error-taxonomy end-to-end gate.
+#
+# The companion to sdk-e2e.sh (happy path). Instead of asserting a successful
+# turn, it drives a real provider FAILURE end to end and asserts the unified
+# AGENT_ERRORS catalog prose reaches the user — proving the whole
+# worker→classifyAgentError→signalError(code,context)→gateway renderer chain,
+# not just that a unit test classifies a string.
+#
+# The mock provider answers /chat/completions with z.ai's exact production 429
+# body ("429 Weekly/Monthly Limit Exhausted. Your limit will reset at …"). A
+# real agent turn is spawned through the worker; the failure must render as:
+#     "Your mock provider's usage limit is used up. It resets 2026-07-10 …."
+# and must NOT surface either the raw "429 Weekly/Monthly Limit Exhausted"
+# (leaked provider text) or the generic "stopped responding" (sweep race
+# terminalization) — the two divergent masks the taxonomy was built to kill.
+#
+# Runs against embedded Postgres + the deterministic mock, so it needs no
+# provider key and is reproducible in CI. Self-contained, same boot flow as
+# sdk-e2e.sh.
+#
+# Usage: scripts/sdk-e2e-error.sh
+#        DATABASE_URL=... scripts/sdk-e2e-error.sh   (use an external Postgres)
+set -euo pipefail
+
+WT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HARNESS="$WT/scripts/sdk-e2e"
+LOBU="node $WT/packages/cli/bin/lobu.js"
+GW_PORT="${GW_PORT:-8795}"
+MOCK_PORT="${MOCK_PORT:-11436}"
+RUN_DIR="$WT/.sdk-e2e-error-run"
+RUN_LOG="$RUN_DIR/run.log"
+MOCK_LOG="$RUN_DIR/mock.log"
+CHAT_OUT="$RUN_DIR/chat.out"
+
+if [ -x /opt/homebrew/opt/node@22/bin/node ] && ! node --version 2>/dev/null | grep -qE '^v(22|23|24)\.'; then
+  export PATH="/opt/homebrew/opt/node@22/bin:$PATH"
+fi
+
+MOCK_PID=""
+cleanup() {
+  [ -n "$MOCK_PID" ] && kill -9 "$MOCK_PID" 2>/dev/null || true
+  lsof -nP -iTCP:"$GW_PORT" -sTCP:LISTEN -t 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+  lsof -nP -iTCP:"$MOCK_PORT" -sTCP:LISTEN -t 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+}
+trap cleanup EXIT
+
+fail() { echo "❌ error-taxonomy e2e FAILED: $*" >&2; [ -f "$RUN_LOG" ] && { echo "--- last 40 lines of run.log ---" >&2; tail -40 "$RUN_LOG" >&2; }; exit 1; }
+
+echo "▶ node $(node --version), gateway :$GW_PORT, mock :$MOCK_PORT (429 mode)"
+rm -rf "$RUN_DIR"; mkdir -p "$RUN_DIR"
+cleanup  # free ports from any prior run
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  node "$HARNESS/fix-embedded-pg-icu.mjs" || fail "could not prepare embedded-postgres ICU symlinks"
+fi
+
+# 1) Mock provider in 429 mode — /models still 200s, /chat/completions 429s.
+MOCK_PORT="$MOCK_PORT" MOCK_MODE="quota-429" node "$HARNESS/mock-openai.mjs" > "$MOCK_LOG" 2>&1 &
+MOCK_PID=$!
+disown "$MOCK_PID" 2>/dev/null || true
+for _ in $(seq 1 20); do
+  curl -fsS "http://127.0.0.1:$MOCK_PORT/v1/models" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+curl -fsS "http://127.0.0.1:$MOCK_PORT/v1/models" >/dev/null 2>&1 || fail "mock server did not come up"
+# Sanity: confirm the mock really 429s on chat before we spend a whole boot.
+code="$(curl -s -o /dev/null -w '%{http_code}' -X POST "http://127.0.0.1:$MOCK_PORT/v1/chat/completions" -H 'content-type: application/json' -d '{}')"
+[ "$code" = "429" ] || fail "mock did not return 429 on chat (got $code)"
+echo "✓ mock provider up in 429 mode"
+
+# 2) Scaffold a project routed through the mock (mirrors sdk-e2e.sh).
+PROJ="$RUN_DIR/proj"; mkdir -p "$PROJ"
+( cd "$PROJ" && $LOBU init . -y --here --provider gemini >/dev/null 2>&1 )
+rm -rf "$PROJ/package.json" "$PROJ/node_modules" "$PROJ/bun.lock"
+cat > "$PROJ/lobu.config.ts" <<'TS'
+import { defineAgent, defineConfig, secret } from "@lobu/cli/config";
+
+const agent = defineAgent({
+  id: "echo", name: "Echo", dir: "./agents/echo",
+  providers: [{ id: "mock", model: "mock-model", key: secret("MOCK_API_KEY") }],
+});
+
+export default defineConfig({ agents: [agent] });
+TS
+mkdir -p "$PROJ/agents/echo"
+[ -f "$PROJ/agents/echo/instructions.md" ] || echo "You are Echo." > "$PROJ/agents/echo/instructions.md"
+
+{
+  printf '\n'
+  echo "MOCK_API_KEY=mock-key-e2e"
+  echo "WORKER_ALLOWED_DOMAINS=127.0.0.1,localhost"
+  echo "LOBU_DISABLE_SYSTEMD_RUN=1"
+  [ -n "${DATABASE_URL:-}" ] && echo "DATABASE_URL=$DATABASE_URL"
+} >> "$PROJ/.env"
+
+# Point the mock provider's upstream at THIS run's mock port (the shipped
+# providers.json hardcodes 11434; we run on a distinct port so a concurrent
+# happy-path gate can't collide).
+REG="$RUN_DIR/providers.json"
+sed "s#http://127.0.0.1:11434/v1#http://127.0.0.1:$MOCK_PORT/v1#" "$HARNESS/providers.json" > "$REG"
+export LOBU_PROVIDER_REGISTRY_PATH="$REG"
+
+# 3) Boot lobu run (auto-applies the project).
+( cd "$PROJ" && $LOBU run --port "$GW_PORT" > "$RUN_LOG" 2>&1 ) &
+for _ in $(seq 1 80); do
+  grep -qiE "Apply complete|auto-apply skipped|Apply halted" "$RUN_LOG" 2>/dev/null && break
+  sleep 1
+done
+grep -qi "Apply complete" "$RUN_LOG" || fail "auto-apply did not complete (skipped/halted?)"
+echo "✓ lobu run auto-applied the project"
+
+# 4) Drive a real turn — the mock 429s, so the turn FAILS. `lobu chat` may exit
+# non-zero when the turn errors; that's expected here. What matters is the
+# RENDERED text.
+( cd "$PROJ" && timeout 90 $LOBU chat "say the safe word" -c local > "$CHAT_OUT" 2>&1 ) || true
+
+echo "--- chat output ---"; cat "$CHAT_OUT"; echo "-------------------"
+
+# 4a) The rendered catalog prose must reach the user.
+grep -qiF "usage limit is used up" "$CHAT_OUT" \
+  || fail "rendered PROVIDER_QUOTA_EXHAUSTED prose missing (got: $(tr -d '\n' < "$CHAT_OUT" | tail -c 300))"
+# 4b) The reset time parsed out of the raw provider body must be threaded through.
+grep -qF "2026-07-10 04:32:47" "$CHAT_OUT" \
+  || fail "reset time not threaded into the rendered message"
+# 4c) The provider label must be SPECIFIC (threaded from the worker's resolved
+# provider), not the generic "Your AI provider" fallback. The resolved provider
+# is the wire protocol the route composed to — here the mock registers with
+# sdkCompat "openai", so a real openai-compatible route (z.ai included) surfaces
+# as "openai provider". What we're guarding is that a concrete provider name
+# reached the render context at all, i.e. the fallback did NOT fire.
+grep -qiE "Your [a-z0-9_-]+ provider's usage limit" "$CHAT_OUT" \
+  || fail "provider label not rendered from context"
+if grep -qiF "Your AI provider's usage limit" "$CHAT_OUT"; then
+  fail "generic provider fallback fired — resolved provider was not threaded into the render context"
+fi
+
+# 4d) NEGATIVE assertions — the two masks the taxonomy killed must NOT appear.
+if grep -qiF "Weekly/Monthly Limit Exhausted" "$CHAT_OUT"; then
+  fail "raw provider 429 body leaked to the user (should be catalog prose)"
+fi
+if grep -qiE "stopped responding|worker.*(unresponsive|not responding)" "$CHAT_OUT"; then
+  fail "generic sweep 'stopped responding' surfaced instead of the real quota error"
+fi
+
+echo "✓ provider 429 rendered as unified catalog prose (code + reset + provider), no raw/generic leak"
+echo "🎉 error-taxonomy e2e passed"

--- a/scripts/sdk-e2e/mock-openai.mjs
+++ b/scripts/sdk-e2e/mock-openai.mjs
@@ -27,6 +27,9 @@ const server = createServer((req, res) => {
     }
     if (url.includes("/chat/completions")) {
       if (MODE === "quota-429") {
+        // z.ai's real 429 carries the reset time in the BODY text (not a
+        // Retry-After header). The error e2e parses that out of the raw string
+        // and asserts it reaches the user via the catalog.
         res.writeHead(429, { "content-type": "application/json" });
         res.end(
           JSON.stringify({

--- a/scripts/sdk-e2e/mock-openai.mjs
+++ b/scripts/sdk-e2e/mock-openai.mjs
@@ -1,6 +1,15 @@
 import { createServer } from "node:http";
 const PORT = Number(process.env.MOCK_PORT || 11434);
 const REPLY = process.env.MOCK_REPLY || "PONG";
+// MOCK_MODE=quota-429 makes /chat/completions answer with z.ai's exact
+// production 429 body so the error-taxonomy e2e can drive a real provider
+// quota failure through the whole worker→gateway→renderer chain. `/models`
+// still 200s so model resolution succeeds and the failure lands where a real
+// quota exhaustion does: on the chat call, mid-turn. Default ("") is the
+// happy-path reply the SDK lifecycle gate relies on — unchanged.
+const MODE = process.env.MOCK_MODE || "";
+const QUOTA_BODY =
+  "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47";
 const server = createServer((req, res) => {
   let body = "";
   req.on("data", (c) => (body += c));
@@ -17,6 +26,15 @@ const server = createServer((req, res) => {
       return;
     }
     if (url.includes("/chat/completions")) {
+      if (MODE === "quota-429") {
+        res.writeHead(429, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: { message: QUOTA_BODY, type: "rate_limit_exceeded" },
+          })
+        );
+        return;
+      }
       let stream = false;
       try {
         stream = JSON.parse(body || "{}").stream === true;


### PR DESCRIPTION
## Why

A prod z.ai 429 (weekly quota exhausted) reached users as either a raw `429 Weekly/Monthly Limit Exhausted…` string or a generic "the worker stopped responding" — two divergent masks of one failure. Root cause: **four independent error classifier/formatter layers** plus the turn-liveness sweep, each rendering the same error differently. Every past fix patched one layer, so the same error kept resurfacing in a new shape.

## What

One classifier, one catalog, one renderer — and the catalog is deliberately **thin**.

- **`classifyError(error) → AgentErrorCode`** is the single classifier. The code's only job is to pick a CTA link.
- **Provider errors** (quota / auth / unknown-model / routing) carry **no prose** in the catalog. The provider's own message already says the useful thing — including when a quota resets — so we **relay it verbatim** as the user-facing body and append the CTA. No reset-time regex, no per-provider reword, no provider-label interpolation. Zero string processing on provider text.
- **Errors we synthesize** (worker died / unresponsive / startup-failed, no-model-configured, sandbox-required) keep a catalog `message` — there's no upstream provider string to relay.
- **One renderer** picks `spec.message ?? payload.error` and resolves the CTA kind to a URL. Both surfaces (Slack/Telegram bridge + browser SSE) use it, so the same error reads identically everywhere.
- The turn-liveness sweep/dispatch layer now carries `AgentErrorCode` instead of free `reason` strings (deleted `WORKER_DIED_MESSAGE` / `WORKER_SANDBOX_REQUIRED_MESSAGE`).

## Deleted (consolidation)

- `AGENT_ERRORS[*].userMessage()` prose + `providerLabel()` — provider's own message is the body
- `extractResetAt()` and its absolute/relative regexes — reset time rides inside the provider message for free
- `AgentErrorContext` (provider/resetAt) end-to-end: `types.ts`, transport `signalError` signature, `gateway-integration`, worker threading
- the auth-hint round-trip (`maybeBuildAuthHintMessage` + the reverse-parse regex) and the worker's ad-hoc `❌ Session failed` formatter

## Latent bug fixed

model-resolver's "No model resolved for this run" was **unclassified** — it dodged the catalog (rendered as a raw `💥 Worker crashed`) *and* the PROVIDER_* Sentry alert. Now classified `NO_MODEL_CONFIGURED`.

## Tests / e2e

New **error-taxonomy e2e** (`scripts/sdk-e2e-error.sh`, wired into the CI `sdk-e2e` job + `make test-e2e-error`): boots `lobu run` (embedded Postgres) with the mock provider in `MOCK_MODE=quota-429` (z.ai's exact 429 body; `/models` still 200s so the failure lands mid-turn), drives a real turn through a **spawned worker**, and asserts the provider message reaches the user **verbatim including the reset time**, classified, with **no** generic-sweep mask. The happy-path `sdk-e2e` stays green (the mock change is additive).

Verified: full tsc across core + agent-worker + server; worker unit 635 pass; render + turn-liveness + token-refresh integration green; both sdk e2es pass end-to-end.

## Known follow-up (not in scope)

pi-coding-agent retries a 429 3× (~14s exponential backoff) before giving up — a minor inefficiency, not the cause of the sweep race (that was an event-loop freeze, fixed in #1774; the heartbeat is a wall-clock interval that survives backoff).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786035218&installation_id=136316292&pr_number=1789&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1789&signature=f5ada5e04b2595ac940bc40dc5dd95228d61d1efcfd9aa0309c4586d351febec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error handling across the app so provider failures now show clearer, category-specific messages and actions.
  * Added support for displaying provider quota/rate-limit errors verbatim, including reset timing when available.
  * Introduced better fallback guidance for worker, session, and configuration failures.

* **Bug Fixes**
  * Prevented provider errors from being replaced by generic crash or “stopped responding” messages.
  * Refined error routing so the most relevant recovery option is shown more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->