### PR TITLE
fix(knowledge): stop forwarding include_classifications into read_knowledge

### DIFF
--- a/packages/server/src/__tests__/unit/read-knowledge-rest-args.test.ts
+++ b/packages/server/src/__tests__/unit/read-knowledge-rest-args.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { parsePlatformsQuery } from "../../rest-api";
+import { GetContentSchema } from "../../tools/get_content/schema";
+import { validateToolArgs } from "../../tools/validate-args";
+import { ToolUserError } from "../../utils/errors";
+
+/**
+ * REST wrappers pass args straight into getContent (withValidatedArgs).
+ * After rejectUnknownKeys (#1836), any key not on GetContentSchema 400s —
+ * including always-present booleans like legacy include_classifications=false.
+ */
+describe("read_knowledge REST → tool arg contract", () => {
+	it("rejects legacy include_classifications (never a tool arg)", () => {
+		expect(() =>
+			validateToolArgs("read_knowledge", GetContentSchema, {
+				include_classifications: true,
+				include_classification: "summary",
+				limit: 1,
+			}),
+		).toThrow(ToolUserError);
+		try {
+			validateToolArgs("read_knowledge", GetContentSchema, {
+				include_classifications: false,
+				limit: 1,
+			});
+			expect.unreachable("should reject");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ToolUserError);
+			expect((err as ToolUserError).message).toMatch(/include_classifications/);
+		}
+	});
+
+	it("rejects singular platform (schema is platforms[])", () => {
+		expect(() =>
+			validateToolArgs("read_knowledge", GetContentSchema, {
+				platform: "slack",
+				limit: 1,
+			}),
+		).toThrow(/platform/);
+	});
+
+	it("accepts the public list shape REST must emit (no plural, platforms only)", () => {
+		const coerced = validateToolArgs("read_knowledge", GetContentSchema, {
+			sort_by: "date",
+			sort_order: "desc",
+			include_classification: "summary",
+			limit: 1,
+			offset: 0,
+			platforms: ["slack"],
+		});
+		expect(coerced).toMatchObject({
+			include_classification: "summary",
+			platforms: ["slack"],
+			limit: 1,
+		});
+		expect(coerced).not.toHaveProperty("include_classifications");
+		expect(coerced).not.toHaveProperty("platform");
+	});
+
+	it("parsePlatformsQuery maps singular platform into platforms[]", () => {
+		expect(parsePlatformsQuery(undefined, "slack")).toEqual(["slack"]);
+		expect(parsePlatformsQuery("telegram,discord", undefined)).toEqual([
+			"telegram",
+			"discord",
+		]);
+		expect(parsePlatformsQuery("telegram", "slack")).toEqual([
+			"telegram",
+			"slack",
+		]);
+		expect(parsePlatformsQuery("slack", "slack")).toEqual(["slack"]);
+		expect(parsePlatformsQuery(undefined, undefined)).toBeUndefined();
+	});
+});

--- a/packages/server/src/rest-api.ts
+++ b/packages/server/src/rest-api.ts
@@ -12,11 +12,11 @@ import {
 	resolveMaxAccessLevel,
 	SCOPE_CHECK_NOT_APPLICABLE,
 } from "./auth/tool-access";
+import { getScopedConnectorDefinition } from "./catalog/connector-definitions";
 import { listOrgInstalled } from "./catalog/installed";
 import { getDb } from "./db/client";
 import { streamInvalidationEvents } from "./events/sse";
 import type { Env } from "./index";
-import { getScopedConnectorDefinition } from "./catalog/connector-definitions";
 import { getOperationsSummary } from "./operations/connector-operations";
 import { manageClassifiers } from "./tools/admin/manage_classifiers";
 import { listWatchers } from "./tools/admin/manage_watchers";
@@ -330,21 +330,17 @@ export async function restListTools(c: Context<{ Bindings: Env }>) {
  * GET /api/knowledge/search
  * Wrapper for read_knowledge MCP tool (search mode)
  *
- * Query Parameters:
- * - query (required): Search text (min 3 characters)
- * - entity_id (optional): Filter by entity ID (integer)
- * - connection_id (optional): Filter by connection ID (integer)
- * - platform (optional): Filter by platform (reddit, trustpilot, etc.)
- * - platforms (optional): Comma-separated platform list
- * - since (optional): Filter by date (ISO date or relative like "7d", "30d")
- * - until (optional): Filter by date (ISO date)
- * - min_similarity (optional): Minimum similarity threshold (0.0-1.0, default: 0.6)
- * - include_classifications (optional): Include classification results (default: false)
- * - include_classification (optional): Include classification aggregates (summary)
- * - limit (optional): Max results (default: 50, max: 500)
- * - offset (optional): Pagination offset (default: 0)
- * - before_occurred_at / before_id (optional): Fetch the next older chronological slice
- * - after_occurred_at / after_id (optional): Fetch the next newer chronological slice
+ * Query Parameters (must be a subset of GetContentSchema — withValidatedArgs
+ * rejects unknown keys):
+ * - query (required on auth route): Search text (min 3 characters)
+ * - entity_id, connection_ids / connection_id, feed_ids, run_ids
+ * - platforms / platform (singular is mapped to platforms[])
+ * - since, until, min_similarity, limit, offset, cursors
+ * - include_classification (optional): aggregates only — "summary"
+ *
+ * Per-item classifications are always attached by the tool handler; there is
+ * no client flag for that (legacy `include_classifications` was internal-only
+ * and must never be forwarded into getContent).
  */
 function parseIdListParam(raw: string | undefined): number[] | undefined {
 	if (!raw) return undefined;
@@ -364,6 +360,19 @@ function parseStringListParam(raw: string | undefined): string[] | undefined {
 	return values.length > 0 ? values : undefined;
 }
 
+/** Merge `platforms=a,b` with legacy singular `platform=a` into schema `platforms`. */
+export function parsePlatformsQuery(
+	platformsCsv: string | undefined,
+	platformSingular: string | undefined,
+): string[] | undefined {
+	const fromList = parseStringListParam(platformsCsv);
+	const singular = platformSingular?.trim();
+	if (!singular) return fromList;
+	if (!fromList) return [singular];
+	if (fromList.includes(singular)) return fromList;
+	return [...fromList, singular];
+}
+
 export async function restSearchKnowledge(c: Context<{ Bindings: Env }>) {
 	try {
 		const query = c.req.query("query");
@@ -372,7 +381,6 @@ export async function restSearchKnowledge(c: Context<{ Bindings: Env }>) {
 		}
 
 		const connectionId = safeParseInt(c.req.query("connection_id"), { min: 1 });
-		const platforms = c.req.query("platforms");
 		const params = {
 			query,
 			entity_id: safeParseInt(c.req.query("entity_id"), { min: 1 }),
@@ -381,21 +389,16 @@ export async function restSearchKnowledge(c: Context<{ Bindings: Env }>) {
 				(connectionId ? [connectionId] : undefined),
 			feed_ids: parseIdListParam(c.req.query("feed_ids")),
 			run_ids: parseIdListParam(c.req.query("run_ids")),
-			platform: c.req.query("platform"),
-			platforms: platforms
-				? platforms
-						.split(",")
-						.map((platform) => platform.trim())
-						.filter(Boolean)
-				: undefined,
+			platforms: parsePlatformsQuery(
+				c.req.query("platforms"),
+				c.req.query("platform"),
+			),
 			since: c.req.query("since"),
 			until: c.req.query("until"),
 			min_similarity: safeParseFloat(c.req.query("min_similarity"), {
 				min: 0,
 				max: 1,
 			}),
-			include_classifications:
-				c.req.query("include_classifications") === "true",
 			include_classification:
 				c.req.query("include_classification") || undefined,
 			limit: safeParseInt(c.req.query("limit"), { min: 1, max: 500 }),
@@ -422,7 +425,6 @@ export async function publicRestSearchKnowledge(c: Context<{ Bindings: Env }>) {
 		const query = c.req.query("query");
 
 		const connectionId = safeParseInt(c.req.query("connection_id"), { min: 1 });
-		const platforms = c.req.query("platforms");
 		const contentIds = c.req.query("content_ids");
 		const params = {
 			query: query?.trim() || undefined,
@@ -432,13 +434,10 @@ export async function publicRestSearchKnowledge(c: Context<{ Bindings: Env }>) {
 				(connectionId ? [connectionId] : undefined),
 			feed_ids: parseIdListParam(c.req.query("feed_ids")),
 			run_ids: parseIdListParam(c.req.query("run_ids")),
-			platform: c.req.query("platform"),
-			platforms: platforms
-				? platforms
-						.split(",")
-						.map((platform) => platform.trim())
-						.filter(Boolean)
-				: undefined,
+			platforms: parsePlatformsQuery(
+				c.req.query("platforms"),
+				c.req.query("platform"),
+			),
 			since: c.req.query("since"),
 			until: c.req.query("until"),
 			engagement_min: safeParseInt(c.req.query("engagement_min"), {
@@ -470,8 +469,6 @@ export async function publicRestSearchKnowledge(c: Context<{ Bindings: Env }>) {
 				min: 0,
 				max: 1,
 			}),
-			include_classifications:
-				c.req.query("include_classifications") === "true",
 			include_classification:
 				c.req.query("include_classification") || undefined,
 			limit: safeParseInt(c.req.query("limit"), { min: 1, max: 500 }),


### PR DESCRIPTION
## Summary

Memory events (and public knowledge search) 400 with:

`unknown argument(s): include_classifications`

That name is an **internal** content-search flag. The tool surface only accepts `include_classification` (singular) for aggregate stats. Per-item classifications are still always attached by the handler.

### Root cause

After `rejectUnknownKeys` (#1836), any key outside `GetContentSchema` hard-fails:

1. **Owletto** sent `include_classifications: true` via `convertFiltersToApiParams` into `apiCall('read_knowledge', …)`.
2. **REST** always set `include_classifications: query === "true"` (boolean always present, even `false`) before calling `getContent` — so public search failed on every request.
3. Singular `platform` was also forwarded; schema only has `platforms[]`.

### Fix

- Server REST: drop plural flag; map `platform` → `platforms[]` via `parsePlatformsQuery`
- Owletto: stop emitting plural; keep `include_classification: 'summary'`
- Unit tests for the REST → tool arg contract

## Test plan

- [x] `bun test packages/server/src/__tests__/unit/read-knowledge-rest-args.test.ts`
- [x] `bun test packages/owletto/src/lib/event-filters.test.ts`
- [ ] Smoke: logged-in Memory Events loads without the unknown-arg error
- [ ] Smoke: `GET /api/atlas/public/knowledge/search?limit=1&sort_by=date` returns JSON (not 400)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786499939&installation_id=136316292&pr_number=1888&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1888&signature=11bdae9475f27b6d76fc9877acfcfb254e3aa0bf3194f741a25f4d0bdcc7a53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Knowledge search now supports combined platform filters from comma-separated and singular query parameters, with duplicate values removed.
  - Platform filters are consistently passed as an array to search results.

- **Bug Fixes**
  - Invalid or unknown search parameters are rejected.
  - Legacy classification and singular platform fields are no longer accepted by the search tool contract.
  - Valid classification, sorting, pagination, and platform options are correctly validated and normalized.

- **Documentation**
  - Updated knowledge search parameter guidance, including supported classification and platform options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->