### PR TITLE
feat(write-gate): action/effect model — child table + manifest

### DIFF
--- a/db/migrations/20260710120000_write_policy_action_effects.sql
+++ b/db/migrations/20260710120000_write_policy_action_effects.sql
@@ -1,0 +1,138 @@
+-- migrate:up
+
+-- v1.1 write-gate model: replace the three positional mode columns
+-- (create_mode/update_mode/delete_mode) on write_approval_policies with an
+-- (action, effect) child table. The parent row is now a pure scope+principal+
+-- delivery HEADER; each governed action gets its own child row. This ends the
+-- connector_action cram (its single `execute` verb was forced onto create_mode)
+-- and lets a new resource class declare its own action vocabulary in code
+-- (write-action-manifest.ts) without a positional-column change.
+--
+-- DEPLOY NOTE: this is a one-shot cut-over, not expand/contract. dbmate runs in
+-- the Helm pre-upgrade Job BEFORE the new pods roll, and the two old replicas
+-- keep querying create_mode/update_mode/delete_mode until they're replaced — so
+-- write-gate resolution 500s for the ~30-90s rollout overlap, then recovers once
+-- the new pods (which read the child table) are live. This blip is accepted, the
+-- same tradeoff taken by the #1827 bare-rename migration; downtime here is
+-- acceptable and buys a clean end state with no lingering legacy columns.
+
+-- ── Preflight ────────────────────────────────────────────────────────────────
+-- The target_scope_kind/target_scope_value/predicate columns were added in the
+-- M1a expand migration but never read by any code. We drop them below; assert
+-- first that nobody populated them via manual SQL, so a real (if unwired) value
+-- can't be silently discarded.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.write_approval_policies
+    WHERE target_scope_kind IS NOT NULL
+       OR target_scope_value IS NOT NULL
+       OR predicate IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'write_approval_policies has non-NULL target_scope_kind/target_scope_value/predicate; refusing to drop populated columns';
+  END IF;
+END $$;
+
+-- ── Child table ──────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.write_policy_action_effects (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  policy_id bigint NOT NULL
+    REFERENCES public.write_approval_policies(id) ON DELETE CASCADE,
+  -- Action/effect domains mirror write-action-manifest.ts. Per-class action
+  -- legality (e.g. connector_action only governs `execute`) is enforced by the
+  -- backfill below + the app-side manifest validators + the resolver's
+  -- fail-closed on undeclared tuples; a table CHECK can't cheaply join the
+  -- parent's resource_class, and the connector-only `disabled` rule already
+  -- lives as a parent CHECK (write_approval_policies_disabled_only_connector).
+  action text NOT NULL CHECK (action IN ('create', 'update', 'delete', 'execute')),
+  effect text NOT NULL CHECK (effect IN ('auto', 'approval', 'deny', 'disabled'))
+);
+
+-- One effect per (policy, action). The resolver reads the requested action's
+-- effect; a scope declaring no row for an action inherits the class default.
+-- squawk-ignore require-concurrent-index-creation -- table created just above; no traffic to block
+CREATE UNIQUE INDEX IF NOT EXISTS write_policy_action_effects_policy_action_key
+  ON public.write_policy_action_effects (policy_id, action);
+
+-- ── Class-aware backfill ─────────────────────────────────────────────────────
+-- entity + agent_config: three rows (create/update/delete from their columns).
+-- Skip an effect that is illegal for the class per the manifest — none exist in
+-- practice (entity/agent_config only ever held auto/approval/deny), but the
+-- filter keeps the backfill honest if a manual row snuck in a bad value.
+INSERT INTO public.write_policy_action_effects (policy_id, action, effect)
+SELECT p.id, v.action, v.effect
+FROM public.write_approval_policies p
+CROSS JOIN LATERAL (
+  VALUES
+    ('create', p.create_mode),
+    ('update', p.update_mode),
+    ('delete', p.delete_mode)
+) AS v(action, effect)
+WHERE p.resource_class IN ('entity', 'agent_config')
+  AND v.effect IN ('auto', 'approval', 'deny');
+
+-- connector_action: EXACTLY ONE `execute` row, sourced from create_mode (the
+-- column the old resolver crammed the execute decision into). Exploding these
+-- into create/update/delete would leave connector_action with no `execute`
+-- policy, silently dropping existing approve/deny rows to the execute=auto
+-- default — a security regression. So map create_mode → execute, one row.
+INSERT INTO public.write_policy_action_effects (policy_id, action, effect)
+SELECT p.id, 'execute', p.create_mode
+FROM public.write_approval_policies p
+WHERE p.resource_class = 'connector_action'
+  AND p.create_mode IN ('auto', 'approval', 'deny', 'disabled');
+
+-- ── Drop the legacy columns ──────────────────────────────────────────────────
+-- The mode columns are replaced by the child table; the target_scope_*/predicate
+-- columns were dead (asserted NULL above). All readers move to the new model in
+-- the same deploy.
+ALTER TABLE public.write_approval_policies
+  DROP COLUMN IF EXISTS create_mode,
+  DROP COLUMN IF EXISTS update_mode,
+  DROP COLUMN IF EXISTS delete_mode,
+  DROP COLUMN IF EXISTS target_scope_kind,
+  DROP COLUMN IF EXISTS target_scope_value,
+  DROP COLUMN IF EXISTS predicate;
+
+-- migrate:down
+
+-- Restore the mode columns (nullable first so the fold-back can populate them),
+-- then reconstruct create/update/delete_mode from the child rows and drop the
+-- child table. Reversible for the four actions this build knows; a child row
+-- with an action the down-path doesn't map (none today) would be dropped.
+ALTER TABLE public.write_approval_policies
+  ADD COLUMN IF NOT EXISTS create_mode text,
+  ADD COLUMN IF NOT EXISTS update_mode text,
+  ADD COLUMN IF NOT EXISTS delete_mode text,
+  ADD COLUMN IF NOT EXISTS target_scope_kind text,
+  ADD COLUMN IF NOT EXISTS target_scope_value text,
+  ADD COLUMN IF NOT EXISTS predicate jsonb;
+
+-- entity/agent_config: fold each action back to its column.
+-- squawk-ignore prefer-robust-stmts -- rollback path; single-shot fold-back, not a re-runnable forward migration
+UPDATE public.write_approval_policies p SET
+  create_mode = COALESCE((SELECT e.effect FROM public.write_policy_action_effects e WHERE e.policy_id = p.id AND e.action = 'create'), 'auto'),
+  update_mode = COALESCE((SELECT e.effect FROM public.write_policy_action_effects e WHERE e.policy_id = p.id AND e.action = 'update'), 'auto'),
+  delete_mode = COALESCE((SELECT e.effect FROM public.write_policy_action_effects e WHERE e.policy_id = p.id AND e.action = 'delete'), 'approval')
+WHERE p.resource_class IN ('entity', 'agent_config');
+
+-- connector_action: fold the execute row back into create_mode (the old cram),
+-- leave update/delete at the historical defaults.
+-- squawk-ignore prefer-robust-stmts -- rollback path; single-shot fold-back
+UPDATE public.write_approval_policies p SET
+  create_mode = COALESCE((SELECT e.effect FROM public.write_policy_action_effects e WHERE e.policy_id = p.id AND e.action = 'execute'), 'auto'),
+  update_mode = 'auto',
+  delete_mode = 'approval'
+WHERE p.resource_class = 'connector_action';
+
+-- rollback path; restore the historical defaults. Kept on one line so the
+-- ignore directive below anchors to this statement.
+-- squawk-ignore prefer-robust-stmts
+ALTER TABLE public.write_approval_policies ALTER COLUMN create_mode SET DEFAULT 'auto', ALTER COLUMN update_mode SET DEFAULT 'auto', ALTER COLUMN delete_mode SET DEFAULT 'approval';
+-- rollback path; the UPDATEs above populate every row before SET NOT NULL, so no
+-- row is ever null when the constraint applies.
+-- squawk-ignore prefer-robust-stmts,adding-not-nullable-field
+ALTER TABLE public.write_approval_policies ALTER COLUMN create_mode SET NOT NULL, ALTER COLUMN update_mode SET NOT NULL, ALTER COLUMN delete_mode SET NOT NULL;
+
+-- squawk-ignore ban-drop-table -- down for the child table this migration introduces
+DROP TABLE IF EXISTS public.write_policy_action_effects;

--- a/packages/server/src/__tests__/integration/authz/write-policy-action-effect-parity.test.ts
+++ b/packages/server/src/__tests__/integration/authz/write-policy-action-effect-parity.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Decision-parity for the v1.1 action/effect model (PR1).
+ *
+ * The migration replaced create_mode/update_mode/delete_mode columns with a
+ * write_policy_action_effects child table. This test proves, against a real
+ * migrated database, that the resolver reaches the SAME decision the old
+ * mode-column model would have — for entity, agent_config, and connector_action,
+ * including the global-delivery-inheritance case and the connector_action
+ * execute-from-create_mode mapping. It also exercises the fail-closed path on a
+ * stored effect this build declares illegal.
+ */
+
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import {
+	evaluateEntityMutation,
+	resolveEntityApprovalPolicy,
+	resolveWritePolicyDecision,
+} from "../../../authz/entity-policy";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import { createTestOrganization } from "../../setup/test-fixtures";
+
+/**
+ * Insert a policy header + its child action-effect rows directly, the way the
+ * migration backfill produces them. `effects` is the complete action set for the
+ * scope (entity/agent_config: create/update/delete; connector_action: execute).
+ */
+async function seedPolicy(args: {
+	orgId: string;
+	resourceClass: string;
+	principalKind?: string | null;
+	principalId?: string | null;
+	entityTypeSlug?: string | null;
+	fieldPath?: string | null;
+	effects: Array<{ action: string; effect: string }>;
+	delivery?: { connectionId?: string; channelId?: string };
+}): Promise<number> {
+	const sql = getTestDb();
+	const rows = await sql<{ id: number }>`
+    INSERT INTO write_approval_policies
+      (organization_id, resource_class, principal_kind, principal_id,
+       entity_type_slug, field_path, entity_id,
+       approval_connection_id, approval_channel_id)
+    VALUES
+      (${args.orgId}, ${args.resourceClass}, ${args.principalKind ?? null},
+       ${args.principalId ?? null}, ${args.entityTypeSlug ?? null},
+       ${args.fieldPath ?? null}, NULL,
+       ${args.delivery?.connectionId ?? null}, ${args.delivery?.channelId ?? null})
+    RETURNING id
+  `;
+	const id = Number(rows[0].id);
+	for (const { action, effect } of args.effects) {
+		await sql`
+      INSERT INTO write_policy_action_effects (policy_id, action, effect)
+      VALUES (${id}, ${action}, ${effect})
+    `;
+	}
+	return id;
+}
+
+describe("write-policy action/effect decision parity", () => {
+	afterAll(async () => {
+		await cleanupTestDatabase();
+	});
+
+	let orgId: string;
+	beforeEach(async () => {
+		const org = await createTestOrganization();
+		orgId = org.id;
+	});
+
+	it("entity: create auto / update auto / delete approval resolve unchanged", async () => {
+		await seedPolicy({
+			orgId,
+			resourceClass: "entity",
+			entityTypeSlug: "task",
+			effects: [
+				{ action: "create", effect: "auto" },
+				{ action: "update", effect: "approval" },
+				{ action: "delete", effect: "deny" },
+			],
+		});
+		const base = {
+			organizationId: orgId,
+			principalKind: "agent" as const,
+			entityTypeSlug: "task",
+		};
+		expect(await evaluateEntityMutation({ ...base, action: "create" })).toBe("allow");
+		expect(await evaluateEntityMutation({ ...base, action: "update" })).toBe(
+			"require_approval",
+		);
+		expect(await evaluateEntityMutation({ ...base, action: "delete" })).toBe("deny");
+	});
+
+	it("entity: scoped row with no delivery inherits the global row's target", async () => {
+		await seedPolicy({
+			orgId,
+			resourceClass: "entity",
+			effects: [
+				{ action: "create", effect: "auto" },
+				{ action: "update", effect: "auto" },
+				{ action: "delete", effect: "approval" },
+			],
+			delivery: { connectionId: "conn_g", channelId: "chan_ops" },
+		});
+		await seedPolicy({
+			orgId,
+			resourceClass: "entity",
+			entityTypeSlug: "topic",
+			effects: [
+				{ action: "create", effect: "approval" },
+				{ action: "update", effect: "approval" },
+				{ action: "delete", effect: "approval" },
+			],
+		});
+		const policy = await resolveEntityApprovalPolicy({
+			organizationId: orgId,
+			principalKind: "agent",
+			entityTypeSlug: "topic",
+		});
+		// scoped row's decision, global row's delivery target.
+		expect(policy.createMode).toBe("approval");
+		expect(policy.deliveryTarget.connectionId).toBe("conn_g");
+		expect(policy.deliveryTarget.channelId).toBe("chan_ops");
+	});
+
+	it("agent_config: per-principal watcher policy resolves each action", async () => {
+		await seedPolicy({
+			orgId,
+			resourceClass: "agent_config",
+			principalKind: "watcher",
+			principalId: "watcher:1",
+			effects: [
+				{ action: "create", effect: "approval" },
+				{ action: "update", effect: "approval" },
+				{ action: "delete", effect: "deny" },
+			],
+		});
+		const base = {
+			organizationId: orgId,
+			resourceClass: "agent_config" as const,
+			principalKind: "watcher" as const,
+			principalId: "watcher:1",
+		};
+		expect(await resolveWritePolicyDecision({ ...base, action: "create" })).toBe(
+			"require_approval",
+		);
+		expect(await resolveWritePolicyDecision({ ...base, action: "delete" })).toBe("deny");
+	});
+
+	it("agent_config: no row uses the class defaults (create/update approval, delete deny)", async () => {
+		const base = {
+			organizationId: orgId,
+			resourceClass: "agent_config" as const,
+			principalKind: "agent" as const,
+		};
+		expect(await resolveWritePolicyDecision({ ...base, action: "create" })).toBe(
+			"require_approval",
+		);
+		expect(await resolveWritePolicyDecision({ ...base, action: "delete" })).toBe("deny");
+	});
+
+	it("connector_action: execute effect (backfilled from create_mode) governs the decision", async () => {
+		// all-watchers: execute → approval
+		await seedPolicy({
+			orgId,
+			resourceClass: "connector_action",
+			principalKind: "watcher",
+			effects: [{ action: "execute", effect: "approval" }],
+		});
+		// specific agent: execute → deny
+		await seedPolicy({
+			orgId,
+			resourceClass: "connector_action",
+			principalKind: "agent",
+			principalId: "agent_xyz",
+			effects: [{ action: "execute", effect: "deny" }],
+		});
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: orgId,
+				resourceClass: "connector_action",
+				principalKind: "watcher",
+				principalId: "watcher:9",
+				action: "execute",
+			}),
+		).toBe("require_approval");
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: orgId,
+				resourceClass: "connector_action",
+				principalKind: "agent",
+				principalId: "agent_xyz",
+				action: "execute",
+			}),
+		).toBe("deny");
+	});
+
+	it("connector_action: no row → auto (connection mode alone governs)", async () => {
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: orgId,
+				resourceClass: "connector_action",
+				principalKind: "agent",
+				action: "execute",
+			}),
+		).toBe("allow");
+	});
+
+	it("fail-closed: a stored effect illegal for the class resolves to deny, not the default", async () => {
+		// 'disabled' is legal only for connector_action; an entity row carrying it
+		// is corrupt/forward data and must fail closed, not read as the create=auto default.
+		await seedPolicy({
+			orgId,
+			resourceClass: "entity",
+			entityTypeSlug: "task",
+			effects: [
+				{ action: "create", effect: "disabled" },
+				{ action: "update", effect: "auto" },
+				{ action: "delete", effect: "approval" },
+			],
+		});
+		expect(
+			await evaluateEntityMutation({
+				organizationId: orgId,
+				principalKind: "agent",
+				action: "create",
+				entityTypeSlug: "task",
+			}),
+		).toBe("deny");
+	});
+});

--- a/packages/server/src/__tests__/unit/entity-policy.test.ts
+++ b/packages/server/src/__tests__/unit/entity-policy.test.ts
@@ -19,16 +19,38 @@ type PolicyRowSeed = {
 	create_mode?: string;
 	update_mode?: string;
 	delete_mode?: string;
+	/** Explicit action→effect child rows; if omitted they're derived from the
+	 * create/update/delete modes (entity/agent_config) or from create_mode as the
+	 * single `execute` effect (connector_action) — mirroring the migration backfill. */
+	effects?: Array<{ action: string; effect: string }>;
 };
 
 const ORG = "org-1";
 
-/** Tagged-template stub that mimics the candidate-policy query: it applies the
- * same (NULL OR match) filters the real SQL does, against seeded rows. Param
- * order matches loadCandidatePolicies: org, resource_class, principal_kind,
- * principal_id, entity_type_slug, entity_id. */
+/** Derive the child action-effect rows a seed implies, matching the migration
+ * backfill: connector_action → one `execute` from create_mode; other classes →
+ * create/update/delete from their mode fields. */
+function seedEffectRows(seed: PolicyRowSeed): Array<{ action: string; effect: string }> {
+	if (seed.effects) return seed.effects;
+	if (seed.resource_class === "connector_action") {
+		return [{ action: "execute", effect: seed.create_mode ?? "auto" }];
+	}
+	return [
+		{ action: "create", effect: seed.create_mode ?? "auto" },
+		{ action: "update", effect: seed.update_mode ?? "auto" },
+		{ action: "delete", effect: seed.delete_mode ?? "approval" },
+	];
+}
+
+/**
+ * Tagged-template stub for the two queries the resolver issues:
+ *  1. the candidate-policy header query (params: org, resource_class,
+ *     principal_kind, principal_id, entity_type_slug, entity_id), and
+ *  2. attachEffects' child query (single param: a pgBigintArray of policy ids).
+ * The child query is detected by its lone string-array param.
+ */
 function stubSql(seeds: PolicyRowSeed[]): DbClient {
-	const rows = seeds.map((seed, index) => ({
+	const headers = seeds.map((seed, index) => ({
 		id: seed.id ?? index + 1,
 		organization_id: ORG,
 		resource_class: seed.resource_class ?? "entity",
@@ -37,15 +59,30 @@ function stubSql(seeds: PolicyRowSeed[]): DbClient {
 		entity_type_slug: seed.entity_type_slug ?? null,
 		field_path: seed.field_path ?? null,
 		entity_id: seed.entity_id ?? null,
-		create_mode: seed.create_mode ?? "auto",
-		update_mode: seed.update_mode ?? "auto",
-		delete_mode: seed.delete_mode ?? "approval",
 		approval_connection_id: null,
 		approval_channel_id: null,
 		approval_team_id: null,
 		approval_channel_name: null,
 	}));
+	const childRows = seeds.flatMap((seed, index) =>
+		seedEffectRows(seed).map((e) => ({
+			policy_id: seed.id ?? index + 1,
+			action: e.action,
+			effect: e.effect,
+		})),
+	);
 	const sql = (_strings: TemplateStringsArray, ...params: unknown[]) => {
+		// attachEffects passes exactly one param: a pgBigintArray string like "{1,2}".
+		if (params.length === 1 && typeof params[0] === "string") {
+			const ids = new Set(
+				(params[0] as string)
+					.replace(/[{}]/g, "")
+					.split(",")
+					.filter(Boolean)
+					.map((n) => Number(n)),
+			);
+			return Promise.resolve(childRows.filter((r) => ids.has(Number(r.policy_id))));
+		}
 		const [org, resourceClass, principalKind, principalId, entityTypeSlug, entityId] =
 			params as [
 				string,
@@ -56,7 +93,7 @@ function stubSql(seeds: PolicyRowSeed[]): DbClient {
 				number | null,
 			];
 		return Promise.resolve(
-			rows.filter(
+			headers.filter(
 				(row) =>
 					row.organization_id === org &&
 					row.resource_class === resourceClass &&
@@ -437,7 +474,7 @@ describe("resolveWritePolicyDecision (connector_action)", () => {
 				organizationId: ORG,
 				resourceClass: "connector_action",
 				principalKind: "agent",
-				action: "create",
+				action: "execute",
 				sql: stubSql([]),
 			}),
 		).toBe("allow");
@@ -449,7 +486,7 @@ describe("resolveWritePolicyDecision (connector_action)", () => {
 				organizationId: ORG,
 				resourceClass: "connector_action",
 				principalKind: "agent",
-				action: "create",
+				action: "execute",
 				sql: stubSql([
 					{ resource_class: "connector_action", create_mode: "approval" },
 				]),
@@ -461,7 +498,7 @@ describe("resolveWritePolicyDecision (connector_action)", () => {
 				resourceClass: "connector_action",
 				principalKind: "watcher",
 				principalId: "watcher:9",
-				action: "create",
+				action: "execute",
 				sql: stubSql([
 					{
 						resource_class: "connector_action",
@@ -480,7 +517,7 @@ describe("resolveWritePolicyDecision (connector_action)", () => {
 				organizationId: ORG,
 				resourceClass: "connector_action",
 				principalKind: "user",
-				action: "create",
+				action: "execute",
 				sql: stubSql([
 					{ resource_class: "connector_action", create_mode: "deny" },
 				]),

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -20,7 +20,12 @@
  * high-volume provenance plumbing, not collaboration edits; gating them would
  * flood approvals. Any new user-facing entity write path MUST call this module.
  */
-import { type DbClient, getDb } from "../db/client";
+import { type DbClient, getDb, pgBigintArray } from "../db/client";
+import {
+	type WriteAction,
+	defaultEffectFor,
+	isLegalActionEffect,
+} from "./write-action-manifest";
 
 export type EntityPolicyDecision = "allow" | "deny" | "require_approval";
 export type EntityPolicyPrincipalKind = "user" | "agent" | "watcher";
@@ -66,6 +71,13 @@ export interface EntityApprovalPolicy {
 	createMode: EntityMutationMode;
 	updateMode: EntityMutationMode;
 	deleteMode: EntityMutationMode;
+	/**
+	 * The effect this policy attaches to each action it declares, from the child
+	 * write_policy_action_effects rows. The create/update/delete convenience
+	 * fields above mirror this map (entity/agent_config); connector_action carries
+	 * only `execute` here and leaves the mode fields at their class defaults.
+	 */
+	effects: Partial<Record<WriteAction, EntityMutationMode>>;
 	deliveryTarget: EntityApprovalDeliveryTarget;
 }
 
@@ -85,6 +97,11 @@ export interface EntityApprovalPolicyInput {
 	approvalChannelName?: string | null;
 }
 
+/**
+ * A header row from write_approval_policies, with its child action→effect rows
+ * attached in `effects` by {@link attachEffects}. The header no longer carries
+ * mode columns; every per-action decision reads `effects`.
+ */
 type EntityApprovalPolicyRow = {
 	id: number;
 	organization_id: string;
@@ -94,14 +111,14 @@ type EntityApprovalPolicyRow = {
 	entity_type_slug: string | null;
 	field_path: string | null;
 	entity_id: number | null;
-	create_mode: string;
-	update_mode: string;
-	delete_mode: string;
 	approval_connection_id: string | null;
 	approval_channel_id: string | null;
 	approval_team_id: string | null;
 	approval_channel_name: string | null;
+	/** Populated post-query from write_policy_action_effects; empty until attached. */
+	effects: Partial<Record<WriteAction, EntityMutationMode>>;
 };
+
 
 export function isEntityMutationMode(
 	value: unknown,
@@ -119,24 +136,17 @@ export function isEntityApprovalUiMode(value: unknown): value is "auto" | "appro
 	return value === "auto" || value === "approval";
 }
 
+/**
+ * Coerce user INPUT to a caller-chosen default when it isn't a legal mode.
+ * (Stored effects READ from the DB fail closed differently — see
+ * {@link attachEffects}, which drops an illegal (action, effect) tuple so the
+ * resolver falls back to the class default rather than reading it as `allow`.)
+ */
 function normalizeMode(
 	value: unknown,
 	fallback: EntityMutationMode,
 ): EntityMutationMode {
 	return isEntityMutationMode(value) ? value : fallback;
-}
-
-/**
- * Parse a mode that was READ FROM THE DATABASE. Unlike {@link normalizeMode}
- * (which coerces user INPUT to a caller-chosen default), an unrecognized stored
- * value fails CLOSED to `deny`: a mode a future build introduced mid-rolling-
- * upgrade, or corrupt data from manual SQL, must never silently read as `allow`.
- * The DB CHECK bounds today's values, so this is a defense-in-depth backstop for
- * exactly the rolling-upgrade case the design calls out — not a reachable path
- * under normal writes.
- */
-function parsePersistedMode(value: unknown): EntityMutationMode {
-	return isEntityMutationMode(value) ? value : "deny";
 }
 
 function normalizeResourceClass(value: unknown): WriteResourceClass {
@@ -149,19 +159,37 @@ function normalizePrincipalKind(value: unknown): PolicyPrincipalKind | null {
 	return value === "agent" || value === "watcher" ? value : null;
 }
 
+/**
+ * The stored effect a policy attaches to `action`, or the class default if the
+ * policy declares no row for that action. A policy is a SPARSE override: a scope
+ * that sets only `execute` (or only `delete`) leaves the other actions at their
+ * class default rather than implicitly `auto`.
+ */
+function effectForRowAction(
+	row: EntityApprovalPolicyRow,
+	resourceClass: WriteResourceClass,
+	action: WriteAction,
+): EntityMutationMode {
+	const stored = row.effects[action];
+	if (stored !== undefined) return stored;
+	return defaultEffectFor(resourceClass, action);
+}
+
 function rowToPolicy(row: EntityApprovalPolicyRow): EntityApprovalPolicy {
+	const resourceClass = normalizeResourceClass(row.resource_class);
 	return {
 		id: Number(row.id),
 		organizationId: row.organization_id,
-		resourceClass: normalizeResourceClass(row.resource_class),
+		resourceClass,
 		principalKind: normalizePrincipalKind(row.principal_kind),
 		principalId: row.principal_id,
 		entityTypeSlug: row.entity_type_slug,
 		fieldPath: row.field_path,
 		entityId: row.entity_id === null ? null : Number(row.entity_id),
-		createMode: parsePersistedMode(row.create_mode),
-		updateMode: parsePersistedMode(row.update_mode),
-		deleteMode: parsePersistedMode(row.delete_mode),
+		createMode: effectForRowAction(row, resourceClass, "create"),
+		updateMode: effectForRowAction(row, resourceClass, "update"),
+		deleteMode: effectForRowAction(row, resourceClass, "delete"),
+		effects: { ...row.effects },
 		deliveryTarget: {
 			connectionId: row.approval_connection_id || null,
 			channelId: row.approval_channel_id,
@@ -186,6 +214,7 @@ export function defaultEntityApprovalPolicy(
 		createMode: "auto",
 		updateMode: "auto",
 		deleteMode: "approval",
+		effects: { create: "auto", update: "auto", delete: "approval" },
 		deliveryTarget: {
 			connectionId: null,
 			channelId: null,
@@ -234,13 +263,20 @@ export function mutationPrincipalId(args: {
 	return null;
 }
 
+/**
+ * The effect this resolved policy attaches to `action`. Reads the policy's
+ * action→effect map, falling back to the class default for an action the policy
+ * declares no row for (a sparse override). Works for every action a class
+ * governs — including connector_action's `execute`, which the old positional
+ * switch could not express.
+ */
 function modeForAction(
 	policy: EntityApprovalPolicy,
-	action: EntityMutationAction,
+	action: WriteAction,
 ): EntityMutationMode {
-	if (action === "create") return policy.createMode;
-	if (action === "update") return policy.updateMode;
-	return policy.deleteMode;
+	const stored = policy.effects[action];
+	if (stored !== undefined) return stored;
+	return defaultEffectFor(policy.resourceClass, action);
 }
 
 /**
@@ -282,15 +318,15 @@ function modeRestrictiveness(mode: EntityMutationMode): number {
 
 /**
  * A row's overall restrictiveness, for the final tie-break: the most restrictive
- * of its three per-action modes. Ensures that when scope AND principal specificity
- * tie, the stricter row wins (deny > approval > auto) rather than DB-return order.
+ * of its declared per-action effects. Ensures that when scope AND principal
+ * specificity tie, the stricter row wins (deny > approval > auto) rather than
+ * DB-return order. A row with no declared effects (shouldn't occur — every saved
+ * scope writes a complete action set) ranks least-restrictive.
  */
 function rowRestrictiveness(row: EntityApprovalPolicyRow): number {
-	return Math.max(
-		modeRestrictiveness(parsePersistedMode(row.create_mode)),
-		modeRestrictiveness(parsePersistedMode(row.update_mode)),
-		modeRestrictiveness(parsePersistedMode(row.delete_mode)),
-	);
+	const effects = Object.values(row.effects);
+	if (effects.length === 0) return modeRestrictiveness("auto");
+	return Math.max(...effects.map((e) => modeRestrictiveness(e)));
 }
 
 /**
@@ -318,6 +354,60 @@ function compareCandidates(
  * targets no principal (any), or targets this principal's kind and either no
  * specific id (any of that kind) or exactly this id.
  */
+type ActionEffectRow = { policy_id: number; action: string; effect: string };
+
+/**
+ * Attach each header row's child action→effect rows in one batched query (keyed
+ * by policy_id, no N+1).
+ *
+ * Fail-closed on a bad STORED value: when a child row exists for an action but
+ * carries an effect this build can't recognize or the manifest declares illegal
+ * for the class (a value a future build introduced mid-rolling-upgrade, or
+ * corrupt data from manual SQL), the action is pinned to `deny` — never silently
+ * dropped. Dropping would let the resolver fall back to the class default (which
+ * for entity create is `auto`), reading a stored-but-unknown value as `allow`.
+ * An ABSENT action (no child row at all) is different: that's a sparse override,
+ * and it correctly inherits the class default.
+ */
+async function attachEffects(
+	sql: DbClient,
+	rows: EntityApprovalPolicyRow[],
+): Promise<EntityApprovalPolicyRow[]> {
+	for (const row of rows) row.effects = {};
+	if (rows.length === 0) return rows;
+	const byId = new Map(rows.map((r) => [Number(r.id), r]));
+	const ids = rows.map((r) => Number(r.id));
+	const effects = await sql<ActionEffectRow>`
+    SELECT policy_id, action, effect
+    FROM write_policy_action_effects
+    WHERE policy_id = ANY(${pgBigintArray(ids)})
+  `;
+	for (const e of effects) {
+		const row = byId.get(Number(e.policy_id));
+		if (!row || !isWriteAction(e.action)) continue;
+		const legal =
+			isEntityMutationMode(e.effect) &&
+			isLegalActionEffect(
+				normalizeResourceClass(row.resource_class),
+				e.action,
+				e.effect,
+			);
+		// Pin an unknown/illegal stored effect to `deny` (fail closed), never drop.
+		row.effects[e.action] =
+			legal && isEntityMutationMode(e.effect) ? e.effect : "deny";
+	}
+	return rows;
+}
+
+function isWriteAction(value: unknown): value is WriteAction {
+	return (
+		value === "create" ||
+		value === "update" ||
+		value === "delete" ||
+		value === "execute"
+	);
+}
+
 async function loadCandidatePolicies(args: {
 	organizationId: string;
 	resourceClass?: WriteResourceClass;
@@ -334,7 +424,6 @@ async function loadCandidatePolicies(args: {
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
        entity_type_slug, field_path, entity_id,
-       create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM write_approval_policies
@@ -350,7 +439,9 @@ async function loadCandidatePolicies(args: {
       AND (entity_type_slug IS NULL OR entity_type_slug = ${args.entityTypeSlug ?? null})
       AND (entity_id IS NULL OR entity_id = ${args.entityId ?? null})
   `;
-	return [...rows].sort(compareCandidates);
+	const list = [...rows];
+	await attachEffects(sql, list);
+	return list.sort(compareCandidates);
 }
 
 function pickPolicy(
@@ -426,29 +517,6 @@ export async function evaluateEntityMutation(args: {
 	return modeToDecision(modeForAction(policy, args.action));
 }
 
-/**
- * The mode a class falls back to when no policy row matches — the per-action
- * defaults baked into {@link defaultEntityApprovalPolicy} for entity, and a
- * conservative "agent-driven config change needs approval, delete is denied"
- * default for agent_config.
- */
-function defaultModeFor(
-	resourceClass: WriteResourceClass,
-	action: EntityMutationAction,
-): EntityMutationMode {
-	if (resourceClass === "agent_config") {
-		// An agent editing agent definitions is high-trust: create/update queue an
-		// approval, delete is denied outright (a human must delete an agent).
-		if (action === "delete") return "deny";
-		return "approval";
-	}
-	if (resourceClass === "connector_action") {
-		// No org connector-action policy → `auto`, so the per-connection
-		// action_modes alone decide (today's behavior). A row only ever tightens.
-		return "auto";
-	}
-	return modeForAction(defaultEntityApprovalPolicy(""), action);
-}
 
 /**
  * Class-generic write decision for a non-scoped resource (agent_config today;
@@ -463,7 +531,7 @@ export async function resolveWritePolicyDecision(args: {
 	resourceClass: Exclude<WriteResourceClass, "entity">;
 	principalKind: EntityPolicyPrincipalKind;
 	principalId?: string | null;
-	action: EntityMutationAction;
+	action: WriteAction;
 	sql?: DbClient;
 }): Promise<EntityPolicyDecision> {
 	if (args.principalKind === "user") return "allow";
@@ -477,7 +545,7 @@ export async function resolveWritePolicyDecision(args: {
 	const match = candidates[0];
 	const mode = match
 		? modeForAction(rowToPolicy(match), args.action)
-		: defaultModeFor(args.resourceClass, args.action);
+		: defaultEffectFor(args.resourceClass, args.action);
 	return modeToDecision(mode);
 }
 
@@ -534,7 +602,6 @@ export async function getGlobalEntityApprovalPolicy(
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
        entity_type_slug, field_path, entity_id,
-       create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM write_approval_policies
@@ -546,9 +613,9 @@ export async function getGlobalEntityApprovalPolicy(
       AND entity_id IS NULL
     LIMIT 1
   `;
-	return rows[0]
-		? rowToPolicy(rows[0])
-		: defaultEntityApprovalPolicy(organizationId);
+	if (!rows[0]) return defaultEntityApprovalPolicy(organizationId);
+	await attachEffects(sql, rows as EntityApprovalPolicyRow[]);
+	return rowToPolicy(rows[0]);
 }
 
 /**
@@ -563,7 +630,6 @@ export async function listEntityApprovalPolicies(
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
        entity_type_slug, field_path, entity_id,
-       create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM write_approval_policies
@@ -582,6 +648,7 @@ export async function listEntityApprovalPolicies(
       field_path ASC NULLS FIRST,
       id ASC
   `;
+	await attachEffects(sql, [...rows]);
 	return rows.map(rowToPolicy);
 }
 
@@ -597,6 +664,53 @@ export async function upsertGlobalEntityApprovalPolicy(
 	});
 }
 
+/**
+ * Turn a policy input into the COMPLETE action→effect set to persist for the
+ * given class. Every save writes a class's full action vocabulary (a complete
+ * bundle, not a sparse override) so the child rows are self-consistent. For the
+ * entity-shaped classes the effects come from create/update/delete; for
+ * connector_action the single `execute` effect is taken from `createMode` (the
+ * field the API carries it in until the connector-action UI ships a dedicated
+ * one). Effects are clamped to what the manifest declares legal for the class.
+ */
+function actionEffectSetForInput(
+	resourceClass: WriteResourceClass,
+	input: EntityApprovalPolicyInput,
+): Array<{ action: WriteAction; effect: EntityMutationMode }> {
+	const clamp = (action: WriteAction, effect: EntityMutationMode) =>
+		isLegalActionEffect(resourceClass, action, effect)
+			? effect
+			: defaultEffectFor(resourceClass, action);
+	if (resourceClass === "connector_action") {
+		return [
+			{
+				action: "execute",
+				effect: clamp("execute", normalizeMode(input.createMode, "auto")),
+			},
+		];
+	}
+	return [
+		{ action: "create", effect: clamp("create", normalizeMode(input.createMode, "auto")) },
+		{ action: "update", effect: clamp("update", normalizeMode(input.updateMode, "auto")) },
+		{ action: "delete", effect: clamp("delete", normalizeMode(input.deleteMode, "approval")) },
+	];
+}
+
+/** Replace a policy's child action-effect rows with the given complete set. */
+async function writeActionEffects(
+	tx: DbClient,
+	policyId: number,
+	set: Array<{ action: WriteAction; effect: EntityMutationMode }>,
+): Promise<void> {
+	await tx`DELETE FROM write_policy_action_effects WHERE policy_id = ${policyId}`;
+	for (const { action, effect } of set) {
+		await tx`
+      INSERT INTO write_policy_action_effects (policy_id, action, effect)
+      VALUES (${policyId}, ${action}, ${effect})
+    `;
+	}
+}
+
 export async function upsertEntityApprovalPolicy(
 	organizationId: string,
 	input: EntityApprovalPolicyInput,
@@ -608,23 +722,19 @@ export async function upsertEntityApprovalPolicy(
 	const entityTypeSlug = input.entityTypeSlug?.trim() || null;
 	const fieldPath = input.fieldPath?.trim() || null;
 	const entityId = input.entityId ?? null;
-	const createMode = normalizeMode(input.createMode, "auto");
-	const updateMode = normalizeMode(input.updateMode, "auto");
-	const deleteMode = normalizeMode(input.deleteMode, "approval");
+	const effectSet = actionEffectSetForInput(resourceClass, input);
 	const approvalConnectionId = input.approvalConnectionId?.trim() || null;
 	const approvalChannelId = input.approvalChannelId?.trim() || null;
 	const approvalTeamId = input.approvalTeamId?.trim() || null;
 	const approvalChannelName = input.approvalChannelName?.trim() || null;
 
 	const sql = getDb();
-	// The identity tuple the unique index keys on. Reused by both UPDATE arms so
-	// the "lost the insert race" recovery targets the exact same row.
+	// Upsert the header row (scope/principal/delivery only — effects live in the
+	// child table). The identity tuple the unique index keys on; reused by both
+	// UPDATE arms so the "lost the insert race" recovery targets the same row.
 	const applyUpdate = (tx: DbClient) => tx<EntityApprovalPolicyRow>`
       UPDATE write_approval_policies
-      SET create_mode = ${createMode},
-          update_mode = ${updateMode},
-          delete_mode = ${deleteMode},
-          approval_connection_id = ${approvalConnectionId},
+      SET approval_connection_id = ${approvalConnectionId},
           approval_channel_id = ${approvalChannelId},
           approval_team_id = ${approvalTeamId},
           approval_channel_name = ${approvalChannelName},
@@ -638,26 +748,23 @@ export async function upsertEntityApprovalPolicy(
         AND entity_id IS NOT DISTINCT FROM ${entityId}
       RETURNING id, organization_id, resource_class, principal_kind, principal_id,
        entity_type_slug, field_path, entity_id,
-       create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     `;
 
 	const row = await sql.begin(async (tx) => {
-		const updated = await applyUpdate(tx);
-		if (updated[0]) return updated[0];
+		let header = (await applyUpdate(tx))[0] ?? null;
 
-		const inserted = await tx<EntityApprovalPolicyRow>`
+		if (!header) {
+			const inserted = await tx<EntityApprovalPolicyRow>`
       INSERT INTO write_approval_policies (
         organization_id, resource_class, principal_kind, principal_id,
         entity_type_slug, field_path, entity_id,
-        create_mode, update_mode, delete_mode,
         approval_connection_id, approval_channel_id, approval_team_id,
         approval_channel_name, created_at, updated_at
       ) VALUES (
         ${organizationId}, ${resourceClass}, ${principalKind}, ${principalId},
         ${entityTypeSlug}, ${fieldPath}, ${entityId},
-        ${createMode}, ${updateMode}, ${deleteMode},
         ${approvalConnectionId},
         ${approvalChannelId}, ${approvalTeamId}, ${approvalChannelName},
         now(), now()
@@ -665,15 +772,19 @@ export async function upsertEntityApprovalPolicy(
       ON CONFLICT DO NOTHING
       RETURNING id, organization_id, resource_class, principal_kind, principal_id,
        entity_type_slug, field_path, entity_id,
-       create_mode, update_mode, delete_mode,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     `;
-		if (inserted[0]) return inserted[0];
+			header = inserted[0] ?? null;
+			// Lost the insert race to a concurrent save — apply this request on top.
+			if (!header) header = (await applyUpdate(tx))[0] ?? null;
+		}
 
-		// Lost the insert race to a concurrent save — apply this request on top.
-		const selected = await applyUpdate(tx);
-		return selected[0] ?? null;
+		if (!header) return null;
+		await writeActionEffects(tx, Number(header.id), effectSet);
+		header.effects = {};
+		for (const { action, effect } of effectSet) header.effects[action] = effect;
+		return header;
 	});
 	if (!row) throw new Error("Failed to save entity approval policy");
 	return rowToPolicy(row);

--- a/packages/server/src/authz/write-action-manifest.ts
+++ b/packages/server/src/authz/write-action-manifest.ts
@@ -86,14 +86,6 @@ export const WRITE_ACTION_MANIFEST: Readonly<
 	},
 };
 
-/** True when `action` is one this class governs. */
-export function isLegalAction(
-	resourceClass: WriteResourceClass,
-	action: WriteAction,
-): boolean {
-	return WRITE_ACTION_MANIFEST[resourceClass].actions.includes(action);
-}
-
 /** True when `(action, effect)` is a legal pair for this class. */
 export function isLegalActionEffect(
 	resourceClass: WriteResourceClass,
@@ -116,11 +108,4 @@ export function defaultEffectFor(
 	const m = WRITE_ACTION_MANIFEST[resourceClass];
 	if (!m.actions.includes(action)) return "deny";
 	return m.defaultEffect[action];
-}
-
-/** The actions a class governs, for iterating a complete action set. */
-export function actionsFor(
-	resourceClass: WriteResourceClass,
-): readonly WriteAction[] {
-	return WRITE_ACTION_MANIFEST[resourceClass].actions;
 }

--- a/packages/server/src/authz/write-action-manifest.ts
+++ b/packages/server/src/authz/write-action-manifest.ts
@@ -1,0 +1,126 @@
+/**
+ * The write-action manifest — the single code-side source of truth for which
+ * (resource class, action, effect) tuples are legal, and the per-(class, action)
+ * default effect when no policy row matches.
+ *
+ * This replaces the positional create_mode/update_mode/delete_mode columns: a
+ * policy is now `(scope, principal) → { action → effect }`, and each class
+ * declares its own action vocabulary here rather than cramming every verb into
+ * three fixed columns. `connector_action` has a single `execute` action instead
+ * of being forced onto `create_mode`.
+ *
+ * A parallel DB CHECK mirrors this map (a TS object can't govern SQL or stored
+ * rows on its own). When the two disagree — a stored row carrying an action or
+ * effect this build no longer declares — the resolver fails CLOSED (deny), never
+ * silently `auto`. See {@link isLegalActionEffect} and {@link defaultEffectFor}.
+ */
+import type { WriteResourceClass } from "./entity-policy";
+
+/**
+ * The verbs a write policy can govern. `create`/`update`/`delete` are the entity
+ * and agent_config actions; `execute` is the connector_action verb (running a
+ * connector operation). `install` is intentionally NOT declared until a class
+ * actually uses it — an undeclared action is illegal, not a reserved no-op.
+ */
+export type WriteAction = "create" | "update" | "delete" | "execute";
+
+/**
+ * The decision a policy attaches to an action. `auto` applies inline; `approval`
+ * queues a durable approval; `deny` is a hard floor (never applies, nothing
+ * queued); `disabled` turns the action off entirely (connector_action only).
+ */
+export type WriteEffect = "auto" | "approval" | "deny" | "disabled";
+
+interface ClassManifest {
+	/** The actions this class governs. An action outside this set is illegal for the class. */
+	readonly actions: readonly WriteAction[];
+	/** The effects legal for this class. An effect outside this set is illegal for the class. */
+	readonly effects: readonly WriteEffect[];
+	/** The effect applied when no policy row matches, per action. */
+	readonly defaultEffect: Readonly<Record<WriteAction, WriteEffect>>;
+}
+
+/**
+ * Per-class legal actions/effects + no-row defaults. Defaults are stated
+ * EXPLICITLY for every legal action (never an implicit `auto`) — an implicit
+ * default would be a silent security downgrade for a class like agent_config
+ * whose delete must default to deny.
+ */
+export const WRITE_ACTION_MANIFEST: Readonly<
+	Record<WriteResourceClass, ClassManifest>
+> = {
+	entity: {
+		actions: ["create", "update", "delete"],
+		effects: ["auto", "approval", "deny"],
+		// Matches the historical entity default (create/update auto, delete approval).
+		defaultEffect: {
+			create: "auto",
+			update: "auto",
+			delete: "approval",
+			execute: "deny",
+		},
+	},
+	agent_config: {
+		actions: ["create", "update", "delete"],
+		effects: ["auto", "approval", "deny"],
+		// An agent editing agent definitions is high-trust: create/update queue an
+		// approval, delete is denied outright (a human must delete an agent).
+		defaultEffect: {
+			create: "approval",
+			update: "approval",
+			delete: "deny",
+			execute: "deny",
+		},
+	},
+	connector_action: {
+		actions: ["execute"],
+		effects: ["auto", "approval", "deny", "disabled"],
+		// No org connector-action policy → auto, so the per-connection action_modes
+		// alone decide (today's behavior). A row only ever tightens.
+		defaultEffect: {
+			execute: "auto",
+			create: "deny",
+			update: "deny",
+			delete: "deny",
+		},
+	},
+};
+
+/** True when `action` is one this class governs. */
+export function isLegalAction(
+	resourceClass: WriteResourceClass,
+	action: WriteAction,
+): boolean {
+	return WRITE_ACTION_MANIFEST[resourceClass].actions.includes(action);
+}
+
+/** True when `(action, effect)` is a legal pair for this class. */
+export function isLegalActionEffect(
+	resourceClass: WriteResourceClass,
+	action: WriteAction,
+	effect: WriteEffect,
+): boolean {
+	const m = WRITE_ACTION_MANIFEST[resourceClass];
+	return m.actions.includes(action) && m.effects.includes(effect);
+}
+
+/**
+ * The no-row default effect for a (class, action). An action the class does not
+ * govern falls back to `deny` — asking "what happens by default when a watcher
+ * does X" for an X this class can't do is answered fail-closed.
+ */
+export function defaultEffectFor(
+	resourceClass: WriteResourceClass,
+	action: WriteAction,
+): WriteEffect {
+	const m = WRITE_ACTION_MANIFEST[resourceClass];
+	if (!m.actions.includes(action)) return "deny";
+	return m.defaultEffect[action];
+}
+
+/** The actions a class governs, for iterating a complete action set. */
+export function actionsFor(
+	resourceClass: WriteResourceClass,
+): readonly WriteAction[] {
+	return WRITE_ACTION_MANIFEST[resourceClass].actions;
+}

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -693,7 +693,7 @@ async function handleExecute(
 		resourceClass: "connector_action",
 		principalKind,
 		principalId,
-		action: "create",
+		action: "execute",
 	});
 	if (policyDecision === "deny") {
 		return {
@@ -1626,7 +1626,7 @@ async function handleApprove(
 					resourceClass: "connector_action",
 					principalKind: recheckPrincipalKind,
 					principalId: pendingRun.policy_principal_id,
-					action: "create",
+					action: "execute",
 				});
 	if (currentMode === "disabled" || recheckDecision === "deny") {
 		const why =


### PR DESCRIPTION
## What

Replaces the write-gate's positional `create_mode`/`update_mode`/`delete_mode` columns with an action/effect child table. This is v1.1 consolidation of the merged write-gate (#1827) — **no UI, resolver mechanics only.**

`write_approval_policies` becomes a scope + principal + delivery **header**; a new `write_policy_action_effects` child (`policy_id` FK CASCADE, `action`, `effect`, `UNIQUE(policy_id, action)`) carries the per-action decision. Each resource class declares its own action vocabulary in a code manifest rather than cramming every verb into three fixed columns — `connector_action` gets a native `execute` action instead of being forced onto `create_mode`.

## Why

The three-column shape couldn't express per-class action sets. `connector_action` (execute-only) was crammed into `create_mode`; adding a fourth verb (`execute`) meant a fourth column. The child table lets each class own its actions and makes the resolver fail closed on any stored tuple this build doesn't declare.

## Changes

- **Migration `20260710120000_write_policy_action_effects.sql`**: preflight-asserts the dead `target_scope_*`/`predicate` columns are NULL, creates the child table, class-aware backfill (entity/agent_config → 3 rows; **connector_action → one `execute` row from `create_mode`** — exploding into CRUD would silently drop existing approve/deny to `execute=auto`), then drops all 6 legacy columns. Reversible down-path. squawk lock-safety clean.
- **`write-action-manifest.ts`** (new): `WRITE_ACTION_MANIFEST` — per-class legal actions/effects + explicit no-row defaults (agent_config create/update=approval, delete=deny; connector_action [execute] default auto; entity create/update auto, delete approval). Unknown tuple → fail closed `deny`.
- **`entity-policy.ts`**: resolver reads header + batched `attachEffects()` child query (no N+1). Sparse override — an absent action inherits the class default; a stored illegal-for-class tuple is pinned to `deny`, not dropped. `resolveWritePolicyDecision` takes a `WriteAction`; connector_action passes `execute` at both `manage_operations.ts` sites.

## Verification

- `make review` (Opus): bug_free 86, simplicity 78, **0 blockers**
- typecheck 0 errors; unit 76 pass (incl. rewritten `entity-policy.test.ts`, 39/39); integration 105 pass incl. new real-PG decision-parity test (7/7) asserting identical decisions across all 3 classes + delivery inheritance + fail-closed on illegal effect
- Scratch-DB roundtrip: `dbmate down` to pre-v1.1 → seed old-schema rows → `up` → verified backfill + down/up restores exact original values

## Rollout

One-shot cutover with a ~30-90s blip while old pods run against the new schema (pre-upgrade migration hook precedent from #1827). Accepted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786237122&installation_id=136316292&pr_number=1834&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1834&signature=f8959d7d8b1153e39b3814bf8c859027c93837abb9b13d5e2af0dbb3f04ff2b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit authorization effects for create, update, delete, and execute actions.
  * Added configurable defaults for supported resource types and actions.
  * Connector operations now use a dedicated execute authorization decision.

* **Bug Fixes**
  * Invalid authorization settings now fail closed by denying access.
  * Approval and execution checks consistently enforce the latest connector policies.
  * Policy inheritance and fallback behavior are handled consistently across resource types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->