### PR TITLE
fix: make agent error recovery actions durable

### DIFF
--- a/db/migrations/20260711110000_runs_thread_response_history_index.sql
+++ b/db/migrations/20260711110000_runs_thread_response_history_index.sql
@@ -1,0 +1,17 @@
+-- migrate:up transaction:false
+
+-- Agent history reloads inspect the newest terminal thread_response row for an
+-- organization. runs retains every streamed response row, so idx_runs_org alone
+-- still leaves Postgres filtering and sorting the full retained org history.
+-- Keep the ordered index limited to rows the history query can consume.
+-- CONCURRENTLY avoids blocking writes to the hot runs queue.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_runs_thread_response_history
+  ON public.runs (organization_id, id DESC)
+  WHERE run_type = 'chat_message'
+    AND queue_name = 'thread_response'
+    AND status IN ('pending', 'completed', 'failed')
+    AND action_input IS NOT NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_runs_thread_response_history;

--- a/packages/agent-worker/src/__tests__/error-handler.test.ts
+++ b/packages/agent-worker/src/__tests__/error-handler.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { WorkerTransport } from "@lobu/core";
+import type { AgentErrorContext, WorkerTransport } from "@lobu/core";
 import { classifyError, handleExecutionError } from "../core/error-handler";
 
 type Recorder = {
@@ -16,7 +16,11 @@ type Recorder = {
     isFullReplacement?: boolean;
     isFinal?: boolean;
   }>;
-  errors: Array<{ message: string; code?: string }>;
+  errors: Array<{
+    message: string;
+    code?: string;
+    context?: AgentErrorContext;
+  }>;
 };
 
 function makeTransport(): Recorder {
@@ -31,8 +35,8 @@ function makeTransport(): Recorder {
     },
     signalDone: asyncNoop,
     signalCompletion: asyncNoop,
-    async signalError(error, errorCode) {
-      errors.push({ message: error.message, code: errorCode });
+    async signalError(error, errorCode, context) {
+      errors.push({ message: error.message, code: errorCode, context });
     },
     sendStatusUpdate: asyncNoop,
     sendCustomEvent: asyncNoop,
@@ -83,7 +87,12 @@ describe("handleExecutionError", () => {
 
     await handleExecutionError(
       new Error('Model "gpt-nope" not found for provider "openai".'),
-      transport
+      transport,
+      {
+        provider: "openai-runtime",
+        providerSlug: "openai",
+        model: "gpt-nope",
+      }
     );
 
     // New contract: the gateway renderer owns the user-facing text (via
@@ -93,6 +102,10 @@ describe("handleExecutionError", () => {
     expect(deltas).toHaveLength(0);
     expect(errors).toHaveLength(1);
     expect(errors[0].code).toBe("PROVIDER_UNKNOWN_MODEL");
+    expect(errors[0].context).toEqual({
+      provider: "openai",
+      model: "gpt-nope",
+    });
   });
 
   test("provider routing failures signal a code, not a crash delta", async () => {

--- a/packages/agent-worker/src/__tests__/model-resolver.test.ts
+++ b/packages/agent-worker/src/__tests__/model-resolver.test.ts
@@ -51,6 +51,7 @@ describe("resolveModelRef", () => {
       defaultProviderSlug: "claude",
     });
     expect(result.provider).toBe("anthropic");
+    expect(result.providerSlug).toBe("claude");
     expect(result.modelId).toBe("claude-opus-4-8");
   });
 
@@ -84,6 +85,7 @@ describe("resolveModelRef", () => {
     });
 
     expect(result.provider).toBe("z-ai");
+    expect(result.providerSlug).toBe("z-ai");
     expect(result.modelId).toBe("glm-5.2");
   });
 
@@ -109,6 +111,7 @@ describe("resolveModelRef", () => {
     });
 
     expect(result.provider).toBe("anthropic");
+    expect(result.providerSlug).toBe("claude");
     expect(result.modelId).toBe("claude-sonnet-4-5");
   });
 

--- a/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
+++ b/packages/agent-worker/src/__tests__/worker-token-refresh.test.ts
@@ -30,6 +30,7 @@ import { writeSnapshot } from "../openclaw/transcript-snapshot";
 
 let originalFetch: typeof globalThis.fetch;
 let capturedAuth: string[];
+let capturedBodies: unknown[];
 let originalDispatcher: string | undefined;
 let originalWorkerToken: string | undefined;
 let originalTtl: string | undefined;
@@ -41,6 +42,7 @@ beforeEach(() => {
   originalTtl = process.env.WORKER_TOKEN_TTL_MS;
   process.env.DISPATCHER_URL = "http://gw.test/lobu";
   capturedAuth = [];
+  capturedBodies = [];
   __resetWorkerTokenManagerForTests();
 });
 
@@ -77,6 +79,9 @@ function stubFetch(opts?: {
         return new Response(JSON.stringify({ token: tok }), { status: 200 });
       }
       if (auth) capturedAuth.push(auth);
+      if (typeof init?.body === "string") {
+        capturedBodies.push(JSON.parse(init.body));
+      }
       const status = opts?.responseStatusByAuth?.(auth) ?? 200;
       return new Response(JSON.stringify({ ok: true }), { status });
     }
@@ -132,6 +137,26 @@ describe("per-turn token adoption (transport reads the live manager token)", () 
     expect(capturedAuth.every((a) => a === "Bearer deployment-token")).toBe(
       true
     );
+  });
+
+  test("carries non-secret provider/model error context on the wire", async () => {
+    stubFetch();
+    const transport = makeTransport("deployment-token");
+
+    await transport.signalError(
+      new Error("quota exhausted"),
+      "PROVIDER_QUOTA_EXHAUSTED",
+      {
+        provider: "z-ai",
+        model: "glm-5.2",
+      }
+    );
+
+    expect(capturedBodies.at(-1)).toMatchObject({
+      error: "quota exhausted",
+      errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+      errorContext: { provider: "z-ai", model: "glm-5.2" },
+    });
   });
 });
 

--- a/packages/agent-worker/src/core/error-handler.ts
+++ b/packages/agent-worker/src/core/error-handler.ts
@@ -13,7 +13,10 @@ const logger = createLogger("worker");
  * carries the tags that make "openai doesn't work" triageable in Sentry.
  */
 interface ExecutionErrorContext {
+  /** Runtime provider/registry alias used for Sentry attribution. */
   provider?: string;
+  /** Lobu provider slug used to target the settings CTA. */
+  providerSlug?: string;
   model?: string;
   agentId?: string;
   runId?: number | string;
@@ -152,7 +155,15 @@ export async function handleExecutionError(
     if (!code) {
       await transport.sendStreamDelta(formatErrorMessage(error), true, true);
     }
-    await transport.signalError(errorInstance, code);
+    const provider = ctx?.providerSlug ?? ctx?.provider;
+    const errorContext =
+      provider || ctx?.model
+        ? {
+            ...(provider ? { provider } : {}),
+            ...(ctx?.model ? { model: ctx.model } : {}),
+          }
+        : undefined;
+    await transport.signalError(errorInstance, code, errorContext);
   } catch (gatewayError) {
     logger.error("Failed to send error via gateway:", gatewayError);
     throw error;

--- a/packages/agent-worker/src/gateway/gateway-integration.ts
+++ b/packages/agent-worker/src/gateway/gateway-integration.ts
@@ -6,6 +6,7 @@
 import {
   createLogger,
   retryWithBackoff,
+  type AgentErrorContext,
   type WorkerTransport,
   type WorkerTransportConfig,
 } from "@lobu/core";
@@ -180,11 +181,16 @@ export class HttpWorkerTransport implements WorkerTransport {
     );
   }
 
-  async signalError(error: Error, errorCode?: string): Promise<void> {
+  async signalError(
+    error: Error,
+    errorCode?: string,
+    errorContext?: AgentErrorContext
+  ): Promise<void> {
     await this.sendResponse(
       this.buildBaseResponse({
         error: error.message,
         ...(errorCode && { errorCode }),
+        ...(errorContext && { errorContext }),
       })
     );
   }

--- a/packages/agent-worker/src/openclaw/model-resolver.ts
+++ b/packages/agent-worker/src/openclaw/model-resolver.ts
@@ -212,6 +212,8 @@ export function resolveModelRef(
   }
 ): {
   provider: string;
+  /** Lobu provider slug retained for exact settings/CTA targeting. */
+  providerSlug: string;
   modelId: string;
 } {
   const defaultModelRef = overrides?.defaultModel || "";
@@ -265,7 +267,11 @@ export function resolveModelRef(
         DEFAULT_PROVIDER_MODELS[routedProvider] ??
         modelId;
     }
-    return { provider: routedProvider, modelId };
+    return {
+      provider: routedProvider,
+      providerSlug: explicitProvider,
+      modelId,
+    };
   }
 
   // When the agent has an explicitly configured provider, route to it and pass
@@ -306,7 +312,11 @@ export function resolveModelRef(
     ) {
       modelId = modelId.slice(defaultProviderSlug.length + 1);
     }
-    return { provider: defaultProvider, modelId };
+    return {
+      provider: defaultProvider,
+      providerSlug: defaultProviderSlug || defaultProvider,
+      modelId,
+    };
   }
 
   // Auto / no-configured-provider mode: derive the provider from the model
@@ -323,7 +333,7 @@ export function resolveModelRef(
         modelId = fallback;
       }
     }
-    return { provider, modelId };
+    return { provider, providerSlug: provider, modelId };
   }
 
   throw new Error(

--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -415,7 +415,11 @@ interface RunAISessionParams {
    * so the worker can tag Sentry captures with which provider/model a later
    * failure belongs to. Fires before any provider call can fail.
    */
-  onModelResolved: (provider: string, modelId: string) => void;
+  onModelResolved: (
+    provider: string,
+    modelId: string,
+    providerSlug: string
+  ) => void;
 
   // Methods delegated from OpenClawWorker (kept on the class; passed here as
   // plain function references so the class can share them with tests without
@@ -556,7 +560,11 @@ export async function runAISession(
 
   const modelRef = typeof rawOptions.model === "string" ? rawOptions.model : "";
 
-  const { provider: rawProvider, modelId } = resolveModelRef(modelRef, {
+  const {
+    provider: rawProvider,
+    providerSlug,
+    modelId,
+  } = resolveModelRef(modelRef, {
     defaultModel: pc.defaultModel,
     defaultProvider: pc.defaultProvider,
     defaultProviderSlug: pc.defaultProviderSlug,
@@ -565,7 +573,7 @@ export async function runAISession(
   });
   // Map gateway slug to model-registry provider name (e.g. "z-ai" → "zai")
   const provider = PROVIDER_REGISTRY_ALIASES[rawProvider] || rawProvider;
-  onModelResolved(provider, modelId);
+  onModelResolved(provider, modelId, providerSlug);
 
   // Dynamic provider base URL from agentOptions.providerBaseUrlMappings
   let providerBaseUrl: string | undefined;

--- a/packages/agent-worker/src/openclaw/worker.ts
+++ b/packages/agent-worker/src/openclaw/worker.ts
@@ -89,6 +89,7 @@ export class OpenClawWorker implements WorkerExecutor {
    * and an opaque worker crash.
    */
   private resolvedProvider: string | undefined;
+  private resolvedProviderSlug: string | undefined;
   private resolvedModelId: string | undefined;
 
   constructor(config: WorkerConfig) {
@@ -136,6 +137,7 @@ export class OpenClawWorker implements WorkerExecutor {
     // Reset per-run resolved provider/model so a prior run's values can't leak
     // into the Sentry tags of a failure that happens before model resolution.
     this.resolvedProvider = undefined;
+    this.resolvedProviderSlug = undefined;
     this.resolvedModelId = undefined;
 
     // Fail loud when the per-run scope the gateway is supposed to
@@ -323,6 +325,7 @@ export class OpenClawWorker implements WorkerExecutor {
             this.workerTransport,
             {
               provider: this.resolvedProvider,
+              providerSlug: this.resolvedProviderSlug,
               model: this.resolvedModelId,
               agentId: this.config.agentId,
               runId: this.config.runId,
@@ -346,6 +349,7 @@ export class OpenClawWorker implements WorkerExecutor {
     } catch (error) {
       await handleExecutionError(error, this.workerTransport, {
         provider: this.resolvedProvider,
+        providerSlug: this.resolvedProviderSlug,
         model: this.resolvedModelId,
         agentId: this.config.agentId,
         runId: this.config.runId,
@@ -527,12 +531,13 @@ export class OpenClawWorker implements WorkerExecutor {
       onSessionFilePathResolved: (filePath) => {
         this.sessionFilePath = filePath;
       },
-      onModelResolved: (provider, modelId) => {
+      onModelResolved: (provider, modelId, providerSlug) => {
         // Stamp for Sentry tagging in execute()'s catch-all + failure
         // branches. Anything that fails after this point (unknown model,
         // unresolved base URL, provider auth) is attributable to a specific
         // provider/model.
         this.resolvedProvider = provider;
+        this.resolvedProviderSlug = providerSlug;
         this.resolvedModelId = modelId;
       },
       loadImageAttachments: () => this.loadImageAttachments(),

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -198,7 +198,8 @@ export enum AgentErrorCode {
  */
 export type AgentErrorCtaKind =
   | "agent-settings" // → <webOrigin>/<slug>/agents/<agentId>/settings
-  | "provider-connect" // → same settings page, provider-connect intent
+  | "provider-connect" // → <webOrigin>/<slug>/inference-providers/new
+  | "provider-management" // → existing provider management, exact provider/model
   | "none";
 
 /**
@@ -236,14 +237,14 @@ export interface AgentErrorSpec {
 export const AGENT_ERRORS: Record<AgentErrorCode, AgentErrorSpec> = {
   // Provider errors — no `message`; the provider's own text is the body.
   // Provider-level failures (quota, credentials, routing) are fixed on the
-  // connect-a-provider page → `provider-connect`. A model-level failure
-  // (unknown/unallowed model) is fixed on the agent's settings → `agent-settings`.
+  // existing provider's management surface. A model-level failure
+  // (unknown/unallowed model) is fixed on the agent's settings.
   [AgentErrorCode.PROVIDER_QUOTA_EXHAUSTED]: {
-    cta: "provider-connect",
+    cta: "provider-management",
     ctaLabel: "Manage provider",
   },
   [AgentErrorCode.PROVIDER_AUTH]: {
-    cta: "provider-connect",
+    cta: "provider-management",
     ctaLabel: "Reconnect provider",
   },
   [AgentErrorCode.PROVIDER_UNKNOWN_MODEL]: {
@@ -251,15 +252,15 @@ export const AGENT_ERRORS: Record<AgentErrorCode, AgentErrorSpec> = {
     ctaLabel: "Choose model",
   },
   [AgentErrorCode.PROVIDER_BASE_URL_UNRESOLVED]: {
-    cta: "provider-connect",
-    ctaLabel: "Connect provider",
+    cta: "provider-management",
+    ctaLabel: "Manage provider",
   },
   // Errors we synthesize — carry our own text (no provider string to relay).
   [AgentErrorCode.NO_MODEL_CONFIGURED]: {
     message:
-      "No model is configured for this agent. Connect a provider to get started.",
+      "No model is configured for this agent. Choose a model in agent settings.",
     cta: "agent-settings",
-    ctaLabel: "Connect a provider",
+    ctaLabel: "Choose a model",
   },
   [AgentErrorCode.WORKER_UNRESPONSIVE]: {
     message:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,6 +104,7 @@ export { getSentry, initSentry } from "./sentry";
 export { extractTraceId, generateTraceId } from "./trace";
 // Core types
 export type {
+  AgentErrorContext,
   AgentInlineGuardrail,
   AgentOptions,
   AuthProfile,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -410,6 +410,13 @@ export interface InstructionProvider {
  * Shared payload contract for worker → platform thread responses.
  * Ensures gateway consumers and workers stay type-aligned.
  */
+export interface AgentErrorContext {
+  /** Lobu provider slug safe to expose to the settings UI. */
+  provider?: string;
+  /** Provider model id safe to expose to the settings UI. */
+  model?: string;
+}
+
 export interface ThreadResponsePayload {
   messageId: string;
   channelId: string;
@@ -436,6 +443,8 @@ export interface ThreadResponsePayload {
    */
   error?: string;
   errorCode?: string;
+  /** Non-secret provider/model targeting for the error CTA. */
+  errorContext?: AgentErrorContext;
   timestamp: number;
   originalMessageId?: string;
   botResponseId?: string;

--- a/packages/core/src/worker/transport.ts
+++ b/packages/core/src/worker/transport.ts
@@ -1,3 +1,5 @@
+import type { AgentErrorContext } from "../types";
+
 /**
  * Worker Transport Interface
  * Defines how workers communicate with the gateway (platform-agnostic).
@@ -47,8 +49,13 @@ export interface WorkerTransport {
    *                the user-facing body for provider errors.
    * @param errorCode - Classified `AgentErrorCode` (see @lobu/core errors); the
    *                    renderer uses it only to select the CTA link.
+   * @param context - Non-secret provider/model targeting for the error CTA.
    */
-  signalError(error: Error, errorCode?: string): Promise<void>;
+  signalError(
+    error: Error,
+    errorCode?: string,
+    context?: AgentErrorContext
+  ): Promise<void>;
 
   /**
    * Send a status update to the gateway

--- a/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
+++ b/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
@@ -155,6 +155,25 @@ describe('migration invariants', () => {
       expect(hashIdx.map((r) => r.indexname)).toEqual(['oauth_tokens_token_hash_key']);
     });
 
+    it('agent history has an ordered partial index over retained thread responses', async () => {
+      const sql = getTestDb();
+      const rows = await sql<{ indexdef: string }[]>`
+        SELECT indexdef FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'runs'
+          AND indexname = 'idx_runs_thread_response_history'
+      `;
+      expect(rows).toHaveLength(1);
+      const def = rows[0]?.indexdef ?? '';
+      expect(def).toContain('(organization_id, id DESC)');
+      expect(def).toContain("run_type = 'chat_message'::text");
+      expect(def).toContain("queue_name = 'thread_response'::text");
+      expect(def).toContain("'pending'::text");
+      expect(def).toContain("'completed'::text");
+      expect(def).toContain("'failed'::text");
+      expect(def).toContain('action_input IS NOT NULL');
+    });
+
     it('redundant/dead indexes are dropped while their covering indexes remain (2026-06-16 audit round 2)', async () => {
       const sql = getTestDb();
       // Dropped: idx_events_source_embedding (redundant btree(event_id) before

--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -34,10 +34,17 @@ async function insertRun(opts: {
 	conversationId: string;
 	runType?: string;
 	status?: string;
+	queueName?: string;
+	actionInput?: Record<string, unknown>;
 }): Promise<number> {
 	const sql = getDb();
 	const runType = opts.runType ?? "chat_message";
 	const status = opts.status ?? "completed";
+	const queueName = opts.queueName ?? runType;
+	const actionInput = opts.actionInput ?? {
+		agentId: opts.agentId,
+		conversationId: opts.conversationId,
+	};
 	const rows = (await sql`
     INSERT INTO public.runs (
       organization_id, run_type, status, action_input,
@@ -46,8 +53,8 @@ async function insertRun(opts: {
       ${opts.organizationId},
       ${runType},
       ${status},
-      ${sql.json({ agentId: opts.agentId, conversationId: opts.conversationId })},
-      ${runType},
+      ${sql.json(actionInput)},
+      ${queueName},
       NOW(),
       NOW()
     )
@@ -261,6 +268,89 @@ describe("agent history routes", () => {
 		expect(card?.fields).toMatchObject({ "metadata.tier": "enterprise" });
 		expect(card?.current).toMatchObject({ "metadata.tier": "free" });
 		expect(card?.attribution).toBe("agent");
+	});
+
+	test("replays only the latest terminal agent error and clears it after success", async () => {
+		setAuthProvider(() => ({
+			userId: USER_ID,
+			platform: "external",
+			exp: Date.now() + 60_000,
+		}));
+
+		const agentId = "agent-1";
+		const threadId = "thread-error";
+		const conversationId = buildApiConversationId({
+			agentId,
+			userId: USER_ID,
+			organizationId: ORG_ID,
+			threadId,
+		});
+		const errorRunId = await insertRun({
+			organizationId: ORG_ID,
+			agentId,
+			conversationId,
+			queueName: "thread_response",
+			actionInput: {
+				messageId: "m-error",
+				channelId: conversationId,
+				conversationId,
+				userId: USER_ID,
+				teamId: "api",
+				timestamp: Date.now(),
+				error: "429 quota exhausted",
+				errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+				errorContext: { provider: "z-ai", model: "glm-5.2" },
+			},
+		});
+
+		const requestHistory = () =>
+			orgContext.run({ organizationId: ORG_ID }, () =>
+				createApp().request(
+					`/api/v1/agents/${agentId}/history/threads/${threadId}/messages`,
+					{ method: "GET", headers: { host: "localhost" } },
+				),
+			);
+
+		const errorResponse = await requestHistory();
+		expect(errorResponse.status).toBe(200);
+		const errorBody = (await errorResponse.json()) as {
+			interactions: Array<Record<string, unknown>>;
+		};
+		expect(errorBody.interactions).toContainEqual({
+			type: "agent-error",
+			runId: errorRunId,
+			error: "429 quota exhausted",
+			errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+			errorContext: { provider: "z-ai", model: "glm-5.2" },
+		});
+
+		// A later successful terminal outcome supersedes the stale error.
+		await insertRun({
+			organizationId: ORG_ID,
+			agentId,
+			conversationId,
+			queueName: "thread_response",
+			actionInput: {
+				messageId: "m-success",
+				channelId: conversationId,
+				conversationId,
+				userId: USER_ID,
+				teamId: "api",
+				timestamp: Date.now() + 1,
+				processedMessageIds: ["m-success"],
+				finalText: "Recovered",
+			},
+		});
+
+		const successResponse = await requestHistory();
+		const successBody = (await successResponse.json()) as {
+			interactions: Array<{ type: string }>;
+		};
+		expect(
+			successBody.interactions.some(
+				(interaction) => interaction.type === "agent-error",
+			),
+		).toBe(false);
 	});
 
 	test("rejects sessions that do not own the requested agent", async () => {

--- a/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
+++ b/packages/server/src/gateway/api/__tests__/response-renderer-finaltext.test.ts
@@ -63,3 +63,25 @@ describe("ApiResponseRenderer.handleCompletion finalText repair", () => {
     expect(complete?.data.finalText).toBeUndefined();
   });
 });
+
+describe("ApiResponseRenderer.handleError targeting context", () => {
+  test("forwards provider/model context on both browser error events", async () => {
+    const { renderer, broadcasts } = makeRenderer();
+
+    await renderer.handleError(
+      basePayload({
+        error: "quota exhausted",
+        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+        errorContext: { provider: "z-ai", model: "glm-5.2" },
+      }),
+      "session-key"
+    );
+
+    for (const event of ["error", "agent-error"]) {
+      expect(broadcasts.find((b) => b.event === event)?.data).toMatchObject({
+        errorCode: "PROVIDER_QUOTA_EXHAUSTED",
+        errorContext: { provider: "z-ai", model: "glm-5.2" },
+      });
+    }
+  });
+});

--- a/packages/server/src/gateway/api/response-renderer.ts
+++ b/packages/server/src/gateway/api/response-renderer.ts
@@ -134,6 +134,7 @@ export class ApiResponseRenderer implements ResponseRenderer {
       type: "error",
       error: errorText,
       errorCode: code,
+      errorContext: payload.errorContext,
       messageId: payload.messageId,
       timestamp: payload.timestamp || Date.now(),
     };

--- a/packages/server/src/gateway/connections/chat-response-bridge.ts
+++ b/packages/server/src/gateway/connections/chat-response-bridge.ts
@@ -20,6 +20,7 @@ import { getDb } from "../../db/client.js";
 import {
   buildAgentSettingsUrl,
   buildProviderConnectUrl,
+  buildProviderManagementUrl,
   type RenderedAgentError,
   renderAgentError,
 } from "../../utils/url-builder.js";
@@ -569,6 +570,9 @@ export class ChatResponseBridge implements ResponseRenderer {
           buildAgentSettingsUrl(gatewayUrl, orgId, agentId),
         // "connect a provider" → the org's connect-a-provider page.
         'provider-connect': () => buildProviderConnectUrl(gatewayUrl, orgId),
+        // Provider auth/quota/routing → manage the exact existing provider.
+        'provider-management': () =>
+          buildProviderManagementUrl(gatewayUrl, orgId, payload.errorContext),
       });
       if (rendered.silent) return;
       // For provider errors `rendered.text` IS the provider's own message (we

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -1050,6 +1050,8 @@ export class MessageHandlerBridge {
             ? await buildProviderConnectUrl(gatewayUrl, organizationId, {
                 provider: modelResolution.provider,
                 model: modelResolution.model,
+                reason: "model_provider_not_connected",
+                agentId,
               })
             : await buildAgentSettingsUrl(gatewayUrl, organizationId, agentId);
         const label =

--- a/packages/server/src/gateway/platform/link-buttons.ts
+++ b/packages/server/src/gateway/platform/link-buttons.ts
@@ -28,7 +28,7 @@ export function isLocalhostUrl(url: string): boolean {
   }
 }
 
-interface LinkButton {
+interface ExtractedLinkButton {
   text: string;
   url: string;
 }
@@ -73,9 +73,9 @@ export function buildCtaCardPayload(args: {
  */
 export function extractSettingsLinkButtons(content: string): {
   processedContent: string;
-  linkButtons: LinkButton[];
+  linkButtons: ExtractedLinkButton[];
 } {
-  const linkButtons: LinkButton[] = [];
+  const linkButtons: ExtractedLinkButton[] = [];
 
   const processedContent = content.replace(
     SETTINGS_LINK_RE,

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -8,7 +8,13 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import type { AgentConfigStore, ParsedMessage } from "@lobu/core";
-import { createLogger, entryToMessage, parseSessionEntries } from "@lobu/core";
+import {
+	AGENT_ERRORS,
+	createLogger,
+	entryToMessage,
+	parseSessionEntries,
+	toAgentErrorCode,
+} from "@lobu/core";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { getDb } from "../../../db/client.js";
@@ -63,6 +69,95 @@ export async function readLatestSnapshotJsonl(
 }
 
 const logger = createLogger("agent-history-routes");
+
+type ToolApprovalHistoryInteraction = {
+	type: "tool-approval";
+	runId: number;
+	action: string | null;
+	proposal: Record<string, unknown> | null;
+	current: Record<string, unknown> | null;
+	fields: Record<string, unknown> | null;
+	attribution: string | null;
+};
+
+type AgentErrorHistoryInteraction = {
+	type: "agent-error";
+	runId: number;
+	error: string;
+	errorCode: string | null;
+	errorContext: { provider?: string; model?: string } | null;
+};
+
+type HistoryInteraction =
+	| ToolApprovalHistoryInteraction
+	| AgentErrorHistoryInteraction;
+
+async function readLatestAgentErrorInteraction(
+	organizationId: string,
+	conversationId: string,
+): Promise<AgentErrorHistoryInteraction | null> {
+	const rows = await getDb()<{
+		id: number;
+		payload: Record<string, unknown> | null;
+	}>`
+		WITH response_rows AS (
+			SELECT id,
+			       CASE
+			         WHEN jsonb_typeof(action_input) = 'string'
+			           THEN (action_input #>> '{}')::jsonb
+			         ELSE action_input
+			       END AS payload
+			FROM public.runs
+			WHERE organization_id = ${organizationId}
+			  AND run_type = 'chat_message'
+			  AND queue_name = 'thread_response'
+			  AND status IN ('pending', 'completed', 'failed')
+			  AND action_input IS NOT NULL
+		)
+		SELECT id, payload
+		FROM response_rows
+		WHERE payload->>'conversationId' = ${conversationId}
+		  AND (payload ? 'error' OR payload ? 'processedMessageIds')
+		ORDER BY id DESC
+		LIMIT 1
+	`;
+	const row = rows[0];
+	if (!row?.payload || typeof row.payload !== "object") return null;
+
+	// A newer successful terminal row supersedes any older error for the thread.
+	if (typeof row.payload.error !== "string") return null;
+	const code = toAgentErrorCode(row.payload.errorCode);
+	const spec = code ? AGENT_ERRORS[code] : undefined;
+	if (spec?.silent) return null;
+	const error = spec?.message ?? row.payload.error;
+	if (!error) return null;
+
+	const rawContext =
+		row.payload.errorContext &&
+		typeof row.payload.errorContext === "object" &&
+		!Array.isArray(row.payload.errorContext)
+			? (row.payload.errorContext as Record<string, unknown>)
+			: null;
+	const provider =
+		typeof rawContext?.provider === "string" ? rawContext.provider : undefined;
+	const model =
+		typeof rawContext?.model === "string" ? rawContext.model : undefined;
+	const errorContext =
+		provider || model
+			? {
+					...(provider ? { provider } : {}),
+					...(model ? { model } : {}),
+				}
+			: null;
+
+	return {
+		type: "agent-error",
+		runId: Number(row.id),
+		error,
+		errorCode: code ?? null,
+		errorContext,
+	};
+}
 
 // Tokenless artifact references persisted in the transcript by the message-send
 // path (`[name](/api/v1/files/:id)`). They carry no expiring credential, so the
@@ -403,15 +498,7 @@ export function createAgentHistoryRoutes(deps: {
 		// pending approval events. Self-cleaning: a resolved approval is
 		// superseded out of current_event_records. Without this the interactive
 		// approval card is lost on reload — only the model's text + link survive.
-		let interactions: Array<{
-			type: "tool-approval";
-			runId: number;
-			action: string | null;
-			proposal: Record<string, unknown> | null;
-			current: Record<string, unknown> | null;
-			fields: Record<string, unknown> | null;
-			attribution: string | null;
-		}> = [];
+		let interactions: HistoryInteraction[] = [];
 		if (scope.organizationId) {
 			const conversationId = buildApiConversationId({
 				agentId: scope.agentId,
@@ -452,6 +539,11 @@ export function createAgentHistoryRoutes(deps: {
 				fields: r.fields ?? null,
 				attribution: r.attribution ?? null,
 			}));
+			const errorInteraction = await readLatestAgentErrorInteraction(
+				scope.organizationId,
+				conversationId,
+			);
+			if (errorInteraction) interactions.push(errorInteraction);
 		}
 		return c.json({ ...data, interactions });
 	});

--- a/packages/server/src/utils/__tests__/render-agent-error.test.ts
+++ b/packages/server/src/utils/__tests__/render-agent-error.test.ts
@@ -11,23 +11,27 @@ import { type AgentErrorCtaResolvers, renderAgentError } from "../url-builder";
 
 const SETTINGS_URL = "https://app.lobu.ai/acme/agents/agent-1/settings";
 const CONNECT_URL = "https://app.lobu.ai/acme/inference-providers/new";
+const MANAGE_URL =
+  "https://app.lobu.ai/acme/infrastructure/models?provider=z-ai&model=glm-5.2";
 
 // Distinct resolvers per CTA kind, so a test can assert that a code routes to
 // the RIGHT page (pick-a-model vs connect-a-provider), not just "some url".
 const resolvers: AgentErrorCtaResolvers = {
   "agent-settings": async () => SETTINGS_URL,
   "provider-connect": async () => CONNECT_URL,
+  "provider-management": async () => MANAGE_URL,
 };
 const resolveNothing: AgentErrorCtaResolvers = {
   "agent-settings": async () => null,
   "provider-connect": async () => null,
+  "provider-management": async () => null,
 };
 
 describe("renderAgentError", () => {
-  it("provider quota RELAYS the provider's own message verbatim + routes to the CONNECT page", async () => {
+  it("provider quota relays the provider message + routes to existing-provider management", async () => {
     // The provider's message already says when the quota resets — we relay it
     // unchanged (no reset-time parsing, no reword) and only add the CTA link. A
-    // quota/provider-level failure is fixed on the connect-a-provider page.
+    // quota/provider-level failure is fixed on existing-provider management.
     const raw =
       "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-10 04:32:47";
     const r = await renderAgentError(
@@ -36,7 +40,7 @@ describe("renderAgentError", () => {
       resolvers
     );
     expect(r.text).toBe(raw);
-    expect(r.ctaUrl).toBe(CONNECT_URL);
+    expect(r.ctaUrl).toBe(MANAGE_URL);
     expect(r.ctaLabel).toBe("Manage provider");
     expect(r.silent).toBe(false);
   });
@@ -48,22 +52,19 @@ describe("renderAgentError", () => {
       resolvers
     );
     expect(r.text).toBe("");
-    expect(r.ctaUrl).toBe(CONNECT_URL);
+    expect(r.ctaUrl).toBe(MANAGE_URL);
   });
 
-  it("auth failure relays the provider message + routes to the CONNECT page (not settings)", async () => {
-    // PROVIDER_AUTH's cta kind is `provider-connect` — its fix is reconnecting
-    // credentials, so it must land on the connect-a-provider page, NOT the
-    // agent's model settings. This is the exact distinction the per-kind
-    // resolver exists for (both kinds used to collapse to one URL).
+  it("auth failure routes to existing-provider management (not add-new or settings)", async () => {
     const r = await renderAgentError(
       AgentErrorCode.PROVIDER_AUTH,
       'Authentication failed for "openai"',
       resolvers
     );
     expect(r.text).toBe('Authentication failed for "openai"');
-    expect(r.ctaUrl).toBe(CONNECT_URL);
+    expect(r.ctaUrl).toBe(MANAGE_URL);
     expect(r.ctaUrl).not.toBe(SETTINGS_URL);
+    expect(r.ctaUrl).not.toBe(CONNECT_URL);
     expect(r.ctaLabel).toBe("Reconnect provider");
   });
 
@@ -75,7 +76,7 @@ describe("renderAgentError", () => {
     );
     expect(r.text).toContain("No model");
     expect(r.ctaUrl).toBe(SETTINGS_URL);
-    expect(r.ctaLabel).toBe("Connect a provider");
+    expect(r.ctaLabel).toBe("Choose a model");
   });
 
   it("WORKER_UNRESPONSIVE uses OUR catalog text (no provider message) and NO CTA", async () => {
@@ -118,7 +119,7 @@ describe("renderAgentError", () => {
   });
 
   it("a CTA code whose resolver is ABSENT degrades to text-only (no throw)", async () => {
-    // provider-connect resolver omitted → PROVIDER_AUTH renders text-only.
+    // provider-management resolver omitted → PROVIDER_AUTH renders text-only.
     const r = await renderAgentError(AgentErrorCode.PROVIDER_AUTH, "auth fail", {
       "agent-settings": async () => SETTINGS_URL,
     });

--- a/packages/server/src/utils/__tests__/url-builder.test.ts
+++ b/packages/server/src/utils/__tests__/url-builder.test.ts
@@ -3,6 +3,7 @@ import {
   buildAgentSettingsUrl,
   buildEntityUrl,
   buildProviderConnectUrl,
+  buildProviderManagementUrl,
   buildResourcePermalink,
   getPublicWebUrl,
 } from '../url-builder';
@@ -86,7 +87,12 @@ describe('getPublicWebUrl', () => {
 function stubOrgSlug(): void {
   beforeEach(() => {
     vi.spyOn(workspaceModule, 'getWorkspaceProvider').mockReturnValue({
-      getOrgSlug: async (orgId: string) => (orgId === 'org-1' ? 'acme' : null),
+      getOrgSlug: async (orgId: string) =>
+        orgId === 'org-1'
+          ? 'acme'
+          : orgId === 'org-special'
+            ? 'acme/team'
+            : null,
     } as unknown as ReturnType<typeof workspaceModule.getWorkspaceProvider>);
   });
   afterEach(() => {
@@ -118,6 +124,15 @@ describe('buildAgentSettingsUrl', () => {
     );
     // agentId is percent-encoded; origin has no /lobu.
     expect(url).toBe('https://app.lobu.com/acme/agents/my%20agent%2Fid/settings');
+  });
+
+  it('percent-encodes the workspace slug', async () => {
+    const url = await buildAgentSettingsUrl(
+      'https://app.lobu.com',
+      'org-special',
+      'agent-1'
+    );
+    expect(url).toBe('https://app.lobu.com/acme%2Fteam/agents/agent-1/settings');
   });
 
   it('returns null when the org slug cannot be resolved', async () => {
@@ -156,10 +171,45 @@ describe('buildProviderConnectUrl', () => {
     );
   });
 
+  it('preserves the preflight reason + agent target', async () => {
+    const url = await buildProviderConnectUrl('https://app.lobu.com', 'org-1', {
+      provider: 'z-ai',
+      model: 'z-ai/glm-5.2',
+      reason: 'model_provider_not_connected',
+      agentId: 'agent/1',
+    });
+    expect(url).toBe(
+      'https://app.lobu.com/acme/inference-providers/new?provider=z-ai&model=z-ai%2Fglm-5.2&reason=model_provider_not_connected&agentId=agent%2F1'
+    );
+  });
+
   it('returns null when org slug or gateway url is missing', async () => {
     expect(await buildProviderConnectUrl(undefined, 'org-1')).toBeNull();
     expect(await buildProviderConnectUrl('https://x', undefined)).toBeNull();
     expect(await buildProviderConnectUrl('https://x', 'unknown-org')).toBeNull();
+  });
+});
+
+describe('buildProviderManagementUrl', () => {
+  stubOrgSlug();
+
+  it('targets the exact existing provider and model', async () => {
+    const url = await buildProviderManagementUrl(
+      'https://app.lobu.com/lobu',
+      'org-1',
+      { provider: 'z-ai', model: 'glm-5.2' }
+    );
+    expect(url).toBe(
+      'https://app.lobu.com/acme/infrastructure/models?provider=z-ai&model=glm-5.2'
+    );
+  });
+
+  it('returns null when org slug or gateway url is missing', async () => {
+    expect(await buildProviderManagementUrl(undefined, 'org-1')).toBeNull();
+    expect(await buildProviderManagementUrl('https://x', undefined)).toBeNull();
+    expect(
+      await buildProviderManagementUrl('https://x', 'unknown-org')
+    ).toBeNull();
   });
 });
 

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -66,15 +66,15 @@ export async function buildAgentSettingsUrl(
   const slug = await getOrganizationSlug(organizationId).catch(() => null);
   if (!slug) return null;
   const webOrigin = publicGatewayUrl.replace(/\/+$/, '').replace(/\/lobu$/, '');
-  return `${webOrigin}/${slug}/agents/${encodeURIComponent(agentId)}/settings`;
+  return `${webOrigin}/${encodeURIComponent(slug)}/agents/${encodeURIComponent(agentId)}/settings`;
 }
 
 /**
  * Build the org's "connect a provider" URL — `<webOrigin>/<orgSlug>/
- * inference-providers/new` — the CTA target for errors whose fix is *connecting
- * a provider* (missing/expired credentials, unroutable provider), as opposed to
- * *picking a model* on an agent (which is {@link buildAgentSettingsUrl}). This
- * is the same live route the pre-enqueue model-provider preflight links to.
+ * inference-providers/new` — the preflight CTA target when the selected model's
+ * provider is not connected yet, as opposed to *picking a model* on an agent
+ * (which is {@link buildAgentSettingsUrl}). This is the same live route the
+ * pre-enqueue model-provider preflight links to.
  *
  * Optional `provider`/`model` prefill the connect form so the user lands on the
  * exact provider to wire up. Returns null when any required piece is missing;
@@ -84,7 +84,12 @@ export async function buildAgentSettingsUrl(
 export async function buildProviderConnectUrl(
   publicGatewayUrl: string | undefined,
   organizationId: string | undefined,
-  prefill?: { provider?: string; model?: string }
+  prefill?: {
+    provider?: string;
+    model?: string;
+    reason?: string;
+    agentId?: string;
+  }
 ): Promise<string | null> {
   if (!publicGatewayUrl || !organizationId) return null;
   const slug = await getOrganizationSlug(organizationId).catch(() => null);
@@ -96,6 +101,31 @@ export async function buildProviderConnectUrl(
   );
   if (prefill?.provider) url.searchParams.set('provider', prefill.provider);
   if (prefill?.model) url.searchParams.set('model', prefill.model);
+  if (prefill?.reason) url.searchParams.set('reason', prefill.reason);
+  if (prefill?.agentId) url.searchParams.set('agentId', prefill.agentId);
+  return url.toString();
+}
+
+/**
+ * Build the org's existing-provider management URL. Provider failures should
+ * land on the configured provider row, not the new-provider flow; provider and
+ * model are non-secret targeting context carried from the worker.
+ */
+export async function buildProviderManagementUrl(
+  publicGatewayUrl: string | undefined,
+  organizationId: string | undefined,
+  target?: { provider?: string; model?: string }
+): Promise<string | null> {
+  if (!publicGatewayUrl || !organizationId) return null;
+  const slug = await getOrganizationSlug(organizationId).catch(() => null);
+  if (!slug) return null;
+  const webOrigin = publicGatewayUrl.replace(/\/+$/, '').replace(/\/lobu$/, '');
+  const url = new URL(
+    `/${encodeURIComponent(slug)}/infrastructure/models`,
+    `${webOrigin}/`
+  );
+  if (target?.provider) url.searchParams.set('provider', target.provider);
+  if (target?.model) url.searchParams.set('model', target.model);
   return url.toString();
 }
 
@@ -113,14 +143,16 @@ export interface RenderedAgentError {
 /**
  * Per-CTA-kind URL resolvers, injected so `renderAgentError` stays free of the
  * per-surface plumbing (org slug / agent id / public origin live in the caller).
- * The catalog's two actionable CTA kinds land on DIFFERENT pages:
+ * The catalog's actionable CTA kinds land on DIFFERENT pages:
  *   - `agent-settings`   → the agent's model/provider settings (pick a model).
  *   - `provider-connect` → the org's connect-a-provider page (wire credentials).
+ *   - `provider-management` → the existing provider's management surface.
  * A kind whose resolver is absent (or resolves null) renders with no button.
  */
 export interface AgentErrorCtaResolvers {
   'agent-settings'?: () => Promise<string | null>;
   'provider-connect'?: () => Promise<string | null>;
+  'provider-management'?: () => Promise<string | null>;
 }
 
 /**
@@ -146,7 +178,9 @@ export async function renderAgentError(
   const text = spec.message ?? providerMessage ?? '';
   let ctaUrl: string | null = null;
   const resolve =
-    spec.cta === 'agent-settings' || spec.cta === 'provider-connect'
+    spec.cta === 'agent-settings' ||
+    spec.cta === 'provider-connect' ||
+    spec.cta === 'provider-management'
       ? resolvers[spec.cta]
       : undefined;
   if (resolve) {


### PR DESCRIPTION
## What changed

- carries non-secret provider/model error context from worker failures through the gateway
- routes runtime provider failures to the exact existing provider configuration
- persists and replays the latest terminal agent error from Postgres after reload, clearing it after a newer success
- adds an ordered partial `runs` index for the retained thread-response history lookup
- pins merged Owletto PR #479 (`a9f9c7f8`)

## Root cause

The consolidation treated runtime provider failures like provider setup and kept browser recovery state only in the live stream. That produced generic/wrong CTAs and lost recovery actions after reload. The initial durable lookup also needed an index to avoid filtering and sorting an organization’s retained response queue on each history load.

## Impact

Users retain the error text and exact recovery action across reloads and replicas. Provider failures open the relevant provider/model settings, while preflight not-connected failures still open the provider connection flow.

## Validation

- red→green worker, renderer, URL, history-route, migration-invariant, and Owletto coverage
- `make review` on final commit: build passed; typecheck=0, unit=0, integration=0
- integration: 255 Vitest files / 2,067 tests passed, plus isolated gateway suites
- migration lint: 0 issues
- Codex review: no blockers
- Claude Fable review: 86 confidence, 0 bugs, 0 blockers, low risk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786325250&installation_id=136316292&pr_number=1847&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1847&signature=e3aa53b5c93bcc68d08eb59f1d16e82068fbedb6aae8370679ad894315aa3784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider-related errors now include targeted provider and model details.
  * Added links to manage existing providers directly from relevant error messages.
  * Model setup errors now offer a clearer “Choose a model” action.
  * Provider connection prompts can preserve the relevant agent and setup context.
  * Conversation history can display the latest unresolved agent error and removes it after a successful response.

* **Bug Fixes**
  * Improved handling of provider-specific error details across live responses and history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->