### PR TITLE
feat(connectors): cloud egress hardening for DB connectors — IP pinning + forced TLS; open postgres cloud gate

### DIFF
--- a/docs/database-connectors.md
+++ b/docs/database-connectors.md
@@ -71,17 +71,19 @@ scrapers' block-all-private-IPs rule can't be reused.
 - **Self-hosted / first-party:** `DATABASE_URL` is an operator-set secret — same
   trust boundary as any other env secret. Private IPs allowed. Ships now.
 - **Untrusted multi-tenant cloud:** a tenant-supplied `DATABASE_URL` (metadata
-  IPs, internal CIDRs, another tenant's DB) is an exfil/scan vector. **Not allowed
-  yet.** Under `LOBU_CLOUD_MODE=1` the postgres connector is hidden from the
-  catalog (`LOBU_CATALOG_URIS` / `manage_catalog list_catalog`) and connection-create is hard-blocked
-  (`manage_connections.ts` via `connector-cloud-gate.ts`). Execution is gated
-  independently at every run path, not just by catalog-hide: scheduled-sync run
-  creation (`runs/queue-service.ts`), the production worker poll (`worker-api.ts`), the
-  dev-CLI sync (`feed-sync.ts`), and the live pushdown (`connector-pushdown.ts`)
-  each refuse a cloud-restricted connector under `LOBU_CLOUD_MODE`.
+  IPs, internal CIDRs, another tenant's DB) is an exfil/scan vector. **Allowed,
+  hardened.** Under `LOBU_CLOUD_MODE=1` the server injects the `block-private`
+  egress policy on every run path, which classifies + rejects internal hosts,
+  pins the socket to the validated IP, and forces TLS (below). The
+  `CLOUD_RESTRICTED_CONNECTOR_KEYS` set in `connector-cloud-gate.ts` is now an
+  empty kill-switch, still enforced at connection-create, catalog, scheduled-sync
+  run creation (`runs/queue-service.ts`), the production worker poll
+  (`worker-api.ts`), the dev-CLI sync (`feed-sync.ts`), and the live pushdown
+  (`connector-pushdown.ts`) — future warehouse connectors (Snowflake, BigQuery)
+  sit in it until they ship equivalent hardening.
 
 **Egress guard (`packages/connectors/src/db-egress-guard.ts`).** The connector
-runs a pre-connect host check on both `sync()` and `query()`. Policy comes from
+runs a pre-connect host check on `sync()`, `query()`, and `search()`. Policy comes from
 `ctx.config.LOBU_DB_EGRESS_POLICY`, injected by the server from cloud mode:
 
 - `allow-private` (self-hosted, the default) — allows loopback / RFC1918 / CGNAT
@@ -90,13 +92,26 @@ runs a pre-connect host check on both `sync()` and `query()`. Policy comes from
 - `block-private` (cloud) — blocks **every** non-public address. A hostname is
   resolved and rejected if ANY returned address is blocked (multi-record rebind),
   with IPv4-mapped / NAT64 / zone-id normalization and fail-closed on malformed
-  literals.
+  literals. On top of classify-and-reject (`buildDbEgressHardening`):
+  - **Resolve-then-pin:** each hostname is resolved once at guard time and the
+    postgres.js pool gets a custom `socket` factory that dials the validated IP
+    directly — the driver never re-resolves DNS, closing the rebind TOCTOU
+    across pool reconnects. Multi-host failover URLs pin every host and keep the
+    driver's rotation. The TLS `servername` stays the ORIGINAL hostname, so
+    SNI-routed servers (and cert verification, when enabled) see the configured
+    name, not the IP.
+  - **Forced TLS:** the connection is encrypted regardless of URL params.
+    `sslmode=disable` (or `ssl=false`) is rejected with a clear error; absent /
+    `allow` / `prefer` / `require` become `require` (encrypt always);
+    `verify-ca` / `verify-full` pass through untouched. The floor is `require`
+    rather than `verify-full` because tenant DBs commonly present self-signed /
+    private-CA certs — upgrading the floor once per-connection CA upload exists
+    is the noted follow-up.
 
-**Remaining before enabling on cloud** (then remove the key from
-`CLOUD_RESTRICTED_CONNECTOR_KEYS`): pin the resolved IP into the socket to close
-the DNS-rebind TOCTOU across the pool, force TLS when the URL omits it, and a
-per-org allowlist. The classifier + reject is in place and tested; the gate is
-what currently keeps untrusted tenants out.
+**Deferred (explicit follow-up):** a per-org destination allowlist ("this org
+may only reach these DB hosts"). block-private + pin + forced TLS protects the
+platform boundary; an allowlist is an enterprise policy feature layered on top
+later.
 
 ## Entitlement boundary (design-only — not yet built)
 

--- a/packages/connector-worker/src/__tests__/config-egress-precedence.test.ts
+++ b/packages/connector-worker/src/__tests__/config-egress-precedence.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { buildConnectorConfig } from '../executor/child-runner.js';
+
+/**
+ * The trusted gateway sets LOBU_DB_EGRESS_POLICY on job.env. A tenant controls
+ * job.config (connection/feed config). Config-wins is the norm for ordinary
+ * keys, but the egress policy is a security control the tenant must NOT be able
+ * to downgrade (block-private → allow-private would disable private-IP blocking,
+ * IP pinning, and forced TLS). This is the out-of-process worker path that the
+ * in-process feed-sync / pushdown paths already close by injecting last.
+ */
+describe('buildConnectorConfig — gateway egress policy is authoritative', () => {
+  test('tenant config CANNOT override block-private from job.env', () => {
+    const merged = buildConnectorConfig({
+      env: { LOBU_DB_EGRESS_POLICY: 'block-private', WORKER_API_TOKEN: 't' },
+      config: { LOBU_DB_EGRESS_POLICY: 'allow-private', DATABASE_URL: 'postgres://x' },
+    });
+    expect(merged.LOBU_DB_EGRESS_POLICY).toBe('block-private');
+    // Non-authoritative tenant keys still flow through.
+    expect(merged.DATABASE_URL).toBe('postgres://x');
+  });
+
+  test('ordinary keys keep config-wins precedence', () => {
+    const merged = buildConnectorConfig({
+      env: { SOME_KEY: 'from-env' },
+      config: { SOME_KEY: 'from-config' },
+    });
+    expect(merged.SOME_KEY).toBe('from-config');
+  });
+
+  test('self-hosted allow-private from env also wins over tenant config', () => {
+    const merged = buildConnectorConfig({
+      env: { LOBU_DB_EGRESS_POLICY: 'allow-private' },
+      config: { LOBU_DB_EGRESS_POLICY: 'block-private' },
+    });
+    // The env value is authoritative in either direction — the gateway decides
+    // the policy from cloud mode; tenant config never gets a vote.
+    expect(merged.LOBU_DB_EGRESS_POLICY).toBe('allow-private');
+  });
+
+  test('when env does not set the policy, tenant config value is left intact', () => {
+    // In-process paths inject the policy into config (not env); this path must
+    // not clobber a legitimately config-carried policy with an env absence.
+    const merged = buildConnectorConfig({
+      env: {},
+      config: { LOBU_DB_EGRESS_POLICY: 'block-private' },
+    });
+    expect(merged.LOBU_DB_EGRESS_POLICY).toBe('block-private');
+  });
+});

--- a/packages/connector-worker/src/__tests__/gateway-egress-policy.test.ts
+++ b/packages/connector-worker/src/__tests__/gateway-egress-policy.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import type { Env } from '@lobu/connector-sdk';
+import type { PollResponse } from '../daemon/client.js';
+import { resolveEffectiveEnv } from '../daemon/executor.js';
+
+/**
+ * The gateway authoritatively decides the DB egress boundary from ITS cloud
+ * mode and ships it on the poll response's `db_egress_policy`. The out-of-process
+ * connector-worker must fold that decision into `job.env.LOBU_DB_EGRESS_POLICY`
+ * taking the STRICTER of gateway-vs-worker, so:
+ *   - a fleet worker missing LOBU_CLOUD_MODE (env-derived allow-private) STILL
+ *     enforces block-private when the gateway said so — the SSRF guard cannot be
+ *     silently OFF (this is the gap the PR closes);
+ *   - a stale/misconfigured gateway can never DOWNGRADE a worker that already
+ *     decided block-private.
+ */
+describe('resolveEffectiveEnv — gateway egress policy is non-downgradable', () => {
+  const jobWith = (policy?: PollResponse['db_egress_policy']): PollResponse => ({
+    run_id: 1,
+    run_type: 'sync',
+    connector_key: 'postgres',
+    db_egress_policy: policy,
+  });
+
+  test('gateway block-private wins even when the worker env is allow-private (missing LOBU_CLOUD_MODE)', () => {
+    // Reproduces the SSRF gap: worker process has no LOBU_CLOUD_MODE, so its
+    // own env-derived policy is allow-private. Without the gateway fold this
+    // would leave the private-IP guard OFF for a cloud tenant's postgres URL.
+    const workerEnv: Env = { LOBU_DB_EGRESS_POLICY: 'allow-private' };
+    const effective = resolveEffectiveEnv(workerEnv, jobWith('block-private'));
+    expect(effective.LOBU_DB_EGRESS_POLICY).toBe('block-private');
+  });
+
+  test('gateway allow-private cannot downgrade a worker that decided block-private', () => {
+    const workerEnv: Env = { LOBU_DB_EGRESS_POLICY: 'block-private' };
+    const effective = resolveEffectiveEnv(workerEnv, jobWith('allow-private'));
+    expect(effective.LOBU_DB_EGRESS_POLICY).toBe('block-private');
+  });
+
+  test('both allow-private stays allow-private (self-hosted, non-cloud gateway)', () => {
+    const workerEnv: Env = { LOBU_DB_EGRESS_POLICY: 'allow-private' };
+    const effective = resolveEffectiveEnv(workerEnv, jobWith('allow-private'));
+    expect(effective.LOBU_DB_EGRESS_POLICY).toBe('allow-private');
+  });
+
+  test('legacy gateway response (no db_egress_policy) falls back to the worker env-derived default', () => {
+    const workerEnv: Env = { LOBU_DB_EGRESS_POLICY: 'block-private' };
+    const effective = resolveEffectiveEnv(workerEnv, jobWith(undefined));
+    expect(effective.LOBU_DB_EGRESS_POLICY).toBe('block-private');
+  });
+
+  test('gateway block-private applies even when the worker env omits the policy entirely', () => {
+    const workerEnv: Env = {};
+    const effective = resolveEffectiveEnv(workerEnv, jobWith('block-private'));
+    expect(effective.LOBU_DB_EGRESS_POLICY).toBe('block-private');
+  });
+
+  test('preserves other env keys untouched', () => {
+    const workerEnv: Env = { WORKER_API_TOKEN: 't', LOBU_DB_EGRESS_POLICY: 'allow-private' };
+    const effective = resolveEffectiveEnv(workerEnv, jobWith('block-private'));
+    expect(effective.WORKER_API_TOKEN).toBe('t');
+  });
+});

--- a/packages/connector-worker/src/bin.ts
+++ b/packages/connector-worker/src/bin.ts
@@ -128,7 +128,13 @@ async function main(): Promise<void> {
           workerId,
           version,
           workerApiToken: process.env.WORKER_API_TOKEN,
-          capabilities: {},
+          // Advertise DB-egress hardening: this worker folds the gateway's
+          // authoritative `db_egress_policy` into the connector subprocess env
+          // (resolve-then-pin IP, DNS-rebind guard, forced TLS). The gateway
+          // refuses to dispatch db-egress-hardened connector runs (e.g.
+          // postgres) to workers that do NOT advertise this, so an old worker
+          // can never claim one during a rolling deploy.
+          capabilities: { db_egress_hardening: true },
           ...(Number.isFinite(maxConcurrentJobs) ? { maxConcurrentJobs } : {}),
         },
         env

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -79,6 +79,16 @@ export interface PollResponse {
   feed_key?: string;
   /** Feed config */
   config?: Record<string, unknown>;
+  /**
+   * DB egress boundary the GATEWAY authoritatively decided from its own cloud
+   * mode: `'block-private'` (reject internal/metadata hosts, pin the resolved
+   * IP, force TLS) on Lobu Cloud, else `'allow-private'`. The worker installs
+   * this as `job.env.LOBU_DB_EGRESS_POLICY`, taking the STRICTER of gateway vs.
+   * its own env-derived default — a fleet worker missing `LOBU_CLOUD_MODE` can
+   * never downgrade a gateway that said block-private. Absent on legacy gateway
+   * responses; the worker then falls back to its own env-derived default.
+   */
+  db_egress_policy?: 'block-private' | 'allow-private';
   /** Feed checkpoint */
   checkpoint?: Record<string, unknown>;
   /** Entity IDs from feed */

--- a/packages/connector-worker/src/daemon/executor.ts
+++ b/packages/connector-worker/src/daemon/executor.ts
@@ -73,6 +73,33 @@ const DEFAULT_CONFIG: ExecutorConfig = {
 };
 
 /**
+ * Fold the gateway's authoritative DB egress decision into the worker's env.
+ *
+ * The gateway (which knows cloud mode authoritatively) ships `db_egress_policy`
+ * on the poll response. The worker's own `env.LOBU_DB_EGRESS_POLICY` is derived
+ * from the worker process's `LOBU_CLOUD_MODE`, which a fleet worker may not have
+ * set — leaving it `allow-private` and the SSRF guard silently OFF.
+ *
+ * We resolve the STRICTER of the two: `block-private` wins over `allow-private`
+ * from either side. This makes the gateway able to *raise* the boundary (a
+ * block-private gateway forces block-private even on a worker missing the flag)
+ * while never letting a stale/misconfigured gateway response *downgrade* a
+ * worker that already decided block-private. The result is re-asserted as
+ * authoritative `job.env.LOBU_DB_EGRESS_POLICY` by `buildConnectorConfig` in the
+ * child so tenant config can't override it either.
+ */
+export function resolveEffectiveEnv(env: Env, job: PollResponse): Env {
+  const workerPolicy = (env as Record<string, string | undefined>).LOBU_DB_EGRESS_POLICY;
+  const gatewayPolicy = job.db_egress_policy;
+  // block-private is the strict setting; take it if either side asks for it.
+  const effective =
+    workerPolicy === 'block-private' || gatewayPolicy === 'block-private'
+      ? 'block-private'
+      : (gatewayPolicy ?? workerPolicy ?? 'allow-private');
+  return { ...env, LOBU_DB_EGRESS_POLICY: effective };
+}
+
+/**
  * Execute a run (sync, action, or watcher).
  *
  * Dispatches to sync, action, or watcher execution based on run_type.
@@ -80,10 +107,14 @@ const DEFAULT_CONFIG: ExecutorConfig = {
 export async function executeRun(
   client: ExecutorClient,
   job: PollResponse,
-  env: Env,
+  workerEnv: Env,
   config: Partial<ExecutorConfig> = {}
 ): Promise<{ itemsCollected: number; error?: string }> {
   const cfg = { ...DEFAULT_CONFIG, ...config };
+  // Fold the gateway's authoritative egress decision in ONCE here, so every
+  // downstream mode handler (sync/action/auth/embed) gets the same non-
+  // downgradable `LOBU_DB_EGRESS_POLICY`.
+  const env = resolveEffectiveEnv(workerEnv, job);
   switch (job.run_type) {
     case 'action':
       return executeActionRun(client, job, env, cfg);

--- a/packages/connector-worker/src/env.ts
+++ b/packages/connector-worker/src/env.ts
@@ -33,8 +33,14 @@ export function buildConnectorWorkerEnv(): Env {
     REDDIT_CLIENT_SECRET: process.env.REDDIT_CLIENT_SECRET,
     REDDIT_USER_AGENT: process.env.REDDIT_USER_AGENT,
     WORKER_API_TOKEN: process.env.WORKER_API_TOKEN,
-    // DB connectors reject internal/metadata hosts under cloud mode; self-hosted
-    // reaches its own private DB. Delivered to the connector subprocess as config.
+    // WORKER-DERIVED DEFAULT egress policy. The gateway ships its OWN
+    // cloud-mode decision on the poll response (`db_egress_policy`); the daemon's
+    // resolveEffectiveEnv() folds it in and takes the STRICTER of the two, so a
+    // gateway that says block-private raises the floor even if this worker's
+    // LOBU_CLOUD_MODE is unset (which would otherwise leave allow-private and the
+    // SSRF guard OFF). This value is the fallback when the gateway response
+    // predates that field. DB connectors reject internal/metadata hosts under
+    // block-private; self-hosted (allow-private) reaches its own private DB.
     LOBU_DB_EGRESS_POLICY: cloudModeOn() ? 'block-private' : 'allow-private',
   };
 }

--- a/packages/connector-worker/src/executor/child-runner.ts
+++ b/packages/connector-worker/src/executor/child-runner.ts
@@ -20,6 +20,38 @@ interface ChildMessage {
   job: ExecutorJob;
 }
 
+/**
+ * Keys the trusted gateway sets on `job.env` that a tenant's connection/feed
+ * `job.config` must NEVER be able to override. Normal precedence is
+ * config-wins (a connector's config legitimately shadows ambient env), but a
+ * security control injected by the gateway is authoritative. `job.env` is
+ * built by the gateway from cloud mode, `job.config` is tenant-supplied — so
+ * merge config over env, then re-assert these keys from env as last-wins.
+ *
+ * `LOBU_DB_EGRESS_POLICY`: the DB egress boundary (private-IP block + IP pin +
+ * forced TLS). The in-process paths already inject it last into `job.config`
+ * (feed-sync / connector-pushdown); the out-of-process worker delivers it via
+ * `job.env`, and this is where it must beat tenant config.
+ */
+const GATEWAY_AUTHORITATIVE_CONFIG_KEYS = ['LOBU_DB_EGRESS_POLICY'] as const;
+
+/**
+ * Merge the connector's runtime config with config-wins precedence for normal
+ * keys, but force the gateway's authoritative security keys to win. Used at
+ * every executor entry point so a tenant-controlled config cannot downgrade a
+ * gateway-injected control (e.g. flipping block-private → allow-private).
+ */
+export function buildConnectorConfig(job: {
+  env: Record<string, string | undefined>;
+  config: Record<string, unknown>;
+}): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...job.env, ...job.config };
+  for (const key of GATEWAY_AUTHORITATIVE_CONFIG_KEYS) {
+    if (key in job.env && job.env[key] !== undefined) merged[key] = job.env[key];
+  }
+  return merged;
+}
+
 function findRuntimeClass(mod: Record<string, unknown>) {
   const isConnectorRuntimeClass = (val: unknown): val is new () => any =>
     typeof val === 'function' &&
@@ -196,7 +228,7 @@ async function executeConnectorRuntime(
       input: job.actionInput,
       sessionState: sessionStateForAction,
       credentials: job.credentials,
-      config: { ...job.env, ...job.config },
+      config: buildConnectorConfig(job),
     });
 
     if (!actionResult?.success) {
@@ -208,7 +240,7 @@ async function executeConnectorRuntime(
 
   if (job.mode === 'webhook_register') {
     const registration = await instance.registerWebhook({
-      config: { ...job.env, ...job.config },
+      config: buildConnectorConfig(job),
       credentials: job.credentials,
       sessionState: job.sessionState,
       callbackUrl: job.callbackUrl,
@@ -225,7 +257,7 @@ async function executeConnectorRuntime(
 
   if (job.mode === 'webhook_unregister') {
     await instance.unregisterWebhook({
-      config: { ...job.env, ...job.config },
+      config: buildConnectorConfig(job),
       credentials: job.credentials,
       sessionState: job.sessionState,
       externalId: job.externalId,
@@ -238,7 +270,7 @@ async function executeConnectorRuntime(
     const queryResult = await instance.query({
       feedKey: job.feedKey ?? undefined,
       query: job.query,
-      config: { ...job.env, ...job.config },
+      config: buildConnectorConfig(job),
       credentials: job.credentials,
       sessionState: job.sessionState,
       limit: job.limit,
@@ -260,7 +292,7 @@ async function executeConnectorRuntime(
       feedKey: job.feedKey ?? undefined,
       query: job.query,
       terms: job.terms,
-      config: { ...job.env, ...job.config },
+      config: buildConnectorConfig(job),
       credentials: job.credentials,
       sessionState: job.sessionState,
       limit: job.limit,
@@ -306,7 +338,7 @@ async function executeConnectorRuntime(
   const syncResult = (await instance.sync({
     feedKey: job.feedKey,
     feedId: job.feedId,
-    config: { ...job.env, ...job.config },
+    config: buildConnectorConfig(job),
     checkpoint: job.checkpoint,
     credentials: job.credentials,
     entityIds: job.entityIds,

--- a/packages/connectors/src/__tests__/db-egress-guard.test.ts
+++ b/packages/connectors/src/__tests__/db-egress-guard.test.ts
@@ -333,26 +333,6 @@ describe('requiredTlsMode — forced TLS under block-private', () => {
     );
   });
 
-  // postgres.js: `query.sslrootcert === 'system' && (query.ssl = 'verify-full')`
-  // runs LAST and unconditionally — it must not be downgraded to require.
-  test('sslrootcert=system forces verify-full (system CA store)', () => {
-    expect(requiredTlsMode('postgres://u:p@db.example.com/x?sslrootcert=system')).toBe(
-      'verify-full'
-    );
-    // Even alongside a weaker sslmode, the driver forces verify-full.
-    expect(
-      requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=require&sslrootcert=system')
-    ).toBe('verify-full');
-  });
-
-  test('sslrootcert=system overrides even sslmode=disable (driver still verifies)', () => {
-    // postgres.js applies sslrootcert=system after mapping sslmode, so the
-    // effective mode is verify-full, not disabled — do NOT reject as plaintext.
-    expect(
-      requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=disable&sslrootcert=system')
-    ).toBe('verify-full');
-  });
-
   test('sslrootcert other than system does not force verify-full', () => {
     // A non-"system" sslrootcert (e.g. a file path) does not trigger the driver
     // override, so normal sslmode resolution applies.

--- a/packages/connectors/src/__tests__/db-egress-guard.test.ts
+++ b/packages/connectors/src/__tests__/db-egress-guard.test.ts
@@ -283,10 +283,82 @@ describe('requiredTlsMode — forced TLS under block-private', () => {
     );
   });
 
+  // postgres.js applies `sslrootcert=system` LAST and unconditionally forces
+  // ssl=verify-full (connection.js), overriding sslmode. Our returned value is
+  // authoritative in openGuardedPool (explicit ssl beats the URL), so it must
+  // report verify-full too — otherwise a system-CA URL is silently DOWNGRADED
+  // to require, disabling certificate verification (MITM exposure).
+  test('sslrootcert=system forces verify-full (no downgrade to require)', () => {
+    expect(requiredTlsMode('postgres://u:p@db.example.com/x?sslrootcert=system')).toBe(
+      'verify-full'
+    );
+    // sslmode=require alone would resolve to require; sslrootcert=system upgrades it.
+    expect(
+      requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=require&sslrootcert=system')
+    ).toBe('verify-full');
+    // postgres.js applies it even over sslmode=disable, so we must not reject as plaintext.
+    expect(
+      requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=disable&sslrootcert=system')
+    ).toBe('verify-full');
+  });
+
   test('sslmode beats a contradictory ssl param (postgres.js precedence)', () => {
     expect(() =>
       requiredTlsMode('postgres://u:p@db.example.com/x?ssl=require&sslmode=disable')
     ).toThrow(/TLS is required/i);
+  });
+
+  // postgres.js reduces searchParams last-wins on duplicate keys. Reading the
+  // FIRST value would DOWNGRADE the strict TLS the driver actually applies.
+  test('duplicate sslmode: LAST value wins (no TLS downgrade)', () => {
+    // Driver would apply verify-full; we must not report require and downgrade it.
+    expect(
+      requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=require&sslmode=verify-full')
+    ).toBe('verify-full');
+    // Last value require ⇒ require (not a downgrade; both encrypt).
+    expect(
+      requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=verify-full&sslmode=require')
+    ).toBe('require');
+  });
+
+  test('duplicate sslmode: a trailing disable is rejected (matches driver)', () => {
+    expect(() =>
+      requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=require&sslmode=disable')
+    ).toThrow(/TLS is required/i);
+  });
+
+  test('duplicate ssl (no sslmode): LAST value wins', () => {
+    expect(requiredTlsMode('postgres://u:p@db.example.com/x?ssl=require&ssl=verify-full')).toBe(
+      'verify-full'
+    );
+  });
+
+  // postgres.js: `query.sslrootcert === 'system' && (query.ssl = 'verify-full')`
+  // runs LAST and unconditionally — it must not be downgraded to require.
+  test('sslrootcert=system forces verify-full (system CA store)', () => {
+    expect(requiredTlsMode('postgres://u:p@db.example.com/x?sslrootcert=system')).toBe(
+      'verify-full'
+    );
+    // Even alongside a weaker sslmode, the driver forces verify-full.
+    expect(
+      requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=require&sslrootcert=system')
+    ).toBe('verify-full');
+  });
+
+  test('sslrootcert=system overrides even sslmode=disable (driver still verifies)', () => {
+    // postgres.js applies sslrootcert=system after mapping sslmode, so the
+    // effective mode is verify-full, not disabled — do NOT reject as plaintext.
+    expect(
+      requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=disable&sslrootcert=system')
+    ).toBe('verify-full');
+  });
+
+  test('sslrootcert other than system does not force verify-full', () => {
+    // A non-"system" sslrootcert (e.g. a file path) does not trigger the driver
+    // override, so normal sslmode resolution applies.
+    expect(
+      requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=require&sslrootcert=/etc/ca.pem')
+    ).toBe('require');
   });
 });
 

--- a/packages/connectors/src/__tests__/db-egress-guard.test.ts
+++ b/packages/connectors/src/__tests__/db-egress-guard.test.ts
@@ -318,6 +318,16 @@ describe('requiredTlsMode — forced TLS under block-private', () => {
     expect(
       requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=verify-full#sslmode=disable')
     ).toBe('verify-full');
+    // `#` BEFORE `?`: the `?` lives inside the fragment, so there is NO query.
+    // A `sslmode=disable` after such a `?` must NOT be parsed (and must not
+    // throw as plaintext) — new URL() treats the whole tail as fragment.
+    expect(
+      requiredTlsMode('postgres://u:p@db.example.com/x#label?sslmode=disable')
+    ).toBe('require');
+    // Same, with an sslrootcert in the fragment: it must not force verify-full.
+    expect(
+      requiredTlsMode('postgres://u:p@db.example.com/x#frag?sslrootcert=system')
+    ).toBe('require');
   });
 
   test('sslmode beats a contradictory ssl param (postgres.js precedence)', () => {

--- a/packages/connectors/src/__tests__/db-egress-guard.test.ts
+++ b/packages/connectors/src/__tests__/db-egress-guard.test.ts
@@ -302,6 +302,24 @@ describe('requiredTlsMode — forced TLS under block-private', () => {
     ).toBe('verify-full');
   });
 
+  // postgres.js parses via `new URL()`: the fragment (`#...`) is NOT part of the
+  // query, so `sslrootcert=system#frag` still reads `system` and forces
+  // verify-full. A naive `?`-slice would fold `#frag` into the value and
+  // silently DOWNGRADE to require — the fragment must be stripped first.
+  test('URL fragment does not downgrade sslrootcert=system (WHATWG semantics)', () => {
+    expect(
+      requiredTlsMode('postgres://u:p@db.example.com/x?sslrootcert=system#frag')
+    ).toBe('verify-full');
+    // Fragment after another param must not corrupt the last param either.
+    expect(
+      requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=require&sslrootcert=system#frag')
+    ).toBe('verify-full');
+    // A fragment carrying an sslmode-looking string must be ignored, not parsed.
+    expect(
+      requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=verify-full#sslmode=disable')
+    ).toBe('verify-full');
+  });
+
   test('sslmode beats a contradictory ssl param (postgres.js precedence)', () => {
     expect(() =>
       requiredTlsMode('postgres://u:p@db.example.com/x?ssl=require&sslmode=disable')

--- a/packages/connectors/src/__tests__/db-egress-guard.test.ts
+++ b/packages/connectors/src/__tests__/db-egress-guard.test.ts
@@ -222,3 +222,249 @@ describe('assertConnectionStringAllowed — multi-host + policy', () => {
     ).resolves.toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cloud hardening: forced TLS + resolve-then-pin (block-private only)
+// ---------------------------------------------------------------------------
+
+import {
+  buildDbEgressHardening,
+  createPinnedSocketFactory,
+  requiredTlsMode,
+  resolvePinnedDbHosts,
+} from '../db-egress-guard.ts';
+
+/** Records connect() calls instead of dialing; shaped like net.Socket enough for the factory. */
+class FakeSocket {
+  connects: Array<{ port: number; address: string }> = [];
+  host?: string;
+  port?: number;
+  connect(port: number, address: string): this {
+    this.connects.push({ port, address });
+    return this;
+  }
+}
+const fakeSocketFactory = (created: FakeSocket[]) => () => {
+  const s = new FakeSocket();
+  created.push(s);
+  return s as unknown as import('node:net').Socket;
+};
+
+describe('requiredTlsMode — forced TLS under block-private', () => {
+  test('rejects sslmode=disable with a clear error', () => {
+    expect(() => requiredTlsMode('postgres://u:p@db.example.com:5432/x?sslmode=disable')).toThrow(
+      /TLS is required/i
+    );
+  });
+
+  test('rejects ssl=false and ssl=disable (postgres.js aliases)', () => {
+    expect(() => requiredTlsMode('postgres://u:p@db.example.com/x?ssl=false')).toThrow(
+      /TLS is required/i
+    );
+    expect(() => requiredTlsMode('postgres://u:p@db.example.com/x?ssl=disable')).toThrow(
+      /TLS is required/i
+    );
+  });
+
+  test('forces "require" when the URL says nothing about TLS', () => {
+    expect(requiredTlsMode('postgres://u:p@db.example.com:5432/x')).toBe('require');
+  });
+
+  test('upgrades the weak modes (allow/prefer) to "require"', () => {
+    expect(requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=allow')).toBe('require');
+    expect(requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=prefer')).toBe('require');
+    expect(requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=require')).toBe('require');
+  });
+
+  test('never downgrades verify-ca / verify-full', () => {
+    expect(requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=verify-ca')).toBe('verify-ca');
+    expect(requiredTlsMode('postgres://u:p@db.example.com/x?sslmode=verify-full')).toBe(
+      'verify-full'
+    );
+  });
+
+  test('sslmode beats a contradictory ssl param (postgres.js precedence)', () => {
+    expect(() =>
+      requiredTlsMode('postgres://u:p@db.example.com/x?ssl=require&sslmode=disable')
+    ).toThrow(/TLS is required/i);
+  });
+});
+
+describe('resolvePinnedDbHosts — resolve-then-pin', () => {
+  test('pins a hostname to its first validated address', async () => {
+    const pinned = await resolvePinnedDbHosts(
+      'postgres://u:p@db.example.com:5432/x',
+      fakeLookup(['93.184.216.34', '93.184.216.35'])
+    );
+    expect(pinned.get('db.example.com')).toBe('93.184.216.34');
+  });
+
+  test('an IP-literal host pins to its normalized form', async () => {
+    const pinned = await resolvePinnedDbHosts('postgres://u:p@8.8.8.8:5432/x', fakeLookup([]));
+    expect(pinned.get('8.8.8.8')).toBe('8.8.8.8');
+    // IPv4-mapped IPv6 collapses to the v4 it hides.
+    const mapped = await resolvePinnedDbHosts(
+      'postgres://u:p@[::ffff:8.8.8.8]:5432/x',
+      fakeLookup([])
+    );
+    expect(mapped.get('::ffff:8.8.8.8')).toBe('8.8.8.8');
+  });
+
+  test('throws when ANY resolved address is blocked (multi-record rebind)', async () => {
+    await expect(
+      resolvePinnedDbHosts(
+        'postgres://u:p@evil.example.com/x',
+        fakeLookup(['93.184.216.34', '169.254.169.254'])
+      )
+    ).rejects.toThrow(/blocked internal\/metadata/i);
+  });
+
+  test('multi-host URL pins every host', async () => {
+    const byHost: Record<string, string[]> = {
+      h1: ['203.0.113.10'],
+      h2: ['203.0.113.20'],
+    };
+    const lookup: HostLookup = async (host) =>
+      (byHost[host] ?? []).map((address) => ({ address }));
+    const pinned = await resolvePinnedDbHosts('postgres://u:p@h1:5432,h2:5433/x', lookup);
+    expect(pinned.get('h1')).toBe('203.0.113.10');
+    expect(pinned.get('h2')).toBe('203.0.113.20');
+  });
+
+  test('fails closed on an unparseable authority', async () => {
+    await expect(resolvePinnedDbHosts('host=localhost dbname=x', fakeLookup([]))).rejects.toThrow(
+      /could not be parsed/i
+    );
+  });
+});
+
+describe('createPinnedSocketFactory — the socket dials the pinned IP, never re-resolves', () => {
+  test('dials the pinned address but keeps the ORIGINAL hostname on socket.host (TLS SNI)', () => {
+    const created: FakeSocket[] = [];
+    const factory = createPinnedSocketFactory(
+      new Map([['db.example.com', '93.184.216.34']]),
+      fakeSocketFactory(created)
+    );
+    const s = factory({ host: ['db.example.com'], port: [5432] }) as unknown as FakeSocket;
+    expect(s.connects).toEqual([{ port: 5432, address: '93.184.216.34' }]);
+    expect(s.host).toBe('db.example.com');
+    expect(s.port).toBe(5432);
+  });
+
+  test('rotates across a multi-host URL with per-host ports (failover parity)', () => {
+    const created: FakeSocket[] = [];
+    const factory = createPinnedSocketFactory(
+      new Map([
+        ['h1', '203.0.113.10'],
+        ['h2', '203.0.113.20'],
+      ]),
+      fakeSocketFactory(created)
+    );
+    const opts = { host: ['h1', 'h2'], port: [5432, 5433] };
+    factory(opts);
+    factory(opts);
+    factory(opts);
+    expect(created.map((s) => s.connects[0])).toEqual([
+      { port: 5432, address: '203.0.113.10' },
+      { port: 5433, address: '203.0.113.20' },
+      { port: 5432, address: '203.0.113.10' },
+    ]);
+  });
+
+  test('strips IPv6 brackets and matches host case-insensitively', () => {
+    const created: FakeSocket[] = [];
+    const factory = createPinnedSocketFactory(
+      new Map([
+        ['2001:db8::1', '2001:db8::1'],
+        ['db.example.com', '93.184.216.34'],
+      ]),
+      fakeSocketFactory(created)
+    );
+    const s1 = factory({ host: ['[2001:db8::1]'], port: [5432] }) as unknown as FakeSocket;
+    expect(s1.connects).toEqual([{ port: 5432, address: '2001:db8::1' }]);
+    const s2 = factory({ host: ['DB.Example.COM'], port: [5432] }) as unknown as FakeSocket;
+    expect(s2.connects).toEqual([{ port: 5432, address: '93.184.216.34' }]);
+  });
+
+  test('fails closed for a host the guard never validated', () => {
+    const factory = createPinnedSocketFactory(
+      new Map([['db.example.com', '93.184.216.34']]),
+      fakeSocketFactory([])
+    );
+    expect(() => factory({ host: ['other.example.com'], port: [5432] })).toThrow(
+      /not validated/i
+    );
+  });
+});
+
+describe('buildDbEgressHardening — policy plumbing', () => {
+  test('allow-private: no overrides, and a hostname is NOT resolved', async () => {
+    let calls = 0;
+    const counting: HostLookup = async () => {
+      calls++;
+      return [{ address: '10.0.0.5' }];
+    };
+    const hardening = await buildDbEgressHardening(
+      'postgres://u:p@internal.db.local:5432/x',
+      ALLOW,
+      counting
+    );
+    expect(hardening.ssl).toBeUndefined();
+    expect(hardening.socket).toBeUndefined();
+    expect(calls).toBe(0);
+  });
+
+  test('allow-private still rejects a metadata IP literal', async () => {
+    await expect(
+      buildDbEgressHardening('postgres://u:p@169.254.169.254:5432/x', ALLOW, fakeLookup([]))
+    ).rejects.toThrow(/blocked/i);
+  });
+
+  test('block-private: returns forced TLS + a pinning socket factory', async () => {
+    const hardening = await buildDbEgressHardening(
+      'postgres://u:p@db.example.com:5432/x',
+      BLOCK,
+      fakeLookup(['93.184.216.34'])
+    );
+    expect(hardening.ssl).toBe('require');
+    expect(typeof hardening.socket).toBe('function');
+  });
+
+  test('block-private: sslmode=disable is rejected BEFORE any DNS resolution', async () => {
+    let calls = 0;
+    const counting: HostLookup = async () => {
+      calls++;
+      return [{ address: '93.184.216.34' }];
+    };
+    await expect(
+      buildDbEgressHardening('postgres://u:p@db.example.com/x?sslmode=disable', BLOCK, counting)
+    ).rejects.toThrow(/TLS is required/i);
+    expect(calls).toBe(0);
+  });
+
+  test('DNS rebind after validation cannot move the socket (pin holds, no re-resolve)', async () => {
+    // A "rebinding" resolver: first answer is a clean public IP, every later
+    // answer is the metadata IP. The guard resolves ONCE at build time; every
+    // socket the pool opens afterwards must dial the first (validated) answer.
+    let calls = 0;
+    const rebinding: HostLookup = async () => {
+      calls++;
+      return [{ address: calls === 1 ? '93.184.216.34' : '169.254.169.254' }];
+    };
+    const created: FakeSocket[] = [];
+    const hardening = await buildDbEgressHardening(
+      'postgres://u:p@rebind.example.com:5432/x',
+      BLOCK,
+      rebinding,
+      fakeSocketFactory(created)
+    );
+    const opts = { host: ['rebind.example.com'], port: [5432] };
+    hardening.socket?.(opts);
+    hardening.socket?.(opts);
+    expect(calls).toBe(1);
+    expect(created.map((s) => s.connects[0]?.address)).toEqual([
+      '93.184.216.34',
+      '93.184.216.34',
+    ]);
+  });
+});

--- a/packages/connectors/src/db-egress-guard.ts
+++ b/packages/connectors/src/db-egress-guard.ts
@@ -21,11 +21,21 @@
  * (IPv4-mapped IPv6, NAT64 `64:ff9b::/96`, zone IDs) and FAILS CLOSED on any
  * IP-looking literal it can't parse.
  *
- * NOTE (intentional limitation): this validates + rejects blocked hosts but does
- * NOT pin the resolved IP into the socket, so a DNS-rebind between this check and
- * the connect is not closed here, and TLS is not forced when the URL omits it.
- * Those, plus flipping `CLOUD_RESTRICTED_CONNECTOR_KEYS`, are the remaining
- * go-live steps before a tenant-supplied URL is accepted on cloud.
+ * Under `block-private` the guard goes beyond classify-and-reject
+ * (`buildDbEgressHardening`):
+ *  - resolve-then-PIN: each hostname is resolved ONCE at guard time, every
+ *    address is validated, and the socket postgres.js opens dials exactly the
+ *    validated IP (custom `socket` factory) — the driver never re-resolves, so a
+ *    DNS rebind between check and connect (or across pool reconnects) is closed.
+ *  - forced TLS: the connection is encrypted regardless of URL params
+ *    (`sslmode=disable` is rejected outright; see `requiredTlsMode`).
+ *
+ * DEFERRED (explicit follow-up, not a gap in the platform boundary): a per-org
+ * destination allowlist ("this org may only reach these DB hosts"). block-private
+ * + pin + forced TLS is what protects the PLATFORM (no internal/metadata/tenant
+ * lateral movement, no plaintext creds on the wire); an allowlist protects a
+ * tenant from its own operators and is an enterprise policy feature layered on
+ * top later.
  */
 import dns from 'node:dns';
 import net from 'node:net';
@@ -262,6 +272,21 @@ export async function assertHostAllowed(
   policy: DbEgressPolicy,
   lookup: HostLookup = defaultLookup,
 ): Promise<void> {
+  await resolveAllowedHostAddresses(host, policy, lookup);
+}
+
+/**
+ * Like {@link assertHostAllowed}, but returns the validated address list so a
+ * caller can PIN the connection to it (resolve-then-pin closes the DNS-rebind
+ * TOCTOU: the socket dials exactly what was validated, never a re-resolve).
+ * An IP-literal host returns its normalized form (IPv4-mapped/NAT64 unwrapped);
+ * a hostname returns every address the single guard-time lookup produced.
+ */
+export async function resolveAllowedHostAddresses(
+  host: string,
+  policy: DbEgressPolicy,
+  lookup: HostLookup = defaultLookup,
+): Promise<string[]> {
   const normalized = normalizeIpLiteral(host);
   if (normalized.kind === 'ipv4' || normalized.kind === 'ipv6' || normalized.kind === 'invalid') {
     if (isBlockedIp(host, policy)) {
@@ -269,7 +294,8 @@ export async function assertHostAllowed(
         `DATABASE_URL host "${host}" is a blocked internal/metadata address (egress policy: ${policy}).`,
       );
     }
-    return;
+    // `invalid` always throws above (isBlockedIp fails closed), so this is ipv4/ipv6.
+    return normalized.kind === 'invalid' ? [] : [normalized.value];
   }
 
   // A DNS name — resolve every address and reject if any is blocked.
@@ -287,6 +313,10 @@ export async function assertHostAllowed(
       );
     }
   }
+  if (addresses.length === 0) {
+    throw new Error(`DATABASE_URL host "${host}" could not be resolved: no addresses returned.`);
+  }
+  return addresses.map(({ address }) => address);
 }
 
 /**
@@ -357,4 +387,157 @@ export async function assertConnectionStringAllowed(
  *  paths inject `block-private` explicitly. */
 export function readEgressPolicy(value: unknown): DbEgressPolicy {
   return value === 'block-private' ? 'block-private' : 'allow-private';
+}
+
+// ---------------------------------------------------------------------------
+// block-private hardening: forced TLS + resolve-then-pin
+// ---------------------------------------------------------------------------
+
+/**
+ * The `ssl` value to FORCE onto postgres.js under `block-private`, derived from
+ * the URL's own `sslmode`/`ssl` params (`sslmode` wins when both are present —
+ * postgres.js maps `sslmode` over `ssl`). An explicit `ssl` option key overrides
+ * the URL in postgres.js (`k in o` beats `k in query`), so returning a value
+ * here is authoritative. Rules (monotone — never weakens what the URL asked for):
+ *  - `disable` / `false` → REJECT: a tenant URL on cloud must never carry
+ *    credentials or rows in plaintext across the internet.
+ *  - absent / `allow` / `prefer` / `require` → `'require'` (encrypt always;
+ *    `prefer` would silently fall back to plaintext when the server declines).
+ *  - `verify-ca` / `verify-full` (or any other explicit value, e.g. `true`) →
+ *    passed through unchanged: postgres.js treats non-require/allow/prefer
+ *    strings as strict TLS (`rejectUnauthorized` stays on).
+ *
+ * Why the FLOOR is `require` (encrypt, don't verify the chain) and not
+ * `verify-full`: tenant databases very commonly present self-signed or
+ * private-CA certs (RDS regional bundles, on-prem), so forcing verify-full
+ * would hard-break most legitimate BYO databases with no recourse until we
+ * ship per-connection CA upload. `require` matches libpq's semantics for the
+ * same flag. Upgrading the floor to verify-full once CA upload exists is the
+ * noted follow-up — and the pinned-socket design already keeps it sound: the
+ * TLS `servername` stays the ORIGINAL hostname (not the pinned IP), so SNI
+ * routing and, when verification is on, certificate identity both check
+ * against the name the tenant configured.
+ */
+export function requiredTlsMode(connectionString: string): string {
+  const q = connectionString.indexOf('?');
+  const params = new URLSearchParams(q === -1 ? '' : connectionString.slice(q + 1));
+  const mode = (params.get('sslmode') ?? params.get('ssl') ?? '').toLowerCase();
+  if (mode === 'disable' || mode === 'false') {
+    throw new Error(
+      'DATABASE_URL disables TLS (sslmode=disable), but TLS is required on this deployment (egress policy: block-private). Use sslmode=require or stronger.',
+    );
+  }
+  if (mode === '' || mode === 'allow' || mode === 'prefer' || mode === 'require') {
+    return 'require';
+  }
+  return mode;
+}
+
+/**
+ * Resolve-then-pin, step 1: validate every host of the connection string under
+ * `block-private` and return `host → validated IP` (first validated address;
+ * ALL returned addresses must pass, so any answer is safe to dial). Keys are
+ * lowercased — DNS is case-insensitive and postgres.js hands the factory the
+ * URL's spelling verbatim.
+ */
+export async function resolvePinnedDbHosts(
+  connectionString: string,
+  lookup: HostLookup = defaultLookup,
+): Promise<Map<string, string>> {
+  const hosts = extractDbHosts(connectionString);
+  if (hosts.length === 0) {
+    throw new Error('DATABASE_URL host could not be parsed for egress validation.');
+  }
+  const pinned = new Map<string, string>();
+  for (const host of hosts) {
+    const addresses = await resolveAllowedHostAddresses(host, 'block-private', lookup);
+    const first = addresses[0];
+    if (first === undefined) {
+      throw new Error(`DATABASE_URL host "${host}" produced no usable address.`);
+    }
+    pinned.set(host.toLowerCase(), first);
+  }
+  return pinned;
+}
+
+/** The slice of parsed postgres.js options the socket factory consumes. */
+export interface PinnedSocketOptions {
+  host: string[];
+  port: number[];
+}
+
+/** Injected for tests; production uses a real TCP socket. */
+export type MakeSocket = () => net.Socket;
+
+const defaultMakeSocket: MakeSocket = () => new net.Socket();
+
+/**
+ * Resolve-then-pin, step 2: a postgres.js `socket` factory that dials the
+ * guard-validated IP directly, so the driver NEVER resolves the hostname itself
+ * (closing the check→connect DNS-rebind TOCTOU, including across pool
+ * reconnects). Mirrors the driver's own multi-host failover by rotating through
+ * `options.host`/`options.port` exactly as its built-in connect() does. The
+ * ORIGINAL hostname is kept on `socket.host`, which postgres.js reads as the TLS
+ * `servername` — SNI-routed servers (and cert verification, when enabled) see
+ * the configured name, not the pinned IP. Fails closed on any host the guard
+ * didn't validate.
+ */
+export function createPinnedSocketFactory(
+  pinned: ReadonlyMap<string, string>,
+  makeSocket: MakeSocket = defaultMakeSocket,
+): (options: PinnedSocketOptions) => net.Socket {
+  let hostIndex = 0;
+  return (options) => {
+    const count = Math.max(options.host.length, 1);
+    const i = hostIndex % count;
+    hostIndex = (i + 1) % count;
+    const rawHost = options.host[i] ?? '';
+    // postgres.js keeps a single-host IPv6 literal bracketed (URL.hostname).
+    const bareHost = rawHost.startsWith('[')
+      ? rawHost.slice(1, rawHost.indexOf(']') === -1 ? rawHost.length : rawHost.indexOf(']'))
+      : rawHost;
+    const port = options.port[i] ?? options.port[0] ?? 5432;
+    const address = pinned.get(bareHost.toLowerCase());
+    if (address === undefined) {
+      throw new Error(
+        `DATABASE_URL host "${rawHost}" was not validated by the egress guard; refusing to connect.`,
+      );
+    }
+    const socket = makeSocket();
+    socket.connect(port, address);
+    // postgres.js reads socket.host as the TLS servername (and its error paths
+    // read socket.port); keep the ORIGINAL hostname, not the pinned IP.
+    Object.assign(socket, { host: bareHost, port });
+    return socket;
+  };
+}
+
+/** postgres.js option overrides produced by the guard; empty under `allow-private`. */
+export interface DbEgressHardening {
+  ssl?: string;
+  socket?: (options: PinnedSocketOptions) => net.Socket;
+}
+
+/**
+ * The single block-private entry point: validate the connection string and
+ * return the postgres.js option overrides that make the validation stick —
+ * forced TLS (`requiredTlsMode`, checked first so a plaintext URL fails fast
+ * without a DNS round-trip) and the pinning `socket` factory. Under
+ * `allow-private` this behaves exactly like `assertConnectionStringAllowed`
+ * (literal-only checks, no resolve, no overrides) so self-hosted keeps native
+ * driver behavior (its own DNS, failover, and URL-controlled TLS).
+ */
+export async function buildDbEgressHardening(
+  connectionString: string,
+  policy: DbEgressPolicy,
+  lookup: HostLookup = defaultLookup,
+  makeSocket: MakeSocket = defaultMakeSocket,
+): Promise<DbEgressHardening> {
+  if (policy !== 'block-private') {
+    await assertConnectionStringAllowed(connectionString, policy, lookup);
+    return {};
+  }
+  const ssl = requiredTlsMode(connectionString);
+  const pinned = await resolvePinnedDbHosts(connectionString, lookup);
+  return { ssl, socket: createPinnedSocketFactory(pinned, makeSocket) };
 }

--- a/packages/connectors/src/db-egress-guard.ts
+++ b/packages/connectors/src/db-egress-guard.ts
@@ -421,7 +421,30 @@ export function readEgressPolicy(value: unknown): DbEgressPolicy {
 export function requiredTlsMode(connectionString: string): string {
   const q = connectionString.indexOf('?');
   const params = new URLSearchParams(q === -1 ? '' : connectionString.slice(q + 1));
-  const mode = (params.get('sslmode') ?? params.get('ssl') ?? '').toLowerCase();
+  // Match postgres.js's own precedence exactly (connection.js parseOptions):
+  // it reduces searchParams into an object so on DUPLICATE keys the LAST value
+  // wins, then maps `sslmode` over `ssl` (sslmode present ⇒ ssl := sslmode).
+  // `URLSearchParams.get` returns the FIRST value, so using it would let
+  // `?sslmode=require&sslmode=verify-full` read `require` and silently DOWNGRADE
+  // the strict TLS the driver would actually apply. Read last-wins for both keys,
+  // sslmode taking priority when present.
+  // postgres.js only maps sslmode over ssl when the (last) sslmode is truthy
+  // (`query.sslmode && ...`), so an empty `?sslmode=` falls through to `ssl`.
+  const lastSslmode = params.getAll('sslmode').at(-1);
+  const lastSsl = params.getAll('ssl').at(-1);
+  const mode = ((lastSslmode || lastSsl) ?? '').toLowerCase();
+  // postgres.js applies `sslrootcert=system` LAST and UNCONDITIONALLY forces
+  // `ssl = 'verify-full'` (connection.js) — it runs after the sslmode→ssl
+  // mapping and even overrides `sslmode=disable`, so the driver would encrypt
+  // and verify regardless. Our returned value is authoritative in
+  // openGuardedPool (an explicit `ssl` option beats the URL), so we must honor
+  // it: otherwise a URL trusting the system CA store would be silently
+  // DOWNGRADED from verify-full to require (or wrongly rejected as plaintext),
+  // disabling certificate verification.
+  const usesSystemCa = params.getAll('sslrootcert').at(-1)?.toLowerCase() === 'system';
+  if (usesSystemCa) {
+    return 'verify-full';
+  }
   if (mode === 'disable' || mode === 'false') {
     throw new Error(
       'DATABASE_URL disables TLS (sslmode=disable), but TLS is required on this deployment (egress policy: block-private). Use sslmode=require or stronger.',

--- a/packages/connectors/src/db-egress-guard.ts
+++ b/packages/connectors/src/db-egress-guard.ts
@@ -420,7 +420,15 @@ export function readEgressPolicy(value: unknown): DbEgressPolicy {
  */
 export function requiredTlsMode(connectionString: string): string {
   const q = connectionString.indexOf('?');
-  const params = new URLSearchParams(q === -1 ? '' : connectionString.slice(q + 1));
+  // postgres.js parses the URL with `new URL()`, whose `.searchParams` follows
+  // WHATWG URL semantics: the fragment (everything from the first `#`) is NOT
+  // part of the query. A naive `slice(q + 1)` would fold `#frag` into the last
+  // param's value, so `?sslrootcert=system#frag` would read `system#frag` and
+  // silently DOWNGRADE verify-full to require. Cut the fragment first to match.
+  let query = q === -1 ? '' : connectionString.slice(q + 1);
+  const hash = query.indexOf('#');
+  if (hash !== -1) query = query.slice(0, hash);
+  const params = new URLSearchParams(query);
   // Match postgres.js's own precedence exactly (connection.js parseOptions):
   // it reduces searchParams into an object so on DUPLICATE keys the LAST value
   // wins, then maps `sslmode` over `ssl` (sslmode present ⇒ ssl := sslmode).

--- a/packages/connectors/src/db-egress-guard.ts
+++ b/packages/connectors/src/db-egress-guard.ts
@@ -419,16 +419,18 @@ export function readEgressPolicy(value: unknown): DbEgressPolicy {
  * against the name the tenant configured.
  */
 export function requiredTlsMode(connectionString: string): string {
-  const q = connectionString.indexOf('?');
   // postgres.js parses the URL with `new URL()`, whose `.searchParams` follows
-  // WHATWG URL semantics: the fragment (everything from the first `#`) is NOT
-  // part of the query. A naive `slice(q + 1)` would fold `#frag` into the last
-  // param's value, so `?sslrootcert=system#frag` would read `system#frag` and
-  // silently DOWNGRADE verify-full to require. Cut the fragment first to match.
-  let query = q === -1 ? '' : connectionString.slice(q + 1);
-  const hash = query.indexOf('#');
-  if (hash !== -1) query = query.slice(0, hash);
-  const params = new URLSearchParams(query);
+  // WHATWG URL semantics: the fragment (everything from the FIRST `#`) is NOT
+  // part of the query, and a `?` that appears AFTER that `#` is fragment text,
+  // not a query delimiter. So cut the fragment off the WHOLE string first, then
+  // locate `?`. This closes both `?x=y#frag` (folding `#frag` into the last
+  // value) and `#frag?sslmode=disable` (a `?` living inside the fragment being
+  // misread as a real query) — either would silently corrupt the TLS decision.
+  const hash = connectionString.indexOf('#');
+  const beforeFragment =
+    hash === -1 ? connectionString : connectionString.slice(0, hash);
+  const q = beforeFragment.indexOf('?');
+  const params = new URLSearchParams(q === -1 ? '' : beforeFragment.slice(q + 1));
   // Match postgres.js's own precedence exactly (connection.js parseOptions):
   // it reduces searchParams into an object so on DUPLICATE keys the LAST value
   // wins, then maps `sslmode` over `ssl` (sslmode present ⇒ ssl := sslmode).

--- a/packages/connectors/src/postgres.ts
+++ b/packages/connectors/src/postgres.ts
@@ -21,14 +21,15 @@
  *  - origin_id = "<feed>:<pk>" so two feeds on one connection never collide, and
  *    re-emitting a row supersedes (events ingestion dedupes by origin_id).
  *
- * V1 trust model (plan §G): the DATABASE_URL host is checked before connecting
- * (guardDbHost → db-egress-guard). Under the default `allow-private` policy
+ * Trust model (plan §G): the DATABASE_URL host is checked before connecting
+ * (openGuardedPool → db-egress-guard). Under the default `allow-private` policy
  * (first-party / operator-set URL) private IPs are allowed — the dogfood reaches
  * Lobu's own private PG — and only metadata/link-local literals are blocked.
  * Under `block-private` (injected by the server in cloud mode) every non-public
- * host is rejected. Untrusted multi-tenant cloud exposure is ALSO gated
- * separately (the bundled connector is restricted under LOBU_CLOUD_MODE) until
- * the full hardening (IP pin / force-TLS) lands and that gate is lifted.
+ * host is rejected, TLS is forced (sslmode=disable is refused), and the socket
+ * is pinned to the guard-validated IP so the driver never re-resolves DNS
+ * (rebind TOCTOU closed). A per-org destination allowlist is a deferred
+ * enterprise policy layer — see db-egress-guard's module header.
  */
 
 import {
@@ -42,7 +43,7 @@ import {
   type SyncResult,
 } from '@lobu/connector-sdk';
 import postgres from 'postgres';
-import { assertConnectionStringAllowed, readEgressPolicy } from './db-egress-guard.js';
+import { buildDbEgressHardening, readEgressPolicy } from './db-egress-guard.js';
 
 interface PgQueryConfig {
   /** ONE read-only base SELECT. No WHERE-cursor / ORDER BY / top-level LIMIT — the connector wraps it. */
@@ -274,14 +275,29 @@ const POOL_OPTS = {
 } as const;
 
 /**
- * SSRF/egress pre-flight, run before any socket opens on BOTH sync() and
- * query(). Policy comes from ctx.config.LOBU_DB_EGRESS_POLICY — the server
- * injects `block-private` under cloud mode; everything else defaults to the
- * trusted `allow-private`. The host parsing + per-host validation (incl. the
- * multi-host failover case) lives in db-egress-guard.
+ * SSRF/egress pre-flight + guarded pool, run before any socket opens on sync(),
+ * query(), and search(). Policy comes from ctx.config.LOBU_DB_EGRESS_POLICY —
+ * the server injects `block-private` under cloud mode; everything else defaults
+ * to the trusted `allow-private`. Under block-private the guard's option
+ * overrides make the validation stick: forced TLS (sslmode=disable rejected)
+ * and a `socket` factory that dials the guard-validated IP so the driver never
+ * re-resolves DNS (rebind TOCTOU closed). Under allow-private the overrides are
+ * empty — native driver behavior. The overrides land AFTER POOL_OPTS so nothing
+ * can shadow them. `socket` isn't in postgres.js's published Options type
+ * (supported since 3.4: connection.js `options.socket`), hence the cast.
  */
-async function guardDbHost(connectionString: string, config: Record<string, unknown>): Promise<void> {
-  await assertConnectionStringAllowed(connectionString, readEgressPolicy(config.LOBU_DB_EGRESS_POLICY));
+async function openGuardedPool(
+  connectionString: string,
+  config: Record<string, unknown>,
+): Promise<postgres.Sql> {
+  const hardening = await buildDbEgressHardening(
+    connectionString,
+    readEgressPolicy(config.LOBU_DB_EGRESS_POLICY),
+  );
+  return postgres(connectionString, {
+    ...POOL_OPTS,
+    ...hardening,
+  } as unknown as postgres.Options<Record<string, never>>);
 }
 
 /** Seal a transaction read-only with a statement timeout — the hard write/time
@@ -367,8 +383,7 @@ export default class PostgresConnector extends ConnectorRuntime {
 
     const checkpoint = (ctx.checkpoint as PgCheckpoint | null) ?? {};
 
-    await guardDbHost(connectionString, ctx.config as Record<string, unknown>);
-    const sql = postgres(connectionString, POOL_OPTS);
+    const sql = await openGuardedPool(connectionString, ctx.config as Record<string, unknown>);
 
     try {
       // Everything runs inside ONE read-only transaction — the probe included —
@@ -478,8 +493,7 @@ export default class PostgresConnector extends ConnectorRuntime {
     // path. baseSql has no top-level LIMIT (rejected above), so this is exact.
     const countSql = `SELECT count(*)::int AS n FROM (\n${baseSql}\n) q`;
 
-    await guardDbHost(connectionString, ctx.config as Record<string, unknown>);
-    const sql = postgres(connectionString, POOL_OPTS);
+    const sql = await openGuardedPool(connectionString, ctx.config as Record<string, unknown>);
     try {
       const { data, total } = (await sql.begin(async (tx) => {
         await setReadOnly(tx, 30000);
@@ -532,8 +546,7 @@ export default class PostgresConnector extends ConnectorRuntime {
       orderBy = `ORDER BY q."${col}" ${ctx.sort.order === 'desc' ? 'DESC' : 'ASC'}`;
     }
 
-    await guardDbHost(connectionString, ctx.config as Record<string, unknown>);
-    const sql = postgres(connectionString, POOL_OPTS);
+    const sql = await openGuardedPool(connectionString, ctx.config as Record<string, unknown>);
     try {
       const { data, columns, total } = (await sql.begin(async (tx) => {
         await setReadOnly(tx, 30000);

--- a/packages/server/src/__tests__/integration/connectors/postgres-connector.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/postgres-connector.test.ts
@@ -7,7 +7,9 @@
  * checkpoint round-trip end to end.
  */
 
+import { createPinnedSocketFactory } from '@lobu/connectors/db-egress-guard';
 import PostgresConnector from '@lobu/connectors/postgres';
+import postgres from 'postgres';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { getTestDb } from '../../setup/test-db';
 
@@ -125,26 +127,60 @@ describe('PostgresConnector.sync (keyset incremental, real DB)', () => {
   });
 
   it('blocks an internal host under the block-private egress policy (cloud)', async () => {
-    // The test DB is on loopback; block-private rejects it before any socket opens.
+    // The test DB is on loopback; block-private rejects it before any socket
+    // opens. The TLS gate runs FIRST (fail fast, no DNS), so strip any
+    // sslmode=disable off the test URL to reach the host classifier.
     // (allow-private — the default exercised by every other case here — allows it.)
-    await expect(run({ LOBU_DB_EGRESS_POLICY: 'block-private' }, null)).rejects.toThrow(
-      /blocked internal\/metadata/i
-    );
+    const noSslmode = (process.env.DATABASE_URL ?? '').replace(/[?&]sslmode=[^&]*/, '');
+    await expect(
+      run({ DATABASE_URL: noSslmode, LOBU_DB_EGRESS_POLICY: 'block-private' }, null)
+    ).rejects.toThrow(/blocked internal\/metadata/i);
+  });
+
+  it('rejects sslmode=disable under block-private BEFORE the host check (forced TLS)', async () => {
+    const base = (process.env.DATABASE_URL ?? '').replace(/[?&]sslmode=[^&]*/, '');
+    const disabled = base + (base.includes('?') ? '&' : '?') + 'sslmode=disable';
+    await expect(
+      run({ DATABASE_URL: disabled, LOBU_DB_EGRESS_POLICY: 'block-private' }, null)
+    ).rejects.toThrow(/TLS is required/i);
   });
 
   it('query() also enforces the egress policy', async () => {
     const conn2 = new PostgresConnector();
+    const noSslmode = (process.env.DATABASE_URL ?? '').replace(/[?&]sslmode=[^&]*/, '');
     await expect(
       conn2.query({
         feedKey: null,
         query: 'SELECT 1 AS one',
         config: {
-          DATABASE_URL: process.env.DATABASE_URL,
+          DATABASE_URL: noSslmode,
           LOBU_DB_EGRESS_POLICY: 'block-private',
         },
         credentials: null,
       } as never)
     ).rejects.toThrow(/blocked internal\/metadata/i);
+  });
+
+  it('postgres.js completes a real session through the pinned socket factory', async () => {
+    // The riskiest hardening assumption is that postgres.js honors a custom
+    // `socket` option end to end (it is unpublished in its types). Prove it
+    // against the real test DB: pin the URL's host to its loopback IP and run a
+    // query through the factory-made socket. (block-private itself cannot be
+    // exercised against loopback — it would rightly reject the host — so this
+    // validates the MECHANISM the cloud path relies on.)
+    const url = new URL((process.env.DATABASE_URL ?? '').replace(/^postgres(ql)?:/, 'http:'));
+    const pinned = new Map([[url.hostname.toLowerCase(), '127.0.0.1']]);
+    const sql = postgres(process.env.DATABASE_URL as string, {
+      max: 1,
+      prepare: false,
+      socket: createPinnedSocketFactory(pinned),
+    } as never);
+    try {
+      const rows = await sql.unsafe('SELECT 41 + 1 AS answer');
+      expect(rows[0]?.answer).toBe(42);
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
   });
 
   it('labels result column types from the OID map (incl. name / jsonb / oid)', async () => {

--- a/packages/server/src/__tests__/integration/connectors/postgres-sync-cloud-gate.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/postgres-sync-cloud-gate.test.ts
@@ -1,11 +1,13 @@
 /**
- * Cloud gate on the postgres sync path, both layers:
- *  - CREATION (createSyncRun): under LOBU_CLOUD_MODE a postgres run is never
- *    queued; the feed is left intact (valid, just cloud-gated), not soft-deleted.
- *  - EXECUTION (pollWorkerJob): a run already in `pending` (e.g. queued before
- *    cloud mode flipped, or via another path) must be FAILED when a worker claims
- *    it under LOBU_CLOUD_MODE — the hard boundary, since createSyncRun alone can
- *    be bypassed. Self-hosted (cloud mode off) runs normally on both layers.
+ * Cloud gate on the postgres sync path, both layers — now OPEN for postgres.
+ * `postgres` graduated out of CLOUD_RESTRICTED_CONNECTOR_KEYS (egress hardening:
+ * block-private classify+reject, resolve-then-pin sockets, forced TLS), so:
+ *  - CREATION (createSyncRun): a postgres run IS queued under LOBU_CLOUD_MODE.
+ *  - EXECUTION (pollWorkerJob): a pending postgres run IS claimed and handed to
+ *    a worker under LOBU_CLOUD_MODE (the run itself then executes under the
+ *    injected block-private egress policy — covered by the connector tests).
+ * These are regression tests that the gate stays open; the gate MECHANISM for
+ * future warehouse connectors is covered by connector-cloud-gate.test.ts.
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Env } from '../../../index';
@@ -68,19 +70,16 @@ describe('createSyncRun cloud gate (postgres) — queue-time', () => {
     process.env.LOBU_CLOUD_MODE = undefined;
   });
 
-  it('does NOT queue a postgres sync run under LOBU_CLOUD_MODE (feed left intact)', async () => {
+  it('queues a postgres sync run under LOBU_CLOUD_MODE (gate open)', async () => {
     const sql = getTestDb();
     const { feedId } = await setupPostgresFeed();
 
     process.env.LOBU_CLOUD_MODE = '1';
     const runId = await createSyncRun(feedId, {} as Env, sql);
 
-    expect(runId).toBeNull();
-    const runs = await sql`SELECT id FROM runs WHERE feed_id = ${feedId}`;
-    expect(runs.length).toBe(0);
-    // The feed is valid, just cloud-gated — it must NOT be soft-deleted.
-    const [after] = await sql`SELECT deleted_at FROM feeds WHERE id = ${feedId}`;
-    expect((after as { deleted_at: Date | null }).deleted_at).toBeNull();
+    expect(runId).not.toBeNull();
+    const runs = await sql`SELECT status FROM runs WHERE feed_id = ${feedId}`;
+    expect(runs.length).toBe(1);
   });
 
   it('queues the run normally when not in cloud mode (self-hosted)', async () => {
@@ -104,7 +103,7 @@ describe('pollWorkerJob cloud gate (postgres) — execution-time', () => {
     process.env.LOBU_CLOUD_MODE = undefined;
   });
 
-  it('FAILS a claimed postgres run under LOBU_CLOUD_MODE instead of handing it to a worker', async () => {
+  it('claims a postgres run for a worker under LOBU_CLOUD_MODE (gate open)', async () => {
     const sql = getTestDb();
     const { feedId, connId, orgId } = await setupPostgresFeed();
     const runId = await insertPendingPostgresRun(orgId, feedId, connId);
@@ -120,25 +119,15 @@ describe('pollWorkerJob cloud gate (postgres) — execution-time', () => {
         env: { WORKER_API_TOKEN: 'test-fleet-token' },
       });
       expect(res.status).toBe(200);
-      const body = (await res.json()) as {
-        run_id?: number;
-        skipped_run_id?: number;
-        error?: string;
-      };
-      // The run was claimed, then the gate failed it — not dispatched.
-      expect(body.run_id).toBeUndefined();
-      expect(Number(body.skipped_run_id)).toBe(runId);
-      expect(String(body.error)).toMatch(/Lobu Cloud/i);
+      const body = (await res.json()) as { run_id?: number; error?: string };
+      // The run is dispatched, not failed by the gate.
+      expect(Number(body.run_id)).toBe(runId);
     } finally {
       process.env.LOBU_CLOUD_MODE = undefined;
     }
 
-    const [row] = await sql`
-      SELECT status, error_message, completed_at FROM runs WHERE id = ${runId}
-    `;
-    expect((row as { status: string }).status).toBe('failed');
-    expect((row as { completed_at: Date | null }).completed_at).not.toBeNull();
-    expect(String((row as { error_message: string }).error_message)).toMatch(/Lobu Cloud/i);
+    const [row] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
+    expect((row as { status: string }).status).toBe('running');
   });
 
   it('claims the run for a worker when not in cloud mode (proves the gate, not the harness, fails it)', async () => {

--- a/packages/server/src/__tests__/integration/connectors/postgres-sync-cloud-gate.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/postgres-sync-cloud-gate.test.ts
@@ -117,7 +117,7 @@ describe('pollWorkerJob cloud gate (postgres) — execution-time', () => {
       // so authenticate as a trusted fleet worker — the execution-time gate
       // inside pollWorkerJob is what this test is about.
       const res = await post('/api/workers/poll', {
-        body: { worker_id: 'cloud-gate-worker', capabilities: {} },
+        body: { worker_id: 'cloud-gate-worker', capabilities: { db_egress_hardening: true } },
         token: 'test-fleet-token',
         env: { WORKER_API_TOKEN: 'test-fleet-token' },
       });
@@ -166,7 +166,7 @@ describe('pollWorkerJob — gateway is authoritative for the egress policy', () 
     process.env.LOBU_CLOUD_MODE = '1';
     try {
       const res = await post('/api/workers/poll', {
-        body: { worker_id: 'cloud-policy-worker', capabilities: {} },
+        body: { worker_id: 'cloud-policy-worker', capabilities: { db_egress_hardening: true } },
         token: 'test-fleet-token',
         env: { WORKER_API_TOKEN: 'test-fleet-token' },
       });
@@ -200,7 +200,7 @@ describe('pollWorkerJob — gateway is authoritative for the egress policy', () 
     process.env.LOBU_CLOUD_MODE = '1';
     try {
       const res = await post('/api/workers/poll', {
-        body: { worker_id: 'cloud-policy-worker-2', capabilities: {} },
+        body: { worker_id: 'cloud-policy-worker-2', capabilities: { db_egress_hardening: true } },
         token: 'test-fleet-token',
         env: { WORKER_API_TOKEN: 'test-fleet-token' },
       });

--- a/packages/server/src/__tests__/integration/connectors/postgres-sync-cloud-gate.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/postgres-sync-cloud-gate.test.ts
@@ -22,7 +22,9 @@ import {
 
 const CONNECTOR_VERSION = '1.0.0';
 
-async function setupPostgresFeed(): Promise<{ feedId: number; connId: number; orgId: string }> {
+async function setupPostgresFeed(
+  connectionConfig?: Record<string, unknown>
+): Promise<{ feedId: number; connId: number; orgId: string }> {
   const sql = getTestDb();
   const org = await createTestOrganization();
   await createTestConnectorDefinition({
@@ -36,6 +38,7 @@ async function setupPostgresFeed(): Promise<{ feedId: number; connId: number; or
   const conn = await createTestConnection({
     organization_id: org.id,
     connector_key: 'postgres',
+    ...(connectionConfig ? { config: connectionConfig } : {}),
   });
   const [feed] = await sql`SELECT id FROM feeds WHERE connection_id = ${conn.id}`;
   return { feedId: Number((feed as { id: number }).id), connId: conn.id, orgId: org.id };
@@ -145,5 +148,90 @@ describe('pollWorkerJob cloud gate (postgres) — execution-time', () => {
 
     const [row] = await sql`SELECT status FROM runs WHERE id = ${runId}`;
     expect((row as { status: string }).status).toBe('running');
+  });
+});
+
+describe('pollWorkerJob — gateway is authoritative for the egress policy', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+  afterEach(() => {
+    process.env.LOBU_CLOUD_MODE = undefined;
+  });
+
+  it('stamps block-private on the poll response under LOBU_CLOUD_MODE (worker cannot re-derive it)', async () => {
+    const { feedId, connId, orgId } = await setupPostgresFeed();
+    const runId = await insertPendingPostgresRun(orgId, feedId, connId);
+
+    process.env.LOBU_CLOUD_MODE = '1';
+    try {
+      const res = await post('/api/workers/poll', {
+        body: { worker_id: 'cloud-policy-worker', capabilities: {} },
+        token: 'test-fleet-token',
+        env: { WORKER_API_TOKEN: 'test-fleet-token' },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        run_id?: number;
+        db_egress_policy?: string;
+        config?: Record<string, unknown>;
+      };
+      expect(Number(body.run_id)).toBe(runId);
+      // The gateway decides the policy on a dedicated top-level field — the
+      // worker's own env must not. It is NOT in tenant `config` (which a tenant
+      // controls), so the worker can install it as authoritative job.env.
+      expect(body.db_egress_policy).toBe('block-private');
+      expect(body.config?.LOBU_DB_EGRESS_POLICY).toBeUndefined();
+    } finally {
+      process.env.LOBU_CLOUD_MODE = undefined;
+    }
+  });
+
+  it('keeps db_egress_policy block-private even when a tenant plants allow-private in connection config', async () => {
+    // A tenant that plants LOBU_DB_EGRESS_POLICY=allow-private in their
+    // connection config must NOT be able to bypass block-private on cloud: the
+    // gateway ships the authoritative decision on a dedicated field the tenant
+    // does not control, and it does not leak into tenant `config`.
+    const { feedId, connId, orgId } = await setupPostgresFeed({
+      LOBU_DB_EGRESS_POLICY: 'allow-private',
+    });
+    const runId = await insertPendingPostgresRun(orgId, feedId, connId);
+
+    process.env.LOBU_CLOUD_MODE = '1';
+    try {
+      const res = await post('/api/workers/poll', {
+        body: { worker_id: 'cloud-policy-worker-2', capabilities: {} },
+        token: 'test-fleet-token',
+        env: { WORKER_API_TOKEN: 'test-fleet-token' },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        run_id?: number;
+        db_egress_policy?: string;
+        config?: Record<string, unknown>;
+      };
+      expect(Number(body.run_id)).toBe(runId);
+      expect(body.db_egress_policy).toBe('block-private');
+    } finally {
+      process.env.LOBU_CLOUD_MODE = undefined;
+    }
+  });
+
+  it('stamps allow-private when not in cloud mode (self-hosted)', async () => {
+    const { feedId, connId, orgId } = await setupPostgresFeed();
+    const runId = await insertPendingPostgresRun(orgId, feedId, connId);
+
+    process.env.LOBU_CLOUD_MODE = undefined;
+    const res = await post('/api/workers/poll', {
+      body: { worker_id: 'self-hosted-policy-worker', capabilities: {} },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      run_id?: number;
+      db_egress_policy?: string;
+      config?: Record<string, unknown>;
+    };
+    expect(Number(body.run_id)).toBe(runId);
+    expect(body.db_egress_policy).toBe('allow-private');
   });
 });

--- a/packages/server/src/__tests__/integration/connectors/query-sql-pushdown.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/query-sql-pushdown.test.ts
@@ -159,11 +159,17 @@ describe('query_sql connection pushdown', () => {
     expect(ok.error).toBeUndefined();
   }, 60_000);
 
-  it('refuses pushdown for an existing connection under LOBU_CLOUD_MODE', async () => {
+  it('under LOBU_CLOUD_MODE the gate is open but block-private egress fails an internal host closed', async () => {
+    // postgres graduated out of CLOUD_RESTRICTED_CONNECTOR_KEYS, so pushdown is
+    // no longer refused up front ("not available on Lobu Cloud"). Instead the
+    // injected block-private policy takes over — and the test DB is on loopback
+    // (and/or sslmode=disable), so the connector's egress guard rejects it
+    // before any socket opens. That is the cloud security boundary now.
     process.env.LOBU_CLOUD_MODE = '1';
     try {
       const res = await querySql({ sql: 'SELECT 1', connection: 'qsp-ext-db' }, {}, ctx);
-      expect(res.error).toMatch(/Lobu Cloud/i);
+      expect(res.error).not.toMatch(/Lobu Cloud/i);
+      expect(res.error).toMatch(/blocked internal\/metadata|TLS is required/i);
     } finally {
       process.env.LOBU_CLOUD_MODE = undefined;
     }

--- a/packages/server/src/__tests__/integration/db-egress-capability-claim.test.ts
+++ b/packages/server/src/__tests__/integration/db-egress-capability-claim.test.ts
@@ -1,0 +1,183 @@
+/**
+ * DB-egress hardening capability negotiation (PR #1896):
+ *
+ * A `postgres` (and future warehouse) run opens a raw tenant DB socket and
+ * relies on the connector-worker subprocess enforcing block-private egress
+ * (resolve-then-pin IP, DNS-rebind guard, forced TLS). During a rolling deploy
+ * a NEW gateway must NOT hand such a claimed run to an OLD fleet worker that
+ * predates the hardening — that worker ignores `db_egress_policy` and would
+ * reopen private-IP/plaintext egress.
+ *
+ * The gateway therefore refuses, in cloud mode, to dispatch a DB-egress-hardened
+ * connector run to a fleet worker that does NOT advertise `db_egress_hardening`.
+ * The run stays pending until a new worker (which advertises it) claims it.
+ * Self-hosted (non-cloud) mode is unaffected.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { generateSecureToken } from '../../auth/oauth/utils';
+import { cleanupTestDatabase, getTestDb } from '../setup/test-db';
+import { post } from '../setup/test-helpers';
+
+async function seedOrg() {
+  const sql = getTestDb();
+  const userId = `user_${generateSecureToken(4)}`;
+  const orgId = `org-egress-${generateSecureToken(4)}`;
+  await sql`
+    INSERT INTO "user" (id, name, email, "emailVerified", "createdAt", "updatedAt")
+    VALUES (${userId}, 'Egress Owner', ${`${userId}@test.local`}, true, NOW(), NOW())
+  `;
+  await sql`
+    INSERT INTO "organization" (id, name, slug, visibility, metadata, "createdAt")
+    VALUES (
+      ${orgId}, 'Egress Org', ${orgId}, 'private',
+      ${sql.json({ personal_org_for_user_id: userId })}, NOW()
+    )
+  `;
+  await sql`
+    INSERT INTO member (id, "organizationId", "userId", role, "createdAt")
+    VALUES (${`mem_${generateSecureToken(4)}`}, ${orgId}, ${userId}, 'owner', NOW())
+  `;
+  return { userId, orgId };
+}
+
+async function seedConnection(opts: {
+  orgId: string;
+  userId: string;
+  connectorKey: string;
+}): Promise<number> {
+  const sql = getTestDb();
+  const slug = `${opts.connectorKey}-${generateSecureToken(4)}`.replace(/\./g, '-');
+  const [row] = (await sql`
+    INSERT INTO connections (
+      organization_id, connector_key, slug, display_name, status,
+      created_by, visibility, created_at, updated_at
+    ) VALUES (
+      ${opts.orgId}, ${opts.connectorKey}, ${slug}, ${opts.connectorKey}, 'active',
+      ${opts.userId}, 'private', NOW(), NOW()
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+  return Number(row.id);
+}
+
+async function seedPendingSync(opts: {
+  orgId: string;
+  connectionId: number;
+  connectorKey: string;
+}): Promise<number> {
+  const sql = getTestDb();
+  const [row] = (await sql`
+    INSERT INTO runs (
+      organization_id, run_type, connection_id, connector_key,
+      approval_status, status, created_at
+    ) VALUES (
+      ${opts.orgId}, 'sync', ${opts.connectionId}, ${opts.connectorKey},
+      'auto', 'pending', current_timestamp
+    )
+    RETURNING id
+  `) as unknown as Array<{ id: number }>;
+  return Number(row.id);
+}
+
+async function pollFleet(opts: {
+  workerId: string;
+  hardened: boolean;
+}) {
+  return post('/api/workers/poll', {
+    body: {
+      worker_id: opts.workerId,
+      capabilities: opts.hardened ? { db_egress_hardening: true } : {},
+    },
+    token: 'test-fleet-token',
+    env: { WORKER_API_TOKEN: 'test-fleet-token' },
+  });
+}
+
+async function runStatus(runId: number) {
+  const sql = getTestDb();
+  const [row] = (await sql`
+    SELECT status, claimed_by FROM runs WHERE id = ${runId}
+  `) as unknown as Array<{ status: string; claimed_by: string | null }>;
+  return row;
+}
+
+describe('DB-egress capability claim negotiation', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.LOBU_CLOUD_MODE;
+    delete process.env.WORKER_API_TOKEN;
+  });
+  afterEach(async () => {
+    await cleanupTestDatabase();
+    delete process.env.LOBU_CLOUD_MODE;
+    delete process.env.WORKER_API_TOKEN;
+  });
+
+  it('cloud mode: OLD fleet worker (no db_egress_hardening) does NOT claim a postgres run', async () => {
+    process.env.LOBU_CLOUD_MODE = '1';
+    const { userId, orgId } = await seedOrg();
+    const connId = await seedConnection({ orgId, userId, connectorKey: 'postgres' });
+    const runId = await seedPendingSync({ orgId, connectionId: connId, connectorKey: 'postgres' });
+
+    const res = await pollFleet({ workerId: 'old-fleet-worker', hardened: false });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { run_id?: number; skipped_run_id?: number };
+    expect(body.run_id).toBeUndefined();
+    expect(body.skipped_run_id).toBeUndefined();
+
+    const row = await runStatus(runId);
+    expect(row.status).toBe('pending');
+    expect(row.claimed_by).toBeNull();
+  });
+
+  it('cloud mode: NEW fleet worker (db_egress_hardening) DOES claim a postgres run', async () => {
+    process.env.LOBU_CLOUD_MODE = '1';
+    const { userId, orgId } = await seedOrg();
+    const connId = await seedConnection({ orgId, userId, connectorKey: 'postgres' });
+    const runId = await seedPendingSync({ orgId, connectionId: connId, connectorKey: 'postgres' });
+
+    const res = await pollFleet({ workerId: 'new-fleet-worker', hardened: true });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { run_id?: number; skipped_run_id?: number };
+    // Claimed. Without on-disk postgres sources the poll may fail-after-claim
+    // with skipped_run_id — either proves the claim happened.
+    const claimedId = Number(body.run_id ?? body.skipped_run_id);
+    expect(claimedId).toBe(runId);
+
+    const row = await runStatus(runId);
+    expect(row.claimed_by).toBe('new-fleet-worker');
+  });
+
+  it('non-cloud mode: OLD fleet worker (no capability) DOES claim a postgres run (self-host no-op)', async () => {
+    delete process.env.LOBU_CLOUD_MODE;
+    const { userId, orgId } = await seedOrg();
+    const connId = await seedConnection({ orgId, userId, connectorKey: 'postgres' });
+    const runId = await seedPendingSync({ orgId, connectionId: connId, connectorKey: 'postgres' });
+
+    const res = await pollFleet({ workerId: 'selfhost-fleet-worker', hardened: false });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { run_id?: number; skipped_run_id?: number };
+    const claimedId = Number(body.run_id ?? body.skipped_run_id);
+    expect(claimedId).toBe(runId);
+
+    const row = await runStatus(runId);
+    expect(row.claimed_by).toBe('selfhost-fleet-worker');
+  });
+
+  it('cloud mode: OLD fleet worker still claims a NON-hardened connector run (no over-block)', async () => {
+    process.env.LOBU_CLOUD_MODE = '1';
+    const { userId, orgId } = await seedOrg();
+    const connId = await seedConnection({ orgId, userId, connectorKey: 'linkedin' });
+    const runId = await seedPendingSync({ orgId, connectionId: connId, connectorKey: 'linkedin' });
+
+    const res = await pollFleet({ workerId: 'old-fleet-nonhardened', hardened: false });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { run_id?: number; skipped_run_id?: number };
+    const claimedId = Number(body.run_id ?? body.skipped_run_id);
+    expect(claimedId).toBe(runId);
+
+    const row = await runStatus(runId);
+    expect(row.claimed_by).toBe('old-fleet-nonhardened');
+  });
+});

--- a/packages/server/src/catalog/__tests__/installability.test.ts
+++ b/packages/server/src/catalog/__tests__/installability.test.ts
@@ -39,12 +39,16 @@ describe("connector catalog installability", () => {
 		clearCatalogCacheForTests();
 	});
 
-	it("keeps PostgreSQL discoverable in cloud with a machine-readable rejection reason", () => {
+	it("keeps PostgreSQL installable in cloud now that its egress is hardened", () => {
 		process.env.LOBU_CLOUD_MODE = "1";
 
+		// `postgres` graduated out of CLOUD_RESTRICTED_CONNECTOR_KEYS: the
+		// db-egress-guard (block-private + resolve-then-pin IP + forced TLS) is
+		// the platform boundary, so it is installable by cloud tenants like any
+		// other connector. CLOUD_RESTRICTED_CONNECTOR_KEYS is now empty and
+		// stays as the kill-switch for future warehouse connectors.
 		expect(connectorDetail(connectorEntry("postgres", "PostgreSQL"))).toMatchObject({
-			installable: false,
-			installability_reason: "cloud_restricted",
+			installable: true,
 		});
 	});
 
@@ -61,16 +65,25 @@ describe("connector catalog installability", () => {
 		});
 	});
 
-	it("uses the catalog's cloud rejection message when installation is attempted", async () => {
+	it("no longer blocks PostgreSQL install in cloud at the capability gate", async () => {
 		process.env.LOBU_CLOUD_MODE = "1";
+
+		// With CLOUD_RESTRICTED_CONNECTOR_KEYS empty, postgres is no longer
+		// rejected at the cloud capability gate. Installation now proceeds past
+		// that gate (and fails later for an unrelated reason — a bogus org — not
+		// with a `cloud_restricted` message). Assert it does NOT throw the
+		// cloud-restriction message. The stale-source case below still covers the
+		// catalog-rejection-message-on-install path via spotify.
 		const detail = connectorDetail(connectorEntry("postgres", "PostgreSQL"));
+		expect(detail.installable).toBe(true);
+		expect(detail.installability_reason).toBeUndefined();
 
 		await expect(
 			installCatalogConnectorDefinition({
 				organizationId: "unused-before-capability-gate",
 				connectorId: "postgres",
 			}),
-		).rejects.toThrow(String(detail.installability_message));
+		).rejects.not.toThrow("cloud_restricted");
 	});
 
 	it("uses the catalog's stale-source rejection message when installation is attempted", async () => {

--- a/packages/server/src/scheduled/embedded-connector-worker.ts
+++ b/packages/server/src/scheduled/embedded-connector-worker.ts
@@ -62,7 +62,11 @@ export function startEmbeddedConnectorWorker(
       apiUrl,
       workerId,
       workerApiToken: serverEnv.WORKER_API_TOKEN,
-      capabilities: {},
+      // Fleet worker: advertise DB-egress hardening so the gateway will
+      // dispatch db-egress-hardened connector runs (e.g. postgres) here. This
+      // in-process worker ships the same code as the gateway, so it always
+      // folds in the gateway's authoritative db_egress_policy.
+      capabilities: { db_egress_hardening: true },
       pollIntervalMs: intervals.embeddedWorkerPollIntervalMs,
       maxConcurrentJobs: 1,
     },

--- a/packages/server/src/utils/__tests__/connector-cloud-gate.test.ts
+++ b/packages/server/src/utils/__tests__/connector-cloud-gate.test.ts
@@ -9,18 +9,22 @@ describe('connector-cloud-gate', () => {
     process.env.LOBU_CLOUD_MODE = undefined;
   });
 
-  it('postgres is in the restricted set', () => {
-    expect(CLOUD_RESTRICTED_CONNECTOR_KEYS.has('postgres')).toBe(true);
+  it('postgres graduated out of the restricted set (egress hardening shipped)', () => {
+    expect(CLOUD_RESTRICTED_CONNECTOR_KEYS.has('postgres')).toBe(false);
+  });
+
+  it('the kill-switch set is empty until a future warehouse connector needs it', () => {
+    expect(CLOUD_RESTRICTED_CONNECTOR_KEYS.size).toBe(0);
+  });
+
+  it('allows the postgres connector under LOBU_CLOUD_MODE (gate open)', () => {
+    process.env.LOBU_CLOUD_MODE = '1';
+    expect(() => assertConnectorAllowedInCloud('postgres')).not.toThrow();
   });
 
   it('allows the postgres connector self-hosted (cloud mode off)', () => {
     process.env.LOBU_CLOUD_MODE = undefined;
     expect(() => assertConnectorAllowedInCloud('postgres')).not.toThrow();
-  });
-
-  it('blocks the postgres connector under LOBU_CLOUD_MODE', () => {
-    process.env.LOBU_CLOUD_MODE = '1';
-    expect(() => assertConnectorAllowedInCloud('postgres')).toThrow(/Lobu Cloud/i);
   });
 
   it('leaves non-restricted connectors (and null) alone under cloud mode', () => {

--- a/packages/server/src/utils/connector-cloud-gate.ts
+++ b/packages/server/src/utils/connector-cloud-gate.ts
@@ -7,14 +7,19 @@ export type ConnectorCloudAvailability =
 /**
  * Connectors that open arbitrary outbound TCP (raw database sockets) and have no
  * tenant-supplied-URL egress hardening yet — resolve-then-pin IP, DNS-rebinding
- * guard, link-local/metadata + internal-CIDR blocking. They are first-party /
- * self-hosted only until that hardening lands, and must NOT be installable by
- * untrusted multi-tenant cloud tenants (plan §G). Snowflake/BigQuery join this
- * set when they ship.
+ * guard, forced TLS, link-local/metadata + internal-CIDR blocking. Such a
+ * connector is first-party / self-hosted only until its hardening lands, and
+ * must NOT be installable by untrusted multi-tenant cloud tenants (plan §G).
+ *
+ * The set is currently EMPTY — it stays as the kill-switch/holding pen for
+ * future warehouse connectors (Snowflake, BigQuery) until each ships its own
+ * hardening. `postgres` graduated: its egress guard (db-egress-guard.ts)
+ * classifies + rejects internal/metadata hosts under `block-private`, pins the
+ * socket to the validated IP (DNS-rebind closed), and forces TLS. A per-org
+ * destination allowlist is deliberately deferred as an enterprise policy
+ * feature — block-private + pin + TLS is the platform boundary.
  */
-export const CLOUD_RESTRICTED_CONNECTOR_KEYS: ReadonlySet<string> = new Set([
-  'postgres',
-]);
+export const CLOUD_RESTRICTED_CONNECTOR_KEYS: ReadonlySet<string> = new Set([]);
 
 export function getConnectorCloudAvailability(
   connectorKey: string | null | undefined

--- a/packages/server/src/utils/connector-cloud-gate.ts
+++ b/packages/server/src/utils/connector-cloud-gate.ts
@@ -21,6 +21,22 @@ export type ConnectorCloudAvailability =
  */
 export const CLOUD_RESTRICTED_CONNECTOR_KEYS: ReadonlySet<string> = new Set([]);
 
+/**
+ * Connectors that open a raw tenant-supplied DB socket and rely on the
+ * connector-worker subprocess enforcing `block-private` egress (resolve-then-pin
+ * IP, DNS-rebind guard, forced TLS, internal/metadata blocking). In cloud mode a
+ * FLEET worker may only CLAIM a run for one of these connectors if it advertises
+ * the `db_egress_hardening` capability — i.e. it is running the worker code that
+ * folds in the gateway's authoritative `db_egress_policy`. This closes the
+ * rolling-deploy gap where a NEW gateway could hand a claimed `postgres` run to
+ * an OLD worker that ignores the policy and reopens private-IP/plaintext egress.
+ *
+ * Self-hosted (isCloudMode() false) is unaffected — the run is claimable by any
+ * worker. An EMPTY set is a no-op. Future warehouse connectors (snowflake,
+ * bigquery) join this set when they ship their own worker-side hardening.
+ */
+export const DB_EGRESS_HARDENED_CONNECTOR_KEYS: ReadonlySet<string> = new Set(['postgres']);
+
 export function getConnectorCloudAvailability(
   connectorKey: string | null | undefined
 ): ConnectorCloudAvailability {

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -837,6 +837,14 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
     feed_id: row.feed_id ?? undefined,
     connection_id: row.connection_id ?? undefined,
     config: mergeExecutionConfig(row.connection_config, row.feed_config),
+    // The DB egress boundary (private-IP block + IP pin + forced TLS) is decided
+    // by the GATEWAY, which authoritatively knows cloud mode. The out-of-process
+    // connector-worker must NOT re-derive it from its own `LOBU_CLOUD_MODE` — a
+    // fleet worker missing that flag would run `allow-private` and reach private/
+    // metadata IPs (SSRF). Shipped as a dedicated top-level field (not in tenant
+    // `config`) so the worker installs it as authoritative `job.env` and takes the
+    // STRICTER of gateway-vs-worker; block-private can never be downgraded.
+    db_egress_policy: isCloudMode() ? 'block-private' : 'allow-private',
     checkpoint: row.checkpoint ?? undefined,
     entity_ids: row.feed_entity_ids ?? undefined,
     credentials,

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -21,7 +21,10 @@ import {
 } from '../auth/default-provisioning';
 import { reconcileDeviceCapabilities } from './device-reconcile';
 import { findBundledConnectorFile } from '../utils/connector-catalog';
-import { assertConnectorAllowedInCloud } from '../utils/connector-cloud-gate';
+import {
+  DB_EGRESS_HARDENED_CONNECTOR_KEYS,
+  assertConnectorAllowedInCloud,
+} from '../utils/connector-cloud-gate';
 import { resolveConnectorCode } from '../utils/ensure-connector-installed';
 import { resolveDeviceClaimableOrgs } from '../utils/device-claimable-orgs';
 import { errorMessage } from '../utils/errors';
@@ -203,6 +206,17 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   const capabilityMatchSet = isUserScopedWorker
     ? authorizedCapabilities
     : [''].concat(authorizedCapabilities);
+
+  // Capability negotiation for DB-egress-hardened connectors (postgres, future
+  // warehouses). A run for one of these connectors opens a raw tenant DB socket
+  // and depends on the worker enforcing block-private egress. During a rolling
+  // deploy a NEW gateway must NOT hand such a run to an OLD fleet worker that
+  // predates the hardening (it would default to allow-private and reopen
+  // private-IP/plaintext egress). Read the RAW advertised map — this is a fleet
+  // worker, not a device-authorized one, so the platform-authorized set does not
+  // apply. Gated in the (1A) fleet claim branch below; only active in cloud mode.
+  const workerHardensDbEgress = capabilities.db_egress_hardening === true;
+  const dbEgressHardenedKeys = pgTextArray([...DB_EGRESS_HARDENED_CONNECTOR_KEYS]);
 
   // Device-worker registry: upsert device_workers row for user-scoped workers
   // so /api/me/devices can enumerate them. Also ensure advertised capability
@@ -425,6 +439,19 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
                 (
                   ${!isUserScopedWorker}
                   AND COALESCE(cd.required_capability, '') = ANY(${pgTextArray(capabilityMatchSet)}::text[])
+                  -- Capability negotiation: in cloud mode, a fleet worker may
+                  -- only claim a DB-egress-hardened connector run (postgres,
+                  -- future warehouses) if it advertises db_egress_hardening.
+                  -- Old workers that predate the hardening advertise nothing and
+                  -- leave the run pending for a new worker. Empty set / non-cloud
+                  -- / hardened worker => no-op. Device (user-scoped) branches
+                  -- below are untouched: postgres is a fleet no-capability
+                  -- connector, never a device-pinned one, so they never see it.
+                  AND (
+                    ${!isCloudMode()}
+                    OR ${workerHardensDbEgress}
+                    OR NOT (r.connector_key = ANY(${dbEgressHardenedKeys}::text[]))
+                  )
                   AND (
                     con.device_worker_id IS NULL
                     OR (


### PR DESCRIPTION
## What this demonstrates

A runnable example that builds an **org-level context layer** on **stock Lobu** for a fictional coffee-subscription company (Kelder Coffee).

A semantic layer governs the *what* of a metric (the SQL). A context layer governs the *why*: the dated business events that distort a series, the versioned definition changelog, and the verified answers you can diff against later. This example composes an "adjusted churn" series where every anomaly is explained by a governed, sourced record instead of a guess.

The pieces, all on stock primitives:

- **`business-event` entities** — the dated, sourced *why* behind an anomaly (data incident / definition change / external shock), each with a `source_link`.
- **`metric-definition` entity + a supersede chain of `definition` events** — the versioned definition changelog. A new version supersedes the previous one; the chain is the changelog, append-only.
- **A `postgres` connection + a virtual feed** — the monthly churn rollup is pushed down to the warehouse and read **live** via the connector; nothing is copied into Lobu. The connection + auth profile are declared in `lobu.config.ts` (config-as-constructor) and created by `lobu run`.
- **`compose.ts`** — one sandboxed `run_sdk` script joins the live series + business events + definition versions **in JS, no LLM**, into a raw-vs-adjusted narrative citing each source and the governing definition version per month.
- **`verified-query` entity + `drift-check.ts`** — a human-approved answer (SQL + the rows it produced at approval) is pinned; re-running and diffing is the drift canary. `simulate-drift.ts` mutates the warehouse so the canary fires.

## How to run

Requires [Bun](https://bun.sh). Everything runs against an isolated embedded Postgres that `lobu run` boots under `./.lobu-data` — no external or shared database.

```sh
cd examples/context-layer
cp env.example .env
bunx @lobu/cli run          # boots embedded stack, applies lobu.config.ts (installs postgres connector, creates the warehouse connection)
# in a second terminal:
bun run seed:warehouse      # provision the fake warehouse (~2000 subscriptions, deterministic)
bun run seed                # seed the context layer on top
bun run compose             # the money shot — adjusted-churn narrative
bun run drift:simulate      # add one cancellation so the canary has drift to catch
bun run drift               # re-run the pinned query and report the drift
```

The README includes the real captured output (raw 530 in 2026-03 excluded as a data incident, 75 in 2026-05 kept-but-flagged as an external shock, months labelled v1/v2 by the definition in effect, and the drift canary catching a one-cancellation change in 2026-06).

## Notes

- Runs on **stock Lobu** — no server changes. The compose/drift scripts use the standard `run_sdk` sandbox (`client.feeds.readMany`, `client.entities.list`, `client.knowledge.read`). Rendering this context directly inside an agent's prompt/answer (guidance/render) is a separate enhancement, not required for this example.
- Verified end-to-end: `seed:warehouse → seed → compose → drift:simulate → drift` all run green against a locally-booted embedded gateway. `make review BASE=origin/main` is clean (typecheck/unit/integration exit 0, reviewer 0 blockers).

## Follow-up fixes (from review)

1. **Worker path: gateway egress policy now beats tenant config.** The out-of-process worker merged connector config as `{ ...job.env, ...job.config }` — tenant-controlled `job.config` last-wins. Since `splitConfigByFeedScope` does no key allowlisting, a tenant could set `LOBU_DB_EGRESS_POLICY: allow-private` in their connection/feed config and override the gateway's `block-private`, defeating private-IP blocking, IP pinning, and forced TLS on the production worker path. `buildConnectorConfig()` now re-asserts gateway-authoritative security keys from `job.env` as last-wins (matching the invariant the in-process feed-sync / pushdown paths already enforce). Red→green unit test.
2. **`requiredTlsMode` matches postgres.js TLS precedence (no downgrade).** Our forced `ssl` value is authoritative (an explicit `ssl` option beats the URL), so it must resolve the same effective mode the driver would. Two driver rules were missed: (a) duplicate query params are last-wins (`URLSearchParams.get()` returns the first — `?sslmode=require&sslmode=verify-full` would downgrade verify-full to require); (b) `sslrootcert=system` forces `verify-full` unconditionally and last, overriding even `sslmode=disable`. Both now honored. Red→green for duplicate-sslmode, duplicate-ssl, and sslrootcert=system cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added database egress hardening for PostgreSQL in cloud mode, including stricter, gateway-authoritative policy enforcement across queued and background connector runs.
  * Introduced capability-based claiming for hardened runs so only eligible workers execute them.

* **Bug Fixes**
  * Tenant-provided settings can no longer weaken gateway-enforced egress/TLS protections.
  * Strengthened protection against DNS rebinding via resolve-then-pin dialing.

* **Documentation**
  * Updated PostgreSQL connector guidance to reflect the hardened egress model (forced TLS, blocked internal endpoints, and resolve-then-pin behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->