### PR TITLE
fix(review): FIFO review-lock queue + 4h default wait

### DIFF
--- a/scripts/lib/__tests__/review-lock.test.sh
+++ b/scripts/lib/__tests__/review-lock.test.sh
@@ -109,6 +109,50 @@ wait
 [ "$(find "$tmp/acquired" -type f | wc -l | tr -d ' ')" -eq 40 ] ||
   fail "not every high-contention owner acquired the lock"
 
+# FIFO: the oldest waiter takes the next turn even when a younger waiter
+# polls far more aggressively. Without ticket ordering this race is ~50/50
+# per release and the oldest waiter can starve indefinitely.
+fifo_tmp="$tmp/fifo"
+mkdir -p "$fifo_tmp"
+REVIEW_LOCK_ROOT_FOR_TESTS="$fifo_tmp/lock" bash -c '
+  set -euo pipefail
+  . "$1"
+  acquire_review_lock
+  touch "$2/held"
+  while [ ! -f "$2/release" ]; do sleep 0.02; done
+  release_review_lock
+' bash "$repo_root/scripts/lib/review-lock.sh" "$fifo_tmp" &
+holder_pid=$!
+wait_for_file "$fifo_tmp/held" "fifo lock holder"
+
+REVIEW_LOCK_ROOT_FOR_TESTS="$fifo_tmp/lock" REVIEW_LOCK_TIMEOUT_SECONDS=20 \
+  REVIEW_LOCK_POLL_SECONDS=0.5 bash -c '
+    set -euo pipefail
+    . "$1"
+    acquire_review_lock >/dev/null
+    echo A >> "$2/order"
+    release_review_lock
+  ' bash "$repo_root/scripts/lib/review-lock.sh" "$fifo_tmp" &
+waiter_a=$!
+# Distinct ticket epoch-seconds make arrival order unambiguous.
+sleep 1.1
+REVIEW_LOCK_ROOT_FOR_TESTS="$fifo_tmp/lock" REVIEW_LOCK_TIMEOUT_SECONDS=20 \
+  REVIEW_LOCK_POLL_SECONDS=0.01 bash -c '
+    set -euo pipefail
+    . "$1"
+    acquire_review_lock >/dev/null
+    echo B >> "$2/order"
+    release_review_lock
+  ' bash "$repo_root/scripts/lib/review-lock.sh" "$fifo_tmp" &
+waiter_b=$!
+sleep 0.5
+touch "$fifo_tmp/release"
+wait "$holder_pid"
+holder_pid=""
+wait "$waiter_a" "$waiter_b"
+[ "$(sed -n '1p' "$fifo_tmp/order")" = "A" ] ||
+  fail "younger fast-polling waiter jumped the FIFO queue: $(tr '\n' ' ' < "$fifo_tmp/order")"
+
 # Signals stop and reap the active child before the host lock is released.
 signal_tmp="$tmp/signal"
 mkdir -p "$signal_tmp"

--- a/scripts/lib/review-lock.sh
+++ b/scripts/lib/review-lock.sh
@@ -20,11 +20,48 @@ release_review_lock() {
   REVIEW_LOCK_HELD=0
 }
 
+# FIFO ordering: each waiter registers a ticket file "<epoch>.<pid>" and only
+# the oldest live ticket may attempt the flock. Without this, every lock
+# release is a poll race that newer waiters win as often as the oldest one —
+# under multi-session contention the oldest review starves past its timeout.
+# Tickets of dead processes are pruned by any waiter, so a killed review never
+# blocks the queue. Reviews from checkouts predating tickets race unordered
+# against ticket holders (same flock, so mutual exclusion still holds).
+review_lock_prune_dead_tickets() {
+  local tickets="$1" t pid stamp now
+  now="$(date +%s)"
+  for t in "$tickets"/*; do
+    [ -e "$t" ] || continue
+    pid="${t##*.}"
+    stamp="${t##*/}"
+    stamp="${stamp%%.*}"
+    [ "$pid" = "$$" ] && continue
+    case "$pid$stamp" in
+      ''|*[!0-9]*) rm -f "$t"; continue ;;
+    esac
+    # A recycled pid can make a ghost ticket look alive forever; no legitimate
+    # waiter outlives a day.
+    if [ $((now - stamp)) -gt 86400 ]; then
+      rm -f "$t"
+      continue
+    fi
+    kill -0 "$pid" 2>/dev/null || rm -f "$t"
+  done
+}
+
+review_lock_head_ticket() {
+  local tickets="$1"
+  # Ticket names are strictly <epoch>.<pid> — no ls-parsing hazard.
+  # shellcheck disable=SC2012
+  ls "$tickets" 2>/dev/null | sort -t. -k1,1n -k2,2n | head -n 1
+}
+
 acquire_review_lock() {
-  local lock_root candidate owner_pid timeout poll_seconds started now announced
+  local lock_root candidate tickets ticket owner_pid timeout poll_seconds started now announced
   lock_root="$(review_lock_root)"
   candidate="$lock_root/full-review.lock"
-  timeout="${REVIEW_LOCK_TIMEOUT_SECONDS:-1800}"
+  tickets="$lock_root/tickets"
+  timeout="${REVIEW_LOCK_TIMEOUT_SECONDS:-14400}"
   poll_seconds="${REVIEW_LOCK_POLL_SECONDS:-2}"
 
   case "$timeout" in
@@ -34,22 +71,30 @@ acquire_review_lock() {
       ;;
   esac
 
-  mkdir -p "$lock_root"
+  mkdir -p "$lock_root" "$tickets"
   chmod 700 "$lock_root"
   touch "$candidate"
   chmod 600 "$candidate"
   exec 9>>"$candidate"
+  ticket="$tickets/$(date +%s).$$"
+  printf '%s\n' "$$" > "$ticket"
   started="$(date +%s)"
   announced=0
 
-  while ! perl -MFcntl=:flock -e \
-    'exit(flock(STDIN, LOCK_EX | LOCK_NB) ? 0 : 1)' <&9; do
+  while :; do
+    review_lock_prune_dead_tickets "$tickets"
+    if [ "$(review_lock_head_ticket "$tickets")" = "${ticket##*/}" ] &&
+      perl -MFcntl=:flock -e \
+        'exit(flock(STDIN, LOCK_EX | LOCK_NB) ? 0 : 1)' <&9; then
+      break
+    fi
     owner_pid="$(sed -n '1p' "$candidate" 2>/dev/null || true)"
     if [ -z "$owner_pid" ]; then
       owner_pid="unknown"
     fi
     now="$(date +%s)"
     if [ $((now - started)) -ge "$timeout" ]; then
+      rm -f "$ticket"
       exec 9>&-
       echo "timed out waiting for full review lock held by pid $owner_pid" >&2
       return 2
@@ -61,6 +106,7 @@ acquire_review_lock() {
     sleep "$poll_seconds"
   done
 
+  rm -f "$ticket"
   # The file may contain a PID from a dead process, but the kernel lock is the
   # source of truth. Rewrite diagnostics only after atomic ownership succeeds.
   : > "$candidate"


### PR DESCRIPTION
## Problem
Tonight five sessions ran `make review` concurrently. The host lock is a 2s poll race: every release wakes all waiters and newer ones win as often as the oldest. The oldest review starved for 55 minutes, and an earlier attempt was killed outright by the 30-minute default wait timeout ("timed out waiting for full review lock").

## Fix (deliberately minimal — no new concurrency)
- **FIFO tickets**: each waiter registers `<epoch>.<pid>` under the lock root; only the oldest live ticket may attempt the flock, so turns go in arrival order. Dead-pid tickets are pruned by any waiter; a 24h age-out guards pid-recycled ghosts.
- **Default wait 1800s → 14400s** so a queued review outlives a realistic queue.

Same single flock, same mutual exclusion, same FD-9 inheritance semantics. Old checkouts contend unordered on the same lock file — still mutually exclusive, just not queued, until they rebase.

Considered and rejected: a 2-slot semaphore + macOS shm sysctl bump — parallel full suites would need proof that no test touches a machine-global resource (several tests hardcode `PORT=8787`-style env), for a win only when 3+ sessions review at once.

## Evidence
- New FIFO regression test: fast-polling younger waiter (0.01s poll) must not beat an older waiter (0.5s poll) — fails on the old lock, passes now.
- `bash scripts/lib/__tests__/review-lock.test.sh` → all scenarios pass (mutual exclusion, stale-pid recovery, 40-contender serialization, signal reaping, commit-status ownership, Herdr close-retention, FIFO).
- `shellcheck` clean on both files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786496639&installation_id=136316292&pr_number=1884&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1884&signature=596febb4c6bc85f7b67bceee0569b3f48f8ebd0db759227e53e2f4b769a1e3a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->