### PR TITLE
feat(write-gate): per-operation connector_action scope

### DIFF
--- a/charts/lobu/values.yaml
+++ b/charts/lobu/values.yaml
@@ -18,11 +18,17 @@ imagePullSecrets:
 # App deployment settings (API backend)
 app:
   replicaCount: 1
-  # With workspaces.enabled=false (Phase 5 default), the chart leaves
-  # strategy unset so the Deployment uses kube-default RollingUpdate.
-  # Setting `workspaces.enabled: true` (legacy RWO path) still pins to
-  # Recreate below.
-  strategy: {}
+  # Recreate: the old pod fully terminates before the new one starts, so at most
+  # ONE server version is ever live. This is a correctness requirement, not just a
+  # single-replica convenience — write-gate policy migrations add scope columns
+  # (e.g. operation_key) whose write predicates only the NEW code carries. Under
+  # RollingUpdate an old pod could serve a scope-blind UPDATE/DELETE concurrently
+  # with the migrated schema and clobber a freshly-written finer-scoped policy row
+  # (a persistent fail-open). Recreate removes the two-version overlap window. With
+  # replicaCount 1 there is no availability cost vs RollingUpdate (never >1 serving
+  # pod anyway). `workspaces.enabled: true` (legacy RWO path) already pinned this.
+  strategy:
+    type: Recreate
 
   resources:
     requests:

--- a/db/migrations/20260711100000_write_policy_operation_key.sql
+++ b/db/migrations/20260711100000_write_policy_operation_key.sql
@@ -20,11 +20,18 @@ ALTER TABLE public.write_approval_policies
 -- the old one, so the table is never left without a uniqueness guarantee.
 -- COALESCE(operation_key,'') keeps blanket (NULL) rows unique.
 --
--- ROLLING-DEPLOY: additive column + expand-before-contract index. Old pods keep
--- writing operation_key=NULL blanket rows (valid under the new key); the new
--- per-operation UI is the only writer of non-NULL operation_key rows and ships in
--- this deploy, so a non-blanket row can only appear once new pods are live. No
--- backfill — every existing row is a blanket row and stays one.
+-- DEPLOY SAFETY: additive column + expand-before-contract index. Old pods write the
+-- blanket rule with a scope-BLIND UPDATE/DELETE (their WHERE has no operation_key
+-- clause), so on the migrated schema an old pod could match BOTH the blanket row AND
+-- a new per-op row in one statement and clobber the per-op effect — a PERSISTENT
+-- fail-open, not the self-healing "old pod can't see the row" kind. This is closed at
+-- the deploy layer, NOT here: the app Deployment is `strategy: Recreate` with
+-- replicaCount 1 (charts/lobu/values.yaml), so the old pod fully terminates before
+-- the new one starts and no two server versions ever serve writes concurrently. If
+-- this is ever backported to a multi-replica RollingUpdate, split into expand (this
+-- migration) + a NEXT-release feature that gates operation_key writes until every pod
+-- carries the scope-aware predicate. No backfill — every existing row is a blanket
+-- row and stays one.
 -- squawk-ignore require-concurrent-index-creation -- low-row-count policy table; brief lock negligible at this scale
 CREATE UNIQUE INDEX IF NOT EXISTS write_approval_policies_class_principal_mode_op_scope_key
   ON public.write_approval_policies (

--- a/db/migrations/20260711100000_write_policy_operation_key.sql
+++ b/db/migrations/20260711100000_write_policy_operation_key.sql
@@ -1,0 +1,70 @@
+-- migrate:up
+
+-- Per-operation connector scope. Until now `connector_action` policy rows carried
+-- a single blanket `execute` effect governing EVERY operation a connection exposes
+-- (send a Slack message, place a Deliveroo order, delete a Linear issue — all one
+-- toggle). This adds an `operation_key` scope dimension so an agent can carry a
+-- stricter rule for a specific operation (e.g. `deliveroo.place_order` = approval)
+-- while the blanket `execute` stays auto for the rest.
+--
+-- Mirrors how `entity_id`/`field_path` already extend entity scope with their own
+-- columns: a row with operation_key set is MORE SPECIFIC than the blanket
+-- (operation_key IS NULL) row and outranks it in the resolver's scope fold. NULL is
+-- the blanket row — every existing row keeps applying to all operations, so old pods
+-- (whose INSERTs don't name operation_key) still write valid blanket rows.
+ALTER TABLE public.write_approval_policies
+  ADD COLUMN IF NOT EXISTS operation_key text NULL;
+
+-- Extend the uniqueness key so a (…, operation_key) row is DISTINCT from the
+-- (…, blanket) row for the same principal+class. Build the new index first, then drop
+-- the old one, so the table is never left without a uniqueness guarantee.
+-- COALESCE(operation_key,'') keeps blanket (NULL) rows unique.
+--
+-- ROLLING-DEPLOY: additive column + expand-before-contract index. Old pods keep
+-- writing operation_key=NULL blanket rows (valid under the new key); the new
+-- per-operation UI is the only writer of non-NULL operation_key rows and ships in
+-- this deploy, so a non-blanket row can only appear once new pods are live. No
+-- backfill — every existing row is a blanket row and stays one.
+-- squawk-ignore require-concurrent-index-creation -- low-row-count policy table; brief lock negligible at this scale
+CREATE UNIQUE INDEX IF NOT EXISTS write_approval_policies_class_principal_mode_op_scope_key
+  ON public.write_approval_policies (
+    organization_id,
+    resource_class,
+    COALESCE(principal_kind, ''),
+    COALESCE(principal_id, ''),
+    COALESCE(principal_mode, ''),
+    COALESCE(operation_key, ''),
+    COALESCE(entity_type_slug, ''),
+    COALESCE(field_path, ''),
+    COALESCE(entity_id, 0)
+  );
+
+-- squawk-ignore require-concurrent-index-deletion -- low-row-count policy table; brief lock negligible at this scale
+DROP INDEX IF EXISTS public.write_approval_policies_class_principal_mode_scope_key;
+
+-- migrate:down
+
+-- Restore the op-less unique key before dropping the op-aware one, so the table
+-- always has a uniqueness guarantee. Safe only because a rollback also drops the
+-- operation_key column below (any op-specific rows would otherwise collide with their
+-- blanket row on the narrower key) — so drop such rows first.
+DELETE FROM public.write_approval_policies WHERE operation_key IS NOT NULL;
+
+-- squawk-ignore require-concurrent-index-creation -- rollback path; low row count
+CREATE UNIQUE INDEX IF NOT EXISTS write_approval_policies_class_principal_mode_scope_key
+  ON public.write_approval_policies (
+    organization_id,
+    resource_class,
+    COALESCE(principal_kind, ''),
+    COALESCE(principal_id, ''),
+    COALESCE(principal_mode, ''),
+    COALESCE(entity_type_slug, ''),
+    COALESCE(field_path, ''),
+    COALESCE(entity_id, 0)
+  );
+
+-- squawk-ignore require-concurrent-index-deletion -- rollback path; brief lock negligible at this scale
+DROP INDEX IF EXISTS public.write_approval_policies_class_principal_mode_op_scope_key;
+
+ALTER TABLE public.write_approval_policies
+  DROP COLUMN IF EXISTS operation_key;

--- a/packages/server/src/__tests__/integration/authz/write-policy-connector-op-scope.test.ts
+++ b/packages/server/src/__tests__/integration/authz/write-policy-connector-op-scope.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Real-PG tests for per-operation connector_action scope. A policy row scoped to a
+ * single operation_key tightens the blanket `execute` rule for THAT operation alone;
+ * every other operation still follows the blanket. The op-specific row wins over the
+ * blanket via the resolver's scope specificity — mirrored in the UI model.
+ */
+
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { resolveWriteEffect } from "../../../authz/entity-policy";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createTestAgent,
+	createTestOrganization,
+} from "../../setup/test-fixtures";
+
+async function seedConnectorPolicy(args: {
+	orgId: string;
+	principalKind?: string | null;
+	principalId?: string | null;
+	operationKey?: string | null;
+	effect: string;
+}): Promise<number> {
+	const sql = getTestDb();
+	const rows = await sql<{ id: number }>`
+    INSERT INTO write_approval_policies
+      (organization_id, resource_class, principal_kind, principal_id, operation_key)
+    VALUES
+      (${args.orgId}, 'connector_action', ${args.principalKind ?? null},
+       ${args.principalId ?? null}, ${args.operationKey ?? null})
+    RETURNING id
+  `;
+	const id = Number(rows[0].id);
+	await sql`
+    INSERT INTO write_policy_action_effects (policy_id, action, effect)
+    VALUES (${id}, 'execute', ${args.effect})
+  `;
+	return id;
+}
+
+const execFor = (orgId: string, agentId: string, operationKey: string | null) =>
+	resolveWriteEffect({
+		organizationId: orgId,
+		resourceClass: "connector_action",
+		principalKind: "agent",
+		principalId: agentId,
+		action: "execute",
+		operationKey,
+	});
+
+describe("connector_action per-operation scope", () => {
+	afterAll(async () => {
+		await cleanupTestDatabase();
+	});
+
+	let orgId: string;
+	beforeEach(async () => {
+		const org = await createTestOrganization();
+		orgId = org.id;
+		await createTestAgent({ organizationId: orgId, agentId: "op-agent" });
+	});
+
+	it("a per-op rule tightens ONLY its operation; others follow the blanket", async () => {
+		// Blanket: every op auto. Per-op: place_order needs approval.
+		await seedConnectorPolicy({
+			orgId,
+			principalKind: "agent",
+			principalId: "op-agent",
+			effect: "auto",
+		});
+		await seedConnectorPolicy({
+			orgId,
+			principalKind: "agent",
+			principalId: "op-agent",
+			operationKey: "deliveroo.place_order",
+			effect: "approval",
+		});
+		// The scoped op resolves approval; a different op resolves the blanket auto.
+		expect(await execFor(orgId, "op-agent", "deliveroo.place_order")).toBe(
+			"approval",
+		);
+		expect(await execFor(orgId, "op-agent", "slack.send_message")).toBe("auto");
+		// The blanket itself (no op) stays auto.
+		expect(await execFor(orgId, "op-agent", null)).toBe("auto");
+	});
+
+	it("a per-op rule can only TIGHTEN — the blanket floor still binds if stricter", async () => {
+		// Blanket denies; a per-op 'auto' must NOT loosen it below the blanket.
+		await seedConnectorPolicy({
+			orgId,
+			principalKind: "agent",
+			principalId: "op-agent",
+			effect: "deny",
+		});
+		await seedConnectorPolicy({
+			orgId,
+			principalKind: "agent",
+			principalId: "op-agent",
+			operationKey: "slack.send_message",
+			effect: "auto",
+		});
+		// Blanket deny + per-op auto → folded most-restrictive → deny.
+		expect(await execFor(orgId, "op-agent", "slack.send_message")).toBe("deny");
+	});
+
+	it("with no per-op rule, an op follows the blanket", async () => {
+		await seedConnectorPolicy({
+			orgId,
+			principalKind: "agent",
+			principalId: "op-agent",
+			operationKey: "slack.send_message",
+			effect: "approval",
+		});
+		// A DIFFERENT op with no rule and no blanket → class default (auto).
+		expect(await execFor(orgId, "op-agent", "deliveroo.place_order")).toBe(
+			"auto",
+		);
+		// The op that DOES have a rule resolves it.
+		expect(await execFor(orgId, "op-agent", "slack.send_message")).toBe(
+			"approval",
+		);
+	});
+
+	it("an org (any-principal) per-op floor binds the agent for that op", async () => {
+		// Org floor: place_order approval for ANY principal. Agent has no override.
+		await seedConnectorPolicy({
+			orgId,
+			operationKey: "deliveroo.place_order",
+			effect: "approval",
+		});
+		expect(await execFor(orgId, "op-agent", "deliveroo.place_order")).toBe(
+			"approval",
+		);
+		// Another op falls back to the class default (auto).
+		expect(await execFor(orgId, "op-agent", "slack.send_message")).toBe("auto");
+	});
+});

--- a/packages/server/src/__tests__/integration/authz/write-policy-connector-op-scope.test.ts
+++ b/packages/server/src/__tests__/integration/authz/write-policy-connector-op-scope.test.ts
@@ -133,4 +133,23 @@ describe("connector_action per-operation scope", () => {
 		// Another op falls back to the class default (auto).
 		expect(await execFor(orgId, "op-agent", "slack.send_message")).toBe("auto");
 	});
+
+	it("connector-qualified keys don't alias: two connectors' same bare op are distinct (F1)", async () => {
+		// linear::create_issue = deny, but github::create_issue must stay auto. The
+		// qualified key is what the gate passes, so a rule on one connector's op can't
+		// leak to another connector that exposes the same bare operation key.
+		await seedConnectorPolicy({
+			orgId,
+			principalKind: "agent",
+			principalId: "op-agent",
+			operationKey: "linear::create_issue",
+			effect: "deny",
+		});
+		expect(await execFor(orgId, "op-agent", "linear::create_issue")).toBe(
+			"deny",
+		);
+		expect(await execFor(orgId, "op-agent", "github::create_issue")).toBe(
+			"auto",
+		);
+	});
 });

--- a/packages/server/src/__tests__/unit/entity-policy.test.ts
+++ b/packages/server/src/__tests__/unit/entity-policy.test.ts
@@ -13,6 +13,9 @@ type PolicyRowSeed = {
 	resource_class?: string;
 	principal_kind?: string | null;
 	principal_id?: string | null;
+	principal_mode?: string | null;
+	/** connector_action per-operation scope; null = the blanket execute row. */
+	operation_key?: string | null;
 	entity_type_slug?: string | null;
 	field_path?: string | null;
 	entity_id?: number | null;
@@ -56,6 +59,8 @@ function stubSql(seeds: PolicyRowSeed[]): DbClient {
 		resource_class: seed.resource_class ?? "entity",
 		principal_kind: seed.principal_kind ?? null,
 		principal_id: seed.principal_id ?? null,
+		principal_mode: seed.principal_mode ?? null,
+		operation_key: seed.operation_key ?? null,
 		entity_type_slug: seed.entity_type_slug ?? null,
 		field_path: seed.field_path ?? null,
 		entity_id: seed.entity_id ?? null,
@@ -86,7 +91,7 @@ function stubSql(seeds: PolicyRowSeed[]): DbClient {
 		// Param order mirrors loadCandidatePolicies' WHERE: org, resourceClass,
 		// then the principal OR-block (principalKind, principalId, then ownerAgentId
 		// interpolated TWICE — once for `::text IS NOT NULL`, once for the `=`
-		// comparison), then the scope filters (entityTypeSlug, entityId).
+		// comparison), then the scope filters (operationKey, entityTypeSlug, entityId).
 		// ownerAgentId folds an 'agent' row for a watcher acting under its agent.
 		const [
 			org,
@@ -95,11 +100,13 @@ function stubSql(seeds: PolicyRowSeed[]): DbClient {
 			principalId,
 			ownerAgentId,
 			,
+			operationKey,
 			entityTypeSlug,
 			entityId,
 		] = params as [
 			string,
 			string,
+			string | null,
 			string | null,
 			string | null,
 			string | null,
@@ -120,6 +127,8 @@ function stubSql(seeds: PolicyRowSeed[]): DbClient {
 							row.principal_kind === "agent" &&
 							(row.principal_id === null ||
 								row.principal_id === ownerAgentId))) &&
+					(row.operation_key === null ||
+						row.operation_key === operationKey) &&
 					(row.entity_type_slug === null ||
 						row.entity_type_slug === entityTypeSlug) &&
 					(row.entity_id === null || row.entity_id === entityId),

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -114,6 +114,9 @@ export interface EntityApprovalPolicy {
 	principalId: string | null;
 	/** 'autonomous' = watcher-only override; NULL = applies to both acting modes. */
 	principalMode: PrincipalMode | null;
+	/** Connector operation this row scopes to (connector_action only); NULL = the
+	 * blanket row governing every operation. */
+	operationKey: string | null;
 	entityTypeSlug: string | null;
 	fieldPath: string | null;
 	entityId: number | null;
@@ -136,6 +139,9 @@ export interface EntityApprovalPolicyInput {
 	principalId?: string | null;
 	/** 'autonomous' scopes this row to watcher runs only; null = both modes. */
 	principalMode?: PrincipalMode | null;
+	/** Scopes a connector_action row to one operation (e.g. 'slack.send_message');
+	 * null = the blanket row for every operation. */
+	operationKey?: string | null;
 	entityTypeSlug?: string | null;
 	fieldPath?: string | null;
 	entityId?: number | null;
@@ -180,6 +186,9 @@ type EntityApprovalPolicyRow = {
 	principal_id: string | null;
 	/** 'autonomous' = watcher-only override; NULL = applies to both modes. */
 	principal_mode: string | null;
+	/** Connector operation this row scopes to (e.g. 'slack.send_message'); NULL =
+	 * the blanket row governing every operation. Only set for connector_action. */
+	operation_key: string | null;
 	entity_type_slug: string | null;
 	field_path: string | null;
 	entity_id: number | null;
@@ -262,6 +271,7 @@ function rowToPolicy(row: EntityApprovalPolicyRow): EntityApprovalPolicy {
 		principalKind: normalizePrincipalKind(row.principal_kind),
 		principalId: row.principal_id,
 		principalMode: normalizePrincipalMode(row.principal_mode),
+		operationKey: row.operation_key,
 		entityTypeSlug: row.entity_type_slug,
 		fieldPath: row.field_path,
 		entityId: row.entity_id === null ? null : Number(row.entity_id),
@@ -288,6 +298,7 @@ export function defaultEntityApprovalPolicy(
 		principalKind: null,
 		principalId: null,
 		principalMode: null,
+		operationKey: null,
 		entityTypeSlug: null,
 		fieldPath: null,
 		entityId: null,
@@ -538,7 +549,12 @@ function scopeSpecificity(row: EntityApprovalPolicyRow): number {
 	return (
 		(row.entity_id !== null ? 4 : 0) +
 		(row.field_path !== null ? 2 : 0) +
-		(row.entity_type_slug !== null ? 1 : 0)
+		// operation_key (connector_action) and entity_type_slug (entity) are mutually
+		// exclusive scope dimensions on disjoint classes; both are the class's finest
+		// non-instance scope, so they share weight 1. A row with either set outranks
+		// the blanket row for its class.
+		(row.entity_type_slug !== null ? 1 : 0) +
+		(row.operation_key !== null ? 1 : 0)
 	);
 }
 
@@ -745,6 +761,10 @@ async function loadCandidatePolicies(args: {
 	ownerAgentId?: string | null;
 	entityTypeSlug?: string | null;
 	entityId?: number | null;
+	/** The connector operation being run (connector_action only). Loads BOTH the
+	 * blanket row (operation_key IS NULL) and any row scoped to this operation; the
+	 * op-specific row wins via {@link scopeSpecificity}. */
+	operationKey?: string | null;
 	sql?: DbClient;
 }): Promise<EntityApprovalPolicyRow[]> {
 	const sql = args.sql ?? getDb();
@@ -754,7 +774,7 @@ async function loadCandidatePolicies(args: {
 	const ownerAgentId = args.ownerAgentId ?? null;
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
-       principal_mode, entity_type_slug, field_path, entity_id,
+       principal_mode, operation_key, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM write_approval_policies
@@ -772,6 +792,7 @@ async function loadCandidatePolicies(args: {
           AND (principal_id IS NULL OR principal_id = ${ownerAgentId})
         )
       )
+      AND (operation_key IS NULL OR operation_key = ${args.operationKey ?? null})
       AND (entity_type_slug IS NULL OR entity_type_slug = ${args.entityTypeSlug ?? null})
       AND (entity_id IS NULL OR entity_id = ${args.entityId ?? null})
   `;
@@ -910,6 +931,9 @@ export async function resolveWritePolicyDecision(args: {
 	 * watcher can never be more permissive than the same agent acting live.
 	 */
 	mode?: PrincipalMode;
+	/** connector_action only: the operation being run — a per-op row tightens the
+	 * blanket execute rule for it alone. Forwarded to {@link resolveWriteEffect}. */
+	operationKey?: string | null;
 	sql?: DbClient;
 }): Promise<EntityPolicyDecision> {
 	return modeToDecision(await resolveWriteEffect(args));
@@ -936,6 +960,9 @@ export async function resolveWriteEffect(args: {
 	ownerResolved?: boolean;
 	action: WriteAction;
 	mode?: PrincipalMode;
+	/** connector_action only: the operation being run (e.g. 'slack.send_message').
+	 * A row scoped to this op tightens the blanket execute rule for it alone. */
+	operationKey?: string | null;
 	sql?: DbClient;
 }): Promise<EntityMutationMode> {
 	if (args.principalKind === "user") return "auto";
@@ -946,6 +973,7 @@ export async function resolveWriteEffect(args: {
 		principalKind: args.principalKind,
 		principalId: args.principalId ?? null,
 		ownerAgentId: args.ownerAgentId ?? null,
+		operationKey: args.operationKey ?? null,
 		sql: args.sql,
 	});
 	return foldEffectWithMode(
@@ -1030,7 +1058,7 @@ export async function getGlobalEntityApprovalPolicy(
 	const sql = getDb();
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
-       principal_mode, entity_type_slug, field_path, entity_id,
+       principal_mode, operation_key, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM write_approval_policies
@@ -1058,7 +1086,7 @@ export async function listEntityApprovalPolicies(
 	const sql = getDb();
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
-       principal_mode, entity_type_slug, field_path, entity_id,
+       principal_mode, operation_key, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM write_approval_policies
@@ -1069,6 +1097,8 @@ export async function listEntityApprovalPolicies(
       CASE WHEN principal_kind IS NULL THEN 0 ELSE 1 END,
       principal_kind ASC NULLS FIRST,
       principal_id ASC NULLS FIRST,
+      CASE WHEN operation_key IS NULL THEN 0 ELSE 1 END,
+      operation_key ASC NULLS FIRST,
       CASE WHEN entity_type_slug IS NULL THEN 0 ELSE 1 END,
       entity_type_slug ASC NULLS FIRST,
       CASE WHEN entity_id IS NULL THEN 0 ELSE 1 END,
@@ -1164,6 +1194,12 @@ export async function upsertEntityApprovalPolicy(
 	const principalMode = principalKind
 		? normalizePrincipalMode(input.principalMode)
 		: null;
+	// operation_key scopes a connector_action row to one operation; meaningless (and
+	// dropped) for any other class so an entity/agent_config row can't smuggle one in.
+	const operationKey =
+		resourceClass === "connector_action"
+			? input.operationKey?.trim() || null
+			: null;
 	const entityTypeSlug = input.entityTypeSlug?.trim() || null;
 	const fieldPath = input.fieldPath?.trim() || null;
 	const entityId = input.entityId ?? null;
@@ -1202,11 +1238,12 @@ export async function upsertEntityApprovalPolicy(
         AND principal_kind IS NOT DISTINCT FROM ${principalKind}
         AND principal_id IS NOT DISTINCT FROM ${principalId}
         AND principal_mode IS NOT DISTINCT FROM ${principalMode}
+        AND operation_key IS NOT DISTINCT FROM ${operationKey}
         AND entity_type_slug IS NOT DISTINCT FROM ${entityTypeSlug}
         AND field_path IS NOT DISTINCT FROM ${fieldPath}
         AND entity_id IS NOT DISTINCT FROM ${entityId}
       RETURNING id, organization_id, resource_class, principal_kind, principal_id,
-       principal_mode, entity_type_slug, field_path, entity_id,
+       principal_mode, operation_key, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     `;
@@ -1218,19 +1255,19 @@ export async function upsertEntityApprovalPolicy(
 			const inserted = await tx<EntityApprovalPolicyRow>`
       INSERT INTO write_approval_policies (
         organization_id, resource_class, principal_kind, principal_id,
-        principal_mode, entity_type_slug, field_path, entity_id,
+        principal_mode, operation_key, entity_type_slug, field_path, entity_id,
         approval_connection_id, approval_channel_id, approval_team_id,
         approval_channel_name, created_at, updated_at
       ) VALUES (
         ${organizationId}, ${resourceClass}, ${principalKind}, ${principalId},
-        ${principalMode}, ${entityTypeSlug}, ${fieldPath}, ${entityId},
+        ${principalMode}, ${operationKey}, ${entityTypeSlug}, ${fieldPath}, ${entityId},
         ${approvalConnectionId},
         ${approvalChannelId}, ${approvalTeamId}, ${approvalChannelName},
         now(), now()
       )
       ON CONFLICT DO NOTHING
       RETURNING id, organization_id, resource_class, principal_kind, principal_id,
-       principal_mode, entity_type_slug, field_path, entity_id,
+       principal_mode, operation_key, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     `;
@@ -1255,6 +1292,7 @@ export async function deleteEntityApprovalPolicy(args: {
 	principalKind?: PolicyPrincipalKind | null;
 	principalId?: string | null;
 	principalMode?: PrincipalMode | null;
+	operationKey?: string | null;
 	entityTypeSlug?: string | null;
 	fieldPath?: string | null;
 	entityId?: number | null;
@@ -1265,6 +1303,10 @@ export async function deleteEntityApprovalPolicy(args: {
 	const principalMode = principalKind
 		? normalizePrincipalMode(args.principalMode)
 		: null;
+	const operationKey =
+		resourceClass === "connector_action"
+			? args.operationKey?.trim() || null
+			: null;
 	const entityTypeSlug = args.entityTypeSlug?.trim() || null;
 	const fieldPath = args.fieldPath?.trim() || null;
 	const entityId = args.entityId ?? null;
@@ -1287,6 +1329,7 @@ export async function deleteEntityApprovalPolicy(args: {
       AND principal_kind IS NOT DISTINCT FROM ${principalKind}
       AND principal_id IS NOT DISTINCT FROM ${principalId}
       AND principal_mode IS NOT DISTINCT FROM ${principalMode}
+      AND operation_key IS NOT DISTINCT FROM ${operationKey}
       AND entity_type_slug IS NOT DISTINCT FROM ${entityTypeSlug}
       AND field_path IS NOT DISTINCT FROM ${fieldPath}
       AND entity_id IS NOT DISTINCT FROM ${entityId}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -36,6 +36,7 @@ import {
 	upsertGlobalEntityApprovalPolicy,
 } from "./authz/entity-policy";
 import { listOperations } from "./operations/connector-operations";
+import { qualifiedOperationKey } from "./tools/admin/manage_operations";
 import {
 	isLegalActionEffect,
 	type WriteAction,
@@ -1687,15 +1688,17 @@ app.get("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
   `;
 	// The org's WRITE connector operations, so the matrix can render one row per
 	// operation under connector_action (always-expanded). Only write ops are gated —
-	// reads never mutate, so they carry no per-op rule. Deduped by operation_key
-	// (the same op can surface from multiple connections); the key is what the policy
-	// row and the execute gate both bind to.
+	// reads never mutate, so they carry no per-op rule. The row's `operation_key` is
+	// the CONNECTOR-QUALIFIED key (`connector_key::op`) — the exact value the policy
+	// row and the execute gate bind to — so Linear's and GitHub's `create_issue`
+	// stay distinct rows. Deduped by that qualified key (the same op can surface from
+	// multiple connections OF THE SAME connector).
 	const opList = await listOperations({
 		organizationId,
 		kind: "write",
 		includeInputSchema: false,
 		includeOutputSchema: false,
-		limit: 500,
+		limit: 1000,
 	});
 	const seenOps = new Set<string>();
 	const operations: Array<{
@@ -1705,10 +1708,11 @@ app.get("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 		connector_name: string;
 	}> = [];
 	for (const op of opList.operations) {
-		if (seenOps.has(op.operation_key)) continue;
-		seenOps.add(op.operation_key);
+		const key = qualifiedOperationKey(op.connector_key, op.operation_key);
+		if (seenOps.has(key)) continue;
+		seenOps.add(key);
 		operations.push({
-			operation_key: op.operation_key,
+			operation_key: key,
 			name: op.name,
 			connector_key: op.connector_key,
 			connector_name: op.connector_name,
@@ -1896,8 +1900,9 @@ app.put("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 			? body.operation_key.trim()
 			: null;
 	// A per-op rule must name an operation the org actually exposes — else a typo
-	// would create a dead row that gates nothing and clutters the matrix. Validate
-	// against the org's write-operation catalog (the same list the matrix renders).
+	// would create a dead row that gates nothing and clutters the matrix. The client
+	// sends the CONNECTOR-QUALIFIED key (`connector_key::op`); validate against the
+	// same qualified catalog the matrix renders.
 	if (operationKey) {
 		const known = await listOperations({
 			organizationId,
@@ -1906,7 +1911,12 @@ app.put("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 			includeOutputSchema: false,
 			limit: 1000,
 		});
-		if (!known.operations.some((op) => op.operation_key === operationKey)) {
+		const knownQualified = new Set(
+			known.operations.map((op) =>
+				qualifiedOperationKey(op.connector_key, op.operation_key),
+			),
+		);
+		if (!knownQualified.has(operationKey)) {
 			return c.json(
 				{
 					error: "invalid_request",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -35,6 +35,7 @@ import {
 	upsertEntityApprovalPolicy,
 	upsertGlobalEntityApprovalPolicy,
 } from "./authz/entity-policy";
+import { listOperations } from "./operations/connector-operations";
 import {
 	isLegalActionEffect,
 	type WriteAction,
@@ -1285,6 +1286,7 @@ function serializeEntityApprovalPolicy(policy: EntityApprovalPolicy) {
 		principal_kind: policy.principalKind,
 		principal_id: policy.principalId,
 		principal_mode: policy.principalMode,
+		operation_key: policy.operationKey,
 		entity_type_slug: policy.entityTypeSlug,
 		field_path: policy.fieldPath,
 		entity_id: policy.entityId,
@@ -1683,10 +1685,40 @@ app.get("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
     ) t
     ORDER BY name ASC
   `;
+	// The org's WRITE connector operations, so the matrix can render one row per
+	// operation under connector_action (always-expanded). Only write ops are gated —
+	// reads never mutate, so they carry no per-op rule. Deduped by operation_key
+	// (the same op can surface from multiple connections); the key is what the policy
+	// row and the execute gate both bind to.
+	const opList = await listOperations({
+		organizationId,
+		kind: "write",
+		includeInputSchema: false,
+		includeOutputSchema: false,
+		limit: 500,
+	});
+	const seenOps = new Set<string>();
+	const operations: Array<{
+		operation_key: string;
+		name: string;
+		connector_key: string;
+		connector_name: string;
+	}> = [];
+	for (const op of opList.operations) {
+		if (seenOps.has(op.operation_key)) continue;
+		seenOps.add(op.operation_key);
+		operations.push({
+			operation_key: op.operation_key,
+			name: op.name,
+			connector_key: op.connector_key,
+			connector_name: op.connector_name,
+		});
+	}
 	return c.json({
 		floor: floor.map(serializeEntityApprovalPolicy),
 		agent: agent.map(serializeEntityApprovalPolicy),
 		entity_types: typeRows.map((r) => ({ slug: r.slug, name: r.name })),
+		connector_operations: operations,
 	});
 });
 
@@ -1829,6 +1861,62 @@ app.put("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 			? body.entity_type_slug.trim()
 			: null;
 
+	// operation_key selects the per-operation connector row (null = the blanket
+	// execute row). Only `connector_action` is op-scoped. Same rules as
+	// entity_type_slug: a present-but-invalid key, or a key on a non-connector class,
+	// must 400 rather than silently coerce to null and overwrite the blanket rule.
+	const opKeyPresent =
+		body.operation_key !== undefined && body.operation_key !== null;
+	if (opKeyPresent && resourceClass !== "connector_action") {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: `operation_key is only valid for resource_class 'connector_action', not '${resourceClass}'.`,
+			},
+			400,
+		);
+	}
+	if (
+		opKeyPresent &&
+		(typeof body.operation_key !== "string" ||
+			body.operation_key.trim() === "")
+	) {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: "operation_key must be a non-empty string or omitted.",
+			},
+			400,
+		);
+	}
+	const operationKey =
+		resourceClass === "connector_action" &&
+		typeof body.operation_key === "string" &&
+		body.operation_key.trim()
+			? body.operation_key.trim()
+			: null;
+	// A per-op rule must name an operation the org actually exposes — else a typo
+	// would create a dead row that gates nothing and clutters the matrix. Validate
+	// against the org's write-operation catalog (the same list the matrix renders).
+	if (operationKey) {
+		const known = await listOperations({
+			organizationId,
+			kind: "write",
+			includeInputSchema: false,
+			includeOutputSchema: false,
+			limit: 1000,
+		});
+		if (!known.operations.some((op) => op.operation_key === operationKey)) {
+			return c.json(
+				{
+					error: "invalid_request",
+					message: `Unknown connector operation '${operationKey}' for this workspace.`,
+				},
+				400,
+			);
+		}
+	}
+
 	// The policy row targets this agent by id (a reusable slug). Confirm the agent
 	// EXISTS in this org before persisting — else a stale/typo'd URL would leave an
 	// orphan row that a future agent recreated with the same id silently inherits.
@@ -1849,6 +1937,7 @@ app.put("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 		principalKind: "agent",
 		principalId: agentId,
 		principalMode,
+		operationKey,
 		entityTypeSlug,
 		effects,
 		// Effect-only endpoint: keep any approval delivery target already on the row.
@@ -1925,12 +2014,41 @@ app.delete("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 	}
 	const entityTypeSlug =
 		resourceClass === "entity" ? (slugRaw?.trim() ?? null) || null : null;
+	// operation_key picks WHICH connector row to delete (null = the blanket execute
+	// row). Same guard as entity_type_slug: a present-but-empty value, or a key on a
+	// non-connector class, must NOT coerce to null and delete the blanket rule.
+	const opKeyRaw = c.req.query("operation_key");
+	if (
+		opKeyRaw !== undefined &&
+		opKeyRaw !== "" &&
+		resourceClass !== "connector_action"
+	) {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: `operation_key is only valid for resource_class 'connector_action', not '${resourceClass}'.`,
+			},
+			400,
+		);
+	}
+	if (opKeyRaw !== undefined && opKeyRaw.trim() === "") {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: "operation_key must be a non-empty string or omitted.",
+			},
+			400,
+		);
+	}
+	const operationKey =
+		resourceClass === "connector_action" ? (opKeyRaw?.trim() ?? null) || null : null;
 	const deleted = await deleteEntityApprovalPolicy({
 		organizationId,
 		resourceClass,
 		principalKind: "agent",
 		principalId: agentId,
 		principalMode,
+		operationKey,
 		entityTypeSlug,
 	});
 	invalidationEmitter.emit(organizationId, {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1698,7 +1698,7 @@ app.get("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 		kind: "write",
 		includeInputSchema: false,
 		includeOutputSchema: false,
-		limit: 1000,
+		limit: Number.MAX_SAFE_INTEGER,
 	});
 	const seenOps = new Set<string>();
 	const operations: Array<{
@@ -1909,7 +1909,7 @@ app.put("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 			kind: "write",
 			includeInputSchema: false,
 			includeOutputSchema: false,
-			limit: 1000,
+			limit: Number.MAX_SAFE_INTEGER,
 		});
 		const knownQualified = new Set(
 			known.operations.map((op) =>

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -88,6 +88,22 @@ type ConnectionRow = {
   name: string;
 };
 
+/**
+ * The write-gate scope key for one connector operation: `${connector_key}::${op}`.
+ * Operation keys (e.g. `send_message`, `create_issue`, `navigate`) are NOT unique
+ * across connectors — Linear and GitHub both expose `create_issue`, chrome/macos/ios
+ * all expose `navigate`. Binding a per-op policy row to the BARE key would make one
+ * admin's rule silently gate every connector that shares the key. Qualifying by
+ * connector_key scopes the rule to exactly the connector shown in the matrix. `::`
+ * separates because operation keys themselves contain dots (`slack.send_message`).
+ */
+export function qualifiedOperationKey(
+  connectorKey: string,
+  operationKey: string,
+): string {
+  return `${connectorKey}::${operationKey}`;
+}
+
 const manageOperationsTool = defineActionTool('manage_operations', {
   list_available: action(ListAvailableAction, handleListAvailable),
   execute: action(ExecuteAction, handleExecute),
@@ -505,7 +521,13 @@ async function handleListAvailable(
     };
   }
 
-  const result = await listOperations({
+  // Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
+  // ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
+  // its hidden count from the global total gives an inconsistent `total` across pages
+  // and can return a short page while visible ops remain past the offset (a client
+  // treating "short page = end" would silently truncate the catalog). Pagination must
+  // run on the post-filter list.
+  const full = await listOperations({
     organizationId: ctx.organizationId,
     connectorKey: args.connector_key,
     connectionId: args.connection_id,
@@ -514,27 +536,28 @@ async function handleListAvailable(
     backend: args.backend,
     includeInputSchema: args.include_input_schema ?? true,
     includeOutputSchema: args.include_output_schema ?? false,
-    limit: args.limit,
-    offset: args.offset,
   });
 
   // Hide any single operation whose PER-OP rule resolves to disabled (the blanket
   // isn't disabled or we'd have returned above). Humans always resolve auto, so this
   // only filters non-human principals; the effect calls short-circuit for users.
   const visibleFlags = await Promise.all(
-    result.operations.map((op) => effectFor(op.operation_key)),
+    full.operations.map((op) =>
+      effectFor(qualifiedOperationKey(op.connector_key, op.operation_key)),
+    ),
   );
-  const operations = result.operations.filter(
+  const visible = full.operations.filter(
     (_op, i) => visibleFlags[i] !== 'disabled',
   );
-  const hidden = result.operations.length - operations.length;
 
+  const offset = args.offset ?? 0;
+  const limit = args.limit ?? visible.length;
   return {
     action: 'list_available',
-    operations,
-    total: result.total - hidden,
-    limit: result.limit,
-    offset: result.offset,
+    operations: visible.slice(offset, offset + limit),
+    total: visible.length,
+    limit,
+    offset,
   };
 }
 
@@ -749,9 +772,14 @@ async function handleExecute(
 		ownerResolved: actor.ownerResolved,
 		mode: actor.mode,
 		action: "execute",
-		// A per-operation rule (e.g. deliveroo.place_order = approval) tightens the
-		// blanket execute for this op alone; the blanket applies to every other op.
-		operationKey: operation.operation_key,
+		// A per-operation rule (e.g. deliveroo::place_order = approval) tightens the
+		// blanket execute for this op alone; the blanket applies to every other op. The
+		// key is connector-qualified so the rule can't leak to another connector that
+		// exposes the same bare operation key.
+		operationKey: qualifiedOperationKey(
+			connection.connector_key,
+			operation.operation_key,
+		),
 	});
 	if (policyDecision === "deny") {
 		return {
@@ -1742,10 +1770,14 @@ async function handleApprove(
 							? "attended"
 							: "autonomous",
 					action: "execute",
-					// Recheck against the SAME operation the run was queued under (its
-					// action_key IS the operation_key), so a per-op rule installed after
-					// queueing still binds — mirrors the queue-time gate above.
-					operationKey: pendingRun.action_key,
+					// Recheck against the SAME operation the run was queued under, using the
+					// connector-qualified key (connector_key from the resolved connection +
+					// the persisted action_key), so a per-op rule installed after queueing
+					// still binds — mirrors the queue-time gate above.
+					operationKey: qualifiedOperationKey(
+						resolved.connection.connector_key,
+						pendingRun.action_key,
+					),
 				});
 	if (currentMode === "disabled" || recheckDecision === "deny") {
 		const why =

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -470,11 +470,11 @@ async function handleListAvailable(
 	args: Static<typeof ListAvailableAction>,
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
-  // A `disabled` connector_action effect turns the connector OFF for this
-  // principal — the operations shouldn't be listed at all (Disabled HIDES the
-  // action, unlike deny/approval which surface then gate on execute). The
-  // connector_action policy is one blanket `execute` per principal today (no
-  // per-op scope yet), so a disabled effect hides the whole connector's ops.
+  // A `disabled` connector_action effect turns an operation OFF for this principal
+  // — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
+  // which surface then gate on execute). Two levels now: the BLANKET `execute` rule
+  // (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
+  // can disable a single op while the rest stay listed.
   const actor = await resolveActingPrincipal(getDb(), {
     organizationId: ctx.organizationId,
     userId: ctx.userId,
@@ -482,17 +482,20 @@ async function handleListAvailable(
     sessionWatcherId: ctx.actingWatcherId ?? null,
     sourceForMode: ctx.sourceContext?.source,
   });
-  const effect = await resolveWriteEffect({
-    organizationId: ctx.organizationId,
-    resourceClass: 'connector_action',
-    principalKind: actor.kind,
-    principalId: actor.id,
-    ownerAgentId: actor.ownerAgentId,
-    ownerResolved: actor.ownerResolved,
-    mode: actor.mode,
-    action: 'execute',
-  });
-  if (effect === 'disabled') {
+  const effectFor = (operationKey?: string | null) =>
+    resolveWriteEffect({
+      organizationId: ctx.organizationId,
+      resourceClass: 'connector_action',
+      principalKind: actor.kind,
+      principalId: actor.id,
+      ownerAgentId: actor.ownerAgentId,
+      ownerResolved: actor.ownerResolved,
+      mode: actor.mode,
+      action: 'execute',
+      operationKey: operationKey ?? null,
+    });
+  // Cheap early exit: a blanket disable hides everything without listing.
+  if ((await effectFor(null)) === 'disabled') {
     return {
       action: 'list_available',
       operations: [],
@@ -515,10 +518,21 @@ async function handleListAvailable(
     offset: args.offset,
   });
 
+  // Hide any single operation whose PER-OP rule resolves to disabled (the blanket
+  // isn't disabled or we'd have returned above). Humans always resolve auto, so this
+  // only filters non-human principals; the effect calls short-circuit for users.
+  const visibleFlags = await Promise.all(
+    result.operations.map((op) => effectFor(op.operation_key)),
+  );
+  const operations = result.operations.filter(
+    (_op, i) => visibleFlags[i] !== 'disabled',
+  );
+  const hidden = result.operations.length - operations.length;
+
   return {
     action: 'list_available',
-    operations: result.operations,
-    total: result.total,
+    operations,
+    total: result.total - hidden,
     limit: result.limit,
     offset: result.offset,
   };
@@ -735,6 +749,9 @@ async function handleExecute(
 		ownerResolved: actor.ownerResolved,
 		mode: actor.mode,
 		action: "execute",
+		// A per-operation rule (e.g. deliveroo.place_order = approval) tightens the
+		// blanket execute for this op alone; the blanket applies to every other op.
+		operationKey: operation.operation_key,
 	});
 	if (policyDecision === "deny") {
 		return {
@@ -1725,6 +1742,10 @@ async function handleApprove(
 							? "attended"
 							: "autonomous",
 					action: "execute",
+					// Recheck against the SAME operation the run was queued under (its
+					// action_key IS the operation_key), so a per-op rule installed after
+					// queueing still binds — mirrors the queue-time gate above.
+					operationKey: pendingRun.action_key,
 				});
 	if (currentMode === "disabled" || recheckDecision === "deny") {
 		const why =

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -536,6 +536,12 @@ async function handleListAvailable(
     backend: args.backend,
     includeInputSchema: args.include_input_schema ?? true,
     includeOutputSchema: args.include_output_schema ?? false,
+    // Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
+    // would silently drop ops past index 100 and make them unreachable at any
+    // caller offset. We must filter per-op-disabled across the full set BEFORE
+    // slicing, so no internal cap here; the caller's limit/offset apply below.
+    limit: Number.MAX_SAFE_INTEGER,
+    offset: 0,
   });
 
   // Hide any single operation whose PER-OP rule resolves to disabled (the blanket


### PR DESCRIPTION
Extends the write-gate agent-envelope (#1837) with **per-operation** connector scope. An agent can now carry a stricter rule for a single connector operation (e.g. `deliveroo::place_order` = approval) while the blanket `execute` stays auto for every other op — the connector analog of per-entity-type scope.

## Design
A new `operation_key` scope column on `write_approval_policies`. For `connector_action`, a row with `operation_key` set is MORE SPECIFIC than the blanket (`operation_key IS NULL`) row and wins in the resolver's scope fold, most-restrictive (a per-op `auto` can't loosen a stricter blanket). Keys are **connector-qualified** (`connector_key::op`) so Linear's and GitHub's `create_issue` stay distinct.

- **Migration**: additive `operation_key` column + expand-before-contract unique index; reversible; squawk-clean.
- **Resolver**: `operation_key` threads through `loadCandidatePolicies` + `scopeSpecificity` + `resolveWriteEffect`/`resolveWritePolicyDecision`.
- **Gate**: `manage_operations` passes the connector-qualified key at execute AND the approve-time recheck; `list_available` hides a per-op-disabled op while keeping the rest (filters the full set before paginating).
- **API**: GET returns the org's write operations (`connector_operations`, qualified + deduped) for the UI; PUT/DELETE accept `operation_key` with validation (connector_action-only, must name a real op).
- **UI** (owletto#476): always-expanded per-op rows, client fold mirrors the server.
- **Deploy**: app Deployment pinned to `strategy: Recreate` (replicaCount 1) so no two server versions serve writes concurrently during a policy-schema migration — closes an old-pod clobber window.

## Review & verification
Fable review found 3 defects (op-key aliasing across connectors, list pagination-before-filtering, rolling-deploy clobber) + a follow-up (list cap at 100) — all fixed, final Fable pass CONFIRMED-GOOD. 292 server tests green (incl. 5 new real-PG resolver tests), 39 UI-model tests green. Migration roundtrip-verified, helm renders Recreate. Verified end-to-end against a live local gateway — screenshot below shows Place Order (Deliveroo) → approval override, Merge PR (GitHub) → deny, and GitHub vs Linear `Create Issue` as distinct rows (the aliasing fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786301131&installation_id=136316292&pr_number=1838&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1838&signature=f6cc4c387e9a36cf91d064c05c7206dd57ee750428d3839e0a46a8094a7810c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-operation write approval policy support for connector actions (via operation-specific scoping).
  * Agent permissions APIs now include `connector_operations` and allow creating/deleting operation-scoped policies with a connector-qualified operation key.
  * Connector action availability and execution/approval rechecks now apply the correct per-operation policy.

* **Bug Fixes**
  * Improved connector operation listing and pagination so disabled per-operation effects are filtered consistently.
  * Prevented per-operation rules from aliasing across connectors that share a bare operation name.

* **Chores**
  * Updated deployment strategy to use `Recreate` to avoid overlapping versions during upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->