### PR TITLE
fix connector setup continuations

### DIFF
--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -104,10 +104,6 @@ export const ConnectCompletionCheck = Type.Object({
       }),
       Type.Object({
         path: Type.String(),
-        contains: Type.Record(Type.String(), Type.Unknown()),
-      }),
-      Type.Object({
-        path: Type.String(),
         includes: Type.Unknown(),
       }),
     ],

--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -40,6 +40,94 @@ const ConnectionFacetsSchema = Type.Object({
 });
 
 // ============================================
+// Connect setup-required continuation
+// ============================================
+//
+// `connections.connect` setup-required outcomes (GitHub app install, missing
+// OAuth app config, interactive pairing, device pairing, ...) are NON-TERMINAL,
+// actionable continuations, NOT business errors. They MUST survive `run_sdk` /
+// `query_sdk` as a structured return value (no `error` field) so an agent can
+// read `next_action`, `resume_call`, and `completion_check` and drive setup
+// instead of seeing a prose-only ScriptError. Absolute URLs are required so the
+// continuation is usable outside the gateway origin. The App install callback
+// (github) creates the active connection ITSELF, so its completion check is a
+// read-back poll — NOT a retry of `connect` (retrying would re-trip the guard).
+
+export const ConnectSetupFamily = Type.Union(
+  [
+    Type.Literal("oauth"),
+    Type.Literal("app_installation"),
+    Type.Literal("env_keys"),
+    Type.Literal("browser"),
+    Type.Literal("interactive"),
+    Type.Literal("device_bound"),
+  ],
+  {
+    description:
+      "Which connection setup family this continuation belongs to. Drives the completion check.",
+  }
+);
+
+export const ConnectSetupNextAction = Type.Union(
+  [
+    Type.Literal("install_app"),
+    Type.Literal("configure_oauth_app"),
+    Type.Literal("select_auth_profile"),
+    Type.Literal("pair_interactive"),
+    Type.Literal("pair_browser"),
+    Type.Literal("connect_device"),
+    Type.Literal("open_setup"),
+  ],
+  {
+    description:
+      "Machine-readable next step the caller should drive to make this connection executable.",
+  }
+);
+
+export const ConnectSdkCall = Type.Object({
+  sdk_method: Type.String({
+    description: "Dotted ClientSDK method name, e.g. connections.connect.",
+  }),
+  arguments: Type.Array(Type.Unknown(), {
+    description:
+      "Positional method arguments. This supports both object-taking methods and connections.get(id).",
+  }),
+});
+
+export const ConnectCompletionCheck = Type.Object({
+  call: ConnectSdkCall,
+  success_when: Type.Union(
+    [
+      Type.Object({
+        path: Type.String(),
+        equals: Type.Unknown(),
+      }),
+      Type.Object({
+        path: Type.String(),
+        contains: Type.Record(Type.String(), Type.Unknown()),
+      }),
+      Type.Object({
+        path: Type.String(),
+        includes: Type.Unknown(),
+      }),
+    ],
+    {
+      description: "Observable condition that marks setup complete.",
+    }
+  ),
+  poll_interval_ms: Type.Integer({ minimum: 250, maximum: 30000 }),
+  description: Type.String({
+    description: "Human-readable summary of the completion check.",
+  }),
+});
+
+export type ConnectSdkCallType = Static<typeof ConnectSdkCall>;
+
+export type ConnectSetupFamilyType = Static<typeof ConnectSetupFamily>;
+export type ConnectSetupNextActionType = Static<typeof ConnectSetupNextAction>;
+export type ConnectCompletionCheckType = Static<typeof ConnectCompletionCheck>;
+
+// ============================================
 // Schema
 // ============================================
 
@@ -78,6 +166,12 @@ export const ListAction = Type.Object({
   connection_ids: Type.Optional(
     Type.Array(Type.Integer({ minimum: 1 }), {
       description: "Filter to specific connection IDs",
+    })
+  ),
+  setup_attempt_id: Type.Optional(
+    Type.String({
+      description:
+        "Filter to connections correlated with an app-install setup attempt",
     })
   ),
   ...PaginationFields,
@@ -601,6 +695,43 @@ export const ManageConnectionsResultSchema = Type.Union([
     status: Type.Literal("active"),
     message: Type.String(),
     view_url: Type.Optional(Type.String()),
+  }),
+  // Setup-required continuation — a NON-TERMINAL, actionable outcome that MUST
+  // survive run_sdk/query_sdk as a return value (no `error` key). Distinct from
+  // the `pending_auth` OAuth-pending variant: that already created a connection
+  // and is waiting on the user's OAuth grant; this variant could NOT create an
+  // executable connection yet and tells the caller exactly what to do next.
+  Type.Object({
+    action: Type.Union([Type.Literal("connect"), Type.Literal("create")]),
+    status: Type.Literal("setup_required"),
+    connector_key: Type.String(),
+    setup_family: ConnectSetupFamily,
+    next_action: ConnectSetupNextAction,
+    resume_call: Type.Optional(ConnectSdkCall),
+    completion_check: Type.Optional(ConnectCompletionCheck),
+    instructions: Type.String(),
+    error_code: Type.Optional(Type.Literal("connector_setup_required")),
+    install_type: Type.Optional(
+      Type.Union([
+        Type.Literal("app_installation"),
+        Type.Literal("oauth_app_profile"),
+      ])
+    ),
+    install_shape: Type.Optional(
+      Type.Union([
+        Type.Literal("oauth-code-exchange"),
+        Type.Literal("github-app"),
+      ])
+    ),
+    setup_instructions: Type.Optional(Type.String()),
+    setup_url: Type.Optional(Type.String()),
+    install_url: Type.Optional(Type.String()),
+    connect_url: Type.Optional(Type.String()),
+    connection_id: Type.Optional(Type.Integer()),
+    slug: Type.Optional(Type.String()),
+    auth_run_id: Type.Optional(Type.Integer()),
+    setup_attempt_id: Type.Optional(Type.String()),
+    provider: Type.Optional(Type.String()),
   }),
   Type.Object({
     action: Type.Literal("connect"),

--- a/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/app-installation-create-guard.test.ts
@@ -136,7 +136,7 @@ afterEach(async () => {
 });
 
 describe("manage_connections — app_installation create guard", () => {
-	it("create with NO installation_ref is rejected with install-flow guidance, no row written", async () => {
+	it("create with NO installation_ref returns an actionable install continuation, no row written", async () => {
 		const org = await createTestOrganization({ name: "App Install Guard Org" });
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
@@ -155,26 +155,28 @@ describe("manage_connections — app_installation create guard", () => {
 			ctx,
 		);
 
-		expect("error" in res).toBe(true);
+		expect("error" in res).toBe(false);
 		expect(res).toMatchObject({
-			error_code: "connector_setup_required",
+			action: "create",
+			status: "setup_required",
+			setup_family: "app_installation",
 			connector_key: CONNECTOR_KEY,
 			provider: "slack",
-			install_type: "app_installation",
-			install_shape: "oauth-code-exchange",
 			next_action: "install_app",
 			install_url: "https://gateway.test/lobu/slack/install",
 		});
 		const setupUrl = new URL((res as { setup_url: string }).setup_url);
 		expect(setupUrl.pathname).toContain("/connectors");
 		expect(setupUrl.searchParams.get("install")).toBe(CONNECTOR_KEY);
-		expect((res as { error: string }).error).not.toMatch(/github/i);
+		expect(res).not.toHaveProperty("resume_call");
 		// Zero rows created.
 		expect(await connectionCount(org.id)).toBe(0);
 	});
 
 	it("connect with NO installation_ref is also rejected (same guard, connect path)", async () => {
-		const org = await createTestOrganization({ name: "App Install Connect Org" });
+		const org = await createTestOrganization({
+			name: "App Install Connect Org",
+		});
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
 		await seedAppInstallConnector(org.id);
@@ -190,15 +192,21 @@ describe("manage_connections — app_installation create guard", () => {
 			ctx,
 		);
 
-		expect("error" in res).toBe(true);
+		// connect returns the same non-terminal continuation as create.
+		expect("error" in res).toBe(false);
 		expect(res).toMatchObject({
-			error_code: "connector_setup_required",
-			provider: "slack",
+			action: "connect",
+			status: "setup_required",
+			setup_family: "app_installation",
 			next_action: "install_app",
 			install_url: "https://gateway.test/lobu/slack/install",
 		});
 		const setupUrl = new URL((res as { setup_url: string }).setup_url);
 		expect(setupUrl.searchParams.get("install")).toBe(CONNECTOR_KEY);
+		expect(res).not.toHaveProperty("resume_call");
+		// Generic oauth-code-exchange installs do not expose a callback correlation
+		// id, so returning an "any active Slack connection" poll would be unsafe.
+		expect(res).not.toHaveProperty("completion_check");
 		expect(await connectionCount(org.id)).toBe(0);
 	});
 
@@ -225,12 +233,13 @@ describe("manage_connections — app_installation create guard", () => {
 			ctx,
 		);
 
-		// The guard did not reject it: either it created the row, or it failed for
-		// some OTHER reason — but NOT with the install-flow guidance.
-		if ("error" in res) {
+		// The app-install guard did not intercept it. A later auth-selection
+		// continuation is valid, but it must not send the caller back to install.
 			expect(res).not.toHaveProperty("next_action", "install_app");
-		} else {
+		if ("action" in res && res.action === "create" && "connection" in res) {
 			expect(await connectionCount(org.id)).toBe(1);
+		} else {
+			expect(await connectionCount(org.id)).toBe(0);
 		}
 	});
 });
@@ -248,16 +257,19 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 
 	/** Assert the create/connect WAS rejected by the app-install guard. */
 	function expectGuardRejected(res: unknown): void {
-		expect(res && typeof res === "object" && "error" in res).toBe(true);
+		expect(res && typeof res === "object" && "error" in res).toBe(false);
 		expect(res).toMatchObject({
-			error_code: "connector_setup_required",
+			status: "setup_required",
+			setup_family: "app_installation",
 			provider: "slack",
 			next_action: "install_app",
 		});
 	}
 
 	it("create WITH a RESOLVABLE auth_profile_slug (oauth intent) is ALLOWED past the guard", async () => {
-		const org = await createTestOrganization({ name: "OAuth Profile Create Org" });
+		const org = await createTestOrganization({
+			name: "OAuth Profile Create Org",
+		});
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
 		await seedAppInstallConnector(org.id);
@@ -285,7 +297,9 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 	});
 
 	it("connect WITH a RESOLVABLE auth_profile_slug (oauth intent) is ALLOWED past the guard", async () => {
-		const org = await createTestOrganization({ name: "OAuth Profile Connect Org" });
+		const org = await createTestOrganization({
+			name: "OAuth Profile Connect Org",
+		});
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
 		await seedAppInstallConnector(org.id);
@@ -338,7 +352,9 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 	});
 
 	it("connect WITH a NON-EXISTENT auth_profile_slug + no installation_ref is REJECTED (bypass closed)", async () => {
-		const org = await createTestOrganization({ name: "Bogus Slug Connect Org" });
+		const org = await createTestOrganization({
+			name: "Bogus Slug Connect Org",
+		});
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
 		await seedAppInstallConnector(org.id);
@@ -354,7 +370,16 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 			TEST_ENV,
 			ctx,
 		);
-		expectGuardRejected(res);
+		// connect path now surfaces the bypass-closed outcome as a setup_required
+		// continuation (no `error` field), so it survives run_sdk. The bogus slug
+		// still falls through to app_installation and is rejected/continued.
+		expect(res && typeof res === "object" && "error" in res).toBe(false);
+		expect(res).toMatchObject({
+			action: "connect",
+			status: "setup_required",
+			setup_family: "app_installation",
+			next_action: "install_app",
+		});
 		expect(await connectionCount(org.id)).toBe(0);
 	});
 
@@ -386,7 +411,9 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 		// browser / interactive). An oauth_app carries only the app's
 		// client_id/secret — it does NOT provide the connection's auth, so pointing
 		// auth_profile_slug at one is the wrong kind and must NOT satisfy the guard.
-		const org = await createTestOrganization({ name: "Wrong Kind Account Org" });
+		const org = await createTestOrganization({
+			name: "Wrong Kind Account Org",
+		});
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
 		await seedAppInstallConnector(org.id);
@@ -474,7 +501,9 @@ describe("manage_connections — app_installation guard is SELECTION-AWARE (regr
 	});
 
 	it("create WITH a RESOLVABLE app_auth_profile_slug is ALLOWED past the guard", async () => {
-		const org = await createTestOrganization({ name: "App Profile Create Org" });
+		const org = await createTestOrganization({
+			name: "App Profile Create Org",
+		});
 		const user = await createTestUser();
 		await addUserToOrganization(user.id, org.id, "owner");
 		await seedAppInstallConnector(org.id);

--- a/packages/server/src/__tests__/integration/connectors/connect-setup-continuation.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connect-setup-continuation.test.ts
@@ -700,7 +700,7 @@ describe("connections.connect — setup_required continuation", () => {
 			return_value?: unknown;
 			error?: { name: string; message: string };
 		}>(
-			`export default async (_ctx, client) => { return await client.connections.connect({ connector_key: ${JSON.stringify(CONNECTORS.appInstall)} }); }`,
+			'export default async (_ctx, client) => { return await client.connections.connect({ connector_key: "demo.cont.appinstall.cont" }); }',
 		);
 
 		// The continuation must survive as a return value — NOT a thrown ScriptError.

--- a/packages/server/src/__tests__/integration/connectors/connect-setup-continuation.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/connect-setup-continuation.test.ts
@@ -1,0 +1,731 @@
+/**
+ * `connections.connect` setup-required continuation contract.
+ *
+ * Setup-required outcomes (GitHub app install, missing OAuth app config,
+ * interactive pairing, env/browser auth selection, ...) are NON-TERMINAL,
+ * actionable continuations — NOT prose-only business errors. They MUST:
+ *
+ *   1. return as a structured `{ action: 'connect', status: 'setup_required' }`
+ *      result (no `error` field), so the action-call boundary does NOT throw and
+ *      the value SURVIVES `run_sdk` as a return_value (red→green proof below);
+ *   2. carry absolute URL(s) + a machine-readable `next_action` +
+ *      `completion_check`;
+ *   3. omit `resume_call` when setup itself creates the active connection
+ *      (GitHub App install / interactive auth), and expose only an immediately
+ *      callable completion poll.
+ *
+ * Covers the setup families: oauth, app_installation, env_keys, browser,
+ * interactive, none (active), and device-bound (see the e2e matrix file).
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import type { ToolContext } from "../../../tools/registry";
+import { manageConnections } from "../../../tools/admin/manage_connections";
+import { getTestDb } from "../../setup/test-db";
+import { pgTextArray } from "../../../db/client";
+import { initWorkspaceProvider } from "../../../workspace";
+import {
+	addUserToOrganization,
+	createTestAccessToken,
+	createTestConnectorDefinition,
+	createTestOAuthClient,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+import { TestMcpClient } from "../../setup/test-mcp-client";
+import { cleanupTestDatabase } from "../../setup/test-db";
+
+const TEST_ENV = {} as Env;
+
+function ctxFor(organizationId: string, userId: string): ToolContext {
+	return {
+		organizationId,
+		userId,
+		memberRole: "owner",
+		agentId: null,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+		// Absolute origin so setup_url/install_url/connect_url are absolute.
+		baseUrl: "https://gateway.test/lobu",
+	} as ToolContext;
+}
+
+const CONNECTORS = {
+	appInstall: "demo.cont.appinstall.cont",
+	oauth: "demo.cont.oauth.cont",
+	env: "demo.cont.env.cont",
+	browser: "demo.cont.browser.cont",
+	interactive: "demo.cont.interactive.cont",
+	none: "demo.cont.none.cont",
+} as const;
+
+async function seedConnectors(organizationId: string): Promise<void> {
+	await createTestConnectorDefinition({
+		key: CONNECTORS.appInstall,
+		name: "App Install Continuation",
+		organization_id: organizationId,
+		auth_schema: {
+			methods: [
+				{
+					type: "app_installation",
+					provider: "github",
+					providerInstance: "cloud",
+					installShape: "github-app",
+					appIdKey: "DEMO_APP_ID",
+					appSlugKey: "DEMO_APP_SLUG",
+					privateKeyKey: "DEMO_APP_PRIVATE_KEY",
+				},
+				{ type: "env_keys", fields: [{ key: "DEMO_TOKEN" }] },
+			],
+		},
+	});
+	await createTestConnectorDefinition({
+		key: CONNECTORS.oauth,
+		name: "OAuth Continuation",
+		organization_id: organizationId,
+		auth_schema: {
+			methods: [
+				{
+					type: "oauth",
+					provider: "google",
+					requiredScopes: ["read"],
+					clientIdKey: "CLIENT_ID",
+					clientSecretKey: "CLIENT_SECRET",
+					tokenUrl: "https://example.test/token",
+				},
+			],
+		},
+	});
+	await createTestConnectorDefinition({
+		key: CONNECTORS.env,
+		name: "Env Continuation",
+		organization_id: organizationId,
+		auth_schema: {
+			methods: [{ type: "env_keys", fields: [{ key: "API_KEY" }] }],
+		},
+	});
+	await createTestConnectorDefinition({
+		key: CONNECTORS.browser,
+		name: "Browser Continuation",
+		organization_id: organizationId,
+		auth_schema: {
+			methods: [{ type: "browser", cookieDomain: "example.test" }],
+		},
+	});
+	await createTestConnectorDefinition({
+		key: CONNECTORS.interactive,
+		name: "Interactive Continuation",
+		organization_id: organizationId,
+		auth_schema: { methods: [{ type: "interactive" }] },
+	});
+	await createTestConnectorDefinition({
+		key: CONNECTORS.none,
+		name: "No Auth Continuation",
+		organization_id: organizationId,
+		auth_schema: { methods: [{ type: "none" }] },
+	});
+}
+
+function isAbsoluteUrl(value: unknown): boolean {
+	return typeof value === "string" && /^https?:\/\//i.test(value);
+}
+
+async function purge(organizationId: string): Promise<void> {
+	const sql = getTestDb();
+	const keys = Object.values(CONNECTORS);
+	// Order matters: connections reference auth_profiles via a composite FK with
+	// ON DELETE SET NULL, so connections must go before auth_profiles (deleting
+	// the profile first tries to NULL the connection's organization_id, which is
+	// NOT NULL).
+	await sql`DELETE FROM runs WHERE organization_id = ${organizationId} AND connector_key = ANY(${pgTextArray(keys)}::text[])`;
+	await sql`DELETE FROM feeds WHERE connection_id IN (SELECT id FROM connections WHERE connector_key = ANY(${pgTextArray(keys)}::text[]) AND organization_id = ${organizationId})`;
+	await sql`DELETE FROM connections WHERE connector_key = ANY(${pgTextArray(keys)}::text[]) AND organization_id = ${organizationId}`;
+	await sql`DELETE FROM auth_profiles WHERE connector_key = ANY(${pgTextArray(keys)}::text[]) AND organization_id = ${organizationId}`;
+	await sql`DELETE FROM connector_definitions WHERE key = ANY(${pgTextArray(keys)}::text[]) AND organization_id = ${organizationId}`;
+}
+
+describe("connections.connect — setup_required continuation", () => {
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+	});
+
+	afterEach(async () => {
+		const sql = getTestDb();
+		const orgs = await sql`SELECT id FROM "organization"`;
+		for (const org of orgs) await purge(org.id as string);
+	});
+
+	it("app_installation: returns an immediately callable completion poll and no connect retry", async () => {
+		const org = await createTestOrganization({ name: "App Install Cont Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+		const ctx = ctxFor(org.id, user.id);
+		const sql = getTestDb();
+		await sql`
+			INSERT INTO connections (
+				organization_id, connector_key, slug, display_name, status, config, created_by
+			) VALUES (
+				${org.id}, ${CONNECTORS.appInstall}, 'older-install', 'Older install',
+				'active', ${sql.json({ installation_ref: 1 })}, ${user.id}
+			)
+		`;
+		await sql`
+			INSERT INTO connections (
+				organization_id, connector_key, slug, display_name, status, config,
+				created_by, created_at
+			)
+			SELECT
+				${org.id}, ${CONNECTORS.appInstall}, 'newer-install-' || n,
+				'Newer install ' || n, 'active', ${sql.json({ installation_ref: 2 })},
+				${user.id}, NOW() + n * interval '1 second'
+			FROM generate_series(1, 55) AS n
+		`;
+
+		const res = (await manageConnections(
+			{ action: "connect", connector_key: CONNECTORS.appInstall },
+			TEST_ENV,
+			ctx,
+		)) as Record<string, unknown>;
+
+		// MUST be a continuation, not an error.
+		expect(res.action).toBe("connect");
+		expect(res.status).toBe("setup_required");
+		expect(res).not.toHaveProperty("error");
+		expect(res.setup_family).toBe("app_installation");
+		expect(res.next_action).toBe("install_app");
+		// Absolute install + setup URLs.
+		expect(isAbsoluteUrl(res.install_url)).toBe(true);
+		expect(isAbsoluteUrl(res.setup_url)).toBe(true);
+		const setupAttemptId = String(res.setup_attempt_id);
+		expect(setupAttemptId).toMatch(/^[0-9a-f-]{36}$/i);
+		expect(
+			new URL(String(res.install_url)).searchParams.get("setup_attempt_id"),
+		).toBe(setupAttemptId);
+		// The callback creates the connection, so there is no resume/retry call.
+		expect(res.resume_call).toBeUndefined();
+		const check = res.completion_check as Record<string, unknown>;
+		expect(check).toMatchObject({
+			call: {
+				sdk_method: "connections.list",
+				arguments: [
+					{
+						connector_key: CONNECTORS.appInstall,
+						status: "active",
+						setup_attempt_id: setupAttemptId,
+					},
+				],
+			},
+			success_when: {
+				path: "connections[].config.setup_attempt_ids",
+				includes: setupAttemptId,
+			},
+		});
+		// The older active connection must NOT satisfy this attempt's condition.
+		const [completionArgs] = (
+			check.call as { arguments: Array<Record<string, unknown>> }
+		).arguments;
+		const before = (await manageConnections(
+			{ action: "list", ...completionArgs },
+			TEST_ENV,
+			ctx,
+		)) as { connections: Array<Record<string, unknown>> };
+		expect(
+			before.connections.some((connection) => {
+				const ids = (connection.config as Record<string, unknown> | undefined)
+					?.setup_attempt_ids;
+				return Array.isArray(ids) && ids.includes(setupAttemptId);
+			}),
+		).toBe(false);
+
+		// Simulate the callback's correlation stamp: now the same completion check
+		// becomes true, including for a re-install that reuses an existing row.
+		await sql`
+			UPDATE connections
+			SET config = config || ${sql.json({ setup_attempt_ids: [setupAttemptId] })}::jsonb
+			WHERE organization_id = ${org.id}
+				AND connector_key = ${CONNECTORS.appInstall}
+				AND slug = 'older-install'
+		`;
+		const after = (await manageConnections(
+			{ action: "list", ...completionArgs },
+			TEST_ENV,
+			ctx,
+		)) as { connections: Array<Record<string, unknown>> };
+		expect(after.connections).toHaveLength(1);
+		expect(after.connections[0]?.slug).toBe("older-install");
+		expect(
+			after.connections.some((connection) => {
+				const ids = (connection.config as Record<string, unknown> | undefined)
+					?.setup_attempt_ids;
+				return Array.isArray(ids) && ids.includes(setupAttemptId);
+			}),
+		).toBe(true);
+	});
+
+	it("oauth (missing app profile): returns setup_required with configure_oauth_app", async () => {
+		const org = await createTestOrganization({ name: "OAuth Cont Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = (await manageConnections(
+			{
+				action: "connect",
+				connector_key: CONNECTORS.oauth,
+				display_name: "Preserved OAuth setup",
+				slug: "preserved-oauth-setup",
+				config: { repository: "acme/widget" },
+			},
+			TEST_ENV,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(res.action).toBe("connect");
+		expect(res.status).toBe("setup_required");
+		expect(res).not.toHaveProperty("error");
+		expect(res.setup_family).toBe("oauth");
+		expect(res.next_action).toBe("configure_oauth_app");
+		expect(isAbsoluteUrl(res.setup_url)).toBe(true);
+		expect(res.resume_call).toMatchObject({
+			sdk_method: "connections.connect",
+			arguments: [
+				{
+					connector_key: CONNECTORS.oauth,
+					display_name: "Preserved OAuth setup",
+					slug: "preserved-oauth-setup",
+					config: { repository: "acme/widget" },
+				},
+			],
+		});
+		// No connection exists yet, so no completion poll could be called now.
+		expect(res.completion_check).toBeUndefined();
+	});
+
+	it("connect resume_call omits secret config values without executable placeholders", async () => {
+		const org = await createTestOrganization({
+			name: "Secret Connect Cont Org",
+		});
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+
+		const res = (await manageConnections(
+			{
+				action: "connect",
+				connector_key: CONNECTORS.oauth,
+				display_name: "Safe resumable connect",
+				config: {
+					repository: "acme/widget",
+					token: "top-level-connect-secret",
+					nested: {
+						region: "eu-west-1",
+						apiKey: "nested-connect-secret",
+					},
+					accounts: [
+						{ label: "primary", access_token: "array-connect-secret" },
+					],
+				},
+			},
+			TEST_ENV,
+			ctxFor(org.id, user.id),
+		)) as Record<string, unknown>;
+
+		expect(res.resume_call).toEqual({
+			sdk_method: "connections.connect",
+			arguments: [
+				{
+					connector_key: CONNECTORS.oauth,
+					display_name: "Safe resumable connect",
+					config: {
+						repository: "acme/widget",
+						nested: { region: "eu-west-1" },
+						accounts: [{ label: "primary" }],
+					},
+				},
+			],
+		});
+		const serialized = JSON.stringify(res.resume_call);
+		expect(serialized).not.toContain("connect-secret");
+		expect(serialized).not.toContain("redacted");
+		expect(serialized).not.toContain("LOBU_REDACTED");
+	});
+
+	it("env_keys (no auth profile): returns setup_required with select_auth_profile", async () => {
+		const org = await createTestOrganization({ name: "Env Cont Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = (await manageConnections(
+			{ action: "connect", connector_key: CONNECTORS.env },
+			TEST_ENV,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(res.status).toBe("setup_required");
+		expect(res).not.toHaveProperty("error");
+		expect(res.setup_family).toBe("env_keys");
+		expect(res.next_action).toBe("select_auth_profile");
+		expect(res.resume_call).toMatchObject({
+			sdk_method: "connections.connect",
+			arguments: [{ connector_key: CONNECTORS.env }],
+		});
+		expect(res.completion_check).toBeUndefined();
+	});
+
+	it("browser (no profile): returns setup_required pointing at browser pairing", async () => {
+		const org = await createTestOrganization({ name: "Browser Cont Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = (await manageConnections(
+			{ action: "connect", connector_key: CONNECTORS.browser },
+			TEST_ENV,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(res.status).toBe("setup_required");
+		expect(res).not.toHaveProperty("error");
+		expect(res.setup_family).toBe("browser");
+		expect(["pair_browser", "select_auth_profile"]).toContain(res.next_action);
+		expect(res.resume_call).toMatchObject({
+			sdk_method: "connections.connect",
+		});
+		expect(res.completion_check).toBeUndefined();
+	});
+
+	it("interactive: creates a pending connection + auth run and returns pair_interactive continuation", async () => {
+		const org = await createTestOrganization({ name: "Interactive Cont Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = (await manageConnections(
+			{ action: "connect", connector_key: CONNECTORS.interactive },
+			TEST_ENV,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(res.status).toBe("setup_required");
+		expect(res).not.toHaveProperty("error");
+		expect(res.setup_family).toBe("interactive");
+		expect(res.next_action).toBe("pair_interactive");
+		// Interactive path MUST create the connection + kick off an auth run.
+		expect(typeof res.connection_id).toBe("number");
+		expect(typeof res.auth_run_id).toBe("number");
+		expect(res.resume_call).toBeUndefined();
+		expect(res.completion_check).toMatchObject({
+			call: {
+				sdk_method: "connections.get",
+				arguments: [res.connection_id],
+			},
+			success_when: { path: "connection.status", equals: "active" },
+		});
+
+		const sql = getTestDb();
+		const conn =
+			(await sql`SELECT status FROM connections WHERE id = ${res.connection_id}`) as Array<{
+				status: string;
+			}>;
+		expect(conn[0].status).toBe("pending_auth");
+		const run =
+			(await sql`SELECT run_type, status FROM runs WHERE id = ${res.auth_run_id}`) as Array<{
+				run_type: string;
+				status: string;
+			}>;
+		expect(run[0].run_type).toBe("auth");
+	});
+
+	it("create uses the same structured env setup continuation", async () => {
+		const org = await createTestOrganization({ name: "Create Env Cont Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+
+		const res = (await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTORS.env,
+				display_name: "Env pending setup",
+			},
+			TEST_ENV,
+			ctxFor(org.id, user.id),
+		)) as Record<string, unknown>;
+
+		expect(res).toMatchObject({
+			action: "create",
+			status: "setup_required",
+			setup_family: "env_keys",
+			next_action: "select_auth_profile",
+			resume_call: {
+				sdk_method: "connections.create",
+				arguments: [
+					{
+						connector_key: CONNECTORS.env,
+						display_name: "Env pending setup",
+					},
+				],
+			},
+		});
+		expect(res).not.toHaveProperty("error");
+		expect(res.completion_check).toBeUndefined();
+	});
+
+	it("create resume_call omits secret config values without executable placeholders", async () => {
+		const org = await createTestOrganization({
+			name: "Secret Create Cont Org",
+		});
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+
+		const res = (await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTORS.env,
+				display_name: "Safe resumable create",
+				config: {
+					workspace: "engineering",
+					secret: "top-level-create-secret",
+					nested: {
+						enabled: true,
+						privateKey: "nested-create-secret",
+					},
+					accounts: [
+						{ label: "primary", refreshTokens: ["array-create-secret"] },
+					],
+				},
+			},
+			TEST_ENV,
+			ctxFor(org.id, user.id),
+		)) as Record<string, unknown>;
+
+		expect(res.resume_call).toEqual({
+			sdk_method: "connections.create",
+			arguments: [
+				{
+					connector_key: CONNECTORS.env,
+					display_name: "Safe resumable create",
+					config: {
+						workspace: "engineering",
+						nested: { enabled: true },
+						accounts: [{ label: "primary" }],
+					},
+				},
+			],
+		});
+		const serialized = JSON.stringify(res.resume_call);
+		expect(serialized).not.toContain("create-secret");
+		expect(serialized).not.toContain("redacted");
+		expect(serialized).not.toContain("LOBU_REDACTED");
+	});
+
+	it("create interactive atomically creates the profile, connection, and auth run", async () => {
+		const org = await createTestOrganization({
+			name: "Create Interactive Cont Org",
+		});
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+
+		const res = (await manageConnections(
+			{ action: "create", connector_key: CONNECTORS.interactive },
+			TEST_ENV,
+			ctxFor(org.id, user.id),
+		)) as Record<string, unknown>;
+
+		expect(res).toMatchObject({
+			action: "create",
+			status: "setup_required",
+			setup_family: "interactive",
+			next_action: "pair_interactive",
+		});
+		expect(typeof res.connection_id).toBe("number");
+		expect(typeof res.auth_run_id).toBe("number");
+		expect(res.resume_call).toBeUndefined();
+		const [row] = await getTestDb()`
+			SELECT c.status, ap.profile_kind, r.run_type
+			FROM connections c
+			JOIN auth_profiles ap ON ap.id = c.auth_profile_id
+			JOIN runs r ON r.auth_profile_id = ap.id
+			WHERE c.id = ${res.connection_id} AND r.id = ${res.auth_run_id}
+		`;
+		expect(row).toMatchObject({
+			status: "pending_auth",
+			profile_kind: "interactive",
+			run_type: "auth",
+		});
+	});
+
+	it("assigns an admin-created interactive auth run to the target connection owner", async () => {
+		const org = await createTestOrganization({
+			name: "Delegated Interactive Cont Org",
+		});
+		const admin = await createTestUser();
+		const targetOwner = await createTestUser();
+		await addUserToOrganization(admin.id, org.id, "owner");
+		await addUserToOrganization(targetOwner.id, org.id, "member");
+		await seedConnectors(org.id);
+
+		const res = (await manageConnections(
+			{
+				action: "create",
+				connector_key: CONNECTORS.interactive,
+				created_by: targetOwner.id,
+			},
+			TEST_ENV,
+			ctxFor(org.id, admin.id),
+		)) as Record<string, unknown>;
+
+		const [row] = await getTestDb()`
+			SELECT c.created_by, r.created_by_user_id
+			FROM connections c
+			JOIN runs r ON r.auth_profile_id = c.auth_profile_id
+			WHERE c.id = ${res.connection_id} AND r.id = ${res.auth_run_id}
+		`;
+		expect(row).toEqual({
+			created_by: targetOwner.id,
+			created_by_user_id: targetOwner.id,
+		});
+	});
+
+	it("interactive setup rolls back profile and connection if the auth run cannot be created", async () => {
+		const org = await createTestOrganization({
+			name: "Interactive Rollback Org",
+		});
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+		await getTestDb()`DELETE FROM connector_versions WHERE connector_key = ${CONNECTORS.interactive}`;
+
+		for (const action of ["connect", "create"] as const) {
+			await expect(
+				manageConnections(
+					{ action, connector_key: CONNECTORS.interactive },
+					TEST_ENV,
+					ctxFor(org.id, user.id),
+				),
+			).rejects.toThrow(
+				/connector version|active connector definition|compiled code/i,
+			);
+			const [counts] = await getTestDb()`
+				SELECT
+				  (SELECT count(*)::int FROM connections WHERE organization_id = ${org.id} AND connector_key = ${CONNECTORS.interactive}) AS connections,
+				  (SELECT count(*)::int FROM auth_profiles WHERE organization_id = ${org.id} AND connector_key = ${CONNECTORS.interactive}) AS profiles
+			`;
+			expect(counts).toMatchObject({ connections: 0, profiles: 0 });
+		}
+	});
+
+	it("device-bound connectors return a setup continuation instead of prose-only failure", async () => {
+		const org = await createTestOrganization({ name: "Device Bound Cont Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+		await getTestDb()`
+			UPDATE connector_definitions
+			SET required_capability = 'computer_use'
+			WHERE organization_id = ${org.id} AND key = ${CONNECTORS.none}
+		`;
+
+		for (const action of ["connect", "create"] as const) {
+			const res = (await manageConnections(
+				{ action, connector_key: CONNECTORS.none },
+				TEST_ENV,
+				ctxFor(org.id, user.id),
+			)) as Record<string, unknown>;
+			expect(res).toMatchObject({
+				action,
+				status: "setup_required",
+				setup_family: "device_bound",
+				next_action: "connect_device",
+			});
+			expect(res).not.toHaveProperty("error");
+			expect(res.resume_call).toBeUndefined();
+			expect(res.completion_check).toBeUndefined();
+		}
+	});
+
+	it("none (no-auth): connects active immediately, not a setup_required", async () => {
+		const org = await createTestOrganization({ name: "None Cont Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+		const ctx = ctxFor(org.id, user.id);
+
+		const res = (await manageConnections(
+			{ action: "connect", connector_key: CONNECTORS.none },
+			TEST_ENV,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(res.action).toBe("connect");
+		expect(res.status).toBe("active");
+		expect(res).not.toHaveProperty("error");
+	});
+
+	it("SURVIVES run_sdk: an app_installation connect returns the continuation as return_value, not a ScriptError", async () => {
+		const org = await createTestOrganization({ name: "Connect RunSdk Org" });
+		const user = await createTestUser({ email: "connect-rsdk@test.com" });
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnectors(org.id);
+		const oauthClient = await createTestOAuthClient();
+		const oauthResult = await createTestAccessToken(
+			user.id,
+			org.id,
+			oauthClient.client_id,
+			{
+				scope: "mcp:read mcp:write mcp:admin",
+			},
+		);
+
+		const client = new TestMcpClient({
+			token: oauthResult.token,
+			orgSlug: org.slug,
+		});
+		const result = await client.runSdk<{
+			success: boolean;
+			return_value?: unknown;
+			error?: { name: string; message: string };
+		}>(
+			`export default async (_ctx, client) => { return await client.connections.connect({ connector_key: ${JSON.stringify(CONNECTORS.appInstall)} }); }`,
+		);
+
+		// The continuation must survive as a return value — NOT a thrown ScriptError.
+		expect(result.success).toBe(true);
+		expect(result.error).toBeUndefined();
+		const rv = result.return_value as Record<string, unknown>;
+		expect(rv.status).toBe("setup_required");
+		expect(rv).not.toHaveProperty("error");
+		expect(rv.setup_family).toBe("app_installation");
+		expect(["install_app", "open_setup"]).toContain(rv.next_action);
+
+		const failed = await client.runSdk<{
+			success: boolean;
+			error?: { name: string; message: string; details?: unknown };
+		}>(
+			`export default async (_ctx, client) => client.connections.connect({ connector_key: "missing-continuation-connector" });`,
+		);
+		expect(failed.success).toBe(false);
+		expect(failed.error).toMatchObject({
+			name: "ClientSdkActionError",
+			message: expect.stringMatching(/connector.*not found/i),
+			details: {
+				error: expect.stringMatching(/connector.*not found/i),
+			},
+		});
+		expect(failed.error?.message).not.toContain('{"');
+	});
+});

--- a/packages/server/src/__tests__/integration/connectors/github-app-install-callback.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-app-install-callback.test.ts
@@ -83,6 +83,7 @@ describe("GitHub App install callback — link installation", () => {
 			store,
 			providerAppId: PROVIDER_APP_ID,
 			metadata: { account_login: "acme-co" },
+			setupAttemptId: "8ad917c5-6176-47e7-9d21-1e927879a5f7",
 		});
 
 		expect(result.createdConnection).toBe(true);
@@ -126,6 +127,9 @@ describe("GitHub App install callback — link installation", () => {
 		expect(rows[0].connector_key).toBe("github");
 		expect(rows[0].status).toBe("active");
 		expect(Number(rows[0].config?.installation_ref)).toBe(result.installId);
+		expect(rows[0].config?.setup_attempt_ids).toContain(
+			"8ad917c5-6176-47e7-9d21-1e927879a5f7",
+		);
 	});
 
 	it("idempotent: a re-install for the same org+installation reuses the install + connection", async () => {
@@ -146,6 +150,7 @@ describe("GitHub App install callback — link installation", () => {
 			store,
 			providerAppId: PROVIDER_APP_ID,
 			metadata: { account_login: "reinstaller" },
+			setupAttemptId: "c14e7ff7-09c3-43c0-a5b1-ee3702d593d2",
 		});
 
 		// Same install row (same-org reinstall refreshes in place), no duplicate connection.
@@ -159,6 +164,12 @@ describe("GitHub App install callback — link installation", () => {
 			WHERE organization_id = ${org.id} AND connector_key = 'github' AND deleted_at IS NULL
 		`) as unknown as Array<{ n: number }>;
 		expect(connCount[0].n).toBe(1);
+		const [reused] = (await sql`
+			SELECT config FROM connections WHERE id = ${second.connectionId}
+		`) as unknown as Array<{ config: Record<string, unknown> }>;
+		expect(reused.config.setup_attempt_ids).toContain(
+			"c14e7ff7-09c3-43c0-a5b1-ee3702d593d2",
+		);
 
 		const installCount = (await sql`
 			SELECT count(*)::int AS n FROM app_installations

--- a/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-app-install-state.test.ts
@@ -121,9 +121,14 @@ function buildRouter(
 		/** Repos the (mocked) /installation/repositories enumeration returns. */
 		installationRepos?: Array<{ owner: string; name: string }>;
 	} = {},
-): { router: ReturnType<typeof createAppInstallRoutes>; captured: RouterCapture } {
+): {
+	router: ReturnType<typeof createAppInstallRoutes>;
+	captured: RouterCapture;
+} {
 	const exchangeReturns =
-		opts.exchangeReturns === undefined ? "fake-user-token" : opts.exchangeReturns;
+		opts.exchangeReturns === undefined
+			? "fake-user-token"
+			: opts.exchangeReturns;
 	const authedLogin = opts.authedLogin ?? "installer-user";
 
 	// Resolve the installations map: explicit `installations`, else the
@@ -221,7 +226,14 @@ async function installCount(organizationId: string): Promise<number> {
 /** Issue feeds on the org's github connections (the auto-provisioned shape). */
 async function issueFeeds(
 	organizationId: string,
-): Promise<Array<{ id: number; repo_owner: string; repo_name: string; next_run_at: Date | null }>> {
+): Promise<
+	Array<{
+		id: number;
+		repo_owner: string;
+		repo_name: string;
+		next_run_at: Date | null;
+	}>
+> {
 	const sql = getDb();
 	const rows = (await sql`
 		SELECT f.id, f.config ->> 'repo_owner' AS repo_owner,
@@ -298,7 +310,8 @@ beforeEach(async () => {
 	// App private key so the spy/registry path is well-formed (value irrelevant —
 	// the spy provider never signs, and repo enumeration is injected).
 	process.env.GITHUB_APP_PRIVATE_KEY =
-		ORIGINAL_ENV_PK ?? "-----BEGIN PRIVATE KEY-----\\nspy\\n-----END PRIVATE KEY-----";
+		ORIGINAL_ENV_PK ??
+		"-----BEGIN PRIVATE KEY-----\\nspy\\n-----END PRIVATE KEY-----";
 	installSpyMintProvider();
 	await cleanTables();
 });
@@ -372,7 +385,9 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 	});
 
 	it("rejects a callback with a GARBAGE setup_action → 400, zero mutation", async () => {
-		const org = await createTestOrganization({ name: "Org GarbageSetupAction" });
+		const org = await createTestOrganization({
+			name: "Org GarbageSetupAction",
+		});
 		await seedGithubConnector(org.id);
 		const state = await createGithubInstallStateStore().create({
 			organizationId: org.id,
@@ -397,8 +412,12 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 		// completing session's org must match the state's org or we reject — else the
 		// victim's installation would land in the attacker's org. (This previously
 		// asserted SUCCESS, codifying the vulnerability; flipped to assert the fix.)
-		const stateOrg = await createTestOrganization({ name: "Attacker Initiator Org" });
-		const ambientOrg = await createTestOrganization({ name: "Victim Session Org" });
+		const stateOrg = await createTestOrganization({
+			name: "Attacker Initiator Org",
+		});
+		const ambientOrg = await createTestOrganization({
+			name: "Victim Session Org",
+		});
 		await seedGithubConnector(stateOrg.id);
 		await seedGithubConnector(ambientOrg.id);
 
@@ -407,7 +426,9 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 
 		// resolveInstallOrgId resolves to the ambient (victim-session) org, NOT the
 		// state's org → mismatch.
-		const { router } = buildRouter(ambientOrg.id, { ownedInstallationIds: [7003] });
+		const { router } = buildRouter(ambientOrg.id, {
+			ownedInstallationIds: [7003],
+		});
 		const res = await router.fetch(
 			new Request(
 				`http://gw.test/github/app/install/callback?installation_id=7003&setup_action=install&state=${state}&code=valid-oauth-code`,
@@ -509,18 +530,24 @@ describe("GitHub App install callback — signed-state CSRF guard", () => {
 		await seedGithubConnector(org.id);
 		const { router } = buildRouter(org.id);
 
+		const setupAttemptId = "d6eed731-cd43-4632-90ac-f066c189a45d";
 		const res = await router.fetch(
-			new Request("http://gw.test/github/app/install"),
+			new Request(
+				`http://gw.test/github/app/install?setup_attempt_id=${setupAttemptId}`,
+			),
 		);
 		expect(res.status).toBe(302);
 		const location = res.headers.get("location") ?? "";
-		expect(location).toContain(`https://github.com/apps/${APP_SLUG}/installations/new`);
+		expect(location).toContain(
+			`https://github.com/apps/${APP_SLUG}/installations/new`,
+		);
 		const minted = new URL(location).searchParams.get("state");
 		expect(minted).toBeTruthy();
 
 		// The minted state resolves to the org server-side (Postgres-backed nonce).
 		const peeked = await createGithubInstallStateStore().peek(minted as string);
 		expect(peeked?.organizationId).toBe(org.id);
+		expect(peeked?.setupAttemptId).toBe(setupAttemptId);
 	});
 });
 
@@ -536,7 +563,9 @@ describe("GitHub App install callback — installation ownership guard", () => {
 		});
 		// /user/installations returns only the attacker's OWN installs (e.g. 555),
 		// NOT the victim id 8888 they're trying to steal.
-		const { router } = buildRouter(attackerOrg.id, { ownedInstallationIds: [555] });
+		const { router } = buildRouter(attackerOrg.id, {
+			ownedInstallationIds: [555],
+		});
 
 		const res = await router.fetch(
 			new Request(
@@ -555,8 +584,11 @@ describe("GitHub App install callback — installation ownership guard", () => {
 		await seedGithubConnector(org.id);
 		const state = await createGithubInstallStateStore().create({
 			organizationId: org.id,
+			setupAttemptId: "6f33f287-957c-4266-a221-6ccbb44369dd",
 		});
-		const { router } = buildRouter(org.id, { ownedInstallationIds: [4242, 999] });
+		const { router } = buildRouter(org.id, {
+			ownedInstallationIds: [4242, 999],
+		});
 
 		const res = await router.fetch(
 			new Request(
@@ -570,11 +602,61 @@ describe("GitHub App install callback — installation ownership guard", () => {
 		// The bound install carries the owned installation id (mint path reads this).
 		const sql = getDb();
 		const rows = (await sql`
-			SELECT external_tenant_id FROM app_installations
-			WHERE organization_id = ${org.id} AND provider_app_id = ${PROVIDER_APP_ID}
+			SELECT ai.external_tenant_id, c.config
+			FROM app_installations ai
+			JOIN connections c
+				ON c.organization_id = ai.organization_id
+				AND c.config ->> 'installation_ref' = ai.id::text
+			WHERE ai.organization_id = ${org.id}
+				AND ai.provider_app_id = ${PROVIDER_APP_ID}
 			LIMIT 1
-		`) as unknown as Array<{ external_tenant_id: string }>;
+		`) as unknown as Array<{
+			external_tenant_id: string;
+			config: Record<string, unknown>;
+		}>;
 		expect(rows[0].external_tenant_id).toBe("4242");
+		expect(rows[0].config.setup_attempt_ids).toContain(
+			"6f33f287-957c-4266-a221-6ccbb44369dd",
+		);
+	});
+
+	it("keeps concurrent setup attempts completable when callbacks arrive in reverse order", async () => {
+		const org = await createTestOrganization({ name: "Concurrent Setup Org" });
+		await seedGithubConnector(org.id);
+		const firstAttempt = "078d631e-dbc2-4caa-887f-76e8d73c5cf5";
+		const secondAttempt = "7f2d0188-95b2-4110-a9f3-f8527f16f76d";
+		const store = createGithubInstallStateStore();
+		const firstState = await store.create({
+			organizationId: org.id,
+			setupAttemptId: firstAttempt,
+		});
+		const secondState = await store.create({
+			organizationId: org.id,
+			setupAttemptId: secondAttempt,
+		});
+		const { router } = buildRouter(org.id, {
+			ownedInstallationIds: [4243],
+		});
+
+		for (const state of [secondState, firstState]) {
+			const res = await router.fetch(
+				new Request(
+					`http://gw.test/github/app/install/callback?installation_id=4243&setup_action=install&state=${state}&code=valid-oauth-code`,
+				),
+			);
+			expect(res.status).toBe(200);
+		}
+
+		const [row] = (await getDb()`
+			SELECT config
+			FROM connections
+			WHERE organization_id = ${org.id}
+				AND connector_key = 'github'
+				AND deleted_at IS NULL
+		`) as unknown as Array<{ config: Record<string, unknown> }>;
+		expect(row.config.setup_attempt_ids).toEqual(
+			expect.arrayContaining([firstAttempt, secondAttempt]),
+		);
 	});
 
 	it("MISSING code → 400, zero mutation (ownership cannot be verified without it)", async () => {
@@ -660,8 +742,7 @@ describe("GitHub App install callback — account-ownership (admin vs member)", 
 			installations: {
 				[opts.installationId]: { login: opts.orgLogin, type: "Organization" },
 			},
-			orgRoles:
-				opts.role === null ? null : { [opts.orgLogin]: opts.role },
+			orgRoles: opts.role === null ? null : { [opts.orgLogin]: opts.role },
 		});
 		const res = await router.fetch(
 			new Request(
@@ -850,7 +931,9 @@ describe("GitHub App install callback — auto-provision feeds", () => {
 	});
 
 	it("is idempotent: re-bind reuses feeds and enqueues no duplicate backfill", async () => {
-		const org = await createTestOrganization({ name: "AutoProvision Reidem Org" });
+		const org = await createTestOrganization({
+			name: "AutoProvision Reidem Org",
+		});
 		await seedGithubConnector(org.id);
 
 		const first = await createGithubInstallStateStore().create({
@@ -892,7 +975,9 @@ describe("GitHub App install callback — auto-provision feeds", () => {
 	});
 
 	it("a successful bind with no accessible repos still succeeds (no feeds, no error)", async () => {
-		const org = await createTestOrganization({ name: "AutoProvision Empty Org" });
+		const org = await createTestOrganization({
+			name: "AutoProvision Empty Org",
+		});
 		await seedGithubConnector(org.id);
 		const state = await createGithubInstallStateStore().create({
 			organizationId: org.id,
@@ -914,7 +999,9 @@ describe("GitHub App install callback — auto-provision feeds", () => {
 	});
 
 	it("CONCURRENCY: two parallel auto-provisions for the same (connection,repo) create exactly ONE feed (DB-enforced)", async () => {
-		const org = await createTestOrganization({ name: "AutoProvision Race Org" });
+		const org = await createTestOrganization({
+			name: "AutoProvision Race Org",
+		});
 		await seedGithubConnector(org.id);
 		// Seed an active install + a connection bound to it — the shape auto-provision
 		// operates on (mirrors what the callback produces).
@@ -926,7 +1013,10 @@ describe("GitHub App install callback — auto-provision feeds", () => {
 			providerAppId: PROVIDER_APP_ID,
 			externalTenantId: "6900",
 			status: "active",
-			metadata: { appIdKey: "GITHUB_APP_ID", privateKeyKey: "GITHUB_APP_PRIVATE_KEY" },
+			metadata: {
+				appIdKey: "GITHUB_APP_ID",
+				privateKeyKey: "GITHUB_APP_PRIVATE_KEY",
+			},
 		});
 		const sql = getDb();
 		const connRows = (await sql`
@@ -965,8 +1055,7 @@ describe("GitHub App install callback — auto-provision feeds", () => {
 		expect(a.feedIds).toEqual([feeds[0].id]);
 		expect(b.feedIds).toEqual([feeds[0].id]);
 		// Only the winner enqueued a backfill (no double-backfill).
-		const totalEnqueued =
-			a.enqueuedRunIds.length + b.enqueuedRunIds.length;
+		const totalEnqueued = a.enqueuedRunIds.length + b.enqueuedRunIds.length;
 		expect(totalEnqueued).toBe(1);
 	});
 });
@@ -1071,7 +1160,9 @@ describe("GitHub App install callback — re-bind recovery (user-auth flow)", ()
 	});
 
 	it("recovery callback with ambiguous installations → 400, zero mutation", async () => {
-		const org = await createTestOrganization({ name: "Recovery Ambiguous Org" });
+		const org = await createTestOrganization({
+			name: "Recovery Ambiguous Org",
+		});
 		await seedGithubConnector(org.id);
 		const state = await createGithubInstallStateStore().create({
 			organizationId: org.id,
@@ -1092,8 +1183,12 @@ describe("GitHub App install callback — re-bind recovery (user-auth flow)", ()
 	});
 
 	it("recovery callback STILL enforces session-org === state-org (anti-fixation)", async () => {
-		const stateOrg = await createTestOrganization({ name: "Recovery Attacker Org" });
-		const ambientOrg = await createTestOrganization({ name: "Recovery Victim Org" });
+		const stateOrg = await createTestOrganization({
+			name: "Recovery Attacker Org",
+		});
+		const ambientOrg = await createTestOrganization({
+			name: "Recovery Victim Org",
+		});
 		await seedGithubConnector(stateOrg.id);
 		await seedGithubConnector(ambientOrg.id);
 		const state = await createGithubInstallStateStore().create({

--- a/packages/server/src/__tests__/integration/connectors/managed-connect-consent-only.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/managed-connect-consent-only.test.ts
@@ -171,10 +171,24 @@ describe('Stage 3 — managed-connect creates a consent-only connection', () => 
       { action: 'connect', connector_key: connectorKey },
       TEST_ENV,
       ctx
-    )) as { connection_id?: number; error?: string };
+    )) as {
+      connection_id?: number;
+      error?: string;
+      status?: string;
+      setup_family?: string;
+      next_action?: string;
+      resume_call?: { sdk_method?: string };
+    };
 
-    // Not treated as managed → the normal OAuth-app requirement applies.
-    expect(result.error).toMatch(/OAuth app profile not configured/i);
+    // Not treated as managed → the normal OAuth-app setup requirement applies.
+    expect(result).toMatchObject({
+      status: 'setup_required',
+      setup_family: 'oauth',
+      next_action: 'configure_oauth_app',
+      resume_call: { sdk_method: 'connections.connect' },
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.connection_id).toBeUndefined();
 
     const sql = getTestDb();
     const connRows = (await sql`
@@ -198,9 +212,23 @@ describe('Stage 3 — managed-connect creates a consent-only connection', () => 
       { action: 'connect', connector_key: connectorKey },
       TEST_ENV,
       ctx
-    )) as { connection_id?: number; error?: string };
+    )) as {
+      connection_id?: number;
+      error?: string;
+      status?: string;
+      setup_family?: string;
+      next_action?: string;
+      resume_call?: { sdk_method?: string };
+    };
 
-    expect(result.error).toMatch(/OAuth app profile not configured/i);
+    expect(result).toMatchObject({
+      status: 'setup_required',
+      setup_family: 'oauth',
+      next_action: 'configure_oauth_app',
+      resume_call: { sdk_method: 'connections.connect' },
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.connection_id).toBeUndefined();
 
     const sql = getTestDb();
     const connRows = (await sql`

--- a/packages/server/src/__tests__/integration/connectors/managed-local-feeds.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/managed-local-feeds.test.ts
@@ -213,9 +213,22 @@ describe('Stage 5 — local managed connection has feeds', () => {
       },
       TEST_ENV,
       ctx
-    )) as { connection?: { id?: number }; error?: string };
+    )) as {
+      connection?: { id?: number };
+      error?: string;
+      status?: string;
+      setup_family?: string;
+      next_action?: string;
+      resume_call?: { sdk_method?: string };
+    };
 
-    expect(result.error).toBeTruthy();
+    expect(result).toMatchObject({
+      status: 'setup_required',
+      setup_family: 'oauth',
+      next_action: 'select_auth_profile',
+      resume_call: { sdk_method: 'connections.create' },
+    });
+    expect(result.error).toBeUndefined();
     expect(result.connection?.id).toBeUndefined();
   });
 

--- a/packages/server/src/gateway/auth/oauth/state-store.ts
+++ b/packages/server/src/gateway/auth/oauth/state-store.ts
@@ -195,6 +195,12 @@ interface GithubInstallStateData {
    * full ownership + session-org checks.
    */
   recovery?: boolean;
+  /**
+   * Opaque correlation id minted by the connection setup continuation. It is
+   * carried through GitHub's signed state and stamped on the linked connection
+   * so the initiating agent can distinguish this callback from older installs.
+   */
+  setupAttemptId?: string;
 }
 
 /**

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -36,10 +36,7 @@
  */
 
 import { Hono } from "hono";
-import {
-	createLogger,
-	getErrorMessage,
-} from "@lobu/core";
+import { createLogger, getErrorMessage } from "@lobu/core";
 import type { ConnectorAuthAppInstallation } from "@lobu/connector-sdk";
 import { getDb } from "../../../db/client.js";
 import { getConfiguredPublicOrigin } from "../../../utils/public-origin.js";
@@ -250,7 +247,9 @@ async function defaultFetchInstallationAccount(
 		}
 		const body = result.data;
 		total = typeof body.total_count === "number" ? body.total_count : seen;
-		const installs = Array.isArray(body.installations) ? body.installations : [];
+		const installs = Array.isArray(body.installations)
+			? body.installations
+			: [];
 		if (installs.length === 0) break;
 		for (const inst of installs) {
 			seen += 1;
@@ -314,7 +313,9 @@ async function defaultFetchSoleAccessibleInstallation(
 		}
 		const body = result.data;
 		total = typeof body.total_count === "number" ? body.total_count : seen;
-		const installs = Array.isArray(body.installations) ? body.installations : [];
+		const installs = Array.isArray(body.installations)
+			? body.installations
+			: [];
 		if (installs.length === 0) break;
 		for (const inst of installs) {
 			seen += 1;
@@ -429,6 +430,7 @@ export async function linkGithubAppInstallation(params: {
 	/** Account/metadata stamped onto the install row (account login, etc.). */
 	metadata?: Record<string, unknown>;
 	createdBy?: string | null;
+	setupAttemptId?: string;
 }): Promise<LinkGithubInstallationResult> {
 	const sql = getDb();
 	const accountLogin =
@@ -486,9 +488,23 @@ export async function linkGithubAppInstallation(params: {
 
 		if (existing.length > 0) {
 			const connectionId = Number(existing[0].id);
+			const setupAttemptIds = Array.isArray(
+				existing[0].config?.setup_attempt_ids,
+			)
+				? existing[0].config.setup_attempt_ids.filter(
+						(value): value is string => typeof value === "string",
+					)
+				: [];
 			const mergedConfig = {
 				...(existing[0].config ?? {}),
 				installation_ref: install.id,
+				...(params.setupAttemptId
+					? {
+							setup_attempt_ids: [
+								...new Set([...setupAttemptIds, params.setupAttemptId]),
+							],
+						}
+					: {}),
 			};
 			await tx`
 				UPDATE connections
@@ -538,12 +554,18 @@ export async function linkGithubAppInstallation(params: {
 					organization_id, connector_key, slug, display_name, status, config, created_by
 				) VALUES (
 					${params.organizationId}, ${GITHUB_CONNECTOR_KEY}, ${slug}, ${displayName},
-					'active', ${tx.json({ installation_ref: install.id })}, ${params.createdBy ?? null}
+					'active', ${tx.json({
+						installation_ref: install.id,
+						...(params.setupAttemptId
+							? { setup_attempt_ids: [params.setupAttemptId] }
+							: {}),
+					})}, ${params.createdBy ?? null}
 				)
 				RETURNING id, slug
 			`,
 		}).catch((err) => {
-			if (err instanceof ConnectionSlugConflictError) throw new Error(err.message);
+			if (err instanceof ConnectionSlugConflictError)
+				throw new Error(err.message);
 			throw err;
 		});
 
@@ -616,8 +638,11 @@ async function defaultFetchInstallationRepositories(
 				owner?: { login?: string };
 			}>;
 		};
-		total = typeof body.total_count === "number" ? body.total_count : repos.length;
-		const page_repos = Array.isArray(body.repositories) ? body.repositories : [];
+		total =
+			typeof body.total_count === "number" ? body.total_count : repos.length;
+		const page_repos = Array.isArray(body.repositories)
+			? body.repositories
+			: [];
 		if (page_repos.length === 0) break;
 		for (const r of page_repos) {
 			const owner = r.owner?.login;
@@ -690,13 +715,15 @@ export async function autoProvisionGithubIssueFeeds(params: {
 		metadata: {
 			...install.metadata,
 			appIdKey: install.metadata?.appIdKey ?? "GITHUB_APP_ID",
-			privateKeyKey: install.metadata?.privateKeyKey ?? "GITHUB_APP_PRIVATE_KEY",
+			privateKeyKey:
+				install.metadata?.privateKeyKey ?? "GITHUB_APP_PRIVATE_KEY",
 		},
 	};
 
 	let token: string;
 	try {
-		const minted = await getInstallationTokenRegistry().mintFor(installWithKeys);
+		const minted =
+			await getInstallationTokenRegistry().mintFor(installWithKeys);
 		token = minted.token;
 	} catch (error) {
 		logger.warn(
@@ -711,7 +738,8 @@ export async function autoProvisionGithubIssueFeeds(params: {
 	}
 
 	const fetchRepos =
-		params.fetchInstallationRepositories ?? defaultFetchInstallationRepositories;
+		params.fetchInstallationRepositories ??
+		defaultFetchInstallationRepositories;
 	const repos = await fetchRepos(token);
 	if (repos.length === 0) {
 		logger.info(
@@ -841,13 +869,15 @@ export async function provisionGithubTeamGraph(params: {
 		metadata: {
 			...install.metadata,
 			appIdKey: install.metadata?.appIdKey ?? "GITHUB_APP_ID",
-			privateKeyKey: install.metadata?.privateKeyKey ?? "GITHUB_APP_PRIVATE_KEY",
+			privateKeyKey:
+				install.metadata?.privateKeyKey ?? "GITHUB_APP_PRIVATE_KEY",
 		},
 	};
 
 	let token: string;
 	try {
-		const minted = await getInstallationTokenRegistry().mintFor(installWithKeys);
+		const minted =
+			await getInstallationTokenRegistry().mintFor(installWithKeys);
 		token = minted.token;
 	} catch (error) {
 		logger.warn(
@@ -1261,15 +1291,25 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 		// the install page would dead-end). Recovery needs the App's OAuth client id
 		// to send the user through user-authorization.
 		const explicitRecovery = c.req.query("recovery") === "1";
+		const rawSetupAttemptId = c.req.query("setup_attempt_id");
+		const setupAttemptId =
+			rawSetupAttemptId &&
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+				rawSetupAttemptId,
+			)
+				? rawSetupAttemptId
+				: undefined;
 		const clientId = creds?.clientId;
 		const alreadyHasInstallRow = await orgHasGithubInstallRow(orgId, appId);
-		const useRecovery = (explicitRecovery || alreadyHasInstallRow) && !!clientId;
+		const useRecovery =
+			(explicitRecovery || alreadyHasInstallRow) && !!clientId;
 
 		const stateStore = createGithubInstallStateStore();
 		if (useRecovery && clientId) {
 			const state = await stateStore.create({
 				organizationId: orgId,
 				recovery: true,
+				...(setupAttemptId ? { setupAttemptId } : {}),
 			});
 			const callbackUrl = githubInstallCallbackUrl(
 				deps.getPublicGatewayUrl?.(),
@@ -1281,7 +1321,10 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 			);
 		}
 
-		const state = await stateStore.create({ organizationId: orgId });
+		const state = await stateStore.create({
+			organizationId: orgId,
+			...(setupAttemptId ? { setupAttemptId } : {}),
+		});
 		const installUrl =
 			renderAppInstallUrl(creds?.installUrlTemplate, appSlug, state) ??
 			githubAppInstallUrl(appSlug, state);
@@ -1478,7 +1521,8 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 			installationId: suppliedInstallationId,
 			recovery: isRecovery,
 			redirectUri: callbackUrl,
-			exchange: deps.exchangeInstallOAuthCode ?? defaultExchangeInstallOAuthCode,
+			exchange:
+				deps.exchangeInstallOAuthCode ?? defaultExchangeInstallOAuthCode,
 			fetchAccount:
 				deps.fetchInstallationAccount ?? defaultFetchInstallationAccount,
 			fetchLogin: deps.fetchAuthedUserLogin ?? defaultFetchAuthedUserLogin,
@@ -1522,8 +1566,9 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 		`) as unknown as Array<{ auth_schema: unknown }>;
 		const hasAppInstallMethod =
 			defRows.length > 0 &&
-			getAppInstallationAuthMethods(normalizeConnectorAuthSchema(defRows[0].auth_schema))
-				.length > 0;
+			getAppInstallationAuthMethods(
+				normalizeConnectorAuthSchema(defRows[0].auth_schema),
+			).length > 0;
 		if (!hasAppInstallMethod) {
 			return c.html(
 				renderOAuthErrorPage(
@@ -1558,6 +1603,9 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				installationId: String(installationId),
 				store: deps.installationStore,
 				providerAppId: appId,
+				...(consumed.setupAttemptId
+					? { setupAttemptId: consumed.setupAttemptId }
+					: {}),
 				// Record the ownership-verified account (GitHub omits it from the
 				// redirect query) so the install row carries the org login/type/id the
 				// team-graph build and UI rely on, falling back to any query value.
@@ -1672,7 +1720,9 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 }
 
 /** Pull the account login GitHub passes (when present) into install metadata. */
-function buildInstallMetadata(c: import("hono").Context): Record<string, unknown> {
+function buildInstallMetadata(
+	c: import("hono").Context,
+): Record<string, unknown> {
 	const metadata: Record<string, unknown> = {};
 	// GitHub doesn't pass the account login on the install redirect, but a
 	// future state-bound flow / the owletto UI can; accept it if present.
@@ -1718,7 +1768,10 @@ interface OAuthInstallStateData {
 function oauthInstallStateStore(
 	provider: string,
 ): OAuthStateStore<OAuthInstallStateData> {
-	return new OAuthStateStore(`${provider}:oauth:state`, `${provider}-install-state`);
+	return new OAuthStateStore(
+		`${provider}:oauth:state`,
+		`${provider}-install-state`,
+	);
 }
 
 /**
@@ -1817,7 +1870,11 @@ function mountOAuthCodeExchangeRoutes(
 		// the primed bundled method (slack-connection-coordinator).
 		const method =
 			(installOrgId
-				? await getOrgAppInstallationMethod(installOrgId, connectorKey, provider)
+				? await getOrgAppInstallationMethod(
+						installOrgId,
+						connectorKey,
+						provider,
+					)
 				: null) ??
 			getPrimedBundledMethod(connectorKey, provider) ??
 			null;
@@ -1951,9 +2008,7 @@ function mountOAuthCodeExchangeRoutes(
 			return c.html(
 				renderOAuthErrorPage(
 					`${provider}_install_failed`,
-					error instanceof Error
-						? error.message
-						: `${display} install failed.`,
+					error instanceof Error ? error.message : `${display} install failed.`,
 				),
 				500,
 			);
@@ -2051,9 +2106,15 @@ export function createInstallRoutes(deps: InstallEngineDeps): Hono {
 			);
 			continue;
 		}
-		if (integration.deliveryKind !== "chat" || !deps.completeChatPendingInstall) {
+		if (
+			integration.deliveryKind !== "chat" ||
+			!deps.completeChatPendingInstall
+		) {
 			oauthInstallLogger.warn(
-				{ provider: integration.provider, deliveryKind: integration.deliveryKind },
+				{
+					provider: integration.provider,
+					deliveryKind: integration.deliveryKind,
+				},
 				"Skipping oauth-code-exchange install routes: no post-install completion for this delivery kind",
 			);
 			continue;

--- a/packages/server/src/gateway/routes/public/app-install.ts
+++ b/packages/server/src/gateway/routes/public/app-install.ts
@@ -36,7 +36,10 @@
  */
 
 import { Hono } from "hono";
-import { createLogger, getErrorMessage } from "@lobu/core";
+import {
+	createLogger,
+	getErrorMessage,
+} from "@lobu/core";
 import type { ConnectorAuthAppInstallation } from "@lobu/connector-sdk";
 import { getDb } from "../../../db/client.js";
 import { getConfiguredPublicOrigin } from "../../../utils/public-origin.js";
@@ -247,9 +250,7 @@ async function defaultFetchInstallationAccount(
 		}
 		const body = result.data;
 		total = typeof body.total_count === "number" ? body.total_count : seen;
-		const installs = Array.isArray(body.installations)
-			? body.installations
-			: [];
+		const installs = Array.isArray(body.installations) ? body.installations : [];
 		if (installs.length === 0) break;
 		for (const inst of installs) {
 			seen += 1;
@@ -313,9 +314,7 @@ async function defaultFetchSoleAccessibleInstallation(
 		}
 		const body = result.data;
 		total = typeof body.total_count === "number" ? body.total_count : seen;
-		const installs = Array.isArray(body.installations)
-			? body.installations
-			: [];
+		const installs = Array.isArray(body.installations) ? body.installations : [];
 		if (installs.length === 0) break;
 		for (const inst of installs) {
 			seen += 1;
@@ -564,8 +563,7 @@ export async function linkGithubAppInstallation(params: {
 				RETURNING id, slug
 			`,
 		}).catch((err) => {
-			if (err instanceof ConnectionSlugConflictError)
-				throw new Error(err.message);
+			if (err instanceof ConnectionSlugConflictError) throw new Error(err.message);
 			throw err;
 		});
 
@@ -638,11 +636,8 @@ async function defaultFetchInstallationRepositories(
 				owner?: { login?: string };
 			}>;
 		};
-		total =
-			typeof body.total_count === "number" ? body.total_count : repos.length;
-		const page_repos = Array.isArray(body.repositories)
-			? body.repositories
-			: [];
+		total = typeof body.total_count === "number" ? body.total_count : repos.length;
+		const page_repos = Array.isArray(body.repositories) ? body.repositories : [];
 		if (page_repos.length === 0) break;
 		for (const r of page_repos) {
 			const owner = r.owner?.login;
@@ -715,15 +710,13 @@ export async function autoProvisionGithubIssueFeeds(params: {
 		metadata: {
 			...install.metadata,
 			appIdKey: install.metadata?.appIdKey ?? "GITHUB_APP_ID",
-			privateKeyKey:
-				install.metadata?.privateKeyKey ?? "GITHUB_APP_PRIVATE_KEY",
+			privateKeyKey: install.metadata?.privateKeyKey ?? "GITHUB_APP_PRIVATE_KEY",
 		},
 	};
 
 	let token: string;
 	try {
-		const minted =
-			await getInstallationTokenRegistry().mintFor(installWithKeys);
+		const minted = await getInstallationTokenRegistry().mintFor(installWithKeys);
 		token = minted.token;
 	} catch (error) {
 		logger.warn(
@@ -738,8 +731,7 @@ export async function autoProvisionGithubIssueFeeds(params: {
 	}
 
 	const fetchRepos =
-		params.fetchInstallationRepositories ??
-		defaultFetchInstallationRepositories;
+		params.fetchInstallationRepositories ?? defaultFetchInstallationRepositories;
 	const repos = await fetchRepos(token);
 	if (repos.length === 0) {
 		logger.info(
@@ -869,15 +861,13 @@ export async function provisionGithubTeamGraph(params: {
 		metadata: {
 			...install.metadata,
 			appIdKey: install.metadata?.appIdKey ?? "GITHUB_APP_ID",
-			privateKeyKey:
-				install.metadata?.privateKeyKey ?? "GITHUB_APP_PRIVATE_KEY",
+			privateKeyKey: install.metadata?.privateKeyKey ?? "GITHUB_APP_PRIVATE_KEY",
 		},
 	};
 
 	let token: string;
 	try {
-		const minted =
-			await getInstallationTokenRegistry().mintFor(installWithKeys);
+		const minted = await getInstallationTokenRegistry().mintFor(installWithKeys);
 		token = minted.token;
 	} catch (error) {
 		logger.warn(
@@ -1301,8 +1291,7 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 				: undefined;
 		const clientId = creds?.clientId;
 		const alreadyHasInstallRow = await orgHasGithubInstallRow(orgId, appId);
-		const useRecovery =
-			(explicitRecovery || alreadyHasInstallRow) && !!clientId;
+		const useRecovery = (explicitRecovery || alreadyHasInstallRow) && !!clientId;
 
 		const stateStore = createGithubInstallStateStore();
 		if (useRecovery && clientId) {
@@ -1521,8 +1510,7 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 			installationId: suppliedInstallationId,
 			recovery: isRecovery,
 			redirectUri: callbackUrl,
-			exchange:
-				deps.exchangeInstallOAuthCode ?? defaultExchangeInstallOAuthCode,
+			exchange: deps.exchangeInstallOAuthCode ?? defaultExchangeInstallOAuthCode,
 			fetchAccount:
 				deps.fetchInstallationAccount ?? defaultFetchInstallationAccount,
 			fetchLogin: deps.fetchAuthedUserLogin ?? defaultFetchAuthedUserLogin,
@@ -1566,9 +1554,8 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 		`) as unknown as Array<{ auth_schema: unknown }>;
 		const hasAppInstallMethod =
 			defRows.length > 0 &&
-			getAppInstallationAuthMethods(
-				normalizeConnectorAuthSchema(defRows[0].auth_schema),
-			).length > 0;
+			getAppInstallationAuthMethods(normalizeConnectorAuthSchema(defRows[0].auth_schema))
+				.length > 0;
 		if (!hasAppInstallMethod) {
 			return c.html(
 				renderOAuthErrorPage(
@@ -1720,9 +1707,7 @@ export function createAppInstallRoutes(deps: AppInstallRouterDeps): Hono {
 }
 
 /** Pull the account login GitHub passes (when present) into install metadata. */
-function buildInstallMetadata(
-	c: import("hono").Context,
-): Record<string, unknown> {
+function buildInstallMetadata(c: import("hono").Context): Record<string, unknown> {
 	const metadata: Record<string, unknown> = {};
 	// GitHub doesn't pass the account login on the install redirect, but a
 	// future state-bound flow / the owletto UI can; accept it if present.
@@ -1768,10 +1753,7 @@ interface OAuthInstallStateData {
 function oauthInstallStateStore(
 	provider: string,
 ): OAuthStateStore<OAuthInstallStateData> {
-	return new OAuthStateStore(
-		`${provider}:oauth:state`,
-		`${provider}-install-state`,
-	);
+	return new OAuthStateStore(`${provider}:oauth:state`, `${provider}-install-state`);
 }
 
 /**
@@ -1870,11 +1852,7 @@ function mountOAuthCodeExchangeRoutes(
 		// the primed bundled method (slack-connection-coordinator).
 		const method =
 			(installOrgId
-				? await getOrgAppInstallationMethod(
-						installOrgId,
-						connectorKey,
-						provider,
-					)
+				? await getOrgAppInstallationMethod(installOrgId, connectorKey, provider)
 				: null) ??
 			getPrimedBundledMethod(connectorKey, provider) ??
 			null;
@@ -2008,7 +1986,9 @@ function mountOAuthCodeExchangeRoutes(
 			return c.html(
 				renderOAuthErrorPage(
 					`${provider}_install_failed`,
-					error instanceof Error ? error.message : `${display} install failed.`,
+					error instanceof Error
+						? error.message
+						: `${display} install failed.`,
 				),
 				500,
 			);
@@ -2106,15 +2086,9 @@ export function createInstallRoutes(deps: InstallEngineDeps): Hono {
 			);
 			continue;
 		}
-		if (
-			integration.deliveryKind !== "chat" ||
-			!deps.completeChatPendingInstall
-		) {
+		if (integration.deliveryKind !== "chat" || !deps.completeChatPendingInstall) {
 			oauthInstallLogger.warn(
-				{
-					provider: integration.provider,
-					deliveryKind: integration.deliveryKind,
-				},
+				{ provider: integration.provider, deliveryKind: integration.deliveryKind },
 				"Skipping oauth-code-exchange install routes: no post-install completion for this delivery kind",
 			);
 			continue;

--- a/packages/server/src/runs/queue-service.ts
+++ b/packages/server/src/runs/queue-service.ts
@@ -467,8 +467,8 @@ export async function createAuthRun(params: {
   connectorKey: string;
   authProfileId: number;
   createdByUserId: string;
-}): Promise<number> {
-  const sql = getDb();
+}, db: DbClient = getDb()): Promise<number> {
+  const sql = db;
 
   // Resolve + verify the connector version is runnable.
   const resolved = await resolveActiveConnectorVersion(sql, {

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -462,7 +462,7 @@ export default async (_ctx, client) => {
 	"connections.list": {
 		summary: "List configured connections in the current organization.",
 		access: "read",
-		signature: "connections.list(input?: { connector_key?: string; status?: string; limit?: number; offset?: number }): Promise<unknown>",
+		signature: "connections.list(input?: { connector_key?: string; status?: string; setup_attempt_id?: string; limit?: number; offset?: number }): Promise<unknown>",
 	},
 	"catalog.listCatalog": {
 		summary: "List global catalog entries (connectors, skills, watchers).",
@@ -476,12 +476,12 @@ export default async (_ctx, client) => {
 	"connections.get": { summary: "Get a connection by id.", access: "read" },
 	"connections.create": {
 		summary:
-			"Create a connection manually (for connectors that do not require OAuth).",
+			"Create from an existing auth profile. Setup gaps return a structured setup_required continuation with next_action and an optional resume_call/completion_check.",
 		access: "write",
 	},
 	"connections.connect": {
 		summary:
-			"Create a pending connection and temporary OAuth authorization URL. The user must open the returned connect_url and approve access before Lobu can access the external account.",
+			"Recommended connector setup entry point. Handles every auth family; setup gaps return a structured setup_required continuation with resolved URLs and directly callable next steps.",
 		access: "admin",
 	},
 	"connections.update": {

--- a/packages/server/src/sandbox/namespaces/connections.ts
+++ b/packages/server/src/sandbox/namespaces/connections.ts
@@ -31,6 +31,7 @@ export interface ConnectionsNamespace {
 		entity_id?: number;
 		created_by?: string;
 		connection_ids?: number[];
+		setup_attempt_id?: string;
 		limit?: number;
 		offset?: number;
 	}): Promise<unknown>;

--- a/packages/server/src/tools/admin/helpers/connect-setup-continuation.ts
+++ b/packages/server/src/tools/admin/helpers/connect-setup-continuation.ts
@@ -1,0 +1,150 @@
+import { isSecretKey } from "@lobu/core";
+import type {
+	ConnectCompletionCheckType,
+	ConnectSdkCallType,
+	ConnectSetupFamilyType,
+	ConnectSetupNextActionType,
+	ManageConnectionsResult,
+} from "@lobu/core/contracts/tools/manage-connections";
+
+export type ConnectionSetupFamily = ConnectSetupFamilyType;
+export type ConnectionSetupNextAction = ConnectSetupNextActionType;
+export type SdkCallDescriptor = ConnectSdkCallType;
+type SetupCompletionCheck = ConnectCompletionCheckType;
+
+function omitSecretValues(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(omitSecretValues);
+	if (!value || typeof value !== "object") return value;
+	return Object.fromEntries(
+		Object.entries(value as Record<string, unknown>)
+			.filter(([key]) => !isSecretKey(key))
+			.map(([key, child]) => [key, omitSecretValues(child)]),
+	);
+}
+
+/**
+ * Build a retry descriptor without reflecting caller-supplied secrets back to
+ * the agent. Secret keys are omitted instead of replaced: a redaction sentinel
+ * in an executable call could be mistaken for a real credential on resume.
+ */
+export function buildSafeConnectionResumeCall(
+	sdkMethod: "connections.connect" | "connections.create",
+	args: object,
+): SdkCallDescriptor {
+	const safeArgs = omitSecretValues(args) as Record<string, unknown>;
+	delete safeArgs.action;
+	return {
+		sdk_method: sdkMethod,
+		arguments: [safeArgs],
+	};
+}
+
+interface ConnectionSetupContinuationInput {
+	action: "connect" | "create";
+	connectorKey: string;
+	setupFamily: ConnectionSetupFamily;
+	nextAction: ConnectionSetupNextAction;
+	instructions: string;
+	resumeCall?: SdkCallDescriptor;
+	completionCheck?: SetupCompletionCheck;
+	setupUrl?: string;
+	installUrl?: string;
+	connectUrl?: string;
+	provider?: string;
+	connectionId?: number;
+	slug?: string;
+	authRunId?: number;
+	setupAttemptId?: string;
+	errorCode?: "connector_setup_required";
+	installType?: "app_installation" | "oauth_app_profile";
+	installShape?: "oauth-code-exchange" | "github-app";
+	setupInstructions?: string;
+}
+
+/**
+ * A setup continuation is deliberately a successful SDK result: no `error`
+ * field means `run_sdk` returns it intact for the agent to act on. The three
+ * affordances are separate: `next_action` is the user step, `resume_call` is
+ * the exact SDK call after manual setup, and `completion_check` is present
+ * only when it can be invoked immediately using values in this result.
+ */
+export function buildConnectionSetupContinuation(
+	input: ConnectionSetupContinuationInput,
+): ManageConnectionsResult {
+	return {
+		action: input.action,
+		status: "setup_required",
+		connector_key: input.connectorKey,
+		setup_family: input.setupFamily,
+		next_action: input.nextAction,
+		instructions: input.instructions,
+		...(input.errorCode ? { error_code: input.errorCode } : {}),
+		...(input.installType ? { install_type: input.installType } : {}),
+		...(input.installShape ? { install_shape: input.installShape } : {}),
+		...(input.setupInstructions
+			? { setup_instructions: input.setupInstructions }
+			: {}),
+		...(input.resumeCall ? { resume_call: input.resumeCall } : {}),
+		...(input.completionCheck
+			? { completion_check: input.completionCheck }
+			: {}),
+		...(input.setupUrl ? { setup_url: input.setupUrl } : {}),
+		...(input.installUrl ? { install_url: input.installUrl } : {}),
+		...(input.connectUrl ? { connect_url: input.connectUrl } : {}),
+		...(input.provider ? { provider: input.provider } : {}),
+		...(input.connectionId !== undefined
+			? { connection_id: input.connectionId }
+			: {}),
+		...(input.slug ? { slug: input.slug } : {}),
+		...(input.authRunId !== undefined ? { auth_run_id: input.authRunId } : {}),
+		...(input.setupAttemptId ? { setup_attempt_id: input.setupAttemptId } : {}),
+	};
+}
+
+export function activeConnectionPoll(
+	connectionId: number,
+): SetupCompletionCheck {
+	return {
+		call: {
+			sdk_method: "connections.get",
+			arguments: [connectionId],
+		},
+		success_when: { path: "connection.status", equals: "active" },
+		poll_interval_ms: 2000,
+		description: "Poll until the connection becomes active.",
+	};
+}
+
+export function installedConnectorPoll(
+	connectorKey: string,
+	setupAttemptId: string,
+): SetupCompletionCheck {
+	return {
+		call: {
+			sdk_method: "connections.list",
+			arguments: [
+				{
+					connector_key: connectorKey,
+					status: "active",
+					setup_attempt_id: setupAttemptId,
+				},
+			],
+		},
+		success_when: {
+			path: "connections[].config.setup_attempt_ids",
+			includes: setupAttemptId,
+		},
+		poll_interval_ms: 2000,
+		description:
+			"Poll until the provider callback marks this exact setup attempt active.",
+	};
+}
+
+export function appendSetupAttemptId(
+	installUrl: string,
+	setupAttemptId: string,
+): string {
+	const url = new URL(installUrl);
+	url.searchParams.set("setup_attempt_id", setupAttemptId);
+	return url.toString();
+}

--- a/packages/server/src/tools/admin/helpers/connect-setup-continuation.ts
+++ b/packages/server/src/tools/admin/helpers/connect-setup-continuation.ts
@@ -22,6 +22,14 @@ function omitSecretValues(value: unknown): unknown {
 	);
 }
 
+function omitUndefinedProperties(
+	value: Record<string, unknown>,
+): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(value).filter(([, child]) => child !== undefined),
+	);
+}
+
 /**
  * Build a retry descriptor without reflecting caller-supplied secrets back to
  * the agent. Secret keys are omitted instead of replaced: a redaction sentinel
@@ -71,34 +79,28 @@ interface ConnectionSetupContinuationInput {
 export function buildConnectionSetupContinuation(
 	input: ConnectionSetupContinuationInput,
 ): ManageConnectionsResult {
-	return {
+	return omitUndefinedProperties({
 		action: input.action,
 		status: "setup_required",
 		connector_key: input.connectorKey,
 		setup_family: input.setupFamily,
 		next_action: input.nextAction,
 		instructions: input.instructions,
-		...(input.errorCode ? { error_code: input.errorCode } : {}),
-		...(input.installType ? { install_type: input.installType } : {}),
-		...(input.installShape ? { install_shape: input.installShape } : {}),
-		...(input.setupInstructions
-			? { setup_instructions: input.setupInstructions }
-			: {}),
-		...(input.resumeCall ? { resume_call: input.resumeCall } : {}),
-		...(input.completionCheck
-			? { completion_check: input.completionCheck }
-			: {}),
-		...(input.setupUrl ? { setup_url: input.setupUrl } : {}),
-		...(input.installUrl ? { install_url: input.installUrl } : {}),
-		...(input.connectUrl ? { connect_url: input.connectUrl } : {}),
-		...(input.provider ? { provider: input.provider } : {}),
-		...(input.connectionId !== undefined
-			? { connection_id: input.connectionId }
-			: {}),
-		...(input.slug ? { slug: input.slug } : {}),
-		...(input.authRunId !== undefined ? { auth_run_id: input.authRunId } : {}),
-		...(input.setupAttemptId ? { setup_attempt_id: input.setupAttemptId } : {}),
-	};
+		error_code: input.errorCode,
+		install_type: input.installType,
+		install_shape: input.installShape,
+		setup_instructions: input.setupInstructions,
+		resume_call: input.resumeCall,
+		completion_check: input.completionCheck,
+		setup_url: input.setupUrl,
+		install_url: input.installUrl,
+		connect_url: input.connectUrl,
+		provider: input.provider,
+		connection_id: input.connectionId,
+		slug: input.slug,
+		auth_run_id: input.authRunId,
+		setup_attempt_id: input.setupAttemptId,
+	}) as ManageConnectionsResult;
 }
 
 export function activeConnectionPoll(

--- a/packages/server/src/tools/admin/helpers/interactive-connection-setup.ts
+++ b/packages/server/src/tools/admin/helpers/interactive-connection-setup.ts
@@ -1,0 +1,56 @@
+import { createAuthRun } from "../../../runs/queue-service";
+import type { DbClient } from "../../../db/client";
+import { createAuthProfile } from "../../../utils/auth-profiles";
+
+type InsertConnection = (
+	db: DbClient,
+	authProfileId: number | null,
+	useSavepoint: boolean,
+) => Promise<Record<string, unknown>[]>;
+
+export async function createConnectionSetupBundle(params: {
+	db: DbClient;
+	interactive: boolean;
+	organizationId: string;
+	connectorKey: string;
+	displayName: string;
+	createdByUserId: string;
+	insertConnection: InsertConnection;
+}): Promise<{
+	rows: Record<string, unknown>[];
+	authRunId: number | null;
+}> {
+	if (!params.interactive) {
+		return {
+			rows: await params.insertConnection(params.db, null, false),
+			authRunId: null,
+		};
+	}
+
+	return params.db.begin(async (tx) => {
+		const profile = await createAuthProfile(
+			{
+				organizationId: params.organizationId,
+				connectorKey: params.connectorKey,
+				displayName: `${params.displayName} (pairing)`,
+				slug: `${params.connectorKey}-interactive-${Date.now()}`,
+				profileKind: "interactive",
+				authData: {},
+				status: "pending_auth",
+				createdBy: params.createdByUserId,
+			},
+			tx,
+		);
+		const rows = await params.insertConnection(tx, profile.id, true);
+		const authRunId = await createAuthRun(
+			{
+				organizationId: params.organizationId,
+				connectorKey: params.connectorKey,
+				authProfileId: profile.id,
+				createdByUserId: params.createdByUserId,
+			},
+			tx,
+		);
+		return { rows, authRunId };
+	});
+}

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -269,25 +269,25 @@ export async function handleConnect(
 		!authSelection.browserMethod;
 	const profileDeviceWorkerIdConnect =
 		authSelection.authProfile?.device_worker_id ?? null;
-  let effectiveDeviceWorkerIdConnect = deviceBinding.deviceWorkerId;
-  if (profileDeviceWorkerIdConnect) {
-    if (!effectiveDeviceWorkerIdConnect) {
-      effectiveDeviceWorkerIdConnect = profileDeviceWorkerIdConnect;
+	let effectiveDeviceWorkerIdConnect = deviceBinding.deviceWorkerId;
+	if (profileDeviceWorkerIdConnect) {
+		if (!effectiveDeviceWorkerIdConnect) {
+			effectiveDeviceWorkerIdConnect = profileDeviceWorkerIdConnect;
 		} else if (
 			effectiveDeviceWorkerIdConnect !== profileDeviceWorkerIdConnect
 		) {
-      return {
-        error: `Auth profile '${authSelection.authProfile!.slug}' lives on a different device than the one selected; pick that device or a different profile.`,
-        setup_url: setupUrl,
-      };
-    }
-  }
-  const isDeviceBoundBrowserSessionConnect =
+			return {
+				error: `Auth profile '${authSelection.authProfile!.slug}' lives on a different device than the one selected; pick that device or a different profile.`,
+				setup_url: setupUrl,
+			};
+		}
+	}
+	const isDeviceBoundBrowserSessionConnect =
 		authSelection.authProfile?.profile_kind === "browser_session" &&
-    !!profileDeviceWorkerIdConnect;
-  // Same guard as create-path: when the profile contributed a device we
-  // didn't already check against, re-run the duplicate-connection check now
-  // so the partial unique index never decides the outcome with a raw error.
+		!!profileDeviceWorkerIdConnect;
+	// Same guard as create-path: when the profile contributed a device we
+	// didn't already check against, re-run the duplicate-connection check now
+	// so the partial unique index never decides the outcome with a raw error.
 	if (
 		effectiveDeviceWorkerIdConnect &&
 		effectiveDeviceWorkerIdConnect !== deviceBinding.deviceWorkerId

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -8,7 +8,6 @@ import { notifyConnectionPermissionRequest } from "../../../../notifications/tri
 import {
 	getPrimaryAuthProfileForKind,
 	getBrowserSessionReadiness,
-	createAuthProfile,
 } from "../../../../utils/auth-profiles";
 import {
   ConnectionSlugConflictError,
@@ -44,7 +43,6 @@ import { buildConnectionsUrl } from "../../../../utils/url-builder";
 import { getOrgUrlContext } from "../../../view-urls";
 import { createConnectToken } from "../../../../utils/connect-tokens";
 import { registerConnectorWebhook } from "../../../../connect/webhook-registration";
-import { createAuthRun } from "../../../../runs/queue-service";
 import { resolveUsernames } from "../../../../utils/resolve-usernames";
 import type { ToolContext } from "../../../registry";
 import type { ManageConnectionsResult, ConnectionsArgs } from "../schemas";
@@ -62,6 +60,7 @@ import {
 	type ConnectionSetupFamily,
 	type ConnectionSetupNextAction,
 } from "../../helpers/connect-setup-continuation";
+import { createConnectionSetupBundle } from "../../helpers/interactive-connection-setup";
 
 export async function handleConnect(
 	args: Extract<ConnectionsArgs, { action: "connect" }>,
@@ -521,43 +520,19 @@ export async function handleConnect(
 	// creation rolls back both rows, so another replica can never observe an
 	// orphaned pending connection that has no pairing work queued.
 	let insertedConn: Record<string, unknown>[];
-	let interactiveAuthRunId: number | null = null;
+	let interactiveAuthRunId: number | null;
 	try {
-		if (isInteractiveConnect) {
-			const bundle = await sql.begin(async (tx) => {
-				const profile = await createAuthProfile(
-					{
-						organizationId,
-						connectorKey: args.connector_key,
-						displayName: `${connectDisplayName} (pairing)`,
-						slug: `${args.connector_key}-interactive-${Date.now()}`,
-						profileKind: "interactive",
-						authData: {},
-						status: "pending_auth",
-						createdBy: userId,
-					},
-					tx,
-				);
-				const rows = await insertConnection(tx, profile.id, true);
-				const authRunId = await createAuthRun(
-					{
-						organizationId,
-						connectorKey: args.connector_key,
-						authProfileId: profile.id,
-						createdByUserId: userId!,
-					},
-					tx,
-				);
-				return { rows, authRunId };
-			});
-			insertedConn = bundle.rows as Record<string, unknown>[];
-			interactiveAuthRunId = bundle.authRunId;
-		} else {
-			insertedConn = (await insertConnection(sql, null, false)) as Record<
-				string,
-				unknown
-			>[];
-		}
+		const bundle = await createConnectionSetupBundle({
+			db: sql,
+			interactive: isInteractiveConnect,
+			organizationId,
+			connectorKey: args.connector_key,
+			displayName: connectDisplayName,
+			createdByUserId: userId!,
+			insertConnection,
+		});
+		insertedConn = bundle.rows;
+		interactiveAuthRunId = bundle.authRunId;
   } catch (err) {
 		if (err instanceof ConnectionSlugConflictError)
 			return { error: err.message, setup_url: setupUrl };

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -2,51 +2,77 @@
  * Connect action handler: create connection + OAuth flow in one call.
  */
 
-import { getDb, pgBigintArray } from '../../../../db/client';
-import { notifyConnectionPermissionRequest } from '../../../../notifications/triggers';
-import { getPrimaryAuthProfileForKind, getBrowserSessionReadiness } from '../../../../utils/auth-profiles';
+import { randomUUID } from "node:crypto";
+import { getDb, pgBigintArray, type DbClient } from "../../../../db/client";
+import { notifyConnectionPermissionRequest } from "../../../../notifications/triggers";
+import {
+	getPrimaryAuthProfileForKind,
+	getBrowserSessionReadiness,
+	createAuthProfile,
+} from "../../../../utils/auth-profiles";
 import {
   ConnectionSlugConflictError,
   connectionSlugFormatError,
   insertConnectionWithSlug,
   resolveNewConnectionSlug,
-} from '../../../../utils/connections';
-import { recordLifecycleEvent } from '../../../../utils/insert-event';
-import { recordToolConfigChange } from '../../helpers/config-audit';
-import logger from '../../../../utils/logger';
-import { ensureConnectorInstalled } from '../../../../utils/ensure-connector-installed';
+} from "../../../../utils/connections";
+import { recordLifecycleEvent } from "../../../../utils/insert-event";
+import { recordToolConfigChange } from "../../helpers/config-audit";
+import logger from "../../../../utils/logger";
+import { ensureConnectorInstalled } from "../../../../utils/ensure-connector-installed";
 import {
   buildOAuthConnectConfig,
   ensureEnvBackedOAuthAppProfile,
   getConnectBaseUrl,
+	getInteractiveMethods,
   resolveConnectionAuthSelection,
   resolveConnectionDisplayName,
   resolveConnectionVisibility,
-} from '../../helpers/connection-helpers';
-import { assertEntityIdsInOrg } from '../../helpers/db-helpers';
+} from "../../helpers/connection-helpers";
+import { assertEntityIdsInOrg } from "../../helpers/db-helpers";
 import {
   buildAppInstallationSetupUrl,
   rejectUnboundAppInstallationCreate,
-} from '../../helpers/app-installation-guard';
-import { buildOAuthAppProfileSetupError } from '../../helpers/connector-setup-errors';
-import { type FeedDefinition, splitConfigByFeedScope } from '../../helpers/feed-helpers';
-import { getScopedConnectorDefinition } from '../../../../catalog/connector-definitions';
-import { buildConnectionsUrl } from '../../../../utils/url-builder';
-import { getOrgUrlContext } from '../../../view-urls';
-import { createConnectToken } from '../../../../utils/connect-tokens';
-import { registerConnectorWebhook } from '../../../../connect/webhook-registration';
-import { resolveUsernames } from '../../../../utils/resolve-usernames';
-import type { ToolContext } from '../../../registry';
-import type { ManageConnectionsResult, ConnectionsArgs } from '../schemas';
-import { resolveDeviceBinding, isManagedPublicOrgConnect } from './device-binding';
+} from "../../helpers/app-installation-guard";
+import { buildOAuthAppProfileSetupError } from "../../helpers/connector-setup-errors";
+import {
+	type FeedDefinition,
+	splitConfigByFeedScope,
+} from "../../helpers/feed-helpers";
+import { getScopedConnectorDefinition } from "../../../../catalog/connector-definitions";
+import { buildConnectionsUrl } from "../../../../utils/url-builder";
+import { getOrgUrlContext } from "../../../view-urls";
+import { createConnectToken } from "../../../../utils/connect-tokens";
+import { registerConnectorWebhook } from "../../../../connect/webhook-registration";
+import { createAuthRun } from "../../../../runs/queue-service";
+import { resolveUsernames } from "../../../../utils/resolve-usernames";
+import type { ToolContext } from "../../../registry";
+import type { ManageConnectionsResult, ConnectionsArgs } from "../schemas";
+import {
+	resolveDeviceBinding,
+	isManagedPublicOrgConnect,
+} from "./device-binding";
 import { getErrorMessage } from "@lobu/core";
+import {
+	activeConnectionPoll,
+	appendSetupAttemptId,
+	buildConnectionSetupContinuation,
+	buildSafeConnectionResumeCall,
+	installedConnectorPoll,
+	type ConnectionSetupFamily,
+	type ConnectionSetupNextAction,
+} from "../../helpers/connect-setup-continuation";
 
 export async function handleConnect(
-  args: Extract<ConnectionsArgs, { action: 'connect' }>,
-  ctx: ToolContext
+	args: Extract<ConnectionsArgs, { action: "connect" }>,
+	ctx: ToolContext,
 ): Promise<ManageConnectionsResult> {
   const sql = getDb();
   const { organizationId, userId } = ctx;
+	const resumeCall = buildSafeConnectionResumeCall(
+		"connections.connect",
+		args,
+	);
 
   const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
   const buildSetupUrl = (opts?: { connectorKey?: string; install?: string }) =>
@@ -55,12 +81,15 @@ export async function handleConnect(
           ownerSlug,
           baseUrl,
           opts?.connectorKey,
-          opts?.install ? { install: opts.install } : undefined
+					opts?.install ? { install: opts.install } : undefined,
         )
       : undefined;
 
   // Ensure connector is installed from bundled catalog if needed
-  await ensureConnectorInstalled({ organizationId, connectorKey: args.connector_key });
+	await ensureConnectorInstalled({
+		organizationId,
+		connectorKey: args.connector_key,
+	});
 
   // Verify connector exists
   const connector = await getScopedConnectorDefinition({
@@ -93,10 +122,54 @@ export async function handleConnect(
     setupUrl,
   });
   if (appInstallGuard) {
-    return {
-      ...appInstallGuard,
-      setup_url: await buildAppInstallationSetupUrl(ctx, args.connector_key),
-    };
+		const setupAttemptId =
+			appInstallGuard.provider === "github" && appInstallGuard.install_url
+				? randomUUID()
+				: undefined;
+		// Setup-required continuation: the App install callback creates the active
+		// connection itself, so do NOT instruct a retry of connect. The guard's
+		// ConnectorSetupError already carries the absolute install_url.
+		return buildConnectionSetupContinuation({
+			action: "connect",
+			connectorKey: args.connector_key,
+			setupFamily: "app_installation",
+			nextAction:
+				appInstallGuard.next_action === "install_app"
+					? "install_app"
+					: "open_setup",
+			instructions: appInstallGuard.error,
+			errorCode: appInstallGuard.error_code,
+			installType: appInstallGuard.install_type,
+			...(appInstallGuard.install_shape
+				? { installShape: appInstallGuard.install_shape }
+				: {}),
+			...(appInstallGuard.setup_instructions
+				? { setupInstructions: appInstallGuard.setup_instructions }
+				: {}),
+			...(setupAttemptId
+				? {
+						completionCheck: installedConnectorPoll(
+							args.connector_key,
+							setupAttemptId,
+						),
+						setupAttemptId,
+					}
+				: {}),
+			setupUrl: await buildAppInstallationSetupUrl(ctx, args.connector_key),
+			...(appInstallGuard.install_url
+				? {
+						installUrl: setupAttemptId
+							? appendSetupAttemptId(
+									appInstallGuard.install_url,
+									setupAttemptId,
+								)
+							: appInstallGuard.install_url,
+					}
+				: {}),
+			...(appInstallGuard.provider
+				? { provider: appInstallGuard.provider }
+				: {}),
+		});
   }
 
   const deviceBinding = await resolveDeviceBinding({
@@ -105,7 +178,19 @@ export async function handleConnect(
     connector,
     deviceWorkerId: args.device_worker_id,
   });
-  if ('error' in deviceBinding) return deviceBinding;
+	if ("error" in deviceBinding) {
+		if (connector.required_capability && !args.device_worker_id) {
+			return buildConnectionSetupContinuation({
+				action: "connect",
+				connectorKey: args.connector_key,
+				setupFamily: "device_bound",
+				nextAction: "connect_device",
+				instructions: deviceBinding.error,
+				setupUrl,
+			});
+		}
+		return deviceBinding;
+	}
   if (deviceBinding.deviceWorkerId) {
     const dup = (await sql`
       SELECT id FROM connections
@@ -158,11 +243,11 @@ export async function handleConnect(
     };
     const connectUrl = `${getConnectBaseUrl(ctx)}/connect/${pending.token}/oauth/start`;
     return {
-      action: 'connect',
+			action: "connect",
       connection_id: pending.id,
       slug: pending.slug,
-      status: 'pending_auth',
-      auth_type: 'oauth',
+			status: "pending_auth",
+			auth_type: "oauth",
       connect_url: connectUrl,
       connect_token: pending.token,
       expires_at: new Date(pending.expires_at).toISOString(),
@@ -180,13 +265,18 @@ export async function handleConnect(
   });
 
   const hasNoAuth =
-    !authSelection.oauthMethod && !authSelection.envMethod && !authSelection.browserMethod;
-  const profileDeviceWorkerIdConnect = authSelection.authProfile?.device_worker_id ?? null;
+		!authSelection.oauthMethod &&
+		!authSelection.envMethod &&
+		!authSelection.browserMethod;
+	const profileDeviceWorkerIdConnect =
+		authSelection.authProfile?.device_worker_id ?? null;
   let effectiveDeviceWorkerIdConnect = deviceBinding.deviceWorkerId;
   if (profileDeviceWorkerIdConnect) {
     if (!effectiveDeviceWorkerIdConnect) {
       effectiveDeviceWorkerIdConnect = profileDeviceWorkerIdConnect;
-    } else if (effectiveDeviceWorkerIdConnect !== profileDeviceWorkerIdConnect) {
+		} else if (
+			effectiveDeviceWorkerIdConnect !== profileDeviceWorkerIdConnect
+		) {
       return {
         error: `Auth profile '${authSelection.authProfile!.slug}' lives on a different device than the one selected; pick that device or a different profile.`,
         setup_url: setupUrl,
@@ -194,12 +284,15 @@ export async function handleConnect(
     }
   }
   const isDeviceBoundBrowserSessionConnect =
-    authSelection.authProfile?.profile_kind === 'browser_session' &&
+		authSelection.authProfile?.profile_kind === "browser_session" &&
     !!profileDeviceWorkerIdConnect;
   // Same guard as create-path: when the profile contributed a device we
   // didn't already check against, re-run the duplicate-connection check now
   // so the partial unique index never decides the outcome with a raw error.
-  if (effectiveDeviceWorkerIdConnect && effectiveDeviceWorkerIdConnect !== deviceBinding.deviceWorkerId) {
+	if (
+		effectiveDeviceWorkerIdConnect &&
+		effectiveDeviceWorkerIdConnect !== deviceBinding.deviceWorkerId
+	) {
     const dup = (await sql`
       SELECT id FROM connections
       WHERE organization_id = ${organizationId}
@@ -216,10 +309,14 @@ export async function handleConnect(
     }
   }
   const browserProfileUsable =
-    authSelection.authProfile?.profile_kind === 'browser_session' &&
+		authSelection.authProfile?.profile_kind === "browser_session" &&
     !isDeviceBoundBrowserSessionConnect
-      ? (await getBrowserSessionReadiness(authSelection.authProfile.auth_data, args.connector_key))
-          .usable
+			? (
+					await getBrowserSessionReadiness(
+						authSelection.authProfile.auth_data,
+						args.connector_key,
+					)
+				).usable
       : false;
   // Device-bound browser_session profiles are "ready" by virtue of the
   // cookies being on disk on the device. `getBrowserSessionReadiness` only
@@ -228,37 +325,78 @@ export async function handleConnect(
   // auth profile" even when the Mac app just created one.
   const hasReadySelection =
     !!authSelection.authProfile &&
-    (authSelection.authProfile.profile_kind === 'browser_session'
+		(authSelection.authProfile.profile_kind === "browser_session"
       ? isDeviceBoundBrowserSessionConnect || browserProfileUsable
-      : authSelection.authProfile.status === 'active') &&
-    (authSelection.selectedKind !== 'oauth_account' ||
-      (authSelection.appAuthProfile?.status === 'active' && !!authSelection.appAuthProfile));
+			: authSelection.authProfile.status === "active") &&
+		(authSelection.selectedKind !== "oauth_account" ||
+			(authSelection.appAuthProfile?.status === "active" &&
+				!!authSelection.appAuthProfile));
 
   const needsConnectFlow =
-    authSelection.preferredMethodType === 'oauth' &&
+		authSelection.preferredMethodType === "oauth" &&
     !!authSelection.oauthMethod &&
     !hasReadySelection &&
     !args.auth_profile_slug;
   const needsBrowserAuth =
     !!authSelection.browserMethod &&
     !!authSelection.authProfile &&
-    authSelection.authProfile.profile_kind === 'browser_session' &&
+		authSelection.authProfile.profile_kind === "browser_session" &&
     !isDeviceBoundBrowserSessionConnect &&
     !browserProfileUsable;
-  const connectionStatus = needsConnectFlow || needsBrowserAuth ? 'pending_auth' : 'active';
+	// Interactive-auth connectors (e.g. WhatsApp QR) bypass standard auth-profile
+	// selection: the connection starts pending_auth and an auth run drives the
+	// interactive pairing. Without this, an interactive connector looks like
+	// no-auth (oauth/env/browser methods all absent) and connect would wrongly
+	// create an ACTIVE, unauthenticated connection.
+	const interactiveMethod =
+		getInteractiveMethods(connector.auth_schema)[0] ?? null;
+	const isInteractiveConnect = !!interactiveMethod && !hasReadySelection;
+	const connectionStatus =
+		needsConnectFlow || needsBrowserAuth || isInteractiveConnect
+			? "pending_auth"
+			: "active";
 
-  if (!hasNoAuth && !needsConnectFlow && !needsBrowserAuth && !hasReadySelection) {
+	if (isInteractiveConnect && !userId) {
     return {
-      error: authSelection.browserMethod
-        ? 'Select or create a browser auth profile before creating the connection.'
-        : authSelection.oauthMethod && authSelection.selectedKind !== 'oauth_account'
-          ? 'Select or create an OAuth account profile before creating the connection.'
-          : authSelection.envMethod
-            ? 'Select or create an auth profile before creating the connection.'
-            : 'Selected auth profile is not ready yet.',
+			error: "Interactive pairing requires an authenticated user.",
       setup_url: setupUrl,
     };
   }
+
+	if (
+		!hasNoAuth &&
+		!needsConnectFlow &&
+		!needsBrowserAuth &&
+		!hasReadySelection &&
+		!isInteractiveConnect
+	) {
+		// Setup-required continuation: a known auth method needs a profile/config
+		// the caller hasn't supplied. Non-terminal — the caller fixes it then retries.
+		const family: ConnectionSetupFamily = authSelection.browserMethod
+			? "browser"
+			: authSelection.envMethod
+				? "env_keys"
+				: "oauth";
+		const nextAction: ConnectionSetupNextAction = authSelection.browserMethod
+			? "pair_browser"
+			: "select_auth_profile";
+		return buildConnectionSetupContinuation({
+			action: "connect",
+			connectorKey: args.connector_key,
+			setupFamily: family,
+			nextAction,
+			instructions: authSelection.browserMethod
+				? "Select or create a browser auth profile before connecting."
+				: authSelection.oauthMethod &&
+						authSelection.selectedKind !== "oauth_account"
+					? "Select or create an OAuth account profile before connecting."
+					: authSelection.envMethod
+						? "Select or create an auth profile (or pass env credentials) before connecting."
+						: "Selected auth profile is not ready yet.",
+			setupUrl,
+			resumeCall,
+		});
+	}
 
   // Create the connection
   const connectDisplayName = await resolveConnectionDisplayName({
@@ -266,7 +404,9 @@ export async function handleConnect(
     connectorName: connector.name,
     username: userId
       ? ((
-          (await resolveUsernames([{ created_by: userId }], 'created_by'))[0] as {
+					(
+						await resolveUsernames([{ created_by: userId }], "created_by")
+					)[0] as {
             created_by_username?: string;
           }
         )?.created_by_username ?? null)
@@ -276,7 +416,7 @@ export async function handleConnect(
   const connectVisibility = await resolveConnectionVisibility(
     organizationId,
     userId,
-    authSelection?.authProfile?.profile_kind
+		authSelection?.authProfile?.profile_kind,
   );
   const connectorFeedsSchema = (connector.feeds_schema ?? null) as Record<
     string,
@@ -288,7 +428,7 @@ export async function handleConnect(
   };
   const splitConfig = splitConfigByFeedScope(
     Object.keys(mergedConfig).length > 0 ? mergedConfig : null,
-    connectorFeedsSchema
+		connectorFeedsSchema,
   );
 
   if (splitConfig.feedConfig) {
@@ -327,7 +467,9 @@ export async function handleConnect(
     return { error: getErrorMessage(err), setup_url: setupUrl };
   }
   const connectEntityIdsValue =
-    args.entity_ids && args.entity_ids.length > 0 ? pgBigintArray(args.entity_ids) : null;
+		args.entity_ids && args.entity_ids.length > 0
+			? pgBigintArray(args.entity_ids)
+			: null;
 
   const connectSlugResult = await resolveNewConnectionSlug({
     organizationId,
@@ -335,18 +477,23 @@ export async function handleConnect(
     explicitSlug: args.slug,
     displayName: connectDisplayName,
   });
-  if ('error' in connectSlugResult) return { error: connectSlugResult.error, setup_url: setupUrl };
+	if ("error" in connectSlugResult)
+		return { error: connectSlugResult.error, setup_url: setupUrl };
 
-  // biome-ignore lint/suspicious/noExplicitAny: postgres.js row shape
-  let insertedConn: any[];
-  try {
-    insertedConn = await insertConnectionWithSlug({
+	const insertConnection = (
+		db: DbClient,
+		authProfileId: number | null,
+		useSavepoint: boolean,
+	) =>
+		insertConnectionWithSlug({
       organizationId,
       connectorKey: args.connector_key,
       displayName: connectDisplayName,
       initialSlug: connectSlugResult.slug,
       explicit: !!args.slug?.trim(),
-      doInsert: (slug) => sql`
+			db,
+			doInsert: (slug) => {
+				const insert = () => db`
         INSERT INTO connections (
           organization_id, connector_key, slug, display_name, status,
           auth_profile_id, app_auth_profile_id, config, created_by, visibility, device_worker_id,
@@ -356,19 +503,64 @@ export async function handleConnect(
           ${slug},
           ${connectDisplayName},
           ${connectionStatus},
-          ${authSelection.authProfile?.id ?? null},
+            ${authProfileId ?? authSelection.authProfile?.id ?? null},
           ${authSelection.appAuthProfile?.id ?? null},
-          ${connectionConfigToInsert ? sql.json(connectionConfigToInsert) : null},
+            ${connectionConfigToInsert ? db.json(connectionConfigToInsert) : null},
           ${userId},
           ${connectVisibility},
           ${effectiveDeviceWorkerIdConnect},
           ${connectEntityIdsValue}::bigint[]
         )
         RETURNING *
-      `,
+        `;
+				return useSavepoint ? db.savepoint(insert) : insert();
+			},
     });
+
+	// Profile, connection, and auth run are one durable unit. A failed run
+	// creation rolls back both rows, so another replica can never observe an
+	// orphaned pending connection that has no pairing work queued.
+	let insertedConn: Record<string, unknown>[];
+	let interactiveAuthRunId: number | null = null;
+	try {
+		if (isInteractiveConnect) {
+			const bundle = await sql.begin(async (tx) => {
+				const profile = await createAuthProfile(
+					{
+						organizationId,
+						connectorKey: args.connector_key,
+						displayName: `${connectDisplayName} (pairing)`,
+						slug: `${args.connector_key}-interactive-${Date.now()}`,
+						profileKind: "interactive",
+						authData: {},
+						status: "pending_auth",
+						createdBy: userId,
+					},
+					tx,
+				);
+				const rows = await insertConnection(tx, profile.id, true);
+				const authRunId = await createAuthRun(
+					{
+						organizationId,
+						connectorKey: args.connector_key,
+						authProfileId: profile.id,
+						createdByUserId: userId!,
+					},
+					tx,
+				);
+				return { rows, authRunId };
+			});
+			insertedConn = bundle.rows as Record<string, unknown>[];
+			interactiveAuthRunId = bundle.authRunId;
+		} else {
+			insertedConn = (await insertConnection(sql, null, false)) as Record<
+				string,
+				unknown
+			>[];
+		}
   } catch (err) {
-    if (err instanceof ConnectionSlugConflictError) return { error: err.message, setup_url: setupUrl };
+		if (err instanceof ConnectionSlugConflictError)
+			return { error: err.message, setup_url: setupUrl };
     throw err;
   }
 
@@ -384,49 +576,76 @@ export async function handleConnect(
       connector_key: args.connector_key,
       status: connectionStatus,
     },
-    'Connection created via connect flow'
+		"Connection created via connect flow",
   );
 
   recordLifecycleEvent({
     organizationId,
-    entityType: 'connection',
-    op: 'created',
+		entityType: "connection",
+		op: "created",
     entityId: connection.id,
     summary: `Connection "${connectDisplayName}" created`,
-    extra: { connector_key: args.connector_key, slug: connection.slug, via: 'connect' },
+		extra: {
+			connector_key: args.connector_key,
+			slug: connection.slug,
+			via: "connect",
+		},
   });
 
   recordToolConfigChange(ctx, {
-    resourceKind: 'connection',
+		resourceKind: "connection",
     resourceId: connection.id,
-    op: 'created',
+		op: "created",
     summary: `Connection '${connectDisplayName}' created`,
     state: insertedConn[0] as Record<string, unknown>,
   });
+
+	// Interactive pairing: the connection is pending_auth with a fresh
+	// interactive profile. Kick off the auth run (the lifecycle that emits QR /
+	// code artifacts) and return a setup_required continuation. The auth run —
+	// not a connect retry — completes the connection.
+	if (isInteractiveConnect) {
+		return buildConnectionSetupContinuation({
+			action: "connect",
+			connectorKey: args.connector_key,
+			setupFamily: "interactive",
+			nextAction: "pair_interactive",
+			instructions:
+				"Connection created as pending_auth. Complete interactive pairing (e.g. scan the QR code) via the auth run, then poll connections.get until status=active.",
+			setupUrl: buildSetupUrl({ connectorKey: args.connector_key }),
+			connectionId: connection.id,
+			slug: connection.slug,
+			completionCheck: activeConnectionPoll(connection.id),
+			authRunId: interactiveAuthRunId!,
+		});
+	}
 
   // If active immediately, return simple result
   if (!needsConnectFlow && !needsBrowserAuth) {
     // Active now with resolvable credentials (env/PAT path) — if the connector
     // declares a webhook block and a feed target is configured, subscribe with
     // the provider once. Best-effort; failures are logged, not fatal.
-    await registerConnectorWebhook({ organizationId, connectionId: connection.id });
+		await registerConnectorWebhook({
+			organizationId,
+			connectionId: connection.id,
+		});
     return {
-      action: 'connect',
+			action: "connect",
       connection_id: connection.id,
       slug: connection.slug,
-      status: 'active',
-      message: 'Connection created and active.',
+			status: "active",
+			message: "Connection created and active.",
       view_url: buildSetupUrl({ connectorKey: args.connector_key }),
     };
   }
 
   if (needsBrowserAuth) {
     return {
-      action: 'connect',
+			action: "connect",
       connection_id: connection.id,
       slug: connection.slug,
-      status: 'pending_auth',
-      auth_type: 'browser',
+			status: "pending_auth",
+			auth_type: "browser",
       auth_profile_slug: authSelection.authProfile?.slug ?? undefined,
       instructions:
         `Complete browser auth for profile '${authSelection.authProfile?.slug}'. ` +
@@ -442,10 +661,20 @@ export async function handleConnect(
 
   if (!authSelection.oauthMethod) {
     await rollbackConnection();
-    return {
-      error: 'Env-key connectors require selecting or creating an auth profile before connecting.',
-      setup_url: setupUrl,
-    };
+		// Reached when a non-oauth method still needs setup (e.g. browser pairing
+		// whose profile wasn't ready). Surface a continuation, not a prose error.
+		return buildConnectionSetupContinuation({
+			action: "connect",
+			connectorKey: args.connector_key,
+			setupFamily: authSelection.browserMethod ? "browser" : "env_keys",
+			nextAction: authSelection.browserMethod
+				? "pair_browser"
+				: "select_auth_profile",
+			instructions:
+				"This connection still needs an auth profile or pairing step before it can run. Complete it, then retry connect.",
+			setupUrl,
+			resumeCall,
+		});
   }
 
   const oauthMethod = authSelection.oauthMethod;
@@ -454,7 +683,7 @@ export async function handleConnect(
     (await getPrimaryAuthProfileForKind({
       organizationId,
       connectorKey: args.connector_key,
-      profileKind: 'oauth_app',
+			profileKind: "oauth_app",
       provider: oauthMethod.provider,
     })) ??
     // Auto-provision an env-backed app profile from deployment env vars
@@ -470,14 +699,34 @@ export async function handleConnect(
       createdBy: userId,
     }));
 
-  if (!appAuthProfile || appAuthProfile.status !== 'active') {
+	if (!appAuthProfile || appAuthProfile.status !== "active") {
     await rollbackConnection();
 
-    return buildOAuthAppProfileSetupError({
+		const setupError = buildOAuthAppProfileSetupError({
       connectorKey: args.connector_key,
       method: oauthMethod,
       setupUrl,
     });
+		// OAuth app credentials are a setup step, not a business error. Surface a
+		// continuation so an agent can read next_action and drive the admin to
+		// configure the OAuth app, then retry connect.
+		return buildConnectionSetupContinuation({
+			action: "connect",
+			connectorKey: args.connector_key,
+			setupFamily: "oauth",
+			nextAction: "configure_oauth_app",
+			instructions: setupError.setup_instructions
+				? `${setupError.error} ${setupError.setup_instructions}`
+				: setupError.error,
+			setupUrl: setupError.setup_url ?? setupUrl,
+			provider: oauthMethod.provider,
+			errorCode: setupError.error_code,
+			installType: setupError.install_type,
+			...(setupError.setup_instructions
+				? { setupInstructions: setupError.setup_instructions }
+				: {}),
+			resumeCall,
+		});
   }
 
   // Link app auth profile to connection; user auth profile will be created
@@ -493,7 +742,7 @@ export async function handleConnect(
     connectionId: connection.id,
     organizationId,
     connectorKey: args.connector_key,
-    authType: 'oauth',
+		authType: "oauth",
     authConfig: {
       ...buildOAuthConnectConfig(oauthMethod),
       // Profile metadata — callback creates the real profile on success
@@ -515,14 +764,16 @@ export async function handleConnect(
     connectionId: connection.id,
     connectorKey: args.connector_key,
     connectUrl,
-  }).catch((err) => logger.error(err, 'Failed to send connection permission notification'));
+	}).catch((err) =>
+		logger.error(err, "Failed to send connection permission notification"),
+	);
 
   return {
-    action: 'connect',
+		action: "connect",
     connection_id: connection.id,
     slug: connection.slug,
-    status: 'pending_auth',
-    auth_type: 'oauth',
+		status: "pending_auth",
+		auth_type: "oauth",
     connect_url: connectUrl,
     connect_token: connectToken.token,
     expires_at: new Date(connectToken.expires_at).toISOString(),

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -7,7 +7,6 @@ import { getErrorMessage, parseJsonObject } from "@lobu/core";
 import { getScopedConnectorDefinition } from "../../../../catalog/connector-definitions";
 import { enrichConnectorGroupsWithCatalogDisplay } from "../../../../catalog/connector-group-display";
 import { unregisterConnectorWebhook } from "../../../../connect/webhook-registration";
-import { createAuthRun } from "../../../../runs/queue-service";
 import {
 	getDb,
 	parsePgNumberArray,
@@ -26,7 +25,6 @@ import {
   getOperationsSummaryBatch,
 } from "../../../../operations/connector-operations";
 import {
-  createAuthProfile,
   getAuthProfileById,
   getAuthProfileBySlug,
   getBrowserSessionReadiness,
@@ -101,6 +99,7 @@ import {
 	buildSafeConnectionResumeCall,
 	installedConnectorPoll,
 } from "../../helpers/connect-setup-continuation";
+import { createConnectionSetupBundle } from "../../helpers/interactive-connection-setup";
 
 // ============================================
 // handleListConnectorGroups
@@ -1193,43 +1192,19 @@ export async function handleCreate(
 		});
 
 	let inserted: Record<string, unknown>[];
-	let interactiveAuthRunId: number | null = null;
+	let interactiveAuthRunId: number | null;
 	try {
-		if (interactiveMethod) {
-			const bundle = await sql.begin(async (tx) => {
-				const profile = await createAuthProfile(
-					{
-						organizationId,
-						connectorKey: args.connector_key,
-						displayName: `${displayName} (pairing)`,
-						slug: `${args.connector_key}-interactive-${Date.now()}`,
-						profileKind: "interactive",
-						authData: {},
-						status: "pending_auth",
-						createdBy: effectiveCreatedBy ?? null,
-					},
-					tx,
-				);
-				const rows = await insertConnection(tx, profile.id, true);
-				const authRunId = await createAuthRun(
-					{
-						organizationId,
-						connectorKey: args.connector_key,
-						authProfileId: profile.id,
-						createdByUserId: effectiveCreatedBy!,
-					},
-					tx,
-				);
-				return { rows, authRunId };
-    });
-			inserted = bundle.rows as Record<string, unknown>[];
-			interactiveAuthRunId = bundle.authRunId;
-		} else {
-			inserted = (await insertConnection(sql, null, false)) as Record<
-				string,
-				unknown
-			>[];
-		}
+		const bundle = await createConnectionSetupBundle({
+			db: sql,
+			interactive: Boolean(interactiveMethod),
+			organizationId,
+			connectorKey: args.connector_key,
+			displayName,
+			createdByUserId: effectiveCreatedBy!,
+			insertConnection,
+		});
+		inserted = bundle.rows;
+		interactiveAuthRunId = bundle.authRunId;
   } catch (err) {
 		if (err instanceof ConnectionSlugConflictError)
 			return { error: err.message };

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -7,10 +7,12 @@ import { getErrorMessage, parseJsonObject } from "@lobu/core";
 import { getScopedConnectorDefinition } from "../../../../catalog/connector-definitions";
 import { enrichConnectorGroupsWithCatalogDisplay } from "../../../../catalog/connector-group-display";
 import { unregisterConnectorWebhook } from "../../../../connect/webhook-registration";
+import { createAuthRun } from "../../../../runs/queue-service";
 import {
 	getDb,
 	parsePgNumberArray,
 	pgBigintArray,
+	type DbClient,
 } from "../../../../db/client";
 import { recordToolConfigChange } from "../../helpers/config-audit";
 import {
@@ -92,6 +94,13 @@ import {
 	deriveConnectionFacets,
 	deriveEffectiveCredentialMode,
 } from "./facets";
+import {
+	activeConnectionPoll,
+	appendSetupAttemptId,
+	buildConnectionSetupContinuation,
+	buildSafeConnectionResumeCall,
+	installedConnectorPoll,
+} from "../../helpers/connect-setup-continuation";
 
 // ============================================
 // handleListConnectorGroups
@@ -182,7 +191,11 @@ export async function handleListConnectorGroups(
 
   if (args.entity_id) {
     query = sql`${query} AND ${sql.unsafe(
-      connectionLinkedToBusinessEntitySql(String(args.entity_id), "c", `'${organizationId}'`),
+			connectionLinkedToBusinessEntitySql(
+				String(args.entity_id),
+				"c",
+				`'${organizationId}'`,
+			),
     )}`;
   }
 
@@ -288,7 +301,7 @@ export async function handleList(
              SELECT string_agg(DISTINCT ent.name, ', ' ORDER BY ent.name)
              FROM entities ent
              WHERE ent.deleted_at IS NULL
-               AND ent.id IN ${sql.unsafe(connectionLinkedEntityIdsSql('c'))}
+               AND ent.id IN ${sql.unsafe(connectionLinkedEntityIdsSql("c"))}
            ) AS entity_names
     FROM connections c
     LEFT JOIN LATERAL (
@@ -318,7 +331,11 @@ export async function handleList(
   }
   if (args.entity_id) {
     query = sql`${query} AND ${sql.unsafe(
-      connectionLinkedToBusinessEntitySql(String(args.entity_id), "c", `'${organizationId}'`),
+			connectionLinkedToBusinessEntitySql(
+				String(args.entity_id),
+				"c",
+				`'${organizationId}'`,
+			),
     )}`;
   }
   if (args.created_by) {
@@ -326,6 +343,11 @@ export async function handleList(
   }
   if (args.connection_ids?.length) {
     query = sql`${query} AND c.id = ANY(${pgBigintArray(args.connection_ids)}::bigint[])`;
+  }
+  if (args.setup_attempt_id) {
+    query = sql`${query} AND c.config->'setup_attempt_ids' @> ${sql.json([
+			args.setup_attempt_id,
+		])}::jsonb`;
   }
 
   // Visibility: anonymous readers see org-visible connections only; non-admin
@@ -539,6 +561,10 @@ export async function handleCreate(
 ): Promise<ManageConnectionsResult> {
   const sql = getDb();
   const { organizationId, userId } = ctx;
+	const createResumeCall = buildSafeConnectionResumeCall(
+		"connections.create",
+		args,
+	);
 
   // Cloud gate: a raw-DB connector (postgres) has no tenant-URL egress hardening
   // yet, so it can't be installed under LOBU_CLOUD_MODE. (The catalog also hides
@@ -660,10 +686,49 @@ export async function handleCreate(
     setupUrl: await buildViewUrl(ctx, args.connector_key),
   });
   if (appInstallGuard) {
-		return {
-			...appInstallGuard,
-			setup_url: await buildAppInstallationSetupUrl(ctx, args.connector_key),
-		};
+		const setupAttemptId =
+			appInstallGuard.provider === "github" && appInstallGuard.install_url
+				? randomUUID()
+				: undefined;
+		return buildConnectionSetupContinuation({
+			action: "create",
+			connectorKey: args.connector_key,
+			setupFamily: "app_installation",
+			nextAction:
+				appInstallGuard.next_action === "install_app"
+					? "install_app"
+					: "open_setup",
+			instructions: appInstallGuard.error,
+			errorCode: appInstallGuard.error_code,
+			installType: appInstallGuard.install_type,
+			...(appInstallGuard.install_shape
+				? { installShape: appInstallGuard.install_shape }
+				: {}),
+			...(appInstallGuard.setup_instructions
+				? { setupInstructions: appInstallGuard.setup_instructions }
+				: {}),
+			setupUrl: await buildAppInstallationSetupUrl(ctx, args.connector_key),
+			...(appInstallGuard.install_url
+				? {
+						installUrl: setupAttemptId
+							? appendSetupAttemptId(
+									appInstallGuard.install_url,
+									setupAttemptId,
+								)
+							: appInstallGuard.install_url,
+					}
+				: {}),
+			provider: appInstallGuard.provider,
+			...(setupAttemptId
+				? {
+						completionCheck: installedConnectorPoll(
+							args.connector_key,
+							setupAttemptId,
+						),
+						setupAttemptId,
+					}
+				: {}),
+		});
 	}
 
   const deviceBinding = await resolveDeviceBinding({
@@ -672,7 +737,19 @@ export async function handleCreate(
     connector,
     deviceWorkerId: args.device_worker_id,
   });
-	if ("error" in deviceBinding) return deviceBinding;
+	if ("error" in deviceBinding) {
+		if (connector.required_capability && !args.device_worker_id) {
+			return buildConnectionSetupContinuation({
+				action: "create",
+				connectorKey: args.connector_key,
+				setupFamily: "device_bound",
+				nextAction: "connect_device",
+				instructions: deviceBinding.error,
+				setupUrl: await buildViewUrl(ctx, args.connector_key),
+			});
+		}
+		return deviceBinding;
+	}
   if (deviceBinding.deviceWorkerId) {
     const dup = (await sql`
       SELECT id FROM connections
@@ -720,6 +797,9 @@ export async function handleCreate(
   // that emits artifacts (qr/code/etc.) for the UI to render.
 	const interactiveMethod =
 		getInteractiveMethods(connector.auth_schema)[0] ?? null;
+	if (interactiveMethod && !userId) {
+		return { error: "Interactive pairing requires an authenticated user." };
+	}
 
   // A `managedBy` connection's OAuth grant lives in a cloud (public) org — the
   // local instance fetches the token at runtime (execution-context.ts) and never
@@ -773,15 +853,28 @@ export async function handleCreate(
 			!!authSelection.envMethod ||
 			!!authSelection.browserMethod;
     if (requiresAuth && !authSelection.authProfile) {
-      return {
-        error: authSelection.browserMethod
+			const setupFamily = authSelection.browserMethod
+				? "browser"
+				: authSelection.envMethod
+					? "env_keys"
+					: "oauth";
+			return buildConnectionSetupContinuation({
+				action: "create",
+				connectorKey: args.connector_key,
+				setupFamily,
+				nextAction: authSelection.browserMethod
+					? "pair_browser"
+					: "select_auth_profile",
+				instructions: authSelection.browserMethod
 					? "Select or create a browser auth profile before creating the connection."
           : authSelection.oauthMethod && authSelection.envMethod
 						? "Select an auth profile for this connector before creating the connection."
             : authSelection.oauthMethod
 							? "Select or create an OAuth account profile before creating the connection."
 							: "Select or create an auth profile before creating the connection.",
-      };
+				setupUrl: await buildViewUrl(ctx, args.connector_key),
+				resumeCall: createResumeCall,
+			});
     }
   }
 
@@ -861,11 +954,28 @@ export async function handleCreate(
     }
     if (!authSelection.appAuthProfile) {
       if (authSelection.oauthMethod) {
-        return buildOAuthAppProfileSetupError({
+				const setupError = buildOAuthAppProfileSetupError({
           connectorKey: args.connector_key,
           method: authSelection.oauthMethod,
           setupUrl: await buildViewUrl(ctx, args.connector_key),
         });
+				return buildConnectionSetupContinuation({
+					action: "create",
+					connectorKey: args.connector_key,
+					setupFamily: "oauth",
+					nextAction: "configure_oauth_app",
+					instructions: setupError.setup_instructions
+						? `${setupError.error} ${setupError.setup_instructions}`
+						: setupError.error,
+					setupUrl: setupError.setup_url,
+					provider: authSelection.oauthMethod.provider,
+					errorCode: setupError.error_code,
+					installType: setupError.install_type,
+					...(setupError.setup_instructions
+						? { setupInstructions: setupError.setup_instructions }
+						: {}),
+					resumeCall: createResumeCall,
+				});
       }
       return {
         error: callerIsAdmin
@@ -963,24 +1073,6 @@ export async function handleCreate(
         }
       : null;
 
-  // Interactive auth: always create a fresh `interactive` auth profile scoped to
-  // this connection. Connection starts in pending_auth; feed is paused; an auth
-  // run drives the authenticate() lifecycle which writes credentials on success.
-  let interactiveAuthProfileId: number | null = null;
-  if (interactiveMethod) {
-    const profile = await createAuthProfile({
-      organizationId,
-      connectorKey: args.connector_key,
-      displayName: `${displayName} (pairing)`,
-      slug: `${args.connector_key}-interactive-${Date.now()}`,
-			profileKind: "interactive",
-      authData: {},
-			status: "pending_auth",
-      createdBy: effectiveCreatedBy ?? null,
-    });
-    interactiveAuthProfileId = profile.id;
-  }
-
   // Device-bound browser auth profiles live on a specific Mac. Pin the
   // connection there automatically; reject mismatches.
   let effectiveDeviceWorkerId = deviceBinding.deviceWorkerId;
@@ -1063,16 +1155,20 @@ export async function handleCreate(
   });
 	if ("error" in slugResult) return { error: slugResult.error };
 
-  // biome-ignore lint/suspicious/noExplicitAny: postgres.js row shape
-  let inserted: any[];
-  try {
-    inserted = await insertConnectionWithSlug({
+	const insertConnection = (
+		db: DbClient,
+		authProfileId: number | null,
+		useSavepoint: boolean,
+	) =>
+		insertConnectionWithSlug({
       organizationId,
       connectorKey: args.connector_key,
       displayName,
       initialSlug: slugResult.slug,
       explicit: !!args.slug?.trim(),
-      doInsert: (slug) => sql`
+			db,
+			doInsert: (slug) => {
+				const insert = () => db`
         INSERT INTO connections (
           organization_id, connector_key, slug, display_name, status,
           auth_profile_id, app_auth_profile_id, config, created_by, visibility, device_worker_id,
@@ -1082,21 +1178,63 @@ export async function handleCreate(
           ${slug},
           ${displayName},
           ${connectionStatus},
-          ${interactiveAuthProfileId ?? authSelection?.authProfile?.id ?? null},
+            ${authProfileId ?? authSelection?.authProfile?.id ?? null},
           ${authSelection?.appAuthProfile?.id ?? null},
-          ${connectionConfigToInsert ? sql.json(connectionConfigToInsert) : null},
+            ${connectionConfigToInsert ? db.json(connectionConfigToInsert) : null},
           ${effectiveCreatedBy},
           ${visibility},
           ${effectiveDeviceWorkerId},
           ${entityIdsValue}::bigint[]
         )
         RETURNING *
-      `,
+        `;
+				return useSavepoint ? db.savepoint(insert) : insert();
+			},
+		});
+
+	let inserted: Record<string, unknown>[];
+	let interactiveAuthRunId: number | null = null;
+	try {
+		if (interactiveMethod) {
+			const bundle = await sql.begin(async (tx) => {
+				const profile = await createAuthProfile(
+					{
+						organizationId,
+						connectorKey: args.connector_key,
+						displayName: `${displayName} (pairing)`,
+						slug: `${args.connector_key}-interactive-${Date.now()}`,
+						profileKind: "interactive",
+						authData: {},
+						status: "pending_auth",
+						createdBy: effectiveCreatedBy ?? null,
+					},
+					tx,
+				);
+				const rows = await insertConnection(tx, profile.id, true);
+				const authRunId = await createAuthRun(
+					{
+						organizationId,
+						connectorKey: args.connector_key,
+						authProfileId: profile.id,
+						createdByUserId: effectiveCreatedBy!,
+					},
+					tx,
+				);
+				return { rows, authRunId };
     });
+			inserted = bundle.rows as Record<string, unknown>[];
+			interactiveAuthRunId = bundle.authRunId;
+		} else {
+			inserted = (await insertConnection(sql, null, false)) as Record<
+				string,
+				unknown
+			>[];
+		}
   } catch (err) {
 		if (err instanceof ConnectionSlugConflictError)
 			return { error: err.message };
-    if (isPersonalCredVisibilityViolation(err)) return { error: PERSONAL_CRED_ORG_VISIBILITY_ERROR };
+		if (isPersonalCredVisibilityViolation(err))
+			return { error: PERSONAL_CRED_ORG_VISIBILITY_ERROR };
     throw err;
   }
 
@@ -1120,18 +1258,35 @@ export async function handleCreate(
     organizationId,
 		entityType: "connection",
 		op: "created",
-    entityId: inserted[0].id,
+		entityId: Number(inserted[0].id),
     summary: `Connection "${displayName}" created`,
     extra: { connector_key: args.connector_key, slug: inserted[0].slug },
   });
 
   recordToolConfigChange(ctx, {
 		resourceKind: "connection",
-    resourceId: inserted[0].id,
+		resourceId: Number(inserted[0].id),
 		op: "created",
     summary: `Connection '${displayName}' created`,
     state: inserted[0] as Record<string, unknown>,
   });
+
+	if (interactiveMethod) {
+		const connectionId = Number(inserted[0].id);
+		return buildConnectionSetupContinuation({
+			action: "create",
+			connectorKey: args.connector_key,
+			setupFamily: "interactive",
+			nextAction: "pair_interactive",
+			instructions:
+				"Connection created as pending_auth. Complete the interactive pairing run, then poll the connection until it is active.",
+			setupUrl: await buildViewUrl(ctx, args.connector_key),
+			connectionId,
+			slug: String(inserted[0].slug),
+			authRunId: interactiveAuthRunId!,
+			completionCheck: activeConnectionPoll(connectionId),
+		});
+	}
 
   return {
 		action: "create",
@@ -1640,7 +1795,8 @@ export async function handleUpdate(
 				error: `Connection slug '${updateExplicitSlug}' already exists for this organization.`,
 			};
     }
-    if (isPersonalCredVisibilityViolation(err)) return { error: PERSONAL_CRED_ORG_VISIBILITY_ERROR };
+		if (isPersonalCredVisibilityViolation(err))
+			return { error: PERSONAL_CRED_ORG_VISIBILITY_ERROR };
     throw err;
   }
 
@@ -1652,8 +1808,7 @@ export async function handleUpdate(
     // Re-pinning (or clearing) the device also clears the "Device was removed"
     // tombstone left by DELETE /api/me/devices — otherwise the connection stays
     // active but UI-flagged error forever after the user picks a new device.
-		const previousError = (updated[0] as Record<string, unknown>)
-			.error_message;
+		const previousError = (updated[0] as Record<string, unknown>).error_message;
 		clearedDeviceTombstone =
 			previousError === "Device was removed" ||
 			previousError === "Device was moved to another workspace";

--- a/packages/server/src/utils/auth-profiles.ts
+++ b/packages/server/src/utils/auth-profiles.ts
@@ -1,5 +1,5 @@
 import { slugify } from '@lobu/core';
-import { getDb } from '../db/client';
+import { getDb, type DbClient } from '../db/client';
 import { ToolUserError } from './errors';
 import { isUniqueViolation } from './pg-errors';
 
@@ -235,8 +235,8 @@ export async function ensureUniqueAuthProfileSlug(params: {
   organizationId: string;
   slug: string;
   excludeId?: number | null;
-}): Promise<string> {
-  const sql = getDb();
+}, db: DbClient = getDb()): Promise<string> {
+  const sql = db;
   const baseSlug = sanitizeProfileSlug(params.slug);
   let candidate = baseSlug;
   let suffix = 2;
@@ -347,12 +347,12 @@ export async function createAuthProfile(params: {
   browserKind?: BrowserKind | null;
   userDataDir?: string | null;
   cdpUrl?: string | null;
-}): Promise<AuthProfileRow> {
-  const sql = getDb();
+}, db: DbClient = getDb()): Promise<AuthProfileRow> {
+  const sql = db;
   const slug = await ensureUniqueAuthProfileSlug({
     organizationId: params.organizationId,
     slug: normalizeAuthProfileSlug(params.slug, params.displayName),
-  });
+  }, db);
 
   const normalizedProvider = params.provider ? params.provider.toLowerCase() : null;
 


### PR DESCRIPTION
## Summary
- return structured `setup_required` continuations for every connector auth family
- resolve GitHub App installation URLs and correlate completion with durable setup attempts
- create interactive auth profile, connection, and auth run atomically
- redact secret config recursively from resumable SDK calls

## Validation
- 76/76 focused DB-backed tests pass in isolated Vitest processes
- workspace packages build and server TypeScript check passes
- depends on and is rebased onto merged #1921

This is part 2 of the connector lifecycle E2E repair. Operation discovery/execution follows after this merges.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786584263&installation_id=136316292&pr_number=1927&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1927&signature=23d858890ea4dcb6df2fcc9a41d1ce855a0da5d5bae0426e2921b0056e026934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->