### PR TITLE
fix(slack): recognize linked identity during claim

### DIFF
--- a/packages/server/src/gateway/__tests__/slack-claim-http-authority.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim-http-authority.test.ts
@@ -1,0 +1,97 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { getDb } from "../../db/client.js";
+import { resolveClaimContext } from "../connections/connection-claim.js";
+import { slackClaimProvider } from "../connections/slack-claim.js";
+import { resolveClaimingUserSlackIdentities } from "../connections/slack-claim-identities.js";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from "./helpers/db-setup.js";
+
+const USER_ID = "claim-user";
+const TEAM_ID = "T-CLAIM";
+const SLACK_USER_ID = "U-ADMIN";
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+}, 60_000);
+
+beforeEach(async () => {
+  await resetTestDatabase();
+  const sql = getDb();
+  await sql`
+    INSERT INTO "user" (
+      id, email, name, username, "emailVerified", "createdAt", "updatedAt"
+    ) VALUES (
+      ${USER_ID}, 'claim@test.example.com', 'Claim User', 'claim-user',
+      true, now(), now()
+    )
+  `;
+}, 30_000);
+
+async function linkSlackUser(teamId: string): Promise<void> {
+  await getDb()`
+    INSERT INTO chat_user_identities (
+      platform, team_id, platform_user_id, lobu_user_id, updated_at
+    ) VALUES ('slack', ${teamId}, ${SLACK_USER_ID}, ${USER_ID}, now())
+  `;
+}
+
+function claimProvider(usersInfo: ReturnType<typeof mock>) {
+  return slackClaimProvider({
+    resolvePending: mock(async () => ({
+      id: "pending-1",
+      teamId: TEAM_ID,
+      teamName: "Acme",
+      botUserId: "B-BOT",
+      installerUserId: "U-INSTALLER",
+      botToken: "xoxb-test",
+      isEnterpriseInstall: false,
+      enterpriseId: null,
+    })),
+    resolveActiveOrgSlug: mock(async () => null),
+    resolveClaimerSlackIdentities: resolveClaimingUserSlackIdentities,
+    usersInfo,
+    claim: mock(async () => ({ installationId: "unused" })),
+  });
+}
+
+const claimEngineDeps = {
+  resolveMemberOrgs: mock(async () => [
+    { id: "org-1", slug: "acme", name: "Acme", isPersonal: false },
+  ]),
+  resolveOrgIfMember: mock(async () => "org-1"),
+  resolveOrgSlug: mock(async () => "acme"),
+};
+
+describe("Slack HTTP claim authority", () => {
+  test("a workspace-linked Slack identity reaches ready instead of signin_required", async () => {
+    await linkSlackUser(TEAM_ID);
+    const usersInfo = mock(async () => ({ isAdmin: true, isOwner: false }));
+    const context = await resolveClaimContext(
+      claimProvider(usersInfo),
+      claimEngineDeps,
+      { userId: USER_ID, ref: TEAM_ID },
+    );
+
+    expect(context.status).toBe("ready");
+    expect(usersInfo).toHaveBeenCalledWith("xoxb-test", SLACK_USER_ID);
+  });
+
+  test("a Slack identity linked in another workspace still requires sign-in", async () => {
+    await linkSlackUser("T-OTHER");
+    const usersInfo = mock(async () => ({ isAdmin: true, isOwner: false }));
+
+    const context = await resolveClaimContext(
+      claimProvider(usersInfo),
+      claimEngineDeps,
+      { userId: USER_ID, ref: TEAM_ID },
+    );
+
+    expect(context).toEqual({
+      status: "signin_required",
+      signinProvider: "slack",
+    });
+    expect(usersInfo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/gateway/connections/slack-claim-identities.ts
+++ b/packages/server/src/gateway/connections/slack-claim-identities.ts
@@ -1,0 +1,84 @@
+import { SLACK_IDENTITY } from "@lobu/connectors/slack-identity";
+import { decodeJwtClaims } from "../../auth/subject-identities.js";
+import { getDb, type DbClient } from "../../db/client.js";
+
+/**
+ * Resolve all of the signed-in user's Slack identities as team/user pairs.
+ * The entity graph and Better Auth account are OAuth-backed sources; the direct
+ * chat-user mapping is written by the one-time `/lobu link` flow. The provider
+ * guard consumes these pairs before org selection, exact-team scopes ordinary
+ * workspace claims, and separately restricts bare-user matches to Grid.
+ */
+export async function resolveClaimingUserSlackIdentities(
+  userId: string,
+  sql: DbClient = getDb(),
+): Promise<Array<{ teamId: string; slackUserId: string }>> {
+  const rows = (await sql`
+    SELECT DISTINCT ei.identifier
+    FROM "member" m
+    JOIN entity_identities auth_ei
+      ON auth_ei.organization_id = m."organizationId"
+     AND auth_ei.namespace = 'auth_user_id'
+     AND auth_ei.identifier = m."userId"
+     AND auth_ei.source_connector = 'auth:signup'
+     AND auth_ei.deleted_at IS NULL
+    JOIN entity_identities ei
+      ON ei.organization_id = auth_ei.organization_id
+     AND ei.entity_id = auth_ei.entity_id
+     AND ei.namespace = ${SLACK_IDENTITY.USER_ID}
+     AND ei.deleted_at IS NULL
+    WHERE m."userId" = ${userId}
+  `) as Array<{ identifier: string }>;
+  const fromGraph = rows
+    .map((r) => String(r.identifier))
+    .map((id) => {
+      const sep = id.indexOf(":");
+      return sep === -1
+        ? null
+        : { teamId: id.slice(0, sep), slackUserId: id.slice(sep + 1) };
+    })
+    .filter((x): x is { teamId: string; slackUserId: string } => x !== null);
+
+  const accountRows = (await sql`
+    SELECT "accountId", "idToken"
+    FROM account
+    WHERE "providerId" = 'slack' AND "userId" = ${userId}
+  `) as Array<{ accountId: string | null; idToken: string | null }>;
+  const fromAccounts = accountRows
+    .map((a) => {
+      const slackUserId = a.accountId?.toUpperCase();
+      if (!slackUserId) return null;
+      const teamId = a.idToken
+        ? ((decodeJwtClaims(a.idToken)?.["https://slack.com/team_id"] as
+            | string
+            | undefined) ?? "")
+        : "";
+      return { teamId: teamId.toUpperCase(), slackUserId };
+    })
+    .filter((x): x is { teamId: string; slackUserId: string } => x !== null);
+
+  // `/lobu link` records a direct, immutable Slack workspace-user → Lobu-user
+  // association here. This is the canonical identity used by Slack interaction
+  // and message routing, and it may exist even when the entity graph was never
+  // populated and the linked Better Auth account predates a stored id_token.
+  // Preserve both dimensions: authorizeSlackClaim will accept this only for the
+  // pending install's exact team, then still require Slack's live admin/owner
+  // verdict for the linked U… id. A link in another workspace grants nothing.
+  const linkedRows = (await sql`
+    SELECT team_id, platform_user_id
+    FROM chat_user_identities
+    WHERE platform = 'slack' AND lobu_user_id = ${userId}
+  `) as Array<{ team_id: string; platform_user_id: string }>;
+  const fromLinkedChatUsers = linkedRows.map((row) => ({
+    teamId: row.team_id.toUpperCase(),
+    slackUserId: row.platform_user_id.toUpperCase(),
+  }));
+
+  const seen = new Set<string>();
+  return [...fromGraph, ...fromAccounts, ...fromLinkedChatUsers].filter((x) => {
+    const key = `${x.teamId}:${x.slackUserId}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,7 +9,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Env } from "@lobu/connector-sdk";
-import { SLACK_IDENTITY } from "@lobu/connectors/slack-identity";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { compress } from "hono/compress";
@@ -22,7 +21,6 @@ import { mcpAuth } from "./auth/middleware";
 import { oauthRoutes } from "./auth/oauth/routes";
 import { findExistingPersonalOrg } from "./auth/personal-org-provisioning";
 import { credentialRoutes } from "./auth/routes";
-import { decodeJwtClaims } from "./auth/subject-identities";
 import { compareWorkerToken } from "./auth/worker-token";
 import {
 	deleteEntityApprovalPolicy,
@@ -65,6 +63,7 @@ import {
 	resolveClaimContext,
 } from "./gateway/connections/connection-claim";
 import { slackClaimProvider } from "./gateway/connections/slack-claim";
+import { resolveClaimingUserSlackIdentities } from "./gateway/connections/slack-claim-identities";
 import { autoLinkBuilderAndWelcome } from "./gateway/connections/slack-claim-onboarding";
 import { createSlackWebApi } from "./gateway/connections/slack-web";
 import {
@@ -2242,95 +2241,6 @@ app.post("/api/:orgSlug/join", async (c) => {
 		role: result.role,
 	});
 });
-
-/**
- * Resolve ALL of the signed-in user's `slack_user_id` identities as
- * `{teamId, slackUserId}` pairs — every workspace they've signed in with Slack
- * for. Reuses the canonical `entity_identities` shape the authz layer writes on
- * Slack sign-in (namespace `slack_user_id`, identifier stored uppercased as
- * `T…:U…` on the user's `$member`), joined to the user's memberships via the
- * guarded `auth_user_id`/`auth:signup` claim so a user-supplied identity row
- * can't hijack the lookup. Org-agnostic (the identity may live in any org the
- * user belongs to), so it runs BEFORE we resolve the org to bind into. The claim
- * guard filters by team (workspace membership) or matches the bare `U…` against
- * a Grid pending install's `installerUserId`.
- */
-async function resolveClaimingUserSlackIdentities(
-	userId: string,
-): Promise<Array<{ teamId: string; slackUserId: string }>> {
-	const sql = getDb();
-	const rows = (await sql`
-		SELECT DISTINCT ei.identifier
-		FROM "member" m
-		JOIN entity_identities auth_ei
-		  ON auth_ei.organization_id = m."organizationId"
-		 AND auth_ei.namespace = 'auth_user_id'
-		 AND auth_ei.identifier = m."userId"
-		 AND auth_ei.source_connector = 'auth:signup'
-		 AND auth_ei.deleted_at IS NULL
-		JOIN entity_identities ei
-		  ON ei.organization_id = auth_ei.organization_id
-		 AND ei.entity_id = auth_ei.entity_id
-		 AND ei.namespace = ${SLACK_IDENTITY.USER_ID}
-		 AND ei.deleted_at IS NULL
-		WHERE m."userId" = ${userId}
-	`) as Array<{ identifier: string }>;
-	// The identity is stored as `T…:U…` (team-scoped). Split into a team id and a
-	// bare `U…` id; the claim guard filters by team (membership) or matches the
-	// bare id against the pending install's installerUserId (Grid).
-	const fromGraph = rows
-		.map((r) => String(r.identifier))
-		.map((id) => {
-			const sep = id.indexOf(":");
-			return sep === -1
-				? null
-				: { teamId: id.slice(0, sep), slackUserId: id.slice(sep + 1) };
-		})
-		.filter((x): x is { teamId: string; slackUserId: string } => x !== null);
-
-	// FALLBACK: the entity-graph `slack_user_id` above is only written once the
-	// user's private-org `$member` provisioning has completed AND their signup
-	// identity landed in a private org (see `persistLoginSlackIdentity` /
-	// `resolveTenantMember`). A brand-new user whose signup org is public — or
-	// whose provisioning hasn't finished — has NO such row, so the graph join is
-	// empty and the claim dead-ends in a "Sign in with Slack" loop even though
-	// they just did. Their linked Better-Auth Slack `account` row is an
-	// independent, always-present proof of the same `U…` (the OIDC subject stored
-	// as `accountId`), captured directly by "Sign in with Slack". Union it in so
-	// claim authority never depends on the identity-graph timing.
-	//
-	// The team is read from the stored `id_token` (`https://slack.com/team_id`)
-	// when present, giving a team-scoped entry for Path 1 (workspace membership);
-	// absent, we still emit the bare `U…` with an empty team, which satisfies the
-	// Grid installer-match (Path 2, `slackUserId === installerUserId`). `U…` ids
-	// are enterprise-global, so the bare match is sound on a Grid.
-	const accountRows = (await sql`
-		SELECT "accountId", "idToken"
-		FROM account
-		WHERE "providerId" = 'slack' AND "userId" = ${userId}
-	`) as Array<{ accountId: string | null; idToken: string | null }>;
-	const fromAccounts = accountRows
-		.map((a) => {
-			const slackUserId = a.accountId?.toUpperCase();
-			if (!slackUserId) return null;
-			const teamId = a.idToken
-				? ((decodeJwtClaims(a.idToken)?.["https://slack.com/team_id"] as
-						| string
-						| undefined) ?? "")
-				: "";
-			return { teamId: teamId.toUpperCase(), slackUserId };
-		})
-		.filter((x): x is { teamId: string; slackUserId: string } => x !== null);
-
-	// De-dup by `team:user` so a user present in both sources isn't doubled.
-	const seen = new Set<string>();
-	return [...fromGraph, ...fromAccounts].filter((x) => {
-		const key = `${x.teamId}:${x.slackUserId}`;
-		if (seen.has(key)) return false;
-		seen.add(key);
-		return true;
-	});
-}
 
 /**
  * The provider-agnostic connection "claim" routes bind a parked (pending)


### PR DESCRIPTION
## What changed

- include exact team-scoped `chat_user_identities` links when resolving the signed-in user's Slack identities
- keep the existing live Slack admin/owner verification before allowing a pending install claim
- add real-Postgres coverage for matching-workspace success and wrong-workspace isolation

## Root cause

The HTTP claim path only consulted entity-graph and Better Auth account identities. A valid Slack identity already linked in `chat_user_identities` was invisible, so the claim page returned `signin_required` after every OAuth round trip.

## Validation

- focused Slack claim suite: 27 passed, 0 failed
- rebased focused authority tests: 2 passed, 0 failed
- `make build-packages`
- `bun run typecheck`
- `bun run check`
- `make review`: 0 bugs, 0 blockers, tests adequate; one unrelated deployment timeout passed immediately in isolation

Closes #1809

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786303294&installation_id=136316292&pr_number=1840&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1840&signature=3baf026f81fb462073209d3715d5078085cec648095c2f1c10c165934ebbfb40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack sign-in claim handling when identities are linked to different workspaces.
  * Prevented Slack profile lookups when the linked identity does not match the workspace in the claim.
  * Added support for recognizing Slack identities from multiple linked account sources.

* **Refactor**
  * Consolidated Slack identity resolution into a dedicated component with duplicate results removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->