### PR TITLE
fix(slack): request MCP install scope

### DIFF
--- a/packages/connectors/src/__tests__/connector-sdk.mock.ts
+++ b/packages/connectors/src/__tests__/connector-sdk.mock.ts
@@ -142,6 +142,7 @@ export function connectorSdkMock() {
     paginateByCursor,
     paginateByOffset,
     ConnectorRuntime: class {},
+    IntegrationConnector: class {},
     calculateEngagementScore: () => 0,
     extensionDomScrape: async (opts: DomScrapeOpts) => {
       const observation = await opts.dispatcher.dispatch('navigate', {

--- a/packages/connectors/src/__tests__/slack.test.ts
+++ b/packages/connectors/src/__tests__/slack.test.ts
@@ -1,14 +1,34 @@
-import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { connectorSdkMock } from "./connector-sdk.mock";
 
-import SlackConnector from "../slack.js";
+mock.module("@lobu/connector-sdk", connectorSdkMock);
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after shared SDK mock
+let SlackConnector: any;
+
+beforeAll(async () => {
+	const module = await import("../slack");
+	SlackConnector = module.default;
+});
 
 describe("Slack connector declaration", () => {
-	it("requests the Slackbot MCP scope during app installation", () => {
+	test("keeps install scopes aligned with the manifest and includes Slackbot MCP", () => {
+		const manifest = JSON.parse(
+			readFileSync(
+				new URL(
+					"../../../../config/slack-app-manifest.self-install.json",
+					import.meta.url,
+				),
+				"utf8",
+			),
+		);
 		const connector = new SlackConnector();
 		const installMethod = connector.definition.authSchema?.methods.find(
-			(method) => method.type === "app_installation",
+			(method: { type: string }) => method.type === "app_installation",
 		);
 
 		expect(installMethod?.permissions).toContain("mcp:connect");
+		expect(installMethod?.permissions).toEqual(manifest.oauth_config.scopes.bot);
 	});
 });

--- a/packages/connectors/src/__tests__/slack.test.ts
+++ b/packages/connectors/src/__tests__/slack.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import SlackConnector from "../slack.js";
+
+describe("Slack connector declaration", () => {
+	it("requests the Slackbot MCP scope during app installation", () => {
+		const connector = new SlackConnector();
+		const installMethod = connector.definition.authSchema?.methods.find(
+			(method) => method.type === "app_installation",
+		);
+
+		expect(installMethod?.permissions).toContain("mcp:connect");
+	});
+});

--- a/packages/connectors/src/slack.ts
+++ b/packages/connectors/src/slack.ts
@@ -32,9 +32,10 @@ import {
 } from "@lobu/connector-sdk";
 
 /**
- * Bot scopes the hosted Lobu Slack app requests (mentions, threads, slash
- * commands, DM assistant chat). Kept in sync with
- * `config/slack-app-manifest.self-install.json`'s `oauth_config.scopes.bot`.
+ * Bot scopes requested by `/slack/install`. The Slack manifest does not drive
+ * that route: the generic install engine reads this connector declaration.
+ * Keep this list exactly aligned with the manifest, and never drop
+ * `mcp:connect` — without it Slackbot cannot discover Lobu's MCP server.
  */
 const SLACK_BOT_SCOPES = [
 	"app_mentions:read",

--- a/packages/connectors/src/slack.ts
+++ b/packages/connectors/src/slack.ts
@@ -51,6 +51,7 @@ const SLACK_BOT_SCOPES = [
 	"im:history",
 	"im:read",
 	"im:write",
+	"mcp:connect",
 	"mpim:history",
 	"mpim:read",
 	"reactions:read",


### PR DESCRIPTION
## Summary
- include `mcp:connect` in the Slack connector install declaration
- add a regression test covering the generated app-install permissions

## Verification
- red: `bun test packages/connectors/src/__tests__/slack.test.ts` failed before the scope was added
- green: `bun test packages/connectors/src/__tests__/slack.test.ts` (1 pass)
- `make build-packages`
- `REVIEWER_CLI=codex make review` (96 bug-free, 0 bugs, 0 blockers)
- live Slackbot `slackbot.mcp.listTools` returned 6 Lobu tools
- production `/mcp` POST requests returned 200 across both app replicas

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786567783&installation_id=136316292&pr_number=1917&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1917&signature=3cc039403dfbfc004d173d85fabf4745ca31469413e776973c5fcaa7b43927a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->