### PR TITLE
chore: remove legacy per-token OAuth callback route

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/connection-visibility-default.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connection-visibility-default.test.ts
@@ -220,7 +220,7 @@ describe('connection visibility default depends on credential kind', () => {
   });
 
   it('the OAuth-callback downgrade SQL flips org→private only when the attached profile is personal', async () => {
-    // The GET /:token/oauth/callback route attaches the freshly-created
+    // The GET /connect/oauth/callback route attaches the freshly-created
     // oauth_account profile and runs this exact CASE. The route wiring is not
     // unit-testable without full connect-token + provider scaffolding, so this
     // pins the mechanism it depends on: downgrade org→private for a personal

--- a/packages/server/src/connect/routes.ts
+++ b/packages/server/src/connect/routes.ts
@@ -11,7 +11,6 @@
  * - POST /connect/:token/cancel       → reset credentials and cancel validation
  * - GET  /connect/:token/oauth/start    → redirect to OAuth provider
  * - GET  /connect/oauth/callback        → stable OAuth callback (token from ?state=)
- * - GET  /connect/:token/oauth/callback → legacy per-token OAuth callback
  */
 
 import { type Context, Hono } from 'hono';
@@ -638,35 +637,6 @@ connectRoutes.get('/oauth/callback', async (c) => {
     tokenRow,
     code,
     authConfig?.redirectUri || `${baseUrl}/connect/oauth/callback`
-  );
-});
-
-/**
- * GET /connect/:token/oauth/callback
- * Legacy per-token OAuth callback -- kept for backwards compatibility.
- */
-connectRoutes.get('/:token/oauth/callback', requireConnectToken, async (c) => {
-  const tokenRow = c.get('tokenRow');
-  const token = c.req.param('token');
-  const code = c.req.query('code');
-  const state = c.req.query('state');
-  const error = c.req.query('error');
-
-  if (error) {
-    return c.redirect(`${getBaseUrl(c)}/connect/${token}?error=${encodeURIComponent(error)}`);
-  }
-
-  if (!code || state !== token) {
-    return c.json({ error: 'Invalid callback parameters' }, 400);
-  }
-
-  const baseUrl = getBaseUrl(c);
-  const authConfig = tokenRow.auth_config as OAuthAuthConfig | null;
-  return handleOAuthCallback(
-    c,
-    tokenRow,
-    code,
-    authConfig?.redirectUri || `${baseUrl}/connect/${token}/oauth/callback`
   );
 });
 


### PR DESCRIPTION
## What

Deletes `GET /connect/:token/oauth/callback` ("kept for backwards compatibility") and its route-table comment line. The stable callback `GET /connect/oauth/callback` (token in `?state=`) is untouched and remains the only callback.

## Why it's dead

The authorize step (`GET /connect/:token/oauth/start`, `routes.ts:568`) always writes the **stable** redirect URI into the token's `auth_config` — and *rewrites* a stale one before redirecting (`routes.ts:572`). So any handshake that starts on current code returns via the stable callback; the per-token route could only be reached by a handshake whose authorize ran on pre-cutover code, i.e. an expired connect token.

Also updates a comment in `connection-visibility-default.test.ts` that referenced the old route name (the test pins `handleOAuthCallback`'s downgrade SQL, shared by the stable route — no test logic change).

## Merge gate

Deploy age must exceed the connect-token TTL since the stable-redirect cutover shipped (long since true), and no OAuth app registration at a provider should list a per-token redirect URI — per-token URIs are unique per token, so fixed registrations can't reference them; only a wildcard registration could, and those also match the stable path. One operator sanity check before merge: confirm access logs show no recent hits on `/connect/*/oauth/callback`.

## Verification

- `tsc --noEmit` clean in `packages/server`
- `connection-visibility-default` + `connection-visibility-oauth-callback` integration tests run locally (the latter drives the real stable callback route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014meECSComSn1SZANxL8dAo

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786414325&installation_id=136316292&pr_number=1874&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1874&signature=87aaca6bc354bd4271b03d040fe44120b9fa68ca4e0c3e4c5210faae90e00340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->