### PR TITLE
Make DOM scrapes action-scoped by default

### DIFF
--- a/examples/brand-intelligence/__tests__/connector-sdk.mock.ts
+++ b/examples/brand-intelligence/__tests__/connector-sdk.mock.ts
@@ -127,8 +127,8 @@ export function connectorSdkMock() {
     extensionDomScrape: async (opts: DomScrapeOpts) => {
       const observation = await opts.dispatcher.dispatch("navigate", {
         cs_scrape: true,
-        persistent: opts.persistent ?? true,
-        focus: opts.focus ?? true,
+        persistent: opts.persistent ?? false,
+        focus: opts.focus ?? false,
         url: opts.url,
         scrape_config: opts.config,
         allowed_origins: opts.allowedOrigins,

--- a/examples/office-bot/deliveroo.connector.ts
+++ b/examples/office-bot/deliveroo.connector.ts
@@ -322,7 +322,7 @@ export default class DeliverooConnector extends ConnectorRuntime {
 
     if (!loggedIn) {
       throw new Error(
-        "Deliveroo restaurants list could not be read — a login/age wall blocked the page. Sign into deliveroo.co.uk in the focused Owletto window, then re-run."
+        "Deliveroo restaurants list could not be read — a login/age wall blocked the page. Sign into deliveroo.co.uk in the paired Chrome profile, then re-run."
       );
     }
 
@@ -366,7 +366,7 @@ export default class DeliverooConnector extends ConnectorRuntime {
 
     if (!loggedIn) {
       throw new Error(
-        "Deliveroo menu could not be read — a login/age wall blocked the page. Sign into deliveroo.co.uk in the focused Owletto window, then re-run."
+        "Deliveroo menu could not be read — a login/age wall blocked the page. Sign into deliveroo.co.uk in the paired Chrome profile, then re-run."
       );
     }
 

--- a/examples/personal-agent/__tests__/connector-sdk.mock.ts
+++ b/examples/personal-agent/__tests__/connector-sdk.mock.ts
@@ -108,8 +108,8 @@ export function connectorSdkMock() {
     extensionDomScrape: async (opts: DomScrapeOpts) => {
       const observation = await opts.dispatcher.dispatch("navigate", {
         cs_scrape: true,
-        persistent: opts.persistent ?? true,
-        focus: opts.focus ?? true,
+        persistent: opts.persistent ?? false,
+        focus: opts.focus ?? false,
         url: opts.url,
         scrape_config: opts.config,
         allowed_origins: opts.allowedOrigins,

--- a/examples/personal-agent/__tests__/linkedin.connector.test.ts
+++ b/examples/personal-agent/__tests__/linkedin.connector.test.ts
@@ -376,7 +376,8 @@ describe("LinkedInConnector home_feed", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].action).toBe("navigate");
     expect(calls[0].input.cs_scrape).toBe(true);
-    expect(calls[0].input.persistent).toBe(true);
+    expect(calls[0].input.persistent).toBe(false);
+    expect(calls[0].input.focus).toBe(false);
     expect(calls[0].input.url).toBe("https://www.linkedin.com/feed/");
     expect(
       (calls[0].input.scrape_config as { scroll: { max: number } }).scroll.max

--- a/examples/personal-agent/linkedin.connector.ts
+++ b/examples/personal-agent/linkedin.connector.ts
@@ -965,8 +965,8 @@ export default class LinkedInConnector extends ConnectorRuntime<
    * Personalized home feed via the extension's content-script scrape. Network
    * capture can't read it (the CDP debugger stops the feed rendering), so we
    * dispatch a `cs_scrape` against linkedin.com/feed/ with the home-feed
-   * selectors. The persistent window is reused/focused so an auth wall can be
-   * cleared in place for the next run.
+   * selectors. Each run uses its own scratch tab; the paired Chrome profile
+   * supplies the shared login cookies.
    */
   private async syncHomeFeed(
     maxScrolls: number,
@@ -986,7 +986,7 @@ export default class LinkedInConnector extends ConnectorRuntime<
 
     if (!loggedIn) {
       throw new Error(
-        "Not logged into LinkedIn. The home feed could not be read — sign in to LinkedIn in the focused Owletto window, then re-run the sync."
+        "Not logged into LinkedIn. Sign in to linkedin.com in the paired Chrome profile, then re-run the sync."
       );
     }
 

--- a/examples/personal-agent/revolut-transactions.connector.ts
+++ b/examples/personal-agent/revolut-transactions.connector.ts
@@ -5,7 +5,7 @@
  * user's transactions by REPLAYING the retail API the Revolut web app
  * (`app.revolut.com`) already calls — not by scraping the rendered DOM. It runs
  * inside the user's real signed-in Chrome via the paired Owletto extension:
- * reuse the persistent window the user signs into once, capture the app's own
+ * reuse the revolut.com sticky anchor the user signs into once, capture the app's own
  * `transactions/last` request headers, then page the FULL history in-page by
  * walking the `?to=<cursor>` parameter and parsing each
  * `GET /api/retail/user/current/transactions/last` JSON page.
@@ -499,7 +499,7 @@ function sleep(ms: number): Promise<void> {
 
 // 1. Auth-check + capture the app's real `transactions/last` request headers.
 // A fresh tab can't inherit Revolut's rwa auth, so headers are only obtainable
-// in the signed-in persistent window. The on-load request fires before our
+// in the signed-in sticky anchor. The on-load request fires before our
 // wrappers install, so after wrapping fetch + XHR we force ONE fresh app
 // request by remounting the SPA route (away + back). The captured header set
 // (notably the in-memory `x-device-id` app token) + a paging cursor are stored
@@ -609,9 +609,9 @@ const pageBatchExpr = (internalPocketId: string): string => {
  * Crawl the FULL retail transaction history by replaying the `transactions/last`
  * API in-page, walking its `?to=<epoch_ms>` cursor — no scrolling.
  *
- * Reuses the ONE persistent window the user signs into once: a fresh background
+ * Reuses the revolut.com sticky anchor the user signs into once: a fresh background
  * tab bounces to sso.revolut.com (rwa auth is bound to the signed-in tab), so
- * the persistent window is the only context where the retail API authenticates.
+ * the sticky anchor is the only context where the retail API authenticates.
  * We capture the app's own request headers there (SETUP_EXPR), then page the
  * whole history in batches that RETURN their raw rows (PAGE_BATCH_EXPR), parsing
  * each batch with the same `parseTransactionsResponse` used for intercepted
@@ -626,7 +626,7 @@ async function crawlFetchPaging(
 ): Promise<{ items: RevolutTransaction[]; apiCallCount: number }> {
   const allowed = REVOLUT_ALLOWED_ORIGINS;
   const PAGE_BATCH_EXPR = pageBatchExpr(internalPocketId);
-  // Open / reuse the single persistent window in the BACKGROUND (not focused) so
+  // Open / reuse the site sticky anchor in the BACKGROUND (not focused) so
   // a routine authed sync never pops the window to the foreground. We only
   // surface it below if the run actually needs the user to sign in.
   const nav = await dispatcher.dispatch<{ tab_id: number }>("navigate", {
@@ -639,7 +639,7 @@ async function crawlFetchPaging(
   const tabId = nav.tab_id;
 
   // Capture headers / auth-check. On a miss (SSO wall / capture fail), FOCUS the
-  // persistent window so the user can complete the passcode in place, then return
+  // sticky anchor so the user can complete the passcode in place, then return
   // no items so the upstream wait-poll fires the sign-in notice and retries.
   const setup = await dispatcher.dispatch<{
     value?: { authed?: boolean; captured?: boolean };

--- a/packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts
+++ b/packages/connector-sdk/src/__tests__/extension-dom-scrape.test.ts
@@ -53,11 +53,14 @@ describe('extensionDomScrape', () => {
     expect(log).toHaveLength(1);
     expect(log[0].action).toBe('navigate');
     expect(log[0].input.cs_scrape).toBe(true);
-    expect(log[0].input.persistent).toBe(true);
-    expect(log[0].input.focus).toBe(true);
+    expect(log[0].input.persistent).toBe(false);
+    expect(log[0].input.focus).toBe(false);
     expect(log[0].input.url).toBe('https://www.example.com/feed/');
     expect(log[0].input.scrape_config).toBe(config);
-    expect(log[0].input.allowed_origins).toEqual(['example.com', '*.example.com']);
+    expect(log[0].input.allowed_origins).toEqual([
+      'example.com',
+      '*.example.com',
+    ]);
 
     expect(res.items).toEqual([{ id: 'a' }, { id: 'b' }]);
     expect(res.loggedIn).toBe(true);
@@ -105,11 +108,51 @@ describe('extensionDomScrape', () => {
         config: {},
         parseRows: (rows) => rows as { id?: string }[],
         allowedOrigins: ['example.com'],
-        persistent: false,
-        focus: false,
+        persistent: true,
+        focus: true,
       })
     ).rejects.toThrow(/cs_scrape returned no result/);
-    expect(log[0].input.persistent).toBe(false);
-    expect(log[0].input.focus).toBe(false);
+    expect(log[0].input.persistent).toBe(true);
+    expect(log[0].input.focus).toBe(true);
+  });
+
+  test('fails loudly when the scrape result reports a different site', async () => {
+    const { dispatcher } = makeDispatcher({
+      result: {
+        host: 'evil.example.net',
+        landedUrl: 'https://evil.example.net/phishing',
+        rows: [],
+      },
+    });
+
+    await expect(
+      extensionDomScrape({
+        dispatcher,
+        url: 'https://www.example.com/feed/',
+        config: {},
+        parseRows: (rows) => rows,
+        allowedOrigins: ['example.com', '*.example.com'],
+      })
+    ).rejects.toThrow(/wrong site/);
+  });
+
+  test('fails loudly when landedUrl disagrees with an otherwise valid result host', async () => {
+    const { dispatcher } = makeDispatcher({
+      result: {
+        host: 'www.example.com',
+        landedUrl: 'https://evil.example.net/phishing',
+        rows: [],
+      },
+    });
+
+    await expect(
+      extensionDomScrape({
+        dispatcher,
+        url: 'https://www.example.com/feed/',
+        config: {},
+        parseRows: (rows) => rows,
+        allowedOrigins: ['example.com', '*.example.com'],
+      })
+    ).rejects.toThrow(/landedUrl reported evil\.example\.net/);
   });
 });

--- a/packages/connector-sdk/src/extension-dom-scrape.ts
+++ b/packages/connector-sdk/src/extension-dom-scrape.ts
@@ -16,12 +16,22 @@ export interface ExtensionScrapeConfig {
   /** Section/day grouping: iterate each `selector`, take its first text line as
    * the group label (when `labelFromFirstLine`), and emit a row per
    * `rowSelector` inside it. The engine reads `cfg.group.selector`. */
-  group?: { selector: string; rowSelector: string; labelFromFirstLine?: boolean };
+  group?: {
+    selector: string;
+    rowSelector: string;
+    labelFromFirstLine?: boolean;
+  };
   id?: { source: string; name?: string; regex?: string; group?: number };
   requireFields?: readonly string[];
   fields?: Record<
     string,
-    { selector?: string; take?: string; attr?: string; firstLine?: boolean; const?: unknown }
+    {
+      selector?: string;
+      take?: string;
+      attr?: string;
+      firstLine?: boolean;
+      const?: unknown;
+    }
   >;
   [k: string]: unknown;
 }
@@ -57,10 +67,50 @@ export interface ExtensionDomScrapeResult<TItem> {
   tabId?: number;
 }
 
+function hostMatchesPattern(host: string, pattern: string): boolean {
+  const normalizedHost = host.toLowerCase().replace(/\.$/, '');
+  const normalizedPattern = pattern.toLowerCase().replace(/\.$/, '');
+  if (normalizedHost === normalizedPattern) return true;
+  if (normalizedPattern.startsWith('*.')) {
+    return normalizedHost.endsWith(normalizedPattern.slice(1));
+  }
+  return false;
+}
+
+function assertExpectedScrapeSite(
+  requestedUrl: string,
+  allowedOrigins: string[],
+  result: ExtensionScrapeResult
+): void {
+  const requestedHost = new URL(requestedUrl).hostname;
+  const expectedHosts = [requestedHost, ...allowedOrigins];
+  const assertHost = (host: string, source: string) => {
+    if (expectedHosts.some((pattern) => hostMatchesPattern(host, pattern)))
+      return;
+    throw new Error(
+      `cs_scrape returned the wrong site: requested ${requestedHost}, but ${source} reported ${host}.`
+    );
+  };
+
+  if (result.host) assertHost(result.host, 'result.host');
+  if (result.landedUrl) {
+    let landedHost: string;
+    try {
+      landedHost = new URL(result.landedUrl).hostname;
+    } catch {
+      throw new Error(
+        `cs_scrape returned the wrong site: landedUrl is not a valid URL (${result.landedUrl}).`
+      );
+    }
+    assertHost(landedHost, 'landedUrl');
+  }
+}
+
 /**
  * Drive one content-script `cs_scrape` navigate and return parsed rows.
- * `persistent`/`focus` default true so a reused, focused window lets the user
- * clear an auth wall in place.
+ * Scrapes default to a background, action-scoped tab that the extension closes
+ * after harvesting. Set `persistent:true` only for a site with tab-bound state;
+ * it selects that site's sticky anchor and serializes work on that anchor.
  */
 export async function extensionDomScrape<TItem>(opts: {
   dispatcher: ChromeActionDispatcher;
@@ -71,14 +121,15 @@ export async function extensionDomScrape<TItem>(opts: {
   persistent?: boolean;
   focus?: boolean;
 }): Promise<ExtensionDomScrapeResult<TItem>> {
-  const observation = await opts.dispatcher.dispatch<ExtensionScrapeObservation>('navigate', {
-    cs_scrape: true,
-    persistent: opts.persistent ?? true,
-    focus: opts.focus ?? true,
-    url: opts.url,
-    scrape_config: opts.config,
-    allowed_origins: opts.allowedOrigins,
-  });
+  const observation =
+    await opts.dispatcher.dispatch<ExtensionScrapeObservation>('navigate', {
+      cs_scrape: true,
+      persistent: opts.persistent ?? false,
+      focus: opts.focus ?? false,
+      url: opts.url,
+      scrape_config: opts.config,
+      allowed_origins: opts.allowedOrigins,
+    });
   const result = observation?.result;
   // Fail loudly on a broken scrape. A missing result (dispatch never produced
   // one) or an `error` field (the in-page script threw — e.g. CSP blocked
@@ -88,11 +139,14 @@ export async function extensionDomScrape<TItem>(opts: {
   // auth wall is different — the engine returns `loggedIn:false` with no error,
   // which is preserved below for the caller to handle.
   if (!result) {
-    throw new Error('cs_scrape returned no result — the content-script dispatch did not complete.');
+    throw new Error(
+      'cs_scrape returned no result — the content-script dispatch did not complete.'
+    );
   }
-  if (typeof result.error === 'string' && result.error) {
-    throw new Error(`cs_scrape failed in the page: ${result.error}`);
+  if (result.error != null && result.error !== '') {
+    throw new Error(`cs_scrape failed in the page: ${String(result.error)}`);
   }
+  assertExpectedScrapeSite(opts.url, opts.allowedOrigins, result);
   const items = opts.parseRows(result.rows ?? []);
   return {
     items,

--- a/packages/connectors/src/__tests__/connector-sdk.mock.ts
+++ b/packages/connectors/src/__tests__/connector-sdk.mock.ts
@@ -146,8 +146,8 @@ export function connectorSdkMock() {
     extensionDomScrape: async (opts: DomScrapeOpts) => {
       const observation = await opts.dispatcher.dispatch('navigate', {
         cs_scrape: true,
-        persistent: opts.persistent ?? true,
-        focus: opts.focus ?? true,
+		persistent: opts.persistent ?? false,
+		focus: opts.focus ?? false,
         url: opts.url,
         scrape_config: opts.config,
         allowed_origins: opts.allowedOrigins,

--- a/packages/connectors/src/__tests__/x.test.ts
+++ b/packages/connectors/src/__tests__/x.test.ts
@@ -684,7 +684,8 @@ describe("XConnector home_feed", () => {
 		expect(calls).toHaveLength(1);
 		expect(calls[0].action).toBe("navigate");
 		expect(calls[0].input.cs_scrape).toBe(true);
-		expect(calls[0].input.persistent).toBe(true);
+		expect(calls[0].input.persistent).toBe(false);
+		expect(calls[0].input.focus).toBe(false);
 		expect(calls[0].input.url).toBe("https://x.com/home");
 		expect(
 			(calls[0].input.scrape_config as { scroll: { max: number } }).scroll.max,

--- a/packages/connectors/src/x.ts
+++ b/packages/connectors/src/x.ts
@@ -1665,7 +1665,7 @@ async function syncHomeFeedViaDomScrape(
 
 	if (!loggedIn) {
 		throw new Error(
-			"Not logged into X. The home timeline could not be read — sign in to x.com in the focused Owletto window, then re-run the sync.",
+			"Not logged into X. Sign in to x.com in the paired Chrome profile, then re-run the sync.",
 		);
 	}
 


### PR DESCRIPTION
## Summary

- default extensionDomScrape to persistent:false and focus:false so every ordinary scrape receives an isolated scratch tab
- keep persistent:true as the explicit sticky-site contract for tab-bound sessions such as Revolut
- fail loudly when result.host or landedUrl clearly disagrees with the requested/allowed site
- update X, LinkedIn, Deliveroo messaging and test mocks for shared-profile cookies without shared tabs
- bump Owletto to lobu-ai/owletto#472, which owns scratch lifecycle and per-site sticky anchors

## Behavior

Before: every default DOM scrape reused one global persistent tab, so overlapping X/LinkedIn or LinkedIn/LinkedIn runs could navigate away each others content-script context.

After: normal scrapes open, scrape, and close independent owned windows. Sticky callers share only their own site anchor and serialize only against that anchor. Chrome-profile cookies remain shared.

## Verification

- red tests reproduced missing scratch cleanup, same-site sticky races, cross-site global-tab reuse, and missing legacy migration
- Owletto full suite: 553 passed
- Owletto production build passed
- connector SDK: 155 passed; typecheck passed
- connectors suite: 171 passed
- personal-agent suite: 77 passed
- brand-intelligence suite: 4 passed
- make review: 0 blockers; build/typecheck/unit passed; unrelated ephemeral-Postgres integration noise remains in existing suites

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786221900&installation_id=136316292&pr_number=1830&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1830&signature=d132f78d4584d42caaa2c8bfb4cee4d88b754e4162d5b7bad0df7d417423d581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated login/help messages across several connectors to give clearer sign-in guidance when data can’t be read.
  * Improved validation for page scrapes so results must come from the expected site, reducing incorrect or mismatched data.

* **Refactor**
  * Changed browser navigation defaults for background scraping to avoid unnecessary focus/persistent behavior, with tests updated to match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

BEGIN_COMMIT_OVERRIDE
fix(connectors): isolate DOM scrapes per action and reject wrong-site results (#1830)
END_COMMIT_OVERRIDE

