### PR TITLE
ci: promote knip unused-files to a blocking gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,9 +527,12 @@ jobs:
         run: bun run check:packages
 
       # Report-only for now: knip surfaces unused files / exports / deps to
-      # establish a baseline. Non-blocking (continue-on-error) until the
-      # baseline is triaged — then this can be promoted to a hard gate.
-      - name: Dead-code report (knip, non-blocking)
+      # The files section is a hard gate: a PR that adds an unreachable file
+      # fails CI. Exports/deps/types stay report-only until their baseline is
+      # triaged — promote sections into the gate by extending --include.
+      - name: Dead-code gate (knip, unused files)
+        run: bun run knip --include files
+      - name: Dead-code report (knip full, non-blocking)
         continue-on-error: true
         run: bun run knip
 

--- a/config/knip.ts
+++ b/config/knip.ts
@@ -93,6 +93,14 @@ const config: KnipConfig = {
         "@vitest/coverage-v8",
       ],
     },
+    "packages/openclaw-plugin": {
+      entry: [
+        // Referenced only as `vitest run --config …` CLI flags (test:e2e /
+        // test:unit scripts), which knip can't trace.
+        "test/e2e/vitest.config.ts",
+        "test/unit/vitest.config.ts",
+      ],
+    },
     "packages/cli": {
       entry: [
         // Tests run via `bun test packages/cli` in CI (nested __tests__ dirs).
@@ -162,6 +170,11 @@ const config: KnipConfig = {
         "vite",
         "winston",
         "zod",
+        // Server's Vercel runtime provider (gateway/runtime/providers/vercel.ts),
+        // reached only through the bundled server.
+        "@vercel/sandbox",
+        // Vendored into dist/vendor by scripts/build.cjs (file copy, no import).
+        "@lobu/pgvector-embedded",
       ],
     },
     ".": {
@@ -175,7 +188,9 @@ const config: KnipConfig = {
         "examples/**/*.connector.ts",
         "examples/**/*.reaction.ts",
         "examples/**/evals/**/*.ts",
-        "examples/**/skills/**/*.ts",
+        // Example test suites run in CI (`bun test examples/personal-agent`,
+        // `bun test examples/brand-intelligence`) and locally for the rest.
+        "examples/**/__tests__/**/*.ts",
       ],
     },
   },


### PR DESCRIPTION
## What

Makes the knip **unused-files** section a hard CI gate; the full report (exports / deps / types, ~250 findings) stays non-blocking until triaged.

## Config fixes that made the gate green

- `examples/**/__tests__/**` declared as entries — these suites run in CI (`bun test examples/personal-agent`, `bun test examples/brand-intelligence`); knip flagged all 10 as unused files. Also drops the stale `examples/**/skills/**` pattern (no matches, per knip's own hint).
- `packages/openclaw-plugin` test vitest configs declared as entries — referenced only via `vitest run --config …` CLI flags, which knip can't trace.
- `@vercel/sandbox` (server's Vercel runtime provider, reached through the bundled server) and `@lobu/pgvector-embedded` (vendored into dist/vendor by `scripts/build.cjs`, a file copy not an import) moved into the cli umbrella's `ignoreDependencies` with rationale comments.

## Evidence

`bun run knip --include files` → exit 0, zero findings (one non-fatal config hint).

Follow-up owed separately: triage the exports/types baseline, then extend `--include` to promote more sections.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786413230&installation_id=136316292&pr_number=1869&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1869&signature=f7139fa8ebd6d3dd7fe5f9fbf8ed8d093a950c0449e67c0938b0f5be0be0c73b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->