### PR TITLE
fix(server): unblock Docker tsc for manage_watchers write-gate

### DIFF
--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -796,7 +796,7 @@ export async function applyManageWatchersProposal(
           principalId: proposal.actingAgentId,
           ownerAgentId: proposal.actingAgentId,
           ownerResolved: true,
-          mode: 'unattended',
+          mode: 'autonomous',
           action: writeGateAction,
         });
         // Only `deny` blocks the apply: this run IS the approval, so a
@@ -842,7 +842,8 @@ async function gateWatcherWrite(
   // queued) the proposal. Same formula the gate has always used.
   const actingAgentId =
     actor.kind !== 'user' ? (actor.ownerAgentId ?? actor.id) : null;
-  const actingWatcherId = ctx.actingWatcherId ?? null;
+  const actingWatcherId =
+    ctx.actingWatcherId != null ? String(ctx.actingWatcherId) : null;
 
   // Escalation guard: a non-human caller must not end up installing behavior OWNED by
   // another agent. A watcher's `agent_id` IS its policy principal, so if restricted


### PR DESCRIPTION
## Summary

`Build and Push Images` is failing on main at `packages/server` tsc:

- `mode: 'unattended'` is not a valid `PrincipalMode` (`attended` | `autonomous`)
- `actingWatcherId` must be `string | null`, not `number | null`

Unblocks deploy of #1907 (Slack OAuth scope grant).

## Test plan

- [ ] Image build passes on main
- [ ] `/health` revision moves past `f049d7547`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786553696&installation_id=136316292&pr_number=1908&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1908&signature=5e0bb0a3d5bf53af64d4d76d6472de91066021dd519600dd0e85732ed31e9dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when approving watcher management changes.
  * Standardized watcher identity handling to support more reliable ownership checks and proposal application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->