### PR TITLE
test(server): deterministic device-feed claim + private-submodule-aware manifest guards

### DIFF
--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -1,8 +1,10 @@
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { generateSecureToken } from '../../auth/oauth/utils';
+import type { Env } from '../../index';
+import { materializeDueFeeds } from '../../scheduled/check-due-feeds';
 import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
 import { post } from '../setup/test-helpers';
 
@@ -115,12 +117,48 @@ async function poll(
   });
 }
 
-function loadOwlettoManifests(kind: 'mac' | 'chrome'): Array<Record<string, unknown>> {
+/**
+ * Poll and claim the just-installed connector's due feed run. When the poll
+ * handler's materialize cooldown is hot (see the primer comment below), the
+ * first poll installs the connector but claims nothing; running the
+ * materializer directly and re-polling is the deterministic equivalent of
+ * waiting out the 5s cooldown.
+ */
+async function pollClaimingDueFeed(workerId: string, connectorManifests: unknown[]) {
+  const first = await poll(workerId, connectorManifests);
+  expect(first.status).toBe(200);
+  const firstBody = await first.json();
+  if (firstBody.connector_key) {
+    return firstBody;
+  }
+
+  await materializeDueFeeds({} as Env, getTestDb());
+  const second = await poll(workerId, connectorManifests);
+  expect(second.status).toBe(200);
+  return second.json();
+}
+
+const OWLETTO_MANIFEST_DIRS = (() => {
   const here = dirname(fileURLToPath(import.meta.url));
-  const dir =
-    kind === 'mac'
-      ? resolve(here, '../../../../owletto/apps/mac/Owletto/ConnectorManifests')
-      : resolve(here, '../../../../owletto/apps/chrome/connector-manifests');
+  return {
+    mac: resolve(here, '../../../../owletto/apps/mac/Owletto/ConnectorManifests'),
+    chrome: resolve(here, '../../../../owletto/apps/chrome/connector-manifests'),
+  };
+})();
+
+/**
+ * The owletto submodule is a private repo, so contributor sandboxes without
+ * access to it cannot init it. Skip the manifest-parity tests there — but in
+ * CI (which checks the submodule out) a missing dir must FAIL, not skip, or a
+ * broken submodule checkout would silently drop manifest validation.
+ */
+function itWithOwlettoManifests(kind: keyof typeof OWLETTO_MANIFEST_DIRS) {
+  if (existsSync(OWLETTO_MANIFEST_DIRS[kind])) return it;
+  return process.env.CI ? it : it.skip;
+}
+
+function loadOwlettoManifests(kind: 'mac' | 'chrome'): Array<Record<string, unknown>> {
+  const dir = OWLETTO_MANIFEST_DIRS[kind];
   return readdirSync(dir)
     .filter((file) => file.endsWith('.json'))
     .sort()
@@ -149,9 +187,16 @@ describe('device connector manifests', () => {
   it('installs a metadata-only device connector from poll and claims its feed run without compiled_code', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
 
-    const res = await poll(workerId, [manifest()]);
-    expect(res.status).toBe(200);
-    const body = await res.json();
+    // Prime the poll handler's module-level due-feed-materialize cooldown
+    // (worker-api/poll.ts). The integration suite runs singleFork +
+    // isolate:false, so any poll in the previous ~5s — from this file or any
+    // other — leaves the cooldown hot and the next poll skips materialization.
+    // Making that state explicit turns a timing-dependent flake into a
+    // deterministic scenario.
+    const primer = await poll(workerId, []);
+    expect(primer.status).toBe(200);
+
+    const body = await pollClaimingDueFeed(workerId, [manifest()]);
 
     const def = await readDefinition(orgId);
     expect(def?.key).toBe(CONNECTOR_KEY);
@@ -193,7 +238,7 @@ describe('device connector manifests', () => {
     expect(await readFeedStatus(orgId)).toBe('paused');
   });
 
-  it('accepts the actual Owletto Mac manifests and installs their connector definitions', async () => {
+  itWithOwlettoManifests('mac')('accepts the actual Owletto Mac manifests and installs their connector definitions', async () => {
     const { orgId, workerId } = await seedDeviceOwner('macos');
     const manifests = loadOwlettoManifests('mac');
 
@@ -206,7 +251,7 @@ describe('device connector manifests', () => {
     expect(await readDefinition(orgId, 'chrome.history')).toBeNull();
   });
 
-  it('accepts the actual Owletto Chrome manifests and installs their connector definitions', async () => {
+  itWithOwlettoManifests('chrome')('accepts the actual Owletto Chrome manifests and installs their connector definitions', async () => {
     const { orgId, workerId } = await seedDeviceOwner('chrome-extension');
     const manifests = loadOwlettoManifests('chrome');
 

--- a/packages/server/src/__tests__/integration/mac-computer-use-action-poll.test.ts
+++ b/packages/server/src/__tests__/integration/mac-computer-use-action-poll.test.ts
@@ -3,7 +3,7 @@
  * `action_key` (chrome convention) and `operation_key` (Mac/iOS decode name).
  */
 
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -14,13 +14,21 @@ import { post } from '../setup/test-helpers';
 const CONNECTOR_KEY = 'apple.computer_use';
 const OPERATION_KEY = 'permissions';
 
+const COMPUTER_USE_MANIFEST_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../owletto/apps/mac/Owletto/ConnectorManifests/apple_computer_use.json',
+);
+
+// Private-submodule guard: skip in sandboxes without owletto access, but in
+// CI a missing manifest must fail loudly, not silently skip.
+const itWithManifest = existsSync(COMPUTER_USE_MANIFEST_PATH)
+  ? it
+  : process.env.CI
+    ? it
+    : it.skip;
+
 function loadComputerUseManifest(): Record<string, unknown> {
-  const here = dirname(fileURLToPath(import.meta.url));
-  const path = resolve(
-    here,
-    '../../../../owletto/apps/mac/Owletto/ConnectorManifests/apple_computer_use.json',
-  );
-  return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown>;
+  return JSON.parse(readFileSync(COMPUTER_USE_MANIFEST_PATH, 'utf8')) as Record<string, unknown>;
 }
 
 async function seedDeviceOwner() {
@@ -78,7 +86,7 @@ describe('mac computer_use action poll', () => {
     await cleanupTestDatabase();
   });
 
-  it('claims a pinned action run and returns operation_key alongside action_key', async () => {
+  itWithManifest('claims a pinned action run and returns operation_key alongside action_key', async () => {
     const { orgId, workerId, deviceWorkerId } = await seedDeviceOwner();
     const manifest = loadComputerUseManifest();
     const connectorManifests = [manifest];


### PR DESCRIPTION
## Summary
- The worker-poll handler's due-feed materialization sits behind a 5s module-level cooldown (`worker-api/poll.ts:37`). The integration suite runs `singleFork` + `isolate: false`, so any poll in the previous 5s — including from another test file — leaves the cooldown hot and the next poll claims nothing. The device-connector claim test primed and failed deterministically; it now claims via a helper that runs `materializeDueFeeds` directly when the first poll comes back empty (the deterministic equivalent of waiting out the cooldown).
- The owletto submodule is private, so contributor/agent sandboxes without access cannot init it. The three manifest-parity tests now skip when the manifest dirs are absent locally but still FAIL in CI (`process.env.CI`), so a broken submodule checkout can't silently drop manifest validation.

Salvages the two legitimate test-robustness ideas from #1853 without weakening CI.

## Test plan
- [x] Red→green: claim test fails deterministically with primed cooldown before the helper, passes after
- [x] Guard verified both ways: local (no CI env) skips when the manifest dir is hidden; `CI=1` fails loudly; submodule restored
- [x] `make review BASE=origin/main` (codex): bug_free 89, simplicity 93, 0 bugs, 0 blockers
- [x] `bun run check:fix` clean, tsc clean

## Notes
Test-only change; no production code touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786436969&installation_id=136316292&pr_number=1878&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1878&signature=4b0cc79e4d00a6c9ccc7c8308b081c0d48c6a72c0737643bf10317b657e5dd38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability for connector feed polling and claiming.
  * Added coverage for metadata-only manifests, including verification that compiled code remains unset.
  * Added conditional handling for optional macOS and Owletto manifest files, with appropriate CI validation.
  * Enhanced acceptance tests for platform-specific connector manifests and action-run results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->