### PR TITLE
fix(connections): reserve managed Slack stable IDs

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/byo-managed-stable-id-collision.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/byo-managed-stable-id-collision.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getDb } from "../../../db/client";
+import { upsertByoChatConnection } from "../../../gateway/connections/chat-connection-service";
+import {
+	resolveSecretValue,
+	SecretStoreRegistry,
+} from "../../../gateway/secrets/index";
+import { createPostgresAppInstallationStore } from "../../../lobu/stores/app-installation-store";
+import { orgContext } from "../../../lobu/stores/org-context";
+import { PostgresSecretStore } from "../../../lobu/stores/postgres-secret-store";
+import {
+	getSlackInstallById,
+	upsertSlackInstallByTeam,
+} from "../../../lobu/stores/slack-installations";
+import { TestWorkspace } from "../../setup/test-mcp-client";
+
+const ENCRYPTION_KEY =
+	"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("BYO chat stable-id namespace", () => {
+	let workspace: TestWorkspace;
+	let secretStore: SecretStoreRegistry;
+
+	beforeAll(async () => {
+		process.env.ENCRYPTION_KEY = ENCRYPTION_KEY;
+		workspace = await TestWorkspace.create({
+			name: "Managed ID Collision Org",
+		});
+
+		const postgresSecrets = new PostgresSecretStore();
+		secretStore = new SecretStoreRegistry(postgresSecrets, {
+			secret: postgresSecrets,
+		});
+	});
+
+	afterAll(async () => {
+		const sql = getDb();
+		await sql`DELETE FROM connections WHERE organization_id = ${workspace.org.id}`;
+		await sql`DELETE FROM app_installations WHERE organization_id = ${workspace.org.id}`;
+	});
+
+	it("rejects slackinst-* before a BYO apply can overwrite a managed row or secret", async () => {
+		const installationStore = createPostgresAppInstallationStore();
+		const install = await upsertSlackInstallByTeam(
+			installationStore,
+			secretStore,
+			workspace.org.id,
+			"TMANAGEDCOLLISION",
+			{
+				teamName: "Managed Collision Co",
+				botUserId: "UMANAGEDCOLLISION",
+				botToken: "xoxb-managed-original",
+			},
+		);
+
+		const sql = getDb();
+		const beforeRows = (await sql`
+			SELECT connector_key, credential_mode, status, config, display_name
+			FROM connections
+			WHERE organization_id = ${workspace.org.id} AND slug = ${install.id}
+			LIMIT 1
+		`) as Array<{
+			connector_key: string;
+			credential_mode: string;
+			status: string;
+			config: Record<string, unknown>;
+			display_name: string | null;
+		}>;
+		expect(beforeRows).toHaveLength(1);
+		expect(beforeRows[0].credential_mode).toBe("managed");
+		const beforeInstall = await getSlackInstallById(
+			installationStore,
+			install.id,
+		);
+		expect(beforeInstall).not.toBeNull();
+		const beforeToken = await orgContext.run(
+			{ organizationId: workspace.org.id },
+			() => resolveSecretValue(secretStore, beforeInstall?.config.botToken),
+		);
+
+		let rejection: unknown;
+		try {
+			await upsertByoChatConnection({
+				organizationId: workspace.org.id,
+				platform: "slack",
+				stableId: install.id,
+				displayName: "Attacker BYO",
+				config: {
+					botToken: "xoxb-byo-attacker",
+					signingSecret: "byo-attacker-signing-secret",
+				},
+			});
+		} catch (error) {
+			rejection = error;
+		}
+		expect(rejection).toBeInstanceOf(Error);
+		expect((rejection as Error).message).toMatch(
+			/reserved for managed Slack installations/,
+		);
+
+		const afterRows = (await sql`
+			SELECT connector_key, credential_mode, status, config, display_name
+			FROM connections
+			WHERE organization_id = ${workspace.org.id} AND slug = ${install.id}
+			LIMIT 1
+		`) as typeof beforeRows;
+		expect(afterRows).toEqual(beforeRows);
+
+		const afterInstall = await getSlackInstallById(
+			installationStore,
+			install.id,
+		);
+		expect(afterInstall).toEqual(beforeInstall);
+		const afterToken = await orgContext.run(
+			{ organizationId: workspace.org.id },
+			() => resolveSecretValue(secretStore, afterInstall?.config.botToken),
+		);
+		expect(afterToken).toBe(beforeToken);
+		expect(afterToken).toBe("xoxb-managed-original");
+	});
+});

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -5,6 +5,7 @@ import {
 	slugToRuntimeConnectionId,
 } from "../../lobu/stores/connections-projection.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
+import { SLACK_INSTALLATION_ID_PREFIX } from "../../lobu/stores/slack-installations.js";
 import { PlatformAdapterConfigSchema } from "../routes/schemas/platform-config.js";
 import { isAdapterlessPlatform } from "./chat-instance-manager.js";
 import { getPlatformDescriptor } from "./platforms/index.js";
@@ -169,6 +170,11 @@ export async function upsertByoChatConnection(
 	created: boolean;
 	changed: boolean;
 }> {
+	if (input.stableId.startsWith(SLACK_INSTALLATION_ID_PREFIX)) {
+		throw new Error(
+			`Stable ID ${input.stableId} is reserved for managed Slack installations`,
+		);
+	}
 	return withStableChatLock(input.organizationId, input.stableId, async () => {
 		const sql = getDb();
 		const slug = runtimeConnectionIdToSlug(input.stableId);


### PR DESCRIPTION
## Summary

- reject BYO chat declarations using the managed Slack `slackinst-*` namespace
- fail before credential parsing, locking, persistence, or runtime-manager calls
- prove the managed connection projection, installation record, and token remain unchanged

## Root cause

`upsertByoChatConnection` searched only BYO rows, so a managed row with the same runtime slug was invisible and the BYO writer could overwrite its projection.

## Validation

- red: regression received `Chat connection manager unavailable` instead of the reserved-namespace rejection
- green: focused Postgres integration test passes after rebasing onto current `main`
- `bun run typecheck` passes
- Claude Fable review: bug-free 90, simplicity 95, zero bugs/blockers
- all GitHub checks passed, including integration and `check-drift`

Closes #1842.