### PR TITLE
feat(providers): stop writing legacy provider:<id>:apiKey secrets — resolver cutover

### DIFF
--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -466,7 +466,9 @@ export class ApplyClient {
 
   /**
    * Set (or rotate) the org-shared API key for a provider. Idempotent.
-   * Lands in `agent_secrets` under `provider:<id>:apiKey`, scoped to the org.
+   * Lands as an org-scoped `inference_providers` row plus its row-unique
+   * `<slug>-<id>` secret (the server rejects provider ids that aren't valid
+   * slugs with a 400).
    */
   async setProviderApiKey(
     agentId: string,

--- a/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
@@ -12,6 +12,10 @@ let inferenceProviderRows: Array<{
   block: { base_url?: string; model?: string } | null;
   ciphertext: string | null;
 }> = [];
+// Rows returned for the row-unique `<slug>-<id>` secret lookup that
+// `readOrgSharedProviderApiKey` performs against the org's live
+// inference_providers row (the post-cutover write shape, issue #1868).
+let rowKeyedSecretRows: Array<{ ciphertext: string }> = [];
 
 // Mock the org-context AsyncLocalStorage lookup so we can simulate a worker
 // request that does (or doesn't) carry an org.
@@ -30,12 +34,15 @@ mock.module("../../../lobu/stores/org-context.js", () => ({
 mock.module("../../../db/client.js", () => ({
   PROD_PG_VALUE_OPTIONS: {},
   closeDbSingleton: async () => undefined,
-  getDb: () => (strings: TemplateStringsArray) =>
-    Promise.resolve(
-      strings.join(" ").includes("FROM inference_providers")
-        ? inferenceProviderRows
-        : orgSharedSecretRows
-    ),
+  getDb: () => (strings: TemplateStringsArray) => {
+    const query = strings.join(" ");
+    // `resolveInferenceProviderConfig` selects `capabilities -> $mod AS block`;
+    // the row-keyed secret read joins on api_key_ref without an AS block.
+    if (query.includes("AS block")) return Promise.resolve(inferenceProviderRows);
+    if (query.includes("FROM inference_providers"))
+      return Promise.resolve(rowKeyedSecretRows);
+    return Promise.resolve(orgSharedSecretRows);
+  },
 }));
 
 // Import AFTER mocks so the module graph picks them up.
@@ -68,6 +75,7 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
     mockOrgId = null;
     orgSharedSecretRows = [];
     inferenceProviderRows = [];
+    rowKeyedSecretRows = [];
   });
 
   afterEach(() => {
@@ -125,6 +133,39 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
     expect(await mod.hasCredentials("agent-1", context)).toBe(true);
     expect(await mod.buildEnvVars("agent-1", {}, context)).toEqual({
       Z_AI_API_KEY: "zai-inference-provider-key",
+    });
+  });
+
+  test("resolves the org key from a cutover-shape inference-provider row (no text block, row-unique secret)", async () => {
+    // Post-cutover write shape (issue #1868): `lobu apply` creates an
+    // inference_providers row with EMPTY capabilities plus a row-unique
+    // `<slug>-<id>` secret — and no legacy provider:<id>:apiKey row at all.
+    // `resolveInferenceProviderConfig` returns null for such a row (no text
+    // block), so tier 2 (`readOrgSharedProviderApiKey`) must find the
+    // row-keyed secret or apply-pushed keys silently stop working.
+    mockOrgId = "org-1";
+    inferenceProviderRows = []; // no text block ⇒ invariant: no-custom-upstream
+    rowKeyedSecretRows = [{ ciphertext: encrypt("zai-row-unique-key") }];
+    orgSharedSecretRows = []; // legacy name absent — nothing wrote it
+
+    const mod = makeModule(false);
+    const context = { organizationId: "org-1" };
+    expect(await mod.hasCredentials("agent-1", context)).toBe(true);
+    expect(await mod.buildEnvVars("agent-1", {}, context)).toEqual({
+      Z_AI_API_KEY: "zai-row-unique-key",
+    });
+  });
+
+  test("row-unique secret outranks a stale legacy provider:<id>:apiKey row", async () => {
+    // Backfilled org: both names exist. Rotation only rewrites the row-unique
+    // secret, so the read must prefer it over the stale legacy copy.
+    mockOrgId = "org-1";
+    rowKeyedSecretRows = [{ ciphertext: encrypt("fresh-rotated-key") }];
+    orgSharedSecretRows = [{ ciphertext: encrypt("stale-legacy-key") }];
+
+    const mod = makeModule(false);
+    expect(await mod.buildEnvVars("agent-1", {}, { organizationId: "org-1" })).toEqual({
+      Z_AI_API_KEY: "fresh-rotated-key",
     });
   });
 

--- a/packages/server/src/gateway/auth/base-provider-module.ts
+++ b/packages/server/src/gateway/auth/base-provider-module.ts
@@ -197,8 +197,10 @@ export abstract class BaseProviderModule
     );
     if (hasProfile) return true;
     // Mirror the resolution chain in `buildEnvVars`: when no per-user auth
-    // profile exists, an org-shared API key written by `lobu apply`
-    // (`provider:<id>:apiKey` in agent_secrets) is a valid credential too.
+    // profile exists, an org-shared API key written by `lobu apply` is a valid
+    // credential too — the inference_providers row's `<slug>-<id>` secret
+    // (post-cutover shape, #1868) or the read-only legacy
+    // `provider:<id>:apiKey` row; `readOrgSharedProviderApiKey` resolves both.
     // Without this, `lobu apply`-provisioned providers report no credentials,
     // so primary-provider detection (and thus the worker's defaultProvider /
     // model resolution) silently fails until the gateway is restarted.

--- a/packages/server/src/lobu/__tests__/agent-routes-provider-api-key.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-provider-api-key.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Resolver-cutover contract for `PUT /:agentId/providers/:providerId/api-key`
+ * (issue #1868): the apply-pushed org provider key must land as an
+ * `inference_providers` row + row-unique `<slug>-<id>` agent_secrets entry —
+ * the same shape `backfill-inference-providers` produces — and must NOT write
+ * the legacy `provider:<id>:apiKey` name anymore.
+ *
+ * Read-path invariants covered here too:
+ *   - `readOrgSharedProviderApiKey` (tier 2 of the worker credential chain and
+ *     the egress secret-proxy fallback) resolves the NEW shape;
+ *   - pre-existing legacy `provider:<id>:apiKey` rows still resolve (read-only
+ *     fallback stays until the fleet is converged);
+ *   - when both exist (backfilled orgs), the row-unique secret wins — rotations
+ *     only ever touch the row secret, so the legacy copy can go stale.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { decrypt, encrypt } from "@lobu/core";
+import {
+	ensureDbForGatewayTests,
+	resetTestDatabase,
+	seedAgentRow,
+} from "../../gateway/__tests__/helpers/db-setup.js";
+import { orgContext } from "../stores/org-context";
+import { authStash, installRouteTestMocks } from "./helpers/route-test-mocks";
+
+installRouteTestMocks();
+
+const ORG = "org-provider-key";
+const AGENT = "agent-provider-key";
+
+let app: import("hono").Hono;
+let sql: ReturnType<typeof import("../../db/client.js").getDb>;
+let readOrgSharedProviderApiKey: typeof import("../stores/provider-secrets.js").readOrgSharedProviderApiKey;
+
+beforeAll(async () => {
+	await ensureDbForGatewayTests();
+	const routes = await import("../agent-routes.js");
+	app = routes.agentRoutes;
+	const dbClient = await import("../../db/client.js");
+	sql = dbClient.getDb();
+	({ readOrgSharedProviderApiKey } = await import(
+		"../stores/provider-secrets.js"
+	));
+}, 60_000);
+
+beforeEach(async () => {
+	await resetTestDatabase();
+	await seedAgentRow(AGENT, { organizationId: ORG });
+	// The route's fire-and-forget config-audit event FKs events.created_by →
+	// "user".id; seed the actor so the audit insert doesn't spam retry noise.
+	await sql`
+		INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+		VALUES ('u1', 'Test', 'u1@t', true, now(), now())
+		ON CONFLICT (id) DO NOTHING
+	`;
+	authStash.user = { id: "u1", name: "T", email: "u1@t", emailVerified: true };
+	authStash.organizationId = ORG;
+	authStash.authSource = "session";
+	authStash.mcpAuthInfo = null;
+});
+
+afterAll(async () => {
+	const { closeDbSingleton } = await import("../../db/client.js");
+	await closeDbSingleton();
+});
+
+async function putKey(providerId: string, value: unknown) {
+	return app.request(
+		`/${AGENT}/providers/${encodeURIComponent(providerId)}/api-key`,
+		{
+			method: "PUT",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ value }),
+		},
+	);
+}
+
+async function providerRows(slug: string) {
+	return (await sql`
+		SELECT id, slug, kind, api_key_ref, capabilities, deleted_at
+		FROM inference_providers
+		WHERE organization_id = ${ORG} AND slug = ${slug}
+	`) as Array<{
+		id: string | number;
+		slug: string;
+		kind: string;
+		api_key_ref: string;
+		capabilities: Record<string, unknown>;
+		deleted_at: string | null;
+	}>;
+}
+
+async function secretRows(pattern: string) {
+	return (await sql`
+		SELECT name, ciphertext FROM agent_secrets
+		WHERE organization_id = ${ORG} AND name LIKE ${pattern}
+	`) as Array<{ name: string; ciphertext: string }>;
+}
+
+describe("PUT /:agentId/providers/:providerId/api-key (resolver cutover)", () => {
+	test("creates an inference_providers row + row-unique secret, no legacy row", async () => {
+		const res = await putKey("z-ai", "zai-key-1");
+		expect(res.status).toBe(200);
+
+		const rows = await providerRows("z-ai");
+		expect(rows).toHaveLength(1);
+		const row = rows[0];
+		expect(row.kind).toBe("z-ai");
+		expect(row.capabilities).toEqual({});
+		expect(row.deleted_at).toBeNull();
+		expect(row.api_key_ref).toBe(`secret://${ORG}/z-ai-${row.id}`);
+
+		const secrets = await secretRows(`z-ai-${row.id}`);
+		expect(secrets).toHaveLength(1);
+		expect(decrypt(secrets[0].ciphertext)).toBe("zai-key-1");
+
+		// The legacy writer is gone: no provider:<id>:apiKey row.
+		expect(await secretRows("provider:%")).toHaveLength(0);
+
+		// Worker-visible tier-2 read resolves the new shape.
+		expect(await readOrgSharedProviderApiKey("z-ai", ORG)).toBe("zai-key-1");
+	});
+
+	test("second PUT rotates the ciphertext in place — no duplicate row or secret", async () => {
+		expect((await putKey("z-ai", "zai-key-1")).status).toBe(200);
+		const [first] = await providerRows("z-ai");
+
+		expect((await putKey("z-ai", "zai-key-2")).status).toBe(200);
+		const rows = await providerRows("z-ai");
+		expect(rows).toHaveLength(1);
+		expect(String(rows[0].id)).toBe(String(first.id));
+
+		const secrets = await secretRows("z-ai-%");
+		expect(secrets).toHaveLength(1);
+		expect(decrypt(secrets[0].ciphertext)).toBe("zai-key-2");
+		expect(await secretRows("provider:%")).toHaveLength(0);
+		expect(await readOrgSharedProviderApiKey("z-ai", ORG)).toBe("zai-key-2");
+	});
+
+	test("invalid provider slug → 400, nothing written anywhere", async () => {
+		const res = await putKey("Not_A-Valid.Slug", "some-key");
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error?: string };
+		expect(body.error).toContain("provider id");
+
+		expect(await providerRows("Not_A-Valid.Slug")).toHaveLength(0);
+		expect(await secretRows("%")).toHaveLength(0);
+	});
+
+	test("404 for an unknown agent is preserved", async () => {
+		const res = await app.request(
+			"/nope-agent/providers/z-ai/api-key",
+			{
+				method: "PUT",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ value: "k" }),
+			},
+		);
+		expect(res.status).toBe(404);
+	});
+
+	test("pre-existing legacy provider:<id>:apiKey rows still resolve (read-only fallback)", async () => {
+		await sql`
+			INSERT INTO agent_secrets (organization_id, name, ciphertext)
+			VALUES (${ORG}, ${"provider:legacy-prov:apiKey"}, ${encrypt("legacy-value")})
+		`;
+		expect(await readOrgSharedProviderApiKey("legacy-prov", ORG)).toBe(
+			"legacy-value",
+		);
+	});
+
+	test("row-unique secret outranks a stale legacy row after rotation", async () => {
+		// Backfilled org: legacy row exists. A post-cutover rotation touches only
+		// the row-unique secret; the read must return the fresh value.
+		await sql`
+			INSERT INTO agent_secrets (organization_id, name, ciphertext)
+			VALUES (${ORG}, ${"provider:z-ai:apiKey"}, ${encrypt("stale-value")})
+		`;
+		expect((await putKey("z-ai", "fresh-value")).status).toBe(200);
+		expect(await readOrgSharedProviderApiKey("z-ai", ORG)).toBe("fresh-value");
+		// And the legacy row was NOT rewritten by the new writer.
+		const legacy = await secretRows("provider:z-ai:apiKey");
+		expect(legacy).toHaveLength(1);
+		expect(decrypt(legacy[0].ciphertext)).toBe("stale-value");
+	});
+
+	test("two concurrent PUTs for a fresh slug converge on one row", async () => {
+		const [a, b] = await Promise.all([
+			putKey("openrouter", "k-a"),
+			putKey("openrouter", "k-b"),
+		]);
+		expect(a.status).toBe(200);
+		expect(b.status).toBe(200);
+
+		const rows = await providerRows("openrouter");
+		expect(rows).toHaveLength(1);
+		const secrets = await secretRows("openrouter-%");
+		expect(secrets).toHaveLength(1);
+		// One of the two values won; either is fine — but it must decrypt.
+		expect(["k-a", "k-b"]).toContain(decrypt(secrets[0].ciphertext));
+		expect(await secretRows("provider:%")).toHaveLength(0);
+	});
+});
+
+describe("readOrgSharedProviderApiKey org scoping (new shape)", () => {
+	test("does not leak another org's row-unique secret", async () => {
+		expect((await putKey("z-ai", "org-a-key")).status).toBe(200);
+		await orgContext.run({ organizationId: "other-org" }, async () => {
+			expect(await readOrgSharedProviderApiKey("z-ai", "other-org")).toBeNull();
+		});
+	});
+});

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -4,7 +4,7 @@
  * All routes are org-scoped via mcpAuth middleware and orgContext.
  */
 
-import { type AuthProfile, encrypt, isSdkCompat } from "@lobu/core";
+import { type AuthProfile, isSdkCompat } from "@lobu/core";
 import { Hono } from "hono";
 import { ensureBuilderAgent } from "../auth/builder-provisioning";
 import { mcpAuth } from "../auth/middleware";
@@ -44,12 +44,12 @@ import {
 	isInferenceModality,
 	isValidInferenceProviderSlug,
 	listInferenceProviders,
-	providerOrgSecretName,
 	rotateInferenceProviderKey,
 	setInferenceProviderDefault,
 	softDeleteInferenceProvider,
 	updateInferenceProviderCapabilities,
 	updateInferenceProviderCoreFields,
+	upsertInferenceProviderApiKey,
 	validateCapabilityBlock,
 } from "./stores/provider-secrets";
 
@@ -1411,16 +1411,19 @@ routes.get("/:agentId/guardrail-judge-default", async (c) => {
 // ── Set the org-shared API key for a provider ────────────────────────────────
 //
 // Writes (or rotates) the org-wide API key declared via `lobu apply` from
-// `[[agents.<id>.providers]] key = "$VAR"`. The key lands in `agent_secrets`
-// under `provider:<id>:apiKey`, scoped to the org. The worker's credential
-// resolution (base-provider-module.ts) checks per-user `auth_profiles` first,
-// then this row, then `process.env` — so per-user BYOK still wins.
+// `[[agents.<id>.providers]] key = "$VAR"`. Since the resolver cutover (issue
+// #1868) the key lands as an `inference_providers` row (kind = slug, empty
+// capabilities — byte-identical to the static catalog behavior) plus a
+// row-unique `<slug>-<id>` `agent_secrets` entry — the exact shape the
+// `backfill-inference-providers` job minted from the legacy
+// `provider:<id>:apiKey` rows, which are no longer written by anything. The
+// worker's credential resolution (base-provider-module.ts) checks per-user
+// `auth_profiles` first, then this org-shared key, then `process.env` — so
+// per-user BYOK still wins.
 //
 // `:agentId` is in the path so the auth/admin gate matches the rest of this
-// router; the secret itself is org-scoped, not per-agent (one z-ai key for the
-// whole org). PUT is idempotent; same name overwrites.
-
-// TODO(inference-providers): remove after resolver cutover
+// router; the key itself is org-scoped, not per-agent (one z-ai key for the
+// whole org). PUT is idempotent; the same slug rotates in place.
 routes.put("/:agentId/providers/:providerId/api-key", async (c) => {
 	const denied = requireSessionOrAdminPat(c);
 	if (denied) return denied;
@@ -1428,6 +1431,21 @@ routes.put("/:agentId/providers/:providerId/api-key", async (c) => {
 
 	if (!(await configStore.hasAgent(agentId))) {
 		return c.json({ error: "Agent not found" }, 404);
+	}
+
+	// The provider id doubles as the `inference_providers.slug` (every catalog
+	// provider id is a valid slug). Reject invalid ids outright instead of
+	// falling back to a legacy-named secret: the acceptance bar for #1868 is
+	// that NOTHING writes `provider:<id>:apiKey` anymore, and a legacy write
+	// would strand the key forever (the backfill skips invalid slugs too).
+	if (!isValidInferenceProviderSlug(providerId)) {
+		return c.json(
+			{
+				error:
+					"Invalid provider id: must be a lowercase alphanumeric slug (a-z, 0-9, hyphens; 1-63 chars)",
+			},
+			400,
+		);
 	}
 
 	let body: { value?: unknown };
@@ -1444,31 +1462,26 @@ routes.put("/:agentId/providers/:providerId/api-key", async (c) => {
 		);
 	}
 
-	const ciphertext = encrypt(value);
-	const name = providerOrgSecretName(providerId);
 	const orgId = (c.get("organizationId") as string | undefined) ?? null;
 	if (!orgId) {
 		return c.json({ error: "Organization context not available" }, 500);
 	}
 
-	const sql = getDb();
-	await sql`
-    INSERT INTO agent_secrets (organization_id, name, ciphertext, created_at, updated_at)
-    VALUES (${orgId}, ${name}, ${ciphertext}, now(), now())
-    ON CONFLICT (organization_id, name) DO UPDATE SET
-      ciphertext = EXCLUDED.ciphertext,
-      updated_at = now()
-  `;
+	const { created } = await upsertInferenceProviderApiKey(
+		orgId,
+		providerId,
+		value,
+	);
 	// Metadata-only: provider keys are audited but never snapshotted (the
 	// writer forces `state` to null for this kind regardless).
 	emitConfigChange(c, {
 		resourceKind: "provider-key",
 		resourceId: `${providerId}`,
-		op: "updated",
+		op: created ? "created" : "updated",
 		summary: `Org API key for provider '${providerId}' set`,
 		state: null,
 	});
-	return c.json({ success: true, name });
+	return c.json({ success: true, provider: providerId, created });
 });
 
 // ── Update agent config (settings) ───────────────────────────────────────────

--- a/packages/server/src/lobu/stores/provider-secrets.ts
+++ b/packages/server/src/lobu/stores/provider-secrets.ts
@@ -5,8 +5,11 @@
  *
  * Resolution order (worker side, see base-provider-module.ts):
  *   1. Per-user `auth_profiles` (BYOK / personal OAuth)
- *   2. Org-shared `agent_secrets` row (this name) — declarative, set via
- *      `lobu apply` from `[[agents.<id>.providers]] key = "$VAR"`
+ *   2. Org-shared key — declarative, set via `lobu apply` from
+ *      `[[agents.<id>.providers]] key = "$VAR"`. Since the resolver cutover
+ *      (issue #1868) the writer lands this as an `inference_providers` row +
+ *      row-unique `<slug>-<id>` secret; the legacy `provider:<id>:apiKey`
+ *      name remains a READ-ONLY fallback for pre-existing rows.
  *   3. Deployment-wide `process.env` (operator's machine, last resort)
  *
  * The org-scoping is enforced by `(organization_id, name)` PK on the table;
@@ -689,6 +692,58 @@ export async function updateInferenceProviderCoreFields(
 }
 
 /**
+ * Create-or-rotate the org-shared provider key pushed by `lobu apply`
+ * (`PUT /:agentId/providers/:providerId/api-key`). This is the resolver-cutover
+ * writer (issue #1868): it produces EXACTLY the shape the
+ * `backfill-inference-providers` job mints from legacy secrets — an
+ * `inference_providers` row (kind = slug, `capabilities = {}` so behavior is
+ * byte-identical to the static catalog) plus a row-unique `<slug>-<id>` secret
+ * — and never touches the legacy `provider:<id>:apiKey` name.
+ *
+ * Race-safe across replicas: rotate-first (FOR UPDATE on the live row), then
+ * create (id minted → INSERT, unique-violation caught as slug_conflict with the
+ * whole tx rolled back, so no stranded vault write), then rotate again when a
+ * concurrent apply won the create. Two concurrent applies therefore converge on
+ * one row with one of the two keys.
+ *
+ * Callers MUST have validated `slug` via {@link isValidInferenceProviderSlug};
+ * an invalid slug throws (the DB CHECK would reject it anyway).
+ */
+export async function upsertInferenceProviderApiKey(
+	organizationId: string,
+	slug: string,
+	apiKey: string,
+): Promise<{ created: boolean }> {
+	if (!isValidInferenceProviderSlug(slug)) {
+		throw new Error(`Invalid inference-provider slug: ${slug}`);
+	}
+
+	if (await rotateInferenceProviderKey(organizationId, slug, apiKey)) {
+		return { created: false };
+	}
+
+	const created = await createInferenceProvider({
+		organizationId,
+		slug,
+		kind: slug,
+		apiKey,
+		capabilities: {},
+	});
+	if (!("error" in created)) return { created: true };
+
+	// Lost the create race to a concurrent apply — its row is live now; rotate
+	// the key into that row's ref instead.
+	if (await rotateInferenceProviderKey(organizationId, slug, apiKey)) {
+		return { created: false };
+	}
+	// Create conflicted but no live row rotates: the row was soft-deleted in the
+	// same instant. Vanishingly rare; surface it rather than looping.
+	throw new Error(
+		`Concurrent modification while writing provider key for ${organizationId}/${slug}`,
+	);
+}
+
+/**
  * Rotate a provider's api key: re-encrypt into the SAME api_key_ref name (the
  * ref is immutable). Returns false when no live row exists for the slug.
  */
@@ -747,7 +802,15 @@ export async function softDeleteInferenceProvider(
 	return rows.length > 0;
 }
 
-export function providerOrgSecretName(providerId: string): string {
+/**
+ * LEGACY org-shared provider secret name — READ path only. Nothing writes this
+ * name anymore (the `lobu apply` writer produces `inference_providers` rows +
+ * `<slug>-<id>` secrets, see {@link upsertInferenceProviderApiKey}); it exists
+ * so {@link readOrgSharedProviderApiKey} keeps resolving rows written before
+ * the cutover. Delete together with the legacy fallback once the fleet is
+ * converged (issue #1868, time-gated with the backfill-job removal).
+ */
+function providerOrgSecretName(providerId: string): string {
 	return `provider:${providerId}:apiKey`;
 }
 
@@ -830,12 +893,53 @@ export async function readEnvironmentSecret(
  * this tier: run dispatch checks it via `hasCredentials`, so a proxy that
  * skips it lets an apply-provisioned org dispatch its agent only to 401 at
  * the first provider call.
+ *
+ * Two storage shapes resolve here, row-unique first (issue #1868):
+ *   1. The org's live `inference_providers` row's `<slug>-<id>` secret (what
+ *      `lobu apply` writes since the resolver cutover, and what the backfill
+ *      minted from legacy rows). Preferred because rotations only ever rewrite
+ *      this name — a backfilled org's legacy copy goes stale after the first
+ *      post-cutover rotation.
+ *   2. The legacy `provider:<id>:apiKey` name — READ-ONLY fallback for
+ *      pre-existing rows (nothing writes it anymore).
+ *
+ * Rows with a custom text upstream are excluded from (1): the URL invariant
+ * (inference-invariant.ts) already short-circuits those to org-row-key-only /
+ * fail-closed BEFORE this tier, and excluding them here keeps this function
+ * safe standalone — its key can never chain onward as if the destination were
+ * the static catalog URL.
  */
 export async function readOrgSharedProviderApiKey(
 	providerId: string,
 	organizationId: string,
 ): Promise<string | null> {
 	const sql = getDb();
+
+	const rowKeyed = (await sql`
+    SELECT s.ciphertext
+    FROM inference_providers p
+    JOIN agent_secrets s
+      ON s.organization_id = p.organization_id
+     AND ('secret://' || p.organization_id || '/' || s.name) = p.api_key_ref
+     AND (s.expires_at IS NULL OR s.expires_at > now())
+    WHERE p.organization_id = ${organizationId}
+      AND p.slug = ${providerId}
+      AND p.deleted_at IS NULL
+      AND (p.capabilities -> 'text' ->> 'base_url') IS NULL
+    LIMIT 1
+  `) as Array<{ ciphertext: string }>;
+	const rowKeyedCiphertext = rowKeyed[0]?.ciphertext;
+	if (rowKeyedCiphertext) {
+		try {
+			return decrypt(rowKeyedCiphertext);
+		} catch (error) {
+			logger.warn(
+				`Failed to decrypt inference-provider row key for ${providerId}: ${getErrorMessage(error)}`,
+			);
+			// Fall through to the legacy name rather than dead-ending the chain.
+		}
+	}
+
 	const rows = (await sql`
     SELECT ciphertext
     FROM agent_secrets


### PR DESCRIPTION
First step of #1868 (the backfill-job deletion stays time-gated; the issue remains open).

## What

`PUT /:agentId/providers/:providerId/api-key` (the `lobu apply` key-push path) no longer writes the legacy `provider:<id>:apiKey` agent_secrets name. It now creates-or-rotates the org's `inference_providers` row directly, producing exactly the shape the hourly `backfill-inference-providers` job minted from legacy rows:

- id minted from the identity sequence, `api_key_ref = secret://<org>/<slug>-<id>`
- `kind = slug`, `capabilities = '{}'::jsonb` (byte-identical static-catalog behavior)
- row-unique `<slug>-<id>` secret upserted in the same transaction

On update of an existing live (org, slug) row the referenced secret's ciphertext is overwritten in place (same immutable ref, no duplicate row). Race-safe across replicas: rotate-first (`FOR UPDATE`), then create (unique-violation caught, tx rolled back, no stranded vault write), then rotate again if a concurrent apply won the create.

## Read-path cutover

A cutover-shape row (empty capabilities) has no `capabilities.text` block, so `resolveInferenceProviderConfig` returns null and the URL-invariant tier never sees it — previously such keys only resolved because the legacy row still existed. `readOrgSharedProviderApiKey` (tier 2 of BOTH credential chains: worker-spawn `base-provider-module.ts` and egress `secret-proxy.ts`) now resolves the live row's `<slug>-<id>` secret first, keeping the legacy `provider:<id>:apiKey` name as a READ-ONLY fallback for pre-existing rows. Row-unique wins because post-cutover rotations only rewrite that name (a backfilled org's legacy copy goes stale after the first rotation). Rows with a custom `capabilities.text.base_url` are excluded from the row-keyed read — the invariant already fail-closes those before this tier.

Per-user BYOK precedence is unchanged: the row-keyed secret resolves at the same tier the legacy name did (after auth profiles).

## Invalid provider ids

Non-slug provider ids (uppercase, dots, etc.) are rejected with 400 instead of falling back to a legacy write: the acceptance bar is that nothing writes `provider:<id>:apiKey` anymore, the backfill skips invalid slugs too (so a legacy write would strand the key forever), and every catalog provider id is a valid slug — a violation is a config typo best surfaced at apply time.

## Tests (red → green)

New `agent-routes-provider-api-key.test.ts` (real-PG route harness) written first — 5/8 failed against the old writer (no `inference_providers` row, legacy row written/rewritten), all 8 pass now: create shape, rotate-in-place without duplicates, invalid slug 400 with nothing written, agent 404 preserved, legacy fallback intact, row-secret-beats-stale-legacy, two concurrent PUTs converge on one row, org scoping. `base-provider-module-credentials.test.ts` extended with the resolver cutover cases (cutover-shape row resolves via tier 2; row-unique outranks stale legacy) — both red before, green after; all 12 pass.

Suites: lobu route dir 61/61, gateway auth 72/72, secret-proxy-harden 17/17, inference-provider store (vitest, real PG) 9/9, `make typecheck` clean, knip introduces no new findings.

## Not in this PR

- `backfill-inference-providers.ts` + its `jobs.ts` registration stay (deleted only after a converged week of apply traffic, per #1868).
- The legacy read fallback + `providerOrgSecretName` (now module-private) stay until that same gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786414120&installation_id=136316292&pr_number=1872&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1872&signature=200481a2f7bfd37b092029fc0bd708f3612b8bc6b8b0cbe7db6913fe988be31e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->