### PR TITLE
refactor+fix(approvals): unify builder-gate path + WI-0.2 platform-identity member resolution

### DIFF
--- a/packages/server/src/__tests__/integration/gateway/builder-admin-tools-platform-identity.test.ts
+++ b/packages/server/src/__tests__/integration/gateway/builder-admin-tools-platform-identity.test.ts
@@ -1,0 +1,163 @@
+/**
+ * WI-0.2: resolveBuilderAdminTools must resolve a PLATFORM user id (e.g. Slack
+ * `U…`) to its linked Lobu member before the member-role lookup.
+ *
+ * On a chat-platform run the worker's `userId` is the platform id, NOT a Lobu
+ * user id. Before the fix the `member.userId = ${userId}` join never matched, so
+ * an org owner driving the builder/system agent from Slack silently lost the
+ * admin-tool grant. The fix maps platform id → lobu user via
+ * `chat_user_identities` first (collision-safe: an ambiguous link grants
+ * nothing).
+ *
+ * Red→green: with `platform:'slack'` the grant only lands once the resolver maps
+ * the Slack id to the member. Web/session runs (`platform:'api'` or absent) use
+ * `userId` directly, unchanged.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  BUILDER_ADMIN_TOOLS,
+  resolveBuilderAdminTools,
+} from '../../../gateway/orchestration/message-consumer';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import {
+  addUserToOrganization,
+  createTestAgent,
+  createTestOrganization,
+  createTestUser,
+} from '../../setup/test-fixtures';
+
+const SLACK_TEAM = 'T_WI02';
+const SLACK_USER = 'U_WI02';
+
+async function linkSlackIdentity(opts: {
+  teamId: string;
+  platformUserId: string;
+  lobuUserId: string;
+}): Promise<void> {
+  await getTestDb()`
+    INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id, updated_at)
+    VALUES ('slack', ${opts.teamId}, ${opts.platformUserId}, ${opts.lobuUserId}, now())
+    ON CONFLICT (platform, team_id, platform_user_id)
+      DO UPDATE SET lobu_user_id = EXCLUDED.lobu_user_id, updated_at = now()
+  `;
+}
+
+/** Point org.system_agent_id at an agent (the builder gate requires the match). */
+async function setSystemAgent(orgId: string, agentId: string): Promise<void> {
+  await getTestDb()`
+    UPDATE organization SET system_agent_id = ${agentId} WHERE id = ${orgId}
+  `;
+}
+
+async function seedOwnerBuilder(): Promise<{
+  orgId: string;
+  userId: string;
+  systemAgentId: string;
+}> {
+  const org = await createTestOrganization();
+  const user = await createTestUser();
+  await addUserToOrganization(user.id, org.id, 'owner');
+  const agent = await createTestAgent({ organizationId: org.id });
+  await setSystemAgent(org.id, agent.agentId);
+  return { orgId: org.id, userId: user.id, systemAgentId: agent.agentId };
+}
+
+describe('resolveBuilderAdminTools — platform identity resolution (WI-0.2)', () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('grants builder tools for a Slack run once the platform id maps to the owner', async () => {
+    const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
+    await linkSlackIdentity({
+      teamId: SLACK_TEAM,
+      platformUserId: SLACK_USER,
+      lobuUserId: userId,
+    });
+
+    const granted = await resolveBuilderAdminTools({
+      agentId: systemAgentId,
+      organizationId: orgId,
+      // A Slack run carries the raw platform id, NOT the Lobu user id.
+      userId: SLACK_USER,
+      platform: 'slack',
+      teamId: SLACK_TEAM,
+    });
+
+    expect(granted).toEqual([...BUILDER_ADMIN_TOOLS]);
+  });
+
+  it('withholds the grant for a Slack run whose platform id is not linked to any member', async () => {
+    const { orgId, systemAgentId } = await seedOwnerBuilder();
+    // No linkSlackIdentity → the platform id resolves to no Lobu user.
+
+    const granted = await resolveBuilderAdminTools({
+      agentId: systemAgentId,
+      organizationId: orgId,
+      userId: SLACK_USER,
+      platform: 'slack',
+      teamId: SLACK_TEAM,
+    });
+
+    expect(granted).toBeUndefined();
+  });
+
+  it('scopes the identity by team: a Slack id linked in a DIFFERENT workspace grants nothing here', async () => {
+    const { orgId, systemAgentId } = await seedOwnerBuilder();
+    const other = await createTestUser();
+    // The same Slack platform_user_id is linked, but only in a DIFFERENT team.
+    // The resolver is team-scoped, so resolving for SLACK_TEAM finds no link and
+    // the owner of the OTHER workspace can't ride this org's builder grant.
+    await linkSlackIdentity({
+      teamId: 'T_OTHER',
+      platformUserId: SLACK_USER,
+      lobuUserId: other.id,
+    });
+
+    const granted = await resolveBuilderAdminTools({
+      agentId: systemAgentId,
+      organizationId: orgId,
+      userId: SLACK_USER,
+      platform: 'slack',
+      teamId: SLACK_TEAM,
+    });
+
+    expect(granted).toBeUndefined();
+  });
+
+  it('grants builder tools for a web/session run using userId directly (no identity lookup)', async () => {
+    const { orgId, userId, systemAgentId } = await seedOwnerBuilder();
+    // platform 'api' → userId is already the Lobu user id, used directly.
+    const granted = await resolveBuilderAdminTools({
+      agentId: systemAgentId,
+      organizationId: orgId,
+      userId,
+      platform: 'api',
+    });
+
+    expect(granted).toEqual([...BUILDER_ADMIN_TOOLS]);
+  });
+
+  it('withholds the grant for a member who is not owner/admin', async () => {
+    const org = await createTestOrganization();
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, org.id, 'member');
+    const agent = await createTestAgent({ organizationId: org.id });
+    await setSystemAgent(org.id, agent.agentId);
+    await linkSlackIdentity({
+      teamId: SLACK_TEAM,
+      platformUserId: SLACK_USER,
+      lobuUserId: user.id,
+    });
+
+    const granted = await resolveBuilderAdminTools({
+      agentId: agent.agentId,
+      organizationId: org.id,
+      userId: SLACK_USER,
+      platform: 'slack',
+      teamId: SLACK_TEAM,
+    });
+
+    expect(granted).toBeUndefined();
+  });
+});

--- a/packages/server/src/gateway/commands/built-in-commands.ts
+++ b/packages/server/src/gateway/commands/built-in-commands.ts
@@ -6,8 +6,8 @@ import {
   consumePreviewClaim,
   listPreviewAgents,
   previewAgentMenu,
-  resolveChatUserIdentity,
 } from "../../preview/slack.js";
+import { resolveChatUserIdentity } from "../../lobu/stores/chat-identity.js";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
 import {
   resolveEffectiveModelRef,

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -104,8 +104,9 @@ export async function resolveBuilderAdminTools(args: {
   if (!args.agentId || !args.organizationId || !args.userId) return undefined;
   try {
     // Map a platform user id to its linked Lobu user before the member join.
-    // Collision-safe (resolveChatUserIdentity returns null on an ambiguous
-    // link), so a grant is only ever made for an unambiguously-identified user.
+    // resolveChatUserIdentity is workspace-scoped (keyed on the PK
+    // platform+team_id+platform_user_id) and returns null when the id isn't
+    // linked, so a grant is only ever made for a linked, known user.
     const platform = args.platform;
     const isChatPlatform =
       platform != null && platform !== "api" && platform !== "";

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -41,6 +41,7 @@ import {
 } from "./deployment-manager.js";
 import { buildWorkerTokenClaims } from "./worker-token-claims.js";
 import { resolveAgentRuntimeSelection } from "../../lobu/stores/environment-store.js";
+import { resolveChatUserIdentity } from "../../lobu/stores/chat-identity.js";
 import { getDb } from "../../db/client.js";
 
 const logger = createLogger("orchestrator");
@@ -89,15 +90,35 @@ export async function resolveBuilderAdminTools(args: {
   agentId?: string;
   organizationId?: string;
   userId?: string;
+  /**
+   * Platform this turn originated from. On a chat platform (slack/telegram/…)
+   * `userId` is the PLATFORM user id (e.g. Slack `U…`), NOT a Lobu user id, so
+   * the member lookup below would never match and an org owner driving the
+   * builder from Slack would silently lose the admin grant. We resolve the
+   * platform id → linked Lobu user first. Absent / "api" → `userId` is already
+   * the session's Lobu user id and is used directly.
+   */
+  platform?: string;
+  teamId?: string;
 }): Promise<string[] | undefined> {
   if (!args.agentId || !args.organizationId || !args.userId) return undefined;
   try {
+    // Map a platform user id to its linked Lobu user before the member join.
+    // Collision-safe (resolveChatUserIdentity returns null on an ambiguous
+    // link), so a grant is only ever made for an unambiguously-identified user.
+    const platform = args.platform;
+    const isChatPlatform =
+      platform != null && platform !== "api" && platform !== "";
+    const lobuUserId = isChatPlatform
+      ? await resolveChatUserIdentity(platform, args.teamId, args.userId)
+      : args.userId;
+    if (!lobuUserId) return undefined;
     const sql = getDb();
     const rows = (await sql`
       SELECT o.system_agent_id, m.role
       FROM organization o
       LEFT JOIN "member" m
-        ON m."organizationId" = o.id AND m."userId" = ${args.userId}
+        ON m."organizationId" = o.id AND m."userId" = ${lobuUserId}
       WHERE o.id = ${args.organizationId}
       LIMIT 1
     `) as unknown as Array<{ system_agent_id: string | null; role: string | null }>;
@@ -351,6 +372,8 @@ export class MessageConsumer {
         agentId: data.agentId,
         organizationId: data.organizationId,
         userId: data.userId,
+        platform: data.platform,
+        teamId: data.teamId,
       });
 
       // Resolve the agent's selected execution environment → runtime provider +

--- a/packages/server/src/lobu/stores/chat-identity.ts
+++ b/packages/server/src/lobu/stores/chat-identity.ts
@@ -19,13 +19,13 @@ import { getDb } from "../../db/client.js";
 /**
  * The Lobu user id a chat-platform user has linked to, or null.
  *
- * Collision-safe: `platform_user_id` is only unique WITHIN a workspace, so the
- * same id can exist for two different Lobu users across workspaces. We scope by
- * `team_id` and require EXACTLY one match — if two rows come back (a genuine
- * cross-workspace collision, or a stale/duplicate link) we return null rather
- * than pick one arbitrarily. Callers use this to grant privilege (builder admin
- * tools, owner re-bind), so an ambiguous identity must resolve to "unknown",
- * never to the wrong user.
+ * Scoped by workspace: `platform_user_id` is only unique WITHIN a workspace, so
+ * the same id can map to different Lobu users across workspaces. This query
+ * filters on all three columns of the `(platform, team_id, platform_user_id)`
+ * primary key, so it returns at most one row — the workspace scoping is what
+ * makes the lookup unambiguous. Callers use this to grant privilege (builder
+ * admin tools, owner re-bind), so an unlinked id must resolve to null, never to
+ * the wrong user.
  */
 export async function resolveChatUserIdentity(
 	platform: string,
@@ -35,10 +35,9 @@ export async function resolveChatUserIdentity(
 	const rows = await getDb()<{ lobu_user_id: string }>`
     SELECT lobu_user_id FROM chat_user_identities
     WHERE platform = ${platform} AND team_id = ${teamId ?? ""} AND platform_user_id = ${platformUserId}
-    LIMIT 2
+    LIMIT 1
   `;
-	if (rows.length !== 1) return null;
-	return rows[0].lobu_user_id;
+	return rows[0]?.lobu_user_id ?? null;
 }
 
 /**

--- a/packages/server/src/lobu/stores/chat-identity.ts
+++ b/packages/server/src/lobu/stores/chat-identity.ts
@@ -1,0 +1,73 @@
+import { getDb } from "../../db/client.js";
+
+/**
+ * Cross-connector chat-identity mapping: `(platform, team_id, platform_user_id)
+ * → lobu_user_id`.
+ *
+ * The `chat_user_identities` table is platform-agnostic — Slack, Telegram, or a
+ * custom connector all link the same way. This module is the generic seam for
+ * resolving and linking those identities so callers don't reach into any one
+ * connector's module (e.g. `preview/slack`). It maps a PLATFORM user id (what a
+ * connector run carries) to the canonical Lobu `user` it's linked to.
+ *
+ * NOTE: this is a 1:1 platform-identity → user link, NOT cross-platform identity
+ * CONSOLIDATION (one human's Slack + Telegram + custom identities merged to one
+ * canonical user). That merge layer is a separate design — see the identity-
+ * consolidation RFC.
+ */
+
+/**
+ * The Lobu user id a chat-platform user has linked to, or null.
+ *
+ * Collision-safe: `platform_user_id` is only unique WITHIN a workspace, so the
+ * same id can exist for two different Lobu users across workspaces. We scope by
+ * `team_id` and require EXACTLY one match — if two rows come back (a genuine
+ * cross-workspace collision, or a stale/duplicate link) we return null rather
+ * than pick one arbitrarily. Callers use this to grant privilege (builder admin
+ * tools, owner re-bind), so an ambiguous identity must resolve to "unknown",
+ * never to the wrong user.
+ */
+export async function resolveChatUserIdentity(
+	platform: string,
+	teamId: string | undefined,
+	platformUserId: string,
+): Promise<string | null> {
+	const rows = await getDb()<{ lobu_user_id: string }>`
+    SELECT lobu_user_id FROM chat_user_identities
+    WHERE platform = ${platform} AND team_id = ${teamId ?? ""} AND platform_user_id = ${platformUserId}
+    LIMIT 2
+  `;
+	if (rows.length !== 1) return null;
+	return rows[0].lobu_user_id;
+}
+
+/**
+ * Link a chat-platform identity to a Lobu user. Generic across connectors.
+ *
+ * Safety guard: an already-linked `(platform, team_id, platform_user_id)` is
+ * NEVER silently re-bound to a DIFFERENT Lobu user by a later call — the
+ * `ON CONFLICT … WHERE lobu_user_id = EXCLUDED.lobu_user_id` predicate only
+ * touches `updated_at` when the mapping is unchanged, so a stale/malicious
+ * re-link is a no-op rather than an account takeover. Re-binding to a new user
+ * is a deliberate operation that must delete the old row first.
+ *
+ * Pass a transaction handle as `sql` to link atomically with a surrounding
+ * write (e.g. the link-claim path); omit it to run on the pooled connection.
+ */
+export async function linkChatUserIdentity(
+	opts: {
+		platform: string;
+		teamId?: string;
+		platformUserId: string;
+		lobuUserId: string;
+	},
+	sql: ReturnType<typeof getDb> = getDb(),
+): Promise<void> {
+	await sql`
+    INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id, updated_at)
+    VALUES (${opts.platform}, ${opts.teamId ?? ""}, ${opts.platformUserId}, ${opts.lobuUserId}, now())
+    ON CONFLICT (platform, team_id, platform_user_id)
+      DO UPDATE SET updated_at = now()
+      WHERE chat_user_identities.lobu_user_id = EXCLUDED.lobu_user_id
+  `;
+}

--- a/packages/server/src/preview/__tests__/slack-preview.test.ts
+++ b/packages/server/src/preview/__tests__/slack-preview.test.ts
@@ -12,6 +12,7 @@ import {
 import { getDb } from "../../db/client.js";
 import { registerBuiltInCommands } from "../../gateway/commands/built-in-commands.js";
 import type { Env } from "../../index";
+import { resolveChatUserIdentity } from "../../lobu/stores/chat-identity.js";
 import {
   bindChatToAgentForOwner,
   bindChatToPreviewAgent,
@@ -20,7 +21,6 @@ import {
   createPreviewClaim,
   listPreviewAgents,
   previewAgentMenu,
-  resolveChatUserIdentity,
 } from "../slack";
 
 /** Inlined from preview/slack.ts — DM channels start with `D`. */

--- a/packages/server/src/preview/slack.ts
+++ b/packages/server/src/preview/slack.ts
@@ -2,6 +2,7 @@ import { createHash, randomInt } from "node:crypto";
 import { slugify } from "@lobu/core";
 import type { Context } from "hono";
 import { getDb } from "../db/client";
+import { linkChatUserIdentity } from "../lobu/stores/chat-identity";
 import { maybeSendSlackWorkspaceWelcome } from "../gateway/connections/slack-connection-coordinator";
 import { parseJsonBody } from "../gateway/routes/shared/helpers";
 import { SecretStoreRegistry } from "../gateway/secrets";
@@ -378,13 +379,15 @@ export async function consumePreviewClaim(args: {
 		// org admin/owner. Real identity proof (Slack OAuth / email match) is a
 		// follow-up.
 		if (claim.createdBy && platformUserId) {
-			await tx`
-        INSERT INTO chat_user_identities (platform, team_id, platform_user_id, lobu_user_id, updated_at)
-        VALUES (${platform}, ${teamId ?? ""}, ${platformUserId}, ${claim.createdBy}, now())
-        ON CONFLICT (platform, team_id, platform_user_id)
-          DO UPDATE SET updated_at = now()
-          WHERE chat_user_identities.lobu_user_id = EXCLUDED.lobu_user_id
-      `;
+			await linkChatUserIdentity(
+				{
+					platform,
+					teamId,
+					platformUserId,
+					lobuUserId: claim.createdBy,
+				},
+				tx,
+			);
 		}
 
 		return {
@@ -717,20 +720,6 @@ export async function workspaceUnlinkedNotice(
 
 	// No agents yet (or the lookup failed) — CLI path only.
 	return [header, "", cliLine].join("\n");
-}
-
-/** The Lobu user id a chat-platform user has linked to, or null. */
-export async function resolveChatUserIdentity(
-	platform: string,
-	teamId: string | undefined,
-	platformUserId: string,
-): Promise<string | null> {
-	const rows = await getDb()<{ lobu_user_id: string }>`
-    SELECT lobu_user_id FROM chat_user_identities
-    WHERE platform = ${platform} AND team_id = ${teamId ?? ""} AND platform_user_id = ${platformUserId}
-    LIMIT 1
-  `;
-	return rows[0]?.lobu_user_id ?? null;
 }
 
 type BindForOwnerResult = { status: "bound" } | { status: "forbidden" };

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1210,277 +1210,44 @@ async function resolveReviewer(ctx: ToolContext): Promise<ApprovalReviewer | nul
 }
 
 /**
- * Claim a pending builder-gate run (manage_agents create/update/delete) for the
- * given action. Returns the claimed run row (with the held proposal +
- * requester) or null when this run_id isn't a pending manage_agents run — in
- * which case the caller falls through to the connector-operation path.
+ * Builder-gate approval handler: the per-family knobs the ONE generic
+ * claim/approve/reject path varies over. manage_agents and manage_watchers both
+ * queue a pending `run_type='internal'` run keyed by `action_key`, hold the
+ * proposal in `action_input`, and apply it via `apply(proposal, ctx, env,
+ * ownerUserId)` on approval — so the whole lifecycle is shared and only these
+ * fields differ. Add a new builder family by registering another handler here.
  */
-async function claimManageAgentsRun(
-	runId: number,
-	organizationId: string,
-	decision: "approved" | "rejected",
-	rejectReason?: string,
-): Promise<{
-	proposal: ManageAgentsProposal;
-	requesterUserId: string | null;
-} | null> {
-	const sql = getDb();
-	const rows =
-		decision === "approved"
-			? await sql`
-          UPDATE runs
-          SET approval_status = 'approved', status = 'running'
-          WHERE id = ${runId}
-            AND organization_id = ${organizationId}
-            AND approval_status = 'pending'
-            AND run_type = 'internal'
-            AND action_key = ${MANAGE_AGENTS_ACTION_KEY}
-          RETURNING action_input, created_by_user_id
-        `
-      : await sql`
-          UPDATE runs
-          SET approval_status = 'rejected', status = 'cancelled',
-              error_message = ${rejectReason ?? 'Rejected by user'}, completed_at = NOW()
-          WHERE id = ${runId}
-            AND organization_id = ${organizationId}
-            AND approval_status = 'pending'
-            AND run_type = 'internal'
-            AND action_key = ${MANAGE_AGENTS_ACTION_KEY}
-          RETURNING action_input, created_by_user_id
-        `;
-  if (rows.length === 0) return null;
-  const row = rows[0] as {
-    action_input: ManageAgentsProposal | null;
-    created_by_user_id: string | null;
-  };
-  if (!row.action_input) return null;
-  return { proposal: row.action_input, requesterUserId: row.created_by_user_id };
+interface BuilderApprovalHandler {
+	/** `runs.action_key` this family's pending rows carry. */
+	actionKey: string;
+	/** Noun for the result message, e.g. "Agent" / "Watcher". */
+	nounLabel: string;
+	/** The proposal shape stored in `action_input` is valid for this family. */
+	isValidProposal(proposal: unknown): boolean;
+	/** Apply the held proposal on approval (the family's write handler). */
+	apply(
+		proposal: unknown,
+		ctx: ToolContext,
+		env: Env,
+		ownerUserId: string | null,
+	): Promise<unknown>;
+	/** One-line action id for event summaries, e.g. `create agent-7`. */
+	describe(proposal: unknown): string;
+	/**
+	 * Optional soft-failure detector for handlers that return `{ error }` /
+	 * partial-failure summaries instead of throwing (manage_watchers). A non-null
+	 * string marks the apply failed even though it didn't throw.
+	 */
+	detectSoftFailure?(output: unknown): string | null;
 }
 
 /**
- * Approve + apply a builder-gate manage_agents run. Returns a result when the
- * run was a pending manage_agents run; null to fall through to the
- * connector-operation approval path.
- */
-async function tryApproveManageAgentsRun(
-	args: Static<typeof ApproveAction>,
-	ctx: ToolContext,
-	env: Env,
-): Promise<ManageOperationsResult | null> {
-	const claimed = await claimManageAgentsRun(
-		args.run_id,
-		ctx.organizationId,
-		"approved",
-	);
-	if (!claimed) return null;
-
-	const { proposal, requesterUserId } = claimed;
-	const reviewer = await resolveReviewer(ctx);
-	await supersedeActionEvent(
-		args.run_id,
-		ctx.organizationId,
-		"confirmed",
-		`manage_agents.${proposal.action} — executing`,
-		`Builder action confirmed: ${proposal.action} ${proposal.agent_id}`,
-		{},
-		reviewer,
-	);
-
-	try {
-		const output = await applyManageAgentsProposal(
-			proposal,
-			ctx,
-			env,
-			requesterUserId,
-		);
-		await getDb()`
-      UPDATE runs SET status = 'completed', completed_at = NOW(),
-        action_output = ${getDb().json(output as unknown as Record<string, unknown>)}
-      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
-    `;
-		const eventId = await supersedeActionEvent(
-			args.run_id,
-			ctx.organizationId,
-			"completed",
-			`manage_agents.${proposal.action} — completed`,
-			`Builder action completed: ${proposal.action} ${proposal.agent_id}`,
-			{ output: output as unknown as Record<string, unknown> },
-			reviewer,
-		);
-		return {
-			action: "approve",
-			approved: true,
-			run_id: args.run_id,
-			event_id: eventId,
-			message: `Agent ${proposal.action} approved and applied.`,
-		};
-	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error);
-		await getDb()`
-      UPDATE runs SET status = 'failed', completed_at = NOW(), error_message = ${errorMessage}
-      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
-    `;
-		const eventId = await supersedeActionEvent(
-			args.run_id,
-			ctx.organizationId,
-			"failed",
-			`manage_agents.${proposal.action} — failed`,
-			`Builder action failed: ${proposal.action} ${proposal.agent_id} — ${errorMessage}`,
-			{ error_message: errorMessage },
-			reviewer,
-		);
-		return {
-			action: "approve",
-			approved: true,
-			run_id: args.run_id,
-			event_id: eventId,
-			message: `Agent ${proposal.action} approved but failed: ${errorMessage}`,
-		};
-	}
-}
-
-/**
- * Claim a pending builder-gate manage_watchers run (create/update/delete/…).
- * Mirrors {@link claimManageAgentsRun}. Returns null when this run_id isn't a
- * pending manage_watchers run — caller falls through to the next approval path.
- */
-async function claimManageWatchersRun(
-	runId: number,
-	organizationId: string,
-	decision: "approved" | "rejected",
-	rejectReason?: string,
-): Promise<{
-	proposal: ManageWatchersProposal;
-	requesterUserId: string | null;
-} | null> {
-	const sql = getDb();
-	const rows =
-		decision === "approved"
-			? await sql`
-          UPDATE runs
-          SET approval_status = 'approved', status = 'running'
-          WHERE id = ${runId}
-            AND organization_id = ${organizationId}
-            AND approval_status = 'pending'
-            AND run_type = 'internal'
-            AND action_key = ${MANAGE_WATCHERS_ACTION_KEY}
-          RETURNING action_input, created_by_user_id
-        `
-			: await sql`
-          UPDATE runs
-          SET approval_status = 'rejected', status = 'cancelled',
-              error_message = ${rejectReason ?? "Rejected by user"}, completed_at = NOW()
-          WHERE id = ${runId}
-            AND organization_id = ${organizationId}
-            AND approval_status = 'pending'
-            AND run_type = 'internal'
-            AND action_key = ${MANAGE_WATCHERS_ACTION_KEY}
-          RETURNING action_input, created_by_user_id
-        `;
-	if (rows.length === 0) return null;
-	const row = rows[0] as {
-		action_input: ManageWatchersProposal | null;
-		created_by_user_id: string | null;
-	};
-	if (!row.action_input?.args) return null;
-	return { proposal: row.action_input, requesterUserId: row.created_by_user_id };
-}
-
-/**
- * Approve + apply a builder-gate manage_watchers run. Returns a result when the
- * run was a pending manage_watchers run; null to fall through to the next path.
- * Routes the terminal event through {@link supersedeActionEvent} (must pass
- * supersedesEventId explicitly — origin-based auto-supersede needs a non-null
- * connection_id, which internal approval events don't have).
- */
-async function tryApproveManageWatchersRun(
-	args: Static<typeof ApproveAction>,
-	ctx: ToolContext,
-	env: Env,
-): Promise<ManageOperationsResult | null> {
-	const claimed = await claimManageWatchersRun(
-		args.run_id,
-		ctx.organizationId,
-		"approved",
-	);
-	if (!claimed) return null;
-
-	const { proposal, requesterUserId } = claimed;
-	const action = proposal.args.action;
-	const reviewer = await resolveReviewer(ctx);
-	await supersedeActionEvent(
-		args.run_id,
-		ctx.organizationId,
-		"confirmed",
-		`manage_watchers.${action} — executing`,
-		`Builder action confirmed: ${action}`,
-		{},
-		reviewer,
-	);
-
-	try {
-		const output = await applyManageWatchersProposal(
-			proposal,
-			ctx,
-			env,
-			requesterUserId,
-		);
-		// handleCreate throws on invalid schedule/timezone, but handleUpdate
-		// returns `{ error }` and handleDelete returns a summary with
-		// failed/successful counts (no throw). Detect soft failures here so we
-		// don't mark the run completed when nothing applied.
-		const softFailure = detectManageWatchersApplyFailure(output);
-		if (softFailure) {
-			return failManageWatchersApproval(
-				args.run_id,
-				ctx.organizationId,
-				action,
-				softFailure,
-				reviewer,
-			);
-		}
-		await getDb()`
-      UPDATE runs SET status = 'completed', completed_at = NOW(),
-        action_output = ${getDb().json(output as unknown as Record<string, unknown>)}
-      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
-    `;
-		const eventId = await supersedeActionEvent(
-			args.run_id,
-			ctx.organizationId,
-			"completed",
-			`manage_watchers.${action} — completed`,
-			`Builder action completed: ${action}`,
-			{ output: output as unknown as Record<string, unknown> },
-			reviewer,
-		);
-		return {
-			action: "approve",
-			approved: true,
-			run_id: args.run_id,
-			event_id: eventId,
-			message: `Watcher ${action} approved and applied.`,
-		};
-	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error);
-		return failManageWatchersApproval(
-			args.run_id,
-			ctx.organizationId,
-			action,
-			errorMessage,
-			reviewer,
-		);
-	}
-}
-
-/**
- * Detect soft failures from manage_watchers write handlers that return errors
- * instead of throwing. create throws (ToolUserError); update returns
- * `{ error: string }` for invalid cron/timezone; delete returns a summary with
- * per-id results and never throws on individual archive failures.
- *
- * Partial delete success (some succeeded, some failed) is treated as completed
- * — the summary is preserved in action_output so the reviewer can see which
- * ids failed.
+ * Soft failures from manage_watchers write handlers that return errors instead
+ * of throwing. create throws (ToolUserError); update returns `{ error: string }`
+ * for invalid cron/timezone; delete returns a summary with per-id results and
+ * never throws on individual archive failures. Partial delete success (some
+ * succeeded, some failed) is treated as completed — the summary is preserved in
+ * action_output so the reviewer can see which ids failed.
  */
 function detectManageWatchersApplyFailure(output: unknown): string | null {
 	if (!output || typeof output !== "object") return null;
@@ -1506,10 +1273,97 @@ function detectManageWatchersApplyFailure(output: unknown): string | null {
 	return null;
 }
 
-async function failManageWatchersApproval(
+const BUILDER_APPROVAL_HANDLERS: BuilderApprovalHandler[] = [
+	{
+		actionKey: MANAGE_AGENTS_ACTION_KEY,
+		nounLabel: "Agent",
+		isValidProposal: (p) => p != null,
+		apply: (p, ctx, env, owner) =>
+			applyManageAgentsProposal(p as ManageAgentsProposal, ctx, env, owner),
+		describe: (p) => {
+			const proposal = p as ManageAgentsProposal;
+			return `${proposal.action} ${proposal.agent_id}`;
+		},
+	},
+	{
+		actionKey: MANAGE_WATCHERS_ACTION_KEY,
+		nounLabel: "Watcher",
+		isValidProposal: (p) => (p as ManageWatchersProposal | null)?.args != null,
+		apply: (p, ctx, env, owner) =>
+			applyManageWatchersProposal(p as ManageWatchersProposal, ctx, env, owner),
+		describe: (p) => (p as ManageWatchersProposal).args.action,
+		detectSoftFailure: detectManageWatchersApplyFailure,
+	},
+];
+
+/**
+ * Atomically claim a pending builder-gate run for ANY registered family. The
+ * `action_key = ANY(...)` predicate + `RETURNING action_key` lets one query
+ * cover every family and hand back the matching handler. Returns null when this
+ * run_id isn't a pending builder run (caller falls through to the next approval
+ * path). `run_type = 'internal'` scopes to builder runs; connector-operation
+ * runs (`run_type='action'`) are handled separately.
+ */
+async function claimBuilderRun(
 	runId: number,
 	organizationId: string,
-	action: string,
+	decision: "approved" | "rejected",
+	rejectReason?: string,
+): Promise<{
+	handler: BuilderApprovalHandler;
+	proposal: unknown;
+	requesterUserId: string | null;
+} | null> {
+	const sql = getDb();
+	const actionKeys = pgTextArray(
+		BUILDER_APPROVAL_HANDLERS.map((h) => h.actionKey),
+	);
+	const rows =
+		decision === "approved"
+			? await sql`
+          UPDATE runs
+          SET approval_status = 'approved', status = 'running'
+          WHERE id = ${runId}
+            AND organization_id = ${organizationId}
+            AND approval_status = 'pending'
+            AND run_type = 'internal'
+            AND action_key = ANY(${actionKeys})
+          RETURNING action_input, created_by_user_id, action_key
+        `
+			: await sql`
+          UPDATE runs
+          SET approval_status = 'rejected', status = 'cancelled',
+              error_message = ${rejectReason ?? "Rejected by user"}, completed_at = NOW()
+          WHERE id = ${runId}
+            AND organization_id = ${organizationId}
+            AND approval_status = 'pending'
+            AND run_type = 'internal'
+            AND action_key = ANY(${actionKeys})
+          RETURNING action_input, created_by_user_id, action_key
+        `;
+	if (rows.length === 0) return null;
+	const row = rows[0] as {
+		action_input: unknown;
+		created_by_user_id: string | null;
+		action_key: string;
+	};
+	const handler = BUILDER_APPROVAL_HANDLERS.find(
+		(h) => h.actionKey === row.action_key,
+	);
+	if (!handler || !handler.isValidProposal(row.action_input)) return null;
+	return {
+		handler,
+		proposal: row.action_input,
+		requesterUserId: row.created_by_user_id,
+	};
+}
+
+/** Mark a claimed builder run failed + supersede its card to 'failed'. */
+async function failBuilderRun(
+	runId: number,
+	organizationId: string,
+	handler: BuilderApprovalHandler,
+	desc: string,
 	errorMessage: string,
 	reviewer: ApprovalReviewer | null,
 ): Promise<ManageOperationsResult> {
@@ -1521,8 +1375,8 @@ async function failManageWatchersApproval(
 		runId,
 		organizationId,
 		"failed",
-		`manage_watchers.${action} — failed`,
-		`Builder action failed: ${action} — ${errorMessage}`,
+		`${handler.actionKey}.${desc} — failed`,
+		`Builder action failed: ${desc} — ${errorMessage}`,
 		{ error_message: errorMessage },
 		reviewer,
 	);
@@ -1531,13 +1385,133 @@ async function failManageWatchersApproval(
 		approved: true,
 		run_id: runId,
 		event_id: eventId,
-		message: `Watcher ${action} approved but failed: ${errorMessage}`,
+		message: `${handler.nounLabel} ${desc} approved but failed: ${errorMessage}`,
+	};
+}
+
+/**
+ * Approve + apply a builder-gate run of ANY registered family. Returns a result
+ * when the run was a pending builder run; null to fall through to the next
+ * approval path. Routes terminal events through {@link supersedeActionEvent}
+ * (supersedesEventId is passed explicitly — origin-based auto-supersede needs a
+ * non-null connection_id, which internal approval events don't have).
+ */
+async function tryApproveBuilderRun(
+	args: Static<typeof ApproveAction>,
+	ctx: ToolContext,
+	env: Env,
+): Promise<ManageOperationsResult | null> {
+	const claimed = await claimBuilderRun(
+		args.run_id,
+		ctx.organizationId,
+		"approved",
+	);
+	if (!claimed) return null;
+
+	const { handler, proposal, requesterUserId } = claimed;
+	const desc = handler.describe(proposal);
+	const reviewer = await resolveReviewer(ctx);
+	await supersedeActionEvent(
+		args.run_id,
+		ctx.organizationId,
+		"confirmed",
+		`${handler.actionKey}.${desc} — executing`,
+		`Builder action confirmed: ${desc}`,
+		{},
+		reviewer,
+	);
+
+	try {
+		const output = await handler.apply(proposal, ctx, env, requesterUserId);
+		// Some handlers return `{ error }` / partial-failure summaries instead of
+		// throwing — treat those as failures so the run isn't marked completed
+		// when nothing applied.
+		const softFailure = handler.detectSoftFailure?.(output) ?? null;
+		if (softFailure) {
+			return failBuilderRun(
+				args.run_id,
+				ctx.organizationId,
+				handler,
+				desc,
+				softFailure,
+				reviewer,
+			);
+		}
+		await getDb()`
+      UPDATE runs SET status = 'completed', completed_at = NOW(),
+        action_output = ${getDb().json(output as unknown as Record<string, unknown>)}
+      WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+    `;
+		const eventId = await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"completed",
+			`${handler.actionKey}.${desc} — completed`,
+			`Builder action completed: ${desc}`,
+			{ output: output as unknown as Record<string, unknown> },
+			reviewer,
+		);
+		return {
+			action: "approve",
+			approved: true,
+			run_id: args.run_id,
+			event_id: eventId,
+			message: `${handler.nounLabel} ${desc} approved and applied.`,
+		};
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		return failBuilderRun(
+			args.run_id,
+			ctx.organizationId,
+			handler,
+			desc,
+			errorMessage,
+			reviewer,
+		);
+	}
+}
+
+/**
+ * Reject a builder-gate run of ANY registered family: cancel it without
+ * applying the held mutation + supersede its card to 'rejected'. Returns a
+ * result when the run was a pending builder run; null to fall through.
+ */
+async function tryRejectBuilderRun(
+	args: Static<typeof RejectAction>,
+	ctx: ToolContext,
+	reason: string,
+	reviewer: ApprovalReviewer | null,
+): Promise<ManageOperationsResult | null> {
+	const claimed = await claimBuilderRun(
+		args.run_id,
+		ctx.organizationId,
+		"rejected",
+		reason,
+	);
+	if (!claimed) return null;
+
+	const { handler, proposal } = claimed;
+	const desc = handler.describe(proposal);
+	const eventId = await supersedeActionEvent(
+		args.run_id,
+		ctx.organizationId,
+		"rejected",
+		`${handler.actionKey}.${desc} — rejected`,
+		`Builder action rejected: ${desc}${args.reason ? ` — ${args.reason}` : ""}`,
+		{ reason },
+		reviewer,
+	);
+	return {
+		action: "reject",
+		rejected: true,
+		run_id: args.run_id,
+		event_id: eventId,
 	};
 }
 
 /**
  * Claim a pending entity_field_change run (a watcher field-change held for
- * approval). Mirrors claimManageAgentsRun. Returns the held proposal, or null when
+ * approval). Mirrors claimBuilderRun. Returns the held proposal, or null when
  * this run isn't a pending field-change run.
  */
 async function claimEntityChangeRun(
@@ -1850,13 +1824,10 @@ async function handleApprove(
 
 	// Builder-gate runs (manage_agents / manage_watchers create/update/delete)
 	// reuse this same durable approval path but have run_type='internal' + no
-	// connection. Apply them via their handlers rather than the connector-
-	// operation executor.
-	const builderResult = await tryApproveManageAgentsRun(args, ctx, env);
+	// connection. One generic path applies them via their registered handler
+	// rather than the connector-operation executor.
+	const builderResult = await tryApproveBuilderRun(args, ctx, env);
 	if (builderResult) return builderResult;
-
-	const watchersBuilderResult = await tryApproveManageWatchersRun(args, ctx, env);
-	if (watchersBuilderResult) return watchersBuilderResult;
 
 	// Watcher field-change gate (run_type='internal', action_key='entity_field_change'):
 	// approve applies the proposed value to the entity (now human-owned).
@@ -2106,54 +2077,8 @@ async function handleReject(
 	const reviewer = await resolveReviewer(ctx);
 
 	// Builder-gate run? Cancel it without applying the held mutation.
-	const claimedBuilder = await claimManageAgentsRun(
-		args.run_id,
-		ctx.organizationId,
-		"rejected",
-		reason,
-	);
-	if (claimedBuilder) {
-		const eventId = await supersedeActionEvent(
-			args.run_id,
-			ctx.organizationId,
-			"rejected",
-			`manage_agents.${claimedBuilder.proposal.action} — rejected`,
-			`Builder action rejected: ${claimedBuilder.proposal.action} ${claimedBuilder.proposal.agent_id}${args.reason ? ` — ${args.reason}` : ""}`,
-			{ reason },
-			reviewer,
-		);
-		return {
-			action: "reject",
-			rejected: true,
-			run_id: args.run_id,
-			event_id: eventId,
-		};
-	}
-
-	const claimedWatchersBuilder = await claimManageWatchersRun(
-		args.run_id,
-		ctx.organizationId,
-		"rejected",
-		reason,
-	);
-	if (claimedWatchersBuilder) {
-		const action = claimedWatchersBuilder.proposal.args.action;
-		const eventId = await supersedeActionEvent(
-			args.run_id,
-			ctx.organizationId,
-			"rejected",
-			`manage_watchers.${action} — rejected`,
-			`Builder action rejected: ${action}${args.reason ? ` — ${args.reason}` : ""}`,
-			{ reason },
-			reviewer,
-		);
-		return {
-			action: "reject",
-			rejected: true,
-			run_id: args.run_id,
-			event_id: eventId,
-		};
-	}
+	const builderReject = await tryRejectBuilderRun(args, ctx, reason, reviewer);
+	if (builderReject) return builderReject;
 
 	// Watcher field-change gate? Cancel it; the entity keeps its human-owned value.
 	const fieldChangeReject = await tryRejectEntityChangeRun(args, ctx);


### PR DESCRIPTION
Two independent pre-launch hardening pieces from the config-approvals chain, plus a review fix.

## 1. Refactor — collapse forked builder-gate approval path (`312d727f8`)
`manage_operations.ts` had two forked copies of the builder-gate claim/approve/reject logic — one for `manage_agents`, one for `manage_watchers` — with `handleApprove` calling both sequentially. Collapsed into one `claimBuilderRun`/`tryApproveBuilderRun`/`tryRejectBuilderRun` over a `BUILDER_APPROVAL_HANDLERS` registry. Pure refactor, zero behavior change, net −75 lines. codex-approved (no defects).

## 2. WI-0.2 — resolve platform userId → Lobu member for admin-tool grant (`d74d44857`)
On a Slack run, `resolveBuilderAdminTools` joined `member.userId = data.userId`, but `data.userId` is the raw platform id (`U…`), never a member UUID — so the org owner driving the builder agent from Slack silently lost admin tools. Now resolves the platform identity to its Lobu user first (generic across connectors, not Slack-specific). Moved `resolveChatUserIdentity` + `linkChatUserIdentity` to a neutral `lobu/stores/chat-identity.ts` (collision-safe resolve + account-takeover-guarded link). 5 new integration tests, red→green proven.

## 3. Review fix (`61d4233a5`)
codex flagged a stale import (`slack-preview.test.ts` still imported the moved function from `../slack`) and that the PK-scoped resolve query's `LIMIT 2` collision guard defends against an unreachable case. Both fixed.

## Verification
- `bunx tsc --noEmit -p packages/server/tsconfig.json` clean
- 26 tests green under CI's singleFork config (server integration + slack-preview)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786559499&installation_id=136316292&pr_number=1912&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1912&signature=b82743bd7d807d7f4d997c508646572060c7ed7a8185a7f1fd57b0f22d87429e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat-platform identities can now be securely linked to Lobu accounts, enabling accurate access and permissions across supported platforms.
  - Builder administration tools are granted based on the linked account’s organization role, including support for Slack and web/API sessions.

- **Improvements**
  - Builder approval and rejection workflows are now handled consistently across supported builder operations.
  - Identity links are protected against unintended reassignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->