### PR TITLE
migration(environments): contract phase — drop vestigial scope + owner_user_id

### DIFF
--- a/db/migrations/20260714120000_drop_environments_scope_owner.sql
+++ b/db/migrations/20260714120000_drop_environments_scope_owner.sql
@@ -1,0 +1,52 @@
+-- migrate:up
+--
+-- CONTRACT PHASE (expand/contract). The EXPAND half shipped in #1914: the store,
+-- routes, and CLI stopped reading/writing environments.scope + owner_user_id,
+-- but the columns stayed in the table so the old code could keep running during
+-- rollout. This migration drops them.
+--
+-- DO NOT MERGE until #1914 (squash 2711b0a83) is fully deployed to prod. The
+-- Helm pre-upgrade hook runs migrations BEFORE the Deployment updates, so if this
+-- lands in a release where any running replica still SELECTs scope/owner_user_id,
+-- that replica hits a contracted schema in the pre-upgrade→rollout gap (Recreate
+-- prevents two serving versions, NOT old-code-against-new-schema). Once every
+-- prod replica is on the #1914 image (which never references these columns), the
+-- drop is safe.
+--
+-- scope ('org'|'private') and owner_user_id were carried from the original
+-- Environments feature (#1618) but were never wired: no UI set them, and no
+-- runtime / exec / route path ever gated on them. Private per-user credentials
+-- come from OAuth connections, not an environment scope. Removing them collapses
+-- `environments` to what it actually is — org-level sandbox-provider config.
+-- Low-row-count admin table; the brief lock is negligible.
+
+ALTER TABLE public.environments
+  DROP CONSTRAINT IF EXISTS environments_scope_check;
+
+-- squawk-ignore ban-drop-column -- vestigial, never read (no UI/route/exec gate); org-level admin table, low row count
+ALTER TABLE public.environments
+  DROP COLUMN IF EXISTS scope;
+
+-- squawk-ignore ban-drop-column -- vestigial, never read (no UI/route/exec gate); org-level admin table, low row count
+ALTER TABLE public.environments
+  DROP COLUMN IF EXISTS owner_user_id;
+
+-- migrate:down
+ALTER TABLE public.environments
+  ADD COLUMN IF NOT EXISTS scope text NOT NULL DEFAULT 'org';
+
+ALTER TABLE public.environments
+  ADD COLUMN IF NOT EXISTS owner_user_id text;
+
+ALTER TABLE public.environments
+  DROP CONSTRAINT IF EXISTS environments_scope_check;
+
+-- Add the CHECK NOT VALID then VALIDATE separately so the rollback doesn't take
+-- a validating table-scan lock (all existing rows default to 'org', so the
+-- validation pass is trivially satisfied).
+ALTER TABLE public.environments
+  ADD CONSTRAINT environments_scope_check CHECK (scope IN ('org', 'private')) NOT VALID;
+
+-- squawk-ignore prefer-robust-stmts -- rollback path; low row count
+ALTER TABLE public.environments
+  VALIDATE CONSTRAINT environments_scope_check;

--- a/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
+++ b/packages/server/src/__tests__/integration/db/migration-invariants.test.ts
@@ -129,6 +129,17 @@ describe('migration invariants', () => {
       expect(rows).toHaveLength(0);
     });
 
+    it('environments.scope + owner_user_id are dropped (contract phase of the #1914 env→provider unification)', async () => {
+      const sql = getTestDb();
+      const rows = await sql<{ column_name: string }[]>`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'environments'
+          AND column_name IN ('scope', 'owner_user_id')
+      `;
+      expect(rows).toHaveLength(0);
+    });
+
     it('missing FK indexes were added and the duplicate token_hash index removed (2026-06-16 audit)', async () => {
       const sql = getTestDb();
       const present = await sql<{ indexname: string }[]>`


### PR DESCRIPTION
Contract half of the expand/contract split from #1914.

## Why now
#1914 shipped the **expand** half: the store, routes, and CLI stopped reading/writing `environments.scope` + `owner_user_id`, but the columns stayed so old code could keep running through rollout. This drops them.

**The gate is satisfied:** prod is confirmed running the #1914 image — `APP_GIT_SHA=2711b0a83779...` on all replicas (2/2 updated+ready, no rollout in flight). No running replica references these columns, so the Helm pre-upgrade migration can safely contract the schema.

## What
`scope` (`'org'|'private'`) and `owner_user_id` were vestigial from the original Environments feature (#1618) — never set by any UI, never gated by any runtime/exec/route path. Private per-user credentials come from OAuth connections, not an env scope. Dropping them collapses `environments` to what it is: org-level sandbox-provider config.

## Safety
- Verified up/down against a throwaway pg replicating the shipped `environments` schema: UP drops both columns + the `scope` CHECK; DOWN restores them (constraint re-added `NOT VALID`→`VALIDATE`, `convalidated=t`, `scope` defaults `'org'`).
- squawk-clean (the two `DROP COLUMN`s carry `squawk-ignore ban-drop-column` with the vestigial-column rationale; low-row-count admin table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786567341&installation_id=136316292&pr_number=1916&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1916&signature=f1740721a446f7810afd09d47d5f5942255272fa40a5352b7323a0631159a034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->