### PR TITLE
feat(watchers): context:true SQL source for entity dedup windows

### DIFF
--- a/packages/core/src/contracts/tools/manage-watchers.ts
+++ b/packages/core/src/contracts/tools/manage-watchers.ts
@@ -3,6 +3,14 @@ import { type Static, Type } from "@sinclair/typebox";
 export const WatcherSourceSchema = Type.Object({
   name: Type.String(),
   query: Type.String(),
+  // When true, this SQL source is CONTEXT (like an @entity ref), not event
+  // content: its rows are handed to the agent for reasoning but are NOT linked
+  // into the window's event set. Use it to feed a filtered set of entities the
+  // agent should look at (e.g. duplicate-merge candidates) — the raw `id` it
+  // projects is an entity id, not an `events.id`, so it must NOT go through the
+  // watcher_window_events FK. A plain (non-context) SQL source stays event
+  // content and its `id` must be an `events.id`.
+  context: Type.Optional(Type.Boolean()),
 });
 export type WatcherSource = Static<typeof WatcherSourceSchema>;
 
@@ -78,6 +86,12 @@ export const SourceSchema = Type.Object({
     description:
       "SQL SELECT query. If it references the events table, time window bounds are auto-applied.",
   }),
+  context: Type.Optional(
+    Type.Boolean({
+      description:
+        "When true, the source is CONTEXT (like an @entity ref), not event content: its rows reach the agent but are NOT linked into the window's event set, so the `id` it projects may be an entity id rather than an events.id. Use for feeding a filtered entity set (e.g. duplicate-merge candidates) the agent should reason over.",
+    })
+  ),
 });
 
 // Flattened schema for MCP compatibility (MCP doesn't support top-level unions)

--- a/packages/server/src/__tests__/unit/watcher-source-refs.test.ts
+++ b/packages/server/src/__tests__/unit/watcher-source-refs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	extractSourcesFromPromptTokens,
 	mergePromptSources,
+	normalizeWatcherSources,
 	parseWatcherSourceRef,
 	validateWatcherSourceRef,
 	watcherSourceKindForRef,
@@ -133,5 +134,41 @@ describe("mergePromptSources", () => {
 			{ name: "slack", query: "@feed:a" },
 			{ name: "slack_2", query: "@connection:7" },
 		]);
+	});
+});
+
+describe("normalizeWatcherSources source.context classification", () => {
+	// A no-ref SQL source never touches the DB in normalizeWatcherSources, so a
+	// stub sql client is enough — it must not be called for these cases.
+	const sql = (() => {
+		throw new Error("sql should not be called for no-ref SQL sources");
+	}) as never;
+
+	it("classifies a plain SQL source as event content (id must be an events.id)", async () => {
+		const [normalized] = await normalizeWatcherSources(sql, "org", [
+			{ name: "window", query: "SELECT id FROM events WHERE 1=0" },
+		]);
+		expect(normalized.kind).toBe("event");
+	});
+
+	it("classifies a context:true SQL source as entity context (no events FK)", async () => {
+		const [normalized] = await normalizeWatcherSources(sql, "org", [
+			{
+				name: "candidates",
+				query: "SELECT id, name FROM entities WHERE entity_type='person'",
+				context: true,
+			},
+		]);
+		// kind:'entity' means its rows reach the agent but are excluded from the
+		// window's content_ids (see watcher-mode allContent), so the entity `id`
+		// never hits the watcher_window_events → events(id) foreign key.
+		expect(normalized.kind).toBe("entity");
+	});
+
+	it("context:false stays event content", async () => {
+		const [normalized] = await normalizeWatcherSources(sql, "org", [
+			{ name: "window", query: "SELECT id FROM events", context: false },
+		]);
+		expect(normalized.kind).toBe("event");
 	});
 });

--- a/packages/server/src/watchers/source-refs.ts
+++ b/packages/server/src/watchers/source-refs.ts
@@ -497,7 +497,11 @@ export async function normalizeWatcherSources(
   for (const source of sources) {
     const ref = parseWatcherSourceRef(source.query);
     if (!ref) {
-      normalized.push({ ...source, kind: 'event' });
+      // A `context: true` SQL source is entity context, not event content: its
+      // rows reach the agent but are never linked into watcher_window_events
+      // (so its `id` may be an entity id, sidestepping the events FK). A plain
+      // SQL source stays event content and its `id` must be an `events.id`.
+      normalized.push({ ...source, kind: source.context ? 'entity' : 'event' });
       continue;
     }
     const { query, kind } = await compileRefToQuery(sql, organizationId, ref);


### PR DESCRIPTION
## Problem

The duplicate-merge watcher (surfaces cross-platform contact duplicates for the user to approve) could never produce output. Root cause, traced against prod:

- A raw-SQL watcher source is classified `kind:'event'`, so every row `id` it projects is inserted into `watcher_window_events` — which has a FK to `events(id)`.
- Entity-dedup needs to window over **person entities**, whose ids are not event ids. `completeWindow` therefore always FK-failed (`insight_window_events_event_id_fkey`) the moment the window had content.
- The only non-event source, `@entity:person`, is unfiltered — it dumps the entire person table (~5.8k rows) and overflows the model context window.

So there was no way to feed a *filtered* set of entities to a watcher agent as reasoning context.

## Fix

Add an opt-in `context: true` flag to a watcher SQL source. A context source is classified `kind:'entity'` (same as an `@entity` ref):

- its rows are handed to the agent for reasoning (`sourcesContent`), but
- they are **excluded** from the window's `content_ids` (`allContent` only takes `kind:'event'` sources), so the projected `id` may be an entity id and never hits the `watcher_window_events → events(id)` FK.

A plain (non-context) SQL source is unchanged: event content, `id` must be an `events.id`.

This unblocks the duplicate-merge watcher — it now feeds only the name-collision candidate persons as context (a small, bounded set), instead of dumping the whole person table or FK-failing.

## Changes
- `WatcherSourceSchema` + `SourceSchema` (core contract): optional `context: boolean`.
- `normalizeWatcherSources`: a `context:true` no-ref SQL source → `kind:'entity'` instead of `'event'`.
- Unit test: red→green on the classification (`context:true` → `'entity'`; plain/`context:false` → `'event'`).

## Verification
- `bun test packages/server/src/__tests__/unit/watcher-source-refs.test.ts` — 14 pass (incl. 3 new). Confirmed red without the normalizer change.
- Core builds clean; pre-commit `tsc --noEmit` passed.
- Not yet exercised end-to-end on prod (needs this server image to ship). The duplicate-merge watcher (org buremba, watcher 6) is already staged on a `context:true` source version and will produce proposals once deployed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786153409&installation_id=136316292&pr_number=1818&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1818&signature=441d0ec61eff9ea02e66cd536d521911415ff8d87717000105d037650763a45f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->