### PR TITLE
example(context-layer): declare the virtual churn feed in lobu.config.ts (#1899 follow-up)

### DIFF
--- a/examples/context-layer/README.md
+++ b/examples/context-layer/README.md
@@ -45,20 +45,20 @@ because the definition change actually changed *which cancellations count*.
 | **Agent eval** | `eval.ts` | Asks a real agent the March question twice — WITH the governed context pushed vs a WITHOUT baseline — and asserts the pushed context changed the answer (cites the migration, corrects ~550 → ~50). Runs a live agent when a model provider is configured; falls back to a labelled deterministic proxy when the local install has no model. |
 | **Verified-query drift canary** | `verified-query` entity + `drift-check.ts` | A human-approved answer (the exact SQL + the rows it produced at approval time) is pinned. Re-running the query and diffing against the pinned answer is the canary: a mismatch means the warehouse (or a definition) moved and the answer needs re-verification — *before* someone repeats a stale number in a board deck. |
 
-The connection, auth profile, and entity schema are declared in
-`lobu.config.ts` (config-as-constructor) and created by `lobu run`. The seed
-script adds the virtual feed, the definition chain (with governing predicates),
-the business events (with structured adjustments), and the pinned verified
-answer on top.
+The connection, auth profile, the virtual churn-rollup feed, and the entity
+schema are all declared in `lobu.config.ts` (config-as-constructor) and created
+by `lobu run`. The seed script adds the definition chain (with governing
+predicates), the business events (with structured adjustments), and the pinned
+verified answer on top.
 
 ```
 context-layer/
-├── lobu.config.ts              # agent, entity types, warehouse connection + auth profile
+├── lobu.config.ts              # agent, entity types, warehouse connection + auth profile + virtual feed
 ├── IDENTITY.md                 # the analyst agent's identity
 ├── env.example                 # copy to .env
 └── scripts/
     ├── seed-warehouse.ts        # provision the fake warehouse (deterministic; incl. payment-failure cohort)
-    ├── seed.ts                  # seed the context layer (feed, definitions+predicates, events+adjustments, pinned answer)
+    ├── seed.ts                  # seed the context layer (definitions+predicates, events+adjustments, pinned answer)
     ├── compose.ts               # THE MONEY SHOT — governed adjusted-churn narrative (definition governs the SQL)
     ├── eval.ts                  # agent eval — does pushing the context change the answer? (real agent or labelled proxy)
     ├── simulate-drift.ts        # mutate the warehouse so the canary has something to catch

--- a/examples/context-layer/lobu.config.ts
+++ b/examples/context-layer/lobu.config.ts
@@ -18,6 +18,7 @@ import {
   defineConnection,
   defineEntityType,
 } from "@lobu/cli/config";
+import { CHURN_ROLLUP_SQL } from "./scripts/lib/env.ts";
 
 const analyst = defineAgent({
   id: "analyst",
@@ -69,6 +70,18 @@ const warehouse = defineConnection({
   connector: "postgres",
   name: "Kelder warehouse",
   authProfile: warehouseAuth,
+  // The monthly churn rollup as a VIRTUAL (federated) feed: read LIVE at
+  // request time through the connector pushdown, never copied into Lobu. A
+  // virtual feed never syncs, so it carries no schedule. Declared here so the
+  // whole warehouse-federation story lives in config — `lobu run` creates it.
+  feeds: [
+    {
+      feed: "query",
+      name: "Monthly churn rollup (live)",
+      virtual: true,
+      config: { query: CHURN_ROLLUP_SQL },
+    },
+  ],
 });
 
 /**

--- a/examples/context-layer/lobu.config.ts
+++ b/examples/context-layer/lobu.config.ts
@@ -51,11 +51,11 @@ const baseline = defineAgent({
 
 /**
  * The warehouse connection, declared as config (config-as-constructor). `lobu
- * run` applies this: it installs the bundled `postgres` connector and creates
- * an authenticated, read-only connection to the fake Kelder warehouse. The
- * credential is a `$VAR` reference resolved from the environment at apply time —
- * it never lives in committed code. The seed then adds a VIRTUAL feed on top of
- * this connection (the live churn rollup).
+ * run` applies this: it installs the bundled `postgres` connector, creates an
+ * authenticated, read-only connection to the fake Kelder warehouse, AND creates
+ * the VIRTUAL churn-rollup feed on it (declared below). The credential is a
+ * `$VAR` reference resolved from the environment at apply time — it never lives
+ * in committed code.
  */
 const warehouseAuth = defineAuthProfile({
   slug: "kelder-warehouse",

--- a/examples/context-layer/scripts/seed.ts
+++ b/examples/context-layer/scripts/seed.ts
@@ -41,14 +41,9 @@ if ((existing.entities ?? []).length > 0) {
   process.exit(0);
 }
 
-// ── 1. Warehouse connection + VIRTUAL feed ──────────────────────────────────
-// Both are declared in lobu.config.ts and created by `lobu run`
-// (config-as-constructor): the `kelder-warehouse` auth profile + connection AND
-// the live churn-rollup virtual feed on top of it. `lobu run` also installs the
-// bundled `postgres` connector. Nothing to do here — the whole
-// warehouse-federation story lives in config.
-
-// ── 2. Metric definition entity + versioned definition chain ───────────────
+// ── 1. Metric definition entity + versioned definition chain ───────────────
+// (The warehouse connection + its VIRTUAL churn-rollup feed are declared in
+// lobu.config.ts and created by `lobu run` — see the file header.)
 const metricRes = await callTool<{ entity?: { id?: number } }>(
   gw,
   "manage_entity",
@@ -130,7 +125,7 @@ console.log(
   `Created churn_rate definition chain: v1 (event ${v1EventId}) superseded by v2`
 );
 
-// ── 3. Business events — the governed "why" records ────────────────────────
+// ── 2. Business events — the governed "why" records ────────────────────────
 const businessEvents = [
   {
     name: "Recharge billing migration wrote false cancellations",
@@ -194,7 +189,7 @@ for (const evt of businessEvents) {
 }
 console.log(`Created ${businessEvents.length} business events`);
 
-// ── 4. Monthly observations (feed the DECLARED metric) ─────────────────────
+// ── 3. Monthly observations (feed the DECLARED metric) ─────────────────────
 const observations: Array<[string, number]> = [
   ["2026-01", 50],
   ["2026-02", 50],
@@ -211,7 +206,7 @@ for (const [month, cancellations] of observations) {
 }
 console.log(`Recorded ${observations.length} monthly churn observations`);
 
-// ── 5. Verified query: pin the approved answer from the live warehouse ─────
+// ── 4. Verified query: pin the approved answer from the live warehouse ─────
 const sql = postgres(WAREHOUSE_URL, { max: 1 });
 const approvedAnswer = (await sql.unsafe(CHURN_ROLLUP_SQL)).map((r) => ({
   ...r,

--- a/examples/context-layer/scripts/seed.ts
+++ b/examples/context-layer/scripts/seed.ts
@@ -1,9 +1,10 @@
 /**
  * Seed the CONTEXT LAYER itself — the org data that explains the warehouse:
  *
- *  1. A `postgres` connection to the Kelder warehouse (env auth profile) and a
- *     VIRTUAL feed on it: the monthly churn rollup, read LIVE at request time
- *     through the connector pushdown. Nothing is copied into Lobu.
+ *  1. (declared in lobu.config.ts, not here) A `postgres` connection to the
+ *     Kelder warehouse (env auth profile) and a VIRTUAL feed on it: the monthly
+ *     churn rollup, read LIVE at request time through the connector pushdown.
+ *     Nothing is copied into Lobu. `lobu run` creates both.
  *  2. The `churn_rate` metric-definition entity, with its definition history
  *     as a supersede chain: v1 (2025-07) superseded by v2 (2026-05, dunning
  *     grace). The chain IS the changelog.
@@ -40,43 +41,12 @@ if ((existing.entities ?? []).length > 0) {
   process.exit(0);
 }
 
-// ── 1. VIRTUAL feed on the warehouse connection ─────────────────────────────
-// The `kelder-warehouse` auth profile + connection are declared in
-// lobu.config.ts and created by `lobu run` (config-as-constructor), which also
-// installs the bundled `postgres` connector. Here we just resolve that
-// connection and add the live churn-rollup feed on top of it.
-const connList = await callTool<{
-  connections?: Array<{ id: number; slug: string; status: string }>;
-}>(gw, "manage_connections", { action: "list", connector_key: "postgres" });
-const warehouseConn = (connList.connections ?? []).find(
-  (c) => c.slug === "kelder-warehouse"
-);
-if (!warehouseConn) {
-  throw new Error(
-    "kelder-warehouse connection not found — did `lobu run` finish applying " +
-      "lobu.config.ts? (it declares the connection). Restart `lobu run` and retry."
-  );
-}
-const connectionId = warehouseConn.id;
-console.log(
-  `Using warehouse connection kelder-warehouse (id ${connectionId}, ${warehouseConn.status})`
-);
-
-const feedRes = await callTool<{ feed?: { id?: number } }>(gw, "manage_feeds", {
-  action: "create_feed",
-  connection_id: connectionId,
-  feed_key: "query",
-  display_name: "Monthly churn rollup (live)",
-  virtual: true,
-  config: { query: CHURN_ROLLUP_SQL },
-});
-const feedId = feedRes.feed?.id;
-if (!feedId) {
-  throw new Error(`feed create returned no id: ${JSON.stringify(feedRes)}`);
-}
-console.log(
-  `Created VIRTUAL feed ${feedId} — churn rollup is read live, never copied`
-);
+// ── 1. Warehouse connection + VIRTUAL feed ──────────────────────────────────
+// Both are declared in lobu.config.ts and created by `lobu run`
+// (config-as-constructor): the `kelder-warehouse` auth profile + connection AND
+// the live churn-rollup virtual feed on top of it. `lobu run` also installs the
+// bundled `postgres` connector. Nothing to do here — the whole
+// warehouse-federation story lives in config.
 
 // ── 2. Metric definition entity + versioned definition chain ───────────────
 const metricRes = await callTool<{ entity?: { id?: number } }>(


### PR DESCRIPTION
Follow-up to #1899 / #1920.

## What
Now that #1899 added the `virtual` flag to the config `ConnectionFeed` shape, this moves the `examples/context-layer` warehouse's live churn-rollup feed out of the imperative `seed.ts` (`manage_feeds create_feed`) call and into the `kelder-warehouse` connection declaration in `lobu.config.ts`. `lobu run` now creates the virtual feed as part of applying the config.

## Why
The example exists to showcase warehouse federation via config-as-constructor. Before #1899 the virtual feed had to be created imperatively, splitting the story across config + script — exactly the friction that spawned the issue. This closes that loop: the connection, its auth profile, and its virtual feed now all live in one config file.

## Change
- `lobu.config.ts`: add `feeds: [{ feed: "query", virtual: true, config: { query: CHURN_ROLLUP_SQL } }]` to the warehouse connection
- `seed.ts`: drop ~36 lines of connection-resolution + feed-creation wiring; the seed now only seeds org data (metric definitions, business events, observations, pinned verified query)

Typechecks clean against the workspace CLI build. (`examples/context-layer` isn't in a CI typecheck path, so verified locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmQussspkJdXEBJrY2vj1p

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786573404&installation_id=136316292&pr_number=1923&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1923&signature=b79b78d0ac2e1d24b3dff04673741295904c78197a4a353ac08d93a20b768bce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->