### PR TITLE
Simplify agent permissions: one Effect envelope, drop principal_mode

### DIFF
--- a/db/migrations/20260713120000_drop_write_policy_principal_mode.sql
+++ b/db/migrations/20260713120000_drop_write_policy_principal_mode.sql
@@ -3,16 +3,144 @@
 -- Retire attended/autonomous dual-mode on write policies. One envelope for
 -- chat and watchers. Table is small admin config (not events-scale).
 -- Cost: O(rows of write_approval_policies) — typically tens per org.
+--
+-- CRITICAL: autonomous-only rows may be STRICTER than the mode-neutral row
+-- for the same scope. Deleting them outright would LOOSEN the effective
+-- policy. Fold each autonomous effect into the mode-neutral envelope first
+-- (most-restrictive wins), then drop the autonomous headers.
 
--- Drop legacy autonomous-only rows (and their effect children via CASCADE
--- would need policy delete first for the child FK; delete effects then headers).
-DELETE FROM write_policy_action_effects
- WHERE policy_id IN (
-   SELECT id FROM write_approval_policies WHERE principal_mode IS NOT NULL
- );
+-- Restrictiveness order: deny > disabled > approval > auto
+-- (deny and disabled both stop the write; prefer deny when both appear).
+WITH auto_effects AS (
+  SELECT
+    p.organization_id,
+    p.resource_class,
+    p.principal_kind,
+    p.principal_id,
+    p.operation_key,
+    p.entity_type_slug,
+    p.field_path,
+    p.entity_id,
+    e.action,
+    e.effect AS auto_effect
+  FROM write_approval_policies p
+  JOIN write_policy_action_effects e ON e.policy_id = p.id
+  WHERE p.principal_mode IS NOT NULL
+),
+neutral AS (
+  SELECT
+    p.id AS policy_id,
+    p.organization_id,
+    p.resource_class,
+    p.principal_kind,
+    p.principal_id,
+    p.operation_key,
+    p.entity_type_slug,
+    p.field_path,
+    p.entity_id
+  FROM write_approval_policies p
+  WHERE p.principal_mode IS NULL
+),
+-- Ensure a mode-neutral header exists for every autonomous scope (so we have
+-- somewhere to fold effects into).
+inserted AS (
+  INSERT INTO write_approval_policies (
+    organization_id, resource_class, principal_kind, principal_id,
+    operation_key, entity_type_slug, field_path, entity_id,
+    created_at, updated_at
+  )
+  SELECT DISTINCT
+    a.organization_id, a.resource_class, a.principal_kind, a.principal_id,
+    a.operation_key, a.entity_type_slug, a.field_path, a.entity_id,
+    now(), now()
+  FROM auto_effects a
+  WHERE NOT EXISTS (
+    SELECT 1 FROM write_approval_policies n
+    WHERE n.organization_id = a.organization_id
+      AND n.resource_class = a.resource_class
+      AND n.principal_kind IS NOT DISTINCT FROM a.principal_kind
+      AND n.principal_id IS NOT DISTINCT FROM a.principal_id
+      AND n.principal_mode IS NULL
+      AND n.operation_key IS NOT DISTINCT FROM a.operation_key
+      AND n.entity_type_slug IS NOT DISTINCT FROM a.entity_type_slug
+      AND n.field_path IS NOT DISTINCT FROM a.field_path
+      AND n.entity_id IS NOT DISTINCT FROM a.entity_id
+  )
+  ON CONFLICT DO NOTHING
+  RETURNING id
+),
+neutral_after AS (
+  SELECT
+    p.id AS policy_id,
+    p.organization_id,
+    p.resource_class,
+    p.principal_kind,
+    p.principal_id,
+    p.operation_key,
+    p.entity_type_slug,
+    p.field_path,
+    p.entity_id
+  FROM write_approval_policies p
+  WHERE p.principal_mode IS NULL
+),
+merged AS (
+  SELECT
+    n.policy_id,
+    a.action,
+    a.auto_effect,
+    e.effect AS neutral_effect
+  FROM auto_effects a
+  JOIN neutral_after n
+    ON n.organization_id = a.organization_id
+   AND n.resource_class = a.resource_class
+   AND n.principal_kind IS NOT DISTINCT FROM a.principal_kind
+   AND n.principal_id IS NOT DISTINCT FROM a.principal_id
+   AND n.operation_key IS NOT DISTINCT FROM a.operation_key
+   AND n.entity_type_slug IS NOT DISTINCT FROM a.entity_type_slug
+   AND n.field_path IS NOT DISTINCT FROM a.field_path
+   AND n.entity_id IS NOT DISTINCT FROM a.entity_id
+  LEFT JOIN write_policy_action_effects e
+    ON e.policy_id = n.policy_id AND e.action = a.action
+),
+-- Rank: deny=3, disabled=2, approval=1, auto=0; pick the max rank.
+picked AS (
+  SELECT
+    policy_id,
+    action,
+    CASE
+      WHEN auto_effect = 'deny' OR neutral_effect = 'deny' THEN 'deny'
+      WHEN auto_effect = 'disabled' OR neutral_effect = 'disabled' THEN 'disabled'
+      WHEN auto_effect = 'approval' OR neutral_effect = 'approval' THEN 'approval'
+      ELSE COALESCE(auto_effect, neutral_effect, 'auto')
+    END AS effect
+  FROM merged
+)
+INSERT INTO write_policy_action_effects (policy_id, action, effect)
+SELECT policy_id, action, effect FROM picked
+ON CONFLICT (policy_id, action) DO UPDATE
+  SET effect = EXCLUDED.effect
+  WHERE write_policy_action_effects.effect IS DISTINCT FROM EXCLUDED.effect
+    -- Only tighten: never loosen an existing neutral effect toward auto.
+    AND (
+      CASE EXCLUDED.effect
+        WHEN 'deny' THEN 3
+        WHEN 'disabled' THEN 2
+        WHEN 'approval' THEN 1
+        ELSE 0
+      END
+      >
+      CASE write_policy_action_effects.effect
+        WHEN 'deny' THEN 3
+        WHEN 'disabled' THEN 2
+        WHEN 'approval' THEN 1
+        ELSE 0
+      END
+    );
 
+-- Autonomous headers (and their child effects via CASCADE) are now redundant.
 DELETE FROM write_approval_policies WHERE principal_mode IS NOT NULL;
 
+-- squawk-ignore require-concurrent-index-deletion -- low-row-count policy table; brief lock negligible at this scale
 DROP INDEX IF EXISTS write_approval_policies_class_principal_mode_op_scope_key;
 
 ALTER TABLE write_approval_policies
@@ -22,6 +150,7 @@ ALTER TABLE write_approval_policies
   DROP COLUMN IF EXISTS principal_mode;
 
 -- Unique identity without principal_mode.
+-- squawk-ignore require-concurrent-index-creation -- low-row-count policy table; brief lock negligible at this scale
 CREATE UNIQUE INDEX IF NOT EXISTS write_approval_policies_class_principal_op_scope_key
   ON write_approval_policies (
     organization_id,
@@ -43,10 +172,15 @@ ALTER TABLE write_approval_policies
 
 ALTER TABLE write_approval_policies
   ADD CONSTRAINT write_approval_policies_principal_mode_check
-  CHECK (principal_mode IS NULL OR principal_mode = 'autonomous');
+  CHECK (principal_mode IS NULL OR principal_mode = 'autonomous') NOT VALID;
+-- squawk-ignore prefer-robust-stmts -- rollback path; low row count
+ALTER TABLE write_approval_policies
+  VALIDATE CONSTRAINT write_approval_policies_principal_mode_check;
 
+-- squawk-ignore require-concurrent-index-deletion -- rollback path; brief lock negligible at this scale
 DROP INDEX IF EXISTS write_approval_policies_class_principal_op_scope_key;
 
+-- squawk-ignore require-concurrent-index-creation -- rollback path; low row count
 CREATE UNIQUE INDEX IF NOT EXISTS write_approval_policies_class_principal_mode_op_scope_key
   ON write_approval_policies (
     organization_id,

--- a/db/migrations/20260713120000_drop_write_policy_principal_mode.sql
+++ b/db/migrations/20260713120000_drop_write_policy_principal_mode.sql
@@ -1,0 +1,61 @@
+-- migrate:up
+--
+-- Retire attended/autonomous dual-mode on write policies. One envelope for
+-- chat and watchers. Table is small admin config (not events-scale).
+-- Cost: O(rows of write_approval_policies) — typically tens per org.
+
+-- Drop legacy autonomous-only rows (and their effect children via CASCADE
+-- would need policy delete first for the child FK; delete effects then headers).
+DELETE FROM write_policy_action_effects
+ WHERE policy_id IN (
+   SELECT id FROM write_approval_policies WHERE principal_mode IS NOT NULL
+ );
+
+DELETE FROM write_approval_policies WHERE principal_mode IS NOT NULL;
+
+DROP INDEX IF EXISTS write_approval_policies_class_principal_mode_op_scope_key;
+
+ALTER TABLE write_approval_policies
+  DROP CONSTRAINT IF EXISTS write_approval_policies_principal_mode_check;
+
+ALTER TABLE write_approval_policies
+  DROP COLUMN IF EXISTS principal_mode;
+
+-- Unique identity without principal_mode.
+CREATE UNIQUE INDEX IF NOT EXISTS write_approval_policies_class_principal_op_scope_key
+  ON write_approval_policies (
+    organization_id,
+    resource_class,
+    COALESCE(principal_kind, ''),
+    COALESCE(principal_id, ''),
+    COALESCE(operation_key, ''),
+    COALESCE(entity_type_slug, ''),
+    COALESCE(field_path, ''),
+    COALESCE(entity_id, 0)
+  );
+
+-- migrate:down
+ALTER TABLE write_approval_policies
+  ADD COLUMN IF NOT EXISTS principal_mode text;
+
+ALTER TABLE write_approval_policies
+  DROP CONSTRAINT IF EXISTS write_approval_policies_principal_mode_check;
+
+ALTER TABLE write_approval_policies
+  ADD CONSTRAINT write_approval_policies_principal_mode_check
+  CHECK (principal_mode IS NULL OR principal_mode = 'autonomous');
+
+DROP INDEX IF EXISTS write_approval_policies_class_principal_op_scope_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS write_approval_policies_class_principal_mode_op_scope_key
+  ON write_approval_policies (
+    organization_id,
+    resource_class,
+    COALESCE(principal_kind, ''),
+    COALESCE(principal_id, ''),
+    COALESCE(principal_mode, ''),
+    COALESCE(operation_key, ''),
+    COALESCE(entity_type_slug, ''),
+    COALESCE(field_path, ''),
+    COALESCE(entity_id, 0)
+  );

--- a/db/migrations/20260713120000_drop_write_policy_principal_mode.sql
+++ b/db/migrations/20260713120000_drop_write_policy_principal_mode.sql
@@ -86,6 +86,7 @@ neutral_after AS (
 merged AS (
   SELECT
     n.policy_id,
+    a.resource_class,
     a.action,
     a.auto_effect,
     e.effect AS neutral_effect
@@ -102,18 +103,43 @@ merged AS (
   LEFT JOIN write_policy_action_effects e
     ON e.policy_id = n.policy_id AND e.action = a.action
 ),
+-- Old runtime attended floor = COALESCE(neutral_effect, class_default). Fold
+-- autonomous against THAT, never against bare COALESCE(..., 'auto'), so an
+-- autonomous-only delete=auto cannot displace entity delete default approval
+-- (or agent_config delete default deny) into an explicit looser neutral row.
+class_default AS (
+  SELECT
+    m.*,
+    CASE
+      WHEN m.resource_class = 'entity' AND m.action = 'delete' THEN 'approval'
+      WHEN m.resource_class = 'agent_config' AND m.action IN ('create', 'update') THEN 'approval'
+      WHEN m.resource_class = 'agent_config' AND m.action = 'delete' THEN 'deny'
+      WHEN m.resource_class = 'connector_action' AND m.action = 'execute' THEN 'auto'
+      -- entity create/update/read, agent_config read, and unknown → auto
+      ELSE 'auto'
+    END AS class_default_effect
+  FROM merged m
+),
+attended AS (
+  SELECT
+    policy_id,
+    action,
+    auto_effect,
+    COALESCE(neutral_effect, class_default_effect) AS attended_effect
+  FROM class_default
+),
 -- Rank: deny=3, disabled=2, approval=1, auto=0; pick the max rank.
 picked AS (
   SELECT
     policy_id,
     action,
     CASE
-      WHEN auto_effect = 'deny' OR neutral_effect = 'deny' THEN 'deny'
-      WHEN auto_effect = 'disabled' OR neutral_effect = 'disabled' THEN 'disabled'
-      WHEN auto_effect = 'approval' OR neutral_effect = 'approval' THEN 'approval'
-      ELSE COALESCE(auto_effect, neutral_effect, 'auto')
+      WHEN auto_effect = 'deny' OR attended_effect = 'deny' THEN 'deny'
+      WHEN auto_effect = 'disabled' OR attended_effect = 'disabled' THEN 'disabled'
+      WHEN auto_effect = 'approval' OR attended_effect = 'approval' THEN 'approval'
+      ELSE COALESCE(auto_effect, attended_effect, 'auto')
     END AS effect
-  FROM merged
+  FROM attended
 )
 INSERT INTO write_policy_action_effects (policy_id, action, effect)
 SELECT policy_id, action, effect FROM picked

--- a/db/migrations/20260713140000_write_policy_target_agent_and_docs.sql
+++ b/db/migrations/20260713140000_write_policy_target_agent_and_docs.sql
@@ -1,0 +1,108 @@
+-- migrate:up
+--
+-- Clarify write_approval_policies as:
+--   WHO acts     → principal_kind / principal_id
+--                  (both NULL = org default; agent + id = that agent's envelope)
+--   WHAT class   → resource_class (entity | agent_config | connector_action)
+--   EXCEPTION    → at most one class-specific scope column:
+--                  entity_type_slug | operation_key | target_agent_id
+--   EFFECTS      → child table write_policy_action_effects (action → effect)
+--
+-- Adds target_agent_id so agent_config can exception "update/delete agent X"
+-- without opening all agent writes.
+
+ALTER TABLE write_approval_policies
+  ADD COLUMN IF NOT EXISTS target_agent_id text;
+
+COMMENT ON TABLE write_approval_policies IS
+  'Write-gate policy: org defaults (principal NULL) + per-agent envelopes + sparse exceptions. Effects live in write_policy_action_effects.';
+
+COMMENT ON COLUMN write_approval_policies.resource_class IS
+  'entity | agent_config | connector_action';
+
+COMMENT ON COLUMN write_approval_policies.principal_kind IS
+  'NULL = org default. agent | watcher = envelope for that principal kind.';
+
+COMMENT ON COLUMN write_approval_policies.principal_id IS
+  'NULL with kind set = any of that kind; set = specific agent/watcher id. Both principal columns NULL = org default.';
+
+COMMENT ON COLUMN write_approval_policies.entity_type_slug IS
+  'entity exception: type slug. NULL = all types for this principal.';
+
+COMMENT ON COLUMN write_approval_policies.operation_key IS
+  'connector_action exception: qualified connector_key::op. NULL = all write ops.';
+
+COMMENT ON COLUMN write_approval_policies.target_agent_id IS
+  'agent_config exception: agents.id being updated/deleted. NULL = any target. create always uses the blanket row.';
+
+COMMENT ON COLUMN write_approval_policies.field_path IS
+  'entity finer scope (field); not used on the agent Permissions matrix.';
+
+COMMENT ON COLUMN write_approval_policies.entity_id IS
+  'entity finer scope (single row); not used on the agent Permissions matrix.';
+
+-- Class ↔ scope consistency (specialized columns only legal on their class).
+ALTER TABLE write_approval_policies
+  DROP CONSTRAINT IF EXISTS write_approval_policies_scope_class_check;
+
+ALTER TABLE write_approval_policies
+  ADD CONSTRAINT write_approval_policies_scope_class_check CHECK (
+    (operation_key IS NULL OR resource_class = 'connector_action')
+    AND (target_agent_id IS NULL OR resource_class = 'agent_config')
+    AND (
+      (entity_type_slug IS NULL AND field_path IS NULL AND entity_id IS NULL)
+      OR resource_class = 'entity'
+    )
+  );
+
+-- Rebuild unique identity to include target_agent_id.
+DROP INDEX IF EXISTS write_approval_policies_class_principal_op_scope_key;
+DROP INDEX IF EXISTS write_approval_policies_identity;
+
+CREATE UNIQUE INDEX write_approval_policies_identity
+  ON write_approval_policies (
+    organization_id,
+    resource_class,
+    COALESCE(principal_kind, ''),
+    COALESCE(principal_id, ''),
+    COALESCE(operation_key, ''),
+    COALESCE(entity_type_slug, ''),
+    COALESCE(field_path, ''),
+    COALESCE(entity_id, 0),
+    COALESCE(target_agent_id, '')
+  );
+
+-- When the target agent is deleted, drop exceptions that named it.
+-- NULL target_agent_id rows are not checked by this FK.
+ALTER TABLE write_approval_policies
+  DROP CONSTRAINT IF EXISTS write_approval_policies_target_agent_fkey;
+
+ALTER TABLE write_approval_policies
+  ADD CONSTRAINT write_approval_policies_target_agent_fkey
+  FOREIGN KEY (organization_id, target_agent_id)
+  REFERENCES agents (organization_id, id)
+  ON DELETE CASCADE;
+
+-- migrate:down
+ALTER TABLE write_approval_policies
+  DROP CONSTRAINT IF EXISTS write_approval_policies_target_agent_fkey;
+
+ALTER TABLE write_approval_policies
+  DROP CONSTRAINT IF EXISTS write_approval_policies_scope_class_check;
+
+DROP INDEX IF EXISTS write_approval_policies_identity;
+
+CREATE UNIQUE INDEX IF NOT EXISTS write_approval_policies_class_principal_op_scope_key
+  ON write_approval_policies (
+    organization_id,
+    resource_class,
+    COALESCE(principal_kind, ''),
+    COALESCE(principal_id, ''),
+    COALESCE(operation_key, ''),
+    COALESCE(entity_type_slug, ''),
+    COALESCE(field_path, ''),
+    COALESCE(entity_id, 0)
+  );
+
+ALTER TABLE write_approval_policies
+  DROP COLUMN IF EXISTS target_agent_id;

--- a/db/migrations/20260713140000_write_policy_target_agent_and_docs.sql
+++ b/db/migrations/20260713140000_write_policy_target_agent_and_docs.sql
@@ -53,13 +53,18 @@ ALTER TABLE write_approval_policies
       (entity_type_slug IS NULL AND field_path IS NULL AND entity_id IS NULL)
       OR resource_class = 'entity'
     )
-  );
+  ) NOT VALID;
+ALTER TABLE write_approval_policies
+  VALIDATE CONSTRAINT write_approval_policies_scope_class_check;
 
 -- Rebuild unique identity to include target_agent_id.
+-- squawk-ignore require-concurrent-index-deletion -- low-row-count policy table; brief lock negligible at this scale
 DROP INDEX IF EXISTS write_approval_policies_class_principal_op_scope_key;
+-- squawk-ignore require-concurrent-index-deletion -- low-row-count policy table; brief lock negligible at this scale
 DROP INDEX IF EXISTS write_approval_policies_identity;
 
-CREATE UNIQUE INDEX write_approval_policies_identity
+-- squawk-ignore require-concurrent-index-creation,prefer-robust-stmts -- low-row-count policy table; brief lock negligible at this scale
+CREATE UNIQUE INDEX IF NOT EXISTS write_approval_policies_identity
   ON write_approval_policies (
     organization_id,
     resource_class,
@@ -77,11 +82,15 @@ CREATE UNIQUE INDEX write_approval_policies_identity
 ALTER TABLE write_approval_policies
   DROP CONSTRAINT IF EXISTS write_approval_policies_target_agent_fkey;
 
+-- squawk-ignore adding-foreign-key-constraint -- low-row-count policy table; brief scan negligible
 ALTER TABLE write_approval_policies
   ADD CONSTRAINT write_approval_policies_target_agent_fkey
   FOREIGN KEY (organization_id, target_agent_id)
   REFERENCES agents (organization_id, id)
-  ON DELETE CASCADE;
+  ON DELETE CASCADE
+  NOT VALID;
+ALTER TABLE write_approval_policies
+  VALIDATE CONSTRAINT write_approval_policies_target_agent_fkey;
 
 -- migrate:down
 ALTER TABLE write_approval_policies
@@ -90,8 +99,10 @@ ALTER TABLE write_approval_policies
 ALTER TABLE write_approval_policies
   DROP CONSTRAINT IF EXISTS write_approval_policies_scope_class_check;
 
+-- squawk-ignore require-concurrent-index-deletion -- rollback path; brief lock negligible at this scale
 DROP INDEX IF EXISTS write_approval_policies_identity;
 
+-- squawk-ignore require-concurrent-index-creation -- rollback path; low row count
 CREATE UNIQUE INDEX IF NOT EXISTS write_approval_policies_class_principal_op_scope_key
   ON write_approval_policies (
     organization_id,

--- a/db/migrations/20260713150000_write_policy_entity_read.sql
+++ b/db/migrations/20260713150000_write_policy_entity_read.sql
@@ -1,0 +1,24 @@
+-- migrate:up
+--
+-- Allow entity `read` as a first-class write-policy action so an agent's
+-- envelope (and the org floor) can say which entity types that principal may
+-- read. Default remains auto (no row = unrestricted within the org) — same as
+-- today's manage_entity get/list behavior for agents.
+
+ALTER TABLE write_policy_action_effects
+  DROP CONSTRAINT IF EXISTS write_policy_action_effects_action_check;
+
+ALTER TABLE write_policy_action_effects
+  ADD CONSTRAINT write_policy_action_effects_action_check
+  CHECK (action IN ('create', 'update', 'delete', 'execute', 'read'));
+
+-- migrate:down
+ALTER TABLE write_policy_action_effects
+  DROP CONSTRAINT IF EXISTS write_policy_action_effects_action_check;
+
+-- Drop any entity read rows before re-tightening the CHECK.
+DELETE FROM write_policy_action_effects WHERE action = 'read';
+
+ALTER TABLE write_policy_action_effects
+  ADD CONSTRAINT write_policy_action_effects_action_check
+  CHECK (action IN ('create', 'update', 'delete', 'execute'));

--- a/db/migrations/20260713150000_write_policy_entity_read.sql
+++ b/db/migrations/20260713150000_write_policy_entity_read.sql
@@ -10,7 +10,9 @@ ALTER TABLE write_policy_action_effects
 
 ALTER TABLE write_policy_action_effects
   ADD CONSTRAINT write_policy_action_effects_action_check
-  CHECK (action IN ('create', 'update', 'delete', 'execute', 'read'));
+  CHECK (action IN ('create', 'update', 'delete', 'execute', 'read')) NOT VALID;
+ALTER TABLE write_policy_action_effects
+  VALIDATE CONSTRAINT write_policy_action_effects_action_check;
 
 -- migrate:down
 ALTER TABLE write_policy_action_effects
@@ -21,4 +23,6 @@ DELETE FROM write_policy_action_effects WHERE action = 'read';
 
 ALTER TABLE write_policy_action_effects
   ADD CONSTRAINT write_policy_action_effects_action_check
-  CHECK (action IN ('create', 'update', 'delete', 'execute'));
+  CHECK (action IN ('create', 'update', 'delete', 'execute')) NOT VALID;
+ALTER TABLE write_policy_action_effects
+  VALIDATE CONSTRAINT write_policy_action_effects_action_check;

--- a/packages/server/src/__tests__/integration/authz/write-policy-action-effect-parity.test.ts
+++ b/packages/server/src/__tests__/integration/authz/write-policy-action-effect-parity.test.ts
@@ -290,18 +290,6 @@ describe("write-policy action/effect decision parity", () => {
 		expect(slugPresentInvalid(null)).toBe(false);
 	});
 
-	it("the DELETE principal_mode guard rejects a PRESENT non-'autonomous' value, null only when ABSENT (codex-14)", () => {
-		// A query param `?principal_mode=` (empty) must NOT map to null and delete the
-		// attended/both-mode row — only a genuinely absent param maps to null.
-		const rejects = (param: string | undefined) =>
-			param !== undefined && param.trim() !== "autonomous";
-		expect(rejects(undefined)).toBe(false); // absent → null (both-mode)
-		expect(rejects("autonomous")).toBe(false);
-		expect(rejects("")).toBe(true); // present empty → 400
-		expect(rejects("  ")).toBe(true); // whitespace → 400
-		expect(rejects("attended")).toBe(true); // typo → 400
-	});
-
 	it("a type scope is rejected for non-entity classes; only entity is type-scoped (codex-13)", () => {
 		// A present entity_type_slug on agent_config/connector_action must 400, not
 		// coerce to null and overwrite the class's blanket policy.

--- a/packages/server/src/__tests__/integration/authz/write-policy-floor-and-mode.test.ts
+++ b/packages/server/src/__tests__/integration/authz/write-policy-floor-and-mode.test.ts
@@ -224,6 +224,48 @@ describe("write-gate floor + single-envelope semantics", () => {
 		).toBe("allow");
 	});
 
+	it("agent_config read: default auto; per-target deny blocks that agent only", async () => {
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: orgId,
+				resourceClass: "agent_config",
+				principalKind: "agent",
+				principalId: "agent-1",
+				action: "read",
+				targetAgentId: "agent-auto",
+			}),
+		).toBe("allow");
+		await seedPolicy({
+			orgId,
+			resourceClass: "agent_config",
+			principalKind: "agent",
+			principalId: "agent-1",
+			targetAgentId: "agent-auto",
+			effects: [{ action: "read", effect: "deny" }],
+		});
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: orgId,
+				resourceClass: "agent_config",
+				principalKind: "agent",
+				principalId: "agent-1",
+				action: "read",
+				targetAgentId: "agent-auto",
+			}),
+		).toBe("deny");
+		// Other targets still auto.
+		expect(
+			await resolveWritePolicyDecision({
+				organizationId: orgId,
+				resourceClass: "agent_config",
+				principalKind: "agent",
+				principalId: "agent-1",
+				action: "read",
+				targetAgentId: "agent-deliv",
+			}),
+		).toBe("allow");
+	});
+
 	it("per-type override tightens only its type; other types follow the agent default", async () => {
 		// Agent default: delete auto. Per-type override for `trip`: delete deny.
 		await seedPolicy({

--- a/packages/server/src/__tests__/integration/authz/write-policy-floor-and-mode.test.ts
+++ b/packages/server/src/__tests__/integration/authz/write-policy-floor-and-mode.test.ts
@@ -1,15 +1,12 @@
 /**
- * Real-PG tests for the write-gate v1.1 agent-envelope semantics (PR2):
+ * Real-PG tests for write-gate floor + single-envelope semantics:
  *
  *  - ORG FLOOR is a hard floor: a per-agent row can never LOOSEN a broader
  *    any-principal (org) row. The strictest matched effect wins.
  *  - The class default is a STARTING POINT, not a floor: an explicit row may
  *    loosen the default (agent_config update = auto → allow).
- *  - AUTONOMOUS ≥ ATTENDED: an autonomous-only row (principal_mode='autonomous')
- *    can only tighten the attended decision, never loosen it.
- *
- * These encode the three gaps Fable flagged; each asserts the fixed behavior
- * against a migrated database so a regression in the fold is caught here.
+ *  - One envelope for chat and watchers (principal_mode dropped): watchers
+ *    inherit the owning agent's envelope via ownerAgentId.
  */
 
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
@@ -31,22 +28,23 @@ async function seedPolicy(args: {
 	resourceClass: string;
 	principalKind?: string | null;
 	principalId?: string | null;
-	principalMode?: string | null;
 	entityTypeSlug?: string | null;
 	fieldPath?: string | null;
 	entityId?: number | null;
+	operationKey?: string | null;
+	targetAgentId?: string | null;
 	effects: Array<{ action: string; effect: string }>;
 }): Promise<number> {
 	const sql = getTestDb();
 	const rows = await sql<{ id: number }>`
     INSERT INTO write_approval_policies
       (organization_id, resource_class, principal_kind, principal_id,
-       principal_mode, entity_type_slug, field_path, entity_id)
+       operation_key, target_agent_id, entity_type_slug, field_path, entity_id)
     VALUES
       (${args.orgId}, ${args.resourceClass}, ${args.principalKind ?? null},
-       ${args.principalId ?? null}, ${args.principalMode ?? null},
-       ${args.entityTypeSlug ?? null}, ${args.fieldPath ?? null},
-       ${args.entityId ?? null})
+       ${args.principalId ?? null}, ${args.operationKey ?? null},
+       ${args.targetAgentId ?? null}, ${args.entityTypeSlug ?? null},
+       ${args.fieldPath ?? null}, ${args.entityId ?? null})
     RETURNING id
   `;
 	const id = Number(rows[0].id);
@@ -59,7 +57,7 @@ async function seedPolicy(args: {
 	return id;
 }
 
-describe("write-gate v1.1 floor + mode semantics", () => {
+describe("write-gate floor + single-envelope semantics", () => {
 	afterAll(async () => {
 		await cleanupTestDatabase();
 	});
@@ -156,24 +154,14 @@ describe("write-gate v1.1 floor + mode semantics", () => {
 		).toBe("require_approval");
 	});
 
-	it("autonomous ≥ attended: an autonomous-only deny tightens, attended stays auto", async () => {
-		// A both-mode row makes delete auto; an autonomous-only row makes it deny.
+	it("chat and watcher share one envelope: same agent policy binds both modes", async () => {
 		await seedPolicy({
 			orgId,
 			resourceClass: "entity",
 			principalKind: "agent",
 			principalId: "agent-1",
-			effects: [{ action: "delete", effect: "auto" }],
-		});
-		await seedPolicy({
-			orgId,
-			resourceClass: "entity",
-			principalKind: "agent",
-			principalId: "agent-1",
-			principalMode: "autonomous",
 			effects: [{ action: "delete", effect: "deny" }],
 		});
-		// Attended: the autonomous-only row does not apply → auto.
 		expect(
 			await evaluateEntityMutation({
 				organizationId: orgId,
@@ -183,8 +171,7 @@ describe("write-gate v1.1 floor + mode semantics", () => {
 				entityTypeSlug: "task",
 				mode: "attended",
 			}),
-		).toBe("allow");
-		// Autonomous (watcher): the autonomous-only deny binds → deny.
+		).toBe("deny");
 		expect(
 			await evaluateEntityMutation({
 				organizationId: orgId,
@@ -197,79 +184,44 @@ describe("write-gate v1.1 floor + mode semantics", () => {
 		).toBe("deny");
 	});
 
-	it("autonomous cannot loosen attended: an autonomous 'auto' can't undo an attended 'approval'", async () => {
-		// Attended row: update approval. Autonomous-only row tries to set auto.
-		await seedPolicy({
-			orgId,
-			resourceClass: "entity",
-			principalKind: "agent",
-			principalId: "agent-1",
-			effects: [{ action: "update", effect: "approval" }],
-		});
-		await seedPolicy({
-			orgId,
-			resourceClass: "entity",
-			principalKind: "agent",
-			principalId: "agent-1",
-			principalMode: "autonomous",
-			effects: [{ action: "update", effect: "auto" }],
-		});
-		// Autonomous folds the attended decision (approval) as its floor → the
-		// autonomous 'auto' is a no-op; the write still needs approval.
+	it("entity read: default auto; per-type deny blocks that type only", async () => {
+		// No row → class default read=auto.
 		expect(
 			await evaluateEntityMutation({
 				organizationId: orgId,
 				principalKind: "agent",
 				principalId: "agent-1",
-				action: "update",
+				action: "read",
 				entityTypeSlug: "task",
-				entityId: 123,
-				mode: "autonomous",
-			}),
-		).toBe("require_approval");
-	});
-
-	it("a sparse autonomous row abstains on actions it does not name", async () => {
-		// Attended: create=auto. An autonomous-only row names ONLY delete=deny.
-		// create must stay auto in autonomous mode — the sparse autonomous row must
-		// NOT pull create toward the class default.
-		await seedPolicy({
-			orgId,
-			resourceClass: "entity",
-			principalKind: "agent",
-			principalId: "agent-1",
-			effects: [{ action: "create", effect: "auto" }],
-		});
-		await seedPolicy({
-			orgId,
-			resourceClass: "entity",
-			principalKind: "agent",
-			principalId: "agent-1",
-			principalMode: "autonomous",
-			effects: [{ action: "delete", effect: "deny" }],
-		});
-		// autonomous create: the autonomous row abstains → inherits attended auto.
-		expect(
-			await evaluateEntityMutation({
-				organizationId: orgId,
-				principalKind: "agent",
-				principalId: "agent-1",
-				action: "create",
-				entityTypeSlug: "task",
-				mode: "autonomous",
 			}),
 		).toBe("allow");
-		// autonomous delete: the autonomous row names it → deny.
+		await seedPolicy({
+			orgId,
+			resourceClass: "entity",
+			principalKind: "agent",
+			principalId: "agent-1",
+			entityTypeSlug: "secret",
+			effects: [{ action: "read", effect: "deny" }],
+		});
 		expect(
 			await evaluateEntityMutation({
 				organizationId: orgId,
 				principalKind: "agent",
 				principalId: "agent-1",
-				action: "delete",
-				entityTypeSlug: "task",
-				mode: "autonomous",
+				action: "read",
+				entityTypeSlug: "secret",
 			}),
 		).toBe("deny");
+		// Other types still auto.
+		expect(
+			await evaluateEntityMutation({
+				organizationId: orgId,
+				principalKind: "agent",
+				principalId: "agent-1",
+				action: "read",
+				entityTypeSlug: "task",
+			}),
+		).toBe("allow");
 	});
 
 	it("per-type override tightens only its type; other types follow the agent default", async () => {
@@ -402,14 +354,12 @@ describe("write-gate v1.1 floor + mode semantics", () => {
 	});
 
 	it("a sparse effects input persists ONLY the named actions (untouched stay abstaining)", async () => {
-		// An autonomous {delete: deny} override must NOT also pin create/update — a
-		// stored row for those would stop them inheriting later attended/blanket
-		// changes. The write path mirrors the resolver's sparse-row semantics.
+		// A sparse {delete: deny} override must NOT also pin create/update — a
+		// stored row for those would stop them inheriting later blanket changes.
 		await upsertEntityApprovalPolicy(orgId, {
 			resourceClass: "entity",
 			principalKind: "agent",
 			principalId: "agent-1",
-			principalMode: "autonomous",
 			effects: { delete: "deny" },
 		});
 		const rows = await listEntityApprovalPolicies(orgId);
@@ -417,7 +367,7 @@ describe("write-gate v1.1 floor + mode semantics", () => {
 			(r) =>
 				r.principalKind === "agent" &&
 				r.principalId === "agent-1" &&
-				r.principalMode === "autonomous",
+				r.entityTypeSlug === null,
 		);
 		expect(stored).toBeTruthy();
 		// Exactly one child effect row — create/update absent (abstaining).
@@ -459,40 +409,6 @@ describe("write-gate v1.1 floor + mode semantics", () => {
 			action: "execute",
 		});
 		expect(effect).toBe("deny");
-	});
-
-	it("the legacy org-settings list hides autonomous-only rows (codex-8)", async () => {
-		// The new agent UI can create an autonomous-only entity row for an agent. The
-		// legacy mode-blind org-settings endpoint must NOT surface it (its DELETE keys
-		// by scope without principal_mode → would hit the wrong row).
-		await upsertEntityApprovalPolicy(orgId, {
-			resourceClass: "entity",
-			principalKind: "agent",
-			principalId: "agent-auto",
-			principalMode: "autonomous",
-			entityTypeSlug: "task",
-			effects: { delete: "deny" },
-		});
-		await upsertEntityApprovalPolicy(orgId, {
-			resourceClass: "entity",
-			principalKind: "agent",
-			principalId: "agent-auto",
-			entityTypeSlug: "task",
-			effects: { delete: "approval" },
-		});
-		// Mirror the endpoint's filter: only principal_mode NULL rows are shown.
-		const shown = (await listEntityApprovalPolicies(orgId, "entity")).filter(
-			(p) => p.principalMode === null,
-		);
-		const autoRows = shown.filter((p) => p.principalMode === "autonomous");
-		expect(autoRows).toHaveLength(0);
-		// The both-mode row for the same scope IS still shown.
-		expect(
-			shown.some(
-				(p) =>
-					p.principalId === "agent-auto" && p.entityTypeSlug === "task",
-			),
-		).toBe(true);
 	});
 
 	it("preserveDelivery keeps a stored approval target across an effect-only update (codex-7)", async () => {

--- a/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-agents-e2e.test.ts
@@ -603,6 +603,62 @@ describe("manage_agents — builder gate e2e", () => {
 		expect(row?.is_system_agent).toBe(true);
 	});
 
+	it("agent principal: agent_config read deny filters list and blocks get", async () => {
+		const sql = getTestDb();
+		await executeTool(
+			"manage_agents",
+			{ action: "create", agent_id: "visible-bot", name: "Visible" },
+			TEST_ENV,
+			ownerCtx,
+		);
+		await executeTool(
+			"manage_agents",
+			{ action: "create", agent_id: "hidden-bot", name: "Hidden" },
+			TEST_ENV,
+			ownerCtx,
+		);
+
+		// Blacklist hidden-bot for builder-agent (default read stays auto).
+		const policyRows = await sql<{ id: number }>`
+			INSERT INTO write_approval_policies
+				(organization_id, resource_class, principal_kind, principal_id, target_agent_id)
+			VALUES
+				(${orgId}, 'agent_config', 'agent', 'builder-agent', 'hidden-bot')
+			RETURNING id
+		`;
+		await sql`
+			INSERT INTO write_policy_action_effects (policy_id, action, effect)
+			VALUES (${policyRows[0].id}, 'read', 'deny')
+		`;
+
+		const list = (await executeTool(
+			"manage_agents",
+			{ action: "list" },
+			TEST_ENV,
+			agentCtx,
+		)) as { agents: Array<{ id: string }> };
+		const ids = list.agents.map((a) => a.id);
+		expect(ids).toContain("visible-bot");
+		expect(ids).not.toContain("hidden-bot");
+
+		await expect(
+			executeTool(
+				"manage_agents",
+				{ action: "get", agent_id: "hidden-bot" },
+				TEST_ENV,
+				agentCtx,
+			),
+		).rejects.toThrow(/Policy denies reading agent/);
+
+		const got = (await executeTool(
+			"manage_agents",
+			{ action: "get", agent_id: "visible-bot" },
+			TEST_ENV,
+			agentCtx,
+		)) as { agent?: { id: string } };
+		expect(got.agent?.id).toBe("visible-bot");
+	});
+
 	it("a non-admin member cannot call admin-tier write actions", async () => {
 		await expect(
 			executeTool(

--- a/packages/server/src/__tests__/unit/entity-policy.test.ts
+++ b/packages/server/src/__tests__/unit/entity-policy.test.ts
@@ -13,9 +13,10 @@ type PolicyRowSeed = {
 	resource_class?: string;
 	principal_kind?: string | null;
 	principal_id?: string | null;
-	principal_mode?: string | null;
 	/** connector_action per-operation scope; null = the blanket execute row. */
 	operation_key?: string | null;
+	/** agent_config exception target; null = any target. */
+	target_agent_id?: string | null;
 	entity_type_slug?: string | null;
 	field_path?: string | null;
 	entity_id?: number | null;
@@ -59,8 +60,8 @@ function stubSql(seeds: PolicyRowSeed[]): DbClient {
 		resource_class: seed.resource_class ?? "entity",
 		principal_kind: seed.principal_kind ?? null,
 		principal_id: seed.principal_id ?? null,
-		principal_mode: seed.principal_mode ?? null,
 		operation_key: seed.operation_key ?? null,
+		target_agent_id: seed.target_agent_id ?? null,
 		entity_type_slug: seed.entity_type_slug ?? null,
 		field_path: seed.field_path ?? null,
 		entity_id: seed.entity_id ?? null,
@@ -89,10 +90,8 @@ function stubSql(seeds: PolicyRowSeed[]): DbClient {
 			return Promise.resolve(childRows.filter((r) => ids.has(Number(r.policy_id))));
 		}
 		// Param order mirrors loadCandidatePolicies' WHERE: org, resourceClass,
-		// then the principal OR-block (principalKind, principalId, then ownerAgentId
-		// interpolated TWICE — once for `::text IS NOT NULL`, once for the `=`
-		// comparison), then the scope filters (operationKey, entityTypeSlug, entityId).
-		// ownerAgentId folds an 'agent' row for a watcher acting under its agent.
+		// principalKind, principalId, ownerAgentId×2, operationKey, targetAgentId,
+		// entityTypeSlug, entityId.
 		const [
 			org,
 			resourceClass,
@@ -101,11 +100,13 @@ function stubSql(seeds: PolicyRowSeed[]): DbClient {
 			ownerAgentId,
 			,
 			operationKey,
+			targetAgentId,
 			entityTypeSlug,
 			entityId,
 		] = params as [
 			string,
 			string,
+			string | null,
 			string | null,
 			string | null,
 			string | null,
@@ -129,6 +130,8 @@ function stubSql(seeds: PolicyRowSeed[]): DbClient {
 								row.principal_id === ownerAgentId))) &&
 					(row.operation_key === null ||
 						row.operation_key === operationKey) &&
+					(row.target_agent_id === null ||
+						row.target_agent_id === targetAgentId) &&
 					(row.entity_type_slug === null ||
 						row.entity_type_slug === entityTypeSlug) &&
 					(row.entity_id === null || row.entity_id === entityId),

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -866,10 +866,8 @@ export async function resolveWritePolicyDecision(args: {
 	ownerResolved?: boolean;
 	action: WriteAction;
 	/**
-	 * Whether the principal is acting attended (a human is driving the agent) or
-	 * autonomously (a watcher / scheduled run). Autonomous folds the attended
-	 * decision as its floor, then tightens with any autonomous-only override — a
-	 * watcher can never be more permissive than the same agent acting live.
+	 * Attribution / SSE labeling only. Write-policy fold is a single envelope
+	 * (principal_mode dropped) — `mode` does not change the decision.
 	 */
 	mode?: PrincipalMode;
 	/** connector_action only: the operation being run — a per-op row tightens the
@@ -879,7 +877,10 @@ export async function resolveWritePolicyDecision(args: {
 	targetAgentId?: string | null;
 	sql?: DbClient;
 }): Promise<EntityPolicyDecision> {
-	return modeToDecision(await resolveWriteEffect(args));
+	const decision = modeToDecision(await resolveWriteEffect(args));
+	// Reads cannot usefully queue approval; treat like entity evaluateEntityMutation.
+	if (args.action === "read" && decision === "require_approval") return "deny";
+	return decision;
 }
 
 /**
@@ -902,6 +903,7 @@ export async function resolveWriteEffect(args: {
 	 */
 	ownerResolved?: boolean;
 	action: WriteAction;
+	/** Attribution only — ignored by the single-envelope fold. */
 	mode?: PrincipalMode;
 	/** connector_action only: the operation being run (e.g. 'slack.send_message').
 	 * A row scoped to this op tightens the blanket execute rule for it alone. */

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -43,9 +43,10 @@ export type EntityMutationMode = "auto" | "approval" | "deny" | "disabled";
 
 /**
  * Which class of write a policy row governs. `entity` is the original class;
- * `agent_config` gates manage_agents create/update/delete; `connector_action`
- * gates connector operation execution. All three share this table + resolver so a
- * new class is a value, not a schema change (see docs/plans/write-gate-generalization.md).
+ * `agent_config` gates manage_agents read/list/get + create/update/delete;
+ * `connector_action` gates connector operation execution. All three share this
+ * table + resolver so a new class is a value, not a schema change (see
+ * docs/plans/write-gate-generalization.md).
  */
 export type WriteResourceClass = "entity" | "agent_config" | "connector_action";
 
@@ -512,12 +513,14 @@ function scopeSpecificity(row: EntityApprovalPolicyRow): number {
 	return (
 		(row.entity_id !== null ? 4 : 0) +
 		(row.field_path !== null ? 2 : 0) +
-		// operation_key (connector_action) and entity_type_slug (entity) are mutually
-		// exclusive scope dimensions on disjoint classes; both are the class's finest
-		// non-instance scope, so they share weight 1. A row with either set outranks
-		// the blanket row for its class.
+		// operation_key (connector_action), entity_type_slug (entity), and
+		// target_agent_id (agent_config) are mutually exclusive scope dimensions on
+		// disjoint classes; each is that class's finest non-instance scope, so they
+		// share weight 1. A row with any set outranks the blanket row for delivery
+		// target ordering (decision fold is still max-restrictive).
 		(row.entity_type_slug !== null ? 1 : 0) +
-		(row.operation_key !== null ? 1 : 0)
+		(row.operation_key !== null ? 1 : 0) +
+		(row.target_agent_id !== null ? 1 : 0)
 	);
 }
 
@@ -872,7 +875,7 @@ export async function resolveWritePolicyDecision(args: {
 	/** connector_action only: the operation being run — a per-op row tightens the
 	 * blanket execute rule for it alone. Forwarded to {@link resolveWriteEffect}. */
 	operationKey?: string | null;
-	/** agent_config only: target agent id for update/delete. */
+	/** agent_config only: target agent id for read/update/delete. */
 	targetAgentId?: string | null;
 	sql?: DbClient;
 }): Promise<EntityPolicyDecision> {
@@ -903,7 +906,7 @@ export async function resolveWriteEffect(args: {
 	/** connector_action only: the operation being run (e.g. 'slack.send_message').
 	 * A row scoped to this op tightens the blanket execute rule for it alone. */
 	operationKey?: string | null;
-	/** agent_config only: target agent id for update/delete. */
+	/** agent_config only: target agent id for read/update/delete. */
 	targetAgentId?: string | null;
 	sql?: DbClient;
 }): Promise<EntityMutationMode> {

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -53,47 +53,22 @@ export type WriteResourceClass = "entity" | "agent_config" | "connector_action";
 export type PolicyPrincipalKind = "agent" | "watcher";
 
 /**
- * How the principal is acting. `attended` — a human is driving (chat, tool call).
- * `autonomous` — a scheduled/watcher run with no human in the loop. A policy row
- * scoped to `autonomous` (principal_mode='autonomous') applies only to
- * autonomous runs; a row with NULL principal_mode applies to BOTH. Autonomous is
- * always evaluated as at-least-as-strict as attended (attended is its floor), so
- * a watcher can never out-permission the same agent acting live.
+ * Headless vs interactive run label for SSE-owner gating and run attribution.
+ * NOT used by write-policy fold (one envelope for all agent runs).
+ * Keep in lockstep with HEADLESS_SOURCES in unified-thread-consumer.ts.
  */
 export type PrincipalMode = "attended" | "autonomous";
 
-/**
- * Worker-token `source` values that mark a run as AUTONOMOUS — a server-dispatched
- * turn with NO human in the loop. Any run whose `sourceContext.source` is one of
- * these evaluates its write-gate decisions in autonomous mode (so an agent's
- * autonomous-only tighter rules bind). Everything else — an interactive turn
- * (`direct-api`, a slack/telegram/web platform turn), a user session — is attended.
- *
- * This MUST stay in lockstep with `HEADLESS_SOURCES` in
- * gateway/platform/unified-thread-consumer.ts: every source that bypasses the
- * SSE-owner gate there is a no-human dispatch and so must be governed
- * autonomously here. Adding a source to one without the other is a bug — a new
- * headless dispatch would otherwise be evaluated as attended and skip an agent's
- * autonomous-only restrictions. Producers of these claims:
- *   - `watcher-run`      gateway/routes/public/agent.ts (session.intent=watcher_run)
- *   - `scheduled-job`    scheduled/jobs.ts (a scheduled agent wake)
- *   - `connector-repair` connectors/repair-agent.ts (auto-fixing a broken connector)
- *   - `internal`         gateway/services/agent-threads.ts (server-dispatched default)
- * An unknown source falls to attended (never LOOSER than autonomous, per the
- * resolver's floor), so the failure mode of a missed source is over-, not
- * under-, restriction for the interactive path — but under-restriction for the
- * headless path, which is why the two sets must not drift.
- */
-const AUTONOMOUS_SOURCES: ReadonlySet<string> = new Set([
-	"watcher-run", // a watcher-dispatched agent turn (agent.ts intent=watcher_run)
-	"scheduled-job", // a scheduled agent wake (scheduled/jobs.ts)
-	"connector-repair", // a repair agent auto-fixing a connector (repair-agent.ts)
-	"internal", // server-dispatched default turn (agent-threads.ts)
+const HEADLESS_RUN_SOURCES: ReadonlySet<string> = new Set([
+	"watcher-run",
+	"scheduled-job",
+	"connector-repair",
+	"internal",
 ]);
 
-/** The acting mode implied by a run's `source` (see {@link AUTONOMOUS_SOURCES}). */
+/** Whether a worker-token source is a headless (no interactive user) dispatch. */
 export function modeForSource(source: string | null | undefined): PrincipalMode {
-	return source != null && AUTONOMOUS_SOURCES.has(source)
+	return source != null && HEADLESS_RUN_SOURCES.has(source)
 		? "autonomous"
 		: "attended";
 }
@@ -112,8 +87,6 @@ export interface EntityApprovalPolicy {
 	/** Non-human principal this row targets; NULL = any principal of its kind. */
 	principalKind: PolicyPrincipalKind | null;
 	principalId: string | null;
-	/** 'autonomous' = watcher-only override; NULL = applies to both acting modes. */
-	principalMode: PrincipalMode | null;
 	/** Connector operation this row scopes to (connector_action only); NULL = the
 	 * blanket row governing every operation. */
 	operationKey: string | null;
@@ -137,8 +110,6 @@ export interface EntityApprovalPolicyInput {
 	resourceClass?: WriteResourceClass;
 	principalKind?: PolicyPrincipalKind | null;
 	principalId?: string | null;
-	/** 'autonomous' scopes this row to watcher runs only; null = both modes. */
-	principalMode?: PrincipalMode | null;
 	/** Scopes a connector_action row to one operation (e.g. 'slack.send_message');
 	 * null = the blanket row for every operation. */
 	operationKey?: string | null;
@@ -184,8 +155,6 @@ type EntityApprovalPolicyRow = {
 	resource_class: string;
 	principal_kind: string | null;
 	principal_id: string | null;
-	/** 'autonomous' = watcher-only override; NULL = applies to both modes. */
-	principal_mode: string | null;
 	/** Connector operation this row scopes to (e.g. 'slack.send_message'); NULL =
 	 * the blanket row governing every operation. Only set for connector_action. */
 	operation_key: string | null;
@@ -240,12 +209,6 @@ function normalizePrincipalKind(value: unknown): PolicyPrincipalKind | null {
 	return value === "agent" || value === "watcher" ? value : null;
 }
 
-/** Stored principal_mode → typed. Only 'autonomous' is a scoping value; anything
- * else (including NULL/'attended') means "applies to both modes". */
-function normalizePrincipalMode(value: unknown): PrincipalMode | null {
-	return value === "autonomous" ? "autonomous" : null;
-}
-
 /**
  * The stored effect a policy attaches to `action`, or the class default if the
  * policy declares no row for that action. A policy is a SPARSE override: a scope
@@ -270,7 +233,6 @@ function rowToPolicy(row: EntityApprovalPolicyRow): EntityApprovalPolicy {
 		resourceClass,
 		principalKind: normalizePrincipalKind(row.principal_kind),
 		principalId: row.principal_id,
-		principalMode: normalizePrincipalMode(row.principal_mode),
 		operationKey: row.operation_key,
 		entityTypeSlug: row.entity_type_slug,
 		fieldPath: row.field_path,
@@ -297,7 +259,6 @@ export function defaultEntityApprovalPolicy(
 		resourceClass: "entity",
 		principalKind: null,
 		principalId: null,
-		principalMode: null,
 		operationKey: null,
 		entityTypeSlug: null,
 		fieldPath: null,
@@ -626,43 +587,10 @@ function foldEffectForAction(
 	return folded ?? defaultEffectFor(resourceClass, action);
 }
 
-/** True when a candidate row applies to autonomous runs only (not attended). */
-function isAutonomousOnlyRow(row: EntityApprovalPolicyRow): boolean {
-	return row.principal_mode === "autonomous";
-}
-
-/**
- * The effective effect for one action AT a given acting mode, layering the
- * attended/autonomous relationship on top of the max-restrictive fold.
- *
- *  - `attended`: fold over rows that apply to attended runs (principal_mode
- *    NULL — "both modes"). Autonomous-only rows are ignored.
- *  - `autonomous`: the ATTENDED result is the floor (a watcher can never be more
- *    permissive than the same agent acting live), then tightened by any
- *    autonomous-only override. So autonomous ≥ attended always holds structurally
- *    — an autonomous-only row that tried to LOOSEN is a no-op because we fold
- *    max-restrictive against the attended floor.
- */
-function foldEffectWithMode(
-	candidates: EntityApprovalPolicyRow[],
-	resourceClass: WriteResourceClass,
-	action: WriteAction,
-	mode: PrincipalMode,
-): EntityMutationMode {
-	const attendedRows = candidates.filter((r) => !isAutonomousOnlyRow(r));
-	const attended = foldEffectForAction(attendedRows, resourceClass, action);
-	if (mode === "attended") return attended;
-	// Autonomous: attended is the floor; autonomous-only overrides can only tighten.
-	// A sparse autonomous row that does NOT name this action ABSTAINS (same rule as
-	// foldEffectForAction) — it must not pull the action toward its class default,
-	// which would tighten an action the admin never touched autonomously.
-	let effect = attended;
-	for (const row of candidates.filter(isAutonomousOnlyRow)) {
-		const stored = row.effects[action];
-		if (stored === undefined) continue; // row abstains on this action
-		effect = moreRestrictive(effect, stored);
-	}
-	return effect;
+/** Effective effect for one action (single envelope for all agent runs). */
+function foldEffectForDecision(
+	candidates: EntityApprovalPolicyRow[], resourceClass: WriteResourceClass, action: WriteAction): EntityMutationMode {
+	return foldEffectForAction(candidates, resourceClass, action);
 }
 
 /**
@@ -774,7 +702,7 @@ async function loadCandidatePolicies(args: {
 	const ownerAgentId = args.ownerAgentId ?? null;
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
-       principal_mode, operation_key, entity_type_slug, field_path, entity_id,
+       operation_key, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM write_approval_policies
@@ -895,7 +823,7 @@ export async function evaluateEntityMutation(args: {
 	// the attended/autonomous relationship.
 	const forEntity = candidates.filter((row) => row.field_path === null);
 	return modeToDecision(
-		foldEffectWithMode(forEntity, "entity", args.action, args.mode ?? "attended"),
+		foldEffectForDecision(forEntity, "entity", args.action),
 	);
 }
 
@@ -976,12 +904,8 @@ export async function resolveWriteEffect(args: {
 		operationKey: args.operationKey ?? null,
 		sql: args.sql,
 	});
-	return foldEffectWithMode(
-		candidates,
-		args.resourceClass,
-		args.action,
-		args.mode ?? "attended",
-	);
+	return foldEffectForDecision(
+		candidates, args.resourceClass, args.action);
 }
 
 /**
@@ -1029,7 +953,6 @@ export async function evaluateEntityFieldUpdates(args: {
 		principalId: args.principalId ?? null,
 		ownerAgentId: args.ownerAgentId ?? null,
 	});
-	const mode = args.mode ?? "attended";
 	for (const [field, owner] of Object.entries(args.fields)) {
 		// Fold max-restrictive over every candidate that applies to THIS field
 		// (its own field_path row, plus all field-agnostic rows). The org floor
@@ -1038,7 +961,7 @@ export async function evaluateEntityFieldUpdates(args: {
 			(row) => row.field_path === null || row.field_path === field,
 		);
 		const policyDecision = modeToDecision(
-			foldEffectWithMode(forField, "entity", "update", mode),
+			foldEffectForDecision(forField, "entity", "update"),
 		);
 		// A human-owned field always needs approval regardless of policy mode; a
 		// deny/disabled policy stops even a human-owned change (deny is a hard floor).
@@ -1058,7 +981,7 @@ export async function getGlobalEntityApprovalPolicy(
 	const sql = getDb();
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
-       principal_mode, operation_key, entity_type_slug, field_path, entity_id,
+       operation_key, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM write_approval_policies
@@ -1086,7 +1009,7 @@ export async function listEntityApprovalPolicies(
 	const sql = getDb();
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
-       principal_mode, operation_key, entity_type_slug, field_path, entity_id,
+       operation_key, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM write_approval_policies
@@ -1190,10 +1113,6 @@ export async function upsertEntityApprovalPolicy(
 	const principalKind = normalizePrincipalKind(input.principalKind);
 	// A principal id is only meaningful with a kind; ignore it otherwise.
 	const principalId = principalKind ? input.principalId?.trim() || null : null;
-	// A mode scoping is only meaningful for a principal-targeted row.
-	const principalMode = principalKind
-		? normalizePrincipalMode(input.principalMode)
-		: null;
 	// operation_key scopes a connector_action row to one operation; meaningless (and
 	// dropped) for any other class so an entity/agent_config row can't smuggle one in.
 	const operationKey =
@@ -1237,13 +1156,12 @@ export async function upsertEntityApprovalPolicy(
         AND resource_class = ${resourceClass}
         AND principal_kind IS NOT DISTINCT FROM ${principalKind}
         AND principal_id IS NOT DISTINCT FROM ${principalId}
-        AND principal_mode IS NOT DISTINCT FROM ${principalMode}
         AND operation_key IS NOT DISTINCT FROM ${operationKey}
         AND entity_type_slug IS NOT DISTINCT FROM ${entityTypeSlug}
         AND field_path IS NOT DISTINCT FROM ${fieldPath}
         AND entity_id IS NOT DISTINCT FROM ${entityId}
       RETURNING id, organization_id, resource_class, principal_kind, principal_id,
-       principal_mode, operation_key, entity_type_slug, field_path, entity_id,
+       operation_key, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     `;
@@ -1255,19 +1173,19 @@ export async function upsertEntityApprovalPolicy(
 			const inserted = await tx<EntityApprovalPolicyRow>`
       INSERT INTO write_approval_policies (
         organization_id, resource_class, principal_kind, principal_id,
-        principal_mode, operation_key, entity_type_slug, field_path, entity_id,
+        operation_key, entity_type_slug, field_path, entity_id,
         approval_connection_id, approval_channel_id, approval_team_id,
         approval_channel_name, created_at, updated_at
       ) VALUES (
         ${organizationId}, ${resourceClass}, ${principalKind}, ${principalId},
-        ${principalMode}, ${operationKey}, ${entityTypeSlug}, ${fieldPath}, ${entityId},
+        ${operationKey}, ${entityTypeSlug}, ${fieldPath}, ${entityId},
         ${approvalConnectionId},
         ${approvalChannelId}, ${approvalTeamId}, ${approvalChannelName},
         now(), now()
       )
       ON CONFLICT DO NOTHING
       RETURNING id, organization_id, resource_class, principal_kind, principal_id,
-       principal_mode, operation_key, entity_type_slug, field_path, entity_id,
+       operation_key, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     `;
@@ -1291,7 +1209,6 @@ export async function deleteEntityApprovalPolicy(args: {
 	resourceClass?: WriteResourceClass;
 	principalKind?: PolicyPrincipalKind | null;
 	principalId?: string | null;
-	principalMode?: PrincipalMode | null;
 	operationKey?: string | null;
 	entityTypeSlug?: string | null;
 	fieldPath?: string | null;
@@ -1300,9 +1217,6 @@ export async function deleteEntityApprovalPolicy(args: {
 	const resourceClass = normalizeResourceClass(args.resourceClass);
 	const principalKind = normalizePrincipalKind(args.principalKind);
 	const principalId = principalKind ? args.principalId?.trim() || null : null;
-	const principalMode = principalKind
-		? normalizePrincipalMode(args.principalMode)
-		: null;
 	const operationKey =
 		resourceClass === "connector_action"
 			? args.operationKey?.trim() || null
@@ -1328,7 +1242,6 @@ export async function deleteEntityApprovalPolicy(args: {
       AND resource_class = ${resourceClass}
       AND principal_kind IS NOT DISTINCT FROM ${principalKind}
       AND principal_id IS NOT DISTINCT FROM ${principalId}
-      AND principal_mode IS NOT DISTINCT FROM ${principalMode}
       AND operation_key IS NOT DISTINCT FROM ${operationKey}
       AND entity_type_slug IS NOT DISTINCT FROM ${entityTypeSlug}
       AND field_path IS NOT DISTINCT FROM ${fieldPath}

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -186,11 +186,6 @@ export function isEntityMutationMode(
 	);
 }
 
-/** The two modes the entity-approval UI/API accept for create/update/delete. */
-export function isEntityApprovalUiMode(value: unknown): value is "auto" | "approval" {
-	return value === "auto" || value === "approval";
-}
-
 /**
  * Coerce user INPUT to a caller-chosen default when it isn't a legal mode.
  * (Stored effects READ from the DB fail closed differently — see
@@ -995,32 +990,9 @@ export async function evaluateEntityFieldUpdates(args: {
 	return decisions;
 }
 
-export async function getGlobalEntityApprovalPolicy(
-	organizationId: string,
-): Promise<EntityApprovalPolicy> {
-	const sql = getDb();
-	const rows = await sql<EntityApprovalPolicyRow>`
-    SELECT id, organization_id, resource_class, principal_kind, principal_id,
-       operation_key, target_agent_id, entity_type_slug, field_path, entity_id,
-       approval_connection_id, approval_channel_id, approval_team_id,
-       approval_channel_name
-    FROM write_approval_policies
-    WHERE organization_id = ${organizationId}
-      AND resource_class = 'entity'
-      AND principal_kind IS NULL
-      AND entity_type_slug IS NULL
-      AND field_path IS NULL
-      AND entity_id IS NULL
-    LIMIT 1
-  `;
-	if (!rows[0]) return defaultEntityApprovalPolicy(organizationId);
-	await attachEffects(sql, rows as EntityApprovalPolicyRow[]);
-	return rowToPolicy(rows[0]);
-}
-
 /**
  * Every policy row for an org, most-general first. Filter by class to list one
- * class's rows (the entity settings page passes `entity`); omit to list all.
+ * class's rows; omit to list all.
  */
 export async function listEntityApprovalPolicies(
 	organizationId: string,
@@ -1054,24 +1026,12 @@ export async function listEntityApprovalPolicies(
 	return rows.map(rowToPolicy);
 }
 
-export async function upsertGlobalEntityApprovalPolicy(
-	organizationId: string,
-	input: EntityApprovalPolicyInput,
-): Promise<EntityApprovalPolicy> {
-	return upsertEntityApprovalPolicy(organizationId, {
-		...input,
-		entityTypeSlug: null,
-		fieldPath: null,
-		entityId: null,
-	});
-}
-
 /**
  * Turn a policy input into the action→effect set to persist for the given class.
- * For the entity-shaped classes the effects come from create/update/delete; for
- * connector_action the single `execute` effect is taken from `createMode` (the
- * field the API carries it in until the connector-action UI ships a dedicated
- * one). Effects are clamped to what the manifest declares legal for the class.
+ * For the entity-shaped classes the effects come from create/update/delete (and
+ * read); for connector_action the single `execute` effect is taken from
+ * `createMode` when no effects map is provided. Effects are clamped to what the
+ * manifest declares legal for the class.
  */
 function actionEffectSetForInput(
 	resourceClass: WriteResourceClass,

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -30,7 +30,7 @@ import {
 
 export type EntityPolicyDecision = "allow" | "deny" | "require_approval";
 export type EntityPolicyPrincipalKind = "user" | "agent" | "watcher";
-export type EntityMutationAction = "create" | "update" | "delete";
+export type EntityMutationAction = "read" | "create" | "update" | "delete";
 /**
  * A stored per-action mode. `auto`/`approval` are the two entity modes; `deny`
  * (a hard floor — the write never applies and no approval is queued) and
@@ -90,6 +90,8 @@ export interface EntityApprovalPolicy {
 	/** Connector operation this row scopes to (connector_action only); NULL = the
 	 * blanket row governing every operation. */
 	operationKey: string | null;
+	/** agent_config exception: target agents.id; NULL = any target. */
+	targetAgentId: string | null;
 	entityTypeSlug: string | null;
 	fieldPath: string | null;
 	entityId: number | null;
@@ -113,6 +115,8 @@ export interface EntityApprovalPolicyInput {
 	/** Scopes a connector_action row to one operation (e.g. 'slack.send_message');
 	 * null = the blanket row for every operation. */
 	operationKey?: string | null;
+	/** agent_config exception: target agent id; null = any target. */
+	targetAgentId?: string | null;
 	entityTypeSlug?: string | null;
 	fieldPath?: string | null;
 	entityId?: number | null;
@@ -158,6 +162,7 @@ type EntityApprovalPolicyRow = {
 	/** Connector operation this row scopes to (e.g. 'slack.send_message'); NULL =
 	 * the blanket row governing every operation. Only set for connector_action. */
 	operation_key: string | null;
+	target_agent_id: string | null;
 	entity_type_slug: string | null;
 	field_path: string | null;
 	entity_id: number | null;
@@ -234,6 +239,7 @@ function rowToPolicy(row: EntityApprovalPolicyRow): EntityApprovalPolicy {
 		principalKind: normalizePrincipalKind(row.principal_kind),
 		principalId: row.principal_id,
 		operationKey: row.operation_key,
+		targetAgentId: row.target_agent_id ?? null,
 		entityTypeSlug: row.entity_type_slug,
 		fieldPath: row.field_path,
 		entityId: row.entity_id === null ? null : Number(row.entity_id),
@@ -260,6 +266,7 @@ export function defaultEntityApprovalPolicy(
 		principalKind: null,
 		principalId: null,
 		operationKey: null,
+		targetAgentId: null,
 		entityTypeSlug: null,
 		fieldPath: null,
 		entityId: null,
@@ -665,6 +672,7 @@ async function attachEffects(
 
 function isWriteAction(value: unknown): value is WriteAction {
 	return (
+		value === "read" ||
 		value === "create" ||
 		value === "update" ||
 		value === "delete" ||
@@ -693,6 +701,8 @@ async function loadCandidatePolicies(args: {
 	 * blanket row (operation_key IS NULL) and any row scoped to this operation; the
 	 * op-specific row wins via {@link scopeSpecificity}. */
 	operationKey?: string | null;
+	/** agent_config: target agents.id being updated/deleted. Loads blanket + that target. */
+	targetAgentId?: string | null;
 	sql?: DbClient;
 }): Promise<EntityApprovalPolicyRow[]> {
 	const sql = args.sql ?? getDb();
@@ -702,7 +712,7 @@ async function loadCandidatePolicies(args: {
 	const ownerAgentId = args.ownerAgentId ?? null;
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
-       operation_key, entity_type_slug, field_path, entity_id,
+       operation_key, target_agent_id, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM write_approval_policies
@@ -721,6 +731,7 @@ async function loadCandidatePolicies(args: {
         )
       )
       AND (operation_key IS NULL OR operation_key = ${args.operationKey ?? null})
+      AND (target_agent_id IS NULL OR target_agent_id = ${args.targetAgentId ?? null})
       AND (entity_type_slug IS NULL OR entity_type_slug = ${args.entityTypeSlug ?? null})
       AND (entity_id IS NULL OR entity_id = ${args.entityId ?? null})
   `;
@@ -776,8 +787,10 @@ export async function resolveEntityApprovalPolicy(args: {
 }
 
 /**
- * Decision for a create or delete. `entityOrgId` is the org of the row being
- * touched (from the locked/fetched entity); a mismatch is always a deny.
+ * Decision for entity read/create/delete (and whole-entity update). `entityOrgId`
+ * is the org of the row being touched (from the locked/fetched entity); a
+ * mismatch is always a deny. `read` is the visibility gate for manage_entity
+ * get/list — approval collapses to deny (you can't queue a read).
  */
 export async function evaluateEntityMutation(args: {
 	organizationId: string;
@@ -800,7 +813,7 @@ export async function evaluateEntityMutation(args: {
 	 * true (agent/user turns, and watchers whose owner resolved).
 	 */
 	ownerResolved?: boolean;
-	/** Attended (human-driven) vs autonomous (watcher). Defaults attended. */
+	/** Headless vs interactive label only — write-policy is one envelope. */
 	mode?: PrincipalMode;
 	sql?: DbClient;
 }): Promise<EntityPolicyDecision> {
@@ -815,16 +828,18 @@ export async function evaluateEntityMutation(args: {
 		principalId: args.principalId ?? null,
 		ownerAgentId: args.ownerAgentId ?? null,
 	});
-	// create/delete act on the WHOLE entity, not any one field — a field-scoped
+	// create/delete/read act on the WHOLE entity, not any one field — a field-scoped
 	// row (e.g. person.ssn=deny) governs only its field's UPDATES and must not
-	// bleed into the entity's create/delete decision. Drop field-scoped rows here
+	// bleed into the entity's create/delete/read decision. Drop field-scoped rows here
 	// (the update path keeps them, matched per-field). What remains — the org
-	// floor, blanket, and type-scoped rows — folds max-restrictive, then layers
-	// the attended/autonomous relationship.
+	// floor, blanket, and type-scoped rows — folds max-restrictive.
 	const forEntity = candidates.filter((row) => row.field_path === null);
-	return modeToDecision(
+	const decision = modeToDecision(
 		foldEffectForDecision(forEntity, "entity", args.action),
 	);
+	// Reads never queue: approval is treated as deny (stricter than auto, no inbox).
+	if (args.action === "read" && decision === "require_approval") return "deny";
+	return decision;
 }
 
 
@@ -862,6 +877,8 @@ export async function resolveWritePolicyDecision(args: {
 	/** connector_action only: the operation being run — a per-op row tightens the
 	 * blanket execute rule for it alone. Forwarded to {@link resolveWriteEffect}. */
 	operationKey?: string | null;
+	/** agent_config only: target agent id for update/delete. */
+	targetAgentId?: string | null;
 	sql?: DbClient;
 }): Promise<EntityPolicyDecision> {
 	return modeToDecision(await resolveWriteEffect(args));
@@ -891,6 +908,8 @@ export async function resolveWriteEffect(args: {
 	/** connector_action only: the operation being run (e.g. 'slack.send_message').
 	 * A row scoped to this op tightens the blanket execute rule for it alone. */
 	operationKey?: string | null;
+	/** agent_config only: target agent id for update/delete. */
+	targetAgentId?: string | null;
 	sql?: DbClient;
 }): Promise<EntityMutationMode> {
 	if (args.principalKind === "user") return "auto";
@@ -902,6 +921,7 @@ export async function resolveWriteEffect(args: {
 		principalId: args.principalId ?? null,
 		ownerAgentId: args.ownerAgentId ?? null,
 		operationKey: args.operationKey ?? null,
+		targetAgentId: args.targetAgentId ?? null,
 		sql: args.sql,
 	});
 	return foldEffectForDecision(
@@ -981,7 +1001,7 @@ export async function getGlobalEntityApprovalPolicy(
 	const sql = getDb();
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
-       operation_key, entity_type_slug, field_path, entity_id,
+       operation_key, target_agent_id, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM write_approval_policies
@@ -1009,7 +1029,7 @@ export async function listEntityApprovalPolicies(
 	const sql = getDb();
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
-       operation_key, entity_type_slug, field_path, entity_id,
+       operation_key, target_agent_id, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     FROM write_approval_policies
@@ -1119,9 +1139,15 @@ export async function upsertEntityApprovalPolicy(
 		resourceClass === "connector_action"
 			? input.operationKey?.trim() || null
 			: null;
-	const entityTypeSlug = input.entityTypeSlug?.trim() || null;
-	const fieldPath = input.fieldPath?.trim() || null;
-	const entityId = input.entityId ?? null;
+	const targetAgentId =
+		resourceClass === "agent_config"
+			? input.targetAgentId?.trim() || null
+			: null;
+	const entityTypeSlug =
+		resourceClass === "entity" ? input.entityTypeSlug?.trim() || null : null;
+	const fieldPath =
+		resourceClass === "entity" ? input.fieldPath?.trim() || null : null;
+	const entityId = resourceClass === "entity" ? (input.entityId ?? null) : null;
 	const effectSet = actionEffectSetForInput(resourceClass, input);
 	const approvalConnectionId = input.approvalConnectionId?.trim() || null;
 	const approvalChannelId = input.approvalChannelId?.trim() || null;
@@ -1157,11 +1183,12 @@ export async function upsertEntityApprovalPolicy(
         AND principal_kind IS NOT DISTINCT FROM ${principalKind}
         AND principal_id IS NOT DISTINCT FROM ${principalId}
         AND operation_key IS NOT DISTINCT FROM ${operationKey}
+        AND target_agent_id IS NOT DISTINCT FROM ${targetAgentId}
         AND entity_type_slug IS NOT DISTINCT FROM ${entityTypeSlug}
         AND field_path IS NOT DISTINCT FROM ${fieldPath}
         AND entity_id IS NOT DISTINCT FROM ${entityId}
       RETURNING id, organization_id, resource_class, principal_kind, principal_id,
-       operation_key, entity_type_slug, field_path, entity_id,
+       operation_key, target_agent_id, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     `;
@@ -1173,19 +1200,19 @@ export async function upsertEntityApprovalPolicy(
 			const inserted = await tx<EntityApprovalPolicyRow>`
       INSERT INTO write_approval_policies (
         organization_id, resource_class, principal_kind, principal_id,
-        operation_key, entity_type_slug, field_path, entity_id,
+        operation_key, target_agent_id, entity_type_slug, field_path, entity_id,
         approval_connection_id, approval_channel_id, approval_team_id,
         approval_channel_name, created_at, updated_at
       ) VALUES (
         ${organizationId}, ${resourceClass}, ${principalKind}, ${principalId},
-        ${operationKey}, ${entityTypeSlug}, ${fieldPath}, ${entityId},
+        ${operationKey}, ${targetAgentId}, ${entityTypeSlug}, ${fieldPath}, ${entityId},
         ${approvalConnectionId},
         ${approvalChannelId}, ${approvalTeamId}, ${approvalChannelName},
         now(), now()
       )
       ON CONFLICT DO NOTHING
       RETURNING id, organization_id, resource_class, principal_kind, principal_id,
-       operation_key, entity_type_slug, field_path, entity_id,
+       operation_key, target_agent_id, entity_type_slug, field_path, entity_id,
        approval_connection_id, approval_channel_id, approval_team_id,
        approval_channel_name
     `;
@@ -1210,6 +1237,7 @@ export async function deleteEntityApprovalPolicy(args: {
 	principalKind?: PolicyPrincipalKind | null;
 	principalId?: string | null;
 	operationKey?: string | null;
+	targetAgentId?: string | null;
 	entityTypeSlug?: string | null;
 	fieldPath?: string | null;
 	entityId?: number | null;
@@ -1221,9 +1249,15 @@ export async function deleteEntityApprovalPolicy(args: {
 		resourceClass === "connector_action"
 			? args.operationKey?.trim() || null
 			: null;
-	const entityTypeSlug = args.entityTypeSlug?.trim() || null;
-	const fieldPath = args.fieldPath?.trim() || null;
-	const entityId = args.entityId ?? null;
+	const targetAgentId =
+		resourceClass === "agent_config"
+			? args.targetAgentId?.trim() || null
+			: null;
+	const entityTypeSlug =
+		resourceClass === "entity" ? args.entityTypeSlug?.trim() || null : null;
+	const fieldPath =
+		resourceClass === "entity" ? args.fieldPath?.trim() || null : null;
+	const entityId = resourceClass === "entity" ? (args.entityId ?? null) : null;
 	// Guard: never let a request delete the workspace default (entity class, any
 	// principal, unscoped) — that row is the fallback and is edited, not removed.
 	if (
@@ -1243,6 +1277,7 @@ export async function deleteEntityApprovalPolicy(args: {
       AND principal_kind IS NOT DISTINCT FROM ${principalKind}
       AND principal_id IS NOT DISTINCT FROM ${principalId}
       AND operation_key IS NOT DISTINCT FROM ${operationKey}
+      AND target_agent_id IS NOT DISTINCT FROM ${targetAgentId}
       AND entity_type_slug IS NOT DISTINCT FROM ${entityTypeSlug}
       AND field_path IS NOT DISTINCT FROM ${fieldPath}
       AND entity_id IS NOT DISTINCT FROM ${entityId}

--- a/packages/server/src/authz/write-action-manifest.ts
+++ b/packages/server/src/authz/write-action-manifest.ts
@@ -17,12 +17,13 @@
 import type { WriteResourceClass } from "./entity-policy";
 
 /**
- * The verbs a write policy can govern. `create`/`update`/`delete` are the entity
- * and agent_config actions; `execute` is the connector_action verb (running a
+ * The verbs a write policy can govern. `read`/`create`/`update`/`delete` are the
+ * entity actions (`read` scopes which types an agent may see); agent_config uses
+ * create/update/delete; `execute` is the connector_action verb (running a write
  * connector operation). `install` is intentionally NOT declared until a class
  * actually uses it — an undeclared action is illegal, not a reserved no-op.
  */
-export type WriteAction = "create" | "update" | "delete" | "execute";
+export type WriteAction = "read" | "create" | "update" | "delete" | "execute";
 
 /**
  * The decision a policy attaches to an action. `auto` applies inline; `approval`
@@ -50,10 +51,14 @@ export const WRITE_ACTION_MANIFEST: Readonly<
 	Record<WriteResourceClass, ClassManifest>
 > = {
 	entity: {
-		actions: ["create", "update", "delete"],
+		// `read` is auto/deny in the UI (approval is legal but treated as deny at
+		// the read gate — you can't "queue" a read for human review usefully).
+		actions: ["read", "create", "update", "delete"],
 		effects: ["auto", "approval", "deny"],
 		// Matches the historical entity default (create/update auto, delete approval).
+		// read defaults auto so existing agents keep unrestricted org-entity access.
 		defaultEffect: {
+			read: "auto",
 			create: "auto",
 			update: "auto",
 			delete: "approval",
@@ -66,6 +71,7 @@ export const WRITE_ACTION_MANIFEST: Readonly<
 		// An agent editing agent definitions is high-trust: create/update queue an
 		// approval, delete is denied outright (a human must delete an agent).
 		defaultEffect: {
+			read: "deny",
 			create: "approval",
 			update: "approval",
 			delete: "deny",
@@ -73,12 +79,16 @@ export const WRITE_ACTION_MANIFEST: Readonly<
 		},
 	},
 	connector_action: {
+		// `execute` covers WRITE ops only. Reads stay on connection action_modes
+		// (MCP readOnlyHint → kind=read → default auto). Destructive writes map
+		// via requires_approval / destructiveHint on the connection layer.
 		actions: ["execute"],
 		effects: ["auto", "approval", "deny", "disabled"],
 		// No org connector-action policy → auto, so the per-connection action_modes
 		// alone decide (today's behavior). A row only ever tightens.
 		defaultEffect: {
 			execute: "auto",
+			read: "deny",
 			create: "deny",
 			update: "deny",
 			delete: "deny",

--- a/packages/server/src/authz/write-action-manifest.ts
+++ b/packages/server/src/authz/write-action-manifest.ts
@@ -74,8 +74,9 @@ export const WRITE_ACTION_MANIFEST: Readonly<
 		effects: ["auto", "approval", "deny"],
 		// An agent editing agent definitions is high-trust: create/update queue an
 		// approval, delete is denied outright (a human must delete an agent).
-		// read defaults auto so existing agents keep unrestricted peer visibility
-		// (tighten via blanket deny + target whitelist, or per-target deny).
+		// read defaults auto so existing agents keep unrestricted peer visibility.
+		// Target exceptions only tighten (max-restrictive fold): use default auto +
+		// per-target deny to blacklist; a per-target auto cannot open a blanket deny.
 		defaultEffect: {
 			read: "auto",
 			create: "approval",

--- a/packages/server/src/authz/write-action-manifest.ts
+++ b/packages/server/src/authz/write-action-manifest.ts
@@ -17,11 +17,11 @@
 import type { WriteResourceClass } from "./entity-policy";
 
 /**
- * The verbs a write policy can govern. `read`/`create`/`update`/`delete` are the
- * entity actions (`read` scopes which types an agent may see); agent_config uses
- * create/update/delete; `execute` is the connector_action verb (running a write
- * connector operation). `install` is intentionally NOT declared until a class
- * actually uses it — an undeclared action is illegal, not a reserved no-op.
+ * The verbs a write policy can govern. `read`/`create`/`update`/`delete` are
+ * shared by entity and agent_config (`read` scopes which entity types / peer
+ * agents a principal may see); `execute` is the connector_action verb (running
+ * a write connector operation). `install` is intentionally NOT declared until a
+ * class actually uses it — an undeclared action is illegal, not a reserved no-op.
  */
 export type WriteAction = "read" | "create" | "update" | "delete" | "execute";
 
@@ -66,12 +66,18 @@ export const WRITE_ACTION_MANIFEST: Readonly<
 		},
 	},
 	agent_config: {
-		actions: ["create", "update", "delete"],
+		// `read` = list/get other agents (and their config surface). Auto/deny in
+		// the UI; approval collapses to deny at the gate. create/update/delete
+		// remain definition CRUD; invoke/call is not a legal action until a
+		// first-class handoff path exists.
+		actions: ["read", "create", "update", "delete"],
 		effects: ["auto", "approval", "deny"],
 		// An agent editing agent definitions is high-trust: create/update queue an
 		// approval, delete is denied outright (a human must delete an agent).
+		// read defaults auto so existing agents keep unrestricted peer visibility
+		// (tighten via blanket deny + target whitelist, or per-target deny).
 		defaultEffect: {
-			read: "deny",
+			read: "auto",
 			create: "approval",
 			update: "approval",
 			delete: "deny",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2231,19 +2231,8 @@ app.delete("/api/:orgSlug/write-permissions", mcpAuth, async (c) => {
 	const targetAgentId =
 		resourceClass === "agent_config" ? (targetRaw?.trim() ?? null) || null : null;
 
-	// Never delete the unscoped entity workspace default via this path either —
-	// deleteEntityApprovalPolicy already guards it; surface a clear error.
-	if (
-		resourceClass === "entity" &&
-		!entityTypeSlug &&
-		!operationKey &&
-		!targetAgentId
-	) {
-		// Blanket entity floor may be cleared of *exception* rows only; deleting
-		// the unscoped entity default is blocked by the policy helper (returns false).
-		// Still allow deleting blanket agent_config / connector_action floor rows.
-	}
-
+	// Unscoped entity floor delete is blocked inside deleteEntityApprovalPolicy
+	// (returns false). Blanket agent_config / connector_action floor rows may clear.
 	const deleted = await deleteEntityApprovalPolicy({
 		organizationId,
 		resourceClass,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -25,12 +25,9 @@ import {
 	deleteEntityApprovalPolicy,
 	type EntityApprovalPolicy,
 	type EntityMutationMode,
-	getGlobalEntityApprovalPolicy,
-	isEntityApprovalUiMode,
 	isEntityMutationMode,
 	listEntityApprovalPolicies,
 	upsertEntityApprovalPolicy,
-	upsertGlobalEntityApprovalPolicy,
 } from "./authz/entity-policy";
 import { listOperations } from "./operations/connector-operations";
 import { qualifiedOperationKey } from "./tools/admin/manage_operations";
@@ -49,10 +46,6 @@ import { getDb } from "./db/client";
 import * as invalidationEmitter from "./events/emitter";
 import { streamInvalidationEvents } from "./events/sse";
 import { invalidationSseAuth } from "./events/sse-invalidation-auth";
-import {
-	resolveBoundChannelRows,
-	stripPlatformPrefix,
-} from "./gateway/channels/bound-channels";
 import {
 	type ClaimEligibleOrg,
 	type ClaimEngineDeps,
@@ -1338,275 +1331,6 @@ async function requireOrganizationSettingsAdmin(c: Context) {
 	return null;
 }
 
-app.get("/api/:orgSlug/entity-approval-policy", mcpAuth, async (c) => {
-	const authError = await requireOrganizationSettingsAdmin(c);
-	if (authError) return authError;
-	const organizationId = c.get("organizationId");
-	if (!organizationId) {
-		return c.json({ error: "Organization context required" }, 401);
-	}
-	const policy = await getGlobalEntityApprovalPolicy(organizationId);
-	const policies = await listEntityApprovalPolicies(organizationId, "entity");
-	const channelRows = await resolveBoundChannelRows(getDb(), {
-		organizationId,
-	});
-	const availableChannels = channelRows.map((row) => {
-		const nativeChannelId = stripPlatformPrefix(row.platform, row.channel_id);
-		return {
-			connection_id: row.id,
-			platform: row.platform,
-			channel_id: row.channel_id,
-			team_id: row.team_id,
-			label: `${row.platform} ${nativeChannelId}`,
-		};
-	});
-
-	return c.json({
-		policy: serializeEntityApprovalPolicy(policy),
-		policies: policies.map(serializeEntityApprovalPolicy),
-		available_channels: availableChannels,
-	});
-});
-
-app.patch("/api/:orgSlug/entity-approval-policy", mcpAuth, async (c) => {
-	const authError = await requireOrganizationSettingsAdmin(c);
-	if (authError) return authError;
-	const organizationId = c.get("organizationId");
-	if (!organizationId) {
-		return c.json({ error: "Organization context required" }, 401);
-	}
-
-	let body: Record<string, unknown>;
-	try {
-		body = await c.req.json();
-	} catch {
-		return c.json(
-			{ error: "invalid_request", message: "Request body must be JSON." },
-			400,
-		);
-	}
-
-	const createMode = body.create_mode;
-	const updateMode = body.update_mode;
-	const deleteMode = body.delete_mode;
-	if (
-		!isEntityApprovalUiMode(createMode) ||
-		!isEntityApprovalUiMode(updateMode) ||
-		!isEntityApprovalUiMode(deleteMode)
-	) {
-		return c.json(
-			{
-				error: "invalid_request",
-				message:
-					'create_mode, update_mode, and delete_mode must be "auto" or "approval".',
-			},
-			400,
-		);
-	}
-
-	// Optional per-principal targeting: an admin can pin one agent/watcher to a
-	// stricter mode. principal_id is only meaningful with a kind. Class is fixed to
-	// 'entity' on this endpoint — connector_action policy rows are ENFORCED by the
-	// gate (manage_operations.execute) but set via SDK/SQL until their own UI
-	// surface lands; this endpoint stays entity-only so its auto/approval mode
-	// validation doesn't have to fork for the deny/disabled connector modes.
-	const principalKind: "agent" | "watcher" | null =
-		body.principal_kind === "agent" || body.principal_kind === "watcher"
-			? body.principal_kind
-			: null;
-	const principalId =
-		principalKind &&
-		typeof body.principal_id === "string" &&
-		body.principal_id.trim()
-			? body.principal_id.trim()
-			: null;
-
-	const approvalConnectionId =
-		typeof body.approval_connection_id === "string" &&
-		body.approval_connection_id.trim()
-			? body.approval_connection_id.trim()
-			: null;
-	const approvalChannelId =
-		typeof body.approval_channel_id === "string" &&
-		body.approval_channel_id.trim()
-			? body.approval_channel_id.trim()
-			: null;
-	const approvalTeamId =
-		typeof body.approval_team_id === "string" && body.approval_team_id.trim()
-			? body.approval_team_id.trim()
-			: null;
-
-	let approvalChannelName =
-		typeof body.approval_channel_name === "string" &&
-		body.approval_channel_name.trim()
-			? body.approval_channel_name.trim()
-			: null;
-
-	if (approvalConnectionId || approvalChannelId || approvalTeamId) {
-		if (!approvalConnectionId || !approvalChannelId) {
-			return c.json(
-				{
-					error: "invalid_request",
-					message:
-						"Approval channel selection requires a connection and channel.",
-				},
-				400,
-			);
-		}
-		const rows = await resolveBoundChannelRows(getDb(), { organizationId });
-		const selected = rows.find((row) => {
-			const rowChannelKey = row.channel_id.includes(":")
-				? row.channel_id
-				: `${row.platform}:${row.channel_id}`;
-			const requestedChannelKey = approvalChannelId.includes(":")
-				? approvalChannelId
-				: `${row.platform}:${approvalChannelId}`;
-			return (
-				row.id === approvalConnectionId &&
-				rowChannelKey === requestedChannelKey &&
-				(!approvalTeamId || row.team_id === approvalTeamId)
-			);
-		});
-		if (!selected) {
-			return c.json(
-				{
-					error: "invalid_request",
-					message: "Approval channel is not available to this workspace.",
-				},
-				400,
-			);
-		}
-		approvalChannelName =
-			approvalChannelName ??
-			`${selected.platform} ${stripPlatformPrefix(selected.platform, selected.channel_id)}`;
-	}
-
-	const entityTypeSlug =
-		typeof body.entity_type_slug === "string" && body.entity_type_slug.trim()
-			? body.entity_type_slug.trim()
-			: null;
-	const fieldPath =
-		typeof body.field_path === "string" && body.field_path.trim()
-			? body.field_path.trim()
-			: null;
-	const entityId =
-		typeof body.entity_id === "number" && Number.isInteger(body.entity_id)
-			? body.entity_id
-			: null;
-
-	if (fieldPath && !entityTypeSlug) {
-		return c.json(
-			{
-				error: "invalid_request",
-				message: "A field-path approval policy requires an entity type.",
-			},
-			400,
-		);
-	}
-	if (entityId !== null) {
-		const entityRows = await getDb()<{ id: number }>`
-      SELECT id FROM entities
-      WHERE id = ${entityId}
-        AND organization_id = ${organizationId}
-        AND deleted_at IS NULL
-      LIMIT 1
-    `;
-		if (!entityRows[0]) {
-			return c.json(
-				{
-					error: "invalid_request",
-					message: "Entity not found in this workspace.",
-				},
-				400,
-			);
-		}
-	}
-
-	const policyInput = {
-		resourceClass: "entity" as const,
-		principalKind,
-		principalId,
-		entityTypeSlug,
-		fieldPath,
-		entityId,
-		createMode,
-		updateMode,
-		deleteMode,
-		approvalConnectionId,
-		approvalChannelId,
-		approvalTeamId,
-		approvalChannelName,
-	};
-	// Only the unscoped, any-principal entity row is the workspace default; a
-	// principal-targeted or scoped row is a specific override.
-	const isWorkspaceDefault =
-		!principalKind && !entityTypeSlug && !fieldPath && entityId === null;
-	const policy = isWorkspaceDefault
-		? await upsertGlobalEntityApprovalPolicy(organizationId, policyInput)
-		: await upsertEntityApprovalPolicy(organizationId, policyInput);
-
-	invalidationEmitter.emit(organizationId, {
-		keys: ["entity-approval-policy"],
-	});
-
-	return c.json({ policy: serializeEntityApprovalPolicy(policy) });
-});
-
-app.delete("/api/:orgSlug/entity-approval-policy", mcpAuth, async (c) => {
-	const authError = await requireOrganizationSettingsAdmin(c);
-	if (authError) return authError;
-	const organizationId = c.get("organizationId");
-	if (!organizationId) {
-		return c.json({ error: "Organization context required" }, 401);
-	}
-	const principalKindRaw = c.req.query("principal_kind")?.trim();
-	const principalKind =
-		principalKindRaw === "agent" || principalKindRaw === "watcher"
-			? principalKindRaw
-			: null;
-	const principalId = principalKind
-		? c.req.query("principal_id")?.trim() || null
-		: null;
-	const entityTypeSlug = c.req.query("entity_type_slug")?.trim() || null;
-	const fieldPath = c.req.query("field_path")?.trim() || null;
-	const entityIdRaw = c.req.query("entity_id")?.trim();
-	const entityId =
-		entityIdRaw && /^\d+$/.test(entityIdRaw) ? Number(entityIdRaw) : null;
-	// A principal-targeted row is deletable even with no scope; only the unscoped,
-	// any-principal default is protected.
-	if (!principalKind && !entityTypeSlug && !fieldPath && entityId === null) {
-		return c.json(
-			{
-				error: "invalid_request",
-				message: "The workspace default policy cannot be deleted.",
-			},
-			400,
-		);
-	}
-	if (fieldPath && !entityTypeSlug) {
-		return c.json(
-			{
-				error: "invalid_request",
-				message: "A field-path approval policy requires an entity type.",
-			},
-			400,
-		);
-	}
-	const deleted = await deleteEntityApprovalPolicy({
-		organizationId,
-		resourceClass: "entity",
-		principalKind,
-		principalId,
-		entityTypeSlug,
-		fieldPath,
-		entityId,
-	});
-	invalidationEmitter.emit(organizationId, {
-		keys: ["entity-approval-policy"],
-	});
-	return c.json({ deleted });
-});
-
 // ---------------------------------------------------------------------------
 // Agent permissions ("Guardrails" is the separate LLM-judge surface; this is the
 // deterministic write-gate envelope). Returns the ORG FLOOR rows (principal_kind
@@ -1986,7 +1710,7 @@ app.put("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 		preserveDelivery: true,
 	});
 	invalidationEmitter.emit(organizationId, {
-		keys: ["entity-approval-policy"],
+		keys: ["write-permissions", "agent-permissions"],
 	});
 	return c.json({ policy: serializeEntityApprovalPolicy(policy) });
 });
@@ -2100,7 +1824,7 @@ app.delete("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 		entityTypeSlug,
 	});
 	invalidationEmitter.emit(organizationId, {
-		keys: ["entity-approval-policy"],
+		keys: ["write-permissions", "agent-permissions"],
 	});
 	return c.json({ deleted });
 });
@@ -2108,7 +1832,7 @@ app.delete("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 // ---------------------------------------------------------------------------
 // Org write-permissions floor (principal_kind NULL). Same matrix shape as agent
 // permissions, but the editable rows ARE the floor agents inherit (and can only
-// tighten). Delivery channels stay on entity-approval-policy.
+// tighten).
 // ---------------------------------------------------------------------------
 app.get("/api/:orgSlug/write-permissions", mcpAuth, async (c) => {
 	const authError = await requireOrganizationSettingsAdmin(c);
@@ -2410,7 +2134,7 @@ app.put("/api/:orgSlug/write-permissions", mcpAuth, async (c) => {
 		preserveDelivery: true,
 	});
 	invalidationEmitter.emit(organizationId, {
-		keys: ["entity-approval-policy", "write-permissions"],
+		keys: ["write-permissions", "agent-permissions"],
 	});
 	return c.json({ policy: serializeEntityApprovalPolicy(policy) });
 });
@@ -2530,7 +2254,7 @@ app.delete("/api/:orgSlug/write-permissions", mcpAuth, async (c) => {
 		entityTypeSlug,
 	});
 	invalidationEmitter.emit(organizationId, {
-		keys: ["entity-approval-policy", "write-permissions"],
+		keys: ["write-permissions", "agent-permissions"],
 	});
 	return c.json({ deleted });
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1277,7 +1277,6 @@ function serializeEntityApprovalPolicy(policy: EntityApprovalPolicy) {
 		resource_class: policy.resourceClass,
 		principal_kind: policy.principalKind,
 		principal_id: policy.principalId,
-		principal_mode: policy.principalMode,
 		operation_key: policy.operationKey,
 		entity_type_slug: policy.entityTypeSlug,
 		field_path: policy.fieldPath,
@@ -1346,15 +1345,7 @@ app.get("/api/:orgSlug/entity-approval-policy", mcpAuth, async (c) => {
 		return c.json({ error: "Organization context required" }, 401);
 	}
 	const policy = await getGlobalEntityApprovalPolicy(organizationId);
-	// This legacy org-settings surface is MODE-BLIND: its PATCH/DELETE key a row by
-	// scope+principal WITHOUT principal_mode, so it can only address the both-mode
-	// (principal_mode NULL) rows. Autonomous-only rows are created and managed solely
-	// by the agent Permissions UI; surfacing them here would let a delete of the
-	// displayed autonomous row hit the same-scope attended row instead. Filter them
-	// out so this endpoint neither shows nor mutates them.
-	const policies = (
-		await listEntityApprovalPolicies(organizationId, "entity")
-	).filter((p) => p.principalMode === null);
+	const policies = await listEntityApprovalPolicies(organizationId, "entity");
 	const channelRows = await resolveBoundChannelRows(getDb(), {
 		organizationId,
 	});
@@ -1653,6 +1644,7 @@ app.get("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 			(p.principalKind === null ||
 				(p.principalKind === "agent" && p.principalId === null)),
 	);
+	// Agent rows: this agent only.
 	const agent = all.filter(
 		(p) =>
 			p.principalKind === "agent" &&
@@ -1677,43 +1669,21 @@ app.get("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
     ) t
     ORDER BY name ASC
   `;
-	// The org's WRITE connector operations, so the matrix can render one row per
-	// operation under connector_action (always-expanded). Only write ops are gated —
-	// reads never mutate, so they carry no per-op rule. The row's `operation_key` is
-	// the CONNECTOR-QUALIFIED key (`connector_key::op`) — the exact value the policy
-	// row and the execute gate bind to — so Linear's and GitHub's `create_issue`
-	// stay distinct rows. Deduped by that qualified key (the same op can surface from
-	// multiple connections OF THE SAME connector).
-	const opList = await listOperations({
-		organizationId,
-		kind: "write",
-		includeInputSchema: false,
-		includeOutputSchema: false,
-		limit: Number.MAX_SAFE_INTEGER,
-	});
-	const seenOps = new Set<string>();
-	const operations: Array<{
-		operation_key: string;
-		name: string;
-		connector_key: string;
-		connector_name: string;
-	}> = [];
-	for (const op of opList.operations) {
-		const key = qualifiedOperationKey(op.connector_key, op.operation_key);
-		if (seenOps.has(key)) continue;
-		seenOps.add(key);
-		operations.push({
-			operation_key: key,
-			name: op.name,
-			connector_key: op.connector_key,
-			connector_name: op.connector_name,
-		});
-	}
+	// connector_operations is intentionally empty: per-op limits live on each
+	// connection (action_modes). The agent matrix only edits the blanket
+	// connector_action.execute envelope. Runtime still enforces any legacy
+	// operation_key policy rows via the write-gate; the UI no longer catalogs every
+	// write op here.
 	return c.json({
 		floor: floor.map(serializeEntityApprovalPolicy),
 		agent: agent.map(serializeEntityApprovalPolicy),
 		entity_types: typeRows.map((r) => ({ slug: r.slug, name: r.name })),
-		connector_operations: operations,
+		connector_operations: [] as Array<{
+			operation_key: string;
+			name: string;
+			connector_key: string;
+			connector_name: string;
+		}>,
 	});
 });
 
@@ -1803,28 +1773,10 @@ app.put("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 		effects[action as WriteAction] = effect;
 	}
 
-	// principal_mode selects WHICH row this write targets: omitted/null = the
-	// both-mode row, 'autonomous' = the autonomous-only override. Silently coercing
-	// any other value to null would make a typo'd/unsupported mode clobber the
-	// ATTENDED row instead of the intended autonomous one — so reject it.
-	if (
-		body.principal_mode !== undefined &&
-		body.principal_mode !== null &&
-		body.principal_mode !== "autonomous"
-	) {
-		return c.json(
-			{
-				error: "invalid_request",
-				message: "principal_mode must be omitted, null, or 'autonomous'.",
-			},
-			400,
-		);
-	}
-	const principalMode = body.principal_mode === "autonomous" ? "autonomous" : null;
 	// entity_type_slug selects the per-type row (null = the blanket all-types row).
 	// Only the `entity` class is type-scoped. A present-but-invalid slug (number,
 	// whitespace) OR a slug on a NON-entity class must not silently coerce to null and
-	// overwrite the broad blanket policy — 400, same as principal_mode.
+	// overwrite the broad blanket policy — 400.
 	const slugPresent =
 		body.entity_type_slug !== undefined && body.entity_type_slug !== null;
 	if (slugPresent && resourceClass !== "entity") {
@@ -1937,7 +1889,6 @@ app.put("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 		resourceClass,
 		principalKind: "agent",
 		principalId: agentId,
-		principalMode,
 		operationKey,
 		entityTypeSlug,
 		effects,
@@ -1972,25 +1923,6 @@ app.delete("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 			400,
 		);
 	}
-	// Same rule as the PUT: principal_mode picks the target row (null = the both-mode
-	// row). ONLY a truly-ABSENT param maps to null — a PRESENT value that isn't exactly
-	// 'autonomous' (a typo, whitespace, or empty `?principal_mode=`) must 400, else the
-	// DELETE would fall through to null and destroy the attended/both-mode row.
-	const principalModeParam = c.req.query("principal_mode");
-	if (
-		principalModeParam !== undefined &&
-		principalModeParam.trim() !== "autonomous"
-	) {
-		return c.json(
-			{
-				error: "invalid_request",
-				message: "principal_mode must be omitted or 'autonomous'.",
-			},
-			400,
-		);
-	}
-	const principalMode =
-		principalModeParam?.trim() === "autonomous" ? "autonomous" : null;
 	// entity_type_slug picks WHICH row to delete (null = the blanket all-types row).
 	// A present-but-empty slug, or a slug on a non-entity class, must NOT coerce to
 	// null and delete the blanket policy instead of the intended per-type override.
@@ -2048,7 +1980,6 @@ app.delete("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 		resourceClass,
 		principalKind: "agent",
 		principalId: agentId,
-		principalMode,
 		operationKey,
 		entityTypeSlug,
 	});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1635,7 +1635,7 @@ app.put("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 		}
 	}
 
-	// target_agent_id: agent_config exception for update/delete of a specific agent.
+	// target_agent_id: agent_config exception for read/update/delete of a specific agent.
 	const targetPresent =
 		body.target_agent_id !== undefined && body.target_agent_id !== null;
 	if (targetPresent && resourceClass !== "agent_config") {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1278,6 +1278,7 @@ function serializeEntityApprovalPolicy(policy: EntityApprovalPolicy) {
 		principal_kind: policy.principalKind,
 		principal_id: policy.principalId,
 		operation_key: policy.operationKey,
+		target_agent_id: policy.targetAgentId,
 		entity_type_slug: policy.entityTypeSlug,
 		field_path: policy.fieldPath,
 		entity_id: policy.entityId,
@@ -1657,9 +1658,13 @@ app.get("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 	// (e.g. `company`) must be offerable as a per-type exception. Dedupe by slug,
 	// preferring the org-owned row, and drop `$member` (per-tenant, never a public
 	// catalog type) to mirror the entity-write resolver.
-	const typeRows = await getDb()<{ slug: string; name: string }>`
-    SELECT slug, name FROM (
-      SELECT DISTINCT ON (et.slug) et.slug, et.name
+	const typeRows = await getDb()<{
+		slug: string;
+		name: string;
+		icon: string | null;
+	}>`
+    SELECT slug, name, icon FROM (
+      SELECT DISTINCT ON (et.slug) et.slug, et.name, et.icon
       FROM entity_types et
       LEFT JOIN organization o ON o.id = et.organization_id
       WHERE et.deleted_at IS NULL
@@ -1669,21 +1674,57 @@ app.get("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
     ) t
     ORDER BY name ASC
   `;
-	// connector_operations is intentionally empty: per-op limits live on each
-	// connection (action_modes). The agent matrix only edits the blanket
-	// connector_action.execute envelope. Runtime still enforces any legacy
-	// operation_key policy rows via the write-gate; the UI no longer catalogs every
-	// write op here.
+	// Write ops for the connector exception picker (opt-in rows, not always expanded).
+	// Only write ops — reads are not gated by agent connector_action policy
+	// (MCP readOnlyHint / kind=read stay on connection action_modes alone).
+	const opList = await listOperations({
+		organizationId,
+		kind: "write",
+		includeInputSchema: false,
+		includeOutputSchema: false,
+		limit: Number.MAX_SAFE_INTEGER,
+	});
+	const seenOps = new Set<string>();
+	const operations: Array<{
+		operation_key: string;
+		name: string;
+		connector_key: string;
+		connector_name: string;
+		kind: "read" | "write";
+		requires_approval: boolean;
+		destructive: boolean;
+	}> = [];
+	for (const op of opList.operations) {
+		const key = qualifiedOperationKey(op.connector_key, op.operation_key);
+		if (seenOps.has(key)) continue;
+		seenOps.add(key);
+		operations.push({
+			operation_key: key,
+			name: op.name,
+			connector_key: op.connector_key,
+			connector_name: op.connector_name,
+			kind: op.kind === "read" ? "read" : "write",
+			requires_approval: op.requires_approval === true,
+			destructive: op.annotations?.destructiveHint === true,
+		});
+	}
+	// Agents in this org (for agent_config target exceptions). Exclude the agent
+	// whose envelope we're editing so self-target rows aren't offered by default.
+	const agentRows = await getDb()<{ id: string; name: string }>`
+    SELECT id, name FROM agents
+    WHERE organization_id = ${organizationId}
+    ORDER BY name ASC, id ASC
+  `;
 	return c.json({
 		floor: floor.map(serializeEntityApprovalPolicy),
 		agent: agent.map(serializeEntityApprovalPolicy),
-		entity_types: typeRows.map((r) => ({ slug: r.slug, name: r.name })),
-		connector_operations: [] as Array<{
-			operation_key: string;
-			name: string;
-			connector_key: string;
-			connector_name: string;
-		}>,
+		entity_types: typeRows.map((r) => ({
+			slug: r.slug,
+			name: r.name,
+			icon: r.icon,
+		})),
+		connector_operations: operations,
+		agents: agentRows.map((a) => ({ id: a.id, name: a.name })),
 	});
 });
 
@@ -1870,6 +1911,54 @@ app.put("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 		}
 	}
 
+	// target_agent_id: agent_config exception for update/delete of a specific agent.
+	const targetPresent =
+		body.target_agent_id !== undefined && body.target_agent_id !== null;
+	if (targetPresent && resourceClass !== "agent_config") {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: `target_agent_id is only valid for resource_class 'agent_config', not '${resourceClass}'.`,
+			},
+			400,
+		);
+	}
+	if (
+		targetPresent &&
+		(typeof body.target_agent_id !== "string" ||
+			body.target_agent_id.trim() === "")
+	) {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: "target_agent_id must be a non-empty string or omitted.",
+			},
+			400,
+		);
+	}
+	const targetAgentId =
+		resourceClass === "agent_config" &&
+		typeof body.target_agent_id === "string" &&
+		body.target_agent_id.trim()
+			? body.target_agent_id.trim()
+			: null;
+	if (targetAgentId) {
+		const targetExists = await getDb()<{ id: string }>`
+      SELECT id FROM agents
+      WHERE id = ${targetAgentId} AND organization_id = ${organizationId}
+      LIMIT 1
+    `;
+		if (!targetExists[0]) {
+			return c.json(
+				{
+					error: "invalid_request",
+					message: `Unknown target agent '${targetAgentId}' for this workspace.`,
+				},
+				400,
+			);
+		}
+	}
+
 	// The policy row targets this agent by id (a reusable slug). Confirm the agent
 	// EXISTS in this org before persisting — else a stale/typo'd URL would leave an
 	// orphan row that a future agent recreated with the same id silently inherits.
@@ -1890,6 +1979,7 @@ app.put("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 		principalKind: "agent",
 		principalId: agentId,
 		operationKey,
+		targetAgentId,
 		entityTypeSlug,
 		effects,
 		// Effect-only endpoint: keep any approval delivery target already on the row.
@@ -1975,16 +2065,472 @@ app.delete("/api/:orgSlug/agent/:agentId/permissions", mcpAuth, async (c) => {
 	}
 	const operationKey =
 		resourceClass === "connector_action" ? (opKeyRaw?.trim() ?? null) || null : null;
+	const targetRaw = c.req.query("target_agent_id");
+	if (
+		targetRaw !== undefined &&
+		targetRaw !== "" &&
+		resourceClass !== "agent_config"
+	) {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: `target_agent_id is only valid for resource_class 'agent_config', not '${resourceClass}'.`,
+			},
+			400,
+		);
+	}
+	if (targetRaw !== undefined && targetRaw.trim() === "") {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: "target_agent_id must be a non-empty string or omitted.",
+			},
+			400,
+		);
+	}
+	const targetAgentId =
+		resourceClass === "agent_config" ? (targetRaw?.trim() ?? null) || null : null;
 	const deleted = await deleteEntityApprovalPolicy({
 		organizationId,
 		resourceClass,
 		principalKind: "agent",
 		principalId: agentId,
 		operationKey,
+		targetAgentId,
 		entityTypeSlug,
 	});
 	invalidationEmitter.emit(organizationId, {
 		keys: ["entity-approval-policy"],
+	});
+	return c.json({ deleted });
+});
+
+// ---------------------------------------------------------------------------
+// Org write-permissions floor (principal_kind NULL). Same matrix shape as agent
+// permissions, but the editable rows ARE the floor agents inherit (and can only
+// tighten). Delivery channels stay on entity-approval-policy.
+// ---------------------------------------------------------------------------
+app.get("/api/:orgSlug/write-permissions", mcpAuth, async (c) => {
+	const authError = await requireOrganizationSettingsAdmin(c);
+	if (authError) return authError;
+	const organizationId = c.get("organizationId");
+	if (!organizationId) {
+		return c.json({ error: "Organization context required" }, 401);
+	}
+	const all = await listEntityApprovalPolicies(organizationId);
+	const typeScoped = (p: EntityApprovalPolicy) =>
+		p.fieldPath === null && p.entityId === null;
+	// Editable floor = any-principal rows. Kind-wide agent rows (principal_kind
+	// agent, principal_id null) also bind as floor for agents but are rare; include
+	// them so the matrix doesn't under-report the bound.
+	const floor = all.filter(
+		(p) =>
+			typeScoped(p) &&
+			(p.principalKind === null ||
+				(p.principalKind === "agent" && p.principalId === null)),
+	);
+	const typeRows = await getDb()<{
+		slug: string;
+		name: string;
+		icon: string | null;
+	}>`
+    SELECT slug, name, icon FROM (
+      SELECT DISTINCT ON (et.slug) et.slug, et.name, et.icon
+      FROM entity_types et
+      LEFT JOIN organization o ON o.id = et.organization_id
+      WHERE et.deleted_at IS NULL
+        AND et.slug <> '$member'
+        AND (et.organization_id = ${organizationId} OR o.visibility = 'public')
+      ORDER BY et.slug, (et.organization_id = ${organizationId}) DESC, et.id ASC
+    ) t
+    ORDER BY name ASC
+  `;
+	const opList = await listOperations({
+		organizationId,
+		kind: "write",
+		includeInputSchema: false,
+		includeOutputSchema: false,
+		limit: Number.MAX_SAFE_INTEGER,
+	});
+	const seenOps = new Set<string>();
+	const operations: Array<{
+		operation_key: string;
+		name: string;
+		connector_key: string;
+		connector_name: string;
+		kind: "read" | "write";
+		requires_approval: boolean;
+		destructive: boolean;
+	}> = [];
+	for (const op of opList.operations) {
+		const key = qualifiedOperationKey(op.connector_key, op.operation_key);
+		if (seenOps.has(key)) continue;
+		seenOps.add(key);
+		operations.push({
+			operation_key: key,
+			name: op.name,
+			connector_key: op.connector_key,
+			connector_name: op.connector_name,
+			kind: op.kind === "read" ? "read" : "write",
+			requires_approval: op.requires_approval === true,
+			destructive: op.annotations?.destructiveHint === true,
+		});
+	}
+	const agentRows = await getDb()<{ id: string; name: string }>`
+    SELECT id, name FROM agents
+    WHERE organization_id = ${organizationId}
+    ORDER BY name ASC, id ASC
+  `;
+	return c.json({
+		// Matrix adapter: floor is empty (no parent bound); `agent` holds the
+		// editable org-floor rows so the shared UI model can treat them as the
+		// override layer with no floor-tightening bound.
+		floor: [],
+		agent: floor.map(serializeEntityApprovalPolicy),
+		entity_types: typeRows.map((r) => ({
+			slug: r.slug,
+			name: r.name,
+			icon: r.icon,
+		})),
+		connector_operations: operations,
+		agents: agentRows.map((a) => ({ id: a.id, name: a.name })),
+	});
+});
+
+app.put("/api/:orgSlug/write-permissions", mcpAuth, async (c) => {
+	const authError = await requireOrganizationSettingsAdmin(c);
+	if (authError) return authError;
+	const organizationId = c.get("organizationId");
+	if (!organizationId) {
+		return c.json({ error: "Organization context required" }, 401);
+	}
+
+	let body: Record<string, unknown>;
+	try {
+		body = await c.req.json();
+	} catch {
+		return c.json(
+			{ error: "invalid_request", message: "Request body must be JSON." },
+			400,
+		);
+	}
+	if (typeof body !== "object" || body === null || Array.isArray(body)) {
+		return c.json(
+			{ error: "invalid_request", message: "Request body must be a JSON object." },
+			400,
+		);
+	}
+
+	const resourceClass =
+		body.resource_class === "entity" ||
+		body.resource_class === "agent_config" ||
+		body.resource_class === "connector_action"
+			? body.resource_class
+			: null;
+	if (!resourceClass) {
+		return c.json(
+			{
+				error: "invalid_request",
+				message:
+					"resource_class must be entity, agent_config, or connector_action.",
+			},
+			400,
+		);
+	}
+
+	const rawEffects =
+		typeof body.effects === "object" &&
+		body.effects !== null &&
+		!Array.isArray(body.effects)
+			? (body.effects as Record<string, unknown>)
+			: null;
+	if (!rawEffects) {
+		return c.json(
+			{ error: "invalid_request", message: "effects must be a JSON object." },
+			400,
+		);
+	}
+	const effects: Partial<Record<WriteAction, EntityMutationMode>> = {};
+	for (const [action, effect] of Object.entries(rawEffects)) {
+		if (
+			!isEntityMutationMode(effect) ||
+			!isLegalActionEffect(resourceClass, action as WriteAction, effect)
+		) {
+			return c.json(
+				{
+					error: "invalid_request",
+					message: `Illegal effect for ${resourceClass}: '${action}' = '${String(effect)}'.`,
+				},
+				400,
+			);
+		}
+		effects[action as WriteAction] = effect;
+	}
+
+	const slugPresent =
+		body.entity_type_slug !== undefined && body.entity_type_slug !== null;
+	if (slugPresent && resourceClass !== "entity") {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: `entity_type_slug is only valid for resource_class 'entity', not '${resourceClass}'.`,
+			},
+			400,
+		);
+	}
+	if (
+		slugPresent &&
+		(typeof body.entity_type_slug !== "string" ||
+			body.entity_type_slug.trim() === "")
+	) {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: "entity_type_slug must be a non-empty string or omitted.",
+			},
+			400,
+		);
+	}
+	const entityTypeSlug =
+		resourceClass === "entity" &&
+		typeof body.entity_type_slug === "string" &&
+		body.entity_type_slug.trim()
+			? body.entity_type_slug.trim()
+			: null;
+
+	const opKeyPresent =
+		body.operation_key !== undefined && body.operation_key !== null;
+	if (opKeyPresent && resourceClass !== "connector_action") {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: `operation_key is only valid for resource_class 'connector_action', not '${resourceClass}'.`,
+			},
+			400,
+		);
+	}
+	if (
+		opKeyPresent &&
+		(typeof body.operation_key !== "string" ||
+			body.operation_key.trim() === "")
+	) {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: "operation_key must be a non-empty string or omitted.",
+			},
+			400,
+		);
+	}
+	const operationKey =
+		resourceClass === "connector_action" &&
+		typeof body.operation_key === "string" &&
+		body.operation_key.trim()
+			? body.operation_key.trim()
+			: null;
+	if (operationKey) {
+		const known = await listOperations({
+			organizationId,
+			kind: "write",
+			includeInputSchema: false,
+			includeOutputSchema: false,
+			limit: Number.MAX_SAFE_INTEGER,
+		});
+		const knownQualified = new Set(
+			known.operations.map((op) =>
+				qualifiedOperationKey(op.connector_key, op.operation_key),
+			),
+		);
+		if (!knownQualified.has(operationKey)) {
+			return c.json(
+				{
+					error: "invalid_request",
+					message: `Unknown connector operation '${operationKey}' for this workspace.`,
+				},
+				400,
+			);
+		}
+	}
+
+	const targetPresent =
+		body.target_agent_id !== undefined && body.target_agent_id !== null;
+	if (targetPresent && resourceClass !== "agent_config") {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: `target_agent_id is only valid for resource_class 'agent_config', not '${resourceClass}'.`,
+			},
+			400,
+		);
+	}
+	if (
+		targetPresent &&
+		(typeof body.target_agent_id !== "string" ||
+			body.target_agent_id.trim() === "")
+	) {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: "target_agent_id must be a non-empty string or omitted.",
+			},
+			400,
+		);
+	}
+	const targetAgentId =
+		resourceClass === "agent_config" &&
+		typeof body.target_agent_id === "string" &&
+		body.target_agent_id.trim()
+			? body.target_agent_id.trim()
+			: null;
+	if (targetAgentId) {
+		const targetExists = await getDb()<{ id: string }>`
+      SELECT id FROM agents
+      WHERE id = ${targetAgentId} AND organization_id = ${organizationId}
+      LIMIT 1
+    `;
+		if (!targetExists[0]) {
+			return c.json(
+				{
+					error: "invalid_request",
+					message: `Unknown target agent '${targetAgentId}' for this workspace.`,
+				},
+				400,
+			);
+		}
+	}
+
+	const policy = await upsertEntityApprovalPolicy(organizationId, {
+		resourceClass,
+		principalKind: null,
+		principalId: null,
+		operationKey,
+		targetAgentId,
+		entityTypeSlug,
+		effects,
+		preserveDelivery: true,
+	});
+	invalidationEmitter.emit(organizationId, {
+		keys: ["entity-approval-policy", "write-permissions"],
+	});
+	return c.json({ policy: serializeEntityApprovalPolicy(policy) });
+});
+
+app.delete("/api/:orgSlug/write-permissions", mcpAuth, async (c) => {
+	const authError = await requireOrganizationSettingsAdmin(c);
+	if (authError) return authError;
+	const organizationId = c.get("organizationId");
+	if (!organizationId) {
+		return c.json({ error: "Organization context required" }, 401);
+	}
+	const resourceClassRaw = c.req.query("resource_class")?.trim();
+	const resourceClass =
+		resourceClassRaw === "entity" ||
+		resourceClassRaw === "agent_config" ||
+		resourceClassRaw === "connector_action"
+			? resourceClassRaw
+			: null;
+	if (!resourceClass) {
+		return c.json(
+			{ error: "invalid_request", message: "resource_class is required." },
+			400,
+		);
+	}
+	const slugRaw = c.req.query("entity_type_slug");
+	if (slugRaw !== undefined && slugRaw !== "" && resourceClass !== "entity") {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: `entity_type_slug is only valid for resource_class 'entity', not '${resourceClass}'.`,
+			},
+			400,
+		);
+	}
+	if (slugRaw !== undefined && slugRaw.trim() === "") {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: "entity_type_slug must be a non-empty string or omitted.",
+			},
+			400,
+		);
+	}
+	const entityTypeSlug =
+		resourceClass === "entity" ? (slugRaw?.trim() ?? null) || null : null;
+	const opKeyRaw = c.req.query("operation_key");
+	if (
+		opKeyRaw !== undefined &&
+		opKeyRaw !== "" &&
+		resourceClass !== "connector_action"
+	) {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: `operation_key is only valid for resource_class 'connector_action', not '${resourceClass}'.`,
+			},
+			400,
+		);
+	}
+	if (opKeyRaw !== undefined && opKeyRaw.trim() === "") {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: "operation_key must be a non-empty string or omitted.",
+			},
+			400,
+		);
+	}
+	const operationKey =
+		resourceClass === "connector_action" ? (opKeyRaw?.trim() ?? null) || null : null;
+	const targetRaw = c.req.query("target_agent_id");
+	if (
+		targetRaw !== undefined &&
+		targetRaw !== "" &&
+		resourceClass !== "agent_config"
+	) {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: `target_agent_id is only valid for resource_class 'agent_config', not '${resourceClass}'.`,
+			},
+			400,
+		);
+	}
+	if (targetRaw !== undefined && targetRaw.trim() === "") {
+		return c.json(
+			{
+				error: "invalid_request",
+				message: "target_agent_id must be a non-empty string or omitted.",
+			},
+			400,
+		);
+	}
+	const targetAgentId =
+		resourceClass === "agent_config" ? (targetRaw?.trim() ?? null) || null : null;
+
+	// Never delete the unscoped entity workspace default via this path either —
+	// deleteEntityApprovalPolicy already guards it; surface a clear error.
+	if (
+		resourceClass === "entity" &&
+		!entityTypeSlug &&
+		!operationKey &&
+		!targetAgentId
+	) {
+		// Blanket entity floor may be cleared of *exception* rows only; deleting
+		// the unscoped entity default is blocked by the policy helper (returns false).
+		// Still allow deleting blanket agent_config / connector_action floor rows.
+	}
+
+	const deleted = await deleteEntityApprovalPolicy({
+		organizationId,
+		resourceClass,
+		principalKind: null,
+		principalId: null,
+		operationKey,
+		targetAgentId,
+		entityTypeSlug,
+	});
+	invalidationEmitter.emit(organizationId, {
+		keys: ["entity-approval-policy", "write-permissions"],
 	});
 	return c.json({ deleted });
 });

--- a/packages/server/src/operations/action-modes.ts
+++ b/packages/server/src/operations/action-modes.ts
@@ -35,19 +35,30 @@ function getActionModes(
 }
 
 /**
- * Default mode for an operation the user never explicitly configured.
- * Preserves today's "all on" behavior: anything that previously required
- * approval still requires approval; anything else auto-approves.
+ * Default mode when the user never set this op on the connection.
+ * - reads → auto (never approval-gated by default)
+ * - writes with requires_approval / destructiveHint → approval
+ * - other writes → auto
  * `disabled` requires an explicit user opt-in.
  */
 function defaultModeFromOperation(operation: {
   requires_approval: boolean;
+  kind?: 'read' | 'write';
+  annotations?: { destructiveHint?: boolean };
 }): ActionMode {
-  return operation.requires_approval ? 'approval' : 'auto';
+  if (operation.kind === 'read') return 'auto';
+  if (operation.requires_approval) return 'approval';
+  if (operation.annotations?.destructiveHint === true) return 'approval';
+  return 'auto';
 }
 
 export function resolveActionMode(
-  operation: { requires_approval: boolean; operation_key: string },
+  operation: {
+    requires_approval: boolean;
+    operation_key: string;
+    kind?: 'read' | 'write';
+    annotations?: { destructiveHint?: boolean };
+  },
   config: Record<string, unknown> | null | undefined
 ): ActionMode {
   const modes = getActionModes(config);

--- a/packages/server/src/operations/connector-operations.ts
+++ b/packages/server/src/operations/connector-operations.ts
@@ -358,11 +358,16 @@ async function getOpenApiOperations(
 }
 
 function getMcpToolKind(tool: DiscoveredTool): "read" | "write" {
+	// MCP ToolAnnotations: readOnlyHint ⇒ safe for side-effect-free calls.
 	return tool.annotations?.readOnlyHint ? "read" : "write";
 }
 
 function getMcpToolRequiresApproval(tool: DiscoveredTool): boolean {
-	return !tool.annotations?.readOnlyHint;
+	// Align with MCP destructiveHint (and connection defaultModeFromOperation):
+	// only destructive writes default to approval. Non-destructive writes stay
+	// auto at the connection layer unless the user tightens action_modes or the
+	// agent/org connector_action policy tightens execute.
+	return tool.annotations?.destructiveHint === true;
 }
 
 async function getMcpOperations(

--- a/packages/server/src/operations/connector-operations.ts
+++ b/packages/server/src/operations/connector-operations.ts
@@ -363,11 +363,11 @@ function getMcpToolKind(tool: DiscoveredTool): "read" | "write" {
 }
 
 function getMcpToolRequiresApproval(tool: DiscoveredTool): boolean {
-	// Align with MCP destructiveHint (and connection defaultModeFromOperation):
-	// only destructive writes default to approval. Non-destructive writes stay
-	// auto at the connection layer unless the user tightens action_modes or the
-	// agent/org connector_action policy tightens execute.
-	return tool.annotations?.destructiveHint === true;
+	// MCP ToolAnnotations are pessimistic: when destructiveHint is omitted on a
+	// write tool, clients treat it as potentially destructive (spec default true).
+	// Only an explicit destructiveHint: false keeps the connection default auto.
+	if (getMcpToolKind(tool) === "read") return false;
+	return tool.annotations?.destructiveHint !== false;
 }
 
 async function getMcpOperations(

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -249,34 +249,39 @@ export default async (_ctx, client) => {
 };`,
 	},
 
-	// agents
+	// agents — admin tier for discovery; agent_config write-policy further
+	// gates list/get (read) and create/update/delete for agent principals.
 	"agents.manage": {
 		summary: "Raw manage_agents action wrapper. Prefer named methods.",
 		access: "admin",
 	},
 	"agents.list": {
-		summary: "List agents in the org (marks the system agent). Requires admin.",
+		summary:
+			"List agents the principal may read (agent_config read; default all). Requires admin tier.",
 		access: "admin",
 		example: "const { agents } = await client.agents.list();",
 	},
 	"agents.get": {
-		summary: "Fetch one agent by id. Requires admin.",
+		summary:
+			"Fetch one agent by id when agent_config read allows that target. Requires admin tier.",
 		access: "admin",
 		example: "const { agent } = await client.agents.get('builder');",
 	},
 	"agents.create": {
 		summary:
-			"Create an agent (queued for approval when invoked by the builder agent). Requires admin.",
+			"Create an agent (queued for approval when invoked by an agent principal). Requires admin tier + agent_config create.",
 		access: "admin",
 		example:
 			"await client.agents.create({ agent_id: 'researcher', name: 'Researcher' });",
 	},
 	"agents.update": {
-		summary: "Update agent fields (may queue for approval). Requires admin.",
+		summary:
+			"Update agent fields (may queue for approval). Requires admin tier + agent_config update.",
 		access: "admin",
 	},
 	"agents.delete": {
-		summary: "Delete an agent (may queue for approval). Requires admin.",
+		summary:
+			"Delete an agent (may queue for approval). Requires admin tier + agent_config delete.",
 		access: "admin",
 	},
 	"agents.setSystemAgent": {

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -17,8 +17,9 @@
  * organization.system_agent_id here (default-org provisioning is the other).
  *
  * Agent/watcher principals: list/get honor agent_config `read` (default auto;
- * per-target exceptions via target_agent_id). Humans skip the write-gate
- * (role tier is separate). create/update/delete still go through the write-gate.
+ * per-target deny tightens via target_agent_id — max-restrictive fold, so
+ * targets cannot loosen a blanket deny). Humans skip the write-gate (role
+ * tier is separate). create/update/delete still go through the write-gate.
  */
 
 import {
@@ -94,7 +95,8 @@ async function assertAgentConfigReadAllowed(
     action: "read",
     targetAgentId,
   });
-  if (decision === "deny") {
+  // require_approval collapses to deny for read (see resolveWritePolicyDecision).
+  if (decision !== "allow") {
     const label = targetAgentId?.trim() || "agents";
     throw new ToolUserError(
       `Policy denies reading agent '${label}' for this principal.`,
@@ -119,7 +121,7 @@ async function agentConfigReadAllowed(
     action: "read",
     targetAgentId,
   });
-  return decision !== "deny";
+  return decision === "allow";
 }
 
 async function handleList(
@@ -148,8 +150,8 @@ async function handleList(
   if (actor.kind === "user") {
     return { action: "list", agents };
   }
-  // Per-target read: drop peers the agent_config envelope denies (whitelist /
-  // blacklist via default + target_agent_id exceptions). Cache by agent id.
+  // Per-target read: drop peers the agent_config envelope denies (blacklist via
+  // default auto + target_agent_id deny). Cache by agent id.
   const allowed: AgentRecord[] = [];
   const cache = new Map<string, boolean>();
   for (const agent of agents) {

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -600,6 +600,9 @@ async function dispatchAgentWrite(
     sessionWatcherId: ctx.actingWatcherId ?? null,
     sourceForMode: ctx.sourceContext?.source,
   });
+  // update/delete name the target agent; create has no target (blanket only).
+  const targetAgentId =
+    action === 'create' ? null : (args.agent_id?.trim() || null);
   const decision = await resolveWritePolicyDecision({
     organizationId: ctx.organizationId,
     resourceClass: 'agent_config',
@@ -607,8 +610,8 @@ async function dispatchAgentWrite(
     principalId: actor.id,
     ownerAgentId: actor.ownerAgentId,
     ownerResolved: actor.ownerResolved,
-    mode: actor.mode,
     action,
+    targetAgentId,
   });
   if (decision === 'deny') {
     throw new ToolUserError(

--- a/packages/server/src/tools/admin/manage_agents.ts
+++ b/packages/server/src/tools/admin/manage_agents.ts
@@ -4,8 +4,8 @@
  * Manage agent definitions within an organization.
  *
  * Actions:
- * - list: List all agents in the org (marks the org's system agent)
- * - get: Get one agent's row
+ * - list: List agents the principal may read (agent_config read policy)
+ * - get: Get one agent when agent_config read allows that target
  * - create: Create an agent owned by the authenticated caller (owner_platform=
  *   'external' + an agent_users mapping, so the per-user chat path can reach it)
  * - update: Update name/description/identity_md on an agent
@@ -15,6 +15,10 @@
  * The org's "system" agent is the builder/console agent backing the
  * org-management surface. `set_system_agent` is the only writer of
  * organization.system_agent_id here (default-org provisioning is the other).
+ *
+ * Agent/watcher principals: list/get honor agent_config `read` (default auto;
+ * per-target exceptions via target_agent_id). Humans skip the write-gate
+ * (role tier is separate). create/update/delete still go through the write-gate.
  */
 
 import {
@@ -27,6 +31,7 @@ import {
 import {
   resolveActingPrincipal,
   resolveWritePolicyDecision,
+  type ActingPrincipal,
 } from '../../authz/entity-policy';
 import { createDbClientFromEnv, getDb } from '../../db/client';
 import type { Env } from '../../index';
@@ -56,8 +61,66 @@ export type { ManageAgentsProposal };
 export const MANAGE_AGENTS_ACTION_KEY = 'manage_agents';
 
 // ============================================
-// Typeon handlers
+// Type handlers
 // ============================================
+
+async function actingPrincipalFor(ctx: ToolContext): Promise<ActingPrincipal> {
+  return resolveActingPrincipal(getDb(), {
+    organizationId: ctx.organizationId,
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    sessionWatcherId: ctx.actingWatcherId ?? null,
+    sourceForMode: ctx.sourceContext?.source,
+  });
+}
+
+/**
+ * agent_config read gate for list/get. Humans skip (admin tier is separate).
+ * Default is auto; deny by target via target_agent_id (or blanket deny + whitelist).
+ */
+async function assertAgentConfigReadAllowed(
+  ctx: ToolContext,
+  targetAgentId: string | null,
+): Promise<void> {
+  const actor = await actingPrincipalFor(ctx);
+  if (actor.kind === "user") return;
+  const decision = await resolveWritePolicyDecision({
+    organizationId: ctx.organizationId,
+    resourceClass: "agent_config",
+    principalKind: actor.kind,
+    principalId: actor.id,
+    ownerAgentId: actor.ownerAgentId,
+    ownerResolved: actor.ownerResolved,
+    action: "read",
+    targetAgentId,
+  });
+  if (decision === "deny") {
+    const label = targetAgentId?.trim() || "agents";
+    throw new ToolUserError(
+      `Policy denies reading agent '${label}' for this principal.`,
+      403,
+    );
+  }
+}
+
+async function agentConfigReadAllowed(
+  ctx: ToolContext,
+  actor: ActingPrincipal,
+  targetAgentId: string,
+): Promise<boolean> {
+  if (actor.kind === "user") return true;
+  const decision = await resolveWritePolicyDecision({
+    organizationId: ctx.organizationId,
+    resourceClass: "agent_config",
+    principalKind: actor.kind,
+    principalId: actor.id,
+    ownerAgentId: actor.ownerAgentId,
+    ownerResolved: actor.ownerResolved,
+    action: "read",
+    targetAgentId,
+  });
+  return decision !== "deny";
+}
 
 async function handleList(
   _args: ManageAgentsArgs,
@@ -80,7 +143,24 @@ async function handleList(
     WHERE a.organization_id = ${ctx.organizationId}
     ORDER BY a.created_at ASC
   `;
-  return { action: 'list', agents: rows as unknown as AgentRecord[] };
+  const agents = rows as unknown as AgentRecord[];
+  const actor = await actingPrincipalFor(ctx);
+  if (actor.kind === "user") {
+    return { action: "list", agents };
+  }
+  // Per-target read: drop peers the agent_config envelope denies (whitelist /
+  // blacklist via default + target_agent_id exceptions). Cache by agent id.
+  const allowed: AgentRecord[] = [];
+  const cache = new Map<string, boolean>();
+  for (const agent of agents) {
+    let ok = cache.get(agent.id);
+    if (ok === undefined) {
+      ok = await agentConfigReadAllowed(ctx, actor, agent.id);
+      cache.set(agent.id, ok);
+    }
+    if (ok) allowed.push(agent);
+  }
+  return { action: "list", agents: allowed };
 }
 
 async function handleGet(
@@ -91,6 +171,9 @@ async function handleGet(
   if (!args.agent_id) {
     throw new ToolUserError('agent_id is required for get action');
   }
+  // Gate before the lookup so a denied target does not distinguish "exists" vs
+  // "forbidden" via timing alone more than a 404 would — we still 403 on deny
+  // after confirming org membership of the id when found; missing stays 404.
   const sql = createDbClientFromEnv(env);
   const rows = await sql`
     SELECT
@@ -109,6 +192,7 @@ async function handleGet(
   if (rows.length === 0) {
     throw new ToolUserError(`Agent "${args.agent_id}" not found`, 404);
   }
+  await assertAgentConfigReadAllowed(ctx, args.agent_id.trim());
   return { action: 'get', agent: rows[0] as unknown as AgentRecord };
 }
 
@@ -593,13 +677,7 @@ async function dispatchAgentWrite(
   // envelope — otherwise it would gate as a null-id agent and skip the owner's
   // approval/deny override. manage_agents has no watcher_source arg, so only the
   // trusted session watcher applies.
-  const actor = await resolveActingPrincipal(getDb(), {
-    organizationId: ctx.organizationId,
-    userId: ctx.userId,
-    agentId: ctx.agentId,
-    sessionWatcherId: ctx.actingWatcherId ?? null,
-    sourceForMode: ctx.sourceContext?.source,
-  });
+  const actor = await actingPrincipalFor(ctx);
   // update/delete name the target agent; create has no target (blanket only).
   const targetAgentId =
     action === 'create' ? null : (args.agent_id?.trim() || null);
@@ -635,11 +713,9 @@ async function dispatchAgentWrite(
   }
 }
 
-// Write actions (create/update/delete) consult the agent_config write-gate:
-// a human member applies immediately; an agent/watcher-driven write follows the
-// org policy and may queue a pending run + approval card (applied later by
-// manage_operations' approve handler via applyManageAgentsProposal → the apply*
-// functions). list/get/set_system_agent stay immediate.
+// create/update/delete consult the agent_config write-gate (human immediate;
+// agent/watcher may queue approval). list/get honor agent_config `read` for
+// agent/watcher principals. set_system_agent stays human/admin immediate.
 const runManageAgents = defineFlatActionTool<ManageAgentsArgs, ManageAgentsResult>(
   'manage_agents',
   {

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -26,6 +26,7 @@ import {
 } from "@lobu/core/contracts/tools/manage-entity";
 import {
 	type ActingPrincipal,
+	evaluateEntityMutation,
 	resolveActingPrincipal,
 } from "../../authz/entity-policy";
 import { runMutationGate } from "../../authz/entity-mutation-gate";
@@ -98,6 +99,37 @@ function actingPrincipalFor(
 		sessionWatcherId: ctx.actingWatcherId ?? null,
 		sourceForMode: ctx.sourceContext?.source,
 	});
+}
+
+/**
+ * Entity read gate for agents/watchers. Humans skip (role ACL is separate).
+ * Default is auto (unrestricted within org); a policy can deny by type.
+ */
+async function assertEntityReadAllowed(
+	args: ManageEntityArgs | undefined,
+	ctx: ToolContext,
+	entityTypeSlug: string | null | undefined,
+): Promise<void> {
+	const actor = await actingPrincipalFor(args, ctx);
+	if (actor.kind === "user") return;
+	const decision = await evaluateEntityMutation({
+		organizationId: ctx.organizationId,
+		principalKind: actor.kind,
+		principalId: actor.id,
+		ownerAgentId: actor.ownerAgentId,
+		ownerResolved: actor.ownerResolved,
+		mode: actor.mode,
+		action: "read",
+		entityTypeSlug: entityTypeSlug ?? null,
+		sql: getDb(),
+	});
+	if (decision === "deny") {
+		const label = entityTypeSlug?.trim() || "this entity type";
+		throw new ToolUserError(
+			`Policy denies reading entities of type '${label}' for this principal.`,
+			403,
+		);
+	}
 }
 
 // ============================================
@@ -726,6 +758,12 @@ async function handleList(
 		);
 	}
 
+	// Type-scoped list: fail closed before querying when the principal can't read
+	// that type. Cross-type list filters after (see below).
+	if (args.entity_type) {
+		await assertEntityReadAllowed(args, ctx, args.entity_type);
+	}
+
 	const sql = getDb();
 
 	// Run list query and entity type schema fetch in parallel
@@ -753,8 +791,44 @@ async function handleList(
 			: Promise.resolve(null),
 	]);
 
-	const { entities, hasMore, totalCount, limit, offset, sortBy, sortOrder } =
+	let { entities, hasMore, totalCount, limit, offset, sortBy, sortOrder } =
 		listResult;
+
+	// Cross-type list: drop rows whose type the agent may not read. Humans skip
+	// the gate above; agents with a blanket auto keep everything.
+	if (!args.entity_type && entities.length > 0) {
+		const actor = await actingPrincipalFor(args, ctx);
+		if (actor.kind !== "user") {
+			const typeCache = new Map<string, boolean>();
+			const allowed: typeof entities = [];
+			for (const e of entities) {
+				const slug = e.entity_type;
+				let ok = typeCache.get(slug);
+				if (ok === undefined) {
+					const decision = await evaluateEntityMutation({
+						organizationId: ctx.organizationId,
+						principalKind: actor.kind,
+						principalId: actor.id,
+						ownerAgentId: actor.ownerAgentId,
+						ownerResolved: actor.ownerResolved,
+						mode: actor.mode,
+						action: "read",
+						entityTypeSlug: slug,
+						sql,
+					});
+					ok = decision === "allow";
+					typeCache.set(slug, ok);
+				}
+				if (ok) allowed.push(e);
+			}
+			// Pagination totals are approximate when filtered; prefer not leaking denied rows.
+			if (allowed.length !== entities.length) {
+				entities = allowed;
+				totalCount = allowed.length;
+				hasMore = false;
+			}
+		}
+	}
 
 	// Batch-load relationships if schema declares x-table-relationships
 	const schema = entityTypeRow?.metadata_schema as Record<
@@ -949,6 +1023,8 @@ async function handleGet(
 	if (!entity) {
 		throw new Error(`Entity with ID ${entityId} not found`);
 	}
+
+	await assertEntityReadAllowed(undefined, ctx, entity.entity_type);
 
 	if (
 		entity.entity_type === MEMBER_ENTITY_TYPE_SLUG &&

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -1385,6 +1385,19 @@ async function handleListLinks(
 		throw new ToolUserError("entity_id is required for list_links", 400);
 
 	const sql = getDb();
+	const typeRows = await sql<{ entity_type: string }>`
+		SELECT et.slug AS entity_type
+		FROM entities e
+		JOIN entity_types et ON et.id = e.entity_type_id
+		WHERE e.id = ${args.entity_id}
+		  AND e.organization_id = ${ctx.organizationId}
+		LIMIT 1
+	`;
+	if (typeRows.length === 0) {
+		throw new ToolUserError(`Entity ${args.entity_id} not found`, 404);
+	}
+	await assertEntityReadAllowed(args, ctx, typeRows[0].entity_type);
+
 	const direction = args.direction ?? "both";
 	const includeDeleted = args.include_deleted ?? false;
 	const limit = Math.min(Math.max(args.limit ?? 100, 1), 500);

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -821,11 +821,11 @@ async function handleList(
 				}
 				if (ok) allowed.push(e);
 			}
-			// Pagination totals are approximate when filtered; prefer not leaking denied rows.
+			// Prefer not leaking exact denied-row counts; keep hasMore from the
+			// underlying query so later pages with allowed types still surface.
 			if (allowed.length !== entities.length) {
 				entities = allowed;
 				totalCount = allowed.length;
-				hasMore = false;
 			}
 		}
 	}

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -506,20 +506,11 @@ async function handleListAvailable(
       principalId: actor.id,
       ownerAgentId: actor.ownerAgentId,
       ownerResolved: actor.ownerResolved,
-      mode: actor.mode,
       action: 'execute',
       operationKey: operationKey ?? null,
     });
-  // Cheap early exit: a blanket disable hides everything without listing.
-  if ((await effectFor(null)) === 'disabled') {
-    return {
-      action: 'list_available',
-      operations: [],
-      total: 0,
-      limit: args.limit ?? 0,
-      offset: args.offset ?? 0,
-    };
-  }
+  // Blanket disable hides WRITE ops only — reads always list (policy is write-only).
+  const blanketDisabled = (await effectFor(null)) === 'disabled';
 
   // Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
   // ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
@@ -544,13 +535,14 @@ async function handleListAvailable(
     offset: 0,
   });
 
-  // Hide any single operation whose PER-OP rule resolves to disabled (the blanket
-  // isn't disabled or we'd have returned above). Humans always resolve auto, so this
-  // only filters non-human principals; the effect calls short-circuit for users.
+  // Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
+  // filtered by agent write-policy. Humans always resolve auto for policy.
   const visibleFlags = await Promise.all(
-    full.operations.map((op) =>
-      effectFor(qualifiedOperationKey(op.connector_key, op.operation_key)),
-    ),
+    full.operations.map(async (op) => {
+      if (op.kind === 'read') return 'auto' as const;
+      if (blanketDisabled) return 'disabled' as const;
+      return effectFor(qualifiedOperationKey(op.connector_key, op.operation_key));
+    }),
   );
   const visible = full.operations.filter(
     (_op, i) => visibleFlags[i] !== 'disabled',
@@ -769,24 +761,28 @@ async function handleExecute(
 		sessionWatcherId: ctx.actingWatcherId ?? null,
 		sourceForMode: ctx.sourceContext?.source,
 	});
-	const policyDecision = await resolveWritePolicyDecision({
-		organizationId: ctx.organizationId,
-		resourceClass: "connector_action",
-		principalKind: actor.kind,
-		principalId: actor.id,
-		ownerAgentId: actor.ownerAgentId,
-		ownerResolved: actor.ownerResolved,
-		mode: actor.mode,
-		action: "execute",
-		// A per-operation rule (e.g. deliveroo::place_order = approval) tightens the
-		// blanket execute for this op alone; the blanket applies to every other op. The
-		// key is connector-qualified so the rule can't leak to another connector that
-		// exposes the same bare operation key.
-		operationKey: qualifiedOperationKey(
-			connection.connector_key,
-			operation.operation_key,
-		),
-	});
+	// Agent write-policy applies to WRITE ops only. Reads stay available under
+	// connection action_modes alone (default auto) — same idea as MCP readOnlyHint.
+	const policyDecision =
+		operation.kind === "read"
+			? "allow"
+			: await resolveWritePolicyDecision({
+					organizationId: ctx.organizationId,
+					resourceClass: "connector_action",
+					principalKind: actor.kind,
+					principalId: actor.id,
+					ownerAgentId: actor.ownerAgentId,
+					ownerResolved: actor.ownerResolved,
+					action: "execute",
+					// A per-operation rule (e.g. deliveroo::place_order = approval) tightens the
+					// blanket execute for this op alone; the blanket applies to every other op. The
+					// key is connector-qualified so the rule can't leak to another connector that
+					// exposes the same bare operation key.
+					operationKey: qualifiedOperationKey(
+						connection.connector_key,
+						operation.operation_key,
+					),
+				});
 	if (policyDecision === "deny") {
 		return {
 			error: `Policy denies '${operation.operation_key}' for this principal.`,
@@ -1765,16 +1761,6 @@ async function handleApprove(
 					principalId: pendingRun.policy_principal_id,
 					ownerAgentId: recheckOwner.ownerAgentId,
 					ownerResolved: recheckOwner.resolved,
-					// Recheck in the SAME mode the run was queued under. Both modes are now
-					// persisted EXPLICITLY ('attended' | 'autonomous'), so an attended run
-					// isn't over-denied by an autonomous-only rule, and an autonomous run
-					// still can't dodge its autonomous-only tightening. NULL is a LEGACY row
-					// (queued before the column) whose true mode is unknown — fail closed to
-					// autonomous (the stricter direction) for those.
-					mode:
-						pendingRun.policy_principal_mode === "attended"
-							? "attended"
-							: "autonomous",
 					action: "execute",
 					// Recheck against the SAME operation the run was queued under, using the
 					// connector-qualified key (connector_key from the resolved connection +

--- a/packages/server/src/tools/get_content/handler.ts
+++ b/packages/server/src/tools/get_content/handler.ts
@@ -7,6 +7,10 @@
  */
 
 import type { ContentItem } from '@lobu/connector-sdk';
+import {
+  evaluateEntityMutation,
+  resolveActingPrincipal,
+} from '../../authz/entity-policy';
 import { hasRequiredMcpScope } from '../../auth/tool-access';
 import { createDbClientFromEnv, getDb, pgBigintArray } from '../../db/client';
 import type { Env } from '../../index';
@@ -113,6 +117,58 @@ async function getContentImpl(
   // Validate entity access if entity_id provided (auth query stays on PG)
   if (args.entity_id) {
     await requireReadAccess(pgSql, args.entity_id, ctx);
+  }
+
+  // Agent/watcher: entity-type read policy (same envelope as manage_entity /
+  // search_memory). Humans skip — role ACL is separate.
+  if (ctx.agentId || ctx.actingWatcherId) {
+    const actor = await resolveActingPrincipal(getDb(), {
+      organizationId: ctx.organizationId,
+      userId: ctx.userId,
+      agentId: ctx.agentId,
+      sessionWatcherId: ctx.actingWatcherId ?? null,
+      sourceForMode: ctx.sourceContext?.source,
+    });
+    if (actor.kind !== 'user') {
+      const typeSlugs = new Set<string>();
+      if (args.entity_types?.length) {
+        for (const t of args.entity_types) {
+          if (typeof t === 'string' && t.trim()) typeSlugs.add(t.trim());
+        }
+      }
+      if (args.entity_id) {
+        const typeRows = await sql`
+          SELECT et.slug AS entity_type
+          FROM entities e
+          JOIN entity_types et ON et.id = e.entity_type_id
+          WHERE e.id = ${args.entity_id}
+            AND e.organization_id = ${ctx.organizationId}
+          LIMIT 1
+        `;
+        if (typeRows[0]?.entity_type) {
+          typeSlugs.add(String(typeRows[0].entity_type));
+        }
+      }
+      for (const slug of typeSlugs) {
+        const decision = await evaluateEntityMutation({
+          organizationId: ctx.organizationId,
+          principalKind: actor.kind,
+          principalId: actor.id,
+          ownerAgentId: actor.ownerAgentId,
+          ownerResolved: actor.ownerResolved,
+          mode: actor.mode,
+          action: 'read',
+          entityTypeSlug: slug,
+          sql: getDb(),
+        });
+        if (decision === 'deny') {
+          throw new ToolUserError(
+            `Policy denies reading entities of type '${slug}' for this principal.`,
+            403,
+          );
+        }
+      }
+    }
   }
   // Stats are now opt-in: callers must explicitly pass `include_classification=summary`
   // (the Atlas events page used to set this unconditionally, which fired a heavy

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -5,7 +5,13 @@
  */
 
 import { type Static, Type } from "@sinclair/typebox";
+import {
+	resolveActingPrincipal,
+	resolveWriteEffect,
+} from "../authz/entity-policy";
+import type { WriteAction } from "../authz/write-action-manifest";
 import { resolveMaxAccessLevel } from "../auth/tool-access";
+import { getDb } from "../db/client";
 import type { Env } from "../index";
 import {
 	METHOD_METADATA,
@@ -18,6 +24,22 @@ import {
 } from "../sandbox/sdk-method-access";
 import type { ToolContext } from "./registry";
 import { withValidatedArgs } from "./validate-args";
+
+/**
+ * agents.* paths → agent_config action that must not be blanket-denied for the
+ * method to appear in discovery. list/get use read; mutate uses create/update/
+ * delete. setSystemAgent is treated as update. manage is raw — hide when every
+ * agent_config action is denied at the blanket.
+ */
+const AGENTS_SDK_ACTION: Record<string, WriteAction | "any"> = {
+	"agents.list": "read",
+	"agents.get": "read",
+	"agents.create": "create",
+	"agents.update": "update",
+	"agents.delete": "delete",
+	"agents.setSystemAgent": "update",
+	"agents.manage": "any",
+};
 
 const SDK_DISCOVERY_METADATA: Record<string, MethodMetadata> = {
 	...METHOD_METADATA,
@@ -90,21 +112,78 @@ export const SdkSearchResultSchema = Type.Object({
 
 export type SdkSearchResult = Static<typeof SdkSearchResultSchema>;
 
-function catalogForCaller(
+async function agentConfigBlanketDenied(
+	ctx: ToolContext,
+	action: WriteAction,
+): Promise<boolean> {
+	if (!ctx.organizationId || (!ctx.agentId && !ctx.actingWatcherId)) {
+		return false;
+	}
+	const actor = await resolveActingPrincipal(getDb(), {
+		organizationId: ctx.organizationId,
+		userId: ctx.userId,
+		agentId: ctx.agentId,
+		sessionWatcherId: ctx.actingWatcherId ?? null,
+		sourceForMode: ctx.sourceContext?.source,
+	});
+	if (actor.kind === "user") return false;
+	const effect = await resolveWriteEffect({
+		organizationId: ctx.organizationId,
+		resourceClass: "agent_config",
+		principalKind: actor.kind,
+		principalId: actor.id,
+		ownerAgentId: actor.ownerAgentId,
+		ownerResolved: actor.ownerResolved,
+		action,
+		targetAgentId: null,
+	});
+	return effect === "deny" || effect === "disabled";
+}
+
+/** Paths hidden for this agent principal by agent_config blanket policy. */
+async function deniedAgentsSdkPaths(ctx: ToolContext): Promise<Set<string>> {
+	const denied = new Set<string>();
+	if (!ctx.agentId && !ctx.actingWatcherId) return denied;
+
+	const actions: WriteAction[] = ["read", "create", "update", "delete"];
+	const denyByAction = new Map<WriteAction, boolean>();
+	for (const action of actions) {
+		denyByAction.set(action, await agentConfigBlanketDenied(ctx, action));
+	}
+	const allDenied = actions.every((a) => denyByAction.get(a));
+
+	for (const [path, mapped] of Object.entries(AGENTS_SDK_ACTION)) {
+		if (mapped === "any") {
+			if (allDenied) denied.add(path);
+			continue;
+		}
+		if (denyByAction.get(mapped)) denied.add(path);
+	}
+	return denied;
+}
+
+async function catalogForCaller(
 	ctx: ToolContext,
 	mode: SdkDiscoveryMode,
-): Array<[string, MethodMetadata]> {
+): Promise<Array<[string, MethodMetadata]>> {
 	const callerMax = resolveMaxAccessLevel(ctx.memberRole, ctx.scopes);
-	return Object.entries(SDK_DISCOVERY_METADATA).filter(([, meta]) =>
-		sdkMethodVisible(meta.access, callerMax, mode),
-	);
+	const policyDenied = await deniedAgentsSdkPaths(ctx);
+	return Object.entries(SDK_DISCOVERY_METADATA).filter(([path, meta]) => {
+		if (!sdkMethodVisible(meta.access, callerMax, mode)) return false;
+		if (policyDenied.has(path)) return false;
+		return true;
+	});
 }
 
 function hiddenMethodNote(
 	path: string,
 	meta: MethodMetadata,
 	mode: SdkDiscoveryMode,
+	policyDenied: Set<string>,
 ): string {
+	if (policyDenied.has(path)) {
+		return `${path} is blocked by this agent's agent_config permissions.`;
+	}
 	if (mode === "read" && meta.access !== "read") {
 		return `${path} exists but requires run_sdk (access: ${meta.access}). Retry with mode='full' or call via run_sdk.`;
 	}
@@ -163,7 +242,8 @@ async function sdkSearchImpl(
 		.filter(Boolean);
 	const lower = normalizeQueryTerm(query);
 	const mode: SdkDiscoveryMode = args.mode ?? "full";
-	const catalog = catalogForCaller(ctx, mode);
+	const catalog = await catalogForCaller(ctx, mode);
+	const policyDenied = await deniedAgentsSdkPaths(ctx);
 	const callerMax = resolveMaxAccessLevel(ctx.memberRole, ctx.scopes);
 	const isMultiMethodQuery =
 		terms.length > 1 &&
@@ -182,8 +262,11 @@ async function sdkSearchImpl(
 			const exact = METADATA_BY_LOWER_PATH.get(term);
 			if (exact) {
 				const [path, meta] = exact;
-				if (!sdkMethodVisible(meta.access, callerMax, mode)) {
-					hidden.push(hiddenMethodNote(path, meta, mode));
+				if (
+					!sdkMethodVisible(meta.access, callerMax, mode) ||
+					policyDenied.has(path)
+				) {
+					hidden.push(hiddenMethodNote(path, meta, mode, policyDenied));
 				} else if (!seen.has(path)) {
 					seen.add(path);
 					matches.push({ path, meta, exact: true });
@@ -238,12 +321,15 @@ async function sdkSearchImpl(
 	const exact = METADATA_BY_LOWER_PATH.get(lower);
 	if (exact) {
 		const [path, meta] = exact;
-		if (!sdkMethodVisible(meta.access, callerMax, mode)) {
+		if (
+			!sdkMethodVisible(meta.access, callerMax, mode) ||
+			policyDenied.has(path)
+		) {
 			return {
 				query,
 				match_count: 0,
 				results: [],
-				notes: hiddenMethodNote(path, meta, mode),
+				notes: hiddenMethodNote(path, meta, mode, policyDenied),
 			};
 		}
 		return {
@@ -293,7 +379,7 @@ async function sdkSearchImpl(
 	if (matches.length === 0) {
 		const hiddenExact = METADATA_BY_LOWER_PATH.get(lower);
 		const existsButHidden = hiddenExact
-			? hiddenMethodNote(hiddenExact[0], hiddenExact[1], mode)
+			? hiddenMethodNote(hiddenExact[0], hiddenExact[1], mode, policyDenied)
 			: undefined;
 		return {
 			query,

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -915,10 +915,10 @@ async function searchImpl(
   }
 
   if (results.length > 0) {
-    results = await filterEntitiesByReadPolicy(ctx, results);
-  }
-  if (results.length > 0) {
-    return withRecall(await formatEntityResult(results, args, ctx), recall);
+    const readable = await filterEntitiesByReadPolicy(ctx, [...results]);
+    if (readable.length > 0) {
+      return withRecall(await formatEntityResult(readable, args, ctx), recall);
+    }
   }
 
   // ========================================

--- a/packages/server/src/tools/search.ts
+++ b/packages/server/src/tools/search.ts
@@ -9,6 +9,10 @@
 
 import { type Static, Type } from '@sinclair/typebox';
 import { hasRequiredMcpScope } from '../auth/tool-access';
+import {
+  evaluateEntityMutation,
+  resolveActingPrincipal,
+} from '../authz/entity-policy';
 import { type AuthzScope, authzScopeFromToolContext } from '../authz/scope';
 import { compileConnectionRowVisibility } from '../authz/connection-visibility';
 import { getDb } from '../db/client';
@@ -723,6 +727,52 @@ export async function gatherRecall(
 
 export const search = withValidatedArgs('search_memory', SearchSchema, searchImpl);
 
+/**
+ * Drop entity hits the acting agent/watcher is not allowed to read. Humans skip.
+ * Default entity read is auto (unrestricted); a type-scoped deny removes those
+ * results so search can't leak around manage_entity get/list.
+ */
+async function filterEntitiesByReadPolicy<T extends { entity_type: string }>(
+  ctx: ToolContext,
+  entities: T[],
+): Promise<T[]> {
+  if (entities.length === 0 || !ctx.organizationId) return entities;
+  // Human-driven tools (no agent/watcher) keep full org entity search.
+  if (!ctx.agentId && !ctx.actingWatcherId) return entities;
+  const actor = await resolveActingPrincipal(getDb(), {
+    organizationId: ctx.organizationId,
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    explicitWatcherId: null,
+    sessionWatcherId: ctx.actingWatcherId ?? null,
+    sourceForMode: ctx.sourceContext?.source,
+  });
+  if (actor.kind === "user") return entities;
+  const typeCache = new Map<string, boolean>();
+  const out: T[] = [];
+  for (const entity of entities) {
+    const slug = entity.entity_type;
+    let ok = typeCache.get(slug);
+    if (ok === undefined) {
+      const decision = await evaluateEntityMutation({
+        organizationId: ctx.organizationId,
+        principalKind: actor.kind,
+        principalId: actor.id,
+        ownerAgentId: actor.ownerAgentId,
+        ownerResolved: actor.ownerResolved,
+        mode: actor.mode,
+        action: "read",
+        entityTypeSlug: slug,
+        sql: getDb(),
+      });
+      ok = decision === "allow";
+      typeCache.set(slug, ok);
+    }
+    if (ok) out.push(entity);
+  }
+  return out;
+}
+
 async function searchImpl(
   args: SearchArgs,
   env: Env,
@@ -749,6 +799,19 @@ async function searchImpl(
   // Validate: must have either query, ID, or embedding
   if (!args.query && !args.entity_id && !args.query_embedding?.length) {
     throw new ToolUserError('Must provide either query, entity_id, or query_embedding', 400);
+  }
+
+  // Type-scoped search: fail closed before querying when the agent can't read that type.
+  if (args.entity_type) {
+    const probe = await filterEntitiesByReadPolicy(ctx, [
+      { entity_type: args.entity_type },
+    ]);
+    if (probe.length === 0) {
+      throw new ToolUserError(
+        `Policy denies reading entities of type '${args.entity_type}' for this principal.`,
+        403,
+      );
+    }
   }
 
   // Helper to run content search in parallel. Runs when we have either a text
@@ -793,7 +856,17 @@ async function searchImpl(
       recallPromise,
     ]);
     if (entity) {
-      return withRecall(await formatEntityResult([entity], args, ctx), recall);
+      const readable = await filterEntitiesByReadPolicy(ctx, [entity]);
+      if (readable.length === 0) {
+        return withRecall(
+          emptyResult({
+            entity_type: entity.entity_type,
+            suggestion: `Entity with ID ${args.entity_id} is not readable under this agent's entity read policy`,
+          }),
+          recall,
+        );
+      }
+      return withRecall(await formatEntityResult(readable, args, ctx), recall);
     }
     return withRecall(
       emptyResult({
@@ -842,6 +915,9 @@ async function searchImpl(
   }
 
   if (results.length > 0) {
+    results = await filterEntitiesByReadPolicy(ctx, results);
+  }
+  if (results.length > 0) {
     return withRecall(await formatEntityResult(results, args, ctx), recall);
   }
 
@@ -858,8 +934,24 @@ async function searchImpl(
     '3. Wait for ingestion to start automatically, then discover watchers with `client.watchers.list(...)` and inspect results with `client.knowledge.read(...)` / `client.watchers.get(...)`.\n\n' +
     '**Alternative:** If you know this entity should exist, verify the spelling or try a different search term.';
 
-  // Fetch top entities per type so the LLM knows what exists
-  const existing_entities = await fetchTopEntitiesByType(ctx.organizationId);
+  // Fetch top entities per type so the LLM knows what exists (still filtered by read policy).
+  let existing_entities = await fetchTopEntitiesByType(ctx.organizationId);
+  if (existing_entities.length > 0) {
+    const flat = existing_entities.flatMap((g) =>
+      g.entities.map((e) => ({ ...e, entity_type: g.entity_type })),
+    );
+    const allowed = await filterEntitiesByReadPolicy(ctx, flat);
+    const byType = new Map<string, Array<{ id: number; name: string }>>();
+    for (const e of allowed) {
+      const list = byType.get(e.entity_type) ?? [];
+      list.push({ id: e.id, name: e.name });
+      byType.set(e.entity_type, list);
+    }
+    existing_entities = [...byType.entries()].map(([entity_type, entities]) => ({
+      entity_type,
+      entities,
+    }));
+  }
 
   return withRecall(
     emptyResult({ suggestion: suggestionText, existing_entities }),


### PR DESCRIPTION
## Summary

- Collapse agent write permissions to a **single Effect** (no Attended/Autonomous dual mode). Chat and watchers share one envelope.
- **Migration** drops `write_approval_policies.principal_mode`.
- **Connector model**: agent write-policy applies to **write ops only**; connection defaults treat **reads as auto**, destructive/`requires_approval` writes as **approval**.
- **UI**: one Effect column, entity-type exceptions only (honest empty state); no always-expanded connector op catalog.
- **Vite**: alias `@lobu/core/errors` to source so dev does not hit CJS `exports is not defined`.

## Product model (connectors)

| Layer | Role |
| --- | --- |
| Op metadata (`kind`, `requires_approval`, MCP hints) | Defaults |
| Connection Actions | Per-op Auto / Approval / Off |
| Agent Permissions | Optional tighten of **writes** (blanket execute) |

## Test plan

- [ ] Open agent Permissions: single Effect column; unattended toggle gone
- [ ] Add exception for a type lists entity types when present
- [ ] Permissions API 200 after migration (no `principal_mode` column error)
- [ ] Connector execute: reads skip agent write-policy; writes still gated
- [ ] Connection Actions defaults: read → auto; requires_approval/destructive → approval
- [ ] Unit: `agent-permissions-model.test.ts`, `entity-policy.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786504815&installation_id=136316292&pr_number=1891&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1891&signature=1d96babe3b91db214f18291b58875da61f148d78455ff0173313e753951a3152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-scoped permission APIs for viewing and managing entity approval policies by `target_agent_id`.
  * Added org-scoped write-permissions APIs to view and manage editable write-floor entries.
* **Authorization**
  * Removed legacy principal-mode scoping from entity and write-policy evaluation; decisions are now mode-agnostic.
  * Enforced entity read authorization across admin tools and memory search (failing closed with 403 when denied).
* **Improvements**
  * Refined approval-mode selection and connector operation visibility; MCP/SDK discovery now respects agent_config permissions.
* **Migrations**
  * Updated policy schema constraints, uniqueness, and indexes; added `target_agent_id` and expanded allowed actions to include `read`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->