### PR TITLE
fix(slack): key channel-about edges on the workspace team (T…), not the Grid enterprise id

### DIFF
--- a/packages/server/src/__tests__/integration/authz/channel-about.test.ts
+++ b/packages/server/src/__tests__/integration/authz/channel-about.test.ts
@@ -81,10 +81,10 @@ describe("channel about edges", () => {
 			organizationId: org.id,
 			connectionId,
 			connectorKey: "slack",
-			teamId: TEAM,
 			channels: [
 				{
 					channelId: CHANNEL,
+					teamId: TEAM,
 					aboutEntityIds: [company.id],
 				},
 			],
@@ -133,8 +133,7 @@ describe("channel about edges", () => {
 			organizationId: org.id,
 			connectionId: "99",
 			connectorKey: "slack",
-			teamId: TEAM,
-			channels: [{ channelId: CHANNEL, aboutEntityIds: [company.id] }],
+			channels: [{ channelId: CHANNEL, teamId: TEAM, aboutEntityIds: [company.id] }],
 		});
 
 		const channels = await listChannelEntitiesAboutBusinessEntity({

--- a/packages/server/src/__tests__/integration/connectors/channel-binding-actions.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/channel-binding-actions.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { SLACK_IDENTITY, slackChannelKey } from "@lobu/connectors/slack-identity";
 import { getDb } from "../../../db/client";
 import {
 	persistSecretValue,
@@ -524,6 +525,115 @@ describe("manage_connections channel-binding actions", () => {
 		expect(edges).toHaveLength(1);
 		expect(Number(edges[0].to_entity_id)).toBe(company.id);
 		expect(edges[0].source).toBe("config");
+	});
+
+	it("about edge on an org-wide Grid install keys the channel entity on the workspace T…, never the enterprise E…", async () => {
+		// An org-wide Grid install's connection tenant id is the ENTERPRISE id (E…).
+		// The channel-about edge must attach to the SAME channel resource entity the
+		// binding + ACL graph own — keyed on the concrete workspace T…, resolved from
+		// conversations.info.context_team_id — NOT a phantom E…:C… entity.
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, orgId, "owner");
+		const sql = getTestDb();
+		await sql`
+      INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+      VALUES (${orgId}, 'company', 'Company', current_timestamp, current_timestamp)
+      ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL
+      DO NOTHING
+    `;
+		const company = await createTestEntity({
+			name: "Grid Acme",
+			entity_type: "company",
+			organization_id: orgId,
+			created_by: user.id,
+		});
+
+		const pg = new PostgresSecretStore();
+		const store = new SecretStoreRegistry(pg, { secret: pg });
+		const tokenRef = await orgContext.run({ organizationId: orgId }, () =>
+			persistSecretValue(
+				store,
+				"installations/slackinst-gridabout/botToken",
+				"xoxb-gridabout",
+			),
+		);
+		const connectionId = await makeManagedSlackConnection({
+			orgId,
+			slug: "slackinst-gridabout",
+			teamId: ENTERPRISE, // org-wide install ⇒ tenant id is the enterprise E…
+		});
+		await sql`UPDATE connections SET config = ${sql.json({ botToken: tokenRef })} WHERE id = ${connectionId}`;
+
+		// The channel lives in workspace WORKSPACE (T…) — the resolver reads it from
+		// conversations.info.context_team_id. Bind with a BARE channel id (no T…/
+		// prefix hint) so resolution goes through the E… → context_team_id path.
+		__setBindingScopeResolverForTests("slack", (params) =>
+			resolveSlackBindingTeam(
+				{
+					slackWeb: {
+						conversationInfo: async () => ({
+							name: "eng",
+							isPrivate: false,
+							contextTeamId: WORKSPACE,
+						}),
+					},
+					secretStore: store,
+				},
+				params,
+			),
+		);
+		try {
+			const synced = (await workspace.owner.connections.manage({
+				action: "sync_channel_bindings",
+				agent_id: agentId,
+				connection_id: connectionId,
+				channels: [{ channel_id: "slack:CGRIDABOUT", about: ["grid-acme"] }],
+			})) as { success?: boolean; about_linked?: number; error?: string };
+			expect(synced.error).toBeUndefined();
+			expect(synced.success).toBe(true);
+			expect(synced.about_linked).toBe(1);
+
+			// The channel resource entity the edge points FROM must be identified on
+			// the workspace key T…:C…, and NO enterprise-keyed E…:C… entity exists.
+			const workspaceKey = slackChannelKey(WORKSPACE, "CGRIDABOUT");
+			const enterpriseKey = slackChannelKey(ENTERPRISE, "CGRIDABOUT");
+			const [wsEntity] = await sql<{ entity_id: number }[]>`
+        SELECT entity_id FROM entity_identities
+        WHERE organization_id = ${orgId}
+          AND namespace = ${SLACK_IDENTITY.CHANNEL_ID}
+          AND identifier = ${workspaceKey}
+          AND deleted_at IS NULL
+      `;
+			expect(wsEntity?.entity_id).toBeDefined();
+			const entEntity = await sql<{ entity_id: number }[]>`
+        SELECT entity_id FROM entity_identities
+        WHERE organization_id = ${orgId}
+          AND namespace = ${SLACK_IDENTITY.CHANNEL_ID}
+          AND identifier = ${enterpriseKey}
+          AND deleted_at IS NULL
+      `;
+			expect(entEntity).toHaveLength(0);
+
+			const edges = await sql<
+				{ from_entity_id: number; to_entity_id: number; channel_key: string }[]
+			>`
+        SELECT r.from_entity_id, r.to_entity_id, r.metadata->>'channel_key' AS channel_key
+        FROM entity_relationships r
+        JOIN entity_relationship_types rt ON rt.id = r.relationship_type_id
+        WHERE r.organization_id = ${orgId}
+          AND rt.slug = 'about'
+          AND r.deleted_at IS NULL
+          AND r.metadata->>'connection_id' = ${String(connectionId)}
+      `;
+			expect(edges).toHaveLength(1);
+			expect(Number(edges[0].to_entity_id)).toBe(company.id);
+			// The edge attaches to the WORKSPACE-keyed channel entity, not the E… one.
+			expect(Number(edges[0].from_entity_id)).toBe(Number(wsEntity.entity_id));
+			expect(edges[0].channel_key).toBe(workspaceKey);
+			expect(edges[0].channel_key).not.toContain(ENTERPRISE);
+		} finally {
+			__setBindingScopeResolverForTests("slack", undefined);
+		}
 	});
 
 	it("surfaces about-linked channels in entity_names and active_connections", async () => {

--- a/packages/server/src/authz/channel-about.ts
+++ b/packages/server/src/authz/channel-about.ts
@@ -27,6 +27,13 @@ export const ABOUT_EDGE_SOURCE_MANUAL = "manual";
 export interface ChannelAboutTarget {
 	/** Bare or platform-prefixed channel id as stored on the binding. */
 	channelId: string;
+	/** The concrete workspace/tenant this channel lives in — the SAME real team
+	 *  the binding is keyed on (for Slack Grid: the workspace `T…`, NEVER the
+	 *  enterprise `E…`). Resolved connector-side (`resolveBindingTeam`) and threaded
+	 *  in so the about edge attaches to the SAME channel resource entity the ACL
+	 *  graph + binding own. `null`/undefined = unknown yet (skip, heal from inbound)
+	 *  for a team-scoped connector, mirroring the binding's null-team behavior. */
+	teamId: string | null | undefined;
 	/** Resolved business-entity ids to link (channel --about--> each). */
 	aboutEntityIds: number[];
 }
@@ -286,7 +293,6 @@ export async function syncConnectionChannelAboutEdges(opts: {
 	organizationId: string;
 	connectionId: string | number;
 	connectorKey: string;
-	teamId: string | null | undefined;
 	channels: ChannelAboutTarget[];
 	userId?: string | null;
 	sql?: DbClient;
@@ -301,13 +307,13 @@ export async function syncConnectionChannelAboutEdges(opts: {
 	for (const channel of opts.channels) {
 		const { key } = channelResourceIdentity(
 			opts.connectorKey,
-			opts.teamId,
+			channel.teamId,
 			channel.channelId,
 		);
 		const channelEntityId = await ensureChannelResourceEntity({
 			organizationId: opts.organizationId,
 			connectorKey: opts.connectorKey,
-			teamId: opts.teamId,
+			teamId: channel.teamId,
 			channelId: channel.channelId,
 			sql,
 		});
@@ -565,13 +571,33 @@ export async function listChannelEntitiesAboutBusinessEntity(opts: {
 	}));
 }
 
-/** Channel key stored on `about` edge metadata for a streaming feed row. */
+/** Channel key stored on `about` edge metadata for a streaming feed row.
+ *
+ * The team half is the channel's CONCRETE workspace, taken from the streaming
+ * feed's binding (`agent_channel_bindings.team_id`) — the SAME real team the
+ * about-edge writer keyed on. For a Grid org-wide install the connection's
+ * `external_tenant_id` is the enterprise `E…`, so it must NOT be used as the
+ * team; the binding holds the real `T…`. The `external_tenant_id` fallback stands
+ * only for a non-team-scoped connector (or a not-yet-healed NULL-team binding),
+ * where it IS the workspace and the writer used it too. Binding channel_id equals
+ * feed_key, so the correlation is exact. */
 export function streamingFeedChannelKeyExpr(
 	feedAlias = "f",
 	connectionAlias = "c",
 ): string {
 	return `UPPER(
-    COALESCE(${connectionAlias}.external_tenant_id, '') || ':' ||
+    COALESCE(
+      (
+        SELECT b.team_id
+        FROM agent_channel_bindings b
+        WHERE b.connection_id = ${feedAlias}.connection_id
+          AND b.channel_id = ${feedAlias}.feed_key
+          AND b.team_id IS NOT NULL
+        LIMIT 1
+      ),
+      ${connectionAlias}.external_tenant_id,
+      ''
+    ) || ':' ||
     CASE
       WHEN ${feedAlias}.feed_key LIKE '%:%'
         THEN split_part(${feedAlias}.feed_key, ':', 2)

--- a/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/channel-bindings.ts
@@ -452,14 +452,58 @@ export async function handleSyncChannelBindings(
 		await svc.listBindings(args.agent_id, organizationId)
 	).filter((binding) => binding.connectionId === String(connection.id));
 	const existingIds = new Set(existing.map((binding) => binding.channelId));
+	const existingTeamByChannel = new Map(
+		existing.map((binding) => [binding.channelId, binding.teamId]),
+	);
+
+	// Resolve each channel's CONCRETE workspace BEFORE opening the txn — the
+	// connector resolver may make a Slack HTTP round-trip (conversations.info), and
+	// an external call must never hold a pooled txn connection open. A declarative
+	// `T…/channel` spec supplies a trusted workspace hint; otherwise the resolver
+	// decides (returns null = unknown yet, healing from inbound — never the
+	// enterprise id). An EXISTING binding already carries its resolved team, so
+	// reuse it rather than re-round-trip. This same team keys BOTH the binding
+	// write and the about edge, so a Grid org-wide install (connection tenant =
+	// enterprise `E…`) never mis-keys the about edge onto a phantom `E…:C…` entity.
+	const teamHintByChannel = new Map(
+		normalized.map((c) => [c.channelId, c.teamHint]),
+	);
+	const resolvedTeamByChannel = new Map<string, string | undefined>();
+	for (const channelId of desired) {
+		const existingTeam = existingTeamByChannel.get(channelId);
+		if (existingTeam) {
+			resolvedTeamByChannel.set(channelId, existingTeam);
+			continue;
+		}
+		resolvedTeamByChannel.set(
+			channelId,
+			(await resolveBindingTeam({
+				connection: {
+					connectorKey: connection.connector_key,
+					externalTenantId: connection.external_tenant_id,
+					connectionId: connection.id,
+					organizationId,
+				},
+				channelId,
+				workspaceHint: teamHintByChannel.get(channelId) ?? null,
+			})) ?? undefined,
+		);
+	}
+
 	const aboutChannels: Array<{
 		channelId: string;
+		teamId: string | undefined;
 		aboutEntityIds: number[];
 	}> = [];
 	try {
 		for (const spec of normalized) {
+			const teamId = resolvedTeamByChannel.get(spec.channelId);
 			if (!spec.about?.length) {
-				aboutChannels.push({ channelId: spec.channelId, aboutEntityIds: [] });
+				aboutChannels.push({
+					channelId: spec.channelId,
+					teamId,
+					aboutEntityIds: [],
+				});
 				continue;
 			}
 			const aboutEntityIds = await resolveAboutEntityRefs(
@@ -468,7 +512,7 @@ export async function handleSyncChannelBindings(
 				sql,
 			);
 			await assertEntityIdsInOrg(sql, organizationId, aboutEntityIds);
-			aboutChannels.push({ channelId: spec.channelId, aboutEntityIds });
+			aboutChannels.push({ channelId: spec.channelId, teamId, aboutEntityIds });
 		}
 	} catch (error) {
 		return {
@@ -485,32 +529,6 @@ export async function handleSyncChannelBindings(
 		aboutLinked: number;
 		aboutRemoved: number;
 	};
-	// Resolve each new channel's CONCRETE workspace BEFORE opening the txn — the
-	// connector resolver may make a Slack HTTP round-trip (conversations.info), and
-	// an external call must never hold a pooled txn connection open. A declarative
-	// `T…/channel` spec supplies a trusted workspace hint; otherwise the resolver
-	// decides (returns null = unknown yet, healing from inbound — never the
-	// enterprise id). Null → undefined, identical to before the hoist.
-	const teamHintByChannel = new Map(
-		normalized.map((c) => [c.channelId, c.teamHint]),
-	);
-	const resolvedTeamByChannel = new Map<string, string | undefined>();
-	for (const channelId of desired) {
-		if (existingIds.has(channelId)) continue;
-		resolvedTeamByChannel.set(
-			channelId,
-			(await resolveBindingTeam({
-				connection: {
-					connectorKey: connection.connector_key,
-					externalTenantId: connection.external_tenant_id,
-					connectionId: connection.id,
-					organizationId,
-				},
-				channelId,
-				workspaceHint: teamHintByChannel.get(channelId) ?? null,
-			})) ?? undefined,
-		);
-	}
 
 	try {
 		reconcileResult = await sql.begin(async (tx) => {
@@ -550,7 +568,6 @@ export async function handleSyncChannelBindings(
 				organizationId,
 				connectionId: connection.id,
 				connectorKey: connection.connector_key,
-				teamId: connection.external_tenant_id,
 				channels: aboutChannels,
 				userId,
 				sql: tx,
@@ -610,13 +627,39 @@ export async function handleSetChannelAbout(
 	}>;
 	const connection = rows[0];
 	if (!connection) return { error: "Chat connection not found" };
+	// The manual about edge must key on the channel's CONCRETE workspace — the
+	// SAME real team the binding uses — never the connection's stored tenant id
+	// (a Grid org-wide install stores the enterprise `E…` there). Prefer the team
+	// already stamped on this channel's binding; otherwise ask the connector's
+	// resolver (never the `E…`, null = unknown yet).
+	const boundTeamRows = (await sql`
+		SELECT team_id
+		FROM agent_channel_bindings
+		WHERE organization_id = ${organizationId}
+			AND connection_id = ${connection.id}
+			AND channel_id = ${args.channel_id}
+			AND team_id IS NOT NULL
+		LIMIT 1
+	`) as Array<{ team_id: string | null }>;
+	const teamId =
+		boundTeamRows[0]?.team_id ??
+		(await resolveBindingTeam({
+			connection: {
+				connectorKey: connection.connector_key,
+				externalTenantId: connection.external_tenant_id,
+				connectionId: connection.id,
+				organizationId,
+			},
+			channelId: args.channel_id,
+		})) ??
+		undefined;
 	try {
 		await assertEntityIdsInOrg(sql, organizationId, args.about_entity_ids);
 		await setManualChannelAboutEdges({
 			organizationId,
 			connectionId: connection.id,
 			connectorKey: connection.connector_key,
-			teamId: connection.external_tenant_id,
+			teamId,
 			channelId: args.channel_id,
 			aboutEntityIds: args.about_entity_ids,
 			userId,

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -219,6 +219,16 @@ async function handleReadFeed(
            c.connector_key,
            c.external_tenant_id,
            c.display_name AS connection_name,
+           -- The channel's CONCRETE workspace, from its binding: the SAME real
+           -- team the about-edge writer keyed on. For a Grid org-wide install the
+           -- connection tenant is the enterprise E-id, so the about lookup must
+           -- NOT fall back to it; the binding holds the real T-id.
+           (SELECT b.team_id FROM agent_channel_bindings b
+             WHERE b.organization_id = f.organization_id
+               AND b.connection_id = f.connection_id
+               AND b.channel_id = f.feed_key
+               AND b.team_id IS NOT NULL
+             LIMIT 1) AS binding_team_id,
            (
              SELECT string_agg(DISTINCT ent.name, ', ' ORDER BY ent.name)
              FROM entities ent
@@ -278,7 +288,14 @@ async function handleReadFeed(
       organizationId,
       connectionId: feed.connection_id,
       connectorKey: String(feed.connector_key ?? 'slack'),
-      teamId: (feed.external_tenant_id as string | null) ?? null,
+      // The binding's real workspace (`T…`) — NOT the connection tenant, which is
+      // the enterprise `E…` on a Grid org-wide install. Falls back to the tenant
+      // only for a non-team-scoped connector / not-yet-healed binding, matching
+      // the writer.
+      teamId:
+        (feed.binding_team_id as string | null) ??
+        (feed.external_tenant_id as string | null) ??
+        null,
       channelId: feedKey,
     });
     return {


### PR DESCRIPTION
Follow-up to #1850. Channel-ABOUT edges on an org-wide Slack Grid install were keyed on the connection's `external_tenant_id` (the enterprise `E…`), attaching to a phantom `E…:C…` channel entity while bindings + the ACL graph own the real `T…:C…` entity. About links silently no-op'd / mis-keyed on org-wide installs.

**Not an ACL gap** (`about` ≠ `member_of`; the visibility gate never reads about-edges) — a functional correctness miss.

**Fix:** realign both writers and readers to the real workspace team.
- `channel-about.ts`: `ChannelAboutTarget` carries a per-channel `teamId`; the channel-entity key uses it. The SQL reader derives the team from the streaming feed's binding (`agent_channel_bindings.team_id`), falling back to `external_tenant_id` only for non-team-scoped connectors / not-yet-healed bindings.
- `channel-bindings.ts`: `sync_channel_bindings` / `set_channel_about` resolve each channel's real workspace via `resolveBindingTeam` (reusing a binding's stored team; never `E…`).
- `manage_feeds.ts`: `read_feed`'s about lookup uses the binding's `T…`.

For non-Grid installs `external_tenant_id == T…`, so behavior is identical to before.

**Verified:** new red→green test (org-wide install keys the about-edge entity on `T…`, no `E…:C…` entity created); channel-about + reader-side regression suites green; `make typecheck` clean after rebuild.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786329070&installation_id=136316292&pr_number=1852&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1852&signature=916cbf5dce1a7e72a75c78814ab399b45c06ebd486304cbad5a56a0707f8a15f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Slack channel identity handling for workspace and enterprise installations.
  - Ensured channel “about” relationships use each channel’s specific workspace team.
  - Improved synchronization of channel bindings and related metadata.
  - Updated streaming feed details to resolve channel information from the correct workspace context.
  - Improved manual channel “about” links when existing workspace bindings are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->