### PR TITLE
fix(oauth): make device-code URL prefill provider-config driven

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -371,7 +371,8 @@
             "grant": "device-code",
             "authType": "device-code",
             "deviceCodeUrl": "https://auth.x.ai/oauth2/device/code",
-            "defaultVerificationUrl": "https://accounts.x.ai/oauth2/device"
+            "defaultVerificationUrl": "https://accounts.x.ai/oauth2/device",
+            "verificationUserCodeParam": "user_code"
           }
         }
       ]

--- a/packages/core/src/provider-config-types.ts
+++ b/packages/core/src/provider-config-types.ts
@@ -52,6 +52,13 @@ export interface ProviderOAuthConfig {
   deviceTokenUrl?: string;
   deviceRedirectUri?: string;
   defaultVerificationUrl?: string;
+  /**
+   * When set (e.g. `"user_code"` for xAI), append this query param to the base
+   * verification URL with the device user code so the approval page can prefill.
+   * When omitted, leave the base URL alone unless the provider returned RFC
+   * `verification_uri_complete`. ChatGPT's codex page does not document prefill.
+   */
+  verificationUserCodeParam?: string;
   pendingStatusCodes?: number[];
   includeScopeInRefresh?: boolean;
   accountIdClaimPath?: string;

--- a/packages/server/src/gateway/auth/oauth/__tests__/fixtures.ts
+++ b/packages/server/src/gateway/auth/oauth/__tests__/fixtures.ts
@@ -63,6 +63,7 @@ export const TEST_XAI_OAUTH: OAuthProviderConfig = {
   authType: "device-code",
   deviceCodeUrl: "https://auth.x.ai/oauth2/device/code",
   defaultVerificationUrl: "https://accounts.x.ai/oauth2/device",
+  verificationUserCodeParam: "user_code",
 };
 
 export const TEST_OAUTH_REGISTRY = [

--- a/packages/server/src/gateway/auth/oauth/__tests__/rfc-device-code-client.test.ts
+++ b/packages/server/src/gateway/auth/oauth/__tests__/rfc-device-code-client.test.ts
@@ -98,36 +98,39 @@ describe("resolveDeviceVerificationUrl / withUserCodeQuery", () => {
         verificationUriComplete:
           "https://accounts.x.ai/oauth2/device?user_code=X3E9-KZ6B",
         verificationUri: "https://accounts.x.ai/oauth2/device",
+        verificationUserCodeParam: "user_code",
         userCode: "IGNORED",
       }),
     ).toBe("https://accounts.x.ai/oauth2/device?user_code=X3E9-KZ6B");
   });
 
-  test("synthesizes ?user_code= from bare verification_uri", () => {
+  test("synthesizes query only when verificationUserCodeParam is set", () => {
     expect(
       resolveDeviceVerificationUrl({
         verificationUri: "https://accounts.x.ai/oauth2/device",
+        verificationUserCodeParam: "user_code",
         userCode: "HZQY-6RSD",
       }),
     ).toBe("https://accounts.x.ai/oauth2/device?user_code=HZQY-6RSD");
   });
 
-  test("does not double-append when user_code is already present", () => {
-    expect(
-      withUserCodeQuery(
-        "https://accounts.x.ai/oauth2/device?user_code=KEEP",
-        "OTHER",
-      ),
-    ).toBe("https://accounts.x.ai/oauth2/device?user_code=KEEP");
-  });
-
-  test("falls back to defaultVerificationUrl", () => {
+  test("leaves bare URL when provider does not opt into prefill", () => {
     expect(
       resolveDeviceVerificationUrl({
         defaultVerificationUrl: "https://auth.openai.com/codex/device",
         userCode: "ABCD-1234",
       }),
-    ).toBe("https://auth.openai.com/codex/device?user_code=ABCD-1234");
+    ).toBe("https://auth.openai.com/codex/device");
+  });
+
+  test("does not double-append when param is already present", () => {
+    expect(
+      withUserCodeQuery(
+        "https://accounts.x.ai/oauth2/device?user_code=KEEP",
+        "OTHER",
+        "user_code",
+      ),
+    ).toBe("https://accounts.x.ai/oauth2/device?user_code=KEEP");
   });
 });
 
@@ -240,7 +243,7 @@ describe("grantStrategyFor(xai)", () => {
 });
 
 describe("OAuthClient OpenAI device-auth (ChatGPT)", () => {
-  test("requestDeviceCode prefills defaultVerificationUrl with user_code", async () => {
+  test("requestDeviceCode returns bare defaultVerificationUrl (no prefill)", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
@@ -262,8 +265,9 @@ describe("OAuthClient OpenAI device-auth (ChatGPT)", () => {
       const result = await client.requestDeviceCode();
       expect(result.userCode).toBe("WXYZ-9876");
       expect(result.deviceAuthId).toBe("dev_abc");
+      // ChatGPT omits verificationUserCodeParam — Codex expects manual entry.
       expect(result.verificationUrl).toBe(
-        "https://auth.openai.com/codex/device?user_code=WXYZ-9876",
+        "https://auth.openai.com/codex/device",
       );
     } finally {
       globalThis.fetch = originalFetch;

--- a/packages/server/src/gateway/auth/oauth/client.ts
+++ b/packages/server/src/gateway/auth/oauth/client.ts
@@ -17,13 +17,21 @@ import {
 const RFC_DEVICE_GRANT = "urn:ietf:params:oauth:grant-type:device_code";
 
 /**
- * Prefer RFC `verification_uri_complete`, else append `user_code` to a base
- * verification URL. Generic for every device-code provider (xAI, ChatGPT, …).
+ * Build the browser verification URL for a device-code start.
+ *
+ * Priority:
+ * 1. RFC `verification_uri_complete` (provider-supplied prefill URL) as-is
+ * 2. Base `verification_uri` / `defaultVerificationUrl`
+ * 3. Optionally append `verificationUserCodeParam=userCode` when the provider
+ *    config opts into prefill (e.g. xAI `"user_code"`). Omitted for providers
+ *    whose pages do not document query prefill (ChatGPT Codex).
  */
 export function resolveDeviceVerificationUrl(options: {
   verificationUriComplete?: string | null;
   verificationUri?: string | null;
   defaultVerificationUrl?: string | null;
+  /** Query param name to prefill, from provider config. Empty/omit = no prefill. */
+  verificationUserCodeParam?: string | null;
   userCode: string;
 }): string {
   const complete = options.verificationUriComplete?.trim();
@@ -38,21 +46,28 @@ export function resolveDeviceVerificationUrl(options: {
       "Device code response missing verification_uri and no defaultVerificationUrl",
     );
   }
-  return withUserCodeQuery(base, options.userCode);
+  const param = options.verificationUserCodeParam?.trim();
+  if (!param) return base;
+  return withUserCodeQuery(base, options.userCode, param);
 }
 
-/** Append `user_code` when the URL does not already carry one. */
-export function withUserCodeQuery(url: string, userCode: string): string {
+/** Append a user-code query param when the URL does not already carry it. */
+export function withUserCodeQuery(
+  url: string,
+  userCode: string,
+  paramName = "user_code",
+): string {
   try {
     const parsed = new URL(url);
-    if (parsed.searchParams.has("user_code")) return parsed.toString();
-    parsed.searchParams.set("user_code", userCode);
+    if (parsed.searchParams.has(paramName)) return parsed.toString();
+    parsed.searchParams.set(paramName, userCode);
     return parsed.toString();
   } catch {
     // Non-absolute URLs are rare for device verification; still be safe.
-    if (/[?&]user_code=/.test(url)) return url;
+    const re = new RegExp(`[?&]${paramName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}=`);
+    if (re.test(url)) return url;
     const sep = url.includes("?") ? "&" : "?";
-    return `${url}${sep}user_code=${encodeURIComponent(userCode)}`;
+    return `${url}${sep}${encodeURIComponent(paramName)}=${encodeURIComponent(userCode)}`;
   }
 }
 
@@ -290,6 +305,7 @@ export class OAuthClient extends BaseOAuth2Client {
           ? data.verification_uri
           : undefined,
       defaultVerificationUrl: this.config.defaultVerificationUrl,
+      verificationUserCodeParam: this.config.verificationUserCodeParam,
       userCode: data.user_code,
     });
     return {
@@ -372,9 +388,11 @@ export class OAuthClient extends BaseOAuth2Client {
         `${this.config.name} openai-device-auth config requires defaultVerificationUrl`,
       );
     }
-    // OpenAI does not return verification_uri*; prefill from the configured base.
+    // OpenAI does not return verification_uri*; use configured base, and only
+    // append a code query param when this provider opts into prefill.
     const verificationUrl = resolveDeviceVerificationUrl({
       defaultVerificationUrl: this.config.defaultVerificationUrl,
+      verificationUserCodeParam: this.config.verificationUserCodeParam,
       userCode: data.user_code,
     });
     return {


### PR DESCRIPTION
## Summary
- Prefill is **provider config**, not global: only append a query param when \`oauth.verificationUserCodeParam\` is set.
- **xAI SuperGrok**: \`verificationUserCodeParam: "user_code"\` → \`?user_code=\`
- **ChatGPT**: param omitted → bare \`https://auth.openai.com/codex/device\`
- Still prefers RFC \`verification_uri_complete\` when the provider returns it.
- UI helper copy no longer claims prefill always; external approve actions remain **buttons**.

## Test plan
- [x] unit tests for synthesize-with-param / bare-without-param / complete preference
- [ ] SuperGrok: URL has \`?user_code=\`
- [ ] ChatGPT: URL is bare codex/device

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786198073&installation_id=136316292&pr_number=1825&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1825&signature=11ff62e01510e19ed3b24ca0586c5655295a10dca06e862afc1de32721c3b560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->