### PR TITLE
feat(watchers): queue watcher-definition writes for approval (WI-0.1)

### DIFF
--- a/packages/agent-worker/src/__tests__/custom-tools.test.ts
+++ b/packages/agent-worker/src/__tests__/custom-tools.test.ts
@@ -178,8 +178,68 @@ describe("maybePostApprovalCard (builder gate)", () => {
       interactionType: "tool_approval",
       runId: 99,
       action: "update",
+      resourceKind: "agent",
       proposal: { agent_id: "support-bot", name: "v2" },
       current: { id: "support-bot", name: "v1" },
+    });
+  });
+
+  test("posts a tool_approval card for a manage_watchers pending_approval result", async () => {
+    const posts: Array<{ url: string; body: any }> = [];
+    globalThis.fetch = mock(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        posts.push({
+          url,
+          body: init?.body ? JSON.parse(String(init.body)) : null,
+        });
+        return Response.json({ id: "appr-w1" });
+      }
+    ) as unknown as typeof fetch;
+
+    const resultText = JSON.stringify({
+      action: "create",
+      run_id: 77,
+      status: "pending_approval",
+      message: "needs approval",
+      // Server stores proposal as `{ args }` — card body flattens for the SPA.
+      proposal: {
+        args: {
+          action: "create",
+          slug: "launch-tracker",
+          name: "Launch Tracker",
+          prompt: "Track launches.",
+          schedule: "0 * * * *",
+          timezone: "UTC",
+          agent_id: "builder-agent",
+        },
+      },
+      current: null,
+    });
+
+    const posted = await maybePostApprovalCard(
+      gw,
+      "manage_watchers",
+      resultText
+    );
+
+    expect(posted).toBe(true);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]!.body).toMatchObject({
+      interactionType: "tool_approval",
+      runId: 77,
+      action: "create",
+      resourceKind: "watcher",
+      proposal: {
+        action: "create",
+        slug: "launch-tracker",
+        name: "Launch Tracker",
+        prompt: "Track launches.",
+        schedule: "0 * * * *",
+        timezone: "UTC",
+        agent_id: "builder-agent",
+      },
+      current: null,
     });
   });
 

--- a/packages/agent-worker/src/shared/tool-implementations.ts
+++ b/packages/agent-worker/src/shared/tool-implementations.ts
@@ -1154,6 +1154,9 @@ const TOOLS_REQUESTING_JSON_FORMAT = new Set([
   // not formatted markdown, to forward an approval card into the chat (see
   // maybePostApprovalCard / createMcpToolDefinitions).
   "manage_agents",
+  // Same shape as manage_agents: watcher definition create/update/delete may
+  // return pending_approval under the agent_config write-gate.
+  "manage_watchers",
   // manage_entity's update path queues a human-owned-field change for approval
   // (approval_queued + approval_run_id + approval_fields/current). Same reason:
   // we need the JSON to forward the entity_field_change approval card.
@@ -1163,9 +1166,11 @@ const TOOLS_REQUESTING_JSON_FORMAT = new Set([
 /**
  * Approval-gate bridge: when a gated write returns a pending-approval result,
  * post a durable approval card into the chat so the SPA renders the interactive
- * Approve/Reject diff. Handles two producers:
+ * Approve/Reject diff. Handles three producers:
  *   - manage_agents write gate → `{ status: 'pending_approval', run_id,
  *     action, proposal, current }` (the builder agent's create/update/delete).
+ *   - manage_watchers write gate → same `pending_approval` shape (watcher
+ *     definition create/update/delete under agent_config).
  *   - manage_entity update gate → `{ approval_queued: true, approval_run_id,
  *     approval_fields, approval_current, approval_attribution }` (a human-owned
  *     entity field the agent proposed changing).
@@ -1225,7 +1230,7 @@ function buildApprovalCardBody(
     return null;
   }
 
-  if (toolName === "manage_agents") {
+  if (toolName === "manage_agents" || toolName === "manage_watchers") {
     if (
       parsed.status !== "pending_approval" ||
       typeof parsed.run_id !== "number"

--- a/packages/agent-worker/src/shared/tool-implementations.ts
+++ b/packages/agent-worker/src/shared/tool-implementations.ts
@@ -1246,7 +1246,7 @@ function buildApprovalCardBody(
       typeof rawProposal === "object" &&
       (rawProposal as { args?: unknown }).args &&
       typeof (rawProposal as { args: unknown }).args === "object"
-        ? ((rawProposal as { args: Record<string, unknown> }).args)
+        ? (rawProposal as { args: Record<string, unknown> }).args
         : ((rawProposal as Record<string, unknown> | null) ?? null);
     return {
       interactionType: "tool_approval",

--- a/packages/agent-worker/src/shared/tool-implementations.ts
+++ b/packages/agent-worker/src/shared/tool-implementations.ts
@@ -1217,7 +1217,8 @@ export async function maybePostApprovalCard(
  * Parse a gated tool result into the /internal/interactions/create body, or
  * null when the result is not a pending approval. entity_field_change carries
  * `fields`/`attribution` (the human-owned-field diff); manage_agents carries
- * `proposal` (the agent row diff). Both share the `tool_approval` transport.
+ * `proposal` (the agent row diff); manage_watchers carries flat watcher args
+ * plus `resourceKind: "watcher"`. All share the `tool_approval` transport.
  */
 function buildApprovalCardBody(
   toolName: string,
@@ -1230,7 +1231,34 @@ function buildApprovalCardBody(
     return null;
   }
 
-  if (toolName === "manage_agents" || toolName === "manage_watchers") {
+  if (toolName === "manage_watchers") {
+    if (
+      parsed.status !== "pending_approval" ||
+      typeof parsed.run_id !== "number"
+    ) {
+      return null;
+    }
+    // Server proposal is `{ args: ManageWatchersArgs }`; SPA renderer needs the
+    // flat watcher fields (action, slug, prompt, schedule, …).
+    const rawProposal = parsed.proposal;
+    const flatProposal =
+      rawProposal &&
+      typeof rawProposal === "object" &&
+      (rawProposal as { args?: unknown }).args &&
+      typeof (rawProposal as { args: unknown }).args === "object"
+        ? ((rawProposal as { args: Record<string, unknown> }).args)
+        : ((rawProposal as Record<string, unknown> | null) ?? null);
+    return {
+      interactionType: "tool_approval",
+      runId: parsed.run_id,
+      action: typeof parsed.action === "string" ? parsed.action : "change",
+      resourceKind: "watcher",
+      proposal: flatProposal,
+      current: parsed.current ?? null,
+    };
+  }
+
+  if (toolName === "manage_agents") {
     if (
       parsed.status !== "pending_approval" ||
       typeof parsed.run_id !== "number"
@@ -1241,6 +1269,7 @@ function buildApprovalCardBody(
       interactionType: "tool_approval",
       runId: parsed.run_id,
       action: typeof parsed.action === "string" ? parsed.action : "change",
+      resourceKind: "agent",
       proposal: parsed.proposal ?? null,
       current: parsed.current ?? null,
     };
@@ -1260,6 +1289,7 @@ function buildApprovalCardBody(
         typeof parsed.approval_action === "string"
           ? parsed.approval_action
           : "change",
+      resourceKind: "entity",
       proposal: parsed.approval_proposal ?? null,
       // entity_field_change diff: field_path -> proposed / current. The SPA
       // routes on `fields` (non-empty) to the entity-field-change card.

--- a/packages/core/src/contracts/tools/manage-watchers.ts
+++ b/packages/core/src/contracts/tools/manage-watchers.ts
@@ -608,12 +608,21 @@ export type ManageWatchersResult = Static<typeof ManageWatchersResultSchema>;
  * builder-gate run. Captures the original manage_watchers args so approve can
  * re-run the same write handler.
  *
+ * Also persists the acting principal resolved at queue time so apply can
+ * re-validate the foreign-owner guard against the ORIGINAL actor (not the
+ * human approver). Without this, a group reassigned between queue and approve
+ * would let A's pending mutation land on B-owned behavior.
+ *
  * Watcher definition writes have no per-field pre-image (unlike manage_agents
  * update `base`); a straight re-run is the launch path — a stale approval may
- * clobber a newer edit.
+ * clobber a newer edit (ownership re-check still rejects foreign owners).
  */
 export interface ManageWatchersProposal {
   args: ManageWatchersArgs;
+  /** Resolved `actor.ownerAgentId ?? actor.id` at queue time; null for humans. */
+  actingAgentId: string | null;
+  /** Session `actingWatcherId` at queue time, if any. */
+  actingWatcherId: string | null;
 }
 export const ListWatchersSchema = Type.Object({
   watcher_id: Type.Optional(

--- a/packages/core/src/contracts/tools/manage-watchers.ts
+++ b/packages/core/src/contracts/tools/manage-watchers.ts
@@ -577,9 +577,44 @@ export const ManageWatchersResultSchema = Type.Union([
       })
     ),
   }),
+  // Builder-gate: non-human principal queued a watcher definition write.
+  // Mirrors manage_agents' pending_approval shape so the worker can forward a
+  // chat approval card from the same result fields (run_id + proposal).
+  Type.Object({
+    action: Type.Union([
+      Type.Literal("create"),
+      Type.Literal("update"),
+      Type.Literal("create_version"),
+      Type.Literal("create_from_version"),
+      Type.Literal("set_reaction_script"),
+      Type.Literal("delete"),
+    ]),
+    run_id: Type.Integer(),
+    event_id: Type.Optional(Type.Integer()),
+    status: Type.Literal("pending_approval"),
+    message: Type.String(),
+    proposal: Type.Unknown(),
+    current: Type.Union([
+      Type.Record(Type.String(), Type.Unknown()),
+      Type.Null(),
+    ]),
+  }),
 ]);
 
 export type ManageWatchersResult = Static<typeof ManageWatchersResultSchema>;
+
+/**
+ * Proposed watcher-definition mutation held in `runs.action_input` for a
+ * builder-gate run. Captures the original manage_watchers args so approve can
+ * re-run the same write handler.
+ *
+ * Watcher definition writes have no per-field pre-image (unlike manage_agents
+ * update `base`); a straight re-run is the launch path — a stale approval may
+ * clobber a newer edit.
+ */
+export interface ManageWatchersProposal {
+  args: ManageWatchersArgs;
+}
 export const ListWatchersSchema = Type.Object({
   watcher_id: Type.Optional(
     Type.String({

--- a/packages/server/src/__tests__/integration/tools/manage-watchers-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-watchers-approval-e2e.test.ts
@@ -365,4 +365,68 @@ describe("manage_watchers — builder gate e2e", () => {
 		`;
 		expect(eventRows[0]?.interaction_status).toBe("failed");
 	});
+
+	it("stale cross-owner approval is rejected on apply after the watcher is reassigned", async () => {
+		// Agent A creates a watcher it owns (queue + approve so A is the owner).
+		const created = (await executeTool(
+			"manage_watchers",
+			{
+				action: "create",
+				slug: "a-owned-then-reassigned",
+				name: "A owned",
+				prompt: "Owned by agent A at queue time.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { watcher_id?: string };
+		const watcherId = created.watcher_id!;
+		expect(watcherId).toBeDefined();
+
+		// Agent A queues an update. The proposal captures A as the acting agent.
+		const pending = (await executeTool(
+			"manage_watchers",
+			{
+				action: "update",
+				watcher_id: watcherId,
+				description: "A's held edit",
+			},
+			TEST_ENV,
+			agentCtx,
+		)) as PendingApproval;
+		expect(pending.status).toBe("pending_approval");
+
+		// Race: the watcher is reassigned to agent B while the approval is pending.
+		const sql = getTestDb();
+		await sql`
+			UPDATE watchers SET agent_id = ${otherAgentId}
+			WHERE id = ${watcherId} AND organization_id = ${orgId}
+		`;
+
+		// Approving must NOT apply A's held mutation to B-owned behavior: the
+		// apply path re-checks ownership against the persisted acting agent under
+		// the group lock and fails closed.
+		const approveRes = (await executeTool(
+			"manage_operations",
+			{ action: "approve", run_id: pending.run_id },
+			TEST_ENV,
+			ownerCtx,
+		)) as { approved?: true; message?: string };
+		expect(approveRes.message).toMatch(/failed/i);
+		expect(approveRes.message).not.toMatch(/applied/i);
+
+		// The held edit was NOT applied.
+		const watcherRows = await sql`
+			SELECT description FROM watchers
+			WHERE id = ${watcherId} AND organization_id = ${orgId}
+		`;
+		expect(watcherRows[0]?.description).not.toBe("A's held edit");
+
+		// Run marked failed; card superseded to failed.
+		const runRows = await sql`
+			SELECT status FROM runs
+			WHERE id = ${pending.run_id} AND organization_id = ${orgId}
+		`;
+		expect(runRows[0]?.status).toBe("failed");
+	});
 });

--- a/packages/server/src/__tests__/integration/tools/manage-watchers-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-watchers-approval-e2e.test.ts
@@ -1,0 +1,308 @@
+/**
+ * manage_watchers — builder-gate approval queue (agent_config write class).
+ *
+ * WRITE definition actions (create/update/delete/create_version/…) route through
+ * the same `agent_config` write-gate class as manage_agents:
+ *   - A HUMAN member applies immediately — no run, no approval card.
+ *   - An AGENT-driven write follows the org policy (default: create/update queue
+ *     a pending `runs` row + approval event; delete is denied). Approving via
+ *     manage_operations applies the held mutation and supersedes the pending card.
+ *
+ * Covers:
+ *   - agent create → pending_approval (NOT 403), no watcher row yet
+ *   - approve → watcher exists, run completed, event superseded 'completed'
+ *   - reject → no watcher, run cancelled, event superseded 'rejected'
+ *   - human create still applies immediately
+ *   - foreign-owner escalation still 403s before queueing
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import type { AuthContext } from "../../../tools/execute";
+import { executeTool } from "../../../tools/execute";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	createTestAgent,
+	createTestOrganization,
+	createTestUser,
+	addUserToOrganization,
+} from "../../setup/test-fixtures";
+
+const TEST_ENV: Env = {
+	ENVIRONMENT: "test",
+	DATABASE_URL: process.env.DATABASE_URL,
+	JWT_SECRET: "test-jwt-secret-for-testing-only",
+	BETTER_AUTH_SECRET: "test-auth-secret-for-testing-only",
+	MAX_CONSECUTIVE_FAILURES: "3",
+	RATE_LIMIT_ENABLED: "false",
+};
+
+type PendingApproval = {
+	status: "pending_approval";
+	run_id: number;
+	event_id?: number;
+	action: string;
+	proposal?: { args?: { action?: string; slug?: string } };
+};
+
+async function watcherExists(orgId: string, slug: string): Promise<boolean> {
+	const sql = getTestDb();
+	const rows = await sql`
+		SELECT 1 FROM watchers WHERE organization_id = ${orgId} AND slug = ${slug}
+	`;
+	return rows.length > 0;
+}
+
+describe("manage_watchers — builder gate e2e", () => {
+	let orgId: string;
+	let ownerId: string;
+	let ownerCtx: AuthContext;
+	let agentCtx: AuthContext;
+	let agentId: string;
+	let otherAgentId: string;
+
+	const baseCtx = (
+		orgIdValue: string,
+		userId: string,
+		memberRole: "owner" | "member",
+		scopes: string[],
+		boundAgentId: string | null = null,
+	): AuthContext => ({
+		organizationId: orgIdValue,
+		tokenOrganizationId: orgIdValue,
+		userId,
+		memberRole,
+		agentId: boundAgentId,
+		requestedAgentId: boundAgentId,
+		isAuthenticated: true,
+		clientId: null,
+		scopes,
+		tokenType: "oauth",
+		requestUrl: `http://localhost/api/${orgIdValue}`,
+		baseUrl: "",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+	});
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+
+		const org = await createTestOrganization({
+			name: "manage_watchers gate e2e",
+		});
+		orgId = org.id;
+		const owner = await createTestUser({ email: "mw-owner@test.com" });
+		ownerId = owner.id;
+		await addUserToOrganization(owner.id, org.id, "owner");
+
+		ownerCtx = baseCtx(org.id, owner.id, "owner", [
+			"mcp:read",
+			"mcp:write",
+			"mcp:admin",
+		]);
+
+		const builder = await createTestAgent({
+			organizationId: org.id,
+			agentId: "builder-agent",
+			ownerUserId: owner.id,
+		});
+		agentId = builder.agentId;
+		const other = await createTestAgent({
+			organizationId: org.id,
+			ownerUserId: owner.id,
+		});
+		otherAgentId = other.agentId;
+
+		// Same owner identity, but acting as the builder agent — principal the
+		// agent_config write-gate holds for approval.
+		agentCtx = baseCtx(
+			org.id,
+			owner.id,
+			"owner",
+			["mcp:read", "mcp:write", "mcp:admin"],
+			agentId,
+		);
+	});
+
+	it("human owner: create applies immediately with no approval run", async () => {
+		const res = (await executeTool(
+			"manage_watchers",
+			{
+				action: "create",
+				slug: "human-watcher",
+				name: "Human Watcher",
+				prompt: "Track things.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { action: string; watcher_id?: string; status?: string };
+		// Immediate apply returns the watcher status ('active'), not pending_approval.
+		expect(res.status).not.toBe("pending_approval");
+		expect(res.watcher_id).toBeDefined();
+		expect(await watcherExists(orgId, "human-watcher")).toBe(true);
+
+		const sql = getTestDb();
+		const runRows = await sql`
+			SELECT 1 FROM runs
+			WHERE organization_id = ${orgId} AND action_key = 'manage_watchers'
+				AND approval_status = 'pending'
+		`;
+		expect(runRows.length).toBe(0);
+	});
+
+	it("agent create produces a pending run + approval event and does NOT create the watcher yet", async () => {
+		const res = (await executeTool(
+			"manage_watchers",
+			{
+				action: "create",
+				slug: "agent-proposed-watcher",
+				name: "Agent Proposed",
+				prompt: "Track launches.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			agentCtx,
+		)) as PendingApproval;
+
+		expect(res.status).toBe("pending_approval");
+		expect(typeof res.run_id).toBe("number");
+		expect(res.action).toBe("create");
+		expect(res.proposal?.args?.slug).toBe("agent-proposed-watcher");
+
+		const sql = getTestDb();
+		const runRows = await sql`
+			SELECT run_type, action_key, approval_status, status, action_input, created_by_user_id
+			FROM runs WHERE id = ${res.run_id} AND organization_id = ${orgId}
+		`;
+		expect(runRows.length).toBe(1);
+		expect(runRows[0]?.run_type).toBe("internal");
+		expect(runRows[0]?.action_key).toBe("manage_watchers");
+		expect(runRows[0]?.approval_status).toBe("pending");
+		expect(runRows[0]?.status).toBe("pending");
+		expect(runRows[0]?.created_by_user_id).toBe(ownerId);
+
+		const eventRows = await sql`
+			SELECT interaction_type, interaction_status
+			FROM current_event_records
+			WHERE run_id = ${res.run_id} AND organization_id = ${orgId}
+				AND semantic_type = 'operation' AND interaction_type = 'approval'
+		`;
+		expect(eventRows.length).toBe(1);
+		expect(eventRows[0]?.interaction_status).toBe("pending");
+
+		expect(await watcherExists(orgId, "agent-proposed-watcher")).toBe(false);
+	});
+
+	it("approve applies the held create: watcher exists, run completed, event superseded", async () => {
+		const created = (await executeTool(
+			"manage_watchers",
+			{
+				action: "create",
+				slug: "approved-watcher",
+				name: "Approved Watcher",
+				prompt: "Track approved items.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			agentCtx,
+		)) as PendingApproval;
+		expect(created.status).toBe("pending_approval");
+		expect(await watcherExists(orgId, "approved-watcher")).toBe(false);
+
+		const approveRes = (await executeTool(
+			"manage_operations",
+			{ action: "approve", run_id: created.run_id },
+			TEST_ENV,
+			ownerCtx,
+		)) as { approved?: true };
+		expect(approveRes.approved).toBe(true);
+
+		expect(await watcherExists(orgId, "approved-watcher")).toBe(true);
+
+		const sql = getTestDb();
+		const runRows = await sql`
+			SELECT approval_status, status FROM runs
+			WHERE id = ${created.run_id} AND organization_id = ${orgId}
+		`;
+		expect(runRows[0]?.approval_status).toBe("approved");
+		expect(runRows[0]?.status).toBe("completed");
+
+		// Current event for the run is now 'completed' (the pending card was superseded).
+		const eventRows = await sql`
+			SELECT interaction_status FROM current_event_records
+			WHERE run_id = ${created.run_id} AND organization_id = ${orgId}
+				AND semantic_type = 'operation' AND interaction_type = 'approval'
+		`;
+		expect(eventRows[0]?.interaction_status).toBe("completed");
+	});
+
+	it("reject cancels the held create: no watcher, run cancelled, event superseded 'rejected'", async () => {
+		const created = (await executeTool(
+			"manage_watchers",
+			{
+				action: "create",
+				slug: "rejected-watcher",
+				name: "Rejected Watcher",
+				prompt: "Track rejected items.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			agentCtx,
+		)) as PendingApproval;
+		expect(created.status).toBe("pending_approval");
+
+		const rejectRes = (await executeTool(
+			"manage_operations",
+			{ action: "reject", run_id: created.run_id, reason: "not now" },
+			TEST_ENV,
+			ownerCtx,
+		)) as { rejected?: true };
+		expect(rejectRes.rejected).toBe(true);
+
+		expect(await watcherExists(orgId, "rejected-watcher")).toBe(false);
+
+		const sql = getTestDb();
+		const runRows = await sql`
+			SELECT approval_status, status FROM runs
+			WHERE id = ${created.run_id} AND organization_id = ${orgId}
+		`;
+		expect(runRows[0]?.approval_status).toBe("rejected");
+		expect(runRows[0]?.status).toBe("cancelled");
+
+		const eventRows = await sql`
+			SELECT interaction_status FROM current_event_records
+			WHERE run_id = ${created.run_id} AND organization_id = ${orgId}
+				AND semantic_type = 'operation' AND interaction_type = 'approval'
+		`;
+		expect(eventRows[0]?.interaction_status).toBe("rejected");
+	});
+
+	it("foreign-owner create still 403s and does not queue a pending run", async () => {
+		await expect(
+			executeTool(
+				"manage_watchers",
+				{
+					action: "create",
+					slug: "foreign-owned",
+					name: "Foreign Owned",
+					prompt: "Should not queue.",
+					agent_id: otherAgentId,
+				},
+				TEST_ENV,
+				agentCtx,
+			),
+		).rejects.toThrow(/cannot install watcher behavior owned by another agent/i);
+
+		const sql = getTestDb();
+		const runRows = await sql`
+			SELECT 1 FROM runs
+			WHERE organization_id = ${orgId} AND action_key = 'manage_watchers'
+				AND approval_status = 'pending'
+				AND action_input::text LIKE '%foreign-owned%'
+		`;
+		expect(runRows.length).toBe(0);
+	});
+});

--- a/packages/server/src/__tests__/integration/tools/manage-watchers-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-watchers-approval-e2e.test.ts
@@ -305,4 +305,64 @@ describe("manage_watchers — builder gate e2e", () => {
 		`;
 		expect(runRows.length).toBe(0);
 	});
+
+	it("approve of update with invalid timezone marks run failed (not completed)", async () => {
+		// Seed a watcher via the human path so there is a target to update.
+		const created = (await executeTool(
+			"manage_watchers",
+			{
+				action: "create",
+				slug: "tz-fail-watcher",
+				name: "TZ Fail Watcher",
+				prompt: "Track timezone failures.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { watcher_id?: string; status?: string };
+		expect(created.watcher_id).toBeDefined();
+		const watcherId = created.watcher_id!;
+
+		// Agent proposes an update with a bad timezone — queues for approval.
+		// handleUpdate returns `{ error }` (does not throw); the apply boundary
+		// must treat that as failure so we never mark the run completed.
+		const pending = (await executeTool(
+			"manage_watchers",
+			{
+				action: "update",
+				watcher_id: watcherId,
+				timezone: "Not/A_Real_Zone",
+			},
+			TEST_ENV,
+			agentCtx,
+		)) as PendingApproval;
+		expect(pending.status).toBe("pending_approval");
+		expect(typeof pending.run_id).toBe("number");
+
+		const approveRes = (await executeTool(
+			"manage_operations",
+			{ action: "approve", run_id: pending.run_id },
+			TEST_ENV,
+			ownerCtx,
+		)) as { approved?: true; message?: string };
+		expect(approveRes.approved).toBe(true);
+		expect(approveRes.message).toMatch(/failed/i);
+		expect(approveRes.message).not.toMatch(/applied/i);
+
+		const sql = getTestDb();
+		const runRows = await sql`
+			SELECT approval_status, status, error_message FROM runs
+			WHERE id = ${pending.run_id} AND organization_id = ${orgId}
+		`;
+		expect(runRows[0]?.approval_status).toBe("approved");
+		expect(runRows[0]?.status).toBe("failed");
+		expect(String(runRows[0]?.error_message ?? "")).toMatch(/timezone|IANA/i);
+
+		const eventRows = await sql`
+			SELECT interaction_status FROM current_event_records
+			WHERE run_id = ${pending.run_id} AND organization_id = ${orgId}
+				AND semantic_type = 'operation' AND interaction_type = 'approval'
+		`;
+		expect(eventRows[0]?.interaction_status).toBe("failed");
+	});
 });

--- a/packages/server/src/__tests__/integration/tools/manage-watchers-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-watchers-approval-e2e.test.ts
@@ -366,6 +366,54 @@ describe("manage_watchers — builder gate e2e", () => {
 		expect(eventRows[0]?.interaction_status).toBe("failed");
 	});
 
+	it("rejects a no-op update (only watcher_id, no patch fields)", async () => {
+		const created = (await executeTool(
+			"manage_watchers",
+			{
+				action: "create",
+				slug: "noop-update-target",
+				name: "Noop target",
+				prompt: "Target.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { watcher_id?: string };
+		const watcherId = created.watcher_id!;
+		await expect(
+			executeTool(
+				"manage_watchers",
+				{ action: "update", watcher_id: watcherId },
+				TEST_ENV,
+				agentCtx,
+			),
+		).rejects.toThrow(/at least one field to change/i);
+	});
+
+	it("rejects set_reaction_script with no reaction_script (would silently clear)", async () => {
+		const created = (await executeTool(
+			"manage_watchers",
+			{
+				action: "create",
+				slug: "reaction-target",
+				name: "Reaction target",
+				prompt: "Target.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { watcher_id?: string };
+		const watcherId = created.watcher_id!;
+		await expect(
+			executeTool(
+				"manage_watchers",
+				{ action: "set_reaction_script", watcher_id: watcherId },
+				TEST_ENV,
+				agentCtx,
+			),
+		).rejects.toThrow(/reaction_script is required/i);
+	});
+
 	it("stale cross-owner approval is rejected on apply after the watcher is reassigned", async () => {
 		// Agent A creates a watcher it owns (queue + approve so A is the owner).
 		const created = (await executeTool(

--- a/packages/server/src/gateway/api/platform.ts
+++ b/packages/server/src/gateway/api/platform.ts
@@ -104,6 +104,13 @@ export class ApiPlatform implements PlatformAdapter {
     // bridge does NOT subscribe to this event, so it never mis-renders it.
     interactionService.on("tool:durable-approval-card", (event: any) => {
       if (event.platform !== "api") return;
+      const resourceKind: string | null = event.resourceKind ?? null;
+      const toolName =
+        event.fields
+          ? "manage_entity"
+          : resourceKind === "watcher"
+            ? "manage_watchers"
+            : "manage_agents";
       this.enqueueInteractionCard(queue, event, "tool-approval", {
         type: "tool-approval",
         requestId: event.id,
@@ -116,7 +123,8 @@ export class ApiPlatform implements PlatformAdapter {
         // card. manage_agents leaves these null and renders its agent-row diff.
         fields: event.fields ?? null,
         attribution: event.attribution ?? null,
-        toolName: event.fields ? "manage_entity" : "manage_agents",
+        resourceKind,
+        toolName,
       });
     });
 

--- a/packages/server/src/gateway/interactions.ts
+++ b/packages/server/src/gateway/interactions.ts
@@ -128,6 +128,8 @@ export interface PostedDurableApproval extends BaseMessage {
   fields: Record<string, unknown> | null;
   /** Who proposed the entity_field_change: 'agent' | 'watcher'. Null for manage_agents. */
   attribution: string | null;
+  /** Discriminator for the SPA: "agent" | "watcher" | "entity". */
+  resourceKind: string | null;
   /** Headless-origin marker (parity with PostedQuestion/PostedToolApproval). */
   source?: string;
 }
@@ -266,7 +268,8 @@ export class InteractionService extends EventEmitter {
     current: Record<string, unknown> | null,
     source?: string,
     fields: Record<string, unknown> | null = null,
-    attribution: string | null = null
+    attribution: string | null = null,
+    resourceKind: string | null = null
   ): Promise<PostedDurableApproval> {
     assertRoutableInteraction(connectionId, platform, "approval card");
     if (this.beforeCreateHook) {
@@ -287,6 +290,7 @@ export class InteractionService extends EventEmitter {
       current,
       fields,
       attribution,
+      resourceKind,
       source,
     };
 

--- a/packages/server/src/gateway/routes/internal/interactions.ts
+++ b/packages/server/src/gateway/routes/internal/interactions.ts
@@ -91,7 +91,8 @@ export function createInteractionRoutes(
             // entity_field_change (manage_entity) carries a human-owned-field
             // diff + who proposed it; manage_agents leaves these null.
             (body.fields ?? null) as Record<string, unknown> | null,
-            typeof body.attribution === "string" ? body.attribution : null
+            typeof body.attribution === "string" ? body.attribution : null,
+            typeof body.resourceKind === "string" ? body.resourceKind : null
           );
           // The live approval card is a one-shot SSE push, and the transcript
           // doesn't carry interaction parts — so on reload the card is lost.

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -71,6 +71,8 @@ type ToolApprovalHistoryInteraction = {
 	current: Record<string, unknown> | null;
 	fields: Record<string, unknown> | null;
 	attribution: string | null;
+	/** Discriminator: "agent" | "watcher" | "entity". */
+	resourceKind: string | null;
 };
 
 type AgentErrorHistoryInteraction = {
@@ -523,6 +525,8 @@ export function createAgentHistoryRoutes(deps: {
 				current: Record<string, unknown> | null;
 				fields: Record<string, unknown> | null;
 				attribution: string | null;
+				resource_kind: string | null;
+				tool: string | null;
 			}>`
 				SELECT run_id,
 				       metadata->>'action' AS action,
@@ -532,7 +536,9 @@ export function createAgentHistoryRoutes(deps: {
 				       -- human-owned-field diff + attribution; manage_agents
 				       -- leaves these null and replays its agent-row proposal.
 				       metadata->'fields' AS fields,
-				       metadata->>'attribution' AS attribution
+				       metadata->>'attribution' AS attribution,
+				       metadata->>'resourceKind' AS resource_kind,
+				       metadata->>'tool' AS tool
 				FROM current_event_records
 				WHERE organization_id = ${scope.organizationId}
 				  AND interaction_type = 'approval'
@@ -540,15 +546,37 @@ export function createAgentHistoryRoutes(deps: {
 				  AND metadata->>'conversationId' = ${conversationId}
 				ORDER BY run_id
 			`;
-			interactions = rows.map((r) => ({
-				type: "tool-approval" as const,
-				runId: Number(r.run_id),
-				action: r.action,
-				proposal: r.proposal ?? null,
-				current: r.current ?? null,
-				fields: r.fields ?? null,
-				attribution: r.attribution ?? null,
-			}));
+			interactions = rows.map((r) => {
+				const resourceKind =
+					r.resource_kind ??
+					(r.tool === "manage_watchers"
+						? "watcher"
+						: r.tool === "manage_agents"
+							? "agent"
+							: r.tool === "entity_field_change" || r.tool === "entity_change"
+								? "entity"
+								: null);
+				// manage_watchers stores proposal as `{ args }`; SPA expects flat fields.
+				const rawProposal = r.proposal ?? null;
+				const proposal =
+					resourceKind === "watcher" &&
+					rawProposal &&
+					typeof rawProposal === "object" &&
+					(rawProposal as { args?: unknown }).args &&
+					typeof (rawProposal as { args: unknown }).args === "object"
+						? ((rawProposal as { args: Record<string, unknown> }).args)
+						: rawProposal;
+				return {
+					type: "tool-approval" as const,
+					runId: Number(r.run_id),
+					action: r.action,
+					proposal,
+					current: r.current ?? null,
+					fields: r.fields ?? null,
+					attribution: r.attribution ?? null,
+					resourceKind,
+				};
+			});
 			const errorInteraction = await readLatestAgentErrorInteraction(
 				scope.organizationId,
 				conversationId,

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -68,6 +68,11 @@ import {
 	MANAGE_AGENTS_ACTION_KEY,
 	type ManageAgentsProposal,
 } from "./manage_agents";
+import {
+	applyManageWatchersProposal,
+	MANAGE_WATCHERS_ACTION_KEY,
+	type ManageWatchersProposal,
+} from "./manage_watchers";
 
 type InlineExecutionResult =
 	| {
@@ -1341,6 +1346,138 @@ async function tryApproveManageAgentsRun(
 }
 
 /**
+ * Claim a pending builder-gate manage_watchers run (create/update/delete/…).
+ * Mirrors {@link claimManageAgentsRun}. Returns null when this run_id isn't a
+ * pending manage_watchers run — caller falls through to the next approval path.
+ */
+async function claimManageWatchersRun(
+	runId: number,
+	organizationId: string,
+	decision: "approved" | "rejected",
+	rejectReason?: string,
+): Promise<{
+	proposal: ManageWatchersProposal;
+	requesterUserId: string | null;
+} | null> {
+	const sql = getDb();
+	const rows =
+		decision === "approved"
+			? await sql`
+          UPDATE runs
+          SET approval_status = 'approved', status = 'running'
+          WHERE id = ${runId}
+            AND organization_id = ${organizationId}
+            AND approval_status = 'pending'
+            AND run_type = 'internal'
+            AND action_key = ${MANAGE_WATCHERS_ACTION_KEY}
+          RETURNING action_input, created_by_user_id
+        `
+			: await sql`
+          UPDATE runs
+          SET approval_status = 'rejected', status = 'cancelled',
+              error_message = ${rejectReason ?? "Rejected by user"}, completed_at = NOW()
+          WHERE id = ${runId}
+            AND organization_id = ${organizationId}
+            AND approval_status = 'pending'
+            AND run_type = 'internal'
+            AND action_key = ${MANAGE_WATCHERS_ACTION_KEY}
+          RETURNING action_input, created_by_user_id
+        `;
+	if (rows.length === 0) return null;
+	const row = rows[0] as {
+		action_input: ManageWatchersProposal | null;
+		created_by_user_id: string | null;
+	};
+	if (!row.action_input?.args) return null;
+	return { proposal: row.action_input, requesterUserId: row.created_by_user_id };
+}
+
+/**
+ * Approve + apply a builder-gate manage_watchers run. Returns a result when the
+ * run was a pending manage_watchers run; null to fall through to the next path.
+ * Routes the terminal event through {@link supersedeActionEvent} (must pass
+ * supersedesEventId explicitly — origin-based auto-supersede needs a non-null
+ * connection_id, which internal approval events don't have).
+ */
+async function tryApproveManageWatchersRun(
+	args: Static<typeof ApproveAction>,
+	ctx: ToolContext,
+	env: Env,
+): Promise<ManageOperationsResult | null> {
+	const claimed = await claimManageWatchersRun(
+		args.run_id,
+		ctx.organizationId,
+		"approved",
+	);
+	if (!claimed) return null;
+
+	const { proposal, requesterUserId } = claimed;
+	const action = proposal.args.action;
+	const reviewer = await resolveReviewer(ctx);
+	await supersedeActionEvent(
+		args.run_id,
+		ctx.organizationId,
+		"confirmed",
+		`manage_watchers.${action} — executing`,
+		`Builder action confirmed: ${action}`,
+		{},
+		reviewer,
+	);
+
+	try {
+		const output = await applyManageWatchersProposal(
+			proposal,
+			ctx,
+			env,
+			requesterUserId,
+		);
+		await getDb()`
+      UPDATE runs SET status = 'completed', completed_at = NOW(),
+        action_output = ${getDb().json(output as unknown as Record<string, unknown>)}
+      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+    `;
+		const eventId = await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"completed",
+			`manage_watchers.${action} — completed`,
+			`Builder action completed: ${action}`,
+			{ output: output as unknown as Record<string, unknown> },
+			reviewer,
+		);
+		return {
+			action: "approve",
+			approved: true,
+			run_id: args.run_id,
+			event_id: eventId,
+			message: `Watcher ${action} approved and applied.`,
+		};
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		await getDb()`
+      UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMessage}
+      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+    `;
+		const eventId = await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"failed",
+			`manage_watchers.${action} — failed`,
+			`Builder action failed: ${action} — ${errorMessage}`,
+			{ error_message: errorMessage },
+			reviewer,
+		);
+		return {
+			action: "approve",
+			approved: true,
+			run_id: args.run_id,
+			event_id: eventId,
+			message: `Watcher ${action} approved but failed: ${errorMessage}`,
+		};
+	}
+}
+
+/**
  * Claim a pending entity_field_change run (a watcher field-change held for
  * approval). Mirrors claimManageAgentsRun. Returns the held proposal, or null when
  * this run isn't a pending field-change run.
@@ -1653,12 +1790,15 @@ async function handleApprove(
 
 	const sql = getDb();
 
-	// Builder-gate runs (manage_agents create/update/delete) reuse this same
-	// durable approval path but have run_type='internal' + no connection. Apply
-	// them via the manage_agents handlers rather than the connector-operation
-	// executor.
+	// Builder-gate runs (manage_agents / manage_watchers create/update/delete)
+	// reuse this same durable approval path but have run_type='internal' + no
+	// connection. Apply them via their handlers rather than the connector-
+	// operation executor.
 	const builderResult = await tryApproveManageAgentsRun(args, ctx, env);
 	if (builderResult) return builderResult;
+
+	const watchersBuilderResult = await tryApproveManageWatchersRun(args, ctx, env);
+	if (watchersBuilderResult) return watchersBuilderResult;
 
 	// Watcher field-change gate (run_type='internal', action_key='entity_field_change'):
 	// approve applies the proposed value to the entity (now human-owned).
@@ -1908,7 +2048,7 @@ async function handleReject(
 	const reason = args.reason ?? "Rejected by user";
 	const reviewer = await resolveReviewer(ctx);
 
-	// Builder-gate run? Cancel it without touching the agents table.
+	// Builder-gate run? Cancel it without applying the held mutation.
 	const claimedBuilder = await claimManageAgentsRun(
 		args.run_id,
 		ctx.organizationId,
@@ -1922,6 +2062,31 @@ async function handleReject(
 			"rejected",
 			`manage_agents.${claimedBuilder.proposal.action} — rejected`,
 			`Builder action rejected: ${claimedBuilder.proposal.action} ${claimedBuilder.proposal.agent_id}${args.reason ? ` — ${args.reason}` : ""}`,
+			{ reason },
+			reviewer,
+		);
+		return {
+			action: "reject",
+			rejected: true,
+			run_id: args.run_id,
+			event_id: eventId,
+		};
+	}
+
+	const claimedWatchersBuilder = await claimManageWatchersRun(
+		args.run_id,
+		ctx.organizationId,
+		"rejected",
+		reason,
+	);
+	if (claimedWatchersBuilder) {
+		const action = claimedWatchersBuilder.proposal.args.action;
+		const eventId = await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"rejected",
+			`manage_watchers.${action} — rejected`,
+			`Builder action rejected: ${action}${args.reason ? ` — ${args.reason}` : ""}`,
 			{ reason },
 			reviewer,
 		);

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1431,6 +1431,20 @@ async function tryApproveManageWatchersRun(
 			env,
 			requesterUserId,
 		);
+		// handleCreate throws on invalid schedule/timezone, but handleUpdate
+		// returns `{ error }` and handleDelete returns a summary with
+		// failed/successful counts (no throw). Detect soft failures here so we
+		// don't mark the run completed when nothing applied.
+		const softFailure = detectManageWatchersApplyFailure(output);
+		if (softFailure) {
+			return failManageWatchersApproval(
+				args.run_id,
+				ctx.organizationId,
+				action,
+				softFailure,
+				reviewer,
+			);
+		}
 		await getDb()`
       UPDATE runs SET status = 'completed', completed_at = NOW(),
         action_output = ${getDb().json(output as unknown as Record<string, unknown>)}
@@ -1454,27 +1468,77 @@ async function tryApproveManageWatchersRun(
 		};
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error);
-		await getDb()`
-      UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMessage}
-      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
-    `;
-		const eventId = await supersedeActionEvent(
+		return failManageWatchersApproval(
 			args.run_id,
 			ctx.organizationId,
-			"failed",
-			`manage_watchers.${action} — failed`,
-			`Builder action failed: ${action} — ${errorMessage}`,
-			{ error_message: errorMessage },
+			action,
+			errorMessage,
 			reviewer,
 		);
-		return {
-			action: "approve",
-			approved: true,
-			run_id: args.run_id,
-			event_id: eventId,
-			message: `Watcher ${action} approved but failed: ${errorMessage}`,
-		};
 	}
+}
+
+/**
+ * Detect soft failures from manage_watchers write handlers that return errors
+ * instead of throwing. create throws (ToolUserError); update returns
+ * `{ error: string }` for invalid cron/timezone; delete returns a summary with
+ * per-id results and never throws on individual archive failures.
+ *
+ * Partial delete success (some succeeded, some failed) is treated as completed
+ * — the summary is preserved in action_output so the reviewer can see which
+ * ids failed.
+ */
+function detectManageWatchersApplyFailure(output: unknown): string | null {
+	if (!output || typeof output !== "object") return null;
+	const result = output as Record<string, unknown>;
+	if (result.error) {
+		return typeof result.error === "string"
+			? result.error
+			: String(result.error);
+	}
+	const summary = result.summary as
+		| { total?: number; successful?: number; failed?: number }
+		| undefined;
+	if (
+		summary &&
+		typeof summary.failed === "number" &&
+		summary.failed > 0 &&
+		summary.successful === 0
+	) {
+		const total =
+			typeof summary.total === "number" ? summary.total : summary.failed;
+		return `Watcher delete failed: 0 of ${total} succeeded`;
+	}
+	return null;
+}
+
+async function failManageWatchersApproval(
+	runId: number,
+	organizationId: string,
+	action: string,
+	errorMessage: string,
+	reviewer: ApprovalReviewer | null,
+): Promise<ManageOperationsResult> {
+	await getDb()`
+    UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMessage}
+    WHERE id = ${runId} AND organization_id = ${organizationId}
+  `;
+	const eventId = await supersedeActionEvent(
+		runId,
+		organizationId,
+		"failed",
+		`manage_watchers.${action} — failed`,
+		`Builder action failed: ${action} — ${errorMessage}`,
+		{ error_message: errorMessage },
+		reviewer,
+	);
+	return {
+		action: "approve",
+		approved: true,
+		run_id: runId,
+		event_id: eventId,
+		message: `Watcher ${action} approved but failed: ${errorMessage}`,
+	};
 }
 
 /**

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -387,9 +387,13 @@ async function fetchCurrentWatcher(
  *
  * Watcher definition writes have no per-field pre-image; the proposal is the
  * full original args for a straight re-run on approve (a stale approval may
- * clobber a newer edit — acceptable for launch).
+ * clobber a newer edit — acceptable for launch). Acting principal is persisted
+ * so apply can re-run the foreign-owner guard against the original actor.
  */
-function buildWatcherProposal(args: ManageWatchersArgs): ManageWatchersProposal {
+function buildWatcherProposal(
+  args: ManageWatchersArgs,
+  acting: { actingAgentId: string | null; actingWatcherId: string | null },
+): ManageWatchersProposal {
   const writeAction = watcherWriteAction(args.action);
   if (!writeAction) {
     throw new ToolUserError(`action "${args.action}" is not a gated watcher write`);
@@ -423,53 +427,111 @@ function buildWatcherProposal(args: ManageWatchersArgs): ManageWatchersProposal 
       throw new ToolUserError('entity_ids is required for create_from_version action');
     }
   }
-  return { args };
+  return {
+    args,
+    actingAgentId: acting.actingAgentId,
+    actingWatcherId: acting.actingWatcherId,
+  };
 }
 
-/** Flat watcher fields shown on the events-tab ActionApprovalCard fallback. */
-const WATCHER_APPROVAL_DISPLAY_KEYS = [
-  'action',
-  'slug',
-  'name',
-  'prompt',
-  'schedule',
-  'timezone',
-  'agent_id',
-  'watcher_id',
-  'watcher_ids',
-] as const;
+/**
+ * Routing-only key rendered in the card title, not the field list. Everything
+ * else present on the proposed args is a mutation input humans must be able to
+ * review (reaction script, execution_config, explicit null clears, …).
+ */
+const WATCHER_APPROVAL_ROUTING_KEYS = new Set(['action']);
 
+/** Display sentinel for an explicit null clear (field present, value null). */
+const WATCHER_APPROVAL_CLEARED = '(cleared)';
+
+/**
+ * Flat watcher mutation fields for the events-tab ActionApprovalCard fallback.
+ * Includes every proposed arg that is present (including explicit `null`
+ * clears); only `action` is omitted (shown in the title). Absent fields
+ * (`undefined`) are excluded so the card does not invent values.
+ */
 function pickWatcherApprovalDisplayFields(
   args: ManageWatchersArgs,
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
-  for (const key of WATCHER_APPROVAL_DISPLAY_KEYS) {
-    const value = args[key as keyof ManageWatchersArgs];
-    if (value === undefined || value === null) continue;
-    out[key] = Array.isArray(value) ? value.join(', ') : value;
+  for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+    if (WATCHER_APPROVAL_ROUTING_KEYS.has(key)) continue;
+    if (value === undefined) continue;
+    // Explicit null = clear (e.g. schedule: null). Render as a visible sentinel
+    // so the card can show the clear rather than dropping the field.
+    if (value === null) {
+      out[key] = WATCHER_APPROVAL_CLEARED;
+      continue;
+    }
+    if (Array.isArray(value)) {
+      // Primitive arrays (watcher_ids, entity_ids, tags) collapse for display;
+      // object arrays (sources) keep structure via JSON in the schema renderer.
+      out[key] = value.every(
+        (v) => v === null || ['string', 'number', 'boolean'].includes(typeof v),
+      )
+        ? value.join(', ')
+        : value;
+      continue;
+    }
+    out[key] = value;
   }
   return out;
 }
 
+/** Human-readable titles for common watcher approval fields. */
+const WATCHER_APPROVAL_FIELD_TITLES: Record<string, string> = {
+  slug: 'Slug',
+  name: 'Name',
+  description: 'Description',
+  prompt: 'Prompt',
+  schedule: 'Schedule',
+  timezone: 'Timezone',
+  agent_id: 'Agent',
+  watcher_id: 'Watcher ID',
+  watcher_ids: 'Watcher IDs',
+  version_id: 'Version ID',
+  entity_id: 'Entity ID',
+  entity_ids: 'Entity IDs',
+  reaction_script: 'Reaction script',
+  execution_config: 'Execution config',
+  device_worker_id: 'Device worker',
+  scheduler_client_id: 'Scheduler client',
+  agent_kind: 'Agent kind',
+  sources: 'Sources',
+  model_config: 'Model config',
+  keying_config: 'Keying config',
+  classifiers: 'Classifiers',
+  tags: 'Tags',
+  change_notes: 'Change notes',
+  set_as_current: 'Set as current',
+  reactions_guidance: 'Reactions guidance',
+  notification_channel: 'Notification channel',
+  notification_priority: 'Notification priority',
+  min_cooldown_seconds: 'Min cooldown (seconds)',
+  name_pattern: 'Name pattern',
+};
+
 function buildWatcherApprovalInputSchema(
   fields: Record<string, unknown>,
 ): Record<string, unknown> {
-  const titles: Record<string, string> = {
-    action: 'Action',
-    slug: 'Slug',
-    name: 'Name',
-    prompt: 'Prompt',
-    schedule: 'Schedule',
-    timezone: 'Timezone',
-    agent_id: 'Agent',
-    watcher_id: 'Watcher ID',
-    watcher_ids: 'Watcher IDs',
-  };
   const properties: Record<string, unknown> = {};
-  for (const key of Object.keys(fields)) {
-    if (titles[key]) {
-      properties[key] = { type: 'string', title: titles[key] };
+  for (const [key, value] of Object.entries(fields)) {
+    const baseTitle = WATCHER_APPROVAL_FIELD_TITLES[key] ?? key;
+    const title =
+      value === WATCHER_APPROVAL_CLEARED ? `${baseTitle} (cleared)` : baseTitle;
+    if (typeof value === 'object' && value !== null) {
+      properties[key] = { type: 'object', title };
+      continue;
     }
+    if (typeof value === 'number') {
+      properties[key] = { type: 'number', title };
+      continue;
+    }
+    if (typeof value === 'boolean') {
+      properties[key] = { type: 'boolean', title };
+      continue;
+    }
+    properties[key] = { type: 'string', title };
   }
   return { type: 'object', properties };
 }
@@ -480,12 +542,16 @@ function buildWatcherApprovalInputSchema(
  * `interaction_type='approval'` event holding the proposed args. The mutation is
  * applied later by manage_operations' approve handler via
  * {@link applyManageWatchersProposal}.
+ *
+ * `acting` is the principal resolved at gate time (same seam as the foreign-
+ * owner check) and is persisted on the proposal so apply can re-validate.
  */
 async function queueWatcherWriteForApproval(
   args: ManageWatchersArgs,
   ctx: ToolContext,
+  acting: { actingAgentId: string | null; actingWatcherId: string | null },
 ): Promise<ManageWatchersResult> {
-  const proposal = buildWatcherProposal(args);
+  const proposal = buildWatcherProposal(args, acting);
   const writeAction = watcherWriteAction(args.action)!;
 
   // create attributes ownership via created_by — fail at request time rather
@@ -587,14 +653,46 @@ async function queueWatcherWriteForApproval(
 }
 
 /**
+ * Foreign-owner escalation guard shared by the request-time gate and the
+ * approve-time apply path. Every effective owner the write would install must
+ * equal `actingAgentId`. Pass null to skip (humans are ungoverned here — same
+ * as the gate's `actor.kind === 'user'` branch). Throws ToolUserError 403.
+ *
+ * Uses {@link resolveEffectiveWatcherOwners} so the check matches what each
+ * handler actually persists (not the supplied args.agent_id alone).
+ */
+async function assertWatcherOwnersMatchActingAgent(
+  args: ManageWatchersArgs,
+  ctx: ToolContext,
+  actingAgentId: string | null,
+  actorKind: string = 'agent',
+): Promise<void> {
+  if (actingAgentId == null) return;
+  const owners = await resolveEffectiveWatcherOwners(args, ctx);
+  const foreign = owners.find((o) => o !== actingAgentId);
+  if (foreign !== undefined) {
+    throw new ToolUserError(
+      `A ${actorKind} cannot install watcher behavior owned by another agent — every affected owner must be itself (${actingAgentId}); found ${foreign ?? 'none'}.`,
+      403,
+    );
+  }
+}
+
+/**
  * Apply a previously-queued manage_watchers proposal. Called by
  * manage_operations' approve handler once a human confirms. Re-runs the original
  * write handler with the held args. `ownerUserId` is the original requester
  * (persisted on the run), so an approving admin doesn't become the created
  * watcher's `created_by`.
  *
+ * Re-takes the watcher-group advisory lock and re-runs the foreign-owner guard
+ * against the PERSISTED acting agent (not the approver). If ownership changed
+ * between queue and approve (e.g. group reassigned to another agent), the apply
+ * fails closed — the approve handler supersedes the card to 'failed'.
+ *
  * Watcher definition writes have no per-field pre-image; this is a straight
- * re-run — a stale approval may clobber a newer edit (acceptable for launch).
+ * re-run — a stale approval may clobber a newer edit (acceptable for launch)
+ * when ownership is still valid.
  */
 export async function applyManageWatchersProposal(
   proposal: ManageWatchersProposal,
@@ -607,7 +705,18 @@ export async function applyManageWatchersProposal(
   // create attributes ownership to the ORIGINAL requester, not the approver.
   const applyCtx: ToolContext =
     writeAction === 'create' ? { ...ctx, userId: ownerUserId } : ctx;
-  return runManageWatchers(args, env, applyCtx);
+  // Lock + re-gate under the same session advisory lock as the request path so
+  // a concurrent reassign can't slip between the ownership re-check and the write.
+  return withWatcherGroupLock(args, applyCtx, async () => {
+    // Humans leave actingAgentId null — skip, matching the gate.
+    await assertWatcherOwnersMatchActingAgent(
+      args,
+      applyCtx,
+      proposal.actingAgentId ?? null,
+      'agent',
+    );
+    return runManageWatchers(args, env, applyCtx);
+  });
 }
 
 /**
@@ -635,6 +744,12 @@ async function gateWatcherWrite(
     sessionWatcherId: ctx.actingWatcherId ?? null,
     sourceForMode: ctx.sourceContext?.source,
   });
+  // Non-human principal identity captured for the ownership guard AND (when
+  // queued) the proposal. Same formula the gate has always used.
+  const actingAgentId =
+    actor.kind !== 'user' ? (actor.ownerAgentId ?? actor.id) : null;
+  const actingWatcherId = ctx.actingWatcherId ?? null;
+
   // Escalation guard: a non-human caller must not end up installing behavior OWNED by
   // another agent. A watcher's `agent_id` IS its policy principal, so if restricted
   // agent A could create/clone/edit a watcher (or a group-shared prompt/reaction)
@@ -645,17 +760,12 @@ async function gateWatcherWrite(
   // and ALL owners a group-wide write touches. EVERY affected owner must be the actor
   // itself. Humans are ungoverned here and may own/assign freely.
   // MUST run BEFORE queueing so a foreign-owner proposal never becomes a pending card.
-  if (actor.kind !== 'user') {
-    const ownAgentId = actor.ownerAgentId ?? actor.id;
-    const owners = await resolveEffectiveWatcherOwners(args, ctx);
-    const foreign = owners.find((o) => o !== ownAgentId);
-    if (foreign !== undefined) {
-      throw new ToolUserError(
-        `A ${actor.kind} cannot install watcher behavior owned by another agent — every affected owner must be itself (${ownAgentId ?? 'none'}); found ${foreign ?? 'none'}.`,
-        403,
-      );
-    }
-  }
+  await assertWatcherOwnersMatchActingAgent(
+    args,
+    ctx,
+    actingAgentId,
+    actor.kind,
+  );
 
   const decision = await resolveWritePolicyDecision({
     organizationId: ctx.organizationId,
@@ -669,7 +779,10 @@ async function gateWatcherWrite(
   });
   if (decision === 'allow') return null;
   if (decision === 'require_approval') {
-    return queueWatcherWriteForApproval(args, ctx);
+    return queueWatcherWriteForApproval(args, ctx, {
+      actingAgentId,
+      actingWatcherId,
+    });
   }
   throw new ToolUserError(
     `Policy denies ${action} of watchers (agent config) for this principal.`,

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -29,6 +29,7 @@ import {
   type ListWatchersArgs,
   type ListWatchersResult,
   type ManageWatchersArgs,
+  type ManageWatchersProposal,
   type ManageWatchersResult,
 } from '@lobu/core/contracts/tools/manage-watchers';
 import type { ReservedSql } from 'postgres';
@@ -38,6 +39,10 @@ import {
 } from '../../authz/entity-policy';
 import { createDbClientFromEnv, getDb } from '../../db/client';
 import type { Env } from '../../index';
+import { notifyActionApprovalNeeded } from '../../notifications/triggers';
+import { insertEvent } from '../../utils/insert-event';
+import logger from '../../utils/logger';
+import { buildResourcePermalink } from '../../utils/url-builder';
 import { ToolUserError } from '../../utils/errors';
 import {
   requireOrgReadAccess,
@@ -47,6 +52,7 @@ import {
 } from '../../utils/organization-access';
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
+import { getOrgUrlContext } from '../view-urls';
 import { defineFlatActionTool, flatAction } from './action-tool';
 import { requireWatcherAccess } from './manage_watchers/shared';
 import { handleCreate, handleUpdate, handleDelete, handleCreateFromVersion } from './manage_watchers/crud';
@@ -67,7 +73,17 @@ export {
   ManageWatchersResultSchema,
   ManageWatchersSchema,
 };
-export type { ManageWatchersArgs, ManageWatchersResult };
+export type { ManageWatchersArgs, ManageWatchersProposal, ManageWatchersResult };
+
+/**
+ * Synthetic `runs.action_key` tagging a manage_watchers write held for approval.
+ * `manage_operations`' approve/reject handlers branch on this value to apply
+ * (or cancel) the held mutation, reusing the same durable runs/events approval
+ * primitive that manage_agents uses. These rows have run_type='internal'
+ * (no connector / connection), so the operation lookup in the connector path is
+ * skipped.
+ */
+export const MANAGE_WATCHERS_ACTION_KEY = 'manage_watchers';
 
 // ============================================
 // Main Function
@@ -140,8 +156,12 @@ async function manageWatchersImpl(
   // takes the lock — human or non-human — because the racing reassign is itself an
   // `update` that flows through this same path, so the lock makes them mutually
   // exclusive. Actions with no existing target group (`create`) skip the lock.
+  //
+  // `require_approval` queues a pending run + card (does NOT apply); `allow`
+  // proceeds to the handler; `deny` / foreign-owner still throw.
   return withWatcherGroupLock(args, ctx, async () => {
-    await gateWatcherWrite(args, ctx);
+    const gated = await gateWatcherWrite(args, ctx);
+    if (gated) return gated;
     return runManageWatchers(args, env, ctx);
   });
 }
@@ -321,18 +341,231 @@ async function resolveEffectiveWatcherOwners(
   }
 }
 
+/** Human label for each gated action, used in card titles + notifications. */
+function watcherActionLabel(args: ManageWatchersArgs): string {
+  switch (args.action) {
+    case 'create':
+      return `Create watcher "${args.slug ?? args.name ?? 'new'}"`;
+    case 'create_from_version':
+      return `Create watchers from version ${args.version_id ?? '?'}`;
+    case 'update':
+      return `Update watcher ${args.watcher_id ?? '?'}`;
+    case 'create_version':
+      return `Create version for watcher ${args.watcher_id ?? '?'}`;
+    case 'set_reaction_script':
+      return `Set reaction script on watcher ${args.watcher_id ?? '?'}`;
+    case 'delete':
+      return `Delete watcher(s) ${(args.watcher_ids ?? []).join(', ') || '?'}`;
+    default:
+      return `Watcher ${args.action}`;
+  }
+}
+
+/**
+ * Fetch a compact current watcher row for the approval card diff. Returns null
+ * when there is no single target (create / bulk delete / missing id).
+ */
+async function fetchCurrentWatcher(
+  organizationId: string,
+  args: ManageWatchersArgs,
+): Promise<Record<string, unknown> | null> {
+  if (args.watcher_id == null) return null;
+  const sql = getDb();
+  const rows = await sql`
+    SELECT id, slug, name, description, agent_id, schedule, timezone, status
+    FROM watchers
+    WHERE organization_id = ${organizationId} AND id = ${Number(args.watcher_id)}
+    LIMIT 1
+  `;
+  return (rows[0] as Record<string, unknown> | undefined) ?? null;
+}
+
+/**
+ * Build the proposed-change payload held on the run. Validates required fields
+ * for the gated write so a malformed proposal is rejected at request time, not
+ * at approve time.
+ *
+ * Watcher definition writes have no per-field pre-image; the proposal is the
+ * full original args for a straight re-run on approve (a stale approval may
+ * clobber a newer edit — acceptable for launch).
+ */
+function buildWatcherProposal(args: ManageWatchersArgs): ManageWatchersProposal {
+  const writeAction = watcherWriteAction(args.action);
+  if (!writeAction) {
+    throw new ToolUserError(`action "${args.action}" is not a gated watcher write`);
+  }
+  if (args.action === 'create') {
+    if (!args.slug) throw new ToolUserError('slug is required for create action');
+    if (!args.prompt) throw new ToolUserError('prompt is required for create action');
+    if (!args.agent_id) {
+      throw new ToolUserError(
+        'agent_id is required to create a watcher (the agent that executes it).',
+      );
+    }
+  }
+  if (args.action === 'update' && args.watcher_id == null) {
+    throw new ToolUserError('watcher_id is required for update action');
+  }
+  if (args.action === 'delete' && (!args.watcher_ids || args.watcher_ids.length === 0)) {
+    throw new ToolUserError('watcher_ids is required for delete action');
+  }
+  if (
+    (args.action === 'create_version' || args.action === 'set_reaction_script') &&
+    args.watcher_id == null
+  ) {
+    throw new ToolUserError(`watcher_id is required for ${args.action} action`);
+  }
+  if (args.action === 'create_from_version') {
+    if (args.version_id == null) {
+      throw new ToolUserError('version_id is required for create_from_version action');
+    }
+    if (!args.entity_ids || args.entity_ids.length === 0) {
+      throw new ToolUserError('entity_ids is required for create_from_version action');
+    }
+  }
+  return { args };
+}
+
+/**
+ * Queue a manage_watchers write for approval instead of running it. Writes a
+ * pending `runs` row (run_type='internal', action_key='manage_watchers') plus an
+ * `interaction_type='approval'` event holding the proposed args. The mutation is
+ * applied later by manage_operations' approve handler via
+ * {@link applyManageWatchersProposal}.
+ */
+async function queueWatcherWriteForApproval(
+  args: ManageWatchersArgs,
+  ctx: ToolContext,
+): Promise<ManageWatchersResult> {
+  const proposal = buildWatcherProposal(args);
+  const writeAction = watcherWriteAction(args.action)!;
+
+  // create attributes ownership via created_by — fail at request time rather
+  // than after the human approves an unattributable create.
+  if (writeAction === 'create' && !ctx.userId) {
+    throw new ToolUserError(
+      'create requires an authenticated caller to own the new watcher',
+    );
+  }
+
+  const current = await fetchCurrentWatcher(ctx.organizationId, args);
+  if (args.action === 'update' && !current) {
+    throw new ToolUserError(`Watcher "${args.watcher_id}" not found`, 404);
+  }
+
+  const sql = getDb();
+  const inserted = await sql`
+    INSERT INTO runs (
+      organization_id, run_type, action_key, action_input,
+      created_by_user_id, approval_status, status, created_at
+    ) VALUES (
+      ${ctx.organizationId}, 'internal', ${MANAGE_WATCHERS_ACTION_KEY},
+      ${sql.json(proposal as unknown as Record<string, unknown>)},
+      ${ctx.userId ?? null}, 'pending', 'pending', current_timestamp
+    )
+    RETURNING id
+  `;
+  const runId = Number((inserted[0] as { id: unknown }).id);
+
+  const label = watcherActionLabel(args);
+  const event = await insertEvent({
+    entityIds: args.entity_id != null ? [args.entity_id] : [],
+    organizationId: ctx.organizationId,
+    originId: `run_${runId}_pending`,
+    title: `${label} — pending approval`,
+    content: `Builder requested: ${label}`,
+    semanticType: 'operation',
+    runId,
+    interactionType: 'approval',
+    interactionStatus: 'pending',
+    interactionInput: proposal as unknown as Record<string, unknown>,
+    metadata: {
+      tool: 'manage_watchers',
+      action_key: MANAGE_WATCHERS_ACTION_KEY,
+      action: args.action,
+      watcher_id: args.watcher_id ?? null,
+      proposal,
+      current: current ?? null,
+      status: 'pending_approval',
+      run_id: runId,
+    },
+    authorName: ctx.clientId ?? 'agent',
+  });
+  const eventId = Number(event.id);
+
+  const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
+  // Run-scoped: the pending event is superseded on approve→complete; a run link
+  // stays valid across the chain.
+  const approvalUrl = buildResourcePermalink(ownerSlug, { kind: 'run', runId }, baseUrl);
+
+  notifyActionApprovalNeeded({
+    orgId: ctx.organizationId,
+    runId,
+    actionKey: MANAGE_WATCHERS_ACTION_KEY,
+    connectionName: label,
+    eventId,
+    approvalUrl,
+  }).catch((error) =>
+    logger.error(error, 'Failed to send manage_watchers approval notification')
+  );
+
+  return {
+    action: args.action as
+      | 'create'
+      | 'update'
+      | 'create_version'
+      | 'create_from_version'
+      | 'set_reaction_script'
+      | 'delete',
+    run_id: runId,
+    event_id: eventId,
+    status: 'pending_approval',
+    // An interactive approval card (change details + Approve/Reject buttons) is
+    // rendered into the chat from this result — so instruct the model to stay
+    // terse and NOT restate the change or paste a link.
+    message: `${label} is queued for approval. A confirmation card with the change details and Approve/Reject buttons is now shown to the user in the chat — reply with at most one short sentence and do NOT restate the change or include an approval link.`,
+    proposal,
+    current,
+  };
+}
+
+/**
+ * Apply a previously-queued manage_watchers proposal. Called by
+ * manage_operations' approve handler once a human confirms. Re-runs the original
+ * write handler with the held args. `ownerUserId` is the original requester
+ * (persisted on the run), so an approving admin doesn't become the created
+ * watcher's `created_by`.
+ *
+ * Watcher definition writes have no per-field pre-image; this is a straight
+ * re-run — a stale approval may clobber a newer edit (acceptable for launch).
+ */
+export async function applyManageWatchersProposal(
+  proposal: ManageWatchersProposal,
+  ctx: ToolContext,
+  env: Env,
+  ownerUserId: string | null,
+): Promise<ManageWatchersResult> {
+  const args = proposal.args;
+  const writeAction = watcherWriteAction(args.action);
+  // create attributes ownership to the ORIGINAL requester, not the approver.
+  const applyCtx: ToolContext =
+    writeAction === 'create' ? { ...ctx, userId: ownerUserId } : ctx;
+  return runManageWatchers(args, env, applyCtx);
+}
+
 /**
  * Enforce the `agent_config` write-gate for a watcher definition write. No-op for
  * read-only actions and for human members (whose decision is always 'allow').
- * A non-human principal is refused on `deny` AND on `require_approval` — there is
- * no watcher-definition approval queue, so fail closed rather than silently apply.
+ * Returns a pending_approval result when the policy requires approval (queued
+ * via the same runs/events primitive manage_agents uses); throws on deny or
+ * foreign-owner escalation; returns null when the write may apply now.
  */
 async function gateWatcherWrite(
   args: ManageWatchersArgs,
   ctx: ToolContext,
-): Promise<void> {
+): Promise<ManageWatchersResult | null> {
   const action = watcherWriteAction(args.action);
-  if (!action) return;
+  if (!action) return null;
   // Resolve the actor through the shared seam. A reaction script editing watchers
   // acts as its own watcher (ctx.actingWatcherId) — the seam folds that watcher's
   // owning agent so the agent's agent_config envelope binds and the reaction can't
@@ -354,6 +587,7 @@ async function gateWatcherWrite(
   // `agent_id` (create_from_version/create_version/set_reaction_script ignore it) —
   // and ALL owners a group-wide write touches. EVERY affected owner must be the actor
   // itself. Humans are ungoverned here and may own/assign freely.
+  // MUST run BEFORE queueing so a foreign-owner proposal never becomes a pending card.
   if (actor.kind !== 'user') {
     const ownAgentId = actor.ownerAgentId ?? actor.id;
     const owners = await resolveEffectiveWatcherOwners(args, ctx);
@@ -376,11 +610,12 @@ async function gateWatcherWrite(
     mode: actor.mode,
     action,
   });
-  if (decision === 'allow') return;
+  if (decision === 'allow') return null;
+  if (decision === 'require_approval') {
+    return queueWatcherWriteForApproval(args, ctx);
+  }
   throw new ToolUserError(
-    decision === 'require_approval'
-      ? `Editing watchers (agent config) requires approval for this principal; a watcher cannot be ${action}d autonomously.`
-      : `Policy denies ${action} of watchers (agent config) for this principal.`,
+    `Policy denies ${action} of watchers (agent config) for this principal.`,
     403,
   );
 }

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -407,8 +407,22 @@ function buildWatcherProposal(
       );
     }
   }
-  if (args.action === 'update' && args.watcher_id == null) {
-    throw new ToolUserError('watcher_id is required for update action');
+  if (args.action === 'update') {
+    if (args.watcher_id == null) {
+      throw new ToolUserError('watcher_id is required for update action');
+    }
+    // Reject a no-op update: with only watcher_id (or only fields handleUpdate
+    // ignores), the apply returns updated_fields:[] but the run would be marked
+    // completed and reported "applied". Require at least one patch field so the
+    // approval reflects a real change.
+    const patchKeys = WATCHER_UPDATE_PATCH_KEYS.filter(
+      (k) => args[k as keyof ManageWatchersArgs] !== undefined,
+    );
+    if (patchKeys.length === 0) {
+      throw new ToolUserError(
+        'update requires at least one field to change (e.g. name, description, prompt, schedule, agent_id).',
+      );
+    }
   }
   if (args.action === 'delete' && (!args.watcher_ids || args.watcher_ids.length === 0)) {
     throw new ToolUserError('watcher_ids is required for delete action');
@@ -418,6 +432,14 @@ function buildWatcherProposal(
     args.watcher_id == null
   ) {
     throw new ToolUserError(`watcher_id is required for ${args.action} action`);
+  }
+  if (args.action === 'set_reaction_script' && args.reaction_script === undefined) {
+    // An omitted script silently REMOVES the existing reaction (handleSetReactionScript
+    // treats missing as falsy). Require the field explicitly; an empty string is the
+    // documented way to clear it.
+    throw new ToolUserError(
+      'reaction_script is required for set_reaction_script (pass an empty string to clear the existing script).',
+    );
   }
   if (args.action === 'create_from_version') {
     if (args.version_id == null) {
@@ -443,6 +465,33 @@ const WATCHER_APPROVAL_ROUTING_KEYS = new Set(['action']);
 
 /** Display sentinel for an explicit null clear (field present, value null). */
 const WATCHER_APPROVAL_CLEARED = '(cleared)';
+
+/**
+ * Fields `handleUpdate` actually patches (mirrors its `updatedFields.push` list
+ * plus the direct name/description/prompt/status/sources/entity_ids columns). An
+ * `update` with none of these present is a no-op that would otherwise be reported
+ * as "applied" — {@link buildWatcherProposal} rejects that.
+ */
+const WATCHER_UPDATE_PATCH_KEYS = [
+  'name',
+  'description',
+  'prompt',
+  'status',
+  'sources',
+  'entity_ids',
+  'model_config',
+  'execution_config',
+  'schedule',
+  'timezone',
+  'agent_id',
+  'scheduler_client_id',
+  'tags',
+  'device_worker_id',
+  'agent_kind',
+  'notification_channel',
+  'notification_priority',
+  'min_cooldown_seconds',
+] as const;
 
 /**
  * Flat watcher mutation fields for the events-tab ActionApprovalCard fallback.

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -464,13 +464,20 @@ function pickWatcherApprovalDisplayFields(
       continue;
     }
     if (Array.isArray(value)) {
-      // Primitive arrays (watcher_ids, entity_ids, tags) collapse for display;
-      // object arrays (sources) keep structure via JSON in the schema renderer.
+      // Primitive arrays (watcher_ids, entity_ids, tags) collapse to a readable
+      // list; object arrays (sources) serialize to JSON so the schema's string
+      // field renders the actual structure, not "[object Object]".
       out[key] = value.every(
         (v) => v === null || ['string', 'number', 'boolean'].includes(typeof v),
       )
         ? value.join(', ')
-        : value;
+        : JSON.stringify(value);
+      continue;
+    }
+    // Structured objects (execution_config, model_config) serialize to JSON for
+    // the same reason — the approval card field is a readOnly string.
+    if (typeof value === 'object') {
+      out[key] = JSON.stringify(value);
       continue;
     }
     out[key] = value;
@@ -519,19 +526,29 @@ function buildWatcherApprovalInputSchema(
     const baseTitle = WATCHER_APPROVAL_FIELD_TITLES[key] ?? key;
     const title =
       value === WATCHER_APPROVAL_CLEARED ? `${baseTitle} (cleared)` : baseTitle;
+    // Every field is readOnly: the watcher approval card is a review-and-decide
+    // surface, not an editor. The apply path always executes the ORIGINAL
+    // proposal.args, so an editable field would silently discard the reviewer's
+    // change. readOnly makes the form render the proposed value as inspectable
+    // text without pretending it can be edited.
+    const base = { title, readOnly: true } as const;
+    // Structured values (execution_config, model_config, sources, arrays of
+    // objects) have no nested schema, so the generic form would coerce them to
+    // "[object Object]". Serialize to a JSON string so the reviewer sees the
+    // actual proposed configuration.
     if (typeof value === 'object' && value !== null) {
-      properties[key] = { type: 'object', title };
+      properties[key] = { ...base, type: 'string' };
       continue;
     }
     if (typeof value === 'number') {
-      properties[key] = { type: 'number', title };
+      properties[key] = { ...base, type: 'number' };
       continue;
     }
     if (typeof value === 'boolean') {
-      properties[key] = { type: 'boolean', title };
+      properties[key] = { ...base, type: 'boolean' };
       continue;
     }
-    properties[key] = { type: 'string', title };
+    properties[key] = { ...base, type: 'string' };
   }
   return { type: 'object', properties };
 }
@@ -715,6 +732,34 @@ export async function applyManageWatchersProposal(
       proposal.actingAgentId ?? null,
       'agent',
     );
+    // Re-run the CURRENT write-gate before applying: policy may have flipped to
+    // `deny` (or the acting principal may have been deleted) while the approval
+    // sat pending. Fail closed rather than execute a now-denied proposal — the
+    // approve handler supersedes the card to 'failed'. Humans (null actingAgentId)
+    // are ungoverned here, matching the request-path gate.
+    if (proposal.actingAgentId != null) {
+      const writeGateAction = watcherWriteAction(args.action);
+      if (writeGateAction) {
+        const decision = await resolveWritePolicyDecision({
+          organizationId: applyCtx.organizationId,
+          resourceClass: 'agent_config',
+          principalKind: 'agent',
+          principalId: proposal.actingAgentId,
+          ownerAgentId: proposal.actingAgentId,
+          ownerResolved: true,
+          mode: 'unattended',
+          action: writeGateAction,
+        });
+        // Only `deny` blocks the apply: this run IS the approval, so a
+        // `require_approval` decision is already satisfied and must not re-block.
+        if (decision === 'deny') {
+          throw new ToolUserError(
+            `Policy now denies ${writeGateAction} of watchers for this principal; the approved change was not applied.`,
+            403,
+          );
+        }
+      }
+    }
     return runManageWatchers(args, env, applyCtx);
   });
 }

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -426,6 +426,54 @@ function buildWatcherProposal(args: ManageWatchersArgs): ManageWatchersProposal 
   return { args };
 }
 
+/** Flat watcher fields shown on the events-tab ActionApprovalCard fallback. */
+const WATCHER_APPROVAL_DISPLAY_KEYS = [
+  'action',
+  'slug',
+  'name',
+  'prompt',
+  'schedule',
+  'timezone',
+  'agent_id',
+  'watcher_id',
+  'watcher_ids',
+] as const;
+
+function pickWatcherApprovalDisplayFields(
+  args: ManageWatchersArgs,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of WATCHER_APPROVAL_DISPLAY_KEYS) {
+    const value = args[key as keyof ManageWatchersArgs];
+    if (value === undefined || value === null) continue;
+    out[key] = Array.isArray(value) ? value.join(', ') : value;
+  }
+  return out;
+}
+
+function buildWatcherApprovalInputSchema(
+  fields: Record<string, unknown>,
+): Record<string, unknown> {
+  const titles: Record<string, string> = {
+    action: 'Action',
+    slug: 'Slug',
+    name: 'Name',
+    prompt: 'Prompt',
+    schedule: 'Schedule',
+    timezone: 'Timezone',
+    agent_id: 'Agent',
+    watcher_id: 'Watcher ID',
+    watcher_ids: 'Watcher IDs',
+  };
+  const properties: Record<string, unknown> = {};
+  for (const key of Object.keys(fields)) {
+    if (titles[key]) {
+      properties[key] = { type: 'string', title: titles[key] };
+    }
+  }
+  return { type: 'object', properties };
+}
+
 /**
  * Queue a manage_watchers write for approval instead of running it. Writes a
  * pending `runs` row (run_type='internal', action_key='manage_watchers') plus an
@@ -468,6 +516,11 @@ async function queueWatcherWriteForApproval(
   const runId = Number((inserted[0] as { id: unknown }).id);
 
   const label = watcherActionLabel(args);
+  // Flat display fields for the events-tab fallback card (ActionApprovalCard
+  // only renders input when interactionInputSchema is present). Keep the
+  // nested proposal in metadata for the apply path / history replay.
+  const displayInput = pickWatcherApprovalDisplayFields(args);
+  const inputSchema = buildWatcherApprovalInputSchema(displayInput);
   const event = await insertEvent({
     entityIds: args.entity_id != null ? [args.entity_id] : [],
     organizationId: ctx.organizationId,
@@ -478,16 +531,20 @@ async function queueWatcherWriteForApproval(
     runId,
     interactionType: 'approval',
     interactionStatus: 'pending',
-    interactionInput: proposal as unknown as Record<string, unknown>,
+    interactionInputSchema: inputSchema,
+    interactionInput: displayInput,
     metadata: {
       tool: 'manage_watchers',
       action_key: MANAGE_WATCHERS_ACTION_KEY,
       action: args.action,
+      resourceKind: 'watcher',
       watcher_id: args.watcher_id ?? null,
       proposal,
       current: current ?? null,
       status: 'pending_approval',
       run_id: runId,
+      input_schema: inputSchema,
+      action_input: displayInput,
     },
     authorName: ctx.clientId ?? 'agent',
   });


### PR DESCRIPTION
Implements WI-0.1 from the final-architecture review: the Slack-launch-demo blocker where the builder agent setting up guardrail watchers hit a hard 403.

## Problem
`gateWatcherWrite` failed CLOSED on the `agent_config` `require_approval` policy — a non-human principal proposing a watcher got a 403, so 'Slackbot sets up watchers' was impossible.

## Fix
Mirror the shipped manage_agents approval pattern: a gated watcher write queues a pending run + approval card instead of 403. Approve re-runs the write under the group lock + re-checks ownership and deny-policy; reject cancels. Both supersede the pending card.

## Hardening (4 codex review rounds)
- Foreign-owner escalation guard runs before queueing AND re-checked at apply under the group lock (stale cross-owner approval can't mutate a reassigned watcher).
- Failed apply (invalid tz, all-failed delete) marks the run failed, not completed.
- Deny-policy re-checked at apply (a proposal denied after queueing doesn't execute).
- Approval card shows every mutation field incl. reaction scripts (no truncation) + null-clears; read-only.
- No-op update and reaction-script-clear footguns rejected at request time.

## Tests
Integration 15/15 (approval lifecycle, security regression proven red→green by disabling the guard, validation rejections), worker unit 12/12, typecheck clean — all run against live PG.

## Deferred (follow-up)
- Generic-approval refactor: agents + watchers still fork ~ the claim/apply/supersede path; will collapse to one shared path when WI-0.3 lands (which needs it).
- One narrow codex P1 (re-resolve reaction-originated principal on deny added mid-pending) rides that refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786550833&installation_id=136316292&pr_number=1903&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1903&signature=9e4c5a291c386cc3f9baf17f513f76dc523fd2841a2b04b3926a848c4b17464d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->