### PR TITLE
fix(chat): connect state adapter before off-instance history ops

### DIFF
--- a/packages/server/src/gateway/connections/__tests__/state-adapter-connect.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/state-adapter-connect.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression: chat-instance-manager builds fresh state adapters for
+ * removeConnection history cleanup (and other off-instance paths). Those
+ * adapters must be connected — otherwise the first store op throws
+ * "LobuStateAdapter is not connected" and BYO chat delete aborts before
+ * soft-deleting the connection row.
+ *
+ * Requires DATABASE_URL (constructor eagerly binds getDb()).
+ */
+import { describe, expect, test } from "bun:test";
+import {
+	createConnectedGatewayStateAdapter,
+	createGatewayStateAdapter,
+} from "../state-adapter.js";
+
+const hasDb = Boolean(process.env.DATABASE_URL);
+
+describe("createGatewayStateAdapter", () => {
+	test.skipIf(!hasDb)(
+		"unconnected adapter rejects store ops with a clear error",
+		async () => {
+			const adapter = createGatewayStateAdapter();
+			await expect(adapter.get("any-key")).rejects.toThrow(
+				/LobuStateAdapter is not connected/,
+			);
+		},
+	);
+});
+
+describe("createConnectedGatewayStateAdapter", () => {
+	test.skipIf(!hasDb)(
+		"connects so store ops no longer fail on the connect gate",
+		async () => {
+			const adapter = await createConnectedGatewayStateAdapter();
+			// get on a missing key returns null — proves ensureConnected passed.
+			await expect(
+				adapter.get("missing-key-after-connect"),
+			).resolves.toBeNull();
+			await adapter.disconnect();
+		},
+	);
+});

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -45,7 +45,7 @@ import {
   type SlackHomeContext,
   type SlackHomeInbox,
 } from "./slack-platform-bridge.js";
-import { createGatewayStateAdapter } from "./state-adapter.js";
+import { createConnectedGatewayStateAdapter } from "./state-adapter.js";
 import {
   type ConnectionSettings,
   isSecretField,
@@ -1681,8 +1681,15 @@ export class ChatInstanceManager {
     return this.ensurePlatformWebhookSecret(connection);
   }
 
+  /**
+   * Postgres-backed Chat SDK state, already connected. Fresh adapters outside a
+   * warm Chat instance (removeConnection history clear, listHistoryChannels
+   * fallback, multi-connection channel resolution) must connect before any
+   * store op — otherwise LobuStateAdapter throws "not connected" (which used
+   * to block BYO chat connection delete when no warm instance existed).
+   */
   private async createStateAdapter(): Promise<any> {
-    return createGatewayStateAdapter();
+    return createConnectedGatewayStateAdapter();
   }
 
   /**

--- a/packages/server/src/gateway/connections/state-adapter.ts
+++ b/packages/server/src/gateway/connections/state-adapter.ts
@@ -379,9 +379,22 @@ class LobuStateAdapter implements StateAdapter {
 /**
  * Build the Chat SDK `StateAdapter` backed by Postgres.
  *
+ * The adapter is **not** connected yet — callers must `await adapter.connect()`
+ * before any store op (or use {@link createConnectedGatewayStateAdapter}).
  * Tests that don't have a live Postgres can pass an in-memory adapter via
  * the dedicated test fixture instead of calling this function.
  */
 export function createGatewayStateAdapter(): StateAdapter {
   return new LobuStateAdapter({ keyPrefix: "chat-conn" });
+}
+
+/**
+ * Same as {@link createGatewayStateAdapter} but already connected. Prefer this
+ * anywhere a fresh adapter is used outside of a boot path that connects itself
+ * (e.g. chat-instance-manager history helpers).
+ */
+export async function createConnectedGatewayStateAdapter(): Promise<StateAdapter> {
+  const adapter = createGatewayStateAdapter();
+  await adapter.connect();
+  return adapter;
 }


### PR DESCRIPTION
## Summary
- BYO chat connection delete builds a fresh `LobuStateAdapter` for history cleanup when no warm Chat instance exists, but never called `connect()`.
- That threw `LobuStateAdapter is not connected` and aborted delete before the connection row was soft-deleted.
- `createStateAdapter()` now returns a connected adapter via `createConnectedGatewayStateAdapter()`.

## Test plan
- [x] Unit test for unconnected vs connected adapter gate (skips without DATABASE_URL)
- [ ] Confirm `manage_connections delete` on a paused BYO Slack connection succeeds after deploy
- [x] Pre-commit biome + tsc passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786544848&installation_id=136316292&pr_number=1894&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1894&signature=0a2e5d628e6357d4cb2dbcdc7af927b0cc99322a50bdd781ec9a69d4b562db47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway state management by ensuring chat instances use a connected state store.
  * State operations now work reliably without requiring separate connection setup.
  * Added coverage to verify connection behavior, missing-key lookups, and clean disconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->