### PR TITLE
Resolver cutover for org provider keys + connector-ops prompt fix

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/apply-cmd.test.ts
@@ -7,6 +7,7 @@ import {
   validateConnectorState,
 } from "../apply-cmd.js";
 import type { ApplyClient, RemoteConnectorDefinition } from "../client.js";
+import { ApiError } from "../../../memory/_lib/errors.js";
 import type { DiffPlan, RemoteSnapshot } from "../diff.js";
 import {
   normalizeConnectionConfigScope,
@@ -224,122 +225,93 @@ describe("pushProviderApiKeys (#11 — provider keys pushed on a noop-only apply
     };
   }
 
-  test("pushes setProviderApiKey for every declared key (otherwise-noop agents)", async () => {
-    const setProviderApiKey = mock(async () => {
+  test("dedupes by provider and rotates the org inference-provider key", async () => {
+    const rotateInferenceProviderKey = mock(async () => {
       /* resolve void */
     });
-    const client = { setProviderApiKey } as unknown as ApplyClient;
+    const createInferenceProvider = mock(async () => ({}));
+    const client = {
+      rotateInferenceProviderKey,
+      createInferenceProvider,
+    } as unknown as ApplyClient;
     const agents = [
       agentWithKeys("a1", [
         { providerId: "anthropic", value: "k-anthropic" },
         { providerId: "openai", value: "k-openai" },
       ]),
-      agentWithKeys("a2", [{ providerId: "zai", value: "k-zai" }]),
+      // Same provider on a second agent: the key is ORG-scoped, so this is
+      // one push (last declaration wins — the previous per-agent PUTs
+      // overwrote the same org row, so last-wins was already the semantics).
+      agentWithKeys("a2", [
+        { providerId: "zai", value: "k-zai" },
+        { providerId: "anthropic", value: "k-anthropic-2" },
+      ]),
     ];
 
     await pushProviderApiKeys(client, agents);
 
-    expect(setProviderApiKey).toHaveBeenCalledTimes(3);
-    expect(setProviderApiKey).toHaveBeenCalledWith(
-      "a1",
+    expect(rotateInferenceProviderKey).toHaveBeenCalledTimes(3);
+    expect(rotateInferenceProviderKey).toHaveBeenCalledWith(
       "anthropic",
-      "k-anthropic"
+      "k-anthropic-2"
     );
-    expect(setProviderApiKey).toHaveBeenCalledWith("a1", "openai", "k-openai");
-    expect(setProviderApiKey).toHaveBeenCalledWith("a2", "zai", "k-zai");
+    expect(rotateInferenceProviderKey).toHaveBeenCalledWith(
+      "openai",
+      "k-openai"
+    );
+    expect(rotateInferenceProviderKey).toHaveBeenCalledWith("zai", "k-zai");
+    expect(createInferenceProvider).not.toHaveBeenCalled();
+  });
+
+  test("creates the org provider row when rotate 404s (no row yet)", async () => {
+    const rotateInferenceProviderKey = mock(async () => {
+      throw new ApiError("PUT .../key failed: Provider not found", 404);
+    });
+    const createInferenceProvider = mock(async () => ({}));
+    const client = {
+      rotateInferenceProviderKey,
+      createInferenceProvider,
+    } as unknown as ApplyClient;
+
+    await pushProviderApiKeys(client, [
+      agentWithKeys("a1", [{ providerId: "anthropic", value: "k-1" }]),
+    ]);
+
+    expect(createInferenceProvider).toHaveBeenCalledTimes(1);
+    expect(createInferenceProvider).toHaveBeenCalledWith({
+      slug: "anthropic",
+      kind: "anthropic",
+      apiKey: "k-1",
+    });
+  });
+
+  test("non-404 rotate failures propagate (no create fallback)", async () => {
+    const rotateInferenceProviderKey = mock(async () => {
+      throw new ApiError("PUT .../key failed: boom", 500);
+    });
+    const createInferenceProvider = mock(async () => ({}));
+    const client = {
+      rotateInferenceProviderKey,
+      createInferenceProvider,
+    } as unknown as ApplyClient;
+
+    await expect(
+      pushProviderApiKeys(client, [
+        agentWithKeys("a1", [{ providerId: "anthropic", value: "k-1" }]),
+      ])
+    ).rejects.toThrow(/boom/);
+    expect(createInferenceProvider).not.toHaveBeenCalled();
   });
 
   test("no-op when no agent declares a provider key", async () => {
-    const setProviderApiKey = mock(async () => {
+    const rotateInferenceProviderKey = mock(async () => {
       /* resolve void */
     });
-    const client = { setProviderApiKey } as unknown as ApplyClient;
+    const client = { rotateInferenceProviderKey } as unknown as ApplyClient;
 
     await pushProviderApiKeys(client, [agentWithKeys("a1", [])]);
 
-    expect(setProviderApiKey).not.toHaveBeenCalled();
-  });
-
-  // Regression: provider keys target `/agents/<id>/providers/...`, so on a
-  // FIRST apply the agent must be created (executePlan) BEFORE the key push, or
-  // the server 404s ("Agent not found"). This models that constraint and proves
-  // the helpers compose in the correct order.
-  describe("ordering with a first-apply create plan", () => {
-    function recordingClient(): {
-      client: ApplyClient;
-      order: string[];
-    } {
-      const createdAgents = new Set<string>();
-      const order: string[] = [];
-      const client = {
-        async upsertAgent(meta: { agentId: string }) {
-          createdAgents.add(meta.agentId);
-          order.push(`upsertAgent:${meta.agentId}`);
-        },
-        async setProviderApiKey(agentId: string, providerId: string) {
-          if (!createdAgents.has(agentId)) {
-            // Mirror the server: the agent must exist first.
-            throw new Error(`Agent not found: ${agentId}`);
-          }
-          order.push(`setProviderApiKey:${agentId}/${providerId}`);
-        },
-      } as unknown as ApplyClient;
-      return { client, order };
-    }
-
-    const desiredAgent = agentWithKeys("new-agent", [
-      { providerId: "anthropic", value: "k-anthropic" },
-    ]);
-    const state: DesiredState = {
-      agents: [desiredAgent],
-      prune: false,
-      memorySchema: { entityTypes: [], relationshipTypes: [] },
-      watchers: [],
-      connectors: { definitions: [], authProfiles: [], connections: [] },
-      requiredSecrets: [],
-    };
-    const plan: DiffPlan = {
-      rows: [
-        {
-          kind: "agent",
-          verb: "create",
-          id: "new-agent",
-          desired: desiredAgent.metadata,
-        },
-      ],
-      counts: { create: 1, update: 0, noop: 0, drift: 0, delete: 0 },
-      notes: [],
-    };
-    const remote = {
-      agents: [],
-      agentSettings: new Map(),
-      platformsByAgent: new Map(),
-      entityTypes: [],
-      relationshipTypes: [],
-      watchers: [],
-      connectorDefinitions: [],
-      authProfiles: [],
-      connections: [],
-      feedsByConnectionId: new Map(),
-    } as unknown as RemoteSnapshot;
-
-    test("executePlan THEN pushProviderApiKeys succeeds (agent exists first)", async () => {
-      const { client, order } = recordingClient();
-      await executePlan({ client, state, plan, remote }, []);
-      await pushProviderApiKeys(client, state.agents);
-      expect(order).toEqual([
-        "upsertAgent:new-agent",
-        "setProviderApiKey:new-agent/anthropic",
-      ]);
-    });
-
-    test("the reverse order (keys before create) reproduces the 404", async () => {
-      const { client } = recordingClient();
-      // Negative control: pushing keys before executePlan is the bug pi caught.
-      await expect(pushProviderApiKeys(client, state.agents)).rejects.toThrow(
-        /Agent not found/
-      );
-    });
+    expect(rotateInferenceProviderKey).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -612,32 +612,40 @@ interface ApplyContext {
 }
 
 /**
- * Push provider API keys as org-shared `agent_secrets` rows so the worker can
- * inject them at runtime without a per-user auth profile. Idempotent (PUT):
- * same value → 200, different value → rotation. Walks all desired agents (not
- * just those with a settings diff) — the secret value isn't part of the
- * settings JSON, so a row can need a key even when every resource is noop (e.g.
- * first apply after the gateway picked up support, or a key-only `.env`
- * change/rotation). Callers invoke this AFTER executePlan (so a just-created
- * agent exists before its `/agents/<id>/providers/...` key push), and also in
- * the all-noop / key-only branch (no agent creates there). Kept outside
- * `executePlan` so both paths can call it without double-pushing.
+ * Push provider API keys into the org's `inference_providers` store — the
+ * single org-key store the worker credential resolution reads (post
+ * resolver-cutover; the legacy `/agents/<id>/providers/<id>/api-key` route is
+ * gone). A key declared per agent in config is an ORG-scoped secret, so keys
+ * are deduped by provider — last declaration wins, matching the previous
+ * PUT-overwrite semantics — and pushed once each: rotate when the org
+ * provider row exists, create the row otherwise (slug doubles as kind;
+ * per-agent provider ids are catalog kinds). Idempotent either way. Walks all
+ * desired agents (not just those with a settings diff) — the secret value
+ * isn't part of the settings JSON, so a key can need pushing even when every
+ * resource is noop (e.g. a key-only `.env` change/rotation).
  */
 export async function pushProviderApiKeys(
   client: ApplyClient,
   agents: DesiredState["agents"]
 ): Promise<void> {
+  const keys = new Map<string, string>();
   for (const desired of agents) {
     for (const { providerId, value } of desired.providerKeys) {
-      await client.setProviderApiKey(
-        desired.metadata.agentId,
-        providerId,
-        value
-      );
-      printText(
-        chalk.dim(`  ↻ provider-key ${desired.metadata.agentId}/${providerId}`)
-      );
+      keys.set(providerId, value);
     }
+  }
+  for (const [providerId, value] of keys) {
+    try {
+      await client.rotateInferenceProviderKey(providerId, value);
+    } catch (err) {
+      if (!(err instanceof ApiError && err.status === 404)) throw err;
+      await client.createInferenceProvider({
+        slug: providerId,
+        kind: providerId,
+        apiKey: value,
+      });
+    }
+    printText(chalk.dim(`  ↻ provider-key ${providerId}`));
   }
 }
 
@@ -1442,11 +1450,9 @@ export async function applyCommand(opts: ApplyOptions = {}): Promise<void> {
   const pendingAuth: PendingAuthEntry[] = [];
   let applyErr: unknown;
   try {
-    // Resources FIRST: executePlan does `upsertAgent` for created agents, and
-    // `setProviderApiKey` targets `/agents/<id>/providers/...` — pushing keys
-    // before the agent exists 404s on a first apply. So run the plan, then push
-    // keys. (The all-noop / key-only short-circuit above pushes keys directly:
-    // there are no agent creates there, so the agents already exist remotely.)
+    // Resources first, then provider keys. Keys are org-scoped
+    // (inference_providers rows), so there is no agent-existence ordering
+    // constraint anymore — the order is kept for stable output only.
     if (hasResourceWork) {
       printText(chalk.bold("\nApplying:"));
       await executePlan({ client, state, plan, remote }, pendingAuth);

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -464,22 +464,6 @@ export class ApplyClient {
     await this.request("POST", `/api/${this.orgSlug}/deployments`, summary);
   }
 
-  /**
-   * Set (or rotate) the org-shared API key for a provider. Idempotent.
-   * Lands in `agent_secrets` under `provider:<id>:apiKey`, scoped to the org.
-   */
-  async setProviderApiKey(
-    agentId: string,
-    providerId: string,
-    value: string
-  ): Promise<void> {
-    await this.request(
-      "PUT",
-      `/api/${this.orgSlug}/agents/${encodeURIComponent(agentId)}/providers/${encodeURIComponent(providerId)}/api-key`,
-      { value }
-    );
-  }
-
   // ── Org inference providers ────────────────────────────────────────────────
   // Org-scoped, mounted UNDER the agents router (`/api/:orgSlug/agents`), so the
   // full path is `/api/<org>/agents/inference-providers…` — verified against

--- a/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
@@ -7,7 +7,9 @@ const TEST_ENCRYPTION_KEY = Buffer.from(
 
 // Controls what the mocked org context and db return per-test.
 let mockOrgId: string | null = null;
-let orgSharedSecretRows: Array<{ ciphertext: string }> = [];
+// One rows array serves both inference_providers reads: the invariant's
+// config read (block + ciphertext) and the org-key tier (ciphertext only) —
+// post-cutover both resolve through the same row.
 let inferenceProviderRows: Array<{
   block: { base_url?: string; model?: string } | null;
   ciphertext: string | null;
@@ -24,18 +26,14 @@ mock.module("../../../lobu/stores/org-context.js", () => ({
   },
 }));
 
-// Mock the db client. `readOrgSharedProviderKey` uses the postgres tagged
+// Mock the db client. Both provider-key reads use the postgres tagged
 // template (`sql\`SELECT ...\``); a tagged-template call invokes the function
 // with (strings, ...values), so returning the rows array satisfies it.
 mock.module("../../../db/client.js", () => ({
   PROD_PG_VALUE_OPTIONS: {},
   closeDbSingleton: async () => undefined,
-  getDb: () => (strings: TemplateStringsArray) =>
-    Promise.resolve(
-      strings.join(" ").includes("FROM inference_providers")
-        ? inferenceProviderRows
-        : orgSharedSecretRows
-    ),
+  getDb: () => (_strings: TemplateStringsArray) =>
+    Promise.resolve(inferenceProviderRows),
 }));
 
 // Import AFTER mocks so the module graph picks them up.
@@ -66,7 +64,6 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
     // Ensure no system key influences the result — we test the org-shared path.
     delete process.env.Z_AI_API_KEY;
     mockOrgId = null;
-    orgSharedSecretRows = [];
     inferenceProviderRows = [];
   });
 
@@ -82,10 +79,11 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
     expect(await mod.hasCredentials("agent-1")).toBe(true);
   });
 
-  test("returns true when only an org-shared API key exists (lobu apply path)", async () => {
-    // No auth profile, but `lobu apply` wrote provider:z-ai:apiKey for the org.
+  test("returns true when only the org provider-row key exists (lobu apply path)", async () => {
+    // No auth profile, and no per-modality block (a backfilled / plain row):
+    // the invariant declines and the org-key tier reads the row's vault key.
     mockOrgId = "org-1";
-    orgSharedSecretRows = [{ ciphertext: encrypt("zai-secret-value") }];
+    inferenceProviderRows = [{ block: null, ciphertext: encrypt("zai-secret-value") }];
 
     const mod = makeModule(false);
     // Pass org explicitly (as the worker session-context path now does) and
@@ -183,9 +181,9 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
     );
   });
 
-  test("returns false when neither profile nor org-shared key exists", async () => {
+  test("returns false when neither profile nor org provider row exists", async () => {
     mockOrgId = "org-1";
-    orgSharedSecretRows = [];
+    inferenceProviderRows = [];
     const mod = makeModule(false);
     expect(
       await mod.hasCredentials("agent-1", { organizationId: "org-1" })
@@ -193,9 +191,11 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
   });
 
   test("returns false when there is no org context and no profile", async () => {
-    // No org id anywhere → org-shared lookup short-circuits, no db hit.
+    // No org id anywhere → org-key lookup short-circuits, no db hit.
     mockOrgId = null;
-    orgSharedSecretRows = [{ ciphertext: encrypt("should-not-be-read") }];
+    inferenceProviderRows = [
+      { block: null, ciphertext: encrypt("should-not-be-read") },
+    ];
     const mod = makeModule(false);
     expect(await mod.hasCredentials("agent-1")).toBe(false);
   });

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -172,12 +172,11 @@ export abstract class BaseProviderModule
     // Keep this availability check aligned with resolveCredential(). An org
     // inference-provider row owns its key whether it uses the catalog URL or a
     // custom upstream; that key is intentionally absent from per-agent auth
-    // profiles and the legacy org-shared provider secret. Treat it as available
-    // so proxy-mode workers receive an opaque credential placeholder and can
-    // reach the gateway, where the invariant resolves the real key at egress.
-    // Conversely, a custom upstream with an unavailable key must fail closed
-    // even when a profile exists, because that profile is not consented for the
-    // custom URL.
+    // profiles. Treat it as available so proxy-mode workers receive an opaque
+    // credential placeholder and can reach the gateway, where the invariant
+    // resolves the real key at egress. Conversely, a custom upstream with an
+    // unavailable key must fail closed even when a profile exists, because
+    // that profile is not consented for the custom URL.
     const invariant = await resolveUrlInvariant(
       this.providerId,
       resolveOrgId(context?.organizationId) ?? undefined
@@ -197,11 +196,12 @@ export abstract class BaseProviderModule
     );
     if (hasProfile) return true;
     // Mirror the resolution chain in `buildEnvVars`: when no per-user auth
-    // profile exists, an org-shared API key written by `lobu apply`
-    // (`provider:<id>:apiKey` in agent_secrets) is a valid credential too.
-    // Without this, `lobu apply`-provisioned providers report no credentials,
-    // so primary-provider detection (and thus the worker's defaultProvider /
-    // model resolution) silently fails until the gateway is restarted.
+    // profile exists, the org's inference-provider row key (written by
+    // `lobu apply` / the console; row-unique vault name) is a valid credential
+    // too. Without this, `lobu apply`-provisioned providers report no
+    // credentials, so primary-provider detection (and thus the worker's
+    // defaultProvider / model resolution) silently fails until the gateway is
+    // restarted.
     return (await readOrgSharedProviderKey(this.providerId, context)) !== null;
   }
 

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -4,7 +4,7 @@
  * All routes are org-scoped via mcpAuth middleware and orgContext.
  */
 
-import { type AuthProfile, encrypt, isSdkCompat } from "@lobu/core";
+import { type AuthProfile, isSdkCompat } from "@lobu/core";
 import { Hono } from "hono";
 import { ensureBuilderAgent } from "../auth/builder-provisioning";
 import { mcpAuth } from "../auth/middleware";
@@ -44,7 +44,6 @@ import {
 	isInferenceModality,
 	isValidInferenceProviderSlug,
 	listInferenceProviders,
-	providerOrgSecretName,
 	rotateInferenceProviderKey,
 	setInferenceProviderDefault,
 	softDeleteInferenceProvider,
@@ -1406,69 +1405,6 @@ routes.get("/:agentId/guardrail-judge-default", async (c) => {
 	return c.json({
 		defaultModel: process.env.EGRESS_JUDGE_MODEL?.trim() || null,
 	});
-});
-
-// ── Set the org-shared API key for a provider ────────────────────────────────
-//
-// Writes (or rotates) the org-wide API key declared via `lobu apply` from
-// `[[agents.<id>.providers]] key = "$VAR"`. The key lands in `agent_secrets`
-// under `provider:<id>:apiKey`, scoped to the org. The worker's credential
-// resolution (base-provider-module.ts) checks per-user `auth_profiles` first,
-// then this row, then `process.env` — so per-user BYOK still wins.
-//
-// `:agentId` is in the path so the auth/admin gate matches the rest of this
-// router; the secret itself is org-scoped, not per-agent (one z-ai key for the
-// whole org). PUT is idempotent; same name overwrites.
-
-// TODO(inference-providers): remove after resolver cutover
-routes.put("/:agentId/providers/:providerId/api-key", async (c) => {
-	const denied = requireSessionOrAdminPat(c);
-	if (denied) return denied;
-	const { agentId, providerId } = c.req.param();
-
-	if (!(await configStore.hasAgent(agentId))) {
-		return c.json({ error: "Agent not found" }, 404);
-	}
-
-	let body: { value?: unknown };
-	try {
-		body = await c.req.json();
-	} catch {
-		return c.json({ error: "Invalid or missing JSON body" }, 400);
-	}
-	const value = typeof body.value === "string" ? body.value.trim() : "";
-	if (!value) {
-		return c.json(
-			{ error: "Body must include a non-empty `value` string" },
-			400,
-		);
-	}
-
-	const ciphertext = encrypt(value);
-	const name = providerOrgSecretName(providerId);
-	const orgId = (c.get("organizationId") as string | undefined) ?? null;
-	if (!orgId) {
-		return c.json({ error: "Organization context not available" }, 500);
-	}
-
-	const sql = getDb();
-	await sql`
-    INSERT INTO agent_secrets (organization_id, name, ciphertext, created_at, updated_at)
-    VALUES (${orgId}, ${name}, ${ciphertext}, now(), now())
-    ON CONFLICT (organization_id, name) DO UPDATE SET
-      ciphertext = EXCLUDED.ciphertext,
-      updated_at = now()
-  `;
-	// Metadata-only: provider keys are audited but never snapshotted (the
-	// writer forces `state` to null for this kind regardless).
-	emitConfigChange(c, {
-		resourceKind: "provider-key",
-		resourceId: `${providerId}`,
-		op: "updated",
-		summary: `Org API key for provider '${providerId}' set`,
-		state: null,
-	});
-	return c.json({ success: true, name });
 });
 
 // ── Update agent config (settings) ───────────────────────────────────────────

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1162,8 +1162,18 @@ routes.put("/inference-providers/:slug/key", async (c) => {
 		);
 	}
 
-	const ok = await rotateInferenceProviderKey(orgId, slug, value);
-	if (!ok) return c.json({ error: "Provider not found" }, 404);
+	const outcome = await rotateInferenceProviderKey(orgId, slug, value);
+	if (outcome === "not_found") {
+		return c.json({ error: "Provider not found" }, 404);
+	}
+	if (outcome === "oauth_provider") {
+		return c.json(
+			{
+				error: `Provider '${slug}' signs in via OAuth — it has no API key to rotate`,
+			},
+			400,
+		);
+	}
 	// Metadata-only: key rotations are audited but the value is never snapshotted.
 	emitConfigChange(c, {
 		resourceKind: "inference-provider",

--- a/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
@@ -170,10 +170,19 @@ describe('inference-provider store', () => {
     expect(await readOrgSharedProviderApiKey('claude', ORG)).toBeNull();
 
     // Rotating an OAuth-backed row is rejected: a vault write would be
-    // silently unread behind the oauth:// ref.
+    // silently unread behind the oauth:// ref. Prove the vault is untouched
+    // byte-for-byte, not merely unreadable.
+    const db = getTestDb();
+    const vaultBefore = await db`
+      SELECT name, ciphertext FROM agent_secrets ORDER BY name
+    `;
     expect(await rotateInferenceProviderKey(ORG, 'claude', 'sk-new')).toBe(
       'oauth_provider'
     );
+    const vaultAfter = await db`
+      SELECT name, ciphertext FROM agent_secrets ORDER BY name
+    `;
+    expect(Array.from(vaultAfter)).toEqual(Array.from(vaultBefore));
     expect(await readOrgSharedProviderApiKey('claude', ORG)).toBeNull();
 
     const listed = await getInferenceProviderBySlug(ORG, 'claude');

--- a/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/inference-provider-store.test.ts
@@ -16,6 +16,7 @@ import {
   getInferenceProviderBySlug,
   getOrgDefaultModel,
   listInferenceProviders,
+  readOrgSharedProviderApiKey,
   resolveInferenceProviderConfig,
   rotateInferenceProviderKey,
   setInferenceProviderDefault,
@@ -85,14 +86,23 @@ describe('inference-provider store', () => {
 
     // ── rotate the key (same immutable ref) ───────────────────────────────
     expect(await rotateInferenceProviderKey(ORG, 'openai', 'sk-rotated')).toBe(
-      true
+      'rotated'
     );
     expect(await readKey(ORG, 'openai')).toBe('sk-rotated');
+    // The resolver-cutover reader (worker-spawn / egress tier) resolves the
+    // same row-unique vault name.
+    expect(await readOrgSharedProviderApiKey('openai', ORG)).toBe('sk-rotated');
+
+    // ── rotate outcomes: missing slug / OAuth-backed row ──────────────────
+    expect(
+      await rotateInferenceProviderKey(ORG, 'no-such-slug', 'sk-x')
+    ).toBe('not_found');
 
     // ── soft-delete ───────────────────────────────────────────────────────
     expect(await softDeleteInferenceProvider(ORG, 'openai')).toBe(true);
     expect(await getInferenceProviderBySlug(ORG, 'openai')).toBeNull();
     expect(await listInferenceProviders(ORG)).toHaveLength(0);
+    expect(await readOrgSharedProviderApiKey('openai', ORG)).toBeNull();
 
     // ── recreate the same slug succeeds (fresh id, fresh keyref) ──────────
     // Give it a text block so the key is resolvable via the modality resolver.
@@ -155,6 +165,16 @@ describe('inference-provider store', () => {
     expect(repaired.capabilities).toEqual({});
     expect(repaired.hasCustomUpstream).toBe(false);
     expect(await readKey(ORG, 'claude')).toBeNull();
+    // The org-key tier must not serve the pre-repair vault key either — the
+    // oauth:// ref never joins to a vault secret.
+    expect(await readOrgSharedProviderApiKey('claude', ORG)).toBeNull();
+
+    // Rotating an OAuth-backed row is rejected: a vault write would be
+    // silently unread behind the oauth:// ref.
+    expect(await rotateInferenceProviderKey(ORG, 'claude', 'sk-new')).toBe(
+      'oauth_provider'
+    );
+    expect(await readOrgSharedProviderApiKey('claude', ORG)).toBeNull();
 
     const listed = await getInferenceProviderBySlug(ORG, 'claude');
     expect(listed?.apiKeyRef).toBe(repaired.apiKeyRef);

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -692,25 +692,33 @@ export async function updateInferenceProviderCoreFields(
  * Rotate a provider's api key: re-encrypt into the SAME api_key_ref name (the
  * ref is immutable). Returns false when no live row exists for the slug.
  */
+export type RotateInferenceProviderKeyResult =
+	| "rotated"
+	| "not_found"
+	/** The row signs in via OAuth (`oauth://` api_key_ref) — it has no vault
+	 *  key to rotate, and writing one would be silently unread. */
+	| "oauth_provider";
+
 export async function rotateInferenceProviderKey(
 	organizationId: string,
 	slug: string,
 	apiKey: string,
-): Promise<boolean> {
+): Promise<RotateInferenceProviderKeyResult> {
 	const sql = getDb();
 	const ciphertext = encrypt(apiKey);
 
 	return await sql.begin(async (tx) => {
 		const rows = (await tx`
-			SELECT id
+			SELECT id, api_key_ref
 			FROM inference_providers
 			WHERE organization_id = ${organizationId} AND slug = ${slug}
 			  AND deleted_at IS NULL
 			LIMIT 1
 			FOR UPDATE
-		`) as Array<{ id: string | number }>;
+		`) as Array<{ id: string | number; api_key_ref: string }>;
 		const row = rows[0];
-		if (!row) return false;
+		if (!row) return "not_found";
+		if (isOAuthInferenceProviderRef(row.api_key_ref)) return "oauth_provider";
 
 		const secretName = inferenceProviderSecretName(slug, Number(row.id));
 
@@ -721,7 +729,7 @@ export async function rotateInferenceProviderKey(
 			DO UPDATE SET ciphertext = EXCLUDED.ciphertext, updated_at = now()
 		`;
 
-		return true;
+		return "rotated";
 	});
 }
 

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -690,7 +690,9 @@ export async function updateInferenceProviderCoreFields(
 
 /**
  * Rotate a provider's api key: re-encrypt into the SAME api_key_ref name (the
- * ref is immutable). Returns false when no live row exists for the slug.
+ * ref is immutable). Returns "not_found" when no live row exists for the slug
+ * and "oauth_provider" for an OAuth-backed row (its `oauth://` ref never reads
+ * the vault, so a write would be silently unused).
  */
 export type RotateInferenceProviderKeyResult =
 	| "rotated"

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -747,10 +747,6 @@ export async function softDeleteInferenceProvider(
 	return rows.length > 0;
 }
 
-export function providerOrgSecretName(providerId: string): string {
-	return `provider:${providerId}:apiKey`;
-}
-
 /**
  * Vault row name for one credential field of a runtime environment. Keyed by
  * `environments.id` (not provider kind) so two environments of the same
@@ -830,6 +826,12 @@ export async function readEnvironmentSecret(
  * this tier: run dispatch checks it via `hasCredentials`, so a proxy that
  * skips it lets an apply-provisioned org dispatch its agent only to 401 at
  * the first provider call.
+ *
+ * Post-cutover this resolves through the org's `inference_providers` row for
+ * the slug (= the module providerId) to its row-unique `<slug>-<id>` vault
+ * name — the same name `createInferenceProvider` / `rotateInferenceProviderKey`
+ * write. The legacy `provider:<id>:apiKey` rows are converged into these by
+ * the backfill task (backfill-inference-providers.ts) and are no longer read.
  */
 export async function readOrgSharedProviderApiKey(
 	providerId: string,
@@ -837,11 +839,15 @@ export async function readOrgSharedProviderApiKey(
 ): Promise<string | null> {
 	const sql = getDb();
 	const rows = (await sql`
-    SELECT ciphertext
-    FROM agent_secrets
-    WHERE organization_id = ${organizationId}
-      AND name = ${providerOrgSecretName(providerId)}
-      AND (expires_at IS NULL OR expires_at > now())
+    SELECT s.ciphertext
+    FROM inference_providers p
+    JOIN agent_secrets s
+      ON s.organization_id = p.organization_id
+     AND ('secret://' || p.organization_id || '/' || s.name) = p.api_key_ref
+     AND (s.expires_at IS NULL OR s.expires_at > now())
+    WHERE p.organization_id = ${organizationId}
+      AND p.slug = ${providerId}
+      AND p.deleted_at IS NULL
     LIMIT 1
   `) as Array<{ ciphertext: string }>;
 	const ciphertext = rows[0]?.ciphertext;

--- a/packages/server/src/scheduled/__tests__/backfill-inference-providers.test.ts
+++ b/packages/server/src/scheduled/__tests__/backfill-inference-providers.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Integration test for the inference-provider backfill — the convergence step
+ * the resolver cutover depends on (readOrgSharedProviderApiKey reads ONLY
+ * inference_providers-backed vault names). Seeds legacy
+ * `provider:<slug>:apiKey` secrets and asserts: row creation with the copied
+ * ciphertext, idempotency, the freshness pass (a legacy rotation newer than
+ * the row-unique copy is carried forward — and an older one is NOT), and the
+ * invalid-slug stranding counter.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { encrypt } from '@lobu/core';
+import { getDb } from '../../db/client';
+import {
+  ensureDbForGatewayTests,
+  resetTestDatabase,
+} from '../../gateway/__tests__/helpers/db-setup';
+import { readOrgSharedProviderApiKey } from '../../lobu/stores/provider-secrets';
+import { backfillInferenceProviders } from '../backfill-inference-providers';
+
+const ORG_ID = 'backfill-org';
+
+beforeAll(async () => {
+  await ensureDbForGatewayTests();
+});
+
+beforeEach(async () => {
+  await resetTestDatabase();
+  const sql = getDb();
+  await sql`
+    INSERT INTO organization (id, name, slug)
+    VALUES (${ORG_ID}, ${ORG_ID}, ${ORG_ID})
+    ON CONFLICT (id) DO NOTHING
+  `;
+});
+
+async function seedLegacySecret(slug: string, value: string): Promise<void> {
+  const sql = getDb();
+  await sql`
+    INSERT INTO agent_secrets (organization_id, name, ciphertext, created_at, updated_at)
+    VALUES (${ORG_ID}, ${`provider:${slug}:apiKey`}, ${encrypt(value)}, now(), now())
+    ON CONFLICT (organization_id, name)
+    DO UPDATE SET ciphertext = EXCLUDED.ciphertext, updated_at = now()
+  `;
+}
+
+describe('backfillInferenceProviders', () => {
+  test('mints a row from a legacy secret; the cutover resolver reads the copied key', async () => {
+    await seedLegacySecret('zorg', 'sk-legacy-1');
+
+    const result = await backfillInferenceProviders();
+    expect(result.created).toBe(1);
+    expect(result.errors).toBe(0);
+
+    const sql = getDb();
+    const rows = (await sql`
+      SELECT slug, kind, api_key_ref FROM inference_providers
+      WHERE organization_id = ${ORG_ID} AND deleted_at IS NULL
+    `) as Array<{ slug: string; kind: string; api_key_ref: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.slug).toBe('zorg');
+    expect(rows[0]?.kind).toBe('zorg');
+    expect(rows[0]?.api_key_ref.startsWith(`secret://${ORG_ID}/zorg-`)).toBe(
+      true
+    );
+
+    // The post-cutover resolver tier resolves the SAME key the legacy row held.
+    expect(await readOrgSharedProviderApiKey('zorg', ORG_ID)).toBe(
+      'sk-legacy-1'
+    );
+
+    // Idempotent: a second pass creates nothing and freshens nothing.
+    const again = await backfillInferenceProviders();
+    expect(again.created).toBe(0);
+    expect(again.freshened).toBe(0);
+  });
+
+  test('freshness pass carries a NEWER legacy rotation forward — never an older one', async () => {
+    await seedLegacySecret('zorg', 'sk-legacy-1');
+    await backfillInferenceProviders();
+
+    const sql = getDb();
+    // Simulate a rotation through the (now deleted) legacy route AFTER the
+    // create pass: the legacy row becomes strictly newer than the copy.
+    await sql`
+      UPDATE agent_secrets
+      SET updated_at = now() - interval '1 hour'
+      WHERE organization_id = ${ORG_ID} AND name LIKE 'zorg-%'
+    `;
+    await sql`
+      UPDATE agent_secrets
+      SET ciphertext = ${encrypt('sk-rotated-2')}, updated_at = now()
+      WHERE organization_id = ${ORG_ID} AND name = 'provider:zorg:apiKey'
+    `;
+
+    const result = await backfillInferenceProviders();
+    expect(result.freshened).toBe(1);
+    expect(await readOrgSharedProviderApiKey('zorg', ORG_ID)).toBe(
+      'sk-rotated-2'
+    );
+
+    // The reverse direction must be a no-op: an OLDER legacy row never
+    // clobbers a newer row-unique key.
+    await sql`
+      UPDATE agent_secrets
+      SET updated_at = now() - interval '2 hours'
+      WHERE organization_id = ${ORG_ID} AND name = 'provider:zorg:apiKey'
+    `;
+    const noop = await backfillInferenceProviders();
+    expect(noop.freshened).toBe(0);
+    expect(await readOrgSharedProviderApiKey('zorg', ORG_ID)).toBe(
+      'sk-rotated-2'
+    );
+  });
+
+  test('legacy names that are not valid slugs are counted, warned, and never minted', async () => {
+    await seedLegacySecret('Bad_Slug', 'sk-unreachable');
+
+    const result = await backfillInferenceProviders();
+    expect(result.invalidSlug).toBe(1);
+    expect(result.created).toBe(0);
+
+    const sql = getDb();
+    const rows = await sql`
+      SELECT id FROM inference_providers
+      WHERE organization_id = ${ORG_ID} AND deleted_at IS NULL
+    `;
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/server/src/scheduled/backfill-inference-providers.ts
+++ b/packages/server/src/scheduled/backfill-inference-providers.ts
@@ -38,6 +38,8 @@ export interface BackfillInferenceProvidersResult {
   created: number;
   skipped: number;
   invalidSlug: number;
+  /** Row-unique secrets refreshed from a NEWER legacy row (see freshness pass). */
+  freshened: number;
 }
 
 /**
@@ -53,6 +55,7 @@ export async function backfillInferenceProviders(): Promise<BackfillInferencePro
     created: 0,
     skipped: 0,
     invalidSlug: 0,
+    freshened: 0,
   };
 
   // Candidate legacy secrets that don't yet have a live inference_providers row
@@ -146,6 +149,42 @@ export async function backfillInferenceProviders(): Promise<BackfillInferencePro
         '[backfill-inference-providers] failed to backfill one provider',
       );
     }
+  }
+
+  // Freshness pass: a key rotated through the legacy
+  // `PUT /agents/:id/providers/:id/api-key` route AFTER the create pass ran
+  // landed only in the legacy `provider:<slug>:apiKey` row, so the row-unique
+  // `<slug>-<id>` copy the resolver reads went stale. Copy the legacy
+  // ciphertext forward wherever the legacy row is strictly newer. The legacy
+  // route is deleted in the same release as the resolver cutover, so this
+  // converges once and is a permanent no-op afterwards (new rotations write
+  // only the row-unique name).
+  try {
+    const freshened = (await sql`
+      UPDATE agent_secrets AS dst
+      SET ciphertext = src.ciphertext, updated_at = now()
+      FROM inference_providers p
+      JOIN agent_secrets src
+        ON src.organization_id = p.organization_id
+       AND src.name = 'provider:' || p.slug || ':apiKey'
+      WHERE dst.organization_id = p.organization_id
+        AND ('secret://' || p.organization_id || '/' || dst.name) = p.api_key_ref
+        AND p.deleted_at IS NULL
+        AND src.updated_at > dst.updated_at
+      RETURNING dst.name
+    `) as Array<{ name: string }>;
+    result.freshened = freshened.length;
+    if (freshened.length > 0) {
+      logger.info(
+        { freshened: freshened.length },
+        '[backfill-inference-providers] refreshed row-unique secrets from newer legacy rows',
+      );
+    }
+  } catch (error) {
+    logger.warn(
+      { err: error },
+      '[backfill-inference-providers] freshness pass failed; next tick retries',
+    );
   }
 
   return result;

--- a/packages/server/src/scheduled/backfill-inference-providers.ts
+++ b/packages/server/src/scheduled/backfill-inference-providers.ts
@@ -25,13 +25,11 @@
  */
 
 import { getDb } from '../db/client';
+import { isValidInferenceProviderSlug } from '../lobu/stores/provider-secrets';
 import logger from '../utils/logger';
 
 // Legacy org-shared provider secret name: `provider:<type>:apiKey`.
 const LEGACY_PROVIDER_SECRET_RE = /^provider:(.+):apiKey$/;
-
-// inference_providers.slug format: ^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$
-const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$/;
 
 export interface BackfillInferenceProvidersResult {
   scanned: number;
@@ -80,11 +78,18 @@ export async function backfillInferenceProviders(): Promise<BackfillInferencePro
     result.scanned++;
     const match = LEGACY_PROVIDER_SECRET_RE.exec(row.name);
     const slug = match?.[1];
-    if (!slug || !SLUG_RE.test(slug)) {
+    if (!slug || !isValidInferenceProviderSlug(slug)) {
       // A legacy type that isn't a valid slug (uppercase, too long, etc.) —
-      // can't be represented as an inference_providers row. Leave it for the
-      // resolver's legacy path; count it so operators can see the gap.
+      // can't be represented as an inference_providers row, and the resolver
+      // no longer has a legacy path, so this credential is unreachable. That
+      // was already true pre-cutover for module lookups (module providerIds
+      // are valid slugs), but WARN loudly so an operator sees the stranded
+      // row instead of a silent counter.
       result.invalidSlug++;
+      logger.warn(
+        { organization_id: row.organization_id, name: row.name },
+        '[backfill-inference-providers] legacy secret name is not a valid provider slug — credential is unreachable; migrate or delete it manually',
+      );
       continue;
     }
 

--- a/packages/server/src/scheduled/backfill-inference-providers.ts
+++ b/packages/server/src/scheduled/backfill-inference-providers.ts
@@ -38,6 +38,8 @@ export interface BackfillInferenceProvidersResult {
   invalidSlug: number;
   /** Row-unique secrets refreshed from a NEWER legacy row (see freshness pass). */
   freshened: number;
+  /** Per-row failures (logged at error level; the hourly tick retries them). */
+  errors: number;
 }
 
 /**
@@ -54,6 +56,7 @@ export async function backfillInferenceProviders(): Promise<BackfillInferencePro
     skipped: 0,
     invalidSlug: 0,
     freshened: 0,
+    errors: 0,
   };
 
   // Candidate legacy secrets that don't yet have a live inference_providers row
@@ -142,10 +145,13 @@ export async function backfillInferenceProviders(): Promise<BackfillInferencePro
         result.skipped++;
       }
     } catch (error) {
-      // A single org's failure must not abort the batch — log and continue so
-      // the rest of the fleet still converges. The next tick retries this one.
-      result.skipped++;
-      logger.warn(
+      // A single org's failure must not abort the batch — log at ERROR and
+      // continue so the rest of the fleet still converges (a poisoned row
+      // must not become a fleet-wide deploy freeze via the boot-time run).
+      // The hourly tick retries it; `errors` makes the failure visible in the
+      // result instead of hiding inside `skipped`.
+      result.errors++;
+      logger.error(
         {
           err: error,
           organization_id: row.organization_id,
@@ -164,31 +170,27 @@ export async function backfillInferenceProviders(): Promise<BackfillInferencePro
   // route is deleted in the same release as the resolver cutover, so this
   // converges once and is a permanent no-op afterwards (new rotations write
   // only the row-unique name).
-  try {
-    const freshened = (await sql`
-      UPDATE agent_secrets AS dst
-      SET ciphertext = src.ciphertext, updated_at = now()
-      FROM inference_providers p
-      JOIN agent_secrets src
-        ON src.organization_id = p.organization_id
-       AND src.name = 'provider:' || p.slug || ':apiKey'
-      WHERE dst.organization_id = p.organization_id
-        AND ('secret://' || p.organization_id || '/' || dst.name) = p.api_key_ref
-        AND p.deleted_at IS NULL
-        AND src.updated_at > dst.updated_at
-      RETURNING dst.name
-    `) as Array<{ name: string }>;
-    result.freshened = freshened.length;
-    if (freshened.length > 0) {
-      logger.info(
-        { freshened: freshened.length },
-        '[backfill-inference-providers] refreshed row-unique secrets from newer legacy rows',
-      );
-    }
-  } catch (error) {
-    logger.warn(
-      { err: error },
-      '[backfill-inference-providers] freshness pass failed; next tick retries',
+  // A freshness failure PROPAGATES: the boot-time caller fails closed on it
+  // (serving with a knowingly-stale key is worse than a restart), and the
+  // hourly scheduler retries via the runs-queue backoff path.
+  const freshened = (await sql`
+    UPDATE agent_secrets AS dst
+    SET ciphertext = src.ciphertext, updated_at = now()
+    FROM inference_providers p
+    JOIN agent_secrets src
+      ON src.organization_id = p.organization_id
+     AND src.name = 'provider:' || p.slug || ':apiKey'
+    WHERE dst.organization_id = p.organization_id
+      AND ('secret://' || p.organization_id || '/' || dst.name) = p.api_key_ref
+      AND p.deleted_at IS NULL
+      AND src.updated_at > dst.updated_at
+    RETURNING dst.name
+  `) as Array<{ name: string }>;
+  result.freshened = freshened.length;
+  if (freshened.length > 0) {
+    logger.info(
+      { freshened: freshened.length },
+      '[backfill-inference-providers] refreshed row-unique secrets from newer legacy rows',
     );
   }
 

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -82,11 +82,15 @@ export async function bootTaskScheduler(
   // one org's poisoned row must not become a fleet-wide deploy freeze; the
   // hourly tick retries it.
   const backfill = await backfillInferenceProviders();
-  if (
+  if (backfill.errors > 0) {
+    logger.error(
+      { ...backfill },
+      '[boot] backfill-inference-providers PARTIALLY converged — some rows failed; hourly tick retries them',
+    );
+  } else if (
     backfill.created > 0 ||
     backfill.freshened > 0 ||
-    backfill.invalidSlug > 0 ||
-    backfill.errors > 0
+    backfill.invalidSlug > 0
   ) {
     logger.info(
       { ...backfill },

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -68,6 +68,33 @@ export async function bootTaskScheduler(
   env: Env,
 ): Promise<TaskScheduler> {
   const scheduler = new TaskScheduler(coreServices.getQueue());
+
+  // Converge legacy provider secrets BEFORE this pod serves traffic: the org
+  // credential resolver reads ONLY inference_providers-backed vault names
+  // (resolver cutover), so a legacy-only org must have its rows minted before
+  // the first credential lookup. Idempotent and cheap once converged. Fail
+  // open on error — if this query fails the DB is unhealthy and credential
+  // reads would fail regardless; the hourly tick retries, and during a
+  // rolling deploy the old pods keep serving meanwhile.
+  try {
+    const backfill = await backfillInferenceProviders();
+    if (
+      backfill.created > 0 ||
+      backfill.freshened > 0 ||
+      backfill.invalidSlug > 0
+    ) {
+      logger.info(
+        { ...backfill },
+        '[boot] backfill-inference-providers converged before serving',
+      );
+    }
+  } catch (error) {
+    logger.error(
+      { err: error },
+      '[boot] backfill-inference-providers failed; hourly tick will retry',
+    );
+  }
+
   registerMaintenanceTasks(scheduler, env, coreServices);
   await scheduler.start();
 
@@ -252,9 +279,10 @@ function registerMaintenanceTasks(
   // row-unique keyref, empty capabilities so behavior is byte-identical). App
   // -level (NOT inline in a migration — the classifier-backfill outage
   // precedent), idempotent (ON CONFLICT DO NOTHING + candidate anti-join),
-  // single-claimant per tick (multi-replica safe). The first tick after a
-  // deploy converges the fleet without an operator step; hourly thereafter is
-  // plenty since it only matters until every legacy secret is migrated.
+  // single-claimant per tick (multi-replica safe). The PRIMARY run is awaited
+  // at boot in bootTaskScheduler (the resolver reads only backfilled names, so
+  // convergence must precede traffic); this hourly tick is the retry safety
+  // net for a failed boot run.
   scheduler.register(
     'backfill-inference-providers',
     async () => {

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -72,26 +72,25 @@ export async function bootTaskScheduler(
   // Converge legacy provider secrets BEFORE this pod serves traffic: the org
   // credential resolver reads ONLY inference_providers-backed vault names
   // (resolver cutover), so a legacy-only org must have its rows minted before
-  // the first credential lookup. Idempotent and cheap once converged. Fail
-  // open on error — if this query fails the DB is unhealthy and credential
-  // reads would fail regardless; the hourly tick retries, and during a
-  // rolling deploy the old pods keep serving meanwhile.
-  try {
-    const backfill = await backfillInferenceProviders();
-    if (
-      backfill.created > 0 ||
-      backfill.freshened > 0 ||
-      backfill.invalidSlug > 0
-    ) {
-      logger.info(
-        { ...backfill },
-        '[boot] backfill-inference-providers converged before serving',
-      );
-    }
-  } catch (error) {
-    logger.error(
-      { err: error },
-      '[boot] backfill-inference-providers failed; hourly tick will retry',
+  // the first credential lookup. Idempotent and cheap once converged.
+  //
+  // Failure semantics are deliberately split: a WHOLE-PASS throw (candidate
+  // scan / freshness UPDATE) propagates and fails the boot — serving with
+  // unconverged or knowingly-stale keys is worse than a pod restart, and
+  // during a rolling deploy the old pods keep serving. PER-ROW failures do
+  // NOT throw (they're counted in `errors` and logged inside the backfill):
+  // one org's poisoned row must not become a fleet-wide deploy freeze; the
+  // hourly tick retries it.
+  const backfill = await backfillInferenceProviders();
+  if (
+    backfill.created > 0 ||
+    backfill.freshened > 0 ||
+    backfill.invalidSlug > 0 ||
+    backfill.errors > 0
+  ) {
+    logger.info(
+      { ...backfill },
+      '[boot] backfill-inference-providers converged before serving',
     );
   }
 

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -119,20 +119,31 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
     if (operationConnections.length > 0) {
       sections.push(
         '',
-        '### Connector Operations (call via `run_sdk` → `client.operations.execute(...)`)'
+        '### Connector Operations',
+        // One path only: `run_sdk` → `client.operations.execute({ connector, operation, input })`.
+        // Deliberately NOT surfacing the local/mcp/openapi backend split — that
+        // is internal plumbing `execute` dispatches on, and showing it invites
+        // the agent to look for a separate MCP/HTTP tool that does not exist.
+        'Run any connector operation the same way: `run_sdk` → `client.operations.execute({ connector, operation, input })`. There is no separate per-connector tool.',
+        'Discover exact operation names + input schemas with `manage_operations.list_available({ include_input_schema: true })`.',
+        'Execution may be policy-gated: a gated op returns `status: "pending_approval"` (a run queued for a human). Surface that to the user rather than treating it as a failure.'
       );
       for (const conn of operationConnections) {
-        const actionCount =
+        const localOps =
           conn.actions_schema && typeof conn.actions_schema === 'object'
-            ? Object.keys(conn.actions_schema as Record<string, unknown>).length
-            : 0;
-        const mcpCount = conn.mcp_config ? 1 : 0;
-        const openApiCount = conn.openapi_config ? 1 : 0;
-        const totalSources = actionCount + mcpCount + openApiCount;
-        if (totalSources === 0) continue;
-        sections.push(
-          `- ${conn.key}: local actions ${actionCount}, mcp ${mcpCount}, openapi ${openApiCount}`
-        );
+            ? Object.keys(conn.actions_schema as Record<string, unknown>)
+            : [];
+        const hasMcp = !!conn.mcp_config;
+        const hasOpenApi = !!conn.openapi_config;
+        if (localOps.length === 0 && !hasMcp && !hasOpenApi) continue;
+        // Prefer showing concrete operation names; fall back to a discovery
+        // pointer when the ops live behind mcp/openapi backends (whose names
+        // aren't in actions_schema — list_available resolves them).
+        const detail =
+          localOps.length > 0
+            ? localOps.join(', ')
+            : 'operations via `manage_operations.list_available`';
+        sections.push(`- ${conn.key}: ${detail}`);
       }
     }
 

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -127,7 +127,7 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
         // `execute` dispatches on, and showing it invites the agent to look
         // for a separate MCP/HTTP tool that does not exist.
         'Run any connector operation the same way: `run_sdk` → `client.operations.execute({ connection_id, operation_key, input })`. There is no separate per-connector tool.',
-        'Discover each connection\'s `connection_id`, its `operation_key`s, and input schemas with `manage_operations.list_available({ include_input_schema: true })`.',
+        'Discover `operation_key`s and input schemas with `manage_operations.list_available({ include_input_schema: true })`; get the `connection_id` from `query_sdk` → `client.connections.list()`.',
         'Execution may be policy-gated: a gated op returns `status: "pending_approval"` (a run queued for a human). Surface that to the user rather than treating it as a failure.'
       );
       for (const conn of operationConnections) {

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -127,7 +127,7 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
         // `execute` dispatches on, and showing it invites the agent to look
         // for a separate MCP/HTTP tool that does not exist.
         'Run any connector operation the same way: `run_sdk` → `client.operations.execute({ connection_id, operation_key, input })`. There is no separate per-connector tool.',
-        'Discover `operation_key`s and input schemas with `manage_operations.list_available({ include_input_schema: true })`; get the `connection_id` from `query_sdk` → `client.connections.list()`.',
+        'Discover `operation_key`s and input schemas with `query_sdk` → `client.operations.listAvailable()`; get the `connection_id` with `client.connections.list()`.',
         'Execution may be policy-gated: a gated op returns `status: "pending_approval"` (a run queued for a human). Surface that to the user rather than treating it as a failure.'
       );
       for (const conn of operationConnections) {

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -120,12 +120,14 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       sections.push(
         '',
         '### Connector Operations',
-        // One path only: `run_sdk` → `client.operations.execute({ connector, operation, input })`.
-        // Deliberately NOT surfacing the local/mcp/openapi backend split — that
-        // is internal plumbing `execute` dispatches on, and showing it invites
-        // the agent to look for a separate MCP/HTTP tool that does not exist.
-        'Run any connector operation the same way: `run_sdk` → `client.operations.execute({ connector, operation, input })`. There is no separate per-connector tool.',
-        'Discover exact operation names + input schemas with `manage_operations.list_available({ include_input_schema: true })`.',
+        // One path only: `run_sdk` → `client.operations.execute(...)` with the
+        // REAL SDK signature (connection_id + operation_key — see
+        // sandbox/namespaces/operations.ts). Deliberately NOT surfacing the
+        // local/mcp/openapi backend split — that is internal plumbing
+        // `execute` dispatches on, and showing it invites the agent to look
+        // for a separate MCP/HTTP tool that does not exist.
+        'Run any connector operation the same way: `run_sdk` → `client.operations.execute({ connection_id, operation_key, input })`. There is no separate per-connector tool.',
+        'Discover each connection\'s `connection_id`, its `operation_key`s, and input schemas with `manage_operations.list_available({ include_input_schema: true })`.',
         'Execution may be policy-gated: a gated op returns `status: "pending_approval"` (a run queued for a human). Surface that to the user rather than treating it as a failure.'
       );
       for (const conn of operationConnections) {


### PR DESCRIPTION
## What

Two related cleanups, both review-hardened through four adversarial Codex rounds (final verdict: **MERGE, 96/100**).

### 1. Connector-ops prompt fix (`workspace-instructions.ts`)

The `### Connector Operations` section listed only backend COUNTS per connector (internal plumbing) and dropped the operation names already in hand. Now: one execution path (`run_sdk` → `client.operations.execute({ connection_id, operation_key, input })` — the **real** SDK signature; the first draft's `{connector, operation}` was caught in review), op names per connector, discovery via `client.operations.listAvailable()` + `client.connections.list()`, and `pending_approval` explained as a queued run rather than a failure. Prompt-cache safe: this block changes only on connection/connector config writes.

### 2. Provider-key resolver cutover (fulfils `TODO(inference-providers): remove after resolver cutover`)

The backfill (#earlier) prepared this as "a pure rename": every legacy `provider:<slug>:apiKey` secret got an `inference_providers` row whose `<slug>-<id>` vault name holds identical ciphertext. This PR lands the rename and deletes the legacy write path:

- **Reader**: `readOrgSharedProviderApiKey` (tier 2 for worker-spawn + egress proxy) now joins `inference_providers` → `agent_secrets` via `api_key_ref` — same linkage as `resolveInferenceProviderConfig`. Rows with a text block keep short-circuiting at the URL invariant; this tier serves plain/backfilled rows.
- **Boot-time convergence** (review blocker): the resolver stops reading legacy names the moment a pod boots, but the backfill ran only hourly — a legacy-only org could lose credentials for up to an hour post-deploy. The backfill now runs **awaited in `bootTaskScheduler`, before `httpServer.listen()`**, on both prod and embedded paths. Whole-pass failures fail the boot (fail closed); per-row failures are counted (`errors`) and logged at error level but don't deploy-freeze the fleet (hourly tick retries).
- **Freshness pass**: a key rotated through the legacy route after the create pass copied it existed only in the legacy row. The backfill now carries strictly-newer legacy ciphertext forward (idempotent; permanent no-op once the route is gone). Older legacy rows can never clobber newer keys.
- **Route deleted**: `PUT /:agentId/providers/:providerId/api-key` and `ApplyClient.setProviderApiKey` are gone. `lobu apply` now pushes keys through the org store: dedupe per provider (keys were always org-scoped; last-wins matches the old PUT-overwrite), rotate, create-on-404.
- **OAuth guard** (review finding): rotating an OAuth-backed row used to write a vault secret its `oauth://` ref never reads — silent success, invisible key. `rotateInferenceProviderKey` now returns `rotated | not_found | oauth_provider`; the route maps `oauth_provider` → 400, which surfaces through `lobu providers set-key` and apply.
- **Slug validation** (review finding): the backfill's local regex rejected 1-char slugs the canonical validator allows; it now uses `isValidInferenceProviderSlug`, and truly unmappable legacy names WARN per row (they were already unreachable for module lookups).

## Verification

- New **DB-backed integration test** for the backfill (bun:test + embedded Postgres, same harness as the reaper tests; discovered by the ci.yml bun:test job): mint + resolver readability, idempotency, freshness-forward, older-source no-clobber, invalid-slug stranding.
- Store round-trip suite (vitest + embedded Postgres) extended: typed rotate outcomes incl. `oauth_provider` with a byte-for-byte vault before/after assertion; `readOrgSharedProviderApiKey` across rotate and soft-delete. 9/9.
- Scheduled suite 39/39, credentials suite 10/10, apply-cmd suite 22/22 (rewritten for org-level push), server + cli `tsc` clean, biome clean.
- Codex confirmed: no remaining callers of the deleted route/method anywhere; both boot paths converge before listen; freshness SQL is valid, idempotent, org-scoped.

## Notes for reviewers

- A residual risk called out during review: if the web console (separate repo) calls the deleted route, it will 404 — repo-wide search here found no callers, and the route's docs describe it as the apply push target only.
- Console-created rows *without* a modality block previously had unreachable keys in the text chain (invariant declined, legacy tier missed); post-cutover their keys resolve — an intended improvement, not a behavior break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014meECSComSn1SZANxL8dAo

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786412756&installation_id=136316292&pr_number=1867&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1867&signature=b3051d50ac4a51dc2555fe5c3f70a1ce52dbfebf3a1d550aab75c07e1b332894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->