### PR TITLE
feat(memory): org guidance events + render authored context into agent prompts

### DIFF
--- a/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
+++ b/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Integration tests: buildWorkspaceInstructions render fidelity + org-wide
+ * `guidance` context injection.
+ *
+ * Render fixes pinned here (all data was already STORED, but dropped at
+ * render time):
+ *   1. entity_types.description
+ *   2. per-field metadata_schema.properties[field].description (and the
+ *      top-level-keys bug: a real JSON Schema used to render "type, properties")
+ *   3. entity_relationship_types.description
+ *   4. connector_definitions.description
+ *
+ * Org guidance pinned here:
+ *   - admin-authored `guidance` events render under "### Organization Context"
+ *   - superseded guidance disappears (only the current event renders)
+ *   - hard char cap with deterministic truncation
+ *   - connector-sourced (connection_id IS NOT NULL) guidance is NOT injected
+ *   - authorship gate: non-admin members and system contexts are rejected at
+ *     save time; owners/admins are accepted
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { deleteContent } from '../../../tools/delete_content';
+import { saveContent } from '../../../tools/save_content';
+import type { ToolContext } from '../../../tools/registry';
+import {
+  GUIDANCE_SEMANTIC_TYPE,
+  loadOrgGuidanceBlock,
+  ORG_GUIDANCE_CHAR_BUDGET,
+  ORG_GUIDANCE_TRUNCATION_MARKER,
+} from '../../../utils/org-guidance';
+import { buildWorkspaceInstructions } from '../../../utils/workspace-instructions';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestConnection,
+  createTestEvent,
+  createTestOrganization,
+  createTestUser,
+  ownerToolContext,
+  seedSystemEntityTypes,
+} from '../../setup/test-fixtures';
+
+const env = {} as never;
+
+describe('buildWorkspaceInstructions render fixes', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    await cleanupTestDatabase();
+    await seedSystemEntityTypes();
+    org = await createTestOrganization({ name: 'Render Org' });
+    const sql = getTestDb();
+
+    // Entity type with a description and a REAL JSON-Schema metadata_schema
+    // (type/properties/required at the top level) with per-field descriptions.
+    await sql`
+      INSERT INTO entity_types (slug, name, description, metadata_schema, organization_id)
+      VALUES (
+        'product',
+        'Product',
+        'Products we track for resale',
+        ${sql.json({
+          type: 'object',
+          properties: {
+            url: { type: 'string', description: 'Canonical product URL' },
+            status: { type: 'string' },
+          },
+          required: ['url'],
+        })},
+        ${org.id}
+      )
+    `;
+
+    // Legacy bare field-map schema (no top-level `type`/`properties`).
+    await sql`
+      INSERT INTO entity_types (slug, name, metadata_schema, organization_id)
+      VALUES (
+        'legacy',
+        'Legacy',
+        ${sql.json({ price: { type: 'number', description: 'Unit price in EUR' }, sku: {} })},
+        ${org.id}
+      )
+    `;
+
+    // Relationship type with a description.
+    await sql`
+      INSERT INTO entity_relationship_types (slug, name, description, organization_id)
+      VALUES ('supplies', 'Supplies', 'Which company supplies which product', ${org.id})
+    `;
+
+    // Org-scoped connector definition with a description + an active connection.
+    await sql`
+      INSERT INTO connector_definitions (key, name, description, actions_schema, organization_id, status)
+      VALUES (
+        'shop.sync',
+        'Shop Sync',
+        'Order + inventory sync for the shop',
+        ${sql.json({ list_orders: {}, refund_order: {} })},
+        ${org.id},
+        'active'
+      )
+    `;
+    await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'shop.sync',
+      createDefaultFeed: false,
+    });
+  });
+
+  it('renders entity type descriptions and per-field descriptions from metadata_schema.properties', async () => {
+    const out = await buildWorkspaceInstructions(org.id);
+    expect(out).not.toBeNull();
+    expect(out).toContain(
+      '- product ("Product") — Products we track for resale — fields: url (Canonical product URL), status'
+    );
+    // The old doubly-lossy render printed the JSON-Schema envelope keys.
+    expect(out).not.toContain('fields: type, properties');
+  });
+
+  it('still renders legacy bare field-map schemas as field names (with descriptions)', async () => {
+    const out = await buildWorkspaceInstructions(org.id);
+    // jsonb canonicalizes key order (shorter keys first): sku before price.
+    expect(out).toContain('- legacy ("Legacy") — fields: sku, price (Unit price in EUR)');
+  });
+
+  it('renders relationship type descriptions', async () => {
+    const out = await buildWorkspaceInstructions(org.id);
+    expect(out).toContain('- supplies — Which company supplies which product');
+  });
+
+  it('renders connector definition descriptions', async () => {
+    const out = await buildWorkspaceInstructions(org.id);
+    expect(out).toContain(
+      '- shop.sync (Order + inventory sync for the shop): list_orders, refund_order'
+    );
+  });
+});
+
+describe('org-wide guidance context', () => {
+  let org: Awaited<ReturnType<typeof createTestOrganization>>;
+  let ownerCtx: ToolContext;
+  let memberCtx: ToolContext;
+
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+    org = await createTestOrganization({ name: 'Guidance Org' });
+    const owner = await createTestUser({ name: 'Owner' });
+    await addUserToOrganization(owner.id, org.id, 'owner');
+    ownerCtx = ownerToolContext(org.id, owner.id);
+
+    const member = await createTestUser({ name: 'Member' });
+    await addUserToOrganization(member.id, org.id, 'member');
+    memberCtx = { ...ownerToolContext(org.id, member.id), memberRole: 'member' };
+  });
+
+  it('rejects a non-admin member saving guidance (fail closed)', async () => {
+    await expect(
+      saveContent(
+        { content: 'evil injected context', semantic_type: GUIDANCE_SEMANTIC_TYPE, metadata: {} } as never,
+        env,
+        memberCtx
+      )
+    ).rejects.toThrow(/owners\/admins/i);
+
+    const out = await buildWorkspaceInstructions(org.id);
+    expect(out).not.toContain('evil injected context');
+  });
+
+  it('rejects a system context (no member role) saving guidance', async () => {
+    const systemCtx: ToolContext = { ...ownerCtx, userId: null, memberRole: null };
+    await expect(
+      saveContent(
+        { content: 'system injected context', semantic_type: GUIDANCE_SEMANTIC_TYPE, metadata: {} } as never,
+        env,
+        systemCtx
+      )
+    ).rejects.toThrow(/owners\/admins/i);
+  });
+
+  it('injects admin-authored guidance into workspace instructions, near the top', async () => {
+    const saved = (await saveContent(
+      {
+        title: 'Fiscal year',
+        content: 'Our fiscal year starts in February.',
+        semantic_type: GUIDANCE_SEMANTIC_TYPE,
+        metadata: {},
+      } as never,
+      env,
+      ownerCtx
+    )) as { id: number };
+    expect(saved.id).toBeGreaterThan(0);
+
+    const out = await buildWorkspaceInstructions(org.id);
+    expect(out).toContain('### Organization Context');
+    expect(out).toContain('Our fiscal year starts in February.');
+    // Near the top: before the schema section.
+    const ctxIdx = out!.indexOf('### Organization Context');
+    const schemaIdx = out!.indexOf('### Tool surface');
+    expect(ctxIdx).toBeGreaterThan(-1);
+    expect(ctxIdx).toBeLessThan(schemaIdx);
+  });
+
+  it('supersede replaces guidance: only the current event renders', async () => {
+    const v1 = (await saveContent(
+      { content: 'All amounts are reported in USD.', semantic_type: GUIDANCE_SEMANTIC_TYPE, metadata: {} } as never,
+      env,
+      ownerCtx
+    )) as { id: number };
+
+    const v2 = (await saveContent(
+      {
+        content: 'All amounts are reported in EUR.',
+        semantic_type: GUIDANCE_SEMANTIC_TYPE,
+        metadata: {},
+        supersedes_event_id: v1.id,
+      } as never,
+      env,
+      ownerCtx
+    )) as { id: number };
+    expect(v2.id).toBeGreaterThan(v1.id);
+
+    const out = await buildWorkspaceInstructions(org.id);
+    expect(out).toContain('All amounts are reported in EUR.');
+    expect(out).not.toContain('All amounts are reported in USD.');
+  });
+
+  it('a deleted (tombstoned) guidance event does NOT render as a blank block', async () => {
+    // Deletion here = supersede with an empty tombstone row (events is
+    // append-only). The tombstone stamps superseded_by on the target, so the
+    // canonical view (current_event_records) masks it. Regression guard: a
+    // deleted guidance must not leave a titled-but-empty block behind.
+    const tombOrg = await createTestOrganization({ name: 'Tombstone Org' });
+    const owner = await createTestUser({ name: 'Tomb Owner' });
+    await addUserToOrganization(owner.id, tombOrg.id, 'owner');
+    const ctx = ownerToolContext(tombOrg.id, owner.id);
+
+    const saved = (await saveContent(
+      {
+        title: 'Soon-deleted',
+        content: 'This guidance is about to be deleted.',
+        semantic_type: GUIDANCE_SEMANTIC_TYPE,
+        metadata: {},
+      } as never,
+      env,
+      ctx
+    )) as { id: number };
+
+    // Present before delete.
+    expect(await loadOrgGuidanceBlock(tombOrg.id)).toContain(
+      'This guidance is about to be deleted.'
+    );
+
+    // Real delete path: inserts an empty-payload tombstone that supersedes it.
+    const del = (await deleteContent(
+      { event_id: saved.id } as never,
+      env,
+      ctx
+    )) as { tombstone_ids: number[] };
+    expect(del.tombstone_ids.length).toBe(1);
+
+    // Gone — not a blank block, not the old text, no dangling title.
+    expect(await loadOrgGuidanceBlock(tombOrg.id)).toBeNull();
+    const out = await buildWorkspaceInstructions(tombOrg.id);
+    expect(out).not.toContain('This guidance is about to be deleted.');
+    expect(out).not.toContain('Soon-deleted');
+    expect(out).not.toContain('### Organization Context');
+  });
+
+  it('an empty/whitespace-payload guidance row never renders (payload guards)', async () => {
+    // Defense-in-depth: even a row that carries semantic_type=guidance,
+    // connection_id NULL, and a whitespace-only payload_text (not a NULL, so it
+    // slips past the SQL `IS NOT NULL` filter) must be dropped by the trim
+    // guard in loadOrgGuidanceBlock — no blank block, no dangling title.
+    const emptyOrg = await createTestOrganization({ name: 'Empty Payload Org' });
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO events (
+        entity_ids, origin_id, title, payload_type, payload_text,
+        semantic_type, connection_id, organization_id, created_at
+      ) VALUES (
+        '{}'::bigint[], ${'empty-guidance-1'}, ${'Blank'}, 'text', ${'   \n  '},
+        ${GUIDANCE_SEMANTIC_TYPE}, NULL, ${emptyOrg.id}, NOW()
+      )
+    `;
+
+    expect(await loadOrgGuidanceBlock(emptyOrg.id)).toBeNull();
+    const out = await buildWorkspaceInstructions(emptyOrg.id);
+    expect(out).not.toContain('### Organization Context');
+    expect(out).not.toContain('Blank');
+  });
+
+  it('rejects a member superseding admin guidance with a non-guidance kind', async () => {
+    // The removal path: authorship is admin-gated, so a member must not be able
+    // to erase guidance by superseding it with a permitted kind (e.g. note).
+    const guarded = (await saveContent(
+      { content: 'Protected org context.', semantic_type: GUIDANCE_SEMANTIC_TYPE, metadata: {} } as never,
+      env,
+      ownerCtx
+    )) as { id: number };
+
+    await expect(
+      saveContent(
+        {
+          content: 'member overwrite attempt',
+          semantic_type: 'note',
+          metadata: {},
+          supersedes_event_id: guarded.id,
+        } as never,
+        env,
+        memberCtx
+      )
+    ).rejects.toThrow(/only organization owners\/admins/i);
+
+    // Still present, still injected.
+    expect(await loadOrgGuidanceBlock(org.id)).toContain('Protected org context.');
+  });
+
+  it('rejects a member deleting admin guidance', async () => {
+    const guarded = (await saveContent(
+      { content: 'Do not delete me.', semantic_type: GUIDANCE_SEMANTIC_TYPE, metadata: {} } as never,
+      env,
+      ownerCtx
+    )) as { id: number };
+
+    await expect(
+      deleteContent({ event_id: guarded.id } as never, env, memberCtx)
+    ).rejects.toThrow(/only organization owners\/admins/i);
+
+    expect(await loadOrgGuidanceBlock(org.id)).toContain('Do not delete me.');
+  });
+
+  it('accepts an admin (not just owner) author', async () => {
+    const admin = await createTestUser({ name: 'Admin' });
+    await addUserToOrganization(admin.id, org.id, 'admin');
+    const adminCtx: ToolContext = { ...ownerToolContext(org.id, admin.id), memberRole: 'admin' };
+    const saved = (await saveContent(
+      { content: 'Admins may also author org context.', semantic_type: GUIDANCE_SEMANTIC_TYPE, metadata: {} } as never,
+      env,
+      adminCtx
+    )) as { id: number };
+    expect(saved.id).toBeGreaterThan(0);
+  });
+
+  it('does NOT inject connector-sourced guidance events', async () => {
+    const conn = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'shop.sync2',
+    });
+    await createTestEvent({
+      organization_id: org.id,
+      connection_id: conn.id,
+      semantic_type: GUIDANCE_SEMANTIC_TYPE,
+      content: 'connector smuggled context',
+    });
+
+    const out = await buildWorkspaceInstructions(org.id);
+    expect(out).not.toContain('connector smuggled context');
+  });
+
+  it('does NOT inject webhook-ingested guidance (connector_key set, connection_id NULL)', async () => {
+    // webhook-ingest.ts writes connector_key='webhook:<id>' with a NULL
+    // connection_id and a caller-configurable semantic_type. `connection_id IS
+    // NULL` alone is NOT proof of admin authorship — the connector_key fence
+    // must also exclude it, or a webhook token holder injects org-wide prompt text.
+    const webhookOrg = await createTestOrganization({ name: 'Webhook Org' });
+    const sql = getTestDb();
+    await sql`
+      INSERT INTO events (
+        entity_ids, origin_id, title, payload_type, payload_text,
+        semantic_type, connection_id, connector_key, organization_id, created_at
+      ) VALUES (
+        '{}'::bigint[], ${'wh-guidance-1'}, ${'Injected'}, 'text',
+        ${'webhook injected org context'}, ${GUIDANCE_SEMANTIC_TYPE},
+        NULL, ${'webhook:9999'}, ${webhookOrg.id}, NOW()
+      )
+    `;
+
+    expect(await loadOrgGuidanceBlock(webhookOrg.id)).toBeNull();
+    const out = await buildWorkspaceInstructions(webhookOrg.id);
+    expect(out).not.toContain('webhook injected org context');
+    expect(out).not.toContain('### Organization Context');
+  });
+
+  it('rejects non-text and empty-content guidance authorship', async () => {
+    await expect(
+      saveContent(
+        {
+          content: 'x',
+          semantic_type: GUIDANCE_SEMANTIC_TYPE,
+          payload_type: 'json_template',
+          payload_template: { kind: 'text', text: 'x' },
+          metadata: {},
+        } as never,
+        env,
+        ownerCtx
+      )
+    ).rejects.toThrow(/'text' or 'markdown'/i);
+
+    await expect(
+      saveContent(
+        { content: '   ', semantic_type: GUIDANCE_SEMANTIC_TYPE, metadata: {} } as never,
+        env,
+        ownerCtx
+      )
+    ).rejects.toThrow(/non-empty content/i);
+  });
+
+  it('caps total injected guidance chars deterministically', async () => {
+    // Use a fresh org so the cap math is exact.
+    const capOrg = await createTestOrganization({ name: 'Cap Org' });
+    const owner = await createTestUser({ name: 'Cap Owner' });
+    await addUserToOrganization(owner.id, capOrg.id, 'owner');
+    const ctx = ownerToolContext(capOrg.id, owner.id);
+
+    for (const marker of ['ALPHA', 'BRAVO', 'CHARLIE', 'DELTA']) {
+      await saveContent(
+        {
+          content: `${marker} ${'x'.repeat(1200)}`,
+          semantic_type: GUIDANCE_SEMANTIC_TYPE,
+          metadata: {},
+        } as never,
+        env,
+        ctx
+      );
+    }
+
+    const out = await buildWorkspaceInstructions(capOrg.id);
+    expect(out).toContain('ALPHA');
+    expect(out).toContain('BRAVO');
+    // 4 x ~1206 chars > 3000: the tail must be cut and marked.
+    expect(out).toContain(ORG_GUIDANCE_TRUNCATION_MARKER.trim());
+    expect(out).not.toContain('DELTA');
+
+    // The rendered guidance block (body + marker) stays WITHIN the declared cap
+    // — the marker length is reserved, not appended past the budget.
+    const block = await loadOrgGuidanceBlock(capOrg.id);
+    expect(block).not.toBeNull();
+    expect(block!.length).toBeLessThanOrEqual(ORG_GUIDANCE_CHAR_BUDGET);
+    expect(block!.endsWith(ORG_GUIDANCE_TRUNCATION_MARKER)).toBe(true);
+    // Exactly one marker (no partial + duplicate).
+    expect(block!.split(ORG_GUIDANCE_TRUNCATION_MARKER.trim()).length).toBe(2);
+
+    // Deterministic: two builds render the identical block.
+    const out2 = await buildWorkspaceInstructions(capOrg.id);
+    expect(out2).toBe(out);
+  });
+
+  it('marks row-cap omission without exceeding the char cap or double-marking', async () => {
+    // Many tiny guidance rows: under the char budget individually but over the
+    // 100-row cap. Exercises the row-limit path — one marker, still within cap.
+    const rowOrg = await createTestOrganization({ name: 'Row Cap Org' });
+    const owner = await createTestUser({ name: 'Row Owner' });
+    await addUserToOrganization(owner.id, rowOrg.id, 'owner');
+    const ctx = ownerToolContext(rowOrg.id, owner.id);
+
+    // 120 rows of ~5 chars each ≈ 600 chars total — well under 3000, but > 100 rows.
+    for (let i = 0; i < 120; i++) {
+      await saveContent(
+        { content: `g${i}`, semantic_type: GUIDANCE_SEMANTIC_TYPE, metadata: {} } as never,
+        env,
+        ctx
+      );
+    }
+
+    const block = await loadOrgGuidanceBlock(rowOrg.id);
+    expect(block).not.toBeNull();
+    expect(block!.length).toBeLessThanOrEqual(ORG_GUIDANCE_CHAR_BUDGET);
+    expect(block!.endsWith(ORG_GUIDANCE_TRUNCATION_MARKER)).toBe(true);
+    expect(block!.split(ORG_GUIDANCE_TRUNCATION_MARKER.trim()).length).toBe(2);
+  });
+});

--- a/packages/server/src/gateway/__tests__/instruction-service.test.ts
+++ b/packages/server/src/gateway/__tests__/instruction-service.test.ts
@@ -1,6 +1,8 @@
 import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { getDb } from "../../db/client.js";
 import { createPostgresAgentConfigStore } from "../../lobu/stores/postgres-stores.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
+import { GUIDANCE_SEMANTIC_TYPE } from "../../utils/org-guidance.js";
 import { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import { InstructionService } from "../services/instruction-service.js";
 import {
@@ -8,6 +10,25 @@ import {
   resetTestDatabase,
   seedAgentRow,
 } from "./helpers/db-setup.js";
+
+/** Insert a minimal org-authored guidance event (the shape save_memory writes). */
+async function seedGuidanceEvent(
+  organizationId: string,
+  text: string
+): Promise<number> {
+  const sql = getDb();
+  const [row] = await sql`
+    INSERT INTO events (
+      entity_ids, organization_id, origin_id, payload_type, payload_text,
+      semantic_type, occurred_at
+    ) VALUES (
+      NULL, ${organizationId}, ${`uc_${crypto.randomUUID()}`}, 'text', ${text},
+      ${GUIDANCE_SEMANTIC_TYPE}, NOW()
+    )
+    RETURNING id
+  `;
+  return Number(row.id);
+}
 
 describe("InstructionService", () => {
   let store: AgentSettingsStore;
@@ -75,5 +96,27 @@ describe("InstructionService", () => {
     // org-b's identity resolved — not org-a's (the unscoped-read bug).
     expect(ctxB.agentInstructions).toContain("I am the ORG-B builder.");
     expect(ctxB.agentInstructions).not.toContain("I am the ORG-A builder.");
+  });
+
+  test("does NOT inject org guidance into agentInstructions (delivered via lobu-memory MCP, not duplicated)", async () => {
+    // Single source of truth: guidance reaches the worker prompt through the
+    // lobu-memory MCP server's instructions (buildWorkspaceInstructions renders
+    // the "Organization Context" section). Injecting it into agentInstructions
+    // here too — under the same org-scope gate — would duplicate it in the
+    // prompt. This test pins that the session-context path stays out of it.
+    await seedAgentRow("agent-guided", { organizationId: "org-a" });
+    await seedGuidanceEvent("org-a", "Fiscal year starts in February.");
+
+    const ctxA = await service.getSessionContext("telegram", {
+      agentId: "agent-guided",
+      organizationId: "org-a",
+      userId: "user-1",
+      workingDirectory: "/workspace/thread-1",
+    } as any);
+
+    expect(ctxA.agentInstructions).not.toContain("## Organization Context");
+    expect(ctxA.agentInstructions).not.toContain(
+      "Fiscal year starts in February."
+    );
   });
 });

--- a/packages/server/src/gateway/services/instruction-service.ts
+++ b/packages/server/src/gateway/services/instruction-service.ts
@@ -321,6 +321,14 @@ export class InstructionService {
       }
     }
 
+    // NOTE: org-wide `guidance` is NOT injected here. Workers receive it
+    // through the mandatory `lobu-memory` MCP server's instructions
+    // (buildWorkspaceInstructions renders the "Organization Context" section),
+    // which the worker folds into its prompt as MCP server instructions. Both
+    // that server and this injection are gated by the same org-scope condition,
+    // so injecting here too would place identical guidance in the prompt twice.
+    // buildWorkspaceInstructions is the single render site for both surfaces.
+
     // Get skills instructions (includes enabled skills from agent settings)
     let skillsInstructions = "";
     try {

--- a/packages/server/src/tools/delete_content.ts
+++ b/packages/server/src/tools/delete_content.ts
@@ -23,6 +23,7 @@ import { getDb, pgBigintArray } from '../db/client';
 import type { Env } from '../index';
 import { insertEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
+import { assertCanRemoveGuidance } from '../utils/org-guidance';
 import { isSystemContext } from './access-control';
 import { TOMBSTONE_SEMANTIC_TYPE } from './constants';
 import type { ToolContext } from './registry';
@@ -105,6 +106,12 @@ async function deleteContentImpl(
   const alreadySupersededSet = new Set(alreadySupersededIds);
 
   const targetIds = candidateIds.filter((id) => !alreadySupersededSet.has(id));
+
+  // Deleting a `guidance` target tombstones it out of every agent prompt — the
+  // same removal that supersede performs. Authorship is admin-gated (and rejects
+  // system contexts), so removal is too: a watcher/automation must not be able
+  // to erase admin org-context either. memberRole is owner/admin only.
+  await assertCanRemoveGuidance(ctx.organizationId, targetIds, ctx.memberRole);
 
   const tombstoneIds: number[] = [];
   for (const targetId of targetIds) {

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -18,6 +18,11 @@ import { ToolUserError } from '../utils/errors';
 import { validateSaveContentSemanticType } from '../utils/event-kind-validation';
 import { insertEvent } from '../utils/insert-event';
 import logger from '../utils/logger';
+import {
+  assertCanAuthorGuidance,
+  assertCanRemoveGuidance,
+  GUIDANCE_SEMANTIC_TYPE,
+} from '../utils/org-guidance';
 import { ensureMemberEntityType } from '../utils/member-entity-type';
 import { requireWriteAccess } from '../utils/organization-access';
 import { trackWatcherReaction } from '../utils/watcher-reactions';
@@ -183,7 +188,36 @@ async function saveContentImpl(
   const semanticType = args.semantic_type;
   if (!semanticType) throw new ToolUserError('semantic_type is required');
 
+  // `guidance` is the built-in org-wide context kind: current guidance events
+  // are injected into EVERY agent's system prompt (workspace instructions +
+  // worker session context), which makes authorship a prompt-injection
+  // surface. Fail closed: only org owners/admins may author it — system
+  // contexts (watcher reactions, memberRole=null) and plain members are
+  // rejected. This is the single choke point for both the MCP tool and the
+  // SDK delegate (`client.knowledge.save`).
+  const isOrgGuidance = semanticType === GUIDANCE_SEMANTIC_TYPE;
+  assertCanAuthorGuidance(semanticType, ctx.memberRole);
+
   const payloadType = args.payload_type ?? 'text';
+
+  // Guidance renders from `payload_text` only (loadOrgGuidanceBlock), so a
+  // media/json_template/empty guidance event would save yet render as nothing.
+  // Constrain authorship to non-whitespace text/markdown rather than silently
+  // storing an un-renderable row.
+  if (isOrgGuidance) {
+    if (payloadType !== 'text' && payloadType !== 'markdown') {
+      throw new ToolUserError(
+        `semantic_type '${GUIDANCE_SEMANTIC_TYPE}' requires payload_type 'text' or 'markdown'.`,
+        422
+      );
+    }
+    if (!args.content || !args.content.trim()) {
+      throw new ToolUserError(
+        `semantic_type '${GUIDANCE_SEMANTIC_TYPE}' requires non-empty content.`,
+        422
+      );
+    }
+  }
 
   // Validate content requirement based on payload_type
   if ((payloadType === 'text' || payloadType === 'markdown') && !args.content) {
@@ -198,15 +232,23 @@ async function saveContentImpl(
     await requireWriteAccess(sql, eid, ctx);
   }
 
-  // 2. Validate semantic_type against $member.event_kinds + entity type event_kinds
-  const kindValidation = await validateSaveContentSemanticType(
-    semanticType,
-    args.metadata,
-    ctx.organizationId,
-    entityIds.length > 0 ? entityIds : undefined
-  );
-  if (!kindValidation.valid) {
-    throw new ToolUserError(kindValidation.errors.join('\n'), 422);
+  // 2. Validate semantic_type against $member.event_kinds + entity type event_kinds.
+  //    `guidance` skips this: it is a code-level built-in kind (org-anchored,
+  //    not declared in the $member/entity event_kinds registries — its
+  //    long-term registry home is a `$org` singleton entity type mirroring
+  //    $member, not built yet). Guidance events may still carry entity anchors
+  //    in entity_ids; type-level guidance is deliberately NOT modeled via this
+  //    kind (entity-type/field `description` columns carry that instead).
+  if (!isOrgGuidance) {
+    const kindValidation = await validateSaveContentSemanticType(
+      semanticType,
+      args.metadata,
+      ctx.organizationId,
+      entityIds.length > 0 ? entityIds : undefined
+    );
+    if (!kindValidation.valid) {
+      throw new ToolUserError(kindValidation.errors.join('\n'), 422);
+    }
   }
 
   // 3. Validate event metadata against entity type's event kind schema (if entity-associated)
@@ -304,6 +346,15 @@ async function saveContentImpl(
 
   // 5. Validate supersedes target exists and belongs to this org
   if (args.supersedes_event_id) {
+    // Superseding a `guidance` target stamps its superseded_by, removing it
+    // from every prompt — the same effect as delete_knowledge. Authorship is
+    // admin-gated, so removal must be too, regardless of the NEW row's kind
+    // (a member could otherwise erase guidance by superseding it with a note).
+    await assertCanRemoveGuidance(
+      ctx.organizationId,
+      [args.supersedes_event_id],
+      ctx.memberRole
+    );
     const existing = await sql`
       SELECT id FROM events
       WHERE id = ${args.supersedes_event_id}

--- a/packages/server/src/utils/org-guidance.ts
+++ b/packages/server/src/utils/org-guidance.ts
@@ -1,0 +1,156 @@
+/**
+ * Org-wide guidance: admin-authored context injected into every agent prompt.
+ *
+ * `guidance` is a built-in, code-level event kind (not declared in any
+ * entity type's `event_kinds` registry): current, non-superseded `guidance`
+ * events for an org render as an "Organization Context" section via the single
+ * site `buildWorkspaceInstructions`. That block is the lobu-memory MCP server's
+ * instructions, which reach BOTH surfaces from one render: the MCP client
+ * directly, and the agent-worker prompt (the worker folds MCP server
+ * instructions into its context). It is deliberately NOT re-injected in
+ * InstructionService — that would duplicate it in the worker prompt.
+ *
+ * Design notes:
+ * - Anchoring: injection selects by organization_id + semantic_type only. A
+ *   guidance event may carry entity anchors, but entity-scoped delivery is a
+ *   later refinement (the kind's eventual registry home is a `$org` singleton
+ *   type, not built). Type/field context is out of scope here — it lives in the
+ *   entity-type/relationship/field `description` columns the renderer surfaces.
+ * - Security: this lands in EVERY agent's system prompt, so both authorship and
+ *   removal are owner/admin-gated (assertCanAuthorGuidance /
+ *   assertCanRemoveGuidance — the latter covers supersede + delete, which mask
+ *   guidance via superseded_by). Rows with a connection_id OR connector_key are
+ *   excluded (provenance fence) so no connector/webhook can smuggle in org-wide
+ *   text — connection_id alone is not proof of admin authorship.
+ * - Cache doctrine: part of the cached system prompt, mutating only on explicit
+ *   admin edit, so it counts as stable data. Rendering is deterministic: stable
+ *   order (event id ASC), no timestamps/counts, hard char cap + row cap with
+ *   deterministic truncation markers.
+ */
+
+import { getDb, pgBigintArray } from '../db/client';
+import { ToolUserError } from './errors';
+
+export const GUIDANCE_SEMANTIC_TYPE = 'guidance';
+
+/** A member role that may author or mutate org-wide guidance. */
+function isGuidanceAuthor(memberRole: string | null | undefined): boolean {
+  return memberRole === 'owner' || memberRole === 'admin';
+}
+
+/**
+ * Fail closed if a non-owner/admin tries to author `guidance`. Authoring
+ * lands text in EVERY agent's system prompt — a prompt-injection surface.
+ */
+export function assertCanAuthorGuidance(
+  semanticType: string,
+  memberRole: string | null | undefined
+): void {
+  if (semanticType === GUIDANCE_SEMANTIC_TYPE && !isGuidanceAuthor(memberRole)) {
+    throw new ToolUserError(
+      `semantic_type '${GUIDANCE_SEMANTIC_TYPE}' is organization-wide context injected into every agent's prompt; only organization owners/admins can save it.`,
+      403
+    );
+  }
+}
+
+/**
+ * Fail closed if a non-owner/admin tries to REMOVE org guidance from prompts by
+ * superseding/tombstoning it. Guidance is masked by `superseded_by`, so any
+ * write that stamps that edge on a guidance target — a supersede with a
+ * different (permitted) kind, or a delete_knowledge tombstone — would silently
+ * erase admin context from every agent. Authorship is admin-gated; removal must
+ * be too. `targetIds` are event ids whose superseded_by this op would stamp.
+ */
+export async function assertCanRemoveGuidance(
+  organizationId: string,
+  targetIds: number[],
+  memberRole: string | null | undefined
+): Promise<void> {
+  if (targetIds.length === 0 || isGuidanceAuthor(memberRole)) return;
+  const sql = getDb();
+  const guarded = await sql<{ id: number }>`
+    SELECT id FROM events
+    WHERE id = ANY(${pgBigintArray(targetIds)}::bigint[])
+      AND organization_id = ${organizationId}
+      AND semantic_type = ${GUIDANCE_SEMANTIC_TYPE}
+    LIMIT 1
+  `;
+  if (guarded.length > 0) {
+    throw new ToolUserError(
+      `Cannot supersede or delete organization-wide '${GUIDANCE_SEMANTIC_TYPE}' context; only organization owners/admins can change it.`,
+      403
+    );
+  }
+}
+
+/** Hard cap on total injected guidance characters (per org, per prompt). */
+export const ORG_GUIDANCE_CHAR_BUDGET = 3000;
+
+export const ORG_GUIDANCE_TRUNCATION_MARKER =
+  '\n[additional organization context truncated — consolidate guidance events]';
+
+/** Row-count bound so the query stays cheap; the char budget governs output. */
+const ORG_GUIDANCE_ROW_LIMIT = 100;
+
+/**
+ * Render the current org guidance as a prompt-ready text block (no heading),
+ * or null when the org has none. Deterministic for a given events state.
+ */
+export async function loadOrgGuidanceBlock(organizationId: string): Promise<string | null> {
+  const sql = getDb();
+
+  // Read the canonical masking view (superseded_by IS NULL) rather than
+  // re-implementing the anti-join — same tombstone parity as query_sql. The
+  // view exposes id/title/payload_text/organization_id/semantic_type/
+  // connection_id/connector_key, so the guidance filters apply unchanged.
+  // Fetch one row past the cap so we can mark (not silently drop) an
+  // over-limit org's tail.
+  //
+  // Provenance fence: only admin-authored rows may render. save_content leaves
+  // both connection_id AND connector_key NULL; every connector/webhook path
+  // stamps at least one — a webhook writes connector_key='webhook:<id>' with a
+  // NULL connection_id (webhook-ingest.ts) and its semantic_type is
+  // caller-configurable, so `connection_id IS NULL` alone is NOT proof of admin
+  // authorship. Require BOTH to be NULL, or a webhook token holder could inject
+  // arbitrary text into every agent's system prompt by labeling deliveries
+  // `guidance`.
+  const rows = await sql`
+    SELECT e.id, e.title, e.payload_text
+    FROM current_event_records e
+    WHERE e.organization_id = ${organizationId}
+      AND e.semantic_type = ${GUIDANCE_SEMANTIC_TYPE}
+      AND e.connection_id IS NULL
+      AND e.connector_key IS NULL
+      AND e.payload_text IS NOT NULL
+    ORDER BY e.id ASC
+    LIMIT ${ORG_GUIDANCE_ROW_LIMIT + 1}
+  `;
+
+  if (rows.length === 0) return null;
+
+  const rowsOmittedByCount = rows.length > ORG_GUIDANCE_ROW_LIMIT;
+  const capped = rowsOmittedByCount ? rows.slice(0, ORG_GUIDANCE_ROW_LIMIT) : rows;
+
+  const blocks: string[] = [];
+  for (const row of capped) {
+    const text = String(row.payload_text).trim();
+    if (!text) continue;
+    const title = typeof row.title === 'string' ? row.title.trim() : '';
+    blocks.push(title ? `**${title}**\n${text}` : text);
+  }
+  if (blocks.length === 0) return null;
+
+  const body = blocks.join('\n\n');
+
+  // Truncate so the FINAL block (body + marker) stays within the declared cap —
+  // reserve the marker's length before slicing rather than appending past it.
+  // A single marker signals omission from either cause (char budget OR row cap).
+  const overBudget = body.length > ORG_GUIDANCE_CHAR_BUDGET;
+  if (overBudget || rowsOmittedByCount) {
+    const keep = ORG_GUIDANCE_CHAR_BUDGET - ORG_GUIDANCE_TRUNCATION_MARKER.length;
+    const head = overBudget ? body.slice(0, Math.max(0, keep)) : body;
+    return head + ORG_GUIDANCE_TRUNCATION_MARKER;
+  }
+  return body;
+}

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -8,6 +8,37 @@
 
 import { getDb } from '../db/client';
 import logger from './logger';
+import { loadOrgGuidanceBlock } from './org-guidance';
+
+/** Collapse whitespace/newlines so an authored description stays one line. */
+function singleLine(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
+}
+
+/**
+ * Render a metadata schema's fields as a compact `name (description)` list.
+ * Accepts both a real JSON Schema (descends into `.properties` — the old
+ * render printed the envelope keys "type, properties" instead) and a legacy
+ * bare field map. Field descriptions are authored schema — surface them.
+ */
+function renderSchemaFields(schema: unknown): string {
+  if (!schema || typeof schema !== 'object') return '';
+  const s = schema as Record<string, unknown>;
+  let props: Record<string, unknown> | null = null;
+  if (s.properties && typeof s.properties === 'object' && !Array.isArray(s.properties)) {
+    props = s.properties as Record<string, unknown>;
+  } else if (typeof s.type !== 'string') {
+    // Legacy shape: the schema IS the field map.
+    props = s;
+  }
+  if (!props) return '';
+  return Object.entries(props)
+    .map(([field, def]) => {
+      const desc = singleLine((def as Record<string, unknown> | null)?.description);
+      return desc ? `${field} (${desc})` : field;
+    })
+    .join(', ');
+}
 
 export async function buildWorkspaceInstructions(organizationId: string): Promise<string | null> {
   const sql = getDb();
@@ -17,17 +48,18 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
     // of the cached system prompt, and live counts would mutate it on every
     // memory write, busting the prompt cache (and all downstream message
     // history) on each context refresh. Only stable schema belongs here; the
-    // agent gets live counts from tool calls at runtime.
-    const [entityTypeRows, relationshipTypes] = await Promise.all([
+    // agent gets live counts from tool calls at runtime. (Org guidance below
+    // also qualifies: admin-authored text that only mutates on explicit edit.)
+    const [entityTypeRows, relationshipTypes, orgGuidance] = await Promise.all([
       sql.unsafe(
-        `SELECT slug, name, metadata_schema, event_kinds FROM entity_types
+        `SELECT slug, name, description, metadata_schema, event_kinds FROM entity_types
          WHERE deleted_at IS NULL
            AND organization_id = $1
          ORDER BY name ASC`,
         [organizationId]
       ),
       sql.unsafe(
-        `SELECT rt.slug, rt.name, rt.is_symmetric, inv.slug as inverse_type_slug
+        `SELECT rt.slug, rt.name, rt.description, rt.is_symmetric, inv.slug as inverse_type_slug
          FROM entity_relationship_types rt
          LEFT JOIN entity_relationship_types inv ON rt.inverse_type_id = inv.id
          WHERE rt.status = 'active'
@@ -36,11 +68,13 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
          ORDER BY rt.name ASC`,
         [organizationId]
       ),
+      loadOrgGuidanceBlock(organizationId),
     ]);
 
     const entityTypeLines = entityTypeRows.map((et: any) => {
-      const fields = et.metadata_schema ? Object.keys(et.metadata_schema).join(', ') : '';
-      return `- ${et.slug} ("${et.name}")${fields ? ` — fields: ${fields}` : ''}`;
+      const desc = singleLine(et.description);
+      const fields = renderSchemaFields(et.metadata_schema);
+      return `- ${et.slug} ("${et.name}")${desc ? ` — ${desc}` : ''}${fields ? ` — fields: ${fields}` : ''}`;
     });
 
     const emittedRelSlugs = new Set<string>();
@@ -54,7 +88,8 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       if (rt.is_symmetric) parts.push('symmetric');
       if (inverseSlug) parts.push(`inverse: ${inverseSlug}`);
       const meta = parts.length > 0 ? ` (${parts.join(', ')})` : '';
-      relTypeLines.push(`- ${slug}${meta}`);
+      const desc = singleLine(rt.description);
+      relTypeLines.push(`- ${slug}${meta}${desc ? ` — ${desc}` : ''}`);
     }
 
     // Assemble
@@ -63,6 +98,17 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       '',
       "You have persistent memory. Use it proactively — don't wait to be asked.",
     ];
+
+    // Org-wide admin-authored context goes near the top: it is the governed
+    // "why" that frames everything below (schema, tools, saving rules).
+    if (orgGuidance) {
+      sections.push(
+        '',
+        '### Organization Context',
+        'Org-wide guidance authored by workspace admins (event kind `guidance`; admins edit it via save_memory with supersedes_event_id).',
+        orgGuidance
+      );
+    }
 
     if (entityTypeLines.length > 0) {
       sections.push('', '### Schema: Entity Types', ...entityTypeLines);
@@ -104,6 +150,7 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
       SELECT DISTINCT ON (cd.key)
         cd.key,
         cd.name,
+        cd.description,
         cd.actions_schema,
         cd.mcp_config,
         cd.openapi_config
@@ -145,7 +192,8 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
           localOps.length > 0
             ? localOps.join(', ')
             : 'operations via `manage_operations.list_available`';
-        sections.push(`- ${conn.key}: ${detail}`);
+        const desc = singleLine(conn.description);
+        sections.push(`- ${conn.key}${desc ? ` (${desc})` : ''}: ${detail}`);
       }
     }
 


### PR DESCRIPTION
## What & why

Two related things: fix four workspace-instruction render bugs where authored schema text was **stored but silently dropped at render time**, and add an org-wide `guidance` event kind whose current events are rendered into agent system prompts.

### Render fixes (data was already stored, dropped at render)
`buildWorkspaceInstructions` was throwing away authored columns:
- `entity_types.description` — now renders on each type line.
- Per-field descriptions from `metadata_schema.properties[field].description` — now render as `name (description)`. A real JSON Schema previously rendered its envelope keys (`fields: type, properties`) because the old code did `Object.keys(metadata_schema)`; `renderSchemaFields` now descends into `.properties` and still handles legacy bare field-map schemas.
- `entity_relationship_types.description` — now renders on each relationship line.
- `connector_definitions.description` — now renders on each connector-ops line.

### `guidance`: org-wide context, one render site → both prompt paths
A new built-in, code-level event kind. Current, non-superseded `guidance` events for an org render as an **"Organization Context"** section via the single site `buildWorkspaceInstructions`. That block is the **lobu-memory MCP server's instructions**, which reach both surfaces from one render: the MCP client directly, and the agent-worker prompt (the worker folds MCP server instructions into its context). It is deliberately **not** re-injected in `InstructionService` — that path and lobu-memory share the same org-scope gate, so a second injection would duplicate guidance in the worker prompt.

`loadOrgGuidanceBlock` reads the canonical `current_event_records` view (`superseded_by IS NULL`) rather than re-implementing the supersession anti-join — same tombstone parity as `query_sql`. Rendering is deterministic: stable order (event id ASC), no timestamps/counts, hard char cap + row cap with deterministic truncation markers.

### Authorship AND removal are admin-only (prompt-injection surface)
Whatever this renders lands in **every** agent's system prompt.
- **Authorship** (`assertCanAuthorGuidance`): only org owners/admins may author `guidance`; system contexts and plain members are rejected at the single save choke point (MCP tool + SDK delegate). Constrained to non-whitespace text/markdown (a media/json_template/empty guidance would save yet render as nothing).
- **Removal** (`assertCanRemoveGuidance`): a member must not erase admin guidance by superseding it with a permitted kind (which stamps `superseded_by` and drops it from every prompt) or by deleting it via `delete_knowledge` — both owner/admin-only, system contexts included.
- **Provenance fence**: the render query requires **both** `connection_id IS NULL` **and** `connector_key IS NULL`. `connection_id` alone is not proof of admin authorship — `webhook-ingest` writes `connector_key='webhook:<id>'` with a NULL `connection_id` and a caller-configurable `semantic_type`, so a webhook token holder could otherwise inject org-wide prompt text by labeling deliveries `guidance`.

### Design: events, not a column; `$org` future
Guidance is anchored by events (`organization_id` + `semantic_type`), not a dedicated column. It may carry entity anchors, but entity-scoped delivery is a later refinement. `guidance` deliberately **skips** the `$member`/entity `event_kinds` registry validation because it is a code-level built-in — its long-term registry home is a `$org` singleton entity type mirroring `$member` (not built yet). Type-level context stays in the entity-type/field/relationship `description` columns, not this kind.

### Cache doctrine
Guidance is part of the cached system prompt and only mutates on an explicit admin edit (save/supersede/delete), so it qualifies as stable data alongside schema — no live counts, which would bust the prompt cache and all downstream message history.

## Tests
- `workspace-instructions.test.ts` (new, 17 tests): all four render fixes, guidance injection near the top, supersede-replaces, tombstone/delete does NOT render a blank block, empty/whitespace-payload row never renders, connector-sourced excluded, webhook-shaped (connector_key set, connection_id NULL) excluded, non-text/empty authorship rejected, char cap, member cannot supersede-with-note or delete admin guidance, admin (not just owner) accepted.
- `instruction-service.test.ts`: pins that the session-context path does NOT inject guidance into `agentInstructions` (single source of truth; delivered via lobu-memory MCP, not duplicated).

## Sample rendered block

```
### Organization Context
Org-wide guidance authored by workspace admins (event kind `guidance`; admins edit it via save_memory with supersedes_event_id).
**Fiscal year**
Our fiscal year starts in February; Q1 targets are set then.

All revenue amounts are reported in EUR unless a metric says otherwise.

### Schema: Entity Types
- product ("Product") — Products we track for resale — fields: url (Canonical product URL), status
```
