### PR TITLE
fix(slack): atomically claim pending installations

### DIFF
--- a/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
@@ -429,6 +429,159 @@ describe("slack-installations projection over app_installations", () => {
     );
     expect(token).toBe("xoxb-a");
   });
+
+  test("concurrent pending claims bind exactly one org and keep ownership stable", async () => {
+    await seedAgentRow("claim-a", { organizationId: "org-claim-race-a" });
+    await seedAgentRow("claim-b", { organizationId: "org-claim-race-b" });
+    const { store, secretStore, slack } = build();
+    const sql = getDb();
+
+    await slack.writeSlackPendingInstall({
+      teamId: "T_CLAIM_RACE",
+      teamName: "Claim Race",
+      botUserId: "U_BOT",
+      botToken: "xoxb-claim-race",
+      installerUserId: "U_INSTALLER",
+      isEnterpriseInstall: false,
+      enterpriseId: null,
+    });
+    const pending = await slack.resolveSlackPendingByTenant("T_CLAIM_RACE");
+    expect(pending).not.toBeNull();
+
+    // Delay org A's app-installation writes so both claim paths overlap. Before
+    // the fix no claim write exists: both callers instead activate sequentially
+    // under the tenant lock and both report success.
+    await sql.unsafe(`
+      CREATE OR REPLACE FUNCTION public.test_delay_slack_pending_claim()
+      RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        IF NEW.organization_id = 'org-claim-race-a' THEN
+          PERFORM pg_sleep(0.75);
+        END IF;
+        RETURN NEW;
+      END;
+      $$
+    `);
+    await sql.unsafe(`
+      CREATE TRIGGER test_delay_slack_pending_claim
+      BEFORE INSERT OR UPDATE ON app_installations
+      FOR EACH ROW EXECUTE FUNCTION public.test_delay_slack_pending_claim()
+    `);
+
+    try {
+      const claims = await Promise.allSettled([
+        slack.claimSlackPendingInstall(
+          store,
+          secretStore,
+          pending!,
+          "org-claim-race-a",
+        ),
+        slack.claimSlackPendingInstall(
+          store,
+          secretStore,
+          pending!,
+          "org-claim-race-b",
+        ),
+      ]);
+
+      const statuses = claims.map((claim) => claim.status);
+      expect(statuses.filter((status) => status === "fulfilled")).toHaveLength(1);
+      expect(statuses.filter((status) => status === "rejected")).toHaveLength(1);
+      const winnerIndex = statuses.findIndex((status) => status === "fulfilled");
+      const winningOrg = ["org-claim-race-a", "org-claim-race-b"][winnerIndex]!;
+      const losingOrg = ["org-claim-race-b", "org-claim-race-a"][winnerIndex]!;
+      const active = await slack.getSlackInstallByTeamId(store, "T_CLAIM_RACE");
+      expect(active?.organizationId).toBe(winningOrg);
+
+      // A stale pre-claim object must not let the loser invoke normal Slack
+      // reinstall transfer semantics after the winning claim has committed.
+      await expect(
+        slack.claimSlackPendingInstall(
+          store,
+          secretStore,
+          pending!,
+          losingOrg,
+        ),
+      ).rejects.toThrow(/already claimed/);
+      expect(
+        (await slack.getSlackInstallByTeamId(store, "T_CLAIM_RACE"))
+          ?.organizationId,
+      ).toBe(winningOrg);
+
+      const rows = await sql`
+        SELECT organization_id, status
+        FROM app_installations
+        WHERE provider = 'slack' AND external_tenant_id = 'T_CLAIM_RACE'
+        ORDER BY id
+      `;
+      expect(rows).toEqual([
+        expect.objectContaining({
+          organization_id: winningOrg,
+          status: "active",
+        }),
+      ]);
+    } finally {
+      await sql.unsafe(
+        "DROP TRIGGER IF EXISTS test_delay_slack_pending_claim ON app_installations",
+      );
+      await sql.unsafe(
+        "DROP FUNCTION IF EXISTS public.test_delay_slack_pending_claim()",
+      );
+    }
+  });
+
+  test("a failed pending claim keeps its encrypted token for the winning org to retry", async () => {
+    await seedAgentRow("claim-retry", {
+      organizationId: "org-claim-retry",
+    });
+    const { store, secretStore, slack } = build();
+    await slack.writeSlackPendingInstall({
+      teamId: "T_CLAIM_RETRY",
+      teamName: "Claim Retry",
+      botUserId: "U_BOT",
+      botToken: "xoxb-claim-retry",
+      installerUserId: "U_INSTALLER",
+      isEnterpriseInstall: false,
+      enterpriseId: null,
+    });
+    const pending = await slack.resolveSlackPendingByTenant("T_CLAIM_RETRY");
+    const failingSecretStore = makeFailingSecretStore(
+      secretStore,
+      "simulated pending claim secret failure",
+    );
+
+    await expect(
+      slack.claimSlackPendingInstall(
+        store,
+        failingSecretStore,
+        pending!,
+        "org-claim-retry",
+      ),
+    ).rejects.toThrow(/simulated pending claim secret failure/);
+
+    const sql = getDb();
+    const parked = await sql`
+      SELECT organization_id, status, metadata ->> 'bot_token_enc' AS token_enc
+      FROM app_installations
+      WHERE id = ${pending!.id}
+    `;
+    expect(parked).toHaveLength(1);
+    expect(parked[0].organization_id).toBe("org-claim-retry");
+    expect(parked[0].status).toBe("pending");
+    expect(parked[0].token_enc).toBeTruthy();
+    expect(
+      (await slack.resolveSlackPendingByTenant("T_CLAIM_RETRY"))?.botToken,
+    ).toBe("xoxb-claim-retry");
+
+    await slack.claimSlackPendingInstall(
+      store,
+      secretStore,
+      pending!,
+      "org-claim-retry",
+    );
+    const active = await slack.getSlackInstallByTeamId(store, "T_CLAIM_RETRY");
+    expect(active?.organizationId).toBe("org-claim-retry");
+  });
 });
 
 describe("Grid install-model routing (per-workspace + org-wide enterprise)", () => {

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -694,17 +694,20 @@ export async function resolveSlackPendingByTenant(
 }
 
 /**
- * Claim a pending (unclaimed) Slack workspace into an org: BIND the install
- * (persist the bot token to the org-scoped secret store + create the active,
- * org-owned `app_installations` + `connections` rows via
- * {@link upsertSlackInstallByTeam}), then DELETE the org-less pending row so the
- * workspace can't be double-claimed. Caller is responsible for authorizing the
- * claim (token-hash match + workspace-admin check) BEFORE invoking this.
+ * Claim a pending (unclaimed) Slack workspace into an org. The first UPDATE is
+ * the authoritative, durable claim: it atomically assigns the pending row to
+ * one org before any secret-store or activation work begins. A racing org's
+ * compare-and-set returns no row, so generic active-install transfer semantics
+ * can never turn a second pending claim into an ownership steal.
  *
- * The bind commits first; the pending delete is a best-effort follow-up on the
- * same team so a crash between them leaves the workspace claimed (active row
- * wins routing) with a harmless leftover pending row that the next claim
- * replaces. Returns the stable `slackinst-<uuid>` install id.
+ * The claimed row deliberately stays `pending` until
+ * {@link upsertSlackInstallByTeam} has persisted the bot token. That function
+ * finds this org-owned row and flips it active in place. If token persistence or
+ * activation fails, the encrypted token remains on the durable pending row and
+ * the SAME org can retry; a different org still cannot claim it.
+ *
+ * Caller is responsible for authorizing the claim (workspace-admin check)
+ * BEFORE invoking this. Returns the stable `slackinst-<uuid>` install id.
  */
 export async function claimSlackPendingInstall(
   store: AppInstallationStore,
@@ -712,6 +715,23 @@ export async function claimSlackPendingInstall(
   pending: SlackPendingInstall,
   organizationId: string
 ): Promise<{ installationId: string }> {
+  const sql = getDb();
+  const claimed = await sql`
+    UPDATE app_installations
+    SET organization_id = ${organizationId}, updated_at = now()
+    WHERE id = ${pending.id}::bigint
+      AND provider = ${SLACK_PROVIDER}
+      AND provider_instance = ${SLACK_PROVIDER_INSTANCE}
+      AND provider_app_id = ${SLACK_PROVIDER_APP_ID}
+      AND external_tenant_id = ${pending.teamId}
+      AND status = 'pending'
+      AND (organization_id IS NULL OR organization_id = ${organizationId})
+    RETURNING id
+  `;
+  if (claimed.length === 0) {
+    throw new Error("Slack workspace pending install was already claimed");
+  }
+
   const row = await upsertSlackInstallByTeam(
     store,
     secretStore,
@@ -726,13 +746,16 @@ export async function claimSlackPendingInstall(
       isEnterpriseInstall: pending.isEnterpriseInstall,
     }
   );
-  // Retire the org-less pending row now that an active, org-owned install owns
-  // the workspace. Team-scoped: at most one pending row per team.
-  await getDb()`
+  // Usually the reserved row was activated in place. If a same-org active row
+  // already existed, the generic upsert refreshed that row instead; retire only
+  // THIS successfully consumed pending row, never a newer reinstall.
+  await sql`
     DELETE FROM app_installations
-    WHERE provider = ${SLACK_PROVIDER}
+    WHERE id = ${pending.id}::bigint
+      AND provider = ${SLACK_PROVIDER}
       AND provider_app_id = ${SLACK_PROVIDER_APP_ID}
       AND external_tenant_id = ${pending.teamId}
+      AND organization_id = ${organizationId}
       AND status = 'pending'
   `;
   return { installationId: row.id };


### PR DESCRIPTION
## What

Atomically reserves a pending Slack installation before loading secrets or activating it. Only one organization can claim a pending workspace installation across replicas; a losing concurrent request cannot transfer it.

## Root cause

The previous path read the same pending row on multiple replicas and did the secret/activation work before any atomic ownership transition. Two organizations could therefore both observe the row as claimable.

## Validation

- Red: focused concurrency suite reproduced two successful claims where exactly one was expected
- Green: focused suite 22/22; related Slack installation suites 53/53
- `make typecheck` and `make build-packages`
- Full `make review` deterministic gates: typecheck=0, unit=0, integration=0
- The final Claude verdict step was attempted but could not run because the configured Claude account reported `Credit balance is too low`

Draft while the wider release-readiness fixes are reviewed independently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786223224&installation_id=136316292&pr_number=1831&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1831&signature=4b18a10a8c22ccab441c3cb5c47a001303642cc9de77726e24802bc30404c80d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->