### PR TITLE
fix(instagram): recover real handle from /_u/ deeplink in following.html

### DIFF
--- a/examples/personal-agent/__tests__/instagram-takeout.connector.test.ts
+++ b/examples/personal-agent/__tests__/instagram-takeout.connector.test.ts
@@ -62,6 +62,18 @@ describe("instagram-identity normalization", () => {
     expect(usernameFromProfileUrl(null)).toBe(null);
   });
 
+  test("recovers the REAL handle from the /_u/ app-deeplink form (following.html)", () => {
+    // following.html links are instagram.com/_u/<handle> — the handle is the
+    // segment AFTER the deeplink marker. Grabbing the first segment maps every
+    // following row to "_u" and mass-merges them into one bogus person.
+    expect(
+      usernameFromProfileUrl("https://www.instagram.com/_u/zeynepkaraman")
+    ).toBe("zeynepkaraman");
+    expect(usernameFromProfileUrl("https://instagram.com/_n/some.user")).toBe(
+      "some.user"
+    );
+  });
+
   test("namespace is the IG-internal username key", () => {
     expect(INSTAGRAM_IDENTITY.USERNAME).toBe("ig_username");
   });
@@ -115,10 +127,11 @@ describe("InstagramTakeoutConnector emits metadata the attributions resolve", ()
       </main></body></html>`
     );
     // Same handle appears in following.html -> must fold onto ONE person.
+    // following.html uses the real /_u/ app-deeplink form (see the connector).
     writeFileSync(
       path.join(root, "following.html"),
       `<html><body><main>
-        <a href="https://www.instagram.com/Aykut.GK">Aykut Gedik</a>
+        <a href="https://www.instagram.com/_u/Aykut.GK">Aykut Gedik</a>
       </main></body></html>`
     );
     return dir;

--- a/examples/personal-agent/instagram-identity.ts
+++ b/examples/personal-agent/instagram-identity.ts
@@ -64,11 +64,22 @@ export function normalizeInstagramUsername(
   return trimmed;
 }
 
-/** Pull a normalized username out of an `instagram.com/<username>` profile link. */
+/**
+ * Pull a normalized username out of an `instagram.com/<username>` profile link.
+ *
+ * The takeout's `following.html` uses Instagram's app-deeplink form
+ * `instagram.com/_u/<username>` (and `/_n/<username>`), where the REAL handle is
+ * the segment AFTER the `_u`/`_n` prefix — the first segment is just the
+ * deeplink marker. `followers_*.html` uses the plain `instagram.com/<username>`.
+ * Grabbing the first segment blindly maps every following row to `_u` and
+ * mass-merges them into one bogus person, so strip the prefix first.
+ */
 export function usernameFromProfileUrl(
   url: string | null | undefined
 ): string | null {
   if (typeof url !== "string") return null;
+  const deep = url.match(/instagram\.com\/_[a-z]\/([^/?#]+)/i);
+  if (deep) return normalizeInstagramUsername(deep[1]);
   const match = url.match(/instagram\.com\/([^/?#]+)/i);
   return match ? normalizeInstagramUsername(match[1]) : null;
 }


### PR DESCRIPTION
Follow-up to #1812, caught by testing against buremba's real Instagram export.

`following.html` links use Instagram's app-deeplink form `instagram.com/_u/<handle>` — the real username is the segment **after** the `_u` marker. The original first-segment regex mapped **all 444 following rows to username `_u`**, which would mass-merge every followed account into ONE bogus person (a catastrophic reverse-fork). `followers_*.html` uses the plain form and was fine.

Fix: strip the `/_u/` (and `/_n/`) deeplink prefix before taking the handle.

Red→green: reverting the fix fails 2 tests (the `_u` recovery test and the cross-feed dedup test, whose fixture now uses the real `_u/` shape). 10/10 with the fix; examples suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786141530&installation_id=136316292&pr_number=1813&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1813&signature=f7ffc36b1c7b4fc5b65132e4cbc2ad113bd1349cf15221abdb69c5b8996a2f2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->