### PR TITLE
fix(review): isolate runs and use Herdr tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 	@echo "  make dev-recover [RESTART=1]               - Free this checkout's dev ports + clean workers; RESTART=1 also boots make dev"
 	@echo "  make clean-test-pg                         - Reap orphaned lobu-test-pg embedded-Postgres clusters (frees macOS shm slots)"
 	@echo "  make typecheck                             - Strict typecheck (same as Dockerfile) for server + owletto"
-	@echo "  make task-setup NAME=<name> [CONTEXT=1]    - Create a paired worktree at .claude/worktrees/<name> (lobu + submodule, .env/ports; opens a Herdr workspace when herdr is on PATH; HERDR=0 to skip; CONTEXT=1 registers Lobu CLI context)"
+	@echo "  make task-setup NAME=<name> [CONTEXT=1]    - Create a paired worktree at .claude/worktrees/<name> (lobu + submodule, .env/ports; opens a Herdr tab/workspace when herdr is on PATH; HERDR=0 to skip; CONTEXT=1 registers Lobu CLI context)"
 	@echo "  make task-clean NAME=<name> [FORCE=1]      - Remove the worktree, both branches, and the Lobu context (refuses if there's uncommitted/unpushed work unless FORCE=1)"
 	@echo "  make e2e-browser [RESTART=1]               - Launch/reuse the stable 'owletto' Chrome harness (extension from this worktree) for Chrome e2e"
 	@echo "  make bump SUBMODULE=<path> [TARGET=<ref>]  - Lightweight worktree + commit + PR for a trivial submodule pointer bump (skips bun install, .env, ports)"

--- a/scripts/lib/__tests__/herdr-lifecycle.test.sh
+++ b/scripts/lib/__tests__/herdr-lifecycle.test.sh
@@ -49,6 +49,8 @@ herdr() {
         return 1
       elif [ "$mode" = "persisted-close-failure" ] && [ "${3:-}" = "workspace-a:persisted-tab" ]; then
         return 1
+      elif [ "$mode" = "retry-after-close" ] && [ "$(grep -c '^tab close workspace-a:retry-tab$' "$calls")" -gt 1 ]; then
+        return 1
       fi
       ;;
     "tab list")
@@ -64,6 +66,8 @@ herdr() {
         printf '{"result":{"tabs":[{"tab_id":"workspace-a:orphan-tab","label":"task-label"}]}}\n'
       elif [ "$mode" = "ambiguous-malformed-tab" ] && grep -q '^tab create ' "$calls"; then
         printf '{"result":{"tabs":[{"tab_id":"workspace-a:orphan-one","label":"task-label"},{"tab_id":"workspace-a:orphan-two","label":"task-label"}]}}\n'
+      elif [ "$mode" = "persisted-close-failure" ]; then
+        printf '{"result":{"tabs":[{"tab_id":"workspace-a:persisted-tab","label":"task-label"}]}}\n'
       else
         printf '{"result":{"tabs":[]}}\n'
       fi
@@ -288,6 +292,27 @@ test_persisted_tab_close_failure_fails_closed_and_preserves_metadata() {
   if grep -q '^workspace list' "$calls"; then
     fail "failed exact close fell through to legacy workspace discovery"
   fi
+}
+
+test_persisted_tab_close_is_retryable_after_later_cleanup_failure() {
+  local worktree="$tmp/retry-after-close"
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  herdr_task_metadata_write "$worktree" "workspace-a" "workspace-a:retry-tab"
+  HERDR_WORKSPACE_ID="workspace-b"
+  HERDR_TAB_ID="workspace-b:caller"
+  export HERDR_WORKSPACE_ID HERDR_TAB_ID
+  mode="retry-after-close"
+
+  : > "$calls"
+  herdr_task_close "$worktree" "task-label" ||
+    fail "initial exact persisted-tab close was not confirmed"
+  # Simulate task-clean failing later while removing the Git worktree. The
+  # persisted id is now stale and Herdr returns tab_not_found on the retry.
+  herdr_task_close "$worktree" "task-label" ||
+    fail "stale exact persisted-tab id made task-clean non-retryable"
+  [ "$(grep -c '^tab close workspace-a:retry-tab$' "$calls")" -eq 2 ] ||
+    fail "retry did not retain exact persisted-tab ownership"
 }
 
 test_task_clean_preserves_worktree_when_exact_close_fails() {
@@ -570,6 +595,7 @@ test_task_workspace_ambiguous_recovery_fails_closed
 test_ordinary_terminal_owns_and_closes_dedicated_workspace
 test_task_tab_cleanup_uses_persisted_identity_across_workspaces
 test_persisted_tab_close_failure_fails_closed_and_preserves_metadata
+test_persisted_tab_close_is_retryable_after_later_cleanup_failure
 test_task_clean_preserves_worktree_when_exact_close_fails
 test_legacy_lookup_closes_cross_workspace_task_tab
 test_ambiguous_legacy_tabs_fail_closed

--- a/scripts/lib/__tests__/herdr-lifecycle.test.sh
+++ b/scripts/lib/__tests__/herdr-lifecycle.test.sh
@@ -52,7 +52,9 @@ herdr() {
       fi
       ;;
     "tab list")
-      if [ "$mode" = "review-locator" ]; then
+      if [ "$mode" = "invalid-review-shape" ]; then
+        printf '{}\n'
+      elif [ "$mode" = "review-locator" ]; then
         if grep -q '^tab close workspace-a:located-review$' "$calls"; then
           printf '{"result":{"tabs":[{"tab_id":"workspace-a:stale-review","label":"locator-review"}]}}\n'
         else
@@ -91,7 +93,9 @@ herdr() {
       fi
       ;;
     "pane list")
-      if [ "$mode" = "review-locator" ]; then
+      if [ "$mode" = "invalid-review-shape" ]; then
+        printf '{}\n'
+      elif [ "$mode" = "review-locator" ]; then
         printf '{"result":{"panes":[{"tab_id":"workspace-a:stale-review","cwd":"%s","foreground_cwd":"%s"},{"tab_id":"workspace-a:located-review","cwd":"%s","foreground_cwd":"%s"}]}}\n' "$HERDR_REVIEW_CWD" "$HERDR_REVIEW_CWD" "$HERDR_REVIEW_CWD" "$HERDR_REVIEW_CWD"
       elif [ "$mode" = "legacy" ] && [ "${4:-}" = "legacy" ]; then
         printf '{"result":{"panes":[{"tab_id":"legacy:task-tab","cwd":"%s/subdir","foreground_cwd":"%s/subdir"}]}}\n' "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE"
@@ -286,6 +290,43 @@ test_persisted_tab_close_failure_fails_closed_and_preserves_metadata() {
   fi
 }
 
+test_task_clean_preserves_worktree_when_exact_close_fails() {
+  local fixture="$tmp/task-clean-fixture" worktree="$tmp/task-clean-fixture/.claude/worktrees/close-failure"
+  mkdir -p "$fixture/scripts/lib" "$fixture/.claude/worktrees" "$fixture/bin"
+  cp "$repo_root/scripts/task-clean.sh" "$fixture/scripts/task-clean.sh"
+  cp "$repo_root/scripts/lib/herdr-task.sh" "$fixture/scripts/lib/herdr-task.sh"
+  cp "$repo_root/scripts/lib/db-name.sh" "$fixture/scripts/lib/db-name.sh"
+  printf '.claude/worktrees/\n' > "$fixture/.gitignore"
+  git -C "$fixture" init -q -b main
+  git -C "$fixture" config user.name test
+  git -C "$fixture" config user.email test@example.com
+  git -C "$fixture" add .gitignore scripts
+  git -C "$fixture" commit -qm init
+  git -C "$fixture" worktree add -q -b feat/close-failure "$worktree" main
+  worktree="$(cd "$worktree" && pwd -P)"
+  herdr_task_metadata_write "$worktree" "workspace-a" "workspace-a:persisted-tab"
+
+  cat > "$fixture/bin/herdr" <<'HERDR'
+#!/usr/bin/env bash
+if [ "${1:-} ${2:-}" = "tab close" ]; then
+  exit 1
+fi
+exit 1
+HERDR
+  chmod +x "$fixture/bin/herdr"
+
+  if PATH="$fixture/bin:$PATH" HERDR=1 \
+    HERDR_WORKSPACE_ID="workspace-b" HERDR_TAB_ID="workspace-b:caller" \
+    bash "$fixture/scripts/task-clean.sh" close-failure --force >/dev/null 2>&1; then
+    fail "task-clean succeeded after the exact persisted Herdr close failed"
+  fi
+  [ -d "$worktree" ] || fail "task-clean deleted the worktree after exact close failure"
+  git -C "$fixture" worktree list --porcelain | grep -Fqx "worktree $worktree" ||
+    fail "task-clean unregistered the worktree after exact close failure"
+  [ "$(herdr_task_metadata_read "$worktree")" = "workspace-a workspace-a:persisted-tab" ] ||
+    fail "task-clean discarded retryable exact Herdr ownership metadata"
+}
+
 test_ambiguous_legacy_tabs_fail_closed() {
   local worktree="$tmp/ambiguous-legacy-worktree"
   mkdir -p "$worktree"
@@ -317,6 +358,22 @@ test_ambiguous_legacy_workspaces_fail_closed() {
   fi
   if grep -Eq '^(worktree remove|workspace close)' "$calls"; then
     fail "ambiguous legacy cleanup closed an unowned task workspace"
+  fi
+}
+
+test_absent_task_owner_is_a_confirmed_noop() {
+  local worktree="$tmp/no-owner-worktree"
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  unset HERDR_WORKSPACE_ID HERDR_TAB_ID
+  export HERDR_TEST_WORKTREE="$worktree"
+  mode="default"
+
+  : > "$calls"
+  herdr_task_close "$worktree" "missing-label" ||
+    fail "valid Herdr snapshots with no task owner did not report a clean no-op"
+  if grep -Eq '^(tab close|workspace close|worktree remove)' "$calls"; then
+    fail "no-owner cleanup mutated an unrelated Herdr resource"
   fi
 }
 
@@ -418,6 +475,33 @@ test_review_close_failure_preserves_state_and_transport() {
     fail "tab ownership was forgotten after unconfirmed close"
 }
 
+test_review_invalid_success_shapes_are_never_proof() {
+  local raw="$tmp/invalid-shape.raw" exit_file="$tmp/invalid-shape.exit" runner="$tmp/invalid-shape.runner" rc
+  printf 'partial review output\n' > "$raw"
+  printf 'runner\n' > "$runner"
+  : > "$calls"
+  mode="invalid-review-shape"
+
+  if herdr_review_snapshot_tabs "workspace-a" >/dev/null 2>&1; then
+    fail "structurally invalid tab snapshot was accepted"
+  fi
+
+  herdr_review_track_files "$raw" "$exit_file" "$runner"
+  herdr_review_track_locator "workspace-a" "review-label" "$tmp" ""
+  set +e
+  herdr_review_recover_tab >/dev/null 2>&1
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || fail "invalid recovery evidence exited $rc instead of ambiguous"
+
+  herdr_review_track_tab "workspace-a:review-tab"
+  if herdr_review_tab_absent "workspace-a:review-tab"; then
+    fail "structurally invalid tab list falsely proved exact tab absence"
+  fi
+  [ "$HERDR_REVIEW_TAB_ID" = "workspace-a:review-tab" ] ||
+    fail "invalid absence evidence discarded exact review ownership"
+}
+
 test_review_timeout_closes_tab_and_removes_transport_and_prompt() {
   local raw="$tmp/timeout.raw" exit_file="$tmp/timeout.exit" runner="$tmp/timeout.runner" prompt="$tmp/timeout.prompt"
   printf 'partial timeout output\n' > "$raw"
@@ -486,14 +570,17 @@ test_task_workspace_ambiguous_recovery_fails_closed
 test_ordinary_terminal_owns_and_closes_dedicated_workspace
 test_task_tab_cleanup_uses_persisted_identity_across_workspaces
 test_persisted_tab_close_failure_fails_closed_and_preserves_metadata
+test_task_clean_preserves_worktree_when_exact_close_fails
 test_legacy_lookup_closes_cross_workspace_task_tab
 test_ambiguous_legacy_tabs_fail_closed
 test_ambiguous_legacy_workspaces_fail_closed
+test_absent_task_owner_is_a_confirmed_noop
 test_current_task_tab_is_never_closed
 test_review_parses_current_herdr_tab_response
 test_review_cleanup_closes_tab_and_removes_temp_files
 test_review_abort_closes_tab_but_preserves_partial_output
 test_review_close_failure_preserves_state_and_transport
+test_review_invalid_success_shapes_are_never_proof
 test_review_timeout_closes_tab_and_removes_transport_and_prompt
 test_review_signals_remove_prompt
 

--- a/scripts/lib/__tests__/herdr-lifecycle.test.sh
+++ b/scripts/lib/__tests__/herdr-lifecycle.test.sh
@@ -27,7 +27,7 @@ herdr() {
   printf '%s\n' "$*" >> "$calls"
   case "${1:-} ${2:-}" in
     "tab create")
-      if [ "$mode" = "malformed-tab" ]; then
+      if [ "$mode" = "malformed-tab" ] || [ "$mode" = "ambiguous-malformed-tab" ]; then
         printf 'warning before malformed tab json\n'
       else
         printf '{"result":{"tab":{"tab_id":"workspace-a:tab-created"}}}\n'
@@ -47,6 +47,8 @@ herdr() {
         marker="$HERDR_REVIEW_EXIT_FILE"
         (sleep 0.1; printf 'late\n' > "$marker") &
         return 1
+      elif [ "$mode" = "persisted-close-failure" ] && [ "${3:-}" = "workspace-a:persisted-tab" ]; then
+        return 1
       fi
       ;;
     "tab list")
@@ -58,12 +60,14 @@ herdr() {
         fi
       elif [ "$mode" = "malformed-tab" ] && grep -q '^tab create ' "$calls"; then
         printf '{"result":{"tabs":[{"tab_id":"workspace-a:orphan-tab","label":"task-label"}]}}\n'
+      elif [ "$mode" = "ambiguous-malformed-tab" ] && grep -q '^tab create ' "$calls"; then
+        printf '{"result":{"tabs":[{"tab_id":"workspace-a:orphan-one","label":"task-label"},{"tab_id":"workspace-a:orphan-two","label":"task-label"}]}}\n'
       else
         printf '{"result":{"tabs":[]}}\n'
       fi
       ;;
     "worktree open")
-      if [ "$mode" = "malformed-workspace" ]; then
+      if [ "$mode" = "malformed-workspace" ] || [ "$mode" = "ambiguous-malformed-workspace" ]; then
         printf 'not-json\n'
       else
         printf '{"result":{"workspace":{"workspace_id":"dedicated-workspace"}}}\n'
@@ -72,10 +76,16 @@ herdr() {
     "workspace list")
       if [ "$mode" = "malformed-workspace" ] && grep -q '^worktree open ' "$calls"; then
         printf '{"result":{"workspaces":[{"workspace_id":"created-workspace","label":"task-label","worktree":{"checkout_path":"%s"}}]}}\n' "$HERDR_TEST_WORKTREE"
+      elif [ "$mode" = "ambiguous-malformed-workspace" ] && grep -q '^worktree open ' "$calls"; then
+        printf '{"result":{"workspaces":[{"workspace_id":"created-workspace-one","label":"task-label","worktree":{"checkout_path":"%s"}},{"workspace_id":"created-workspace-two","label":"task-label","worktree":{"checkout_path":"%s"}}]}}\n' "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE"
       elif [ "$mode" = "legacy" ]; then
         printf '{"result":{"workspaces":[{"workspace_id":"other","label":"other"},{"workspace_id":"legacy","label":"task-label"}]}}\n'
       elif [ "$mode" = "current-tab" ]; then
         printf '{"result":{"workspaces":[{"workspace_id":"workspace-a","label":"task-label"}]}}\n'
+      elif [ "$mode" = "ambiguous-legacy" ] || [ "$mode" = "persisted-close-failure" ]; then
+        printf '{"result":{"workspaces":[{"workspace_id":"workspace-a","label":"task-label"}]}}\n'
+      elif [ "$mode" = "ambiguous-legacy-workspace" ]; then
+        printf '{"result":{"workspaces":[{"workspace_id":"legacy-workspace-one","label":"task-label","worktree":{"checkout_path":"%s"}},{"workspace_id":"legacy-workspace-two","label":"task-label","worktree":{"checkout_path":"%s"}}]}}\n' "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE"
       else
         printf '{"result":{"workspaces":[]}}\n'
       fi
@@ -87,6 +97,12 @@ herdr() {
         printf '{"result":{"panes":[{"tab_id":"legacy:task-tab","cwd":"%s/subdir","foreground_cwd":"%s/subdir"}]}}\n' "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE"
       elif [ "$mode" = "current-tab" ]; then
         printf '{"result":{"panes":[{"tab_id":"workspace-a:current-tab","cwd":"%s","foreground_cwd":"%s"}]}}\n' "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE"
+      elif [ "$mode" = "ambiguous-malformed-tab" ]; then
+        printf '{"result":{"panes":[{"tab_id":"workspace-a:orphan-one","cwd":"%s","foreground_cwd":"%s"},{"tab_id":"workspace-a:orphan-two","cwd":"%s","foreground_cwd":"%s"}]}}\n' "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE"
+      elif [ "$mode" = "ambiguous-legacy" ]; then
+        printf '{"result":{"panes":[{"tab_id":"workspace-a:legacy-one","cwd":"%s","foreground_cwd":"%s"},{"tab_id":"workspace-a:legacy-two","cwd":"%s","foreground_cwd":"%s"}]}}\n' "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE"
+      elif [ "$mode" = "persisted-close-failure" ]; then
+        printf '{"result":{"panes":[{"tab_id":"workspace-a:fallback-tab","cwd":"%s","foreground_cwd":"%s"}]}}\n' "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE"
       else
         printf '{"result":{"panes":[]}}\n'
       fi
@@ -156,6 +172,24 @@ test_task_tab_malformed_create_response_closes_created_tab() {
     fail "malformed tab response orphaned the created tab"
 }
 
+test_task_tab_ambiguous_recovery_fails_closed() {
+  local worktree="$tmp/ambiguous-malformed-tab-worktree"
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  HERDR_WORKSPACE_ID="workspace-a"
+  HERDR_TAB_ID="workspace-a:caller"
+  export HERDR_WORKSPACE_ID HERDR_TAB_ID HERDR_TEST_WORKTREE="$worktree"
+  mode="ambiguous-malformed-tab"
+
+  : > "$calls"
+  if herdr_task_open "$worktree" "$worktree" "task-label" >/dev/null 2>&1; then
+    fail "ambiguous malformed tab response unexpectedly succeeded"
+  fi
+  if grep -q '^tab close ' "$calls"; then
+    fail "ambiguous recovery closed an unowned task tab"
+  fi
+}
+
 test_task_workspace_malformed_create_response_closes_created_workspace() {
   local worktree="$tmp/malformed-workspace"
   mkdir -p "$worktree"
@@ -170,6 +204,23 @@ test_task_workspace_malformed_create_response_closes_created_workspace() {
   fi
   grep -Eq '^worktree remove --workspace created-workspace( --force)?$|^workspace close created-workspace$' "$calls" ||
     fail "malformed workspace response orphaned the created workspace"
+}
+
+test_task_workspace_ambiguous_recovery_fails_closed() {
+  local worktree="$tmp/ambiguous-malformed-workspace"
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  unset HERDR_WORKSPACE_ID HERDR_TAB_ID
+  export HERDR_TEST_WORKTREE="$worktree"
+  mode="ambiguous-malformed-workspace"
+
+  : > "$calls"
+  if herdr_task_open "$worktree" "$worktree" "task-label" >/dev/null 2>&1; then
+    fail "ambiguous malformed workspace response unexpectedly succeeded"
+  fi
+  if grep -Eq '^(worktree remove|workspace close)' "$calls"; then
+    fail "ambiguous recovery closed an unowned task workspace"
+  fi
 }
 
 test_ordinary_terminal_owns_and_closes_dedicated_workspace() {
@@ -208,6 +259,65 @@ test_task_tab_cleanup_uses_persisted_identity_across_workspaces() {
 
   grep -Fxq "tab close workspace-a:tab-7" "$calls" ||
     fail "cross-workspace cleanup did not close the persisted task tab"
+}
+
+test_persisted_tab_close_failure_fails_closed_and_preserves_metadata() {
+  local worktree="$tmp/persisted-close-failure"
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  herdr_task_metadata_write "$worktree" "workspace-a" "workspace-a:persisted-tab"
+  HERDR_WORKSPACE_ID="workspace-b"
+  HERDR_TAB_ID="workspace-b:caller"
+  export HERDR_WORKSPACE_ID HERDR_TAB_ID HERDR_TEST_WORKTREE="$worktree"
+  mode="persisted-close-failure"
+
+  : > "$calls"
+  if herdr_task_close "$worktree" "task-label"; then
+    fail "failed exact persisted-tab close unexpectedly succeeded"
+  fi
+  [ "$(herdr_task_metadata_read "$worktree")" = "workspace-a workspace-a:persisted-tab" ] ||
+    fail "failed exact close discarded persisted task ownership"
+  [ "$(grep -c '^tab close ' "$calls")" -eq 1 ] ||
+    fail "failed exact close fell through to a heuristic tab close"
+  grep -Fxq 'tab close workspace-a:persisted-tab' "$calls" ||
+    fail "cleanup did not attempt the exact persisted tab"
+  if grep -q '^workspace list' "$calls"; then
+    fail "failed exact close fell through to legacy workspace discovery"
+  fi
+}
+
+test_ambiguous_legacy_tabs_fail_closed() {
+  local worktree="$tmp/ambiguous-legacy-worktree"
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  unset HERDR_WORKSPACE_ID HERDR_TAB_ID
+  export HERDR_TEST_WORKTREE="$worktree"
+  mode="ambiguous-legacy"
+
+  : > "$calls"
+  if herdr_task_close "$worktree" "task-label"; then
+    fail "ambiguous legacy task tabs unexpectedly reported success"
+  fi
+  if grep -q '^tab close ' "$calls"; then
+    fail "ambiguous legacy cleanup closed an unowned task tab"
+  fi
+}
+
+test_ambiguous_legacy_workspaces_fail_closed() {
+  local worktree="$tmp/ambiguous-legacy-workspace"
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  unset HERDR_WORKSPACE_ID HERDR_TAB_ID
+  export HERDR_TEST_WORKTREE="$worktree"
+  mode="ambiguous-legacy-workspace"
+
+  : > "$calls"
+  if herdr_task_close "$worktree" "task-label"; then
+    fail "ambiguous legacy task workspaces unexpectedly reported success"
+  fi
+  if grep -Eq '^(worktree remove|workspace close)' "$calls"; then
+    fail "ambiguous legacy cleanup closed an unowned task workspace"
+  fi
 }
 
 test_legacy_lookup_closes_cross_workspace_task_tab() {
@@ -370,10 +480,15 @@ test_review_signals_remove_prompt() {
 test_task_tab_open_records_identity
 test_repeated_task_setup_reuses_tab_without_orphaning
 test_task_tab_malformed_create_response_closes_created_tab
+test_task_tab_ambiguous_recovery_fails_closed
 test_task_workspace_malformed_create_response_closes_created_workspace
+test_task_workspace_ambiguous_recovery_fails_closed
 test_ordinary_terminal_owns_and_closes_dedicated_workspace
 test_task_tab_cleanup_uses_persisted_identity_across_workspaces
+test_persisted_tab_close_failure_fails_closed_and_preserves_metadata
 test_legacy_lookup_closes_cross_workspace_task_tab
+test_ambiguous_legacy_tabs_fail_closed
+test_ambiguous_legacy_workspaces_fail_closed
 test_current_task_tab_is_never_closed
 test_review_parses_current_herdr_tab_response
 test_review_cleanup_closes_tab_and_removes_temp_files

--- a/scripts/lib/__tests__/herdr-lifecycle.test.sh
+++ b/scripts/lib/__tests__/herdr-lifecycle.test.sh
@@ -36,13 +36,26 @@ herdr() {
     "tab get")
       if [ "$mode" = "repeat" ] && [ "${3:-}" = "workspace-a:tab-created" ]; then
         printf '{"result":{"tab":{"tab_id":"workspace-a:tab-created"}}}\n'
+      elif [ "$mode" = "review-close-failure" ]; then
+        printf '{"result":{"tab":{"tab_id":"workspace-a:review-tab"}}}\n'
       else
+        return 1
+      fi
+      ;;
+    "tab close")
+      if [ "$mode" = "review-close-failure" ]; then
+        marker="$HERDR_REVIEW_EXIT_FILE"
+        (sleep 0.1; printf 'late\n' > "$marker") &
         return 1
       fi
       ;;
     "tab list")
       if [ "$mode" = "review-locator" ]; then
-        printf '{"result":{"tabs":[{"tab_id":"workspace-a:located-review","label":"locator-review"}]}}\n'
+        if grep -q '^tab close workspace-a:located-review$' "$calls"; then
+          printf '{"result":{"tabs":[{"tab_id":"workspace-a:stale-review","label":"locator-review"}]}}\n'
+        else
+          printf '{"result":{"tabs":[{"tab_id":"workspace-a:stale-review","label":"locator-review"},{"tab_id":"workspace-a:located-review","label":"locator-review"}]}}\n'
+        fi
       elif [ "$mode" = "malformed-tab" ] && grep -q '^tab create ' "$calls"; then
         printf '{"result":{"tabs":[{"tab_id":"workspace-a:orphan-tab","label":"task-label"}]}}\n'
       else
@@ -68,7 +81,9 @@ herdr() {
       fi
       ;;
     "pane list")
-      if [ "$mode" = "legacy" ] && [ "${4:-}" = "legacy" ]; then
+      if [ "$mode" = "review-locator" ]; then
+        printf '{"result":{"panes":[{"tab_id":"workspace-a:stale-review","cwd":"%s","foreground_cwd":"%s"},{"tab_id":"workspace-a:located-review","cwd":"%s","foreground_cwd":"%s"}]}}\n' "$HERDR_REVIEW_CWD" "$HERDR_REVIEW_CWD" "$HERDR_REVIEW_CWD" "$HERDR_REVIEW_CWD"
+      elif [ "$mode" = "legacy" ] && [ "${4:-}" = "legacy" ]; then
         printf '{"result":{"panes":[{"tab_id":"legacy:task-tab","cwd":"%s/subdir","foreground_cwd":"%s/subdir"}]}}\n' "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE"
       elif [ "$mode" = "current-tab" ]; then
         printf '{"result":{"panes":[{"tab_id":"workspace-a:current-tab","cwd":"%s","foreground_cwd":"%s"}]}}\n' "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE"
@@ -78,6 +93,13 @@ herdr() {
       ;;
   esac
   return 0
+}
+
+test_review_parses_current_herdr_tab_response() {
+  local parsed
+  parsed="$(herdr_review_parse_created_tab '{"id":"cli:tab:create","result":{"type":"tab_created","tab":{"tab_id":"workspace-a:review-tab"},"root_pane":{"pane_id":"workspace-a:review-pane"}}}')"
+  [ "$parsed" = "workspace-a:review-tab workspace-a:review-pane" ] ||
+    fail "current Herdr tab response parsed as: $parsed"
 }
 
 test_task_tab_open_records_identity() {
@@ -235,6 +257,8 @@ test_review_cleanup_closes_tab_and_removes_temp_files() {
 
   grep -Fxq "tab close workspace-a:review-tab" "$calls" ||
     fail "normal review cleanup did not close its tab"
+  grep -Fxq "tab get workspace-a:review-tab" "$calls" ||
+    fail "normal review cleanup did not verify tab closure"
   assert_file_missing "$raw"
   assert_file_missing "$exit_file"
   assert_file_missing "$runner"
@@ -249,15 +273,39 @@ test_review_abort_closes_tab_but_preserves_partial_output() {
 
   herdr_review_track_files "$raw" "$exit_file" "$runner"
   # Model interruption after tab creation but before create's JSON was parsed:
-  # cleanup must recover the id from the unique label locator.
-  herdr_review_track_locator "workspace-a" "locator-review"
+  # cleanup must ignore a pre-existing same-label tab and recover only the new
+  # tab whose pane has this run's exact cwd.
+  herdr_review_track_locator "workspace-a" "locator-review" "$tmp" "workspace-a:stale-review"
   herdr_review_abort >/dev/null 2>&1
 
   grep -Fxq "tab close workspace-a:located-review" "$calls" ||
     fail "aborted review cleanup did not close its tab"
+  if grep -Fxq "tab close workspace-a:stale-review" "$calls"; then
+    fail "aborted review cleanup closed the stale same-label tab"
+  fi
   [ -s "$raw" ] || fail "aborted review output was not preserved"
   assert_file_missing "$exit_file"
   assert_file_missing "$runner"
+}
+
+test_review_close_failure_preserves_state_and_transport() {
+  local raw="$tmp/failed-close.raw" exit_file="$tmp/failed-close.exit" runner="$tmp/failed-close.runner"
+  printf 'partial review output\n' > "$raw"
+  printf 'runner\n' > "$runner"
+  : > "$calls"
+  mode="review-close-failure"
+
+  herdr_review_track_files "$raw" "$exit_file" "$runner"
+  herdr_review_track_tab "workspace-a:review-tab"
+  if herdr_review_cleanup >/dev/null 2>&1; then
+    fail "unconfirmed Herdr tab close unexpectedly succeeded"
+  fi
+  sleep 0.2
+  [ -e "$raw" ] || fail "raw output was deleted after unconfirmed close"
+  [ -e "$exit_file" ] || fail "late exit marker was not preserved after unconfirmed close"
+  [ -e "$runner" ] || fail "runner was deleted after unconfirmed close"
+  [ "$HERDR_REVIEW_TAB_ID" = "workspace-a:review-tab" ] ||
+    fail "tab ownership was forgotten after unconfirmed close"
 }
 
 test_review_timeout_closes_tab_and_removes_transport_and_prompt() {
@@ -327,8 +375,10 @@ test_ordinary_terminal_owns_and_closes_dedicated_workspace
 test_task_tab_cleanup_uses_persisted_identity_across_workspaces
 test_legacy_lookup_closes_cross_workspace_task_tab
 test_current_task_tab_is_never_closed
+test_review_parses_current_herdr_tab_response
 test_review_cleanup_closes_tab_and_removes_temp_files
 test_review_abort_closes_tab_but_preserves_partial_output
+test_review_close_failure_preserves_state_and_transport
 test_review_timeout_closes_tab_and_removes_transport_and_prompt
 test_review_signals_remove_prompt
 

--- a/scripts/lib/__tests__/herdr-lifecycle.test.sh
+++ b/scripts/lib/__tests__/herdr-lifecycle.test.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+# shellcheck source=scripts/lib/herdr-task.sh
+. "$repo_root/scripts/lib/herdr-task.sh"
+# shellcheck source=scripts/lib/herdr-review-lifecycle.sh
+. "$repo_root/scripts/lib/herdr-review-lifecycle.sh"
+
+tmp="$(mktemp -d /tmp/lobu-herdr-lifecycle-test.XXXXXX)"
+trap 'rm -rf "$tmp"' EXIT
+calls="$tmp/herdr-calls"
+mode="default"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_missing() {
+  [ ! -e "$1" ] || fail "expected $1 to be removed"
+}
+
+herdr() {
+  printf '%s\n' "$*" >> "$calls"
+  case "${1:-} ${2:-}" in
+    "tab create")
+      if [ "$mode" = "malformed-tab" ]; then
+        printf 'warning before malformed tab json\n'
+      else
+        printf '{"result":{"tab":{"tab_id":"workspace-a:tab-created"}}}\n'
+      fi
+      ;;
+    "tab get")
+      if [ "$mode" = "repeat" ] && [ "${3:-}" = "workspace-a:tab-created" ]; then
+        printf '{"result":{"tab":{"tab_id":"workspace-a:tab-created"}}}\n'
+      else
+        return 1
+      fi
+      ;;
+    "tab list")
+      if [ "$mode" = "review-locator" ]; then
+        printf '{"result":{"tabs":[{"tab_id":"workspace-a:located-review","label":"locator-review"}]}}\n'
+      elif [ "$mode" = "malformed-tab" ] && grep -q '^tab create ' "$calls"; then
+        printf '{"result":{"tabs":[{"tab_id":"workspace-a:orphan-tab","label":"task-label"}]}}\n'
+      else
+        printf '{"result":{"tabs":[]}}\n'
+      fi
+      ;;
+    "worktree open")
+      if [ "$mode" = "malformed-workspace" ]; then
+        printf 'not-json\n'
+      else
+        printf '{"result":{"workspace":{"workspace_id":"dedicated-workspace"}}}\n'
+      fi
+      ;;
+    "workspace list")
+      if [ "$mode" = "malformed-workspace" ] && grep -q '^worktree open ' "$calls"; then
+        printf '{"result":{"workspaces":[{"workspace_id":"created-workspace","label":"task-label","worktree":{"checkout_path":"%s"}}]}}\n' "$HERDR_TEST_WORKTREE"
+      elif [ "$mode" = "legacy" ]; then
+        printf '{"result":{"workspaces":[{"workspace_id":"other","label":"other"},{"workspace_id":"legacy","label":"task-label"}]}}\n'
+      elif [ "$mode" = "current-tab" ]; then
+        printf '{"result":{"workspaces":[{"workspace_id":"workspace-a","label":"task-label"}]}}\n'
+      else
+        printf '{"result":{"workspaces":[]}}\n'
+      fi
+      ;;
+    "pane list")
+      if [ "$mode" = "legacy" ] && [ "${4:-}" = "legacy" ]; then
+        printf '{"result":{"panes":[{"tab_id":"legacy:task-tab","cwd":"%s/subdir","foreground_cwd":"%s/subdir"}]}}\n' "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE"
+      elif [ "$mode" = "current-tab" ]; then
+        printf '{"result":{"panes":[{"tab_id":"workspace-a:current-tab","cwd":"%s","foreground_cwd":"%s"}]}}\n' "$HERDR_TEST_WORKTREE" "$HERDR_TEST_WORKTREE"
+      else
+        printf '{"result":{"panes":[]}}\n'
+      fi
+      ;;
+  esac
+  return 0
+}
+
+test_task_tab_open_records_identity() {
+  local worktree="$tmp/open-worktree" metadata
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  HERDR_WORKSPACE_ID="workspace-a"
+  HERDR_TAB_ID="workspace-a:tab-1"
+  export HERDR_WORKSPACE_ID HERDR_TAB_ID
+  mode="default"
+
+  : > "$calls"
+  [ "$(herdr_task_open "$worktree" "$worktree" "task-label")" = "workspace-a" ] ||
+    fail "task tab open did not return its workspace"
+  metadata="$(herdr_task_metadata_read "$worktree")"
+  [ "$metadata" = "workspace-a workspace-a:tab-created" ] ||
+    fail "task tab identity was not persisted: $metadata"
+}
+
+test_repeated_task_setup_reuses_tab_without_orphaning() {
+  local worktree="$tmp/repeated-worktree" create_count
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  HERDR_WORKSPACE_ID="workspace-a"
+  HERDR_TAB_ID="workspace-a:caller"
+  export HERDR_WORKSPACE_ID HERDR_TAB_ID
+  mode="repeat"
+
+  : > "$calls"
+  herdr_task_open "$worktree" "$worktree" "task-label" >/dev/null
+  herdr_task_open "$worktree" "$worktree" "task-label" >/dev/null
+
+  create_count=$(grep -c '^tab create ' "$calls")
+  [ "$create_count" -eq 1 ] ||
+    fail "repeated task setup created $create_count tabs instead of reusing one"
+  [ "$(herdr_task_metadata_read "$worktree")" = "workspace-a workspace-a:tab-created" ] ||
+    fail "repeated setup replaced the authoritative tab identity"
+}
+
+test_task_tab_malformed_create_response_closes_created_tab() {
+  local worktree="$tmp/malformed-tab-worktree"
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  HERDR_WORKSPACE_ID="workspace-a"
+  HERDR_TAB_ID="workspace-a:caller"
+  export HERDR_WORKSPACE_ID HERDR_TAB_ID
+  mode="malformed-tab"
+
+  : > "$calls"
+  if herdr_task_open "$worktree" "$worktree" "task-label" >/dev/null 2>&1; then
+    fail "malformed tab response unexpectedly succeeded"
+  fi
+  grep -Fxq "tab close workspace-a:orphan-tab" "$calls" ||
+    fail "malformed tab response orphaned the created tab"
+}
+
+test_task_workspace_malformed_create_response_closes_created_workspace() {
+  local worktree="$tmp/malformed-workspace"
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  unset HERDR_WORKSPACE_ID HERDR_TAB_ID
+  export HERDR_TEST_WORKTREE="$worktree"
+  mode="malformed-workspace"
+
+  : > "$calls"
+  if herdr_task_open "$worktree" "$worktree" "task-label" >/dev/null 2>&1; then
+    fail "malformed workspace response unexpectedly succeeded"
+  fi
+  grep -Eq '^worktree remove --workspace created-workspace( --force)?$|^workspace close created-workspace$' "$calls" ||
+    fail "malformed workspace response orphaned the created workspace"
+}
+
+test_ordinary_terminal_owns_and_closes_dedicated_workspace() {
+  local worktree="$tmp/ordinary-worktree"
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  unset HERDR_WORKSPACE_ID HERDR_TAB_ID
+  mode="ordinary"
+
+  : > "$calls"
+  [ "$(herdr_task_open "$worktree" "$worktree" "task-label")" = "dedicated-workspace" ] ||
+    fail "ordinary terminal did not create a dedicated workspace"
+  [ "$(herdr_task_metadata_read "$worktree")" = "dedicated-workspace " ] ||
+    fail "ordinary terminal workspace identity was not persisted"
+  herdr_task_close "$worktree" "task-label"
+  grep -Fxq "worktree remove --workspace dedicated-workspace" "$calls" ||
+    fail "ordinary terminal cleanup did not remove its dedicated workspace"
+  if grep -q '^tab create ' "$calls"; then
+    fail "ordinary terminal unexpectedly created a tab without a current workspace"
+  fi
+}
+
+test_task_tab_cleanup_uses_persisted_identity_across_workspaces() {
+  local worktree="$tmp/worktree"
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+
+  herdr_task_metadata_write "$worktree" "workspace-a" "workspace-a:tab-7"
+  HERDR_WORKSPACE_ID="workspace-b"
+  HERDR_TAB_ID="workspace-b:tab-1"
+  export HERDR_WORKSPACE_ID HERDR_TAB_ID
+  mode="default"
+
+  : > "$calls"
+  herdr_task_close "$worktree" "task-label"
+
+  grep -Fxq "tab close workspace-a:tab-7" "$calls" ||
+    fail "cross-workspace cleanup did not close the persisted task tab"
+}
+
+test_legacy_lookup_closes_cross_workspace_task_tab() {
+  local worktree="$tmp/legacy-worktree"
+  mkdir -p "$worktree/subdir"
+  git -C "$worktree" init -q
+  unset HERDR_WORKSPACE_ID HERDR_TAB_ID
+  export HERDR_TEST_WORKTREE="$worktree"
+  mode="legacy"
+
+  : > "$calls"
+  herdr_task_close "$worktree" "task-label"
+  grep -Fxq "tab close legacy:task-tab" "$calls" ||
+    fail "legacy cross-workspace lookup did not close the task tab"
+}
+
+test_current_task_tab_is_never_closed() {
+  local worktree="$tmp/current-worktree"
+  mkdir -p "$worktree"
+  git -C "$worktree" init -q
+  herdr_task_metadata_write "$worktree" "workspace-a" "workspace-a:current-tab"
+  HERDR_WORKSPACE_ID="workspace-a"
+  HERDR_TAB_ID="workspace-a:current-tab"
+  export HERDR_WORKSPACE_ID HERDR_TAB_ID HERDR_TEST_WORKTREE="$worktree"
+  mode="current-tab"
+
+  : > "$calls"
+  if herdr_task_close "$worktree" "task-label"; then
+    fail "current-tab cleanup unexpectedly reported that it closed an owner"
+  fi
+  if grep -Eq '^(tab close|workspace close|worktree remove)' "$calls"; then
+    fail "current task cleanup attempted to close its own tab/workspace"
+  fi
+}
+
+test_review_cleanup_closes_tab_and_removes_temp_files() {
+  local raw="$tmp/review.raw" exit_file="$tmp/review.exit" runner="$tmp/review.runner"
+  printf 'review output\n' > "$raw"
+  printf '0\n' > "$exit_file"
+  printf 'runner\n' > "$runner"
+  : > "$calls"
+  mode="default"
+
+  herdr_review_track_files "$raw" "$exit_file" "$runner"
+  herdr_review_track_tab "workspace-a:review-tab"
+  herdr_review_cleanup
+
+  grep -Fxq "tab close workspace-a:review-tab" "$calls" ||
+    fail "normal review cleanup did not close its tab"
+  assert_file_missing "$raw"
+  assert_file_missing "$exit_file"
+  assert_file_missing "$runner"
+}
+
+test_review_abort_closes_tab_but_preserves_partial_output() {
+  local raw="$tmp/aborted.raw" exit_file="$tmp/aborted.exit" runner="$tmp/aborted.runner"
+  printf 'partial review output\n' > "$raw"
+  printf 'runner\n' > "$runner"
+  : > "$calls"
+  mode="review-locator"
+
+  herdr_review_track_files "$raw" "$exit_file" "$runner"
+  # Model interruption after tab creation but before create's JSON was parsed:
+  # cleanup must recover the id from the unique label locator.
+  herdr_review_track_locator "workspace-a" "locator-review"
+  herdr_review_abort >/dev/null 2>&1
+
+  grep -Fxq "tab close workspace-a:located-review" "$calls" ||
+    fail "aborted review cleanup did not close its tab"
+  [ -s "$raw" ] || fail "aborted review output was not preserved"
+  assert_file_missing "$exit_file"
+  assert_file_missing "$runner"
+}
+
+test_review_timeout_closes_tab_and_removes_transport_and_prompt() {
+  local raw="$tmp/timeout.raw" exit_file="$tmp/timeout.exit" runner="$tmp/timeout.runner" prompt="$tmp/timeout.prompt"
+  printf 'partial timeout output\n' > "$raw"
+  printf 'runner\n' > "$runner"
+  printf 'prompt\n' > "$prompt"
+  : > "$calls"
+  mode="default"
+
+  herdr_review_track_files "$raw" "$exit_file" "$runner"
+  herdr_review_track_prompt "$prompt"
+  herdr_review_track_tab "workspace-a:timeout-tab"
+  herdr_review_close_tab
+  herdr_review_cleanup
+  herdr_review_release_prompt
+
+  grep -Fxq "tab close workspace-a:timeout-tab" "$calls" ||
+    fail "review timeout cleanup did not close its tab"
+  assert_file_missing "$raw"
+  assert_file_missing "$exit_file"
+  assert_file_missing "$runner"
+  assert_file_missing "$prompt"
+}
+
+test_review_signals_remove_prompt() {
+  local signal expected prompt rc lifecycle
+  lifecycle="$repo_root/scripts/lib/herdr-review-lifecycle.sh"
+  grep -Fq "trap 'exit 130' INT" "$repo_root/scripts/review.sh" ||
+    fail "review script does not route Ctrl-C through deterministic EXIT cleanup"
+  grep -Fq "trap 'exit 143' TERM" "$repo_root/scripts/review.sh" ||
+    fail "review script does not route TERM through deterministic EXIT cleanup"
+
+  for signal in INT TERM; do
+    case "$signal" in INT) expected=130 ;; TERM) expected=143 ;; esac
+    prompt="$tmp/signal-${signal}.prompt"
+    printf 'prompt\n' > "$prompt"
+    set +e
+    PROMPT="$prompt" SIGNAL="$signal" EXPECTED="$expected" LIFECYCLE="$lifecycle" bash -c '
+      set -euo pipefail
+      . "$LIFECYCLE"
+      herdr() { return 0; }
+      herdr_review_track_prompt "$PROMPT"
+      cleanup() {
+        ec=$?
+        trap - EXIT INT TERM
+        herdr_review_abort
+        exit "$ec"
+      }
+      trap cleanup EXIT
+      trap "exit 130" INT
+      trap "exit 143" TERM
+      kill -s "$SIGNAL" "$$"
+    ' >/dev/null 2>&1
+    rc=$?
+    set -e
+    [ "$rc" -eq "$expected" ] || fail "$signal cleanup exited $rc, expected $expected"
+    assert_file_missing "$prompt"
+  done
+}
+
+test_task_tab_open_records_identity
+test_repeated_task_setup_reuses_tab_without_orphaning
+test_task_tab_malformed_create_response_closes_created_tab
+test_task_workspace_malformed_create_response_closes_created_workspace
+test_ordinary_terminal_owns_and_closes_dedicated_workspace
+test_task_tab_cleanup_uses_persisted_identity_across_workspaces
+test_legacy_lookup_closes_cross_workspace_task_tab
+test_current_task_tab_is_never_closed
+test_review_cleanup_closes_tab_and_removes_temp_files
+test_review_abort_closes_tab_but_preserves_partial_output
+test_review_timeout_closes_tab_and_removes_transport_and_prompt
+test_review_signals_remove_prompt
+
+echo "herdr lifecycle tests passed"

--- a/scripts/lib/__tests__/review-database-url.test.sh
+++ b/scripts/lib/__tests__/review-database-url.test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+# shellcheck source=scripts/lib/review-database-url.sh
+. "$repo_root/scripts/lib/review-database-url.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+accept() {
+  validate_review_database_url "$1" >/dev/null || fail "rejected safe URL: $1"
+}
+
+reject() {
+  if validate_review_database_url "$1" >/dev/null 2>&1; then
+    fail "accepted unsafe URL: $1"
+  fi
+}
+
+accept 'postgresql://user@127.0.0.1/lobu_test'
+accept 'postgres://user:secret@localhost:5432/lobu_test_review?sslmode=disable'
+reject 'postgresql://prod.example/production'
+reject 'postgresql://prod.example/lobu_test?database=production'
+reject 'postgresql://prod.example/lobu_test?%64atabase=production'
+reject 'postgresql://prod.example/lobu_test?database%00ignored=production'
+reject 'postgresql://prod.example/lobu_test?dbname=production'
+reject 'https://prod.example/lobu_test'
+reject 'not a database URL'
+
+echo "review database URL tests passed"

--- a/scripts/lib/__tests__/review-lock.test.sh
+++ b/scripts/lib/__tests__/review-lock.test.sh
@@ -84,17 +84,17 @@ wait
 # Signals stop and reap the active child before the host lock is released.
 signal_tmp="$tmp/signal"
 mkdir -p "$signal_tmp"
-TMPDIR="$tmp/signal-caller" bash -c '
+TMPDIR="$tmp/signal-caller" REVIEW_PROCESS_TERM_GRACE_SECONDS=0.3 bash -c '
   set -euo pipefail
   . "$1"
   . "$2"
   trap '\''stop_active_review_child; exit 143'\'' TERM
   trap '\''release_review_lock'\'' EXIT
   acquire_review_lock
-  touch "$3/held"
-  run_review_child bash -c '\''echo "$$" > "$1"; sleep 30'\'' bash "$3/child-pid"
+  run_review_child python3 "$3" late-grandchild "$4/child-pid" "$4/late-pid"
 ' bash "$repo_root/scripts/lib/review-lock.sh" \
-  "$repo_root/scripts/lib/review-process.sh" "$signal_tmp" &
+  "$repo_root/scripts/lib/review-process.sh" \
+  "$repo_root/scripts/lib/__tests__/review-process-fixture.py" "$signal_tmp" &
 holder_pid=$!
 while [ ! -f "$signal_tmp/child-pid" ]; do sleep 0.01; done
 child_pid="$(sed -n '1p' "$signal_tmp/child-pid")"
@@ -104,6 +104,10 @@ REVIEW_LOCK_TIMEOUT_SECONDS=10 REVIEW_LOCK_POLL_SECONDS=0.01 bash -c '
   acquire_review_lock >/dev/null
   if kill -0 "$3" 2>/dev/null; then
     touch "$2/reacquired-before-child-exit"
+  fi
+  late_pid="$(sed -n '\''1p'\'' "$2/late-pid" 2>/dev/null || true)"
+  if [ -n "$late_pid" ] && kill -0 "$late_pid" 2>/dev/null; then
+    touch "$2/reacquired-before-late-descendant-exit"
   fi
   touch "$2/reacquired"
   release_review_lock
@@ -121,6 +125,8 @@ contender_pid=""
 [ -e "$signal_tmp/reacquired" ] || fail "signal contender never reacquired the lock"
 [ ! -e "$signal_tmp/reacquired-before-child-exit" ] ||
   fail "host lock was reacquired before the active child exited"
+[ ! -e "$signal_tmp/reacquired-before-late-descendant-exit" ] ||
+  fail "host lock was reacquired before a late descendant exited"
 if kill -0 "$child_pid" 2>/dev/null; then
   fail "active child $child_pid survived signal cleanup"
 fi

--- a/scripts/lib/__tests__/review-lock.test.sh
+++ b/scripts/lib/__tests__/review-lock.test.sh
@@ -5,23 +5,29 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 # shellcheck source=scripts/lib/review-lock.sh
 . "$repo_root/scripts/lib/review-lock.sh"
+# shellcheck source=scripts/lib/review-process.sh
+. "$repo_root/scripts/lib/review-process.sh"
 
 tmp="$(mktemp -d /tmp/lobu-review-lock-test.XXXXXX)"
 holder_pid=""
+contender_pid=""
 cleanup() {
   [ -z "$holder_pid" ] || kill "$holder_pid" 2>/dev/null || true
+  [ -z "$contender_pid" ] || kill "$contender_pid" 2>/dev/null || true
   wait "$holder_pid" 2>/dev/null || true
+  wait "$contender_pid" 2>/dev/null || true
   rm -rf "$tmp"
 }
 trap cleanup EXIT
 export TMPDIR="$tmp"
+export REVIEW_LOCK_ROOT_FOR_TESTS="$tmp/host-lock"
 
 fail() {
   echo "FAIL: $*" >&2
   exit 1
 }
 
-# A live owner blocks a second review even when it advertises another database.
+# A live owner blocks a second review even with a different caller TMPDIR.
 TMPDIR="$tmp" bash -c '
   set -euo pipefail
   . "$1"
@@ -35,6 +41,7 @@ while [ ! -f "$tmp/held" ]; do sleep 0.05; done
 
 set +e
 REVIEW_DATABASE_URL='postgresql://user@127.0.0.1/lobu_test_other' \
+  TMPDIR="$tmp/another-tmp" \
   REVIEW_LOCK_TIMEOUT_SECONDS=0 acquire_review_lock >/dev/null 2>&1
 blocked_exit=$?
 set -e
@@ -44,13 +51,78 @@ touch "$tmp/release"
 wait "$holder_pid"
 holder_pid=""
 
-# A dead owner's symlink is recovered atomically.
-mkdir -p "$tmp/lobu-review-locks"
-ln -s 999999 "$tmp/lobu-review-locks/full-review"
+# A stale lock file has no ownership once its process is gone.
+mkdir -p "$REVIEW_LOCK_ROOT_FOR_TESTS"
+printf '999999\n' > "$REVIEW_LOCK_ROOT_FOR_TESTS/full-review.lock"
 acquire_review_lock
-[ "$(readlink "$tmp/lobu-review-locks/full-review")" = "$$" ] ||
-  fail "stale lock was not replaced"
 release_review_lock
-[ ! -e "$tmp/lobu-review-locks/full-review" ] || fail "owned lock was not released"
+
+# High-contention stale recovery must serialize every successful owner.
+printf '999999\n' > "$REVIEW_LOCK_ROOT_FOR_TESTS/full-review.lock"
+mkdir -p "$tmp/acquired"
+rm -f "$tmp/overlap"
+for contender in $(seq 1 40); do
+  TMPDIR="$tmp/caller-$contender" REVIEW_LOCK_TIMEOUT_SECONDS=10 \
+    REVIEW_LOCK_POLL_SECONDS=0.01 bash -c '
+      set -euo pipefail
+      . "$1"
+      acquire_review_lock >/dev/null
+      if ! mkdir "$2/critical" 2>/dev/null; then
+        touch "$2/overlap"
+      fi
+      touch "$2/acquired/$3"
+      sleep 0.02
+      rmdir "$2/critical" 2>/dev/null || true
+      release_review_lock
+    ' bash "$repo_root/scripts/lib/review-lock.sh" "$tmp" "$contender" &
+done
+wait
+[ ! -e "$tmp/overlap" ] || fail "high-contention owners overlapped"
+[ "$(find "$tmp/acquired" -type f | wc -l | tr -d ' ')" -eq 40 ] ||
+  fail "not every high-contention owner acquired the lock"
+
+# Signals stop and reap the active child before the host lock is released.
+signal_tmp="$tmp/signal"
+mkdir -p "$signal_tmp"
+TMPDIR="$tmp/signal-caller" bash -c '
+  set -euo pipefail
+  . "$1"
+  . "$2"
+  trap '\''stop_active_review_child; exit 143'\'' TERM
+  trap '\''release_review_lock'\'' EXIT
+  acquire_review_lock
+  touch "$3/held"
+  run_review_child bash -c '\''echo "$$" > "$1"; sleep 30'\'' bash "$3/child-pid"
+' bash "$repo_root/scripts/lib/review-lock.sh" \
+  "$repo_root/scripts/lib/review-process.sh" "$signal_tmp" &
+holder_pid=$!
+while [ ! -f "$signal_tmp/child-pid" ]; do sleep 0.01; done
+child_pid="$(sed -n '1p' "$signal_tmp/child-pid")"
+REVIEW_LOCK_TIMEOUT_SECONDS=10 REVIEW_LOCK_POLL_SECONDS=0.01 bash -c '
+  set -euo pipefail
+  . "$1"
+  acquire_review_lock >/dev/null
+  if kill -0 "$3" 2>/dev/null; then
+    touch "$2/reacquired-before-child-exit"
+  fi
+  touch "$2/reacquired"
+  release_review_lock
+' bash "$repo_root/scripts/lib/review-lock.sh" "$signal_tmp" "$child_pid" &
+contender_pid=$!
+kill -TERM "$holder_pid"
+set +e
+wait "$holder_pid"
+signal_exit=$?
+set -e
+holder_pid=""
+[ "$signal_exit" -eq 143 ] || fail "signal holder exited $signal_exit, expected 143"
+wait "$contender_pid"
+contender_pid=""
+[ -e "$signal_tmp/reacquired" ] || fail "signal contender never reacquired the lock"
+[ ! -e "$signal_tmp/reacquired-before-child-exit" ] ||
+  fail "host lock was reacquired before the active child exited"
+if kill -0 "$child_pid" 2>/dev/null; then
+  fail "active child $child_pid survived signal cleanup"
+fi
 
 echo "review lock tests passed"

--- a/scripts/lib/__tests__/review-lock.test.sh
+++ b/scripts/lib/__tests__/review-lock.test.sh
@@ -11,11 +11,17 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 tmp="$(mktemp -d /tmp/lobu-review-lock-test.XXXXXX)"
 holder_pid=""
 contender_pid=""
+status_holder=""
+status_waiter=""
 cleanup() {
   [ -z "$holder_pid" ] || kill "$holder_pid" 2>/dev/null || true
   [ -z "$contender_pid" ] || kill "$contender_pid" 2>/dev/null || true
+  [ -z "$status_holder" ] || kill "$status_holder" 2>/dev/null || true
+  [ -z "$status_waiter" ] || kill "$status_waiter" 2>/dev/null || true
   wait "$holder_pid" 2>/dev/null || true
   wait "$contender_pid" 2>/dev/null || true
+  wait "$status_holder" 2>/dev/null || true
+  wait "$status_waiter" 2>/dev/null || true
   rm -rf "$tmp"
 }
 trap cleanup EXIT
@@ -25,6 +31,15 @@ export REVIEW_LOCK_ROOT_FOR_TESTS="$tmp/host-lock"
 fail() {
   echo "FAIL: $*" >&2
   exit 1
+}
+
+wait_for_file() {
+  local path="$1" description="$2"
+  for _ in $(seq 1 500); do
+    [ -e "$path" ] && return 0
+    sleep 0.01
+  done
+  fail "timed out waiting for $description"
 }
 
 # A live owner blocks a second review even with a different caller TMPDIR.
@@ -37,7 +52,7 @@ TMPDIR="$tmp" bash -c '
   release_review_lock
 ' bash "$repo_root/scripts/lib/review-lock.sh" "$tmp" &
 holder_pid=$!
-while [ ! -f "$tmp/held" ]; do sleep 0.05; done
+wait_for_file "$tmp/held" "initial lock holder"
 
 set +e
 REVIEW_DATABASE_URL='postgresql://user@127.0.0.1/lobu_test_other' \
@@ -96,7 +111,7 @@ TMPDIR="$tmp/signal-caller" REVIEW_PROCESS_TERM_GRACE_SECONDS=0.3 bash -c '
   "$repo_root/scripts/lib/review-process.sh" \
   "$repo_root/scripts/lib/__tests__/review-process-fixture.py" "$signal_tmp" &
 holder_pid=$!
-while [ ! -f "$signal_tmp/child-pid" ]; do sleep 0.01; done
+wait_for_file "$signal_tmp/child-pid" "signal-test child pid"
 child_pid="$(sed -n '1p' "$signal_tmp/child-pid")"
 REVIEW_LOCK_TIMEOUT_SECONDS=10 REVIEW_LOCK_POLL_SECONDS=0.01 bash -c '
   set -euo pipefail
@@ -130,5 +145,94 @@ contender_pid=""
 if kill -0 "$child_pid" 2>/dev/null; then
   fail "active child $child_pid survived signal cleanup"
 fi
+
+# A review invocation that never acquires the lock does not own the commit
+# status. Timing out or being canceled while waiting must not overwrite the
+# active owner's pending status.
+status_tmp="$tmp/status-waiter"
+mkdir -p "$status_tmp/bin" "$status_tmp/lock"
+cat > "$status_tmp/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$status_tmp/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "auth status") exit 0 ;;
+  "repo view") printf 'lobu-ai/lobu\n' ;;
+  "api -X") printf '%s\n' "$*" >> "$REVIEW_STATUS_CALLS" ;;
+esac
+EOF
+chmod +x "$status_tmp/bin/claude" "$status_tmp/bin/gh"
+
+REVIEW_LOCK_ROOT_FOR_TESTS="$status_tmp/lock" HOLDER_READY="$status_tmp/holder-ready" bash -c '
+  set -euo pipefail
+  . "$1/scripts/lib/review-lock.sh"
+  acquire_review_lock
+  : > "$HOLDER_READY"
+  sleep 30
+' bash "$repo_root" &
+status_holder=$!
+for _ in $(seq 1 100); do
+  [ -e "$status_tmp/holder-ready" ] && break
+  sleep 0.02
+done
+[ -e "$status_tmp/holder-ready" ] || fail "status-test lock holder never started"
+
+: > "$status_tmp/status-calls"
+set +e
+PATH="$status_tmp/bin:$PATH" \
+  REVIEW_STATUS_CALLS="$status_tmp/status-calls" \
+  REVIEW_LOCK_ROOT_FOR_TESTS="$status_tmp/lock" \
+  REVIEW_LOCK_TIMEOUT_SECONDS=0 \
+  bash "$repo_root/scripts/review.sh" >/dev/null 2>&1
+waiter_exit=$?
+set -e
+[ "$waiter_exit" -eq 2 ] || fail "timed-out review waiter exited $waiter_exit"
+[ ! -s "$status_tmp/status-calls" ] || fail "timed-out review waiter posted a commit status"
+
+: > "$status_tmp/status-calls"
+PATH="$status_tmp/bin:$PATH" \
+  REVIEW_STATUS_CALLS="$status_tmp/status-calls" \
+  REVIEW_LOCK_ROOT_FOR_TESTS="$status_tmp/lock" \
+  REVIEW_LOCK_TIMEOUT_SECONDS=30 \
+  REVIEW_LOCK_POLL_SECONDS=0.05 \
+  bash "$repo_root/scripts/review.sh" >"$status_tmp/waiter.out" 2>&1 &
+status_waiter=$!
+for _ in $(seq 1 100); do
+  grep -q 'another full review owns this host' "$status_tmp/waiter.out" 2>/dev/null && break
+  sleep 0.02
+done
+grep -q 'another full review owns this host' "$status_tmp/waiter.out" 2>/dev/null ||
+  fail "cancel-test review waiter never blocked on the lock"
+kill -TERM "$status_waiter"
+set +e
+wait "$status_waiter"
+waiter_exit=$?
+set -e
+status_waiter=""
+[ "$waiter_exit" -eq 143 ] || fail "canceled review waiter exited $waiter_exit"
+[ ! -s "$status_tmp/status-calls" ] || fail "canceled review waiter posted a commit status"
+
+kill "$status_holder" 2>/dev/null || true
+wait "$status_holder" 2>/dev/null || true
+status_holder=""
+
+# Once the invocation acquires the lock and starts the pending status, an early
+# failure still finalizes that owned status as an error.
+: > "$status_tmp/status-calls"
+set +e
+PATH="$status_tmp/bin:$PATH" \
+  REVIEW_STATUS_CALLS="$status_tmp/status-calls" \
+  REVIEW_LOCK_ROOT_FOR_TESTS="$status_tmp/lock" \
+  REVIEW_DATABASE_URL='postgres://localhost/production' \
+  bash "$repo_root/scripts/review.sh" >/dev/null 2>&1
+owner_exit=$?
+set -e
+[ "$owner_exit" -eq 2 ] || fail "early-failing review owner exited $owner_exit"
+[ "$(grep -c 'state=pending' "$status_tmp/status-calls")" -eq 1 ] ||
+  fail "review owner did not post exactly one pending status"
+[ "$(grep -c 'state=error' "$status_tmp/status-calls")" -eq 1 ] ||
+  fail "review owner did not finalize its pending status as error"
 
 echo "review lock tests passed"

--- a/scripts/lib/__tests__/review-lock.test.sh
+++ b/scripts/lib/__tests__/review-lock.test.sh
@@ -7,6 +7,8 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 . "$repo_root/scripts/lib/review-lock.sh"
 # shellcheck source=scripts/lib/review-process.sh
 . "$repo_root/scripts/lib/review-process.sh"
+# shellcheck source=scripts/lib/herdr-review-lifecycle.sh
+. "$repo_root/scripts/lib/herdr-review-lifecycle.sh"
 
 tmp="$(mktemp -d /tmp/lobu-review-lock-test.XXXXXX)"
 holder_pid=""
@@ -234,5 +236,71 @@ set -e
   fail "review owner did not post exactly one pending status"
 [ "$(grep -c 'state=error' "$status_tmp/status-calls")" -eq 1 ] ||
   fail "review owner did not finalize its pending status as error"
+
+# A signaled review whose exact Herdr tab cannot yet be closed must retain the
+# host lock until its runner termination is confirmed. A second review cannot
+# enter the destructive suite during that ambiguous interval.
+close_tmp="$tmp/close-retains-lock"
+mkdir -p "$close_tmp/lock"
+REVIEW_LOCK_ROOT_FOR_TESTS="$close_tmp/lock" \
+  REVIEW_CLOSE_RETRY_SECONDS_FOR_TESTS=0.01 \
+  LOCK_LIB="$repo_root/scripts/lib/review-lock.sh" \
+  LIFECYCLE_LIB="$repo_root/scripts/lib/herdr-review-lifecycle.sh" \
+  CLOSE_TMP="$close_tmp" bash -c '
+    set -euo pipefail
+    . "$LOCK_LIB"
+    . "$LIFECYCLE_LIB"
+    herdr() {
+      case "${1:-} ${2:-}" in
+        "tab close") : > "$CLOSE_TMP/close-attempted"; return 1 ;;
+        "tab get") printf '\''{"result":{"tab":{"tab_id":"workspace-a:review-tab"}}}\n'\'' ;;
+        "tab list") printf '\''{"result":{"tabs":[{"tab_id":"workspace-a:review-tab"}]}}\n'\'' ;;
+        *) return 1 ;;
+      esac
+    }
+    cleanup() {
+      ec=$?
+      trap - EXIT INT TERM HUP
+      herdr_review_abort_until_safe_to_release_lock
+      release_review_lock
+      exit "$ec"
+    }
+    trap cleanup EXIT
+    trap "exit 143" TERM
+    acquire_review_lock
+    raw="$CLOSE_TMP/review.raw"
+    exit_file="$CLOSE_TMP/review.exit"
+    runner="$CLOSE_TMP/review.runner"
+    printf partial > "$raw"
+    printf runner > "$runner"
+    herdr_review_track_files "$raw" "$exit_file" "$runner"
+    herdr_review_track_locator workspace-a review-label "$CLOSE_TMP" ""
+    herdr_review_track_tab workspace-a:review-tab
+    herdr_review_mark_runner_may_be_live
+    : > "$CLOSE_TMP/holder-ready"
+    while true; do sleep 0.05; done
+  ' &
+holder_pid=$!
+wait_for_file "$close_tmp/holder-ready" "close-failure lock holder"
+kill -TERM "$holder_pid"
+wait_for_file "$close_tmp/close-attempted" "exact Herdr close attempt"
+
+set +e
+REVIEW_LOCK_ROOT_FOR_TESTS="$close_tmp/lock" REVIEW_LOCK_TIMEOUT_SECONDS=0 \
+  bash -c '. "$1"; acquire_review_lock' bash "$repo_root/scripts/lib/review-lock.sh" >/dev/null 2>&1
+blocked_exit=$?
+set -e
+[ "$blocked_exit" -eq 2 ] || fail "second review acquired lock while Herdr runner might still live"
+
+printf '143\n' > "$close_tmp/review.exit"
+set +e
+wait "$holder_pid"
+holder_exit=$?
+set -e
+holder_pid=""
+[ "$holder_exit" -eq 143 ] || fail "signaled close-failure owner exited $holder_exit"
+
+REVIEW_LOCK_ROOT_FOR_TESTS="$close_tmp/lock" REVIEW_LOCK_TIMEOUT_SECONDS=0 \
+  bash -c '. "$1"; acquire_review_lock; release_review_lock' bash "$repo_root/scripts/lib/review-lock.sh"
 
 echo "review lock tests passed"

--- a/scripts/lib/__tests__/review-lock.test.sh
+++ b/scripts/lib/__tests__/review-lock.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+# shellcheck source=scripts/lib/review-lock.sh
+. "$repo_root/scripts/lib/review-lock.sh"
+
+tmp="$(mktemp -d /tmp/lobu-review-lock-test.XXXXXX)"
+holder_pid=""
+cleanup() {
+  [ -z "$holder_pid" ] || kill "$holder_pid" 2>/dev/null || true
+  wait "$holder_pid" 2>/dev/null || true
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+export TMPDIR="$tmp"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# A live owner blocks a second review even when it advertises another database.
+TMPDIR="$tmp" bash -c '
+  set -euo pipefail
+  . "$1"
+  acquire_review_lock
+  touch "$2/held"
+  while [ ! -f "$2/release" ]; do sleep 0.05; done
+  release_review_lock
+' bash "$repo_root/scripts/lib/review-lock.sh" "$tmp" &
+holder_pid=$!
+while [ ! -f "$tmp/held" ]; do sleep 0.05; done
+
+set +e
+REVIEW_DATABASE_URL='postgresql://user@127.0.0.1/lobu_test_other' \
+  REVIEW_LOCK_TIMEOUT_SECONDS=0 acquire_review_lock >/dev/null 2>&1
+blocked_exit=$?
+set -e
+[ "$blocked_exit" -eq 2 ] || fail "concurrent review was not blocked (exit $blocked_exit)"
+
+touch "$tmp/release"
+wait "$holder_pid"
+holder_pid=""
+
+# A dead owner's symlink is recovered atomically.
+mkdir -p "$tmp/lobu-review-locks"
+ln -s 999999 "$tmp/lobu-review-locks/full-review"
+acquire_review_lock
+[ "$(readlink "$tmp/lobu-review-locks/full-review")" = "$$" ] ||
+  fail "stale lock was not replaced"
+release_review_lock
+[ ! -e "$tmp/lobu-review-locks/full-review" ] || fail "owned lock was not released"
+
+echo "review lock tests passed"

--- a/scripts/lib/__tests__/review-lock.test.sh
+++ b/scripts/lib/__tests__/review-lock.test.sh
@@ -16,6 +16,14 @@ contender_pid=""
 status_holder=""
 status_waiter=""
 cleanup() {
+  trap - EXIT INT TERM HUP
+  # The close-retains-lock fixture deliberately turns TERM into a wait for its
+  # runner marker. If this test itself is interrupted before the main path
+  # writes that marker, a plain TERM+wait deadlocks and leaves FD 9 held. Give
+  # the synthetic runner its terminal marker before stopping the fixture.
+  if [ -n "$holder_pid" ] && [ -d "$tmp/close-retains-lock" ]; then
+    printf '143\n' > "$tmp/close-retains-lock/review.exit" 2>/dev/null || true
+  fi
   [ -z "$holder_pid" ] || kill "$holder_pid" 2>/dev/null || true
   [ -z "$contender_pid" ] || kill "$contender_pid" 2>/dev/null || true
   [ -z "$status_holder" ] || kill "$status_holder" 2>/dev/null || true
@@ -27,6 +35,9 @@ cleanup() {
   rm -rf "$tmp"
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 export TMPDIR="$tmp"
 export REVIEW_LOCK_ROOT_FOR_TESTS="$tmp/host-lock"
 

--- a/scripts/lib/__tests__/review-process-fixture.py
+++ b/scripts/lib/__tests__/review-process-fixture.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Process-tree fixtures for the review supervisor shell tests."""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def late_grandchild(ready_path: Path, late_pid_path: Path) -> None:
+    def terminate(_signum: int, _frame: object) -> None:
+        child = subprocess.Popen(["sleep", "30"], close_fds=True)
+        late_pid_path.write_text(f"{child.pid}\n", encoding="utf-8")
+        while True:
+            time.sleep(1)
+
+    signal.signal(signal.SIGTERM, terminate)
+    ready_path.write_text(f"{os.getpid()}\n", encoding="utf-8")
+    while True:
+        time.sleep(1)
+
+
+def main() -> int:
+    if len(sys.argv) != 4 or sys.argv[1] != "late-grandchild":
+        print(
+            "usage: review-process-fixture.py late-grandchild READY LATE_PID",
+            file=sys.stderr,
+        )
+        return 2
+    late_grandchild(Path(sys.argv[2]), Path(sys.argv[3]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/__tests__/review-process.test.sh
+++ b/scripts/lib/__tests__/review-process.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+# shellcheck source=scripts/lib/review-process.sh
+. "$repo_root/scripts/lib/review-process.sh"
+
+tmp="$(mktemp -d /tmp/lobu-review-process-test.XXXXXX)"
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+HERDR_WORKSPACE_ID='test-workspace'
+REVIEW_HERDR_PANE_ID=''
+REVIEW_HERDR_PANE_NAME='test-review-pane'
+REVIEW_HERDR_RAW_FILE="$tmp/raw"
+REVIEW_HERDR_EXIT_FILE="$tmp/exit"
+touch "$REVIEW_HERDR_RAW_FILE" "$REVIEW_HERDR_EXIT_FILE"
+
+herdr() {
+  case "$1 $2" in
+    'pane list')
+      printf '%s\n' '{"result":{"panes":[{"label":"test-review-pane","pane_id":"test-pane"}]}}'
+      ;;
+    'pane close')
+      printf '%s\n' "$*" >> "$tmp/herdr-calls"
+      # Simulate the pane racing to write its exit marker during close.
+      touch "$REVIEW_HERDR_EXIT_FILE"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+close_review_herdr_pane
+grep -Fx 'pane close test-pane' "$tmp/herdr-calls" >/dev/null ||
+  fail "Herdr pane was not closed"
+[ ! -e "$tmp/raw" ] || fail "Herdr raw file survived cleanup"
+[ ! -e "$tmp/exit" ] || fail "late Herdr exit file survived cleanup"
+[ -z "$REVIEW_HERDR_PANE_ID" ] || fail "Herdr pane ownership was not cleared"
+
+echo "review process tests passed"

--- a/scripts/lib/__tests__/review-process.test.sh
+++ b/scripts/lib/__tests__/review-process.test.sh
@@ -3,11 +3,15 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-# shellcheck source=scripts/lib/review-process.sh
-. "$repo_root/scripts/lib/review-process.sh"
+process_lib="$repo_root/scripts/lib/review-process.sh"
+process_fixture="$repo_root/scripts/lib/__tests__/review-process-fixture.py"
 
 tmp="$(mktemp -d /tmp/lobu-review-process-test.XXXXXX)"
+holder_pid=""
 cleanup() {
+  [ -z "$holder_pid" ] || kill -KILL "$holder_pid" 2>/dev/null || true
+  wait "$holder_pid" 2>/dev/null || true
+  pkill -KILL -f "$tmp" 2>/dev/null || true
   rm -rf "$tmp"
 }
 trap cleanup EXIT
@@ -17,32 +21,75 @@ fail() {
   exit 1
 }
 
-HERDR_WORKSPACE_ID='test-workspace'
-REVIEW_HERDR_PANE_ID=''
-REVIEW_HERDR_PANE_NAME='test-review-pane'
-REVIEW_HERDR_RAW_FILE="$tmp/raw"
-REVIEW_HERDR_EXIT_FILE="$tmp/exit"
-touch "$REVIEW_HERDR_RAW_FILE" "$REVIEW_HERDR_EXIT_FILE"
-
-herdr() {
-  case "$1 $2" in
-    'pane list')
-      printf '%s\n' '{"result":{"panes":[{"label":"test-review-pane","pane_id":"test-pane"}]}}'
-      ;;
-    'pane close')
-      printf '%s\n' "$*" >> "$tmp/herdr-calls"
-      # Simulate the pane racing to write its exit marker during close.
-      touch "$REVIEW_HERDR_EXIT_FILE"
-      ;;
-    *) return 1 ;;
-  esac
+wait_for_file() {
+  local path="$1" attempts=0
+  while [ ! -f "$path" ] && [ "$attempts" -lt 400 ]; do
+    sleep 0.01
+    attempts=$((attempts + 1))
+  done
+  [ -f "$path" ] || fail "timed out waiting for $path"
 }
 
-close_review_herdr_pane
-grep -Fx 'pane close test-pane' "$tmp/herdr-calls" >/dev/null ||
-  fail "Herdr pane was not closed"
-[ ! -e "$tmp/raw" ] || fail "Herdr raw file survived cleanup"
-[ ! -e "$tmp/exit" ] || fail "late Herdr exit file survived cleanup"
-[ -z "$REVIEW_HERDR_PANE_ID" ] || fail "Herdr pane ownership was not cleared"
+test_signal_during_spawn_does_not_orphan_command() {
+  local control_root="$tmp/spawn-control" rc
+  mkdir -p "$control_root"
+  REVIEW_PROCESS_CONTROL_ROOT_FOR_TESTS="$control_root" \
+    REVIEW_PARENT_PUBLISH_DELAY_FOR_TESTS=1 \
+    REVIEW_SUPERVISOR_START_DELAY_SECONDS=1 \
+    PROCESS_LIB="$process_lib" MARKER="$tmp/should-not-run" bash -c '
+      set -euo pipefail
+      . "$PROCESS_LIB"
+      trap "stop_active_review_child; exit 143" TERM
+      run_review_child "$@"
+    ' bash bash -c 'touch "$1"; sleep 30' bash "$tmp/should-not-run" &
+  holder_pid=$!
+
+  for _ in $(seq 1 400); do
+    find "$control_root" -name supervisor.pid -type f | grep -q . && break
+    sleep 0.01
+  done
+  find "$control_root" -name supervisor.pid -type f | grep -q . ||
+    fail "supervisor did not publish spawn ownership"
+  kill -TERM "$holder_pid"
+  set +e
+  wait "$holder_pid"
+  rc=$?
+  set -e
+  holder_pid=""
+  [ "$rc" -eq 143 ] || fail "spawn-interrupted runner exited $rc"
+  [ ! -e "$tmp/should-not-run" ] || fail "command started after spawn interruption"
+  [ -z "$(find "$control_root" -name supervisor.pid -type f -print -quit)" ] ||
+    fail "spawn interruption left supervisor state behind"
+}
+
+test_late_grandchild_is_killed_with_process_group() {
+  local control_root="$tmp/late-control" late_pid rc
+  mkdir -p "$control_root"
+  REVIEW_PROCESS_CONTROL_ROOT_FOR_TESTS="$control_root" \
+    REVIEW_PROCESS_TERM_GRACE_SECONDS=0.3 \
+    PROCESS_LIB="$process_lib" READY="$tmp/late.ready" LATE_PID="$tmp/late.pid" bash -c '
+      set -euo pipefail
+      . "$PROCESS_LIB"
+      trap "stop_active_review_child; exit 143" TERM
+      run_review_child "$@"
+    ' bash python3 "$process_fixture" late-grandchild "$tmp/late.ready" "$tmp/late.pid" &
+  holder_pid=$!
+  wait_for_file "$tmp/late.ready"
+  kill -TERM "$holder_pid"
+  wait_for_file "$tmp/late.pid"
+  late_pid="$(sed -n '1p' "$tmp/late.pid")"
+  set +e
+  wait "$holder_pid"
+  rc=$?
+  set -e
+  holder_pid=""
+  [ "$rc" -eq 143 ] || fail "late-grandchild runner exited $rc"
+  if kill -0 "$late_pid" 2>/dev/null; then
+    fail "late grandchild $late_pid survived process-group cleanup"
+  fi
+}
+
+test_signal_during_spawn_does_not_orphan_command
+test_late_grandchild_is_killed_with_process_group
 
 echo "review process tests passed"

--- a/scripts/lib/herdr-review-lifecycle.sh
+++ b/scripts/lib/herdr-review-lifecycle.sh
@@ -10,6 +10,7 @@ HERDR_REVIEW_RAW_FILE=""
 HERDR_REVIEW_EXIT_FILE=""
 HERDR_REVIEW_RUNNER_FILE=""
 HERDR_REVIEW_PROMPT_FILE=""
+HERDR_REVIEW_RUNNER_MAY_BE_LIVE=0
 
 herdr_review_track_files() {
   HERDR_REVIEW_RAW_FILE="$1"
@@ -23,6 +24,21 @@ herdr_review_track_prompt() {
 
 herdr_review_track_tab() {
   HERDR_REVIEW_TAB_ID="$1"
+}
+
+herdr_review_mark_runner_may_be_live() {
+  HERDR_REVIEW_RUNNER_MAY_BE_LIVE=1
+}
+
+herdr_review_runner_termination_confirmed() {
+  local exit_value
+  [ "$HERDR_REVIEW_RUNNER_MAY_BE_LIVE" = "1" ] || return 0
+  [ -n "$HERDR_REVIEW_EXIT_FILE" ] && [ -f "$HERDR_REVIEW_EXIT_FILE" ] || return 1
+  exit_value="$(sed -n '1p' "$HERDR_REVIEW_EXIT_FILE" 2>/dev/null || true)"
+  case "$exit_value" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  HERDR_REVIEW_RUNNER_MAY_BE_LIVE=0
 }
 
 herdr_review_track_locator() {
@@ -61,13 +77,24 @@ herdr_review_snapshot_tabs() {
   printf '%s' "$tab_json" | python3 -c '
 import json, sys
 try:
-    tabs = json.load(sys.stdin).get("result", {}).get("tabs", [])
-except (json.JSONDecodeError, AttributeError):
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError:
+    raise SystemExit(1)
+if not isinstance(payload, dict):
+    raise SystemExit(1)
+result = payload.get("result")
+if not isinstance(result, dict) or "tabs" not in result:
+    raise SystemExit(1)
+tabs = result["tabs"]
+if not isinstance(tabs, list):
     raise SystemExit(1)
 for tab in tabs:
+    if not isinstance(tab, dict):
+        raise SystemExit(1)
     tab_id = tab.get("tab_id")
-    if tab_id:
-        print(tab_id)
+    if not isinstance(tab_id, str) or not tab_id:
+        raise SystemExit(1)
+    print(tab_id)
 '
 }
 
@@ -83,22 +110,45 @@ herdr_review_recover_tab() {
     python3 -c '
 import json, os
 
+def collection(raw, name):
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError
+    result = payload.get("result")
+    if not isinstance(result, dict) or name not in result:
+        raise ValueError
+    values = result[name]
+    if not isinstance(values, list) or any(not isinstance(value, dict) for value in values):
+        raise ValueError
+    return values
+
 try:
-    tabs = json.loads(os.environ["HERDR_REVIEW_TAB_JSON"]).get("result", {}).get("tabs", [])
-    panes = json.loads(os.environ["HERDR_REVIEW_PANE_JSON"]).get("result", {}).get("panes", [])
-except (json.JSONDecodeError, AttributeError):
+    tabs = collection(os.environ["HERDR_REVIEW_TAB_JSON"], "tabs")
+    panes = collection(os.environ["HERDR_REVIEW_PANE_JSON"], "panes")
+except (json.JSONDecodeError, ValueError):
     raise SystemExit(2)
+
+for tab in tabs:
+    if not isinstance(tab.get("tab_id"), str) or not tab["tab_id"]:
+        raise SystemExit(2)
+    if "label" in tab and tab["label"] is not None and not isinstance(tab["label"], str):
+        raise SystemExit(2)
+for pane in panes:
+    if not isinstance(pane.get("tab_id"), str) or not pane["tab_id"]:
+        raise SystemExit(2)
+    for key in ("cwd", "foreground_cwd"):
+        if key in pane and pane[key] is not None and not isinstance(pane[key], str):
+            raise SystemExit(2)
 
 label = os.environ["HERDR_REVIEW_TAB_LABEL"]
 expected_cwd = os.path.realpath(os.environ["HERDR_REVIEW_CWD"])
 before = set(filter(None, os.environ["HERDR_REVIEW_BEFORE_TAB_IDS"].splitlines()))
-new_labelled = [
-    tab.get("tab_id")
-    for tab in tabs
-    if tab.get("tab_id") and tab.get("label") == label and tab.get("tab_id") not in before
-]
-if not new_labelled:
+new_tabs = [tab for tab in tabs if tab["tab_id"] not in before]
+if not new_tabs:
     raise SystemExit(1)
+new_labelled = [tab["tab_id"] for tab in new_tabs if tab.get("label") == label]
+if not new_labelled:
+    raise SystemExit(2)
 
 matches = []
 for tab_id in new_labelled:
@@ -123,13 +173,27 @@ herdr_review_tab_absent() {
   # enough—transport errors look the same—so require a valid list snapshot that
   # excludes the exact owned id before declaring closure.
   if get_json="$(herdr tab get "$tab_id" 2>/dev/null)"; then
-    printf '%s' "$get_json" | python3 -c '
-import json, sys
+    HERDR_REVIEW_TAB_ID_TO_FIND="$tab_id" printf '%s' "$get_json" | \
+      HERDR_REVIEW_TAB_ID_TO_FIND="$tab_id" python3 -c '
+import json, os, sys
 try:
-    tab = json.load(sys.stdin).get("result", {}).get("tab") or {}
-except (json.JSONDecodeError, AttributeError):
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError:
     raise SystemExit(1)
-raise SystemExit(1 if tab.get("tab_id") else 0)
+if not isinstance(payload, dict):
+    raise SystemExit(1)
+result = payload.get("result")
+if not isinstance(result, dict) or "tab" not in result:
+    raise SystemExit(1)
+tab = result["tab"]
+if tab is None:
+    raise SystemExit(0)
+if not isinstance(tab, dict):
+    raise SystemExit(1)
+found = tab.get("tab_id")
+if not isinstance(found, str) or not found or found != os.environ["HERDR_REVIEW_TAB_ID_TO_FIND"]:
+    raise SystemExit(1)
+raise SystemExit(1)
 ' || return 1
   fi
 
@@ -138,9 +202,23 @@ raise SystemExit(1 if tab.get("tab_id") else 0)
     HERDR_REVIEW_TAB_ID_TO_FIND="$tab_id" python3 -c '
 import json, os, sys
 try:
-    tabs = json.load(sys.stdin).get("result", {}).get("tabs", [])
-except (json.JSONDecodeError, AttributeError):
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError:
     raise SystemExit(1)
+if not isinstance(payload, dict):
+    raise SystemExit(1)
+result = payload.get("result")
+if not isinstance(result, dict) or "tabs" not in result:
+    raise SystemExit(1)
+tabs = result["tabs"]
+if not isinstance(tabs, list):
+    raise SystemExit(1)
+for tab in tabs:
+    if not isinstance(tab, dict):
+        raise SystemExit(1)
+    found = tab.get("tab_id")
+    if not isinstance(found, str) or not found:
+        raise SystemExit(1)
 target = os.environ["HERDR_REVIEW_TAB_ID_TO_FIND"]
 raise SystemExit(1 if any(tab.get("tab_id") == target for tab in tabs) else 0)
 '
@@ -190,6 +268,7 @@ herdr_review_forget_files() {
   HERDR_REVIEW_RAW_FILE=""
   HERDR_REVIEW_EXIT_FILE=""
   HERDR_REVIEW_RUNNER_FILE=""
+  HERDR_REVIEW_RUNNER_MAY_BE_LIVE=0
 }
 
 herdr_review_release_prompt() {
@@ -220,4 +299,26 @@ herdr_review_abort() {
   fi
   herdr_review_release_prompt
   herdr_review_forget_files
+}
+
+# The Herdr runner is external to this shell and cannot inherit the host flock.
+# If exact tab closure is ambiguous, keep this process (and therefore FD 9)
+# alive until either a retry confirms the tab is absent or the runner writes its
+# terminal exit marker. Only then can another destructive review safely start.
+herdr_review_abort_until_safe_to_release_lock() {
+  local announced=0 retry_seconds="${REVIEW_CLOSE_RETRY_SECONDS_FOR_TESTS:-0.25}"
+  while true; do
+    if herdr_review_abort; then
+      return 0
+    fi
+    if herdr_review_runner_termination_confirmed; then
+      echo ">> Herdr review runner terminated; retained tab diagnostics for manual cleanup" >&2
+      return 0
+    fi
+    if [ "$announced" = "0" ]; then
+      echo ">> retaining full review lock until the Herdr runner is confirmed stopped" >&2
+      announced=1
+    fi
+    sleep "$retry_seconds"
+  done
 }

--- a/scripts/lib/herdr-review-lifecycle.sh
+++ b/scripts/lib/herdr-review-lifecycle.sh
@@ -1,11 +1,11 @@
-# herdr-review-lifecycle.sh — ownership and cleanup for a review tab.
-# Sourced by review.sh. The caller may also invoke herdr_review_abort from its
-# EXIT trap so Ctrl-C and unexpected failures cannot orphan a privileged review.
+# herdr-review-lifecycle.sh — exact ownership and cleanup for a review tab.
 # shellcheck shell=bash
 
 HERDR_REVIEW_TAB_ID=""
 HERDR_REVIEW_WORKSPACE_ID=""
 HERDR_REVIEW_TAB_LABEL=""
+HERDR_REVIEW_CWD=""
+HERDR_REVIEW_BEFORE_TAB_IDS=""
 HERDR_REVIEW_RAW_FILE=""
 HERDR_REVIEW_EXIT_FILE=""
 HERDR_REVIEW_RUNNER_FILE=""
@@ -28,38 +28,161 @@ herdr_review_track_tab() {
 herdr_review_track_locator() {
   HERDR_REVIEW_WORKSPACE_ID="$1"
   HERDR_REVIEW_TAB_LABEL="$2"
+  HERDR_REVIEW_CWD="$3"
+  HERDR_REVIEW_BEFORE_TAB_IDS="$4"
 }
 
 herdr_review_forget_tab() {
   HERDR_REVIEW_TAB_ID=""
   HERDR_REVIEW_WORKSPACE_ID=""
   HERDR_REVIEW_TAB_LABEL=""
+  HERDR_REVIEW_CWD=""
+  HERDR_REVIEW_BEFORE_TAB_IDS=""
+}
+
+herdr_review_parse_created_tab() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+try:
+    result = json.load(sys.stdin).get("result", {})
+except (json.JSONDecodeError, AttributeError):
+    raise SystemExit(1)
+tab_id = (result.get("tab") or {}).get("tab_id") or ""
+pane_id = (result.get("root_pane") or {}).get("pane_id") or ""
+if not tab_id or not pane_id:
+    raise SystemExit(1)
+print(tab_id, pane_id)
+'
+}
+
+herdr_review_snapshot_tabs() {
+  local workspace_id="$1" tab_json
+  tab_json="$(herdr tab list --workspace "$workspace_id" 2>/dev/null)" || return 1
+  printf '%s' "$tab_json" | python3 -c '
+import json, sys
+try:
+    tabs = json.load(sys.stdin).get("result", {}).get("tabs", [])
+except (json.JSONDecodeError, AttributeError):
+    raise SystemExit(1)
+for tab in tabs:
+    tab_id = tab.get("tab_id")
+    if tab_id:
+        print(tab_id)
+'
+}
+
+herdr_review_recover_tab() {
+  local tab_json pane_json
+  tab_json="$(herdr tab list --workspace "$HERDR_REVIEW_WORKSPACE_ID" 2>/dev/null)" || return 2
+  pane_json="$(herdr pane list --workspace "$HERDR_REVIEW_WORKSPACE_ID" 2>/dev/null)" || return 2
+  HERDR_REVIEW_TAB_JSON="$tab_json" \
+    HERDR_REVIEW_PANE_JSON="$pane_json" \
+    HERDR_REVIEW_TAB_LABEL="$HERDR_REVIEW_TAB_LABEL" \
+    HERDR_REVIEW_CWD="$HERDR_REVIEW_CWD" \
+    HERDR_REVIEW_BEFORE_TAB_IDS="$HERDR_REVIEW_BEFORE_TAB_IDS" \
+    python3 -c '
+import json, os
+
+try:
+    tabs = json.loads(os.environ["HERDR_REVIEW_TAB_JSON"]).get("result", {}).get("tabs", [])
+    panes = json.loads(os.environ["HERDR_REVIEW_PANE_JSON"]).get("result", {}).get("panes", [])
+except (json.JSONDecodeError, AttributeError):
+    raise SystemExit(2)
+
+label = os.environ["HERDR_REVIEW_TAB_LABEL"]
+expected_cwd = os.path.realpath(os.environ["HERDR_REVIEW_CWD"])
+before = set(filter(None, os.environ["HERDR_REVIEW_BEFORE_TAB_IDS"].splitlines()))
+new_labelled = [
+    tab.get("tab_id")
+    for tab in tabs
+    if tab.get("tab_id") and tab.get("label") == label and tab.get("tab_id") not in before
+]
+if not new_labelled:
+    raise SystemExit(1)
+
+matches = []
+for tab_id in new_labelled:
+    for pane in panes:
+        if pane.get("tab_id") != tab_id:
+            continue
+        cwd = pane.get("foreground_cwd") or pane.get("cwd") or ""
+        if cwd and os.path.realpath(cwd) == expected_cwd:
+            matches.append(tab_id)
+            break
+
+if len(matches) != 1:
+    raise SystemExit(2)
+print(matches[0])
+'
+}
+
+herdr_review_tab_absent() {
+  local tab_id="$1" get_json list_json
+
+  # A successful get proves the tab is still live. A failed get alone is not
+  # enough—transport errors look the same—so require a valid list snapshot that
+  # excludes the exact owned id before declaring closure.
+  if get_json="$(herdr tab get "$tab_id" 2>/dev/null)"; then
+    printf '%s' "$get_json" | python3 -c '
+import json, sys
+try:
+    tab = json.load(sys.stdin).get("result", {}).get("tab") or {}
+except (json.JSONDecodeError, AttributeError):
+    raise SystemExit(1)
+raise SystemExit(1 if tab.get("tab_id") else 0)
+' || return 1
+  fi
+
+  list_json="$(herdr tab list --workspace "$HERDR_REVIEW_WORKSPACE_ID" 2>/dev/null)" || return 1
+  HERDR_REVIEW_TAB_ID_TO_FIND="$tab_id" printf '%s' "$list_json" | \
+    HERDR_REVIEW_TAB_ID_TO_FIND="$tab_id" python3 -c '
+import json, os, sys
+try:
+    tabs = json.load(sys.stdin).get("result", {}).get("tabs", [])
+except (json.JSONDecodeError, AttributeError):
+    raise SystemExit(1)
+target = os.environ["HERDR_REVIEW_TAB_ID_TO_FIND"]
+raise SystemExit(1 if any(tab.get("tab_id") == target for tab in tabs) else 0)
+'
 }
 
 herdr_review_close_tab() {
-  local tab_id="$HERDR_REVIEW_TAB_ID" tab_json
-  command -v herdr >/dev/null 2>&1 || return 0
-  # If interruption lands after tab creation but before its JSON was parsed,
-  # recover the id from the unique per-run label.
-  if [ -z "$tab_id" ] && [ -n "$HERDR_REVIEW_WORKSPACE_ID" ] && [ -n "$HERDR_REVIEW_TAB_LABEL" ]; then
-    tab_json="$(herdr tab list --workspace "$HERDR_REVIEW_WORKSPACE_ID" 2>/dev/null || true)"
-    tab_id="$(printf '%s' "$tab_json" | HERDR_REVIEW_TAB_LABEL="$HERDR_REVIEW_TAB_LABEL" python3 -c 'import json,os,sys
-label=os.environ["HERDR_REVIEW_TAB_LABEL"]
-for tab in json.load(sys.stdin).get("result", {}).get("tabs", []):
-  if tab.get("label")==label:
-    print(tab.get("tab_id") or ""); break
-' 2>/dev/null || true)"
+  local tab_id="$HERDR_REVIEW_TAB_ID" recovered recovery_exit attempts
+  if [ -z "$tab_id" ] && { [ -z "$HERDR_REVIEW_WORKSPACE_ID" ] || [ -z "$HERDR_REVIEW_TAB_LABEL" ]; }; then
+    return 0
   fi
+  command -v herdr >/dev/null 2>&1 || return 1
+
   if [ -z "$tab_id" ]; then
-    herdr_review_forget_tab
-    return 0
+    if recovered="$(herdr_review_recover_tab)"; then
+      recovery_exit=0
+    else
+      recovery_exit=$?
+    fi
+    if [ "$recovery_exit" -eq 0 ] && [ -n "$recovered" ]; then
+      tab_id="$recovered"
+      HERDR_REVIEW_TAB_ID="$tab_id"
+    elif [ "$recovery_exit" -eq 1 ]; then
+      # A valid before/after snapshot proves this invocation created no tab.
+      herdr_review_forget_tab
+      return 0
+    else
+      echo ">> warning: could not uniquely recover the Herdr review tab" >&2
+      return 1
+    fi
   fi
-  # Closing the tab terminates its shell and any still-running Claude process.
-  if herdr tab close "$tab_id" >/dev/null 2>&1; then
-    herdr_review_forget_tab
-    return 0
-  fi
-  echo ">> warning: failed to close Herdr review tab $tab_id" >&2
+
+  herdr tab close "$tab_id" >/dev/null 2>&1 || true
+  attempts=0
+  while [ "$attempts" -lt 20 ]; do
+    if herdr_review_tab_absent "$tab_id"; then
+      herdr_review_forget_tab
+      return 0
+    fi
+    sleep 0.05
+    attempts=$((attempts + 1))
+  done
+  echo ">> warning: Herdr review tab $tab_id closure was not confirmed" >&2
   return 1
 }
 
@@ -74,20 +197,21 @@ herdr_review_release_prompt() {
   HERDR_REVIEW_PROMPT_FILE=""
 }
 
-# Normal completion: the caller has already copied RAW/CLAUDE_EXIT into shell
-# variables, so the tab and all transport files can be removed.
 herdr_review_cleanup() {
-  herdr_review_close_tab || true
+  if ! herdr_review_close_tab; then
+    echo ">> Herdr review diagnostics retained because tab closure is unconfirmed" >&2
+    return 1
+  fi
   rm -f "$HERDR_REVIEW_RAW_FILE" "$HERDR_REVIEW_EXIT_FILE" "$HERDR_REVIEW_RUNNER_FILE"
   herdr_review_forget_files
 }
 
-# Abnormal completion: stop the tab/process, retain non-empty partial output for
-# diagnosis, and remove only the runner/control files. This is called by the
-# top-level EXIT trap on Ctrl-C, TERM, or an unexpected script error.
 herdr_review_abort() {
   local raw_file="$HERDR_REVIEW_RAW_FILE"
-  herdr_review_close_tab || true
+  if ! herdr_review_close_tab; then
+    echo ">> Herdr review state retained because tab closure is unconfirmed" >&2
+    return 1
+  fi
   rm -f "$HERDR_REVIEW_EXIT_FILE" "$HERDR_REVIEW_RUNNER_FILE"
   if [ -n "$raw_file" ] && [ -s "$raw_file" ]; then
     echo ">> interrupted Claude output preserved at $raw_file" >&2

--- a/scripts/lib/herdr-review-lifecycle.sh
+++ b/scripts/lib/herdr-review-lifecycle.sh
@@ -1,0 +1,99 @@
+# herdr-review-lifecycle.sh — ownership and cleanup for a review tab.
+# Sourced by review.sh. The caller may also invoke herdr_review_abort from its
+# EXIT trap so Ctrl-C and unexpected failures cannot orphan a privileged review.
+# shellcheck shell=bash
+
+HERDR_REVIEW_TAB_ID=""
+HERDR_REVIEW_WORKSPACE_ID=""
+HERDR_REVIEW_TAB_LABEL=""
+HERDR_REVIEW_RAW_FILE=""
+HERDR_REVIEW_EXIT_FILE=""
+HERDR_REVIEW_RUNNER_FILE=""
+HERDR_REVIEW_PROMPT_FILE=""
+
+herdr_review_track_files() {
+  HERDR_REVIEW_RAW_FILE="$1"
+  HERDR_REVIEW_EXIT_FILE="$2"
+  HERDR_REVIEW_RUNNER_FILE="$3"
+}
+
+herdr_review_track_prompt() {
+  HERDR_REVIEW_PROMPT_FILE="$1"
+}
+
+herdr_review_track_tab() {
+  HERDR_REVIEW_TAB_ID="$1"
+}
+
+herdr_review_track_locator() {
+  HERDR_REVIEW_WORKSPACE_ID="$1"
+  HERDR_REVIEW_TAB_LABEL="$2"
+}
+
+herdr_review_forget_tab() {
+  HERDR_REVIEW_TAB_ID=""
+  HERDR_REVIEW_WORKSPACE_ID=""
+  HERDR_REVIEW_TAB_LABEL=""
+}
+
+herdr_review_close_tab() {
+  local tab_id="$HERDR_REVIEW_TAB_ID" tab_json
+  command -v herdr >/dev/null 2>&1 || return 0
+  # If interruption lands after tab creation but before its JSON was parsed,
+  # recover the id from the unique per-run label.
+  if [ -z "$tab_id" ] && [ -n "$HERDR_REVIEW_WORKSPACE_ID" ] && [ -n "$HERDR_REVIEW_TAB_LABEL" ]; then
+    tab_json="$(herdr tab list --workspace "$HERDR_REVIEW_WORKSPACE_ID" 2>/dev/null || true)"
+    tab_id="$(printf '%s' "$tab_json" | HERDR_REVIEW_TAB_LABEL="$HERDR_REVIEW_TAB_LABEL" python3 -c 'import json,os,sys
+label=os.environ["HERDR_REVIEW_TAB_LABEL"]
+for tab in json.load(sys.stdin).get("result", {}).get("tabs", []):
+  if tab.get("label")==label:
+    print(tab.get("tab_id") or ""); break
+' 2>/dev/null || true)"
+  fi
+  if [ -z "$tab_id" ]; then
+    herdr_review_forget_tab
+    return 0
+  fi
+  # Closing the tab terminates its shell and any still-running Claude process.
+  if herdr tab close "$tab_id" >/dev/null 2>&1; then
+    herdr_review_forget_tab
+    return 0
+  fi
+  echo ">> warning: failed to close Herdr review tab $tab_id" >&2
+  return 1
+}
+
+herdr_review_forget_files() {
+  HERDR_REVIEW_RAW_FILE=""
+  HERDR_REVIEW_EXIT_FILE=""
+  HERDR_REVIEW_RUNNER_FILE=""
+}
+
+herdr_review_release_prompt() {
+  rm -f "$HERDR_REVIEW_PROMPT_FILE"
+  HERDR_REVIEW_PROMPT_FILE=""
+}
+
+# Normal completion: the caller has already copied RAW/CLAUDE_EXIT into shell
+# variables, so the tab and all transport files can be removed.
+herdr_review_cleanup() {
+  herdr_review_close_tab || true
+  rm -f "$HERDR_REVIEW_RAW_FILE" "$HERDR_REVIEW_EXIT_FILE" "$HERDR_REVIEW_RUNNER_FILE"
+  herdr_review_forget_files
+}
+
+# Abnormal completion: stop the tab/process, retain non-empty partial output for
+# diagnosis, and remove only the runner/control files. This is called by the
+# top-level EXIT trap on Ctrl-C, TERM, or an unexpected script error.
+herdr_review_abort() {
+  local raw_file="$HERDR_REVIEW_RAW_FILE"
+  herdr_review_close_tab || true
+  rm -f "$HERDR_REVIEW_EXIT_FILE" "$HERDR_REVIEW_RUNNER_FILE"
+  if [ -n "$raw_file" ] && [ -s "$raw_file" ]; then
+    echo ">> interrupted Claude output preserved at $raw_file" >&2
+  else
+    rm -f "$raw_file"
+  fi
+  herdr_review_release_prompt
+  herdr_review_forget_files
+}

--- a/scripts/lib/herdr-task.sh
+++ b/scripts/lib/herdr-task.sh
@@ -109,6 +109,49 @@ raise SystemExit(0 if isinstance(value,list) else 1)
 ' >/dev/null 2>&1
 }
 
+# A close command's exit status is not sufficient proof that an exact tab is
+# gone: a transport failure can arrive after Herdr applied the request, and a
+# stale persisted id is expected when task-clean is retried after a later Git
+# cleanup failure. Require a strict workspace snapshot that excludes the exact
+# id before releasing ownership.
+herdr_task_tab_absent() {
+  local workspace_id="$1" tab_id="$2" json
+  json="$(herdr tab list --workspace "$workspace_id" 2>/dev/null)" || return 1
+  printf '%s' "$json" | HERDR_TASK_TAB_ID="$tab_id" python3 -c 'import json,os,sys
+try:
+  payload=json.load(sys.stdin)
+except json.JSONDecodeError:
+  raise SystemExit(1)
+if not isinstance(payload,dict):
+  raise SystemExit(1)
+result=payload.get("result")
+if not isinstance(result,dict) or "tabs" not in result:
+  raise SystemExit(1)
+tabs=result["tabs"]
+if not isinstance(tabs,list):
+  raise SystemExit(1)
+for tab in tabs:
+  if not isinstance(tab,dict):
+    raise SystemExit(1)
+  found=tab.get("tab_id")
+  if not isinstance(found,str) or not found:
+    raise SystemExit(1)
+target=os.environ["HERDR_TASK_TAB_ID"]
+raise SystemExit(1 if any(tab["tab_id"]==target for tab in tabs) else 0)
+' >/dev/null 2>&1
+}
+
+herdr_task_close_exact_tab() {
+  local workspace_id="$1" tab_id="$2" attempts=0
+  herdr tab close "$tab_id" >/dev/null 2>&1 || true
+  while [[ "$attempts" -lt 20 ]]; do
+    herdr_task_tab_absent "$workspace_id" "$tab_id" && return 0
+    sleep 0.05
+    attempts=$((attempts + 1))
+  done
+  return 1
+}
+
 # Open a git worktree in Herdr. Prints workspace_id on stdout.
 #
 # When task-setup runs *inside* an existing Herdr pane (the common "click new →
@@ -196,7 +239,9 @@ herdr_task_close() {
   if read -r metadata_ws metadata_tab <<<"$(herdr_task_metadata_read "$worktree_path" 2>/dev/null || true)" && [[ -n "$metadata_ws" ]]; then
     if [[ -n "$metadata_tab" ]]; then
       [[ "$metadata_tab" != "${HERDR_TAB_ID:-}" ]] || return 1
-      herdr tab close "$metadata_tab" >/dev/null 2>&1 && return 0
+      if herdr_task_close_exact_tab "$metadata_ws" "$metadata_tab"; then
+        return 0
+      fi
       return 1
     fi
     [[ "$metadata_ws" != "${HERDR_WORKSPACE_ID:-}" ]] || return 1

--- a/scripts/lib/herdr-task.sh
+++ b/scripts/lib/herdr-task.sh
@@ -1,23 +1,27 @@
 # herdr-task.sh — optional Herdr workspace wiring for task worktrees.
 # Sourced by task-setup.sh / task-clean.sh. Set HERDR=0 to skip.
+# shellcheck shell=bash
 
 herdr_task_enabled() {
   [[ "${HERDR:-1}" != "0" ]] && command -v herdr >/dev/null 2>&1
 }
 
-# Open (or attach) an existing git worktree as a Herdr workspace. Prints workspace_id on stdout.
+# Open a git worktree in Herdr. Prints workspace_id on stdout.
 #
 # When task-setup runs *inside* an existing Herdr pane (the common "click new →
-# start agent → run make task-setup" flow), Herdr exports $HERDR_WORKSPACE_ID.
-# In that case we relabel the *current* workspace to the task name instead of
-# spawning a second one — otherwise the pane you're typing in keeps its launch
-# label (e.g. "~") while an empty correctly-labeled workspace appears beside it.
+# start agent → run make task-setup" flow), create a new tab for the worktree.
+# The calling agent keeps its full-size pane and task commands remain easy to
+# follow from the tab bar instead of being added as splits to the active tab.
 herdr_task_open() {
   local repo="$1" worktree_path="$2" label="$3"
-  local json ws
+  local json ws tab
   herdr_task_enabled || return 1
   if [[ -n "${HERDR_WORKSPACE_ID:-}" ]]; then
-    herdr workspace rename "$HERDR_WORKSPACE_ID" "$label" >/dev/null 2>&1 || true
+    json="$(herdr tab create --workspace "$HERDR_WORKSPACE_ID" --cwd "$worktree_path" --label "$label" --no-focus 2>/dev/null)" || return 1
+    tab="$(printf '%s' "$json" | python3 -c 'import sys,json
+d=json.load(sys.stdin)
+print((d.get("result",{}).get("tab") or {}).get("tab_id",""))' 2>/dev/null)" || return 1
+    [[ -n "$tab" ]] || return 1
     printf '%s' "$HERDR_WORKSPACE_ID"
     return 0
   fi
@@ -30,24 +34,38 @@ print(d.get("result",{}).get("workspace",{}).get("workspace_id",""))' 2>/dev/nul
   printf '%s' "$ws"
 }
 
-# Close the Herdr workspace tied to a worktree path, if any.
+# Close the Herdr tab or workspace tied to a worktree path, if any.
 #
-# Prefers matching by the worktree's checkout_path (set when herdr_task_open
-# spawned a dedicated worktree workspace). Falls back to matching by label ==
-# task name: when task-setup ran inside an existing pane, herdr_task_open
-# relabeled that workspace in place rather than binding it to a checkout, so
-# Herdr has no checkout_path for it — the label is the only handle we have.
+# Tabs are matched by pane cwd. Dedicated workspaces are matched by the
+# worktree's checkout_path, with a legacy label fallback for workspaces made by
+# older versions of this helper.
 #
-# NEVER closes the CURRENT workspace ($HERDR_WORKSPACE_ID). `make task-clean`
-# is routinely run from inside the very pane that task-setup relabeled in place;
-# closing that pane tears down the live session (and under memory pressure the
-# teardown escalates to a SIGKILL of the whole process tree). The git-worktree
-# teardown that follows still removes the checkout, so sparing the pane loses
-# nothing but the (now-stale-labeled) window, which the user can reuse.
+# NEVER closes the current tab or workspace. `make task-clean` may be run from
+# inside the task itself, and tearing down that active session can kill the
+# caller before git cleanup completes.
 herdr_task_close() {
   local worktree_path="$1" label="${2:-}"
-  local json ws matched_by
+  local json ws matched_by tab
   herdr_task_enabled || return 1
+
+  # Worktrees opened from an existing Herdr session live in their own tab.
+  # Match by pane cwd first and label second, and never close the caller's tab.
+  if [[ -n "${HERDR_WORKSPACE_ID:-}" ]]; then
+    json="$(herdr pane list --workspace "$HERDR_WORKSPACE_ID" 2>/dev/null)" || return 1
+    tab="$(printf '%s' "$json" | WORKTREE_PATH="$worktree_path" CURRENT_TAB="${HERDR_TAB_ID:-}" python3 -c 'import os,sys,json
+path=os.environ["WORKTREE_PATH"]
+current=os.environ.get("CURRENT_TAB","")
+for pane in json.load(sys.stdin).get("result",{}).get("panes",[]):
+  tid=pane.get("tab_id") or ""
+  if tid and tid != current and (pane.get("cwd")==path or pane.get("foreground_cwd")==path):
+    print(tid); break
+' 2>/dev/null)" || return 1
+    if [[ -n "$tab" ]]; then
+      herdr tab close "$tab" >/dev/null 2>&1 || return 1
+      return 0
+    fi
+  fi
+
   json="$(herdr workspace list 2>/dev/null)" || return 1
   # Emit "<match_kind> <workspace_id>": "path" when bound to the checkout,
   # else "label" when only the label matches. Path wins over label. The current

--- a/scripts/lib/herdr-task.sh
+++ b/scripts/lib/herdr-task.sh
@@ -6,6 +6,105 @@ herdr_task_enabled() {
   [[ "${HERDR:-1}" != "0" ]] && command -v herdr >/dev/null 2>&1
 }
 
+# Store the Herdr identity in Git's per-worktree metadata directory. Unlike a
+# marker inside the checkout, this does not dirty the worktree; unlike a lookup
+# scoped to the caller's current Herdr workspace, it remains authoritative when
+# task-clean is launched from another workspace or an ordinary terminal.
+herdr_task_metadata_path() {
+  git -C "$1" rev-parse --path-format=absolute --git-path lobu-herdr-task 2>/dev/null
+}
+
+herdr_task_metadata_write() {
+  local worktree_path="$1" workspace_id="$2" tab_id="${3:-}" metadata_path
+  metadata_path="$(herdr_task_metadata_path "$worktree_path")" || return 1
+  printf 'workspace_id=%s\ntab_id=%s\n' "$workspace_id" "$tab_id" > "$metadata_path"
+}
+
+herdr_task_metadata_read() {
+  local worktree_path="$1" metadata_path key value workspace_id="" tab_id=""
+  metadata_path="$(herdr_task_metadata_path "$worktree_path")" || return 1
+  [[ -f "$metadata_path" ]] || return 1
+  while IFS='=' read -r key value; do
+    case "$key" in
+      workspace_id) workspace_id="$value" ;;
+      tab_id) tab_id="$value" ;;
+    esac
+  done < "$metadata_path"
+  [[ -n "$workspace_id" ]] || return 1
+  printf '%s %s\n' "$workspace_id" "$tab_id"
+}
+
+# A create request can reach the Herdr server even if its CLI response is
+# truncated or otherwise cannot be parsed. Compare the tab list from before and
+# after the request so a newly-created task tab can still be closed.
+herdr_task_recover_new_tab() {
+  local workspace_id="$1" worktree_path="$2" label="$3" before_json="$4"
+  local after_json pane_json tab_id
+  after_json="$(herdr tab list --workspace "$workspace_id" 2>/dev/null || true)"
+  pane_json="$(herdr pane list --workspace "$workspace_id" 2>/dev/null || true)"
+  tab_id="$(BEFORE_JSON="$before_json" AFTER_JSON="$after_json" PANE_JSON="$pane_json" WORKTREE_PATH="$worktree_path" LABEL="$label" python3 -c 'import json,os
+
+def load(name):
+  try:
+    return json.loads(os.environ.get(name, ""))
+  except Exception:
+    return {}
+
+before={tab.get("tab_id") for tab in load("BEFORE_JSON").get("result",{}).get("tabs",[]) if tab.get("tab_id")}
+tabs=load("AFTER_JSON").get("result",{}).get("tabs",[])
+path=os.environ["WORKTREE_PATH"]
+prefix=path.rstrip("/")+"/"
+matching_panes={pane.get("tab_id") for pane in load("PANE_JSON").get("result",{}).get("panes",[]) if pane.get("tab_id") and any(cwd==path or cwd.startswith(prefix) for cwd in (pane.get("cwd") or "", pane.get("foreground_cwd") or ""))}
+new_tabs=[tab for tab in tabs if tab.get("tab_id") and tab.get("tab_id") not in before]
+for tab in new_tabs:
+  if tab.get("tab_id") in matching_panes:
+    print(tab["tab_id"]); raise SystemExit
+for tab in new_tabs:
+  if tab.get("label")==os.environ.get("LABEL", ""):
+    print(tab["tab_id"]); raise SystemExit
+' 2>/dev/null || true)"
+  [[ -n "$tab_id" ]] || return 1
+  herdr tab close "$tab_id" >/dev/null 2>&1
+}
+
+# Same recovery for `herdr worktree open`: only a workspace absent from the
+# pre-create snapshot is eligible, so a malformed response for an already-open
+# worktree can never close an existing user workspace.
+herdr_task_recover_new_workspace() {
+  local worktree_path="$1" label="$2" before_json="$3"
+  local after_json workspace_id
+  after_json="$(herdr workspace list 2>/dev/null || true)"
+  workspace_id="$(BEFORE_JSON="$before_json" AFTER_JSON="$after_json" WORKTREE_PATH="$worktree_path" LABEL="$label" python3 -c 'import json,os
+
+def load(name):
+  try:
+    return json.loads(os.environ.get(name, ""))
+  except Exception:
+    return {}
+
+before={workspace.get("workspace_id") for workspace in load("BEFORE_JSON").get("result",{}).get("workspaces",[]) if workspace.get("workspace_id")}
+workspaces=[workspace for workspace in load("AFTER_JSON").get("result",{}).get("workspaces",[]) if workspace.get("workspace_id") and workspace.get("workspace_id") not in before]
+for workspace in workspaces:
+  if (workspace.get("worktree") or {}).get("checkout_path")==os.environ["WORKTREE_PATH"]:
+    print(workspace["workspace_id"]); raise SystemExit
+for workspace in workspaces:
+  if workspace.get("label")==os.environ.get("LABEL", ""):
+    print(workspace["workspace_id"]); raise SystemExit
+' 2>/dev/null || true)"
+  [[ -n "$workspace_id" ]] || return 1
+  herdr worktree remove --workspace "$workspace_id" --force >/dev/null 2>&1 || \
+    herdr workspace close "$workspace_id" >/dev/null 2>&1
+}
+
+herdr_task_snapshot_valid() {
+  local json="$1" collection="$2"
+  printf '%s' "$json" | COLLECTION="$collection" python3 -c 'import json,os,sys
+d=json.load(sys.stdin)
+value=d.get("result",{}).get(os.environ["COLLECTION"])
+raise SystemExit(0 if isinstance(value,list) else 1)
+' >/dev/null 2>&1
+}
+
 # Open a git worktree in Herdr. Prints workspace_id on stdout.
 #
 # When task-setup runs *inside* an existing Herdr pane (the common "click new →
@@ -14,23 +113,61 @@ herdr_task_enabled() {
 # follow from the tab bar instead of being added as splits to the active tab.
 herdr_task_open() {
   local repo="$1" worktree_path="$2" label="$3"
-  local json ws tab
+  local json ws tab metadata_ws metadata_tab before_json
   herdr_task_enabled || return 1
+
+  # Refreshing an existing task must not create another tab and overwrite the
+  # only identity task-clean knows about. Reuse the persisted live owner even
+  # when setup is launched from another workspace or an ordinary terminal.
+  if read -r metadata_ws metadata_tab <<<"$(herdr_task_metadata_read "$worktree_path" 2>/dev/null || true)" && [[ -n "$metadata_ws" ]]; then
+    if [[ -n "$metadata_tab" ]] && herdr tab get "$metadata_tab" >/dev/null 2>&1; then
+      printf '%s' "$metadata_ws"
+      return 0
+    fi
+    if [[ -z "$metadata_tab" ]] && herdr workspace get "$metadata_ws" >/dev/null 2>&1; then
+      printf '%s' "$metadata_ws"
+      return 0
+    fi
+  fi
+
   if [[ -n "${HERDR_WORKSPACE_ID:-}" ]]; then
-    json="$(herdr tab create --workspace "$HERDR_WORKSPACE_ID" --cwd "$worktree_path" --label "$label" --no-focus 2>/dev/null)" || return 1
-    tab="$(printf '%s' "$json" | python3 -c 'import sys,json
+    before_json="$(herdr tab list --workspace "$HERDR_WORKSPACE_ID" 2>/dev/null)" || return 1
+    herdr_task_snapshot_valid "$before_json" tabs || return 1
+    if ! json="$(herdr tab create --workspace "$HERDR_WORKSPACE_ID" --cwd "$worktree_path" --label "$label" --no-focus 2>/dev/null)"; then
+      herdr_task_recover_new_tab "$HERDR_WORKSPACE_ID" "$worktree_path" "$label" "$before_json" || true
+      return 1
+    fi
+    if ! tab="$(printf '%s' "$json" | python3 -c 'import sys,json
 d=json.load(sys.stdin)
-print((d.get("result",{}).get("tab") or {}).get("tab_id",""))' 2>/dev/null)" || return 1
-    [[ -n "$tab" ]] || return 1
+print((d.get("result",{}).get("tab") or {}).get("tab_id",""))' 2>/dev/null)" || [[ -z "$tab" ]]; then
+      herdr_task_recover_new_tab "$HERDR_WORKSPACE_ID" "$worktree_path" "$label" "$before_json" || true
+      return 1
+    fi
+    if ! herdr_task_metadata_write "$worktree_path" "$HERDR_WORKSPACE_ID" "$tab"; then
+      herdr tab close "$tab" >/dev/null 2>&1 || true
+      return 1
+    fi
     printf '%s' "$HERDR_WORKSPACE_ID"
     return 0
   fi
-  json="$(herdr worktree open --cwd "$repo" --path "$worktree_path" --label "$label" --no-focus --json 2>/dev/null)" || return 1
-  ws="$(printf '%s' "$json" | python3 -c 'import sys,json
+  before_json="$(herdr workspace list 2>/dev/null)" || return 1
+  herdr_task_snapshot_valid "$before_json" workspaces || return 1
+  if ! json="$(herdr worktree open --cwd "$repo" --path "$worktree_path" --label "$label" --no-focus --json 2>/dev/null)"; then
+    herdr_task_recover_new_workspace "$worktree_path" "$label" "$before_json" || true
+    return 1
+  fi
+  if ! ws="$(printf '%s' "$json" | python3 -c 'import sys,json
 d=json.load(sys.stdin)
-print(d.get("result",{}).get("workspace",{}).get("workspace_id",""))' 2>/dev/null)" || return 1
-  [[ -n "$ws" ]] || return 1
+print(d.get("result",{}).get("workspace",{}).get("workspace_id",""))' 2>/dev/null)" || [[ -z "$ws" ]]; then
+    herdr_task_recover_new_workspace "$worktree_path" "$label" "$before_json" || true
+    return 1
+  fi
   herdr workspace rename "$ws" "$label" >/dev/null 2>&1 || true
+  if ! herdr_task_metadata_write "$worktree_path" "$ws"; then
+    herdr worktree remove --workspace "$ws" --force >/dev/null 2>&1 || \
+      herdr workspace close "$ws" >/dev/null 2>&1 || true
+    return 1
+  fi
   printf '%s' "$ws"
 }
 
@@ -45,28 +182,54 @@ print(d.get("result",{}).get("workspace",{}).get("workspace_id",""))' 2>/dev/nul
 # caller before git cleanup completes.
 herdr_task_close() {
   local worktree_path="$1" label="${2:-}"
-  local json ws matched_by tab
+  local json ws matched_by tab candidate_ws metadata_ws metadata_tab
   herdr_task_enabled || return 1
 
-  # Worktrees opened from an existing Herdr session live in their own tab.
-  # Match by pane cwd first and label second, and never close the caller's tab.
-  if [[ -n "${HERDR_WORKSPACE_ID:-}" ]]; then
-    json="$(herdr pane list --workspace "$HERDR_WORKSPACE_ID" 2>/dev/null)" || return 1
-    tab="$(printf '%s' "$json" | WORKTREE_PATH="$worktree_path" CURRENT_TAB="${HERDR_TAB_ID:-}" python3 -c 'import os,sys,json
+  # Prefer the exact identity recorded at creation. This works even when the
+  # caller is outside Herdr or in a different workspace.
+  if read -r metadata_ws metadata_tab <<<"$(herdr_task_metadata_read "$worktree_path" 2>/dev/null || true)" && [[ -n "$metadata_ws" ]]; then
+    if [[ -n "$metadata_tab" && "$metadata_tab" != "${HERDR_TAB_ID:-}" ]]; then
+      if herdr tab close "$metadata_tab" >/dev/null 2>&1; then
+        return 0
+      fi
+    elif [[ -z "$metadata_tab" && "$metadata_ws" != "${HERDR_WORKSPACE_ID:-}" ]]; then
+      if herdr worktree remove --workspace "$metadata_ws" >/dev/null 2>&1 || \
+         herdr worktree remove --workspace "$metadata_ws" --force >/dev/null 2>&1 || \
+         herdr workspace close "$metadata_ws" >/dev/null 2>&1; then
+        return 0
+      fi
+    fi
+  fi
+
+  # Metadata may be absent for legacy task tabs. Enumerate every workspace,
+  # rather than only the caller's, and match panes by checkout cwd. Never close
+  # the tab that is executing task-clean.
+  json="$(herdr workspace list 2>/dev/null)" || return 1
+  while IFS= read -r candidate_ws; do
+    [[ -n "$candidate_ws" ]] || continue
+    local pane_json
+    pane_json="$(herdr pane list --workspace "$candidate_ws" 2>/dev/null)" || continue
+    tab="$(printf '%s' "$pane_json" | WORKTREE_PATH="$worktree_path" CURRENT_TAB="${HERDR_TAB_ID:-}" python3 -c 'import os,sys,json
 path=os.environ["WORKTREE_PATH"]
 current=os.environ.get("CURRENT_TAB","")
+prefix=path.rstrip("/")+"/"
 for pane in json.load(sys.stdin).get("result",{}).get("panes",[]):
   tid=pane.get("tab_id") or ""
-  if tid and tid != current and (pane.get("cwd")==path or pane.get("foreground_cwd")==path):
+  cwd=pane.get("cwd") or ""
+  foreground=pane.get("foreground_cwd") or ""
+  if tid and tid != current and (cwd==path or cwd.startswith(prefix) or foreground==path or foreground.startswith(prefix)):
     print(tid); break
 ' 2>/dev/null)" || return 1
     if [[ -n "$tab" ]]; then
       herdr tab close "$tab" >/dev/null 2>&1 || return 1
       return 0
     fi
-  fi
+  done < <(printf '%s' "$json" | python3 -c 'import sys,json
+for workspace in json.load(sys.stdin).get("result",{}).get("workspaces",[]):
+  workspace_id=workspace.get("workspace_id") or ""
+  if workspace_id: print(workspace_id)
+' 2>/dev/null)
 
-  json="$(herdr workspace list 2>/dev/null)" || return 1
   # Emit "<match_kind> <workspace_id>": "path" when bound to the checkout,
   # else "label" when only the label matches. Path wins over label. The current
   # workspace is skipped in BOTH branches so we never close our own session.

--- a/scripts/lib/herdr-task.sh
+++ b/scripts/lib/herdr-task.sh
@@ -186,7 +186,7 @@ print(d.get("result",{}).get("workspace",{}).get("workspace_id",""))' 2>/dev/nul
 # caller before git cleanup completes.
 herdr_task_close() {
   local worktree_path="$1" label="${2:-}"
-  local json ws matched_by tab candidate_ws metadata_ws metadata_tab pane_json pane_tabs matching_tabs tab_count
+  local json ws matched_by tab candidate_ws metadata_ws metadata_tab pane_json pane_tabs matching_tabs tab_count locator locator_exit
   herdr_task_enabled || return 1
 
   # Prefer the exact identity recorded at creation. This works even when the
@@ -210,6 +210,7 @@ herdr_task_close() {
   # rather than only the caller's, and match panes by checkout cwd. Never close
   # the tab that is executing task-clean.
   json="$(herdr workspace list 2>/dev/null)" || return 1
+  herdr_task_snapshot_valid "$json" workspaces || return 1
   matching_tabs=""
   while IFS= read -r candidate_ws; do
     [[ -n "$candidate_ws" ]] || continue
@@ -219,12 +220,18 @@ path=os.environ["WORKTREE_PATH"]
 current=os.environ.get("CURRENT_TAB","")
 prefix=path.rstrip("/")+"/"
 matches=set()
+current_match=False
 for pane in json.load(sys.stdin).get("result",{}).get("panes",[]):
   tid=pane.get("tab_id") or ""
   cwd=pane.get("cwd") or ""
   foreground=pane.get("foreground_cwd") or ""
-  if tid and tid != current and (cwd==path or cwd.startswith(prefix) or foreground==path or foreground.startswith(prefix)):
-    matches.add(tid)
+  if tid and (cwd==path or cwd.startswith(prefix) or foreground==path or foreground.startswith(prefix)):
+    if tid == current:
+      current_match=True
+    else:
+      matches.add(tid)
+if current_match:
+  print("__CURRENT_TASK_TAB__")
 for tid in sorted(matches):
   print(tid)
 ' 2>/dev/null)" || return 1
@@ -237,6 +244,9 @@ for workspace in json.load(sys.stdin).get("result",{}).get("workspaces",[]):
   if workspace_id: print(workspace_id)
 ' 2>/dev/null)
   if [[ -n "$matching_tabs" ]]; then
+    if printf '%s\n' "$matching_tabs" | grep -Fxq '__CURRENT_TASK_TAB__'; then
+      return 1
+    fi
     tab="$(printf '%s\n' "$matching_tabs" | sort -u)"
     tab_count="$(printf '%s\n' "$tab" | awk 'NF { count++ } END { print count+0 }')"
     [[ "$tab_count" = "1" ]] || return 1
@@ -245,29 +255,50 @@ for workspace in json.load(sys.stdin).get("result",{}).get("workspaces",[]):
   fi
 
   # Emit "<match_kind> <workspace_id>": "path" when bound to the checkout,
-  # else "label" when only the label matches. Path wins over label. The current
-  # workspace is skipped in BOTH branches so we never close our own session.
-  read -r matched_by ws <<<"$(printf '%s' "$json" | WORKTREE_PATH="$worktree_path" LABEL="$label" CURRENT_WS="${HERDR_WORKSPACE_ID:-}" python3 -c 'import os,sys,json
+  # else "label" when only the label matches. Path wins over label. A match on
+  # the current workspace is an owned-but-uncloseable failure, never "absent".
+  if locator="$(printf '%s' "$json" | WORKTREE_PATH="$worktree_path" LABEL="$label" CURRENT_WS="${HERDR_WORKSPACE_ID:-}" python3 -c 'import os,sys,json
 path=os.environ["WORKTREE_PATH"]
 label=os.environ.get("LABEL","")
 current=os.environ.get("CURRENT_WS","")
 d=json.load(sys.stdin)
 path_matches=[]
 label_matches=[]
+current_match=False
 for w in d.get("result",{}).get("workspaces",[]):
   wid=w.get("workspace_id") or ""
-  if wid and wid==current:
-    continue  # never close the pane we are running in
   wt=w.get("worktree") or {}
   if wt.get("checkout_path")==path:
-    path_matches.append(wid)
+    if wid == current:
+      current_match=True
+    else:
+      path_matches.append(wid)
   elif label and w.get("label")==label:
-    label_matches.append(wid)
+    if wid == current:
+      current_match=True
+    else:
+      label_matches.append(wid)
+if current_match:
+  raise SystemExit(2)
 if len(path_matches)==1:
   print("path", path_matches[0])
 elif not path_matches and len(label_matches)==1:
   print("label", label_matches[0])
-' 2>/dev/null)"
+elif path_matches or label_matches:
+  raise SystemExit(2)
+else:
+  raise SystemExit(3)
+' 2>/dev/null)"; then
+    locator_exit=0
+  else
+    locator_exit=$?
+  fi
+  if [[ "$locator_exit" = "3" ]]; then
+    # A valid all-workspace snapshot and every valid pane list found no owner.
+    return 0
+  fi
+  [[ "$locator_exit" = "0" ]] || return 1
+  read -r matched_by ws <<<"$locator"
   [[ -n "$ws" ]] || return 1
   if [[ "$matched_by" == "path" ]]; then
     herdr worktree remove --workspace "$ws" >/dev/null 2>&1 || \

--- a/scripts/lib/herdr-task.sh
+++ b/scripts/lib/herdr-task.sh
@@ -56,12 +56,14 @@ path=os.environ["WORKTREE_PATH"]
 prefix=path.rstrip("/")+"/"
 matching_panes={pane.get("tab_id") for pane in load("PANE_JSON").get("result",{}).get("panes",[]) if pane.get("tab_id") and any(cwd==path or cwd.startswith(prefix) for cwd in (pane.get("cwd") or "", pane.get("foreground_cwd") or ""))}
 new_tabs=[tab for tab in tabs if tab.get("tab_id") and tab.get("tab_id") not in before]
-for tab in new_tabs:
-  if tab.get("tab_id") in matching_panes:
-    print(tab["tab_id"]); raise SystemExit
-for tab in new_tabs:
-  if tab.get("label")==os.environ.get("LABEL", ""):
-    print(tab["tab_id"]); raise SystemExit
+path_matches=[tab["tab_id"] for tab in new_tabs if tab.get("tab_id") in matching_panes]
+if len(path_matches)==1:
+  print(path_matches[0]); raise SystemExit
+if path_matches:
+  raise SystemExit
+label_matches=[tab["tab_id"] for tab in new_tabs if tab.get("label")==os.environ.get("LABEL", "")]
+if len(label_matches)==1:
+  print(label_matches[0])
 ' 2>/dev/null || true)"
   [[ -n "$tab_id" ]] || return 1
   herdr tab close "$tab_id" >/dev/null 2>&1
@@ -84,12 +86,14 @@ def load(name):
 
 before={workspace.get("workspace_id") for workspace in load("BEFORE_JSON").get("result",{}).get("workspaces",[]) if workspace.get("workspace_id")}
 workspaces=[workspace for workspace in load("AFTER_JSON").get("result",{}).get("workspaces",[]) if workspace.get("workspace_id") and workspace.get("workspace_id") not in before]
-for workspace in workspaces:
-  if (workspace.get("worktree") or {}).get("checkout_path")==os.environ["WORKTREE_PATH"]:
-    print(workspace["workspace_id"]); raise SystemExit
-for workspace in workspaces:
-  if workspace.get("label")==os.environ.get("LABEL", ""):
-    print(workspace["workspace_id"]); raise SystemExit
+path_matches=[workspace["workspace_id"] for workspace in workspaces if (workspace.get("worktree") or {}).get("checkout_path")==os.environ["WORKTREE_PATH"]]
+if len(path_matches)==1:
+  print(path_matches[0]); raise SystemExit
+if path_matches:
+  raise SystemExit
+label_matches=[workspace["workspace_id"] for workspace in workspaces if workspace.get("label")==os.environ.get("LABEL", "")]
+if len(label_matches)==1:
+  print(label_matches[0])
 ' 2>/dev/null || true)"
   [[ -n "$workspace_id" ]] || return 1
   herdr worktree remove --workspace "$workspace_id" --force >/dev/null 2>&1 || \
@@ -182,53 +186,63 @@ print(d.get("result",{}).get("workspace",{}).get("workspace_id",""))' 2>/dev/nul
 # caller before git cleanup completes.
 herdr_task_close() {
   local worktree_path="$1" label="${2:-}"
-  local json ws matched_by tab candidate_ws metadata_ws metadata_tab
+  local json ws matched_by tab candidate_ws metadata_ws metadata_tab pane_json pane_tabs matching_tabs tab_count
   herdr_task_enabled || return 1
 
   # Prefer the exact identity recorded at creation. This works even when the
-  # caller is outside Herdr or in a different workspace.
+  # caller is outside Herdr or in a different workspace. Metadata is
+  # authoritative: if its exact owner cannot be closed, fail without guessing
+  # from cwd or label so a later retry can use the same identity.
   if read -r metadata_ws metadata_tab <<<"$(herdr_task_metadata_read "$worktree_path" 2>/dev/null || true)" && [[ -n "$metadata_ws" ]]; then
-    if [[ -n "$metadata_tab" && "$metadata_tab" != "${HERDR_TAB_ID:-}" ]]; then
-      if herdr tab close "$metadata_tab" >/dev/null 2>&1; then
-        return 0
-      fi
-    elif [[ -z "$metadata_tab" && "$metadata_ws" != "${HERDR_WORKSPACE_ID:-}" ]]; then
-      if herdr worktree remove --workspace "$metadata_ws" >/dev/null 2>&1 || \
-         herdr worktree remove --workspace "$metadata_ws" --force >/dev/null 2>&1 || \
-         herdr workspace close "$metadata_ws" >/dev/null 2>&1; then
-        return 0
-      fi
+    if [[ -n "$metadata_tab" ]]; then
+      [[ "$metadata_tab" != "${HERDR_TAB_ID:-}" ]] || return 1
+      herdr tab close "$metadata_tab" >/dev/null 2>&1 && return 0
+      return 1
     fi
+    [[ "$metadata_ws" != "${HERDR_WORKSPACE_ID:-}" ]] || return 1
+    herdr worktree remove --workspace "$metadata_ws" >/dev/null 2>&1 || \
+      herdr worktree remove --workspace "$metadata_ws" --force >/dev/null 2>&1 || \
+      herdr workspace close "$metadata_ws" >/dev/null 2>&1 || return 1
+    return 0
   fi
 
   # Metadata may be absent for legacy task tabs. Enumerate every workspace,
   # rather than only the caller's, and match panes by checkout cwd. Never close
   # the tab that is executing task-clean.
   json="$(herdr workspace list 2>/dev/null)" || return 1
+  matching_tabs=""
   while IFS= read -r candidate_ws; do
     [[ -n "$candidate_ws" ]] || continue
-    local pane_json
-    pane_json="$(herdr pane list --workspace "$candidate_ws" 2>/dev/null)" || continue
-    tab="$(printf '%s' "$pane_json" | WORKTREE_PATH="$worktree_path" CURRENT_TAB="${HERDR_TAB_ID:-}" python3 -c 'import os,sys,json
+    pane_json="$(herdr pane list --workspace "$candidate_ws" 2>/dev/null)" || return 1
+    pane_tabs="$(printf '%s' "$pane_json" | WORKTREE_PATH="$worktree_path" CURRENT_TAB="${HERDR_TAB_ID:-}" python3 -c 'import os,sys,json
 path=os.environ["WORKTREE_PATH"]
 current=os.environ.get("CURRENT_TAB","")
 prefix=path.rstrip("/")+"/"
+matches=set()
 for pane in json.load(sys.stdin).get("result",{}).get("panes",[]):
   tid=pane.get("tab_id") or ""
   cwd=pane.get("cwd") or ""
   foreground=pane.get("foreground_cwd") or ""
   if tid and tid != current and (cwd==path or cwd.startswith(prefix) or foreground==path or foreground.startswith(prefix)):
-    print(tid); break
+    matches.add(tid)
+for tid in sorted(matches):
+  print(tid)
 ' 2>/dev/null)" || return 1
-    if [[ -n "$tab" ]]; then
-      herdr tab close "$tab" >/dev/null 2>&1 || return 1
-      return 0
+    if [[ -n "$pane_tabs" ]]; then
+      matching_tabs+="${matching_tabs:+$'\n'}$pane_tabs"
     fi
   done < <(printf '%s' "$json" | python3 -c 'import sys,json
 for workspace in json.load(sys.stdin).get("result",{}).get("workspaces",[]):
   workspace_id=workspace.get("workspace_id") or ""
   if workspace_id: print(workspace_id)
 ' 2>/dev/null)
+  if [[ -n "$matching_tabs" ]]; then
+    tab="$(printf '%s\n' "$matching_tabs" | sort -u)"
+    tab_count="$(printf '%s\n' "$tab" | awk 'NF { count++ } END { print count+0 }')"
+    [[ "$tab_count" = "1" ]] || return 1
+    herdr tab close "$tab" >/dev/null 2>&1 || return 1
+    return 0
+  fi
 
   # Emit "<match_kind> <workspace_id>": "path" when bound to the checkout,
   # else "label" when only the label matches. Path wins over label. The current
@@ -238,18 +252,21 @@ path=os.environ["WORKTREE_PATH"]
 label=os.environ.get("LABEL","")
 current=os.environ.get("CURRENT_WS","")
 d=json.load(sys.stdin)
-by_label=""
+path_matches=[]
+label_matches=[]
 for w in d.get("result",{}).get("workspaces",[]):
   wid=w.get("workspace_id") or ""
   if wid and wid==current:
     continue  # never close the pane we are running in
   wt=w.get("worktree") or {}
   if wt.get("checkout_path")==path:
-    print("path", wid); break
-  if label and not by_label and w.get("label")==label:
-    by_label=wid
-else:
-  if by_label: print("label", by_label)
+    path_matches.append(wid)
+  elif label and w.get("label")==label:
+    label_matches.append(wid)
+if len(path_matches)==1:
+  print("path", path_matches[0])
+elif not path_matches and len(label_matches)==1:
+  print("label", label_matches[0])
 ' 2>/dev/null)"
   [[ -n "$ws" ]] || return 1
   if [[ "$matched_by" == "path" ]]; then

--- a/scripts/lib/review-database-url.sh
+++ b/scripts/lib/review-database-url.sh
@@ -1,0 +1,36 @@
+# review-database-url.sh — validate explicit databases used by destructive tests.
+# shellcheck shell=bash
+
+validate_review_database_url() {
+  local database_url="$1"
+
+  REVIEW_DATABASE_URL_TO_VALIDATE="$database_url" node <<'NODE'
+const raw = process.env.REVIEW_DATABASE_URL_TO_VALIDATE;
+let url;
+try {
+  url = new URL(raw);
+} catch {
+  console.error('REVIEW_DATABASE_URL must be a valid PostgreSQL URL');
+  process.exit(2);
+}
+
+if (url.protocol !== 'postgres:' && url.protocol !== 'postgresql:') {
+  console.error('REVIEW_DATABASE_URL must use postgres:// or postgresql://');
+  process.exit(2);
+}
+
+const databaseName = url.pathname.replace(/^\//, '');
+if (!databaseName.startsWith('lobu_test')) {
+  console.error("REVIEW_DATABASE_URL database must start with 'lobu_test'");
+  process.exit(2);
+}
+
+for (const [key] of url.searchParams) {
+  const normalized = key.toLowerCase();
+  if (normalized.includes('\0') || normalized === 'database' || normalized === 'dbname') {
+    console.error(`REVIEW_DATABASE_URL must not override the database via '${key}'`);
+    process.exit(2);
+  }
+}
+NODE
+}

--- a/scripts/lib/review-lock.sh
+++ b/scripts/lib/review-lock.sh
@@ -1,0 +1,41 @@
+# review-lock.sh — host-wide ownership for the destructive full review suite.
+# shellcheck shell=bash
+
+REVIEW_LOCK_PATH=""
+
+release_review_lock() {
+  [ -n "$REVIEW_LOCK_PATH" ] || return 0
+  if [ "$(readlink "$REVIEW_LOCK_PATH" 2>/dev/null || true)" = "$$" ]; then
+    rm -f "$REVIEW_LOCK_PATH"
+  fi
+  REVIEW_LOCK_PATH=""
+}
+
+acquire_review_lock() {
+  local lock_root candidate owner_pid waited=0
+  lock_root="${TMPDIR:-/tmp}/lobu-review-locks"
+  candidate="$lock_root/full-review"
+  mkdir -p "$lock_root"
+
+  # Database isolation is necessary but not sufficient: the full suite also
+  # owns machine-global ports, embedded Postgres processes, and constrained
+  # macOS shared-memory slots. Serialize the whole gate even when callers use
+  # different REVIEW_DATABASE_URL values.
+  while ! ln -s "$$" "$candidate" 2>/dev/null; do
+    owner_pid="$(readlink "$candidate" 2>/dev/null || true)"
+    if [ -z "$owner_pid" ] || ! kill -0 "$owner_pid" 2>/dev/null; then
+      rm -f "$candidate"
+      continue
+    fi
+    if [ "$waited" -eq 0 ]; then
+      echo ">> another full review owns this host (pid $owner_pid); waiting"
+    fi
+    if [ "$waited" -ge "${REVIEW_LOCK_TIMEOUT_SECONDS:-1800}" ]; then
+      echo "timed out waiting for full review lock held by pid $owner_pid" >&2
+      return 2
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  REVIEW_LOCK_PATH="$candidate"
+}

--- a/scripts/lib/review-lock.sh
+++ b/scripts/lib/review-lock.sh
@@ -1,41 +1,69 @@
 # review-lock.sh — host-wide ownership for the destructive full review suite.
 # shellcheck shell=bash
 
-REVIEW_LOCK_PATH=""
+# FD 9 is intentionally inherited by review children. Kernel flock ownership
+# then survives an abrupt parent exit until every child is gone, so another
+# review cannot overlap an orphaned test process.
+REVIEW_LOCK_HELD=0
+
+review_lock_root() {
+  if [ -n "${REVIEW_LOCK_ROOT_FOR_TESTS:-}" ]; then
+    printf '%s\n' "$REVIEW_LOCK_ROOT_FOR_TESTS"
+  else
+    printf '/tmp/lobu-review-locks-%s\n' "$(id -u)"
+  fi
+}
 
 release_review_lock() {
-  [ -n "$REVIEW_LOCK_PATH" ] || return 0
-  if [ "$(readlink "$REVIEW_LOCK_PATH" 2>/dev/null || true)" = "$$" ]; then
-    rm -f "$REVIEW_LOCK_PATH"
-  fi
-  REVIEW_LOCK_PATH=""
+  [ "$REVIEW_LOCK_HELD" = "1" ] || return 0
+  exec 9>&-
+  REVIEW_LOCK_HELD=0
 }
 
 acquire_review_lock() {
-  local lock_root candidate owner_pid waited=0
-  lock_root="${TMPDIR:-/tmp}/lobu-review-locks"
-  candidate="$lock_root/full-review"
-  mkdir -p "$lock_root"
+  local lock_root candidate owner_pid timeout poll_seconds started now announced
+  lock_root="$(review_lock_root)"
+  candidate="$lock_root/full-review.lock"
+  timeout="${REVIEW_LOCK_TIMEOUT_SECONDS:-1800}"
+  poll_seconds="${REVIEW_LOCK_POLL_SECONDS:-2}"
 
-  # Database isolation is necessary but not sufficient: the full suite also
-  # owns machine-global ports, embedded Postgres processes, and constrained
-  # macOS shared-memory slots. Serialize the whole gate even when callers use
-  # different REVIEW_DATABASE_URL values.
-  while ! ln -s "$$" "$candidate" 2>/dev/null; do
-    owner_pid="$(readlink "$candidate" 2>/dev/null || true)"
-    if [ -z "$owner_pid" ] || ! kill -0 "$owner_pid" 2>/dev/null; then
-      rm -f "$candidate"
-      continue
+  case "$timeout" in
+    ''|*[!0-9]*)
+      echo "REVIEW_LOCK_TIMEOUT_SECONDS must be a non-negative integer" >&2
+      return 2
+      ;;
+  esac
+
+  mkdir -p "$lock_root"
+  chmod 700 "$lock_root"
+  touch "$candidate"
+  chmod 600 "$candidate"
+  exec 9>>"$candidate"
+  started="$(date +%s)"
+  announced=0
+
+  while ! perl -MFcntl=:flock -e \
+    'exit(flock(STDIN, LOCK_EX | LOCK_NB) ? 0 : 1)' <&9; do
+    owner_pid="$(sed -n '1p' "$candidate" 2>/dev/null || true)"
+    if [ -z "$owner_pid" ]; then
+      owner_pid="unknown"
     fi
-    if [ "$waited" -eq 0 ]; then
-      echo ">> another full review owns this host (pid $owner_pid); waiting"
-    fi
-    if [ "$waited" -ge "${REVIEW_LOCK_TIMEOUT_SECONDS:-1800}" ]; then
+    now="$(date +%s)"
+    if [ $((now - started)) -ge "$timeout" ]; then
+      exec 9>&-
       echo "timed out waiting for full review lock held by pid $owner_pid" >&2
       return 2
     fi
-    sleep 2
-    waited=$((waited + 2))
+    if [ "$announced" = "0" ]; then
+      echo ">> another full review owns this host (pid $owner_pid); waiting"
+      announced=1
+    fi
+    sleep "$poll_seconds"
   done
-  REVIEW_LOCK_PATH="$candidate"
+
+  # The file may contain a PID from a dead process, but the kernel lock is the
+  # source of truth. Rewrite diagnostics only after atomic ownership succeeds.
+  : > "$candidate"
+  printf '%s\n' "$$" >&9
+  REVIEW_LOCK_HELD=1
 }

--- a/scripts/lib/review-process-supervisor.py
+++ b/scripts/lib/review-process-supervisor.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Run one review command in its own session and own every descendant."""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+
+def write_identity(path: Path, value: int) -> None:
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(f"{value}\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def group_alive(process_group: int) -> bool:
+    try:
+        os.killpg(process_group, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def signal_group(process_group: Optional[int], sig: signal.Signals) -> None:
+    if process_group is None:
+        return
+    try:
+        os.killpg(process_group, sig)
+    except ProcessLookupError:
+        pass
+
+
+def wait_for_group_exit(
+    child: subprocess.Popen, process_group: int, timeout: float
+) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        child.poll()
+        if not group_alive(process_group):
+            return True
+        time.sleep(0.02)
+    child.poll()
+    return not group_alive(process_group)
+
+
+def main() -> int:
+    if len(sys.argv) < 4 or sys.argv[1] != "--control-dir" or sys.argv[3] != "--":
+        print(
+            "usage: review-process-supervisor.py --control-dir DIR -- COMMAND [ARG...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    control_dir = Path(sys.argv[2])
+    command = sys.argv[4:]
+    if not command:
+        print("review supervisor requires a command", file=sys.stderr)
+        return 2
+
+    control_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    requested_signal: Optional[signal.Signals] = None
+    process_group: Optional[int] = None
+
+    def request_shutdown(signum: int, _frame: object) -> None:
+        nonlocal requested_signal
+        requested_signal = signal.Signals(signum)
+        signal_group(process_group, signal.SIGTERM)
+
+    for handled in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+        signal.signal(handled, request_shutdown)
+
+    # Publish supervisor ownership before any optional delay or child spawn.
+    # The parent trap can therefore find and stop us even if its signal lands
+    # between the shell's asynchronous launch and `$!` assignment.
+    write_identity(control_dir / "supervisor.pid", os.getpid())
+
+    delay = float(os.environ.get("REVIEW_SUPERVISOR_START_DELAY_SECONDS", "0"))
+    if delay > 0:
+        deadline = time.monotonic() + delay
+        while requested_signal is None and time.monotonic() < deadline:
+            time.sleep(max(0, min(0.02, deadline - time.monotonic())))
+    if requested_signal is not None:
+        return 128 + requested_signal.value
+
+    child = subprocess.Popen(command, start_new_session=True, close_fds=True)
+    process_group = child.pid
+    write_identity(control_dir / "process-group.pid", process_group)
+
+    if requested_signal is not None:
+        signal_group(process_group, signal.SIGTERM)
+
+    while child.poll() is None and requested_signal is None:
+        time.sleep(0.02)
+
+    child_exit = child.poll()
+    grace = float(os.environ.get("REVIEW_PROCESS_TERM_GRACE_SECONDS", "2"))
+
+    # A command may exit while leaving workers behind, or a TERM handler may
+    # fork one last cleanup child after the first group signal. Keep supervising
+    # the session until it is empty; escalate only after the grace period.
+    if group_alive(process_group):
+        signal_group(process_group, signal.SIGTERM)
+        if not wait_for_group_exit(child, process_group, grace):
+            signal_group(process_group, signal.SIGKILL)
+            while not wait_for_group_exit(child, process_group, 0.5):
+                signal_group(process_group, signal.SIGKILL)
+
+    if child_exit is None:
+        child_exit = child.wait()
+
+    if requested_signal is not None:
+        return 128 + requested_signal.value
+    if child_exit < 0:
+        return 128 - child_exit
+    return child_exit
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/review-process.sh
+++ b/scripts/lib/review-process.sh
@@ -1,101 +1,141 @@
-# review-process.sh — child and Herdr lifecycle ownership for the review gate.
+# review-process.sh — process-session ownership for the destructive review gate.
 # shellcheck shell=bash
 
+REVIEW_PROCESS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REVIEW_ACTIVE_CHILD_PID=""
-REVIEW_HERDR_PANE_ID=""
-REVIEW_HERDR_PANE_NAME=""
-REVIEW_HERDR_RAW_FILE=""
-REVIEW_HERDR_EXIT_FILE=""
+REVIEW_ACTIVE_CONTROL_DIR=""
+REVIEW_PREVIOUS_BACKGROUND_PID=""
 REVIEW_INLINE_RAW_FILE=""
 
+review_process_control_root() {
+  if [ -n "${REVIEW_PROCESS_CONTROL_ROOT_FOR_TESTS:-}" ]; then
+    printf '%s\n' "$REVIEW_PROCESS_CONTROL_ROOT_FOR_TESTS"
+  else
+    printf '/tmp/lobu-review-processes-%s\n' "$(id -u)"
+  fi
+}
+
+review_read_pid_file() {
+  local path="$1" value
+  [ -f "$path" ] || return 1
+  value="$(sed -n '1p' "$path" 2>/dev/null || true)"
+  case "$value" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf '%s\n' "$value"
+}
+
 run_review_child() {
-  local child_exit
-  "$@" &
-  REVIEW_ACTIVE_CHILD_PID=$!
-  if wait "$REVIEW_ACTIVE_CHILD_PID"; then
+  local child_exit control_root control_dir supervisor_pid nounset_enabled
+  local -a command
+  [ "$#" -gt 0 ] || return 2
+
+  control_root="$(review_process_control_root)"
+  mkdir -p "$control_root"
+  chmod 700 "$control_root"
+  control_dir="$(mktemp -d "$control_root/run.XXXXXX")"
+  nounset_enabled=0
+  case "$-" in *u*) nounset_enabled=1; set +u ;; esac
+  REVIEW_PREVIOUS_BACKGROUND_PID="$!"
+  [ "$nounset_enabled" = "0" ] || set -u
+  REVIEW_ACTIVE_CONTROL_DIR="$control_dir"
+  REVIEW_ACTIVE_CHILD_PID=""
+
+  if declare -F "$1" >/dev/null 2>&1; then
+    # The function name is intentionally dynamic.
+    # shellcheck disable=SC2163
+    export -f "$1"
+    command=(bash -c "$1")
+  else
+    command=("$@")
+  fi
+
+  python3 "$REVIEW_PROCESS_LIB_DIR/review-process-supervisor.py" \
+    --control-dir "$control_dir" -- "${command[@]}" &
+  if [ -n "${REVIEW_PARENT_PUBLISH_DELAY_FOR_TESTS:-}" ]; then
+    sleep "$REVIEW_PARENT_PUBLISH_DELAY_FOR_TESTS"
+  fi
+  supervisor_pid=$!
+  REVIEW_ACTIVE_CHILD_PID="$supervisor_pid"
+
+  if wait "$supervisor_pid"; then
     child_exit=0
   else
     child_exit=$?
   fi
+
   REVIEW_ACTIVE_CHILD_PID=""
+  REVIEW_ACTIVE_CONTROL_DIR=""
+  REVIEW_PREVIOUS_BACKGROUND_PID=""
+  rm -rf "$control_dir"
   return "$child_exit"
 }
 
-review_descendant_pids() {
-  local parent_pid="$1"
-  local child_pid
-  for child_pid in $(pgrep -P "$parent_pid" 2>/dev/null || true); do
-    printf '%s\n' "$child_pid"
-    review_descendant_pids "$child_pid"
-  done
-}
-
 stop_active_review_child() {
-  local child_pid descendant pid alive attempts
-  local -a descendants
-  child_pid="$REVIEW_ACTIVE_CHILD_PID"
-  [ -n "$child_pid" ] || return 0
+  local control_dir supervisor_pid process_group last_background_pid attempts nounset_enabled
+  control_dir="$REVIEW_ACTIVE_CONTROL_DIR"
+  supervisor_pid="$REVIEW_ACTIVE_CHILD_PID"
+  nounset_enabled=0
+  case "$-" in *u*) nounset_enabled=1; set +u ;; esac
+  last_background_pid="$!"
+  [ "$nounset_enabled" = "0" ] || set -u
+  [ -n "$control_dir" ] || return 0
 
-  descendants=()
-  while IFS= read -r descendant; do
-    [ -n "$descendant" ] && descendants[${#descendants[@]}]="$descendant"
-  done < <(review_descendant_pids "$child_pid")
-  kill -TERM "$child_pid" "${descendants[@]}" 2>/dev/null || true
+  # If a signal interrupted the shell between `python3 ... &` and publishing
+  # `$!`, wait for the supervisor's atomically-written identity instead of
+  # guessing from the shell's previous background job.
+  attempts=0
+  while [ -z "$supervisor_pid" ] && [ "$attempts" -lt 100 ]; do
+    supervisor_pid="$(review_read_pid_file "$control_dir/supervisor.pid" || true)"
+    [ -n "$supervisor_pid" ] && break
+    sleep 0.01
+    attempts=$((attempts + 1))
+  done
+  if [ -z "$supervisor_pid" ] && [ -n "$last_background_pid" ] &&
+    [ "$last_background_pid" != "$REVIEW_PREVIOUS_BACKGROUND_PID" ]; then
+    supervisor_pid="$last_background_pid"
+  fi
+
+  if [ -n "$supervisor_pid" ]; then
+    kill -TERM "$supervisor_pid" 2>/dev/null || true
+  fi
 
   attempts=0
-  while [ "$attempts" -lt 40 ]; do
-    alive=0
-    for pid in "$child_pid" "${descendants[@]}"; do
-      if kill -0 "$pid" 2>/dev/null; then
-        alive=1
+  while [ "$attempts" -lt 240 ]; do
+    process_group="$(review_read_pid_file "$control_dir/process-group.pid" || true)"
+    if [ -n "$supervisor_pid" ] && ! kill -0 "$supervisor_pid" 2>/dev/null; then
+      if [ -z "$process_group" ] || ! kill -0 "-$process_group" 2>/dev/null; then
         break
       fi
-    done
-    [ "$alive" = "1" ] || break
-    sleep 0.05
+    fi
+    sleep 0.025
     attempts=$((attempts + 1))
   done
 
-  if [ "$alive" = "1" ]; then
-    kill -KILL "$child_pid" "${descendants[@]}" 2>/dev/null || true
+  process_group="$(review_read_pid_file "$control_dir/process-group.pid" || true)"
+  if [ -n "$process_group" ] && kill -0 "-$process_group" 2>/dev/null; then
+    kill -KILL "-$process_group" 2>/dev/null || true
+    while kill -0 "-$process_group" 2>/dev/null; do
+      sleep 0.025
+    done
   fi
-  wait "$child_pid" 2>/dev/null || true
+
+  if [ -n "$supervisor_pid" ] && kill -0 "$supervisor_pid" 2>/dev/null; then
+    kill -KILL "$supervisor_pid" 2>/dev/null || true
+  fi
+  [ -z "$supervisor_pid" ] || wait "$supervisor_pid" 2>/dev/null || true
+
   REVIEW_ACTIVE_CHILD_PID=""
+  REVIEW_ACTIVE_CONTROL_DIR=""
+  REVIEW_PREVIOUS_BACKGROUND_PID=""
+  rm -rf "$control_dir"
 }
 
-register_review_herdr_pane() {
-  local pane_name="$1"
-  local start_output="$2"
-  local pane_id
-  REVIEW_HERDR_PANE_NAME="$pane_name"
-  pane_id="$(printf '%s\n' "$start_output" | jq -r \
-    '.result.pane_id // .result.pane.pane_id // .pane_id // empty' 2>/dev/null || true)"
-  if [ -z "$pane_id" ]; then
-    pane_id="$(herdr pane list --workspace "$HERDR_WORKSPACE_ID" 2>/dev/null | jq -r \
-      --arg label "$pane_name" \
-      '.result.panes[]? | select(.label == $label) | .pane_id' | head -n1)"
+review_process_abort_inline() {
+  if [ -n "$REVIEW_INLINE_RAW_FILE" ] && [ -s "$REVIEW_INLINE_RAW_FILE" ]; then
+    echo ">> interrupted inline Claude output preserved at $REVIEW_INLINE_RAW_FILE" >&2
+  else
+    rm -f "${REVIEW_INLINE_RAW_FILE:-}"
   fi
-  REVIEW_HERDR_PANE_ID="$pane_id"
-}
-
-close_review_herdr_pane() {
-  local pane_id="$REVIEW_HERDR_PANE_ID"
-  if [ -z "$pane_id" ] && [ -n "$REVIEW_HERDR_PANE_NAME" ] &&
-    command -v herdr >/dev/null 2>&1; then
-    pane_id="$(herdr pane list --workspace "$HERDR_WORKSPACE_ID" 2>/dev/null | jq -r \
-      --arg label "$REVIEW_HERDR_PANE_NAME" \
-      '.result.panes[]? | select(.label == $label) | .pane_id' | head -n1)"
-  fi
-  if [ -n "$pane_id" ] && command -v herdr >/dev/null 2>&1; then
-    herdr pane close "$pane_id" >/dev/null 2>&1 || true
-  fi
-  # Remove after pane termination so a racing writer cannot recreate the exit
-  # marker after cleanup.
-  rm -f "${REVIEW_HERDR_RAW_FILE:-}" "${REVIEW_HERDR_EXIT_FILE:-}"
-  rm -f "${REVIEW_INLINE_RAW_FILE:-}"
-  REVIEW_HERDR_PANE_ID=""
-  REVIEW_HERDR_PANE_NAME=""
-  REVIEW_HERDR_RAW_FILE=""
-  REVIEW_HERDR_EXIT_FILE=""
   REVIEW_INLINE_RAW_FILE=""
 }

--- a/scripts/lib/review-process.sh
+++ b/scripts/lib/review-process.sh
@@ -1,0 +1,101 @@
+# review-process.sh — child and Herdr lifecycle ownership for the review gate.
+# shellcheck shell=bash
+
+REVIEW_ACTIVE_CHILD_PID=""
+REVIEW_HERDR_PANE_ID=""
+REVIEW_HERDR_PANE_NAME=""
+REVIEW_HERDR_RAW_FILE=""
+REVIEW_HERDR_EXIT_FILE=""
+REVIEW_INLINE_RAW_FILE=""
+
+run_review_child() {
+  local child_exit
+  "$@" &
+  REVIEW_ACTIVE_CHILD_PID=$!
+  if wait "$REVIEW_ACTIVE_CHILD_PID"; then
+    child_exit=0
+  else
+    child_exit=$?
+  fi
+  REVIEW_ACTIVE_CHILD_PID=""
+  return "$child_exit"
+}
+
+review_descendant_pids() {
+  local parent_pid="$1"
+  local child_pid
+  for child_pid in $(pgrep -P "$parent_pid" 2>/dev/null || true); do
+    printf '%s\n' "$child_pid"
+    review_descendant_pids "$child_pid"
+  done
+}
+
+stop_active_review_child() {
+  local child_pid descendant pid alive attempts
+  local -a descendants
+  child_pid="$REVIEW_ACTIVE_CHILD_PID"
+  [ -n "$child_pid" ] || return 0
+
+  descendants=()
+  while IFS= read -r descendant; do
+    [ -n "$descendant" ] && descendants[${#descendants[@]}]="$descendant"
+  done < <(review_descendant_pids "$child_pid")
+  kill -TERM "$child_pid" "${descendants[@]}" 2>/dev/null || true
+
+  attempts=0
+  while [ "$attempts" -lt 40 ]; do
+    alive=0
+    for pid in "$child_pid" "${descendants[@]}"; do
+      if kill -0 "$pid" 2>/dev/null; then
+        alive=1
+        break
+      fi
+    done
+    [ "$alive" = "1" ] || break
+    sleep 0.05
+    attempts=$((attempts + 1))
+  done
+
+  if [ "$alive" = "1" ]; then
+    kill -KILL "$child_pid" "${descendants[@]}" 2>/dev/null || true
+  fi
+  wait "$child_pid" 2>/dev/null || true
+  REVIEW_ACTIVE_CHILD_PID=""
+}
+
+register_review_herdr_pane() {
+  local pane_name="$1"
+  local start_output="$2"
+  local pane_id
+  REVIEW_HERDR_PANE_NAME="$pane_name"
+  pane_id="$(printf '%s\n' "$start_output" | jq -r \
+    '.result.pane_id // .result.pane.pane_id // .pane_id // empty' 2>/dev/null || true)"
+  if [ -z "$pane_id" ]; then
+    pane_id="$(herdr pane list --workspace "$HERDR_WORKSPACE_ID" 2>/dev/null | jq -r \
+      --arg label "$pane_name" \
+      '.result.panes[]? | select(.label == $label) | .pane_id' | head -n1)"
+  fi
+  REVIEW_HERDR_PANE_ID="$pane_id"
+}
+
+close_review_herdr_pane() {
+  local pane_id="$REVIEW_HERDR_PANE_ID"
+  if [ -z "$pane_id" ] && [ -n "$REVIEW_HERDR_PANE_NAME" ] &&
+    command -v herdr >/dev/null 2>&1; then
+    pane_id="$(herdr pane list --workspace "$HERDR_WORKSPACE_ID" 2>/dev/null | jq -r \
+      --arg label "$REVIEW_HERDR_PANE_NAME" \
+      '.result.panes[]? | select(.label == $label) | .pane_id' | head -n1)"
+  fi
+  if [ -n "$pane_id" ] && command -v herdr >/dev/null 2>&1; then
+    herdr pane close "$pane_id" >/dev/null 2>&1 || true
+  fi
+  # Remove after pane termination so a racing writer cannot recreate the exit
+  # marker after cleanup.
+  rm -f "${REVIEW_HERDR_RAW_FILE:-}" "${REVIEW_HERDR_EXIT_FILE:-}"
+  rm -f "${REVIEW_INLINE_RAW_FILE:-}"
+  REVIEW_HERDR_PANE_ID=""
+  REVIEW_HERDR_PANE_NAME=""
+  REVIEW_HERDR_RAW_FILE=""
+  REVIEW_HERDR_EXIT_FILE=""
+  REVIEW_INLINE_RAW_FILE=""
+}

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -105,6 +105,7 @@ post_review_status() {
     || echo ">> warning: failed to post GitHub commit status '$PI_REVIEW_STATUS_CONTEXT'" >&2
 }
 
+REVIEW_STATUS_STARTED=0
 REVIEW_STATUS_FINALIZED=0
 finalize_review_status() {
   post_review_status "$1" "$2" "${3:-}"
@@ -344,7 +345,7 @@ process.exit(1);
 }
 
 review_exit_cleanup() {
-  local ec=$?
+  local ec=$? post_failure_status=0
   trap - EXIT INT TERM HUP
   stop_active_review_child
   review_process_abort_inline
@@ -352,10 +353,14 @@ review_exit_cleanup() {
   # Otherwise this closes the tab/process and keeps any non-empty partial raw
   # output for diagnosis before the script exits.
   herdr_review_abort || true
-  release_review_lock
-  if [ "$ec" -ne 0 ] && [ "${REVIEW_STATUS_FINALIZED:-0}" != "1" ]; then
+  if [ "$ec" -ne 0 ] && [ "$REVIEW_LOCK_HELD" = "1" ] && \
+     [ "$REVIEW_STATUS_STARTED" = "1" ] && [ "$REVIEW_STATUS_FINALIZED" != "1" ]; then
+    post_failure_status=1
+  fi
+  if [ "$post_failure_status" = "1" ]; then
     post_review_status error "Claude review failed before verdict (exit $ec)"
   fi
+  release_review_lock
   exit "$ec"
 }
 trap review_exit_cleanup EXIT
@@ -365,6 +370,7 @@ trap 'exit 129' HUP
 
 acquire_review_lock
 
+REVIEW_STATUS_STARTED=1
 post_review_status pending "Claude review running"
 
 # --- env --------------------------------------------------------------------

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -32,6 +32,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/lib/review-database-url.sh"
 # shellcheck source=scripts/lib/review-process.sh
 . "$SCRIPT_DIR/lib/review-process.sh"
+# shellcheck source=scripts/lib/herdr-review-lifecycle.sh
+. "$SCRIPT_DIR/lib/herdr-review-lifecycle.sh"
 
 # --- preflight --------------------------------------------------------------
 
@@ -143,10 +145,9 @@ run_claude_review_herdr() {
   exit_file="$(mktemp /tmp/lobu-review-claude-exit.XXXXXX)"
   runner_file="$(mktemp /tmp/lobu-review-claude-runner.XXXXXX)"
   rm -f "$exit_file"
+  herdr_review_track_files "$raw_file" "$exit_file" "$runner_file"
   pane_name="claude-review-${HEAD_SHA:0:8}-$$"
-  REVIEW_HERDR_PANE_NAME="$pane_name"
-  REVIEW_HERDR_RAW_FILE="$raw_file"
-  REVIEW_HERDR_EXIT_FILE="$exit_file"
+  herdr_review_track_locator "$HERDR_WORKSPACE_ID" "$pane_name"
 
   cat > "$runner_file" <<'RUNNER'
 set +e
@@ -193,6 +194,7 @@ RUNNER
     read -r tab_id pane_id <<<"$(printf '%s' "$tab_json" | python3 -c 'import json,sys
 d=json.load(sys.stdin).get("result", {})
 print((d.get("tab") or {}).get("tab_id", ""), (d.get("root_pane") or {}).get("pane_id", ""))' 2>/dev/null)"
+    [ -n "$tab_id" ] && herdr_review_track_tab "$tab_id"
     if [ -z "$tab_id" ] || [ -z "$pane_id" ]; then
       start_exit=1
       started="Herdr tab create returned no tab/pane id: $tab_json"
@@ -206,15 +208,12 @@ print((d.get("tab") or {}).get("tab_id", ""), (d.get("root_pane") or {}).get("pa
   fi
   set -e
   if [ $start_exit -ne 0 ]; then
-    [ -n "${tab_id:-}" ] && herdr tab close "$tab_id" >/dev/null 2>&1 || true
-    rm -f "$runner_file"
+    herdr_review_cleanup
     echo ">> Herdr Claude tab failed to start; falling back to inline Claude" >&2
     printf '%s\n' "$started" >&2
-    close_review_herdr_pane
     run_claude_review_inline "$prompt_file"
     return
   fi
-  register_review_herdr_pane "$pane_name" "$started"
 
   echo ">> Claude review is visible in Herdr tab '$pane_name'"
   local waited=0
@@ -222,9 +221,12 @@ print((d.get("tab") or {}).get("tab_id", ""), (d.get("root_pane") or {}).get("pa
     sleep 2
     waited=$((waited + 2))
     if [ "$waited" -ge "${CLAUDE_REVIEW_TIMEOUT_SECONDS:-1200}" ]; then
+      # Stop the tab first so tee flushes its final partial output, then copy it
+      # into RAW before deleting the transport files.
+      herdr_review_close_tab
       RAW="$(cat "$raw_file" 2>/dev/null || true)"
       CLAUDE_EXIT=124
-      close_review_herdr_pane
+      herdr_review_cleanup
       echo ">> Claude review tab timed out after ${waited}s" >&2
       return
     fi
@@ -232,11 +234,7 @@ print((d.get("tab") or {}).get("tab_id", ""), (d.get("root_pane") or {}).get("pa
 
   RAW="$(cat "$raw_file" 2>/dev/null || true)"
   CLAUDE_EXIT="$(cat "$exit_file" 2>/dev/null || echo 1)"
-  rm -f "$raw_file" "$exit_file" "$runner_file"
-  REVIEW_HERDR_PANE_ID=""
-  REVIEW_HERDR_PANE_NAME=""
-  REVIEW_HERDR_RAW_FILE=""
-  REVIEW_HERDR_EXIT_FILE=""
+  herdr_review_cleanup
 }
 
 run_claude_review() {
@@ -331,18 +329,24 @@ process.exit(1);
   printf '%s\n' "$raw" | sed -e 's/^```json//' -e 's/^```//' -e 's/```$//'
 }
 
-handle_review_signal() {
-  local exit_code="$1"
-  trap - INT TERM HUP
+review_exit_cleanup() {
+  local ec=$?
+  trap - EXIT INT TERM HUP
   stop_active_review_child
-  close_review_herdr_pane
-  exit "$exit_code"
+  # If the normal Herdr path completed, its tracked state is already empty.
+  # Otherwise this closes the tab/process and keeps any non-empty partial raw
+  # output for diagnosis before the script exits.
+  herdr_review_abort
+  release_review_lock
+  if [ "$ec" -ne 0 ] && [ "${REVIEW_STATUS_FINALIZED:-0}" != "1" ]; then
+    post_review_status error "Claude review failed before verdict (exit $ec)"
+  fi
+  exit "$ec"
 }
-
-trap 'handle_review_signal 130' INT
-trap 'handle_review_signal 143' TERM
-trap 'handle_review_signal 129' HUP
-trap 'ec=$?; stop_active_review_child; close_review_herdr_pane; release_review_lock; if [ $ec -ne 0 ] && [ "${REVIEW_STATUS_FINALIZED:-0}" != "1" ]; then post_review_status error "Claude review failed before verdict (exit $ec)"; fi' EXIT
+trap review_exit_cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 
 acquire_review_lock
 
@@ -418,6 +422,9 @@ run_review_unit_suites() {
   "${DETERMINISTIC_TEST_ENV[@]}" bash "$SCRIPT_DIR/lib/__tests__/review-lock.test.sh";               ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   "${DETERMINISTIC_TEST_ENV[@]}" bash "$SCRIPT_DIR/lib/__tests__/review-database-url.test.sh";        ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   "${DETERMINISTIC_TEST_ENV[@]}" bash "$SCRIPT_DIR/lib/__tests__/review-process.test.sh";             ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  # Shell lifecycle regressions: Herdr task/review tabs must be owned and
+  # cleaned without invoking the real Herdr daemon.
+  "${DETERMINISTIC_TEST_ENV[@]}" bash "$SCRIPT_DIR/lib/__tests__/herdr-lifecycle.test.sh";            ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   # Guard: every packages/server *.test.ts must run in >=1 runner (vitest or a
   # bun job). Fails loudly if a file drifts into running nowhere — the
   # silent-skip class this change fixes.
@@ -481,10 +488,11 @@ PROMPT_FILE="$(pwd)/prompts/review-prompt.md"
 
 echo ">> invoking Claude CLI (model: $CLAUDE_REVIEW_MODEL, effort: $CLAUDE_REVIEW_EFFORT)"
 CLAUDE_PROMPT_FILE="$(mktemp /tmp/lobu-review-prompt.XXXXXX)"
+herdr_review_track_prompt "$CLAUDE_PROMPT_FILE"
 cat "$PROMPT_FILE" > "$CLAUDE_PROMPT_FILE"
 printf '\n\nReview the diff. Emit only the JSON verdict.\n' >> "$CLAUDE_PROMPT_FILE"
 run_claude_review "$CLAUDE_PROMPT_FILE"
-rm -f "$CLAUDE_PROMPT_FILE"
+herdr_review_release_prompt
 
 VERDICT="$RAW"
 VERDICT="$(extract_json_verdict "$VERDICT")"

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -138,24 +138,37 @@ run_claude_review_inline() {
 
 run_claude_review_herdr() {
   local prompt_file="$1"
-  local raw_file exit_file pane_name started
+  local raw_file exit_file runner_file pane_name tab_json tab_id pane_id started
   raw_file="$(mktemp /tmp/lobu-review-claude-raw.XXXXXX)"
   exit_file="$(mktemp /tmp/lobu-review-claude-exit.XXXXXX)"
+  runner_file="$(mktemp /tmp/lobu-review-claude-runner.XXXXXX)"
   rm -f "$exit_file"
   pane_name="claude-review-${HEAD_SHA:0:8}-$$"
   REVIEW_HERDR_PANE_NAME="$pane_name"
   REVIEW_HERDR_RAW_FILE="$raw_file"
   REVIEW_HERDR_EXIT_FILE="$exit_file"
 
-  echo ">> spawning Herdr pane '$pane_name' for Claude review"
+  cat > "$runner_file" <<'RUNNER'
+set +e
+claude -p "$(cat "$PROMPT_FILE")" \
+  --model "$CLAUDE_REVIEW_MODEL" \
+  --effort "$CLAUDE_REVIEW_EFFORT" \
+  --output-format text \
+  --no-session-persistence \
+  --tools Bash,Read,Grep,LS \
+  --permission-mode bypassPermissions < /dev/null | tee "$RAW_FILE"
+claude_exit=${PIPESTATUS[0]}
+printf "%s\n" "$claude_exit" > "$EXIT_FILE"
+exit "$claude_exit"
+RUNNER
+
+  echo ">> spawning Herdr tab '$pane_name' for Claude review"
   set +e
-  # Variables in the single-quoted payload expand inside the spawned Bash.
-  # shellcheck disable=SC2016
-  started="$(
-    herdr agent start "$pane_name" \
+  tab_json="$(
+    herdr tab create \
       --workspace "$HERDR_WORKSPACE_ID" \
       --cwd "$PWD" \
-      --split down \
+      --label "$pane_name" \
       --no-focus \
       --env "PATH=$PATH" \
       --env "HOME=$HOME" \
@@ -173,25 +186,29 @@ run_claude_review_herdr() {
       --env "CLAUDE_REVIEW_EFFORT=$CLAUDE_REVIEW_EFFORT" \
       --env "PROMPT_FILE=$prompt_file" \
       --env "RAW_FILE=$raw_file" \
-      --env "EXIT_FILE=$exit_file" \
-      -- bash -lc '
-        set +e
-        claude -p "$(cat "$PROMPT_FILE")" \
-          --model "$CLAUDE_REVIEW_MODEL" \
-          --effort "$CLAUDE_REVIEW_EFFORT" \
-          --output-format text \
-          --no-session-persistence \
-          --tools Bash,Read,Grep,LS \
-          --permission-mode bypassPermissions < /dev/null | tee "$RAW_FILE"
-        claude_exit=${PIPESTATUS[0]}
-        printf "%s\n" "$claude_exit" > "$EXIT_FILE"
-        exit "$claude_exit"
-      ' 2>&1
+      --env "EXIT_FILE=$exit_file" 2>&1
   )"
   local start_exit=$?
+  if [ $start_exit -eq 0 ]; then
+    read -r tab_id pane_id <<<"$(printf '%s' "$tab_json" | python3 -c 'import json,sys
+d=json.load(sys.stdin).get("result", {})
+print((d.get("tab") or {}).get("tab_id", ""), (d.get("root_pane") or {}).get("pane_id", ""))' 2>/dev/null)"
+    if [ -z "$tab_id" ] || [ -z "$pane_id" ]; then
+      start_exit=1
+      started="Herdr tab create returned no tab/pane id: $tab_json"
+    else
+      herdr pane rename "$pane_id" "$pane_name" >/dev/null 2>&1 || true
+      started="$(herdr pane run "$pane_id" "bash $(printf '%q' "$runner_file")" 2>&1)"
+      start_exit=$?
+    fi
+  else
+    started="$tab_json"
+  fi
   set -e
   if [ $start_exit -ne 0 ]; then
-    echo ">> Herdr Claude pane failed to start; falling back to inline Claude" >&2
+    [ -n "${tab_id:-}" ] && herdr tab close "$tab_id" >/dev/null 2>&1 || true
+    rm -f "$runner_file"
+    echo ">> Herdr Claude tab failed to start; falling back to inline Claude" >&2
     printf '%s\n' "$started" >&2
     close_review_herdr_pane
     run_claude_review_inline "$prompt_file"
@@ -199,7 +216,7 @@ run_claude_review_herdr() {
   fi
   register_review_herdr_pane "$pane_name" "$started"
 
-  echo ">> Claude review is visible in Herdr pane '$pane_name'"
+  echo ">> Claude review is visible in Herdr tab '$pane_name'"
   local waited=0
   while [ ! -f "$exit_file" ]; do
     sleep 2
@@ -208,14 +225,14 @@ run_claude_review_herdr() {
       RAW="$(cat "$raw_file" 2>/dev/null || true)"
       CLAUDE_EXIT=124
       close_review_herdr_pane
-      echo ">> Claude review pane timed out after ${waited}s" >&2
+      echo ">> Claude review tab timed out after ${waited}s" >&2
       return
     fi
   done
 
   RAW="$(cat "$raw_file" 2>/dev/null || true)"
   CLAUDE_EXIT="$(cat "$exit_file" 2>/dev/null || echo 1)"
-  rm -f "$raw_file" "$exit_file"
+  rm -f "$raw_file" "$exit_file" "$runner_file"
   REVIEW_HERDR_PANE_ID=""
   REVIEW_HERDR_PANE_NAME=""
   REVIEW_HERDR_RAW_FILE=""

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -37,7 +37,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # --- preflight --------------------------------------------------------------
 
-for cmd in claude jq git node perl pgrep; do
+for cmd in claude jq git node perl python3; do
   command -v "$cmd" >/dev/null 2>&1 || { echo "$cmd not found on PATH." >&2; exit 2; }
 done
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "Not inside a git work tree." >&2; exit 2; }
@@ -140,14 +140,22 @@ run_claude_review_inline() {
 
 run_claude_review_herdr() {
   local prompt_file="$1"
-  local raw_file exit_file runner_file pane_name tab_json tab_id pane_id started
+  local raw_file exit_file runner_file pane_name before_tabs tab_json tab_id pane_id started
   raw_file="$(mktemp /tmp/lobu-review-claude-raw.XXXXXX)"
   exit_file="$(mktemp /tmp/lobu-review-claude-exit.XXXXXX)"
   runner_file="$(mktemp /tmp/lobu-review-claude-runner.XXXXXX)"
   rm -f "$exit_file"
   herdr_review_track_files "$raw_file" "$exit_file" "$runner_file"
   pane_name="claude-review-${HEAD_SHA:0:8}-$$"
-  herdr_review_track_locator "$HERDR_WORKSPACE_ID" "$pane_name"
+
+  if ! before_tabs="$(herdr_review_snapshot_tabs "$HERDR_WORKSPACE_ID")"; then
+    rm -f "$raw_file" "$exit_file" "$runner_file"
+    herdr_review_forget_files
+    echo ">> could not snapshot Herdr tabs; running Claude inline" >&2
+    run_claude_review_inline "$prompt_file"
+    return
+  fi
+  herdr_review_track_locator "$HERDR_WORKSPACE_ID" "$pane_name" "$PWD" "$before_tabs"
 
   cat > "$runner_file" <<'RUNNER'
 set +e
@@ -191,9 +199,7 @@ RUNNER
   )"
   local start_exit=$?
   if [ $start_exit -eq 0 ]; then
-    read -r tab_id pane_id <<<"$(printf '%s' "$tab_json" | python3 -c 'import json,sys
-d=json.load(sys.stdin).get("result", {})
-print((d.get("tab") or {}).get("tab_id", ""), (d.get("root_pane") or {}).get("pane_id", ""))' 2>/dev/null)"
+    read -r tab_id pane_id <<<"$(herdr_review_parse_created_tab "$tab_json" 2>/dev/null || true)"
     [ -n "$tab_id" ] && herdr_review_track_tab "$tab_id"
     if [ -z "$tab_id" ] || [ -z "$pane_id" ]; then
       start_exit=1
@@ -208,7 +214,10 @@ print((d.get("tab") or {}).get("tab_id", ""), (d.get("root_pane") or {}).get("pa
   fi
   set -e
   if [ $start_exit -ne 0 ]; then
-    herdr_review_cleanup
+    if ! herdr_review_cleanup; then
+      echo ">> Herdr tab creation state is ambiguous; refusing inline fallback" >&2
+      return 1
+    fi
     echo ">> Herdr Claude tab failed to start; falling back to inline Claude" >&2
     printf '%s\n' "$started" >&2
     run_claude_review_inline "$prompt_file"
@@ -223,7 +232,12 @@ print((d.get("tab") or {}).get("tab_id", ""), (d.get("root_pane") or {}).get("pa
     if [ "$waited" -ge "${CLAUDE_REVIEW_TIMEOUT_SECONDS:-1200}" ]; then
       # Stop the tab first so tee flushes its final partial output, then copy it
       # into RAW before deleting the transport files.
-      herdr_review_close_tab
+      if ! herdr_review_close_tab; then
+        RAW="$(cat "$raw_file" 2>/dev/null || true)"
+        CLAUDE_EXIT=124
+        echo ">> Claude review tab timed out and could not be closed" >&2
+        return 1
+      fi
       RAW="$(cat "$raw_file" 2>/dev/null || true)"
       CLAUDE_EXIT=124
       herdr_review_cleanup
@@ -333,10 +347,11 @@ review_exit_cleanup() {
   local ec=$?
   trap - EXIT INT TERM HUP
   stop_active_review_child
+  review_process_abort_inline
   # If the normal Herdr path completed, its tracked state is already empty.
   # Otherwise this closes the tab/process and keeps any non-empty partial raw
   # output for diagnosis before the script exits.
-  herdr_review_abort
+  herdr_review_abort || true
   release_review_lock
   if [ "$ec" -ne 0 ] && [ "${REVIEW_STATUS_FINALIZED:-0}" != "1" ]; then
     post_review_status error "Claude review failed before verdict (exit $ec)"
@@ -408,6 +423,18 @@ DETERMINISTIC_TEST_ENV=(
   OPENAI_AUTH_TOKEN=
 )
 
+run_deterministic() {
+  env \
+    ANTHROPIC_API_KEY= \
+    ANTHROPIC_AUTH_TOKEN= \
+    CLAUDE_CODE_OAUTH_TOKEN= \
+    OPENAI_API_KEY= \
+    OPENAI_AUTH_TOKEN= \
+    "$@"
+}
+export -f run_deterministic
+export SCRIPT_DIR
+
 echo ">> typecheck → $TYPECHECK_LOG"
 set +e
 run_review_child "${DETERMINISTIC_TEST_ENV[@]}" bun run typecheck > "$TYPECHECK_LOG" 2>&1
@@ -419,30 +446,30 @@ set +e
 run_review_unit_suites() {
   local ec
   UNIT_EXIT=0
-  "${DETERMINISTIC_TEST_ENV[@]}" bash "$SCRIPT_DIR/lib/__tests__/review-lock.test.sh";               ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
-  "${DETERMINISTIC_TEST_ENV[@]}" bash "$SCRIPT_DIR/lib/__tests__/review-database-url.test.sh";        ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
-  "${DETERMINISTIC_TEST_ENV[@]}" bash "$SCRIPT_DIR/lib/__tests__/review-process.test.sh";             ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic bash "$SCRIPT_DIR/lib/__tests__/review-lock.test.sh";               ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic bash "$SCRIPT_DIR/lib/__tests__/review-database-url.test.sh";        ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic bash "$SCRIPT_DIR/lib/__tests__/review-process.test.sh";             ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   # Shell lifecycle regressions: Herdr task/review tabs must be owned and
   # cleaned without invoking the real Herdr daemon.
-  "${DETERMINISTIC_TEST_ENV[@]}" bash "$SCRIPT_DIR/lib/__tests__/herdr-lifecycle.test.sh";            ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic bash "$SCRIPT_DIR/lib/__tests__/herdr-lifecycle.test.sh";            ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   # Guard: every packages/server *.test.ts must run in >=1 runner (vitest or a
   # bun job). Fails loudly if a file drifts into running nowhere — the
   # silent-skip class this change fixes.
-  "${DETERMINISTIC_TEST_ENV[@]}" node scripts/check-test-runner-coverage.mjs;                      ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic node scripts/check-test-runner-coverage.mjs;                      ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   # Guard: no raw JS array bound as a SQL param (the fetch_types:false trap —
   # a malformed array literal that Postgres rejects, historically silent).
-  "${DETERMINISTIC_TEST_ENV[@]}" node scripts/check-raw-array-params.mjs;                          ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic node scripts/check-raw-array-params.mjs;                          ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   # Guard: the per-user connection-visibility READ-SEAM gate must come from the
   # one compiler (authz/connection-visibility.ts), not be re-derived inline —
   # that is how the authz gate silently drifts and leaks private-connection data.
-  "${DETERMINISTIC_TEST_ENV[@]}" node scripts/check-connection-visibility-compiler.mjs;            ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
-  "${DETERMINISTIC_TEST_ENV[@]}" bun test packages/core packages/cli packages/connectors;          ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
-  "${DETERMINISTIC_TEST_ENV[@]}" bun test packages/agent-worker;                                   ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
-  "${DETERMINISTIC_TEST_ENV[@]}" bun test packages/server/src/__tests__/unit;                      ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
-  "${DETERMINISTIC_TEST_ENV[@]}" bun test packages/server/src/auth/__tests__/tool-access.test.ts;  ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic node scripts/check-connection-visibility-compiler.mjs;            ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic bun test packages/core packages/cli packages/connectors;          ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic bun test packages/agent-worker;                                   ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic bun test packages/server/src/__tests__/unit;                      ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic bun test packages/server/src/auth/__tests__/tool-access.test.ts;  ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   # NOTE: src/gateway/infrastructure/queue runs in the gateway integration loop
   # below (not here) — see #1238; running it in both jobs double-executes it.
-  "${DETERMINISTIC_TEST_ENV[@]}" bun test packages/connector-worker;                               ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic bun test packages/connector-worker;                               ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   return "$UNIT_EXIT"
 }
 run_review_child run_review_unit_suites > "$UNIT_LOG" 2>&1
@@ -454,7 +481,7 @@ set +e
 run_review_integration_suites() {
   local ec
   INTEGRATION_EXIT=0
-  (cd packages/server && "${DETERMINISTIC_TEST_ENV[@]}" node ../../node_modules/.bin/vitest run --reporter=default); ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
+  (cd packages/server && run_deterministic node ../../node_modules/.bin/vitest run --reporter=default); ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
   # Each gateway test file runs in its own bun process: bun has no per-file
   # isolation and the gateway suites aren't mutually hermetic, so co-running a
   # whole __tests__ dir in one process leaks DB/module state across files (see
@@ -468,11 +495,11 @@ run_review_integration_suites() {
     for d in $dirs; do
       files=$(find "$d" -maxdepth 1 -type f -name '*.test.ts' | sort)
       for f in $files; do
-        "${DETERMINISTIC_TEST_ENV[@]}" bun test "$f" || rc=1
+        run_deterministic bun test "$f" || rc=1
       done
     done
     exit $rc );                                                                        ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
-  (cd packages/server && "${DETERMINISTIC_TEST_ENV[@]}" bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__ src/auth/oauth/__tests__); ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
+  (cd packages/server && run_deterministic bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__ src/auth/oauth/__tests__); ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
   return "$INTEGRATION_EXIT"
 }
 run_review_child run_review_integration_suites > "$INTEGRATION_LOG" 2>&1

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -168,7 +168,9 @@ claude -p "$(cat "$PROMPT_FILE")" \
   --tools Bash,Read,Grep,LS \
   --permission-mode bypassPermissions < /dev/null | tee "$RAW_FILE"
 claude_exit=${PIPESTATUS[0]}
-printf "%s\n" "$claude_exit" > "$EXIT_FILE"
+exit_tmp="${EXIT_FILE}.tmp.$$"
+printf "%s\n" "$claude_exit" > "$exit_tmp"
+mv "$exit_tmp" "$EXIT_FILE"
 exit "$claude_exit"
 RUNNER
 
@@ -207,6 +209,10 @@ RUNNER
       started="Herdr tab create returned no tab/pane id: $tab_json"
     else
       herdr pane rename "$pane_id" "$pane_name" >/dev/null 2>&1 || true
+      # A transport failure can still mean the command reached Herdr. Mark the
+      # runner as possibly live before dispatch so EXIT cleanup retains the
+      # global lock until exact closure or its terminal marker is confirmed.
+      herdr_review_mark_runner_may_be_live
       started="$(herdr pane run "$pane_id" "bash $(printf '%q' "$runner_file")" 2>&1)"
       start_exit=$?
     fi
@@ -352,7 +358,7 @@ review_exit_cleanup() {
   # If the normal Herdr path completed, its tracked state is already empty.
   # Otherwise this closes the tab/process and keeps any non-empty partial raw
   # output for diagnosis before the script exits.
-  herdr_review_abort || true
+  herdr_review_abort_until_safe_to_release_lock
   if [ "$ec" -ne 0 ] && [ "$REVIEW_LOCK_HELD" = "1" ] && \
      [ "$REVIEW_STATUS_STARTED" = "1" ] && [ "$REVIEW_STATUS_FINALIZED" != "1" ]; then
     post_failure_status=1

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -28,10 +28,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/review-lock.sh
 . "$SCRIPT_DIR/lib/review-lock.sh"
+# shellcheck source=scripts/lib/review-database-url.sh
+. "$SCRIPT_DIR/lib/review-database-url.sh"
+# shellcheck source=scripts/lib/review-process.sh
+. "$SCRIPT_DIR/lib/review-process.sh"
 
 # --- preflight --------------------------------------------------------------
 
-for cmd in claude jq git; do
+for cmd in claude jq git node perl pgrep; do
   command -v "$cmd" >/dev/null 2>&1 || { echo "$cmd not found on PATH." >&2; exit 2; }
 done
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "Not inside a git work tree." >&2; exit 2; }
@@ -107,8 +111,11 @@ finalize_review_status() {
 
 run_claude_review_inline() {
   local prompt_file="$1"
+  local raw_file
+  raw_file="$(mktemp /tmp/lobu-review-claude-inline.XXXXXX)"
+  REVIEW_INLINE_RAW_FILE="$raw_file"
   set +e
-  RAW="$(
+  run_review_child env \
     BASE_BRANCH="$BASE_BRANCH" \
     HEAD_SHA="$HEAD_SHA" \
     TYPECHECK_LOG="$TYPECHECK_LOG" TYPECHECK_EXIT="$TYPECHECK_EXIT" \
@@ -121,10 +128,12 @@ run_claude_review_inline() {
       --output-format text \
       --no-session-persistence \
       --tools Bash,Read,Grep,LS \
-      --permission-mode bypassPermissions < /dev/null
-  )"
+      --permission-mode bypassPermissions < /dev/null > "$raw_file"
   CLAUDE_EXIT=$?
   set -e
+  RAW="$(cat "$raw_file" 2>/dev/null || true)"
+  rm -f "$raw_file"
+  REVIEW_INLINE_RAW_FILE=""
 }
 
 run_claude_review_herdr() {
@@ -134,9 +143,14 @@ run_claude_review_herdr() {
   exit_file="$(mktemp /tmp/lobu-review-claude-exit.XXXXXX)"
   rm -f "$exit_file"
   pane_name="claude-review-${HEAD_SHA:0:8}-$$"
+  REVIEW_HERDR_PANE_NAME="$pane_name"
+  REVIEW_HERDR_RAW_FILE="$raw_file"
+  REVIEW_HERDR_EXIT_FILE="$exit_file"
 
   echo ">> spawning Herdr pane '$pane_name' for Claude review"
   set +e
+  # Variables in the single-quoted payload expand inside the spawned Bash.
+  # shellcheck disable=SC2016
   started="$(
     herdr agent start "$pane_name" \
       --workspace "$HERDR_WORKSPACE_ID" \
@@ -179,9 +193,11 @@ run_claude_review_herdr() {
   if [ $start_exit -ne 0 ]; then
     echo ">> Herdr Claude pane failed to start; falling back to inline Claude" >&2
     printf '%s\n' "$started" >&2
+    close_review_herdr_pane
     run_claude_review_inline "$prompt_file"
     return
   fi
+  register_review_herdr_pane "$pane_name" "$started"
 
   echo ">> Claude review is visible in Herdr pane '$pane_name'"
   local waited=0
@@ -191,7 +207,7 @@ run_claude_review_herdr() {
     if [ "$waited" -ge "${CLAUDE_REVIEW_TIMEOUT_SECONDS:-1200}" ]; then
       RAW="$(cat "$raw_file" 2>/dev/null || true)"
       CLAUDE_EXIT=124
-      rm -f "$raw_file" "$exit_file"
+      close_review_herdr_pane
       echo ">> Claude review pane timed out after ${waited}s" >&2
       return
     fi
@@ -200,6 +216,10 @@ run_claude_review_herdr() {
   RAW="$(cat "$raw_file" 2>/dev/null || true)"
   CLAUDE_EXIT="$(cat "$exit_file" 2>/dev/null || echo 1)"
   rm -f "$raw_file" "$exit_file"
+  REVIEW_HERDR_PANE_ID=""
+  REVIEW_HERDR_PANE_NAME=""
+  REVIEW_HERDR_RAW_FILE=""
+  REVIEW_HERDR_EXIT_FILE=""
 }
 
 run_claude_review() {
@@ -294,7 +314,18 @@ process.exit(1);
   printf '%s\n' "$raw" | sed -e 's/^```json//' -e 's/^```//' -e 's/```$//'
 }
 
-trap 'ec=$?; release_review_lock; if [ $ec -ne 0 ] && [ "${REVIEW_STATUS_FINALIZED:-0}" != "1" ]; then post_review_status error "Claude review failed before verdict (exit $ec)"; fi' EXIT
+handle_review_signal() {
+  local exit_code="$1"
+  trap - INT TERM HUP
+  stop_active_review_child
+  close_review_herdr_pane
+  exit "$exit_code"
+}
+
+trap 'handle_review_signal 130' INT
+trap 'handle_review_signal 143' TERM
+trap 'handle_review_signal 129' HUP
+trap 'ec=$?; stop_active_review_child; close_review_herdr_pane; release_review_lock; if [ $ec -ne 0 ] && [ "${REVIEW_STATUS_FINALIZED:-0}" != "1" ]; then post_review_status error "Claude review failed before verdict (exit $ec)"; fi' EXIT
 
 acquire_review_lock
 
@@ -315,12 +346,7 @@ fi
 # runs can instead opt into distinct pre-created test databases through the
 # deliberately named REVIEW_DATABASE_URL; reject non-test names defensively.
 if [ -n "$REVIEW_DATABASE_URL" ]; then
-  REVIEW_DATABASE_NAME="${REVIEW_DATABASE_URL%%\?*}"
-  REVIEW_DATABASE_NAME="${REVIEW_DATABASE_NAME##*/}"
-  if [[ "$REVIEW_DATABASE_NAME" != lobu_test* ]]; then
-    echo "REVIEW_DATABASE_URL database must start with 'lobu_test'" >&2
-    exit 2
-  fi
+  validate_review_database_url "$REVIEW_DATABASE_URL"
   export DATABASE_URL="$REVIEW_DATABASE_URL"
 else
   unset DATABASE_URL
@@ -340,7 +366,7 @@ REVIEW_RUN_DIR="$(mktemp -d /tmp/lobu-review.XXXXXX)"
 BUILD_LOG="$REVIEW_RUN_DIR/build.log"
 echo ">> make build-packages → $BUILD_LOG"
 set +e
-make build-packages > "$BUILD_LOG" 2>&1
+run_review_child make build-packages > "$BUILD_LOG" 2>&1
 BUILD_EXIT=$?
 set -e
 if [ $BUILD_EXIT -ne 0 ]; then
@@ -363,15 +389,18 @@ DETERMINISTIC_TEST_ENV=(
 
 echo ">> typecheck → $TYPECHECK_LOG"
 set +e
-"${DETERMINISTIC_TEST_ENV[@]}" bun run typecheck > "$TYPECHECK_LOG" 2>&1
+run_review_child "${DETERMINISTIC_TEST_ENV[@]}" bun run typecheck > "$TYPECHECK_LOG" 2>&1
 TYPECHECK_EXIT=$?
 set -e
 
 echo ">> unit tests → $UNIT_LOG"
 set +e
-UNIT_EXIT=0
-{
+run_review_unit_suites() {
+  local ec
+  UNIT_EXIT=0
   "${DETERMINISTIC_TEST_ENV[@]}" bash "$SCRIPT_DIR/lib/__tests__/review-lock.test.sh";               ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  "${DETERMINISTIC_TEST_ENV[@]}" bash "$SCRIPT_DIR/lib/__tests__/review-database-url.test.sh";        ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  "${DETERMINISTIC_TEST_ENV[@]}" bash "$SCRIPT_DIR/lib/__tests__/review-process.test.sh";             ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   # Guard: every packages/server *.test.ts must run in >=1 runner (vitest or a
   # bun job). Fails loudly if a file drifts into running nowhere — the
   # silent-skip class this change fixes.
@@ -390,13 +419,17 @@ UNIT_EXIT=0
   # NOTE: src/gateway/infrastructure/queue runs in the gateway integration loop
   # below (not here) — see #1238; running it in both jobs double-executes it.
   "${DETERMINISTIC_TEST_ENV[@]}" bun test packages/connector-worker;                               ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
-} > "$UNIT_LOG" 2>&1
+  return "$UNIT_EXIT"
+}
+run_review_child run_review_unit_suites > "$UNIT_LOG" 2>&1
+UNIT_EXIT=$?
 set -e
 
 echo ">> integration tests → $INTEGRATION_LOG"
 set +e
-INTEGRATION_EXIT=0
-{
+run_review_integration_suites() {
+  local ec
+  INTEGRATION_EXIT=0
   (cd packages/server && "${DETERMINISTIC_TEST_ENV[@]}" node ../../node_modules/.bin/vitest run --reporter=default); ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
   # Each gateway test file runs in its own bun process: bun has no per-file
   # isolation and the gateway suites aren't mutually hermetic, so co-running a
@@ -416,7 +449,10 @@ INTEGRATION_EXIT=0
     done
     exit $rc );                                                                        ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
   (cd packages/server && "${DETERMINISTIC_TEST_ENV[@]}" bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__ src/auth/oauth/__tests__); ec=$?; [ $ec -gt $INTEGRATION_EXIT ] && INTEGRATION_EXIT=$ec
-} > "$INTEGRATION_LOG" 2>&1
+  return "$INTEGRATION_EXIT"
+}
+run_review_child run_review_integration_suites > "$INTEGRATION_LOG" 2>&1
+INTEGRATION_EXIT=$?
 set -e
 
 echo ">> suite exit codes: typecheck=$TYPECHECK_EXIT unit=$UNIT_EXIT integration=$INTEGRATION_EXIT"

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -3,7 +3,7 @@
 # with the diff against the base branch. Prints a JSON verdict on the last line.
 #
 # Usage:
-#   ./scripts/review.sh                 # base = main
+#   ./scripts/review.sh                 # base = origin/main when available
 #   ./scripts/review.sh --base develop  # override base
 #   BASE=develop ./scripts/review.sh    # env-var override
 #
@@ -25,6 +25,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/review-lock.sh
+. "$SCRIPT_DIR/lib/review-lock.sh"
+
 # --- preflight --------------------------------------------------------------
 
 for cmd in claude jq git; do
@@ -40,7 +44,16 @@ fi
 
 # --- args -------------------------------------------------------------------
 
-BASE_BRANCH="${BASE:-main}"
+if [ -n "${BASE:-}" ]; then
+  BASE_BRANCH="$BASE"
+elif git show-ref --verify --quiet refs/remotes/origin/main; then
+  # Task worktrees often outlive the primary checkout's local `main` ref. Use
+  # the fetched remote-tracking branch by default so a stale local main cannot
+  # silently widen or distort the diff sent to the reviewer.
+  BASE_BRANCH="origin/main"
+else
+  BASE_BRANCH="main"
+fi
 CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-opus}"
 CLAUDE_REVIEW_EFFORT="${CLAUDE_REVIEW_EFFORT:-high}"
 PI_REVIEW_STATUS_CONTEXT="${PI_REVIEW_STATUS_CONTEXT:-pi-review}"
@@ -48,6 +61,7 @@ PI_REVIEW_MIN_BUG_FREE="${PI_REVIEW_MIN_BUG_FREE:-80}"
 PI_REVIEW_MAX_SLOP="${PI_REVIEW_MAX_SLOP:-15}"
 PI_REVIEW_MIN_SIMPLICITY="${PI_REVIEW_MIN_SIMPLICITY:-70}"
 CLAUDE_REVIEW_HERDR="${CLAUDE_REVIEW_HERDR:-auto}"
+REVIEW_DATABASE_URL="${REVIEW_DATABASE_URL:-}"
 while [ $# -gt 0 ]; do
   case "$1" in
     --base) BASE_BRANCH="$2"; shift 2 ;;
@@ -280,7 +294,9 @@ process.exit(1);
   printf '%s\n' "$raw" | sed -e 's/^```json//' -e 's/^```//' -e 's/```$//'
 }
 
-trap 'ec=$?; if [ $ec -ne 0 ] && [ "${REVIEW_STATUS_FINALIZED:-0}" != "1" ]; then post_review_status error "Claude review failed before verdict (exit $ec)"; fi' EXIT
+trap 'ec=$?; release_review_lock; if [ $ec -ne 0 ] && [ "${REVIEW_STATUS_FINALIZED:-0}" != "1" ]; then post_review_status error "Claude review failed before verdict (exit $ec)"; fi' EXIT
+
+acquire_review_lock
 
 post_review_status pending "Claude review running"
 
@@ -294,12 +310,21 @@ if [ -f .env ]; then
 fi
 
 # Tests must NOT run against whatever DATABASE_URL .env points at (often a
-# shared/tailnet DB) — they run DDL like `DROP SCHEMA public`. Unset it so the
-# test harness spawns an isolated, ephemeral embedded Postgres per run (see
-# packages/server/src/__tests__/setup/embedded-postgres-backend.ts). This also
-# removes the old "ALTER SCHEMA public OWNER" hack: the embedded cluster's
-# bootstrap role already owns its schema.
-unset DATABASE_URL
+# shared/tailnet DB) — they run DDL like `DROP SCHEMA public`. By default the
+# test harness therefore spawns an isolated embedded Postgres. Parallel review
+# runs can instead opt into distinct pre-created test databases through the
+# deliberately named REVIEW_DATABASE_URL; reject non-test names defensively.
+if [ -n "$REVIEW_DATABASE_URL" ]; then
+  REVIEW_DATABASE_NAME="${REVIEW_DATABASE_URL%%\?*}"
+  REVIEW_DATABASE_NAME="${REVIEW_DATABASE_NAME##*/}"
+  if [[ "$REVIEW_DATABASE_NAME" != lobu_test* ]]; then
+    echo "REVIEW_DATABASE_URL database must start with 'lobu_test'" >&2
+    exit 2
+  fi
+  export DATABASE_URL="$REVIEW_DATABASE_URL"
+else
+  unset DATABASE_URL
+fi
 
 # The dev .env also sets PUBLIC_GATEWAY_URL=http://localhost:8787, which makes the
 # public-origin / public-pages-contract tests fail ("expected 'localhost' to be
@@ -311,7 +336,8 @@ unset PUBLIC_GATEWAY_URL
 # Tests need workspace packages built. Worktree's `dist/` may be stale or
 # missing — always rebuild before tests. Cheap if up-to-date.
 
-BUILD_LOG="/tmp/lobu-review-build.log"
+REVIEW_RUN_DIR="$(mktemp -d /tmp/lobu-review.XXXXXX)"
+BUILD_LOG="$REVIEW_RUN_DIR/build.log"
 echo ">> make build-packages → $BUILD_LOG"
 set +e
 make build-packages > "$BUILD_LOG" 2>&1
@@ -323,9 +349,9 @@ fi
 
 # --- test suites ------------------------------------------------------------
 
-TYPECHECK_LOG="/tmp/lobu-review-typecheck.log"
-UNIT_LOG="/tmp/lobu-review-unit.log"
-INTEGRATION_LOG="/tmp/lobu-review-integration.log"
+TYPECHECK_LOG="$REVIEW_RUN_DIR/typecheck.log"
+UNIT_LOG="$REVIEW_RUN_DIR/unit.log"
+INTEGRATION_LOG="$REVIEW_RUN_DIR/integration.log"
 DETERMINISTIC_TEST_ENV=(
   env
   ANTHROPIC_API_KEY=
@@ -345,6 +371,7 @@ echo ">> unit tests → $UNIT_LOG"
 set +e
 UNIT_EXIT=0
 {
+  "${DETERMINISTIC_TEST_ENV[@]}" bash "$SCRIPT_DIR/lib/__tests__/review-lock.test.sh";               ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   # Guard: every packages/server *.test.ts must run in >=1 runner (vitest or a
   # bun job). Fails loudly if a file drifts into running nowhere — the
   # silent-skip class this change fixes.
@@ -365,9 +392,6 @@ UNIT_EXIT=0
   "${DETERMINISTIC_TEST_ENV[@]}" bun test packages/connector-worker;                               ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
 } > "$UNIT_LOG" 2>&1
 set -e
-
-echo ">> make clean-test-pg before integration"
-make clean-test-pg
 
 echo ">> integration tests → $INTEGRATION_LOG"
 set +e

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -117,7 +117,11 @@ fi
 # still be run safely from inside the task itself.
 # shellcheck source=scripts/lib/herdr-task.sh
 . "$script_dir/lib/herdr-task.sh"
-if herdr_task_close "$worktree_dir" "$name"; then
+if herdr_task_enabled; then
+  if ! herdr_task_close "$worktree_dir" "$name"; then
+    echo "error: failed to close the exact Herdr task owner; worktree and retry metadata were preserved" >&2
+    exit 1
+  fi
   echo "→ closed Herdr task tab/workspace for $worktree_dir"
 fi
 

--- a/scripts/task-clean.sh
+++ b/scripts/task-clean.sh
@@ -112,18 +112,21 @@ if [[ $force -eq 0 ]]; then
   fi
 fi
 
+# Close the Herdr owner while Git's per-worktree metadata still exists. The
+# helper refuses to close the caller's current tab/workspace, so task-clean can
+# still be run safely from inside the task itself.
+# shellcheck source=scripts/lib/herdr-task.sh
+. "$script_dir/lib/herdr-task.sh"
+if herdr_task_close "$worktree_dir" "$name"; then
+  echo "→ closed Herdr task tab/workspace for $worktree_dir"
+fi
+
 echo "→ removing worktree $worktree_dir"
 if git -C "$repo" worktree list --porcelain 2>/dev/null | grep -qF "worktree $worktree_dir"; then
   git -C "$repo" worktree remove "$worktree_dir" --force
 else
   echo "→ worktree path already gone from git (e.g. closed via Herdr)"
   rm -rf "$worktree_dir" 2>/dev/null || true
-fi
-
-# shellcheck source=scripts/lib/herdr-task.sh
-. "$script_dir/lib/herdr-task.sh"
-if herdr_task_close "$worktree_dir" "$name"; then
-  echo "→ closed Herdr workspace for $worktree_dir"
 fi
 
 # Returns 0 if branch <b> in <gitdir> carries no local-only commits (its tip is

--- a/scripts/task-setup.sh
+++ b/scripts/task-setup.sh
@@ -225,7 +225,7 @@ fi
 . "$script_dir/lib/herdr-task.sh"
 herdr_ws=""
 if herdr_ws="$(herdr_task_open "$repo" "$worktree_dir" "$name")"; then
-  echo "→ opened Herdr workspace '$herdr_ws' (label: $name)"
+  echo "→ opened Herdr task tab/workspace '$herdr_ws' (label: $name)"
 else
   if herdr_task_enabled; then
     echo "warning: Herdr is installed but worktree open failed (run manually: herdr worktree open --cwd $repo --path $worktree_dir --label $name)" >&2


### PR DESCRIPTION
## Summary
- serialize host-wide review runs without cross-run PostgreSQL cleanup
- own and clean child process groups and exact Herdr tabs
- open task and Claude review commands in tabs instead of split panes
- fail closed on ambiguous tab ownership and interrupted cleanup

## Validation
- exact `make review`: build/typecheck/unit/integration green
- Claude Opus review: 0 blockers, bug-free confidence 84
- review lock/process/database URL/Herdr lifecycle regressions green
- live Herdr run created and cleaned one temporary review tab with no splits

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786232505&installation_id=136316292&pr_number=1832&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1832&signature=b8847f5f9842c66bc7e5e47100aa37443b011e947222edf81be051a34c510d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer Herdr task tab/workspace tracking, reuse, recovery, and cleanup.
  * Added review process supervision to terminate interrupted commands and child processes reliably.
  * Added host-wide locking to prevent concurrent full reviews.
  * Added validation for review database connection URLs.
  * Improved review setup, temporary output handling, deterministic test execution, and fallback behavior.

* **Bug Fixes**
  * Improved cleanup after interrupted or failed reviews while preserving retryable state and diagnostic output.
  * Improved base-branch selection when local references are stale.

* **Documentation**
  * Clarified task setup messages to refer to Herdr tabs/workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->