### PR TITLE
refactor: drop Gemini/ElevenLabs audio integrations — OpenAI-only STT+TTS

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -118,7 +118,7 @@
           "apiKeyInstructions": "Get your API key from <a href=\"https://aistudio.google.com/apikey\" target=\"_blank\" class=\"text-blue-600 hover:underline\">Google AI Studio</a>",
           "apiKeyPlaceholder": "AIza...",
           "sdkCompat": "openai",
-          "modalities": ["text", "image", "tts"],
+          "modalities": ["text", "image"],
           "defaultModel": "gemini-2.5-pro",
           "models": ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"]
         }
@@ -188,23 +188,6 @@
           "modalities": ["text"],
           "models": ["glm-5.2", "glm-4.6", "glm-4.5-air"],
           "defaultModel": "glm-5.2"
-        }
-      ]
-    },
-    {
-      "id": "elevenlabs",
-      "name": "ElevenLabs",
-      "description": "Voice and speech models",
-      "providers": [
-        {
-          "displayName": "ElevenLabs",
-          "iconUrl": "https://www.google.com/s2/favicons?domain=elevenlabs.io&sz=128",
-          "envVarName": "ELEVENLABS_API_KEY",
-          "upstreamBaseUrl": "https://api.elevenlabs.io",
-          "apiKeyInstructions": "Get your API key from <a href=\"https://elevenlabs.io/app/api-keys\" target=\"_blank\" class=\"text-blue-600 hover:underline\">ElevenLabs</a>",
-          "apiKeyPlaceholder": "sk_...",
-          "sdkCompat": "openai",
-          "modalities": ["tts"]
         }
       ]
     },

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -53,12 +53,12 @@ If the error still isn't actionable, open an issue with the full output.
 
 ## LLM provider support
 
-Lobu is provider-agnostic. The bundled `config/providers.json` ships 17 providers including:
+Lobu is provider-agnostic. The bundled `config/providers.json` ships 16 providers including:
 
 - Anthropic Claude
 - OpenAI (GPT-4, GPT-4o, etc.)
 - OpenAI-compatible: Groq, Together AI, Fireworks, OpenRouter, Cerebras, NVIDIA, xAI, DeepSeek, Mistral, Cohere, Perplexity, Z-AI, Gemini
-- Specialized: ElevenLabs (STT), OpenCode Zen
+- Specialized: OpenCode Zen
 
 Add API keys via the admin UI (Settings → Providers) at runtime. No env-var required. Per-agent model selection picks among configured providers.
 

--- a/packages/agent-worker/src/__tests__/audio-provider-suggestions.test.ts
+++ b/packages/agent-worker/src/__tests__/audio-provider-suggestions.test.ts
@@ -26,14 +26,14 @@ describe("audio provider suggestions", () => {
       available: false,
       providers: [
         { provider: "openai", name: "OpenAI" },
-        { provider: "gemini", name: "Google Gemini" },
+        { provider: "acme-voice", name: "Acme Voice" },
       ],
     });
 
     expect(normalized.available).toBe(false);
     expect(normalized.usedFallback).toBe(false);
-    expect(normalized.providerIds).toEqual(["chatgpt", "openai", "gemini"]);
-    expect(normalized.providerDisplayList).toBe("OpenAI, Google Gemini");
+    expect(normalized.providerIds).toEqual(["chatgpt", "openai", "acme-voice"]);
+    expect(normalized.providerDisplayList).toBe("OpenAI, Acme Voice");
   });
 
   test("falls back safely when capability payload is malformed", () => {
@@ -44,7 +44,7 @@ describe("audio provider suggestions", () => {
 
     expect(normalized.available).toBe(true);
     expect(normalized.usedFallback).toBe(true);
-    expect(normalized.providerIds).toEqual(["chatgpt", "gemini", "elevenlabs"]);
+    expect(normalized.providerIds).toEqual(["chatgpt"]);
     expect(normalized.providerDisplayList).toBe("");
   });
 
@@ -60,7 +60,7 @@ describe("audio provider suggestions", () => {
 
     expect(normalized.available).toBeNull();
     expect(normalized.usedFallback).toBe(true);
-    expect(normalized.providerIds).toEqual(["chatgpt", "gemini", "elevenlabs"]);
+    expect(normalized.providerIds).toEqual(["chatgpt"]);
     expect(normalized.providerDisplayList).toBe("");
   });
 });
@@ -80,10 +80,7 @@ describe("generate_audio dynamic provider messaging", () => {
           return new Response(
             JSON.stringify({
               available: true,
-              providers: [
-                { provider: "openai", name: "OpenAI" },
-                { provider: "gemini", name: "Google Gemini" },
-              ],
+              providers: [{ provider: "openai", name: "OpenAI" }],
             }),
             { status: 200, headers: { "Content-Type": "application/json" } }
           );
@@ -118,7 +115,7 @@ describe("generate_audio dynamic provider messaging", () => {
 
     const text = extractText(result as any);
 
-    expect(text).toContain("OpenAI, Google Gemini");
+    expect(text).toContain("OpenAI");
     expect(text).toContain("Ask an admin");
   });
 });
@@ -136,10 +133,7 @@ describe("OpenClawWorker audio permission hint", () => {
         return new Response(
           JSON.stringify({
             available: true,
-            providers: [
-              { provider: "openai", name: "OpenAI" },
-              { provider: "elevenlabs", name: "ElevenLabs" },
-            ],
+            providers: [{ provider: "openai", name: "OpenAI" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } }
         );
@@ -157,7 +151,7 @@ describe("OpenClawWorker audio permission hint", () => {
       "token"
     );
 
-    expect(hint).toContain("OpenAI, ElevenLabs");
+    expect(hint).toContain("OpenAI");
     expect(hint).toContain("Ask an admin");
   });
 

--- a/packages/agent-worker/src/shared/audio-provider-suggestions.ts
+++ b/packages/agent-worker/src/shared/audio-provider-suggestions.ts
@@ -7,14 +7,11 @@ interface AudioProviderSuggestions {
   usedFallback: boolean;
 }
 
-const FALLBACK_PROVIDER_IDS = ["chatgpt", "gemini", "elevenlabs"] as const;
+const FALLBACK_PROVIDER_IDS = ["chatgpt"] as const;
 
 const KNOWN_PROVIDER_LABELS: Record<string, string> = {
   chatgpt: "ChatGPT/OpenAI",
   openai: "OpenAI",
-  gemini: "Google Gemini",
-  google: "Google Gemini",
-  elevenlabs: "ElevenLabs",
 };
 
 function normalizeProviderId(raw: unknown): string | null {
@@ -28,9 +25,6 @@ function prefillProviderIdsFromCapabilityProvider(
 ): string[] {
   if (providerId === "openai") {
     return ["chatgpt", "openai"];
-  }
-  if (providerId === "google") {
-    return ["gemini"];
   }
   return [providerId];
 }

--- a/packages/server/src/__tests__/live-providers/provider-keyless.test.ts
+++ b/packages/server/src/__tests__/live-providers/provider-keyless.test.ts
@@ -46,9 +46,6 @@ const flattened = registry.providers.flatMap((entry) =>
 	(entry.providers || []).map((provider) => ({ id: entry.id, provider })),
 );
 
-// Providers with no chat surface at all (voice/STT only).
-const VOICE_ONLY = new Set(["elevenlabs"]);
-
 const TIMEOUT_MS = 20_000;
 setDefaultTimeout(60_000);
 
@@ -73,7 +70,7 @@ for (const { id, provider } of flattened) {
 	const base = provider.upstreamBaseUrl.replace(/\/$/, "");
 
 	describe(`keyless: ${id} (${provider.displayName})`, () => {
-		test.skipIf(VOICE_ONLY.has(id))(
+		test(
 			"chat endpoint exists (route must not 404)",
 			async () => {
 				const { status } = await probe(`${base}/chat/completions`, {

--- a/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
+++ b/packages/server/src/__tests__/live-providers/provider-smoke.test.ts
@@ -10,7 +10,7 @@
  * This suite walks EVERY provider in config/providers.json and, for each one
  * whose API key is present in the environment, performs a real round-trip:
  *   1. list models            — validates auth + the models endpoint
- *      (skipped for providers with no model-listing surface: z-ai, elevenlabs)
+ *      (skipped for providers with no model-listing surface: z-ai)
  *   2. chat completion        — validates the OpenAI-compatible chat surface
  *   3. tool-calling (lenient) — validates the agent's primary capability,
  *                               warn-only since model support varies
@@ -58,8 +58,6 @@ const flattened = registry.providers.flatMap((entry) =>
  * Chat models for providers whose registry entry has no defaultModel.
  * Mirrors DEFAULT_PROVIDER_MODELS in agent-worker/src/openclaw/model-resolver.ts
  * (not importable here — agent-worker is not a dependency of server).
- * elevenlabs is voice-only and deliberately absent: with no model, the chat
- * and tool tests below no-op for it.
  */
 const FALLBACK_CHAT_MODELS: Record<string, string> = {
 	"z-ai": "glm-4.7",

--- a/packages/server/src/gateway/__tests__/transcription-service.test.ts
+++ b/packages/server/src/gateway/__tests__/transcription-service.test.ts
@@ -6,26 +6,46 @@ describe("TranscriptionService provider fallback", () => {
     mock.restore();
   });
 
-  test("falls back to next configured provider when first fails", async () => {
+  test("falls back to a config-driven STT provider when the built-in fails", async () => {
     const authProfilesManager = {
       getBestProfile: mock(async (_agentId: string, providerId: string) => {
         if (providerId === "chatgpt") {
           return { credential: "openai-key" };
         }
-        if (providerId === "gemini") {
-          return { credential: "gemini-key" };
+        if (providerId === "groq") {
+          return { credential: "groq-key" };
         }
         return null;
       }),
     } as any;
 
-    const service = new TranscriptionService(authProfilesManager);
+    const providerConfigSource = mock(async () => ({
+      groq: {
+        displayName: "Groq",
+        iconUrl: "https://example.com/icon.png",
+        envVarName: "GROQ_API_KEY",
+        upstreamBaseUrl: "https://api.groq.com/openai/v1",
+        apiKeyInstructions: "x",
+        apiKeyPlaceholder: "x",
+        sdkCompat: "openai",
+        stt: {
+          enabled: true,
+          transcriptionPath: "/audio/transcriptions",
+          model: "whisper-large-v3-turbo",
+        },
+      },
+    }));
+
+    const service = new TranscriptionService(
+      authProfilesManager,
+      providerConfigSource
+    );
     const transcribeWithProvider = mock(
       async (_buffer: Buffer, config: any) => {
-        if (config.provider === "openai") {
+        if (config.profileProviderId === "chatgpt") {
           throw new Error("openai unauthorized");
         }
-        return "hello from gemini";
+        return "hello from groq";
       }
     );
     (service as any).transcribeWithProvider = transcribeWithProvider;
@@ -39,8 +59,8 @@ describe("TranscriptionService provider fallback", () => {
     expect(transcribeWithProvider).toHaveBeenCalledTimes(2);
     expect("text" in result).toBe(true);
     if ("text" in result) {
-      expect(result.text).toBe("hello from gemini");
-      expect(result.provider).toBe("gemini");
+      expect(result.text).toBe("hello from groq");
+      expect(result.provider).toBe("openai");
     }
   });
 

--- a/packages/server/src/gateway/services/transcription-service.ts
+++ b/packages/server/src/gateway/services/transcription-service.ts
@@ -3,12 +3,11 @@
  *
  * Supports speech-to-text and text-to-speech via auth profiles (installed providers):
  * - OpenAI (chatgpt auth profile) - Whisper for STT, TTS API for speech
- * - Google Gemini (gemini auth profile) - Audio input/output
- * - ElevenLabs (elevenlabs auth profile) - STT and high-quality TTS
  *
- * STT selection: built-ins (chatgpt/openai, gemini, elevenlabs) plus optional
- * config-driven STT providers declared in system-skills provider config.
- * TTS selection stays built-in only (openai → gemini → elevenlabs).
+ * STT selection: the OpenAI built-in plus optional config-driven
+ * OpenAI-compatible STT providers declared in system-skills provider config
+ * (Groq etc. — any provider with an OpenAI-shaped /audio/transcriptions).
+ * TTS selection stays built-in only (OpenAI).
  */
 
 import type { ProviderConfigEntry } from "@lobu/core";
@@ -37,7 +36,7 @@ const PROVIDER_FETCH_TIMEOUT_MS = Number(
   process.env.TRANSCRIPTION_FETCH_TIMEOUT_MS ?? 120_000
 );
 
-type TranscriptionProvider = "openai" | "gemini" | "elevenlabs";
+type TranscriptionProvider = "openai";
 
 interface TranscriptionConfig {
   profileProviderId: string;
@@ -96,16 +95,6 @@ const TTS_CAPABLE_PROVIDERS: {
     profileProviderId: "chatgpt",
     ttsProvider: "openai",
     displayName: "OpenAI",
-  },
-  {
-    profileProviderId: "gemini",
-    ttsProvider: "gemini",
-    displayName: "Google Gemini",
-  },
-  {
-    profileProviderId: "elevenlabs",
-    ttsProvider: "elevenlabs",
-    displayName: "ElevenLabs",
   },
 ];
 
@@ -202,7 +191,7 @@ export class TranscriptionService {
 
   /**
    * Get transcription config for an agent by checking installed auth profiles.
-   * First TTS-capable provider with a valid profile wins (openai → gemini → elevenlabs).
+   * First TTS-capable provider with a valid profile wins (OpenAI only).
    */
   async getConfig(agentId: string): Promise<TranscriptionConfig | null> {
     const configs = await this.getTranscriptionConfigs(agentId);
@@ -471,10 +460,6 @@ export class TranscriptionService {
           mimeType,
           config.openaiCompat
         );
-      case "gemini":
-        return this.transcribeWithGemini(buffer, config.apiKey, mimeType);
-      case "elevenlabs":
-        return this.transcribeWithElevenLabs(buffer, config.apiKey, mimeType);
       default:
         throw new Error(`Unknown provider: ${config.provider}`);
     }
@@ -514,81 +499,6 @@ export class TranscriptionService {
     return data.text;
   }
 
-  private async transcribeWithGemini(
-    buffer: Buffer,
-    apiKey: string,
-    mimeType: string
-  ): Promise<string> {
-    // Gemini uses inline audio data with base64 encoding
-    const resp = await fetch(
-      `https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          contents: [
-            {
-              parts: [
-                {
-                  text: "Transcribe this audio exactly as spoken. Return only the transcription text, nothing else:",
-                },
-                {
-                  inline_data: {
-                    mime_type: mimeType,
-                    data: buffer.toString("base64"),
-                  },
-                },
-              ],
-            },
-          ],
-        }),
-        signal: AbortSignal.timeout(PROVIDER_FETCH_TIMEOUT_MS),
-      }
-    );
-
-    if (!resp.ok) {
-      const error = await resp.text();
-      throw new Error(`Gemini API error: ${resp.status} - ${error}`);
-    }
-
-    const data = (await resp.json()) as {
-      candidates: Array<{
-        content: { parts: Array<{ text: string }> };
-      }>;
-    };
-    return data.candidates[0]?.content?.parts[0]?.text || "";
-  }
-
-  private async transcribeWithElevenLabs(
-    buffer: Buffer,
-    apiKey: string,
-    mimeType: string
-  ): Promise<string> {
-    // ElevenLabs speech-to-text API
-    const formData = new FormData();
-    const ext = this.getExtensionFromMime(mimeType);
-    formData.append(
-      "audio",
-      new Blob([buffer], { type: mimeType }),
-      `audio.${ext}`
-    );
-
-    const resp = await fetch("https://api.elevenlabs.io/v1/speech-to-text", {
-      method: "POST",
-      headers: { "xi-api-key": apiKey },
-      body: formData,
-      signal: AbortSignal.timeout(PROVIDER_FETCH_TIMEOUT_MS),
-    });
-
-    if (!resp.ok) {
-      const error = await resp.text();
-      throw new Error(`ElevenLabs API error: ${resp.status} - ${error}`);
-    }
-
-    const data = (await resp.json()) as { text: string };
-    return data.text;
-  }
-
   // ==========================================================================
   // Provider-specific implementations - Synthesis (TTS)
   // ==========================================================================
@@ -601,10 +511,6 @@ export class TranscriptionService {
     switch (config.provider) {
       case "openai":
         return this.synthesizeWithOpenAI(text, config, options);
-      case "gemini":
-        return this.synthesizeWithGemini(text, config.apiKey);
-      case "elevenlabs":
-        return this.synthesizeWithElevenLabs(text, config.apiKey, options);
       default:
         throw new Error(`Unknown provider: ${config.provider}`);
     }
@@ -647,107 +553,6 @@ export class TranscriptionService {
     return {
       audioBuffer: Buffer.from(arrayBuffer),
       mimeType: "audio/opus",
-    };
-  }
-
-  private async synthesizeWithGemini(
-    text: string,
-    apiKey: string
-  ): Promise<{ audioBuffer: Buffer; mimeType: string }> {
-    const resp = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent?key=${apiKey}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          contents: [
-            {
-              parts: [{ text: `Please speak this text aloud: "${text}"` }],
-            },
-          ],
-          generationConfig: {
-            responseModalities: ["AUDIO"],
-            speechConfig: {
-              voiceConfig: {
-                prebuiltVoiceConfig: {
-                  voiceName: "Aoede", // Default Gemini voice
-                },
-              },
-            },
-          },
-        }),
-        signal: AbortSignal.timeout(PROVIDER_FETCH_TIMEOUT_MS),
-      }
-    );
-
-    if (!resp.ok) {
-      const error = await resp.text();
-      throw new Error(`Gemini TTS API error: ${resp.status} - ${error}`);
-    }
-
-    const data = (await resp.json()) as {
-      candidates: Array<{
-        content: {
-          parts: Array<{
-            inlineData?: { mimeType: string; data: string };
-          }>;
-        };
-      }>;
-    };
-
-    const audioPart = data.candidates[0]?.content?.parts?.find((p) =>
-      p.inlineData?.mimeType?.startsWith("audio/")
-    );
-
-    if (!audioPart?.inlineData) {
-      throw new Error("Gemini did not return audio data");
-    }
-
-    return {
-      audioBuffer: Buffer.from(audioPart.inlineData.data, "base64"),
-      mimeType: audioPart.inlineData.mimeType,
-    };
-  }
-
-  private async synthesizeWithElevenLabs(
-    text: string,
-    apiKey: string,
-    options: VoiceOptions
-  ): Promise<{ audioBuffer: Buffer; mimeType: string }> {
-    // ElevenLabs TTS API
-    // Default voice: Rachel (21m00Tcm4TlvDq8ikWAM)
-    const voiceId = options.voice || "21m00Tcm4TlvDq8ikWAM";
-
-    const resp = await fetch(
-      `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`,
-      {
-        method: "POST",
-        headers: {
-          "xi-api-key": apiKey,
-          "Content-Type": "application/json",
-          Accept: "audio/mpeg",
-        },
-        body: JSON.stringify({
-          text,
-          model_id: "eleven_monolingual_v1",
-          voice_settings: {
-            stability: 0.5,
-            similarity_boost: 0.5,
-          },
-        }),
-        signal: AbortSignal.timeout(PROVIDER_FETCH_TIMEOUT_MS),
-      }
-    );
-
-    if (!resp.ok) {
-      const error = await resp.text();
-      throw new Error(`ElevenLabs TTS API error: ${resp.status} - ${error}`);
-    }
-
-    const arrayBuffer = await resp.arrayBuffer();
-    return {
-      audioBuffer: Buffer.from(arrayBuffer),
-      mimeType: "audio/mpeg",
     };
   }
 

--- a/packages/server/src/utils/inline-attachments.ts
+++ b/packages/server/src/utils/inline-attachments.ts
@@ -189,8 +189,9 @@ function inferKindFromMime(mime: string): string {
  * recoverable history.
  *
  * Picks the first agent in the org whose auth profiles include an STT
- * provider (OpenAI, Gemini, or ElevenLabs). If none exists, leaves the
- * placeholder untouched — graceful degradation.
+ * provider (OpenAI, or any OpenAI-compatible provider with a declared
+ * `stt` block). If none exists, leaves the placeholder untouched —
+ * graceful degradation.
  */
 export function triggerAudioTranscriptions(
   organizationId: string,


### PR DESCRIPTION
## Summary

Rescoped from the earlier TTS-removal draft after owner review: **the voice feature stays intact** — `generate_audio`, TTS synthesis, and inbound voice-note transcription all keep working. What goes is the two unused provider integrations:

- `transcribeWithGemini` / `transcribeWithElevenLabs` and `synthesizeWithGemini` / `synthesizeWithElevenLabs` bespoke branches in the transcription service
- `TTS_CAPABLE_PROVIDERS` trimmed to OpenAI; worker fallback suggestions trimmed to match
- ElevenLabs catalog entry deleted (TTS-only, no other purpose); Gemini keeps `text`+`image` but no longer advertises `tts`
- Docs + test fixtures updated

**Extensibility preserved:** any OpenAI-compatible STT provider (Groq today, others by catalog edit) still works via the config-driven candidate path — no code needed per provider. Gemini/ElevenLabs audio required bespoke code because neither exposes OpenAI-shaped audio endpoints.

**Evidence:** prod has zero Gemini/ElevenLabs audio keys or usage ever (0 configured, 6 audio events total in 1.17M). The deleted branches were unreachable in practice.

## Gates
- `make typecheck` clean
- Server audio suites 8/8, worker suites (audio-provider-suggestions, generated-media, custom-tools) 20/20 — `generate_audio` exercised and passing
- `InferenceModality` union and image generation untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Audio transcription and text-to-speech now use OpenAI or configured OpenAI-compatible providers such as Groq.
  * Gemini no longer supports text-to-speech.
  * ElevenLabs is no longer available as a provider.
  * Audio provider suggestions and fallback guidance now show only supported providers.
  * Updated provider documentation and validation coverage to reflect the streamlined provider set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->