### PR TITLE
fix(oauth): prefill device-code verification URLs with user_code

### DIFF
--- a/packages/server/src/gateway/auth/oauth/__tests__/rfc-device-code-client.test.ts
+++ b/packages/server/src/gateway/auth/oauth/__tests__/rfc-device-code-client.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { OAuthClient } from "../client.js";
+import {
+  OAuthClient,
+  resolveDeviceVerificationUrl,
+  withUserCodeQuery,
+} from "../client.js";
 import { grantStrategyFor } from "../grant-strategy.js";
-import { TEST_XAI_OAUTH } from "./fixtures.js";
+import { TEST_CHATGPT_OAUTH, TEST_XAI_OAUTH } from "./fixtures.js";
 
 /**
- * Pins the RFC 8628 device-code wire shape used by xAI SuperGrok OAuth.
+ * Pins the RFC 8628 device-code wire shape used by xAI SuperGrok OAuth,
+ * plus generic verification_uri_complete / ?user_code= synthesis.
  */
 
 interface Captured {
@@ -13,11 +18,28 @@ interface Captured {
   rawBody: string;
 }
 
+type DeviceCodePayload = {
+  device_code: string;
+  user_code: string;
+  verification_uri?: string;
+  verification_uri_complete?: string;
+  interval?: number;
+  expires_in?: number;
+};
+
 const originalFetch = globalThis.fetch;
 let calls: Captured[];
+let deviceCodePayload: DeviceCodePayload;
 
 beforeEach(() => {
   calls = [];
+  deviceCodePayload = {
+    device_code: "dev-code-abc",
+    user_code: "ABCD-1234",
+    verification_uri: "https://accounts.x.ai/oauth2/device",
+    interval: 5,
+    expires_in: 1800,
+  };
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
     const headers = new Headers(init?.headers);
@@ -28,16 +50,10 @@ beforeEach(() => {
     });
 
     if (url.includes("/oauth2/device/code")) {
-      return new Response(
-        JSON.stringify({
-          device_code: "dev-code-abc",
-          user_code: "ABCD-1234",
-          verification_uri: "https://accounts.x.ai/oauth2/device",
-          interval: 5,
-          expires_in: 1800,
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
+      return new Response(JSON.stringify(deviceCodePayload), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     if (url.includes("/oauth2/token")) {
@@ -75,14 +91,56 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
+describe("resolveDeviceVerificationUrl / withUserCodeQuery", () => {
+  test("prefers verification_uri_complete as-is", () => {
+    expect(
+      resolveDeviceVerificationUrl({
+        verificationUriComplete:
+          "https://accounts.x.ai/oauth2/device?user_code=X3E9-KZ6B",
+        verificationUri: "https://accounts.x.ai/oauth2/device",
+        userCode: "IGNORED",
+      }),
+    ).toBe("https://accounts.x.ai/oauth2/device?user_code=X3E9-KZ6B");
+  });
+
+  test("synthesizes ?user_code= from bare verification_uri", () => {
+    expect(
+      resolveDeviceVerificationUrl({
+        verificationUri: "https://accounts.x.ai/oauth2/device",
+        userCode: "HZQY-6RSD",
+      }),
+    ).toBe("https://accounts.x.ai/oauth2/device?user_code=HZQY-6RSD");
+  });
+
+  test("does not double-append when user_code is already present", () => {
+    expect(
+      withUserCodeQuery(
+        "https://accounts.x.ai/oauth2/device?user_code=KEEP",
+        "OTHER",
+      ),
+    ).toBe("https://accounts.x.ai/oauth2/device?user_code=KEEP");
+  });
+
+  test("falls back to defaultVerificationUrl", () => {
+    expect(
+      resolveDeviceVerificationUrl({
+        defaultVerificationUrl: "https://auth.openai.com/codex/device",
+        userCode: "ABCD-1234",
+      }),
+    ).toBe("https://auth.openai.com/codex/device?user_code=ABCD-1234");
+  });
+});
+
 describe("OAuthClient RFC device-code (xAI)", () => {
-  test("requestDeviceCode posts form-urlencoded client_id+scope", async () => {
+  test("requestDeviceCode posts form-urlencoded and synthesizes ?user_code=", async () => {
     const client = new OAuthClient(TEST_XAI_OAUTH);
     const result = await client.requestDeviceCode();
 
     expect(result.userCode).toBe("ABCD-1234");
     expect(result.deviceAuthId).toBe("dev-code-abc");
-    expect(result.verificationUrl).toBe("https://accounts.x.ai/oauth2/device");
+    expect(result.verificationUrl).toBe(
+      "https://accounts.x.ai/oauth2/device?user_code=ABCD-1234",
+    );
     expect(result.interval).toBe(5);
 
     expect(calls).toHaveLength(1);
@@ -91,6 +149,22 @@ describe("OAuthClient RFC device-code (xAI)", () => {
     const params = new URLSearchParams(calls[0]!.rawBody);
     expect(params.get("client_id")).toBe(TEST_XAI_OAUTH.clientId);
     expect(params.get("scope")).toBe(TEST_XAI_OAUTH.scope);
+  });
+
+  test("prefers provider verification_uri_complete over synthesis", async () => {
+    deviceCodePayload = {
+      device_code: "dev-code-abc",
+      user_code: "ABCD-1234",
+      verification_uri: "https://accounts.x.ai/oauth2/device",
+      verification_uri_complete:
+        "https://accounts.x.ai/oauth2/device?user_code=ABCD-1234&src=provider",
+      interval: 5,
+    };
+    const client = new OAuthClient(TEST_XAI_OAUTH);
+    const result = await client.requestDeviceCode();
+    expect(result.verificationUrl).toBe(
+      "https://accounts.x.ai/oauth2/device?user_code=ABCD-1234&src=provider",
+    );
   });
 
   test("pollForToken returns null on authorization_pending", async () => {
@@ -127,7 +201,7 @@ describe("OAuthClient RFC device-code (xAI)", () => {
 });
 
 describe("grantStrategyFor(xai)", () => {
-  test("dispatches device-code and maps deviceAuthId", async () => {
+  test("dispatches device-code and maps deviceAuthId with prefilled URL", async () => {
     const strategy = grantStrategyFor(TEST_XAI_OAUTH);
     const started = await strategy.start(TEST_XAI_OAUTH, {
       kind: "org",
@@ -139,6 +213,9 @@ describe("grantStrategyFor(xai)", () => {
     if (started.mode !== "device") throw new Error("expected device");
     expect(started.userCode).toBe("ABCD-1234");
     expect(started.deviceAuthId).toBe("dev-code-abc");
+    expect(started.verificationUrl).toBe(
+      "https://accounts.x.ai/oauth2/device?user_code=ABCD-1234",
+    );
 
     const completed = await strategy.complete(
       TEST_XAI_OAUTH,
@@ -159,5 +236,37 @@ describe("grantStrategyFor(xai)", () => {
       refreshToken: "refresh-ok",
       authType: "device-code",
     });
+  });
+});
+
+describe("OAuthClient OpenAI device-auth (ChatGPT)", () => {
+  test("requestDeviceCode prefills defaultVerificationUrl with user_code", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/deviceauth/usercode")) {
+        return new Response(
+          JSON.stringify({
+            device_auth_id: "dev_abc",
+            user_code: "WXYZ-9876",
+            interval: 5,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    try {
+      const client = new OAuthClient(TEST_CHATGPT_OAUTH);
+      const result = await client.requestDeviceCode();
+      expect(result.userCode).toBe("WXYZ-9876");
+      expect(result.deviceAuthId).toBe("dev_abc");
+      expect(result.verificationUrl).toBe(
+        "https://auth.openai.com/codex/device?user_code=WXYZ-9876",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/server/src/gateway/auth/oauth/client.ts
+++ b/packages/server/src/gateway/auth/oauth/client.ts
@@ -16,6 +16,46 @@ import {
 
 const RFC_DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 
+/**
+ * Prefer RFC `verification_uri_complete`, else append `user_code` to a base
+ * verification URL. Generic for every device-code provider (xAI, ChatGPT, …).
+ */
+export function resolveDeviceVerificationUrl(options: {
+  verificationUriComplete?: string | null;
+  verificationUri?: string | null;
+  defaultVerificationUrl?: string | null;
+  userCode: string;
+}): string {
+  const complete = options.verificationUriComplete?.trim();
+  if (complete) return complete;
+
+  const base =
+    options.verificationUri?.trim() ||
+    options.defaultVerificationUrl?.trim() ||
+    "";
+  if (!base) {
+    throw new Error(
+      "Device code response missing verification_uri and no defaultVerificationUrl",
+    );
+  }
+  return withUserCodeQuery(base, options.userCode);
+}
+
+/** Append `user_code` when the URL does not already carry one. */
+export function withUserCodeQuery(url: string, userCode: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.searchParams.has("user_code")) return parsed.toString();
+    parsed.searchParams.set("user_code", userCode);
+    return parsed.toString();
+  } catch {
+    // Non-absolute URLs are rare for device verification; still be safe.
+    if (/[?&]user_code=/.test(url)) return url;
+    const sep = url.includes("?") ? "&" : "?";
+    return `${url}${sep}user_code=${encodeURIComponent(userCode)}`;
+  }
+}
+
 interface TokenResponse {
   access_token: string;
   refresh_token?: string;
@@ -240,14 +280,18 @@ export class OAuthClient extends BaseOAuth2Client {
     ) {
       throw new Error("Device code response missing device_code or user_code");
     }
-    const verificationUrl =
-      (typeof data.verification_uri === "string" && data.verification_uri) ||
-      this.config.defaultVerificationUrl;
-    if (!verificationUrl) {
-      throw new Error(
-        "Device code response missing verification_uri and no defaultVerificationUrl",
-      );
-    }
+    const verificationUrl = resolveDeviceVerificationUrl({
+      verificationUriComplete:
+        typeof data.verification_uri_complete === "string"
+          ? data.verification_uri_complete
+          : undefined,
+      verificationUri:
+        typeof data.verification_uri === "string"
+          ? data.verification_uri
+          : undefined,
+      defaultVerificationUrl: this.config.defaultVerificationUrl,
+      userCode: data.user_code,
+    });
     return {
       deviceAuthId: data.device_code,
       userCode: data.user_code,
@@ -323,12 +367,16 @@ export class OAuthClient extends BaseOAuth2Client {
       user_code: string;
       interval?: number;
     };
-    const verificationUrl = this.config.defaultVerificationUrl?.trim();
-    if (!verificationUrl) {
+    if (!this.config.defaultVerificationUrl?.trim()) {
       throw new Error(
         `${this.config.name} openai-device-auth config requires defaultVerificationUrl`,
       );
     }
+    // OpenAI does not return verification_uri*; prefill from the configured base.
+    const verificationUrl = resolveDeviceVerificationUrl({
+      defaultVerificationUrl: this.config.defaultVerificationUrl,
+      userCode: data.user_code,
+    });
     return {
       deviceAuthId: data.device_auth_id,
       userCode: data.user_code,


### PR DESCRIPTION
## Summary
- Device-code OAuth (xAI SuperGrok + ChatGPT) now returns a **prefilled** verification URL: prefer RFC `verification_uri_complete`, otherwise synthesize `?user_code=` onto the base / default verification URI.
- Inference-provider form **auto-opens** that URL on start (same pattern as Claude redirect) and replaces the muted "Enter it at…" link with a primary **Open … to approve** button so re-opening is obvious.
- Claude authorization-code flow is unchanged (already auto-opens authorize URL).

## Test plan
- [x] `bun test packages/server/src/gateway/auth/oauth/__tests__/rfc-device-code-client.test.ts` (synthesis, complete preference, ChatGPT prefill)
- [x] `bun test packages/server/src/gateway/auth/chatgpt/__tests__/device-code-client.test.ts`
- [x] `vitest` create-provider-form tests
- [ ] Manual: Add provider → SuperGrok Sign in → code tab opens `https://accounts.x.ai/oauth2/device?user_code=…`
- [ ] Manual: ChatGPT device code opens `https://auth.openai.com/codex/device?user_code=…`
- [ ] Manual: Claude Sign in still opens authorize URL as before

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786196784&installation_id=136316292&pr_number=1824&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1824&signature=1c3e7969ca3dbfb35c038b59fd8b159ca085ee6a343f0a215ef759a7332fd5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->