### PR TITLE
feat(twitter): identity attributions for the takeout connector

### DIFF
--- a/examples/personal-agent/__tests__/twitter-takeout.connector.test.ts
+++ b/examples/personal-agent/__tests__/twitter-takeout.connector.test.ts
@@ -115,6 +115,49 @@ describe("TwitterTakeoutConnector identity attributions", () => {
       });
     }
   });
+
+  test("auto-create is gated on the numeric id (no handle-only forks)", () => {
+    // A handle-only row (no numeric id) must MATCH by handle but never MINT —
+    // a person with no primary x_user_id can't merge with a later live-X event
+    // that carries the real id, so minting one forks a permanent duplicate.
+    const def = new TwitterTakeoutConnector().definition;
+
+    const reply = def.feeds.tweets.eventKinds.reply.attributions[0];
+    expect(reply.autoCreate).toBe(true);
+    expect(reply.target.createWhen).toEqual({
+      path: "metadata.in_reply_to_user_id",
+      exists: true,
+    });
+
+    for (const feed of ["followers", "following"] as const) {
+      const kind = feed === "followers" ? "follower" : "following";
+      const attr = def.feeds[feed].eventKinds[kind].attributions[0];
+      expect(attr.target.createWhen).toEqual({
+        path: "metadata.account_id",
+        exists: true,
+      });
+    }
+  });
+
+  test("a follow row with only a userLink (no accountId) still emits, gated off mint", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "x-takeout-"));
+    const dataDir = path.join(dir, "data");
+    mkdirSync(dataDir);
+    writeFileSync(
+      path.join(dataDir, "follower.js"),
+      `window.YTD.follower.part0 = ${JSON.stringify([
+        { follower: { userLink: "https://twitter.com/handleonly" } },
+      ])}`
+    );
+
+    const connector = new TwitterTakeoutConnector();
+    const events = (connector as any).readFollowEvents(dataDir, "follower");
+    expect(events).toHaveLength(1);
+    const [event] = events;
+    // No account_id -> createWhen(exists) is false -> matches by handle only.
+    expect(resolvePath(event, "metadata.account_id")).toBeUndefined();
+    expect(resolvePath(event, "metadata.handle")).toBe("handleonly");
+  });
 });
 
 describe("TwitterTakeoutConnector emits metadata the attributions resolve", () => {

--- a/examples/personal-agent/__tests__/twitter-takeout.connector.test.ts
+++ b/examples/personal-agent/__tests__/twitter-takeout.connector.test.ts
@@ -1,0 +1,190 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { connectorSdkMock } from "./connector-sdk.mock";
+
+// Stub @lobu/connector-sdk (it pulls in playwright) so the connector imports
+// without the browser stack. Shared superset — see connector-sdk.mock.ts.
+mock.module("@lobu/connector-sdk", connectorSdkMock);
+
+let TwitterTakeoutConnector: any;
+let normalizeXUserId: any;
+let normalizeXHandle: any;
+let handleFromUserLink: any;
+let X_IDENTITY: any;
+
+beforeAll(async () => {
+  const connectorMod = await import("../twitter-takeout.connector");
+  TwitterTakeoutConnector = connectorMod.default;
+  const identityMod = await import("../x-identity");
+  normalizeXUserId = identityMod.normalizeXUserId;
+  normalizeXHandle = identityMod.normalizeXHandle;
+  handleFromUserLink = identityMod.handleFromUserLink;
+  X_IDENTITY = identityMod.X_IDENTITY;
+});
+
+describe("x-identity normalization", () => {
+  test("normalizeXUserId keeps digits, strips leading zeros, rejects junk", () => {
+    expect(normalizeXUserId("44196397")).toBe("44196397");
+    expect(normalizeXUserId("007")).toBe("7");
+    expect(normalizeXUserId(" 123 ")).toBe("123");
+    expect(normalizeXUserId("abc")).toBe(null);
+    expect(normalizeXUserId("")).toBe(null);
+    expect(normalizeXUserId(null)).toBe(null);
+    expect(normalizeXUserId(undefined)).toBe(null);
+  });
+
+  test("normalizeXHandle strips @, lowercases, enforces 1–15 [a-z0-9_]", () => {
+    expect(normalizeXHandle("@Jack")).toBe("jack");
+    expect(normalizeXHandle("elonmusk")).toBe("elonmusk");
+    expect(normalizeXHandle("a".repeat(16))).toBe(null);
+    expect(normalizeXHandle("has space")).toBe(null);
+    expect(normalizeXHandle("")).toBe(null);
+  });
+
+  test("handleFromUserLink recovers the normalized handle from a profile link", () => {
+    expect(handleFromUserLink("https://twitter.com/Jack")).toBe("jack");
+    expect(handleFromUserLink("https://x.com/elonmusk?ref=1")).toBe("elonmusk");
+    expect(handleFromUserLink("not-a-link")).toBe(null);
+    expect(handleFromUserLink(null)).toBe(null);
+  });
+
+  test("namespaces match the built-in @lobu/connectors x-identity verbatim", () => {
+    // The resolver matches on the namespace STRING across the connector/
+    // connection boundary — these MUST equal the built-in values or takeout
+    // people will never fuse with the live X connector's people.
+    expect(X_IDENTITY.USER_ID).toBe("x_user_id");
+    expect(X_IDENTITY.HANDLE).toBe("x_handle");
+  });
+});
+
+describe("TwitterTakeoutConnector identity attributions", () => {
+  test("reply targets attribute `about` a person keyed primary on x_user_id", () => {
+    const def = new TwitterTakeoutConnector().definition;
+    const attr = def.feeds.tweets.eventKinds.reply.attributions?.[0];
+    expect(attr).toBeDefined();
+    expect(attr.role).toBe("about");
+    expect(attr.autoCreate).toBe(true);
+    expect(attr.target.entityType).toBe("person");
+
+    const uid = attr.target.identities.find(
+      (i: { namespace: string }) => i.namespace === X_IDENTITY.USER_ID
+    );
+    expect(uid).toMatchObject({
+      namespace: "x_user_id",
+      eventPath: "metadata.in_reply_to_user_id",
+      primary: true,
+    });
+    const handle = attr.target.identities.find(
+      (i: { namespace: string }) => i.namespace === X_IDENTITY.HANDLE
+    );
+    expect(handle).toMatchObject({
+      namespace: "x_handle",
+      eventPath: "metadata.in_reply_to_screen_name",
+    });
+    // The handle is a soft key — only the numeric id is primary.
+    expect(handle.primary).toBeUndefined();
+  });
+
+  test("DMs attribute BOTH parties match-only (never mint from a raw id)", () => {
+    const def = new TwitterTakeoutConnector().definition;
+    const rules = def.feeds.messages.eventKinds.dm_message.attributions;
+    expect(rules).toHaveLength(2);
+    for (const rule of rules) {
+      expect(rule.autoCreate).toBe(false);
+      expect(rule.target.identities[0].namespace).toBe("x_user_id");
+      expect(rule.target.identities[0].matchOnly).toBe(true);
+    }
+    expect(rules[0].target.identities[0].eventPath).toBe("metadata.sender_id");
+    expect(rules[1].target.identities[0].eventPath).toBe(
+      "metadata.recipient_id"
+    );
+  });
+
+  test("followers/following mint a person keyed primary on x_user_id", () => {
+    const def = new TwitterTakeoutConnector().definition;
+    for (const feed of ["followers", "following"] as const) {
+      const kind = feed === "followers" ? "follower" : "following";
+      const attr = def.feeds[feed].eventKinds[kind].attributions?.[0];
+      expect(attr.autoCreate).toBe(true);
+      expect(attr.target.identities[0]).toMatchObject({
+        namespace: "x_user_id",
+        eventPath: "metadata.account_id",
+        primary: true,
+      });
+    }
+  });
+});
+
+describe("TwitterTakeoutConnector emits metadata the attributions resolve", () => {
+  test("a reply row emits normalized handle + numeric id the identity keys on", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "x-takeout-"));
+    const dataDir = path.join(dir, "data");
+    mkdirSync(dataDir);
+    // Twitter archive files are `window.YTD.tweets.part0 = [ ... ]` JS.
+    writeFileSync(
+      path.join(dataDir, "tweets.js"),
+      `window.YTD.tweets.part0 = ${JSON.stringify([
+        {
+          tweet: {
+            id_str: "1700000000000000001",
+            full_text: "@Jack hey there",
+            created_at: "Wed Oct 04 12:00:00 +0000 2023",
+            in_reply_to_status_id_str: "1699000000000000000",
+            in_reply_to_user_id_str: "12",
+            in_reply_to_screen_name: "Jack",
+          },
+        },
+      ])}`
+    );
+
+    const connector = new TwitterTakeoutConnector();
+    const events = (connector as any).readTweetEvents(dataDir);
+    expect(events).toHaveLength(1);
+    const [event] = events;
+    expect(event.origin_type).toBe("reply");
+
+    const attr =
+      connector.definition.feeds.tweets.eventKinds.reply.attributions[0];
+    for (const identity of attr.target.identities) {
+      expect(resolvePath(event, identity.eventPath)).toBeTruthy();
+    }
+    // Handle is emitted already-canonical (server won't run the normalizer).
+    expect(resolvePath(event, "metadata.in_reply_to_screen_name")).toBe("jack");
+    // Raw display value preserved separately.
+    expect(resolvePath(event, "metadata.in_reply_to_screen_name_raw")).toBe(
+      "Jack"
+    );
+    expect(resolvePath(event, "metadata.in_reply_to_user_id")).toBe("12");
+  });
+
+  test("a following row emits account_id + handle the identity keys on", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "x-takeout-"));
+    const dataDir = path.join(dir, "data");
+    mkdirSync(dataDir);
+    writeFileSync(
+      path.join(dataDir, "following.js"),
+      `window.YTD.following.part0 = ${JSON.stringify([
+        {
+          following: {
+            accountId: "44196397",
+            userLink: "https://twitter.com/elonmusk",
+          },
+        },
+      ])}`
+    );
+
+    const connector = new TwitterTakeoutConnector();
+    const events = (connector as any).readFollowEvents(dataDir, "following");
+    expect(events).toHaveLength(1);
+    const [event] = events;
+    expect(event.origin_type).toBe("following");
+    expect(resolvePath(event, "metadata.account_id")).toBe("44196397");
+    expect(resolvePath(event, "metadata.handle")).toBe("elonmusk");
+  });
+});
+
+function resolvePath(obj: any, dotPath: string): unknown {
+  return dotPath.split(".").reduce((acc, key) => acc?.[key], obj);
+}

--- a/examples/personal-agent/twitter-takeout.connector.ts
+++ b/examples/personal-agent/twitter-takeout.connector.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import {
   type ConnectorDefinition,
   ConnectorRuntime,
+  type EventAttributionRule,
   type EventEnvelope,
   type SyncContext,
   type SyncResult,
@@ -16,6 +17,121 @@ import {
   takeBatch,
   twitterSnowflakeDate,
 } from "./takeout-utils.ts";
+import {
+  handleFromUserLink,
+  normalizeXHandle,
+  X_IDENTITY,
+} from "./x-identity.ts";
+
+/**
+ * A tweet the user *replied to* names the person they replied to via
+ * `in_reply_to_user_id` (immutable numeric id) + `in_reply_to_screen_name`
+ * (mutable handle). Emit it as an `about` attribution keyed on the SAME
+ * `x_user_id`/`x_handle` namespaces the live X connector uses, so a reply
+ * target consolidates onto the person the live connector already tracks —
+ * across the connector/connection boundary. `autoCreate` mints a person for
+ * reply targets not yet seen (they are, by definition, people the user engaged).
+ */
+const X_REPLY_TARGET_ATTRIBUTIONS: EventAttributionRule[] = [
+  {
+    role: "about",
+    autoCreate: true,
+    target: {
+      entityType: "person",
+      titlePath: "metadata.in_reply_to_screen_name",
+      identities: [
+        {
+          namespace: X_IDENTITY.USER_ID,
+          eventPath: "metadata.in_reply_to_user_id",
+          primary: true,
+        },
+        {
+          namespace: X_IDENTITY.HANDLE,
+          eventPath: "metadata.in_reply_to_screen_name",
+        },
+      ],
+    },
+    traits: {
+      x_handle: {
+        eventPath: "metadata.in_reply_to_screen_name",
+        behavior: "prefer_non_empty",
+      },
+      last_x_interaction_at: {
+        eventPath: "occurred_at",
+        behavior: "overwrite",
+      },
+    },
+  },
+];
+
+/**
+ * A DM names both parties by immutable numeric id (`sender_id`/`recipient_id`)
+ * but a takeout gives no way to tell which id is the connected account itself.
+ * So attribute BOTH ids `matchOnly` (accrete DM history onto an already-known
+ * person, but never MINT one from a raw numeric id — that would risk minting a
+ * "person" for the user's own account). No handle is present in the DM archive.
+ */
+const X_DM_PARTY_ATTRIBUTIONS: EventAttributionRule[] = [
+  {
+    role: "about",
+    autoCreate: false,
+    target: {
+      entityType: "person",
+      identities: [
+        {
+          namespace: X_IDENTITY.USER_ID,
+          eventPath: "metadata.sender_id",
+          matchOnly: true,
+        },
+      ],
+    },
+    traits: {
+      last_x_dm_at: { eventPath: "occurred_at", behavior: "overwrite" },
+    },
+  },
+  {
+    role: "about",
+    autoCreate: false,
+    target: {
+      entityType: "person",
+      identities: [
+        {
+          namespace: X_IDENTITY.USER_ID,
+          eventPath: "metadata.recipient_id",
+          matchOnly: true,
+        },
+      ],
+    },
+  },
+];
+
+/**
+ * Followers/following name a person by immutable numeric `account_id` +
+ * (optional) `handle` recovered from the profile link. These ARE the user's
+ * network, so `autoCreate` mints a person per row, keyed primary on `x_user_id`
+ * so they fuse with the live connector's people.
+ */
+const X_FOLLOW_ATTRIBUTIONS: EventAttributionRule[] = [
+  {
+    role: "about",
+    autoCreate: true,
+    target: {
+      entityType: "person",
+      titlePath: "metadata.handle",
+      identities: [
+        {
+          namespace: X_IDENTITY.USER_ID,
+          eventPath: "metadata.account_id",
+          primary: true,
+        },
+        { namespace: X_IDENTITY.HANDLE, eventPath: "metadata.handle" },
+      ],
+    },
+    traits: {
+      x_handle: { eventPath: "metadata.handle", behavior: "prefer_non_empty" },
+    },
+  },
+];
 
 interface TwitterTakeoutCheckpoint {
   last_tweets_timestamp?: string;
@@ -91,6 +207,12 @@ export default class TwitterTakeoutConnector extends ConnectorRuntime<
         configSchema: localTakeoutSchema(
           "Path to the X/Twitter archive folder containing data/tweets.js."
         ),
+        eventKinds: {
+          reply: {
+            description: "A reply the user posted to another account",
+            attributions: X_REPLY_TARGET_ATTRIBUTIONS,
+          },
+        },
       },
       messages: {
         key: "messages",
@@ -98,6 +220,12 @@ export default class TwitterTakeoutConnector extends ConnectorRuntime<
         configSchema: localTakeoutSchema(
           "Path to the X/Twitter archive folder containing DM files."
         ),
+        eventKinds: {
+          dm_message: {
+            description: "A direct message between the user and a counterparty",
+            attributions: X_DM_PARTY_ATTRIBUTIONS,
+          },
+        },
       },
       likes: {
         key: "likes",
@@ -112,6 +240,12 @@ export default class TwitterTakeoutConnector extends ConnectorRuntime<
         configSchema: localTakeoutSchema(
           "Path to the X/Twitter archive folder containing data/follower.js."
         ),
+        eventKinds: {
+          follower: {
+            description: "An account that follows the user",
+            attributions: X_FOLLOW_ATTRIBUTIONS,
+          },
+        },
       },
       following: {
         key: "following",
@@ -119,6 +253,12 @@ export default class TwitterTakeoutConnector extends ConnectorRuntime<
         configSchema: localTakeoutSchema(
           "Path to the X/Twitter archive folder containing data/following.js."
         ),
+        eventKinds: {
+          following: {
+            description: "An account the user follows",
+            attributions: X_FOLLOW_ATTRIBUTIONS,
+          },
+        },
       },
     },
   };
@@ -231,7 +371,14 @@ export default class TwitterTakeoutConnector extends ConnectorRuntime<
               entities: tweet.entities,
               in_reply_to_status_id: tweet.in_reply_to_status_id_str,
               in_reply_to_user_id: tweet.in_reply_to_user_id_str,
-              in_reply_to_screen_name: tweet.in_reply_to_screen_name,
+              // Normalized at emit time (lowercased handle): the server does not
+              // run this example connector's identity normalizer, so the value
+              // must already be in canonical `x_handle` form to match the live
+              // X connector's people. Raw display name kept separately.
+              in_reply_to_screen_name: normalizeXHandle(
+                tweet.in_reply_to_screen_name
+              ),
+              in_reply_to_screen_name_raw: tweet.in_reply_to_screen_name,
             },
           },
         ];
@@ -316,7 +463,7 @@ export default class TwitterTakeoutConnector extends ConnectorRuntime<
         const item = kind === "follower" ? record.follower : record.following;
         if (!item?.accountId && !item?.userLink) return [];
         const occurredAt = new Date("1970-01-02T00:00:00.000Z");
-        const handle = item.userLink?.match(/twitter\.com\/([^/?#]+)/)?.[1];
+        const handle = handleFromUserLink(item.userLink);
         return [
           {
             origin_id: stableId(`x_${kind}`, [item.accountId, item.userLink]),

--- a/examples/personal-agent/twitter-takeout.connector.ts
+++ b/examples/personal-agent/twitter-takeout.connector.ts
@@ -29,8 +29,14 @@ import {
  * (mutable handle). Emit it as an `about` attribution keyed on the SAME
  * `x_user_id`/`x_handle` namespaces the live X connector uses, so a reply
  * target consolidates onto the person the live connector already tracks —
- * across the connector/connection boundary. `autoCreate` mints a person for
- * reply targets not yet seen (they are, by definition, people the user engaged).
+ * across the connector/connection boundary.
+ *
+ * `createWhen: { in_reply_to_user_id exists }` gates minting on the IMMUTABLE
+ * numeric id: a reply whose archive row carries only a handle (no user id)
+ * matches an existing person by `x_handle` but NEVER auto-creates. Otherwise a
+ * handle-only person would fork — a later live-X event carrying the real
+ * primary `x_user_id` won't merge into a person that has no primary id, so the
+ * two would coexist as duplicates. Mint only when we have the durable key.
  */
 const X_REPLY_TARGET_ATTRIBUTIONS: EventAttributionRule[] = [
   {
@@ -38,6 +44,7 @@ const X_REPLY_TARGET_ATTRIBUTIONS: EventAttributionRule[] = [
     autoCreate: true,
     target: {
       entityType: "person",
+      createWhen: { path: "metadata.in_reply_to_user_id", exists: true },
       titlePath: "metadata.in_reply_to_screen_name",
       identities: [
         {
@@ -108,8 +115,13 @@ const X_DM_PARTY_ATTRIBUTIONS: EventAttributionRule[] = [
 /**
  * Followers/following name a person by immutable numeric `account_id` +
  * (optional) `handle` recovered from the profile link. These ARE the user's
- * network, so `autoCreate` mints a person per row, keyed primary on `x_user_id`
- * so they fuse with the live connector's people.
+ * network, so `autoCreate` mints a person per row keyed primary on `x_user_id`
+ * so they fuse with the live connector's people — but ONLY when the numeric
+ * `account_id` is present. A follow row that carries only a `userLink`/handle
+ * (no account id) matches an existing person by `x_handle` but never mints:
+ * a handle-only person can't merge with a later live-X event that has the real
+ * primary `x_user_id`, so minting one would fork a duplicate. `createWhen`
+ * gates the mint on the durable key.
  */
 const X_FOLLOW_ATTRIBUTIONS: EventAttributionRule[] = [
   {
@@ -117,6 +129,7 @@ const X_FOLLOW_ATTRIBUTIONS: EventAttributionRule[] = [
     autoCreate: true,
     target: {
       entityType: "person",
+      createWhen: { path: "metadata.account_id", exists: true },
       titlePath: "metadata.handle",
       identities: [
         {

--- a/examples/personal-agent/x-identity.ts
+++ b/examples/personal-agent/x-identity.ts
@@ -1,0 +1,86 @@
+/**
+ * X (Twitter) connector identity namespaces and normalization.
+ *
+ * Single source of truth for the X identity vocabulary in the example package.
+ * The takeout connector (twitter-takeout.connector.ts) imports from here, and a
+ * server that wires the example package in would assemble `xIdentityModule` into
+ * its ingest normalizer chain — mirroring @lobu/connectors/x-identity.ts.
+ *
+ * The namespace string values MUST match the built-in @lobu/connectors
+ * x-identity.ts verbatim (`x_user_id`, `x_handle`): the resolver matches on the
+ * namespace STRING, not the imported symbol, so a takeout event keyed on
+ * `x_user_id` consolidates onto the same `person` the live X connector links —
+ * even though the two connectors live in different packages and connections.
+ *
+ * `x_user_id` (immutable numeric id) is the PRIMARY key: it survives a @handle
+ * change, so the same person never forks. `x_handle` is a mutable secondary
+ * claim (not recall-indexed).
+ */
+
+import type { ConnectorIdentityModule } from "./linkedin-identity.ts";
+
+/** Connector-owned identity namespaces (not SDK-global). */
+export const X_IDENTITY = {
+  /** Immutable X/Twitter numeric user id — primary namespace for attribution. */
+  USER_ID: "x_user_id",
+  /** Mutable/reusable @handle — secondary claim, not recall-indexed. */
+  HANDLE: "x_handle",
+} as const;
+
+export type XIdentityNamespace = (typeof X_IDENTITY)[keyof typeof X_IDENTITY];
+
+/** Immutable numeric X user id: digits only, leading zeros stripped. */
+export function normalizeXUserId(
+  raw: string | null | undefined
+): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  return trimmed.replace(/^0+(?=\d)/, "");
+}
+
+/** Mutable @handle: strip leading @, lowercase, 1–15 [a-z0-9_]. */
+export function normalizeXHandle(
+  raw: string | null | undefined
+): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim().replace(/^@+/, "").toLowerCase();
+  if (!trimmed || !/^[a-z0-9_]{1,15}$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+/** Pull a normalized @handle out of a `twitter.com/<handle>` profile link. */
+export function handleFromUserLink(
+  userLink: string | null | undefined
+): string | null {
+  if (typeof userLink !== "string") return null;
+  const match = userLink.match(/(?:twitter|x)\.com\/([^/?#]+)/i);
+  return match ? normalizeXHandle(match[1]) : null;
+}
+
+/**
+ * Normalize an X identity namespace value. Returns `undefined` when the
+ * namespace is not X-owned (caller falls back to generic hygiene).
+ */
+export function normalizeXIdentityValue(
+  namespace: string,
+  raw: string
+): string | null | undefined {
+  switch (namespace) {
+    case X_IDENTITY.USER_ID:
+      return normalizeXUserId(raw);
+    case X_IDENTITY.HANDLE:
+      return normalizeXHandle(raw);
+    default:
+      return undefined;
+  }
+}
+
+/** The X connector's contribution to the server identity wiring. */
+export const xIdentityModule: ConnectorIdentityModule = {
+  key: "x",
+  // Only the immutable user id is recall-indexed; x_handle is a mutable
+  // secondary claim (see idx_events_metadata_x_user_id — no handle index).
+  recallNamespaces: [X_IDENTITY.USER_ID],
+  normalize: normalizeXIdentityValue,
+};


### PR DESCRIPTION
## What

The Twitter/X **takeout** connector emitted **no identity attributions at all** — so its tweets/DMs/follows landed as orphan events that never populated the `person` graph. This adds attributions so takeout data consolidates onto the **live X connector's people**, across the connector/connection boundary.

This is the same identity-graph consolidation the LinkedIn merge (#1801) achieved via slug — but here keyed on the immutable numeric `x_user_id` (which the live X connector already marks **primary**), so a @handle change can't fork the entity. That's strictly stronger than LinkedIn's slug (LinkedIn takeout has no stable member id; Twitter does).

## Why not fold connectors like LinkedIn?

LinkedIn's live connector was file-based (examples/), so that merge stayed self-contained. The X live connector is a 2070-line **built-in** in `packages/connectors/src/x.ts` (needs a server redeploy to change). Duplicating it file-based risks drift; folding takeout into it needs a redeploy I can't e2e-verify here. The high-value, low-risk move is to make the takeout populate the graph via shared identity namespaces — the "both live and backfill" outcome is achieved through the identity graph, not connector-file merging. Connector-file merge can follow once we decide the built-in-vs-file shape.

## Attributions added

| feed | role | autoCreate | key |
|---|---|---|---|
| tweets → `reply` | about | yes | `in_reply_to_user_id` (primary) + `in_reply_to_screen_name` |
| messages → `dm_message` | about ×2 | no (match-only) | `sender_id`, `recipient_id` — never mint a person from a raw id (avoids minting the user's own account) |
| followers/following | about | yes | `account_id` (primary) + `handle` |

A sibling `examples/personal-agent/x-identity.ts` mirrors `@lobu/connectors/x-identity.ts` (the example package depends only on `connector-sdk`, so the vocabulary is redeclared — namespace **strings** match verbatim, which is what the resolver keys on). The reply handle is normalized at emit time since the server won't run the example connector's normalizer; the raw display value is preserved as `in_reply_to_screen_name_raw`.

## Tests

9 new tests (identity normalization, attribution shape, emit round-trip). Full `examples/personal-agent` suite: **55/55 green**. Project `tsc --noEmit` clean (pre-commit).

Refs #1801 (LinkedIn merge, same pattern).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786123570&installation_id=136316292&pr_number=1805&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1805&signature=d4d9c892473ca9c3d8236fb7c81ecb7b009772144c66bca15d203b7fb459ab39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved X/Twitter identity handling in the personal agent example, including cleaner matching for user IDs, handles, replies, DMs, followers, and following activity.
  * Reply, DM, and follow events now map more consistently to the right person records, with raw and normalized values preserved where useful.

* **Tests**
  * Added coverage for identity normalization and event attribution behavior to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->