### PR TITLE
fix(server): chrome-extension pins mean browser affinity, not job host

### DIFF
--- a/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
+++ b/packages/server/src/__tests__/integration/browser-affinity-poll-claim.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Browser-affinity claim rules (PR #1826):
+ *
+ * When a non-chrome* connection (LinkedIn/X/…) is pinned to a chrome-extension
+ * device, that pin means "scrape with this browser", NOT "run the parent sync
+ * on the extension". Fleet claims parent sync; the extension must not.
+ *
+ * chrome* connectors still execute on the extension when pinned.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { generateSecureToken } from '../../auth/oauth/utils';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { post } from '../setup/test-helpers';
+
+const DEBUGGER_CAPS = ['browser.tabs', 'browser.scripting', 'browser.debugger'];
+
+async function seedOrg() {
+  const sql = getTestDb();
+  const userId = `user_${generateSecureToken(4)}`;
+  const orgId = `org-aff-${generateSecureToken(4)}`;
+  await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${userId}, 'Affinity Owner', ${`${userId}@test.local`}, true, NOW(), NOW())
+  `;
+  await sql`
+    INSERT INTO "organization" (id, name, slug, visibility, metadata, "createdAt")
+    VALUES (
+      ${orgId}, 'Affinity Org', ${orgId}, 'private',
+      ${sql.json({ personal_org_for_user_id: userId })}, NOW()
+    )
+  `;
+  await sql`
+    INSERT INTO member (id, "organizationId", "userId", role, "createdAt")
+    VALUES (${`mem_${generateSecureToken(4)}`}, ${orgId}, ${userId}, 'owner', NOW())
+  `;
+  return { userId, orgId };
+}
+
+async function seedExtWorker(userId: string, orgId: string): Promise<{
+  deviceWorkerId: string;
+  workerId: string;
+}> {
+  const sql = getTestDb();
+  const workerId = `ext-${generateSecureToken(6)}`;
+  const [row] = (await sql`
+    INSERT INTO device_workers (
+      user_id, worker_id, platform, app_version, capabilities, label, organization_id, last_seen_at
+    ) VALUES (
+      ${userId}, ${workerId}, 'chrome-extension', '0.1.0',
+      ${sql.json(DEBUGGER_CAPS)}, 'Test Ext', ${orgId}, NOW()
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  return { deviceWorkerId: String(row.id), workerId };
+}
+
+async function seedConnection(opts: {
+  orgId: string;
+  userId: string;
+  connectorKey: string;
+  deviceWorkerId: string | null;
+}): Promise<number> {
+  const sql = getTestDb();
+  const slug = `${opts.connectorKey}-${generateSecureToken(4)}`.replace(/\./g, '-');
+  const [row] = (await sql`
+    INSERT INTO connections (
+      organization_id, connector_key, slug, display_name, status,
+      created_by, visibility, device_worker_id, created_at, updated_at
+    ) VALUES (
+      ${opts.orgId}, ${opts.connectorKey}, ${slug}, ${opts.connectorKey}, 'active',
+      ${opts.userId}, 'private', ${opts.deviceWorkerId}::uuid, NOW(), NOW()
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+  return Number(row.id);
+}
+
+async function seedPendingSync(opts: {
+  orgId: string;
+  connectionId: number;
+  connectorKey: string;
+}): Promise<number> {
+  const sql = getTestDb();
+  const [row] = (await sql`
+    INSERT INTO runs (
+      organization_id, run_type, connection_id, connector_key,
+      approval_status, status, created_at
+    ) VALUES (
+      ${opts.orgId}, 'sync', ${opts.connectionId}, ${opts.connectorKey},
+      'auto', 'pending', current_timestamp
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+  return Number(row.id);
+}
+
+async function pollExtension(workerId: string) {
+  return post('/api/workers/poll', {
+    body: {
+      worker_id: workerId,
+      platform: 'chrome-extension',
+      app_version: '0.1.0',
+      label: 'Test Ext',
+      capabilities: {
+        'browser.tabs': true,
+        'browser.scripting': true,
+        'browser.debugger': true,
+      },
+    },
+  });
+}
+
+async function pollFleet(workerId = 'fleet-affinity-worker') {
+  return post('/api/workers/poll', {
+    body: { worker_id: workerId, capabilities: {} },
+    token: 'test-fleet-token',
+    env: { WORKER_API_TOKEN: 'test-fleet-token' },
+  });
+}
+
+describe('browser-affinity poll claim', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.LOBU_CLOUD_MODE;
+    delete process.env.WORKER_API_TOKEN;
+  });
+  afterEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.LOBU_CLOUD_MODE;
+    delete process.env.WORKER_API_TOKEN;
+  });
+
+  it('fleet claims a LinkedIn sync pinned to a chrome-extension (browser affinity)', async () => {
+    const { userId, orgId } = await seedOrg();
+    const { deviceWorkerId } = await seedExtWorker(userId, orgId);
+    const connId = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'linkedin',
+      deviceWorkerId,
+    });
+    const runId = await seedPendingSync({
+      orgId,
+      connectionId: connId,
+      connectorKey: 'linkedin',
+    });
+
+    const res = await pollFleet();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      run_id?: number;
+      skipped_run_id?: number;
+      connector_key?: string;
+    };
+    // Claimed by fleet. Without on-disk linkedin connector sources the poll
+    // may fail-after-claim with skipped_run_id — either proves the claim path.
+    const claimedId = Number(body.run_id ?? body.skipped_run_id);
+    expect(claimedId).toBe(runId);
+
+    const sql = getTestDb();
+    const [row] = (await sql`
+      SELECT claimed_by FROM runs WHERE id = ${runId}
+    `) as unknown as Array<{ claimed_by: string | null }>;
+    expect(row.claimed_by).toBe('fleet-affinity-worker');
+  });
+
+  it('chrome-extension does NOT claim a LinkedIn sync pinned to itself (affinity, not job host)', async () => {
+    const { userId, orgId } = await seedOrg();
+    const { deviceWorkerId, workerId } = await seedExtWorker(userId, orgId);
+    const connId = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'linkedin',
+      deviceWorkerId,
+    });
+    const runId = await seedPendingSync({
+      orgId,
+      connectionId: connId,
+      connectorKey: 'linkedin',
+    });
+
+    // Warm registration + claim attempt
+    const res = await pollExtension(workerId);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { run_id?: number };
+    expect(body.run_id).toBeUndefined();
+
+    const sql = getTestDb();
+    const [row] = (await sql`
+      SELECT status, claimed_by FROM runs WHERE id = ${runId}
+    `) as unknown as Array<{ status: string; claimed_by: string | null }>;
+    expect(row.status).toBe('pending');
+    expect(row.claimed_by).toBeNull();
+  });
+
+  it('chrome-extension still claims a chrome connector sync pinned to itself', async () => {
+    const { userId, orgId } = await seedOrg();
+    const { deviceWorkerId, workerId } = await seedExtWorker(userId, orgId);
+    const connId = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'chrome',
+      deviceWorkerId,
+    });
+    const runId = await seedPendingSync({
+      orgId,
+      connectionId: connId,
+      connectorKey: 'chrome',
+    });
+
+    // Register + claim. chrome may fail-after-claim without compiled sources.
+    const res = await pollExtension(workerId);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      run_id?: number;
+      skipped_run_id?: number;
+      connector_key?: string;
+    };
+    const claimedId = Number(body.run_id ?? body.skipped_run_id);
+    expect(claimedId).toBe(runId);
+
+    const sql = getTestDb();
+    const [row] = (await sql`
+      SELECT claimed_by FROM runs WHERE id = ${runId}
+    `) as unknown as Array<{ claimed_by: string | null }>;
+    expect(row.claimed_by).toBe(workerId);
+  });
+
+  it('fleet does NOT claim a macos-pinned non-browser-affinity sync (no regression)', async () => {
+    const sql = getTestDb();
+    const { userId, orgId } = await seedOrg();
+    const workerId = `mac-${generateSecureToken(6)}`;
+    const [mac] = (await sql`
+      INSERT INTO device_workers (
+        user_id, worker_id, platform, app_version, capabilities, label, organization_id, last_seen_at
+      ) VALUES (
+        ${userId}, ${workerId}, 'macos', '0.1.0',
+        ${sql.json(['whatsapp_local'])}, 'Mac', ${orgId}, NOW()
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: string }>;
+    const connId = await seedConnection({
+      orgId,
+      userId,
+      connectorKey: 'whatsapp.local',
+      deviceWorkerId: String(mac.id),
+    });
+    const runId = await seedPendingSync({
+      orgId,
+      connectionId: connId,
+      connectorKey: 'whatsapp.local',
+    });
+
+    const res = await pollFleet('fleet-no-macos-steal');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { run_id?: number };
+    expect(body.run_id).toBeUndefined();
+
+    const [row] = (await sql`
+      SELECT status FROM runs WHERE id = ${runId}
+    `) as unknown as Array<{ status: string }>;
+    expect(row.status).toBe('pending');
+  });
+});

--- a/packages/server/src/__tests__/integration/dispatch-chrome-autobind.test.ts
+++ b/packages/server/src/__tests__/integration/dispatch-chrome-autobind.test.ts
@@ -11,7 +11,10 @@
  */
 
 import { afterAll, beforeEach, describe, expect, it } from 'vitest';
-import { resolveOnlineChromeConnection } from '../../worker-api/dispatch-chrome-action';
+import {
+  preferredBrowserWorkerForConnection,
+  resolveOnlineChromeConnection,
+} from '../../worker-api/dispatch-chrome-action';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import { createTestOrganization, createTestUser } from '../setup/test-fixtures';
 
@@ -147,5 +150,58 @@ describe('resolveOnlineChromeConnection — self-healing chrome pin', () => {
     expect(res?.deviceWorkerId).toBe(pinned);
     expect(res?.deviceWorkerId).not.toBe(fresher);
     expect(await pinOf(connId)).toBe(pinned);
+  });
+
+  it('honors preferredDeviceWorkerId over last_seen when that extension is online', async () => {
+    // Data connection (LinkedIn) pin → chrome-extension means browser affinity.
+    const preferred = await seedExtWorker(userId, orgId, { online: true });
+    await sql`
+      UPDATE device_workers
+      SET last_seen_at = now() - interval '3 minutes'
+      WHERE id = ${preferred}::uuid
+    `;
+    const fresher = await seedExtWorker(userId, orgId, { online: true });
+    // Org chrome connection may be stuck on the fresher (or null).
+    const chromeConnId = await seedChromeConn(orgId, userId, fresher);
+
+    const res = await resolveOnlineChromeConnection(orgId, sql, {
+      preferredDeviceWorkerId: preferred,
+    });
+
+    expect(res?.deviceWorkerId).toBe(preferred);
+    expect(res?.deviceWorkerId).not.toBe(fresher);
+    // Chrome connection is re-pinned so the action run can be claimed.
+    expect(await pinOf(chromeConnId)).toBe(preferred);
+  });
+
+  it('returns null when preferred extension is offline (fail-closed, no last_seen steal)', async () => {
+    const preferredOffline = await seedExtWorker(userId, orgId, { online: false });
+    await seedExtWorker(userId, orgId, { online: true }); // would otherwise win
+    await seedChromeConn(orgId, userId, null);
+
+    const res = await resolveOnlineChromeConnection(orgId, sql, {
+      preferredDeviceWorkerId: preferredOffline,
+      failIfPreferredOffline: true,
+    });
+
+    expect(res).toBeNull();
+  });
+
+  it('preferredBrowserWorkerForConnection only returns chrome-extension pins', async () => {
+    const ext = await seedExtWorker(userId, orgId, { online: true });
+    const slug = `li-${Math.random().toString(36).slice(2, 8)}`;
+    const [li] = (await sql`
+      INSERT INTO connections (
+        organization_id, connector_key, slug, display_name, status,
+        created_by, visibility, device_worker_id, created_at, updated_at
+      ) VALUES (
+        ${orgId}, 'linkedin', ${slug}, 'LinkedIn', 'active',
+        ${userId}, 'private', ${ext}::uuid, NOW(), NOW()
+      )
+      RETURNING id
+    `) as unknown as Array<{ id: number }>;
+
+    expect(await preferredBrowserWorkerForConnection(li.id, sql)).toBe(ext);
+    expect(await preferredBrowserWorkerForConnection(null, sql)).toBeNull();
   });
 });

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -209,8 +209,12 @@ async function executeLocalActionInline(
 						actionKey,
 						actionInput,
 						parentRunId: runId,
+						// Browser affinity: data connection pin to a chrome-extension
+						// selects which Owletto browser receives scrapes.
+						parentConnectionId: connection.id,
 						abortSignal,
 					});
+
 					if (dispatchResult.status !== "completed") {
 						throw new Error(
 							dispatchResult.error_message ??

--- a/packages/server/src/worker-api/dispatch-chrome-action.ts
+++ b/packages/server/src/worker-api/dispatch-chrome-action.ts
@@ -5,17 +5,14 @@
  * call a chrome connector action against the paired Owletto extension in
  * the same org. We:
  *
- *   1. Look up the parent sync run's org from runs.
- *   2. Pick an online chrome connection in that org.
+ *   1. Look up the parent sync run's org (+ optional data connection) from runs.
+ *   2. Pick an online chrome connection / extension (prefer parent connection's
+ *      chrome-extension pin when set — browser affinity for LinkedIn/X/etc.).
  *   3. Enqueue an action run via `createConnectorOperationRun` (the same
  *      helper `manage_operations.execute` uses for device-bound calls).
  *   4. Await completion via the shared `waitForDeviceActionRun` (also
  *      reused from manage_operations).
  *   5. Return the action_output.
- *
- * No new state machine, no new queue — the device-action runs queue does
- * the work end-to-end, the same way the user drove it manually via
- * `POST /api/{org}/manage_operations { action: 'execute' }` earlier today.
  *
  * Multi-replica safe by reuse: all signalling is via Postgres rows on the
  * `runs` table; the chrome extension's `/api/workers/complete-action` POST
@@ -47,37 +44,50 @@ export interface ChromeActionDispatchResult {
   error_message?: string;
 }
 
+export type ResolveOnlineChromeOptions = {
+  /**
+   * Prefer this device_workers.id when it is an online debugger-capable
+   * chrome-extension. Used for browser affinity: a LinkedIn/X/Revolut
+   * connection may set device_worker_id to a chrome-extension worker to mean
+   * "scrape with this browser" (parent sync still runs on the fleet — see
+   * poll.ts browser-affinity claim rules).
+   */
+  preferredDeviceWorkerId?: string | null;
+  /**
+   * When preferredDeviceWorkerId is set but that extension is offline / not
+   * eligible, fail instead of falling back to last_seen (avoids scraping the
+   * wrong profile). Default true when a preference is provided.
+   */
+  failIfPreferredOffline?: boolean;
+};
+
 /**
- * Resolve an online Owletto Chrome extension to run a chrome action against, and
- * self-heal the org's `chrome` connection pin when needed.
+ * Resolve an online Owletto Chrome extension to run a chrome action against.
  *
- * Both this dispatch and the poll claim gate on `connections.device_worker_id`,
- * but re-pairing mints a NEW device worker and can leave the chrome connection
- * pinned to the old (now offline) one — or never pinned at all. Without a
- * heal, server-side chrome connectors (Revolut, LinkedIn) fail with "no online
- * paired extension" even when another extension IS online.
+ * Resolution order:
+ *   1. preferredDeviceWorkerId if online + chrome-extension + debugger
+ *   2. The org chrome connection's current pin if still online (sticky —
+ *      multi-Chrome orgs must not jump to last_seen DESC)
+ *   3. Freshest online debugger-capable extension (heal NULL / stale pin)
  *
- * Sticky pin: when the current pin is still an online debugger-capable
- * chrome-extension, keep it. Users with multiple Chromes (e.g. Mac mini +
- * MacBook) deliberately pin scrapers to one machine; always rebinding to
- * `last_seen_at DESC` would steal actions to whichever extension last polled.
- * Only repin when the pin is NULL or the pinned worker is offline / missing
- * debugger — covering re-pair and first-use.
- *
- * Returns the chrome connection id + the resolved worker, or null when no online
- * extension exists in the org.
+ * When we select a worker, the org `chrome` connection is repinned to it so
+ * the poll claim path can route the action run.
  */
 export async function resolveOnlineChromeConnection(
   organizationId: string,
-  sql = getDb()
+  sql = getDb(),
+  opts: ResolveOnlineChromeOptions = {}
 ): Promise<{ connectionId: number; deviceWorkerId: string } | null> {
-  // Prefer the connection's current pin when that worker is still online and
-  // debugger-capable. Fall back to the most recently seen online extension.
+  const preferredId = opts.preferredDeviceWorkerId ?? null;
+  const failIfPreferredOffline =
+    opts.failIfPreferredOffline ?? preferredId != null;
+
   const rows = (await sql`
     SELECT
       con.id AS connection_id,
       con.device_worker_id AS current_pin,
       pinned.id AS pinned_online_worker_id,
+      preferred.id AS preferred_online_worker_id,
       fresh.id AS fresh_online_worker_id
     FROM connections con
     LEFT JOIN device_workers pinned
@@ -86,6 +96,13 @@ export async function resolveOnlineChromeConnection(
      AND pinned.platform = 'chrome-extension'
      AND pinned.capabilities::jsonb @> '["browser.debugger"]'::jsonb
      AND pinned.last_seen_at > now() - make_interval(mins => ${DEVICE_ONLINE_WINDOW_MINUTES})
+    LEFT JOIN device_workers preferred
+      ON ${preferredId}::uuid IS NOT NULL
+     AND preferred.id = ${preferredId}::uuid
+     AND preferred.organization_id = con.organization_id
+     AND preferred.platform = 'chrome-extension'
+     AND preferred.capabilities::jsonb @> '["browser.debugger"]'::jsonb
+     AND preferred.last_seen_at > now() - make_interval(mins => ${DEVICE_ONLINE_WINDOW_MINUTES})
     LEFT JOIN LATERAL (
       SELECT dw.id
       FROM device_workers dw
@@ -105,6 +122,7 @@ export async function resolveOnlineChromeConnection(
     connection_id: number;
     current_pin: string | null;
     pinned_online_worker_id: string | null;
+    preferred_online_worker_id: string | null;
     fresh_online_worker_id: string | null;
   }>;
 
@@ -113,11 +131,33 @@ export async function resolveOnlineChromeConnection(
     connection_id,
     current_pin,
     pinned_online_worker_id,
+    preferred_online_worker_id,
     fresh_online_worker_id,
   } = rows[0];
 
-  // Sticky: keep a still-online deliberate pin. Otherwise heal to the freshest
-  // online debugger extension (NULL pin or stale post-re-pair pin).
+  // Explicit browser affinity (data connection pin → chrome-extension) wins.
+  if (preferredId) {
+    if (preferred_online_worker_id) {
+      if (current_pin !== preferred_online_worker_id) {
+        await sql`
+          UPDATE connections
+          SET device_worker_id = ${preferred_online_worker_id}::uuid, updated_at = now()
+          WHERE id = ${connection_id}
+            AND deleted_at IS NULL
+        `;
+      }
+      return {
+        connectionId: connection_id,
+        deviceWorkerId: preferred_online_worker_id,
+      };
+    }
+    if (failIfPreferredOffline) {
+      // Caller surfaces a clear error — do not silently scrape another profile.
+      return null;
+    }
+  }
+
+  // Sticky org chrome pin, else freshest online debugger extension.
   const online_worker_id = pinned_online_worker_id ?? fresh_online_worker_id;
   if (!online_worker_id) return null;
 
@@ -126,10 +166,33 @@ export async function resolveOnlineChromeConnection(
       UPDATE connections
       SET device_worker_id = ${online_worker_id}::uuid, updated_at = now()
       WHERE id = ${connection_id}
+        AND deleted_at IS NULL
     `;
   }
 
   return { connectionId: connection_id, deviceWorkerId: online_worker_id };
+}
+
+/**
+ * Look up browser affinity for a parent sync: if the data connection is pinned
+ * to a chrome-extension worker, that pin means "use this browser" (not "run
+ * the parent sync on the extension" — see poll.ts).
+ */
+export async function preferredBrowserWorkerForConnection(
+  connectionId: number | null | undefined,
+  sql = getDb()
+): Promise<string | null> {
+  if (connectionId == null) return null;
+  const rows = (await sql`
+    SELECT dw.id
+    FROM connections con
+    JOIN device_workers dw ON dw.id = con.device_worker_id
+    WHERE con.id = ${connectionId}
+      AND con.deleted_at IS NULL
+      AND dw.platform = 'chrome-extension'
+    LIMIT 1
+  `) as Array<{ id: string }>;
+  return rows[0]?.id ?? null;
 }
 
 /**
@@ -138,13 +201,6 @@ export async function resolveOnlineChromeConnection(
  *   1. Pick an online paired Owletto chrome connection in `organizationId`.
  *   2. Enqueue a device-bound chrome action run via `createConnectorOperationRun`.
  *   3. Await completion via `waitForDeviceActionRun` and return its output.
- *
- * Used by the HTTP bridge (a connector on the worker fleet, after it has
- * authorized the parent sync run) AND by `manage_operations` inline action
- * execution (a connector action — e.g. the office-bot Deliveroo connector —
- * running in-gateway that wants to scrape the paired extension). Caller is
- * responsible for any parent-run authorization; this function only resolves a
- * chrome worker and drives the run.
  */
 export async function dispatchChromeActionToExtension(params: {
   organizationId: string;
@@ -152,22 +208,39 @@ export async function dispatchChromeActionToExtension(params: {
   actionInput: Record<string, unknown>;
   /** Parent run id, for log correlation only. */
   parentRunId?: number;
+  /**
+   * Data connection that owns the parent sync (e.g. LinkedIn). When pinned to
+   * a chrome-extension, scrapes target that browser.
+   */
+  parentConnectionId?: number | null;
   /** Abort the wait early (e.g. the calling reaction hit its budget). */
   abortSignal?: AbortSignal;
 }): Promise<ChromeActionDispatchResult> {
-  const { organizationId, actionKey, actionInput, parentRunId, abortSignal } =
-    params;
+  const {
+    organizationId,
+    actionKey,
+    actionInput,
+    parentRunId,
+    parentConnectionId,
+    abortSignal,
+  } = params;
   const sql = getDb();
 
-  // (1) Pick an online chrome extension in this org and pin the chrome
-  //     connection to it (self-heals NULL / stale-after-re-pair pins so the
-  //     poll claim can route the run). See resolveOnlineChromeConnection.
-  const chromeConnection = await resolveOnlineChromeConnection(organizationId, sql);
+  const preferredDeviceWorkerId = await preferredBrowserWorkerForConnection(
+    parentConnectionId,
+    sql
+  );
+
+  const chromeConnection = await resolveOnlineChromeConnection(organizationId, sql, {
+    preferredDeviceWorkerId,
+    failIfPreferredOffline: preferredDeviceWorkerId != null,
+  });
   if (!chromeConnection) {
     return {
       status: 'failed',
-      error_message:
-        'No online paired Owletto Chrome extension in this organization. Pair a Chrome extension first (and make sure it is running).',
+      error_message: preferredDeviceWorkerId
+        ? 'The Chrome extension selected for this connection is offline. Open Owletto in that browser (and stay signed in) to continue.'
+        : 'No online paired Owletto Chrome extension in this organization. Pair a Chrome extension first (and make sure it is running).',
     };
   }
 
@@ -182,7 +255,6 @@ export async function dispatchChromeActionToExtension(params: {
     operationInput.holder_run_id = parentRunId;
   }
 
-  // (2) Insert a device-bound chrome connector action run.
   let runId: number;
   try {
     runId = await createConnectorOperationRun({
@@ -207,19 +279,16 @@ export async function dispatchChromeActionToExtension(params: {
     {
       run_id: runId,
       parent_run_id: parentRunId,
+      parent_connection_id: parentConnectionId,
       action_key: actionKey,
       chrome_connection_id: chromeConnection.connectionId,
       device_worker_id: chromeConnection.deviceWorkerId,
+      preferred_device_worker_id: preferredDeviceWorkerId,
     },
     '[dispatchChromeAction] dispatched'
   );
 
-  // (3) Wait for the chrome extension to claim and complete.
   const result = await waitForDeviceActionRun(runId, organizationId, abortSignal);
-  // `waitForDeviceActionRun` returns `output: unknown` (a device/connector run
-  // can produce any JSON). Chrome actions return object results and this
-  // result's `output` feeds `completeRunInline`, which requires an object, so
-  // narrow here: a non-object output is a protocol violation, floored to `{}`.
   const output =
     result.output && typeof result.output === 'object' && !Array.isArray(result.output)
       ? (result.output as Record<string, unknown>)
@@ -247,12 +316,10 @@ export async function dispatchChromeAction(c: Context<{ Bindings: Env }>) {
 
   const sql = getDb();
 
-  // (1) Authorize: parent run must exist, be a running sync claimed by
-  // this worker. We don't re-gate on workerAuthMode — the parent claim
-  // already gated org access; trusted callers (WORKER_API_TOKEN) are
-  // server-side fleets that already have full access.
+  // Authorize: parent run must exist, be a running sync claimed by this worker.
+  // connection_id drives browser affinity when pinned to a chrome-extension.
   const parentRows = (await sql`
-    SELECT r.organization_id, r.status, r.claimed_by, r.run_type
+    SELECT r.organization_id, r.status, r.claimed_by, r.run_type, r.connection_id
     FROM runs r
     WHERE r.id = ${body.parent_run_id}
     LIMIT 1
@@ -261,6 +328,7 @@ export async function dispatchChromeAction(c: Context<{ Bindings: Env }>) {
     status: string;
     claimed_by: string | null;
     run_type: string;
+    connection_id: number | null;
   }>;
   if (parentRows.length === 0) {
     return c.json({ error: 'parent_run not found' }, 404);
@@ -281,15 +349,13 @@ export async function dispatchChromeAction(c: Context<{ Bindings: Env }>) {
       400
     );
   }
-  const organizationId = parentRun.organization_id;
 
-  // (2-4) Resolve a chrome worker, enqueue the device action run, and await
-  // completion — shared with manage_operations inline action execution.
   const result = await dispatchChromeActionToExtension({
-    organizationId,
+    organizationId: parentRun.organization_id,
     actionKey: body.action_key,
     actionInput: body.action_input ?? {},
     parentRunId: body.parent_run_id,
+    parentConnectionId: parentRun.connection_id,
   });
   return c.json(result);
 }

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -398,6 +398,10 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
         SELECT r.id
         FROM runs r
         LEFT JOIN connections con ON con.id = r.connection_id
+        -- Pin target platform: chrome-extension pins on non-chrome connectors mean
+        -- browser affinity (scrape via that extension), not "run parent sync on
+        -- the extension". See dispatch-chrome-action preferredBrowserWorkerForConnection.
+        LEFT JOIN device_workers pin_dw ON pin_dw.id = con.device_worker_id
         LEFT JOIN LATERAL (
           SELECT cd.required_capability
           FROM connector_definitions cd
@@ -414,13 +418,21 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
             (
               r.run_type IN ('sync', 'action', 'embed_backfill', 'auth')
               AND (
-                -- (1A) trusted/anonymous fleet worker: the no-capability cloud
-                --      connectors plus any capability it happens to advertise,
-                --      in any org — but NEVER a connection pinned to a device.
+                -- (1A) trusted/anonymous fleet worker: no-capability cloud
+                --      connectors, any org — never a connection pinned for
+                --      *execution*. Browser-affinity pins (chrome-extension on
+                --      non-chrome parent syncs) still allow fleet claim.
                 (
                   ${!isUserScopedWorker}
                   AND COALESCE(cd.required_capability, '') = ANY(${pgTextArray(capabilityMatchSet)}::text[])
-                  AND con.device_worker_id IS NULL
+                  AND (
+                    con.device_worker_id IS NULL
+                    OR (
+                      pin_dw.platform = 'chrome-extension'
+                      AND r.run_type IN ('sync', 'auth', 'embed_backfill')
+                      AND r.connector_key NOT LIKE 'chrome%'
+                    )
+                  )
                 )
                 -- (1B) user-scoped device worker: an unpinned capability-matched
                 --      device connector in an org this worker can see. Capability
@@ -435,11 +447,10 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
                   AND con.device_worker_id IS NULL
                   AND r.organization_id = ANY(${pgTextArray(baseOrgScopeIds)}::text[])
                 )
-                -- ... or any connection explicitly pinned to THIS device (this is
-                --     "run the Reddit connector on my Mac"). Still: a device-only
-                --     connector needs the capability currently advertised, and the
-                --     pin only counts in an org this worker can see (which includes
-                --     the org the device is attached to).
+                -- ... or any connection explicitly pinned to THIS device for
+                --     *execution* (e.g. WhatsApp on Mac). Browser-affinity pins
+                --     (chrome-extension + non-chrome parent sync) must NOT be
+                --     claimed by the extension — those runs stay on the fleet.
                 OR (
                   ${isUserScopedWorker}
                   AND ${deviceWorkerId}::uuid IS NOT NULL
@@ -449,6 +460,11 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
                     OR cd.required_capability = ANY(${pgTextArray(authorizedCapabilities)}::text[])
                   )
                   AND r.organization_id = ANY(${pgTextArray(orgScopeIds)}::text[])
+                  AND NOT (
+                    pin_dw.platform = 'chrome-extension'
+                    AND r.run_type IN ('sync', 'auth', 'embed_backfill')
+                    AND r.connector_key NOT LIKE 'chrome%'
+                  )
                 )
               )
             )

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -428,6 +428,9 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
                   AND (
                     con.device_worker_id IS NULL
                     OR (
+                      -- Browser affinity (not job host). Exclude run_type=action:
+                      -- scrape actions are always connector_key='chrome' and use
+                      -- the org chrome connection pin, not LinkedIn's affinity pin.
                       pin_dw.platform = 'chrome-extension'
                       AND r.run_type IN ('sync', 'auth', 'embed_backfill')
                       AND r.connector_key NOT LIKE 'chrome%'


### PR DESCRIPTION
## Summary

- When a LinkedIn/X/Revolut (non-`chrome*`) connection is pinned to a **chrome-extension** device, that pin means **use this browser for scrapes**, not run the parent sync on the extension.
- Parent sync stays on the cloud/fleet connector-worker; extension only receives action runs.
- Dispatch prefers that extension over org-wide `last_seen` when the preferred worker is online; fail closed if the preferred browser is offline (avoids scraping the wrong profile).

## Changes

| File | What |
|------|------|
| `poll.ts` | Fleet can claim browser-affinity pins; extensions cannot claim non-chrome parent syncs |
| `dispatch-chrome-action.ts` | Prefer parent connection’s chrome-extension pin; sticky + last_seen fallback when no preference |
| `manage_operations.ts` | Pass `parentConnectionId` for inline chrome scrapes |
| tests | Prefer pin over fresher last_seen; offline preferred returns null |

## How to test

1. Pair Owletto on the Chrome that has LinkedIn/X logged in (e.g. Mac mini Chrome).
2. Pin the **LinkedIn/X connection** to that chrome-extension device worker id (same `device_worker_id` field).
3. Trigger `home_feed` — parent sync should run on fleet; scrapes should hit the pinned browser only.
4. With a second extension online and newer `last_seen`, scrapes must still use the pin.
5. With pin offline, dispatch fails with offline message (not silent steal).

```bash
# integration tests (needs Postgres + pgvector)
DATABASE_URL=… bunx vitest run packages/server/src/__tests__/integration/dispatch-chrome-autobind.test.ts
```

## No API/DB schema change

Reuses existing `connections.device_worker_id`. Behavior change only for chrome-extension pins on non-chrome parent connectors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786207409&installation_id=136316292&pr_number=1826&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1826&signature=9b81402b78e71abbd0fca1f84a115bc337b420a5f86c17fc40325059e4996f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser affinity so certain actions can stay tied to the same browser connection when available.
  * Improved browser selection to prefer a previously linked Chrome connection when present.

* **Bug Fixes**
  * Prevented fallback to a different browser connection when the preferred one is offline and strict matching is enabled.
  * Tightened run-claiming behavior so pinned browser connections are handled more consistently across Chrome-related workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->