### PR TITLE
fix(oauth): stop advertising device-only scopes to third-party MCP clients

### DIFF
--- a/packages/server/src/__tests__/integration/oauth/discovery.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/discovery.test.ts
@@ -28,9 +28,15 @@ describe('OAuth Discovery Endpoints', () => {
       expect(body.authorization_servers).toBeInstanceOf(Array);
       expect(body.authorization_servers.length).toBeGreaterThan(0);
 
-      // Supported features
+      // Supported features — only scopes third-party auth-code clients may receive
       expect(body.scopes_supported).toContain('mcp:read');
       expect(body.scopes_supported).toContain('mcp:write');
+      expect(body.scopes_supported).toContain('mcp:admin');
+      expect(body.scopes_supported).toContain('profile:read');
+      // First-party device/login scopes must not be advertised (Slack et al.
+      // request every scopes_supported entry).
+      expect(body.scopes_supported).not.toContain('device_worker:run');
+      expect(body.scopes_supported).not.toContain('connections:token');
       expect(body.bearer_methods_supported).toContain('header');
 
       // Resource documentation
@@ -75,6 +81,11 @@ describe('OAuth Discovery Endpoints', () => {
       // Token endpoint auth methods
       expect(body.token_endpoint_auth_methods_supported).toBeInstanceOf(Array);
       expect(body.token_endpoint_auth_methods_supported).toContain('client_secret_post');
+
+      // First-party device/login scopes stay off discovery
+      expect(body.scopes_supported).toContain('mcp:read');
+      expect(body.scopes_supported).not.toContain('device_worker:run');
+      expect(body.scopes_supported).not.toContain('connections:token');
     });
 
     it('should support OAuth 2.1 features', async () => {

--- a/packages/server/src/__tests__/integration/oauth/login-connections-token-scope.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/login-connections-token-scope.test.ts
@@ -168,9 +168,10 @@ describe('Stage 1 — login token carries connections:token', () => {
 
   it('an authorization-code grant does NOT get connections:token (no third-party over-grant)', async () => {
     // The authorization-code consent path is used by arbitrary third-party MCP
-    // clients (Claude Desktop, Cursor, …). Approving the SAME MCP scopes the CLI
-    // requests must NOT silently add connections:token — only `lobu login`
-    // (device-code) gets it.
+    // clients (Claude Desktop, Cursor, Slack, …). Even when they request the
+    // full first-party scope list (common when clients copy scopes_supported),
+    // device_worker:run / connections:token must be stripped — only `lobu login`
+    // (device-code) or an explicit PAT gets those.
     const app = buildApp();
     const sql = getTestDb();
 
@@ -195,12 +196,13 @@ describe('Stage 1 — login token carries connections:token', () => {
     const verifier = randomBytes(32).toString('base64url');
     const challenge = createHash('sha256').update(verifier).digest('base64url');
 
-    // Consent — approve the same MCP scopes `lobu login` requests.
+    // Consent — Slack-style over-request of every AVAILABLE_SCOPES entry.
     const authorize = await call(app, 'POST', '/oauth/authorize/consent', {
       body: {
         client_id: client.client_id,
         redirect_uri: redirectUri,
-        scope: 'mcp:read mcp:write mcp:admin profile:read',
+        scope:
+          'mcp:read mcp:write mcp:admin profile:read device_worker:run connections:token',
         code_challenge: challenge,
         code_challenge_method: 'S256',
         resource: `${ORIGIN}/mcp/${org.slug}`,
@@ -232,10 +234,15 @@ describe('Stage 1 — login token carries connections:token', () => {
       LIMIT 1
     `) as unknown as Array<{ scope: string | null }>;
     expect(rows.length).toBe(1);
-    // The requested MCP scopes are present...
-    expect((rows[0].scope ?? '').split(' ')).toContain('mcp:read');
-    // ...but connections:token was NOT silently added to a third-party token.
-    expect((rows[0].scope ?? '').split(' ')).not.toContain('connections:token');
+    const granted = (rows[0].scope ?? '').split(' ').filter(Boolean);
+    // Public MCP scopes survive...
+    expect(granted).toContain('mcp:read');
+    expect(granted).toContain('mcp:write');
+    expect(granted).toContain('mcp:admin');
+    expect(granted).toContain('profile:read');
+    // ...but first-party scopes are stripped, not hard-rejected.
+    expect(granted).not.toContain('connections:token');
+    expect(granted).not.toContain('device_worker:run');
   });
 
   it('a profile:read-only device grant (no MCP scopes) does NOT get connections:token', async () => {

--- a/packages/server/src/__tests__/unit/oauth-scope-filter.test.ts
+++ b/packages/server/src/__tests__/unit/oauth-scope-filter.test.ts
@@ -1,5 +1,41 @@
 import { describe, expect, it } from 'bun:test';
-import { filterScopeByRole } from '../../auth/oauth/scopes';
+import {
+  DISCOVERY_SCOPES,
+  filterScopeByRole,
+  NON_PUBLIC_OAUTH_SCOPES,
+  stripNonPublicOAuthScopes,
+} from '../../auth/oauth/scopes';
+
+describe('DISCOVERY_SCOPES', () => {
+  it('excludes first-party-only scopes that third-party MCP clients must not request', () => {
+    expect(DISCOVERY_SCOPES).toContain('mcp:read');
+    expect(DISCOVERY_SCOPES).toContain('mcp:write');
+    expect(DISCOVERY_SCOPES).toContain('mcp:admin');
+    expect(DISCOVERY_SCOPES).toContain('profile:read');
+    for (const scope of NON_PUBLIC_OAUTH_SCOPES) {
+      expect(DISCOVERY_SCOPES).not.toContain(scope);
+    }
+  });
+});
+
+describe('stripNonPublicOAuthScopes', () => {
+  it('strips device_worker:run and connections:token from a Slack-style full-list request', () => {
+    const result = stripNonPublicOAuthScopes(
+      'mcp:read mcp:write mcp:admin profile:read device_worker:run connections:token'
+    );
+    expect(result).toBe('mcp:read mcp:write mcp:admin profile:read');
+  });
+
+  it('returns empty string when only non-public scopes were requested', () => {
+    expect(stripNonPublicOAuthScopes('device_worker:run connections:token')).toBe('');
+  });
+
+  it('passes public scopes through unchanged', () => {
+    expect(stripNonPublicOAuthScopes('mcp:read mcp:write profile:read')).toBe(
+      'mcp:read mcp:write profile:read'
+    );
+  });
+});
 
 describe('filterScopeByRole', () => {
   it('keeps mcp:admin when the user is an owner', () => {

--- a/packages/server/src/auth/oauth/provider.ts
+++ b/packages/server/src/auth/oauth/provider.ts
@@ -9,7 +9,7 @@ import type { DbClient } from '../../db/client';
 import { findExistingPersonalOrg } from '../personal-org-provisioning';
 import { PersonalAccessTokenService } from '../tokens';
 import { OAuthClientsStore } from './clients';
-import { AVAILABLE_SCOPES } from './scopes';
+import { DISCOVERY_SCOPES } from './scopes';
 import type {
   AuthInfo,
   AuthorizationParams,
@@ -782,7 +782,10 @@ export class OAuthProvider {
       token_endpoint: `${this.baseUrl}/oauth/token`,
       registration_endpoint: `${this.baseUrl}/oauth/register`,
       revocation_endpoint: `${this.baseUrl}/oauth/revoke`,
-      scopes_supported: [...AVAILABLE_SCOPES],
+      // Only scopes grantable to third-party auth-code MCP clients. Device-
+      // only scopes stay off discovery so clients like Slack do not request
+      // them (they often ask for every entry in scopes_supported).
+      scopes_supported: [...DISCOVERY_SCOPES],
       response_types_supported: ['code'],
       response_modes_supported: ['query'],
       device_authorization_endpoint: `${this.baseUrl}/oauth/device_authorization`,
@@ -819,7 +822,7 @@ export class OAuthProvider {
     return {
       resource: `${this.baseUrl}/mcp`,
       authorization_servers: [this.baseUrl],
-      scopes_supported: [...AVAILABLE_SCOPES],
+      scopes_supported: [...DISCOVERY_SCOPES],
       bearer_methods_supported: ['header'],
       resource_name: 'Lobu',
       resource_documentation: `${this.baseUrl}/docs`,

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -16,7 +16,11 @@ import { requireAuth } from '../middleware';
 import { findExistingPersonalOrg } from '../personal-org-provisioning';
 import { buildAuthMd } from './auth-md';
 import { OAuthProvider } from './provider';
-import { DEFAULT_SCOPES_STRING, filterScopeByRole } from './scopes';
+import {
+  DEFAULT_SCOPES_STRING,
+  filterScopeByRole,
+  stripNonPublicOAuthScopes,
+} from './scopes';
 import type { AuthorizationParams, OAuthClientMetadata, TokenRequestParams } from './types';
 import { createOAuthError, validateRedirectUri } from './utils';
 import { getConfiguredPublicOrigin } from '../../utils/public-origin';
@@ -530,10 +534,15 @@ oauthRoutes.get('/oauth/authorize', async (c) => {
   const webUrl = getBaseUrl(c);
   const consentUrl = new URL('/oauth/consent', webUrl);
 
-  // Pass params to consent page via query string
+  // Pass params to consent page via query string. Strip first-party-only scopes
+  // so the UI (and the later consent POST) never offer device_worker:run /
+  // connections:token to third-party MCP clients that requested the full
+  // discovery list.
+  const publicScope =
+    stripNonPublicOAuthScopes(params.scope) || DEFAULT_SCOPES_STRING;
   consentUrl.searchParams.set('client_id', params.client_id);
   consentUrl.searchParams.set('redirect_uri', params.redirect_uri);
-  consentUrl.searchParams.set('scope', params.scope || DEFAULT_SCOPES_STRING);
+  consentUrl.searchParams.set('scope', publicScope);
   consentUrl.searchParams.set('state', params.state || '');
   consentUrl.searchParams.set('code_challenge', params.code_challenge);
   consentUrl.searchParams.set('code_challenge_method', params.code_challenge_method);
@@ -583,25 +592,24 @@ oauthRoutes.post('/oauth/authorize/consent', requireAuth, async (c) => {
     return c.json(createOAuthError('invalid_request', 'Invalid JSON body'), 400);
   }
 
-  const consentHasMcpScopes = hasMcpScopes(body.scope);
-
-  // `device_worker:run` is device-code-only — it mints a personal-device
-  // credential that the Owletto Mac app / Chrome extension / local runner
-  // authenticate `/api/workers/*` with, and device tokens are force-bound to
-  // the personal org in the device/approve handler below. Letting it slip in
-  // via the authorization-code consent path would bypass that invariant and
-  // bind a team-org token a device client could mistake for its identity.
-  // Third-party MCP clients (the only consent-path users) never need it.
-  const requestedConsentScopes = (body.scope ?? '').split(/\s+/).filter(Boolean);
-  if (requestedConsentScopes.includes('device_worker:run')) {
+  // First-party scopes (`device_worker:run`, `connections:token`) are not
+  // grantable here. Clients that still request them (e.g. Slack after reading
+  // a broad cached scopes_supported) get them stripped rather than a hard
+  // invalid_scope, so MCP login can complete with the public scopes they need.
+  // Device workers continue to use the device-authorization flow, which never
+  // hits this path.
+  const publicConsentScope = stripNonPublicOAuthScopes(body.scope);
+  if ((body.scope ?? '').trim() && !publicConsentScope) {
     return c.json(
       createOAuthError(
         'invalid_scope',
-        '`device_worker:run` is only available via the device-authorization flow'
+        'Requested scopes are only available via the device-authorization flow or an explicit PAT'
       ),
       400
     );
   }
+  body.scope = publicConsentScope || DEFAULT_SCOPES_STRING;
+  const consentHasMcpScopes = hasMcpScopes(body.scope);
 
   // User denied consent
   if (!body.approved) {
@@ -674,13 +682,9 @@ oauthRoutes.post('/oauth/authorize/consent', requireAuth, async (c) => {
           400
         );
       }
-      // NOTE: `connections:token` is deliberately NOT granted here. The
-      // authorization-code consent path is used by arbitrary third-party MCP
-      // clients (Claude Desktop, Cursor, ChatGPT, …); granting it here would
-      // silently widen their tokens beyond the scopes they requested/consented
-      // to. Only the first-party `lobu login` device-code grant gets it (see
-      // POST /oauth/device/approve) — that is the credential the local
-      // instance's managed-connector resolver uses.
+      // NOTE: `connections:token` / `device_worker:run` were already stripped
+      // above via stripNonPublicOAuthScopes. Only the first-party `lobu login`
+      // device-code grant (or an explicit PAT) gets those.
       params.scope = filtered;
     }
 

--- a/packages/server/src/auth/oauth/scopes.ts
+++ b/packages/server/src/auth/oauth/scopes.ts
@@ -5,7 +5,7 @@
  * that normalize, compare, and persist scope lists across auth_data records.
  */
 
-/** All available scopes */
+/** All available scopes (including first-party / device-flow-only grants). */
 export const AVAILABLE_SCOPES = [
   'mcp:read',
   'mcp:write',
@@ -19,6 +19,29 @@ export const AVAILABLE_SCOPES = [
   // (`lobu token create --scope connections:token`).
   'connections:token',
 ] as const;
+
+/**
+ * Scopes that must not appear in AS/PRM `scopes_supported` and must never be
+ * granted on the authorization-code consent path.
+ *
+ * Third-party MCP clients (Slack, Claude Desktop, Cursor, …) often request
+ * every scope listed in discovery. Advertising these first-party scopes there
+ * caused Slack to ask for `device_worker:run`, which the auth-code consent
+ * handler correctly refused.
+ *
+ * - `device_worker:run` — personal device workers only (device-code grant).
+ * - `connections:token` — first-party `lobu login` device-code grant or an
+ *   explicitly minted PAT; never third-party auth-code tokens.
+ */
+export const NON_PUBLIC_OAUTH_SCOPES = ['device_worker:run', 'connections:token'] as const;
+
+/**
+ * Scopes advertised via OAuth discovery (RFC 8414 / RFC 9728).
+ * Subset of AVAILABLE_SCOPES that third-party auth-code clients may receive.
+ */
+export const DISCOVERY_SCOPES = AVAILABLE_SCOPES.filter(
+  (scope) => !(NON_PUBLIC_OAUTH_SCOPES as readonly string[]).includes(scope)
+) as readonly string[];
 
 /** Default scopes for MCP access */
 export const DEFAULT_SCOPES = ['mcp:read', 'mcp:write'] as const;
@@ -62,6 +85,22 @@ export const CONNECTIONS_TOKEN_SCOPE = 'connections:token';
 
 /** Default scopes as a space-separated string (for OAuth params) */
 export const DEFAULT_SCOPES_STRING = DEFAULT_SCOPES.join(' ');
+
+/**
+ * Drop first-party-only scopes from an authorization-code request.
+ *
+ * MCP clients that already cached a broad `scopes_supported` list may still
+ * request `device_worker:run` / `connections:token`. Stripping (rather than
+ * rejecting) lets them complete consent with the scopes they actually need.
+ */
+export function stripNonPublicOAuthScopes(scope: string | undefined | null): string {
+  return (scope || '')
+    .split(/\s+/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .filter((s) => !(NON_PUBLIC_OAUTH_SCOPES as readonly string[]).includes(s))
+    .join(' ');
+}
 
 /**
  * Strip `mcp:admin` from a requested scope string when the user is not an


### PR DESCRIPTION
## Summary

- Third-party MCP clients (Slack, Claude Desktop, Cursor, …) often request every entry in OAuth `scopes_supported`. Discovery previously advertised first-party scopes (`device_worker:run`, `connections:token`), so Slack's consent URL asked for device-worker scopes and Approve failed with `device_worker:run is only available via the device-authorization flow`.
- Advertise only public MCP scopes (`mcp:*`, `profile:read`) in AS/PRM discovery.
- On the authorization-code consent path, strip non-public scopes instead of hard-rejecting so clients with a cached broad scope list can still complete login.
- Device-code (`lobu login`, Owletto, Chrome) is unchanged and still grants those scopes when requested.

## Test plan

- [x] Unit tests for `DISCOVERY_SCOPES` / `stripNonPublicOAuthScopes` / `filterScopeByRole`
- [x] Integration tests updated (discovery excludes non-public scopes; auth-code consent with Slack-style full scope list succeeds without `device_worker:run` / `connections:token`)
- [ ] CI integration suite
- [ ] After deploy: reconnect Slack MCP server; consent should approve without device-worker error

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786550265&installation_id=136316292&pr_number=1901&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1901&signature=0de5522f48956f0e206d640407821a4f3208b14d793482daf6162cbfb8db2fd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->