### PR TITLE
feat(watcher-prefill): watcher config-approval producer + review endpoint (WI-0.3 parity)

### DIFF
--- a/packages/server/src/lobu/__tests__/agent-routes-pending-proposal.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-pending-proposal.test.ts
@@ -49,6 +49,11 @@ async function insertPendingProposal(opts: {
 	tool: "manage_agents" | "manage_watchers";
 	proposal: Record<string, unknown>;
 	current?: Record<string, unknown> | null;
+	// The event's top-level action. manage_agents keeps `action` on the proposal;
+	// manage_watchers nests it in `args`, so the producer stamps args.action into
+	// metadata.action explicitly — mirror that here rather than reading it off the
+	// (possibly nested) proposal.
+	action?: string;
 }): Promise<number> {
 	const organizationId = opts.organizationId ?? ORG;
 	const { getDb } = await import("../../db/client.js");
@@ -78,7 +83,11 @@ async function insertPendingProposal(opts: {
 			interactionInput: opts.proposal,
 			metadata: {
 				tool: opts.tool,
-				action: (opts.proposal as { action?: string }).action ?? null,
+				action:
+					opts.action ??
+					(opts.proposal as { action?: string }).action ??
+					(opts.proposal as { args?: { action?: string } }).args?.action ??
+					null,
 				proposal: opts.proposal,
 				current: opts.current ?? null,
 				status: "pending_approval",
@@ -217,6 +226,172 @@ describe("GET /:agentId/config/pending/:runId", () => {
 	test("400 on a non-numeric run id", async () => {
 		const app = await importAgentRoutes();
 		const res = await app.request(`/${AGENT}/config/pending/not-a-number`);
+		expect(res.status).toBe(400);
+	});
+});
+
+const WATCHER_ID = 501;
+
+// The endpoint reads the watcher's owner + target from the held proposal/event
+// metadata (`current.agent_id`, `args.watcher_id`), NOT from the `watchers`
+// table — so no watcher row needs seeding; the proposal fixtures carry it all.
+
+/** A real ManageWatchersProposal: `{ args: {...}, actingAgentId, actingWatcherId }`
+ *  with watcher_id / agent_id nested INSIDE args. */
+function watcherProposal(
+	args: Record<string, unknown>,
+): Record<string, unknown> {
+	return { args, actingAgentId: null, actingWatcherId: null };
+}
+
+describe("GET /:agentId/watchers/:watcherId/pending/:runId", () => {
+	test("returns the held manage_watchers update proposal for the target watcher", async () => {
+		const app = await importAgentRoutes();
+		const runId = await insertPendingProposal({
+			tool: "manage_watchers",
+			proposal: watcherProposal({
+				action: "update",
+				watcher_id: WATCHER_ID,
+				name: "New Watcher Name",
+				prompt: "Watch for X",
+			}),
+			current: { id: WATCHER_ID, agent_id: AGENT, name: "Old" },
+		});
+
+		const res = await app.request(
+			`/${AGENT}/watchers/${WATCHER_ID}/pending/${runId}`,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			runId: number;
+			resourceKind: string | null;
+			action: string | null;
+			proposal: Record<string, unknown> | null;
+			current: Record<string, unknown> | null;
+		};
+		expect(body.runId).toBe(runId);
+		expect(body.resourceKind).toBe("watcher");
+		expect(body.action).toBe("update");
+		expect(
+			(body.proposal as { args?: { name?: string } }).args?.name,
+		).toBe("New Watcher Name");
+		expect(body.current).toMatchObject({ id: WATCHER_ID });
+	});
+
+	test("resolves the owning agent from the proposal args when it reassigns owner", async () => {
+		// An update may reassign the owner via args.agent_id; the endpoint prefers
+		// the PROPOSED owner over the current row so the review lands on the right
+		// agent-nested route.
+		const app = await importAgentRoutes();
+		const runId = await insertPendingProposal({
+			tool: "manage_watchers",
+			proposal: watcherProposal({
+				action: "update",
+				watcher_id: WATCHER_ID,
+				agent_id: AGENT,
+				name: "N",
+			}),
+			current: { id: WATCHER_ID, agent_id: "old-owner" },
+		});
+		const res = await app.request(
+			`/${AGENT}/watchers/${WATCHER_ID}/pending/${runId}`,
+		);
+		expect(res.status).toBe(200);
+	});
+
+	test("404 for a manage_watchers CREATE proposal (not single-form review)", async () => {
+		const app = await importAgentRoutes();
+		const runId = await insertPendingProposal({
+			tool: "manage_watchers",
+			proposal: watcherProposal({
+				action: "create",
+				watcher_id: WATCHER_ID,
+				agent_id: AGENT,
+			}),
+		});
+		const res = await app.request(
+			`/${AGENT}/watchers/${WATCHER_ID}/pending/${runId}`,
+		);
+		expect(res.status).toBe(404);
+	});
+
+	test("404 for a manage_agents run on the watcher endpoint (wrong tool)", async () => {
+		const app = await importAgentRoutes();
+		const runId = await insertPendingProposal({
+			tool: "manage_agents",
+			proposal: { action: "update", agent_id: AGENT, name: "X" },
+		});
+		const res = await app.request(
+			`/${AGENT}/watchers/${WATCHER_ID}/pending/${runId}`,
+		);
+		expect(res.status).toBe(404);
+	});
+
+	test("404 when the proposal targets a DIFFERENT watcher", async () => {
+		const app = await importAgentRoutes();
+		const runId = await insertPendingProposal({
+			tool: "manage_watchers",
+			proposal: watcherProposal({
+				action: "update",
+				watcher_id: 999,
+				name: "X",
+			}),
+			current: { id: 999, agent_id: AGENT },
+		});
+		const res = await app.request(
+			`/${AGENT}/watchers/${WATCHER_ID}/pending/${runId}`,
+		);
+		expect(res.status).toBe(404);
+	});
+
+	test("404 when the watcher is owned by a DIFFERENT agent (authz boundary)", async () => {
+		const app = await importAgentRoutes();
+		const runId = await insertPendingProposal({
+			tool: "manage_watchers",
+			proposal: watcherProposal({
+				action: "update",
+				watcher_id: WATCHER_ID,
+				name: "X",
+			}),
+			current: { id: WATCHER_ID, agent_id: "other-agent" },
+		});
+		// Path agent is AGENT, but the watcher's owner (current + no args.agent_id)
+		// is other-agent → 404.
+		const res = await app.request(
+			`/${AGENT}/watchers/${WATCHER_ID}/pending/${runId}`,
+		);
+		expect(res.status).toBe(404);
+	});
+
+	test("404 when the run belongs to a different org", async () => {
+		const app = await importAgentRoutes();
+		const { getDb } = await import("../../db/client.js");
+		await getDb()`
+			INSERT INTO organization (id, name, slug)
+			VALUES ('other-w-org', 'other-w-org', 'other-w-org')
+			ON CONFLICT (id) DO NOTHING
+		`;
+		const runId = await insertPendingProposal({
+			organizationId: "other-w-org",
+			tool: "manage_watchers",
+			proposal: watcherProposal({
+				action: "update",
+				watcher_id: WATCHER_ID,
+				name: "X",
+			}),
+			current: { id: WATCHER_ID, agent_id: AGENT },
+		});
+		const res = await app.request(
+			`/${AGENT}/watchers/${WATCHER_ID}/pending/${runId}`,
+		);
+		expect(res.status).toBe(404);
+	});
+
+	test("400 on a non-numeric run id", async () => {
+		const app = await importAgentRoutes();
+		const res = await app.request(
+			`/${AGENT}/watchers/${WATCHER_ID}/pending/not-a-number`,
+		);
 		expect(res.status).toBe(400);
 	});
 });

--- a/packages/server/src/lobu/agent-routes.ts
+++ b/packages/server/src/lobu/agent-routes.ts
@@ -1411,6 +1411,91 @@ routes.get("/:agentId/config/pending/:runId", async (c) => {
 	});
 });
 
+// GET /:agentId/watchers/:watcherId/pending/:runId — the watcher parity of the
+// agent config-prefill endpoint above. A pending `manage_watchers` update run is
+// reviewed on the watcher edit form (nested under its owning agent), prefilled
+// via `?run_id=`. Returns the held proposal so the form can render + approve it.
+//
+// AuthZ: org-scoped by middleware; the held proposal must target `:watcherId`
+// AND be owned by `:agentId`. A manage_watchers proposal is `{ args, ... }` with
+// watcher_id / agent_id nested INSIDE `args` (unlike manage_agents, top-level) —
+// hence a separate endpoint rather than folding into the agent one.
+routes.get("/:agentId/watchers/:watcherId/pending/:runId", async (c) => {
+	const { agentId, watcherId } = c.req.param();
+	const organizationId = c.get("organizationId") as string;
+	const runId = Number(c.req.param("runId"));
+	if (!Number.isInteger(runId) || runId <= 0) {
+		return c.json({ error: "Invalid run id" }, 400);
+	}
+
+	const rows = await getDb()<{
+		action: string | null;
+		proposal: Record<string, unknown> | null;
+		current: Record<string, unknown> | null;
+		tool: string | null;
+	}>`
+		SELECT e.metadata->>'action' AS action,
+		       e.metadata->'proposal' AS proposal,
+		       e.metadata->'current' AS current,
+		       e.metadata->>'tool' AS tool
+		FROM runs r
+		JOIN current_event_records e
+		  ON e.run_id = r.id
+		 AND e.interaction_type = 'approval'
+		 AND e.interaction_status = 'pending'
+		WHERE r.id = ${runId}
+		  AND r.organization_id = ${organizationId}
+		  AND r.run_type = 'internal'
+		  AND r.approval_status = 'pending'
+		ORDER BY e.id DESC
+		LIMIT 1
+	`;
+	const row = rows[0];
+	if (!row) return c.json({ error: "No pending proposal for this run" }, 404);
+
+	// Scoped to manage_watchers UPDATE: the watcher edit form reviews a single
+	// existing watcher's config. create / create_from_version / set_reaction_script
+	// aren't a single-form review (they keep the run-permalink path), so 404 here.
+	const rawProposal = row.proposal ?? null;
+	if (
+		row.tool !== "manage_watchers" ||
+		row.action !== "update" ||
+		!rawProposal ||
+		typeof rawProposal !== "object"
+	) {
+		return c.json({ error: "No pending proposal for this run" }, 404);
+	}
+
+	// manage_watchers proposal nests the target under `args`. The held proposal
+	// must target the watcher in the path, and its owning agent (args.agent_id ??
+	// current owner) must be the agent in the path. Don't leak cross-target/agent
+	// existence — same 404 as "no pending proposal".
+	const args = (rawProposal as { args?: Record<string, unknown> }).args ?? null;
+	if (!args || typeof args !== "object") {
+		return c.json({ error: "No pending proposal for this run" }, 404);
+	}
+	const targetWatcherId = args.watcher_id ?? null;
+	if (String(targetWatcherId) !== String(watcherId)) {
+		return c.json({ error: "No pending proposal for this run" }, 404);
+	}
+	const current = row.current ?? null;
+	const ownerAgentId =
+		(args.agent_id as string | null | undefined) ??
+		(current?.agent_id as string | null | undefined) ??
+		null;
+	if (ownerAgentId !== agentId) {
+		return c.json({ error: "No pending proposal for this run" }, 404);
+	}
+
+	return c.json({
+		runId,
+		resourceKind: "watcher" as const,
+		action: row.action,
+		proposal: rawProposal,
+		current,
+	});
+});
+
 // ── Recent guardrail trips ───────────────────────────────────────────────────
 //
 // Read-only audit feed for the agent's Guardrails tab. Each `guardrail-trip`

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -42,7 +42,10 @@ import type { Env } from '../../index';
 import { notifyActionApprovalNeeded } from '../../notifications/triggers';
 import { insertEvent } from '../../utils/insert-event';
 import logger from '../../utils/logger';
-import { buildResourcePermalink } from '../../utils/url-builder';
+import {
+  buildResourcePermalink,
+  buildWatcherSettingsUrl,
+} from '../../utils/url-builder';
 import { ToolUserError } from '../../utils/errors';
 import {
   requireOrgReadAccess,
@@ -683,9 +686,28 @@ async function queueWatcherWriteForApproval(
   const eventId = Number(event.id);
 
   const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
-  // Run-scoped: the pending event is superseded on approve→complete; a run link
-  // stays valid across the chain.
-  const approvalUrl = buildResourcePermalink(ownerSlug, { kind: 'run', runId }, baseUrl);
+  // An `update` is config-shaped, so its review surface is the watcher edit form
+  // prefilled via `?run_id=` (WI-0.3, watcher parity with manage_agents): the
+  // reviewer sees the proposed change in the real form and Approves/Rejects. The
+  // route is nested under the OWNING agent (an update may reassign the owner via
+  // args.agent_id, so prefer the proposed owner, else the current one). create /
+  // create_from_version / set_reaction_script etc. aren't a single-form review,
+  // so they keep the run permalink (valid across the supersede chain on approve).
+  const ownerAgentId =
+    args.agent_id ?? (current?.agent_id as string | null | undefined) ?? null;
+  const settingsReviewUrl =
+    args.action === 'update' && args.watcher_id != null && ownerAgentId
+      ? await buildWatcherSettingsUrl(
+          baseUrl,
+          ctx.organizationId,
+          ownerAgentId,
+          args.watcher_id,
+          { runId },
+        ).catch(() => null)
+      : null;
+  const approvalUrl =
+    settingsReviewUrl ??
+    buildResourcePermalink(ownerSlug, { kind: 'run', runId }, baseUrl);
 
   notifyActionApprovalNeeded({
     orgId: ctx.organizationId,

--- a/packages/server/src/utils/__tests__/url-builder.test.ts
+++ b/packages/server/src/utils/__tests__/url-builder.test.ts
@@ -5,6 +5,7 @@ import {
   buildProviderConnectUrl,
   buildProviderManagementUrl,
   buildResourcePermalink,
+  buildWatcherSettingsUrl,
   getPublicWebUrl,
 } from '../url-builder';
 import {
@@ -169,6 +170,63 @@ describe('buildAgentSettingsUrl', () => {
     expect(await buildAgentSettingsUrl(undefined, 'org-1', 'a')).toBeNull();
     expect(await buildAgentSettingsUrl('https://x', undefined, 'a')).toBeNull();
     expect(await buildAgentSettingsUrl('https://x', 'org-1', undefined)).toBeNull();
+  });
+});
+
+describe('buildWatcherSettingsUrl', () => {
+  stubOrgSlug();
+  // WI-0.3 watcher parity: an update proposal's review CTA deep-links to the
+  // watcher edit form (nested under its owning agent), prefilled via ?run_id=.
+  it('deep-links to the watcher edit route under its owning agent', async () => {
+    const url = await buildWatcherSettingsUrl(
+      'https://app.lobu.com/lobu',
+      'org-1',
+      'lobu-builder',
+      7
+    );
+    expect(url).toBe(
+      'https://app.lobu.com/acme/agents/lobu-builder/behaviors/watcher/7'
+    );
+  });
+
+  it('appends ?run_id when a review run is given', async () => {
+    const url = await buildWatcherSettingsUrl(
+      'https://app.lobu.com/lobu',
+      'org-1',
+      'lobu-builder',
+      7,
+      { runId: 42 }
+    );
+    expect(url).toBe(
+      'https://app.lobu.com/acme/agents/lobu-builder/behaviors/watcher/7?run_id=42'
+    );
+  });
+
+  it('accepts a string watcher id and percent-encodes agent + slug', async () => {
+    const url = await buildWatcherSettingsUrl(
+      'https://app.lobu.com',
+      'org-special',
+      'my agent/id',
+      '7'
+    );
+    expect(url).toBe(
+      'https://app.lobu.com/acme%2Fteam/agents/my%20agent%2Fid/behaviors/watcher/7'
+    );
+  });
+
+  it('returns null when the org slug cannot be resolved', async () => {
+    expect(
+      await buildWatcherSettingsUrl('https://app.lobu.com', 'unknown-org', 'a', 7)
+    ).toBeNull();
+  });
+
+  it('returns null when any required piece is missing', async () => {
+    expect(await buildWatcherSettingsUrl(undefined, 'org-1', 'a', 7)).toBeNull();
+    expect(await buildWatcherSettingsUrl('https://x', undefined, 'a', 7)).toBeNull();
+    expect(await buildWatcherSettingsUrl('https://x', 'org-1', undefined, 7)).toBeNull();
+    expect(
+      await buildWatcherSettingsUrl('https://x', 'org-1', 'a', undefined)
+    ).toBeNull();
   });
 });
 

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -74,6 +74,35 @@ export async function buildAgentSettingsUrl(
 }
 
 /**
+ * Build a watcher's edit URL —
+ * `<webOrigin>/<orgSlug>/agents/<agentId>/behaviors/watcher/<watcherId>` — the
+ * review target for a pending `manage_watchers` update. Mirrors
+ * {@link buildAgentSettingsUrl}: `?run_id=<id>` prefills the watcher edit form
+ * with the proposed change for Approve/Reject (WI-0.3, watcher parity).
+ *
+ * A watcher is owned by an agent (`watchers.agent_id`), so the route is nested
+ * under that agent — the caller passes the owning agent id (from the current
+ * watcher row). Returns null when any required piece is missing; the producer
+ * falls back to the run permalink.
+ */
+export async function buildWatcherSettingsUrl(
+  publicGatewayUrl: string | undefined,
+  organizationId: string | undefined,
+  agentId: string | undefined,
+  watcherId: string | number | undefined,
+  opts?: { runId?: number }
+): Promise<string | null> {
+  if (!publicGatewayUrl || !organizationId || !agentId || watcherId == null) {
+    return null;
+  }
+  const slug = await getOrganizationSlug(organizationId).catch(() => null);
+  if (!slug) return null;
+  const webOrigin = publicGatewayUrl.replace(/\/+$/, '').replace(/\/lobu$/, '');
+  const base = `${webOrigin}/${encodeURIComponent(slug)}/agents/${encodeURIComponent(agentId)}/behaviors/watcher/${encodeURIComponent(String(watcherId))}`;
+  return opts?.runId ? `${base}?run_id=${opts.runId}` : base;
+}
+
+/**
  * Build the org's "connect a provider" URL — `<webOrigin>/<orgSlug>/
  * inference-providers/new` — the preflight CTA target when the selected model's
  * provider is not connected yet, as opposed to *picking a model* on an agent


### PR DESCRIPTION
## What

Server side of the watcher config-approval prefill — WI-0.3 parity with the agent side (#1918). Completes the single prefill-URL review architecture so it's no longer agent-only: a builder `manage_watchers` **update** is config-shaped, so its approval CTA now deep-links to the watcher edit form prefilled via `?run_id=` (mirroring `manage_agents`) instead of a dead run permalink.

The review UI stays in one place (the web app); every channel only delivers a URL — no per-channel approval-card renderer to fork.

## Changes

- **`buildWatcherSettingsUrl`** — `/<slug>/agents/<agentId>/behaviors/watcher/<id>?run_id=`. The route is nested under the owning agent; an update may reassign the owner via `args.agent_id`, so it prefers the proposed owner, else the current one.
- **`queueWatcherWriteForApproval`** — `update` proposals emit the settings URL; other actions keep the run permalink (they aren't single-form review surfaces).
- **`GET /:agentId/watchers/:watcherId/pending/:runId`** — watcher parity of the agent config-prefill endpoint. `manage_watchers` proposals nest `watcher_id`/`agent_id` inside `args` (unlike `manage_agents`, top-level), so it's a separate endpoint. Scoped to `update`, verifies the target watcher + owning agent, org-scoped (correct under N replicas).

## Tests (red→green)

8 watcher-endpoint cases (happy, owner-reassign, non-update 404, wrong-tool 404, cross-target/agent/org 404, bad-id 400) + 6 `url-builder` cases. The endpoint's `action==='update'` guard surfaced a real bug in the test helper (it read `metadata.action` off the wrong nesting for watcher proposals) — fixed. Existing `manage-watchers-approval-e2e` (9 tests) stays green.

Bumps the owletto submodule to the matching consumer commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KN7SxbQFLFcpQLvxmtthyG

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786580568&installation_id=136316292&pr_number=1924&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1924&signature=0f16acf22e7d9ce0307f0d9ce2157cb8fd69e39ee8118474583dae99762414df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->