### PR TITLE
fix: current catalog models + GPT-5.6 shortlist

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -300,7 +300,7 @@
           },
           "models": [
             "anthropic/claude-sonnet-5",
-            "openai/gpt-5.5",
+            "openai/gpt-5.6-sol",
             "google/gemini-2.5-pro"
           ]
         }
@@ -431,9 +431,9 @@
           "apiKeyPlaceholder": "sk-...",
           "sdkCompat": "openai",
           "modalities": ["text", "image", "tts"],
-          "defaultModel": "gpt-5.5",
+          "defaultModel": "gpt-5.6-sol",
           "modelsEndpoint": "/models",
-          "models": ["gpt-5.5", "gpt-5.5-mini", "gpt-5-nano"]
+          "models": ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5"]
         }
       ]
     }

--- a/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
@@ -139,7 +139,9 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 			expect(
 				b?.installed_providers?.some((p) => p.providerId === "openai"),
 			).toBe(true);
-			expect(b?.model).toBe("claude/claude-sonnet-4-6");
+			// Claude's pin comes from the provider catalog, so adding a current
+			// default there must not leave provisioning on a stale code constant.
+			expect(b?.model).toBe("claude/claude-sonnet-5");
 		} finally {
 			if (prev === undefined) delete process.env.ANTHROPIC_API_KEY;
 			else process.env.ANTHROPIC_API_KEY = prev;
@@ -192,10 +194,10 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		);
 	});
 
-	it("provisions a usable builder when ONLY an Anthropic system key is present (not in providers.json)", async () => {
-		// Anthropic/Claude is the canonical platform key but isn't in
-		// providers.json, so this exercises the env-var fallback with an empty
-		// registry — the case that would otherwise yield 0 providers / no model.
+	it("provisions a usable builder when ONLY an Anthropic system key is present", async () => {
+		// ANTHROPIC_AUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN are alternate credentials
+		// for the config-driven Claude provider. They must still use that provider's
+		// current catalog default rather than a second hardcoded model source.
 		// Hermetic: clear EVERY providers.json env var (read from the file so the
 		// list can't drift) plus the Claude env vars, then set only Anthropic.
 		const raw = JSON.parse(await readFile(PROVIDERS_JSON, "utf-8")) as {
@@ -227,7 +229,7 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 			expect(
 				b?.installed_providers?.some((p) => p.providerId === "claude"),
 			).toBe(true);
-			expect(b?.model).toBe("claude/claude-sonnet-4-6");
+			expect(b?.model).toBe("claude/claude-sonnet-5");
 		} finally {
 			for (const [k, v] of Object.entries(saved)) {
 				if (v === undefined) delete process.env[k];

--- a/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
@@ -115,8 +115,8 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 			true,
 		);
 		// Deterministic default from providers.json (`openai` → its curated
-		// defaultModel, currently `gpt-5.5`).
-		expect(b?.model).toBe("openai/gpt-5.5");
+		// defaultModel, currently `gpt-5.6-sol`).
+		expect(b?.model).toBe("openai/gpt-5.6-sol");
 		expect(await readPointer(org.id)).toBe(BUILDER_AGENT_ID);
 	});
 
@@ -169,7 +169,7 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		expect(res.created).toBe(false);
 		const b = await readBuilder(org.id);
 		expect(b?.installed_providers?.length ?? 0).toBeGreaterThan(0);
-		expect(b?.model).toBe("openai/gpt-5.5");
+		expect(b?.model).toBe("openai/gpt-5.6-sol");
 	});
 
 	it("keeps providers + pinned model consistent when repairing a model-only gap", async () => {

--- a/packages/server/src/auth/system-provider-resolution.ts
+++ b/packages/server/src/auth/system-provider-resolution.ts
@@ -39,7 +39,6 @@ const MODEL_PROVIDER_PREFERENCE = [
 
 const ZAI_PROVIDER_ID = "z-ai";
 const ZAI_SYSTEM_ENV_VARS = ["Z_AI_API_KEY", "ZAI_API_KEY"];
-export const ZAI_FALLBACK_MODEL = "z-ai/glm-5.2";
 
 const CLAUDE_PROVIDER_ID = "claude";
 const CLAUDE_SYSTEM_ENV_VARS = [
@@ -47,7 +46,6 @@ const CLAUDE_SYSTEM_ENV_VARS = [
 	"ANTHROPIC_AUTH_TOKEN",
 	"CLAUDE_CODE_OAUTH_TOKEN",
 ];
-export const CLAUDE_FALLBACK_MODEL = "claude/claude-sonnet-4-6";
 
 function hasZaiSystemKey(): boolean {
 	return ZAI_SYSTEM_ENV_VARS.some((v) => !!resolveEnv(v));
@@ -107,19 +105,19 @@ export async function resolveSystemKeyProvidersAndModel(): Promise<ResolvedSyste
 	const pickModel = (providerId: string): string | null => {
 		const cfg = configs[providerId];
 		const dm = cfg?.defaultModel?.trim();
-		if (cfg?.envVarName && resolveEnv(cfg.envVarName) && dm) {
+		if (installed.has(providerId) && dm) {
 			return `${providerId}/${dm}`;
 		}
 		return null;
 	};
 
-	// Prefer Claude (always a real API key) over ZAI and config-declared providers.
-	// ZAI is still installed when its key is present; it is only pinned when Claude
-	// is absent and no providers.json default resolves.
+	// Prefer Claude over ZAI and the remaining config-declared providers, but use
+	// the catalog's defaultModel for every provider. Keeping a second model ID in
+	// code made auto-provisioned agents lag the picker after catalog updates.
 	let model: string | null = hasClaudeSystemKey()
-		? CLAUDE_FALLBACK_MODEL
+		? pickModel(CLAUDE_PROVIDER_ID)
 		: hasZaiSystemKey()
-			? ZAI_FALLBACK_MODEL
+			? pickModel(ZAI_PROVIDER_ID)
 			: null;
 	for (const providerId of MODEL_PROVIDER_PREFERENCE) {
 		if (model) break;

--- a/packages/server/src/gateway/auth/__tests__/build-provider-catalog.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/build-provider-catalog.test.ts
@@ -88,6 +88,19 @@ describe("buildProviderCatalog", () => {
     expect(groq?.defaultModel).toBe("llama-3.3-70b-versatile");
   });
 
+  test("marks providers backed by a system credential as available", () => {
+    moduleRegistry.register(
+      fakeModule({
+        providerId: "claude",
+        providerDisplayName: "Claude",
+        hasSystemKey: () => true,
+      })
+    );
+
+    const claude = buildProviderCatalog().find((e) => e.slug === "claude");
+    expect(claude?.systemAvailable).toBe(true);
+  });
+
   test("supportedAuthTypes defaults to [authType] when absent", () => {
     moduleRegistry.register(fakeModule({ providerId: "cerebras" }));
     const catalog = buildProviderCatalog();

--- a/packages/server/src/gateway/auth/provider-catalog.ts
+++ b/packages/server/src/gateway/auth/provider-catalog.ts
@@ -45,6 +45,8 @@ export interface ProviderCatalogEntry {
   baseUrl: string;
   defaultModel: string | null;
   modelsEndpoint: string | null;
+  /** True when this deployment has a process-level credential for the provider. */
+  systemAvailable: boolean;
   /**
    * Static fallback model IDs (from providers.json), used by the model picker
    * when a provider has no live `modelsEndpoint` or the live fetch is empty.
@@ -112,6 +114,7 @@ export function buildProviderCatalog(
         baseUrl,
         defaultModel,
         modelsEndpoint: config?.modelsEndpoint ?? null,
+        systemAvailable: module.hasSystemKey?.() ?? false,
         models: config?.models ?? module.catalogModels ?? [],
         apiKeyPlaceholder:
           config?.apiKeyPlaceholder ?? module.apiKeyPlaceholder ?? "",


### PR DESCRIPTION
## Summary
- Stop hardcoding Claude/ZAI fallback model IDs; builder provisioning pins each provider’s `providers.json` `defaultModel` (Claude → `claude/claude-sonnet-5`).
- Expose `systemAvailable` on `GET …/inference-providers/catalog` so the UI can surface deployment-level credentials.
- Owletto model picker (submodule [owletto#474](https://github.com/lobu-ai/owletto/pull/474)): autocomplete includes curated models for system providers without an org row; freeform refs remain.
- Update OpenAI curated shortlist to GPT-5.6 Sol/Terra/Luna (`gpt-5.6-sol` default), keep `gpt-5.5` as fallback while OpenAI finishes account rollout; OpenRouter shortlist uses `openai/gpt-5.6-sol`.

## Why not live `/models` for autocomplete
Provider list endpoints (e.g. OpenAI) return a noisy identity-only dump. Autocomplete stays curated in `config/providers.json`; freeform covers brand-new IDs before curation.

## Test plan
- [x] `bun test packages/server/src/gateway/auth/__tests__/build-provider-catalog.test.ts`
- [x] Owletto `model-selector` vitest
- [x] Provider registry contract against updated `providers.json`
- [ ] CI full suite / Postgres builder-provisioning e2e (`openai/gpt-5.6-sol`, `claude/claude-sonnet-5`)
- [ ] After deploy: catalog returns `systemAvailable` + 5.6 models; freeform still works
- [ ] Note: some OpenAI keys may still `model_not_found` on 5.6 until provider rollout completes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786232825&installation_id=136316292&pr_number=1833&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1833&signature=5edbb9493615f60045768a1a0c99803bc93199d26e379818521c8b1e275590b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added updated GPT-5.6 model options, including Sol, Terra, and Luna variants.
  - Provider availability now reflects configured system credentials.
- **Improvements**
  - Default model selection now follows each provider’s current catalog configuration.
  - Claude and ZAI provisioning uses the appropriate catalog-defined default models.
- **Bug Fixes**
  - Updated automatic builder provisioning to use the latest OpenAI and Claude model defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->