### PR TITLE
chore(personal-agent): point buremba LinkedIn connection at the unified connector

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -683,7 +683,7 @@ const instagramTakeoutConnection = defineConnection({
 // require a company_url, so add them per-company when tracking a specific page
 // (e.g. { feed: "company_updates", config: { company_url: "https://www.linkedin.com/company/openai" } }).
 const linkedinConnection = defineConnection({
-  slug: "linkedin-takeout-buremba",
+  slug: "linkedin-buremba",
   connector: "linkedin",
   name: "LinkedIn",
   feeds: [


### PR DESCRIPTION
The config declared `linkedin-takeout-buremba` bound to the merged `linkedin` connector, but that slug is remotely bound to the old `linkedin.takeout` (now-paused conn 410). The unified connector is conn 412 `linkedin-buremba`. Update the slug so `lobu apply` reflects the go-forward connection and stops erroring on the connector_key mismatch. Config-only; dry-run plan is non-destructive (updates device pins, re-installs connectors, leaves the paused conn as ignored drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786143722&installation_id=136316292&pr_number=1815&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1815&signature=e2c8680819f62a2230e72c450904f4ca41a33c7b27c89c4f570b67f767d7385b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->