### PR TITLE
fix(watchers): unblock main typecheck + bump owletto (WI-0.1)

### DIFF
--- a/packages/core/src/contracts/tools/manage-watchers.ts
+++ b/packages/core/src/contracts/tools/manage-watchers.ts
@@ -621,8 +621,8 @@ export interface ManageWatchersProposal {
   args: ManageWatchersArgs;
   /** Resolved `actor.ownerAgentId ?? actor.id` at queue time; null for humans. */
   actingAgentId: string | null;
-  /** Session `actingWatcherId` at queue time, if any. */
-  actingWatcherId: string | null;
+  /** Session `actingWatcherId` at queue time, if any (numeric watcher id). */
+  actingWatcherId: number | null;
 }
 export const ListWatchersSchema = Type.Object({
   watcher_id: Type.Optional(

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -392,7 +392,7 @@ async function fetchCurrentWatcher(
  */
 function buildWatcherProposal(
   args: ManageWatchersArgs,
-  acting: { actingAgentId: string | null; actingWatcherId: string | null },
+  acting: { actingAgentId: string | null; actingWatcherId: number | null },
 ): ManageWatchersProposal {
   const writeAction = watcherWriteAction(args.action);
   if (!writeAction) {
@@ -615,7 +615,7 @@ function buildWatcherApprovalInputSchema(
 async function queueWatcherWriteForApproval(
   args: ManageWatchersArgs,
   ctx: ToolContext,
-  acting: { actingAgentId: string | null; actingWatcherId: string | null },
+  acting: { actingAgentId: string | null; actingWatcherId: number | null },
 ): Promise<ManageWatchersResult> {
   const proposal = buildWatcherProposal(args, acting);
   const writeAction = watcherWriteAction(args.action)!;
@@ -796,7 +796,10 @@ export async function applyManageWatchersProposal(
           principalId: proposal.actingAgentId,
           ownerAgentId: proposal.actingAgentId,
           ownerResolved: true,
-          mode: 'unattended',
+          // Apply-time re-check of an already-approved proposal: headless, no
+          // human in the loop, so the run mode is autonomous (matching the
+          // token minted for the approved run).
+          mode: 'autonomous',
           action: writeGateAction,
         });
         // Only `deny` blocks the apply: this run IS the approval, so a


### PR DESCRIPTION
Two coupled fixes to get main green:

1. **Submodule bump** — main pinned owletto SHA 14c75088 which lived only on the unmerged branch feat/watcher-approval-queue (WI-0.1's owletto side). Merged that to owletto/main (owletto #489) and bump the parent pointer to 7cd04cd1. Clears the failing Submodule Drift check.

2. **WI-0.1 type regression** — the fresh-build typecheck (first since #1903 merged) surfaced two type errors WI-0.1's local typecheck missed because it ran against stale core dist:
   - apply-path re-gate passed `mode: 'unattended'` — not a valid PrincipalMode (`attended | autonomous`); the headless apply of an approved proposal is `autonomous`.
   - `ManageWatchersProposal.actingWatcherId` typed string|null but `ToolContext.actingWatcherId` is number|null (watcher ids are numeric).

Folded together because main-red blocks every PR's required typecheck, including this one's. 9/9 manage-watchers approval e2e green; full `make typecheck` clean on a fresh build.