### PR TITLE
feat(slack): support both per-workspace and org-wide Grid installs + provider-fallback preflight

### DIFF
--- a/config/slack-app-manifest.self-install.json
+++ b/config/slack-app-manifest.self-install.json
@@ -77,7 +77,7 @@
       "is_enabled": true,
       "request_url": "https://example.com/api/v1/webhooks/CONNECTION_ID"
     },
-    "org_deploy_enabled": false,
+    "org_deploy_enabled": true,
     "socket_mode_enabled": false,
     "token_rotation_enabled": false
   }

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -692,6 +692,88 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
     expect(posted).not.toContain("api/proxy");
   });
 
+  test("configured model provider unconnected, but org has another connected provider → falls back and enqueues", async () => {
+    // The agent is configured for z-ai/glm-5.2 (not routable here), but the org
+    // has a connected+routable openai provider. Instead of dead-ending with a
+    // setup link, the run must proceed on openai's default model. This is the
+    // new-user gap: a default agent shipped with a model whose provider the org
+    // never connected must NOT hard-block when another provider IS connected.
+    const zai = {
+      providerId: "z-ai",
+      hasSystemKey: () => false,
+      hasCredentials: async () => false, // unroutable: no credentials
+      getProxyBaseUrlMappings: () => ({}),
+      getModelOptions: async () => [{ value: "z-ai/glm-5.2" }],
+    };
+    const openai = {
+      providerId: "openai",
+      hasSystemKey: () => false,
+      hasCredentials: async () => true,
+      getProxyBaseUrlMappings: () => ({ openai: "https://gw/api/proxy/openai" }),
+      getModelOptions: async () => [{ value: "gpt-4o-mini" }],
+    };
+    const providerCatalog = {
+      getInstalledModules: mock(async () => [zai, openai]),
+      // The configured model resolves to the z-ai module (unroutable).
+      findProviderForModel: mock(async () => zai),
+    };
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      binding: {
+        agentId: "lobu-builder",
+        organizationId: "org-bound",
+        model: "z-ai/glm-5.2",
+      },
+      providerCatalog,
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(thread, makeMessage(), "mention");
+
+    // Ran, did not post a setup-link error.
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
+    const payload = enqueueMessage.mock.calls[0]?.[0] as any;
+    // The fallback provider's default model (prefixed with its providerId) wins.
+    expect(payload.agentOptions?.model).toBe("openai/gpt-4o-mini");
+    expect(
+      thread.post.mock.calls.every(
+        (c: unknown[]) => !String(c[0]).includes("Open this setup link"),
+      ),
+    ).toBe(true);
+  });
+
+  test("no connected provider at all → still posts the setup-link error, no enqueue", async () => {
+    // Guard the negative: when the configured provider is unroutable AND there is
+    // no other connected provider, we must NOT silently proceed — surface setup.
+    const zai = {
+      providerId: "z-ai",
+      hasSystemKey: () => false,
+      hasCredentials: async () => false,
+      getProxyBaseUrlMappings: () => ({}),
+      getModelOptions: async () => [{ value: "z-ai/glm-5.2" }],
+    };
+    const providerCatalog = {
+      getInstalledModules: mock(async () => [zai]),
+      findProviderForModel: mock(async () => zai),
+    };
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      binding: {
+        agentId: "lobu-builder",
+        organizationId: "org-bound",
+        model: "z-ai/glm-5.2",
+      },
+      providerCatalog,
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(thread, makeMessage(), "mention");
+
+    expect(enqueueMessage).not.toHaveBeenCalled();
+    expect(thread.post).toHaveBeenCalledTimes(1);
+    expect(String(thread.post.mock.calls[0]?.[0])).toContain(
+      "Open this setup link",
+    );
+  });
+
   test("cross-org: routes the worker turn under the BOUND agent's org, not the connection's", async () => {
     // Regression for the hosted-preview cross-org bug: a `/lobu link <code>`
     // binds an agent that lives in a DIFFERENT org than the preview connection.

--- a/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
@@ -124,6 +124,24 @@ function makeAppInstallationStore(): TrackedAppStore {
 			// Unambiguous only — 2+ matches ⇒ null (see resolveSoleActiveByMetadata).
 			return matches.length === 1 ? matches[0] : null;
 		},
+		resolveActiveByMetadataFlag: async (
+			provider: string,
+			providerAppId: string,
+			key: string,
+			value: string,
+			flagKey: string,
+		) => {
+			const matches = rows.filter(
+				(r) =>
+					r.provider === provider &&
+					r.providerAppId === providerAppId &&
+					r.status === "active" &&
+					r.metadata[key] === value &&
+					r.metadata[flagKey] === true,
+			);
+			// Unambiguous only — 2+ matches ⇒ null (see resolveActiveByMetadataFlag).
+			return matches.length === 1 ? matches[0] : null;
+		},
 		getByTenantAndOrg: async (key: any, org: string) => {
       const matches = rows.filter(
 				(r) => tupleEq(r, key) && r.organizationId === org,

--- a/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
@@ -35,6 +35,7 @@ mock.module("../../lobu/stores/slack-installations.js", () => ({
 	// Also imported by the coordinator module (webhook routing); unused here.
 	getSlackInstallByTeamId: mock(async () => null),
 	getSlackInstallByEnterpriseId: mock(async () => null),
+	getSlackEnterpriseInstall: mock(async () => null),
 	resolveSlackPendingByTenant: mock(async () => null),
 	claimSlackWelcomeDm: mock(async () => null),
 }));

--- a/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
@@ -430,3 +430,99 @@ describe("slack-installations projection over app_installations", () => {
     expect(token).toBe("xoxb-a");
   });
 });
+
+describe("Grid install-model routing (per-workspace + org-wide enterprise)", () => {
+  test("org-wide enterprise install routes by enterprise_id EVEN WITH sibling per-workspace installs present", async () => {
+    // The workaround's failure mode: getSlackInstallByEnterpriseId (sole-active)
+    // returns null once 2+ installs share an enterprise. An org-wide install must
+    // still route unambiguously via the is_enterprise_install flag.
+    const { store, secretStore, slack } = build();
+    const ENT = "E_GRID";
+    await seedAgentRow("t", { organizationId: "org-x" });
+
+    // A sibling per-workspace install under the same enterprise (adds ambiguity).
+    await slack.upsertSlackInstallByTeam(store, secretStore, "org-x", "T_SIBLING", {
+      botToken: "xoxb-sibling",
+      enterpriseId: ENT,
+      // per-workspace: is_enterprise_install NOT set
+    });
+    // The org-wide install (installed against its home team T_HOME).
+    const orgWide = await slack.upsertSlackInstallByTeam(store, secretStore, "org-x", "T_HOME", {
+      botToken: "xoxb-orgwide",
+      enterpriseId: ENT,
+      isEnterpriseInstall: true,
+    });
+
+    // Sole-active is (correctly) ambiguous now — proves the old path can't route.
+    expect(await slack.getSlackInstallByEnterpriseId(store, ENT)).toBeNull();
+
+    // The org-wide resolver picks the enterprise install unambiguously.
+    const routed = await slack.getSlackEnterpriseInstall(store, ENT);
+    expect(routed?.id).toBe(orgWide.id);
+  });
+
+  test("sole per-workspace Grid install still routes by enterprise_id (no org-wide install)", async () => {
+    // A Grid enterprise with exactly ONE (non-org-wide) install: the legacy
+    // sole-active fallback must keep working, and the org-wide resolver returns
+    // null (nothing flagged).
+    const { store, secretStore, slack } = build();
+    const ENT = "E_SOLO";
+    await seedAgentRow("t", { organizationId: "org-y" });
+    const only = await slack.upsertSlackInstallByTeam(store, secretStore, "org-y", "T_ONLY", {
+      botToken: "xoxb-only",
+      enterpriseId: ENT,
+    });
+
+    expect(await slack.getSlackEnterpriseInstall(store, ENT)).toBeNull();
+    const routed = await slack.getSlackInstallByEnterpriseId(store, ENT);
+    expect(routed?.id).toBe(only.id);
+  });
+
+  test("claim persists is_enterprise_install so an org-wide install is routable after claim", async () => {
+    // End-to-end of the plumbing: a pending ENTERPRISE install, once claimed,
+    // must carry is_enterprise_install=true on the active row (else the org-wide
+    // router never matches it).
+    const { store, secretStore, slack } = build();
+    const ENT = "E_CLAIM";
+    await seedAgentRow("t", { organizationId: "org-claim" });
+    await slack.writeSlackPendingInstall({
+      teamId: "T_CLAIM",
+      teamName: "Claimed WS",
+      botUserId: "U_BOT",
+      botToken: "xoxb-claim",
+      installerUserId: "U_INSTALLER",
+      isEnterpriseInstall: true,
+      enterpriseId: ENT,
+    });
+    const pending = await slack.resolveSlackPendingByTenant("T_CLAIM");
+    expect(pending?.isEnterpriseInstall).toBe(true);
+
+    await slack.claimSlackPendingInstall(store, secretStore, pending!, "org-claim");
+
+    const routed = await slack.getSlackEnterpriseInstall(store, ENT);
+    expect(routed?.organizationId).toBe("org-claim");
+  });
+
+  test("a plain per-workspace claim does NOT set is_enterprise_install (not org-wide routable)", async () => {
+    // Guard the negative: a standalone (non-Grid) or Grid single-workspace claim
+    // must not be picked up by the org-wide router.
+    const { store, secretStore, slack } = build();
+    await seedAgentRow("t", { organizationId: "org-plain" });
+    await slack.writeSlackPendingInstall({
+      teamId: "T_PLAIN",
+      teamName: "Plain WS",
+      botUserId: "U_BOT",
+      botToken: "xoxb-plain",
+      installerUserId: "U_INSTALLER",
+      isEnterpriseInstall: false,
+      enterpriseId: "E_PLAIN",
+    });
+    const pending = await slack.resolveSlackPendingByTenant("T_PLAIN");
+    await slack.claimSlackPendingInstall(store, secretStore, pending!, "org-plain");
+
+    expect(await slack.getSlackEnterpriseInstall(store, "E_PLAIN")).toBeNull();
+    // But it IS still reachable as the sole per-workspace install for its enterprise.
+    const solo = await slack.getSlackInstallByEnterpriseId(store, "E_PLAIN");
+    expect(solo?.organizationId).toBe("org-plain");
+  });
+});

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -85,68 +85,151 @@ async function buildProviderSetupUrl(params: {
   return url.toString();
 }
 
+/**
+ * Is this provider module usable RIGHT NOW for this agent/org — i.e. it has a
+ * credential (system key or org-shared/agent key) AND a routable proxy mapping?
+ * Both checks matter: a provider can be "installed" yet have no key, and a keyed
+ * provider can still fail to produce a route (misconfigured upstream).
+ */
+async function providerIsRoutable(
+  provider: {
+    providerId: string;
+    hasSystemKey(): boolean;
+    hasCredentials(
+      agentId: string,
+      ctx: { organizationId: string; userId: string }
+    ): Promise<boolean>;
+    getProxyBaseUrlMappings(
+      proxyBaseUrl: string,
+      agentId: string,
+      ctx: { organizationId: string; userId: string }
+    ): Record<string, string>;
+  },
+  ctx: {
+    services: CoreServices;
+    agentId: string;
+    organizationId: string;
+    userId: string;
+  }
+): Promise<boolean> {
+  const hasCredentials =
+    provider.hasSystemKey() ||
+    (await provider.hasCredentials(ctx.agentId, {
+      organizationId: ctx.organizationId,
+      userId: ctx.userId,
+    }));
+  if (!hasCredentials) return false;
+  const proxyBaseUrl = `${webOriginFromGateway(ctx.services.getPublicGatewayUrl())}/api/proxy`;
+  const mappings = provider.getProxyBaseUrlMappings(proxyBaseUrl, ctx.agentId, {
+    organizationId: ctx.organizationId,
+    userId: ctx.userId,
+  });
+  return Object.keys(mappings).length > 0;
+}
+
+/**
+ * Pick a concrete, routable model from a connected provider so a run can proceed
+ * even though the agent's CONFIGURED model names a provider the org never
+ * connected. Returns the provider's default/first model as a `provider/model`
+ * ref, or null if the provider exposes no usable model. This is what turns the
+ * old hard dead-end ("connect claude first") into graceful degradation onto a
+ * provider the org actually has (e.g. openai), which matters most for a new user
+ * whose default agent shipped with a model whose provider they never set up.
+ */
+async function firstModelForProvider(provider: {
+  providerId: string;
+  getModelOptions?: (a: string, b: string) => Promise<Array<{ value: string }>>;
+}): Promise<string | null> {
+  if (!provider.getModelOptions) return null;
+  const options = await provider.getModelOptions("", "").catch(() => []);
+  const first = options[0]?.value?.trim();
+  if (!first) return null;
+  return first.startsWith(`${provider.providerId}/`)
+    ? first
+    : `${provider.providerId}/${first}`;
+}
+
+type ModelProviderResolution =
+  | { kind: "ok" }
+  | { kind: "fallback"; model: string; from: string; to: string }
+  | { kind: "error"; message: string };
+
+/**
+ * Preflight the model a message will run on. Order of outcomes:
+ *  - ok: the configured model's provider is connected + routable → run as-is.
+ *  - fallback: it is NOT routable, but the org has another connected provider →
+ *    run on that provider's default model instead of failing.
+ *  - error: no connected+routable provider exists at all → surface a setup link.
+ */
 async function validateMessageModelProvider(params: {
   services: CoreServices;
   agentId: string;
   organizationId?: string;
   userId: string;
   modelRef?: unknown;
-}): Promise<string | null> {
-  if (typeof params.modelRef !== "string") return null;
+}): Promise<ModelProviderResolution> {
+  if (typeof params.modelRef !== "string") return { kind: "ok" };
   const modelRef = params.modelRef.trim();
   const providerId = parseProviderFromModelRef(modelRef);
-  if (!providerId) return null;
+  if (!providerId) return { kind: "ok" };
 
   const catalog = params.services.getProviderCatalogService?.();
-  if (!catalog || !params.organizationId) return null;
+  if (!catalog || !params.organizationId) return { kind: "ok" };
+  const organizationId = params.organizationId;
 
   const providers = await catalog.getInstalledModules(
     params.agentId,
-    params.organizationId
+    organizationId
   );
   const provider = await catalog.findProviderForModel(modelRef, providers);
+
+  const routableCtx = {
+    services: params.services,
+    agentId: params.agentId,
+    organizationId,
+    userId: params.userId,
+  };
+
+  // Happy path: the configured model's provider is present, keyed, and routable.
+  if (provider && (await providerIsRoutable(provider, routableCtx))) {
+    return { kind: "ok" };
+  }
+
+  // The configured model can't run. Before dead-ending, look for ANY other
+  // connected provider on this agent that IS routable, and fall back to its
+  // default model. Skip the failed provider itself.
+  for (const candidate of providers) {
+    if (provider && candidate.providerId === provider.providerId) continue;
+    if (!(await providerIsRoutable(candidate, routableCtx))) continue;
+    const fallbackModel = await firstModelForProvider(candidate);
+    if (fallbackModel) {
+      return {
+        kind: "fallback",
+        model: fallbackModel,
+        from: modelRef,
+        to: candidate.providerId,
+      };
+    }
+  }
+
+  // Genuinely nothing usable — surface the setup link for the intended provider.
   const setupUrl = await buildProviderSetupUrl({
     publicGatewayUrl: params.services.getPublicGatewayUrl(),
-    organizationId: params.organizationId,
+    organizationId,
     providerId,
     agentId: params.agentId,
     modelRef,
     reason: "model_provider_not_connected",
   });
-
-  if (!provider) {
-    return (
+  const reason = !provider
+    ? `but it isn't connected for this agent`
+    : `but Lobu has no credentials for it`;
+  return {
+    kind: "error",
+    message:
       `I can't run this yet: the selected model (${modelRef}) needs provider "${providerId}", ` +
-      `but it isn't connected for this agent. Open this setup link to connect it: ${setupUrl}`
-    );
-  }
-
-  const hasCredentials =
-    provider.hasSystemKey() ||
-    (await provider.hasCredentials(params.agentId, {
-      organizationId: params.organizationId,
-      userId: params.userId,
-    }));
-  if (!hasCredentials) {
-    return (
-      `I can't run this yet: the selected model (${modelRef}) needs provider "${provider.providerId}", ` +
-      `but Lobu has no credentials for it. Open this setup link to connect or add credentials: ${setupUrl}`
-    );
-  }
-
-  const proxyBaseUrl = `${webOriginFromGateway(params.services.getPublicGatewayUrl())}/api/proxy`;
-  const mappings = provider.getProxyBaseUrlMappings(proxyBaseUrl, params.agentId, {
-    organizationId: params.organizationId,
-    userId: params.userId,
-  });
-  if (Object.keys(mappings).length === 0) {
-    return (
-      `I can't run this yet: the selected model (${modelRef}) needs provider "${provider.providerId}", ` +
-      `but Lobu could not build a route for it. Open this setup link to reconnect the provider: ${setupUrl}`
-    );
-  }
-
-  return null;
+      `${reason}. Open this setup link to connect or add credentials: ${setupUrl}`,
+  };
 }
 
 /**
@@ -952,20 +1035,37 @@ export class MessageHandlerBridge {
         organizationId
       );
 
-      const modelProviderError = await validateMessageModelProvider({
+      const modelResolution = await validateMessageModelProvider({
         services: this.services,
         agentId,
         organizationId,
         userId,
         modelRef: agentOptions.model,
       });
-      if (modelProviderError) {
+      if (modelResolution.kind === "error") {
         logger.warn(
           { traceId, agentId, organizationId, model: agentOptions.model },
-          "Rejecting inbound message before enqueue because model provider is not routable"
+          "Rejecting inbound message before enqueue: no connected+routable model provider"
         );
-        await thread.post(modelProviderError);
+        await thread.post(modelResolution.message);
         return;
+      }
+      if (modelResolution.kind === "fallback") {
+        // The configured model's provider isn't connected, but the org has
+        // another one that is. Run on it rather than dead-ending, and record
+        // the swap so the divergence is visible in logs/traces.
+        logger.warn(
+          {
+            traceId,
+            agentId,
+            organizationId,
+            configuredModel: modelResolution.from,
+            fallbackModel: modelResolution.model,
+            fallbackProvider: modelResolution.to,
+          },
+          "Configured model provider not connected; falling back to a connected provider"
+        );
+        agentOptions.model = modelResolution.model;
       }
 
       const payload = buildMessagePayload({

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -3,6 +3,7 @@ import { Chat } from "chat";
 import type { AppInstallationStore } from "../../lobu/stores/app-installation-store.js";
 import {
   claimSlackWelcomeDm,
+  getSlackEnterpriseInstall,
   getSlackInstallByEnterpriseId,
   getSlackInstallByTeamId,
   resolveSlackPendingByTenant,
@@ -438,14 +439,22 @@ export class SlackConnectionCoordinator {
       //    `forwardWebhook` resolve it via the Slack install projection). Per-message
       //    routing is via `/lobu link` bindings.
       const store = this.deps.getAppInstallationStore();
-      // Exact team id first; on a Grid workspace the event's team id is a sibling
-      // of the install's, so fall back to the shared enterprise id — but only
-      // when that enterprise has a SINGLE install (else it's ambiguous and the
-      // fallback returns null rather than cross-tenant misroute).
+      // Routing precedence for both install models:
+      //  a) EXACT team id — a per-workspace install (Grid or standalone) whose
+      //     own workspace homes this event.
+      //  b) ORG-WIDE enterprise install — a Grid install with
+      //     `is_enterprise_install=true` covers EVERY sibling workspace, so a
+      //     sibling-stamped event routes here by `enterprise_id`. Unambiguous
+      //     because Slack allows one org-wide install per enterprise, EVEN when
+      //     per-workspace installs of other siblings also exist.
+      //  c) SOLE per-workspace Grid install — legacy/self-install fallback for a
+      //     Grid enterprise that has exactly one (non-org-wide) install and no
+      //     org-wide one; still by enterprise_id, but only when unambiguous.
       const installation =
         (await getSlackInstallByTeamId(store, teamId)) ??
         (enterpriseId
-          ? await getSlackInstallByEnterpriseId(store, enterpriseId)
+          ? ((await getSlackEnterpriseInstall(store, enterpriseId)) ??
+            (await getSlackInstallByEnterpriseId(store, enterpriseId)))
           : null);
       if (installation && installation.status !== "stopped") {
         if (!(await this.deps.ensureConnectionRunning(installation.id))) {

--- a/packages/server/src/lobu/stores/app-installation-store.ts
+++ b/packages/server/src/lobu/stores/app-installation-store.ts
@@ -121,6 +121,28 @@ export interface AppInstallationStore {
     value: string
   ): Promise<AppInstallationRow | null>;
 
+  /**
+   * Resolve the SOLE active install for a provider app whose `metadata[key]`
+   * equals `value` AND whose `metadata[flagKey]` is boolean `true` — unambiguous
+   * only. Distinct from {@link resolveSoleActiveByMetadata}: it filters to rows
+   * carrying a truthy flag, so a match survives even when OTHER (non-flagged)
+   * installs share the same `value`.
+   *
+   * Its Slack consumer routes a Grid ORG-WIDE install (`is_enterprise_install`)
+   * by `enterprise_id`: Slack allows exactly one org-wide install per enterprise,
+   * so this is unambiguous EVEN WHEN per-workspace installs of sibling teams also
+   * exist under the same enterprise — which is precisely the case
+   * {@link resolveSoleActiveByMetadata} could not handle (it saw 2+ and gave up).
+   * Returns null when none match or, defensively, when 2+ flagged rows match.
+   */
+  resolveActiveByMetadataFlag(
+    provider: string,
+    providerAppId: string,
+    key: string,
+    value: string,
+    flagKey: string
+  ): Promise<AppInstallationRow | null>;
+
   getById(id: number): Promise<AppInstallationRow | null>;
   listByOrg(organizationId: string): Promise<AppInstallationRow[]>;
   setStatus(id: number, status: AppInstallationStatus): Promise<void>;
@@ -335,6 +357,24 @@ export function createPostgresAppInstallationStore(): AppInstallationStore {
           AND provider_app_id = ${providerAppId}
           AND status = 'active'
           AND metadata ->> ${key} = ${value}
+        LIMIT 2
+      `;
+      return rows.length === 1 ? rowToInstallation(rows[0]) : null;
+    },
+
+    async resolveActiveByMetadataFlag(provider, providerAppId, key, value, flagKey) {
+      const sql = getDb();
+      // Match active installs where metadata[key] = value AND metadata[flagKey]
+      // is JSON boolean true. `key`/`flagKey` are bound as `->>` / `->` operands,
+      // never spliced into SQL. LIMIT 2 detects (defensively) an impossible
+      // duplicate org-wide install; Slack guarantees at most one per enterprise.
+      const rows = await sql`
+        SELECT * FROM app_installations
+        WHERE provider = ${provider}
+          AND provider_app_id = ${providerAppId}
+          AND status = 'active'
+          AND metadata ->> ${key} = ${value}
+          AND (metadata -> ${flagKey}) = 'true'::jsonb
         LIMIT 2
       `;
       return rows.length === 1 ? rowToInstallation(rows[0]) : null;

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -139,6 +139,15 @@ export async function upsertSlackInstallByTeam(
      * null for a plain (non-Grid) workspace.
      */
     enterpriseId?: string | null;
+    /**
+     * True when this is a Grid ORG-WIDE install (`is_enterprise_install` from
+     * `oauth.v2.access`) — one installation covering every workspace in the
+     * enterprise. Persisted so sibling-workspace events route to this row by
+     * `enterprise_id` unambiguously (see {@link getSlackEnterpriseInstall}),
+     * without the sole-active heuristic. Absent/false for a per-workspace install
+     * (Grid single-workspace or standalone).
+     */
+    isEnterpriseInstall?: boolean;
   }
 ): Promise<SlackInstallationRow> {
   // Bind the org for the secret-store put + the row write so they land in the
@@ -197,6 +206,9 @@ export async function upsertSlackInstallByTeam(
       }
       if (data.enterpriseId) {
         metadata.enterprise_id = data.enterpriseId;
+      }
+      if (data.isEnterpriseInstall) {
+        metadata.is_enterprise_install = true;
       }
       if (process.env.SLACK_CLIENT_ID) {
         metadata.slack_client_id = process.env.SLACK_CLIENT_ID;
@@ -361,6 +373,29 @@ export async function getSlackInstallByEnterpriseId(
     SLACK_PROVIDER_APP_ID,
     "enterprise_id",
     enterpriseId
+  );
+  return row ? toSlackRow(row) : null;
+}
+
+/**
+ * Resolve the ORG-WIDE (Grid) install for an enterprise: the single active
+ * install with `is_enterprise_install=true` for this `enterprise_id`. Slack
+ * permits exactly ONE org-wide install per enterprise, so this is unambiguous
+ * even when per-workspace installs of sibling teams also exist under the same
+ * enterprise — unlike {@link getSlackInstallByEnterpriseId}, which gives up on
+ * 2+ matches. This is the routing key that lets one enterprise install serve
+ * every sibling workspace's events, replacing the sole-active workaround.
+ */
+export async function getSlackEnterpriseInstall(
+  store: AppInstallationStore,
+  enterpriseId: string
+): Promise<SlackInstallationRow | null> {
+  const row = await store.resolveActiveByMetadataFlag(
+    SLACK_PROVIDER,
+    SLACK_PROVIDER_APP_ID,
+    "enterprise_id",
+    enterpriseId,
+    "is_enterprise_install"
   );
   return row ? toSlackRow(row) : null;
 }
@@ -640,6 +675,7 @@ export async function claimSlackPendingInstall(
       botToken: pending.botToken,
       installerUserId: pending.installerUserId ?? undefined,
       enterpriseId: pending.enterpriseId,
+      isEnterpriseInstall: pending.isEnterpriseInstall,
     }
   );
   // Retire the org-less pending row now that an active, org-owned install owns


### PR DESCRIPTION
## What & why

Two related fixes surfaced by live Enterprise-Grid e2e on `lobubot.slack.com`:

### 1. Model-provider preflight fallback (`ace5ae640`)
Texting the bot dead-ended with *"the selected model (claude/…) needs provider 'claude', but Lobu has no credentials for it"* whenever an agent's configured model named a provider the org hadn't connected. `validateMessageModelProvider` now returns `ok | fallback | error`: if the configured model's provider isn't connected/routable but the org has **another** connected+routable provider, the message runs on that provider's default model instead of hard-blocking. The setup-link error is reserved for when **no** provider works. (+2 bridge tests)

### 2. Both Slack install models (`c2d118941`)
Directive: support **both** per-workspace AND org-wide Grid — not everyone has Enterprise; don't rip out per-workspace.
- Manifest `org_deploy_enabled: true`.
- Persist `is_enterprise_install` on the active install (claim path + `upsertSlackInstallByTeam`).
- New `getSlackEnterpriseInstall` via `store.resolveActiveByMetadataFlag` routes a Grid **org-wide** install (`is_enterprise_install=true`) by `enterprise_id`, serving all siblings unambiguously even when per-workspace sibling installs coexist — the case the old sole-active fallback couldn't handle.
- Routing precedence: `byTeam(exact)` → `byEnterprise(org-wide flag)` → `byEnterprise(sole-active legacy)`. Per-workspace stays team-keyed. No workaround left in the org-wide path. (+4 Postgres integration tests)

### 3. Test-mock fixups (`57ead681c`)
Two pre-existing gateway tests used hand-rolled stubs that predated the new store method / export; taught them about `resolveActiveByMetadataFlag` and `getSlackEnterpriseInstall`.

## Verification
- typecheck ✅, unit ✅. All 4 touched test files pass under the gate's per-file isolation (coordinator 16/0, claim 2/0, bridge 42/0, slack-installations 15/0).
- The gate's 3 integration failures were the stale mocks above, now fixed.
- `make review` LLM step was blocked on an API billing error (not code); suites themselves are green.
- Clean-slate reinstall e2e on real Grid workspaces is the follow-up once this deploys.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786137836&installation_id=136316292&pr_number=1811&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1811&signature=2c8c02b93af4fdd0a9d7a986e9b1155f8eb72fffe741ca31bcffaa97e808698b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Slack Enterprise Grid support, including better handling of org-wide installs and workspace-level installs.
  * Messages can now route to a connected provider’s default model when the originally configured provider isn’t available.

* **Bug Fixes**
  * Incoming Slack messages now choose the correct installation more reliably across team and enterprise setups.
  * Unlinked preview chats now show a setup error only when no usable provider is available, instead of failing prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->