### PR TITLE
fix(slack): preserve org install on workspace uninstall

### DIFF
--- a/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
@@ -640,6 +640,46 @@ describe("Grid install-model routing (per-workspace + org-wide enterprise)", () 
     );
   });
 
+  test("revokeSlackInstallsForUninstall keeps a coexisting org-wide install active for a workspace uninstall", async () => {
+    const { store, secretStore, slack } = build();
+    const ENT = "E_COEXIST";
+    const TEAM = "T_COEXIST";
+    await seedAgentRow("t", { organizationId: "org-coexist" });
+    const orgWide = await slack.upsertSlackInstallByTeam(
+      store,
+      secretStore,
+      "org-coexist",
+      ENT,
+      {
+        botToken: "xoxb-orgwide",
+        enterpriseId: ENT,
+        isEnterpriseInstall: true,
+      },
+    );
+    const workspace = await slack.upsertSlackInstallByTeam(
+      store,
+      secretStore,
+      "org-coexist",
+      TEAM,
+      {
+        botToken: "xoxb-workspace",
+        enterpriseId: ENT,
+        isEnterpriseInstall: false,
+      },
+    );
+
+    const stopped = await slack.revokeSlackInstallsForUninstall(store, {
+      teamId: TEAM,
+      enterpriseId: ENT,
+    });
+
+    expect(stopped).toEqual([workspace.id]);
+    expect(await slack.getSlackInstallByTeamId(store, TEAM)).toBeNull();
+    expect((await slack.getSlackEnterpriseInstall(store, ENT))?.id).toBe(
+      orgWide.id,
+    );
+  });
+
   test("revokeSlackInstallsForUninstall is a no-op for an unknown tenant", async () => {
     const { store, slack } = build();
     expect(

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -502,10 +502,10 @@ export async function markSlackInstallStopped(
  * suspended) rather than deletes — audit/rollback, consistent with
  * {@link markSlackInstallStopped}; a later reinstall reactivates the same row.
  *
- * Resolves the affected installs WITHOUT assuming the event carries a team id:
- *   - the exact `team_id` install (a per-workspace install), when present;
- *   - the ORG-WIDE install keyed on `enterprise_id` (a Grid org-wide uninstall
- *     often carries only the enterprise id, no team id).
+ * Resolves the affected install WITHOUT assuming the event carries a team id:
+ *   - when `team_id` is present, the exact per-workspace install;
+ *   - otherwise, the ORG-WIDE install keyed on `enterprise_id` (a Grid org-wide
+ *     uninstall often carries only the enterprise id, no team id).
  * A per-workspace uninstall thus stops only that workspace's row; a sibling's
  * separately-installed row (matched by its own team id) is untouched. Returns the
  * external ids that were stopped (may be empty — an already-inactive or unknown
@@ -519,8 +519,7 @@ export async function revokeSlackInstallsForUninstall(
   if (tenant.teamId) {
     const byTeam = await getSlackInstallByTeamId(store, tenant.teamId);
     if (byTeam) toStop.set(byTeam.id, byTeam);
-  }
-  if (tenant.enterpriseId) {
+  } else if (tenant.enterpriseId) {
     const orgWide = await getSlackEnterpriseInstall(store, tenant.enterpriseId);
     if (orgWide) toStop.set(orgWide.id, orgWide);
   }


### PR DESCRIPTION
## What changed

Workspace-scoped Slack uninstall events now stop only the matching workspace installation when the event contains both `team_id` and `enterprise_id`. Enterprise-wide installs are stopped only when no workspace identifier is present.

## Root cause

The uninstall handler evaluated the workspace and enterprise branches independently. Slack workspace uninstall payloads can carry both identifiers, so the handler stopped the exact workspace row and then also stopped the coexisting org-wide Grid installation.

## Impact

Uninstalling one Slack workspace no longer disconnects a separate organization-wide installation or its sibling workspaces.

## Validation

- Red regression: coexisting workspace + org-wide install expected one stopped row but received two.
- Focused uninstall tests: 4 passed.
- Full Slack installation test file: 21 passed.
- `make build-packages` passed.
- Typecheck and Biome passed.
- `make review BASE=origin/main`: typecheck, unit, and integration passed; Claude verdict reported 0 blockers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786221643&installation_id=136316292&pr_number=1829&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1829&signature=ac53c3e2e3d57ebc417b1860acc6254827be7d32a8ed63e00891778ffad71a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->