### PR TITLE
chore: remove verified-dead symbols, stale worker dep, NUL-byte artifact

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent-worker": {
       "name": "@lobu/worker",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "bin": {
         "lobu-worker": "./dist/index.js",
       },
@@ -43,7 +43,7 @@
     },
     "packages/cli": {
       "name": "@lobu/cli",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "bin": {
         "lobu": "bin/lobu.js",
       },
@@ -129,7 +129,7 @@
     },
     "packages/client": {
       "name": "@lobu/client",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.99.0",
@@ -138,7 +138,7 @@
     },
     "packages/connector-sdk": {
       "name": "@lobu/connector-sdk",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
         "@sinclair/typebox": "^0.34.41",
@@ -162,14 +162,13 @@
     },
     "packages/connector-worker": {
       "name": "@lobu/connector-worker",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "bin": {
         "connector-worker": "./dist/bin.js",
       },
       "dependencies": {
         "@lobu/connector-sdk": "workspace:*",
         "@lobu/embeddings": "workspace:*",
-        "@lobu/worker": "workspace:*",
         "@xenova/transformers": "^2.17.2",
         "esbuild": "^0.28.1",
         "jimp": "^1.6.0",
@@ -197,7 +196,7 @@
     },
     "packages/core": {
       "name": "@lobu/core",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
@@ -216,7 +215,7 @@
     },
     "packages/embeddings": {
       "name": "@lobu/embeddings",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
         "@xenova/transformers": "^2.17.2",
@@ -230,7 +229,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "@lobu/openclaw-plugin",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
       },
@@ -334,7 +333,7 @@
     },
     "packages/pgvector-embedded": {
       "name": "@lobu/pgvector-embedded",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "devDependencies": {
         "@types/node": "20.19.9",
         "typescript": "^5.7.2",
@@ -342,7 +341,7 @@
     },
     "packages/promptfoo-provider": {
       "name": "@lobu/promptfoo-provider",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.3",

--- a/config/knip.ts
+++ b/config/knip.ts
@@ -34,8 +34,6 @@ const config: KnipConfig = {
         "integration-tests/**/*.test.ts",
       ],
       ignoreDependencies: [
-        // Loaded via dynamic specifier in src/index.ts.
-        "@lobu/worker",
         // Native media/ML deps reached at runtime by connector bundles
         // (embeddings, image processing), not statically imported in src/.
         "@xenova/transformers",

--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "@lobu/connector-sdk": "workspace:*",
     "@lobu/embeddings": "workspace:*",
-    "@lobu/worker": "workspace:*",
     "@xenova/transformers": "^2.17.2",
     "esbuild": "^0.28.1",
     "jimp": "^1.6.0",

--- a/packages/server/src/auth/oauth/scopes.ts
+++ b/packages/server/src/auth/oauth/scopes.ts
@@ -41,13 +41,6 @@ export const AVAILABLE_PAT_SCOPES = [
 ] as const;
 
 /**
- * Default scope requested when device-authing against an external MCP server
- * (gateway device-auth flow). Includes `profile:read` so the gateway can
- * introspect who the credential belongs to.
- */
-export const DEFAULT_MCP_DEVICE_SCOPE = 'mcp:read mcp:write profile:read';
-
-/**
  * The least-privilege scope a token must carry to fetch a managed connector's
  * access token via POST /oauth/connection-token.
  *

--- a/packages/server/src/authz/channel-visibility.ts
+++ b/packages/server/src/authz/channel-visibility.ts
@@ -234,7 +234,7 @@ export async function filterChannelsForRequester<T extends GatedChannelRow>(
   const enforcingTenants: EnforcingTenant[] = [];
   for (const r of rows) {
     if (states.get(r.id)?.status !== "enforced" || !r.team_id) continue;
-    const dedupe = `${r.platform} ${r.team_id}`;
+    const dedupe = `${r.platform}\u0000${r.team_id}`;
     if (seenTenant.has(dedupe)) continue;
     seenTenant.add(dedupe);
     enforcingTenants.push({ platform: r.platform, teamId: r.team_id });

--- a/packages/server/src/catalog/load.ts
+++ b/packages/server/src/catalog/load.ts
@@ -146,14 +146,6 @@ export async function listCatalogEntries(
 	return result;
 }
 
-export async function getCatalogEntry(
-	kind: CatalogKind,
-	id: string,
-): Promise<CatalogEntry | undefined> {
-	const entries = (await listCatalogEntries([kind]))[kind];
-	return entries.find((entry) => entry.id === id);
-}
-
 export function clearCatalogCacheForTests(): void {
 	manifestCache.clear();
 	inMemoryFallback = null;

--- a/packages/server/src/gateway/guardrails/output-scan.ts
+++ b/packages/server/src/gateway/guardrails/output-scan.ts
@@ -27,14 +27,6 @@ import { recordGuardrailTrip } from "./audit.js";
 
 const logger = createLogger("output-guardrail");
 
-/**
- * Streaming chunks split arbitrarily across token boundaries; a secret like
- * `sk-abc…` can arrive as `"sk-an"` then `"t-…"` and bypass any per-delta
- * regex. Callers keep a rolling tail of recent emitted text and scan
- * `tail + delta` so patterns straddling a chunk boundary still match.
- */
-export const OUTPUT_GUARDRAIL_TAIL_CHARS = 256;
-
 export interface OutputScanContext {
   agentId: string;
   organizationId?: string;

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -38,13 +38,6 @@ import {
 import { errorResponse } from "../shared/helpers.js";
 import { verifySettingsSession } from "./settings-auth.js";
 
-export type { AgentThreadSummary } from "../../services/agent-thread-list.js";
-export {
-	buildApiConversationId,
-	extractThreadIdFromConversationId,
-} from "../../services/api-conversation-id.js";
-export { readSnapshotJsonl } from "../../services/transcript-snapshot.js";
-
 /**
  * Read the latest completed transcript snapshot for an agent's most-recent
  * conversation. Returns the raw JSONL content + sessionId-equivalent, or

--- a/packages/server/src/lobu/stores/environment-store.ts
+++ b/packages/server/src/lobu/stores/environment-store.ts
@@ -117,20 +117,6 @@ export async function deleteEnvironment(
   return deleted;
 }
 
-export async function getEnvironmentProviderKind(
-  id: string,
-  organizationId: string
-): Promise<string | null> {
-  const sql = getDb();
-  const rows = (await sql`
-    SELECT provider_kind
-    FROM environments
-    WHERE id = ${id} AND organization_id = ${organizationId}
-    LIMIT 1
-  `) as Array<{ provider_kind: string }>;
-  return rows[0]?.provider_kind ?? null;
-}
-
 /**
  * Resolve an agent's selected environment to the runtime claims stamped into
  * its worker token. Returns `{}` for builtin/unset/unknown so the caller falls

--- a/packages/server/src/preview/managed-platforms.ts
+++ b/packages/server/src/preview/managed-platforms.ts
@@ -4,7 +4,3 @@ export const MANAGED_CHAT_PLATFORMS = ["slack", "telegram"] as const;
 export const MANAGED_CHAT_PLATFORMS_SET = new Set<string>(
 	MANAGED_CHAT_PLATFORMS,
 );
-
-export function isManagedChatPlatform(platform: string): boolean {
-	return MANAGED_CHAT_PLATFORMS_SET.has(platform);
-}


### PR DESCRIPTION
## What

Small verified dead-code sweep. Every deleted symbol was confirmed single-occurrence repo-wide (`rg -a`, zero owletto references), and knip confirms each was flagged unused on main.

### Dead exports deleted (definition + body)
- `getEnvironmentProviderKind` — packages/server/src/lobu/stores/environment-store.ts
- `getCatalogEntry` — packages/server/src/catalog/load.ts
- `isManagedChatPlatform` — packages/server/src/preview/managed-platforms.ts (`MANAGED_CHAT_PLATFORMS`/`_SET` kept — both have live consumers)
- `OUTPUT_GUARDRAIL_TAIL_CHARS` — packages/server/src/gateway/guardrails/output-scan.ts
- `DEFAULT_MCP_DEVICE_SCOPE` — packages/server/src/auth/oauth/scopes.ts

### Dead re-exports removed
- agent-history.ts no longer re-exports `buildApiConversationId`, `extractThreadIdFromConversationId`, `readSnapshotJsonl`, `AgentThreadSummary` — all consumers already import from the source modules.

### NUL-byte artifact
- channel-visibility.ts had a raw NUL byte inside the tenant-dedupe template literal (`${r.platform}<NUL>${r.team_id}`), which breaks plain `grep` on the file. Replaced the raw byte with the `\u0000` escape — the runtime string is byte-identical, so the dedupe-key separator semantics are unchanged (a plain strip would have concatenated platform+team_id ambiguously).

### Stale dependency
- Removed unused `@lobu/worker` from packages/connector-worker/package.json (no static or dynamic imports; see #1860) plus its stale knip `ignoreDependencies` entry — the comment claimed a dynamic specifier in src/index.ts that no longer exists. The CLI umbrella's `@lobu/worker` ignore entry is intentionally untouched.

## Verification
- `make typecheck` (strict, server + owletto): clean
- `bun run knip`: diffed against an origin/main baseline worktree — exactly the 9 deleted symbols disappear from the report, zero new findings (knip exits 1 on main already from pre-existing findings)
- `make review BASE=origin/main`: running (queued behind another review holding the host lock); verdict will be posted to this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786412237&installation_id=136316292&pr_number=1865&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1865&signature=3098d2cecbadef091b13dca98dc84588c0fcd3cbc1c354f8f5f1995132b1f127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal dependency and catalog management.
  - Updated agent runtime selection to better handle explicit, missing, or deleted environments.
  - Streamlined output scanning and channel visibility handling.
  - Removed several unused internal exports and helper APIs.
- **Tests**
  - Added a mechanism to reset catalog caches during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->