### PR TITLE
fix(runtime): delete environment credentials on deletion + sweep orphans (§22)

### DIFF
--- a/db/migrations/20260713160000_sweep_orphan_environment_credentials.sql
+++ b/db/migrations/20260713160000_sweep_orphan_environment_credentials.sql
@@ -1,0 +1,22 @@
+-- migrate:up
+
+-- Sweep orphaned runtime-environment credentials left behind by environment
+-- deletions that ran before `deleteEnvironment` purged them. Each environment's
+-- vault rows are named `environment:<id>:<field>` (see environmentSecretName()
+-- in provider-secrets.ts); delete every such row whose embedded <id> — the
+-- segment between the two colons — has no matching `environments` row.
+--
+-- `agent_secrets` is NOT the append-only `events` table, so a plain DELETE is
+-- correct and required: every swept row is a decryptable provider token (eg a
+-- Vercel access token) whose owning environment is already gone. Survivors —
+-- secrets for environments that still exist — are untouched. The `name LIKE
+-- 'environment:%'` predicate is served by agent_secrets_name_prefix_idx
+-- (text_pattern_ops), so only the environment-prefixed rows are scanned.
+DELETE FROM agent_secrets
+WHERE name LIKE 'environment:%'
+  AND split_part(name, ':', 2) NOT IN (SELECT id FROM environments);
+
+-- migrate:down
+
+-- No-op: the swept rows were orphans with no owning environment, so there is
+-- nothing to restore.

--- a/packages/server/src/lobu/stores/__tests__/environment-store.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/environment-store.test.ts
@@ -1,0 +1,93 @@
+/**
+ * deleteEnvironment credential sweep — runs against whichever backend
+ * globalSetup selected (ephemeral embedded Postgres with `bun run test`, real
+ * Postgres with DATABASE_URL set). Verifies that deleting an environment also
+ * purges its runtime-connection credentials from the vault, and that a sibling
+ * environment's credentials survive.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTestDatabase, getTestDb } from "../../../__tests__/setup/test-db";
+import { createEnvironment, deleteEnvironment } from "../environment-store";
+import { readEnvironmentSecret, writeEnvironmentSecret } from "../provider-secrets";
+
+const ORG = "org-env-cred-sweep";
+
+/** Count live vault rows for one environment's credential fields. */
+async function countEnvironmentSecrets(
+  organizationId: string,
+  environmentId: string
+): Promise<number> {
+  const db = getTestDb();
+  const rows = await db<{ count: number }[]>`
+    SELECT count(*)::int AS count
+    FROM agent_secrets
+    WHERE organization_id = ${organizationId}
+      AND name LIKE ${`environment:${environmentId}:%`}
+      AND (expires_at IS NULL OR expires_at > now())
+  `;
+  return rows[0]?.count ?? 0;
+}
+
+describe("deleteEnvironment credential sweep", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  afterEach(async () => {
+    const db = getTestDb();
+    await db`TRUNCATE environments, agent_secrets`;
+  });
+
+  it("deletes the environment's vault credentials with the row", async () => {
+    const env = await createEnvironment(ORG, {
+      name: "vercel-prod",
+      providerKind: "vercel",
+    });
+    await writeEnvironmentSecret(env.id, "token", ORG, "vercel-token-xxxx");
+
+    expect(await countEnvironmentSecrets(ORG, env.id)).toBe(1);
+    expect(await readEnvironmentSecret(env.id, "token", ORG)).toBe(
+      "vercel-token-xxxx"
+    );
+
+    const deleted = await deleteEnvironment(env.id, ORG);
+    expect(deleted).toBe(true);
+
+    // No decryptable provider token survives the deleted row.
+    expect(await countEnvironmentSecrets(ORG, env.id)).toBe(0);
+    expect(await readEnvironmentSecret(env.id, "token", ORG)).toBeNull();
+  });
+
+  it("leaves a sibling environment's credentials untouched", async () => {
+    const a = await createEnvironment(ORG, {
+      name: "vercel-a",
+      providerKind: "vercel",
+    });
+    const b = await createEnvironment(ORG, {
+      name: "vercel-b",
+      providerKind: "vercel",
+    });
+    await writeEnvironmentSecret(a.id, "token", ORG, "vercel-token-aaaa");
+    await writeEnvironmentSecret(b.id, "token", ORG, "vercel-token-bbbb");
+
+    expect(await deleteEnvironment(a.id, ORG)).toBe(true);
+
+    // A's secret was swept with its row; B's survives.
+    expect(await countEnvironmentSecrets(ORG, a.id)).toBe(0);
+    expect(await countEnvironmentSecrets(ORG, b.id)).toBe(1);
+    expect(await readEnvironmentSecret(b.id, "token", ORG)).toBe(
+      "vercel-token-bbbb"
+    );
+  });
+
+  it("succeeds for an environment that was never credentialed", async () => {
+    const env = await createEnvironment(ORG, {
+      name: "vercel-empty",
+      providerKind: "vercel",
+    });
+
+    expect(await deleteEnvironment(env.id, ORG)).toBe(true);
+    expect(await countEnvironmentSecrets(ORG, env.id)).toBe(0);
+  });
+});

--- a/packages/server/src/lobu/stores/environment-store.ts
+++ b/packages/server/src/lobu/stores/environment-store.ts
@@ -89,9 +89,14 @@ export async function setEnvironmentCredentialName(
 }
 
 /**
- * Delete an environment and null out any agent pinned to it (so dependent
- * agents fall back to the default runtime). The vault credential rows are left
- * in place — credential lifecycle is independent of the row.
+ * Delete an environment, null out any agent pinned to it (so dependent agents
+ * fall back to the default runtime), and purge its runtime-connection
+ * credentials from the vault — all in ONE transaction. The vault rows
+ * (`environment:<id>:<field>`) are deleted atomically with the environment row,
+ * so a transient failure rolls the whole thing back rather than leaving a
+ * decryptable provider token behind (which a post-commit purge could do — a
+ * retry would see the row already gone and skip the purge). The `:` suffix on
+ * the prefix prevents collisions (env-1 vs env-11).
  */
 export async function deleteEnvironment(
   id: string,
@@ -111,6 +116,11 @@ export async function deleteEnvironment(
         UPDATE agents
         SET environment_id = NULL
         WHERE environment_id = ${id} AND organization_id = ${organizationId}
+      `;
+      await tx`
+        DELETE FROM agent_secrets
+        WHERE organization_id = ${organizationId}
+          AND name LIKE ${`environment:${id}:%`}
       `;
     }
   });


### PR DESCRIPTION
Closes the §22 credential-hygiene hole from the final-architecture review.

## Problem
`deleteEnvironment` deleted the environments row but left the `environment:<id>:*` vault rows in place, so every deleted environment left a decryptable provider token (e.g. a Vercel access token) behind indefinitely.

## Fix
- Delete the credential rows in the SAME transaction as the environment row (atomic — a transient failure rolls back rather than orphaning tokens).
- Migration sweeps already-orphaned `environment:%` secrets whose environment no longer exists.

## Tests
3/3 integration (deletes creds with row; leaves siblings; handles never-credentialed). codex-reviewed (P1 atomicity fixed; P2 rotate-while-delete race deferred with migration backstop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786550450&installation_id=136316292&pr_number=1902&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1902&signature=3946799e9d7f555903b86515be2b098b6110186bfc153c5b943684c23126d513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->