### PR TITLE
fix: close MCP SDK consistency gaps

### DIFF
--- a/db/migrations/20260712110000_scheduler_summary_consistency.sql
+++ b/db/migrations/20260712110000_scheduler_summary_consistency.sql
@@ -1,0 +1,48 @@
+-- migrate:up
+
+-- A paused feed is not runnable. Keep the scheduler cursor structurally NULL
+-- so every API consumer sees the same state, regardless of which code path
+-- paused it (tool, device reconciliation, auth revocation, or soft delete).
+UPDATE feeds
+SET next_run_at = NULL,
+    updated_at = current_timestamp
+WHERE status = 'paused'
+  AND next_run_at IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION clear_paused_feed_next_run_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.status = 'paused' THEN
+    NEW.next_run_at := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS feeds_clear_paused_next_run_at ON feeds;
+CREATE TRIGGER feeds_clear_paused_next_run_at
+BEFORE INSERT OR UPDATE OF status, next_run_at ON feeds
+FOR EACH ROW
+EXECUTE FUNCTION clear_paused_feed_next_run_at();
+
+-- Repair watcher summaries created before completion paths consistently
+-- stamped last_fired_at. Run creation is the durable dispatch record.
+UPDATE watchers w
+SET last_fired_at = latest.fired_at,
+    updated_at = current_timestamp
+FROM (
+  SELECT watcher_id, MAX(created_at) AS fired_at
+  FROM runs
+  WHERE watcher_id IS NOT NULL
+    AND status = 'completed'
+  GROUP BY watcher_id
+) latest
+WHERE w.id = latest.watcher_id
+  AND (w.last_fired_at IS NULL OR w.last_fired_at < latest.fired_at);
+
+-- migrate:down
+
+DROP TRIGGER IF EXISTS feeds_clear_paused_next_run_at ON feeds;
+DROP FUNCTION IF EXISTS clear_paused_feed_next_run_at();

--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -626,7 +626,15 @@ const instagramTakeoutDir = localTakeoutDir(
   "INSTAGRAM_TAKEOUT_DIR",
   "instagram"
 );
-const linkedinTakeoutDir = localTakeoutDir("LINKEDIN_TAKEOUT_DIR", "linkedin");
+// LinkedIn is also a browser connector. Unlike takeout-only connections, never
+// synthesize a local path for it: a browser-only deployment must not provision
+// CSV feeds that can only fail forever. Opt in with either an explicit LinkedIn
+// directory or an explicitly configured shared takeout root.
+const linkedinTakeoutDir =
+  process.env.LINKEDIN_TAKEOUT_DIR ??
+  (process.env.LOCAL_TAKEOUT_ROOT
+    ? `${process.env.LOCAL_TAKEOUT_ROOT}/linkedin`
+    : null);
 
 const takeoutConnection = defineConnection({
   slug: "google-takeout-buremba",
@@ -688,16 +696,20 @@ const linkedinConnection = defineConnection({
   name: "LinkedIn",
   feeds: [
     // Local Data Export (CSV) feeds.
-    { feed: "messages", config: { takeout_dir: linkedinTakeoutDir } },
-    { feed: "connections", config: { takeout_dir: linkedinTakeoutDir } },
-    { feed: "invitations", config: { takeout_dir: linkedinTakeoutDir } },
-    { feed: "applied_jobs", config: { takeout_dir: linkedinTakeoutDir } },
-    { feed: "profile", config: { takeout_dir: linkedinTakeoutDir } },
-    { feed: "companies", config: { takeout_dir: linkedinTakeoutDir } },
-    { feed: "learning", config: { takeout_dir: linkedinTakeoutDir } },
-    { feed: "events", config: { takeout_dir: linkedinTakeoutDir } },
-    { feed: "endorsements", config: { takeout_dir: linkedinTakeoutDir } },
-    { feed: "media", config: { takeout_dir: linkedinTakeoutDir } },
+    ...(linkedinTakeoutDir
+      ? [
+          "messages",
+          "connections",
+          "invitations",
+          "applied_jobs",
+          "profile",
+          "companies",
+          "learning",
+          "events",
+          "endorsements",
+          "media",
+        ].map((feed) => ({ feed, config: { takeout_dir: linkedinTakeoutDir } }))
+      : []),
     // Live Chrome-extension feed (no company_url needed).
     { feed: "home_feed", config: { max_scrolls: 8 } },
   ],

--- a/packages/connector-sdk/src/connector-types.ts
+++ b/packages/connector-sdk/src/connector-types.ts
@@ -589,8 +589,11 @@ export interface ActionDefinition {
   description?: string;
   /** Whether this action requires human approval before execution */
   requiresApproval: boolean;
+	/** Semantic effect used by operation discovery and policy. Defaults to write. */
+	kind?: 'read' | 'write';
   /** MCP tool annotations for client-side confirmation UX */
   annotations?: {
+		readOnlyHint?: boolean;
     destructiveHint?: boolean;
     openWorldHint?: boolean;
     idempotentHint?: boolean;

--- a/packages/connectors/src/google_calendar.ts
+++ b/packages/connectors/src/google_calendar.ts
@@ -204,6 +204,7 @@ export default class GoogleCalendarConnector extends ConnectorRuntime {
       },
       get_event: {
         key: 'get_event',
+		kind: 'read',
         name: 'Get Event',
         description: 'Get full event details.',
         inputSchema: {

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -249,6 +249,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       },
       search: {
         key: 'search',
+		kind: 'read',
         name: 'Search Emails',
         description: 'Search emails by query.',
         inputSchema: {
@@ -268,6 +269,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
       },
       get_thread: {
         key: 'get_thread',
+		kind: 'read',
         name: 'Get Thread',
         description: 'Read full thread content.',
         inputSchema: {

--- a/packages/connectors/src/youtube.ts
+++ b/packages/connectors/src/youtube.ts
@@ -451,6 +451,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
     actions: {
       search: {
         key: 'search',
+		kind: 'read',
         name: 'Search Videos',
         description: 'Search public YouTube by keyword and return matching videos.',
         inputSchema: {
@@ -477,6 +478,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
       },
       get_video: {
         key: 'get_video',
+		kind: 'read',
         name: 'Get Video',
         description: 'Fetch metadata for one YouTube video by id or URL.',
         inputSchema: {
@@ -500,6 +502,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
       },
       search_liked_videos: {
         key: 'search_liked_videos',
+		kind: 'read',
         name: 'Search Liked Videos',
         description:
           "Filter the authenticated user's liked videos by title or channel name (substring match).",
@@ -523,6 +526,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
       },
       list_playlists: {
         key: 'list_playlists',
+		kind: 'read',
         name: 'List Playlists',
         description: "List the authenticated user's YouTube playlists.",
         inputSchema: {
@@ -539,6 +543,7 @@ export default class YouTubeConnector extends ConnectorRuntime {
       },
       get_playlist: {
         key: 'get_playlist',
+		kind: 'read',
         name: 'Get Playlist',
         description: 'List videos in one of your playlists, with an optional title filter.',
         inputSchema: {

--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -545,6 +545,8 @@ export const ManageConnectionsResultSchema = Type.Union([
   Type.Object({
     error: Type.String(),
     setup_url: Type.Optional(Type.String()),
+    install_type: Type.Optional(Type.Literal("app_installation")),
+    next_action: Type.Optional(Type.Literal("open_setup_url")),
   }),
   Type.Object({
     action: Type.Literal("list"),

--- a/packages/core/src/contracts/tools/manage-entity-schema.ts
+++ b/packages/core/src/contracts/tools/manage-entity-schema.ts
@@ -106,6 +106,12 @@ export const ManageEntitySchemaSchema = Type.Object({
       description: "[create/update] JSON Schema for metadata validation",
     })
   ),
+  list_scope: Type.Optional(
+    Type.Union([Type.Literal("accessible"), Type.Literal("organization")], {
+      description:
+        "[list] accessible (default) includes the current org plus public schemas; organization returns only the bound org.",
+    })
+  ),
 
   // Entity type fields
   icon: Type.Optional(
@@ -332,6 +338,11 @@ export const ManageEntitySchemaResultSchema = Type.Union([
     schema_type: Type.Literal("entity_type"),
     action: Type.Literal("list"),
     entity_types: Type.Array(EntityTypeRowSchema),
+    list_scope: Type.Union([
+      Type.Literal("accessible"),
+      Type.Literal("organization"),
+    ]),
+    organization_id: Type.String(),
   }),
   Type.Object({
     schema_type: Type.Literal("entity_type"),
@@ -364,6 +375,11 @@ export const ManageEntitySchemaResultSchema = Type.Union([
     schema_type: Type.Literal("relationship_type"),
     action: Type.Literal("list"),
     relationship_types: Type.Array(RelationshipTypeRowSchema),
+    list_scope: Type.Union([
+      Type.Literal("accessible"),
+      Type.Literal("organization"),
+    ]),
+    organization_id: Type.String(),
   }),
   Type.Object({
     schema_type: Type.Literal("relationship_type"),

--- a/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
@@ -162,10 +162,11 @@ describe("manage_connections — app_installation create guard", () => {
 		};
 		const err = structured.error;
 		expect(err).toMatch(/install/i);
-		expect(err).toMatch(/\/github\/app\/install/);
 		expect(structured.install_type).toBe("app_installation");
 		expect(structured.next_action).toBe("open_setup_url");
-		expect(structured.setup_url).toBeDefined();
+		const setupUrl = new URL(structured.setup_url as string);
+		expect(setupUrl.pathname).toContain("/connectors");
+		expect(setupUrl.searchParams.get("install")).toBe(CONNECTOR_KEY);
 		// Zero rows created.
 		expect(await connectionCount(org.id)).toBe(0);
 	});
@@ -188,10 +189,12 @@ describe("manage_connections — app_installation create guard", () => {
 		);
 
 		expect("error" in res).toBe(true);
-		expect((res as { error: string }).error).toMatch(/\/github\/app\/install/);
+		expect((res as { error: string }).error).toMatch(/install/i);
 		expect((res as { install_type?: string }).install_type).toBe("app_installation");
 		expect((res as { next_action?: string }).next_action).toBe("open_setup_url");
-		expect((res as { setup_url?: string }).setup_url).toBeDefined();
+		const setupUrl = new URL((res as { setup_url: string }).setup_url);
+		expect(setupUrl.pathname).toContain("/connectors");
+		expect(setupUrl.searchParams.get("install")).toBe(CONNECTOR_KEY);
 		expect(await connectionCount(org.id)).toBe(0);
 	});
 
@@ -236,8 +239,8 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 		if (res && typeof res === "object" && "error" in res) {
 			// A later failure (e.g. missing OAuth profile) is fine — it must just NOT
 			// be the install-flow guidance the guard produces.
-			expect((res as { error: string }).error).not.toMatch(
-				/\/github\/app\/install/,
+			expect((res as { error: string }).error).not.toContain(
+				"connected by installing its app",
 			);
 		}
 		// No error at all is also a pass (guard skipped, create proceeded).
@@ -246,7 +249,10 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 	/** Assert the create/connect WAS rejected by the app-install guard. */
 	function expectGuardRejected(res: unknown): void {
 		expect(res && typeof res === "object" && "error" in res).toBe(true);
-		expect((res as { error: string }).error).toMatch(/\/github\/app\/install/);
+		const structured = res as { error: string; setup_url: string };
+		expect(structured.error).toContain("connected by installing its app");
+		const setupUrl = new URL(structured.setup_url);
+		expect(setupUrl.searchParams.get("install")).toBe(CONNECTOR_KEY);
 	}
 
 	it("create WITH a RESOLVABLE auth_profile_slug (oauth intent) is ALLOWED past the guard", async () => {
@@ -578,8 +584,7 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 			TEST_ENV,
 			ctx,
 		);
-		expect("error" in res).toBe(true);
-		expect((res as { error: string }).error).toMatch(/\/github\/app\/install/);
+		expectGuardRejected(res);
 		expect(await connectionCount(org.id)).toBe(0);
 	});
 });

--- a/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
@@ -154,9 +154,18 @@ describe("manage_connections — app_installation create guard", () => {
 		);
 
 		expect("error" in res).toBe(true);
-		const err = (res as { error: string }).error;
+		const structured = res as {
+			error: string;
+			install_type?: string;
+			next_action?: string;
+			setup_url?: string;
+		};
+		const err = structured.error;
 		expect(err).toMatch(/install/i);
 		expect(err).toMatch(/\/github\/app\/install/);
+		expect(structured.install_type).toBe("app_installation");
+		expect(structured.next_action).toBe("open_setup_url");
+		expect(structured.setup_url).toBeDefined();
 		// Zero rows created.
 		expect(await connectionCount(org.id)).toBe(0);
 	});
@@ -180,6 +189,9 @@ describe("manage_connections — app_installation create guard", () => {
 
 		expect("error" in res).toBe(true);
 		expect((res as { error: string }).error).toMatch(/\/github\/app\/install/);
+		expect((res as { install_type?: string }).install_type).toBe("app_installation");
+		expect((res as { next_action?: string }).next_action).toBe("open_setup_url");
+		expect((res as { setup_url?: string }).setup_url).toBeDefined();
 		expect(await connectionCount(org.id)).toBe(0);
 	});
 

--- a/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
+++ b/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
@@ -20,6 +20,7 @@ import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
   addUserToOrganization,
   createTestConnectorDefinition,
+	createTestConnection,
   createTestOrganization,
   createTestUser,
 } from '../../setup/test-fixtures';
@@ -173,6 +174,28 @@ describe('migration invariants', () => {
       expect(def).toContain("'failed'::text");
       expect(def).toContain('action_input IS NOT NULL');
     });
+
+		it('paused feeds cannot retain a scheduler cursor', async () => {
+			const org = await createTestOrganization({ name: 'Paused Feed Invariant Org' });
+			await createTestConnectorDefinition({
+				organization_id: org.id,
+				key: 'paused-feed-invariant',
+				name: 'Paused Feed Invariant',
+			});
+			const connection = await createTestConnection({
+				organization_id: org.id,
+				connector_key: 'paused-feed-invariant',
+			});
+			const sql = getTestDb();
+			const [feed] = await sql`
+				UPDATE feeds
+				SET status = 'paused', next_run_at = NOW() - INTERVAL '1 hour'
+				WHERE connection_id = ${connection.id}
+				RETURNING status, next_run_at
+			`;
+			expect(feed.status).toBe('paused');
+			expect(feed.next_run_at).toBeNull();
+		});
 
     it('redundant/dead indexes are dropped while their covering indexes remain (2026-06-16 audit round 2)', async () => {
       const sql = getTestDb();

--- a/packages/server/src/__tests__/integration/entity-schema/entity-types.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/entity-types.test.ts
@@ -144,6 +144,44 @@ describe('entity schema CRUD', () => {
       await owner.entity_schema.deleteType('lst-asset');
     });
 
+		it('reports list scope and can restrict results to the bound organization', async () => {
+			const publicOrg = await createTestOrganization({
+				name: 'Public Schema Catalog',
+				visibility: 'public',
+			});
+			const publicOwner = await createTestUser({ email: 'public-schema-owner@test.com' });
+			await addUserToOrganization(publicOwner.id, publicOrg.id, 'owner');
+			const publicClient = await TestApiClient.for({
+				organizationId: publicOrg.id,
+				userId: publicOwner.id,
+				memberRole: 'owner',
+			});
+			await publicClient.entity_schema.createType({
+				slug: 'public-schema-only',
+				name: 'Public Schema Only',
+			});
+
+			const accessible = (await owner.entity_schema.listTypes()) as {
+				list_scope: string;
+				entity_types: Array<{ slug: string }>;
+			};
+			expect(accessible.list_scope).toBe('accessible');
+			expect(accessible.entity_types.map((type) => type.slug)).toContain(
+				'public-schema-only'
+			);
+
+			const local = (await owner.entity_schema.listTypes({
+				list_scope: 'organization',
+			})) as {
+				list_scope: string;
+				entity_types: Array<{ slug: string }>;
+			};
+			expect(local.list_scope).toBe('organization');
+			expect(local.entity_types.map((type) => type.slug)).not.toContain(
+				'public-schema-only'
+			);
+		});
+
     it('round-trips a derived backing (sql) and reverts to stored', async () => {
       type Got = {
         entity_type?: {
@@ -268,6 +306,16 @@ describe('entity schema CRUD', () => {
         })
       ).rejects.toThrow(/backing\.sql cannot be empty/i);
     });
+
+		it('rejects the silently ignored top-level properties alias', async () => {
+			await expect(
+				owner.entity_schema.createType({
+					slug: 'wrong-schema-shape',
+					name: 'Wrong Schema Shape',
+					properties: { title: { type: 'string' } },
+				} as never)
+			).rejects.toThrow(/properties.*metadata_schema/i);
+		});
   });
 
   describe('relationship_type', () => {

--- a/packages/server/src/__tests__/integration/events/save-content-occurred-at.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-occurred-at.test.ts
@@ -67,7 +67,17 @@ describe('saveContent > occurred_at default', () => {
       } as never,
       {} as never,
       ctx()
-    )) as { id: number };
+    )) as {
+			id: number;
+			indexing_status: string;
+			exact_read: { method: string; content_id: number };
+		};
+
+		expect(result.indexing_status).toBe('pending');
+		expect(result.exact_read).toEqual({
+			method: 'client.knowledge.read',
+			content_id: result.id,
+		});
 
     const sql = getTestDb();
     const [row] = await sql`

--- a/packages/server/src/__tests__/unit/connector-operation-kind.test.ts
+++ b/packages/server/src/__tests__/unit/connector-operation-kind.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { getLocalActionKind } from "../../operations/connector-operations";
+
+describe("local connector operation classification", () => {
+	it("honors explicit read kinds", () => {
+		expect(getLocalActionKind({ kind: "read" })).toBe("read");
+	});
+
+	it("honors MCP-compatible readOnlyHint annotations", () => {
+		expect(
+			getLocalActionKind({ annotations: { readOnlyHint: true } }),
+		).toBe("read");
+	});
+
+	it("fails closed to write when no semantic kind is declared", () => {
+		expect(
+			getLocalActionKind({
+				requiresApproval: false,
+				annotations: { idempotentHint: true, destructiveHint: false },
+			}),
+		).toBe("write");
+	});
+});

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -76,6 +76,18 @@ describe("sdkSearch", () => {
 		expect(result.match_count).toBeGreaterThan(0);
 	});
 
+	it("resolves multiple dotted method names independently", async () => {
+		const result = await sdkSearch(
+			{ query: "entities.get entities.delete entities.link" },
+			stubEnv,
+			writeCtx,
+		);
+		const joined = result.results.join("\n");
+		expect(joined).toContain("entities.get");
+		expect(joined).toContain("entities.delete");
+		expect(joined).toContain("entities.link");
+	});
+
 	it("returns empty + helpful note for unknown queries", async () => {
 		const result = await sdkSearch(
 			{ query: "definitelyNotAMethod" },
@@ -94,5 +106,21 @@ describe("sdkSearch", () => {
 		);
 		expect(result.results.length).toBeLessThanOrEqual(2);
 		expect(result.notes).toContain("more matches");
+	});
+
+	it("shows exact list signatures instead of implying uniform pagination", async () => {
+		const paginated = await sdkSearch(
+			{ query: "entities.list" },
+			stubEnv,
+			readCtx,
+		);
+		expect(paginated.results[0]).toContain("limit?: number");
+
+		const unpaginated = await sdkSearch(
+			{ query: "metrics.list" },
+			stubEnv,
+			readCtx,
+		);
+		expect(unpaginated.results[0]).toContain("not paginated");
 	});
 });

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -88,6 +88,29 @@ describe("sdkSearch", () => {
 		expect(joined).toContain("entities.link");
 	});
 
+	it("explains restricted methods in a multi-method query", async () => {
+		const result = await sdkSearch(
+			{ query: "watchers.list agents.list" },
+			stubEnv,
+			writeCtx,
+		);
+		expect(result.results.join("\n")).toContain("watchers.list");
+		expect(result.results.join("\n")).not.toContain("agents.list");
+		expect(result.notes).toContain("agents.list requires workspace admin/owner");
+	});
+
+	it("explains write methods hidden from a multi-method read query", async () => {
+		const result = await sdkSearch(
+			{ query: "watchers.list watchers.create", mode: "read" },
+			stubEnv,
+			writeCtx,
+		);
+		expect(result.results.join("\n")).toContain("watchers.list");
+		expect(result.results.join("\n")).not.toContain("watchers.create");
+		expect(result.notes).toContain("watchers.create exists but requires run_sdk");
+		expect(result.notes).toContain("Showing query_sdk-safe methods only");
+	});
+
 	it("returns empty + helpful note for unknown queries", async () => {
 		const result = await sdkSearch(
 			{ query: "definitelyNotAMethod" },

--- a/packages/server/src/catalog/__tests__/merge.test.ts
+++ b/packages/server/src/catalog/__tests__/merge.test.ts
@@ -42,6 +42,26 @@ describe("catalog/merge", () => {
 		expect(merged[1]?.detail.installable).toBe(true);
 	});
 
+	it("counts explicitly read-only catalog actions as reads", () => {
+		const [item] = mergeConnectorInstalledWithCatalog([], [
+			{
+				id: "example",
+				name: "Example",
+				detail: {
+					actions_schema: {
+						search: { kind: "read" },
+						create: { kind: "write" },
+					},
+				},
+			},
+		]);
+		expect(item?.detail.operations_summary).toMatchObject({
+			total: 2,
+			reads: 1,
+			writes: 1,
+		});
+	});
+
 	it("mergeSkillInstalledWithCatalog skips hidden catalog skills", () => {
 		const merged = mergeSkillInstalledWithCatalog(
 			[

--- a/packages/server/src/catalog/merge.ts
+++ b/packages/server/src/catalog/merge.ts
@@ -1,8 +1,15 @@
 import type { CatalogEntry, InstalledItem } from "./types";
 
-function actionCountFromSchema(actionsSchema: unknown): number {
-	if (!actionsSchema || typeof actionsSchema !== "object") return 0;
-	return Object.keys(actionsSchema).length;
+function actionCountsFromSchema(actionsSchema: unknown): { reads: number; writes: number } {
+	if (!actionsSchema || typeof actionsSchema !== "object") return { reads: 0, writes: 0 };
+	let reads = 0;
+	let writes = 0;
+	for (const action of Object.values(actionsSchema)) {
+		const def = action as { kind?: unknown; annotations?: { readOnlyHint?: unknown } };
+		if (def?.kind === "read" || def?.annotations?.readOnlyHint === true) reads += 1;
+		else writes += 1;
+	}
+	return { reads, writes };
 }
 
 function sortConnectorItems(items: InstalledItem[]): InstalledItem[] {
@@ -36,7 +43,8 @@ export function mergeConnectorInstalledWithCatalog(
 	for (const entry of catalog) {
 		if (merged.has(entry.id)) continue;
 		const detail = entry.detail;
-		const actionCount = actionCountFromSchema(detail.actions_schema);
+		const actionCounts = actionCountsFromSchema(detail.actions_schema);
+		const actionCount = actionCounts.reads + actionCounts.writes;
 		merged.set(entry.id, {
 			id: entry.id,
 			name: entry.name,
@@ -50,8 +58,8 @@ export function mergeConnectorInstalledWithCatalog(
 				catalog_origin: "catalog",
 				operations_summary: {
 					total: actionCount,
-					reads: 0,
-					writes: actionCount,
+					reads: actionCounts.reads,
+					writes: actionCounts.writes,
 					local_action: actionCount,
 					mcp_tool: 0,
 					http_operation: 0,

--- a/packages/server/src/operations/connector-operations.ts
+++ b/packages/server/src/operations/connector-operations.ts
@@ -398,6 +398,12 @@ async function getMcpOperations(
 	}));
 }
 
+export function getLocalActionKind(def: Record<string, any>): "read" | "write" {
+	return def.kind === "read" || def.annotations?.readOnlyHint === true
+		? "read"
+		: "write";
+}
+
 function getLocalActionOperations(
 	connectorKey: string,
 	connectorName: string,
@@ -410,7 +416,7 @@ function getLocalActionOperations(
 		operation_key: key,
 		name: def.name ?? humanizeOperationKey(key),
 		description: def.description,
-		kind: "write",
+		kind: getLocalActionKind(def),
 		backend: "local_action",
 		requires_approval: def.requiresApproval ?? false,
 		annotations:

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -8,6 +8,8 @@ export type MethodAccess = "read" | "write" | "external" | "admin";
 export interface MethodMetadata {
 	summary: string;
 	access: MethodAccess;
+	/** Exact callable TypeScript signature, including whether pagination exists. */
+	signature?: string;
 	throws?: readonly string[];
 	/** Single-line copy-pasteable snippet. */
 	example?: string;
@@ -40,6 +42,7 @@ export const METHOD_METADATA: Record<string, MethodMetadata> = {
 		summary:
 			"List entities in the current organization with optional filters. Returns `{ action, entities, metadata }` where `entities` is the page and `metadata` carries `total_count`, `has_more`, `limit`, `offset`.",
 		access: "read",
+		signature: "entities.list(input?: { entity_type?: string; parent_id?: number; search?: string; limit?: number; offset?: number }): Promise<unknown>",
 		example:
 			"const { entities } = await client.entities.list({ entity_type: 'company' });",
 		usageExample: `// All companies in the workspace, newest first.
@@ -112,8 +115,11 @@ export default async (_ctx, client) => {
 		access: "write",
 	},
 	"entitySchema.listTypes": {
-		summary: "List entity types in the organization.",
+		summary:
+			"List entity types. Defaults to accessible (current org plus public schemas); pass list_scope: 'organization' for only the bound org.",
 		access: "read",
+		signature:
+			"entitySchema.listTypes(input?: { list_scope?: 'accessible' | 'organization' }): Promise<unknown>",
 	},
 	"entitySchema.getType": {
 		summary: "Get an entity type by slug.",
@@ -121,7 +127,7 @@ export default async (_ctx, client) => {
 	},
 	"entitySchema.createType": {
 		summary:
-			"Create an entity type. The metadata shape goes in `metadata_schema` (a JSON Schema), NOT `properties` — a top-level `properties` key is silently ignored.",
+			"Create an entity type. The metadata shape goes in `metadata_schema` (a JSON Schema); an invalid top-level `properties` alias is rejected.",
 		access: "write",
 		example:
 			"await client.entitySchema.createType({ slug: 'widget', name: 'Widget', metadata_schema: { type: 'object', properties: { color: { type: 'string' } } } });",
@@ -139,8 +145,11 @@ export default async (_ctx, client) => {
 		access: "read",
 	},
 	"entitySchema.listRelTypes": {
-		summary: "List relationship types.",
+		summary:
+			"List relationship types. Defaults to accessible (current org plus public schemas); pass list_scope: 'organization' for only the bound org.",
 		access: "read",
+		signature:
+			"entitySchema.listRelTypes(input?: { list_scope?: 'accessible' | 'organization' }): Promise<unknown>",
 	},
 	"entitySchema.getRelType": {
 		summary: "Get a relationship type by slug.",
@@ -417,10 +426,12 @@ export default async (_ctx, client) => {
 	"connections.list": {
 		summary: "List configured connections in the current organization.",
 		access: "read",
+		signature: "connections.list(input?: { connector_key?: string; status?: string; limit?: number; offset?: number }): Promise<unknown>",
 	},
 	"catalog.listCatalog": {
 		summary: "List global catalog entries (connectors, skills, watchers).",
 		access: "read",
+		signature: "catalog.listCatalog(input?: { kinds?: Array<'connectors' | 'skills'> }): Promise<unknown> // not paginated",
 	},
 	"catalog.listInstalled": {
 		summary: "List installed org or agent resources.",
@@ -509,7 +520,11 @@ export default async (_ctx, client) => {
 		summary: "Raw manage_feeds action wrapper. Prefer named methods.",
 		access: "external",
 	},
-	"feeds.list": { summary: "List data-sync feeds.", access: "read" },
+	"feeds.list": {
+		summary: "List data-sync feeds.",
+		access: "read",
+		signature: "feeds.list(input?: { connection_id?: number; status?: string; limit?: number; offset?: number }): Promise<unknown>",
+	},
 	"feeds.get": { summary: "Get a feed by id.", access: "read" },
 	"feeds.readMany": {
 		summary:
@@ -535,6 +550,7 @@ export default async (_ctx, client) => {
 	"authProfiles.list": {
 		summary: "List reusable auth profiles.",
 		access: "read",
+		signature: "authProfiles.list(input?: { connector_key?: string; provider?: string; profile_kind?: AuthProfileKind }): Promise<unknown> // not paginated",
 	},
 	"authProfiles.get": {
 		summary: "Get an auth profile by slug.",
@@ -565,6 +581,7 @@ export default async (_ctx, client) => {
 	"classifiers.list": {
 		summary: "List classifier templates.",
 		access: "read",
+		signature: "classifiers.list(input?: { entity_id?: number; status?: string }): Promise<unknown> // not paginated",
 	},
 	"classifiers.create": {
 		summary: "Create a classifier template.",
@@ -618,6 +635,7 @@ export default async (_ctx, client) => {
 		summary:
 			"List declared metrics per entity type: measures, dimensions, and segments with descriptions. Keyword-search with `q`. Pair with `metrics.query`.",
 		access: "read",
+		signature: "metrics.list(input?: { entity_type?: string; q?: string }): Promise<unknown> // not paginated",
 		example: "const { entity_types } = await client.metrics.list({ q: 'spend' });",
 		usageExample: `// Discover governed measures before running one.
 export default async (_ctx, client) => {

--- a/packages/server/src/sandbox/namespaces/entity-schema.ts
+++ b/packages/server/src/sandbox/namespaces/entity-schema.ts
@@ -23,7 +23,7 @@ export interface EntitySchemaAddRuleInput {
 
 export interface EntitySchemaNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	listTypes(): Promise<unknown>;
+	listTypes(input?: { list_scope?: "accessible" | "organization" }): Promise<unknown>;
 	getType(slug: string): Promise<unknown>;
 	createType(input: {
 		slug: string;
@@ -59,7 +59,7 @@ export interface EntitySchemaNamespace {
 	deleteType(slug: string): Promise<unknown>;
 	auditType(slug: string): Promise<unknown>;
 
-	listRelTypes(): Promise<unknown>;
+	listRelTypes(input?: { list_scope?: "accessible" | "organization" }): Promise<unknown>;
 	getRelType(slug: string): Promise<unknown>;
 	createRelType(input: {
 		slug: string;
@@ -98,14 +98,14 @@ export function buildEntitySchemaNamespace(
 
 	return {
 		manage,
-		listTypes: () => callEntity({ action: "list" }),
+		listTypes: (input) => callEntity({ action: "list", ...input }),
 		getType: (slug) => callEntity({ action: "get", slug }),
 		createType: (input) => callEntity({ action: "create", ...input }),
 		updateType: (input) => callEntity({ action: "update", ...input }),
 		deleteType: (slug) => callEntity({ action: "delete", slug }),
 		auditType: (slug) => callEntity({ action: "audit", slug }),
 
-		listRelTypes: () => callRel({ action: "list" }),
+		listRelTypes: (input) => callRel({ action: "list", ...input }),
 		getRelType: (slug) => callRel({ action: "get", slug }),
 		createRelType: (input) => callRel({ action: "create", ...input }),
 		updateRelType: (input) => callRel({ action: "update", ...input }),

--- a/packages/server/src/tools/admin/helpers/app-installation-guard.ts
+++ b/packages/server/src/tools/admin/helpers/app-installation-guard.ts
@@ -27,7 +27,10 @@
  */
 
 import { parseJsonObject } from '@lobu/core';
+import { buildConnectionsUrl } from '../../../utils/url-builder';
 import { resolveAuthProfileSlugToId } from '../../../utils/auth-profiles';
+import type { ToolContext } from '../../registry';
+import { getOrgUrlContext } from '../../view-urls';
 import {
   getEnvAuthFieldKeys,
   isPrimaryAuthMethodAppInstallation,
@@ -49,6 +52,18 @@ function hasManagedByOrg(config: Record<string, unknown>): boolean {
   }
   const org = (managedBy as Record<string, unknown>).org;
   return typeof org === 'string' && org.trim().length > 0;
+}
+
+export async function buildAppInstallationSetupUrl(
+	ctx: ToolContext,
+	connectorKey: string,
+): Promise<string | undefined> {
+	const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
+	return ownerSlug && baseUrl
+		? buildConnectionsUrl(ownerSlug, baseUrl, undefined, {
+				install: connectorKey,
+			})
+		: undefined;
 }
 
 /**
@@ -132,7 +147,7 @@ export async function rejectUnboundAppInstallationCreate(params: {
   return {
     error:
       `Connector '${params.connectorKey}' is connected by installing its app (which links the connection automatically), not by creating a connection directly. ` +
-      `Start the app install flow instead — for GitHub that's /github/app/install. ` +
+			`Start the connector's app install flow instead. ` +
       `(To use a different auth method this connector supports, pass an auth profile or credentials.)`,
 		install_type: 'app_installation',
 		next_action: 'open_setup_url',

--- a/packages/server/src/tools/admin/helpers/app-installation-guard.ts
+++ b/packages/server/src/tools/admin/helpers/app-installation-guard.ts
@@ -74,7 +74,11 @@ export async function rejectUnboundAppInstallationCreate(params: {
   connectorKey: string;
   authProfileSlug?: string | null;
   appAuthProfileSlug?: string | null;
-}): Promise<{ error: string } | null> {
+	}): Promise<{
+		error: string;
+		install_type: 'app_installation';
+		next_action: 'open_setup_url';
+	} | null> {
   const schema = normalizeConnectorAuthSchema(params.authSchema);
   // Only connectors whose PRIMARY method is app_installation are in scope.
   if (!isPrimaryAuthMethodAppInstallation(schema)) return null;
@@ -130,5 +134,7 @@ export async function rejectUnboundAppInstallationCreate(params: {
       `Connector '${params.connectorKey}' is connected by installing its app (which links the connection automatically), not by creating a connection directly. ` +
       `Start the app install flow instead — for GitHub that's /github/app/install. ` +
       `(To use a different auth method this connector supports, pass an auth profile or credentials.)`,
+		install_type: 'app_installation',
+		next_action: 'open_setup_url',
   };
 }

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -24,7 +24,10 @@ import {
   resolveConnectionVisibility,
 } from '../../helpers/connection-helpers';
 import { assertEntityIdsInOrg } from '../../helpers/db-helpers';
-import { rejectUnboundAppInstallationCreate } from '../../helpers/app-installation-guard';
+import {
+	buildAppInstallationSetupUrl,
+	rejectUnboundAppInstallationCreate,
+} from '../../helpers/app-installation-guard';
 import { type FeedDefinition, splitConfigByFeedScope } from '../../helpers/feed-helpers';
 import { getScopedConnectorDefinition } from '../../../../catalog/connector-definitions';
 import { buildConnectionsUrl } from '../../../../utils/url-builder';
@@ -84,11 +87,10 @@ export async function handleConnect(
     authProfileSlug: args.auth_profile_slug,
     appAuthProfileSlug: args.app_auth_profile_slug,
   });
-  if (appInstallGuard) {
+	if (appInstallGuard) {
 		return {
 			...appInstallGuard,
-			setup_url:
-				buildSetupUrl({ install: args.connector_key }) ?? "/github/app/install",
+			setup_url: await buildAppInstallationSetupUrl(ctx, args.connector_key),
 		};
 	}
 

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -84,7 +84,13 @@ export async function handleConnect(
     authProfileSlug: args.auth_profile_slug,
     appAuthProfileSlug: args.app_auth_profile_slug,
   });
-  if (appInstallGuard) return appInstallGuard;
+  if (appInstallGuard) {
+		return {
+			...appInstallGuard,
+			setup_url:
+				buildSetupUrl({ install: args.connector_key }) ?? "/github/app/install",
+		};
+	}
 
   const deviceBinding = await resolveDeviceBinding({
     organizationId,

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -652,7 +652,13 @@ export async function handleCreate(
     authProfileSlug: args.auth_profile_slug,
     appAuthProfileSlug: args.app_auth_profile_slug,
   });
-  if (appInstallGuard) return appInstallGuard;
+  if (appInstallGuard) {
+		return {
+			...appInstallGuard,
+			setup_url:
+				(await buildViewUrl(ctx, args.connector_key)) ?? "/github/app/install",
+		};
+	}
 
   const deviceBinding = await resolveDeviceBinding({
     organizationId,

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -56,7 +56,10 @@ import {
 	runStatusLiteral,
 } from "../../../../utils/run-statuses";
 import type { ToolContext } from "../../../registry";
-import { rejectUnboundAppInstallationCreate } from "../../helpers/app-installation-guard";
+import {
+	buildAppInstallationSetupUrl,
+	rejectUnboundAppInstallationCreate,
+} from "../../helpers/app-installation-guard";
 import {
   buildViewUrl,
   enrichWithAuthProfiles,
@@ -652,11 +655,10 @@ export async function handleCreate(
     authProfileSlug: args.auth_profile_slug,
     appAuthProfileSlug: args.app_auth_profile_slug,
   });
-  if (appInstallGuard) {
+	if (appInstallGuard) {
 		return {
 			...appInstallGuard,
-			setup_url:
-				(await buildViewUrl(ctx, args.connector_key)) ?? "/github/app/install",
+			setup_url: await buildAppInstallationSetupUrl(ctx, args.connector_key),
 		};
 	}
 

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -49,7 +49,7 @@ export { ManageEntitySchemaResultSchema, ManageEntitySchemaSchema };
 const runEntityTypeActions = defineFlatActionTool<ManageEntitySchemaArgs, ManageEntitySchemaResult>(
   'manage_entity_schema',
   {
-    list: flatAction((_args, ctx) => etHandleList(ctx)),
+    list: flatAction(etHandleList),
     get: flatAction((args, ctx) => etHandleGet(args.slug, ctx)),
     create: flatAction((args, ctx) => etHandleCreate(args, ctx)),
     update: flatAction((args, ctx) => etHandleUpdate(args, ctx)),
@@ -83,6 +83,15 @@ async function manageEntitySchemaImpl(
   env: Env,
   ctx: ToolContext
 ): Promise<ManageEntitySchemaResult> {
+	if (
+		(args.action === 'create' || args.action === 'update') &&
+		Object.hasOwn(args as object, 'properties')
+	) {
+		throw new ToolUserError(
+			"[invalid_schema] top-level properties is not supported; put JSON Schema fields under metadata_schema.properties",
+			422
+		);
+	}
   if (args.schema_type === 'entity_type') {
     return runEntityTypeActions(args, env, ctx);
   }
@@ -246,15 +255,22 @@ async function recordAudit(
 // Entity Type Action Handlers
 // ============================================
 
-async function etHandleList(ctx: ToolContext): Promise<ManageEntitySchemaResult> {
+async function etHandleList(
+	args: ManageEntitySchemaArgs,
+	ctx: ToolContext
+): Promise<ManageEntitySchemaResult> {
   const sql = getDb();
+	const scopePredicate =
+		args.list_scope === 'organization'
+			? 'et.organization_id = $1'
+			: "(et.organization_id = $1 OR o.visibility = 'public')";
 
   const rows = await sql.unsafe(
     `SELECT ${ENTITY_TYPE_COLUMNS_WITH_ORG}
      FROM entity_types et
      LEFT JOIN organization o ON o.id = et.organization_id
      WHERE et.deleted_at IS NULL
-       AND (et.organization_id = $1 OR o.visibility = 'public')
+		 AND ${scopePredicate}
      ORDER BY (et.organization_id = $1) DESC, et.name ASC`,
     [ctx.organizationId]
   );
@@ -280,7 +296,13 @@ async function etHandleList(ctx: ToolContext): Promise<ManageEntitySchemaResult>
     return a.name.localeCompare(b.name);
   });
 
-  return { schema_type: 'entity_type', action: 'list', entity_types: entityTypes };
+	return {
+		schema_type: 'entity_type',
+		action: 'list',
+		entity_types: entityTypes,
+		list_scope: args.list_scope ?? 'accessible',
+		organization_id: ctx.organizationId,
+	};
 }
 
 /**
@@ -856,6 +878,10 @@ async function rtHandleList(
   const sql = getDb();
   const includeDeleted = args.include_deleted ?? false;
   const deletedClause = includeDeleted ? '' : 'AND rt.deleted_at IS NULL';
+	const scopePredicate =
+		args.list_scope === 'organization'
+			? 'rt.organization_id = $1'
+			: "(rt.organization_id = $1 OR o.visibility = 'public')";
 
   const rows = await sql.unsafe<RelationshipTypeRow>(
     `SELECT
@@ -875,7 +901,7 @@ async function rtHandleList(
         AND organization_id = $1
       GROUP BY relationship_type_id
     ) rc ON rc.relationship_type_id = rt.id
-    WHERE (rt.organization_id = $1 OR o.visibility = 'public')
+		WHERE ${scopePredicate}
       ${deletedClause}
     ORDER BY (rt.organization_id = $1) DESC, rt.name ASC`,
     [ctx.organizationId]
@@ -893,6 +919,8 @@ async function rtHandleList(
       ...(r as unknown as RelationshipTypeRow),
       relationship_count: Number(r.relationship_count) || 0,
     })),
+		list_scope: args.list_scope ?? 'accessible',
+		organization_id: ctx.organizationId,
   };
 }
 

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -174,7 +174,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'save_memory',
     description:
-      "Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.",
+      "Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_id })`; semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.",
     inputSchema: SaveContentSchema,
     annotations: { ...WRITE_WITHOUT_CONFIRM, title: 'Save memory' },
     handler: saveContent,

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -146,6 +146,9 @@ interface SaveContentResult {
   created_at: string;
   supersedes_event_id?: number;
   view_url?: string;
+	/** Semantic search is asynchronous; exact reads by id are available immediately. */
+	indexing_status: 'pending';
+	exact_read: { method: 'client.knowledge.read'; content_id: number };
 }
 
 // ============================================
@@ -418,6 +421,11 @@ async function saveContentImpl(
     title: row.title as string | null,
     semantic_type: semanticType,
     created_at: String(row.created_at),
+		indexing_status: 'pending',
+		exact_read: {
+			method: 'client.knowledge.read',
+			content_id: Number(row.id),
+		},
   };
   if (args.supersedes_event_id) {
     result.supersedes_event_id = args.supersedes_event_id;

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -157,6 +157,23 @@ async function sdkSearchImpl(
 			}
 		}
 		const entries = [...matches.entries()];
+		const notes: string[] = [];
+		if (entries.length > limit) {
+			notes.push(
+				`${entries.length - limit} more matches; raise \`limit\` or refine the query.`,
+			);
+		}
+		for (const token of methodTokens) {
+			const meta = METHOD_METADATA[token];
+			if (meta && !matches.has(token)) {
+				notes.push(hiddenMethodNote(token, meta, mode));
+			}
+		}
+		if (mode === "read") {
+			notes.push(
+				"Showing query_sdk-safe methods only. Pass mode='full' for write/admin methods.",
+			);
+		}
 		return {
 			query,
 			match_count: entries.length,
@@ -165,10 +182,7 @@ async function sdkSearchImpl(
 					? renderDrillDown(path, meta)
 					: renderListLine(path, meta),
 			),
-			notes:
-				entries.length > limit
-					? `${entries.length - limit} more matches; raise \`limit\` or refine the query.`
-					: undefined,
+			notes: notes.length > 0 ? notes.join(" ") : undefined,
 		};
 	}
 

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -109,6 +109,9 @@ function renderDrillDown(path: string, meta: MethodMetadata): string {
 	lines.push(
 		`  access: ${meta.access}${meta.cost ? ` (cost: ${meta.cost})` : ""}`,
 	);
+	if (meta.signature) {
+		lines.push(`  signature: ${meta.signature}`);
+	}
 	if (meta.throws && meta.throws.length > 0) {
 		lines.push(`  throws: ${meta.throws.join(", ")}`);
 	}
@@ -136,6 +139,38 @@ async function sdkSearchImpl(
 	const lower = query.toLowerCase();
 	const mode: SdkDiscoveryMode = args.mode ?? "full";
 	const catalog = catalogForCaller(ctx, mode);
+	const methodTokens = lower
+		.split(/[\s,]+/)
+		.map((token) => token.replace(/^[`'"(]+|[`'").;]+$/g, ""))
+		.filter((token) => token.includes("."));
+
+	// Agents commonly ask for several exact methods in one discovery call. Treat
+	// each dotted token as its own query instead of searching for the entire
+	// whitespace-joined sentence as one impossible substring.
+	if (methodTokens.length > 1) {
+		const matches = new Map<string, MethodMetadata>();
+		for (const token of methodTokens) {
+			for (const [path, meta] of catalog) {
+				if (path.toLowerCase() === token || path.toLowerCase().includes(token)) {
+					matches.set(path, meta);
+				}
+			}
+		}
+		const entries = [...matches.entries()];
+		return {
+			query,
+			match_count: entries.length,
+			results: entries.slice(0, limit).map(([path, meta]) =>
+				methodTokens.includes(path.toLowerCase())
+					? renderDrillDown(path, meta)
+					: renderListLine(path, meta),
+			),
+			notes:
+				entries.length > limit
+					? `${entries.length - limit} more matches; raise \`limit\` or refine the query.`
+					: undefined,
+		};
+	}
 
 	if (lower in METHOD_METADATA) {
 		const meta = METHOD_METADATA[lower];

--- a/scripts/lib/__tests__/review-reviewer.test.sh
+++ b/scripts/lib/__tests__/review-reviewer.test.sh
@@ -66,6 +66,9 @@ case "$failure_message" in
 esac
 
 review_script="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/review.sh"
+grep -Fq 'CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-fable}"' "$review_script" ||
+  fail "Claude reviewer must default to the Fable model"
+
 schema_arg_count="$(grep -F -- '--json-schema "$(cat "$SCHEMA_FILE")"' "$review_script" | wc -l | tr -d ' ')"
 [ "$schema_arg_count" -eq 2 ] ||
   fail "Claude reviewer must receive the verdict schema inline and in Herdr"

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -63,7 +63,7 @@ elif git show-ref --verify --quiet refs/remotes/origin/main; then
 else
   BASE_BRANCH="main"
 fi
-CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-opus}"
+CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-fable}"
 CLAUDE_REVIEW_EFFORT="${CLAUDE_REVIEW_EFFORT:-high}"
 CODEX_REVIEW_MODEL="${CODEX_REVIEW_MODEL:-}"
 REVIEWER_CLI="${REVIEWER_CLI:-auto}"


### PR DESCRIPTION
## Summary

- close the SDK, tool-contract, entity-schema, scheduler-summary, and app-install consistency gaps tracked in #1881
- classify connector operations consistently as read or write across SDK metadata, server routing, bundled connectors, and Owletto
- make Claude the review path use Fable by default, with a regression assertion
- add the scheduler summary consistency migration and focused contract/integration coverage

## Nested dependency

- Owletto change merged in lobu-ai/owletto#485
- parent pointer targets merged `owletto/main` SHA `8187d62f`

## Validation

- pre-commit Biome checks and TypeScript typecheck
- `make review BASE=origin/main` with `REVIEWER_CLI=claude` and the default Fable model
- deterministic review gates: typecheck=0, unit=0, integration=0
- focused regression tests for review model default, manifests, operation kinds, schema contracts, search pagination, app installation, and migration invariants

Closes #1881

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786495238&installation_id=136316292&pr_number=1882&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1882&signature=9b19d7067a6da6a64369f72fbd6d14c5c8781a9577d76fe3d494fa8bc3fdeb95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added organization-scoped or accessible-scoped listings for entity and relationship types.
  - SDK search results can show method signatures and handle multiple method queries.
  - Read-only connector actions are now identified more accurately.
  - Content saves report indexing status and provide an exact-read reference.
  - App installation errors now include setup guidance and a setup URL.

- **Bug Fixes**
  - Paused feeds no longer retain scheduled run times.
  - Corrected historical watcher firing summaries.
  - Improved validation for invalid entity schema input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->