### PR TITLE
fix(auth): clarify email device login approvals

### DIFF
--- a/packages/cli/src/__tests__/login-email.test.ts
+++ b/packages/cli/src/__tests__/login-email.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { loginCommand } from "../commands/login";
-import * as context from "../internal/context";
-import * as credentials from "../internal/credentials";
+
+const openMock = mock(async (_url: string) => undefined);
+mock.module("open", () => ({ default: openMock }));
+
+const { loginCommand } = await import("../commands/login");
+const context = await import("../internal/context");
+const credentials = await import("../internal/credentials");
 
 /**
  * Regression guard for `lobu login --email`: after the server accepts the
@@ -12,9 +16,12 @@ import * as credentials from "../internal/credentials";
 describe("login --email (user_claimed)", () => {
   afterEach(() => {
     mock.restore();
+    openMock.mockClear();
   });
 
-  function mockOAuthServer(): { calls: string[] } {
+  function mockOAuthServer(
+    options: { expiresIn?: number; tokenResult?: "success" | "pending" } = {}
+  ): { calls: string[] } {
     const calls: string[] = [];
     const fetchMock = mock(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : (input as Request).url;
@@ -42,14 +49,19 @@ describe("login --email (user_claimed)", () => {
           device_code: "dev-code",
           user_code: "ABCD-1234",
           verification_uri: "https://lobu.test/oauth/device",
-          expires_in: 600,
-          interval: 0,
+          verification_uri_complete:
+            "https://lobu.test/oauth/device?user_code=ABCD-1234",
+          expires_in: options.expiresIn ?? 600,
+          interval: 1,
         });
       }
       if (url.endsWith("/oauth/device/email")) {
         return jsonResponse({ status: "pending" }, 202);
       }
       if (url.endsWith("/oauth/token")) {
+        if (options.tokenResult === "pending") {
+          return jsonResponse({ error: "authorization_pending" }, 400);
+        }
         return jsonResponse({
           access_token: "claimed-access-token",
           refresh_token: "claimed-refresh-token",
@@ -70,6 +82,10 @@ describe("login --email (user_claimed)", () => {
     });
     spyOn(credentials, "loadCredentials").mockResolvedValue(null);
     const saveSpy = spyOn(credentials, "saveCredentials").mockResolvedValue();
+    const output: string[] = [];
+    spyOn(console, "log").mockImplementation((...args) => {
+      output.push(args.join(" "));
+    });
 
     const originalFetch = globalThis.fetch;
     const { calls } = mockOAuthServer();
@@ -87,6 +103,43 @@ describe("login --email (user_claimed)", () => {
     expect(saveSpy.mock.calls[0]?.[0]).toMatchObject({
       accessToken: "claimed-access-token",
     });
+    const text = output.join("\n");
+    expect(text).toContain("ABCD-1234");
+    expect(text).toContain(
+      "https://lobu.test/oauth/device?user_code=ABCD-1234"
+    );
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  test("opens the browser to the complete verification URL for interactive login", async () => {
+    spyOn(context, "resolveContext").mockResolvedValue({
+      name: "prod",
+      url: "https://lobu.test/lobu/api/v1",
+      source: "config",
+    });
+    spyOn(credentials, "loadCredentials").mockResolvedValue(null);
+    const saveSpy = spyOn(credentials, "saveCredentials").mockResolvedValue();
+    spyOn(process.stdout, "isTTY", "get").mockReturnValue(false);
+    spyOn(process.stdin, "isTTY", "get").mockReturnValue(false);
+    spyOn(console, "log").mockImplementation(() => undefined);
+
+    const originalFetch = globalThis.fetch;
+    const { calls } = mockOAuthServer({ expiresIn: 0 });
+    try {
+      await loginCommand({ context: "prod" });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(openMock).toHaveBeenCalledTimes(1);
+    expect(openMock.mock.calls[0]?.[0]).toBe(
+      "https://lobu.test/oauth/device?user_code=ABCD-1234"
+    );
+    expect(calls.some((u) => u.endsWith("/oauth/device/email"))).toBe(false);
+    expect(calls.some((u) => u.endsWith("/oauth/token"))).toBe(false);
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
   });
 
   test("errors without polling when the server has no claim endpoint", async () => {

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -147,6 +147,8 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
   // `--email`. Approval happens out of band, so we then poll regardless of TTY.
   const emailClaim = Boolean(options.email);
   if (emailClaim) {
+    const verificationUrl =
+      authorization.verificationUriComplete ?? authorization.verificationUri;
     // Support was already verified above, before client/device-code creation.
     // tryOAuthStep returns the callback's value or undefined on error;
     // sendEmailClaim resolves void, so return a truthy sentinel to distinguish
@@ -165,6 +167,10 @@ export async function loginCommand(options: LoginOptions): Promise<void> {
         `\n  Sent a confirmation link to ${chalk.white(options.email as string)}.`
       )
     );
+    console.log(
+      chalk.dim(`  Code: ${chalk.bold.white(authorization.userCode)}`)
+    );
+    console.log(chalk.dim(`  Fallback approval URL: ${verificationUrl}`));
     console.log(
       chalk.dim("  Waiting for the user to approve from their email...\n")
     );

--- a/packages/server/src/__tests__/integration/oauth/device-email-claim.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/device-email-claim.test.ts
@@ -14,20 +14,34 @@
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
+import { render } from '@react-email/render';
+import { MagicLinkEmail } from '../../../email/templates/magic-link';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
-import { createTestDeviceCode, createTestOAuthClient, createTestUser } from '../../setup/test-fixtures';
+import { createTestUser } from '../../setup/test-fixtures';
 import { post } from '../../setup/test-helpers';
 
 const DEVICE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code';
 
 async function pendingUserCode(): Promise<string> {
-  const client = await createTestOAuthClient({
-    grant_types: [DEVICE_GRANT, 'refresh_token'],
+  const register = await post('/oauth/register', {
+    body: {
+      client_name: 'Claim Test Agent',
+      grant_types: [DEVICE_GRANT, 'refresh_token'],
+      token_endpoint_auth_method: 'none',
+    },
   });
-  const device = await createTestDeviceCode(client.client_id, {
-    scope: 'mcp:read mcp:write',
+  expect(register.status).toBe(201);
+  const client = (await register.json()) as { client_id: string };
+
+  const device = await post('/oauth/device_authorization', {
+    body: {
+      client_id: client.client_id,
+      scope: 'mcp:read mcp:write',
+    },
   });
-  return device.userCode;
+  expect(device.status).toBe(200);
+  const body = (await device.json()) as { user_code: string };
+  return body.user_code;
 }
 
 async function verificationExistsFor(email: string): Promise<boolean> {
@@ -104,5 +118,19 @@ describe('POST /oauth/device/email — agent account claim', () => {
       body: { user_code: 123, email: { nested: true } },
     });
     expect(res.status).toBe(400);
+  });
+});
+
+describe('MagicLinkEmail authorization copy', () => {
+  it('includes the device user code so stale approval emails are distinguishable', async () => {
+    const text = await render(
+      MagicLinkEmail({
+        mode: 'authorize',
+        url: 'https://app.lobu.ai/api/auth/magic-link/verify?token=t&callbackURL=%2Foauth%2Fdevice%3Fuser_code%3DB49F-VMPZ',
+      }),
+      { plainText: true }
+    );
+
+    expect(text).toContain('Approval code: B49F-VMPZ');
   });
 });

--- a/packages/server/src/email/templates/magic-link.tsx
+++ b/packages/server/src/email/templates/magic-link.tsx
@@ -13,12 +13,14 @@ interface MagicLinkProps {
 
 export function MagicLinkEmail({ url, mode = 'sign-in' }: MagicLinkProps) {
   if (mode === 'authorize') {
+    const userCode = extractDeviceUserCode(url);
     return (
       <BrandedEmail
         preview="An application is requesting access to your Lobu account"
         heading="Authorize access to Lobu"
         intro="An application is requesting access to your Lobu account. Click below to review the request — you'll see what it can access before you approve. This link expires in 15 minutes."
         cta={{ href: url, label: 'Review request' }}
+        afterCta={userCode ? `Approval code: ${userCode}` : undefined}
         footerNote="If you didn't request this, you can safely ignore this email — no access is granted unless you approve."
       />
     );
@@ -36,3 +38,22 @@ export function MagicLinkEmail({ url, mode = 'sign-in' }: MagicLinkProps) {
 
 export const magicLinkSubject = 'Your Lobu sign-in link';
 export const authorizeAppSubject = 'Authorize access to your Lobu account';
+
+function extractDeviceUserCode(url: string): string | null {
+  try {
+    const magicLinkUrl = new URL(url);
+    const callbackUrl =
+      magicLinkUrl.searchParams.get('callbackURL') ??
+      magicLinkUrl.searchParams.get('newUserCallbackURL');
+    if (!callbackUrl) return null;
+
+    const consentUrl = new URL(callbackUrl, magicLinkUrl.origin);
+    const userCode = consentUrl.searchParams.get('user_code')?.trim();
+    if (!userCode) return null;
+
+    const normalized = userCode.toUpperCase();
+    return /^[A-Z0-9]{4}-[A-Z0-9]{4}$/.test(normalized) ? normalized : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What changed

- Show the device approval code visibly in authorization magic-link emails.
- Print the same approval code and fallback approval URL for `lobu login --email`.
- Add CLI coverage that normal browser login opens the complete device approval URL.
- Add server coverage that authorization emails include the approval code.

## Why

`lobu login --email` could send a valid approval link, but the email did not visibly identify which device-code request it belonged to. Clicking an older email could land on `Invalid or expired user code`, even though the current direct browser device-code flow was healthy.

## Validation

- Red test reproduced missing visible approval code in the email template.
- `bun run test run src/__tests__/integration/oauth/device-email-claim.test.ts`
- `bun test packages/cli/src/__tests__/login-email.test.ts`
- `bun run typecheck` in `packages/server`
- `bun run build` in `packages/cli`
- Live isolated-home smoke test for normal browser login opened `/oauth/device?user_code=...` and completed authorization.
- `make review` local build/typecheck/unit/integration phases passed with `typecheck=0 unit=0 integration=0`; Claude verdict step was attempted with opus, sonnet, and haiku but failed due external `Credit balance is too low`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786159951&installation_id=136316292&pr_number=1820&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1820&signature=9b1e537ef5be997408b5c7c5fef53d47cc2e92bb9e6693a03a04fa026d84ad0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->