### PR TITLE
feat: rename devices + sticky chrome pin for multi-extension orgs

### DIFF
--- a/packages/server/src/__tests__/integration/dispatch-chrome-autobind.test.ts
+++ b/packages/server/src/__tests__/integration/dispatch-chrome-autobind.test.ts
@@ -127,4 +127,25 @@ describe('resolveOnlineChromeConnection — self-healing chrome pin', () => {
     expect(res).toBeNull();
     expect(await pinOf(connId)).toBeNull();
   });
+
+  it('keeps a still-online deliberate pin (does not jump to a fresher extension)', async () => {
+    // Older but still online pin (Mac mini) vs a more recently seen MacBook
+    // extension — multi-Chrome orgs must not steal scrapes to last_seen DESC.
+    const pinned = await seedExtWorker(userId, orgId, { online: true });
+    // Age the pinned worker's last_seen slightly so the fresher one would win
+    // under the old ORDER BY last_seen_at DESC rule.
+    await sql`
+      UPDATE device_workers
+      SET last_seen_at = now() - interval '2 minutes'
+      WHERE id = ${pinned}::uuid
+    `;
+    const fresher = await seedExtWorker(userId, orgId, { online: true });
+    const connId = await seedChromeConn(orgId, userId, pinned);
+
+    const res = await resolveOnlineChromeConnection(orgId, sql);
+
+    expect(res?.deviceWorkerId).toBe(pinned);
+    expect(res?.deviceWorkerId).not.toBe(fresher);
+    expect(await pinOf(connId)).toBe(pinned);
+  });
 });

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -1577,13 +1577,32 @@ export async function handleUpdate(
 		hasDeviceWorkerArg ||
 		(updateProfileDeviceWorkerId && !hasDeviceWorkerArg)
 	) {
+    // Re-pinning (or clearing) the device also clears the "Device was removed"
+    // tombstone left by DELETE /api/me/devices — otherwise the connection stays
+    // active but UI-flagged error forever after the user picks a new device.
     await sql`
       UPDATE connections
-      SET device_worker_id = ${nextDeviceWorkerId}, updated_at = NOW()
+      SET device_worker_id = ${nextDeviceWorkerId},
+          error_message = CASE
+            WHEN error_message IN (
+              'Device was removed',
+              'Device was moved to another workspace'
+            ) THEN NULL
+            ELSE error_message
+          END,
+          updated_at = NOW()
       WHERE id = ${args.connection_id} AND organization_id = ${organizationId}
     `;
 		(updated[0] as Record<string, unknown>).device_worker_id =
 			nextDeviceWorkerId;
+		if (
+			(updated[0] as Record<string, unknown>).error_message ===
+				"Device was removed" ||
+			(updated[0] as Record<string, unknown>).error_message ===
+				"Device was moved to another workspace"
+		) {
+			(updated[0] as Record<string, unknown>).error_message = null;
+		}
   }
 
   const updatedConnection = updated[0] as {

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -1573,6 +1573,7 @@ export async function handleUpdate(
     throw err;
   }
 
+	let clearedDeviceTombstone = false;
 	if (
 		hasDeviceWorkerArg ||
 		(updateProfileDeviceWorkerId && !hasDeviceWorkerArg)
@@ -1580,6 +1581,11 @@ export async function handleUpdate(
     // Re-pinning (or clearing) the device also clears the "Device was removed"
     // tombstone left by DELETE /api/me/devices — otherwise the connection stays
     // active but UI-flagged error forever after the user picks a new device.
+		const previousError = (updated[0] as Record<string, unknown>)
+			.error_message;
+		clearedDeviceTombstone =
+			previousError === "Device was removed" ||
+			previousError === "Device was moved to another workspace";
     await sql`
       UPDATE connections
       SET device_worker_id = ${nextDeviceWorkerId},
@@ -1591,16 +1597,13 @@ export async function handleUpdate(
             ELSE error_message
           END,
           updated_at = NOW()
-      WHERE id = ${args.connection_id} AND organization_id = ${organizationId}
+      WHERE id = ${args.connection_id}
+        AND organization_id = ${organizationId}
+        AND deleted_at IS NULL
     `;
 		(updated[0] as Record<string, unknown>).device_worker_id =
 			nextDeviceWorkerId;
-		if (
-			(updated[0] as Record<string, unknown>).error_message ===
-				"Device was removed" ||
-			(updated[0] as Record<string, unknown>).error_message ===
-				"Device was moved to another workspace"
-		) {
+		if (clearedDeviceTombstone) {
 			(updated[0] as Record<string, unknown>).error_message = null;
 		}
   }
@@ -1642,6 +1645,7 @@ export async function handleUpdate(
     ...(hasAuthProfileArg ? ["auth_profile_id"] : []),
     ...(hasAppAuthProfileArg ? ["app_auth_profile_id"] : []),
     ...(hasDeviceWorkerArg ? ["device_worker_id"] : []),
+    ...(clearedDeviceTombstone ? ["error_message"] : []),
     ...(args.entity_ids !== undefined ? ["entity_ids"] : []),
     ...(args.config !== undefined ? ["config"] : []),
   ];

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -352,12 +352,21 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
   }
 }
 
+/** Max length for a user-set device display name. */
+const DEVICE_LABEL_MAX_LEN = 80;
+
 /**
- * PATCH /api/me/devices/:id  { organization_id }
+ * PATCH /api/me/devices/:id  { organization_id?, label? }
  *
- * Re-attach one of the caller's devices to a different workspace they belong to.
- * A device's connectors live in its workspace; moving the device un-pins and
- * pauses the connections (and their feeds) it backed in the previous one.
+ * Update one of the caller's devices. At least one field is required:
+ *
+ *  - `label` — human display name (Devices page). Empty/null clears it so the
+ *    UI falls back to the platform label ("Chrome", "Mac", …). Poll heartbeats
+ *    only overwrite when the device itself sends a non-null label, so a
+ *    user-set name sticks across Chrome extension / Mac app check-ins.
+ *  - `organization_id` — re-attach to a different workspace the caller belongs
+ *    to. Moving un-pins and pauses the connections (and their feeds) it backed
+ *    in the previous workspace.
  */
 export async function updateDeviceWorkerOrg(c: Context<{ Bindings: Env }>) {
   const userId = c.var.user?.id;
@@ -368,28 +377,68 @@ export async function updateDeviceWorkerOrg(c: Context<{ Bindings: Env }>) {
   if (!deviceWorkerId) {
     return c.json({ error: 'device id is required' }, 400);
   }
-  let organizationId: string;
+  let body: { organization_id?: string | null; label?: string | null };
   try {
-    const body = await c.req.json<{ organization_id?: string }>();
-    organizationId = (body.organization_id ?? '').trim();
-    if (!organizationId) {
-      return c.json({ error: 'organization_id is required' }, 400);
-    }
+    body = await c.req.json<{ organization_id?: string | null; label?: string | null }>();
   } catch {
     return c.json({ error: 'Invalid or missing JSON body' }, 400);
   }
+
+  const hasOrg = Object.hasOwn(body, 'organization_id');
+  const hasLabel = Object.hasOwn(body, 'label');
+  if (!hasOrg && !hasLabel) {
+    return c.json(
+      { error: 'Provide organization_id and/or label to update' },
+      400
+    );
+  }
+
+  const organizationId = hasOrg
+    ? (body.organization_id ?? '').toString().trim()
+    : null;
+  if (hasOrg && !organizationId) {
+    return c.json({ error: 'organization_id is required when provided' }, 400);
+  }
+
+  // Normalize label: trim; empty string / null → clear (store NULL). Cap length.
+  let nextLabel: string | null | undefined;
+  if (hasLabel) {
+    if (body.label == null) {
+      nextLabel = null;
+    } else if (typeof body.label !== 'string') {
+      return c.json({ error: 'label must be a string or null' }, 400);
+    } else {
+      const trimmed = body.label.trim();
+      if (trimmed.length === 0) {
+        nextLabel = null;
+      } else if (trimmed.length > DEVICE_LABEL_MAX_LEN) {
+        return c.json(
+          { error: `label must be at most ${DEVICE_LABEL_MAX_LEN} characters` },
+          400
+        );
+      } else {
+        nextLabel = trimmed;
+      }
+    }
+  }
+
   try {
     const sql = getDb();
-    const role = await getWorkspaceRole(sql, organizationId, userId);
-    if (!role) {
-      return c.json({ error: 'You are not a member of that workspace' }, 403);
+
+    if (organizationId) {
+      const role = await getWorkspaceRole(sql, organizationId, userId);
+      if (!role) {
+        return c.json({ error: 'You are not a member of that workspace' }, 403);
+      }
     }
+
     const updated = await sql.begin(async (tx) => {
       const owned = (await tx`
         SELECT organization_id FROM device_workers WHERE id = ${deviceWorkerId} AND user_id = ${userId} LIMIT 1
       `) as unknown as Array<{ organization_id: string | null }>;
       if (owned.length === 0) return false;
-      if (owned[0].organization_id !== organizationId) {
+
+      if (organizationId && owned[0].organization_id !== organizationId) {
         const affected = (await tx`
           UPDATE connections
           SET device_worker_id = NULL,
@@ -408,12 +457,20 @@ export async function updateDeviceWorkerOrg(c: Context<{ Bindings: Env }>) {
         }
         await tx`UPDATE device_workers SET organization_id = ${organizationId} WHERE id = ${deviceWorkerId}`;
       }
+
+      if (hasLabel) {
+        await tx`
+          UPDATE device_workers
+          SET label = ${nextLabel ?? null}
+          WHERE id = ${deviceWorkerId} AND user_id = ${userId}
+        `;
+      }
       return true;
     });
     if (!updated) {
       return c.json({ error: 'Device not found or not owned by you' }, 404);
     }
-    return c.json({ ok: true });
+    return c.json({ ok: true, ...(hasLabel ? { label: nextLabel ?? null } : {}) });
   } catch (err: unknown) {
     logger.error({ error: errorMessage(err) }, '[updateDeviceWorkerOrg] Error');
     return c.json({ error: errorMessage(err) }, 500);

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -397,7 +397,7 @@ export async function updateDeviceWorkerOrg(c: Context<{ Bindings: Env }>) {
     ? (body.organization_id ?? '').toString().trim()
     : null;
   if (hasOrg && !organizationId) {
-    return c.json({ error: 'organization_id is required when provided' }, 400);
+    return c.json({ error: 'organization_id must not be empty' }, 400);
   }
 
   // Normalize label: trim; empty string / null → clear (store NULL). Cap length.

--- a/packages/server/src/worker-api/dispatch-chrome-action.ts
+++ b/packages/server/src/worker-api/dispatch-chrome-action.ts
@@ -49,18 +49,20 @@ export interface ChromeActionDispatchResult {
 
 /**
  * Resolve an online Owletto Chrome extension to run a chrome action against, and
- * self-heal the org's `chrome` connection pin to it.
+ * self-heal the org's `chrome` connection pin when needed.
  *
  * Both this dispatch and the poll claim gate on `connections.device_worker_id`,
- * but nothing keeps the generic `chrome` action connection bound to the current
- * extension worker: re-pairing mints a NEW device worker and leaves the chrome
- * connection pinned to the old (now offline) one — or never pinned at all (it's
- * not a bundled device connector, so `device-reconcile` doesn't touch it). The
- * result: a server-side chrome connector (Revolut, LinkedIn) can't reach an
- * extension that IS online, and dispatch fails with "no online paired
- * extension". So resolve any online, debugger-capable chrome-extension worker in
- * the org INDEPENDENT of the existing pin, then repin the connection to it
- * before enqueuing — fixing both the NULL-pin and stale-pin (post-re-pair) cases.
+ * but re-pairing mints a NEW device worker and can leave the chrome connection
+ * pinned to the old (now offline) one — or never pinned at all. Without a
+ * heal, server-side chrome connectors (Revolut, LinkedIn) fail with "no online
+ * paired extension" even when another extension IS online.
+ *
+ * Sticky pin: when the current pin is still an online debugger-capable
+ * chrome-extension, keep it. Users with multiple Chromes (e.g. Mac mini +
+ * MacBook) deliberately pin scrapers to one machine; always rebinding to
+ * `last_seen_at DESC` would steal actions to whichever extension last polled.
+ * Only repin when the pin is NULL or the pinned worker is offline / missing
+ * debugger — covering re-pair and first-use.
  *
  * Returns the chrome connection id + the resolved worker, or null when no online
  * extension exists in the org.
@@ -69,29 +71,56 @@ export async function resolveOnlineChromeConnection(
   organizationId: string,
   sql = getDb()
 ): Promise<{ connectionId: number; deviceWorkerId: string } | null> {
+  // Prefer the connection's current pin when that worker is still online and
+  // debugger-capable. Fall back to the most recently seen online extension.
   const rows = (await sql`
     SELECT
       con.id AS connection_id,
       con.device_worker_id AS current_pin,
-      dw.id AS online_worker_id
+      pinned.id AS pinned_online_worker_id,
+      fresh.id AS fresh_online_worker_id
     FROM connections con
-    JOIN device_workers dw ON dw.organization_id = con.organization_id
+    LEFT JOIN device_workers pinned
+      ON pinned.id = con.device_worker_id
+     AND pinned.organization_id = con.organization_id
+     AND pinned.platform = 'chrome-extension'
+     AND pinned.capabilities::jsonb @> '["browser.debugger"]'::jsonb
+     AND pinned.last_seen_at > now() - make_interval(mins => ${DEVICE_ONLINE_WINDOW_MINUTES})
+    LEFT JOIN LATERAL (
+      SELECT dw.id
+      FROM device_workers dw
+      WHERE dw.organization_id = con.organization_id
+        AND dw.platform = 'chrome-extension'
+        AND dw.capabilities::jsonb @> '["browser.debugger"]'::jsonb
+        AND dw.last_seen_at > now() - make_interval(mins => ${DEVICE_ONLINE_WINDOW_MINUTES})
+      ORDER BY dw.last_seen_at DESC
+      LIMIT 1
+    ) fresh ON TRUE
     WHERE con.organization_id = ${organizationId}
       AND con.connector_key = 'chrome'
       AND con.status = 'active'
       AND con.deleted_at IS NULL
-      AND dw.platform = 'chrome-extension'
-      AND dw.capabilities::jsonb @> '["browser.debugger"]'::jsonb
-      AND dw.last_seen_at > now() - make_interval(mins => ${DEVICE_ONLINE_WINDOW_MINUTES})
-    ORDER BY dw.last_seen_at DESC
     LIMIT 1
-  `) as Array<{ connection_id: number; current_pin: string | null; online_worker_id: string }>;
+  `) as Array<{
+    connection_id: number;
+    current_pin: string | null;
+    pinned_online_worker_id: string | null;
+    fresh_online_worker_id: string | null;
+  }>;
 
   if (rows.length === 0) return null;
-  const { connection_id, current_pin, online_worker_id } = rows[0];
+  const {
+    connection_id,
+    current_pin,
+    pinned_online_worker_id,
+    fresh_online_worker_id,
+  } = rows[0];
 
-  // Self-heal the pin so the poll claim (which gates on device_worker_id) routes
-  // the run to the online worker. Covers a NULL pin and a stale post-re-pair pin.
+  // Sticky: keep a still-online deliberate pin. Otherwise heal to the freshest
+  // online debugger extension (NULL pin or stale post-re-pair pin).
+  const online_worker_id = pinned_online_worker_id ?? fresh_online_worker_id;
+  if (!online_worker_id) return null;
+
   if (current_pin !== online_worker_id) {
     await sql`
       UPDATE connections


### PR DESCRIPTION
## Summary
- Allow renaming devices via `PATCH /api/me/devices/:id` with `{ label }` (empty/null clears to platform default).
- Owletto account device detail page: pencil rename control.
- Sticky chrome pin: `resolveOnlineChromeConnection` keeps a still-online deliberate pin instead of always rebinding to the most recently seen extension (fixes Mac mini vs MacBook scrape hopping).
- Re-pinning a connection clears stale `Device was removed` / moved-workspace error messages.

## Context (buremba)
- MacBook Chrome (history/bookmarks/downloads): `709f0d3a…`
- Mac mini Chrome (X / LinkedIn / Revolut scrapes): `2e8a0557…`
- After deploy: name them **Burak’s MacBook Chrome** and **Burak’s Mac mini Chrome** (or via UI).

## Test plan
- [ ] Integration: `dispatch-chrome-autobind` (NULL pin, offline re-pair, sticky online pin)
- [ ] PATCH label rename + clear; name sticks across extension poll
- [ ] With two online Chromes, chrome connection pinned to mini stays on mini across scrapes
- [ ] Re-pin connection after device delete clears “Device was removed”

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786196044&installation_id=136316292&pr_number=1823&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1823&signature=d1de32ddb553dedb80e40a1f6ba552e7afa9f8875fe44c5f4abf5b5f7d0893eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device labels can now be updated via the device endpoint (with validation and support for clearing the label).
  * When a label is changed, the response returns the updated label.

* **Bug Fixes**
  * Chrome connections now preserve an existing pin when it still targets an online, usable worker.
  * Updating/pinning connections now clears stale “removed/moved” error messages when appropriate.

* **Tests**
  * Added an integration test covering the “don’t repin an already pinned, online worker” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->