### PR TITLE
fix(connector-worker): stream worker_id + NUL-safe takeout checkpoint

### DIFF
--- a/examples/personal-agent/takeout-utils.ts
+++ b/examples/personal-agent/takeout-utils.ts
@@ -107,8 +107,15 @@ export function maxEventCursor(
   );
 }
 
+// Composite watermark: ISO timestamp + origin_id so events sharing a second
+// still order deterministically. The delimiter is persisted inside the jsonb
+// checkpoint column, so it must NOT be NUL: Postgres rejects NUL in jsonb
+// (unsupported Unicode escape sequence). \u0001 (SOH) sorts before every
+// printable char (preserving timestamp-first ordering) and is jsonb-safe.
+const CURSOR_DELIMITER = "\u0001";
+
 function eventCursor(event: EventEnvelope): string {
-  return `${event.occurred_at.toISOString()}\0${event.origin_id}`;
+  return `${event.occurred_at.toISOString()}${CURSOR_DELIMITER}${event.origin_id}`;
 }
 
 export function stableId(

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -140,6 +140,7 @@ export interface ContentItem {
 export interface StreamBatch {
   type: 'batch';
   run_id: number;
+  worker_id: string;
   items: ContentItem[];
   checkpoint?: Record<string, unknown>;
 }

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -185,6 +185,7 @@ async function executeSyncRun(
         await client.stream({
           type: 'batch',
           run_id,
+          worker_id: client.id,
           items: batch,
           checkpoint: lastCheckpoint ?? undefined,
         });
@@ -226,6 +227,7 @@ async function executeSyncRun(
             await client.stream({
               type: 'batch',
               run_id,
+              worker_id: client.id,
               items: [],
               checkpoint: lastCheckpoint,
             });

--- a/packages/server/src/tools/validate-args.ts
+++ b/packages/server/src/tools/validate-args.ts
@@ -22,6 +22,7 @@ import { FormatRegistry } from '@sinclair/typebox';
 import { TypeCompiler, type TypeCheck } from '@sinclair/typebox/compiler';
 import { Value } from '@sinclair/typebox/value';
 import { ToolUserError } from '../utils/errors';
+import { stripNul } from '../utils/strip-nul';
 
 // typebox's Value.Check FAILS (returns false) on any `format` constraint that
 // isn't registered — there is no permissive default. `manage_schedules` gates
@@ -73,9 +74,6 @@ function actionOf(variant: TSchema): string {
  *   (`before_occurred_at`) are Type.String; the list→page round trip must
  *   survive validation.
  */
-const stripNul = (str: string): string =>
-  str.indexOf('\u0000') === -1 ? str : str.replace(/\u0000/g, '');
-
 function normalizeArgs(value: unknown): unknown {
   // Postgres text columns and tsquery cannot contain NUL (0x00): a string
   // carrying one raises `invalid byte sequence for encoding "UTF8": 0x00`,

--- a/packages/server/src/utils/__tests__/strip-nul.test.ts
+++ b/packages/server/src/utils/__tests__/strip-nul.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { stripNul, stripNulDeep } from "../strip-nul";
+
+describe("stripNul", () => {
+  it("returns the string unchanged when there is no NUL", () => {
+    expect(stripNul("hello")).toBe("hello");
+  });
+
+  it("removes NUL bytes", () => {
+    expect(stripNul("a\u0000b")).toBe("ab");
+  });
+
+  it("leaves other control chars (e.g. the jsonb-safe SOH delimiter) intact", () => {
+    expect(stripNul("2026-06-27T23:00:00.000Z\u0001li_connection_x")).toBe(
+      "2026-06-27T23:00:00.000Z\u0001li_connection_x",
+    );
+  });
+});
+
+describe("stripNulDeep", () => {
+  it("strips NUL from a nested connector checkpoint (the LinkedIn takeout bug)", () => {
+    // Reproduces the exact payload that 500ed /api/workers/complete with
+    // "unsupported Unicode escape sequence": a composite cursor whose delimiter
+    // was NUL, written into the jsonb checkpoint column.
+    const checkpoint = {
+      last_connections_timestamp:
+        "2026-06-27T23:00:00.000Z\u0000li_connection_abc",
+    };
+    expect(stripNulDeep(checkpoint)).toEqual({
+      last_connections_timestamp:
+        "2026-06-27T23:00:00.000Zli_connection_abc",
+    });
+  });
+
+  it("strips NUL from object keys, arrays, and deep nesting", () => {
+    const input = {
+      ["k\u0000ey"]: ["a\u0000b", { c: "d\u0000e" }],
+    };
+    expect(stripNulDeep(input)).toEqual({ key: ["ab", { c: "de" }] });
+  });
+
+  it("passes primitives and non-plain objects through untouched", () => {
+    expect(stripNulDeep(42)).toBe(42);
+    expect(stripNulDeep(null)).toBe(null);
+    const d = new Date(0);
+    expect(stripNulDeep(d)).toBe(d);
+  });
+});

--- a/packages/server/src/utils/strip-nul.ts
+++ b/packages/server/src/utils/strip-nul.ts
@@ -1,0 +1,29 @@
+/**
+ * Postgres text/jsonb columns cannot contain NUL (0x00): a string carrying one
+ * raises unsupported-Unicode-escape (jsonb) or invalid-UTF8-0x00 (text).
+ * External connector data (LinkedIn/Twitter takeout rows, browser scrapes)
+ * routinely carries stray NULs, so every write boundary that persists worker-
+ * or connector-supplied JSON must strip them first.
+ *
+ * stripNul handles one string; stripNulDeep walks plain objects/arrays (keys
+ * included) and is the reusable chokepoint. Class instances and Dates pass
+ * through untouched so callers do not lose prototype behavior.
+ */
+export const stripNul = (str: string): string =>
+  str.indexOf("\u0000") === -1 ? str : str.replace(/\u0000/g, "");
+
+export function stripNulDeep(value: unknown): unknown {
+  if (typeof value === "string") return stripNul(value);
+  if (Array.isArray(value)) return value.map(stripNulDeep);
+  if (value && typeof value === "object") {
+    const proto = Object.getPrototypeOf(value);
+    if (proto === Object.prototype || proto === null) {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value)) {
+        out[stripNul(k)] = stripNulDeep(v);
+      }
+      return out;
+    }
+  }
+  return value;
+}

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -34,6 +34,7 @@ import {
 } from "../utils/inline-attachments";
 import { insertEvent, recordLifecycleEvent } from "../utils/insert-event";
 import logger from "../utils/logger";
+import { stripNulDeep } from "../utils/strip-nul";
 import { advanceWatcherSchedule } from "../watchers/automation";
 import { authorizeRunForWorker } from "./shared";
 
@@ -183,6 +184,18 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 			}>;
 			checkpoint?: Record<string, unknown>;
 		}>();
+
+		// Connector-supplied checkpoints (LinkedIn takeout cursors, browser
+		// scrapes) can carry stray NUL (0x00), which Postgres rejects when written
+		// to the jsonb checkpoint column (unsupported Unicode escape sequence).
+		// Item payloads go through insertEvent which already sanitizes; the
+		// checkpoint writes below are raw sql.json, so strip it here.
+		if (batch.checkpoint) {
+			batch.checkpoint = stripNulDeep(batch.checkpoint) as Record<
+				string,
+				unknown
+			>;
+		}
 
 		const denied = await authorizeRunForWorker(
 			c,
@@ -393,6 +406,16 @@ export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 			exit_signal?: string | null;
 			exit_reason?: "ok" | "error_message" | "timeout" | "oom" | "crash";
 		}>();
+
+		// Strip NUL (0x00) from connector-supplied jsonb payloads before they hit
+		// Postgres (see streamContent). The final checkpoint and refreshed browser
+		// auth_update are written via raw sql.json below.
+		if (req.checkpoint) {
+			req.checkpoint = stripNulDeep(req.checkpoint) as Record<string, unknown>;
+		}
+		if (req.auth_update) {
+			req.auth_update = stripNulDeep(req.auth_update) as Record<string, unknown>;
+		}
 
 		const denied = await authorizeRunForWorker(c, req.run_id, req.worker_id);
 		if (denied) return denied;


### PR DESCRIPTION
## What

Self-hosted device workers (user-mode) could not sync local-file **takeout** connectors (LinkedIn/Twitter/Instagram/Google) into a cloud org. Two bugs on the `@lobu/connector-worker daemon` → server path, both **masked for the trusted-fleet cloud worker** (which `authorizeRunForWorker` waves through in token mode). Only surfaced now, dogfooding the identity graph from a self-hosted daemon.

### 1. `stream()` omitted `worker_id` → 400, every batch lost

`client.stream()` / `executor.flushBatch` sent `{type, run_id, items, checkpoint}` with no `worker_id`, but `authorizeRunForWorker` **requires** it for user-mode workers (it waves through non-user/token mode). Result: `POST /api/workers/stream` returned 400 `worker_id is required` and every content batch was dropped.

Fix: add `worker_id` to `StreamBatch` and pass `client.id` at both `client.stream` call sites.

### 2. Takeout checkpoint used a NUL delimiter → jsonb 500 on complete

`takeout-utils.ts` `eventCursor()` built its composite watermark as the ISO timestamp joined to `origin_id` by a **NUL (0x00)** byte. That cursor string *is* the checkpoint, written to the jsonb `checkpoint` column via `sql.json`, so `POST /api/workers/complete` returned 500 `unsupported Unicode escape sequence`. Shared by **all** takeout connectors.

Fix (root, connector-side): switch the delimiter from NUL (0x00) to **SOH (0x01)** — it sorts before every printable char (so timestamp-first ordering is preserved) and is valid in jsonb.

Fix (defense-in-depth, server-side): extract `stripNul`/`stripNulDeep` into `utils/strip-nul.ts` (dedup from `validate-args`' private copy) and strip NUL from `checkpoint` + `auth_update` in `streamContent` and `completeWorkerJob`, since worker-supplied JSON bypasses the tool-arg sanitizer chokepoint.

## Why it matters

This is the "any CLI worker with a filesystem" path: a self-hosted `@lobu/connector-worker daemon` run against prod with the CLI's own session token can sync a local-file connector into a cloud org, with the server shipping the compiled connector code inline. No new platform, no Swift changes — these two fixes are all that was missing.

## Testing

- New `packages/server/src/utils/__tests__/strip-nul.test.ts` — 6 tests, including an exact reproduction of the LinkedIn checkpoint payload that 500'd. Green.
- Proven **live end-to-end**: 2,544 slug-keyed LinkedIn people synced into the `buremba` org via a self-hosted daemon (incremental 1000+1000+544, then 0). People now carry the normalized `linkedin_slug` alias → real `entity_identities` → dedup-able by the duplicate-merge watcher.
- `make review` green (typecheck, unit fails=0, integration fails=0, biome clean, build 0 errors).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786119936&installation_id=136316292&pr_number=1800&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1800&signature=43c61a4fdf26670dd889cea1285a04e69f6bdf421a771362b982adc56fc165dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving checkpoints and auth updates, preventing failures caused by hidden invalid characters in JSON data.
  * Preserved stable ordering for events processed at the same time, reducing issues with checkpointing and filtering.
  * Added worker identity to streaming updates so batch and checkpoint progress is tracked more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->