### PR TITLE
fix(agents): org-scope agent-id-keyed binding reads/deletes; drop shadowed route

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/channel-bindings-org-fence.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-bindings-org-fence.test.ts
@@ -1,0 +1,121 @@
+/**
+ * ChannelBindingService — per-org fence on agent-id-keyed reads/deletes.
+ *
+ * Lobu auto-provisions a per-org system agent whose id string is the SAME
+ * across every org (`lobu-builder` exists as a row in ~20 orgs, disambiguated
+ * only by `organization_id` — the agents PK is `(organization_id, id)`). So any
+ * read/delete that keys on `agent_id` ALONE, without also fencing on org, would
+ * smear one org's bindings into another org's view (a tenant-isolation bug).
+ *
+ * These pin the fence: `listBindings` / `deleteAllBindings` must be strictly
+ * org-scoped, and must refuse to run org-less (the leaky fallback that returned
+ * / deleted EVERY tenant's rows for a shared agent id is gone).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getDb } from "../../../db/client";
+import { ChannelBindingService } from "../../../gateway/channels/binding-service";
+import { orgContext } from "../../../lobu/stores/org-context";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import { createTestAgent, createTestOrganization } from "../../setup/test-fixtures";
+
+const SHARED_AGENT_ID = "lobu-builder";
+
+describe("ChannelBindingService org fence (agent_id shared across orgs)", () => {
+  let orgAId: string;
+  let orgBId: string;
+
+  beforeAll(async () => {
+    await cleanupTestDatabase();
+    const sql = getTestDb();
+
+    const orgA = await createTestOrganization({ name: "Fence Org A" });
+    const orgB = await createTestOrganization({ name: "Fence Org B" });
+    orgAId = orgA.id;
+    orgBId = orgB.id;
+
+    // The SAME agent id in BOTH orgs — the real `lobu-builder` shape.
+    await createTestAgent({ organizationId: orgAId, agentId: SHARED_AGENT_ID });
+    await createTestAgent({ organizationId: orgBId, agentId: SHARED_AGENT_ID });
+
+    // One binding per org, under that org's builder. connection_id is nullable;
+    // we insert directly so the test doesn't need a full chat-connection graph.
+    await sql`
+      INSERT INTO agent_channel_bindings
+        (organization_id, agent_id, platform, channel_id, team_id, created_at)
+      VALUES
+        (${orgAId}, ${SHARED_AGENT_ID}, 'slack', 'slack:CORGA', 'TA', now())
+    `;
+    await sql`
+      INSERT INTO agent_channel_bindings
+        (organization_id, agent_id, platform, channel_id, team_id, created_at)
+      VALUES
+        (${orgBId}, ${SHARED_AGENT_ID}, 'slack', 'slack:CORGB', 'TB', now())
+    `;
+  });
+
+  afterAll(async () => {
+    const sql = getTestDb();
+    await sql`DELETE FROM agent_channel_bindings WHERE organization_id IN (${orgAId}, ${orgBId})`;
+  });
+
+  it("listBindings returns ONLY the requested org's bindings, never a same-named agent's in another org", async () => {
+    const svc = new ChannelBindingService();
+
+    const aBindings = await svc.listBindings(SHARED_AGENT_ID, orgAId);
+    expect(aBindings.map((b) => b.channelId).sort()).toEqual(["slack:CORGA"]);
+    // The leak this pins: org B's channel must NOT appear in org A's listing.
+    expect(aBindings.some((b) => b.channelId === "slack:CORGB")).toBe(false);
+
+    const bBindings = await svc.listBindings(SHARED_AGENT_ID, orgBId);
+    expect(bBindings.map((b) => b.channelId).sort()).toEqual(["slack:CORGB"]);
+    expect(bBindings.some((b) => b.channelId === "slack:CORGA")).toBe(false);
+  });
+
+  it("deleteAllBindings only wipes the requested org's bindings — the other org's survive", async () => {
+    const sql = getDb();
+    const svc = new ChannelBindingService();
+
+    const removed = await svc.deleteAllBindings(SHARED_AGENT_ID, orgAId);
+    expect(removed).toBe(1);
+
+    // Org B's binding is untouched.
+    const surviving = await sql<{ channel_id: string }[]>`
+      SELECT channel_id FROM agent_channel_bindings
+      WHERE organization_id = ${orgBId} AND agent_id = ${SHARED_AGENT_ID}
+    `;
+    expect(surviving.map((r) => r.channel_id)).toEqual(["slack:CORGB"]);
+
+    // Org A's is gone.
+    const gone = await sql<{ n: number }[]>`
+      SELECT COUNT(*)::int AS n FROM agent_channel_bindings
+      WHERE organization_id = ${orgAId} AND agent_id = ${SHARED_AGENT_ID}
+    `;
+    expect(Number(gone[0]?.n)).toBe(0);
+  });
+
+  it("refuses to run org-less: no explicit org AND no ambient org context throws (closes the cross-org leak)", async () => {
+    const svc = new ChannelBindingService();
+    // Outside any orgContext.run() and with no explicit org, the old code fell
+    // back to a global `WHERE agent_id = …`. It must now throw instead.
+    await expect(
+      // @ts-expect-error — org is now REQUIRED; assert the runtime guard too.
+      svc.listBindings(SHARED_AGENT_ID, undefined),
+    ).rejects.toThrow(/requires organizationId/);
+    await expect(
+      // @ts-expect-error — org is now REQUIRED; assert the runtime guard too.
+      svc.deleteAllBindings(SHARED_AGENT_ID, undefined),
+    ).rejects.toThrow(/requires organizationId/);
+  });
+
+  it("ambient orgContext scopes the read when no explicit org is passed", async () => {
+    const svc = new ChannelBindingService();
+    // requireOrgId falls back to the AsyncLocalStorage org — so a request wrapped
+    // in org B's context reading agent lobu-builder still only sees org B's rows.
+    const bViaContext = await orgContext.run({ organizationId: orgBId }, () =>
+      // @ts-expect-error — exercise the ambient-context path with org omitted.
+      svc.listBindings(SHARED_AGENT_ID, undefined),
+    );
+    expect(bViaContext.map((b) => b.channelId)).toEqual(["slack:CORGB"]);
+  });
+});

--- a/packages/server/src/gateway/__tests__/agent-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-routes.test.ts
@@ -4,6 +4,8 @@ import { orgContext } from "../../lobu/stores/org-context.js";
 import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
 import { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import { UserAgentsStore } from "../auth/user-agents-store.js";
+import { ChannelBindingService } from "../channels/binding-service.js";
+import { getDb } from "../../db/client.js";
 import { createAgentRoutes } from "../routes/public/agents.js";
 import { setAuthProvider } from "../routes/public/settings-auth.js";
 import {
@@ -13,6 +15,7 @@ import {
 } from "./helpers/db-setup.js";
 
 const ORG_ID = "test-org-agent-routes";
+const ORG_OTHER = "test-org-agent-routes-other";
 
 describe("agent routes", () => {
   let agentMetadataStore: AgentMetadataStore;
@@ -81,5 +84,59 @@ describe("agent routes", () => {
     const data = (await response.json()) as any;
     expect(data.agents).toHaveLength(1);
     expect(data.agents[0]?.agentId).toBe("agent-1");
+  });
+
+  test("GET collection is org-scoped: never surfaces another org's same-named agent", async () => {
+    // A DIFFERENT org owns the SAME agent id (agents PK = (org, id)), owned by a
+    // DIFFERENT user, with its own channel binding. The GET collection derives
+    // each agent's org from the authoritative per-caller source, so u1 must see
+    // ONLY their org's `agent-1` (name + channelCount), never org-other's.
+    const sql = getDb();
+    await orgContext.run({ organizationId: ORG_OTHER }, async () => {
+      await seedAgentRow("agent-1", {
+        organizationId: ORG_OTHER,
+        name: "Other Org Agent 1",
+        ownerPlatform: "telegram",
+        ownerUserId: "someone-else",
+      });
+    });
+    // One binding for u1's agent-1 (ORG_ID) and one for the other org's agent-1.
+    await sql`
+      INSERT INTO agent_channel_bindings
+        (organization_id, agent_id, platform, channel_id, team_id, created_at)
+      VALUES (${ORG_ID}, 'agent-1', 'slack', 'slack:CMINE', 'T', now())
+    `;
+    await sql`
+      INSERT INTO agent_channel_bindings
+        (organization_id, agent_id, platform, channel_id, team_id, created_at)
+      VALUES (${ORG_OTHER}, 'agent-1', 'slack', 'slack:COTHER1', 'T', now()),
+             (${ORG_OTHER}, 'agent-1', 'slack', 'slack:COTHER2', 'T', now())
+    `;
+
+    setAuthProvider(() => ({
+      userId: "u1",
+      oauthUserId: "u1",
+      platform: "external",
+      exp: Date.now() + 60_000,
+    }));
+
+    const app = createAgentRoutes({
+      userAgentsStore,
+      agentMetadataStore,
+      agentSettingsStore,
+      channelBindingService: new ChannelBindingService(),
+    });
+
+    const response = await orgContext.run({ organizationId: ORG_ID }, () =>
+      app.request("/")
+    );
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as any;
+    // Exactly ORG_ID's agent-1 — the other org's same-named agent is NOT listed.
+    expect(data.agents).toHaveLength(1);
+    expect(data.agents[0]?.agentId).toBe("agent-1");
+    expect(data.agents[0]?.name).toBe("Agent 1");
+    // channelCount is org-fenced: 1 (ORG_ID's binding), NOT 2 (org-other's).
+    expect(data.agents[0]?.channelCount).toBe(1);
   });
 });

--- a/packages/server/src/gateway/__tests__/rest-api-hardening.test.ts
+++ b/packages/server/src/gateway/__tests__/rest-api-hardening.test.ts
@@ -40,7 +40,6 @@ import {
   resetTestDatabase,
   seedAgentRow,
 } from "./helpers/db-setup.js";
-import { getDb } from "../../db/client.js";
 
 // ─── Constants ─────────────────────────────────────────────────────────────────
 
@@ -171,24 +170,6 @@ describe("auth: missing and expired sessions", () => {
     expect(response.status).toBe(401);
   });
 
-  test("DELETE /api/v1/agents/:agentId without session returns 401", async () => {
-    const app = createAgentRoutes({
-      userAgentsStore,
-      agentMetadataStore,
-      agentSettingsStore,
-      channelBindingService: {
-        async getBinding() { return null; },
-        async createBinding() { return true; },
-        async listBindings() { return []; },
-        async deleteAllBindings() { return 0; },
-      } as any,
-    });
-
-    const response = await orgContext.run({ organizationId: ORG_A }, () =>
-      app.request("/agent-auth-test", { method: "DELETE" })
-    );
-    expect(response.status).toBe(401);
-  });
 
   test("expired session is rejected (401)", async () => {
     setAuthProvider(() => makeExpiredSession());
@@ -304,28 +285,6 @@ describe("cross-org isolation: agents cannot leak across organizations", () => {
     expect(response.status).toBe(404);
   });
 
-  test("user from org-a cannot DELETE agent belonging to org-b", async () => {
-    setAuthProvider(() =>
-      makeSession({ userId: "u-a", oauthUserId: "u-a" })
-    );
-
-    const app = createAgentRoutes({
-      userAgentsStore: userAgentsStoreA,
-      agentMetadataStore: agentMetadataStoreB,
-      agentSettingsStore: agentSettingsStoreA,
-      channelBindingService: {
-        async getBinding() { return null; },
-        async createBinding() { return true; },
-        async listBindings() { return []; },
-        async deleteAllBindings() { return 0; },
-      } as any,
-    });
-
-    const response = await orgContext.run({ organizationId: ORG_B }, () =>
-      app.request("/agent-org-b", { method: "DELETE" })
-    );
-    expect(response.status).toBe(404);
-  });
 
 });
 
@@ -517,28 +476,6 @@ describe("agent CRUD: access control and input validation", () => {
       })
     );
     expect(response.status).toBe(404);
-  });
-
-  test("non-owner cannot DELETE another user's agent (404)", async () => {
-    setAuthProvider(() =>
-      makeSession({ userId: "attacker", oauthUserId: "attacker" })
-    );
-
-    const response = await orgContext.run({ organizationId: ORG_A }, () =>
-      buildApp().request("/my-agent", { method: "DELETE" })
-    );
-    expect(response.status).toBe(404);
-  });
-
-  test("owner can successfully delete their own agent (200)", async () => {
-    setAuthProvider(() => makeSession({ userId: "owner", oauthUserId: "owner" }));
-
-    const response = await orgContext.run({ organizationId: ORG_A }, () =>
-      buildApp().request("/my-agent", { method: "DELETE" })
-    );
-    expect(response.status).toBe(200);
-    const data = (await response.json()) as any;
-    expect(data.success).toBe(true);
   });
 
   test("PATCH with malformed JSON body returns 400", async () => {

--- a/packages/server/src/gateway/channels/binding-service.ts
+++ b/packages/server/src/gateway/channels/binding-service.ts
@@ -1,7 +1,7 @@
 import { createLogger } from "@lobu/core";
 import { type DbClient, getDb, tsTime } from "../../db/client.js";
 import { runtimeConnectionIdToSlug } from "../../lobu/stores/connections-projection.js";
-import { requireOrgId, resolveOrgId } from "../../lobu/stores/org-context.js";
+import { requireOrgId } from "../../lobu/stores/org-context.js";
 import {
 	resolveStreamingChannelFeedId,
 	softDeleteStreamingChannelFeed,
@@ -218,36 +218,38 @@ export class ChannelBindingService {
 
 	async listBindings(
 		agentId: string,
-		organizationId?: string,
+		organizationId: string,
 	): Promise<ChannelBinding[]> {
 		const sql = getDb();
-		const orgId = resolveOrgId(organizationId);
-		const rows = orgId
-			? await sql`
+		// Org is REQUIRED: an agent id is unique only WITHIN an org (the
+		// per-org "lobu-builder" system agent has the SAME id across ~20 orgs),
+		// so an org-less `WHERE agent_id = …` would smear every tenant's
+		// bindings for that id into one caller's view.
+		const orgId = requireOrgId(
+			organizationId,
+			"ChannelBindingService.listBindings",
+		);
+		const rows = await sql`
           SELECT * FROM agent_channel_bindings
           WHERE agent_id = ${agentId} AND organization_id = ${orgId}
-        `
-			: await sql`
-          SELECT * FROM agent_channel_bindings WHERE agent_id = ${agentId}
         `;
 		return rows.map(rowToBinding);
 	}
 
 	async deleteAllBindings(
 		agentId: string,
-		organizationId?: string,
+		organizationId: string,
 	): Promise<number> {
 		const sql = getDb();
-		const orgId = resolveOrgId(organizationId);
-		const rows = orgId
-			? await sql`
+		// Org is REQUIRED — see listBindings. An org-less DELETE would wipe
+		// every tenant's bindings for a shared agent id (e.g. "lobu-builder").
+		const orgId = requireOrgId(
+			organizationId,
+			"ChannelBindingService.deleteAllBindings",
+		);
+		const rows = await sql`
           DELETE FROM agent_channel_bindings
           WHERE agent_id = ${agentId} AND organization_id = ${orgId}
-          RETURNING platform, channel_id, team_id, connection_id
-        `
-			: await sql`
-          DELETE FROM agent_channel_bindings
-          WHERE agent_id = ${agentId}
           RETURNING platform, channel_id, team_id, connection_id
         `;
 		logger.info(`Deleted ${rows.length} bindings for agent ${agentId}`);

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -272,12 +272,14 @@ const deleteAgentRoute = createRoute({
   method: "delete",
   path: "/api/v1/agents/{agentId}",
   tags: ["Agents"],
-  summary: "Delete an agent",
+  // Deletes the SESSION only (the path param is a sessionKey); the agent row
+  // itself persists — it's owned by the org or the user's personal org.
+  summary: "Delete an agent session",
   security: [{ bearerAuth: [] }],
   request: { params: AgentIdParamSchema },
   responses: {
     200: {
-      description: "Agent deleted",
+      description: "Agent session deleted",
       content: { "application/json": { schema: SuccessResponseSchema } },
     },
     ...errorResponses(ErrorResponseSchema, {
@@ -1072,7 +1074,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
 
     return c.json({
       success: true,
-      message: "Agent deleted",
+      message: "Agent session deleted",
       agentId: sessionKey,
     });
   });

--- a/packages/server/src/gateway/routes/public/agents.ts
+++ b/packages/server/src/gateway/routes/public/agents.ts
@@ -18,6 +18,7 @@ import type {
 import type { SettingsTokenPayload } from "../../auth/settings/token-service.js";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
 import type { ChannelBindingService } from "../../channels/binding-service.js";
+import { orgContext } from "../../../lobu/stores/org-context.js";
 import { resolveSettingsLookupUserId } from "../shared/agent-ownership.js";
 import {
   errorResponse,
@@ -40,25 +41,51 @@ interface AgentRoutesConfig {
   channelBindingService: ChannelBindingService;
 }
 
-async function listOwnedAgentIds(
+/**
+ * The `(agentId, organizationId)` pairs the caller owns, each org resolved from
+ * an authoritative per-caller source — NEVER the unscoped `getMetadata` (a
+ * global `WHERE id = $agentId` that returns an arbitrary tenant's row). The org
+ * is the fence key for the listing, so it must be tenant-safe:
+ *  - `agent_users` mappings → `findAgentOrganizations` (per-caller, may yield
+ *    multiple orgs for the same agent id; each is a distinct owned instance).
+ *  - external browser sessions also own via the legacy `agents.owner_user_id`
+ *    column; `listAllAgents` is ambient-org-scoped (`listAgents` filters on the
+ *    ALS org) and carries each row's `organizationId`, so it's safe to trust.
+ * De-duped on `(agentId, organizationId)`.
+ */
+async function listOwnedAgentInstances(
   payload: SettingsTokenPayload,
   config: Pick<AgentRoutesConfig, "userAgentsStore" | "agentMetadataStore">
-): Promise<string[]> {
+): Promise<Array<{ agentId: string; organizationId: string }>> {
   const lookupUserId = resolveSettingsLookupUserId(payload);
-  const agentIds = new Set(
-    await config.userAgentsStore.listAgents(payload.platform, lookupUserId)
+  const byKey = new Map<string, { agentId: string; organizationId: string }>();
+  const add = (agentId: string, organizationId: string) => {
+    byKey.set(`${organizationId} ${agentId}`, { agentId, organizationId });
+  };
+
+  const mappedAgentIds = await config.userAgentsStore.listAgents(
+    payload.platform,
+    lookupUserId
   );
+  for (const agentId of mappedAgentIds) {
+    const orgs = await config.userAgentsStore.findAgentOrganizations(
+      payload.platform,
+      lookupUserId,
+      agentId
+    );
+    for (const organizationId of orgs) add(agentId, organizationId);
+  }
 
   if (payload.platform === "external") {
     const allAgents = await config.agentMetadataStore.listAllAgents();
     for (const agent of allAgents) {
-      if (agent.owner.userId === lookupUserId) {
-        agentIds.add(agent.agentId);
+      if (agent.owner.userId === lookupUserId && agent.organizationId) {
+        add(agent.agentId, agent.organizationId);
       }
     }
   }
 
-  return [...agentIds];
+  return [...byKey.values()];
 }
 
 /**
@@ -109,7 +136,7 @@ export function createAgentRoutes(config: AgentRoutesConfig): Hono {
 
       // Check per-user limit (admins bypass)
       if (!payload.isAdmin && MAX_AGENTS_PER_USER > 0) {
-        const userAgents = await listOwnedAgentIds(payload, config);
+        const userAgents = await listOwnedAgentInstances(payload, config);
         if (userAgents.length >= MAX_AGENTS_PER_USER) {
           return errorResponse(
             c,
@@ -160,27 +187,30 @@ export function createAgentRoutes(config: AgentRoutesConfig): Hono {
     if (payload instanceof Response) return payload;
 
     try {
-      const agentIds = await listOwnedAgentIds(payload, config);
+      // Each owned instance carries its authoritative org (the fence key).
+      const instances = await listOwnedAgentInstances(payload, config);
 
       const agents = [];
-      for (const agentId of agentIds) {
-        const metadata = await config.agentMetadataStore.getMetadata(agentId);
-        // An agent id is unique only within its org; skip (rather than list
-        // cross-org) if the agent has no resolvable org.
-        if (metadata?.organizationId) {
-          const bindings = await config.channelBindingService.listBindings(
-            agentId,
-            metadata.organizationId
-          );
-          agents.push({
-            agentId,
-            name: metadata.name,
-            description: metadata.description,
-            createdAt: metadata.createdAt,
-            lastUsedAt: metadata.lastUsedAt,
-            channelCount: bindings.length,
-          });
-        }
+      for (const { agentId, organizationId } of instances) {
+        // Read metadata + bindings scoped to the resolved org. getMetadata reads
+        // the ambient ALS org, so pin it to THIS org so it selects the right
+        // row instead of an arbitrary tenant's via the global lookup.
+        const metadata = await orgContext.run({ organizationId }, () =>
+          config.agentMetadataStore.getMetadata(agentId)
+        );
+        if (!metadata) continue;
+        const bindings = await config.channelBindingService.listBindings(
+          agentId,
+          organizationId
+        );
+        agents.push({
+          agentId,
+          name: metadata.name,
+          description: metadata.description,
+          createdAt: metadata.createdAt,
+          lastUsedAt: metadata.lastUsedAt,
+          channelCount: bindings.length,
+        });
       }
 
       return c.json({ agents });
@@ -242,73 +272,11 @@ export function createAgentRoutes(config: AgentRoutesConfig): Hono {
     )
   );
 
-  // DELETE /api/v1/agents/{agentId} - Delete an agent
-  router.delete("/:agentId", async (c) =>
-    withOwnedAgent(
-      c,
-      {
-        access: ownershipAccessConfig,
-        errorLabel: "Failed to delete agent",
-        logger,
-      },
-      async ({ session, agentId, access }) => {
-        // Owner fields are only populated for non-admin sessions (admins
-        // bypass the ownership check), matching the prior inline behavior.
-        const ownerPlatform = access.ownerPlatform;
-        const ownerUserId = access.ownerUserId;
-
-        // Resolve the agent's own org — an agent id is unique only within its
-        // org (the per-org "lobu-builder" shares one id across tenants), so the
-        // unbind must be org-scoped or it would wipe a same-named agent's
-        // bindings in another tenant. `access.organizationId` is the ownership-
-        // resolved org; fall back to the agent row's own org for admin bypass.
-        const metadata = await config.agentMetadataStore.getMetadata(agentId);
-        const organizationId =
-          access.organizationId ?? metadata?.organizationId;
-        if (!organizationId) {
-          return errorResponse(c, "Agent has no organization", 400);
-        }
-
-        // Auto-unbind all channels
-        const unboundCount =
-          await config.channelBindingService.deleteAllBindings(
-            agentId,
-            organizationId
-          );
-
-        // Delete settings
-        await config.agentSettingsStore.deleteSettings(agentId);
-
-        // Delete metadata
-        await config.agentMetadataStore.deleteAgent(agentId);
-
-        // Remove from user's list
-        await config.userAgentsStore.removeAgent(
-          session.platform,
-          resolveSettingsLookupUserId(session),
-          agentId
-        );
-        if (
-          ownerPlatform &&
-          ownerUserId &&
-          (ownerPlatform !== session.platform ||
-            ownerUserId !== session.userId)
-        ) {
-          await config.userAgentsStore.removeAgent(
-            ownerPlatform,
-            ownerUserId,
-            agentId
-          );
-        }
-
-        logger.info(
-          `Deleted agent ${agentId} (unbound ${unboundCount} channels)`
-        );
-
-        return c.json({ success: true, unboundChannels: unboundCount });
-      }
-    )
-  );
+  // NOTE: DELETE /api/v1/agents/:agentId is served by the session-only handler
+  // in `agent.ts` (mounted first; Hono is first-match), and the APP/CLI delete
+  // via `/api/:orgSlug/agents/:id` (org-context middleware; bindings/settings
+  // cleaned by the composite `(org_id, agent_id)` FK ON DELETE CASCADE). A
+  // second item-DELETE here would be dead code, so it is intentionally absent.
 
   logger.debug("Agent management routes registered");
   return router;

--- a/packages/server/src/gateway/routes/public/agents.ts
+++ b/packages/server/src/gateway/routes/public/agents.ts
@@ -165,9 +165,13 @@ export function createAgentRoutes(config: AgentRoutesConfig): Hono {
       const agents = [];
       for (const agentId of agentIds) {
         const metadata = await config.agentMetadataStore.getMetadata(agentId);
-        if (metadata) {
-          const bindings =
-            await config.channelBindingService.listBindings(agentId);
+        // An agent id is unique only within its org; skip (rather than list
+        // cross-org) if the agent has no resolvable org.
+        if (metadata?.organizationId) {
+          const bindings = await config.channelBindingService.listBindings(
+            agentId,
+            metadata.organizationId
+          );
           agents.push({
             agentId,
             name: metadata.name,
@@ -253,9 +257,24 @@ export function createAgentRoutes(config: AgentRoutesConfig): Hono {
         const ownerPlatform = access.ownerPlatform;
         const ownerUserId = access.ownerUserId;
 
+        // Resolve the agent's own org — an agent id is unique only within its
+        // org (the per-org "lobu-builder" shares one id across tenants), so the
+        // unbind must be org-scoped or it would wipe a same-named agent's
+        // bindings in another tenant. `access.organizationId` is the ownership-
+        // resolved org; fall back to the agent row's own org for admin bypass.
+        const metadata = await config.agentMetadataStore.getMetadata(agentId);
+        const organizationId =
+          access.organizationId ?? metadata?.organizationId;
+        if (!organizationId) {
+          return errorResponse(c, "Agent has no organization", 400);
+        }
+
         // Auto-unbind all channels
         const unboundCount =
-          await config.channelBindingService.deleteAllBindings(agentId);
+          await config.channelBindingService.deleteAllBindings(
+            agentId,
+            organizationId
+          );
 
         // Delete settings
         await config.agentSettingsStore.deleteSettings(agentId);


### PR DESCRIPTION
Tenant-isolation hardening for agent channel bindings.

**Root issue:** `ChannelBindingService.listBindings`/`deleteAllBindings` had an org-less fallback (`WHERE agent_id = $1`). The per-org system agent `lobu-builder` shares one id across ~20 orgs, so an org-less call could read or DELETE another tenant's bindings.

**Changes:**
- `binding-service.ts`: `organizationId` now REQUIRED on both methods (`requireOrgId`); org-less branches removed. Closes the cross-tenant wipe primitive at the source.
- `agents.ts` GET collection: org-scoped via the authoritative per-caller `agent_users` mapping (`findAgentOrganizations`), not an unscoped `getMetadata`.
- Removed the shadowed `/api/v1/agents/:id` item-DELETE handler (never runs — the session-only handler in `agent.ts` is mounted first; Hono first-match wins).
- Fixed the live session-DELETE OpenAPI copy to "Delete an agent session" (behavior unchanged).

**Verified:** cross-org binding-fence regression test + GET org-scope test (both red→green on real Postgres); `make typecheck` clean.

Reviewed by Fable + codex (gpt-5.6-sol). The app/CLI delete via `/api/:orgSlug/agents/:id` (org-scoped, FK ON DELETE CASCADE) — unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786327212&installation_id=136316292&pr_number=1848&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1848&signature=32ec5a8bb547c20f4483168311265a1b77af5fb3ee25b9e3deb959f39a8eaca2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->