### PR TITLE
fix(connections): recover same-org tenant swap deadlocks

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/connections-unify-write-through.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connections-unify-write-through.test.ts
@@ -21,9 +21,9 @@ import { getDb } from "../../../db/client";
 import { SecretStoreRegistry } from "../../../gateway/secrets/index";
 import { createPostgresAppInstallationStore } from "../../../lobu/stores/app-installation-store";
 import { upsertChatConnectionProjection } from "../../../lobu/stores/connections-projection";
-import { createPostgresAgentConnectionStore } from "../../../lobu/stores/postgres-stores";
-import { PostgresSecretStore } from "../../../lobu/stores/postgres-secret-store";
 import { orgContext } from "../../../lobu/stores/org-context";
+import { PostgresSecretStore } from "../../../lobu/stores/postgres-secret-store";
+import { createPostgresAgentConnectionStore } from "../../../lobu/stores/postgres-stores";
 import { upsertSlackInstallByTeam } from "../../../lobu/stores/slack-installations";
 import { initWorkspaceProvider } from "../../../workspace";
 import {
@@ -51,7 +51,10 @@ interface ProjRow {
 	updated_at: string;
 }
 
-async function projBySlug(orgId: string, slug: string): Promise<ProjRow | null> {
+async function projBySlug(
+	orgId: string,
+	slug: string,
+): Promise<ProjRow | null> {
 	const rows = (await getDb()`
 		SELECT slug, connector_key, status, credential_mode, external_tenant_id,
 		       config, deleted_at, updated_at
@@ -110,7 +113,10 @@ describe("connections-unify single-table store (chat)", () => {
 		const read = await withOrg(orgId, () => store.getConnection("wt-slack-1"));
 		expect(read?.id).toBe("wt-slack-1");
 		expect(read?.platform).toBe("slack");
-		expect(read?.config).toEqual({ platform: "slack", botToken: "secret://wt-1" });
+		expect(read?.config).toEqual({
+			platform: "slack",
+			botToken: "secret://wt-1",
+		});
 		expect(read?.settings).toEqual({ allowGroups: true });
 		expect(read?.metadata?.teamId).toBe("TW1");
 		expect(read?.status).toBe("active");
@@ -219,6 +225,75 @@ describe("connections-unify single-table store (chat)", () => {
 			  AND external_tenant_id = 'TDEMO' AND status = 'active' AND deleted_at IS NULL
 		`) as Array<{ count: number }>;
 		expect(Number(count)).toBe(1);
+	});
+
+	it("concurrent same-org tenant swaps recover from a PostgreSQL deadlock", async () => {
+		const db = getDb();
+		const swapA = "wt-swap-a";
+		const swapB = "wt-swap-b";
+		const slugA = `agentconn-${swapA}`;
+		const slugB = `agentconn-${swapB}`;
+		const writeActive = (id: string, teamId: string) =>
+			withOrg(orgId, () =>
+				store.saveConnection({
+					id,
+					platform: "slack",
+					agentId,
+					organizationId: orgId,
+					config: { platform: "slack", botToken: `secret://${id}` },
+					settings: { allowGroups: true },
+					metadata: { teamId },
+					status: "active",
+					createdAt: Date.now(),
+					updatedAt: Date.now(),
+				}),
+			);
+
+		await writeActive(swapA, "TSWAP-X");
+		await writeActive(swapB, "TSWAP-Y");
+
+		// Widen the real deadlock window after each transaction has demoted (and
+		// row-locked) the other's target. Both then try to upsert their own
+		// locked-by-the-peer row, so PostgreSQL aborts one transaction with 40P01;
+		// the store must retry that fully rolled-back transaction.
+		await db.unsafe(`
+			CREATE OR REPLACE FUNCTION test_delay_connection_swap_1842()
+			RETURNS trigger LANGUAGE plpgsql AS $$
+			BEGIN
+				IF OLD.status = 'active' AND NEW.status = 'paused'
+					AND NEW.slug IN ('${slugA}', '${slugB}') THEN
+					PERFORM pg_sleep(0.25);
+				END IF;
+				RETURN NEW;
+			END;
+			$$;
+			CREATE TRIGGER test_delay_connection_swap_1842
+			AFTER UPDATE ON connections
+			FOR EACH ROW EXECUTE FUNCTION test_delay_connection_swap_1842();
+		`);
+
+		try {
+			await Promise.all([
+				writeActive(swapA, "TSWAP-Y"),
+				writeActive(swapB, "TSWAP-X"),
+			]);
+		} finally {
+			await db.unsafe(`
+				DROP TRIGGER IF EXISTS test_delay_connection_swap_1842 ON connections;
+				DROP FUNCTION IF EXISTS test_delay_connection_swap_1842();
+			`);
+		}
+
+		const a = await projBySlug(orgId, slugA);
+		const b = await projBySlug(orgId, slugB);
+		expect(a).toMatchObject({
+			status: "active",
+			external_tenant_id: "TSWAP-Y",
+		});
+		expect(b).toMatchObject({
+			status: "active",
+			external_tenant_id: "TSWAP-X",
+		});
 	});
 
 	it("managed Slack install projects a credential_mode=managed row resolvable by its slackinst- id", async () => {

--- a/packages/server/src/lobu/stores/postgres-stores.ts
+++ b/packages/server/src/lobu/stores/postgres-stores.ts
@@ -23,6 +23,26 @@ export function isValidAgentId(agentId: string): boolean {
 	return AGENT_ID_PATTERN.test(agentId);
 }
 
+async function withChatConnectionDeadlockRetry<T>(
+	context: { organizationId: string; slug: string },
+	transaction: () => Promise<T>,
+): Promise<T> {
+	try {
+		return await transaction();
+	} catch (error) {
+		const code =
+			error && typeof error === "object"
+				? (error as { code?: unknown }).code
+				: undefined;
+		if (code !== "40P01") throw error;
+		logger.warn(
+			context,
+			"chat connection write deadlocked — retrying transaction",
+		);
+		return transaction();
+	}
+}
+
 export async function agentExistsInOrganization(
 	organizationId: string,
 	agentId: string,
@@ -362,46 +382,59 @@ export function createPostgresAgentConnectionStore(): AgentConnectionStore {
 			// together. The advisory lock is TRANSACTION-scoped — calling the writer
 			// on the pool handle would release it after the first statement and
 			// defeat the cross-replica serialization.
-			await sql.begin(async (tx: typeof sql) => {
-				const configToPersist = { ...connection.config };
-				const existingRows = await tx`
+			//
+			// A concurrent same-org tenant swap can deadlock after each transaction
+			// demotes the other's target. Retrying once is safe here: every effect is
+			// enclosed by this transaction, so PostgreSQL rolls the aborted attempt
+			// back completely before the callback is re-run.
+			await withChatConnectionDeadlockRetry(
+				{ organizationId: orgId, slug },
+				() =>
+					sql.begin(async (tx: typeof sql) => {
+						const configToPersist = { ...connection.config };
+						const existingRows = await tx`
           SELECT config
           FROM connections
           WHERE slug = ${slug} AND organization_id = ${orgId}
           LIMIT 1
         `;
-				const existingConfig =
-					existingRows[0] &&
-					typeof existingRows[0].config === "object" &&
-					existingRows[0].config
-						? (existingRows[0].config as Record<string, any>)
-						: null;
+						const existingConfig =
+							existingRows[0] &&
+							typeof existingRows[0].config === "object" &&
+							existingRows[0].config
+								? (existingRows[0].config as Record<string, any>)
+								: null;
 
-				// ChatInstanceManager normalizes secret fields into `secret://` refs
-				// before reaching here. The remaining special case is the API surface
-				// that hands back `***last4`-redacted values when a sanitized
-				// connection is round-tripped to an UPDATE — preserve the existing
-				// ref/value so a non-edited secret doesn't overwrite the real one.
-				if (existingConfig) {
-					for (const [key, value] of Object.entries(configToPersist)) {
-						if (!isSecretField(key) || !isRedactedSecretValue(value)) continue;
+						// ChatInstanceManager normalizes secret fields into `secret://` refs
+						// before reaching here. The remaining special case is the API surface
+						// that hands back `***last4`-redacted values when a sanitized
+						// connection is round-tripped to an UPDATE — preserve the existing
+						// ref/value so a non-edited secret doesn't overwrite the real one.
+						if (existingConfig) {
+							for (const [key, value] of Object.entries(configToPersist)) {
+								if (!isSecretField(key) || !isRedactedSecretValue(value))
+									continue;
 
-						const existingValue = existingConfig[key];
-						if (typeof existingValue === "string" && existingValue.length > 0) {
-							configToPersist[key] = existingValue;
+								const existingValue = existingConfig[key];
+								if (
+									typeof existingValue === "string" &&
+									existingValue.length > 0
+								) {
+									configToPersist[key] = existingValue;
+								}
+							}
 						}
-					}
-				}
 
-				// `connections` is the sole source of truth — persist the chat projection.
-				await upsertChatConnectionProjection(
-					tx,
-					(v) => sql.json(v),
-					{ ...connection, config: configToPersist },
-					orgId,
-					"byo",
-				);
-			});
+						// `connections` is the sole source of truth — persist the chat projection.
+						await upsertChatConnectionProjection(
+							tx,
+							(v) => sql.json(v),
+							{ ...connection, config: configToPersist },
+							orgId,
+							"byo",
+						);
+					}),
+			);
 		},
 		async updateConnection(connectionId, updates) {
 			const existing = await this.getConnection(connectionId);


### PR DESCRIPTION
## What changed

- retry a BYO chat connection save once when PostgreSQL aborts it with 40P01
- keep the retry around the complete database transaction so the replay has no external or partially committed effects
- add a real Postgres regression that deterministically widens the A-to-B / B-to-A tenant-swap lock cycle

## Root cause

Two same-org connection writes swapping Slack tenants can each demote and row-lock the other target before upserting their own row. That creates a row-to-row cycle, so PostgreSQL aborts one writer with 40P01.

## Impact

The aborted writer now replays once after PostgreSQL rolls its first transaction back. Both connection updates complete instead of one surfacing a transient failure.

## Validation

- red: regression failed with `PostgresError: deadlock detected` at the projection upsert
- green: focused Postgres integration test, 8/8
- `make build-packages`
- `bun run typecheck`
- server unit suite: 484 passed, 16 skipped, 0 failed
- `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=fable make review`: bug-free 90, simplicity 88, zero blockers; full typecheck/unit/integration gate passed

Refs #1842 (bug 1 only; the managed/BYO namespace collision remains separate).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786359095&installation_id=136316292&pr_number=1854&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1854&signature=8d1713e3cd171d326953e50a9d9355f10a51457df2f69454042f679c6c8a8a56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple connection updates occur at the same time.
  * Prevented intermittent failures during concurrent Slack connection changes.
  * Ensured connection statuses and tenant assignments remain accurate after simultaneous updates.
* **Tests**
  * Added coverage for concurrent connection updates and verified consistent final results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->