### PR TITLE
fix(oauth): never CDN-cache OAuth discovery metadata

### DIFF
--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -274,6 +274,18 @@ function getProvider(c: { env: Env; req: { url: string } }): OAuthProvider {
 // ============================================
 
 /**
+ * OAuth discovery metadata must never be CDN-cached. Cloudflare's public-HTML
+ * rule respects origin Cache-Control for `/.well-known/*`; without an explicit
+ * no-store, a deploy that changes scopes_supported can stay invisible for
+ * hours — third-party MCP clients (Slack) then request stale scopes, we grant
+ * a subset, and the client reports "must accept all required permissions".
+ */
+function setOAuthDiscoveryNoCache(c: { header: (name: string, value: string) => void }) {
+  c.header('Cache-Control', 'no-store');
+  c.header('Pragma', 'no-cache');
+}
+
+/**
  * GET /.well-known/oauth-protected-resource
  * RFC 9728 - OAuth Protected Resource Metadata
  *
@@ -285,11 +297,13 @@ oauthRoutes.get('/.well-known/oauth-protected-resource/:path{.+}', (c) => {
   const resourcePath = c.req.param('path');
   const origin = getBaseUrl(c);
   metadata.resource = `${origin}/${resourcePath}`;
+  setOAuthDiscoveryNoCache(c);
   return c.json(metadata);
 });
 
 oauthRoutes.get('/.well-known/oauth-protected-resource', (c) => {
   const provider = getProvider(c);
+  setOAuthDiscoveryNoCache(c);
   return c.json(provider.getProtectedResourceMetadata());
 });
 
@@ -301,12 +315,14 @@ oauthRoutes.get('/.well-known/oauth-protected-resource', (c) => {
  */
 oauthRoutes.get('/.well-known/openid-configuration', (c) => {
   const provider = getProvider(c);
+  setOAuthDiscoveryNoCache(c);
   return c.json(provider.getAuthorizationServerMetadata());
 });
 
 // Also serve at /oauth-authorization-server for strict RFC 8414 compliance
 oauthRoutes.get('/.well-known/oauth-authorization-server', (c) => {
   const provider = getProvider(c);
+  setOAuthDiscoveryNoCache(c);
   return c.json(provider.getAuthorizationServerMetadata());
 });
 
@@ -320,6 +336,7 @@ oauthRoutes.get('/.well-known/oauth-authorization-server', (c) => {
 oauthRoutes.get('/auth.md', (c) => {
   return c.body(buildAuthMd(getBaseUrl(c)), 200, {
     'Content-Type': 'text/markdown; charset=utf-8',
+    'Cache-Control': 'no-store',
   });
 });
 


### PR DESCRIPTION
## Summary

- Cloudflare was caching `/.well-known/oauth-*` discovery without origin `Cache-Control`.
- After #1901 narrowed `scopes_supported`, Slack still saw the old list (including `device_worker:run`), requested it, got a subset after consent strip, and failed with “must accept all the required permissions.”
- Set `Cache-Control: no-store` on OAuth discovery + `auth.md`.
- Also purged CF cache for `app.lobu.ai` and excluded `/.well-known/` from the zone cache rule (ops, already applied).

## Test plan

- [x] Purge CF → discovery returns public scopes only
- [ ] After deploy: `curl -sSI https://app.lobu.ai/.well-known/oauth-authorization-server` shows `Cache-Control: no-store` and `cf-cache-status: DYNAMIC` or bypass
- [ ] Retry Slack MCP connect

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786551947&installation_id=136316292&pr_number=1905&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1905&signature=4cab7c8ea4bad94d981373d41f58b5e9428926f95111f588ca3953b2f75c0488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->