### PR TITLE
fix(authz): rewire channel-about to connector-owned identity registry (unbreak main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,7 +423,7 @@ jobs:
         # (src/lobu/stores/__tests__) that vitest owns, so we target
         # src/lobu/__tests__ specifically rather than the whole src/lobu tree.
         working-directory: packages/server
-        run: bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__
+        run: bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__ src/auth/oauth/__tests__
 
   format-lint:
     runs-on: ubuntu-latest

--- a/packages/server/src/__tests__/integration/authz/channel-about.test.ts
+++ b/packages/server/src/__tests__/integration/authz/channel-about.test.ts
@@ -4,15 +4,17 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+	slackAclSource,
+	slackChannelKey,
+	slackChannelsToResources,
+} from "@lobu/connectors/slack-identity";
+import {
 	ABOUT_EDGE_SOURCE_CONFIG,
 	ensureAboutRelationshipType,
 	listChannelEntitiesAboutBusinessEntity,
 	syncConnectionChannelAboutEdges,
 } from "../../../authz/channel-about";
-import {
-	buildSlackChannelGraph,
-	slackChannelKey,
-} from "../../../authz/slack-channel-graph";
+import { buildAccessGraph } from "../../../authz/access-graph";
 import { clearEntityLinkRulesCache } from "../../../utils/entity-link-upsert";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
@@ -94,17 +96,19 @@ describe("channel about edges", () => {
 		expect(Number(before[0].to_entity_id)).toBe(company.id);
 		expect(before[0].source).toBe(ABOUT_EDGE_SOURCE_CONFIG);
 
-		await buildSlackChannelGraph({
+		await buildAccessGraph({
 			organizationId: org.id,
 			connectionId,
-			teamId: TEAM,
-			channels: [
+			connectorKey: slackAclSource.key,
+			resourceType: slackAclSource.resourceType,
+			memberIdentities: slackAclSource.memberIdentities,
+			resources: slackChannelsToResources(TEAM, [
 				{
 					channelId: CHANNEL,
 					name: "eng",
 					memberSlackUserIds: [],
 				},
-			],
+			]),
 		});
 
 		const after = await aboutEdges(org.id);

--- a/packages/server/src/authz/channel-about.ts
+++ b/packages/server/src/authz/channel-about.ts
@@ -16,8 +16,7 @@ import {
 } from "../db/client.js";
 import { resolveEventAttributionsForItems } from "../utils/entity-link-upsert.js";
 import { ensureResourceEntityType } from "./access-graph.js";
-import { slackChannelKey } from "./slack-channel-graph.js";
-import { SLACK_SOURCE } from "./sources.js";
+import { aclSourceFor, channelReadIdentityFor } from "./sources.js";
 
 const logger = createLogger("channel-about");
 
@@ -78,7 +77,12 @@ async function findAboutRelationshipTypeId(
 	return rows[0] ? Number(rows[0].id) : null;
 }
 
-/** Team-scoped resource key + identity namespace for a chat channel. */
+/** Team-scoped resource key + identity namespace for a chat channel.
+ *
+ * Connector-agnostic: a connector that registers a `ChannelReadIdentity`
+ * contributes both its channel identity namespace and the exact team-scoped key
+ * construction the ACL sync writes, so this names no platform. Connectors with
+ * no registered chat gate fall back to the generic `chat_channel_id` form. */
 export function channelResourceIdentity(
 	connectorKey: string,
 	teamId: string | null | undefined,
@@ -87,11 +91,10 @@ export function channelResourceIdentity(
 	const bare = channelId.includes(":")
 		? channelId.slice(channelId.indexOf(":") + 1)
 		: channelId;
-	if (connectorKey === "slack" && teamId) {
-		return {
-			namespace: SLACK_SOURCE.resourceType.namespace,
-			key: slackChannelKey(teamId, bare),
-		};
+	const readIdentity = channelReadIdentityFor(connectorKey);
+	const key = readIdentity?.buildChannelKey(teamId, bare);
+	if (readIdentity && key) {
+		return { namespace: readIdentity.channelNamespace, key };
 	}
 	const team = teamId?.trim() || "";
 	return {
@@ -102,7 +105,8 @@ export function channelResourceIdentity(
 
 /**
  * Ensure a channel resource entity exists (eager, before ACL sync). Returns the
- * entity id, or null when the key cannot be formed (missing team on Slack).
+ * entity id, or null when the key cannot be formed (e.g. a chat connector whose
+ * team-scoped key needs a team id that wasn't supplied).
  */
 export async function ensureChannelResourceEntity(opts: {
 	organizationId: string;
@@ -113,17 +117,28 @@ export async function ensureChannelResourceEntity(opts: {
 	sql?: DbClient;
 }): Promise<number | null> {
 	const sql = opts.sql ?? getDb();
+	const bare = opts.channelId.includes(":")
+		? opts.channelId.slice(opts.channelId.indexOf(":") + 1)
+		: opts.channelId;
+	// A registered chat connector's key construction can refuse (return null) when
+	// its team-scoped key can't be formed — bail rather than materialize a bad
+	// resource under the generic fallback namespace.
+	const readIdentity = channelReadIdentityFor(opts.connectorKey);
+	if (readIdentity && readIdentity.buildChannelKey(opts.teamId, bare) === null) {
+		return null;
+	}
+	// The resource entity type comes from the connector's ACL source. A connector
+	// that declares none produces no access-controlled channel resource, so there
+	// is nothing to materialize — skip rather than fabricate a type.
+	const resourceType = aclSourceFor(opts.connectorKey)?.resourceType;
+	if (!resourceType) return null;
+
 	const { namespace, key } = channelResourceIdentity(
 		opts.connectorKey,
 		opts.teamId,
 		opts.channelId,
 	);
-	if (opts.connectorKey === "slack" && !opts.teamId) return null;
-
-	await ensureResourceEntityType(
-		opts.organizationId,
-		SLACK_SOURCE.resourceType,
-	);
+	await ensureResourceEntityType(opts.organizationId, resourceType);
 
 	const resolved = await resolveEventAttributionsForItems(
 		{
@@ -142,7 +157,7 @@ export async function ensureChannelResourceEntity(opts: {
 				channel_about: [
 					{
 						role: "about",
-						entityType: SLACK_SOURCE.resourceType.slug,
+						entityType: resourceType.slug,
 						autoCreate: true,
 						titlePath: "metadata.resource_name",
 						identities: [

--- a/packages/server/src/authz/sources.ts
+++ b/packages/server/src/authz/sources.ts
@@ -16,6 +16,17 @@ import { slackAclSource, slackChannelReadIdentity } from '@lobu/connectors/slack
 /** Every registered ACL source (contributed by its connector package). */
 export const ACL_SOURCES: AclSourceDef[] = [slackAclSource, githubAclSource];
 
+const ACL_SOURCE_BY_KEY = new Map<string, AclSourceDef>(ACL_SOURCES.map((s) => [s.key, s]));
+
+/**
+ * The ACL source descriptor for a connector key, or null when that connector
+ * contributes no access-controlled resource type. Lets a caller read a
+ * connector's `resourceType` (namespace + slug) without naming the connector.
+ */
+export function aclSourceFor(key: string): AclSourceDef | null {
+  return ACL_SOURCE_BY_KEY.get(key) ?? null;
+}
+
 /** Resource entity-type slugs that the read gate treats as access-controlled.
  * Validated to simple identifiers so they can be inlined as SQL literals. */
 export const RESOURCE_TYPE_SLUGS: string[] = ACL_SOURCES.map((s) => {

--- a/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
@@ -34,6 +34,7 @@ mock.module("../../lobu/stores/slack-installations.js", () => ({
 	}),
 	// Also imported by the coordinator module (webhook routing); unused here.
 	getSlackInstallByTeamId: mock(async () => null),
+	getSlackInstallByEnterpriseId: mock(async () => null),
 	resolveSlackPendingByTenant: mock(async () => null),
 	claimSlackWelcomeDm: mock(async () => null),
 }));

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -33,6 +33,9 @@ export default defineConfig({
       // src/tools/admin/__tests__ is bun:test (schedule-delivery suites), run via
       // the same `bun test … src/tools/admin/__tests__` job — keep it off vitest.
       "src/tools/admin/__tests__/**",
+      // src/auth/oauth/__tests__ is bun:test (OAuth scope suites), run via the
+      // same `bun test … src/auth/oauth/__tests__` job — keep it off vitest.
+      "src/auth/oauth/__tests__/**",
       "**/node_modules/**",
       "**/dist/**",
     ],

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -201,7 +201,7 @@ INTEGRATION_EXIT=0
       done
     done
     exit $rc );                                                                        ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
-  (cd packages/server && "${DETERMINISTIC_TEST_ENV[@]}" bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__); ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
+  (cd packages/server && "${DETERMINISTIC_TEST_ENV[@]}" bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__ src/auth/oauth/__tests__); ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
 } > "$INTEGRATION_LOG" 2>&1
 set -e
 


### PR DESCRIPTION
## Why

Merging #1787 (connector-owned identity refactor) broke `main`'s typecheck.

`channel-about.ts` was added by **#1767** (per-channel about links), which merged into main **after** #1787's branch was cut. It imported `slackChannelKey` (from `slack-channel-graph.ts`) and `SLACK_SOURCE` (from `sources.ts`) — both **deleted** by #1787. Neither PR could see the other, so the squash-merge of #1787 left `channel-about.ts` referencing deleted symbols → `tsc` fails on main.

## Fix

Rewire `channel-about.ts` to the same connector-owned registry the rest of the ACL gate uses — no Slack naming:

- `channelResourceIdentity()` → resolves the channel namespace + team-scoped key via `channelReadIdentityFor(connectorKey).buildChannelKey`, falling back to the generic `chat_channel_id` form for unregistered connectors.
- `ensureChannelResourceEntity()` → resolves the resource type via a new `aclSourceFor(connectorKey)` helper (mirrors `channelReadIdentityFor`), and returns null for a connector with no ACL source rather than fabricating a resource type.
- New `aclSourceFor(key)` in `authz/sources.ts`.
- `channel-about.test.ts` builds the graph via the generic `buildAccessGraph` + `slackChannelsToResources` (both connector-owned) instead of the deleted `buildSlackChannelGraph`.

## Verification

- Server `tsc --noEmit`: clean (was 2 errors on main).
- authz integration suite: **39/39** green (incl. channel-about 2/2, slack-channel-visibility, github-repo-visibility, signin-slack-identity-collapse).

Unblocks #1788 (entity merge), which is stacked behind a healthy main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786053382&installation_id=136316292&pr_number=1792&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1792&signature=2383346985f7b43bfa6d13263d15af733a217af789fc0838fede265e1792cea3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved re-sync behavior for channel “about” relationships by using the access-graph configuration path to keep existing channel links intact.
  * Updated channel “about” relationship materialization to be connector-aware, using connector-provided identity and resource details for more reliable entity resolution.
  * Reduced cases where channel entities could not be resolved, improving lookup and relationship accuracy across supported connectors.
* **Tests / CI**
  * Expanded integration coverage by adding OAuth test suites to the Bun test phase and excluding OAuth suites from the Vitest integration gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->