### PR TITLE
fix(slack): binding team_id is always the workspace team (T…), never the Grid enterprise id

### DIFF
--- a/PR1-data-reconcile.sql
+++ b/PR1-data-reconcile.sql
@@ -1,0 +1,94 @@
+-- ============================================================================
+-- PR1 data reconcile: heal existing Slack channel bindings whose team_id holds
+-- a Grid ENTERPRISE id (E…) instead of the concrete WORKSPACE id (T…).
+--
+-- INVARIANT (enforced by this PR going forward): agent_channel_bindings.team_id
+-- ALWAYS names the concrete Slack WORKSPACE (T…), never the enterprise id (E…).
+-- Historical rows written by the connection-derived binding writers copied the
+-- connection's external_tenant_id (the E… on an org-wide install) into team_id.
+--
+-- This backfills those rows to the real T… sourced from captured inbound
+-- messages (`channel_messages.team_id`), which reliably carry the real workspace
+-- (never the enterprise id). A binding with NO captured message to source from
+-- is set to NULL ("unknown yet") so it self-heals from the first inbound
+-- message — we NEVER leave an E… in team_id, and we NEVER invent a workspace.
+--
+-- Contract:
+--   * READ-ONLY / rollback-by-default. Wrapped in a transaction that ROLLBACKs.
+--     Flip to COMMIT for the real run after reviewing the preview counts.
+--   * events is APPEND-ONLY. This touches ONLY agent_channel_bindings. It never
+--     DELETEs from events (or anything else) — it UPDATEs team_id in place.
+--   * Idempotent: re-running only affects rows still holding a non-T… team.
+--   * Manual, parked for a supervised prod run (NOT auto-applied by a migration).
+--
+-- Usage:
+--   psql "$DATABASE_URL" -f PR1-data-reconcile.sql          # preview (rollback)
+--   then set the final ROLLBACK → COMMIT and re-run to apply.
+-- ============================================================================
+
+BEGIN;
+
+-- An "E… team" binding is any Slack binding whose team_id is NOT a workspace id
+-- (T…). We match the enterprise shape explicitly (E…) AND, defensively, any
+-- non-T… non-null team so a stray value can't slip through.
+-- ---------------------------------------------------------------------------
+
+-- Preview: how many Slack bindings currently hold a non-workspace team_id.
+SELECT
+  count(*)                                              AS non_workspace_bindings,
+  count(*) FILTER (WHERE b.team_id ~ '^E')             AS enterprise_id_bindings
+FROM agent_channel_bindings b
+WHERE b.platform LIKE 'slack%'
+  AND b.team_id IS NOT NULL
+  AND b.team_id !~ '^T';
+
+-- The real workspace per (connection_id, channel_id): the most-recently-seen
+-- T… team on a captured inbound message for that channel. channel_messages
+-- carries the message's real workspace id (never the enterprise id).
+CREATE TEMP TABLE _binding_real_team ON COMMIT DROP AS
+SELECT DISTINCT ON (cm.connection_id, cm.channel_id)
+  cm.connection_id,
+  cm.channel_id,
+  cm.team_id AS real_team_id
+FROM channel_messages cm
+WHERE cm.platform LIKE 'slack%'
+  AND cm.team_id ~ '^T'
+ORDER BY cm.connection_id, cm.channel_id, cm.occurred_at DESC;
+
+-- 1) Backfill the real workspace where we have message evidence.
+--    Match channel_messages on the binding's connection + channel. Bindings
+--    store the canonical `slack:C…` key; captured messages may store the bare
+--    or prefixed id — try both.
+UPDATE agent_channel_bindings b
+SET team_id = t.real_team_id
+FROM _binding_real_team t
+WHERE b.platform LIKE 'slack%'
+  AND b.team_id IS NOT NULL
+  AND b.team_id !~ '^T'
+  AND b.connection_id = t.connection_id
+  AND (
+        b.channel_id = t.channel_id
+     OR b.channel_id = 'slack:' || t.channel_id
+     OR 'slack:' || b.channel_id = t.channel_id
+  );
+
+-- 2) Any remaining non-workspace team_id has NO message evidence to source a
+--    real workspace from. Set it to NULL ("unknown yet") so it self-heals from
+--    the first inbound message — NEVER leave an E… in place.
+UPDATE agent_channel_bindings b
+SET team_id = NULL
+WHERE b.platform LIKE 'slack%'
+  AND b.team_id IS NOT NULL
+  AND b.team_id !~ '^T';
+
+-- Post-reconcile verification: zero Slack bindings should hold a non-T… team.
+SELECT
+  count(*) FILTER (WHERE b.team_id ~ '^T')                       AS workspace_bindings,
+  count(*) FILTER (WHERE b.team_id IS NULL)                      AS null_team_bindings_to_heal,
+  count(*) FILTER (WHERE b.team_id IS NOT NULL AND b.team_id !~ '^T') AS remaining_bad_bindings
+FROM agent_channel_bindings b
+WHERE b.platform LIKE 'slack%';
+
+-- Default: preview only. Flip to COMMIT for the supervised apply.
+ROLLBACK;
+-- COMMIT;

--- a/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
@@ -321,6 +321,110 @@ describe("slack channel visibility gate (e2e via search_memory)", () => {
 		expect(channels).not.toContain("C01SEC");
   });
 
+	it("org-wide Grid install (conn tenant = E…, bindings carry T…) STILL graphs and stays ENFORCED", async () => {
+    // Regression guard for the codex finding: once bindings carry the real
+    // workspace `T…` instead of the enterprise `E…`, an org-wide install's ACL
+    // sync must NOT drop every row (which would silently downgrade to the legacy
+    // per-agent fence). connTeamId is the enterprise id here — the relaxed scope
+    // filter accepts every T… binding on the connection and graphs it.
+    const org = await createTestOrganization({ name: "GridCo" });
+    const alice = await createTestUser({ name: "GridAlice" });
+    await addUserToOrganization(alice.id, org.id, "owner");
+    const agent = await createTestAgent({ organizationId: org.id });
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+      VALUES (${org.id}, 'person', 'Person', current_timestamp, current_timestamp)
+      ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+      DO NOTHING
+    `;
+
+    const ENTERPRISE = "E0BDSKL1KJL";
+    const WORKSPACE = "T0BF8TKGW79";
+    const GRID_CONN = "slackinst-gridco"; // managed org-wide install
+    // Connection tenant id is the ENTERPRISE id (org-wide install).
+    await insertChatConnectionRow({
+      id: GRID_CONN,
+      agentId: null,
+      platform: "slack",
+      organizationId: org.id,
+      status: "active",
+      metadata: { teamId: ENTERPRISE },
+    });
+    // Bindings carry the concrete WORKSPACE T… (post-invariant), NOT the E….
+    for (const channel of ["C01ENG", "C01SEC"]) {
+      await sql`
+        INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, connection_id)
+        SELECT ${org.id}, ${agent.agentId}, 'slack', ${channel}, ${WORKSPACE}, id
+        FROM connections
+        WHERE organization_id = ${org.id} AND slug = ${GRID_CONN} AND deleted_at IS NULL
+      `;
+      await sql`
+        INSERT INTO channel_messages (
+          organization_id, connection_id, platform, channel_id,
+          platform_message_id, author_name, is_bot, text, occurred_at
+        ) VALUES (
+          ${org.id}, ${GRID_CONN}, 'slack', ${channel},
+          ${`${channel}-0`}, 'Alice', false, 'quarterly revenue in this channel', NOW()
+        )
+      `;
+    }
+    // Alice signed in + linked Slack, scoped to the real WORKSPACE.
+    const aliceEntity = await createTestEntity({
+      name: "GridAlice",
+      entity_type: "$member",
+      organization_id: org.id,
+      created_by: alice.id,
+    });
+    const aliceSlack = normalizeSlackUserId(WORKSPACE, "U01ALICE");
+    await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+      VALUES
+        (${org.id}, ${aliceEntity.id}, 'auth_user_id', ${alice.id}, 'auth:signup'),
+        (${org.id}, ${aliceEntity.id}, 'slack_user_id', ${aliceSlack}, 'connector:slack')
+    `;
+
+    // Drive the REAL production sync. resolveBotIdentity is stubbed (as in prod
+    // wiring). The graph is keyed on the binding's WORKSPACE T… (slack-acl-sync
+    // groups by binding team), and members resolve on that same T….
+    const membersByChannel: Record<string, string[]> = {
+      C01ENG: ["U01ALICE"],
+      C01SEC: ["U01BOB"],
+    };
+    const result = await syncSlackConnectionAcl(
+      {
+        slackWeb: {
+          conversationMembers: async (_t, channelId) =>
+            membersByChannel[channelId] ?? [],
+        },
+        resolveBotIdentity: async () => ({
+          token: "xoxb-grid-token",
+          botUserId: null,
+        }),
+      },
+      { connectionId: GRID_CONN, organizationId: org.id },
+    );
+    // Pre-fix: connTeamId=E… ≠ binding T… dropped BOTH rows → 0 synced →
+    // connection never graphed → gate falls back to the legacy fence (NOT
+    // enforced). Post-fix: both channels graph and the gate enforces.
+    expect(result.ok).toBe(true);
+    expect(result.channelsSynced).toBe(2);
+
+    const asAlice = search(
+      { query: "quarterly revenue", include_content: true },
+      {} as Parameters<typeof search>[1],
+      { organizationId: org.id, userId: alice.id, agentId: agent.agentId } as SearchCtx,
+    );
+    const channels = ((await asAlice).conversation_messages ?? []).map(
+      (m) => m.channel_id,
+    );
+    // ENFORCED (not legacy fence): Alice (member of #eng only) recalls #eng,
+    // never #secret. If the connection had fallen back to the legacy fence she'd
+    // see BOTH — that is exactly the downgrade this guards against.
+    expect(channels).toContain("C01ENG");
+    expect(channels).not.toContain("C01SEC");
+  });
+
 	it("scopes the production sync to the connection workspace — a second workspace never leaks in", async () => {
     const { org, agent } = await setupWorkspace();
     const sql = getTestDb();

--- a/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-visibility.test.ts
@@ -12,7 +12,12 @@
 
 import { normalizeSlackUserId } from "@lobu/connectors/slack-identity";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { syncSlackConnectionAcl } from "../../../authz/slack-acl-sync";
+import {
+	resolveSlackBotIdentity,
+	syncSlackConnectionAcl,
+} from "../../../authz/slack-acl-sync";
+import { createPostgresAppInstallationStore } from "../../../lobu/stores/app-installation-store";
+import { createSlackWebApi } from "../../../gateway/connections/slack-web";
 import {
 	slackAclSource,
 	slackChannelsToResources,
@@ -421,6 +426,166 @@ describe("slack channel visibility gate (e2e via search_memory)", () => {
     // ENFORCED (not legacy fence): Alice (member of #eng only) recalls #eng,
     // never #secret. If the connection had fallen back to the legacy fence she'd
     // see BOTH — that is exactly the downgrade this guards against.
+    expect(channels).toContain("C01ENG");
+    expect(channels).not.toContain("C01SEC");
+  });
+
+	it("org-wide Grid install: resolves the bot credential by the slackinst- install id via the REAL resolveSlackBotIdentity (NOT the team-keyed miss), then graphs + ENFORCES", async () => {
+    // The load-bearing half of the ACL-sync fix, driven WITHOUT stubbing
+    // resolveBotIdentity: a Grid org-wide install's app_installations row is
+    // keyed on the ENTERPRISE id (E…), so getSlackInstallByTeamId(T…) MISSES for
+    // the sibling workspace. resolveSlackBotIdentity must resolve the token by
+    // the connection's slackinst- slug (= the install external_id) via
+    // getSlackInstallById instead. If it can't, it returns null → sync throws →
+    // connection marked ACL-failed → the gate drops ALL channels (fail-closed
+    // OUTAGE). This proves the by-id branch, the graph build, and enforcement.
+    const org = await createTestOrganization({ name: "GridById" });
+    const alice = await createTestUser({ name: "GridByIdAlice" });
+    await addUserToOrganization(alice.id, org.id, "owner");
+    const agent = await createTestAgent({ organizationId: org.id });
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+      VALUES (${org.id}, 'person', 'Person', current_timestamp, current_timestamp)
+      ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+      DO NOTHING
+    `;
+
+    const ENTERPRISE = "E0GRIDENT99";
+    const WORKSPACE = "T0GRIDWS123";
+    const INSTALL_ID = "slackinst-grid-byid";
+    const ENTERPRISE_TOKEN = "xoxb-enterprise-token"; // plaintext ⇒ no-op secret store
+    const BOT_USER = "U0GRIDBOT";
+
+    // The connection: slug IS the install external id (slackinst-…), tenant id is
+    // the ENTERPRISE id (org-wide install). No BYO token on the connection — the
+    // ONLY way to a token is the install, resolved by id.
+    await insertChatConnectionRow({
+      id: INSTALL_ID,
+      agentId: null,
+      platform: "slack",
+      organizationId: org.id,
+      status: "active",
+      metadata: { teamId: ENTERPRISE },
+    });
+    // The REAL org-wide app_installations row: external_tenant_id = E…,
+    // external_id = the slackinst- slug, is_enterprise_install=true, a bot token.
+    // getSlackInstallByTeamId(T0GRIDWS123) will NOT match this (its tenant is E…);
+    // getSlackInstallById(slackinst-grid-byid) WILL.
+    await sql`
+      INSERT INTO app_installations
+        (organization_id, provider, provider_instance, provider_app_id,
+         external_tenant_id, status, metadata)
+      VALUES
+        (${org.id}, 'slack', 'cloud', 'cloud', ${ENTERPRISE}, 'active',
+         ${sql.json({
+           external_id: INSTALL_ID,
+           is_enterprise_install: true,
+           enterprise_id: ENTERPRISE,
+           bot_user_id: BOT_USER,
+           config: { platform: "slack", botToken: ENTERPRISE_TOKEN },
+         })})
+    `;
+    // Bindings carry the concrete sibling WORKSPACE T… (post-invariant).
+    for (const channel of ["C01ENG", "C01SEC"]) {
+      await sql`
+        INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, connection_id)
+        SELECT ${org.id}, ${agent.agentId}, 'slack', ${channel}, ${WORKSPACE}, id
+        FROM connections
+        WHERE organization_id = ${org.id} AND slug = ${INSTALL_ID} AND deleted_at IS NULL
+      `;
+      await sql`
+        INSERT INTO channel_messages (
+          organization_id, connection_id, platform, channel_id,
+          platform_message_id, author_name, is_bot, text, occurred_at
+        ) VALUES (
+          ${org.id}, ${INSTALL_ID}, 'slack', ${channel},
+          ${`${channel}-0`}, 'Alice', false, 'quarterly revenue in this channel', NOW()
+        )
+      `;
+    }
+    // Alice signed in + linked Slack, scoped to the real WORKSPACE.
+    const aliceEntity = await createTestEntity({
+      name: "GridByIdAlice",
+      entity_type: "$member",
+      organization_id: org.id,
+      created_by: alice.id,
+    });
+    const aliceSlack = normalizeSlackUserId(WORKSPACE, "U01ALICE");
+    await sql`
+      INSERT INTO entity_identities (organization_id, entity_id, namespace, identifier, source_connector)
+      VALUES
+        (${org.id}, ${aliceEntity.id}, 'auth_user_id', ${alice.id}, 'auth:signup'),
+        (${org.id}, ${aliceEntity.id}, 'slack_user_id', ${aliceSlack}, 'connector:slack')
+    `;
+
+    // A no-op secret store: the install's botToken is plaintext, so
+    // resolveSecretValue returns it verbatim without ever calling `.get`.
+    const secretStore = {
+      get: async () => undefined,
+    } as unknown as Parameters<typeof resolveSlackBotIdentity>[0]["secretStore"];
+    const installStore = createPostgresAppInstallationStore();
+    const slackWeb = createSlackWebApi();
+
+    // Capture the token each membership fetch is made with — it MUST be the
+    // enterprise install token, which proves the by-id resolution hit.
+    const fetchedWithTokens: string[] = [];
+    const result = await syncSlackConnectionAcl(
+      {
+        slackWeb: {
+          conversationMembers: async (token, channelId) => {
+            fetchedWithTokens.push(token);
+            return channelId === "C01ENG" ? ["U01ALICE"] : ["U01BOB"];
+          },
+          conversationInfo: async () => ({
+            name: "eng",
+            isPrivate: false,
+            contextTeamId: WORKSPACE,
+          }),
+        },
+        // The REAL production resolver — NOT stubbed. This is the whole point.
+        resolveBotIdentity: (params) =>
+          resolveSlackBotIdentity({ installStore, secretStore, slackWeb }, params),
+      },
+      { connectionId: INSTALL_ID, organizationId: org.id },
+    );
+
+    // Credential resolved by the install id: the enterprise token was used to
+    // fetch every channel's members. A miss would have returned null → throw →
+    // ok:false, channelsSynced:0 → ACL-failed.
+    expect(result.ok).toBe(true);
+    expect(result.channelsSynced).toBe(2);
+    expect(fetchedWithTokens.length).toBe(2);
+    expect(fetchedWithTokens.every((t) => t === ENTERPRISE_TOKEN)).toBe(true);
+
+    // Directly assert the by-id resolution too (independent of the sync loop):
+    // asked to graph the sibling WORKSPACE T…, it returns the enterprise token +
+    // bot id — even though getSlackInstallByTeamId(T…) would miss.
+    const identity = await resolveSlackBotIdentity(
+      { installStore, secretStore, slackWeb },
+      { organizationId: org.id, teamId: WORKSPACE, connectionId: INSTALL_ID },
+    );
+    expect(identity).toEqual({ token: ENTERPRISE_TOKEN, botUserId: BOT_USER });
+
+    // The connection is now ENFORCED (authz_source_acl_state full+fresh), NOT
+    // failed — so the gate enforces membership rather than dropping everything.
+    const [state] = await sql<{ acl_support: string; freshness_state: string }>`
+      SELECT acl_support, freshness_state FROM authz_source_acl_state
+      WHERE organization_id = ${org.id} AND connection_id = ${INSTALL_ID}
+    `;
+    expect(state?.acl_support).toBe("full");
+    expect(state?.freshness_state).toBe("fresh");
+
+    // End-to-end through the gate: Alice (member of #eng only) recalls #eng,
+    // never #secret. Legacy-fence fallback would show BOTH.
+    const asAlice = search(
+      { query: "quarterly revenue", include_content: true },
+      {} as Parameters<typeof search>[1],
+      { organizationId: org.id, userId: alice.id, agentId: agent.agentId } as SearchCtx,
+    );
+    const channels = ((await asAlice).conversation_messages ?? []).map(
+      (m) => m.channel_id,
+    );
     expect(channels).toContain("C01ENG");
     expect(channels).not.toContain("C01SEC");
   });

--- a/packages/server/src/__tests__/integration/connectors/channel-binding-actions.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-binding-actions.test.ts
@@ -17,7 +17,11 @@ import {
 } from "../../../gateway/secrets";
 import { orgContext } from "../../../lobu/stores/org-context";
 import { PostgresSecretStore } from "../../../lobu/stores/postgres-secret-store";
+import { ChannelBindingService } from "../../../gateway/channels/binding-service";
+import { slugToRuntimeConnectionId } from "../../../lobu/stores/connections-projection";
 import { __setBindChannelNotifyDepsForTests } from "../../../gateway/channels/bind-channel-notify";
+import { __setBindingScopeResolverForTests } from "../../../gateway/channels/binding-scope-resolver";
+import { resolveSlackBindingTeam } from "../../../gateway/connections/slack-binding-scope";
 import { __setSlackWebApiForTests } from "../../../tools/admin/manage_connections/handlers/channel-bindings";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
@@ -33,6 +37,10 @@ import {
 import { TestMcpClient, TestWorkspace } from "../../setup/test-mcp-client";
 
 const TEAM = "TACME";
+/** A Grid enterprise id (org-wide install tenant) — must NEVER reach a binding. */
+const ENTERPRISE = "E0BDSKL1KJL";
+/** The concrete workspace a Grid channel resolves to. */
+const WORKSPACE = "T0BF8TKGW79";
 
 async function makeManagedSlackConnection(opts: {
 	orgId: string;
@@ -317,6 +325,155 @@ describe("manage_connections channel-binding actions", () => {
       WHERE organization_id = ${orgId} AND agent_id = ${agentId}
     `;
 		expect(bound.map((r) => r.channel_id)).toContain("slack:D999");
+	});
+
+	it("bind_channel on an org-wide Grid install NEVER stores the enterprise id — stores the workspace T… from context_team_id", async () => {
+		// An org-wide Grid install's connection tenant id is the ENTERPRISE id
+		// (E…). The binding must carry the concrete WORKSPACE (T…), which the
+		// connector resolver reads from conversations.info.context_team_id — never
+		// the E….
+		const pg = new PostgresSecretStore();
+		const store = new SecretStoreRegistry(pg, { secret: pg });
+		const tokenRef = await orgContext.run({ organizationId: orgId }, () =>
+			persistSecretValue(store, "installations/slackinst-grid/botToken", "xoxb-grid"),
+		);
+		const connectionId = await makeManagedSlackConnection({
+			orgId,
+			slug: "slackinst-grid",
+			teamId: ENTERPRISE, // org-wide install ⇒ tenant id is the enterprise E…
+		});
+		const sql = getTestDb();
+		await sql`UPDATE connections SET config = ${sql.json({ botToken: tokenRef })} WHERE id = ${connectionId}`;
+
+		// Drive the REAL Slack resolver with a stub Slack Web API + secret store so
+		// the E… → conversations.info.context_team_id path is exercised end to end.
+		__setBindingScopeResolverForTests("slack", (params) =>
+			resolveSlackBindingTeam(
+				{
+					slackWeb: {
+						conversationInfo: async () => ({
+							name: "eng",
+							isPrivate: false,
+							contextTeamId: WORKSPACE,
+						}),
+					},
+					secretStore: store,
+				},
+				params,
+			),
+		);
+		try {
+			const res = (await workspace.owner.connections.manage({
+				action: "bind_channel",
+				agent_id: agentId,
+				connection_id: connectionId,
+				channel_id: "slack:CGRID",
+			})) as { success?: boolean; team_id?: string; error?: string };
+			expect(res.error).toBeUndefined();
+			expect(res.success).toBe(true);
+			expect(res.team_id).toBe(WORKSPACE);
+			expect(res.team_id).not.toBe(ENTERPRISE);
+
+			const bound = await getDb()<{ team_id: string | null }[]>`
+				SELECT team_id FROM agent_channel_bindings
+				WHERE organization_id = ${orgId} AND channel_id = 'slack:CGRID'
+			`;
+			expect(bound[0]?.team_id).toBe(WORKSPACE);
+			expect(bound[0]?.team_id).not.toBe(ENTERPRISE);
+		} finally {
+			__setBindingScopeResolverForTests("slack", undefined);
+		}
+	});
+
+	it("bind_channel writes NULL (not the enterprise id) when the workspace is unresolvable yet", async () => {
+		// Private channel the bot isn't in: conversations.info throws. The binding
+		// gets a NULL team (unknown-yet, heals from inbound) — NEVER the E….
+		const pg = new PostgresSecretStore();
+		const store = new SecretStoreRegistry(pg, { secret: pg });
+		const tokenRef = await orgContext.run({ organizationId: orgId }, () =>
+			persistSecretValue(store, "installations/slackinst-grid2/botToken", "xoxb-grid2"),
+		);
+		const connectionId = await makeManagedSlackConnection({
+			orgId,
+			slug: "slackinst-grid2",
+			teamId: ENTERPRISE,
+		});
+		const sql = getTestDb();
+		await sql`UPDATE connections SET config = ${sql.json({ botToken: tokenRef })} WHERE id = ${connectionId}`;
+
+		__setBindingScopeResolverForTests("slack", (params) =>
+			resolveSlackBindingTeam(
+				{
+					slackWeb: {
+						conversationInfo: async () => {
+							throw new Error("Slack conversations.info failed: not_in_channel");
+						},
+					},
+					secretStore: store,
+				},
+				params,
+			),
+		);
+		try {
+			const res = (await workspace.owner.connections.manage({
+				action: "bind_channel",
+				agent_id: agentId,
+				connection_id: connectionId,
+				channel_id: "slack:CPRIV",
+			})) as { success?: boolean; team_id?: string; error?: string };
+			expect(res.error).toBeUndefined();
+			expect(res.success).toBe(true);
+			expect(res.team_id).toBeUndefined();
+
+			const bound = await getDb()<{ team_id: string | null }[]>`
+				SELECT team_id FROM agent_channel_bindings
+				WHERE organization_id = ${orgId} AND channel_id = 'slack:CPRIV'
+			`;
+			expect(bound[0]?.team_id).toBeNull();
+		} finally {
+			__setBindingScopeResolverForTests("slack", undefined);
+		}
+	});
+
+	it("lazy self-heal: a NULL-team binding converges to the real T… after an inbound message", async () => {
+		const connectionId = await makeManagedSlackConnection({
+			orgId,
+			slug: "slackinst-heal",
+			teamId: ENTERPRISE,
+		});
+		const sql = getTestDb();
+		// A binding written before its workspace was known — NULL team.
+		await sql`
+			INSERT INTO agent_channel_bindings (organization_id, agent_id, platform, channel_id, team_id, connection_id)
+			VALUES (${orgId}, ${agentId}, 'slack', 'slack:CHEAL', NULL, ${connectionId})
+		`;
+		const svc = new ChannelBindingService();
+		// The inbound message carries the REAL workspace T…; heal converges to it.
+		await svc.healBindingTeam(
+			slugToRuntimeConnectionId("slackinst-heal"),
+			"slack:CHEAL",
+			orgId,
+			WORKSPACE,
+		);
+		const healed = await getDb()<{ team_id: string | null }[]>`
+			SELECT team_id FROM agent_channel_bindings
+			WHERE organization_id = ${orgId} AND channel_id = 'slack:CHEAL'
+		`;
+		expect(healed[0]?.team_id).toBe(WORKSPACE);
+
+		// Guard: a stray/foreign team on a later message must NOT overwrite a
+		// known workspace.
+		await svc.healBindingTeam(
+			slugToRuntimeConnectionId("slackinst-heal"),
+			"slack:CHEAL",
+			orgId,
+			"T99OTHER",
+		);
+		const after = await getDb()<{ team_id: string | null }[]>`
+			SELECT team_id FROM agent_channel_bindings
+			WHERE organization_id = ${orgId} AND channel_id = 'slack:CHEAL'
+		`;
+		expect(after[0]?.team_id).toBe(WORKSPACE);
 	});
 
 	it("sync_channel_bindings writes config-sourced about edges from entity slugs", async () => {

--- a/packages/server/src/__tests__/unit/conversation-visibility.test.ts
+++ b/packages/server/src/__tests__/unit/conversation-visibility.test.ts
@@ -32,7 +32,7 @@ describe("isConversationVisible", () => {
 		expect(isConversationVisible("slack:C123:1781.0", v)).toBe(true);
 	});
 
-	it("fails closed when the channel id is bound in more than one workspace", () => {
+	it("fails closed when the channel id is bound in more than one REAL workspace", () => {
 		// Same channel id across two Slack teams — the conversation id carries no
 		// team, so it must NOT show even though T1 is visible.
 		const v = vis({
@@ -40,6 +40,35 @@ describe("isConversationVisible", () => {
 			channelTeams: { "slack:C123": ["T1", "T2"] },
 		});
 		expect(isConversationVisible("slack:C123:1781.0", v)).toBe(false);
+	});
+
+	it("is VISIBLE when a channel is bound {NULL, T…} — the NULL is a wildcard that resolves to T…", () => {
+		// A binding written before its workspace healed carries a NULL team ("" in
+		// the map). It is unknown-yet, NOT a second distinct workspace, so the
+		// conversation resolves to the single real team T1 and stays visible.
+		const v = vis({
+			visibleKeys: ["slack:T1:C123"],
+			channelTeams: { "slack:C123": ["", "T1"] },
+		});
+		expect(isConversationVisible("slack:C123:1781.0", v)).toBe(true);
+	});
+
+	it("is VISIBLE for a lone real team (defensive: the {E…, T…} case can no longer occur)", () => {
+		// The invariant guarantees team_id is never a Grid enterprise id, so a
+		// channel only ever carries at most one real workspace. A lone T… is visible.
+		const v = vis({
+			visibleKeys: ["slack:T1:C777"],
+			channelTeams: { "slack:C777": ["T1"] },
+		});
+		expect(isConversationVisible("slack:C777:9.9", v)).toBe(true);
+	});
+
+	it("fails closed on two DISTINCT real teams {T_A, T_B} — genuine cross-workspace ambiguity", () => {
+		const v = vis({
+			visibleKeys: ["slack:TA:C555"],
+			channelTeams: { "slack:C555": ["TA", "TB"] },
+		});
+		expect(isConversationVisible("slack:C555:1.1", v)).toBe(false);
 	});
 
 	it("fails closed when the requester isn't a member of the channel's team", () => {

--- a/packages/server/src/__tests__/unit/slack-binding-scope.test.ts
+++ b/packages/server/src/__tests__/unit/slack-binding-scope.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { BindingConnection } from "../../gateway/channels/binding-scope-resolver";
+import { resolveBindingTeam } from "../../gateway/channels/binding-scope-resolver";
+import { resolveSlackBindingTeam } from "../../gateway/connections/slack-binding-scope";
+
+/**
+ * The binding-team invariant: `agent_channel_bindings.team_id` is ALWAYS the
+ * concrete WORKSPACE (`T…`), never a Grid ENTERPRISE id (`E…`). These cover the
+ * connector resolver's non-DB branches (hint priority, `T…`-stored fast path)
+ * and the generic default dispatch. The `E…` → conversations.info branch (which
+ * loads a bot token from the DB) is covered end-to-end in the integration suite.
+ */
+
+const ENTERPRISE = "E0BDSKL1KJL";
+const WORKSPACE = "T0BF8TKGW79";
+
+function conn(externalTenantId: string | null): BindingConnection {
+	return {
+		connectorKey: "slack",
+		externalTenantId,
+		connectionId: 1,
+		organizationId: "org-1",
+	};
+}
+
+// Stub: any conversations.info call would throw — proves the non-DB branches
+// resolve WITHOUT ever hitting Slack.
+const throwingWeb = {
+	conversationInfo: async () => {
+		throw new Error("conversations.info must not be called on these branches");
+	},
+};
+const unusedSecretStore = {
+	get: async () => {
+		throw new Error("secret store must not be used on these branches");
+	},
+};
+
+describe("resolveSlackBindingTeam", () => {
+	it("prefers a trusted workspace (T…) hint over everything, no round-trip", async () => {
+		const team = await resolveSlackBindingTeam(
+			{ slackWeb: throwingWeb, secretStore: unusedSecretStore },
+			{ connection: conn(ENTERPRISE), channelId: "slack:C1", workspaceHint: WORKSPACE },
+		);
+		expect(team).toBe(WORKSPACE);
+	});
+
+	it("uses the connection's stored tenant id when it is already a workspace (T…)", async () => {
+		const team = await resolveSlackBindingTeam(
+			{ slackWeb: throwingWeb, secretStore: unusedSecretStore },
+			{ connection: conn(WORKSPACE), channelId: "slack:C1" },
+		);
+		expect(team).toBe(WORKSPACE);
+	});
+
+});
+
+describe("resolveBindingTeam (generic dispatch)", () => {
+	it("defaults a non-Slack connector to the connection's stored tenant id", async () => {
+		const team = await resolveBindingTeam({
+			connection: {
+				connectorKey: "telegram",
+				externalTenantId: "chat-999",
+				connectionId: 2,
+				organizationId: "org-1",
+			},
+			channelId: "telegram:998877",
+		});
+		expect(team).toBe("chat-999");
+	});
+
+	it("a trusted hint wins for the default connector too", async () => {
+		const team = await resolveBindingTeam({
+			connection: {
+				connectorKey: "telegram",
+				externalTenantId: "chat-999",
+				connectionId: 2,
+				organizationId: "org-1",
+			},
+			channelId: "telegram:998877",
+			workspaceHint: "chat-hint",
+		});
+		expect(team).toBe("chat-hint");
+	});
+});

--- a/packages/server/src/authz/slack-acl-sync.ts
+++ b/packages/server/src/authz/slack-acl-sync.ts
@@ -36,7 +36,10 @@ import {
   runtimeConnectionIdToSlug,
   slugToRuntimeConnectionId,
 } from '../lobu/stores/connections-projection.js';
-import { getSlackInstallByTeamId } from '../lobu/stores/slack-installations.js';
+import {
+  getSlackInstallById,
+  getSlackInstallByTeamId,
+} from '../lobu/stores/slack-installations.js';
 import { orgContext } from '../lobu/stores/org-context.js';
 import {
   type SlackChannelInput,
@@ -116,13 +119,18 @@ export async function syncSlackConnectionAcl(
     connectionId,
   });
 
-  // `resolveBoundChannelRows` joins bindings on (org, agent, platform) — NOT on
-  // workspace — so an agent with a SECOND Slack connection (another workspace)
-  // would pull that workspace's channels in here too. A real workspace
-  // connection carries `metadata.teamId`; scope to it so we only ever fetch
-  // members with THIS connection's token and stamp THIS connection's ACL state.
-  // A preview connection (no teamId, the hosted-bot invariant) serves cross-org
-  // bindings by design, so it stays unscoped.
+  // `resolveBoundChannelRows` narrows bindings to THIS connection (by slug), so
+  // every row here already belongs to it — we trust connection_id as the scope,
+  // NOT a team-string round-trip. `connTeamId` is only used to guard the BYO
+  // multi-workspace case: when the connection's tenant id is itself a WORKSPACE
+  // (`T…`), a binding for a DIFFERENT workspace is a stray second-connection row
+  // and is dropped (fetched with the wrong token → fail-closed otherwise). When
+  // the tenant id is NOT a workspace — a Grid ENTERPRISE (`E…`) org-wide install,
+  // whose bindings correctly carry the sibling workspace `T…`, or a preview
+  // connection (no teamId) — we accept EVERY real-team binding on the connection
+  // and group by the binding's own team. Without this relaxation an org-wide
+  // install (connTeamId = E…) drops all its `T…` bindings and silently
+  // downgrades to the legacy per-agent fence.
   const [conn] = await sql<{ team_id: string | null }>`
 		SELECT COALESCE(external_tenant_id, config->'chatMetadata'->>'teamId') AS team_id
 		FROM connections
@@ -133,14 +141,18 @@ export async function syncSlackConnectionAcl(
 		LIMIT 1
 	`;
   const connTeamId = conn?.team_id ?? null;
+  // Is the connection's tenant id itself a concrete workspace? Only then do we
+  // enforce workspace equality (BYO foreign-workspace guard). An enterprise `E…`
+  // or absent tenant id does NOT constrain the binding team.
+  const connScopesWorkspace = /^T[A-Z0-9]+$/i.test(connTeamId ?? '');
 
-  // Only Slack rows that carry a team id can be team-scoped into the graph; a
-  // channel with no team id is dropped fail-closed by the gate anyway.
+  // Only Slack rows that carry a real workspace team can be team-scoped into the
+  // graph; a channel with no team id is dropped fail-closed by the gate anyway.
   const slackRows = bound.filter(
     (r) =>
       r.platform.startsWith('slack') &&
       r.team_id &&
-      (connTeamId === null || r.team_id === connTeamId),
+      (!connScopesWorkspace || r.team_id === connTeamId),
   );
   if (slackRows.length === 0) {
     return { ok: true, teamsSynced: 0, channelsSynced: 0 };
@@ -272,7 +284,29 @@ export async function resolveSlackBotIdentity(
   const { installStore, secretStore, slackWeb } = deps;
   const { organizationId, teamId, connectionId } = params;
 
-  // Primary: the workspace OAuth app-installation (the hosted/managed path).
+  // Primary: resolve the install by THIS connection's concrete id
+  // (`slackinst-<uuid>` slug = the install external id), NOT by round-tripping
+  // the team string. On a Grid ORG-WIDE install the install row is keyed on the
+  // ENTERPRISE id, so a per-team `getSlackInstallByTeamId(T…)` lookup misses for
+  // every sibling workspace — but the one bot token is enterprise-wide and reads
+  // every workspace's channels. Resolving by connection id gives us that token
+  // for any `T…` we're graphing. Only slackinst- slugs are installs; a BYO slug
+  // (`agentconn-…`) skips straight to the fallback below.
+  const connSlug = runtimeConnectionIdToSlug(connectionId);
+  const installById = connSlug.startsWith('slackinst-')
+    ? await getSlackInstallById(installStore, connSlug)
+    : null;
+  if (installById && installById.status === 'active') {
+    const tokenRef = (installById.config as { botToken?: string }).botToken;
+    const token = await orgContext.run(
+      { organizationId: installById.organizationId },
+      () => resolveSecretValue(secretStore, tokenRef),
+    );
+    if (token) return { token, botUserId: installById.botUserId ?? null };
+  }
+
+  // Secondary: the workspace OAuth app-installation keyed by team (a normal,
+  // non-org-wide install whose connection slug may not be the install id).
   const install = await getSlackInstallByTeamId(installStore, teamId);
   if (install && install.status === 'active') {
     const tokenRef = (install.config as { botToken?: string }).botToken;

--- a/packages/server/src/gateway/channels/binding-scope-resolver.ts
+++ b/packages/server/src/gateway/channels/binding-scope-resolver.ts
@@ -1,0 +1,107 @@
+/**
+ * Connector-owned "which workspace does this binding belong to" resolver.
+ *
+ * `agent_channel_bindings.team_id` is a HARD invariant: it ALWAYS names the
+ * concrete workspace/tenant a channel lives in, never a broader install
+ * identity (for Slack Grid: the workspace `T…`, NEVER the enterprise `E…`).
+ * The generic binding-write path (`channel-bindings` handlers,
+ * `slack-claim-onboarding`) must not know how any one connector computes that —
+ * it just calls {@link resolveBindingTeam}. Each connector owns its own rule.
+ *
+ * Why a server-side module list and NOT `ConnectorIdentityModule`: identity
+ * modules are a pure, synchronous namespace-normalizer (no I/O). Resolving a
+ * Slack binding's workspace on a Grid org-wide install needs a
+ * `conversations.info` round-trip (the install identity is the enterprise id —
+ * only the channel's `context_team_id` reveals its workspace), so the Slack
+ * resolver lives in the Slack server module where the Slack Web API + secret
+ * store are reachable. Core/generic code never names a connector; dispatch is by
+ * `connectorKey` against a static module list (mirrors
+ * `CONNECTOR_IDENTITY_MODULES`).
+ *
+ * Contract: a resolver returns the concrete workspace team id, or `null` when it
+ * cannot be determined YET (e.g. a private channel the bot isn't in). `null`
+ * means "unknown" — the row is written with a NULL team and heals from the first
+ * inbound event (which carries the real workspace id). A resolver MUST NEVER
+ * return a broader install identity (an `E…`) as if it were the workspace.
+ */
+
+import { slackBindingScopeModule } from "../connections/slack-binding-scope.js";
+
+/** What a resolver needs about the connection backing a binding. */
+export interface BindingConnection {
+  connectorKey: string;
+  /** The connection's stored tenant identity. For most connectors this IS the
+   *  workspace; for a Slack Grid org-wide install it is the enterprise `E…`,
+   *  which the Slack resolver deliberately refuses to treat as a workspace. */
+  externalTenantId: string | null;
+  /** Numeric `connections.id` — lets a resolver load the bot credential. */
+  connectionId: number;
+  organizationId: string;
+}
+
+export interface BindingScopeResolveParams {
+  connection: BindingConnection;
+  /** Bound channel id (may be platform-prefixed `slack:C…` or bare). */
+  channelId: string;
+  /** A trusted workspace hint carried by the write's origin (e.g. a slash
+   *  command / deep-link `team_id`), when the caller has one. Preferred over any
+   *  live lookup — it's the real workspace, already verified by the platform. */
+  workspaceHint?: string | null;
+}
+
+/** Resolve the concrete workspace team a binding belongs to, or null if unknown
+ *  yet (heal-from-inbound). */
+export type BindingScopeResolver = (
+  params: BindingScopeResolveParams,
+) => Promise<string | null>;
+
+/** A connector's self-description for binding-scope resolution. */
+export interface BindingScopeModule {
+  /** Connector/platform key (`slack`, …). */
+  key: string;
+  resolve: BindingScopeResolver;
+}
+
+/**
+ * The connector modules that own a binding-scope rule — the ONE place this
+ * generic module enumerates connectors (mirrors `CONNECTOR_IDENTITY_MODULES`).
+ * Only connectors whose tenant identity differs from their workspace need one;
+ * every other connector uses the default (stored tenant id) below.
+ */
+const BINDING_SCOPE_MODULES: readonly BindingScopeModule[] = [
+  slackBindingScopeModule,
+];
+
+/** Test-only per-connector resolver overrides (the Slack module wires the real
+ *  Slack Web API + secret store, which tests replace with stubs). */
+const testOverrides = new Map<string, BindingScopeResolver>();
+
+/** Test seam: override the resolver for one connector key. Pass `undefined` to
+ *  clear. Tests MUST clear in a `finally`/`afterEach` to avoid leaking. */
+export function __setBindingScopeResolverForTests(
+  connectorKey: string,
+  resolve: BindingScopeResolver | undefined,
+): void {
+  if (resolve) testOverrides.set(connectorKey, resolve);
+  else testOverrides.delete(connectorKey);
+}
+
+/**
+ * Resolve the workspace team id to stamp on a new/updated binding. Dispatches to
+ * the connector's module; falls back to the connection's stored tenant id for
+ * connectors whose tenant identity IS the workspace (the common case — no
+ * special handling needed). Returns null only when the connector's resolver says
+ * the workspace is unknown yet.
+ */
+export async function resolveBindingTeam(
+  params: BindingScopeResolveParams,
+): Promise<string | null> {
+  const key = params.connection.connectorKey;
+  const override = testOverrides.get(key);
+  if (override) return override(params);
+  const mod = BINDING_SCOPE_MODULES.find((m) => m.key === key);
+  if (mod) return mod.resolve(params);
+  // Default: the connection's tenant id is the workspace (Telegram chat, a
+  // single-workspace connector, …). A trusted hint still wins when present.
+  return params.workspaceHint ?? params.connection.externalTenantId ?? null;
+}

--- a/packages/server/src/gateway/channels/binding-service.ts
+++ b/packages/server/src/gateway/channels/binding-service.ts
@@ -94,6 +94,41 @@ export class ChannelBindingService {
 		return rows[0] ? rowToBinding(rows[0]) : null;
 	}
 
+	/**
+	 * Lazy self-heal: converge a binding's `team_id` to the real WORKSPACE id an
+	 * inbound message carries. A binding written before its workspace was known
+	 * (the resolver returned null → NULL team) heals here on the first message.
+	 *
+	 * Guarded to ONLY fill an unknown (NULL/empty) team — never overwrite an
+	 * already-set workspace, so a stray/foreign `team_id` on a message can't
+	 * repoint a live binding. Keyed on the concrete (org, connection, channel).
+	 * Best-effort by contract: a heal failure must never block message routing.
+	 */
+	async healBindingTeam(
+		connectionId: string,
+		channelId: string,
+		organizationId: string,
+		realTeamId: string,
+	): Promise<void> {
+		if (!realTeamId.trim()) return;
+		const sql = getDb();
+		// Resolve the binding by the concrete connection (via slug, exactly like
+		// getBindingForConnection) so a runtime slug id maps to the right numeric
+		// connection_id. Only fills an unknown team.
+		const slug = runtimeConnectionIdToSlug(connectionId);
+		await sql`
+			UPDATE agent_channel_bindings b
+			SET team_id = ${realTeamId}
+			FROM connections c
+			WHERE c.id = b.connection_id
+				AND c.slug = ${slug}
+				AND c.deleted_at IS NULL
+				AND b.organization_id = ${organizationId}
+				AND b.channel_id = ${channelId}
+				AND (b.team_id IS NULL OR b.team_id = '')
+		`;
+	}
+
 	async createBinding(
 		agentId: string,
 		platform: string,

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -619,6 +619,32 @@ export class MessageHandlerBridge {
     const routingOrgId =
       resolved.organizationId ?? this.connection.organizationId;
 
+    // Lazy self-heal (Slack Grid): a binding written before its workspace was
+    // known carries a NULL team. Inbound Slack events reliably carry the REAL
+    // workspace `T…` (never the enterprise `E…`), so converge the binding's team
+    // to it on the first message. Guarded to fill only an unknown team; best-
+    // effort — a heal failure must never block routing.
+    if (
+      resolved.source === "binding" &&
+      platform === "slack" &&
+      /^T[A-Z0-9]+$/i.test(teamId ?? "") &&
+      routingOrgId
+    ) {
+      try {
+        await channelBindingService.healBindingTeam(
+          this.connection.id,
+          channelId,
+          routingOrgId,
+          teamId as string,
+        );
+      } catch (err) {
+        logger.debug(
+          { channelId, teamId, error: String(err) },
+          "binding team self-heal failed (non-fatal)"
+        );
+      }
+    }
+
     // Durable transcript capture: persist this inbound message so
     // read_conversation can serve channel history from Postgres instead of the
     // throttled platform history API. Fire-and-forget + idempotent. thread_id is

--- a/packages/server/src/gateway/connections/slack-binding-scope.ts
+++ b/packages/server/src/gateway/connections/slack-binding-scope.ts
@@ -82,11 +82,9 @@ export async function resolveSlackBindingTeam(
   const { connection, channelId, workspaceHint } = params;
   const stored = connection.externalTenantId;
 
-  // 1. A trusted, real-workspace hint wins with no round-trip. Reject a hint
-  //    that is the connection's own enterprise id (a mis-supplied E…).
-  if (isSlackWorkspaceId(workspaceHint) && workspaceHint !== stored) {
-    return workspaceHint.trim();
-  }
+  // 1. A trusted, real-workspace (T…) hint wins with no round-trip. The
+  //    workspace-shape check already excludes an enterprise `E…` hint, so a
+  //    valid hint is always safe to use verbatim.
   if (isSlackWorkspaceId(workspaceHint)) return workspaceHint.trim();
 
   // 2/3. If the stored tenant is already a workspace id (normal install), use

--- a/packages/server/src/gateway/connections/slack-binding-scope.ts
+++ b/packages/server/src/gateway/connections/slack-binding-scope.ts
@@ -1,0 +1,155 @@
+/**
+ * Slack's binding-scope resolver — the ONE place that knows a Slack binding's
+ * `team_id` must be the concrete WORKSPACE (`T…`), never a Grid ENTERPRISE id
+ * (`E…`).
+ *
+ * The generic binding-write path calls `resolveBindingTeam` (see
+ * `channels/binding-scope-resolver`); this module registers the Slack rule so no
+ * connector-specific logic leaks into that path or into the read-side gate/ACL.
+ *
+ * Resolution order:
+ *   1. A trusted workspace hint (a slash-command / deep-link `team_id`) that is
+ *      NOT the connection's enterprise id — it's the real workspace, already
+ *      verified by Slack. Preferred: no round-trip.
+ *   2. `conversations.info.context_team_id` — the channel's workspace context.
+ *      This is the only install-time signal on a Grid org-wide install, where
+ *      the connection's `external_tenant_id` is the enterprise id.
+ *   3. The connection's `external_tenant_id` ONLY when it is a workspace id
+ *      (`T…`) — a normal (non-Grid, non-org-wide) install stores the workspace
+ *      there and needs no round-trip.
+ *   4. Otherwise `null` — unknown yet (e.g. a private channel the bot isn't in).
+ *      The binding is written with a NULL team and heals from the first inbound
+ *      message, which carries the real `T…`. We NEVER write the enterprise id.
+ */
+
+import { createLogger } from "@lobu/core";
+import { getDb } from "../../db/client.js";
+import type {
+  BindingScopeModule,
+  BindingScopeResolveParams,
+} from "../channels/binding-scope-resolver.js";
+import { stripPlatformPrefix } from "../channels/bound-channels.js";
+import { orgContext } from "../../lobu/stores/org-context.js";
+import {
+  resolveSecretValue,
+  type SecretStore,
+  SecretStoreRegistry,
+} from "../secrets/index.js";
+import { PostgresSecretStore } from "../../lobu/stores/postgres-secret-store.js";
+import { createSlackWebApi, type SlackWebApi } from "./slack-web.js";
+
+const logger = createLogger("slack-binding-scope");
+
+/**
+ * A Slack workspace id is `T…`; a Grid enterprise id is `E…`. This is the one
+ * shape check the CONNECTOR is allowed to make about its own identity space —
+ * it lives here, inside the Slack module, and never touches the generic
+ * gate/ACL. Used only to reject the enterprise id from ever being stamped as a
+ * workspace.
+ */
+function isSlackWorkspaceId(id: string | null | undefined): id is string {
+  return typeof id === "string" && /^T[A-Z0-9]+$/i.test(id.trim());
+}
+
+/** Load a connection's bot-token `secret://` ref (top-level or chatMetadata). */
+async function loadBotTokenRef(
+  connectionId: number,
+  organizationId: string,
+): Promise<string | null> {
+  const sql = getDb();
+  const [row] = await sql<{ bot_token_ref: string | null }>`
+    SELECT COALESCE(config->>'botToken', config->'chatMetadata'->>'botToken') AS bot_token_ref
+    FROM connections
+    WHERE id = ${connectionId}
+      AND organization_id = ${organizationId}
+      AND connector_key = 'slack'
+      AND deleted_at IS NULL
+    LIMIT 1
+  `;
+  return row?.bot_token_ref ?? null;
+}
+
+/** Injectable seam so tests drive the resolver with a stub Slack API + store. */
+export interface SlackBindingScopeDeps {
+  slackWeb: Pick<SlackWebApi, "conversationInfo">;
+  secretStore: SecretStore;
+}
+
+export async function resolveSlackBindingTeam(
+  deps: SlackBindingScopeDeps,
+  params: BindingScopeResolveParams,
+): Promise<string | null> {
+  const { connection, channelId, workspaceHint } = params;
+  const stored = connection.externalTenantId;
+
+  // 1. A trusted, real-workspace hint wins with no round-trip. Reject a hint
+  //    that is the connection's own enterprise id (a mis-supplied E…).
+  if (isSlackWorkspaceId(workspaceHint) && workspaceHint !== stored) {
+    return workspaceHint.trim();
+  }
+  if (isSlackWorkspaceId(workspaceHint)) return workspaceHint.trim();
+
+  // 2/3. If the stored tenant is already a workspace id (normal install), use
+  //      it directly — no need to hit Slack.
+  if (isSlackWorkspaceId(stored)) return stored.trim();
+
+  // The stored tenant is an enterprise id (or absent): ask Slack which
+  // workspace this channel lives in via conversations.info.context_team_id.
+  const tokenRef = await loadBotTokenRef(
+    connection.connectionId,
+    connection.organizationId,
+  );
+  if (!tokenRef) {
+    logger.info(
+      { connectionId: connection.connectionId, channelId },
+      "Slack binding-scope: no bot token to resolve channel workspace — leaving team NULL to heal from inbound",
+    );
+    return null;
+  }
+  const token = await orgContext.run(
+    { organizationId: connection.organizationId },
+    () => resolveSecretValue(deps.secretStore, tokenRef),
+  );
+  if (!token) return null;
+
+  try {
+    const info = await deps.slackWeb.conversationInfo(
+      token,
+      stripPlatformPrefix("slack", channelId),
+    );
+    if (isSlackWorkspaceId(info.contextTeamId)) {
+      return info.contextTeamId.trim();
+    }
+  } catch (error) {
+    // A private channel the bot isn't in yet (channel_not_found / not_in_channel)
+    // or any transient failure: leave the team NULL and heal from inbound. NEVER
+    // fall back to the enterprise id.
+    logger.info(
+      {
+        connectionId: connection.connectionId,
+        channelId,
+        error: String(error),
+      },
+      "Slack binding-scope: conversations.info failed — leaving team NULL to heal from inbound",
+    );
+  }
+  return null;
+}
+
+/** A PG-backed secret store — Slack bot tokens are written under the default
+ *  (PG) scheme, so this resolves them exactly as the gateway's store. */
+function slackSecretStore(): SecretStore {
+  const pg = new PostgresSecretStore();
+  return new SecretStoreRegistry(pg, { secret: pg });
+}
+
+/** The Slack binding-scope module — wired with the real Slack Web API + the
+ *  process secret store. Enumerated by the generic resolver's module list. */
+export const slackBindingScopeModule: BindingScopeModule = {
+  key: "slack",
+  resolve: (params) =>
+    resolveSlackBindingTeam(
+      { slackWeb: createSlackWebApi(), secretStore: slackSecretStore() },
+      params,
+    ),
+};

--- a/packages/server/src/gateway/connections/slack-claim-onboarding.ts
+++ b/packages/server/src/gateway/connections/slack-claim-onboarding.ts
@@ -27,6 +27,7 @@ import { BUILDER_AGENT_ID, ensureBuilderAgent } from "../../auth/builder-provisi
 import { getDb } from "../../db/client.js";
 import { canonicalSlackChannelId } from "../../preview/slack.js";
 import { ChannelBindingService } from "../channels/binding-service.js";
+import { resolveBindingTeam } from "../channels/binding-scope-resolver.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
 import {
   resolveSecretValue,
@@ -174,11 +175,37 @@ async function linkBuilderToInstallerDm(args: {
   // Store under the canonical `slack:<id>` key — inbound messages reach the
   // dispatcher already canonicalized, so a raw `D…` key would never route.
   const channelId = canonicalSlackChannelId(dmChannelId);
+  // Resolve the DM's CONCRETE workspace. On a Grid org-wide install the claim's
+  // `teamId` (and the connection's external_tenant_id) is the enterprise `E…`,
+  // which must never land in a binding — the resolver returns the real
+  // workspace or null (heal-from-inbound). Not the raw `teamId`.
+  const [conn] = (await getDb()`
+    SELECT external_tenant_id FROM connections
+    WHERE id = ${Number(connection.connectionId)}
+      AND organization_id = ${organizationId}
+      AND deleted_at IS NULL
+    LIMIT 1
+  `) as Array<{ external_tenant_id: string | null }>;
+  const bindingTeamId =
+    (await resolveBindingTeam({
+      connection: {
+        connectorKey: "slack",
+        externalTenantId: conn?.external_tenant_id ?? teamId ?? null,
+        connectionId: Number(connection.connectionId),
+        organizationId,
+      },
+      channelId,
+      // The claim's teamId is the workspace for a normal install — a trusted hint
+      // the resolver uses directly (no Slack round-trip). For an org-wide install
+      // it's the enterprise id, which the resolver rejects and resolves via
+      // conversations.info instead.
+      workspaceHint: teamId,
+    })) ?? undefined;
   await new ChannelBindingService().createBinding(
     builderId,
     "slack",
     channelId,
-    teamId,
+    bindingTeamId,
     { organizationId, connectionId: connection.connectionId },
   );
   logger.info(

--- a/packages/server/src/gateway/connections/slack-web.ts
+++ b/packages/server/src/gateway/connections/slack-web.ts
@@ -25,14 +25,23 @@ export interface SlackWebApi {
    */
   conversationMembers(botToken: string, channelId: string): Promise<string[]>;
   /**
-   * `conversations.info` → the channel's human-readable name (e.g. `general`)
-   * and privacy flag. `name` is null when Slack omits it (e.g. a DM/MPIM or an
-   * unreadable channel); callers fall back to the channel id.
+   * `conversations.info` → the channel's human-readable name (e.g. `general`),
+   * privacy flag, and the CONCRETE workspace team the channel lives in
+   * (`context_team_id`). `name` is null when Slack omits it (e.g. a DM/MPIM or
+   * an unreadable channel); callers fall back to the channel id. `contextTeamId`
+   * is the real `T…` workspace id — on a Grid org-wide install this is the ONLY
+   * place a binding can learn the channel's workspace (the install identity is
+   * the enterprise `E…`, never a workspace), so the binding-team resolver reads
+   * it here. Null when Slack omits it or the channel is unreadable.
    */
   conversationInfo(
     botToken: string,
     channelId: string
-  ): Promise<{ name: string | null; isPrivate: boolean }>;
+  ): Promise<{
+    name: string | null;
+    isPrivate: boolean;
+    contextTeamId: string | null;
+  }>;
   /**
    * `users.info` → the workspace-admin flags for one user. Used by the
    * marketplace-claim flow to verify the claiming user is a workspace admin or
@@ -174,11 +183,15 @@ export function createSlackWebApi(): SlackWebApi {
         channel: channelId,
       });
       const ch = json.channel as
-        | { name?: string; is_private?: boolean }
+        | { name?: string; is_private?: boolean; context_team_id?: string }
         | undefined;
       return {
         name: typeof ch?.name === "string" ? ch.name : null,
         isPrivate: ch?.is_private === true,
+        contextTeamId:
+          typeof ch?.context_team_id === "string" && ch.context_team_id
+            ? ch.context_team_id
+            : null,
       };
     },
     async usersInfo(botToken, userId) {

--- a/packages/server/src/gateway/services/agent-thread-list.ts
+++ b/packages/server/src/gateway/services/agent-thread-list.ts
@@ -117,8 +117,16 @@ export async function resolveChannelVisibility(
 }
 
 /** Can the requester read this platform conversation (`{platform}:{channel}:{thread}`)?
- *  Fail-closed: unbound, or a channel bound in more than one workspace (can't tie
- *  the conversation to a team), is not visible. */
+ *  Fail-closed: unbound, or a channel bound in ≥2 DISTINCT REAL workspaces (can't
+ *  tie the conversation to a single team), is not visible.
+ *
+ *  A NULL/"" team is a WILDCARD ("workspace unknown yet" — a binding written
+ *  before its workspace healed from the first inbound event), NOT a distinct
+ *  workspace. `team_id` is now guaranteed to be a real workspace or NULL (never a
+ *  Grid enterprise id), so the gate needs zero connector knowledge: it counts
+ *  distinct non-null teams and only fails closed on genuine cross-workspace
+ *  ambiguity (2+ real teams). One real team + any number of NULLs resolves to
+ *  that team; all-NULL resolves via the wildcard visible key. */
 export function isConversationVisible(
 	conversationId: string,
 	vis: ChannelVisibility,
@@ -127,11 +135,13 @@ export function isConversationVisible(
 	const platform = (parts[0] ?? "").toLowerCase();
 	const channel = parts[1] ?? "";
 	const teams = vis.channelTeams.get(`${platform}:${channel}`);
-	if (!teams || teams.size !== 1) return false; // unbound or ambiguous workspace
-	const [team] = [...teams];
-	return vis.visibleKeys.has(
-		channelVisibilityKey(platform, team || null, channel),
-	);
+	if (!teams || teams.size === 0) return false; // unbound
+	const realTeams = [...teams].filter((t) => t !== "");
+	if (realTeams.length > 1) return false; // genuine cross-workspace ambiguity
+	// One real team (NULLs are wildcards that resolve to it), or all-NULL (a
+	// teamless/unknown-yet binding — resolves via the "" wildcard visible key).
+	const team = realTeams[0] ?? null;
+	return vis.visibleKeys.has(channelVisibilityKey(platform, team, channel));
 }
 
 async function findConversationSessionFile(

--- a/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
@@ -18,6 +18,7 @@
 import { createLogger } from "@lobu/core";
 import { getDb } from "../../../../db/client";
 import { ChannelBindingService } from "../../../../gateway/channels/binding-service";
+import { resolveBindingTeam } from "../../../../gateway/channels/binding-scope-resolver";
 import { scheduleChannelBindConfirmation } from "../../../../gateway/channels/bind-channel-notify";
 import {
 	runtimeConnectionIdToSlug,
@@ -51,6 +52,11 @@ type ChannelBindingInput =
 
 type NormalizedChannelSpec = {
 	channelId: string;
+	/** The workspace parsed from a declarative `T…/channel` spec, when present.
+	 *  Preserved as a trusted per-channel workspace hint so a Grid org-wide
+	 *  install (whose connection tenant id is the enterprise `E…`) still stamps
+	 *  the real workspace on the binding instead of dropping it. */
+	teamHint?: string;
 	about?: Array<number | string>;
 };
 
@@ -63,20 +69,30 @@ function normalizeChannelSpec(
 		typeof input === "string" ? { channel_id: input, about: undefined } : input;
 	let channelId = raw.channel_id.trim();
 	if (!channelId) return { error: "Channel ids cannot be empty" };
+	let teamHint: string | undefined;
 	if (connectorKey === "slack") {
 		const slash = channelId.indexOf("/");
 		if (slash >= 0) {
 			const teamId = channelId.slice(0, slash);
 			channelId = channelId.slice(slash + 1);
-			if (externalTenantId && teamId !== externalTenantId) {
+			// Only reject a `T…/channel` spec against a WORKSPACE tenant id. A Grid
+			// org-wide install stores its enterprise `E…` in external_tenant_id, so
+			// a `T…` prefix there is the channel's real workspace, NOT a mismatch —
+			// preserve it as the binding team hint rather than reject.
+			if (
+				externalTenantId &&
+				externalTenantId.startsWith("T") &&
+				teamId !== externalTenantId
+			) {
 				return {
 					error: `Channel ${raw.channel_id} belongs to a different Slack workspace`,
 				};
 			}
+			if (teamId) teamHint = teamId;
 		}
 		channelId = canonicalSlackChannelId(channelId);
 	}
-	return { channelId, about: raw.about };
+	return { channelId, teamHint, about: raw.about };
 }
 
 const logger = createLogger("manage-connections-channels");
@@ -287,7 +303,20 @@ export async function handleBindChannel(
 	}>;
 	const connection = connections[0];
 	if (!connection) return { error: "Active chat connection not found" };
-	const teamId = connection.external_tenant_id ?? undefined;
+	// The binding's team is the CONCRETE workspace the channel lives in — the
+	// connector-owned resolver decides how to derive it (for Slack Grid the
+	// connection's tenant id is the enterprise `E…`, never the workspace). Null
+	// = unknown yet; the row heals from the first inbound message.
+	const teamId =
+		(await resolveBindingTeam({
+			connection: {
+				connectorKey: connection.connector_key,
+				externalTenantId: connection.external_tenant_id,
+				connectionId: connection.id,
+				organizationId,
+			},
+			channelId,
+		})) ?? undefined;
 
 	const svc = new ChannelBindingService();
 	const runtimeConnectionId = slugToRuntimeConnectionId(connection.slug);
@@ -457,15 +486,33 @@ export async function handleSyncChannelBindings(
 		aboutRemoved: number;
 	};
 	try {
+		const teamHintByChannel = new Map(
+			normalized.map((c) => [c.channelId, c.teamHint]),
+		);
 		reconcileResult = await sql.begin(async (tx) => {
 			const bound: string[] = [];
 			for (const channelId of desired) {
 				if (!existingIds.has(channelId)) {
+					// Resolve the CONCRETE workspace via the connector-owned resolver.
+					// A declarative `T…/channel` spec supplies a trusted workspace hint;
+					// otherwise the resolver decides (and returns null = unknown yet,
+					// healing from inbound — never the enterprise id).
+					const teamId =
+						(await resolveBindingTeam({
+							connection: {
+								connectorKey: connection.connector_key,
+								externalTenantId: connection.external_tenant_id,
+								connectionId: connection.id,
+								organizationId,
+							},
+							channelId,
+							workspaceHint: teamHintByChannel.get(channelId) ?? null,
+						})) ?? undefined;
 					await svc.createBinding(
 						args.agent_id,
 						connection.connector_key,
 						channelId,
-						connection.external_tenant_id ?? undefined,
+						teamId,
 						{
 							configuredBy: userId ?? undefined,
 							organizationId,
@@ -655,11 +702,23 @@ export async function handleConnectChannelDm(
 		boundChannelId,
 		organizationId,
 	);
+	// Resolve the DM's concrete workspace (never the enterprise id on a Grid
+	// org-wide install). Null = unknown yet; heals from the first inbound DM.
+	const dmTeamId =
+		(await resolveBindingTeam({
+			connection: {
+				connectorKey: "slack",
+				externalTenantId: connection.external_tenant_id,
+				connectionId: connection.id,
+				organizationId,
+			},
+			channelId: boundChannelId,
+		})) ?? undefined;
 	await svc.createBinding(
 		args.agent_id,
 		"slack",
 		boundChannelId,
-		connection.external_tenant_id ?? undefined,
+		dmTeamId,
 		{
 			configuredBy: userId ?? undefined,
 			organizationId,

--- a/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
@@ -485,34 +485,43 @@ export async function handleSyncChannelBindings(
 		aboutLinked: number;
 		aboutRemoved: number;
 	};
-	try {
-		const teamHintByChannel = new Map(
-			normalized.map((c) => [c.channelId, c.teamHint]),
+	// Resolve each new channel's CONCRETE workspace BEFORE opening the txn — the
+	// connector resolver may make a Slack HTTP round-trip (conversations.info), and
+	// an external call must never hold a pooled txn connection open. A declarative
+	// `T…/channel` spec supplies a trusted workspace hint; otherwise the resolver
+	// decides (returns null = unknown yet, healing from inbound — never the
+	// enterprise id). Null → undefined, identical to before the hoist.
+	const teamHintByChannel = new Map(
+		normalized.map((c) => [c.channelId, c.teamHint]),
+	);
+	const resolvedTeamByChannel = new Map<string, string | undefined>();
+	for (const channelId of desired) {
+		if (existingIds.has(channelId)) continue;
+		resolvedTeamByChannel.set(
+			channelId,
+			(await resolveBindingTeam({
+				connection: {
+					connectorKey: connection.connector_key,
+					externalTenantId: connection.external_tenant_id,
+					connectionId: connection.id,
+					organizationId,
+				},
+				channelId,
+				workspaceHint: teamHintByChannel.get(channelId) ?? null,
+			})) ?? undefined,
 		);
+	}
+
+	try {
 		reconcileResult = await sql.begin(async (tx) => {
 			const bound: string[] = [];
 			for (const channelId of desired) {
 				if (!existingIds.has(channelId)) {
-					// Resolve the CONCRETE workspace via the connector-owned resolver.
-					// A declarative `T…/channel` spec supplies a trusted workspace hint;
-					// otherwise the resolver decides (and returns null = unknown yet,
-					// healing from inbound — never the enterprise id).
-					const teamId =
-						(await resolveBindingTeam({
-							connection: {
-								connectorKey: connection.connector_key,
-								externalTenantId: connection.external_tenant_id,
-								connectionId: connection.id,
-								organizationId,
-							},
-							channelId,
-							workspaceHint: teamHintByChannel.get(channelId) ?? null,
-						})) ?? undefined;
 					await svc.createBinding(
 						args.agent_id,
 						connection.connector_key,
 						channelId,
-						teamId,
+						resolvedTeamByChannel.get(channelId),
 						{
 							configuredBy: userId ?? undefined,
 							organizationId,


### PR DESCRIPTION
Fixes a bug where a Slack DM the bot replied in was **hidden from the web sidebar** for org-wide Grid installs, and establishes a clean data invariant.

**Root cause:** an org-wide Grid install's routing key (`external_tenant_id`) is the enterprise id (`E…`). That id was being written into channel bindings' `team_id` slot. When a channel was bound under both the real workspace team (`T…`) and the enterprise id, the visibility gate saw ">1 workspace" and failed closed — hiding the conversation.

**Invariant:** `agent_channel_bindings.team_id` is ALWAYS the concrete workspace team (`T…`), never `E…`. The read side (visibility gate + ACL) is 100% connector-agnostic — no Slack-specific logic leaks into shared code.

**How:**
- New connector-owned resolver (`binding-scope-resolver.ts` generic dispatch + `slack-binding-scope.ts` Slack rule): resolve the binding's team from a trusted event/deep-link hint → `conversations.info.context_team_id` → else `null`. Never stores `E…`. The 4 connection-derived binding writers route through it.
- **Lazy self-heal:** an unknown (`NULL`) team converges to the real `T…` from the first inbound message (`healBindingTeam`; fills only, never overwrites).
- **Gate is NULL-tolerant:** `isConversationVisible` treats `NULL`/`""` as a wildcard (unknown-yet), fails closed only on ≥2 distinct real teams. No enterprise-id knowledge.
- **ACL-sync fix (in-scope, prevents a regression):** an org-wide connection with `T…` bindings still builds the ACL graph and stays ENFORCED — the credential is resolved by the concrete `slackinst-` install id (`getSlackInstallById`), not a team-string round-trip that would miss.
- `slackPost`/`conversationInfo` now expose `context_team_id`; team resolution hoisted out of the sync-path DB transaction.

**Verified (real Postgres, red→green):** the ACL-sync enforcement guard (org-wide install stays enforced, not downgraded to the legacy fence) — **15/15**, including a test that drives the REAL enterprise-credential branch (revert → fail-closed outage; fix → enforced). Gate NULL-tolerance, write-never-stores-`E…`, and lazy-heal convergence all covered. `make typecheck` clean.

Reviewed by Fable (SHIP, acl-sync regression CLOSED) + codex (gpt-5.6-sol).

`PR1-data-reconcile.sql` is included but NOT executed — parked for a supervised prod run (backfills the one anomalous `E…`-in-`team_id` binding from `channel_messages.team_id`; rollback-default; never touches `events`).

Follow-ups (out of scope): about-edge `E…` keying (`syncConnectionChannelAboutEdges` — not an ACL gap, `about` ≠ `member_of`); optional live Grid inbound-event self-heal smoke.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786327467&installation_id=136316292&pr_number=1850&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1850&signature=bb14e3b9e27c1bf3453530421e2bff24b6756ff2d1425c94ff6f00b98a25eb9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->