### PR TITLE
fix(slack): authorize claim via linked Slack account, not just the identity graph

### DIFF
--- a/packages/server/src/auth/subject-identities.ts
+++ b/packages/server/src/auth/subject-identities.ts
@@ -148,7 +148,7 @@ export interface LoginAccountForSlackIdentity {
  * same trust level as the access token we already store and use. Mirrors
  * better-auth's own `decodeJwt`. Returns null on any malformation.
  */
-function decodeJwtClaims(jwt: string): Record<string, unknown> | null {
+export function decodeJwtClaims(jwt: string): Record<string, unknown> | null {
 	const seg = jwt.split(".")[1];
 	if (!seg) return null;
 	try {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -22,6 +22,7 @@ import { mcpAuth } from "./auth/middleware";
 import { oauthRoutes } from "./auth/oauth/routes";
 import { findExistingPersonalOrg } from "./auth/personal-org-provisioning";
 import { credentialRoutes } from "./auth/routes";
+import { decodeJwtClaims } from "./auth/subject-identities";
 import { compareWorkerToken } from "./auth/worker-token";
 import { globalCatalogRoutes, orgInstalledRoutes } from "./catalog/routes";
 import { connectionTokenRoutes } from "./connect/connection-token-route";
@@ -1468,7 +1469,7 @@ async function resolveClaimingUserSlackIdentities(
 	// The identity is stored as `T…:U…` (team-scoped). Split into a team id and a
 	// bare `U…` id; the claim guard filters by team (membership) or matches the
 	// bare id against the pending install's installerUserId (Grid).
-	return rows
+	const fromGraph = rows
 		.map((r) => String(r.identifier))
 		.map((id) => {
 			const sep = id.indexOf(":");
@@ -1477,6 +1478,49 @@ async function resolveClaimingUserSlackIdentities(
 				: { teamId: id.slice(0, sep), slackUserId: id.slice(sep + 1) };
 		})
 		.filter((x): x is { teamId: string; slackUserId: string } => x !== null);
+
+	// FALLBACK: the entity-graph `slack_user_id` above is only written once the
+	// user's private-org `$member` provisioning has completed AND their signup
+	// identity landed in a private org (see `persistLoginSlackIdentity` /
+	// `resolveTenantMember`). A brand-new user whose signup org is public — or
+	// whose provisioning hasn't finished — has NO such row, so the graph join is
+	// empty and the claim dead-ends in a "Sign in with Slack" loop even though
+	// they just did. Their linked Better-Auth Slack `account` row is an
+	// independent, always-present proof of the same `U…` (the OIDC subject stored
+	// as `accountId`), captured directly by "Sign in with Slack". Union it in so
+	// claim authority never depends on the identity-graph timing.
+	//
+	// The team is read from the stored `id_token` (`https://slack.com/team_id`)
+	// when present, giving a team-scoped entry for Path 1 (workspace membership);
+	// absent, we still emit the bare `U…` with an empty team, which satisfies the
+	// Grid installer-match (Path 2, `slackUserId === installerUserId`). `U…` ids
+	// are enterprise-global, so the bare match is sound on a Grid.
+	const accountRows = (await sql`
+		SELECT "accountId", "idToken"
+		FROM account
+		WHERE "providerId" = 'slack' AND "userId" = ${userId}
+	`) as Array<{ accountId: string | null; idToken: string | null }>;
+	const fromAccounts = accountRows
+		.map((a) => {
+			const slackUserId = a.accountId?.toUpperCase();
+			if (!slackUserId) return null;
+			const teamId = a.idToken
+				? ((decodeJwtClaims(a.idToken)?.["https://slack.com/team_id"] as
+						| string
+						| undefined) ?? "")
+				: "";
+			return { teamId: teamId.toUpperCase(), slackUserId };
+		})
+		.filter((x): x is { teamId: string; slackUserId: string } => x !== null);
+
+	// De-dup by `team:user` so a user present in both sources isn't doubled.
+	const seen = new Set<string>();
+	return [...fromGraph, ...fromAccounts].filter((x) => {
+		const key = `${x.teamId}:${x.slackUserId}`;
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
 }
 
 /**


### PR DESCRIPTION
## Problem

Installing the hosted Lobu Slack app into a workspace, then opening the claim page (`/connector/slack/connection?ref=<team>`), dead-ends in an infinite **"Sign in with Slack to verify you can connect this connection"** loop. Signing in with Slack succeeds, the page reloads, and asks again — forever. `GET /api/connector/slack/connection/claim-context` returns `403` every time.

Found live on prod while testing an Enterprise Grid install (workspace `LobuBot`, enterprise `E0BDSKL1KJL`).

## Root cause

The claim authority check resolves the claimer's Slack `U…` identities **solely** from the `entity_identities` graph — an `auth:signup`-sourced `slack_user_id` on the user's `$member` entity. That row is only written by `persistLoginSlackIdentity`, and only *after* `resolveTenantMember` finds the user's **private** personal org (`o.visibility = 'private'`).

A user whose signup identity lives in a **public** org (or whose personal-org provisioning hasn't completed) has no such row. So:

- `resolveClaimingUserSlackIdentities` returns `[]`
- `authorizeSlackClaim` matches neither Path 1 (workspace membership) nor Path 2 (Grid installer-match)
- → `signin_required` → `403` → the loop, even though the user just signed in with Slack.

Verified against prod: the affected user is a member of 8 orgs but has an `auth:signup` `auth_user_id` in only one (`market`, which is `public` → filtered out), and their only `slack_user_id` is `connector:slack`-sourced (from the ACL graph), which the resolver's `auth:signup`-gated join can't use.

## Fix

Union in the user's linked Better-Auth Slack **`account`** rows (`providerId='slack'`, `accountId` = the OIDC `U…` subject) as an independent identity source, captured directly at "Sign in with Slack" — no dependence on identity-graph provisioning timing.

- Team id decoded from the stored `id_token` (`https://slack.com/team_id`) when present → team-scoped entry for **Path 1** (workspace membership).
- Bare enterprise-global `U…` always satisfies the **Path 2** Grid installer-match.

Authority gates are unchanged: the fallback supplies *identity* only. Path 1 still runs the `usersInfo` admin/owner check; Path 2 stays strictly Grid-gated (`pending.enterpriseId` required) and matches the installer id.

## Validation

- Logic validated against real prod data: the new `account` query returns the installer's `U…` for the stuck user.
- Existing authorize tests: 9/9 pass. `make review` build/typecheck/unit (76) + integration (105) all green.
- Real end-to-end re-run on prod pending after deploy.

## Follow-ups (not in this PR, one-concern)

- Pre-Grid-fix active installs (`LobuDemo`, `LobuSandbox`) have no `enterprise_id` persisted → Grid sibling-workspace events won't route. Backfill needed.
- Multiple active installs per enterprise make the sole-install enterprise fallback ambiguous — routing design gap to revisit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786123446&installation_id=136316292&pr_number=1804&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1804&signature=83cbe1e68ff1b0445cfb39973dda37398b2267ca85280331a83709b1bf7d31c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->