### PR TITLE
feat(linkedin): emit primary member_id from the live post author

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -564,6 +564,14 @@ describe("normalizeLinkedInMemberId", () => {
     // A slash-bearing URL is not a bare id token.
     expect(normalizeLinkedInMemberId("https://x.com/in/foo")).toBe(null);
   });
+
+  test("rejects a NON-person URN so a company id never becomes a person id", () => {
+    // The whole point: a company actor's urn must not normalize to a person id.
+    expect(normalizeLinkedInMemberId("urn:li:fsd_company:99")).toBe(null);
+    expect(normalizeLinkedInMemberId("urn:li:organization:123")).toBe(null);
+    // A bare colon-string that isn't a person URN is rejected too.
+    expect(normalizeLinkedInMemberId("foo:bar")).toBe(null);
+  });
 });
 
 describe("LinkedInConnector live post author identity (member id)", () => {
@@ -640,17 +648,15 @@ describe("LinkedInConnector live post author identity (member id)", () => {
     expect(post.authorSlug).toBeUndefined();
   });
 
-  test("company_updates post attribution keys primary on member id, mint-gated", () => {
+  test("company_updates post attribution matches member id + slug equal-weight (neither primary)", () => {
     const def = new LinkedInConnector().definition;
     const attr = def.feeds.company_updates.eventKinds.post.attributions?.[0];
     expect(attr).toBeDefined();
     expect(attr.role).toBe("authored_by");
     expect(attr.autoCreate).toBe(true);
-    // Mint only when the durable member id is present (no slug-only forks).
-    expect(attr.target.createWhen).toEqual({
-      path: "metadata.author_member_id",
-      exists: true,
-    });
+    // NO createWhen gate: a member_id-primary mint-gate would fork the existing
+    // slug-keyed takeout person. Equal-weight union binds them instead.
+    expect(attr.target.createWhen).toBeUndefined();
 
     const memberId = attr.target.identities.find(
       (i: { namespace: string }) => i.namespace === LINKEDIN_IDENTITY.MEMBER_ID
@@ -658,17 +664,48 @@ describe("LinkedInConnector live post author identity (member id)", () => {
     expect(memberId).toMatchObject({
       namespace: "linkedin_member_id",
       eventPath: "metadata.author_member_id",
-      primary: true,
     });
+    // CRITICAL: member_id is NOT primary — a primary that misses would mint a
+    // new person and fork the takeout-first slug person.
+    expect(memberId.primary).toBeUndefined();
+
     const slug = attr.target.identities.find(
       (i: { namespace: string }) => i.namespace === LINKEDIN_IDENTITY.SLUG
     );
-    // Slug is the soft bridge to takeout people — present but NOT primary.
     expect(slug).toMatchObject({
       namespace: "linkedin_slug",
       eventPath: "metadata.author_linkedin_slug",
     });
     expect(slug.primary).toBeUndefined();
+  });
+
+  test("parseCompanyUpdates reads the miniProfile urn as a bare string too", () => {
+    // Voyager sometimes gives `miniProfile` as the urn STRING itself (not a ref
+    // or an object). Codex flagged this shape as previously missed.
+    const json = {
+      included: [
+        {
+          entityUrn: "urn:li:actor:3",
+          name: { text: "Bare Shape" },
+          miniProfile: "urn:li:fsd_profile:ACoAABbareXYZ",
+        },
+      ],
+      data: {
+        data: {
+          feed: {
+            "*elements": [
+              {
+                entityUrn: "urn:li:activity:3",
+                commentary: { text: { text: "post body" } },
+                "*actor": "urn:li:actor:3",
+              },
+            ],
+          },
+        },
+      },
+    };
+    const [post] = parseCompanyUpdates("", json);
+    expect(post.authorMemberId).toBe("ACoAABbareXYZ");
   });
 });
 

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -13,7 +13,9 @@ let buildHomeFeedEvents: any;
 let parseHomeFeedAuthor: any;
 let isHomeFeedNoise: any;
 let filterPostsSinceCheckpoint: any;
+let parseCompanyUpdates: any;
 let normalizeLinkedInSlug: any;
+let normalizeLinkedInMemberId: any;
 let LINKEDIN_IDENTITY: any;
 
 beforeAll(async () => {
@@ -23,8 +25,10 @@ beforeAll(async () => {
   parseHomeFeedAuthor = mod.parseHomeFeedAuthor;
   isHomeFeedNoise = mod.isHomeFeedNoise;
   filterPostsSinceCheckpoint = mod.filterPostsSinceCheckpoint;
+  parseCompanyUpdates = mod.parseCompanyUpdates;
   const identityMod = await import("../linkedin-identity");
   normalizeLinkedInSlug = identityMod.normalizeLinkedInSlug;
+  normalizeLinkedInMemberId = identityMod.normalizeLinkedInMemberId;
   LINKEDIN_IDENTITY = identityMod.LINKEDIN_IDENTITY;
 });
 
@@ -541,6 +545,130 @@ describe("LinkedInConnector takeout identity attributions", () => {
     // The definition exposes the renamed feed key, not the old "jobs" takeout.
     expect(connector.definition.feeds.applied_jobs).toBeDefined();
     expect(connector.definition.feeds.applied_jobs.name).toBe("Applied Jobs");
+  });
+});
+
+describe("normalizeLinkedInMemberId", () => {
+  test("reduces fsd_profile / member URNs and bare ids to the id token", () => {
+    expect(normalizeLinkedInMemberId("urn:li:fsd_profile:ACoAAB1234xyz")).toBe(
+      "ACoAAB1234xyz"
+    );
+    expect(normalizeLinkedInMemberId("urn:li:member:987654")).toBe("987654");
+    expect(normalizeLinkedInMemberId("ACoAAB1234xyz")).toBe("ACoAAB1234xyz");
+  });
+
+  test("rejects empty / non-id junk", () => {
+    expect(normalizeLinkedInMemberId("")).toBe(null);
+    expect(normalizeLinkedInMemberId(null)).toBe(null);
+    expect(normalizeLinkedInMemberId(undefined)).toBe(null);
+    // A slash-bearing URL is not a bare id token.
+    expect(normalizeLinkedInMemberId("https://x.com/in/foo")).toBe(null);
+  });
+});
+
+describe("LinkedInConnector live post author identity (member id)", () => {
+  test("parseCompanyUpdates extracts author member id + slug from the Voyager actor", () => {
+    // Minimal Voyager-shaped payload: an element referencing an actor in
+    // `included`, the actor carrying an fsd_profile urn + a /in/ profile URL.
+    const json = {
+      included: [
+        {
+          entityUrn: "urn:li:actor:1",
+          name: { text: "Jane Doe" },
+          description: { text: "CEO at Acme" },
+          "*miniProfile": "urn:li:fsd_profile:ACoAABcdef123",
+          navigationContext: {
+            actionTarget: "https://www.linkedin.com/in/Jane-Doe/",
+          },
+        },
+      ],
+      data: {
+        data: {
+          feed: {
+            "*elements": [
+              {
+                entityUrn: "urn:li:activity:7200000000000000000",
+                "*commentary": null,
+                commentary: { text: { text: "Hello world" } },
+                "*actor": "urn:li:actor:1",
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const posts = parseCompanyUpdates("", json);
+    expect(posts).toHaveLength(1);
+    const [post] = posts;
+    expect(post.author).toBe("Jane Doe");
+    expect(post.authorMemberId).toBe("ACoAABcdef123");
+    // The case-variant /in/ URL collapses to the canonical slug.
+    expect(post.authorSlug).toBe("jane-doe");
+  });
+
+  test("a company-authored post (no member urn) yields no member id", () => {
+    const json = {
+      included: [
+        {
+          entityUrn: "urn:li:actor:2",
+          name: { text: "Acme Inc" },
+          // company actor: a fsd_company urn, not fsd_profile
+          "*miniProfile": "urn:li:fsd_company:99",
+          navigationContext: {
+            actionTarget: "https://www.linkedin.com/company/acme/",
+          },
+        },
+      ],
+      data: {
+        data: {
+          feed: {
+            "*elements": [
+              {
+                entityUrn: "urn:li:activity:1",
+                commentary: { text: { text: "We are hiring" } },
+                "*actor": "urn:li:actor:2",
+              },
+            ],
+          },
+        },
+      },
+    };
+    const [post] = parseCompanyUpdates("", json);
+    expect(post.authorMemberId).toBeUndefined();
+    // /company/ URL is not a person slug.
+    expect(post.authorSlug).toBeUndefined();
+  });
+
+  test("company_updates post attribution keys primary on member id, mint-gated", () => {
+    const def = new LinkedInConnector().definition;
+    const attr = def.feeds.company_updates.eventKinds.post.attributions?.[0];
+    expect(attr).toBeDefined();
+    expect(attr.role).toBe("authored_by");
+    expect(attr.autoCreate).toBe(true);
+    // Mint only when the durable member id is present (no slug-only forks).
+    expect(attr.target.createWhen).toEqual({
+      path: "metadata.author_member_id",
+      exists: true,
+    });
+
+    const memberId = attr.target.identities.find(
+      (i: { namespace: string }) => i.namespace === LINKEDIN_IDENTITY.MEMBER_ID
+    );
+    expect(memberId).toMatchObject({
+      namespace: "linkedin_member_id",
+      eventPath: "metadata.author_member_id",
+      primary: true,
+    });
+    const slug = attr.target.identities.find(
+      (i: { namespace: string }) => i.namespace === LINKEDIN_IDENTITY.SLUG
+    );
+    // Slug is the soft bridge to takeout people — present but NOT primary.
+    expect(slug).toMatchObject({
+      namespace: "linkedin_slug",
+      eventPath: "metadata.author_linkedin_slug",
+    });
+    expect(slug.primary).toBeUndefined();
   });
 });
 

--- a/examples/personal-agent/linkedin-identity.ts
+++ b/examples/personal-agent/linkedin-identity.ts
@@ -44,11 +44,21 @@ export interface ConnectorIdentityModule {
 /** Connector-owned identity namespaces (not SDK-global). */
 export const LINKEDIN_IDENTITY = {
   /**
-   * Canonical `/in/<vanity>` profile slug, lowercased — primary namespace for
-   * attribution. Case- and URL-noise-insensitive, so the same person never
-   * forks across the CASE-SENSITIVE `entity_identities` UNIQUE index.
+   * Canonical `/in/<vanity>` profile slug, lowercased. Case- and URL-noise-
+   * insensitive, so the same person never forks across the CASE-SENSITIVE
+   * `entity_identities` UNIQUE index. USER-CHANGEABLE (vanity URL edit), so it
+   * is a soft key — NOT `primary` — matched equal-weight with email/member id.
    */
   SLUG: "linkedin_slug",
+  /**
+   * Immutable numeric member id from `urn:li:fsd_profile:<id>`. The live
+   * connector's Voyager feed exposes it on the post actor; the takeout export
+   * does NOT (it only has the vanity slug). When present it is the PRIMARY key:
+   * it survives a vanity-URL change, so a person who renames their slug still
+   * resolves to one entity. A takeout-only person (slug, no member id) still
+   * bridges to their live-connector self via the shared slug/email.
+   */
+  MEMBER_ID: "linkedin_member_id",
 } as const;
 
 export type LinkedInIdentityNamespace =
@@ -76,6 +86,27 @@ export function normalizeLinkedInSlug(
 }
 
 /**
+ * Extract the immutable numeric member id from a LinkedIn profile URN or a bare
+ * id. `urn:li:fsd_profile:ACoAAB1234`, `urn:li:member:1234`, and `1234` all
+ * reduce to the trailing id token. Returns `null` when no `[A-Za-z0-9_-]` id
+ * token can be recovered. (fsd_profile ids are opaque base64-ish, not just
+ * digits, so the charset is permissive — but URN separators are stripped.)
+ */
+export function normalizeLinkedInMemberId(
+  raw: string | null | undefined
+): string | null {
+  if (typeof raw !== "string") return null;
+  const value = raw.trim();
+  if (!value) return null;
+  // Take the segment after the last `:` (URN tail) or the whole bare value.
+  const tail = value.includes(":")
+    ? value.slice(value.lastIndexOf(":") + 1)
+    : value;
+  if (!/^[A-Za-z0-9_-]+$/.test(tail)) return null;
+  return tail;
+}
+
+/**
  * Normalize a LinkedIn identity namespace value. Returns `undefined` when the
  * namespace is not LinkedIn-owned (caller falls back to generic hygiene). The
  * generic `email` namespace is deliberately NOT handled here — connector-sdk
@@ -88,6 +119,8 @@ export function normalizeLinkedInIdentityValue(
   switch (namespace) {
     case LINKEDIN_IDENTITY.SLUG:
       return normalizeLinkedInSlug(raw);
+    case LINKEDIN_IDENTITY.MEMBER_ID:
+      return normalizeLinkedInMemberId(raw);
     default:
       return undefined;
   }

--- a/examples/personal-agent/linkedin-identity.ts
+++ b/examples/personal-agent/linkedin-identity.ts
@@ -51,12 +51,14 @@ export const LINKEDIN_IDENTITY = {
    */
   SLUG: "linkedin_slug",
   /**
-   * Immutable numeric member id from `urn:li:fsd_profile:<id>`. The live
-   * connector's Voyager feed exposes it on the post actor; the takeout export
-   * does NOT (it only has the vanity slug). When present it is the PRIMARY key:
-   * it survives a vanity-URL change, so a person who renames their slug still
-   * resolves to one entity. A takeout-only person (slug, no member id) still
-   * bridges to their live-connector self via the shared slug/email.
+   * Immutable member id from `urn:li:fsd_profile:<id>`. The live connector's
+   * Voyager feed exposes it on the post actor; the takeout export does NOT (it
+   * only has the vanity slug). Matched EQUAL-WEIGHT with the slug (NOT primary):
+   * takeout people pre-exist keyed on slug alone, and a primary member_id would
+   * fork them (a primary that matches nothing mints a new person rather than
+   * falling back to a slug hit). Equal-weight lets a live post bind the existing
+   * slug-person AND accrete the member id — so a LATER vanity-URL change still
+   * resolves via the (now-attached) member id.
    */
   MEMBER_ID: "linkedin_member_id",
 } as const;
@@ -86,11 +88,13 @@ export function normalizeLinkedInSlug(
 }
 
 /**
- * Extract the immutable numeric member id from a LinkedIn profile URN or a bare
- * id. `urn:li:fsd_profile:ACoAAB1234`, `urn:li:member:1234`, and `1234` all
- * reduce to the trailing id token. Returns `null` when no `[A-Za-z0-9_-]` id
- * token can be recovered. (fsd_profile ids are opaque base64-ish, not just
- * digits, so the charset is permissive — but URN separators are stripped.)
+ * Extract the immutable member id from a LinkedIn PERSON URN or a bare id.
+ * `urn:li:fsd_profile:ACoAAB1234` and `urn:li:member:1234` reduce to the
+ * trailing id token; a bare `ACoAAB1234` passes through. Returns `null` for
+ * anything else — critically for a NON-person URN like `urn:li:fsd_company:99`,
+ * so a company id can never be normalized into a `person` member id. (Opaque
+ * fsd ids are base64-ish, so the token charset is permissive, but the URN
+ * PREFIX is checked: only `fsd_profile` / `member` are person namespaces.)
  */
 export function normalizeLinkedInMemberId(
   raw: string | null | undefined
@@ -98,12 +102,14 @@ export function normalizeLinkedInMemberId(
   if (typeof raw !== "string") return null;
   const value = raw.trim();
   if (!value) return null;
-  // Take the segment after the last `:` (URN tail) or the whole bare value.
-  const tail = value.includes(":")
-    ? value.slice(value.lastIndexOf(":") + 1)
-    : value;
-  if (!/^[A-Za-z0-9_-]+$/.test(tail)) return null;
-  return tail;
+  // A colon-bearing input MUST be a person URN — reject company/other URNs so a
+  // non-person id never slips through as a person's primary key.
+  if (value.includes(":")) {
+    const m = value.match(/^urn:li:(?:fsd_profile|member):([A-Za-z0-9_-]+)$/);
+    return m ? m[1] : null;
+  }
+  // A bare id (no URN) is an already-extracted token.
+  return /^[A-Za-z0-9_-]+$/.test(value) ? value : null;
 }
 
 /**

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -39,6 +39,7 @@ import path from "node:path";
 import {
   LINKEDIN_EMAIL_NAMESPACE,
   LINKEDIN_IDENTITY,
+  normalizeLinkedInMemberId,
   normalizeLinkedInSlug,
 } from "./linkedin-identity.ts";
 import {
@@ -194,15 +195,19 @@ const LINKEDIN_MESSAGE_ATTRIBUTIONS: EventAttributionRule[] = [
 
 /**
  * Link a live `post` to its author. The Voyager feed (company_updates) exposes
- * the actor's immutable `urn:li:fsd_profile:<id>` as `author_member_id` — the
- * PRIMARY key that survives a vanity-URL change — plus the `/in/<slug>` as a
- * soft key that bridges to takeout-ingested people (who have only a slug).
+ * the actor's immutable `urn:li:fsd_profile:<id>` as `author_member_id` plus the
+ * `/in/<slug>`. Both are identities; NEITHER is `primary` — they match
+ * EQUAL-WEIGHT (same as the connections/messages attributions).
  *
- * `createWhen: { author_member_id exists }` gates minting on the durable id:
- * a post with only a slug (or neither, e.g. a home-feed scrape) MATCHES an
- * existing person but never mints, so we don't fork a member-id-less duplicate
- * that a later takeout/live event can't merge into. This is the live half of
- * the slug-churn hardening — takeout alone can't supply a member id.
+ * Why not primary member_id: takeout-ingested people already exist keyed on
+ * `linkedin_slug` (no member id — the export has none). A `primary` member_id
+ * would be authoritative: on a live post it would find no member-id match, mint
+ * a NEW person, and fork the existing slug-person (the resolver does not fall
+ * back to a secondary slug hit when a primary is present). Equal-weight instead
+ * UNIONS the hits: the live post matches the existing person by slug AND
+ * accretes the member_id onto them. Durability still holds — once the member_id
+ * is on the person, a later vanity-URL change still resolves via that member_id
+ * in the equal-weight union. Real authors, so mint on no match.
  */
 const LINKEDIN_POST_AUTHOR_ATTRIBUTIONS: EventAttributionRule[] = [
   {
@@ -210,13 +215,11 @@ const LINKEDIN_POST_AUTHOR_ATTRIBUTIONS: EventAttributionRule[] = [
     autoCreate: true,
     target: {
       entityType: "person",
-      createWhen: { path: "metadata.author_member_id", exists: true },
       titlePath: "author_name",
       identities: [
         {
           namespace: LINKEDIN_IDENTITY.MEMBER_ID,
           eventPath: "metadata.author_member_id",
-          primary: true,
         },
         {
           namespace: LINKEDIN_IDENTITY.SLUG,
@@ -475,19 +478,24 @@ export function parseCompanyUpdates(
       actorObj?.description?.text ?? actorObj?.description ?? undefined;
 
     // Actor identity: the member's immutable `urn:li:fsd_profile:<id>` and the
-    // vanity `/in/<slug>`. Voyager threads these through a few shapes (the actor
-    // may be a ref into `included`, and the profile urn/url hides under
-    // `*miniProfile` / `navigationContext.actionTarget` / `navigationUrl`).
-    // Best-effort — a company-authored post has no member id and yields null.
+    // vanity `/in/<slug>`. Voyager threads the profile urn through several
+    // shapes — the actor may be a ref into `included`, and the urn hides under
+    // `*miniProfile` (a bare urn string OR a ref to resolve), `miniProfile` (a
+    // bare urn string OR an object with `entityUrn`), `urn`, or `entityUrn`.
+    // normalizeLinkedInMemberId returns null for a non-person urn (e.g. a
+    // company actor's `urn:li:fsd_company:…`), so a company-authored post yields
+    // no member id and its attribution match-only-gates off (createWhen).
     const authorUrn: string =
-      actorObj?.["*miniProfile"] ??
-      actorObj?.miniProfile?.entityUrn ??
+      (typeof actorObj?.["*miniProfile"] === "string"
+        ? actorObj["*miniProfile"]
+        : resolve(actorObj?.["*miniProfile"])?.entityUrn) ??
+      (typeof actorObj?.miniProfile === "string"
+        ? actorObj.miniProfile
+        : actorObj?.miniProfile?.entityUrn) ??
       actorObj?.urn ??
       actorObj?.entityUrn ??
       "";
-    const authorMemberId = /urn:li:(?:fsd_profile|member):/.test(authorUrn)
-      ? authorUrn.slice(authorUrn.lastIndexOf(":") + 1)
-      : undefined;
+    const authorMemberId = normalizeLinkedInMemberId(authorUrn) ?? undefined;
     const authorProfileUrl: string =
       actorObj?.navigationContext?.actionTarget ??
       actorObj?.navigationUrl ??

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -95,6 +95,10 @@ interface LinkedInPost {
   text: string;
   author: string;
   authorHeadline?: string;
+  /** Immutable `urn:li:fsd_profile:<id>` tail — primary identity when present. */
+  authorMemberId?: string;
+  /** Canonical `/in/<slug>` vanity id — soft identity, bridges to takeout. */
+  authorSlug?: string;
   likes: number;
   comments: number;
   shares: number;
@@ -181,6 +185,51 @@ const LINKEDIN_MESSAGE_ATTRIBUTIONS: EventAttributionRule[] = [
         behavior: "prefer_non_empty",
       },
       last_linkedin_message_at: {
+        eventPath: "occurred_at",
+        behavior: "overwrite",
+      },
+    },
+  },
+];
+
+/**
+ * Link a live `post` to its author. The Voyager feed (company_updates) exposes
+ * the actor's immutable `urn:li:fsd_profile:<id>` as `author_member_id` — the
+ * PRIMARY key that survives a vanity-URL change — plus the `/in/<slug>` as a
+ * soft key that bridges to takeout-ingested people (who have only a slug).
+ *
+ * `createWhen: { author_member_id exists }` gates minting on the durable id:
+ * a post with only a slug (or neither, e.g. a home-feed scrape) MATCHES an
+ * existing person but never mints, so we don't fork a member-id-less duplicate
+ * that a later takeout/live event can't merge into. This is the live half of
+ * the slug-churn hardening — takeout alone can't supply a member id.
+ */
+const LINKEDIN_POST_AUTHOR_ATTRIBUTIONS: EventAttributionRule[] = [
+  {
+    role: "authored_by",
+    autoCreate: true,
+    target: {
+      entityType: "person",
+      createWhen: { path: "metadata.author_member_id", exists: true },
+      titlePath: "author_name",
+      identities: [
+        {
+          namespace: LINKEDIN_IDENTITY.MEMBER_ID,
+          eventPath: "metadata.author_member_id",
+          primary: true,
+        },
+        {
+          namespace: LINKEDIN_IDENTITY.SLUG,
+          eventPath: "metadata.author_linkedin_slug",
+        },
+      ],
+    },
+    traits: {
+      linkedin_headline: {
+        eventPath: "metadata.author_headline",
+        behavior: "prefer_non_empty",
+      },
+      last_linkedin_post_at: {
         eventPath: "occurred_at",
         behavior: "overwrite",
       },
@@ -377,7 +426,10 @@ export function filterPostsSinceCheckpoint(
 
 // ── Voyager API Response Parsers ──────────────────────────────
 
-function parseCompanyUpdates(_url: string, json: unknown): LinkedInPost[] {
+export function parseCompanyUpdates(
+  _url: string,
+  json: unknown
+): LinkedInPost[] {
   const posts: LinkedInPost[] = [];
   const data = json as any;
 
@@ -422,6 +474,29 @@ function parseCompanyUpdates(_url: string, json: unknown): LinkedInPost[] {
     const authorDesc =
       actorObj?.description?.text ?? actorObj?.description ?? undefined;
 
+    // Actor identity: the member's immutable `urn:li:fsd_profile:<id>` and the
+    // vanity `/in/<slug>`. Voyager threads these through a few shapes (the actor
+    // may be a ref into `included`, and the profile urn/url hides under
+    // `*miniProfile` / `navigationContext.actionTarget` / `navigationUrl`).
+    // Best-effort — a company-authored post has no member id and yields null.
+    const authorUrn: string =
+      actorObj?.["*miniProfile"] ??
+      actorObj?.miniProfile?.entityUrn ??
+      actorObj?.urn ??
+      actorObj?.entityUrn ??
+      "";
+    const authorMemberId = /urn:li:(?:fsd_profile|member):/.test(authorUrn)
+      ? authorUrn.slice(authorUrn.lastIndexOf(":") + 1)
+      : undefined;
+    const authorProfileUrl: string =
+      actorObj?.navigationContext?.actionTarget ??
+      actorObj?.navigationUrl ??
+      resolve(actorObj?.["*miniProfile"])?.publicIdentifier ??
+      "";
+    // normalizeLinkedInSlug pulls the `/in/<slug>` segment from a full URL (and
+    // returns null for a company `/company/…` URL or anything slug-invalid).
+    const authorSlug = normalizeLinkedInSlug(authorProfileUrl);
+
     // Get social counts
     const socialRef = el["*socialDetail"] ?? el.socialDetail;
     const social = resolve(socialRef);
@@ -446,6 +521,8 @@ function parseCompanyUpdates(_url: string, json: unknown): LinkedInPost[] {
       text,
       author: authorName,
       authorHeadline: typeof authorDesc === "string" ? authorDesc : undefined,
+      authorMemberId: authorMemberId || undefined,
+      authorSlug: authorSlug ?? undefined,
       likes: counts.numLikes ?? 0,
       comments: counts.numComments ?? 0,
       shares: counts.numShares ?? 0,
@@ -623,10 +700,13 @@ export default class LinkedInConnector extends ConnectorRuntime<
         eventKinds: {
           post: {
             description: "A company LinkedIn post",
+            attributions: LINKEDIN_POST_AUTHOR_ATTRIBUTIONS,
             metadataSchema: {
               type: "object",
               properties: {
                 author_headline: { type: "string" },
+                author_member_id: { type: "string" },
+                author_linkedin_slug: { type: "string" },
                 likes: { type: "number" },
                 comments: { type: "number" },
                 shares: { type: "number" },
@@ -964,6 +1044,10 @@ export default class LinkedInConnector extends ConnectorRuntime<
       }),
       metadata: {
         author_headline: post.authorHeadline,
+        // Author identity for the `post` attribution. member_id (primary) when
+        // Voyager exposed the actor's fsd_profile urn; slug bridges to takeout.
+        author_member_id: post.authorMemberId,
+        author_linkedin_slug: post.authorSlug,
         likes: post.likes,
         comments: post.comments,
         shares: post.shares,


### PR DESCRIPTION
## What

The LinkedIn takeout export has **no stable member id** — only the user-changeable vanity slug — so a slug rename would fork a person into duplicates. The **live** connector's Voyager feed (`company_updates`) *does* expose the author's immutable `urn:li:fsd_profile:<id>`. This extracts it (+ the `/in/` slug) from the post actor and emits `linkedin_member_id` as a **primary** identity on a new `post` attribution, with the slug as a soft bridge to takeout-ingested people.

This is the durable slug-churn fix flagged during the connector merge (#1801): takeout alone can't supply a member id, so only the live connector can harden the identity.

## How

- `parseCompanyUpdates` now pulls the actor's `urn:li:fsd_profile:<id>` (from `*miniProfile` / `entityUrn`) and the `/in/<slug>` (from `navigationContext.actionTarget` / `navigationUrl`), emitting `author_member_id` + `author_linkedin_slug` on the post metadata.
- New `LINKEDIN_POST_AUTHOR_ATTRIBUTIONS` (role `authored_by`) keys **primary** on `linkedin_member_id`, secondary on `linkedin_slug`.
- `createWhen({ author_member_id exists })` gates minting on the durable id — a post with only a slug (or a company-authored post with neither) **matches** an existing person but never mints a member-id-less duplicate. (Same fork-avoidance lesson codex caught in the Twitter PR.)
- Adds `normalizeLinkedInMemberId` + `LINKEDIN_IDENTITY.MEMBER_ID`.

## Identity model

| key | primary? | source | role |
|---|---|---|---|
| `linkedin_member_id` | **yes** | live Voyager actor | survives vanity-URL change |
| `linkedin_slug` | no | takeout + live | soft bridge; user-changeable |
| `email` | no | takeout | cross-channel bridge |

A takeout-only person (slug, no member id) still bridges to their live-connector self via the shared slug/email; once a live post supplies the member id, that becomes the canonical key.

## Tests

5 new tests: member-id URN normalization, actor extraction from a Voyager-shaped fixture, company-actor yields no member id, and the attribution shape. `examples/personal-agent` suite **52/0**; pre-commit tsc + biome green.

Refs #1801 (merge), #1805 (same createWhen mint-gating pattern).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786124752&installation_id=136316292&pr_number=1806&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1806&signature=f86f591385b8781d6ef5386db19cf7abc2b60078e2c72556b5d281bfc6d6aea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for LinkedIn member ID normalization, including common person ID formats and bare tokens.
  * Improved company update attribution so posts can more reliably identify the author from either member ID or profile slug.

* **Bug Fixes**
  * Enhanced author matching for LinkedIn company updates, helping reduce duplicate or mismatched post authors when profile URLs or IDs vary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->