### PR TITLE
fix(cli): whoami wrongly reports 'Not logged in' when refresh token is stale

### DIFF
--- a/packages/cli/src/internal/__tests__/credentials.test.ts
+++ b/packages/cli/src/internal/__tests__/credentials.test.ts
@@ -373,8 +373,24 @@ describe("credentials", () => {
     expect(result).toBe(creds);
   });
 
-  test("refreshCredentials returns null when refreshTokens() fails and no concurrent rotation", async () => {
-    const creds = buildCreds();
+  test("refreshCredentials keeps a still-valid token when refresh is not yet needed", async () => {
+    // A non-expired access token must not be discarded just because it *could*
+    // be refreshed. Previously whoami eagerly refreshed and, on a stale refresh
+    // token (400 invalid_grant), reported "Not logged in" despite a valid
+    // session — the Owletto Mac app reads whoami --json for its menu bar.
+    const creds = buildCreds({ expiresAt: Date.now() + 60 * 60_000 });
+    const store = { version: 2, contexts: { [currentContextName]: creds } };
+    readFileSpy.mockResolvedValue(JSON.stringify(store));
+    const refreshSpy = spyOn(oauth, "refreshTokens").mockResolvedValue(null);
+
+    const result = await refreshCredentials(creds);
+
+    expect(result).toBe(creds);
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  test("refreshCredentials returns null when an expired token's refresh fails", async () => {
+    const creds = buildCreds({ expiresAt: Date.now() - 60_000 });
     const store = { version: 2, contexts: { [currentContextName]: creds } };
     readFileSpy.mockResolvedValue(JSON.stringify(store));
     spyOn(oauth, "refreshTokens").mockResolvedValue(null);

--- a/packages/cli/src/internal/credentials.ts
+++ b/packages/cli/src/internal/credentials.ts
@@ -272,6 +272,12 @@ async function doRefreshCredentials(
   const creds = existing ?? (await loadCredentials(target.name));
   if (!creds) return null;
   if (!credentialCanRefresh(creds)) return creds;
+  // A still-valid access token must not be discarded just because it *could* be
+  // refreshed: if the refresh token is stale (400 invalid_grant), an eager
+  // refresh would collapse a live session to null, so `whoami` reports "Not
+  // logged in" while every reactive-refresh command still works. Only refresh
+  // when the token is actually near expiry — matching getAgentApiToken.
+  if (!credentialNeedsRefresh(creds)) return creds;
 
   const result = await attemptRefresh(target, creds);
   if (result) return result;


### PR DESCRIPTION
## What

`lobu whoami` prints "Not logged in" even when you have a valid, unexpired access token and every other command (`lobu org list`, `lobu call`, `lobu apply`) works fine. Hit this today: token good for another ~22 hours, but whoami insisted I was logged out.

## Why it happens

`doRefreshCredentials` in `packages/cli/src/internal/credentials.ts` gated the refresh only on `credentialCanRefresh` (do we *have* a refresh token) and never on `credentialNeedsRefresh` (is the access token actually near expiry). So for any credential with a refresh token, it hit the OAuth token endpoint on every call. If the refresh token was stale — `POST /oauth/token` returns `400 invalid_grant "Invalid or expired refresh token"`, which happens once a refresh has already been rotated/consumed — `attemptRefresh` returned null and the whole thing collapsed to null. whoami reads that as logged out.

The token-getter path (`getAgentApiToken`, line 139) already does this correctly: `if (!credentialNeedsRefresh(creds)) return creds.accessToken;`. The two paths had just drifted — reactive refresh checks expiry, whoami's eager refresh didn't.

This is more than cosmetic: the file comment notes `whoami --json` is the contract the Owletto Mac app reads to drive its menu bar, so a teammate with a valid session but a stale refresh token shows up as logged out in the app.

## Fix

One gate, matching the existing pattern — skip the refresh when the token isn't near expiry:

```ts
if (!credentialCanRefresh(creds)) return creds;
if (!credentialNeedsRefresh(creds)) return creds;   // <- added
const result = await attemptRefresh(target, creds);
```

## Verification

- Unit (red→green): added a test asserting a still-valid token survives a failed refresh (`refreshTokens` mocked to null) and is returned unchanged; kept the genuinely-correct expired-token-refresh-fails→null case. The old test asserted the buggy behavior (valid token + failed refresh → null) and was replaced.
- Full CLI credentials/api-client/whoami suites: 32 pass, 0 fail.
- End-to-end against the real stale credential that was failing: fixed decision path returns `canRefresh: true, needsRefresh: false` → returns the valid creds → LOGGED IN, reversing the false negative.
- Pre-commit `tsc --noEmit` + biome clean.

No callers relied on eager-always-refresh (`getToken` already pre-checks expiry; whoami is the direct beneficiary).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786072639&installation_id=136316292&pr_number=1795&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1795&signature=5c5db91ad4f8b984dd1e1086959730de3684a9b7495a1d09bf8b44ca67e54289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential refresh behavior so still-valid access tokens are kept instead of being replaced unnecessarily.
  * Refresh now re-checks whether credentials actually need renewal before attempting an OAuth refresh.

* **Tests**
  * Added coverage for the case where credentials are still valid and no refresh should occur.
  * Updated the expired-token refresh failure test description for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->