### PR TITLE
feat(instagram): IG-internal identity dedup for the takeout connections feed

### DIFF
--- a/examples/personal-agent/__tests__/instagram-takeout.connector.test.ts
+++ b/examples/personal-agent/__tests__/instagram-takeout.connector.test.ts
@@ -1,0 +1,165 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { connectorSdkMock } from "./connector-sdk.mock";
+
+// Stub @lobu/connector-sdk (it pulls in playwright) so the connector imports
+// without the browser stack. Shared superset — see connector-sdk.mock.ts.
+mock.module("@lobu/connector-sdk", connectorSdkMock);
+
+let InstagramTakeoutConnector: any;
+let normalizeInstagramUsername: any;
+let usernameFromProfileUrl: any;
+let INSTAGRAM_IDENTITY: any;
+
+beforeAll(async () => {
+  const connectorMod = await import("../instagram-takeout.connector");
+  InstagramTakeoutConnector = connectorMod.default;
+  const identityMod = await import("../instagram-identity");
+  normalizeInstagramUsername = identityMod.normalizeInstagramUsername;
+  usernameFromProfileUrl = identityMod.usernameFromProfileUrl;
+  INSTAGRAM_IDENTITY = identityMod.INSTAGRAM_IDENTITY;
+});
+
+describe("instagram-identity normalization", () => {
+  test("normalizeInstagramUsername strips @, lowercases, enforces handle grammar", () => {
+    expect(normalizeInstagramUsername("@Jack")).toBe("jack");
+    expect(normalizeInstagramUsername("some.user_1")).toBe("some.user_1");
+    expect(normalizeInstagramUsername(" MixedCase ")).toBe("mixedcase");
+    expect(normalizeInstagramUsername("a".repeat(31))).toBe(null);
+    expect(normalizeInstagramUsername("has space")).toBe(null);
+    expect(normalizeInstagramUsername("bad/slash")).toBe(null);
+    expect(normalizeInstagramUsername("")).toBe(null);
+    expect(normalizeInstagramUsername(null)).toBe(null);
+  });
+
+  test("reserved non-profile path segments are rejected (no post/reel forks)", () => {
+    for (const seg of [
+      "p",
+      "reel",
+      "reels",
+      "stories",
+      "explore",
+      "accounts",
+    ]) {
+      expect(normalizeInstagramUsername(seg)).toBe(null);
+    }
+  });
+
+  test("usernameFromProfileUrl recovers the normalized handle from a profile link", () => {
+    expect(usernameFromProfileUrl("https://www.instagram.com/Jack")).toBe(
+      "jack"
+    );
+    expect(
+      usernameFromProfileUrl("https://instagram.com/some.user_1?hl=en")
+    ).toBe("some.user_1");
+    // A shared-post link resolves to a reserved segment -> not a person.
+    expect(usernameFromProfileUrl("https://instagram.com/p/Cabc123/")).toBe(
+      null
+    );
+    expect(usernameFromProfileUrl("not-a-link")).toBe(null);
+    expect(usernameFromProfileUrl(null)).toBe(null);
+  });
+
+  test("namespace is the IG-internal username key", () => {
+    expect(INSTAGRAM_IDENTITY.USERNAME).toBe("ig_username");
+  });
+});
+
+describe("InstagramTakeoutConnector identity attributions", () => {
+  test("connections feed attributes `about` a person keyed EQUAL-WEIGHT on ig_username", () => {
+    const def = new InstagramTakeoutConnector().definition;
+    for (const kind of [
+      "follower",
+      "following",
+      "blocked_profiles",
+      "restricted_profiles",
+    ] as const) {
+      const attr = def.feeds.connections.eventKinds[kind].attributions?.[0];
+      expect(attr).toBeDefined();
+      expect(attr.role).toBe("about");
+      expect(attr.autoCreate).toBe(true);
+      expect(attr.target.entityType).toBe("person");
+      const id = attr.target.identities[0];
+      expect(id).toMatchObject({
+        namespace: "ig_username",
+        eventPath: "metadata.username",
+      });
+      // Username is user-changeable -> a soft key, NEVER primary (equal-weight,
+      // like linkedin_slug). A primary would fork the same handle across feeds.
+      expect(id.primary).toBeUndefined();
+    }
+  });
+
+  test("auto-create is gated on a resolvable username (no id-less forks)", () => {
+    const def = new InstagramTakeoutConnector().definition;
+    const attr = def.feeds.connections.eventKinds.follower.attributions[0];
+    expect(attr.target.createWhen).toEqual({
+      path: "metadata.username",
+      exists: true,
+    });
+  });
+});
+
+describe("InstagramTakeoutConnector emits metadata the attributions resolve", () => {
+  function writeConnectionsFixture(): string {
+    const dir = mkdtempSync(path.join(tmpdir(), "ig-takeout-"));
+    const root = path.join(dir, "connections", "followers_and_following");
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      path.join(root, "followers_1.html"),
+      `<html><body><main>
+        <a href="https://www.instagram.com/aykut.gk">Aykut Gedik</a>
+        <a href="https://www.instagram.com/p/Cxyz/">a shared post</a>
+      </main></body></html>`
+    );
+    // Same handle appears in following.html -> must fold onto ONE person.
+    writeFileSync(
+      path.join(root, "following.html"),
+      `<html><body><main>
+        <a href="https://www.instagram.com/Aykut.GK">Aykut Gedik</a>
+      </main></body></html>`
+    );
+    return dir;
+  }
+
+  test("a follower row emits a normalized username the identity keys on", () => {
+    const dir = writeConnectionsFixture();
+    const connector = new InstagramTakeoutConnector();
+    const events = (connector as any).readConnectionEvents(dir);
+    const followers = events.filter(
+      (e: any) =>
+        e.origin_type === "follower" && e.author_name === "Aykut Gedik"
+    );
+    expect(followers).toHaveLength(1);
+    expect(resolvePath(followers[0], "metadata.username")).toBe("aykut.gk");
+    expect(resolvePath(followers[0], "metadata.platform")).toBe("instagram");
+  });
+
+  test("the same handle in followers AND following normalizes to ONE key (dedup)", () => {
+    const dir = writeConnectionsFixture();
+    const connector = new InstagramTakeoutConnector();
+    const events = (connector as any).readConnectionEvents(dir);
+    const usernames = events
+      .filter((e: any) => ["follower", "following"].includes(e.origin_type))
+      .map((e: any) => resolvePath(e, "metadata.username"))
+      .filter(Boolean);
+    // "aykut.gk" (follower) and "Aykut.GK" (following) collapse to one value.
+    expect(new Set(usernames)).toEqual(new Set(["aykut.gk"]));
+  });
+
+  test("a non-profile link (shared post) emits no username -> mint-gated off", () => {
+    const dir = writeConnectionsFixture();
+    const connector = new InstagramTakeoutConnector();
+    const events = (connector as any).readConnectionEvents(dir);
+    const postRow = events.find((e: any) => e.author_name === "a shared post");
+    expect(postRow).toBeDefined();
+    // username is undefined -> createWhen(exists) false -> never mints a person.
+    expect(resolvePath(postRow, "metadata.username")).toBeUndefined();
+  });
+});
+
+function resolvePath(obj: any, dotPath: string): unknown {
+  return dotPath.split(".").reduce((acc, key) => acc?.[key], obj);
+}

--- a/examples/personal-agent/instagram-identity.ts
+++ b/examples/personal-agent/instagram-identity.ts
@@ -1,0 +1,99 @@
+/**
+ * Instagram connector identity namespaces and normalization.
+ *
+ * Single source of truth for the Instagram identity vocabulary in the example
+ * package. The takeout connector (instagram-takeout.connector.ts) imports from
+ * here; a server wiring the example package would assemble `instagramIdentityModule`
+ * into its ingest normalizer chain — mirroring x-identity.ts / linkedin-identity.ts.
+ *
+ * Unlike X (immutable numeric `x_user_id`) or LinkedIn (member id from the live
+ * Voyager feed), the Instagram TAKEOUT exposes NO stable numeric id anywhere —
+ * every people-bearing surface (followers/following/blocked HTML) names a person
+ * only by `instagram.com/<username>`. So `ig_username` is the only key available.
+ * It is USER-CHANGEABLE, hence a soft key (NOT `primary`) — matched equal-weight,
+ * exactly like `linkedin_slug`. This is deliberately an IG-INTERNAL dedup key: it
+ * folds the same handle across the export's own feeds (a person who is BOTH a
+ * follower and a following becomes ONE entity). There is no live Instagram
+ * connector to fuse with, so the namespace string is scoped to this package.
+ */
+
+import type { ConnectorIdentityModule } from "./linkedin-identity.ts";
+
+/** Connector-owned identity namespaces (not SDK-global). */
+export const INSTAGRAM_IDENTITY = {
+  /**
+   * Instagram `@username` (handle), lowercased and stripped of the leading `@`.
+   * The ONLY cross-referenceable person key a takeout gives. USER-CHANGEABLE, so
+   * it is a soft key — NOT `primary` — matched equal-weight. Case-insensitive so
+   * the same person never forks across the CASE-SENSITIVE `entity_identities`
+   * UNIQUE index.
+   */
+  USERNAME: "ig_username",
+} as const;
+
+export type InstagramIdentityNamespace =
+  (typeof INSTAGRAM_IDENTITY)[keyof typeof INSTAGRAM_IDENTITY];
+
+/**
+ * Normalize an Instagram username. Lowercase, strip a leading `@`, and require
+ * the handle grammar (1–30 of [a-z0-9._]). Returns `null` for anything that is
+ * not a plausible handle — which importantly rejects the non-profile paths that
+ * appear as `instagram.com/<segment>` links (`p`, `reel`, `stories`, `explore`,
+ * `accounts`), so a shared-post link never mints a "person".
+ */
+export function normalizeInstagramUsername(
+  raw: string | null | undefined
+): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim().replace(/^@+/, "").toLowerCase();
+  if (!trimmed || !/^[a-z0-9._]{1,30}$/.test(trimmed)) return null;
+  // Reserved non-profile path segments that show up as instagram.com/<seg>.
+  const RESERVED = new Set([
+    "p",
+    "reel",
+    "reels",
+    "stories",
+    "explore",
+    "accounts",
+    "direct",
+    "about",
+    "developer",
+    "legal",
+  ]);
+  if (RESERVED.has(trimmed)) return null;
+  return trimmed;
+}
+
+/** Pull a normalized username out of an `instagram.com/<username>` profile link. */
+export function usernameFromProfileUrl(
+  url: string | null | undefined
+): string | null {
+  if (typeof url !== "string") return null;
+  const match = url.match(/instagram\.com\/([^/?#]+)/i);
+  return match ? normalizeInstagramUsername(match[1]) : null;
+}
+
+/**
+ * Normalize an Instagram identity namespace value. Returns `undefined` when the
+ * namespace is not IG-owned (caller falls back to generic hygiene).
+ */
+export function normalizeInstagramIdentityValue(
+  namespace: string,
+  raw: string
+): string | null | undefined {
+  switch (namespace) {
+    case INSTAGRAM_IDENTITY.USERNAME:
+      return normalizeInstagramUsername(raw);
+    default:
+      return undefined;
+  }
+}
+
+/** The Instagram connector's contribution to the server identity wiring. */
+export const instagramIdentityModule: ConnectorIdentityModule = {
+  key: "instagram",
+  // No recall index for ig_username — it is a match/attribution key only, like
+  // linkedin_slug (no idx_events_metadata_ig_username exists).
+  recallNamespaces: [],
+  normalize: normalizeInstagramIdentityValue,
+};

--- a/examples/personal-agent/instagram-takeout.connector.ts
+++ b/examples/personal-agent/instagram-takeout.connector.ts
@@ -3,10 +3,15 @@ import path from "node:path";
 import {
   type ConnectorDefinition,
   ConnectorRuntime,
+  type EventAttributionRule,
   type EventEnvelope,
   type SyncContext,
   type SyncResult,
 } from "@lobu/connector-sdk";
+import {
+  INSTAGRAM_IDENTITY,
+  usernameFromProfileUrl,
+} from "./instagram-identity.ts";
 import {
   assertDirectory,
   batchSize,
@@ -17,6 +22,48 @@ import {
   stripHtml,
   takeBatch,
 } from "./takeout-utils.ts";
+
+/**
+ * IG-INTERNAL identity attribution for the connections feed (followers /
+ * following / blocked / restricted). The takeout has no numeric id, so people
+ * are keyed on `ig_username` — the only cross-referenceable handle a takeout
+ * gives. It is USER-CHANGEABLE, so it is matched EQUAL-WEIGHT (NOT `primary`),
+ * exactly like `linkedin_slug`: the same handle appearing in BOTH followers and
+ * following folds onto ONE person instead of forking two.
+ *
+ * `createWhen: { metadata.username exists }` gates minting on a normalized
+ * handle being present — a `blocked`/`restricted` row that is only a display
+ * name with no resolvable `instagram.com/<user>` link (so `username` is absent)
+ * accretes onto an existing person but never MINTS an id-less duplicate. This is
+ * the same mint-gate that codex flagged for the X handle-only-follow case.
+ */
+const IG_CONNECTION_ATTRIBUTIONS: EventAttributionRule[] = [
+  {
+    role: "about",
+    autoCreate: true,
+    target: {
+      entityType: "person",
+      createWhen: { path: "metadata.username", exists: true },
+      titlePath: "author_name",
+      identities: [
+        {
+          namespace: INSTAGRAM_IDENTITY.USERNAME,
+          eventPath: "metadata.username",
+        },
+      ],
+    },
+    traits: {
+      ig_username: {
+        eventPath: "metadata.username",
+        behavior: "prefer_non_empty",
+      },
+      instagram_profile_url: {
+        eventPath: "metadata.profile_url",
+        behavior: "prefer_non_empty",
+      },
+    },
+  },
+];
 
 interface InstagramTakeoutCheckpoint {
   last_messages_timestamp?: string;
@@ -56,6 +103,24 @@ export default class InstagramTakeoutConnector extends ConnectorRuntime<
         configSchema: localTakeoutSchema(
           "Path to the Instagram export folder."
         ),
+        eventKinds: {
+          follower: {
+            description: "An account that follows the user",
+            attributions: IG_CONNECTION_ATTRIBUTIONS,
+          },
+          following: {
+            description: "An account the user follows",
+            attributions: IG_CONNECTION_ATTRIBUTIONS,
+          },
+          blocked_profiles: {
+            description: "An account the user has blocked",
+            attributions: IG_CONNECTION_ATTRIBUTIONS,
+          },
+          restricted_profiles: {
+            description: "An account the user has restricted",
+            attributions: IG_CONNECTION_ATTRIBUTIONS,
+          },
+        },
       },
       saved: {
         key: "saved",
@@ -333,6 +398,10 @@ export default class InstagramTakeoutConnector extends ConnectorRuntime<
         const url = match[1] ?? "";
         const name = stripHtml(match[2] ?? "");
         if (!url || !name) return [];
+        // Normalized handle keyed by the identity resolver. `undefined` (not "")
+        // when the link is not a resolvable profile, so `createWhen exists`
+        // gates minting a person on a real handle being present.
+        const username = usernameFromProfileUrl(url) ?? undefined;
         return [
           {
             origin_id: stableId("ig_connection", [kind, url, name]),
@@ -345,7 +414,7 @@ export default class InstagramTakeoutConnector extends ConnectorRuntime<
               platform: "instagram",
               kind,
               profile_url: url,
-              username: url.match(/instagram\.com\/([^/?#]+)/)?.[1],
+              username,
             },
           },
         ];


### PR DESCRIPTION
## What

Adds an `ig_username` identity to the Instagram **takeout** connector so the same handle appearing across the export's own feeds (followers / following / blocked / restricted) folds onto **one** person entity instead of forking duplicates.

## Why this shape

The Instagram takeout exposes **no stable numeric id** — every people-bearing surface names a person only by `instagram.com/<username>`. And there is **no live Instagram connector** to fuse with (confirmed: none in `packages/connectors`). So the only achievable win is *IG-internal* dedup, keyed on the username.

Because the username is **user-changeable**, it is matched **equal-weight (never `primary`)** — exactly like `linkedin_slug`. A primary key here would *fork* the same handle across feeds (the resolver mints on a primary miss rather than falling back to a secondary hit).

## Fork/mint safety

- `createWhen: { metadata.username exists }` gates auto-create on a resolvable handle — a `blocked`/`restricted` row that is only a display name (no profile link) accretes but never **mints** an id-less duplicate.
- The normalizer rejects reserved non-profile segments (`p`, `reel`, `stories`, …) so a shared-post link never becomes a "person".
- Emitted `metadata.username` is now **normalized** (lowercased, `@`-stripped) so it matches the resolver key and doesn't fork on case.

## Tests

9 new tests (normalization, reserved-path rejection, **cross-feed dedup** — same handle in followers + following → one key, and the mint-gate). Full `examples/personal-agent` suite: **75 pass / 0 fail**.

Reviewed by codex (advisor): "no correctness bugs" — confirmed equal-weight key, createWhen gate, key match, and case normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786141241&installation_id=136316292&pr_number=1812&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1812&signature=d5389cf5bcc268ec989fe2590d2c6049bced7485d9282a6d28a0a66cd617a735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Instagram identity normalization for usernames and profile URLs.
  * Improved Instagram connection handling with shared attribution rules across connection types.

* **Bug Fixes**
  * Normalizes usernames consistently by trimming, lowercasing, and stripping `@`.
  * Ignores non-profile and reserved Instagram paths, preventing incorrect identity creation.
  * Deduplicates username metadata across differently formatted profile links.

* **Tests**
  * Added coverage for username normalization, profile URL parsing, attribution behavior, and gated auto-creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->