### PR TITLE
feat(linkedin): identity-graph attributions for the takeout connector

### DIFF
--- a/examples/personal-agent/__tests__/connector-sdk.mock.ts
+++ b/examples/personal-agent/__tests__/connector-sdk.mock.ts
@@ -95,6 +95,14 @@ export function connectorSdkMock() {
     requireBearerClient: notUsed("requireBearerClient"),
     paginateByCursor,
     paginateByOffset,
+    // Generic identity namespaces (real values — connectors read IDENTITY.EMAIL
+    // at module load to declare cross-channel identity specs).
+    IDENTITY: {
+      PHONE: "phone",
+      EMAIL: "email",
+      EMAIL_DOMAIN: "email_domain",
+      AUTH_USER_ID: "auth_user_id",
+    },
     ConnectorRuntime: class {},
     calculateEngagementScore: () => 0,
     extensionDomScrape: async (opts: DomScrapeOpts) => {

--- a/examples/personal-agent/__tests__/linkedin-takeout.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin-takeout.connector.test.ts
@@ -87,7 +87,9 @@ describe("LinkedInTakeoutConnector identity attributions", () => {
 
     // The full URL survives only as a display trait, never as an identity.
     expect(
-      identities.some((i: { namespace: string }) => i.namespace === "linkedin_url")
+      identities.some(
+        (i: { namespace: string }) => i.namespace === "linkedin_url"
+      )
     ).toBe(false);
     expect(attr.traits.linkedin_url).toMatchObject({
       eventPath: "metadata.linkedin_url",

--- a/examples/personal-agent/__tests__/linkedin-takeout.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin-takeout.connector.test.ts
@@ -1,0 +1,155 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { connectorSdkMock } from "./connector-sdk.mock";
+
+// Stub @lobu/connector-sdk (it pulls in playwright) so the connector imports
+// without the browser stack. Shared superset — see connector-sdk.mock.ts.
+mock.module("@lobu/connector-sdk", connectorSdkMock);
+
+let LinkedInTakeoutConnector: any;
+let normalizeLinkedInSlug: any;
+let LINKEDIN_IDENTITY: any;
+
+beforeAll(async () => {
+  const connectorMod = await import("../linkedin-takeout.connector");
+  LinkedInTakeoutConnector = connectorMod.default;
+  const identityMod = await import("../linkedin-identity");
+  normalizeLinkedInSlug = identityMod.normalizeLinkedInSlug;
+  LINKEDIN_IDENTITY = identityMod.LINKEDIN_IDENTITY;
+});
+
+describe("normalizeLinkedInSlug", () => {
+  test("collapses protocol / www / case / trailing-slash / bare-slug variants to one slug", () => {
+    const canonical = "jane-doe";
+    const variants = [
+      "https://www.linkedin.com/in/jane-doe/",
+      "http://linkedin.com/in/jane-doe",
+      "https://www.linkedin.com/in/Jane-Doe",
+      "https://www.LinkedIn.com/in/Jane-Doe/?trk=contacts",
+      "linkedin.com/in/jane-doe#section",
+      "jane-doe",
+    ];
+    for (const v of variants) {
+      expect(normalizeLinkedInSlug(v)).toBe(canonical);
+    }
+  });
+
+  test("preserves the full alphanumeric slug (with the trailing id hash)", () => {
+    expect(
+      normalizeLinkedInSlug("https://www.linkedin.com/in/tolga-ozen-65b10513a")
+    ).toBe("tolga-ozen-65b10513a");
+  });
+
+  test("rejects empty, non-/in/ URLs, and junk", () => {
+    expect(normalizeLinkedInSlug("")).toBe(null);
+    expect(normalizeLinkedInSlug("   ")).toBe(null);
+    expect(normalizeLinkedInSlug(null)).toBe(null);
+    expect(normalizeLinkedInSlug(undefined)).toBe(null);
+    // A non-profile URL has no `/in/` segment; the whole string fails the
+    // slug charset (slashes/dots are not slug chars).
+    expect(normalizeLinkedInSlug("https://www.linkedin.com/company/acme")).toBe(
+      null
+    );
+    expect(normalizeLinkedInSlug("https://example.com/profile")).toBe(null);
+  });
+});
+
+describe("LinkedInTakeoutConnector identity attributions", () => {
+  test("connections feed mints a person keyed on linkedin_slug + email, neither primary", () => {
+    const def = new LinkedInTakeoutConnector().definition;
+    const attr = def.feeds.connections.eventKinds.connection.attributions?.[0];
+    expect(attr).toBeDefined();
+    expect(attr.autoCreate).toBe(true);
+    expect(attr.target.entityType).toBe("person");
+    expect(attr.target.titlePath).toBe("author_name");
+
+    const identities = attr.target.identities;
+    const slug = identities.find(
+      (i: { namespace: string }) => i.namespace === LINKEDIN_IDENTITY.SLUG
+    );
+    expect(slug).toMatchObject({
+      namespace: "linkedin_slug",
+      eventPath: "metadata.linkedin_slug",
+    });
+    // Equal-weight cross-channel matching: no primary until the live connector.
+    expect(slug.primary).toBeUndefined();
+
+    const email = identities.find(
+      (i: { namespace: string }) => i.namespace === "email"
+    );
+    expect(email).toMatchObject({
+      namespace: "email",
+      eventPath: "metadata.email",
+    });
+    expect(email.primary).toBeUndefined();
+
+    // The full URL survives only as a display trait, never as an identity.
+    expect(
+      identities.some((i: { namespace: string }) => i.namespace === "linkedin_url")
+    ).toBe(false);
+    expect(attr.traits.linkedin_url).toMatchObject({
+      eventPath: "metadata.linkedin_url",
+      behavior: "prefer_non_empty",
+    });
+  });
+
+  test("messages feed attributes the sender via their profile-url slug", () => {
+    const def = new LinkedInTakeoutConnector().definition;
+    const attr = def.feeds.messages.eventKinds.message.attributions?.[0];
+    expect(attr).toBeDefined();
+    expect(attr.autoCreate).toBe(true);
+    expect(attr.role).toBe("authored_by");
+    expect(attr.target.identities).toEqual([
+      {
+        namespace: "linkedin_slug",
+        eventPath: "metadata.sender_linkedin_slug",
+      },
+    ]);
+  });
+
+  test("a real connections row emits the metadata the slug identity resolves", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "li-takeout-"));
+    writeFileSync(
+      path.join(dir, "Connections.csv"),
+      [
+        "First Name,Last Name,URL,Email Address,Company,Position,Connected On",
+        "Jane,Doe,https://www.LinkedIn.com/in/Jane-Doe/,jane@acme.com,Acme,CEO,01 Jan 2024",
+      ].join("\n")
+    );
+
+    const connector = new LinkedInTakeoutConnector();
+    const events = (connector as any).readConnections(dir);
+    expect(events).toHaveLength(1);
+    const [event] = events;
+    expect(event.origin_type).toBe("connection");
+    expect(event.author_name).toBe("Jane Doe");
+
+    // The connection attribution's identity specs point at exactly these keys.
+    const attr =
+      connector.definition.feeds.connections.eventKinds.connection
+        .attributions[0];
+    for (const identity of attr.target.identities) {
+      const value = resolvePath(event, identity.eventPath);
+      expect(value).toBeTruthy();
+    }
+    // Full URL survives as a display trait...
+    expect(resolvePath(event, "metadata.linkedin_url")).toBe(
+      "https://www.LinkedIn.com/in/Jane-Doe/"
+    );
+    expect(resolvePath(event, "metadata.email")).toBe("jane@acme.com");
+    // ...but the connector emits the ALREADY-canonical slug the identity keys
+    // on, since the server won't run this example connector's normalizer. The
+    // case-variant URL collapses to `jane-doe` at emit time.
+    const slugSpec = attr.target.identities.find(
+      (i: { namespace: string }) => i.namespace === "linkedin_slug"
+    );
+    expect(slugSpec.eventPath).toBe("metadata.linkedin_slug");
+    expect(resolvePath(event, "metadata.linkedin_slug")).toBe("jane-doe");
+  });
+});
+
+function resolvePath(obj: any, dotPath: string): unknown {
+  return dotPath.split(".").reduce((acc, key) => acc?.[key], obj);
+}

--- a/examples/personal-agent/linkedin-identity.ts
+++ b/examples/personal-agent/linkedin-identity.ts
@@ -1,0 +1,107 @@
+/**
+ * LinkedIn connector identity namespaces and normalization.
+ *
+ * Single source of truth for the LinkedIn identity vocabulary. The connector
+ * (linkedin-takeout.connector.ts) imports from here, and a server that wires
+ * the example package in would assemble `linkedInIdentityModule` into its
+ * ingest normalizer chain — mirroring @lobu/connectors/x-identity.ts.
+ *
+ * `linkedin_slug` (the canonical `/in/<vanity>` slug, lowercased) is the
+ * primary key for a LinkedIn person: it survives the case/protocol/`www.`/query
+ * noise that full URLs carry, so the CASE-SENSITIVE `entity_identities` UNIQUE
+ * index can't fork one person into duplicates. The full URL is kept only as a
+ * display TRAIT, not an identity. `email` is the GENERIC cross-channel bridge
+ * (namespace owned by connector-sdk, shared with Gmail/contacts), so a LinkedIn
+ * person joins the same entity as their Gmail/contacts identity.
+ */
+
+import { IDENTITY } from "@lobu/connector-sdk";
+
+/**
+ * Connector-owned identity module contract. Mirrors
+ * `@lobu/connectors/connector-identity-module` — redeclared here because the
+ * example package depends only on `@lobu/connector-sdk`, which does not
+ * re-export that type.
+ */
+export interface ConnectorIdentityModule {
+  /** Connector/platform key. */
+  key: string;
+  /**
+   * Namespaces this connector owns that participate in read-time event recall.
+   * Each MUST have a physical `idx_events_metadata_<ns>` partial index. LinkedIn
+   * owns none — `linkedin_slug` is a match/attribution key, not a recall key.
+   */
+  recallNamespaces: string[];
+  /**
+   * Normalize a value for one of this connector's namespaces. Returns
+   * `undefined` when the namespace is not owned here (the caller chains to the
+   * next module, then to generic SDK hygiene). `null` means the namespace IS
+   * owned but the value is invalid.
+   */
+  normalize(namespace: string, raw: string): string | null | undefined;
+}
+
+/** Connector-owned identity namespaces (not SDK-global). */
+export const LINKEDIN_IDENTITY = {
+  /**
+   * Canonical `/in/<vanity>` profile slug, lowercased — primary namespace for
+   * attribution. Case- and URL-noise-insensitive, so the same person never
+   * forks across the CASE-SENSITIVE `entity_identities` UNIQUE index.
+   */
+  SLUG: "linkedin_slug",
+} as const;
+
+export type LinkedInIdentityNamespace =
+  (typeof LINKEDIN_IDENTITY)[keyof typeof LINKEDIN_IDENTITY];
+
+/**
+ * Extract the canonical LinkedIn vanity slug from either a full profile URL or
+ * a bare slug, lowercased. `https://www.LinkedIn.com/in/Jane-Doe/?trk=x` and
+ * `jane-doe` both collapse to `jane-doe`. A slug is the `/in/(<slug>)` path
+ * segment; a bare input (no `/in/`) is treated as an already-extracted slug.
+ * Returns `null` when no valid `[a-z0-9\-_%]` slug can be recovered.
+ */
+export function normalizeLinkedInSlug(
+  raw: string | null | undefined
+): string | null {
+  if (typeof raw !== "string") return null;
+  const value = raw.trim();
+  if (!value) return null;
+  // Full/partial URL → pull out the `/in/<slug>` segment (stops at the next
+  // `/`, `?` or `#`). A bare input without `/in/` is treated as the slug.
+  const match = value.match(/\/in\/([^/?#]+)/i);
+  const slug = (match ? match[1] : value).toLowerCase();
+  if (!/^[a-z0-9\-_%]+$/.test(slug)) return null;
+  return slug;
+}
+
+/**
+ * Normalize a LinkedIn identity namespace value. Returns `undefined` when the
+ * namespace is not LinkedIn-owned (caller falls back to generic hygiene). The
+ * generic `email` namespace is deliberately NOT handled here — connector-sdk
+ * owns email normalization.
+ */
+export function normalizeLinkedInIdentityValue(
+  namespace: string,
+  raw: string
+): string | null | undefined {
+  switch (namespace) {
+    case LINKEDIN_IDENTITY.SLUG:
+      return normalizeLinkedInSlug(raw);
+    default:
+      return undefined;
+  }
+}
+
+/** Generic email namespace, shared cross-channel bridge (owned by the SDK). */
+export const LINKEDIN_EMAIL_NAMESPACE = IDENTITY.EMAIL;
+
+/** The LinkedIn connector's contribution to the server identity wiring. */
+export const linkedInIdentityModule: ConnectorIdentityModule = {
+  key: "linkedin",
+  // `linkedin_slug` is an attribution/match key, not recall-indexed — there is
+  // no idx_events_metadata_linkedin_slug. Cross-channel email recall is handled
+  // by the generic `email` namespace, not LinkedIn.
+  recallNamespaces: [],
+  normalize: normalizeLinkedInIdentityValue,
+};

--- a/examples/personal-agent/linkedin-takeout.connector.ts
+++ b/examples/personal-agent/linkedin-takeout.connector.ts
@@ -3,10 +3,16 @@ import path from "node:path";
 import {
   type ConnectorDefinition,
   ConnectorRuntime,
+  type EventAttributionRule,
   type EventEnvelope,
   type SyncContext,
   type SyncResult,
 } from "@lobu/connector-sdk";
+import {
+  LINKEDIN_EMAIL_NAMESPACE,
+  LINKEDIN_IDENTITY,
+  normalizeLinkedInSlug,
+} from "./linkedin-identity.ts";
 import {
   assertDirectory,
   batchSize,
@@ -17,6 +23,75 @@ import {
   stripHtml,
   takeBatch,
 } from "./takeout-utils.ts";
+
+/**
+ * Link a `connection` event to the connected person via their canonical
+ * `linkedin_slug` (extracted from the profile URL) plus their `email`. Neither
+ * is `primary` — they match equal-weight cross-channel until a stable primary
+ * id arrives from the live connector. The full URL is kept as a display trait,
+ * not an identity (case/URL noise would fork the entity). Connections ARE the
+ * user's network, so we mint (`autoCreate`) a person per row.
+ */
+const LINKEDIN_CONNECTION_ATTRIBUTIONS: EventAttributionRule[] = [
+  {
+    role: "about",
+    autoCreate: true,
+    target: {
+      entityType: "person",
+      titlePath: "author_name",
+      identities: [
+        {
+          namespace: LINKEDIN_IDENTITY.SLUG,
+          eventPath: "metadata.linkedin_slug",
+        },
+        { namespace: LINKEDIN_EMAIL_NAMESPACE, eventPath: "metadata.email" },
+      ],
+    },
+    traits: {
+      linkedin_url: {
+        eventPath: "metadata.linkedin_url",
+        behavior: "prefer_non_empty",
+      },
+      company: { eventPath: "metadata.company", behavior: "prefer_non_empty" },
+      position: {
+        eventPath: "metadata.position",
+        behavior: "prefer_non_empty",
+      },
+    },
+  },
+];
+
+/**
+ * Link a `message` event to its sender (the counterparty) via the
+ * `linkedin_slug` extracted from their profile URL, plus display name. Real
+ * counterparties, so mint on no match.
+ */
+const LINKEDIN_MESSAGE_ATTRIBUTIONS: EventAttributionRule[] = [
+  {
+    role: "authored_by",
+    autoCreate: true,
+    target: {
+      entityType: "person",
+      titlePath: "metadata.from",
+      identities: [
+        {
+          namespace: LINKEDIN_IDENTITY.SLUG,
+          eventPath: "metadata.sender_linkedin_slug",
+        },
+      ],
+    },
+    traits: {
+      linkedin_url: {
+        eventPath: "metadata.sender_profile_url",
+        behavior: "prefer_non_empty",
+      },
+      last_linkedin_message_at: {
+        eventPath: "occurred_at",
+        behavior: "overwrite",
+      },
+    },
+  },
+];
 
 interface LinkedInTakeoutCheckpoint {
   last_messages_timestamp?: string;
@@ -48,6 +123,12 @@ export default class LinkedInTakeoutConnector extends ConnectorRuntime<
         configSchema: localTakeoutSchema(
           "Path to the LinkedIn Data Export folder."
         ),
+        eventKinds: {
+          message: {
+            description: "A LinkedIn direct message",
+            attributions: LINKEDIN_MESSAGE_ATTRIBUTIONS,
+          },
+        },
       },
       connections: {
         key: "connections",
@@ -55,6 +136,12 @@ export default class LinkedInTakeoutConnector extends ConnectorRuntime<
         configSchema: localTakeoutSchema(
           "Path to the LinkedIn Data Export folder."
         ),
+        eventKinds: {
+          connection: {
+            description: "A first-degree LinkedIn connection",
+            attributions: LINKEDIN_CONNECTION_ATTRIBUTIONS,
+          },
+        },
       },
       invitations: {
         key: "invitations",
@@ -247,6 +334,8 @@ export default class LinkedInTakeoutConnector extends ConnectorRuntime<
             conversation_title: row["CONVERSATION TITLE"],
             from: row.FROM,
             sender_profile_url: row["SENDER PROFILE URL"],
+            sender_linkedin_slug:
+              normalizeLinkedInSlug(row["SENDER PROFILE URL"]) ?? undefined,
             to: row.TO,
             recipient_profile_urls: row["RECIPIENT PROFILE URLS"],
             subject: row.SUBJECT,
@@ -286,6 +375,11 @@ export default class LinkedInTakeoutConnector extends ConnectorRuntime<
             company: row.Company,
             position: row.Position,
             linkedin_url: row.URL,
+            // Pre-canonicalized identity key. The server never loads example
+            // connectors' normalizer modules, so we emit the already-lowercased
+            // /in/<slug> here; the engine stores it verbatim (trim fallback) and
+            // case-variant URLs from any source collapse to one entity.
+            linkedin_slug: normalizeLinkedInSlug(row.URL) ?? undefined,
           },
         },
       ];


### PR DESCRIPTION
## What

The LinkedIn takeout connector emitted connection/message events but declared no identity rules, so people were never linked or minted through the resolver into `entity_identities`. That's why buremba's ~4,900 bulk-imported LinkedIn people have no identity keys and no aliases — they're unlinkable and invisible to the duplicate-merge watcher.

This adds a `linkedin-identity` module (mirroring `x-identity.ts`) and attribution rules on the `connections` and `messages` feeds so LinkedIn people join the identity graph.

## Identity model

- Key on **`linkedin_slug`** — the canonical lowercased `/in/<vanity>` slug — plus the generic **`email`** namespace. Neither is `primary`: equal-weight cross-channel matching, until a live connector can supply the immutable member id (then that becomes the primary, like `x_user_id`).
- **`linkedin_url` (the full URL) is a display trait, not an identity key.** Keying on the full URL forks the same person across `http`/`https`/`www`/trailing-slash/query variants (the `entity_identities` unique index is case-sensitive).
- The connector **pre-canonicalizes the slug in `sync()`** (emits `metadata.linkedin_slug` / `sender_linkedin_slug`), because the server only loads `@lobu/connectors` normalizer modules, not example connectors. The engine stores the value verbatim via the trim fallback, so case-variant URLs collapse to one entity.

## Why slug, not the full URL or a member id

The takeout export gives only the vanity URL — there's no stable member URN in it (that only comes from the live API/extension connector). The slug is the stable core with 95% coverage; email is present for only ~2.5% of connections, so slug does the identity work.

## Dry-run against the real export

- Connections: 2,544 events, **100% carry a unique `linkedin_slug`**, 0 name-only.
- Messages: 7,056 events → **671 distinct senders** keyed by slug (487 name-only where the export's profile URL was blank).
- Message senders dedup against connections via shared slug at ingestion — a person you're connected to and messaged becomes one entity.

## Tests

`normalizeLinkedInSlug` collapses protocol/www/case/trailing-slash/query/bare-slug variants to one slug and rejects non-`/in/` URLs and junk; the attribution rules key on the pre-cleaned slug + email (neither primary); a real connections row emits `metadata.linkedin_slug = jane-doe` from a `https://www.LinkedIn.com/in/Jane-Doe/` URL. 6 pass. Pre-commit tsc + biome clean.

## Deferred follow-up

The live/browser `linkedin` connector still has no identity rules. Give it the same slug/email keys (or merge the two LinkedIn connectors into one key like `x.ts`) so browser-discovered people dedup with takeout people. Tracked separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786110796&installation_id=136316292&pr_number=1797&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1797&signature=4c4f660e0d03b11107a9f7cabcaefb7d8665b8bf14338f3091a4c38b61e94308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved LinkedIn data handling so profile URLs and slugs are normalized consistently.
  * Messages and connections now link more reliably to the right person profile.

* **Bug Fixes**
  * Fixed identity matching for LinkedIn message senders and connection records.
  * Better handling of URL variants, case differences, and trailing slashes.

* **Tests**
  * Added coverage for LinkedIn URL normalization and identity attribution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->