### PR TITLE
fix(instagram): reject _u/_n deeplink markers in the username normalizer

### DIFF
--- a/examples/personal-agent/__tests__/instagram-takeout.connector.test.ts
+++ b/examples/personal-agent/__tests__/instagram-takeout.connector.test.ts
@@ -47,6 +47,13 @@ describe("instagram-identity normalization", () => {
     }
   });
 
+  test("the _u/_n deeplink markers never normalize to a username (no mass-merge)", () => {
+    // Defense-in-depth: even a raw `_u` reaching the normalizer must be rejected,
+    // so a following row that somehow keeps the marker can't fork/mass-merge.
+    expect(normalizeInstagramUsername("_u")).toBe(null);
+    expect(normalizeInstagramUsername("_n")).toBe(null);
+  });
+
   test("usernameFromProfileUrl recovers the normalized handle from a profile link", () => {
     expect(usernameFromProfileUrl("https://www.instagram.com/Jack")).toBe(
       "jack"

--- a/examples/personal-agent/instagram-identity.ts
+++ b/examples/personal-agent/instagram-identity.ts
@@ -48,6 +48,10 @@ export function normalizeInstagramUsername(
   const trimmed = raw.trim().replace(/^@+/, "").toLowerCase();
   if (!trimmed || !/^[a-z0-9._]{1,30}$/.test(trimmed)) return null;
   // Reserved non-profile path segments that show up as instagram.com/<seg>.
+  // Includes the `_u`/`_n` app-deeplink markers: even though usernameFromProfileUrl
+  // strips them upstream, rejecting them here is defense-in-depth so a raw `_u`
+  // reaching normalization can NEVER become a person (which would mass-merge
+  // every following row into one bogus entity).
   const RESERVED = new Set([
     "p",
     "reel",
@@ -59,6 +63,8 @@ export function normalizeInstagramUsername(
     "about",
     "developer",
     "legal",
+    "_u",
+    "_n",
   ]);
   if (RESERVED.has(trimmed)) return null;
   return trimmed;


### PR DESCRIPTION
Defense-in-depth follow-up to the /_u/ deeplink fix. Even if a raw `_u` reaches `normalizeInstagramUsername` (bypassing the URL-level strip), it must never become a person — otherwise every `following` row keyed on `_u` mass-merges into one bogus entity. Adds `_u`/`_n` to the reserved set. +1 test. Verified against buremba's real export (444 following rows previously all mapped to `_u`; confirmed NO bogus `_u` person was created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786141806&installation_id=136316292&pr_number=1814&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1814&signature=7d2c7a302d9e046123996c08e6be6434f1789e1b76a81ddb6dbb00b851a96c9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->