### PR TITLE
feat(schedules): timezone-aware crons, until_at bound, idempotent create

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "packages/agent-worker": {
       "name": "@lobu/worker",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "bin": {
         "lobu-worker": "./dist/index.js",
       },
@@ -43,7 +43,7 @@
     },
     "packages/cli": {
       "name": "@lobu/cli",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "bin": {
         "lobu": "bin/lobu.js",
       },
@@ -87,7 +87,7 @@
         "chalk": "^5.3.0",
         "chat": "^4.26.0",
         "commander": "^14.0.1",
-        "cron-parser": "^5.5.0",
+        "cron-parser": "^5.6.1",
         "dotenv": "^16.4.5",
         "embedded-postgres": "18.3.0-beta.17",
         "esbuild": "^0.28.1",
@@ -129,7 +129,7 @@
     },
     "packages/client": {
       "name": "@lobu/client",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.99.0",
@@ -138,7 +138,7 @@
     },
     "packages/connector-sdk": {
       "name": "@lobu/connector-sdk",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
         "@sinclair/typebox": "^0.34.41",
@@ -162,7 +162,7 @@
     },
     "packages/connector-worker": {
       "name": "@lobu/connector-worker",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "bin": {
         "connector-worker": "./dist/bin.js",
       },
@@ -197,7 +197,7 @@
     },
     "packages/core": {
       "name": "@lobu/core",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
@@ -216,7 +216,7 @@
     },
     "packages/embeddings": {
       "name": "@lobu/embeddings",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
         "@xenova/transformers": "^2.17.2",
@@ -230,7 +230,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "@lobu/openclaw-plugin",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "dependencies": {
         "@lobu/core": "workspace:*",
       },
@@ -334,7 +334,7 @@
     },
     "packages/pgvector-embedded": {
       "name": "@lobu/pgvector-embedded",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "devDependencies": {
         "@types/node": "20.19.9",
         "typescript": "^5.7.2",
@@ -342,7 +342,7 @@
     },
     "packages/promptfoo-provider": {
       "name": "@lobu/promptfoo-provider",
-      "version": "13.4.0",
+      "version": "14.0.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.3",
@@ -381,7 +381,7 @@
         "ajv-formats": "^3.0.1",
         "better-auth": "^1.4.10",
         "chat": "^4.26.0",
-        "cron-parser": "^5.5.0",
+        "cron-parser": "^5.6.1",
         "handlebars": "^4.7.9",
         "hono": "^4.10.4",
         "hono-pino": "^0.10.3",
@@ -2151,7 +2151,7 @@
 
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
-    "cron-parser": ["cron-parser@5.5.0", "", { "dependencies": { "luxon": "^3.7.1" } }, "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww=="],
+    "cron-parser": ["cron-parser@5.6.1", "", { "dependencies": { "luxon": "^3.7.2" } }, "sha512-QBm4o1PwZiuY7KFbVvW7FLC8bozy7YWzv+Fz6KRS7sQghzcbDZCGxr/Bc5b6TQreAoSwuWVP491dIcK0THCX6A=="],
 
     "cronstrue": ["cronstrue@3.24.0", "", { "bin": { "cronstrue": "bin/cli.js" } }, "sha512-t/Ji3Ur2c/pzhIAWNwC0ftl3JAE4dLfCjAdZoTZXmPDZwcispnS1PaMcMS4OmIIXyIVouAz+yw+mfQiE3hz5OQ=="],
 

--- a/db/migrations/20260712090000_scheduled_jobs_tz_until_idempotency.sql
+++ b/db/migrations/20260712090000_scheduled_jobs_tz_until_idempotency.sql
@@ -1,0 +1,16 @@
+-- migrate:up
+
+-- Timezone-aware, bounded, dedup-safe schedules. All nullable, no backfill:
+-- NULL timezone = server time (existing behavior), NULL until_at = recur
+-- forever, NULL idempotency_key = no create dedup.
+ALTER TABLE scheduled_jobs
+  ADD COLUMN IF NOT EXISTS timezone text,
+  ADD COLUMN IF NOT EXISTS until_at timestamptz,
+  ADD COLUMN IF NOT EXISTS idempotency_key text;
+
+-- migrate:down
+
+ALTER TABLE scheduled_jobs
+  DROP COLUMN IF EXISTS idempotency_key,
+  DROP COLUMN IF EXISTS until_at,
+  DROP COLUMN IF EXISTS timezone;

--- a/db/migrations/20260712090001_scheduled_jobs_idempotency_index.sql
+++ b/db/migrations/20260712090001_scheduled_jobs_idempotency_index.sql
@@ -1,0 +1,11 @@
+-- migrate:up transaction:false
+
+-- One schedule per (org, client-chosen idempotency key). Partial: rows created
+-- without a key (the common case) stay out of the index entirely.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS scheduled_jobs_org_idempotency_key_uniq
+  ON public.scheduled_jobs (organization_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.scheduled_jobs_org_idempotency_key_uniq;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,7 +77,7 @@
     "chalk": "^5.3.0",
     "chat": "^4.26.0",
     "commander": "^14.0.1",
-    "cron-parser": "^5.5.0",
+    "cron-parser": "^5.6.1",
     "dotenv": "^16.4.5",
     "embedded-postgres": "18.3.0-beta.17",
     "esbuild": "^0.28.1",

--- a/packages/core/src/contracts/tools/manage-schedules.ts
+++ b/packages/core/src/contracts/tools/manage-schedules.ts
@@ -53,6 +53,28 @@ export const CreateAction = Type.Object({
    * each firing. When omitted, the job is one-shot.
    */
   cron: Type.Optional(Type.String()),
+  timezone: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: 64,
+      description:
+        "IANA timezone the cron is evaluated in (e.g. 'Asia/Taipei'), DST-aware. Omit for server time (UTC).",
+    })
+  ),
+  until_at: Type.Optional(
+    Type.String({
+      description:
+        "ISO timestamp after which a recurring schedule stops firing and is retired. Must not be before run_at.",
+    })
+  ),
+  idempotency_key: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: 200,
+      description:
+        "Client-chosen dedup key. Retrying create with the same key returns the existing schedule instead of creating a duplicate.",
+    })
+  ),
   /** Handler-specific payload. The `type` field selects the handler. */
   payload: ActionUnion,
   /**
@@ -87,6 +109,12 @@ export const UpdateAction = Type.Object({
    * leave the cadence unchanged.
    */
   cron: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  /** New IANA timezone for cron evaluation, or `null` to clear (server time). Omit to leave unchanged. */
+  timezone: Type.Optional(
+    Type.Union([Type.String({ minLength: 1, maxLength: 64 }), Type.Null()])
+  ),
+  /** New end bound (ISO timestamp), or `null` to clear it (recur forever). Omit to leave unchanged. */
+  until_at: Type.Optional(Type.Union([Type.String(), Type.Null()])),
   /** New `wake_agent` prompt (the only editable payload field). */
   prompt: Type.Optional(Type.String({ minLength: 1, maxLength: 4000 })),
   /**

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -52,7 +52,7 @@
 		"@better-auth/passkey": "^1.6.9",
 		"better-auth": "^1.4.10",
 		"chat": "^4.26.0",
-		"cron-parser": "^5.5.0",
+		"cron-parser": "^5.6.1",
 		"handlebars": "^4.7.9",
 		"hono": "^4.10.4",
 		"hono-pino": "^0.10.3",

--- a/packages/server/src/scheduled/__tests__/scheduled-jobs-tz-until.test.ts
+++ b/packages/server/src/scheduled/__tests__/scheduled-jobs-tz-until.test.ts
@@ -1,0 +1,376 @@
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { getDb } from "../../db/client";
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from "../../gateway/__tests__/helpers/db-setup";
+import type { ToolContext } from "../../tools/registry";
+import { manageSchedules } from "../../tools/admin/manage_schedules";
+import {
+  createScheduledJob,
+  registerScheduledJobsTicker,
+  type ScheduledJobRow,
+} from "../scheduled-jobs-service";
+
+const ORG = "org-tz-until";
+const USER = "user-tz-until";
+
+function ctx(): ToolContext {
+  return {
+    organizationId: ORG,
+    userId: USER,
+    memberRole: "admin",
+    agentId: null,
+    sourceContext: null,
+    isAuthenticated: true,
+    clientId: "lobu-worker",
+    scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+    tokenType: "pat",
+    scopedToOrg: true,
+    allowCrossOrg: false,
+  } as unknown as ToolContext;
+}
+
+/** Register the real ticker against a fake scheduler; returns a tick runner. */
+function makeTicker() {
+  const handlers = new Map<string, (job: unknown) => Promise<void>>();
+  const spawned: Array<{ name: string; payload: Record<string, unknown> }> = [];
+  registerScheduledJobsTicker({
+    register: (name: string, handler: (job: unknown) => Promise<void>) =>
+      handlers.set(name, handler),
+    spawn: async (name: string, payload: Record<string, unknown>) => {
+      spawned.push({ name, payload });
+      return "spawned-run";
+    },
+  } as never);
+  return {
+    spawned,
+    tick: () => handlers.get("scheduled-jobs-tick")!({ payload: {}, taskRunId: 1 }),
+  };
+}
+
+async function seedOrg(id: string): Promise<void> {
+  await getDb()`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${id}, ${id}, ${id})
+    ON CONFLICT (id) DO NOTHING
+  `;
+}
+
+async function readRow(id: string): Promise<ScheduledJobRow> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT * FROM scheduled_jobs WHERE id = ${id}
+  `) as unknown as ScheduledJobRow[];
+  return rows[0];
+}
+
+function minutesAgo(n: number): Date {
+  return new Date(Date.now() - n * 60_000);
+}
+
+describe("scheduled jobs: timezone-aware cron advance", () => {
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedOrg(ORG);
+  });
+
+  test("advances next_run_at in the schedule's timezone (9am Taipei = 01:00 UTC)", async () => {
+    const job = await createScheduledJob({
+      organizationId: ORG,
+      actionType: "send_notification",
+      actionArgs: { title: "tz test" },
+      description: "9am Taipei daily",
+      cron: "0 9 * * *",
+      timezone: "Asia/Taipei",
+      runAt: minutesAgo(1),
+      createdByUser: USER,
+    });
+    const { tick, spawned } = makeTicker();
+
+    await tick();
+
+    expect(spawned).toHaveLength(1);
+    const after = await readRow(job.id);
+    expect(after.paused).toBe(false);
+    // Taipei is UTC+8 with no DST: the next 09:00 wall-clock is always 01:00Z.
+    const next = new Date(after.next_run_at);
+    expect(next.getUTCHours()).toBe(1);
+    expect(next.getUTCMinutes()).toBe(0);
+    expect(next.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  test("without a timezone the same cron advances in server time (UTC)", async () => {
+    const job = await createScheduledJob({
+      organizationId: ORG,
+      actionType: "send_notification",
+      actionArgs: { title: "utc control" },
+      description: "9am server-time daily",
+      cron: "0 9 * * *",
+      runAt: minutesAgo(1),
+      createdByUser: USER,
+    });
+    const { tick, spawned } = makeTicker();
+
+    await tick();
+
+    expect(spawned).toHaveLength(1);
+    const after = await readRow(job.id);
+    expect(new Date(after.next_run_at).getUTCHours()).toBe(9);
+  });
+});
+
+describe("scheduled jobs: until_at bound", () => {
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedOrg(ORG);
+  });
+
+  test("fires the occurrence AT the bound, then retires instead of advancing", async () => {
+    const due = minutesAgo(1);
+    const job = await createScheduledJob({
+      organizationId: ORG,
+      actionType: "send_notification",
+      actionArgs: { title: "last firing" },
+      description: "bounded every-minute",
+      cron: "* * * * *",
+      runAt: due,
+      untilAt: due,
+      createdByUser: USER,
+    });
+    const { tick, spawned } = makeTicker();
+
+    await tick();
+
+    expect(spawned).toHaveLength(1);
+    const after = await readRow(job.id);
+    expect(after.paused).toBe(true);
+    expect(after.last_fired_at).not.toBeNull();
+  });
+
+  test("keeps advancing while the next occurrence is within the bound", async () => {
+    const job = await createScheduledJob({
+      organizationId: ORG,
+      actionType: "send_notification",
+      actionArgs: { title: "still running" },
+      description: "bounded but not done",
+      cron: "* * * * *",
+      runAt: minutesAgo(1),
+      untilAt: new Date(Date.now() + 24 * 3600_000),
+      createdByUser: USER,
+    });
+    const { tick, spawned } = makeTicker();
+
+    await tick();
+
+    expect(spawned).toHaveLength(1);
+    const after = await readRow(job.id);
+    expect(after.paused).toBe(false);
+    expect(new Date(after.next_run_at).getTime()).toBeGreaterThan(Date.now() - 60_000);
+  });
+
+  test("a due row already past its bound retires without firing", async () => {
+    // Only reachable when an update pushed next_run_at beyond until_at;
+    // simulate that end state directly.
+    const job = await createScheduledJob({
+      organizationId: ORG,
+      actionType: "send_notification",
+      actionArgs: { title: "never fires" },
+      description: "past bound",
+      cron: "* * * * *",
+      runAt: minutesAgo(60),
+      untilAt: minutesAgo(120),
+      createdByUser: USER,
+    });
+    const { tick, spawned } = makeTicker();
+
+    await tick();
+
+    expect(spawned).toHaveLength(0);
+    const after = await readRow(job.id);
+    expect(after.paused).toBe(true);
+    expect(after.last_fired_at).toBeNull();
+  });
+});
+
+describe("scheduled jobs: idempotent create", () => {
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedOrg(ORG);
+  });
+
+  test("same (org, key) returns the existing row, ignoring the retried args", async () => {
+    const first = await createScheduledJob({
+      organizationId: ORG,
+      actionType: "send_notification",
+      actionArgs: { title: "original" },
+      description: "original schedule",
+      runAt: new Date(Date.now() + 3600_000),
+      idempotencyKey: "morning-checkin",
+      createdByUser: USER,
+    });
+    const retried = await createScheduledJob({
+      organizationId: ORG,
+      actionType: "send_notification",
+      actionArgs: { title: "retry with different args" },
+      description: "retried schedule",
+      runAt: new Date(Date.now() + 7200_000),
+      idempotencyKey: "morning-checkin",
+      createdByUser: USER,
+    });
+
+    expect(retried.id).toBe(first.id);
+    expect(retried.description).toBe("original schedule");
+  });
+
+  test("same key in a different org creates an independent schedule", async () => {
+    await seedOrg("org-tz-until-other");
+    const a = await createScheduledJob({
+      organizationId: ORG,
+      actionType: "send_notification",
+      actionArgs: { title: "a" },
+      description: "org a",
+      runAt: new Date(Date.now() + 3600_000),
+      idempotencyKey: "shared-key",
+      createdByUser: USER,
+    });
+    const b = await createScheduledJob({
+      organizationId: "org-tz-until-other",
+      actionType: "send_notification",
+      actionArgs: { title: "b" },
+      description: "org b",
+      runAt: new Date(Date.now() + 3600_000),
+      idempotencyKey: "shared-key",
+      createdByUser: USER,
+    });
+
+    expect(b.id).not.toBe(a.id);
+  });
+
+  test("no key means no dedup — repeated creates make distinct rows", async () => {
+    const mk = () =>
+      createScheduledJob({
+        organizationId: ORG,
+        actionType: "send_notification",
+        actionArgs: { title: "dup" },
+        description: "unkeyed",
+        runAt: new Date(Date.now() + 3600_000),
+        createdByUser: USER,
+      });
+    const [a, b] = [await mk(), await mk()];
+    expect(b.id).not.toBe(a.id);
+  });
+});
+
+describe("manage_schedules tool: create/update validation + round-trip", () => {
+  beforeAll(async () => {
+    await ensureDbForGatewayTests();
+  }, 60_000);
+
+  beforeEach(async () => {
+    await resetTestDatabase();
+    await seedOrg(ORG);
+  });
+
+  const basePayload = { type: "send_notification", title: "hi" } as const;
+
+  test("create persists and echoes timezone, until_at, idempotency_key; retry dedups", async () => {
+    const args = {
+      action: "create",
+      description: "bounded Taipei schedule",
+      run_at: new Date(Date.now() + 3600_000).toISOString(),
+      cron: "0 9 * * *",
+      timezone: "Asia/Taipei",
+      until_at: new Date(Date.now() + 7 * 24 * 3600_000).toISOString(),
+      idempotency_key: "tool-checkin",
+      payload: basePayload,
+    };
+    const first = (await manageSchedules(args, {} as never, ctx())) as {
+      schedule: { id: string; timezone: string; until_at: string; idempotency_key: string };
+    };
+    expect(first.schedule.timezone).toBe("Asia/Taipei");
+    expect(first.schedule.until_at).not.toBeNull();
+    expect(first.schedule.idempotency_key).toBe("tool-checkin");
+
+    const retry = (await manageSchedules(args, {} as never, ctx())) as { schedule: { id: string } };
+    expect(retry.schedule.id).toBe(first.schedule.id);
+  });
+
+  test("create rejects an unknown timezone", async () => {
+    const res = (await manageSchedules(
+      {
+        action: "create",
+        description: "bad tz",
+        run_at: new Date().toISOString(),
+        cron: "0 9 * * *",
+        timezone: "Mars/Olympus_Mons",
+        payload: basePayload,
+      },
+      {} as never,
+      ctx()
+    )) as { error?: string };
+    expect(res.error).toContain("Unknown IANA timezone");
+  });
+
+  test("create rejects until_at before run_at", async () => {
+    const res = (await manageSchedules(
+      {
+        action: "create",
+        description: "inverted bound",
+        run_at: new Date(Date.now() + 3600_000).toISOString(),
+        until_at: new Date().toISOString(),
+        payload: basePayload,
+      },
+      {} as never,
+      ctx()
+    )) as { error?: string };
+    expect(res.error).toContain("until_at must not be before run_at");
+  });
+
+  test("update can set and clear timezone and until_at", async () => {
+    const created = (await manageSchedules(
+      {
+        action: "create",
+        description: "to be updated",
+        run_at: new Date(Date.now() + 3600_000).toISOString(),
+        cron: "0 9 * * *",
+        payload: basePayload,
+      },
+      {} as never,
+      ctx()
+    )) as { schedule: { id: string } };
+
+    const set = (await manageSchedules(
+      {
+        action: "update",
+        id: created.schedule.id,
+        timezone: "Asia/Taipei",
+        until_at: new Date(Date.now() + 24 * 3600_000).toISOString(),
+      },
+      {} as never,
+      ctx()
+    )) as { schedule: { timezone: string | null; until_at: string | null } };
+    expect(set.schedule.timezone).toBe("Asia/Taipei");
+    expect(set.schedule.until_at).not.toBeNull();
+
+    const cleared = (await manageSchedules(
+      { action: "update", id: created.schedule.id, timezone: null, until_at: null },
+      {} as never,
+      ctx()
+    )) as { schedule: { timezone: string | null; until_at: string | null } };
+    expect(cleared.schedule.timezone).toBeNull();
+    expect(cleared.schedule.until_at).toBeNull();
+  });
+});

--- a/packages/server/src/scheduled/__tests__/scheduled-jobs-tz-until.test.ts
+++ b/packages/server/src/scheduled/__tests__/scheduled-jobs-tz-until.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { getDb } from "../../db/client";
+import { nextRunAt } from "../../utils/cron";
 import {
   ensureDbForGatewayTests,
   resetTestDatabase,
@@ -68,6 +69,29 @@ async function readRow(id: string): Promise<ScheduledJobRow> {
 function minutesAgo(n: number): Date {
   return new Date(Date.now() - n * 60_000);
 }
+
+describe("nextRunAt timezone evaluation (no DB)", () => {
+  test("daily 9am survives spring-forward: Europe/London 2026-03-29 fires at 08:00Z", () => {
+    // UK clocks jump 01:00→02:00 on 2026-03-29. cron-parser 5.5.0 skipped
+    // this occurrence entirely (returned 03-30); fixed in 5.6.x.
+    expect(nextRunAt("0 9 * * *", new Date("2026-03-28T12:00:00Z"), "Europe/London")).toBe(
+      "2026-03-29T08:00:00.000Z"
+    );
+  });
+
+  test("daily 9am survives fall-back: Europe/London 2026-10-25 fires at 09:00Z", () => {
+    expect(nextRunAt("0 9 * * *", new Date("2026-10-24T12:00:00Z"), "Europe/London")).toBe(
+      "2026-10-25T09:00:00.000Z"
+    );
+  });
+
+  test("null timezone falls back to server-time evaluation", () => {
+    const next = new Date(nextRunAt("0 9 * * *", new Date("2026-03-28T12:00:00Z"), null));
+    expect(next.toISOString()).toBe(
+      new Date(nextRunAt("0 9 * * *", new Date("2026-03-28T12:00:00Z"))).toISOString()
+    );
+  });
+});
 
 describe("scheduled jobs: timezone-aware cron advance", () => {
   beforeAll(async () => {

--- a/packages/server/src/scheduled/scheduled-jobs-service.ts
+++ b/packages/server/src/scheduled/scheduled-jobs-service.ts
@@ -131,6 +131,9 @@ export interface ScheduledJobRow {
   delivery_context: ScheduledDeliveryContext | null;
   cron: string | null;
   next_run_at: string;
+  timezone: string | null;
+  until_at: string | null;
+  idempotency_key: string | null;
   last_fired_at: string | null;
   last_fired_run_id: number | null;
   paused: boolean;
@@ -152,6 +155,12 @@ interface CreateScheduledJobParams {
   description: string;
   cron?: string | null;
   runAt: Date;
+  /** IANA zone the cron is evaluated in; null/omitted = server time. */
+  timezone?: string | null;
+  /** Stop recurring after this instant; the ticker pauses the row instead of advancing past it. */
+  untilAt?: Date | null;
+  /** Client-chosen dedup key: a retried create with the same (org, key) returns the existing row. */
+  idempotencyKey?: string | null;
   createdByUser?: string | null;
   createdByAgent?: string | null;
   sourceRunId?: number | null;
@@ -166,20 +175,28 @@ export async function createScheduledJob(
     throw new Error('scheduled_jobs requires created_by_user or created_by_agent');
   }
   const sql = getDb();
+  // ON CONFLICT rides the partial unique index on (org, idempotency_key).
+  // The no-op DO UPDATE (vs DO NOTHING) makes RETURNING yield the existing
+  // row, so a retried create gets the original schedule back instead of a
+  // duplicate — or an empty result it would have to re-query for.
   const rows = (await sql`
     INSERT INTO scheduled_jobs (
       organization_id, action_type, action_args, delivery_context, cron, next_run_at,
+      timezone, until_at, idempotency_key,
       description,
       created_by_user, created_by_agent,
       source_run_id, source_event_id, source_thread_id
     ) VALUES (
       ${params.organizationId}, ${params.actionType},
       ${sql.json(params.actionArgs)}, ${params.deliveryContext ? sql.json(params.deliveryContext) : null}, ${params.cron ?? null}, ${params.runAt},
+      ${params.timezone ?? null}, ${params.untilAt ?? null}, ${params.idempotencyKey ?? null},
       ${params.description},
       ${params.createdByUser ?? null}, ${params.createdByAgent ?? null},
       ${params.sourceRunId ?? null}, ${params.sourceEventId ?? null},
       ${params.sourceThreadId ?? null}
     )
+    ON CONFLICT (organization_id, idempotency_key) WHERE idempotency_key IS NOT NULL
+    DO UPDATE SET idempotency_key = EXCLUDED.idempotency_key
     RETURNING *
   `) as unknown as ScheduledJobRow[];
   return rows[0];
@@ -239,6 +256,10 @@ interface UpdateScheduledJobParams {
   description?: string;
   /** `null` clears the cron (recurring → one-shot); a string sets a new cadence. */
   cron?: string | null;
+  /** `null` clears the zone (back to server time); a string sets a new zone. */
+  timezone?: string | null;
+  /** `null` clears the bound (recur forever); a Date sets/moves it. */
+  untilAt?: Date | null;
   /** Reschedule the next firing. */
   runAt?: Date;
   /** Replace the durable action payload (e.g. a new wake_agent prompt). */
@@ -257,11 +278,15 @@ export async function updateScheduledJob(
 ): Promise<ScheduledJobRow | null> {
   const sql = getDb();
   const setCron = params.cron !== undefined;
+  const setTimezone = params.timezone !== undefined;
+  const setUntilAt = params.untilAt !== undefined;
   const rows = (await sql`
     UPDATE scheduled_jobs
     SET
       description = COALESCE(${params.description ?? null}, description),
       cron = CASE WHEN ${setCron} THEN ${params.cron ?? null} ELSE cron END,
+      timezone = CASE WHEN ${setTimezone} THEN ${params.timezone ?? null} ELSE timezone END,
+      until_at = CASE WHEN ${setUntilAt} THEN ${params.untilAt ?? null} ELSE until_at END,
       next_run_at = COALESCE(${params.runAt ?? null}, next_run_at),
       action_args = COALESCE(${params.actionArgs ? sql.json(params.actionArgs) : null}, action_args),
       updated_at = now()
@@ -312,6 +337,19 @@ export function registerScheduledJobsTicker(scheduler: TaskScheduler): void {
       if (claimed.length === 0) return;
 
       for (const row of claimed) {
+        const untilAtMs = row.until_at ? new Date(row.until_at).getTime() : null;
+        // A due row past its until_at bound retires without firing. Normal
+        // advancement never lands next_run_at past until_at (see below), so
+        // this is only reachable when an update pushed run_at beyond the
+        // bound. Same conditional-advance guard as the paths below.
+        if (untilAtMs !== null && new Date(row.next_run_at).getTime() > untilAtMs) {
+          await sql`
+            UPDATE scheduled_jobs
+            SET paused = true, updated_at = now()
+            WHERE id = ${row.id} AND next_run_at <= now()
+          `;
+          continue;
+        }
         const tickIso = row.next_run_at;
         const idempotencyKey = `scheduled_job:${row.id}:${tickIso}`;
         try {
@@ -349,16 +387,20 @@ export function registerScheduledJobsTicker(scheduler: TaskScheduler): void {
         // re-claimed every tick. `<= now()` is a no-op once any pod has
         // advanced the row (next_run_at is then in the future) and never
         // clobbers an operator re-schedule to a future time.
-        const nextAt = row.cron ? nextCronTickAt(row.cron) : null;
-        if (nextAt) {
+        const nextAt = row.cron ? nextCronTickAt(row.cron, new Date(), row.timezone) : null;
+        // A recurring row whose next occurrence would land past until_at is
+        // done: fall through to the one-shot pause path instead of advancing.
+        const withinBound =
+          nextAt !== null && (untilAtMs === null || new Date(nextAt).getTime() <= untilAtMs);
+        if (withinBound) {
           await sql`
             UPDATE scheduled_jobs
             SET last_fired_at = now(), next_run_at = ${nextAt}, updated_at = now()
             WHERE id = ${row.id} AND next_run_at <= now()
           `;
         } else {
-          // One-shot: mark as fired + paused so the index ignores it.
-          // Re-pausing an already-paused row is idempotent.
+          // One-shot, or recurring past its until_at bound: mark as fired +
+          // paused so the index ignores it. Re-pausing is idempotent.
           await sql`
             UPDATE scheduled_jobs
             SET last_fired_at = now(), paused = true, updated_at = now()

--- a/packages/server/src/tools/admin/manage_schedules.ts
+++ b/packages/server/src/tools/admin/manage_schedules.ts
@@ -43,7 +43,7 @@ import {
 } from '../../scheduled/scheduled-jobs-service';
 import type { ToolContext, ToolSourceContext } from '../registry';
 import logger from '../../utils/logger';
-import { nextRunAt as nextCronTickAt } from '../../utils/cron';
+import { nextRunAt as nextCronTickAt, validateTimezone } from '../../utils/cron';
 import { getErrorMessage } from "@lobu/core";
 
 // ============================================
@@ -76,10 +76,26 @@ async function handleCreate(
   if (Number.isNaN(runAtDate.getTime())) {
     return { error: `run_at is not a valid ISO timestamp: ${args.run_at}` };
   }
-  // If cron is set, sanity-check it by computing the next tick from now.
+  if (args.timezone) {
+    const tzError = validateTimezone(args.timezone);
+    if (tzError) return { error: tzError };
+  }
+  let untilAtDate: Date | null = null;
+  if (args.until_at !== undefined) {
+    untilAtDate = new Date(args.until_at);
+    if (Number.isNaN(untilAtDate.getTime())) {
+      return { error: `until_at is not a valid ISO timestamp: ${args.until_at}` };
+    }
+    if (untilAtDate.getTime() < runAtDate.getTime()) {
+      return { error: 'until_at must not be before run_at.' };
+    }
+  }
+  // If cron is set, sanity-check it by computing the next tick from now —
+  // in the schedule's timezone, so a zone the parser can't handle is
+  // rejected here rather than blowing up the ticker later.
   if (args.cron) {
     try {
-      nextCronTickAt(args.cron);
+      nextCronTickAt(args.cron, new Date(), args.timezone);
     } catch (err) {
       return {
         error: `cron expression rejected: ${getErrorMessage(err)}`,
@@ -104,6 +120,9 @@ async function handleCreate(
     description: args.description,
     cron: args.cron ?? null,
     runAt: runAtDate,
+    timezone: args.timezone ?? null,
+    untilAt: untilAtDate,
+    idempotencyKey: args.idempotency_key ?? null,
     createdByUser: ctx.userId ?? null,
     createdByAgent: ctx.agentId ?? null,
     sourceRunId: args.source_run_id ?? null,
@@ -138,6 +157,10 @@ async function handleUpdate(
       return { error: `run_at is not a valid ISO timestamp: ${args.run_at}` };
     }
   }
+  if (typeof args.timezone === 'string') {
+    const tzError = validateTimezone(args.timezone);
+    if (tzError) return { error: tzError };
+  }
   // A string cron is validated (empty string rejected); explicit null clears
   // the cadence (recurring → one-shot); omitted leaves it unchanged.
   if (typeof args.cron === 'string') {
@@ -147,9 +170,20 @@ async function handleUpdate(
       };
     }
     try {
-      nextCronTickAt(args.cron);
+      nextCronTickAt(args.cron, new Date(), typeof args.timezone === 'string' ? args.timezone : undefined);
     } catch (err) {
       return { error: `cron expression rejected: ${getErrorMessage(err)}` };
+    }
+  }
+  let untilAt: Date | null | undefined;
+  if (args.until_at !== undefined) {
+    if (args.until_at === null) {
+      untilAt = null;
+    } else {
+      untilAt = new Date(args.until_at);
+      if (Number.isNaN(untilAt.getTime())) {
+        return { error: `until_at is not a valid ISO timestamp: ${args.until_at}` };
+      }
     }
   }
 
@@ -180,6 +214,8 @@ async function handleUpdate(
     id: args.id,
     description: args.description,
     cron: args.cron,
+    timezone: args.timezone,
+    untilAt,
     runAt,
     actionArgs,
   });
@@ -287,6 +323,9 @@ function serializeSchedule(row: ScheduledJobRow) {
     delivery_context: row.delivery_context,
     cron: row.cron,
     next_run_at: row.next_run_at,
+    timezone: row.timezone,
+    until_at: row.until_at,
+    idempotency_key: row.idempotency_key,
     last_fired_at: row.last_fired_at,
     last_fired_run_id: row.last_fired_run_id,
     paused: row.paused,

--- a/packages/server/src/utils/cron.ts
+++ b/packages/server/src/utils/cron.ts
@@ -10,10 +10,26 @@ const MIN_INTERVAL_MS = 60_000; // 1 minute minimum between runs
 /**
  * Compute the next run time from a cron expression.
  * Returns an ISO string suitable for storing in `next_run_at`.
+ *
+ * `tz` is an IANA zone name; when set, wall-clock fields in the expression
+ * ("0 9 * * *") are evaluated in that zone, DST included. When omitted the
+ * expression is evaluated in server time (UTC in prod).
  */
-export function nextRunAt(schedule: string, from: Date = new Date()): string {
-  const interval = CronExpressionParser.parse(schedule, { currentDate: from });
+export function nextRunAt(schedule: string, from: Date = new Date(), tz?: string | null): string {
+  const interval = CronExpressionParser.parse(schedule, { currentDate: from, tz: tz ?? undefined });
   return interval.next().toDate().toISOString();
+}
+
+/**
+ * Validate an IANA timezone name. Returns null if valid, error message if not.
+ */
+export function validateTimezone(tz: string): string | null {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return null;
+  } catch {
+    return `Unknown IANA timezone: ${tz}`;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- `nextRunAt()` now takes an IANA timezone and evaluates cron wall-clock fields in that zone (DST-aware via cron-parser's native `tz` option). `scheduled_jobs` advance passes the row's zone, so "9am daily Asia/Taipei" stays 9am Taipei year-round.
- `scheduled_jobs` gains three nullable columns: `timezone`, `until_at` (recurring schedules retire after the bound via the existing one-shot pause path), `idempotency_key` (retried create returns the existing schedule via ON CONFLICT no-op upsert on a partial unique index — no pre-SELECT).
- `manage_schedules` create/update accept `timezone` + `until_at` (update can clear with `null`); create accepts `idempotency_key`.
- Bumps cron-parser 5.5.0 → 5.6.1: 5.5.0 silently skips wall-clock occurrences landing on a DST spring-forward day (repro'd red on 5.5.0, green on 5.6.1; regression tests included).

Covers the same use-case as #1853 (bounded, deduplicated, timezone-correct schedules) with server-side timezone evaluation instead of storing client-compiled metadata — no `schedule_metadata`/`completed_at` columns, no tick-loop rewrite. The tick loop keeps its existing lock-free spawn+advance design; the only additions are the until_at retire branches and the tz-aware advance.

## Test plan
- [x] `bun run check:fix` clean
- [x] `make typecheck` passes
- [x] `make review BASE=origin/main` (codex): 0 blockers, 0 bugs after DST fix
- [x] New real-Postgres suite (15 tests): tz advance incl. DST spring-forward/fall-back regressions, all until_at semantics, create dedup within/across orgs
- [x] `bun test src/scheduled src/tools/admin/__tests__` 72 pass; `packages/cli` 612 pass; `packages/core` 636 pass
- [x] squawk clean on both migrations (nullable adds + CONCURRENTLY partial index)

## Notes
Replaces #1853.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786412441&installation_id=136316292&pr_number=1866&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1866&signature=54c8c99d472dfb1b786e82f03f85d9d98bdb640512362798b17b12dabb7e4a1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->