### PR TITLE
Persist OAuth inference providers

### DIFF
--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -101,8 +101,7 @@ function createConsoleLogger(serviceName: string): Logger {
     },
     info: (message: any, ...args: any[]) => {
       if (currentLevel >= 2)
-        // codeql[js/clear-text-logging]: formatMessage redacts sensitive object keys before writing info logs.
-        console.log(formatMessage("info", message, ...args));
+        console.log(formatMessage("info", message, ...args)); // lgtm[js/clear-text-logging] formatMessage redacts sensitive object keys before writing info logs.
     },
     debug: (message: any, ...args: any[]) => {
       if (currentLevel >= 3)

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -101,6 +101,7 @@ function createConsoleLogger(serviceName: string): Logger {
     },
     info: (message: any, ...args: any[]) => {
       if (currentLevel >= 2)
+        // codeql[js/clear-text-logging]: formatMessage redacts sensitive object keys before writing info logs.
         console.log(formatMessage("info", message, ...args));
     },
     debug: (message: any, ...args: any[]) => {

--- a/packages/server/src/lobu/__tests__/inference-providers-oauth.test.ts
+++ b/packages/server/src/lobu/__tests__/inference-providers-oauth.test.ts
@@ -22,55 +22,60 @@
  */
 
 import {
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-} from 'bun:test';
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
 import {
-  ensureDbForGatewayTests,
-  resetTestDatabase,
-} from '../../gateway/__tests__/helpers/db-setup.js';
-import { orgContext } from '../stores/org-context';
+	ensureDbForGatewayTests,
+	resetTestDatabase,
+} from "../../gateway/__tests__/helpers/db-setup.js";
+import { orgContext } from "../stores/org-context";
 import {
-  authStash,
-  coreServicesStash,
-  installRouteTestMocks,
-} from './helpers/route-test-mocks';
+	buildRealClaudeAuthStack,
+	type RealClaudeAuthStack,
+} from "./helpers/real-claude-auth-stack";
 import {
-  buildRealClaudeAuthStack,
-  type RealClaudeAuthStack,
-} from './helpers/real-claude-auth-stack';
+	authStash,
+	coreServicesStash,
+	installRouteTestMocks,
+} from "./helpers/route-test-mocks";
 
 installRouteTestMocks();
 
 const TEST_ENCRYPTION_KEY =
-  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+	"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
-const ORG = 'org-oauth';
-const USER = 'u1';
+const ORG = "org-oauth";
+const USER = "u1";
 const ORG_BUCKET = `__org_oauth__:${ORG}`;
 
-const EXPECTED_REDIRECT_URI = 'https://platform.claude.com/oauth/code/callback';
+const EXPECTED_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback";
 
 const realFetch = globalThis.fetch;
 
 beforeAll(async () => {
-  await ensureDbForGatewayTests();
-  process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+	await ensureDbForGatewayTests();
+	process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
 }, 60_000);
 
 async function importAgentRoutes() {
-  const mod = await import('../agent-routes.js');
-  return mod.agentRoutes;
+	const mod = await import("../agent-routes.js");
+	return mod.agentRoutes;
 }
 
 async function seedOrg(): Promise<void> {
-  const { getDb } = await import('../../db/client.js');
-  const sql = getDb();
-  await sql`
+	const { getDb } = await import("../../db/client.js");
+	const sql = getDb();
+	await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${USER}, 'Test', 'u1@test', true, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `;
+	await sql`
     INSERT INTO organization (id, name, slug)
     VALUES (${ORG}, ${ORG}, ${ORG})
     ON CONFLICT (id) DO NOTHING
@@ -80,135 +85,195 @@ async function seedOrg(): Promise<void> {
 /** Captures the body POSTed to Anthropic's token endpoint, returns a fake
  *  token. Every other URL falls through to the real fetch. */
 function installTokenEndpointMock(captured: {
-  url?: string;
-  contentType?: string | null;
-  body?: string;
+	url?: string;
+	contentType?: string | null;
+	body?: string;
 }): void {
-  globalThis.fetch = (async (input: any, init?: any) => {
-    const url = typeof input === 'string' ? input : input.url;
-    if (url.includes('platform.claude.com') && url.includes('/oauth/token')) {
-      captured.url = url;
-      captured.contentType = init?.headers?.['Content-Type'] ?? null;
-      captured.body = typeof init?.body === 'string' ? init.body : '';
-      return new Response(
-        JSON.stringify({
-          access_token: 'sk-ant-oat01-test-access',
-          refresh_token: 'sk-ant-ort01-test-refresh',
-          token_type: 'Bearer',
-          expires_in: 28800,
-          scope: 'user:inference',
-        }),
-        { status: 200, headers: { 'content-type': 'application/json' } }
-      );
-    }
-    return realFetch(input, init);
-  }) as typeof fetch;
+	globalThis.fetch = (async (
+		input: Parameters<typeof fetch>[0],
+		init?: Parameters<typeof fetch>[1],
+	) => {
+		const url =
+			typeof input === "string"
+				? input
+				: input instanceof URL
+					? input.href
+					: input.url;
+		if (url.includes("platform.claude.com") && url.includes("/oauth/token")) {
+			captured.url = url;
+			captured.contentType = init?.headers?.["Content-Type"] ?? null;
+			captured.body = typeof init?.body === "string" ? init.body : "";
+			return new Response(
+				JSON.stringify({
+					access_token: "sk-ant-oat01-test-access",
+					refresh_token: "sk-ant-ort01-test-refresh",
+					token_type: "Bearer",
+					expires_in: 28800,
+					scope: "user:inference",
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}
+		return realFetch(input, init);
+	}) as typeof fetch;
 }
 
-describe('Org OAuth: redirect_uri matches between authorize and exchange', () => {
-  let stack: RealClaudeAuthStack;
+describe("Org OAuth: redirect_uri matches between authorize and exchange", () => {
+	let stack: RealClaudeAuthStack;
 
-  beforeEach(async () => {
-    await resetTestDatabase();
-    await seedOrg();
-    authStash.user = {
-      id: USER,
-      name: 'Test',
-      email: 'u1@test',
-      emailVerified: true,
-    };
-    authStash.organizationId = ORG;
-    authStash.authSource = 'session';
-    authStash.mcpAuthInfo = null;
+	beforeEach(async () => {
+		await resetTestDatabase();
+		await seedOrg();
+		authStash.user = {
+			id: USER,
+			name: "Test",
+			email: "u1@test",
+			emailVerified: true,
+		};
+		authStash.organizationId = ORG;
+		authStash.authSource = "session";
+		authStash.mcpAuthInfo = null;
 
-    stack = await orgContext.run({ organizationId: ORG }, () =>
-      buildRealClaudeAuthStack()
-    );
-    coreServicesStash.services = {
-      getOAuthStateStore: () => stack.oauthStateStore,
-      getAuthProfilesManager: () => stack.authProfilesManager,
-    };
-  });
+		stack = await orgContext.run({ organizationId: ORG }, () =>
+			buildRealClaudeAuthStack(),
+		);
+		coreServicesStash.services = {
+			getOAuthStateStore: () => stack.oauthStateStore,
+			getAuthProfilesManager: () => stack.authProfilesManager,
+		};
+	});
 
-  afterEach(async () => {
-    globalThis.fetch = realFetch;
-    coreServicesStash.services = null;
-    await stack?.shutdown();
-  });
+	afterEach(async () => {
+		globalThis.fetch = realFetch;
+		coreServicesStash.services = null;
+		await stack?.shutdown();
+	});
 
-  test('exchange reuses the authorize redirect_uri and stores to the org bucket', async () => {
-    const captured: {
-      url?: string;
-      contentType?: string | null;
-      body?: string;
-    } = {};
-    installTokenEndpointMock(captured);
+	test("exchange reuses the authorize redirect_uri and stores to the org bucket", async () => {
+		const captured: {
+			url?: string;
+			contentType?: string | null;
+			body?: string;
+		} = {};
+		installTokenEndpointMock(captured);
 
-    const app = await importAgentRoutes();
+		const app = await importAgentRoutes();
 
-    // 1. start → JSON { mode:'redirect', authorizeUrl }; pull redirect_uri + state.
-    const startRes = await app.request('/inference-providers/oauth/start', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ providerId: 'claude' }),
-    });
-    expect(startRes.status).toBe(200);
-    const startJson = (await startRes.json()) as {
-      mode: string;
-      authorizeUrl: string;
-    };
-    expect(startJson.mode).toBe('redirect');
-    const authorizeUrl = new URL(startJson.authorizeUrl);
-    const authorizeRedirectUri = authorizeUrl.searchParams.get('redirect_uri');
-    const state = authorizeUrl.searchParams.get('state');
-    expect(authorizeRedirectUri).toBe(EXPECTED_REDIRECT_URI);
-    expect(state).toBeTruthy();
-    // #3 extraAuthParams echo: the authorize URL carries `code=true`.
-    expect(authorizeUrl.searchParams.get('code')).toBe('true');
+		// 1. start → JSON { mode:'redirect', authorizeUrl }; pull redirect_uri + state.
+		const startRes = await app.request("/inference-providers/oauth/start", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ providerId: "claude" }),
+		});
+		expect(startRes.status).toBe(200);
+		const startJson = (await startRes.json()) as {
+			mode: string;
+			authorizeUrl: string;
+		};
+		expect(startJson.mode).toBe("redirect");
+		const authorizeUrl = new URL(startJson.authorizeUrl);
+		const authorizeRedirectUri = authorizeUrl.searchParams.get("redirect_uri");
+		const state = authorizeUrl.searchParams.get("state");
+		expect(authorizeRedirectUri).toBe(EXPECTED_REDIRECT_URI);
+		expect(state).toBeTruthy();
+		// #3 extraAuthParams echo: the authorize URL carries `code=true`.
+		expect(authorizeUrl.searchParams.get("code")).toBe("true");
 
-    // 2. complete with the pasted `code#state` → token exchange.
-    const completeRes = await app.request(
-      '/inference-providers/oauth/complete',
-      {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          providerId: 'claude',
-          code: `fake-auth-code#${state}`,
-        }),
-      }
-    );
-    expect(completeRes.status).toBe(200);
-    expect(await completeRes.json()).toEqual({ status: 'success' });
+		// 2. complete with the pasted `code#state` → token exchange.
+		const completeRes = await app.request(
+			"/inference-providers/oauth/complete",
+			{
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					providerId: "claude",
+					code: `fake-auth-code#${state}`,
+				}),
+			},
+		);
+		expect(completeRes.status).toBe(200);
+		expect(await completeRes.json()).toEqual({ status: "success" });
 
-    // #1305: exchange must be form-encoded and carry the SAME redirect_uri.
-    expect(captured.contentType).toBe('application/x-www-form-urlencoded');
-    const exchangeParams = new URLSearchParams(captured.body ?? '');
-    expect(exchangeParams.get('redirect_uri')).toBe(authorizeRedirectUri);
-    expect(exchangeParams.get('redirect_uri')).toBe(EXPECTED_REDIRECT_URI);
+		// #1305: exchange must be form-encoded and carry the SAME redirect_uri.
+		expect(captured.contentType).toBe("application/x-www-form-urlencoded");
+		const exchangeParams = new URLSearchParams(captured.body ?? "");
+		expect(exchangeParams.get("redirect_uri")).toBe(authorizeRedirectUri);
+		expect(exchangeParams.get("redirect_uri")).toBe(EXPECTED_REDIRECT_URI);
 
-    // Persisted via the REAL AuthProfilesManager to the ORG BUCKET.
-    const stored = await orgContext.run({ organizationId: ORG }, () =>
-      stack.authProfilesManager.getProviderProfiles(ORG_BUCKET, 'claude', USER)
-    );
-    expect(stored).toHaveLength(1);
-    expect(stored[0]).toMatchObject({ provider: 'claude', authType: 'oauth' });
-    expect(stored[0]?.credential).toBe('sk-ant-oat01-test-access');
-  });
+		// Persisted via the REAL AuthProfilesManager to the ORG BUCKET.
+		const stored = await orgContext.run({ organizationId: ORG }, () =>
+			stack.authProfilesManager.getProviderProfiles(ORG_BUCKET, "claude", USER),
+		);
+		expect(stored).toHaveLength(1);
+		expect(stored[0]).toMatchObject({ provider: "claude", authType: "oauth" });
+		expect(stored[0]?.credential).toBe("sk-ant-oat01-test-access");
 
-  test('headless (non-session) start hard-fails with a clear message', async () => {
-    authStash.authSource = 'pat';
-    authStash.mcpAuthInfo = { scopes: ['mcp:admin'] };
+		const { listInferenceProviders, resolveInferenceProviderConfig } =
+			await import("../stores/provider-secrets");
+		const providers = await listInferenceProviders(ORG);
+		expect(providers).toHaveLength(1);
+		expect(providers[0]).toMatchObject({
+			slug: "claude",
+			kind: "claude",
+			displayName: "Claude",
+			status: "active",
+		});
+		expect(
+			await resolveInferenceProviderConfig(ORG, "claude", "text"),
+		).toBeNull();
 
-    const app = await importAgentRoutes();
-    const res = await app.request('/inference-providers/oauth/start', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ providerId: 'claude' }),
-    });
-    expect(res.status).toBe(403);
-    expect((await res.json()) as { error: string }).toEqual({
-      error: 'OAuth providers require interactive sign-in',
-    });
-  });
+		const { getDb } = await import("../../db/client.js");
+		const sql = getDb();
+		await sql`
+      UPDATE inference_providers
+      SET deleted_at = now()
+      WHERE organization_id = ${ORG} AND slug = 'claude'
+    `;
+		const repairedRes = await app.request("/inference-providers");
+		expect(repairedRes.status).toBe(200);
+		const repaired = (await repairedRes.json()) as {
+			providers: Array<{
+				slug: string;
+				kind: string;
+				displayName: string | null;
+			}>;
+		};
+		expect(repaired.providers).toHaveLength(1);
+		expect(repaired.providers[0]).toMatchObject({
+			slug: "claude",
+			kind: "claude",
+			displayName: "Claude",
+		});
+
+		const deleteRes = await app.request("/inference-providers/claude", {
+			method: "DELETE",
+		});
+		expect(deleteRes.status).toBe(200);
+		const afterDeleteRes = await app.request("/inference-providers");
+		expect(afterDeleteRes.status).toBe(200);
+		const afterDelete = (await afterDeleteRes.json()) as {
+			providers: Array<{ slug: string }>;
+		};
+		expect(afterDelete.providers).toHaveLength(0);
+		const removedProfiles = await orgContext.run({ organizationId: ORG }, () =>
+			stack.authProfilesManager.getProviderProfiles(ORG_BUCKET, "claude", USER),
+		);
+		expect(removedProfiles).toHaveLength(0);
+	});
+
+	test("headless (non-session) start hard-fails with a clear message", async () => {
+		authStash.authSource = "pat";
+		authStash.mcpAuthInfo = { scopes: ["mcp:admin"] };
+
+		const app = await importAgentRoutes();
+		const res = await app.request("/inference-providers/oauth/start", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ providerId: "claude" }),
+		});
+		expect(res.status).toBe(403);
+		expect((await res.json()) as { error: string }).toEqual({
+			error: "OAuth providers require interactive sign-in",
+		});
+	});
 });

--- a/packages/server/src/lobu/__tests__/inference-providers-oauth.test.ts
+++ b/packages/server/src/lobu/__tests__/inference-providers-oauth.test.ts
@@ -93,16 +93,20 @@ function installTokenEndpointMock(captured: {
 		input: Parameters<typeof fetch>[0],
 		init?: Parameters<typeof fetch>[1],
 	) => {
-		const url =
-			typeof input === "string"
-				? input
-				: input instanceof URL
-					? input.href
-					: input.url;
-		if (url.includes("platform.claude.com") && url.includes("/oauth/token")) {
-			captured.url = url;
-			captured.contentType = init?.headers?.["Content-Type"] ?? null;
-			captured.body = typeof init?.body === "string" ? init.body : "";
+			const url =
+				typeof input === "string"
+					? input
+					: input instanceof URL
+						? input.href
+						: input.url;
+			const parsedUrl = new URL(url);
+			if (
+				parsedUrl.hostname === "platform.claude.com" &&
+				parsedUrl.pathname === "/v1/oauth/token"
+			) {
+				captured.url = url;
+				captured.contentType = init?.headers?.["Content-Type"] ?? null;
+				captured.body = typeof init?.body === "string" ? init.body : "";
 			return new Response(
 				JSON.stringify({
 					access_token: "sk-ant-oat01-test-access",

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -9,6 +9,7 @@ import { Hono } from "hono";
 import { ensureBuilderAgent } from "../auth/builder-provisioning";
 import { mcpAuth } from "../auth/middleware";
 import { getDb } from "../db/client";
+import { grantStrategyFor } from "../gateway/auth/oauth/grant-strategy";
 import {
 	CHATGPT_PROVIDER,
 	CLAUDE_PROVIDER,
@@ -19,6 +20,7 @@ import {
 	type ProviderCatalogService,
 } from "../gateway/auth/provider-catalog";
 import { createAuthProfileLabel } from "../gateway/auth/settings/auth-profiles-manager";
+import { orgBucketAgentId } from "../gateway/auth/settings/user-auth-profile-store";
 import {
 	ProviderRegistryService,
 	resolveProviderRegistryPath,
@@ -27,18 +29,17 @@ import type { Env } from "../index";
 import { getApplyContext } from "../utils/apply-context";
 import { recordConfigChangeEvent } from "../utils/insert-event";
 import logger from "../utils/logger";
+import { generateCodeVerifier } from "../utils/pkce";
 import { countRuntimeMessagingClientsByAgent } from "./client-routes";
 import { getLobuCoreServices } from "./gateway";
 import { orgContext } from "./stores/org-context";
-import { grantStrategyFor } from "../gateway/auth/oauth/grant-strategy";
-import { orgBucketAgentId } from "../gateway/auth/settings/user-auth-profile-store";
-import { generateCodeVerifier } from "../utils/pkce";
 import {
 	AGENT_ID_PATTERN,
 	createPostgresAgentConfigStore,
 } from "./stores/postgres-stores";
 import {
 	createInferenceProvider,
+	ensureOAuthInferenceProvider,
 	type InferenceCapabilities,
 	type InferenceCapabilityBlock,
 	isInferenceModality,
@@ -62,13 +63,13 @@ const routes = new Hono<{ Bindings: Env }>();
  * a string leak to the UI, where `.map` would throw.
  */
 function toStringArray(value: unknown): string[] {
-  if (Array.isArray(value)) return value.map(String);
+	if (Array.isArray(value)) return value.map(String);
 	if (typeof value === "string") {
 		const inner = value.replace(/^\{/, "").replace(/\}$/, "").trim();
-    if (!inner) return [];
+		if (!inner) return [];
 		return inner.split(",").map((s) => s.replace(/^"|"$/g, "").trim());
-  }
-  return [];
+	}
+	return [];
 }
 
 const configStore = createPostgresAgentConfigStore();
@@ -188,7 +189,7 @@ routes.use("*", mcpAuth);
 routes.use("*", async (c, next) => {
 	const orgId = c.get("organizationId");
 	if (!orgId) return c.json({ error: "Organization required" }, 401);
-  return orgContext.run({ organizationId: orgId }, next);
+	return orgContext.run({ organizationId: orgId }, next);
 });
 
 /**
@@ -209,8 +210,8 @@ export function requireSessionOrAdminPat(c: any): Response | null {
 	const authSource = c.get("authSource") as "session" | "pat" | "oauth" | null;
 
 	if (authSource === "session") {
-    return null;
-  }
+		return null;
+	}
 
 	if (authSource === "pat" || authSource === "oauth") {
 		const authInfo = c.get("mcpAuthInfo");
@@ -218,17 +219,17 @@ export function requireSessionOrAdminPat(c: any): Response | null {
 			? authInfo.scopes
 			: [];
 		if (scopes.includes("mcp:admin")) {
-      return null;
-    }
-    return c.json(
-      {
+			return null;
+		}
+		return c.json(
+			{
 				error: "forbidden",
-        error_description:
+				error_description:
 					"This route requires a web session or a token with mcp:admin scope.",
-      },
+			},
 			403,
-    );
-  }
+		);
+	}
 
 	return c.json({ error: "Authentication required" }, 401);
 }
@@ -264,15 +265,15 @@ function emitConfigChange(
 function sanitizeClientProfileMetadata(
 	metadata: AuthProfile["metadata"],
 ): AuthProfile["metadata"] | undefined {
-  if (!metadata) return undefined;
-  const next = {
-    ...(metadata.email ? { email: metadata.email } : {}),
+	if (!metadata) return undefined;
+	const next = {
+		...(metadata.email ? { email: metadata.email } : {}),
 		...(typeof metadata.expiresAt === "number"
 			? { expiresAt: metadata.expiresAt }
 			: {}),
-    ...(metadata.accountId ? { accountId: metadata.accountId } : {}),
-  };
-  return Object.keys(next).length > 0 ? next : undefined;
+		...(metadata.accountId ? { accountId: metadata.accountId } : {}),
+	};
+	return Object.keys(next).length > 0 ? next : undefined;
 }
 
 /**
@@ -283,17 +284,17 @@ function sanitizeClientProfileMetadata(
  * UI uses it only as "is a key already saved?" signal, never reads its value.
  */
 function sanitizeAuthProfileForClient(profile: AuthProfile) {
-  const metadata = sanitizeClientProfileMetadata(profile.metadata);
-  return {
-    id: profile.id,
-    provider: profile.provider,
-    model: profile.model,
+	const metadata = sanitizeClientProfileMetadata(profile.metadata);
+	return {
+		id: profile.id,
+		provider: profile.provider,
+		model: profile.model,
 		credential: "",
-    label: profile.label,
-    authType: profile.authType,
-    ...(metadata ? { metadata } : {}),
-    createdAt: profile.createdAt,
-  };
+		label: profile.label,
+		authType: profile.authType,
+		...(metadata ? { metadata } : {}),
+		createdAt: profile.createdAt,
+	};
 }
 
 /**
@@ -313,56 +314,56 @@ function sanitizeAuthProfileForClient(profile: AuthProfile) {
  * rather than reporting a save that was dropped.
  */
 async function reconcileAgentAuthProfiles(
-  agentId: string,
-  userId: string,
+	agentId: string,
+	userId: string,
 	desired: AuthProfile[],
 ): Promise<void> {
-  const manager = getLobuCoreServices()?.getAuthProfilesManager?.();
-  if (!manager) {
+	const manager = getLobuCoreServices()?.getAuthProfilesManager?.();
+	if (!manager) {
 		throw new Error(
 			"Auth profile store is not available — retry once startup completes",
 		);
-  }
-  const store = manager.getUserAuthProfileStore();
-  for (const profile of desired) {
+	}
+	const store = manager.getUserAuthProfileStore();
+	for (const profile of desired) {
 		const credential =
 			typeof profile.credential === "string" ? profile.credential.trim() : "";
-    if (!credential) continue;
-    const metadata = sanitizeClientProfileMetadata(profile.metadata);
-    await manager.upsertProfile({
-      userId,
-      agentId,
-      id: profile.id,
-      provider: profile.provider,
-      credential,
-      authType: profile.authType,
-      label: profile.label,
-      model: profile.model,
-      ...(metadata ? { metadata } : {}),
-      makePrimary: true,
-    });
-  }
+		if (!credential) continue;
+		const metadata = sanitizeClientProfileMetadata(profile.metadata);
+		await manager.upsertProfile({
+			userId,
+			agentId,
+			id: profile.id,
+			provider: profile.provider,
+			credential,
+			authType: profile.authType,
+			label: profile.label,
+			model: profile.model,
+			...(metadata ? { metadata } : {}),
+			makePrimary: true,
+		});
+	}
 	const desiredIds = new Set(
 		desired.map((profile) => profile.id).filter(Boolean),
 	);
-  const current = await store.list(userId, agentId);
-  for (const existing of current) {
-    if (!desiredIds.has(existing.id)) {
-      await store.remove(userId, agentId, {
-        provider: existing.provider,
-        profileId: existing.id,
-      });
-    }
-  }
+	const current = await store.list(userId, agentId);
+	for (const existing of current) {
+		if (!desiredIds.has(existing.id)) {
+			await store.remove(userId, agentId, {
+				provider: existing.provider,
+				profileId: existing.id,
+			});
+		}
+	}
 }
 
 /** True if the submitted profile list contains at least one fresh credential. */
 function hasFreshCredential(profiles: AuthProfile[]): boolean {
-  return profiles.some(
+	return profiles.some(
 		(profile) =>
 			typeof profile.credential === "string" &&
 			profile.credential.trim().length > 0,
-  );
+	);
 }
 
 // ── Resolve the org's builder/system agent ───────────────────────────────────
@@ -371,30 +372,30 @@ function hasFreshCredential(profiles: AuthProfile[]): boolean {
 // Registered before any `/:agentId` route so the literal path wins.
 routes.get("/system-agent", async (c) => {
 	const orgId = c.get("organizationId")!;
-  const sql = getDb();
-  // Backfill / heal the org's builder on demand. Orgs created before the
-  // builder feature have no system agent yet, and an org whose builder was
-  // provisioned before its providers resolved needs its providers/model filled
-  // in. ensureBuilderAgent is idempotent + one SELECT on the healthy path, and
-  // best-effort (never throws), so it can't break console load.
-  await ensureBuilderAgent(orgId, sql);
-  const rows = await sql`
+	const sql = getDb();
+	// Backfill / heal the org's builder on demand. Orgs created before the
+	// builder feature have no system agent yet, and an org whose builder was
+	// provisioned before its providers resolved needs its providers/model filled
+	// in. ensureBuilderAgent is idempotent + one SELECT on the healthy path, and
+	// best-effort (never throws), so it can't break console load.
+	await ensureBuilderAgent(orgId, sql);
+	const rows = await sql`
     SELECT system_agent_id FROM organization WHERE id = ${orgId} LIMIT 1
   `;
-  return c.json({
-    systemAgentId: (rows[0]?.system_agent_id as string | null) ?? null,
-  });
+	return c.json({
+		systemAgentId: (rows[0]?.system_agent_id as string | null) ?? null,
+	});
 });
 
 // ── List agents ──────────────────────────────────────────────────────────────
 
 routes.get("/", async (c) => {
-  const agents = await configStore.listAgents();
+	const agents = await configStore.listAgents();
 
-  // Count connections per agent
-  const sql = getDb();
+	// Count connections per agent
+	const sql = getDb();
 	const orgId = c.get("organizationId")!;
-  const connCounts = await sql`
+	const connCounts = await sql`
     SELECT c.agent_id,
       count(*)::int as count,
       count(*) FILTER (WHERE c.status = 'active')::int as active_count
@@ -405,7 +406,7 @@ routes.get("/", async (c) => {
       AND c.deleted_at IS NULL
     GROUP BY c.agent_id
   `;
-  const countMap = new Map(connCounts.map((r: any) => [r.agent_id, r.count]));
+	const countMap = new Map(connCounts.map((r: any) => [r.agent_id, r.count]));
 	const activeCountMap = new Map(
 		connCounts.map((r: any) => [r.agent_id, r.active_count]),
 	);
@@ -417,27 +418,27 @@ routes.get("/", async (c) => {
 		platformRows,
 		providerRows,
 	] = await Promise.all([
-      countRuntimeMessagingClientsByAgent(orgId),
-      // Watchers owned by each agent (active only).
-      sql`
+		countRuntimeMessagingClientsByAgent(orgId),
+		// Watchers owned by each agent (active only).
+		sql`
         SELECT agent_id, count(*)::int as count
         FROM watchers
         WHERE organization_id = ${orgId} AND status = 'active' AND agent_id IS NOT NULL
         GROUP BY agent_id
       `,
-      // Distinct end-users per agent across messaging platforms.
-      sql`
+		// Distinct end-users per agent across messaging platforms.
+		sql`
         SELECT u.agent_id, count(DISTINCT (u.platform, u.user_id))::int as count
         FROM agent_users u
         JOIN agents a ON a.id = u.agent_id
         WHERE a.organization_id = ${orgId}
         GROUP BY u.agent_id
       `,
-      // Distinct connection platforms per agent. Cast to text so the driver always
-      // returns a JS array — array_agg over an enum/varchar column can come back as
-      // a raw `'{telegram,slack}'` string when postgres.js has no array parser for
-      // the element OID, which then blows up `.map` in the UI.
-      sql`
+		// Distinct connection platforms per agent. Cast to text so the driver always
+		// returns a JS array — array_agg over an enum/varchar column can come back as
+		// a raw `'{telegram,slack}'` string when postgres.js has no array parser for
+		// the element OID, which then blows up `.map` in the UI.
+		sql`
         SELECT c.agent_id, array_agg(DISTINCT c.connector_key::text) as platforms
         FROM connections c
         JOIN agents a ON a.id = c.agent_id AND a.organization_id = c.organization_id
@@ -446,102 +447,102 @@ routes.get("/", async (c) => {
           AND c.deleted_at IS NULL
         GROUP BY c.agent_id
       `,
-      // Provider ids per agent, from the agent row's installed_providers list.
-      sql`
+		// Provider ids per agent, from the agent row's installed_providers list.
+		sql`
         SELECT id, installed_providers
         FROM agents
         WHERE organization_id = ${orgId}
       `,
-    ]);
+	]);
 
-  const clientCountMap = new Map<string, Set<string>>();
-  for (const [agentId, runtimeIds] of runtimeClientCounts.entries()) {
-    let ids = clientCountMap.get(agentId);
-    if (!ids) {
-      ids = new Set<string>();
-      clientCountMap.set(agentId, ids);
-    }
-    for (const clientId of runtimeIds) ids.add(clientId);
-  }
+	const clientCountMap = new Map<string, Set<string>>();
+	for (const [agentId, runtimeIds] of runtimeClientCounts.entries()) {
+		let ids = clientCountMap.get(agentId);
+		if (!ids) {
+			ids = new Set<string>();
+			clientCountMap.set(agentId, ids);
+		}
+		for (const clientId of runtimeIds) ids.add(clientId);
+	}
 	const watcherCountMap = new Map(
 		watcherCounts.map((r: any) => [r.agent_id, r.count]),
 	);
 	const userCountMap = new Map(
 		userCounts.map((r: any) => [r.agent_id, r.count]),
 	);
-  const platformsMap = new Map(
+	const platformsMap = new Map(
 		platformRows.map((r: any) => [r.agent_id, toStringArray(r.platforms)]),
-  );
-  const providersMap = new Map<string, string[]>();
-  for (const r of providerRows) {
-    const set = new Set<string>();
-    for (const p of ((r as any).installed_providers ?? []) as any[]) {
-      const id = p?.providerId ?? p?.provider;
-      if (id) set.add(String(id));
-    }
-    providersMap.set((r as any).id, [...set]);
-  }
+	);
+	const providersMap = new Map<string, string[]>();
+	for (const r of providerRows) {
+		const set = new Set<string>();
+		for (const p of ((r as any).installed_providers ?? []) as any[]) {
+			const id = p?.providerId ?? p?.provider;
+			if (id) set.add(String(id));
+		}
+		providersMap.set((r as any).id, [...set]);
+	}
 
-  return c.json({
-    agents: agents.map((a) => ({
-      ...a,
-      connectionCount: countMap.get(a.agentId) ?? 0,
-      activeConnectionCount: activeCountMap.get(a.agentId) ?? 0,
-      clientCount: clientCountMap.get(a.agentId)?.size ?? 0,
-      watcherCount: watcherCountMap.get(a.agentId) ?? 0,
-      userCount: userCountMap.get(a.agentId) ?? 0,
-      platforms: platformsMap.get(a.agentId) ?? [],
-      providers: providersMap.get(a.agentId) ?? [],
+	return c.json({
+		agents: agents.map((a) => ({
+			...a,
+			connectionCount: countMap.get(a.agentId) ?? 0,
+			activeConnectionCount: activeCountMap.get(a.agentId) ?? 0,
+			clientCount: clientCountMap.get(a.agentId)?.size ?? 0,
+			watcherCount: watcherCountMap.get(a.agentId) ?? 0,
+			userCount: userCountMap.get(a.agentId) ?? 0,
+			platforms: platformsMap.get(a.agentId) ?? [],
+			providers: providersMap.get(a.agentId) ?? [],
 			status: (activeCountMap.get(a.agentId) ?? 0) > 0 ? "active" : "idle",
-    })),
-  });
+		})),
+	});
 });
 
 // ── Create agent ─────────────────────────────────────────────────────────────
 
 routes.post("/", async (c) => {
-  const denied = requireSessionOrAdminPat(c);
-  if (denied) return denied;
-  const body = await c.req.json<{
-    agentId: string;
-    name: string;
-    description?: string;
-  }>();
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const body = await c.req.json<{
+		agentId: string;
+		name: string;
+		description?: string;
+	}>();
 	const user = c.get("user");
 	if (!user) return c.json({ error: "Authentication required" }, 401);
 
-  const { agentId, name, description } = body;
+	const { agentId, name, description } = body;
 	if (!agentId || !name)
 		return c.json({ error: "agentId and name are required" }, 400);
 
-  // Validate agentId format
-  if (!AGENT_ID_PATTERN.test(agentId)) {
-    return c.json(
-      {
-        error:
+	// Validate agentId format
+	if (!AGENT_ID_PATTERN.test(agentId)) {
+		return c.json(
+			{
+				error:
 					"agentId must be 3-60 lowercase alphanumeric chars with hyphens, starting with a letter",
-      },
+			},
 			400,
-    );
-  }
+		);
+	}
 
 	const orgId = c.get("organizationId") as string;
 
-  // Atomic create + auto-inject. Two concurrent `lobu apply` runs from the
-  // same operator can both reach this endpoint with the same agentId. The
-  // previous version did INSERT-then-saveSettings as two separate writes:
-  // a "loser" returning 200 in the idempotent branch could see the row
-  // before the winner's saveSettings landed, then immediately PATCH it with
-  // operator config — only for the winner's deferred saveSettings to clobber
-  // it moments later. Folding `pre_approved_tools` into the same INSERT
-  // statement closes that gap: the row + auto-injected pre-approvals land
-  // atomically and the loser's idempotent 200 already reflects
-  // fully-initialized state. The `lobu-memory` MCP server itself is no longer
-  // stored per-agent — it's derived at worker startup by McpConfigService.
-  const sql = getDb();
-  const now = new Date();
+	// Atomic create + auto-inject. Two concurrent `lobu apply` runs from the
+	// same operator can both reach this endpoint with the same agentId. The
+	// previous version did INSERT-then-saveSettings as two separate writes:
+	// a "loser" returning 200 in the idempotent branch could see the row
+	// before the winner's saveSettings landed, then immediately PATCH it with
+	// operator config — only for the winner's deferred saveSettings to clobber
+	// it moments later. Folding `pre_approved_tools` into the same INSERT
+	// statement closes that gap: the row + auto-injected pre-approvals land
+	// atomically and the loser's idempotent 200 already reflects
+	// fully-initialized state. The `lobu-memory` MCP server itself is no longer
+	// stored per-agent — it's derived at worker startup by McpConfigService.
+	const sql = getDb();
+	const now = new Date();
 	const ownerPreApprovedTools = ["/mcp/lobu-memory/tools/*"];
-  const inserted = await sql`
+	const inserted = await sql`
     INSERT INTO agents (
       id, organization_id, name, description, owner_platform, owner_user_id,
       pre_approved_tools, created_at, updated_at
@@ -555,23 +556,23 @@ routes.post("/", async (c) => {
     RETURNING id
   `;
 
-  if (inserted.length === 0) {
-    // Another writer (or a previous apply cycle) already owns this id in
-    // *this* org. Return idempotent 200 with the existing row's metadata.
-    // Cross-org collisions are no longer possible — the PK is per-org now.
-    const existing = await configStore.getMetadata(agentId);
-    if (!existing) {
+	if (inserted.length === 0) {
+		// Another writer (or a previous apply cycle) already owns this id in
+		// *this* org. Return idempotent 200 with the existing row's metadata.
+		// Cross-org collisions are no longer possible — the PK is per-org now.
+		const existing = await configStore.getMetadata(agentId);
+		if (!existing) {
 			return c.json({ error: "Agent metadata missing" }, 500);
-    }
-    return c.json(
-      {
-        agentId,
-        name: existing.name,
-        description: existing.description,
-      },
+		}
+		return c.json(
+			{
+				agentId,
+				name: existing.name,
+				description: existing.description,
+			},
 			200,
-    );
-  }
+		);
+	}
 
 	emitConfigChange(c, {
 		resourceKind: "agent",
@@ -581,7 +582,7 @@ routes.post("/", async (c) => {
 		state: { agentId, name, description: description ?? null },
 	});
 
-  return c.json({ agentId, name, description }, 201);
+	return c.json({ agentId, name, description }, 201);
 });
 
 // ── Org-scoped inference-provider routes ─────────────────────────────────────
@@ -591,33 +592,33 @@ routes.post("/", async (c) => {
 // defined lower in this file.
 
 routes.get("/inference-providers", async (c) => {
-  const orgId = requireOrgId(c);
+	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;
-  const providers = await listInferenceProviders(orgId);
-  return c.json({ providers });
+	await ensureVisibleOAuthProvidersForUser(c, orgId);
+	const providers = await listInferenceProviders(orgId);
+	return c.json({ providers });
 });
 
 // Bundled provider catalog (PUBLIC metadata only — no secrets). Renders the
 // default "Available" add-cards on the inference-providers page; each entry
 // carries enough pre-fill data that adopting a bundled provider needs only an
 // API key. Registered before any `/:agentId` route so the literal path matches.
-routes.get('/inference-providers/catalog', async (c) => {
-  try {
-    const registry = new ProviderRegistryService(resolveProviderRegistryPath());
-    const configs = await registry.getProviderConfigs();
-    // Built from the module registry (not just providers.json) so Claude /
-    // ChatGPT (OAuth modules) appear too, each carrying its auth metadata.
-    const catalog = buildProviderCatalog(configs);
-    return c.json({ catalog });
-  } catch (err) {
-    logger.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      '[inference-providers/catalog] failed to load bundled provider catalog',
-    );
-    return c.json({ catalog: [] });
-  }
+routes.get("/inference-providers/catalog", async (c) => {
+	try {
+		const registry = new ProviderRegistryService(resolveProviderRegistryPath());
+		const configs = await registry.getProviderConfigs();
+		// Built from the module registry (not just providers.json) so Claude /
+		// ChatGPT (OAuth modules) appear too, each carrying its auth metadata.
+		const catalog = buildProviderCatalog(configs);
+		return c.json({ catalog });
+	} catch (err) {
+		logger.warn(
+			{ err: err instanceof Error ? err.message : String(err) },
+			"[inference-providers/catalog] failed to load bundled provider catalog",
+		);
+		return c.json({ catalog: [] });
+	}
 });
-
 
 // ── Org-scoped LLM-provider OAuth (subscription login) ───────────────────────
 //
@@ -633,21 +634,52 @@ routes.get('/inference-providers/catalog', async (c) => {
 // session user) HARD-FAILS — OAuth sign-in has no non-interactive path.
 
 const OAUTH_PROVIDER_CONFIGS: Record<string, OAuthProviderConfig> = {
-  claude: CLAUDE_PROVIDER,
-  chatgpt: CHATGPT_PROVIDER,
+	claude: CLAUDE_PROVIDER,
+	chatgpt: CHATGPT_PROVIDER,
 };
+
+async function ensureVisibleOAuthProvidersForUser(
+	c: any,
+	orgId: string,
+): Promise<void> {
+	const user = c.get("user") as { id: string } | undefined;
+	if (!user?.id) return;
+	const authProfilesManager = getLobuCoreServices()?.getAuthProfilesManager?.();
+	if (!authProfilesManager) return;
+
+	for (const config of Object.values(OAUTH_PROVIDER_CONFIGS)) {
+		const profiles = await orgContext.run({ organizationId: orgId }, () =>
+			authProfilesManager.getProviderProfiles(
+				orgBucketAgentId(orgId),
+				config.id,
+				user.id,
+			),
+		);
+		if (profiles.length === 0) continue;
+		await ensureOAuthInferenceProvider({
+			organizationId: orgId,
+			slug: config.id,
+			kind: config.id,
+			displayName: config.name,
+			createdBy: user.id,
+		});
+	}
+}
 
 /** Resolve the OAuth provider config, or a 400 Response if unknown. */
 function resolveOAuthProvider(
-  c: any,
-  providerId: unknown
+	c: any,
+	providerId: unknown,
 ): OAuthProviderConfig | Response {
-  const id = typeof providerId === 'string' ? providerId : '';
-  const config = OAUTH_PROVIDER_CONFIGS[id];
-  if (!config) {
-    return c.json({ error: `Provider '${id}' does not support OAuth sign-in` }, 400);
-  }
-  return config;
+	const id = typeof providerId === "string" ? providerId : "";
+	const config = OAUTH_PROVIDER_CONFIGS[id];
+	if (!config) {
+		return c.json(
+			{ error: `Provider '${id}' does not support OAuth sign-in` },
+			400,
+		);
+	}
+	return config;
 }
 
 /**
@@ -656,259 +688,295 @@ function resolveOAuthProvider(
  * Returns the session user, or a Response (403 headless, 401 unauthenticated).
  */
 function requireInteractiveUser(c: any): { id: string } | Response {
-  const user = c.get('user') as { id: string } | undefined;
-  const authSource = c.get('authSource') as string | null;
-  if (authSource !== 'session' || !user) {
-    return c.json(
-      { error: 'OAuth providers require interactive sign-in' },
-      403
-    );
-  }
-  return user;
+	const user = c.get("user") as { id: string } | undefined;
+	const authSource = c.get("authSource") as string | null;
+	if (authSource !== "session" || !user) {
+		return c.json(
+			{ error: "OAuth providers require interactive sign-in" },
+			403,
+		);
+	}
+	return user;
 }
 
-routes.post('/inference-providers/oauth/start', async (c) => {
-  const config = resolveOAuthProvider(c, await readProviderId(c));
-  if (config instanceof Response) return config;
-  const user = requireInteractiveUser(c);
-  if (user instanceof Response) return user;
-  const orgId = requireOrgId(c);
-  if (typeof orgId !== 'string') return orgId;
+routes.post("/inference-providers/oauth/start", async (c) => {
+	const config = resolveOAuthProvider(c, await readProviderId(c));
+	if (config instanceof Response) return config;
+	const user = requireInteractiveUser(c);
+	if (user instanceof Response) return user;
+	const orgId = requireOrgId(c);
+	if (typeof orgId !== "string") return orgId;
 
-  const strategy = grantStrategyFor(config);
-  const bucketAgentId = orgBucketAgentId(orgId);
+	const strategy = grantStrategyFor(config);
+	const bucketAgentId = orgBucketAgentId(orgId);
 
-  if ((config.grant ?? 'authorization-code') === 'authorization-code') {
-    const oauthStateStore = getLobuCoreServices()?.getOAuthStateStore?.();
-    if (!oauthStateStore) {
-      return c.json({ error: 'Embedded Lobu auth is not available' }, 503);
-    }
-    // Mint the PKCE verifier + state row FIRST, then build the authorize URL
-    // around that exact state so `complete` can validate it and recover the
-    // verifier. The bucket agentId rides the state so complete stores to the
-    // same org bucket even though no agents row exists for it.
-    const codeVerifier = generateCodeVerifier();
-    const stateToken = await oauthStateStore.create({
-      userId: user.id,
-      agentId: bucketAgentId,
-      codeVerifier,
-      context: { platform: 'web', channelId: bucketAgentId },
-    });
-    const result = await strategy.start(
-      config,
-      { kind: 'org', slug: orgId, organizationId: orgId, userId: user.id },
-      { stateToken, codeVerifier }
-    );
-    return c.json(result);
-  }
+	if ((config.grant ?? "authorization-code") === "authorization-code") {
+		const oauthStateStore = getLobuCoreServices()?.getOAuthStateStore?.();
+		if (!oauthStateStore) {
+			return c.json({ error: "Embedded Lobu auth is not available" }, 503);
+		}
+		// Mint the PKCE verifier + state row FIRST, then build the authorize URL
+		// around that exact state so `complete` can validate it and recover the
+		// verifier. The bucket agentId rides the state so complete stores to the
+		// same org bucket even though no agents row exists for it.
+		const codeVerifier = generateCodeVerifier();
+		const stateToken = await oauthStateStore.create({
+			userId: user.id,
+			agentId: bucketAgentId,
+			codeVerifier,
+			context: { platform: "web", channelId: bucketAgentId },
+		});
+		const result = await strategy.start(
+			config,
+			{ kind: "org", slug: orgId, organizationId: orgId, userId: user.id },
+			{ stateToken, codeVerifier },
+		);
+		return c.json(result);
+	}
 
-  // device-code (ChatGPT): no state store — deviceAuthId + userCode round-trip
-  // directly through the client on poll.
-  const result = await strategy.start(config, {
-    kind: 'org',
-    slug: orgId,
-    organizationId: orgId,
-    userId: user.id,
-  });
-  return c.json(result);
+	// device-code (ChatGPT): no state store — deviceAuthId + userCode round-trip
+	// directly through the client on poll.
+	const result = await strategy.start(config, {
+		kind: "org",
+		slug: orgId,
+		organizationId: orgId,
+		userId: user.id,
+	});
+	return c.json(result);
 });
 
-routes.post('/inference-providers/oauth/complete', async (c) => {
-  const body = (await c.req.json().catch(() => ({}))) as {
-    providerId?: unknown;
-    code?: unknown;
-    deviceAuthId?: unknown;
-    userCode?: unknown;
-  };
-  const config = resolveOAuthProvider(c, body.providerId);
-  if (config instanceof Response) return config;
-  const user = requireInteractiveUser(c);
-  if (user instanceof Response) return user;
-  const orgId = requireOrgId(c);
-  if (typeof orgId !== 'string') return orgId;
+routes.post("/inference-providers/oauth/complete", async (c) => {
+	const body = (await c.req.json().catch(() => ({}))) as {
+		providerId?: unknown;
+		code?: unknown;
+		deviceAuthId?: unknown;
+		userCode?: unknown;
+	};
+	const config = resolveOAuthProvider(c, body.providerId);
+	if (config instanceof Response) return config;
+	const user = requireInteractiveUser(c);
+	if (user instanceof Response) return user;
+	const orgId = requireOrgId(c);
+	if (typeof orgId !== "string") return orgId;
 
-  const authProfilesManager = getLobuCoreServices()?.getAuthProfilesManager?.();
-  if (!authProfilesManager) {
-    return c.json({ error: 'Embedded Lobu auth is not available' }, 503);
-  }
+	const authProfilesManager = getLobuCoreServices()?.getAuthProfilesManager?.();
+	if (!authProfilesManager) {
+		return c.json({ error: "Embedded Lobu auth is not available" }, 503);
+	}
 
-  const strategy = grantStrategyFor(config);
-  const scope = {
-    kind: 'org' as const,
-    slug: orgId,
-    organizationId: orgId,
-    userId: user.id,
-  };
-  const bucketAgentId = orgBucketAgentId(orgId);
+	const strategy = grantStrategyFor(config);
+	const scope = {
+		kind: "org" as const,
+		slug: orgId,
+		organizationId: orgId,
+		userId: user.id,
+	};
+	const bucketAgentId = orgBucketAgentId(orgId);
 
-  try {
-    let stored: Awaited<ReturnType<typeof strategy.complete>>;
-    if ((config.grant ?? 'authorization-code') === 'authorization-code') {
-      const input = typeof body.code === 'string' ? body.code.trim() : '';
-      if (!input) return c.json({ error: 'Missing OAuth code' }, 400);
-      const parts = input.split('#');
-      if (parts.length !== 2 || !parts[0] || !parts[1]) {
-        return c.json({ error: 'OAuth code must be in code#state format' }, 400);
-      }
-      const oauthStateStore = getLobuCoreServices()?.getOAuthStateStore?.();
-      if (!oauthStateStore) {
-        return c.json({ error: 'Embedded Lobu auth is not available' }, 503);
-      }
-      const stateData = await oauthStateStore.consume(parts[1].trim());
-      if (!stateData) {
-        return c.json({ error: 'OAuth state expired or is invalid' }, 400);
-      }
-      if (stateData.userId !== user.id || stateData.agentId !== bucketAgentId) {
-        return c.json({ error: 'OAuth state does not match this session' }, 403);
-      }
-      stored = await strategy.complete(config, scope, {
-        mode: 'redirect',
-        code: parts[0].trim(),
-        state: parts[1].trim(),
-        codeVerifier: stateData.codeVerifier,
-      });
-    } else {
-      const deviceAuthId =
-        typeof body.deviceAuthId === 'string' ? body.deviceAuthId.trim() : '';
-      const userCode =
-        typeof body.userCode === 'string' ? body.userCode.trim() : '';
-      if (!deviceAuthId || !userCode) {
-        return c.json({ error: 'Missing deviceAuthId or userCode' }, 400);
-      }
-      stored = await strategy.complete(config, scope, {
-        mode: 'device',
-        deviceAuthId,
-        userCode,
-      });
-      if (!stored) return c.json({ status: 'pending' });
-    }
+	try {
+		let stored: Awaited<ReturnType<typeof strategy.complete>>;
+		if ((config.grant ?? "authorization-code") === "authorization-code") {
+			const input = typeof body.code === "string" ? body.code.trim() : "";
+			if (!input) return c.json({ error: "Missing OAuth code" }, 400);
+			const parts = input.split("#");
+			if (parts.length !== 2 || !parts[0] || !parts[1]) {
+				return c.json(
+					{ error: "OAuth code must be in code#state format" },
+					400,
+				);
+			}
+			const oauthStateStore = getLobuCoreServices()?.getOAuthStateStore?.();
+			if (!oauthStateStore) {
+				return c.json({ error: "Embedded Lobu auth is not available" }, 503);
+			}
+			const stateData = await oauthStateStore.consume(parts[1].trim());
+			if (!stateData) {
+				return c.json({ error: "OAuth state expired or is invalid" }, 400);
+			}
+			if (stateData.userId !== user.id || stateData.agentId !== bucketAgentId) {
+				return c.json(
+					{ error: "OAuth state does not match this session" },
+					403,
+				);
+			}
+			stored = await strategy.complete(config, scope, {
+				mode: "redirect",
+				code: parts[0].trim(),
+				state: parts[1].trim(),
+				codeVerifier: stateData.codeVerifier,
+			});
+		} else {
+			const deviceAuthId =
+				typeof body.deviceAuthId === "string" ? body.deviceAuthId.trim() : "";
+			const userCode =
+				typeof body.userCode === "string" ? body.userCode.trim() : "";
+			if (!deviceAuthId || !userCode) {
+				return c.json({ error: "Missing deviceAuthId or userCode" }, 400);
+			}
+			stored = await strategy.complete(config, scope, {
+				mode: "device",
+				deviceAuthId,
+				userCode,
+			});
+			if (!stored) return c.json({ status: "pending" });
+		}
 
-    // authorization-code never returns null (it either exchanges or throws); the
-    // device branch already handled its pending case. This guards the type.
-    if (!stored) return c.json({ status: 'pending' });
+		// authorization-code never returns null (it either exchanges or throws); the
+		// device branch already handled its pending case. This guards the type.
+		if (!stored) return c.json({ status: "pending" });
 
-    // Persist to the org bucket. `organizationId` on the row is what keeps these
-    // tokens refreshing (scanAllOAuth COALESCE + refreshForUserAgent branch);
-    // the profile's providerId must be the config id so the refresh job's
-    // `doRefresh` matches it to the right refresher.
-    await authProfilesManager.upsertProfile({
-      agentId: bucketAgentId,
-      userId: user.id,
-      provider: config.id,
-      credential: stored.accessToken,
-      authType: stored.authType,
-      label: createAuthProfileLabel(config.name, stored.accessToken, stored.accountId),
-      metadata: {
-        ...(stored.refreshToken ? { refreshToken: stored.refreshToken } : {}),
-        expiresAt: stored.expiresAt,
-        ...(stored.accountId ? { accountId: stored.accountId } : {}),
-      },
-      makePrimary: true,
-      organizationId: orgId,
-    });
+		// Persist to the org bucket. `organizationId` on the row is what keeps these
+		// tokens refreshing (scanAllOAuth COALESCE + refreshForUserAgent branch);
+		// the profile's providerId must be the config id so the refresh job's
+		// `doRefresh` matches it to the right refresher.
+		await authProfilesManager.upsertProfile({
+			agentId: bucketAgentId,
+			userId: user.id,
+			provider: config.id,
+			credential: stored.accessToken,
+			authType: stored.authType,
+			label: createAuthProfileLabel(
+				config.name,
+				stored.accessToken,
+				stored.accountId,
+			),
+			metadata: {
+				...(stored.refreshToken ? { refreshToken: stored.refreshToken } : {}),
+				expiresAt: stored.expiresAt,
+				...(stored.accountId ? { accountId: stored.accountId } : {}),
+			},
+			makePrimary: true,
+			organizationId: orgId,
+		});
 
-    return c.json({ status: 'success' });
-  } catch (error) {
-    return c.json(
-      { error: error instanceof Error ? error.message : 'OAuth exchange failed' },
-      400
-    );
-  }
+		const provider = await ensureOAuthInferenceProvider({
+			organizationId: orgId,
+			slug: config.id,
+			kind: config.id,
+			displayName: config.name,
+			createdBy: user.id,
+		});
+		emitConfigChange(c, {
+			resourceKind: "inference-provider",
+			resourceId: provider.slug,
+			op: "created",
+			summary: `Inference provider '${provider.slug}' connected`,
+			state: {
+				slug: provider.slug,
+				kind: provider.kind,
+				displayName: provider.displayName,
+				capabilities: provider.capabilities,
+				hasCustomUpstream: provider.hasCustomUpstream,
+				status: provider.status,
+			},
+		});
+
+		return c.json({ status: "success" });
+	} catch (error) {
+		return c.json(
+			{
+				error: error instanceof Error ? error.message : "OAuth exchange failed",
+			},
+			400,
+		);
+	}
 });
 
 /** Read `providerId` from the JSON body (start route). Kept tiny so the two
  *  OAuth handlers share the parse without duplicating the try/catch. */
 async function readProviderId(c: any): Promise<unknown> {
-  const body = (await c.req.json().catch(() => ({}))) as { providerId?: unknown };
-  return body.providerId;
+	const body = (await c.req.json().catch(() => ({}))) as {
+		providerId?: unknown;
+	};
+	return body.providerId;
 }
 
-routes.post('/inference-providers', async (c) => {
-  const denied = requireSessionOrAdminPat(c);
-  if (denied) return denied;
-  const orgId = requireOrgId(c);
+routes.post("/inference-providers", async (c) => {
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;
 
-  let body: {
-    slug?: unknown;
-    kind?: unknown;
-    displayName?: unknown;
-    apiKey?: unknown;
-    capabilities?: unknown;
-  };
-  try {
-    body = await c.req.json();
-  } catch {
+	let body: {
+		slug?: unknown;
+		kind?: unknown;
+		displayName?: unknown;
+		apiKey?: unknown;
+		capabilities?: unknown;
+	};
+	try {
+		body = await c.req.json();
+	} catch {
 		return c.json({ error: "Invalid or missing JSON body" }, 400);
-  }
+	}
 
 	const slug = typeof body.slug === "string" ? body.slug : "";
 	const kind = typeof body.kind === "string" ? body.kind : "";
 	const apiKey = typeof body.apiKey === "string" ? body.apiKey : "";
 	if (!slug) return c.json({ error: "Body must include a `slug` string" }, 400);
-  if (!isValidInferenceProviderSlug(slug)) {
-    return c.json(
-      {
-        error:
+	if (!isValidInferenceProviderSlug(slug)) {
+		return c.json(
+			{
+				error:
 					"`slug` must be lowercase alphanumeric + hyphen, 1-63 chars, no leading/trailing hyphen",
-      },
+			},
 			400,
-    );
-  }
+		);
+	}
 	if (!kind) return c.json({ error: "Body must include a `kind` string" }, 400);
-  if (!apiKey) {
+	if (!apiKey) {
 		return c.json(
 			{ error: "Body must include a non-empty `apiKey` string" },
 			400,
 		);
-  }
-  const capErr = validateCapabilitiesMap(body.capabilities);
-  if (capErr) return c.json({ error: capErr }, 400);
+	}
+	const capErr = validateCapabilitiesMap(body.capabilities);
+	if (capErr) return c.json({ error: capErr }, 400);
 
-  // Gate: a provider is addable via a pasted API key only if its wire protocol
-  // is one we can route (present in SDK_COMPAT_PROTOCOLS). `kind` is the catalog
-  // slug the user picked; a known catalog entry whose sdkCompat isn't routable
-  // (e.g. a subscription-only OAuth provider) is rejected so an unroutable row
-  // can't be created. Unknown kinds (custom endpoints) pass — they're treated as
-  // OpenAI-compatible by the synthesize path.
-  try {
-    const registry = new ProviderRegistryService(resolveProviderRegistryPath());
-    const catalog = buildProviderCatalog(await registry.getProviderConfigs());
-    const entry = catalog.find((e) => e.slug === kind);
-    if (entry && !isSdkCompat(entry.sdkCompat)) {
-      return c.json(
-        {
-          error: `Provider '${kind}' can't be added with an API key — it signs in instead.`,
-        },
-        400
-      );
-    }
-  } catch (err) {
-    // Fail open on catalog-load errors: don't block creation on a metadata
-    // read. The synthesize path still gates routing downstream.
-    logger.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      '[inference-providers POST] catalog gate check failed; allowing',
-    );
-  }
+	// Gate: a provider is addable via a pasted API key only if its wire protocol
+	// is one we can route (present in SDK_COMPAT_PROTOCOLS). `kind` is the catalog
+	// slug the user picked; a known catalog entry whose sdkCompat isn't routable
+	// (e.g. a subscription-only OAuth provider) is rejected so an unroutable row
+	// can't be created. Unknown kinds (custom endpoints) pass — they're treated as
+	// OpenAI-compatible by the synthesize path.
+	try {
+		const registry = new ProviderRegistryService(resolveProviderRegistryPath());
+		const catalog = buildProviderCatalog(await registry.getProviderConfigs());
+		const entry = catalog.find((e) => e.slug === kind);
+		if (entry && !isSdkCompat(entry.sdkCompat)) {
+			return c.json(
+				{
+					error: `Provider '${kind}' can't be added with an API key — it signs in instead.`,
+				},
+				400,
+			);
+		}
+	} catch (err) {
+		// Fail open on catalog-load errors: don't block creation on a metadata
+		// read. The synthesize path still gates routing downstream.
+		logger.warn(
+			{ err: err instanceof Error ? err.message : String(err) },
+			"[inference-providers POST] catalog gate check failed; allowing",
+		);
+	}
 
-  const createdBy = c.get('user')?.id ?? null;
+	const createdBy = c.get("user")?.id ?? null;
 
-  const result = await createInferenceProvider({
-    organizationId: orgId,
-    slug,
-    kind,
+	const result = await createInferenceProvider({
+		organizationId: orgId,
+		slug,
+		kind,
 		displayName: typeof body.displayName === "string" ? body.displayName : null,
-    apiKey,
-    capabilities: (body.capabilities as InferenceCapabilities) ?? {},
-    createdBy,
-  });
+		apiKey,
+		capabilities: (body.capabilities as InferenceCapabilities) ?? {},
+		createdBy,
+	});
 	if ("error" in result) {
-    return c.json(
-      { error: `A provider with slug '${result.slug}' already exists` },
+		return c.json(
+			{ error: `A provider with slug '${result.slug}' already exists` },
 			409,
-    );
-  }
+		);
+	}
 	emitConfigChange(c, {
 		resourceKind: "inference-provider",
 		resourceId: result.slug,
@@ -924,50 +992,50 @@ routes.post('/inference-providers', async (c) => {
 		},
 	});
 
-  // Never echo the key or the api_key_ref back to the caller.
-  return c.json(
-    {
-      provider: {
-        id: result.id,
-        slug: result.slug,
-        kind: result.kind,
-        displayName: result.displayName,
-        capabilities: result.capabilities,
-        hasCustomUpstream: result.hasCustomUpstream,
-        status: result.status,
-        createdAt: result.createdAt,
-      },
-    },
+	// Never echo the key or the api_key_ref back to the caller.
+	return c.json(
+		{
+			provider: {
+				id: result.id,
+				slug: result.slug,
+				kind: result.kind,
+				displayName: result.displayName,
+				capabilities: result.capabilities,
+				hasCustomUpstream: result.hasCustomUpstream,
+				status: result.status,
+				createdAt: result.createdAt,
+			},
+		},
 		201,
-  );
+	);
 });
 
 // Edit a provider's core fields. Only displayName is mutable — slug (agents
 // reference it) and kind (catalog linkage) are immutable. Key rotation and
 // per-modality capability edits keep their dedicated routes below; the Edit UI
 // calls whichever it needs.
-routes.put('/inference-providers/:slug', async (c) => {
-  const denied = requireSessionOrAdminPat(c);
-  if (denied) return denied;
-  const orgId = requireOrgId(c);
-  if (typeof orgId !== 'string') return orgId;
-  const { slug } = c.req.param();
+routes.put("/inference-providers/:slug", async (c) => {
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const orgId = requireOrgId(c);
+	if (typeof orgId !== "string") return orgId;
+	const { slug } = c.req.param();
 
-  let body: { displayName?: unknown };
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json({ error: 'Invalid or missing JSON body' }, 400);
-  }
+	let body: { displayName?: unknown };
+	try {
+		body = await c.req.json();
+	} catch {
+		return c.json({ error: "Invalid or missing JSON body" }, 400);
+	}
 
-  // Empty / whitespace-only name means "leave unchanged" (pass undefined).
-  const rawName = typeof body.displayName === 'string' ? body.displayName : '';
-  const displayName = rawName.trim() ? rawName.trim() : undefined;
+	// Empty / whitespace-only name means "leave unchanged" (pass undefined).
+	const rawName = typeof body.displayName === "string" ? body.displayName : "";
+	const displayName = rawName.trim() ? rawName.trim() : undefined;
 
-  const updated = await updateInferenceProviderCoreFields(orgId, slug, {
-    displayName,
-  });
-  if (!updated) return c.json({ error: 'Provider not found' }, 404);
+	const updated = await updateInferenceProviderCoreFields(orgId, slug, {
+		displayName,
+	});
+	if (!updated) return c.json({ error: "Provider not found" }, 404);
 	emitConfigChange(c, {
 		resourceKind: "inference-provider",
 		resourceId: updated.slug,
@@ -983,33 +1051,33 @@ routes.put('/inference-providers/:slug', async (c) => {
 		},
 		changedFields: ["displayName"],
 	});
-  return c.json({
-    provider: {
-      id: updated.id,
-      slug: updated.slug,
-      kind: updated.kind,
-      displayName: updated.displayName,
-      capabilities: updated.capabilities,
-      hasCustomUpstream: updated.hasCustomUpstream,
-      status: updated.status,
-      createdAt: updated.createdAt,
-    },
-  });
+	return c.json({
+		provider: {
+			id: updated.id,
+			slug: updated.slug,
+			kind: updated.kind,
+			displayName: updated.displayName,
+			capabilities: updated.capabilities,
+			hasCustomUpstream: updated.hasCustomUpstream,
+			status: updated.status,
+			createdAt: updated.createdAt,
+		},
+	});
 });
 
 // Mark one org inference provider as THE org default. Its `capabilities.text.model`
 // becomes the org-default model — the tail of the layered fallback
 // (behavior → agent → org default). Exactly one live default per org (enforced
 // by a partial unique index); setting a new one clears the prior in one txn.
-routes.put('/inference-providers/:slug/default', async (c) => {
-  const denied = requireSessionOrAdminPat(c);
-  if (denied) return denied;
-  const orgId = requireOrgId(c);
-  if (typeof orgId !== 'string') return orgId;
-  const { slug } = c.req.param();
+routes.put("/inference-providers/:slug/default", async (c) => {
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const orgId = requireOrgId(c);
+	if (typeof orgId !== "string") return orgId;
+	const { slug } = c.req.param();
 
-  const ok = await setInferenceProviderDefault(orgId, slug);
-  if (!ok) return c.json({ error: 'Provider not found' }, 404);
+	const ok = await setInferenceProviderDefault(orgId, slug);
+	if (!ok) return c.json({ error: "Provider not found" }, 404);
 	emitConfigChange(c, {
 		resourceKind: "inference-provider",
 		resourceId: slug,
@@ -1018,39 +1086,39 @@ routes.put('/inference-providers/:slug/default', async (c) => {
 		state: { slug, isDefault: true },
 		changedFields: ["isDefault"],
 	});
-  return c.json({ success: true, slug, isDefault: true });
+	return c.json({ success: true, slug, isDefault: true });
 });
 
-routes.put('/inference-providers/:slug/capabilities/:modality', async (c) => {
-  const denied = requireSessionOrAdminPat(c);
-  if (denied) return denied;
-  const orgId = requireOrgId(c);
+routes.put("/inference-providers/:slug/capabilities/:modality", async (c) => {
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;
-  const { slug, modality } = c.req.param();
+	const { slug, modality } = c.req.param();
 
-  if (!isInferenceModality(modality)) {
-    return c.json(
-      { error: 'modality must be one of: text, image, stt, tts' },
-      400
-    );
-  }
+	if (!isInferenceModality(modality)) {
+		return c.json(
+			{ error: "modality must be one of: text, image, stt, tts" },
+			400,
+		);
+	}
 
-  let body: { block?: unknown };
-  try {
-    body = await c.req.json();
-  } catch {
+	let body: { block?: unknown };
+	try {
+		body = await c.req.json();
+	} catch {
 		return c.json({ error: "Invalid or missing JSON body" }, 400);
-  }
-  const block = body.block;
-  const err = validateCapabilityBlock(modality, block);
-  if (err) return c.json({ error: err }, 400);
+	}
+	const block = body.block;
+	const err = validateCapabilityBlock(modality, block);
+	if (err) return c.json({ error: err }, 400);
 
-  const updated = await updateInferenceProviderCapabilities(
-    orgId,
-    slug,
-    modality,
+	const updated = await updateInferenceProviderCapabilities(
+		orgId,
+		slug,
+		modality,
 		block as InferenceCapabilityBlock,
-  );
+	);
 	if (!updated) return c.json({ error: "Provider not found" }, 404);
 	emitConfigChange(c, {
 		resourceKind: "inference-provider",
@@ -1067,42 +1135,42 @@ routes.put('/inference-providers/:slug/capabilities/:modality', async (c) => {
 		},
 		changedFields: [`capabilities.${modality}`],
 	});
-  return c.json({
-    provider: {
-      id: updated.id,
-      slug: updated.slug,
-      kind: updated.kind,
-      displayName: updated.displayName,
-      capabilities: updated.capabilities,
-      hasCustomUpstream: updated.hasCustomUpstream,
-      status: updated.status,
-      createdAt: updated.createdAt,
-    },
-  });
+	return c.json({
+		provider: {
+			id: updated.id,
+			slug: updated.slug,
+			kind: updated.kind,
+			displayName: updated.displayName,
+			capabilities: updated.capabilities,
+			hasCustomUpstream: updated.hasCustomUpstream,
+			status: updated.status,
+			createdAt: updated.createdAt,
+		},
+	});
 });
 
 routes.put("/inference-providers/:slug/key", async (c) => {
-  const denied = requireSessionOrAdminPat(c);
-  if (denied) return denied;
-  const orgId = requireOrgId(c);
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;
-  const { slug } = c.req.param();
+	const { slug } = c.req.param();
 
-  let body: { value?: unknown };
-  try {
-    body = await c.req.json();
-  } catch {
+	let body: { value?: unknown };
+	try {
+		body = await c.req.json();
+	} catch {
 		return c.json({ error: "Invalid or missing JSON body" }, 400);
-  }
+	}
 	const value = typeof body.value === "string" ? body.value : "";
-  if (!value) {
+	if (!value) {
 		return c.json(
 			{ error: "Body must include a non-empty `value` string" },
 			400,
 		);
-  }
+	}
 
-  const ok = await rotateInferenceProviderKey(orgId, slug, value);
+	const ok = await rotateInferenceProviderKey(orgId, slug, value);
 	if (!ok) return c.json({ error: "Provider not found" }, 404);
 	// Metadata-only: key rotations are audited but the value is never snapshotted.
 	emitConfigChange(c, {
@@ -1113,18 +1181,33 @@ routes.put("/inference-providers/:slug/key", async (c) => {
 		state: null,
 		changedFields: ["apiKey"],
 	});
-  return c.json({ success: true });
+	return c.json({ success: true });
 });
 
 routes.delete("/inference-providers/:slug", async (c) => {
-  const denied = requireSessionOrAdminPat(c);
-  if (denied) return denied;
-  const orgId = requireOrgId(c);
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const orgId = requireOrgId(c);
 	if (typeof orgId !== "string") return orgId;
-  const { slug } = c.req.param();
+	const { slug } = c.req.param();
 
-  const ok = await softDeleteInferenceProvider(orgId, slug);
+	const ok = await softDeleteInferenceProvider(orgId, slug);
 	if (!ok) return c.json({ error: "Provider not found" }, 404);
+	const user = c.get("user") as { id: string } | undefined;
+	const oauthConfig = OAUTH_PROVIDER_CONFIGS[slug];
+	const authProfilesManager = getLobuCoreServices()?.getAuthProfilesManager?.();
+	// Only an interactive user can revoke their org-bucket OAuth profile. Admin
+	// PAT callers may tombstone the visible row, but must not delete another
+	// user's subscription credential.
+	if (user?.id && oauthConfig && authProfilesManager) {
+		await orgContext.run({ organizationId: orgId }, () =>
+			authProfilesManager.deleteProviderProfiles(
+				orgBucketAgentId(orgId),
+				oauthConfig.id,
+				{ userId: user.id },
+			),
+		);
+	}
 	emitConfigChange(c, {
 		resourceKind: "inference-provider",
 		resourceId: slug,
@@ -1132,20 +1215,20 @@ routes.delete("/inference-providers/:slug", async (c) => {
 		summary: `Inference provider '${slug}' deleted`,
 		state: null,
 	});
-  return c.json({ success: true });
+	return c.json({ success: true });
 });
 
 // ── Get agent detail ─────────────────────────────────────────────────────────
 
 routes.get("/:agentId", async (c) => {
-  const { agentId } = c.req.param();
-  const metadata = await configStore.getMetadata(agentId);
+	const { agentId } = c.req.param();
+	const metadata = await configStore.getMetadata(agentId);
 	if (!metadata) return c.json({ error: "Agent not found" }, 404);
 
-  const settings = await configStore.getSettings(agentId);
-  const sql = getDb();
+	const settings = await configStore.getSettings(agentId);
+	const sql = getDb();
 	const organizationId = c.get("organizationId") as string;
-  const [connectionStats] = await sql`
+	const [connectionStats] = await sql`
     SELECT
       count(*)::int as connection_count,
       count(*) FILTER (WHERE status = 'active')::int as active_connection_count
@@ -1153,37 +1236,37 @@ routes.get("/:agentId", async (c) => {
     WHERE agent_id = ${agentId} AND organization_id = ${organizationId}
       AND credential_mode IS NOT NULL AND deleted_at IS NULL
   `;
-  const clientIds = new Set<string>();
+	const clientIds = new Set<string>();
 	const runtimeClientCounts =
 		await countRuntimeMessagingClientsByAgent(organizationId);
-  for (const runtimeClientId of runtimeClientCounts.get(agentId) ?? []) {
-    clientIds.add(runtimeClientId);
-  }
+	for (const runtimeClientId of runtimeClientCounts.get(agentId) ?? []) {
+		clientIds.add(runtimeClientId);
+	}
 
-  return c.json({
-    ...metadata,
-    settings,
-    connectionCount: connectionStats?.connection_count ?? 0,
-    activeConnectionCount: connectionStats?.active_connection_count ?? 0,
-    clientCount: clientIds.size,
+	return c.json({
+		...metadata,
+		settings,
+		connectionCount: connectionStats?.connection_count ?? 0,
+		activeConnectionCount: connectionStats?.active_connection_count ?? 0,
+		clientCount: clientIds.size,
 		status:
 			(connectionStats?.active_connection_count ?? 0) > 0 ? "active" : "idle",
-  });
+	});
 });
 
 // ── Update agent metadata ────────────────────────────────────────────────────
 
 routes.patch("/:agentId", async (c) => {
-  const denied = requireSessionOrAdminPat(c);
-  if (denied) return denied;
-  const { agentId } = c.req.param();
-  const body = await c.req.json<{ name?: string; description?: string }>();
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const { agentId } = c.req.param();
+	const body = await c.req.json<{ name?: string; description?: string }>();
 
-  if (!(await configStore.hasAgent(agentId))) {
+	if (!(await configStore.hasAgent(agentId))) {
 		return c.json({ error: "Agent not found" }, 404);
-  }
+	}
 
-  await configStore.updateMetadata(agentId, body);
+	await configStore.updateMetadata(agentId, body);
 	// Snapshot the row as stored (post-merge), not the request body.
 	const metadata = await configStore.getMetadata(agentId);
 	emitConfigChange(c, {
@@ -1194,22 +1277,22 @@ routes.patch("/:agentId", async (c) => {
 		state: metadata ? { ...metadata, agentId } : null,
 		changedFields: Object.keys(body),
 	});
-  return c.json({ success: true });
+	return c.json({ success: true });
 });
 
 // ── Delete agent ─────────────────────────────────────────────────────────────
 
 routes.delete("/:agentId", async (c) => {
-  const denied = requireSessionOrAdminPat(c);
-  if (denied) return denied;
-  const { agentId } = c.req.param();
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const { agentId } = c.req.param();
 
-  if (!(await configStore.hasAgent(agentId))) {
+	if (!(await configStore.hasAgent(agentId))) {
 		return c.json({ error: "Agent not found" }, 404);
-  }
+	}
 
-  // Cascade handled by FK ON DELETE CASCADE
-  await configStore.deleteMetadata(agentId);
+	// Cascade handled by FK ON DELETE CASCADE
+	await configStore.deleteMetadata(agentId);
 	emitConfigChange(c, {
 		resourceKind: "agent",
 		resourceId: agentId,
@@ -1217,32 +1300,32 @@ routes.delete("/:agentId", async (c) => {
 		summary: `Agent '${agentId}' deleted`,
 		state: null,
 	});
-  return c.json({ success: true });
+	return c.json({ success: true });
 });
 
 // ── Get agent config (settings) ──────────────────────────────────────────────
 
 routes.get("/:agentId/config", async (c) => {
-  const { agentId } = c.req.param();
-  const settings = await configStore.getSettings(agentId);
+	const { agentId } = c.req.param();
+	const settings = await configStore.getSettings(agentId);
 	if (!settings) return c.json({ error: "Agent not found" }, 404);
 
-  // `configStore` doesn't carry auth profiles (they live in
-  // `user_auth_profiles`, keyed by the requesting user). Merge the caller's
-  // sanitized profiles in so the agent settings UI can show which providers
-  // already have a credential connected.
+	// `configStore` doesn't carry auth profiles (they live in
+	// `user_auth_profiles`, keyed by the requesting user). Merge the caller's
+	// sanitized profiles in so the agent settings UI can show which providers
+	// already have a credential connected.
 	const user = c.get("user");
-  const authProfilesManager = getLobuCoreServices()?.getAuthProfilesManager?.();
-  const authProfiles =
-    user?.id && authProfilesManager
+	const authProfilesManager = getLobuCoreServices()?.getAuthProfilesManager?.();
+	const authProfiles =
+		user?.id && authProfilesManager
 			? (
 					await authProfilesManager
 						.getUserAuthProfileStore()
 						.list(user.id, agentId)
 				).map(sanitizeAuthProfileForClient)
-      : [];
+			: [];
 
-  return c.json({ ...settings, authProfiles });
+	return c.json({ ...settings, authProfiles });
 });
 
 // ── Recent guardrail trips ───────────────────────────────────────────────────
@@ -1254,29 +1337,29 @@ routes.get("/:agentId/config", async (c) => {
 // would force an expensive `event_embeddings` join. Org-scoped + Postgres-backed
 // and therefore correct under N replicas (any pod can serve it).
 routes.get("/:agentId/guardrail-trips", async (c) => {
-  const { agentId } = c.req.param();
+	const { agentId } = c.req.param();
 	const organizationId = c.get("organizationId") as string;
 
-  // Clamp to a sane window — the UI asks for 50; cap so a hand-crafted query
-  // can't ask for an unbounded scan.
+	// Clamp to a sane window — the UI asks for 50; cap so a hand-crafted query
+	// can't ask for an unbounded scan.
 	const limitRaw = Number.parseInt(c.req.query("limit") ?? "50", 10);
-  const limit = Number.isFinite(limitRaw)
-    ? Math.min(Math.max(limitRaw, 1), 200)
-    : 50;
+	const limit = Number.isFinite(limitRaw)
+		? Math.min(Math.max(limitRaw, 1), 200)
+		: 50;
 
-  // Optional narrowing to a single guardrail — the per-guardrail detail view
-  // asks for just that guardrail's catches.
+	// Optional narrowing to a single guardrail — the per-guardrail detail view
+	// asks for just that guardrail's catches.
 	const guardrail = c.req.query("guardrail");
 
-  // Optional narrowing to one conversation — the chat view asks for just the
-  // trips that fired during this conversation so it can flag the affected turn.
+	// Optional narrowing to one conversation — the chat view asks for just the
+	// trips that fired during this conversation so it can flag the affected turn.
 	const conversationId = c.req.query("conversationId");
 
-  const sql = getDb();
-  // `recordGuardrailTrip` writes `created_at` (default now()) but leaves
-  // `occurred_at` null, so coalesce to `created_at` — otherwise the UI shows
-  // "null" for the timestamp of every real trip.
-  const rows = await sql`
+	const sql = getDb();
+	// `recordGuardrailTrip` writes `created_at` (default now()) but leaves
+	// `occurred_at` null, so coalesce to `created_at` — otherwise the UI shows
+	// "null" for the timestamp of every real trip.
+	const rows = await sql`
     SELECT id, COALESCE(occurred_at, created_at) AS occurred_at, metadata
       FROM events
      WHERE organization_id = ${organizationId}
@@ -1288,36 +1371,36 @@ routes.get("/:agentId/guardrail-trips", async (c) => {
      LIMIT ${limit}
   `;
 
-  const agentName = (await configStore.getMetadata(agentId))?.name;
+	const agentName = (await configStore.getMetadata(agentId))?.name;
 
-  const trips = rows.map((row) => {
-    const metadata = (row.metadata ?? {}) as {
-      stage?: string;
-      guardrail?: string;
-      reason?: string | null;
-      conversation_id?: string | null;
-    };
-    const occurredAt =
-      row.occurred_at instanceof Date
-        ? row.occurred_at.toISOString()
-        : row.occurred_at
-          ? String(row.occurred_at)
+	const trips = rows.map((row) => {
+		const metadata = (row.metadata ?? {}) as {
+			stage?: string;
+			guardrail?: string;
+			reason?: string | null;
+			conversation_id?: string | null;
+		};
+		const occurredAt =
+			row.occurred_at instanceof Date
+				? row.occurred_at.toISOString()
+				: row.occurred_at
+					? String(row.occurred_at)
 					: "";
-    return {
-      id: Number(row.id),
-      occurredAt,
-      agentId,
-      ...(agentName ? { agentName } : {}),
-      stage: metadata.stage,
-      guardrailName: metadata.guardrail,
-      ...(metadata.reason ? { reason: metadata.reason } : {}),
-      ...(metadata.conversation_id
-        ? { conversationId: metadata.conversation_id }
-        : {}),
-    };
-  });
+		return {
+			id: Number(row.id),
+			occurredAt,
+			agentId,
+			...(agentName ? { agentName } : {}),
+			stage: metadata.stage,
+			guardrailName: metadata.guardrail,
+			...(metadata.reason ? { reason: metadata.reason } : {}),
+			...(metadata.conversation_id
+				? { conversationId: metadata.conversation_id }
+				: {}),
+		};
+	});
 
-  return c.json({ trips });
+	return c.json({ trips });
 });
 
 // ── Judge model default (for custom guardrail authoring) ─────────────────────
@@ -1346,37 +1429,37 @@ routes.get("/:agentId/guardrail-judge-default", async (c) => {
 
 // TODO(inference-providers): remove after resolver cutover
 routes.put("/:agentId/providers/:providerId/api-key", async (c) => {
-  const denied = requireSessionOrAdminPat(c);
-  if (denied) return denied;
-  const { agentId, providerId } = c.req.param();
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const { agentId, providerId } = c.req.param();
 
-  if (!(await configStore.hasAgent(agentId))) {
+	if (!(await configStore.hasAgent(agentId))) {
 		return c.json({ error: "Agent not found" }, 404);
-  }
+	}
 
-  let body: { value?: unknown };
-  try {
-    body = await c.req.json();
-  } catch {
+	let body: { value?: unknown };
+	try {
+		body = await c.req.json();
+	} catch {
 		return c.json({ error: "Invalid or missing JSON body" }, 400);
-  }
+	}
 	const value = typeof body.value === "string" ? body.value : "";
-  if (!value) {
+	if (!value) {
 		return c.json(
 			{ error: "Body must include a non-empty `value` string" },
 			400,
 		);
-  }
+	}
 
-  const ciphertext = encrypt(value);
-  const name = providerOrgSecretName(providerId);
+	const ciphertext = encrypt(value);
+	const name = providerOrgSecretName(providerId);
 	const orgId = (c.get("organizationId") as string | undefined) ?? null;
-  if (!orgId) {
+	if (!orgId) {
 		return c.json({ error: "Organization context not available" }, 500);
-  }
+	}
 
-  const sql = getDb();
-  await sql`
+	const sql = getDb();
+	await sql`
     INSERT INTO agent_secrets (organization_id, name, ciphertext, created_at, updated_at)
     VALUES (${orgId}, ${name}, ${ciphertext}, now(), now())
     ON CONFLICT (organization_id, name) DO UPDATE SET
@@ -1392,7 +1475,7 @@ routes.put("/:agentId/providers/:providerId/api-key", async (c) => {
 		summary: `Org API key for provider '${providerId}' set`,
 		state: null,
 	});
-  return c.json({ success: true, name });
+	return c.json({ success: true, name });
 });
 
 // ── Update agent config (settings) ───────────────────────────────────────────
@@ -1407,73 +1490,73 @@ const GUARDRAIL_STAGES = new Set(["input", "output", "pre-tool", "egress"]);
  * we reject malformed input at the write boundary instead.
  */
 export function validateGuardrailsInline(value: unknown): string | null {
-  if (value === undefined) return null;
+	if (value === undefined) return null;
 	if (!Array.isArray(value)) return "guardrailsInline must be an array";
-  for (let i = 0; i < value.length; i++) {
-    const entry = value[i];
+	for (let i = 0; i < value.length; i++) {
+		const entry = value[i];
 		if (typeof entry !== "object" || entry === null) {
-      return `guardrailsInline[${i}] must be an object`;
-    }
-    const g = entry as Record<string, unknown>;
+			return `guardrailsInline[${i}] must be an object`;
+		}
+		const g = entry as Record<string, unknown>;
 		if (typeof g.name !== "string" || g.name.trim() === "") {
-      return `guardrailsInline[${i}].name must be a non-empty string`;
-    }
+			return `guardrailsInline[${i}].name must be a non-empty string`;
+		}
 		if (typeof g.enabled !== "boolean") {
-      return `guardrailsInline[${i}].enabled must be a boolean`;
-    }
+			return `guardrailsInline[${i}].enabled must be a boolean`;
+		}
 		if (typeof g.stage !== "string" || !GUARDRAIL_STAGES.has(g.stage)) {
-      return `guardrailsInline[${i}].stage must be one of: input, output, pre-tool, egress`;
-    }
+			return `guardrailsInline[${i}].stage must be one of: input, output, pre-tool, egress`;
+		}
 		if (typeof g.policy !== "string" || g.policy.trim() === "") {
-      return `guardrailsInline[${i}].policy must be a non-empty string`;
-    }
+			return `guardrailsInline[${i}].policy must be a non-empty string`;
+		}
 		if (g.model !== undefined && typeof g.model !== "string") {
-      return `guardrailsInline[${i}].model must be a string`;
-    }
-    if (
-      g.tools !== undefined &&
+			return `guardrailsInline[${i}].model must be a string`;
+		}
+		if (
+			g.tools !== undefined &&
 			(!Array.isArray(g.tools) || g.tools.some((t) => typeof t !== "string"))
-    ) {
-      return `guardrailsInline[${i}].tools must be an array of strings`;
-    }
-    if (
-      g.domains !== undefined &&
-      (!Array.isArray(g.domains) ||
+		) {
+			return `guardrailsInline[${i}].tools must be an array of strings`;
+		}
+		if (
+			g.domains !== undefined &&
+			(!Array.isArray(g.domains) ||
 				g.domains.some((d) => typeof d !== "string"))
-    ) {
-      return `guardrailsInline[${i}].domains must be an array of strings`;
-    }
-  }
-  return null;
+		) {
+			return `guardrailsInline[${i}].domains must be an array of strings`;
+		}
+	}
+	return null;
 }
 
 routes.patch("/:agentId/config", async (c) => {
-  const denied = requireSessionOrAdminPat(c);
-  if (denied) return denied;
-  const { agentId } = c.req.param();
-  const updates = await c.req.json();
+	const denied = requireSessionOrAdminPat(c);
+	if (denied) return denied;
+	const { agentId } = c.req.param();
+	const updates = await c.req.json();
 
-  if (!(await configStore.hasAgent(agentId))) {
+	if (!(await configStore.hasAgent(agentId))) {
 		return c.json({ error: "Agent not found" }, 404);
-  }
+	}
 
-  // Validate inline guardrail shape before it is persisted. An invalid `stage`
-  // (or missing name/policy) would otherwise be written verbatim and then crash
-  // the guardrail aggregator mid-message (it indexes `seen[stage]`).
-  const guardrailError = validateGuardrailsInline(
+	// Validate inline guardrail shape before it is persisted. An invalid `stage`
+	// (or missing name/policy) would otherwise be written verbatim and then crash
+	// the guardrail aggregator mid-message (it indexes `seen[stage]`).
+	const guardrailError = validateGuardrailsInline(
 		(updates as { guardrailsInline?: unknown }).guardrailsInline,
-  );
-  if (guardrailError) {
-    return c.json(
+	);
+	if (guardrailError) {
+		return c.json(
 			{ error: "invalid_guardrail", error_description: guardrailError },
 			400,
-    );
-  }
+		);
+	}
 
-  // Custom guardrails are LLM judges and need a model. With no gateway default
-  // (`EGRESS_JUDGE_MODEL` unset), every inline guardrail must carry its own
-  // `model` — otherwise it would fail closed at runtime with no model to call.
-  const judgeDefault = process.env.EGRESS_JUDGE_MODEL?.trim();
+	// Custom guardrails are LLM judges and need a model. With no gateway default
+	// (`EGRESS_JUDGE_MODEL` unset), every inline guardrail must carry its own
+	// `model` — otherwise it would fail closed at runtime with no model to call.
+	const judgeDefault = process.env.EGRESS_JUDGE_MODEL?.trim();
 	if (
 		!judgeDefault &&
 		Array.isArray((updates as { guardrailsInline?: unknown }).guardrailsInline)
@@ -1481,55 +1564,55 @@ routes.patch("/:agentId/config", async (c) => {
 		const inline = (
 			updates as { guardrailsInline: Array<{ name?: string; model?: string }> }
 		).guardrailsInline;
-    const missing = inline.find(
+		const missing = inline.find(
 			(g) => typeof g?.model !== "string" || g.model.trim() === "",
-    );
-    if (missing) {
-      return c.json(
-        {
+		);
+		if (missing) {
+			return c.json(
+				{
 					error: "guardrail_model_required",
 					error_description: `Custom guardrail "${missing.name ?? "(unnamed)"}" needs a model: the gateway has no default judge model (EGRESS_JUDGE_MODEL is unset).`,
-        },
+				},
 				400,
-      );
-    }
-  }
+			);
+		}
+	}
 
-  // Auth profiles aren't part of the agent settings row — they're
-  // user-scoped and live in `user_auth_profiles` with secrets in the secret
-  // store. Pull them out of the settings patch and persist them through the
-  // proper path; otherwise an api-key typed into the UI is silently dropped.
-  const { authProfiles, ...settingsUpdates } = updates as {
-    authProfiles?: AuthProfile[];
-  } & Record<string, unknown>;
+	// Auth profiles aren't part of the agent settings row — they're
+	// user-scoped and live in `user_auth_profiles` with secrets in the secret
+	// store. Pull them out of the settings patch and persist them through the
+	// proper path; otherwise an api-key typed into the UI is silently dropped.
+	const { authProfiles, ...settingsUpdates } = updates as {
+		authProfiles?: AuthProfile[];
+	} & Record<string, unknown>;
 
-  if (Array.isArray(authProfiles)) {
+	if (Array.isArray(authProfiles)) {
 		const user = c.get("user");
-    if (!user?.id) {
-      // Admin-PAT callers (`lobu apply`) manage declared-agent credentials
-      // out of band; reject only if they actually tried to set one here.
-      if (hasFreshCredential(authProfiles)) {
-        return c.json(
+		if (!user?.id) {
+			// Admin-PAT callers (`lobu apply`) manage declared-agent credentials
+			// out of band; reject only if they actually tried to set one here.
+			if (hasFreshCredential(authProfiles)) {
+				return c.json(
 					{ error: "Setting agent auth profiles requires a web session" },
 					403,
-        );
-      }
-    } else {
-      try {
-        await reconcileAgentAuthProfiles(agentId, user.id, authProfiles);
-      } catch (error) {
-        return c.json(
-          {
-            error:
+				);
+			}
+		} else {
+			try {
+				await reconcileAgentAuthProfiles(agentId, user.id, authProfiles);
+			} catch (error) {
+				return c.json(
+					{
+						error:
 							error instanceof Error
 								? error.message
 								: "Failed to persist auth profiles",
-          },
+					},
 					503,
-        );
-      }
-    }
-  }
+				);
+			}
+		}
+	}
 
 	if (typeof settingsUpdates.defaultModel === "string") {
 		const modelRef = settingsUpdates.defaultModel.trim();
@@ -1557,7 +1640,7 @@ routes.patch("/:agentId/config", async (c) => {
 		}
 	}
 
-  await configStore.updateSettings(agentId, settingsUpdates);
+	await configStore.updateSettings(agentId, settingsUpdates);
 	// Snapshot the merged settings row as stored (the store merges partial
 	// patches server-side), so the audit state reflects what took effect.
 	const merged = await configStore.getSettings(agentId);
@@ -1569,7 +1652,7 @@ routes.patch("/:agentId/config", async (c) => {
 		state: merged ? { ...merged } : null,
 		changedFields: Object.keys(settingsUpdates),
 	});
-  return c.json({ success: true });
+	return c.json({ success: true });
 });
 
 // ============================================================
@@ -1587,7 +1670,7 @@ function requireOrgId(c: any): string | Response {
 	const orgId = c.get("organizationId") as string | undefined;
 	if (!orgId)
 		return c.json({ error: "Organization context not available" }, 500);
-  return orgId;
+	return orgId;
 }
 
 /**
@@ -1595,15 +1678,15 @@ function requireOrgId(c: any): string | Response {
  * error string on the first invalid modality/block, or null when valid.
  */
 function validateCapabilitiesMap(value: unknown): string | null {
-  if (value === undefined) return null;
+	if (value === undefined) return null;
 	if (typeof value !== "object" || value === null || Array.isArray(value)) {
 		return "capabilities must be an object";
-  }
-  for (const [modality, block] of Object.entries(value)) {
-    const err = validateCapabilityBlock(modality, block);
-    if (err) return err;
-  }
-  return null;
+	}
+	for (const [modality, block] of Object.entries(value)) {
+		const err = validateCapabilityBlock(modality, block);
+		if (err) return err;
+	}
+	return null;
 }
 
 export { routes as agentRoutes };

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -910,9 +910,9 @@ routes.post("/inference-providers", async (c) => {
 		return c.json({ error: "Invalid or missing JSON body" }, 400);
 	}
 
-	const slug = typeof body.slug === "string" ? body.slug : "";
-	const kind = typeof body.kind === "string" ? body.kind : "";
-	const apiKey = typeof body.apiKey === "string" ? body.apiKey : "";
+	const slug = typeof body.slug === "string" ? body.slug.trim() : "";
+	const kind = typeof body.kind === "string" ? body.kind.trim() : "";
+	const apiKey = typeof body.apiKey === "string" ? body.apiKey.trim() : "";
 	if (!slug) return c.json({ error: "Body must include a `slug` string" }, 400);
 	if (!isValidInferenceProviderSlug(slug)) {
 		return c.json(
@@ -1162,7 +1162,7 @@ routes.put("/inference-providers/:slug/key", async (c) => {
 	} catch {
 		return c.json({ error: "Invalid or missing JSON body" }, 400);
 	}
-	const value = typeof body.value === "string" ? body.value : "";
+	const value = typeof body.value === "string" ? body.value.trim() : "";
 	if (!value) {
 		return c.json(
 			{ error: "Body must include a non-empty `value` string" },
@@ -1443,7 +1443,7 @@ routes.put("/:agentId/providers/:providerId/api-key", async (c) => {
 	} catch {
 		return c.json({ error: "Invalid or missing JSON body" }, 400);
 	}
-	const value = typeof body.value === "string" ? body.value : "";
+	const value = typeof body.value === "string" ? body.value.trim() : "";
 	if (!value) {
 		return c.json(
 			{ error: "Body must include a non-empty `value` string" },

--- a/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../__tests__/setup/test-db';
 import {
   createInferenceProvider,
+  ensureOAuthInferenceProvider,
   getInferenceProviderBySlug,
   getOrgDefaultModel,
   listInferenceProviders,
@@ -125,6 +126,38 @@ describe('inference-provider store', () => {
       apiKey: 'k2',
     });
     expect(second).toEqual({ error: 'slug_conflict', slug: 'groq' });
+  });
+
+  it('repairs an existing same-slug secret row when OAuth signs in', async () => {
+    const legacy = await createInferenceProvider({
+      organizationId: ORG,
+      slug: 'claude',
+      kind: 'claude',
+      displayName: 'Legacy Claude',
+      apiKey: 'sk-old',
+      capabilities: {
+        text: { base_url: 'https://tenant.example.com/v1', model: 'claude-x' },
+      },
+    });
+    if ('error' in legacy) throw new Error('expected legacy create to succeed');
+
+    const repaired = await ensureOAuthInferenceProvider({
+      organizationId: ORG,
+      slug: 'claude',
+      kind: 'claude',
+      displayName: 'Claude',
+      createdBy: 'user-1',
+    });
+
+    expect(repaired.id).toBe(legacy.id);
+    expect(repaired.apiKeyRef).toBe(`oauth://${ORG}/claude-${legacy.id}`);
+    expect(repaired.displayName).toBe('Claude');
+    expect(repaired.capabilities).toEqual({});
+    expect(repaired.hasCustomUpstream).toBe(false);
+    expect(await readKey(ORG, 'claude')).toBeNull();
+
+    const listed = await getInferenceProviderBySlug(ORG, 'claude');
+    expect(listed?.apiKeyRef).toBe(repaired.apiKeyRef);
   });
 
   it('returns null when updating capabilities for a missing slug', async () => {

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -232,6 +232,18 @@ interface RawInferenceProviderRow {
 	is_default: boolean;
 }
 
+function oauthInferenceProviderRef(
+	organizationId: string,
+	slug: string,
+	id: number | string,
+): string {
+	return `oauth://${organizationId}/${slug}-${id}`;
+}
+
+function isOAuthInferenceProviderRef(ref: string): boolean {
+	return ref.startsWith("oauth://");
+}
+
 function mapRow(r: RawInferenceProviderRow): InferenceProviderRow {
 	return {
 		id: Number(r.id),
@@ -354,21 +366,45 @@ export async function ensureOAuthInferenceProvider(args: {
 	try {
 		return await sql.begin(async (tx) => {
 			const existing = (await tx`
-				SELECT id, organization_id, slug, kind, display_name, api_key_ref,
-				       capabilities, has_custom_upstream, status, created_at
-				FROM inference_providers
-				WHERE organization_id = ${organizationId}
-				  AND slug = ${slug}
-				  AND deleted_at IS NULL
-				LIMIT 1
-			`) as RawInferenceProviderRow[];
-			if (existing[0]) return mapRow(existing[0]);
+					SELECT id, organization_id, slug, kind, display_name, api_key_ref,
+					       capabilities, has_custom_upstream, status, created_at
+					FROM inference_providers
+					WHERE organization_id = ${organizationId}
+					  AND slug = ${slug}
+					  AND deleted_at IS NULL
+					LIMIT 1
+				`) as RawInferenceProviderRow[];
+			const existingRow = existing[0];
+			if (existingRow) {
+				if (isOAuthInferenceProviderRef(existingRow.api_key_ref)) {
+					return mapRow(existingRow);
+				}
+
+				const apiKeyRef = oauthInferenceProviderRef(
+					organizationId,
+					slug,
+					existingRow.id,
+				);
+				const repaired = (await tx`
+						UPDATE inference_providers
+						SET kind = ${kind},
+						    display_name = COALESCE(${displayName}, display_name),
+						    api_key_ref = ${apiKeyRef},
+						    capabilities = '{}'::jsonb,
+						    created_by = COALESCE(created_by, ${createdBy}),
+						    updated_at = now()
+						WHERE id = ${existingRow.id}
+						RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
+						          capabilities, has_custom_upstream, status, created_at
+					`) as RawInferenceProviderRow[];
+				return mapRow(repaired[0]);
+			}
 
 			const idRows = (await tx`
-				SELECT nextval(pg_get_serial_sequence('inference_providers', 'id')) AS id
-			`) as Array<{ id: string | number }>;
+					SELECT nextval(pg_get_serial_sequence('inference_providers', 'id')) AS id
+				`) as Array<{ id: string | number }>;
 			const id = Number(idRows[0]?.id);
-			const apiKeyRef = `oauth://${organizationId}/${slug}-${id}`;
+			const apiKeyRef = oauthInferenceProviderRef(organizationId, slug, id);
 
 			const rows = (await tx`
 				INSERT INTO inference_providers
@@ -389,8 +425,7 @@ export async function ensureOAuthInferenceProvider(args: {
 			/inference_providers_org_slug_live/.test(msg) ||
 			/duplicate key/.test(msg)
 		) {
-			const existing = await getInferenceProviderBySlug(organizationId, slug);
-			if (existing) return existing;
+			return await ensureOAuthInferenceProvider(args);
 		}
 		throw error;
 	}

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -14,12 +14,7 @@
  * the org that calls this provider).
  */
 
-import {
-	createLogger,
-	decrypt,
-	encrypt,
-	getErrorMessage,
-} from "@lobu/core";
+import { createLogger, decrypt, encrypt, getErrorMessage } from "@lobu/core";
 import { getDb } from "../../db/client.js";
 
 const logger = createLogger("provider-secrets");
@@ -331,6 +326,77 @@ export async function createInferenceProvider(args: {
 }
 
 /**
+ * Ensure an OAuth-backed provider is visible in the org provider list.
+ *
+ * OAuth credentials live in `auth_profiles` (the per-user org bucket), not in
+ * `agent_secrets`. The row still needs a stable `api_key_ref` for the existing
+ * table contract, so use an `oauth://` ref that never joins to a vault secret.
+ * Static catalog routing then falls through to the OAuth profile. If someone
+ * later configures a custom `base_url` on this row, the invariant sees no row
+ * key and fails closed rather than sending a subscription token to a tenant URL.
+ */
+export async function ensureOAuthInferenceProvider(args: {
+	organizationId: string;
+	slug: string;
+	kind: string;
+	displayName?: string | null;
+	createdBy?: string | null;
+}): Promise<InferenceProviderRow> {
+	const {
+		organizationId,
+		slug,
+		kind,
+		displayName = null,
+		createdBy = null,
+	} = args;
+	const sql = getDb();
+
+	try {
+		return await sql.begin(async (tx) => {
+			const existing = (await tx`
+				SELECT id, organization_id, slug, kind, display_name, api_key_ref,
+				       capabilities, has_custom_upstream, status, created_at
+				FROM inference_providers
+				WHERE organization_id = ${organizationId}
+				  AND slug = ${slug}
+				  AND deleted_at IS NULL
+				LIMIT 1
+			`) as RawInferenceProviderRow[];
+			if (existing[0]) return mapRow(existing[0]);
+
+			const idRows = (await tx`
+				SELECT nextval(pg_get_serial_sequence('inference_providers', 'id')) AS id
+			`) as Array<{ id: string | number }>;
+			const id = Number(idRows[0]?.id);
+			const apiKeyRef = `oauth://${organizationId}/${slug}-${id}`;
+
+			const rows = (await tx`
+				INSERT INTO inference_providers
+					(id, organization_id, slug, kind, display_name, api_key_ref, capabilities, created_by)
+				VALUES (
+					${id}, ${organizationId}, ${slug}, ${kind}, ${displayName},
+					${apiKeyRef}, '{}'::jsonb, ${createdBy}
+				)
+				RETURNING id, organization_id, slug, kind, display_name, api_key_ref,
+				          capabilities, has_custom_upstream, status, created_at
+			`) as RawInferenceProviderRow[];
+
+			return mapRow(rows[0]);
+		});
+	} catch (error) {
+		const msg = getErrorMessage(error);
+		if (
+			/inference_providers_org_slug_live/.test(msg) ||
+			/duplicate key/.test(msg)
+		) {
+			const existing = await getInferenceProviderBySlug(organizationId, slug);
+			if (existing) return existing;
+		}
+		throw error;
+	}
+}
+
+/**
  * List an org's live inference providers. NEVER returns the ciphertext / key or
  * the api_key_ref — this feeds the settings UI.
  */
@@ -344,9 +410,7 @@ export async function listInferenceProviders(
 		FROM inference_providers
 		WHERE organization_id = ${organizationId} AND deleted_at IS NULL
 		ORDER BY slug
-	`) as Array<
-		Omit<RawInferenceProviderRow, "organization_id" | "api_key_ref">
-	>;
+	`) as Array<Omit<RawInferenceProviderRow, "organization_id" | "api_key_ref">>;
 	return rows.map((r) => ({
 		id: Number(r.id),
 		slug: r.slug,
@@ -502,11 +566,14 @@ export async function resolveInferenceProviderConfig(
 		WHERE p.organization_id = ${organizationId} AND p.slug = ${slug}
 		  AND p.deleted_at IS NULL
 		LIMIT 1
-	`) as Array<{ block: InferenceCapabilityBlock | null; ciphertext: string | null }>;
+	`) as Array<{
+		block: InferenceCapabilityBlock | null;
+		ciphertext: string | null;
+	}>;
 
 	const row = rows[0];
 	// No live row, or the row has no block for this modality ⇒ static fallback.
-	if (!row || !row.block) return null;
+	if (!row?.block) return null;
 
 	let apiKey: string | undefined;
 	if (row.ciphertext) {
@@ -646,7 +713,7 @@ export async function softDeleteInferenceProvider(
 }
 
 export function providerOrgSecretName(providerId: string): string {
-  return `provider:${providerId}:apiKey`;
+	return `provider:${providerId}:apiKey`;
 }
 
 /**
@@ -657,10 +724,10 @@ export function providerOrgSecretName(providerId: string): string {
  * `(organization_id, name)` PK on `agent_secrets`.
  */
 export function environmentSecretName(
-  environmentId: string,
-  field: string
+	environmentId: string,
+	field: string,
 ): string {
-  return `environment:${environmentId}:${field}`;
+	return `environment:${environmentId}:${field}`;
 }
 
 /**
@@ -670,14 +737,14 @@ export function environmentSecretName(
  * {@link readEnvironmentSecret} at exec time.
  */
 export async function writeEnvironmentSecret(
-  environmentId: string,
-  field: string,
-  organizationId: string,
-  value: string
+	environmentId: string,
+	field: string,
+	organizationId: string,
+	value: string,
 ): Promise<void> {
-  const sql = getDb();
-  const ciphertext = encrypt(value);
-  await sql`
+	const sql = getDb();
+	const ciphertext = encrypt(value);
+	await sql`
     INSERT INTO agent_secrets (organization_id, name, ciphertext, updated_at)
     VALUES (${organizationId}, ${environmentSecretName(environmentId, field)}, ${ciphertext}, now())
     ON CONFLICT (organization_id, name)
@@ -691,12 +758,12 @@ export async function writeEnvironmentSecret(
  * Mirrors {@link readOrgSharedProviderApiKey} but keyed per-environment.
  */
 export async function readEnvironmentSecret(
-  environmentId: string,
-  field: string,
-  organizationId: string
+	environmentId: string,
+	field: string,
+	organizationId: string,
 ): Promise<string | null> {
-  const sql = getDb();
-  const rows = (await sql`
+	const sql = getDb();
+	const rows = (await sql`
     SELECT ciphertext
     FROM agent_secrets
     WHERE organization_id = ${organizationId}
@@ -704,19 +771,19 @@ export async function readEnvironmentSecret(
       AND (expires_at IS NULL OR expires_at > now())
     LIMIT 1
   `) as Array<{ ciphertext: string }>;
-  const ciphertext = rows[0]?.ciphertext;
-  if (!ciphertext) return null;
-  try {
-    return decrypt(ciphertext);
-  } catch (error) {
-    logger.warn(
-      `Failed to decrypt environment secret ${environmentSecretName(
-        environmentId,
-        field
-      )}: ${getErrorMessage(error)}`
-    );
-    return null;
-  }
+	const ciphertext = rows[0]?.ciphertext;
+	if (!ciphertext) return null;
+	try {
+		return decrypt(ciphertext);
+	} catch (error) {
+		logger.warn(
+			`Failed to decrypt environment secret ${environmentSecretName(
+				environmentId,
+				field,
+			)}: ${getErrorMessage(error)}`,
+		);
+		return null;
+	}
 }
 
 /**
@@ -730,11 +797,11 @@ export async function readEnvironmentSecret(
  * the first provider call.
  */
 export async function readOrgSharedProviderApiKey(
-  providerId: string,
-  organizationId: string
+	providerId: string,
+	organizationId: string,
 ): Promise<string | null> {
-  const sql = getDb();
-  const rows = (await sql`
+	const sql = getDb();
+	const rows = (await sql`
     SELECT ciphertext
     FROM agent_secrets
     WHERE organization_id = ${organizationId}
@@ -742,14 +809,14 @@ export async function readOrgSharedProviderApiKey(
       AND (expires_at IS NULL OR expires_at > now())
     LIMIT 1
   `) as Array<{ ciphertext: string }>;
-  const ciphertext = rows[0]?.ciphertext;
-  if (!ciphertext) return null;
-  try {
-    return decrypt(ciphertext);
-  } catch (error) {
-    logger.warn(
-      `Failed to decrypt org-shared key for provider ${providerId}: ${getErrorMessage(error)}`
-    );
-    return null;
-  }
+	const ciphertext = rows[0]?.ciphertext;
+	if (!ciphertext) return null;
+	try {
+		return decrypt(ciphertext);
+	} catch (error) {
+		logger.warn(
+			`Failed to decrypt org-shared key for provider ${providerId}: ${getErrorMessage(error)}`,
+		);
+		return null;
+	}
 }


### PR DESCRIPTION
## Summary
- Persists visible org inference-provider rows when Claude/ChatGPT OAuth sign-in completes.
- Repairs existing org-bucket OAuth profiles into visible provider rows on provider-list reads.
- Uses `oauth://` refs for OAuth-backed provider rows so custom upstreams still fail closed instead of leaking subscription tokens.
- Removes the session user's org-bucket OAuth profile when deleting an OAuth provider, preventing unintended resurrection.
- Updates the Owletto submodule to include the merged UI/Chrome changes from lobu-ai/owletto#463.

## Root cause
The OAuth route stored the subscription token in the per-user org auth bucket, but never created the org-visible `inference_providers` row. The UI could complete sign-in, close the form, and still show no saved provider.

## Review
- Claude CLI Opus reviewed the server diff: verdict OK, no merge-blocking correctness gaps.
- Opus follow-up reviewed the delete/repair behavior after the profile-removal fix: verdict OK.
- Owletto PR was separately reviewed by Opus; its initial stale manifest hash blocker was fixed and rechecked.

## Validation
- `bun test packages/server/src/lobu/__tests__/inference-providers-oauth.test.ts`
- `bun run typecheck` in `packages/server`
- `bun run build:server` in `packages/server`
- Owletto validation in submodule: manifest-hash recomputation, Chrome tool tests, provider-form test, and `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786068079&installation_id=136316292&pr_number=1793&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1793&signature=d8f207d908aee697d3b98c1899b12f943d5a00b9a484b781919396ee01446151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth-connected inference providers now support a smoother connect flow, including better handling of authorization and device-code sign-in.
  * Agent and provider settings updates now return more consistent success responses.

* **Bug Fixes**
  * Improved OAuth reliability, including stricter verification during sign-in and better recovery when a provider is missing or soft-deleted.
  * Fixed several cases where secret values could be shown in responses.
  * Tightened validation for agent guardrail settings and improved limits on trip feed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->