### PR TITLE
fix: managed OAuth redirects

### DIFF
--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -168,6 +168,7 @@ export interface RemoteConnection {
   device_worker_id?: string | null;
   agent_id?: string | null;
   credential_mode?: "managed" | "byo" | null;
+  effective_credential_mode?: "managed" | "byo" | null;
 }
 
 export interface RemoteFeed {

--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -636,6 +636,106 @@ describe("lobu init --from-org", () => {
     expect(source).not.toContain("rename credential keys");
   });
 
+  test("managed OAuth connections export as managedBy instead of local OAuth app credentials", async () => {
+    const dir = mkFixtureDir();
+    await initFromOrg({
+      targetDir: dir,
+      org: "lobu-team",
+      fetchImpl: buildFetch({
+        "/oauth/userinfo": () => ({
+          organizations: [
+            { id: "org-1", slug: "lobu-team", name: "Lobu Team" },
+          ],
+        }),
+        "/agents/lone/config": () => ({ updatedAt: 0 }),
+        "/agents": () => ({ agents: [{ agentId: "lone", name: "Lone" }] }),
+        "watchers?include_details": () => ({ watchers: [] }),
+        manage_entity_schema: () => ({
+          entity_types: [],
+          relationship_types: [],
+        }),
+        manage_auth_profiles: () => ({
+          auth_profiles: [
+            {
+              slug: "gmail-account",
+              display_name: "Gmail account",
+              connector_key: "google.gmail",
+              profile_kind: "oauth_account",
+              status: "active",
+            },
+            {
+              slug: "gmail-app",
+              display_name: "Gmail OAuth app",
+              connector_key: "google.gmail",
+              profile_kind: "oauth_app",
+              status: "active",
+            },
+          ],
+        }),
+        manage_connections: () => ({
+          connections: [
+            {
+              id: 42,
+              slug: "gmail",
+              connector_key: "google.gmail",
+              display_name: "Gmail",
+              status: "active",
+              auth_profile_slug: "gmail-account",
+              app_auth_profile_slug: "gmail-app",
+              config: null,
+              device_worker_id: null,
+              effective_credential_mode: "managed",
+            },
+          ],
+        }),
+        manage_feeds: () => ({ feeds: [] }),
+        manage_catalog: (body) => {
+          const gmail = {
+            id: "google.gmail",
+            name: "Gmail",
+            detail: {
+              auth_schema: {
+                methods: [
+                  {
+                    type: "oauth",
+                    provider: "google",
+                    clientIdKey: "GOOGLE_CLIENT_ID",
+                    clientSecretKey: "GOOGLE_CLIENT_SECRET",
+                  },
+                ],
+              },
+            },
+          };
+          if (body.action === "list_catalog") {
+            return { catalogs: { connectors: { entries: [gmail] } } };
+          }
+          if (body.action === "list_installed") {
+            return { installed: { connectors: { items: [gmail] } } };
+          }
+          throw new Error(
+            `unexpected manage_catalog action: ${String(body.action)}`
+          );
+        },
+      }),
+    });
+
+    const source = readFileSync(join(dir, "lobu.config.ts"), "utf-8");
+    expect(source).toContain('managedBy: { org: "lobu-team" }');
+    expect(source).not.toContain("defineAuthProfile");
+    expect(source).not.toContain("gmailApp");
+    expect(source).not.toContain("gmailAccount");
+    expect(source).not.toContain("consent_only");
+    expect(source).not.toContain("GOOGLE_CLIENT_SECRET");
+
+    const { state } = await loadDesiredStateFromConfig({ cwd: dir });
+    const conn = state.connectors.connections[0];
+    expect(conn?.slug).toBe("gmail");
+    expect(conn?.authProfileSlug).toBeUndefined();
+    expect(conn?.appAuthProfileSlug).toBeUndefined();
+    expect(conn?.config).toEqual({ managedBy: { org: "lobu-team" } });
+    expect(state.connectors.authProfiles).toEqual([]);
+  });
+
   test("relationship-type rules hydrate via list_rules (real list omits them)", async () => {
     const dir = mkFixtureDir();
     await initFromOrg({

--- a/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
@@ -676,7 +676,8 @@ function emitConnection(
   authHandles: Map<string, string>,
   connectorHandles: Map<string, string>,
   imports: ImportTracker,
-  minter: IdentMinter
+  minter: IdentMinter,
+  managedByOrg?: string
 ): Handle {
   imports.use("defineConnection");
   const connectorRef =
@@ -686,18 +687,21 @@ function emitConnection(
     `connector: ${connectorRef}`,
   ];
   if (c.display_name) fields.push(`name: ${str(c.display_name)}`);
-  if (c.auth_profile_slug) {
+  if (managedByOrg) {
+    fields.push(`managedBy: { org: ${str(managedByOrg)} }`);
+  } else if (c.auth_profile_slug) {
     const ref =
       authHandles.get(c.auth_profile_slug) ?? str(c.auth_profile_slug);
     fields.push(`authProfile: ${ref}`);
   }
-  if (c.app_auth_profile_slug) {
+  if (!managedByOrg && c.app_auth_profile_slug) {
     const ref =
       authHandles.get(c.app_auth_profile_slug) ?? str(c.app_auth_profile_slug);
     fields.push(`appAuthProfile: ${ref}`);
   }
-  if (c.config && Object.keys(c.config).length > 0) {
-    fields.push(`config: ${emitValue(c.config, 1)}`);
+  const config = managedByOrg ? stripManagedGrantConfig(c.config) : c.config;
+  if (config && Object.keys(config).length > 0) {
+    fields.push(`config: ${emitValue(config, 1)}`);
   }
   if (c.device_worker_id) {
     fields.push(`deviceWorkerId: ${str(c.device_worker_id)}`);
@@ -722,6 +726,44 @@ function emitConnection(
     name,
     decl: `const ${name} = defineConnection(${objectLiteral(fields, 0)});`,
   };
+}
+
+function isManagedGrantHolderConnection(c: RemoteConnection): boolean {
+  const credentialMode = c.effective_credential_mode ?? c.credential_mode;
+  return (
+    !!c.app_auth_profile_slug &&
+    (c.config?.consent_only === true ||
+      c.config?.managedBy !== undefined ||
+      credentialMode === "managed")
+  );
+}
+
+function stripManagedGrantConfig(
+  config: RemoteConnection["config"]
+): RemoteConnection["config"] {
+  if (!config) return config;
+  const next = { ...config };
+  delete next.consent_only;
+  delete next.managedBy;
+  return Object.keys(next).length > 0 ? next : null;
+}
+
+function managedOnlyAuthProfileSlugs(
+  connections: Array<{ connection: RemoteConnection; feeds: RemoteFeed[] }>
+): Set<string> {
+  const managedRefs = new Set<string>();
+  const nonManagedRefs = new Set<string>();
+  for (const { connection } of connections) {
+    const target = isManagedGrantHolderConnection(connection)
+      ? managedRefs
+      : nonManagedRefs;
+    if (connection.auth_profile_slug) target.add(connection.auth_profile_slug);
+    if (connection.app_auth_profile_slug) {
+      target.add(connection.app_auth_profile_slug);
+    }
+  }
+  for (const ref of nonManagedRefs) managedRefs.delete(ref);
+  return managedRefs;
 }
 
 // ── Fetch the org's full declared state ─────────────────────────────────────
@@ -925,7 +967,9 @@ function generateProject(
   }
   const authHandles = new Map<string, string>();
   const authDecls: string[] = [];
+  const authProfilesToSkip = managedOnlyAuthProfileSlugs(state.connections);
   for (const p of state.authProfiles) {
+    if (authProfilesToSkip.has(p.slug)) continue;
     const h = emitAuthProfile(
       p,
       secrets,
@@ -948,13 +992,17 @@ function generateProject(
   const connDecls: string[] = [];
   const connHandles: string[] = [];
   for (const { connection, feeds } of state.connections) {
+    const managedByOrg = isManagedGrantHolderConnection(connection)
+      ? orgSlug
+      : undefined;
     const h = emitConnection(
       connection,
       feeds,
       authHandles,
       connectorHandles,
       imports,
-      minter
+      minter,
+      managedByOrg
     );
     connDecls.push(h.decl);
     connHandles.push(h.name);

--- a/packages/server/src/auth/oauth/__tests__/scopes.test.ts
+++ b/packages/server/src/auth/oauth/__tests__/scopes.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'bun:test';
+
+import { hasAllScopes } from '../scopes';
+
+describe('OAuth scope helpers', () => {
+  it('treats Google userinfo scopes as equivalent to OIDC email/profile aliases', () => {
+    expect(
+      hasAllScopes(
+        [
+          'openid',
+          'https://www.googleapis.com/auth/userinfo.email',
+          'https://www.googleapis.com/auth/userinfo.profile',
+          'https://www.googleapis.com/auth/gmail.readonly',
+        ],
+        ['openid', 'email', 'profile', 'https://www.googleapis.com/auth/gmail.readonly']
+      )
+    ).toBe(true);
+  });
+
+  it('still requires connector-specific scopes exactly', () => {
+    expect(
+      hasAllScopes(
+        ['openid', 'email', 'profile'],
+        ['openid', 'email', 'profile', 'https://www.googleapis.com/auth/gmail.readonly']
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/server/src/auth/oauth/scopes.ts
+++ b/packages/server/src/auth/oauth/scopes.ts
@@ -114,12 +114,28 @@ export function normalizeScopeList(value: unknown): string[] {
   ).filter(Boolean);
 }
 
+function equivalentScopes(scope: string): string[] {
+  switch (scope) {
+    case 'email':
+    case 'https://www.googleapis.com/auth/userinfo.email':
+      return ['email', 'https://www.googleapis.com/auth/userinfo.email'];
+    case 'profile':
+    case 'https://www.googleapis.com/auth/userinfo.profile':
+      return ['profile', 'https://www.googleapis.com/auth/userinfo.profile'];
+    default:
+      return [scope];
+  }
+}
+
 export function hasAllScopes(granted: Iterable<string>, required: Iterable<string>): boolean {
-  const grantedSet = new Set(
-    Array.from(granted)
-      .map((scope) => scope.trim())
-      .filter(Boolean)
-  );
+  const grantedSet = new Set<string>();
+  for (const scope of granted) {
+    const normalized = scope.trim();
+    if (!normalized) continue;
+    for (const equivalent of equivalentScopes(normalized)) {
+      grantedSet.add(equivalent);
+    }
+  }
   for (const scope of required) {
     const normalized = scope.trim();
     if (!normalized) continue;


### PR DESCRIPTION
Fixes the managed OAuth connector flow end to end.\n\nChanges:\n- Export managed OAuth grant-holder connections from init --from-org as managedBy instead of local auth/app profiles.\n- Use the app origin for Owletto connector OAuth /connect URLs instead of API paths.\n- Treat Google userinfo.email/userinfo.profile as equivalent to OIDC email/profile when reconciling granted scopes, so successful Gmail consent activates the profile/connection.\n\nLive validation:\n- Added https://app.lobu.ai/connect/oauth/callback to the managed Google OAuth client.\n- Completed Gmail OAuth for buremba test connection 405.\n- Verified credentials with test_auth_profile.\n- Ran a live Gmail read-only search operation successfully.\n\nLocal validation:\n- bun test packages/server/src/auth/oauth/__tests__/scopes.test.ts\n- bun test packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts\n- bunx tsc -p packages/cli/tsconfig.json --noEmit\n- bunx tsc -p packages/server/tsconfig.json --noEmit\n- bunx tsc -p packages/owletto/tsconfig.json --noEmit\n- Biome checks for touched CLI/Owletto files\n\nOwletto submodule PR merged first: lobu-ai/owletto#462

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786046630&installation_id=136316292&pr_number=1790&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1790&signature=1df1ccc85dd7672b2f4e5907474eccc46a7cae9cf0c2677063095e93e0b66a36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->