### PR TITLE
fix(connections): set fallback agent_id via manage_connections update + advisory lock ordering

### DIFF
--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -149,10 +149,16 @@ export const CreateAction = Type.Object({
 export const UpdateAction = Type.Object({
   action: Type.Literal("update", {
     description:
-      "Patch a connection's settings, status, slug, or device binding.",
+      "Patch a connection's settings, status, slug, device binding, or (chat connections) fallback agent.",
   }),
   connection_id: Type.Number({ description: "Connection ID" }),
   display_name: Type.Optional(Type.String()),
+  agent_id: Type.Optional(
+    Type.Union([Type.String(), Type.Null()], {
+      description:
+        "Fallback agent for a chat connection (used only when no channel binding matches; agent_channel_bindings remain authoritative). Null clears the fallback.",
+    })
+  ),
   slug: Type.Optional(
     Type.String({
       description:

--- a/packages/server/src/__tests__/integration/connectors/connection-agent-id-update.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-agent-id-update.test.ts
@@ -25,6 +25,7 @@ import { ChatInstanceManager } from "../../../gateway/connections/chat-instance-
 import type { PlatformConnection } from "../../../gateway/connections/types";
 import { SecretStoreRegistry } from "../../../gateway/secrets/index";
 import { __setChatInstanceManagerForTests } from "../../../lobu/gateway";
+import { upsertChatConnectionProjection } from "../../../lobu/stores/connections-projection";
 import { orgContext } from "../../../lobu/stores/org-context";
 import { createPostgresAppInstallationStore } from "../../../lobu/stores/app-installation-store";
 import { PostgresSecretStore } from "../../../lobu/stores/postgres-secret-store";
@@ -809,4 +810,132 @@ describe("manage_connections update — chat fallback agent_id", () => {
 		expect(rows[0]?.credential_mode).toBe("byo");
 		expect(rows[0]?.agent_id).toBe(agentB);
 	}, 30_000);
+
+	it("the projection acquires the managed-advisory BEFORE its same-org sibling ROW lock (no cross-org projection-order cycle)", async () => {
+		// THIRD-order cycle (the mirror of the round-3 fix). The projection's
+		// same-org one-active demote is a ROW lock. Pre-fix the projection's
+		// order was org-advisory → sibling ROW → managed-advisory → cross-org
+		// rows, which inverts against saveConnection's org → managed → rows:
+		//   Tx B (projection): holds O(B,T) + sibling ROW, then wants M(T).
+		//   Tx A (saveConnection): holds O(A,T) + M(T), then wants a B-side row.
+		//   ⇒ A waits B's row, B waits M(T) = 40P01.
+		// The fix moves the projection's managed-advisory ABOVE its same-org
+		// demote, so BOTH paths are org → managed → ALL rows and no cycle forms.
+		//
+		// This drives the REAL projection (via saveConnection activating a row
+		// whose SAME-ORG sibling is active, forcing the projection's line-227
+		// same-org demote) and proves the ordering directly: hold the same-org
+		// SIBLING row, run the REAL projection write, and while it is parked on
+		// that sibling row, probe M(T). Post-fix the projection has ALREADY taken
+		// M(T) before the sibling demote ⇒ probe fails (M(T) held). Pre-fix
+		// (managed-advisory below the sibling demote) the projection would be
+		// parked on the sibling row WITHOUT M(T) ⇒ probe would succeed. This is
+		// the exact invariant the fix establishes on the projection side.
+		const sql = getDb();
+		const teamId = "TPROJORDER1";
+		const managedKey = `chatconn:managed:slack:${teamId}`;
+
+		// A same-org MANAGED sibling that is currently active — the projection's
+		// one-active demote (line 227) will target it when we activate a new row.
+		const siblingSlug = "slackinst-projorder-sibling";
+		await sql`
+			INSERT INTO connections (
+				organization_id, connector_key, external_tenant_id, agent_id,
+				display_name, status, config, credential_mode, slug, visibility,
+				created_at, updated_at
+			) VALUES (
+				${orgId}, 'slack', ${teamId}, ${agentA},
+				'Proj sibling', 'active', ${sql.json({ platform: "slack", botToken: "secret://projsib" })},
+				'managed', ${siblingSlug}, 'org', now(), now()
+			)
+		`;
+
+		let rowHeldGate!: () => void;
+		const rowHeld = new Promise<void>((resolve) => {
+			rowHeldGate = resolve;
+		});
+		let releaseHolder!: () => void;
+		const release = new Promise<void>((resolve) => {
+			releaseHolder = resolve;
+		});
+		// Hold the SAME-ORG SIBLING row so the projection's line-227 demote must
+		// wait on it — parking the REAL projection write exactly at its first row
+		// lock, with whatever advisories it has taken by then still held.
+		const holderTxn = sql.begin(async (tx: typeof sql) => {
+			await tx`
+				SELECT id FROM connections
+				WHERE organization_id = ${orgId} AND slug = ${siblingSlug}
+				  AND deleted_at IS NULL
+				FOR UPDATE
+			`;
+			rowHeldGate();
+			await release;
+		});
+		await rowHeld;
+
+		// REAL projection write, called DIRECTLY (not via saveConnection, so the
+		// ordering under test is the PROJECTION's own, not saveConnection's
+		// pre-acquire). Activating a NEW managed row for the same tenant makes the
+		// projection run org-advisory → managed-advisory → same-org demote, which
+		// blocks on the held sibling row.
+		const newSlug = "slackinst-projorder-new";
+		const projWrite = getDb().begin((tx: typeof sql) =>
+			upsertChatConnectionProjection(
+				tx,
+				(v) => sql.json(v),
+				{
+					id: newSlug,
+					platform: "slack",
+					agentId: agentB,
+					organizationId: orgId,
+					config: { platform: "slack", botToken: "secret://projnew" },
+					settings: { allowGroups: true },
+					metadata: { teamId, teamName: "Proj new" },
+					status: "active",
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+				},
+				orgId,
+				"managed",
+			),
+		);
+
+		const blockedOnRow = async (): Promise<boolean> => {
+			const r = (await sql`
+				SELECT 1 FROM pg_locks
+				WHERE locktype IN ('tuple', 'transactionid') AND NOT granted
+			`) as unknown[];
+			return r.length > 0;
+		};
+		for (let i = 0; i < 400 && !(await blockedOnRow()); i += 1) {
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+		expect(await blockedOnRow()).toBe(true);
+		// The projection is parked on its same-org sibling demote row. Post-fix
+		// it has ALREADY acquired M(T) (managed-advisory moved above the demote)
+		// ⇒ probe cannot take it. Pre-fix it would still be BELOW the demote and
+		// M(T) would be free ⇒ probe would succeed. This directly asserts the
+		// projection's managed-advisory precedes its same-org row lock.
+		const probe = (await sql`
+			SELECT pg_try_advisory_xact_lock(hashtext(${managedKey})) AS got
+		`) as Array<{ got: boolean }>;
+		expect(probe[0]?.got).toBe(false);
+
+		releaseHolder();
+		await projWrite; // must NOT throw 40P01
+		await holderTxn;
+
+		// The projection demoted the same-org sibling and activated the new row.
+		const sib = (await sql`
+			SELECT status FROM connections
+			WHERE organization_id = ${orgId} AND slug = ${siblingSlug}
+		`) as Array<{ status: string }>;
+		expect(sib[0]?.status).toBe("paused");
+		const created = (await sql`
+			SELECT status, credential_mode FROM connections
+			WHERE organization_id = ${orgId} AND slug = ${newSlug}
+		`) as Array<{ status: string; credential_mode: string | null }>;
+		expect(created[0]?.status).toBe("active");
+		expect(created[0]?.credential_mode).toBe("managed");
+	}, 40_000);
 });

--- a/packages/server/src/__tests__/integration/connectors/connection-agent-id-update.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-agent-id-update.test.ts
@@ -584,4 +584,115 @@ describe("manage_connections update — chat fallback agent_id", () => {
 		`) as Array<{ agent_id: string | null }>;
 		expect(rows[0]?.agent_id).toBe(agentB);
 	}, 30_000);
+
+	it("a MANAGED saveConnection takes the managed-global advisory lock BEFORE its row lock (no cross-org transfer deadlock)", async () => {
+		// A MANAGED write takes TWO advisory locks in the projection: the
+		// org-specific tenant lock, THEN the GLOBAL managed-workspace lock, which
+		// then row-locks OTHER orgs' rows to demote a transferred install. A
+		// concurrent cross-org transfer takes chatconn:managed:slack:T then tries
+		// to demote THIS org's managed row. If saveConnection row-locked first
+		// (FOR UPDATE) and only reached chatconn:managed AFTER, the two invert:
+		// transfer holds managed-global + waits on our row; we hold our row +
+		// wait on managed-global ⇒ 40P01. Post-fix saveConnection pre-acquires
+		// chatconn:managed BEFORE its row lock, so it simply queues behind the
+		// transfer's managed-global lock — no cycle.
+		//
+		// Reproduce: a manual holder txn takes chatconn:managed:slack:T (the
+		// transfer's position after ITS own org-specific lock), then runs the
+		// REAL saveConnection on THIS org's managed row until pg_locks shows it
+		// blocked on chatconn:managed, then the holder row-locks this org's row.
+		// Inverted order ⇒ deadlock here; fixed order ⇒ clean.
+		const sql = getDb();
+		const teamId = "TXFER1";
+		const runtimeId = "slackinst-xfer-1"; // managed slug passes through verbatim
+		const seed = (agentId: string) => ({
+			id: runtimeId,
+			platform: "slack",
+			agentId,
+			organizationId: orgId,
+			config: { platform: "slack", botToken: "secret://xfer-1" },
+			settings: { allowGroups: true },
+			metadata: { teamId, teamName: "Transfer Co" },
+			status: "active" as const,
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		});
+		// Seed as MANAGED so saveConnection's credential_mode peek sees 'managed'
+		// and takes the managed-global lock (a BYO row would correctly skip it).
+		await sql`
+			INSERT INTO connections (
+				organization_id, connector_key, external_tenant_id, agent_id,
+				display_name, status, config, credential_mode, slug, visibility,
+				created_at, updated_at
+			) VALUES (
+				${orgId}, 'slack', ${teamId}, ${agentA},
+				'Transfer Co', 'active', ${sql.json({ platform: "slack", botToken: "secret://xfer-1" })},
+				'managed', ${runtimeId}, 'org', now(), now()
+			)
+		`;
+
+		const managedKey = `chatconn:managed:slack:${teamId}`;
+		const waitingOnManaged = async (): Promise<boolean> => {
+			const r = (await sql`
+				WITH k AS (SELECT hashtext(${managedKey})::bigint AS key)
+				SELECT 1 FROM pg_locks, k
+				WHERE locktype = 'advisory' AND NOT granted
+				  AND classid::bigint = ((k.key >> 32) & 4294967295)
+				  AND objid::bigint = (k.key & 4294967295)
+			`) as unknown[];
+			return r.length > 0;
+		};
+
+		let managedHeld!: () => void;
+		const managedHeldGate = new Promise<void>((resolve) => {
+			managedHeld = resolve;
+		});
+		let transferProceed!: () => void;
+		const transferGate = new Promise<void>((resolve) => {
+			transferProceed = resolve;
+		});
+
+		// T2 — the transfer's managed-lock-then-demote sequence.
+		const transferTxn = sql.begin(async (tx: typeof sql) => {
+			await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
+				managedKey,
+			]);
+			managedHeld();
+			await transferGate;
+			// Demote THIS org's managed row (what the projection's transfer branch
+			// does to any other-org managed row for the team) — the row lock.
+			await tx`
+				UPDATE connections SET status = 'paused', updated_at = now()
+				WHERE organization_id = ${orgId} AND slug = ${runtimeId}
+				  AND deleted_at IS NULL
+			`;
+		});
+		await managedHeldGate;
+
+		// T1 — the REAL managed write path.
+		const saveTxn = orgContext.run({ organizationId: orgId }, () =>
+			connStore.saveConnection(seed(agentB)),
+		);
+
+		for (let i = 0; i < 200 && !(await waitingOnManaged()); i += 1) {
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+		// Post-fix: T1 pre-acquires chatconn:managed before its row lock ⇒ it is
+		// provably parked on the managed-global lock, holding no row. Pre-fix it
+		// would instead already hold the row and be waiting on managed-global,
+		// and the reinstallProceed step below would 40P01.
+		expect(await waitingOnManaged()).toBe(true);
+
+		transferProceed();
+		await transferTxn;
+		await saveTxn;
+
+		const rows = (await sql`
+			SELECT agent_id, credential_mode FROM connections
+			WHERE organization_id = ${orgId} AND slug = ${runtimeId}
+		`) as Array<{ agent_id: string | null; credential_mode: string | null }>;
+		expect(rows[0]?.agent_id).toBe(agentB);
+		// Still managed — the write preserved credential_mode.
+		expect(rows[0]?.credential_mode).toBe("managed");
+	}, 30_000);
 });

--- a/packages/server/src/__tests__/integration/connectors/connection-agent-id-update.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-agent-id-update.test.ts
@@ -1,0 +1,436 @@
+/**
+ * manage_connections `update` — chat fallback agent (`agent_id`).
+ *
+ * An OAuth-installed chat connection has no full config to re-apply, so
+ * `apply_chat_connection` (which requires credentials) cannot reassign its
+ * fallback agent — `update` must. These tests drive the real handler through
+ * the sandbox namespace (so `withValidatedArgs` runs) against `lobu_test`,
+ * with a real ChatInstanceManager wired to the Postgres connection store via
+ * the gateway test seam, proving:
+ *   1. `update` with agent_id persists connections.agent_id (the runtime
+ *      fallback; channel bindings remain authoritative) and audits the change
+ *      with `agent_id` in changed_fields;
+ *   2. `agent_id: null` clears the fallback;
+ *   3. an agent_id outside the org rejects ("Agent not found") without
+ *      touching the row;
+ *   4. `update` with agent_id on a NON-chat connection rejects — nothing
+ *      reads that column for data connectors;
+ *   5. the unknown-arg chokepoint rejects agent_id on an action that lacks it
+ *      (`get`) instead of silently dropping it — the original bug shape.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getDb } from "../../../db/client";
+import { ChatInstanceManager } from "../../../gateway/connections/chat-instance-manager";
+import type { PlatformConnection } from "../../../gateway/connections/types";
+import { SecretStoreRegistry } from "../../../gateway/secrets/index";
+import { __setChatInstanceManagerForTests } from "../../../lobu/gateway";
+import { orgContext } from "../../../lobu/stores/org-context";
+import { createPostgresAppInstallationStore } from "../../../lobu/stores/app-installation-store";
+import { PostgresSecretStore } from "../../../lobu/stores/postgres-secret-store";
+import { createPostgresAgentConnectionStore } from "../../../lobu/stores/postgres-stores";
+import { upsertSlackInstallByTeam } from "../../../lobu/stores/slack-installations";
+import {
+	createTestAgent,
+	createTestConnection,
+} from "../../setup/test-fixtures";
+import { TestWorkspace } from "../../setup/test-mcp-client";
+
+const ENCRYPTION_KEY =
+	"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const RUNTIME_ID = "agentfb-slack-1";
+const SLUG = `agentconn-${RUNTIME_ID}`;
+
+async function agentIdOf(connectionId: number): Promise<string | null> {
+	const rows = (await getDb()`
+		SELECT agent_id FROM connections WHERE id = ${connectionId}
+	`) as Array<{ agent_id: string | null }>;
+	return rows[0]?.agent_id ?? null;
+}
+
+async function connRow(
+	connectionId: number,
+): Promise<{ credential_mode: string | null; config: Record<string, unknown> }> {
+	const rows = (await getDb()`
+		SELECT credential_mode, config FROM connections WHERE id = ${connectionId}
+	`) as Array<{ credential_mode: string | null; config: Record<string, unknown> }>;
+	return rows[0];
+}
+
+/** The audit write is fire-and-forget (retryWithBackoff), so poll for it. */
+async function waitForAuditEvent(
+	orgId: string,
+	connectionId: number,
+): Promise<Record<string, unknown> | null> {
+	for (let i = 0; i < 50; i += 1) {
+		const rows = (await getDb()`
+			SELECT metadata FROM events
+			WHERE organization_id = ${orgId}
+			  AND origin_type = 'config_connection_updated'
+			  AND metadata->>'resource_id' = ${String(connectionId)}
+			ORDER BY id DESC
+			LIMIT 1
+		`) as Array<{ metadata: Record<string, unknown> }>;
+		if (rows.length > 0) return rows[0].metadata;
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+	return null;
+}
+
+describe("manage_connections update — chat fallback agent_id", () => {
+	let workspace: TestWorkspace;
+	let orgId: string;
+	let agentA: string;
+	let agentB: string;
+	let chatConnectionId: number;
+	let dataConnectionId: number;
+	let managedConnectionId: number;
+	let manager: ChatInstanceManager;
+
+	beforeAll(async () => {
+		process.env.ENCRYPTION_KEY = ENCRYPTION_KEY;
+		workspace = await TestWorkspace.create({ name: "Agent Fallback Org" });
+		orgId = workspace.org.id;
+		agentA = (await createTestAgent({ organizationId: orgId })).agentId;
+		agentB = (await createTestAgent({ organizationId: orgId })).agentId;
+
+		// Real manager + real Postgres store, injected via the test seam — the
+		// full persistence chain (manager → store → connections projection) runs.
+		const store = createPostgresAgentConnectionStore();
+		manager = new ChatInstanceManager();
+		(manager as unknown as { connectionStore: unknown }).connectionStore =
+			store;
+		const pss = new PostgresSecretStore();
+		(manager as unknown as { services: unknown }).services = {
+			getSecretStore: () => new SecretStoreRegistry(pss, { secret: pss }),
+		};
+		__setChatInstanceManagerForTests(manager);
+
+		// A BYO chat connection whose fallback agent starts as agentA.
+		await orgContext.run({ organizationId: orgId }, () =>
+			store.saveConnection({
+				id: RUNTIME_ID,
+				platform: "slack",
+				agentId: agentA,
+				organizationId: orgId,
+				config: { platform: "slack", botToken: "secret://agentfb-1" },
+				settings: { allowGroups: true },
+				metadata: { teamId: "TAFB1", teamName: "Agent FB" },
+				status: "active",
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			}),
+		);
+		const rows = (await getDb()`
+			SELECT id FROM connections
+			WHERE organization_id = ${orgId} AND slug = ${SLUG}
+		`) as Array<{ id: number }>;
+		chatConnectionId = Number(rows[0].id);
+
+		// A non-chat (data) connection for the rejection path.
+		dataConnectionId = Number(
+			(
+				await createTestConnection({
+					organization_id: orgId,
+					connector_key: "github",
+					display_name: "Data GitHub",
+					created_by: workspace.users.owner.id,
+				})
+			).id,
+		);
+
+		// A MANAGED (OAuth-installed) Slack connection — credential_mode='managed'.
+		// This is the real target of the feature: you can't apply_chat_connection
+		// on it (no full config), so `update` must set its fallback agent WITHOUT
+		// reclassifying it to BYO.
+		const pss2 = new PostgresSecretStore();
+		const managedSecretStore = new SecretStoreRegistry(pss2, { secret: pss2 });
+		const installStore = createPostgresAppInstallationStore();
+		const installRow = await upsertSlackInstallByTeam(
+			installStore,
+			managedSecretStore,
+			orgId,
+			"TMANAGED1",
+			{ teamName: "Managed Co", botUserId: "U-MGD", botToken: "xoxb-managed" },
+		);
+		const managedRows = (await getDb()`
+			SELECT id FROM connections
+			WHERE organization_id = ${orgId} AND slug = ${installRow.id}
+		`) as Array<{ id: number }>;
+		managedConnectionId = Number(managedRows[0].id);
+	}, 60_000);
+
+	afterAll(async () => {
+		__setChatInstanceManagerForTests(null);
+		const sql = getDb();
+		await sql`DELETE FROM connections WHERE organization_id = ${orgId}`;
+	});
+
+	it("sets the fallback agent on a chat connection and audits it", async () => {
+		expect(await agentIdOf(chatConnectionId)).toBe(agentA);
+
+		const result = (await workspace.owner.connections.update({
+			connection_id: chatConnectionId,
+			agent_id: agentB,
+		})) as { action?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.action).toBe("update");
+
+		expect(await agentIdOf(chatConnectionId)).toBe(agentB);
+
+		const audit = await waitForAuditEvent(orgId, chatConnectionId);
+		expect(audit).not.toBeNull();
+		expect(audit?.changed_fields).toContain("agent_id");
+	});
+
+	it("agent_id: null clears the fallback", async () => {
+		const result = (await workspace.owner.connections.update({
+			connection_id: chatConnectionId,
+			agent_id: null,
+		})) as { error?: string };
+		expect(result.error).toBeUndefined();
+		expect(await agentIdOf(chatConnectionId)).toBeNull();
+	});
+
+	it("rejects an agent_id that does not exist in the org, leaving the row untouched", async () => {
+		const before = await agentIdOf(chatConnectionId);
+		const result = (await workspace.owner.connections.update({
+			connection_id: chatConnectionId,
+			agent_id: "agent-does-not-exist",
+		})) as { error?: string };
+		expect(result.error).toBe("Agent not found");
+		expect(await agentIdOf(chatConnectionId)).toBe(before);
+	});
+
+	it("rejects agent_id on a non-chat connection", async () => {
+		const result = (await workspace.owner.connections.update({
+			connection_id: dataConnectionId,
+			agent_id: agentB,
+		})) as { error?: string };
+		expect(result.error).toMatch(/applies only to chat connections/);
+		expect(await agentIdOf(dataConnectionId)).toBeNull();
+	});
+
+	it("rejects agent_id on an action that lacks it instead of silently dropping it", async () => {
+		await expect(
+			workspace.owner.connections.manage({
+				action: "get",
+				connection_id: chatConnectionId,
+				agent_id: agentB,
+			}),
+		).rejects.toThrow(/unknown argument\(s\): agent_id/);
+	});
+
+	it("denies a member (non-admin) who owns the connection but is not an admin from setting agent_id", async () => {
+		// A chat connection OWNED BY THE MEMBER. `update` is member-writable and
+		// the member owns this row, so they pass the ownership gate — but
+		// reassigning the fallback agent is channel-binding-tier authority, so
+		// it must still be refused. Otherwise the member could point their
+		// connection's fallback at another member's agent (an escalation
+		// bind_channel forbids).
+		const memberRuntimeId = "agentfb-member-1";
+		await orgContext.run({ organizationId: orgId }, () =>
+			(
+				manager as unknown as { connectionStore: { saveConnection: (c: unknown) => Promise<void> } }
+			).connectionStore.saveConnection({
+				id: memberRuntimeId,
+				platform: "slack",
+				agentId: agentA,
+				organizationId: orgId,
+				config: { platform: "slack", botToken: "secret://member-1" },
+				settings: { allowGroups: true },
+				metadata: { teamId: "TMEMBER1", teamName: "Member FB" },
+				status: "active",
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			}),
+		);
+		const rows = (await getDb()`
+			SELECT id FROM connections
+			WHERE organization_id = ${orgId} AND slug = ${`agentconn-${memberRuntimeId}`}
+		`) as Array<{ id: number }>;
+		const memberConnId = Number(rows[0].id);
+		await getDb()`
+			UPDATE connections SET created_by = ${workspace.users.member.id}
+			WHERE id = ${memberConnId}
+		`;
+
+		const before = await agentIdOf(memberConnId);
+		const result = (await workspace.member.connections.update({
+			connection_id: memberConnId,
+			agent_id: agentB,
+		})) as { error?: string };
+		expect(result.error).toMatch(/Only admins can set/);
+		// Row untouched — the escalation was blocked before any write.
+		expect(await agentIdOf(memberConnId)).toBe(before);
+	});
+
+	it("a warm instance routes to the NEW agent after an agentId-only update (shared reference mutated in place)", async () => {
+		// The message-handler bridge captures the instance's `connection` object
+		// at start time and reads `connection.agentId` per inbound message. Seed
+		// a warm instance whose connection object we hold a reference to — the
+		// same reference the bridge would hold — then run an agentId-only update
+		// and assert THAT object now carries the new agent. If updateConnection
+		// replaced the reference instead of mutating in place, the captured
+		// object (and thus the live bridge) would keep routing to the old agent.
+		const instances = (
+			manager as unknown as { instances: Map<string, { connection: PlatformConnection; rowVersion: number }> }
+		).instances;
+
+		// Reset the fallback to agentA, then register the warm instance holding
+		// the current runtime connection (as the bridge would).
+		await workspace.owner.connections.update({
+			connection_id: chatConnectionId,
+			agent_id: agentA,
+		});
+		const warmConnection = (await manager.getConnection(
+			RUNTIME_ID,
+		)) as PlatformConnection;
+		expect(warmConnection.agentId).toBe(agentA);
+		// A warm instance holds PLAINTEXT credentials resolved at startup — the
+		// store row holds `secret://` refs. Stamp a plaintext token to prove the
+		// update path leaves the warm config alone (no secret:// clobber).
+		(warmConnection.config as Record<string, unknown>).botToken =
+			"xoxb-plaintext-live-token";
+		const configRef = warmConnection.config;
+		instances.set(RUNTIME_ID, {
+			connection: warmConnection,
+			rowVersion: warmConnection.updatedAt,
+		});
+
+		try {
+			await workspace.owner.connections.update({
+				connection_id: chatConnectionId,
+				agent_id: agentB,
+			});
+			// Same object reference the bridge holds now sees the new agent.
+			expect(warmConnection.agentId).toBe(agentB);
+			expect(instances.get(RUNTIME_ID)?.connection).toBe(warmConnection);
+			// Config untouched — still the plaintext token, not a secret:// ref.
+			// (A blanket Object.assign from storage would have overwritten it.)
+			expect(warmConnection.config).toBe(configRef);
+			expect(
+				(warmConnection.config as Record<string, unknown>).botToken,
+			).toBe("xoxb-plaintext-live-token");
+
+			// Clearing to null must also propagate to the captured reference.
+			await workspace.owner.connections.update({
+				connection_id: chatConnectionId,
+				agent_id: null,
+			});
+			expect(warmConnection.agentId).toBeUndefined();
+			expect(
+				(warmConnection.config as Record<string, unknown>).botToken,
+			).toBe("xoxb-plaintext-live-token");
+		} finally {
+			instances.delete(RUNTIME_ID);
+		}
+	});
+
+	it("sets agent_id on a MANAGED connection without reclassifying it to BYO", async () => {
+		const before = await connRow(managedConnectionId);
+		expect(before.credential_mode).toBe("managed");
+
+		const result = (await workspace.owner.connections.update({
+			connection_id: managedConnectionId,
+			agent_id: agentB,
+		})) as { action?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.action).toBe("update");
+
+		expect(await agentIdOf(managedConnectionId)).toBe(agentB);
+		// The whole point: still MANAGED. A store-forced "byo" here would later
+		// skip revokeManagedConnection on delete (leaking install creds).
+		const after = await connRow(managedConnectionId);
+		expect(after.credential_mode).toBe("managed");
+	});
+
+	it("rejects an empty-string agent_id instead of destructively clearing", async () => {
+		// Seed a known fallback, then attempt an empty-string update. "" is a
+		// falsy string Type.String() permits; without an explicit guard it would
+		// skip the existence check and clear the fallback. Contract: only null
+		// clears.
+		await workspace.owner.connections.update({
+			connection_id: chatConnectionId,
+			agent_id: agentA,
+		});
+		expect(await agentIdOf(chatConnectionId)).toBe(agentA);
+
+		const result = (await workspace.owner.connections.update({
+			connection_id: chatConnectionId,
+			agent_id: "",
+		})) as { error?: string };
+		expect(result.error).toMatch(/non-empty/);
+		// Fallback untouched — not cleared.
+		expect(await agentIdOf(chatConnectionId)).toBe(agentA);
+	});
+
+	// The credential_mode-preserve read must be scoped to the LIVE row. Slug
+	// uniqueness holds only for live rows, so a same-slug TOMBSTONE of the
+	// OPPOSITE mode must never be the row whose credential_mode gets preserved
+	// — otherwise an agent_id update reclassifies the live connection.
+	describe("same-slug opposite-mode tombstone does not reclassify the live row", () => {
+		// Seed a deleted row + a live row sharing one slug, then set agent_id on
+		// the live connection and return its credential_mode afterward.
+		async function seedPairAndUpdate(
+			slug: string,
+			tombstoneMode: "managed" | "byo",
+			liveMode: "managed" | "byo",
+		): Promise<string | null> {
+			const sql = getDb();
+			// Tombstone: same slug, opposite mode, soft-deleted.
+			await sql`
+				INSERT INTO connections (
+					organization_id, connector_key, external_tenant_id, agent_id,
+					display_name, status, config, credential_mode, slug, visibility,
+					deleted_at, created_at, updated_at
+				) VALUES (
+					${orgId}, 'slack', ${`tenant-tomb-${slug}`}, ${agentA},
+					'Tombstone', 'active', ${sql.json({ platform: "slack" })},
+					${tombstoneMode}, ${slug}, 'org', now(), now(), now()
+				)
+			`;
+			// Live row: same slug, the mode we must preserve.
+			const liveRows = (await sql`
+				INSERT INTO connections (
+					organization_id, connector_key, external_tenant_id, agent_id,
+					display_name, status, config, credential_mode, slug, visibility,
+					created_at, updated_at
+				) VALUES (
+					${orgId}, 'slack', ${`tenant-live-${slug}`}, ${agentA},
+					'Live', 'active', ${sql.json({ platform: "slack", botToken: "secret://live" })},
+					${liveMode}, ${slug}, 'org', now(), now()
+				)
+				RETURNING id
+			`) as Array<{ id: number }>;
+			const liveId = Number(liveRows[0].id);
+
+			const result = (await workspace.owner.connections.update({
+				connection_id: liveId,
+				agent_id: agentB,
+			})) as { error?: string };
+			expect(result.error).toBeUndefined();
+			expect(await agentIdOf(liveId)).toBe(agentB);
+			return (await connRow(liveId)).credential_mode;
+		}
+
+		it("live BYO + managed tombstone stays BYO", async () => {
+			const mode = await seedPairAndUpdate(
+				"agentconn-tomb-byo-live",
+				"managed",
+				"byo",
+			);
+			expect(mode).toBe("byo");
+		});
+
+		it("live managed + byo tombstone stays managed (else finding #1 reopens)", async () => {
+			const mode = await seedPairAndUpdate(
+				"slackinst-tomb-managed-live",
+				"byo",
+				"managed",
+			);
+			expect(mode).toBe("managed");
+		});
+	});
+});

--- a/packages/server/src/__tests__/integration/connectors/connection-agent-id-update.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-agent-id-update.test.ts
@@ -87,6 +87,9 @@ describe("manage_connections update — chat fallback agent_id", () => {
 	let dataConnectionId: number;
 	let managedConnectionId: number;
 	let manager: ChatInstanceManager;
+	let connStore: ReturnType<typeof createPostgresAgentConnectionStore>;
+	let installStore: ReturnType<typeof createPostgresAppInstallationStore>;
+	let managedSecretStore: SecretStoreRegistry;
 
 	beforeAll(async () => {
 		process.env.ENCRYPTION_KEY = ENCRYPTION_KEY;
@@ -97,10 +100,10 @@ describe("manage_connections update — chat fallback agent_id", () => {
 
 		// Real manager + real Postgres store, injected via the test seam — the
 		// full persistence chain (manager → store → connections projection) runs.
-		const store = createPostgresAgentConnectionStore();
+		connStore = createPostgresAgentConnectionStore();
 		manager = new ChatInstanceManager();
 		(manager as unknown as { connectionStore: unknown }).connectionStore =
-			store;
+			connStore;
 		const pss = new PostgresSecretStore();
 		(manager as unknown as { services: unknown }).services = {
 			getSecretStore: () => new SecretStoreRegistry(pss, { secret: pss }),
@@ -109,7 +112,7 @@ describe("manage_connections update — chat fallback agent_id", () => {
 
 		// A BYO chat connection whose fallback agent starts as agentA.
 		await orgContext.run({ organizationId: orgId }, () =>
-			store.saveConnection({
+			connStore.saveConnection({
 				id: RUNTIME_ID,
 				platform: "slack",
 				agentId: agentA,
@@ -145,8 +148,8 @@ describe("manage_connections update — chat fallback agent_id", () => {
 		// on it (no full config), so `update` must set its fallback agent WITHOUT
 		// reclassifying it to BYO.
 		const pss2 = new PostgresSecretStore();
-		const managedSecretStore = new SecretStoreRegistry(pss2, { secret: pss2 });
-		const installStore = createPostgresAppInstallationStore();
+		managedSecretStore = new SecretStoreRegistry(pss2, { secret: pss2 });
+		installStore = createPostgresAppInstallationStore();
 		const installRow = await upsertSlackInstallByTeam(
 			installStore,
 			managedSecretStore,
@@ -433,4 +436,152 @@ describe("manage_connections update — chat fallback agent_id", () => {
 			expect(mode).toBe("managed");
 		});
 	});
+
+	it("a managed reinstall preserves the configured fallback agent_id; explicit null still clears", async () => {
+		// Configure the fallback via the real update path — the exact scenario
+		// PR1 exists for.
+		const set = (await workspace.owner.connections.update({
+			connection_id: managedConnectionId,
+			agent_id: agentA,
+		})) as { error?: string };
+		expect(set.error).toBeUndefined();
+		expect(await agentIdOf(managedConnectionId)).toBe(agentA);
+
+		// The workspace reinstalls (same team, fresh token). A reinstall carries
+		// NO agent-routing intent, so it must not touch the fallback.
+		await upsertSlackInstallByTeam(
+			installStore,
+			managedSecretStore,
+			orgId,
+			"TMANAGED1",
+			{
+				teamName: "Managed Co",
+				botUserId: "U-MGD",
+				botToken: "xoxb-managed-reinstalled",
+			},
+		);
+		expect(await agentIdOf(managedConnectionId)).toBe(agentA);
+		// Still the same live row, still managed.
+		expect((await connRow(managedConnectionId)).credential_mode).toBe(
+			"managed",
+		);
+
+		// An EXPLICIT clear (agent_id: null) must still null the column — the
+		// preserve applies only to writes that carry no agent_id intent.
+		const clear = (await workspace.owner.connections.update({
+			connection_id: managedConnectionId,
+			agent_id: null,
+		})) as { error?: string };
+		expect(clear.error).toBeUndefined();
+		expect(await agentIdOf(managedConnectionId)).toBeNull();
+
+		// …and a reinstall on an intentionally-cleared fallback keeps it cleared
+		// (preserve must not resurrect a value from nowhere).
+		await upsertSlackInstallByTeam(
+			installStore,
+			managedSecretStore,
+			orgId,
+			"TMANAGED1",
+			{
+				teamName: "Managed Co",
+				botUserId: "U-MGD",
+				botToken: "xoxb-managed-reinstalled-2",
+			},
+		);
+		expect(await agentIdOf(managedConnectionId)).toBeNull();
+	});
+
+	it("saveConnection takes the tenant advisory lock BEFORE the row lock (no deadlock against a managed reinstall)", async () => {
+		// Lock-order contract: every chat-connection write path acquires the
+		// tenant ADVISORY lock first, THEN connections row locks. The managed
+		// reinstall path (upsertChatConnectionProjection) is advisory → row;
+		// if saveConnection row-locked first (FOR UPDATE) and only then reached
+		// the projection's advisory lock, a concurrent update + reinstall would
+		// deadlock. This test holds the advisory lock the way a reinstall does,
+		// runs the REAL saveConnection until it blocks on that lock, then takes
+		// the row lock the reinstall would take next: with the inverted order
+		// saveConnection already holds the row ⇒ Postgres aborts one txn with
+		// "deadlock detected"; with the fixed order it holds nothing ⇒ clean.
+		const sql = getDb();
+		const runtimeId = "agentfb-lockorder-1";
+		const lockSlug = `agentconn-${runtimeId}`;
+		const teamId = "TLOCK1";
+		const seed = (agentId: string) => ({
+			id: runtimeId,
+			platform: "slack",
+			agentId,
+			organizationId: orgId,
+			config: { platform: "slack", botToken: "secret://lockorder-1" },
+			settings: { allowGroups: true },
+			metadata: { teamId, teamName: "Lock Order" },
+			status: "active" as const,
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		});
+		await orgContext.run({ organizationId: orgId }, () =>
+			connStore.saveConnection(seed(agentA)),
+		);
+
+		// Same key derivation as chatTenantAdvisoryLockKey / the projection.
+		const lockKey = `chatconn:${orgId}:slack:${teamId}`;
+		// int8 advisory locks surface in pg_locks as classid = high 32 bits,
+		// objid = low 32 bits of the (sign-extended) hashtext key.
+		const waitingOnAdvisory = async (): Promise<boolean> => {
+			const rows = (await sql`
+				WITH k AS (SELECT hashtext(${lockKey})::bigint AS key)
+				SELECT 1 FROM pg_locks, k
+				WHERE locktype = 'advisory' AND NOT granted
+				  AND classid::bigint = ((k.key >> 32) & 4294967295)
+				  AND objid::bigint = (k.key & 4294967295)
+			`) as unknown[];
+			return rows.length > 0;
+		};
+
+		let advisoryHeld!: () => void;
+		const advisoryHeldGate = new Promise<void>((resolve) => {
+			advisoryHeld = resolve;
+		});
+		let reinstallProceed!: () => void;
+		const reinstallGate = new Promise<void>((resolve) => {
+			reinstallProceed = resolve;
+		});
+
+		// T2 — the reinstall's exact lock sequence: advisory tenant lock, then
+		// the connections row.
+		const reinstallTxn = sql.begin(async (tx: typeof sql) => {
+			await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
+				lockKey,
+			]);
+			advisoryHeld();
+			await reinstallGate;
+			await tx`
+				UPDATE connections SET updated_at = now()
+				WHERE organization_id = ${orgId} AND slug = ${lockSlug}
+				  AND deleted_at IS NULL
+			`;
+		});
+		await advisoryHeldGate;
+
+		// T1 — the REAL fallback-agent update write path.
+		const updateTxn = orgContext.run({ organizationId: orgId }, () =>
+			connStore.saveConnection(seed(agentB)),
+		);
+
+		// Wait until T1 is provably blocked on the advisory lock T2 holds.
+		for (let i = 0; i < 200 && !(await waitingOnAdvisory()); i += 1) {
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+		expect(await waitingOnAdvisory()).toBe(true);
+
+		// Now T2 takes its row lock. Inverted order ⇒ deadlock detected here.
+		reinstallProceed();
+		await reinstallTxn;
+		await updateTxn;
+
+		const rows = (await sql`
+			SELECT agent_id FROM connections
+			WHERE organization_id = ${orgId} AND slug = ${lockSlug}
+		`) as Array<{ agent_id: string | null }>;
+		expect(rows[0]?.agent_id).toBe(agentB);
+	}, 30_000);
 });

--- a/packages/server/src/__tests__/integration/connectors/connection-agent-id-update.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-agent-id-update.test.ts
@@ -617,8 +617,10 @@ describe("manage_connections update — chat fallback agent_id", () => {
 			createdAt: Date.now(),
 			updatedAt: Date.now(),
 		});
-		// Seed as MANAGED so saveConnection's credential_mode peek sees 'managed'
-		// and takes the managed-global lock (a BYO row would correctly skip it).
+		// Seed as MANAGED. saveConnection now pre-acquires the managed-global lock
+		// for EVERY active tenant-bound write (mode-independent), so both a
+		// managed and a BYO row would take it — this case keeps the managed
+		// variant; the BYO variant is covered by the lock-presence test below.
 		await sql`
 			INSERT INTO connections (
 				organization_id, connector_key, external_tenant_id, agent_id,
@@ -694,5 +696,117 @@ describe("manage_connections update — chat fallback agent_id", () => {
 		expect(rows[0]?.agent_id).toBe(agentB);
 		// Still managed — the write preserved credential_mode.
 		expect(rows[0]?.credential_mode).toBe("managed");
+	}, 30_000);
+
+	it("a BYO tenant-bound saveConnection acquires chatconn:managed BEFORE it row-locks the target (mode-independent pre-acquire closes the peek TOCTOU)", async () => {
+		// The managed-global lock must be taken by EVERY active tenant-bound write
+		// regardless of credential_mode. A lock-free peek at the mode was a
+		// TOCTOU: a concurrent managed install could flip a byo/empty row to
+		// managed between the peek and the FOR UPDATE; the projection (now
+		// managed) then takes chatconn:managed while this txn already holds the
+		// target row ⇒ the cross-org cycle reopens.
+		//
+		// The distinguishing property is ORDER: post-fix a BYO write takes
+		// chatconn:managed BEFORE it row-locks the target; pre-fix (byo peek) it
+		// row-locks the target first and only reaches chatconn:managed inside the
+		// projection. Isolate that: hold the TARGET ROW lock in a manual txn and
+		// run the REAL BYO saveConnection. Post-fix it parks on the ROW while
+		// already HOLDING chatconn:managed ⇒ a probe txn canNOT acquire
+		// chatconn:managed (a conditional pg_try_advisory_xact_lock fails).
+		// Pre-fix it parks on the ROW WITHOUT holding chatconn:managed ⇒ the
+		// probe WOULD succeed. This asserts the managed lock is held while the
+		// BYO write waits on the row — the exact ordering guarantee, isolated
+		// from the projection's own (later) acquire.
+		const sql = getDb();
+		const teamId = "TBYOLOCK1";
+		const runtimeId = "agentfb-byolock-1";
+		const byoSlug = `agentconn-${runtimeId}`;
+		const managedKey = `chatconn:managed:slack:${teamId}`;
+
+		// Seed the row so the manual holder can row-lock it (and so the BYO
+		// saveConnection updates rather than inserts — an INSERT takes no
+		// pre-existing row lock to contend on).
+		await sql`
+			INSERT INTO connections (
+				organization_id, connector_key, external_tenant_id, agent_id,
+				display_name, status, config, credential_mode, slug, visibility,
+				created_at, updated_at
+			) VALUES (
+				${orgId}, 'slack', ${teamId}, ${agentA},
+				'BYO Lock', 'active', ${sql.json({ platform: "slack", botToken: "secret://byolock-1" })},
+				'byo', ${byoSlug}, 'org', now(), now()
+			)
+		`;
+
+		let rowHeldGate!: () => void;
+		const rowHeld = new Promise<void>((resolve) => {
+			rowHeldGate = resolve;
+		});
+		let releaseRow!: () => void;
+		const release = new Promise<void>((resolve) => {
+			releaseRow = resolve;
+		});
+		// Holder txn: lock the TARGET ROW, signal, then wait.
+		const holderTxn = sql.begin(async (tx: typeof sql) => {
+			await tx`
+				SELECT id FROM connections
+				WHERE organization_id = ${orgId} AND slug = ${byoSlug}
+				  AND deleted_at IS NULL
+				FOR UPDATE
+			`;
+			rowHeldGate();
+			await release;
+		});
+		await rowHeld;
+
+		// The REAL BYO write (existing byo row ⇒ credential_mode peeks/reads byo).
+		const byoWrite = orgContext.run({ organizationId: orgId }, () =>
+			connStore.saveConnection({
+				id: runtimeId,
+				platform: "slack",
+				agentId: agentB,
+				organizationId: orgId,
+				config: { platform: "slack", botToken: "secret://byolock-1" },
+				settings: { allowGroups: true },
+				metadata: { teamId, teamName: "BYO Lock" },
+				status: "active",
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			}),
+		);
+
+		// Wait until the BYO write is provably blocked on the target ROW the
+		// holder owns (ShareLock on the tuple / the holder's xid).
+		const blockedOnRow = async (): Promise<boolean> => {
+			const r = (await sql`
+				SELECT 1 FROM pg_locks
+				WHERE locktype IN ('tuple', 'transactionid')
+				  AND NOT granted
+			`) as unknown[];
+			return r.length > 0;
+		};
+		for (let i = 0; i < 200 && !(await blockedOnRow()); i += 1) {
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+		expect(await blockedOnRow()).toBe(true);
+
+		// While the BYO write waits on the row, probe chatconn:managed with a
+		// CONDITIONAL lock. Post-fix the BYO write already HOLDS it ⇒ probe fails
+		// (false). Pre-fix (byo peek skipped it) ⇒ probe would succeed (true).
+		const probe = (await sql`
+			SELECT pg_try_advisory_xact_lock(hashtext(${managedKey})) AS got
+		`) as Array<{ got: boolean }>;
+		expect(probe[0]?.got).toBe(false);
+
+		releaseRow();
+		await holderTxn;
+		await byoWrite;
+
+		const rows = (await sql`
+			SELECT credential_mode, agent_id FROM connections
+			WHERE organization_id = ${orgId} AND slug = ${byoSlug}
+		`) as Array<{ credential_mode: string | null; agent_id: string | null }>;
+		expect(rows[0]?.credential_mode).toBe("byo");
+		expect(rows[0]?.agent_id).toBe(agentB);
 	}, 30_000);
 });

--- a/packages/server/src/__tests__/unit/validate-args.test.ts
+++ b/packages/server/src/__tests__/unit/validate-args.test.ts
@@ -68,12 +68,70 @@ describe("validateToolArgs coercion", () => {
     expect(() => validateToolArgs("t", optSchema, { note: null })).toThrow(ToolUserError);
   });
 
-  it("rejects unknown properties only under additionalProperties:false", () => {
+  it("rejects unknown top-level keys, naming them and the valid set", () => {
+    // TypeBox Type.Object accepts extra keys, so an unknown argument used to
+    // be silently dropped — the call "succeeded" while ignoring the caller's
+    // intent (e.g. agent_id passed to an action that lacked it).
     const strict = Type.Object({ a: Type.String() }, { additionalProperties: false });
     const open = Type.Object({ a: Type.String() });
     expect(() => validateToolArgs("t", strict, { a: "x", extra: 1 })).toThrow(ToolUserError);
-    const out = validateToolArgs("t", open, { a: "x", extra: 1 }) as Record<string, unknown>;
+    let caught: unknown;
+    try {
+      validateToolArgs("t", open, { a: "x", extra: 1 });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ToolUserError);
+    const msg = (caught as ToolUserError).message;
+    expect(msg).toMatch(/unknown argument\(s\): extra/);
+    expect(msg).toMatch(/valid arguments are: a/);
+  });
+
+  it("rejects Object.prototype-named keys (constructor, toString) — no prototype-chain false accept", () => {
+    // `key in properties` would walk Object.prototype and wrongly accept these
+    // as "known" keys; Object.hasOwn does not.
+    const s = Type.Object({ a: Type.String() });
+    for (const bad of ["constructor", "toString", "hasOwnProperty"]) {
+      let caught: unknown;
+      try {
+        validateToolArgs("t", s, { a: "x", [bad]: 1 });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(ToolUserError);
+      expect((caught as ToolUserError).message).toMatch(
+        new RegExp(`unknown argument\\(s\\): ${bad}`)
+      );
+    }
+  });
+
+  it("rejects a JSON __proto__ key as unknown and does not pollute the prototype", () => {
+    // JSON.parse produces `__proto__` as an OWN enumerable property (unlike a
+    // JS object literal, which sets the prototype). normalizeArgs must copy it
+    // as a real own key (via defineProperty), not through `obj[k] =` which
+    // would invoke the __proto__ setter and mutate the prototype — hiding it
+    // from Object.keys so rejectUnknownKeys can't reject it.
+    const s = Type.Object({ a: Type.String() });
+    const payload = JSON.parse('{"a":"x","__proto__":{"polluted":"yes"}}');
+    let caught: unknown;
+    try {
+      validateToolArgs("t", s, payload);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ToolUserError);
+    expect((caught as ToolUserError).message).toMatch(/unknown argument\(s\): __proto__/);
+    // No prototype pollution occurred.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("still passes extra keys through passthrough schemas (additionalProperties / Record)", () => {
+    const passthrough = Type.Object({ a: Type.String() }, { additionalProperties: true });
+    const out = validateToolArgs("t", passthrough, { a: "x", extra: 1 }) as Record<string, unknown>;
     expect(out.extra).toBe(1);
+    const record = Type.Record(Type.String(), Type.Number());
+    const rec = validateToolArgs("t", record, { anything: 2 }) as Record<string, unknown>;
+    expect(rec.anything).toBe(2);
   });
 
   it("accepts a valid uuid format and rejects a bad one", () => {
@@ -100,13 +158,31 @@ describe("validateToolArgs union variant dispatch", () => {
     expect(out.id).toBe(5);
   });
 
-  it("tolerates fields from other variants (flattened advertised schema)", () => {
-    const out = validateToolArgs("t", union, {
-      action: "create",
-      name: "x",
-      id: 99,
-    }) as Record<string, unknown>;
-    expect(out.name).toBe("x");
+  it("rejects a field from ANOTHER variant, naming the matched action's valid args", () => {
+    // `id` belongs to the delete variant; passing it to create used to be
+    // silently dropped. The unknown-key check runs against the MATCHED
+    // variant's properties (post-dispatch), so the error names the action
+    // and its actual argument set.
+    let caught: unknown;
+    try {
+      validateToolArgs("t", union, { action: "create", name: "x", id: 99 });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ToolUserError);
+    const msg = (caught as ToolUserError).message;
+    expect(msg).toMatch(/unknown argument\(s\): id/);
+    expect(msg).toMatch(/action 'create'/);
+    expect(msg).toMatch(/name/);
+  });
+
+  it("accepts every declared arg of the matched variant, action key included (no flattened-union false positive)", () => {
+    const out = validateToolArgs("t", union, { action: "delete", id: 7 }) as Record<
+      string,
+      unknown
+    >;
+    expect(out.action).toBe("delete");
+    expect(out.id).toBe(7);
   });
 
   it("reports the variant's missing field, not a union blob", () => {

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -295,6 +295,8 @@ export async function updateChatConnection(input: {
 	organizationId: string;
 	connectionId: number;
 	displayName?: string;
+	/** Fallback agent for the chat runtime; `null` clears it, `undefined` leaves it untouched. */
+	agentId?: string | null;
 	config?: Record<string, unknown>;
 	status?: string;
 }): Promise<void> {
@@ -323,12 +325,20 @@ export async function updateChatConnection(input: {
 		const providerMetadata = await validateProviderIdentity(config);
 		await orgContext.run({ organizationId: input.organizationId }, () =>
 			manager.updateConnection(runtimeId, {
+				...(input.agentId !== undefined ? { agentId: input.agentId } : {}),
 				config,
 				metadata: {
 					...providerMetadata,
 					...(input.displayName ? { teamName: input.displayName } : {}),
 				},
 			}),
+		);
+	} else if (input.agentId !== undefined) {
+		// agentId-only update: no config change, so no restart is needed — the
+		// manager persists the new fallback agent and refreshes any warm
+		// in-memory instance in place.
+		await orgContext.run({ organizationId: input.organizationId }, () =>
+			manager.updateConnection(runtimeId, { agentId: input.agentId }),
 		);
 	}
 	if (input.status === "active") {

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -779,7 +779,38 @@ export class ChatInstanceManager {
     } else {
       const instance = this.instances.get(id);
       if (instance) {
-        instance.connection = connection;
+        // Mutate the EXISTING connection object in place (never replace the
+        // reference): registerMessageHandlers captured this same object at
+        // start time and reads `this.connection.agentId` per message, so a
+        // fresh object here would orphan that reference and the fallback-agent
+        // change would not take effect on a warm pod until an unrelated
+        // restart.
+        //
+        // Apply ONLY the fields that changed — NEVER a blanket
+        // `Object.assign(warm, fromStore)`. This branch runs with
+        // `needsRestart === false`, i.e. config did not meaningfully change,
+        // and the warm instance's `config` holds the PLAINTEXT credentials
+        // resolved at startup (`startInstanceUnscoped` → resolveConfigForRuntime)
+        // while the store's `connection.config` holds `secret://` refs.
+        // Copying config over (and then bumping rowVersion so it won't
+        // rehydrate) would make the live adapter read `secret://…` as the
+        // actual bot token. So propagate agentId / settings / metadata and
+        // leave the runtime config untouched.
+        const warm = instance.connection;
+        if (updates.agentId !== undefined) {
+          if (updates.agentId) {
+            warm.agentId = updates.agentId;
+          } else {
+            delete warm.agentId;
+          }
+        }
+        if (updates.settings !== undefined) {
+          warm.settings = { ...warm.settings, ...updates.settings };
+        }
+        if (updates.metadata !== undefined) {
+          warm.metadata = { ...(warm.metadata || {}), ...updates.metadata };
+        }
+        warm.updatedAt = connection.updatedAt;
         instance.rowVersion = reread.updatedAt;
       }
     }

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -779,23 +779,15 @@ export class ChatInstanceManager {
     } else {
       const instance = this.instances.get(id);
       if (instance) {
-        // Mutate the EXISTING connection object in place (never replace the
-        // reference): registerMessageHandlers captured this same object at
-        // start time and reads `this.connection.agentId` per message, so a
-        // fresh object here would orphan that reference and the fallback-agent
-        // change would not take effect on a warm pod until an unrelated
-        // restart.
-        //
-        // Apply ONLY the fields that changed — NEVER a blanket
-        // `Object.assign(warm, fromStore)`. This branch runs with
-        // `needsRestart === false`, i.e. config did not meaningfully change,
-        // and the warm instance's `config` holds the PLAINTEXT credentials
-        // resolved at startup (`startInstanceUnscoped` → resolveConfigForRuntime)
-        // while the store's `connection.config` holds `secret://` refs.
-        // Copying config over (and then bumping rowVersion so it won't
-        // rehydrate) would make the live adapter read `secret://…` as the
-        // actual bot token. So propagate agentId / settings / metadata and
-        // leave the runtime config untouched.
+        // Mutate the EXISTING connection object in place: message handlers
+        // captured this object at start time, so replacing the reference would
+        // hide the change from them until an unrelated restart. And never copy
+        // `config` here (no blanket Object.assign): this branch means config
+        // didn't meaningfully change, and the warm instance's config holds
+        // PLAINTEXT credentials resolved at startup while the store row holds
+        // `secret://` refs — clobbering it would make the live adapter read
+        // `secret://…` as the bot token. Only agentId / settings / metadata
+        // propagate.
         const warm = instance.connection;
         if (updates.agentId !== undefined) {
           if (updates.agentId) {

--- a/packages/server/src/lobu/gateway.ts
+++ b/packages/server/src/lobu/gateway.ts
@@ -601,6 +601,15 @@ export function getChatInstanceManager(): any {
 	return chatInstanceManager;
 }
 
+/**
+ * Test-only seam: inject a ChatInstanceManager without full gateway startup
+ * (the integration suite runs `isolate:false`, where vi.mock on shared
+ * singletons is unreliable — see app-installation-credential.test.ts).
+ */
+export function __setChatInstanceManagerForTests(manager: unknown): void {
+	chatInstanceManager = manager;
+}
+
 export function getLobuCoreServices(): any {
 	return coreServices;
 }

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -139,26 +139,31 @@ export function chatTenantAdvisoryLockKey(
 }
 
 /**
- * Advisory-lock key for the GLOBAL managed-workspace tuple — the SECOND lock a
- * MANAGED write takes (org-specific `chatTenantAdvisoryLockKey` FIRST, then this
- * one), serializing the cross-org transfer/demote of a Slack team across ALL
- * orgs (hence org-independent, unlike the per-org key). Managed-only: BYO
- * connections legitimately coexist cross-org and must NOT take it. Returns null
- * when `credentialMode !== 'managed'` or the write is not a tenant-bound
- * activation. Every writer that reaches the managed demote (the projection) OR
- * pre-acquires to keep the global lock order intact (saveConnection) derives its
- * key HERE so the two can never drift.
+ * Advisory-lock key for the GLOBAL managed-workspace tuple — the SECOND lock in
+ * a chat write's lock order (org-specific `chatTenantAdvisoryLockKey` FIRST,
+ * then this one), serializing the cross-org transfer/demote of a workspace
+ * across ALL orgs (hence org-independent, unlike the per-org key).
+ *
+ * The KEY is MODE-INDEPENDENT — it names a (platform, tenant) workspace, not a
+ * credential mode. Only the ACT of demoting other orgs' rows is managed-only
+ * (see the projection's demote block), but the LOCK ORDER must be honored by
+ * every active tenant-bound write regardless of mode: a BYO write that later
+ * turns out to race a managed transfer must already hold this lock before it
+ * row-locks anything, or the advisory↔row cycle reopens. So this returns the
+ * key for ANY active tenant-bound write. Over-acquiring on a BYO write only
+ * serializes it against managed writes on the same tenant (harmless); the
+ * danger is UNDER-acquiring. Returns null only when the write is not an active
+ * tenant-bound activation (paused / tenantless — takes no advisory lock at
+ * all). Both the projection and saveConnection derive the key HERE so they
+ * can never drift.
  */
 export function managedTenantAdvisoryLockKey(
   conn: StoredConnection,
-  credentialMode: ChatCredentialMode,
 ): string | null {
   const rawTeamId = conn.metadata?.teamId;
   const externalTenantId =
     typeof rawTeamId === "string" && rawTeamId.length > 0 ? rawTeamId : null;
-  return credentialMode === "managed" &&
-    legacyStatusToConnections(conn.status) === "active" &&
-    externalTenantId
+  return legacyStatusToConnections(conn.status) === "active" && externalTenantId
     ? `chatconn:managed:${conn.platform}:${externalTenantId}`
     : null;
 }
@@ -204,7 +209,7 @@ export async function upsertChatConnectionProjection(
   const externalTenantId =
     typeof rawTeamId === "string" && rawTeamId.length > 0 ? rawTeamId : null;
   const tenantLockKey = chatTenantAdvisoryLockKey(conn, orgId);
-  const managedLockKey = managedTenantAdvisoryLockKey(conn, credentialMode);
+  const managedLockKey = managedTenantAdvisoryLockKey(conn);
   const displayName =
     (typeof conn.metadata?.teamName === "string" && conn.metadata.teamName) ||
     conn.platform;
@@ -242,41 +247,50 @@ export async function upsertChatConnectionProjection(
       );
     }
 
-    // A MANAGED install binds a provider workspace (Slack team) to exactly ONE
+    // GLOBAL managed-workspace lock — the SECOND advisory lock, held before ANY
+    // other-org row is touched. Acquire it for EVERY active tenant-bound write
+    // (managedLockKey is mode-independent), not just managed writes: the lock
+    // order (org-advisory → managed-advisory → rows) must be identical on every
+    // path, or a BYO write that races a managed transfer inverts against it.
+    // Over-acquiring on a BYO write only serializes it with managed writes on
+    // the same tenant (harmless). The DEMOTE, however, is managed-only: a
+    // MANAGED install binds a provider workspace (Slack team) to exactly ONE
     // org — the OAuth install moves with the workspace. On a reinstall/transfer
     // of the same team into a different org, the old org's managed projection
     // would otherwise stay 'active', leaving a stale routing/ACL row for a team
-    // this org no longer owns. Demote any OTHER org's active managed projection
-    // for this team (global tenant lock so it serializes cross-replica). BYO
-    // connections can legitimately coexist cross-org, so this is managed-only.
+    // this org no longer owns. So demote any OTHER org's active managed
+    // projection ONLY when THIS write is itself managed; BYO connections can
+    // legitimately coexist cross-org and must not demote anyone.
     if (managedLockKey) {
       await sql.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
         managedLockKey,
       ]);
-      const transferred = await sql`
-        UPDATE connections SET status = 'paused', updated_at = now()
-        WHERE connector_key = ${conn.platform}
-          AND external_tenant_id = ${externalTenantId}
-          AND credential_mode = 'managed'
-          AND status = 'active'
-          AND deleted_at IS NULL
-          AND organization_id <> ${orgId}
-        RETURNING slug, organization_id
-      `;
-      if (transferred.length > 0) {
-        logger.info(
-          {
-            orgId,
-            platform: conn.platform,
-            teamId: externalTenantId,
-            activated: slug,
-            demoted: transferred.map(
-              (r: { slug: string; organization_id: string }) =>
-                `${r.organization_id}:${r.slug}`,
-            ),
-          },
-          "Demoted stale managed install in another org (workspace transfer)",
-        );
+      if (credentialMode === "managed") {
+        const transferred = await sql`
+          UPDATE connections SET status = 'paused', updated_at = now()
+          WHERE connector_key = ${conn.platform}
+            AND external_tenant_id = ${externalTenantId}
+            AND credential_mode = 'managed'
+            AND status = 'active'
+            AND deleted_at IS NULL
+            AND organization_id <> ${orgId}
+          RETURNING slug, organization_id
+        `;
+        if (transferred.length > 0) {
+          logger.info(
+            {
+              orgId,
+              platform: conn.platform,
+              teamId: externalTenantId,
+              activated: slug,
+              demoted: transferred.map(
+                (r: { slug: string; organization_id: string }) =>
+                  `${r.organization_id}:${r.slug}`,
+              ),
+            },
+            "Demoted stale managed install in another org (workspace transfer)",
+          );
+        }
       }
     }
   }

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -139,6 +139,31 @@ export function chatTenantAdvisoryLockKey(
 }
 
 /**
+ * Advisory-lock key for the GLOBAL managed-workspace tuple — the SECOND lock a
+ * MANAGED write takes (org-specific `chatTenantAdvisoryLockKey` FIRST, then this
+ * one), serializing the cross-org transfer/demote of a Slack team across ALL
+ * orgs (hence org-independent, unlike the per-org key). Managed-only: BYO
+ * connections legitimately coexist cross-org and must NOT take it. Returns null
+ * when `credentialMode !== 'managed'` or the write is not a tenant-bound
+ * activation. Every writer that reaches the managed demote (the projection) OR
+ * pre-acquires to keep the global lock order intact (saveConnection) derives its
+ * key HERE so the two can never drift.
+ */
+export function managedTenantAdvisoryLockKey(
+  conn: StoredConnection,
+  credentialMode: ChatCredentialMode,
+): string | null {
+  const rawTeamId = conn.metadata?.teamId;
+  const externalTenantId =
+    typeof rawTeamId === "string" && rawTeamId.length > 0 ? rawTeamId : null;
+  return credentialMode === "managed" &&
+    legacyStatusToConnections(conn.status) === "active" &&
+    externalTenantId
+    ? `chatconn:managed:${conn.platform}:${externalTenantId}`
+    : null;
+}
+
+/**
  * Write-through: upsert the `connections` projection of a chat connection by
  * (org, slug), INSIDE the caller's transaction so a crash can never diverge the
  * two sources. The folded `config` carries the adapter config (with `secret://`
@@ -179,6 +204,7 @@ export async function upsertChatConnectionProjection(
   const externalTenantId =
     typeof rawTeamId === "string" && rawTeamId.length > 0 ? rawTeamId : null;
   const tenantLockKey = chatTenantAdvisoryLockKey(conn, orgId);
+  const managedLockKey = managedTenantAdvisoryLockKey(conn, credentialMode);
   const displayName =
     (typeof conn.metadata?.teamName === "string" && conn.metadata.teamName) ||
     conn.platform;
@@ -223,9 +249,9 @@ export async function upsertChatConnectionProjection(
     // this org no longer owns. Demote any OTHER org's active managed projection
     // for this team (global tenant lock so it serializes cross-replica). BYO
     // connections can legitimately coexist cross-org, so this is managed-only.
-    if (credentialMode === "managed") {
+    if (managedLockKey) {
       await sql.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
-        `chatconn:managed:${conn.platform}:${externalTenantId}`,
+        managedLockKey,
       ]);
       const transferred = await sql`
         UPDATE connections SET status = 'paused', updated_at = now()

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -115,6 +115,30 @@ export function connectionsRowToStored(
 }
 
 /**
+ * Advisory-lock key for a chat connection's tenant tuple — the FIRST lock in
+ * the global lock order for chat-connection writes (tenant advisory lock →
+ * `connections` row locks). Returns null when the write is not a tenant-bound
+ * activation (paused / tenantless), in which case no advisory lock is taken
+ * anywhere on the path. Every writer that row-locks a chat connection row
+ * (saveConnection's `FOR UPDATE`, this module's upsert/demote) must derive its
+ * guard AND key from THIS helper so the two can never drift — a writer that
+ * row-locks first and only then reaches the advisory lock inverts the order
+ * and deadlocks against a concurrent managed reinstall.
+ */
+export function chatTenantAdvisoryLockKey(
+  conn: StoredConnection,
+  orgId: string,
+): string | null {
+  const rawTeamId = conn.metadata?.teamId;
+  const externalTenantId =
+    typeof rawTeamId === "string" && rawTeamId.length > 0 ? rawTeamId : null;
+  return legacyStatusToConnections(conn.status) === "active" &&
+    externalTenantId
+    ? `chatconn:${orgId}:${conn.platform}:${externalTenantId}`
+    : null;
+}
+
+/**
  * Write-through: upsert the `connections` projection of a chat connection by
  * (org, slug), INSIDE the caller's transaction so a crash can never diverge the
  * two sources. The folded `config` carries the adapter config (with `secret://`
@@ -131,6 +155,15 @@ export function connectionsRowToStored(
  *
  * `sql` is the transaction handle; `jsonOf` builds a json-bound param from the
  * outer sql instance (postgres.js `sql.json`).
+ *
+ * `opts.preserveAgentId`: the fallback `agent_id` is ROUTING state set by an
+ * admin (`manage_connections update`), not connection state the caller owns —
+ * a managed reinstall re-persists tokens/config but carries NO agent-routing
+ * intent, and `StoredConnection.agentId === undefined` cannot distinguish
+ * "no intent" from an explicit clear (the manager deletes the key on clear).
+ * So the caller declares intent: with `preserveAgentId` the conflict UPDATE
+ * keeps the existing row's `agent_id` (a fresh insert still starts NULL);
+ * without it, `agent_id` is written from `conn.agentId` (set or clear).
  */
 export async function upsertChatConnectionProjection(
   sql: any,
@@ -138,12 +171,14 @@ export async function upsertChatConnectionProjection(
   conn: StoredConnection,
   orgId: string,
   credentialMode: ChatCredentialMode,
+  opts?: { preserveAgentId?: boolean },
 ): Promise<void> {
   const slug = runtimeConnectionIdToSlug(conn.id);
   const status = legacyStatusToConnections(conn.status);
   const rawTeamId = conn.metadata?.teamId;
   const externalTenantId =
     typeof rawTeamId === "string" && rawTeamId.length > 0 ? rawTeamId : null;
+  const tenantLockKey = chatTenantAdvisoryLockKey(conn, orgId);
   const displayName =
     (typeof conn.metadata?.teamName === "string" && conn.metadata.teamName) ||
     conn.platform;
@@ -155,7 +190,7 @@ export async function upsertChatConnectionProjection(
 
   if (status === "active" && externalTenantId) {
     await sql.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
-      `chatconn:${orgId}:${conn.platform}:${externalTenantId}`,
+      tenantLockKey,
     ]);
     const demoted = await sql`
       UPDATE connections SET status = 'paused', updated_at = now()
@@ -233,7 +268,11 @@ export async function upsertChatConnectionProjection(
     ON CONFLICT (organization_id, slug) WHERE deleted_at IS NULL DO UPDATE SET
       connector_key = EXCLUDED.connector_key,
       external_tenant_id = EXCLUDED.external_tenant_id,
-      agent_id = EXCLUDED.agent_id,
+      agent_id = ${
+        opts?.preserveAgentId
+          ? sql`connections.agent_id`
+          : sql`EXCLUDED.agent_id`
+      },
       display_name = EXCLUDED.display_name,
       status = EXCLUDED.status,
       config = EXCLUDED.config,

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -116,14 +116,15 @@ export function connectionsRowToStored(
 
 /**
  * Advisory-lock key for a chat connection's tenant tuple — the FIRST lock in
- * the global lock order for chat-connection writes (tenant advisory lock →
- * `connections` row locks). Returns null when the write is not a tenant-bound
- * activation (paused / tenantless), in which case no advisory lock is taken
- * anywhere on the path. Every writer that row-locks a chat connection row
- * (saveConnection's `FOR UPDATE`, this module's upsert/demote) must derive its
- * guard AND key from THIS helper so the two can never drift — a writer that
- * row-locks first and only then reaches the advisory lock inverts the order
- * and deadlocks against a concurrent managed reinstall.
+ * the universal order for chat-connection writes: org-tenant advisory →
+ * managed-workspace advisory (`managedTenantAdvisoryLockKey`) → only then any
+ * `connections` row lock. Returns null when the write is not an active
+ * tenant-bound activation (paused / tenantless), which takes no advisory lock
+ * anywhere. Every writer that row-locks a chat connection row (saveConnection's
+ * `FOR UPDATE`, this module's upsert/demotes) must derive its guard AND key
+ * from these helpers so they can never drift — row-locking before finishing
+ * the advisories inverts the order and deadlocks against a concurrent
+ * reinstall.
  */
 export function chatTenantAdvisoryLockKey(
   conn: StoredConnection,
@@ -139,23 +140,15 @@ export function chatTenantAdvisoryLockKey(
 }
 
 /**
- * Advisory-lock key for the GLOBAL managed-workspace tuple — the SECOND lock in
- * a chat write's lock order (org-specific `chatTenantAdvisoryLockKey` FIRST,
- * then this one), serializing the cross-org transfer/demote of a workspace
- * across ALL orgs (hence org-independent, unlike the per-org key).
- *
- * The KEY is MODE-INDEPENDENT — it names a (platform, tenant) workspace, not a
- * credential mode. Only the ACT of demoting other orgs' rows is managed-only
- * (see the projection's demote block), but the LOCK ORDER must be honored by
- * every active tenant-bound write regardless of mode: a BYO write that later
- * turns out to race a managed transfer must already hold this lock before it
- * row-locks anything, or the advisory↔row cycle reopens. So this returns the
- * key for ANY active tenant-bound write. Over-acquiring on a BYO write only
- * serializes it against managed writes on the same tenant (harmless); the
- * danger is UNDER-acquiring. Returns null only when the write is not an active
- * tenant-bound activation (paused / tenantless — takes no advisory lock at
- * all). Both the projection and saveConnection derive the key HERE so they
- * can never drift.
+ * Advisory-lock key for the GLOBAL managed-workspace tuple — the SECOND lock
+ * in the order (see `chatTenantAdvisoryLockKey`), serializing the cross-org
+ * transfer/demote of a workspace across ALL orgs (hence org-independent). The
+ * key is MODE-INDEPENDENT — it names the (platform, tenant) workspace, not a
+ * credential mode — and is returned for EVERY active tenant-bound write, not
+ * just managed ones: only managed writes demote anyone, but a BYO write must
+ * already hold this lock before it row-locks anything or the advisory↔row
+ * cycle reopens. Over-acquiring on BYO merely serializes it against managed
+ * writes on the same tenant; under-acquiring is the only unsafe outcome.
  */
 export function managedTenantAdvisoryLockKey(
   conn: StoredConnection,
@@ -220,18 +213,12 @@ export async function upsertChatConnectionProjection(
   };
 
   if (status === "active" && externalTenantId) {
-    // UNIVERSAL lock order for chat writes: org-advisory → managed-advisory →
-    // ALL row locks. BOTH advisories are acquired UP FRONT, before ANY row is
-    // touched, so every path (this projection AND saveConnection) takes locks
-    // in the identical order and no advisory↔row cycle can form. In particular
-    // the same-org one-active demote below is a ROW lock — it MUST come AFTER
-    // the managed-advisory, or a concurrent cross-org write (which takes the
-    // managed-advisory then row-locks THIS org's sibling) would invert against
-    // it. The managed-advisory is mode-INDEPENDENT and taken for EVERY active
-    // tenant-bound write; over-acquiring on a BYO write only serializes it with
-    // managed writes on the same tenant (harmless). pg_advisory_xact_lock is
-    // reentrant, so a caller (saveConnection) that already holds these is a
-    // no-op here.
+    // Universal order (see chatTenantAdvisoryLockKey): BOTH advisories up
+    // front, before ANY row lock — in particular the same-org demote below is
+    // a row lock and must follow the managed-advisory, or a concurrent
+    // cross-org write (managed-advisory, then row-locks THIS org's sibling)
+    // inverts against it. Locks are reentrant, so a caller (saveConnection)
+    // that already holds them is a no-op here.
     await sql.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
       tenantLockKey,
     ]);
@@ -243,8 +230,7 @@ export async function upsertChatConnectionProjection(
 
     // Same-org one-active-per-(org, platform, tenant): demote any OTHER active
     // sibling in THIS org so the partial-unique `connections_active_chat_tenant`
-    // index is never contended. First ROW lock — taken with BOTH advisories
-    // already held.
+    // index is never contended.
     const demoted = await sql`
       UPDATE connections SET status = 'paused', updated_at = now()
       WHERE organization_id = ${orgId}
@@ -269,16 +255,12 @@ export async function upsertChatConnectionProjection(
       );
     }
 
-    // Cross-org managed transfer/demote — managed writes ONLY. A MANAGED install
-    // binds a provider workspace (Slack team) to exactly ONE org — the OAuth
-    // install moves with the workspace. On a reinstall/transfer of the same team
-    // into a different org, the old org's managed projection would otherwise
-    // stay 'active', leaving a stale routing/ACL row for a team this org no
-    // longer owns. Demote any OTHER org's active managed projection. BYO
-    // connections can legitimately coexist cross-org, so they took the
-    // managed-advisory (for lock-order uniformity) but demote no one. The
-    // managed-advisory is already held above, so these other-org row locks
-    // never precede it.
+    // Cross-org managed transfer/demote — managed writes ONLY. A MANAGED
+    // install binds a provider workspace (Slack team) to exactly ONE org: the
+    // OAuth install moves with the workspace, and without this the old org
+    // would keep a stale active routing/ACL row for a team it no longer owns.
+    // BYO connections legitimately coexist cross-org, so they demote no one
+    // (they hold the managed-advisory purely for lock-order uniformity).
     if (managedLockKey && credentialMode === "managed") {
       const transferred = await sql`
         UPDATE connections SET status = 'paused', updated_at = now()

--- a/packages/server/src/lobu/stores/connections-projection.ts
+++ b/packages/server/src/lobu/stores/connections-projection.ts
@@ -220,9 +220,31 @@ export async function upsertChatConnectionProjection(
   };
 
   if (status === "active" && externalTenantId) {
+    // UNIVERSAL lock order for chat writes: org-advisory → managed-advisory →
+    // ALL row locks. BOTH advisories are acquired UP FRONT, before ANY row is
+    // touched, so every path (this projection AND saveConnection) takes locks
+    // in the identical order and no advisory↔row cycle can form. In particular
+    // the same-org one-active demote below is a ROW lock — it MUST come AFTER
+    // the managed-advisory, or a concurrent cross-org write (which takes the
+    // managed-advisory then row-locks THIS org's sibling) would invert against
+    // it. The managed-advisory is mode-INDEPENDENT and taken for EVERY active
+    // tenant-bound write; over-acquiring on a BYO write only serializes it with
+    // managed writes on the same tenant (harmless). pg_advisory_xact_lock is
+    // reentrant, so a caller (saveConnection) that already holds these is a
+    // no-op here.
     await sql.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
       tenantLockKey,
     ]);
+    if (managedLockKey) {
+      await sql.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
+        managedLockKey,
+      ]);
+    }
+
+    // Same-org one-active-per-(org, platform, tenant): demote any OTHER active
+    // sibling in THIS org so the partial-unique `connections_active_chat_tenant`
+    // index is never contended. First ROW lock — taken with BOTH advisories
+    // already held.
     const demoted = await sql`
       UPDATE connections SET status = 'paused', updated_at = now()
       WHERE organization_id = ${orgId}
@@ -247,50 +269,41 @@ export async function upsertChatConnectionProjection(
       );
     }
 
-    // GLOBAL managed-workspace lock — the SECOND advisory lock, held before ANY
-    // other-org row is touched. Acquire it for EVERY active tenant-bound write
-    // (managedLockKey is mode-independent), not just managed writes: the lock
-    // order (org-advisory → managed-advisory → rows) must be identical on every
-    // path, or a BYO write that races a managed transfer inverts against it.
-    // Over-acquiring on a BYO write only serializes it with managed writes on
-    // the same tenant (harmless). The DEMOTE, however, is managed-only: a
-    // MANAGED install binds a provider workspace (Slack team) to exactly ONE
-    // org — the OAuth install moves with the workspace. On a reinstall/transfer
-    // of the same team into a different org, the old org's managed projection
-    // would otherwise stay 'active', leaving a stale routing/ACL row for a team
-    // this org no longer owns. So demote any OTHER org's active managed
-    // projection ONLY when THIS write is itself managed; BYO connections can
-    // legitimately coexist cross-org and must not demote anyone.
-    if (managedLockKey) {
-      await sql.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
-        managedLockKey,
-      ]);
-      if (credentialMode === "managed") {
-        const transferred = await sql`
-          UPDATE connections SET status = 'paused', updated_at = now()
-          WHERE connector_key = ${conn.platform}
-            AND external_tenant_id = ${externalTenantId}
-            AND credential_mode = 'managed'
-            AND status = 'active'
-            AND deleted_at IS NULL
-            AND organization_id <> ${orgId}
-          RETURNING slug, organization_id
-        `;
-        if (transferred.length > 0) {
-          logger.info(
-            {
-              orgId,
-              platform: conn.platform,
-              teamId: externalTenantId,
-              activated: slug,
-              demoted: transferred.map(
-                (r: { slug: string; organization_id: string }) =>
-                  `${r.organization_id}:${r.slug}`,
-              ),
-            },
-            "Demoted stale managed install in another org (workspace transfer)",
-          );
-        }
+    // Cross-org managed transfer/demote — managed writes ONLY. A MANAGED install
+    // binds a provider workspace (Slack team) to exactly ONE org — the OAuth
+    // install moves with the workspace. On a reinstall/transfer of the same team
+    // into a different org, the old org's managed projection would otherwise
+    // stay 'active', leaving a stale routing/ACL row for a team this org no
+    // longer owns. Demote any OTHER org's active managed projection. BYO
+    // connections can legitimately coexist cross-org, so they took the
+    // managed-advisory (for lock-order uniformity) but demote no one. The
+    // managed-advisory is already held above, so these other-org row locks
+    // never precede it.
+    if (managedLockKey && credentialMode === "managed") {
+      const transferred = await sql`
+        UPDATE connections SET status = 'paused', updated_at = now()
+        WHERE connector_key = ${conn.platform}
+          AND external_tenant_id = ${externalTenantId}
+          AND credential_mode = 'managed'
+          AND status = 'active'
+          AND deleted_at IS NULL
+          AND organization_id <> ${orgId}
+        RETURNING slug, organization_id
+      `;
+      if (transferred.length > 0) {
+        logger.info(
+          {
+            orgId,
+            platform: conn.platform,
+            teamId: externalTenantId,
+            activated: slug,
+            demoted: transferred.map(
+              (r: { slug: string; organization_id: string }) =>
+                `${r.organization_id}:${r.slug}`,
+            ),
+          },
+          "Demoted stale managed install in another org (workspace transfer)",
+        );
       }
     }
   }

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -353,12 +353,12 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 				// Global lock order for chat-connection writes: BOTH tenant advisory
 				// locks FIRST — org-specific (`chatTenantAdvisoryLockKey`), then the
 				// GLOBAL managed-workspace lock (`managedTenantAdvisoryLockKey`) —
-				// THEN any `connections` row lock. The projection's real order is:
-				// org-advisory → same-org sibling rows (one-active demote) →
-				// managed-advisory → other-org rows (transfer demote) → target
-				// upsert. saveConnection can't replicate the interleaved row locks
-				// (it doesn't know the siblings yet), so instead it takes BOTH
-				// advisories up front, before ANY row lock — which is strictly safe:
+				// THEN any `connections` row lock. This order is now UNIVERSAL: the
+				// projection (`upsertChatConnectionProjection`) takes both advisories
+				// up front too (org-advisory → managed-advisory → same-org demote →
+				// cross-org transfer demote → target upsert), so no path locks a
+				// `connections` row between the two advisories. saveConnection takes
+				// BOTH advisories before ANY row lock — which is strictly safe:
 				// a txn holding both advisories before it row-locks anything can
 				// never be the party that holds a row while waiting on an advisory,
 				// so it cannot participate in the advisory↔row cycle. pg_advisory_-

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -9,6 +9,7 @@ import { recordLifecycleEvent } from "../../utils/insert-event";
 import {
 	chatTenantAdvisoryLockKey,
 	connectionsRowToStored,
+	managedTenantAdvisoryLockKey,
 	runtimeConnectionIdToSlug,
 	softDeleteChatConnectionProjection,
 	upsertChatConnectionProjection,
@@ -349,20 +350,53 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 			// defeat the cross-replica serialization.
 			await sql.begin(async (tx: typeof sql) => {
 				const configToPersist = { ...connection.config };
-				// Global lock order for chat-connection writes: tenant ADVISORY lock
-				// first, THEN `connections` row locks. The projection writer (also
-				// reached via the managed Slack reinstall path, in ITS own txn) is
-				// advisory → row; if this txn took the row lock below (FOR UPDATE)
-				// and only then reached the projection's advisory lock, a concurrent
-				// fallback-agent update + workspace reinstall would deadlock
-				// (row→advisory here vs advisory→row there). Same guard + key as the
-				// projection (chatTenantAdvisoryLockKey — the connection passed on is
-				// identical in status/platform/metadata); pg_advisory_xact_lock is
-				// reentrant, so the projection re-acquiring it below is a no-op.
-				const tenantLockKey = chatTenantAdvisoryLockKey(connection, orgId);
+				// Global lock order for chat-connection writes: tenant ADVISORY
+				// locks FIRST, THEN `connections` row locks. A MANAGED write in the
+				// projection takes TWO advisory locks in order — the org-specific
+				// tenant lock, then the GLOBAL managed-workspace lock (which then
+				// row-locks OTHER orgs' rows to demote a transferred install). If
+				// this txn row-locked first (FOR UPDATE below) and only then reached
+				// those advisory locks, a concurrent write + cross-org transfer would
+				// deadlock (row→advisory here vs advisory→row there). So replicate
+				// the projection's EXACT acquisition order at the top of the txn:
+				// org-specific lock, then (managed only) the managed-global lock.
+				// pg_advisory_xact_lock is reentrant — the projection re-taking both
+				// inside this same txn is a harmless no-op.
+				//
+				// Managed-ness must be known BEFORE the row lock, but the projection
+				// derives it from the row's credential_mode (read below FOR UPDATE).
+				// Take a LOCK-FREE peek at credential_mode here purely to decide
+				// whether to pre-acquire the managed-global lock. Over-acquiring is
+				// safe (it only serializes); the risk is UNDER-acquiring. A managed
+				// row's credential_mode never flips to byo (the projection preserves
+				// it; only the install path sets managed), so a row that is managed
+				// now is still managed at the FOR UPDATE below — this peek cannot
+				// make a managed write skip the lock. A BYO / brand-new row correctly
+				// skips it. `keyConn` carries the incoming status/platform/metadata
+				// the key helpers read; the peeked mode only gates the managed key.
+				const peek = (await tx`
+          SELECT credential_mode
+          FROM connections
+          WHERE slug = ${slug} AND organization_id = ${orgId}
+            AND deleted_at IS NULL
+          LIMIT 1
+        `) as Array<{ credential_mode: string | null }>;
+				const peekedMode: "managed" | "byo" =
+					peek[0]?.credential_mode === "managed" ? "managed" : "byo";
+				const keyConn = { ...connection, organizationId: orgId };
+				const tenantLockKey = chatTenantAdvisoryLockKey(keyConn, orgId);
 				if (tenantLockKey) {
 					await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
 						tenantLockKey,
+					]);
+				}
+				const managedLockKey = managedTenantAdvisoryLockKey(
+					keyConn,
+					peekedMode,
+				);
+				if (managedLockKey) {
+					await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
+						managedLockKey,
 					]);
 				}
 				// Scope to the LIVE row only, and lock it. Slug uniqueness holds

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -7,6 +7,7 @@ import type {
 import { getDb, tsTime, tsTimeOrNull } from "../../db/client";
 import { recordLifecycleEvent } from "../../utils/insert-event";
 import {
+	chatTenantAdvisoryLockKey,
 	connectionsRowToStored,
 	runtimeConnectionIdToSlug,
 	softDeleteChatConnectionProjection,
@@ -348,6 +349,22 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 			// defeat the cross-replica serialization.
 			await sql.begin(async (tx: typeof sql) => {
 				const configToPersist = { ...connection.config };
+				// Global lock order for chat-connection writes: tenant ADVISORY lock
+				// first, THEN `connections` row locks. The projection writer (also
+				// reached via the managed Slack reinstall path, in ITS own txn) is
+				// advisory → row; if this txn took the row lock below (FOR UPDATE)
+				// and only then reached the projection's advisory lock, a concurrent
+				// fallback-agent update + workspace reinstall would deadlock
+				// (row→advisory here vs advisory→row there). Same guard + key as the
+				// projection (chatTenantAdvisoryLockKey — the connection passed on is
+				// identical in status/platform/metadata); pg_advisory_xact_lock is
+				// reentrant, so the projection re-acquiring it below is a no-op.
+				const tenantLockKey = chatTenantAdvisoryLockKey(connection, orgId);
+				if (tenantLockKey) {
+					await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
+						tenantLockKey,
+					]);
+				}
 				// Scope to the LIVE row only, and lock it. Slug uniqueness holds
 				// solely for live rows (the projection's ON CONFLICT targets the
 				// `WHERE deleted_at IS NULL` partial index), so a same-slug

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -350,40 +350,23 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 			// defeat the cross-replica serialization.
 			await sql.begin(async (tx: typeof sql) => {
 				const configToPersist = { ...connection.config };
-				// Global lock order for chat-connection writes: BOTH tenant advisory
-				// locks FIRST — org-specific (`chatTenantAdvisoryLockKey`), then the
-				// GLOBAL managed-workspace lock (`managedTenantAdvisoryLockKey`) —
-				// THEN any `connections` row lock. This order is now UNIVERSAL: the
-				// projection (`upsertChatConnectionProjection`) takes both advisories
-				// up front too (org-advisory → managed-advisory → same-org demote →
-				// cross-org transfer demote → target upsert), so no path locks a
-				// `connections` row between the two advisories. saveConnection takes
-				// BOTH advisories before ANY row lock — which is strictly safe:
-				// a txn holding both advisories before it row-locks anything can
-				// never be the party that holds a row while waiting on an advisory,
-				// so it cannot participate in the advisory↔row cycle. pg_advisory_-
-				// xact_lock is reentrant, so the projection re-taking both inside
-				// this same txn is a harmless no-op.
-				//
-				// The managed-global lock is acquired UNCONDITIONALLY for every
-				// active tenant-bound write — NOT gated on credential_mode. A
-				// lock-free peek at the mode would be a TOCTOU: a concurrent managed
-				// install can flip a byo/empty row to managed between the peek and
-				// the FOR UPDATE, after which the projection (running with the now-
-				// managed mode) takes the managed lock while this txn already holds
-				// the target row → the cycle reopens. The managed key is
-				// mode-INDEPENDENT (it names the workspace, not the mode), and
-				// over-acquiring on a genuine BYO write only serializes it against
-				// managed writes on the same tenant (harmless); UNDER-acquiring is
-				// the only unsafe outcome, so we always take it.
-				const keyConn = { ...connection, organizationId: orgId };
-				const tenantLockKey = chatTenantAdvisoryLockKey(keyConn, orgId);
+				// Universal lock order for chat writes (see chatTenantAdvisoryLockKey):
+				// org-tenant advisory → managed-workspace advisory → only then any
+				// `connections` row lock (the FOR UPDATE below, and every row lock in
+				// the projection). The managed lock is taken UNCONDITIONALLY rather
+				// than after peeking at credential_mode — the peek would be a TOCTOU
+				// (a concurrent managed install can flip the mode between peek and
+				// FOR UPDATE, reopening the advisory↔row cycle); over-acquiring on a
+				// BYO write merely serializes it against managed writes on the same
+				// tenant. Both locks are reentrant, so the projection re-taking them
+				// inside this txn is a no-op.
+				const tenantLockKey = chatTenantAdvisoryLockKey(connection, orgId);
 				if (tenantLockKey) {
 					await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
 						tenantLockKey,
 					]);
 				}
-				const managedLockKey = managedTenantAdvisoryLockKey(keyConn);
+				const managedLockKey = managedTenantAdvisoryLockKey(connection);
 				if (managedLockKey) {
 					await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
 						managedLockKey,

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -348,17 +348,42 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 			// defeat the cross-replica serialization.
 			await sql.begin(async (tx: typeof sql) => {
 				const configToPersist = { ...connection.config };
+				// Scope to the LIVE row only, and lock it. Slug uniqueness holds
+				// solely for live rows (the projection's ON CONFLICT targets the
+				// `WHERE deleted_at IS NULL` partial index), so a same-slug
+				// tombstone — e.g. a deleted managed install whose slackinst-* id
+				// was later recreated as BYO — must NOT be read here. Without the
+				// filter, LIMIT 1 could pick the tombstone and its credential_mode
+				// would reclassify the live row (managed↔byo). FOR UPDATE ties the
+				// read to the same live row the upsert below writes.
 				const existingRows = await tx`
-          SELECT config
+          SELECT config, credential_mode
           FROM connections
           WHERE slug = ${slug} AND organization_id = ${orgId}
+            AND deleted_at IS NULL
           LIMIT 1
+          FOR UPDATE
         `;
 				const existingConfig =
 					existingRows[0] &&
 					typeof existingRows[0].config === "object" &&
 					existingRows[0].config
 						? (existingRows[0].config as Record<string, any>)
+						: null;
+
+				// The generic store has no notion of managed vs BYO — it always
+				// carried "byo" here, which reclassified an OAuth-MANAGED chat
+				// connection to BYO on any store-driven edit (e.g. setting a
+				// fallback agent_id via manage_connections update). A reclassified
+				// managed row skips revokeManagedConnection on delete (leaking the
+				// install's credentials) and loses managed-credential edit
+				// protection. Preserve the existing mode; only a brand-new row
+				// defaults to byo (managed rows are created by the Slack install
+				// path, which passes "managed" explicitly).
+				const existingCredentialMode =
+					existingRows[0]?.credential_mode === "managed" ||
+					existingRows[0]?.credential_mode === "byo"
+						? (existingRows[0].credential_mode as "managed" | "byo")
 						: null;
 
 				// ChatInstanceManager normalizes secret fields into `secret://` refs
@@ -383,7 +408,7 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 					(v) => sql.json(v),
 					{ ...connection, config: configToPersist },
 					orgId,
-					"byo",
+					existingCredentialMode ?? "byo",
 				);
 			});
 		},

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -350,39 +350,32 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 			// defeat the cross-replica serialization.
 			await sql.begin(async (tx: typeof sql) => {
 				const configToPersist = { ...connection.config };
-				// Global lock order for chat-connection writes: tenant ADVISORY
-				// locks FIRST, THEN `connections` row locks. A MANAGED write in the
-				// projection takes TWO advisory locks in order — the org-specific
-				// tenant lock, then the GLOBAL managed-workspace lock (which then
-				// row-locks OTHER orgs' rows to demote a transferred install). If
-				// this txn row-locked first (FOR UPDATE below) and only then reached
-				// those advisory locks, a concurrent write + cross-org transfer would
-				// deadlock (row→advisory here vs advisory→row there). So replicate
-				// the projection's EXACT acquisition order at the top of the txn:
-				// org-specific lock, then (managed only) the managed-global lock.
-				// pg_advisory_xact_lock is reentrant — the projection re-taking both
-				// inside this same txn is a harmless no-op.
+				// Global lock order for chat-connection writes: BOTH tenant advisory
+				// locks FIRST — org-specific (`chatTenantAdvisoryLockKey`), then the
+				// GLOBAL managed-workspace lock (`managedTenantAdvisoryLockKey`) —
+				// THEN any `connections` row lock. The projection's real order is:
+				// org-advisory → same-org sibling rows (one-active demote) →
+				// managed-advisory → other-org rows (transfer demote) → target
+				// upsert. saveConnection can't replicate the interleaved row locks
+				// (it doesn't know the siblings yet), so instead it takes BOTH
+				// advisories up front, before ANY row lock — which is strictly safe:
+				// a txn holding both advisories before it row-locks anything can
+				// never be the party that holds a row while waiting on an advisory,
+				// so it cannot participate in the advisory↔row cycle. pg_advisory_-
+				// xact_lock is reentrant, so the projection re-taking both inside
+				// this same txn is a harmless no-op.
 				//
-				// Managed-ness must be known BEFORE the row lock, but the projection
-				// derives it from the row's credential_mode (read below FOR UPDATE).
-				// Take a LOCK-FREE peek at credential_mode here purely to decide
-				// whether to pre-acquire the managed-global lock. Over-acquiring is
-				// safe (it only serializes); the risk is UNDER-acquiring. A managed
-				// row's credential_mode never flips to byo (the projection preserves
-				// it; only the install path sets managed), so a row that is managed
-				// now is still managed at the FOR UPDATE below — this peek cannot
-				// make a managed write skip the lock. A BYO / brand-new row correctly
-				// skips it. `keyConn` carries the incoming status/platform/metadata
-				// the key helpers read; the peeked mode only gates the managed key.
-				const peek = (await tx`
-          SELECT credential_mode
-          FROM connections
-          WHERE slug = ${slug} AND organization_id = ${orgId}
-            AND deleted_at IS NULL
-          LIMIT 1
-        `) as Array<{ credential_mode: string | null }>;
-				const peekedMode: "managed" | "byo" =
-					peek[0]?.credential_mode === "managed" ? "managed" : "byo";
+				// The managed-global lock is acquired UNCONDITIONALLY for every
+				// active tenant-bound write — NOT gated on credential_mode. A
+				// lock-free peek at the mode would be a TOCTOU: a concurrent managed
+				// install can flip a byo/empty row to managed between the peek and
+				// the FOR UPDATE, after which the projection (running with the now-
+				// managed mode) takes the managed lock while this txn already holds
+				// the target row → the cycle reopens. The managed key is
+				// mode-INDEPENDENT (it names the workspace, not the mode), and
+				// over-acquiring on a genuine BYO write only serializes it against
+				// managed writes on the same tenant (harmless); UNDER-acquiring is
+				// the only unsafe outcome, so we always take it.
 				const keyConn = { ...connection, organizationId: orgId };
 				const tenantLockKey = chatTenantAdvisoryLockKey(keyConn, orgId);
 				if (tenantLockKey) {
@@ -390,10 +383,7 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 						tenantLockKey,
 					]);
 				}
-				const managedLockKey = managedTenantAdvisoryLockKey(
-					keyConn,
-					peekedMode,
-				);
+				const managedLockKey = managedTenantAdvisoryLockKey(keyConn);
 				if (managedLockKey) {
 					await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
 						managedLockKey,

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -302,12 +302,17 @@ export async function upsertSlackInstallByTeam(
     };
     const db = getDb();
     await db.begin(async (tx: typeof db) => {
+      // preserveAgentId: an install/reinstall (re)persists tokens + config but
+      // carries NO agent-routing intent — the fallback `agent_id` is set by an
+      // admin via manage_connections update. Without the flag, this upsert
+      // would clobber the configured fallback to NULL on every reinstall.
       await upsertChatConnectionProjection(
         tx,
         (v) => db.json(v),
         projection,
         organizationId,
-        "managed"
+        "managed",
+        { preserveAgentId: true }
       );
     });
 

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -1223,6 +1223,7 @@ export async function handleUpdate(
 	const hasAuthProfileArg = Object.hasOwn(args, "auth_profile_slug");
 	const hasAppAuthProfileArg = Object.hasOwn(args, "app_auth_profile_slug");
 	const hasDeviceWorkerArg = Object.hasOwn(args, "device_worker_id");
+	const hasAgentIdArg = Object.hasOwn(args, "agent_id");
 
   // `update` is now member-writable so members can edit their own
   // connection. Resolve the caller's role once up front and gate every
@@ -1241,7 +1242,42 @@ export async function handleUpdate(
     }
   }
 
+	// Reassigning a chat connection's fallback agent (or clearing it) is the
+	// same class of authority as a channel binding: it decides which agent an
+	// unbound DM/mention runs — and thus whose agent_users those platform
+	// people are recorded into. bind_channel is owner/admin-only for exactly
+	// this reason (OWNER_ADMIN_ACTIONS in auth/tool-access.ts). `update` is
+	// member-writable (a member may rename / rebind their OWN connection), so
+	// without this gate a member could point their connection's fallback at
+	// another member's agent — an escalation bind_channel forbids. Require
+	// admin to touch agent_id, matching the channel-binding tier.
+	if (hasAgentIdArg && !callerIsAdmin) {
+		return {
+			error:
+				"Only admins can set a chat connection's fallback agent (agent_id).",
+		};
+	}
+
 	if (existing.credential_mode !== null) {
+		// Three explicit cases — never rely on truthiness, because `""` is a
+		// falsy string that Type.String() permits: (1) null CLEARS the fallback;
+		// (2) a non-empty string must resolve to a real agent in this org
+		// (mirrors handleApplyChatConnection); (3) an empty string is invalid —
+		// without this guard `""` would skip the existence check and then be
+		// treated downstream as a destructive clear.
+		if (hasAgentIdArg) {
+			if (args.agent_id === "") {
+				return { error: "agent_id must be a non-empty agent id or null" };
+			}
+			if (typeof args.agent_id === "string") {
+				const agents = await sql`
+          SELECT 1 FROM agents
+          WHERE organization_id = ${organizationId} AND id = ${args.agent_id}
+          LIMIT 1
+        `;
+				if (agents.length === 0) return { error: "Agent not found" };
+			}
+		}
 		try {
 			await updateChatConnection({
 				organizationId,
@@ -1249,6 +1285,7 @@ export async function handleUpdate(
 				displayName: args.display_name,
 				config: args.config,
 				status: args.status,
+				...(hasAgentIdArg ? { agentId: args.agent_id ?? null } : {}),
 			});
 			const read = await handleGet(
 				{ action: "get", connection_id: args.connection_id },
@@ -1265,12 +1302,23 @@ export async function handleUpdate(
 					...(args.display_name !== undefined ? ["display_name"] : []),
 					...(args.config !== undefined ? ["config"] : []),
 					...(args.status !== undefined ? ["status"] : []),
+					...(hasAgentIdArg ? ["agent_id"] : []),
 				],
 			});
 			return { action: "update", connection: read.connection };
 		} catch (error) {
 			return { error: getErrorMessage(error) };
 		}
+	}
+
+	// Non-chat connections have no runtime that reads connections.agent_id
+	// (routing consults it only as a chat fallback after channel bindings
+	// miss) — reject rather than silently writing a column nothing reads.
+	if (hasAgentIdArg) {
+		return {
+			error:
+				"agent_id applies only to chat connections (it sets the chat runtime's fallback agent); this connection has no chat runtime.",
+		};
 	}
 
   // App profile updates: non-admins may only set the connector's pinned

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -1242,15 +1242,11 @@ export async function handleUpdate(
     }
   }
 
-	// Reassigning a chat connection's fallback agent (or clearing it) is the
-	// same class of authority as a channel binding: it decides which agent an
-	// unbound DM/mention runs — and thus whose agent_users those platform
-	// people are recorded into. bind_channel is owner/admin-only for exactly
-	// this reason (OWNER_ADMIN_ACTIONS in auth/tool-access.ts). `update` is
-	// member-writable (a member may rename / rebind their OWN connection), so
-	// without this gate a member could point their connection's fallback at
-	// another member's agent — an escalation bind_channel forbids. Require
-	// admin to touch agent_id, matching the channel-binding tier.
+	// Setting/clearing the fallback agent is the same class of authority as a
+	// channel binding (bind_channel is owner/admin-only, OWNER_ADMIN_ACTIONS in
+	// auth/tool-access.ts): it decides which agent an unbound DM/mention runs.
+	// `update` itself is member-writable, so without this gate a member could
+	// point their own connection's fallback at another member's agent.
 	if (hasAgentIdArg && !callerIsAdmin) {
 		return {
 			error:

--- a/packages/server/src/tools/validate-args.ts
+++ b/packages/server/src/tools/validate-args.ts
@@ -88,7 +88,20 @@ function normalizeArgs(value: unknown): unknown {
     if (proto === Object.prototype || proto === null) {
       const out: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(value)) {
-        if (v !== undefined) out[stripNul(k)] = normalizeArgs(v);
+        if (v === undefined) continue;
+        const key = stripNul(k);
+        // `out[key] = …` invokes the `__proto__` accessor for a key named
+        // `__proto__`, mutating the prototype instead of creating an own key —
+        // so `Object.keys` never sees it and rejectUnknownKeys can't reject it
+        // (prototype-pollution bypass). `defineProperty` always creates a
+        // plain own data property, so a JSON `__proto__` key becomes a real
+        // (unknown) argument that validation then rejects.
+        Object.defineProperty(out, key, {
+          value: normalizeArgs(v),
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
       }
       return out;
     }
@@ -107,6 +120,40 @@ function compileSchema(schema: TSchema): TypeCheck<TSchema> {
   return compiled;
 }
 
+/**
+ * Reject top-level keys the schema does not declare. TypeBox `Type.Object`
+ * accepts extra keys by default, so an unknown argument (a typo, or a field
+ * that belongs to a DIFFERENT action variant) used to be silently dropped —
+ * the call "succeeded" while ignoring the caller's intent. This runs against
+ * the MATCHED variant's properties (never the union: clients see the
+ * flattened merged schema, so only post-dispatch is the allowed key set
+ * well-defined; the `action` discriminator is a declared property of every
+ * variant and thus always allowed).
+ *
+ * Skipped when the schema declares `additionalProperties` as anything other
+ * than `false` (e.g. `Type.Record` passthrough) or has no `properties` at
+ * all — those schemas accept arbitrary keys by design.
+ */
+function rejectUnknownKeys(toolName: string, schema: TSchema, coerced: unknown): void {
+  const { properties, additionalProperties } = schema as {
+    properties?: Record<string, unknown>;
+    additionalProperties?: unknown;
+  };
+  if (!properties) return;
+  if (additionalProperties !== undefined && additionalProperties !== false) return;
+  if (!coerced || typeof coerced !== 'object' || Array.isArray(coerced)) return;
+  // Object.hasOwn, NOT `key in properties`: `in` walks Object.prototype, so
+  // args named `constructor`, `toString`, `hasOwnProperty`, etc. would be
+  // wrongly accepted as "known" keys.
+  const unknown = Object.keys(coerced).filter((key) => !Object.hasOwn(properties, key));
+  if (unknown.length === 0) return;
+  const action = (properties.action as { const?: unknown } | undefined)?.const;
+  const scope = action !== undefined ? ` for action '${String(action)}'` : '';
+  throw new ToolUserError(
+    `Invalid arguments for ${toolName}: unknown argument(s): ${unknown.join(', ')} — valid arguments${scope} are: ${Object.keys(properties).join(', ')}`
+  );
+}
+
 function checkAgainst(toolName: string, schema: TSchema, args: unknown): unknown {
   // Convert returns a coerced copy — the handler must receive it, otherwise
   // coercion would satisfy the validator but the handler would still see the
@@ -117,7 +164,10 @@ function checkAgainst(toolName: string, schema: TSchema, args: unknown): unknown
   // path requires sort_by to be UNSET; injecting the default broke it.
   const coerced = Value.Convert(schema, normalizeArgs(args));
   const validator = compileSchema(schema);
-  if (validator.Check(coerced)) return coerced;
+  if (validator.Check(coerced)) {
+    rejectUnknownKeys(toolName, schema, coerced);
+    return coerced;
+  }
 
   // Deduplicate by path — TypeBox emits both `Expected required property` and
   // `Expected <type>` against the same missing field, which would otherwise


### PR DESCRIPTION
## What

Adds an `agent_id` field to `manage_connections update` so an admin can set a connection's **fallback routing agent** directly (the connection's owning agent that inbound messages route to when no per-channel binding matches). Previously the only way to set it was `apply_chat_connection`, which requires a `signingSecret` that OAuth installs don't have.

This is what unblocks a fresh Slack install replying: set the connection's `agent_id`, and unbound DMs/mentions route to that agent instead of falling through to the Builder ("pick a provider") dead-end.

## Changes

- **`manage_connections update` gains `agent_id`** (`core/contracts` + `crud.ts` handler): admin-gated, agent-must-exist check, explicit-null clears, non-chat connections rejected, `credential_mode` preserved.
- **Strict unknown-arg rejection + prototype-pollution guards** in `validate-args.ts` (`Object.hasOwn` / `Object.defineProperty`).
- **Reinstall preserves the fallback `agent_id`** — a managed Slack reinstall no longer nulls the assigned fallback (`preserveAgentId` intent flag on the projection writer).
- **Universal advisory-lock ordering** (`org-advisory → managed-advisory → all rows`) across `saveConnection` and the projection, closing three distinct deadlock classes found during review (reinstall clobber, same-org, cross-org managed, and a TOCTOU on a lock-free mode peek).
- Warm-instance updates mutate `agentId`/settings/metadata in place (never clobber plaintext runtime config with `secret://` refs).

## Testing

- red→green integration tests for every fix (embedded Postgres), including real `40P01` reproductions for each deadlock and both credential-mode tombstone directions.
- 25/25 connectors integration + validate-args suites green; `make typecheck` (server strict) clean.
- Reviewed via 5 rounds of `codex gpt-5.6-sol` (high effort) with a full lock-audit table confirming no advisory↔row cycle remains.

## Known follow-up (pre-existing, not introduced here)

A pure row↔row deadlock exists on `main` when two same-org BYO connections concurrently swap to each other's exact Slack tenants (verified pre-existing: demote code from 2026-06-30). Tracked separately — fix is a deterministic row-lock order or a safe `40P01` retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786280931&installation_id=136316292&pr_number=1836&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1836&signature=7daf71f6cfb28af76d46e6cc2d37080348b2e29cec9440dbef9a6123e41f5268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring or clearing a fallback agent for chat connections.
  * Fallback agents apply only when no channel-specific agent is matched.
  * Updates can be recorded in connection audit history.

* **Bug Fixes**
  * Improved connection updates without restarting active chat instances.
  * Preserved configured agents during installation and reconnection flows.
  * Retained connection mode during updates.

* **Validation**
  * Strengthened argument validation, including unknown and unsafe keys.
  * Added clearer validation for unsupported, invalid, or unauthorized agent assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->