### PR TITLE
fix(slack): org-wide Grid install (oauth.v2.access no team id) + sibling pending routing

### DIFF
--- a/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
@@ -525,4 +525,61 @@ describe("Grid install-model routing (per-workspace + org-wide enterprise)", () 
     const solo = await slack.getSlackInstallByEnterpriseId(store, "E_PLAIN");
     expect(solo?.organizationId).toBe("org-plain");
   });
+
+  test("org-wide pending (keyed on enterprise id) resolves for a sibling-workspace event via the enterprise fallback", async () => {
+    // The real org-wide install flow: oauth.v2.access returns no team id, so the
+    // pending row is keyed on the ENTERPRISE id (E_ORG). A sibling-workspace event
+    // in the pre-claim window arrives stamped with the sibling's team id (T_SIB),
+    // which never equals E_ORG — so resolveSlackPendingByTenant must fall back to
+    // the enterprise id to find the parked org-wide install (else the unclaimed
+    // reply / connect-link never fires for siblings).
+    const { slack } = build();
+    await slack.writeSlackPendingInstall({
+      teamId: "E_ORG", // enterprise id stands in as the identity key (no team id)
+      teamName: "Org Sandbox",
+      botUserId: "U_BOT",
+      botToken: "xoxb-org",
+      installerUserId: "U_OWNER",
+      isEnterpriseInstall: true,
+      enterpriseId: "E_ORG",
+    });
+
+    // Exact miss on the sibling team id, but enterprise fallback finds it.
+    const bySibling = await slack.resolveSlackPendingByTenant("T_SIB", "E_ORG");
+    expect(bySibling?.teamId).toBe("E_ORG");
+    expect(bySibling?.isEnterpriseInstall).toBe(true);
+
+    // Without the enterprise hint, a sibling team id alone does NOT resolve it.
+    expect(await slack.resolveSlackPendingByTenant("T_SIB")).toBeNull();
+
+    // The exact enterprise-id key still resolves directly (the claim ref path).
+    expect((await slack.resolveSlackPendingByTenant("E_ORG"))?.teamId).toBe(
+      "E_ORG",
+    );
+  });
+
+  test("a plain per-workspace pending is NOT matched by a sibling's enterprise id", async () => {
+    // Guard the negative: a non-org-wide pending row (is_enterprise_install=false)
+    // must never be claimed by an unrelated sibling event that happens to carry
+    // the same enterprise id — only a flagged org-wide row answers the fallback.
+    const { slack } = build();
+    await slack.writeSlackPendingInstall({
+      teamId: "T_ONLY",
+      teamName: "Single WS",
+      botUserId: "U_BOT",
+      botToken: "xoxb-only",
+      installerUserId: "U_INSTALLER",
+      isEnterpriseInstall: false,
+      enterpriseId: "E_SHARED",
+    });
+
+    // A different sibling under the same enterprise must not resolve this row.
+    expect(
+      await slack.resolveSlackPendingByTenant("T_OTHER", "E_SHARED"),
+    ).toBeNull();
+    // Its own team id still resolves it.
+    expect((await slack.resolveSlackPendingByTenant("T_ONLY"))?.teamId).toBe(
+      "T_ONLY",
+    );
+  });
 });

--- a/packages/server/src/gateway/connections/__tests__/slack-web.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-web.test.ts
@@ -61,3 +61,79 @@ describe("createSlackWebApi wire format", () => {
     );
   });
 });
+
+describe("exchangeOAuthCode install shapes", () => {
+  const OAUTH_ARGS = {
+    clientId: "cid",
+    clientSecret: "secret",
+    code: "the-code",
+    redirectUri: "https://app.lobu.ai/lobu/slack/oauth_callback",
+  };
+
+  test("per-workspace install returns the team id as the identity key", async () => {
+    globalThis.fetch = mock(async () => ({
+      json: async () => ({
+        ok: true,
+        access_token: "xoxb-ws",
+        team: { id: "T123", name: "Acme" },
+        enterprise: null,
+        is_enterprise_install: false,
+        bot_user_id: "B1",
+        authed_user: { id: "U1" },
+      }),
+    })) as unknown as typeof fetch;
+
+    const api = createSlackWebApi();
+    const result = await api.exchangeOAuthCode(OAUTH_ARGS);
+
+    expect(result.teamId).toBe("T123");
+    expect(result.teamName).toBe("Acme");
+    expect(result.isEnterpriseInstall).toBe(false);
+    expect(result.enterpriseId).toBeNull();
+  });
+
+  test("org-wide enterprise install (no team id) resolves the enterprise id as the identity key", async () => {
+    // Grid org-wide install: Slack's oauth.v2.access returns NO `team` — the app
+    // is installed at the enterprise level — but sets `is_enterprise_install:true`
+    // and `enterprise:{id,name}`. The exchange must NOT reject this as a failed
+    // install; the enterprise id is the routing/identity key.
+    globalThis.fetch = mock(async () => ({
+      json: async () => ({
+        ok: true,
+        access_token: "xoxb-ent",
+        team: null,
+        enterprise: { id: "E0BDSKL1KJL", name: "LobuSandbox" },
+        is_enterprise_install: true,
+        bot_user_id: "B2",
+        authed_user: { id: "U2" },
+      }),
+    })) as unknown as typeof fetch;
+
+    const api = createSlackWebApi();
+    const result = await api.exchangeOAuthCode(OAUTH_ARGS);
+
+    expect(result.isEnterpriseInstall).toBe(true);
+    expect(result.enterpriseId).toBe("E0BDSKL1KJL");
+    // The enterprise id stands in as the identity key so the pending row,
+    // claim ref, and enterprise-fallback routing all get a stable non-null id.
+    expect(result.teamId).toBe("E0BDSKL1KJL");
+    expect(result.teamName).toBe("LobuSandbox");
+  });
+
+  test("no team id AND not an enterprise install still throws", async () => {
+    globalThis.fetch = mock(async () => ({
+      json: async () => ({
+        ok: true,
+        access_token: "xoxb-x",
+        team: null,
+        enterprise: null,
+        is_enterprise_install: false,
+      }),
+    })) as unknown as typeof fetch;
+
+    const api = createSlackWebApi();
+    await expect(api.exchangeOAuthCode(OAUTH_ARGS)).rejects.toThrow(
+      /no team id/,
+    );
+  });
+});

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -473,11 +473,15 @@ export class SlackConnectionCoordinator {
       // 3) A workspace that installed Lobu but hasn't been CLAIMED into a Lobu
       //    org yet (a `pending` install). Don't silently drop their messages —
       //    reply with the connect link so a workspace admin can finish setup.
-      const pending = await resolveSlackPendingByTenant(teamId);
+      const pending = await resolveSlackPendingByTenant(teamId, enterpriseId);
       if (pending) {
         return await this.replyUnclaimedWorkspace(
           pending.botToken,
-          teamId,
+          // Use the PENDING ROW's own key as the claim ref, not the event's team
+          // id: for a Grid org-wide install the pending row is keyed on the
+          // enterprise id, and a sibling-workspace event's team id would not
+          // resolve the pending row at claim time.
+          pending.teamId,
           body,
           contentType,
           request.headers.get("x-slack-retry-num") !== null,

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -223,28 +223,47 @@ export function createSlackWebApi(): SlackWebApi {
           `Slack oauth.v2.access failed: ${String(json.error ?? res.status)}`
         );
       }
-      const team = json.team as { id?: string; name?: string } | undefined;
-      const enterprise = json.enterprise as { id?: string } | undefined;
+      const team = json.team as
+        | { id?: string; name?: string }
+        | null
+        | undefined;
+      const enterprise = json.enterprise as
+        | { id?: string; name?: string }
+        | null
+        | undefined;
       const authedUser = json.authed_user as { id?: string } | undefined;
       const botToken = json.access_token;
-      const teamId = team?.id;
+      const isEnterpriseInstall = json.is_enterprise_install === true;
+      const enterpriseId =
+        typeof enterprise?.id === "string" ? enterprise.id : null;
+      // For a Grid ORG-WIDE install the app is installed at the enterprise level,
+      // so `oauth.v2.access` returns NO `team` — the enterprise id is the only
+      // identity. Fall back to it as the routing/identity key (the pending row,
+      // claim ref, and enterprise-fallback routing all key on this). A missing
+      // team id is only fatal for a NON-enterprise install.
+      const identityId =
+        team?.id ?? (isEnterpriseInstall ? enterpriseId : null);
       if (typeof botToken !== "string" || !botToken) {
         throw new Error("Slack oauth.v2.access returned no access_token");
       }
-      if (typeof teamId !== "string" || !teamId) {
+      if (typeof identityId !== "string" || !identityId) {
         throw new Error("Slack oauth.v2.access returned no team id");
       }
+      const subjectName =
+        (typeof team?.name === "string" ? team.name : null) ??
+        (isEnterpriseInstall && typeof enterprise?.name === "string"
+          ? enterprise.name
+          : null);
       return {
         botToken,
-        teamId,
-        teamName: typeof team?.name === "string" ? team.name : null,
+        teamId: identityId,
+        teamName: subjectName,
         botUserId:
           typeof json.bot_user_id === "string" ? json.bot_user_id : null,
         authedUserId:
           typeof authedUser?.id === "string" ? authedUser.id : null,
-        isEnterpriseInstall: json.is_enterprise_install === true,
-        enterpriseId:
-          typeof enterprise?.id === "string" ? enterprise.id : null,
+        isEnterpriseInstall,
+        enterpriseId,
       };
     },
   };

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -600,17 +600,31 @@ export async function writeSlackPendingInstall(
 
 /** Resolve the pending (unclaimed) install for a Slack workspace, if any. */
 export async function resolveSlackPendingByTenant(
-  teamId: string
+  teamId: string,
+  enterpriseId?: string | null
 ): Promise<SlackPendingInstall | null> {
   const sql = getDb();
+  // Match the pending row by its own external_tenant_id (the exact workspace, or
+  // — for a Grid ORG-WIDE install — the enterprise id). A sibling-workspace event
+  // arriving in the post-install/pre-claim window carries the sibling's team_id,
+  // which never equals the org-wide pending row's enterprise-id key, so fall back
+  // to the enterprise id (only when the org-wide row also flags itself, so a plain
+  // per-workspace pending row is never matched by a sibling's enterprise id).
   const rows = (await sql`
     SELECT id, external_tenant_id, metadata
     FROM app_installations
     WHERE provider = ${SLACK_PROVIDER}
       AND provider_app_id = ${SLACK_PROVIDER_APP_ID}
-      AND external_tenant_id = ${teamId}
       AND status = 'pending'
-    ORDER BY created_at DESC
+      AND (
+        external_tenant_id = ${teamId}
+        OR (
+          ${enterpriseId ?? null}::text IS NOT NULL
+          AND external_tenant_id = ${enterpriseId ?? null}
+          AND (metadata->'is_enterprise_install') = 'true'::jsonb
+        )
+      )
+    ORDER BY (external_tenant_id = ${teamId}) DESC, created_at DESC
     LIMIT 1
   `) as Array<{
     id: number | string;


### PR DESCRIPTION
## Problem

Driving the real new-user flow (`app.lobu.ai/lobu/slack/install` → Slack OAuth → pick the **org** under "Your organisations" → Allow) for a Grid **org-wide** install failed at the callback with:

> **Authentication Failed — Slack oauth.v2.access returned no team id** (`slack_install_failed`)

## Root cause

For a Grid org-wide install the app is installed at the enterprise level, so `oauth.v2.access` returns **no `team`** — instead `is_enterprise_install: true` + `enterprise: {id, name}`. `exchangeOAuthCode` threw unconditionally on a missing team id, rejecting the enterprise response **before any of the enterprise-routing code (#1811) ran** — that routing was effectively dead code for the org-wide path.

## Fix (2 commits)

1. **OAuth exchange** (`slack-web.ts`): when `is_enterprise_install`, fall back to the enterprise id as the identity/routing key; a missing team id stays fatal only for a non-enterprise install. `teamName` falls back to `enterprise.name`.
2. **Pending routing** (`slack-installations.ts` + `slack-connection-coordinator.ts`): an org-wide install parks its pending row keyed on the enterprise id. A sibling-workspace event in the post-install/pre-claim window carries the sibling's `team_id`, which never equals that key — so `resolveSlackPendingByTenant` now falls back to the enterprise id (only for a row flagged `is_enterprise_install=true`; exact team-id match still wins), and the unclaimed-workspace connect reply uses the pending row's own key as the claim ref so it resolves at claim time.

Downstream was already coherent: `slack-claim.ts` Path 2 (Grid installer-identity match, gated on `pending.enterpriseId`) authorizes the Org Owner who provisioned without joining a workspace; `upsertSlackInstallByTeam` uses the enterprise id as `external_tenant_id`; `getSlackEnterpriseInstall` matches it.

Supports **both** install models — the per-workspace path is unchanged (covered by an explicit test).

## Tests (red→green)

- `slack-web.test.ts`: new `exchangeOAuthCode install shapes` — per-workspace, org-wide-enterprise (reproduced the exact "no team id" throw red), genuine-no-team-still-throws.
- `slack-installations.test.ts` (real Postgres): sibling event resolves the enterprise-keyed pending via the fallback (red without the store fix); negative guard — a plain per-workspace pending is **not** matched by a sibling's enterprise id.

Local gates: `make review` suites all green (typecheck=0, unit=0, integration=0); 5 Slack suites (56 tests) pass isolated; `make typecheck` clean; biome clean. (The `make review` LLM-verdict step hit an API "credit balance" error — infra, not code.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786152697&installation_id=136316292&pr_number=1816&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1816&signature=ef0981e0fd79ffc676c3a91ab978426b7fb260fdc8ad22054a2065d221992a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Slack connection support for enterprise/org-wide installs, including better handling of workspace and enterprise identifiers during setup.
  * Pending Slack install links now resolve more reliably across related workspaces in the same enterprise.

* **Bug Fixes**
  * Fixed Slack OAuth setup for enterprise installs when a workspace ID is not present.
  * Prevented incorrect matches between regular workspace installs and enterprise-wide pending installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->