### PR TITLE
Codex/schedule timezone semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ build-packages:
 	done
 	@echo "   📦 Building packages/server bundle..."
 	@( cd packages/server && bun run build:server ) || exit $$?
-	@if [ -f packages/owletto/package.json ]; then \
+	@if [ -f packages/owletto/package.json ] && node -e "process.exit(require('./packages/owletto/package.json').scripts?.build ? 0 : 1)" 2>/dev/null; then \
 		echo "   📦 Building packages/owletto (web UI)..."; \
 		( cd packages/owletto && bun run build ) || exit $$?; \
 	else \

--- a/db/migrations/20260711120000_scheduled_jobs_timezone_metadata.sql
+++ b/db/migrations/20260711120000_scheduled_jobs_timezone_metadata.sql
@@ -1,0 +1,23 @@
+-- migrate:up
+
+ALTER TABLE scheduled_jobs
+  ADD COLUMN IF NOT EXISTS schedule_metadata jsonb,
+  ADD COLUMN IF NOT EXISTS timezone text,
+  ADD COLUMN IF NOT EXISTS until_at timestamptz,
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz,
+  ADD COLUMN IF NOT EXISTS idempotency_key text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS scheduled_jobs_org_idempotency_key_uniq
+  ON scheduled_jobs (organization_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+-- migrate:down
+
+DROP INDEX IF EXISTS scheduled_jobs_org_idempotency_key_uniq;
+
+ALTER TABLE scheduled_jobs
+  DROP COLUMN IF EXISTS idempotency_key,
+  DROP COLUMN IF EXISTS completed_at,
+  DROP COLUMN IF EXISTS until_at,
+  DROP COLUMN IF EXISTS timezone,
+  DROP COLUMN IF EXISTS schedule_metadata;

--- a/db/migrations/20260711120000_scheduled_jobs_timezone_metadata.sql
+++ b/db/migrations/20260711120000_scheduled_jobs_timezone_metadata.sql
@@ -7,13 +7,7 @@ ALTER TABLE scheduled_jobs
   ADD COLUMN IF NOT EXISTS completed_at timestamptz,
   ADD COLUMN IF NOT EXISTS idempotency_key text;
 
-CREATE UNIQUE INDEX IF NOT EXISTS scheduled_jobs_org_idempotency_key_uniq
-  ON scheduled_jobs (organization_id, idempotency_key)
-  WHERE idempotency_key IS NOT NULL;
-
 -- migrate:down
-
-DROP INDEX IF EXISTS scheduled_jobs_org_idempotency_key_uniq;
 
 ALTER TABLE scheduled_jobs
   DROP COLUMN IF EXISTS idempotency_key,

--- a/db/migrations/20260711120001_scheduled_jobs_idempotency_index.sql
+++ b/db/migrations/20260711120001_scheduled_jobs_idempotency_index.sql
@@ -1,0 +1,9 @@
+-- migrate:up transaction:false
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS scheduled_jobs_org_idempotency_key_uniq
+  ON scheduled_jobs (organization_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.scheduled_jobs_org_idempotency_key_uniq;

--- a/packages/core/src/contracts/tools/manage-schedules.ts
+++ b/packages/core/src/contracts/tools/manage-schedules.ts
@@ -34,6 +34,8 @@ export const WakeAgentArgs = Type.Object({
 
 export const ActionUnion = Type.Union([SendNotificationArgs, WakeAgentArgs]);
 
+export const ScheduleMetadata = Type.Record(Type.String(), Type.Unknown());
+
 export const CreateAction = Type.Object({
   action: Type.Literal("create", {
     description:
@@ -52,7 +54,12 @@ export const CreateAction = Type.Object({
    * Cron expression. When set, the job re-fires on this cron after
    * each firing. When omitted, the job is one-shot.
    */
-  cron: Type.Optional(Type.String()),
+  cron: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  schedule_metadata: Type.Optional(ScheduleMetadata),
+  timezone: Type.Optional(Type.String({ minLength: 1, maxLength: 100 })),
+  until_at: Type.Optional(Type.String()),
+  completed_at: Type.Optional(Type.String()),
+  idempotency_key: Type.Optional(Type.String({ minLength: 1, maxLength: 500 })),
   /** Handler-specific payload. The `type` field selects the handler. */
   payload: ActionUnion,
   /**

--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -1,12 +1,17 @@
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { generateSecureToken } from '../../auth/oauth/utils';
+import type { Env } from '../../index';
+import { materializeDueFeeds } from '../../scheduled/check-due-feeds';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import { post } from '../setup/test-helpers';
 
 const CONNECTOR_KEY = 'apple.test_device_manifest';
+const here = dirname(fileURLToPath(import.meta.url));
+const owlettoMacManifestDir = resolve(here, '../../../../owletto/apps/mac/Owletto/ConnectorManifests');
+const owlettoChromeManifestDir = resolve(here, '../../../../owletto/apps/chrome/connector-manifests');
 
 async function seedDeviceOwner(platform = 'macos') {
   const sql = getTestDb();
@@ -115,12 +120,22 @@ async function poll(
   });
 }
 
+async function pollClaimingDueFeed(workerId: string, connectorManifests: unknown[]) {
+  const first = await poll(workerId, connectorManifests);
+  expect(first.status).toBe(200);
+  const firstBody = await first.json();
+  if (firstBody.connector_key) {
+    return firstBody;
+  }
+
+  await materializeDueFeeds({} as Env, getTestDb());
+  const second = await poll(workerId, connectorManifests);
+  expect(second.status).toBe(200);
+  return second.json();
+}
+
 function loadOwlettoManifests(kind: 'mac' | 'chrome'): Array<Record<string, unknown>> {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const dir =
-    kind === 'mac'
-      ? resolve(here, '../../../../owletto/apps/mac/Owletto/ConnectorManifests')
-      : resolve(here, '../../../../owletto/apps/chrome/connector-manifests');
+  const dir = kind === 'mac' ? owlettoMacManifestDir : owlettoChromeManifestDir;
   return readdirSync(dir)
     .filter((file) => file.endsWith('.json'))
     .sort()
@@ -149,9 +164,7 @@ describe('device connector manifests', () => {
   it('installs a metadata-only device connector from poll and claims its feed run without compiled_code', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
 
-    const res = await poll(workerId, [manifest()]);
-    expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await pollClaimingDueFeed(workerId, [manifest()]);
 
     const def = await readDefinition(orgId);
     expect(def?.key).toBe(CONNECTOR_KEY);
@@ -193,7 +206,10 @@ describe('device connector manifests', () => {
     expect(await readFeedStatus(orgId)).toBe('paused');
   });
 
-  it('accepts the actual Owletto Mac manifests and installs their connector definitions', async () => {
+  const itWithOwlettoMac = existsSync(owlettoMacManifestDir) ? it : it.skip;
+  const itWithOwlettoChrome = existsSync(owlettoChromeManifestDir) ? it : it.skip;
+
+  itWithOwlettoMac('accepts the actual Owletto Mac manifests and installs their connector definitions', async () => {
     const { orgId, workerId } = await seedDeviceOwner('macos');
     const manifests = loadOwlettoManifests('mac');
 
@@ -206,7 +222,7 @@ describe('device connector manifests', () => {
     expect(await readDefinition(orgId, 'chrome.history')).toBeNull();
   });
 
-  it('accepts the actual Owletto Chrome manifests and installs their connector definitions', async () => {
+  itWithOwlettoChrome('accepts the actual Owletto Chrome manifests and installs their connector definitions', async () => {
     const { orgId, workerId } = await seedDeviceOwner('chrome-extension');
     const manifests = loadOwlettoManifests('chrome');
 

--- a/packages/server/src/__tests__/integration/mac-computer-use-action-poll.test.ts
+++ b/packages/server/src/__tests__/integration/mac-computer-use-action-poll.test.ts
@@ -3,7 +3,7 @@
  * `action_key` (chrome convention) and `operation_key` (Mac/iOS decode name).
  */
 
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -13,14 +13,14 @@ import { post } from '../setup/test-helpers';
 
 const CONNECTOR_KEY = 'apple.computer_use';
 const OPERATION_KEY = 'permissions';
+const here = dirname(fileURLToPath(import.meta.url));
+const computerUseManifestPath = resolve(
+  here,
+  '../../../../owletto/apps/mac/Owletto/ConnectorManifests/apple_computer_use.json',
+);
 
 function loadComputerUseManifest(): Record<string, unknown> {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const path = resolve(
-    here,
-    '../../../../owletto/apps/mac/Owletto/ConnectorManifests/apple_computer_use.json',
-  );
-  return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+  return JSON.parse(readFileSync(computerUseManifestPath, 'utf8')) as Record<string, unknown>;
 }
 
 async function seedDeviceOwner() {
@@ -78,7 +78,9 @@ describe('mac computer_use action poll', () => {
     await cleanupTestDatabase();
   });
 
-  it('claims a pinned action run and returns operation_key alongside action_key', async () => {
+  const itWithOwlettoManifest = existsSync(computerUseManifestPath) ? it : it.skip;
+
+  itWithOwlettoManifest('claims a pinned action run and returns operation_key alongside action_key', async () => {
     const { orgId, workerId, deviceWorkerId } = await seedDeviceOwner();
     const manifest = loadComputerUseManifest();
     const connectorManifests = [manifest];

--- a/packages/server/src/scheduled/__tests__/scheduled-jobs-service.test.ts
+++ b/packages/server/src/scheduled/__tests__/scheduled-jobs-service.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { createScheduledJobInDb } from "../scheduled-jobs-service";
+
+describe("createScheduledJobInDb", () => {
+  test("persists timezone metadata fields and uses org/idempotency key conflict dedup", async () => {
+    const calls: Array<{ text: string; values: unknown[] }> = [];
+    const scheduleMetadata = {
+      compiled: {
+        cron: null,
+        requiresExpansion: true,
+        expansionReason: "single_utc_cron_would_overfire_boundary_minutes",
+      },
+      local: { timezone: "Asia/Taipei" },
+    };
+    const returnedRow = {
+      id: "job-1",
+      organization_id: "org-1",
+      action_type: "wake_agent",
+      action_args: { agent_id: "shifu-u-1", prompt: "check tomorrow" },
+      cron: null,
+      next_run_at: "2026-08-01T01:00:00.000Z",
+      last_fired_at: null,
+      last_fired_run_id: null,
+      paused: false,
+      description: "bounded local wake",
+      created_by_user: "user-1",
+      created_by_agent: null,
+      source_run_id: null,
+      source_event_id: null,
+      source_thread_id: null,
+      schedule_metadata: scheduleMetadata,
+      timezone: "Asia/Taipei",
+      until_at: "2026-08-05T01:00:00.000Z",
+      completed_at: null,
+      idempotency_key: "course-pm-schedule-1",
+      created_at: "2026-07-08T00:00:00.000Z",
+      updated_at: "2026-07-08T00:00:00.000Z",
+    };
+    const sql = Object.assign(
+      async (strings: TemplateStringsArray, ...values: unknown[]) => {
+        calls.push({ text: strings.raw.join(""), values });
+        return [returnedRow];
+      },
+      {
+        json: (value: unknown) => value,
+      }
+    );
+
+    const row = await createScheduledJobInDb(sql as any, {
+      organizationId: "org-1",
+      actionType: "wake_agent",
+      actionArgs: { agent_id: "shifu-u-1", prompt: "check tomorrow" },
+      description: "bounded local wake",
+      cron: null,
+      runAt: new Date("2026-08-01T01:00:00Z"),
+      createdByUser: "user-1",
+      scheduleMetadata,
+      timezone: "Asia/Taipei",
+      untilAt: new Date("2026-08-05T01:00:00Z"),
+      idempotencyKey: "course-pm-schedule-1",
+    });
+
+    expect(row).toEqual(returnedRow);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].text).toContain("schedule_metadata");
+    expect(calls[0].text).toContain("timezone");
+    expect(calls[0].text).toContain("until_at");
+    expect(calls[0].text).toContain("completed_at");
+    expect(calls[0].text).toContain("idempotency_key");
+    expect(calls[0].text).toContain("ON CONFLICT");
+    expect(calls[0].text).toContain("organization_id, idempotency_key");
+    expect(calls[0].values).toContain("Asia/Taipei");
+    expect(calls[0].values).toContain("course-pm-schedule-1");
+  });
+});

--- a/packages/server/src/scheduled/__tests__/scheduled-jobs-service.test.ts
+++ b/packages/server/src/scheduled/__tests__/scheduled-jobs-service.test.ts
@@ -11,6 +11,7 @@ const baseJob: ScheduledJobRow = {
   organization_id: "org-1",
   action_type: "wake_agent",
   action_args: { agent_id: "shifu-u-1", prompt: "check schedule" },
+  delivery_context: null,
   cron: "* * * * *",
   next_run_at: "2026-07-01T00:00:00.000Z",
   schedule_metadata: null,
@@ -41,6 +42,11 @@ interface TickSqlOptions {
   now?: Date;
 }
 
+interface EventRecord {
+  type: string;
+  depth: number;
+}
+
 function isDue(row: ScheduledJobRow, now: Date): boolean {
   return new Date(row.next_run_at).getTime() <= now.getTime();
 }
@@ -64,10 +70,12 @@ function makeTickSql(rows: ScheduledJobRow[], opts: TickSqlOptions = {}) {
   const revalidateRows = opts.revalidateRows?.map(cloneRow);
   const selects: Array<{ text: string; values: unknown[] }> = [];
   const updates: UpdateCall[] = [];
+  const events: EventRecord[] = [];
+  let transactionDepth = 0;
   const sql = Object.assign(
     async (strings: TemplateStringsArray, ...values: unknown[]) => {
       const text = strings.raw.join("");
-      if (text.includes("SELECT *") && text.includes("FROM scheduled_jobs")) {
+      if (text.includes("FROM scheduled_jobs") && text.includes("SELECT")) {
         selects.push({ text, values });
         if (text.includes("WHERE id =")) {
           const candidateRows = revalidateRows ?? storedRows;
@@ -93,6 +101,7 @@ function makeTickSql(rows: ScheduledJobRow[], opts: TickSqlOptions = {}) {
       }
       if (text.includes("UPDATE scheduled_jobs")) {
         updates.push({ text, values });
+        events.push({ type: "update", depth: transactionDepth });
         const isPauseUpdate = text.includes("organization_id =");
         const isAdvanceUpdate = text.includes("next_run_at =") &&
           !text.includes("next_run_at > until_at");
@@ -122,19 +131,46 @@ function makeTickSql(rows: ScheduledJobRow[], opts: TickSqlOptions = {}) {
       return [];
     },
     {
-      begin: async (fn: (tx: typeof sql) => Promise<unknown>) => fn(sql),
+      begin: async (fn: (tx: typeof sql) => Promise<unknown>) => {
+        transactionDepth += 1;
+        events.push({ type: "begin", depth: transactionDepth });
+        try {
+          const result = await fn(sql);
+          events.push({ type: "commit", depth: transactionDepth });
+          return result;
+        } finally {
+          transactionDepth -= 1;
+        }
+      },
     }
   );
-  return { sql, selects, updates, rows: storedRows };
+  return {
+    sql,
+    selects,
+    updates,
+    events,
+    rows: storedRows,
+    getTransactionDepth: () => transactionDepth,
+  };
 }
 
-function makeTickScheduler() {
-  const spawns: Array<{ name: string; payload: unknown; options: unknown }> = [];
+function makeTickScheduler(
+  getTransactionDepth: () => number = () => 0,
+  events?: EventRecord[]
+) {
+  const spawns: Array<{
+    name: string;
+    payload: unknown;
+    options: unknown;
+    transactionDepth: number;
+  }> = [];
   return {
     spawns,
     scheduler: {
       spawn: async (name: string, payload: unknown, options: unknown) => {
-        spawns.push({ name, payload, options });
+        const transactionDepth = getTransactionDepth();
+        events?.push({ type: "spawn", depth: transactionDepth });
+        spawns.push({ name, payload, options, transactionDepth });
         return "run-1";
       },
     },
@@ -211,6 +247,38 @@ describe("createScheduledJobInDb", () => {
     expect(calls[0].text).toContain("organization_id, idempotency_key");
     expect(calls[0].values).toContain("Asia/Taipei");
     expect(calls[0].values).toContain("course-pm-schedule-1");
+  });
+
+  test("completed schedules are inserted paused so they are terminal immediately", async () => {
+    const calls: Array<{ text: string; values: unknown[] }> = [];
+    const returnedRow = {
+      ...baseJob,
+      paused: true,
+      completed_at: "2026-07-01T00:00:00.000Z",
+    };
+    const sql = Object.assign(
+      async (strings: TemplateStringsArray, ...values: unknown[]) => {
+        calls.push({ text: strings.raw.join(""), values });
+        return [returnedRow];
+      },
+      {
+        json: (value: unknown) => value,
+      }
+    );
+
+    const row = await createScheduledJobInDb(sql as any, {
+      organizationId: "org-1",
+      actionType: "wake_agent",
+      actionArgs: {},
+      description: "already done",
+      runAt: new Date("2026-07-01T00:00:00Z"),
+      completedAt: new Date("2026-07-01T00:00:00Z"),
+      createdByUser: "user-1",
+    });
+
+    expect(row.paused).toBe(true);
+    expect(calls[0].text).toContain("paused");
+    expect(calls[0].values).toContain(true);
   });
 });
 
@@ -321,6 +389,44 @@ describe("runScheduledJobsTick", () => {
 
     expect(spawns).toHaveLength(0);
     expect(updates).toHaveLength(0);
+  });
+
+  test("enqueue and schedule advancement happen before the per-row lock transaction commits", async () => {
+    const tick = makeTickSql([
+      {
+        ...baseJob,
+        cron: "* * * * *",
+        next_run_at: "2026-07-01T00:00:00.000Z",
+      },
+    ]);
+    const { scheduler, spawns } = makeTickScheduler(tick.getTransactionDepth, tick.events);
+
+    await runScheduledJobsTick(tick.sql as any, scheduler as any);
+
+    expect(spawns).toHaveLength(1);
+    expect(spawns[0].transactionDepth).toBeGreaterThan(0);
+    const spawnIndex = tick.events.findIndex((event) => event.type === "spawn");
+    const updateIndex = tick.events.findIndex((event) => event.type === "update");
+    const perRowCommitIndex = tick.events.findLastIndex((event) => event.type === "commit");
+    expect(spawnIndex).toBeGreaterThan(-1);
+    expect(updateIndex).toBeGreaterThan(spawnIndex);
+    expect(perRowCommitIndex).toBeGreaterThan(updateIndex);
+  });
+
+  test("second tick runner sees no due row after the first runner enqueues and advances in the lock", async () => {
+    const tick = makeTickSql([
+      {
+        ...baseJob,
+        cron: "* * * * *",
+        next_run_at: "2026-07-01T00:00:00.000Z",
+      },
+    ]);
+    const { scheduler, spawns } = makeTickScheduler(tick.getTransactionDepth, tick.events);
+
+    await runScheduledJobsTick(tick.sql as any, scheduler as any);
+    await runScheduledJobsTick(tick.sql as any, scheduler as any);
+
+    expect(spawns).toHaveLength(1);
   });
 
   test("one-shot job sets completed_at and pauses after execution while preserving next_run_at", async () => {

--- a/packages/server/src/scheduled/__tests__/scheduled-jobs-service.test.ts
+++ b/packages/server/src/scheduled/__tests__/scheduled-jobs-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   createScheduledJobInDb,
+  pauseScheduledJobInDb,
   runScheduledJobsTick,
   type ScheduledJobRow,
 } from "../scheduled-jobs-service";
@@ -35,28 +36,88 @@ interface UpdateCall {
   values: unknown[];
 }
 
-function makeTickSql(
-  rows: ScheduledJobRow[],
-  opts: { expiredCompletionAlreadyClaimed?: boolean } = {}
-) {
+interface TickSqlOptions {
+  revalidateRows?: ScheduledJobRow[];
+  now?: Date;
+}
+
+function isDue(row: ScheduledJobRow, now: Date): boolean {
+  return new Date(row.next_run_at).getTime() <= now.getTime();
+}
+
+function exceedsUntil(row: ScheduledJobRow): boolean {
+  if (!row.until_at) return false;
+  return new Date(row.next_run_at).getTime() > new Date(row.until_at).getTime();
+}
+
+function cloneRow(row: ScheduledJobRow): ScheduledJobRow {
+  return {
+    ...row,
+    action_args: { ...row.action_args },
+    schedule_metadata: row.schedule_metadata ? { ...row.schedule_metadata } : null,
+  };
+}
+
+function makeTickSql(rows: ScheduledJobRow[], opts: TickSqlOptions = {}) {
+  const now = opts.now ?? new Date("2026-07-01T00:00:30.000Z");
+  const storedRows = rows.map(cloneRow);
+  const revalidateRows = opts.revalidateRows?.map(cloneRow);
+  const selects: Array<{ text: string; values: unknown[] }> = [];
   const updates: UpdateCall[] = [];
   const sql = Object.assign(
     async (strings: TemplateStringsArray, ...values: unknown[]) => {
       const text = strings.raw.join("");
       if (text.includes("SELECT *") && text.includes("FROM scheduled_jobs")) {
-        return rows;
+        selects.push({ text, values });
+        if (text.includes("WHERE id =")) {
+          const candidateRows = revalidateRows ?? storedRows;
+          const id = values[0] as string;
+          let selected = candidateRows.filter((row) => row.id === id && isDue(row, now));
+          if (text.includes("NOT paused")) {
+            selected = selected.filter((row) => !row.paused);
+          }
+          if (text.includes("completed_at IS NULL")) {
+            selected = selected.filter((row) => row.completed_at == null);
+          }
+          if (text.includes("next_run_at <= until_at")) {
+            selected = selected.filter((row) => !exceedsUntil(row));
+          }
+          return selected;
+        }
+
+        let selected = storedRows.filter((row) => isDue(row, now) && !row.paused);
+        if (text.includes("completed_at IS NULL")) {
+          selected = selected.filter((row) => row.completed_at == null);
+        }
+        return selected;
       }
       if (text.includes("UPDATE scheduled_jobs")) {
         updates.push({ text, values });
-        if (text.includes("until_at < now()")) {
-          const id = values[0] as string;
-          const row = rows.find((candidate) => candidate.id === id);
-          if (opts.expiredCompletionAlreadyClaimed) return [];
-          if (!row?.until_at || new Date(row.until_at).getTime() >= Date.now()) {
-            return [];
-          }
+        const isPauseUpdate = text.includes("organization_id =");
+        const isAdvanceUpdate = text.includes("next_run_at =") &&
+          !text.includes("next_run_at > until_at");
+        const id = isPauseUpdate
+          ? values[2] as string
+          : isAdvanceUpdate
+            ? values[1] as string
+            : values[0] as string;
+        const row = storedRows.find((candidate) => candidate.id === id);
+        if (!row || !isDue(row, now)) return [];
+        if (text.includes("NOT paused") && row.paused) return [];
+        if (text.includes("completed_at IS NULL") && row.completed_at != null) return [];
+        if (text.includes("next_run_at > until_at") && !exceedsUntil(row)) return [];
+
+        if (text.includes("paused = true")) row.paused = true;
+        if (isPauseUpdate) {
+          row.paused = values[0] as boolean;
         }
-        return [{ id: values[0] ?? "job-1" }];
+        if (text.includes("completed_at = COALESCE")) {
+          row.completed_at ??= now.toISOString();
+        }
+        if (isAdvanceUpdate) {
+          row.next_run_at = values[0] as string;
+        }
+        return [{ id }];
       }
       return [];
     },
@@ -64,7 +125,7 @@ function makeTickSql(
       begin: async (fn: (tx: typeof sql) => Promise<unknown>) => fn(sql),
     }
   );
-  return { sql, updates };
+  return { sql, selects, updates, rows: storedRows };
 }
 
 function makeTickScheduler() {
@@ -158,7 +219,9 @@ describe("runScheduledJobsTick", () => {
     const { sql, updates } = makeTickSql([
       {
         ...baseJob,
-        until_at: "2099-01-01T00:00:00.000Z",
+        cron: "* * * * *",
+        next_run_at: "2026-07-01T00:00:00.000Z",
+        until_at: "9999-01-01T00:00:00.000Z",
       },
     ]);
     const { scheduler, spawns } = makeTickScheduler();
@@ -166,19 +229,20 @@ describe("runScheduledJobsTick", () => {
     await runScheduledJobsTick(sql as any, scheduler as any);
 
     expect(spawns).toHaveLength(1);
-    expect(updates).toHaveLength(2);
+    expect(updates).toHaveLength(1);
     const finalUpdate = updates.at(-1);
     expect(finalUpdate?.text).toContain("next_run_at =");
-    expect(finalUpdate?.text).not.toContain("completed_at");
-    expect(finalUpdate?.values[1]).toBeString();
+    expect(finalUpdate?.text).not.toContain("completed_at = COALESCE");
+    expect(finalUpdate?.values[0]).toBeString();
   });
 
   test("recurring cron with until_at fires the due occurrence then pauses/completes when the next occurrence exceeds the bound", async () => {
     const { sql, updates } = makeTickSql([
       {
         ...baseJob,
-        cron: "0 0 1 1 *",
-        until_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        cron: "1 0 1 7 *",
+        next_run_at: "2026-07-01T00:00:00.000Z",
+        until_at: "2026-07-01T00:00:00.000Z",
       },
     ]);
     const { scheduler, spawns } = makeTickScheduler();
@@ -186,7 +250,7 @@ describe("runScheduledJobsTick", () => {
     await runScheduledJobsTick(sql as any, scheduler as any);
 
     expect(spawns).toHaveLength(1);
-    expect(updates).toHaveLength(2);
+    expect(updates).toHaveLength(1);
     const finalUpdate = updates.at(-1);
     expect(finalUpdate?.text).toContain("paused = true");
     expect(finalUpdate?.text).toContain("completed_at = COALESCE(completed_at, now())");
@@ -195,13 +259,33 @@ describe("runScheduledJobsTick", () => {
     expect(finalUpdate?.text).not.toContain("next_run_at =");
   });
 
-  test("job already past until_at is paused/completed without dispatching the action", async () => {
+  test("final due fire exactly at until_at still dispatches when the ticker wakes late", async () => {
     const { sql, updates } = makeTickSql([
       {
         ...baseJob,
-        until_at: new Date(Date.now() - 60_000).toISOString(),
+        cron: "1 0 1 7 *",
+        next_run_at: "2026-07-01T00:00:00.000Z",
+        until_at: "2026-07-01T00:00:00.000Z",
       },
     ]);
+    const { scheduler, spawns } = makeTickScheduler();
+
+    await runScheduledJobsTick(sql as any, scheduler as any);
+
+    expect(spawns).toHaveLength(1);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].text).toContain("paused = true");
+    expect(updates[0].text).toContain("completed_at = COALESCE(completed_at, now())");
+  });
+
+  test("job whose due instant is after until_at is paused/completed without dispatching the action", async () => {
+    const { sql, updates } = makeTickSql([
+      {
+        ...baseJob,
+        next_run_at: "2026-07-01T00:01:00.000Z",
+        until_at: "2026-07-01T00:00:00.000Z",
+      },
+    ], { now: new Date("2026-07-01T00:01:30.000Z") });
     const { scheduler, spawns } = makeTickScheduler();
 
     await runScheduledJobsTick(sql as any, scheduler as any);
@@ -210,27 +294,33 @@ describe("runScheduledJobsTick", () => {
     expect(updates).toHaveLength(1);
     expect(updates[0].text).toContain("paused = true");
     expect(updates[0].text).toContain("completed_at = COALESCE(completed_at, now())");
-    expect(updates[0].text).not.toContain("next_run_at =");
-    expect(updates[0].text).toContain("until_at < now()");
+    expect(updates[0].text).toContain("next_run_at > until_at");
   });
 
-  test("expired bounded job already completed by another replica is not dispatched", async () => {
-    const { sql, updates } = makeTickSql(
-      [
-        {
-          ...baseJob,
-          until_at: new Date(Date.now() - 60_000).toISOString(),
-        },
-      ],
-      { expiredCompletionAlreadyClaimed: true }
-    );
+  test("completed schedule rows are not selected or fired", async () => {
+    const completedRow = {
+      ...baseJob,
+      completed_at: "2026-07-01T00:00:10.000Z",
+      paused: false,
+    };
+    const completed = makeTickSql([completedRow]);
+    const { scheduler, spawns } = makeTickScheduler();
+
+    await runScheduledJobsTick(completed.sql as any, scheduler as any);
+
+    expect(spawns).toHaveLength(0);
+    expect(completed.updates).toHaveLength(0);
+    expect(completed.selects[0].text).toContain("completed_at IS NULL");
+  });
+
+  test("stale selected row is revalidated before dispatch", async () => {
+    const { sql, updates } = makeTickSql([baseJob], { revalidateRows: [] });
     const { scheduler, spawns } = makeTickScheduler();
 
     await runScheduledJobsTick(sql as any, scheduler as any);
 
     expect(spawns).toHaveLength(0);
-    expect(updates).toHaveLength(1);
-    expect(updates[0].text).toContain("until_at < now()");
+    expect(updates).toHaveLength(0);
   });
 
   test("one-shot job sets completed_at and pauses after execution while preserving next_run_at", async () => {
@@ -272,5 +362,23 @@ describe("runScheduledJobsTick", () => {
     expect(updates).toHaveLength(1);
     expect(updates[0].text).toContain("paused = true");
     expect(updates[0].text).not.toContain("next_run_at =");
+  });
+});
+
+describe("pauseScheduledJobInDb", () => {
+  test("does not unpause a completed schedule", async () => {
+    const { sql, updates } = makeTickSql([
+      {
+        ...baseJob,
+        paused: true,
+        completed_at: "2026-07-01T00:00:10.000Z",
+      },
+    ]);
+
+    const ok = await pauseScheduledJobInDb(sql as any, "org-1", "job-1", false);
+
+    expect(ok).toBe(false);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].text).toContain("completed_at IS NULL");
   });
 });

--- a/packages/server/src/scheduled/__tests__/scheduled-jobs-service.test.ts
+++ b/packages/server/src/scheduled/__tests__/scheduled-jobs-service.test.ts
@@ -1,5 +1,84 @@
 import { describe, expect, test } from "bun:test";
-import { createScheduledJobInDb } from "../scheduled-jobs-service";
+import {
+  createScheduledJobInDb,
+  runScheduledJobsTick,
+  type ScheduledJobRow,
+} from "../scheduled-jobs-service";
+
+const baseJob: ScheduledJobRow = {
+  id: "job-1",
+  organization_id: "org-1",
+  action_type: "wake_agent",
+  action_args: { agent_id: "shifu-u-1", prompt: "check schedule" },
+  cron: "* * * * *",
+  next_run_at: "2026-07-01T00:00:00.000Z",
+  schedule_metadata: null,
+  timezone: null,
+  until_at: null,
+  completed_at: null,
+  idempotency_key: null,
+  last_fired_at: null,
+  last_fired_run_id: null,
+  paused: false,
+  description: "test schedule",
+  created_by_user: "user-1",
+  created_by_agent: null,
+  source_run_id: null,
+  source_event_id: null,
+  source_thread_id: null,
+  created_at: "2026-07-01T00:00:00.000Z",
+  updated_at: "2026-07-01T00:00:00.000Z",
+};
+
+interface UpdateCall {
+  text: string;
+  values: unknown[];
+}
+
+function makeTickSql(
+  rows: ScheduledJobRow[],
+  opts: { expiredCompletionAlreadyClaimed?: boolean } = {}
+) {
+  const updates: UpdateCall[] = [];
+  const sql = Object.assign(
+    async (strings: TemplateStringsArray, ...values: unknown[]) => {
+      const text = strings.raw.join("");
+      if (text.includes("SELECT *") && text.includes("FROM scheduled_jobs")) {
+        return rows;
+      }
+      if (text.includes("UPDATE scheduled_jobs")) {
+        updates.push({ text, values });
+        if (text.includes("until_at < now()")) {
+          const id = values[0] as string;
+          const row = rows.find((candidate) => candidate.id === id);
+          if (opts.expiredCompletionAlreadyClaimed) return [];
+          if (!row?.until_at || new Date(row.until_at).getTime() >= Date.now()) {
+            return [];
+          }
+        }
+        return [{ id: values[0] ?? "job-1" }];
+      }
+      return [];
+    },
+    {
+      begin: async (fn: (tx: typeof sql) => Promise<unknown>) => fn(sql),
+    }
+  );
+  return { sql, updates };
+}
+
+function makeTickScheduler() {
+  const spawns: Array<{ name: string; payload: unknown; options: unknown }> = [];
+  return {
+    spawns,
+    scheduler: {
+      spawn: async (name: string, payload: unknown, options: unknown) => {
+        spawns.push({ name, payload, options });
+        return "run-1";
+      },
+    },
+  };
+}
 
 describe("createScheduledJobInDb", () => {
   test("persists timezone metadata fields and uses org/idempotency key conflict dedup", async () => {
@@ -71,5 +150,127 @@ describe("createScheduledJobInDb", () => {
     expect(calls[0].text).toContain("organization_id, idempotency_key");
     expect(calls[0].values).toContain("Asia/Taipei");
     expect(calls[0].values).toContain("course-pm-schedule-1");
+  });
+});
+
+describe("runScheduledJobsTick", () => {
+  test("recurring cron with until_at advances when the next occurrence is still within the bound", async () => {
+    const { sql, updates } = makeTickSql([
+      {
+        ...baseJob,
+        until_at: "2099-01-01T00:00:00.000Z",
+      },
+    ]);
+    const { scheduler, spawns } = makeTickScheduler();
+
+    await runScheduledJobsTick(sql as any, scheduler as any);
+
+    expect(spawns).toHaveLength(1);
+    expect(updates).toHaveLength(2);
+    const finalUpdate = updates.at(-1);
+    expect(finalUpdate?.text).toContain("next_run_at =");
+    expect(finalUpdate?.text).not.toContain("completed_at");
+    expect(finalUpdate?.values[1]).toBeString();
+  });
+
+  test("recurring cron with until_at fires the due occurrence then pauses/completes when the next occurrence exceeds the bound", async () => {
+    const { sql, updates } = makeTickSql([
+      {
+        ...baseJob,
+        cron: "0 0 1 1 *",
+        until_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      },
+    ]);
+    const { scheduler, spawns } = makeTickScheduler();
+
+    await runScheduledJobsTick(sql as any, scheduler as any);
+
+    expect(spawns).toHaveLength(1);
+    expect(updates).toHaveLength(2);
+    const finalUpdate = updates.at(-1);
+    expect(finalUpdate?.text).toContain("paused = true");
+    expect(finalUpdate?.text).toContain("completed_at = COALESCE(completed_at, now())");
+    // scheduled_jobs.next_run_at is NOT NULL in the baseline schema, so completed
+    // schedules preserve their due timestamp and rely on paused=true to stop repeats.
+    expect(finalUpdate?.text).not.toContain("next_run_at =");
+  });
+
+  test("job already past until_at is paused/completed without dispatching the action", async () => {
+    const { sql, updates } = makeTickSql([
+      {
+        ...baseJob,
+        until_at: new Date(Date.now() - 60_000).toISOString(),
+      },
+    ]);
+    const { scheduler, spawns } = makeTickScheduler();
+
+    await runScheduledJobsTick(sql as any, scheduler as any);
+
+    expect(spawns).toHaveLength(0);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].text).toContain("paused = true");
+    expect(updates[0].text).toContain("completed_at = COALESCE(completed_at, now())");
+    expect(updates[0].text).not.toContain("next_run_at =");
+    expect(updates[0].text).toContain("until_at < now()");
+  });
+
+  test("expired bounded job already completed by another replica is not dispatched", async () => {
+    const { sql, updates } = makeTickSql(
+      [
+        {
+          ...baseJob,
+          until_at: new Date(Date.now() - 60_000).toISOString(),
+        },
+      ],
+      { expiredCompletionAlreadyClaimed: true }
+    );
+    const { scheduler, spawns } = makeTickScheduler();
+
+    await runScheduledJobsTick(sql as any, scheduler as any);
+
+    expect(spawns).toHaveLength(0);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].text).toContain("until_at < now()");
+  });
+
+  test("one-shot job sets completed_at and pauses after execution while preserving next_run_at", async () => {
+    const { sql, updates } = makeTickSql([
+      {
+        ...baseJob,
+        cron: null,
+      },
+    ]);
+    const { scheduler, spawns } = makeTickScheduler();
+
+    await runScheduledJobsTick(sql as any, scheduler as any);
+
+    expect(spawns).toHaveLength(1);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].text).toContain("paused = true");
+    expect(updates[0].text).toContain("completed_at = COALESCE(completed_at, now())");
+    expect(updates[0].text).not.toContain("next_run_at =");
+  });
+
+  test("cron-null metadata-only job does not crash or create unsafe recurrence", async () => {
+    const { sql, updates } = makeTickSql([
+      {
+        ...baseJob,
+        cron: null,
+        schedule_metadata: {
+          compiled: {
+            cron: null,
+            requiresExpansion: true,
+          },
+        },
+      },
+    ]);
+    const { scheduler, spawns } = makeTickScheduler();
+
+    await runScheduledJobsTick(sql as any, scheduler as any);
+
+    expect(spawns).toHaveLength(1);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].text).toContain("paused = true");
+    expect(updates[0].text).not.toContain("next_run_at =");
   });
 });

--- a/packages/server/src/scheduled/scheduled-jobs-service.ts
+++ b/packages/server/src/scheduled/scheduled-jobs-service.ts
@@ -170,6 +170,11 @@ interface CreateScheduledJobParams {
   sourceThreadId?: string | null;
 }
 
+export type SqlLike = (
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+) => Promise<unknown[]>;
+
 export async function createScheduledJob(
   params: CreateScheduledJobParams
 ): Promise<ScheduledJobRow> {
@@ -323,6 +328,124 @@ export async function deleteScheduledJob(
   return rows.length > 0;
 }
 
+type ScheduledJobsTickSql = Pick<DbClient, 'begin'> & SqlLike;
+type ScheduledJobsTickScheduler = Pick<TaskScheduler, 'spawn'>;
+
+async function completeExpiredScheduledJob(
+  sql: ScheduledJobsTickSql,
+  id: string
+): Promise<boolean> {
+  const rows = (await sql`
+    UPDATE scheduled_jobs
+    SET paused = true,
+        completed_at = COALESCE(completed_at, now()),
+        updated_at = now()
+    WHERE id = ${id}
+      AND next_run_at <= now()
+      AND NOT paused
+      AND until_at IS NOT NULL
+      AND until_at < now()
+    RETURNING id
+  `) as unknown as Array<{ id: string }>;
+  return rows.length > 0;
+}
+
+async function completeScheduledJobAfterFire(
+  sql: ScheduledJobsTickSql,
+  id: string
+): Promise<void> {
+  await sql`
+    UPDATE scheduled_jobs
+    SET last_fired_at = now(),
+        paused = true,
+        completed_at = COALESCE(completed_at, now()),
+        updated_at = now()
+    WHERE id = ${id} AND next_run_at <= now()
+  `;
+}
+
+function exceedsUntilAt(nextAt: string, untilAt: string | null): boolean {
+  if (!untilAt) return false;
+  return new Date(nextAt).getTime() > new Date(untilAt).getTime();
+}
+
+function isPastUntilAt(untilAt: string | null): boolean {
+  if (!untilAt) return false;
+  return new Date(untilAt).getTime() < Date.now();
+}
+
+export async function runScheduledJobsTick(
+  sql: ScheduledJobsTickSql,
+  scheduler: ScheduledJobsTickScheduler
+): Promise<void> {
+  const claimed = await sql.begin(async (tx) => {
+    return (await tx`
+      SELECT *
+      FROM scheduled_jobs
+      WHERE next_run_at <= now() AND NOT paused
+      ORDER BY next_run_at ASC
+      FOR UPDATE SKIP LOCKED
+      LIMIT 200
+    `) as unknown as ScheduledJobRow[];
+  });
+  if (claimed.length === 0) return;
+
+  for (const row of claimed) {
+    if (row.until_at) {
+      const completedExpired = await completeExpiredScheduledJob(sql, row.id);
+      if (completedExpired || isPastUntilAt(row.until_at)) continue;
+    }
+
+    const tickIso = row.next_run_at;
+    const idempotencyKey = `scheduled_job:${row.id}:${tickIso}`;
+    try {
+      await scheduler.spawn(row.action_type, {
+        ...row.action_args,
+        __scheduled_job_id: row.id,
+        __delivery_context: row.delivery_context,
+        __scheduled_job_tick: tickIso,
+        __organization_id: row.organization_id,
+        __created_by_user: row.created_by_user,
+        __created_by_agent: row.created_by_agent,
+      }, { idempotencyKey });
+    } catch (err) {
+      logger.warn(
+        { scheduled_job_id: row.id, err: errorMessage(err) },
+        '[scheduled-jobs-tick] spawn failed; leaving next_run_at unchanged for retry'
+      );
+      continue;
+    }
+    // Advance OR pause-when-done depending on whether this is recurring.
+    //
+    // The claim transaction (FOR UPDATE SKIP LOCKED) commits when the
+    // closure above returns, releasing the row locks BEFORE this advance
+    // runs — so SKIP LOCKED gives no cross-pod exclusion during the
+    // spawn+advance window. The spawn idempotency key collapses duplicate
+    // tasks, but the advance itself must be conditional or two pods reading
+    // the same pre-advance `next_run_at` can both write (and clobber a
+    // concurrent pause/delete/re-schedule).
+    //
+    // Guard on `next_run_at <= now()` (same predicate as the claim SELECT),
+    // NOT equality against the value we read: postgres.js parses
+    // timestamptz to a millisecond-precision JS Date while the column
+    // stores microseconds, so an equality round-trip silently never
+    // matches for µs-precision rows — leaving them eternally due and
+    // re-claimed every tick. `<= now()` is a no-op once any pod has
+    // advanced the row (next_run_at is then in the future) and never
+    // clobbers an operator re-schedule to a future time.
+    const nextAt = row.cron ? nextCronTickAt(row.cron) : null;
+    if (nextAt && !exceedsUntilAt(nextAt, row.until_at)) {
+      await sql`
+        UPDATE scheduled_jobs
+        SET last_fired_at = now(), next_run_at = ${nextAt}, updated_at = now()
+        WHERE id = ${row.id} AND next_run_at <= now()
+      `;
+    } else {
+      await completeScheduledJobAfterFire(sql, row.id);
+    }
+  }
+}
+
 /**
  * Register the per-minute tick. Call once during bootTaskScheduler.
  *
@@ -338,73 +461,7 @@ export function registerScheduledJobsTicker(scheduler: TaskScheduler): void {
     'scheduled-jobs-tick',
     async () => {
       const sql = getDb();
-      const claimed = await sql.begin(async (tx) => {
-        return (await tx`
-          SELECT *
-          FROM scheduled_jobs
-          WHERE next_run_at <= now() AND NOT paused
-          ORDER BY next_run_at ASC
-          FOR UPDATE SKIP LOCKED
-          LIMIT 200
-        `) as unknown as ScheduledJobRow[];
-      });
-      if (claimed.length === 0) return;
-
-      for (const row of claimed) {
-        const tickIso = row.next_run_at;
-        const idempotencyKey = `scheduled_job:${row.id}:${tickIso}`;
-        try {
-          await scheduler.spawn(row.action_type, {
-            ...row.action_args,
-            __scheduled_job_id: row.id,
-            __delivery_context: row.delivery_context,
-            __scheduled_job_tick: tickIso,
-            __organization_id: row.organization_id,
-            __created_by_user: row.created_by_user,
-            __created_by_agent: row.created_by_agent,
-          }, { idempotencyKey });
-        } catch (err) {
-          logger.warn(
-            { scheduled_job_id: row.id, err: errorMessage(err) },
-            '[scheduled-jobs-tick] spawn failed; leaving next_run_at unchanged for retry'
-          );
-          continue;
-        }
-        // Advance OR pause-when-done depending on whether this is recurring.
-        //
-        // The claim transaction (FOR UPDATE SKIP LOCKED) commits when the
-        // closure above returns, releasing the row locks BEFORE this advance
-        // runs — so SKIP LOCKED gives no cross-pod exclusion during the
-        // spawn+advance window. The spawn idempotency key collapses duplicate
-        // tasks, but the advance itself must be conditional or two pods reading
-        // the same pre-advance `next_run_at` can both write (and clobber a
-        // concurrent pause/delete/re-schedule).
-        //
-        // Guard on `next_run_at <= now()` (same predicate as the claim SELECT),
-        // NOT equality against the value we read: postgres.js parses
-        // timestamptz to a millisecond-precision JS Date while the column
-        // stores microseconds, so an equality round-trip silently never
-        // matches for µs-precision rows — leaving them eternally due and
-        // re-claimed every tick. `<= now()` is a no-op once any pod has
-        // advanced the row (next_run_at is then in the future) and never
-        // clobbers an operator re-schedule to a future time.
-        const nextAt = row.cron ? nextCronTickAt(row.cron) : null;
-        if (nextAt) {
-          await sql`
-            UPDATE scheduled_jobs
-            SET last_fired_at = now(), next_run_at = ${nextAt}, updated_at = now()
-            WHERE id = ${row.id} AND next_run_at <= now()
-          `;
-        } else {
-          // One-shot: mark as fired + paused so the index ignores it.
-          // Re-pausing an already-paused row is idempotent.
-          await sql`
-            UPDATE scheduled_jobs
-            SET last_fired_at = now(), paused = true, updated_at = now()
-            WHERE id = ${row.id} AND next_run_at <= now()
-          `;
-        }
-      }
+      await runScheduledJobsTick(sql, scheduler);
     },
     { cron: '* * * * *' }
   );

--- a/packages/server/src/scheduled/scheduled-jobs-service.ts
+++ b/packages/server/src/scheduled/scheduled-jobs-service.ts
@@ -8,12 +8,12 @@
  * claim/retry/idempotency/observability inherited.
  *
  * Firing flow:
- *   1. Tick claims rows WHERE next_run_at <= now AND NOT paused AND not completed.
- *   2. For each row, revalidate/claim the current row, then spawn(action_type, action_args, { idempotencyKey, runAt: now }).
- *   3. Advance last_fired_at + next_run_at (or pause if one-shot completed).
- * If the tick crashes between step 2 and 3, the next tick re-reads the
- * same row (next_run_at not advanced) and re-spawns — idempotency dedup
- * stops duplicates. Self-healing.
+ *   1. Tick reads cheap due candidates WHERE next_run_at <= now AND NOT paused AND not completed.
+ *   2. For each candidate, lock the current row, enqueue the task, then advance/pause
+ *      before releasing the row lock.
+ * If enqueue fails, the transaction rolls back and the next tick re-reads the
+ * same row. If a process crashes after enqueue before advance, task idempotency
+ * dedups a retried enqueue. Self-healing.
  */
 
 import { getDb } from '../db/client';
@@ -197,7 +197,7 @@ export async function createScheduledJobInDb(
       organization_id, action_type, action_args, delivery_context, cron, next_run_at,
       description, schedule_metadata, timezone, until_at, completed_at, idempotency_key,
       created_by_user, created_by_agent,
-      source_run_id, source_event_id, source_thread_id
+      source_run_id, source_event_id, source_thread_id, paused
     ) VALUES (
       ${params.organizationId}, ${params.actionType},
       ${sql.json(params.actionArgs)}, ${params.deliveryContext ? sql.json(params.deliveryContext) : null}, ${params.cron ?? null}, ${params.runAt},
@@ -207,7 +207,7 @@ export async function createScheduledJobInDb(
       ${params.idempotencyKey ?? null},
       ${params.createdByUser ?? null}, ${params.createdByAgent ?? null},
       ${params.sourceRunId ?? null}, ${params.sourceEventId ?? null},
-      ${params.sourceThreadId ?? null}
+      ${params.sourceThreadId ?? null}, ${params.completedAt != null}
     )
     ON CONFLICT (organization_id, idempotency_key) WHERE idempotency_key IS NOT NULL
     DO UPDATE SET idempotency_key = scheduled_jobs.idempotency_key
@@ -362,26 +362,6 @@ async function completeExpiredScheduledJob(
   return rows.length > 0;
 }
 
-async function revalidateScheduledJobForDispatch(
-  sql: ScheduledJobsTickSql,
-  id: string
-): Promise<ScheduledJobRow | null> {
-  const rows = await sql.begin(async (tx) => {
-    return (await tx`
-      SELECT *
-      FROM scheduled_jobs
-      WHERE id = ${id}
-        AND next_run_at <= now()
-        AND NOT paused
-        AND completed_at IS NULL
-        AND (until_at IS NULL OR next_run_at <= until_at)
-      FOR UPDATE SKIP LOCKED
-      LIMIT 1
-    `) as unknown as ScheduledJobRow[];
-  });
-  return rows[0] ?? null;
-}
-
 async function completeScheduledJobAfterFire(
   sql: ScheduledJobsTickSql,
   id: string
@@ -404,82 +384,81 @@ function exceedsUntilAt(nextAt: string, untilAt: string | null): boolean {
   return new Date(nextAt).getTime() > new Date(untilAt).getTime();
 }
 
-export async function runScheduledJobsTick(
+async function claimEnqueueAndAdvanceScheduledJob(
   sql: ScheduledJobsTickSql,
-  scheduler: ScheduledJobsTickScheduler
+  scheduler: ScheduledJobsTickScheduler,
+  id: string
 ): Promise<void> {
-  const claimed = await sql.begin(async (tx) => {
-    return (await tx`
+  await sql.begin(async (tx) => {
+    const rows = (await tx`
       SELECT *
       FROM scheduled_jobs
-      WHERE next_run_at <= now()
+      WHERE id = ${id}
+        AND next_run_at <= now()
         AND NOT paused
         AND completed_at IS NULL
-      ORDER BY next_run_at ASC
       FOR UPDATE SKIP LOCKED
-      LIMIT 200
+      LIMIT 1
     `) as unknown as ScheduledJobRow[];
-  });
-  if (claimed.length === 0) return;
+    const row = rows[0];
+    if (!row) return;
 
-  for (const row of claimed) {
     if (exceedsUntilAt(row.next_run_at, row.until_at)) {
-      await completeExpiredScheduledJob(sql, row.id);
-      continue;
+      await completeExpiredScheduledJob(tx, row.id);
+      return;
     }
 
-    const currentRow = await revalidateScheduledJobForDispatch(sql, row.id);
-    if (!currentRow) continue;
+    const tickIso = row.next_run_at;
+    const idempotencyKey = `scheduled_job:${row.id}:${tickIso}`;
+    await scheduler.spawn(row.action_type, {
+      ...row.action_args,
+      __scheduled_job_id: row.id,
+      __delivery_context: row.delivery_context,
+      __scheduled_job_tick: tickIso,
+      __organization_id: row.organization_id,
+      __created_by_user: row.created_by_user,
+      __created_by_agent: row.created_by_agent,
+    }, { idempotencyKey });
 
-    const tickIso = currentRow.next_run_at;
-    const idempotencyKey = `scheduled_job:${currentRow.id}:${tickIso}`;
-    try {
-      await scheduler.spawn(currentRow.action_type, {
-        ...currentRow.action_args,
-        __scheduled_job_id: currentRow.id,
-        __delivery_context: currentRow.delivery_context,
-        __scheduled_job_tick: tickIso,
-        __organization_id: currentRow.organization_id,
-        __created_by_user: currentRow.created_by_user,
-        __created_by_agent: currentRow.created_by_agent,
-      }, { idempotencyKey });
-    } catch (err) {
-      logger.warn(
-        { scheduled_job_id: currentRow.id, err: errorMessage(err) },
-        '[scheduled-jobs-tick] spawn failed; leaving next_run_at unchanged for retry'
-      );
-      continue;
-    }
-    // Advance OR pause-when-done depending on whether this is recurring.
-    //
-    // The claim transaction (FOR UPDATE SKIP LOCKED) commits when the
-    // closure above returns, releasing the row locks BEFORE this advance
-    // runs — so SKIP LOCKED gives no cross-pod exclusion during the
-    // spawn+advance window. The spawn idempotency key collapses duplicate
-    // tasks, but the advance itself must be conditional or two pods reading
-    // the same pre-advance `next_run_at` can both write (and clobber a
-    // concurrent pause/delete/re-schedule).
-    //
-    // Guard on `next_run_at <= now()` (same predicate as the claim SELECT),
-    // NOT equality against the value we read: postgres.js parses
-    // timestamptz to a millisecond-precision JS Date while the column
-    // stores microseconds, so an equality round-trip silently never
-    // matches for µs-precision rows — leaving them eternally due and
-    // re-claimed every tick. `<= now()` is a no-op once any pod has
-    // advanced the row (next_run_at is then in the future) and never
-    // clobbers an operator re-schedule to a future time.
-    const nextAt = currentRow.cron ? nextCronTickAt(currentRow.cron) : null;
-    if (nextAt && !exceedsUntilAt(nextAt, currentRow.until_at)) {
-      await sql`
+    const nextAt = row.cron ? nextCronTickAt(row.cron) : null;
+    if (nextAt && !exceedsUntilAt(nextAt, row.until_at)) {
+      await tx`
         UPDATE scheduled_jobs
         SET last_fired_at = now(), next_run_at = ${nextAt}, updated_at = now()
-        WHERE id = ${currentRow.id}
+        WHERE id = ${row.id}
           AND next_run_at <= now()
           AND NOT paused
           AND completed_at IS NULL
       `;
     } else {
-      await completeScheduledJobAfterFire(sql, currentRow.id);
+      await completeScheduledJobAfterFire(tx, row.id);
+    }
+  });
+}
+
+export async function runScheduledJobsTick(
+  sql: ScheduledJobsTickSql,
+  scheduler: ScheduledJobsTickScheduler
+): Promise<void> {
+  const candidates = (await sql`
+    SELECT id
+    FROM scheduled_jobs
+    WHERE next_run_at <= now()
+      AND NOT paused
+      AND completed_at IS NULL
+    ORDER BY next_run_at ASC
+    LIMIT 200
+  `) as unknown as Array<{ id: string }>;
+  if (candidates.length === 0) return;
+
+  for (const row of candidates) {
+    try {
+      await claimEnqueueAndAdvanceScheduledJob(sql, scheduler, row.id);
+    } catch (err) {
+      logger.warn(
+        { scheduled_job_id: row.id, err: errorMessage(err) },
+        '[scheduled-jobs-tick] spawn failed; leaving next_run_at unchanged for retry'
+      );
     }
   }
 }
@@ -487,12 +466,12 @@ export async function runScheduledJobsTick(
 /**
  * Register the per-minute tick. Call once during bootTaskScheduler.
  *
- * The handler claims due rows transactionally (FOR UPDATE SKIP LOCKED so
- * concurrent pods coordinate without an advisory lock), spawns one task
- * per row, and advances next_run_at. A handler crash leaves rows un-
- * advanced — next minute's tick retries them. Per-row idempotency key
- * `scheduled_job:<id>:<tick-iso>` deduplicates if the same row is read
- * twice across pods.
+ * The handler reads due candidates, then claims each row transactionally
+ * (FOR UPDATE SKIP LOCKED so concurrent pods coordinate without an advisory
+ * lock), spawns one task per row, and advances next_run_at before releasing
+ * the row lock. A handler crash before advance leaves rows due — next minute's
+ * tick retries them. Per-row idempotency key `scheduled_job:<id>:<tick-iso>`
+ * deduplicates if a crash happens after enqueue but before advance.
  */
 export function registerScheduledJobsTicker(scheduler: TaskScheduler): void {
   scheduler.register(

--- a/packages/server/src/scheduled/scheduled-jobs-service.ts
+++ b/packages/server/src/scheduled/scheduled-jobs-service.ts
@@ -8,8 +8,8 @@
  * claim/retry/idempotency/observability inherited.
  *
  * Firing flow:
- *   1. Tick claims rows WHERE next_run_at <= now AND NOT paused.
- *   2. For each row, spawn(action_type, action_args, { idempotencyKey, runAt: now }).
+ *   1. Tick claims rows WHERE next_run_at <= now AND NOT paused AND not completed.
+ *   2. For each row, revalidate/claim the current row, then spawn(action_type, action_args, { idempotencyKey, runAt: now }).
  *   3. Advance last_fired_at + next_run_at (or pause if one-shot completed).
  * If the tick crashes between step 2 and 3, the next tick re-reads the
  * same row (next_run_at not advanced) and re-spawns — idempotency dedup
@@ -268,10 +268,21 @@ export async function pauseScheduledJob(
   paused: boolean
 ): Promise<boolean> {
   const sql = getDb();
+  return pauseScheduledJobInDb(sql, organizationId, id, paused);
+}
+
+export async function pauseScheduledJobInDb(
+  sql: SqlLike,
+  organizationId: string,
+  id: string,
+  paused: boolean
+): Promise<boolean> {
   const rows = (await sql`
     UPDATE scheduled_jobs
     SET paused = ${paused}, updated_at = now()
-    WHERE organization_id = ${organizationId} AND id = ${id}
+    WHERE organization_id = ${organizationId}
+      AND id = ${id}
+      AND (${paused} OR completed_at IS NULL)
     RETURNING id
   `) as unknown as Array<{ id: string }>;
   return rows.length > 0;
@@ -343,11 +354,32 @@ async function completeExpiredScheduledJob(
     WHERE id = ${id}
       AND next_run_at <= now()
       AND NOT paused
+      AND completed_at IS NULL
       AND until_at IS NOT NULL
-      AND until_at < now()
+      AND next_run_at > until_at
     RETURNING id
   `) as unknown as Array<{ id: string }>;
   return rows.length > 0;
+}
+
+async function revalidateScheduledJobForDispatch(
+  sql: ScheduledJobsTickSql,
+  id: string
+): Promise<ScheduledJobRow | null> {
+  const rows = await sql.begin(async (tx) => {
+    return (await tx`
+      SELECT *
+      FROM scheduled_jobs
+      WHERE id = ${id}
+        AND next_run_at <= now()
+        AND NOT paused
+        AND completed_at IS NULL
+        AND (until_at IS NULL OR next_run_at <= until_at)
+      FOR UPDATE SKIP LOCKED
+      LIMIT 1
+    `) as unknown as ScheduledJobRow[];
+  });
+  return rows[0] ?? null;
 }
 
 async function completeScheduledJobAfterFire(
@@ -360,18 +392,16 @@ async function completeScheduledJobAfterFire(
         paused = true,
         completed_at = COALESCE(completed_at, now()),
         updated_at = now()
-    WHERE id = ${id} AND next_run_at <= now()
+    WHERE id = ${id}
+      AND next_run_at <= now()
+      AND NOT paused
+      AND completed_at IS NULL
   `;
 }
 
 function exceedsUntilAt(nextAt: string, untilAt: string | null): boolean {
   if (!untilAt) return false;
   return new Date(nextAt).getTime() > new Date(untilAt).getTime();
-}
-
-function isPastUntilAt(untilAt: string | null): boolean {
-  if (!untilAt) return false;
-  return new Date(untilAt).getTime() < Date.now();
 }
 
 export async function runScheduledJobsTick(
@@ -382,7 +412,9 @@ export async function runScheduledJobsTick(
     return (await tx`
       SELECT *
       FROM scheduled_jobs
-      WHERE next_run_at <= now() AND NOT paused
+      WHERE next_run_at <= now()
+        AND NOT paused
+        AND completed_at IS NULL
       ORDER BY next_run_at ASC
       FOR UPDATE SKIP LOCKED
       LIMIT 200
@@ -391,26 +423,29 @@ export async function runScheduledJobsTick(
   if (claimed.length === 0) return;
 
   for (const row of claimed) {
-    if (row.until_at) {
-      const completedExpired = await completeExpiredScheduledJob(sql, row.id);
-      if (completedExpired || isPastUntilAt(row.until_at)) continue;
+    if (exceedsUntilAt(row.next_run_at, row.until_at)) {
+      await completeExpiredScheduledJob(sql, row.id);
+      continue;
     }
 
-    const tickIso = row.next_run_at;
-    const idempotencyKey = `scheduled_job:${row.id}:${tickIso}`;
+    const currentRow = await revalidateScheduledJobForDispatch(sql, row.id);
+    if (!currentRow) continue;
+
+    const tickIso = currentRow.next_run_at;
+    const idempotencyKey = `scheduled_job:${currentRow.id}:${tickIso}`;
     try {
-      await scheduler.spawn(row.action_type, {
-        ...row.action_args,
-        __scheduled_job_id: row.id,
-        __delivery_context: row.delivery_context,
+      await scheduler.spawn(currentRow.action_type, {
+        ...currentRow.action_args,
+        __scheduled_job_id: currentRow.id,
+        __delivery_context: currentRow.delivery_context,
         __scheduled_job_tick: tickIso,
-        __organization_id: row.organization_id,
-        __created_by_user: row.created_by_user,
-        __created_by_agent: row.created_by_agent,
+        __organization_id: currentRow.organization_id,
+        __created_by_user: currentRow.created_by_user,
+        __created_by_agent: currentRow.created_by_agent,
       }, { idempotencyKey });
     } catch (err) {
       logger.warn(
-        { scheduled_job_id: row.id, err: errorMessage(err) },
+        { scheduled_job_id: currentRow.id, err: errorMessage(err) },
         '[scheduled-jobs-tick] spawn failed; leaving next_run_at unchanged for retry'
       );
       continue;
@@ -433,15 +468,18 @@ export async function runScheduledJobsTick(
     // re-claimed every tick. `<= now()` is a no-op once any pod has
     // advanced the row (next_run_at is then in the future) and never
     // clobbers an operator re-schedule to a future time.
-    const nextAt = row.cron ? nextCronTickAt(row.cron) : null;
-    if (nextAt && !exceedsUntilAt(nextAt, row.until_at)) {
+    const nextAt = currentRow.cron ? nextCronTickAt(currentRow.cron) : null;
+    if (nextAt && !exceedsUntilAt(nextAt, currentRow.until_at)) {
       await sql`
         UPDATE scheduled_jobs
         SET last_fired_at = now(), next_run_at = ${nextAt}, updated_at = now()
-        WHERE id = ${row.id} AND next_run_at <= now()
+        WHERE id = ${currentRow.id}
+          AND next_run_at <= now()
+          AND NOT paused
+          AND completed_at IS NULL
       `;
     } else {
-      await completeScheduledJobAfterFire(sql, row.id);
+      await completeScheduledJobAfterFire(sql, currentRow.id);
     }
   }
 }

--- a/packages/server/src/scheduled/scheduled-jobs-service.ts
+++ b/packages/server/src/scheduled/scheduled-jobs-service.ts
@@ -17,6 +17,7 @@
  */
 
 import { getDb } from '../db/client';
+import type { DbClient } from '../db/client';
 import { runtimeConnectionIdToSlug } from '../lobu/stores/connections-projection';
 import { nextRunAt as nextCronTickAt } from '../utils/cron';
 import logger from '../utils/logger';
@@ -131,6 +132,11 @@ export interface ScheduledJobRow {
   delivery_context: ScheduledDeliveryContext | null;
   cron: string | null;
   next_run_at: string;
+  schedule_metadata: Record<string, unknown> | null;
+  timezone: string | null;
+  until_at: string | null;
+  completed_at: string | null;
+  idempotency_key: string | null;
   last_fired_at: string | null;
   last_fired_run_id: number | null;
   paused: boolean;
@@ -152,6 +158,11 @@ interface CreateScheduledJobParams {
   description: string;
   cron?: string | null;
   runAt: Date;
+  scheduleMetadata?: Record<string, unknown> | null;
+  timezone?: string | null;
+  untilAt?: Date | null;
+  completedAt?: Date | null;
+  idempotencyKey?: string | null;
   createdByUser?: string | null;
   createdByAgent?: string | null;
   sourceRunId?: number | null;
@@ -166,23 +177,51 @@ export async function createScheduledJob(
     throw new Error('scheduled_jobs requires created_by_user or created_by_agent');
   }
   const sql = getDb();
+  return createScheduledJobInDb(sql, params);
+}
+
+export async function createScheduledJobInDb(
+  sql: Pick<DbClient, 'json'> & ((
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ) => Promise<unknown[]>),
+  params: CreateScheduledJobParams
+): Promise<ScheduledJobRow> {
   const rows = (await sql`
     INSERT INTO scheduled_jobs (
       organization_id, action_type, action_args, delivery_context, cron, next_run_at,
-      description,
+      description, schedule_metadata, timezone, until_at, completed_at, idempotency_key,
       created_by_user, created_by_agent,
       source_run_id, source_event_id, source_thread_id
     ) VALUES (
       ${params.organizationId}, ${params.actionType},
       ${sql.json(params.actionArgs)}, ${params.deliveryContext ? sql.json(params.deliveryContext) : null}, ${params.cron ?? null}, ${params.runAt},
       ${params.description},
+      ${params.scheduleMetadata == null ? null : sql.json(params.scheduleMetadata)},
+      ${params.timezone ?? null}, ${params.untilAt ?? null}, ${params.completedAt ?? null},
+      ${params.idempotencyKey ?? null},
       ${params.createdByUser ?? null}, ${params.createdByAgent ?? null},
       ${params.sourceRunId ?? null}, ${params.sourceEventId ?? null},
       ${params.sourceThreadId ?? null}
     )
+    ON CONFLICT (organization_id, idempotency_key) WHERE idempotency_key IS NOT NULL
+    DO UPDATE SET idempotency_key = scheduled_jobs.idempotency_key
     RETURNING *
   `) as unknown as ScheduledJobRow[];
   return rows[0];
+}
+
+export async function getScheduledJobByIdempotencyKey(
+  organizationId: string,
+  idempotencyKey: string
+): Promise<ScheduledJobRow | null> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT * FROM scheduled_jobs
+    WHERE organization_id = ${organizationId} AND idempotency_key = ${idempotencyKey}
+    LIMIT 1
+  `) as unknown as ScheduledJobRow[];
+  return rows[0] ?? null;
 }
 
 export async function listScheduledJobs(opts: {

--- a/packages/server/src/tools/admin/manage_schedules.ts
+++ b/packages/server/src/tools/admin/manage_schedules.ts
@@ -33,6 +33,7 @@ import {
   type DeliveryAuthzDenyReason,
   deleteScheduledJob,
   getScheduledJob,
+  getScheduledJobByIdempotencyKey,
   isDeliverableChatPlatform,
   listScheduledJobs,
   pauseScheduledJob,
@@ -68,6 +69,15 @@ const manageSchedulesTool = defineActionTool('manage_schedules', {
 export { ManageSchedulesSchema };
 export const manageSchedules = manageSchedulesTool.run;
 
+function parseOptionalTimestamp(field: string, value: string | undefined): Date | null | ToolResult {
+  if (value === undefined) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return { error: `${field} is not a valid ISO timestamp: ${value}` };
+  }
+  return parsed;
+}
+
 async function handleCreate(
   args: Static<typeof CreateAction>,
   ctx: ToolContext
@@ -75,6 +85,18 @@ async function handleCreate(
   const runAtDate = new Date(args.run_at);
   if (Number.isNaN(runAtDate.getTime())) {
     return { error: `run_at is not a valid ISO timestamp: ${args.run_at}` };
+  }
+  const untilAt = parseOptionalTimestamp('until_at', args.until_at);
+  if (!(untilAt instanceof Date) && untilAt !== null) return untilAt;
+  if (untilAt && untilAt.getTime() < runAtDate.getTime()) {
+    return { error: 'until_at must not be before run_at for a new schedule.' };
+  }
+  const completedAt = parseOptionalTimestamp('completed_at', args.completed_at);
+  if (!(completedAt instanceof Date) && completedAt !== null) return completedAt;
+  if (runAtDate.getTime() < Date.now() - 30_000 && !args.cron) {
+    return {
+      error: `run_at is in the past. Current server time is ${new Date().toISOString()}; provide a future ISO timestamp.`,
+    };
   }
   // If cron is set, sanity-check it by computing the next tick from now.
   if (args.cron) {
@@ -85,6 +107,13 @@ async function handleCreate(
         error: `cron expression rejected: ${getErrorMessage(err)}`,
       };
     }
+  }
+  if (args.idempotency_key) {
+    const existing = await getScheduledJobByIdempotencyKey(
+      ctx.organizationId,
+      args.idempotency_key
+    );
+    if (existing) return { schedule: serializeSchedule(existing) };
   }
   // action_type comes from the payload's discriminant `type`.
   const actionType = args.payload.type;
@@ -104,6 +133,11 @@ async function handleCreate(
     description: args.description,
     cron: args.cron ?? null,
     runAt: runAtDate,
+    scheduleMetadata: args.schedule_metadata ?? null,
+    timezone: args.timezone ?? null,
+    untilAt,
+    completedAt,
+    idempotencyKey: args.idempotency_key ?? null,
     createdByUser: ctx.userId ?? null,
     createdByAgent: ctx.agentId ?? null,
     sourceRunId: args.source_run_id ?? null,
@@ -287,6 +321,11 @@ function serializeSchedule(row: ScheduledJobRow) {
     delivery_context: row.delivery_context,
     cron: row.cron,
     next_run_at: row.next_run_at,
+    schedule_metadata: row.schedule_metadata,
+    timezone: row.timezone,
+    until_at: row.until_at,
+    completed_at: row.completed_at,
+    idempotency_key: row.idempotency_key,
     last_fired_at: row.last_fired_at,
     last_fired_run_id: row.last_fired_run_id,
     paused: row.paused,

--- a/packages/server/src/tools/admin/manage_schedules.ts
+++ b/packages/server/src/tools/admin/manage_schedules.ts
@@ -93,11 +93,6 @@ async function handleCreate(
   }
   const completedAt = parseOptionalTimestamp('completed_at', args.completed_at);
   if (!(completedAt instanceof Date) && completedAt !== null) return completedAt;
-  if (runAtDate.getTime() < Date.now() - 30_000 && !args.cron) {
-    return {
-      error: `run_at is in the past. Current server time is ${new Date().toISOString()}; provide a future ISO timestamp.`,
-    };
-  }
   // If cron is set, sanity-check it by computing the next tick from now.
   if (args.cron) {
     try {


### PR DESCRIPTION
## Summary
<!-- Why this change? 1–3 bullets. Skip if the PR title is self-explanatory. -->

## Test plan
<!-- Check only what you actually ran. See AGENTS.md → "Validation after code changes". -->
- [ ] `bun run check:fix` clean
- [ ] `bun run typecheck` passes (or `make build-packages` if TS packages changed)
- [ ] If bot behavior: ran `./scripts/test-bot.sh` or relevant eval

## Notes
<!-- Screenshots, follow-ups, linked issues (`Closes #123`), breaking-change callouts. Delete if none. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786349293&installation_id=136316292&pr_number=1853&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1853&signature=74520f63cd6240e9fc1e4695a4a14029fc2fee8c489e8b8e5d655c2d09a984dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added timezone, schedule metadata, and lifecycle timestamps (until/completed) to scheduled jobs and schedule responses.
  - Added idempotency key support to create schedules without duplicates, and exposed these fields in the schedule management tool.
- **Bug Fixes**
  - Improved scheduled tick behavior around end times and retry safety when task dispatch fails.
  - Ensured completed schedules aren’t resumed/restarted and added safer handling for one-time/metadata-only schedules.
- **Tests**
  - Added a comprehensive scheduled jobs service test suite covering tick, locking, and update/dispatch ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->