### PR TITLE
fix(apply): re-apply a local connector whose feed set changed

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/extract-connector-key.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/extract-connector-key.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { extractDeclaredConnectorKey } from "../desired-state.js";
+import { locallyDeclaredConnectorKeys } from "../apply-cmd.js";
+import type { DesiredState } from "../desired-state.js";
+
+describe("extractDeclaredConnectorKey", () => {
+  test("pulls the connector key from a readonly definition literal", () => {
+    const src = [
+      "export default class LinkedInConnector extends ConnectorRuntime {",
+      "  readonly definition: ConnectorDefinition = {",
+      `    key: "linkedin",`,
+      `    name: "LinkedIn",`,
+      "    feeds: {",
+      `      home_feed: { key: "home_feed" },`,
+      `      connections: { key: "connections" },`,
+      "    },",
+      "  };",
+      "}",
+    ].join("\n");
+    // Must return the CONNECTOR key, not the first nested feed key.
+    expect(extractDeclaredConnectorKey(src)).toBe("linkedin");
+  });
+
+  test("handles a dotted key and single quotes", () => {
+    const src = `readonly definition = {\n  key: 'linkedin.takeout',\n};`;
+    expect(extractDeclaredConnectorKey(src)).toBe("linkedin.takeout");
+  });
+
+  test("returns null when no definition block is present", () => {
+    expect(extractDeclaredConnectorKey("const x = 1;")).toBeNull();
+  });
+
+  test("is not fooled by an earlier unrelated key: property", () => {
+    const src = [
+      `const other = { key: "not-it" };`,
+      "readonly definition: ConnectorDefinition = {",
+      `  key: "the-real-key",`,
+      "};",
+    ].join("\n");
+    expect(extractDeclaredConnectorKey(src)).toBe("the-real-key");
+  });
+});
+
+describe("locallyDeclaredConnectorKeys — includes declaredKeyHint", () => {
+  test("a connectorFromFile source (key null) contributes its hint to the skip set", () => {
+    const state = {
+      connectors: {
+        definitions: [
+          {
+            key: null,
+            declaredKeyHint: "linkedin",
+            sourcePath: "/abs/linkedin.connector.ts",
+            sourceFile: "linkedin.connector.ts",
+          },
+          { key: "revolut", sourceFile: "revolut.connector.ts" },
+        ],
+        authProfiles: [],
+        connections: [],
+      },
+    } as unknown as DesiredState;
+    const keys = locallyDeclaredConnectorKeys(state);
+    expect(keys.has("linkedin")).toBe(true); // from the hint (key is null)
+    expect(keys.has("revolut")).toBe(true); // from the resolved key
+  });
+});

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -586,12 +586,20 @@ export function validateConnectorState(
 }
 
 // Connector keys declared locally (`*.connector.ts` / `type: connector`).
-// We don't know the key for an auto-discovered `*.connector.ts` until the
-// server compiles it — those have `key === null` — so they can't be in the
-// skip set; their connections are validated only after install (when the key
-// is known and the def is in the refreshed catalog).
+// A `type: connector` doc carries a resolved `key`; a `connectorFromFile()`
+// source has `key === null` (the server compiles it) but a best-effort
+// `declaredKeyHint` parsed statically from the source. Both belong in the
+// schema-skip set: a connection referencing a locally-supplied connector must
+// be validated against the FRESHLY-uploaded definition (post-install), not the
+// stale server schema — otherwise re-applying a connector whose feed set
+// changed rejects the new feeds. The hint only widens this skip set; the
+// authoritative key still comes from the server at install time.
 export function locallyDeclaredConnectorKeys(state: DesiredState): Set<string> {
-  return declaredConnectorKeys(state.connectors.definitions);
+  const keys = declaredConnectorKeys(state.connectors.definitions);
+  for (const def of state.connectors.definitions) {
+    if (def.declaredKeyHint) keys.add(def.declaredKeyHint);
+  }
+  return keys;
 }
 
 // ── Apply executor ─────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -189,6 +189,14 @@ export interface DesiredAuthProfile {
 export interface DesiredConnectorDefinition {
   /** Connector key — diff key (`null` until the server compiles a `.ts`). */
   key: string | null;
+  /**
+   * Best-effort static `definition.key` parsed from `sourceCode` WITHOUT a
+   * compile. Used only to widen the pre-diff schema-skip set so re-applying a
+   * local connector whose feed set changed doesn't validate the connection
+   * against the stale server schema. NOT used for diffing/pruning — `key`
+   * stays the authoritative (server-compiled) value there.
+   */
+  declaredKeyHint?: string;
   /** Local `.ts` path (absolute) — mutually exclusive with `sourceUrl`. */
   sourcePath?: string;
   /** Remote URL — mutually exclusive with `sourcePath`. */
@@ -740,6 +748,26 @@ interface LoadDesiredStateOptions {
  * compiled `definition.key`; reference it by its `defineConnector` class
  * (`connector: myConnector`) to make that match exact.
  */
+/**
+ * Best-effort extraction of a connector's static `definition.key` from its
+ * source WITHOUT compiling it. Connector keys are always plain string literals
+ * (the platform indexes on them statically), declared as the first `key:` in
+ * the `definition` object — e.g. `readonly definition: ConnectorDefinition = {
+ * key: "linkedin", ...`. Returns `null` when the shape can't be matched with
+ * confidence, preserving the prior null-key behavior (the server remains the
+ * authoritative source of the compiled key; this hint only affects which
+ * connectors the pre-diff pass treats as locally-declared).
+ */
+export function extractDeclaredConnectorKey(sourceCode: string): string | null {
+  // Anchor on the `definition` assignment so we don't pick up an unrelated
+  // earlier `key:` (feed keys are nested and come later, after this match).
+  const defIdx = sourceCode.search(/\bdefinition\b\s*(?::[^=]*)?=\s*\{/);
+  if (defIdx === -1) return null;
+  const after = sourceCode.slice(defIdx);
+  const keyMatch = after.match(/\bkey\s*:\s*(["'`])([^"'`]+)\1/);
+  return keyMatch?.[2] ?? null;
+}
+
 function resolveConnectorSources(
   sources: ConnectorSource[],
   cwd: string
@@ -788,7 +816,16 @@ function resolveConnectorSources(
       );
     }
     defs.push({
+      // `key` stays null: the server compiles the source and is the
+      // authoritative source of the real key, and null-ness gates the diff /
+      // prune logic (see diff.ts `hasUnnamedLocalDefs`). We keep a separate
+      // best-effort static hint (no compile) purely to widen the pre-diff
+      // schema-skip set — see `localConnectorKeyHints` in apply-cmd. Without it,
+      // re-applying a connector whose feed set changed (e.g. folding takeout
+      // feeds into `linkedin`) validates the connection against the STALE
+      // server schema and rejects the new feeds.
       key: null,
+      declaredKeyHint: extractDeclaredConnectorKey(sourceCode) ?? undefined,
       sourcePath: abs,
       sourceCode,
       sourceFile: rel.replace(/^\.\//, ""),


### PR DESCRIPTION
## What

`lobu apply` rejected a connection whose local connector's **feed set changed** since it was last installed. Concretely, folding the takeout feeds into the `linkedin` connector (PR #1801) failed at apply with:

```
connection "linkedin-takeout-buremba" references unknown feed "messages" for
connector "linkedin" (known feeds: company_updates, home_feed, jobs)
```

## Root cause

A `connectorFromFile()` source ships with `key: null` — the CLI doesn't compile it, so it can't know the connector's key up front; the server compiles it and returns the real key. But `locallyDeclaredConnectorKeys()` (which feeds `skipSchemaForConnectorKeys`) only collects non-null keys. So a locally-declared connector whose key already exists server-side is **absent** from the skip set, and its connection is validated against the **stale server-registered schema** (the old feed set) instead of being validated post-install against the freshly-uploaded definition.

## Fix

Parse the connector's static `definition.key` from its source **without compiling** — a scoped regex anchored on the `definition` object literal's first `key:` (connector keys are always plain string literals; the platform indexes on them statically). Store it in a new `declaredKeyHint` field and include it in `locallyDeclaredConnectorKeys()`.

Deliberately kept narrow:
- `key` **stays `null`** — the diff/prune logic (`hasUnnamedLocalDefs`, `connectorDefinitionId`) still treats these as server-compiled, so no change to plan verbs, prune notes, or install behavior.
- The hint **only** widens the pre-diff schema-skip set, so the connection is validated against the newly-uploaded definition.
- Extraction is best-effort: `null` when the shape can't be matched confidently, preserving prior behavior.
- The server remains the authoritative source of the compiled key.

## Testing

- New `extract-connector-key.test.ts` — 5 tests incl. "returns the connector key, not the first nested feed key", "not fooled by an earlier unrelated `key:`", dotted/single-quote keys, and the `declaredKeyHint` → skip-set widening.
- Verified the extractor returns `linkedin` from the real merged connector source.
- Full apply suite: **211 pass / 0 fail** (diff/prune/idempotency unchanged). Typecheck + biome clean.

Unblocks #1801's consolidated `linkedin` connection from applying over the existing `linkedin` (v2.0.0) definition.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786122416&installation_id=136316292&pr_number=1803&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1803&signature=1efc2ad2151196bdf0bfb0669a15038d9ea192f8ca8ce040bbf0f6c5a6873941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->