### PR TITLE
feat(agents): merge defaultModel+installedProviders into one ordered models allow-list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         # pure-unit subdirectories that don't touch Postgres.
         run: |
           bun test packages/server/src/__tests__/unit
-          bun test packages/server/src/auth/__tests__/tool-access.test.ts
+          bun test packages/server/src/auth/__tests__/tool-access.test.ts packages/server/src/auth/__tests__/system-provider-resolution.test.ts
 
       - name: connector-worker (bun:test)
         # openclaw-plugin e2e tests need a live backend and belong in the

--- a/db/migrations/20260710130000_agent_models_list.sql
+++ b/db/migrations/20260710130000_agent_models_list.sql
@@ -1,0 +1,250 @@
+-- migrate:up
+
+-- Merge the agent's two model-provider columns into ONE ordered `models` list:
+-- a jsonb array of explicit `<providerSlug>/<model>` refs. Index 0 = the
+-- agent's default; the rest are its alternates (fallback candidates and the
+-- per-channel override pick-list). NULL/empty ⇒ every org provider is
+-- available and the default falls through to the org default model.
+--
+-- ATOMIC CUTOVER: the legacy `model` + `installed_providers` columns are
+-- backfilled into `models` and then DROPPED in this same migration — there is
+-- no dual-write window. This migration must run as part of the coordinated
+-- deploy: old server code cannot run against the post-migration schema.
+
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS models jsonb;
+
+-- Backfill order per agent:
+--   1. The legacy `model` ref, when it is a real `<slug>/<model>` (skipped when
+--      empty / 'auto' / slash-less). A `<slug>/auto` ref contributes its SLUG
+--      (resolved to a concrete model below) but not the 'auto' ref itself —
+--      'auto' is removed everywhere.
+--   2. Each `installed_providers` entry, in install order, whose slug isn't
+--      already covered — resolved to a CONCRETE model `<slug>/<default>` from:
+--        a. the provider's catalog defaultModel (config/providers.json,
+--         inlined below — a SQL migration cannot read the config file), else
+--        b. the org's own `inference_providers` row for that slug
+--           (`capabilities.text.model` — the same field the runtime uses as a
+--           synthesized org-provider's default), else
+--        c. the entry is SKIPPED (never emit `<slug>/auto`).
+--
+-- RESTRICTION INVARIANT (critical): an agent that was RESTRICTED before this
+-- migration (had a non-empty `model` OR any `installed_providers` entry) must
+-- NEVER end up with `models = NULL` — NULL is allow-all, so that would silently
+-- WIDEN its access. When such an agent's providers resolve to zero concrete
+-- refs (e.g. a `chatgpt/auto`-only agent with no catalog default and no org
+-- row), we preserve its restriction with a deterministic sentinel ref
+-- `<slug>/__unresolved__` per distinct restricted slug: non-NULL (not allow-all)
+-- and it never matches a real model, so the gate stays closed rather than open.
+--
+-- Idempotent: only rows with `models IS NULL` are touched. The join is on the
+-- composite PK (id, organization_id) — the same agent id exists in many orgs.
+
+WITH provider_defaults(slug, default_model) AS (
+    -- Snapshot of config/providers.json defaultModel per provider id at
+    -- migration-authoring time. Providers without a defaultModel there
+    -- (chatgpt, elevenlabs) are intentionally absent.
+    VALUES
+        ('claude', 'claude-sonnet-5'),
+        ('groq', 'llama-3.3-70b-versatile'),
+        ('gemini', 'gemini-2.5-pro'),
+        ('together-ai', 'meta-llama/Llama-3.3-70B-Instruct-Turbo'),
+        ('nvidia', 'nvidia/moonshotai/kimi-k2.6'),
+        ('z-ai', 'glm-5.2'),
+        ('fireworks', 'accounts/fireworks/models/llama-v3p3-70b-instruct'),
+        ('mistral', 'mistral-large-latest'),
+        ('deepseek', 'deepseek-v4-flash'),
+        ('openrouter', 'anthropic/claude-sonnet-5'),
+        ('cerebras', 'llama-3.3-70b'),
+        ('opencode-zen', 'claude-sonnet-4-6'),
+        ('xai', 'grok-4'),
+        ('perplexity', 'sonar'),
+        ('cohere', 'command-a-03-2025'),
+        ('openai', 'gpt-5.6-sol')
+),
+restricted AS (
+    -- Agents that were RESTRICTED before this migration: a non-empty legacy
+    -- `model` OR at least one installed provider. These must never become NULL.
+    SELECT a.id, a.organization_id
+    FROM agents a
+    WHERE a.models IS NULL
+      AND (
+          COALESCE(a.model, '') <> ''
+          OR jsonb_array_length(COALESCE(a.installed_providers, '[]'::jsonb)) > 0
+      )
+),
+candidates AS (
+    -- ord 0: the legacy model ref's slug (+ the explicit ref when concrete).
+    SELECT a.id,
+           a.organization_id,
+           0 AS ord,
+           split_part(a.model, '/', 1) AS slug,
+           CASE
+               WHEN substr(a.model, position('/' in a.model) + 1)
+                    NOT IN ('', 'auto')
+               THEN a.model
+           END AS explicit_ref
+    FROM agents a
+    WHERE a.models IS NULL
+      AND COALESCE(a.model, '') <> ''
+      AND position('/' in a.model) > 1
+  UNION ALL
+    -- ord 1..n: installed providers, in install order (slug only).
+    SELECT a.id,
+           a.organization_id,
+           ip.ord::int AS ord,
+           ip.value->>'providerId' AS slug,
+           NULL AS explicit_ref
+    FROM agents a,
+         jsonb_array_elements(COALESCE(a.installed_providers, '[]'::jsonb))
+             WITH ORDINALITY AS ip(value, ord)
+    WHERE a.models IS NULL
+      AND COALESCE(ip.value->>'providerId', '') <> ''
+),
+resolved AS (
+    -- Concrete ref per candidate: the explicit legacy ref wins; otherwise the
+    -- slug's catalog default, else the org row's text model. In EVERY prefixed
+    -- path the model is qualified to `<slug>/<model>` ONLY when it isn't already
+    -- `<slug>/…`-qualified — provider-native ids can contain slashes (openrouter
+    -- `anthropic/…`, nvidia `nvidia/moonshotai/…`), so a catalog default or org
+    -- model that already carries its slug must NOT be double-prefixed to
+    -- `<slug>/<slug>/…`. NULL ⇒ no concrete model.
+    SELECT c.id,
+           c.organization_id,
+           c.ord,
+           c.slug,
+           CASE
+               WHEN c.explicit_ref IS NOT NULL THEN c.explicit_ref
+               WHEN pd.default_model IS NOT NULL
+                   THEN CASE
+                       WHEN pd.default_model LIKE c.slug || '/%'
+                       THEN pd.default_model
+                       ELSE c.slug || '/' || pd.default_model
+                   END
+               WHEN NULLIF(org.capabilities->'text'->>'model', '') IS NOT NULL
+                   THEN CASE
+                       WHEN (org.capabilities->'text'->>'model')
+                            LIKE c.slug || '/%'
+                       THEN org.capabilities->'text'->>'model'
+                       ELSE c.slug || '/' || (org.capabilities->'text'->>'model')
+                   END
+           END AS ref
+    FROM candidates c
+    LEFT JOIN provider_defaults pd
+           ON pd.slug = c.slug
+    LEFT JOIN inference_providers org
+           ON org.organization_id = c.organization_id
+          AND org.slug = c.slug
+          AND org.deleted_at IS NULL
+),
+ranked AS (
+    -- First appearance per slug wins (the legacy model ref sorts first). A slug
+    -- whose only candidates resolved to NULL still appears here (ref NULL) so we
+    -- can emit a restriction sentinel for it below — otherwise a restricted
+    -- agent whose every provider is unresolvable would fold to zero rows.
+    SELECT id, organization_id, ord, slug, ref,
+           ROW_NUMBER() OVER (
+               PARTITION BY organization_id, id, slug ORDER BY ord
+           ) AS rn
+    FROM resolved
+),
+refs AS (
+    -- The concrete refs (first appearance per slug), plus — for a RESTRICTED
+    -- agent whose slug resolved to no concrete model — a deterministic sentinel
+    -- `<slug>/__unresolved__` so the agent stays non-NULL (restricted), never
+    -- silently widening to allow-all.
+    SELECT rk.id, rk.organization_id, rk.ord,
+           COALESCE(rk.ref, rk.slug || '/__unresolved__') AS ref
+    FROM ranked rk
+    WHERE rk.rn = 1
+      AND (rk.ref IS NOT NULL
+           OR EXISTS (
+               SELECT 1 FROM restricted r
+               WHERE r.id = rk.id AND r.organization_id = rk.organization_id
+           ))
+),
+folded AS (
+    SELECT id, organization_id,
+           jsonb_agg(ref ORDER BY ord) AS models
+    FROM refs
+    GROUP BY id, organization_id
+),
+-- A RESTRICTED agent that produced NO folded row at all (e.g. legacy
+-- `model = 'auto'` or a bare unqualified `model = 'gpt-4o'` with no providers —
+-- the slash filter drops it as a candidate, so `folded` has nothing for it)
+-- must STILL end up non-NULL, or it would silently widen to allow-all after the
+-- column drop. Give it a single deterministic `legacy/__unresolved__` sentinel:
+-- non-NULL (restricted) and never routable, so the gate stays closed.
+restricted_no_fold AS (
+    SELECT r.id, r.organization_id,
+           '["legacy/__unresolved__"]'::jsonb AS models
+    FROM restricted r
+    WHERE NOT EXISTS (
+        SELECT 1 FROM folded f
+        WHERE f.id = r.id AND f.organization_id = r.organization_id
+    )
+),
+final_models AS (
+    SELECT id, organization_id, models FROM folded
+    UNION ALL
+    SELECT id, organization_id, models FROM restricted_no_fold
+)
+UPDATE agents a
+SET models = f.models,
+    updated_at = now()
+FROM final_models f
+WHERE a.id = f.id
+  AND a.organization_id = f.organization_id
+  AND a.models IS NULL;
+
+-- Drop the legacy columns AFTER the backfill (atomic cutover, no dual-write).
+ALTER TABLE agents DROP COLUMN IF EXISTS model;
+ALTER TABLE agents DROP COLUMN IF EXISTS installed_providers;
+
+-- Defense-in-depth for the per-binding (Listen) model override: null out any
+-- legacy `agent_channel_bindings.model` that is NOT a valid `<slug>/<model>`
+-- ref (e.g. the retired literal 'auto', or a bare model id with no provider
+-- prefix). The runtime already fails such overrides closed (drops them and
+-- falls to the agent default), but clearing them here keeps the stored state
+-- honest and avoids re-warning on every message. Idempotent.
+UPDATE agent_channel_bindings
+SET model = NULL
+WHERE model IS NOT NULL
+  AND (
+      position('/' in model) <= 1
+      OR model LIKE '%/'
+      OR split_part(model, '/', 2) = 'auto'
+  );
+
+-- migrate:down
+
+-- Best-effort restore: models[0] becomes the pinned `model`, and each distinct
+-- slug prefix becomes an installed_providers entry (install timestamps are not
+-- recoverable; now() epoch millis are stamped).
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS model text;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS installed_providers jsonb DEFAULT '[]'::jsonb;
+
+UPDATE agents a
+SET model = a.models->>0,
+    installed_providers = COALESCE(
+        (
+            SELECT jsonb_agg(
+                       jsonb_build_object(
+                           'providerId', slugs.slug,
+                           'installedAt', (extract(epoch from now()) * 1000)::bigint
+                       )
+                       ORDER BY slugs.first_ord
+                   )
+            FROM (
+                SELECT split_part(ref.value, '/', 1) AS slug,
+                       min(ref.ord) AS first_ord
+                FROM jsonb_array_elements_text(a.models)
+                         WITH ORDINALITY AS ref(value, ord)
+                WHERE position('/' in ref.value) > 1
+                GROUP BY split_part(ref.value, '/', 1)
+            ) AS slugs
+        ),
+        '[]'::jsonb
+    )
+WHERE a.models IS NOT NULL;
+
+ALTER TABLE agents DROP COLUMN IF EXISTS models;

--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -157,15 +157,12 @@ describe("apply diff — settings", () => {
     expect(renderPlan(plan)).toMatchSnapshot();
   });
 
-  test("updates when provider declarations change but ignores installedAt churn", () => {
+  test("#5: updates when the models list changes; noop when it matches", () => {
     const desired = buildState([
       buildDesiredAgent("triage", {
         metadata: { agentId: "triage", name: "Triage" },
         settings: {
-          installedProviders: [
-            { providerId: "anthropic", installedAt: 200 },
-            { providerId: "openai", installedAt: 200 },
-          ],
+          models: ["anthropic/claude-sonnet-5", "openai/gpt-5"],
         },
       }),
     ]);
@@ -173,13 +170,7 @@ describe("apply diff — settings", () => {
       ...emptyRemote(),
       agents: [{ agentId: "triage", name: "Triage" }],
       agentSettings: new Map<string, AgentSettings | null>([
-        [
-          "triage",
-          {
-            installedProviders: [{ providerId: "anthropic", installedAt: 100 }],
-            updatedAt: 0,
-          },
-        ],
+        ["triage", { models: ["anthropic/claude-sonnet-5"], updatedAt: 0 }],
       ]),
       platformsByAgent: new Map([["triage", []]]),
     };
@@ -187,19 +178,17 @@ describe("apply diff — settings", () => {
     const settingsRow = plan.rows.find((r) => r.kind === "settings");
     expect(settingsRow?.verb).toBe("update");
     if (settingsRow?.kind === "settings") {
-      expect(settingsRow.changedFields).toContain("installedProviders");
+      expect(settingsRow.changedFields).toContain("models");
     }
 
+    // Same ordered list ⇒ noop.
     const unchanged = computeDiff(desired, {
       ...remote,
       agentSettings: new Map<string, AgentSettings | null>([
         [
           "triage",
           {
-            installedProviders: [
-              { providerId: "anthropic", installedAt: 1 },
-              { providerId: "openai", installedAt: 2 },
-            ],
+            models: ["anthropic/claude-sonnet-5", "openai/gpt-5"],
             updatedAt: 0,
           },
         ],
@@ -209,6 +198,36 @@ describe("apply diff — settings", () => {
       (r) => r.kind === "settings"
     );
     expect(unchangedSettingsRow?.verb).toBe("noop");
+  });
+
+  test("#5: models is order-sensitive — reordering is a change (index 0 = default)", () => {
+    const desired = buildState([
+      buildDesiredAgent("triage", {
+        metadata: { agentId: "triage", name: "Triage" },
+        settings: { models: ["openai/gpt-5", "anthropic/claude-sonnet-5"] },
+      }),
+    ]);
+    const remote: RemoteSnapshot = {
+      ...emptyRemote(),
+      agents: [{ agentId: "triage", name: "Triage" }],
+      agentSettings: new Map<string, AgentSettings | null>([
+        [
+          "triage",
+          {
+            models: ["anthropic/claude-sonnet-5", "openai/gpt-5"],
+            updatedAt: 0,
+          },
+        ],
+      ]),
+      platformsByAgent: new Map([["triage", []]]),
+    };
+    const settingsRow = computeDiff(desired, remote).rows.find(
+      (r) => r.kind === "settings"
+    );
+    expect(settingsRow?.verb).toBe("update");
+    if (settingsRow?.kind === "settings") {
+      expect(settingsRow.changedFields).toContain("models");
+    }
   });
 });
 

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -41,10 +41,9 @@ describe("mapProjectToDesiredState", () => {
     const agent = state.agents[0];
     expect(agent?.metadata.agentId).toBe("crm");
     expect(agent?.metadata.name).toBe("crm"); // defaults to id
-    expect(agent?.settings.installedProviders?.[0]?.providerId).toBe(
-      "anthropic"
-    );
-    expect(agent?.settings.defaultModel).toBe("claude-sonnet-4-6");
+    // The provider collapses to a single ordered `models` list entry
+    // (`<provider>/<model>`) — no separate installedProviders/defaultModel.
+    expect(agent?.settings.models).toEqual(["anthropic/claude-sonnet-4-6"]);
     expect(agent?.settings.networkConfig?.allowedDomains).toEqual([
       "github.com",
     ]);
@@ -54,6 +53,79 @@ describe("mapProjectToDesiredState", () => {
     ]);
     expect(state.requiredSecrets).toContain("ANTHROPIC_API_KEY");
     expect(state.memory).toEqual({ org: "o" });
+  });
+
+  test("#5: multiple providers → ordered models list; already-qualified model not double-prefixed", () => {
+    const multi = defineAgent({
+      id: "multi",
+      providers: [
+        { id: "openai", model: "gpt-5", key: secret("ANTHROPIC_API_KEY") },
+        // Already `<slug>/…`-qualified (provider-native id with a slash).
+        {
+          id: "openrouter",
+          model: "openrouter/anthropic/claude-sonnet-5",
+          key: secret("ANTHROPIC_API_KEY"),
+        },
+      ],
+    });
+    const state = mapProjectToDesiredState(
+      defineConfig({ org: "o", agents: [multi] }),
+      env
+    );
+    const agent = state.agents[0];
+    // Order preserved (index 0 = primary); no `<slug>/<slug>/…` double-prefix.
+    expect(agent?.settings.models).toEqual([
+      "openai/gpt-5",
+      "openrouter/anthropic/claude-sonnet-5",
+    ]);
+  });
+
+  test("#3: a provider with NO model maps to the sentinel ref (no crash)", () => {
+    // `lobu init --provider chatgpt` emits a provider with no model (ChatGPT has
+    // no catalog default). map-config must NOT crash on p.model.trim() — it maps
+    // to the `<slug>/__unresolved__` restriction sentinel so the agent stays
+    // gated (never allow-all).
+    const chat = defineAgent({
+      id: "chat",
+      providers: [{ id: "chatgpt", key: secret("ANTHROPIC_API_KEY") }],
+    });
+    const state = mapProjectToDesiredState(
+      defineConfig({ org: "o", agents: [chat] }),
+      env
+    );
+    expect(state.agents[0]?.settings.models).toEqual([
+      "chatgpt/__unresolved__",
+    ]);
+  });
+
+  test("#3: mixed — a model-less provider (sentinel) alongside a concrete one", () => {
+    const mixed = defineAgent({
+      id: "mixed",
+      providers: [
+        { id: "chatgpt", key: secret("ANTHROPIC_API_KEY") },
+        { id: "openai", model: "gpt-5", key: secret("ANTHROPIC_API_KEY") },
+      ],
+    });
+    const state = mapProjectToDesiredState(
+      defineConfig({ org: "o", agents: [mixed] }),
+      env
+    );
+    expect(state.agents[0]?.settings.models).toEqual([
+      "chatgpt/__unresolved__",
+      "openai/gpt-5",
+    ]);
+  });
+
+  test("#5: a provider with NO id is a config error (never emits '/__unresolved__')", () => {
+    const bad = defineAgent({
+      id: "bad",
+      // A provider entry with no id is meaningless — must throw at map time,
+      // not silently emit a bogus "/__unresolved__" ref the server rejects.
+      providers: [{} as any],
+    });
+    expect(() =>
+      mapProjectToDesiredState(defineConfig({ org: "o", agents: [bad] }), env)
+    ).toThrow(/provider with no "id"/);
   });
 
   test("maps agent platforms: stable id + RESOLVED secret values + literals + collected secrets", () => {

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -217,7 +217,7 @@ export interface DesiredAgent {
    * Settings payload destined for `PATCH /:agentId/config`. Built by the mapper
    * + agent-dir loader: networkConfig, skillsConfig,
    * preApprovedTools, guardrails, toolsConfig, nixConfig,
-   * defaultModel, installedProviders,
+   * models (ordered `<provider>/<model>` refs),
    * identityMd/soulMd/userMd.
    */
   settings: Partial<AgentSettings>;

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -332,9 +332,9 @@ function diffAgent(
  * AgentSettings shape currently has no redacted leaf strings, so this is a
  * forward-compatible guard rather than a hot path today.
  *
- * Field set: limited to the keys lobu.config.ts can express today. Settings that
- * only the UI mutates (e.g. `installedProviders[].installedAt`) are
- * excluded so unrelated UI activity doesn't show up as drift in the plan.
+ * Field set: limited to the keys lobu.config.ts can express today. The agent's
+ * model configuration is a single ordered `models` list of explicit
+ * `<provider>/<model>` refs (the merged defaultModel + installedProviders).
  */
 const SETTINGS_FIELDS: Array<keyof AgentSettings> = [
   "networkConfig",
@@ -343,18 +343,11 @@ const SETTINGS_FIELDS: Array<keyof AgentSettings> = [
   "toolsConfig",
   "guardrails",
   "preApprovedTools",
-  "defaultModel",
-  "installedProviders",
+  "models",
   "soulMd",
   "userMd",
   "identityMd",
 ];
-
-function normalizeInstalledProviders(
-  providers: AgentSettings["installedProviders"] | undefined
-): string[] | undefined {
-  return providers?.map((provider) => provider.providerId);
-}
 
 function diffSettings(
   agentId: string,
@@ -364,17 +357,6 @@ function diffSettings(
   const changed: string[] = [];
   for (const field of SETTINGS_FIELDS) {
     if (!(field in desired)) continue;
-    if (field === "installedProviders") {
-      if (
-        !deepEqual(
-          normalizeInstalledProviders(desired.installedProviders),
-          normalizeInstalledProviders(remote?.installedProviders)
-        )
-      ) {
-        changed.push(field);
-      }
-      continue;
-    }
     if (!deepEqual(desired[field], remote?.[field])) {
       changed.push(field);
     }

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -24,7 +24,7 @@ import type {
   RelationshipType,
   Watcher,
 } from "../../../config/index.js";
-import { isSecretRef } from "../../../config/index.js";
+import { isSecretRef, UNRESOLVED_MODEL_SUFFIX } from "../../../config/index.js";
 import { ValidationError } from "../../memory/_lib/errors.js";
 import type {
   DesiredAgent,
@@ -88,9 +88,9 @@ function envRefName(value: string): string | null {
   return match ? (match[1] ?? null) : null;
 }
 
-/** Provider id used as the storage key; falls back to the model when omitted. */
+/** Provider slug used as the storage key. `id` is required on a provider. */
 function providerId(provider: ProviderConfig): string {
-  return provider.id ?? provider.model;
+  return (provider.id ?? "").trim();
 }
 
 /**
@@ -279,18 +279,29 @@ function mapAgent(
   const settings: Partial<AgentSettings> = {};
 
   if (agent.providers?.length) {
-    // installedProviders stays the provider-install/catalog list; the model
-    // collapses to a single defaultModel — the primary provider's declared
-    // model, or "<providerId>/auto" for its newest live model.
-    settings.installedProviders = agent.providers.map((p) => ({
-      providerId: providerId(p),
-      installedAt: Date.now(),
-    }));
-    const primary = agent.providers[0];
-    if (primary) {
-      const primaryModel = primary.model?.trim();
-      settings.defaultModel = primaryModel || `${providerId(primary)}/auto`;
-    }
+    // Each declared provider becomes one explicit ref in the ordered `models`
+    // list (index 0 = the primary/default). A provider WITH a concrete model
+    // emits `<providerId>/<model>` (never `<providerId>/auto` — auto is gone);
+    // a model already `<slug>/`-qualified (provider-native ids can contain
+    // slashes) is used verbatim, never double-prefixed. A provider with NO
+    // model (e.g. ChatGPT, which has no catalog default) emits the
+    // `<providerId>/__unresolved__` restriction sentinel — the same way the
+    // server represents "provider intended, no model resolved" — so the agent
+    // stays gated (never allow-all) and the config still applies without a
+    // crash.
+    settings.models = agent.providers.map((p) => {
+      const id = providerId(p);
+      // A provider with no id is a config error — it would emit a bogus
+      // "/__unresolved__" ref the server rejects. Fail loudly at map time.
+      if (!id) {
+        throw new Error(
+          `Agent "${agent.id}" has a provider with no "id". Every provider must declare an "id" (e.g. { id: "openai", model: "gpt-5" }).`
+        );
+      }
+      const model = p.model?.trim();
+      if (!model) return `${id}/${UNRESOLVED_MODEL_SUFFIX}`;
+      return model.startsWith(`${id}/`) ? model : `${id}/${model}`;
+    });
   }
 
   const allowed = agent.network?.allowed ?? [];

--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -87,8 +87,7 @@ function fullOrgRoutes(): Record<string, () => unknown> {
       organizations: [{ id: "org-1", slug: "acme", name: "Acme Inc" }],
     }),
     "/agents/sales/config": () => ({
-      installedProviders: [{ providerId: "anthropic", installedAt: 111 }],
-      defaultModel: "claude/sonnet-4-5",
+      models: ["anthropic/claude-sonnet-5"],
       networkConfig: {
         allowedDomains: ["github.com", ".github.com"],
         deniedDomains: ["evil.com"],
@@ -251,10 +250,7 @@ describe("lobu init --from-org", () => {
       name: "Sales",
       description: "Revenue agent",
     });
-    expect(agent?.settings.installedProviders?.[0]?.providerId).toBe(
-      "anthropic"
-    );
-    expect(agent?.settings.defaultModel).toBe("claude/sonnet-4-5");
+    expect(agent?.settings.models).toEqual(["anthropic/claude-sonnet-5"]);
     expect(agent?.settings.networkConfig).toEqual({
       allowedDomains: ["github.com", ".github.com"],
       deniedDomains: ["evil.com"],
@@ -383,6 +379,45 @@ describe("lobu init --from-org", () => {
     expect(state.memorySchema.entityTypes).toHaveLength(0);
     expect(state.watchers).toHaveLength(0);
     expect(state.connectors.connections).toHaveLength(0);
+  });
+
+  test("#3: a server models[] with an __unresolved__ sentinel round-trips (no crash, no spurious diff)", async () => {
+    const dir = mkFixtureDir();
+    await initFromOrg({
+      targetDir: dir,
+      fetchImpl: buildFetch({
+        "/oauth/userinfo": () => ({
+          organizations: [{ id: "org-1", slug: "acme", name: "Acme Inc" }],
+        }),
+        // The server represents "provider intended, no model resolved" as a
+        // sentinel ref. Bootstrap must emit a provider config with NO model,
+        // and re-mapping must reproduce the SAME models[] — a stable no-op.
+        "/agents/lone/config": () => ({
+          models: ["chatgpt/__unresolved__", "openai/gpt-5"],
+          updatedAt: 0,
+        }),
+        "/agents": () => ({ agents: [{ agentId: "lone", name: "Lone" }] }),
+        "watchers?include_details": () => ({ watchers: [] }),
+        manage_entity_schema: () => ({
+          entity_types: [],
+          relationship_types: [],
+        }),
+        manage_auth_profiles: () => ({ auth_profiles: [] }),
+        manage_connections: () => ({ connections: [] }),
+      }),
+    });
+
+    const env = {
+      CHATGPT_API_KEY: "x",
+      OPENAI_API_KEY: "y",
+    } as NodeJS.ProcessEnv;
+    const { state } = await loadDesiredStateFromConfig({ cwd: dir, env });
+    // Re-mapped models EXACTLY equal the server's list — the sentinel round-trips
+    // (a diff against the remote would be a no-op).
+    expect(state.agents[0]?.settings.models).toEqual([
+      "chatgpt/__unresolved__",
+      "openai/gpt-5",
+    ]);
   });
 
   test("env auth profile → credentials keyed by the connector's auth-schema field, not <SLUG>_VALUE", async () => {

--- a/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
@@ -17,6 +17,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import type { AgentSettings } from "@lobu/core";
 import chalk from "chalk";
+import { UNRESOLVED_MODEL_SUFFIX } from "../../../config/index.js";
 import { printText } from "../../../internal/output.js";
 import type {
   ApplyClient,
@@ -277,28 +278,33 @@ function emitAgent(
   const files: Array<{ relPath: string; body: string }> = [];
   const dir = `agents/${agent.agentId}`;
 
-  // providers ← installedProviders (+ secret key). The agent's single
-  // defaultModel attaches to the PRIMARY provider (installedProviders[0]); a
-  // bare "<id>/auto" is the implicit default, so it's not emitted.
-  const providers = settings?.installedProviders ?? [];
-  if (providers.length > 0) {
-    const defaultModel = settings?.defaultModel?.trim();
-    const primaryId = providers[0]?.providerId;
-    const items = providers.map((p) => {
-      const id = p.providerId;
-      const model =
-        id === primaryId && defaultModel && defaultModel !== `${id}/auto`
-          ? defaultModel
-          : undefined;
-      const envVar = envVarFor(id, "API_KEY");
-      const provFields = [
-        `id: ${str(id)}`,
-        ...(model ? [`model: ${str(model)}`] : []),
-        `key: ${secrets.ref(envVar)}`,
-      ];
-      return objectLiteral(provFields, 2);
-    });
-    fields.push(`providers: [\n    ${items.join(",\n    ")},\n  ]`);
+  // providers ← models[] (+ secret key). Each `<slug>/<model>` ref becomes one
+  // provider `{ id, model }`, in list order (index 0 = the primary/default).
+  // An `<slug>/__unresolved__` restriction sentinel carries no real model, so
+  // it re-emits as a provider with no `model` (the operator picks one). The
+  // ref's model may itself contain slashes (provider-native ids), so only the
+  // FIRST segment is the slug; the remainder is the model.
+  const models = settings?.models ?? [];
+  if (models.length > 0) {
+    const items = models
+      .map((ref) => {
+        const slash = ref.indexOf("/");
+        if (slash <= 0) return null;
+        const id = ref.slice(0, slash);
+        const model = ref.slice(slash + 1);
+        const isSentinel = model === UNRESOLVED_MODEL_SUFFIX;
+        const envVar = envVarFor(id, "API_KEY");
+        const provFields = [
+          `id: ${str(id)}`,
+          ...(isSentinel ? [] : [`model: ${str(model)}`]),
+          `key: ${secrets.ref(envVar)}`,
+        ];
+        return objectLiteral(provFields, 2);
+      })
+      .filter((item): item is string => item !== null);
+    if (items.length > 0) {
+      fields.push(`providers: [\n    ${items.join(",\n    ")},\n  ]`);
+    }
   }
 
   // network ← networkConfig (allowed/denied).

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -18,9 +18,9 @@ export async function validateCommand(cwd: string): Promise<boolean> {
 
   const warnings: string[] = [];
   for (const agent of state.agents) {
-    if (!agent.settings.installedProviders?.length) {
+    if (!agent.settings.models?.length) {
       warnings.push(
-        `agent "${agent.metadata.agentId}" has no providers configured. It will need provider keys at runtime.`
+        `agent "${agent.metadata.agentId}" has no models configured. It will need provider keys + a model at runtime.`
       );
     }
   }

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -395,9 +395,31 @@ export function defineWatcher(config: Omit<Watcher, "kind">): Watcher {
 // Agents
 // ---------------------------------------------------------------------------
 
+/**
+ * Model suffix for a provider with no resolved concrete model. Kept in lockstep
+ * with the server's `UNRESOLVED_MODEL_SUFFIX` (a `<slug>/__unresolved__` ref is
+ * a restriction sentinel: it keeps the agent gated, never routes, never emits
+ * `<slug>/auto`). Duplicated here rather than imported so the CLI never depends
+ * on the server package.
+ */
+export const UNRESOLVED_MODEL_SUFFIX = "__unresolved__";
+
 export interface ProviderConfig {
-  id?: string;
-  model: string;
+  /**
+   * Provider slug (`openai`, `chatgpt`, an org inference-provider slug, …).
+   * REQUIRED — a provider entry with no id is meaningless (it would map to a
+   * `/__unresolved__` ref the server rejects).
+   */
+  id: string;
+  /**
+   * Concrete model id for this provider (`gpt-5`, or a provider-native id that
+   * may itself contain slashes). OPTIONAL: some providers have no catalog
+   * default (e.g. ChatGPT) and `lobu init --provider <id>` omits it; a provider
+   * with no model maps to the `<slug>/__unresolved__` restriction sentinel in
+   * the agent's ordered `models` list (the operator picks a concrete model
+   * later). Never emits `<slug>/auto`.
+   */
+  model?: string;
   key?: string | SecretRef;
 }
 

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -10,7 +10,6 @@ import type { PluginsConfig } from "./plugin-types";
 import type {
   AgentInlineGuardrail,
   AuthProfile,
-  InstalledProvider,
   NetworkConfig,
   NixConfig,
   SkillsConfig,
@@ -27,13 +26,15 @@ import type {
  */
 export interface AgentSettings {
   /**
-   * The agent's default model — a `provider/model` ref (e.g.
-   * "claude/claude-sonnet-4-6") or the literal "auto" (newest live model for the
-   * provider). Optional: when unset, model resolution falls through to the org's
-   * default inference provider (`inference_providers.is_default` →
-   * `capabilities.text.model`). A behavior may override this per-run.
+   * Ordered list of explicit model refs `<providerSlug>/<model>`. Index 0 = the
+   * agent's default (default provider + default model). Remaining entries are
+   * the agent's alternates: fallback candidates and the pick-list for
+   * per-channel (Listen) overrides. Every slug must resolve to an org-level
+   * provider (`inference_providers` row) or a built-in module. Empty/absent ⇒
+   * all org providers (org rows AND deployment system-key providers) are
+   * available and the default falls through to the org default model.
    */
-  defaultModel?: string;
+  models?: string[];
   /** Network access configuration */
   networkConfig?: NetworkConfig;
   /** Nix environment configuration */
@@ -77,8 +78,6 @@ export interface AgentSettings {
    * host's settings JSON column still round-trips this list.
    */
   authProfiles?: AuthProfile[];
-  /** Installed providers for this agent (index 0 = primary). */
-  installedProviders?: InstalledProvider[];
   /** Enable verbose logging (show tool calls, reasoning, etc.) */
   verboseLogging?: boolean;
   /**

--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -412,8 +412,9 @@ export const BindChannelAction = Type.Object({
     Type.String({
       maxLength: 200,
       description:
-        'Optional per-binding model override (a `provider/model` ref or "auto"). ' +
-        "Wins over the agent/org default for messages on this channel.",
+        "Optional per-binding model override — an explicit `<provider>/<model>` ref. " +
+        "Must be one of the agent's allowed models (its `models` list) when that " +
+        "list is non-empty. Wins over the agent/org default for messages on this channel.",
     })
   ),
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -111,7 +111,6 @@ export type {
   ConversationMessage,
   DeclaredCredential,
   HistoryMessage,
-  InstalledProvider,
   InstructionContext,
   InstructionProvider,
   LogLevel,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,22 +2,6 @@ import type { GuardrailStage } from "./guardrails/types";
 import type { SecretRef } from "./secret-refs";
 
 /**
- * Represents a provider installed for a specific agent.
- * Stored in AgentSettings.installedProviders as an ordered array (index 0 = primary).
- */
-export interface InstalledProvider {
-  /**
-   * Provider reference. For built-in providers this is the provider id
-   * ("claude", "chatgpt", "gemini", "z-ai"); for an org-defined inference
-   * provider it is the row's slug. Custom upstreams live on the org's
-   * `inference_providers` row (capabilities.<modality>.base_url), NOT here —
-   * the old per-agent `config.baseUrl` override was removed with that move.
-   */
-  providerId: string;
-  installedAt: number;
-}
-
-/**
  * CLI backend configuration for pi-agent integration.
  * Providers can ship CLI tools that pi-agent invokes as backends.
  */
@@ -389,6 +373,15 @@ export interface InstructionContext {
    * so an unscoped read returns an arbitrary org's row.
    */
   organizationId?: string;
+  /**
+   * Whether agent-scoped settings reads are org-safe for this turn. False for an
+   * orgless DB-backed agent (a shared id like "lobu-builder" exists in every
+   * org, so an id-only read would leak another tenant's identity/soul/skills).
+   * When false, instruction providers MUST skip the by-id settings read and use
+   * their generic (no-agent) branch. True (or absent) for a normal org-scoped
+   * agent and for declared/SDK-embedded agents (whose settings are org-agnostic).
+   */
+  orgScoped?: boolean;
   sessionKey: string;
   workingDirectory: string;
   availableProjects?: string[];

--- a/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/auth/builder-provisioning-e2e.test.ts
@@ -1,13 +1,12 @@
 /**
  * ensureBuilderAgent — provisioning reliability e2e.
  *
- * Reproduces + guards the prod bug: the builder was provisioned with
- * `installed_providers = []` and no model whenever the live module registry
- * wasn't populated, and the org sentinel then made that broken state
- * permanent. This test process never boots the gateway, so the module registry
- * is empty here too — exactly the prod failure mode. The fix resolves
- * providers/model deterministically from `config/providers.json` and repairs
- * builders stuck in the broken state.
+ * Reproduces + guards the prod bug: the builder was provisioned with an empty
+ * `models` list whenever the live module registry wasn't populated, and the
+ * org sentinel then made that broken state permanent. This test process never
+ * boots the gateway, so the module registry is empty here too — exactly the
+ * prod failure mode. The fix resolves the models list deterministically from
+ * `config/providers.json` and repairs builders stuck in the broken state.
  */
 
 import { access, readFile } from "node:fs/promises";
@@ -86,14 +85,16 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 
 	async function readBuilder(orgId: string) {
 		const rows = (await sql`
-      SELECT installed_providers, model FROM agents
+      SELECT models FROM agents
       WHERE organization_id = ${orgId} AND id = ${BUILDER_AGENT_ID} LIMIT 1
     `) as unknown as Array<{
-			installed_providers: Array<{ providerId: string }> | null;
-			model: string | null;
+			models: string[] | null;
 		}>;
 		return rows[0];
 	}
+
+	const slugsOf = (models: string[] | null | undefined): string[] =>
+		(models ?? []).map((ref) => ref.slice(0, ref.indexOf("/")));
 
 	async function readPointer(orgId: string): Promise<string | null> {
 		const rows = (await sql`
@@ -102,21 +103,19 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		return rows[0]?.system_agent_id ?? null;
 	}
 
-	it("provisions a builder with providers + a pinned model even when the module registry is empty", async () => {
+	it("provisions a builder with a concrete models list even when the module registry is empty", async () => {
 		const org = await createTestOrganization({ name: "builder fresh" });
 		const res = await ensureBuilderAgent(org.id, sql);
 
 		expect(res.created).toBe(true);
 		const b = await readBuilder(org.id);
 		expect(b).toBeTruthy();
-		expect(Array.isArray(b?.installed_providers)).toBe(true);
-		expect(b?.installed_providers?.length ?? 0).toBeGreaterThan(0);
-		expect(b?.installed_providers?.some((p) => p.providerId === "openai")).toBe(
-			true,
-		);
+		expect(Array.isArray(b?.models)).toBe(true);
+		expect(b?.models?.length ?? 0).toBeGreaterThan(0);
+		expect(slugsOf(b?.models)).toContain("openai");
 		// Deterministic default from providers.json (`openai` → its curated
-		// defaultModel, currently `gpt-5.6-sol`).
-		expect(b?.model).toBe("openai/gpt-5.6-sol");
+		// defaultModel, currently `gpt-5.6-sol`) at index 0.
+		expect(b?.models?.[0]).toBe("openai/gpt-5.6-sol");
 		expect(await readPointer(org.id)).toBe(BUILDER_AGENT_ID);
 	});
 
@@ -135,27 +134,27 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 
 			expect(res.created).toBe(true);
 			const b = await readBuilder(org.id);
-			// openai still installs (its key resolves) but must NOT be the pin.
-			expect(
-				b?.installed_providers?.some((p) => p.providerId === "openai"),
-			).toBe(true);
+			// openai still lands in the list (its key resolves) but must NOT be the pin.
+			expect(slugsOf(b?.models)).toContain("openai");
 			// Claude's pin comes from the provider catalog, so adding a current
 			// default there must not leave provisioning on a stale code constant.
-			expect(b?.model).toBe("claude/claude-sonnet-5");
+			expect(b?.models?.[0]).toBe("claude/claude-sonnet-5");
 		} finally {
 			if (prev === undefined) delete process.env.ANTHROPIC_API_KEY;
 			else process.env.ANTHROPIC_API_KEY = prev;
 		}
 	});
 
-	it("repairs a builder stuck with empty providers/model (sentinel no longer makes breakage permanent)", async () => {
+	it("repairs a builder that was NEVER configured (models NULL), sentinel notwithstanding", async () => {
 		const org = await createTestOrganization({ name: "builder broken" });
-		// Simulate the prod failure: builder row with no providers/model, and the
-		// sentinel already written — the old code skipped on the sentinel and left
-		// it broken forever.
+		// Simulate the prod failure: builder row with models NULL (never
+		// configured) and the sentinel already written — the old code skipped on
+		// the sentinel and left it broken forever. NOTE: NULL is the broken state;
+		// an EMPTY list ([]) is a VALID allow-all policy and is NOT repaired
+		// (covered by the dedicated #6 test below).
 		await sql`
-      INSERT INTO agents (id, organization_id, name, owner_platform, installed_providers, model, created_at, updated_at)
-      VALUES (${BUILDER_AGENT_ID}, ${org.id}, 'Builder', 'external', '[]'::jsonb, NULL, now(), now())
+      INSERT INTO agents (id, organization_id, name, owner_platform, created_at, updated_at)
+      VALUES (${BUILDER_AGENT_ID}, ${org.id}, 'Builder', 'external', now(), now())
     `;
 		await sql`
       UPDATE "organization"
@@ -168,30 +167,13 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 
 		expect(res.created).toBe(false);
 		const b = await readBuilder(org.id);
-		expect(b?.installed_providers?.length ?? 0).toBeGreaterThan(0);
-		expect(b?.model).toBe("openai/gpt-5.6-sol");
-	});
-
-	it("keeps providers + pinned model consistent when repairing a model-only gap", async () => {
-		// Legacy builder: a provider installed but no model. The repair must not
-		// pin a model whose provider isn't installed (no dangling ref).
-		const org = await createTestOrganization({ name: "builder model-gap" });
-		await sql`
-      INSERT INTO agents (id, organization_id, name, owner_platform, installed_providers, model, created_at, updated_at)
-      VALUES (${BUILDER_AGENT_ID}, ${org.id}, 'Builder', 'external',
-        '[{"providerId":"claude","installedAt":1}]'::jsonb, NULL, now(), now())
-    `;
-
-		const res = await ensureBuilderAgent(org.id, sql);
-
-		expect(res.created).toBe(false);
-		const b = await readBuilder(org.id);
-		expect(b?.model).toBeTruthy();
-		// Invariant: the pinned model's provider is always installed.
-		const pid = b?.model?.slice(0, b.model.indexOf("/")) ?? "";
-		expect(b?.installed_providers?.some((p) => p.providerId === pid)).toBe(
-			true,
-		);
+		expect(b?.models?.length ?? 0).toBeGreaterThan(0);
+		expect(b?.models?.[0]).toBe("openai/gpt-5.6-sol");
+		// Every repaired ref is provider-qualified and concrete (never auto).
+		for (const ref of b?.models ?? []) {
+			expect(ref.includes("/")).toBe(true);
+			expect(ref.split("/").slice(1).join("/")).not.toBe("auto");
+		}
 	});
 
 	it("provisions a usable builder when ONLY an Anthropic system key is present", async () => {
@@ -226,10 +208,8 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 
 			expect(res.created).toBe(true);
 			const b = await readBuilder(org.id);
-			expect(
-				b?.installed_providers?.some((p) => p.providerId === "claude"),
-			).toBe(true);
-			expect(b?.model).toBe("claude/claude-sonnet-5");
+			expect(slugsOf(b?.models)).toContain("claude");
+			expect(b?.models?.[0]).toBe("claude/claude-sonnet-5");
 		} finally {
 			for (const [k, v] of Object.entries(saved)) {
 				if (v === undefined) delete process.env[k];
@@ -249,9 +229,9 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
       WHERE id = ${org.id}
     `;
 		await sql`
-      INSERT INTO agents (id, organization_id, name, owner_platform, installed_providers, model, created_at, updated_at)
+      INSERT INTO agents (id, organization_id, name, owner_platform, models, created_at, updated_at)
       VALUES (${BUILDER_AGENT_ID}, ${org.id}, 'Builder', 'external',
-        '[{"providerId":"openai","installedAt":1}]'::jsonb, 'openai/gpt-4o', now(), now())
+        '["openai/gpt-4o"]'::jsonb, now(), now())
     `;
 
 		await ensureBuilderAgent(org.id, sql);
@@ -299,7 +279,7 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 		expect(await readPointer(org.id)).toBe(BUILDER_AGENT_ID);
 	});
 
-	it("does not clobber a working builder, and never overwrites the model/providers (idempotent fast path)", async () => {
+	it("does not clobber a working builder, and never overwrites the models list (idempotent fast path)", async () => {
 		const org = await createTestOrganization({ name: "builder idempotent" });
 		await ensureBuilderAgent(org.id, sql);
 		const before = await readBuilder(org.id);
@@ -308,9 +288,24 @@ describe("ensureBuilderAgent — provisioning reliability", () => {
 
 		expect(res.created).toBe(false);
 		const after = await readBuilder(org.id);
-		expect(after?.model).toBe(before?.model);
-		expect(after?.installed_providers?.length).toBe(
-			before?.installed_providers?.length,
-		);
+		expect(after?.models).toEqual(before?.models);
+	});
+
+	it("#6: an EMPTY models list ([]) is a valid allow-all policy and survives provisioning unchanged", async () => {
+		// [] means "allow all org + system-key providers" — a deliberate policy,
+		// NOT the broken "never configured" (NULL) state. Provisioning must NOT
+		// overwrite it back to a system-key list.
+		const org = await createTestOrganization({ name: "builder empty-allow" });
+		await sql`
+      INSERT INTO agents (id, organization_id, name, owner_platform, models, created_at, updated_at)
+      VALUES (${BUILDER_AGENT_ID}, ${org.id}, 'Builder', 'external', '[]'::jsonb, now(), now())
+    `;
+
+		const res = await ensureBuilderAgent(org.id, sql);
+
+		expect(res.created).toBe(false);
+		const b = await readBuilder(org.id);
+		// Untouched: still the deliberate empty allow-all list.
+		expect(b?.models).toEqual([]);
 	});
 });

--- a/packages/server/src/__tests__/integration/auth/default-provisioning.test.ts
+++ b/packages/server/src/__tests__/integration/auth/default-provisioning.test.ts
@@ -98,7 +98,7 @@ describe('ensureDefaultAgent', () => {
     expect(agents).toHaveLength(0);
   });
 
-  it('stamps owner_user_id + installed_providers + agent_users on insert', async () => {
+  it('stamps owner_user_id + models + agent_users on insert', async () => {
     const orgId = `org-owner-${generateSecureToken(4)}`;
     await seedOrg(orgId);
 
@@ -120,18 +120,22 @@ describe('ensureDefaultAgent', () => {
     await ensureDefaultAgent(orgId);
 
     const rows = await sql`
-      SELECT owner_platform, owner_user_id, installed_providers
+      SELECT owner_platform, owner_user_id, models
         FROM agents
        WHERE organization_id = ${orgId} AND id = ${DEFAULT_AGENT_ID}
     `;
     expect(rows).toHaveLength(1);
     expect(String(rows[0].owner_platform)).toBe('external');
     expect(String(rows[0].owner_user_id)).toBe(ownerUserId);
-    // installed_providers shape: array of { providerId, installedAt }.
-    // We don't pin a count because system keys depend on test env vars;
-    // we just assert the column is now a JSON array (object/array, never
-    // null/empty-string).
-    expect(Array.isArray(rows[0].installed_providers)).toBe(true);
+    // models shape: ordered array of explicit "<slug>/<model>" refs. We don't
+    // pin a count because system keys depend on test env vars; we just assert
+    // the column is a JSON array of provider-qualified refs (never null/
+    // empty-string, never "auto").
+    expect(Array.isArray(rows[0].models)).toBe(true);
+    for (const ref of rows[0].models as string[]) {
+      expect(ref.includes('/')).toBe(true);
+      expect(ref.split('/').slice(1).join('/')).not.toBe('auto');
+    }
 
     const userAgents = await sql`
       SELECT platform, user_id
@@ -145,8 +149,8 @@ describe('ensureDefaultAgent', () => {
 
   it('backfills owner + agent_users on a legacy row past the sentinel', async () => {
     // Simulate a legacy install: the row exists with the old
-    // owner_platform='lobu', owner_user_id=NULL, installed_providers='[]'
-    // shape, and the sentinel is already set so the fast-path would skip.
+    // owner_platform='lobu', owner_user_id=NULL, no models shape, and the
+    // sentinel is already set so the fast-path would skip.
     const orgId = `org-backfill-${generateSecureToken(4)}`;
     await seedOrg(orgId);
 
@@ -168,11 +172,10 @@ describe('ensureDefaultAgent', () => {
     await sql`
       INSERT INTO agents (
         id, organization_id, name, owner_platform, owner_user_id,
-        installed_providers, created_at, updated_at
+        created_at, updated_at
       ) VALUES (
         ${DEFAULT_AGENT_ID}, ${orgId}, 'Owletto Personal',
         'lobu', NULL,
-        '[]'::jsonb,
         NOW(), NOW()
       )
     `;
@@ -197,6 +200,50 @@ describe('ensureDefaultAgent', () => {
     `;
     expect(userAgents).toHaveLength(1);
     expect(String(userAgents[0].user_id)).toBe(ownerUserId);
+  });
+
+  it('#6: an EMPTY models list ([]) survives a backfill pass unchanged (deliberate allow-all)', async () => {
+    // [] = "allow all org + system-key providers", a valid deliberate policy.
+    // The backfill must NOT treat it as broken and overwrite it.
+    const orgId = `org-empty-allow-${generateSecureToken(4)}`;
+    await seedOrg(orgId);
+
+    const ownerUserId = `user_${generateSecureToken(4)}`;
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+      VALUES (${ownerUserId}, 'Owner', ${`${ownerUserId}@test.local`}, true, NOW(), NOW())
+      ON CONFLICT (id) DO NOTHING
+    `;
+    await sql`
+      UPDATE "organization"
+         SET metadata = ${JSON.stringify({
+           personal_org_for_user_id: ownerUserId,
+           [DEFAULT_AGENT_SENTINEL]: new Date().toISOString(),
+         })}
+       WHERE id = ${orgId}
+    `;
+    await sql`
+      INSERT INTO agents (
+        id, organization_id, name, owner_platform, owner_user_id,
+        models, created_at, updated_at
+      ) VALUES (
+        ${DEFAULT_AGENT_ID}, ${orgId}, 'Owletto Personal',
+        'external', ${ownerUserId},
+        '[]'::jsonb,
+        NOW(), NOW()
+      )
+    `;
+
+    const result = await ensureDefaultAgent(orgId);
+    expect(result.created).toBe(false);
+
+    const rows = await sql`
+      SELECT models FROM agents
+       WHERE organization_id = ${orgId} AND id = ${DEFAULT_AGENT_ID}
+    `;
+    // The deliberate empty allow-all list is preserved, never re-populated.
+    expect(rows[0].models).toEqual([]);
   });
 
   it('skips creation (but stamps sentinel) when other agents already exist', async () => {

--- a/packages/server/src/__tests__/integration/connectors/channel-binding-actions.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-binding-actions.test.ts
@@ -176,6 +176,58 @@ describe("manage_connections channel-binding actions", () => {
 		expect(after.bindings).toHaveLength(0);
 	});
 
+	it("gates the per-binding model against the agent's exact models list", async () => {
+		const connectionId = await makeManagedSlackConnection({
+			orgId,
+			slug: "slackinst-modelgate",
+			teamId: TEAM,
+		});
+		// Restrict the agent to exactly one model.
+		const sql = getTestDb();
+		await sql`
+      UPDATE agents SET models = ${sql.json(["openai/gpt-5"])}
+      WHERE organization_id = ${orgId} AND id = ${agentId}
+    `;
+
+		// An in-list model is accepted.
+		const ok = (await workspace.owner.connections.manage({
+			action: "bind_channel",
+			agent_id: agentId,
+			connection_id: connectionId,
+			channel_id: "slack:CMODEL_OK",
+			model: "openai/gpt-5",
+		})) as { success?: boolean; error?: string };
+		expect(ok.success).toBe(true);
+
+		// A model NOT in the agent's list is rejected (same provider, diff model).
+		const rejected = (await workspace.owner.connections.manage({
+			action: "bind_channel",
+			agent_id: agentId,
+			connection_id: connectionId,
+			channel_id: "slack:CMODEL_BAD",
+			model: "openai/gpt-4o",
+		})) as { success?: boolean; error?: string };
+		expect(rejected.success).toBeUndefined();
+		expect(String(rejected.error)).toContain("allowed models list");
+
+		// "auto" is rejected outright (auto is gone repo-wide).
+		const autoRejected = (await workspace.owner.connections.manage({
+			action: "bind_channel",
+			agent_id: agentId,
+			connection_id: connectionId,
+			channel_id: "slack:CMODEL_AUTO",
+			model: "openai/auto",
+		})) as { success?: boolean; error?: string };
+		expect(autoRejected.success).toBeUndefined();
+		expect(String(autoRejected.error)).toContain("auto");
+
+		// Reset for later cases (beforeEach only clears bindings/connections).
+		await sql`
+      UPDATE agents SET models = NULL
+      WHERE organization_id = ${orgId} AND id = ${agentId}
+    `;
+	});
+
 	it("rejects bind_channel for a missing connection", async () => {
 		const res = (await workspace.owner.connections.manage({
 			action: "bind_channel",

--- a/packages/server/src/auth/__tests__/system-provider-resolution.test.ts
+++ b/packages/server/src/auth/__tests__/system-provider-resolution.test.ts
@@ -1,0 +1,159 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { access } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { type ModuleInterface, moduleRegistry } from "@lobu/core";
+import { resolveSystemKeyProvidersAndModel } from "../system-provider-resolution";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// packages/server/src/auth/__tests__ → repo root.
+const PROVIDERS_JSON = path.resolve(
+  HERE,
+  "../../../../../config/providers.json"
+);
+
+function clearRegistry(): void {
+  (
+    moduleRegistry as unknown as { modules: Map<string, ModuleInterface> }
+  ).modules = new Map();
+}
+
+/**
+ * A fake system-key provider module whose concrete default comes ONLY from live
+ * getModelOptions (no providers.json entry) — the Bedrock shape. #9: such a
+ * provider must still make it into the resolved models list, not be skipped.
+ */
+function registerLiveOnlySystemKeyModule(
+  providerId: string,
+  liveModelId: string
+): void {
+  moduleRegistry.register({
+    name: `${providerId}-provider`,
+    isEnabled: () => true,
+    providerId,
+    providerDisplayName: providerId,
+    providerIconUrl: "",
+    authType: "api-key",
+    sdkCompat: "openai",
+    hasSystemKey: () => true,
+    getSecretEnvVarNames: () => [],
+    getModelOptions: async () => [{ value: `${providerId}/${liveModelId}` }],
+  } as unknown as ModuleInterface);
+}
+
+/**
+ * A fake system-key module that resolves NO concrete model (no providers.json
+ * entry, no live options). #3(c): it must become a `<slug>/__unresolved__`
+ * restriction sentinel, NOT be dropped (which would let the list collapse to
+ * `[]` = allow-all when it is the only provider).
+ */
+function registerUnresolvableSystemKeyModule(providerId: string): void {
+  moduleRegistry.register({
+    name: `${providerId}-provider`,
+    isEnabled: () => true,
+    providerId,
+    providerDisplayName: providerId,
+    providerIconUrl: "",
+    authType: "api-key",
+    sdkCompat: "openai",
+    hasSystemKey: () => true,
+    getSecretEnvVarNames: () => [],
+    getModelOptions: async () => [],
+  } as unknown as ModuleInterface);
+}
+
+describe("resolveSystemKeyProvidersAndModel (#9 — every system-key provider resolves)", () => {
+  const prevRegistryPath = process.env.LOBU_PROVIDER_REGISTRY_PATH;
+  const prevOpenAI = process.env.OPENAI_API_KEY;
+  const CLAUDE_ENV = [
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+  ];
+  const ZAI_ENV = ["Z_AI_API_KEY", "ZAI_API_KEY"];
+  const savedClaude: Record<string, string | undefined> = {};
+  const savedZai: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    await access(PROVIDERS_JSON);
+    process.env.LOBU_PROVIDER_REGISTRY_PATH = PROVIDERS_JSON;
+    process.env.OPENAI_API_KEY = "sk-test-system-resolution";
+    // Hermetic: clear ambient Claude/ZAI keys so openai is the config default.
+    for (const v of CLAUDE_ENV) {
+      savedClaude[v] = process.env[v];
+      delete process.env[v];
+    }
+    for (const v of ZAI_ENV) {
+      savedZai[v] = process.env[v];
+      delete process.env[v];
+    }
+  });
+
+  afterEach(() => clearRegistry());
+
+  afterAll(() => {
+    if (prevRegistryPath === undefined)
+      delete process.env.LOBU_PROVIDER_REGISTRY_PATH;
+    else process.env.LOBU_PROVIDER_REGISTRY_PATH = prevRegistryPath;
+    if (prevOpenAI === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = prevOpenAI;
+    for (const [k, v] of Object.entries(savedClaude)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    for (const [k, v] of Object.entries(savedZai)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  test("a system-key provider whose model is live-only (Bedrock-shape) appears alongside openai", async () => {
+    // openai resolves via providers.json (system key set); the fake provider has
+    // NO providers.json entry — its only concrete model is a live option.
+    registerLiveOnlySystemKeyModule("amazon-bedrock", "amazon.nova-lite-v1:0");
+
+    const { models } = await resolveSystemKeyProvidersAndModel();
+    const slugs = models.map((ref) => ref.slice(0, ref.indexOf("/")));
+
+    // openai (config default) is present…
+    expect(slugs).toContain("openai");
+    // …and the live-only system-key provider is NOT dropped.
+    expect(slugs).toContain("amazon-bedrock");
+    // Its concrete ref came from live options, never `<slug>/auto`.
+    expect(models).toContain("amazon-bedrock/amazon.nova-lite-v1:0");
+    expect(models.every((ref) => !ref.endsWith("/auto"))).toBe(true);
+  });
+
+  test("#3(c): a system-key provider with NO resolvable model becomes a sentinel (not dropped)", () => {
+    // openai resolves concretely; the unresolvable provider must be KEPT as a
+    // `<slug>/__unresolved__` sentinel so the list never collapses toward
+    // allow-all when a provider is present but nothing resolved.
+    registerUnresolvableSystemKeyModule("noconcrete");
+
+    return resolveSystemKeyProvidersAndModel().then(({ models }) => {
+      expect(models).toContain("noconcrete/__unresolved__");
+      // openai still resolves its real model.
+      expect(models.some((r) => r.startsWith("openai/") && r !== "openai/__unresolved__")).toBe(
+        true
+      );
+    });
+  });
+
+  test("#4: a catalog default that is ALREADY slug-qualified is NOT double-prefixed", async () => {
+    // nvidia's providers.json defaultModel is `nvidia/moonshotai/kimi-k2.6`
+    // (already slug-qualified). Provisioning must emit it verbatim, never
+    // `nvidia/nvidia/moonshotai/…`.
+    const prevNvidia = process.env.NVIDIA_API_KEY;
+    process.env.NVIDIA_API_KEY = "nvapi-test";
+    try {
+      const { models } = await resolveSystemKeyProvidersAndModel();
+      const nvidiaRefs = models.filter((r) => r.startsWith("nvidia/"));
+      expect(nvidiaRefs.length).toBeGreaterThan(0);
+      expect(nvidiaRefs).toContain("nvidia/moonshotai/kimi-k2.6");
+      expect(nvidiaRefs.every((r) => !r.startsWith("nvidia/nvidia/"))).toBe(true);
+    } finally {
+      if (prevNvidia === undefined) delete process.env.NVIDIA_API_KEY;
+      else process.env.NVIDIA_API_KEY = prevNvidia;
+    }
+  });
+});

--- a/packages/server/src/auth/builder-provisioning.ts
+++ b/packages/server/src/auth/builder-provisioning.ts
@@ -5,9 +5,9 @@
  * that manages agents, connections, watchers, and workflows on the user's
  * behalf. `organization.system_agent_id` points at it.
  *
- *   - installs system-key model providers + pins a default model up front (so
- *     the agent can chat the moment it's created, instead of "No model
- *     configured"),
+ *   - resolves the system-key model providers into a concrete `models` list up
+ *     front (so the agent can chat the moment it's created, instead of "No
+ *     model configured"),
  *   - attributes ownership to the personal-org owner via the
  *     `personal_org_for_user_id` org-metadata marker,
  *   - writes a sentinel into `organization.metadata` so a deleted builder agent
@@ -19,8 +19,8 @@
  * directly (via `ProviderRegistryService`) rather than depending on the live
  * `moduleRegistry` being populated. The registry is only fully wired during
  * gateway boot, so a provisioning call that ran against an empty registry used
- * to silently create a builder with `installed_providers = []` and no model —
- * and the sentinel then made that broken state permanent. Reading the config
+ * to silently create a builder with no models — and the sentinel then made
+ * that broken state permanent. Reading the config
  * file is deterministic regardless of where/when provisioning runs, and the
  * repair path below heals any builder that was created in the broken state.
  *
@@ -35,10 +35,7 @@ import type { DbClient } from "../db/client";
 import { getDb } from "../db/client";
 import logger from "../utils/logger";
 import { hasOrgSentinel } from "./default-provisioning";
-import {
-	type InstalledProvider,
-	resolveSystemKeyProvidersAndModel,
-} from "./system-provider-resolution";
+import { resolveSystemKeyProvidersAndModel } from "./system-provider-resolution";
 
 export const BUILDER_AGENT_ID = "lobu-builder";
 export const BUILDER_AGENT_SENTINEL = "builder_agent_provisioned";
@@ -134,13 +131,13 @@ async function linkOwnerAndPointer(
 
 /**
  * Provision the org's builder agent and point `organization.system_agent_id`
- * at it — creating it if missing, or healing it if a prior run left it with no
- * providers / no model.
+ * at it — creating it if missing, or healing it if a prior run left it with an
+ * empty `models` list.
  *
  * Behaviour:
- *   - Builder row present + has providers and a model → no-op (fast path).
- *   - Builder row present but missing providers/model → repair (fill the empty
- *     fields; never removes a working config).
+ *   - Builder row present + has models → no-op (fast path).
+ *   - Builder row present but models empty → repair (fill the list; never
+ *     removes a working config).
  *   - Builder row absent + sentinel set → respect deletion (do NOT recreate).
  *   - Builder row absent + no sentinel → create.
  *
@@ -155,69 +152,38 @@ export async function ensureBuilderAgent(
 	const client = sql ?? getDb();
 	try {
 		const rows = (await client`
-      SELECT installed_providers, model FROM agents
+      SELECT models FROM agents
       WHERE organization_id = ${organizationId} AND id = ${BUILDER_AGENT_ID}
       LIMIT 1
     `) as unknown as Array<{
-			installed_providers: InstalledProvider[] | null;
-			model: string | null;
+			models: string[] | null;
 		}>;
 		const existing = rows[0];
 
 		if (existing) {
-			const providersEmpty =
-				!Array.isArray(existing.installed_providers) ||
-				existing.installed_providers.length === 0;
-			const modelEmpty =
-				!existing.model || String(existing.model).trim() === "";
+			// Heal `models` ONLY when it was never configured (NULL/absent). Two
+			// list states are both VALID policies we must never overwrite:
+			//   - a non-empty list = the admin's curated exact allow-list;
+			//   - an EMPTY list ([]) = the deliberate "allow all org + system-key
+			//     providers" policy (allow-all).
+			// Only a genuine NULL means "never configured", which is the broken
+			// state this repair exists for. Each resolved ref carries its provider,
+			// so the list is consistent by construction.
+			const neverConfigured =
+				existing.models === null || existing.models === undefined;
 
-			// Heal providers/model only when broken, keeping providers + model
-			// CONSISTENT — the pinned model's provider must always be installed, so we
-			// never leave a dangling ref (e.g. model=openai/... with providers=[claude]).
-			// The healthy path skips this provider-config read entirely.
-			if (providersEmpty || modelEmpty) {
+			if (neverConfigured) {
 				const resolved = await resolveSystemKeyProvidersAndModel();
-				const existingProviders: InstalledProvider[] = Array.isArray(
-					existing.installed_providers,
-				)
-					? existing.installed_providers
-					: [];
-				// Keep an existing model if present, otherwise take the resolved pick.
-				const newModel = modelEmpty ? resolved.model : existing.model;
-				// Providers = existing ∪ resolved, plus the (new) model's own provider.
-				const providerMap = new Map<string, InstalledProvider>();
-				for (const p of existingProviders) providerMap.set(p.providerId, p);
-				for (const p of resolved.providers) {
-					if (!providerMap.has(p.providerId)) providerMap.set(p.providerId, p);
-				}
-				if (newModel) {
-					const slash = newModel.indexOf("/");
-					const modelProviderId = slash > 0 ? newModel.slice(0, slash) : "";
-					if (modelProviderId && !providerMap.has(modelProviderId)) {
-						providerMap.set(modelProviderId, {
-							providerId: modelProviderId,
-							installedAt: Date.now(),
-						});
-					}
-				}
-				const mergedProviders = [...providerMap.values()];
-				// Union only ever grows, so a length change means we added a provider.
-				const writeProviders =
-					mergedProviders.length !== existingProviders.length;
-				const writeModel = modelEmpty && !!newModel;
-				if (writeProviders || writeModel) {
+				if (resolved.models.length > 0) {
 					await client`
             UPDATE agents SET
-              installed_providers = CASE WHEN ${writeProviders}
-                THEN ${client.json(mergedProviders)} ELSE installed_providers END,
-              model = CASE WHEN ${writeModel}
-                THEN ${newModel} ELSE model END,
+              models = ${client.json(resolved.models)},
               updated_at = now()
             WHERE organization_id = ${organizationId} AND id = ${BUILDER_AGENT_ID}
           `;
 					logger.info(
-						{ organizationId, writeProviders, writeModel, model: newModel },
-						"[builder-provisioning] Repaired builder providers/model",
+						{ organizationId, models: resolved.models },
+						"[builder-provisioning] Repaired builder models",
 					);
 				}
 			}
@@ -260,12 +226,12 @@ export async function ensureBuilderAgent(
       INSERT INTO agents (
         id, organization_id, name, identity_md,
         owner_platform, owner_user_id,
-        installed_providers, model,
+        models,
         created_at, updated_at
       ) VALUES (
         ${BUILDER_AGENT_ID}, ${organizationId}, ${BUILDER_AGENT_NAME}, ${BUILDER_AGENT_IDENTITY},
         'external', ${ownerUserId},
-        ${client.json(resolved.providers)}, ${resolved.model},
+        ${client.json(resolved.models)},
         NOW(), NOW()
       )
       ON CONFLICT (organization_id, id) DO NOTHING
@@ -285,8 +251,7 @@ export async function ensureBuilderAgent(
 				organizationId,
 				agentId: BUILDER_AGENT_ID,
 				ownerUserId,
-				providers: resolved.providers.length,
-				model: resolved.model,
+				models: resolved.models,
 			},
 			"[builder-provisioning] Provisioned builder agent",
 		);

--- a/packages/server/src/auth/default-provisioning.ts
+++ b/packages/server/src/auth/default-provisioning.ts
@@ -27,10 +27,7 @@ import { getDb } from "../db/client";
 import { getNextNumericId } from "../tools/admin/helpers/db-helpers";
 import { nextRunAt } from "../utils/cron";
 import logger from "../utils/logger";
-import {
-	type InstalledProvider,
-	resolveSystemKeyProvidersAndModel,
-} from "./system-provider-resolution";
+import { resolveSystemKeyProvidersAndModel } from "./system-provider-resolution";
 
 export const DEFAULT_AGENT_SENTINEL = "default_agent_provisioned";
 export const DEFAULT_WATCHER_SENTINEL = "default_watcher_provisioned";
@@ -126,10 +123,9 @@ export async function hasOrgSentinel(
  *     ownership check in `verifyOwnedAgentAccess`).
  *   - agent_users mapping for that (platform, user_id) so `ownsAgent`
  *     returns true on the PAT-session path.
- *   - installed_providers populated with all currently-available
- *     system-key providers when empty. Never removes existing entries
- *     and never overwrites a non-empty list — admins may have curated
- *     the list intentionally.
+ *   - `models` populated from the currently-available system-key providers
+ *     when empty. Never overwrites a non-empty list — admins may have
+ *     curated the list intentionally.
  *
  * Idempotent and only writes when there's something to fix. Returns
  * silently when the row is absent (caller decides whether to INSERT).
@@ -139,7 +135,7 @@ async function backfillDefaultAgent(
 	client: DbClient,
 ): Promise<void> {
 	const rows = (await client`
-    SELECT owner_platform, owner_user_id, installed_providers, model
+    SELECT owner_platform, owner_user_id, models
       FROM agents
      WHERE organization_id = ${organizationId}
        AND id = ${DEFAULT_AGENT_ID}
@@ -147,8 +143,7 @@ async function backfillDefaultAgent(
   `) as unknown as Array<{
 		owner_platform: string | null;
 		owner_user_id: string | null;
-		installed_providers: unknown;
-		model: string | null;
+		models: unknown;
 	}>;
 	const row = rows[0];
 	if (!row) return;
@@ -160,65 +155,30 @@ async function backfillDefaultAgent(
 			? ownerUserIdRaw
 			: null;
 
-	const installedNow = Array.isArray(row.installed_providers)
-		? (row.installed_providers as Array<{ providerId: string }>)
-		: [];
-	const providersEmpty = installedNow.length === 0;
-
-	const modelEmpty = !row.model || String(row.model).trim() === "";
-	const configuredModel = modelEmpty ? null : String(row.model).trim();
+	// Heal `models` ONLY when it was never configured (genuine NULL). An EMPTY
+	// list ([]) is the deliberate "allow all org + system-key providers" policy
+	// and must survive a provisioning pass unchanged; a non-empty list is an
+	// admin's curated allow-list. Only NULL means "never configured".
+	const neverConfigured = row.models === null || row.models === undefined;
 	const needsOwnerFix =
 		ownerUserId &&
 		(row.owner_user_id !== ownerUserId || row.owner_platform !== "external");
-	const needsProvidersFix = providersEmpty;
-	const needsModelFix = modelEmpty;
 
-	if (needsOwnerFix || needsProvidersFix || needsModelFix) {
-		const resolved =
-			needsModelFix || needsProvidersFix
-				? await resolveSystemKeyProvidersAndModel()
-				: null;
-		const existingProviders: InstalledProvider[] = installedNow.map((p) => ({
-			providerId: p.providerId,
-			installedAt: Date.now(),
-		}));
-		const newModel =
-			modelEmpty && resolved?.model ? resolved.model : configuredModel;
-
-		let nextProviders = existingProviders;
-		if (needsProvidersFix && resolved) {
-			nextProviders = resolved.providers;
-		} else if (resolved) {
-			const providerMap = new Map<string, InstalledProvider>();
-			for (const p of existingProviders) providerMap.set(p.providerId, p);
-			for (const p of resolved.providers) {
-				if (!providerMap.has(p.providerId)) providerMap.set(p.providerId, p);
-			}
-			if (newModel) {
-				const slash = newModel.indexOf("/");
-				const modelProviderId = slash > 0 ? newModel.slice(0, slash) : "";
-				if (modelProviderId && !providerMap.has(modelProviderId)) {
-					providerMap.set(modelProviderId, {
-						providerId: modelProviderId,
-						installedAt: Date.now(),
-					});
-				}
-			}
-			nextProviders = [...providerMap.values()];
-		}
-
-		const writeProviders =
-			needsProvidersFix || nextProviders.length !== existingProviders.length;
-		const writeModel = modelEmpty && !!newModel;
+	if (needsOwnerFix || neverConfigured) {
+		// Each ref carries its provider, so a single resolved list keeps the
+		// default and its provider consistent by construction.
+		const resolved = neverConfigured
+			? await resolveSystemKeyProvidersAndModel()
+			: null;
+		const writeModels =
+			neverConfigured && !!resolved && resolved.models.length > 0;
 
 		await client`
       UPDATE agents SET
         owner_platform = ${needsOwnerFix ? "external" : row.owner_platform},
         owner_user_id = ${needsOwnerFix ? ownerUserId : row.owner_user_id},
-        installed_providers = CASE WHEN ${writeProviders}
-          THEN ${client.json(nextProviders)} ELSE installed_providers END,
-        model = CASE WHEN ${writeModel}
-          THEN ${newModel} ELSE model END,
+        models = CASE WHEN ${writeModels}
+          THEN ${client.json(resolved?.models ?? [])} ELSE models END,
         updated_at = NOW()
       WHERE organization_id = ${organizationId}
         AND id = ${DEFAULT_AGENT_ID}
@@ -228,10 +188,7 @@ async function backfillDefaultAgent(
 				organizationId,
 				agentId: DEFAULT_AGENT_ID,
 				ownerFixed: !!needsOwnerFix,
-				providersAdded: writeProviders
-					? nextProviders.map((p) => p.providerId)
-					: [],
-				modelSet: writeModel ? newModel : undefined,
+				modelsSet: writeModels ? resolved?.models : undefined,
 			},
 			"[default-provisioning] Backfilled default agent",
 		);
@@ -273,10 +230,10 @@ export async function ensureDefaultAgent(
 	try {
 		// Always run the backfill — it's idempotent and only writes when there's
 		// a divergence to fix. Legacy installs that ran ensureDefaultAgent before
-		// this PR have the row but with `owner_user_id = NULL` and
-		// `installed_providers = []`; the sentinel-fast-path would have skipped
-		// them otherwise, and `lobu chat -c local` would still hit 403 / "No
-		// model configured" on those installs.
+		// this PR have the row but with `owner_user_id = NULL` and no `models`;
+		// the sentinel-fast-path would have skipped them otherwise, and
+		// `lobu chat -c local` would still hit 403 / "No model configured" on
+		// those installs.
 		await backfillDefaultAgent(organizationId, client);
 
 		const provisioned = await hasOrgSentinel(
@@ -310,8 +267,8 @@ export async function ensureDefaultAgent(
 
 		// Resolve the set of model providers that have a system-level credential
 		// available at this boot (env-var API keys, claude OAuth-discovery, etc.)
-		// and install them onto the default agent up front. Without this, the row
-		// exists but `installed_providers = '[]'` and `lobu chat -c local` would
+		// into a concrete `models` list for the default agent up front. Without
+		// this, the row exists with no models and `lobu chat -c local` would
 		// immediately hit "No model configured" — even though the env keys are
 		// sitting right there in the same process.
 		const resolved = await resolveSystemKeyProvidersAndModel();
@@ -330,19 +287,19 @@ export async function ensureDefaultAgent(
 				: null;
 
 		// Insert the default agent. The PK is (organization_id, id) so we can
-		// ON CONFLICT DO NOTHING to guard against a parallel boot. `model` is the
-		// agent's single defaultModel ref (a `provider/model` string or "auto");
-		// the old model_selection/provider_model_preferences fields are gone.
+		// ON CONFLICT DO NOTHING to guard against a parallel boot. `models` is the
+		// agent's ordered list of explicit `provider/model` refs (index 0 = the
+		// default); the old model/installed_providers columns are gone.
 		await client`
       INSERT INTO agents (
         id, organization_id, name, identity_md,
         owner_platform, owner_user_id,
-        installed_providers, model,
+        models,
         created_at, updated_at
       ) VALUES (
         ${DEFAULT_AGENT_ID}, ${organizationId}, ${DEFAULT_AGENT_NAME}, ${DEFAULT_AGENT_IDENTITY},
         'external', ${ownerUserId},
-        ${client.json(resolved.providers)}, ${resolved.model},
+        ${client.json(resolved.models)},
         NOW(), NOW()
       )
       ON CONFLICT (organization_id, id) DO NOTHING

--- a/packages/server/src/auth/system-provider-resolution.ts
+++ b/packages/server/src/auth/system-provider-resolution.ts
@@ -1,6 +1,7 @@
 /**
- * Resolve system-key model providers and a default pinned model for
- * auto-provisioned agents (builder, owletto-default).
+ * Resolve the system-key model providers available to this deployment into an
+ * ordered `models` list (explicit `<slug>/<model>` refs) for auto-provisioned
+ * agents (builder, owletto-default). Index 0 is the pinned default.
  *
  * Reads `config/providers.json` directly so provisioning is deterministic
  * regardless of whether the gateway module registry is initialized.
@@ -10,6 +11,7 @@ import type { ProviderConfigEntry } from "@lobu/core";
 import { getErrorMessage } from "@lobu/core";
 import { resolveEnv } from "../gateway/auth/mcp/string-substitution";
 import { collectProviderModelOptions } from "../gateway/auth/provider-model-options";
+import { UNRESOLVED_MODEL_SUFFIX } from "../gateway/auth/provider-catalog";
 import { getModelProviderModules } from "../gateway/modules/module-system";
 import {
 	ProviderRegistryService,
@@ -17,14 +19,9 @@ import {
 } from "../gateway/services/provider-registry-service";
 import logger from "../utils/logger";
 
-export interface InstalledProvider {
-	providerId: string;
-	installedAt: number;
-}
-
 export interface ResolvedSystemProviders {
-	providers: InstalledProvider[];
-	model: string | null;
+	/** Ordered explicit `<slug>/<model>` refs; index 0 = the pinned default. */
+	models: string[];
 }
 
 const MODEL_PROVIDER_PREFERENCE = [
@@ -56,8 +53,8 @@ function hasClaudeSystemKey(): boolean {
 }
 
 export async function resolveSystemKeyProvidersAndModel(): Promise<ResolvedSystemProviders> {
-	const now = Date.now();
-	const installed = new Map<string, InstalledProvider>();
+	// Ordered set of provider slugs with a system-level credential.
+	const installed = new Set<string>();
 
 	let configs: Record<string, ProviderConfigEntry> = {};
 	try {
@@ -71,79 +68,127 @@ export async function resolveSystemKeyProvidersAndModel(): Promise<ResolvedSyste
 	}
 	for (const [providerId, cfg] of Object.entries(configs)) {
 		if (cfg.envVarName && resolveEnv(cfg.envVarName)) {
-			installed.set(providerId, { providerId, installedAt: now });
+			installed.add(providerId);
 		}
 	}
 
 	if (hasZaiSystemKey()) {
-		installed.set(ZAI_PROVIDER_ID, {
-			providerId: ZAI_PROVIDER_ID,
-			installedAt: now,
-		});
+		installed.add(ZAI_PROVIDER_ID);
 	}
 
 	if (hasClaudeSystemKey()) {
-		installed.set(CLAUDE_PROVIDER_ID, {
-			providerId: CLAUDE_PROVIDER_ID,
-			installedAt: now,
-		});
+		installed.add(CLAUDE_PROVIDER_ID);
 	}
 
 	try {
 		for (const m of getModelProviderModules()) {
-			if (m.hasSystemKey() && !installed.has(m.providerId)) {
-				installed.set(m.providerId, {
-					providerId: m.providerId,
-					installedAt: now,
-				});
+			if (m.hasSystemKey()) {
+				installed.add(m.providerId);
 			}
 		}
 	} catch {
 		// Registry not available — the providers.json + Claude floor already applies.
 	}
 
-	const pickModel = (providerId: string): string | null => {
-		const cfg = configs[providerId];
-		const dm = cfg?.defaultModel?.trim();
-		if (installed.has(providerId) && dm) {
-			return `${providerId}/${dm}`;
+	// Live model options per provider (from the module registry) — the ONLY
+	// source of a concrete default for providers whose defaultModel isn't in
+	// providers.json (e.g. Bedrock declares it on the module). Fetched ONCE and
+	// reused so EVERY system-key provider can resolve a concrete model, not just
+	// the one that becomes the default. Best-effort: unavailable ⇒ empty map.
+	let liveOptions: Record<string, Array<{ value: string }>> = {};
+	if (installed.size > 0) {
+		try {
+			liveOptions = await collectProviderModelOptions("", "");
+		} catch {
+			// Registry/model fetch unavailable — fall back to providers.json only.
 		}
-		return null;
+	}
+
+	// Prefix a bare model id with its slug, unless it is ALREADY `<slug>/…`
+	// qualified. Provider-native ids can contain slashes (nvidia
+	// `nvidia/moonshotai/kimi-k2.6`, openrouter `anthropic/claude-sonnet-5`), so
+	// a catalog default or live option that already carries its slug must NOT be
+	// double-prefixed to `<slug>/<slug>/…`.
+	const qualify = (providerId: string, model: string): string =>
+		model.startsWith(`${providerId}/`) ? model : `${providerId}/${model}`;
+
+	// Concrete model ref per slug: the catalog defaultModel first, else the
+	// provider's first live model option. No `auto` refs — a provider with no
+	// resolvable concrete model returns null (caller decides sentinel vs skip).
+	const concreteRef = (providerId: string): string | null => {
+		const dm = configs[providerId]?.defaultModel?.trim();
+		if (dm) return qualify(providerId, dm);
+		const first = liveOptions[providerId]?.[0]?.value?.trim();
+		if (!first) return null;
+		return qualify(providerId, first);
 	};
+
+	const pickDefault = (providerId: string): string | null =>
+		installed.has(providerId) ? concreteRef(providerId) : null;
 
 	// Prefer Claude over ZAI and the remaining config-declared providers, but use
 	// the catalog's defaultModel for every provider. Keeping a second model ID in
 	// code made auto-provisioned agents lag the picker after catalog updates.
-	let model: string | null = hasClaudeSystemKey()
-		? pickModel(CLAUDE_PROVIDER_ID)
+	let defaultRef: string | null = hasClaudeSystemKey()
+		? pickDefault(CLAUDE_PROVIDER_ID)
 		: hasZaiSystemKey()
-			? pickModel(ZAI_PROVIDER_ID)
+			? pickDefault(ZAI_PROVIDER_ID)
 			: null;
 	for (const providerId of MODEL_PROVIDER_PREFERENCE) {
-		if (model) break;
-		model = pickModel(providerId);
+		if (defaultRef) break;
+		defaultRef = pickDefault(providerId);
 	}
-	if (!model) {
+	if (!defaultRef) {
 		for (const providerId of Object.keys(configs)) {
-			model = pickModel(providerId);
-			if (model) break;
+			defaultRef = pickDefault(providerId);
+			if (defaultRef) break;
 		}
 	}
-	if (!model && installed.size > 0) {
-		try {
-			const optionsByProvider = await collectProviderModelOptions("", "");
-			for (const { providerId } of installed.values()) {
-				const first = optionsByProvider[providerId]?.[0]?.value?.trim();
-				if (first) {
-					model = first.startsWith(`${providerId}/`)
-						? first
-						: `${providerId}/${first}`;
-					break;
-				}
+	if (!defaultRef) {
+		// Still nothing from config-declared providers — take the first installed
+		// provider that resolves a concrete (live) model as the default.
+		for (const providerId of installed) {
+			defaultRef = concreteRef(providerId);
+			if (defaultRef) break;
+		}
+	}
+
+	// Default first, then EVERY other system-key provider. A provider that
+	// resolves to a concrete model (via catalog default OR live options) is added
+	// as that ref; a provider that resolves to NOTHING is added as a
+	// `<slug>/__unresolved__` restriction SENTINEL — never dropped. Dropping it
+	// would let "system providers exist but none resolved" collapse to an empty
+	// `models` list, which the provisioning callers persist as `[]` = allow-all,
+	// silently widening the restriction. The sentinel keeps the agent gated
+	// (non-empty, never routes) until a concrete model resolves.
+	const models: string[] = defaultRef ? [defaultRef] : [];
+	const defaultSlug = defaultRef ? defaultRef.split("/", 1)[0] : null;
+	const sentinelled: string[] = [];
+	for (const providerId of installed) {
+		if (providerId === defaultSlug) continue;
+		const ref = concreteRef(providerId);
+		if (ref) {
+			models.push(ref);
+		} else {
+			models.push(`${providerId}/${UNRESOLVED_MODEL_SUFFIX}`);
+			sentinelled.push(providerId);
+		}
+	}
+	// If NO provider resolved a concrete default (defaultRef null) but system
+	// providers exist, the list is all sentinels — restricted, not allow-all.
+	if (!defaultRef) {
+		for (const providerId of installed) {
+			if (!models.some((m) => m.startsWith(`${providerId}/`))) {
+				models.push(`${providerId}/${UNRESOLVED_MODEL_SUFFIX}`);
+				sentinelled.push(providerId);
 			}
-		} catch {
-			// Registry/model fetch unavailable — model may stay null.
 		}
 	}
-	return { providers: [...installed.values()], model };
+	if (sentinelled.length > 0) {
+		logger.info(
+			{ sentinelled },
+			"[system-provider-resolution] System-key providers with no concrete model kept as restriction sentinels (agent stays gated, not allow-all)",
+		);
+	}
+	return { models };
 }

--- a/packages/server/src/catalog/installed.ts
+++ b/packages/server/src/catalog/installed.ts
@@ -154,35 +154,34 @@ export async function listAgentInstalled(
 	}
 
 	if (wanted.has("providers")) {
-		const installed = settings.installedProviders ?? [];
-		const installedById = new Map(
-			installed.map((provider) => [provider.providerId, provider]),
-		);
+		// "Installed" = the provider's slug appears as a `<slug>/` prefix in the
+		// agent's `models` list.
+		const installedSlugs = new Set<string>();
+		for (const ref of settings.models ?? []) {
+			const slash = ref.indexOf("/");
+			if (slash > 0) installedSlugs.add(ref.slice(0, slash));
+		}
 		const modules = getModelProviderModules().filter(
 			(module) => module.catalogVisible !== false,
 		);
 		result.providers = {
 			kind: "providers",
-			items: modules.map((module) => {
-				const entry = installedById.get(module.providerId);
-				return {
-					id: module.providerId,
-					name: module.providerDisplayName,
-					detail: {
-						icon_url: module.providerIconUrl ?? "",
-						auth_type: module.authType ?? "api-key",
-						supported_auth_types: module.supportedAuthTypes ?? [
-							module.authType ?? "api-key",
-						],
-						api_key_instructions: module.apiKeyInstructions ?? "",
-						api_key_placeholder: module.apiKeyPlaceholder ?? "",
-						description: module.catalogDescription ?? "",
-						system_available: module.hasSystemKey(),
-						installed: Boolean(entry),
-						installed_at: entry?.installedAt,
-					},
-				};
-			}),
+			items: modules.map((module) => ({
+				id: module.providerId,
+				name: module.providerDisplayName,
+				detail: {
+					icon_url: module.providerIconUrl ?? "",
+					auth_type: module.authType ?? "api-key",
+					supported_auth_types: module.supportedAuthTypes ?? [
+						module.authType ?? "api-key",
+					],
+					api_key_instructions: module.apiKeyInstructions ?? "",
+					api_key_placeholder: module.apiKeyPlaceholder ?? "",
+					description: module.catalogDescription ?? "",
+					system_available: module.hasSystemKey(),
+					installed: installedSlugs.has(module.providerId),
+				},
+			})),
 		};
 	}
 

--- a/packages/server/src/catalog/types.ts
+++ b/packages/server/src/catalog/types.ts
@@ -15,7 +15,7 @@
  *   | connectors  | `connector_definitions` (+ versions) per org          | yes         |
  *   | watchers    | watcher inventory rows                                | yes (rows)  |
  *   | skills      | agent `skillsConfig` in settings                      | no          |
- *   | providers   | agent `installedProviders` + module registry metadata | no          |
+ *   | providers   | agent `models` slug prefixes + module registry metadata | no        |
  *   | guardrails  | agent `guardrails` enable list + gateway registry     | no          |
  *
  * Only connector *definitions* are persisted as installable catalog entries in

--- a/packages/server/src/gateway/__tests__/agent-settings-store.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-settings-store.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { createPostgresAgentConfigStore } from "../../lobu/stores/postgres-stores.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
+import { DeclaredAgentRegistry } from "../services/declared-agent-registry.js";
 import {
   ensureDbForGatewayTests,
   resetTestDatabase,
@@ -32,13 +33,13 @@ describe("AgentSettingsStore", () => {
       await orgContext.run({ organizationId: ORG_ID }, async () => {
         await seedAgentRow("shared-agent", { organizationId: ORG_ID });
         await store.saveSettings("shared-agent", {
-          defaultModel: "openai/gpt-4o-mini",
+          models: ["openai/gpt-4o-mini"],
         });
       });
       await orgContext.run({ organizationId: otherOrg }, async () => {
         await seedAgentRow("shared-agent", { organizationId: otherOrg });
         await store.saveSettings("shared-agent", {
-          defaultModel: "z-ai/glm-5.2",
+          models: ["z-ai/glm-5.2"],
         });
       });
 
@@ -46,16 +47,73 @@ describe("AgentSettingsStore", () => {
         organizationId: ORG_ID,
       });
 
-      expect(settings?.defaultModel).toBe("openai/gpt-4o-mini");
+      expect(settings?.models).toEqual(["openai/gpt-4o-mini"]);
+    });
+
+    test("R7 #2 COLLISION: a declared id must NOT shadow a real tenant DB row (DB wins, isDeclaredAgentScoped=false)", async () => {
+      // A declared (SDK-embedded) agent and a tenant DB agent share the id
+      // "shared-agent". The declared settings are org-agnostic; a tenant's
+      // org-scoped read must return the DB row, NOT the declared identity.
+      await orgContext.run({ organizationId: ORG_ID }, async () => {
+        await seedAgentRow("shared-agent", { organizationId: ORG_ID });
+        await store.saveSettings("shared-agent", {
+          models: ["tenant/db-model"],
+          identityMd: "TENANT DB IDENTITY",
+        });
+      });
+
+      const declared = new DeclaredAgentRegistry();
+      declared.replaceAll(
+        new Map([
+          [
+            "shared-agent",
+            {
+              settings: {
+                models: ["declared/model"],
+                identityMd: "DECLARED IDENTITY",
+              } as never,
+              credentials: [],
+            },
+          ],
+        ])
+      );
+      store.setDeclaredAgents(declared);
+
+      // Org-scoped read of the tenant's agent returns the DB row (DB wins).
+      const scoped = await store.getSettings("shared-agent", {
+        organizationId: ORG_ID,
+      });
+      expect(scoped?.models).toEqual(["tenant/db-model"]);
+      expect(scoped?.identityMd).toBe("TENANT DB IDENTITY");
+
+      // …and the collision does NOT flip the orgless guard open for that org.
+      expect(
+        await store.isDeclaredAgentScoped("shared-agent", ORG_ID)
+      ).toBe(false);
+
+      // An org with NO DB row falls back to the declared overlay (legitimate).
+      const otherOrg = `${ORG_ID}-nodbrow`;
+      const declaredView = await store.getSettings("shared-agent", {
+        organizationId: otherOrg,
+      });
+      expect(declaredView?.models).toEqual(["declared/model"]);
+      expect(
+        await store.isDeclaredAgentScoped("shared-agent", otherOrg)
+      ).toBe(true);
+
+      // Orgless read is org-agnostic → declared overlay applies.
+      expect(await store.isDeclaredAgentScoped("shared-agent", undefined)).toBe(
+        true
+      );
     });
 
     test("saveSettings stores and getSettings retrieves", async () => {
       await withOrg(async () => {
         await seedAgentRow("agent-1", { organizationId: ORG_ID });
-        await store.saveSettings("agent-1", { defaultModel: "claude-sonnet-4" });
+        await store.saveSettings("agent-1", { models: ["claude/claude-sonnet-4"] });
         const result = await store.getSettings("agent-1");
         expect(result).not.toBeNull();
-        expect(result!.defaultModel).toBe("claude-sonnet-4");
+        expect(result!.models).toEqual(["claude/claude-sonnet-4"]);
         expect(result!.updatedAt).toBeGreaterThan(0);
       });
     });
@@ -70,10 +128,10 @@ describe("AgentSettingsStore", () => {
     test("updateSettings merges with existing", async () => {
       await withOrg(async () => {
         await seedAgentRow("agent-1", { organizationId: ORG_ID });
-        await store.saveSettings("agent-1", { defaultModel: "claude-sonnet-4" });
+        await store.saveSettings("agent-1", { models: ["claude/claude-sonnet-4"] });
         await store.updateSettings("agent-1", { soulMd: "Be helpful" });
         const result = await store.getSettings("agent-1");
-        expect(result!.defaultModel).toBe("claude-sonnet-4");
+        expect(result!.models).toEqual(["claude/claude-sonnet-4"]);
         expect(result!.soulMd).toBe("Be helpful");
       });
     });
@@ -81,13 +139,13 @@ describe("AgentSettingsStore", () => {
     test("deleteSettings removes settings", async () => {
       await withOrg(async () => {
         await seedAgentRow("agent-1", { organizationId: ORG_ID });
-        await store.saveSettings("agent-1", { defaultModel: "claude-sonnet-4" });
+        await store.saveSettings("agent-1", { models: ["claude/claude-sonnet-4"] });
         await store.deleteSettings("agent-1");
         const result = await store.getSettings("agent-1");
         // After deleteSettings the row still exists but settings columns are
         // reset; getSettings returns a default-shaped object with no model.
         expect(result).not.toBeNull();
-        expect(result!.defaultModel).toBeUndefined();
+        expect(result!.models).toBeUndefined();
       });
     });
 
@@ -104,12 +162,12 @@ describe("AgentSettingsStore", () => {
       await withOrg(async () => {
         await seedAgentRow("agent-1", { organizationId: ORG_ID });
         await store.saveSettings("agent-1", {
-          defaultModel: "claude-sonnet-4",
+          models: ["claude/claude-sonnet-4"],
           soulMd: "Original",
         });
         await store.updateSettings("agent-1", { userMd: "New field" });
         const result = await store.getSettings("agent-1");
-        expect(result!.defaultModel).toBe("claude-sonnet-4");
+        expect(result!.models).toEqual(["claude/claude-sonnet-4"]);
         expect(result!.soulMd).toBe("Original");
         expect(result!.userMd).toBe("New field");
       });
@@ -118,10 +176,10 @@ describe("AgentSettingsStore", () => {
     test("overwrites overlapping fields", async () => {
       await withOrg(async () => {
         await seedAgentRow("agent-1", { organizationId: ORG_ID });
-        await store.saveSettings("agent-1", { defaultModel: "claude-sonnet-4" });
-        await store.updateSettings("agent-1", { defaultModel: "claude-opus-4" });
+        await store.saveSettings("agent-1", { models: ["claude/claude-sonnet-4"] });
+        await store.updateSettings("agent-1", { models: ["claude/claude-opus-4"] });
         const result = await store.getSettings("agent-1");
-        expect(result!.defaultModel).toBe("claude-opus-4");
+        expect(result!.models).toEqual(["claude/claude-opus-4"]);
       });
     });
   });

--- a/packages/server/src/gateway/__tests__/declared-agent-registry.test.ts
+++ b/packages/server/src/gateway/__tests__/declared-agent-registry.test.ts
@@ -1,9 +1,36 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { type ModuleInterface, moduleRegistry } from "@lobu/core";
+import { ApiKeyProviderModule } from "../auth/api-key-provider-module.js";
 import {
   buildRegistryMap,
   DeclaredAgentRegistry,
   entryFromAgentConfig,
 } from "../services/declared-agent-registry.js";
+
+function clearRegistry(): void {
+  (
+    moduleRegistry as unknown as { modules: Map<string, ModuleInterface> }
+  ).modules = new Map();
+}
+
+/** Register a real config-driven module so its catalog defaultModel resolves. */
+function registerApiKeyModule(providerId: string, defaultModel: string): void {
+  moduleRegistry.register(
+    new ApiKeyProviderModule({
+      providerId,
+      slug: providerId,
+      sdkCompat: "openai",
+      upstreamBaseUrl: `https://${providerId}.example.com/v1`,
+      defaultModel,
+      envVarName: `${providerId.toUpperCase()}_API_KEY`,
+      providerDisplayName: providerId,
+      providerIconUrl: "",
+      apiKeyInstructions: "",
+      apiKeyPlaceholder: "",
+      authProfilesManager: { getBestProfile: async () => null } as never,
+    }) as unknown as ModuleInterface
+  );
+}
 
 describe("DeclaredAgentRegistry", () => {
   test("starts empty", () => {
@@ -25,24 +52,25 @@ describe("DeclaredAgentRegistry", () => {
 });
 
 describe("entryFromAgentConfig", () => {
-  test("expands providers into installed list, credentials, and the primary model", () => {
+  afterEach(() => clearRegistry());
+
+  test("expands providers into an ordered concrete models list + credentials", () => {
     const entry = entryFromAgentConfig({
       id: "agent-1",
       name: "Agent 1",
       providers: [
         { id: "openai", model: "gpt-4o", key: "sk-1" },
-        { id: "anthropic", secretRef: "vault://anth" },
+        { id: "anthropic", model: "anthropic/claude-sonnet-5", secretRef: "vault://anth" },
       ],
       network: { allowed: ["github.com"] },
       nixPackages: ["jq"],
     } as any);
 
-    expect(entry.settings.installedProviders).toEqual([
-      { providerId: "openai", installedAt: expect.any(Number) },
-      { providerId: "anthropic", installedAt: expect.any(Number) },
+    // Bare declared models get slug-prefixed; already-prefixed refs pass through.
+    expect(entry.settings.models).toEqual([
+      "openai/gpt-4o",
+      "anthropic/claude-sonnet-5",
     ]);
-    // The primary provider's declared model becomes the agent's defaultModel.
-    expect(entry.settings.defaultModel).toBe("gpt-4o");
     expect(entry.settings.networkConfig).toEqual({
       allowedDomains: ["github.com"],
       deniedDomains: undefined,
@@ -54,15 +82,43 @@ describe("entryFromAgentConfig", () => {
     ]);
   });
 
-  test("defaults to '<primary>/auto' when the primary declares no model", () => {
+  test("resolves a provider with no declared model to its catalog defaultModel (never auto)", () => {
+    registerApiKeyModule("acme", "acme-large-1");
     const entry = entryFromAgentConfig({
       id: "agent-2",
       name: "Agent 2",
-      providers: [{ id: "claude" }, { id: "openai", model: "gpt-4o" }],
+      providers: [{ id: "acme" }, { id: "openai", model: "gpt-4o" }],
     } as any);
 
-    // Primary (claude) has no model → auto; the non-primary model is ignored.
-    expect(entry.settings.defaultModel).toBe("claude/auto");
+    // The primary keeps its position with a CONCRETE ref from the catalog.
+    expect(entry.settings.models).toEqual(["acme/acme-large-1", "openai/gpt-4o"]);
+  });
+
+  test("#3(b): a provider with no model + no catalog default becomes a restriction sentinel (NOT dropped)", () => {
+    const entry = entryFromAgentConfig({
+      id: "agent-3",
+      name: "Agent 3",
+      providers: [{ id: "unknown-provider" }, { id: "openai", model: "gpt-4o" }],
+    } as any);
+
+    // The unresolvable provider is kept as a sentinel so the agent stays
+    // RESTRICTED (gated), never dropped to allow-all.
+    expect(entry.settings.models).toEqual([
+      "unknown-provider/__unresolved__",
+      "openai/gpt-4o",
+    ]);
+  });
+
+  test("#3(b): an agent whose ONLY provider is unresolvable is restricted, not allow-all", () => {
+    const entry = entryFromAgentConfig({
+      id: "agent-4",
+      name: "Agent 4",
+      providers: [{ id: "unknown-provider" }],
+    } as any);
+
+    // A declared-provider agent must NEVER end with models undefined (= allow-all).
+    expect(entry.settings.models).toEqual(["unknown-provider/__unresolved__"]);
+    expect(entry.settings.models).not.toBeUndefined();
   });
 });
 
@@ -72,12 +128,12 @@ describe("buildRegistryMap", () => {
       {
         id: "agent-a",
         name: "Agent A",
-        providers: [{ id: "openai", key: "sk-1" }],
+        providers: [{ id: "openai", model: "gpt-4o", key: "sk-1" }],
       } as any,
       {
         id: "agent-b",
         name: "Agent B",
-        providers: [{ id: "anthropic", key: "sk-2" }],
+        providers: [{ id: "anthropic", model: "claude-sonnet-5", key: "sk-2" }],
       } as any,
     ]);
 

--- a/packages/server/src/gateway/__tests__/enqueue-model-gate.test.ts
+++ b/packages/server/src/gateway/__tests__/enqueue-model-gate.test.ts
@@ -1,0 +1,336 @@
+/**
+ * #1 (round-3): the exact-model allow-list must be enforced at ENQUEUE time —
+ * on the payload that `sendToWorkerQueue` serializes into the queue job the
+ * worker reads verbatim — NOT only in deployment env-gen. Deployment-time
+ * enforcement is defeated by warm/resumed workers (which never re-run
+ * createWorkerDeployment) and by the persist-before-deploy ordering.
+ *
+ * This drives `handleMessage` with a fake queue that captures the persisted
+ * payload, a deployment manager exposing a model policy, and asserts the
+ * ENQUEUED model was gated to the agent's allow-list — including the warm path
+ * (createWorkerDeployment is never reached / returns early).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { MessagePayload } from "@lobu/core";
+import type { IMessageQueue } from "../infrastructure/queue/index.js";
+import type {
+  DeploymentManager,
+  OrchestratorConfig,
+} from "../orchestration/deployment-manager.js";
+import { enforceModelAllowList } from "../auth/settings/model-selection.js";
+import { generateDeploymentName } from "../orchestration/deployment-manager.js";
+import { MessageConsumer } from "../orchestration/message-consumer.js";
+
+// The deployment name the consumer derives for makePayload()'s routing keys.
+// Returning a deployment with THIS name from listDeployments makes
+// ensureWorkerExists take the WARM branch (scaleDeployment only) — proving the
+// gate runs even when createWorkerDeployment is never reached.
+const WARM_DEPLOYMENT_NAME = generateDeploymentName({
+  userId: "user-1",
+  platform: "slack",
+  channelId: "chan-1",
+  conversationId: "conv-1",
+});
+
+process.env.ENCRYPTION_KEY ||=
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+/** Fake queue that records every `send` payload for later inspection. */
+function makeCapturingQueue(): {
+  queue: IMessageQueue;
+  sends: Array<{ name: string; data: MessagePayload }>;
+} {
+  const sends: Array<{ name: string; data: MessagePayload }> = [];
+  const queue = {
+    start: mock(async () => {}),
+    stop: mock(async () => {}),
+    createQueue: mock(async () => {}),
+    send: mock(async (name: string, data: unknown) => {
+      // thread_message_* is the worker-facing queue we care about.
+      if (name.startsWith("thread_message_")) {
+        sends.push({ name, data: data as MessagePayload });
+      }
+      return "job-1";
+    }),
+    work: mock(async () => {}),
+    pauseWorker: mock(async () => {}),
+    resumeWorker: mock(async () => {}),
+    getQueueStats: mock(async () => ({
+      waiting: 0,
+      active: 0,
+      completed: 0,
+      failed: 0,
+    })),
+    isHealthy: mock(() => true),
+  } as unknown as IMessageQueue;
+  return { queue, sends };
+}
+
+function makeConfig(): OrchestratorConfig {
+  return {
+    queues: { retryLimit: 3, expireInSeconds: 600 },
+    worker: { maxDeployments: 0 },
+  } as unknown as OrchestratorConfig;
+}
+
+/**
+ * A deployment manager exposing a model policy and a WARM path: an existing
+ * deployment (listDeployments returns the target), so `ensureWorkerExists` only
+ * scaleDeployment's — createWorkerDeployment is never called. This is the exact
+ * case the deployment-time gate cannot cover.
+ */
+function makeWarmDeploymentManager(
+  allowedRefs: string[] | null
+): DeploymentManager {
+  return {
+    listDeployments: mock(async () => [
+      { deploymentName: WARM_DEPLOYMENT_NAME, status: "running" },
+    ]),
+    scaleDeployment: mock(async () => {}),
+    updateDeploymentActivity: mock(async () => {}),
+    syncNetworkConfigGrants: mock(async () => {}),
+    createWorkerDeployment: mock(async () => {
+      throw new Error("createWorkerDeployment must NOT be called on the warm path");
+    }),
+    getProviderCatalogService: () => ({
+      // Mirror the real resolveDispatchModel: gate + (here) treat every listed
+      // ref as routable, so replacement picks the first listed real model.
+      resolveDispatchModel: async (
+        _agentId: string,
+        _org: string | undefined,
+        requested: string | undefined
+      ) => {
+        const gate = enforceModelAllowList(requested, allowedRefs, () => true);
+        return { ...gate, modules: [], allowedRefs };
+      },
+    }),
+  } as unknown as DeploymentManager;
+}
+
+/** Deployment manager with NO ProviderCatalogService wired — for R5 #3. */
+function makeUnwiredCatalogDeploymentManager(): DeploymentManager {
+  return {
+    listDeployments: mock(async () => [
+      { deploymentName: WARM_DEPLOYMENT_NAME, status: "running" },
+    ]),
+    scaleDeployment: mock(async () => {}),
+    updateDeploymentActivity: mock(async () => {}),
+    syncNetworkConfigGrants: mock(async () => {}),
+    createWorkerDeployment: mock(async () => {}),
+    getProviderCatalogService: () => undefined,
+  } as unknown as DeploymentManager;
+}
+
+/** Deployment manager whose policy lookup THROWS — for the #1 fail-closed test. */
+function makeThrowingDeploymentManager(): DeploymentManager {
+  return {
+    listDeployments: mock(async () => [
+      { deploymentName: WARM_DEPLOYMENT_NAME, status: "running" },
+    ]),
+    scaleDeployment: mock(async () => {}),
+    updateDeploymentActivity: mock(async () => {}),
+    syncNetworkConfigGrants: mock(async () => {}),
+    createWorkerDeployment: mock(async () => {
+      throw new Error("createWorkerDeployment must NOT be called on the warm path");
+    }),
+    getProviderCatalogService: () => ({
+      resolveDispatchModel: async () => {
+        throw new Error("db down");
+      },
+    }),
+  } as unknown as DeploymentManager;
+}
+
+/**
+ * Deployment manager whose resolveDispatchModel applies routability: only the
+ * refs in `routable` are considered routable. Mirrors the real resolver's
+ * "first non-sentinel AND routable" replacement — for the #4 test.
+ */
+function makeRoutableDeploymentManager(
+  allowedRefs: string[] | null,
+  routable: Set<string>
+): DeploymentManager {
+  return {
+    listDeployments: mock(async () => [
+      { deploymentName: WARM_DEPLOYMENT_NAME, status: "running" },
+    ]),
+    scaleDeployment: mock(async () => {}),
+    updateDeploymentActivity: mock(async () => {}),
+    syncNetworkConfigGrants: mock(async () => {}),
+    createWorkerDeployment: mock(async () => {}),
+    getProviderCatalogService: () => ({
+      resolveDispatchModel: async (
+        _agentId: string,
+        _org: string | undefined,
+        requested: string | undefined
+      ) => {
+        const gate = enforceModelAllowList(requested, allowedRefs, (r) =>
+          routable.has(r)
+        );
+        return { ...gate, modules: [], allowedRefs };
+      },
+    }),
+  } as unknown as DeploymentManager;
+}
+
+function makePayload(model: string | undefined): MessagePayload {
+  return {
+    messageId: "msg-1",
+    userId: "user-1",
+    channelId: "chan-1",
+    conversationId: "conv-1",
+    platform: "slack",
+    organizationId: "org-1",
+    agentId: "agent-1",
+    messageText: "hi",
+    platformMetadata: {},
+    agentOptions: model ? { model } : {},
+  } as unknown as MessagePayload;
+}
+
+async function drive(
+  consumer: MessageConsumer,
+  model: string | undefined
+): Promise<void> {
+  await (
+    consumer as unknown as { handleMessage: (job: unknown) => Promise<void> }
+  ).handleMessage({ id: "1", data: makePayload(model) });
+  // Let the fire-and-forget ensureWorkerExists settle.
+  await new Promise((r) => setTimeout(r, 60));
+}
+
+describe("#1: exact-model gate enforced at ENQUEUE time (covers warm/resumed)", () => {
+  test("a disallowed model on the WARM path is gated BEFORE the payload is persisted", async () => {
+    const { queue, sends } = makeCapturingQueue();
+    // agent.models = ["openai/gpt-5"]; the request asks for openai/gpt-4o.
+    const consumer = new MessageConsumer(
+      makeConfig(),
+      makeWarmDeploymentManager(["openai/gpt-5"]),
+      queue
+    );
+
+    await drive(consumer, "openai/gpt-4o");
+
+    // The PERSISTED payload's model was gated to the listed ref — not gpt-4o.
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.data.agentOptions?.model).toBe("openai/gpt-5");
+    expect(sends[0]?.data.agentOptions?.model).not.toBe("openai/gpt-4o");
+  });
+
+  test("an in-list model passes through unchanged", async () => {
+    const { queue, sends } = makeCapturingQueue();
+    const consumer = new MessageConsumer(
+      makeConfig(),
+      makeWarmDeploymentManager(["openai/gpt-5", "claude/claude-sonnet-5"]),
+      queue
+    );
+
+    await drive(consumer, "claude/claude-sonnet-5");
+
+    expect(sends[0]?.data.agentOptions?.model).toBe("claude/claude-sonnet-5");
+  });
+
+  test("allow-all (null policy) leaves the requested model unchanged", async () => {
+    const { queue, sends } = makeCapturingQueue();
+    const consumer = new MessageConsumer(
+      makeConfig(),
+      makeWarmDeploymentManager(null),
+      queue
+    );
+
+    await drive(consumer, "anything/goes");
+
+    expect(sends[0]?.data.agentOptions?.model).toBe("anything/goes");
+  });
+
+  test("a sentinel-only policy drops the model (fails closed) before persistence", async () => {
+    const { queue, sends } = makeCapturingQueue();
+    const consumer = new MessageConsumer(
+      makeConfig(),
+      makeWarmDeploymentManager(["chatgpt/__unresolved__"]),
+      queue
+    );
+
+    await drive(consumer, "chatgpt/gpt-4o");
+
+    // The disallowed model was dropped; no sentinel/real model reaches the queue.
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.data.agentOptions?.model).toBeUndefined();
+  });
+
+  test("#1 FAIL CLOSED: a policy-lookup ERROR drops the requested model (never survives on warm)", async () => {
+    const { queue, sends } = makeCapturingQueue();
+    // resolveDispatchModel throws "db down". The disallowed model MUST NOT
+    // survive on the persisted payload — the warm path won't re-gate later.
+    const consumer = new MessageConsumer(
+      makeConfig(),
+      makeThrowingDeploymentManager(),
+      queue
+    );
+
+    await drive(consumer, "openai/forbidden");
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.data.agentOptions?.model).toBeUndefined();
+  });
+
+  test("#2 CROSS-TENANT GUARD: a payload with NO organizationId drops the model (never id-only lookup)", async () => {
+    const { queue, sends } = makeCapturingQueue();
+    const consumer = new MessageConsumer(
+      makeConfig(),
+      makeWarmDeploymentManager(["openai/gpt-5"]),
+      queue
+    );
+
+    // No org → the gate must fail closed rather than query the agent id across
+    // orgs (a declared agent exists in every org → wrong-tenant policy). Build
+    // the payload directly with no organizationId (passing undefined to the
+    // helper would trigger its default).
+    const payload = makePayload("openai/gpt-4o");
+    delete (payload as { organizationId?: string }).organizationId;
+    await (
+      consumer as unknown as { handleMessage: (job: unknown) => Promise<void> }
+    ).handleMessage({ id: "1", data: payload });
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.data.agentOptions?.model).toBeUndefined();
+  });
+
+  test("#4 ROUTABILITY: replacement picks the first non-sentinel ROUTABLE ref, not just non-sentinel", async () => {
+    const { queue, sends } = makeCapturingQueue();
+    // allow=["xai/grok-4","openai/gpt-5"]; xai UNCREDENTIALED, openai routable.
+    // A disallowed request must replace onto openai/gpt-5 (routable), NOT the
+    // first non-sentinel xai/grok-4 (which would fail at run).
+    const consumer = new MessageConsumer(
+      makeConfig(),
+      makeRoutableDeploymentManager(
+        ["xai/grok-4", "openai/gpt-5"],
+        new Set(["openai/gpt-5"])
+      ),
+      queue
+    );
+
+    await drive(consumer, "claude/forbidden");
+
+    expect(sends[0]?.data.agentOptions?.model).toBe("openai/gpt-5");
+    expect(sends[0]?.data.agentOptions?.model).not.toBe("xai/grok-4");
+  });
+
+  test("R5 #3: an UNWIRED ProviderCatalogService drops the requested model (fail closed)", async () => {
+    const { queue, sends } = makeCapturingQueue();
+    // The catalog isn't injected yet (startup / a persisted job drained before
+    // wiring). The unvalidated model MUST NOT survive to the warm worker.
+    const consumer = new MessageConsumer(
+      makeConfig(),
+      makeUnwiredCatalogDeploymentManager(),
+      queue
+    );
+
+    await drive(consumer, "openai/forbidden");
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.data.agentOptions?.model).toBeUndefined();
+  });
+});

--- a/packages/server/src/gateway/__tests__/list-connections-cross-tenant.test.ts
+++ b/packages/server/src/gateway/__tests__/list-connections-cross-tenant.test.ts
@@ -1,0 +1,89 @@
+/**
+ * R7 BLOCK #1 layer (c): the class-root footgun. `listConnections` org-scopes
+ * ONLY via ambient `tryGetOrgId()` and DROPS the org filter when there's no
+ * ambient org. An AGENT-scoped list with no ambient org would return ANOTHER
+ * tenant's rows for a shared agent id. The guard: an `agentId`-filtered call
+ * with NO ambient org returns [] (never all-tenant rows). Unfiltered
+ * (all-tenant) callers — reconcile loops, admin/list — pass no `agentId` and
+ * are unaffected.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { getDb } from "../../db/client.js";
+import { orgContext } from "../../lobu/stores/org-context.js";
+import { createPostgresAgentConnectionStore } from "../../lobu/stores/postgres-stores.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "./helpers/db-setup.js";
+
+const ORG_A = "org-a-listconn";
+const ORG_B = "org-b-listconn";
+const SHARED_AGENT = "lobu-builder";
+
+let nextConnId = 5000;
+async function seedChatConnection(org: string, agentId: string, slug: string) {
+  const sql = getDb();
+  // `id` is bigint; runtime metadata folds into `config.chatMetadata`;
+  // `credential_mode IS NOT NULL` marks it a chat row (what listConnections filters on).
+  await sql`
+    INSERT INTO connections (
+      id, organization_id, agent_id, connector_key, slug,
+      credential_mode, config, status, created_at, updated_at
+    ) VALUES (
+      ${nextConnId++}, ${org}, ${agentId}, 'slack', ${slug},
+      'managed', ${sql.json({ chatMetadata: { botUsername: `${org}-bot` } })},
+      'active', now(), now()
+    )
+  `;
+}
+
+describe("listConnections — agent-scoped cross-tenant guard", () => {
+  const store = createPostgresAgentConnectionStore();
+
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await orgContext.run({ organizationId: ORG_A }, async () => {
+      await seedAgentRow(SHARED_AGENT, { organizationId: ORG_A });
+    });
+    await orgContext.run({ organizationId: ORG_B }, async () => {
+      await seedAgentRow(SHARED_AGENT, { organizationId: ORG_B });
+    });
+    await seedChatConnection(ORG_A, SHARED_AGENT, "conn-a");
+    await seedChatConnection(ORG_B, SHARED_AGENT, "conn-b");
+  }, 60_000);
+
+  test("agent-scoped list with NO ambient org returns [] (no cross-tenant rows)", async () => {
+    // No orgContext.run — the orgless case a shared-id worker token produces.
+    const rows = await store.listConnections({
+      platform: "slack",
+      agentId: SHARED_AGENT,
+    });
+    expect(rows).toEqual([]);
+  });
+
+  test("agent-scoped list INSIDE an org returns ONLY that org's rows", async () => {
+    const rowsA = await orgContext.run({ organizationId: ORG_A }, () =>
+      store.listConnections({ platform: "slack", agentId: SHARED_AGENT })
+    );
+    expect(rowsA).toHaveLength(1);
+    expect(rowsA[0]?.metadata?.botUsername).toBe(`${ORG_A}-bot`);
+
+    const rowsB = await orgContext.run({ organizationId: ORG_B }, () =>
+      store.listConnections({ platform: "slack", agentId: SHARED_AGENT })
+    );
+    expect(rowsB).toHaveLength(1);
+    expect(rowsB[0]?.metadata?.botUsername).toBe(`${ORG_B}-bot`);
+  });
+
+  test("UNFILTERED (no agentId) list is unaffected — still returns all rows (reconcile/admin path)", async () => {
+    // The reconcile loops / admin list legitimately read all tenants unscoped.
+    const rows = await store.listConnections();
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -663,11 +663,28 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
     expect(enqueueMessage).not.toHaveBeenCalled();
   });
 
-  test("unroutable model provider posts a plain Slack text fallback and skips enqueue", async () => {
-    const providerCatalog = {
-      getInstalledModules: mock(async () => []),
-      findProviderForModel: mock(async () => null),
+  // Build a mock ProviderCatalogService for the preflight path. `findProviderForModel`
+  // matches a ref to its module by the `<slug>/` prefix (mirrors the real one).
+  function makeCatalogMock(opts: {
+    modules: Array<{ providerId: string }>;
+    allowedRefs: string[] | null;
+  }) {
+    return {
+      getModelPolicy: mock(async () => ({
+        modules: opts.modules,
+        allowedRefs: opts.allowedRefs,
+      })),
+      findProviderForModel: mock(async (ref: string, mods?: Array<{ providerId: string }>) => {
+        const slash = ref.indexOf("/");
+        const prefix = slash > 0 ? ref.slice(0, slash) : ref;
+        return (mods ?? opts.modules).find((m) => m.providerId === prefix);
+      }),
     };
+  }
+
+  test("unroutable model provider posts a plain Slack text fallback and skips enqueue", async () => {
+    // Empty allow-list (allow-all) but the provider module isn't present/routable.
+    const providerCatalog = makeCatalogMock({ modules: [], allowedRefs: null });
     const { bridge, enqueueMessage } = makePreviewHarness({
       binding: {
         agentId: "lobu-builder",
@@ -692,12 +709,89 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
     expect(posted).not.toContain("api/proxy");
   });
 
-  test("configured model provider unconnected, but org has another connected provider → falls back and enqueues", async () => {
-    // The agent is configured for z-ai/glm-5.2 (not routable here), but the org
-    // has a connected+routable openai provider. Instead of dead-ending with a
-    // setup link, the run must proceed on openai's default model. This is the
-    // new-user gap: a default agent shipped with a model whose provider the org
-    // never connected must NOT hard-block when another provider IS connected.
+  test("EXACT GATE: an override on a LISTED provider but NOT in the list is rejected", async () => {
+    // The agent allows only openai/gpt-5. The override is openai/other — same
+    // PROVIDER, different MODEL — so the exact gate must reject it, even though a
+    // provider-slug gate would have let it through.
+    const openai = {
+      providerId: "openai",
+      hasSystemKey: () => true,
+      hasCredentials: async () => true,
+      getProxyBaseUrlMappings: () => ({ openai: "https://gw/api/proxy/openai" }),
+      getModelOptions: async () => [{ value: "openai/gpt-5" }],
+    };
+    const providerCatalog = makeCatalogMock({
+      modules: [openai],
+      allowedRefs: ["openai/gpt-5"],
+    });
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      binding: {
+        agentId: "lobu-builder",
+        organizationId: "org-bound",
+        model: "openai/other",
+      },
+      providerCatalog,
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(thread, makeMessage(), "mention");
+
+    // openai/other is NOT in the allow-list, so the exact gate blocks it. The
+    // only listed ref (openai/gpt-5) is routable, so preflight falls back to it.
+    // The disallowed model must never reach the worker.
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
+    const payload = enqueueMessage.mock.calls[0]?.[0] as any;
+    expect(payload.agentOptions?.model).not.toBe("openai/other");
+    expect(payload.agentOptions?.model).toBe("openai/gpt-5");
+  });
+
+  test("FALLBACK iterates the LISTED alternates in order, never the catalog default", async () => {
+    // models=["xai/grok-4","openai/gpt-5"] but the DEFAULT provider (xai) is
+    // unroutable. The fallback must be the LISTED alternate openai/gpt-5 (an
+    // exact models[] entry), and the code must NOT consult getModelOptions to
+    // pick a provider's catalog/first default. We prove that by exploding if
+    // getModelOptions is ever called.
+    const xai = {
+      providerId: "xai",
+      hasSystemKey: () => false,
+      hasCredentials: async () => false, // unroutable
+      getProxyBaseUrlMappings: () => ({}),
+      getModelOptions: async () => {
+        throw new Error("fallback must not consult getModelOptions");
+      },
+    };
+    const openai = {
+      providerId: "openai",
+      hasSystemKey: () => true,
+      hasCredentials: async () => true,
+      getProxyBaseUrlMappings: () => ({ openai: "https://gw/api/proxy/openai" }),
+      getModelOptions: async () => {
+        throw new Error("fallback must not consult getModelOptions");
+      },
+    };
+    const providerCatalog = makeCatalogMock({
+      modules: [xai, openai],
+      allowedRefs: ["xai/grok-4", "openai/gpt-5"],
+    });
+    const { bridge, enqueueMessage } = makePreviewHarness({
+      binding: {
+        agentId: "lobu-builder",
+        organizationId: "org-bound",
+        model: "xai/grok-4",
+      },
+      providerCatalog,
+    });
+    const thread = makeThread(undefined);
+
+    await bridge.handleMessage(thread, makeMessage(), "mention");
+
+    expect(enqueueMessage).toHaveBeenCalledTimes(1);
+    const payload = enqueueMessage.mock.calls[0]?.[0] as any;
+    // The exact LISTED alternate wins.
+    expect(payload.agentOptions?.model).toBe("openai/gpt-5");
+  });
+
+  test("configured model provider unconnected, but a listed alternate IS routable → falls back and enqueues", async () => {
     const zai = {
       providerId: "z-ai",
       hasSystemKey: () => false,
@@ -710,13 +804,13 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
       hasSystemKey: () => false,
       hasCredentials: async () => true,
       getProxyBaseUrlMappings: () => ({ openai: "https://gw/api/proxy/openai" }),
-      getModelOptions: async () => [{ value: "gpt-4o-mini" }],
+      getModelOptions: async () => [{ value: "openai/gpt-4o-mini" }],
     };
-    const providerCatalog = {
-      getInstalledModules: mock(async () => [zai, openai]),
-      // The configured model resolves to the z-ai module (unroutable).
-      findProviderForModel: mock(async () => zai),
-    };
+    const providerCatalog = makeCatalogMock({
+      modules: [zai, openai],
+      // Both the failed default and the routable alternate are listed exactly.
+      allowedRefs: ["z-ai/glm-5.2", "openai/gpt-4o-mini"],
+    });
     const { bridge, enqueueMessage } = makePreviewHarness({
       binding: {
         agentId: "lobu-builder",
@@ -729,10 +823,9 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
 
     await bridge.handleMessage(thread, makeMessage(), "mention");
 
-    // Ran, did not post a setup-link error.
+    // Ran on the listed alternate, did not post a setup-link error.
     expect(enqueueMessage).toHaveBeenCalledTimes(1);
     const payload = enqueueMessage.mock.calls[0]?.[0] as any;
-    // The fallback provider's default model (prefixed with its providerId) wins.
     expect(payload.agentOptions?.model).toBe("openai/gpt-4o-mini");
     expect(
       thread.post.mock.calls.every(
@@ -742,8 +835,6 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
   });
 
   test("no connected provider at all → still posts the setup-link error, no enqueue", async () => {
-    // Guard the negative: when the configured provider is unroutable AND there is
-    // no other connected provider, we must NOT silently proceed — surface setup.
     const zai = {
       providerId: "z-ai",
       hasSystemKey: () => false,
@@ -751,10 +842,10 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
       getProxyBaseUrlMappings: () => ({}),
       getModelOptions: async () => [{ value: "z-ai/glm-5.2" }],
     };
-    const providerCatalog = {
-      getInstalledModules: mock(async () => [zai]),
-      findProviderForModel: mock(async () => zai),
-    };
+    const providerCatalog = makeCatalogMock({
+      modules: [zai],
+      allowedRefs: ["z-ai/glm-5.2"],
+    });
     const { bridge, enqueueMessage } = makePreviewHarness({
       binding: {
         agentId: "lobu-builder",

--- a/packages/server/src/gateway/__tests__/model-selection.test.ts
+++ b/packages/server/src/gateway/__tests__/model-selection.test.ts
@@ -1,33 +1,171 @@
 import { describe, expect, mock, test } from "bun:test";
 import {
   composeEffectiveModelRef,
+  enforceModelAllowList,
   resolveEffectiveModelRef,
 } from "../auth/settings/model-selection.js";
 
-describe("resolveEffectiveModelRef (agent layer)", () => {
-  test("returns the agent's defaultModel", () => {
-    expect(resolveEffectiveModelRef({ defaultModel: "openai/gpt-5" })).toBe(
-      "openai/gpt-5",
-    );
+describe("enforceModelAllowList (universal dispatch gate — decision A/B)", () => {
+  test("#1: an out-of-list model on a LISTED provider is REPLACED with the first listed real model", () => {
+    // models=["openai/gpt-5"], requested "openai/gpt-4o" (same provider, diff
+    // model). This is the exact direct-API / watcher / schedule bypass case.
+    const r = enforceModelAllowList("openai/gpt-4o", ["openai/gpt-5"]);
+    expect(r.replaced).toBe(true);
+    expect(r.model).toBe("openai/gpt-5");
   });
 
-  test("preserves the literal 'auto'", () => {
-    expect(resolveEffectiveModelRef({ defaultModel: "auto" })).toBe("auto");
+  test("#1: a stale session.model no longer in the list is replaced", () => {
+    const r = enforceModelAllowList("claude/old-model", [
+      "openai/gpt-5",
+      "claude/claude-sonnet-5",
+    ]);
+    expect(r.model).toBe("openai/gpt-5"); // first listed real model
+    expect(r.replaced).toBe(true);
+  });
+
+  test("an EXACT listed ref passes unchanged", () => {
+    const r = enforceModelAllowList("claude/claude-sonnet-5", [
+      "openai/gpt-5",
+      "claude/claude-sonnet-5",
+    ]);
+    expect(r.model).toBe("claude/claude-sonnet-5");
+    expect(r.replaced).toBe(false);
+  });
+
+  test("allow-all (null) passes any well-formed model unchanged", () => {
+    const r = enforceModelAllowList("anything/goes", null);
+    expect(r.model).toBe("anything/goes");
+    expect(r.replaced).toBe(false);
+  });
+
+  test("#2: a sentinel-only list HARD-FAILS CLOSED (model dropped, never escalates)", () => {
+    const r = enforceModelAllowList("chatgpt/gpt-4o", [
+      "chatgpt/__unresolved__",
+    ]);
+    // No real listed model → model dropped (undefined) → run fails closed.
+    expect(r.model).toBeUndefined();
+    expect(r.replaced).toBe(true);
+  });
+
+  test("#2: an all-sentinel list requested-sentinel is dropped (never routes)", () => {
+    const r = enforceModelAllowList("chatgpt/__unresolved__", [
+      "chatgpt/__unresolved__",
+    ]);
+    expect(r.model).toBeUndefined();
+  });
+
+  test("#2 mixed-list: a requested SENTINEL default resolves to the listed REAL alternate", () => {
+    // models=["unknown/__unresolved__","openai/gpt-4o"], the agent default is
+    // the sentinel — it must resolve to the real listed alternate, NOT undefined.
+    const r = enforceModelAllowList("unknown/__unresolved__", [
+      "unknown/__unresolved__",
+      "openai/gpt-4o",
+    ]);
+    expect(r.model).toBe("openai/gpt-4o");
+    expect(r.replaced).toBe(true);
+  });
+
+  test("#2 mixed-list: an OUT-OF-LIST model resolves to the first REAL listed ref (skips leading sentinel)", () => {
+    const r = enforceModelAllowList("claude/old", [
+      "ghost/__unresolved__",
+      "openai/gpt-4o",
+    ]);
+    expect(r.model).toBe("openai/gpt-4o");
+  });
+
+  test("#4 ROUTABILITY: replacement picks the first non-sentinel ROUTABLE ref, not just non-sentinel", () => {
+    // allow=["xai/grok-4","openai/gpt-5"], xai UNCREDENTIALED. A disallowed
+    // request must replace onto openai/gpt-5 (routable), NOT dead xai/grok-4.
+    const isRoutable = (ref: string) => ref === "openai/gpt-5";
+    const r = enforceModelAllowList(
+      "claude/forbidden",
+      ["xai/grok-4", "openai/gpt-5"],
+      isRoutable,
+    );
+    expect(r.model).toBe("openai/gpt-5");
+    expect(r.model).not.toBe("xai/grok-4");
+  });
+
+  test("#4 ROUTABILITY: fails closed when NO listed ref is routable", () => {
+    const r = enforceModelAllowList(
+      "claude/forbidden",
+      ["xai/grok-4", "openai/gpt-5"],
+      () => false,
+    );
+    expect(r.model).toBeUndefined();
+    expect(r.replaced).toBe(true);
+  });
+
+  test("#4: without a routability predicate, falls back to first NON-SENTINEL (structural only)", () => {
+    const r = enforceModelAllowList("claude/forbidden", [
+      "xai/grok-4",
+      "openai/gpt-5",
+    ]);
+    expect(r.model).toBe("xai/grok-4");
+  });
+
+  test("R5 #1: an EXACT-LISTED but UNROUTABLE request is replaced onto the first routable listed ref", () => {
+    // allow=["xai/grok-4","openai/gpt-5"], xai UNCREDENTIALED, requested exactly
+    // "xai/grok-4" (in the list) — the includes-branch must NOT short-circuit
+    // past routability; it replaces onto openai/gpt-5.
+    const isRoutable = (ref: string) => ref === "openai/gpt-5";
+    const r = enforceModelAllowList(
+      "xai/grok-4",
+      ["xai/grok-4", "openai/gpt-5"],
+      isRoutable,
+    );
+    expect(r.model).toBe("openai/gpt-5");
+    expect(r.replaced).toBe(true);
+  });
+
+  test("R5 #1: an EXACT-LISTED but UNROUTABLE request with NO other routable ref fails closed", () => {
+    const r = enforceModelAllowList("xai/grok-4", ["xai/grok-4"], () => false);
+    expect(r.model).toBeUndefined();
+    expect(r.replaced).toBe(true);
+  });
+
+  test("R5 #1: an EXACT-LISTED ROUTABLE request still passes unchanged", () => {
+    const r = enforceModelAllowList(
+      "openai/gpt-5",
+      ["xai/grok-4", "openai/gpt-5"],
+      (ref) => ref === "openai/gpt-5",
+    );
+    expect(r.model).toBe("openai/gpt-5");
+    expect(r.replaced).toBe(false);
+  });
+
+  test("R5 #2: DENY-ALL (allowedRefs=[]) drops any requested model (fail closed)", () => {
+    const r = enforceModelAllowList("openai/gpt-5", []);
+    expect(r.model).toBeUndefined();
+    expect(r.replaced).toBe(true);
+  });
+
+  test("undefined requested model stays undefined", () => {
+    expect(enforceModelAllowList(undefined, ["openai/gpt-5"]).model).toBeUndefined();
+  });
+});
+
+describe("resolveEffectiveModelRef (agent layer)", () => {
+  test("returns the head of the agent's models list", () => {
+    expect(
+      resolveEffectiveModelRef({ models: ["openai/gpt-5", "claude/claude-sonnet-5"] }),
+    ).toBe("openai/gpt-5");
   });
 
   test("undefined when the agent pins nothing", () => {
-    expect(resolveEffectiveModelRef({ defaultModel: "  " })).toBeUndefined();
+    expect(resolveEffectiveModelRef({ models: ["  "] })).toBeUndefined();
+    expect(resolveEffectiveModelRef({ models: [] })).toBeUndefined();
     expect(resolveEffectiveModelRef({})).toBeUndefined();
     expect(resolveEffectiveModelRef(null)).toBeUndefined();
   });
 });
 
 describe("composeEffectiveModelRef (agent → org fallback)", () => {
-  test("agent defaultModel wins over the org default", async () => {
+  test("agent models[0] wins over the org default", async () => {
     const readOrg = mock(async () => "claude/claude-sonnet-4-6");
     expect(
       await composeEffectiveModelRef(
-        { defaultModel: "openai/gpt-5" },
+        { models: ["openai/gpt-5"] },
         "org-1",
         readOrg,
       ),

--- a/packages/server/src/gateway/__tests__/platform-helpers-model-resolution.test.ts
+++ b/packages/server/src/gateway/__tests__/platform-helpers-model-resolution.test.ts
@@ -7,7 +7,7 @@ import {
 describe("resolveAgentOptions model resolution (layered fallback)", () => {
   test("behavior override (baseOptions.model) wins over the agent default", async () => {
     const settingsStore = {
-      getSettings: async () => ({ defaultModel: "openai/gpt-5" }) as any,
+      getSettings: async () => ({ models: ["openai/gpt-5"] }) as any,
     };
 
     const resolved = await resolveAgentOptions(
@@ -21,9 +21,9 @@ describe("resolveAgentOptions model resolution (layered fallback)", () => {
     expect(resolved.model).toBe("claude/claude-opus-4-8");
   });
 
-  test("uses the agent defaultModel when no behavior override", async () => {
+  test("uses the agent models[0] when no behavior override", async () => {
     const settingsStore = {
-      getSettings: async () => ({ defaultModel: "openai/gpt-5" }) as any,
+      getSettings: async () => ({ models: ["openai/gpt-5"] }) as any,
     };
 
     const resolved = await resolveAgentOptions(
@@ -36,14 +36,65 @@ describe("resolveAgentOptions model resolution (layered fallback)", () => {
     expect(resolved.model).toBe("openai/gpt-5");
   });
 
+  test("#6: a legacy 'auto' override is IGNORED and falls back to the agent default", async () => {
+    // A stale Listen binding with model='auto' must NOT propagate as the run
+    // model — `auto` is gone repo-wide. The malformed override is dropped and
+    // the agent's models[0] wins.
+    const settingsStore = {
+      getSettings: async () => ({ models: ["openai/gpt-5"] }) as any,
+    };
+
+    const resolved = await resolveAgentOptions(
+      "agent-1",
+      { model: "auto" },
+			settingsStore as any,
+      "org-1",
+    );
+
+    expect(resolved.model).toBe("openai/gpt-5");
+    expect(resolved.model).not.toBe("auto");
+  });
+
+  test("#6: a bare (unqualified) override is IGNORED and falls back to the agent default", async () => {
+    const settingsStore = {
+      getSettings: async () => ({ models: ["openai/gpt-5"] }) as any,
+    };
+
+    const resolved = await resolveAgentOptions(
+      "agent-1",
+      { model: "gpt-4o" }, // no provider prefix
+			settingsStore as any,
+      "org-1",
+    );
+
+    expect(resolved.model).toBe("openai/gpt-5");
+  });
+
+  test("a valid <provider>/<model> override still wins over the agent default", async () => {
+    const settingsStore = {
+      getSettings: async () => ({ models: ["openai/gpt-5"] }) as any,
+    };
+
+    const resolved = await resolveAgentOptions(
+      "agent-1",
+      { model: "claude/claude-sonnet-5" },
+			settingsStore as any,
+      "org-1",
+    );
+
+    // Note: the exact-allow-list gate (deployment-manager backstop) validates
+    // this later; resolveAgentOptions only ensures a WELL-FORMED override wins.
+    expect(resolved.model).toBe("claude/claude-sonnet-5");
+  });
+
   test("reads the agent row scoped to the caller's org (shared agent id across orgs)", async () => {
     // A shared agent id (e.g. "lobu-builder") exists in multiple orgs, each with
-    // its own defaultModel. The worker-dispatch path has no ambient orgContext,
+    // its own models list. The worker-dispatch path has no ambient orgContext,
     // so getSettings MUST receive the org explicitly — otherwise it reads an
     // arbitrary org's row and mis-resolves the model (the Gemini/Claude 404 bug).
-    const rowsByOrg: Record<string, { defaultModel: string }> = {
-      "org-a": { defaultModel: "claude/claude-sonnet-4-6" },
-      "org-b": { defaultModel: "gemini/gemini-2.5-flash" },
+    const rowsByOrg: Record<string, { models: string[] }> = {
+      "org-a": { models: ["claude/claude-sonnet-4-6"] },
+      "org-b": { models: ["gemini/gemini-2.5-flash"] },
     };
     const seenAgentIds: string[] = [];
     const settingsStore = {

--- a/packages/server/src/gateway/__tests__/session-context-cross-tenant.test.ts
+++ b/packages/server/src/gateway/__tests__/session-context-cross-tenant.test.ts
@@ -1,0 +1,178 @@
+/**
+ * R6: the orgless cross-tenant guard must cover EVERY agent-scoped read in
+ * `/session-context`, not just the model. A DB-backed shared id (e.g.
+ * "lobu-builder", present in every org) with an ORGLESS worker token must NOT
+ * id-only read another tenant's identity/soul/skills or derive another tenant's
+ * lobu-memory MCP org slug. Declared (SDK-embedded) agents are org-agnostic and
+ * must still resolve; a normal org-scoped agent must be fully intact.
+ *
+ * Drives the REAL InstructionService + McpConfigService with a spy settings
+ * store, asserting the `orgScoped` flag gates the by-id reads.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { InstructionContext } from "@lobu/core";
+import { McpConfigService } from "../auth/mcp/config-service.js";
+import {
+  BaseInstructionProvider,
+  InstructionService,
+} from "../services/instruction-service.js";
+
+/** A platform provider that, if not gated, leaks a foreign tenant's identity. */
+class LeakyPlatformProvider extends BaseInstructionProvider {
+  readonly name = "leaky-platform";
+  readonly priority = 20;
+  public called = false;
+  protected buildInstructions(): string {
+    this.called = true;
+    return "FOREIGN PLATFORM IDENTITY @foreign-bot UFOREIGN";
+  }
+}
+
+function makeSettingsStore(opts: { isDeclared: boolean }) {
+  const reads: Array<{ agentId: string; organizationId?: string }> = [];
+  const store = {
+    isDeclaredAgent: () => opts.isDeclared,
+    getSettings: async (
+      agentId: string,
+      ctx?: { organizationId?: string }
+    ) => {
+      reads.push({ agentId, organizationId: ctx?.organizationId });
+      // The FOREIGN tenant's config that must never leak on the orgless path.
+      return {
+        identityMd: "FOREIGN IDENTITY",
+        soulMd: "FOREIGN SOUL",
+        userMd: "FOREIGN USER",
+        skillsConfig: {
+          skills: [
+            { name: "foreign-skill", enabled: true, content: "FOREIGN SKILL" },
+          ],
+        },
+      };
+    },
+  };
+  return { store, reads };
+}
+
+function makeMcpConfig(resolvedSlug: string | null) {
+  const calls: Array<{ agentId: string; organizationId?: string }> = [];
+  const service = new McpConfigService({
+    lobuMemory: {
+      resolveOrgSlug: async (
+        agentId: string,
+        organizationId: string | undefined
+      ) => {
+        calls.push({ agentId, organizationId });
+        // Mirror the real cross-tenant-safe resolver: null when orgless.
+        if (!organizationId) return null;
+        return resolvedSlug;
+      },
+    },
+  });
+  return { service, calls };
+}
+
+function ctx(overrides: Partial<InstructionContext>): InstructionContext {
+  return {
+    userId: "u1",
+    agentId: "lobu-builder",
+    sessionKey: "u1",
+    workingDirectory: "/workspace",
+    availableProjects: [],
+    ...overrides,
+  };
+}
+
+describe("session-context cross-tenant guard (R6) — all agent-scoped reads", () => {
+  test("orgless DB-backed shared id: NO foreign identity/soul/skills, NO foreign MCP slug", async () => {
+    const { store, reads } = makeSettingsStore({ isDeclared: false });
+    const { service: mcp, calls } = makeMcpConfig("foreign-org");
+    const svc = new InstructionService(mcp, store as never);
+
+    const result = await svc.getSessionContext(
+      "api",
+      // orgless (no organizationId) + orgScoped:false — the gateway sets this.
+      ctx({ organizationId: undefined, orgScoped: false })
+    );
+
+    // Identity/soul/user: NOT the foreign tenant's.
+    expect(result.agentInstructions).not.toContain("FOREIGN");
+    // Skills: generic discovery blurb, NOT the foreign skill content.
+    expect(result.skillsInstructions).not.toContain("FOREIGN SKILL");
+    // No by-id settings read happened at all.
+    expect(reads).toHaveLength(0);
+    // MCP: the orgless resolve returned null → no lobu-memory slug leaked.
+    expect(result.mcpStatus).toHaveLength(0);
+    // resolveOrgSlug was consulted with NO org (so it returned null).
+    expect(calls.every((c) => !c.organizationId)).toBe(true);
+  });
+
+  test("orgless DECLARED agent: still resolves its (org-agnostic) instructions", async () => {
+    const { store } = makeSettingsStore({ isDeclared: true });
+    const { service: mcp } = makeMcpConfig("declared-org");
+    const svc = new InstructionService(mcp, store as never);
+
+    // A declared agent is org-agnostic → orgScoped is true even with no org.
+    const result = await svc.getSessionContext(
+      "api",
+      ctx({ organizationId: undefined, orgScoped: true })
+    );
+
+    // The declared agent's own identity/soul resolve.
+    expect(result.agentInstructions).toContain("FOREIGN IDENTITY");
+  });
+
+  test("normal org-scoped agent: identity + skills + MCP all intact (regression)", async () => {
+    const { store, reads } = makeSettingsStore({ isDeclared: false });
+    const { service: mcp, calls } = makeMcpConfig("acme");
+    const svc = new InstructionService(mcp, store as never);
+
+    const result = await svc.getSessionContext(
+      "api",
+      ctx({ organizationId: "acme-org", orgScoped: true })
+    );
+
+    // Settings read happened, org-scoped.
+    expect(reads.length).toBeGreaterThan(0);
+    expect(reads.every((r) => r.organizationId === "acme-org")).toBe(true);
+    // Identity + skills resolve.
+    expect(result.agentInstructions).toContain("FOREIGN IDENTITY");
+    expect(result.skillsInstructions).toContain("foreign-skill");
+    // MCP resolved with the org → a lobu-memory status entry exists.
+    expect(result.mcpStatus.length).toBeGreaterThan(0);
+    expect(calls.every((c) => c.organizationId === "acme-org")).toBe(true);
+  });
+
+  test("R7 #1(a): the PLATFORM provider is gated by orgScoped — skipped for orgless db-backed", async () => {
+    const { store } = makeSettingsStore({ isDeclared: false });
+    const { service: mcp } = makeMcpConfig(null);
+    const svc = new InstructionService(mcp, store as never);
+    const leaky = new LeakyPlatformProvider();
+    svc.registerPlatformProvider("slack", leaky);
+
+    const result = await svc.getSessionContext(
+      "slack",
+      ctx({ organizationId: undefined, orgScoped: false })
+    );
+
+    // The platform provider was NOT invoked → no foreign platform identity.
+    expect(leaky.called).toBe(false);
+    expect(result.platformInstructions).toBe("");
+  });
+
+  test("R7 #1(a): the PLATFORM provider RUNS for a normal org-scoped agent (regression)", async () => {
+    const { store } = makeSettingsStore({ isDeclared: false });
+    const { service: mcp } = makeMcpConfig("acme");
+    const svc = new InstructionService(mcp, store as never);
+    const leaky = new LeakyPlatformProvider();
+    svc.registerPlatformProvider("slack", leaky);
+
+    const result = await svc.getSessionContext(
+      "slack",
+      ctx({ organizationId: "acme-org", orgScoped: true })
+    );
+
+    expect(leaky.called).toBe(true);
+    expect(result.platformInstructions).toContain("FOREIGN PLATFORM IDENTITY");
+  });
+});

--- a/packages/server/src/gateway/__tests__/worker-gateway-session-context.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-gateway-session-context.test.ts
@@ -21,7 +21,10 @@ describe("WorkerGateway session context", () => {
     }
   });
 
-  test("syncs only agent-configured skills into skillsConfig", async () => {
+  test("syncs only agent-configured skills into skillsConfig (declared agent, orgless)", async () => {
+    // A DECLARED (SDK-embedded) agent has org-agnostic settings, so an orgless
+    // token legitimately syncs its skills. (A DB-backed agent with an orgless
+    // token would fail closed — covered by the cross-tenant test below.)
     const gateway = new WorkerGateway(
       { send: async () => undefined } as any,
       "https://gateway.example.com",
@@ -41,6 +44,7 @@ describe("WorkerGateway session context", () => {
       undefined,
       undefined,
       {
+        isDeclaredAgent: () => true,
         getSettings: async () => ({
           skillsConfig: {
             skills: [

--- a/packages/server/src/gateway/__tests__/worker-path-org-scope-e2e.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-path-org-scope-e2e.test.ts
@@ -4,7 +4,7 @@
  * (lobu-builder) exists in multiple orgs.
  *
  * This reproduces the original Slack-bot bug condition: two orgs both own an
- * agent id `lobu-builder`, each with a different `defaultModel`. The worker
+ * agent id `lobu-builder`, each with a different `models` list. The worker
  * path runs with NO ambient orgContext. Before the #1779 fix, `resolveAgentOptions`
  * fell to an id-only read and returned an arbitrary org's model (the Gemini/Claude
  * 404). This drives the real resolver against the real store and asserts the
@@ -38,19 +38,19 @@ describe("worker-path org scope (real store, shared agent id)", () => {
     await resetTestDatabase();
     store = new AgentSettingsStore(createPostgresAgentConfigStore());
 
-    // Seed the SAME agent id in two orgs with different defaultModels. Order
+    // Seed the SAME agent id in two orgs with different models lists. Order
     // matters: org-claude is created first so an unscoped `WHERE id = $agentId`
     // (no ORDER BY) tends to return it — the wrong row for a gemini install.
     await seedAgentRow(AGENT, { organizationId: ORG_CLAUDE });
     await seedAgentRow(AGENT, { organizationId: ORG_GEMINI });
     await orgContext.run({ organizationId: ORG_CLAUDE }, () =>
       store.saveSettings(AGENT, {
-        defaultModel: "claude/claude-sonnet-4-6",
+        models: ["claude/claude-sonnet-4-6"],
       } as any),
     );
     await orgContext.run({ organizationId: ORG_GEMINI }, () =>
       store.saveSettings(AGENT, {
-        defaultModel: "gemini/gemini-2.5-flash",
+        models: ["gemini/gemini-2.5-flash"],
       } as any),
     );
   });
@@ -72,7 +72,7 @@ describe("worker-path org scope (real store, shared agent id)", () => {
 
     // Whatever it returns, it is NOT reliably the gemini org — demonstrating why
     // the explicit org scope is required. In this seeding it returns claude's.
-    expect(unscoped?.defaultModel).toBe("claude/claude-sonnet-4-6");
+    expect(unscoped?.models?.[0]).toBe("claude/claude-sonnet-4-6");
   });
 
   test("each org resolves its own model independently", async () => {

--- a/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
@@ -53,12 +53,18 @@ function buildGatewayNoCatalog(getSettings: () => Promise<any>): WorkerGateway {
 }
 
 async function sessionContextModel(
-  gateway: WorkerGateway
+  gateway: WorkerGateway,
+  opts: { agentId?: string; organizationId?: string } = {}
 ): Promise<string | undefined> {
   const token = generateWorkerToken("user-1", "conv-1", "worker-a", {
     channelId: "channel-1",
-    agentId: AGENT,
-    organizationId: ORG,
+    agentId: opts.agentId ?? AGENT,
+    // organizationId omitted when opts.organizationId is explicitly undefined.
+    ...("organizationId" in opts
+      ? opts.organizationId
+        ? { organizationId: opts.organizationId }
+        : {}
+      : { organizationId: ORG }),
   });
   const res = await gateway.getApp().request("/session-context", {
     headers: { authorization: `Bearer ${token}`, host: "gateway.example.com" },
@@ -94,17 +100,17 @@ describe("worker model fallback (real DB, both channels)", () => {
     expect(await getOrgDefaultModel(ORG)).toBe("openai/gpt-5");
   });
 
-  test("Channel 1: agent with no defaultModel → org default in agentOptions.model", async () => {
+  test("Channel 1: agent with no models → org default in agentOptions.model", async () => {
     const store = {
-      getSettings: async () => ({ defaultModel: undefined }),
+      getSettings: async () => ({ models: undefined }),
     } as any;
     const opts = await resolveAgentOptions(AGENT, {}, store, ORG);
     expect(opts.model).toBe("openai/gpt-5");
   });
 
-  test("Channel 1: agent defaultModel wins over org default", async () => {
+  test("Channel 1: agent models[0] wins over org default", async () => {
     const store = {
-      getSettings: async () => ({ defaultModel: "claude/claude-sonnet-4-6" }),
+      getSettings: async () => ({ models: ["claude/claude-sonnet-4-6"] }),
     } as any;
     const opts = await resolveAgentOptions(AGENT, {}, store, ORG);
     expect(opts.model).toBe("claude/claude-sonnet-4-6");
@@ -112,7 +118,7 @@ describe("worker model fallback (real DB, both channels)", () => {
 
   test("Channel 1: behavior override wins over both agent and org", async () => {
     const store = {
-      getSettings: async () => ({ defaultModel: "claude/claude-sonnet-4-6" }),
+      getSettings: async () => ({ models: ["claude/claude-sonnet-4-6"] }),
     } as any;
     const opts = await resolveAgentOptions(
       AGENT,
@@ -127,7 +133,7 @@ describe("worker model fallback (real DB, both channels)", () => {
     const sql = getDb();
     await sql`DELETE FROM inference_providers WHERE organization_id = ${ORG}`;
     const store = {
-      getSettings: async () => ({ defaultModel: undefined }),
+      getSettings: async () => ({ models: undefined }),
     } as any;
     const opts = await resolveAgentOptions(AGENT, {}, store, ORG);
     expect(opts.model).toBeUndefined();
@@ -135,16 +141,161 @@ describe("worker model fallback (real DB, both channels)", () => {
 
   test("Channel 2: /session-context returns no defaultModel without a routable provider catalog", async () => {
     const gateway = buildGatewayNoCatalog(async () => ({
-      defaultModel: "claude/claude-sonnet-4-6",
+      models: ["claude/claude-sonnet-4-6"],
     }));
     // Accurate contract: with no ProviderCatalogService, Channel 2 surfaces no
     // defaultModel (the worker uses Channel 1's agentOptions.model instead).
     expect(await sessionContextModel(gateway)).toBeUndefined();
   });
 
+  test("#2(b): a SENTINEL default publishes NO defaultModel via /session-context (fails closed)", async () => {
+    // The agent's only model is a restriction sentinel. Even though the org has
+    // a credentialed provider that session-context WOULD fall back to, a sentinel
+    // must never be published as defaultModel nor cause a credentialed-module
+    // fallback — the worker must get "no routable model", not "__unresolved__".
+    const sql = getDb();
+    await sql`DELETE FROM inference_providers WHERE organization_id = ${ORG}`;
+    await createInferenceProvider({
+      organizationId: ORG,
+      slug: "byo",
+      kind: "openai",
+      apiKey: "sk-byo",
+      capabilities: {
+        text: { base_url: "https://api.byo.example.com", model: "byo-model" },
+      },
+    });
+    await setInferenceProviderDefault(ORG, "byo");
+
+    const catalog = new ProviderCatalogService(
+      { getSettings: async () => ({ models: ["byo/__unresolved__"] }) } as any,
+      {} as any,
+      (org: string) => listInferenceProviders(org),
+    );
+    const gateway = new WorkerGateway(
+      { send: async () => undefined } as any,
+      "https://gateway.example.com",
+      { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
+      {
+        getSessionContext: async () => ({
+          agentInstructions: "",
+          platformInstructions: "",
+          networkInstructions: "",
+          skillsInstructions: "",
+          mcpStatus: [],
+        }),
+      } as any,
+      undefined,
+      catalog,
+      { getSettings: async () => ({ models: ["byo/__unresolved__"] }) } as any,
+    );
+
+    // Fails closed: no defaultModel published (never "byo/__unresolved__", and
+    // no silent fallback to the credentialed byo module).
+    expect(await sessionContextModel(gateway)).toBeUndefined();
+  });
+
+  test("#3 mixed-list: a SENTINEL-first list publishes the first REAL routable ref via /session-context", async () => {
+    // models=["chatgpt/__unresolved__","byo2/byo2-model"]. models[0] is a
+    // sentinel, but session-context must resolve the later real+routable ref
+    // (byo2, a credentialed custom-upstream org provider) — NOT return {} — so
+    // the OpenAI-compatible byo2 module + its default reach the worker.
+    const sql = getDb();
+    await sql`DELETE FROM inference_providers WHERE organization_id = ${ORG}`;
+    await createInferenceProvider({
+      organizationId: ORG,
+      slug: "byo2",
+      kind: "openai",
+      apiKey: "sk-byo2",
+      capabilities: {
+        text: { base_url: "https://api.byo2.example.com", model: "byo2-model" },
+      },
+    });
+    await setInferenceProviderDefault(ORG, "byo2");
+
+    const settings = {
+      getSettings: async () => ({
+        models: ["chatgpt/__unresolved__", "byo2/byo2-model"],
+      }),
+    } as any;
+    const catalog = new ProviderCatalogService(
+      settings,
+      { getBestProfile: async () => null } as any,
+      (org: string) => listInferenceProviders(org),
+      // registerUpstream: make the synthesized byo2 slug routable on this pod.
+      () => {},
+    );
+    const gateway = new WorkerGateway(
+      { send: async () => undefined } as any,
+      "https://gateway.example.com",
+      { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
+      {
+        getSessionContext: async () => ({
+          agentInstructions: "",
+          platformInstructions: "",
+          networkInstructions: "",
+          skillsInstructions: "",
+          mcpStatus: [],
+        }),
+      } as any,
+      undefined,
+      catalog,
+      settings,
+    );
+
+    // The real routable ref is published — NOT undefined, NOT the sentinel.
+    expect(await sessionContextModel(gateway)).toBe("byo2/byo2-model");
+  });
+
+  test("R5 #4: an ORGLESS worker token publishes NO model for a db-backed shared id (no cross-org read)", async () => {
+    // A shared id (lobu-builder) exists in many orgs. An orgless token must NOT
+    // cause session-context to id-only read ANOTHER org's models[0] and PUBLISH
+    // it as the worker's defaultModel. The settings store here WOULD return a
+    // foreign model — the MODEL resolver must refuse the orgless db read and
+    // publish nothing (fail closed). Track whether the foreign model is used by
+    // the MODEL path specifically.
+    const settings = {
+      // DB-backed (not declared): isDeclaredAgent is false, so the MODEL policy
+      // read must be refused for an orgless db-backed agent.
+      isDeclaredAgent: () => false,
+      getSettings: async () => ({ models: ["claude/other-org-model"] }),
+    } as any;
+    const catalog = new ProviderCatalogService(
+      settings,
+      { getBestProfile: async () => null } as any,
+      (org: string) => listInferenceProviders(org),
+      () => {},
+    );
+    const gateway = new WorkerGateway(
+      { send: async () => undefined } as any,
+      "https://gateway.example.com",
+      { getWorkerConfig: async () => ({ mcpServers: {} }) } as any,
+      {
+        getSessionContext: async () => ({
+          agentInstructions: "",
+          platformInstructions: "",
+          networkInstructions: "",
+          skillsInstructions: "",
+          mcpStatus: [],
+        }),
+      } as any,
+      undefined,
+      catalog,
+      settings,
+    );
+
+    // Orgless token → NO model published (the foreign org's model must never
+    // reach the worker as defaultModel).
+    const published = await sessionContextModel(gateway, {
+      agentId: "lobu-builder",
+      organizationId: undefined,
+    });
+    expect(published).toBeUndefined();
+    expect(published).not.toBe("claude/other-org-model");
+  });
+
   test("org default reaches an agent with NO installed providers (custom upstream synthesized)", async () => {
     // The layered fallback's headline case: an agent that pins nothing and has
-    // NO installedProviders must still get the org default provider synthesized
+    // an EMPTY models list must still get the org default provider synthesized
     // into its modules — otherwise a custom-upstream org default reaches the
     // worker as a bare model ref with no base_url/credentials and can't route.
     const sql = getDb();
@@ -166,8 +317,8 @@ describe("worker model fallback (real DB, both channels)", () => {
     expect(await setInferenceProviderDefault(ORG, "byo-default")).toBe(true);
 
     const catalog = new ProviderCatalogService(
-      // Agent settings with EMPTY installedProviders — the exact gap.
-      { getSettings: async () => ({ installedProviders: [] }) } as any,
+      // Agent settings with an EMPTY models list — the exact gap.
+      { getSettings: async () => ({ models: [] }) } as any,
       {} as any,
       (org: string) => listInferenceProviders(org),
     );

--- a/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/provider-catalog-org-inference.test.ts
@@ -9,7 +9,11 @@ import { ProviderCatalogService } from "../provider-catalog.js";
  * getInstalledModules to map an org row's `kind` → protocol) can resolve it.
  * Keyed by `name`; the registry only stores enabled modules.
  */
-function registerFakeModule(providerId: string, sdkCompat: string): void {
+function registerFakeModule(
+  providerId: string,
+  sdkCompat: string,
+  opts: { hasSystemKey?: boolean } = {}
+): void {
   moduleRegistry.register({
     name: `${providerId}-provider`,
     isEnabled: () => true,
@@ -18,6 +22,7 @@ function registerFakeModule(providerId: string, sdkCompat: string): void {
     providerIconUrl: "",
     authType: "oauth",
     sdkCompat,
+    hasSystemKey: () => opts.hasSystemKey ?? false,
     getSecretEnvVarNames: () => [],
   } as unknown as ModuleInterface);
 }
@@ -30,22 +35,24 @@ function clearRegistry(): void {
 
 /**
  * Org-owned inference-provider slugs (rows in `inference_providers`) must become
- * ROUTABLE worker model providers: an agent with `model: "<orgSlug>/<model>"`
+ * ROUTABLE worker model providers: an agent with `models: ["<orgSlug>/<model>"]`
  * routes through the gateway proxy to the org's custom `capabilities.text.base_url`.
  *
- * getInstalledModules synthesizes an ApiKeyProviderModule for any installed slug
- * that isn't a providers.json module but matches a custom-upstream org row. The
- * org KEY is never read here — it is injected at egress by resolveUrlInvariant;
- * the synthetic module only makes the slug appear in the worker provider config
- * and the proxy slug maps. Registration happens per-pod, hydrated from the row
- * (multi-replica safe: no shared in-memory map another replica must read).
+ * getInstalledModules resolves the agent's `models` list (ordered explicit
+ * `<slug>/<model>` refs) into modules: a slug that isn't a providers.json module
+ * but matches a custom-upstream org row is synthesized into an
+ * ApiKeyProviderModule. The org KEY is never read here — it is injected at
+ * egress by resolveUrlInvariant; the synthetic module only makes the slug appear
+ * in the worker provider config and the proxy slug maps. Registration happens
+ * per-pod, hydrated from the row (multi-replica safe: no shared in-memory map
+ * another replica must read).
  *
  * These tests inject the store reader + registerUpstream callback and a fake
  * settings store, so no DB/proxy wiring is required.
  */
 
 function makeCatalog(opts: {
-  installedProviderIds: string[];
+  models: string[] | undefined;
   orgRows?: InferenceProviderListItem[];
   registerUpstream?: (
     upstream: { slug: string; upstreamBaseUrl: string },
@@ -55,17 +62,14 @@ function makeCatalog(opts: {
 }): ProviderCatalogService {
   const agentSettingsStore = {
     getSettings: async () => ({
-      installedProviders: opts.installedProviderIds.map((providerId) => ({
-        providerId,
-        installedAt: 1,
-      })),
+      models: opts.models,
     }),
   } as never;
-  const authProfilesManager = {} as never;
+  // findProviderForModel probes each module's getModelOptions, which resolves
+  // credentials through the profiles manager — stub it to "no profile".
+  const authProfilesManager = { getBestProfile: async () => null } as never;
   const listOrgInferenceProviders =
-    opts.withOrgReader === false
-      ? undefined
-      : async () => opts.orgRows ?? [];
+    opts.withOrgReader === false ? undefined : async () => opts.orgRows ?? [];
   return new ProviderCatalogService(
     agentSettingsStore,
     authProfilesManager,
@@ -100,7 +104,7 @@ describe("ProviderCatalogService.getInstalledModules — org inference providers
     const registered: Array<{ slug: string; providerId: string; url: string }> =
       [];
     const catalog = makeCatalog({
-      installedProviderIds: ["myzai"],
+      models: ["myzai/glm-4.6"],
       orgRows: [customUpstreamRow("myzai")],
       registerUpstream: (upstream, providerId) =>
         registered.push({
@@ -145,7 +149,7 @@ describe("ProviderCatalogService.getInstalledModules — org inference providers
     // Claude-like catalog module so kind "claude" resolves to sdkCompat anthropic.
     registerFakeModule("claude", "anthropic");
     const catalog = makeCatalog({
-      installedProviderIds: ["my-claude"],
+      models: ["my-claude/claude-x"],
       orgRows: [customUpstreamRow("my-claude", { kind: "claude" })],
       registerUpstream: () => {},
     });
@@ -164,7 +168,7 @@ describe("ProviderCatalogService.getInstalledModules — org inference providers
   test("does NOT synthesize when the org row has no custom text base_url", async () => {
     const registered: string[] = [];
     const catalog = makeCatalog({
-      installedProviderIds: ["myzai"],
+      models: ["myzai/glm-4.6"],
       orgRows: [
         customUpstreamRow("myzai", {
           capabilities: {},
@@ -182,32 +186,285 @@ describe("ProviderCatalogService.getInstalledModules — org inference providers
   test("does NOT synthesize when organizationId is absent (slug dropped as before)", async () => {
     let readerCalled = false;
     const catalog = makeCatalog({
-      installedProviderIds: ["myzai"],
+      models: ["myzai/glm-4.6"],
       orgRows: [customUpstreamRow("myzai")],
     });
     // Wrap to detect that the reader is never consulted without an org.
-    (catalog as never as { listOrgInferenceProviders?: unknown }).listOrgInferenceProviders =
-      async () => {
-        readerCalled = true;
-        return [customUpstreamRow("myzai")];
-      };
+    (
+      catalog as never as { listOrgInferenceProviders?: unknown }
+    ).listOrgInferenceProviders = async () => {
+      readerCalled = true;
+      return [customUpstreamRow("myzai")];
+    };
 
     const modules = await catalog.getInstalledModules("agent-1");
     expect(modules).toHaveLength(0);
     expect(readerCalled).toBe(false);
   });
 
-  test("preserves install order and drops unmatched slugs", async () => {
-    // Two org-synthesized slugs plus one installed slug with NO matching row.
+  test("preserves models order and drops unmatched slugs", async () => {
+    // Two org-synthesized slugs plus one models entry with NO matching row.
     // The unmatched slug is dropped (as a non-providers.json slug always was),
-    // and the two synthesized modules keep installedProviders order.
+    // and the two synthesized modules keep the models-list order.
     const catalog = makeCatalog({
-      installedProviderIds: ["myzai", "no-such-provider", "acme"],
+      models: ["myzai/glm-4.6", "no-such-provider/x", "acme/m-1"],
       orgRows: [customUpstreamRow("acme"), customUpstreamRow("myzai")],
     });
     const modules = await catalog.getInstalledModules("agent-1", "org-1");
     const ids = modules.map((m) => m.providerId);
-    // Install order preserved (myzai before acme); unmatched slug dropped.
+    // models order preserved (myzai before acme); unmatched slug dropped.
     expect(ids).toEqual(["myzai", "acme"]);
+  });
+
+  test("dedups slugs by first appearance across multiple models of one provider", async () => {
+    const catalog = makeCatalog({
+      models: ["myzai/glm-4.6", "myzai/glm-5.2", "acme/m-1"],
+      orgRows: [customUpstreamRow("acme"), customUpstreamRow("myzai")],
+    });
+    const modules = await catalog.getInstalledModules("agent-1", "org-1");
+    expect(modules.map((m) => m.providerId)).toEqual(["myzai", "acme"]);
+  });
+
+  test("decision B: does NOT append the org default to a non-empty list", async () => {
+    const catalog = makeCatalog({
+      models: ["myzai/glm-4.6"],
+      orgRows: [
+        customUpstreamRow("myzai"),
+        customUpstreamRow("acme", { isDefault: true }),
+      ],
+    });
+    const modules = await catalog.getInstalledModules("agent-1", "org-1");
+    // The org default (acme) is NOT reachable — only the listed slug resolves.
+    expect(modules.map((m) => m.providerId)).toEqual(["myzai"]);
+  });
+
+  test("GATE: an org provider NOT in the agent's non-empty models list does not resolve", async () => {
+    // "acme" is org-installed (a live inference_providers row) but the agent's
+    // models list names only "myzai" — so acme must NOT be routable for this
+    // agent. Decision B: NO org-default tail — only the listed slugs resolve.
+    const catalog = makeCatalog({
+      models: ["myzai/glm-4.6"],
+      orgRows: [
+        customUpstreamRow("myzai", { isDefault: true }),
+        customUpstreamRow("acme"),
+      ],
+    });
+    const modules = await catalog.getInstalledModules("agent-1", "org-1");
+    expect(modules.map((m) => m.providerId)).toEqual(["myzai"]);
+
+    // The resolver finds no provider for an out-of-list model ref.
+    const provider = await catalog.findProviderForModel("acme/some-model", modules);
+    expect(provider).toBeUndefined();
+  });
+
+  test("EMPTY models list ⇒ all org rows (default first) plus system-key registry modules", async () => {
+    // Decision: an agent with no models list gets every org provider — the org
+    // default row first, the remaining org rows, then every registry module
+    // with a deployment/system key not already covered.
+    registerFakeModule("housekey", "openai", { hasSystemKey: true });
+    registerFakeModule("keyless", "openai", { hasSystemKey: false });
+    const catalog = makeCatalog({
+      models: [],
+      orgRows: [
+        customUpstreamRow("myzai"),
+        customUpstreamRow("acme", { isDefault: true }),
+      ],
+    });
+    const modules = await catalog.getInstalledModules("agent-1", "org-1");
+    const ids = modules.map((m) => m.providerId);
+    // Org default first, then remaining org rows, then system-key modules.
+    expect(ids).toEqual(["acme", "myzai", "housekey"]);
+    // A registry module WITHOUT a system key is not exposed.
+    expect(ids).not.toContain("keyless");
+  });
+
+  test("ABSENT models (undefined) behaves like the empty list", async () => {
+    registerFakeModule("housekey", "openai", { hasSystemKey: true });
+    const catalog = makeCatalog({
+      models: undefined,
+      orgRows: [customUpstreamRow("acme", { isDefault: true })],
+    });
+    const modules = await catalog.getInstalledModules("agent-1", "org-1");
+    expect(modules.map((m) => m.providerId)).toEqual(["acme", "housekey"]);
+  });
+});
+
+describe("ProviderCatalogService.getModelPolicy — exact allow-list", () => {
+  afterEach(() => clearRegistry());
+
+  test("non-empty list ⇒ allowedRefs is EXACTLY the listed refs (decision B: NO org-default tail)", async () => {
+    const catalog = makeCatalog({
+      models: ["myzai/glm-4.6"],
+      orgRows: [
+        // acme is the org default but must NOT leak into allowedRefs/modules.
+        customUpstreamRow("acme", { isDefault: true }),
+        customUpstreamRow("myzai"),
+      ],
+    });
+    const { allowedRefs, modules } = await catalog.getModelPolicy(
+      "agent-1",
+      "org-1"
+    );
+    // Exactly the listed ref — no org-default concrete ref appended.
+    expect(allowedRefs).toEqual(["myzai/glm-4.6"]);
+    // Modules cover ONLY the listed provider — the org default is not added.
+    expect(modules.map((m) => m.providerId)).toEqual(["myzai"]);
+  });
+
+  test("decision B: a sentinel-only list resolves to zero routable modules (hard fail closed)", async () => {
+    // models = ["chatgpt/__unresolved__"] is the "restricted but nothing
+    // resolvable yet" state: the allow-list contains only the sentinel, and no
+    // real module routes it — findProviderForModel refuses the sentinel.
+    registerFakeModule("chatgpt", "openai", { hasSystemKey: true });
+    const catalog = makeCatalog({
+      models: ["chatgpt/__unresolved__"],
+      orgRows: [],
+    });
+    const { allowedRefs, modules } = await catalog.getModelPolicy(
+      "agent-1",
+      "org-1"
+    );
+    expect(allowedRefs).toEqual(["chatgpt/__unresolved__"]);
+    // #2(a): the sentinel's slug MUST NOT contribute a provider module — even
+    // though a credentialed chatgpt module exists in the registry. Zero modules
+    // means session-context has nothing to fall back to → hard fail closed.
+    expect(modules).toHaveLength(0);
+    // And findProviderForModel refuses the sentinel ref outright.
+    const provider = await catalog.findProviderForModel(
+      "chatgpt/__unresolved__",
+      modules
+    );
+    expect(provider).toBeUndefined();
+  });
+
+  test("#2(a): a MIXED list exposes the real provider's module but NOT the sentinel's", async () => {
+    // models=["ghost/__unresolved__","myzai/glm-4.6"]. The real provider (myzai)
+    // routes; the sentinel's slug (ghost) contributes NO module.
+    const catalog = makeCatalog({
+      models: ["ghost/__unresolved__", "myzai/glm-4.6"],
+      orgRows: [customUpstreamRow("myzai", { isDefault: true })],
+    });
+    const { allowedRefs, modules } = await catalog.getModelPolicy(
+      "agent-1",
+      "org-1"
+    );
+    // The sentinel stays in the exact allow-list (it's a listed entry)…
+    expect(allowedRefs).toEqual(["ghost/__unresolved__", "myzai/glm-4.6"]);
+    // …but only the real provider resolves a module.
+    expect(modules.map((m) => m.providerId)).toEqual(["myzai"]);
+  });
+
+  test("GATE is EXACT: a different model on a LISTED provider is NOT allowed", async () => {
+    const catalog = makeCatalog({
+      models: ["myzai/glm-4.6"],
+      orgRows: [customUpstreamRow("myzai", { isDefault: true })],
+    });
+    const { allowedRefs } = await catalog.getModelPolicy("agent-1", "org-1");
+    // The provider is myzai but "myzai/other" is a DIFFERENT model → excluded.
+    expect(allowedRefs).toContain("myzai/glm-4.6");
+    expect(allowedRefs).not.toContain("myzai/other");
+  });
+
+  test("empty list ⇒ allowedRefs is null (allow-all)", async () => {
+    const catalog = makeCatalog({
+      models: [],
+      orgRows: [customUpstreamRow("acme", { isDefault: true })],
+    });
+    const { allowedRefs } = await catalog.getModelPolicy("agent-1", "org-1");
+    expect(allowedRefs).toBeNull();
+  });
+
+  test("multiple same-provider entries are BOTH in the exact allow-list (ordered)", async () => {
+    // The gate must permit each listed model of one provider — this is what
+    // lets models[1..] act as ordered same-provider fallbacks.
+    const catalog = makeCatalog({
+      models: ["myzai/glm-4.6", "myzai/glm-5.2"],
+      orgRows: [customUpstreamRow("myzai", { isDefault: true })],
+    });
+    const { allowedRefs } = await catalog.getModelPolicy("agent-1", "org-1");
+    expect(allowedRefs?.[0]).toBe("myzai/glm-4.6");
+    expect(allowedRefs).toContain("myzai/glm-5.2");
+  });
+});
+
+describe("ProviderCatalogService.getModelPolicy — not-found / orgless are DENY-ALL (R5 #2/#4)", () => {
+  afterEach(() => clearRegistry());
+
+  function makeCatalogWithSettings(settings: {
+    getSettings: (agentId: string, ctx?: { organizationId?: string }) => Promise<unknown>;
+    isDeclaredAgent?: (agentId: string) => boolean;
+  }): ProviderCatalogService {
+    return new ProviderCatalogService(
+      settings as never,
+      { getBestProfile: async () => null } as never,
+      (async () => []) as never,
+      (() => {}) as never
+    );
+  }
+
+  test("R5 #2: a NOT-FOUND agent (getSettings→null) is DENY-ALL (allowedRefs=[], zero modules)", async () => {
+    // Register a system-key module: if this were allow-all it would leak here.
+    registerFakeModule("housekey", "openai", { hasSystemKey: true });
+    const catalog = makeCatalogWithSettings({
+      getSettings: async () => null,
+    });
+    const { allowedRefs, modules } = await catalog.getModelPolicy(
+      "ghost-agent",
+      "org-1"
+    );
+    expect(allowedRefs).toEqual([]); // deny-all, NOT null (allow-all)
+    expect(modules).toHaveLength(0);
+
+    // Any requested model fails closed.
+    const resolved = await catalog.resolveDispatchModel(
+      "ghost-agent",
+      "org-1",
+      "openai/gpt-5"
+    );
+    expect(resolved.model).toBeUndefined();
+    expect(resolved.replaced).toBe(true);
+  });
+
+  test("R5 #4: an ORGLESS db-backed read is DENY-ALL (no id-only cross-org lookup)", async () => {
+    registerFakeModule("housekey", "openai", { hasSystemKey: true });
+    let getSettingsCalled = false;
+    const catalog = makeCatalogWithSettings({
+      getSettings: async () => {
+        getSettingsCalled = true;
+        // Even if the store WOULD return another org's list, the resolver must
+        // refuse the orgless read before this runs.
+        return { models: ["claude/other-org-model"] };
+      },
+      isDeclaredAgent: () => false,
+    });
+    const { allowedRefs, modules } = await catalog.getModelPolicy(
+      "lobu-builder",
+      undefined // no org
+    );
+    expect(allowedRefs).toEqual([]);
+    expect(modules).toHaveLength(0);
+    // The DB read was never attempted for the orgless db-backed agent.
+    expect(getSettingsCalled).toBe(false);
+  });
+
+  test("R5 #4: an ORGLESS DECLARED agent still resolves its org-agnostic policy", async () => {
+    const catalog = makeCatalogWithSettings({
+      getSettings: async () => ({ models: ["openai/gpt-5"] }),
+      isDeclaredAgent: () => true, // declared/SDK-embedded → org-agnostic
+    });
+    const { allowedRefs } = await catalog.getModelPolicy(
+      "declared-agent",
+      undefined
+    );
+    expect(allowedRefs).toEqual(["openai/gpt-5"]);
+  });
+
+  test("a present agent with an EMPTY models list keeps ALLOW-ALL (null)", async () => {
+    registerFakeModule("housekey", "openai", { hasSystemKey: true });
+    const catalog = makeCatalogWithSettings({
+      getSettings: async () => ({ models: [] }),
+    });
+    const { allowedRefs } = await catalog.getModelPolicy("agent-1", "org-1");
+    expect(allowedRefs).toBeNull(); // allow-all preserved — NOT collapsed to deny
   });
 });

--- a/packages/server/src/gateway/auth/mcp/config-service.ts
+++ b/packages/server/src/gateway/auth/mcp/config-service.ts
@@ -28,7 +28,16 @@ interface McpStatus {
 }
 
 interface LobuMemoryConfigOptions {
-  resolveOrgSlug?: (agentId: string) => Promise<string | null>;
+  /**
+   * Resolve the org slug for the lobu-memory MCP endpoint. Takes the token's
+   * organizationId — NOT an id-only agent lookup — so a shared agent id can't
+   * derive an ARBITRARY org's slug. Returns null when the org can't be resolved
+   * (orgless db-backed agent) → no lobu-memory MCP for that turn (fail closed).
+   */
+  resolveOrgSlug?: (
+    agentId: string,
+    organizationId: string | undefined
+  ) => Promise<string | null>;
 }
 
 interface McpConfigServiceOptions {
@@ -75,7 +84,10 @@ export class McpConfigService {
     const effectiveAgentId = agentId || userId;
     logger.info(`Building MCP config for user ${userId}`);
 
-    const lobuMemory = await this.deriveLobuMemoryServer(effectiveAgentId);
+    const lobuMemory = await this.deriveLobuMemoryServer(
+      effectiveAgentId,
+      tokenData.organizationId
+    );
     if (lobuMemory) {
       workerConfig.mcpServers[LOBU_MEMORY_MCP_ID] = {
         ...lobuMemory,
@@ -104,9 +116,15 @@ export class McpConfigService {
     return workerConfig;
   }
 
-  /** Get status of system MCPs for a specific agent. */
-  async getMcpStatus(agentId: string): Promise<McpStatus[]> {
-    const lobuMemory = await this.deriveLobuMemoryServer(agentId);
+  /** Get status of system MCPs for a specific agent (org-scoped). */
+  async getMcpStatus(
+    agentId: string,
+    organizationId?: string
+  ): Promise<McpStatus[]> {
+    const lobuMemory = await this.deriveLobuMemoryServer(
+      agentId,
+      organizationId
+    );
     if (!lobuMemory) return [];
     return [
       {
@@ -118,13 +136,17 @@ export class McpConfigService {
     ];
   }
 
-  /** Get HTTP proxy metadata for a specific MCP server. */
+  /** Get HTTP proxy metadata for a specific MCP server (org-scoped). */
   async getHttpServer(
     id: string,
-    agentId?: string
+    agentId?: string,
+    organizationId?: string
   ): Promise<HttpMcpServerConfig | undefined> {
     if (id !== LOBU_MEMORY_MCP_ID || !agentId) return undefined;
-    const lobuMemory = await this.deriveLobuMemoryServer(agentId);
+    const lobuMemory = await this.deriveLobuMemoryServer(
+      agentId,
+      organizationId
+    );
     if (!lobuMemory) return undefined;
     return {
       id: LOBU_MEMORY_MCP_ID,
@@ -133,19 +155,25 @@ export class McpConfigService {
     };
   }
 
-  /** Get all HTTP proxy metadata for system MCPs. */
+  /** Get all HTTP proxy metadata for system MCPs (org-scoped). */
   async getAllHttpServers(
-    agentId?: string
+    agentId?: string,
+    organizationId?: string
   ): Promise<Map<string, HttpMcpServerConfig>> {
     const servers = new Map<string, HttpMcpServerConfig>();
     if (!agentId) return servers;
-    const lobuMemory = await this.getHttpServer(LOBU_MEMORY_MCP_ID, agentId);
+    const lobuMemory = await this.getHttpServer(
+      LOBU_MEMORY_MCP_ID,
+      agentId,
+      organizationId
+    );
     if (lobuMemory) servers.set(LOBU_MEMORY_MCP_ID, lobuMemory);
     return servers;
   }
 
   private async deriveLobuMemoryServer(
-    agentId: string
+    agentId: string,
+    organizationId: string | undefined
   ): Promise<{ url: string; type: "streamable-http"; internal: true } | null> {
     const resolveOrgSlug = this.lobuMemory?.resolveOrgSlug;
     if (!resolveOrgSlug) {
@@ -153,7 +181,7 @@ export class McpConfigService {
     }
 
     try {
-      const orgSlug = await resolveOrgSlug(agentId);
+      const orgSlug = await resolveOrgSlug(agentId, organizationId);
       if (!orgSlug) {
         return null;
       }

--- a/packages/server/src/gateway/auth/mcp/proxy-forward.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-forward.ts
@@ -65,7 +65,7 @@ async function handleProxyRequestAuthenticated(
 	tokenData: NonNullable<ReturnType<typeof verifyWorkerToken>>,
 ): Promise<Response> {
 	const agentId = tokenData.agentId || tokenData.userId;
-	const httpServer = await proxy.configService.getHttpServer(mcpId, agentId);
+	const httpServer = await proxy.configService.getHttpServer(mcpId, agentId, tokenData.organizationId);
 
 	if (!httpServer) {
 		return sendJsonRpcError(c, -32601, `MCP server '${mcpId}' not found`);

--- a/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-rest-routes.ts
@@ -42,7 +42,7 @@ async function handleListToolsAuthenticated(
 	if (!agentId || !requesterUserId) {
 		return c.json({ error: "Invalid authentication token" }, 401);
 	}
-	const httpServer = await proxy.configService.getHttpServer(mcpId, agentId);
+	const httpServer = await proxy.configService.getHttpServer(mcpId, agentId, auth.tokenData.organizationId);
 	if (!httpServer) {
 		return c.json({ error: `MCP server '${mcpId}' not found` }, 404);
 	}
@@ -105,7 +105,7 @@ async function handleCallToolAuthenticated(
 	if (!agentId || !requesterUserId) {
 		return c.json({ error: "Invalid authentication token" }, 401);
 	}
-	const httpServer = await proxy.configService.getHttpServer(mcpId, agentId);
+	const httpServer = await proxy.configService.getHttpServer(mcpId, agentId, auth.tokenData.organizationId);
 	if (!httpServer) {
 		return c.json({ error: `MCP server '${mcpId}' not found` }, 404);
 	}
@@ -310,7 +310,7 @@ async function handleListAllToolsAuthenticated(
 ): Promise<Response> {
 	const agentId = auth.tokenData.agentId || auth.tokenData.userId;
 
-	const allHttpServers = await proxy.configService.getAllHttpServers(agentId);
+	const allHttpServers = await proxy.configService.getAllHttpServers(agentId, auth.tokenData.organizationId);
 	const allMcpIds = Array.from(allHttpServers.keys());
 
 	const mcpServers: Record<string, { tools: McpTool[] }> = {};

--- a/packages/server/src/gateway/auth/mcp/proxy-shared.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy-shared.ts
@@ -90,9 +90,11 @@ export interface McpConfigSource {
 	getHttpServer(
 		id: string,
 		agentId?: string,
+		organizationId?: string,
 	): Promise<HttpMcpServerConfig | undefined>;
 	getAllHttpServers(
 		agentId?: string,
+		organizationId?: string,
 	): Promise<Map<string, HttpMcpServerConfig>>;
 }
 

--- a/packages/server/src/gateway/auth/mcp/proxy.ts
+++ b/packages/server/src/gateway/auth/mcp/proxy.ts
@@ -112,7 +112,14 @@ export class McpProxy {
 		isError: boolean;
 	}> {
 		return runWithOrganizationContext(options?.organizationId, () =>
-			this.executeToolDirectScoped(agentId, userId, mcpId, toolName, args),
+			this.executeToolDirectScoped(
+				agentId,
+				userId,
+				mcpId,
+				toolName,
+				args,
+				options.organizationId,
+			),
 		);
 	}
 
@@ -122,11 +129,16 @@ export class McpProxy {
 		mcpId: string,
 		toolName: string,
 		args: Record<string, unknown>,
+		organizationId: string,
 	): Promise<{
 		content: Array<{ type: string; text: string }>;
 		isError: boolean;
 	}> {
-		const httpServer = await this.configService.getHttpServer(mcpId, agentId);
+		const httpServer = await this.configService.getHttpServer(
+			mcpId,
+			agentId,
+			organizationId,
+		);
 		if (!httpServer) {
 			return {
 				content: [{ type: "text", text: `MCP server '${mcpId}' not found` }],
@@ -237,7 +249,11 @@ export class McpProxy {
 			if (cached) return cached;
 		}
 
-		const httpServer = await this.configService.getHttpServer(mcpId, agentId);
+		const httpServer = await this.configService.getHttpServer(
+			mcpId,
+			agentId,
+			tokenData.organizationId,
+		);
 		if (!httpServer) {
 			return { tools: [] };
 		}

--- a/packages/server/src/gateway/auth/model-sentinel.ts
+++ b/packages/server/src/gateway/auth/model-sentinel.ts
@@ -1,0 +1,20 @@
+/**
+ * Restriction-sentinel helpers, in their own module to avoid an import cycle
+ * between `provider-catalog` (dispatch resolution) and
+ * `settings/model-selection` (allow-list enforcement) — both need these.
+ */
+
+/**
+ * Model suffix used by the migration/provisioning to keep a RESTRICTED agent
+ * closed when no concrete model could be resolved for a declared provider. A
+ * `<slug>/__unresolved__` (or `legacy/__unresolved__`) ref is NEVER routable:
+ * it exists only to keep `models` non-empty (not allow-all) so the exact gate
+ * stays closed until an operator picks a real model.
+ */
+export const UNRESOLVED_MODEL_SUFFIX = "__unresolved__";
+
+/** True when a model ref is an unresolved restriction sentinel (never routes). */
+export function isUnresolvedModelRef(ref: string): boolean {
+  const slash = ref.indexOf("/");
+  return slash > 0 && ref.slice(slash + 1) === UNRESOLVED_MODEL_SUFFIX;
+}

--- a/packages/server/src/gateway/auth/provider-catalog.ts
+++ b/packages/server/src/gateway/auth/provider-catalog.ts
@@ -1,6 +1,5 @@
 import {
   createLogger,
-  type InstalledProvider,
   isSdkCompat,
   type ProviderConfigEntry,
   SDK_COMPAT_PROTOCOLS,
@@ -13,10 +12,18 @@ import {
   type ProviderUpstreamConfig,
 } from "../modules/module-system.js";
 import { ApiKeyProviderModule } from "./api-key-provider-module.js";
+import {
+  isUnresolvedModelRef,
+  UNRESOLVED_MODEL_SUFFIX,
+} from "./model-sentinel.js";
 import type { AgentSettingsStore } from "./settings/agent-settings-store.js";
 import type { AuthProfilesManager } from "./settings/auth-profiles-manager.js";
+import { enforceModelAllowList } from "./settings/model-selection.js";
 
 const logger = createLogger("provider-catalog");
+
+// Re-export the sentinel helpers so existing importers keep working.
+export { isUnresolvedModelRef, UNRESOLVED_MODEL_SUFFIX };
 
 /** Auth mechanism a provider supports. */
 export type ProviderAuthType = "oauth" | "device-code" | "api-key";
@@ -165,21 +172,62 @@ function orgProviderKeyEnvVarName(slug: string): string {
 }
 
 /**
- * Resolve an agent's installed providers.
+ * The THREE distinct model-policy states — kept distinct so the caller can map
+ * each to the right allow-list semantics (a fail-open bug conflated the first
+ * two into allow-all):
+ *   - `not-found`   : no agent row (or a cross-org / cross-tenant refusal) →
+ *                     the caller must DENY ALL (empty allow-list, zero modules).
+ *   - `unrestricted`: the agent exists with an EMPTY/absent `models` list → the
+ *                     deliberate allow-all policy.
+ *   - `restricted`  : the agent has a non-empty `models` list → the exact refs.
  */
-async function resolveInstalledProviders(
+type AgentModelPolicy =
+  | { kind: "not-found" }
+  | { kind: "unrestricted" }
+  | { kind: "restricted"; models: string[] };
+
+/**
+ * Resolve an agent's ordered `models` list into one of the three policy states.
+ *
+ * REFUSES an id-only cross-org read: when `organizationId` is undefined the read
+ * is NOT org-scoped, and a shared agent id (e.g. "lobu-builder") lives in many
+ * orgs — an id-only match could read ANOTHER tenant's models list. For a
+ * policy-enforcement read that is a cross-tenant leak, so we return `not-found`
+ * (deny) rather than risk it. (Declared/SDK-embedded agents are resolved by the
+ * settings store BEFORE any DB scope, so their org-agnostic settings still
+ * resolve; only the DB-backed path requires org.)
+ */
+async function resolveAgentModels(
   agentSettingsStore: AgentSettingsStore,
   agentId: string,
   organizationId?: string
-): Promise<InstalledProvider[]> {
-  // Org-scope the read: a shared agent id (e.g. "lobu-builder") lives in many
-  // orgs, and this runs on the worker-dispatch path with no ambient orgContext,
-  // so an unscoped read can return another org's installed-provider list. Pass
-  // the org explicitly so the agent's real providers resolve.
+): Promise<AgentModelPolicy> {
+  // Declared (SDK-embedded) agents have org-agnostic settings; getSettings
+  // resolves them without a DB scope, so an orgless declared-agent turn still
+  // reads its REAL policy (not a cross-org DB row). The check is ORG-AWARE: a
+  // declared id that ALSO has a real DB row in the given org is treated as
+  // DB-backed (the DB row wins), so a collision never flips the orgless guard
+  // open for a tenant's agent.
+  const isDeclared = agentSettingsStore.isDeclaredAgentScoped
+    ? await agentSettingsStore.isDeclaredAgentScoped(agentId, organizationId)
+    : (agentSettingsStore.isDeclaredAgent?.(agentId) ?? false);
+
+  // A DB-backed agent policy read MUST be org-scoped. Without an org, refuse the
+  // id-only fallback (a shared id like "lobu-builder" would read another org's
+  // row — a cross-tenant leak) and DENY.
+  if (!isDeclared && !organizationId) {
+    return { kind: "not-found" };
+  }
+
   const settings = await agentSettingsStore.getSettings(agentId, {
     organizationId,
   });
-  return settings?.installedProviders || [];
+  // NULL settings = the agent row does not exist in THIS org (or the agent-org
+  // pair mismatched). Not-found MUST deny-all, never collapse to allow-all.
+  if (!settings) return { kind: "not-found" };
+  return settings.models && settings.models.length > 0
+    ? { kind: "restricted", models: settings.models }
+    : { kind: "unrestricted" };
 }
 
 /**
@@ -262,41 +310,68 @@ export class ProviderCatalogService {
   }
 
   /**
-   * Resolve an agent's installedProviders to their module instances.
-   * Returns modules in the agent's install order.
+   * Resolve an agent's model policy: the routable provider modules PLUS the
+   * exact-ref allow-list that gates which `<slug>/<model>` refs may run.
    *
-   * Providers.json modules resolve directly. Any installed slug that isn't a
+   * A NON-empty `models` list is an EXACT allow-list (gate): only the exact
+   * refs it names may run (`allowedRefs`), and only the providers those refs
+   * (plus the org default's concrete ref, appended as the safety tail) name
+   * are routed as modules. models[0] is the default; the remaining entries are
+   * the agent's alternates — the ORDERED fallback candidates and the
+   * per-channel (Listen) override pick-list.
+   *
+   * An EMPTY/absent list is allow-all (`allowedRefs = null`): every org
+   * provider routes (default row first, remaining `inference_providers` rows in
+   * listing order, then every deployment/system-key registry module), and any
+   * ref whose provider is among them may run.
+   *
+   * Providers.json modules resolve directly. Any slug that isn't a
    * providers.json module is resolved (when `organizationId` is provided) from
    * the org's inference_providers rows: a matching row with a custom text
    * upstream is synthesized into a routable ApiKeyProviderModule. Slugs with no
    * matching custom-upstream row (or when no org is given) are dropped, as
    * before.
    */
-  async getInstalledModules(
+  async getModelPolicy(
     agentId: string,
     organizationId?: string
-  ): Promise<ModelProviderModule[]> {
-    const installed = await resolveInstalledProviders(
+  ): Promise<{
+    modules: ModelProviderModule[];
+    /** Ordered exact allow-list, or null when the agent allows all providers. */
+    allowedRefs: string[] | null;
+  }> {
+    const policy = await resolveAgentModels(
       this.agentSettingsStore,
       agentId,
       organizationId
     );
+
+    // NOT-FOUND ⇒ DENY-ALL: no agent row (or an orgless/cross-tenant refusal).
+    // Return an EMPTY allow-list (distinct from `null` allow-all) with ZERO
+    // modules, so any requested model fails closed. This is the fail-open bug
+    // fix — a missing agent must never expose every org/system-key provider.
+    if (policy.kind === "not-found") {
+      return { modules: [], allowedRefs: [] };
+    }
+
+    const models = policy.kind === "restricted" ? policy.models : [];
 
     const allModules = getModelProviderModules();
     const moduleMap = new Map(allModules.map((m) => [m.providerId, m]));
 
     // Slugs not backed by a providers.json module may be org-defined inference
     // providers. Load the org's rows once and index by slug so each unmatched
-    // installed slug — AND the org DEFAULT provider — can be synthesized.
+    // slug — AND the org DEFAULT provider — can be synthesized.
+    let orgRows: InferenceProviderListItem[] = [];
     let orgRowsBySlug: Map<string, InferenceProviderListItem> | undefined;
     let orgDefaultSlug: string | undefined;
     // Protocol per catalog slug, so a synthesized org row routes with the wire
     // protocol its `kind` declares (openai/anthropic/…), not a hardcoded one.
     let sdkCompatByKind: Map<string, SdkCompat> | undefined;
     if (organizationId && this.listOrgInferenceProviders) {
-      const rows = await this.listOrgInferenceProviders(organizationId);
-      orgRowsBySlug = new Map(rows.map((r) => [r.slug, r]));
-      orgDefaultSlug = rows.find((r) => r.isDefault)?.slug;
+      orgRows = await this.listOrgInferenceProviders(organizationId);
+      orgRowsBySlug = new Map(orgRows.map((r) => [r.slug, r]));
+      orgDefaultSlug = orgRows.find((r) => r.isDefault)?.slug;
       sdkCompatByKind = new Map();
       for (const entry of buildProviderCatalog()) {
         if (isSdkCompat(entry.sdkCompat)) {
@@ -305,22 +380,60 @@ export class ProviderCatalogService {
       }
     }
 
-    // Resolve providers in install order, then append the org default when it
-    // isn't already covered. The default must reach the worker even for an agent
-    // with NO installed providers — that is the exact case the org-default
-    // fallback exists to serve (behavior → agent → ORG default). Without this a
-    // bare-config agent gets a routable model ref (`slug/model`) but no provider
-    // config/credentials, so the run can't route to a custom upstream.
-    const providerIds = installed.map((ip) => ip.providerId);
-    if (orgDefaultSlug && !providerIds.includes(orgDefaultSlug)) {
-      providerIds.push(orgDefaultSlug);
+    const providerIds: string[] = [];
+    const seenSlug = new Set<string>();
+    const pushSlug = (slug: string) => {
+      if (slug && !seenSlug.has(slug)) {
+        seenSlug.add(slug);
+        providerIds.push(slug);
+      }
+    };
+
+    // The exact allow-list (null = allow-all). Non-empty models list ⇒
+    // allowedRefs is EXACTLY the listed refs — NO org-default safety tail.
+    // An unroutable listed model FAILS CLOSED at dispatch; it never silently
+    // escalates to an unlisted org-default model (that would widen the
+    // restriction). A list of only `<slug>/__unresolved__` sentinels resolves
+    // to zero routable modules → the run hard-fails closed (the intended
+    // "restricted but nothing resolvable yet" state). The org default is only
+    // consulted for the allow-ALL (empty/absent) case below.
+    let allowedRefs: string[] | null = null;
+    if (models.length > 0) {
+      const refs: string[] = [];
+      const seenRef = new Set<string>();
+      const pushRef = (ref: string) => {
+        if (ref && !seenRef.has(ref)) {
+          seenRef.add(ref);
+          refs.push(ref);
+        }
+      };
+      for (const ref of models) {
+        pushRef(ref);
+        // A `<slug>/__unresolved__` sentinel keeps its place in the exact
+        // allow-list (so a mixed list still knows it's a listed entry), but its
+        // slug must NOT contribute a provider module — the sentinel is inert and
+        // must never route. Skipping the slug here is what makes a sentinel-only
+        // list resolve to ZERO modules → hard fail closed.
+        if (isUnresolvedModelRef(ref)) continue;
+        const slash = ref.indexOf("/");
+        if (slash > 0) pushSlug(ref.slice(0, slash));
+      }
+      allowedRefs = refs;
+    } else {
+      // Empty/absent ⇒ ALL org providers: default row first, remaining org
+      // rows, then every deployment/system-key registry module.
+      if (orgDefaultSlug) pushSlug(orgDefaultSlug);
+      for (const row of orgRows) pushSlug(row.slug);
+      for (const module of allModules) {
+        if (module.hasSystemKey()) pushSlug(module.providerId);
+      }
     }
 
-    const resolved: ModelProviderModule[] = [];
+    const modules: ModelProviderModule[] = [];
     for (const providerId of providerIds) {
       const staticModule = moduleMap.get(providerId);
       if (staticModule) {
-        resolved.push(staticModule);
+        modules.push(staticModule);
         continue;
       }
       const row = orgRowsBySlug?.get(providerId);
@@ -330,17 +443,77 @@ export class ProviderCatalogService {
         // protocol, and custom endpoints, are OpenAI-compatible).
         const sdkCompat = sdkCompatByKind?.get(row.kind) ?? "openai";
         const synthesized = this.synthesizeOrgProviderModule(row, sdkCompat);
-        if (synthesized) resolved.push(synthesized);
+        if (synthesized) modules.push(synthesized);
       }
     }
-    return resolved;
+    return { modules, allowedRefs };
   }
 
   /**
-   * Get raw installed provider entries for an agent.
+   * Resolve an agent's routable provider modules (the module list only). Thin
+   * wrapper over getModelPolicy for callers that don't need the allow-list.
    */
-  async getInstalledProviders(agentId: string): Promise<InstalledProvider[]> {
-    return resolveInstalledProviders(this.agentSettingsStore, agentId);
+  async getInstalledModules(
+    agentId: string,
+    organizationId?: string
+  ): Promise<ModelProviderModule[]> {
+    return (await this.getModelPolicy(agentId, organizationId)).modules;
+  }
+
+  /**
+   * The SINGLE, shared dispatch-model resolver used by BOTH the enqueue gate
+   * (message-consumer) and session-context (gateway), so they always agree on
+   * the effective model for a turn.
+   *
+   * Given a requested model, apply the exact allow-list; when the request is
+   * disallowed or a sentinel, replace it with the first LISTED ref that is both
+   * non-sentinel AND ROUTABLE (its provider module is present and keyed) — not
+   * merely the first non-sentinel. Returns `{ model, modules, allowedRefs }`;
+   * `model` is undefined when nothing routable qualifies (fail closed).
+   */
+  async resolveDispatchModel(
+    agentId: string,
+    organizationId: string | undefined,
+    requestedModel: string | undefined,
+    userId?: string
+  ): Promise<{
+    model: string | undefined;
+    replaced: boolean;
+    modules: ModelProviderModule[];
+    allowedRefs: string[] | null;
+  }> {
+    const { modules, allowedRefs } = await this.getModelPolicy(
+      agentId,
+      organizationId
+    );
+    // A ref is routable when its (non-sentinel) provider module is present in
+    // the policy's modules AND has a system key or stored credentials.
+    const routableCache = new Map<string, boolean>();
+    const isRoutable = (ref: string): boolean => {
+      // Synchronous predicate for enforceModelAllowList: we precompute below.
+      return routableCache.get(ref) ?? false;
+    };
+    // Precompute routability for each listed real ref (credential checks are
+    // async, so we resolve them up front and feed the synchronous predicate).
+    if (allowedRefs) {
+      for (const ref of allowedRefs) {
+        if (isUnresolvedModelRef(ref)) {
+          routableCache.set(ref, false);
+          continue;
+        }
+        const provider = await this.findProviderForModel(ref, modules);
+        if (!provider) {
+          routableCache.set(ref, false);
+          continue;
+        }
+        const routable =
+          provider.hasSystemKey() ||
+          (await provider.hasCredentials(agentId, { organizationId, userId }));
+        routableCache.set(ref, routable);
+      }
+    }
+    const gate = enforceModelAllowList(requestedModel, allowedRefs, isRoutable);
+    return { ...gate, modules, allowedRefs };
   }
 
   /**
@@ -350,6 +523,10 @@ export class ProviderCatalogService {
     model: string,
     providers?: ModelProviderModule[]
   ): Promise<ModelProviderModule | undefined> {
+    // A restriction sentinel is never a real model — it must NOT resolve to a
+    // credentialed provider by slug-prefix (that would route the sentinel as if
+    // real, widening the restriction). Return undefined so the run fails closed.
+    if (isUnresolvedModelRef(model)) return undefined;
     const candidates = providers || getModelProviderModules();
     for (const provider of candidates) {
       if (!provider.getModelOptions) continue;

--- a/packages/server/src/gateway/auth/settings/agent-settings-store.ts
+++ b/packages/server/src/gateway/auth/settings/agent-settings-store.ts
@@ -70,20 +70,68 @@ export class AgentSettingsStore {
     this.declaredAgents = registry;
   }
 
+  /**
+   * True when `agentId` is a declared (SDK-embedded) agent whose settings are
+   * org-agnostic (no persisted Postgres row). Lets a policy-enforcement read
+   * distinguish "declared agent, org not required" from a DB-backed agent that
+   * MUST be org-scoped — an orgless DB read of a shared id is a cross-tenant
+   * leak.
+   */
+  isDeclaredAgent(agentId: string): boolean {
+    return this.declaredAgents?.has(agentId) ?? false;
+  }
+
   async getSettings(
     agentId: string,
     context?: { organizationId?: string }
   ): Promise<AgentSettings | null> {
     const declared = this.declaredAgents?.get(agentId);
+
+    // DECLARED/DB DISJOINTNESS (cross-tenant): declared (SDK-embedded) settings
+    // are org-agnostic. A declared id must NOT shadow a REAL tenant DB row that
+    // shares the id — otherwise an org-scoped read of a tenant's agent would be
+    // mis-served the declared identity/skills/model. So when an org IS supplied,
+    // the org-scoped DB row wins: read it first, and only fall back to the
+    // declared overlay when the tenant has NO row for that id. When NO org is
+    // supplied, the read is org-agnostic and the declared overlay applies (that
+    // is the legitimate orgless declared-agent case).
+    if (context?.organizationId) {
+      const dbRow = await orgContext.run(
+        { organizationId: context.organizationId },
+        () => this.configStore.getSettings(agentId)
+      );
+      if (dbRow) return dbRow;
+      return declared ? (declared.settings as AgentSettings) : null;
+    }
+
     if (declared) {
       return declared.settings as AgentSettings;
     }
-    if (context?.organizationId) {
-      return orgContext.run({ organizationId: context.organizationId }, () =>
-        this.configStore.getSettings(agentId)
-      );
-    }
     return this.configStore.getSettings(agentId);
+  }
+
+  /**
+   * True when `agentId` resolves to declared (SDK-embedded) settings FOR THIS
+   * READ — i.e. it is in the declared registry AND (when an org is given) the
+   * tenant has NO persisted DB row that would take precedence. Used by the
+   * cross-tenant guard to decide whether an orgless read is safe (declared =
+   * org-agnostic) or must be denied (a DB-backed agent with no org). A colliding
+   * id that has a real DB row in the given org is NOT treated as declared, so it
+   * never flips the orgless guard open.
+   */
+  async isDeclaredAgentScoped(
+    agentId: string,
+    organizationId?: string
+  ): Promise<boolean> {
+    if (!this.declaredAgents?.has(agentId)) return false;
+    // No org → org-agnostic declared read; the registry membership is decisive.
+    if (!organizationId) return true;
+    // Org given → a real tenant DB row takes precedence over the declared
+    // overlay, so this id is NOT "declared" for that org (it's DB-backed).
+    const dbRow = await orgContext.run({ organizationId }, () =>
+      this.configStore.getSettings(agentId)
+    );
+    return !dbRow;
   }
 
   async saveSettings(

--- a/packages/server/src/gateway/auth/settings/model-selection.ts
+++ b/packages/server/src/gateway/auth/settings/model-selection.ts
@@ -1,4 +1,77 @@
 import type { AgentSettings } from "@lobu/core";
+import { isUnresolvedModelRef } from "../model-sentinel.js";
+
+/**
+ * Enforce the EXACT-model allow-list against a requested model ref. This is the
+ * pure core of the universal dispatch gate applied in the deployment manager —
+ * the single point every dispatch lane (direct API, Listen bridge,
+ * chat-instance, watcher HTTP, scheduled-job direct enqueue) converges on
+ * before a worker runs.
+ *
+ * Decision B semantics — NO org-default escalation:
+ *   - `allowedRefs === null` (allow-all) ⇒ the requested model passes unchanged
+ *     (but an `__unresolved__` sentinel is never a real model → dropped).
+ *   - `allowedRefs === []` (deny-all — e.g. a not-found agent) ⇒ nothing
+ *     qualifies, so any requested model is dropped (fail closed).
+ *   - requested ref is EXACTLY in the list ⇒ passes unchanged, PROVIDED it is
+ *     routable (when a routability predicate is supplied); an exact-but-
+ *     unroutable ref is replaced with the first routable listed ref (fail
+ *     closed if none), never sent dead to the worker.
+ *   - requested ref is NOT in the list ⇒ replaced with the first LISTED ref that
+ *     is non-sentinel AND routable. If none qualifies (all sentinels /
+ *     none routable), the model is dropped (undefined) so the run FAILS CLOSED —
+ *     it never escalates to an unlisted model.
+ *
+ * Returns the effective model ref, or undefined to run with no model (fail
+ * closed / auto-detect for the allow-all case).
+ */
+export function enforceModelAllowList(
+  requestedModel: string | undefined,
+  allowedRefs: string[] | null,
+  /**
+   * Optional routability predicate. When provided, the REPLACEMENT for a
+   * disallowed/sentinel requested model is the first listed ref that is BOTH
+   * non-sentinel AND routable (`isRoutable(ref) === true`) — not merely the
+   * first non-sentinel. This unifies the enqueue gate and session-context with
+   * the friendly Listen bridge: a list like ["xai/grok-4","openai/gpt-5"] with
+   * xai UNCREDENTIALED and openai credentialed replaces onto openai/gpt-5, not a
+   * dead xai/grok-4. Omitted ⇒ first non-sentinel (structural check only).
+   */
+  isRoutable?: (ref: string) => boolean,
+): { model: string | undefined; replaced: boolean } {
+  if (!requestedModel) return { model: undefined, replaced: false };
+  // The first LISTED ref that is a legal replacement: non-sentinel, and (when a
+  // routability predicate is supplied) routable. Only such a ref may substitute
+  // for a disallowed/sentinel request; otherwise we fail closed.
+  const isReplacement = (r: string): boolean =>
+    !isUnresolvedModelRef(r) && (isRoutable ? isRoutable(r) : true);
+  const firstReplacement = allowedRefs?.find(isReplacement) ?? undefined;
+
+  // A sentinel is never a real, routable model. Drop it, but — for a MIXED
+  // list like ["x/__unresolved__","openai/gpt-4o"] — replace it with the first
+  // listed real+routable model rather than failing closed. Only when NO such
+  // ref exists (all-sentinel, or none routable) do we fail closed (undefined).
+  if (isUnresolvedModelRef(requestedModel)) {
+    return { model: firstReplacement, replaced: true };
+  }
+  if (allowedRefs === null) return { model: requestedModel, replaced: false };
+  if (allowedRefs.includes(requestedModel)) {
+    // Exact-listed — but it may still be UNROUTABLE (uncredentialed provider).
+    // An exact-listed request passes unchanged ONLY when there's no routability
+    // predicate OR it is routable; otherwise fall through to the first routable
+    // listed replacement (fail closed if none). Without this, an exact-but-dead
+    // ref (e.g. requested "xai/grok-4" with xai uncredentialed) would reach the
+    // worker and fail at run.
+    if (!isRoutable || isRoutable(requestedModel)) {
+      return { model: requestedModel, replaced: false };
+    }
+    return { model: firstReplacement, replaced: true };
+  }
+  // Out-of-list: replace with the first listed real+routable model; if none
+  // qualifies (all sentinels / none routable), firstReplacement is undefined →
+  // fail closed.
+  return { model: firstReplacement, replaced: true };
+}
 
 /**
  * Reads the org's default model — the fallback tail. Injected (not imported) so
@@ -11,31 +84,31 @@ export type OrgDefaultModelReader = (
 
 /**
  * The agent-layer model ref — the middle of the layered fallback
- * `behavior → agent → org default`. Pure and synchronous: it returns the agent's
- * own `defaultModel` (a `provider/model` ref or the literal "auto"), or undefined
- * when the agent pins no model. The caller composes the tail:
+ * `behavior → agent → org default`. Pure and synchronous: it returns the head
+ * of the agent's `models` list (an explicit `provider/model` ref), or undefined
+ * when the list is empty/absent. The caller composes the tail:
  * `resolveEffectiveModelRef(settings) ?? await getOrgDefaultModel(orgId)`.
  *
  * The per-behavior override sits ABOVE this and is injected at run-enqueue into
  * `agentOptions.model` (so it wins before this is consulted).
  */
 export function resolveEffectiveModelRef(
-  settings: Pick<AgentSettings, "defaultModel"> | null | undefined,
+  settings: Pick<AgentSettings, "models"> | null | undefined,
 ): string | undefined {
-  const model = settings?.defaultModel?.trim();
+  const model = settings?.models?.[0]?.trim();
   return model ? model : undefined;
 }
 
 /**
  * Compose the full layered fallback for a run: the caller has already applied any
  * per-behavior override (it wins upstream, injected into the run's `model`
- * option), so this resolves `agent.defaultModel → org default`. Returns undefined
+ * option), so this resolves `agent.models[0] → org default`. Returns undefined
  * only when the agent pins nothing AND the org has no default — the worker then
  * surfaces its actionable "no model" error. `organizationId` may be undefined
  * (org-agnostic contexts), in which case only the agent layer is consulted.
  */
 export async function composeEffectiveModelRef(
-  settings: Pick<AgentSettings, "defaultModel"> | null | undefined,
+  settings: Pick<AgentSettings, "models"> | null | undefined,
   organizationId: string | undefined,
   getOrgDefaultModel: OrgDefaultModelReader,
 ): Promise<string | undefined> {

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -760,14 +760,18 @@ export function createGatewayApp(
               agentConfigStore.getSettings(a.agentId),
             )
           : null;
-      const providers = (settings?.installedProviders || []).map(
-				(p: { providerId: string }) => p.providerId,
-      );
+      const providers: string[] = [];
+      for (const ref of settings?.models || []) {
+        const slash = ref.indexOf("/");
+        if (slash > 0 && !providers.includes(ref.slice(0, slash))) {
+          providers.push(ref.slice(0, slash));
+        }
+      }
       agentDetails.push({
         agentId: a.agentId,
         name: a.name,
         providers,
-        model: settings?.defaultModel || "auto",
+        model: settings?.models?.[0] ?? null,
       });
     }
 

--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -68,7 +68,7 @@ export function registerBuiltInCommands(
       });
 
       const effectiveModel = resolveEffectiveModelRef(settings);
-      const model = effectiveModel || "auto (org default)";
+      const model = effectiveModel || "(org default)";
       const skillsCount = settings?.skillsConfig?.skills
         ? Object.keys(settings.skillsConfig.skills).length
         : 0;

--- a/packages/server/src/gateway/connections/__tests__/slack-instruction-provider.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-instruction-provider.test.ts
@@ -1,0 +1,70 @@
+/**
+ * R7 BLOCK #1 layer (b): SlackInstructionProvider must NOT leak another tenant's
+ * Slack identity. Its `listConnections` read is agent-scoped and — without an
+ * ambient org — would return ANOTHER org's newest Slack connection for a shared
+ * agent id (foreign botUsername/botUserId). So:
+ *   - orgless context ⇒ "" (no identity without an org);
+ *   - org-present ⇒ the read runs INSIDE the token org (orgContext.run).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { InstructionContext } from "@lobu/core";
+import { orgContext } from "../../../lobu/stores/org-context.js";
+import { SlackInstructionProvider } from "../slack-instruction-provider.js";
+
+function ctx(overrides: Partial<InstructionContext>): InstructionContext {
+  return {
+    userId: "u1",
+    agentId: "lobu-builder",
+    sessionKey: "u1",
+    workingDirectory: "/workspace",
+    availableProjects: [],
+    ...overrides,
+  };
+}
+
+describe("SlackInstructionProvider — cross-tenant guard", () => {
+  test("orgless context: returns '' (no Slack identity leaked) and does NOT read connections", async () => {
+    let listCalled = false;
+    const manager = {
+      listConnections: async () => {
+        listCalled = true;
+        return [
+          { metadata: { botUsername: "foreign-bot", botUserId: "UFOREIGN" } },
+        ];
+      },
+    } as never;
+    const provider = new SlackInstructionProvider(manager);
+
+    const result = await provider.getInstructions(
+      ctx({ organizationId: undefined })
+    );
+
+    expect(result).toBe("");
+    // No connection read happened at all — nothing to leak.
+    expect(listCalled).toBe(false);
+  });
+
+  test("org-present: reads connections INSIDE the token org and returns the identity", async () => {
+    let seenOrg: string | undefined;
+    const manager = {
+      listConnections: async (_filter: unknown) => {
+        // Capture the AMBIENT org the read runs under (must be the token org).
+        seenOrg = orgContext.getStore()?.organizationId;
+        return [
+          { metadata: { botUsername: "acme-bot", botUserId: "UACME" } },
+        ];
+      },
+    } as never;
+    const provider = new SlackInstructionProvider(manager);
+
+    const result = await provider.getInstructions(
+      ctx({ organizationId: "acme-org" })
+    );
+
+    expect(seenOrg).toBe("acme-org");
+    expect(result).toContain("@acme-bot");
+    expect(result).toContain("UACME");
+    expect(result).not.toContain("foreign");
+  });
+});

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -12,6 +12,7 @@ import {
 import type { CommandDispatcher } from "../commands/command-dispatcher.js";
 import { createChatReply } from "../commands/command-reply-adapters.js";
 import type { ArtifactStore } from "../files/artifact-store.js";
+import type { ModelProviderModule } from "../modules/module-system.js";
 import type { CoreServices } from "../platform.js";
 import {
   buildMessagePayload,
@@ -55,7 +56,7 @@ function sanitizeRefLabel(name: string): string {
 
 function parseProviderFromModelRef(modelRef: string): string | null {
   const trimmed = modelRef.trim();
-  if (!trimmed || trimmed === "auto") return null;
+  if (!trimmed) return null;
   const slash = trimmed.indexOf("/");
   if (slash <= 0) return null;
   return trimmed.slice(0, slash);
@@ -127,28 +128,6 @@ async function providerIsRoutable(
   return Object.keys(mappings).length > 0;
 }
 
-/**
- * Pick a concrete, routable model from a connected provider so a run can proceed
- * even though the agent's CONFIGURED model names a provider the org never
- * connected. Returns the provider's default/first model as a `provider/model`
- * ref, or null if the provider exposes no usable model. This is what turns the
- * old hard dead-end ("connect claude first") into graceful degradation onto a
- * provider the org actually has (e.g. openai), which matters most for a new user
- * whose default agent shipped with a model whose provider they never set up.
- */
-async function firstModelForProvider(provider: {
-  providerId: string;
-  getModelOptions?: (a: string, b: string) => Promise<Array<{ value: string }>>;
-}): Promise<string | null> {
-  if (!provider.getModelOptions) return null;
-  const options = await provider.getModelOptions("", "").catch(() => []);
-  const first = options[0]?.value?.trim();
-  if (!first) return null;
-  return first.startsWith(`${provider.providerId}/`)
-    ? first
-    : `${provider.providerId}/${first}`;
-}
-
 type ModelProviderResolution =
   | { kind: "ok" }
   | { kind: "fallback"; model: string; from: string; to: string }
@@ -156,10 +135,17 @@ type ModelProviderResolution =
 
 /**
  * Preflight the model a message will run on. Order of outcomes:
- *  - ok: the configured model's provider is connected + routable → run as-is.
- *  - fallback: it is NOT routable, but the org has another connected provider →
- *    run on that provider's default model instead of failing.
- *  - error: no connected+routable provider exists at all → surface a setup link.
+ *  - ok: the configured EXACT ref is allowed and its provider is routable.
+ *  - fallback: it isn't routable (or, under a non-empty list, not allowed), but
+ *    the agent has a listed ALTERNATE whose exact ref is routable → run that
+ *    alternate. Alternates are tried in the agent's models[] order.
+ *  - error: nothing usable → surface a setup link.
+ *
+ * The gate is EXACT: when the agent has a non-empty `models` list, a ref that
+ * isn't in that list is rejected even if its PROVIDER prefix is listed — so
+ * `models:["openai/gpt-5"]` does not admit `openai/other`. There is NO
+ * org-default tail: an unroutable listed model falls back only to another
+ * LISTED alternate, never to an unlisted model.
  */
 async function validateMessageModelProvider(params: {
   services: CoreServices;
@@ -177,11 +163,10 @@ async function validateMessageModelProvider(params: {
   if (!catalog || !params.organizationId) return { kind: "ok" };
   const organizationId = params.organizationId;
 
-  const providers = await catalog.getInstalledModules(
+  const { modules, allowedRefs } = await catalog.getModelPolicy(
     params.agentId,
     organizationId
   );
-  const provider = await catalog.findProviderForModel(modelRef, providers);
 
   const routableCtx = {
     services: params.services,
@@ -190,24 +175,40 @@ async function validateMessageModelProvider(params: {
     userId: params.userId,
   };
 
-  // Happy path: the configured model's provider is present, keyed, and routable.
-  if (provider && (await providerIsRoutable(provider, routableCtx))) {
-    return { kind: "ok" };
+  // A concrete ref is usable when (a) it clears the exact allow-list — always,
+  // when the agent allows all providers — and (b) its provider module is
+  // present and routable (keyed + a proxy route builds).
+  const refIsAllowed = (ref: string): boolean =>
+    allowedRefs === null || allowedRefs.includes(ref);
+  const providerForRef = async (
+    ref: string
+  ): Promise<ModelProviderModule | undefined> =>
+    catalog.findProviderForModel(ref, modules);
+
+  // Happy path: the exact ref is allowed AND its provider is routable.
+  if (refIsAllowed(modelRef)) {
+    const provider = await providerForRef(modelRef);
+    if (provider && (await providerIsRoutable(provider, routableCtx))) {
+      return { kind: "ok" };
+    }
   }
 
-  // The configured model can't run. Before dead-ending, look for ANY other
-  // connected provider on this agent that IS routable, and fall back to its
-  // default model. Skip the failed provider itself.
-  for (const candidate of providers) {
-    if (provider && candidate.providerId === provider.providerId) continue;
-    if (!(await providerIsRoutable(candidate, routableCtx))) continue;
-    const fallbackModel = await firstModelForProvider(candidate);
-    if (fallbackModel) {
+  // The configured ref can't run. Fall back to the agent's listed ALTERNATES,
+  // in order — the exact refs the agent declared (not a provider's catalog
+  // default), so multiple same-provider entries act as ordered fallbacks. When
+  // the agent allows all providers there is no alternate list to walk; the
+  // original ref was the only ask, so we go straight to the setup link.
+  if (allowedRefs !== null) {
+    for (const altRef of allowedRefs) {
+      if (altRef === modelRef) continue;
+      const altProvider = await providerForRef(altRef);
+      if (!altProvider) continue;
+      if (!(await providerIsRoutable(altProvider, routableCtx))) continue;
       return {
         kind: "fallback",
-        model: fallbackModel,
+        model: altRef,
         from: modelRef,
-        to: candidate.providerId,
+        to: altProvider.providerId,
       };
     }
   }
@@ -221,14 +222,14 @@ async function validateMessageModelProvider(params: {
     modelRef,
     reason: "model_provider_not_connected",
   });
-  const reason = !provider
-    ? `but it isn't connected for this agent`
-    : `but Lobu has no credentials for it`;
+  const reason = !refIsAllowed(modelRef)
+    ? `but that model isn't in this agent's allowed model list`
+    : `but its provider isn't connected or has no credentials`;
   return {
     kind: "error",
     message:
-      `I can't run this yet: the selected model (${modelRef}) needs provider "${providerId}", ` +
-      `${reason}. Open this setup link to connect or add credentials: ${setupUrl}`,
+      `I can't run this yet: the selected model (${modelRef}) ${reason}. ` +
+      `Open this setup link to connect a provider or pick an allowed model: ${setupUrl}`,
   };
 }
 

--- a/packages/server/src/gateway/connections/slack-instruction-provider.ts
+++ b/packages/server/src/gateway/connections/slack-instruction-provider.ts
@@ -1,4 +1,5 @@
 import type { InstructionContext } from "@lobu/core";
+import { orgContext } from "../../lobu/stores/org-context.js";
 import { BaseInstructionProvider } from "../services/instruction-service.js";
 import type { ChatInstanceManager } from "./chat-instance-manager.js";
 
@@ -13,10 +14,21 @@ export class SlackInstructionProvider extends BaseInstructionProvider {
   protected async buildInstructions(
     context: InstructionContext
   ): Promise<string> {
-    const connections = await this.manager.listConnections({
-      platform: "slack",
-      agentId: context.agentId,
-    });
+    // Defense in depth: no Slack identity without an org. `listConnections` is
+    // agent-scoped and — without an ambient org — would return ANOTHER tenant's
+    // newest Slack connection for a shared agent id (leaking foreign
+    // botUsername/botUserId). Require the org and run the read INSIDE it so it's
+    // actually tenant-scoped. (The InstructionService also gates this provider
+    // out when `orgScoped === false`; this is the belt to that suspenders.)
+    if (!context.organizationId) return "";
+    const connections = await orgContext.run(
+      { organizationId: context.organizationId },
+      () =>
+        this.manager.listConnections({
+          platform: "slack",
+          agentId: context.agentId,
+        })
+    );
     const connection = connections[0];
     if (!connection) return "";
 

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -20,7 +20,10 @@ import { getRevokedTokenStore } from "../auth/revoked-token-store.js";
 import type { McpConfigService } from "../auth/mcp/config-service.js";
 import type { McpProxy } from "../auth/mcp/proxy.js";
 import type { McpTool } from "../auth/mcp/tool-cache.js";
-import type { ProviderCatalogService } from "../auth/provider-catalog.js";
+import {
+	isUnresolvedModelRef,
+	type ProviderCatalogService,
+} from "../auth/provider-catalog.js";
 import { composeEffectiveModelRef } from "../auth/settings/model-selection.js";
 import { getOrgDefaultModel } from "../../lobu/stores/provider-secrets.js";
 import type { IMessageQueue } from "../infrastructure/queue/index.js";
@@ -514,11 +517,36 @@ export class WorkerGateway {
         return c.json({ error: "Invalid token (missing conversationId)" }, 401);
       }
 
+      // CROSS-TENANT GUARD (hoisted): compute org-scope safety ONCE, before any
+      // agent-scoped read (instructions, MCP, skills, model). A DB-backed agent's
+      // settings read MUST be org-scoped — the worker token can be orgless, and a
+      // shared id (e.g. "lobu-builder", present in every org) would id-only read
+      // ANOTHER org's identity/soul/skills/MCP-slug and ship it to the worker.
+      // Declared (SDK-embedded) agents are org-agnostic, so they resolve without
+      // an org. When `!orgScopedOk` for a DB-backed agent we deny ALL agent-scoped
+      // reads (fail closed to generic/no-agent behavior).
+      const tokenOrgId = auth.tokenData.organizationId;
+      // ORG-AWARE declared check: a declared id that ALSO has a real DB row in
+      // the token's org is DB-backed (the DB row wins), so a collision cannot
+      // flip the orgless guard open for a tenant's agent. Falls back to the
+      // synchronous membership check for a store without the org-aware method.
+      const store = this.agentSettingsStore;
+      const isDeclared =
+        !!agentId && store
+          ? store.isDeclaredAgentScoped
+            ? await store.isDeclaredAgentScoped(agentId, tokenOrgId)
+            : (store.isDeclaredAgent?.(agentId) ?? false)
+          : false;
+      const orgScopedOk = !!tokenOrgId || isDeclared;
+
       // Build instruction context
       const instructionContext: InstructionContext = {
         userId,
         agentId: agentId || "",
-        organizationId: auth.tokenData.organizationId,
+        organizationId: tokenOrgId,
+        // Instruction providers skip their by-id settings read when this is
+        // false (orgless DB-backed agent) and use the generic branch.
+        orgScoped: orgScopedOk,
         sessionKey: sessionKey || "",
         workingDirectory: "/workspace",
         availableProjects: [],
@@ -593,44 +621,60 @@ export class WorkerGateway {
         }
       }
 
-      // Resolve dynamic provider configuration
+      // Resolve dynamic provider configuration. The org-scope guard
+      // (tokenOrgId / orgScopedOk) was hoisted above — a DB-backed agent with no
+      // org reads nothing here (fail closed). `agentSettings` is null in that
+      // case, which is ALSO the correct fail-closed value the skills-sync below
+      // reuses (no duplicate id-only read).
       const agentSettings =
-        this.agentSettingsStore && agentId
+        this.agentSettingsStore && agentId && orgScopedOk
           ? await this.agentSettingsStore.getSettings(agentId, {
-              organizationId: auth.tokenData.organizationId,
+              organizationId: tokenOrgId,
             })
           : null;
+      // The layered fallback default (agent models[0] or org default). For a
+      // non-empty models list this is models[0] — which may be a SENTINEL.
+      const layeredDefault = orgScopedOk
+        ? await composeEffectiveModelRef(agentSettings, tokenOrgId, getOrgDefaultModel)
+        : undefined;
+      // Resolve the EFFECTIVE dispatch model through the SAME shared resolver the
+      // enqueue gate uses: when models[0] is a sentinel but a later listed ref is
+      // real+routable, this picks that ref (e.g. ["chatgpt/__unresolved__",
+      // "openai/gpt-5"] → "openai/gpt-5" with the OpenAI module published). Only
+      // an all-sentinel / nothing-routable list — or an orgless DB-backed agent
+      // (resolveDispatchModel then reads not-found → deny) — yields undefined
+      // (fail closed).
+      const effectiveModel =
+        agentId && this.providerCatalogService && orgScopedOk
+          ? (
+              await this.providerCatalogService.resolveDispatchModel(
+                agentId,
+                tokenOrgId,
+                layeredDefault,
+                userId
+              )
+            ).model
+          : undefined;
       const providerConfig = await this.resolveProviderConfig(
         agentId || "",
-        await composeEffectiveModelRef(
-          agentSettings,
-          auth.tokenData.organizationId,
-          getOrgDefaultModel
-        ),
+        effectiveModel,
         baseUrl,
         auth.token,
-        auth.tokenData.organizationId,
+        tokenOrgId,
         userId
       );
 
-      // Fetch enabled skills with content for worker filesystem sync
+      // Enabled skills for worker filesystem sync. REUSE the org-scoped
+      // `agentSettings` fetched above — it is null for an orgless DB-backed agent
+      // (the correct fail-closed value: NO skill content leaks cross-tenant), and
+      // this removes the duplicate id-only read that ignored the org guard.
       let skillsConfig: Array<{ name: string; content: string }> = [];
       const mcpContext: Record<string, string> = {};
-      if (this.agentSettingsStore && agentId) {
-        try {
-          const settings =
-            await this.agentSettingsStore.getSettings(agentId, {
-              organizationId: auth.tokenData.organizationId,
-            });
-          const skills = settings?.skillsConfig?.skills || [];
-          skillsConfig = skills
-            .filter((s) => s.enabled && s.content)
-            .map((s) => ({ name: s.name, content: s.content! }));
-        } catch (error) {
-          logger.error("Failed to fetch skills config for worker sync", {
-            error,
-          });
-        }
+      if (agentSettings) {
+        const skills = agentSettings.skillsConfig?.skills || [];
+        skillsConfig = skills
+          .filter((s) => s.enabled && s.content)
+          .map((s) => ({ name: s.name, content: s.content! }));
       }
 
       const mergedSkillsInstructions = contextData.skillsInstructions || "";
@@ -844,6 +888,20 @@ export class WorkerGateway {
         organizationId
       );
     if (effectiveProviders.length === 0) {
+      return {};
+    }
+
+    // FAIL CLOSED on a restriction sentinel: a `<slug>/__unresolved__` model is
+    // NOT a real model — it must never route. If the resolved default is a
+    // sentinel, publish NO provider config (no defaultProvider, no defaultModel),
+    // so the worker surfaces "no routable model" instead of stripping the
+    // "__unresolved__" prefix and sending it to a credentialed upstream, or
+    // silently falling back to the first credentialed module.
+    if (agentModel && isUnresolvedModelRef(agentModel)) {
+      logger.warn(
+        { agentId, organizationId, agentModel },
+        "Agent's default model is an unresolved restriction sentinel — publishing no routable model (fail closed)"
+      );
       return {};
     }
 

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -862,6 +862,18 @@ export class DeploymentManager {
   }
 
   /**
+   * The provider-catalog service, when wired. Exposed so the message consumer
+   * can enforce the exact-model allow-list at ENQUEUE time (before the payload
+   * is persisted to the queue) — the deployment-time enforcement is too late
+   * for warm/resumed workers that never re-run createWorkerDeployment.
+   */
+  getProviderCatalogService():
+    | import("../auth/provider-catalog.js").ProviderCatalogService
+    | undefined {
+    return this.providerCatalogService;
+  }
+
+  /**
    * Inject grant store for auto-adding domain grants at deployment time.
    */
   setGrantStore(store: GrantStore): void {
@@ -1582,13 +1594,44 @@ export class DeploymentManager {
       }
     }
 
-    // Resolve per-agent installed providers (catalog-only when active, no global fallback)
-    const effectiveProviders = this.providerCatalogService
-      ? await this.providerCatalogService.getInstalledModules(
-          agentId,
-          validated.organizationId
-        )
-      : this.providerModules;
+    // EXACT-MODEL GATE + module resolution (defense-in-depth backstop for the
+    // COLD path — the authoritative gate is at enqueue time in the message
+    // consumer, which the warm path also passes). Use the SHARED
+    // `resolveDispatchModel` so this backstop agrees with the enqueue gate and
+    // session-context on the effective (allow-listed, non-sentinel, ROUTABLE)
+    // model. A sentinel-only / nothing-routable list yields undefined → fail
+    // closed. Modules come from the same policy resolution.
+    const requestedModel = validated.agentOptions?.model as string | undefined;
+    let effectiveProviders: ModelProviderModule[];
+    let allowedRefs: string[] | null = null;
+    let agentModel: string | undefined = requestedModel;
+    if (this.providerCatalogService) {
+      const resolved = await this.providerCatalogService.resolveDispatchModel(
+        agentId,
+        validated.organizationId,
+        requestedModel,
+        userId
+      );
+      effectiveProviders = resolved.modules;
+      allowedRefs = resolved.allowedRefs;
+      agentModel = resolved.model;
+      if (resolved.replaced && validated.agentOptions) {
+        logger.warn(
+          {
+            agentId,
+            organizationId: validated.organizationId,
+            requestedModel,
+            allowedRefs,
+            effectiveModel: agentModel ?? null,
+          },
+          "Deployment backstop: requested model not routable under the agent's models list — enforcing fail-closed gate"
+        );
+        if (agentModel) validated.agentOptions.model = agentModel;
+        else delete validated.agentOptions.model;
+      }
+    } else {
+      effectiveProviders = this.providerModules;
+    }
 
     for (const provider of effectiveProviders) {
       envVars = provider.injectSystemKeyFallback(envVars);
@@ -1603,8 +1646,7 @@ export class DeploymentManager {
 
     // Inject provider metadata into agentOptions so the worker can configure
     // the SDK generically without hardcoded provider checks.
-    // Determine primary provider from the model in agentOptions.
-    const agentModel = validated.agentOptions?.model as string | undefined;
+    // Determine primary provider from the (now gate-checked) model.
     let primaryProvider: ModelProviderModule | undefined;
 
     if (

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -534,6 +534,14 @@ export class MessageConsumer {
         organizationId: data.organizationId,
       });
 
+      // EXACT-MODEL GATE (enqueue chokepoint — covers cold AND warm/resumed):
+      // BOTH the cold and warm paths funnel through here before
+      // `sendToWorkerQueue` serializes `data.agentOptions.model` into the queue
+      // job that the worker reads verbatim. Deployment-time enforcement is too
+      // late — warm workers never re-run createWorkerDeployment. So enforce the
+      // agent's exact allow-list on the payload model NOW, before it's persisted.
+      await this.enforceModelPolicyAtEnqueue(data);
+
       // 1) Send to thread queue immediately (queue persists; worker will drain on attach)
       await Sentry.startSpan(
         {
@@ -641,6 +649,103 @@ export class MessageConsumer {
   /**
    * Send message to worker queue for the worker to consume
    */
+  /**
+   * Enforce the agent's exact-model allow-list on the OUTBOUND payload model,
+   * at enqueue time. This is the authoritative gate: every dispatch lane
+   * (direct API, Listen bridge, chat-instance, watcher HTTP, scheduled-job
+   * direct enqueue) — cold, warm, or resumed — funnels through `handleMessage`
+   * → here → `sendToWorkerQueue`, which serializes `data.agentOptions.model`
+   * into the queue job the worker reads verbatim. Mutating the model here
+   * guarantees a disallowed/stale/sentinel model can never reach the worker,
+   * regardless of whether a deployment is (re)created.
+   *
+   * Uses the SHARED `resolveDispatchModel` resolver (same one session-context
+   * uses) so both layers agree on the effective model — a disallowed/sentinel
+   * request is replaced with the first listed ref that is non-sentinel AND
+   * routable, not merely non-sentinel.
+   *
+   * FAILS CLOSED on a policy-lookup error: a DB/catalog blip must NEVER let a
+   * disallowed or sentinel model reach the worker. Since the warm path never
+   * re-runs createWorkerDeployment, we cannot rely on the deployment-time gate
+   * as a fallback — so when the lookup throws AND a model was requested, we DROP
+   * the model (worker resolves the agent/org default or surfaces
+   * NO_MODEL_CONFIGURED), never leaving the unvalidated requested model in place.
+   */
+  private async enforceModelPolicyAtEnqueue(
+    data: MessagePayload
+  ): Promise<void> {
+    const requested = data.agentOptions?.model;
+    if (!requested) return;
+    // FAIL CLOSED when we cannot scope/run a policy check for a REQUESTED model:
+    //  - no agentId → can't identify the agent's policy;
+    //  - no catalog → the ProviderCatalogService isn't wired yet (startup, or a
+    //    persisted job drained before wiring). The warm worker would otherwise
+    //    read the unvalidated model verbatim.
+    // In every such case we DROP the model rather than silently pass it.
+    if (!data.agentId) {
+      logger.warn(
+        { requestedModel: requested },
+        "Enqueue-time model gate: missing agentId — dropping the requested model (fail-closed)"
+      );
+      if (data.agentOptions) delete data.agentOptions.model;
+      return;
+    }
+    const catalog = this.deploymentManager.getProviderCatalogService?.();
+    if (!catalog) {
+      logger.warn(
+        { agentId: data.agentId, requestedModel: requested },
+        "Enqueue-time model gate: ProviderCatalogService not wired — dropping the requested model (fail-closed)"
+      );
+      if (data.agentOptions) delete data.agentOptions.model;
+      return;
+    }
+    // CROSS-TENANT GUARD: a policy-enforcement read MUST be org-scoped. A
+    // declared agent id (e.g. `lobu-builder`) exists in EVERY org, so an
+    // id-only lookup could enforce another tenant's models list. If the org is
+    // somehow missing here, fail closed (drop the model) rather than risk
+    // gating against the wrong org's policy.
+    if (!data.organizationId) {
+      logger.warn(
+        { agentId: data.agentId, requestedModel: requested },
+        "Enqueue-time model gate: missing organizationId — dropping the requested model (fail-closed, cross-tenant guard)"
+      );
+      if (data.agentOptions) delete data.agentOptions.model;
+      return;
+    }
+    try {
+      const resolved = await catalog.resolveDispatchModel(
+        data.agentId,
+        data.organizationId,
+        requested,
+        data.userId
+      );
+      if (!resolved.replaced) return;
+      logger.warn(
+        {
+          agentId: data.agentId,
+          organizationId: data.organizationId,
+          requestedModel: requested,
+          allowedRefs: resolved.allowedRefs,
+          effectiveModel: resolved.model ?? null,
+        },
+        "Enqueue-time model gate: requested model is not routable under the agent's allowed models list — enforcing (fail-closed)"
+      );
+      if (data.agentOptions) {
+        if (resolved.model) data.agentOptions.model = resolved.model;
+        else delete data.agentOptions.model;
+      }
+    } catch (err) {
+      // FAIL CLOSED: never leave an unvalidated requested model on the payload.
+      // The warm path won't re-gate at deployment time, so a lookup failure must
+      // drop the model rather than let a possibly-disallowed/sentinel model run.
+      logger.warn(
+        { agentId: data.agentId, err: getErrorMessage(err) },
+        "Enqueue-time model gate: policy lookup FAILED — dropping the requested model (fail-closed)"
+      );
+      if (data.agentOptions) delete data.agentOptions.model;
+    }
+  }
+
   private async sendToWorkerQueue(
     data: MessagePayload,
     deploymentName: string

--- a/packages/server/src/gateway/routes/public/agent-config.ts
+++ b/packages/server/src/gateway/routes/public/agent-config.ts
@@ -18,7 +18,6 @@ import type {
 	AgentSettingsStore,
 } from "../../auth/settings/agent-settings-store.js";
 import type { AuthProfilesManager } from "../../auth/settings/auth-profiles-manager.js";
-import { resolveEffectiveModelRef } from "../../auth/settings/model-selection.js";
 import {
 	canEditSettingsSection,
 	type ResolvedProviderView,
@@ -126,16 +125,35 @@ async function resolveSettingsView(
 	) as Record<SettingsSectionKey, ResolvedSectionView>;
 
 	const providerSources = Object.fromEntries(
-		(settings?.installedProviders || []).map((provider) => [
-			provider.providerId,
+		orderedProviderSlugs(settings?.models).map((providerId) => [
+			providerId,
 			{
-				id: provider.providerId,
+				id: providerId,
 				canEdit: canEditSettingsSection("model", viewer),
 			} satisfies ResolvedProviderView,
 		]),
 	);
 
 	return { sections, providerSources, settings };
+}
+
+/**
+ * Ordered provider slugs derived from a `models` list — the `<slug>/` prefixes
+ * in first-appearance order.
+ */
+function orderedProviderSlugs(models: string[] | undefined): string[] {
+	const slugs: string[] = [];
+	const seen = new Set<string>();
+	for (const ref of models ?? []) {
+		const slash = ref.indexOf("/");
+		if (slash <= 0) continue;
+		const slug = ref.slice(0, slash);
+		if (!seen.has(slug)) {
+			seen.add(slug);
+			slugs.push(slug);
+		}
+	}
+	return slugs;
 }
 
 async function buildResolvedConfigResponse(
@@ -214,9 +232,7 @@ async function buildResolvedConfigResponse(
 		capabilities: [] as string[],
 	}));
 
-	const installedIds = (settings?.installedProviders || []).map(
-		(provider) => provider.providerId,
-	);
+	const installedIds = orderedProviderSlugs(settings?.models);
 	const installedIdSet = new Set(installedIds);
 	const catalogProviders = allProviderMeta.filter(
 		(provider) => !installedIdSet.has(provider.id),
@@ -259,9 +275,11 @@ async function buildResolvedConfigResponse(
 			icons: providerIconUrls,
 			configManaged: [] as string[],
 		},
-		// The agent's model (middle of the layered fallback behavior → agent →
-		// org default). Empty string ⇒ inherit the org default.
-		defaultModel: resolveEffectiveModelRef(settings) || "",
+		// The agent's ordered EXACT model allow-list (`<slug>/<model>` refs).
+		// models[0] is the default (middle of the layered fallback behavior →
+		// agent → org default); the rest are alternates. Empty/absent ⇒ inherit
+		// the org default + allow all org providers.
+		models: settings?.models ?? [],
 		skills: sanitized.skillsConfig?.skills || [],
 		tools: {
 			nixPackages: sanitized.nixConfig?.packages || [],

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -774,8 +774,8 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
     // agent per chat, never used the user's actual default agent, and the
     // saveSettings UPDATE silently no-op'd on a row that didn't exist yet.
     // Default-agent provisioning runs at signup (`ensureDefaultAgent`) and
-    // already populates `installed_providers` from system-key providers,
-    // so the row exists with credentials by the time chat reaches here.
+    // already populates `models` from system-key providers, so the row
+    // exists with credentials by the time chat reaches here.
     //
     // Org resolution: `createLobuAuthBridge` (outer middleware on `/lobu/*`)
     // sets `c.get("organizationId")` from the PAT — that's the common path

--- a/packages/server/src/gateway/services/agent-threads.ts
+++ b/packages/server/src/gateway/services/agent-threads.ts
@@ -96,6 +96,12 @@ export async function createThreadForAgent(
     status: "created",
     provider: "claude",
     agentId,
+    // Persist the owning org onto the session (previously only stamped into the
+    // token). Internal scheduled/repair threads read the session — not the
+    // token — at enqueue, and a missing org there makes the enqueue-time model
+    // gate query the agent id ACROSS orgs (a declared agent like `lobu-builder`
+    // exists in every org), enforcing another tenant's policy. Cross-tenant leak.
+    organizationId,
     dryRun: false,
   };
   await sessionManager.setSession(session);
@@ -161,6 +167,12 @@ export async function enqueueAgentMessage(
     channelId,
     teamId: "api",
     agentId: realAgentId,
+    // Top-level org so the enqueue-time model gate resolves the RIGHT tenant's
+    // policy. Without it, getModelPolicy(agentId, undefined) falls back to an
+    // id-only cross-org read and can enforce another org's models list.
+    ...(session.organizationId
+      ? { organizationId: session.organizationId }
+      : {}),
     botId: "lobu-api",
     platform: "api",
     messageText,

--- a/packages/server/src/gateway/services/core-services.ts
+++ b/packages/server/src/gateway/services/core-services.ts
@@ -784,13 +784,19 @@ export class CoreServices {
 		// connector-backed operations; the worker only receives lobu-memory.
 		this.mcpConfigService = new McpConfigService({
 			lobuMemory: {
-				resolveOrgSlug: async (agentId: string) => {
+				// CROSS-TENANT SAFE: resolve the lobu-memory org slug from the token's
+				// organizationId, NOT an id-only agent lookup. A shared agent id
+				// (`lobu-builder`) exists in every org, so `WHERE a.id = agentId` alone
+				// would pick an ARBITRARY org's slug and build the wrong tenant's
+				// `/mcp/<orgSlug>` endpoint. When the token carries no org (orgless
+				// db-backed agent) we return null → no lobu-memory MCP (fail closed).
+				resolveOrgSlug: async (
+					_agentId: string,
+					organizationId: string | undefined,
+				) => {
+					if (!organizationId) return null;
 					const rows = await getDb()`
-            SELECT o.slug
-            FROM agents a
-            JOIN organization o ON o.id = a.organization_id
-            WHERE a.id = ${agentId}
-            LIMIT 1
+            SELECT slug FROM organization WHERE id = ${organizationId} LIMIT 1
           `;
 					const slug = rows[0]?.slug;
 					return typeof slug === "string" && slug.trim() ? slug.trim() : null;

--- a/packages/server/src/gateway/services/declared-agent-registry.ts
+++ b/packages/server/src/gateway/services/declared-agent-registry.ts
@@ -1,5 +1,9 @@
 import type { AgentSettings, DeclaredCredential } from "@lobu/core";
 import { createLogger } from "@lobu/core";
+import {
+  buildProviderCatalog,
+  UNRESOLVED_MODEL_SUFFIX,
+} from "../auth/provider-catalog.js";
 import type { AgentConfig } from "../config/index.js";
 
 const logger = createLogger("declared-agent-registry");
@@ -59,17 +63,36 @@ export function entryFromAgentConfig(agent: AgentConfig): DeclaredAgentEntry {
   if (agent.userMd) settings.userMd = agent.userMd;
 
   if (agent.providers?.length) {
-    // installedProviders stays the credential/catalog list (routes org
-    // providers). The agent's model collapses to a single defaultModel: the
-    // primary provider's declared model, or "<providerId>/auto" so the worker
-    // resolves that provider's newest live model.
-    settings.installedProviders = agent.providers.map((p) => ({
-      providerId: p.id,
-      installedAt: Date.now(),
-    }));
-    const primary = agent.providers[0];
-    const primaryModel = primary.model?.trim();
-    settings.defaultModel = primaryModel || `${primary.id}/auto`;
+    // Each declared provider becomes one explicit `<providerId>/<model>` ref in
+    // the ordered `models` list (index 0 = the primary/default). A provider
+    // that declares no model resolves to its catalog defaultModel; if none
+    // exists it becomes a `<providerId>/__unresolved__` restriction sentinel —
+    // NEVER dropped to nothing. Dropping it would leave an agent that DECLARED
+    // providers with `models` undefined = allow-all, silently widening the
+    // intended restriction. The sentinel keeps the exact gate CLOSED (it never
+    // routes) until a real model is picked. Refs are always concrete or
+    // sentinel, never "<providerId>/auto".
+    const catalogDefaults = new Map(
+      buildProviderCatalog().map((entry) => [entry.slug, entry.defaultModel])
+    );
+    const models: string[] = [];
+    for (const provider of agent.providers) {
+      const declared = provider.model?.trim();
+      const model = declared || catalogDefaults.get(provider.id) || "";
+      if (!model) {
+        logger.warn(
+          `Declared provider "${provider.id}" on agent "${agent.id}" has no model and no catalog default — kept as a restriction sentinel (agent stays gated, not allow-all)`
+        );
+        models.push(`${provider.id}/${UNRESOLVED_MODEL_SUFFIX}`);
+        continue;
+      }
+      models.push(
+        model.startsWith(`${provider.id}/`) ? model : `${provider.id}/${model}`
+      );
+    }
+    // providers were declared ⇒ ALWAYS a non-empty models list (restricted),
+    // never undefined/allow-all.
+    settings.models = models;
   }
 
   if (agent.network) {

--- a/packages/server/src/gateway/services/instruction-service.ts
+++ b/packages/server/src/gateway/services/instruction-service.ts
@@ -47,8 +47,15 @@ class SkillsInstructionProvider extends BaseInstructionProvider {
   protected async buildInstructions(
     context: InstructionContext
   ): Promise<string> {
-    // If no settings store or agentId, return generic skill discovery instructions
-    if (!this.agentSettingsStore || !context.agentId) {
+    // If no settings store or agentId, return generic skill discovery instructions.
+    // Also fail closed (generic) for an orgless DB-backed agent: an id-only read
+    // of a shared id would leak another org's skills — `orgScoped === false` says
+    // "do NOT read agent settings by id".
+    if (
+      !this.agentSettingsStore ||
+      !context.agentId ||
+      context.orgScoped === false
+    ) {
       return this.getGenericSkillsInstructions();
     }
 
@@ -242,10 +249,14 @@ export class InstructionService {
     context: InstructionContext,
     options?: { settingsUrl?: string }
   ): Promise<SessionContextData> {
-    // Get platform-specific instructions
+    // Get platform-specific instructions. A platform provider may do an
+    // agent-scoped DB read (e.g. SlackInstructionProvider.listConnections),
+    // so it is gated by the SAME org-scope guard as skills/agent instructions:
+    // an orgless DB-backed agent (`orgScoped === false`) skips it entirely
+    // (platformInstructions stays "") to avoid leaking another tenant's data.
     let platformInstructions = "";
     const platformProvider = this.platformProviders.get(platform);
-    if (platformProvider) {
+    if (platformProvider && context.orgScoped !== false) {
       try {
         platformInstructions = await platformProvider.getInstructions(context);
         logger.info(
@@ -271,9 +282,15 @@ export class InstructionService {
       logger.error("Failed to get network instructions:", error);
     }
 
-    // Build agent instructions from identity/soul/user settings
+    // Build agent instructions from identity/soul/user settings. Skip the by-id
+    // read for an orgless DB-backed agent (`orgScoped === false`) — it would
+    // id-only read another org's identity/soul/user for a shared id.
     let agentInstructions = "";
-    if (this.agentSettingsStore && context.agentId) {
+    if (
+      this.agentSettingsStore &&
+      context.agentId &&
+      context.orgScoped !== false
+    ) {
       try {
         const settings = await this.agentSettingsStore.getSettings(
           context.agentId,
@@ -319,12 +336,16 @@ export class InstructionService {
       logger.error("Failed to get skills instructions:", error);
     }
 
-    // Get MCP status data
+    // Get MCP status data. Pass the org so the lobu-memory slug is resolved from
+    // the token's org (not an id-only agent lookup); orgless db-backed → none.
     let mcpStatus: McpStatus[] = [];
     if (this.mcpConfigService) {
       try {
         mcpStatus =
-          (await this.mcpConfigService.getMcpStatus(context.agentId)) || [];
+          (await this.mcpConfigService.getMcpStatus(
+            context.agentId,
+            context.organizationId
+          )) || [];
         logger.info(`Got MCP status for ${mcpStatus.length} MCPs`);
       } catch (error) {
         logger.error("Failed to get MCP status:", error);

--- a/packages/server/src/gateway/services/platform-helpers.ts
+++ b/packages/server/src/gateway/services/platform-helpers.ts
@@ -99,7 +99,7 @@ export async function resolveAgentOptions(
   // system agent like "lobu-builder"), and the worker-dispatch path runs
   // without ambient orgContext, so an unscoped read returns an arbitrary org's
   // row — cross-tenant config bleed that mis-resolved the model to another
-  // org's `defaultModel`. Pass the org explicitly so the right row wins.
+  // org's `models` list. Pass the org explicitly so the right row wins.
   const settings = await agentSettingsStore.getSettings(agentId, {
     organizationId,
   });
@@ -111,11 +111,30 @@ export async function resolveAgentOptions(
 
   // Layered model fallback: behavior override → agent default → org default.
   // A per-behavior override arrives as baseOptions.model (injected at enqueue)
-  // and wins; otherwise resolve agent.defaultModel, then the org default. Only
+  // and wins; otherwise resolve agent.models[0], then the org default. Only
   // when all three are empty do we leave model unset (worker surfaces an
   // actionable "no model" error).
-  const behaviorOverride =
+  //
+  // A malformed override (not a `<slug>/<model>` ref — e.g. a legacy "auto"
+  // binding, or a bare model id) is IGNORED here and falls through to the
+  // agent default, rather than propagating an unroutable/ungated value. `auto`
+  // is gone repo-wide, so it never wins as an override. The exact allow-list
+  // gate (deployment-manager backstop) still validates the resulting ref.
+  const rawOverride =
     typeof baseOptions.model === "string" ? baseOptions.model.trim() : "";
+  const overrideSlash = rawOverride.indexOf("/");
+  const behaviorOverride =
+    overrideSlash > 0 &&
+    overrideSlash < rawOverride.length - 1 &&
+    rawOverride.slice(overrideSlash + 1) !== "auto"
+      ? rawOverride
+      : "";
+  if (rawOverride && !behaviorOverride) {
+    logger.warn(
+      { agentId, rejectedOverride: rawOverride },
+      "Ignoring malformed model override (not a <provider>/<model> ref); falling back to the agent default",
+    );
+  }
   const effectiveModelRef =
     behaviorOverride ||
     (await composeEffectiveModelRef(

--- a/packages/server/src/lobu/__tests__/agent-routes-models-config.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-models-config.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Round-2 review coverage for the agent PATCH/GET `/config` model surface:
+ *   #1  a PATCH carrying a removed legacy field (defaultModel / installedProviders)
+ *       is REJECTED (400) — never silently dropped to models=NULL=allow-all.
+ *   #8  GET returns the ordered `models` list and NO legacy `defaultModel`.
+ *   #7  a PATCH whose `models` fails validation is ATOMIC — it rejects BEFORE
+ *       mutating auth profiles, so a co-sent credential is NOT persisted.
+ *
+ * Drives the real `agentRoutes` Hono app over the embedded-PG harness with the
+ * shared route-test auth mocks (same pattern as agent-routes-guardrail-trips).
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from "../../gateway/__tests__/helpers/db-setup.js";
+import {
+  authStash,
+  coreServicesStash,
+  installRouteTestMocks,
+} from "./helpers/route-test-mocks";
+
+installRouteTestMocks();
+
+const TEST_ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+const ORG = "org-models-config";
+const AGENT = "models-config-agent";
+
+async function seedOrgAndAgent(): Promise<void> {
+  const { getDb } = await import("../../db/client.js");
+  const sql = getDb();
+  await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${ORG}, ${ORG}, ${ORG}) ON CONFLICT (id) DO NOTHING
+  `;
+  await sql`
+    INSERT INTO agents (id, organization_id, name)
+    VALUES (${AGENT}, ${ORG}, 'Models Config Agent')
+    ON CONFLICT (organization_id, id) DO NOTHING
+  `;
+}
+
+async function importAgentRoutes() {
+  const mod = await import("../agent-routes.js");
+  return mod.agentRoutes;
+}
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+  process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+}, 60_000);
+
+beforeEach(async () => {
+  await resetTestDatabase();
+  await seedOrgAndAgent();
+  authStash.user = {
+    id: "u1",
+    name: "Test",
+    email: "u1@test",
+    emailVerified: true,
+  };
+  authStash.organizationId = ORG;
+  authStash.authSource = "session";
+  authStash.mcpAuthInfo = null;
+  coreServicesStash.services = null;
+}, 30_000);
+
+describe("agent PATCH/GET /config — models surface", () => {
+  test("#1: a PATCH carrying legacy defaultModel is rejected (not silently dropped)", async () => {
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ defaultModel: "openai/gpt-5" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string; field?: string };
+    expect(body.error).toBe("legacy_model_field");
+    expect(body.field).toBe("defaultModel");
+  });
+
+  test("#1: a PATCH carrying legacy installedProviders is rejected", async () => {
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        installedProviders: [{ providerId: "openai", installedAt: 1 }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error?: string }).error).toBe(
+      "legacy_model_field"
+    );
+  });
+
+  test("#8: GET returns the ordered models list and no defaultModel", async () => {
+    const { getDb } = await import("../../db/client.js");
+    const sql = getDb();
+    await sql`
+      UPDATE agents SET models = ${sql.json(["openai/gpt-5", "claude/claude-sonnet-5"])}
+      WHERE organization_id = ${ORG} AND id = ${AGENT}
+    `;
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.models).toEqual(["openai/gpt-5", "claude/claude-sonnet-5"]);
+    expect(body).not.toHaveProperty("defaultModel");
+    expect(body).not.toHaveProperty("installedProviders");
+  });
+
+  test("#7: a PATCH with an invalid models list rejects BEFORE persisting auth profiles (atomic)", async () => {
+    // Spy manager: record any upsertProfile call. The handler must NOT reach it
+    // when models validation fails first.
+    const upserts: unknown[] = [];
+    coreServicesStash.services = {
+      getAuthProfilesManager: () => ({
+        upsertProfile: async (p: unknown) => {
+          upserts.push(p);
+        },
+        getUserAuthProfileStore: () => ({
+          list: async () => [],
+        }),
+      }),
+    };
+
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        // "ghost" is not a provider in this org → validation fails.
+        models: ["ghost/some-model"],
+        authProfiles: [
+          {
+            id: "p1",
+            provider: "ghost",
+            model: "ghost/some-model",
+            label: "key",
+            authType: "api-key",
+            credential: "sk-should-not-persist",
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error?: string }).error).toBe(
+      "model_provider_not_connected"
+    );
+    // The credential was NEVER persisted — the PATCH was a true no-op.
+    expect(upserts).toHaveLength(0);
+
+    // And the agent's models were not mutated either.
+    const { getDb } = await import("../../db/client.js");
+    const sql = getDb();
+    const rows = (await sql`
+      SELECT models FROM agents WHERE organization_id = ${ORG} AND id = ${AGENT}
+    `) as Array<{ models: string[] | null }>;
+    expect(rows[0]?.models ?? null).toBeNull();
+  });
+
+  test("#6: a PATCH with a __unresolved__ sentinel + a soulMd change succeeds and round-trips", async () => {
+    // A migrated legacy agent carries `models = ["legacy/__unresolved__"]`.
+    // Editing ANY setting (soulMd) PATCHes the FULL desired settings incl.
+    // models; the sentinel must be ACCEPTED as valid (not invalid_model_ref),
+    // so the apply doesn't break on an unrelated edit.
+    const app = await importAgentRoutes();
+    const res = await app.request(`/${AGENT}/config`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        models: ["legacy/__unresolved__", "chatgpt/__unresolved__"],
+        soulMd: "Be concise.",
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    // GET round-trips the exact sentinel list + the soulMd edit.
+    const get = await app.request(`/${AGENT}/config`);
+    const body = (await get.json()) as Record<string, unknown>;
+    expect(body.models).toEqual([
+      "legacy/__unresolved__",
+      "chatgpt/__unresolved__",
+    ]);
+    expect(body.soulMd).toBe("Be concise.");
+  });
+});

--- a/packages/server/src/lobu/__tests__/agent-routes-models-validation.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-models-validation.test.ts
@@ -1,0 +1,88 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+  LEGACY_MODEL_FIELDS,
+  validateModelsUpdate,
+} from "../agent-routes.js";
+import { orgContext } from "../stores/org-context.js";
+import { createInferenceProvider } from "../stores/provider-secrets.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+  seedAgentRow,
+} from "../../gateway/__tests__/helpers/db-setup.js";
+
+const ORG = "test-org-models-validation";
+const AGENT = "models-agent";
+
+// A stub Hono context: validateModelsUpdate only reads c.req.url + c.req.param
+// to build the (informational) setup URLs in an error body.
+const stubC = {
+  req: {
+    url: "https://gw.example.com/api/agents/models-agent/config",
+    param: () => undefined,
+  },
+} as any;
+
+async function validate(models: unknown) {
+  return orgContext.run({ organizationId: ORG }, () =>
+    validateModelsUpdate({ models, organizationId: ORG, agentId: AGENT, c: stubC })
+  );
+}
+
+describe("validateModelsUpdate (exact model refs)", () => {
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await orgContext.run({ organizationId: ORG }, async () => {
+      await seedAgentRow(AGENT, { organizationId: ORG });
+      // An org provider slug the refs can resolve against.
+      await createInferenceProvider({
+        organizationId: ORG,
+        slug: "myco",
+        kind: "openai",
+        apiKey: "sk-test",
+        capabilities: { text: { model: "myco-large" } },
+      });
+    });
+  });
+
+  test("accepts explicit <slug>/<model> refs whose provider exists in the org", async () => {
+    expect(await validate(["myco/myco-large"])).toBeNull();
+  });
+
+  test("accepts an empty list (allow-all policy)", async () => {
+    expect(await validate([])).toBeNull();
+  });
+
+  test("rejects a bare model id (no provider prefix)", async () => {
+    const err = await validate(["just-a-model"]);
+    expect(err?.error).toBe("invalid_model_ref");
+  });
+
+  test("rejects an `auto` model suffix (auto is gone repo-wide)", async () => {
+    const err = await validate(["myco/auto"]);
+    expect(err?.error).toBe("invalid_model_ref");
+    expect(String(err?.error_description)).toContain("auto");
+  });
+
+  test("rejects a ref whose provider does not exist in the org", async () => {
+    const err = await validate(["ghost/some-model"]);
+    expect(err?.error).toBe("model_provider_not_connected");
+    expect(err?.provider).toBe("ghost");
+  });
+
+  test("rejects a non-array / non-string payload", async () => {
+    expect((await validate("myco/myco-large"))?.error).toBe("invalid_models");
+    expect((await validate([1, 2]))?.error).toBe("invalid_models");
+  });
+
+  test("LEGACY_MODEL_FIELDS names the removed fields the route guard rejects", () => {
+    expect([...LEGACY_MODEL_FIELDS]).toEqual([
+      "defaultModel",
+      "installedProviders",
+    ]);
+  });
+});

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -15,12 +15,11 @@ import {
 	getOAuthProviderConfigs,
 	type OAuthProviderConfig,
 } from "../gateway/auth/oauth/providers";
-import {
-	buildProviderCatalog,
-	type ProviderCatalogService,
-} from "../gateway/auth/provider-catalog";
+import { isUnresolvedModelRef } from "../gateway/auth/model-sentinel";
+import { buildProviderCatalog } from "../gateway/auth/provider-catalog";
 import { createAuthProfileLabel } from "../gateway/auth/settings/auth-profiles-manager";
 import { orgBucketAgentId } from "../gateway/auth/settings/user-auth-profile-store";
+import { getModelProviderModules } from "../gateway/modules/module-system";
 import {
 	ProviderRegistryService,
 	resolveProviderRegistryPath,
@@ -90,86 +89,88 @@ function buildRequestBaseUrls(c: any, agentId: string, providerId: string) {
 	};
 }
 
-function parseProviderFromModelRef(modelRef: string): string | null {
-	const trimmed = modelRef.trim();
-	if (!trimmed || trimmed === "auto") return null;
-	const slash = trimmed.indexOf("/");
-	if (slash <= 0) return null;
-	return trimmed.slice(0, slash);
-}
+/**
+ * Validate a PATCHed `models` list. Every entry must be an explicit
+ * `<slug>/<model>` ref (no bare model ids, no `auto` in either position) whose
+ * slug resolves at the ORG level: a registry provider module OR one of the
+ * org's `inference_providers` rows. Validating against the org-level set (not
+ * the agent's own list) is what makes the write atomic — an entry can never
+ * dangle on "the agent hasn't installed that provider yet", because the list
+ * being written IS the install.
+ *
+ * Returns `{ error }` JSON on the first invalid entry, or null when valid.
+ */
+/**
+ * Legacy agent-settings model fields removed in the atomic cutover. A PATCH
+ * carrying any of these is rejected (see the config route) rather than silently
+ * dropped — silently dropping would reset a RESTRICTED agent to `models = NULL`
+ * (allow-all), widening access. Exported for the route guard + its test.
+ */
+export const LEGACY_MODEL_FIELDS = ["defaultModel", "installedProviders"] as const;
 
-async function validateModelProviderRoutable(params: {
-	catalog: ProviderCatalogService;
-	agentId: string;
-	modelRef: string;
+export async function validateModelsUpdate(params: {
+	models: unknown;
 	organizationId: string;
-	userId?: string;
+	agentId: string;
 	c: any;
 }): Promise<Record<string, unknown> | null> {
-	const providerId = parseProviderFromModelRef(params.modelRef);
-	if (!providerId) return null;
+	if (
+		!Array.isArray(params.models) ||
+		params.models.some((m) => typeof m !== "string")
+	) {
+		return {
+			error: "invalid_models",
+			error_description: "models must be an array of strings",
+		};
+	}
 
-	const providers = await params.catalog.getInstalledModules(
-		params.agentId,
-		params.organizationId,
-	);
-	const provider = await params.catalog.findProviderForModel(
-		params.modelRef,
-		providers,
-	);
-	const urls = buildRequestBaseUrls(params.c, params.agentId, providerId);
+	const entries = (params.models as string[]).map((m) => m.trim());
+	const invalid = (ref: string, why: string): Record<string, unknown> => ({
+		error: "invalid_model_ref",
+		error_description: `Invalid models entry "${ref}": ${why}. Every entry must be an explicit "<provider>/<model>" ref.`,
+		model: ref,
+	});
+	for (const ref of entries) {
+		// A `<slug>/__unresolved__` restriction sentinel is a deliberate,
+		// non-routable placeholder (emitted by the migration/provisioning for a
+		// "provider intended, no concrete model" agent). It must round-trip
+		// through PATCH — e.g. editing soulMd on a migrated legacy agent PATCHes
+		// the full settings incl. `models`, which may contain a sentinel — so
+		// accept it as valid without the model-shape / org-provider checks below.
+		if (isUnresolvedModelRef(ref)) continue;
+		const slash = ref.indexOf("/");
+		if (!ref || slash <= 0 || slash === ref.length - 1) {
+			return invalid(ref, "expected a provider-qualified model ref");
+		}
+		if (ref.slice(slash + 1).trim() === "auto") {
+			return invalid(ref, '"auto" is not a model; pick a concrete model');
+		}
+	}
 
-	if (!provider) {
+	// Org-level slug resolution: registry modules ∪ the org's provider rows.
+	const orgSlugs = new Set<string>(
+		getModelProviderModules().map((m) => m.providerId),
+	);
+	for (const row of await listInferenceProviders(params.organizationId)) {
+		orgSlugs.add(row.slug);
+	}
+	for (const ref of entries) {
+		// Sentinels are accepted above; skip the org-provider existence check
+		// (their slug — e.g. `legacy` — is intentionally not a real provider).
+		if (isUnresolvedModelRef(ref)) continue;
+		const providerId = ref.slice(0, ref.indexOf("/"));
+		if (orgSlugs.has(providerId)) continue;
+		const urls = buildRequestBaseUrls(params.c, params.agentId, providerId);
 		return {
 			error: "model_provider_not_connected",
 			error_description:
-				`The selected model (${params.modelRef}) uses provider "${providerId}", but that provider is not connected to this agent. ` +
-				`Open ${urls.settingsUrl}, connect "${providerId}" in Providers, then save again. ` +
+				`The model "${ref}" uses provider "${providerId}", but that provider does not exist in this organization. ` +
+				`Add it under Providers (or fix the slug), then save again. ` +
 				`Expected gateway proxy URL after setup: ${urls.expectedProxyUrl}`,
-			model: params.modelRef,
+			model: ref,
 			provider: providerId,
 			settingsUrl: urls.settingsUrl,
 			expectedProxyUrl: urls.expectedProxyUrl,
-		};
-	}
-
-	const hasCredentials =
-		provider.hasSystemKey() ||
-		(await provider.hasCredentials(params.agentId, {
-			organizationId: params.organizationId,
-			userId: params.userId,
-		}));
-	if (!hasCredentials) {
-		return {
-			error: "model_provider_credentials_missing",
-			error_description:
-				`The selected model (${params.modelRef}) uses provider "${provider.providerId}", but Lobu has no credentials for that provider. ` +
-				`Open ${urls.settingsUrl}, connect or add credentials for "${provider.providerId}", then save again. ` +
-				`Expected gateway proxy URL after setup: ${urls.expectedProxyUrl}`,
-			model: params.modelRef,
-			provider: provider.providerId,
-			settingsUrl: urls.settingsUrl,
-			expectedProxyUrl: urls.expectedProxyUrl,
-		};
-	}
-
-	const mappings = provider.getProxyBaseUrlMappings(
-		urls.proxyBaseUrl,
-		params.agentId,
-		{ organizationId: params.organizationId, userId: params.userId },
-	);
-	const expectedProxyUrl = Object.values(mappings)[0] || urls.expectedProxyUrl;
-	if (Object.keys(mappings).length === 0) {
-		return {
-			error: "model_provider_route_missing",
-			error_description:
-				`The selected model (${params.modelRef}) uses provider "${provider.providerId}", but Lobu could not build a gateway route for it. ` +
-				`Open ${urls.settingsUrl} and reconnect the provider, or restart/redeploy the gateway. ` +
-				`Expected gateway proxy URL: ${expectedProxyUrl}`,
-			model: params.modelRef,
-			provider: provider.providerId,
-			settingsUrl: urls.settingsUrl,
-			expectedProxyUrl,
 		};
 	}
 
@@ -447,9 +448,9 @@ routes.get("/", async (c) => {
           AND c.deleted_at IS NULL
         GROUP BY c.agent_id
       `,
-		// Provider ids per agent, from the agent row's installed_providers list.
+		// Provider ids per agent, derived from the `models` list's slug prefixes.
 		sql`
-        SELECT id, installed_providers
+        SELECT id, models
         FROM agents
         WHERE organization_id = ${orgId}
       `,
@@ -476,9 +477,10 @@ routes.get("/", async (c) => {
 	const providersMap = new Map<string, string[]>();
 	for (const r of providerRows) {
 		const set = new Set<string>();
-		for (const p of ((r as any).installed_providers ?? []) as any[]) {
-			const id = p?.providerId ?? p?.provider;
-			if (id) set.add(String(id));
+		for (const ref of ((r as any).models ?? []) as unknown[]) {
+			if (typeof ref !== "string") continue;
+			const slash = ref.indexOf("/");
+			if (slash > 0) set.add(ref.slice(0, slash));
 		}
 		providersMap.set((r as any).id, [...set]);
 	}
@@ -1577,6 +1579,63 @@ routes.patch("/:agentId/config", async (c) => {
 		authProfiles?: AuthProfile[];
 	} & Record<string, unknown>;
 
+	// Atomic cutover: the legacy model fields are GONE. An old client (pre-PR4
+	// CLI, stale web build) that still sends them would have its restricted
+	// declaration silently dropped to `models = NULL` = allow-all — a silent
+	// access widening. Reject loudly so the operator upgrades instead.
+	for (const legacyField of LEGACY_MODEL_FIELDS) {
+		if (legacyField in settingsUpdates) {
+			return c.json(
+				{
+					error: "legacy_model_field",
+					error_description:
+						`This server no longer accepts "${legacyField}". The agent's model configuration is now a single ordered "models" list of explicit "<provider>/<model>" refs. Upgrade your client (CLI / web) and send "models" instead.`,
+					field: legacyField,
+				},
+				400,
+			);
+		}
+	}
+
+	// ATOMICITY (#7): validate the `models` allow-list BEFORE mutating anything
+	// else (auth profiles, settings row). A models-validation failure must leave
+	// the PATCH a true no-op — reconciling auth profiles first and THEN 503-ing
+	// on models would persist a credential change while claiming "nothing saved".
+	if (settingsUpdates.models !== undefined) {
+		const organizationId = c.get("organizationId") as string;
+		let error: Record<string, unknown> | null;
+		try {
+			error = await validateModelsUpdate({
+				models: settingsUpdates.models,
+				organizationId,
+				agentId,
+				c,
+			});
+		} catch (err) {
+			// FAIL CLOSED: the `models` list is an access gate, so a lookup/infra
+			// failure while validating it must REJECT the write — never persist an
+			// unvalidated allow-list (that could silently widen or misconfigure
+			// access). Nothing has been mutated yet, so this is a true no-op.
+			logger.warn(
+				{ agentId, err },
+				"Failed to validate models list before saving agent settings — rejecting",
+			);
+			return c.json(
+				{
+					error: "models_validation_failed",
+					error_description:
+						"Could not validate the models list against the organization's providers. No change was saved; please retry.",
+				},
+				503,
+			);
+		}
+		if (error) return c.json(error, 400);
+		// Persist the trimmed refs, not the raw client payload.
+		settingsUpdates.models = (settingsUpdates.models as string[]).map((m) =>
+			m.trim(),
+		);
+	}
+
 	if (Array.isArray(authProfiles)) {
 		const user = c.get("user");
 		if (!user?.id) {
@@ -1600,32 +1659,6 @@ routes.patch("/:agentId/config", async (c) => {
 								: "Failed to persist auth profiles",
 					},
 					503,
-				);
-			}
-		}
-	}
-
-	if (typeof settingsUpdates.defaultModel === "string") {
-		const modelRef = settingsUpdates.defaultModel.trim();
-		if (modelRef) {
-			try {
-				const catalog = getLobuCoreServices()?.getProviderCatalogService?.();
-				const organizationId = c.get("organizationId") as string | undefined;
-				if (catalog && organizationId) {
-					const error = await validateModelProviderRoutable({
-						catalog,
-						agentId,
-						modelRef,
-						organizationId,
-						userId: c.get("user")?.id,
-						c,
-					});
-					if (error) return c.json(error, 400);
-				}
-			} catch (error) {
-				logger.warn(
-					{ agentId, modelRef, error },
-					"Failed to validate model/provider routability before saving agent settings",
 				);
 			}
 		}

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -4,6 +4,7 @@ import type {
 	AgentMetadata,
 	AgentSettings,
 } from "@lobu/core";
+import { createLogger } from "@lobu/core";
 import { getDb, tsTime, tsTimeOrNull } from "../../db/client";
 import { recordLifecycleEvent } from "../../utils/insert-event";
 import {
@@ -13,6 +14,8 @@ import {
 	upsertChatConnectionProjection,
 } from "./connections-projection";
 import { getOrgId, tryGetOrgId } from "./org-context";
+
+const logger = createLogger("postgres-stores");
 
 export const AGENT_ID_PATTERN = /^[a-z][a-z0-9-]{2,59}$/;
 
@@ -50,11 +53,11 @@ export async function touchAgentLastUsed(
 
 function rowToSettings(row: Record<string, any>): AgentSettings {
 	return {
-		// The `model` column is the agent's single defaultModel ref (a
-		// `provider/model` string or "auto"). The legacy `model_selection` /
-		// `provider_model_preferences` columns are no longer read (dropped in a
-		// follow-up migration after backfill).
-		defaultModel: row.model ?? undefined,
+		// The `models` column is the agent's ordered list of explicit
+		// `<providerSlug>/<model>` refs (index 0 = default). NULL/empty ⇒ all org
+		// providers are available and the default falls through to the org
+		// default model.
+		models: row.models ?? undefined,
 		networkConfig: row.network_config ?? undefined,
 		nixConfig: row.nix_config ?? undefined,
 		soulMd: row.soul_md ?? undefined,
@@ -63,7 +66,6 @@ function rowToSettings(row: Record<string, any>): AgentSettings {
 		skillsConfig: row.skills_config ?? undefined,
 		toolsConfig: row.tools_config ?? undefined,
 		pluginsConfig: row.plugins_config ?? undefined,
-		installedProviders: row.installed_providers ?? undefined,
 		verboseLogging: row.verbose_logging ?? undefined,
 		showToolCalls: row.show_tool_calls ?? undefined,
 		preApprovedTools: row.pre_approved_tools ?? undefined,
@@ -111,22 +113,22 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			const orgId = tryGetOrgId();
 			const rows = orgId
 				? await sql`
-            SELECT model,
+            SELECT models,
                    network_config, nix_config,
                    soul_md, user_md, identity_md,
                    skills_config, tools_config, plugins_config,
-                   installed_providers, verbose_logging, show_tool_calls,
+                   verbose_logging, show_tool_calls,
                    pre_approved_tools, guardrails, guardrails_inline,
                    environment_id, updated_at
             FROM agents
             WHERE id = ${agentId} AND organization_id = ${orgId}
           `
 				: await sql`
-            SELECT model,
+            SELECT models,
                    network_config, nix_config,
                    soul_md, user_md, identity_md,
                    skills_config, tools_config, plugins_config,
-                   installed_providers, verbose_logging, show_tool_calls,
+                   verbose_logging, show_tool_calls,
                    pre_approved_tools, guardrails, guardrails_inline,
                    environment_id, updated_at
             FROM agents
@@ -141,7 +143,7 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			const now = new Date();
 			await sql`
         UPDATE agents SET
-          model = ${settings.defaultModel ?? null},
+          models = ${settings.models ? sql.json(settings.models) : null},
           network_config = ${sql.json(settings.networkConfig ?? {})},
           nix_config = ${sql.json(settings.nixConfig ?? {})},
           soul_md = ${settings.soulMd ?? ""},
@@ -150,7 +152,6 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
           skills_config = ${sql.json(settings.skillsConfig ?? { skills: [] })},
           tools_config = ${sql.json(settings.toolsConfig ?? {})},
           plugins_config = ${sql.json(settings.pluginsConfig ?? {})},
-          installed_providers = ${sql.json(settings.installedProviders ?? [])},
           verbose_logging = ${settings.verboseLogging ?? false},
           show_tool_calls = ${settings.showToolCalls ?? false},
           pre_approved_tools = ${sql.json(settings.preApprovedTools ?? [])},
@@ -175,11 +176,11 @@ export function createPostgresAgentConfigStore(): AgentConfigStore {
 			const orgId = getOrgId();
 			await sql`
         UPDATE agents SET
-          model = NULL,
+          models = NULL,
           network_config = '{}', nix_config = '{}',
           soul_md = '', user_md = '', identity_md = '',
           skills_config = '{"skills": []}', tools_config = '{}', plugins_config = '{}',
-          installed_providers = '[]', verbose_logging = false,
+          verbose_logging = false,
           show_tool_calls = false,
           pre_approved_tools = '[]', guardrails = '[]', guardrails_inline = '[]',
           environment_id = NULL,
@@ -321,6 +322,21 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 			const orgId = tryGetOrgId();
 			const agentId = filter?.agentId ?? null;
 			const platform = filter?.platform ?? null;
+
+			// CROSS-TENANT GUARD: an AGENT-scoped list with NO ambient org would drop
+			// the org filter below and return ANOTHER tenant's rows for a shared
+			// agent id (`lobu-builder`). That's a leak. Callers that legitimately
+			// want all-tenant rows (reconcile loops, admin/list) do NOT pass
+			// `agentId` and run either unscoped-by-design or inside their own
+			// `orgContext.run` — so requiring an ambient org ONLY when `agentId` is
+			// set is the tightest guard that leaves those callers untouched.
+			if (agentId && !orgId) {
+				logger.warn(
+					{ agentId, platform },
+					"[listConnections] agent-scoped list with no org context — returning empty (cross-tenant guard)",
+				);
+				return [];
+			}
 
 			// `connections` is the sole source of truth; `credential_mode IS NOT NULL`
 			// selects chat rows only (data connectors leave it NULL). filter.agentId →

--- a/packages/server/src/scheduled/__tests__/wake-agent-delivery.test.ts
+++ b/packages/server/src/scheduled/__tests__/wake-agent-delivery.test.ts
@@ -7,7 +7,10 @@ import {
   seedAgentRow,
 } from "../../gateway/__tests__/helpers/db-setup";
 import type { CoreServices } from "../../gateway/services/core-services";
-import { enqueueAgentMessage } from "../../gateway/services/agent-threads";
+import {
+  createThreadForAgent,
+  enqueueAgentMessage,
+} from "../../gateway/services/agent-threads";
 import { runtimeConnectionIdToSlug } from "../../lobu/stores/connections-projection";
 import { runWakeAgentTask, type WakeAgentTaskPayload } from "../jobs";
 
@@ -260,4 +263,60 @@ test("internal API-thread dispatch marks a supplied model as a behavior override
     model: "z-ai/glm-5.2",
     behaviorModelOverride: true,
   });
+});
+
+test("#2: createThreadForAgent STORES organizationId on the session", async () => {
+  let stored: { organizationId?: string } | undefined;
+  const deps = {
+    sessionManager: {
+      setSession: async (s: { organizationId?: string }) => {
+        stored = s;
+      },
+    },
+  } as unknown as Parameters<typeof createThreadForAgent>[0];
+
+  await createThreadForAgent(deps, {
+    agentId: AGENT,
+    organizationId: "org-B",
+    userId: USER,
+  });
+
+  // The session (read at enqueue by internal threads) carries the org, not just
+  // the token.
+  expect(stored?.organizationId).toBe("org-B");
+});
+
+test("#2: enqueueAgentMessage threads the session's organizationId to the TOP-LEVEL payload", async () => {
+  // The enqueue-time model gate reads payload.organizationId. An internal
+  // scheduled/repair thread must carry the RIGHT org top-level, or the gate
+  // queries the agent id across orgs (declared agents exist in every org) and
+  // enforces another tenant's policy. Cross-tenant leak.
+  const enqueued: MessagePayload[] = [];
+  const deps = {
+    sessionManager: {
+      getSession: async () => ({
+        userId: USER,
+        conversationId: "thread-2",
+        agentId: AGENT,
+        provider: "claude",
+        organizationId: "org-B",
+      }),
+      touchSession: async () => {},
+    },
+    queueProducer: {
+      enqueueMessage: async (message: MessagePayload) => {
+        enqueued.push(message);
+        return "queued";
+      },
+    },
+  } as unknown as Parameters<typeof enqueueAgentMessage>[0];
+
+  await enqueueAgentMessage(deps, {
+    threadId: "thread-2",
+    messageText: "wake up",
+  });
+
+  // Top-level org (not just platformMetadata) so the gate resolves org-B, not
+  // an id-only cross-org read.
+  expect(enqueued[0].organizationId).toBe("org-B");
 });

--- a/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
@@ -210,6 +210,42 @@ export async function handleListChannelBindings(
 	};
 }
 
+/**
+ * Validate a per-binding model override against the agent's `models` list.
+ * Returns an error string, or null when the model is acceptable.
+ *
+ * Rules:
+ *   - unset ⇒ ok (the binding inherits the agent/org default).
+ *   - "auto" (or any non-`<slug>/<model>` shape) ⇒ rejected: `auto` is gone
+ *     repo-wide, and a binding override must be an explicit concrete ref.
+ *   - non-empty agent `models` list ⇒ the override MUST be an exact member.
+ *   - empty/absent agent `models` list ⇒ any explicit `<slug>/<model>` ref is
+ *     accepted (the agent allows all providers).
+ */
+async function validateBindingModel(
+	organizationId: string,
+	agentId: string,
+	model: string | undefined,
+): Promise<string | null> {
+	const ref = model?.trim();
+	if (!ref) return null;
+	const slash = ref.indexOf("/");
+	if (slash <= 0 || slash === ref.length - 1 || ref.slice(slash + 1) === "auto") {
+		return `Invalid binding model "${ref}": use an explicit "<provider>/<model>" ref (\"auto\" is not supported).`;
+	}
+	const sql = getDb();
+	const rows = (await sql`
+		SELECT models FROM agents
+		WHERE id = ${agentId} AND organization_id = ${organizationId}
+		LIMIT 1
+	`) as Array<{ models: string[] | null }>;
+	const models = rows[0]?.models;
+	if (Array.isArray(models) && models.length > 0 && !models.includes(ref)) {
+		return `Model "${ref}" is not in this agent's allowed models list. Pick one of: ${models.join(", ")}.`;
+	}
+	return null;
+}
+
 /** Bind a chat channel to an agent (owner/admin tier). Materializes the
  *  channel's streaming feed via ChannelBindingService.createBinding. */
 export async function handleBindChannel(
@@ -222,6 +258,17 @@ export async function handleBindChannel(
 	}
 	const channelId = args.channel_id.trim();
 	if (!channelId) return { error: "Invalid channel_id" };
+
+	// Gate the per-binding model override against the agent's EXACT allowed
+	// list. A Listen binding must not be able to route this channel to a model
+	// the agent isn't allowed to use.
+	const modelError = await validateBindingModel(
+		organizationId,
+		args.agent_id,
+		args.model,
+	);
+	if (modelError) return { error: modelError };
+
 	const sql = getDb();
 	const connections = (await sql`
 		SELECT id, slug, connector_key, external_tenant_id

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -36,6 +36,12 @@ export default defineConfig({
       // src/auth/oauth/__tests__ is bun:test (OAuth scope suites), run via the
       // same `bun test … src/auth/oauth/__tests__` job — keep it off vitest.
       "src/auth/oauth/__tests__/**",
+      // src/auth/__tests__ is a MIXED dir: most files are vitest-style and must
+      // stay visible to vitest. system-provider-resolution imports bun:test, so
+      // vitest cannot load it — exclude just that file (it runs via its own bun
+      // test job). Do NOT broaden to src/auth/__tests__/** — that orphans the
+      // vitest files. (tool-access is framework-less and runs fine in both.)
+      "src/auth/__tests__/system-provider-resolution.test.ts",
       "**/node_modules/**",
       "**/dist/**",
     ],

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -478,7 +478,7 @@ run_review_unit_suites() {
   run_deterministic bun test packages/core packages/cli packages/connectors;          ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   run_deterministic bun test packages/agent-worker;                                   ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   run_deterministic bun test packages/server/src/__tests__/unit;                      ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
-  run_deterministic bun test packages/server/src/auth/__tests__/tool-access.test.ts;  ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic bun test packages/server/src/auth/__tests__/tool-access.test.ts packages/server/src/auth/__tests__/system-provider-resolution.test.ts;  ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   # NOTE: src/gateway/infrastructure/queue runs in the gateway integration loop
   # below (not here) — see #1238; running it in both jobs double-executes it.
   run_deterministic bun test packages/connector-worker;                               ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec


### PR DESCRIPTION
Collapses the two-field agent model config (`defaultModel: string` + `installedProviders: string[]`) into a single ordered `models: string[]` list of explicit `<provider>/<model>` refs. **First = default AND the allow-list.**

## Semantics
- At every dispatch path the requested model must be one of `models[]`, else it is replaced with the first **routable** (credentialed, module-present) non-sentinel ref — failing **closed** if none. Never escalates to an unlisted model.
- Three-state agent policy (`resolveAgentModels`): not-found (agent absent / mismatched org / orgless db read) ⇒ **deny-all**; present-empty ⇒ allow-all; present-nonempty ⇒ exact list.
- Sentinel `<slug>/__unresolved__` = "provider intended, no model resolved" — inert: never routed, never allow-all. System-key providers with no concrete model are kept as restriction sentinels so an agent stays gated rather than silently widening to allow-all.
- Shared `resolveDispatchModel` used by the enqueue gate (message-consumer), session-context, and the deployment backstop — all agree.

## Atomic cutover
The server hard-rejects `defaultModel`/`installedProviders` on `PATCH …/config` with **400 `legacy_model_field`** (fail-loud over silent access-widening). Paired with the owletto UI (owletto#477, submodule bumped in this PR) so the Settings save sends `models`.

## Migration
`20260710130000_agent_models_list`: backfill `WHERE models IS NULL` then drop legacy columns. Idempotent, lock-safe metadata ops, `events` untouched, sentinel preserves the restriction invariant (no silent widen).

## Cross-tenant hardening
Every agent-scoped read in /session-context (model, skills, instruction, MCP, Slack provider `listConnections`) is org-scoped or fails closed for an orgless shared-id worker token.

## CLI
Folds the CLI config migration (`define.ts`, `map-config.ts`, `diff.ts`) into the same wave.

## Test / review
- `make review`: **bug_free 84, 0 bugs, 0 blockers**. Suites green: typecheck=0, unit 76/0, integration 119/0 (new `enqueue-model-gate` + `session-context-cross-tenant` tests run).
- **E2E** against a live server: config PATCH with `models[]` → 200 and persists (reorder takes); legacy `defaultModel`/`installedProviders` → 400 `legacy_model_field`.
- Rebased onto #1837 (write-gate agent-envelope) cleanly; verified both features coexist (73 model/cross-tenant/agent-routes tests pass on the merged tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786301850&installation_id=136316292&pr_number=1839&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1839&signature=93680bc3d36f10db05f7f62a896e6d69e1caabbf6996ae55127ad4552f1ad0d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->