### PR TITLE
feat(cli): declare virtual (federated) feeds in lobu.config.ts (#1899)

### DIFF
--- a/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/diff.test.ts
@@ -887,6 +887,89 @@ describe("apply diff — connectors", () => {
     ).toBe("noop");
   });
 
+  test("creates a virtual feed from config; virtual/collected kind is immutable on drift (#1899)", () => {
+    const desired = buildState([], {
+      connectors: {
+        definitions: [],
+        authProfiles: [
+          {
+            slug: "wh-env",
+            connector: "postgres",
+            kind: "env" as const,
+            credentials: { DATABASE_URL: "$DATABASE_URL" },
+            sourceFile: "connectors/postgres.yaml",
+          },
+        ],
+        connections: [
+          {
+            slug: "warehouse",
+            connector: "postgres",
+            authProfileSlug: "wh-env",
+            feeds: [
+              {
+                feedKey: "query",
+                virtual: true,
+                config: { query: "SELECT 1" },
+              },
+            ],
+            sourceFile: "connectors/postgres.yaml",
+          },
+        ],
+      },
+    });
+
+    // No remote feed yet → the virtual feed is a create.
+    const createPlan = computeDiff(desired, {
+      ...emptyRemote(),
+      connections: [
+        {
+          id: 9,
+          slug: "warehouse",
+          connector_key: "postgres",
+          status: "active",
+          auth_profile_slug: "wh-env",
+          app_auth_profile_slug: null,
+          config: {},
+        },
+      ],
+    });
+    expect(createPlan.rows.find((r) => r.kind === "feed")?.verb).toBe("create");
+
+    // Remote has the same key as a COLLECTED feed → kind mismatch is a hard error
+    // (immutable), not a silent update that apply couldn't persist.
+    expect(() =>
+      computeDiff(desired, {
+        ...emptyRemote(),
+        connections: [
+          {
+            id: 9,
+            slug: "warehouse",
+            connector_key: "postgres",
+            status: "active",
+            auth_profile_slug: "wh-env",
+            app_auth_profile_slug: null,
+            config: {},
+          },
+        ],
+        feedsByConnectionId: new Map([
+          [
+            9,
+            [
+              {
+                id: 21,
+                connection_id: 9,
+                feed_key: "query",
+                status: "active",
+                config: { query: "SELECT 1" },
+                virtual: false,
+              },
+            ],
+          ],
+        ]),
+      })
+    ).toThrow(/virtual\/collected kind is immutable/);
+  });
+
   test("update when feed schedule changes; needs-auth when oauth profile inactive", () => {
     const remote: RemoteSnapshot = {
       ...emptyRemote(),

--- a/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
+++ b/packages/cli/src/commands/_lib/apply/__tests__/map-config.test.ts
@@ -617,6 +617,45 @@ describe("mapProjectToDesiredState", () => {
     ).toThrow(/more than once/);
   });
 
+  test("maps a virtual feed to DesiredFeed.virtual (config-as-constructor, #1899)", () => {
+    const conn = defineConnection({
+      slug: "warehouse",
+      connector: "postgres",
+      feeds: [
+        {
+          feed: "query",
+          name: "Churn rollup (live)",
+          virtual: true,
+          config: { query: "SELECT 1" },
+        },
+      ],
+    });
+    const state = mapProjectToDesiredState(
+      defineConfig({ agents: [], connections: [conn] })
+    );
+    expect(state.connectors.connections[0]?.feeds).toEqual([
+      {
+        feedKey: "query",
+        name: "Churn rollup (live)",
+        config: { query: "SELECT 1" },
+        virtual: true,
+      },
+    ]);
+  });
+
+  test("rejects a virtual feed that also declares a schedule (#1899)", () => {
+    const conn = defineConnection({
+      slug: "warehouse",
+      connector: "postgres",
+      feeds: [{ feed: "query", virtual: true, schedule: "0 * * * *" }],
+    });
+    expect(() =>
+      mapProjectToDesiredState(
+        defineConfig({ agents: [], connections: [conn] })
+      )
+    ).toThrow(/virtual.*cannot have a schedule/);
+  });
+
   test("--only skips connectors and their secrets", () => {
     const auth = defineAuthProfile({
       slug: "gh-app",

--- a/packages/cli/src/commands/_lib/apply/apply-cmd.ts
+++ b/packages/cli/src/commands/_lib/apply/apply-cmd.ts
@@ -1029,6 +1029,7 @@ export async function executePlan(
         name: feed.name,
         schedule: feed.schedule,
         config: feed.config,
+        virtual: feed.virtual,
       });
     }
     printText(renderProgress(row.verb, "feed", row.id));

--- a/packages/cli/src/commands/_lib/apply/client.ts
+++ b/packages/cli/src/commands/_lib/apply/client.ts
@@ -179,6 +179,7 @@ export interface RemoteFeed {
   status: string;
   schedule?: string | null;
   config?: Record<string, unknown> | null;
+  virtual?: boolean;
 }
 
 interface InstallConnectorResult {
@@ -1407,6 +1408,7 @@ export class ApplyClient {
     name?: string;
     schedule?: string;
     config?: Record<string, unknown>;
+    virtual?: boolean;
   }): Promise<RemoteFeed> {
     const body = await this.feedsTool<{ feed?: RemoteFeed }>({
       action: "create_feed",
@@ -1415,6 +1417,7 @@ export class ApplyClient {
       ...(payload.name ? { display_name: payload.name } : {}),
       ...(payload.schedule ? { schedule: payload.schedule } : {}),
       ...(payload.config ? { config: payload.config } : {}),
+      ...(payload.virtual ? { virtual: true } : {}),
     });
     if (!body.feed) {
       throw new ApiError(

--- a/packages/cli/src/commands/_lib/apply/desired-state.ts
+++ b/packages/cli/src/commands/_lib/apply/desired-state.ts
@@ -141,6 +141,8 @@ export interface DesiredFeed {
   name?: string;
   schedule?: string;
   config?: Record<string, unknown>;
+  /** Federated (live-pushdown, no-copy) feed — never synced; schedule is NULL. */
+  virtual?: boolean;
 }
 
 export interface DesiredConnection {

--- a/packages/cli/src/commands/_lib/apply/diff.ts
+++ b/packages/cli/src/commands/_lib/apply/diff.ts
@@ -823,6 +823,18 @@ function diffFeed(
   desired: DesiredFeed,
   remote: RemoteFeed | undefined
 ): FeedDiffRow {
+  // `virtual` is fixed at create: a virtual feed reads live and stores nothing,
+  // a collected feed syncs into `events` — the server exposes no update path to
+  // flip one into the other. Diffing it as a mutable field would push a change
+  // apply can't persist, so the drift would resurface every apply. Treat a
+  // mismatch on an existing feed as a hard error (recreate under a new key to
+  // change kind), mirroring the inference-provider `kind` immutability.
+  if (remote && Boolean(desired.virtual) !== Boolean(remote.virtual)) {
+    throw new ValidationError(
+      `connection "${connectionSlug}" feed "${desired.feedKey}" is declared ${desired.virtual ? "virtual" : "collected"} but the server has it as ${remote.virtual ? "virtual" : "collected"}. ` +
+        `A feed's virtual/collected kind is immutable — delete it and recreate under a new feed key to change it.`
+    );
+  }
   return buildDiffRow({
     kind: "feed",
     id: `${connectionSlug}/${desired.feedKey}`,

--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -622,6 +622,14 @@ function mapConnection(connection: Connection): DesiredConnection {
       );
     }
     seenFeeds.add(feed.feed);
+    // A virtual feed is read live and never synced — a schedule is meaningless
+    // there (the server persists schedule = NULL regardless). Reject the
+    // contradiction at config time rather than silently dropping the schedule.
+    if (feed.virtual && feed.schedule) {
+      throw new ValidationError(
+        `connection "${connection.slug}" feed "${feed.feed}" is virtual (read live, never synced) so it cannot have a schedule — remove "schedule"`
+      );
+    }
     if (feed.schedule) {
       const err = cronError(feed.schedule);
       if (err) {
@@ -635,6 +643,7 @@ function mapConnection(connection: Connection): DesiredConnection {
       ...(feed.name ? { name: feed.name } : {}),
       ...(feed.schedule ? { schedule: feed.schedule } : {}),
       ...(feed.config ? { config: feed.config } : {}),
+      ...(feed.virtual ? { virtual: true } : {}),
     };
   });
   const authSlug = authProfileSlug(connection.authProfile);

--- a/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/__tests__/init-from-org.test.ts
@@ -206,6 +206,16 @@ function fullOrgRoutes(): Record<string, () => unknown> {
           schedule: "0 */6 * * *",
           config: { repo_owner: "lobu-ai", repo_name: "lobu" },
         },
+        {
+          id: 2,
+          connection_id: 7,
+          feed_key: "query",
+          display_name: "Churn rollup (live)",
+          status: "active",
+          schedule: null,
+          config: { query: "SELECT 1" },
+          virtual: true,
+        },
       ],
     }),
   };
@@ -344,7 +354,17 @@ describe("lobu init --from-org", () => {
     expect(conn?.authProfileSlug).toBe("github-account");
     expect(conn?.appAuthProfileSlug).toBe("github-app");
     expect(conn?.config).toEqual({ repo_owner: "lobu-ai", repo_name: "lobu" });
+    // Feeds are emitted sorted by feed_key (query < stargazers). The virtual
+    // feed must round-trip `virtual: true` — otherwise the generated config
+    // declares it collected and the first `lobu apply` fails the
+    // virtual/collected immutability check.
     expect(conn?.feeds).toEqual([
+      {
+        feedKey: "query",
+        name: "Churn rollup (live)",
+        config: { query: "SELECT 1" },
+        virtual: true,
+      },
       {
         feedKey: "stargazers",
         name: "Stars",

--- a/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
+++ b/packages/cli/src/commands/_lib/init-from-org/bootstrap.ts
@@ -723,6 +723,11 @@ function emitConnection(
         if (f.config && Object.keys(f.config).length > 0) {
           fFields.push(`config: ${emitValue(f.config, 3)}`);
         }
+        // A virtual (federated) feed must round-trip: without this the generated
+        // config declares it as collected, and the first `lobu apply` fails the
+        // virtual/collected immutability check in diffFeed. Virtual feeds never
+        // sync, so no schedule is emitted.
+        if (f.virtual) fFields.push(`virtual: true`);
         return objectLiteral(fFields, 2);
       });
     fields.push(`feeds: [\n    ${items.join(",\n    ")},\n  ]`);

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -194,10 +194,11 @@ export interface ConnectionFeed {
   config?: Record<string, unknown>;
   /**
    * A virtual feed is federated: rows are read LIVE at request time via
-   * pushdown and never copied into `events`. It is never synced, so `schedule`
-   * is ignored (a virtual feed always persists `schedule = NULL`). Declaring a
-   * `virtual` feed here lets the whole warehouse-federation story live in
-   * `lobu.config.ts` instead of an imperative `manage_feeds create_feed` call.
+   * pushdown and never copied into `events`. It is never synced, so pairing it
+   * with a `schedule` is rejected at apply time (a virtual feed always persists
+   * `schedule = NULL`). Declaring a `virtual` feed here lets the whole
+   * warehouse-federation story live in `lobu.config.ts` instead of an imperative
+   * `manage_feeds create_feed` call.
    */
   virtual?: boolean;
 }

--- a/packages/cli/src/config/define.ts
+++ b/packages/cli/src/config/define.ts
@@ -192,6 +192,14 @@ export interface ConnectionFeed {
   name?: string;
   schedule?: string;
   config?: Record<string, unknown>;
+  /**
+   * A virtual feed is federated: rows are read LIVE at request time via
+   * pushdown and never copied into `events`. It is never synced, so `schedule`
+   * is ignored (a virtual feed always persists `schedule = NULL`). Declaring a
+   * `virtual` feed here lets the whole warehouse-federation story live in
+   * `lobu.config.ts` instead of an imperative `manage_feeds create_feed` call.
+   */
+  virtual?: boolean;
 }
 
 /**


### PR DESCRIPTION
Closes #1899.

## Problem
A connection's feed can be declared in `lobu.config.ts`, but the config `ConnectionFeed` shape had no `virtual` flag — so a **virtual (federated, live-pushdown, no-copy)** feed couldn't be declared in config and had to be created imperatively via `manage_feeds create_feed` in a seed script. That splits the warehouse-federation story across config + script for the exact case the `examples/context-layer` example showcases.

## Fix
The server and imperative path already accept `virtual: true`; only the config→apply chain didn't thread it. Threaded end to end:
- `ConnectionFeed` (config type) + `DesiredFeed` (apply IR) gain `virtual?: boolean`
- `mapConnection` carries it through; `createFeed` sends it; `RemoteFeed` exposes it
- A virtual feed never syncs → a config pairing `virtual` with a `schedule` is rejected at config time
- `virtual`/`collected` is fixed at create (no server update path) → a drift mismatch on an existing feed is a hard error (recreate under a new key), mirroring inference-provider `kind` immutability

## Test
Red→fix→green unit coverage: `mapConnection` maps `virtual` and rejects virtual-with-schedule; `diffFeed` creates a virtual feed and hard-errors on a virtual/collected drift.

## Follow-up (separate)
Migrate `examples/context-layer` to move its virtual feed from the imperative `seed.ts` call into `lobu.config.ts` now that the flag exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmQussspkJdXEBJrY2vj1p

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786571604&installation_id=136316292&pr_number=1920&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1920&signature=452d991c411bf003e505d4bddd6f848cb493af7bd16ad6f2981e865e81486bc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->