### PR TITLE
fix(server): restore lobu request logging

### DIFF
--- a/packages/server/src/__tests__/server-lifecycle.test.ts
+++ b/packages/server/src/__tests__/server-lifecycle.test.ts
@@ -6,7 +6,7 @@
  * #948 + the #943 7-hygiene catch-up):
  *
  *   1. Middleware ordering on the Hono wrapper:
- *      peer-address stash → env-inject → sentry-5xx-capture → onError
+ *      peer-address stash → env-inject → request logger → sentry-5xx-capture → onError
  *   2. Route mounts: `/lobu` mounted only when lobuApp is non-null; `/` always.
  *   3. httpServer timeouts: keepAliveTimeout=75000, headersTimeout=76000.
  *   4. Shutdown ordering documented in createServerLifecycle().
@@ -28,21 +28,20 @@ vi.mock("@sentry/node", () => ({
 }));
 
 vi.mock("../utils/logger", () => {
-	const noop = (): void => undefined;
 	// Recursive `child` is required because several modules (e.g.
 	// identity/connectors/google.ts) call `logger.child(...)` at module-load
 	// time. Match pino's interface so any caller's `.info / .warn / .error /
 	// .child` works without instrumentation.
 	const make = (): Record<string, unknown> => {
 		const self: Record<string, unknown> = {
-			info: noop,
-			warn: noop,
-			error: noop,
-			debug: noop,
-			trace: noop,
-			fatal: noop,
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn(),
+			trace: vi.fn(),
+			fatal: vi.fn(),
 		};
-		self.child = () => make();
+		self.child = vi.fn(() => self);
 		return self;
 	};
 	const logger = make();
@@ -132,6 +131,22 @@ describe("serializeBootError", () => {
 });
 
 describe("buildWrapperApp", () => {
+	it("logs requests handled by the /lobu mounted app", async () => {
+		const { buildWrapperApp } = await import("../server-lifecycle");
+		const { default: logger } = await import("../utils/logger");
+		const { Hono } = await import("hono");
+		const lobuApp = new Hono();
+		lobuApp.get("/ping", (c) => c.text("lobu-pong"));
+		const info = logger.info as ReturnType<typeof vi.fn>;
+		info.mockClear();
+
+		const wrapper = buildWrapperApp({} as never, lobuApp);
+		const response = await wrapper.request("/lobu/ping");
+
+		expect(response.status).toBe(200);
+		expect(info).toHaveBeenCalled();
+	});
+
 	it("mounts mainApp at / and lobuApp at /lobu when present", async () => {
 		const { buildWrapperApp } = await import("../server-lifecycle");
 		const { Hono } = await import("hono");

--- a/packages/server/src/__tests__/webhook-signatures.test.ts
+++ b/packages/server/src/__tests__/webhook-signatures.test.ts
@@ -173,12 +173,30 @@ describe("slack app-webhook provider route", () => {
 
   it("rejects a forged signature 401 before delegating", async () => {
     const handler = vi.fn(async () => new Response("ok"));
-    const router = makeRouter(handler);
+    const warn = vi.fn();
+    const router = createAppWebhookRoutes({
+      installationStore: {} as never,
+      secretStore: { get: async () => null },
+      providers: [
+        createDeclaredAppWebhookProvider({
+          provider: "slack",
+          appId: "slack-app",
+          webhookSchema: SLACK_WEBHOOK_SCHEMA,
+          handleDelivery: createChatWebhookDelivery({ handleChatAppWebhook: handler }),
+        }),
+      ],
+      resolveAppWebhookSecret: async () => SIGNING_SECRET,
+      logger: { warn } as never,
+    });
 
     const res = await router.fetch(delivery("{}", nowTs(), "v0=forged"));
 
     expect(res.status).toBe(401);
     expect(handler).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      { provider: "slack" },
+      "[app-webhook] signature verification failed — rejecting delivery",
+    );
   });
 
   it("delegates a fresh, valid delivery to handleSlackAppWebhook", async () => {

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -783,6 +783,8 @@ export function createChatWebhookDelivery(options: {
 export interface AppWebhookRouterDeps {
 	installationStore: AppInstallationStore;
 	secretStore: SecretStore;
+	/** Optional logger override for route-level verification tests. */
+	logger?: Pick<typeof logger, "info" | "warn" | "error">;
 	/** Provider plugins keyed by `provider` (the `:provider` path param). */
 	providers: AppWebhookProvider[];
 	/**
@@ -832,6 +834,7 @@ function json(status: number, body: Record<string, unknown>): Response {
 export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 	const router = new Hono();
 	const providers = new Map(deps.providers.map((p) => [p.provider, p]));
+	const routeLogger = deps.logger ?? logger;
 
 	router.post("/api/v1/app-webhooks/:provider", async (c) => {
 		const providerName = c.req.param("provider");
@@ -854,13 +857,17 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 		//    deliveries just because its secret went unconfigured.
 		const appSecret = await deps.resolveAppWebhookSecret(providerName);
 		if (!appSecret) {
-			logger.warn(
+			routeLogger.warn(
 				{ provider: providerName },
 				"[app-webhook] no app webhook secret configured — rejecting delivery",
 			);
 			return json(401, { error: "Unauthorized" });
 		}
 		if (!provider.verify(rawBody, c.req.raw.headers, appSecret)) {
+			routeLogger.warn(
+				{ provider: providerName },
+				"[app-webhook] signature verification failed — rejecting delivery",
+			);
 			return json(401, { error: "Unauthorized" });
 		}
 
@@ -880,7 +887,7 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 					method: c.req.raw.method,
 				});
 			} catch (error) {
-				logger.error(
+				routeLogger.error(
 					{ provider: providerName, error: String(error) },
 					"[app-webhook] handleDelivery failed",
 				);
@@ -892,7 +899,7 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 		//    tenant (e.g. an app-level ping) is acked without landing.
 		const tenant = provider.extractTenant(rawBody, c.req.raw.headers);
 		if (!tenant) {
-			logger.info(
+			routeLogger.info(
 				{ provider: providerName },
 				"[app-webhook] delivery carries no tenant — acked without landing",
 			);
@@ -910,7 +917,7 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 			externalTenantId: tenant.externalTenantId,
 		});
 		if (!install) {
-			logger.info(
+			routeLogger.info(
 				{
 					provider: providerName,
 					providerInstance: tenant.providerInstance,
@@ -937,7 +944,7 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 				});
 				return json(200, { ok: true, triggered });
 			} catch (error) {
-				logger.error(
+				routeLogger.error(
 					{ provider: providerName, installationId: install.id, error: String(error) },
 					"[app-webhook] onDelivery trigger failed",
 				);
@@ -1018,7 +1025,7 @@ export function createAppWebhookRoutes(deps: AppWebhookRouterDeps): Hono {
 					: undefined,
 			);
 		} catch (error) {
-			logger.error(
+			routeLogger.error(
 				{ provider: providerName, installationId: install.id, error: String(error) },
 				"[app-webhook] failed to land delivery",
 			);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -13,7 +13,6 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { compress } from "hono/compress";
 import { cors } from "hono/cors";
-import { pinoLogger } from "hono-pino";
 import { LOBU_LOGO_PNG_BASE64 } from "./assets/logo";
 import { createAuth } from "./auth";
 import { getAuthConfig as getAuthConfigFromEnv } from "./auth/config";
@@ -421,14 +420,6 @@ app.use(
 		],
 		exposeHeaders: ["Content-Type"],
 		credentials: true, // Required for better-auth cookies
-	}),
-);
-
-// Add Pino logger middleware
-app.use(
-	"*",
-	pinoLogger({
-		pino: logger,
 	}),
 );
 

--- a/packages/server/src/server-lifecycle.ts
+++ b/packages/server/src/server-lifecycle.ts
@@ -18,6 +18,7 @@ import v8 from "node:v8";
 import { getRequestListener } from "@hono/node-server";
 import * as Sentry from "@sentry/node";
 import { Hono } from "hono";
+import { pinoLogger } from "hono-pino";
 import { closeDbSingleton } from "./db/client";
 import { mountViteDev } from "./dev-vite";
 import { markShuttingDown } from "./lifecycle-state";
@@ -140,8 +141,9 @@ export function reportBootFailure(err: unknown): never {
  *      BEFORE the env-inject middleware replaces shared fields)
  *   2. env-inject                (`Object.assign(c.env, env)` — preserves
  *      `c.env.incoming` so the Node adapter's `getConnInfo` keeps working)
- *   3. sentry 5xx response capture (for inner-catch returns that never throw)
- *   4. `app.onError` for thrown exceptions
+ *   3. request logger             (covers both `/lobu` and the main app)
+ *   4. sentry 5xx response capture (for inner-catch returns that never throw)
+ *   5. `app.onError` for thrown exceptions
  *
  * Route mounts:
  *   - `/lobu` → `lobuApp` (only when non-null)
@@ -183,7 +185,12 @@ export function buildWrapperApp(
 		return next();
 	});
 
-	// 3. Server-error capture. Two layers cover both shapes of failing route:
+	// 3. Request logging belongs on the wrapper because `/lobu` and the main app
+	// are sibling mounts. Putting it inside only one child silently drops the
+	// other child's requests from the access log.
+	wrapper.use("*", pinoLogger({ pino: logger }));
+
+	// 4. Server-error capture. Two layers cover both shapes of failing route:
 	//   (a) routes that throw — handled by `app.onError` below.
 	//   (b) routes that try/catch internally and `return c.json(..., 500)` —
 	//       the framework never sees the exception, so onError doesn't fire.


### PR DESCRIPTION
## What changed

- move the Hono request logger to the outer wrapper so both `/lobu` and `/` mounts are covered exactly once
- emit a safe warning when app-webhook signature verification fails
- inject the route logger for deterministic tests without exposing request bodies, signatures, or secrets
- add regressions for `/lobu` access logging and forged Slack signature warnings

## Root cause

The Pino middleware lived only on `mainApp`, while `/lobu` is a sibling app mounted by `buildWrapperApp`. Requests handled by that mount bypassed access logging, and the invalid-signature branch returned 401 without a route warning.

## Validation

- red: 2 targeted failures, 27 passing
- green: 29/29 targeted tests passing
- rebased targeted rerun: 29/29 passing
- server typecheck passed
- `make build-packages` passed
- `make review`: typecheck=0, unit=0, integration=0; 0 bugs, 0 blockers

Closes #1810

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786303825&installation_id=136316292&pr_number=1841&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1841&signature=22f1a047d1958d994911d9c6cd0976fe37d18d1a19b5a96ceb7aaeff0c234d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Standardized request logging across application routes, including mounted `/lobu` endpoints.
  * Improved logging for app-webhook delivery events, including invalid signatures, missing configuration, processing failures, and delivery outcomes.

* **Bug Fixes**
  * Webhook requests with forged signatures are rejected with HTTP 401 before reaching delivery handlers.
  * Webhook-related failures now provide clearer diagnostic log details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->