### PR TITLE
feat(dev): owletto-mac / owletto-mac-e2e build tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Development Makefile for Lobu
 
-.PHONY: help setup build test clean dev dev-db dev-embedded build-packages ensure-submodule clean-workers clean-test-pg test-unit test-integration test-e2e test-e2e-sdk test-e2e-cli test-providers-live typecheck task-setup task-clean dev-recover clean-merged e2e-browser bump review
+.PHONY: help setup build test clean dev dev-db dev-embedded build-packages ensure-submodule clean-workers clean-test-pg test-unit test-integration test-e2e test-e2e-sdk test-e2e-cli test-providers-live typecheck task-setup task-clean dev-recover clean-merged e2e-browser bump review owletto-mac owletto-mac-e2e
 
 # Default target
 help:
@@ -24,6 +24,8 @@ help:
 	@echo "  make e2e-browser [RESTART=1]               - Launch/reuse the stable 'owletto' Chrome harness (extension from this worktree) for Chrome e2e"
 	@echo "  make bump SUBMODULE=<path> [TARGET=<ref>]  - Lightweight worktree + commit + PR for a trivial submodule pointer bump (skips bun install, .env, ports)"
 	@echo "  make review [BASE=<branch>]                - Run local review (typecheck+unit+integration + Claude); posts pi-review status and PR comment"
+	@echo "  make owletto-mac [INSTALL=1] [OPEN=1]      - Build Owletto.app with the Developer ID identity (TCC grants match the notarized release); INSTALL=1 replaces /Applications/Owletto.app, OPEN=1 launches it"
+	@echo "  make owletto-mac-e2e [SKIP_BUILD=1]        - Build/install the signed Owletto.app then probe prod computer_use (permissions + list_windows) via the paired device connection"
 
 # Strict typecheck — mirrors the Dockerfile so local matches CI. Catches
 # what `build-packages` (relaxed, bundler-only) misses.
@@ -113,6 +115,20 @@ task-setup:
 task-clean:
 	@: $${NAME?Usage: make task-clean NAME=<name> [FORCE=1]}
 	@./scripts/task-clean.sh "$(NAME)" $$( [ "$(FORCE)" = "1" ] && echo --force )
+
+# Build the Owletto Mac app locally with the same Developer ID identity as the
+# mac-release CI, so TCC grants (Screen Recording, Accessibility) match the
+# notarized release instead of a default Apple Development build. Syncs the
+# owletto submodule first. INSTALL=1 replaces /Applications/Owletto.app; OPEN=1
+# launches it. See scripts/build-owletto-mac.sh header for details.
+owletto-mac:
+	@INSTALL="$(INSTALL)" OPEN="$(OPEN)" ./scripts/build-owletto-mac.sh
+
+# Build/install the signed Owletto.app then probe prod computer_use against the
+# paired device connection (permissions + list_windows). SKIP_BUILD=1 reuses the
+# already-installed /Applications/Owletto.app. See scripts/owletto-mac-e2e.sh.
+owletto-mac-e2e:
+	@SKIP_BUILD="$(SKIP_BUILD)" ./scripts/owletto-mac-e2e.sh
 
 # Reap task worktrees whose PR is already merged (worktree + branches + dev DB
 # + Lobu context). Dry-run by default — prints what it would remove; pass

--- a/scripts/build-owletto-mac.sh
+++ b/scripts/build-owletto-mac.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Build Owletto.app with the same Developer ID identity as mac-release CI.
+# TCC grants (Screen Recording, Accessibility, etc.) then match the notarized
+# release — unlike a default Xcode Debug build (Apple Development cert).
+#
+# Usage:
+#   make owletto-mac                  # build → /tmp/owletto-build/.../Owletto.app
+#   make owletto-mac INSTALL=1        # also replace /Applications/Owletto.app
+#   make owletto-mac INSTALL=1 OPEN=1 # install and launch
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"$ROOT/scripts/sync-owletto-submodule.sh"
+MAC="$ROOT/packages/owletto/apps/mac"
+DERIVED="${DERIVED:-/tmp/owletto-build}"
+TEAM_ID="CCV9Q352W3"
+SIGN_ID="Developer ID Application"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+[ -f "$MAC/Owletto.xcodeproj/project.pbxproj" ] \
+  || die "packages/owletto not initialized — run: git submodule update --init packages/owletto"
+
+if ! security find-identity -v -p codesigning 2>/dev/null | grep -q "Developer ID Application"; then
+  die "$(cat <<EOF
+No Developer ID Application cert in your login keychain.
+  • Keychain Access → import the Developer ID .p12 (same cert as CI), or
+  • Download it from developer.apple.com (team $TEAM_ID), or
+  • For prod E2E only: install the release DMG instead of building locally
+    https://github.com/lobu-ai/lobu/releases/latest/download/Owletto.dmg
+EOF
+)"
+fi
+
+echo ">> Building Owletto (Release, $SIGN_ID)..."
+(
+  cd "$MAC"
+  xcodebuild -scheme Owletto -configuration Release \
+    -derivedDataPath "$DERIVED" \
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGN_IDENTITY="$SIGN_ID" \
+    DEVELOPMENT_TEAM="$TEAM_ID" \
+    ENABLE_HARDENED_RUNTIME=YES \
+    build
+)
+
+APP="$DERIVED/Build/Products/Release/Owletto.app"
+[ -d "$APP" ] || die "build succeeded but $APP is missing"
+
+# Xcode + SPM Sparkle: re-seal nested helpers (same leaf-first order as CI).
+echo ">> Re-signing Sparkle helpers..."
+SPARKLE="$APP/Contents/Frameworks/Sparkle.framework/Versions/B"
+OPTS=(--force --options runtime --timestamp --sign "$SIGN_ID")
+
+resign_xpc() {
+  local name="$1"
+  local dir="$SPARKLE/XPCServices/${name}.xpc"
+  [ -d "$dir" ] || return 0
+  codesign "${OPTS[@]}" "$dir/Contents/MacOS/$name"
+  codesign "${OPTS[@]}" "$dir"
+}
+
+resign_xpc Downloader
+resign_xpc Installer
+if [ -d "$SPARKLE/Updater.app" ]; then
+  codesign "${OPTS[@]}" "$SPARKLE/Updater.app/Contents/MacOS/Updater"
+  codesign "${OPTS[@]}" "$SPARKLE/Updater.app"
+fi
+[ -f "$SPARKLE/Autoupdate" ] && codesign "${OPTS[@]}" "$SPARKLE/Autoupdate"
+codesign "${OPTS[@]}" "$APP/Contents/Frameworks/Sparkle.framework"
+codesign "${OPTS[@]}" "$APP"
+codesign --verify --deep --strict "$APP"
+
+echo ">> Built: $APP"
+
+if [ "${INSTALL:-}" = "1" ]; then
+  echo ">> Installing to /Applications/Owletto.app (quit Owletto first if it's running)"
+  osascript -e 'tell application "Owletto" to quit' 2>/dev/null || true
+  sleep 1
+  rm -rf /Applications/Owletto.app
+  cp -R "$APP" /Applications/Owletto.app
+  echo ">> Installed: /Applications/Owletto.app"
+fi
+
+if [ "${OPEN:-}" = "1" ]; then
+  if [ "${INSTALL:-}" = "1" ]; then
+    open /Applications/Owletto.app
+  else
+    open "$APP"
+  fi
+fi

--- a/scripts/owletto-mac-e2e.sh
+++ b/scripts/owletto-mac-e2e.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Build/install Owletto (Developer ID) and probe prod computer_use.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ORG="${ORG:-buremba}"
+CONTEXT="${CONTEXT:-lobu}"
+CONN_ID="${CONN_ID:-397}"
+
+cd "$ROOT"
+git -c submodule.recurse=false pull --ff-only origin main
+"$ROOT/scripts/sync-owletto-submodule.sh"
+
+if [ "${SKIP_BUILD:-}" != "1" ]; then
+  echo "== build + install =="
+  INSTALL=1 OPEN=1 "$ROOT/scripts/build-owletto-mac.sh"
+else
+  echo "== SKIP_BUILD=1 — using existing /Applications/Owletto.app =="
+fi
+
+echo "== codesign =="
+codesign -dv --verbose=4 /Applications/Owletto.app 2>&1 | grep -E "Authority|Identifier|TeamIdentifier" || true
+
+echo "== waiting for Owletto to pair/poll (${POLL_WAIT_SECS:-45}s) =="
+echo "   (menubar Owletto should show connected to prod before probes run)"
+sleep "${POLL_WAIT_SECS:-45}"
+
+probe() {
+  local op="$1"
+  local attempt max_attempts="${PROBE_RETRIES:-3}"
+  echo "== $op =="
+  for attempt in $(seq 1 "$max_attempts"); do
+    if [ "$attempt" -gt 1 ]; then
+      echo "   retry $attempt/$max_attempts (server or device may still be waking)..."
+      sleep 10
+    fi
+    if lobu memory exec "export default async (_ctx, client) => {
+      return await client.operations.execute({
+        connection_id: ${CONN_ID}, operation_key: \"${op}\", input: {},
+      });
+    }" -c "$CONTEXT" --org "$ORG" 2>&1 | tee /tmp/owletto-e2e-"$op".log | grep -q '"success": true'; then
+      cat /tmp/owletto-e2e-"$op".log
+      return 0
+    fi
+    cat /tmp/owletto-e2e-"$op".log
+    if ! grep -qE 'CONNECTION_ENDED|CONNECTION_CLOSED|CONNECTION_DESTROYED|device worker did not complete' /tmp/owletto-e2e-"$op".log; then
+      return 1
+    fi
+  done
+  echo "error: $op failed after $max_attempts attempts" >&2
+  echo "  • Confirm Owletto menubar is connected (prod gateway, signed in)" >&2
+  echo "  • Connection ${CONN_ID} should be bound to this Mac device" >&2
+  return 1
+}
+
+probe permissions
+probe list_windows
+
+echo "== done =="

--- a/scripts/sync-owletto-submodule.sh
+++ b/scripts/sync-owletto-submodule.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Checkout packages/owletto to the SHA pinned by the parent repo.
+#
+# Safe by default: exits if the submodule has local edits. Pass RESET_OWLETTO=1
+# to discard uncommitted owletto changes (reset --hard + clean -fd).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OWLETTO="$ROOT/packages/owletto"
+cd "$ROOT"
+
+owletto_dirty() {
+  [ -d "$OWLETTO/.git" ] || [ -f "$OWLETTO/.git" ] || return 1
+  ! git -C "$OWLETTO" diff --quiet \
+    || ! git -C "$OWLETTO" diff --cached --quiet \
+    || [ -n "$(git -C "$OWLETTO" ls-files --others --exclude-standard)" ]
+}
+
+if owletto_dirty; then
+  if [ "${RESET_OWLETTO:-}" != "1" ]; then
+    echo "error: packages/owletto has local changes (uncommitted or untracked)." >&2
+    echo >&2
+    git -C "$OWLETTO" status --short >&2 || true
+    echo >&2
+    cat >&2 <<'EOF'
+Refusing to overwrite them. Options:
+  • Keep your work: commit in packages/owletto, or use a worktree (make task-setup)
+    for owletto development.
+  • Discard owletto-only edits and continue:
+    RESET_OWLETTO=1 make owletto-mac
+    RESET_OWLETTO=1 make owletto-mac-e2e
+EOF
+    exit 1
+  fi
+
+  echo ">> RESET_OWLETTO=1 — discarding local packages/owletto edits"
+  git -C "$OWLETTO" reset --hard
+  git -C "$OWLETTO" clean -fd
+fi
+
+git submodule update --init packages/owletto


### PR DESCRIPTION
## What

Adds local Mac build tooling for the Owletto app, wired up as `make` targets that were previously referenced by scripts but never existed.

- **`scripts/build-owletto-mac.sh`** — builds `Owletto.app` (Release) signed with the **Developer ID Application** identity (team `CCV9Q352W3`), the same cert as the mac-release CI. This makes local TCC grants (Screen Recording, Accessibility) match the notarized release, unlike a default Xcode Debug build (Apple Development cert). Re-seals the nested Sparkle auto-updater helpers leaf-first, verifies `--deep --strict`. Optional `INSTALL=1` (replace `/Applications/Owletto.app`) and `OPEN=1` (launch).
- **`scripts/owletto-mac-e2e.sh`** — builds/installs the signed app, then probes prod `computer_use` (`permissions` + `list_windows`) against the paired device connection via `lobu memory exec`. `SKIP_BUILD=1` reuses the installed app.
- **`scripts/sync-owletto-submodule.sh`** — checks out `packages/owletto` to the parent-pinned SHA; refuses to clobber a dirty submodule unless `RESET_OWLETTO=1`.
- **`Makefile`** — `owletto-mac` / `owletto-mac-e2e` targets + `help` entries.

## Why

These scripts existed only as uncommitted local tooling and advertised `make owletto-mac` / `make owletto-mac-e2e` targets that were never defined. This lands them properly and wires up the targets so the documented UX works.

## Verification

- `make -n owletto-mac` / `owletto-mac-e2e` resolve; `make help` lists both.
- `bash -n` clean on all three scripts.
- `sync-owletto-submodule.sh` runs clean (exit 0), leaves submodule clean.
- `build-owletto-mac.sh` gets past the cert guard and starts a real `xcodebuild` (Sparkle 2.9.1 resolved) — full build not run to completion in CI.
- Pre-commit biome + `tsc --noEmit` pass.

Note: hardcoded to team `CCV9Q352W3` and device connection `397` — personal dev tooling, not general-purpose.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786111499&installation_id=136316292&pr_number=1798&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1798&signature=a19f5661e97719d5cc4694bcf20a53b20cc2b6e3e46d909da0c5767fbe44f869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->