### PR TITLE
fix(slack): typed cross-org claim fence (stop over-matching Grid enterprise siblings)

### DIFF
--- a/packages/server/src/gateway/__tests__/slack-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim.test.ts
@@ -11,6 +11,8 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
+import { CrossOrgTransferBlockedError } from "../../lobu/stores/app-installation-store.js";
+import { ClaimMoveBlockedError } from "../connections/connection-claim.js";
 import { slackClaimProvider } from "../connections/slack-claim.js";
 import type { SlackClaimProviderDeps } from "../connections/slack-claim.js";
 import type { SlackPendingInstall } from "../../lobu/stores/slack-installations.js";
@@ -208,5 +210,39 @@ describe("slackClaimProvider.bind", () => {
     const { deps, claim } = makeDeps();
     await slackClaimProvider(deps).bind(pendingInstall(), "org-1", "user-1", true);
     expect(claim.mock.calls[0]![2]).toBe(true);
+  });
+
+  test("translates a store CrossOrgTransferBlockedError into ClaimMoveBlockedError carrying the other org", async () => {
+    // The atomic (raced) path: deps.claim throws the store-specific error; the
+    // adapter must re-resolve the incumbent org and rethrow the engine's
+    // provider-agnostic ClaimMoveBlockedError so the engine returns a 409.
+    const resolveActiveBindingElsewhere = mock(async () => ({
+      orgSlug: "incumbent",
+      orgName: "Incumbent Org",
+    }));
+    const { deps } = makeDeps({
+      resolveActiveBindingElsewhere,
+      claim: mock(async () => {
+        throw new CrossOrgTransferBlockedError("org-incumbent");
+      }),
+    });
+    const pending = pendingInstall({ enterpriseId: "E-GRID" });
+    let thrown: unknown;
+    try {
+      await slackClaimProvider(deps).bind(pending, "org-target", "user-1", false);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ClaimMoveBlockedError);
+    expect((thrown as ClaimMoveBlockedError).existing).toEqual({
+      orgSlug: "incumbent",
+      orgName: "Incumbent Org",
+    });
+    // Re-resolved against the pending's team + enterprise + target org.
+    expect(resolveActiveBindingElsewhere).toHaveBeenCalledWith(
+      TEAM,
+      "E-GRID",
+      "org-target",
+    );
   });
 });

--- a/packages/server/src/gateway/__tests__/slack-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim.test.ts
@@ -154,36 +154,44 @@ describe("slackClaimProvider.resolveExistingBinding", () => {
 });
 
 describe("slackClaimProvider.resolveActiveBindingElsewhere", () => {
-  test("keys the store lookup on the pending's team + enterprise + target org", async () => {
+  test("keys the store lookup on the pending's team + enterprise + org-wide flag + target org", async () => {
     const resolveActiveBindingElsewhere = mock(async () => ({
       orgSlug: "other",
       orgName: "Other Org",
+      matchKind: "enterprise_scope_overlap" as const,
     }));
     const { deps } = makeDeps({ resolveActiveBindingElsewhere });
     const foreign = await slackClaimProvider(deps).resolveActiveBindingElsewhere(
       TEAM,
-      pendingInstall({ enterpriseId: "E-GRID" }),
+      pendingInstall({ enterpriseId: "E-GRID", isEnterpriseInstall: true }),
       "org-target",
     );
-    expect(foreign).toEqual({ orgSlug: "other", orgName: "Other Org" });
+    expect(foreign).toEqual({
+      orgSlug: "other",
+      orgName: "Other Org",
+      matchKind: "enterprise_scope_overlap",
+    });
+    // Forwards enterprise id + the CLAIMING install's org-wide flag.
     expect(resolveActiveBindingElsewhere).toHaveBeenCalledWith(
       TEAM,
       "E-GRID",
+      true,
       "org-target",
     );
   });
 
-  test("passes a null enterpriseId through for a plain workspace", async () => {
+  test("passes a null enterpriseId + false org-wide flag for a plain workspace", async () => {
     const resolveActiveBindingElsewhere = mock(async () => null);
     const { deps } = makeDeps({ resolveActiveBindingElsewhere });
     await slackClaimProvider(deps).resolveActiveBindingElsewhere(
       TEAM,
-      pendingInstall({ enterpriseId: null }),
+      pendingInstall({ enterpriseId: null, isEnterpriseInstall: false }),
       "org-target",
     );
     expect(resolveActiveBindingElsewhere).toHaveBeenCalledWith(
       TEAM,
       null,
+      false,
       "org-target",
     );
   });
@@ -219,6 +227,7 @@ describe("slackClaimProvider.bind", () => {
     const resolveActiveBindingElsewhere = mock(async () => ({
       orgSlug: "incumbent",
       orgName: "Incumbent Org",
+      matchKind: "same_workspace" as const,
     }));
     const { deps } = makeDeps({
       resolveActiveBindingElsewhere,
@@ -226,7 +235,7 @@ describe("slackClaimProvider.bind", () => {
         throw new CrossOrgTransferBlockedError("org-incumbent");
       }),
     });
-    const pending = pendingInstall({ enterpriseId: "E-GRID" });
+    const pending = pendingInstall({ enterpriseId: "E-GRID", isEnterpriseInstall: true });
     let thrown: unknown;
     try {
       await slackClaimProvider(deps).bind(pending, "org-target", "user-1", false);
@@ -237,11 +246,13 @@ describe("slackClaimProvider.bind", () => {
     expect((thrown as ClaimMoveBlockedError).existing).toEqual({
       orgSlug: "incumbent",
       orgName: "Incumbent Org",
+      matchKind: "same_workspace",
     });
-    // Re-resolved against the pending's team + enterprise + target org.
+    // Re-resolved against the pending's team + enterprise + org-wide flag + target org.
     expect(resolveActiveBindingElsewhere).toHaveBeenCalledWith(
       TEAM,
       "E-GRID",
+      true,
       "org-target",
     );
   });

--- a/packages/server/src/gateway/__tests__/slack-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-claim.test.ts
@@ -41,6 +41,7 @@ function makeDeps(overrides: Partial<SlackClaimProviderDeps> = {}): {
   const deps: SlackClaimProviderDeps = {
     resolvePending: mock(async () => pendingInstall()),
     resolveActiveOrgSlug: mock(async () => null),
+    resolveActiveBindingElsewhere: mock(async () => null),
     resolveClaimerSlackIdentities: mock(async () => [
       { teamId: TEAM, slackUserId: "U-ADMIN" },
     ]),
@@ -150,6 +151,42 @@ describe("slackClaimProvider.resolveExistingBinding", () => {
   });
 });
 
+describe("slackClaimProvider.resolveActiveBindingElsewhere", () => {
+  test("keys the store lookup on the pending's team + enterprise + target org", async () => {
+    const resolveActiveBindingElsewhere = mock(async () => ({
+      orgSlug: "other",
+      orgName: "Other Org",
+    }));
+    const { deps } = makeDeps({ resolveActiveBindingElsewhere });
+    const foreign = await slackClaimProvider(deps).resolveActiveBindingElsewhere(
+      TEAM,
+      pendingInstall({ enterpriseId: "E-GRID" }),
+      "org-target",
+    );
+    expect(foreign).toEqual({ orgSlug: "other", orgName: "Other Org" });
+    expect(resolveActiveBindingElsewhere).toHaveBeenCalledWith(
+      TEAM,
+      "E-GRID",
+      "org-target",
+    );
+  });
+
+  test("passes a null enterpriseId through for a plain workspace", async () => {
+    const resolveActiveBindingElsewhere = mock(async () => null);
+    const { deps } = makeDeps({ resolveActiveBindingElsewhere });
+    await slackClaimProvider(deps).resolveActiveBindingElsewhere(
+      TEAM,
+      pendingInstall({ enterpriseId: null }),
+      "org-target",
+    );
+    expect(resolveActiveBindingElsewhere).toHaveBeenCalledWith(
+      TEAM,
+      null,
+      "org-target",
+    );
+  });
+});
+
 describe("slackClaimProvider.bind", () => {
   test("maps the Slack installationId onto the engine's bindingId contract", async () => {
     const { deps, claim } = makeDeps();
@@ -157,11 +194,19 @@ describe("slackClaimProvider.bind", () => {
       pendingInstall(),
       "org-1",
       "user-1",
+      false,
     );
     expect(result).toEqual({ bindingId: "slackinst-bound" });
     expect(claim).toHaveBeenCalledTimes(1);
-    const [boundPending, boundOrg] = claim.mock.calls[0]!;
+    const [boundPending, boundOrg, boundConfirmMove] = claim.mock.calls[0]!;
     expect((boundPending as SlackPendingInstall).teamId).toBe(TEAM);
     expect(boundOrg).toBe("org-1");
+    expect(boundConfirmMove).toBe(false);
+  });
+
+  test("forwards confirmMove:true to the store claim (deliberate move)", async () => {
+    const { deps, claim } = makeDeps();
+    await slackClaimProvider(deps).bind(pendingInstall(), "org-1", "user-1", true);
+    expect(claim.mock.calls[0]![2]).toBe(true);
   });
 });

--- a/packages/server/src/gateway/connections/__tests__/connection-claim.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/connection-claim.test.ts
@@ -13,6 +13,7 @@ import {
   type ClaimEligibleOrg,
   type ClaimEngineDeps,
   type ClaimForeignBinding,
+  ClaimMoveBlockedError,
   type ClaimProvider,
   claimHttpStatus,
   claimPendingConnection,
@@ -216,6 +217,27 @@ describe("claimPendingConnection", () => {
 
     test("fence maps to 409 in the HTTP layer", () => {
       expect(claimHttpStatus("already_connected_elsewhere")).toBe(409);
+    });
+
+    test("atomic-guard trip in bind maps to already_connected_elsewhere, NOT claim_failed", async () => {
+      // The raced path: the sequential pre-check saw null (foreign binding not yet
+      // committed), so bind runs — and its atomic under-lock fence trips, throwing
+      // ClaimMoveBlockedError. The engine must surface the SAME 409 outcome as the
+      // pre-check, carrying the other org, never a 500 claim_failed.
+      const racedBind = mock(async () => {
+        throw new ClaimMoveBlockedError(foreign);
+      });
+      const { provider } = makeProvider({
+        // Pre-check misses (simulating the race), bind's atomic fence catches it.
+        resolveActiveBindingElsewhere: mock(async () => null),
+        bind: racedBind,
+      });
+      const result = await claimPendingConnection(provider, makeDeps(), input);
+      expect(result).toEqual({
+        status: "already_connected_elsewhere",
+        existing: foreign,
+      });
+      expect(racedBind).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/server/src/gateway/connections/__tests__/connection-claim.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/connection-claim.test.ts
@@ -164,7 +164,16 @@ describe("claimPendingConnection", () => {
   // be silently walked into a second org. The engine surfaces the other org and
   // refuses to bind unless the claimer explicitly confirms the move.
   describe("cross-org fence", () => {
-    const foreign: ClaimForeignBinding = { orgSlug: "acme", orgName: "Acme" };
+    const foreign: ClaimForeignBinding = {
+      orgSlug: "acme",
+      orgName: "Acme",
+      matchKind: "same_workspace",
+    };
+    const overlap: ClaimForeignBinding = {
+      orgSlug: "grid",
+      orgName: "Grid Org",
+      matchKind: "enterprise_scope_overlap",
+    };
 
     test("(a) first claim into org A binds normally (no foreign binding)", async () => {
       const { provider, bind } = makeProvider();
@@ -196,7 +205,7 @@ describe("claimPendingConnection", () => {
       expect(resolveActiveBindingElsewhere.mock.calls[0]![2]).toBe("org-1");
     });
 
-    test("(c) second claim WITH confirmMove binds and skips the fence", async () => {
+    test("(c) second claim WITH confirmMove binds a same_workspace conflict (fence still runs)", async () => {
       const resolveActiveBindingElsewhere = mock(async () => foreign);
       const { provider, bind } = makeProvider({ resolveActiveBindingElsewhere });
       const result = await claimPendingConnection(provider, makeDeps(), {
@@ -209,26 +218,43 @@ describe("claimPendingConnection", () => {
         orgSlug: "acme",
         bindingId: "binding-bound",
       });
-      // confirmMove short-circuits the pre-check (bind re-enforces atomically).
-      expect(resolveActiveBindingElsewhere).not.toHaveBeenCalled();
+      // The pre-check ALWAYS runs now (so enterprise_scope_overlap is never
+      // silently confirmed away); confirmMove only waives the same_workspace block.
+      expect(resolveActiveBindingElsewhere).toHaveBeenCalledTimes(1);
       expect(bind).toHaveBeenCalledTimes(1);
       expect(bind.mock.calls[0]![3]).toBe(true);
     });
 
-    test("fence maps to 409 in the HTTP layer", () => {
-      expect(claimHttpStatus("already_connected_elsewhere")).toBe(409);
+    test("enterprise_scope_overlap blocks EVEN WITH confirmMove (not overridable)", async () => {
+      const resolveActiveBindingElsewhere = mock(async () => overlap);
+      const { provider, bind } = makeProvider({ resolveActiveBindingElsewhere });
+      const result = await claimPendingConnection(provider, makeDeps(), {
+        ...input,
+        organizationId: "other-org",
+        confirmMove: true,
+      });
+      expect(result).toEqual({
+        status: "enterprise_scope_overlap",
+        existing: overlap,
+      });
+      // A Grid scope overlap is a routing collision, not a movable binding — the
+      // cross-key demote can't move it, so confirmMove must NOT bind it.
+      expect(bind).not.toHaveBeenCalled();
     });
 
-    test("atomic-guard trip in bind maps to already_connected_elsewhere, NOT claim_failed", async () => {
+    test("both fence statuses map to 409, kept distinct", () => {
+      expect(claimHttpStatus("already_connected_elsewhere")).toBe(409);
+      expect(claimHttpStatus("enterprise_scope_overlap")).toBe(409);
+    });
+
+    test("atomic-guard trip in bind maps by matchKind (same_workspace → already_connected_elsewhere)", async () => {
       // The raced path: the sequential pre-check saw null (foreign binding not yet
       // committed), so bind runs — and its atomic under-lock fence trips, throwing
-      // ClaimMoveBlockedError. The engine must surface the SAME 409 outcome as the
-      // pre-check, carrying the other org, never a 500 claim_failed.
+      // ClaimMoveBlockedError. The engine must surface the SAME typed 409 outcome.
       const racedBind = mock(async () => {
         throw new ClaimMoveBlockedError(foreign);
       });
       const { provider } = makeProvider({
-        // Pre-check misses (simulating the race), bind's atomic fence catches it.
         resolveActiveBindingElsewhere: mock(async () => null),
         bind: racedBind,
       });
@@ -238,6 +264,20 @@ describe("claimPendingConnection", () => {
         existing: foreign,
       });
       expect(racedBind).toHaveBeenCalledTimes(1);
+    });
+
+    test("atomic-guard trip with an enterprise overlap maps to enterprise_scope_overlap", async () => {
+      const { provider } = makeProvider({
+        resolveActiveBindingElsewhere: mock(async () => null),
+        bind: mock(async () => {
+          throw new ClaimMoveBlockedError(overlap);
+        }),
+      });
+      const result = await claimPendingConnection(provider, makeDeps(), input);
+      expect(result).toEqual({
+        status: "enterprise_scope_overlap",
+        existing: overlap,
+      });
     });
   });
 

--- a/packages/server/src/gateway/connections/__tests__/connection-claim.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/connection-claim.test.ts
@@ -12,6 +12,7 @@ import {
   type ClaimAuthorization,
   type ClaimEligibleOrg,
   type ClaimEngineDeps,
+  type ClaimForeignBinding,
   type ClaimProvider,
   claimHttpStatus,
   claimPendingConnection,
@@ -43,6 +44,7 @@ function makeProvider(overrides: Partial<ClaimProvider<StubPending>> = {}): {
     subjectKind: "workspace",
     resolvePending: mock(async () => ({ ref: REF, name: "Acme" })),
     resolveExistingBinding: mock(async () => null),
+    resolveActiveBindingElsewhere: mock(async () => null),
     authorize,
     bind,
     ...overrides,
@@ -155,6 +157,66 @@ describe("claimPendingConnection", () => {
       alreadyConnected: true,
     });
     expect(bind).not.toHaveBeenCalled();
+  });
+
+  // Cross-org fence (PR2): a subject already ACTIVE in a DIFFERENT org must not
+  // be silently walked into a second org. The engine surfaces the other org and
+  // refuses to bind unless the claimer explicitly confirms the move.
+  describe("cross-org fence", () => {
+    const foreign: ClaimForeignBinding = { orgSlug: "acme", orgName: "Acme" };
+
+    test("(a) first claim into org A binds normally (no foreign binding)", async () => {
+      const { provider, bind } = makeProvider();
+      const result = await claimPendingConnection(provider, makeDeps(), input);
+      expect(result).toEqual({
+        status: "ok",
+        orgSlug: "acme",
+        bindingId: "binding-bound",
+      });
+      // bind is called with confirmMove=false on the un-fenced first claim.
+      expect(bind).toHaveBeenCalledTimes(1);
+      expect(bind.mock.calls[0]![3]).toBe(false);
+    });
+
+    test("(b) naive second claim into org B is fenced, never bound", async () => {
+      const resolveActiveBindingElsewhere = mock(async () => foreign);
+      const { provider, bind } = makeProvider({ resolveActiveBindingElsewhere });
+      const result = await claimPendingConnection(provider, makeDeps(), {
+        ...input,
+        organizationId: "other-org",
+      });
+      expect(result).toEqual({
+        status: "already_connected_elsewhere",
+        existing: foreign,
+      });
+      expect(bind).not.toHaveBeenCalled();
+      // The fence is asked against the membership-resolved TARGET org id.
+      expect(resolveActiveBindingElsewhere).toHaveBeenCalledTimes(1);
+      expect(resolveActiveBindingElsewhere.mock.calls[0]![2]).toBe("org-1");
+    });
+
+    test("(c) second claim WITH confirmMove binds and skips the fence", async () => {
+      const resolveActiveBindingElsewhere = mock(async () => foreign);
+      const { provider, bind } = makeProvider({ resolveActiveBindingElsewhere });
+      const result = await claimPendingConnection(provider, makeDeps(), {
+        ...input,
+        organizationId: "other-org",
+        confirmMove: true,
+      });
+      expect(result).toEqual({
+        status: "ok",
+        orgSlug: "acme",
+        bindingId: "binding-bound",
+      });
+      // confirmMove short-circuits the pre-check (bind re-enforces atomically).
+      expect(resolveActiveBindingElsewhere).not.toHaveBeenCalled();
+      expect(bind).toHaveBeenCalledTimes(1);
+      expect(bind.mock.calls[0]![3]).toBe(true);
+    });
+
+    test("fence maps to 409 in the HTTP layer", () => {
+      expect(claimHttpStatus("already_connected_elsewhere")).toBe(409);
+    });
   });
 
   test("404s when the subject has no install at all", async () => {

--- a/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
@@ -969,6 +969,17 @@ describe("Grid install-model routing (per-workspace + org-wide enterprise)", () 
       `;
       expect(releasedPending[0]?.organization_id).toBeNull();
 
+      // FIX 2: the fenced claim token-first persisted a bot token under a minted
+      // slackinst- id in the REFUSED org's bucket; it must be purged, not leaked.
+      const { orgContext } = await import("../../../lobu/stores/org-context.js");
+      const refusedOrgSecrets = await orgContext.run(
+        { organizationId: "org-claim-fence-b" },
+        () => secretStore.list("installations/"),
+      );
+      expect(
+        refusedOrgSecrets.filter((s) => s.name.startsWith("installations/slackinst-")),
+      ).toHaveLength(0);
+
       // (c) A deliberate claim WITH confirmMove moves the workspace to org B.
       const pendingC = await slack.resolveSlackPendingByTenant("T_CLAIM_FENCE");
       await slack.claimSlackPendingInstall(
@@ -984,6 +995,123 @@ describe("Grid install-model routing (per-workspace + org-wide enterprise)", () 
       expect((await slack.getSlackInstallById(store, boundA.installationId))?.status).toBe(
         "stopped",
       );
+    });
+
+    // FIX 1: Grid cross-key. Org A holds a per-workspace install (tuple keyed on
+    // the TEAM id) carrying enterprise_id=E; a fence-active claim of the ORG-WIDE
+    // pending (tuple keyed on the ENTERPRISE id) into org B touches a DIFFERENT
+    // tuple, so the tuple lock/guard alone would miss it. The enterprise-keyed
+    // fence arm must still refuse it.
+    test("a cross-key Grid claim (enterprise-id tuple vs team-id tuple) is fenced", async () => {
+      await seedAgentRow("grid-a", { organizationId: "org-grid-a" });
+      await seedAgentRow("grid-b", { organizationId: "org-grid-b" });
+      const { store, secretStore, slack } = build();
+      const { CrossOrgTransferBlockedError } = await import(
+        "../../../lobu/stores/app-installation-store.js"
+      );
+
+      // org A: a per-workspace install of T_GRID_HOME under enterprise E_GRID.
+      await slack.upsertSlackInstallByTeam(store, secretStore, "org-grid-a", "T_GRID_HOME", {
+        botToken: "xoxb-grid-home",
+        enterpriseId: "E_GRID",
+      });
+
+      // A Grid ORG-WIDE pending keyed on the ENTERPRISE id (external_tenant_id=E_GRID).
+      await slack.writeSlackPendingInstall({
+        teamId: "E_GRID",
+        teamName: "Grid Wide",
+        botUserId: "U_BOT",
+        botToken: "xoxb-grid-wide",
+        installerUserId: "U_INSTALLER",
+        isEnterpriseInstall: true,
+        enterpriseId: "E_GRID",
+      });
+      const pendingWide = await slack.resolveSlackPendingByTenant("E_GRID", "E_GRID");
+      expect(pendingWide?.teamId).toBe("E_GRID");
+
+      // A naive (confirmMove=false) claim into org B must be refused by the
+      // enterprise-keyed fence arm, even though the tuples differ.
+      await expect(
+        slack.claimSlackPendingInstall(store, secretStore, pendingWide!, "org-grid-b"),
+      ).rejects.toBeInstanceOf(CrossOrgTransferBlockedError);
+      // org A's per-workspace install is untouched.
+      expect(
+        (await slack.getSlackInstallByTeamId(store, "T_GRID_HOME"))?.organizationId,
+      ).toBe("org-grid-a");
+    });
+
+    // FIX 1 (atomic): two CONCURRENT cross-key claims of the same enterprise into
+    // two orgs. Without the enterprise-keyed advisory lock they take different
+    // per-tuple locks and both read the fence as clear before either commits,
+    // silently binding two orgs. The shared metadata-group lock serializes them so
+    // at most one wins.
+    test("concurrent cross-key Grid claims into two orgs bind exactly one (atomic)", async () => {
+      await seedAgentRow("grid-race-a", { organizationId: "org-grid-race-a" });
+      await seedAgentRow("grid-race-b", { organizationId: "org-grid-race-b" });
+      const { store, secretStore, slack } = build();
+      const sql = getDb();
+
+      // org A: per-workspace install (team-id tuple) under E_RACE — NOT yet claimed
+      // by the racers; this is the incumbent the fence must protect.
+      await slack.upsertSlackInstallByTeam(store, secretStore, "org-grid-race-a", "T_RACE_HOME", {
+        botToken: "xoxb-race-home",
+        enterpriseId: "E_RACE",
+      });
+
+      // Two separate ORG-WIDE pendings (enterprise-id tuple) — one per racing org.
+      // (A real deploy has one pending; two lets both callers pass the durable
+      // pending-row claim and race into the activation fence, which is the path
+      // under test.)
+      await slack.writeSlackPendingInstall({
+        teamId: "E_RACE",
+        teamName: "Race Wide",
+        botUserId: "U_BOT",
+        botToken: "xoxb-race-wide",
+        installerUserId: "U_INSTALLER",
+        isEnterpriseInstall: true,
+        enterpriseId: "E_RACE",
+      });
+      const pending = await slack.resolveSlackPendingByTenant("E_RACE", "E_RACE");
+
+      // Delay one activation so both overlap inside the fence window.
+      await sql.unsafe(`
+        CREATE OR REPLACE FUNCTION public.test_delay_grid_race()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+          IF NEW.organization_id = 'org-grid-race-a' THEN
+            PERFORM pg_sleep(0.5);
+          END IF;
+          RETURN NEW;
+        END;
+        $$
+      `);
+      await sql.unsafe(`
+        CREATE TRIGGER test_delay_grid_race
+        BEFORE INSERT OR UPDATE ON app_installations
+        FOR EACH ROW EXECUTE FUNCTION public.test_delay_grid_race()
+      `);
+      try {
+        const results = await Promise.allSettled([
+          slack.claimSlackPendingInstall(store, secretStore, pending!, "org-grid-race-a"),
+          slack.claimSlackPendingInstall(store, secretStore, pending!, "org-grid-race-b"),
+        ]);
+        const rejected = results.filter((r) => r.status === "rejected");
+        // At least one racer is fenced; neither silently co-binds a second org.
+        expect(rejected.length).toBeGreaterThanOrEqual(1);
+        // Exactly one active install exists for the enterprise across both orgs
+        // (the incumbent T_RACE_HOME, or a confirmed winner — never two).
+        const activeByEnt = await sql`
+          SELECT organization_id FROM app_installations
+          WHERE provider = 'slack'
+            AND status = 'active'
+            AND (external_tenant_id = 'E_RACE' OR metadata ->> 'enterprise_id' = 'E_RACE')
+        `;
+        const orgs = new Set(activeByEnt.map((r: { organization_id: string }) => r.organization_id));
+        expect(orgs.size).toBe(1);
+      } finally {
+        await sql.unsafe("DROP TRIGGER IF EXISTS test_delay_grid_race ON app_installations");
+        await sql.unsafe("DROP FUNCTION IF EXISTS public.test_delay_grid_race()");
+      }
     });
   });
 });

--- a/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
@@ -842,4 +842,148 @@ describe("Grid install-model routing (per-workspace + org-wide enterprise)", () 
       }),
     ).toEqual([]);
   });
+
+  // Cross-org claim fence (PR2): a workspace already ACTIVE in one org must not be
+  // silently transferred into a second org by a naive claim. The store enforces
+  // this atomically under the active-tenant advisory lock; the read-side helper
+  // powers the engine's friendly `already_connected_elsewhere` pre-check.
+  describe("cross-org fence", () => {
+    test("resolveSlackActiveBindingElsewhere finds a foreign active install (team_id), null for the owning org", async () => {
+      await seedAgentRow("fence-a", { organizationId: "org-fence-a" });
+      const { store, secretStore, slack } = build();
+      await slack.upsertSlackInstallByTeam(
+        store,
+        secretStore,
+        "org-fence-a",
+        "T_FENCE",
+        { botToken: "xoxb-a" },
+      );
+      // A DIFFERENT org sees org-fence-a's binding as foreign.
+      const foreign = await slack.resolveSlackActiveBindingElsewhere(
+        "T_FENCE",
+        null,
+        "org-fence-b",
+      );
+      expect(foreign?.organizationId).toBe("org-fence-a");
+      expect(foreign?.orgSlug).toBe("org-fence-a");
+      // The owning org itself sees no foreign binding.
+      expect(
+        await slack.resolveSlackActiveBindingElsewhere(
+          "T_FENCE",
+          null,
+          "org-fence-a",
+        ),
+      ).toBeNull();
+    });
+
+    test("resolveSlackActiveBindingElsewhere matches a Grid sibling by enterprise_id", async () => {
+      await seedAgentRow("fence-ent", { organizationId: "org-fence-ent" });
+      const { store, secretStore, slack } = build();
+      // Install on ONE workspace of the enterprise.
+      await slack.upsertSlackInstallByTeam(
+        store,
+        secretStore,
+        "org-fence-ent",
+        "T_GRID_HOME",
+        { botToken: "xoxb-grid", enterpriseId: "E_GRID_FENCE" },
+      );
+      // A sibling-workspace team id misses on team_id but matches on enterprise.
+      const foreign = await slack.resolveSlackActiveBindingElsewhere(
+        "T_GRID_SIBLING",
+        "E_GRID_FENCE",
+        "org-other",
+      );
+      expect(foreign?.organizationId).toBe("org-fence-ent");
+      // A genuinely different plain workspace (no enterprise) never collides.
+      expect(
+        await slack.resolveSlackActiveBindingElsewhere(
+          "T_GRID_SIBLING",
+          null,
+          "org-other",
+        ),
+      ).toBeNull();
+    });
+
+    test("(a) first claim into org A succeeds, (b) naive claim into org B is fenced, (c) confirmMove moves it", async () => {
+      await seedAgentRow("claim-fence-a", { organizationId: "org-claim-fence-a" });
+      await seedAgentRow("claim-fence-b", { organizationId: "org-claim-fence-b" });
+      const { store, secretStore, slack } = build();
+      const { CrossOrgTransferBlockedError } = await import(
+        "../../../lobu/stores/app-installation-store.js"
+      );
+
+      // (a) First claim into org A binds the workspace.
+      await slack.writeSlackPendingInstall({
+        teamId: "T_CLAIM_FENCE",
+        teamName: "Fence Co",
+        botUserId: "U_BOT",
+        botToken: "xoxb-fence",
+        installerUserId: "U_INSTALLER",
+        isEnterpriseInstall: false,
+        enterpriseId: null,
+      });
+      const pendingA = await slack.resolveSlackPendingByTenant("T_CLAIM_FENCE");
+      const boundA = await slack.claimSlackPendingInstall(
+        store,
+        secretStore,
+        pendingA!,
+        "org-claim-fence-a",
+      );
+      expect(
+        (await slack.getSlackInstallByTeamId(store, "T_CLAIM_FENCE"))
+          ?.organizationId,
+      ).toBe("org-claim-fence-a");
+
+      // (b) A naive second claim into org B (confirmMove defaulting false) is
+      // refused atomically — the active row stays with org A, and the durable
+      // pending-row claim is released back to org-less so it isn't stranded.
+      await slack.writeSlackPendingInstall({
+        teamId: "T_CLAIM_FENCE",
+        teamName: "Fence Co",
+        botUserId: "U_BOT",
+        botToken: "xoxb-fence",
+        installerUserId: "U_INSTALLER",
+        isEnterpriseInstall: false,
+        enterpriseId: null,
+      });
+      const pendingB = await slack.resolveSlackPendingByTenant("T_CLAIM_FENCE");
+      await expect(
+        slack.claimSlackPendingInstall(
+          store,
+          secretStore,
+          pendingB!,
+          "org-claim-fence-b",
+        ),
+      ).rejects.toBeInstanceOf(CrossOrgTransferBlockedError);
+      // org A still owns the single active install — no silent steal.
+      const afterFence = await slack.getSlackInstallByTeamId(
+        store,
+        "T_CLAIM_FENCE",
+      );
+      expect(afterFence?.organizationId).toBe("org-claim-fence-a");
+      expect(afterFence?.id).toBe(boundA.installationId);
+      // The pending row was released (org-less), still claimable.
+      const releasedPending = await getDb()`
+        SELECT organization_id FROM app_installations
+        WHERE id = ${pendingB!.id}::bigint AND status = 'pending'
+      `;
+      expect(releasedPending[0]?.organization_id).toBeNull();
+
+      // (c) A deliberate claim WITH confirmMove moves the workspace to org B.
+      const pendingC = await slack.resolveSlackPendingByTenant("T_CLAIM_FENCE");
+      await slack.claimSlackPendingInstall(
+        store,
+        secretStore,
+        pendingC!,
+        "org-claim-fence-b",
+        true,
+      );
+      const moved = await slack.getSlackInstallByTeamId(store, "T_CLAIM_FENCE");
+      expect(moved?.organizationId).toBe("org-claim-fence-b");
+      // org A's prior active row was demoted by the confirmed transfer.
+      expect((await slack.getSlackInstallById(store, boundA.installationId))?.status).toBe(
+        "stopped",
+      );
+    });
+  });
 });

--- a/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/slack-installations.test.ts
@@ -848,7 +848,8 @@ describe("Grid install-model routing (per-workspace + org-wide enterprise)", () 
   // this atomically under the active-tenant advisory lock; the read-side helper
   // powers the engine's friendly `already_connected_elsewhere` pre-check.
   describe("cross-org fence", () => {
-    test("resolveSlackActiveBindingElsewhere finds a foreign active install (team_id), null for the owning org", async () => {
+    // CASE 1: same exact workspace team id in another org → same_workspace.
+    test("resolveSlackActiveBindingElsewhere matches same team_id in another org (same_workspace), null for the owning org", async () => {
       await seedAgentRow("fence-a", { organizationId: "org-fence-a" });
       const { store, secretStore, slack } = build();
       await slack.upsertSlackInstallByTeam(
@@ -858,50 +859,101 @@ describe("Grid install-model routing (per-workspace + org-wide enterprise)", () 
         "T_FENCE",
         { botToken: "xoxb-a" },
       );
-      // A DIFFERENT org sees org-fence-a's binding as foreign.
+      // A DIFFERENT org sees org-fence-a's binding as foreign (same_workspace).
       const foreign = await slack.resolveSlackActiveBindingElsewhere(
         "T_FENCE",
         null,
+        false,
         "org-fence-b",
       );
       expect(foreign?.organizationId).toBe("org-fence-a");
       expect(foreign?.orgSlug).toBe("org-fence-a");
+      expect(foreign?.matchKind).toBe("same_workspace");
       // The owning org itself sees no foreign binding.
       expect(
         await slack.resolveSlackActiveBindingElsewhere(
           "T_FENCE",
           null,
+          false,
           "org-fence-a",
         ),
       ).toBeNull();
     });
 
-    test("resolveSlackActiveBindingElsewhere matches a Grid sibling by enterprise_id", async () => {
-      await seedAgentRow("fence-ent", { organizationId: "org-fence-ent" });
+    // CASE 3 (the over-match fix): two INDEPENDENT per-workspace siblings sharing an
+    // enterprise, NEITHER org-wide → ALLOWED. The old broad enterprise arm blocked
+    // this; the typed arm must NOT.
+    test("two per-workspace Grid siblings (same enterprise, neither org-wide) do NOT conflict", async () => {
+      await seedAgentRow("sib-a", { organizationId: "org-sib-a" });
       const { store, secretStore, slack } = build();
-      // Install on ONE workspace of the enterprise.
+      // org A holds a PER-WORKSPACE install (isEnterpriseInstall omitted/false).
       await slack.upsertSlackInstallByTeam(
         store,
         secretStore,
-        "org-fence-ent",
-        "T_GRID_HOME",
-        { botToken: "xoxb-grid", enterpriseId: "E_GRID_FENCE" },
+        "org-sib-a",
+        "T_SIB_A",
+        { botToken: "xoxb-sib-a", enterpriseId: "E_SIB" },
       );
-      // A sibling-workspace team id misses on team_id but matches on enterprise.
+      // A DIFFERENT sibling workspace (T_SIB_B), also per-workspace, claimed into
+      // another org: NOT a conflict — independent workspaces of one Grid may live
+      // in different orgs.
       const foreign = await slack.resolveSlackActiveBindingElsewhere(
-        "T_GRID_SIBLING",
-        "E_GRID_FENCE",
-        "org-other",
+        "T_SIB_B",
+        "E_SIB",
+        false,
+        "org-sib-b",
       );
-      expect(foreign?.organizationId).toBe("org-fence-ent");
-      // A genuinely different plain workspace (no enterprise) never collides.
-      expect(
-        await slack.resolveSlackActiveBindingElsewhere(
-          "T_GRID_SIBLING",
-          null,
-          "org-other",
-        ),
-      ).toBeNull();
+      expect(foreign).toBeNull();
+    });
+
+    // CASE 4a: the CLAIMING install is ORG-WIDE → any foreign sibling overlaps →
+    // enterprise_scope_overlap.
+    test("an org-wide Grid claim overlaps a per-workspace sibling in another org (enterprise_scope_overlap)", async () => {
+      await seedAgentRow("ow-a", { organizationId: "org-ow-a" });
+      const { store, secretStore, slack } = build();
+      // org A holds a per-workspace sibling of E_OW.
+      await slack.upsertSlackInstallByTeam(
+        store,
+        secretStore,
+        "org-ow-a",
+        "T_OW_SIB",
+        { botToken: "xoxb-ow", enterpriseId: "E_OW" },
+      );
+      // We claim the ORG-WIDE install (external tenant = enterprise, org-wide flag)
+      // into another org → overlaps org A's per-workspace sibling.
+      const foreign = await slack.resolveSlackActiveBindingElsewhere(
+        "E_OW",
+        "E_OW",
+        true,
+        "org-ow-b",
+      );
+      expect(foreign?.organizationId).toBe("org-ow-a");
+      expect(foreign?.matchKind).toBe("enterprise_scope_overlap");
+    });
+
+    // CASE 4b: the FOREIGN install is ORG-WIDE and we claim a per-workspace sibling
+    // → its org-wide scope covers ours → enterprise_scope_overlap.
+    test("a per-workspace claim overlaps a FOREIGN org-wide Grid install (enterprise_scope_overlap)", async () => {
+      await seedAgentRow("owf-a", { organizationId: "org-owf-a" });
+      const { store, secretStore, slack } = build();
+      // org A holds the ORG-WIDE install of E_OWF (external tenant = enterprise).
+      await slack.upsertSlackInstallByTeam(
+        store,
+        secretStore,
+        "org-owf-a",
+        "E_OWF",
+        { botToken: "xoxb-owf", enterpriseId: "E_OWF", isEnterpriseInstall: true },
+      );
+      // We claim a per-workspace sibling into another org → the foreign org-wide
+      // install already covers it.
+      const foreign = await slack.resolveSlackActiveBindingElsewhere(
+        "T_OWF_SIB",
+        "E_OWF",
+        false,
+        "org-owf-b",
+      );
+      expect(foreign?.organizationId).toBe("org-owf-a");
+      expect(foreign?.matchKind).toBe("enterprise_scope_overlap");
     });
 
     test("(a) first claim into org A succeeds, (b) naive claim into org B is fenced, (c) confirmMove moves it", async () => {

--- a/packages/server/src/gateway/connections/connection-claim.ts
+++ b/packages/server/src/gateway/connections/connection-claim.ts
@@ -33,6 +33,22 @@ export interface ClaimForeignBinding {
   orgName: string | null;
 }
 
+/**
+ * A provider's `bind` throws this when its ATOMIC (under-lock) cross-org fence
+ * trips — the raced path the engine's sequential pre-check could not see (two
+ * concurrent claims both read null before either committed). The engine catches
+ * it and maps it to the SAME `already_connected_elsewhere` result the pre-check
+ * returns, so both paths yield a consistent 409 carrying the other org, never a
+ * 500 `claim_failed`. Provider-agnostic on purpose: the Slack adapter translates
+ * its store-specific `CrossOrgTransferBlockedError` into this.
+ */
+export class ClaimMoveBlockedError extends Error {
+  constructor(readonly existing: ClaimForeignBinding) {
+    super("Subject already actively bound in a different org (move not confirmed)");
+    this.name = "ClaimMoveBlockedError";
+  }
+}
+
 /** Terminal outcome of the bind (`claimPendingConnection`). */
 export type ClaimResult =
   | {
@@ -297,6 +313,11 @@ export async function claimPendingConnection<P>(
     const orgSlug = await deps.resolveOrgSlug(organizationId);
     return { status: "ok", orgSlug, bindingId };
   } catch (err) {
+    // The atomic (under-lock) fence in the provider's bind tripped on the raced
+    // path — surface the SAME explicit outcome as the pre-check, not a 500.
+    if (err instanceof ClaimMoveBlockedError) {
+      return { status: "already_connected_elsewhere", existing: err.existing };
+    }
     return {
       status: "claim_failed",
       message: err instanceof Error ? err.message : String(err),

--- a/packages/server/src/gateway/connections/connection-claim.ts
+++ b/packages/server/src/gateway/connections/connection-claim.ts
@@ -27,6 +27,12 @@ export type ClaimError =
   | { status: "no_org" }
   | { status: "claim_failed"; message: string };
 
+/** The identity of the OTHER org a subject is already actively bound to. */
+export interface ClaimForeignBinding {
+  orgSlug: string | null;
+  orgName: string | null;
+}
+
 /** Terminal outcome of the bind (`claimPendingConnection`). */
 export type ClaimResult =
   | {
@@ -36,6 +42,16 @@ export type ClaimResult =
       /** True when the subject was already connected (idempotent no-op). */
       alreadyConnected?: boolean;
     }
+  /**
+   * The subject is ALREADY actively bound in a DIFFERENT org than the one the
+   * claimer confirmed. The engine does NOT silently create a second binding (that
+   * silent duplication is a cross-org pollution vector). It returns this explicit
+   * outcome carrying the other org's identity so the UI can prompt "This
+   * workspace is already connected in <org>. Move it here?" — the caller re-issues
+   * the claim with `confirmMove: true` to proceed (fence, not forbid: a single
+   * external workspace may legitimately serve multiple orgs).
+   */
+  | { status: "already_connected_elsewhere"; existing: ClaimForeignBinding }
   | ClaimError;
 
 /** A Lobu org the claimer may bind the subject into. */
@@ -92,13 +108,35 @@ export interface ClaimProvider<P = unknown> {
    * `already_connected` success rather than an error.
    */
   resolveExistingBinding(ref: string): Promise<{ orgSlug: string | null } | null>;
+  /**
+   * The identity of an org OTHER than `targetOrganizationId` that already holds
+   * an active binding for this subject, or null when the only (or no) active
+   * binding is in the target org itself. Used to FENCE a silent cross-org walk:
+   * a non-null result blocks the bind (returning `already_connected_elsewhere`)
+   * unless the claimer explicitly confirmed the move. The provider decides what
+   * "same subject" means across its keying (e.g. Slack matches team_id AND a Grid
+   * enterprise_id) — the engine only asks the question.
+   */
+  resolveActiveBindingElsewhere(
+    ref: string,
+    pending: P,
+    targetOrganizationId: string,
+  ): Promise<ClaimForeignBinding | null>;
   /** The provider's authority verdict for the claiming user against `pending`. */
   authorize(userId: string, pending: P): Promise<ClaimAuthorization>;
-  /** Bind: persist the token + create the active install, returning its id. */
+  /**
+   * Bind: persist the token + create the active install, returning its id. When
+   * `confirmMove` is set the caller has explicitly approved MOVING an active
+   * binding that lives in another org into `organizationId`; the provider must
+   * re-verify and enforce the cross-org fence atomically (under the same lock as
+   * the write) so a concurrent claim on another pod cannot slip a silent move
+   * through the engine's pre-check.
+   */
   bind(
     pending: P,
     organizationId: string,
     userId: string,
+    confirmMove: boolean,
   ): Promise<{ bindingId: string }>;
 }
 
@@ -198,6 +236,13 @@ export async function claimPendingConnection<P>(
     userId: string | null;
     ref: string;
     organizationId?: string;
+    /**
+     * The claimer explicitly confirmed MOVING an active binding that lives in
+     * another org into the confirmed org. Without it a subject already active
+     * elsewhere yields `already_connected_elsewhere` (fence, not forbid): the
+     * second claim must be deliberate, never a silent duplicate.
+     */
+    confirmMove?: boolean;
   },
 ): Promise<ClaimResult> {
   try {
@@ -226,10 +271,28 @@ export async function claimPendingConnection<P>(
     );
     if (!organizationId) return { status: "not_member_of_org" };
 
+    // Cross-org fence. If this subject is already ACTIVE in a DIFFERENT org, a
+    // naive bind would silently transfer/duplicate it (the install store demotes
+    // the prior org's active row on activation — a silent ownership steal). Only
+    // proceed when the claimer explicitly confirmed the move; otherwise surface
+    // the other org so the UI can prompt. This is the pre-check for a friendly
+    // outcome — `bind` re-enforces it atomically for the multi-pod race.
+    if (!input.confirmMove) {
+      const elsewhere = await provider.resolveActiveBindingElsewhere(
+        input.ref,
+        target.pending,
+        organizationId,
+      );
+      if (elsewhere) {
+        return { status: "already_connected_elsewhere", existing: elsewhere };
+      }
+    }
+
     const { bindingId } = await provider.bind(
       target.pending,
       organizationId,
       input.userId as string,
+      input.confirmMove ?? false,
     );
     const orgSlug = await deps.resolveOrgSlug(organizationId);
     return { status: "ok", orgSlug, bindingId };
@@ -257,6 +320,7 @@ export function claimHttpStatus(
     case "not_member_of_org":
       return 403;
     case "no_org":
+    case "already_connected_elsewhere":
       return 409;
     default:
       return 500;

--- a/packages/server/src/gateway/connections/connection-claim.ts
+++ b/packages/server/src/gateway/connections/connection-claim.ts
@@ -27,10 +27,23 @@ export type ClaimError =
   | { status: "no_org" }
   | { status: "claim_failed"; message: string };
 
-/** The identity of the OTHER org a subject is already actively bound to. */
+/**
+ * Which cross-org conflict the fence matched — the two are DIFFERENT concepts and
+ * map to different outcomes:
+ *  - `same_workspace`: the SAME external subject (exact team id) is active in
+ *    another org. A genuine "already connected elsewhere; move it?" case.
+ *  - `enterprise_scope_overlap`: a ROUTING overlap where one side is an org-wide
+ *    Grid install that covers sibling workspaces the other org claims per-
+ *    workspace (or vice-versa). Not the same subject — a scope collision — so it
+ *    is surfaced distinctly and blocked by default (no silent move).
+ */
+export type ClaimConflictKind = "same_workspace" | "enterprise_scope_overlap";
+
+/** The identity of the OTHER org a subject conflicts with, and how it matched. */
 export interface ClaimForeignBinding {
   orgSlug: string | null;
   orgName: string | null;
+  matchKind: ClaimConflictKind;
 }
 
 /**
@@ -59,15 +72,25 @@ export type ClaimResult =
       alreadyConnected?: boolean;
     }
   /**
-   * The subject is ALREADY actively bound in a DIFFERENT org than the one the
-   * claimer confirmed. The engine does NOT silently create a second binding (that
-   * silent duplication is a cross-org pollution vector). It returns this explicit
-   * outcome carrying the other org's identity so the UI can prompt "This
-   * workspace is already connected in <org>. Move it here?" — the caller re-issues
-   * the claim with `confirmMove: true` to proceed (fence, not forbid: a single
-   * external workspace may legitimately serve multiple orgs).
+   * The SAME external subject (exact workspace) is ALREADY actively bound in a
+   * DIFFERENT org than the one the claimer confirmed. The engine does NOT silently
+   * create a second binding (that silent duplication is a cross-org pollution
+   * vector). It returns this explicit outcome carrying the other org's identity so
+   * the UI can prompt "This workspace is already connected in <org>. Move it
+   * here?" — the caller re-issues with `confirmMove: true` to proceed (fence, not
+   * forbid: a single external workspace may legitimately serve multiple orgs).
    */
   | { status: "already_connected_elsewhere"; existing: ClaimForeignBinding }
+  /**
+   * A Grid ENTERPRISE-SCOPE overlap: an org-wide install in one org covers the
+   * sibling workspaces another org claims per-workspace (or vice-versa). This is
+   * NOT the same subject — it's a routing collision — so it is distinct from
+   * `already_connected_elsewhere`. Blocked by DEFAULT (safety) and NOT overridable
+   * by `confirmMove`: the cross-key demote can't actually move an org-wide vs
+   * per-workspace install, so a "move it here" prompt would be a lie. Lifting this
+   * needs product support for Grid carve-outs + atomic group demotion.
+   */
+  | { status: "enterprise_scope_overlap"; existing: ClaimForeignBinding }
   | ClaimError;
 
 /** A Lobu org the claimer may bind the subject into. */
@@ -287,19 +310,24 @@ export async function claimPendingConnection<P>(
     );
     if (!organizationId) return { status: "not_member_of_org" };
 
-    // Cross-org fence. If this subject is already ACTIVE in a DIFFERENT org, a
-    // naive bind would silently transfer/duplicate it (the install store demotes
-    // the prior org's active row on activation — a silent ownership steal). Only
-    // proceed when the claimer explicitly confirmed the move; otherwise surface
-    // the other org so the UI can prompt. This is the pre-check for a friendly
-    // outcome — `bind` re-enforces it atomically for the multi-pod race.
-    if (!input.confirmMove) {
-      const elsewhere = await provider.resolveActiveBindingElsewhere(
-        input.ref,
-        target.pending,
-        organizationId,
-      );
-      if (elsewhere) {
+    // Cross-org fence. If this subject conflicts with an ACTIVE binding in a
+    // DIFFERENT org, a naive bind would silently transfer/duplicate it (the install
+    // store demotes the prior org's active row on activation). The check ALWAYS
+    // runs — even under `confirmMove` — because an `enterprise_scope_overlap` is
+    // never overridable (the cross-key demote can't move it), while a
+    // `same_workspace` conflict IS the deliberate move `confirmMove` authorizes.
+    // This is the pre-check for a friendly outcome; `bind` re-enforces atomically.
+    const elsewhere = await provider.resolveActiveBindingElsewhere(
+      input.ref,
+      target.pending,
+      organizationId,
+    );
+    if (elsewhere) {
+      if (elsewhere.matchKind === "enterprise_scope_overlap") {
+        return { status: "enterprise_scope_overlap", existing: elsewhere };
+      }
+      // same_workspace: a confirmed move proceeds; otherwise fence.
+      if (!input.confirmMove) {
         return { status: "already_connected_elsewhere", existing: elsewhere };
       }
     }
@@ -314,9 +342,14 @@ export async function claimPendingConnection<P>(
     return { status: "ok", orgSlug, bindingId };
   } catch (err) {
     // The atomic (under-lock) fence in the provider's bind tripped on the raced
-    // path — surface the SAME explicit outcome as the pre-check, not a 500.
+    // path — surface the SAME typed outcome as the pre-check (by matchKind), not a
+    // 500.
     if (err instanceof ClaimMoveBlockedError) {
-      return { status: "already_connected_elsewhere", existing: err.existing };
+      const status =
+        err.existing.matchKind === "enterprise_scope_overlap"
+          ? "enterprise_scope_overlap"
+          : "already_connected_elsewhere";
+      return { status, existing: err.existing };
     }
     return {
       status: "claim_failed",
@@ -342,6 +375,7 @@ export function claimHttpStatus(
       return 403;
     case "no_org":
     case "already_connected_elsewhere":
+    case "enterprise_scope_overlap":
       return 409;
     default:
       return 500;

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -31,15 +31,17 @@ export interface SlackClaimProviderDeps {
   /** The org slug the workspace is ALREADY connected to (active install), or null. */
   resolveActiveOrgSlug(team: string): Promise<string | null>;
   /**
-   * The identity of an org OTHER than `targetOrganizationId` that already holds
-   * an ACTIVE install for this workspace, or null. Matches on the workspace
-   * `team_id` AND — for a Grid install — the `enterprise_id`, so a Grid claim
-   * that keys on enterprise still sees a sibling-workspace binding. Powers the
-   * cross-org fence: a non-null result blocks a silent second bind.
+   * The TYPED cross-org conflict for claiming `team` into `targetOrganizationId`,
+   * or null when there is none. Matches the exact workspace `team_id`
+   * (`same_workspace`) and — only across an ORG-WIDE Grid install on either side —
+   * an `enterprise_id` scope overlap (`enterprise_scope_overlap`). Two independent
+   * per-workspace siblings of one enterprise do NOT conflict. `isEnterpriseInstall`
+   * is the CLAIMING install's org-wide flag. Powers the cross-org fence.
    */
   resolveActiveBindingElsewhere(
     team: string,
     enterpriseId: string | null,
+    isEnterpriseInstall: boolean,
     targetOrganizationId: string,
   ): Promise<ClaimForeignBinding | null>;
   /**
@@ -137,6 +139,7 @@ export function slackClaimProvider(
       deps.resolveActiveBindingElsewhere(
         ref,
         pending.enterpriseId,
+        pending.isEnterpriseInstall,
         targetOrganizationId,
       ),
     authorize: (userId, pending) => authorizeSlackClaim(deps, userId, pending),
@@ -152,17 +155,18 @@ export function slackClaimProvider(
         // The store's ATOMIC fence tripped on the raced path (the sequential
         // pre-check saw null). Translate the store-specific error into the
         // engine's provider-agnostic ClaimMoveBlockedError so the raced path
-        // returns the SAME `already_connected_elsewhere` 409 as the pre-check,
-        // carrying the other org (still resolvable — the fenced claim released
-        // its own pending row, leaving the incumbent active row intact).
+        // returns the SAME typed 409 as the pre-check (by matchKind), carrying the
+        // other org (still resolvable — the fenced claim released its own pending
+        // row, leaving the incumbent active row intact).
         if (err instanceof CrossOrgTransferBlockedError) {
           const existing = await deps.resolveActiveBindingElsewhere(
             pending.teamId,
             pending.enterpriseId,
+            pending.isEnterpriseInstall,
             organizationId,
           );
           throw new ClaimMoveBlockedError(
-            existing ?? { orgSlug: null, orgName: null },
+            existing ?? { orgSlug: null, orgName: null, matchKind: "same_workspace" },
           );
         }
         throw err;

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -1,8 +1,10 @@
+import { CrossOrgTransferBlockedError } from "../../lobu/stores/app-installation-store.js";
 import type { SlackPendingInstall } from "../../lobu/stores/slack-installations.js";
-import type {
-  ClaimAuthorization,
-  ClaimForeignBinding,
-  ClaimProvider,
+import {
+  type ClaimAuthorization,
+  type ClaimForeignBinding,
+  type ClaimProvider,
+  ClaimMoveBlockedError,
 } from "./connection-claim.js";
 import type { SlackWebApi } from "./slack-web.js";
 
@@ -139,12 +141,32 @@ export function slackClaimProvider(
       ),
     authorize: (userId, pending) => authorizeSlackClaim(deps, userId, pending),
     bind: async (pending, organizationId, _userId, confirmMove) => {
-      const { installationId } = await deps.claim(
-        pending,
-        organizationId,
-        confirmMove,
-      );
-      return { bindingId: installationId };
+      try {
+        const { installationId } = await deps.claim(
+          pending,
+          organizationId,
+          confirmMove,
+        );
+        return { bindingId: installationId };
+      } catch (err) {
+        // The store's ATOMIC fence tripped on the raced path (the sequential
+        // pre-check saw null). Translate the store-specific error into the
+        // engine's provider-agnostic ClaimMoveBlockedError so the raced path
+        // returns the SAME `already_connected_elsewhere` 409 as the pre-check,
+        // carrying the other org (still resolvable — the fenced claim released
+        // its own pending row, leaving the incumbent active row intact).
+        if (err instanceof CrossOrgTransferBlockedError) {
+          const existing = await deps.resolveActiveBindingElsewhere(
+            pending.teamId,
+            pending.enterpriseId,
+            organizationId,
+          );
+          throw new ClaimMoveBlockedError(
+            existing ?? { orgSlug: null, orgName: null },
+          );
+        }
+        throw err;
+      }
     },
   };
 }

--- a/packages/server/src/gateway/connections/slack-claim.ts
+++ b/packages/server/src/gateway/connections/slack-claim.ts
@@ -1,5 +1,9 @@
 import type { SlackPendingInstall } from "../../lobu/stores/slack-installations.js";
-import type { ClaimAuthorization, ClaimProvider } from "./connection-claim.js";
+import type {
+  ClaimAuthorization,
+  ClaimForeignBinding,
+  ClaimProvider,
+} from "./connection-claim.js";
 import type { SlackWebApi } from "./slack-web.js";
 
 /**
@@ -25,6 +29,18 @@ export interface SlackClaimProviderDeps {
   /** The org slug the workspace is ALREADY connected to (active install), or null. */
   resolveActiveOrgSlug(team: string): Promise<string | null>;
   /**
+   * The identity of an org OTHER than `targetOrganizationId` that already holds
+   * an ACTIVE install for this workspace, or null. Matches on the workspace
+   * `team_id` AND — for a Grid install — the `enterprise_id`, so a Grid claim
+   * that keys on enterprise still sees a sibling-workspace binding. Powers the
+   * cross-org fence: a non-null result blocks a silent second bind.
+   */
+  resolveActiveBindingElsewhere(
+    team: string,
+    enterpriseId: string | null,
+    targetOrganizationId: string,
+  ): Promise<ClaimForeignBinding | null>;
+  /**
    * ALL of the claiming user's `slack_user_id` identities as `{teamId, slackUserId}`
    * pairs (bare `U…` ids, across every workspace they've signed in with Slack for).
    * A team-scoped match doubles as the workspace-membership proof; the full list
@@ -36,10 +52,16 @@ export interface SlackClaimProviderDeps {
   ): Promise<Array<{ teamId: string; slackUserId: string }>>;
   /** `users.info` admin/owner flags for the claimer. */
   usersInfo: SlackWebApi["usersInfo"];
-  /** Bind: persist the token + create the active install, returning its id. */
+  /**
+   * Bind: persist the token + create the active install, returning its id.
+   * `confirmMove` is true when the claimer explicitly approved MOVING a workspace
+   * that is active in another org; the store must re-enforce the cross-org fence
+   * atomically under its active-tenant advisory lock when it is false.
+   */
   claim(
     pending: SlackPendingInstall,
     organizationId: string,
+    confirmMove: boolean,
   ): Promise<{ installationId: string }>;
 }
 
@@ -109,9 +131,19 @@ export function slackClaimProvider(
       const orgSlug = await deps.resolveActiveOrgSlug(ref);
       return orgSlug ? { orgSlug } : null;
     },
+    resolveActiveBindingElsewhere: (ref, pending, targetOrganizationId) =>
+      deps.resolveActiveBindingElsewhere(
+        ref,
+        pending.enterpriseId,
+        targetOrganizationId,
+      ),
     authorize: (userId, pending) => authorizeSlackClaim(deps, userId, pending),
-    bind: async (pending, organizationId) => {
-      const { installationId } = await deps.claim(pending, organizationId);
+    bind: async (pending, organizationId, _userId, confirmMove) => {
+      const { installationId } = await deps.claim(
+        pending,
+        organizationId,
+        confirmMove,
+      );
       return { bindingId: installationId };
     },
   };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2410,15 +2410,21 @@ function buildSlackClaimProvider(): ClaimProvider {
 		resolveActiveBindingElsewhere: async (
 			team,
 			enterpriseId,
+			isEnterpriseInstall,
 			targetOrganizationId,
 		) => {
 			const foreign = await resolveSlackActiveBindingElsewhere(
 				team,
 				enterpriseId,
+				isEnterpriseInstall,
 				targetOrganizationId,
 			);
 			return foreign
-				? { orgSlug: foreign.orgSlug, orgName: foreign.orgName }
+				? {
+						orgSlug: foreign.orgSlug,
+						orgName: foreign.orgName,
+						matchKind: foreign.matchKind,
+					}
 				: null;
 		},
 		resolveClaimerSlackIdentities: resolveClaimingUserSlackIdentities,
@@ -2544,7 +2550,14 @@ app.post("/api/connector/:connector/connection/claim", async (c) => {
 			alreadyConnected: result.alreadyConnected ?? false,
 		});
 	}
-	if (result.status === "already_connected_elsewhere") {
+	if (
+		result.status === "already_connected_elsewhere" ||
+		result.status === "enterprise_scope_overlap"
+	) {
+		// Two DISTINCT 409 conflicts, kept distinguishable for the SPA via `error`:
+		// already_connected_elsewhere (same workspace — re-POST confirmMove:true) vs
+		// enterprise_scope_overlap (Grid org-wide/per-workspace routing collision —
+		// NOT overridable, admin resolves out-of-band).
 		// Not an error the user must fix — a decision. Surface the other org so the
 		// SPA can prompt "already connected in <org>. Move it here?" and re-POST
 		// with confirmMove:true. 409 (state conflict requiring explicit resolution).

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -83,6 +83,7 @@ import {
 } from "./lobu/gateway";
 import {
 	claimSlackPendingInstall,
+	resolveSlackActiveBindingElsewhere,
 	resolveSlackPendingByTenant,
 } from "./lobu/stores/slack-installations";
 import { handleMcp, MCP_APP_DIRS } from "./mcp-handler";
@@ -2406,9 +2407,23 @@ function buildSlackClaimProvider(): ClaimProvider {
 			`) as Array<{ slug: string }>;
 			return rows[0]?.slug ?? null;
 		},
+		resolveActiveBindingElsewhere: async (
+			team,
+			enterpriseId,
+			targetOrganizationId,
+		) => {
+			const foreign = await resolveSlackActiveBindingElsewhere(
+				team,
+				enterpriseId,
+				targetOrganizationId,
+			);
+			return foreign
+				? { orgSlug: foreign.orgSlug, orgName: foreign.orgName }
+				: null;
+		},
 		resolveClaimerSlackIdentities: resolveClaimingUserSlackIdentities,
 		usersInfo: (botToken, uid) => createSlackWebApi().usersInfo(botToken, uid),
-		claim: async (pending, organizationId) => {
+		claim: async (pending, organizationId, confirmMove) => {
 			const core = getLobuCoreServices();
 			if (!core) throw new Error("Lobu core services unavailable");
 			const result = await claimSlackPendingInstall(
@@ -2416,6 +2431,7 @@ function buildSlackClaimProvider(): ClaimProvider {
 				core.getSecretStore(),
 				pending,
 				organizationId,
+				confirmMove,
 			);
 			// Post-claim, best-effort: auto-link the org's Builder agent to the
 			// installer's DM and fire the welcome DM. Never throws — a failure here
@@ -2487,9 +2503,13 @@ app.post("/api/connector/:connector/connection/claim", async (c) => {
 	const provider = buildProvider();
 	const userId = await resolveClaimSessionUser(c.env, c.req.raw);
 
-	let body: { ref?: unknown; org?: unknown };
+	let body: { ref?: unknown; org?: unknown; confirmMove?: unknown };
 	try {
-		body = (await c.req.json()) as { ref?: unknown; org?: unknown };
+		body = (await c.req.json()) as {
+			ref?: unknown;
+			org?: unknown;
+			confirmMove?: unknown;
+		};
 	} catch {
 		body = {};
 	}
@@ -2502,6 +2522,10 @@ app.post("/api/connector/:connector/connection/claim", async (c) => {
 		typeof body.org === "string" && body.org.trim()
 			? body.org.trim()
 			: undefined;
+	// Explicit opt-in to MOVE a workspace already active in another org into the
+	// confirmed org. Without it the engine fences the second claim and returns
+	// `already_connected_elsewhere` (deliberate move, never a silent duplicate).
+	const confirmMove = body.confirmMove === true;
 
 	// All branching lives in the injectable engine so it stays unit-testable;
 	// the route only wires real deps + maps outcomes to HTTP.
@@ -2509,6 +2533,7 @@ app.post("/api/connector/:connector/connection/claim", async (c) => {
 		userId,
 		ref,
 		organizationId,
+		confirmMove,
 	});
 
 	if (result.status === "ok") {
@@ -2518,6 +2543,19 @@ app.post("/api/connector/:connector/connection/claim", async (c) => {
 			provider: provider.provider,
 			alreadyConnected: result.alreadyConnected ?? false,
 		});
+	}
+	if (result.status === "already_connected_elsewhere") {
+		// Not an error the user must fix — a decision. Surface the other org so the
+		// SPA can prompt "already connected in <org>. Move it here?" and re-POST
+		// with confirmMove:true. 409 (state conflict requiring explicit resolution).
+		return c.json(
+			{
+				error: result.status,
+				existing: result.existing,
+				provider: provider.provider,
+			},
+			claimHttpStatus(result.status),
+		);
 	}
 	if (result.status === "claim_failed") {
 		logger.error(

--- a/packages/server/src/lobu/stores/app-installation-store.ts
+++ b/packages/server/src/lobu/stores/app-installation-store.ts
@@ -6,6 +6,24 @@ function activeTenantLockTag(key: AppInstallationTenantKey): string {
 }
 
 /**
+ * Advisory-lock tag that serializes activation across every install sharing a
+ * `metadata` grouping key (e.g. Slack Grid `enterprise_id`), regardless of their
+ * differing tenant tuples. The per-tuple lock (an org-wide Grid install keys on
+ * the ENTERPRISE id, a per-workspace install on the TEAM id) does NOT serialize
+ * two cross-key claims of the same enterprise; this second lock does, so the
+ * cross-org fence stays atomic across replicas even when the two racers touch
+ * different tuples.
+ */
+function fenceGroupLockTag(
+  provider: string,
+  providerAppId: string,
+  metadataKey: string,
+  value: string
+): string {
+  return `app_installations:fence:${provider}:${providerAppId}:${metadataKey}:${value}`;
+}
+
+/**
  * A generic, provider-agnostic app installation: the multi-tenant record of
  * "Lobu App <X> is installed into external tenant <Y>". One model spans GitHub
  * Apps (installation_id), Slack OAuth v2 (team_id), and Jira/Atlassian Connect
@@ -82,6 +100,18 @@ export interface AppInstallationUpsert extends AppInstallationTenantKey {
    * for reinstall/OAuth paths).
    */
   blockCrossOrgTransfer?: boolean;
+  /**
+   * Extends {@link blockCrossOrgTransfer} to a SECONDARY grouping key: an active
+   * install owned by a different org whose `metadata[key] === value` also trips
+   * the fence, even if its tenant tuple differs. This closes the Slack Grid
+   * cross-key hole — an org-wide install keys on the enterprise id, a
+   * per-workspace install on the team id, so the tuple lock/guard alone misses
+   * the counterpart. When set (with `blockCrossOrgTransfer`), the activation ALSO
+   * takes a `metadata`-grouped advisory lock so two concurrent cross-key claims
+   * serialize, and the guard SELECT matches this key too. Ignored without
+   * `blockCrossOrgTransfer`.
+   */
+  crossOrgFenceMetadataMatch?: { key: string; value: string };
 }
 
 /**
@@ -282,14 +312,39 @@ export function createPostgresAppInstallationStore(): AppInstallationStore {
         // here — not before the lock — so a concurrent activation on another pod
         // cannot slip a foreign owner in between the check and the demote.
         if (install.blockCrossOrgTransfer) {
+          const fenceMatch = install.crossOrgFenceMetadataMatch;
+          // A cross-key claim (e.g. Grid org-wide vs per-workspace) touches a
+          // DIFFERENT tenant tuple, so the tuple lock above does NOT serialize it.
+          // Take a second lock on the shared metadata grouping key so the two
+          // racers order deterministically before either reads the fence.
+          if (fenceMatch) {
+            await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
+              fenceGroupLockTag(
+                install.provider,
+                install.providerAppId,
+                fenceMatch.key,
+                fenceMatch.value
+              ),
+            ]);
+          }
           const foreign = await tx`
             SELECT organization_id FROM app_installations
             WHERE provider = ${install.provider}
-              AND provider_instance = ${install.providerInstance}
               AND provider_app_id = ${install.providerAppId}
-              AND external_tenant_id = ${install.externalTenantId}
               AND status = 'active'
               AND organization_id <> ${install.organizationId}
+              AND (
+                (
+                  provider_instance = ${install.providerInstance}
+                  AND external_tenant_id = ${install.externalTenantId}
+                )
+                OR (
+                  ${fenceMatch ? fenceMatch.value : null}::text IS NOT NULL
+                  AND metadata ->> ${fenceMatch ? fenceMatch.key : ""} = ${
+                    fenceMatch ? fenceMatch.value : null
+                  }
+                )
+              )
             LIMIT 1
           `;
           if (foreign.length > 0) {

--- a/packages/server/src/lobu/stores/app-installation-store.ts
+++ b/packages/server/src/lobu/stores/app-installation-store.ts
@@ -110,8 +110,26 @@ export interface AppInstallationUpsert extends AppInstallationTenantKey {
    * takes a `metadata`-grouped advisory lock so two concurrent cross-key claims
    * serialize, and the guard SELECT matches this key too. Ignored without
    * `blockCrossOrgTransfer`.
+   *
+   * The match must NOT over-fence: two INDEPENDENT per-workspace siblings sharing
+   * a grouping value (both non-org-wide Grid installs) may legitimately live in
+   * different orgs. So the grouping arm only matches when a scope-spanning install
+   * is involved:
+   *  - `claimIsScopeWide` true → the CLAIMING install spans the group, so ANY
+   *    foreign row carrying `metadata[key] === value` overlaps it.
+   *  - else → only a foreign row that ITSELF spans the group matches, i.e. one
+   *    whose `metadata[scopeFlagKey]` is boolean `true`.
+   * When neither holds (both sides per-workspace), the grouping arm is inert and
+   * only the exact tuple fences.
    */
-  crossOrgFenceMetadataMatch?: { key: string; value: string };
+  crossOrgFenceMetadataMatch?: {
+    key: string;
+    value: string;
+    /** True when the claiming install spans the whole group (e.g. Grid org-wide). */
+    claimIsScopeWide: boolean;
+    /** Metadata flag identifying a foreign row that spans the group. */
+    scopeFlagKey: string;
+  };
 }
 
 /**
@@ -327,6 +345,13 @@ export function createPostgresAppInstallationStore(): AppInstallationStore {
               ),
             ]);
           }
+          // The grouping arm matches a foreign row sharing the value ONLY when a
+          // scope-spanning install is involved: either WE span the group
+          // (`claimIsScopeWide` → any foreign sibling overlaps) or the FOREIGN row
+          // itself spans it (its `scopeFlagKey` is true). Two independent
+          // per-workspace siblings (neither scope-wide) never match, so a genuine
+          // second-workspace claim of the same Grid into another org is allowed.
+          const claimScopeWide = fenceMatch?.claimIsScopeWide === true;
           const foreign = await tx`
             SELECT organization_id FROM app_installations
             WHERE provider = ${install.provider}
@@ -343,6 +368,12 @@ export function createPostgresAppInstallationStore(): AppInstallationStore {
                   AND metadata ->> ${fenceMatch ? fenceMatch.key : ""} = ${
                     fenceMatch ? fenceMatch.value : null
                   }
+                  AND (
+                    ${claimScopeWide}
+                    OR (metadata -> ${
+                      fenceMatch ? fenceMatch.scopeFlagKey : ""
+                    }) = 'true'::jsonb
+                  )
                 )
               )
             LIMIT 1

--- a/packages/server/src/lobu/stores/app-installation-store.ts
+++ b/packages/server/src/lobu/stores/app-installation-store.ts
@@ -71,6 +71,29 @@ export interface AppInstallationUpsert extends AppInstallationTenantKey {
    * provided `metadata` value (the first writer's mint is kept).
    */
   preserveMetadataKeysOnUpdate?: string[];
+  /**
+   * Refuse the silent cross-org TRANSFER. When true and an ACTIVE row for this
+   * tuple is owned by a DIFFERENT org, the activation aborts (throws
+   * {@link CrossOrgTransferBlockedError}) instead of demoting the prior owner —
+   * the fence for a claim that must be a deliberate move, not a silent slot
+   * steal. Checked INSIDE the advisory-locked transaction, so it holds across
+   * replicas even against a concurrent activation of the same tuple. Default
+   * false (transfer proceeds, preserving the historical one-active-owner behavior
+   * for reinstall/OAuth paths).
+   */
+  blockCrossOrgTransfer?: boolean;
+}
+
+/**
+ * Thrown by {@link AppInstallationStore.upsert} when `blockCrossOrgTransfer` is
+ * set and an active install for the tuple is owned by a different org. Carries
+ * that org's id so the caller can surface it.
+ */
+export class CrossOrgTransferBlockedError extends Error {
+  constructor(readonly ownerOrganizationId: string) {
+    super("Active install owned by a different org; transfer not confirmed");
+    this.name = "CrossOrgTransferBlockedError";
+  }
 }
 
 export interface AppInstallationStore {
@@ -253,6 +276,28 @@ export function createPostgresAppInstallationStore(): AppInstallationStore {
         await tx.unsafe("SELECT pg_advisory_xact_lock(hashtext($1))", [
           activeTenantLockTag(install),
         ]);
+
+        // Cross-org fence (atomic, under the lock): when the caller forbids a
+        // silent transfer, refuse to demote a DIFFERENT-org active owner. Checked
+        // here — not before the lock — so a concurrent activation on another pod
+        // cannot slip a foreign owner in between the check and the demote.
+        if (install.blockCrossOrgTransfer) {
+          const foreign = await tx`
+            SELECT organization_id FROM app_installations
+            WHERE provider = ${install.provider}
+              AND provider_instance = ${install.providerInstance}
+              AND provider_app_id = ${install.providerAppId}
+              AND external_tenant_id = ${install.externalTenantId}
+              AND status = 'active'
+              AND organization_id <> ${install.organizationId}
+            LIMIT 1
+          `;
+          if (foreign.length > 0) {
+            throw new CrossOrgTransferBlockedError(
+              foreign[0].organization_id as string
+            );
+          }
+        }
 
         // Demote any active row for this tuple owned by a DIFFERENT org — a
         // transfer takes the single active slot from the prior owner. (A same-org

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -7,10 +7,11 @@ import {
   deleteSecretsByPrefix,
   persistSecretValue,
 } from "../../gateway/secrets/index.js";
-import type {
-  AppInstallationRow,
-  AppInstallationStatus,
-  AppInstallationStore,
+import {
+  type AppInstallationRow,
+  type AppInstallationStatus,
+  type AppInstallationStore,
+  CrossOrgTransferBlockedError,
 } from "./app-installation-store.js";
 import { upsertChatConnectionProjection } from "./connections-projection.js";
 import { orgContext } from "./org-context.js";
@@ -148,6 +149,14 @@ export async function upsertSlackInstallByTeam(
      * (Grid single-workspace or standalone).
      */
     isEnterpriseInstall?: boolean;
+    /**
+     * When true, refuse a SILENT cross-org transfer: if this workspace is already
+     * ACTIVE in a different org, the activation aborts
+     * ({@link CrossOrgTransferBlockedError}) instead of stealing the slot. Set on
+     * the claim path so a second-org claim must be a deliberate, confirmed move.
+     * Absent on the OAuth reinstall path (transfer is the intended behavior there).
+     */
+    blockCrossOrgTransfer?: boolean;
   }
 ): Promise<SlackInstallationRow> {
   // Bind the org for the secret-store put + the row write so they land in the
@@ -226,6 +235,7 @@ export async function upsertSlackInstallByTeam(
       status: "active",
       metadata: buildMetadata(plannedId),
       preserveMetadataKeysOnUpdate: ["external_id", "welcome_dm_sent"],
+      blockCrossOrgTransfer: data.blockCrossOrgTransfer,
     });
     const canonicalId = row.metadata.external_id as string;
 
@@ -253,6 +263,7 @@ export async function upsertSlackInstallByTeam(
         status: "active",
         metadata: buildMetadata(canonicalId),
         preserveMetadataKeysOnUpdate: ["external_id", "welcome_dm_sent"],
+        blockCrossOrgTransfer: data.blockCrossOrgTransfer,
       });
       await deleteSecretsByPrefix(
         secretStore,
@@ -398,6 +409,64 @@ export async function getSlackEnterpriseInstall(
     "is_enterprise_install"
   );
   return row ? toSlackRow(row) : null;
+}
+
+/** An active Slack install owned by an org OTHER than a claim's target org. */
+export interface SlackForeignActiveBinding {
+  organizationId: string;
+  orgSlug: string | null;
+  orgName: string | null;
+}
+
+/**
+ * Resolve an ACTIVE Slack install for a workspace owned by an org OTHER than
+ * `targetOrganizationId`, or null when the only (or no) active install is the
+ * target org's own. This is the read half of the cross-org claim fence: a
+ * non-null result means claiming the workspace into `targetOrganizationId` would
+ * MOVE (steal the active slot from) another org, so it must be a deliberate,
+ * confirmed move rather than a silent duplicate.
+ *
+ * Matches the SAME subject the router would: the exact workspace `team_id`, and
+ * — for a Grid install — any sibling install sharing this `enterprise_id`. The
+ * enterprise arm is gated on a non-null `enterpriseId` so two genuinely
+ * different plain workspaces never collide. Returns the most recently updated
+ * foreign row (deterministic) with its org identity for the UI prompt.
+ */
+export async function resolveSlackActiveBindingElsewhere(
+  teamId: string,
+  enterpriseId: string | null,
+  targetOrganizationId: string
+): Promise<SlackForeignActiveBinding | null> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT ai.organization_id, o.slug, o.name
+    FROM app_installations ai
+    JOIN "organization" o ON o.id = ai.organization_id
+    WHERE ai.provider = ${SLACK_PROVIDER}
+      AND ai.provider_app_id = ${SLACK_PROVIDER_APP_ID}
+      AND ai.status = 'active'
+      AND ai.organization_id IS DISTINCT FROM ${targetOrganizationId}
+      AND (
+        ai.external_tenant_id = ${teamId}
+        OR (
+          ${enterpriseId ?? null}::text IS NOT NULL
+          AND ai.metadata ->> 'enterprise_id' = ${enterpriseId ?? null}
+        )
+      )
+    ORDER BY ai.updated_at DESC, ai.id DESC
+    LIMIT 1
+  `) as Array<{
+    organization_id: string;
+    slug: string | null;
+    name: string | null;
+  }>;
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    organizationId: row.organization_id,
+    orgSlug: row.slug ?? null,
+    orgName: row.name ?? null,
+  };
 }
 
 /**
@@ -708,12 +777,19 @@ export async function resolveSlackPendingByTenant(
  *
  * Caller is responsible for authorizing the claim (workspace-admin check)
  * BEFORE invoking this. Returns the stable `slackinst-<uuid>` install id.
+ *
+ * When `confirmMove` is false and the workspace is already ACTIVE in another
+ * org, activation throws {@link CrossOrgTransferBlockedError} — the atomic fence
+ * against a silent second-org claim stealing the active slot. The durable
+ * pending-row claim is rolled back to org-less so a genuine first claim can
+ * still succeed once the user confirms the move (or claims elsewhere).
  */
 export async function claimSlackPendingInstall(
   store: AppInstallationStore,
   secretStore: WritableSecretStore,
   pending: SlackPendingInstall,
-  organizationId: string
+  organizationId: string,
+  confirmMove = false
 ): Promise<{ installationId: string }> {
   const sql = getDb();
   const claimed = await sql`
@@ -732,20 +808,43 @@ export async function claimSlackPendingInstall(
     throw new Error("Slack workspace pending install was already claimed");
   }
 
-  const row = await upsertSlackInstallByTeam(
-    store,
-    secretStore,
-    organizationId,
-    pending.teamId,
-    {
-      teamName: pending.teamName ?? undefined,
-      botUserId: pending.botUserId ?? undefined,
-      botToken: pending.botToken,
-      installerUserId: pending.installerUserId ?? undefined,
-      enterpriseId: pending.enterpriseId,
-      isEnterpriseInstall: pending.isEnterpriseInstall,
+  let row: SlackInstallationRow;
+  try {
+    row = await upsertSlackInstallByTeam(
+      store,
+      secretStore,
+      organizationId,
+      pending.teamId,
+      {
+        teamName: pending.teamName ?? undefined,
+        botUserId: pending.botUserId ?? undefined,
+        botToken: pending.botToken,
+        installerUserId: pending.installerUserId ?? undefined,
+        enterpriseId: pending.enterpriseId,
+        isEnterpriseInstall: pending.isEnterpriseInstall,
+        blockCrossOrgTransfer: !confirmMove,
+      }
+    );
+  } catch (err) {
+    if (err instanceof CrossOrgTransferBlockedError) {
+      // The fence tripped: this workspace is already active in another org and
+      // the move was not confirmed. Release the durable pending-row claim (back
+      // to org-less, still pending) so a genuine first claim from the rightful
+      // org — or a later confirmed move — can still proceed. Never leave the row
+      // stranded under an org that failed to activate.
+      await sql`
+        UPDATE app_installations
+        SET organization_id = NULL, updated_at = now()
+        WHERE id = ${pending.id}::bigint
+          AND provider = ${SLACK_PROVIDER}
+          AND provider_app_id = ${SLACK_PROVIDER_APP_ID}
+          AND external_tenant_id = ${pending.teamId}
+          AND organization_id = ${organizationId}
+          AND status = 'pending'
+      `;
     }
-  );
+    throw err;
+  }
   // Usually the reserved row was activated in place. If a same-org active row
   // already existed, the generic upsert refreshed that row instead; retire only
   // THIS successfully consumed pending row, never a newer reinstall.

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -187,6 +187,15 @@ export async function upsertSlackInstallByTeam(
     const plannedId =
       (existing?.metadata.external_id as string | undefined) ?? candidateId;
 
+    // For a Grid claim, fence on the enterprise id too: an org-wide install keys
+    // on the enterprise id and a per-workspace install on the team id, so the
+    // store's per-tuple lock/guard would miss the counterpart. Only when we are
+    // actually blocking a transfer AND this is a Grid install.
+    const crossOrgFenceEnterpriseMatch =
+      data.blockCrossOrgTransfer && data.enterpriseId
+        ? { key: "enterprise_id", value: data.enterpriseId }
+        : undefined;
+
     // TOKEN FIRST — persist the bot token BEFORE any row is created/activated, so
     // the invariant "no active Slack install without a resolvable botToken" holds
     // even if this throws: on failure we simply never wrote/flipped a row. A
@@ -225,18 +234,41 @@ export async function upsertSlackInstallByTeam(
       return metadata;
     };
 
-    const row = await store.upsert({
-      organizationId,
-      provider: SLACK_PROVIDER,
-      providerInstance: SLACK_PROVIDER_INSTANCE,
-      providerAppId: SLACK_PROVIDER_APP_ID,
-      externalTenantId: teamId,
-      authProfileId: null,
-      status: "active",
-      metadata: buildMetadata(plannedId),
-      preserveMetadataKeysOnUpdate: ["external_id", "welcome_dm_sent"],
-      blockCrossOrgTransfer: data.blockCrossOrgTransfer,
-    });
+    let row: AppInstallationRow;
+    try {
+      row = await store.upsert({
+        organizationId,
+        provider: SLACK_PROVIDER,
+        providerInstance: SLACK_PROVIDER_INSTANCE,
+        providerAppId: SLACK_PROVIDER_APP_ID,
+        externalTenantId: teamId,
+        authProfileId: null,
+        status: "active",
+        metadata: buildMetadata(plannedId),
+        preserveMetadataKeysOnUpdate: ["external_id", "welcome_dm_sent"],
+        blockCrossOrgTransfer: data.blockCrossOrgTransfer,
+        crossOrgFenceMetadataMatch: crossOrgFenceEnterpriseMatch,
+      });
+    } catch (err) {
+      // The cross-org fence tripped AFTER we token-first persisted the bot token
+      // (above) but BEFORE any row was activated. The minted `plannedId` prefix is
+      // known only here, so purge its now-orphaned secret from THIS (refused) org's
+      // bucket rather than leaking a live token. Same-org scope as the put (we are
+      // inside orgContext.run). Best-effort — a leftover would be harmless (no row
+      // references it) but the whole point is to not leave a live token behind.
+      if (err instanceof CrossOrgTransferBlockedError) {
+        await deleteSecretsByPrefix(
+          secretStore,
+          `installations/${plannedId}/`
+        ).catch((cleanupError) => {
+          logger.warn(
+            { plannedId, teamId, error: String(cleanupError) },
+            "Failed to purge Slack token secret after cross-org fence block"
+          );
+        });
+      }
+      throw err;
+    }
     const canonicalId = row.metadata.external_id as string;
 
     // Concurrency reconciliation: if a racing first-install won the id (the store
@@ -264,6 +296,7 @@ export async function upsertSlackInstallByTeam(
         metadata: buildMetadata(canonicalId),
         preserveMetadataKeysOnUpdate: ["external_id", "welcome_dm_sent"],
         blockCrossOrgTransfer: data.blockCrossOrgTransfer,
+        crossOrgFenceMetadataMatch: crossOrgFenceEnterpriseMatch,
       });
       await deleteSecretsByPrefix(
         secretStore,

--- a/packages/server/src/lobu/stores/slack-installations.ts
+++ b/packages/server/src/lobu/stores/slack-installations.ts
@@ -187,13 +187,20 @@ export async function upsertSlackInstallByTeam(
     const plannedId =
       (existing?.metadata.external_id as string | undefined) ?? candidateId;
 
-    // For a Grid claim, fence on the enterprise id too: an org-wide install keys
-    // on the enterprise id and a per-workspace install on the team id, so the
-    // store's per-tuple lock/guard would miss the counterpart. Only when we are
-    // actually blocking a transfer AND this is a Grid install.
+    // For a Grid claim, fence on the enterprise id too — but ONLY across a
+    // scope-spanning (org-wide) install, never between two independent per-
+    // workspace siblings of the same enterprise (those may live in different orgs).
+    // `claimIsScopeWide` = this claim is org-wide; the guard also matches a FOREIGN
+    // org-wide row (its `is_enterprise_install` flag) even when this claim is per-
+    // workspace. Only when actually blocking a transfer AND this is a Grid install.
     const crossOrgFenceEnterpriseMatch =
       data.blockCrossOrgTransfer && data.enterpriseId
-        ? { key: "enterprise_id", value: data.enterpriseId }
+        ? {
+            key: "enterprise_id",
+            value: data.enterpriseId,
+            claimIsScopeWide: data.isEnterpriseInstall === true,
+            scopeFlagKey: "is_enterprise_install",
+          }
         : undefined;
 
     // TOKEN FIRST — persist the bot token BEFORE any row is created/activated, so
@@ -444,35 +451,59 @@ export async function getSlackEnterpriseInstall(
   return row ? toSlackRow(row) : null;
 }
 
+/** Which cross-org conflict the Slack fence matched (see engine `ClaimConflictKind`). */
+export type SlackForeignMatchKind = "same_workspace" | "enterprise_scope_overlap";
+
 /** An active Slack install owned by an org OTHER than a claim's target org. */
 export interface SlackForeignActiveBinding {
   organizationId: string;
   orgSlug: string | null;
   orgName: string | null;
+  matchKind: SlackForeignMatchKind;
 }
 
 /**
- * Resolve an ACTIVE Slack install for a workspace owned by an org OTHER than
- * `targetOrganizationId`, or null when the only (or no) active install is the
- * target org's own. This is the read half of the cross-org claim fence: a
- * non-null result means claiming the workspace into `targetOrganizationId` would
- * MOVE (steal the active slot from) another org, so it must be a deliberate,
- * confirmed move rather than a silent duplicate.
+ * Resolve an ACTIVE Slack install, owned by an org OTHER than
+ * `targetOrganizationId`, that CONFLICTS with claiming `teamId` — TYPED by which
+ * of two distinct conflicts it is. Null when there is no conflict.
  *
- * Matches the SAME subject the router would: the exact workspace `team_id`, and
- * — for a Grid install — any sibling install sharing this `enterprise_id`. The
- * enterprise arm is gated on a non-null `enterpriseId` so two genuinely
- * different plain workspaces never collide. Returns the most recently updated
- * foreign row (deterministic) with its org identity for the UI prompt.
+ * The four cases (see the coordinator's spec):
+ *  1. Same exact workspace `team_id` in another org → `same_workspace`. The real
+ *     "same workspace elsewhere" case; a deliberate move can proceed.
+ *  2. Same exact org-wide enterprise `external_tenant_id` in another org → also a
+ *     `team_id` match here (external_tenant_id equals the claimed id), so it falls
+ *     under case 1's exact-id arm. No special handling.
+ *  3. DIFFERENT per-workspace siblings (T_A vs T_B) sharing one enterprise, with
+ *     NEITHER side org-wide → ALLOWED. Two independent workspaces of one Grid may
+ *     belong to different Lobu orgs, so the enterprise arm must NOT match here.
+ *  4. An org-wide install (`is_enterprise_install`) on EITHER side vs a per-
+ *     workspace install of a sibling in another org → `enterprise_scope_overlap`.
+ *     A real routing overlap (org-wide covers all siblings), surfaced distinctly
+ *     and blocked by default.
+ *
+ * So the enterprise arm trips ONLY when at least one side is org-wide: either the
+ * CLAIMING install (`isEnterpriseInstall`) or the FOREIGN row
+ * (`metadata->>'is_enterprise_install' = 'true'`). Exact-id matches always win and
+ * are reported as `same_workspace`.
  */
 export async function resolveSlackActiveBindingElsewhere(
   teamId: string,
   enterpriseId: string | null,
+  isEnterpriseInstall: boolean,
   targetOrganizationId: string
 ): Promise<SlackForeignActiveBinding | null> {
   const sql = getDb();
+  // Enterprise arm only when SOME side is org-wide (case 4). When the claiming
+  // side is org-wide, any foreign sibling of the enterprise overlaps; otherwise
+  // only a foreign ORG-WIDE row overlaps our per-workspace claim.
+  const enterpriseArmActive = enterpriseId != null && isEnterpriseInstall;
+  const foreignOrgWideArmActive = enterpriseId != null;
   const rows = (await sql`
-    SELECT ai.organization_id, o.slug, o.name
+    SELECT
+      ai.organization_id,
+      o.slug,
+      o.name,
+      (ai.external_tenant_id = ${teamId}) AS exact_match
     FROM app_installations ai
     JOIN "organization" o ON o.id = ai.organization_id
     WHERE ai.provider = ${SLACK_PROVIDER}
@@ -480,18 +511,28 @@ export async function resolveSlackActiveBindingElsewhere(
       AND ai.status = 'active'
       AND ai.organization_id IS DISTINCT FROM ${targetOrganizationId}
       AND (
+        -- Case 1/2: exact same external subject (team id, or org-wide enterprise id).
         ai.external_tenant_id = ${teamId}
+        -- Case 4a: WE are org-wide → any foreign sibling of this enterprise overlaps.
         OR (
-          ${enterpriseId ?? null}::text IS NOT NULL
+          ${enterpriseArmActive}
           AND ai.metadata ->> 'enterprise_id' = ${enterpriseId ?? null}
         )
+        -- Case 4b: a foreign ORG-WIDE row covers our per-workspace claim's enterprise.
+        OR (
+          ${foreignOrgWideArmActive}
+          AND ai.metadata ->> 'enterprise_id' = ${enterpriseId ?? null}
+          AND (ai.metadata -> 'is_enterprise_install') = 'true'::jsonb
+        )
       )
-    ORDER BY ai.updated_at DESC, ai.id DESC
+    -- Prefer an exact-id (same_workspace) match over an enterprise-scope match.
+    ORDER BY exact_match DESC, ai.updated_at DESC, ai.id DESC
     LIMIT 1
   `) as Array<{
     organization_id: string;
     slug: string | null;
     name: string | null;
+    exact_match: boolean;
   }>;
   const row = rows[0];
   if (!row) return null;
@@ -499,6 +540,7 @@ export async function resolveSlackActiveBindingElsewhere(
     organizationId: row.organization_id,
     orgSlug: row.slug ?? null,
     orgName: row.name ?? null,
+    matchKind: row.exact_match ? "same_workspace" : "enterprise_scope_overlap",
   };
 }
 


### PR DESCRIPTION
Fences a silent cross-org Slack claim: claiming a workspace already actively connected in a DIFFERENT org returns a typed 409 instead of silently binding.

**Model (fence, not forbid — multi-org-per-workspace is supported):**
- Same exact workspace `T…` across orgs → `already_connected_elsewhere` (409; overridable with `confirmMove:true` for a deliberate move).
- Two independent per-workspace siblings of one Grid sharing an `enterprise_id`, neither org-wide → **ALLOWED** (they may belong to different orgs).
- Org-wide `E…` vs a per-workspace `T…` cross-org (a real routing overlap) → new distinct `enterprise_scope_overlap` (409; NOT `confirmMove`-overridable, block-by-default until Grid carve-outs are a product decision).

**Correctness:** the check is atomic inside the existing advisory-locked upsert (tuple + enterprise-group lock, deadlock-free ordering); orphaned bot-token secret purged on a fenced claim; the atomic-guard-trip path returns the same typed 409, not a 500.

**Verified:** 66 tests green (DB-backed cross-key fence, independent-sibling ALLOW, `enterprise_scope_overlap`, secret purge, 409 mapping), red→green on the over-match case; `make typecheck` clean.

Reviewed by Fable (SHIP) + codex (gpt-5.6-sol, atomic guard confirmed correct).

Follow-up (separate owletto PR): SPA renders the two 409 kinds distinctly — `already_connected_elsewhere` gets a "Move it here?" confirm; `enterprise_scope_overlap` is a non-overridable block.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786327321&installation_id=136316292&pr_number=1849&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1849&signature=f7d59f3acf287c62d141f81738304803b5674de63ae0cd63344d8461f448e480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->