### PR TITLE
docs(examples): context-layer example — governed why over a live warehouse

### DIFF
--- a/config/knip.ts
+++ b/config/knip.ts
@@ -188,6 +188,10 @@ const config: KnipConfig = {
         "examples/**/*.connector.ts",
         "examples/**/*.reaction.ts",
         "examples/**/evals/**/*.ts",
+        // Standalone example run scripts (`bun run seed`, `bun run compose`,
+        // etc. in an example's package.json) are file-path entrypoints, not
+        // imported by the workspace graph — treat them as entries.
+        "examples/**/scripts/**/*.ts",
         // Example test suites run in CI (`bun test examples/personal-agent`,
         // `bun test examples/brand-intelligence`) and locally for the rest.
         "examples/**/__tests__/**/*.ts",

--- a/examples/context-layer/.gitignore
+++ b/examples/context-layer/.gitignore
@@ -1,0 +1,4 @@
+# Local secrets and embedded Postgres data created by `lobu run` / the scripts.
+.env
+.lobu-data/
+.connector-meta-*/

--- a/examples/context-layer/IDENTITY.md
+++ b/examples/context-layer/IDENTITY.md
@@ -1,0 +1,13 @@
+# Analyst
+
+You are the data analyst for Kelder Coffee, a coffee-subscription company.
+
+You answer metric questions using the org's context layer:
+
+- `metric-definition` entities carry the governed definition of each metric —
+  the current version is the unsuperseded `definition` event; the supersede
+  chain is the changelog.
+- `business-event` entities are the governed "why" behind anomalies. Check them
+  before explaining any movement; cite their `source_link`.
+- `verified-query` entities pin approved answers. Prefer them when one matches
+  the question, and flag drift instead of silently quoting stale numbers.

--- a/examples/context-layer/README.md
+++ b/examples/context-layer/README.md
@@ -1,0 +1,173 @@
+# context-layer — a governed "why" over a live warehouse
+
+A **semantic layer** governs the *what* of a metric: the SQL, the joins, the
+canonical definition of `churn_rate`. It answers "what is the number." It does
+not answer "why did the number move," "which months are garbage," or "which
+definition was in effect when this was computed." Those live in people's heads,
+in Slack threads, in a Linear incident nobody linked.
+
+A **context layer** governs the *why*. This example builds one for a fictional
+coffee-subscription company (Kelder Coffee) on **stock Lobu** — no custom
+server, no forked connectors. It reads a live warehouse, overlays the governed
+business context, and composes an "adjusted churn" series where every anomaly is
+explained by a dated, sourced record instead of a guess.
+
+## The story the data tells
+
+The fake warehouse (`subscriptions` table, ~2000 rows) has a deliberately messy
+churn series:
+
+- **30 organic cancellations/month**, steady, Jul 2025 → Jun 2026.
+- **+500 cancellations on 2026-03-12/13** — a bad Recharge billing migration
+  wrote false cancellation rows. The numbers are *wrong*.
+- **+45 cancellations on 2026-05-19..21** — a real courier strike. The numbers
+  are *right* but the cause is external and temporary.
+- **A definition change on 2026-05-01** — churn moves to v2 (a 28-day dunning
+  grace excludes payment-failure cancellations).
+
+Raw churn shows a terrifying 530 in March and an elevated 75 in May. Neither is
+"churn getting worse." A context layer makes that legible without archaeology.
+
+## How the pieces map
+
+| Concept | Where it lives | What it governs |
+|---------|----------------|-----------------|
+| **Business events** | `business-event` entities | The dated, sourced *why* behind an anomaly — a data incident, a definition change, an external shock. Each carries a `source_link` (Linear ticket, decision doc, Slack thread) and an `expected_effect` instruction. |
+| **Definition changelog** | `metric-definition` entity + a supersede chain of `definition` events | The versioned meaning of the metric. A new version **supersedes** the previous one, so the current definition is the one unsuperseded event and the whole chain is the changelog — append-only, never edited. |
+| **Live warehouse federation** | a `postgres` connection + a **virtual feed** | The monthly rollup is pushed down to the warehouse and read **live** at request time through the connector — nothing is copied into Lobu. The numbers are whatever the warehouse says right now. |
+| **Deterministic composition** | `compose.ts` → one sandboxed `run_sdk` script | Joins the live series + business events + definition versions **in JS, no LLM**, into a raw-vs-adjusted series with a flag and a governing version per month. |
+| **Verified-query drift canary** | `verified-query` entity + `drift-check.ts` | A human-approved answer (the exact SQL + the rows it produced at approval time) is pinned. Re-running the query and diffing against the pinned answer is the canary: a mismatch means the warehouse (or a definition) moved and the answer needs re-verification — *before* someone repeats a stale number in a board deck. |
+
+The connection, auth profile, and entity schema are declared in
+`lobu.config.ts` (config-as-constructor) and created by `lobu run`. The seed
+script adds the virtual feed, the definition chain, the business events, and the
+pinned verified answer on top.
+
+```
+context-layer/
+├── lobu.config.ts              # agent, entity types, warehouse connection + auth profile
+├── IDENTITY.md                 # the analyst agent's identity
+├── env.example                 # copy to .env
+└── scripts/
+    ├── seed-warehouse.ts        # provision the fake warehouse (deterministic)
+    ├── seed.ts                  # seed the context layer (feed, definitions, events, pinned answer)
+    ├── compose.ts               # THE MONEY SHOT — adjusted churn narrative
+    ├── simulate-drift.ts        # mutate the warehouse so the canary has something to catch
+    ├── drift-check.ts           # re-run the pinned query, diff vs the approved answer
+    └── lib/{env,gateway}.ts     # shared env + a tiny local-gateway client
+```
+
+## Run it
+
+Requires [Bun](https://bun.sh). Everything runs against an **isolated embedded
+Postgres** that `lobu run` boots under `./.lobu-data` — no external database, no
+shared dev/prod DB.
+
+```sh
+cd examples/context-layer
+cp env.example .env
+
+# 1. Boot the embedded Lobu stack (applies lobu.config.ts: installs the postgres
+#    connector, creates the warehouse connection, registers the entity types).
+#    Leave this running in one terminal.
+bunx @lobu/cli run
+
+# In a second terminal:
+bun run seed:warehouse   # provision the fake Kelder warehouse (~2000 subscriptions)
+bun run seed             # seed the context layer on top of it
+bun run compose          # compose the adjusted-churn narrative  ← the money shot
+bun run drift:simulate   # add one cancellation so the canary has drift to catch
+bun run drift            # re-run the pinned query and report the drift
+```
+
+## Sample output
+
+Real output captured from an end-to-end run against the embedded stack.
+
+### `bun run compose`
+
+```
+Connected to local gateway (org: local-install)
+  (run_sdk: 5 SDK calls in 254ms, sandboxed)
+
+=== Adjusted churn for churn_rate ===
+
+┌────┬─────────┬─────┬──────────┬─────┬───────────────────────────────────┐
+│    │ month   │ raw │ adjusted │ def │ flags                             │
+├────┼─────────┼─────┼──────────┼─────┼───────────────────────────────────┤
+│  0 │ 2025-07 │ 30  │ 30       │ v1  │                                   │
+│  1 │ 2025-08 │ 30  │ 30       │ v1  │                                   │
+│  2 │ 2025-09 │ 30  │ 30       │ v1  │                                   │
+│  3 │ 2025-10 │ 30  │ 30       │ v1  │                                   │
+│  4 │ 2025-11 │ 30  │ 30       │ v1  │                                   │
+│  5 │ 2025-12 │ 30  │ 30       │ v1  │                                   │
+│  6 │ 2026-01 │ 30  │ 30       │ v1  │                                   │
+│  7 │ 2026-02 │ 30  │ 30       │ v1  │                                   │
+│  8 │ 2026-03 │ 530 │ —        │ v1  │ data_incident                     │
+│  9 │ 2026-04 │ 30  │ 30       │ v1  │                                   │
+│ 10 │ 2026-05 │ 75  │ 75       │ v2  │ external_shock, definition_change │
+│ 11 │ 2026-06 │ 30  │ 30       │ v2  │                                   │
+└────┴─────────┴─────┴──────────┴─────┴───────────────────────────────────┘
+
+=== Definition changelog ===
+  v1 (from 2025-07-01): churn_rate v1 = subscriptions cancelled in month / active subscriptions at month start. A subscription churns the day cancelled_at is set.
+  v2 (from 2026-05-01) [current]: churn_rate v2 = cancellations excluding payment-failure cancellations inside a 28-day dunning grace / active subscriptions at month start.
+
+=== Narrative ===
+  • 2026-03: raw 530 EXCLUDED — Recharge billing migration wrote false cancellations (https://linear.app/kelder/issue/DATA-142). Adjusted series drops this month.
+  • 2026-05: raw 75 genuinely elevated — Courier strike (Randstad region) (https://kelder.slack.com/archives/C042/p1747650000). Real but flagged; do not extrapolate.
+  • 2026-05: definition moved to v2 — Churn definition v2: dunning grace period (https://notion.so/kelder/churn-v2). Do not compare raw across the boundary.
+
+Adjusted churn excludes months distorted by data incidents and labels each month with the governed definition version in effect. Every flag cites its source of truth.
+```
+
+The March spike (a data incident) is **excluded** from the adjusted series. The
+May elevation (a real courier strike) is **kept but flagged** — real, temporary,
+don't extrapolate. Every month from 2026-05 is labelled **v2**; earlier months
+**v1**. No LLM ran; the composition is a deterministic join over the live
+warehouse and the governed records.
+
+### `bun run drift:simulate` then `bun run drift`
+
+Before any mutation the pinned answer matches the live warehouse:
+
+```
+Verified query: "How many cancellations did we have per month?"
+Approved by head-of-data on 2026-07-12 (12 pinned rows vs 12 live rows)
+
+✅ No drift — the pinned answer still matches the live warehouse.
+```
+
+`bun run drift:simulate` inserts one new cancellation into 2026-06:
+
+```
+Inserted 1 new cancellation (id 2001) into 2026-06. Warehouse now reports 31 cancellations for that month.
+Run `bun run drift` — the canary should now report drift.
+```
+
+Now the canary fires (and exits non-zero, so CI catches it):
+
+```
+Verified query: "How many cancellations did we have per month?"
+Approved by head-of-data on 2026-07-12 (12 pinned rows vs 12 live rows)
+
+⚠️  DRIFT DETECTED in 1 month(s):
+┌───┬─────────┬────────┬─────────┐
+│   │ month   │ pinned │ current │
+├───┼─────────┼────────┼─────────┤
+│ 0 │ 2026-06 │ 30     │ 31      │
+└───┴─────────┴────────┴─────────┘
+
+The pinned answer is stale. Re-verify before quoting either side.
+```
+
+## Notes
+
+- Runs on **stock Lobu**. The composition and drift scripts use the standard
+  `run_sdk` sandbox (`client.feeds.readMany`, `client.entities.list`,
+  `client.knowledge.read`) — no server changes. Rendering this context directly
+  inside an agent's prompt/answer is a separate enhancement, not required here.
+- The warehouse is deterministic — re-running `bun run seed:warehouse` resets it
+  to the approved state (and clears any simulated drift).
+- The context-layer seed is idempotent: it refuses to double-seed. To reseed,
+  stop `lobu run`, delete `./.lobu-data`, and start over.

--- a/examples/context-layer/env.example
+++ b/examples/context-layer/env.example
@@ -1,0 +1,25 @@
+# Copy to .env before running: cp env.example .env
+# (the repo gitignores .env, so this template ships without the dot)
+
+# Where `lobu run` keeps this example's local data. A filesystem path (not a
+# postgres:// URL) makes `lobu run` boot an embedded Postgres rooted here —
+# fully isolated from any other Lobu install on your machine.
+DATABASE_URL=./.lobu-data
+
+# Pin the embedded Postgres TCP port so the fake warehouse below has a stable
+# address across restarts.
+LOBU_PG_PORT=6543
+
+# The embedded gateway encrypts connector credentials at rest and needs an
+# encryption key. For a throwaway local demo, let it mint an ephemeral one.
+# (For anything you keep, set a real ENCRYPTION_KEY instead so the encrypted
+# rows survive a restart.)
+LOBU_ALLOW_EPHEMERAL_ENCRYPTION_KEY=1
+
+# The fake Kelder Coffee warehouse. By default it lives as a second database
+# inside the embedded cluster above — zero extra prerequisites. Point it at any
+# other local Postgres if you prefer (the seed script creates the database).
+KELDER_WAREHOUSE_URL=postgresql://postgres:postgres@127.0.0.1:6543/kelder_warehouse?sslmode=disable
+
+# Where the scripts find the local gateway (default matches `lobu run`).
+# LOBU_URL=http://127.0.0.1:8787

--- a/examples/context-layer/lobu.config.ts
+++ b/examples/context-layer/lobu.config.ts
@@ -1,0 +1,300 @@
+/**
+ * Kelder Coffee — an org-level CONTEXT LAYER on stock Lobu.
+ *
+ * A semantic layer governs the WHAT of a metric (the SQL). A context layer
+ * governs the WHY: the dated business events that distort a series, the
+ * versioned definition changelog, and the verified answers you can diff
+ * against later. This config declares that schema; the entity/field
+ * descriptions below are not decoration — they are the context agents get
+ * when they touch these records, so they are written as instructions.
+ *
+ * No `org:` on purpose — `lobu run` auto-applies this config to the local
+ * bootstrap org of the embedded server.
+ */
+import {
+  defineAgent,
+  defineAuthProfile,
+  defineConfig,
+  defineConnection,
+  defineEntityType,
+} from "@lobu/cli/config";
+
+const analyst = defineAgent({
+  id: "analyst",
+  dir: ".",
+  name: "analyst",
+  description:
+    "Answers metric questions for Kelder Coffee. Must consult business-event " +
+    "records and the current metric-definition version before explaining any " +
+    "movement in a series — never speculate about a spike that has a governed why.",
+});
+
+/**
+ * The warehouse connection, declared as config (config-as-constructor). `lobu
+ * run` applies this: it installs the bundled `postgres` connector and creates
+ * an authenticated, read-only connection to the fake Kelder warehouse. The
+ * credential is a `$VAR` reference resolved from the environment at apply time —
+ * it never lives in committed code. The seed then adds a VIRTUAL feed on top of
+ * this connection (the live churn rollup).
+ */
+const warehouseAuth = defineAuthProfile({
+  slug: "kelder-warehouse",
+  connector: "postgres",
+  authKind: "env",
+  name: "Kelder warehouse (read-only)",
+  credentials: { DATABASE_URL: "$KELDER_WAREHOUSE_URL" },
+});
+
+const warehouse = defineConnection({
+  slug: "kelder-warehouse",
+  connector: "postgres",
+  name: "Kelder warehouse",
+  authProfile: warehouseAuth,
+});
+
+/**
+ * The "governed why" record. One row per thing-that-happened that a metric
+ * reader must know about. This is the heart of the context layer: anomaly
+ * explanations become lookups instead of archaeology.
+ */
+const businessEvent = defineEntityType({
+  key: "business-event",
+  name: "Business Event",
+  description:
+    "A dated, sourced record of something that changed or distorted a metric — " +
+    "a data incident, a definition change, an external shock, a campaign, or a " +
+    "pricing change. Before explaining any movement in a metric, check the " +
+    "business events overlapping that period; if one exists, cite it (with its " +
+    "source_link) instead of speculating.",
+  required: ["event_date", "event_type"],
+  properties: {
+    event_date: {
+      type: "string",
+      description: "ISO date (YYYY-MM-DD) the event took effect.",
+      "x-table-label": "Date",
+      "x-table-column": true,
+    },
+    event_type: {
+      type: "string",
+      enum: [
+        "data_incident",
+        "definition_change",
+        "external_shock",
+        "campaign",
+        "pricing_change",
+      ],
+      description:
+        "What kind of why this is. data_incident = the numbers are wrong " +
+        "(exclude/repair them); definition_change = the metric's meaning moved; " +
+        "external_shock = the numbers are right but the cause is external and " +
+        "temporary; campaign/pricing_change = self-inflicted, expected shifts.",
+      "x-table-label": "Type",
+      "x-table-column": true,
+    },
+    affected_metrics: {
+      type: "array",
+      items: { type: "string" },
+      description:
+        "Metric slugs this event distorts or shifts (must match a " +
+        "metric-definition entity's metric slug, e.g. churn_rate).",
+      "x-table-label": "Affects",
+      "x-table-column": true,
+    },
+    expected_effect: {
+      type: "string",
+      description:
+        "Operative instruction for anyone reading the affected metrics: what " +
+        "the series will look like and how to treat it (e.g. 'exclude 2026-03 " +
+        "from churn trend — rows are migration artifacts, not real churn').",
+    },
+    owner: {
+      type: "string",
+      description: "Person or team accountable for this record being correct.",
+      "x-table-label": "Owner",
+    },
+    source_link: {
+      type: "string",
+      description:
+        "Deep link to the source of truth — incident ticket, decision doc, or " +
+        "Slack thread. Always cite this when the event is used in an answer.",
+    },
+  },
+});
+
+/**
+ * The versioned definition of a business metric. The definition text lives in
+ * `definition` EVENTS attached to this entity; a new version supersedes the
+ * previous one, so the current definition is the one unsuperseded event and
+ * the full supersede chain is the changelog — append-only, never edited.
+ *
+ * The eventSets/measures/dimensions below are the DECLARED metric contract
+ * (metrics_config): governed aggregations over observation events recorded in
+ * Lobu, resolved to this entity via its metadata.aliases.
+ */
+const metricDefinition = defineEntityType({
+  key: "metric-definition",
+  name: "Metric Definition",
+  description:
+    "The governed definition of one business metric, versioned over time. Read " +
+    "the current `definition` event before computing or explaining the metric; " +
+    "when a month straddles a definition change, say which version was in " +
+    "effect. metadata.aliases carries the metric slug so observation events " +
+    "resolve to this entity.",
+  required: ["metric"],
+  properties: {
+    metric: {
+      type: "string",
+      description: "Stable metric slug, e.g. churn_rate.",
+      "x-table-label": "Metric",
+      "x-table-column": true,
+    },
+    unit: {
+      type: "string",
+      description: "Unit of the metric's readings (e.g. cancellations/month).",
+    },
+    owner: {
+      type: "string",
+      description: "Team that owns this metric's definition.",
+      "x-table-label": "Owner",
+    },
+    aliases: {
+      type: "array",
+      items: { type: "string" },
+      description:
+        "Alias strings observation events use to resolve to this entity — an " +
+        "observation's metadata.metric must equal one of these.",
+    },
+  },
+  eventKinds: {
+    definition: {
+      description:
+        "One version of this metric's definition. Save a new version with " +
+        "supersedes_event_id pointing at the previous version's event — the " +
+        "chain is the changelog and only the newest version stays current.",
+      metadataSchema: {
+        type: "object",
+        properties: {
+          version: {
+            type: "string",
+            description: "Version tag, e.g. v2.",
+          },
+          effective_from: {
+            type: "string",
+            description:
+              "ISO date this version starts governing the metric. Earlier " +
+              "periods stay governed by the version that preceded it.",
+          },
+          approved_by: {
+            type: "string",
+            description: "Who signed off on this version.",
+          },
+        },
+        required: ["version", "effective_from"],
+      },
+    },
+    observation: {
+      description:
+        "A periodic reading of this metric recorded in Lobu. metadata.metric " +
+        "must equal one of the entity's aliases so the declared measures below " +
+        "resolve it.",
+      metadataSchema: {
+        type: "object",
+        properties: {
+          metric: { type: "string", description: "Metric slug (alias match)." },
+          month: {
+            type: "string",
+            description: "Observation month (YYYY-MM).",
+          },
+          cancellations: {
+            type: "number",
+            description: "Cancellations recorded for the month.",
+          },
+        },
+        required: ["metric", "month", "cancellations"],
+      },
+    },
+  },
+  // Declared metric contract — compiled server-side, queryable via
+  // client.metrics.query / the metric catalog. No on-read inference.
+  eventSets: {
+    churn_observations: {
+      by: "alias",
+      field: "metadata->>'metric'",
+      where: "semantic_type = 'observation'",
+    },
+  },
+  measures: {
+    total_cancellations: {
+      eventSet: "churn_observations",
+      agg: "sum",
+      expr: "(metadata->>'cancellations')::numeric",
+      description: "Total recorded cancellations from internal observations.",
+    },
+  },
+  dimensions: {
+    month: {
+      expr: "metadata->>'month'",
+      description: "Observation month (YYYY-MM).",
+    },
+  },
+});
+
+/**
+ * The trust loop: a question answered once, correctly, then pinned. Re-running
+ * the SQL and diffing against the approved answer is the drift canary — a
+ * mismatch means the warehouse (or a definition) moved and the answer needs
+ * re-verification, BEFORE someone repeats a stale number in a board deck.
+ */
+const verifiedQuery = defineEntityType({
+  key: "verified-query",
+  name: "Verified Query",
+  description:
+    "A business question with a human-approved, pinned answer: the exact SQL " +
+    "plus the result rows it produced at approval time. Prefer these over " +
+    "ad-hoc SQL when one matches the question. If the drift check reports a " +
+    "mismatch, treat the pinned answer as stale and flag it for " +
+    "re-verification — do not silently quote either side.",
+  required: ["question", "sql"],
+  properties: {
+    question: {
+      type: "string",
+      description: "The business question this query answers, verbatim.",
+      "x-table-label": "Question",
+      "x-table-column": true,
+    },
+    sql: {
+      type: "string",
+      description:
+        "The exact read-only SQL that produced the approved answer. Runs " +
+        "against the warehouse connection (same query the virtual feed uses).",
+    },
+    approved_answer: {
+      type: "array",
+      items: { type: "object" },
+      description:
+        "The result rows pinned at approval time. The drift canary diffs live " +
+        "results against these.",
+    },
+    approved_by: {
+      type: "string",
+      description: "Who verified and approved the answer.",
+      "x-table-label": "Approved by",
+    },
+    approved_at: {
+      type: "string",
+      description: "ISO date of approval.",
+      "x-table-label": "Approved",
+      "x-table-column": true,
+    },
+  },
+});
+
+export default defineConfig({
+  orgName: "Kelder Coffee",
+  orgDescription:
+    "Fictional coffee-subscription company demonstrating Lobu as an org-level context layer",
+  agents: [analyst],
+  entities: [businessEvent, metricDefinition, verifiedQuery],
+  authProfiles: [warehouseAuth],
+  connections: [warehouse],
+});

--- a/examples/context-layer/package.json
+++ b/examples/context-layer/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@lobu/example-context-layer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "seed:warehouse": "bun scripts/seed-warehouse.ts",
+    "seed": "bun scripts/seed.ts",
+    "compose": "bun scripts/compose.ts",
+    "drift": "bun scripts/drift-check.ts",
+    "drift:simulate": "bun scripts/simulate-drift.ts"
+  },
+  "devDependencies": {
+    "@lobu/cli": "^14.0.0",
+    "postgres": "^3.4.7"
+  }
+}

--- a/examples/context-layer/scripts/compose.ts
+++ b/examples/context-layer/scripts/compose.ts
@@ -1,0 +1,205 @@
+/**
+ * THE MONEY SHOT — compose the "governed why" over a LIVE warehouse.
+ *
+ * One sandboxed `run_sdk` script does the whole join, in-process, on the
+ * gateway:
+ *
+ *   1. `client.feeds.readMany` on the VIRTUAL churn feed — the monthly rollup
+ *      is pushed down to the warehouse and read LIVE. Nothing is copied into
+ *      Lobu; the numbers are whatever the warehouse says right now.
+ *   2. `client.entities.list` on `business-event` — the dated, sourced records
+ *      that explain the distortions in that series.
+ *   3. `client.knowledge.read({ include_superseded: true })` on the
+ *      `metric-definition` entity — the definition changelog (the supersede
+ *      chain), so each month can be labelled with the version in effect.
+ *
+ * The script joins these by month in plain JS and returns a composed narrative:
+ * raw vs adjusted churn per month, a flag per month citing each overlapping
+ * business event's `source_link`, and the definition version governing it.
+ *
+ * The composition is deterministic — no LLM. The context layer turns "why did
+ * March spike?" from archaeology into a lookup.
+ *
+ * Prereqs: `lobu run` is up here, and `seed:warehouse` + `seed` have run.
+ */
+
+import { connectLocalGateway, runSdkSource } from "./lib/gateway.ts";
+
+/**
+ * The sandboxed SDK script. Exports `default async (ctx, client) => ...`; the
+ * gateway runs it in-process with a scoped `client`. Everything inside this
+ * template literal executes on the server, NOT in this Bun process.
+ */
+const SANDBOX_SCRIPT = `
+export default async (_ctx, client) => {
+  // ── 1. Resolve the pieces of the context layer ──────────────────────────
+  const feedList = await client.feeds.list({});
+  const churnFeed = (feedList.feeds ?? []).find(
+    (f) => f.kind === "virtual" && f.feed_key === "query",
+  );
+  if (!churnFeed) throw new Error("virtual churn feed not found — run seed first");
+
+  const metricList = await client.entities.list({ entity_type: "metric-definition" });
+  const metric = (metricList.entities ?? [])[0];
+  if (!metric) throw new Error("metric-definition entity not found — run seed first");
+
+  const eventList = await client.entities.list({ entity_type: "business-event" });
+  const businessEvents = eventList.entities ?? [];
+
+  // ── 2. Read the churn rollup LIVE from the warehouse (pushdown) ──────────
+  const feedRead = await client.feeds.readMany({ feed_ids: [churnFeed.id] });
+  const feedResult = (feedRead.results ?? []).find((r) => r.ok);
+  if (!feedResult) {
+    throw new Error("virtual feed read failed: " + JSON.stringify(feedRead));
+  }
+  const churnRows = feedResult.result.rows ?? [];
+
+  // ── 3. Read the definition changelog (supersede chain) ──────────────────
+  const changelogRes = await client.knowledge.read({
+    entity_id: metric.id,
+    semantic_type: "definition",
+    include_superseded: true,
+    sort_by: "date",
+    sort_order: "asc",
+  });
+  // knowledge.read (get_content) returns { content: ContentItem[] }; each item's
+  // body is text_content. Read those shapes directly so a real API change fails
+  // loudly instead of silently yielding [].
+  const changelog = (changelogRes.content ?? [])
+    .map((e) => ({
+      id: e.id,
+      title: e.title,
+      definition: e.text_content,
+      version: e.metadata?.version,
+      effective_from: e.metadata?.effective_from,
+    }))
+    .sort((a, b) => String(a.effective_from).localeCompare(String(b.effective_from)));
+
+  // Which definition version governs a given YYYY-MM month?
+  const versionFor = (month) => {
+    let current = changelog[0];
+    for (const def of changelog) {
+      if (String(def.effective_from).slice(0, 7) <= month) current = def;
+    }
+    return current?.version ?? null;
+  };
+  changelog.forEach((d, i) => {
+    d.is_current = i === changelog.length - 1;
+  });
+
+  // ── 4. Join by month in JS ──────────────────────────────────────────────
+  const months = churnRows.map((row) => {
+    const month = String(row.month);
+    const raw = Number(row.cancellations);
+
+    // Business events overlapping this month.
+    const flags = businessEvents
+      .filter((ev) => String(ev.metadata?.event_date ?? "").slice(0, 7) === month)
+      .map((ev) => ({
+        event: ev.name,
+        type: ev.metadata?.event_type,
+        date: ev.metadata?.event_date,
+        source: ev.metadata?.source_link,
+      }));
+
+    // A data_incident means the numbers are WRONG — exclude that month from the
+    // adjusted series. Everything else is real (keep the number, keep the flag).
+    const excluded = flags.some((f) => f.type === "data_incident");
+
+    return {
+      month,
+      raw_cancellations: raw,
+      adjusted_cancellations: excluded ? null : raw,
+      excluded,
+      flags,
+      definition_version: versionFor(month),
+    };
+  });
+
+  // ── 5. A human-readable narrative citing sources + versions ─────────────
+  const lines = [];
+  for (const m of months) {
+    for (const f of m.flags) {
+      if (f.type === "data_incident") {
+        lines.push(
+          m.month + ": raw " + m.raw_cancellations + " EXCLUDED — " + f.event +
+            " (" + f.source + "). Adjusted series drops this month.",
+        );
+      } else if (f.type === "definition_change") {
+        lines.push(
+          m.month + ": definition moved to " + m.definition_version + " — " +
+            f.event + " (" + f.source + "). Do not compare raw across the boundary.",
+        );
+      } else {
+        lines.push(
+          m.month + ": raw " + m.raw_cancellations + " genuinely elevated — " +
+            f.event + " (" + f.source + "). Real but flagged; do not extrapolate.",
+        );
+      }
+    }
+  }
+
+  return {
+    metric: metric.name,
+    months,
+    narrative: {
+      definitions_changelog: changelog,
+      flagged_months: lines,
+      summary:
+        "Adjusted churn excludes months distorted by data incidents and labels " +
+        "each month with the governed definition version in effect. Every flag " +
+        "cites its source of truth.",
+    },
+  };
+};
+`;
+
+interface Composed {
+  metric: string;
+  months: Array<{
+    month: string;
+    raw_cancellations: number;
+    adjusted_cancellations: number | null;
+    excluded: boolean;
+    flags: Array<{ event: string; type: string; date: string; source: string }>;
+    definition_version: string | null;
+  }>;
+  narrative: {
+    definitions_changelog: Array<{
+      version: string;
+      effective_from: string;
+      definition: string;
+      is_current: boolean;
+    }>;
+    flagged_months: string[];
+    summary: string;
+  };
+}
+
+const gw = await connectLocalGateway();
+console.log(`Connected to local gateway (org: ${gw.org})`);
+
+const composed = await runSdkSource<Composed>(gw, SANDBOX_SCRIPT);
+
+console.log(`\n=== Adjusted churn for ${composed.metric} ===\n`);
+const table = composed.months.map((m) => ({
+  month: m.month,
+  raw: m.raw_cancellations,
+  adjusted: m.excluded ? "—" : m.adjusted_cancellations,
+  def: m.definition_version,
+  flags: m.flags.map((f) => f.type).join(", ") || "",
+}));
+console.table(table);
+
+console.log("\n=== Definition changelog ===");
+for (const d of composed.narrative.definitions_changelog) {
+  console.log(
+    `  ${d.version} (from ${d.effective_from})${d.is_current ? " [current]" : ""}: ${d.definition}`
+  );
+}
+
+console.log("\n=== Narrative ===");
+for (const line of composed.narrative.flagged_months) {
+  console.log(`  • ${line}`);
+}
+console.log(`\n${composed.narrative.summary}`);

--- a/examples/context-layer/scripts/drift-check.ts
+++ b/examples/context-layer/scripts/drift-check.ts
@@ -1,0 +1,106 @@
+/**
+ * The trust loop's drift canary.
+ *
+ * A `verified-query` entity pins a human-approved answer: the exact rollup SQL
+ * plus the result rows it produced at approval time. This script re-reads the
+ * SAME rollup LIVE from the warehouse (through the virtual-feed pushdown — the
+ * path an analyst would actually use) and diffs it against the pinned
+ * `approved_answer`.
+ *
+ * No drift  → the pinned answer is still trustworthy; quote it freely.
+ * Drift     → the warehouse (or a definition) moved. Treat the pinned answer as
+ *             stale and flag it for re-verification BEFORE anyone repeats a
+ *             number that no longer matches reality.
+ *
+ * Run `bun run drift:simulate` first to see it catch a real change.
+ *
+ * Prereqs: `lobu run` is up here, and `seed:warehouse` + `seed` have run.
+ */
+
+import { connectLocalGateway, runSdkSource } from "./lib/gateway.ts";
+
+const SANDBOX_SCRIPT = `
+export default async (_ctx, client) => {
+  // ── The pinned, approved answer ─────────────────────────────────────────
+  const vqList = await client.entities.list({ entity_type: "verified-query" });
+  const vq = (vqList.entities ?? [])[0];
+  if (!vq) throw new Error("verified-query entity not found — run seed first");
+  const pinned = (vq.metadata?.approved_answer ?? []).map((r) => ({
+    month: String(r.month),
+    cancellations: Number(r.cancellations),
+  }));
+
+  // ── The LIVE answer, re-read through the same virtual-feed pushdown ──────
+  const feedList = await client.feeds.list({});
+  const churnFeed = (feedList.feeds ?? []).find(
+    (f) => f.kind === "virtual" && f.feed_key === "query",
+  );
+  if (!churnFeed) throw new Error("virtual churn feed not found — run seed first");
+  const feedRead = await client.feeds.readMany({ feed_ids: [churnFeed.id] });
+  const feedResult = (feedRead.results ?? []).find((r) => r.ok);
+  if (!feedResult) throw new Error("virtual feed read failed: " + JSON.stringify(feedRead));
+  const live = (feedResult.result.rows ?? []).map((r) => ({
+    month: String(r.month),
+    cancellations: Number(r.cancellations),
+  }));
+
+  // ── Diff by month ───────────────────────────────────────────────────────
+  const pinnedByMonth = Object.fromEntries(pinned.map((r) => [r.month, r.cancellations]));
+  const liveByMonth = Object.fromEntries(live.map((r) => [r.month, r.cancellations]));
+  const months = [...new Set([...Object.keys(pinnedByMonth), ...Object.keys(liveByMonth)])].sort();
+
+  const drift = [];
+  for (const month of months) {
+    const p = pinnedByMonth[month];
+    const c = liveByMonth[month];
+    if (p !== c) drift.push({ month, pinned: p ?? null, current: c ?? null });
+  }
+
+  return {
+    question: vq.metadata?.question,
+    approved_by: vq.metadata?.approved_by,
+    approved_at: vq.metadata?.approved_at,
+    pinned_rows: pinned.length,
+    live_rows: live.length,
+    drift,
+  };
+};
+`;
+
+interface DriftReport {
+  question: string;
+  approved_by: string;
+  approved_at: string;
+  pinned_rows: number;
+  live_rows: number;
+  drift: Array<{
+    month: string;
+    pinned: number | null;
+    current: number | null;
+  }>;
+}
+
+const gw = await connectLocalGateway();
+console.log(`Connected to local gateway (org: ${gw.org})`);
+
+const report = await runSdkSource<DriftReport>(gw, SANDBOX_SCRIPT);
+
+console.log(`\nVerified query: "${report.question}"`);
+console.log(
+  `Approved by ${report.approved_by} on ${report.approved_at} ` +
+    `(${report.pinned_rows} pinned rows vs ${report.live_rows} live rows)\n`
+);
+
+if (report.drift.length === 0) {
+  console.log(
+    "✅ No drift — the pinned answer still matches the live warehouse."
+  );
+} else {
+  console.log(`⚠️  DRIFT DETECTED in ${report.drift.length} month(s):`);
+  console.table(report.drift);
+  console.log(
+    "\nThe pinned answer is stale. Re-verify before quoting either side.\n" +
+      "(This is the canary firing on purpose — run `bun run drift:simulate` mutated the warehouse.)"
+  );
+  process.exitCode = 1;
+}

--- a/examples/context-layer/scripts/lib/env.ts
+++ b/examples/context-layer/scripts/lib/env.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared environment defaults for the example scripts. Bun auto-loads `.env`
+ * from the working directory; these fall back to the values in `env.example`
+ * so the scripts also work without one.
+ */
+
+export const GATEWAY_URL = (
+  process.env.LOBU_URL ?? "http://127.0.0.1:8787"
+).replace(/\/$/, "");
+
+export const WAREHOUSE_URL =
+  process.env.KELDER_WAREHOUSE_URL ??
+  "postgresql://postgres:postgres@127.0.0.1:6543/kelder_warehouse?sslmode=disable";
+
+/** The one governed rollup — the virtual feed's live query AND the pinned
+ *  verified query are this exact SQL. */
+export const CHURN_ROLLUP_SQL = `SELECT to_char(date_trunc('month', cancelled_at), 'YYYY-MM') AS month,
+       count(*)::int AS cancellations
+  FROM subscriptions
+ WHERE cancelled_at IS NOT NULL
+ GROUP BY 1
+ ORDER BY 1`;
+
+/** Admin URL for the warehouse server (same server, `postgres` database) —
+ *  used only to CREATE DATABASE kelder_warehouse. */
+export function warehouseAdminUrl(): string {
+  const url = new URL(WAREHOUSE_URL);
+  url.pathname = "/postgres";
+  return url.toString();
+}
+
+export function warehouseDbName(): string {
+  return (
+    new URL(WAREHOUSE_URL).pathname.replace(/^\//, "") || "kelder_warehouse"
+  );
+}

--- a/examples/context-layer/scripts/lib/gateway.ts
+++ b/examples/context-layer/scripts/lib/gateway.ts
@@ -1,0 +1,104 @@
+/**
+ * Minimal client for the LOCAL Lobu gateway started by `lobu run`.
+ *
+ * Auth: `POST /api/local-init` mints a session for the single-operator local
+ * install (loopback-only endpoint; `X-Lobu-Client` is its CSRF gate). Tools
+ * are then plain REST: `POST /api/:orgSlug/:toolName` with a bearer token —
+ * the same admin surface `lobu call` uses.
+ */
+
+import { GATEWAY_URL } from "./env.ts";
+
+export interface Gateway {
+  base: string;
+  org: string;
+  token: string;
+}
+
+export async function connectLocalGateway(): Promise<Gateway> {
+  let res: Response;
+  try {
+    res = await fetch(`${GATEWAY_URL}/api/local-init`, {
+      method: "POST",
+      headers: { "X-Lobu-Client": "context-layer-example" },
+    });
+  } catch (err) {
+    throw new Error(
+      `Cannot reach the local gateway at ${GATEWAY_URL} — is \`lobu run\` running in this directory? (${err})`
+    );
+  }
+  if (!res.ok) {
+    throw new Error(
+      `local-init failed (${res.status}): ${await res.text()} — this example needs the embedded local server started by \`lobu run\`.`
+    );
+  }
+  const body = (await res.json()) as {
+    session_token?: string;
+    device_token?: string;
+    organization?: { slug?: string };
+  };
+  const token = body.session_token ?? body.device_token;
+  const org = body.organization?.slug;
+  if (!token || !org) {
+    throw new Error(
+      `local-init returned no session/org: ${JSON.stringify(body)}`
+    );
+  }
+  return { base: GATEWAY_URL, org, token };
+}
+
+export async function callTool<T = Record<string, unknown>>(
+  gw: Gateway,
+  tool: string,
+  args: Record<string, unknown>
+): Promise<T> {
+  const res = await fetch(`${gw.base}/api/${gw.org}/${tool}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${gw.token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(args),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`${tool} failed (${res.status}): ${text}`);
+  }
+  return JSON.parse(text) as T;
+}
+
+interface SdkScriptResult {
+  success: boolean;
+  return_value?: unknown;
+  logs: Array<{ level: string; message: string }>;
+  error?: { name: string; message: string; line?: number };
+  duration_ms: number;
+  sdk_calls: number;
+}
+
+/**
+ * Submit a sandboxed SDK script SOURCE (a string exporting
+ * `default async (ctx, client) => ...`) to the gateway's `run_sdk` tool and
+ * return its return_value. The example keeps its sandbox body inline in the
+ * calling script for readability, so the source is passed directly. Script logs
+ * are forwarded to the terminal.
+ */
+export async function runSdkSource<T>(gw: Gateway, script: string): Promise<T> {
+  const result = await callTool<SdkScriptResult>(gw, "run_sdk", {
+    script,
+    timeout_ms: 60_000,
+  });
+  for (const log of result.logs ?? []) {
+    console.error(`  [sandbox:${log.level}] ${log.message}`);
+  }
+  if (!result.success) {
+    throw new Error(
+      `run_sdk script failed: ${result.error?.name}: ${result.error?.message}` +
+        (result.error?.line ? ` (line ${result.error.line})` : "")
+    );
+  }
+  console.error(
+    `  (run_sdk: ${result.sdk_calls} SDK calls in ${result.duration_ms}ms, sandboxed)`
+  );
+  return result.return_value as T;
+}

--- a/examples/context-layer/scripts/seed-warehouse.ts
+++ b/examples/context-layer/scripts/seed-warehouse.ts
@@ -1,0 +1,157 @@
+/**
+ * Provision the fake Kelder Coffee warehouse: a `kelder_warehouse` database
+ * with one `subscriptions` table (~2000 rows). Deterministic — reseeding
+ * always produces the same data.
+ *
+ * The shape of the story (what the context layer will explain):
+ *  - 30 organic cancellations per month, 2025-07 .. 2026-06
+ *  - +500 cancellations on 2026-03-12/13 — billing-migration artifacts
+ *    (rows written by a bad Recharge migration, not customers leaving)
+ *  - +45 cancellations on 2026-05-19..21 — a courier strike (real, temporary)
+ *
+ * By default the database is created inside the embedded Postgres cluster
+ * `lobu run` boots for this example (LOBU_PG_PORT pins its port), so there is
+ * no external prerequisite. Point KELDER_WAREHOUSE_URL at any local Postgres
+ * (e.g. the dev-stack one) to use that instead. Run `lobu run` first.
+ */
+
+import postgres from "postgres";
+import {
+  WAREHOUSE_URL,
+  warehouseAdminUrl,
+  warehouseDbName,
+} from "./lib/env.ts";
+
+const PLANS = ["starter", "regular", "fanatic"] as const;
+const TOTAL_SUBSCRIPTIONS = 2000;
+
+interface SubscriptionRow {
+  id: number;
+  customer_id: number;
+  plan: string;
+  started_at: string;
+  cancelled_at: string | null;
+  cancel_reason: string | null;
+}
+
+function iso(d: Date): string {
+  return d.toISOString();
+}
+
+function daysBefore(date: Date, days: number): Date {
+  return new Date(date.getTime() - days * 86_400_000);
+}
+
+/** Build the deterministic cancellation schedule: [date, reason][] */
+function cancellationSchedule(): Array<[Date, string]> {
+  const out: Array<[Date, string]> = [];
+  // 30 organic cancellations per month, 2025-07 .. 2026-06.
+  const months: Array<[number, number]> = [];
+  for (let m = 6; m < 12; m++) months.push([2025, m]); // Jul..Dec 2025
+  for (let m = 0; m < 6; m++) months.push([2026, m]); // Jan..Jun 2026
+  for (const [year, month] of months) {
+    for (let i = 0; i < 30; i++) {
+      const day = 1 + ((i * 7 + month) % 27);
+      out.push([
+        new Date(Date.UTC(year, month, day, 9 + (i % 12))),
+        "customer_request",
+      ]);
+    }
+  }
+  // 2026-03: the billing migration writes ~500 false cancellations on 12/13.
+  for (let i = 0; i < 500; i++) {
+    const day = i < 250 ? 12 : 13;
+    out.push([
+      new Date(Date.UTC(2026, 2, day, i % 24, (i * 13) % 60)),
+      "billing_migration_artifact",
+    ]);
+  }
+  // 2026-05: courier strike, 45 extra genuine cancellations on 19..21.
+  for (let i = 0; i < 45; i++) {
+    const day = 19 + (i % 3);
+    out.push([
+      new Date(Date.UTC(2026, 4, day, 10 + (i % 10))),
+      "courier_strike",
+    ]);
+  }
+  return out;
+}
+
+function buildRows(): SubscriptionRow[] {
+  const cancellations = cancellationSchedule();
+  const rows: SubscriptionRow[] = [];
+  for (let i = 0; i < TOTAL_SUBSCRIPTIONS; i++) {
+    const cancelled = i < cancellations.length ? cancellations[i]! : null;
+    const started = cancelled
+      ? daysBefore(cancelled[0], 90 + ((i * 17) % 300))
+      : new Date(Date.UTC(2025, 0, 1 + ((i * 11) % 540)));
+    rows.push({
+      id: i + 1,
+      customer_id: 10_000 + i,
+      plan: PLANS[i % PLANS.length]!,
+      started_at: iso(started),
+      cancelled_at: cancelled ? iso(cancelled[0]) : null,
+      cancel_reason: cancelled ? cancelled[1] : null,
+    });
+  }
+  return rows;
+}
+
+async function ensureDatabase(): Promise<void> {
+  const admin = postgres(warehouseAdminUrl(), { max: 1 });
+  const dbName = warehouseDbName();
+  if (!/^[a-z_][a-z0-9_]*$/.test(dbName)) {
+    throw new Error(`Unsafe warehouse database name: ${dbName}`);
+  }
+  try {
+    await admin.unsafe(`CREATE DATABASE ${dbName}`);
+    console.log(`Created database ${dbName}`);
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code !== "42P04") throw err; // 42P04 = already exists
+    console.log(`Database ${dbName} already exists`);
+  } finally {
+    await admin.end();
+  }
+}
+
+async function main() {
+  await ensureDatabase();
+
+  const sql = postgres(WAREHOUSE_URL, { max: 1 });
+  try {
+    await sql`DROP TABLE IF EXISTS subscriptions`;
+    await sql`CREATE TABLE subscriptions (
+      id            integer PRIMARY KEY,
+      customer_id   integer NOT NULL,
+      plan          text NOT NULL,
+      started_at    timestamptz NOT NULL,
+      cancelled_at  timestamptz,
+      cancel_reason text
+    )`;
+
+    const rows = buildRows();
+    for (let i = 0; i < rows.length; i += 500) {
+      await sql`INSERT INTO subscriptions ${sql(rows.slice(i, i + 500))}`;
+    }
+
+    const [{ total, cancelled }] = (await sql`
+      SELECT count(*)::int AS total, count(cancelled_at)::int AS cancelled
+        FROM subscriptions
+    `) as unknown as Array<{ total: number; cancelled: number }>;
+    console.log(`Seeded ${total} subscriptions (${cancelled} cancelled)`);
+
+    const monthly = await sql`
+      SELECT to_char(date_trunc('month', cancelled_at), 'YYYY-MM') AS month,
+             count(*)::int AS cancellations
+        FROM subscriptions
+       WHERE cancelled_at IS NOT NULL
+       GROUP BY 1 ORDER BY 1
+    `;
+    console.table(monthly.map((r) => ({ ...r })));
+  } finally {
+    await sql.end();
+  }
+}
+
+await main();

--- a/examples/context-layer/scripts/seed.ts
+++ b/examples/context-layer/scripts/seed.ts
@@ -1,0 +1,243 @@
+/**
+ * Seed the CONTEXT LAYER itself — the org data that explains the warehouse:
+ *
+ *  1. A `postgres` connection to the Kelder warehouse (env auth profile) and a
+ *     VIRTUAL feed on it: the monthly churn rollup, read LIVE at request time
+ *     through the connector pushdown. Nothing is copied into Lobu.
+ *  2. The `churn_rate` metric-definition entity, with its definition history
+ *     as a supersede chain: v1 (2025-07) superseded by v2 (2026-05, dunning
+ *     grace). The chain IS the changelog.
+ *  3. Three business events — the governed "why" records:
+ *       2026-03-12 billing migration (data incident),
+ *       2026-05-01 churn definition v2 (definition change),
+ *       2026-05-19 courier strike (external shock).
+ *  4. Monthly churn observations recorded in Lobu (for the DECLARED metric —
+ *     metrics_config on metric-definition makes them queryable via
+ *     client.metrics.query).
+ *  5. The pinned verified-query entity: the rollup SQL + the human-approved
+ *     answer, captured now from the live warehouse.
+ *
+ * Prereqs: `lobu run` is up in this directory and `bun run seed:warehouse`
+ * has been executed. Idempotent guard: refuses to double-seed.
+ */
+
+import postgres from "postgres";
+import { CHURN_ROLLUP_SQL, WAREHOUSE_URL } from "./lib/env.ts";
+import { callTool, connectLocalGateway } from "./lib/gateway.ts";
+
+const gw = await connectLocalGateway();
+console.log(`Connected to local gateway (org: ${gw.org})`);
+
+// ── Guard: refuse to double-seed ────────────────────────────────────────────
+const existing = await callTool<{ entities?: unknown[] }>(gw, "manage_entity", {
+  action: "list",
+  entity_type: "metric-definition",
+});
+if ((existing.entities ?? []).length > 0) {
+  console.log(
+    "Already seeded (metric-definition entities exist). Wipe ./.lobu-data and restart `lobu run` to reseed."
+  );
+  process.exit(0);
+}
+
+// ── 1. VIRTUAL feed on the warehouse connection ─────────────────────────────
+// The `kelder-warehouse` auth profile + connection are declared in
+// lobu.config.ts and created by `lobu run` (config-as-constructor), which also
+// installs the bundled `postgres` connector. Here we just resolve that
+// connection and add the live churn-rollup feed on top of it.
+const connList = await callTool<{
+  connections?: Array<{ id: number; slug: string; status: string }>;
+}>(gw, "manage_connections", { action: "list", connector_key: "postgres" });
+const warehouseConn = (connList.connections ?? []).find(
+  (c) => c.slug === "kelder-warehouse"
+);
+if (!warehouseConn) {
+  throw new Error(
+    "kelder-warehouse connection not found — did `lobu run` finish applying " +
+      "lobu.config.ts? (it declares the connection). Restart `lobu run` and retry."
+  );
+}
+const connectionId = warehouseConn.id;
+console.log(
+  `Using warehouse connection kelder-warehouse (id ${connectionId}, ${warehouseConn.status})`
+);
+
+const feedRes = await callTool<{ feed?: { id?: number } }>(gw, "manage_feeds", {
+  action: "create_feed",
+  connection_id: connectionId,
+  feed_key: "query",
+  display_name: "Monthly churn rollup (live)",
+  virtual: true,
+  config: { query: CHURN_ROLLUP_SQL },
+});
+const feedId = feedRes.feed?.id;
+if (!feedId) {
+  throw new Error(`feed create returned no id: ${JSON.stringify(feedRes)}`);
+}
+console.log(
+  `Created VIRTUAL feed ${feedId} — churn rollup is read live, never copied`
+);
+
+// ── 2. Metric definition entity + versioned definition chain ───────────────
+const metricRes = await callTool<{ entity?: { id?: number } }>(
+  gw,
+  "manage_entity",
+  {
+    action: "create",
+    entity_type: "metric-definition",
+    name: "churn_rate",
+    slug: "churn-rate",
+    metadata: {
+      metric: "churn_rate",
+      unit: "cancellations/month",
+      owner: "data@kelder.coffee",
+      // Observations resolve to this entity by alias (metadata.metric match).
+      aliases: ["churn_rate"],
+    },
+  }
+);
+const metricEntityId = metricRes.entity?.id;
+if (!metricEntityId) {
+  throw new Error(
+    `metric entity create returned no id: ${JSON.stringify(metricRes)}`
+  );
+}
+
+const v1 = await callTool<{ id?: number; event_id?: number }>(
+  gw,
+  "save_memory",
+  {
+    content:
+      "churn_rate v1 = subscriptions cancelled in month / active subscriptions at month start. " +
+      "A subscription churns the day cancelled_at is set.",
+    semantic_type: "definition",
+    title: "churn_rate v1",
+    entity_ids: [metricEntityId],
+    metadata: {
+      version: "v1",
+      effective_from: "2025-07-01",
+      approved_by: "head-of-data",
+    },
+  }
+);
+const v1EventId = v1.id ?? v1.event_id;
+if (!v1EventId) {
+  throw new Error(`definition v1 save returned no id: ${JSON.stringify(v1)}`);
+}
+
+await callTool(gw, "save_memory", {
+  content:
+    "churn_rate v2 = cancellations excluding payment-failure cancellations inside a 28-day " +
+    "dunning grace / active subscriptions at month start.",
+  semantic_type: "definition",
+  title: "churn_rate v2",
+  entity_ids: [metricEntityId],
+  supersedes_event_id: v1EventId,
+  metadata: {
+    version: "v2",
+    effective_from: "2026-05-01",
+    approved_by: "head-of-data",
+  },
+});
+console.log(
+  `Created churn_rate definition chain: v1 (event ${v1EventId}) superseded by v2`
+);
+
+// ── 3. Business events — the governed "why" records ────────────────────────
+const businessEvents = [
+  {
+    name: "Recharge billing migration wrote false cancellations",
+    slug: "billing-migration-2026-03",
+    metadata: {
+      event_date: "2026-03-12",
+      event_type: "data_incident",
+      affected_metrics: ["churn_rate"],
+      expected_effect:
+        "Exclude 2026-03 from churn trend analysis: ~500 cancellations recorded on " +
+        "2026-03-12/13 are migration artifacts (cancel_reason=billing_migration_artifact), " +
+        "not customers leaving.",
+      owner: "data-platform",
+      source_link: "https://linear.app/kelder/issue/DATA-142",
+    },
+  },
+  {
+    name: "Churn definition v2: dunning grace period",
+    slug: "churn-definition-v2",
+    metadata: {
+      event_date: "2026-05-01",
+      event_type: "definition_change",
+      affected_metrics: ["churn_rate"],
+      expected_effect:
+        "From 2026-05 the series is computed under churn_rate v2 (payment-failure " +
+        "cancellations in a 28-day dunning grace no longer count). Do not compare raw " +
+        "pre/post numbers without noting the version change.",
+      owner: "data@kelder.coffee",
+      source_link: "https://notion.so/kelder/churn-v2",
+    },
+  },
+  {
+    name: "Courier strike (Randstad region)",
+    slug: "courier-strike-2026-05",
+    metadata: {
+      event_date: "2026-05-19",
+      event_type: "external_shock",
+      affected_metrics: ["churn_rate"],
+      expected_effect:
+        "2026-05 churn is genuinely elevated (~45 extra cancellations 2026-05-19..21, " +
+        "cancel_reason=courier_strike). Real but temporary — do not extrapolate the May level.",
+      owner: "ops",
+      source_link: "https://kelder.slack.com/archives/C042/p1747650000",
+    },
+  },
+];
+for (const evt of businessEvents) {
+  await callTool(gw, "manage_entity", {
+    action: "create",
+    entity_type: "business-event",
+    ...evt,
+  });
+}
+console.log(`Created ${businessEvents.length} business events`);
+
+// ── 4. Monthly observations (feed the DECLARED metric) ─────────────────────
+const observations: Array<[string, number]> = [
+  ["2026-01", 30],
+  ["2026-02", 30],
+  ["2026-03", 530],
+  ["2026-04", 30],
+];
+for (const [month, cancellations] of observations) {
+  await callTool(gw, "save_memory", {
+    content: `churn observation ${month}: ${cancellations} cancellations`,
+    semantic_type: "observation",
+    entity_ids: [metricEntityId],
+    metadata: { metric: "churn_rate", month, cancellations },
+  });
+}
+console.log(`Recorded ${observations.length} monthly churn observations`);
+
+// ── 5. Verified query: pin the approved answer from the live warehouse ─────
+const sql = postgres(WAREHOUSE_URL, { max: 1 });
+const approvedAnswer = (await sql.unsafe(CHURN_ROLLUP_SQL)).map((r) => ({
+  ...r,
+}));
+await sql.end();
+
+await callTool(gw, "manage_entity", {
+  action: "create",
+  entity_type: "verified-query",
+  name: "Monthly churn rollup — approved",
+  slug: "monthly-churn-rollup",
+  metadata: {
+    question: "How many cancellations did we have per month?",
+    sql: CHURN_ROLLUP_SQL,
+    approved_answer: approvedAnswer,
+    approved_by: "head-of-data",
+    approved_at: "2026-07-12",
+  },
+});
+console.log(
+  `Pinned verified query with ${approvedAnswer.length} approved rows`
+);
+
+console.log("\nContext layer seeded. Next: bun run compose");

--- a/examples/context-layer/scripts/simulate-drift.ts
+++ b/examples/context-layer/scripts/simulate-drift.ts
@@ -1,0 +1,54 @@
+/**
+ * Demo helper: nudge the warehouse so the drift canary has something to catch.
+ *
+ * Inserts ONE new cancellation into the fake Kelder warehouse. The pinned
+ * verified-query answer was captured before this row existed, so the next
+ * `bun run drift` will report a one-cancellation drift for the affected month —
+ * exactly the "the warehouse moved under a pinned answer" case the trust loop
+ * is built to surface.
+ *
+ * Idempotent-ish: each run adds one more cancellation in the current demo
+ * month, so drift grows by one each time. Re-run `seed:warehouse` to reset.
+ *
+ * Prereq: `bun run seed:warehouse` has provisioned the warehouse.
+ */
+
+import postgres from "postgres";
+import { WAREHOUSE_URL } from "./lib/env.ts";
+
+const sql = postgres(WAREHOUSE_URL, { max: 1 });
+try {
+  // Pick a stable demo month at the end of the seeded window so the drift shows
+  // up on a clean (unflagged) month rather than a distorted one.
+  const cancelledAt = "2026-06-15T12:00:00Z";
+
+  const [{ next_id }] = (await sql`
+    SELECT coalesce(max(id), 0) + 1 AS next_id FROM subscriptions
+  `) as unknown as Array<{ next_id: number }>;
+
+  await sql`
+    INSERT INTO subscriptions (id, customer_id, plan, started_at, cancelled_at, cancel_reason)
+    VALUES (
+      ${next_id},
+      ${900000 + next_id},
+      'regular',
+      '2026-01-01T00:00:00Z',
+      ${cancelledAt},
+      'customer_request'
+    )
+  `;
+
+  const [{ june }] = (await sql`
+    SELECT count(*)::int AS june
+      FROM subscriptions
+     WHERE to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '2026-06'
+  `) as unknown as Array<{ june: number }>;
+
+  console.log(
+    `Inserted 1 new cancellation (id ${next_id}) into 2026-06. ` +
+      `Warehouse now reports ${june} cancellations for that month.`
+  );
+  console.log("Run `bun run drift` — the canary should now report drift.");
+} finally {
+  await sql.end();
+}

--- a/examples/context-layer/tsconfig.json
+++ b/examples/context-layer/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## What this demonstrates

A runnable example that builds an **org-level context layer** on **stock Lobu** for a fictional coffee-subscription company (Kelder Coffee).

A semantic layer governs the *what* of a metric (the SQL). A context layer governs the *why*: the dated business events that distort a series, the versioned definition changelog, and the verified answers you can diff against later. This example composes an "adjusted churn" series where every anomaly is explained by a governed, sourced record instead of a guess.

The pieces, all on stock primitives:

- **`business-event` entities** — the dated, sourced *why* behind an anomaly (data incident / definition change / external shock), each with a `source_link`.
- **`metric-definition` entity + a supersede chain of `definition` events** — the versioned definition changelog. A new version supersedes the previous one; the chain is the changelog, append-only.
- **A `postgres` connection + a virtual feed** — the monthly churn rollup is pushed down to the warehouse and read **live** via the connector; nothing is copied into Lobu. The connection + auth profile are declared in `lobu.config.ts` (config-as-constructor) and created by `lobu run`.
- **`compose.ts`** — one sandboxed `run_sdk` script joins the live series + business events + definition versions **in JS, no LLM**, into a raw-vs-adjusted narrative citing each source and the governing definition version per month.
- **`verified-query` entity + `drift-check.ts`** — a human-approved answer (SQL + the rows it produced at approval) is pinned; re-running and diffing is the drift canary. `simulate-drift.ts` mutates the warehouse so the canary fires.

## How to run

Requires [Bun](https://bun.sh). Everything runs against an isolated embedded Postgres that `lobu run` boots under `./.lobu-data` — no external or shared database.

```sh
cd examples/context-layer
cp env.example .env
bunx @lobu/cli run          # boots embedded stack, applies lobu.config.ts (installs postgres connector, creates the warehouse connection)
# in a second terminal:
bun run seed:warehouse      # provision the fake warehouse (~2000 subscriptions, deterministic)
bun run seed                # seed the context layer on top
bun run compose             # the money shot — adjusted-churn narrative
bun run drift:simulate      # add one cancellation so the canary has drift to catch
bun run drift               # re-run the pinned query and report the drift
```

The README includes the real captured output (raw 530 in 2026-03 excluded as a data incident, 75 in 2026-05 kept-but-flagged as an external shock, months labelled v1/v2 by the definition in effect, and the drift canary catching a one-cancellation change in 2026-06).

## Notes

- Runs on **stock Lobu** — no server changes. The compose/drift scripts use the standard `run_sdk` sandbox (`client.feeds.readMany`, `client.entities.list`, `client.knowledge.read`). Rendering this context directly inside an agent's prompt/answer (guidance/render) is a separate enhancement, not required for this example.
- Verified end-to-end: `seed:warehouse → seed → compose → drift:simulate → drift` all run green against a locally-booted embedded gateway. `make review BASE=origin/main` is clean (typecheck/unit/integration exit 0, reviewer 0 blockers).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786546476&installation_id=136316292&pr_number=1897&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1897&signature=af5bf378750555503370bcfe44a8281d10510260487cb22f70287b6aa71c09dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->