### PR TITLE
feat(cli): config-less infra commands — providers, environments, clients

### DIFF
--- a/packages/cli/src/commands/__tests__/infra-commands.test.ts
+++ b/packages/cli/src/commands/__tests__/infra-commands.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Route-contract tests for the config-less infra commands: assert each command
+ * hits the right path with the right body/query, with the network mocked at
+ * `resolveApiClient` (same seam whoami.test.ts uses).
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import * as providersInternal from "../../internal/index.js";
+import { clientsListCommand, clientsRevokeCommand } from "../clients.js";
+import {
+  environmentCreateCommand,
+  environmentSetCredentialCommand,
+} from "../environment.js";
+import {
+  providersCreateCommand,
+  providersListCommand,
+  providersSetCapabilityCommand,
+} from "../providers/manage.js";
+
+interface RecordedCall {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+let calls: RecordedCall[];
+let responses: unknown[];
+
+/** Minimal ApiClient stand-in: records every call, replays queued responses. */
+function fakeClient() {
+  const next = () => (responses.length > 0 ? responses.shift() : {});
+  return {
+    get: async (path: string) => {
+      calls.push({ method: "GET", path });
+      return next();
+    },
+    post: async (path: string, body?: unknown) => {
+      calls.push({ method: "POST", path, body });
+      return next();
+    },
+    patch: async (path: string, body?: unknown) => {
+      calls.push({ method: "PATCH", path, body });
+      return next();
+    },
+    delete: async (path: string) => {
+      calls.push({ method: "DELETE", path });
+      return next();
+    },
+    request: async (method: string, path: string, body?: unknown) => {
+      calls.push({ method, path, body });
+      return next();
+    },
+  };
+}
+
+beforeEach(() => {
+  calls = [];
+  responses = [];
+  spyOn(providersInternal, "resolveApiClient").mockImplementation(
+    async () =>
+      ({
+        client: fakeClient(),
+        contextName: "test",
+        apiBaseUrl: "https://api.test",
+        orgSlug: "testorg",
+        token: "tok",
+      }) as never
+  );
+  spyOn(process.stdout, "write").mockImplementation(() => true);
+  spyOn(console, "log").mockImplementation(() => undefined);
+  spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  mock.restore();
+  delete process.env.LOBU_TEST_PROVIDER_KEY;
+});
+
+describe("providers", () => {
+  test("list hits the org inference-providers route", async () => {
+    responses = [{ providers: [] }];
+    await providersListCommand({ json: true });
+    expect(calls).toEqual([
+      { method: "GET", path: "/api/testorg/agents/inference-providers" },
+    ]);
+  });
+
+  test("create resolves $VAR key, merges --model, and sets default", async () => {
+    process.env.LOBU_TEST_PROVIDER_KEY = "sk-resolved";
+    responses = [{ provider: { slug: "z-ai" } }, {}];
+    await providersCreateCommand("z-ai", {
+      kind: "z-ai",
+      key: "$LOBU_TEST_PROVIDER_KEY",
+      model: "glm-5.2",
+      default: true,
+      json: true,
+    });
+    expect(calls[0]).toEqual({
+      method: "POST",
+      path: "/api/testorg/agents/inference-providers",
+      body: {
+        slug: "z-ai",
+        kind: "z-ai",
+        apiKey: "sk-resolved",
+        capabilities: { text: { model: "glm-5.2" } },
+      },
+    });
+    expect(calls[1]).toEqual({
+      method: "PUT",
+      path: "/api/testorg/agents/inference-providers/z-ai/default",
+      body: undefined,
+    });
+  });
+
+  test("set-capability sends the block for one modality", async () => {
+    await providersSetCapabilityCommand("z-ai", "text", {
+      model: "glm-5.2",
+      baseUrl: "https://api.z.ai/v1",
+    });
+    expect(calls).toEqual([
+      {
+        method: "PUT",
+        path: "/api/testorg/agents/inference-providers/z-ai/capabilities/text",
+        body: { block: { model: "glm-5.2", base_url: "https://api.z.ai/v1" } },
+      },
+    ]);
+  });
+});
+
+describe("environment", () => {
+  test("create sends snake-case provider_kind and parsed credential", async () => {
+    responses = [{ environment: { id: "env_1", name: "prod" } }];
+    await environmentCreateCommand("prod", {
+      provider: "vercel",
+      scope: "org",
+      credential: ["token=tok-1", "teamId=team_1"],
+      json: true,
+    });
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: "/api/testorg/environments",
+        body: {
+          name: "prod",
+          provider_kind: "vercel",
+          scope: "org",
+          credential: { token: "tok-1", teamId: "team_1" },
+        },
+      },
+    ]);
+  });
+
+  test("set-credential PUTs to the credential route", async () => {
+    await environmentSetCredentialCommand("env_1", {
+      credential: ["token=tok-2"],
+    });
+    expect(calls).toEqual([
+      {
+        method: "PUT",
+        path: "/api/testorg/environments/env_1/credential",
+        body: { credential: { token: "tok-2" } },
+      },
+    ]);
+  });
+});
+
+describe("clients", () => {
+  test("list encodes the agent filter", async () => {
+    responses = [{ clients: [] }];
+    await clientsListCommand({ agent: "my/agent", json: true });
+    expect(calls).toEqual([
+      { method: "GET", path: "/api/testorg/clients?agentId=my%2Fagent" },
+    ]);
+  });
+
+  test("revoke deletes the mcp client and requires --yes", async () => {
+    await clientsRevokeCommand("mcp_client_1", { yes: true });
+    expect(calls).toEqual([
+      { method: "DELETE", path: "/api/testorg/clients/mcp/mcp_client_1" },
+    ]);
+
+    // Without --yes: refuses before any network call.
+    calls = [];
+    const exitSpy = spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("exit");
+    }) as never);
+    await expect(clientsRevokeCommand("mcp_client_1", {})).rejects.toThrow(
+      "exit"
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/__tests__/infra-commands.test.ts
+++ b/packages/cli/src/commands/__tests__/infra-commands.test.ts
@@ -13,16 +13,23 @@ import {
   spyOn,
   test,
 } from "bun:test";
-import * as providersInternal from "../../internal/index.js";
+import * as internal from "../../internal/index.js";
 import { clientsListCommand, clientsRevokeCommand } from "../clients.js";
 import {
   environmentCreateCommand,
+  environmentDeleteCommand,
+  environmentListCommand,
   environmentSetCredentialCommand,
 } from "../environment.js";
 import {
+  providersCatalogCommand,
   providersCreateCommand,
+  providersDeleteCommand,
   providersListCommand,
   providersSetCapabilityCommand,
+  providersSetDefaultCommand,
+  providersSetKeyCommand,
+  providersUpdateCommand,
 } from "../providers/manage.js";
 
 interface RecordedCall {
@@ -33,30 +40,39 @@ interface RecordedCall {
 
 let calls: RecordedCall[];
 let responses: unknown[];
+let logLines: string[];
+let errorLines: string[];
+/** When set, the fake client throws for any call whose path ends with this. */
+let failPathSuffix: string | null;
 
 /** Minimal ApiClient stand-in: records every call, replays queued responses. */
 function fakeClient() {
-  const next = () => (responses.length > 0 ? responses.shift() : {});
+  const next = (path: string) => {
+    if (failPathSuffix && path.endsWith(failPathSuffix)) {
+      throw new Error(`simulated failure: ${path}`);
+    }
+    return responses.length > 0 ? responses.shift() : {};
+  };
   return {
     get: async (path: string) => {
       calls.push({ method: "GET", path });
-      return next();
+      return next(path);
     },
     post: async (path: string, body?: unknown) => {
       calls.push({ method: "POST", path, body });
-      return next();
+      return next(path);
     },
     patch: async (path: string, body?: unknown) => {
       calls.push({ method: "PATCH", path, body });
-      return next();
+      return next(path);
     },
     delete: async (path: string) => {
       calls.push({ method: "DELETE", path });
-      return next();
+      return next(path);
     },
     request: async (method: string, path: string, body?: unknown) => {
       calls.push({ method, path, body });
-      return next();
+      return next(path);
     },
   };
 }
@@ -64,7 +80,10 @@ function fakeClient() {
 beforeEach(() => {
   calls = [];
   responses = [];
-  spyOn(providersInternal, "resolveApiClient").mockImplementation(
+  logLines = [];
+  errorLines = [];
+  failPathSuffix = null;
+  spyOn(internal, "resolveApiClient").mockImplementation(
     async () =>
       ({
         client: fakeClient(),
@@ -75,14 +94,29 @@ beforeEach(() => {
       }) as never
   );
   spyOn(process.stdout, "write").mockImplementation(() => true);
-  spyOn(console, "log").mockImplementation(() => undefined);
-  spyOn(console, "error").mockImplementation(() => undefined);
+  spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    logLines.push(args.map(String).join(" "));
+  });
+  spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+    errorLines.push(args.map(String).join(" "));
+  });
 });
 
 afterEach(() => {
   mock.restore();
   delete process.env.LOBU_TEST_PROVIDER_KEY;
 });
+
+/** Guarded delete-style commands: assert refusal without --yes (no network). */
+async function expectYesGuard(run: () => Promise<void>): Promise<void> {
+  const exitSpy = spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("exit");
+  }) as never);
+  await expect(run()).rejects.toThrow("exit");
+  expect(exitSpy).toHaveBeenCalledWith(1);
+  expect(calls).toEqual([]);
+  exitSpy.mockRestore();
+}
 
 describe("providers", () => {
   test("list hits the org inference-providers route", async () => {
@@ -91,6 +125,40 @@ describe("providers", () => {
     expect(calls).toEqual([
       { method: "GET", path: "/api/testorg/agents/inference-providers" },
     ]);
+  });
+
+  test("catalog fetches /catalog and renders auth by supportedAuthTypes", async () => {
+    responses = [
+      {
+        catalog: [
+          {
+            slug: "claude",
+            displayName: "Claude",
+            authType: "oauth",
+            supportedAuthTypes: ["oauth", "api-key"],
+            defaultModel: null,
+          },
+          {
+            slug: "sub-only",
+            displayName: "Sub Only",
+            authType: "oauth",
+            supportedAuthTypes: ["oauth"],
+            defaultModel: null,
+          },
+        ],
+      },
+    ];
+    await providersCatalogCommand({});
+    expect(calls).toEqual([
+      {
+        method: "GET",
+        path: "/api/testorg/agents/inference-providers/catalog",
+      },
+    ]);
+    const claudeLine = logLines.find((l) => l.includes("claude"));
+    const subOnlyLine = logLines.find((l) => l.includes("sub-only"));
+    expect(claudeLine).toContain("api key or web sign-in");
+    expect(subOnlyLine).toContain("sign-in via web console");
   });
 
   test("create resolves $VAR key, merges --model, and sets default", async () => {
@@ -120,6 +188,52 @@ describe("providers", () => {
     });
   });
 
+  test("create --default reports partial success when the default PUT fails", async () => {
+    responses = [{ provider: { slug: "p1" } }];
+    failPathSuffix = "/p1/default";
+    await expect(
+      providersCreateCommand("p1", {
+        kind: "openai",
+        key: "sk-literal",
+        default: true,
+      })
+    ).rejects.toThrow("simulated failure");
+    // The provider row exists — the operator must learn create succeeded.
+    expect(errorLines.join("\n")).toContain("was created");
+    expect(errorLines.join("\n")).toContain("lobu providers set-default p1");
+  });
+
+  test("update trims the name and PUTs displayName", async () => {
+    responses = [{ provider: { slug: "z-ai" } }];
+    await providersUpdateCommand("z-ai", { name: "  Z AI  ", json: true });
+    expect(calls).toEqual([
+      {
+        method: "PUT",
+        path: "/api/testorg/agents/inference-providers/z-ai",
+        body: { displayName: "Z AI" },
+      },
+    ]);
+  });
+
+  test("update rejects a blank name before any network call", async () => {
+    await expect(
+      providersUpdateCommand("z-ai", { name: "   " })
+    ).rejects.toThrow("--name must not be blank");
+    expect(calls).toEqual([]);
+  });
+
+  test("set-key rotates via /key with a resolved $VAR value", async () => {
+    process.env.LOBU_TEST_PROVIDER_KEY = "sk-rotated";
+    await providersSetKeyCommand("z-ai", { key: "$LOBU_TEST_PROVIDER_KEY" });
+    expect(calls).toEqual([
+      {
+        method: "PUT",
+        path: "/api/testorg/agents/inference-providers/z-ai/key",
+        body: { value: "sk-rotated" },
+      },
+    ]);
+  });
+
   test("set-capability sends the block for one modality", async () => {
     await providersSetCapabilityCommand("z-ai", "text", {
       model: "glm-5.2",
@@ -133,9 +247,41 @@ describe("providers", () => {
       },
     ]);
   });
+
+  test("set-default PUTs /default", async () => {
+    await providersSetDefaultCommand("z-ai", {});
+    expect(calls).toEqual([
+      {
+        method: "PUT",
+        path: "/api/testorg/agents/inference-providers/z-ai/default",
+        body: undefined,
+      },
+    ]);
+  });
+
+  test("delete requires --yes, then DELETEs", async () => {
+    await expectYesGuard(() => providersDeleteCommand("z-ai", {}));
+    await providersDeleteCommand("z-ai", { yes: true });
+    expect(calls).toEqual([
+      {
+        method: "DELETE",
+        path: "/api/testorg/agents/inference-providers/z-ai",
+      },
+    ]);
+  });
 });
 
 describe("environment", () => {
+  test("list hits the environments route", async () => {
+    responses = [
+      { builtin: { id: "builtin" }, environments: [], availableProviders: [] },
+    ];
+    await environmentListCommand({ json: true });
+    expect(calls).toEqual([
+      { method: "GET", path: "/api/testorg/environments" },
+    ]);
+  });
+
   test("create sends snake-case provider_kind and parsed credential", async () => {
     responses = [{ environment: { id: "env_1", name: "prod" } }];
     await environmentCreateCommand("prod", {
@@ -170,6 +316,14 @@ describe("environment", () => {
       },
     ]);
   });
+
+  test("delete requires --yes, then DELETEs", async () => {
+    await expectYesGuard(() => environmentDeleteCommand("env_1", {}));
+    await environmentDeleteCommand("env_1", { yes: true });
+    expect(calls).toEqual([
+      { method: "DELETE", path: "/api/testorg/environments/env_1" },
+    ]);
+  });
 });
 
 describe("clients", () => {
@@ -181,21 +335,11 @@ describe("clients", () => {
     ]);
   });
 
-  test("revoke deletes the mcp client and requires --yes", async () => {
+  test("revoke requires --yes, then DELETEs the mcp client", async () => {
+    await expectYesGuard(() => clientsRevokeCommand("mcp_client_1", {}));
     await clientsRevokeCommand("mcp_client_1", { yes: true });
     expect(calls).toEqual([
       { method: "DELETE", path: "/api/testorg/clients/mcp/mcp_client_1" },
     ]);
-
-    // Without --yes: refuses before any network call.
-    calls = [];
-    const exitSpy = spyOn(process, "exit").mockImplementation((() => {
-      throw new Error("exit");
-    }) as never);
-    await expect(clientsRevokeCommand("mcp_client_1", {})).rejects.toThrow(
-      "exit"
-    );
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(calls).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/_lib/__tests__/secret-value.test.ts
+++ b/packages/cli/src/commands/_lib/__tests__/secret-value.test.ts
@@ -67,8 +67,13 @@ describe("parseKeyValueEntries", () => {
   });
 
   test("never echoes entry content in errors — not even the key part", () => {
-    // A pasted secret can land on either side of the `=`.
-    for (const entry of ["sk-live-oops", "sk-live-oops=", "=sk-live-oops"]) {
+    // A pasted secret can land on either side of the `=`, or after a `$`.
+    for (const entry of [
+      "sk-live-oops",
+      "sk-live-oops=",
+      "=sk-live-oops",
+      "token=$sk-live-oops",
+    ]) {
       let message = "";
       try {
         parseKeyValueEntries([entry], "--credential");
@@ -79,5 +84,13 @@ describe("parseKeyValueEntries", () => {
       expect(message).not.toContain("sk-live-oops");
       expect(message).toContain("entry #1");
     }
+  });
+
+  test("unset $VAR errors name the variable only for valid identifiers", () => {
+    // A real env-var NAME is an identifier the user typed as a reference —
+    // naming it is safe and useful.
+    expect(() =>
+      parseKeyValueEntries(["token=$LOBU_TEST_UNSET_VAR"], "--credential")
+    ).toThrow("$LOBU_TEST_UNSET_VAR");
   });
 });

--- a/packages/cli/src/commands/_lib/__tests__/secret-value.test.ts
+++ b/packages/cli/src/commands/_lib/__tests__/secret-value.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { parseKeyValueEntries, resolveSecretFlag } from "../secret-value.js";
+
+const ENV_KEYS = ["LOBU_TEST_SECRET", "LOBU_TEST_TOKEN"];
+
+afterEach(() => {
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+describe("resolveSecretFlag", () => {
+  test("passes a literal value through", () => {
+    expect(resolveSecretFlag("sk-live-123", "--key")).toBe("sk-live-123");
+  });
+
+  test("resolves a $VAR reference from the environment", () => {
+    process.env.LOBU_TEST_SECRET = "resolved-value";
+    expect(resolveSecretFlag("$LOBU_TEST_SECRET", "--key")).toBe(
+      "resolved-value"
+    );
+  });
+
+  test("trims whitespace on both literal and resolved values", () => {
+    process.env.LOBU_TEST_SECRET = "  padded  ";
+    expect(resolveSecretFlag("$LOBU_TEST_SECRET", "--key")).toBe("padded");
+    expect(resolveSecretFlag("  literal  ", "--key")).toBe("literal");
+  });
+
+  test("throws when the referenced env var is unset", () => {
+    expect(() => resolveSecretFlag("$LOBU_TEST_SECRET", "--key")).toThrow(
+      "$LOBU_TEST_SECRET"
+    );
+  });
+
+  test("throws on an empty value and a bare $", () => {
+    expect(() => resolveSecretFlag("", "--key")).toThrow("--key");
+    expect(() => resolveSecretFlag("$", "--key")).toThrow("--key");
+  });
+});
+
+describe("parseKeyValueEntries", () => {
+  test("parses key=value entries into a record", () => {
+    expect(
+      parseKeyValueEntries(["token=abc", "teamId=team_1"], "--credential")
+    ).toEqual({ token: "abc", teamId: "team_1" });
+  });
+
+  test("resolves $VAR values from the environment", () => {
+    process.env.LOBU_TEST_TOKEN = "tok-999";
+    expect(
+      parseKeyValueEntries(["token=$LOBU_TEST_TOKEN"], "--credential")
+    ).toEqual({ token: "tok-999" });
+  });
+
+  test("keeps = characters inside the value", () => {
+    expect(parseKeyValueEntries(["query=a=b"], "--credential")).toEqual({
+      query: "a=b",
+    });
+  });
+
+  test("rejects entries without a key or =", () => {
+    expect(() => parseKeyValueEntries(["no-equals"], "--credential")).toThrow(
+      "key=value"
+    );
+    expect(() => parseKeyValueEntries(["=value"], "--credential")).toThrow(
+      "key=value"
+    );
+  });
+});

--- a/packages/cli/src/commands/_lib/__tests__/secret-value.test.ts
+++ b/packages/cli/src/commands/_lib/__tests__/secret-value.test.ts
@@ -65,4 +65,19 @@ describe("parseKeyValueEntries", () => {
       "key=value"
     );
   });
+
+  test("never echoes entry content in errors — not even the key part", () => {
+    // A pasted secret can land on either side of the `=`.
+    for (const entry of ["sk-live-oops", "sk-live-oops=", "=sk-live-oops"]) {
+      let message = "";
+      try {
+        parseKeyValueEntries([entry], "--credential");
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+      expect(message).not.toBe("");
+      expect(message).not.toContain("sk-live-oops");
+      expect(message).toContain("entry #1");
+    }
+  });
 });

--- a/packages/cli/src/commands/_lib/cloud-options.ts
+++ b/packages/cli/src/commands/_lib/cloud-options.ts
@@ -1,0 +1,9 @@
+/**
+ * Options shared by every cloud subcommand registered through
+ * `withCommonOpts` — one shape, not a per-command-group copy.
+ */
+export interface CloudCommandOptions {
+  context?: string;
+  org?: string;
+  json?: boolean;
+}

--- a/packages/cli/src/commands/_lib/secret-value.ts
+++ b/packages/cli/src/commands/_lib/secret-value.ts
@@ -31,9 +31,9 @@ export function resolveSecretFlag(raw: string, flagName: string): string {
 /**
  * Parse repeatable `key=value` flag entries into a record. Values follow the
  * `$VAR` convention above, so `--credential 'token=$VERCEL_TOKEN'` reads the
- * env var instead of putting the token on the command line. Malformed-entry
- * errors deliberately do NOT echo the entry — a pasted bare secret must not
- * end up on stderr.
+ * env var instead of putting the token on the command line. Errors reference
+ * entries only by index, never by content — a mistakenly pasted secret must
+ * not end up on stderr, and even the "key" part can be one (`sk-live-…=`).
  */
 export function parseKeyValueEntries(
   entries: string[],
@@ -41,14 +41,13 @@ export function parseKeyValueEntries(
 ): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [index, entry] of entries.entries()) {
+    const label = `${flagName} entry #${index + 1}`;
     const eq = entry.indexOf("=");
     const key = eq > 0 ? entry.slice(0, eq).trim() : "";
     if (!key) {
-      throw new Error(
-        `${flagName} entry #${index + 1} must be key=value (value not shown).`
-      );
+      throw new Error(`${label} must be key=value (value not shown).`);
     }
-    out[key] = resolveSecretFlag(entry.slice(eq + 1), `${flagName} ${key}`);
+    out[key] = resolveSecretFlag(entry.slice(eq + 1), label);
   }
   return out;
 }

--- a/packages/cli/src/commands/_lib/secret-value.ts
+++ b/packages/cli/src/commands/_lib/secret-value.ts
@@ -3,7 +3,9 @@
  *
  * Follows the same convention as `lobu apply` config (`secret()` / `$VAR`):
  * a value starting with `$` names an environment variable resolved at call
- * time, so real secrets never land in shell history or process listings.
+ * time. The reference must be single-quoted on the command line
+ * (`--key '$MY_KEY'`) — unquoted, the shell expands it before the CLI runs
+ * and the real secret lands in argv anyway.
  */
 
 /** Resolve a flag value that may be a `$VAR` environment reference. */
@@ -28,25 +30,25 @@ export function resolveSecretFlag(raw: string, flagName: string): string {
 
 /**
  * Parse repeatable `key=value` flag entries into a record. Values follow the
- * `$VAR` convention above, so `--credential token=$VERCEL_TOKEN` reads the
- * env var instead of putting the token on the command line.
+ * `$VAR` convention above, so `--credential 'token=$VERCEL_TOKEN'` reads the
+ * env var instead of putting the token on the command line. Malformed-entry
+ * errors deliberately do NOT echo the entry — a pasted bare secret must not
+ * end up on stderr.
  */
 export function parseKeyValueEntries(
   entries: string[],
   flagName: string
 ): Record<string, string> {
   const out: Record<string, string> = {};
-  for (const entry of entries) {
+  for (const [index, entry] of entries.entries()) {
     const eq = entry.indexOf("=");
-    if (eq <= 0) {
-      throw new Error(`${flagName} entries must be key=value, got "${entry}".`);
-    }
-    const key = entry.slice(0, eq).trim();
-    const rawValue = entry.slice(eq + 1);
+    const key = eq > 0 ? entry.slice(0, eq).trim() : "";
     if (!key) {
-      throw new Error(`${flagName} entries must be key=value, got "${entry}".`);
+      throw new Error(
+        `${flagName} entry #${index + 1} must be key=value (value not shown).`
+      );
     }
-    out[key] = resolveSecretFlag(rawValue, `${flagName} ${key}`);
+    out[key] = resolveSecretFlag(entry.slice(eq + 1), `${flagName} ${key}`);
   }
   return out;
 }

--- a/packages/cli/src/commands/_lib/secret-value.ts
+++ b/packages/cli/src/commands/_lib/secret-value.ts
@@ -1,0 +1,52 @@
+/**
+ * Secret-bearing flag values for imperative infra commands.
+ *
+ * Follows the same convention as `lobu apply` config (`secret()` / `$VAR`):
+ * a value starting with `$` names an environment variable resolved at call
+ * time, so real secrets never land in shell history or process listings.
+ */
+
+/** Resolve a flag value that may be a `$VAR` environment reference. */
+export function resolveSecretFlag(raw: string, flagName: string): string {
+  const value = raw.trim();
+  if (!value) {
+    throw new Error(`${flagName} must not be empty.`);
+  }
+  if (!value.startsWith("$")) return value;
+  const name = value.slice(1);
+  if (!name) {
+    throw new Error(`${flagName} is "$" with no variable name.`);
+  }
+  const resolved = process.env[name];
+  if (!resolved?.trim()) {
+    throw new Error(
+      `${flagName} references $${name}, but that environment variable is not set.`
+    );
+  }
+  return resolved.trim();
+}
+
+/**
+ * Parse repeatable `key=value` flag entries into a record. Values follow the
+ * `$VAR` convention above, so `--credential token=$VERCEL_TOKEN` reads the
+ * env var instead of putting the token on the command line.
+ */
+export function parseKeyValueEntries(
+  entries: string[],
+  flagName: string
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const entry of entries) {
+    const eq = entry.indexOf("=");
+    if (eq <= 0) {
+      throw new Error(`${flagName} entries must be key=value, got "${entry}".`);
+    }
+    const key = entry.slice(0, eq).trim();
+    const rawValue = entry.slice(eq + 1);
+    if (!key) {
+      throw new Error(`${flagName} entries must be key=value, got "${entry}".`);
+    }
+    out[key] = resolveSecretFlag(rawValue, `${flagName} ${key}`);
+  }
+  return out;
+}

--- a/packages/cli/src/commands/_lib/secret-value.ts
+++ b/packages/cli/src/commands/_lib/secret-value.ts
@@ -8,6 +8,13 @@
  * and the real secret lands in argv anyway.
  */
 
+/**
+ * A `$`-prefixed value is only echoed back in errors when what follows is a
+ * plausible env-var NAME (an identifier). Anything else could be a pasted
+ * secret that happens to start with `$` — never put it on stderr.
+ */
+const ENV_VAR_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 /** Resolve a flag value that may be a `$VAR` environment reference. */
 export function resolveSecretFlag(raw: string, flagName: string): string {
   const value = raw.trim();
@@ -16,8 +23,10 @@ export function resolveSecretFlag(raw: string, flagName: string): string {
   }
   if (!value.startsWith("$")) return value;
   const name = value.slice(1);
-  if (!name) {
-    throw new Error(`${flagName} is "$" with no variable name.`);
+  if (!ENV_VAR_NAME.test(name)) {
+    throw new Error(
+      `${flagName} starts with "$" but is not a valid environment variable name (value not shown).`
+    );
   }
   const resolved = process.env[name];
   if (!resolved?.trim()) {

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -11,11 +11,9 @@ import { resolveApiClient } from "../internal/index.js";
 import { printJson } from "../internal/output.js";
 import { agentCountsText, fetchAgents } from "./_lib/agents-view.js";
 
-export interface AgentCommandOptions {
-  context?: string;
-  org?: string;
-  json?: boolean;
-}
+import type { CloudCommandOptions as AgentCommandOptions } from "./_lib/cloud-options.js";
+
+export type { AgentCommandOptions };
 
 export async function agentListCommand(
   options: AgentCommandOptions = {}

--- a/packages/cli/src/commands/clients.ts
+++ b/packages/cli/src/commands/clients.ts
@@ -1,0 +1,92 @@
+/**
+ * Connected-client commands over `/api/<org>/clients` — the org's MCP OAuth
+ * clients plus messaging identities. Revoke kills an MCP client's tokens and
+ * live sessions; messaging clients have no revoke (they are platform users).
+ */
+
+import chalk from "chalk";
+import { resolveApiClient } from "../internal/index.js";
+import { printJson } from "../internal/output.js";
+
+export interface ClientsCommandOptions {
+  context?: string;
+  org?: string;
+  json?: boolean;
+}
+
+interface ClientRecord {
+  id: string;
+  kind: "mcp" | "messaging";
+  title: string | null;
+  identifier: string | null;
+  platform: string | null;
+  assignedAgentId: string | null;
+  assignedAgentName: string | null;
+  status: string;
+  authState: string;
+  lastSeenAt: number | null;
+  firstParty: boolean;
+}
+
+export async function clientsListCommand(
+  options: ClientsCommandOptions & { agent?: string } = {}
+): Promise<void> {
+  const { client, orgSlug } = await resolveApiClient(options);
+  const query = options.agent
+    ? `?agentId=${encodeURIComponent(options.agent)}`
+    : "";
+  const { clients } = await client.get<{ clients: ClientRecord[] }>(
+    `/api/${orgSlug}/clients${query}`
+  );
+
+  if (options.json) {
+    printJson(clients);
+    return;
+  }
+
+  if (clients.length === 0) {
+    console.log(chalk.dim(`\n  No connected clients in org ${orgSlug}.\n`));
+    return;
+  }
+
+  console.log(chalk.bold(`\n  Connected clients in ${orgSlug}`));
+  for (const record of clients) {
+    const dot =
+      record.status === "connected" || record.status === "linked"
+        ? chalk.green("●")
+        : chalk.dim("○");
+    const title = record.title ?? record.identifier ?? record.id;
+    const platform = record.platform ? chalk.dim(` ${record.platform}`) : "";
+    const agent = record.assignedAgentName
+      ? chalk.dim(` → ${record.assignedAgentName}`)
+      : "";
+    const firstParty = record.firstParty ? chalk.dim(" [lobu]") : "";
+    const lastSeen = record.lastSeenAt
+      ? chalk.dim(`  last seen ${new Date(record.lastSeenAt).toISOString()}`)
+      : "";
+    console.log(
+      `  ${dot} ${chalk.bold(title)} ${chalk.dim(`(${record.kind})`)}${platform}${agent}${firstParty}${lastSeen}`
+    );
+    if (record.kind === "mcp") {
+      console.log(chalk.dim(`    id: ${record.id}`));
+    }
+  }
+  console.log(
+    chalk.dim("\n  Revoke an MCP client: lobu clients revoke <id> --yes\n")
+  );
+}
+
+export async function clientsRevokeCommand(
+  clientId: string,
+  options: ClientsCommandOptions & { yes?: boolean } = {}
+): Promise<void> {
+  if (!options.yes) {
+    console.error(chalk.red("\n  Refusing to revoke without --yes.\n"));
+    process.exit(1);
+  }
+  const { client, orgSlug } = await resolveApiClient(options);
+  await client.delete(
+    `/api/${orgSlug}/clients/mcp/${encodeURIComponent(clientId)}`
+  );
+  console.log(chalk.green(`\n  Revoked MCP client ${clientId}.\n`));
+}

--- a/packages/cli/src/commands/clients.ts
+++ b/packages/cli/src/commands/clients.ts
@@ -7,12 +7,7 @@
 import chalk from "chalk";
 import { resolveApiClient } from "../internal/index.js";
 import { printJson } from "../internal/output.js";
-
-export interface ClientsCommandOptions {
-  context?: string;
-  org?: string;
-  json?: boolean;
-}
+import type { CloudCommandOptions } from "./_lib/cloud-options.js";
 
 interface ClientRecord {
   id: string;
@@ -29,7 +24,7 @@ interface ClientRecord {
 }
 
 export async function clientsListCommand(
-  options: ClientsCommandOptions & { agent?: string } = {}
+  options: CloudCommandOptions & { agent?: string } = {}
 ): Promise<void> {
   const { client, orgSlug } = await resolveApiClient(options);
   const query = options.agent
@@ -78,7 +73,7 @@ export async function clientsListCommand(
 
 export async function clientsRevokeCommand(
   clientId: string,
-  options: ClientsCommandOptions & { yes?: boolean } = {}
+  options: CloudCommandOptions & { yes?: boolean } = {}
 ): Promise<void> {
   if (!options.yes) {
     console.error(chalk.red("\n  Refusing to revoke without --yes.\n"));

--- a/packages/cli/src/commands/environment.ts
+++ b/packages/cli/src/commands/environment.ts
@@ -8,13 +8,8 @@
 import chalk from "chalk";
 import { resolveApiClient } from "../internal/index.js";
 import { printJson } from "../internal/output.js";
+import type { CloudCommandOptions } from "./_lib/cloud-options.js";
 import { parseKeyValueEntries } from "./_lib/secret-value.js";
-
-export interface EnvironmentCommandOptions {
-  context?: string;
-  org?: string;
-  json?: boolean;
-}
 
 interface EnvironmentRow {
   id: string;
@@ -32,7 +27,7 @@ interface EnvironmentListResponse {
 }
 
 export async function environmentListCommand(
-  options: EnvironmentCommandOptions = {}
+  options: CloudCommandOptions = {}
 ): Promise<void> {
   const { client, orgSlug } = await resolveApiClient(options);
   const body = await client.get<EnvironmentListResponse>(
@@ -82,7 +77,7 @@ export async function environmentListCommand(
 
 export async function environmentCreateCommand(
   name: string,
-  options: EnvironmentCommandOptions & {
+  options: CloudCommandOptions & {
     provider: string;
     scope?: string;
     credential?: string[];
@@ -114,7 +109,7 @@ export async function environmentCreateCommand(
   const credentialNote = credential
     ? ""
     : chalk.dim(
-        `  Add its credential with: lobu environment set-credential ${environment.id} --credential key=$VAR\n`
+        `  Add its credential with: lobu environment set-credential ${environment.id} --credential 'key=$VAR'\n`
       );
   console.log(
     chalk.green(
@@ -125,7 +120,7 @@ export async function environmentCreateCommand(
 
 export async function environmentSetCredentialCommand(
   id: string,
-  options: EnvironmentCommandOptions & { credential: string[] }
+  options: CloudCommandOptions & { credential: string[] }
 ): Promise<void> {
   if (!options.credential?.length) {
     console.error(chalk.red("\n  Pass at least one --credential key=value.\n"));
@@ -144,7 +139,7 @@ export async function environmentSetCredentialCommand(
 
 export async function environmentDeleteCommand(
   id: string,
-  options: EnvironmentCommandOptions & { yes?: boolean } = {}
+  options: CloudCommandOptions & { yes?: boolean } = {}
 ): Promise<void> {
   if (!options.yes) {
     console.error(chalk.red("\n  Refusing to delete without --yes.\n"));

--- a/packages/cli/src/commands/environment.ts
+++ b/packages/cli/src/commands/environment.ts
@@ -1,0 +1,156 @@
+/**
+ * Sandbox environment commands over `/api/<org>/environments` — the only
+ * surface for provider-backed runtimes (environments are not part of
+ * `lobu apply`, and deletes are deliberately imperative + `--yes`-gated so a
+ * config edit can never drop a credential).
+ */
+
+import chalk from "chalk";
+import { resolveApiClient } from "../internal/index.js";
+import { printJson } from "../internal/output.js";
+import { parseKeyValueEntries } from "./_lib/secret-value.js";
+
+export interface EnvironmentCommandOptions {
+  context?: string;
+  org?: string;
+  json?: boolean;
+}
+
+interface EnvironmentRow {
+  id: string;
+  name: string;
+  providerKind: string;
+  scope?: string;
+  connected?: boolean;
+  details?: Record<string, string>;
+}
+
+interface EnvironmentListResponse {
+  builtin?: { id: string; kind: string; availableInCloud?: boolean };
+  environments: EnvironmentRow[];
+  availableProviders: string[];
+}
+
+export async function environmentListCommand(
+  options: EnvironmentCommandOptions = {}
+): Promise<void> {
+  const { client, orgSlug } = await resolveApiClient(options);
+  const body = await client.get<EnvironmentListResponse>(
+    `/api/${orgSlug}/environments`
+  );
+
+  if (options.json) {
+    printJson(body);
+    return;
+  }
+
+  console.log(chalk.bold(`\n  Environments in ${orgSlug}`));
+  if (body.builtin) {
+    console.log(
+      `  ${chalk.green("●")} ${chalk.bold("builtin")} ${chalk.dim("(local runtime)")}`
+    );
+  }
+  for (const env of body.environments) {
+    const connected = env.connected
+      ? chalk.green("connected")
+      : chalk.yellow("no credential");
+    const details =
+      env.details && Object.keys(env.details).length > 0
+        ? chalk.dim(
+            `  ${Object.entries(env.details)
+              .map(([k, v]) => `${k}=${v}`)
+              .join(" ")}`
+          )
+        : "";
+    console.log(
+      `  ${chalk.green("●")} ${chalk.bold(env.name)} ${chalk.dim(env.providerKind)}  ${connected}${details}  ${chalk.dim(env.id)}`
+    );
+  }
+  if (body.environments.length === 0) {
+    console.log(chalk.dim("  No provider-backed environments."));
+  }
+  if (body.availableProviders.length > 0) {
+    console.log(
+      chalk.dim(
+        `\n  Available providers: ${body.availableProviders.join(", ")}\n`
+      )
+    );
+  } else {
+    console.log();
+  }
+}
+
+export async function environmentCreateCommand(
+  name: string,
+  options: EnvironmentCommandOptions & {
+    provider: string;
+    scope?: string;
+    credential?: string[];
+  }
+): Promise<void> {
+  if (options.scope && options.scope !== "org" && options.scope !== "private") {
+    console.error(chalk.red("\n  --scope must be `org` or `private`.\n"));
+    process.exit(1);
+  }
+  const credential = options.credential?.length
+    ? parseKeyValueEntries(options.credential, "--credential")
+    : undefined;
+
+  const { client, orgSlug } = await resolveApiClient(options);
+  const { environment } = await client.post<{ environment: EnvironmentRow }>(
+    `/api/${orgSlug}/environments`,
+    {
+      name,
+      provider_kind: options.provider,
+      ...(options.scope ? { scope: options.scope } : {}),
+      ...(credential ? { credential } : {}),
+    }
+  );
+
+  if (options.json) {
+    printJson(environment);
+    return;
+  }
+  const credentialNote = credential
+    ? ""
+    : chalk.dim(
+        `  Add its credential with: lobu environment set-credential ${environment.id} --credential key=$VAR\n`
+      );
+  console.log(
+    chalk.green(
+      `\n  Created environment ${name} (${environment.id}) in ${orgSlug}.\n`
+    ) + credentialNote
+  );
+}
+
+export async function environmentSetCredentialCommand(
+  id: string,
+  options: EnvironmentCommandOptions & { credential: string[] }
+): Promise<void> {
+  if (!options.credential?.length) {
+    console.error(chalk.red("\n  Pass at least one --credential key=value.\n"));
+    process.exit(1);
+  }
+  const credential = parseKeyValueEntries(options.credential, "--credential");
+
+  const { client, orgSlug } = await resolveApiClient(options);
+  await client.request(
+    "PUT",
+    `/api/${orgSlug}/environments/${encodeURIComponent(id)}/credential`,
+    { credential }
+  );
+  console.log(chalk.green(`\n  Updated credential for environment ${id}.\n`));
+}
+
+export async function environmentDeleteCommand(
+  id: string,
+  options: EnvironmentCommandOptions & { yes?: boolean } = {}
+): Promise<void> {
+  if (!options.yes) {
+    console.error(chalk.red("\n  Refusing to delete without --yes.\n"));
+    process.exit(1);
+  }
+  const { client, orgSlug } = await resolveApiClient(options);
+  await client.delete(`/api/${orgSlug}/environments/${encodeURIComponent(id)}`);
+  console.log(chalk.green(`\n  Deleted environment ${id}.\n`));
+}

--- a/packages/cli/src/commands/providers/manage.ts
+++ b/packages/cli/src/commands/providers/manage.ts
@@ -17,13 +17,8 @@ import type {
 } from "../../config/define.js";
 import { resolveApiClient } from "../../internal/index.js";
 import { printJson } from "../../internal/output.js";
+import type { CloudCommandOptions } from "../_lib/cloud-options.js";
 import { resolveSecretFlag } from "../_lib/secret-value.js";
-
-export interface ProviderCommandOptions {
-  context?: string;
-  org?: string;
-  json?: boolean;
-}
 
 /** Server-routable modalities (`isInferenceModality` in provider-secrets.ts). */
 const MODALITIES: ReadonlySet<string> = new Set([
@@ -71,7 +66,7 @@ function capabilitiesSummary(
 }
 
 export async function providersListCommand(
-  options: ProviderCommandOptions = {}
+  options: CloudCommandOptions = {}
 ): Promise<void> {
   const { client, orgSlug } = await resolveApiClient(options);
   const { providers } = await client.get<{ providers: OrgProviderRow[] }>(
@@ -108,7 +103,7 @@ export async function providersListCommand(
 }
 
 export async function providersCatalogCommand(
-  options: ProviderCommandOptions = {}
+  options: CloudCommandOptions = {}
 ): Promise<void> {
   const { client, orgSlug } = await resolveApiClient(options);
   const { catalog } = await client.get<{ catalog: CatalogEntry[] }>(
@@ -130,26 +125,31 @@ export async function providersCatalogCommand(
     const model = entry.defaultModel
       ? chalk.dim(`  default: ${entry.defaultModel}`)
       : "";
-    // "oauth" and "device-code" providers sign in through the web console —
-    // the server's OAuth routes require an interactive session, not a PAT.
-    const auth =
-      entry.authType === "api-key"
-        ? chalk.dim("  api key")
-        : chalk.yellow("  sign-in via web console");
+    // `supportedAuthTypes`, not `authType`: kinds like Claude list OAuth as
+    // primary but also take a key, and `create --key` works for them. Sign-in
+    // itself stays web-console-only (the OAuth routes reject PATs).
+    const supported = entry.supportedAuthTypes ?? [entry.authType];
+    const takesApiKey = supported.includes("api-key");
+    const signsIn = supported.some((t) => t !== "api-key");
+    const auth = takesApiKey
+      ? signsIn
+        ? chalk.dim("  api key or web sign-in")
+        : chalk.dim("  api key")
+      : chalk.yellow("  sign-in via web console");
     console.log(
       `  ${chalk.bold(entry.slug)} ${chalk.dim(entry.displayName)}${auth}${model}`
     );
   }
   console.log(
     chalk.dim(
-      "\n  Add one: lobu providers create <slug> --kind <kind> --key $MY_API_KEY\n"
+      "\n  Add one: lobu providers create <slug> --kind <kind> --key '$MY_API_KEY'\n"
     )
   );
 }
 
 export async function providersCreateCommand(
   slug: string,
-  options: ProviderCommandOptions & {
+  options: CloudCommandOptions & {
     kind: string;
     key: string;
     name?: string;
@@ -174,10 +174,22 @@ export async function providersCreateCommand(
   );
 
   if (options.default) {
-    await client.request(
-      "PUT",
-      `${providersBase(orgSlug)}/${encodeURIComponent(slug)}/default`
-    );
+    try {
+      await client.request(
+        "PUT",
+        `${providersBase(orgSlug)}/${encodeURIComponent(slug)}/default`
+      );
+    } catch (error) {
+      // The provider row exists at this point — a bare failure would read as
+      // "nothing happened" and a retried create then 409s on the slug.
+      console.error(
+        chalk.yellow(
+          `\n  Provider ${slug} was created, but setting it as org default failed.` +
+            `\n  Retry with: lobu providers set-default ${slug}\n`
+        )
+      );
+      throw error;
+    }
   }
 
   if (options.json) {
@@ -234,12 +246,8 @@ function buildCapabilities(
 
 export async function providersUpdateCommand(
   slug: string,
-  options: ProviderCommandOptions & { name?: string }
+  options: CloudCommandOptions & { name: string }
 ): Promise<void> {
-  if (!options.name?.trim()) {
-    console.error(chalk.red("\n  Pass --name <display name>.\n"));
-    process.exit(1);
-  }
   const { client, orgSlug } = await resolveApiClient(options);
   const { provider } = await client.request<{ provider: OrgProviderRow }>(
     "PUT",
@@ -256,7 +264,7 @@ export async function providersUpdateCommand(
 
 export async function providersSetKeyCommand(
   slug: string,
-  options: ProviderCommandOptions & { key: string }
+  options: CloudCommandOptions & { key: string }
 ): Promise<void> {
   const value = resolveSecretFlag(options.key, "--key");
   const { client, orgSlug } = await resolveApiClient(options);
@@ -271,7 +279,7 @@ export async function providersSetKeyCommand(
 export async function providersSetCapabilityCommand(
   slug: string,
   modality: string,
-  options: ProviderCommandOptions & {
+  options: CloudCommandOptions & {
     model?: string;
     baseUrl?: string;
     modelsEndpoint?: string;
@@ -312,7 +320,7 @@ export async function providersSetCapabilityCommand(
 
 export async function providersSetDefaultCommand(
   slug: string,
-  options: ProviderCommandOptions = {}
+  options: CloudCommandOptions = {}
 ): Promise<void> {
   const { client, orgSlug } = await resolveApiClient(options);
   await client.request(
@@ -324,7 +332,7 @@ export async function providersSetDefaultCommand(
 
 export async function providersDeleteCommand(
   slug: string,
-  options: ProviderCommandOptions & { yes?: boolean } = {}
+  options: CloudCommandOptions & { yes?: boolean } = {}
 ): Promise<void> {
   if (!options.yes) {
     console.error(chalk.red("\n  Refusing to delete without --yes.\n"));

--- a/packages/cli/src/commands/providers/manage.ts
+++ b/packages/cli/src/commands/providers/manage.ts
@@ -248,11 +248,18 @@ export async function providersUpdateCommand(
   slug: string,
   options: CloudCommandOptions & { name: string }
 ): Promise<void> {
+  // requiredOption guarantees presence, not substance — the server treats a
+  // blank displayName as "leave unchanged", which would print "Renamed" for
+  // a no-op.
+  const displayName = options.name.trim();
+  if (!displayName) {
+    throw new Error("--name must not be blank.");
+  }
   const { client, orgSlug } = await resolveApiClient(options);
   const { provider } = await client.request<{ provider: OrgProviderRow }>(
     "PUT",
     `${providersBase(orgSlug)}/${encodeURIComponent(slug)}`,
-    { displayName: options.name }
+    { displayName }
   );
 
   if (options.json) {

--- a/packages/cli/src/commands/providers/manage.ts
+++ b/packages/cli/src/commands/providers/manage.ts
@@ -1,0 +1,336 @@
+/**
+ * Org inference-provider commands — the imperative, config-less counterpart to
+ * `defineConfig({ providers: [...] })` + `lobu apply`. Both edit the same
+ * store: the org's `/inference-providers` REST surface (mounted under the
+ * agents router). Use these when there is no `lobu.config.ts` for the project
+ * — e.g. adding a model provider to an org that only exists server-side.
+ *
+ * OAuth (subscription sign-in) providers are the one exception: their
+ * start/complete routes require an interactive browser session, so the CLI
+ * points at the web console instead of driving the flow.
+ */
+
+import chalk from "chalk";
+import type {
+  InferenceCapabilityBlock,
+  InferenceModality,
+} from "../../config/define.js";
+import { resolveApiClient } from "../../internal/index.js";
+import { printJson } from "../../internal/output.js";
+import { resolveSecretFlag } from "../_lib/secret-value.js";
+
+export interface ProviderCommandOptions {
+  context?: string;
+  org?: string;
+  json?: boolean;
+}
+
+/** Server-routable modalities (`isInferenceModality` in provider-secrets.ts). */
+const MODALITIES: ReadonlySet<string> = new Set([
+  "text",
+  "image",
+  "stt",
+  "tts",
+]);
+
+interface OrgProviderRow {
+  id: number;
+  slug: string;
+  kind: string;
+  displayName: string | null;
+  capabilities: Partial<Record<string, InferenceCapabilityBlock>>;
+  hasCustomUpstream: boolean;
+  status: string;
+  createdAt: string;
+  isDefault?: boolean;
+}
+
+interface CatalogEntry {
+  slug: string;
+  displayName: string;
+  authType: string;
+  supportedAuthTypes?: string[];
+  defaultModel: string | null;
+  modalities?: string[];
+  systemAvailable?: boolean;
+}
+
+function providersBase(orgSlug: string): string {
+  return `/api/${orgSlug}/agents/inference-providers`;
+}
+
+function capabilitiesSummary(
+  capabilities: Partial<Record<string, InferenceCapabilityBlock>>
+): string {
+  const parts: string[] = [];
+  for (const [modality, block] of Object.entries(capabilities)) {
+    if (!block) continue;
+    parts.push(block.model ? `${modality}:${block.model}` : modality);
+  }
+  return parts.join(", ");
+}
+
+export async function providersListCommand(
+  options: ProviderCommandOptions = {}
+): Promise<void> {
+  const { client, orgSlug } = await resolveApiClient(options);
+  const { providers } = await client.get<{ providers: OrgProviderRow[] }>(
+    providersBase(orgSlug)
+  );
+
+  if (options.json) {
+    printJson(providers);
+    return;
+  }
+
+  if (providers.length === 0) {
+    console.log(
+      chalk.dim(
+        `\n  No model providers in org ${orgSlug}. Add one with \`lobu providers create\`.\n`
+      )
+    );
+    return;
+  }
+
+  console.log(chalk.bold(`\n  Model providers in ${orgSlug}`));
+  for (const provider of providers) {
+    const defaultTag = provider.isDefault ? chalk.cyan("  [default]") : "";
+    const name = provider.displayName
+      ? chalk.dim(` — ${provider.displayName}`)
+      : "";
+    const caps = capabilitiesSummary(provider.capabilities);
+    const capsText = caps ? chalk.dim(`  (${caps})`) : "";
+    console.log(
+      `  ${chalk.green("●")} ${chalk.bold(provider.slug)} ${chalk.dim(provider.kind)}${defaultTag}${capsText}${name}`
+    );
+  }
+  console.log();
+}
+
+export async function providersCatalogCommand(
+  options: ProviderCommandOptions = {}
+): Promise<void> {
+  const { client, orgSlug } = await resolveApiClient(options);
+  const { catalog } = await client.get<{ catalog: CatalogEntry[] }>(
+    `${providersBase(orgSlug)}/catalog`
+  );
+
+  if (options.json) {
+    printJson(catalog);
+    return;
+  }
+
+  if (catalog.length === 0) {
+    console.log(chalk.dim("\n  No bundled providers in the catalog.\n"));
+    return;
+  }
+
+  console.log(chalk.bold("\n  Available provider kinds"));
+  for (const entry of catalog) {
+    const model = entry.defaultModel
+      ? chalk.dim(`  default: ${entry.defaultModel}`)
+      : "";
+    // "oauth" and "device-code" providers sign in through the web console —
+    // the server's OAuth routes require an interactive session, not a PAT.
+    const auth =
+      entry.authType === "api-key"
+        ? chalk.dim("  api key")
+        : chalk.yellow("  sign-in via web console");
+    console.log(
+      `  ${chalk.bold(entry.slug)} ${chalk.dim(entry.displayName)}${auth}${model}`
+    );
+  }
+  console.log(
+    chalk.dim(
+      "\n  Add one: lobu providers create <slug> --kind <kind> --key $MY_API_KEY\n"
+    )
+  );
+}
+
+export async function providersCreateCommand(
+  slug: string,
+  options: ProviderCommandOptions & {
+    kind: string;
+    key: string;
+    name?: string;
+    model?: string;
+    capabilities?: string;
+    default?: boolean;
+  }
+): Promise<void> {
+  const apiKey = resolveSecretFlag(options.key, "--key");
+  const capabilities = buildCapabilities(options.capabilities, options.model);
+
+  const { client, orgSlug } = await resolveApiClient(options);
+  const { provider } = await client.post<{ provider: OrgProviderRow }>(
+    providersBase(orgSlug),
+    {
+      slug,
+      kind: options.kind,
+      apiKey,
+      ...(options.name ? { displayName: options.name } : {}),
+      ...(capabilities ? { capabilities } : {}),
+    }
+  );
+
+  if (options.default) {
+    await client.request(
+      "PUT",
+      `${providersBase(orgSlug)}/${encodeURIComponent(slug)}/default`
+    );
+  }
+
+  if (options.json) {
+    printJson({ ...provider, isDefault: options.default ?? false });
+    return;
+  }
+  const defaultNote = options.default ? " and set as org default" : "";
+  console.log(
+    chalk.green(`\n  Created provider ${slug} in ${orgSlug}${defaultNote}.\n`)
+  );
+}
+
+/** Merge `--capabilities <json>` with the `--model` shorthand (text model). */
+function buildCapabilities(
+  capabilitiesJson: string | undefined,
+  model: string | undefined
+): Partial<Record<InferenceModality, InferenceCapabilityBlock>> | undefined {
+  let capabilities:
+    | Partial<Record<InferenceModality, InferenceCapabilityBlock>>
+    | undefined;
+  if (capabilitiesJson) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(capabilitiesJson);
+    } catch (error) {
+      throw new Error(
+        `--capabilities is not valid JSON: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(
+        '--capabilities must be a JSON object like {"text":{"model":"gpt-4o"}}.'
+      );
+    }
+    for (const modality of Object.keys(parsed)) {
+      if (!MODALITIES.has(modality)) {
+        throw new Error(
+          `--capabilities has unknown modality "${modality}" (use text, image, stt, tts).`
+        );
+      }
+    }
+    capabilities = parsed as Partial<
+      Record<InferenceModality, InferenceCapabilityBlock>
+    >;
+  }
+  if (model) {
+    capabilities = {
+      ...capabilities,
+      text: { ...capabilities?.text, model },
+    };
+  }
+  return capabilities;
+}
+
+export async function providersUpdateCommand(
+  slug: string,
+  options: ProviderCommandOptions & { name?: string }
+): Promise<void> {
+  if (!options.name?.trim()) {
+    console.error(chalk.red("\n  Pass --name <display name>.\n"));
+    process.exit(1);
+  }
+  const { client, orgSlug } = await resolveApiClient(options);
+  const { provider } = await client.request<{ provider: OrgProviderRow }>(
+    "PUT",
+    `${providersBase(orgSlug)}/${encodeURIComponent(slug)}`,
+    { displayName: options.name }
+  );
+
+  if (options.json) {
+    printJson(provider);
+    return;
+  }
+  console.log(chalk.green(`\n  Renamed provider ${slug}.\n`));
+}
+
+export async function providersSetKeyCommand(
+  slug: string,
+  options: ProviderCommandOptions & { key: string }
+): Promise<void> {
+  const value = resolveSecretFlag(options.key, "--key");
+  const { client, orgSlug } = await resolveApiClient(options);
+  await client.request(
+    "PUT",
+    `${providersBase(orgSlug)}/${encodeURIComponent(slug)}/key`,
+    { value }
+  );
+  console.log(chalk.green(`\n  Rotated API key for provider ${slug}.\n`));
+}
+
+export async function providersSetCapabilityCommand(
+  slug: string,
+  modality: string,
+  options: ProviderCommandOptions & {
+    model?: string;
+    baseUrl?: string;
+    modelsEndpoint?: string;
+  }
+): Promise<void> {
+  if (!MODALITIES.has(modality)) {
+    console.error(
+      chalk.red(`\n  Modality must be one of: text, image, stt, tts.\n`)
+    );
+    process.exit(1);
+  }
+  const block: InferenceCapabilityBlock = {
+    ...(options.model ? { model: options.model } : {}),
+    ...(options.baseUrl ? { base_url: options.baseUrl } : {}),
+    ...(options.modelsEndpoint
+      ? { models_endpoint: options.modelsEndpoint }
+      : {}),
+  };
+  if (Object.keys(block).length === 0) {
+    console.error(
+      chalk.red(
+        "\n  Pass at least one of --model, --base-url, --models-endpoint.\n"
+      )
+    );
+    process.exit(1);
+  }
+
+  const { client, orgSlug } = await resolveApiClient(options);
+  await client.request(
+    "PUT",
+    `${providersBase(orgSlug)}/${encodeURIComponent(slug)}/capabilities/${encodeURIComponent(modality)}`,
+    { block }
+  );
+  console.log(
+    chalk.green(`\n  Updated ${modality} capabilities for provider ${slug}.\n`)
+  );
+}
+
+export async function providersSetDefaultCommand(
+  slug: string,
+  options: ProviderCommandOptions = {}
+): Promise<void> {
+  const { client, orgSlug } = await resolveApiClient(options);
+  await client.request(
+    "PUT",
+    `${providersBase(orgSlug)}/${encodeURIComponent(slug)}/default`
+  );
+  console.log(chalk.green(`\n  Provider ${slug} is now the org default.\n`));
+}
+
+export async function providersDeleteCommand(
+  slug: string,
+  options: ProviderCommandOptions & { yes?: boolean } = {}
+): Promise<void> {
+  if (!options.yes) {
+    console.error(chalk.red("\n  Refusing to delete without --yes.\n"));
+    process.exit(1);
+  }
+  const { client, orgSlug } = await resolveApiClient(options);
+  await client.delete(`${providersBase(orgSlug)}/${encodeURIComponent(slug)}`);
+  console.log(chalk.green(`\n  Deleted provider ${slug}.\n`));
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,10 +40,8 @@ import { Command } from "commander";
 // (no runtime module load), so they do NOT defeat the lazy-import hot path —
 // the handler modules are still pulled in only inside each `.action`.
 import type { AgentCommandOptions } from "./commands/agent.js";
-import type { ClientsCommandOptions } from "./commands/clients.js";
-import type { EnvironmentCommandOptions } from "./commands/environment.js";
+import type { CloudCommandOptions } from "./commands/_lib/cloud-options.js";
 import type { InitOptions } from "./commands/init.js";
-import type { ProviderCommandOptions } from "./commands/providers/manage.js";
 import { GATEWAY_DEFAULT_URL } from "./internal/index.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -69,6 +67,14 @@ function withCommonOpts(
   if (opts.org) cmd.option("--org <slug>", "Org slug override");
   if (opts.json) cmd.option("--json", "Print JSON");
   return cmd;
+}
+
+/** Commander accumulator for repeatable `--flag <entry>` options. */
+function collectOption(
+  value: string,
+  previous: string[] | undefined
+): string[] {
+  return previous ? [...previous, value] : [value];
 }
 
 function handleCliError(error: unknown): void {
@@ -117,6 +123,9 @@ Cloud:
   link | unlink            Bind this directory to a (context, org)
   apply | deploy           Sync lobu.config.ts to cloud (idempotent)
   agent <subcmd>           CRUD agents via REST
+  providers <subcmd>       Manage org model providers (create, set-key, ...)
+  environment <subcmd>     Manage sandbox environments (runtime providers)
+  clients <subcmd>         List / revoke connected clients (MCP, messaging)
   call [tool]              Invoke an admin REST tool by name (--list to discover)
   token [create]           Print or mint personal access tokens
 
@@ -746,7 +755,7 @@ Memory:
   withCommonOpts(
     providers.command("list").description("List the org's model providers"),
     { org: true, json: true }
-  ).action(async (options: ProviderCommandOptions) => {
+  ).action(async (options: CloudCommandOptions) => {
     const { providersListCommand } = await import(
       "./commands/providers/manage.js"
     );
@@ -758,7 +767,7 @@ Memory:
       .command("catalog")
       .description("List provider kinds available to add"),
     { org: true, json: true }
-  ).action(async (options: ProviderCommandOptions) => {
+  ).action(async (options: CloudCommandOptions) => {
     const { providersCatalogCommand } = await import(
       "./commands/providers/manage.js"
     );
@@ -773,7 +782,10 @@ Memory:
         "--kind <kind>",
         "Provider kind (see `providers catalog`)"
       )
-      .requiredOption("--key <key>", "API key value or $ENV_VAR reference")
+      .requiredOption(
+        "--key <key>",
+        "API key value or '$ENV_VAR' env reference (quote it)"
+      )
       .option("--name <name>", "Display name")
       .option("--model <id>", "Default text model")
       .option(
@@ -785,7 +797,7 @@ Memory:
   ).action(
     async (
       slug: string,
-      options: ProviderCommandOptions & {
+      options: CloudCommandOptions & {
         kind: string;
         key: string;
         name?: string;
@@ -805,13 +817,10 @@ Memory:
     providers
       .command("update <slug>")
       .description("Rename a provider")
-      .option("--name <name>", "Display name"),
+      .requiredOption("--name <name>", "Display name"),
     { org: true, json: true }
   ).action(
-    async (
-      slug: string,
-      options: ProviderCommandOptions & { name?: string }
-    ) => {
+    async (slug: string, options: CloudCommandOptions & { name: string }) => {
       const { providersUpdateCommand } = await import(
         "./commands/providers/manage.js"
       );
@@ -823,10 +832,13 @@ Memory:
     providers
       .command("set-key <slug>")
       .description("Rotate a provider's API key")
-      .requiredOption("--key <key>", "API key value or $ENV_VAR reference"),
+      .requiredOption(
+        "--key <key>",
+        "API key value or '$ENV_VAR' env reference (quote it)"
+      ),
     { org: true }
   ).action(
-    async (slug: string, options: ProviderCommandOptions & { key: string }) => {
+    async (slug: string, options: CloudCommandOptions & { key: string }) => {
       const { providersSetKeyCommand } = await import(
         "./commands/providers/manage.js"
       );
@@ -849,7 +861,7 @@ Memory:
     async (
       slug: string,
       modality: string,
-      options: ProviderCommandOptions & {
+      options: CloudCommandOptions & {
         model?: string;
         baseUrl?: string;
         modelsEndpoint?: string;
@@ -867,7 +879,7 @@ Memory:
       .command("set-default <slug>")
       .description("Make a provider the org default"),
     { org: true }
-  ).action(async (slug: string, options: ProviderCommandOptions) => {
+  ).action(async (slug: string, options: CloudCommandOptions) => {
     const { providersSetDefaultCommand } = await import(
       "./commands/providers/manage.js"
     );
@@ -881,10 +893,7 @@ Memory:
       .option("--yes", "Confirm deletion"),
     { org: true }
   ).action(
-    async (
-      slug: string,
-      options: ProviderCommandOptions & { yes?: boolean }
-    ) => {
+    async (slug: string, options: CloudCommandOptions & { yes?: boolean }) => {
       const { providersDeleteCommand } = await import(
         "./commands/providers/manage.js"
       );
@@ -900,7 +909,7 @@ Memory:
   withCommonOpts(environment.command("list").description("List environments"), {
     org: true,
     json: true,
-  }).action(async (options: EnvironmentCommandOptions) => {
+  }).action(async (options: CloudCommandOptions) => {
     const { environmentListCommand } = await import(
       "./commands/environment.js"
     );
@@ -915,15 +924,14 @@ Memory:
       .option("--scope <scope>", "org (default) or private")
       .option(
         "--credential <entry>",
-        "Credential field as key=value or key=$ENV_VAR (repeatable)",
-        (value: string, previous: string[] | undefined) =>
-          previous ? [...previous, value] : [value]
+        "Credential field as 'key=value' or 'key=$ENV_VAR' (repeatable, quote it)",
+        collectOption
       ),
     { org: true, json: true }
   ).action(
     async (
       name: string,
-      options: EnvironmentCommandOptions & {
+      options: CloudCommandOptions & {
         provider: string;
         scope?: string;
         credential?: string[];
@@ -942,15 +950,14 @@ Memory:
       .description("Set or rotate an environment's credential")
       .requiredOption(
         "--credential <entry>",
-        "Credential field as key=value or key=$ENV_VAR (repeatable)",
-        (value: string, previous: string[] | undefined) =>
-          previous ? [...previous, value] : [value]
+        "Credential field as 'key=value' or 'key=$ENV_VAR' (repeatable, quote it)",
+        collectOption
       ),
     { org: true }
   ).action(
     async (
       id: string,
-      options: EnvironmentCommandOptions & { credential: string[] }
+      options: CloudCommandOptions & { credential: string[] }
     ) => {
       const { environmentSetCredentialCommand } = await import(
         "./commands/environment.js"
@@ -966,10 +973,7 @@ Memory:
       .option("--yes", "Confirm deletion"),
     { org: true }
   ).action(
-    async (
-      id: string,
-      options: EnvironmentCommandOptions & { yes?: boolean }
-    ) => {
+    async (id: string, options: CloudCommandOptions & { yes?: boolean }) => {
       const { environmentDeleteCommand } = await import(
         "./commands/environment.js"
       );
@@ -988,7 +992,7 @@ Memory:
       .description("List connected clients")
       .option("--agent <agentId>", "Only clients assigned to this agent"),
     { org: true, json: true }
-  ).action(async (options: ClientsCommandOptions & { agent?: string }) => {
+  ).action(async (options: CloudCommandOptions & { agent?: string }) => {
     const { clientsListCommand } = await import("./commands/clients.js");
     await clientsListCommand(options);
   });
@@ -1002,7 +1006,7 @@ Memory:
   ).action(
     async (
       clientId: string,
-      options: ClientsCommandOptions & { yes?: boolean }
+      options: CloudCommandOptions & { yes?: boolean }
     ) => {
       const { clientsRevokeCommand } = await import("./commands/clients.js");
       await clientsRevokeCommand(clientId, options);
@@ -1034,8 +1038,7 @@ Memory:
       .option(
         "--arg <entry>",
         "Add a top-level arg as key=string or key:=<json> (repeatable)",
-        (value: string, previous: string[] | undefined) =>
-          previous ? [...previous, value] : [value]
+        collectOption
       )
       .option("--raw", "Emit compact JSON (default is pretty-printed)")
       .option("--url <url>", "Server URL override"),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,7 +40,10 @@ import { Command } from "commander";
 // (no runtime module load), so they do NOT defeat the lazy-import hot path —
 // the handler modules are still pulled in only inside each `.action`.
 import type { AgentCommandOptions } from "./commands/agent.js";
+import type { ClientsCommandOptions } from "./commands/clients.js";
+import type { EnvironmentCommandOptions } from "./commands/environment.js";
 import type { InitOptions } from "./commands/init.js";
+import type { ProviderCommandOptions } from "./commands/providers/manage.js";
 import { GATEWAY_DEFAULT_URL } from "./internal/index.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -728,6 +731,281 @@ Memory:
     ) => {
       const { agentConfigPatchCommand } = await import("./commands/agent.js");
       await agentConfigPatchCommand(agentId, options);
+    }
+  );
+
+  // ─── providers ──────────────────────────────────────────────────────
+  // Org model providers over the same REST surface the web console and
+  // `lobu apply` (`defineConfig({ providers })`) edit — one store, many
+  // editors. Exists so a project with no lobu.config.ts can still add a
+  // provider. Secret-bearing flags take `$VAR` env references.
+  const providers = program
+    .command("providers")
+    .description("Manage org model providers (inference providers)");
+
+  withCommonOpts(
+    providers.command("list").description("List the org's model providers"),
+    { org: true, json: true }
+  ).action(async (options: ProviderCommandOptions) => {
+    const { providersListCommand } = await import(
+      "./commands/providers/manage.js"
+    );
+    await providersListCommand(options);
+  });
+
+  withCommonOpts(
+    providers
+      .command("catalog")
+      .description("List provider kinds available to add"),
+    { org: true, json: true }
+  ).action(async (options: ProviderCommandOptions) => {
+    const { providersCatalogCommand } = await import(
+      "./commands/providers/manage.js"
+    );
+    await providersCatalogCommand(options);
+  });
+
+  withCommonOpts(
+    providers
+      .command("create <slug>")
+      .description("Add a model provider with an API key")
+      .requiredOption(
+        "--kind <kind>",
+        "Provider kind (see `providers catalog`)"
+      )
+      .requiredOption("--key <key>", "API key value or $ENV_VAR reference")
+      .option("--name <name>", "Display name")
+      .option("--model <id>", "Default text model")
+      .option(
+        "--capabilities <json>",
+        'Per-modality overrides, e.g. {"text":{"model":"gpt-4o"}}'
+      )
+      .option("--default", "Set as the org default provider"),
+    { org: true, json: true }
+  ).action(
+    async (
+      slug: string,
+      options: ProviderCommandOptions & {
+        kind: string;
+        key: string;
+        name?: string;
+        model?: string;
+        capabilities?: string;
+        default?: boolean;
+      }
+    ) => {
+      const { providersCreateCommand } = await import(
+        "./commands/providers/manage.js"
+      );
+      await providersCreateCommand(slug, options);
+    }
+  );
+
+  withCommonOpts(
+    providers
+      .command("update <slug>")
+      .description("Rename a provider")
+      .option("--name <name>", "Display name"),
+    { org: true, json: true }
+  ).action(
+    async (
+      slug: string,
+      options: ProviderCommandOptions & { name?: string }
+    ) => {
+      const { providersUpdateCommand } = await import(
+        "./commands/providers/manage.js"
+      );
+      await providersUpdateCommand(slug, options);
+    }
+  );
+
+  withCommonOpts(
+    providers
+      .command("set-key <slug>")
+      .description("Rotate a provider's API key")
+      .requiredOption("--key <key>", "API key value or $ENV_VAR reference"),
+    { org: true }
+  ).action(
+    async (slug: string, options: ProviderCommandOptions & { key: string }) => {
+      const { providersSetKeyCommand } = await import(
+        "./commands/providers/manage.js"
+      );
+      await providersSetKeyCommand(slug, options);
+    }
+  );
+
+  withCommonOpts(
+    providers
+      .command("set-capability <slug> <modality>")
+      .description("Set one modality's model/endpoint (text, image, stt, tts)")
+      .option("--model <id>", "Default model for the modality")
+      .option("--base-url <url>", "Upstream base URL override")
+      .option(
+        "--models-endpoint <path>",
+        "Model-discovery path (e.g. /models)"
+      ),
+    { org: true }
+  ).action(
+    async (
+      slug: string,
+      modality: string,
+      options: ProviderCommandOptions & {
+        model?: string;
+        baseUrl?: string;
+        modelsEndpoint?: string;
+      }
+    ) => {
+      const { providersSetCapabilityCommand } = await import(
+        "./commands/providers/manage.js"
+      );
+      await providersSetCapabilityCommand(slug, modality, options);
+    }
+  );
+
+  withCommonOpts(
+    providers
+      .command("set-default <slug>")
+      .description("Make a provider the org default"),
+    { org: true }
+  ).action(async (slug: string, options: ProviderCommandOptions) => {
+    const { providersSetDefaultCommand } = await import(
+      "./commands/providers/manage.js"
+    );
+    await providersSetDefaultCommand(slug, options);
+  });
+
+  withCommonOpts(
+    providers
+      .command("delete <slug>")
+      .description("Delete a provider")
+      .option("--yes", "Confirm deletion"),
+    { org: true }
+  ).action(
+    async (
+      slug: string,
+      options: ProviderCommandOptions & { yes?: boolean }
+    ) => {
+      const { providersDeleteCommand } = await import(
+        "./commands/providers/manage.js"
+      );
+      await providersDeleteCommand(slug, options);
+    }
+  );
+
+  // ─── environment ────────────────────────────────────────────────────
+  const environment = program
+    .command("environment")
+    .description("Manage sandbox environments (runtime providers)");
+
+  withCommonOpts(environment.command("list").description("List environments"), {
+    org: true,
+    json: true,
+  }).action(async (options: EnvironmentCommandOptions) => {
+    const { environmentListCommand } = await import(
+      "./commands/environment.js"
+    );
+    await environmentListCommand(options);
+  });
+
+  withCommonOpts(
+    environment
+      .command("create <name>")
+      .description("Create an environment")
+      .requiredOption("--provider <kind>", "Runtime provider kind")
+      .option("--scope <scope>", "org (default) or private")
+      .option(
+        "--credential <entry>",
+        "Credential field as key=value or key=$ENV_VAR (repeatable)",
+        (value: string, previous: string[] | undefined) =>
+          previous ? [...previous, value] : [value]
+      ),
+    { org: true, json: true }
+  ).action(
+    async (
+      name: string,
+      options: EnvironmentCommandOptions & {
+        provider: string;
+        scope?: string;
+        credential?: string[];
+      }
+    ) => {
+      const { environmentCreateCommand } = await import(
+        "./commands/environment.js"
+      );
+      await environmentCreateCommand(name, options);
+    }
+  );
+
+  withCommonOpts(
+    environment
+      .command("set-credential <id>")
+      .description("Set or rotate an environment's credential")
+      .requiredOption(
+        "--credential <entry>",
+        "Credential field as key=value or key=$ENV_VAR (repeatable)",
+        (value: string, previous: string[] | undefined) =>
+          previous ? [...previous, value] : [value]
+      ),
+    { org: true }
+  ).action(
+    async (
+      id: string,
+      options: EnvironmentCommandOptions & { credential: string[] }
+    ) => {
+      const { environmentSetCredentialCommand } = await import(
+        "./commands/environment.js"
+      );
+      await environmentSetCredentialCommand(id, options);
+    }
+  );
+
+  withCommonOpts(
+    environment
+      .command("delete <id>")
+      .description("Delete an environment")
+      .option("--yes", "Confirm deletion"),
+    { org: true }
+  ).action(
+    async (
+      id: string,
+      options: EnvironmentCommandOptions & { yes?: boolean }
+    ) => {
+      const { environmentDeleteCommand } = await import(
+        "./commands/environment.js"
+      );
+      await environmentDeleteCommand(id, options);
+    }
+  );
+
+  // ─── clients ────────────────────────────────────────────────────────
+  const clients = program
+    .command("clients")
+    .description("List and revoke connected clients (MCP apps, messaging)");
+
+  withCommonOpts(
+    clients
+      .command("list")
+      .description("List connected clients")
+      .option("--agent <agentId>", "Only clients assigned to this agent"),
+    { org: true, json: true }
+  ).action(async (options: ClientsCommandOptions & { agent?: string }) => {
+    const { clientsListCommand } = await import("./commands/clients.js");
+    await clientsListCommand(options);
+  });
+
+  withCommonOpts(
+    clients
+      .command("revoke <clientId>")
+      .description("Revoke an MCP client's tokens and sessions")
+      .option("--yes", "Confirm revocation"),
+    { org: true }
+  ).action(
+    async (
+      clientId: string,
+      options: ClientsCommandOptions & { yes?: boolean }
+    ) => {
+      const { clientsRevokeCommand } = await import("./commands/clients.js");
+      await clientsRevokeCommand(clientId, options);
     }
   );
 


### PR DESCRIPTION
## Why

Org-level infra (model providers, sandbox environments, connected clients) had full REST + web-console coverage but **no CLI path when there is no \`lobu.config.ts\`** — e.g. a server-side-only project where you just want to add a model provider with an API key. \`lobu call\` can't reach these either (they're standalone routes, not \`manage_*\` tools).

This came out of a route-by-route audit of all mutating infra REST routes vs config-less CLI coverage. Every gap route below is now covered.

## What

All commands follow the existing \`lobu agent\` pattern: \`resolveApiClient\` (login context + \`--org\` override), same REST routes the web console and \`lobu apply\` edit — one store, many editors.

### \`lobu providers\` → \`/api/<org>/agents/inference-providers\`
| command | route |
|---|---|
| \`list\` | \`GET /\` |
| \`catalog\` | \`GET /catalog\` (kinds + auth mode) |
| \`create <slug> --kind --key [--model] [--capabilities] [--default]\` | \`POST /\` (+ \`PUT /:slug/default\`) |
| \`update <slug> --name\` | \`PUT /:slug\` |
| \`set-key <slug> --key\` | \`PUT /:slug/key\` |
| \`set-capability <slug> <modality> [--model] [--base-url] [--models-endpoint]\` | \`PUT /:slug/capabilities/:modality\` |
| \`set-default <slug>\` | \`PUT /:slug/default\` |
| \`delete <slug> --yes\` | \`DELETE /:slug\` |

### \`lobu environment\` → \`/api/<org>/environments\`
\`list\` / \`create <name> --provider [--scope] [--credential k=v…]\` / \`set-credential <id> --credential k=v…\` / \`delete <id> --yes\`

### \`lobu clients\` → \`/api/<org>/clients\`
\`list [--agent]\` / \`revoke <clientId> --yes\` (\`DELETE /mcp/:clientId\`)

### Secrets
\`--key\` and \`--credential k=v\` values accept \`$VAR\` env references (same convention as \`secret()\` / \`$VAR\` in apply config), so real keys stay out of shell history. Shared helper \`_lib/secret-value.ts\` with unit tests.

## Deliberately NOT wrapped

- **Provider OAuth start/complete** — those routes require an interactive browser session (\`requireInteractiveUser\` rejects PATs by design). \`providers catalog\` labels oauth/device-code kinds "sign-in via web console".
- **\`PUT /:agentId/providers/:providerId/api-key\`** — legacy, marked \`TODO(inference-providers): remove after resolver cutover\`; no new surface built on it. The org-level \`providers set-key\` is the replacement.
- **Environments in \`lobu apply\`** — deletes/credentials stay imperative + \`--yes\` gated so a config edit can never silently drop a credential. Can revisit later.

## Verification

- \`tsc --noEmit\` clean (cli package), biome clean, pre-commit hooks passed
- \`bun test\` — 9/9 new secret-value tests pass
- Live e2e against a real org (read-only): \`providers list\` (showed existing openai + z-ai providers), \`providers catalog\`, \`environment list\` (builtin + vercel available), \`clients list\` (MCP + messaging rows) — all render correctly
- \`--yes\` guards verified to refuse without the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014meECSComSn1SZANxL8dAo

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786408035&installation_id=136316292&pr_number=1862&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1862&signature=381e537691070f0990e5fbe6b41dddf62f12e913c820af41bc61fde8aba28403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI commands for managing inference providers, including creation, updates, credentials, capabilities, defaults, and deletion.
  * Added environment management commands for listing, creating, configuring credentials, and deleting environments.
  * Added connected-client commands to list and revoke clients, with JSON output support.
  * Added environment-variable resolution for secret CLI values and key-value credentials, with validation and clear errors.
* **Tests**
  * Added coverage for secret resolution and credential parsing, including invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->