### PR TITLE
fix: relabel current Herdr workspace on task-setup; fix task-clean teardown

### DIFF
--- a/scripts/lib/herdr-task.sh
+++ b/scripts/lib/herdr-task.sh
@@ -6,10 +6,21 @@ herdr_task_enabled() {
 }
 
 # Open (or attach) an existing git worktree as a Herdr workspace. Prints workspace_id on stdout.
+#
+# When task-setup runs *inside* an existing Herdr pane (the common "click new →
+# start agent → run make task-setup" flow), Herdr exports $HERDR_WORKSPACE_ID.
+# In that case we relabel the *current* workspace to the task name instead of
+# spawning a second one — otherwise the pane you're typing in keeps its launch
+# label (e.g. "~") while an empty correctly-labeled workspace appears beside it.
 herdr_task_open() {
   local repo="$1" worktree_path="$2" label="$3"
   local json ws
   herdr_task_enabled || return 1
+  if [[ -n "${HERDR_WORKSPACE_ID:-}" ]]; then
+    herdr workspace rename "$HERDR_WORKSPACE_ID" "$label" >/dev/null 2>&1 || true
+    printf '%s' "$HERDR_WORKSPACE_ID"
+    return 0
+  fi
   json="$(herdr worktree open --cwd "$repo" --path "$worktree_path" --label "$label" --no-focus --json 2>/dev/null)" || return 1
   ws="$(printf '%s' "$json" | python3 -c 'import sys,json
 d=json.load(sys.stdin)

--- a/scripts/lib/herdr-task.sh
+++ b/scripts/lib/herdr-task.sh
@@ -31,23 +31,42 @@ print(d.get("result",{}).get("workspace",{}).get("workspace_id",""))' 2>/dev/nul
 }
 
 # Close the Herdr workspace tied to a worktree path, if any.
+#
+# Prefers matching by the worktree's checkout_path (set when herdr_task_open
+# spawned a dedicated worktree workspace). Falls back to matching by label ==
+# task name: when task-setup ran inside an existing pane, herdr_task_open
+# relabeled that workspace in place rather than binding it to a checkout, so
+# Herdr has no checkout_path for it — the label is the only handle we have.
 herdr_task_close() {
-  local worktree_path="$1"
-  local json ws
+  local worktree_path="$1" label="${2:-}"
+  local json ws matched_by
   herdr_task_enabled || return 1
-  json="$(herdr workspace list --json 2>/dev/null)" || return 1
-  ws="$(printf '%s' "$json" | WORKTREE_PATH="$worktree_path" python3 -c 'import os,sys,json
+  json="$(herdr workspace list 2>/dev/null)" || return 1
+  # Emit "<match_kind> <workspace_id>": "path" when bound to the checkout,
+  # else "label" when only the label matches. Path wins over label.
+  read -r matched_by ws <<<"$(printf '%s' "$json" | WORKTREE_PATH="$worktree_path" LABEL="$label" python3 -c 'import os,sys,json
 path=os.environ["WORKTREE_PATH"]
+label=os.environ.get("LABEL","")
 d=json.load(sys.stdin)
+by_label=""
 for w in d.get("result",{}).get("workspaces",[]):
   wt=w.get("worktree") or {}
   if wt.get("checkout_path")==path:
-    print(w.get("workspace_id") or "")
-    break
-' 2>/dev/null)" || return 1
+    print("path", w.get("workspace_id") or ""); break
+  if label and not by_label and w.get("label")==label:
+    by_label=w.get("workspace_id") or ""
+else:
+  if by_label: print("label", by_label)
+' 2>/dev/null)"
   [[ -n "$ws" ]] || return 1
-  herdr worktree remove --workspace "$ws" >/dev/null 2>&1 || \
-    herdr worktree remove --workspace "$ws" --force >/dev/null 2>&1 || \
+  if [[ "$matched_by" == "path" ]]; then
+    herdr worktree remove --workspace "$ws" >/dev/null 2>&1 || \
+      herdr worktree remove --workspace "$ws" --force >/dev/null 2>&1 || \
+      herdr workspace close "$ws" >/dev/null 2>&1 || return 1
+  else
+    # Label-matched (relabeled-in-place) workspace: not worktree-backed, so
+    # just close it — worktree removal is handled by the git worktree teardown.
     herdr workspace close "$ws" >/dev/null 2>&1 || return 1
+  fi
   return 0
 }

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -122,7 +122,7 @@ fi
 
 # shellcheck source=scripts/lib/herdr-task.sh
 . "$script_dir/lib/herdr-task.sh"
-if herdr_task_close "$worktree_dir"; then
+if herdr_task_close "$worktree_dir" "$name"; then
   echo "→ closed Herdr workspace for $worktree_dir"
 fi
 


### PR DESCRIPTION
When `make task-setup` runs inside an existing Herdr pane (the common "click new → start agent → run setup" flow), the pane you are typing in kept its launch label (e.g. `~`) while an empty correctly-labeled workspace appeared beside it. This makes the sidebar relabel the *current* workspace in place instead, using the `$HERDR_WORKSPACE_ID` Herdr exports into every pane. Falls back to the original `herdr worktree open` path when run outside a Herdr pane.

While e2e-testing that, found two teardown bugs in `herdr_task_close`:

1. It called `herdr workspace list --json`, but that subcommand emits JSON by default and *rejects* `--json` (usage error, rc=2). The list call always failed, so `herdr_task_close` silently bailed and never closed any workspace — pre-existing, independent of the relabel change.
2. A relabeled-in-place workspace has no `checkout_path` in Herdr, so the checkout_path match found nothing. Added a `label == task-name` fallback (path match still wins) and pass `$name` through from `task-clean.sh`.

## Testing

Verified end-to-end against live Herdr on macOS:

- **In-pane path**: click-new pane → `make task-setup` relabels `~` → task name in place, no duplicate workspace → `make task-clean` prints `→ closed Herdr workspace` and the workspace is gone (closed via label fallback).
- **Outside-pane path**: `make task-setup` with `HERDR_WORKSPACE_ID` unset spawns a worktree-backed workspace → `task-clean` closes it via checkout_path match.
- Matcher unit-tested for: path-wins, label-fallback, no-match, empty-label-safe.

No orphaned workspaces in either path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786106940&installation_id=136316292&pr_number=1796&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1796&signature=97aee886c83d01b5be2fb03865b0c10a72c838a905b5960a088310f77d6514c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task setup now works more smoothly when run inside an existing workspace, reusing the current workspace instead of creating a new one.
  * Task cleanup now recognizes tasks by name as well as by workspace path, improving shutdown behavior for renamed tasks.

* **Bug Fixes**
  * Prevented cleanup from missing tasks that were renamed in place.
  * Improved workspace removal/closing behavior so the right action is taken in each case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->