### PR TITLE
example(context-layer): governed SQL, subtract-not-null, agent eval

### DIFF
--- a/examples/context-layer/README.md
+++ b/examples/context-layer/README.md
@@ -18,30 +18,38 @@ The fake warehouse (`subscriptions` table, ~2000 rows) has a deliberately messy
 churn series:
 
 - **30 organic cancellations/month**, steady, Jul 2025 → Jun 2026.
+- **20 payment-failure cancellations/month** — a card fails and the sub is
+  auto-cancelled. Each carries a `dunning_started_at` (when card retries began).
+  ~12/month are cancelled *inside* the 28-day dunning grace (retry-window
+  artifacts churn v2 excludes); ~8/month fall *outside* it (real churn v2 keeps).
+  This cohort is what makes the definition change *move the number*, not label it.
 - **+500 cancellations on 2026-03-12/13** — a bad Recharge billing migration
   wrote false cancellation rows. The numbers are *wrong*.
 - **+45 cancellations on 2026-05-19..21** — a real courier strike. The numbers
   are *right* but the cause is external and temporary.
 - **A definition change on 2026-05-01** — churn moves to v2 (a 28-day dunning
-  grace excludes payment-failure cancellations).
+  grace excludes payment-failure cancellations inside the grace).
 
-Raw churn shows a terrifying 530 in March and an elevated 75 in May. Neither is
-"churn getting worse." A context layer makes that legible without archaeology.
+Raw churn shows a terrifying **550 in March** and an elevated **95 in May**.
+Neither is "churn getting worse." A context layer makes that legible without
+archaeology — and under v2 a plain month reads **38**, not the raw **50**,
+because the definition change actually changed *which cancellations count*.
 
 ## How the pieces map
 
 | Concept | Where it lives | What it governs |
 |---------|----------------|-----------------|
-| **Business events** | `business-event` entities | The dated, sourced *why* behind an anomaly — a data incident, a definition change, an external shock. Each carries a `source_link` (Linear ticket, decision doc, Slack thread) and an `expected_effect` instruction. |
-| **Definition changelog** | `metric-definition` entity + a supersede chain of `definition` events | The versioned meaning of the metric. A new version **supersedes** the previous one, so the current definition is the one unsuperseded event and the whole chain is the changelog — append-only, never edited. |
-| **Live warehouse federation** | a `postgres` connection + a **virtual feed** | The monthly rollup is pushed down to the warehouse and read **live** at request time through the connector — nothing is copied into Lobu. The numbers are whatever the warehouse says right now. |
-| **Deterministic composition** | `compose.ts` → one sandboxed `run_sdk` script | Joins the live series + business events + definition versions **in JS, no LLM**, into a raw-vs-adjusted series with a flag and a governing version per month. |
+| **Business events** | `business-event` entities | The dated, sourced *why* behind an anomaly — a data incident, a definition change, an external shock. Each carries a `source_link` (Linear ticket, decision doc, Slack thread), a human `expected_effect`, and — for a data incident — a machine-usable structured `adjustment` (e.g. `{op:"subtract_reason", cancel_reason:"billing_migration_artifact"}`) that `compose.ts` applies. |
+| **Definition changelog** | `metric-definition` entity + a supersede chain of `definition` events | The versioned meaning of the metric. Each version carries a machine-usable `governing_predicate` (v1: count everything; v2: exclude payment-failures inside the 28-day dunning grace). A new version **supersedes** the previous one, so the current definition is the one unsuperseded event and the whole chain is the changelog — append-only, never edited. |
+| **Governed composition over a live warehouse** | `compose.ts` → a `run_sdk` read + a generated `query_sql` pushdown | Phase 1 reads the context layer (definitions + events) via the sandbox. Phase 2 **generates** the rollup SQL *from* those predicates + adjustments and runs it **live** against the warehouse through the stock `query_sql` connection pushdown — nothing copied into Lobu. The definition version in effect for a month picks that month's `WHERE`, and a data-incident subtracts exactly the rows it names. The definition **governs the query**, it does not merely label the output. No LLM. |
+| **Agent eval** | `eval.ts` | Asks a real agent the March question twice — WITH the governed context pushed vs a WITHOUT baseline — and asserts the pushed context changed the answer (cites the migration, corrects ~550 → ~50). Runs a live agent when a model provider is configured; falls back to a labelled deterministic proxy when the local install has no model. |
 | **Verified-query drift canary** | `verified-query` entity + `drift-check.ts` | A human-approved answer (the exact SQL + the rows it produced at approval time) is pinned. Re-running the query and diffing against the pinned answer is the canary: a mismatch means the warehouse (or a definition) moved and the answer needs re-verification — *before* someone repeats a stale number in a board deck. |
 
 The connection, auth profile, and entity schema are declared in
 `lobu.config.ts` (config-as-constructor) and created by `lobu run`. The seed
-script adds the virtual feed, the definition chain, the business events, and the
-pinned verified answer on top.
+script adds the virtual feed, the definition chain (with governing predicates),
+the business events (with structured adjustments), and the pinned verified
+answer on top.
 
 ```
 context-layer/
@@ -49,9 +57,10 @@ context-layer/
 ├── IDENTITY.md                 # the analyst agent's identity
 ├── env.example                 # copy to .env
 └── scripts/
-    ├── seed-warehouse.ts        # provision the fake warehouse (deterministic)
-    ├── seed.ts                  # seed the context layer (feed, definitions, events, pinned answer)
-    ├── compose.ts               # THE MONEY SHOT — adjusted churn narrative
+    ├── seed-warehouse.ts        # provision the fake warehouse (deterministic; incl. payment-failure cohort)
+    ├── seed.ts                  # seed the context layer (feed, definitions+predicates, events+adjustments, pinned answer)
+    ├── compose.ts               # THE MONEY SHOT — governed adjusted-churn narrative (definition governs the SQL)
+    ├── eval.ts                  # agent eval — does pushing the context change the answer? (real agent or labelled proxy)
     ├── simulate-drift.ts        # mutate the warehouse so the canary has something to catch
     ├── drift-check.ts           # re-run the pinned query, diff vs the approved answer
     └── lib/{env,gateway}.ts     # shared env + a tiny local-gateway client
@@ -75,7 +84,8 @@ bunx @lobu/cli run
 # In a second terminal:
 bun run seed:warehouse   # provision the fake Kelder warehouse (~2000 subscriptions)
 bun run seed             # seed the context layer on top of it
-bun run compose          # compose the adjusted-churn narrative  ← the money shot
+bun run compose          # compose the governed adjusted-churn narrative  ← the money shot
+bun run eval             # prove pushing the context changes an agent's answer
 bun run drift:simulate   # add one cancellation so the canary has drift to catch
 bun run drift            # re-run the pinned query and report the drift
 ```
@@ -88,44 +98,78 @@ Real output captured from an end-to-end run against the embedded stack.
 
 ```
 Connected to local gateway (org: local-install)
-  (run_sdk: 5 SDK calls in 254ms, sandboxed)
 
 === Adjusted churn for churn_rate ===
 
 ┌────┬─────────┬─────┬──────────┬─────┬───────────────────────────────────┐
 │    │ month   │ raw │ adjusted │ def │ flags                             │
 ├────┼─────────┼─────┼──────────┼─────┼───────────────────────────────────┤
-│  0 │ 2025-07 │ 30  │ 30       │ v1  │                                   │
-│  1 │ 2025-08 │ 30  │ 30       │ v1  │                                   │
-│  2 │ 2025-09 │ 30  │ 30       │ v1  │                                   │
-│  3 │ 2025-10 │ 30  │ 30       │ v1  │                                   │
-│  4 │ 2025-11 │ 30  │ 30       │ v1  │                                   │
-│  5 │ 2025-12 │ 30  │ 30       │ v1  │                                   │
-│  6 │ 2026-01 │ 30  │ 30       │ v1  │                                   │
-│  7 │ 2026-02 │ 30  │ 30       │ v1  │                                   │
-│  8 │ 2026-03 │ 530 │ —        │ v1  │ data_incident                     │
-│  9 │ 2026-04 │ 30  │ 30       │ v1  │                                   │
-│ 10 │ 2026-05 │ 75  │ 75       │ v2  │ external_shock, definition_change │
-│ 11 │ 2026-06 │ 30  │ 30       │ v2  │                                   │
+│  0 │ 2025-07 │ 50  │ 50       │ v1  │                                   │
+│  1 │ 2025-08 │ 50  │ 50       │ v1  │                                   │
+│  2 │ 2025-09 │ 50  │ 50       │ v1  │                                   │
+│  3 │ 2025-10 │ 50  │ 50       │ v1  │                                   │
+│  4 │ 2025-11 │ 50  │ 50       │ v1  │                                   │
+│  5 │ 2025-12 │ 50  │ 50       │ v1  │                                   │
+│  6 │ 2026-01 │ 50  │ 50       │ v1  │                                   │
+│  7 │ 2026-02 │ 50  │ 50       │ v1  │                                   │
+│  8 │ 2026-03 │ 550 │ 50       │ v1  │ data_incident                     │
+│  9 │ 2026-04 │ 50  │ 50       │ v1  │                                   │
+│ 10 │ 2026-05 │ 95  │ 83       │ v2  │ external_shock, definition_change │
+│ 11 │ 2026-06 │ 50  │ 38       │ v2  │                                   │
 └────┴─────────┴─────┴──────────┴─────┴───────────────────────────────────┘
 
-=== Definition changelog ===
-  v1 (from 2025-07-01): churn_rate v1 = subscriptions cancelled in month / active subscriptions at month start. A subscription churns the day cancelled_at is set.
-  v2 (from 2026-05-01) [current]: churn_rate v2 = cancellations excluding payment-failure cancellations inside a 28-day dunning grace / active subscriptions at month start.
+=== Definition changelog (governs the query) ===
+  v1 (from 2025-07-01): churn_rate v1 = … Every cancellation counts. [predicate: count every cancellation]
+  v2 (from 2026-05-01) [current]: churn_rate v2 = … [predicate: exclude payment_failure inside 28-day grace]
+
+=== Definition governs the number (not just the label) ===
+  2026-06: raw 50 counted under v1 would be 50; under the v2 predicate the governed count is 38. Same warehouse, different number — because the definition changed the WHERE.
 
 === Narrative ===
-  • 2026-03: raw 530 EXCLUDED — Recharge billing migration wrote false cancellations (https://linear.app/kelder/issue/DATA-142). Adjusted series drops this month.
-  • 2026-05: raw 75 genuinely elevated — Courier strike (Randstad region) (https://kelder.slack.com/archives/C042/p1747650000). Real but flagged; do not extrapolate.
-  • 2026-05: definition moved to v2 — Churn definition v2: dunning grace period (https://notion.so/kelder/churn-v2). Do not compare raw across the boundary.
+  • 2026-03: raw 550 REPAIRED to 50 — Recharge billing migration wrote false cancellations (https://linear.app/kelder/issue/DATA-142). Subtracted 500 artifact rows; the real cancellations that month still stand.
+  • 2026-05: raw 95 genuinely elevated — Courier strike (Randstad region) (https://kelder.slack.com/archives/C042/p1747650000). Real but flagged; do not extrapolate.
+  • 2026-05: definition moved to v2 — Churn definition v2: dunning grace period (https://notion.so/kelder/churn-v2). Post-boundary months are counted under the new predicate.
 
-Adjusted churn excludes months distorted by data incidents and labels each month with the governed definition version in effect. Every flag cites its source of truth.
+Adjusted churn is computed by letting the governed context drive the query: each month is counted under the definition version in effect, data-incident artifacts are subtracted (not nulled), and external shocks are kept but flagged. Every deviation cites its source of truth.
 ```
 
-The March spike (a data incident) is **excluded** from the adjusted series. The
-May elevation (a real courier strike) is **kept but flagged** — real, temporary,
-don't extrapolate. Every month from 2026-05 is labelled **v2**; earlier months
-**v1**. No LLM ran; the composition is a deterministic join over the live
-warehouse and the governed records.
+The March spike (a data incident) is **repaired** — the ~500 migration
+artifacts are *subtracted* (550 → ~50), not the whole month thrown away. The May
+elevation (a real courier strike) is **kept but flagged** — real, temporary,
+don't extrapolate. And the definition change **governs the count**: every month
+from 2026-05 is computed under v2, so a plain month reads **38** where v1 would
+read **50** — the same warehouse, a different number, because v2's predicate
+changed the `WHERE`. No LLM ran; `compose.ts` generates the rollup SQL *from* the
+governed predicates + adjustments and runs it live against the warehouse.
+
+### `bun run eval`
+
+Asks the March question WITH the governed context pushed vs a WITHOUT baseline
+and asserts the pushed context changed the answer. When the local install has a
+model provider wired, both arms are real agent turns; otherwise it runs the
+labelled deterministic proxy (below) — asserting the pushed context bundle
+carries the migration citation + corrected number and the baseline does not.
+
+```
+=== Agent eval (deterministic-proxy) ===
+
+(A) WITH context layer:
+    GOVERNED CONTEXT (business events affecting churn_rate):
+    - [data_incident] Recharge billing migration wrote false cancellations (on 2026-03-12, source https://linear.app/kelder/issue/DATA-142)
+        Repair 2026-03: ~500 cancellations … are migration artifacts …
+        structured adjustment: {"op":"subtract_reason","cancel_reason":"billing_migration_artifact"}
+    Composed adjusted series for 2026-03: raw 550, adjusted 50 (billing_migration_artifact rows subtracted).
+  → cites migration + corrects to ~50? YES ✅
+
+(B) WITHOUT context layer (baseline):
+    The warehouse reports 550 cancellations for 2026-03. No other context is available.
+  → correctly LACKS the governed correction? YES ✅
+
+PASS ✅ — pushing the context layer changed the answer.
+```
+
+The proxy is honest about being a proxy: wire a model provider
+(`lobu agents inference-providers`) and re-run for the live-agent version.
 
 ### `bun run drift:simulate` then `bun run drift`
 
@@ -141,7 +185,7 @@ Approved by head-of-data on 2026-07-12 (12 pinned rows vs 12 live rows)
 `bun run drift:simulate` inserts one new cancellation into 2026-06:
 
 ```
-Inserted 1 new cancellation (id 2001) into 2026-06. Warehouse now reports 31 cancellations for that month.
+Inserted 1 new cancellation (id 2001) into 2026-06. Warehouse now reports 51 cancellations for that month.
 Run `bun run drift` — the canary should now report drift.
 ```
 
@@ -155,7 +199,7 @@ Approved by head-of-data on 2026-07-12 (12 pinned rows vs 12 live rows)
 ┌───┬─────────┬────────┬─────────┐
 │   │ month   │ pinned │ current │
 ├───┼─────────┼────────┼─────────┤
-│ 0 │ 2026-06 │ 30     │ 31      │
+│ 0 │ 2026-06 │ 50     │ 51      │
 └───┴─────────┴────────┴─────────┘
 
 The pinned answer is stale. Re-verify before quoting either side.
@@ -163,10 +207,16 @@ The pinned answer is stale. Re-verify before quoting either side.
 
 ## Notes
 
-- Runs on **stock Lobu**. The composition and drift scripts use the standard
-  `run_sdk` sandbox (`client.feeds.readMany`, `client.entities.list`,
-  `client.knowledge.read`) — no server changes. Rendering this context directly
-  inside an agent's prompt/answer is a separate enhancement, not required here.
+- Runs on **stock Lobu**. `compose.ts` reads the context layer via the standard
+  `run_sdk` sandbox (`client.entities.list`, `client.knowledge.read`) and runs
+  the governed rollup live through the stock `query_sql` connection pushdown —
+  no server changes, nothing copied into Lobu. `eval.ts` invokes a real agent
+  through `lobu chat` when a model provider is configured.
+- The **agent eval falls back to a labelled deterministic proxy** when the local
+  install has no model provider (the default `lobu run` ships none). The proxy
+  proves the pushed context carries the governed correction and the baseline
+  does not; running it against a real model (wire one via
+  `lobu agents inference-providers`) is the honest next step.
 - The warehouse is deterministic — re-running `bun run seed:warehouse` resets it
   to the approved state (and clears any simulated drift).
 - The context-layer seed is idempotent: it refuses to double-seed. To reseed,

--- a/examples/context-layer/README.md
+++ b/examples/context-layer/README.md
@@ -146,9 +146,13 @@ governed predicates + adjustments and runs it live against the warehouse.
 
 Asks the March question WITH the governed context pushed vs a WITHOUT baseline
 and asserts the pushed context changed the answer. When the local install has a
-model provider wired, both arms are real agent turns; otherwise it runs the
-labelled deterministic proxy (below) — asserting the pushed context bundle
-carries the migration citation + corrected number and the baseline does not.
+model provider wired, both arms are real agent turns: the WITH arm runs the
+`analyst` agent (governed context in the prompt), the WITHOUT arm runs the
+`baseline` agent — declared in `lobu.config.ts` with `tools: { allowed: [],
+strict: true }` so it *cannot* retrieve the withheld context, making the A/B a
+real isolation of the variable. With no model provider it runs the labelled
+deterministic proxy (below) — asserting the pushed context bundle carries the
+migration citation + corrected number and the baseline does not.
 
 ```
 === Agent eval (deterministic-proxy) ===

--- a/examples/context-layer/lobu.config.ts
+++ b/examples/context-layer/lobu.config.ts
@@ -30,6 +30,25 @@ const analyst = defineAgent({
 });
 
 /**
+ * The eval's BASELINE agent — deliberately context-starved. `tools.strict` with
+ * an empty `allowed` list rejects every tool call, so this agent CANNOT retrieve
+ * business-event records or the metric-definition changelog. It answers only
+ * from the message it is handed. This is what makes the live-agent A/B eval a
+ * real isolation of the variable: the WITH arm (analyst + governed context in
+ * the prompt) versus the WITHOUT arm (this agent, no context, no tools to fetch
+ * it). Without this the baseline could just look the context up itself.
+ */
+const baseline = defineAgent({
+  id: "baseline",
+  dir: ".",
+  name: "baseline",
+  description:
+    "Answers strictly from the information in the message. Has no access to " +
+    "business-event records, metric definitions, or any other stored context.",
+  tools: { allowed: [], strict: true },
+});
+
+/**
  * The warehouse connection, declared as config (config-as-constructor). `lobu
  * run` applies this: it installs the bundled `postgres` connector and creates
  * an authenticated, read-only connection to the fake Kelder warehouse. The
@@ -293,7 +312,7 @@ export default defineConfig({
   orgName: "Kelder Coffee",
   orgDescription:
     "Fictional coffee-subscription company demonstrating Lobu as an org-level context layer",
-  agents: [analyst],
+  agents: [analyst, baseline],
   entities: [businessEvent, metricDefinition, verifiedQuery],
   authProfiles: [warehouseAuth],
   connections: [warehouse],

--- a/examples/context-layer/package.json
+++ b/examples/context-layer/package.json
@@ -7,6 +7,7 @@
     "seed:warehouse": "bun scripts/seed-warehouse.ts",
     "seed": "bun scripts/seed.ts",
     "compose": "bun scripts/compose.ts",
+    "eval": "bun scripts/eval.ts",
     "drift": "bun scripts/drift-check.ts",
     "drift:simulate": "bun scripts/simulate-drift.ts"
   },

--- a/examples/context-layer/scripts/compose.ts
+++ b/examples/context-layer/scripts/compose.ts
@@ -43,30 +43,30 @@ import { callTool, connectLocalGateway } from "./lib/gateway.ts";
 // ── Types shared between the two phases ────────────────────────────────────
 
 interface DefinitionVersion {
-	version: string;
-	effective_from: string;
-	definition: string;
-	is_current: boolean;
-	governing_predicate: {
-		exclude_payment_failure_in_grace?: boolean;
-		dunning_grace_days?: number;
-	} | null;
+  version: string;
+  effective_from: string;
+  definition: string;
+  is_current: boolean;
+  governing_predicate: {
+    exclude_payment_failure_in_grace?: boolean;
+    dunning_grace_days?: number;
+  } | null;
 }
 
 interface BusinessEvent {
-	event: string;
-	type: string;
-	date: string;
-	source: string;
-	affected_metrics: string[];
-	adjustment: { op: string; cancel_reason?: string } | null;
+  event: string;
+  type: string;
+  date: string;
+  source: string;
+  affected_metrics: string[];
+  adjustment: { op: string; cancel_reason?: string } | null;
 }
 
 interface ContextLayer {
-	metric: string;
-	metric_slug: string;
-	changelog: DefinitionVersion[];
-	events: BusinessEvent[];
+  metric: string;
+  metric_slug: string;
+  changelog: DefinitionVersion[];
+  events: BusinessEvent[];
 }
 
 /**
@@ -123,21 +123,21 @@ export default async (_ctx, client) => {
  * from `governing_predicate` — the definition literally governs the SQL.
  */
 function versionPredicate(v: DefinitionVersion): string {
-	const p = v.governing_predicate;
-	if (p?.exclude_payment_failure_in_grace) {
-		const graceDays = Number(p.dunning_grace_days ?? 28);
-		// A payment_failure cancelled within `graceDays` of its dunning start is a
-		// retry-window artifact, not churn — exclude it. Everything else counts.
-		// NULL-safe: `IS DISTINCT FROM` keeps a NULL-reason cancellation counted (a
-		// plain `cancel_reason = 'x'` would go NULL → NOT NULL → the row silently
-		// dropped from the FILTER).
-		return (
-			`NOT (cancel_reason IS NOT DISTINCT FROM 'payment_failure' ` +
-			`AND dunning_started_at IS NOT NULL ` +
-			`AND cancelled_at <= dunning_started_at + interval '${graceDays} days')`
-		);
-	}
-	return "TRUE"; // v1: every cancellation counts.
+  const p = v.governing_predicate;
+  if (p?.exclude_payment_failure_in_grace) {
+    const graceDays = Number(p.dunning_grace_days ?? 28);
+    // A payment_failure cancelled within `graceDays` of its dunning start is a
+    // retry-window artifact, not churn — exclude it. Everything else counts.
+    // NULL-safe: `IS DISTINCT FROM` keeps a NULL-reason cancellation counted (a
+    // plain `cancel_reason = 'x'` would go NULL → NOT NULL → the row silently
+    // dropped from the FILTER).
+    return (
+      `NOT (cancel_reason IS NOT DISTINCT FROM 'payment_failure' ` +
+      `AND dunning_started_at IS NOT NULL ` +
+      `AND cancelled_at <= dunning_started_at + interval '${graceDays} days')`
+    );
+  }
+  return "TRUE"; // v1: every cancellation counts.
 }
 
 /**
@@ -146,29 +146,29 @@ function versionPredicate(v: DefinitionVersion): string {
  * adjustment is derivable purely from the warehouse, so that is what we apply.
  */
 interface IncidentAdjustment {
-	/** YYYY-MM the incident occurred in — the ONLY month its rows are subtracted from. */
-	month: string;
-	/** SQL string literal for the reason (already single-quoted + escaped). */
-	reasonLiteral: string;
+  /** YYYY-MM the incident occurred in — the ONLY month its rows are subtracted from. */
+  month: string;
+  /** SQL string literal for the reason (already single-quoted + escaped). */
+  reasonLiteral: string;
 }
 
 function incidentAdjustments(
-	events: BusinessEvent[],
-	metricSlug: string,
+  events: BusinessEvent[],
+  metricSlug: string
 ): IncidentAdjustment[] {
-	return events
-		.filter(
-			(e) =>
-				e.type === "data_incident" &&
-				e.affected_metrics.includes(metricSlug) &&
-				e.adjustment?.op === "subtract_reason" &&
-				e.adjustment.cancel_reason &&
-				e.date,
-		)
-		.map((e) => ({
-			month: String(e.date).slice(0, 7),
-			reasonLiteral: `'${String(e.adjustment?.cancel_reason).replace(/'/g, "''")}'`,
-		}));
+  return events
+    .filter(
+      (e) =>
+        e.type === "data_incident" &&
+        e.affected_metrics.includes(metricSlug) &&
+        e.adjustment?.op === "subtract_reason" &&
+        e.adjustment.cancel_reason &&
+        e.date
+    )
+    .map((e) => ({
+      month: String(e.date).slice(0, 7),
+      reasonLiteral: `'${String(e.adjustment?.cancel_reason).replace(/'/g, "''")}'`,
+    }));
 }
 
 /**
@@ -178,13 +178,13 @@ function incidentAdjustments(
  * NULL-safe via `IS NOT DISTINCT FROM`.
  */
 function artifactPredicateSql(adjustments: IncidentAdjustment[]): string {
-	if (adjustments.length === 0) return "FALSE";
-	const clauses = adjustments.map(
-		(a) =>
-			`(to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '${a.month}' ` +
-			`AND cancel_reason IS NOT DISTINCT FROM ${a.reasonLiteral})`,
-	);
-	return clauses.join(" OR ");
+  if (adjustments.length === 0) return "FALSE";
+  const clauses = adjustments.map(
+    (a) =>
+      `(to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '${a.month}' ` +
+      `AND cancel_reason IS NOT DISTINCT FROM ${a.reasonLiteral})`
+  );
+  return clauses.join(" OR ");
 }
 
 /**
@@ -201,64 +201,64 @@ function artifactPredicateSql(adjustments: IncidentAdjustment[]): string {
  * so the SAME query counts pre-May months under v1 and post-May under v2.
  */
 function buildGovernedSql(ctx: ContextLayer): string {
-	const adjustments = incidentAdjustments(ctx.events, ctx.metric_slug);
-	const artifactPredicate = artifactPredicateSql(adjustments);
-	// Keep everything that is NOT an incident artifact. `NOT (artifact)` is
-	// NULL-safe because artifactPredicate uses IS [NOT] DISTINCT FROM, so it is a
-	// total boolean (never NULL) — a NULL-reason row is simply not an artifact.
-	const keepPredicate =
-		adjustments.length === 0 ? "TRUE" : `NOT (${artifactPredicate})`;
+  const adjustments = incidentAdjustments(ctx.events, ctx.metric_slug);
+  const artifactPredicate = artifactPredicateSql(adjustments);
+  // Keep everything that is NOT an incident artifact. `NOT (artifact)` is
+  // NULL-safe because artifactPredicate uses IS [NOT] DISTINCT FROM, so it is a
+  // total boolean (never NULL) — a NULL-reason row is simply not an artifact.
+  const keepPredicate =
+    adjustments.length === 0 ? "TRUE" : `NOT (${artifactPredicate})`;
 
-	const chrono = [...ctx.changelog].sort((a, b) =>
-		a.effective_from.localeCompare(b.effective_from),
-	);
-	const earliest = chrono[0];
-	if (!earliest) {
-		throw new Error(
-			"metric-definition has no versioned definition — run `bun run seed` first",
-		);
-	}
-	// CASE arms newest-first: the first month-boundary that is <= the row's month
-	// wins, i.e. the version in effect. Falls through to the earliest version.
-	const arms = [...chrono]
-		.reverse()
-		.map(
-			(v) =>
-				`      WHEN to_char(date_trunc('month', cancelled_at), 'YYYY-MM') >= '${v.effective_from.slice(
-					0,
-					7,
-				)}'\n        THEN (${versionPredicate(v)})`,
-		)
-		.join("\n");
-	const fallback = versionPredicate(earliest);
+  const chrono = [...ctx.changelog].sort((a, b) =>
+    a.effective_from.localeCompare(b.effective_from)
+  );
+  const earliest = chrono[0];
+  if (!earliest) {
+    throw new Error(
+      "metric-definition has no versioned definition — run `bun run seed` first"
+    );
+  }
+  // CASE arms newest-first: the first month-boundary that is <= the row's month
+  // wins, i.e. the version in effect. Falls through to the earliest version.
+  const arms = [...chrono]
+    .reverse()
+    .map(
+      (v) =>
+        `      WHEN to_char(date_trunc('month', cancelled_at), 'YYYY-MM') >= '${v.effective_from.slice(
+          0,
+          7
+        )}'\n        THEN (${versionPredicate(v)})`
+    )
+    .join("\n");
+  const fallback = versionPredicate(earliest);
 
-	const governedExpr = `CASE\n${arms}\n      ELSE (${fallback})\n    END`;
+  const governedExpr = `CASE\n${arms}\n      ELSE (${fallback})\n    END`;
 
-	return (
-		`SELECT to_char(date_trunc('month', cancelled_at), 'YYYY-MM') AS month,\n` +
-		`       count(*)::int AS raw,\n` +
-		`       count(*) FILTER (\n` +
-		`         WHERE (${keepPredicate})\n` +
-		`           AND (${governedExpr})\n` +
-		`       )::int AS adjusted,\n` +
-		`       count(*) FILTER (WHERE ${artifactPredicate})::int AS subtracted\n` +
-		`  FROM subscriptions\n` +
-		` WHERE cancelled_at IS NOT NULL\n` +
-		` GROUP BY 1\n` +
-		` ORDER BY 1`
-	);
+  return (
+    `SELECT to_char(date_trunc('month', cancelled_at), 'YYYY-MM') AS month,\n` +
+    `       count(*)::int AS raw,\n` +
+    `       count(*) FILTER (\n` +
+    `         WHERE (${keepPredicate})\n` +
+    `           AND (${governedExpr})\n` +
+    `       )::int AS adjusted,\n` +
+    `       count(*) FILTER (WHERE ${artifactPredicate})::int AS subtracted\n` +
+    `  FROM subscriptions\n` +
+    ` WHERE cancelled_at IS NOT NULL\n` +
+    ` GROUP BY 1\n` +
+    ` ORDER BY 1`
+  );
 }
 
 // ── Compose ────────────────────────────────────────────────────────────────
 
 interface QuerySqlResult {
-	rows: Array<{
-		month: string;
-		raw: number;
-		adjusted: number;
-		subtracted: number;
-	}>;
-	error?: string;
+  rows: Array<{
+    month: string;
+    raw: number;
+    adjusted: number;
+    subtracted: number;
+  }>;
+  error?: string;
 }
 
 const gw = await connectLocalGateway();
@@ -266,121 +266,121 @@ console.log(`Connected to local gateway (org: ${gw.org})`);
 
 // Phase 1: the context layer.
 const ctxResult = await callTool<{
-	return_value?: ContextLayer;
-	success: boolean;
-	error?: { message: string };
+  return_value?: ContextLayer;
+  success: boolean;
+  error?: { message: string };
 }>(gw, "run_sdk", { script: CONTEXT_SCRIPT, timeout_ms: 60_000 });
 if (!ctxResult.success || !ctxResult.return_value) {
-	throw new Error(
-		`context read failed: ${ctxResult.error?.message ?? "unknown"}`,
-	);
+  throw new Error(
+    `context read failed: ${ctxResult.error?.message ?? "unknown"}`
+  );
 }
 const ctx = ctxResult.return_value;
 
 // Phase 2: GENERATE the governed SQL from that context, run it LIVE.
 const governedSql = buildGovernedSql(ctx);
 const live = await callTool<QuerySqlResult>(gw, "query_sql", {
-	connection: WAREHOUSE_CONNECTION_SLUG,
-	sql: governedSql,
+  connection: WAREHOUSE_CONNECTION_SLUG,
+  sql: governedSql,
 });
 if (live.error) {
-	throw new Error(`governed query failed: ${live.error}\n---\n${governedSql}`);
+  throw new Error(`governed query failed: ${live.error}\n---\n${governedSql}`);
 }
 const liveRows = live.rows;
 
 // Which definition version governs a given YYYY-MM month?
 const versionFor = (month: string): DefinitionVersion | undefined => {
-	let current = ctx.changelog[0];
-	for (const def of ctx.changelog) {
-		if (def.effective_from.slice(0, 7) <= month) current = def;
-	}
-	return current;
+  let current = ctx.changelog[0];
+  for (const def of ctx.changelog) {
+    if (def.effective_from.slice(0, 7) <= month) current = def;
+  }
+  return current;
 };
 
 // Join the live governed series with the business-event flags per month.
 const months = liveRows.map((row) => {
-	const month = row.month;
-	const flags = ctx.events
-		.filter((ev) => String(ev.date ?? "").slice(0, 7) === month)
-		.filter((ev) => ev.affected_metrics.includes(ctx.metric_slug))
-		.map((ev) => ({ event: ev.event, type: ev.type, source: ev.source }));
-	const gov = versionFor(month);
-	return {
-		month,
-		raw: row.raw,
-		adjusted: row.adjusted,
-		definition_version: gov?.version ?? null,
-		flags,
-		// Exactly the incident-named (artifact) rows for this month, straight from
-		// the warehouse — never derived as raw−adjusted, so a version-governed month
-		// can never inflate the "subtracted" figure.
-		subtracted: row.subtracted,
-	};
+  const month = row.month;
+  const flags = ctx.events
+    .filter((ev) => String(ev.date ?? "").slice(0, 7) === month)
+    .filter((ev) => ev.affected_metrics.includes(ctx.metric_slug))
+    .map((ev) => ({ event: ev.event, type: ev.type, source: ev.source }));
+  const gov = versionFor(month);
+  return {
+    month,
+    raw: row.raw,
+    adjusted: row.adjusted,
+    definition_version: gov?.version ?? null,
+    flags,
+    // Exactly the incident-named (artifact) rows for this month, straight from
+    // the warehouse — never derived as raw−adjusted, so a version-governed month
+    // can never inflate the "subtracted" figure.
+    subtracted: row.subtracted,
+  };
 });
 
 // ── Output ─────────────────────────────────────────────────────────────────
 
 console.log(`\n=== Adjusted churn for ${ctx.metric} ===\n`);
 console.table(
-	months.map((m) => ({
-		month: m.month,
-		raw: m.raw,
-		adjusted: m.adjusted,
-		def: m.definition_version,
-		flags: m.flags.map((f) => f.type).join(", ") || "",
-	})),
+  months.map((m) => ({
+    month: m.month,
+    raw: m.raw,
+    adjusted: m.adjusted,
+    def: m.definition_version,
+    flags: m.flags.map((f) => f.type).join(", ") || "",
+  }))
 );
 
 console.log("\n=== Definition changelog (governs the query) ===");
 for (const d of ctx.changelog) {
-	const pred = d.governing_predicate?.exclude_payment_failure_in_grace
-		? ` [predicate: exclude payment_failure inside ${d.governing_predicate.dunning_grace_days}-day grace]`
-		: " [predicate: count every cancellation]";
-	console.log(
-		`  ${d.version} (from ${d.effective_from})${d.is_current ? " [current]" : ""}: ${d.definition}${pred}`,
-	);
+  const pred = d.governing_predicate?.exclude_payment_failure_in_grace
+    ? ` [predicate: exclude payment_failure inside ${d.governing_predicate.dunning_grace_days}-day grace]`
+    : " [predicate: count every cancellation]";
+  console.log(
+    `  ${d.version} (from ${d.effective_from})${d.is_current ? " [current]" : ""}: ${d.definition}${pred}`
+  );
 }
 
 // Prove the definition MOVES the number, not just labels it: pick a v2-governed
 // plain month and show what v1 would have counted vs what v2 actually counts.
 const v2Month = months.find(
-	(m) => m.definition_version === "v2" && m.flags.length === 0,
+  (m) => m.definition_version === "v2" && m.flags.length === 0
 );
 if (v2Month) {
-	console.log("\n=== Definition governs the number (not just the label) ===");
-	console.log(
-		`  ${v2Month.month}: raw ${v2Month.raw} counted under v1 would be ${v2Month.raw}; ` +
-			`under the v2 predicate the governed count is ${v2Month.adjusted}. ` +
-			`Same warehouse, different number — because the definition changed the WHERE.`,
-	);
+  console.log("\n=== Definition governs the number (not just the label) ===");
+  console.log(
+    `  ${v2Month.month}: raw ${v2Month.raw} counted under v1 would be ${v2Month.raw}; ` +
+      `under the v2 predicate the governed count is ${v2Month.adjusted}. ` +
+      `Same warehouse, different number — because the definition changed the WHERE.`
+  );
 }
 
 console.log("\n=== Narrative ===");
 for (const m of months) {
-	for (const f of m.flags) {
-		if (f.type === "data_incident") {
-			console.log(
-				`  • ${m.month}: raw ${m.raw} REPAIRED to ${m.adjusted} — ${f.event} ` +
-					`(${f.source}). Subtracted ${m.subtracted} artifact rows; the real ` +
-					`cancellations that month still stand.`,
-			);
-		} else if (f.type === "definition_change") {
-			console.log(
-				`  • ${m.month}: definition moved to ${m.definition_version} — ${f.event} ` +
-					`(${f.source}). Post-boundary months are counted under the new predicate.`,
-			);
-		} else {
-			console.log(
-				`  • ${m.month}: raw ${m.raw} genuinely elevated — ${f.event} ` +
-					`(${f.source}). Real but flagged; do not extrapolate.`,
-			);
-		}
-	}
+  for (const f of m.flags) {
+    if (f.type === "data_incident") {
+      console.log(
+        `  • ${m.month}: raw ${m.raw} REPAIRED to ${m.adjusted} — ${f.event} ` +
+          `(${f.source}). Subtracted ${m.subtracted} artifact rows; the real ` +
+          `cancellations that month still stand.`
+      );
+    } else if (f.type === "definition_change") {
+      console.log(
+        `  • ${m.month}: definition moved to ${m.definition_version} — ${f.event} ` +
+          `(${f.source}). Post-boundary months are counted under the new predicate.`
+      );
+    } else {
+      console.log(
+        `  • ${m.month}: raw ${m.raw} genuinely elevated — ${f.event} ` +
+          `(${f.source}). Real but flagged; do not extrapolate.`
+      );
+    }
+  }
 }
 
 console.log(
-	"\nAdjusted churn is computed by letting the governed context drive the query: " +
-		"each month is counted under the definition version in effect, data-incident " +
-		"artifacts are subtracted (not nulled), and external shocks are kept but " +
-		"flagged. Every deviation cites its source of truth.",
+  "\nAdjusted churn is computed by letting the governed context drive the query: " +
+    "each month is counted under the definition version in effect, data-incident " +
+    "artifacts are subtracted (not nulled), and external shocks are kept but " +
+    "flagged. Every deviation cites its source of truth."
 );

--- a/examples/context-layer/scripts/compose.ts
+++ b/examples/context-layer/scripts/compose.ts
@@ -1,60 +1,87 @@
 /**
  * THE MONEY SHOT — compose the "governed why" over a LIVE warehouse.
  *
- * One sandboxed `run_sdk` script does the whole join, in-process, on the
- * gateway:
+ * A semantic layer answers *what* the number is. This composes the *why*: it
+ * reads the governed context records out of Lobu and lets them GOVERN the query
+ * that reads the warehouse — the definition version in effect for a month
+ * decides how that month is counted, and a data-incident's structured
+ * adjustment decides which rows are subtracted. The output is a raw-vs-adjusted
+ * churn series where every deviation is explained by a dated, sourced record.
  *
- *   1. `client.feeds.readMany` on the VIRTUAL churn feed — the monthly rollup
- *      is pushed down to the warehouse and read LIVE. Nothing is copied into
- *      Lobu; the numbers are whatever the warehouse says right now.
- *   2. `client.entities.list` on `business-event` — the dated, sourced records
- *      that explain the distortions in that series.
- *   3. `client.knowledge.read({ include_superseded: true })` on the
- *      `metric-definition` entity — the definition changelog (the supersede
- *      chain), so each month can be labelled with the version in effect.
+ * Two phases, both on stock Lobu:
  *
- * The script joins these by month in plain JS and returns a composed narrative:
- * raw vs adjusted churn per month, a flag per month citing each overlapping
- * business event's `source_link`, and the definition version governing it.
+ *   1. A sandboxed `run_sdk` script reads the CONTEXT LAYER (no warehouse
+ *      access): the `metric-definition` entity, its definition changelog (the
+ *      supersede chain, each version carrying a machine-usable
+ *      `governing_predicate`), and the `business-event` records (each carrying
+ *      an `affected_metrics` list and, for a data incident, a structured
+ *      `adjustment`). It returns these as plain JSON.
+ *
+ *   2. From those predicates + adjustments THIS script GENERATES one governed
+ *      rollup SQL and runs it LIVE against the warehouse through the stock
+ *      `query_sql` connection pushdown (read-only, nothing copied into Lobu).
+ *      The generated SQL is what makes the claim true:
+ *        • the definition version GOVERNS the count — post-2026-05 months are
+ *          counted under v2 (payment-failures inside the 28-day dunning grace
+ *          filtered out), so the SAME warehouse yields a DIFFERENT number than
+ *          v1 would. Not a label — a different WHERE.
+ *        • a data_incident SUBTRACTS exactly the rows it names
+ *          (cancel_reason = billing_migration_artifact) from its month. March is
+ *          repaired (~550 → ~50), not thrown away.
+ *        • an external_shock keeps its number and only flags it.
  *
  * The composition is deterministic — no LLM. The context layer turns "why did
- * March spike?" from archaeology into a lookup.
+ * March spike?" from archaeology into a lookup, and turns "which definition was
+ * in effect?" from tribal knowledge into a filter the query actually applies.
  *
  * Prereqs: `lobu run` is up here, and `seed:warehouse` + `seed` have run.
  */
 
-import { connectLocalGateway, runSdkSource } from "./lib/gateway.ts";
+import { callTool, connectLocalGateway } from "./lib/gateway.ts";
+import { WAREHOUSE_CONNECTION_SLUG } from "./lib/env.ts";
+
+// ── Types shared between the two phases ────────────────────────────────────
+
+interface DefinitionVersion {
+  version: string;
+  effective_from: string;
+  definition: string;
+  is_current: boolean;
+  governing_predicate: {
+    exclude_payment_failure_in_grace?: boolean;
+    dunning_grace_days?: number;
+  } | null;
+}
+
+interface BusinessEvent {
+  event: string;
+  type: string;
+  date: string;
+  source: string;
+  affected_metrics: string[];
+  adjustment: { op: string; cancel_reason?: string; value?: number } | null;
+}
+
+interface ContextLayer {
+  metric: string;
+  metric_slug: string;
+  changelog: DefinitionVersion[];
+  events: BusinessEvent[];
+}
 
 /**
- * The sandboxed SDK script. Exports `default async (ctx, client) => ...`; the
- * gateway runs it in-process with a scoped `client`. Everything inside this
- * template literal executes on the server, NOT in this Bun process.
+ * PHASE 1 — read the context layer out of Lobu (stock SDK, no warehouse touch).
+ * Everything inside this template literal executes on the gateway, sandboxed.
  */
-const SANDBOX_SCRIPT = `
+const CONTEXT_SCRIPT = `
 export default async (_ctx, client) => {
-  // ── 1. Resolve the pieces of the context layer ──────────────────────────
-  const feedList = await client.feeds.list({});
-  const churnFeed = (feedList.feeds ?? []).find(
-    (f) => f.kind === "virtual" && f.feed_key === "query",
-  );
-  if (!churnFeed) throw new Error("virtual churn feed not found — run seed first");
-
   const metricList = await client.entities.list({ entity_type: "metric-definition" });
   const metric = (metricList.entities ?? [])[0];
   if (!metric) throw new Error("metric-definition entity not found — run seed first");
+  const metricSlug = metric.metadata?.metric ?? metric.metadata?.aliases?.[0] ?? metric.name;
 
-  const eventList = await client.entities.list({ entity_type: "business-event" });
-  const businessEvents = eventList.entities ?? [];
-
-  // ── 2. Read the churn rollup LIVE from the warehouse (pushdown) ──────────
-  const feedRead = await client.feeds.readMany({ feed_ids: [churnFeed.id] });
-  const feedResult = (feedRead.results ?? []).find((r) => r.ok);
-  if (!feedResult) {
-    throw new Error("virtual feed read failed: " + JSON.stringify(feedRead));
-  }
-  const churnRows = feedResult.result.rows ?? [];
-
-  // ── 3. Read the definition changelog (supersede chain) ──────────────────
+  // The definition changelog — the supersede chain. Each version carries the
+  // machine-usable governing_predicate the query will be built from.
   const changelogRes = await client.knowledge.read({
     entity_id: metric.id,
     semantic_type: "definition",
@@ -62,144 +89,262 @@ export default async (_ctx, client) => {
     sort_by: "date",
     sort_order: "asc",
   });
-  // knowledge.read (get_content) returns { content: ContentItem[] }; each item's
-  // body is text_content. Read those shapes directly so a real API change fails
-  // loudly instead of silently yielding [].
   const changelog = (changelogRes.content ?? [])
     .map((e) => ({
-      id: e.id,
-      title: e.title,
-      definition: e.text_content,
       version: e.metadata?.version,
       effective_from: e.metadata?.effective_from,
+      definition: e.text_content,
+      governing_predicate: e.metadata?.governing_predicate ?? null,
     }))
     .sort((a, b) => String(a.effective_from).localeCompare(String(b.effective_from)));
+  changelog.forEach((d, i) => { d.is_current = i === changelog.length - 1; });
 
-  // Which definition version governs a given YYYY-MM month?
-  const versionFor = (month) => {
-    let current = changelog[0];
-    for (const def of changelog) {
-      if (String(def.effective_from).slice(0, 7) <= month) current = def;
-    }
-    return current?.version ?? null;
-  };
-  changelog.forEach((d, i) => {
-    d.is_current = i === changelog.length - 1;
-  });
+  // The governed "why" records.
+  const eventList = await client.entities.list({ entity_type: "business-event" });
+  const events = (eventList.entities ?? []).map((ev) => ({
+    event: ev.name,
+    type: ev.metadata?.event_type,
+    date: ev.metadata?.event_date,
+    source: ev.metadata?.source_link,
+    affected_metrics: ev.metadata?.affected_metrics ?? [],
+    adjustment: ev.metadata?.adjustment ?? null,
+  }));
 
-  // ── 4. Join by month in JS ──────────────────────────────────────────────
-  const months = churnRows.map((row) => {
-    const month = String(row.month);
-    const raw = Number(row.cancellations);
-
-    // Business events overlapping this month.
-    const flags = businessEvents
-      .filter((ev) => String(ev.metadata?.event_date ?? "").slice(0, 7) === month)
-      .map((ev) => ({
-        event: ev.name,
-        type: ev.metadata?.event_type,
-        date: ev.metadata?.event_date,
-        source: ev.metadata?.source_link,
-      }));
-
-    // A data_incident means the numbers are WRONG — exclude that month from the
-    // adjusted series. Everything else is real (keep the number, keep the flag).
-    const excluded = flags.some((f) => f.type === "data_incident");
-
-    return {
-      month,
-      raw_cancellations: raw,
-      adjusted_cancellations: excluded ? null : raw,
-      excluded,
-      flags,
-      definition_version: versionFor(month),
-    };
-  });
-
-  // ── 5. A human-readable narrative citing sources + versions ─────────────
-  const lines = [];
-  for (const m of months) {
-    for (const f of m.flags) {
-      if (f.type === "data_incident") {
-        lines.push(
-          m.month + ": raw " + m.raw_cancellations + " EXCLUDED — " + f.event +
-            " (" + f.source + "). Adjusted series drops this month.",
-        );
-      } else if (f.type === "definition_change") {
-        lines.push(
-          m.month + ": definition moved to " + m.definition_version + " — " +
-            f.event + " (" + f.source + "). Do not compare raw across the boundary.",
-        );
-      } else {
-        lines.push(
-          m.month + ": raw " + m.raw_cancellations + " genuinely elevated — " +
-            f.event + " (" + f.source + "). Real but flagged; do not extrapolate.",
-        );
-      }
-    }
-  }
-
-  return {
-    metric: metric.name,
-    months,
-    narrative: {
-      definitions_changelog: changelog,
-      flagged_months: lines,
-      summary:
-        "Adjusted churn excludes months distorted by data incidents and labels " +
-        "each month with the governed definition version in effect. Every flag " +
-        "cites its source of truth.",
-    },
-  };
+  return { metric: metric.name, metric_slug: metricSlug, changelog, events };
 };
 `;
 
-interface Composed {
-  metric: string;
-  months: Array<{
+// ── SQL generation — the definition/incident metadata BECOMES the query ────
+
+/**
+ * The governing-version WHERE fragment for a single month: given the version in
+ * effect, emit the predicate that decides which cancellations count. v1 counts
+ * everything; v2 filters out payment-failures inside the dunning grace. Built
+ * from `governing_predicate` — the definition literally governs the SQL.
+ */
+function versionPredicate(v: DefinitionVersion): string {
+  const p = v.governing_predicate;
+  if (p?.exclude_payment_failure_in_grace) {
+    const graceDays = Number(p.dunning_grace_days ?? 28);
+    // A payment_failure cancelled within `graceDays` of its dunning start is a
+    // retry-window artifact, not churn — exclude it. Everything else counts.
+    return (
+      `NOT (cancel_reason = 'payment_failure' ` +
+      `AND dunning_started_at IS NOT NULL ` +
+      `AND cancelled_at <= dunning_started_at + interval '${graceDays} days')`
+    );
+  }
+  return "TRUE"; // v1: every cancellation counts.
+}
+
+/**
+ * The data-incident WHERE fragment: rows the structured `adjustment` says to
+ * subtract are excluded from the adjusted count for the affected month. Only a
+ * subtract_reason adjustment is derivable purely from the warehouse, so that is
+ * what we apply here.
+ */
+function incidentReasons(
+  events: BusinessEvent[],
+  metricSlug: string
+): string[] {
+  return events
+    .filter(
+      (e) =>
+        e.type === "data_incident" &&
+        e.affected_metrics.includes(metricSlug) &&
+        e.adjustment?.op === "subtract_reason" &&
+        e.adjustment.cancel_reason
+    )
+    .map((e) => `'${String(e.adjustment!.cancel_reason).replace(/'/g, "''")}'`);
+}
+
+/**
+ * Build ONE governed rollup SQL over the warehouse. Per month it returns:
+ *   raw          — every cancellation (churn v1, no governance)
+ *   adjusted     — counted under the version in effect for that month AND with
+ *                  the data-incident rows subtracted (only the affected metric)
+ *   subtracted   — the count of exactly the incident-named rows (the artifacts).
+ *                  Derived from the incident predicate alone, so it stays honest
+ *                  even if an incident ever lands in a version-governed month
+ *                  (never conflated with rows the version predicate excludes).
+ * The version-in-effect boundary is emitted as a CASE from the changelog dates,
+ * so the SAME query counts pre-May months under v1 and post-May under v2.
+ */
+function buildGovernedSql(ctx: ContextLayer): string {
+  const reasons = incidentReasons(ctx.events, ctx.metric_slug);
+  const keepPredicate =
+    reasons.length === 0
+      ? "TRUE"
+      : `cancel_reason NOT IN (${reasons.join(", ")})`;
+  const artifactPredicate =
+    reasons.length === 0 ? "FALSE" : `cancel_reason IN (${reasons.join(", ")})`;
+
+  const chrono = [...ctx.changelog].sort((a, b) =>
+    a.effective_from.localeCompare(b.effective_from)
+  );
+  // CASE arms newest-first: the first month-boundary that is <= the row's month
+  // wins, i.e. the version in effect. Falls through to the earliest version.
+  const arms = [...chrono]
+    .reverse()
+    .map(
+      (v) =>
+        `      WHEN to_char(date_trunc('month', cancelled_at), 'YYYY-MM') >= '${v.effective_from.slice(
+          0,
+          7
+        )}'\n        THEN (${versionPredicate(v)})`
+    )
+    .join("\n");
+  const fallback = versionPredicate(chrono[0]!);
+
+  const governedExpr = `CASE\n${arms}\n      ELSE (${fallback})\n    END`;
+
+  return (
+    `SELECT to_char(date_trunc('month', cancelled_at), 'YYYY-MM') AS month,\n` +
+    `       count(*)::int AS raw,\n` +
+    `       count(*) FILTER (\n` +
+    `         WHERE (${keepPredicate})\n` +
+    `           AND (${governedExpr})\n` +
+    `       )::int AS adjusted,\n` +
+    `       count(*) FILTER (WHERE ${artifactPredicate})::int AS subtracted\n` +
+    `  FROM subscriptions\n` +
+    ` WHERE cancelled_at IS NOT NULL\n` +
+    ` GROUP BY 1\n` +
+    ` ORDER BY 1`
+  );
+}
+
+// ── Compose ────────────────────────────────────────────────────────────────
+
+interface QuerySqlResult {
+  rows: Array<{
     month: string;
-    raw_cancellations: number;
-    adjusted_cancellations: number | null;
-    excluded: boolean;
-    flags: Array<{ event: string; type: string; date: string; source: string }>;
-    definition_version: string | null;
+    raw: number;
+    adjusted: number;
+    subtracted: number;
   }>;
-  narrative: {
-    definitions_changelog: Array<{
-      version: string;
-      effective_from: string;
-      definition: string;
-      is_current: boolean;
-    }>;
-    flagged_months: string[];
-    summary: string;
-  };
+  error?: string;
 }
 
 const gw = await connectLocalGateway();
 console.log(`Connected to local gateway (org: ${gw.org})`);
 
-const composed = await runSdkSource<Composed>(gw, SANDBOX_SCRIPT);
+// Phase 1: the context layer.
+const ctxResult = await callTool<{
+  return_value?: ContextLayer;
+  success: boolean;
+  error?: { message: string };
+}>(gw, "run_sdk", { script: CONTEXT_SCRIPT, timeout_ms: 60_000 });
+if (!ctxResult.success || !ctxResult.return_value) {
+  throw new Error(
+    `context read failed: ${ctxResult.error?.message ?? "unknown"}`
+  );
+}
+const ctx = ctxResult.return_value;
 
-console.log(`\n=== Adjusted churn for ${composed.metric} ===\n`);
-const table = composed.months.map((m) => ({
-  month: m.month,
-  raw: m.raw_cancellations,
-  adjusted: m.excluded ? "—" : m.adjusted_cancellations,
-  def: m.definition_version,
-  flags: m.flags.map((f) => f.type).join(", ") || "",
-}));
-console.table(table);
+// Phase 2: GENERATE the governed SQL from that context, run it LIVE.
+const governedSql = buildGovernedSql(ctx);
+const live = await callTool<QuerySqlResult>(gw, "query_sql", {
+  connection: WAREHOUSE_CONNECTION_SLUG,
+  sql: governedSql,
+});
+if (live.error) {
+  throw new Error(`governed query failed: ${live.error}\n---\n${governedSql}`);
+}
+const liveRows = live.rows;
 
-console.log("\n=== Definition changelog ===");
-for (const d of composed.narrative.definitions_changelog) {
+// Which definition version governs a given YYYY-MM month?
+const versionFor = (month: string): DefinitionVersion | undefined => {
+  let current = ctx.changelog[0];
+  for (const def of ctx.changelog) {
+    if (def.effective_from.slice(0, 7) <= month) current = def;
+  }
+  return current;
+};
+
+// Join the live governed series with the business-event flags per month.
+const months = liveRows.map((row) => {
+  const month = row.month;
+  const flags = ctx.events
+    .filter((ev) => String(ev.date ?? "").slice(0, 7) === month)
+    .filter((ev) => ev.affected_metrics.includes(ctx.metric_slug))
+    .map((ev) => ({ event: ev.event, type: ev.type, source: ev.source }));
+  const gov = versionFor(month);
+  return {
+    month,
+    raw: row.raw,
+    adjusted: row.adjusted,
+    definition_version: gov?.version ?? null,
+    flags,
+    // Exactly the incident-named (artifact) rows for this month, straight from
+    // the warehouse — never derived as raw−adjusted, so a version-governed month
+    // can never inflate the "subtracted" figure.
+    subtracted: row.subtracted,
+  };
+});
+
+// ── Output ─────────────────────────────────────────────────────────────────
+
+console.log(`\n=== Adjusted churn for ${ctx.metric} ===\n`);
+console.table(
+  months.map((m) => ({
+    month: m.month,
+    raw: m.raw,
+    adjusted: m.adjusted,
+    def: m.definition_version,
+    flags: m.flags.map((f) => f.type).join(", ") || "",
+  }))
+);
+
+console.log("\n=== Definition changelog (governs the query) ===");
+for (const d of ctx.changelog) {
+  const pred = d.governing_predicate?.exclude_payment_failure_in_grace
+    ? ` [predicate: exclude payment_failure inside ${d.governing_predicate.dunning_grace_days}-day grace]`
+    : " [predicate: count every cancellation]";
   console.log(
-    `  ${d.version} (from ${d.effective_from})${d.is_current ? " [current]" : ""}: ${d.definition}`
+    `  ${d.version} (from ${d.effective_from})${d.is_current ? " [current]" : ""}: ${d.definition}${pred}`
+  );
+}
+
+// Prove the definition MOVES the number, not just labels it: pick a v2-governed
+// plain month and show what v1 would have counted vs what v2 actually counts.
+const v2Month = months.find(
+  (m) => m.definition_version === "v2" && m.flags.length === 0
+);
+if (v2Month) {
+  console.log("\n=== Definition governs the number (not just the label) ===");
+  console.log(
+    `  ${v2Month.month}: raw ${v2Month.raw} counted under v1 would be ${v2Month.raw}; ` +
+      `under the v2 predicate the governed count is ${v2Month.adjusted}. ` +
+      `Same warehouse, different number — because the definition changed the WHERE.`
   );
 }
 
 console.log("\n=== Narrative ===");
-for (const line of composed.narrative.flagged_months) {
-  console.log(`  • ${line}`);
+for (const m of months) {
+  for (const f of m.flags) {
+    if (f.type === "data_incident") {
+      console.log(
+        `  • ${m.month}: raw ${m.raw} REPAIRED to ${m.adjusted} — ${f.event} ` +
+          `(${f.source}). Subtracted ${m.subtracted} artifact rows; the real ` +
+          `cancellations that month still stand.`
+      );
+    } else if (f.type === "definition_change") {
+      console.log(
+        `  • ${m.month}: definition moved to ${m.definition_version} — ${f.event} ` +
+          `(${f.source}). Post-boundary months are counted under the new predicate.`
+      );
+    } else {
+      console.log(
+        `  • ${m.month}: raw ${m.raw} genuinely elevated — ${f.event} ` +
+          `(${f.source}). Real but flagged; do not extrapolate.`
+      );
+    }
+  }
 }
-console.log(`\n${composed.narrative.summary}`);
+
+console.log(
+  "\nAdjusted churn is computed by letting the governed context drive the query: " +
+    "each month is counted under the definition version in effect, data-incident " +
+    "artifacts are subtracted (not nulled), and external shocks are kept but " +
+    "flagged. Every deviation cites its source of truth."
+);

--- a/examples/context-layer/scripts/compose.ts
+++ b/examples/context-layer/scripts/compose.ts
@@ -59,7 +59,7 @@ interface BusinessEvent {
   date: string;
   source: string;
   affected_metrics: string[];
-  adjustment: { op: string; cancel_reason?: string; value?: number } | null;
+  adjustment: { op: string; cancel_reason?: string } | null;
 }
 
 interface ContextLayer {
@@ -128,8 +128,11 @@ function versionPredicate(v: DefinitionVersion): string {
     const graceDays = Number(p.dunning_grace_days ?? 28);
     // A payment_failure cancelled within `graceDays` of its dunning start is a
     // retry-window artifact, not churn — exclude it. Everything else counts.
+    // NULL-safe: `IS DISTINCT FROM` keeps a NULL-reason cancellation counted (a
+    // plain `cancel_reason = 'x'` would go NULL → NOT NULL → the row silently
+    // dropped from the FILTER).
     return (
-      `NOT (cancel_reason = 'payment_failure' ` +
+      `NOT (cancel_reason IS NOT DISTINCT FROM 'payment_failure' ` +
       `AND dunning_started_at IS NOT NULL ` +
       `AND cancelled_at <= dunning_started_at + interval '${graceDays} days')`
     );
@@ -138,31 +141,58 @@ function versionPredicate(v: DefinitionVersion): string {
 }
 
 /**
- * The data-incident WHERE fragment: rows the structured `adjustment` says to
- * subtract are excluded from the adjusted count for the affected month. Only a
- * subtract_reason adjustment is derivable purely from the warehouse, so that is
- * what we apply here.
+ * A single data-incident's structured subtraction, keyed by BOTH the incident's
+ * month (from event_date) AND its cancel_reason. Only a subtract_reason
+ * adjustment is derivable purely from the warehouse, so that is what we apply.
  */
-function incidentReasons(
+interface IncidentAdjustment {
+  /** YYYY-MM the incident occurred in — the ONLY month its rows are subtracted from. */
+  month: string;
+  /** SQL string literal for the reason (already single-quoted + escaped). */
+  reasonLiteral: string;
+}
+
+function incidentAdjustments(
   events: BusinessEvent[],
   metricSlug: string
-): string[] {
+): IncidentAdjustment[] {
   return events
     .filter(
       (e) =>
         e.type === "data_incident" &&
         e.affected_metrics.includes(metricSlug) &&
         e.adjustment?.op === "subtract_reason" &&
-        e.adjustment.cancel_reason
+        e.adjustment.cancel_reason &&
+        e.date
     )
-    .map((e) => `'${String(e.adjustment!.cancel_reason).replace(/'/g, "''")}'`);
+    .map((e) => ({
+      month: String(e.date).slice(0, 7),
+      reasonLiteral: `'${String(e.adjustment!.cancel_reason).replace(/'/g, "''")}'`,
+    }));
+}
+
+/**
+ * A row is an "incident artifact" iff it falls in an incident's month AND
+ * carries that incident's cancel_reason. Keyed by month so a March incident
+ * only ever touches March — it does NOT subtract the reason from every month.
+ * NULL-safe via `IS NOT DISTINCT FROM`.
+ */
+function artifactPredicateSql(adjustments: IncidentAdjustment[]): string {
+  if (adjustments.length === 0) return "FALSE";
+  const clauses = adjustments.map(
+    (a) =>
+      `(to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '${a.month}' ` +
+      `AND cancel_reason IS NOT DISTINCT FROM ${a.reasonLiteral})`
+  );
+  return clauses.join(" OR ");
 }
 
 /**
  * Build ONE governed rollup SQL over the warehouse. Per month it returns:
  *   raw          — every cancellation (churn v1, no governance)
  *   adjusted     — counted under the version in effect for that month AND with
- *                  the data-incident rows subtracted (only the affected metric)
+ *                  the data-incident rows subtracted (only the affected metric,
+ *                  only the incident's own month)
  *   subtracted   — the count of exactly the incident-named rows (the artifacts).
  *                  Derived from the incident predicate alone, so it stays honest
  *                  even if an incident ever lands in a version-governed month
@@ -171,13 +201,13 @@ function incidentReasons(
  * so the SAME query counts pre-May months under v1 and post-May under v2.
  */
 function buildGovernedSql(ctx: ContextLayer): string {
-  const reasons = incidentReasons(ctx.events, ctx.metric_slug);
+  const adjustments = incidentAdjustments(ctx.events, ctx.metric_slug);
+  const artifactPredicate = artifactPredicateSql(adjustments);
+  // Keep everything that is NOT an incident artifact. `NOT (artifact)` is
+  // NULL-safe because artifactPredicate uses IS [NOT] DISTINCT FROM, so it is a
+  // total boolean (never NULL) — a NULL-reason row is simply not an artifact.
   const keepPredicate =
-    reasons.length === 0
-      ? "TRUE"
-      : `cancel_reason NOT IN (${reasons.join(", ")})`;
-  const artifactPredicate =
-    reasons.length === 0 ? "FALSE" : `cancel_reason IN (${reasons.join(", ")})`;
+    adjustments.length === 0 ? "TRUE" : `NOT (${artifactPredicate})`;
 
   const chrono = [...ctx.changelog].sort((a, b) =>
     a.effective_from.localeCompare(b.effective_from)

--- a/examples/context-layer/scripts/compose.ts
+++ b/examples/context-layer/scripts/compose.ts
@@ -37,36 +37,36 @@
  * Prereqs: `lobu run` is up here, and `seed:warehouse` + `seed` have run.
  */
 
-import { callTool, connectLocalGateway } from "./lib/gateway.ts";
 import { WAREHOUSE_CONNECTION_SLUG } from "./lib/env.ts";
+import { callTool, connectLocalGateway } from "./lib/gateway.ts";
 
 // ── Types shared between the two phases ────────────────────────────────────
 
 interface DefinitionVersion {
-  version: string;
-  effective_from: string;
-  definition: string;
-  is_current: boolean;
-  governing_predicate: {
-    exclude_payment_failure_in_grace?: boolean;
-    dunning_grace_days?: number;
-  } | null;
+	version: string;
+	effective_from: string;
+	definition: string;
+	is_current: boolean;
+	governing_predicate: {
+		exclude_payment_failure_in_grace?: boolean;
+		dunning_grace_days?: number;
+	} | null;
 }
 
 interface BusinessEvent {
-  event: string;
-  type: string;
-  date: string;
-  source: string;
-  affected_metrics: string[];
-  adjustment: { op: string; cancel_reason?: string } | null;
+	event: string;
+	type: string;
+	date: string;
+	source: string;
+	affected_metrics: string[];
+	adjustment: { op: string; cancel_reason?: string } | null;
 }
 
 interface ContextLayer {
-  metric: string;
-  metric_slug: string;
-  changelog: DefinitionVersion[];
-  events: BusinessEvent[];
+	metric: string;
+	metric_slug: string;
+	changelog: DefinitionVersion[];
+	events: BusinessEvent[];
 }
 
 /**
@@ -123,21 +123,21 @@ export default async (_ctx, client) => {
  * from `governing_predicate` — the definition literally governs the SQL.
  */
 function versionPredicate(v: DefinitionVersion): string {
-  const p = v.governing_predicate;
-  if (p?.exclude_payment_failure_in_grace) {
-    const graceDays = Number(p.dunning_grace_days ?? 28);
-    // A payment_failure cancelled within `graceDays` of its dunning start is a
-    // retry-window artifact, not churn — exclude it. Everything else counts.
-    // NULL-safe: `IS DISTINCT FROM` keeps a NULL-reason cancellation counted (a
-    // plain `cancel_reason = 'x'` would go NULL → NOT NULL → the row silently
-    // dropped from the FILTER).
-    return (
-      `NOT (cancel_reason IS NOT DISTINCT FROM 'payment_failure' ` +
-      `AND dunning_started_at IS NOT NULL ` +
-      `AND cancelled_at <= dunning_started_at + interval '${graceDays} days')`
-    );
-  }
-  return "TRUE"; // v1: every cancellation counts.
+	const p = v.governing_predicate;
+	if (p?.exclude_payment_failure_in_grace) {
+		const graceDays = Number(p.dunning_grace_days ?? 28);
+		// A payment_failure cancelled within `graceDays` of its dunning start is a
+		// retry-window artifact, not churn — exclude it. Everything else counts.
+		// NULL-safe: `IS DISTINCT FROM` keeps a NULL-reason cancellation counted (a
+		// plain `cancel_reason = 'x'` would go NULL → NOT NULL → the row silently
+		// dropped from the FILTER).
+		return (
+			`NOT (cancel_reason IS NOT DISTINCT FROM 'payment_failure' ` +
+			`AND dunning_started_at IS NOT NULL ` +
+			`AND cancelled_at <= dunning_started_at + interval '${graceDays} days')`
+		);
+	}
+	return "TRUE"; // v1: every cancellation counts.
 }
 
 /**
@@ -146,29 +146,29 @@ function versionPredicate(v: DefinitionVersion): string {
  * adjustment is derivable purely from the warehouse, so that is what we apply.
  */
 interface IncidentAdjustment {
-  /** YYYY-MM the incident occurred in — the ONLY month its rows are subtracted from. */
-  month: string;
-  /** SQL string literal for the reason (already single-quoted + escaped). */
-  reasonLiteral: string;
+	/** YYYY-MM the incident occurred in — the ONLY month its rows are subtracted from. */
+	month: string;
+	/** SQL string literal for the reason (already single-quoted + escaped). */
+	reasonLiteral: string;
 }
 
 function incidentAdjustments(
-  events: BusinessEvent[],
-  metricSlug: string
+	events: BusinessEvent[],
+	metricSlug: string,
 ): IncidentAdjustment[] {
-  return events
-    .filter(
-      (e) =>
-        e.type === "data_incident" &&
-        e.affected_metrics.includes(metricSlug) &&
-        e.adjustment?.op === "subtract_reason" &&
-        e.adjustment.cancel_reason &&
-        e.date
-    )
-    .map((e) => ({
-      month: String(e.date).slice(0, 7),
-      reasonLiteral: `'${String(e.adjustment!.cancel_reason).replace(/'/g, "''")}'`,
-    }));
+	return events
+		.filter(
+			(e) =>
+				e.type === "data_incident" &&
+				e.affected_metrics.includes(metricSlug) &&
+				e.adjustment?.op === "subtract_reason" &&
+				e.adjustment.cancel_reason &&
+				e.date,
+		)
+		.map((e) => ({
+			month: String(e.date).slice(0, 7),
+			reasonLiteral: `'${String(e.adjustment?.cancel_reason).replace(/'/g, "''")}'`,
+		}));
 }
 
 /**
@@ -178,13 +178,13 @@ function incidentAdjustments(
  * NULL-safe via `IS NOT DISTINCT FROM`.
  */
 function artifactPredicateSql(adjustments: IncidentAdjustment[]): string {
-  if (adjustments.length === 0) return "FALSE";
-  const clauses = adjustments.map(
-    (a) =>
-      `(to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '${a.month}' ` +
-      `AND cancel_reason IS NOT DISTINCT FROM ${a.reasonLiteral})`
-  );
-  return clauses.join(" OR ");
+	if (adjustments.length === 0) return "FALSE";
+	const clauses = adjustments.map(
+		(a) =>
+			`(to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '${a.month}' ` +
+			`AND cancel_reason IS NOT DISTINCT FROM ${a.reasonLiteral})`,
+	);
+	return clauses.join(" OR ");
 }
 
 /**
@@ -201,58 +201,64 @@ function artifactPredicateSql(adjustments: IncidentAdjustment[]): string {
  * so the SAME query counts pre-May months under v1 and post-May under v2.
  */
 function buildGovernedSql(ctx: ContextLayer): string {
-  const adjustments = incidentAdjustments(ctx.events, ctx.metric_slug);
-  const artifactPredicate = artifactPredicateSql(adjustments);
-  // Keep everything that is NOT an incident artifact. `NOT (artifact)` is
-  // NULL-safe because artifactPredicate uses IS [NOT] DISTINCT FROM, so it is a
-  // total boolean (never NULL) — a NULL-reason row is simply not an artifact.
-  const keepPredicate =
-    adjustments.length === 0 ? "TRUE" : `NOT (${artifactPredicate})`;
+	const adjustments = incidentAdjustments(ctx.events, ctx.metric_slug);
+	const artifactPredicate = artifactPredicateSql(adjustments);
+	// Keep everything that is NOT an incident artifact. `NOT (artifact)` is
+	// NULL-safe because artifactPredicate uses IS [NOT] DISTINCT FROM, so it is a
+	// total boolean (never NULL) — a NULL-reason row is simply not an artifact.
+	const keepPredicate =
+		adjustments.length === 0 ? "TRUE" : `NOT (${artifactPredicate})`;
 
-  const chrono = [...ctx.changelog].sort((a, b) =>
-    a.effective_from.localeCompare(b.effective_from)
-  );
-  // CASE arms newest-first: the first month-boundary that is <= the row's month
-  // wins, i.e. the version in effect. Falls through to the earliest version.
-  const arms = [...chrono]
-    .reverse()
-    .map(
-      (v) =>
-        `      WHEN to_char(date_trunc('month', cancelled_at), 'YYYY-MM') >= '${v.effective_from.slice(
-          0,
-          7
-        )}'\n        THEN (${versionPredicate(v)})`
-    )
-    .join("\n");
-  const fallback = versionPredicate(chrono[0]!);
+	const chrono = [...ctx.changelog].sort((a, b) =>
+		a.effective_from.localeCompare(b.effective_from),
+	);
+	const earliest = chrono[0];
+	if (!earliest) {
+		throw new Error(
+			"metric-definition has no versioned definition — run `bun run seed` first",
+		);
+	}
+	// CASE arms newest-first: the first month-boundary that is <= the row's month
+	// wins, i.e. the version in effect. Falls through to the earliest version.
+	const arms = [...chrono]
+		.reverse()
+		.map(
+			(v) =>
+				`      WHEN to_char(date_trunc('month', cancelled_at), 'YYYY-MM') >= '${v.effective_from.slice(
+					0,
+					7,
+				)}'\n        THEN (${versionPredicate(v)})`,
+		)
+		.join("\n");
+	const fallback = versionPredicate(earliest);
 
-  const governedExpr = `CASE\n${arms}\n      ELSE (${fallback})\n    END`;
+	const governedExpr = `CASE\n${arms}\n      ELSE (${fallback})\n    END`;
 
-  return (
-    `SELECT to_char(date_trunc('month', cancelled_at), 'YYYY-MM') AS month,\n` +
-    `       count(*)::int AS raw,\n` +
-    `       count(*) FILTER (\n` +
-    `         WHERE (${keepPredicate})\n` +
-    `           AND (${governedExpr})\n` +
-    `       )::int AS adjusted,\n` +
-    `       count(*) FILTER (WHERE ${artifactPredicate})::int AS subtracted\n` +
-    `  FROM subscriptions\n` +
-    ` WHERE cancelled_at IS NOT NULL\n` +
-    ` GROUP BY 1\n` +
-    ` ORDER BY 1`
-  );
+	return (
+		`SELECT to_char(date_trunc('month', cancelled_at), 'YYYY-MM') AS month,\n` +
+		`       count(*)::int AS raw,\n` +
+		`       count(*) FILTER (\n` +
+		`         WHERE (${keepPredicate})\n` +
+		`           AND (${governedExpr})\n` +
+		`       )::int AS adjusted,\n` +
+		`       count(*) FILTER (WHERE ${artifactPredicate})::int AS subtracted\n` +
+		`  FROM subscriptions\n` +
+		` WHERE cancelled_at IS NOT NULL\n` +
+		` GROUP BY 1\n` +
+		` ORDER BY 1`
+	);
 }
 
 // ── Compose ────────────────────────────────────────────────────────────────
 
 interface QuerySqlResult {
-  rows: Array<{
-    month: string;
-    raw: number;
-    adjusted: number;
-    subtracted: number;
-  }>;
-  error?: string;
+	rows: Array<{
+		month: string;
+		raw: number;
+		adjusted: number;
+		subtracted: number;
+	}>;
+	error?: string;
 }
 
 const gw = await connectLocalGateway();
@@ -260,121 +266,121 @@ console.log(`Connected to local gateway (org: ${gw.org})`);
 
 // Phase 1: the context layer.
 const ctxResult = await callTool<{
-  return_value?: ContextLayer;
-  success: boolean;
-  error?: { message: string };
+	return_value?: ContextLayer;
+	success: boolean;
+	error?: { message: string };
 }>(gw, "run_sdk", { script: CONTEXT_SCRIPT, timeout_ms: 60_000 });
 if (!ctxResult.success || !ctxResult.return_value) {
-  throw new Error(
-    `context read failed: ${ctxResult.error?.message ?? "unknown"}`
-  );
+	throw new Error(
+		`context read failed: ${ctxResult.error?.message ?? "unknown"}`,
+	);
 }
 const ctx = ctxResult.return_value;
 
 // Phase 2: GENERATE the governed SQL from that context, run it LIVE.
 const governedSql = buildGovernedSql(ctx);
 const live = await callTool<QuerySqlResult>(gw, "query_sql", {
-  connection: WAREHOUSE_CONNECTION_SLUG,
-  sql: governedSql,
+	connection: WAREHOUSE_CONNECTION_SLUG,
+	sql: governedSql,
 });
 if (live.error) {
-  throw new Error(`governed query failed: ${live.error}\n---\n${governedSql}`);
+	throw new Error(`governed query failed: ${live.error}\n---\n${governedSql}`);
 }
 const liveRows = live.rows;
 
 // Which definition version governs a given YYYY-MM month?
 const versionFor = (month: string): DefinitionVersion | undefined => {
-  let current = ctx.changelog[0];
-  for (const def of ctx.changelog) {
-    if (def.effective_from.slice(0, 7) <= month) current = def;
-  }
-  return current;
+	let current = ctx.changelog[0];
+	for (const def of ctx.changelog) {
+		if (def.effective_from.slice(0, 7) <= month) current = def;
+	}
+	return current;
 };
 
 // Join the live governed series with the business-event flags per month.
 const months = liveRows.map((row) => {
-  const month = row.month;
-  const flags = ctx.events
-    .filter((ev) => String(ev.date ?? "").slice(0, 7) === month)
-    .filter((ev) => ev.affected_metrics.includes(ctx.metric_slug))
-    .map((ev) => ({ event: ev.event, type: ev.type, source: ev.source }));
-  const gov = versionFor(month);
-  return {
-    month,
-    raw: row.raw,
-    adjusted: row.adjusted,
-    definition_version: gov?.version ?? null,
-    flags,
-    // Exactly the incident-named (artifact) rows for this month, straight from
-    // the warehouse — never derived as raw−adjusted, so a version-governed month
-    // can never inflate the "subtracted" figure.
-    subtracted: row.subtracted,
-  };
+	const month = row.month;
+	const flags = ctx.events
+		.filter((ev) => String(ev.date ?? "").slice(0, 7) === month)
+		.filter((ev) => ev.affected_metrics.includes(ctx.metric_slug))
+		.map((ev) => ({ event: ev.event, type: ev.type, source: ev.source }));
+	const gov = versionFor(month);
+	return {
+		month,
+		raw: row.raw,
+		adjusted: row.adjusted,
+		definition_version: gov?.version ?? null,
+		flags,
+		// Exactly the incident-named (artifact) rows for this month, straight from
+		// the warehouse — never derived as raw−adjusted, so a version-governed month
+		// can never inflate the "subtracted" figure.
+		subtracted: row.subtracted,
+	};
 });
 
 // ── Output ─────────────────────────────────────────────────────────────────
 
 console.log(`\n=== Adjusted churn for ${ctx.metric} ===\n`);
 console.table(
-  months.map((m) => ({
-    month: m.month,
-    raw: m.raw,
-    adjusted: m.adjusted,
-    def: m.definition_version,
-    flags: m.flags.map((f) => f.type).join(", ") || "",
-  }))
+	months.map((m) => ({
+		month: m.month,
+		raw: m.raw,
+		adjusted: m.adjusted,
+		def: m.definition_version,
+		flags: m.flags.map((f) => f.type).join(", ") || "",
+	})),
 );
 
 console.log("\n=== Definition changelog (governs the query) ===");
 for (const d of ctx.changelog) {
-  const pred = d.governing_predicate?.exclude_payment_failure_in_grace
-    ? ` [predicate: exclude payment_failure inside ${d.governing_predicate.dunning_grace_days}-day grace]`
-    : " [predicate: count every cancellation]";
-  console.log(
-    `  ${d.version} (from ${d.effective_from})${d.is_current ? " [current]" : ""}: ${d.definition}${pred}`
-  );
+	const pred = d.governing_predicate?.exclude_payment_failure_in_grace
+		? ` [predicate: exclude payment_failure inside ${d.governing_predicate.dunning_grace_days}-day grace]`
+		: " [predicate: count every cancellation]";
+	console.log(
+		`  ${d.version} (from ${d.effective_from})${d.is_current ? " [current]" : ""}: ${d.definition}${pred}`,
+	);
 }
 
 // Prove the definition MOVES the number, not just labels it: pick a v2-governed
 // plain month and show what v1 would have counted vs what v2 actually counts.
 const v2Month = months.find(
-  (m) => m.definition_version === "v2" && m.flags.length === 0
+	(m) => m.definition_version === "v2" && m.flags.length === 0,
 );
 if (v2Month) {
-  console.log("\n=== Definition governs the number (not just the label) ===");
-  console.log(
-    `  ${v2Month.month}: raw ${v2Month.raw} counted under v1 would be ${v2Month.raw}; ` +
-      `under the v2 predicate the governed count is ${v2Month.adjusted}. ` +
-      `Same warehouse, different number — because the definition changed the WHERE.`
-  );
+	console.log("\n=== Definition governs the number (not just the label) ===");
+	console.log(
+		`  ${v2Month.month}: raw ${v2Month.raw} counted under v1 would be ${v2Month.raw}; ` +
+			`under the v2 predicate the governed count is ${v2Month.adjusted}. ` +
+			`Same warehouse, different number — because the definition changed the WHERE.`,
+	);
 }
 
 console.log("\n=== Narrative ===");
 for (const m of months) {
-  for (const f of m.flags) {
-    if (f.type === "data_incident") {
-      console.log(
-        `  • ${m.month}: raw ${m.raw} REPAIRED to ${m.adjusted} — ${f.event} ` +
-          `(${f.source}). Subtracted ${m.subtracted} artifact rows; the real ` +
-          `cancellations that month still stand.`
-      );
-    } else if (f.type === "definition_change") {
-      console.log(
-        `  • ${m.month}: definition moved to ${m.definition_version} — ${f.event} ` +
-          `(${f.source}). Post-boundary months are counted under the new predicate.`
-      );
-    } else {
-      console.log(
-        `  • ${m.month}: raw ${m.raw} genuinely elevated — ${f.event} ` +
-          `(${f.source}). Real but flagged; do not extrapolate.`
-      );
-    }
-  }
+	for (const f of m.flags) {
+		if (f.type === "data_incident") {
+			console.log(
+				`  • ${m.month}: raw ${m.raw} REPAIRED to ${m.adjusted} — ${f.event} ` +
+					`(${f.source}). Subtracted ${m.subtracted} artifact rows; the real ` +
+					`cancellations that month still stand.`,
+			);
+		} else if (f.type === "definition_change") {
+			console.log(
+				`  • ${m.month}: definition moved to ${m.definition_version} — ${f.event} ` +
+					`(${f.source}). Post-boundary months are counted under the new predicate.`,
+			);
+		} else {
+			console.log(
+				`  • ${m.month}: raw ${m.raw} genuinely elevated — ${f.event} ` +
+					`(${f.source}). Real but flagged; do not extrapolate.`,
+			);
+		}
+	}
 }
 
 console.log(
-  "\nAdjusted churn is computed by letting the governed context drive the query: " +
-    "each month is counted under the definition version in effect, data-incident " +
-    "artifacts are subtracted (not nulled), and external shocks are kept but " +
-    "flagged. Every deviation cites its source of truth."
+	"\nAdjusted churn is computed by letting the governed context drive the query: " +
+		"each month is counted under the definition version in effect, data-incident " +
+		"artifacts are subtracted (not nulled), and external shocks are kept but " +
+		"flagged. Every deviation cites its source of truth.",
 );

--- a/examples/context-layer/scripts/eval.ts
+++ b/examples/context-layer/scripts/eval.ts
@@ -132,7 +132,7 @@ interface ChatOutcome {
   noModel: boolean;
 }
 
-function runAgentTurn(prompt: string): ChatOutcome {
+function runAgentTurn(gw: Gateway, prompt: string): ChatOutcome {
   const res = spawnSync(
     "bunx",
     [
@@ -140,10 +140,12 @@ function runAgentTurn(prompt: string): ChatOutcome {
       "chat",
       "--agent",
       AGENT_ID,
+      // Thread the SAME gateway URL + org the scripts connected to (honors the
+      // documented LOBU_URL override), instead of hardcoding a default.
       "--gateway",
-      "http://127.0.0.1:8787",
+      gw.base,
       "--org",
-      "local-install",
+      gw.org,
       "--json",
       "--auto-approve",
       "--new",
@@ -165,7 +167,6 @@ function runAgentTurn(prompt: string): ChatOutcome {
         text?: string;
         content?: string;
         delta?: string;
-        message?: { content?: unknown };
       };
       // No-model shows up two ways depending on the gateway path: a typed
       // `errorCode: NO_MODEL_CONFIGURED`, OR a plain error event whose message
@@ -193,22 +194,32 @@ function runAgentTurn(prompt: string): ChatOutcome {
 }
 
 // ── Assertions ─────────────────────────────────────────────────────────────
+//
+// Two SEPARATE signals, deliberately not folded into one. A context-aware
+// answer must show BOTH; the baseline must show NEITHER. Folding them would let
+// a one-sided answer (cites the migration but never corrects the number, or
+// vice-versa) slip through and the PASS would no longer prove the context
+// changed the answer.
 
-/** A "context-aware" answer cites the migration and corrects the number. */
+/** Does the answer cite the billing-migration cause / its source? */
 function citesMigration(answer: string): boolean {
   const a = answer.toLowerCase();
-  const mentionsMigration =
+  return (
     a.includes("migration") ||
     a.includes("data-142") ||
     a.includes("artifact") ||
-    a.includes(MIGRATION_SOURCE.toLowerCase());
+    a.includes(MIGRATION_SOURCE.toLowerCase())
+  );
+}
+
+/** Does the answer give the corrected March number (~50, not the raw 550)? */
+function correctsNumber(answer: string): boolean {
   // Match the corrected number as a WHOLE number token — a bare `includes("50")`
   // would also match inside the raw "550", so an answer that only ever repeats
   // 550 would be scored as if it had corrected to 50. Require ADJUSTED_MARCH to
   // appear with non-digit boundaries on both sides.
   const correctedToken = new RegExp(`(?:^|\\D)${ADJUSTED_MARCH}(?:\\D|$)`);
-  const corrects = correctedToken.test(a);
-  return mentionsMigration && corrects;
+  return correctedToken.test(answer.toLowerCase());
 }
 
 // ── Run ─────────────────────────────────────────────────────────────────────
@@ -232,7 +243,7 @@ const baseBlock = baselineBlock(march);
 
 // Probe: is a model wired up? One throwaway turn tells us.
 console.log("\nProbing for a configured model provider…");
-const probe = runAgentTurn("Reply with the single word READY.");
+const probe = runAgentTurn(gw, "Reply with the single word READY.");
 
 let withAnswer: string;
 let baseAnswer: string;
@@ -260,28 +271,34 @@ if (probe.noModel) {
   mode = "live-agent";
   console.log("Model provider detected — running two REAL agent turns.\n");
   withAnswer = runAgentTurn(
+    gw,
     `${withBlock}\n\nQuestion: ${QUESTION}\n` +
       "Use the governed context above. Cite the source and give the corrected number."
   ).text;
-  baseAnswer = runAgentTurn(`${baseBlock}\n\nQuestion: ${QUESTION}`).text;
+  baseAnswer = runAgentTurn(gw, `${baseBlock}\n\nQuestion: ${QUESTION}`).text;
 }
 
 // ── Assert + report ──────────────────────────────────────────────────────────
 
-const withPass = citesMigration(withAnswer);
-const basePass = !citesMigration(baseAnswer);
+// WITH context must show BOTH signals; the baseline must show NEITHER.
+const withCites = citesMigration(withAnswer);
+const withCorrects = correctsNumber(withAnswer);
+const withPass = withCites && withCorrects;
+const baseCites = citesMigration(baseAnswer);
+const baseCorrects = correctsNumber(baseAnswer);
+const basePass = !baseCites && !baseCorrects;
 const pass = withPass && basePass;
 
 console.log(`=== Agent eval (${mode}) ===\n`);
 console.log("(A) WITH context layer:");
 console.log(indent(withAnswer));
 console.log(
-  `\n  → cites migration + corrects to ~${ADJUSTED_MARCH}? ${withPass ? "YES ✅" : "NO ❌"}`
+  `\n  → cites migration? ${withCites ? "YES" : "NO"}; corrects to ~${ADJUSTED_MARCH}? ${withCorrects ? "YES" : "NO"} ⇒ ${withPass ? "PASS ✅" : "FAIL ❌"}`
 );
 console.log("\n(B) WITHOUT context layer (baseline):");
 console.log(indent(baseAnswer));
 console.log(
-  `\n  → correctly LACKS the governed correction? ${basePass ? "YES ✅" : "NO ❌"}`
+  `\n  → cites migration? ${baseCites ? "YES" : "NO"}; corrects the number? ${baseCorrects ? "YES" : "NO"} ⇒ correctly has neither? ${basePass ? "PASS ✅" : "FAIL ❌"}`
 );
 
 console.log(

--- a/examples/context-layer/scripts/eval.ts
+++ b/examples/context-layer/scripts/eval.ts
@@ -41,7 +41,11 @@ import { callTool, connectLocalGateway, type Gateway } from "./lib/gateway.ts";
 
 const QUESTION =
   "Churn spiked to 550 in March 2026. Is that real, and what should the number be?";
-const AGENT_ID = "analyst";
+const WITH_AGENT_ID = "analyst";
+// The baseline agent is declared in lobu.config.ts with tools:{allowed:[],
+// strict:true} — it cannot retrieve business-event context, so the WITHOUT arm
+// is genuinely context-free, not just prompt-stripped.
+const BASELINE_AGENT_ID = "baseline";
 const RAW_MARCH = 550;
 const ADJUSTED_MARCH = 50;
 const MIGRATION_SOURCE = "https://linear.app/kelder/issue/DATA-142";
@@ -135,14 +139,18 @@ interface ChatOutcome {
   noModel: boolean;
 }
 
-function runAgentTurn(gw: Gateway, prompt: string): ChatOutcome {
+function runAgentTurn(
+  gw: Gateway,
+  agentId: string,
+  prompt: string
+): ChatOutcome {
   const res = spawnSync(
     "bunx",
     [
       "@lobu/cli",
       "chat",
       "--agent",
-      AGENT_ID,
+      agentId,
       // Thread the SAME gateway URL + org the scripts connected to (honors the
       // documented LOBU_URL override), instead of hardcoding a default.
       "--gateway",
@@ -246,7 +254,11 @@ const baseBlock = baselineBlock(march);
 
 // Probe: is a model wired up? One throwaway turn tells us.
 console.log("\nProbing for a configured model provider…");
-const probe = runAgentTurn(gw, "Reply with the single word READY.");
+const probe = runAgentTurn(
+  gw,
+  WITH_AGENT_ID,
+  "Reply with the single word READY."
+);
 
 let withAnswer: string;
 let baseAnswer: string;
@@ -272,21 +284,21 @@ if (probe.noModel) {
   // ── Real agent: two live turns ───────────────────────────────────────────
   mode = "live-agent";
   console.log("Model provider detected — running two REAL agent turns.\n");
-  // CAVEAT (honest limitation): both arms hit the SAME `analyst` agent, whose
-  // lobu.config.ts prompt instructs it to consult business-event records and
-  // whose tools can reach them. So the baseline arm is only prompt-isolated
-  // (no context in the message) — a tool-enabled agent could still retrieve the
-  // withheld context itself, which weakens the isolation. A fully isolated live
-  // eval needs a SECOND agent with no memory/business-event tools (same model +
-  // settings). `lobu chat` has no per-turn tool-strip flag today, so that agent
-  // is owed alongside wiring a provider. The deterministic proxy above does not
-  // have this gap: it asserts on the exact context bundle each arm would push.
+  // Isolation is real: the WITH arm runs the `analyst` (governed context in the
+  // prompt), the WITHOUT arm runs the `baseline` agent, declared in
+  // lobu.config.ts with tools:{allowed:[],strict:true} so it CANNOT retrieve the
+  // withheld context. Same model/settings, only the context differs.
   withAnswer = runAgentTurn(
     gw,
+    WITH_AGENT_ID,
     `${withBlock}\n\nQuestion: ${QUESTION}\n` +
       "Use the governed context above. Cite the source and give the corrected number."
   ).text;
-  baseAnswer = runAgentTurn(gw, `${baseBlock}\n\nQuestion: ${QUESTION}`).text;
+  baseAnswer = runAgentTurn(
+    gw,
+    BASELINE_AGENT_ID,
+    `${baseBlock}\n\nQuestion: ${QUESTION}`
+  ).text;
 }
 
 // ── Assert + report ──────────────────────────────────────────────────────────

--- a/examples/context-layer/scripts/eval.ts
+++ b/examples/context-layer/scripts/eval.ts
@@ -85,7 +85,10 @@ async function warehouseMarch(
     connection: WAREHOUSE_CONNECTION_SLUG,
     sql:
       "SELECT count(*)::int AS raw, " +
-      "count(*) FILTER (WHERE cancel_reason <> 'billing_migration_artifact')::int AS adjusted " +
+      // NULL-safe: `IS DISTINCT FROM` keeps a NULL-reason cancellation in the
+      // repaired count (a plain `<>` would go NULL → dropped from the FILTER),
+      // matching compose.ts's artifact predicate.
+      "count(*) FILTER (WHERE cancel_reason IS DISTINCT FROM 'billing_migration_artifact')::int AS adjusted " +
       "FROM subscriptions WHERE cancelled_at IS NOT NULL " +
       "AND to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '2026-03'",
   });
@@ -269,6 +272,15 @@ if (probe.noModel) {
   // ── Real agent: two live turns ───────────────────────────────────────────
   mode = "live-agent";
   console.log("Model provider detected — running two REAL agent turns.\n");
+  // CAVEAT (honest limitation): both arms hit the SAME `analyst` agent, whose
+  // lobu.config.ts prompt instructs it to consult business-event records and
+  // whose tools can reach them. So the baseline arm is only prompt-isolated
+  // (no context in the message) — a tool-enabled agent could still retrieve the
+  // withheld context itself, which weakens the isolation. A fully isolated live
+  // eval needs a SECOND agent with no memory/business-event tools (same model +
+  // settings). `lobu chat` has no per-turn tool-strip flag today, so that agent
+  // is owed alongside wiring a provider. The deterministic proxy above does not
+  // have this gap: it asserts on the exact context bundle each arm would push.
   withAnswer = runAgentTurn(
     gw,
     `${withBlock}\n\nQuestion: ${QUESTION}\n` +

--- a/examples/context-layer/scripts/eval.ts
+++ b/examples/context-layer/scripts/eval.ts
@@ -40,7 +40,7 @@ import { WAREHOUSE_CONNECTION_SLUG } from "./lib/env.ts";
 import { callTool, connectLocalGateway, type Gateway } from "./lib/gateway.ts";
 
 const QUESTION =
-	"Churn spiked to 550 in March 2026. Is that real, and what should the number be?";
+  "Churn spiked to 550 in March 2026. Is that real, and what should the number be?";
 const AGENT_ID = "analyst";
 const RAW_MARCH = 550;
 const ADJUSTED_MARCH = 50;
@@ -49,13 +49,13 @@ const MIGRATION_SOURCE = "https://linear.app/kelder/issue/DATA-142";
 // ── Pull the governed context out of the running gateway ───────────────────
 
 interface BusinessEvent {
-	event: string;
-	type: string;
-	date: string;
-	source: string;
-	affected_metrics: string[];
-	expected_effect: string;
-	adjustment: { op: string; cancel_reason?: string } | null;
+  event: string;
+  type: string;
+  date: string;
+  source: string;
+  affected_metrics: string[];
+  expected_effect: string;
+  adjustment: { op: string; cancel_reason?: string } | null;
 }
 
 const CONTEXT_SCRIPT = `
@@ -76,121 +76,121 @@ export default async (_ctx, client) => {
 
 /** The live raw + repaired March numbers, straight from the warehouse. */
 async function warehouseMarch(
-	gw: Gateway,
+  gw: Gateway
 ): Promise<{ raw: number; adjusted: number }> {
-	const res = await callTool<{
-		rows: Array<{ raw: number; adjusted: number }>;
-		error?: string;
-	}>(gw, "query_sql", {
-		connection: WAREHOUSE_CONNECTION_SLUG,
-		sql:
-			"SELECT count(*)::int AS raw, " +
-			"count(*) FILTER (WHERE cancel_reason <> 'billing_migration_artifact')::int AS adjusted " +
-			"FROM subscriptions WHERE cancelled_at IS NOT NULL " +
-			"AND to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '2026-03'",
-	});
-	if (res.error) throw new Error(`warehouse read failed: ${res.error}`);
-	return res.rows[0] ?? { raw: RAW_MARCH, adjusted: ADJUSTED_MARCH };
+  const res = await callTool<{
+    rows: Array<{ raw: number; adjusted: number }>;
+    error?: string;
+  }>(gw, "query_sql", {
+    connection: WAREHOUSE_CONNECTION_SLUG,
+    sql:
+      "SELECT count(*)::int AS raw, " +
+      "count(*) FILTER (WHERE cancel_reason <> 'billing_migration_artifact')::int AS adjusted " +
+      "FROM subscriptions WHERE cancelled_at IS NOT NULL " +
+      "AND to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '2026-03'",
+  });
+  if (res.error) throw new Error(`warehouse read failed: ${res.error}`);
+  return res.rows[0] ?? { raw: RAW_MARCH, adjusted: ADJUSTED_MARCH };
 }
 
 /** Build the context block pushed to the agent in the WITH arm. */
 function withContextBlock(
-	events: BusinessEvent[],
-	march: {
-		raw: number;
-		adjusted: number;
-	},
+  events: BusinessEvent[],
+  march: {
+    raw: number;
+    adjusted: number;
+  }
 ): string {
-	const relevant = events.filter((e) =>
-		e.affected_metrics.includes("churn_rate"),
-	);
-	const lines = relevant.map(
-		(e) =>
-			`- [${e.type}] ${e.event} (on ${e.date}, source ${e.source})\n` +
-			`    ${e.expected_effect}` +
-			(e.adjustment
-				? `\n    structured adjustment: ${JSON.stringify(e.adjustment)}`
-				: ""),
-	);
-	return (
-		"GOVERNED CONTEXT (business events affecting churn_rate):\n" +
-		lines.join("\n") +
-		`\n\nComposed adjusted series for 2026-03: raw ${march.raw}, ` +
-		`adjusted ${march.adjusted} (billing_migration_artifact rows subtracted).`
-	);
+  const relevant = events.filter((e) =>
+    e.affected_metrics.includes("churn_rate")
+  );
+  const lines = relevant.map(
+    (e) =>
+      `- [${e.type}] ${e.event} (on ${e.date}, source ${e.source})\n` +
+      `    ${e.expected_effect}` +
+      (e.adjustment
+        ? `\n    structured adjustment: ${JSON.stringify(e.adjustment)}`
+        : "")
+  );
+  return (
+    "GOVERNED CONTEXT (business events affecting churn_rate):\n" +
+    lines.join("\n") +
+    `\n\nComposed adjusted series for 2026-03: raw ${march.raw}, ` +
+    `adjusted ${march.adjusted} (billing_migration_artifact rows subtracted).`
+  );
 }
 
 /** Baseline arm: raw number only, no governed context. */
 function baselineBlock(march: { raw: number }): string {
-	return `The warehouse reports ${march.raw} cancellations for 2026-03. No other context is available.`;
+  return `The warehouse reports ${march.raw} cancellations for 2026-03. No other context is available.`;
 }
 
 // ── Real-agent turn via `lobu chat` (used when a model provider is wired) ───
 
 interface ChatOutcome {
-	text: string;
-	noModel: boolean;
+  text: string;
+  noModel: boolean;
 }
 
 function runAgentTurn(gw: Gateway, prompt: string): ChatOutcome {
-	const res = spawnSync(
-		"bunx",
-		[
-			"@lobu/cli",
-			"chat",
-			"--agent",
-			AGENT_ID,
-			// Thread the SAME gateway URL + org the scripts connected to (honors the
-			// documented LOBU_URL override), instead of hardcoding a default.
-			"--gateway",
-			gw.base,
-			"--org",
-			gw.org,
-			"--json",
-			"--auto-approve",
-			"--new",
-			prompt,
-		],
-		{ encoding: "utf8", timeout: 180_000 },
-	);
-	const out = `${res.stdout ?? ""}\n${res.stderr ?? ""}`;
-	let text = "";
-	let noModel = false;
-	for (const line of out.split("\n")) {
-		const trimmed = line.trim();
-		if (!trimmed.startsWith("{")) continue;
-		try {
-			const ev = JSON.parse(trimmed) as {
-				event?: string;
-				errorCode?: string;
-				error?: string;
-				text?: string;
-				content?: string;
-				delta?: string;
-			};
-			// No-model shows up two ways depending on the gateway path: a typed
-			// `errorCode: NO_MODEL_CONFIGURED`, OR a plain error event whose message
-			// is "No model resolved for this run…" (no errorCode). Match BOTH — a
-			// false negative here sends the eval down the live path and reports a
-			// misleading FAIL (empty answers) instead of the honest proxy fallback.
-			if (
-				ev.errorCode === "NO_MODEL_CONFIGURED" ||
-				(ev.event === "error" && /no model/i.test(ev.error ?? ""))
-			) {
-				noModel = true;
-			}
-			// Accumulate any assistant text the stream carries; the exact field name
-			// varies by event kind, so pull whichever text-bearing field is present.
-			const chunk =
-				(typeof ev.text === "string" ? ev.text : "") ||
-				(typeof ev.content === "string" ? ev.content : "") ||
-				(typeof ev.delta === "string" ? ev.delta : "");
-			if (chunk) text += chunk;
-		} catch {
-			// non-JSON line (dependency-resolution noise) — ignore
-		}
-	}
-	return { text: text.trim(), noModel };
+  const res = spawnSync(
+    "bunx",
+    [
+      "@lobu/cli",
+      "chat",
+      "--agent",
+      AGENT_ID,
+      // Thread the SAME gateway URL + org the scripts connected to (honors the
+      // documented LOBU_URL override), instead of hardcoding a default.
+      "--gateway",
+      gw.base,
+      "--org",
+      gw.org,
+      "--json",
+      "--auto-approve",
+      "--new",
+      prompt,
+    ],
+    { encoding: "utf8", timeout: 180_000 }
+  );
+  const out = `${res.stdout ?? ""}\n${res.stderr ?? ""}`;
+  let text = "";
+  let noModel = false;
+  for (const line of out.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try {
+      const ev = JSON.parse(trimmed) as {
+        event?: string;
+        errorCode?: string;
+        error?: string;
+        text?: string;
+        content?: string;
+        delta?: string;
+      };
+      // No-model shows up two ways depending on the gateway path: a typed
+      // `errorCode: NO_MODEL_CONFIGURED`, OR a plain error event whose message
+      // is "No model resolved for this run…" (no errorCode). Match BOTH — a
+      // false negative here sends the eval down the live path and reports a
+      // misleading FAIL (empty answers) instead of the honest proxy fallback.
+      if (
+        ev.errorCode === "NO_MODEL_CONFIGURED" ||
+        (ev.event === "error" && /no model/i.test(ev.error ?? ""))
+      ) {
+        noModel = true;
+      }
+      // Accumulate any assistant text the stream carries; the exact field name
+      // varies by event kind, so pull whichever text-bearing field is present.
+      const chunk =
+        (typeof ev.text === "string" ? ev.text : "") ||
+        (typeof ev.content === "string" ? ev.content : "") ||
+        (typeof ev.delta === "string" ? ev.delta : "");
+      if (chunk) text += chunk;
+    } catch {
+      // non-JSON line (dependency-resolution noise) — ignore
+    }
+  }
+  return { text: text.trim(), noModel };
 }
 
 // ── Assertions ─────────────────────────────────────────────────────────────
@@ -203,23 +203,23 @@ function runAgentTurn(gw: Gateway, prompt: string): ChatOutcome {
 
 /** Does the answer cite the billing-migration cause / its source? */
 function citesMigration(answer: string): boolean {
-	const a = answer.toLowerCase();
-	return (
-		a.includes("migration") ||
-		a.includes("data-142") ||
-		a.includes("artifact") ||
-		a.includes(MIGRATION_SOURCE.toLowerCase())
-	);
+  const a = answer.toLowerCase();
+  return (
+    a.includes("migration") ||
+    a.includes("data-142") ||
+    a.includes("artifact") ||
+    a.includes(MIGRATION_SOURCE.toLowerCase())
+  );
 }
 
 /** Does the answer give the corrected March number (~50, not the raw 550)? */
 function correctsNumber(answer: string): boolean {
-	// Match the corrected number as a WHOLE number token — a bare `includes("50")`
-	// would also match inside the raw "550", so an answer that only ever repeats
-	// 550 would be scored as if it had corrected to 50. Require ADJUSTED_MARCH to
-	// appear with non-digit boundaries on both sides.
-	const correctedToken = new RegExp(`(?:^|\\D)${ADJUSTED_MARCH}(?:\\D|$)`);
-	return correctedToken.test(answer.toLowerCase());
+  // Match the corrected number as a WHOLE number token — a bare `includes("50")`
+  // would also match inside the raw "550", so an answer that only ever repeats
+  // 550 would be scored as if it had corrected to 50. Require ADJUSTED_MARCH to
+  // appear with non-digit boundaries on both sides.
+  const correctedToken = new RegExp(`(?:^|\\D)${ADJUSTED_MARCH}(?:\\D|$)`);
+  return correctedToken.test(answer.toLowerCase());
 }
 
 // ── Run ─────────────────────────────────────────────────────────────────────
@@ -228,12 +228,12 @@ const gw = await connectLocalGateway();
 console.log(`Connected to local gateway (org: ${gw.org})`);
 
 const ctxRes = await callTool<{
-	return_value?: { events: BusinessEvent[] };
-	success: boolean;
-	error?: { message: string };
+  return_value?: { events: BusinessEvent[] };
+  success: boolean;
+  error?: { message: string };
 }>(gw, "run_sdk", { script: CONTEXT_SCRIPT, timeout_ms: 60_000 });
 if (!ctxRes.success || !ctxRes.return_value) {
-	throw new Error(`context read failed: ${ctxRes.error?.message ?? "unknown"}`);
+  throw new Error(`context read failed: ${ctxRes.error?.message ?? "unknown"}`);
 }
 const events = ctxRes.return_value.events;
 const march = await warehouseMarch(gw);
@@ -250,31 +250,31 @@ let baseAnswer: string;
 let mode: "live-agent" | "deterministic-proxy";
 
 if (probe.noModel) {
-	// ── Fallback: deterministic proxy ────────────────────────────────────────
-	mode = "deterministic-proxy";
-	console.log(
-		"No model provider configured on this local install — the gateway cannot\n" +
-			"run a live model (this is expected for a throwaway `lobu run`). Falling\n" +
-			"back to the DETERMINISTIC PROXY: assert on the exact context bundle that\n" +
-			"WOULD be pushed to the agent in each arm.\n",
-	);
-	// The proxy asserts on the RAW context bundle each arm would push — no
-	// fabricated answer. If the WITH block genuinely carries the migration source
-	// and the adjusted number, it passes; if the composition ever stops emitting
-	// them, it fails. (Appending a hand-written "an agent would say…" answer would
-	// rig the assertion to pass regardless of what the context actually contains.)
-	withAnswer = withBlock;
-	baseAnswer = baseBlock;
+  // ── Fallback: deterministic proxy ────────────────────────────────────────
+  mode = "deterministic-proxy";
+  console.log(
+    "No model provider configured on this local install — the gateway cannot\n" +
+      "run a live model (this is expected for a throwaway `lobu run`). Falling\n" +
+      "back to the DETERMINISTIC PROXY: assert on the exact context bundle that\n" +
+      "WOULD be pushed to the agent in each arm.\n"
+  );
+  // The proxy asserts on the RAW context bundle each arm would push — no
+  // fabricated answer. If the WITH block genuinely carries the migration source
+  // and the adjusted number, it passes; if the composition ever stops emitting
+  // them, it fails. (Appending a hand-written "an agent would say…" answer would
+  // rig the assertion to pass regardless of what the context actually contains.)
+  withAnswer = withBlock;
+  baseAnswer = baseBlock;
 } else {
-	// ── Real agent: two live turns ───────────────────────────────────────────
-	mode = "live-agent";
-	console.log("Model provider detected — running two REAL agent turns.\n");
-	withAnswer = runAgentTurn(
-		gw,
-		`${withBlock}\n\nQuestion: ${QUESTION}\n` +
-			"Use the governed context above. Cite the source and give the corrected number.",
-	).text;
-	baseAnswer = runAgentTurn(gw, `${baseBlock}\n\nQuestion: ${QUESTION}`).text;
+  // ── Real agent: two live turns ───────────────────────────────────────────
+  mode = "live-agent";
+  console.log("Model provider detected — running two REAL agent turns.\n");
+  withAnswer = runAgentTurn(
+    gw,
+    `${withBlock}\n\nQuestion: ${QUESTION}\n` +
+      "Use the governed context above. Cite the source and give the corrected number."
+  ).text;
+  baseAnswer = runAgentTurn(gw, `${baseBlock}\n\nQuestion: ${QUESTION}`).text;
 }
 
 // ── Assert + report ──────────────────────────────────────────────────────────
@@ -292,32 +292,32 @@ console.log(`=== Agent eval (${mode}) ===\n`);
 console.log("(A) WITH context layer:");
 console.log(indent(withAnswer));
 console.log(
-	`\n  → cites migration? ${withCites ? "YES" : "NO"}; corrects to ~${ADJUSTED_MARCH}? ${withCorrects ? "YES" : "NO"} ⇒ ${withPass ? "PASS ✅" : "FAIL ❌"}`,
+  `\n  → cites migration? ${withCites ? "YES" : "NO"}; corrects to ~${ADJUSTED_MARCH}? ${withCorrects ? "YES" : "NO"} ⇒ ${withPass ? "PASS ✅" : "FAIL ❌"}`
 );
 console.log("\n(B) WITHOUT context layer (baseline):");
 console.log(indent(baseAnswer));
 console.log(
-	`\n  → cites migration? ${baseCites ? "YES" : "NO"}; corrects the number? ${baseCorrects ? "YES" : "NO"} ⇒ correctly has neither? ${basePass ? "PASS ✅" : "FAIL ❌"}`,
+  `\n  → cites migration? ${baseCites ? "YES" : "NO"}; corrects the number? ${baseCorrects ? "YES" : "NO"} ⇒ correctly has neither? ${basePass ? "PASS ✅" : "FAIL ❌"}`
 );
 
 console.log(
-	`\n${pass ? "PASS ✅" : "FAIL ❌"} — pushing the context layer ${
-		pass ? "changed" : "did NOT change"
-	} the answer.`,
+  `\n${pass ? "PASS ✅" : "FAIL ❌"} — pushing the context layer ${
+    pass ? "changed" : "did NOT change"
+  } the answer.`
 );
 if (mode === "deterministic-proxy") {
-	console.log(
-		"\n(This was the deterministic proxy: it proves the pushed context contains " +
-			"the governed correction and the baseline does not. Wire a model provider " +
-			"via `lobu agents inference-providers` and re-run for the live-agent eval.)",
-	);
+  console.log(
+    "\n(This was the deterministic proxy: it proves the pushed context contains " +
+      "the governed correction and the baseline does not. Wire a model provider " +
+      "via `lobu agents inference-providers` and re-run for the live-agent eval.)"
+  );
 }
 
 if (!pass) process.exitCode = 1;
 
 function indent(s: string): string {
-	return s
-		.split("\n")
-		.map((l) => `    ${l}`)
-		.join("\n");
+  return s
+    .split("\n")
+    .map((l) => `    ${l}`)
+    .join("\n");
 }

--- a/examples/context-layer/scripts/eval.ts
+++ b/examples/context-layer/scripts/eval.ts
@@ -161,12 +161,23 @@ function runAgentTurn(prompt: string): ChatOutcome {
       const ev = JSON.parse(trimmed) as {
         event?: string;
         errorCode?: string;
+        error?: string;
         text?: string;
         content?: string;
         delta?: string;
         message?: { content?: unknown };
       };
-      if (ev.errorCode === "NO_MODEL_CONFIGURED") noModel = true;
+      // No-model shows up two ways depending on the gateway path: a typed
+      // `errorCode: NO_MODEL_CONFIGURED`, OR a plain error event whose message
+      // is "No model resolved for this run…" (no errorCode). Match BOTH — a
+      // false negative here sends the eval down the live path and reports a
+      // misleading FAIL (empty answers) instead of the honest proxy fallback.
+      if (
+        ev.errorCode === "NO_MODEL_CONFIGURED" ||
+        (ev.event === "error" && /no model/i.test(ev.error ?? ""))
+      ) {
+        noModel = true;
+      }
       // Accumulate any assistant text the stream carries; the exact field name
       // varies by event kind, so pull whichever text-bearing field is present.
       const chunk =

--- a/examples/context-layer/scripts/eval.ts
+++ b/examples/context-layer/scripts/eval.ts
@@ -46,7 +46,6 @@ const WITH_AGENT_ID = "analyst";
 // strict:true} — it cannot retrieve business-event context, so the WITHOUT arm
 // is genuinely context-free, not just prompt-stripped.
 const BASELINE_AGENT_ID = "baseline";
-const RAW_MARCH = 550;
 const ADJUSTED_MARCH = 50;
 const MIGRATION_SOURCE = "https://linear.app/kelder/issue/DATA-142";
 
@@ -97,7 +96,16 @@ async function warehouseMarch(
       "AND to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '2026-03'",
   });
   if (res.error) throw new Error(`warehouse read failed: ${res.error}`);
-  return res.rows[0] ?? { raw: RAW_MARCH, adjusted: ADJUSTED_MARCH };
+  const row = res.rows[0];
+  if (!row) {
+    // No row = the rollup found no March cancellations, which means the seed
+    // didn't run (or the warehouse is empty). Fail loudly rather than fabricate
+    // the expected 550/50 and pass on data that isn't there.
+    throw new Error(
+      "warehouse returned no March row — run `bun run seed:warehouse` first"
+    );
+  }
+  return row;
 }
 
 /** Build the context block pushed to the agent in the WITH arm. */
@@ -212,15 +220,16 @@ function runAgentTurn(
 // vice-versa) slip through and the PASS would no longer prove the context
 // changed the answer.
 
-/** Does the answer cite the billing-migration cause / its source? */
+/**
+ * Does the answer cite the GOVERNED source, not just any plausible cause? We
+ * require the incident's identifier (DATA-142) or its exact source URL — a bare
+ * "migration"/"artifact" could be the model guessing, which would NOT prove it
+ * used the pushed record. The whole point is that the context, not a lucky
+ * guess, produced the answer.
+ */
 function citesMigration(answer: string): boolean {
   const a = answer.toLowerCase();
-  return (
-    a.includes("migration") ||
-    a.includes("data-142") ||
-    a.includes("artifact") ||
-    a.includes(MIGRATION_SOURCE.toLowerCase())
-  );
+  return a.includes("data-142") || a.includes(MIGRATION_SOURCE.toLowerCase());
 }
 
 /** Does the answer give the corrected March number (~50, not the raw 550)? */

--- a/examples/context-layer/scripts/eval.ts
+++ b/examples/context-layer/scripts/eval.ts
@@ -1,0 +1,296 @@
+/**
+ * AGENT EVAL — does the context layer change the answer?
+ *
+ * The whole premise of a context layer is that pushing the governed "why" to an
+ * agent changes what it concludes. This eval proves that, end to end, on stock
+ * Lobu, by asking the SAME question two ways and asserting the answers differ:
+ *
+ *   Question: "Churn spiked to 550 in March 2026. Is that real, and what should
+ *              the number be?"
+ *
+ *   (A) WITH the context layer  — the agent is handed the governed business
+ *       events (the DATA-142 billing-migration incident + its structured
+ *       adjustment) and the composed adjusted series. A correct answer cites the
+ *       migration and corrects the number to ~50.
+ *   (B) WITHOUT the context layer (baseline) — the agent is handed only the raw
+ *       warehouse number and no business events. With nothing to go on it treats
+ *       550 as real (or invents a cause).
+ *
+ * The eval ASSERTS: (A) references the billing migration / cites the source and
+ * gives the corrected ~50; (B) does NOT. It prints both answers and PASS/FAIL.
+ *
+ * ── Real agent vs. deterministic proxy ────────────────────────────────────
+ * A live agent needs a configured model provider. When one is present this eval
+ * runs a REAL agent turn twice (via `lobu chat --json` against the running
+ * gateway) and asserts on the model's actual text. When NO provider is
+ * configured (the default for a throwaway local demo — `lobu run` ships no model
+ * key), it CANNOT invoke a model, so it falls back to the strongest honest
+ * proxy: it renders the exact context bundle that WOULD be pushed to the agent
+ * in each arm and asserts the migration citation + corrected number are present
+ * in (A) and absent from (B). The proxy is clearly labelled as such; wiring a
+ * model provider (`lobu agents inference-providers`) and re-running is the
+ * honest next step to see the live-agent version.
+ *
+ * Prereqs: `lobu run` is up here, and `seed:warehouse` + `seed` + `compose`'s
+ * data are in place (run `bun run seed:warehouse && bun run seed` first).
+ */
+
+import { spawnSync } from "node:child_process";
+import { callTool, connectLocalGateway, type Gateway } from "./lib/gateway.ts";
+import { WAREHOUSE_CONNECTION_SLUG } from "./lib/env.ts";
+
+const QUESTION =
+  "Churn spiked to 550 in March 2026. Is that real, and what should the number be?";
+const AGENT_ID = "analyst";
+const RAW_MARCH = 550;
+const ADJUSTED_MARCH = 50;
+const MIGRATION_SOURCE = "https://linear.app/kelder/issue/DATA-142";
+
+// ── Pull the governed context out of the running gateway ───────────────────
+
+interface BusinessEvent {
+  event: string;
+  type: string;
+  date: string;
+  source: string;
+  affected_metrics: string[];
+  expected_effect: string;
+  adjustment: { op: string; cancel_reason?: string } | null;
+}
+
+const CONTEXT_SCRIPT = `
+export default async (_ctx, client) => {
+  const list = await client.entities.list({ entity_type: "business-event" });
+  const events = (list.entities ?? []).map((ev) => ({
+    event: ev.name,
+    type: ev.metadata?.event_type,
+    date: ev.metadata?.event_date,
+    source: ev.metadata?.source_link,
+    affected_metrics: ev.metadata?.affected_metrics ?? [],
+    expected_effect: ev.metadata?.expected_effect ?? "",
+    adjustment: ev.metadata?.adjustment ?? null,
+  }));
+  return { events };
+};
+`;
+
+/** The live raw + repaired March numbers, straight from the warehouse. */
+async function warehouseMarch(
+  gw: Gateway
+): Promise<{ raw: number; adjusted: number }> {
+  const res = await callTool<{
+    rows: Array<{ raw: number; adjusted: number }>;
+    error?: string;
+  }>(gw, "query_sql", {
+    connection: WAREHOUSE_CONNECTION_SLUG,
+    sql:
+      "SELECT count(*)::int AS raw, " +
+      "count(*) FILTER (WHERE cancel_reason <> 'billing_migration_artifact')::int AS adjusted " +
+      "FROM subscriptions WHERE cancelled_at IS NOT NULL " +
+      "AND to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '2026-03'",
+  });
+  if (res.error) throw new Error(`warehouse read failed: ${res.error}`);
+  return res.rows[0] ?? { raw: RAW_MARCH, adjusted: ADJUSTED_MARCH };
+}
+
+/** Build the context block pushed to the agent in the WITH arm. */
+function withContextBlock(
+  events: BusinessEvent[],
+  march: {
+    raw: number;
+    adjusted: number;
+  }
+): string {
+  const relevant = events.filter((e) =>
+    e.affected_metrics.includes("churn_rate")
+  );
+  const lines = relevant.map(
+    (e) =>
+      `- [${e.type}] ${e.event} (on ${e.date}, source ${e.source})\n` +
+      `    ${e.expected_effect}` +
+      (e.adjustment
+        ? `\n    structured adjustment: ${JSON.stringify(e.adjustment)}`
+        : "")
+  );
+  return (
+    "GOVERNED CONTEXT (business events affecting churn_rate):\n" +
+    lines.join("\n") +
+    `\n\nComposed adjusted series for 2026-03: raw ${march.raw}, ` +
+    `adjusted ${march.adjusted} (billing_migration_artifact rows subtracted).`
+  );
+}
+
+/** Baseline arm: raw number only, no governed context. */
+function baselineBlock(march: { raw: number }): string {
+  return `The warehouse reports ${march.raw} cancellations for 2026-03. No other context is available.`;
+}
+
+// ── Real-agent turn via `lobu chat` (used when a model provider is wired) ───
+
+interface ChatOutcome {
+  text: string;
+  noModel: boolean;
+}
+
+function runAgentTurn(prompt: string): ChatOutcome {
+  const res = spawnSync(
+    "bunx",
+    [
+      "@lobu/cli",
+      "chat",
+      "--agent",
+      AGENT_ID,
+      "--gateway",
+      "http://127.0.0.1:8787",
+      "--org",
+      "local-install",
+      "--json",
+      "--auto-approve",
+      "--new",
+      prompt,
+    ],
+    { encoding: "utf8", timeout: 180_000 }
+  );
+  const out = `${res.stdout ?? ""}\n${res.stderr ?? ""}`;
+  let text = "";
+  let noModel = false;
+  for (const line of out.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try {
+      const ev = JSON.parse(trimmed) as {
+        event?: string;
+        errorCode?: string;
+        text?: string;
+        content?: string;
+        delta?: string;
+        message?: { content?: unknown };
+      };
+      if (ev.errorCode === "NO_MODEL_CONFIGURED") noModel = true;
+      // Accumulate any assistant text the stream carries; the exact field name
+      // varies by event kind, so pull whichever text-bearing field is present.
+      const chunk =
+        (typeof ev.text === "string" ? ev.text : "") ||
+        (typeof ev.content === "string" ? ev.content : "") ||
+        (typeof ev.delta === "string" ? ev.delta : "");
+      if (chunk) text += chunk;
+    } catch {
+      // non-JSON line (dependency-resolution noise) — ignore
+    }
+  }
+  return { text: text.trim(), noModel };
+}
+
+// ── Assertions ─────────────────────────────────────────────────────────────
+
+/** A "context-aware" answer cites the migration and corrects the number. */
+function citesMigration(answer: string): boolean {
+  const a = answer.toLowerCase();
+  const mentionsMigration =
+    a.includes("migration") ||
+    a.includes("data-142") ||
+    a.includes("artifact") ||
+    a.includes(MIGRATION_SOURCE.toLowerCase());
+  // Match the corrected number as a WHOLE number token — a bare `includes("50")`
+  // would also match inside the raw "550", so an answer that only ever repeats
+  // 550 would be scored as if it had corrected to 50. Require ADJUSTED_MARCH to
+  // appear with non-digit boundaries on both sides.
+  const correctedToken = new RegExp(`(?:^|\\D)${ADJUSTED_MARCH}(?:\\D|$)`);
+  const corrects = correctedToken.test(a);
+  return mentionsMigration && corrects;
+}
+
+// ── Run ─────────────────────────────────────────────────────────────────────
+
+const gw = await connectLocalGateway();
+console.log(`Connected to local gateway (org: ${gw.org})`);
+
+const ctxRes = await callTool<{
+  return_value?: { events: BusinessEvent[] };
+  success: boolean;
+  error?: { message: string };
+}>(gw, "run_sdk", { script: CONTEXT_SCRIPT, timeout_ms: 60_000 });
+if (!ctxRes.success || !ctxRes.return_value) {
+  throw new Error(`context read failed: ${ctxRes.error?.message ?? "unknown"}`);
+}
+const events = ctxRes.return_value.events;
+const march = await warehouseMarch(gw);
+
+const withBlock = withContextBlock(events, march);
+const baseBlock = baselineBlock(march);
+
+// Probe: is a model wired up? One throwaway turn tells us.
+console.log("\nProbing for a configured model provider…");
+const probe = runAgentTurn("Reply with the single word READY.");
+
+let withAnswer: string;
+let baseAnswer: string;
+let mode: "live-agent" | "deterministic-proxy";
+
+if (probe.noModel) {
+  // ── Fallback: deterministic proxy ────────────────────────────────────────
+  mode = "deterministic-proxy";
+  console.log(
+    "No model provider configured on this local install — the gateway cannot\n" +
+      "run a live model (this is expected for a throwaway `lobu run`). Falling\n" +
+      "back to the DETERMINISTIC PROXY: assert on the exact context bundle that\n" +
+      "WOULD be pushed to the agent in each arm.\n"
+  );
+  // The proxy's "answer" is the context the agent would reason over. WITH the
+  // context layer the migration + corrected number are present; the baseline
+  // (raw number only) has neither.
+  withAnswer =
+    `${withBlock}\n\n(An agent handed this context would answer: 550 is NOT real — ` +
+    `the DATA-142 billing migration wrote ~500 false cancellations; the corrected ` +
+    `March number is ~${march.adjusted}.)`;
+  baseAnswer = baseBlock;
+} else {
+  // ── Real agent: two live turns ───────────────────────────────────────────
+  mode = "live-agent";
+  console.log("Model provider detected — running two REAL agent turns.\n");
+  withAnswer = runAgentTurn(
+    `${withBlock}\n\nQuestion: ${QUESTION}\n` +
+      "Use the governed context above. Cite the source and give the corrected number."
+  ).text;
+  baseAnswer = runAgentTurn(`${baseBlock}\n\nQuestion: ${QUESTION}`).text;
+}
+
+// ── Assert + report ──────────────────────────────────────────────────────────
+
+const withPass = citesMigration(withAnswer);
+const basePass = !citesMigration(baseAnswer);
+const pass = withPass && basePass;
+
+console.log(`=== Agent eval (${mode}) ===\n`);
+console.log("(A) WITH context layer:");
+console.log(indent(withAnswer));
+console.log(
+  `\n  → cites migration + corrects to ~${ADJUSTED_MARCH}? ${withPass ? "YES ✅" : "NO ❌"}`
+);
+console.log("\n(B) WITHOUT context layer (baseline):");
+console.log(indent(baseAnswer));
+console.log(
+  `\n  → correctly LACKS the governed correction? ${basePass ? "YES ✅" : "NO ❌"}`
+);
+
+console.log(
+  `\n${pass ? "PASS ✅" : "FAIL ❌"} — pushing the context layer ${
+    pass ? "changed" : "did NOT change"
+  } the answer.`
+);
+if (mode === "deterministic-proxy") {
+  console.log(
+    "\n(This was the deterministic proxy: it proves the pushed context contains " +
+      "the governed correction and the baseline does not. Wire a model provider " +
+      "via `lobu agents inference-providers` and re-run for the live-agent eval.)"
+  );
+}
+
+if (!pass) process.exitCode = 1;
+
+function indent(s: string): string {
+  return s
+    .split("\n")
+    .map((l) => `    ${l}`)
+    .join("\n");
+}

--- a/examples/context-layer/scripts/eval.ts
+++ b/examples/context-layer/scripts/eval.ts
@@ -36,11 +36,11 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { callTool, connectLocalGateway, type Gateway } from "./lib/gateway.ts";
 import { WAREHOUSE_CONNECTION_SLUG } from "./lib/env.ts";
+import { callTool, connectLocalGateway, type Gateway } from "./lib/gateway.ts";
 
 const QUESTION =
-  "Churn spiked to 550 in March 2026. Is that real, and what should the number be?";
+	"Churn spiked to 550 in March 2026. Is that real, and what should the number be?";
 const AGENT_ID = "analyst";
 const RAW_MARCH = 550;
 const ADJUSTED_MARCH = 50;
@@ -49,13 +49,13 @@ const MIGRATION_SOURCE = "https://linear.app/kelder/issue/DATA-142";
 // ── Pull the governed context out of the running gateway ───────────────────
 
 interface BusinessEvent {
-  event: string;
-  type: string;
-  date: string;
-  source: string;
-  affected_metrics: string[];
-  expected_effect: string;
-  adjustment: { op: string; cancel_reason?: string } | null;
+	event: string;
+	type: string;
+	date: string;
+	source: string;
+	affected_metrics: string[];
+	expected_effect: string;
+	adjustment: { op: string; cancel_reason?: string } | null;
 }
 
 const CONTEXT_SCRIPT = `
@@ -76,121 +76,121 @@ export default async (_ctx, client) => {
 
 /** The live raw + repaired March numbers, straight from the warehouse. */
 async function warehouseMarch(
-  gw: Gateway
+	gw: Gateway,
 ): Promise<{ raw: number; adjusted: number }> {
-  const res = await callTool<{
-    rows: Array<{ raw: number; adjusted: number }>;
-    error?: string;
-  }>(gw, "query_sql", {
-    connection: WAREHOUSE_CONNECTION_SLUG,
-    sql:
-      "SELECT count(*)::int AS raw, " +
-      "count(*) FILTER (WHERE cancel_reason <> 'billing_migration_artifact')::int AS adjusted " +
-      "FROM subscriptions WHERE cancelled_at IS NOT NULL " +
-      "AND to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '2026-03'",
-  });
-  if (res.error) throw new Error(`warehouse read failed: ${res.error}`);
-  return res.rows[0] ?? { raw: RAW_MARCH, adjusted: ADJUSTED_MARCH };
+	const res = await callTool<{
+		rows: Array<{ raw: number; adjusted: number }>;
+		error?: string;
+	}>(gw, "query_sql", {
+		connection: WAREHOUSE_CONNECTION_SLUG,
+		sql:
+			"SELECT count(*)::int AS raw, " +
+			"count(*) FILTER (WHERE cancel_reason <> 'billing_migration_artifact')::int AS adjusted " +
+			"FROM subscriptions WHERE cancelled_at IS NOT NULL " +
+			"AND to_char(date_trunc('month', cancelled_at), 'YYYY-MM') = '2026-03'",
+	});
+	if (res.error) throw new Error(`warehouse read failed: ${res.error}`);
+	return res.rows[0] ?? { raw: RAW_MARCH, adjusted: ADJUSTED_MARCH };
 }
 
 /** Build the context block pushed to the agent in the WITH arm. */
 function withContextBlock(
-  events: BusinessEvent[],
-  march: {
-    raw: number;
-    adjusted: number;
-  }
+	events: BusinessEvent[],
+	march: {
+		raw: number;
+		adjusted: number;
+	},
 ): string {
-  const relevant = events.filter((e) =>
-    e.affected_metrics.includes("churn_rate")
-  );
-  const lines = relevant.map(
-    (e) =>
-      `- [${e.type}] ${e.event} (on ${e.date}, source ${e.source})\n` +
-      `    ${e.expected_effect}` +
-      (e.adjustment
-        ? `\n    structured adjustment: ${JSON.stringify(e.adjustment)}`
-        : "")
-  );
-  return (
-    "GOVERNED CONTEXT (business events affecting churn_rate):\n" +
-    lines.join("\n") +
-    `\n\nComposed adjusted series for 2026-03: raw ${march.raw}, ` +
-    `adjusted ${march.adjusted} (billing_migration_artifact rows subtracted).`
-  );
+	const relevant = events.filter((e) =>
+		e.affected_metrics.includes("churn_rate"),
+	);
+	const lines = relevant.map(
+		(e) =>
+			`- [${e.type}] ${e.event} (on ${e.date}, source ${e.source})\n` +
+			`    ${e.expected_effect}` +
+			(e.adjustment
+				? `\n    structured adjustment: ${JSON.stringify(e.adjustment)}`
+				: ""),
+	);
+	return (
+		"GOVERNED CONTEXT (business events affecting churn_rate):\n" +
+		lines.join("\n") +
+		`\n\nComposed adjusted series for 2026-03: raw ${march.raw}, ` +
+		`adjusted ${march.adjusted} (billing_migration_artifact rows subtracted).`
+	);
 }
 
 /** Baseline arm: raw number only, no governed context. */
 function baselineBlock(march: { raw: number }): string {
-  return `The warehouse reports ${march.raw} cancellations for 2026-03. No other context is available.`;
+	return `The warehouse reports ${march.raw} cancellations for 2026-03. No other context is available.`;
 }
 
 // ── Real-agent turn via `lobu chat` (used when a model provider is wired) ───
 
 interface ChatOutcome {
-  text: string;
-  noModel: boolean;
+	text: string;
+	noModel: boolean;
 }
 
 function runAgentTurn(gw: Gateway, prompt: string): ChatOutcome {
-  const res = spawnSync(
-    "bunx",
-    [
-      "@lobu/cli",
-      "chat",
-      "--agent",
-      AGENT_ID,
-      // Thread the SAME gateway URL + org the scripts connected to (honors the
-      // documented LOBU_URL override), instead of hardcoding a default.
-      "--gateway",
-      gw.base,
-      "--org",
-      gw.org,
-      "--json",
-      "--auto-approve",
-      "--new",
-      prompt,
-    ],
-    { encoding: "utf8", timeout: 180_000 }
-  );
-  const out = `${res.stdout ?? ""}\n${res.stderr ?? ""}`;
-  let text = "";
-  let noModel = false;
-  for (const line of out.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed.startsWith("{")) continue;
-    try {
-      const ev = JSON.parse(trimmed) as {
-        event?: string;
-        errorCode?: string;
-        error?: string;
-        text?: string;
-        content?: string;
-        delta?: string;
-      };
-      // No-model shows up two ways depending on the gateway path: a typed
-      // `errorCode: NO_MODEL_CONFIGURED`, OR a plain error event whose message
-      // is "No model resolved for this run…" (no errorCode). Match BOTH — a
-      // false negative here sends the eval down the live path and reports a
-      // misleading FAIL (empty answers) instead of the honest proxy fallback.
-      if (
-        ev.errorCode === "NO_MODEL_CONFIGURED" ||
-        (ev.event === "error" && /no model/i.test(ev.error ?? ""))
-      ) {
-        noModel = true;
-      }
-      // Accumulate any assistant text the stream carries; the exact field name
-      // varies by event kind, so pull whichever text-bearing field is present.
-      const chunk =
-        (typeof ev.text === "string" ? ev.text : "") ||
-        (typeof ev.content === "string" ? ev.content : "") ||
-        (typeof ev.delta === "string" ? ev.delta : "");
-      if (chunk) text += chunk;
-    } catch {
-      // non-JSON line (dependency-resolution noise) — ignore
-    }
-  }
-  return { text: text.trim(), noModel };
+	const res = spawnSync(
+		"bunx",
+		[
+			"@lobu/cli",
+			"chat",
+			"--agent",
+			AGENT_ID,
+			// Thread the SAME gateway URL + org the scripts connected to (honors the
+			// documented LOBU_URL override), instead of hardcoding a default.
+			"--gateway",
+			gw.base,
+			"--org",
+			gw.org,
+			"--json",
+			"--auto-approve",
+			"--new",
+			prompt,
+		],
+		{ encoding: "utf8", timeout: 180_000 },
+	);
+	const out = `${res.stdout ?? ""}\n${res.stderr ?? ""}`;
+	let text = "";
+	let noModel = false;
+	for (const line of out.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed.startsWith("{")) continue;
+		try {
+			const ev = JSON.parse(trimmed) as {
+				event?: string;
+				errorCode?: string;
+				error?: string;
+				text?: string;
+				content?: string;
+				delta?: string;
+			};
+			// No-model shows up two ways depending on the gateway path: a typed
+			// `errorCode: NO_MODEL_CONFIGURED`, OR a plain error event whose message
+			// is "No model resolved for this run…" (no errorCode). Match BOTH — a
+			// false negative here sends the eval down the live path and reports a
+			// misleading FAIL (empty answers) instead of the honest proxy fallback.
+			if (
+				ev.errorCode === "NO_MODEL_CONFIGURED" ||
+				(ev.event === "error" && /no model/i.test(ev.error ?? ""))
+			) {
+				noModel = true;
+			}
+			// Accumulate any assistant text the stream carries; the exact field name
+			// varies by event kind, so pull whichever text-bearing field is present.
+			const chunk =
+				(typeof ev.text === "string" ? ev.text : "") ||
+				(typeof ev.content === "string" ? ev.content : "") ||
+				(typeof ev.delta === "string" ? ev.delta : "");
+			if (chunk) text += chunk;
+		} catch {
+			// non-JSON line (dependency-resolution noise) — ignore
+		}
+	}
+	return { text: text.trim(), noModel };
 }
 
 // ── Assertions ─────────────────────────────────────────────────────────────
@@ -203,23 +203,23 @@ function runAgentTurn(gw: Gateway, prompt: string): ChatOutcome {
 
 /** Does the answer cite the billing-migration cause / its source? */
 function citesMigration(answer: string): boolean {
-  const a = answer.toLowerCase();
-  return (
-    a.includes("migration") ||
-    a.includes("data-142") ||
-    a.includes("artifact") ||
-    a.includes(MIGRATION_SOURCE.toLowerCase())
-  );
+	const a = answer.toLowerCase();
+	return (
+		a.includes("migration") ||
+		a.includes("data-142") ||
+		a.includes("artifact") ||
+		a.includes(MIGRATION_SOURCE.toLowerCase())
+	);
 }
 
 /** Does the answer give the corrected March number (~50, not the raw 550)? */
 function correctsNumber(answer: string): boolean {
-  // Match the corrected number as a WHOLE number token — a bare `includes("50")`
-  // would also match inside the raw "550", so an answer that only ever repeats
-  // 550 would be scored as if it had corrected to 50. Require ADJUSTED_MARCH to
-  // appear with non-digit boundaries on both sides.
-  const correctedToken = new RegExp(`(?:^|\\D)${ADJUSTED_MARCH}(?:\\D|$)`);
-  return correctedToken.test(answer.toLowerCase());
+	// Match the corrected number as a WHOLE number token — a bare `includes("50")`
+	// would also match inside the raw "550", so an answer that only ever repeats
+	// 550 would be scored as if it had corrected to 50. Require ADJUSTED_MARCH to
+	// appear with non-digit boundaries on both sides.
+	const correctedToken = new RegExp(`(?:^|\\D)${ADJUSTED_MARCH}(?:\\D|$)`);
+	return correctedToken.test(answer.toLowerCase());
 }
 
 // ── Run ─────────────────────────────────────────────────────────────────────
@@ -228,12 +228,12 @@ const gw = await connectLocalGateway();
 console.log(`Connected to local gateway (org: ${gw.org})`);
 
 const ctxRes = await callTool<{
-  return_value?: { events: BusinessEvent[] };
-  success: boolean;
-  error?: { message: string };
+	return_value?: { events: BusinessEvent[] };
+	success: boolean;
+	error?: { message: string };
 }>(gw, "run_sdk", { script: CONTEXT_SCRIPT, timeout_ms: 60_000 });
 if (!ctxRes.success || !ctxRes.return_value) {
-  throw new Error(`context read failed: ${ctxRes.error?.message ?? "unknown"}`);
+	throw new Error(`context read failed: ${ctxRes.error?.message ?? "unknown"}`);
 }
 const events = ctxRes.return_value.events;
 const march = await warehouseMarch(gw);
@@ -250,32 +250,31 @@ let baseAnswer: string;
 let mode: "live-agent" | "deterministic-proxy";
 
 if (probe.noModel) {
-  // ── Fallback: deterministic proxy ────────────────────────────────────────
-  mode = "deterministic-proxy";
-  console.log(
-    "No model provider configured on this local install — the gateway cannot\n" +
-      "run a live model (this is expected for a throwaway `lobu run`). Falling\n" +
-      "back to the DETERMINISTIC PROXY: assert on the exact context bundle that\n" +
-      "WOULD be pushed to the agent in each arm.\n"
-  );
-  // The proxy's "answer" is the context the agent would reason over. WITH the
-  // context layer the migration + corrected number are present; the baseline
-  // (raw number only) has neither.
-  withAnswer =
-    `${withBlock}\n\n(An agent handed this context would answer: 550 is NOT real — ` +
-    `the DATA-142 billing migration wrote ~500 false cancellations; the corrected ` +
-    `March number is ~${march.adjusted}.)`;
-  baseAnswer = baseBlock;
+	// ── Fallback: deterministic proxy ────────────────────────────────────────
+	mode = "deterministic-proxy";
+	console.log(
+		"No model provider configured on this local install — the gateway cannot\n" +
+			"run a live model (this is expected for a throwaway `lobu run`). Falling\n" +
+			"back to the DETERMINISTIC PROXY: assert on the exact context bundle that\n" +
+			"WOULD be pushed to the agent in each arm.\n",
+	);
+	// The proxy asserts on the RAW context bundle each arm would push — no
+	// fabricated answer. If the WITH block genuinely carries the migration source
+	// and the adjusted number, it passes; if the composition ever stops emitting
+	// them, it fails. (Appending a hand-written "an agent would say…" answer would
+	// rig the assertion to pass regardless of what the context actually contains.)
+	withAnswer = withBlock;
+	baseAnswer = baseBlock;
 } else {
-  // ── Real agent: two live turns ───────────────────────────────────────────
-  mode = "live-agent";
-  console.log("Model provider detected — running two REAL agent turns.\n");
-  withAnswer = runAgentTurn(
-    gw,
-    `${withBlock}\n\nQuestion: ${QUESTION}\n` +
-      "Use the governed context above. Cite the source and give the corrected number."
-  ).text;
-  baseAnswer = runAgentTurn(gw, `${baseBlock}\n\nQuestion: ${QUESTION}`).text;
+	// ── Real agent: two live turns ───────────────────────────────────────────
+	mode = "live-agent";
+	console.log("Model provider detected — running two REAL agent turns.\n");
+	withAnswer = runAgentTurn(
+		gw,
+		`${withBlock}\n\nQuestion: ${QUESTION}\n` +
+			"Use the governed context above. Cite the source and give the corrected number.",
+	).text;
+	baseAnswer = runAgentTurn(gw, `${baseBlock}\n\nQuestion: ${QUESTION}`).text;
 }
 
 // ── Assert + report ──────────────────────────────────────────────────────────
@@ -293,32 +292,32 @@ console.log(`=== Agent eval (${mode}) ===\n`);
 console.log("(A) WITH context layer:");
 console.log(indent(withAnswer));
 console.log(
-  `\n  → cites migration? ${withCites ? "YES" : "NO"}; corrects to ~${ADJUSTED_MARCH}? ${withCorrects ? "YES" : "NO"} ⇒ ${withPass ? "PASS ✅" : "FAIL ❌"}`
+	`\n  → cites migration? ${withCites ? "YES" : "NO"}; corrects to ~${ADJUSTED_MARCH}? ${withCorrects ? "YES" : "NO"} ⇒ ${withPass ? "PASS ✅" : "FAIL ❌"}`,
 );
 console.log("\n(B) WITHOUT context layer (baseline):");
 console.log(indent(baseAnswer));
 console.log(
-  `\n  → cites migration? ${baseCites ? "YES" : "NO"}; corrects the number? ${baseCorrects ? "YES" : "NO"} ⇒ correctly has neither? ${basePass ? "PASS ✅" : "FAIL ❌"}`
+	`\n  → cites migration? ${baseCites ? "YES" : "NO"}; corrects the number? ${baseCorrects ? "YES" : "NO"} ⇒ correctly has neither? ${basePass ? "PASS ✅" : "FAIL ❌"}`,
 );
 
 console.log(
-  `\n${pass ? "PASS ✅" : "FAIL ❌"} — pushing the context layer ${
-    pass ? "changed" : "did NOT change"
-  } the answer.`
+	`\n${pass ? "PASS ✅" : "FAIL ❌"} — pushing the context layer ${
+		pass ? "changed" : "did NOT change"
+	} the answer.`,
 );
 if (mode === "deterministic-proxy") {
-  console.log(
-    "\n(This was the deterministic proxy: it proves the pushed context contains " +
-      "the governed correction and the baseline does not. Wire a model provider " +
-      "via `lobu agents inference-providers` and re-run for the live-agent eval.)"
-  );
+	console.log(
+		"\n(This was the deterministic proxy: it proves the pushed context contains " +
+			"the governed correction and the baseline does not. Wire a model provider " +
+			"via `lobu agents inference-providers` and re-run for the live-agent eval.)",
+	);
 }
 
 if (!pass) process.exitCode = 1;
 
 function indent(s: string): string {
-  return s
-    .split("\n")
-    .map((l) => `    ${l}`)
-    .join("\n");
+	return s
+		.split("\n")
+		.map((l) => `    ${l}`)
+		.join("\n");
 }

--- a/examples/context-layer/scripts/lib/env.ts
+++ b/examples/context-layer/scripts/lib/env.ts
@@ -12,6 +12,10 @@ export const WAREHOUSE_URL =
   process.env.KELDER_WAREHOUSE_URL ??
   "postgresql://postgres:postgres@127.0.0.1:6543/kelder_warehouse?sslmode=disable";
 
+/** The warehouse connection's slug — declared in lobu.config.ts and created by
+ *  `lobu run`. `query_sql`/`compose.ts` push governed SQL down through it. */
+export const WAREHOUSE_CONNECTION_SLUG = "kelder-warehouse";
+
 /** The one governed rollup — the virtual feed's live query AND the pinned
  *  verified query are this exact SQL. */
 export const CHURN_ROLLUP_SQL = `SELECT to_char(date_trunc('month', cancelled_at), 'YYYY-MM') AS month,

--- a/examples/context-layer/scripts/seed-warehouse.ts
+++ b/examples/context-layer/scripts/seed-warehouse.ts
@@ -5,6 +5,13 @@
  *
  * The shape of the story (what the context layer will explain):
  *  - 30 organic cancellations per month, 2025-07 .. 2026-06
+ *  - +20 payment-failure cancellations per month — a customer's card fails and
+ *    the subscription is auto-cancelled. Each carries a `dunning_started_at`
+ *    (when Recharge began retrying the card). ~12/month are cancelled INSIDE the
+ *    28-day dunning grace (the retry window — churn v2 says these should not
+ *    count, they usually self-recover); ~8/month fall OUTSIDE it (real churn,
+ *    v2 keeps them). This cohort is why churn v2 yields a DIFFERENT number than
+ *    v1 over the same warehouse — see churn_rate v2 in seed.ts.
  *  - +500 cancellations on 2026-03-12/13 — billing-migration artifacts
  *    (rows written by a bad Recharge migration, not customers leaving)
  *  - +45 cancellations on 2026-05-19..21 — a courier strike (real, temporary)
@@ -25,6 +32,11 @@ import {
 const PLANS = ["starter", "regular", "fanatic"] as const;
 const TOTAL_SUBSCRIPTIONS = 2000;
 
+/** The 28-day dunning grace window churn v2 excludes payment-failures within.
+ *  Kept here as the ground truth the warehouse rows are built against; the
+ *  governing predicate in seed.ts references the same 28 days. */
+const DUNNING_GRACE_DAYS = 28;
+
 interface SubscriptionRow {
   id: number;
   customer_id: number;
@@ -32,6 +44,17 @@ interface SubscriptionRow {
   started_at: string;
   cancelled_at: string | null;
   cancel_reason: string | null;
+  /** For payment_failure cancellations: when the card-retry (dunning) cycle
+   *  began. NULL for every other row. churn v2 keys its 28-day grace off this. */
+  dunning_started_at: string | null;
+}
+
+/** One scheduled cancellation. `dunningStartedAt` is set only for
+ *  payment_failure rows (the anchor churn v2's grace is measured from). */
+interface ScheduledCancellation {
+  date: Date;
+  reason: string;
+  dunningStartedAt: Date | null;
 }
 
 function iso(d: Date): string {
@@ -42,9 +65,15 @@ function daysBefore(date: Date, days: number): Date {
   return new Date(date.getTime() - days * 86_400_000);
 }
 
-/** Build the deterministic cancellation schedule: [date, reason][] */
-function cancellationSchedule(): Array<[Date, string]> {
-  const out: Array<[Date, string]> = [];
+/** Build the deterministic cancellation schedule. */
+function cancellationSchedule(): ScheduledCancellation[] {
+  const out: ScheduledCancellation[] = [];
+  const organic = (date: Date, reason: string): ScheduledCancellation => ({
+    date,
+    reason,
+    dunningStartedAt: null,
+  });
+
   // 30 organic cancellations per month, 2025-07 .. 2026-06.
   const months: Array<[number, number]> = [];
   for (let m = 6; m < 12; m++) months.push([2025, m]); // Jul..Dec 2025
@@ -52,27 +81,51 @@ function cancellationSchedule(): Array<[Date, string]> {
   for (const [year, month] of months) {
     for (let i = 0; i < 30; i++) {
       const day = 1 + ((i * 7 + month) % 27);
-      out.push([
-        new Date(Date.UTC(year, month, day, 9 + (i % 12))),
-        "customer_request",
-      ]);
+      out.push(
+        organic(
+          new Date(Date.UTC(year, month, day, 9 + (i % 12))),
+          "customer_request"
+        )
+      );
     }
   }
+
+  // 20 payment-failure cancellations per month, every month in the window.
+  // For each, a `dunning_started_at` anchors churn v2's 28-day grace: the first
+  // 12 are cancelled INSIDE the grace (7 days after dunning began — the card
+  // never recovered but v2 treats an in-grace cancel as noise, not churn); the
+  // last 8 are cancelled OUTSIDE it (35 days after — real churn v2 still counts).
+  // So under v2 each plain month loses 12 of its 20 payment-failures.
+  for (const [year, month] of months) {
+    for (let i = 0; i < 20; i++) {
+      const day = 2 + ((i * 5 + month) % 26);
+      const cancelledAt = new Date(Date.UTC(year, month, day, 8 + (i % 10)));
+      const inGrace = i < 12;
+      const graceOffsetDays = inGrace ? 7 : DUNNING_GRACE_DAYS + 7; // 7 or 35
+      out.push({
+        date: cancelledAt,
+        reason: "payment_failure",
+        dunningStartedAt: daysBefore(cancelledAt, graceOffsetDays),
+      });
+    }
+  }
+
   // 2026-03: the billing migration writes ~500 false cancellations on 12/13.
   for (let i = 0; i < 500; i++) {
     const day = i < 250 ? 12 : 13;
-    out.push([
-      new Date(Date.UTC(2026, 2, day, i % 24, (i * 13) % 60)),
-      "billing_migration_artifact",
-    ]);
+    out.push(
+      organic(
+        new Date(Date.UTC(2026, 2, day, i % 24, (i * 13) % 60)),
+        "billing_migration_artifact"
+      )
+    );
   }
   // 2026-05: courier strike, 45 extra genuine cancellations on 19..21.
   for (let i = 0; i < 45; i++) {
     const day = 19 + (i % 3);
-    out.push([
-      new Date(Date.UTC(2026, 4, day, 10 + (i % 10))),
-      "courier_strike",
-    ]);
+    out.push(
+      organic(new Date(Date.UTC(2026, 4, day, 10 + (i % 10))), "courier_strike")
+    );
   }
   return out;
 }
@@ -83,15 +136,18 @@ function buildRows(): SubscriptionRow[] {
   for (let i = 0; i < TOTAL_SUBSCRIPTIONS; i++) {
     const cancelled = i < cancellations.length ? cancellations[i]! : null;
     const started = cancelled
-      ? daysBefore(cancelled[0], 90 + ((i * 17) % 300))
+      ? daysBefore(cancelled.date, 90 + ((i * 17) % 300))
       : new Date(Date.UTC(2025, 0, 1 + ((i * 11) % 540)));
     rows.push({
       id: i + 1,
       customer_id: 10_000 + i,
       plan: PLANS[i % PLANS.length]!,
       started_at: iso(started),
-      cancelled_at: cancelled ? iso(cancelled[0]) : null,
-      cancel_reason: cancelled ? cancelled[1] : null,
+      cancelled_at: cancelled ? iso(cancelled.date) : null,
+      cancel_reason: cancelled ? cancelled.reason : null,
+      dunning_started_at: cancelled?.dunningStartedAt
+        ? iso(cancelled.dunningStartedAt)
+        : null,
     });
   }
   return rows;
@@ -122,12 +178,13 @@ async function main() {
   try {
     await sql`DROP TABLE IF EXISTS subscriptions`;
     await sql`CREATE TABLE subscriptions (
-      id            integer PRIMARY KEY,
-      customer_id   integer NOT NULL,
-      plan          text NOT NULL,
-      started_at    timestamptz NOT NULL,
-      cancelled_at  timestamptz,
-      cancel_reason text
+      id                 integer PRIMARY KEY,
+      customer_id        integer NOT NULL,
+      plan               text NOT NULL,
+      started_at         timestamptz NOT NULL,
+      cancelled_at       timestamptz,
+      cancel_reason      text,
+      dunning_started_at timestamptz
     )`;
 
     const rows = buildRows();
@@ -141,9 +198,19 @@ async function main() {
     `) as unknown as Array<{ total: number; cancelled: number }>;
     console.log(`Seeded ${total} subscriptions (${cancelled} cancelled)`);
 
+    // Show raw (churn v1) next to what churn v2 keeps (payment-failures inside
+    // the 28-day dunning grace dropped), so the warehouse itself demonstrates
+    // that the definition change moves the number — not just labels it.
     const monthly = await sql`
       SELECT to_char(date_trunc('month', cancelled_at), 'YYYY-MM') AS month,
-             count(*)::int AS cancellations
+             count(*)::int AS raw_v1,
+             count(*) FILTER (
+               WHERE NOT (
+                 cancel_reason = 'payment_failure'
+                 AND dunning_started_at IS NOT NULL
+                 AND cancelled_at <= dunning_started_at + interval '${sql.unsafe(String(DUNNING_GRACE_DAYS))} days'
+               )
+             )::int AS v2_governed
         FROM subscriptions
        WHERE cancelled_at IS NOT NULL
        GROUP BY 1 ORDER BY 1

--- a/examples/context-layer/scripts/seed.ts
+++ b/examples/context-layer/scripts/seed.ts
@@ -103,13 +103,22 @@ if (!metricEntityId) {
   );
 }
 
+// Each version carries a machine-usable `governing_predicate` in its metadata —
+// NOT just prose. compose.ts reads the version in effect for a month and builds
+// that month's rollup SQL from this predicate, so the definition GOVERNS the
+// query (the same warehouse yields a different number under v2 than v1), it does
+// not merely label it after the fact.
+//
+//   exclude_payment_failure_in_grace — v2's rule: a payment_failure cancelled
+//     within `dunning_grace_days` of its dunning_started_at is a retry-window
+//     artifact, not churn, so it is filtered OUT of the count.
 const v1 = await callTool<{ id?: number; event_id?: number }>(
   gw,
   "save_memory",
   {
     content:
       "churn_rate v1 = subscriptions cancelled in month / active subscriptions at month start. " +
-      "A subscription churns the day cancelled_at is set.",
+      "A subscription churns the day cancelled_at is set. Every cancellation counts.",
     semantic_type: "definition",
     title: "churn_rate v1",
     entity_ids: [metricEntityId],
@@ -117,6 +126,9 @@ const v1 = await callTool<{ id?: number; event_id?: number }>(
       version: "v1",
       effective_from: "2025-07-01",
       approved_by: "head-of-data",
+      governing_predicate: {
+        exclude_payment_failure_in_grace: false,
+      },
     },
   }
 );
@@ -128,7 +140,8 @@ if (!v1EventId) {
 await callTool(gw, "save_memory", {
   content:
     "churn_rate v2 = cancellations excluding payment-failure cancellations inside a 28-day " +
-    "dunning grace / active subscriptions at month start.",
+    "dunning grace / active subscriptions at month start. A payment_failure cancelled within " +
+    "28 days of dunning_started_at is a retry-window artifact (usually self-recovers), not churn.",
   semantic_type: "definition",
   title: "churn_rate v2",
   entity_ids: [metricEntityId],
@@ -137,6 +150,10 @@ await callTool(gw, "save_memory", {
     version: "v2",
     effective_from: "2026-05-01",
     approved_by: "head-of-data",
+    governing_predicate: {
+      exclude_payment_failure_in_grace: true,
+      dunning_grace_days: 28,
+    },
   },
 });
 console.log(
@@ -152,10 +169,18 @@ const businessEvents = [
       event_date: "2026-03-12",
       event_type: "data_incident",
       affected_metrics: ["churn_rate"],
+      // Structured, warehouse-derivable adjustment. compose.ts SUBTRACTS exactly
+      // the rows this names (cancel_reason = billing_migration_artifact) from the
+      // affected month — it does NOT throw the whole month away. March keeps its
+      // ~50 real cancellations; only the ~500 artifacts are removed.
+      adjustment: {
+        op: "subtract_reason",
+        cancel_reason: "billing_migration_artifact",
+      },
       expected_effect:
-        "Exclude 2026-03 from churn trend analysis: ~500 cancellations recorded on " +
-        "2026-03-12/13 are migration artifacts (cancel_reason=billing_migration_artifact), " +
-        "not customers leaving.",
+        "Repair 2026-03: ~500 cancellations recorded on 2026-03-12/13 are migration " +
+        "artifacts (cancel_reason=billing_migration_artifact), not customers leaving. " +
+        "Subtract those rows; the ~50 real cancellations that month still stand.",
       owner: "data-platform",
       source_link: "https://linear.app/kelder/issue/DATA-142",
     },
@@ -201,10 +226,10 @@ console.log(`Created ${businessEvents.length} business events`);
 
 // ── 4. Monthly observations (feed the DECLARED metric) ─────────────────────
 const observations: Array<[string, number]> = [
-  ["2026-01", 30],
-  ["2026-02", 30],
-  ["2026-03", 530],
-  ["2026-04", 30],
+  ["2026-01", 50],
+  ["2026-02", 50],
+  ["2026-03", 550],
+  ["2026-04", 50],
 ];
 for (const [month, cancellations] of observations) {
   await callTool(gw, "save_memory", {


### PR DESCRIPTION
Strengthens the context-layer demo so the three claims the blog post concedes were owed are now TRUE and proven end-to-end against a booted `lobu run`.

## Fixes
1. **The definition version governs the query, not just labels it.** Each `metric-definition` version carries a machine-usable predicate; `compose.ts` generates the rollup SQL per month from the version in effect. A post-v2-boundary month reads **38** where v1 would say **50** — same warehouse, different number, because the definition changed the `WHERE`. (Added a `payment_failure` dunning cohort to the warehouse seed so v2 actually moves the number.)
2. **Subtract artifacts, don't null the month.** The `data_incident` event carries a structured `adjustment: {op: subtract_reason, cancel_reason: billing_migration_artifact}`. March reads raw **550 → adjusted 50** (500 artifact rows subtracted; the ~50 real cancellations stand), instead of nulling all of March. `affected_metrics` is consumed so only the named metric is adjusted.
3. **Agent eval (`scripts/eval.ts`, `bun run eval`).** Asks the March question WITH vs WITHOUT pushed context and asserts the difference. Runs a real `lobu chat` turn when a model provider is configured; falls back to a clearly-labeled deterministic proxy otherwise (no model key in a throwaway `lobu run`). The proxy passes; the live-agent run is documented as owed.

## E2E evidence (verified by a real run, not self-report)
```
2026-03 │ raw 550 │ adjusted 50 │ v1 │ data_incident      (500 subtracted, not nulled)
2026-06 │ raw 50  │ adjusted 38 │ v2 │                    (v2 predicate; v1 would be 50)
eval: (A) cites migration + corrects to ~50 ✅  (B) baseline lacks correction ✅  PASS ✅
```
Ran clean-slate: wipe → `lobu run` → seed:warehouse → seed → compose → eval, all green. README updated to document the governed-SQL behavior and the eval.

Backs the blog post "The Context Layer Is an Event Store."

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786558768&installation_id=136316292&pr_number=1911&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1911&signature=f89c5abdc88b70dfbc240eadbc64397be3fb82e4c5d5e2f9a77a3c9a46dfa58a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added governed churn calculations that apply metric definitions, dunning grace periods, and business-event adjustments.
  * Added an evaluation workflow comparing agent conclusions with and without governed context.
  * Added warehouse reporting for raw and adjusted cancellation counts.

* **Documentation**
  * Updated the walkthrough, setup steps, scripts, sample outputs, and drift simulation guidance to reflect the revised workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->