### PR TITLE
fix(linkedin): drop the unused optional oauth auth method

### DIFF
--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -548,6 +548,21 @@ describe("LinkedInConnector takeout identity attributions", () => {
   });
 });
 
+describe("LinkedInConnector auth schema", () => {
+  test("is none-only so a takeout/extension connection needs no OAuth handshake", () => {
+    const def = new LinkedInConnector().definition;
+    const methods = def.authSchema.methods;
+    expect(methods).toHaveLength(1);
+    expect(methods[0].type).toBe("none");
+    // No oauth method — the server would otherwise pick it as authoritative and
+    // force a LinkedIn OAuth flow before a connection could be created, blocking
+    // the takeout + extension use cases (no feed consumes an OAuth token).
+    expect(methods.some((m: { type: string }) => m.type === "oauth")).toBe(
+      false
+    );
+  });
+});
+
 describe("normalizeLinkedInMemberId", () => {
   test("reduces fsd_profile / member URNs and bare ids to the id token", () => {
     expect(normalizeLinkedInMemberId("urn:li:fsd_profile:ACoAAB1234xyz")).toBe(

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -658,26 +658,20 @@ export default class LinkedInConnector extends ConnectorRuntime<
       "Scrapes LinkedIn (home feed, company pages, hiring signals) via the paired Owletto Chrome extension, and ingests local LinkedIn Data Export CSV files.",
     version: "3.0.0",
     faviconDomain: "linkedin.com",
+    // Auth is `none`: every live feed authenticates implicitly through the
+    // paired Owletto Chrome extension (the user's own signed-in linkedin.com
+    // session — no OAuth token is ever read), and takeout feeds read local CSV
+    // files. A previously-declared OPTIONAL oauth method was removed: no feed
+    // consumed it, yet the server's connection-create picks the first non-`none`
+    // method as authoritative and forced an irrelevant LinkedIn OAuth handshake
+    // before a (takeout or extension-driven) connection could be created —
+    // blocking exactly the "one connector, both live and backfill" use case the
+    // merge exists for. If real OAuth sign-in is ever needed downstream, add it
+    // back behind a feed that actually uses the token.
     authSchema: {
       methods: [
         {
           type: "none",
-        },
-        {
-          type: "oauth",
-          provider: "linkedin",
-          requiredScopes: ["openid", "profile", "email"],
-          loginScopes: ["openid", "profile", "email"],
-          authorizationUrl: "https://www.linkedin.com/oauth/v2/authorization",
-          tokenUrl: "https://www.linkedin.com/oauth/v2/accessToken",
-          userinfoUrl: "https://api.linkedin.com/v2/userinfo",
-          tokenEndpointAuthMethod: "client_secret_post",
-          clientIdKey: "LINKEDIN_CLIENT_ID",
-          clientSecretKey: "LINKEDIN_CLIENT_SECRET",
-          description:
-            "Optional LinkedIn OAuth app config for sign-in. Current company page and jobs feeds run via the Chrome extension; OAuth is here for downstream sign-in flows.",
-          setupInstructions:
-            "Create a LinkedIn OAuth app, add {{redirect_uri}} as the callback URL, then paste the client ID and client secret below.",
         },
       ],
     },


### PR DESCRIPTION
## What

Removes the optional LinkedIn `oauth` method from the merged connector's `authSchema`, leaving `none`.

## Why

No feed consumes an OAuth token — live feeds (home_feed / company_updates / jobs) authenticate implicitly through the paired Owletto Chrome extension (the user's own signed-in linkedin.com session), and takeout feeds read local CSV files. The oauth method was purely declarative ("Optional… here for downstream sign-in flows").

But the server's `getPreferredAuthMethodType` picks the **first non-`none`** method as authoritative, so it forced an irrelevant LinkedIn OAuth handshake before **any new connection** could be created (`pending_auth`, `Select or create an OAuth account profile`). That blocked the exact use case the merge (#1801) exists for: a **takeout** connection on the unified `linkedin` connector couldn't be created without completing OAuth it never uses.

Discovered dogfooding on buremba: creating a takeout connection on the merged connector returned a `pending_auth` OAuth flow. A pre-existing connection (`linkedin-e2e`, created 2026-05-28 before the oauth method existed) is grandfathered and unaffected.

## Tests

`examples/personal-agent` suite **66/0**; new test guards the schema stays none-only. Pre-commit tsc + biome green.

Refs #1801 (merge), #1806 (member_id).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786125420&installation_id=136316292&pr_number=1807&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1807&signature=08fb54f75e6e3883f3bea11431290c5b33a1e69c0d72b3217558c39919c1d8ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->