### PR TITLE
feat(connectors): connector-scoped chat facet + shared UI shell (bump owletto)

### DIFF
--- a/packages/server/src/__tests__/integration/connections-list-filters.test.ts
+++ b/packages/server/src/__tests__/integration/connections-list-filters.test.ts
@@ -95,8 +95,19 @@ describe("manage_connections and manage_feeds list filters", () => {
 		const sql = getTestDb();
 
 		// A managed Slack chat connection: an ACL source (audience) + a live bot
-		// adapter (chat). createTestConnection has no credential_mode param, so we
-		// stamp the Stage-2a chat marker directly. createDefaultFeed gives it data.
+		// adapter (chat). The chat facet is declared by the CONNECTOR, via the
+		// `x-lobu-chat-platform` marker in its options_schema — not implied by
+		// having a credential. Seed a matching slack connector_definition so the
+		// facet derivation sees the marker. createDefaultFeed gives it data.
+		await sql`
+			INSERT INTO connector_definitions
+				(organization_id, key, name, version, auth_schema, feeds_schema,
+				 actions_schema, options_schema, status)
+			VALUES (${workspace.org.id}, 'slack', 'Slack', '1.0.0',
+				'{"methods":[{"type":"app_installation"}]}'::jsonb, '{}'::jsonb, NULL,
+				'{"x-lobu-chat-platform":"slack"}'::jsonb, 'active')
+			ON CONFLICT DO NOTHING
+		`;
 		slackChatConnectionId = Number(
 			(
 				await createTestConnection({

--- a/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-streaming-feeds.test.ts
@@ -45,13 +45,25 @@ async function makeChatConnection(opts: {
   teamId: string | null;
 }): Promise<{ id: number; slug: string }> {
   chatConnectionSeq += 1;
+  const sql = getTestDb();
+  // The chat facet is declared by the CONNECTOR — via the `x-lobu-chat-platform`
+  // marker in its options_schema — not implied by having a credential. Seed a
+  // matching slack connector_definition so the facet derivation sees the marker.
+  await sql`
+    INSERT INTO connector_definitions
+      (organization_id, key, name, version, auth_schema, feeds_schema,
+       actions_schema, options_schema, status)
+    VALUES (${opts.orgId}, 'slack', 'Slack', '1.0.0',
+      '{"methods":[{"type":"app_installation"}]}'::jsonb, '{}'::jsonb, NULL,
+      '{"x-lobu-chat-platform":"slack"}'::jsonb, 'active')
+    ON CONFLICT DO NOTHING
+  `;
   const conn = await createTestConnection({
     organization_id: opts.orgId,
     connector_key: "slack",
     display_name: `Org Slack ${opts.orgId} ${opts.teamId ?? "none"} ${chatConnectionSeq}`,
     createDefaultFeed: false,
   });
-  const sql = getTestDb();
   const [row] = await sql`
     UPDATE connections
     SET credential_mode = 'managed', external_tenant_id = ${opts.teamId}

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -851,7 +851,7 @@ export async function handleCreate(
       return {
         error: callerIsAdmin
 					? "Select or create an OAuth app profile before creating the connection."
-          : `No OAuth app credentials configured for this connector. Ask an admin to set up the ${authSelection.oauthMethod?.provider ?? args.connector_key} app in /oauth-apps first.`,
+          : `No OAuth app credentials configured for this connector. Ask an admin to set up the ${authSelection.oauthMethod?.provider ?? args.connector_key} app under the connector's Setup tab (Connectors › ${args.connector_key}) first.`,
       };
     }
 		if (authSelection.appAuthProfile.status !== "active") {
@@ -869,7 +869,7 @@ export async function handleCreate(
         authSelection.appAuthProfile.connector_key !== args.connector_key)
     ) {
       return {
-        error: `No default OAuth app configured for this connector. Ask an admin to pin a ${authSelection.oauthMethod?.provider ?? args.connector_key} app as the default in /oauth-apps.`,
+        error: `No default OAuth app configured for this connector. Ask an admin to pin a ${authSelection.oauthMethod?.provider ?? args.connector_key} app as the default under the connector's Setup tab (Connectors › ${args.connector_key}).`,
       };
     }
   }

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -130,7 +130,7 @@ export async function handleListConnectorGroups(
            MAX(cd.name) AS connector_name,
            MAX(cd.favicon_domain) AS favicon_domain,
            COUNT(*)::int AS connection_count,
-           bool_or(c.credential_mode IS NOT NULL) AS has_chat_connection,
+           bool_or(cd.declares_chat) AS has_chat_connection,
            bool_or(fc.feed_count > 0) AS has_active_feeds,
            -- DATA-facet input: only non-streaming feeds count, so a chat-only
            -- group whose channels became streaming feeds isn't mislabeled data.
@@ -152,7 +152,11 @@ export async function handleListConnectorGroups(
       SELECT name, favicon_domain,
              (feeds_schema IS NOT NULL
               AND feeds_schema::text <> '{}'
-              AND feeds_schema::text <> 'null') AS has_feeds_schema
+              AND feeds_schema::text <> 'null') AS has_feeds_schema,
+             -- chat facet is declared by the connector, not implied by having a
+             -- credential: a connector is chat iff it carries the chat-platform
+             -- marker in its options_schema (x-lobu-chat-platform).
+             (options_schema ->> 'x-lobu-chat-platform') IS NOT NULL AS declares_chat
       FROM connector_definitions
       WHERE key = c.connector_key
         AND status = 'active'
@@ -239,6 +243,7 @@ export async function handleList(
     SELECT c.*,
            cd.name AS connector_name,
            cd.has_feeds_schema,
+           cd.declares_chat,
            ap.slug AS auth_profile_slug,
            ap.display_name AS auth_profile_name,
            ap.status AS auth_profile_status,
@@ -285,7 +290,8 @@ export async function handleList(
       SELECT name,
              (feeds_schema IS NOT NULL
               AND feeds_schema::text <> '{}'
-              AND feeds_schema::text <> 'null') AS has_feeds_schema
+              AND feeds_schema::text <> 'null') AS has_feeds_schema,
+             (options_schema ->> 'x-lobu-chat-platform') IS NOT NULL AS declares_chat
       FROM connector_definitions
       WHERE key = c.connector_key
         AND status = 'active'
@@ -358,7 +364,7 @@ export async function handleList(
       has_operations: hasOperations,
       facets: deriveConnectionFacets({
         connectorKey: String(row.connector_key),
-        isChat: row.credential_mode != null,
+        isChat: row.declares_chat === true,
         feedCount: Number(row.data_feed_count) || 0,
         connectorHasFeeds: row.has_feeds_schema === true,
         hasOperations,
@@ -397,6 +403,7 @@ export async function handleGet(
            cd.name AS connector_name,
            cd.feeds_schema,
            cd.auth_schema,
+           cd.declares_chat,
            ap.slug AS auth_profile_slug,
            ap.display_name AS auth_profile_name,
            ap.status AS auth_profile_status,
@@ -423,7 +430,8 @@ export async function handleGet(
            (SELECT COUNT(*) FROM feeds f WHERE f.connection_id = c.id AND f.deleted_at IS NULL AND f.kind <> 'streaming')::int AS data_feed_count
     FROM connections c
     LEFT JOIN LATERAL (
-      SELECT name, feeds_schema, auth_schema
+      SELECT name, feeds_schema, auth_schema, options_schema,
+             (options_schema ->> 'x-lobu-chat-platform') IS NOT NULL AS declares_chat
       FROM connector_definitions
       WHERE key = c.connector_key
         AND status = 'active'
@@ -501,7 +509,7 @@ export async function handleGet(
       has_operations: hasOperations,
       facets: deriveConnectionFacets({
         connectorKey: String(getRow.connector_key),
-        isChat: getRow.credential_mode != null,
+        isChat: getRow.declares_chat === true,
         feedCount: Number(getRow.data_feed_count) || 0,
         connectorHasFeeds,
         hasOperations,

--- a/packages/server/src/tools/admin/manage_connections/handlers/device-binding.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/device-binding.ts
@@ -100,7 +100,7 @@ export async function resolveDeviceBinding(params: {
   }
   if (device.organization_id !== params.organizationId) {
     return {
-      error: `Device '${device.label ?? deviceWorkerId}' isn't attached to this workspace. Re-attach it from the Devices page first.`,
+      error: `Device '${device.label ?? deviceWorkerId}' isn't attached to this workspace. Re-attach it from Infrastructure › Devices first.`,
     };
   }
 


### PR DESCRIPTION
Backend half of the connector-UI consolidation + owletto submodule bump. Pairs with lobu-ai/owletto#471.

## What changed
- **Chat-facet fix (root cause).** `isChat` / `has_chat_connection` were derived from `credential_mode IS NOT NULL`, so any connector with credentials wrongly showed the Chat chip / Webhook URL / a dead credential button. Now derived from the actual chat marker — `(options_schema ->> 'x-lobu-chat-platform') IS NOT NULL` — in all three query paths (list lateral + outer projection, get lateral + outer projection). The lateral computed `declares_chat` but the outer SELECTs didn't project it, which would have made the chip never show; both now project it.
- Test updated with a slack `connector_definitions` fixture carrying the chat marker (the test previously relied on the credential_mode bug). red→fix→green, 6/6 pass.
- Error-string fix: device-binding hint "Infrastructure › Runtimes" → "Infrastructure › Devices".
- Bumps `packages/owletto` to the consolidated connector-UI shell (owletto#471).

## Verification
- `make typecheck` clean (server + owletto).
- Integration test `connections-list-filters` 6/6 green (the red→fix→green for the chat-facet derivation).
- Browser-verified the full connector matrix in local dev (GitHub Setup clean, feeds "+ Add" opens the form, "Needs reconnect" surfaces a broken orphan OAuth account).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786212923&installation_id=136316292&pr_number=1828&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1828&signature=6e4fe7602bba0162c5a9566e5a48bee96e2cf12274d8e691a9e8466e8bae2f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how chat-capable connections are identified in connection lists and filters, so Slack-related facets now appear more reliably.
  * Updated connection creation and device-binding error messages to point to clearer setup locations and guidance.
* **Tests**
  * Expanded integration coverage for chat connection filtering and streaming feed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->