### PR TITLE
fix: recover stale pending watcher runs

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/automation-contract.test.ts
@@ -17,9 +17,9 @@ import { ApiResponseRenderer } from "../../../gateway/api/response-renderer";
 import { UnifiedThreadResponseConsumer } from "../../../gateway/platform/unified-thread-consumer";
 import type { Env } from "../../../index";
 import { createWatcherRun } from "../../../runs/queue-service";
+import { nextRunAt } from "../../../utils/cron";
 import { generateWindowToken } from "../../../utils/jwt";
 import { computePendingWindow } from "../../../utils/window-utils";
-import { nextRunAt } from "../../../utils/cron";
 import {
 	advanceWatcherSchedule,
 	dispatchPendingWatcherRuns,
@@ -1585,6 +1585,90 @@ describe("watcher automation contract", () => {
 	});
 
 	describe("sweepStaleWatcherRuns liveness reaping", () => {
+		it("finalizes a stale scheduled pending run and advances its watcher schedule", async () => {
+			const { sql, watcherId } = await createAutomatedWatcher();
+			const materialized = await materializeDueWatcherRuns({} as Env);
+			expect(materialized.runsCreated).toBe(1);
+
+			const [queued] = await sql`
+        UPDATE runs
+        SET created_at = NOW() - INTERVAL '3 hours'
+        WHERE watcher_id = ${watcherId}
+          AND run_type = 'watcher'
+          AND status = 'pending'
+        RETURNING id
+      `;
+			expect(queued).toBeDefined();
+
+			const [sweepA, sweepB] = await Promise.all([
+				sweepStaleWatcherRuns(sql),
+				sweepStaleWatcherRuns(sql),
+			]);
+			expect(sweepA.timedOut + sweepB.timedOut).toBe(1);
+
+			const [run] = await sql`
+        SELECT status, completed_at, error_message
+        FROM runs
+        WHERE id = ${Number(queued.id)}
+      `;
+			expect(String(run.status)).toBe("timeout");
+			expect(run.completed_at).not.toBeNull();
+			expect(String(run.error_message ?? "")).toMatch(/pending.*2 hours/i);
+
+			const [watcher] =
+				await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
+			expect(new Date(watcher.next_run_at as string).getTime()).toBeGreaterThan(
+				Date.now(),
+			);
+
+			const retry = await materializeDueWatcherRuns({} as Env);
+			expect(retry.runsCreated).toBe(0);
+		});
+
+		it("leaves a fresh scheduled pending run available for dispatch", async () => {
+			const { sql, watcherId } = await createAutomatedWatcher();
+			const materialized = await materializeDueWatcherRuns({} as Env);
+			expect(materialized.runsCreated).toBe(1);
+
+			const { timedOut } = await sweepStaleWatcherRuns(sql);
+			expect(timedOut).toBe(0);
+			const [run] = await sql`
+        SELECT status FROM runs
+        WHERE watcher_id = ${watcherId} AND run_type = 'watcher'
+      `;
+			expect(String(run.status)).toBe("pending");
+		});
+
+		it("does not expire a stale manually triggered pending run", async () => {
+			const { sql, watcherId } = await createAutomatedWatcher();
+			await materializeDueWatcherRuns({} as Env);
+			await sql`
+        UPDATE runs
+        SET created_at = NOW() - INTERVAL '3 hours',
+            approved_input = jsonb_set(
+              approved_input,
+              '{dispatch_source}',
+              '"manual"'::jsonb
+            )
+        WHERE watcher_id = ${watcherId}
+          AND run_type = 'watcher'
+          AND status = 'pending'
+      `;
+
+			const { timedOut } = await sweepStaleWatcherRuns(sql);
+			expect(timedOut).toBe(0);
+			const [run] = await sql`
+        SELECT status FROM runs
+        WHERE watcher_id = ${watcherId} AND run_type = 'watcher'
+      `;
+			expect(String(run.status)).toBe("pending");
+			const [watcher] =
+				await sql`SELECT next_run_at FROM watchers WHERE id = ${watcherId}`;
+			expect(new Date(watcher.next_run_at as string).getTime()).toBeLessThan(
+				Date.now(),
+			);
+		});
+
 		// Seed a `running` watcher run with controlled claim/heartbeat ages.
 		// Omitting `heartbeatAgo` mirrors a client that never heartbeats — the
 		// claim sets last_heartbeat_at == claimed_at, so the row must fall to the

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -476,7 +476,11 @@ export async function sweepStaleWatcherRuns(
 	const sql = db ?? getDb();
 	const heartbeatStaleInterval = intervals.watcherRunHeartbeatStaleInterval;
 	const coarseStaleInterval = intervals.watcherRunStaleInterval;
-	const timedOut = await markStaleRunsAsTimeout(sql, {
+	const pendingTimedOut = await finalizeStalePendingWatcherRuns(
+		sql,
+		coarseStaleInterval,
+	);
+	const executingTimedOut = await markStaleRunsAsTimeout(sql, {
 		runTypes: ["watcher"],
 		heartbeatSemantics: "beat-after-claim",
 		heartbeatStaleInterval,
@@ -484,10 +488,89 @@ export async function sweepStaleWatcherRuns(
 		heartbeatErrorMessage: `Watcher run heartbeat went silent for over ${heartbeatStaleInterval} — the executor crashed or was abandoned`,
 		coarseErrorMessage: `Watcher run exceeded ${coarseStaleInterval} without reaching terminal state`,
 	});
+	const timedOut = pendingTimedOut + executingTimedOut;
 	if (timedOut > 0) {
-		logger.warn({ timedOut }, "[watchers] Swept stale watcher runs");
+		logger.warn(
+			{ timedOut, pendingTimedOut, executingTimedOut },
+			"[watchers] Swept stale watcher runs",
+		);
 	}
 	return { timedOut };
+}
+
+/**
+ * Terminalize scheduled watcher runs that were never claimed before the
+ * coarse watcher TTL elapsed. A `pending` row is part of the active-run set,
+ * so without this recovery it blocks materialization forever while the
+ * watcher's `next_run_at` remains in the past.
+ *
+ * The run and watcher are locked together in Postgres. Competing replicas,
+ * dispatchers, and materializers therefore converge on one transition:
+ * either a dispatcher claims the row first, or one sweeper marks it timeout
+ * and advances the schedule. Advancing inside the same transaction prevents
+ * the next automation tick from immediately recreating the missed run.
+ *
+ * Manual runs are intentionally excluded: a manual caller owns retry policy.
+ * Fresh scheduled rows are protected by the same generous TTL used for
+ * non-heartbeating executions, allowing device-pinned watchers to wait for a
+ * temporarily offline device without being churned.
+ */
+async function finalizeStalePendingWatcherRuns(
+	sql: DbClient,
+	staleInterval: string,
+): Promise<number> {
+	return sql.begin(async (tx) => {
+		const candidates = await tx<{
+			id: number;
+			watcher_id: number;
+			schedule: string | null;
+			timezone: string | null;
+		}>`
+      SELECT r.id, r.watcher_id, w.schedule, w.timezone
+      FROM runs r
+      JOIN watchers w ON w.id = r.watcher_id
+      WHERE r.run_type = 'watcher'
+        AND r.status = 'pending'
+        AND r.created_at < current_timestamp - ${staleInterval}::interval
+        AND r.approved_input->>'dispatch_source' = 'scheduled'
+      ORDER BY r.created_at ASC
+      FOR UPDATE OF r, w SKIP LOCKED
+      LIMIT 100
+    `;
+
+		let finalized = 0;
+		for (const candidate of candidates) {
+			const result = await tx`
+        UPDATE runs
+        SET status = 'timeout',
+            completed_at = current_timestamp,
+            error_message = ${`Watcher run remained pending for over ${staleInterval} without being claimed`}
+        WHERE id = ${candidate.id}
+          AND status = 'pending'
+      `;
+			if (Number(result.count ?? 0) === 0) continue;
+			finalized++;
+
+			if (!candidate.schedule) continue;
+			const next = nextRunAt(
+				candidate.schedule,
+				new Date(),
+				candidate.timezone,
+			);
+			await tx`
+        UPDATE watchers
+        SET next_run_at = ${next}::timestamptz,
+            updated_at = current_timestamp
+        WHERE id = ${candidate.watcher_id}
+          AND status = 'active'
+          AND schedule IS NOT NULL
+          AND next_run_at IS NOT NULL
+          AND next_run_at <= current_timestamp
+      `;
+		}
+
+		return finalized;
+	});
 }
 
 /**


### PR DESCRIPTION
## Root cause

Scheduled watcher runs that remained pending were excluded from stale-run sweeping. Because pending runs count as active, one unclaimed row could block future materialization indefinitely while the watcher schedule stayed overdue.

## Change

Finalize scheduled watcher runs that remain pending beyond the coarse watcher TTL, using a Postgres transaction with row locks and SKIP LOCKED for multi-replica safety. Advance the watcher schedule in its configured timezone in the same transaction. Fresh and manually triggered pending runs remain untouched.

## Impact

Abandoned scheduled watcher runs now become terminal and stop blocking future schedule ticks. Concurrent sweepers converge on one finalization, valid dispatcher claims win the row-lock race, and manual retry policy is preserved.

## Validation

- Claude Fable review: bug-free 88, simplicity 88, slop 0, bugs 0, zero blockers
- Full review gate: typecheck=0, unit=0, integration=0
- Real PostgreSQL watcher automation contract: 41/41 passed
- Focused stale-watcher liveness group: 8/8 passed

Refs #1880

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786497234&installation_id=136316292&pr_number=1885&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1885&signature=7b557003e82f5af87f8f474c1fffc15be4f4d976b6f6f4d6e131be76562009c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->