### PR TITLE
fix(errors): consolidate the "no usable model" CTA across all surfaces

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,12 @@
       "import": "./dist/__tests__/fixtures/index.js",
       "require": "./dist/__tests__/fixtures/index.js"
     },
+    "./errors": {
+      "types": "./dist/errors.d.ts",
+      "bun": "./src/errors.ts",
+      "import": "./dist/errors.js",
+      "require": "./dist/errors.js"
+    },
     "./contracts/tools/manage-connections": {
       "types": "./dist/contracts/tools/manage-connections.d.ts",
       "bun": "./src/contracts/tools/manage-connections.ts",

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -197,7 +197,7 @@ export enum AgentErrorCode {
  * live in `core` with no gateway dependency.
  */
 export type AgentErrorCtaKind =
-  | "agent-settings" // → <webOrigin>/<slug>/agents/<agentId>
+  | "agent-settings" // → <webOrigin>/<slug>/agents/<agentId>/settings
   | "provider-connect" // → same settings page, provider-connect intent
   | "none";
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -235,8 +235,11 @@ export interface AgentErrorSpec {
 
 export const AGENT_ERRORS: Record<AgentErrorCode, AgentErrorSpec> = {
   // Provider errors — no `message`; the provider's own text is the body.
+  // Provider-level failures (quota, credentials, routing) are fixed on the
+  // connect-a-provider page → `provider-connect`. A model-level failure
+  // (unknown/unallowed model) is fixed on the agent's settings → `agent-settings`.
   [AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED]: {
-    cta: "agent-settings",
+    cta: "provider-connect",
     ctaLabel: "Manage provider",
   },
   [AgentErrorCode.PROVIDER_AUTH]: {
@@ -248,7 +251,7 @@ export const AGENT_ERRORS: Record<AgentErrorCode, AgentErrorSpec> = {
     ctaLabel: "Choose model",
   },
   [AgentErrorCode.PROVIDER_BASE_URL_UNRESOLVED]: {
-    cta: "agent-settings",
+    cta: "provider-connect",
     ctaLabel: "Connect provider",
   },
   // Errors we synthesize — carry our own text (no provider string to relay).

--- a/packages/server/src/gateway/__tests__/link-buttons.test.ts
+++ b/packages/server/src/gateway/__tests__/link-buttons.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { extractSettingsLinkButtons } from "../platform/link-buttons.js";
+import {
+  buildCtaCardPayload,
+  extractSettingsLinkButtons,
+} from "../platform/link-buttons.js";
 
 describe("extractSettingsLinkButtons", () => {
   test("extracts settings link and replaces with label", () => {
@@ -108,5 +111,49 @@ describe("extractSettingsLinkButtons", () => {
 
     expect(linkButtons).toHaveLength(1);
     expect(linkButtons[0]!.url).toBe("https://example.com/agent?claim=legacy");
+  });
+});
+
+describe("buildCtaCardPayload", () => {
+  // The shared seam that both the terminal-error bridge and the pre-enqueue
+  // preflight use so a CTA renders identically (native button) everywhere.
+  test("real URL → { card, fallbackText } with the URL in the fallback", () => {
+    const out = buildCtaCardPayload({
+      text: "No model configured.",
+      url: "https://app.lobu.ai/acme/agents/a1/settings",
+      label: "Choose a model",
+    });
+    expect(typeof out).toBe("object");
+    const obj = out as { card: unknown; fallbackText: string };
+    expect(obj.card).toBeDefined();
+    expect(obj.fallbackText).toBe(
+      "No model configured.\n\nChoose a model: https://app.lobu.ai/acme/agents/a1/settings"
+    );
+  });
+
+  test("no URL → plain text string (no card)", () => {
+    const out = buildCtaCardPayload({ text: "Try again in a moment." });
+    expect(out).toBe("Try again in a moment.");
+  });
+
+  test("loopback URL → text-only fallback (localhost can't be an inline button)", () => {
+    const out = buildCtaCardPayload({
+      text: "Connect a provider.",
+      url: "http://localhost:8787/acme/inference-providers/new",
+      label: "Connect a provider",
+    });
+    expect(typeof out).toBe("string");
+    expect(out).toBe(
+      "Connect a provider.\n\nConnect a provider: http://localhost:8787/acme/inference-providers/new"
+    );
+  });
+
+  test("default label when none supplied", () => {
+    const out = buildCtaCardPayload({
+      text: "x",
+      url: "https://app.lobu.ai/acme/agents/a1/settings",
+    });
+    const obj = out as { card: unknown; fallbackText: string };
+    expect(obj.fallbackText).toContain("Open settings: ");
   });
 });

--- a/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
+++ b/packages/server/src/gateway/__tests__/message-handler-bridge.test.ts
@@ -699,13 +699,15 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
 
     expect(enqueueMessage).not.toHaveBeenCalled();
     expect(thread.post).toHaveBeenCalledTimes(1);
+    // The preflight now emits its reason text + a provider-connect CTA through
+    // the shared buildCtaCardPayload path. With no WorkspaceProvider inited in
+    // this bun suite, the org slug can't resolve, so the CTA URL is null and the
+    // payload degrades to a plain text string (no card) — the fallback the
+    // helper guarantees. Assert the new copy; there's no setup URL to check.
     const posted = thread.post.mock.calls[0]?.[0];
     expect(typeof posted).toBe("string");
-    expect(posted).toContain("selected model (z-ai/glm-5.2)");
-    expect(posted).toContain("Open this setup link");
-    expect(posted).toContain("https://gateway.example.com/inference-providers/new");
-    expect(posted).toContain("provider=z-ai");
-    expect(posted).toContain("agentId=lobu-builder");
+    expect(posted).toContain("z-ai/glm-5.2");
+    expect(posted).toContain("isn't connected or has no credentials");
     expect(posted).not.toContain("api/proxy");
   });
 
@@ -823,13 +825,13 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
 
     await bridge.handleMessage(thread, makeMessage(), "mention");
 
-    // Ran on the listed alternate, did not post a setup-link error.
+    // Ran on the listed alternate, did not post a "can't run this yet" error.
     expect(enqueueMessage).toHaveBeenCalledTimes(1);
     const payload = enqueueMessage.mock.calls[0]?.[0] as any;
     expect(payload.agentOptions?.model).toBe("openai/gpt-4o-mini");
     expect(
       thread.post.mock.calls.every(
-        (c: unknown[]) => !String(c[0]).includes("Open this setup link"),
+        (c: unknown[]) => !String(c[0]).includes("I can't run this yet"),
       ),
     ).toBe(true);
   });
@@ -860,8 +862,10 @@ describe("MessageHandlerBridge.handleMessage — Slack Preview unlinked chat", (
 
     expect(enqueueMessage).not.toHaveBeenCalled();
     expect(thread.post).toHaveBeenCalledTimes(1);
+    // Model is allowed but its provider isn't routable → the new provider-connect
+    // reason copy (see the sibling test for why this degrades to a text string).
     expect(String(thread.post.mock.calls[0]?.[0])).toContain(
-      "Open this setup link",
+      "isn't connected or has no credentials",
     );
   });
 

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -19,6 +19,7 @@ import { Actions, Card, CardText, LinkButton } from "chat";
 import { getDb } from "../../db/client.js";
 import {
   buildAgentSettingsUrl,
+  buildProviderConnectUrl,
   type RenderedAgentError,
   renderAgentError,
 } from "../../utils/url-builder.js";
@@ -29,8 +30,8 @@ import {
 } from "../guardrails/output-scan.js";
 import type { ThreadResponsePayload } from "../infrastructure/queue/index.js";
 import {
+  buildCtaCardPayload,
   extractSettingsLinkButtons,
-  isLocalhostUrl,
 } from "../platform/link-buttons.js";
 import type { ResponseRenderer } from "../platform/response-renderer.js";
 import { captureChannelMessage } from "./channel-transcript.js";
@@ -559,16 +560,16 @@ export class ChatResponseBridge implements ResponseRenderer {
     const code = toAgentErrorCode(payload.errorCode);
     let ctaButton: RenderedAgentError | null = null;
     if (code) {
-      const rendered = await renderAgentError(
-        code,
-        payload.error,
-        () =>
-          buildAgentSettingsUrl(
-            this.manager.getPublicGatewayUrl(),
-            this.resolveOrganizationId(payload, ctx) ?? undefined,
-            this.resolveAgentId(payload, ctx) ?? undefined
-          )
-      );
+      const gatewayUrl = this.manager.getPublicGatewayUrl();
+      const orgId = this.resolveOrganizationId(payload, ctx) ?? undefined;
+      const agentId = this.resolveAgentId(payload, ctx) ?? undefined;
+      const rendered = await renderAgentError(code, payload.error, {
+        // "pick a model" → the agent's settings tab.
+        'agent-settings': () =>
+          buildAgentSettingsUrl(gatewayUrl, orgId, agentId),
+        // "connect a provider" → the org's connect-a-provider page.
+        'provider-connect': () => buildProviderConnectUrl(gatewayUrl, orgId),
+      });
       if (rendered.silent) return;
       // For provider errors `rendered.text` IS the provider's own message (we
       // relay it verbatim); for our synthesized errors it's the catalog line.
@@ -592,24 +593,18 @@ export class ChatResponseBridge implements ResponseRenderer {
     }
 
     // Coded error with a resolved CTA → post a Card with a native link button
-    // (same mechanism the ephemeral settings-link path uses) so the user gets a
-    // clickable action, not a bare URL in prose. Loopback URLs can't be
-    // rendered as inline buttons by some platforms, so fall through to text.
-    if (ctaButton?.ctaUrl && !isLocalhostUrl(ctaButton.ctaUrl)) {
-      const label = ctaButton.ctaLabel ?? "Open settings";
-      const card = Card({
-        children: [
-          CardText(ctaButton.text),
-          Actions([LinkButton({ url: ctaButton.ctaUrl, label })]),
-        ],
-      });
+    // (shared with the pre-enqueue preflight via buildCtaCardPayload) so the
+    // user gets a clickable action, not a bare URL in prose. Loopback URLs fall
+    // back to text inside the helper.
+    if (ctaButton?.ctaUrl) {
       await this.postToPayloadTarget(
         payload,
         ctx,
-        {
-          card,
-          fallbackText: `${ctaButton.text}\n\n${label}: ${ctaButton.ctaUrl}`,
-        },
+        buildCtaCardPayload({
+          text: ctaButton.text,
+          url: ctaButton.ctaUrl,
+          label: ctaButton.ctaLabel,
+        }),
         "Failed to send error card"
       );
       return;

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -20,7 +20,11 @@ import {
   resolveAgentOptions,
 } from "../services/platform-helpers.js";
 import { resolveSlackBotIdentity } from "../../authz/slack-acl-sync.js";
-import { getOrganizationSlug } from "../../utils/url-builder.js";
+import {
+  buildAgentSettingsUrl,
+  buildProviderConnectUrl,
+} from "../../utils/url-builder.js";
+import { buildCtaCardPayload } from "../platform/link-buttons.js";
 import { stripPlatformPrefix } from "../channels/bound-channels.js";
 import { captureChannelMessage } from "./channel-transcript.js";
 import { createSlackWebApi } from "./slack-web.js";
@@ -65,25 +69,6 @@ function parseProviderFromModelRef(modelRef: string): string | null {
 function webOriginFromGateway(publicGatewayUrl: string): string {
   const base = publicGatewayUrl.replace(/\/$/, "");
   return base.endsWith("/lobu") ? base.slice(0, -"/lobu".length) : base;
-}
-
-async function buildProviderSetupUrl(params: {
-  publicGatewayUrl: string;
-  organizationId?: string;
-  agentId: string;
-  providerId: string;
-  modelRef: string;
-  reason: string;
-}): Promise<string> {
-  const origin = webOriginFromGateway(params.publicGatewayUrl);
-  const orgSlug = await getOrganizationSlug(params.organizationId).catch(() => null);
-  const pathPrefix = orgSlug ? `/${encodeURIComponent(orgSlug)}` : "";
-  const url = new URL(`${pathPrefix}/inference-providers/new`, `${origin}/`);
-  url.searchParams.set("provider", params.providerId);
-  url.searchParams.set("model", params.modelRef);
-  url.searchParams.set("reason", params.reason);
-  url.searchParams.set("agentId", params.agentId);
-  return url.toString();
 }
 
 /**
@@ -131,7 +116,17 @@ async function providerIsRoutable(
 type ModelProviderResolution =
   | { kind: "ok" }
   | { kind: "fallback"; model: string; from: string; to: string }
-  | { kind: "error"; message: string };
+  // A pre-enqueue rejection: the specific reason text + a CTA kind. The caller
+  // resolves the kind to a URL and renders it through the SAME shared card path
+  // as the terminal-error bridge (native button, platform-agnostic) — never a
+  // URL inlined into prose.
+  | {
+      kind: "error";
+      text: string;
+      cta: "agent-settings" | "provider-connect";
+      provider: string;
+      model: string;
+    };
 
 /**
  * Preflight the model a message will run on. Order of outcomes:
@@ -213,23 +208,21 @@ async function validateMessageModelProvider(params: {
     }
   }
 
-  // Genuinely nothing usable — surface the setup link for the intended provider.
-  const setupUrl = await buildProviderSetupUrl({
-    publicGatewayUrl: params.services.getPublicGatewayUrl(),
-    organizationId,
-    providerId,
-    agentId: params.agentId,
-    modelRef,
-    reason: "model_provider_not_connected",
-  });
-  const reason = !refIsAllowed(modelRef)
-    ? `but that model isn't in this agent's allowed model list`
-    : `but its provider isn't connected or has no credentials`;
+  // Genuinely nothing usable. The two reasons take DIFFERENT fixes, so they map
+  // to different CTA kinds: a model that isn't in the agent's allow-list is
+  // fixed by picking an allowed one (agent-settings); a provider with no
+  // credentials/route is fixed by connecting it (provider-connect). The caller
+  // renders the text + CTA through the shared card path.
+  const modelNotAllowed = !refIsAllowed(modelRef);
+  const text = modelNotAllowed
+    ? `I can't run this yet: the model \`${modelRef}\` isn't in this agent's allowed model list. Pick an allowed model to continue.`
+    : `I can't run this yet: the provider for \`${modelRef}\` isn't connected or has no credentials. Connect it to continue.`;
   return {
     kind: "error",
-    message:
-      `I can't run this yet: the selected model (${modelRef}) ${reason}. ` +
-      `Open this setup link to connect a provider or pick an allowed model: ${setupUrl}`,
+    text,
+    cta: modelNotAllowed ? "agent-settings" : "provider-connect",
+    provider: providerId,
+    model: modelRef,
   };
 }
 
@@ -1048,7 +1041,28 @@ export class MessageHandlerBridge {
           { traceId, agentId, organizationId, model: agentOptions.model },
           "Rejecting inbound message before enqueue: no connected+routable model provider"
         );
-        await thread.post(modelResolution.message);
+        // Resolve the CTA kind to a URL and render through the SAME shared card
+        // path the terminal-error bridge uses — native button, platform-
+        // agnostic, no URL inlined in prose.
+        const gatewayUrl = this.services.getPublicGatewayUrl();
+        const ctaUrl =
+          modelResolution.cta === "provider-connect"
+            ? await buildProviderConnectUrl(gatewayUrl, organizationId, {
+                provider: modelResolution.provider,
+                model: modelResolution.model,
+              })
+            : await buildAgentSettingsUrl(gatewayUrl, organizationId, agentId);
+        const label =
+          modelResolution.cta === "provider-connect"
+            ? "Connect a provider"
+            : "Choose a model";
+        await thread.post(
+          buildCtaCardPayload({
+            text: modelResolution.text,
+            url: ctaUrl,
+            label,
+          })
+        );
         return;
       }
       if (modelResolution.kind === "fallback") {

--- a/packages/server/src/gateway/platform/link-buttons.ts
+++ b/packages/server/src/gateway/platform/link-buttons.ts
@@ -6,6 +6,8 @@
  * from the content so platforms can render native buttons instead.
  */
 
+import { Actions, Card, CardText, LinkButton } from "chat";
+
 const SETTINGS_LINK_RE =
   /\[([^\]]+)\]\((https?:\/\/[^)]*\/(?:connect\/claim|agent)\?claim=[^)]+)\)/g;
 
@@ -29,6 +31,39 @@ export function isLocalhostUrl(url: string): boolean {
 interface LinkButton {
   text: string;
   url: string;
+}
+
+/**
+ * Turn a rendered error/notice (`text` + optional CTA `url`/`label`) into the
+ * post payload a Chat SDK target accepts — a `{ card, fallbackText }` with a
+ * native link button when the URL is real, or a plain string otherwise. THE one
+ * place a CTA becomes a card, shared by the terminal-error bridge and the
+ * pre-enqueue model-provider preflight so both surfaces render identically
+ * (native button on Slack/Telegram/web, never a bare URL in prose).
+ *
+ * Falls back to text when there's no URL or it's a loopback address (some
+ * platforms reject localhost inline-button URLs) — the URL is appended so the
+ * action is still reachable.
+ */
+export function buildCtaCardPayload(args: {
+  text: string;
+  url?: string | null;
+  label?: string;
+}): { card: unknown; fallbackText: string } | string {
+  const { text } = args;
+  const label = args.label ?? "Open settings";
+  if (!args.url || isLocalhostUrl(args.url)) {
+    return args.url ? `${text}\n\n${label}: ${args.url}` : text;
+  }
+  return {
+    card: Card({
+      children: [
+        CardText(text),
+        Actions([LinkButton({ url: args.url, label })]),
+      ],
+    }),
+    fallbackText: `${text}\n\n${label}: ${args.url}`,
+  };
 }
 
 /**

--- a/packages/server/src/utils/__tests__/render-agent-error.test.ts
+++ b/packages/server/src/utils/__tests__/render-agent-error.test.ts
@@ -7,25 +7,36 @@
 
 import { describe, expect, it } from "vitest";
 import { AgentErrorCode } from "@lobu/core";
-import { renderAgentError } from "../url-builder";
+import { type AgentErrorCtaResolvers, renderAgentError } from "../url-builder";
 
-const SETTINGS_URL = "https://app.lobu.ai/acme/agents/agent-1";
-const resolveSettings = async () => SETTINGS_URL;
-const resolveNothing = async () => null;
+const SETTINGS_URL = "https://app.lobu.ai/acme/agents/agent-1/settings";
+const CONNECT_URL = "https://app.lobu.ai/acme/inference-providers/new";
+
+// Distinct resolvers per CTA kind, so a test can assert that a code routes to
+// the RIGHT page (pick-a-model vs connect-a-provider), not just "some url".
+const resolvers: AgentErrorCtaResolvers = {
+  "agent-settings": async () => SETTINGS_URL,
+  "provider-connect": async () => CONNECT_URL,
+};
+const resolveNothing: AgentErrorCtaResolvers = {
+  "agent-settings": async () => null,
+  "provider-connect": async () => null,
+};
 
 describe("renderAgentError", () => {
-  it("provider quota RELAYS the provider's own message verbatim + a settings CTA", async () => {
+  it("provider quota RELAYS the provider's own message verbatim + routes to the CONNECT page", async () => {
     // The provider's message already says when the quota resets — we relay it
-    // unchanged (no reset-time parsing, no reword) and only add the CTA link.
+    // unchanged (no reset-time parsing, no reword) and only add the CTA link. A
+    // quota/provider-level failure is fixed on the connect-a-provider page.
     const raw =
       "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47";
     const r = await renderAgentError(
       AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
       raw,
-      resolveSettings
+      resolvers
     );
     expect(r.text).toBe(raw);
-    expect(r.ctaUrl).toBe(SETTINGS_URL);
+    expect(r.ctaUrl).toBe(CONNECT_URL);
     expect(r.ctaLabel).toBe("Manage provider");
     expect(r.silent).toBe(false);
   });
@@ -34,21 +45,37 @@ describe("renderAgentError", () => {
     const r = await renderAgentError(
       AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED,
       undefined,
-      resolveSettings
+      resolvers
     );
     expect(r.text).toBe("");
-    expect(r.ctaUrl).toBe(SETTINGS_URL);
+    expect(r.ctaUrl).toBe(CONNECT_URL);
   });
 
-  it("auth failure relays the provider message + a reconnect CTA", async () => {
+  it("auth failure relays the provider message + routes to the CONNECT page (not settings)", async () => {
+    // PROVIDER_AUTH's cta kind is `provider-connect` — its fix is reconnecting
+    // credentials, so it must land on the connect-a-provider page, NOT the
+    // agent's model settings. This is the exact distinction the per-kind
+    // resolver exists for (both kinds used to collapse to one URL).
     const r = await renderAgentError(
       AgentErrorCode.PROVIDER_AUTH,
       'Authentication failed for "openai"',
-      resolveSettings
+      resolvers
     );
     expect(r.text).toBe('Authentication failed for "openai"');
-    expect(r.ctaUrl).toBe(SETTINGS_URL);
+    expect(r.ctaUrl).toBe(CONNECT_URL);
+    expect(r.ctaUrl).not.toBe(SETTINGS_URL);
     expect(r.ctaLabel).toBe("Reconnect provider");
+  });
+
+  it("NO_MODEL_CONFIGURED (agent-settings kind) routes to the SETTINGS page", async () => {
+    const r = await renderAgentError(
+      AgentErrorCode.NO_MODEL_CONFIGURED,
+      undefined,
+      resolvers
+    );
+    expect(r.text).toContain("No model");
+    expect(r.ctaUrl).toBe(SETTINGS_URL);
+    expect(r.ctaLabel).toBe("Connect a provider");
   });
 
   it("WORKER_UNRESPONSIVE uses OUR catalog text (no provider message) and NO CTA", async () => {
@@ -58,9 +85,11 @@ describe("renderAgentError", () => {
       // Even if a stray message is passed, a synthesized error prefers its own
       // catalog text.
       "some raw string",
-      async () => {
-        called = true;
-        return SETTINGS_URL;
+      {
+        "agent-settings": async () => {
+          called = true;
+          return SETTINGS_URL;
+        },
       }
     );
     expect(r.text.toLowerCase()).toContain("try again");
@@ -73,18 +102,27 @@ describe("renderAgentError", () => {
     const r = await renderAgentError(
       AgentErrorCode.SESSION_TIMEOUT,
       undefined,
-      resolveSettings
+      resolvers
     );
     expect(r.silent).toBe(true);
   });
 
-  it("a synthesized CTA code with an unresolvable URL degrades to text-only", async () => {
+  it("a CTA code whose resolver returns null degrades to text-only", async () => {
     const r = await renderAgentError(
       AgentErrorCode.NO_MODEL_CONFIGURED,
       undefined,
       resolveNothing
     );
     expect(r.text).toContain("No model");
+    expect(r.ctaUrl).toBeNull();
+  });
+
+  it("a CTA code whose resolver is ABSENT degrades to text-only (no throw)", async () => {
+    // provider-connect resolver omitted → PROVIDER_AUTH renders text-only.
+    const r = await renderAgentError(AgentErrorCode.PROVIDER_AUTH, "auth fail", {
+      "agent-settings": async () => SETTINGS_URL,
+    });
+    expect(r.text).toBe("auth fail");
     expect(r.ctaUrl).toBeNull();
   });
 });

--- a/packages/server/src/utils/__tests__/url-builder.test.ts
+++ b/packages/server/src/utils/__tests__/url-builder.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildAgentSettingsUrl,
   buildEntityUrl,
+  buildProviderConnectUrl,
   buildResourcePermalink,
   getPublicWebUrl,
 } from '../url-builder';
@@ -119,6 +120,35 @@ describe('buildAgentSettingsUrl', () => {
     expect(await buildAgentSettingsUrl(undefined, 'org-1', 'a')).toBeNull();
     expect(await buildAgentSettingsUrl('https://x', undefined, 'a')).toBeNull();
     expect(await buildAgentSettingsUrl('https://x', 'org-1', undefined)).toBeNull();
+  });
+});
+
+describe('buildProviderConnectUrl', () => {
+  // The "connect a provider" CTA target — distinct from buildAgentSettingsUrl.
+  // Its fix is wiring credentials, so it lands on /inference-providers/new, the
+  // live connect form, NOT the agent's model settings.
+  it('builds the connect-a-provider URL (distinct page from agent settings)', async () => {
+    const url = await buildProviderConnectUrl(
+      'https://app.lobu.com/lobu',
+      'org-1'
+    );
+    expect(url).toBe('https://app.lobu.com/acme/inference-providers/new');
+  });
+
+  it('prefills provider + model on the connect form when given', async () => {
+    const url = await buildProviderConnectUrl('https://app.lobu.com', 'org-1', {
+      provider: 'z-ai',
+      model: 'z-ai/glm-5.2',
+    });
+    expect(url).toBe(
+      'https://app.lobu.com/acme/inference-providers/new?provider=z-ai&model=z-ai%2Fglm-5.2'
+    );
+  });
+
+  it('returns null when org slug or gateway url is missing', async () => {
+    expect(await buildProviderConnectUrl(undefined, 'org-1')).toBeNull();
+    expect(await buildProviderConnectUrl('https://x', undefined)).toBeNull();
+    expect(await buildProviderConnectUrl('https://x', 'unknown-org')).toBeNull();
   });
 });
 

--- a/packages/server/src/utils/__tests__/url-builder.test.ts
+++ b/packages/server/src/utils/__tests__/url-builder.test.ts
@@ -11,15 +11,7 @@ import {
   __resetPublicOriginCachesForTests,
   __setLocalFrontendForTests,
 } from '../public-origin';
-
-// buildAgentSettingsUrl resolves the org slug via the workspace provider; stub
-// it so the test asserts only the URL SHAPE (the `/settings` deep-link), not
-// tenant lookup.
-vi.mock('../../workspace', () => ({
-  getWorkspaceProvider: () => ({
-    getOrgSlug: async (orgId: string) => (orgId === 'org-1' ? 'acme' : null),
-  }),
-}));
+import * as workspaceModule from '../../workspace';
 
 /**
  * Behavior contract for `getPublicWebUrl`:
@@ -85,7 +77,25 @@ describe('getPublicWebUrl', () => {
   });
 });
 
+// Stub the org-slug lookup so the URL-builder tests assert only URL SHAPE, not
+// tenant resolution. A `vi.spyOn` in beforeEach (not a module-level `vi.mock`)
+// is required: the server vitest config runs `isolate: false`, so a module-mock
+// declared here does NOT apply once an earlier test file has loaded the real
+// `../../workspace` module into the shared registry — the spy re-applies on
+// every run regardless of load order.
+function stubOrgSlug(): void {
+  beforeEach(() => {
+    vi.spyOn(workspaceModule, 'getWorkspaceProvider').mockReturnValue({
+      getOrgSlug: async (orgId: string) => (orgId === 'org-1' ? 'acme' : null),
+    } as unknown as ReturnType<typeof workspaceModule.getWorkspaceProvider>);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+}
+
 describe('buildAgentSettingsUrl', () => {
+  stubOrgSlug();
   // Regression: the CTA for provider/model errors ("Connect a provider" /
   // "Choose a model") MUST deep-link to the agent's /settings tab. The bare
   // /agents/<id> route redirects to Chat — the surface the user just failed on
@@ -124,6 +134,7 @@ describe('buildAgentSettingsUrl', () => {
 });
 
 describe('buildProviderConnectUrl', () => {
+  stubOrgSlug();
   // The "connect a provider" CTA target — distinct from buildAgentSettingsUrl.
   // Its fix is wiring credentials, so it lands on /inference-providers/new, the
   // live connect form, NOT the agent's model settings.

--- a/packages/server/src/utils/__tests__/url-builder.test.ts
+++ b/packages/server/src/utils/__tests__/url-builder.test.ts
@@ -1,10 +1,24 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { buildEntityUrl, buildResourcePermalink, getPublicWebUrl } from '../url-builder';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildAgentSettingsUrl,
+  buildEntityUrl,
+  buildResourcePermalink,
+  getPublicWebUrl,
+} from '../url-builder';
 import {
   HOSTED_UI_FALLBACK_ORIGIN,
   __resetPublicOriginCachesForTests,
   __setLocalFrontendForTests,
 } from '../public-origin';
+
+// buildAgentSettingsUrl resolves the org slug via the workspace provider; stub
+// it so the test asserts only the URL SHAPE (the `/settings` deep-link), not
+// tenant lookup.
+vi.mock('../../workspace', () => ({
+  getWorkspaceProvider: () => ({
+    getOrgSlug: async (orgId: string) => (orgId === 'org-1' ? 'acme' : null),
+  }),
+}));
 
 /**
  * Behavior contract for `getPublicWebUrl`:
@@ -67,6 +81,44 @@ describe('getPublicWebUrl', () => {
   it('falls back to HOSTED_UI_FALLBACK_ORIGIN even when requestUrl is given (backend-only host)', () => {
     __setLocalFrontendForTests(false);
     expect(getPublicWebUrl('https://request.lobu.com/mcp')).toBe(HOSTED_UI_FALLBACK_ORIGIN);
+  });
+});
+
+describe('buildAgentSettingsUrl', () => {
+  // Regression: the CTA for provider/model errors ("Connect a provider" /
+  // "Choose a model") MUST deep-link to the agent's /settings tab. The bare
+  // /agents/<id> route redirects to Chat — the surface the user just failed on
+  // — so a missing /settings suffix drops the admin nowhere useful.
+  it('deep-links to the agent /settings tab (not the bare, chat-redirecting route)', async () => {
+    const url = await buildAgentSettingsUrl(
+      'https://app.lobu.com/lobu',
+      'org-1',
+      'lobu-builder'
+    );
+    expect(url).toBe('https://app.lobu.com/acme/agents/lobu-builder/settings');
+    expect(url?.endsWith('/settings')).toBe(true);
+  });
+
+  it('strips the embedded-mode /lobu suffix from the web origin', async () => {
+    const url = await buildAgentSettingsUrl(
+      'https://app.lobu.com/lobu/',
+      'org-1',
+      'my agent/id'
+    );
+    // agentId is percent-encoded; origin has no /lobu.
+    expect(url).toBe('https://app.lobu.com/acme/agents/my%20agent%2Fid/settings');
+  });
+
+  it('returns null when the org slug cannot be resolved', async () => {
+    expect(
+      await buildAgentSettingsUrl('https://app.lobu.com', 'unknown-org', 'a')
+    ).toBeNull();
+  });
+
+  it('returns null when any required piece is missing', async () => {
+    expect(await buildAgentSettingsUrl(undefined, 'org-1', 'a')).toBeNull();
+    expect(await buildAgentSettingsUrl('https://x', undefined, 'a')).toBeNull();
+    expect(await buildAgentSettingsUrl('https://x', 'org-1', undefined)).toBeNull();
   });
 });
 

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -40,10 +40,17 @@ export async function getOrganizationSlug(
 }
 
 /**
- * Build the agent's admin-settings URL — `<webOrigin>/<orgSlug>/agents/<agentId>`
- * — the CTA target for provider/model errors (connect a provider, choose a
- * model, reconnect credentials). Returns null when any required piece is
- * missing; callers fall back to a non-linked message.
+ * Build the agent's model/provider settings URL —
+ * `<webOrigin>/<orgSlug>/agents/<agentId>/settings` — the CTA target for
+ * provider/model errors (connect a provider, choose a model, reconnect
+ * credentials). Returns null when any required piece is missing; callers fall
+ * back to a non-linked message.
+ *
+ * The `/settings` suffix is load-bearing: the bare `/agents/<id>` route
+ * redirects to the agent's Chat page (`redirectBareAgentToChat`), which is the
+ * surface the user just failed on — not where the model is fixed. `/settings`
+ * lands on the tab that hosts the models allow-list editor, so the CTA drops
+ * the admin exactly where they pick a model / connect a provider.
  *
  * `publicGatewayUrl` is the gateway base, which in embedded mode carries the
  * `/lobu` path suffix (the gateway is mounted at `/lobu` under the web app).
@@ -59,7 +66,7 @@ export async function buildAgentSettingsUrl(
   const slug = await getOrganizationSlug(organizationId).catch(() => null);
   if (!slug) return null;
   const webOrigin = publicGatewayUrl.replace(/\/+$/, '').replace(/\/lobu$/, '');
-  return `${webOrigin}/${slug}/agents/${encodeURIComponent(agentId)}`;
+  return `${webOrigin}/${slug}/agents/${encodeURIComponent(agentId)}/settings`;
 }
 
 export interface RenderedAgentError {

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -69,6 +69,36 @@ export async function buildAgentSettingsUrl(
   return `${webOrigin}/${slug}/agents/${encodeURIComponent(agentId)}/settings`;
 }
 
+/**
+ * Build the org's "connect a provider" URL — `<webOrigin>/<orgSlug>/
+ * inference-providers/new` — the CTA target for errors whose fix is *connecting
+ * a provider* (missing/expired credentials, unroutable provider), as opposed to
+ * *picking a model* on an agent (which is {@link buildAgentSettingsUrl}). This
+ * is the same live route the pre-enqueue model-provider preflight links to.
+ *
+ * Optional `provider`/`model` prefill the connect form so the user lands on the
+ * exact provider to wire up. Returns null when any required piece is missing;
+ * callers fall back to a non-linked message. The `/lobu` embedded-mode suffix is
+ * stripped like the sibling builders.
+ */
+export async function buildProviderConnectUrl(
+  publicGatewayUrl: string | undefined,
+  organizationId: string | undefined,
+  prefill?: { provider?: string; model?: string }
+): Promise<string | null> {
+  if (!publicGatewayUrl || !organizationId) return null;
+  const slug = await getOrganizationSlug(organizationId).catch(() => null);
+  if (!slug) return null;
+  const webOrigin = publicGatewayUrl.replace(/\/+$/, '').replace(/\/lobu$/, '');
+  const url = new URL(
+    `/${encodeURIComponent(slug)}/inference-providers/new`,
+    `${webOrigin}/`
+  );
+  if (prefill?.provider) url.searchParams.set('provider', prefill.provider);
+  if (prefill?.model) url.searchParams.set('model', prefill.model);
+  return url.toString();
+}
+
 export interface RenderedAgentError {
   /** User-facing body (no link appended — carry `ctaUrl` separately). */
   text: string;
@@ -81,6 +111,19 @@ export interface RenderedAgentError {
 }
 
 /**
+ * Per-CTA-kind URL resolvers, injected so `renderAgentError` stays free of the
+ * per-surface plumbing (org slug / agent id / public origin live in the caller).
+ * The catalog's two actionable CTA kinds land on DIFFERENT pages:
+ *   - `agent-settings`   → the agent's model/provider settings (pick a model).
+ *   - `provider-connect` → the org's connect-a-provider page (wire credentials).
+ * A kind whose resolver is absent (or resolves null) renders with no button.
+ */
+export interface AgentErrorCtaResolvers {
+  'agent-settings'?: () => Promise<string | null>;
+  'provider-connect'?: () => Promise<string | null>;
+}
+
+/**
  * THE renderer: turn an `AgentErrorCode` + the raw provider message into the
  * user-facing body and a resolved CTA link. Every surface — Slack/Telegram
  * bridge, browser SSE — calls this so the same error reads identically
@@ -90,20 +133,24 @@ export interface RenderedAgentError {
  * we relay the provider's OWN message verbatim (it already says the useful thing
  * — the reset time, the bad model id). For errors we synthesize (worker/config),
  * the catalog carries the text. The code's only job is to pick the CTA *kind*;
- * this function resolves that kind to a concrete URL (the only layer that knows
- * the org slug / agent id / public origin). `resolveSettingsUrl` is injected so
- * this stays free of the per-surface plumbing.
+ * this resolves that kind to a concrete URL via the matching injected resolver,
+ * so "connect a provider" and "pick a model" land on their own pages instead of
+ * collapsing to one.
  */
 export async function renderAgentError(
   code: AgentErrorCode,
   providerMessage: string | undefined,
-  resolveSettingsUrl: () => Promise<string | null>
+  resolvers: AgentErrorCtaResolvers
 ): Promise<RenderedAgentError> {
   const spec = AGENT_ERRORS[code];
   const text = spec.message ?? providerMessage ?? '';
   let ctaUrl: string | null = null;
-  if (spec.cta === 'agent-settings' || spec.cta === 'provider-connect') {
-    ctaUrl = await resolveSettingsUrl().catch(() => null);
+  const resolve =
+    spec.cta === 'agent-settings' || spec.cta === 'provider-connect'
+      ? resolvers[spec.cta]
+      : undefined;
+  if (resolve) {
+    ctaUrl = await resolve().catch(() => null);
   }
   return {
     text,


### PR DESCRIPTION
Consolidates every "your agent can't run — connect a provider / choose a model" prompt so it's consistent on **Slack, Telegram, and web**, and each CTA lands on the **correct page**. Companion owletto PR: lobu-ai/owletto#478 (web surface).

## The gaps (all fixed)

**G1 — card CTA redirected to Chat.** `buildAgentSettingsUrl` returned bare `/agents/<id>`, which the frontend redirects to the agent's Chat page — the surface the user just failed on. Now `/agents/<id>/settings` (the models-list editor).

**G2 — two CTA kinds, one URL.** `renderAgentError` resolved both `agent-settings` and `provider-connect` to the *same* URL, so "connect a provider" and "pick a model" collapsed onto one page. Each kind now has its own resolver: `provider-connect` → `/inference-providers/new` (new `buildProviderConnectUrl`), `agent-settings` → `/agents/<id>/settings`. Catalog CTA kinds corrected so each error lands on its actual fix (quota/auth/base-url are provider-level → `provider-connect`).

**G3 — the preflight bypassed the catalog.** The pre-enqueue model-provider check hand-built an `"I can't run this yet: … <url>"` string with the URL **inlined as prose** and posted it raw — a parallel, button-less path. It now returns its specific text + a CTA kind and renders through the **same** card helper as the terminal-error bridge. Extracted `buildCtaCardPayload` (link-buttons.ts) as the one place a CTA becomes a native card; deleted the one-off `buildProviderSetupUrl`.

**G4 — web surface dropped the CTA entirely** (owletto PR). The browser chat rendered `Error: <text>` and ignored `errorCode`, so the button was Slack/Telegram-only. It now reads the SSE `errorCode` and renders the same link-button, driven by the shared `@lobu/core` `AGENT_ERRORS` catalog — single source of truth.

## Principles honored
- **Expose the message, don't over-unwrap:** provider errors still relay pi's own text verbatim; the preflight keeps its specific wording. We only attach the CTA.
- **Consistent everywhere:** one catalog, one renderer, one card helper; the web reads the same catalog. No Slack-specific paths.

## Verification
- Red→green tests: `buildAgentSettingsUrl`/`buildProviderConnectUrl` (url-builder.test.ts), per-kind renderer routing (render-agent-error.test.ts), the shared `buildCtaCardPayload` (link-buttons.test.ts), and the web resolver (owletto agent-error-cta.test.ts).
- `make build-packages` ✅, `make typecheck` (server + owletto) ✅. `make review` gates on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent Settings CTAs now deep-link directly to the agent’s Settings page (not the chat redirect).
  * “Connect a provider” CTAs now route correctly for provider-related errors.
  * URL generation is more robust for embedded origins and missing/unknown organization context.
  * CTA rendering now provides consistent link-button payloads, with localhost/loopback URLs falling back to text-only.
* **Tests**
  * Updated and expanded coverage for URL building, CTA payload formatting, and agent error CTA routing (including missing-resolver behavior) plus Slack preview expectations.
* **Chores**
  * Expanded shared core package exports for error definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->