### PR TITLE
fix(oauth): grant over-requested scopes on auth-code for Slack MCP

### DIFF
--- a/packages/server/src/__tests__/integration/oauth/login-connections-token-scope.test.ts
+++ b/packages/server/src/__tests__/integration/oauth/login-connections-token-scope.test.ts
@@ -166,12 +166,12 @@ describe('Stage 1 — login token carries connections:token', () => {
     expect((rows[0].scope ?? '').split(' ')).toContain('mcp:admin');
   });
 
-  it('an authorization-code grant does NOT get connections:token (no third-party over-grant)', async () => {
-    // The authorization-code consent path is used by arbitrary third-party MCP
-    // clients (Claude Desktop, Cursor, Slack, …). Even when they request the
-    // full first-party scope list (common when clients copy scopes_supported),
-    // device_worker:run / connections:token must be stripped — only `lobu login`
-    // (device-code) or an explicit PAT gets those.
+  it('an authorization-code grant covers Slack-style over-request of first-party scopes', async () => {
+    // Slack MCP caches scopes_supported and keeps requesting every entry it
+    // once saw (including device_worker:run / connections:token). The token
+    // `scope` field must cover the full request or Slack fails with
+    // "must accept all the required permissions". Discovery no longer
+    // advertises those scopes for new clients; this path is compatibility.
     const app = buildApp();
     const sql = getTestDb();
 
@@ -196,13 +196,13 @@ describe('Stage 1 — login token carries connections:token', () => {
     const verifier = randomBytes(32).toString('base64url');
     const challenge = createHash('sha256').update(verifier).digest('base64url');
 
-    // Consent — Slack-style over-request of every AVAILABLE_SCOPES entry.
+    const fullScope =
+      'mcp:read mcp:write mcp:admin profile:read device_worker:run connections:token';
     const authorize = await call(app, 'POST', '/oauth/authorize/consent', {
       body: {
         client_id: client.client_id,
         redirect_uri: redirectUri,
-        scope:
-          'mcp:read mcp:write mcp:admin profile:read device_worker:run connections:token',
+        scope: fullScope,
         code_challenge: challenge,
         code_challenge_method: 'S256',
         resource: `${ORIGIN}/mcp/${org.slug}`,
@@ -225,24 +225,29 @@ describe('Stage 1 — login token carries connections:token', () => {
       },
     });
     expect(tokenRes.status).toBe(200);
-    const tokens = (await tokenRes.json()) as { access_token: string };
+    const tokens = (await tokenRes.json()) as {
+      access_token: string;
+      scope?: string;
+      resource?: string;
+    };
+    // Token response must cover every requested scope (Slack checks this).
+    for (const s of fullScope.split(' ')) {
+      expect((tokens.scope ?? '').split(' ')).toContain(s);
+    }
+    expect(tokens.resource).toBe(`${ORIGIN}/mcp/${org.slug}`);
 
     const rows = (await sql`
-      SELECT scope FROM oauth_tokens
+      SELECT scope, resource FROM oauth_tokens
       WHERE token_hash = ${hashToken(tokens.access_token)}
         AND token_type = 'access'
       LIMIT 1
-    `) as unknown as Array<{ scope: string | null }>;
+    `) as unknown as Array<{ scope: string | null; resource: string | null }>;
     expect(rows.length).toBe(1);
     const granted = (rows[0].scope ?? '').split(' ').filter(Boolean);
-    // Public MCP scopes survive...
     expect(granted).toContain('mcp:read');
-    expect(granted).toContain('mcp:write');
-    expect(granted).toContain('mcp:admin');
-    expect(granted).toContain('profile:read');
-    // ...but first-party scopes are stripped, not hard-rejected.
-    expect(granted).not.toContain('connections:token');
-    expect(granted).not.toContain('device_worker:run');
+    expect(granted).toContain('device_worker:run');
+    expect(granted).toContain('connections:token');
+    expect(rows[0].resource).toBe(`${ORIGIN}/mcp/${org.slug}`);
   });
 
   it('a profile:read-only device grant (no MCP scopes) does NOT get connections:token', async () => {

--- a/packages/server/src/auth/oauth/provider.ts
+++ b/packages/server/src/auth/oauth/provider.ts
@@ -276,6 +276,11 @@ export class OAuthProvider {
       expires_in: ACCESS_TOKEN_LIFETIME_SECONDS,
       refresh_token: newRefreshToken,
       scope: scope || undefined,
+      ...(oldRefreshToken.resource
+        ? { resource: oldRefreshToken.resource }
+        : params.resource
+          ? { resource: params.resource }
+          : {}),
     };
   }
 
@@ -319,6 +324,9 @@ export class OAuthProvider {
       expires_in: ACCESS_TOKEN_LIFETIME_SECONDS,
       refresh_token: refreshToken,
       scope: scope || undefined,
+      // RFC 8707: echo the authorized resource so MCP clients can confirm the
+      // audience matches the protected resource they started from.
+      ...(resource ? { resource } : {}),
     };
   }
 

--- a/packages/server/src/auth/oauth/routes.ts
+++ b/packages/server/src/auth/oauth/routes.ts
@@ -16,11 +16,7 @@ import { requireAuth } from '../middleware';
 import { findExistingPersonalOrg } from '../personal-org-provisioning';
 import { buildAuthMd } from './auth-md';
 import { OAuthProvider } from './provider';
-import {
-  DEFAULT_SCOPES_STRING,
-  filterScopeByRole,
-  stripNonPublicOAuthScopes,
-} from './scopes';
+import { DEFAULT_SCOPES_STRING, filterScopeByRole } from './scopes';
 import type { AuthorizationParams, OAuthClientMetadata, TokenRequestParams } from './types';
 import { createOAuthError, validateRedirectUri } from './utils';
 import { getConfiguredPublicOrigin } from '../../utils/public-origin';
@@ -547,19 +543,18 @@ oauthRoutes.get('/oauth/authorize', async (c) => {
     return c.redirect(loginUrl.toString());
   }
 
-  // MCP scopes or other scopes — show consent page as before
+  // MCP scopes or other scopes — show consent page as before.
+  // Pass the client-requested scope through unchanged. Discovery no longer
+  // advertises device-only scopes, but some MCP clients (Slack) cache an older
+  // scopes_supported list and keep requesting them. Stripping here made the
+  // token `scope` a subset of what the client asked for, and Slack then fails
+  // with "must accept all the required permissions".
   const webUrl = getBaseUrl(c);
   const consentUrl = new URL('/oauth/consent', webUrl);
 
-  // Pass params to consent page via query string. Strip first-party-only scopes
-  // so the UI (and the later consent POST) never offer device_worker:run /
-  // connections:token to third-party MCP clients that requested the full
-  // discovery list.
-  const publicScope =
-    stripNonPublicOAuthScopes(params.scope) || DEFAULT_SCOPES_STRING;
   consentUrl.searchParams.set('client_id', params.client_id);
   consentUrl.searchParams.set('redirect_uri', params.redirect_uri);
-  consentUrl.searchParams.set('scope', publicScope);
+  consentUrl.searchParams.set('scope', params.scope || DEFAULT_SCOPES_STRING);
   consentUrl.searchParams.set('state', params.state || '');
   consentUrl.searchParams.set('code_challenge', params.code_challenge);
   consentUrl.searchParams.set('code_challenge_method', params.code_challenge_method);
@@ -609,23 +604,13 @@ oauthRoutes.post('/oauth/authorize/consent', requireAuth, async (c) => {
     return c.json(createOAuthError('invalid_request', 'Invalid JSON body'), 400);
   }
 
-  // First-party scopes (`device_worker:run`, `connections:token`) are not
-  // grantable here. Clients that still request them (e.g. Slack after reading
-  // a broad cached scopes_supported) get them stripped rather than a hard
-  // invalid_scope, so MCP login can complete with the public scopes they need.
-  // Device workers continue to use the device-authorization flow, which never
-  // hits this path.
-  const publicConsentScope = stripNonPublicOAuthScopes(body.scope);
-  if ((body.scope ?? '').trim() && !publicConsentScope) {
-    return c.json(
-      createOAuthError(
-        'invalid_scope',
-        'Requested scopes are only available via the device-authorization flow or an explicit PAT'
-      ),
-      400
-    );
-  }
-  body.scope = publicConsentScope || DEFAULT_SCOPES_STRING;
+  // Keep the client-requested scope set. Discovery no longer advertises
+  // first-party-only scopes, but clients that cached an older scopes_supported
+  // (notably Slack MCP) still request them and require the token `scope` to
+  // cover every requested entry. Unknown values are filtered later via
+  // parseScopes / AVAILABLE_SCOPES at token use. Device-specific *behavior*
+  // (personal-org force-bind, mint-child-token) stays gated on the device
+  // flow / resource binding, not solely on the scope string.
   const consentHasMcpScopes = hasMcpScopes(body.scope);
 
   // User denied consent
@@ -699,9 +684,9 @@ oauthRoutes.post('/oauth/authorize/consent', requireAuth, async (c) => {
           400
         );
       }
-      // NOTE: `connections:token` / `device_worker:run` were already stripped
-      // above via stripNonPublicOAuthScopes. Only the first-party `lobu login`
-      // device-code grant (or an explicit PAT) gets those.
+      // Grant exactly the role-filtered request (may include first-party scope
+      // names when a client still over-requests them). Runtime capability gates
+      // stay separate from this compatibility grant.
       params.scope = filtered;
     }
 

--- a/packages/server/src/auth/oauth/types.ts
+++ b/packages/server/src/auth/oauth/types.ts
@@ -79,6 +79,8 @@ export interface OAuthTokenResponse {
   expires_in: number;
   refresh_token?: string;
   scope?: string;
+  /** RFC 8707 authorized resource (MCP audience), when the grant was resource-bound. */
+  resource?: string;
 }
 
 /**

--- a/packages/server/src/worker-api/device-management.ts
+++ b/packages/server/src/worker-api/device-management.ts
@@ -168,6 +168,17 @@ export async function mintDeviceChildToken(c: Context<{ Bindings: Env }>) {
       403
     );
   }
+  // MCP OAuth clients (Slack, Cursor, …) may receive `device_worker:run` in
+  // the token scope string for authorize-request compatibility when they
+  // over-request from a cached scopes_supported list. Those tokens are
+  // resource-bound to `/mcp` and must not mint sibling device credentials.
+  // Real device grants (device-code / lobu login) have no resource audience.
+  if (c.var.mcpAuthInfo?.resource) {
+    return c.json(
+      { error: 'insufficient_scope', required: 'device-bound token without MCP resource' },
+      403
+    );
+  }
 
   const body = await parseJsonBody<{
     platform?: string;


### PR DESCRIPTION
## Summary

Prod logs show Slack OAuth **succeeds** (consent 200, token 200) with
`mcp:read mcp:write mcp:admin profile:read`, then Slack shows
\"must accept all the required permissions\" without calling userinfo or MCP.

Root cause: Slack still requests first-party scopes from a **cached**
`scopes_supported` (provider registered 2026-06-28). We stripped those on
auth-code consent, so the token `scope` was a subset of what Slack asked for.

- Stop stripping on authorize/consent for auth-code grants
- Grant the full requested available scope set (still role-filters `mcp:admin`)
- Echo `resource` on token responses (RFC 8707)
- Reject `mint-child-token` for resource-bound MCP tokens (safety for
  over-granted `device_worker:run` names)

Discovery still only advertises public scopes for new clients.

## Test plan

- [x] Unit tests for discovery scopes / strip helper / role filter
- [x] Integration test updated for Slack-style over-request grant
- [ ] After deploy: reconnect Slack MCP; token scope in DB should match request
- [ ] Confirm connect succeeds in Slackbot

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786552998&installation_id=136316292&pr_number=1907&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1907&signature=a80f2a0bad709a04c3b886ef254ae79d53f9cc16bc72680e8f1747ce249076cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->