### PR TITLE
fix(task-clean): never close the current Herdr workspace

### DIFF
--- a/scripts/lib/herdr-task.sh
+++ b/scripts/lib/herdr-task.sh
@@ -37,24 +37,36 @@ print(d.get("result",{}).get("workspace",{}).get("workspace_id",""))' 2>/dev/nul
 # task name: when task-setup ran inside an existing pane, herdr_task_open
 # relabeled that workspace in place rather than binding it to a checkout, so
 # Herdr has no checkout_path for it — the label is the only handle we have.
+#
+# NEVER closes the CURRENT workspace ($HERDR_WORKSPACE_ID). `make task-clean`
+# is routinely run from inside the very pane that task-setup relabeled in place;
+# closing that pane tears down the live session (and under memory pressure the
+# teardown escalates to a SIGKILL of the whole process tree). The git-worktree
+# teardown that follows still removes the checkout, so sparing the pane loses
+# nothing but the (now-stale-labeled) window, which the user can reuse.
 herdr_task_close() {
   local worktree_path="$1" label="${2:-}"
   local json ws matched_by
   herdr_task_enabled || return 1
   json="$(herdr workspace list 2>/dev/null)" || return 1
   # Emit "<match_kind> <workspace_id>": "path" when bound to the checkout,
-  # else "label" when only the label matches. Path wins over label.
-  read -r matched_by ws <<<"$(printf '%s' "$json" | WORKTREE_PATH="$worktree_path" LABEL="$label" python3 -c 'import os,sys,json
+  # else "label" when only the label matches. Path wins over label. The current
+  # workspace is skipped in BOTH branches so we never close our own session.
+  read -r matched_by ws <<<"$(printf '%s' "$json" | WORKTREE_PATH="$worktree_path" LABEL="$label" CURRENT_WS="${HERDR_WORKSPACE_ID:-}" python3 -c 'import os,sys,json
 path=os.environ["WORKTREE_PATH"]
 label=os.environ.get("LABEL","")
+current=os.environ.get("CURRENT_WS","")
 d=json.load(sys.stdin)
 by_label=""
 for w in d.get("result",{}).get("workspaces",[]):
+  wid=w.get("workspace_id") or ""
+  if wid and wid==current:
+    continue  # never close the pane we are running in
   wt=w.get("worktree") or {}
   if wt.get("checkout_path")==path:
-    print("path", w.get("workspace_id") or ""); break
+    print("path", wid); break
   if label and not by_label and w.get("label")==label:
-    by_label=w.get("workspace_id") or ""
+    by_label=wid
 else:
   if by_label: print("label", by_label)
 ' 2>/dev/null)"


### PR DESCRIPTION
## What

`make task-clean` could kill the herdr session it was run from.

## Why

`make task-setup`, when run inside an existing herdr pane, relabels the *current* workspace (`$HERDR_WORKSPACE_ID`) to the task name in place rather than spawning a dedicated one (`herdr_task_open`, herdr-task.sh:19-21). Later, `herdr_task_close` matched a workspace **by label == task name** and closed it — which is the very pane you're working in. Under memory pressure the teardown escalated from a clean workspace-close into a `SIGKILL` (exit 137) of the whole process tree. Observed live: running `task-clean` while a `make review` bun suite was still going killed the session.

There was no guard preventing `herdr_task_close` from closing the current workspace.

## Fix

Skip `$HERDR_WORKSPACE_ID` in both the path-match and label-match branches, so `herdr_task_close` never closes the pane it runs in. The git-worktree teardown that follows `herdr_task_close` still removes the checkout — only the live pane is spared (its label is now stale, but the user can reuse the window). On no match, `herdr_task_close` returns 1, which `task-clean.sh:125` already treats as a no-op.

## Verification

Tested the matcher against the exact failure scenario:
- **The bug:** a workspace labeled with the task name whose id == the current workspace → now returns no match (spared). ✓
- **No regression:** a same-labeled workspace that is NOT current still closes; path matches to a non-current workspace still work. ✓

Pre-commit tsc + biome clean. (The one shellcheck SC2148 on line 1 is pre-existing — this is a sourced lib with no shebang by design.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786112093&installation_id=136316292&pr_number=1799&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1799&signature=f3f137d29703eee25f84d8385e45f7e7bd26ffc7899c786bf7287abf57f65fc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->