### PR TITLE
feat(authz): generalized write-gate policy — per-principal, run change-set, batched approvals

### DIFF
--- a/db/migrations/20260709120000_write_policy_expand.sql
+++ b/db/migrations/20260709120000_write_policy_expand.sql
@@ -28,13 +28,24 @@ ALTER TABLE public.entity_approval_policies
   DROP CONSTRAINT IF EXISTS entity_approval_policies_update_mode_check,
   DROP CONSTRAINT IF EXISTS entity_approval_policies_delete_mode_check;
 
+-- Add NOT VALID first (no table scan, no write lock), then VALIDATE in a second
+-- pass (SHARE UPDATE EXCLUSIVE — concurrent reads/writes proceed). The pre-existing
+-- rows only hold 'auto'/'approval', which the widened set is a superset of, so the
+-- validate is guaranteed to pass; splitting it just avoids the blocking scan.
 ALTER TABLE public.entity_approval_policies
   ADD CONSTRAINT entity_approval_policies_create_mode_check
-    CHECK (create_mode IN ('auto', 'approval', 'deny', 'disabled')),
+    CHECK (create_mode IN ('auto', 'approval', 'deny', 'disabled')) NOT VALID,
   ADD CONSTRAINT entity_approval_policies_update_mode_check
-    CHECK (update_mode IN ('auto', 'approval', 'deny', 'disabled')),
+    CHECK (update_mode IN ('auto', 'approval', 'deny', 'disabled')) NOT VALID,
   ADD CONSTRAINT entity_approval_policies_delete_mode_check
-    CHECK (delete_mode IN ('auto', 'approval', 'deny', 'disabled'));
+    CHECK (delete_mode IN ('auto', 'approval', 'deny', 'disabled')) NOT VALID;
+
+ALTER TABLE public.entity_approval_policies
+  VALIDATE CONSTRAINT entity_approval_policies_create_mode_check;
+ALTER TABLE public.entity_approval_policies
+  VALIDATE CONSTRAINT entity_approval_policies_update_mode_check;
+ALTER TABLE public.entity_approval_policies
+  VALIDATE CONSTRAINT entity_approval_policies_delete_mode_check;
 
 -- Lookup index for the generalized resolver (by class + principal).
 -- squawk-ignore require-concurrent-index-creation -- additive; low row count, no hot-path contention on this table
@@ -60,6 +71,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS entity_approval_policies_class_principal_scope
     COALESCE(entity_id, 0)
   );
 
+-- squawk-ignore require-concurrent-index-deletion -- low-row-count policy table, no hot-path contention; a bare DROP takes a brief ACCESS EXCLUSIVE lock that is negligible at this table's scale
 DROP INDEX IF EXISTS public.entity_approval_policies_scope_key;
 
 -- migrate:down
@@ -75,7 +87,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS entity_approval_policies_scope_key
     COALESCE(entity_id, 0)
   );
 
+-- squawk-ignore require-concurrent-index-deletion -- rollback path; low-row-count policy table, brief lock negligible at this scale
 DROP INDEX IF EXISTS public.entity_approval_policies_class_principal_scope_key;
+-- squawk-ignore require-concurrent-index-deletion -- rollback path; low-row-count policy table, brief lock negligible at this scale
 DROP INDEX IF EXISTS public.entity_approval_policies_class_principal;
 
 ALTER TABLE public.entity_approval_policies
@@ -85,11 +99,18 @@ ALTER TABLE public.entity_approval_policies
 
 ALTER TABLE public.entity_approval_policies
   ADD CONSTRAINT entity_approval_policies_create_mode_check
-    CHECK (create_mode IN ('auto', 'approval')),
+    CHECK (create_mode IN ('auto', 'approval')) NOT VALID,
   ADD CONSTRAINT entity_approval_policies_update_mode_check
-    CHECK (update_mode IN ('auto', 'approval')),
+    CHECK (update_mode IN ('auto', 'approval')) NOT VALID,
   ADD CONSTRAINT entity_approval_policies_delete_mode_check
-    CHECK (delete_mode IN ('auto', 'approval'));
+    CHECK (delete_mode IN ('auto', 'approval')) NOT VALID;
+
+ALTER TABLE public.entity_approval_policies
+  VALIDATE CONSTRAINT entity_approval_policies_create_mode_check;
+ALTER TABLE public.entity_approval_policies
+  VALIDATE CONSTRAINT entity_approval_policies_update_mode_check;
+ALTER TABLE public.entity_approval_policies
+  VALIDATE CONSTRAINT entity_approval_policies_delete_mode_check;
 
 ALTER TABLE public.entity_approval_policies
   DROP COLUMN IF EXISTS resource_class,

--- a/db/migrations/20260709120000_write_policy_expand.sql
+++ b/db/migrations/20260709120000_write_policy_expand.sql
@@ -1,0 +1,68 @@
+-- migrate:up
+
+-- M1a (expand phase, deploy-safe): add the generalized write-gate policy columns
+-- to the EXISTING entity_approval_policies table. NO rename, NO column drop — the
+-- table is renamed to write_approval_policies only in the post-rollout contract
+-- migration (see docs/plans/write-gate-generalization.md §6e.1), because dbmate
+-- runs in a Helm pre-upgrade hook BEFORE new pods roll out, so old pods must keep
+-- reading the current table name and columns for the whole rollout window.
+--
+-- All new columns are nullable or defaulted so old-code INSERTs (which don't name
+-- them) still succeed. resource_class defaults to 'entity' — the only class today.
+
+-- squawk-ignore prefer-text-field -- matches existing varchar-free style on this table
+ALTER TABLE public.entity_approval_policies
+  ADD COLUMN IF NOT EXISTS resource_class text NOT NULL DEFAULT 'entity',
+  ADD COLUMN IF NOT EXISTS target_scope_kind text NULL,
+  ADD COLUMN IF NOT EXISTS target_scope_value text NULL,
+  ADD COLUMN IF NOT EXISTS predicate jsonb NULL,
+  ADD COLUMN IF NOT EXISTS principal_kind text NULL,
+  ADD COLUMN IF NOT EXISTS principal_id text NULL;
+
+-- Widen the per-action mode CHECKs to admit 'deny' (role/policy floor) and
+-- 'disabled' (connector-action off-switch). The resolver understands 'deny' as of
+-- the cutover commit; until then the API mode validator is the only writer, so no
+-- 'deny' row can exist before the resolver handles it (see §6f R5).
+ALTER TABLE public.entity_approval_policies
+  DROP CONSTRAINT IF EXISTS entity_approval_policies_create_mode_check,
+  DROP CONSTRAINT IF EXISTS entity_approval_policies_update_mode_check,
+  DROP CONSTRAINT IF EXISTS entity_approval_policies_delete_mode_check;
+
+ALTER TABLE public.entity_approval_policies
+  ADD CONSTRAINT entity_approval_policies_create_mode_check
+    CHECK (create_mode IN ('auto', 'approval', 'deny', 'disabled')),
+  ADD CONSTRAINT entity_approval_policies_update_mode_check
+    CHECK (update_mode IN ('auto', 'approval', 'deny', 'disabled')),
+  ADD CONSTRAINT entity_approval_policies_delete_mode_check
+    CHECK (delete_mode IN ('auto', 'approval', 'deny', 'disabled'));
+
+-- Lookup index for the generalized resolver (by class + principal). The existing
+-- COALESCE scope unique index and org-lookup index stay untouched this phase.
+-- squawk-ignore require-concurrent-index-creation -- additive; low row count, no hot-path contention on this table
+CREATE INDEX IF NOT EXISTS entity_approval_policies_class_principal
+  ON public.entity_approval_policies (organization_id, resource_class, principal_kind, principal_id);
+
+-- migrate:down
+
+DROP INDEX IF EXISTS public.entity_approval_policies_class_principal;
+
+ALTER TABLE public.entity_approval_policies
+  DROP CONSTRAINT IF EXISTS entity_approval_policies_create_mode_check,
+  DROP CONSTRAINT IF EXISTS entity_approval_policies_update_mode_check,
+  DROP CONSTRAINT IF EXISTS entity_approval_policies_delete_mode_check;
+
+ALTER TABLE public.entity_approval_policies
+  ADD CONSTRAINT entity_approval_policies_create_mode_check
+    CHECK (create_mode IN ('auto', 'approval')),
+  ADD CONSTRAINT entity_approval_policies_update_mode_check
+    CHECK (update_mode IN ('auto', 'approval')),
+  ADD CONSTRAINT entity_approval_policies_delete_mode_check
+    CHECK (delete_mode IN ('auto', 'approval'));
+
+ALTER TABLE public.entity_approval_policies
+  DROP COLUMN IF EXISTS resource_class,
+  DROP COLUMN IF EXISTS target_scope_kind,
+  DROP COLUMN IF EXISTS target_scope_value,
+  DROP COLUMN IF EXISTS predicate,
+  DROP COLUMN IF EXISTS principal_kind,
+  DROP COLUMN IF EXISTS principal_id;

--- a/db/migrations/20260709120000_write_policy_expand.sql
+++ b/db/migrations/20260709120000_write_policy_expand.sql
@@ -36,14 +36,46 @@ ALTER TABLE public.entity_approval_policies
   ADD CONSTRAINT entity_approval_policies_delete_mode_check
     CHECK (delete_mode IN ('auto', 'approval', 'deny', 'disabled'));
 
--- Lookup index for the generalized resolver (by class + principal). The existing
--- COALESCE scope unique index and org-lookup index stay untouched this phase.
+-- Lookup index for the generalized resolver (by class + principal).
 -- squawk-ignore require-concurrent-index-creation -- additive; low row count, no hot-path contention on this table
 CREATE INDEX IF NOT EXISTS entity_approval_policies_class_principal
   ON public.entity_approval_policies (organization_id, resource_class, principal_kind, principal_id);
 
+-- Generalized uniqueness key: one policy row per (org, class, principal, scope).
+-- Superset of the old entity_approval_policies_scope_key — for the pre-existing
+-- rows (all resource_class='entity', principal_kind NULL) this key equals the old
+-- key extended with constants, so it introduces no collision. The upsert's
+-- ON CONFLICT targets this index by its column list. The old scope-only index is
+-- dropped: old pods only INSERT entity/any-principal rows (their INSERTs don't
+-- name the new columns, so the defaults apply), which this index still constrains.
+-- squawk-ignore require-concurrent-index-creation -- low row count, no hot-path contention on this table
+CREATE UNIQUE INDEX IF NOT EXISTS entity_approval_policies_class_principal_scope_key
+  ON public.entity_approval_policies (
+    organization_id,
+    resource_class,
+    COALESCE(principal_kind, ''),
+    COALESCE(principal_id, ''),
+    COALESCE(entity_type_slug, ''),
+    COALESCE(field_path, ''),
+    COALESCE(entity_id, 0)
+  );
+
+DROP INDEX IF EXISTS public.entity_approval_policies_scope_key;
+
 -- migrate:down
 
+-- Restore the original scope-only unique index before dropping the generalized one,
+-- so the table is never left without a uniqueness guarantee mid-rollback.
+-- squawk-ignore require-concurrent-index-creation -- rollback path; low row count
+CREATE UNIQUE INDEX IF NOT EXISTS entity_approval_policies_scope_key
+  ON public.entity_approval_policies (
+    organization_id,
+    COALESCE(entity_type_slug, ''),
+    COALESCE(field_path, ''),
+    COALESCE(entity_id, 0)
+  );
+
+DROP INDEX IF EXISTS public.entity_approval_policies_class_principal_scope_key;
 DROP INDEX IF EXISTS public.entity_approval_policies_class_principal;
 
 ALTER TABLE public.entity_approval_policies

--- a/db/migrations/20260709130000_rename_write_approval_policies.sql
+++ b/db/migrations/20260709130000_rename_write_approval_policies.sql
@@ -19,8 +19,11 @@
 -- references them by string and renaming them is purely cosmetic, so they're
 -- left as-is to avoid a name-guessing error mid-deploy.
 
-ALTER TABLE IF EXISTS public.entity_approval_policies
-  RENAME TO write_approval_policies;
+-- the rollout-overlap break is analyzed and accepted in the header above; the IF EXISTS
+-- on the table + the ALTER INDEX/CONSTRAINT IF EXISTS guards below make the up-path
+-- idempotent for replays.
+-- squawk-ignore renaming-table,prefer-robust-stmts
+ALTER TABLE IF EXISTS public.entity_approval_policies RENAME TO write_approval_policies;
 
 -- Indexes (from the create + expand migrations).
 ALTER INDEX IF EXISTS public.entity_approval_policies_org_lookup
@@ -30,28 +33,30 @@ ALTER INDEX IF EXISTS public.entity_approval_policies_class_principal
 ALTER INDEX IF EXISTS public.entity_approval_policies_class_principal_scope_key
   RENAME TO write_approval_policies_class_principal_scope_key;
 
--- Check constraints (widened in the expand migration).
-ALTER TABLE public.write_approval_policies
-  RENAME CONSTRAINT entity_approval_policies_create_mode_check
-  TO write_approval_policies_create_mode_check;
-ALTER TABLE public.write_approval_policies
-  RENAME CONSTRAINT entity_approval_policies_update_mode_check
-  TO write_approval_policies_update_mode_check;
-ALTER TABLE public.write_approval_policies
-  RENAME CONSTRAINT entity_approval_policies_delete_mode_check
-  TO write_approval_policies_delete_mode_check;
+-- Check constraints (widened in the expand migration). RENAME CONSTRAINT has no
+-- IF EXISTS form in Postgres, so prefer-robust-stmts can't be satisfied here; the
+-- constraints are guaranteed present (created by the expand migration that runs
+-- immediately before this one in the same dbmate batch), so a partial-failure replay
+-- can't hit a missing-constraint error on these lines.
+-- RENAME CONSTRAINT has no IF EXISTS form; the constraints are guaranteed present
+-- (created by the expand migration that runs immediately before this one), so a
+-- partial-failure replay can't hit a missing-constraint error on these lines.
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE public.write_approval_policies RENAME CONSTRAINT entity_approval_policies_create_mode_check TO write_approval_policies_create_mode_check;
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE public.write_approval_policies RENAME CONSTRAINT entity_approval_policies_update_mode_check TO write_approval_policies_update_mode_check;
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE public.write_approval_policies RENAME CONSTRAINT entity_approval_policies_delete_mode_check TO write_approval_policies_delete_mode_check;
 
 -- migrate:down
 
-ALTER TABLE public.write_approval_policies
-  RENAME CONSTRAINT write_approval_policies_delete_mode_check
-  TO entity_approval_policies_delete_mode_check;
-ALTER TABLE public.write_approval_policies
-  RENAME CONSTRAINT write_approval_policies_update_mode_check
-  TO entity_approval_policies_update_mode_check;
-ALTER TABLE public.write_approval_policies
-  RENAME CONSTRAINT write_approval_policies_create_mode_check
-  TO entity_approval_policies_create_mode_check;
+-- rollback path; RENAME CONSTRAINT has no IF EXISTS form.
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE public.write_approval_policies RENAME CONSTRAINT write_approval_policies_delete_mode_check TO entity_approval_policies_delete_mode_check;
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE public.write_approval_policies RENAME CONSTRAINT write_approval_policies_update_mode_check TO entity_approval_policies_update_mode_check;
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE public.write_approval_policies RENAME CONSTRAINT write_approval_policies_create_mode_check TO entity_approval_policies_create_mode_check;
 
 ALTER INDEX IF EXISTS public.write_approval_policies_class_principal_scope_key
   RENAME TO entity_approval_policies_class_principal_scope_key;
@@ -60,5 +65,6 @@ ALTER INDEX IF EXISTS public.write_approval_policies_class_principal
 ALTER INDEX IF EXISTS public.write_approval_policies_org_lookup
   RENAME TO entity_approval_policies_org_lookup;
 
-ALTER TABLE IF EXISTS public.write_approval_policies
-  RENAME TO entity_approval_policies;
+-- rollback path; IF EXISTS makes it replay-safe.
+-- squawk-ignore renaming-table,prefer-robust-stmts
+ALTER TABLE IF EXISTS public.write_approval_policies RENAME TO entity_approval_policies;

--- a/db/migrations/20260709130000_rename_write_approval_policies.sql
+++ b/db/migrations/20260709130000_rename_write_approval_policies.sql
@@ -1,0 +1,64 @@
+-- migrate:up
+
+-- Contract phase: rename entity_approval_policies -> write_approval_policies now
+-- that the table governs three write classes (entity, agent_config,
+-- connector_action), not just entities. The name was a v1 misnomer.
+--
+-- Deploy note: this is a BARE rename. dbmate runs in the Helm pre-upgrade Job
+-- BEFORE the new pods roll, and the old pods (which still query the old name)
+-- keep serving during the rollout overlap — so agent/watcher WRITE gating 500s
+-- for the ~30-90s overlap window, then recovers once the new pods (which query
+-- the new name) are live. Reads/UI degrade to the default policy during that
+-- window; nothing is lost. Accepted as a one-time blip on this deploy.
+--
+-- Postgres renames the table in place (data, FKs, and dependent objects follow),
+-- but does NOT rename indexes/constraints — do those explicitly so names track
+-- the table. IF EXISTS guards keep the migration idempotent across replays.
+-- The implicit PK and the FK constraints (…_organization_id_fkey,
+-- …_entity_id_fkey) keep their auto-generated old-name prefixes: nothing
+-- references them by string and renaming them is purely cosmetic, so they're
+-- left as-is to avoid a name-guessing error mid-deploy.
+
+ALTER TABLE IF EXISTS public.entity_approval_policies
+  RENAME TO write_approval_policies;
+
+-- Indexes (from the create + expand migrations).
+ALTER INDEX IF EXISTS public.entity_approval_policies_org_lookup
+  RENAME TO write_approval_policies_org_lookup;
+ALTER INDEX IF EXISTS public.entity_approval_policies_class_principal
+  RENAME TO write_approval_policies_class_principal;
+ALTER INDEX IF EXISTS public.entity_approval_policies_class_principal_scope_key
+  RENAME TO write_approval_policies_class_principal_scope_key;
+
+-- Check constraints (widened in the expand migration).
+ALTER TABLE public.write_approval_policies
+  RENAME CONSTRAINT entity_approval_policies_create_mode_check
+  TO write_approval_policies_create_mode_check;
+ALTER TABLE public.write_approval_policies
+  RENAME CONSTRAINT entity_approval_policies_update_mode_check
+  TO write_approval_policies_update_mode_check;
+ALTER TABLE public.write_approval_policies
+  RENAME CONSTRAINT entity_approval_policies_delete_mode_check
+  TO write_approval_policies_delete_mode_check;
+
+-- migrate:down
+
+ALTER TABLE public.write_approval_policies
+  RENAME CONSTRAINT write_approval_policies_delete_mode_check
+  TO entity_approval_policies_delete_mode_check;
+ALTER TABLE public.write_approval_policies
+  RENAME CONSTRAINT write_approval_policies_update_mode_check
+  TO entity_approval_policies_update_mode_check;
+ALTER TABLE public.write_approval_policies
+  RENAME CONSTRAINT write_approval_policies_create_mode_check
+  TO entity_approval_policies_create_mode_check;
+
+ALTER INDEX IF EXISTS public.write_approval_policies_class_principal_scope_key
+  RENAME TO entity_approval_policies_class_principal_scope_key;
+ALTER INDEX IF EXISTS public.write_approval_policies_class_principal
+  RENAME TO entity_approval_policies_class_principal;
+ALTER INDEX IF EXISTS public.write_approval_policies_org_lookup
+  RENAME TO entity_approval_policies_org_lookup;
+
+ALTER TABLE IF EXISTS public.write_approval_policies
+  RENAME TO entity_approval_policies;

--- a/db/migrations/20260709140000_dedupe_window_key.sql
+++ b/db/migrations/20260709140000_dedupe_window_key.sql
@@ -1,0 +1,34 @@
+-- migrate:up transaction:false
+
+-- (sol review #4) Include the run window in the entity-change dedupe identity.
+--
+-- The batch-approval contract groups a run's proposals by runs.window_id, and
+-- window_id rides the COLUMN (not action_input) so the md5(action_input) replay
+-- guard stays byte-stable. But that means two DIFFERENT windows that happen to
+-- produce a byte-identical proposal collided on the old index and the second
+-- window silently reused the first's pending run — its batch card then found
+-- nothing to approve. Adding COALESCE(window_id, 0) to the key keeps same-window
+-- replica-race dedupe (identical proposal, same window → one run) while making
+-- distinct windows distinct. NULL windows collapse to 0 so windowless proposals
+-- still dedupe among themselves exactly as before.
+--
+-- Split across two migrations (create here, drop-old next): a `transaction:false`
+-- migration is still sent as ONE simple-query batch, and Postgres wraps a
+-- multi-statement batch in an implicit transaction — which CONCURRENTLY forbids.
+-- So each CONCURRENTLY statement gets its own single-statement migration. The new
+-- index lands BEFORE the old is dropped, so the replica-race guard is never gone.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS runs_entity_change_pending_dedupe_v2
+  ON public.runs (
+    organization_id,
+    action_key,
+    COALESCE(window_id, 0),
+    md5(action_input::text)
+  )
+  WHERE run_type = 'internal'
+    AND action_key IN ('entity_field_change', 'entity_change')
+    AND approval_status = 'pending'
+    AND status = 'pending';
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.runs_entity_change_pending_dedupe_v2;

--- a/db/migrations/20260709140010_drop_old_dedupe_index.sql
+++ b/db/migrations/20260709140010_drop_old_dedupe_index.sql
@@ -1,0 +1,16 @@
+-- migrate:up transaction:false
+
+-- Second half of the dedupe-key swap (see 20260709140000): now that the
+-- window-aware v2 index exists, drop the old window-blind one. Separate migration
+-- because two CONCURRENTLY statements can't share a `transaction:false` file (the
+-- batch runs in an implicit transaction Postgres forbids CONCURRENTLY inside).
+DROP INDEX CONCURRENTLY IF EXISTS public.runs_entity_change_pending_dedupe;
+
+-- migrate:down transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS runs_entity_change_pending_dedupe
+  ON public.runs (organization_id, action_key, md5(action_input::text))
+  WHERE run_type = 'internal'
+    AND action_key IN ('entity_field_change', 'entity_change')
+    AND approval_status = 'pending'
+    AND status = 'pending';

--- a/db/migrations/20260709150000_runs_policy_principal.sql
+++ b/db/migrations/20260709150000_runs_policy_principal.sql
@@ -13,13 +13,18 @@ ALTER TABLE public.runs
   ADD COLUMN IF NOT EXISTS policy_principal_kind text,
   ADD COLUMN IF NOT EXISTS policy_principal_id text;
 
+-- `runs` is a hot, high-row-count table: validate the CHECK in a second pass so the
+-- ADD takes no table scan / write lock (the columns were just added, so every
+-- existing row is NULL and passes — the VALIDATE is a formality that stays online).
 ALTER TABLE public.runs
   DROP CONSTRAINT IF EXISTS runs_policy_principal_kind_check;
 ALTER TABLE public.runs
   ADD CONSTRAINT runs_policy_principal_kind_check CHECK (
     policy_principal_kind IS NULL
     OR policy_principal_kind IN ('agent', 'watcher', 'user')
-  );
+  ) NOT VALID;
+ALTER TABLE public.runs
+  VALIDATE CONSTRAINT runs_policy_principal_kind_check;
 
 -- (sol review #7) `disabled` is only meaningful for the connector_action class
 -- (an action turned off entirely). The widened mode CHECK from the expand
@@ -36,7 +41,9 @@ ALTER TABLE public.write_approval_policies
       AND update_mode <> 'disabled'
       AND delete_mode <> 'disabled'
     )
-  );
+  ) NOT VALID;
+ALTER TABLE public.write_approval_policies
+  VALIDATE CONSTRAINT write_approval_policies_disabled_only_connector;
 
 -- migrate:down
 

--- a/db/migrations/20260709150000_runs_policy_principal.sql
+++ b/db/migrations/20260709150000_runs_policy_principal.sql
@@ -1,0 +1,50 @@
+-- migrate:up
+
+-- (sol review #5) Persist the trusted principal that queued a connector-action
+-- run, so its write-gate policy can be RE-EVALUATED at approve time against the
+-- principal that requested it — not the human who approves. Without this, a
+-- deny/disabled installed AFTER queueing but BEFORE approval would not stop the
+-- execution, and a principal-specific policy could not be re-checked at all.
+--
+-- Nullable + additive: existing rows (and every human-initiated run) carry NULL,
+-- meaning "no per-principal policy applies", which is the correct default. Only
+-- agent/watcher-queued runs populate these, so backfill is unnecessary.
+ALTER TABLE public.runs
+  ADD COLUMN IF NOT EXISTS policy_principal_kind text,
+  ADD COLUMN IF NOT EXISTS policy_principal_id text;
+
+ALTER TABLE public.runs
+  DROP CONSTRAINT IF EXISTS runs_policy_principal_kind_check;
+ALTER TABLE public.runs
+  ADD CONSTRAINT runs_policy_principal_kind_check CHECK (
+    policy_principal_kind IS NULL
+    OR policy_principal_kind IN ('agent', 'watcher', 'user')
+  );
+
+-- (sol review #7) `disabled` is only meaningful for the connector_action class
+-- (an action turned off entirely). The widened mode CHECK from the expand
+-- migration accepts it for every class; constrain it so a manual SQL write can't
+-- leave an entity/agent_config row in a `disabled` state the resolver would then
+-- have to fail closed on. deny/approval/auto stay legal for all classes.
+ALTER TABLE public.write_approval_policies
+  DROP CONSTRAINT IF EXISTS write_approval_policies_disabled_only_connector;
+ALTER TABLE public.write_approval_policies
+  ADD CONSTRAINT write_approval_policies_disabled_only_connector CHECK (
+    resource_class = 'connector_action'
+    OR (
+      create_mode <> 'disabled'
+      AND update_mode <> 'disabled'
+      AND delete_mode <> 'disabled'
+    )
+  );
+
+-- migrate:down
+
+ALTER TABLE public.write_approval_policies
+  DROP CONSTRAINT IF EXISTS write_approval_policies_disabled_only_connector;
+
+ALTER TABLE public.runs
+  DROP CONSTRAINT IF EXISTS runs_policy_principal_kind_check;
+ALTER TABLE public.runs
+  DROP COLUMN IF EXISTS policy_principal_id,
+  DROP COLUMN IF EXISTS policy_principal_kind;

--- a/docs/plans/write-gate-generalization.md
+++ b/docs/plans/write-gate-generalization.md
@@ -130,9 +130,21 @@ sort by `(scope_specificity desc, principal_specificity desc)`; ties → restric
 (`deny > approval > auto`). Hard invariants (cross-org, field-ownership) sit above
 policy, unconditionally.
 
-## 5. Implementation — three small PRs (v1)
+## 5. Implementation — ONE v1 PR, stacked commits (DECIDED)
+**v1 ships as a single PR** so it's usable end-to-end at merge (no backend-without-UI
+half-state) — INCLUDING batched approvals (§6b). Reviewability comes from clean stacked
+commits read in order, NOT from separate PRs:
+1. `migration + agentId plumbing` (no behavior change)
+2. `per-principal policy resolver + tests`
+3. `batched approvals (window_id grouping) + conversational revision`
+4. `UI: class tabs + principal picker + batch card`
+5. `manage_agents as a governed class + human-admin-immediate behavior`
 
-**PR 1 — DB + `agentId` plumbing (refactor, NO behavior change).**
+The sub-sections below detail each commit's content.
+
+### Commit-level content (was: three small PRs)
+
+**Commit 1 — DB + `agentId` plumbing (refactor, NO behavior change).**
 Migration 1: rename `entity_approval_policies` → `write_approval_policies`; add
 `resource_class`/`target_scope_*`/`principal_*`/`predicate jsonb NULL`; move to id-based
 CRUD + new unique index; backfill existing rows (`resource_class='entity'`, collapse any
@@ -140,20 +152,27 @@ field/row-scoped rows to their type row — enumerate first, they're rare per th
 defaults). Thread `agentId` through the gate request + 3 call sites. All behavior
 identical (defaults preserve today's decisions). Reviewable as pure refactor.
 
-**PR 2 — per-principal policy for entities (the new capability; backend + tests).**
+**Commit 2 — per-principal policy for entities (the new capability; backend + tests).**
 Resolver consumes `principal_kind`/`principal_id`; add the second specificity axis +
 restrictive-wins. Prove red→fix→green: watcher #N auto-allowed while other agents gated;
 tie-break; users never gated; field-ownership approval still fires (regression guard).
 
-**PR 3 — UI (frontend-only; the acknowledged gap).**
+**Commit 3 — batched approvals + conversational revision (§6b).**
+Group proposals by `window_id` into one parent `runs` row + child proposals; batch card
+data; approve-all / reject-all; the in-place child-proposal update operation for the
+conversational-revision loop; reject-with-reason re-dispatch. Backend + tests.
+
+**Commit 4 — UI (frontend).**
 `organization-settings-page.tsx`: resource-class tab strip (Entities + Agents) + a
 principal picker beside the type picker; generalize `useEntityApprovalPolicy` →
-`useWriteApprovalPolicy(resourceClass)`; widen the effect type. NO predicate builder, NO
-connector reflection page. Approvals inbox untouched.
+`useWriteApprovalPolicy(resourceClass)`; widen the effect type. Batch approval card
+(collapsible list reusing the existing before→after diff renderer,
+`event-card.tsx:524-542`). NO predicate builder, NO connector reflection page.
 
-Agents-as-a-governed-class (wiring `manage_agents` through the generalized gate + the
-`manage_agents` human-immediate behavior change + building its `isStale`) is a **fourth
-small PR** once PRs 1–3 land — kept separate because it carries the one behavior change.
+**Commit 5 — `manage_agents` as a governed class.**
+Wire `manage_agents` through the generalized gate; build its `isStale`; implement the
+human-admin-immediate behavior change (drop today's unconditional-approval for humans).
+Carries the one intentional behavior change — kept as its own commit for a clean review.
 
 ## 6. Roadmap after v1
 - **v1.1 — granular scopes**: predicate DSL (flat AND-only `{field, op, value}`, no

--- a/docs/plans/write-gate-generalization.md
+++ b/docs/plans/write-gate-generalization.md
@@ -1,0 +1,220 @@
+# Write-gate generalization — policy for every governed write
+
+> **Related:** the read-side ACL program → [`authz-acl-permission-program.md`](authz-acl-permission-program.md)
+> (who can *see* what). This doc is the **write** side (who/what may *change* what).
+> Connector authz backbone → [`connector-authz-model.md`](connector-authz-model.md).
+
+**Status: FINALIZED — decisions locked via interview; reviewed independently by
+Codex + Fable (12 correctness fixes folded in, cited inline). Extends the shipped
+entity-approval system (#1802); does NOT introduce a policy engine (Cedar was
+spiked and dropped, #1802 — the TS interceptor IS our policy-as-code).**
+
+Most of this system already exists. The shipped surface is ~1,640 LOC: the mutation
+gate, the interceptor chain, the entity approval flow (propose→approve→apply), the
+connector action-approval path, and `manage_agents`' own propose/apply path. What is
+missing is **generalization plumbing + one new scope axis (principal) + the UI**.
+This RFC scopes that as **three small, independently-reviewable PRs**, then a roadmap.
+
+## 0. The requirement
+Admins governing an org must be able to say, for any governed write — adding an
+entity, changing a schema, adding an entity type, creating an agent/watcher/schedule,
+installing a connector, running a connector action — whether it **commits**, **needs
+human approval**, or is **denied**; and to scope that decision by resource type and by
+**which principal** (a specific agent or watcher) is acting. Humans are governed by
+role (a code manifest), not by this policy surface.
+
+## 1. Locked decisions
+1. **Effects**: `auto | approval | deny` for all classes; `disabled` additionally for
+   connector-action execution only.
+2. **Roles stay CODE** — a `WRITE_ACTION_MANIFEST` (`tool.action → {resourceClass,
+   role floor}`) that `tool-access.ts` consumes; a coverage test asserts every write
+   action is classified. NO `role_permissions` table until custom roles are requested.
+   The role floor is a **safety floor**: if role says deny, policy cannot override.
+3. **Users are never gated by policy** — the `principalKind==="user" → allow`
+   invariant (`entity-policy.ts:243,270`) stays. No user-principal policy rows.
+4. **Agents & watchers ARE principals** — policy may target `principal_kind`
+   (agent|watcher) + optional `principal_id`. NULL = any. This is the newly-requested
+   capability: "watcher #6 may auto-create person entities; every other agent needs
+   approval."
+5. **Per-principal policy is an effect SELECTOR, not a grant.** Enforcement order:
+   `hard invariants > org/resource ownership > role/MCP/capability floor > write-policy
+   winner > approval/apply staleness`. "Agent X may install connectors" means "IF X
+   legitimately reaches the write path, this effect applies" — never a bypass of the
+   capability floor. (Codex + Fable.)
+6. **One policy table**, typed scope kinds per resource class (a code map declares
+   which kinds are legal per class; the DB never assumes every class supports every
+   scope). Narrowest match wins.
+7. **Two enforcement moments, one policy authority (the hooks).** Durable
+   propose→approve for config/data writes; synchronous decision for connector-action
+   execution (a live run pauses — nothing to re-apply later). Both read one table.
+8. **Command adapter for apply-on-approve**, per class: `WriteCommandAdapter{ prepare,
+   apply, isStale, describe }`. Approve calls `adapter.apply(prepared)` — NEVER a raw
+   re-dispatch. (Codex.)
+9. **Tie-break = restrictive-wins** (`deny > approval > auto`), not oldest-row. (Fable.)
+10. **v1 scopes = entity_type + principal ONLY.** Row (`entity_id`) and field
+    (`field_path`) scopes DEFER to v1.1 — they are redundant with the predicate feature
+    that lands then, and each carries cost v1 need not pay (entity_id = FK cascade;
+    field_path = per-field decision folding). **Field OWNERSHIP is unaffected** — the
+    `field_controls` human-ownership guardrail (`entity-policy.ts:278`) is a hard
+    invariant above policy, not a field-scoped policy row; it survives v1 untouched.
+
+## 2. What already exists (verified)
+- `authz/entity-mutation-gate.ts` (230 LOC): pluggable interceptor pipeline;
+  `runMutationGate()` folds decisions (deny wins; first defer short-circuits; per-field
+  approval sets union for updates). `registerMutationInterceptor()` seam (no external
+  callers yet).
+- `authz/approval-interceptor.ts` (224) + `authz/entity-policy.ts` (446): the ONE
+  registered interceptor, over `entity_approval_policies`; scope specificity
+  `entity_id(4) > field_path(2) > entity_type(1)`.
+- `tools/admin/entity-field-approval.ts` (673): durable propose→approve→apply for
+  entities, with per-field staleness (`:575-617`).
+- `tools/admin/manage_agents.ts`: SECOND propose/apply path already built
+  (`buildProposal` → `runs.action_input` → `applyManageAgents*`) — but **no `isStale`**
+  (`applyUpdate` blindly overwrites, `:184-192`).
+- `operations/action-modes.ts` (69): connector action policy — `resolveActionMode`
+  over `connection.config.action_modes` → disabled|approval|auto. Approval ENFORCEMENT
+  already shared: `manage_operations.ts:681` creates a `runs` row
+  (`approvalMode:"queued"`) + `:732` an `interaction_type:'approval'` event — same
+  primitive as entities.
+- UI: `organization-settings-page.tsx` "Agent change approvals" (entity-only, real API
+  `/api/:org/entity-approval-policy`). Approve/reject inbox = generic Events-tab card,
+  already works for any `runs` row.
+
+Conclusion: the mechanism is done. Missing = generalization columns, `agentId`
+threading (3 call sites), the principal axis, and the UI.
+
+## 3. Correctness fixes from review (folded in)
+- `agentId` is NOT on `EntityMutationRequest` today (only on an internal
+  classification helper, `entity-policy.ts:139`). Per-principal needs it threaded
+  through the request + `manage_entity` / `promote-keyed-entities` /
+  `entity-management` call sites. (Codex + Fable.)
+- The COALESCE natural-key unique index + upsert-with-race-retry
+  (`entity-policy.ts:357-421`, migration `:24-30`) cannot extend to new columns
+  cleanly → **Migration 1 moves to id-based CRUD** + a new unique index. (Fable.)
+- Generic `scope_value text` loses the `entity_id` FK cascade → keep a typed side
+  column for FK-able scope kinds, or add explicit cleanup. (Fable.) *(Moot in v1 since
+  entity_id scope is deferred, but relevant when it returns.)*
+- Delivery-target inheritance assumes exactly one global row
+  (`entity-policy.ts:196-209`) → define the inheritance chain per class or scoped
+  approvals silently fall back to generic admin fan-out. (Fable.)
+- `manage_agents` currently queues approval **unconditionally for everyone incl. human
+  admins** (`:497-507`). **RESOLVED: human admin agent edits apply immediately** (drop
+  the human-gating); agent/watcher-authored changes follow policy. Note as an
+  intentional behavior change in the PR. (Fable-flagged.)
+- Adapter extraction is real work: the agent adapter's `isStale` must be BUILT.
+- Code-API naming: separate `target_scope_*` from `principal_*` even if physical
+  columns are generic — don't call both "scope". (Codex.)
+
+## 4. Schema (write_approval_policies)
+```
+id, organization_id,
+resource_class     text NOT NULL,   -- entity | entity_type | agent | watcher | schedule
+                                    --   | feed | classifier | connector | connector_action
+target_scope_kind  text NOT NULL,   -- v1: global | entity_type  (per-class equivalents)
+                                    --   v1.1+: field_path | entity_id | entity_predicate
+                                    --   later: connection_id | connector_slug | connection_op
+target_scope_value text NULL,
+predicate          jsonb NULL,       -- RESERVED in v1 (unused); populated in v1.1
+principal_kind     text NULL,        -- agent | watcher ; NULL = any
+principal_id       text NULL,        -- specific agent/watcher id ; NULL = any of kind
+create_mode/update_mode/delete_mode text
+   CHECK (... IN ('auto','approval','deny'))          -- 'disabled' only for connector_action
+approval_connection_id/channel_id/team_id/channel_name,
+created_at, updated_at
+UNIQUE (organization_id, resource_class, target_scope_kind,
+        COALESCE(target_scope_value,''), COALESCE(principal_kind,''),
+        COALESCE(principal_id,''))
+```
+Resolution: load candidate rows for `(org, resource_class)` matching scope + principal;
+sort by `(scope_specificity desc, principal_specificity desc)`; ties → restrictive-wins
+(`deny > approval > auto`). Hard invariants (cross-org, field-ownership) sit above
+policy, unconditionally.
+
+## 5. Implementation — three small PRs (v1)
+
+**PR 1 — DB + `agentId` plumbing (refactor, NO behavior change).**
+Migration 1: rename `entity_approval_policies` → `write_approval_policies`; add
+`resource_class`/`target_scope_*`/`principal_*`/`predicate jsonb NULL`; move to id-based
+CRUD + new unique index; backfill existing rows (`resource_class='entity'`, collapse any
+field/row-scoped rows to their type row — enumerate first, they're rare per the shipped
+defaults). Thread `agentId` through the gate request + 3 call sites. All behavior
+identical (defaults preserve today's decisions). Reviewable as pure refactor.
+
+**PR 2 — per-principal policy for entities (the new capability; backend + tests).**
+Resolver consumes `principal_kind`/`principal_id`; add the second specificity axis +
+restrictive-wins. Prove red→fix→green: watcher #N auto-allowed while other agents gated;
+tie-break; users never gated; field-ownership approval still fires (regression guard).
+
+**PR 3 — UI (frontend-only; the acknowledged gap).**
+`organization-settings-page.tsx`: resource-class tab strip (Entities + Agents) + a
+principal picker beside the type picker; generalize `useEntityApprovalPolicy` →
+`useWriteApprovalPolicy(resourceClass)`; widen the effect type. NO predicate builder, NO
+connector reflection page. Approvals inbox untouched.
+
+Agents-as-a-governed-class (wiring `manage_agents` through the generalized gate + the
+`manage_agents` human-immediate behavior change + building its `isStale`) is a **fourth
+small PR** once PRs 1–3 land — kept separate because it carries the one behavior change.
+
+## 6. Roadmap after v1
+- **v1.1 — granular scopes**: predicate DSL (flat AND-only `{field, op, value}`, no
+  OR/nesting; eval = **pre-image ∨ post-image** — Fable: merged-only is bypassable;
+  create=proposal, delete=current; `$`-path field addressing) + evaluator + contract +
+  builder UI. Thread current/patch values into the gate. Row scope = `{$id eq N}`; field
+  scope via field-path predicates (or reinstate `field_path` scope if per-field union is
+  cleaner). **Note: the entity-filter DSL does NOT exist today (Fable, verified) — this
+  is net-new, which is why it's deferred.**
+- **v1.2 — more classes**: watcher · schedule · feed · classifier.
+- **LAST — connectors + connector-action consolidation**: add the `connector_action`
+  class; `resolveActionMode` stops reading `connection.config.action_modes`, asks the
+  same policy resolver (the hooks become the single decision authority); migrate the
+  blob → scoped rows (migration 2). Ships last because it's a sync→async refactor on the
+  hot tool-list-filtering path (`connector-operations.ts:577`) + credential-replay
+  staleness. **Architecture unified day one** (the class is first-class in the table);
+  only the refactor is deferred.
+- **Enterprise (Snowflake-informed)**: privileges-to-roles-not-users (already our
+  model); design the manifest **hierarchy-ready** (a role can include another) for
+  custom roles; extend `field_controls` ownership to **object ownership** on the
+  principal axis; name our type-scope as **future-grants** ("policy applies to objects
+  that don't exist yet"). **ADD auditability** — a queryable *effective-policy* view +
+  *gate-decision log* (the gap an enterprise security eval will probe; we're 80% there
+  via append-only `events` + `runs`). Do NOT build Snowflake's full role graph /
+  secondary roles / MANAGE GRANTS for v1.
+
+## 6b. Batched approvals + conversational revision (operational follow-on)
+**Problem:** today it's one `runs` row + one Slack card per proposal (dedupe is
+per-*entity*, `entity-field-approval.ts:303`, not batch grouping). A watcher window
+creating 100 entities ⇒ 100 cards. Unusable at watcher scale.
+
+**Grouping key already exists:** `window_id` is threaded through
+(`manage_operations.ts:695`) — every proposal from one watcher run is tagged with it.
+
+**Design (DECIDED):**
+- Group all proposals from one `window_id` into **ONE batch approval** — a parent
+  `runs` row with child proposals — rendered as a single card: summary
+  ("87 creates · 11 updates · 2 deletes") + **read-only expandable diff**.
+- Coarse controls: **Approve all** (applies the batch) / **Reject all** (one reason).
+- **Subset changes are CONVERSATIONAL, not a diff-editing UI (DECIDED).** The reviewer
+  asks the agent — "the 3 SaaS ones have wrong company names, fix them" — and the agent
+  revises those child proposals **in place** (reject-reason as context), then the batch
+  card updates and the reviewer approves. The card stays read-only; ALL mutation flows
+  through the agent. The human does judgment, never data entry. This CUTS the per-item
+  inline-editor UI entirely.
+- **Revision loop = reject-with-reason re-dispatches the agent (DECIDED).** Rejecting a
+  batch or an item with a reason re-runs the watcher/agent with that reason as context;
+  it produces a revised batch that returns for approval. **This closes the feedback-loop
+  gap** identified in the original investigation (reject reason is captured on
+  `runs.error_message` today but dead-ends).
+- **One new operation** (the only non-trivial wiring): let the agent *target a pending
+  batch's child proposal and update it in place* — mutate the pending `runs.action_input`
+  proposal, not the live entity. Small; reuses the existing proposal storage.
+
+**Sequencing:** NOT v1. Highest-value operational follow-on — build right after the core
+lands, BEFORE pushing watchers-at-scale on customers (100 cards makes the feature
+unusable for exactly watchers' main use case).
+
+## 7. Non-goals
+- No policy engine / DSL runtime (Cedar dropped, #1802).
+- No `role_permissions` config table (roles stay code until custom roles are demanded).
+- No user-principal policy rows (users stay manifest-governed).
+- No raw-SQL predicates from admins (structured conditions only, v1.1).
+- No inline diff-editor in the approval card — subset changes are conversational (§6b).

--- a/docs/plans/write-gate-generalization.md
+++ b/docs/plans/write-gate-generalization.md
@@ -365,3 +365,35 @@ approval read from — one source, two views (mirrors "one writer many mirrors")
 - No user-principal policy rows (users stay manifest-governed).
 - No raw-SQL predicates from admins (structured conditions only, v1.1).
 - No inline diff-editor in the approval card — subset changes are conversational (§6b).
+
+## 8. Codex sol review (post-implementation) — fixed + deferred
+
+A `gpt-5.6-sol` review of the full branch found 10 findings. Resolved on-branch:
+- **#1 precedence inversion (high, FIXED):** `specificity()` made principal weight
+  (16/8) outrank target scope (≤7), inverting the RFC's target-first order. Replaced
+  with a tuple comparator: scope-specificity → principal-specificity → restrictive-wins
+  (`deny>disabled>approval>auto`) → id. Inverse regression added.
+- **#2 watcher_source principal spoof (high, FIXED):** caller-supplied `watcher_source`
+  could reclassify an agent as `watcher:<id>` to dodge its agent policy.
+  `classifyMutationPrincipal`/`mutationPrincipalId` now prefer trusted `ctx.agentId`.
+- **Display bug (FIXED in owletto):** `deny`/`disabled` rendered as "Auto"; now
+  "Denied"/"Disabled".
+
+Deferred (tracked follow-ups, NOT in v1):
+- **#3** approve/reject should require `ctx.userId != null`, not just `!clientId`.
+- **#5** re-evaluate connector_action `deny`/`disabled` at execute time, not only queue.
+- **#7** `normalizeMode` unknown → `deny` (fail-closed), not `auto`.
+- **#8** legacy `manage_agents` pending runs without `proposal.base` must fail closed.
+- **#9** thread `window_id` through `manage_entity` watcher writes (not only promotion).
+- **#4** add `window_id` to the entity-change dedup key (cross-window collapse).
+- **#6** bare rename outage — ACCEPTED tradeoff (user chose clean-cut).
+
+**Part B — architecture (sol + prior reviews agree):** code-defined resolver over one
+Postgres policy authority is right (beats Cedar/OPA, OpenFGA/SpiceDB, per-class tables).
+sol's material suggestion for v1.1: make the table **action-oriented** — replace the
+three entity-shaped `create_mode/update_mode/delete_mode` columns with `(action, effect)`
+rows (action ∈ create/update/delete/execute/install; effect ∈ auto/approval/deny/disabled),
+so verbs like `execute`/`install` aren't crammed into create/update/delete semantics. A
+code registry declares legal actions/effects/targets/predicate-fields per resource class.
+Closer to the Snowflake privilege model. Adopt when connector_action's own UI + the
+v1.1 predicate engine land.

--- a/docs/plans/write-gate-generalization.md
+++ b/docs/plans/write-gate-generalization.md
@@ -105,7 +105,7 @@ threading (3 call sites), the principal axis, and the UI.
 - Code-API naming: separate `target_scope_*` from `principal_*` even if physical
   columns are generic — don't call both "scope". (Codex.)
 
-## 4. Schema (write_approval_policies)
+## 4. Schema (columns added to entity_approval_policies; renamed to write_approval_policies in the LATER contract PR — see §6e.1)
 ```
 id, organization_id,
 resource_class     text NOT NULL,   -- entity | entity_type | agent | watcher | schedule
@@ -134,23 +134,30 @@ policy, unconditionally.
 **v1 ships as a single PR** so it's usable end-to-end at merge (no backend-without-UI
 half-state) — INCLUDING batched approvals (§6b). Reviewability comes from clean stacked
 commits read in order, NOT from separate PRs:
-1. `migration + agentId plumbing` (no behavior change)
-2. `per-principal policy resolver + tests`
-3. `batched approvals (window_id grouping) + conversational revision`
-4. `UI: class tabs + principal picker + batch card`
-5. `manage_agents as a governed class + human-admin-immediate behavior`
+1. `M1a expand (additive columns, deploy-safe) + principal identity plumbing` — agent AND
+   watcher ids threaded; NO rename, NO column drop (§6e.1). No behavior change.
+2. `M1b cutover + per-principal resolver + additive API + tests` — new code reads new
+   columns; backfill verbatim-move; scope-keyed API gains resource_class/principal_* additively
+   (§6e.2); resolver understands deny before CHECK admits it (§6f R5).
+3. `manage_agents as a governed class` (backend: gate wiring + isStale + human-immediate) —
+   BEFORE the UI so the Agents tab has real backend (fixes Codex gap #2).
+4. `run change-set first-class (windowId on runs.window_id column) + batched approvals +
+   conversational revision (revision rewrites run+event+card)` (§6b/§6c/§6e.3/§6f).
+5. `UI: class tabs (Entities+Agents) + principal picker + run-diff view + batch card`.
+- **Follow-up PR (post-rollout): M1c contract** — rename table → write_approval_policies,
+  drop old scope columns (§6e.1). NOT in the v1 PR.
 
 The sub-sections below detail each commit's content.
 
 ### Commit-level content (was: three small PRs)
 
-**Commit 1 — DB + `agentId` plumbing (refactor, NO behavior change).**
-Migration 1: rename `entity_approval_policies` → `write_approval_policies`; add
-`resource_class`/`target_scope_*`/`principal_*`/`predicate jsonb NULL`; move to id-based
-CRUD + new unique index; backfill existing rows (`resource_class='entity'`, collapse any
-field/row-scoped rows to their type row — enumerate first, they're rare per the shipped
-defaults). Thread `agentId` through the gate request + 3 call sites. All behavior
-identical (defaults preserve today's decisions). Reviewable as pure refactor.
+**Commit 1 — M1a expand + principal plumbing (refactor, NO behavior change).**
+M1a (deploy-safe, additive): ADD `resource_class DEFAULT 'entity'`, `target_scope_*`,
+`principal_*`, `predicate jsonb NULL` columns to the EXISTING `entity_approval_policies`
+table; widen mode CHECK. **No rename, no column drop** — old pods keep working (§6e.1).
+Thread principal identity (agent → agentId, watcher → watcherId, system → NULL; §6d.1)
+through the gate request + the 3 call sites (`manage_entity`, `promote-keyed-entities`,
+`entity-management`). Behavior identical (defaults preserve today's decisions).
 
 **Commit 2 — per-principal policy for entities (the new capability; backend + tests).**
 Resolver consumes `principal_kind`/`principal_id`; add the second specificity axis +
@@ -204,8 +211,12 @@ Carries the one intentional behavior change — kept as its own commit for a cle
 per-*entity*, `entity-field-approval.ts:303`, not batch grouping). A watcher window
 creating 100 entities ⇒ 100 cards. Unusable at watcher scale.
 
-**Grouping key already exists:** `window_id` is threaded through
-(`manage_operations.ts:695`) — every proposal from one watcher run is tagged with it.
+**Grouping key must be ADDED (correction, §6e.3):** entity-change proposal runs carry NO
+window_id today (`manage_operations.ts:695` is a different path — connector-action reactions).
+The `runs.window_id`/`runs.watcher_id` COLUMNS exist (baseline.sql:1868-1890) but proposals
+don't set them. Thread windowId through the gate → deferral builders → propose INSERT, into
+the `runs.window_id` COLUMN (not `action_input` — preserves the md5 dedupe identity). Group on
+that column.
 
 **Design (DECIDED):**
 - Group all proposals from one `window_id` into **ONE batch approval** — a parent
@@ -230,6 +241,123 @@ creating 100 entities ⇒ 100 cards. Unusable at watcher scale.
 **Sequencing:** NOT v1. Highest-value operational follow-on — build right after the core
 lands, BEFORE pushing watchers-at-scale on customers (100 cards makes the feature
 unusable for exactly watchers' main use case).
+
+## 6e. Blocking gaps from Fable review (deploy-safety — MUST close)
+1. **Migration is NOT deploy-window safe — needs two-phase (CRITICAL).** Migrations run in
+   a Helm **pre-upgrade hook BEFORE new pods roll out** (`docker/app/start.sh:48-53`; a past
+   incident is documented there). A bare `RENAME` → old pods hit the new schema → every
+   agent/watcher entity write throws (`loadCandidatePolicies` errors; only
+   `principalKind==="user"` short-circuits before the query) + settings API 500s for the
+   whole rollout. **DECIDED: additive-expand / cutover / contract, three migrations:**
+   - **M1a (expand, deploy-safe):** CREATE the NEW columns on the EXISTING
+     `entity_approval_policies` table (`resource_class DEFAULT 'entity'`, `target_scope_*`,
+     `principal_*`, `predicate jsonb NULL`); widen mode CHECK per §6d.2. NO rename, NO column
+     drop. Old pods keep working (they ignore new columns; INSERTs get the DEFAULT).
+   - **M1b (cutover, same PR, later commit):** new code reads/writes the new columns;
+     backfill `target_scope_*` from the old `entity_type_slug/field_path/entity_id`
+     (verbatim-move per §6d.3, not lossy). Table KEEPS its name this cycle — do NOT rename
+     while old pods may exist.
+   - **M1c (contract, FOLLOW-UP PR after full rollout):** rename table →
+     `write_approval_policies` (+ compat updatable VIEW `entity_approval_policies` if any
+     external SQL references it), drop the old `entity_type_slug/field_path/entity_id`
+     columns. Two-phase column drop per the repo's squawk discipline.
+   → Net: **the physical table stays `entity_approval_policies` through v1**; the "rename"
+     is a post-rollout contract step. All code uses the new columns from M1b.
+2. **The HTTP API generalization is BACKEND work — assign it, don't leave it homeless.**
+   Shipped contract is natural-key upsert/delete (`index.ts:1370,1531`) consumed by the live
+   UI (`entities.ts:158-219`). DECIDED: keep the **scope-keyed** endpoints (translate to
+   id-based rows server-side, preserving the upsert-race retry), and make them ADDITIVE —
+   accept/return `resource_class`/`principal_*`, default `resource_class='entity'` when
+   omitted so the shipped UI keeps working unchanged. This backend change lands in the
+   per-principal commit (Commit 2), NOT the UI commit. Kills the "id-based CRUD breaks the
+   shipped UI" contradiction — we do NOT move to id-based endpoints, only id-based storage.
+3. **§6b window_id claim was WRONG — corrected.** `manage_operations.ts:695` is
+   `trackWatcherReaction` for connector-action runs (writes `watcher_reactions.window_id`), a
+   DIFFERENT path. Entity-change proposal runs carry NO window_id: the deferral builders
+   don't accept it (`entity-mutation-gate.ts:165-183`), `promote-keyed-entities.ts` has
+   `windowId` in scope but doesn't pass it, and `proposeEntityChange` sets neither
+   `runs.window_id` nor `runs.watcher_id` columns (which EXIST, baseline.sql:1868-1890 —
+   watcher_id currently lives only in `action_input`). **DECIDED: thread windowId through the
+   gate request → deferral builders → propose INSERT, writing the `runs.window_id` COLUMN
+   (NOT into action_input — that would change the `md5(action_input)` dedupe identity across
+   window retries). Grouping reads the column.** This is §6c/Commit 4 scope.
+
+## 6f. Residual risks (Fable — note in PR, not blocking)
+- **R1 (§6b revision must rewrite the CARD, not just the run).** The pending event's
+  `interaction_input`/`metadata` and the Slack card are propose-time snapshots
+  (`entity-field-approval.ts:386-447`); approve applies from `runs.action_input`. Revising
+  `action_input` alone ⇒ card shows OLD, approve applies NEW. The in-place revision op MUST
+  also rewrite the pending event + refresh/replace the Slack message. (Undersold as "small".)
+- **R2 (revise-vs-approve-all race).** The revision UPDATE must guard
+  `approval_status='pending'` so it blocks on the claim row-lock and no-ops after a claim
+  (mirrors `claimEntityChangeRun`, `manage_operations.ts:1212-1234`).
+- **R3 (batch card is net-new UI).** `FieldChangeDiff` (`event-card.tsx:522-589`) is reusable
+  PER ITEM, but the parent-batch card, a new batch action_key + its dedupe story, and the
+  per-child staleness loop on approve-all are new. Budget it.
+- **R4 (backfill collision rule).** A collapsed/moved scoped row can collide with an existing
+  type row under the new unique index — but §6d.3 verbatim-MOVE (to `field_path`/`entity_id`
+  scope kinds, reserved now) avoids collapse entirely, so no collision. Confirm no two rows
+  share the exact new unique key; if they do, restrictive-wins.
+- **R5 (deny fail-open).** `normalizeMode` coerces unknown modes to fallback
+  (`entity-policy.ts:83-88`) → a `deny` row reads as auto until the resolver understands it.
+  **Land deny-handling in the resolver (Commit 2) BEFORE widening the CHECK to allow deny, OR
+  widen CHECK in the same commit as the resolver change.** Don't let M1a admit `deny` while
+  the resolver still normalizes it.
+
+## 6c. Watcher-run change-set is FIRST-CLASS — diff ≠ approval (DECIDED)
+**Correction to §6b framing.** The diff of "what a watcher run changed" is a property of
+the RUN, not of the approval flow. A run that AUTO-applies 100 changes must be just as
+inspectable as one that needed approval. Do NOT encapsulate the change-set inside
+`entity-field-approval.ts`.
+
+**Two layers:**
+1. **Run change-set (always visible, any policy outcome).** Every watcher/agent run
+   records its create/update/delete change-set, grouped by `watcher_run_id`/`window_id`,
+   viewable as a diff on the RUN itself — whether auto-applied, approval-gated, or denied.
+   This is observability ("what did watcher #6 do at 3pm?"), independent of gating.
+2. **Approval is an OVERLAY.** When policy = approval, the same change-set gets
+   approve/reject + reviewer routing. When policy = auto, the change-set still exists and
+   is still viewable; it just applied without a gate.
+
+**Already partially exists** (grounds this, not net-new): `watcher_run_id` threaded through
+`complete_window` (`manage_watchers/complete-window.ts:72,148`);
+`promoted-entities-recap.tsx` + `watcher-summary-view.tsx` in owletto render a run recap.
+The work is to make the change-set the FIRST-CLASS primitive both the recap AND the batch
+approval read from — one source, two views (mirrors "one writer many mirrors").
+
+**This also fixes Codex gap #6**: the batch grouping contract lives on the RUN change-set
+(`watcher_run_id`), not invented inside the approval flow.
+
+## 6d. Blocking gaps from final review (Codex — MUST close before coding)
+1. **Principal identity mapping — SPECIFY exactly.** Not just `agentId`. Define
+   principal resolution for every context: agent run → `(agent, agentId)`; watcher run →
+   `(watcher, watcherId)`; system/automation token (no agent id) → `(agent, NULL)`; user →
+   never a policy principal. Today `watcherId` is *attribution*, not policy identity —
+   promote it. This is Commit 1 scope, not deferrable.
+2. **Effect model is resource-class-aware, not one flat CHECK.** `disabled` applies ONLY
+   to connector_action; `deny` for entities means the entity code must handle a deny
+   outcome (today it only knows auto/approval). Define per-class legal effects in CODE
+   (a map) + a lightweight DB CHECK; the three mode columns are reused positionally per
+   class via the manifest. Connector-action execution mode uses the create_mode column
+   (single-verb class) — document it.
+3. **Migration collapse needs a deterministic rule, not "collapse."** When folding a
+   field/row-scoped row into its type row, modes may conflict → **restrictive-wins**
+   (deny>approval>auto) per verb; delivery target → keep the more-specific row's target,
+   else inherit global. PREFLIGHT: if a collapse would change an effective decision, LOG
+   each collapsed row (no silent mode changes). Better: since scoped rows are rare, MOVE
+   them to `target_scope_kind='field_path'/'entity_id'` verbatim (they're valid v1.1
+   shapes reserved now) instead of collapsing — zero decision change. **Adopt the
+   verbatim-move; no lossy collapse.**
+4. **Effect resolution vs notification routing are SEPARATE concerns.** Specify (a) which
+   row wins the effect, and (b) independently, the delivery-target inheritance chain:
+   winning row's target → nearest ancestor scope's target → class global → org global →
+   generic admin fan-out. A principal-specific row with no target inherits down this chain.
+5. **§6b parent/child + revision concurrency (SPECIFY):** parent run + child-proposal
+   rows; child cards suppressed (only the parent card posts); in-place child edit uses
+   **optimistic version** on the child row; after any revision, **re-run policy + staleness
+   on the changed child** before it's approvable; **approve-all = per-child partial apply**
+   (not atomic — a stale child fails individually and re-opens, the rest apply), matching
+   today's single-proposal apply-failure-reopens semantics (`manage_operations.ts:1419`).
 
 ## 7. Non-goals
 - No policy engine / DSL runtime (Cedar dropped, #1802).

--- a/packages/core/src/contracts/tools/manage-agents.ts
+++ b/packages/core/src/contracts/tools/manage-agents.ts
@@ -68,7 +68,13 @@ export type ManageAgentsResult =
   | { action: "list"; agents: AgentRecord[] }
   | { action: "get"; agent: AgentRecord }
   | { action: "create"; agent_id: string; created: boolean }
-  | { action: "update"; agent_id: string; updated_fields: string[] }
+  | {
+      action: "update";
+      agent_id: string;
+      updated_fields: string[];
+      /** Fields a stale approval skipped because another writer changed them first. */
+      skipped_fields?: string[];
+    }
   | { action: "delete"; agent_id: string; deleted: boolean }
   | { action: "set_system_agent"; system_agent_id: string }
   | {
@@ -90,4 +96,15 @@ export interface ManageAgentsProposal {
   name?: string;
   description?: string;
   identity_md?: string;
+  /**
+   * Pre-image of the fields this update proposes to change, captured when the
+   * update was queued. On approve, applyUpdate only overwrites a field whose
+   * live value still equals its pre-image — so a stale approval never clobbers a
+   * newer human edit to that field. Present only for queued `update` proposals.
+   */
+  base?: {
+    name?: string | null;
+    description?: string | null;
+    identity_md?: string | null;
+  };
 }

--- a/packages/core/src/contracts/tools/manage-operations.ts
+++ b/packages/core/src/contracts/tools/manage-operations.ts
@@ -139,6 +139,23 @@ export const RejectAction = Type.Object({
   reason: Type.Optional(Type.String()),
 });
 
+export const ApproveBatchAction = Type.Object({
+  action: Type.Literal("approve_batch", {
+    description:
+      "Approve every pending proposal a watcher run produced, in one go. Groups by the run's window.",
+  }),
+  window_id: Type.Number(),
+});
+
+export const RejectBatchAction = Type.Object({
+  action: Type.Literal("reject_batch", {
+    description:
+      "Reject every pending proposal a watcher run produced. The reason is fed back to the agent so it can revise its proposals (the conversational revision loop).",
+  }),
+  window_id: Type.Number(),
+  reason: Type.Optional(Type.String()),
+});
+
 /**
  * Result of `manage_operations` — discriminated union (on `action`/`status`,
  * plus an error variant). TypeBox-first: `Static<>` derives the TS type from
@@ -214,6 +231,21 @@ export const ManageOperationsResultSchema = Type.Union([
     run_id: Type.Integer(),
     event_id: Type.Optional(Type.Integer()),
   }),
+  Type.Object({
+    action: Type.Literal("approve_batch"),
+    window_id: Type.Integer(),
+    approved_count: Type.Integer(),
+    failed_count: Type.Integer(),
+    run_ids: Type.Array(Type.Integer()),
+    message: Type.String(),
+  }),
+  Type.Object({
+    action: Type.Literal("reject_batch"),
+    window_id: Type.Integer(),
+    rejected_count: Type.Integer(),
+    run_ids: Type.Array(Type.Integer()),
+    message: Type.String(),
+  }),
 ]);
 export type ManageOperationsResult = Static<
   typeof ManageOperationsResultSchema
@@ -226,6 +258,8 @@ export const ManageOperationsSchema = Type.Union([
   GetRunAction,
   ApproveAction,
   RejectAction,
+  ApproveBatchAction,
+  RejectBatchAction,
 ]);
 
 export type ManageOperationsArgs = Static<typeof ManageOperationsSchema>;

--- a/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
@@ -3,19 +3,23 @@
  * (`executeTool(name, args, env, authCtx)`), the same entry the REST proxy and
  * the builder agent's worker use.
  *
- * The builder gate (this feature) routes WRITE actions (create/update/delete)
- * through the durable runs/events approval primitive that manage_operations
- * uses: a write produces a pending `runs` row (approval_status='pending') + an
- * approval `events` card; the mutation only lands when a web session approves
- * via manage_operations.approve, and is cancelled on reject. Read actions
- * (list/get) and set_system_agent stay immediate.
+ * WRITE actions (create/update/delete) route through the `agent_config`
+ * write-gate class. The decision is per-principal:
+ *   - A HUMAN member applies immediately — no run, no approval card. Role
+ *     restrictions for humans live in the tool-access tier (admin-only).
+ *   - An AGENT-driven write follows the org policy (default: create/update queue
+ *     a pending `runs` row + approval card, applied on approve / cancelled on
+ *     reject; delete is denied). This is the durable runs/events primitive that
+ *     manage_operations uses.
  *
  * Covers:
- *   - create gate: pending run + pending approval event, NO agent yet.
+ *   - human owner: create/update/delete apply immediately.
+ *   - agent principal create gate: pending run + pending approval event, NO agent yet.
  *   - approve(run_id): agent now exists (owner_platform='external' + the
  *     agent_users ownership mapping), run completed, event superseded.
  *   - reject(run_id): no agent, run cancelled, event superseded 'rejected'.
- *   - update / delete gates apply on approve.
+ *   - agent update gate applies on approve; agent delete is denied outright.
+ *   - stale approval: applyUpdate skips a field a newer edit already changed.
  *   - set_system_agent / get / list (including the `is_system_agent` flag) stay
  *     immediate.
  *   - access: a non-admin member cannot call the admin-tier actions.
@@ -60,6 +64,7 @@ describe("manage_agents — builder gate e2e", () => {
 	let orgId: string;
 	let ownerId: string;
 	let ownerCtx: AuthContext;
+	let agentCtx: AuthContext;
 	let memberCtx: AuthContext;
 
 	const baseCtx = (
@@ -67,12 +72,13 @@ describe("manage_agents — builder gate e2e", () => {
 		userId: string,
 		memberRole: "owner" | "member",
 		scopes: string[],
+		agentId: string | null = null,
 	): AuthContext => ({
 		organizationId: orgIdValue,
 		tokenOrganizationId: orgIdValue,
 		userId,
 		memberRole,
-		agentId: null,
+		agentId,
 		requestedAgentId: null,
 		isAuthenticated: true,
 		clientId: null,
@@ -101,15 +107,77 @@ describe("manage_agents — builder gate e2e", () => {
 			"mcp:write",
 			"mcp:admin",
 		]);
+		// Same owner identity, but acting as an agent (agentId set) — this is the
+		// principal the write-gate holds for approval.
+		agentCtx = baseCtx(
+			org.id,
+			owner.id,
+			"owner",
+			["mcp:read", "mcp:write", "mcp:admin"],
+			"builder-agent",
+		);
 		memberCtx = baseCtx(org.id, member.id, "member", ["mcp:read", "mcp:write"]);
 	});
 
-	it("create produces a pending run + approval event and does NOT create the agent yet", async () => {
+	it("human owner: create applies immediately with no approval run", async () => {
+		const res = (await executeTool(
+			"manage_agents",
+			{ action: "create", agent_id: "human-bot", name: "Human Bot" },
+			TEST_ENV,
+			ownerCtx,
+		)) as { action: string; created?: boolean; status?: string };
+		expect(res.status).toBeUndefined();
+		expect(res.created).toBe(true);
+		expect(await agentExists(orgId, "human-bot")).toBe(true);
+
+		// No pending manage_agents run was created for this immediate apply.
+		const sql = getTestDb();
+		const runRows = await sql`
+			SELECT 1 FROM runs
+			WHERE organization_id = ${orgId} AND action_key = 'manage_agents'
+				AND (action_input->>'agent_id') = 'human-bot'
+		`;
+		expect(runRows.length).toBe(0);
+	});
+
+	it("human owner: update and delete apply immediately", async () => {
+		await executeTool(
+			"manage_agents",
+			{ action: "create", agent_id: "human-edit-bot", name: "v1" },
+			TEST_ENV,
+			ownerCtx,
+		);
+		const upd = (await executeTool(
+			"manage_agents",
+			{ action: "update", agent_id: "human-edit-bot", name: "v2" },
+			TEST_ENV,
+			ownerCtx,
+		)) as { action: string; updated_fields?: string[]; status?: string };
+		expect(upd.status).toBeUndefined();
+		expect(upd.updated_fields).toContain("name");
+		const sql = getTestDb();
+		const nameRows = await sql`
+			SELECT name FROM agents WHERE organization_id = ${orgId} AND id = 'human-edit-bot'
+		`;
+		expect(nameRows[0]?.name).toBe("v2");
+
+		const del = (await executeTool(
+			"manage_agents",
+			{ action: "delete", agent_id: "human-edit-bot" },
+			TEST_ENV,
+			ownerCtx,
+		)) as { action: string; deleted?: boolean; status?: string };
+		expect(del.status).toBeUndefined();
+		expect(del.deleted).toBe(true);
+		expect(await agentExists(orgId, "human-edit-bot")).toBe(false);
+	});
+
+	it("agent create produces a pending run + approval event and does NOT create the agent yet", async () => {
 		const res = (await executeTool(
 			"manage_agents",
 			{ action: "create", agent_id: "support-bot", name: "Support Bot" },
 			TEST_ENV,
-			ownerCtx,
+			agentCtx,
 		)) as PendingApproval;
 
 		expect(res.status).toBe("pending_approval");
@@ -156,7 +224,7 @@ describe("manage_agents — builder gate e2e", () => {
 			"manage_agents",
 			{ action: "create", agent_id: "approved-bot", name: "Approved Bot" },
 			TEST_ENV,
-			ownerCtx,
+			agentCtx,
 		)) as PendingApproval;
 		expect(created.status).toBe("pending_approval");
 		expect(await agentExists(orgId, "approved-bot")).toBe(false);
@@ -209,7 +277,7 @@ describe("manage_agents — builder gate e2e", () => {
 			"manage_agents",
 			{ action: "create", agent_id: "rejected-bot", name: "Rejected Bot" },
 			TEST_ENV,
-			ownerCtx,
+			agentCtx,
 		)) as PendingApproval;
 		expect(created.status).toBe("pending_approval");
 
@@ -240,27 +308,21 @@ describe("manage_agents — builder gate e2e", () => {
 		expect(eventRows[0]?.interaction_status).toBe("rejected");
 	});
 
-	it("update gate applies field changes on approve", async () => {
-		// Land a base agent first (create → approve).
-		const created = (await executeTool(
+	it("agent update gate applies field changes on approve", async () => {
+		// Land a base agent immediately as the human owner.
+		await executeTool(
 			"manage_agents",
 			{ action: "create", agent_id: "editable-bot", name: "Editable Bot" },
 			TEST_ENV,
 			ownerCtx,
-		)) as PendingApproval;
-		await executeTool(
-			"manage_operations",
-			{ action: "approve", run_id: created.run_id },
-			TEST_ENV,
-			ownerCtx,
 		);
 
-		// Now gate an update.
+		// An agent-driven update is gated.
 		const upd = (await executeTool(
 			"manage_agents",
 			{ action: "update", agent_id: "editable-bot", name: "Editable Bot v2" },
 			TEST_ENV,
-			ownerCtx,
+			agentCtx,
 		)) as PendingApproval;
 		expect(upd.status).toBe("pending_approval");
 
@@ -283,51 +345,70 @@ describe("manage_agents — builder gate e2e", () => {
 		expect(nameRows[0]?.name).toBe("Editable Bot v2");
 	});
 
-	it("delete gate removes the agent on approve", async () => {
-		const created = (await executeTool(
-			"manage_agents",
-			{ action: "create", agent_id: "doomed-bot", name: "Doomed Bot" },
-			TEST_ENV,
-			ownerCtx,
-		)) as PendingApproval;
+	it("a stale approval skips a field another writer already changed", async () => {
 		await executeTool(
-			"manage_operations",
-			{ action: "approve", run_id: created.run_id },
+			"manage_agents",
+			{ action: "create", agent_id: "raced-bot", name: "Original" },
 			TEST_ENV,
 			ownerCtx,
 		);
-		expect(await agentExists(orgId, "doomed-bot")).toBe(true);
-
-		const del = (await executeTool(
+		// Agent proposes name → "Agent Name" (pre-image captured: "Original").
+		const upd = (await executeTool(
 			"manage_agents",
-			{ action: "delete", agent_id: "doomed-bot" },
+			{ action: "update", agent_id: "raced-bot", name: "Agent Name" },
 			TEST_ENV,
-			ownerCtx,
+			agentCtx,
 		)) as PendingApproval;
-		expect(del.status).toBe("pending_approval");
-		// Still present until approval.
-		expect(await agentExists(orgId, "doomed-bot")).toBe(true);
+		expect(upd.status).toBe("pending_approval");
 
+		// Meanwhile a human renames it — pre-image no longer matches.
 		await executeTool(
-			"manage_operations",
-			{ action: "approve", run_id: del.run_id },
+			"manage_agents",
+			{ action: "update", agent_id: "raced-bot", name: "Human Name" },
 			TEST_ENV,
 			ownerCtx,
 		);
-		expect(await agentExists(orgId, "doomed-bot")).toBe(false);
+
+		// Approving the stale proposal must NOT clobber the human's newer name.
+		await executeTool(
+			"manage_operations",
+			{ action: "approve", run_id: upd.run_id },
+			TEST_ENV,
+			ownerCtx,
+		);
+		const sql = getTestDb();
+		const nameRows = await sql`
+			SELECT name FROM agents WHERE organization_id = ${orgId} AND id = 'raced-bot'
+		`;
+		expect(nameRows[0]?.name).toBe("Human Name");
+	});
+
+	it("agent delete is denied outright (a human must delete an agent)", async () => {
+		await executeTool(
+			"manage_agents",
+			{ action: "create", agent_id: "protected-bot", name: "Protected Bot" },
+			TEST_ENV,
+			ownerCtx,
+		);
+		expect(await agentExists(orgId, "protected-bot")).toBe(true);
+
+		await expect(
+			executeTool(
+				"manage_agents",
+				{ action: "delete", agent_id: "protected-bot" },
+				TEST_ENV,
+				agentCtx,
+			),
+		).rejects.toThrow();
+		// The agent survives the denied delete.
+		expect(await agentExists(orgId, "protected-bot")).toBe(true);
 	});
 
 	it("get / set_system_agent / list stay immediate", async () => {
-		// Land an agent through the gate.
-		const created = (await executeTool(
+		// Land an agent immediately as the human owner.
+		await executeTool(
 			"manage_agents",
 			{ action: "create", agent_id: "system-bot", name: "System Bot" },
-			TEST_ENV,
-			ownerCtx,
-		)) as PendingApproval;
-		await executeTool(
-			"manage_operations",
-			{ action: "approve", run_id: created.run_id },
 			TEST_ENV,
 			ownerCtx,
 		);

--- a/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
@@ -383,6 +383,52 @@ describe("manage_agents — builder gate e2e", () => {
 		expect(nameRows[0]?.name).toBe("Human Name");
 	});
 
+	it("a legacy pending run with no pre-image fails closed (does NOT clobber)", async () => {
+		// Simulates a run queued BEFORE the base-capture branch shipped: its
+		// action_input has no `base`. Approving it must skip the field (fail closed),
+		// never blind-overwrite a newer human edit (sol review #8).
+		await executeTool(
+			"manage_agents",
+			{ action: "create", agent_id: "legacy-bot", name: "Original" },
+			TEST_ENV,
+			ownerCtx,
+		);
+		const upd = (await executeTool(
+			"manage_agents",
+			{ action: "update", agent_id: "legacy-bot", name: "Agent Name" },
+			TEST_ENV,
+			agentCtx,
+		)) as PendingApproval;
+
+		const sql = getTestDb();
+		// Strip `base` from the queued proposal to mimic a pre-branch legacy run.
+		await sql`
+			UPDATE runs
+			SET action_input = (action_input - 'base')
+			WHERE id = ${upd.run_id} AND organization_id = ${orgId}
+		`;
+
+		// A human renames it after the (now base-less) proposal was queued.
+		await executeTool(
+			"manage_agents",
+			{ action: "update", agent_id: "legacy-bot", name: "Human Name" },
+			TEST_ENV,
+			ownerCtx,
+		);
+
+		// Approving the legacy proposal must NOT overwrite the human's newer name.
+		await executeTool(
+			"manage_operations",
+			{ action: "approve", run_id: upd.run_id },
+			TEST_ENV,
+			ownerCtx,
+		);
+		const nameRows = await sql`
+			SELECT name FROM agents WHERE organization_id = ${orgId} AND id = 'legacy-bot'
+		`;
+		expect(nameRows[0]?.name).toBe("Human Name");
+	});
+
 	it("agent delete is denied outright (a human must delete an agent)", async () => {
 		await executeTool(
 			"manage_agents",

--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -867,11 +867,13 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     const [after] = await sql`SELECT metadata FROM entities WHERE id = ${Number(row.entity_id)}`;
     expect((after.metadata as Record<string, unknown>).severity).toBe('high');
 
-    // The rejection reason is recorded as a feedback event (the revision hook).
+    // The rejection reason is recorded as a `correction` feedback event — the
+    // SAME channel getRecentFeedbackSummary reads to feed the watcher's next run
+    // (the revision loop). Keyed to the watcher, field_path='$batch_reject'.
     const feedback = await sql`
       SELECT metadata FROM current_event_records
       WHERE organization_id = ${workspace.org.id}
-        AND semantic_type = 'change_set'
+        AND semantic_type = 'correction'
         AND (metadata->>'kind') = 'watcher_batch_reject'
     `;
     expect(feedback.length).toBe(1);

--- a/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/promote-keyed-entities.test.ts
@@ -180,12 +180,13 @@ async function readWindowToken(
 async function completeWithToken(
   ctx: Awaited<ReturnType<typeof setupKeyedWatcher>>,
   windowToken: string,
-  runId: number
+  runId: number,
+  extractedData: Record<string, unknown> = KEYED_EXTRACTED_DATA
 ): Promise<number> {
   const completion = (await ctx.api.watchers.completeWindow({
     watcher_id: String(ctx.watcherId),
     window_token: windowToken,
-    extracted_data: KEYED_EXTRACTED_DATA,
+    extracted_data: extractedData,
     run_metadata: { watcher_run_id: runId },
   })) as { action: string; window_id: number };
   expect(completion.action).toBe('complete_window');
@@ -263,6 +264,26 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
       expect(Number(md.window_id)).toBe(windowId);
       expect(Number(md.watcher_id)).toBe(watcherId);
     }
+
+    // The run carries a FIRST-CLASS change-set event listing what it applied —
+    // even though these creates were auto-applied (no approval involved). This
+    // is the run's own diff, not an approval artifact.
+    const changeSet = await sql`
+      SELECT title, metadata, entity_ids
+      FROM current_event_records
+      WHERE run_id = ${runId}
+        AND organization_id = ${workspace.org.id}
+        AND semantic_type = 'change_set'
+    `;
+    expect(changeSet).toHaveLength(1);
+    const csMeta = changeSet[0].metadata as Record<string, unknown>;
+    expect(csMeta.kind).toBe('watcher_change_set');
+    expect(Number(csMeta.window_id)).toBe(windowId);
+    expect(Number(csMeta.created_count)).toBe(2);
+    expect(Number(csMeta.updated_count)).toBe(0);
+    const csChanges = csMeta.changes as Array<{ kind: string; entityId: number }>;
+    expect(csChanges).toHaveLength(2);
+    expect(csChanges.every((c) => c.kind === 'created')).toBe(true);
   });
 
   it('is idempotent across a same-window replay — no duplicate entities', async () => {
@@ -721,5 +742,141 @@ describe('complete_window promotes keyed rows into entities (P2 phase 1)', () =>
     // The squatter is untouched; the promoted entity carries its origin window.
     const promoted = await sql`SELECT metadata FROM entities WHERE id = ${appCrashes?.entity_id}`;
     expect(Number((promoted[0].metadata as Record<string, unknown>).window_id)).toBe(windowId);
+  });
+
+  it('groups a run\'s proposals by window and approves them all in one batch', async () => {
+    const ctx = await setupKeyedWatcher();
+    const { sql, workspace, watcherId } = ctx;
+
+    await createTestEvent({
+      entity_id: ctx.parentEntityId,
+      organization_id: workspace.org.id,
+      content: 'Users report the app crashing and loading slowly.',
+      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    const runId = await queueRunningRun(ctx);
+    const token = await readWindowToken(ctx);
+
+    // Run 1: create both entities with a `severity` field.
+    const windowId = await completeWithToken(ctx, token, runId, {
+      problems: [
+        { category: 'Stability', name: 'App Crashes', severity: 'low' },
+        { category: 'Performance', name: 'Slow Loading', severity: 'low' },
+      ],
+    });
+
+    // A human takes ownership of `severity` on BOTH promoted entities.
+    const ids = await sql`
+      SELECT ei.identifier, ei.entity_id FROM entity_identities ei
+      WHERE ei.organization_id = ${workspace.org.id} AND ei.namespace = 'watcher_key'
+      ORDER BY ei.identifier
+    `;
+    for (const row of ids) {
+      await workspace.owner.entities.update({
+        entity_id: Number(row.entity_id),
+        metadata: { severity: 'high' },
+        field_note: 'human-owned',
+      });
+    }
+
+    // Run 2 (same window): the watcher proposes a new severity for BOTH — each is
+    // blocked (human-owned) and queues its own pending proposal, sharing window_id.
+    await completeWithToken(ctx, token, runId, {
+      problems: [
+        { category: 'Stability', name: 'App Crashes', severity: 'critical' },
+        { category: 'Performance', name: 'Slow Loading', severity: 'critical' },
+      ],
+    });
+
+    const pending = await sql`
+      SELECT id, window_id FROM runs
+      WHERE organization_id = ${workspace.org.id}
+        AND run_type = 'internal' AND action_key = 'entity_field_change'
+        AND approval_status = 'pending'
+      ORDER BY id ASC
+    `;
+    expect(pending.length).toBe(2);
+    // Both proposals carry the run's window_id on the COLUMN (batch grouping key).
+    expect(pending.every((r) => Number(r.window_id) === windowId)).toBe(true);
+
+    // approve_batch approves every pending proposal for the window in one call.
+    const batchRes = (await executeTool(
+      'manage_operations',
+      { action: 'approve_batch', window_id: windowId },
+      TEST_ENV,
+      ownerAuthCtx(workspace.org.id, workspace.users.owner.id)
+    )) as { action: string; approved_count?: number; failed_count?: number };
+    expect(batchRes.action).toBe('approve_batch');
+    expect(batchRes.approved_count).toBe(2);
+    expect(batchRes.failed_count).toBe(0);
+
+    // Both proposals applied and their runs completed.
+    for (const row of ids) {
+      const [applied] = await sql`SELECT metadata FROM entities WHERE id = ${Number(row.entity_id)}`;
+      expect((applied.metadata as Record<string, unknown>).severity).toBe('critical');
+    }
+    const stillPending = await sql`
+      SELECT id FROM runs
+      WHERE organization_id = ${workspace.org.id}
+        AND run_type = 'internal' AND action_key = 'entity_field_change'
+        AND approval_status = 'pending'
+    `;
+    expect(stillPending.length).toBe(0);
+  });
+
+  it('reject_batch cancels a run\'s proposals and records the reason for revision', async () => {
+    const ctx = await setupKeyedWatcher();
+    const { sql, workspace } = ctx;
+
+    await createTestEvent({
+      entity_id: ctx.parentEntityId,
+      organization_id: workspace.org.id,
+      content: 'Users report the app crashing and loading slowly.',
+      occurred_at: new Date(Date.now() - 60 * 60 * 1000),
+    });
+
+    const runId = await queueRunningRun(ctx);
+    const token = await readWindowToken(ctx);
+    const windowId = await completeWithToken(ctx, token, runId, {
+      problems: [{ category: 'Stability', name: 'App Crashes', severity: 'low' }],
+    });
+    const [row] = await sql`
+      SELECT ei.entity_id FROM entity_identities ei
+      WHERE ei.organization_id = ${workspace.org.id} AND ei.namespace = 'watcher_key' LIMIT 1
+    `;
+    await workspace.owner.entities.update({
+      entity_id: Number(row.entity_id),
+      metadata: { severity: 'high' },
+      field_note: 'human-owned',
+    });
+    await completeWithToken(ctx, token, runId, {
+      problems: [{ category: 'Stability', name: 'App Crashes', severity: 'critical' }],
+    });
+
+    const rejectRes = (await executeTool(
+      'manage_operations',
+      { action: 'reject_batch', window_id: windowId, reason: 'severity should stay high' },
+      TEST_ENV,
+      ownerAuthCtx(workspace.org.id, workspace.users.owner.id)
+    )) as { action: string; rejected_count?: number };
+    expect(rejectRes.action).toBe('reject_batch');
+    expect(rejectRes.rejected_count).toBe(1);
+
+    // The human-owned value is untouched; the proposal run is cancelled.
+    const [after] = await sql`SELECT metadata FROM entities WHERE id = ${Number(row.entity_id)}`;
+    expect((after.metadata as Record<string, unknown>).severity).toBe('high');
+
+    // The rejection reason is recorded as a feedback event (the revision hook).
+    const feedback = await sql`
+      SELECT metadata FROM current_event_records
+      WHERE organization_id = ${workspace.org.id}
+        AND semantic_type = 'change_set'
+        AND (metadata->>'kind') = 'watcher_batch_reject'
+    `;
+    expect(feedback.length).toBe(1);
+    expect((feedback[0].metadata as Record<string, unknown>).reason).toBe(
+      'severity should stay high'
+    );
   });
 });

--- a/packages/server/src/__tests__/unit/approval-notification-render.test.ts
+++ b/packages/server/src/__tests__/unit/approval-notification-render.test.ts
@@ -37,13 +37,11 @@ describe("approval notification rendering", () => {
 			"Review topic fields: Severity, Name",
 		);
 		expect(formatActionApprovalBody({ approvalUrl, details })).toBe(
-			"Requested by: Watcher &lt;One&gt;\n" +
-				"Entity: [App &amp; Crashes](https://app.lobu.ai/acme/topic/app-crashes)\n" +
-				"\nProposed change:\n" +
-				"Severity:\n~high~\n→ critical\n" +
-				"Name:\n~Old Name~\n→ New &lt;Name&gt;\n" +
-				"\nWhy approval is needed: Field is protected: severity (currently set by you).\n" +
-				"\nReview: [Review in Lobu](https://app.lobu.ai/acme/runs/42)",
+			"**Watcher &lt;One&gt;** wants to update [App &amp; Crashes](https://app.lobu.ai/acme/topic/app-crashes):\n" +
+				"- Severity: ~high~\n→ critical\n" +
+				"- Name: ~Old Name~\n→ New &lt;Name&gt;\n" +
+				"\nField is protected: severity (currently set by you).\n" +
+				"\n[Review in Lobu](https://app.lobu.ai/acme/runs/42)",
 		);
 		expect(cardText(buildActionApprovalCard({ runId: 42, approvalUrl, details }))).toBe(
 			"*Requested by:* Watcher &lt;One&gt;\n" +
@@ -63,10 +61,9 @@ describe("approval notification rendering", () => {
 			reason: null,
 		};
 		expect(formatActionApprovalBody({ details })).toBe(
-			"Entity: Topic (#9)\n" +
-				"\nProposed change:\n" +
-				'Status:\n~Not set~\n→ { "nested": true }\n' +
-				"\nWhy approval is needed: This change needs a human approval before it is applied.",
+			"**A watcher** wants to update Topic (#9):\n" +
+				'- Status: ~Not set~\n→ { "nested": true }\n' +
+				"\nThis change needs a human approval before it is applied.",
 		);
 		expect(cardText(buildActionApprovalCard({ details }))).toBe(
 			'\n*Status*\n~Not set~\n→ { "nested": true }\n' +
@@ -89,12 +86,10 @@ describe("approval notification rendering", () => {
 			"Review creating topic",
 		);
 		expect(formatActionApprovalBody({ approvalUrl, details })).toBe(
-			"Requested by: A watcher\n" +
-				"Entity: Slow &amp; Loading\n" +
-				"\nProposed action: Create this entity\n" +
-				"\nEntity type: topic\nName: Slow &amp; Loading\nParent id: 3\n" +
-				'\nWhy approval is needed: A watcher proposes creating topic "Slow &amp; Loading".\n' +
-				"\nReview: [Review in Lobu](https://app.lobu.ai/acme/runs/44)",
+			"**A watcher** wants to create Slow &amp; Loading.\n" +
+				"- Entity type: topic\n- Name: Slow &amp; Loading\n- Parent id: 3\n" +
+				'\nA watcher proposes creating topic "Slow &amp; Loading".\n' +
+				"\n[Review in Lobu](https://app.lobu.ai/acme/runs/44)",
 		);
 		expect(cardText(buildActionApprovalCard({ runId: 44, approvalUrl, details }))).toBe(
 			"*Requested by:* A watcher\n" +
@@ -132,11 +127,9 @@ describe("approval notification rendering", () => {
 				details,
 			}),
 		).toBe(
-			"Requested by: An agent\n" +
-				"Entity: [Old &lt;Topic&gt;](https://app.lobu.ai/acme/topic/old-topic)\n" +
-				"\nProposed action: Delete this entity\n" +
-				"\nEntity id: 11\nEntity type: topic\nName: Old &lt;Topic&gt;\nForce delete tree: false\n" +
-				"\nReview: [Review in Lobu](https://app.lobu.ai/acme/runs/45)",
+			"**An agent** wants to delete [Old &lt;Topic&gt;](https://app.lobu.ai/acme/topic/old-topic).\n" +
+				"- Entity id: 11\n- Entity type: topic\n- Name: Old &lt;Topic&gt;\n- Force delete tree: false\n" +
+				"\n[Review in Lobu](https://app.lobu.ai/acme/runs/45)",
 		);
 		expect(cardText(buildActionApprovalCard({ runId: 45, details }))).toBe(
 			"*Requested by:* An agent\n" +

--- a/packages/server/src/__tests__/unit/entity-mutation-gate.test.ts
+++ b/packages/server/src/__tests__/unit/entity-mutation-gate.test.ts
@@ -12,7 +12,7 @@ import type { DbClient } from "../../db/client";
 
 /**
  * Policy-query stub: the builtin approval interceptor (always first in the
- * registry) queries entity_approval_policies on the request's sql handle; an
+ * registry) queries write_approval_policies on the request's sql handle; an
  * empty result set resolves to the default policy (create/update auto), i.e.
  * the interceptor contributes allow / an empty require-approval set, leaving
  * the outcome to the test-registered stubs.

--- a/packages/server/src/__tests__/unit/entity-policy.test.ts
+++ b/packages/server/src/__tests__/unit/entity-policy.test.ts
@@ -8,6 +8,9 @@ import {
 
 type PolicyRowSeed = {
 	id?: number;
+	resource_class?: string;
+	principal_kind?: string | null;
+	principal_id?: string | null;
 	entity_type_slug?: string | null;
 	field_path?: string | null;
 	entity_id?: number | null;
@@ -19,11 +22,16 @@ type PolicyRowSeed = {
 const ORG = "org-1";
 
 /** Tagged-template stub that mimics the candidate-policy query: it applies the
- * same (NULL OR match) filters the real SQL does, against seeded rows. */
+ * same (NULL OR match) filters the real SQL does, against seeded rows. Param
+ * order matches loadCandidatePolicies: org, resource_class, principal_kind,
+ * principal_id, entity_type_slug, entity_id. */
 function stubSql(seeds: PolicyRowSeed[]): DbClient {
 	const rows = seeds.map((seed, index) => ({
 		id: seed.id ?? index + 1,
 		organization_id: ORG,
+		resource_class: seed.resource_class ?? "entity",
+		principal_kind: seed.principal_kind ?? null,
+		principal_id: seed.principal_id ?? null,
 		entity_type_slug: seed.entity_type_slug ?? null,
 		field_path: seed.field_path ?? null,
 		entity_id: seed.entity_id ?? null,
@@ -36,15 +44,24 @@ function stubSql(seeds: PolicyRowSeed[]): DbClient {
 		approval_channel_name: null,
 	}));
 	const sql = (_strings: TemplateStringsArray, ...params: unknown[]) => {
-		const [org, entityTypeSlug, entityId] = params as [
-			string,
-			string | null,
-			number | null,
-		];
+		const [org, resourceClass, principalKind, principalId, entityTypeSlug, entityId] =
+			params as [
+				string,
+				string,
+				string | null,
+				string | null,
+				string | null,
+				number | null,
+			];
 		return Promise.resolve(
 			rows.filter(
 				(row) =>
 					row.organization_id === org &&
+					row.resource_class === resourceClass &&
+					(row.principal_kind === null ||
+						(row.principal_kind === principalKind &&
+							(row.principal_id === null ||
+								row.principal_id === principalId))) &&
 					(row.entity_type_slug === null ||
 						row.entity_type_slug === entityTypeSlug) &&
 					(row.entity_id === null || row.entity_id === entityId),
@@ -152,6 +169,93 @@ describe("evaluateEntityMutation", () => {
 		).toBe("require_approval");
 	});
 
+	test("deny mode is a hard floor — the write is denied, not queued", async () => {
+		expect(
+			await evaluateEntityMutation({
+				organizationId: ORG,
+				principalKind: "agent",
+				action: "create",
+				entityTypeSlug: "task",
+				sql: stubSql([{ entity_type_slug: "task", create_mode: "deny" }]),
+			}),
+		).toBe("deny");
+	});
+
+	test("per-principal row beats a broader any-principal row", async () => {
+		// Global says auto for creates; a row pinned to this one agent says approval.
+		const sql = stubSql([
+			{ create_mode: "auto" },
+			{ principal_kind: "agent", principal_id: "agent-77", create_mode: "approval" },
+		]);
+		expect(
+			await evaluateEntityMutation({
+				organizationId: ORG,
+				principalKind: "agent",
+				principalId: "agent-77",
+				action: "create",
+				entityTypeSlug: "task",
+				sql,
+			}),
+		).toBe("require_approval");
+		// A different agent is unaffected and falls back to the global auto.
+		expect(
+			await evaluateEntityMutation({
+				organizationId: ORG,
+				principalKind: "agent",
+				principalId: "agent-99",
+				action: "create",
+				entityTypeSlug: "task",
+				sql,
+			}),
+		).toBe("allow");
+	});
+
+	test("principal-kind row (any id) applies to every agent of that kind", async () => {
+		const sql = stubSql([
+			{ principal_kind: "watcher", delete_mode: "deny" },
+		]);
+		expect(
+			await evaluateEntityMutation({
+				organizationId: ORG,
+				principalKind: "watcher",
+				principalId: "watcher:5",
+				action: "delete",
+				entityTypeSlug: "task",
+				sql,
+			}),
+		).toBe("deny");
+		// An agent (different kind) is not matched by a watcher-kind row.
+		expect(
+			await evaluateEntityMutation({
+				organizationId: ORG,
+				principalKind: "agent",
+				principalId: "agent-1",
+				action: "delete",
+				entityTypeSlug: "task",
+				sql,
+			}),
+		).toBe("require_approval");
+	});
+
+	test("a pinned-principal row outranks a more-scoped any-principal row", async () => {
+		// entity-type row (any principal) says auto; principal row (no scope) says
+		// approval. Principal specificity dominates, so the pinned agent is gated.
+		const sql = stubSql([
+			{ entity_type_slug: "task", update_mode: "auto" },
+			{ principal_kind: "agent", principal_id: "agent-77", update_mode: "approval" },
+		]);
+		expect(
+			await evaluateEntityMutation({
+				organizationId: ORG,
+				principalKind: "agent",
+				principalId: "agent-77",
+				action: "update",
+				entityTypeSlug: "task",
+				sql,
+			}),
+		).toBe("require_approval");
+	});
+
 	test("entity-scoped (row-level) policy beats the type policy", async () => {
 		const sql = stubSql([
 			{ entity_type_slug: "task", delete_mode: "auto" },
@@ -242,6 +346,39 @@ describe("evaluateEntityFieldUpdates", () => {
 			...baseArgs,
 			entityId: 9999,
 			principalKind: "agent",
+			fields: { status: "none" },
+			sql,
+		});
+		expect(other.status).toBe("allow");
+	});
+
+	test("deny mode on a field denies it even when human-owned", async () => {
+		const decisions = await evaluateEntityFieldUpdates({
+			...baseArgs,
+			principalKind: "agent",
+			fields: { locked: "human", status: "none" },
+			sql: stubSql([{ entity_type_slug: "task", update_mode: "deny" }]),
+		});
+		expect(decisions.locked).toBe("deny");
+		expect(decisions.status).toBe("deny");
+	});
+
+	test("per-principal update policy gates only the pinned watcher", async () => {
+		const sql = stubSql([
+			{ principal_kind: "watcher", principal_id: "watcher:6", update_mode: "approval" },
+		]);
+		const pinned = await evaluateEntityFieldUpdates({
+			...baseArgs,
+			principalKind: "watcher",
+			principalId: "watcher:6",
+			fields: { status: "none" },
+			sql,
+		});
+		expect(pinned.status).toBe("require_approval");
+		const other = await evaluateEntityFieldUpdates({
+			...baseArgs,
+			principalKind: "watcher",
+			principalId: "watcher:7",
 			fields: { status: "none" },
 			sql,
 		});

--- a/packages/server/src/__tests__/unit/entity-policy.test.ts
+++ b/packages/server/src/__tests__/unit/entity-policy.test.ts
@@ -346,6 +346,65 @@ describe("resolveWritePolicyDecision (agent_config)", () => {
 	});
 });
 
+describe("resolveWritePolicyDecision (connector_action)", () => {
+	test("no policy row → auto, so the connection mode alone governs", async () => {
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: ORG,
+				resourceClass: "connector_action",
+				principalKind: "agent",
+				action: "create",
+				sql: stubSql([]),
+			}),
+		).toBe("allow");
+	});
+
+	test("an org policy can force connector-action approval or deny", async () => {
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: ORG,
+				resourceClass: "connector_action",
+				principalKind: "agent",
+				action: "create",
+				sql: stubSql([
+					{ resource_class: "connector_action", create_mode: "approval" },
+				]),
+			}),
+		).toBe("require_approval");
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: ORG,
+				resourceClass: "connector_action",
+				principalKind: "watcher",
+				principalId: "watcher:9",
+				action: "create",
+				sql: stubSql([
+					{
+						resource_class: "connector_action",
+						principal_kind: "watcher",
+						principal_id: "watcher:9",
+						create_mode: "deny",
+					},
+				]),
+			}),
+		).toBe("deny");
+	});
+
+	test("a human applies connector actions immediately regardless of policy", async () => {
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: ORG,
+				resourceClass: "connector_action",
+				principalKind: "user",
+				action: "create",
+				sql: stubSql([
+					{ resource_class: "connector_action", create_mode: "deny" },
+				]),
+			}),
+		).toBe("allow");
+	});
+});
+
 describe("evaluateEntityFieldUpdates", () => {
 	const baseArgs = {
 		organizationId: ORG,

--- a/packages/server/src/__tests__/unit/entity-policy.test.ts
+++ b/packages/server/src/__tests__/unit/entity-policy.test.ts
@@ -4,6 +4,7 @@ import {
 	classifyMutationPrincipal,
 	evaluateEntityFieldUpdates,
 	evaluateEntityMutation,
+	resolveWritePolicyDecision,
 } from "../../authz/entity-policy";
 
 type PolicyRowSeed = {
@@ -281,6 +282,67 @@ describe("evaluateEntityMutation", () => {
 				sql,
 			}),
 		).toBe("allow");
+	});
+});
+
+describe("resolveWritePolicyDecision (agent_config)", () => {
+	test("a human member applies immediately regardless of policy", async () => {
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: ORG,
+				resourceClass: "agent_config",
+				principalKind: "user",
+				action: "update",
+				sql: stubSql([{ resource_class: "agent_config", update_mode: "deny" }]),
+			}),
+		).toBe("allow");
+	});
+
+	test("default: agent create/update queue approval, delete is denied", async () => {
+		const sql = stubSql([]);
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: ORG,
+				resourceClass: "agent_config",
+				principalKind: "agent",
+				action: "create",
+				sql,
+			}),
+		).toBe("require_approval");
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: ORG,
+				resourceClass: "agent_config",
+				principalKind: "agent",
+				action: "delete",
+				sql,
+			}),
+		).toBe("deny");
+	});
+
+	test("an org policy row can loosen the agent_config default to auto", async () => {
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: ORG,
+				resourceClass: "agent_config",
+				principalKind: "agent",
+				action: "update",
+				sql: stubSql([{ resource_class: "agent_config", update_mode: "auto" }]),
+			}),
+		).toBe("allow");
+	});
+
+	test("an entity-class row does not leak into an agent_config decision", async () => {
+		// Only an entity row exists; agent_config falls back to its own default.
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: ORG,
+				resourceClass: "agent_config",
+				principalKind: "agent",
+				action: "update",
+				sql: stubSql([{ resource_class: "entity", update_mode: "auto" }]),
+			}),
+		).toBe("require_approval");
 	});
 });
 

--- a/packages/server/src/__tests__/unit/entity-policy.test.ts
+++ b/packages/server/src/__tests__/unit/entity-policy.test.ts
@@ -4,6 +4,7 @@ import {
 	classifyMutationPrincipal,
 	evaluateEntityFieldUpdates,
 	evaluateEntityMutation,
+	mutationPrincipalId,
 	resolveWritePolicyDecision,
 } from "../../authz/entity-policy";
 
@@ -73,14 +74,21 @@ function stubSql(seeds: PolicyRowSeed[]): DbClient {
 }
 
 describe("classifyMutationPrincipal", () => {
-	test("watcher source wins", () => {
+	test("a genuine watcher (no agentId) classifies as watcher", () => {
+		expect(
+			classifyMutationPrincipal({ watcherSource: { watcher_id: 5 } }),
+		).toBe("watcher");
+	});
+
+	test("SECURITY: a trusted agentId beats a caller-supplied watcher_source", () => {
+		// An agent run cannot demote itself to a watcher (and escape its agent
+		// policy) by tagging the write with a watcher_source it controls.
 		expect(
 			classifyMutationPrincipal({
-				userId: "u1",
-				agentId: "a1",
+				agentId: "agent-A",
 				watcherSource: { watcher_id: 5 },
 			}),
-		).toBe("watcher");
+		).toBe("agent");
 	});
 
 	test("real user session is a user", () => {
@@ -95,6 +103,26 @@ describe("classifyMutationPrincipal", () => {
 
 	test("system/automation context (no user, no agent) is an agent, not a user", () => {
 		expect(classifyMutationPrincipal({})).toBe("agent");
+	});
+});
+
+describe("mutationPrincipalId", () => {
+	test("a genuine watcher (no agentId) resolves to watcher:<id>", () => {
+		expect(mutationPrincipalId({ agentId: null, watcherId: 6 })).toBe(
+			"watcher:6",
+		);
+	});
+
+	test("SECURITY: agentId wins over a caller-supplied watcherId — no spoofing", () => {
+		// An agent supplying watcher_source:{watcher_id:6} still resolves to its own
+		// agent id, so it is matched against ITS agent policy, not watcher:6's.
+		expect(mutationPrincipalId({ agentId: "agent-A", watcherId: 6 })).toBe(
+			"agent-A",
+		);
+	});
+
+	test("no principal id → null (any agent)", () => {
+		expect(mutationPrincipalId({})).toBeNull();
 	});
 });
 
@@ -238,9 +266,10 @@ describe("evaluateEntityMutation", () => {
 		).toBe("require_approval");
 	});
 
-	test("a pinned-principal row outranks a more-scoped any-principal row", async () => {
-		// entity-type row (any principal) says auto; principal row (no scope) says
-		// approval. Principal specificity dominates, so the pinned agent is gated.
+	test("scope specificity outranks principal: entity-type row beats a principal-global row", async () => {
+		// entity-type row (any principal) says auto; an agent-global row says approval.
+		// Per the RFC, TARGET SCOPE wins over principal specificity, so the more-
+		// scoped entity-type rule governs — the pinned agent is NOT gated here.
 		const sql = stubSql([
 			{ entity_type_slug: "task", update_mode: "auto" },
 			{ principal_kind: "agent", principal_id: "agent-77", update_mode: "approval" },
@@ -254,7 +283,62 @@ describe("evaluateEntityMutation", () => {
 				entityTypeSlug: "task",
 				sql,
 			}),
+		).toBe("allow");
+	});
+
+	test("an agent-global auto must NOT shadow an entity-type-specific deny", async () => {
+		// The inverse-regression sol asked for: a broad per-principal `auto` cannot
+		// open up a narrowly-scoped `deny`. Scope specificity wins → deny.
+		const sql = stubSql([
+			{ entity_type_slug: "invoice", update_mode: "deny" },
+			{ principal_kind: "agent", principal_id: "agent-A", update_mode: "auto" },
+		]);
+		expect(
+			await evaluateEntityMutation({
+				organizationId: ORG,
+				principalKind: "agent",
+				principalId: "agent-A",
+				action: "update",
+				entityTypeSlug: "invoice",
+				sql,
+			}),
+		).toBe("deny");
+	});
+
+	test("principal breaks a SCOPE tie: two global rows, the pinned one wins", async () => {
+		// Both rows are global scope (equal scope specificity), so principal
+		// specificity is the tie-break — the agent-pinned approval governs.
+		const sql = stubSql([
+			{ update_mode: "auto" },
+			{ principal_kind: "agent", principal_id: "agent-77", update_mode: "approval" },
+		]);
+		expect(
+			await evaluateEntityMutation({
+				organizationId: ORG,
+				principalKind: "agent",
+				principalId: "agent-77",
+				action: "update",
+				entityTypeSlug: "task",
+				sql,
+			}),
 		).toBe("require_approval");
+	});
+
+	test("restrictive-wins breaks a full tie: deny beats auto at equal specificity", async () => {
+		// Same scope + same (null) principal → tie broken by restrictiveness: deny wins.
+		const sql = stubSql([
+			{ entity_type_slug: "task", update_mode: "auto" },
+			{ entity_type_slug: "task", update_mode: "deny" },
+		]);
+		expect(
+			await evaluateEntityMutation({
+				organizationId: ORG,
+				principalKind: "agent",
+				action: "update",
+				entityTypeSlug: "task",
+				sql,
+			}),
+		).toBe("deny");
 	});
 
 	test("entity-scoped (row-level) policy beats the type policy", async () => {

--- a/packages/server/src/__tests__/unit/entity-policy.test.ts
+++ b/packages/server/src/__tests__/unit/entity-policy.test.ts
@@ -489,6 +489,52 @@ describe("resolveWritePolicyDecision (connector_action)", () => {
 	});
 });
 
+describe("persisted mode fails closed (sol review #7)", () => {
+	test("an UNKNOWN stored mode resolves to deny, never allow", async () => {
+		// A mode a future build introduced mid-rolling-upgrade, or corrupt data from
+		// manual SQL, must NOT read as `allow`. parsePersistedMode maps it to deny.
+		expect(
+			await evaluateEntityMutation({
+				organizationId: ORG,
+				principalKind: "agent",
+				action: "create",
+				entityTypeSlug: "task",
+				sql: stubSql([
+					{ entity_type_slug: "task", create_mode: "quantum-approve" },
+				]),
+			}),
+		).toBe("deny");
+	});
+
+	test("unknown stored mode fails closed for agent_config too", async () => {
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: ORG,
+				resourceClass: "agent_config",
+				principalKind: "agent",
+				action: "update",
+				sql: stubSql([
+					{ resource_class: "agent_config", update_mode: "??" },
+				]),
+			}),
+		).toBe("deny");
+	});
+
+	test("a valid stored mode still resolves normally (no over-eager deny)", async () => {
+		expect(
+			await evaluateEntityMutation({
+				organizationId: ORG,
+				principalKind: "agent",
+				action: "create",
+				entityTypeSlug: "task",
+				sql: stubSql([
+					{ entity_type_slug: "task", create_mode: "approval" },
+				]),
+			}),
+		).toBe("require_approval");
+	});
+});
+
 describe("evaluateEntityFieldUpdates", () => {
 	const baseArgs = {
 		organizationId: ORG,

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -689,7 +689,7 @@ manage_catalog: list_catalog=read+public list_installed=read+public ?=read
 manage_agents: list=admin get=admin create=admin update=admin delete=admin set_system_agent=admin ?=read
 manage_feeds: list_feeds=read+public read_feed=read+public read_feeds=read+public create_feed=admin update_feed=admin delete_feed=admin trigger_feed=admin ?=read
 manage_auth_profiles: list_auth_profiles=read+public get_auth_profile=admin test_auth_profile=admin create_auth_profile=write update_auth_profile=write delete_auth_profile=admin set_default_auth_profile=admin ?=read
-manage_operations: list_available=read+public execute=admin list_runs=read+public get_run=read+public approve=write reject=write ?=read
+manage_operations: list_available=read+public execute=admin list_runs=read+public get_run=read+public approve=write reject=write approve_batch=write reject_batch=write ?=read
 notify: send=admin ?=admin
 manage_schedules: create=admin list=admin update=admin pause=admin cancel=admin ?=admin
 manage_watchers: create=admin update=admin create_version=admin complete_window=write trigger=admin delete=admin set_reaction_script=admin get_versions=read+public get_version_details=read+public get_component_reference=read+public submit_feedback=admin get_feedback=read+public list_promoted=read create_from_version=admin ?=read

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -43,12 +43,17 @@ const MEMBER_WRITE_ACTIONS: Record<string, Set<string> | null> = {
 	// requireWatcherAccess; watcher ADMINISTRATION (create/update/delete/…)
 	// stays admin-tier below.
 	manage_watchers: new Set(["complete_window"]),
-	// `approve`/`reject` are write-tier so the recorded FIELD OWNER of an
-	// entity-change proposal (a plain member) can decide their own run. The
-	// handler enforces admin-or-run-owner per run — a member who is not that
-	// run's owner is rejected there with the same admin-access message.
-	// `execute` stays admin-tier below.
-	manage_operations: new Set(["approve", "reject"]),
+	// `approve`/`reject` (and their `*_batch` forms) are write-tier so the
+	// recorded FIELD OWNER of an entity-change proposal (a plain member) can
+	// decide their own run. The handler enforces admin-or-run-owner per run — a
+	// member who is not that run's owner is rejected there with the same
+	// admin-access message. `execute` stays admin-tier below.
+	manage_operations: new Set([
+		"approve",
+		"reject",
+		"approve_batch",
+		"reject_batch",
+	]),
 };
 
 const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {

--- a/packages/server/src/authz/approval-interceptor.ts
+++ b/packages/server/src/authz/approval-interceptor.ts
@@ -124,6 +124,7 @@ async function evaluate(
 		const decisions = await evaluateEntityFieldUpdates({
 			organizationId: req.organizationId,
 			principalKind: req.principalKind,
+			principalId: req.principalId ?? null,
 			entityTypeSlug: req.entityTypeSlug,
 			entityId: req.entityId,
 			entityOrgId: req.entityOrgId ?? null,
@@ -146,6 +147,7 @@ async function evaluate(
 	const decision = await evaluateEntityMutation({
 		organizationId: req.organizationId,
 		principalKind: req.principalKind,
+		principalId: req.principalId ?? null,
 		action: req.action,
 		entityTypeSlug: req.entityTypeSlug,
 		entityId: req.action === "delete" ? req.entityId : undefined,

--- a/packages/server/src/authz/approval-interceptor.ts
+++ b/packages/server/src/authz/approval-interceptor.ts
@@ -179,6 +179,7 @@ async function evaluate(
 				proposal: req.proposal,
 				attribution: req.attribution,
 				watcherId: req.watcherId,
+				windowId: req.windowId,
 			}),
 		};
 	}
@@ -211,6 +212,7 @@ async function evaluate(
 						metadata?: Record<string, unknown> | null;
 					},
 					watcher_id: req.watcherId ?? null,
+					window_id: req.windowId ?? null,
 					attribution: req.attribution,
 					reason: reasonFor(
 						req.attribution,

--- a/packages/server/src/authz/approval-interceptor.ts
+++ b/packages/server/src/authz/approval-interceptor.ts
@@ -60,6 +60,7 @@ export function buildCreateDeferral(args: {
 	proposal: Record<string, unknown>;
 	attribution: MutationAttribution;
 	watcherId?: number | null;
+	windowId?: number | null;
 }): DeferredMutation {
 	const name =
 		typeof args.entityData.name === "string" ? args.entityData.name : undefined;
@@ -74,6 +75,7 @@ export function buildCreateDeferral(args: {
 				entity_data: args.entityData,
 				proposal: args.proposal,
 				watcher_id: args.watcherId ?? null,
+				window_id: args.windowId ?? null,
 				attribution: args.attribution,
 				reason: reasonFor(
 					args.attribution,
@@ -91,6 +93,7 @@ export function buildFieldChangeDeferral(args: {
 	current: Record<string, unknown>;
 	attribution: MutationAttribution;
 	watcherId?: number | null;
+	windowId?: number | null;
 }): DeferredMutation {
 	return {
 		display: {
@@ -105,6 +108,7 @@ export function buildFieldChangeDeferral(args: {
 				fields: args.fields,
 				current: args.current,
 				watcher_id: args.watcherId ?? null,
+				window_id: args.windowId ?? null,
 				attribution: args.attribution,
 				reason: fieldChangeReason(args.attribution, Object.keys(args.fields)),
 			}),

--- a/packages/server/src/authz/entity-mutation-gate.ts
+++ b/packages/server/src/authz/entity-mutation-gate.ts
@@ -176,6 +176,8 @@ export function deferEntityFieldChange(args: {
 	current: Record<string, unknown>;
 	attribution: MutationAttribution;
 	watcherId?: number | null;
+	/** Groups this proposal's run into a per-window batch approval card. */
+	windowId?: number | null;
 }): DeferredMutation {
 	return buildFieldChangeDeferral(args);
 }
@@ -186,6 +188,8 @@ export function deferEntityCreate(args: {
 	proposal: Record<string, unknown>;
 	attribution: MutationAttribution;
 	watcherId?: number | null;
+	/** Groups this proposal's run into a per-window batch approval card. */
+	windowId?: number | null;
 }): DeferredMutation {
 	return buildCreateDeferral(args);
 }

--- a/packages/server/src/authz/entity-mutation-gate.ts
+++ b/packages/server/src/authz/entity-mutation-gate.ts
@@ -71,6 +71,13 @@ interface EntityMutationBase {
 	 * per-principal resolver in a later commit.
 	 */
 	principalId?: string | null;
+	/**
+	 * The watcher-run window that produced this mutation, if any. Threaded so a
+	 * deferred approval lands on the `runs.window_id` COLUMN — that's what groups a
+	 * run's N proposals into ONE batch approval card, and (with the window in the
+	 * dedup key) keeps identical proposals from different windows distinct.
+	 */
+	windowId?: number | null;
 }
 
 export interface CreateMutationRequest extends EntityMutationBase {

--- a/packages/server/src/authz/entity-mutation-gate.ts
+++ b/packages/server/src/authz/entity-mutation-gate.ts
@@ -63,6 +63,14 @@ interface EntityMutationBase {
 	/** Attribution + watcher id used by an interceptor to label a deferral. */
 	attribution: MutationAttribution;
 	watcherId?: number | null;
+	/**
+	 * Stable identity of the acting non-human principal, for per-principal policy
+	 * matching (a policy row may target one agent or watcher). Agent → agent id;
+	 * watcher → `watcher:<id>`; system/automation token (no agent id) → null.
+	 * Null means "any principal of this kind". Plumbed here now; consumed by the
+	 * per-principal resolver in a later commit.
+	 */
+	principalId?: string | null;
 }
 
 export interface CreateMutationRequest extends EntityMutationBase {

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -103,7 +103,6 @@ type EntityApprovalPolicyRow = {
 	approval_channel_name: string | null;
 };
 
-
 export function isEntityMutationMode(
 	value: unknown,
 ): value is EntityMutationMode {

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -184,35 +184,42 @@ export function defaultEntityApprovalPolicy(
 }
 
 /**
- * Who is performing this mutation, for policy purposes. A watcher-attributed
- * call is a watcher; a real user session (userId without an agent run) is a
- * human; everything else — agent runs, automation/system tokens — is an agent.
- * Used identically by create, update, and delete gates so a system context
- * can neither bypass policy (as a fake "user") nor get spuriously denied.
+ * Who is performing this mutation, for policy purposes. Precedence is DELIBERATE
+ * and security-relevant: a real agent run (trusted `agentId` on the context) is
+ * classified as an agent EVEN IF the request also carries a `watcher_source`.
+ * `watcher_source` is a caller-supplied arg (attribution, e.g. for card labels);
+ * letting it override the trusted agent identity would let an agent escape its
+ * own per-principal policy by tagging its write as a watcher's. A genuine watcher
+ * promotion runs with no agentId, so it still classifies as a watcher. A real
+ * user session (userId, no agentId) is a human; everything else is an agent.
  */
 export function classifyMutationPrincipal(args: {
 	userId?: string | null;
 	agentId?: string | null;
 	watcherSource?: unknown;
 }): EntityPolicyPrincipalKind {
+	// Trusted agent identity wins over the caller-supplied watcher tag.
+	if (args.agentId) return "agent";
 	if (args.watcherSource) return "watcher";
-	if (args.userId && !args.agentId) return "user";
+	if (args.userId) return "user";
 	return "agent";
 }
 
 /**
  * Stable identity of the acting non-human principal, for per-principal policy
- * matching. Watcher → `watcher:<id>`; agent (or automation token with an agent
- * id) → that id; system/automation token with no id → null ("any agent"). Users
- * are never policy principals, so this returns null for them too. Kept alongside
- * {@link classifyMutationPrincipal} so kind and id are computed from one source.
+ * matching. Mirrors {@link classifyMutationPrincipal}'s precedence: a trusted
+ * `agentId` wins — an agent run resolves to its own agent id even when a
+ * `watcherId` (from a caller-supplied watcher_source) is also present, so it
+ * can't spoof `watcher:<id>` to dodge its agent policy. Only a genuine watcher
+ * path (agentId null) resolves to `watcher:<id>`; no id → null ("any agent").
  */
 export function mutationPrincipalId(args: {
 	agentId?: string | null;
 	watcherId?: number | null;
 }): string | null {
+	if (args.agentId) return args.agentId;
 	if (args.watcherId != null) return `watcher:${args.watcherId}`;
-	return args.agentId ?? null;
+	return null;
 }
 
 function modeForAction(
@@ -237,22 +244,59 @@ function modeToDecision(mode: EntityMutationMode): EntityPolicyDecision {
 }
 
 /**
- * How specific a candidate row is for the request it survived filtering against.
- * Higher wins. Principal specificity dominates scope specificity: a row that
- * names the acting principal always beats a broader-scoped row that targets "any
- * principal", so an admin can pin one noisy agent/watcher to `approval` without
- * that being shadowed by a global entity-type default. Within one principal tier,
- * the entity_id > field_path > entity_type ordering is preserved. Scores never
- * collide across tiers: principal weights (16/8) sit above every scope weight (≤7).
+ * Target-scope specificity: entity_id > field_path > entity_type > global. Weights
+ * are strictly ordered so a more-specific scope always outranks a broader one.
  */
-function specificity(row: EntityApprovalPolicyRow): number {
-	const principalScore =
-		row.principal_id !== null ? 16 : row.principal_kind !== null ? 8 : 0;
+function scopeSpecificity(row: EntityApprovalPolicyRow): number {
 	return (
-		principalScore +
 		(row.entity_id !== null ? 4 : 0) +
 		(row.field_path !== null ? 2 : 0) +
 		(row.entity_type_slug !== null ? 1 : 0)
+	);
+}
+
+/** Principal specificity: exact id > kind-wide > any. Used only to break scope ties. */
+function principalSpecificity(row: EntityApprovalPolicyRow): number {
+	return row.principal_id !== null ? 2 : row.principal_kind !== null ? 1 : 0;
+}
+
+/** Restrictive rank of a single stored mode — higher = more restrictive. */
+function modeRestrictiveness(mode: EntityMutationMode): number {
+	if (mode === "deny") return 3;
+	if (mode === "disabled") return 3;
+	if (mode === "approval") return 2;
+	return 1; // auto
+}
+
+/**
+ * A row's overall restrictiveness, for the final tie-break: the most restrictive
+ * of its three per-action modes. Ensures that when scope AND principal specificity
+ * tie, the stricter row wins (deny > approval > auto) rather than DB-return order.
+ */
+function rowRestrictiveness(row: EntityApprovalPolicyRow): number {
+	return Math.max(
+		modeRestrictiveness(normalizeMode(row.create_mode, "auto")),
+		modeRestrictiveness(normalizeMode(row.update_mode, "auto")),
+		modeRestrictiveness(normalizeMode(row.delete_mode, "auto")),
+	);
+}
+
+/**
+ * Order candidate rows most-authoritative first, per the RFC's declared ordering
+ * (docs/plans/write-gate-generalization.md §4): TARGET SCOPE specificity first,
+ * THEN principal specificity, then restrictive-wins as the final tie-break. So an
+ * entity-type `deny` beats an agent-global `auto` — a broad per-principal row can
+ * never shadow a narrowly-scoped rule. `id` last makes the order deterministic.
+ */
+function compareCandidates(
+	a: EntityApprovalPolicyRow,
+	b: EntityApprovalPolicyRow,
+): number {
+	return (
+		scopeSpecificity(b) - scopeSpecificity(a) ||
+		principalSpecificity(b) - principalSpecificity(a) ||
+		rowRestrictiveness(b) - rowRestrictiveness(a) ||
+		Number(b.id) - Number(a.id)
 	);
 }
 
@@ -294,7 +338,7 @@ async function loadCandidatePolicies(args: {
       AND (entity_type_slug IS NULL OR entity_type_slug = ${args.entityTypeSlug ?? null})
       AND (entity_id IS NULL OR entity_id = ${args.entityId ?? null})
   `;
-	return [...rows].sort((a, b) => specificity(b) - specificity(a));
+	return [...rows].sort(compareCandidates);
 }
 
 function pickPolicy(

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -374,7 +374,7 @@ export async function evaluateEntityMutation(args: {
  * The mode a class falls back to when no policy row matches — the per-action
  * defaults baked into {@link defaultEntityApprovalPolicy} for entity, and a
  * conservative "agent-driven config change needs approval, delete is denied"
- * default for agent_config. A class with no explicit default resolves to `auto`.
+ * default for agent_config.
  */
 function defaultModeFor(
 	resourceClass: WriteResourceClass,
@@ -385,6 +385,11 @@ function defaultModeFor(
 		// approval, delete is denied outright (a human must delete an agent).
 		if (action === "delete") return "deny";
 		return "approval";
+	}
+	if (resourceClass === "connector_action") {
+		// No org connector-action policy → `auto`, so the per-connection
+		// action_modes alone decide (today's behavior). A row only ever tightens.
+		return "auto";
 	}
 	return modeForAction(defaultEntityApprovalPolicy(""), action);
 }

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -36,11 +36,12 @@ export type EntityMutationAction = "create" | "update" | "delete";
 export type EntityMutationMode = "auto" | "approval" | "deny" | "disabled";
 
 /**
- * Which class of write a policy row governs. Only `entity` exists in v1; the
- * column is populated so the connector-action class can land in the same table
- * and resolver without a schema change (see docs/plans/write-gate-generalization.md).
+ * Which class of write a policy row governs. `entity` is the original class;
+ * `agent_config` gates manage_agents create/update/delete; `connector_action`
+ * gates connector operation execution. All three share this table + resolver so a
+ * new class is a value, not a schema change (see docs/plans/write-gate-generalization.md).
  */
-export type WriteResourceClass = "entity" | "connector_action";
+export type WriteResourceClass = "entity" | "agent_config" | "connector_action";
 
 /** A non-human principal a policy row may target. NULL principal = any of this kind. */
 export type PolicyPrincipalKind = "agent" | "watcher";
@@ -127,7 +128,9 @@ function normalizeMode(
 }
 
 function normalizeResourceClass(value: unknown): WriteResourceClass {
-	return value === "connector_action" ? "connector_action" : "entity";
+	if (value === "agent_config") return "agent_config";
+	if (value === "connector_action") return "connector_action";
+	return "entity";
 }
 
 function normalizePrincipalKind(value: unknown): PolicyPrincipalKind | null {
@@ -365,6 +368,56 @@ export async function evaluateEntityMutation(args: {
 		principalId: args.principalId ?? null,
 	});
 	return modeToDecision(modeForAction(policy, args.action));
+}
+
+/**
+ * The mode a class falls back to when no policy row matches — the per-action
+ * defaults baked into {@link defaultEntityApprovalPolicy} for entity, and a
+ * conservative "agent-driven config change needs approval, delete is denied"
+ * default for agent_config. A class with no explicit default resolves to `auto`.
+ */
+function defaultModeFor(
+	resourceClass: WriteResourceClass,
+	action: EntityMutationAction,
+): EntityMutationMode {
+	if (resourceClass === "agent_config") {
+		// An agent editing agent definitions is high-trust: create/update queue an
+		// approval, delete is denied outright (a human must delete an agent).
+		if (action === "delete") return "deny";
+		return "approval";
+	}
+	return modeForAction(defaultEntityApprovalPolicy(""), action);
+}
+
+/**
+ * Class-generic write decision for a non-scoped resource (agent_config today;
+ * connector_action later). Humans with any org membership apply immediately —
+ * the write-gate governs non-human principals; role restrictions for humans live
+ * in the tool-access tier. For an agent/watcher, the matched policy row wins;
+ * with no row, the class default applies. Entity writes keep their own scoped
+ * paths ({@link evaluateEntityMutation} / {@link evaluateEntityFieldUpdates}).
+ */
+export async function resolveWritePolicyDecision(args: {
+	organizationId: string;
+	resourceClass: Exclude<WriteResourceClass, "entity">;
+	principalKind: EntityPolicyPrincipalKind;
+	principalId?: string | null;
+	action: EntityMutationAction;
+	sql?: DbClient;
+}): Promise<EntityPolicyDecision> {
+	if (args.principalKind === "user") return "allow";
+	const candidates = await loadCandidatePolicies({
+		organizationId: args.organizationId,
+		resourceClass: args.resourceClass,
+		principalKind: args.principalKind,
+		principalId: args.principalId ?? null,
+		sql: args.sql,
+	});
+	const match = candidates[0];
+	const mode = match
+		? modeForAction(rowToPolicy(match), args.action)
+		: defaultModeFor(args.resourceClass, args.action);
+	return modeToDecision(mode);
 }
 
 /**

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -6,7 +6,7 @@
  *  - Built-in invariants that no org policy can disable: writes never cross
  *    organizations, and a non-human write to a human-owned field always needs
  *    approval (field ownership is how a user pins a value).
- *  - The org's persisted `entity_approval_policies` rows: per-action
+ *  - The org's persisted `write_approval_policies` rows: per-action
  *    auto/approval modes, scoped global → entity type → field → single entity
  *    (entity_id), most specific row wins. Rows also carry the Slack delivery
  *    target for approval notifications.
@@ -281,7 +281,7 @@ async function loadCandidatePolicies(args: {
        create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
-    FROM entity_approval_policies
+    FROM write_approval_policies
     WHERE organization_id = ${args.organizationId}
       AND resource_class = ${resourceClass}
       AND (
@@ -476,7 +476,7 @@ export async function getGlobalEntityApprovalPolicy(
        create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
-    FROM entity_approval_policies
+    FROM write_approval_policies
     WHERE organization_id = ${organizationId}
       AND resource_class = 'entity'
       AND principal_kind IS NULL
@@ -505,7 +505,7 @@ export async function listEntityApprovalPolicies(
        create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
-    FROM entity_approval_policies
+    FROM write_approval_policies
     WHERE organization_id = ${organizationId}
       AND (${resourceClass ?? null}::text IS NULL OR resource_class = ${resourceClass ?? null})
     ORDER BY
@@ -559,7 +559,7 @@ export async function upsertEntityApprovalPolicy(
 	// The identity tuple the unique index keys on. Reused by both UPDATE arms so
 	// the "lost the insert race" recovery targets the exact same row.
 	const applyUpdate = (tx: DbClient) => tx<EntityApprovalPolicyRow>`
-      UPDATE entity_approval_policies
+      UPDATE write_approval_policies
       SET create_mode = ${createMode},
           update_mode = ${updateMode},
           delete_mode = ${deleteMode},
@@ -587,7 +587,7 @@ export async function upsertEntityApprovalPolicy(
 		if (updated[0]) return updated[0];
 
 		const inserted = await tx<EntityApprovalPolicyRow>`
-      INSERT INTO entity_approval_policies (
+      INSERT INTO write_approval_policies (
         organization_id, resource_class, principal_kind, principal_id,
         entity_type_slug, field_path, entity_id,
         create_mode, update_mode, delete_mode,
@@ -646,7 +646,7 @@ export async function deleteEntityApprovalPolicy(args: {
 	}
 	const sql = getDb();
 	const rows = await sql<{ id: number }>`
-    DELETE FROM entity_approval_policies
+    DELETE FROM write_approval_policies
     WHERE organization_id = ${args.organizationId}
       AND resource_class = ${resourceClass}
       AND principal_kind IS NOT DISTINCT FROM ${principalKind}

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -25,7 +25,25 @@ import { type DbClient, getDb } from "../db/client";
 export type EntityPolicyDecision = "allow" | "deny" | "require_approval";
 export type EntityPolicyPrincipalKind = "user" | "agent" | "watcher";
 export type EntityMutationAction = "create" | "update" | "delete";
-export type EntityMutationMode = "auto" | "approval";
+/**
+ * A stored per-action mode. `auto`/`approval` are the two entity modes; `deny`
+ * (a hard floor — the write never applies and no approval is queued) and
+ * `disabled` (the action is turned off entirely, used by the connector-action
+ * class) are admitted by the widened DB CHECK. The resolver maps each to an
+ * {@link EntityPolicyDecision}; unknown values coerce to the caller's fallback
+ * so a mode this build predates can never silently read as `allow`.
+ */
+export type EntityMutationMode = "auto" | "approval" | "deny" | "disabled";
+
+/**
+ * Which class of write a policy row governs. Only `entity` exists in v1; the
+ * column is populated so the connector-action class can land in the same table
+ * and resolver without a schema change (see docs/plans/write-gate-generalization.md).
+ */
+export type WriteResourceClass = "entity" | "connector_action";
+
+/** A non-human principal a policy row may target. NULL principal = any of this kind. */
+export type PolicyPrincipalKind = "agent" | "watcher";
 
 export interface EntityApprovalDeliveryTarget {
 	connectionId: string | null;
@@ -37,6 +55,10 @@ export interface EntityApprovalDeliveryTarget {
 export interface EntityApprovalPolicy {
 	id: number;
 	organizationId: string;
+	resourceClass: WriteResourceClass;
+	/** Non-human principal this row targets; NULL = any principal of its kind. */
+	principalKind: PolicyPrincipalKind | null;
+	principalId: string | null;
 	entityTypeSlug: string | null;
 	fieldPath: string | null;
 	entityId: number | null;
@@ -47,6 +69,9 @@ export interface EntityApprovalPolicy {
 }
 
 export interface EntityApprovalPolicyInput {
+	resourceClass?: WriteResourceClass;
+	principalKind?: PolicyPrincipalKind | null;
+	principalId?: string | null;
 	entityTypeSlug?: string | null;
 	fieldPath?: string | null;
 	entityId?: number | null;
@@ -62,6 +87,9 @@ export interface EntityApprovalPolicyInput {
 type EntityApprovalPolicyRow = {
 	id: number;
 	organization_id: string;
+	resource_class: string;
+	principal_kind: string | null;
+	principal_id: string | null;
 	entity_type_slug: string | null;
 	field_path: string | null;
 	entity_id: number | null;
@@ -74,9 +102,20 @@ type EntityApprovalPolicyRow = {
 	approval_channel_name: string | null;
 };
 
+
 export function isEntityMutationMode(
 	value: unknown,
 ): value is EntityMutationMode {
+	return (
+		value === "auto" ||
+		value === "approval" ||
+		value === "deny" ||
+		value === "disabled"
+	);
+}
+
+/** The two modes the entity-approval UI/API accept for create/update/delete. */
+export function isEntityApprovalUiMode(value: unknown): value is "auto" | "approval" {
 	return value === "auto" || value === "approval";
 }
 
@@ -87,10 +126,21 @@ function normalizeMode(
 	return isEntityMutationMode(value) ? value : fallback;
 }
 
+function normalizeResourceClass(value: unknown): WriteResourceClass {
+	return value === "connector_action" ? "connector_action" : "entity";
+}
+
+function normalizePrincipalKind(value: unknown): PolicyPrincipalKind | null {
+	return value === "agent" || value === "watcher" ? value : null;
+}
+
 function rowToPolicy(row: EntityApprovalPolicyRow): EntityApprovalPolicy {
 	return {
 		id: Number(row.id),
 		organizationId: row.organization_id,
+		resourceClass: normalizeResourceClass(row.resource_class),
+		principalKind: normalizePrincipalKind(row.principal_kind),
+		principalId: row.principal_id,
 		entityTypeSlug: row.entity_type_slug,
 		fieldPath: row.field_path,
 		entityId: row.entity_id === null ? null : Number(row.entity_id),
@@ -112,6 +162,9 @@ export function defaultEntityApprovalPolicy(
 	return {
 		id: 0,
 		organizationId,
+		resourceClass: "entity",
+		principalKind: null,
+		principalId: null,
 		entityTypeSlug: null,
 		fieldPath: null,
 		entityId: null,
@@ -168,29 +221,73 @@ function modeForAction(
 	return policy.deleteMode;
 }
 
+/**
+ * The winning mode's effect on a mutation. `deny` and `disabled` both stop the
+ * write with no approval queued; `approval` queues one; `auto` applies inline.
+ * Centralized so the create/delete and per-field update paths agree — and so a
+ * future mode can never be read as `allow` by omission.
+ */
+function modeToDecision(mode: EntityMutationMode): EntityPolicyDecision {
+	if (mode === "deny" || mode === "disabled") return "deny";
+	if (mode === "approval") return "require_approval";
+	return "allow";
+}
+
+/**
+ * How specific a candidate row is for the request it survived filtering against.
+ * Higher wins. Principal specificity dominates scope specificity: a row that
+ * names the acting principal always beats a broader-scoped row that targets "any
+ * principal", so an admin can pin one noisy agent/watcher to `approval` without
+ * that being shadowed by a global entity-type default. Within one principal tier,
+ * the entity_id > field_path > entity_type ordering is preserved. Scores never
+ * collide across tiers: principal weights (16/8) sit above every scope weight (≤7).
+ */
 function specificity(row: EntityApprovalPolicyRow): number {
+	const principalScore =
+		row.principal_id !== null ? 16 : row.principal_kind !== null ? 8 : 0;
 	return (
+		principalScore +
 		(row.entity_id !== null ? 4 : 0) +
 		(row.field_path !== null ? 2 : 0) +
 		(row.entity_type_slug !== null ? 1 : 0)
 	);
 }
 
-/** All policy rows that could match this entity type / entity, most specific first. */
+/**
+ * All policy rows that could match this write, most specific first. Filters by
+ * resource class (default `entity`) and by principal: a row applies when it
+ * targets no principal (any), or targets this principal's kind and either no
+ * specific id (any of that kind) or exactly this id.
+ */
 async function loadCandidatePolicies(args: {
 	organizationId: string;
+	resourceClass?: WriteResourceClass;
+	principalKind?: PolicyPrincipalKind | null;
+	principalId?: string | null;
 	entityTypeSlug?: string | null;
 	entityId?: number | null;
 	sql?: DbClient;
 }): Promise<EntityApprovalPolicyRow[]> {
 	const sql = args.sql ?? getDb();
+	const resourceClass = args.resourceClass ?? "entity";
+	const principalKind = args.principalKind ?? null;
+	const principalId = args.principalId ?? null;
 	const rows = await sql<EntityApprovalPolicyRow>`
-    SELECT id, organization_id, entity_type_slug, field_path, entity_id,
+    SELECT id, organization_id, resource_class, principal_kind, principal_id,
+       entity_type_slug, field_path, entity_id,
        create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM entity_approval_policies
     WHERE organization_id = ${args.organizationId}
+      AND resource_class = ${resourceClass}
+      AND (
+        principal_kind IS NULL
+        OR (
+          principal_kind = ${principalKind}
+          AND (principal_id IS NULL OR principal_id = ${principalId})
+        )
+      )
       AND (entity_type_slug IS NULL OR entity_type_slug = ${args.entityTypeSlug ?? null})
       AND (entity_id IS NULL OR entity_id = ${args.entityId ?? null})
   `;
@@ -213,6 +310,7 @@ function pickPolicy(
 	if (!policy.deliveryTarget.connectionId && !policy.deliveryTarget.channelId) {
 		const global = candidates.find(
 			(row) =>
+				row.principal_kind === null &&
 				row.entity_type_slug === null &&
 				row.field_path === null &&
 				row.entity_id === null,
@@ -230,6 +328,9 @@ function pickPolicy(
  */
 export async function resolveEntityApprovalPolicy(args: {
 	organizationId: string;
+	resourceClass?: WriteResourceClass;
+	principalKind?: PolicyPrincipalKind | null;
+	principalId?: string | null;
 	entityTypeSlug?: string | null;
 	fieldPath?: string | null;
 	entityId?: number | null;
@@ -246,6 +347,8 @@ export async function resolveEntityApprovalPolicy(args: {
 export async function evaluateEntityMutation(args: {
 	organizationId: string;
 	principalKind: EntityPolicyPrincipalKind;
+	/** Stable acting-principal id for per-principal matching; null = any of its kind. */
+	principalId?: string | null;
 	action: EntityMutationAction;
 	entityTypeSlug?: string | null;
 	entityId?: number | null;
@@ -256,10 +359,12 @@ export async function evaluateEntityMutation(args: {
 		return "deny";
 	}
 	if (args.principalKind === "user") return "allow";
-	const policy = await resolveEntityApprovalPolicy(args);
-	return modeForAction(policy, args.action) === "approval"
-		? "require_approval"
-		: "allow";
+	const policy = await resolveEntityApprovalPolicy({
+		...args,
+		principalKind: args.principalKind,
+		principalId: args.principalId ?? null,
+	});
+	return modeToDecision(modeForAction(policy, args.action));
 }
 
 /**
@@ -270,6 +375,8 @@ export async function evaluateEntityMutation(args: {
 export async function evaluateEntityFieldUpdates(args: {
 	organizationId: string;
 	principalKind: EntityPolicyPrincipalKind;
+	/** Stable acting-principal id for per-principal matching; null = any of its kind. */
+	principalId?: string | null;
 	entityTypeSlug: string;
 	entityId: number;
 	entityOrgId?: string | null;
@@ -286,13 +393,22 @@ export async function evaluateEntityFieldUpdates(args: {
 		for (const field of Object.keys(args.fields)) decisions[field] = "allow";
 		return decisions;
 	}
-	const candidates = await loadCandidatePolicies(args);
+	const candidates = await loadCandidatePolicies({
+		...args,
+		principalKind: args.principalKind,
+		principalId: args.principalId ?? null,
+	});
 	for (const [field, owner] of Object.entries(args.fields)) {
 		const policy = pickPolicy(candidates, args.organizationId, field);
+		// A human-owned field always needs approval regardless of policy mode; a
+		// deny/disabled policy stops even a human-owned change (deny is a hard floor).
+		const policyDecision = modeToDecision(policy.updateMode);
 		decisions[field] =
-			owner === "human" || policy.updateMode === "approval"
-				? "require_approval"
-				: "allow";
+			policyDecision === "deny"
+				? "deny"
+				: owner === "human" || policyDecision === "require_approval"
+					? "require_approval"
+					: "allow";
 	}
 	return decisions;
 }
@@ -302,12 +418,15 @@ export async function getGlobalEntityApprovalPolicy(
 ): Promise<EntityApprovalPolicy> {
 	const sql = getDb();
 	const rows = await sql<EntityApprovalPolicyRow>`
-    SELECT id, organization_id, entity_type_slug, field_path, entity_id,
+    SELECT id, organization_id, resource_class, principal_kind, principal_id,
+       entity_type_slug, field_path, entity_id,
        create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM entity_approval_policies
     WHERE organization_id = ${organizationId}
+      AND resource_class = 'entity'
+      AND principal_kind IS NULL
       AND entity_type_slug IS NULL
       AND field_path IS NULL
       AND entity_id IS NULL
@@ -318,18 +437,29 @@ export async function getGlobalEntityApprovalPolicy(
 		: defaultEntityApprovalPolicy(organizationId);
 }
 
+/**
+ * Every policy row for an org, most-general first. Filter by class to list one
+ * class's rows (the entity settings page passes `entity`); omit to list all.
+ */
 export async function listEntityApprovalPolicies(
 	organizationId: string,
+	resourceClass?: WriteResourceClass,
 ): Promise<EntityApprovalPolicy[]> {
 	const sql = getDb();
 	const rows = await sql<EntityApprovalPolicyRow>`
-    SELECT id, organization_id, entity_type_slug, field_path, entity_id,
+    SELECT id, organization_id, resource_class, principal_kind, principal_id,
+       entity_type_slug, field_path, entity_id,
        create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM entity_approval_policies
     WHERE organization_id = ${organizationId}
+      AND (${resourceClass ?? null}::text IS NULL OR resource_class = ${resourceClass ?? null})
     ORDER BY
+      resource_class ASC,
+      CASE WHEN principal_kind IS NULL THEN 0 ELSE 1 END,
+      principal_kind ASC NULLS FIRST,
+      principal_id ASC NULLS FIRST,
       CASE WHEN entity_type_slug IS NULL THEN 0 ELSE 1 END,
       entity_type_slug ASC NULLS FIRST,
       CASE WHEN entity_id IS NULL THEN 0 ELSE 1 END,
@@ -357,6 +487,10 @@ export async function upsertEntityApprovalPolicy(
 	organizationId: string,
 	input: EntityApprovalPolicyInput,
 ): Promise<EntityApprovalPolicy> {
+	const resourceClass = normalizeResourceClass(input.resourceClass);
+	const principalKind = normalizePrincipalKind(input.principalKind);
+	// A principal id is only meaningful with a kind; ignore it otherwise.
+	const principalId = principalKind ? input.principalId?.trim() || null : null;
 	const entityTypeSlug = input.entityTypeSlug?.trim() || null;
 	const fieldPath = input.fieldPath?.trim() || null;
 	const entityId = input.entityId ?? null;
@@ -369,8 +503,9 @@ export async function upsertEntityApprovalPolicy(
 	const approvalChannelName = input.approvalChannelName?.trim() || null;
 
 	const sql = getDb();
-	const row = await sql.begin(async (tx) => {
-		const updated = await tx<EntityApprovalPolicyRow>`
+	// The identity tuple the unique index keys on. Reused by both UPDATE arms so
+	// the "lost the insert race" recovery targets the exact same row.
+	const applyUpdate = (tx: DbClient) => tx<EntityApprovalPolicyRow>`
       UPDATE entity_approval_policies
       SET create_mode = ${createMode},
           update_mode = ${updateMode},
@@ -381,31 +516,41 @@ export async function upsertEntityApprovalPolicy(
           approval_channel_name = ${approvalChannelName},
           updated_at = now()
       WHERE organization_id = ${organizationId}
+        AND resource_class = ${resourceClass}
+        AND principal_kind IS NOT DISTINCT FROM ${principalKind}
+        AND principal_id IS NOT DISTINCT FROM ${principalId}
         AND entity_type_slug IS NOT DISTINCT FROM ${entityTypeSlug}
         AND field_path IS NOT DISTINCT FROM ${fieldPath}
         AND entity_id IS NOT DISTINCT FROM ${entityId}
-      RETURNING id, organization_id, entity_type_slug, field_path, entity_id,
+      RETURNING id, organization_id, resource_class, principal_kind, principal_id,
+       entity_type_slug, field_path, entity_id,
        create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     `;
+
+	const row = await sql.begin(async (tx) => {
+		const updated = await applyUpdate(tx);
 		if (updated[0]) return updated[0];
 
 		const inserted = await tx<EntityApprovalPolicyRow>`
       INSERT INTO entity_approval_policies (
-        organization_id, entity_type_slug, field_path, entity_id,
+        organization_id, resource_class, principal_kind, principal_id,
+        entity_type_slug, field_path, entity_id,
         create_mode, update_mode, delete_mode,
         approval_connection_id, approval_channel_id, approval_team_id,
         approval_channel_name, created_at, updated_at
       ) VALUES (
-        ${organizationId}, ${entityTypeSlug}, ${fieldPath}, ${entityId},
+        ${organizationId}, ${resourceClass}, ${principalKind}, ${principalId},
+        ${entityTypeSlug}, ${fieldPath}, ${entityId},
         ${createMode}, ${updateMode}, ${deleteMode},
         ${approvalConnectionId},
         ${approvalChannelId}, ${approvalTeamId}, ${approvalChannelName},
         now(), now()
       )
       ON CONFLICT DO NOTHING
-      RETURNING id, organization_id, entity_type_slug, field_path, entity_id,
+      RETURNING id, organization_id, resource_class, principal_kind, principal_id,
+       entity_type_slug, field_path, entity_id,
        create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
@@ -413,25 +558,7 @@ export async function upsertEntityApprovalPolicy(
 		if (inserted[0]) return inserted[0];
 
 		// Lost the insert race to a concurrent save — apply this request on top.
-		const selected = await tx<EntityApprovalPolicyRow>`
-      UPDATE entity_approval_policies
-      SET create_mode = ${createMode},
-          update_mode = ${updateMode},
-          delete_mode = ${deleteMode},
-          approval_connection_id = ${approvalConnectionId},
-          approval_channel_id = ${approvalChannelId},
-          approval_team_id = ${approvalTeamId},
-          approval_channel_name = ${approvalChannelName},
-          updated_at = now()
-      WHERE organization_id = ${organizationId}
-        AND entity_type_slug IS NOT DISTINCT FROM ${entityTypeSlug}
-        AND field_path IS NOT DISTINCT FROM ${fieldPath}
-        AND entity_id IS NOT DISTINCT FROM ${entityId}
-      RETURNING id, organization_id, entity_type_slug, field_path, entity_id,
-       create_mode, update_mode, delete_mode,
-       approval_connection_id, approval_channel_id, approval_team_id,
-       approval_channel_name
-    `;
+		const selected = await applyUpdate(tx);
 		return selected[0] ?? null;
 	});
 	if (!row) throw new Error("Failed to save entity approval policy");
@@ -440,18 +567,37 @@ export async function upsertEntityApprovalPolicy(
 
 export async function deleteEntityApprovalPolicy(args: {
 	organizationId: string;
+	resourceClass?: WriteResourceClass;
+	principalKind?: PolicyPrincipalKind | null;
+	principalId?: string | null;
 	entityTypeSlug?: string | null;
 	fieldPath?: string | null;
 	entityId?: number | null;
 }): Promise<boolean> {
+	const resourceClass = normalizeResourceClass(args.resourceClass);
+	const principalKind = normalizePrincipalKind(args.principalKind);
+	const principalId = principalKind ? args.principalId?.trim() || null : null;
 	const entityTypeSlug = args.entityTypeSlug?.trim() || null;
 	const fieldPath = args.fieldPath?.trim() || null;
 	const entityId = args.entityId ?? null;
-	if (!entityTypeSlug && !fieldPath && entityId === null) return false;
+	// Guard: never let a request delete the workspace default (entity class, any
+	// principal, unscoped) — that row is the fallback and is edited, not removed.
+	if (
+		resourceClass === "entity" &&
+		principalKind === null &&
+		!entityTypeSlug &&
+		!fieldPath &&
+		entityId === null
+	) {
+		return false;
+	}
 	const sql = getDb();
 	const rows = await sql<{ id: number }>`
     DELETE FROM entity_approval_policies
     WHERE organization_id = ${args.organizationId}
+      AND resource_class = ${resourceClass}
+      AND principal_kind IS NOT DISTINCT FROM ${principalKind}
+      AND principal_id IS NOT DISTINCT FROM ${principalId}
       AND entity_type_slug IS NOT DISTINCT FROM ${entityTypeSlug}
       AND field_path IS NOT DISTINCT FROM ${fieldPath}
       AND entity_id IS NOT DISTINCT FROM ${entityId}

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -127,6 +127,19 @@ function normalizeMode(
 	return isEntityMutationMode(value) ? value : fallback;
 }
 
+/**
+ * Parse a mode that was READ FROM THE DATABASE. Unlike {@link normalizeMode}
+ * (which coerces user INPUT to a caller-chosen default), an unrecognized stored
+ * value fails CLOSED to `deny`: a mode a future build introduced mid-rolling-
+ * upgrade, or corrupt data from manual SQL, must never silently read as `allow`.
+ * The DB CHECK bounds today's values, so this is a defense-in-depth backstop for
+ * exactly the rolling-upgrade case the design calls out — not a reachable path
+ * under normal writes.
+ */
+function parsePersistedMode(value: unknown): EntityMutationMode {
+	return isEntityMutationMode(value) ? value : "deny";
+}
+
 function normalizeResourceClass(value: unknown): WriteResourceClass {
 	if (value === "agent_config") return "agent_config";
 	if (value === "connector_action") return "connector_action";
@@ -147,9 +160,9 @@ function rowToPolicy(row: EntityApprovalPolicyRow): EntityApprovalPolicy {
 		entityTypeSlug: row.entity_type_slug,
 		fieldPath: row.field_path,
 		entityId: row.entity_id === null ? null : Number(row.entity_id),
-		createMode: normalizeMode(row.create_mode, "auto"),
-		updateMode: normalizeMode(row.update_mode, "auto"),
-		deleteMode: normalizeMode(row.delete_mode, "approval"),
+		createMode: parsePersistedMode(row.create_mode),
+		updateMode: parsePersistedMode(row.update_mode),
+		deleteMode: parsePersistedMode(row.delete_mode),
 		deliveryTarget: {
 			connectionId: row.approval_connection_id || null,
 			channelId: row.approval_channel_id,
@@ -275,9 +288,9 @@ function modeRestrictiveness(mode: EntityMutationMode): number {
  */
 function rowRestrictiveness(row: EntityApprovalPolicyRow): number {
 	return Math.max(
-		modeRestrictiveness(normalizeMode(row.create_mode, "auto")),
-		modeRestrictiveness(normalizeMode(row.update_mode, "auto")),
-		modeRestrictiveness(normalizeMode(row.delete_mode, "auto")),
+		modeRestrictiveness(parsePersistedMode(row.create_mode)),
+		modeRestrictiveness(parsePersistedMode(row.update_mode)),
+		modeRestrictiveness(parsePersistedMode(row.delete_mode)),
 	);
 }
 

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -144,6 +144,21 @@ export function classifyMutationPrincipal(args: {
 	return "agent";
 }
 
+/**
+ * Stable identity of the acting non-human principal, for per-principal policy
+ * matching. Watcher → `watcher:<id>`; agent (or automation token with an agent
+ * id) → that id; system/automation token with no id → null ("any agent"). Users
+ * are never policy principals, so this returns null for them too. Kept alongside
+ * {@link classifyMutationPrincipal} so kind and id are computed from one source.
+ */
+export function mutationPrincipalId(args: {
+	agentId?: string | null;
+	watcherId?: number | null;
+}): string | null {
+	if (args.watcherId != null) return `watcher:${args.watcherId}`;
+	return args.agentId ?? null;
+}
+
 function modeForAction(
 	policy: EntityApprovalPolicy,
 	action: EntityMutationAction,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -27,8 +27,8 @@ import { compareWorkerToken } from "./auth/worker-token";
 import {
 	deleteEntityApprovalPolicy,
 	type EntityApprovalPolicy,
-	type EntityMutationMode,
 	getGlobalEntityApprovalPolicy,
+	isEntityApprovalUiMode,
 	listEntityApprovalPolicies,
 	upsertEntityApprovalPolicy,
 	upsertGlobalEntityApprovalPolicy,
@@ -1271,16 +1271,13 @@ app.post("/api/:orgSlug/actions/execute", mcpAuth, async (c) => {
 	return restToolProxy(c, "manage_operations", { action: "execute", ...body });
 });
 
-function isEntityMutationMode(value: unknown): value is EntityMutationMode {
-	return value === "auto" || value === "approval";
-}
-
-function serializeEntityApprovalPolicy(
-	policy: EntityApprovalPolicy,
-) {
+function serializeEntityApprovalPolicy(policy: EntityApprovalPolicy) {
 	return {
 		id: policy.id,
 		organization_id: policy.organizationId,
+		resource_class: policy.resourceClass,
+		principal_kind: policy.principalKind,
+		principal_id: policy.principalId,
 		entity_type_slug: policy.entityTypeSlug,
 		field_path: policy.fieldPath,
 		entity_id: policy.entityId,
@@ -1345,7 +1342,7 @@ app.get("/api/:orgSlug/entity-approval-policy", mcpAuth, async (c) => {
 		return c.json({ error: "Organization context required" }, 401);
 	}
 	const policy = await getGlobalEntityApprovalPolicy(organizationId);
-	const policies = await listEntityApprovalPolicies(organizationId);
+	const policies = await listEntityApprovalPolicies(organizationId, "entity");
 	const channelRows = await resolveBoundChannelRows(getDb(), {
 		organizationId,
 	});
@@ -1389,9 +1386,9 @@ app.patch("/api/:orgSlug/entity-approval-policy", mcpAuth, async (c) => {
 	const updateMode = body.update_mode;
 	const deleteMode = body.delete_mode;
 	if (
-		!isEntityMutationMode(createMode) ||
-		!isEntityMutationMode(updateMode) ||
-		!isEntityMutationMode(deleteMode)
+		!isEntityApprovalUiMode(createMode) ||
+		!isEntityApprovalUiMode(updateMode) ||
+		!isEntityApprovalUiMode(deleteMode)
 	) {
 		return c.json(
 			{
@@ -1402,6 +1399,20 @@ app.patch("/api/:orgSlug/entity-approval-policy", mcpAuth, async (c) => {
 			400,
 		);
 	}
+
+	// Optional per-principal targeting: an admin can pin one agent/watcher to a
+	// stricter mode. principal_id is only meaningful with a kind. Class is fixed to
+	// 'entity' on this endpoint — the connector-action class has its own surface.
+	const principalKind: "agent" | "watcher" | null =
+		body.principal_kind === "agent" || body.principal_kind === "watcher"
+			? body.principal_kind
+			: null;
+	const principalId =
+		principalKind &&
+		typeof body.principal_id === "string" &&
+		body.principal_id.trim()
+			? body.principal_id.trim()
+			: null;
 
 	const approvalConnectionId =
 		typeof body.approval_connection_id === "string" &&
@@ -1505,6 +1516,9 @@ app.patch("/api/:orgSlug/entity-approval-policy", mcpAuth, async (c) => {
 	}
 
 	const policyInput = {
+		resourceClass: "entity" as const,
+		principalKind,
+		principalId,
 		entityTypeSlug,
 		fieldPath,
 		entityId,
@@ -1516,10 +1530,13 @@ app.patch("/api/:orgSlug/entity-approval-policy", mcpAuth, async (c) => {
 		approvalTeamId,
 		approvalChannelName,
 	};
-	const policy =
-		entityTypeSlug || fieldPath || entityId !== null
-			? await upsertEntityApprovalPolicy(organizationId, policyInput)
-			: await upsertGlobalEntityApprovalPolicy(organizationId, policyInput);
+	// Only the unscoped, any-principal entity row is the workspace default; a
+	// principal-targeted or scoped row is a specific override.
+	const isWorkspaceDefault =
+		!principalKind && !entityTypeSlug && !fieldPath && entityId === null;
+	const policy = isWorkspaceDefault
+		? await upsertGlobalEntityApprovalPolicy(organizationId, policyInput)
+		: await upsertEntityApprovalPolicy(organizationId, policyInput);
 
 	invalidationEmitter.emit(organizationId, {
 		keys: ["entity-approval-policy"],
@@ -1535,12 +1552,22 @@ app.delete("/api/:orgSlug/entity-approval-policy", mcpAuth, async (c) => {
 	if (!organizationId) {
 		return c.json({ error: "Organization context required" }, 401);
 	}
+	const principalKindRaw = c.req.query("principal_kind")?.trim();
+	const principalKind =
+		principalKindRaw === "agent" || principalKindRaw === "watcher"
+			? principalKindRaw
+			: null;
+	const principalId = principalKind
+		? c.req.query("principal_id")?.trim() || null
+		: null;
 	const entityTypeSlug = c.req.query("entity_type_slug")?.trim() || null;
 	const fieldPath = c.req.query("field_path")?.trim() || null;
 	const entityIdRaw = c.req.query("entity_id")?.trim();
 	const entityId =
 		entityIdRaw && /^\d+$/.test(entityIdRaw) ? Number(entityIdRaw) : null;
-	if (!entityTypeSlug && !fieldPath && entityId === null) {
+	// A principal-targeted row is deletable even with no scope; only the unscoped,
+	// any-principal default is protected.
+	if (!principalKind && !entityTypeSlug && !fieldPath && entityId === null) {
 		return c.json(
 			{
 				error: "invalid_request",
@@ -1560,6 +1587,9 @@ app.delete("/api/:orgSlug/entity-approval-policy", mcpAuth, async (c) => {
 	}
 	const deleted = await deleteEntityApprovalPolicy({
 		organizationId,
+		resourceClass: "entity",
+		principalKind,
+		principalId,
 		entityTypeSlug,
 		fieldPath,
 		entityId,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1402,7 +1402,10 @@ app.patch("/api/:orgSlug/entity-approval-policy", mcpAuth, async (c) => {
 
 	// Optional per-principal targeting: an admin can pin one agent/watcher to a
 	// stricter mode. principal_id is only meaningful with a kind. Class is fixed to
-	// 'entity' on this endpoint — the connector-action class has its own surface.
+	// 'entity' on this endpoint — connector_action policy rows are ENFORCED by the
+	// gate (manage_operations.execute) but set via SDK/SQL until their own UI
+	// surface lands; this endpoint stays entity-only so its auto/approval mode
+	// validation doesn't have to fork for the deny/disabled connector modes.
 	const principalKind: "agent" | "watcher" | null =
 		body.principal_kind === "agent" || body.principal_kind === "watcher"
 			? body.principal_kind

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -203,38 +203,42 @@ function buildApprovalRenderModel(
 	};
 }
 
-/** In-app Markdown body. */
+/**
+ * In-app Markdown body. Kept tight — the structured approval card (with the
+ * Approve/Reject buttons) is the primary surface; this body is the scannable
+ * one-glance summary above it: WHO wants to do WHAT to WHICH entity, the diff,
+ * and one review link. No "Requested by:/Proposed action:/Why approval is
+ * needed:" scaffolding — a single natural sentence carries it.
+ */
 function renderApprovalBody(
 	model: ApprovalRenderModel,
 	approvalUrl?: string,
 ): string {
 	const lines: string[] = [];
-	if (model.requestedBy) lines.push(`Requested by: ${model.requestedBy}`);
 	const label = escapeNotificationText(
-		model.entityName ?? model.entityTypeLabel ?? "Entity",
+		model.entityName ?? model.entityTypeLabel ?? "this entity",
 	);
 	const entityLink = model.entityUrl
 		? `[${label}](${model.entityUrl})`
 		: model.entityId
 			? `${label} (#${model.entityId})`
-			: model.entityName
-				? label
-				: null;
-	if (entityLink) lines.push(`Entity: ${entityLink}`);
+			: label;
+	const who = model.requestedBy ?? "A watcher";
 
+	// One summary line: "<Watcher> wants to <verb> <entity>."
 	if (model.diffs) {
-		lines.push("", "Proposed change:");
-		for (const d of model.diffs) lines.push(`${d.label}:`, d.diff);
-	}
-	if (model.action) {
-		lines.push("", `Proposed action: ${model.action}`);
+		lines.push(`**${who}** wants to update ${entityLink}:`);
+		for (const d of model.diffs) lines.push(`- ${d.label}: ${d.diff}`);
+	} else {
+		const verb = model.action === "Delete this entity" ? "delete" : "create";
+		lines.push(`**${who}** wants to ${verb} ${entityLink}.`);
 		if (model.proposal.length > 0) {
-			lines.push("");
-			for (const p of model.proposal) lines.push(`${p.label}: ${p.value}`);
+			for (const p of model.proposal) lines.push(`- ${p.label}: ${p.value}`);
 		}
 	}
-	if (model.why) lines.push("", `Why approval is needed: ${model.why}`);
-	if (approvalUrl) lines.push("", `Review: ${formatReviewLink(approvalUrl)}`);
+	// The proposer's own reason, inline and unlabeled (it reads as a sentence).
+	if (model.why) lines.push("", model.why);
+	if (approvalUrl) lines.push("", formatReviewLink(approvalUrl));
 	return lines.join("\n");
 }
 

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -531,6 +531,15 @@ export async function createConnectorOperationRun(params: {
    */
   approvalMode: 'inline' | 'queued' | 'device';
   requireCompiledCode?: boolean;
+  /**
+   * The TRUSTED principal (kind + stable id) that requested this operation,
+   * derived from execution context — never from caller-supplied attribution.
+   * Persisted so a queued run's connector-action policy can be RE-EVALUATED at
+   * approve time against the principal that queued it, not the approver (sol
+   * review #5). Null for a human requester (no per-principal policy applies).
+   */
+  policyPrincipalKind?: 'agent' | 'watcher' | 'user' | null;
+  policyPrincipalId?: string | null;
 }): Promise<number> {
   const sql = getDb();
 
@@ -562,12 +571,15 @@ export async function createConnectorOperationRun(params: {
   const inserted = await sql`
     INSERT INTO runs (
       organization_id, run_type, connection_id, connector_key, connector_version,
-      action_key, action_input, approval_status, status, created_at
+      action_key, action_input, approval_status, status,
+      policy_principal_kind, policy_principal_id, created_at
     ) VALUES (
       ${params.organizationId}, 'action', ${params.connectionId},
       ${params.connectorKey}, ${connectorVersion},
       ${params.operationKey}, ${sql.json(params.operationInput)},
-      ${approvalStatus}, ${status}, current_timestamp
+      ${approvalStatus}, ${status},
+      ${params.policyPrincipalKind ?? null}, ${params.policyPrincipalId ?? null},
+      current_timestamp
     )
     RETURNING id
   `;

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -57,6 +57,13 @@ export interface EntityFieldChangeProposal {
 	/** field_path -> current human-owned value (for the diff card). */
 	current?: Record<string, unknown>;
 	watcher_id?: number | null;
+	/**
+	 * The watcher-run window that produced this proposal, if any. Stamped onto the
+	 * `runs.window_id` COLUMN (never into action_input, so the md5(action_input)
+	 * dedupe identity is unaffected) so a run that produced N proposals groups them
+	 * into ONE batch approval card. Stripped from action_input before the insert.
+	 */
+	window_id?: number | null;
 	/** Who proposed the change — drives the card label/author. Defaults to 'watcher'. */
 	attribution?: "watcher" | "agent";
 	reason?: string | null;
@@ -87,6 +94,8 @@ export interface EntityDeleteProposal {
 		metadata?: Record<string, unknown> | null;
 	};
 	watcher_id?: number | null;
+	/** See EntityFieldChangeProposal.window_id — batches proposals by run window. */
+	window_id?: number | null;
 	attribution?: "watcher" | "agent";
 	reason?: string | null;
 }
@@ -96,6 +105,8 @@ export interface EntityCreateProposal {
 	entity_data: EntityData;
 	proposal: Record<string, unknown>;
 	watcher_id?: number | null;
+	/** See EntityFieldChangeProposal.window_id — batches proposals by run window. */
+	window_id?: number | null;
 	attribution?: "watcher" | "agent";
 	reason?: string | null;
 }
@@ -270,6 +281,10 @@ export async function proposeEntityChange(
 ): Promise<{ runId: number; eventId: number; approvalUrl?: string }> {
 	const sql = getDb();
 	const operation = operationOf(proposal);
+	// window_id groups a run's proposals into one batch card — it rides the
+	// runs.window_id COLUMN, never action_input, so the md5(action_input) dedupe
+	// identity is byte-identical whether or not a window produced the proposal.
+	const { window_id: windowId, ...actionInputProposal } = proposal;
 	const updateProposal =
 		operation === "update" ? asUpdateProposal(proposal) : null;
 	const deleteProposal =
@@ -334,11 +349,12 @@ export async function proposeEntityChange(
 	try {
 		const inserted = await sql`
       INSERT INTO runs (
-        organization_id, run_type, action_key, action_input,
+        organization_id, run_type, action_key, action_input, window_id,
         created_by_user_id, approval_status, status, created_at
       ) VALUES (
         ${ctx.organizationId}, 'internal', ${actionKey},
-        ${sql.json(proposal as unknown as Record<string, unknown>)},
+        ${sql.json(actionInputProposal as unknown as Record<string, unknown>)},
+        ${windowId ?? null},
         null, 'pending', 'pending', current_timestamp
       )
       RETURNING id

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -451,6 +451,10 @@ export async function proposeEntityChange(
 			watcher_id: proposal.watcher_id ?? null,
 			watcher_name: watcherName,
 			watcher_agent_id: watcherAgentId,
+			// The run window this proposal belongs to, if any. Stamped so the UI can
+			// tell this proposal is part of a BATCH (the change-set card owns the
+			// Approve/Reject decision) and suppress this card's own duplicate buttons.
+			window_id: windowId ?? null,
 			entity_name: entityName ?? null,
 			entity_type: entityType ?? null,
 			entity_slug: createProposal ? null : (entity?.slug ?? null),

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -673,7 +673,16 @@ export async function applyEntityChangeProposal(
 	if (operation === "create") {
 		const createProposal = asCreateProposal(proposal);
 		return createEntity(
-			{ ...createProposal.entity_data, organization_id: ctx.organizationId },
+			{
+				...createProposal.entity_data,
+				organization_id: ctx.organizationId,
+				// The watcher that PROPOSED the create is not a real user row, so
+				// entities.created_by (NOT NULL, FK → user) must attribute the create to
+				// the human who APPROVED it. Approval is human-gated (requireHuman-
+				// ApprovalContext), so ctx.userId is a verified user here — using it
+				// avoids the "system" fallback that fails the FK.
+				created_by: ctx.userId ?? createProposal.entity_data.created_by,
+			},
 			{
 				hookContext: {
 					organizationId: ctx.organizationId,

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -314,6 +314,10 @@ export async function proposeEntityChange(
       AND r.action_key = ${actionKey}
       AND r.approval_status = 'pending'
       AND r.status = 'pending'
+      -- Same proposal from a DIFFERENT window is a distinct ask (each window gets
+      -- its own batch card); only a byte-identical replay of the SAME window
+      -- collapses. Matches the runs_entity_change_pending_dedupe unique index.
+      AND r.window_id IS NOT DISTINCT FROM ${windowId ?? null}
       AND COALESCE(r.action_input->>'operation', 'update') = ${operation}
       AND COALESCE(r.action_input->>'entity_id', '') = ${"entity_id" in proposal ? String(proposal.entity_id) : ""}
 	      AND (
@@ -364,7 +368,7 @@ export async function proposeEntityChange(
 		// Two replicas raced the SELECT above with a byte-identical proposal — the
 		// partial unique index (runs_entity_change_pending_dedupe) made one lose.
 		// Resolve to the winner's pending run instead of stacking a duplicate card.
-		if (isUniqueViolation(err, "runs_entity_change_pending_dedupe")) {
+		if (isUniqueViolation(err, "runs_entity_change_pending_dedupe_v2")) {
 			const winner = await findExisting();
 			if (winner.length > 0) return dedupeHit(winner[0]);
 		}

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -24,6 +24,11 @@ import {
   type ManageAgentsProposal,
   type ManageAgentsResult,
 } from '@lobu/core/contracts/tools/manage-agents';
+import {
+  classifyMutationPrincipal,
+  mutationPrincipalId,
+  resolveWritePolicyDecision,
+} from '../../authz/entity-policy';
 import { createDbClientFromEnv, getDb } from '../../db/client';
 import type { Env } from '../../index';
 import { isValidAgentId } from '../../lobu/stores/postgres-stores';
@@ -164,36 +169,70 @@ export async function applyCreate(
 export async function applyUpdate(
   args: ManageAgentsArgs,
   ctx: ToolContext,
-  env: Env
+  env: Env,
+  /**
+   * Pre-image captured when a queued update was proposed. When present, a field
+   * is written only if its live value still equals its pre-image — a stale
+   * approval skips (and reports) fields another writer has since changed. Absent
+   * for immediate (human) applies, which overwrite unconditionally.
+   */
+  base?: ManageAgentsProposal['base']
 ): Promise<ManageAgentsResult> {
   if (!args.agent_id) {
     throw new ToolUserError('agent_id is required for update action');
   }
   const sql = createDbClientFromEnv(env);
-  const updatedFields: string[] = [];
-  if (args.name !== undefined) updatedFields.push('name');
-  if (args.description !== undefined) updatedFields.push('description');
-  if (args.identity_md !== undefined) updatedFields.push('identity_md');
-  if (updatedFields.length === 0) {
+  const requested: string[] = [];
+  if (args.name !== undefined) requested.push('name');
+  if (args.description !== undefined) requested.push('description');
+  if (args.identity_md !== undefined) requested.push('identity_md');
+  if (requested.length === 0) {
     throw new ToolUserError(
       'update requires at least one of: name, description, identity_md'
     );
   }
-  // Per-field CASE WHEN ... THEN ... ELSE col END so only provided fields change
-  // (mirrors manage_watchers crud's partial-update idiom).
-  const rows = await sql`
+  // Each field is written iff (no pre-image given) OR (its live value still
+  // equals the pre-image). `${base ? … : true}` collapses to a constant per
+  // field so the guard is a no-op for immediate applies. IS NOT DISTINCT FROM
+  // matches NULLs. updated_at only bumps when at least one field actually changes.
+  const nameGuard = base ? base.name !== undefined : false;
+  const descGuard = base ? base.description !== undefined : false;
+  const identityGuard = base ? base.identity_md !== undefined : false;
+  const rows = await sql<{ id: string; name: string | null; description: string | null; identity_md: string | null }>`
     UPDATE agents SET
-      updated_at = NOW(),
-      name = CASE WHEN ${args.name !== undefined} THEN ${args.name ?? null} ELSE name END,
-      description = CASE WHEN ${args.description !== undefined} THEN ${args.description ?? null} ELSE description END,
-      identity_md = CASE WHEN ${args.identity_md !== undefined} THEN ${args.identity_md ?? ''} ELSE identity_md END
+      name = CASE
+        WHEN ${args.name !== undefined}
+          AND (${!nameGuard} OR name IS NOT DISTINCT FROM ${base?.name ?? null})
+        THEN ${args.name ?? null} ELSE name END,
+      description = CASE
+        WHEN ${args.description !== undefined}
+          AND (${!descGuard} OR description IS NOT DISTINCT FROM ${base?.description ?? null})
+        THEN ${args.description ?? null} ELSE description END,
+      identity_md = CASE
+        WHEN ${args.identity_md !== undefined}
+          AND (${!identityGuard} OR identity_md IS NOT DISTINCT FROM ${base?.identity_md ?? null})
+        THEN ${args.identity_md ?? ''} ELSE identity_md END,
+      updated_at = NOW()
     WHERE organization_id = ${ctx.organizationId} AND id = ${args.agent_id}
-    RETURNING id
+    RETURNING id, name, description, identity_md
   `;
   if (rows.length === 0) {
     throw new ToolUserError(`Agent "${args.agent_id}" not found`, 404);
   }
-  return { action: 'update', agent_id: args.agent_id, updated_fields: updatedFields };
+  // Report which requested fields actually landed (a stale field was skipped).
+  const after = rows[0];
+  const appliedFields = requested.filter((field) => {
+    if (field === 'name') return after.name === (args.name ?? null);
+    if (field === 'description') return after.description === (args.description ?? null);
+    return after.identity_md === (args.identity_md ?? '');
+  });
+  const skippedFields = requested.filter((f) => !appliedFields.includes(f));
+  return {
+    action: 'update',
+    agent_id: args.agent_id,
+    updated_fields: appliedFields,
+    ...(skippedFields.length > 0 ? { skipped_fields: skippedFields } : {}),
+  };
 }
 
 export async function applyDelete(
@@ -345,6 +384,18 @@ async function queueWriteForApproval(
     throw new ToolUserError(`Agent "${proposal.agent_id}" not found`, 404);
   }
 
+  // Capture the pre-image of each field this update touches, so the eventual
+  // approve applies only fields that haven't since been changed by someone else.
+  if (proposal.action === 'update' && current) {
+    proposal.base = {};
+    if (proposal.name !== undefined)
+      proposal.base.name = (current.name as string | null) ?? null;
+    if (proposal.description !== undefined)
+      proposal.base.description = (current.description as string | null) ?? null;
+    if (proposal.identity_md !== undefined)
+      proposal.base.identity_md = (current.identity_md as string | null) ?? null;
+  }
+
   // Reject a delete of the org's system agent up-front (same guard as
   // applyDelete) so we never surface an un-approvable card.
   if (proposal.action === 'delete') {
@@ -456,7 +507,7 @@ export async function applyManageAgentsProposal(
     case 'create':
       return applyCreate(args, applyCtx, env);
     case 'update':
-      return applyUpdate(args, applyCtx, env);
+      return applyUpdate(args, applyCtx, env, proposal.base);
     case 'delete':
       return applyDelete(args, applyCtx, env);
   }
@@ -489,19 +540,65 @@ async function manageAgentsImpl(
   return runManageAgents(args, env, ctx);
 }
 
-// Write actions (create/update/delete) DON'T run their apply* handler here —
-// they queue a pending run + approval card via queueWriteForApproval, and are
-// applied later by manage_operations' approve handler (which calls
-// applyManageAgentsProposal → the apply* functions). list/get/set_system_agent
-// stay immediate.
+/**
+ * Route one agent write through the `agent_config` write-gate class. The policy
+ * decides per (principal, action): a human member applies immediately, an
+ * agent/watcher-driven write follows the org's policy (default: create/update
+ * queue an approval, delete is denied). `require_approval` → queue a pending run
+ * + card; `allow` → run the apply* handler now; `deny` → refuse.
+ */
+async function dispatchAgentWrite(
+  action: 'create' | 'update' | 'delete',
+  args: ManageAgentsArgs,
+  ctx: ToolContext,
+  env: Env
+): Promise<ManageAgentsResult> {
+  const principalKind = classifyMutationPrincipal({
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+  });
+  const decision = await resolveWritePolicyDecision({
+    organizationId: ctx.organizationId,
+    resourceClass: 'agent_config',
+    principalKind,
+    principalId: mutationPrincipalId({ agentId: ctx.agentId }),
+    action,
+  });
+  if (decision === 'deny') {
+    throw new ToolUserError(
+      `Policy denies ${action} of agents for this principal.`,
+      403
+    );
+  }
+  if (decision === 'require_approval') {
+    return queueWriteForApproval(args, ctx, env);
+  }
+  // allow → apply immediately (validate the proposal first so an immediate apply
+  // enforces the same required-field checks the queued path does).
+  buildProposal(args);
+  switch (action) {
+    case 'create':
+      return applyCreate(args, ctx, env);
+    case 'update':
+      return applyUpdate(args, ctx, env);
+    case 'delete':
+      return applyDelete(args, ctx, env);
+  }
+}
+
+// Write actions (create/update/delete) consult the agent_config write-gate:
+// a human member applies immediately; an agent/watcher-driven write follows the
+// org policy and may queue a pending run + approval card (applied later by
+// manage_operations' approve handler via applyManageAgentsProposal → the apply*
+// functions). list/get/set_system_agent stay immediate.
 const runManageAgents = defineFlatActionTool<ManageAgentsArgs, ManageAgentsResult>(
   'manage_agents',
   {
     list: flatAction((args, ctx, env) => handleList(args, ctx, env)),
     get: flatAction((args, ctx, env) => handleGet(args, ctx, env)),
-    create: flatAction((args, ctx, env) => queueWriteForApproval(args, ctx, env)),
-    update: flatAction((args, ctx, env) => queueWriteForApproval(args, ctx, env)),
-    delete: flatAction((args, ctx, env) => queueWriteForApproval(args, ctx, env)),
+    create: flatAction((args, ctx, env) => dispatchAgentWrite('create', args, ctx, env)),
+    update: flatAction((args, ctx, env) => dispatchAgentWrite('update', args, ctx, env)),
+    delete: flatAction((args, ctx, env) => dispatchAgentWrite('delete', args, ctx, env)),
     set_system_agent: flatAction((args, ctx, env) => handleSetSystemAgent(args, ctx, env)),
   }
 );

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -176,7 +176,18 @@ export async function applyUpdate(
    * approval skips (and reports) fields another writer has since changed. Absent
    * for immediate (human) applies, which overwrite unconditionally.
    */
-  base?: ManageAgentsProposal['base']
+  base?: ManageAgentsProposal['base'],
+  /**
+   * Set by the QUEUED-approval apply path ({@link applyManageAgentsProposal}).
+   * A queued update MUST carry a pre-image for every field it writes — that's
+   * how a stale approval is prevented from clobbering a newer human edit. A
+   * legacy pending run created before this branch has no `base`; without this
+   * flag a missing base read as "overwrite unconditionally" and silently
+   * clobbered the newer value (sol review #8). With it set, a field lacking a
+   * pre-image FAILS CLOSED: the field is skipped and reported, never written on
+   * blind faith. Immediate (human) applies leave this false and overwrite.
+   */
+  requireBase = false
 ): Promise<ManageAgentsResult> {
   if (!args.agent_id) {
     throw new ToolUserError('agent_id is required for update action');
@@ -191,8 +202,26 @@ export async function applyUpdate(
       'update requires at least one of: name, description, identity_md'
     );
   }
-  // Each field is written iff (no pre-image given) OR (its live value still
-  // equals the pre-image). `${base ? … : true}` collapses to a constant per
+  // A queued apply with no pre-image for a requested field can't safely write it
+  // (it might clobber a human edit made after the proposal was queued). Fail that
+  // field closed: drop it from the requested set so its CASE arm never fires and
+  // it's reported as skipped. Legacy pre-`base` runs thus apply nothing rather
+  // than everything. Immediate applies (requireBase=false) are unaffected.
+  const unbackedFields = requireBase
+    ? requested.filter((field) => {
+        if (field === 'name') return base?.name === undefined;
+        if (field === 'description') return base?.description === undefined;
+        return base?.identity_md === undefined;
+      })
+    : [];
+  const writable = requested.filter((f) => !unbackedFields.includes(f));
+  const writeName = args.name !== undefined && writable.includes('name');
+  const writeDesc =
+    args.description !== undefined && writable.includes('description');
+  const writeIdentity =
+    args.identity_md !== undefined && writable.includes('identity_md');
+  // Each writable field is written iff (no pre-image given) OR (its live value
+  // still equals the pre-image). `${base ? … : true}` collapses to a constant per
   // field so the guard is a no-op for immediate applies. IS NOT DISTINCT FROM
   // matches NULLs. updated_at only bumps when at least one field actually changes.
   const nameGuard = base ? base.name !== undefined : false;
@@ -201,15 +230,15 @@ export async function applyUpdate(
   const rows = await sql<{ id: string; name: string | null; description: string | null; identity_md: string | null }>`
     UPDATE agents SET
       name = CASE
-        WHEN ${args.name !== undefined}
+        WHEN ${writeName}
           AND (${!nameGuard} OR name IS NOT DISTINCT FROM ${base?.name ?? null})
         THEN ${args.name ?? null} ELSE name END,
       description = CASE
-        WHEN ${args.description !== undefined}
+        WHEN ${writeDesc}
           AND (${!descGuard} OR description IS NOT DISTINCT FROM ${base?.description ?? null})
         THEN ${args.description ?? null} ELSE description END,
       identity_md = CASE
-        WHEN ${args.identity_md !== undefined}
+        WHEN ${writeIdentity}
           AND (${!identityGuard} OR identity_md IS NOT DISTINCT FROM ${base?.identity_md ?? null})
         THEN ${args.identity_md ?? ''} ELSE identity_md END,
       updated_at = NOW()
@@ -219,9 +248,11 @@ export async function applyUpdate(
   if (rows.length === 0) {
     throw new ToolUserError(`Agent "${args.agent_id}" not found`, 404);
   }
-  // Report which requested fields actually landed (a stale field was skipped).
+  // Report which requested fields actually landed. A field is skipped when its
+  // live value diverged from the pre-image (stale) OR it had no pre-image on a
+  // queued apply (unbacked — never written on blind faith).
   const after = rows[0];
-  const appliedFields = requested.filter((field) => {
+  const appliedFields = writable.filter((field) => {
     if (field === 'name') return after.name === (args.name ?? null);
     if (field === 'description') return after.description === (args.description ?? null);
     return after.identity_md === (args.identity_md ?? '');
@@ -507,7 +538,9 @@ export async function applyManageAgentsProposal(
     case 'create':
       return applyCreate(args, applyCtx, env);
     case 'update':
-      return applyUpdate(args, applyCtx, env, proposal.base);
+      // Queued apply: require a pre-image per field. A legacy pending run with no
+      // `base` thus skips (never blind-overwrites a newer human edit) — fail closed.
+      return applyUpdate(args, applyCtx, env, proposal.base, true);
     case 'delete':
       return applyDelete(args, applyCtx, env);
   }

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -26,6 +26,7 @@ import {
 } from "@lobu/core/contracts/tools/manage-entity";
 import {
 	classifyMutationPrincipal,
+	mutationPrincipalId,
 	type EntityPolicyPrincipalKind,
 } from "../../authz/entity-policy";
 import { runMutationGate } from "../../authz/entity-mutation-gate";
@@ -257,6 +258,10 @@ async function handleCreate(
 		sql: getDb(),
 		attribution,
 		watcherId: args.watcher_source?.watcher_id ?? null,
+		principalId: mutationPrincipalId({
+			agentId: ctx.agentId,
+			watcherId: args.watcher_source?.watcher_id ?? null,
+		}),
 		entityTypeSlug: args.entity_type,
 		entityData,
 		proposal,
@@ -1001,6 +1006,10 @@ async function handleDelete(
 		sql: getDb(),
 		attribution,
 		watcherId: args?.watcher_source?.watcher_id ?? null,
+		principalId: mutationPrincipalId({
+			agentId: ctx.agentId,
+			watcherId: args?.watcher_source?.watcher_id ?? null,
+		}),
 		entityTypeSlug: entity.entity_type,
 		entityId,
 		entityOrgId: null,

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -258,6 +258,7 @@ async function handleCreate(
 		sql: getDb(),
 		attribution,
 		watcherId: args.watcher_source?.watcher_id ?? null,
+		windowId: args.watcher_source?.window_id ?? null,
 		principalId: mutationPrincipalId({
 			agentId: ctx.agentId,
 			watcherId: args.watcher_source?.watcher_id ?? null,
@@ -410,6 +411,7 @@ async function handleUpdate(
 		policyPrincipalKind: principalKindForMutation(args, ctx),
 		attribution: args.watcher_source ? "watcher" : "agent",
 		watcherId: args.watcher_source?.watcher_id ?? null,
+		windowId: args.watcher_source?.window_id ?? null,
 	});
 	const entityDetails =
 		(await getEntity(updatedEntity.id, env, ctx)) ?? updatedEntity;
@@ -1006,6 +1008,7 @@ async function handleDelete(
 		sql: getDb(),
 		attribution,
 		watcherId: args?.watcher_source?.watcher_id ?? null,
+		windowId: args?.watcher_source?.window_id ?? null,
 		principalId: mutationPrincipalId({
 			agentId: ctx.agentId,
 			watcherId: args?.watcher_source?.watcher_id ?? null,

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -46,7 +46,7 @@ import logger from "../../utils/logger";
 import { buildResourcePermalink } from "../../utils/url-builder";
 import { trackWatcherReaction } from "../../utils/watcher-reactions";
 import { dispatchChromeActionToExtension } from "../../worker-api/dispatch-chrome-action";
-import { isAdminOrOwnerRole, isSystemContext } from "../access-control";
+import { isAdminOrOwnerRole } from "../access-control";
 import type { ToolContext } from "../registry";
 import { getOrgUrlContext } from "../view-urls";
 import { action, defineActionTool } from "./action-tool";
@@ -675,14 +675,15 @@ async function handleExecute(
 		agentId: ctx.agentId,
 		watcherSource: args.watcher_source ?? null,
 	});
+	const principalId = mutationPrincipalId({
+		agentId: ctx.agentId,
+		watcherId: args.watcher_source?.watcher_id ?? null,
+	});
 	const policyDecision = await resolveWritePolicyDecision({
 		organizationId: ctx.organizationId,
 		resourceClass: "connector_action",
 		principalKind,
-		principalId: mutationPrincipalId({
-			agentId: ctx.agentId,
-			watcherId: args.watcher_source?.watcher_id ?? null,
-		}),
+		principalId,
 		action: "create",
 	});
 	if (policyDecision === "deny") {
@@ -722,6 +723,10 @@ async function handleExecute(
 		operationInput: input,
 		approvalMode,
 		requireCompiledCode: operation.backend === "local_action",
+		// Persist the TRUSTED principal so a queued run's policy is re-evaluated
+		// at approve time against who queued it, not who approves it (sol #5).
+		policyPrincipalKind: principalKind,
+		policyPrincipalId: principalId,
 	});
 
 	if (args.watcher_source) {
@@ -1331,19 +1336,48 @@ async function isPendingEntityRunOwner(
 }
 
 /**
- * The admin-or-run-owner gate shared by approve/reject. The tool-access tier
+ * Approving/rejecting a run is a HUMAN decision — it must come from a verified
+ * user session, never from any non-human context. This is the security floor
+ * beneath {@link requireApprovalAuthority}'s role check.
+ *
+ * Rejecting `ctx.clientId` alone is not enough: an in-process watcher/system
+ * context runs with `userId=null` and NO client id, so it would slip past a
+ * client-id-only guard AND past {@link isSystemContext}'s role bypass — letting
+ * an automation approve a run it queued (sol review #3). We therefore require a
+ * positive human identity: `userId` present, and no agent identity on the
+ * context. Returns an error result (surfaced to the caller) or null when the
+ * context is a genuine human. One gate, called by every approve/reject entry.
+ */
+function requireHumanApprovalContext(
+	ctx: ToolContext,
+	verb: "approve" | "reject",
+): { error: string } | null {
+	if (ctx.agentId || ctx.clientId) {
+		return {
+			error: `Operation ${verb === "approve" ? "approval" : "rejection"} requires a human web session. Agents cannot ${verb} operations.`,
+		};
+	}
+	if (!ctx.userId) {
+		return {
+			error: `Operation ${verb === "approve" ? "approval" : "rejection"} requires a signed-in user. This request has no verified human identity.`,
+		};
+	}
+	return null;
+}
+
+/**
+ * The admin-or-run-owner gate shared by approve/reject, layered ON TOP of
+ * {@link requireHumanApprovalContext} (which every caller runs first, so a
+ * verified human identity is already guaranteed here). The tool-access tier
  * admits write-tier members so a recorded field owner can decide their own
  * run; everyone else non-admin gets the same admin-access denial the action
- * tier used to throw.
+ * tier used to throw. No system-context bypass — a run decision is always human.
  */
 async function requireApprovalAuthority(
 	action: "approve" | "reject",
 	runId: number,
 	ctx: ToolContext,
 ): Promise<void> {
-	// In-process system calls (userId=null + no member role) bypass role policy
-	// here exactly as they do at the action-router tier.
-	if (isSystemContext(ctx)) return;
 	if (isAdminOrOwnerRole(ctx.memberRole)) return;
 	if (await isPendingEntityRunOwner(runId, ctx.organizationId, ctx.userId)) {
 		return;
@@ -1510,12 +1544,8 @@ async function handleApprove(
 	ctx: ToolContext,
 	env: Env,
 ): Promise<ManageOperationsResult> {
-	if (ctx.clientId) {
-		return {
-			error:
-				"Operation approval requires a web session. Agents cannot approve their own operations.",
-		};
-	}
+	const humanGate = requireHumanApprovalContext(ctx, "approve");
+	if (humanGate) return humanGate;
 	await requireApprovalAuthority("approve", args.run_id, ctx);
 
 	const sql = getDb();
@@ -1533,7 +1563,8 @@ async function handleApprove(
 	if (fieldChangeResult) return fieldChangeResult;
 
 	const pendingRows = await sql`
-    SELECT id, connection_id, action_key, action_input
+    SELECT id, connection_id, action_key, action_input,
+           policy_principal_kind, policy_principal_id
     FROM runs
     WHERE id = ${args.run_id}
       AND organization_id = ${ctx.organizationId}
@@ -1550,6 +1581,8 @@ async function handleApprove(
 		connection_id: number;
 		action_key: string;
 		action_input: Record<string, unknown> | null;
+		policy_principal_kind: string | null;
+		policy_principal_id: string | null;
 	};
 	const resolved = await getOperationForConnection(
 		ctx.organizationId,
@@ -1560,6 +1593,55 @@ async function handleApprove(
 		return {
 			error: `Operation '${pendingRun.action_key}' is no longer available for this connection.`,
 		};
+	}
+
+	// (sol #5) Re-evaluate the connector-action write-gate NOW, at approve time,
+	// against the CURRENT connection mode + org policy — using the trusted
+	// principal persisted when the run was queued (not the approver). A deny or
+	// disabled installed after queueing but before this approval must cancel it,
+	// not sail through on the stale queue-time check.
+	const currentMode = resolveActionMode(
+		resolved.operation,
+		resolved.connection.config,
+	);
+	const recheckPrincipalKind =
+		pendingRun.policy_principal_kind === "agent" ||
+		pendingRun.policy_principal_kind === "watcher"
+			? pendingRun.policy_principal_kind
+			: "user";
+	const recheckDecision =
+		recheckPrincipalKind === "user"
+			? "allow"
+			: await resolveWritePolicyDecision({
+					organizationId: ctx.organizationId,
+					resourceClass: "connector_action",
+					principalKind: recheckPrincipalKind,
+					principalId: pendingRun.policy_principal_id,
+					action: "create",
+				});
+	if (currentMode === "disabled" || recheckDecision === "deny") {
+		const why =
+			currentMode === "disabled"
+				? `Operation '${pendingRun.action_key}' is now disabled on this connection.`
+				: `Policy now denies '${pendingRun.action_key}' for the requesting principal.`;
+		const reviewer = await resolveReviewer(ctx);
+		await sql`
+      UPDATE runs
+      SET approval_status = 'rejected', status = 'cancelled',
+          error_message = ${why}, completed_at = NOW()
+      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+        AND approval_status = 'pending'
+    `;
+		await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"rejected",
+			`${pendingRun.action_key} — blocked by policy`,
+			why,
+			{ reason: why },
+			reviewer,
+		);
+		return { error: `${why} The approval was cancelled.` };
 	}
 
 	const approvedInput = args.input ?? pendingRun.action_input ?? {};
@@ -1666,12 +1748,8 @@ async function handleReject(
 	args: Static<typeof RejectAction>,
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
-	if (ctx.clientId) {
-		return {
-			error:
-				"Operation rejection requires a web session. Agents cannot reject operations.",
-		};
-	}
+	const humanGate = requireHumanApprovalContext(ctx, "reject");
+	if (humanGate) return humanGate;
 	await requireApprovalAuthority("reject", args.run_id, ctx);
 
 	const sql = getDb();
@@ -1766,12 +1844,8 @@ async function handleApproveBatch(
 	ctx: ToolContext,
 	env: Env,
 ): Promise<ManageOperationsResult> {
-	if (ctx.clientId) {
-		return {
-			error:
-				"Batch approval requires a web session. Agents cannot approve their own operations.",
-		};
-	}
+	const humanGate = requireHumanApprovalContext(ctx, "approve");
+	if (humanGate) return humanGate;
 	const runIds = await pendingRunIdsForWindow(args.window_id, ctx.organizationId);
 	if (runIds.length === 0) {
 		return {
@@ -1801,21 +1875,48 @@ async function handleApproveBatch(
 }
 
 /**
+ * The watcher + touched entities behind a window's proposal runs. Resolved from
+ * the change_set event the watcher run recorded for this window (it carries both
+ * watcher_id and the entity_ids the run touched), so the rejection feedback can
+ * be keyed to the watcher and associated with those entities.
+ */
+async function resolveWindowRevisionContext(
+	windowId: number,
+	organizationId: string,
+): Promise<{ watcherId: number | null; entityIds: number[] }> {
+	const sql = getDb();
+	const rows = await sql<{ watcher_id: string | null; entity_ids: number[] | null }>`
+    SELECT (metadata->>'watcher_id')::bigint AS watcher_id, entity_ids
+    FROM events
+    WHERE organization_id = ${organizationId}
+      AND semantic_type = 'change_set'
+      AND (metadata->>'window_id')::bigint = ${windowId}
+    ORDER BY id DESC
+    LIMIT 1
+  `;
+	if (rows.length === 0) return { watcherId: null, entityIds: [] };
+	return {
+		watcherId: rows[0].watcher_id != null ? Number(rows[0].watcher_id) : null,
+		entityIds: (rows[0].entity_ids ?? []).map(Number),
+	};
+}
+
+/**
  * Reject every pending proposal a watcher run produced, feeding the reason back
- * so the user can ask the agent to revise (the conversational revision loop —
- * no inline diff editor). Reuses the single-run reject path per proposal, then
- * records ONE feedback event on the run carrying the reason.
+ * so the watcher's next run revises (the conversational revision loop — no inline
+ * diff editor). Reuses the single-run reject path per proposal, then records the
+ * reason as a `correction` feedback event keyed to the watcher — the SAME channel
+ * getRecentFeedbackSummary injects into future watcher runs. That closes the loop
+ * for real: the run view shows why the batch was rejected AND the watcher's next
+ * turn reads "Past Corrections from User Feedback" and adjusts, rather than the
+ * feedback sitting inert (sol review #10).
  */
 async function handleRejectBatch(
 	args: Static<typeof RejectBatchAction>,
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
-	if (ctx.clientId) {
-		return {
-			error:
-				"Batch rejection requires a web session. Agents cannot reject operations.",
-		};
-	}
+	const humanGate = requireHumanApprovalContext(ctx, "reject");
+	if (humanGate) return humanGate;
 	const runIds = await pendingRunIdsForWindow(args.window_id, ctx.organizationId);
 	const reason = args.reason ?? "Rejected by user";
 	let rejected = 0;
@@ -1823,19 +1924,32 @@ async function handleRejectBatch(
 		const result = await handleReject({ action: "reject", run_id: runId, reason }, ctx);
 		if (!("error" in result)) rejected += 1;
 	}
-	// One feedback event on the window/run carrying the reason, so the run view
-	// shows why the batch was rejected and the agent's next turn can read it.
 	if (rejected > 0) {
+		const { watcherId, entityIds } = await resolveWindowRevisionContext(
+			args.window_id,
+			ctx.organizationId,
+		);
+		// A `correction` event — the durable, run-linked revision channel. Keyed to
+		// the watcher (getRecentFeedbackSummary reads by watcher_id) and associated
+		// with the entities the run touched, so both the watcher's next turn and the
+		// entity/run views surface it. field_path='$batch_reject' marks it a
+		// whole-run rejection (distinct from a single-field correction); the reason
+		// rides `note`, which the summary renders verbatim.
 		await insertEvent({
-			entityIds: [],
+			entityIds,
 			organizationId: ctx.organizationId,
 			originId: `window_${args.window_id}_batch_reject`,
 			title: `Batch rejected — ${rejected} proposals`,
 			content: `The user rejected this run's proposals: ${reason}`,
-			semanticType: "change_set",
+			semanticType: "correction",
+			createdBy: ctx.userId ?? null,
 			metadata: {
 				kind: "watcher_batch_reject",
 				window_id: args.window_id,
+				watcher_id: watcherId,
+				field_path: "$batch_reject",
+				mutation: "set",
+				note: reason,
 				rejected_count: rejected,
 				reason,
 			},
@@ -1848,7 +1962,7 @@ async function handleRejectBatch(
 		run_ids: runIds,
 		message:
 			rejected > 0
-				? `Rejected ${rejected} proposals. Ask the agent to revise them with your feedback.`
+				? `Rejected ${rejected} proposals. The watcher's next run will see this feedback and revise.`
 				: "No pending proposals for this run.",
 	};
 }

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -25,6 +25,11 @@ import { getDb, pgBigintArray, pgTextArray } from "../../db/client";
 import type { Env } from "../../index";
 import { callTool as callProxyTool } from "../../mcp-proxy/client";
 import { resolveCredentialsByConnectionId } from "../../mcp-proxy/credential-resolver";
+import {
+	classifyMutationPrincipal,
+	mutationPrincipalId,
+	resolveWritePolicyDecision,
+} from "../../authz/entity-policy";
 import { notifyActionApprovalNeeded } from "../../notifications/triggers";
 import { resolveActionMode } from "../../operations/action-modes";
 import {
@@ -658,7 +663,34 @@ async function handleExecute(
 			error: `Operation '${operation.operation_key}' is disabled on this connection.`,
 		};
 	}
-	const shouldQueue = mode === "approval";
+
+	// Org-level connector-action policy, from the SAME write-gate the entity and
+	// agent_config classes use. It folds with the per-connection action_modes by
+	// restrictive-wins: a `deny` blocks outright; an `approval` upgrades a
+	// connection that would auto-run to queued. A human applies immediately (the
+	// policy governs non-human principals); with no policy row, the class default
+	// is auto, so the connection mode alone decides — today's behavior is intact.
+	const principalKind = classifyMutationPrincipal({
+		userId: ctx.userId,
+		agentId: ctx.agentId,
+		watcherSource: args.watcher_source ?? null,
+	});
+	const policyDecision = await resolveWritePolicyDecision({
+		organizationId: ctx.organizationId,
+		resourceClass: "connector_action",
+		principalKind,
+		principalId: mutationPrincipalId({
+			agentId: ctx.agentId,
+			watcherId: args.watcher_source?.watcher_id ?? null,
+		}),
+		action: "create",
+	});
+	if (policyDecision === "deny") {
+		return {
+			error: `Policy denies '${operation.operation_key}' for this principal.`,
+		};
+	}
+	const shouldQueue = mode === "approval" || policyDecision === "require_approval";
 
 	// Detect device-bound connector by reading the connector definition's
 	// `runtime` field. When set (e.g. chrome-extension, macos, ios), the

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -21,7 +21,12 @@ import {
 	RejectBatchAction,
 } from "@lobu/core/contracts/tools/manage-operations";
 import type { Static } from "@sinclair/typebox";
-import { getDb, pgBigintArray, pgTextArray } from "../../db/client";
+import {
+	getDb,
+	parsePgNumberArray,
+	pgBigintArray,
+	pgTextArray,
+} from "../../db/client";
 import type { Env } from "../../index";
 import { callTool as callProxyTool } from "../../mcp-proxy/client";
 import { resolveCredentialsByConnectionId } from "../../mcp-proxy/credential-resolver";
@@ -1885,7 +1890,7 @@ async function resolveWindowRevisionContext(
 	organizationId: string,
 ): Promise<{ watcherId: number | null; entityIds: number[] }> {
 	const sql = getDb();
-	const rows = await sql<{ watcher_id: string | null; entity_ids: number[] | null }>`
+	const rows = await sql<{ watcher_id: string | null; entity_ids: unknown }>`
     SELECT (metadata->>'watcher_id')::bigint AS watcher_id, entity_ids
     FROM events
     WHERE organization_id = ${organizationId}
@@ -1897,7 +1902,9 @@ async function resolveWindowRevisionContext(
 	if (rows.length === 0) return { watcherId: null, entityIds: [] };
 	return {
 		watcherId: rows[0].watcher_id != null ? Number(rows[0].watcher_id) : null,
-		entityIds: (rows[0].entity_ids ?? []).map(Number),
+		// entity_ids arrives as a raw PG array string under fetch_types:false — never
+		// call .map on it directly. parsePgNumberArray handles both string and array.
+		entityIds: parsePgNumberArray(rows[0].entity_ids),
 	};
 }
 

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -9,6 +9,7 @@
 import { getErrorMessage } from "@lobu/core";
 import {
 	ApproveAction,
+	ApproveBatchAction,
 	ExecuteAction,
 	GetRunAction,
 	ListAvailableAction,
@@ -17,6 +18,7 @@ import {
 	ManageOperationsResultSchema,
 	ManageOperationsSchema,
 	RejectAction,
+	RejectBatchAction,
 } from "@lobu/core/contracts/tools/manage-operations";
 import type { Static } from "@sinclair/typebox";
 import { getDb, pgBigintArray, pgTextArray } from "../../db/client";
@@ -80,6 +82,8 @@ const manageOperationsTool = defineActionTool('manage_operations', {
   get_run: action(GetRunAction, handleGetRun),
   approve: action(ApproveAction, handleApprove),
   reject: action(RejectAction, handleReject),
+  approve_batch: action(ApproveBatchAction, handleApproveBatch),
+  reject_batch: action(RejectBatchAction, handleRejectBatch),
 });
 
 export { ManageOperationsResultSchema, ManageOperationsSchema };
@@ -1700,5 +1704,119 @@ async function handleReject(
 		rejected: true,
 		run_id: args.run_id,
 		event_id: eventId,
+	};
+}
+
+/** Pending proposal runs a single watcher run produced, grouped by its window. */
+async function pendingRunIdsForWindow(
+	windowId: number,
+	organizationId: string,
+): Promise<number[]> {
+	const sql = getDb();
+	const rows = await sql<{ id: number }>`
+    SELECT id FROM runs
+    WHERE window_id = ${windowId}
+      AND organization_id = ${organizationId}
+      AND approval_status = 'pending'
+      AND run_type = 'internal'
+    ORDER BY id ASC
+  `;
+	return rows.map((r) => Number(r.id));
+}
+
+/**
+ * Approve every pending proposal a watcher run produced, in one action. Reuses
+ * the single-run approve path per proposal so each still applies through its own
+ * gate/apply handler — the batch is purely the grouping, not a second code path.
+ */
+async function handleApproveBatch(
+	args: Static<typeof ApproveBatchAction>,
+	ctx: ToolContext,
+	env: Env,
+): Promise<ManageOperationsResult> {
+	if (ctx.clientId) {
+		return {
+			error:
+				"Batch approval requires a web session. Agents cannot approve their own operations.",
+		};
+	}
+	const runIds = await pendingRunIdsForWindow(args.window_id, ctx.organizationId);
+	if (runIds.length === 0) {
+		return {
+			action: "approve_batch",
+			window_id: args.window_id,
+			approved_count: 0,
+			failed_count: 0,
+			run_ids: [],
+			message: "No pending proposals for this run.",
+		};
+	}
+	let approved = 0;
+	let failed = 0;
+	for (const runId of runIds) {
+		const result = await handleApprove({ action: "approve", run_id: runId }, ctx, env);
+		if ("error" in result) failed += 1;
+		else approved += 1;
+	}
+	return {
+		action: "approve_batch",
+		window_id: args.window_id,
+		approved_count: approved,
+		failed_count: failed,
+		run_ids: runIds,
+		message: `Approved ${approved} of ${runIds.length} proposals${failed > 0 ? ` (${failed} failed)` : ""}.`,
+	};
+}
+
+/**
+ * Reject every pending proposal a watcher run produced, feeding the reason back
+ * so the user can ask the agent to revise (the conversational revision loop —
+ * no inline diff editor). Reuses the single-run reject path per proposal, then
+ * records ONE feedback event on the run carrying the reason.
+ */
+async function handleRejectBatch(
+	args: Static<typeof RejectBatchAction>,
+	ctx: ToolContext,
+): Promise<ManageOperationsResult> {
+	if (ctx.clientId) {
+		return {
+			error:
+				"Batch rejection requires a web session. Agents cannot reject operations.",
+		};
+	}
+	const runIds = await pendingRunIdsForWindow(args.window_id, ctx.organizationId);
+	const reason = args.reason ?? "Rejected by user";
+	let rejected = 0;
+	for (const runId of runIds) {
+		const result = await handleReject({ action: "reject", run_id: runId, reason }, ctx);
+		if (!("error" in result)) rejected += 1;
+	}
+	// One feedback event on the window/run carrying the reason, so the run view
+	// shows why the batch was rejected and the agent's next turn can read it.
+	if (rejected > 0) {
+		await insertEvent({
+			entityIds: [],
+			organizationId: ctx.organizationId,
+			originId: `window_${args.window_id}_batch_reject`,
+			title: `Batch rejected — ${rejected} proposals`,
+			content: `The user rejected this run's proposals: ${reason}`,
+			semanticType: "change_set",
+			metadata: {
+				kind: "watcher_batch_reject",
+				window_id: args.window_id,
+				rejected_count: rejected,
+				reason,
+			},
+		});
+	}
+	return {
+		action: "reject_batch",
+		window_id: args.window_id,
+		rejected_count: rejected,
+		run_ids: runIds,
+		message:
+			rejected > 0
+				? `Rejected ${rejected} proposals. Ask the agent to revise them with your feedback.`
+				: "No pending proposals for this run.",
 	};
 }

--- a/packages/server/src/tools/admin/manage_watchers/complete-window.ts
+++ b/packages/server/src/tools/admin/manage_watchers/complete-window.ts
@@ -537,6 +537,38 @@ export async function handleCompleteWindow(
       // flush each AFTER the window transaction commits (approvals must not ride
       // the tx).
       deferredApprovals = promote.deferred;
+
+      // Record the applied change-set as a FIRST-CLASS event on the run — even
+      // for fully-auto promotions. The diff is a property of the run, not of the
+      // approval flow: a watcher run that auto-applied 100 entity changes still
+      // shows exactly what it changed. Rides the window tx (it describes writes
+      // that just committed on this same tx) and is scoped to the run + the
+      // entities it touched, so the run view and the entity views both resolve it.
+      if (promote.changes.length > 0 && watcherRunId && Number.isFinite(watcherRunId)) {
+        const createdCount = promote.changes.filter((c) => c.kind === 'created').length;
+        const updatedCount = promote.changes.length - createdCount;
+        await insertEvent(
+          {
+            entityIds: promote.changes.map((c) => c.entityId),
+            organizationId: watcherOrgId,
+            originId: `run_${watcherRunId}_changeset`,
+            title: `Watcher applied ${createdCount} new + ${updatedCount} updated`,
+            content: `This run created ${createdCount} and updated ${updatedCount} entities.`,
+            semanticType: 'change_set',
+            runId: watcherRunId,
+            metadata: {
+              kind: 'watcher_change_set',
+              window_id: windowId,
+              watcher_id: Number(watcherId),
+              created_count: createdCount,
+              updated_count: updatedCount,
+              changes: promote.changes,
+            },
+            createdBy: watcherCreatedBy,
+          },
+          { sql: tx }
+        );
+      }
     }
 
     // ============================================

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -8,7 +8,7 @@
 
 import type { ContentItem } from '@lobu/connector-sdk';
 import { hasRequiredMcpScope } from '../../auth/tool-access';
-import { createDbClientFromEnv, getDb } from '../../db/client';
+import { createDbClientFromEnv, getDb, pgBigintArray } from '../../db/client';
 import type { Env } from '../../index';
 import { ToolUserError } from '../../utils/errors';
 import {
@@ -37,6 +37,51 @@ import { GetContentSchema, type GetContentArgs, getIncludeSupersededValidationEr
 import type { ContentRow, GetContentResult, IdRow } from './types';
 import { handleWatcherMode } from './watcher-mode';
 import { withValidatedArgs } from '../validate-args';
+
+/**
+ * Stamp `metadata.pending_proposal_count` onto every `change_set` content item,
+ * counting the pending proposal runs still open for its window. The change_set
+ * event is permanent, so its batch Approve/Reject buttons can't derive their
+ * visibility from the event alone — a resolved window would keep showing live
+ * buttons that error on click. One batched query over all present windows keeps
+ * this off the per-item hot path; items with no window are left untouched.
+ */
+async function stampPendingProposalCounts(
+  sql: ReturnType<typeof getDb>,
+  organizationId: string,
+  items: ContentItem[]
+): Promise<void> {
+  const windowIds = new Set<number>();
+  for (const item of items) {
+    if (item.semantic_type !== 'change_set') continue;
+    const wid = (item.metadata as Record<string, unknown> | undefined)?.window_id;
+    if (typeof wid === 'number') windowIds.add(wid);
+  }
+  if (windowIds.size === 0) return;
+
+  const rows = await sql<{ window_id: number; pending: number }>`
+    SELECT window_id, COUNT(*)::int AS pending
+    FROM runs
+    WHERE organization_id = ${organizationId}
+      AND run_type = 'internal'
+      AND approval_status = 'pending'
+      AND window_id = ANY(${pgBigintArray([...windowIds])}::bigint[])
+    GROUP BY window_id
+  `;
+  const pendingByWindow = new Map<number, number>();
+  for (const r of rows) pendingByWindow.set(Number(r.window_id), Number(r.pending));
+
+  for (const item of items) {
+    if (item.semantic_type !== 'change_set') continue;
+    const metadata = (item.metadata ?? {}) as Record<string, unknown>;
+    const wid = metadata.window_id;
+    if (typeof wid !== 'number') continue;
+    item.metadata = {
+      ...metadata,
+      pending_proposal_count: pendingByWindow.get(wid) ?? 0,
+    };
+  }
+}
 
 // ============================================
 // Main Function
@@ -438,6 +483,13 @@ async function getContentImpl(
       baseUrl,
       excerptsMap,
     });
+
+    // Stamp a LIVE pending-proposal count onto every change_set card. The
+    // change_set event is permanent (it records what the run did), so its
+    // batch Approve/Reject buttons must key off the CURRENT run state — not the
+    // event itself — or they linger after every proposal is resolved and a
+    // second click hits an already-decided run ("Run not found or not pending").
+    await stampPendingProposalCounts(sql, ctx.organizationId, contentItems);
 
     const result: GetContentResult = {
       content: contentItems,

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -109,6 +109,12 @@ export interface EntityData {
   // Organization scoping
   organization_id?: string;
 
+  // Attribution: entities.created_by is NOT NULL and FK → user. Set explicitly by
+  // the approval-apply path to the approving human (a watcher/agent proposer isn't
+  // a user row). Falls back to "system" — which is only valid where a matching
+  // user exists — when omitted.
+  created_by?: string | null;
+
   // Common fields
   enabled_classifiers?: string[] | null;
 
@@ -314,7 +320,7 @@ export async function createEntity(
 
 	const metadata = mergeConvenienceFields(data, data.metadata || {}, "create");
 
-	const createdBy = (data as any).created_by || "system";
+	const createdBy = data.created_by || "system";
 
 	// Validate parent hierarchy (replaces prevent_entity_cycles trigger)
 	if (data.parent_id) {

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -15,6 +15,7 @@ import {
 	type MutationPrincipalKind,
 	runMutationGate,
 } from "../authz/entity-mutation-gate";
+import { mutationPrincipalId } from "../authz/entity-policy";
 import {
 	createDbClientFromEnv,
 	type DbClient,
@@ -533,6 +534,10 @@ export async function updateEntity(
 					sql: tx,
 					attribution: opts?.attribution ?? "agent",
 					watcherId: opts?.watcherId ?? null,
+					principalId: mutationPrincipalId({
+						agentId: ctx.agentId,
+						watcherId: opts?.watcherId ?? null,
+					}),
 					entityTypeSlug: String(current[0].entity_type),
 					entityId,
 					entityOrgId: String(current[0].organization_id),

--- a/packages/server/src/utils/entity-management.ts
+++ b/packages/server/src/utils/entity-management.ts
@@ -43,6 +43,8 @@ interface EntityUpdateOptions {
 	/** Attribution for a deferred approval of blocked fields. Defaults to 'agent'. */
 	attribution?: MutationAttribution;
 	watcherId?: number | null;
+	/** Watcher-run window, so a deferred approval groups into its per-window batch. */
+	windowId?: number | null;
 }
 
 // ============================================
@@ -534,6 +536,7 @@ export async function updateEntity(
 					sql: tx,
 					attribution: opts?.attribution ?? "agent",
 					watcherId: opts?.watcherId ?? null,
+					windowId: opts?.windowId ?? null,
 					principalId: mutationPrincipalId({
 						agentId: ctx.agentId,
 						watcherId: opts?.watcherId ?? null,
@@ -643,6 +646,7 @@ export async function updateEntity(
 				),
 				attribution: opts?.attribution ?? "agent",
 				watcherId: opts?.watcherId ?? null,
+				windowId: opts?.windowId ?? null,
 			}),
 		};
 	}

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -43,7 +43,11 @@ import {
 import { mutationPrincipalId } from '../authz/entity-policy';
 import type { DbClient } from '../db/client';
 import type { KeyingConfig } from '../types/watchers';
-import { type BlockedChange, mergeEntityFields } from './entity-field-merge';
+import {
+  type AppliedChange,
+  type BlockedChange,
+  mergeEntityFields,
+} from './entity-field-merge';
 import { getValueAtPath } from './object-path';
 import logger from './logger';
 import { isUniqueViolation } from './pg-errors';
@@ -72,6 +76,20 @@ export interface PromoteKeyedEntitiesParams {
   createdBy?: string | null;
 }
 
+/**
+ * One entity this run touched inline, for the first-class run change-set. Emitted
+ * for auto-applied changes too — the diff is a property of the run, not of the
+ * approval flow, so a fully-auto watcher run still shows exactly what it changed.
+ */
+export interface PromotedEntityChange {
+  entityId: number;
+  name: string;
+  /** `created` = brand-new entity; `updated` = existing entity whose fields changed. */
+  kind: 'created' | 'updated';
+  /** For `updated`, the fields written inline (old→new). Empty for `created`. */
+  applied: Record<string, AppliedChange>;
+}
+
 export interface PromoteKeyedEntitiesResult {
   /** Number of distinct keyed rows that resolved to an entity. */
   promoted: number;
@@ -83,6 +101,12 @@ export interface PromoteKeyedEntitiesResult {
    * (never writing inline, never on the caller's tx).
    */
   deferred: DeferredMutation[];
+  /**
+   * The applied change-set: every entity this run created or updated inline. The
+   * caller records this as a first-class event on the run so the change is
+   * visible on the run itself, independent of any approval.
+   */
+  changes: PromotedEntityChange[];
 }
 
 /**
@@ -273,6 +297,8 @@ async function upsertKeyedEntity(params: {
   entityId: number;
   created: boolean;
   blocked: Record<string, BlockedChange>;
+  /** Fields the watcher actually wrote inline (auto-applied), old→new. */
+  applied: Record<string, AppliedChange>;
   blockedCreate: boolean;
 }> {
   const { tx, organizationId, identifier } = params;
@@ -328,14 +354,20 @@ async function upsertKeyedEntity(params: {
       actorId: null,
       requireApproval,
     });
-    return { entityId, created: false, blocked: merge.blocked, blockedCreate: false };
+    return {
+      entityId,
+      created: false,
+      blocked: merge.blocked,
+      applied: merge.applied,
+      blockedCreate: false,
+    };
   }
 
   // Org policy holds creates of this type for approval — no insert, no identity
   // claim. The caller queues a durable create proposal post-commit; when it is
   // approved and re-promoted, the identity claim above dedupes as usual.
   if (params.createNeedsApproval) {
-    return { entityId: 0, created: false, blocked: {}, blockedCreate: true };
+    return { entityId: 0, created: false, blocked: {}, applied: {}, blockedCreate: true };
   }
 
   // 2. Create the entity (sequence-allocated id — multi-replica safe),
@@ -366,7 +398,7 @@ async function upsertKeyedEntity(params: {
     RETURNING entity_id
   `;
   if (claimed.length > 0) {
-    return { entityId, created: true, blocked: {}, blockedCreate: false };
+    return { entityId, created: true, blocked: {}, applied: {}, blockedCreate: false };
   }
 
   // Lost the race: another live transaction already claimed this key. Resolve
@@ -390,11 +422,17 @@ async function upsertKeyedEntity(params: {
       DELETE FROM entities
       WHERE id = ${entityId} AND organization_id = ${organizationId}
     `;
-    return { entityId: Number(winner[0].entity_id), created: false, blocked: {}, blockedCreate: false };
+    return {
+      entityId: Number(winner[0].entity_id),
+      created: false,
+      blocked: {},
+      applied: {},
+      blockedCreate: false,
+    };
   }
   // Extremely unlikely: the conflicting claim was tombstoned between our INSERT
   // and this re-read. Keep our entity as the canonical one.
-  return { entityId, created: true, blocked: {}, blockedCreate: false };
+  return { entityId, created: true, blocked: {}, applied: {}, blockedCreate: false };
 }
 
 /**
@@ -419,6 +457,7 @@ export async function promoteKeyedEntities(
     promoted: 0,
     created: 0,
     deferred: [],
+    changes: [],
   };
 
   const rows = getValueAtPath(extractedData, keyingConfig.entity_path);
@@ -502,7 +541,7 @@ export async function promoteKeyedEntities(
     };
 
     try {
-      const { created, blocked, entityId, blockedCreate } = await tx.savepoint((sp) =>
+      const { created, blocked, applied, entityId, blockedCreate } = await tx.savepoint((sp) =>
         upsertKeyedEntity({
           tx: sp,
           organizationId,
@@ -540,6 +579,7 @@ export async function promoteKeyedEntities(
               proposal: createProposal,
               attribution: 'watcher',
               watcherId,
+              windowId,
             })
           );
         }
@@ -547,6 +587,14 @@ export async function promoteKeyedEntities(
       }
       result.promoted += 1;
       if (created) result.created += 1;
+      // Record the applied change on the run's change-set. A brand-new entity is
+      // a `created` change; an existing entity is `updated` only if the watcher
+      // actually wrote a field inline (an all-blocked or no-op sync adds nothing).
+      if (created) {
+        result.changes.push({ entityId, name, kind: 'created', applied: {} });
+      } else if (Object.keys(applied).length > 0) {
+        result.changes.push({ entityId, name, kind: 'updated', applied });
+      }
       const blockedFields = Object.keys(blocked);
       if (blockedFields.length > 0) {
         result.deferred.push(
@@ -556,6 +604,7 @@ export async function promoteKeyedEntities(
             current: Object.fromEntries(blockedFields.map((f) => [f, blocked[f].current])),
             attribution: 'watcher',
             watcherId,
+            windowId,
           })
         );
       }

--- a/packages/server/src/utils/promote-keyed-entities.ts
+++ b/packages/server/src/utils/promote-keyed-entities.ts
@@ -40,6 +40,7 @@ import {
   type DeferredMutation,
   runMutationGate,
 } from '../authz/entity-mutation-gate';
+import { mutationPrincipalId } from '../authz/entity-policy';
 import type { DbClient } from '../db/client';
 import type { KeyingConfig } from '../types/watchers';
 import { type BlockedChange, mergeEntityFields } from './entity-field-merge';
@@ -264,6 +265,8 @@ async function upsertKeyedEntity(params: {
   /** Extracted entity field values to sync into metadata (excludes the stable key). */
   fieldValues: Record<string, unknown>;
   createdBy: string;
+  /** Watcher whose run is promoting this entity — used for per-principal policy. */
+  watcherId: number;
   /** Org policy: creates of this type queue an approval instead of inserting. */
   createNeedsApproval: boolean;
 }): Promise<{
@@ -300,6 +303,8 @@ async function upsertKeyedEntity(params: {
       principalKind: 'watcher',
       sql: tx,
       attribution: 'watcher',
+      watcherId: params.watcherId,
+      principalId: mutationPrincipalId({ agentId: null, watcherId: params.watcherId }),
       entityTypeSlug: params.entityTypeSlug,
       entityId,
       fields: Object.fromEntries(
@@ -451,6 +456,7 @@ export async function promoteKeyedEntities(
     sql: tx,
     attribution: 'watcher',
     watcherId,
+    principalId: mutationPrincipalId({ agentId: null, watcherId }),
     entityTypeSlug,
     entityData: { entity_type: entityTypeSlug, name: '' },
     proposal: {},
@@ -509,6 +515,7 @@ export async function promoteKeyedEntities(
           metadata,
           fieldValues,
           createdBy,
+          watcherId,
           createNeedsApproval,
         })
       );

--- a/packages/server/src/utils/watcher-feedback.ts
+++ b/packages/server/src/utils/watcher-feedback.ts
@@ -54,6 +54,16 @@ export async function getRecentFeedbackSummary(
     const value = row.corrected_value;
 
     let line: string;
+    // A whole-run rejection (manage_operations.reject_batch) rather than a
+    // single-field correction: the user turned down the run's proposals with a
+    // reason (in `note`). Render it as guidance for the next run, not a field set.
+    if (path === '$batch_reject') {
+      line = `- Window ${start}–${end}: the user REJECTED this run's proposed changes${
+        row.note ? ` — ${row.note}` : ''
+      }. Revise your extraction accordingly.`;
+      lines.push(line);
+      continue;
+    }
     if (mutation === 'remove') {
       line = `- Window ${start}–${end}: drop "${path}"`;
     } else if (mutation === 'add') {


### PR DESCRIPTION
## What this ships

A generalized **write-gate policy system**: one policy table + resolver + interceptor pipeline that governs every non-human write, with a per-principal axis (a policy can target a specific agent or watcher), and the diff of what a watcher run changed as a first-class artifact on the run itself.

Most of the machinery already existed (~1,640 LOC shipped). This adds the generalization plumbing, the principal axis, agent-config governance, the run change-set + batched approvals, and the UI.

## Stacked commits

1. **M1a expand migration + principal plumbing** — additive, deploy-safe columns on `entity_approval_policies` (`resource_class`, `target_scope_*`, `predicate`, `principal_kind`, `principal_id`); widened mode CHECKs; `principalId` threaded through every entity gate call. No rename, no drop — old pods keep reading the current schema through the whole rollout (dbmate runs in the Helm pre-upgrade hook *before* new pods roll out).
2. **Per-principal resolver + additive API** — the resolver filters by resource class + principal (NULL = any; specific principal outranks scope specificity). Modes gain `deny` (hard floor) and `disabled`; `modeToDecision` centralizes the mapping so no future mode reads as `allow` by omission (fixes the fail-open risk). Generalized unique index; additive PATCH/DELETE API.
3. **manage_agents as the `agent_config` class** — create/update/delete resolve through the shared gate: a human member applies immediately; an agent/watcher-driven write follows policy (default create/update queue approval, delete denied). `applyUpdate` gains optimistic concurrency — a queued update captures a per-field pre-image and on approve won't clobber a newer human edit.
4. **First-class run change-set + batched approvals + revision** — a watcher run records what it created/updated as a `change_set` event **even for auto-applied changes** (the diff is a property of the run, not the approval flow). A run's proposals group into one batch by `runs.window_id`; `approve_batch` / `reject_batch` reuse the single-run paths; reject feeds the reason back for the conversational revision loop.
5. **UI** (owletto) — per-principal "Applies to" picker on scoped policies; a run change-set card with per-entity before→after diffs; batch Approve-all / Reject-with-feedback.

## Verification

- `tsc` + biome clean across server and owletto; owletto SPA builds.
- Both migrations apply via **dbmate** (the exact tool the prod Helm pre-upgrade hook uses); the table rename is validated up → down → up (reversible + idempotent).
- **Tests green** against Homebrew PG18 + pgvector 0.8.1:
  - entity-policy unit (29): principal precedence, deny floor, kind-vs-id matching, agent_config + connector_action defaults.
  - access-matrix snapshot (64): pins every tool/action tier (caught the batch-action mis-tiering below).
  - manage-agents e2e (10): human applies immediately, agent create/update gate→approve, agent delete denied, stale-approval skip.
  - promote-keyed-entities integration (9): change-set event on the run, both proposals batch-approve in one call, reject_batch cancels + records the reason while the human-owned value is untouched.
  - entity-mutation-gate (8): unchanged, green.

## Also in this PR (post-review)

- **fix:** `approve_batch`/`reject_batch` defaulted to read-tier (a non-owner could approve). Now write-tier with the handler enforcing admin-or-run-owner. Caught by the access-matrix snapshot in `make review`.
- **rename:** `entity_approval_policies` → `write_approval_policies` (it governs three classes now). Bare rename — accepts a ~30-90s write-gating blip during the rollout overlap, no compat shim.
- **connector_action enforcement:** `manage_operations.execute` now consults the same write-gate (resource_class `connector_action`), folding with per-connection `action_modes` by restrictive-wins. No policy row → auto → connection mode alone decides (behavior intact).

## Deferred to v1.1

- Row-level (`entity_id`) / column-level (`field_path`) predicate scopes — columns ship now, governed by the predicate engine later.
- `connector_action` policy rows are **enforced** but set via SDK/SQL until their own admin UI surface lands (the entity PATCH endpoint stays entity-only to avoid forking mode validation).

Design record: `docs/plans/write-gate-generalization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generalized write-approval policies with resource-class scoping and per-principal targeting.
  * Added `approve_batch`/`reject_batch` to approve or reject pending watcher proposals by window.
* **Behavior Changes**
  * Write-gate modes now include `deny`/`disabled` (blocked), `approval` (queued), and `auto` (applies inline).
  * Approval execution is now restricted to verified human sessions; batch actions produce aggregated outcomes and correction feedback.
  * Agent management is fully gate-based, including staleness-safe queued updates with `skipped_fields`.
* **Database**
  * Expanded/renamed policy storage and indexes for generalized scoping; added run window and policy-principal support; updated dedupe keys.
* **Documentation**
  * Published the write-gate generalization RFC.
* **Tests**
  * Extended coverage for policy precedence, batch actions, staleness handling, and agent edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
