### PR TITLE
fix: keep agent history available on replay errors

### DIFF
--- a/packages/agent-worker/src/openclaw/session-runner.ts
+++ b/packages/agent-worker/src/openclaw/session-runner.ts
@@ -518,9 +518,10 @@ interface RunAISessionParams {
    */
   onSessionFilePathResolved: (sessionFilePath: string) => void;
   /**
-   * Called as soon as the model ref is resolved to a (provider, modelId) pair
-   * so the worker can tag Sentry captures with which provider/model a later
-   * failure belongs to. Fires before any provider call can fail.
+   * Called as soon as the model ref is resolved to a
+   * (provider, modelId, providerSlug) triple so the worker can tag Sentry
+   * captures with which provider/model a later failure belongs to. Fires before
+   * any provider call can fail.
    */
   onModelResolved: (
     provider: string,

--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -353,6 +353,73 @@ describe("agent history routes", () => {
 		).toBe(false);
 	});
 
+	test("returns transcript messages when supplemental error history is malformed", async () => {
+		setAuthProvider(() => ({
+			userId: USER_ID,
+			platform: "external",
+			exp: Date.now() + 60_000,
+		}));
+
+		const agentId = "agent-1";
+		const threadId = "thread-malformed-error";
+		const conversationId = buildApiConversationId({
+			agentId,
+			userId: USER_ID,
+			organizationId: ORG_ID,
+			threadId,
+		});
+		const jsonl =
+			`{"type":"session","version":3,"id":"s-malformed","timestamp":"2026-07-11T00:00:00Z","cwd":"/w"}\n` +
+			`{"type":"message","id":"u-malformed","parentId":null,"timestamp":"2026-07-11T00:00:01Z","message":{"role":"user","content":[{"type":"text","text":"Keep this message"}]}}\n`;
+		const snapshotRunId = await insertRun({
+			organizationId: ORG_ID,
+			agentId,
+			conversationId,
+		});
+		const sql = getDb();
+		await sql`
+			INSERT INTO public.agent_transcript_snapshot
+				(organization_id, agent_id, conversation_id, run_id,
+				 snapshot_jsonl, byte_size, terminal_status)
+			VALUES
+				(${ORG_ID}, ${agentId}, ${conversationId}, ${snapshotRunId},
+				 ${jsonl}, ${Buffer.byteLength(jsonl, "utf-8")}, 'completed')
+		`;
+
+		// The history query supports legacy JSON-encoded strings. This scalar is
+		// valid jsonb but invalid when decoded and cast back to jsonb, so only the
+		// supplementary agent-error lookup fails.
+		await sql`
+			INSERT INTO public.runs (
+				organization_id, run_type, status, action_input,
+				queue_name, run_at, created_at
+			) VALUES (
+				${ORG_ID},
+				'chat_message',
+				'completed',
+				${sql.json("not-json")},
+				'thread_response',
+				NOW(),
+				NOW()
+			)
+		`;
+
+		const response = await orgContext.run({ organizationId: ORG_ID }, () =>
+			createApp().request(
+				`/api/v1/agents/${agentId}/history/threads/${threadId}/messages`,
+				{ method: "GET", headers: { host: "localhost" } },
+			),
+		);
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			messages: Array<{ id: string }>;
+			interactions: Array<unknown>;
+		};
+		expect(body.messages.map((message) => message.id)).toEqual(["u-malformed"]);
+		expect(body.interactions).toEqual([]);
+	});
+
 	test("rejects sessions that do not own the requested agent", async () => {
 		setAuthProvider(() => ({
 			userId: "u2",

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -92,71 +92,88 @@ type HistoryInteraction =
 	| ToolApprovalHistoryInteraction
 	| AgentErrorHistoryInteraction;
 
+/**
+ * Rehydrate the latest non-silent terminal agent error for a conversation.
+ * This interaction is supplemental to transcript history, so storage or legacy
+ * payload parsing failures log and degrade to no interaction instead of
+ * failing the messages endpoint.
+ */
 async function readLatestAgentErrorInteraction(
 	organizationId: string,
 	conversationId: string,
 ): Promise<AgentErrorHistoryInteraction | null> {
-	const rows = await getDb()<{
-		id: number;
-		payload: Record<string, unknown> | null;
-	}>`
-		WITH response_rows AS (
-			SELECT id,
-			       CASE
-			         WHEN jsonb_typeof(action_input) = 'string'
-			           THEN (action_input #>> '{}')::jsonb
-			         ELSE action_input
-			       END AS payload
-			FROM public.runs
-			WHERE organization_id = ${organizationId}
-			  AND run_type = 'chat_message'
-			  AND queue_name = 'thread_response'
-			  AND status IN ('pending', 'completed', 'failed')
-			  AND action_input IS NOT NULL
-		)
-		SELECT id, payload
-		FROM response_rows
-		WHERE payload->>'conversationId' = ${conversationId}
-		  AND (payload ? 'error' OR payload ? 'processedMessageIds')
-		ORDER BY id DESC
-		LIMIT 1
-	`;
-	const row = rows[0];
-	if (!row?.payload || typeof row.payload !== "object") return null;
+	try {
+		const rows = await getDb()<{
+			id: number;
+			payload: Record<string, unknown> | null;
+		}>`
+			WITH response_rows AS (
+				SELECT id,
+				       CASE
+				         WHEN jsonb_typeof(action_input) = 'string'
+				           THEN (action_input #>> '{}')::jsonb
+				         ELSE action_input
+				       END AS payload
+				FROM public.runs
+				WHERE organization_id = ${organizationId}
+				  AND run_type = 'chat_message'
+				  AND queue_name = 'thread_response'
+				  AND status IN ('pending', 'completed', 'failed')
+				  AND action_input IS NOT NULL
+			)
+			SELECT id, payload
+			FROM response_rows
+			WHERE payload->>'conversationId' = ${conversationId}
+			  AND (payload ? 'error' OR payload ? 'processedMessageIds')
+			ORDER BY id DESC
+			LIMIT 1
+		`;
+		const row = rows[0];
+		if (!row?.payload || typeof row.payload !== "object") return null;
 
-	// A newer successful terminal row supersedes any older error for the thread.
-	if (typeof row.payload.error !== "string") return null;
-	const code = toAgentErrorCode(row.payload.errorCode);
-	const spec = code ? AGENT_ERRORS[code] : undefined;
-	if (spec?.silent) return null;
-	const error = spec?.message ?? row.payload.error;
-	if (!error) return null;
+		// A newer successful terminal row supersedes any older error for the thread.
+		if (typeof row.payload.error !== "string") return null;
+		const code = toAgentErrorCode(row.payload.errorCode);
+		const spec = code ? AGENT_ERRORS[code] : undefined;
+		if (spec?.silent) return null;
+		const error = spec?.message ?? row.payload.error;
+		if (!error) return null;
 
-	const rawContext =
-		row.payload.errorContext &&
-		typeof row.payload.errorContext === "object" &&
-		!Array.isArray(row.payload.errorContext)
-			? (row.payload.errorContext as Record<string, unknown>)
-			: null;
-	const provider =
-		typeof rawContext?.provider === "string" ? rawContext.provider : undefined;
-	const model =
-		typeof rawContext?.model === "string" ? rawContext.model : undefined;
-	const errorContext =
-		provider || model
-			? {
-					...(provider ? { provider } : {}),
-					...(model ? { model } : {}),
-				}
-			: null;
+		const rawContext =
+			row.payload.errorContext &&
+			typeof row.payload.errorContext === "object" &&
+			!Array.isArray(row.payload.errorContext)
+				? (row.payload.errorContext as Record<string, unknown>)
+				: null;
+		const provider =
+			typeof rawContext?.provider === "string"
+				? rawContext.provider
+				: undefined;
+		const model =
+			typeof rawContext?.model === "string" ? rawContext.model : undefined;
+		const errorContext =
+			provider || model
+				? {
+						...(provider ? { provider } : {}),
+						...(model ? { model } : {}),
+					}
+				: null;
 
-	return {
-		type: "agent-error",
-		runId: Number(row.id),
-		error,
-		errorCode: code ?? null,
-		errorContext,
-	};
+		return {
+			type: "agent-error",
+			runId: Number(row.id),
+			error,
+			errorCode: code ?? null,
+			errorContext,
+		};
+	} catch (error) {
+		logger.warn("Failed to read latest agent error interaction", {
+			error,
+			organizationId,
+			conversationId,
+		});
+		return null;
+	}
 }
 
 // Tokenless artifact references persisted in the transcript by the message-send


### PR DESCRIPTION
## Summary

- keep transcript history available when supplemental agent-error reconstruction hits a database or malformed legacy-payload failure
- log the degraded supplemental lookup and return no synthetic error interaction
- add a PostgreSQL regression covering the malformed legacy JSON scalar
- correct the model-resolution callback documentation to describe its three arguments

## Validation

- red before fix: malformed supplemental history returned HTTP 500 with PostgreSQL `22P02`
- green after fix: `bun test --timeout 30000 packages/server/src/gateway/__tests__/agent-history-routes.test.ts` — 8 passed, 0 failed
- `make build-packages` — passed
- `make review` — typecheck=0, unit=0, integration=0
- Fable review of exact rebased SHA `f00d8513a` — pass (95%), no blockers
- Codex review of exact rebased SHA `f00d8513a` — pass, no blockers

The related browser-bundle fix is already merged in Owletto #482 and pinned on Lobu main by #1856.