### PR TITLE
fix(auth-profiles): create_auth_profile auto-installs its connector (#1898)

### DIFF
--- a/packages/server/src/__tests__/integration/connectors/auth-profile-auto-install.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/auth-profile-auto-install.test.ts
@@ -1,0 +1,68 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../../../index';
+import { manageAuthProfiles } from '../../../tools/admin/manage_auth_profiles';
+import { initWorkspaceProvider } from '../../../workspace';
+import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { seedOwnerContext } from '../../setup/test-fixtures';
+
+const TEST_ENV = {
+  ENVIRONMENT: 'test',
+  DATABASE_URL: process.env.DATABASE_URL,
+} as unknown as Env;
+
+describe('create_auth_profile — auto-installs its connector (#1898)', () => {
+  beforeAll(async () => {
+    await initWorkspaceProvider();
+  });
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  it('installs a bundled connector on demand so an auth profile can be created before any connection', async () => {
+    // Fresh org, `postgres` connector NOT installed. Before the fix this hit the
+    // seed chicken/egg: create_auth_profile errored "Connector 'postgres' not
+    // found or not active" because only manage_connections create auto-installed
+    // the connector — and creating a connection needs the auth profile.
+    const { org, ctx } = await seedOwnerContext({
+      orgName: 'Auto-install Org',
+      userName: 'Auto-install Owner',
+    });
+    const sql = getTestDb();
+
+    const before = await sql`
+      SELECT 1 FROM connector_definitions
+      WHERE key = 'postgres' AND organization_id = ${org.id} AND status = 'active'
+      LIMIT 1
+    `;
+    expect(before).toHaveLength(0);
+
+    const res = await manageAuthProfiles(
+      {
+        action: 'create_auth_profile',
+        connector_key: 'postgres',
+        profile_kind: 'env',
+        display_name: 'Postgres Credentials',
+        slug: 'postgres-db',
+        credentials: { DATABASE_URL: 'postgresql://user:pass@localhost:5432/db' },
+      },
+      TEST_ENV,
+      ctx
+    );
+
+    // The profile is created (no connector-not-found error)…
+    expect('error' in res ? res.error : undefined).toBeUndefined();
+    expect('auth_profile' in res).toBe(true);
+    if ('auth_profile' in res) {
+      expect(res.auth_profile.connector_key).toBe('postgres');
+    }
+
+    // …because the connector was auto-installed from the bundled catalog.
+    const after = await sql`
+      SELECT 1 FROM connector_definitions
+      WHERE key = 'postgres' AND organization_id = ${org.id} AND status = 'active'
+      LIMIT 1
+    `;
+    expect(after).toHaveLength(1);
+  });
+});

--- a/packages/server/src/tools/admin/manage_auth_profiles.ts
+++ b/packages/server/src/tools/admin/manage_auth_profiles.ts
@@ -48,6 +48,7 @@ import { createConnectToken } from '../../utils/connect-tokens';
 import type { ToolContext } from '../registry';
 import { action, defineActionTool } from './action-tool';
 import { getScopedConnectorDefinition } from "../../catalog/connector-definitions";
+import { ensureConnectorInstalled } from '../../utils/ensure-connector-installed';
 import { callerIsAdmin } from './helpers/db-helpers';
 import {
   buildOAuthConnectConfig,
@@ -337,6 +338,18 @@ async function handleCreateAuthProfile(
         error: `Only admins can create ${args.profile_kind} auth profiles. Ask an organization owner or admin to configure these credentials.`,
       };
     }
+  }
+
+  // Auto-install the connector from the bundled catalog if the org hasn't
+  // installed it yet — parity with `manage_connections create`. Without this,
+  // seeding a fresh org hits a chicken/egg: an auth profile needs the connector
+  // installed, but the only other installer is creating a connection, which
+  // needs the auth profile. A no-op when already installed or not bundled.
+  if (args.connector_key) {
+    await ensureConnectorInstalled({
+      organizationId: ctx.organizationId,
+      connectorKey: args.connector_key,
+    });
   }
 
   // browser_session profiles are device-scoped; connector_key is optional


### PR DESCRIPTION
Closes #1898.

## Problem
On a fresh org the natural seed order failed with `Connector 'postgres' not found or not active`: `create_auth_profile` required the connector already installed, but only `manage_connections create` auto-installed it — a chicken/egg since creating a connection needs the auth profile.

## Fix
Call `ensureConnectorInstalled` inside `create_auth_profile` before resolving the connector, mirroring `manage_connections create`. A no-op when the connector is already installed or the key isn't a bundled connector.

## Test
Red→fix→green integration test: fresh org, `postgres` not installed → `create_auth_profile` succeeds and the connector gets installed. Without the call, the test fails with the exact `Connector 'postgres' not found or not active` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmQussspkJdXEBJrY2vj1p

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786570701&installation_id=136316292&pr_number=1919&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1919&signature=6fdb6823b319c4f944309e642a8c3e7d947e1da02cba5cd9326eebb4ba196919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auth profile creation now automatically installs the referenced connector when it is not already active.
  * Connector setup is handled seamlessly before the auth profile is created.

* **Tests**
  * Added coverage confirming automatic connector installation during auth profile creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->