### PR TITLE
fix(review): select cross-harness reviewer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help:
 	@echo "  make task-clean NAME=<name> [FORCE=1]      - Remove the worktree, both branches, and the Lobu context (refuses if there's uncommitted/unpushed work unless FORCE=1)"
 	@echo "  make e2e-browser [RESTART=1]               - Launch/reuse the stable 'owletto' Chrome harness (extension from this worktree) for Chrome e2e"
 	@echo "  make bump SUBMODULE=<path> [TARGET=<ref>]  - Lightweight worktree + commit + PR for a trivial submodule pointer bump (skips bun install, .env, ports)"
-	@echo "  make review [BASE=<branch>]                - Run local review (typecheck+unit+integration + Claude); posts pi-review status and PR comment"
+	@echo "  make review [BASE=<branch>]                - Run local review (typecheck+unit+integration + cross-harness reviewer); posts pi-review status and PR comment"
 	@echo "  make owletto-mac [INSTALL=1] [OPEN=1]      - Build Owletto.app with the Developer ID identity (TCC grants match the notarized release); INSTALL=1 replaces /Applications/Owletto.app, OPEN=1 launches it"
 	@echo "  make owletto-mac-e2e [SKIP_BUILD=1]        - Build/install the signed Owletto.app then probe prod computer_use (permissions + list_windows) via the paired device connection"
 
@@ -277,9 +277,11 @@ clean-test-pg:
 	@echo "✅ Test-PG clusters + dirs reaped"
 
 # --- Local AI review gate ---------------------------------------------------
-# Local-only: runs the deterministic suites in cwd, then invokes Claude CLI against
-# `git diff <BASE>...HEAD` (BASE defaults to main; override with BASE=<branch>
-# env or `--base <branch>` arg). Prints a JSON verdict on the last line. If
+# Local-only: runs the deterministic suites in cwd, then invokes the reviewer
+# from the model family opposite the current harness against
+# `git diff <BASE>...HEAD` (BASE defaults to origin/main when available;
+# override with BASE=<branch> env or `--base <branch>` arg). Prints a JSON
+# verdict on the last line. If
 # GitHub auth is available, posts a pi-review commit status; if the current
 # branch has an open PR, also posts/updates a PR comment. See docs/REVIEW_SCHEMA.md.
 

--- a/docs/REVIEW_SCHEMA.md
+++ b/docs/REVIEW_SCHEMA.md
@@ -2,9 +2,13 @@
 
 After making changes on a feature branch, the agent runs `make review`
 locally. `scripts/review.sh` drives the deterministic test suites in cwd,
-invokes `pi` against `git diff <base>...HEAD` (base defaults to `main`,
-override with `BASE=<branch>` or `--base <branch>`), and prints a JSON
-verdict matching this schema. The script posts a `pi-review` commit status
+invokes an independent CLI reviewer against `git diff <base>...HEAD` (base
+defaults to `origin/main` when available, override with `BASE=<branch>` or
+`--base <branch>`), and prints a JSON verdict matching this schema. Codex
+harnesses use Claude; other environments, including Claude Code, use Codex.
+Set `REVIEWER_CLI=codex|claude` to override automatic selection. The script
+also accepts `CLAUDE_REVIEW_MODEL`, `CLAUDE_REVIEW_EFFORT`, and
+`CODEX_REVIEW_MODEL` overrides. It posts a `pi-review` commit status
 whenever GitHub auth is available; if a PR exists for the current branch, it
 also posts an idempotent PR comment (marker-keyed upsert) with the verdict.
 **GitHub Actions does not run review** — it's a local-driven gate owned by
@@ -209,9 +213,9 @@ exceptions, use an explicit env override or admin merge.
 Specific actionable suggestions. Each object has `file`, `line`, `change`.
 Empty array if none.
 
-These are read by the local Claude Code agent and applied between review
-iterations — not by pi itself. Be specific (file path + line + concrete
-change). Vibe suggestions ("consider refactoring", "this could be cleaner")
+These are read by the local coding agent and applied between review
+iterations — not by the reviewer itself. Be specific (file path + line +
+concrete change). Vibe suggestions ("consider refactoring", "this could be cleaner")
 don't belong here — the agent can't act on them; surface those as `notes`
 instead.
 
@@ -247,8 +251,8 @@ nuanced gates later.
 ## Local gate flow
 
 Today's flow: agent finishes a change → opens a PR → runs `make review` from
-the branch's worktree → pi reviews and prints the JSON verdict → the script
-posts/updates the `pi-review` commit status and PR comment. Branch protection
-can require `pi-review`, so a new commit remains unmergeable until the local
+the branch's worktree → the cross-harness reviewer prints the JSON verdict →
+the script posts/updates the `pi-review` commit status and PR comment. Branch
+protection can require `pi-review`, so a new commit remains unmergeable until the local
 review runs and passes for that exact SHA. Human/admin merge remains the
 explicit escape hatch for intentional exceptions.

--- a/prompts/review-output-schema.json
+++ b/prompts/review-output-schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "description": "Lobu merge-review verdict. Judge the diff against the requested base and report concrete changed-path defects only.",
+  "additionalProperties": false,
+  "required": [
+    "bug_free_confidence",
+    "bugs",
+    "slop",
+    "simplicity",
+    "blockers",
+    "change_type",
+    "behavior_change_risk",
+    "tests_adequate",
+    "suggested_fixes",
+    "notes",
+    "categories"
+  ],
+  "properties": {
+    "bug_free_confidence": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100,
+      "description": "Confidence that the diff is bug-free; 90 or more requires strong verification."
+    },
+    "bugs": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Count of concrete defects caused by the diff."
+    },
+    "slop": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100,
+      "description": "Amount of unnecessary or generated waste; lower is better."
+    },
+    "simplicity": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100,
+      "description": "How simple and maintainable the change is; higher is better."
+    },
+    "blockers": {
+      "type": "array",
+      "description": "Merge-blocking defects caused by the diff.",
+      "items": { "type": "string" }
+    },
+    "change_type": {
+      "type": "string",
+      "enum": ["feat", "fix", "refactor", "docs", "chore", "test", "deps"]
+    },
+    "behavior_change_risk": {
+      "type": "string",
+      "enum": ["none", "low", "medium", "high"]
+    },
+    "tests_adequate": {
+      "type": "boolean",
+      "description": "Whether changed behavior has adequate automated coverage."
+    },
+    "suggested_fixes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["file", "line", "change"],
+        "properties": {
+          "file": { "type": "string" },
+          "line": { "type": ["integer", "null"], "minimum": 1 },
+          "change": { "type": "string" }
+        }
+      }
+    },
+    "notes": {
+      "type": "string",
+      "description": "Concise review summary, including any non-blocking or environmental observations."
+    },
+    "categories": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "src",
+        "tests",
+        "docs",
+        "config",
+        "deps",
+        "migrations",
+        "ci",
+        "generated"
+      ],
+      "properties": {
+        "src": { "type": "integer", "minimum": 0 },
+        "tests": { "type": "integer", "minimum": 0 },
+        "docs": { "type": "integer", "minimum": 0 },
+        "config": { "type": "integer", "minimum": 0 },
+        "deps": { "type": "integer", "minimum": 0 },
+        "migrations": { "type": "integer", "minimum": 0 },
+        "ci": { "type": "integer", "minimum": 0 },
+        "generated": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/prompts/review-prompt.md
+++ b/prompts/review-prompt.md
@@ -206,7 +206,7 @@ attributable to the diff. Style nits and naming preferences don't count.
 
 ### Suggested fixes
 
-Suggested fixes are read by the local Claude Code agent and applied between
+Suggested fixes are read by the local coding agent and applied between
 review iterations — not by the review subprocess itself. Be specific (file path + line number +
 concrete change). Don't include vibe suggestions like "consider refactoring
 this" or "this could be cleaner" — the agent can't act on those. If you

--- a/scripts/lib/__tests__/review-reviewer.test.sh
+++ b/scripts/lib/__tests__/review-reviewer.test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+# shellcheck source=scripts/lib/review-reviewer.sh
+. "$repo_root/scripts/lib/review-reviewer.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_auto_selected() {
+  local expected="$1"
+  shift
+  local actual
+  actual="$(
+    unset CODEX_THREAD_ID CODEX_MANAGED_PACKAGE_ROOT CODEX_CI
+    while [ $# -gt 0 ]; do
+      export "${1?}"
+      shift
+    done
+    review_select_reviewer auto
+  )"
+  [ "$actual" = "$expected" ] || fail "expected $expected, selected $actual"
+}
+
+assert_auto_selected codex
+assert_auto_selected claude CODEX_THREAD_ID=thread-1
+assert_auto_selected claude CODEX_MANAGED_PACKAGE_ROOT=/tmp/codex
+assert_auto_selected claude CODEX_CI=1
+assert_auto_selected codex CODEX_CI=0
+
+[ "$(CODEX_THREAD_ID=thread-1 review_select_reviewer codex)" = "codex" ] ||
+  fail "codex override was not honored"
+[ "$(review_select_reviewer claude)" = "claude" ] ||
+  fail "claude override was not honored"
+
+if review_select_reviewer invalid >/dev/null 2>&1; then
+  fail "invalid reviewer override unexpectedly succeeded"
+fi
+
+review_should_retry_inline 0 "" || fail "empty successful output did not request an inline retry"
+review_should_retry_inline 0 $' \n\t' || fail "whitespace-only successful output did not request an inline retry"
+if review_should_retry_inline 0 '{"ok":true}'; then
+  fail "non-empty successful output requested an inline retry"
+fi
+if review_should_retry_inline 1 ""; then
+  fail "failed reviewer requested an inline retry"
+fi
+
+failure_message="$(review_fail_closed_message codex "command not found on PATH")"
+case "$failure_message" in
+  *"Independent review could not be completed by 'codex'"*) ;;
+  *) fail "fail-closed message does not name the selected reviewer" ;;
+esac
+case "$failure_message" in
+  *"fails closed"*"will not fall back"*) ;;
+  *) fail "fail-closed message does not explain fallback policy" ;;
+esac
+case "$failure_message" in
+  *"REVIEWER_CLI=claude|codex"*) ;;
+  *) fail "fail-closed message does not explain the explicit override" ;;
+esac
+
+review_script="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/review.sh"
+schema_arg_count="$(grep -F -- '--json-schema "$(cat "$SCHEMA_FILE")"' "$review_script" | wc -l | tr -d ' ')"
+[ "$schema_arg_count" -eq 2 ] ||
+  fail "Claude reviewer must receive the verdict schema inline and in Herdr"
+
+grep -Fq '2> "$diagnostic_file"' "$review_script" ||
+  fail "inline Codex reviewer stderr must be retained for fail-closed diagnostics"
+
+echo "review reviewer selection tests passed"

--- a/scripts/lib/review-process.sh
+++ b/scripts/lib/review-process.sh
@@ -6,6 +6,7 @@ REVIEW_ACTIVE_CHILD_PID=""
 REVIEW_ACTIVE_CONTROL_DIR=""
 REVIEW_PREVIOUS_BACKGROUND_PID=""
 REVIEW_INLINE_RAW_FILE=""
+REVIEW_INLINE_DIAGNOSTIC_FILE=""
 
 review_process_control_root() {
   if [ -n "${REVIEW_PROCESS_CONTROL_ROOT_FOR_TESTS:-}" ]; then
@@ -137,5 +138,11 @@ review_process_abort_inline() {
   else
     rm -f "${REVIEW_INLINE_RAW_FILE:-}"
   fi
+  if [ -n "$REVIEW_INLINE_DIAGNOSTIC_FILE" ] && [ -s "$REVIEW_INLINE_DIAGNOSTIC_FILE" ]; then
+    echo ">> interrupted inline reviewer diagnostics preserved at $REVIEW_INLINE_DIAGNOSTIC_FILE" >&2
+  else
+    rm -f "${REVIEW_INLINE_DIAGNOSTIC_FILE:-}"
+  fi
   REVIEW_INLINE_RAW_FILE=""
+  REVIEW_INLINE_DIAGNOSTIC_FILE=""
 }

--- a/scripts/lib/review-reviewer.sh
+++ b/scripts/lib/review-reviewer.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+review_is_codex_harness() {
+  [ -n "${CODEX_THREAD_ID:-}" ] ||
+    [ -n "${CODEX_MANAGED_PACKAGE_ROOT:-}" ] ||
+    [ "${CODEX_CI:-}" = "1" ]
+}
+
+review_select_reviewer() {
+  case "$1" in
+    auto)
+      if review_is_codex_harness; then
+        printf 'claude\n'
+      else
+        printf 'codex\n'
+      fi
+      ;;
+    codex|claude)
+      printf '%s\n' "$1"
+      ;;
+    *)
+      echo "invalid REVIEWER_CLI=$1 (expected auto, codex, or claude)" >&2
+      return 2
+      ;;
+  esac
+}
+
+review_should_retry_inline() {
+  [ "$1" -eq 0 ] || return 1
+  [ -z "$(printf '%s' "$2" | tr -d '[:space:]')" ]
+}
+
+review_fail_closed_message() {
+  local reviewer="$1"
+  local detail="$2"
+  printf "Independent review could not be completed by '%s': %s. The review gate fails closed and will not fall back to another reviewer. Fix the selected reviewer's installation, authentication, quota, or configuration, then rerun; use REVIEWER_CLI=claude|codex only to explicitly select the intended independent reviewer.\n" \
+    "$reviewer" "$detail"
+}

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Local review runner: typecheck + unit + integration in cwd, then Claude CLI
-# with the diff against the base branch. Prints a JSON verdict on the last line.
+# Local review runner: typecheck + unit + integration in cwd, then an independent
+# CLI reviewer with the diff against the base branch. Prints a JSON verdict on
+# the last line.
 #
 # Usage:
 #   ./scripts/review.sh                 # base = origin/main when available
@@ -16,10 +17,10 @@
 # available, so branch protection can require the local agent review.
 # If there's no PR, the verdict still prints locally.
 #
-# Auth: uses the operator's Claude CLI auth for the local review verdict, and
+# Reviewer selection: Codex harnesses run Claude, while other environments
+# (including Claude Code) run Codex. Override with REVIEWER_CLI=codex|claude.
+# Auth uses the operator's selected CLI auth for the local review verdict, and
 # `gh auth token` for GitHub (optional — missing auth just skips posting).
-# Do not route the verdict through Codex/OpenAI providers here: the gate should
-# work from Codex sessions even when Codex provider quota is exhausted.
 # Commit statuses use the legacy Statuses API because `gh api check-runs`
 # requires GitHub App auth, and a user PAT cannot create check-runs.
 
@@ -34,10 +35,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/lib/review-process.sh"
 # shellcheck source=scripts/lib/herdr-review-lifecycle.sh
 . "$SCRIPT_DIR/lib/herdr-review-lifecycle.sh"
+# shellcheck source=scripts/lib/review-reviewer.sh
+. "$SCRIPT_DIR/lib/review-reviewer.sh"
 
 # --- preflight --------------------------------------------------------------
 
-for cmd in claude jq git node perl python3; do
+for cmd in jq git node perl python3; do
   command -v "$cmd" >/dev/null 2>&1 || { echo "$cmd not found on PATH." >&2; exit 2; }
 done
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "Not inside a git work tree." >&2; exit 2; }
@@ -62,10 +65,13 @@ else
 fi
 CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-opus}"
 CLAUDE_REVIEW_EFFORT="${CLAUDE_REVIEW_EFFORT:-high}"
+CODEX_REVIEW_MODEL="${CODEX_REVIEW_MODEL:-}"
+REVIEWER_CLI="${REVIEWER_CLI:-auto}"
 PI_REVIEW_STATUS_CONTEXT="${PI_REVIEW_STATUS_CONTEXT:-pi-review}"
 PI_REVIEW_MIN_BUG_FREE="${PI_REVIEW_MIN_BUG_FREE:-80}"
 PI_REVIEW_MAX_SLOP="${PI_REVIEW_MAX_SLOP:-15}"
 PI_REVIEW_MIN_SIMPLICITY="${PI_REVIEW_MIN_SIMPLICITY:-70}"
+# Existing Herdr control applies to either selected reviewer.
 CLAUDE_REVIEW_HERDR="${CLAUDE_REVIEW_HERDR:-auto}"
 REVIEW_DATABASE_URL="${REVIEW_DATABASE_URL:-}"
 while [ $# -gt 0 ]; do
@@ -74,6 +80,12 @@ while [ $# -gt 0 ]; do
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
+
+REVIEWER_CLI_SELECTED="$(review_select_reviewer "$REVIEWER_CLI")"
+command -v "$REVIEWER_CLI_SELECTED" >/dev/null 2>&1 || {
+  review_fail_closed_message "$REVIEWER_CLI_SELECTED" "command not found on PATH" >&2
+  exit 2
+}
 
 HEAD_SHA="$(git rev-parse HEAD)"
 MERGE_BASE="$(git merge-base HEAD "$BASE_BRANCH" 2>/dev/null || true)"
@@ -85,6 +97,7 @@ fi
 echo ">> cwd:  $(pwd)"
 echo ">> base: $BASE_BRANCH (merge-base $MERGE_BASE)"
 echo ">> head: $HEAD_SHA"
+echo ">> reviewer: $REVIEWER_CLI_SELECTED"
 
 post_review_status() {
   [ "$GH_AVAILABLE" = "1" ] || return 0
@@ -112,69 +125,123 @@ finalize_review_status() {
   REVIEW_STATUS_FINALIZED=1
 }
 
-run_claude_review_inline() {
+run_reviewer_inline() {
   local prompt_file="$1"
-  local raw_file
-  raw_file="$(mktemp /tmp/lobu-review-claude-inline.XXXXXX)"
+  local raw_file diagnostic_file
+  raw_file="$(mktemp /tmp/lobu-review-"${REVIEWER_CLI_SELECTED}"-inline.XXXXXX)"
+  diagnostic_file="${raw_file}.stderr"
   REVIEW_INLINE_RAW_FILE="$raw_file"
+  REVIEW_INLINE_DIAGNOSTIC_FILE="$diagnostic_file"
   set +e
-  run_review_child env \
-    BASE_BRANCH="$BASE_BRANCH" \
-    HEAD_SHA="$HEAD_SHA" \
-    TYPECHECK_LOG="$TYPECHECK_LOG" TYPECHECK_EXIT="$TYPECHECK_EXIT" \
-    UNIT_LOG="$UNIT_LOG" UNIT_EXIT="$UNIT_EXIT" \
-    INTEGRATION_LOG="$INTEGRATION_LOG" INTEGRATION_EXIT="$INTEGRATION_EXIT" \
-    DATABASE_URL="${DATABASE_URL:-}" \
-    claude -p "$(cat "$prompt_file")" \
-      --model "$CLAUDE_REVIEW_MODEL" \
-      --effort "$CLAUDE_REVIEW_EFFORT" \
-      --output-format text \
-      --no-session-persistence \
-      --tools Bash,Read,Grep,LS \
-      --permission-mode bypassPermissions < /dev/null > "$raw_file"
-  CLAUDE_EXIT=$?
+  case "$REVIEWER_CLI_SELECTED" in
+    claude)
+      run_review_child env \
+        BASE_BRANCH="$BASE_BRANCH" \
+        HEAD_SHA="$HEAD_SHA" \
+        TYPECHECK_LOG="$TYPECHECK_LOG" TYPECHECK_EXIT="$TYPECHECK_EXIT" \
+        UNIT_LOG="$UNIT_LOG" UNIT_EXIT="$UNIT_EXIT" \
+        INTEGRATION_LOG="$INTEGRATION_LOG" INTEGRATION_EXIT="$INTEGRATION_EXIT" \
+        DATABASE_URL="${DATABASE_URL:-}" \
+        claude -p "$(cat "$prompt_file")" \
+          --model "$CLAUDE_REVIEW_MODEL" \
+          --effort "$CLAUDE_REVIEW_EFFORT" \
+          --json-schema "$(cat "$SCHEMA_FILE")" \
+          --output-format text \
+          --no-session-persistence \
+          --tools Bash,Read,Grep,LS \
+          --permission-mode bypassPermissions < /dev/null > "$raw_file"
+      ;;
+    codex)
+      # The review subcommand cannot combine --base with the Lobu prompt. Use
+      # structured exec so deterministic test results remain part of the gate.
+      local codex_args=(
+        codex exec
+        --sandbox read-only
+        --output-schema "$SCHEMA_FILE"
+        --output-last-message "$raw_file"
+        --ephemeral
+      )
+      if [ -n "$CODEX_REVIEW_MODEL" ]; then
+        codex_args+=(--model "$CODEX_REVIEW_MODEL")
+      fi
+      run_review_child env \
+        BASE_BRANCH="$BASE_BRANCH" \
+        HEAD_SHA="$HEAD_SHA" \
+        TYPECHECK_LOG="$TYPECHECK_LOG" TYPECHECK_EXIT="$TYPECHECK_EXIT" \
+        UNIT_LOG="$UNIT_LOG" UNIT_EXIT="$UNIT_EXIT" \
+        INTEGRATION_LOG="$INTEGRATION_LOG" INTEGRATION_EXIT="$INTEGRATION_EXIT" \
+        DATABASE_URL="${DATABASE_URL:-}" \
+        "${codex_args[@]}" "$(cat "$prompt_file")" < /dev/null > /dev/null 2> "$diagnostic_file"
+      ;;
+  esac
+  REVIEWER_EXIT=$?
   set -e
   RAW="$(cat "$raw_file" 2>/dev/null || true)"
-  rm -f "$raw_file"
+  if [ "$REVIEWER_EXIT" -ne 0 ] && [ -s "$diagnostic_file" ]; then
+    RAW="${RAW}${RAW:+$'\n'}$(cat "$diagnostic_file")"
+  fi
+  rm -f "$raw_file" "$diagnostic_file"
   REVIEW_INLINE_RAW_FILE=""
+  REVIEW_INLINE_DIAGNOSTIC_FILE=""
 }
 
-run_claude_review_herdr() {
+run_reviewer_herdr() {
   local prompt_file="$1"
   local raw_file exit_file runner_file pane_name before_tabs tab_json tab_id pane_id started
-  raw_file="$(mktemp /tmp/lobu-review-claude-raw.XXXXXX)"
-  exit_file="$(mktemp /tmp/lobu-review-claude-exit.XXXXXX)"
-  runner_file="$(mktemp /tmp/lobu-review-claude-runner.XXXXXX)"
+  raw_file="$(mktemp /tmp/lobu-review-"${REVIEWER_CLI_SELECTED}"-raw.XXXXXX)"
+  exit_file="$(mktemp /tmp/lobu-review-"${REVIEWER_CLI_SELECTED}"-exit.XXXXXX)"
+  runner_file="$(mktemp /tmp/lobu-review-"${REVIEWER_CLI_SELECTED}"-runner.XXXXXX)"
   rm -f "$exit_file"
   herdr_review_track_files "$raw_file" "$exit_file" "$runner_file"
-  pane_name="claude-review-${HEAD_SHA:0:8}-$$"
+  pane_name="${REVIEWER_CLI_SELECTED}-review-${HEAD_SHA:0:8}-$$"
 
   if ! before_tabs="$(herdr_review_snapshot_tabs "$HERDR_WORKSPACE_ID")"; then
     rm -f "$raw_file" "$exit_file" "$runner_file"
     herdr_review_forget_files
-    echo ">> could not snapshot Herdr tabs; running Claude inline" >&2
-    run_claude_review_inline "$prompt_file"
+    echo ">> could not snapshot Herdr tabs; running $REVIEWER_CLI_SELECTED inline" >&2
+    run_reviewer_inline "$prompt_file"
     return
   fi
   herdr_review_track_locator "$HERDR_WORKSPACE_ID" "$pane_name" "$PWD" "$before_tabs"
 
   cat > "$runner_file" <<'RUNNER'
 set +e
-claude -p "$(cat "$PROMPT_FILE")" \
-  --model "$CLAUDE_REVIEW_MODEL" \
-  --effort "$CLAUDE_REVIEW_EFFORT" \
-  --output-format text \
-  --no-session-persistence \
-  --tools Bash,Read,Grep,LS \
-  --permission-mode bypassPermissions < /dev/null | tee "$RAW_FILE"
-claude_exit=${PIPESTATUS[0]}
+case "$REVIEWER_CLI_SELECTED" in
+  claude)
+    claude -p "$(cat "$PROMPT_FILE")" \
+      --model "$CLAUDE_REVIEW_MODEL" \
+      --effort "$CLAUDE_REVIEW_EFFORT" \
+      --json-schema "$(cat "$SCHEMA_FILE")" \
+      --output-format text \
+      --no-session-persistence \
+      --tools Bash,Read,Grep,LS \
+      --permission-mode bypassPermissions < /dev/null | tee "$RAW_FILE"
+    reviewer_exit=${PIPESTATUS[0]}
+    ;;
+  codex)
+    # Keep this command aligned with the inline path above. The Lobu prompt is
+    # required because it connects deterministic suite exits to the verdict.
+    codex_args=(
+      codex exec
+      --sandbox read-only
+      --output-schema "$SCHEMA_FILE"
+      --output-last-message "$RAW_FILE"
+      --ephemeral
+    )
+    if [ -n "$CODEX_REVIEW_MODEL" ]; then
+      codex_args+=(--model "$CODEX_REVIEW_MODEL")
+    fi
+    "${codex_args[@]}" "$(cat "$PROMPT_FILE")" < /dev/null
+    reviewer_exit=$?
+    ;;
+esac
 exit_tmp="${EXIT_FILE}.tmp.$$"
-printf "%s\n" "$claude_exit" > "$exit_tmp"
+printf "%s\n" "$reviewer_exit" > "$exit_tmp"
 mv "$exit_tmp" "$EXIT_FILE"
-exit "$claude_exit"
+exit "$reviewer_exit"
 RUNNER
 
-  echo ">> spawning Herdr tab '$pane_name' for Claude review"
+  echo ">> spawning Herdr tab '$pane_name' for $REVIEWER_CLI_SELECTED review"
   set +e
   tab_json="$(
     herdr tab create \
@@ -194,9 +261,12 @@ RUNNER
       --env "INTEGRATION_LOG=$INTEGRATION_LOG" \
       --env "INTEGRATION_EXIT=$INTEGRATION_EXIT" \
       --env "DATABASE_URL=${DATABASE_URL:-}" \
+      --env "REVIEWER_CLI_SELECTED=$REVIEWER_CLI_SELECTED" \
       --env "CLAUDE_REVIEW_MODEL=$CLAUDE_REVIEW_MODEL" \
       --env "CLAUDE_REVIEW_EFFORT=$CLAUDE_REVIEW_EFFORT" \
+      --env "CODEX_REVIEW_MODEL=$CODEX_REVIEW_MODEL" \
       --env "PROMPT_FILE=$prompt_file" \
+      --env "SCHEMA_FILE=$SCHEMA_FILE" \
       --env "RAW_FILE=$raw_file" \
       --env "EXIT_FILE=$exit_file" 2>&1
   )"
@@ -225,13 +295,13 @@ RUNNER
       echo ">> Herdr tab creation state is ambiguous; refusing inline fallback" >&2
       return 1
     fi
-    echo ">> Herdr Claude tab failed to start; falling back to inline Claude" >&2
+    echo ">> Herdr $REVIEWER_CLI_SELECTED tab failed to start; falling back to inline $REVIEWER_CLI_SELECTED" >&2
     printf '%s\n' "$started" >&2
-    run_claude_review_inline "$prompt_file"
+    run_reviewer_inline "$prompt_file"
     return
   fi
 
-  echo ">> Claude review is visible in Herdr tab '$pane_name'"
+  echo ">> $REVIEWER_CLI_SELECTED review is visible in Herdr tab '$pane_name'"
   local waited=0
   while [ ! -f "$exit_file" ]; do
     sleep 2
@@ -241,34 +311,38 @@ RUNNER
       # into RAW before deleting the transport files.
       if ! herdr_review_close_tab; then
         RAW="$(cat "$raw_file" 2>/dev/null || true)"
-        CLAUDE_EXIT=124
-        echo ">> Claude review tab timed out and could not be closed" >&2
+        REVIEWER_EXIT=124
+        echo ">> $REVIEWER_CLI_SELECTED review tab timed out and could not be closed" >&2
         return 1
       fi
       RAW="$(cat "$raw_file" 2>/dev/null || true)"
-      CLAUDE_EXIT=124
+      REVIEWER_EXIT=124
       herdr_review_cleanup
-      echo ">> Claude review tab timed out after ${waited}s" >&2
+      echo ">> $REVIEWER_CLI_SELECTED review tab timed out after ${waited}s" >&2
       return
     fi
   done
 
   RAW="$(cat "$raw_file" 2>/dev/null || true)"
-  CLAUDE_EXIT="$(cat "$exit_file" 2>/dev/null || echo 1)"
+  REVIEWER_EXIT="$(cat "$exit_file" 2>/dev/null || echo 1)"
   herdr_review_cleanup
+  if review_should_retry_inline "$REVIEWER_EXIT" "$RAW"; then
+    echo ">> $REVIEWER_CLI_SELECTED review returned empty output; retrying once inline" >&2
+    run_reviewer_inline "$prompt_file"
+  fi
 }
 
-run_claude_review() {
+run_reviewer() {
   local prompt_file="$1"
   if [ "$CLAUDE_REVIEW_HERDR" != "0" ] &&
      [ -n "${HERDR_WORKSPACE_ID:-}" ] &&
      command -v herdr >/dev/null 2>&1; then
-    run_claude_review_herdr "$prompt_file"
+    run_reviewer_herdr "$prompt_file"
   else
     if [ "$CLAUDE_REVIEW_HERDR" = "1" ]; then
-      echo ">> CLAUDE_REVIEW_HERDR=1 but no Herdr workspace is available; running inline" >&2
+      echo ">> CLAUDE_REVIEW_HERDR=1 but no Herdr workspace is available; running $REVIEWER_CLI_SELECTED inline" >&2
     fi
-    run_claude_review_inline "$prompt_file"
+    run_reviewer_inline "$prompt_file"
   fi
 }
 
@@ -364,7 +438,7 @@ review_exit_cleanup() {
     post_failure_status=1
   fi
   if [ "$post_failure_status" = "1" ]; then
-    post_review_status error "Claude review failed before verdict (exit $ec)"
+    post_review_status error "$REVIEWER_CLI_SELECTED review failed before verdict (exit $ec)"
   fi
   release_review_lock
   exit "$ec"
@@ -377,7 +451,7 @@ trap 'exit 129' HUP
 acquire_review_lock
 
 REVIEW_STATUS_STARTED=1
-post_review_status pending "Claude review running"
+post_review_status pending "$REVIEWER_CLI_SELECTED review running"
 
 # --- env --------------------------------------------------------------------
 
@@ -418,7 +492,7 @@ run_review_child make build-packages > "$BUILD_LOG" 2>&1
 BUILD_EXIT=$?
 set -e
 if [ $BUILD_EXIT -ne 0 ]; then
-  echo "!! build failed (exit $BUILD_EXIT) — proceeding so Claude can review the diff, but unit tests will likely fail" >&2
+  echo "!! build failed (exit $BUILD_EXIT) — proceeding so $REVIEWER_CLI_SELECTED can review the diff, but unit tests will likely fail" >&2
 fi
 
 # --- test suites ------------------------------------------------------------
@@ -461,6 +535,7 @@ run_review_unit_suites() {
   run_deterministic bash "$SCRIPT_DIR/lib/__tests__/review-lock.test.sh";               ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   run_deterministic bash "$SCRIPT_DIR/lib/__tests__/review-database-url.test.sh";        ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   run_deterministic bash "$SCRIPT_DIR/lib/__tests__/review-process.test.sh";             ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
+  run_deterministic bash "$SCRIPT_DIR/lib/__tests__/review-reviewer.test.sh";            ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
   # Shell lifecycle regressions: Herdr task/review tabs must be owned and
   # cleaned without invoking the real Herdr daemon.
   run_deterministic bash "$SCRIPT_DIR/lib/__tests__/herdr-lifecycle.test.sh";            ec=$?; [ $ec -gt $UNIT_EXIT ] && UNIT_EXIT=$ec
@@ -520,17 +595,19 @@ set -e
 
 echo ">> suite exit codes: typecheck=$TYPECHECK_EXIT unit=$UNIT_EXIT integration=$INTEGRATION_EXIT"
 
-# --- Claude review ----------------------------------------------------------
+# --- agent review -----------------------------------------------------------
 
 PROMPT_FILE="$(pwd)/prompts/review-prompt.md"
+SCHEMA_FILE="$(pwd)/prompts/review-output-schema.json"
 [ -f "$PROMPT_FILE" ] || { echo "prompt not found: $PROMPT_FILE" >&2; exit 2; }
+[ -f "$SCHEMA_FILE" ] || { echo "schema not found: $SCHEMA_FILE" >&2; exit 2; }
 
-echo ">> invoking Claude CLI (model: $CLAUDE_REVIEW_MODEL, effort: $CLAUDE_REVIEW_EFFORT)"
-CLAUDE_PROMPT_FILE="$(mktemp /tmp/lobu-review-prompt.XXXXXX)"
-herdr_review_track_prompt "$CLAUDE_PROMPT_FILE"
-cat "$PROMPT_FILE" > "$CLAUDE_PROMPT_FILE"
-printf '\n\nReview the diff. Emit only the JSON verdict.\n' >> "$CLAUDE_PROMPT_FILE"
-run_claude_review "$CLAUDE_PROMPT_FILE"
+echo ">> invoking $REVIEWER_CLI_SELECTED review"
+REVIEW_PROMPT_FILE="$(mktemp /tmp/lobu-review-prompt.XXXXXX)"
+herdr_review_track_prompt "$REVIEW_PROMPT_FILE"
+cat "$PROMPT_FILE" > "$REVIEW_PROMPT_FILE"
+printf '\n\nReview the diff. Emit only the JSON verdict.\n' >> "$REVIEW_PROMPT_FILE"
+run_reviewer "$REVIEW_PROMPT_FILE"
 herdr_review_release_prompt
 
 VERDICT="$RAW"
@@ -549,8 +626,13 @@ if ! echo "$VERDICT" | jq -e '
   (.notes | type == "string") and
   (.categories | type == "object")
 ' >/dev/null 2>&1; then
-  finalize_review_status error "Claude review did not produce a valid JSON verdict"
-  echo "Claude review did not produce a valid JSON verdict. claude exit=$CLAUDE_EXIT" >&2
+  if [ "$REVIEWER_EXIT" -ne 0 ]; then
+    REVIEW_FAILURE_DETAIL="reviewer process exited with status $REVIEWER_EXIT"
+  else
+    REVIEW_FAILURE_DETAIL="reviewer returned no schema-valid JSON verdict"
+  fi
+  finalize_review_status error "Independent $REVIEWER_CLI_SELECTED review could not be completed"
+  review_fail_closed_message "$REVIEWER_CLI_SELECTED" "$REVIEW_FAILURE_DETAIL" >&2
   echo "logs: $TYPECHECK_LOG $UNIT_LOG $INTEGRATION_LOG" >&2
   echo "raw output:" >&2
   printf '%s\n' "$RAW" >&2


### PR DESCRIPTION
## What changed

- select the reviewer from the opposite model family: Codex harnesses use Claude, other environments use Codex
- support explicit `REVIEWER_CLI=codex|claude` and model overrides
- fail closed when the selected reviewer is unavailable, exits nonzero, or produces no schema-valid verdict; never silently switch reviewers
- name the selected reviewer and remediation in the failure message
- pass the verdict schema to Claude in both inline and Herdr paths
- retain Codex stderr so auth, quota, flag, and configuration errors are shown in failure diagnostics
- preserve exact-owned Herdr run isolation and inline empty-output retry behavior

## Validation

- reviewer-selection, fail-closed messaging, schema wiring, process, lock, and Herdr lifecycle tests passed
- shell syntax checks passed
- full typecheck, unit, and integration suites passed
- Claude Fable structured review: bug-free 85, bugs 0, blockers 0, tests adequate

Closes #1835