### PR TITLE
test(watchers): remove cross-table id assumption

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/source-id-and-cross-org.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/source-id-and-cross-org.test.ts
@@ -163,7 +163,6 @@ describe("manage_watchers source-id + cross-org guards", () => {
 			JWT_SECRET: "test-jwt-secret-for-testing-only",
 		} as Env);
 		expect(token.content_ids).toEqual([event.id]);
-		expect(token.content_ids).not.toContain(customer.id);
 
 		const orgScoped = (await owner.watchers.create({
 			slug: "source-ref-org-count",


### PR DESCRIPTION
## What changed

- remove the invalid assertion that an event id cannot equal an entity id
- retain the direct assertion that the signed content ids contain only the event-backed source

## Root cause

`events.id` and `entities.id` are allocated by independent PostgreSQL sequences. The fixture can legitimately produce the same integer for both rows, so `not.toContain(customer.id)` tested numeric coincidence rather than whether entity-backed content leaked into the signed token.

## Validation

- red: focused Vitest test failed at the cross-table inequality assertion
- green: focused watcher source-id/cross-org suite passed 10/10 after removing it
- `make review`: build, typecheck, unit, and integration suites passed

Closes #1786

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786320953&installation_id=136316292&pr_number=1845&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1845&signature=df2838b673d9f741668eeb6ea0d1f153ce47ed11a8508505b2ae5eb78a559075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->