### PR TITLE
chore(dx): add `make pre-pr` fast no-DB CI gates + verify-HEAD rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@
 - **Workers never receive real credentials.** They may receive only placeholders/proxied access.
 - Default to static `import`. New dynamic imports require measured cost justification here or in the package AGENTS plus a rationale comment at the call site. Tests may dynamically import after mocks.
 - Bug fixes require red→fix→green evidence. If you cannot reproduce, bail and report the dead end.
-- Run `make review` before PR/merge.
+- Run `make pre-pr` (fast no-DB CI gates: typecheck + knip + lint) AND `make review` (LLM verdict) before PR/merge. `make review` does NOT run typecheck/knip/tests — it is not proof CI will pass. If you touch server/runtime code, also run the relevant `bun test`/`make test-integration` suite.
+- After committing a fix, verify it landed with `git show HEAD:<file>` (or `git diff --stat origin/main...HEAD`). A fix left in the working tree but never committed will not reach CI — confirm HEAD, not just the working tree.
 
 ## Agent workflow
 - Do only what was asked. Delete ephemeral files you create. Do not create `*.md` unless asked.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Development Makefile for Lobu
 
-.PHONY: help setup build test clean dev dev-db dev-embedded build-packages ensure-submodule clean-workers clean-test-pg test-unit test-integration test-e2e test-e2e-sdk test-e2e-cli test-providers-live typecheck task-setup task-clean dev-recover clean-merged e2e-browser bump review owletto-mac owletto-mac-e2e
+.PHONY: help setup build test clean dev dev-db dev-embedded build-packages ensure-submodule clean-workers clean-test-pg test-unit test-integration test-e2e test-e2e-sdk test-e2e-cli test-providers-live typecheck task-setup task-clean dev-recover clean-merged e2e-browser bump review pre-pr owletto-mac owletto-mac-e2e
 
 # Default target
 help:
@@ -287,3 +287,22 @@ clean-test-pg:
 
 review:
 	@./scripts/review.sh $(if $(BASE),--base $(BASE),)
+
+# Fast, deterministic CI gates that need NO database — the exact checks that
+# `make review` (LLM-verdict only) does NOT run. Run this before opening/updating
+# a PR so knip / typecheck / lint failures don't surface only in CI.
+# NOT a substitute for the DB-backed suites (make test-integration) when you
+# touch server/runtime code — but it catches the cheap, common misses.
+pre-pr:
+	@echo "🔎 [1/3] Strict typecheck (root + excluded packages)..."
+	@bun run typecheck
+	@for pkg in server connector-worker connector-sdk openclaw-plugin embeddings cli; do \
+		echo "   typecheck packages/$$pkg..."; \
+		( cd "packages/$$pkg" && bunx tsc --noEmit ) || exit $$?; \
+	done
+	@echo "🔎 [2/3] Dead-code gate (knip --include files)..."
+	@bun run knip --include files
+	@echo "🔎 [3/3] Lint/format (biome)..."
+	@bun run check
+	@echo "✅ pre-pr gates clean. NOTE: confirm your fix is in 'git show HEAD:<file>',"
+	@echo "   not just the working tree — a fix that isn't committed won't reach CI."

--- a/Makefile
+++ b/Makefile
@@ -294,15 +294,20 @@ review:
 # NOT a substitute for the DB-backed suites (make test-integration) when you
 # touch server/runtime code — but it catches the cheap, common misses.
 pre-pr:
-	@echo "🔎 [1/3] Strict typecheck (root + excluded packages)..."
+	@echo "🔎 [1/4] Build workspace packages (fresh dist)..."
+	@# Typecheck resolves @lobu/* against built dist, not src. Without this a
+	@# stale core dist yields PHANTOM errors on any contract change (e.g. a new
+	@# field the dist predates) — the exact trap CI avoids by building first.
+	@make build-packages
+	@echo "🔎 [2/4] Strict typecheck (root + excluded packages)..."
 	@bun run typecheck
 	@for pkg in server connector-worker connector-sdk openclaw-plugin embeddings cli; do \
 		echo "   typecheck packages/$$pkg..."; \
 		( cd "packages/$$pkg" && bunx tsc --noEmit ) || exit $$?; \
 	done
-	@echo "🔎 [2/3] Dead-code gate (knip --include files)..."
+	@echo "🔎 [3/4] Dead-code gate (knip --include files)..."
 	@bun run knip --include files
-	@echo "🔎 [3/3] Lint/format (biome)..."
+	@echo "🔎 [4/4] Lint/format (biome)..."
 	@bun run check
 	@echo "✅ pre-pr gates clean. NOTE: confirm your fix is in 'git show HEAD:<file>',"
 	@echo "   not just the working tree — a fix that isn't committed won't reach CI."


### PR DESCRIPTION
## Why
`make review` is **LLM-verdict-only** — it does not run typecheck, knip, lint, or tests. A green `make review` is not proof CI will pass.

This session, three PRs (#1895/#1896/#1897) merged red on exactly the gates `make review` skips:
- **knip dead-code**: new `examples/context-layer/scripts/*.ts` flagged unused (no example had used a `bun run scripts/*` pattern before).
- **stale unit test**: `installability.test.ts` asserted the *old* "postgres blocked in cloud" behavior that #1896's own change inverts — a 1.5s no-DB test that was never re-run.
- **uncommitted fix**: a real `sslrootcert=system` → `verify-full` TLS-hardening fix (pi-review blocker) was sitting in the working tree but never committed, so the pushed HEAD still had the MITM-exposure bug.

## What
- `make pre-pr`: runs the fast, deterministic, **no-DB** CI gates locally — root + excluded-package typecheck, `knip --include files`, and biome. These are the cheap common misses; it's explicitly *not* a substitute for `make test-integration` when you touch server/runtime code.
- AGENTS.md: run `make pre-pr` alongside `make review` before PR; and after committing a fix, **verify it's in `git show HEAD`, not just the working tree** (the third failure above).

## Verification
Dogfooded on this branch: `knip` exit 0, `biome` exit 0, pre-commit tsc passed, `make -n pre-pr` expands correctly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786548723&installation_id=136316292&pr_number=1900&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1900&signature=90823324790427dd74b6e550d51c9a103dd2b58f3b51386d793b096e64dadb13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->