### PR TITLE
chore: delete dead back-compat re-export shims

### DIFF
--- a/packages/server/src/__tests__/integration/lobu/gateway-org-context.test.ts
+++ b/packages/server/src/__tests__/integration/lobu/gateway-org-context.test.ts
@@ -32,7 +32,7 @@ import {
   createLobuAuthBridge,
   createLobuOrgContextMiddleware,
 } from "../../../lobu/gateway";
-import { clearMultiTenantCachesForTests } from "../../../workspace/multi-tenant";
+import { clearMultiTenantCachesForTests } from "../../../workspace/multi-tenant-caches";
 import { cleanupTestDatabase } from "../../setup/test-db";
 import {
   addUserToOrganization,

--- a/packages/server/src/auth/system-provider-resolution.ts
+++ b/packages/server/src/auth/system-provider-resolution.ts
@@ -11,7 +11,7 @@ import type { ProviderConfigEntry } from "@lobu/core";
 import { getErrorMessage } from "@lobu/core";
 import { resolveEnv } from "../gateway/auth/mcp/string-substitution";
 import { collectProviderModelOptions } from "../gateway/auth/provider-model-options";
-import { UNRESOLVED_MODEL_SUFFIX } from "../gateway/auth/provider-catalog";
+import { UNRESOLVED_MODEL_SUFFIX } from "../gateway/auth/model-sentinel";
 import { getModelProviderModules } from "../gateway/modules/module-system";
 import {
 	ProviderRegistryService,

--- a/packages/server/src/gateway/__tests__/session-context-cross-tenant.test.ts
+++ b/packages/server/src/gateway/__tests__/session-context-cross-tenant.test.ts
@@ -11,12 +11,9 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { InstructionContext } from "@lobu/core";
+import { BaseInstructionProvider, type InstructionContext } from "@lobu/core";
 import { McpConfigService } from "../auth/mcp/config-service.js";
-import {
-  BaseInstructionProvider,
-  InstructionService,
-} from "../services/instruction-service.js";
+import { InstructionService } from "../services/instruction-service.js";
 
 /** A platform provider that, if not gated, leaks a foreign tenant's identity. */
 class LeakyPlatformProvider extends BaseInstructionProvider {

--- a/packages/server/src/gateway/auth/agent-metadata-store.ts
+++ b/packages/server/src/gateway/auth/agent-metadata-store.ts
@@ -4,9 +4,6 @@ import {
   createLogger,
 } from "@lobu/core";
 
-// Re-export so existing imports from this module keep working.
-export type { AgentMetadata };
-
 const logger = createLogger("agent-metadata-store");
 
 /**

--- a/packages/server/src/gateway/auth/provider-catalog.ts
+++ b/packages/server/src/gateway/auth/provider-catalog.ts
@@ -12,18 +12,12 @@ import {
   type ProviderUpstreamConfig,
 } from "../modules/module-system.js";
 import { ApiKeyProviderModule } from "./api-key-provider-module.js";
-import {
-  isUnresolvedModelRef,
-  UNRESOLVED_MODEL_SUFFIX,
-} from "./model-sentinel.js";
+import { isUnresolvedModelRef } from "./model-sentinel.js";
 import type { AgentSettingsStore } from "./settings/agent-settings-store.js";
 import type { AuthProfilesManager } from "./settings/auth-profiles-manager.js";
 import { enforceModelAllowList } from "./settings/model-selection.js";
 
 const logger = createLogger("provider-catalog");
-
-// Re-export the sentinel helpers so existing importers keep working.
-export { isUnresolvedModelRef, UNRESOLVED_MODEL_SUFFIX };
 
 /** Auth mechanism a provider supports. */
 export type ProviderAuthType = "oauth" | "device-code" | "api-key";

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -1,13 +1,12 @@
 #!/usr/bin/env bun
 
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { createLogger } from "@lobu/core";
+import { type AgentMetadata, createLogger } from "@lobu/core";
 import { apiReference } from "@scalar/hono-api-reference";
 import { cors } from "hono/cors";
 import { secureHeaders } from "hono/secure-headers";
 import { createPostgresAppInstallationStore } from "../../lobu/stores/app-installation-store.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
-import type { AgentMetadata } from "../auth/agent-metadata-store.js";
 import { takePendingTool } from "../auth/mcp/pending-tool-store.js";
 import { setEnvResolver } from "../auth/mcp/string-substitution.js";
 import { createAuthProfileLabel } from "../auth/settings/auth-profiles-manager.js";

--- a/packages/server/src/gateway/connections/slack-instruction-provider.ts
+++ b/packages/server/src/gateway/connections/slack-instruction-provider.ts
@@ -1,6 +1,5 @@
-import type { InstructionContext } from "@lobu/core";
+import { BaseInstructionProvider, type InstructionContext } from "@lobu/core";
 import { orgContext } from "../../lobu/stores/org-context.js";
-import { BaseInstructionProvider } from "../services/instruction-service.js";
 import type { ChatInstanceManager } from "./chat-instance-manager.js";
 
 export class SlackInstructionProvider extends BaseInstructionProvider {

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -20,10 +20,8 @@ import { getRevokedTokenStore } from "../auth/revoked-token-store.js";
 import type { McpConfigService } from "../auth/mcp/config-service.js";
 import type { McpProxy } from "../auth/mcp/proxy.js";
 import type { McpTool } from "../auth/mcp/tool-cache.js";
-import {
-	isUnresolvedModelRef,
-	type ProviderCatalogService,
-} from "../auth/provider-catalog.js";
+import { isUnresolvedModelRef } from "../auth/model-sentinel.js";
+import type { ProviderCatalogService } from "../auth/provider-catalog.js";
 import { composeEffectiveModelRef } from "../auth/settings/model-selection.js";
 import { getOrgDefaultModel } from "../../lobu/stores/provider-secrets.js";
 import type { IMessageQueue } from "../infrastructure/queue/index.js";

--- a/packages/server/src/gateway/services/declared-agent-registry.ts
+++ b/packages/server/src/gateway/services/declared-agent-registry.ts
@@ -1,9 +1,7 @@
 import type { AgentSettings, DeclaredCredential } from "@lobu/core";
 import { createLogger } from "@lobu/core";
-import {
-  buildProviderCatalog,
-  UNRESOLVED_MODEL_SUFFIX,
-} from "../auth/provider-catalog.js";
+import { UNRESOLVED_MODEL_SUFFIX } from "../auth/model-sentinel.js";
+import { buildProviderCatalog } from "../auth/provider-catalog.js";
 import type { AgentConfig } from "../config/index.js";
 
 const logger = createLogger("declared-agent-registry");

--- a/packages/server/src/gateway/services/instruction-service.ts
+++ b/packages/server/src/gateway/services/instruction-service.ts
@@ -12,10 +12,6 @@ import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.j
 
 const logger = createLogger("instruction-service");
 
-// Re-export so existing `import { BaseInstructionProvider } from
-// "../services/instruction-service"` paths keep working.
-export { BaseInstructionProvider };
-
 interface McpStatus {
   id: string;
   name: string;

--- a/packages/server/src/workspace/multi-tenant.ts
+++ b/packages/server/src/workspace/multi-tenant.ts
@@ -18,18 +18,11 @@ import type {
   WorkspaceProvider,
 } from './types';
 import {
-  clearMultiTenantCachesForTests as clearMultiTenantCachesForTestsShared,
   memberRoleCache,
   orgSlugCache,
   ownerCache,
   sessionCache,
 } from './multi-tenant-caches';
-
-// Re-export the test-only cache clearer so existing imports
-// (`from '../workspace/multi-tenant'`) keep working; the cache instances
-// themselves live in `./multi-tenant-caches` to keep test cleanup off this
-// file's heavy import graph.
-export const clearMultiTenantCachesForTests = clearMultiTenantCachesForTestsShared;
 
 /**
  * Path namespaces that don't carry an org context. Authenticated requests to


### PR DESCRIPTION
## What

Removes four forwarding re-exports left behind by earlier refactors and points every importer at the canonical module:

| Shim | Canonical source | Importers migrated |
|---|---|---|
| `agent-metadata-store.ts` → `export type { AgentMetadata }` | `@lobu/core` | `gateway/cli/gateway.ts` |
| `instruction-service.ts` → `export { BaseInstructionProvider }` | `@lobu/core` | `slack-instruction-provider.ts`, `session-context-cross-tenant.test.ts` |
| `provider-catalog.ts` → `export { isUnresolvedModelRef, UNRESOLVED_MODEL_SUFFIX }` | `gateway/auth/model-sentinel.ts` | `auth/system-provider-resolution.ts`, `gateway/gateway/index.ts`, `services/declared-agent-registry.ts` |
| `workspace/multi-tenant.ts` → `clearMultiTenantCachesForTests` alias | `workspace/multi-tenant-caches.ts` | `gateway-org-context.test.ts` |

Pure import-graph cleanup — no behavior change. `AgentMetadataStore` (the class) and `ProviderCatalogService` are untouched; only the forwarded names are gone.

## Verification

- `tsc --noEmit` clean in `packages/server` (it caught the `gateway/cli/gateway.ts` importer grep missed)
- `biome lint` — same pre-existing findings as `main`, none in touched lines
- Affected tests run locally (session-context-cross-tenant, gateway-org-context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014meECSComSn1SZANxL8dAo

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786414316&installation_id=136316292&pr_number=1873&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1873&signature=96ff51495bbf074c5228ffd95dc81a2a2e00b89d8166383be0d38696217fe2fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->