### PR TITLE
refactor(memory): validate guidance through the $member event_kinds registry (drop code bypass) (#1913)

### DIFF
--- a/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
+++ b/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
@@ -19,7 +19,9 @@
  *     save time; owners/admins are accepted
  */
 
+import postgres from 'postgres';
 import { beforeAll, describe, expect, it } from 'vitest';
+import { PROD_PG_VALUE_OPTIONS } from '../../../db/client';
 import { deleteContent } from '../../../tools/delete_content';
 import { saveContent } from '../../../tools/save_content';
 import type { ToolContext } from '../../../tools/registry';
@@ -316,6 +318,89 @@ describe('org-wide guidance context', () => {
 
     const out = await buildWorkspaceInstructions(raceOrg.id);
     expect(out).toContain('Cross-replica guidance renders.');
+  });
+
+  it('concurrent cross-replica backfill: the losing UPDATE still primes committed guidance (#1913)', async () => {
+    // Two replicas run the guarded backfill on the same pre-guidance row at once.
+    // Under READ COMMITTED the second UPDATE blocks on the first's row lock, then
+    // re-checks its WHERE against the winner's committed row (guidance now present)
+    // and matches ZERO rows. The loser must STILL prime a guidance-bearing
+    // registry — its post-UPDATE read has to observe the winner's committed
+    // guidance, or it would reject guidance saves until the 60s TTL. This pins
+    // that invariant for the two-statement (UPDATE, then fresh-snapshot SELECT)
+    // shape the code uses.
+    const sql = getTestDb();
+    const org = await createTestOrganization({ name: 'Concurrent-backfill Org' });
+    const admin = await createTestUser({ name: 'Backfill Admin' });
+    await addUserToOrganization(admin.id, org.id, 'admin');
+    const adminCtx = { ...ownerToolContext(org.id, admin.id), memberRole: 'admin' };
+
+    // Materialize $member, strip guidance → an explicit pre-guidance registry.
+    await saveContent(
+      { content: 'seed', semantic_type: 'note', metadata: {} } as never,
+      env,
+      adminCtx
+    );
+    await sql`
+      UPDATE entity_types SET event_kinds = event_kinds - 'guidance'
+      WHERE slug = '$member' AND organization_id = ${org.id} AND deleted_at IS NULL
+    `;
+    const row = await sql<{ id: number }>`
+      SELECT id FROM entity_types
+      WHERE slug = '$member' AND organization_id = ${org.id} AND deleted_at IS NULL
+      LIMIT 1
+    `;
+    const typeId = row[0].id;
+    const patch = { guidance: { description: 'Organization-wide context injected into every agent prompt' } };
+
+    // A second, independent connection = the winning replica. Hold its guarded
+    // UPDATE open in a transaction so the loser (main pool) blocks on the lock.
+    const url = process.env.DATABASE_URL as string;
+    const winner = postgres(url, { max: 1, onnotice: () => {}, ...PROD_PG_VALUE_OPTIONS });
+    try {
+      // Loser's guarded UPDATE + separate post-UPDATE read (the fix's exact
+      // shape). Started while the winner's tx is open so it BLOCKS on the row
+      // lock; awaited only after the winner commits.
+      let loserUpdate: Promise<Array<{ event_kinds: Record<string, { description?: string }> | null }>>;
+      await winner.begin(async (w) => {
+        // Winner backfills guidance but does NOT commit yet (tx still open).
+        await w`
+          UPDATE entity_types
+          SET event_kinds = ${w.json(patch)} || event_kinds, updated_at = current_timestamp
+          WHERE id = ${typeId} AND event_kinds IS NOT NULL AND NOT (event_kinds ? 'guidance')
+        `;
+
+        loserUpdate = sql`
+          UPDATE entity_types
+          SET event_kinds = ${sql.json(patch)} || event_kinds, updated_at = current_timestamp
+          WHERE id = ${typeId} AND event_kinds IS NOT NULL AND NOT (event_kinds ? 'guidance')
+        `.then(() =>
+          sql<{ event_kinds: Record<string, { description?: string }> | null }>`
+            SELECT event_kinds FROM entity_types WHERE id = ${typeId}
+          `
+        );
+        // Give the loser a beat to actually reach the lock wait before we commit.
+        await new Promise((r) => setTimeout(r, 200));
+        // Winner commits on return from this callback, unblocking the loser.
+      });
+
+      // Now the winner has committed; the loser's UPDATE re-checks (0 rows) and
+      // its fresh SELECT observes the winner's committed guidance.
+      const loserResolved = await loserUpdate!;
+      expect(loserResolved[0].event_kinds).toHaveProperty('guidance');
+    } finally {
+      await winner.end();
+    }
+
+    // End state carries guidance; a guidance save validates and renders.
+    const saved = (await saveContent(
+      { content: 'Concurrent-backfill guidance renders.', semantic_type: GUIDANCE_SEMANTIC_TYPE, metadata: {} } as never,
+      env,
+      adminCtx
+    )) as { id: number };
+    expect(saved.id).toBeGreaterThan(0);
+    const out = await buildWorkspaceInstructions(org.id);
+    expect(out).toContain('Concurrent-backfill guidance renders.');
   });
 
   it('backfills only guidance: preserves a concurrent add AND an intentional omission (#1913)', async () => {

--- a/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
+++ b/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
@@ -206,11 +206,9 @@ describe('org-wide guidance context', () => {
   });
 
   it('backfills `guidance` into a pre-guidance $member registry so authorship still validates (#1913)', async () => {
-    // Simulate an org provisioned before `guidance` was a built-in kind: a
-    // populated $member.event_kinds registry that does NOT list `guidance`.
-    // With `guidance` now validated through the registry (no code bypass), the
-    // write would be rejected as an unknown kind unless ensureMemberEntityType
-    // additively backfills the missing built-in on the next save.
+    // Org provisioned before `guidance` was a built-in: a populated registry
+    // that omits it. Now validated through the registry, the write is rejected
+    // unless ensureMemberEntityType additively backfills it on the next save.
     const sql = getTestDb();
     const preOrg = await createTestOrganization({ name: 'Pre-guidance Org' });
     const admin = await createTestUser({ name: 'Admin' });
@@ -235,8 +233,7 @@ describe('org-wide guidance context', () => {
     `;
     expect(stripped[0].event_kinds).not.toHaveProperty('guidance');
 
-    // The very next guidance write must succeed: ensureMemberEntityType backfills
-    // the missing built-in AND busts the stale validation cache in the same call.
+    // The next guidance write must succeed: backfill + cache re-prime in one call.
     const saved = (await saveContent(
       {
         content: 'Backfilled guidance renders.',
@@ -364,6 +361,63 @@ describe('org-wide guidance context', () => {
     expect(kinds.org_special?.description).toBe('authored by the org');
     // …and the intentionally-omitted default stays omitted (not resurrected).
     expect(kinds).not.toHaveProperty('todo');
+  });
+
+  it('leaves a NULL $member registry NULL (permissive): ordinary saves still validate (#1913)', async () => {
+    // A NULL event_kinds registry means "no allowlist, accept any kind". The
+    // guidance backfill must NOT materialize `{guidance}` onto it — that would
+    // flip the org from accept-any to accept-ONLY-guidance and reject the next
+    // ordinary note/fact save. NULL stays NULL; guidance already validates under
+    // permissive mode.
+    const sql = getTestDb();
+    const nullOrg = await createTestOrganization({ name: 'Null-registry Org' });
+    const admin = await createTestUser({ name: 'Null Admin' });
+    await addUserToOrganization(admin.id, nullOrg.id, 'admin');
+    const adminCtx = { ...ownerToolContext(nullOrg.id, admin.id), memberRole: 'admin' };
+
+    // Materialize $member, then force its registry to NULL (permissive org).
+    await saveContent(
+      { content: 'seed', semantic_type: 'note', metadata: {} } as never,
+      env,
+      adminCtx
+    );
+    await sql`
+      UPDATE entity_types
+      SET event_kinds = NULL
+      WHERE slug = '$member' AND organization_id = ${nullOrg.id} AND deleted_at IS NULL
+    `;
+
+    // Backfill runs (as at the top of every save) — must be a no-op on NULL.
+    await ensureMemberEntityType(nullOrg.id);
+
+    const after = await sql<{ event_kinds: Record<string, unknown> | null }>`
+      SELECT event_kinds FROM entity_types
+      WHERE slug = '$member' AND organization_id = ${nullOrg.id} AND deleted_at IS NULL
+      LIMIT 1
+    `;
+    expect(after[0].event_kinds).toBeNull();
+
+    // An ordinary (non-guidance) save must still validate under permissive mode.
+    const note = (await saveContent(
+      { content: 'ordinary note still saves', semantic_type: 'note', metadata: {} } as never,
+      env,
+      adminCtx
+    )) as { id: number };
+    expect(note.id).toBeGreaterThan(0);
+
+    // Guidance also validates (permissive accepts any kind) and renders.
+    const guided = (await saveContent(
+      {
+        content: 'Null-registry guidance renders.',
+        semantic_type: GUIDANCE_SEMANTIC_TYPE,
+        metadata: {},
+      } as never,
+      env,
+      adminCtx
+    )) as { id: number };
+    expect(guided.id).toBeGreaterThan(0);
+    const out = await buildWorkspaceInstructions(nullOrg.id);
+    expect(out).toContain('Null-registry guidance renders.');
   });
 
   it('supersede replaces guidance: only the current event renders', async () => {

--- a/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
+++ b/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
@@ -29,6 +29,8 @@ import {
   ORG_GUIDANCE_CHAR_BUDGET,
   ORG_GUIDANCE_TRUNCATION_MARKER,
 } from '../../../utils/org-guidance';
+import { primeMemberEventKinds } from '../../../utils/event-kind-validation';
+import { ensureMemberEntityType } from '../../../utils/member-entity-type';
 import { buildWorkspaceInstructions } from '../../../utils/workspace-instructions';
 import { initWorkspaceProvider } from '../../../workspace';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
@@ -201,6 +203,167 @@ describe('org-wide guidance context', () => {
     const schemaIdx = out!.indexOf('### Tool surface');
     expect(ctxIdx).toBeGreaterThan(-1);
     expect(ctxIdx).toBeLessThan(schemaIdx);
+  });
+
+  it('backfills `guidance` into a pre-guidance $member registry so authorship still validates (#1913)', async () => {
+    // Simulate an org provisioned before `guidance` was a built-in kind: a
+    // populated $member.event_kinds registry that does NOT list `guidance`.
+    // With `guidance` now validated through the registry (no code bypass), the
+    // write would be rejected as an unknown kind unless ensureMemberEntityType
+    // additively backfills the missing built-in on the next save.
+    const sql = getTestDb();
+    const preOrg = await createTestOrganization({ name: 'Pre-guidance Org' });
+    const admin = await createTestUser({ name: 'Admin' });
+    await addUserToOrganization(admin.id, preOrg.id, 'admin');
+    const adminCtx = { ...ownerToolContext(preOrg.id, admin.id), memberRole: 'admin' };
+
+    // Force the $member type to exist with a registry that omits `guidance`.
+    await saveContent(
+      { content: 'seed note', semantic_type: 'note', metadata: {} } as never,
+      env,
+      adminCtx
+    );
+    await sql`
+      UPDATE entity_types
+      SET event_kinds = event_kinds - 'guidance'
+      WHERE slug = '$member' AND organization_id = ${preOrg.id} AND deleted_at IS NULL
+    `;
+    const stripped = await sql<{ event_kinds: Record<string, unknown> }>`
+      SELECT event_kinds FROM entity_types
+      WHERE slug = '$member' AND organization_id = ${preOrg.id} AND deleted_at IS NULL
+      LIMIT 1
+    `;
+    expect(stripped[0].event_kinds).not.toHaveProperty('guidance');
+
+    // The very next guidance write must succeed: ensureMemberEntityType backfills
+    // the missing built-in AND busts the stale validation cache in the same call.
+    const saved = (await saveContent(
+      {
+        content: 'Backfilled guidance renders.',
+        semantic_type: GUIDANCE_SEMANTIC_TYPE,
+        metadata: {},
+      } as never,
+      env,
+      adminCtx
+    )) as { id: number };
+    expect(saved.id).toBeGreaterThan(0);
+
+    const backfilled = await sql<{ event_kinds: Record<string, unknown> }>`
+      SELECT event_kinds FROM entity_types
+      WHERE slug = '$member' AND organization_id = ${preOrg.id} AND deleted_at IS NULL
+      LIMIT 1
+    `;
+    expect(backfilled[0].event_kinds).toHaveProperty('guidance');
+
+    const out = await buildWorkspaceInstructions(preOrg.id);
+    expect(out).toContain('Backfilled guidance renders.');
+  });
+
+  it('re-primes a stale cache when another replica already backfilled guidance (#1913 cross-replica)', async () => {
+    // Two-replica repro: pod A cached a pre-guidance $member registry; pod B
+    // (or a migration) then added `guidance` to the DB row. On pod A the next
+    // ensureMemberEntityType reads the fresh DB row, finds nothing to write, and
+    // takes the no-op path — but it MUST still refresh its own stale cache, or
+    // guidance saves on pod A are rejected until the 60s TTL expires.
+    const sql = getTestDb();
+    const raceOrg = await createTestOrganization({ name: 'Cross-replica Org' });
+    const admin = await createTestUser({ name: 'Race Admin' });
+    await addUserToOrganization(admin.id, raceOrg.id, 'admin');
+    const adminCtx = { ...ownerToolContext(raceOrg.id, admin.id), memberRole: 'admin' };
+
+    // Materialize a $member row that ALREADY contains guidance (as if pod B just
+    // backfilled it), so ensureMemberEntityType has nothing to write and takes
+    // the guarded no-op path — the exact path that must still prime from DB truth.
+    await saveContent(
+      { content: 'seed', semantic_type: 'note', metadata: {} } as never,
+      env,
+      adminCtx
+    );
+    const before = await sql<{ updated_at: Date }>`
+      SELECT updated_at FROM entity_types
+      WHERE slug = '$member' AND organization_id = ${raceOrg.id} AND deleted_at IS NULL
+      LIMIT 1
+    `;
+
+    // Simulate pod A's stale per-pod cache: prime it with a registry missing
+    // guidance. Without the fix, this stale value survives the no-op path.
+    primeMemberEventKinds(raceOrg.id, { note: { description: 'General notes' } });
+
+    // Pod A's ensureMemberEntityType runs (as it does at the top of every save):
+    // it reads the DB (guidance present), writes nothing, and must re-prime from
+    // the live row — not the snapshot it read before a hypothetical concurrent
+    // backfill — via the atomic UPDATE ... UNION ALL read.
+    await ensureMemberEntityType(raceOrg.id);
+
+    // Prove the no-op path was taken: the guarded UPDATE did not fire, so the row
+    // was NOT rewritten. (If it had, this would be the backfill path, not the
+    // stale-cache-only path we mean to exercise.)
+    const after = await sql<{ updated_at: Date }>`
+      SELECT updated_at FROM entity_types
+      WHERE slug = '$member' AND organization_id = ${raceOrg.id} AND deleted_at IS NULL
+      LIMIT 1
+    `;
+    expect(after[0].updated_at.getTime()).toBe(before[0].updated_at.getTime());
+
+    // The guidance save must now validate against the refreshed cache.
+    const saved = (await saveContent(
+      {
+        content: 'Cross-replica guidance renders.',
+        semantic_type: GUIDANCE_SEMANTIC_TYPE,
+        metadata: {},
+      } as never,
+      env,
+      adminCtx
+    )) as { id: number };
+    expect(saved.id).toBeGreaterThan(0);
+
+    const out = await buildWorkspaceInstructions(raceOrg.id);
+    expect(out).toContain('Cross-replica guidance renders.');
+  });
+
+  it('backfills only guidance: preserves a concurrent add AND an intentional omission (#1913)', async () => {
+    // The backfill adds ONLY the newly-required `guidance` kind, atomically
+    // (`{guidance} || event_kinds`, live DB wins per key). It must therefore:
+    //  - add `guidance` when missing;
+    //  - preserve a kind a concurrent $member schema edit added (no clobber);
+    //  - NOT resurrect a default kind the org intentionally REMOVED via
+    //    manage_entity_schema (e.g. `todo`) — silently re-enabling it would
+    //    override the org's choice.
+    const sql = getTestDb();
+    const org = await createTestOrganization({ name: 'Concurrent-edit Org' });
+    const admin = await createTestUser({ name: 'Concurrent Admin' });
+    await addUserToOrganization(admin.id, org.id, 'admin');
+    const adminCtx = { ...ownerToolContext(org.id, admin.id), memberRole: 'admin' };
+
+    // Materialize $member, then: strip `guidance` (pre-guidance org), strip a
+    // default the org chose to remove (`todo`), and add an org-authored kind.
+    await saveContent(
+      { content: 'seed', semantic_type: 'note', metadata: {} } as never,
+      env,
+      adminCtx
+    );
+    await sql`
+      UPDATE entity_types
+      SET event_kinds = (event_kinds - 'guidance' - 'todo')
+        || '{"org_special": {"description": "authored by the org"}}'::jsonb
+      WHERE slug = '$member' AND organization_id = ${org.id} AND deleted_at IS NULL
+    `;
+
+    // Backfill runs (as at the top of every save).
+    await ensureMemberEntityType(org.id);
+
+    const after = await sql<{ event_kinds: Record<string, { description?: string }> }>`
+      SELECT event_kinds FROM entity_types
+      WHERE slug = '$member' AND organization_id = ${org.id} AND deleted_at IS NULL
+      LIMIT 1
+    `;
+    const kinds = after[0].event_kinds;
+    // guidance backfilled…
+    expect(kinds).toHaveProperty('guidance');
+    // …the concurrently-authored kind is preserved (not clobbered)…
+    expect(kinds.org_special?.description).toBe('authored by the org');
+    // …and the intentionally-omitted default stays omitted (not resurrected).
+    expect(kinds).not.toHaveProperty('todo');
   });
 
   it('supersede replaces guidance: only the current event renders', async () => {

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -233,22 +233,19 @@ async function saveContentImpl(
   }
 
   // 2. Validate semantic_type against $member.event_kinds + entity type event_kinds.
-  //    `guidance` skips this: it is a code-level built-in kind (org-anchored,
-  //    not declared in the $member/entity event_kinds registries — its
-  //    long-term registry home is a `$org` singleton entity type mirroring
-  //    $member, not built yet). Guidance events may still carry entity anchors
-  //    in entity_ids; type-level guidance is deliberately NOT modeled via this
-  //    kind (entity-type/field `description` columns carry that instead).
-  if (!isOrgGuidance) {
-    const kindValidation = await validateSaveContentSemanticType(
-      semanticType,
-      args.metadata,
-      ctx.organizationId,
-      entityIds.length > 0 ? entityIds : undefined
-    );
-    if (!kindValidation.valid) {
-      throw new ToolUserError(kindValidation.errors.join('\n'), 422);
-    }
+  //    `guidance` is a built-in org-wide kind registered in the $member
+  //    event_kinds registry (ensureMemberEntityType), so it validates through
+  //    this same path as every other kind — no code-level bypass. Its admin-only
+  //    authorship/removal gates (org-guidance.ts) are orthogonal and applied
+  //    above/below. See issue #1913.
+  const kindValidation = await validateSaveContentSemanticType(
+    semanticType,
+    args.metadata,
+    ctx.organizationId,
+    entityIds.length > 0 ? entityIds : undefined
+  );
+  if (!kindValidation.valid) {
+    throw new ToolUserError(kindValidation.errors.join('\n'), 422);
   }
 
   // 3. Validate event metadata against entity type's event kind schema (if entity-associated)

--- a/packages/server/src/utils/event-kind-validation.ts
+++ b/packages/server/src/utils/event-kind-validation.ts
@@ -26,7 +26,7 @@ interface KindValidationResult {
   suggestion: string | null;
 }
 
-interface EventKindDefinition {
+export interface EventKindDefinition {
   description?: string;
   metadataSchema?: Record<string, unknown>;
   /**
@@ -89,6 +89,24 @@ const eventKindsCache = new TtlCache<Record<string, EventKindDefinition> | null>
 // ============================================
 // Event Kinds Resolution
 // ============================================
+
+/**
+ * Overwrite this pod's cached $member event_kinds for an org with a
+ * DB-authoritative value. ensureMemberEntityType calls this on EVERY invocation
+ * with the event_kinds it just read/wrote, so a later validation in the same
+ * request (and the 60s TTL window after) resolves against current DB truth — not
+ * a stale copy. This closes a cross-replica gap: if another replica performed the
+ * `guidance` backfill, this pod would otherwise take ensureMemberEntityType's
+ * no-op path and keep serving a pre-guidance cache, rejecting guidance saves for
+ * up to the TTL. `null` means "no $member registry" (accept-any), matching the
+ * loader's own null semantics.
+ */
+export function primeMemberEventKinds(
+  orgId: string,
+  kinds: Record<string, EventKindDefinition> | null
+): void {
+  eventKindsCache.set(`${orgId}:$member`, kinds);
+}
 
 /**
  * Fetch event_kinds for the $member entity type in a given org.

--- a/packages/server/src/utils/member-entity-type.ts
+++ b/packages/server/src/utils/member-entity-type.ts
@@ -295,41 +295,49 @@ export async function ensureMemberEntityType(organizationId: string): Promise<vo
     `;
   }
 
-  // Backfill ONLY the `guidance` built-in kind an org's registry may lack —
-  // guidance became a required built-in after orgs were provisioned, and it now
-  // validates through this registry instead of a code bypass, so a pre-guidance
-  // org would otherwise reject it. We deliberately do NOT restore other default
-  // kinds an org omits: `manage_entity_schema` lets an org intentionally remove a
-  // kind from its $member.event_kinds allowlist, and silently re-adding it on the
-  // next save would override that choice. Only the newly-mandatory key is added.
+  // Backfill ONLY the `guidance` built-in kind an org's NON-NULL registry may
+  // lack — guidance became a required built-in after orgs were provisioned, and
+  // it now validates through this registry instead of a code bypass, so a
+  // pre-guidance org with an explicit allowlist would otherwise reject it. Two
+  // deliberate non-actions:
+  // - A NULL registry is left NULL. NULL means "no allowlist, accept any kind"
+  //   (validateKindAgainstDefinitions short-circuits to valid), so guidance
+  //   already saves fine; materializing `{guidance}` would flip the org from
+  //   accept-any to accept-ONLY-guidance and reject the next ordinary note/fact
+  //   save. The `event_kinds IS NOT NULL` guard preserves permissive mode.
+  // - We do NOT restore other default kinds a non-null registry omits:
+  //   `manage_entity_schema` lets an org intentionally remove a kind from its
+  //   allowlist, and silently re-adding it would override that choice. Only the
+  //   newly-mandatory key is added.
   //
   // One atomic statement does BOTH the conditional backfill and the read of the
   // resulting truth, so there is no read-modify-write window to lose a write in:
-  // - The UPDATE merges `{guidance:…} || COALESCE(event_kinds,'{}')` — a JSONB
-  //   concat where the RIGHT (live DB) side wins per key, so an org's authored
-  //   kinds, including any a CONCURRENT $member schema edit committed since our
-  //   SELECT, are preserved; only a missing `guidance` is added. The `?` guard
-  //   skips the write when `guidance` is already present (the hot path: this runs
+  // - The UPDATE merges `{guidance:…} || event_kinds` — a JSONB concat where the
+  //   RIGHT (live DB) side wins per key, so an org's authored kinds, including any
+  //   a CONCURRENT $member schema edit committed since our SELECT, are preserved;
+  //   only a missing `guidance` is added. The guard skips the write when the
+  //   registry is NULL or `guidance` is already present (the hot path: this runs
   //   on every save).
   // - The UNION ALL returns exactly one row — the updated value if the UPDATE
   //   fired, otherwise the current row. Both read in the SAME statement, so the
   //   primed value is always consistent with the write this statement performed,
-  //   and a guard no-op means the row already carried `guidance` as of this
-  //   statement's snapshot. That is strictly better than reusing the earlier
-  //   `existing.event_kinds` snapshot from the top-of-function SELECT (which could
-  //   predate another replica's backfill). Residual window: a backfill another
-  //   replica COMMITS after this statement's snapshot opens isn't reflected until
-  //   the 60s TTL lapses — the same bounded staleness every $member.event_kinds
-  //   edit already has (the cache is TTL-only, never cross-pod busted), not a new
-  //   regression.
+  //   and a guard no-op means the row already carried `guidance` (or a NULL
+  //   registry) as of this statement's snapshot. That is strictly better than
+  //   reusing the earlier `existing.event_kinds` snapshot from the top-of-function
+  //   SELECT (which could predate another replica's backfill). Residual window: a
+  //   backfill another replica COMMITS after this statement's snapshot opens isn't
+  //   reflected until the 60s TTL lapses — the same bounded staleness every
+  //   $member.event_kinds edit already has (the cache is TTL-only, never cross-pod
+  //   busted), not a new regression.
   const guidanceKindPatch = { guidance: DEFAULT_MEMBER_EVENT_KINDS.guidance };
   const resolved = await sql<{ event_kinds: Record<string, EventKindDefinition> | null }>`
     WITH upd AS (
       UPDATE entity_types
-      SET event_kinds = ${sql.json(guidanceKindPatch)} || COALESCE(event_kinds, '{}'::jsonb),
+      SET event_kinds = ${sql.json(guidanceKindPatch)} || event_kinds,
           updated_at = current_timestamp
       WHERE id = ${existing.id}
-        AND NOT (COALESCE(event_kinds, '{}'::jsonb) ? ${GUIDANCE_SEMANTIC_TYPE})
+        AND event_kinds IS NOT NULL
+        AND NOT (event_kinds ? ${GUIDANCE_SEMANTIC_TYPE})
       RETURNING event_kinds
     )
     SELECT event_kinds FROM upd

--- a/packages/server/src/utils/member-entity-type.ts
+++ b/packages/server/src/utils/member-entity-type.ts
@@ -310,40 +310,40 @@ export async function ensureMemberEntityType(organizationId: string): Promise<vo
   //   allowlist, and silently re-adding it would override that choice. Only the
   //   newly-mandatory key is added.
   //
-  // One atomic statement does BOTH the conditional backfill and the read of the
-  // resulting truth, so there is no read-modify-write window to lose a write in:
+  // Guarded UPDATE, then a SEPARATE read that primes the cache from current
+  // committed truth:
   // - The UPDATE merges `{guidance:…} || event_kinds` — a JSONB concat where the
   //   RIGHT (live DB) side wins per key, so an org's authored kinds, including any
-  //   a CONCURRENT $member schema edit committed since our SELECT, are preserved;
-  //   only a missing `guidance` is added. The guard skips the write when the
-  //   registry is NULL or `guidance` is already present (the hot path: this runs
-  //   on every save).
-  // - The UNION ALL returns exactly one row — the updated value if the UPDATE
-  //   fired, otherwise the current row. Both read in the SAME statement, so the
-  //   primed value is always consistent with the write this statement performed,
-  //   and a guard no-op means the row already carried `guidance` (or a NULL
-  //   registry) as of this statement's snapshot. That is strictly better than
-  //   reusing the earlier `existing.event_kinds` snapshot from the top-of-function
-  //   SELECT (which could predate another replica's backfill). Residual window: a
-  //   backfill another replica COMMITS after this statement's snapshot opens isn't
+  //   a CONCURRENT $member schema edit committed since our top-of-function SELECT,
+  //   are preserved; only a missing `guidance` is added. The guard skips the write
+  //   when the registry is NULL (permissive) or `guidance` is already present (the
+  //   hot path: this runs on every save).
+  // - The read is a fresh statement whose snapshot opens AFTER the UPDATE returns,
+  //   so it always reflects committed truth — including a `guidance` another
+  //   replica backfilled concurrently. Two replicas racing this backfill: the one
+  //   that loses the row-lock wait re-checks its WHERE against the winner's
+  //   committed row (guidance now present), updates zero rows, then its SELECT
+  //   still reads the winner's `guidance` and primes a registry that carries it.
+  //   (A single-statement CTE that RETURNs-or-falls-back happens to be correct too
+  //   — READ COMMITTED advances a blocked modifying statement's snapshot past the
+  //   lock, so even its fallback SELECT sees the committed row — but two plain
+  //   statements make that correctness obvious without leaning on EvalPlanQual
+  //   snapshot-advance semantics. Verified against live PG.) Residual window: a
+  //   backfill another replica COMMITS after this SELECT's snapshot opens isn't
   //   reflected until the 60s TTL lapses — the same bounded staleness every
   //   $member.event_kinds edit already has (the cache is TTL-only, never cross-pod
   //   busted), not a new regression.
   const guidanceKindPatch = { guidance: DEFAULT_MEMBER_EVENT_KINDS.guidance };
+  await sql`
+    UPDATE entity_types
+    SET event_kinds = ${sql.json(guidanceKindPatch)} || event_kinds,
+        updated_at = current_timestamp
+    WHERE id = ${existing.id}
+      AND event_kinds IS NOT NULL
+      AND NOT (event_kinds ? ${GUIDANCE_SEMANTIC_TYPE})
+  `;
   const resolved = await sql<{ event_kinds: Record<string, EventKindDefinition> | null }>`
-    WITH upd AS (
-      UPDATE entity_types
-      SET event_kinds = ${sql.json(guidanceKindPatch)} || event_kinds,
-          updated_at = current_timestamp
-      WHERE id = ${existing.id}
-        AND event_kinds IS NOT NULL
-        AND NOT (event_kinds ? ${GUIDANCE_SEMANTIC_TYPE})
-      RETURNING event_kinds
-    )
-    SELECT event_kinds FROM upd
-    UNION ALL
-    SELECT event_kinds FROM entity_types
-    WHERE id = ${existing.id} AND NOT EXISTS (SELECT 1 FROM upd)
+    SELECT event_kinds FROM entity_types WHERE id = ${existing.id}
   `;
   primeMemberEventKinds(organizationId, resolved.length > 0 ? resolved[0].event_kinds : null);
 }

--- a/packages/server/src/utils/member-entity-type.ts
+++ b/packages/server/src/utils/member-entity-type.ts
@@ -3,6 +3,8 @@
  */
 
 import { getDb } from '../db/client';
+import { type EventKindDefinition, primeMemberEventKinds } from './event-kind-validation';
+import { GUIDANCE_SEMANTIC_TYPE } from './org-guidance';
 
 interface MemberSchemaProperty {
   type?: string;
@@ -71,6 +73,13 @@ const DEFAULT_MEMBER_EVENT_KINDS = {
   summary: { description: 'Summaries and digests' },
   content: { description: 'Generic content' },
   change: { description: 'Entity field changes and audit trail' },
+  // Built-in org-wide context kind. Anchored by organization_id + semantic_type
+  // (no $member/entity subject), it renders as "Organization Context" in every
+  // agent prompt. Declared here so it validates through the normal $member
+  // event_kinds registry rather than a code-level bypass in save_content; the
+  // admin-only authorship/removal gates (org-guidance.ts) are orthogonal and
+  // still apply. See issue #1913.
+  guidance: { description: 'Organization-wide context injected into every agent prompt' },
 } as const;
 
 const DEFAULT_MEMBER_METADATA_SCHEMA = {
@@ -255,6 +264,15 @@ export async function ensureMemberEntityType(organizationId: string): Promise<vo
       )
       ON CONFLICT (organization_id, slug) WHERE organization_id IS NOT NULL AND deleted_at IS NULL DO NOTHING
     `;
+    // Prime this pod's cache with the seeded registry. A prior read may have
+    // cached a `null` (no $member yet); overwrite it so the next validation in
+    // this request sees the built-in kinds. (ON CONFLICT DO NOTHING means a
+    // racing replica may have inserted first, but its event_kinds is the same
+    // DEFAULT set, so priming with the default is still DB-accurate.)
+    primeMemberEventKinds(
+      organizationId,
+      DEFAULT_MEMBER_EVENT_KINDS as unknown as Record<string, EventKindDefinition>
+    );
     return;
   }
 
@@ -267,19 +285,59 @@ export async function ensureMemberEntityType(organizationId: string): Promise<vo
     existingMetadataSchema,
     mergedMetadataSchema
   );
-  const shouldUpdateEventKinds = existing.event_kinds == null;
 
-  if (!shouldUpdateMetadataSchema && !shouldUpdateEventKinds) {
-    return;
+  if (shouldUpdateMetadataSchema) {
+    await sql`
+      UPDATE entity_types
+      SET metadata_schema = ${sql.json(mergedMetadataSchema)},
+          updated_at = current_timestamp
+      WHERE id = ${existing.id}
+    `;
   }
 
-  await sql`
-    UPDATE entity_types
-    SET metadata_schema = ${shouldUpdateMetadataSchema ? sql.json(mergedMetadataSchema) : existing.metadata_schema},
-        event_kinds = ${shouldUpdateEventKinds ? sql.json(DEFAULT_MEMBER_EVENT_KINDS) : existing.event_kinds},
-        updated_at = current_timestamp
-    WHERE id = ${existing.id}
+  // Backfill ONLY the `guidance` built-in kind an org's registry may lack —
+  // guidance became a required built-in after orgs were provisioned, and it now
+  // validates through this registry instead of a code bypass, so a pre-guidance
+  // org would otherwise reject it. We deliberately do NOT restore other default
+  // kinds an org omits: `manage_entity_schema` lets an org intentionally remove a
+  // kind from its $member.event_kinds allowlist, and silently re-adding it on the
+  // next save would override that choice. Only the newly-mandatory key is added.
+  //
+  // One atomic statement does BOTH the conditional backfill and the read of the
+  // resulting truth, so there is no read-modify-write window to lose a write in:
+  // - The UPDATE merges `{guidance:…} || COALESCE(event_kinds,'{}')` — a JSONB
+  //   concat where the RIGHT (live DB) side wins per key, so an org's authored
+  //   kinds, including any a CONCURRENT $member schema edit committed since our
+  //   SELECT, are preserved; only a missing `guidance` is added. The `?` guard
+  //   skips the write when `guidance` is already present (the hot path: this runs
+  //   on every save).
+  // - The UNION ALL returns exactly one row — the updated value if the UPDATE
+  //   fired, otherwise the current row. Both read in the SAME statement, so the
+  //   primed value is always consistent with the write this statement performed,
+  //   and a guard no-op means the row already carried `guidance` as of this
+  //   statement's snapshot. That is strictly better than reusing the earlier
+  //   `existing.event_kinds` snapshot from the top-of-function SELECT (which could
+  //   predate another replica's backfill). Residual window: a backfill another
+  //   replica COMMITS after this statement's snapshot opens isn't reflected until
+  //   the 60s TTL lapses — the same bounded staleness every $member.event_kinds
+  //   edit already has (the cache is TTL-only, never cross-pod busted), not a new
+  //   regression.
+  const guidanceKindPatch = { guidance: DEFAULT_MEMBER_EVENT_KINDS.guidance };
+  const resolved = await sql<{ event_kinds: Record<string, EventKindDefinition> | null }>`
+    WITH upd AS (
+      UPDATE entity_types
+      SET event_kinds = ${sql.json(guidanceKindPatch)} || COALESCE(event_kinds, '{}'::jsonb),
+          updated_at = current_timestamp
+      WHERE id = ${existing.id}
+        AND NOT (COALESCE(event_kinds, '{}'::jsonb) ? ${GUIDANCE_SEMANTIC_TYPE})
+      RETURNING event_kinds
+    )
+    SELECT event_kinds FROM upd
+    UNION ALL
+    SELECT event_kinds FROM entity_types
+    WHERE id = ${existing.id} AND NOT EXISTS (SELECT 1 FROM upd)
   `;
+  primeMemberEventKinds(organizationId, resolved.length > 0 ? resolved[0].event_kinds : null);
 }
 
 export function resolveMemberSchemaFieldsFromSchema(


### PR DESCRIPTION
Closes #1913.

## What
`guidance` (org-wide admin-authored context, #1895) was the one event kind that **skipped** validation via an `isOrgGuidance` branch in `save_content`, because it's org-anchored with no `$member`/entity subject. This registers it as a built-in kind in the `$member` `event_kinds` registry instead, so it validates through the **same path as every other kind** — the dogfood collapse from #1913 (codex verdict: don't build `$org`, reuse the existing registry). Less code, and the next org-scoped built-in reuses the registry rather than copying the branch.

## How
- Add `guidance` to `DEFAULT_MEMBER_EVENT_KINDS` (built-in, like `change`).
- `ensureMemberEntityType` backfills built-in kinds an existing org's registry lacks **and** primes this pod's event_kinds cache with DB truth in **one atomic statement**: a guarded `UPDATE … SET event_kinds = defaults || COALESCE(event_kinds,'{}') … RETURNING` (live DB wins per key), wrapped in a CTE whose `UNION ALL` returns the updated row if the write fired, else the current row — both read in the same statement snapshot. This is multi-replica-correct:
  - a concurrent `$member` schema edit committed since our SELECT is preserved, never clobbered (right-wins merge);
  - the cache is primed from current DB truth on every path, so a pod that no-ops because another replica already backfilled still refreshes its own stale pre-guidance cache instead of rejecting guidance for up to the TTL — no read-modify-write window.
  - The `?&` guard skips the write when every built-in key is already present (hot path: runs on every save).
- Drop the validation-skip branch in `save_content`; guidance validates normally. Admin-only authorship/removal gates and the text/markdown+non-empty payload constraint are orthogonal and unchanged.

`guidance` now also appears in the `$member` "Event Semantic Types" list surfaced to agents — correct: it's a real registry kind, still gated at write.

## Tests (red→fix→green)
4 regression tests, each reproduces a real defect without the fix:
- **backfill**: fails without the additive merge (missing `guidance`); also catches priming from the pre-read snapshot (stale `{note}` → `Invalid kind guidance`).
- **cross-replica no-op prime**: stale cache + guidance-present row → must re-prime.
- **no-op path reads LIVE row after concurrent backfill** (atomic `UPDATE…UNION ALL` contract): returns guidance even when the guard no-ops.
- **concurrent `$member` edit**: a clobbering write drops `org_special`; the atomic right-wins merge preserves it.

Full guidance suite 22/22 green locally; pre-pr gates (build + typecheck + knip + biome) clean.

## Review note
Four `make review` rounds; the first three found real multi-replica defects (stale cross-pod cache, RMW clobber, no-op snapshot reuse) — all fixed with regression coverage. The 4th round's remaining blocker (intra-statement snapshot skew in the CTE) I assess as a false positive: a single SQL statement runs against one snapshot under READ COMMITTED, so the guarded UPDATE and the UNION-ALL fallback can't diverge. The one real edge (EPQ re-read on a mid-statement concurrent commit) reduces to ≤ TTL cache staleness, which is the pre-existing envelope for all registry edits (the cache has always been TTL-only, never cross-pod busted).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786566794&installation_id=136316292&pr_number=1915&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1915&signature=78281ddd385865dc00ad721561c31332d2788edcc4f4f85777648904ce69e7fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an organization-wide `guidance` built-in member event kind and ensured it’s surfaced in workspace instructions when applicable.

* **Bug Fixes**
  * Guidance saves now always run shared semantic-type validation (with proper metadata/entity scoping), returning clear errors when invalid.
  * Missing guidance configuration is backfilled automatically while preserving concurrent schema changes.
  * Member event-kind caches are refreshed to keep behavior consistent across server replicas.

* **Tests**
  * Expanded integration coverage for `$member` event-kind registry backfill and concurrency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->