### PR TITLE
ci: collect coverage from all bun:test suites and the server integration suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,13 @@ jobs:
           cd packages/pgvector-embedded && bun run build && cd ../..
           cd packages/cli && bun run build && cd ../..
 
+      # bunfig.toml routes every `bun test --coverage` run to ./coverage/lcov.info
+      # (bun 1.3.x ignores --coverage-dir when bunfig sets coverageDir), so each
+      # step moves its report to a unique name before the next step overwrites it.
       - name: core / cli (bun:test)
-        run: bun test packages/core packages/cli --coverage
+        run: |
+          bun test packages/core packages/cli --coverage
+          mv coverage/lcov.info coverage/core-cli.lcov.info
 
       - name: worker (bun:test, full suite)
         # The previous CI cherry-picked 8 of 18 files because pi-coding-agent
@@ -89,7 +94,9 @@ jobs:
         # passes; if Linux turns out different we'll narrow this back down,
         # but we own the WASM concern via run-script-runtime.test.ts under
         # Node + isolated-vm in the integration job below.
-        run: bun test packages/agent-worker
+        run: |
+          bun test packages/agent-worker --coverage
+          mv coverage/lcov.info coverage/agent-worker.lcov.info
 
       - name: server (bun:test units)
         # The gateway code that used to live in packages/gateway is now under
@@ -98,27 +105,36 @@ jobs:
         # is intentionally NOT repeated here — see #1238). Here we only run the
         # pure-unit subdirectories that don't touch Postgres.
         run: |
-          bun test packages/server/src/__tests__/unit
-          bun test packages/server/src/auth/__tests__/tool-access.test.ts packages/server/src/auth/__tests__/system-provider-resolution.test.ts
+          bun test packages/server/src/__tests__/unit --coverage
+          mv coverage/lcov.info coverage/server-units.lcov.info
+          bun test packages/server/src/auth/__tests__/tool-access.test.ts packages/server/src/auth/__tests__/system-provider-resolution.test.ts --coverage
+          mv coverage/lcov.info coverage/server-units-auth.lcov.info
 
       - name: connector-worker (bun:test)
         # openclaw-plugin e2e tests need a live backend and belong in the
         # smoke-example workflow, not the unit job.
         run: |
-          bun test packages/connector-worker
+          bun test packages/connector-worker --coverage
+          mv coverage/lcov.info coverage/connector-worker.lcov.info
 
       - name: client / promptfoo-provider (bun:test)
         # Previously unrun in CI: the client SSE/auth suite and the
         # promptfoo-provider tests (which had no `test` script wired anywhere).
         # Neither needs Postgres.
-        run: bun test packages/client packages/promptfoo-provider
+        run: |
+          bun test packages/client packages/promptfoo-provider --coverage
+          mv coverage/lcov.info coverage/client-promptfoo.lcov.info
 
       - name: connector-sdk (bun:test)
         # Checkpoint/watermark + url-guards moved here from bundled scraper-utils.
-        run: bun test packages/connector-sdk
+        run: |
+          bun test packages/connector-sdk --coverage
+          mv coverage/lcov.info coverage/connector-sdk.lcov.info
 
       - name: connectors (bun:test)
-        run: bun test packages/connectors
+        run: |
+          bun test packages/connectors --coverage
+          mv coverage/lcov.info coverage/connectors.lcov.info
 
       - name: example connectors (bun:test)
         # Unbundled connectors live under examples/; mock @lobu/connector-sdk
@@ -131,7 +147,8 @@ jobs:
         if: always()
         uses: codecov/codecov-action@v7
         with:
-          files: coverage/lcov.info
+          files: coverage/core-cli.lcov.info,coverage/agent-worker.lcov.info,coverage/server-units.lcov.info,coverage/server-units-auth.lcov.info,coverage/connector-worker.lcov.info,coverage/client-promptfoo.lcov.info,coverage/connector-sdk.lcov.info,coverage/connectors.lcov.info
+          flags: unit
           fail_ci_if_error: false
 
   # SDK lifecycle e2e — the hard gate that the WHOLE TypeScript-SDK path runs,
@@ -385,8 +402,17 @@ jobs:
         # independently asserts zero failures — and a missing/unparseable
         # report (crashed run) also fails.
         run: |
-          node ../../node_modules/.bin/vitest run --reporter=default --reporter=json --outputFile.json="$RUNNER_TEMP/vitest-report.json"
+          node ../../node_modules/.bin/vitest run --reporter=default --reporter=json --outputFile.json="$RUNNER_TEMP/vitest-report.json" \
+            --coverage.enabled --coverage.provider=v8 --coverage.reporter=lcov --coverage.reportsDirectory=coverage
           node ../../scripts/assert-vitest-report-clean.mjs "$RUNNER_TEMP/vitest-report.json"
+
+      - name: Upload server integration coverage
+        if: always()
+        uses: codecov/codecov-action@v7
+        with:
+          files: packages/server/coverage/lcov.info
+          flags: server-integration
+          fail_ci_if_error: false
 
       - name: server gateway suites (bun:test, needs Postgres)
         # The gateway bun:test files are excluded from vitest (vitest.config.ts)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,15 +404,9 @@ jobs:
         run: |
           node ../../node_modules/.bin/vitest run --reporter=default --reporter=json --outputFile.json="$RUNNER_TEMP/vitest-report.json" \
             --coverage.enabled --coverage.provider=v8 --coverage.reporter=lcov --coverage.reportsDirectory=coverage
+          # vitest writes coverage/lcov.info; rename so later bun steps don't clobber it.
+          mv coverage/lcov.info coverage/vitest.lcov.info
           node ../../scripts/assert-vitest-report-clean.mjs "$RUNNER_TEMP/vitest-report.json"
-
-      - name: Upload server integration coverage
-        if: always()
-        uses: codecov/codecov-action@v7
-        with:
-          files: packages/server/coverage/lcov.info
-          flags: server-integration
-          fail_ci_if_error: false
 
       - name: server gateway suites (bun:test, needs Postgres)
         # The gateway bun:test files are excluded from vitest (vitest.config.ts)
@@ -427,6 +421,8 @@ jobs:
         # if a gateway test file ever escapes this loop. Covers
         # src/gateway/infrastructure/queue too (#1238). Run all dirs and fail at
         # the end so one run reports every failing dir, not just the first.
+        # packages/server/bunfig.toml routes --coverage to ./coverage/lcov.info
+        # (lcov only); each dir is moved to a unique name before the next overwrites it.
         working-directory: packages/server
         run: |
           set -uo pipefail
@@ -437,7 +433,11 @@ jobs:
           rc=0
           for d in $dirs; do
             echo "::group::bun test $d"
-            bun test "$d" || rc=1
+            bun test "$d" --coverage || rc=1
+            if [ -f coverage/lcov.info ]; then
+              safe=$(printf '%s' "$d" | tr '/' '-')
+              mv coverage/lcov.info "coverage/gateway-${safe}.lcov.info"
+            fi
             echo "::endgroup::"
           done
           exit $rc
@@ -449,7 +449,18 @@ jobs:
         # (src/lobu/stores/__tests__) that vitest owns, so we target
         # src/lobu/__tests__ specifically rather than the whole src/lobu tree.
         working-directory: packages/server
-        run: bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__ src/auth/oauth/__tests__
+        run: |
+          bun test src/lobu/__tests__ src/scheduled src/workspace/__tests__ src/tools/admin/__tests__ src/auth/oauth/__tests__ --coverage
+          mv coverage/lcov.info coverage/server-postgres-other.lcov.info
+
+      - name: Upload server integration coverage
+        if: always()
+        uses: codecov/codecov-action@v7
+        with:
+          # vitest + every instrumented bun:test step above write into this dir.
+          directory: packages/server/coverage
+          flags: server-integration
+          fail_ci_if_error: false
 
   format-lint:
     runs-on: ubuntu-latest

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -3,4 +3,7 @@ linker = "hoisted"
 
 [test]
 coverageDir = "coverage"
-coverageReporter = ["text", "lcov"]
+# lcov only: the text reporter's table deterministically crashes bun 1.3.5 with
+# "An internal error occurred (WriteFailed)" on large packages (server units) in
+# CI. CLI flags can't override this (bunfig wins over --coverage-reporter).
+coverageReporter = ["lcov"]

--- a/packages/server/bunfig.toml
+++ b/packages/server/bunfig.toml
@@ -1,2 +1,5 @@
 [test]
 preload = ["./src/__tests__/setup/bun-test-teardown.ts"]
+coverageDir = "coverage"
+# Match root bunfig: text reporter crashes bun 1.3.5 on large suites (WriteFailed).
+coverageReporter = ["lcov"]


### PR DESCRIPTION
## What

Closes the coverage gap found in the 2026-07-12 codebase audit: CI collected coverage only for core+cli (~10% of executable code); the server — 58% of the codebase — and every other package ran uninstrumented.

- **All bun:test unit-job steps now run `--coverage`** (agent-worker, server units, connector-worker, client/promptfoo, connector-sdk, connectors). bunfig routes every run to `./coverage/lcov.info` and **bun 1.3.x ignores `--coverage-dir` when bunfig sets `coverageDir`** (verified locally), so each step `mv`s its report to a unique name; the codecov upload lists all eight (`flags: unit`).
- **Server integration suite (vitest under Node)** runs with `--coverage.enabled --coverage.provider=v8 --coverage.reporter=lcov` and uploads separately (`flags: server-integration`). `@vitest/coverage-v8` was already a server devDependency (knip config even anticipated it).
- Example-connector suites stay uninstrumented deliberately — example coverage isn't a meaningful signal.

No thresholds yet — this PR is visibility only; ratchet later once a baseline exists.

## Evidence

- `bun test packages/promptfoo-provider --coverage` locally → lcov produced; confirmed the `--coverage-dir` bunfig-precedence quirk that motivated the mv pattern.
- `vitest run src/utils/stable-keys.test.ts --coverage.enabled --coverage.provider=v8 --coverage.reporter=lcov` in packages/server → 8/8 pass, `coverage/lcov.info` written.
- This PR's own CI run exercises every changed step end-to-end.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786413463&installation_id=136316292&pr_number=1871&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1871&signature=c3b3231d40bcd9cb7153064b88a1ca82c7984b6a57d7c72d93ba582b7a2cf4fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->