### PR TITLE
fix(slack): stop the install on an app_uninstalled/app_deleted event

### DIFF
--- a/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-connection-coordinator.test.ts
@@ -9,7 +9,9 @@ import {
 } from "bun:test";
 import { getDb } from "../../db/client.js";
 import {
+  getSlackEnterpriseInstall,
   getSlackInstallByEnterpriseId,
+  getSlackInstallByTeamId,
   upsertSlackInstallByTeam,
 } from "../../lobu/stores/slack-installations.js";
 import {
@@ -303,6 +305,185 @@ describe("SlackConnectionCoordinator", () => {
 
     expect(response.status).toBe(200);
     expect(forwarded).toEqual([seeded.id]);
+  });
+
+  test("handleAppWebhook revokes the install on an app_uninstalled event (per-workspace)", async () => {
+    // Slack posts `app_uninstalled` when a workspace removes the app. The bot
+    // token is now dead; leaving the install `active` would route events to a
+    // zombie row that fails every send. The install must be stopped.
+    const appStore = makeAppInstallationStore();
+    const secretStore = makeSecretStore();
+    const seeded = await upsertSlackInstallByTeam(
+      appStore,
+      secretStore,
+      "org-acme",
+      "T-GONE",
+      { botToken: "xoxb-gone" },
+    );
+    const forwarded: string[] = [];
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        listSlackConnections: async () => [],
+        getAppInstallationStore: () => appStore,
+        getSecretStore: () => secretStore,
+        forwardWebhook: mock(async (connectionId: string) => {
+          forwarded.push(connectionId);
+          return new Response("ok");
+        }),
+      }),
+    );
+
+    const response = await coordinator.handleAppWebhook(
+      new Request("https://gateway.example.com/slack/events", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "event_callback",
+          team_id: "T-GONE",
+          event: { type: "app_uninstalled" },
+        }),
+      }),
+    );
+
+    // Acked (Slack retries on non-2xx), NOT forwarded to the dead install.
+    expect(response.status).toBe(200);
+    expect(forwarded).toEqual([]);
+    // The install is no longer active.
+    expect(
+      await getSlackInstallByTeamId(appStore, "T-GONE"),
+    ).toBeNull();
+    expect((seeded as { id: string }).id).toBeTruthy();
+  });
+
+  test("handleAppWebhook does NOT revoke the install on a tokens_revoked event", async () => {
+    // tokens_revoked can fire for a single user-token de-authorization while the
+    // bot install is still valid — stopping the whole install would be too
+    // aggressive. Only app_uninstalled/app_deleted revoke.
+    const appStore = makeAppInstallationStore();
+    const secretStore = makeSecretStore();
+    const seeded = await upsertSlackInstallByTeam(
+      appStore,
+      secretStore,
+      "org-acme",
+      "T-KEEP",
+      { botToken: "xoxb-keep" },
+    );
+
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        listSlackConnections: async () => [],
+        getAppInstallationStore: () => appStore,
+        getSecretStore: () => secretStore,
+        // A tokens_revoked isn't a user message, so it won't forward; the assert
+        // that matters is the install stays active.
+        forwardWebhook: mock(async () => new Response("ok")),
+      }),
+    );
+
+    await coordinator.handleAppWebhook(
+      new Request("https://gateway.example.com/slack/events", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "event_callback",
+          team_id: "T-KEEP",
+          event: { type: "tokens_revoked", tokens: { bot: ["B1"] } },
+        }),
+      }),
+    );
+
+    // Install is still active — tokens_revoked is not treated as an uninstall.
+    expect((await getSlackInstallByTeamId(appStore, "T-KEEP"))?.id).toBe(
+      seeded.id,
+    );
+  });
+
+  test("handleAppWebhook revokes the org-wide install on an enterprise app_uninstalled event", async () => {
+    // A Grid org-wide uninstall arrives stamped with the enterprise id (and often
+    // no team id). The org-wide install (keyed on the enterprise id) must be
+    // stopped so sibling events stop routing to the dead token.
+    const appStore = makeAppInstallationStore();
+    const secretStore = makeSecretStore();
+    await upsertSlackInstallByTeam(
+      appStore,
+      secretStore,
+      "org-acme",
+      "E-GRID", // org-wide install is keyed on the enterprise id (no team id)
+      {
+        botToken: "xoxb-orgwide",
+        enterpriseId: "E-GRID",
+        isEnterpriseInstall: true,
+      },
+    );
+    expect(await getSlackEnterpriseInstall(appStore, "E-GRID")).not.toBeNull();
+
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        listSlackConnections: async () => [],
+        getAppInstallationStore: () => appStore,
+        getSecretStore: () => secretStore,
+      }),
+    );
+
+    const response = await coordinator.handleAppWebhook(
+      new Request("https://gateway.example.com/slack/events", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "event_callback",
+          enterprise_id: "E-GRID",
+          event: { type: "app_uninstalled" },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    // The org-wide install is stopped (no longer resolvable by the router).
+    expect(await getSlackEnterpriseInstall(appStore, "E-GRID")).toBeNull();
+  });
+
+  test("app_uninstalled for one Grid workspace does NOT revoke a sibling's own install", async () => {
+    // A per-workspace uninstall must stop only that workspace's install — a
+    // sibling's separately-installed row (same enterprise) stays active.
+    const appStore = makeAppInstallationStore();
+    const secretStore = makeSecretStore();
+    await upsertSlackInstallByTeam(appStore, secretStore, "org-acme", "T-GONE", {
+      botToken: "xoxb-gone",
+      enterpriseId: "E-GRID",
+    });
+    const sibling = await upsertSlackInstallByTeam(
+      appStore,
+      secretStore,
+      "org-acme",
+      "T-STAYS",
+      { botToken: "xoxb-stays", enterpriseId: "E-GRID" },
+    );
+
+    const coordinator = new SlackConnectionCoordinator(
+      makeDeps({
+        listSlackConnections: async () => [],
+        getAppInstallationStore: () => appStore,
+        getSecretStore: () => secretStore,
+      }),
+    );
+
+    await coordinator.handleAppWebhook(
+      new Request("https://gateway.example.com/slack/events", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "event_callback",
+          team_id: "T-GONE",
+          enterprise_id: "E-GRID",
+          event: { type: "app_uninstalled" },
+        }),
+      }),
+    );
+
+    expect(await getSlackInstallByTeamId(appStore, "T-GONE")).toBeNull();
+    // The sibling's OWN per-workspace install is untouched.
+    const stays = await getSlackInstallByTeamId(appStore, "T-STAYS");
+    expect(stays?.id).toBe(sibling.id);
   });
 
   test("Grid: a DM stamped with a sibling team id routes via the enterprise fallback", async () => {

--- a/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
@@ -37,6 +37,7 @@ mock.module("../../lobu/stores/slack-installations.js", () => ({
 	getSlackInstallByEnterpriseId: mock(async () => null),
 	getSlackEnterpriseInstall: mock(async () => null),
 	resolveSlackPendingByTenant: mock(async () => null),
+	revokeSlackInstallsForUninstall: mock(async () => []),
 	claimSlackWelcomeDm: mock(async () => null),
 }));
 

--- a/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
@@ -582,4 +582,71 @@ describe("Grid install-model routing (per-workspace + org-wide enterprise)", () 
       "T_ONLY",
     );
   });
+
+  test("revokeSlackInstallsForUninstall stops the org-wide install and its connection projection (enterprise uninstall)", async () => {
+    // A Grid org-wide uninstall carries only the enterprise id. The org-wide
+    // install (keyed on the enterprise id) must be stopped so the router stops
+    // sending to the dead token — verified end-to-end against real Postgres,
+    // including the connections projection pause that markSlackInstallStopped does.
+    const { store, secretStore, slack } = build();
+    const ENT = "E_UNINSTALL";
+    await seedAgentRow("t", { organizationId: "org-u" });
+    const orgWide = await slack.upsertSlackInstallByTeam(
+      store,
+      secretStore,
+      "org-u",
+      ENT, // org-wide is keyed on the enterprise id (no team id)
+      { botToken: "xoxb-orgwide", enterpriseId: ENT, isEnterpriseInstall: true },
+    );
+    expect(await slack.getSlackEnterpriseInstall(store, ENT)).not.toBeNull();
+
+    const stopped = await slack.revokeSlackInstallsForUninstall(store, {
+      teamId: null,
+      enterpriseId: ENT,
+    });
+    expect(stopped).toEqual([orgWide.id]);
+
+    // No longer routable — the row is suspended, not active.
+    expect(await slack.getSlackEnterpriseInstall(store, ENT)).toBeNull();
+  });
+
+  test("revokeSlackInstallsForUninstall stops only the uninstalled workspace, not a sibling", async () => {
+    const { store, secretStore, slack } = build();
+    const ENT = "E_MIXED";
+    await seedAgentRow("t", { organizationId: "org-m" });
+    await slack.upsertSlackInstallByTeam(store, secretStore, "org-m", "T_GONE", {
+      botToken: "xoxb-gone",
+      enterpriseId: ENT,
+    });
+    const sibling = await slack.upsertSlackInstallByTeam(
+      store,
+      secretStore,
+      "org-m",
+      "T_STAYS",
+      { botToken: "xoxb-stays", enterpriseId: ENT },
+    );
+
+    const stopped = await slack.revokeSlackInstallsForUninstall(store, {
+      teamId: "T_GONE",
+      enterpriseId: ENT,
+    });
+    // Only the uninstalled workspace's install (no org-wide flagged row exists,
+    // so the enterprise arm resolves nothing — the two per-ws rows are ambiguous).
+    expect(stopped).toEqual([expect.any(String)]);
+    expect(await slack.getSlackInstallByTeamId(store, "T_GONE")).toBeNull();
+    // The sibling's own install stays active.
+    expect((await slack.getSlackInstallByTeamId(store, "T_STAYS"))?.id).toBe(
+      sibling.id,
+    );
+  });
+
+  test("revokeSlackInstallsForUninstall is a no-op for an unknown tenant", async () => {
+    const { store, slack } = build();
+    expect(
+      await slack.revokeSlackInstallsForUninstall(store, {
+        teamId: "T_NEVER_SEEN",
+        enterpriseId: "E_NEVER_SEEN",
+      }),
+    ).toEqual([]);
+  });
 });

--- a/packages/server/src/gateway/connections/slack-connection-coordinator.ts
+++ b/packages/server/src/gateway/connections/slack-connection-coordinator.ts
@@ -7,6 +7,7 @@ import {
   getSlackInstallByEnterpriseId,
   getSlackInstallByTeamId,
   resolveSlackPendingByTenant,
+  revokeSlackInstallsForUninstall,
   writeSlackPendingInstall,
 } from "../../lobu/stores/slack-installations.js";
 import { getConfiguredPublicOrigin } from "../../utils/public-origin.js";
@@ -274,6 +275,31 @@ export function parseSlackUserMessageEvent(
   return { channel: event.channel, user: event.user };
 }
 
+/**
+ * True when the Events API body is an `app_uninstalled` / `app_deleted` event —
+ * Slack posts these when a workspace or org removes (or deletes) the app, killing
+ * the bot token, so the matching install must be stopped (see
+ * {@link revokeSlackInstallsForUninstall}).
+ *
+ * Deliberately does NOT include `tokens_revoked`: that fires for INDIVIDUAL token
+ * revocations (e.g. one user de-authorizing their user token) and does not
+ * necessarily mean the bot install is gone — stopping the whole install on it
+ * would be too aggressive. Only the JSON Events API carries these; form
+ * (slash/interactivity) bodies never do.
+ */
+export function isSlackUninstallEvent(body: string, contentType: string): boolean {
+  if (contentType.includes("application/x-www-form-urlencoded")) return false;
+  let payload: { type?: string; event?: { type?: string } };
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return false;
+  }
+  if (payload.type !== "event_callback") return false;
+  const t = payload.event?.type;
+  return t === "app_uninstalled" || t === "app_deleted";
+}
+
 type SlackInstallation = {
   botToken: string;
   botUserId?: string;
@@ -413,6 +439,24 @@ export class SlackConnectionCoordinator {
     // `enterprise_id`. Captured so path 2 can fall back to an enterprise match
     // when the exact team id misses.
     const enterpriseId = this.extractEnterpriseId(body, contentType);
+
+    // App/token removal: Slack invalidated the bot token, so stop the matching
+    // install(s) BEFORE any routing — a still-`active` row would keep routing
+    // events to a dead token and fail every forward. Ack 200 either way (a
+    // non-2xx makes Slack retry the uninstall). Handled here (not per-connection)
+    // because an org-wide uninstall carries only the enterprise id, no team id.
+    if (isSlackUninstallEvent(body, contentType)) {
+      const store = this.deps.getAppInstallationStore();
+      const stopped = await revokeSlackInstallsForUninstall(store, {
+        teamId,
+        enterpriseId,
+      });
+      logger.info(
+        { teamId, enterpriseId, stopped },
+        "Slack app_uninstalled — stopped install(s)",
+      );
+      return new Response("", { status: 200 });
+    }
 
     if (teamId) {
       // 1) A BYO agent-owned Slack connection for this workspace (created via

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -495,6 +495,41 @@ export async function markSlackInstallStopped(
   `;
 }
 
+/**
+ * Handle a Slack `app_uninstalled` / `app_deleted` event: stop the install(s)
+ * whose bot token Slack just invalidated, so the router stops sending events to a
+ * dead token (a zombie `active` row would fail every forward). Tombstones (marks
+ * suspended) rather than deletes — audit/rollback, consistent with
+ * {@link markSlackInstallStopped}; a later reinstall reactivates the same row.
+ *
+ * Resolves the affected installs WITHOUT assuming the event carries a team id:
+ *   - the exact `team_id` install (a per-workspace install), when present;
+ *   - the ORG-WIDE install keyed on `enterprise_id` (a Grid org-wide uninstall
+ *     often carries only the enterprise id, no team id).
+ * A per-workspace uninstall thus stops only that workspace's row; a sibling's
+ * separately-installed row (matched by its own team id) is untouched. Returns the
+ * external ids that were stopped (may be empty — an already-inactive or unknown
+ * tenant is a no-op).
+ */
+export async function revokeSlackInstallsForUninstall(
+  store: AppInstallationStore,
+  tenant: { teamId?: string | null; enterpriseId?: string | null }
+): Promise<string[]> {
+  const toStop = new Map<string, SlackInstallationRow>();
+  if (tenant.teamId) {
+    const byTeam = await getSlackInstallByTeamId(store, tenant.teamId);
+    if (byTeam) toStop.set(byTeam.id, byTeam);
+  }
+  if (tenant.enterpriseId) {
+    const orgWide = await getSlackEnterpriseInstall(store, tenant.enterpriseId);
+    if (orgWide) toStop.set(orgWide.id, orgWide);
+  }
+  for (const id of toStop.keys()) {
+    await markSlackInstallStopped(store, id);
+  }
+  return [...toStop.keys()];
+}
+
 /** Delete a Slack install and purge its bot-token secret. */
 export async function deleteSlackInstall(
   store: AppInstallationStore,


### PR DESCRIPTION
## Problem

Found live while renaming the Grid bot: after a **full org uninstall** of the Slack app from the E0BDSKL1KJL enterprise, all 4 \`app_installations\` rows stayed \`status='active'\`. Slack posts \`app_uninstalled\` when a workspace/org removes the app, but **Lobu never handled it** — so the row lingers active with a now-dead bot token. The router keeps forwarding events to that zombie row, failing every send. A workspace that uninstalls and never reinstalls leaves a permanent broken install.

(This time it self-healed because the reinstall upserted over the stale rows — but that only masks the bug.)

## Fix

- \`isSlackUninstallEvent\` parses the Events API body for \`app_uninstalled\` / \`app_deleted\`. **Not** \`tokens_revoked\` — that can fire for a single user-token de-authorization while the bot install is still valid, so revoking the whole install on it would be too aggressive (covered by a negative test).
- \`handleAppWebhook\` intercepts the uninstall **before** any routing and acks 200 (a non-2xx makes Slack retry the uninstall).
- \`revokeSlackInstallsForUninstall\` stops the exact-team install **and** the org-wide install keyed on \`enterprise_id\` (a Grid org-wide uninstall carries only the enterprise id, no team id). It marks the row **suspended** (tombstone — a later reinstall reactivates the same row, consistent with \`markSlackInstallStopped\`) and pauses the connection projection so the runtime stops reading it. A per-workspace uninstall stops only that workspace's row; a sibling's separately-installed row is untouched.

## Tests (red→green)

- **Coordinator (unit):** revokes per-workspace \`app_uninstalled\`; revokes org-wide enterprise \`app_uninstalled\`; does **not** revoke a sibling's own install; does **not** revoke on \`tokens_revoked\`.
- **Store (real Postgres):** enterprise uninstall stops the org-wide row incl. the connection-projection pause; sibling-safe; unknown-tenant no-op.

All new tests red without the fix. \`make typecheck\` clean; biome clean; 5 Slack suites pass isolated (coordinator 20, installations 20, slack-web 5, pending-claim 2, slack-routes 16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786156843&installation_id=136316292&pr_number=1819&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1819&signature=02f7c221fce1282792d396336c3392fd1376f1993dc258a2e1f85d7d1ad72f78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Slack app uninstall events so affected installs are stopped immediately.
  * Enterprise-wide uninstall events now deactivate the matching org install, while workspace uninstall events only affect the targeted workspace.
  * Slack webhook requests for uninstall events now return success right away, reducing failed retries and preventing unnecessary forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->