### PR TITLE
fix connector operation lifecycle affordances

### DIFF
--- a/packages/core/src/contracts/tools/manage-operations.ts
+++ b/packages/core/src/contracts/tools/manage-operations.ts
@@ -25,7 +25,8 @@ export const KindLiteral = Type.Union(
 
 export const ListAvailableAction = Type.Object({
   action: Type.Literal("list_available", {
-    description: "List connector/MCP/HTTP operations available for execution.",
+    description:
+      "Discover connector operations (capabilities) across bundled, custom, and device connectors, with per-operation connection readiness. Returns a PUBLIC DTO (no backend_config). Capabilities stay discoverable even with no connection; use the readiness + next_action fields to drive discover → connect/setup → poll → execute.",
   }),
   connector_key: Type.Optional(
     Type.String({ description: "Filter by connector key" })
@@ -36,6 +37,19 @@ export const ListAvailableAction = Type.Object({
   entity_id: Type.Optional(Type.Number({ description: "Filter by entity ID" })),
   kind: Type.Optional(KindLiteral),
   backend: Type.Optional(BackendLiteral),
+  query: Type.Optional(
+    Type.String({
+      description:
+        "Data-driven search over connector name/key, operation name/key, description, and input-schema property names/terms. A query like 'github create issue' returns matching capabilities across every installed connector (including ones with no connection yet).",
+    })
+  ),
+  include_disconnected: Type.Optional(
+    Type.Boolean({
+      default: true,
+      description:
+        "Include capabilities whose connector has NO ready connection (default true). Set false to list only executable operations.",
+    })
+  ),
   include_input_schema: Type.Optional(
     Type.Boolean({
       default: true,

--- a/packages/server/src/__tests__/integration/authz/write-policy-connector-op-scope.test.ts
+++ b/packages/server/src/__tests__/integration/authz/write-policy-connector-op-scope.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
-import { resolveWriteEffect } from "../../../authz/entity-policy";
+import {
+	resolveWriteEffect,
+	resolveWriteEffects,
+} from "../../../authz/entity-policy";
+import type { DbClient } from "../../../db/client";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
 	createTestAgent,
@@ -151,5 +155,49 @@ describe("connector_action per-operation scope", () => {
 		expect(await execFor(orgId, "op-agent", "github::create_issue")).toBe(
 			"auto",
 		);
+	});
+
+	it("batches blanket and per-operation effects into one header/effects query pair", async () => {
+		await seedConnectorPolicy({
+			orgId,
+			principalKind: "agent",
+			principalId: "op-agent",
+			effect: "auto",
+		});
+		await seedConnectorPolicy({
+			orgId,
+			principalKind: "agent",
+			principalId: "op-agent",
+			operationKey: "github::create_issue",
+			effect: "disabled",
+		});
+
+		let queryCount = 0;
+		const raw = getTestDb();
+		const counting = new Proxy(raw, {
+			apply(target, thisArg, args) {
+				queryCount += 1;
+				return Reflect.apply(target, thisArg, args);
+			},
+		}) as DbClient;
+		const effects = await resolveWriteEffects({
+			organizationId: orgId,
+			resourceClass: "connector_action",
+			principalKind: "agent",
+			principalId: "op-agent",
+			action: "execute",
+			operationKeys: [
+				"github::create_issue",
+				"github::list_issues",
+				"linear::create_issue",
+			],
+			sql: counting,
+		});
+
+		expect(queryCount).toBe(2);
+		expect(effects.get(null)).toBe("auto");
+		expect(effects.get("github::create_issue")).toBe("disabled");
+		expect(effects.get("github::list_issues")).toBe("auto");
+		expect(effects.get("linear::create_issue")).toBe("auto");
 	});
 });

--- a/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
+++ b/packages/server/src/__tests__/integration/operations-execute-backends.test.ts
@@ -1,0 +1,425 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { Env } from "../../index";
+import { manageOperations } from "../../tools/admin/manage_operations";
+import type { ToolContext } from "../../tools/registry";
+import { createAuthProfile } from "../../utils/auth-profiles";
+import { initWorkspaceProvider } from "../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestConnection,
+	createTestConnectorDefinition,
+	createTestOrganization,
+	createTestUser,
+} from "../setup/test-fixtures";
+
+const LOCAL = "demo.ops.backend.local";
+const MCP = "demo.ops.backend.mcp";
+const HTTP = "demo.ops.backend.http";
+
+function context(organizationId: string, userId: string): ToolContext {
+	return {
+		organizationId,
+		userId,
+		memberRole: "owner",
+		agentId: null,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+		baseUrl: "https://gateway.test/lobu",
+	} as ToolContext;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+describe("operations.execute backend lifecycle", () => {
+	let orgId: string;
+	let userId: string;
+	let ctx: ToolContext;
+	let localConnectionId: number;
+	let mcpConnectionId: number;
+	let secondMcpConnectionId: number;
+	let httpConnectionId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+		const org = await createTestOrganization({ name: "Operation Backends Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		orgId = org.id;
+		userId = user.id;
+		ctx = context(orgId, userId);
+
+		for (const [key, name] of [
+			[LOCAL, "Local backend"],
+			[MCP, "MCP backend"],
+			[HTTP, "HTTP backend"],
+		] as const) {
+			await createTestConnectorDefinition({
+				key,
+				name,
+				organization_id: orgId,
+				auth_schema: { methods: [{ type: "oauth", provider: "test" }] },
+			});
+		}
+
+		const sql = getTestDb();
+		await sql`
+			UPDATE connector_definitions
+			SET actions_schema = ${sql.json({
+				echo: {
+					name: "Echo",
+					kind: "write",
+					input_schema: {
+						type: "object",
+						properties: { value: { type: "string" } },
+						required: ["value"],
+					},
+				},
+				needs_approval: {
+					name: "Needs approval",
+					kind: "write",
+					requiresApproval: true,
+				},
+			})}
+			WHERE organization_id = ${orgId} AND key = ${LOCAL}
+		`;
+		await sql`
+			UPDATE connector_versions
+			SET compiled_code = ${`
+				class ConnectorRuntime {
+					async sync() { return { items: [] }; }
+					async execute(ctx) {
+						return { success: true, output: { backend: 'local_action', value: ctx.input.value ?? null } };
+					}
+				}
+				export { ConnectorRuntime };
+			`}
+			WHERE connector_key = ${LOCAL}
+		`;
+		await sql`
+			UPDATE connector_definitions
+			SET mcp_config = ${sql.json({ upstream_url: "https://mcp.example.test/mcp" })}
+			WHERE organization_id = ${orgId} AND key = ${MCP}
+		`;
+		await sql`
+			UPDATE connector_definitions
+			SET openapi_config = ${sql.json({
+				specUrl: "https://api.example.test/openapi.json",
+				serverUrl: "https://api.example.test",
+			})}
+			WHERE organization_id = ${orgId} AND key = ${HTTP}
+		`;
+
+		const local = await createTestConnection({
+			organization_id: orgId,
+			connector_key: LOCAL,
+			created_by: userId,
+			visibility: "private",
+		});
+		const mcp = await createTestConnection({
+			organization_id: orgId,
+			connector_key: MCP,
+			created_by: userId,
+			visibility: "private",
+		});
+		const secondMcp = await createTestConnection({
+			organization_id: orgId,
+			connector_key: MCP,
+			created_by: userId,
+			visibility: "private",
+		});
+		const http = await createTestConnection({
+			organization_id: orgId,
+			connector_key: HTTP,
+			created_by: userId,
+			visibility: "private",
+			config: { action_modes: { create_item: "auto" } },
+		});
+		localConnectionId = local.id;
+		mcpConnectionId = mcp.id;
+		secondMcpConnectionId = secondMcp.id;
+		httpConnectionId = http.id;
+		for (const [connectorKey, connectionId] of [
+			[LOCAL, local.id],
+			[MCP, mcp.id],
+			[MCP, secondMcp.id],
+			[HTTP, http.id],
+		] as const) {
+			const accountId = `acct_${connectionId}_${connectorKey}`;
+			await sql`
+				INSERT INTO "account" (
+				  id, "accountId", "providerId", "userId",
+				  "accessToken", "accessTokenExpiresAt", scope,
+				  "createdAt", "updatedAt"
+				) VALUES (
+				  ${accountId}, ${accountId}, 'test', ${userId},
+				  ${`backend-test-token-${connectionId}`}, ${new Date(Date.now() + 60 * 60 * 1000).toISOString()}, 'read write',
+				  NOW(), NOW()
+				)
+			`;
+			const profile = await createAuthProfile({
+				organizationId: orgId,
+				connectorKey,
+				displayName: `${connectorKey} test OAuth`,
+				profileKind: "oauth_account",
+				provider: "test",
+				accountId,
+				status: "active",
+				createdBy: userId,
+			});
+			await sql`
+				UPDATE connections
+				SET auth_profile_id = ${profile.id}
+				WHERE id = ${connectionId}
+			`;
+		}
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+				const url = String(input);
+				if (url === "https://api.example.test/openapi.json") {
+					return jsonResponse({
+						openapi: "3.0.0",
+						servers: [{ url: "https://api.example.test" }],
+						paths: {
+							"/items": {
+								post: {
+									operationId: "create_item",
+									requestBody: {
+										content: {
+											"application/json": {
+												schema: { type: "object" },
+											},
+										},
+									},
+									responses: { "200": { description: "ok" } },
+								},
+							},
+						},
+					});
+				}
+				if (url === "https://api.example.test/items") {
+					return jsonResponse({ created: true, body: JSON.parse(String(init?.body)) });
+				}
+				if (url === "https://mcp.example.test/mcp") {
+					const request = JSON.parse(String(init?.body)) as {
+						id?: number;
+						method: string;
+						params?: Record<string, unknown>;
+					};
+					if (request.method === "tools/list") {
+						return jsonResponse({
+							jsonrpc: "2.0",
+							id: request.id,
+							result: {
+								tools: [
+									{
+										name: "remote_echo",
+										description: "Echo through MCP",
+										inputSchema: { type: "object" },
+										annotations: { readOnlyHint: true },
+									},
+								],
+							},
+						});
+					}
+					if (request.method === "tools/call") {
+						if (
+							(request.params?.arguments as Record<string, unknown> | undefined)
+								?.fail_transport === true
+						) {
+							throw new Error("upstream transport failed");
+						}
+						const authorization = new Headers(init?.headers).get("authorization");
+						return jsonResponse({
+							jsonrpc: "2.0",
+							id: request.id,
+							result: {
+								content: [{ type: "text", text: authorization }],
+								isError: false,
+							},
+						});
+					}
+					return jsonResponse({ jsonrpc: "2.0", id: request.id, result: {} });
+				}
+				throw new Error(`Unexpected fetch: ${url}`);
+			}),
+		);
+	});
+
+	afterAll(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("executes a server-side local action inline without a worker claim wait", async () => {
+		const started = Date.now();
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: localConnectionId,
+				operation_key: "echo",
+				input: { value: "local-ok" },
+			},
+			{} as Env,
+			ctx,
+		);
+		expect(result).toMatchObject({
+			action: "execute",
+			status: "completed",
+			output: { backend: "local_action", value: "local-ok" },
+		});
+		expect(Date.now() - started).toBeLessThan(10_000);
+	});
+
+	it("queues destructive local actions for approval", async () => {
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: localConnectionId,
+				operation_key: "needs_approval",
+				input: {},
+			},
+			{} as Env,
+			ctx,
+		);
+		expect(result).toMatchObject({
+			action: "execute",
+			status: "pending_approval",
+		});
+		expect(result).toHaveProperty("approval_url");
+	});
+
+	it("executes an upstream MCP tool with the selected connection's credentials and session", async () => {
+		const listed = await manageOperations(
+			{ action: "list_available", connection_id: mcpConnectionId },
+			{} as Env,
+			ctx,
+		);
+		expect(listed).toMatchObject({
+			action: "list_available",
+			operations: [
+				expect.objectContaining({
+					operation_key: "remote_echo",
+					backend: "mcp_tool",
+				}),
+			],
+		});
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: mcpConnectionId,
+				operation_key: "remote_echo",
+				input: { value: "mcp" },
+			},
+			{} as Env,
+			ctx,
+		);
+		expect(result).toMatchObject({
+			action: "execute",
+			status: "completed",
+			output: {
+				content: [
+					{
+						type: "text",
+						text: `Bearer backend-test-token-${mcpConnectionId}`,
+					},
+				],
+			},
+		});
+
+		const secondResult = await manageOperations(
+			{
+				action: "execute",
+				connection_id: secondMcpConnectionId,
+				operation_key: "remote_echo",
+				input: { value: "second-account" },
+			},
+			{} as Env,
+			ctx,
+		);
+		expect(secondResult).toMatchObject({
+			action: "execute",
+			status: "completed",
+			output: {
+				content: [
+					{
+						type: "text",
+						text: `Bearer backend-test-token-${secondMcpConnectionId}`,
+					},
+				],
+			},
+		});
+	});
+
+	it("finalizes an upstream MCP run as failed when transport setup throws", async () => {
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: mcpConnectionId,
+				operation_key: "remote_echo",
+				input: { fail_transport: true },
+			},
+			{} as Env,
+			ctx,
+		);
+		expect(result).toMatchObject({
+			action: "execute",
+			status: "failed",
+			error_message: "upstream transport failed",
+		});
+		const [run] = await getTestDb()`
+			SELECT status, error_message
+			FROM runs
+			WHERE id = ${(result as { run_id: number }).run_id}
+		`;
+		expect(run).toMatchObject({
+			status: "failed",
+			error_message: "upstream transport failed",
+		});
+	});
+
+	it("discovers and executes an OpenAPI HTTP operation", async () => {
+		const listed = await manageOperations(
+			{ action: "list_available", connection_id: httpConnectionId },
+			{} as Env,
+			ctx,
+		);
+		expect(listed).toMatchObject({
+			action: "list_available",
+			operations: [
+				expect.objectContaining({
+					operation_key: "create_item",
+					backend: "http_operation",
+				}),
+			],
+		});
+		const result = await manageOperations(
+			{
+				action: "execute",
+				connection_id: httpConnectionId,
+				operation_key: "create_item",
+				input: { body: { value: "http-ok" } },
+			},
+			{} as Env,
+			ctx,
+		);
+		expect(result).toMatchObject({
+			action: "execute",
+			status: "completed",
+			output: {
+				body: { created: true, body: { value: "http-ok" } },
+			},
+		});
+	});
+});

--- a/packages/server/src/__tests__/integration/operations-list-available-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/operations-list-available-lifecycle.test.ts
@@ -1,0 +1,732 @@
+/**
+ * `operations.listAvailable` — connector-capability discovery contract.
+ *
+ * The list must be a PUBLIC DTO (no backend_config leaked), keep capabilities
+ * discoverable even when no connection exists, and distinguish DECLARED
+ * capabilities from EXECUTABLE targets using per-connection readiness —
+ * including inactive and offline-device cases — WITHOUT leaking private
+ * connection ids for non-usable connections. Each operation carries a
+ * machine-readable next_action, and `query` searches across connector name/key,
+ * operation name/key, description, and schema terms.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { pgTextArray } from "../../db/client";
+import { manageConnections } from "../../tools/admin/manage_connections";
+import { manageOperations } from "../../tools/admin/manage_operations";
+import type { ToolContext } from "../../tools/registry";
+import { createAuthProfile } from "../../utils/auth-profiles";
+import { initWorkspaceProvider } from "../../workspace";
+import { getTestDb } from "../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestConnection,
+	createTestConnectorDefinition,
+	createTestOrganization,
+	createTestUser,
+} from "../setup/test-fixtures";
+
+async function createOfflineDeviceWorker(
+	userId: string,
+	orgId: string,
+): Promise<string> {
+	const sql = getTestDb();
+	const workerId = `ext-${Math.random().toString(36).slice(2, 10)}`;
+	const lastSeen = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2h ago → offline
+	const [row] = (await sql`
+		INSERT INTO device_workers (
+			user_id, worker_id, platform, capabilities, label, organization_id, last_seen_at
+		) VALUES (
+			${userId}, ${workerId}, 'chrome-extension',
+			${sql.json([])}, 'Test Ext', ${orgId}, ${lastSeen}
+		)
+		RETURNING id
+	`) as unknown as Array<{ id: string }>;
+	return String(row.id);
+}
+
+function ctxFor(organizationId: string, userId: string): ToolContext {
+	return {
+		organizationId,
+		userId,
+		memberRole: "owner",
+		agentId: null,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+		baseUrl: "https://gateway.test/lobu",
+	} as ToolContext;
+}
+
+const KEY_READY = "demo.ops.ready";
+const KEY_DISCONNECTED = "demo.ops.disconnected";
+const KEY_INACTIVE = "demo.ops.inactive";
+const KEY_DEVICE = "demo.ops.device";
+
+const ACTIONS_SCHEMA = {
+	create_issue: {
+		name: "Create issue",
+		description: "Create an issue in the tracker with a title and body.",
+		kind: "write",
+		input_schema: {
+			type: "object",
+			properties: { title: { type: "string" } },
+			required: ["title"],
+		},
+	},
+	list_issues: {
+		name: "List issues",
+		description: "List open issues.",
+		kind: "read",
+	},
+};
+
+async function seedConnector(
+	organizationId: string,
+	key: string,
+	name: string,
+): Promise<void> {
+	await createTestConnectorDefinition({
+		key,
+		name,
+		organization_id: organizationId,
+		auth_schema: { methods: [{ type: "none" }] },
+	});
+	// actions_schema is a column on connector_definitions; update it directly so
+	// the operation is a declared local_action capability.
+	const sql = getTestDb();
+	await sql`UPDATE connector_definitions SET actions_schema = ${sql.json(ACTIONS_SCHEMA)} WHERE key = ${key} AND organization_id = ${organizationId}`;
+}
+
+async function purge(organizationId: string): Promise<void> {
+	const sql = getTestDb();
+	const keys = [KEY_READY, KEY_DISCONNECTED, KEY_INACTIVE, KEY_DEVICE];
+	await sql`DELETE FROM feeds WHERE connection_id IN (SELECT id FROM connections WHERE connector_key = ANY(${pgTextArray(keys)}::text[]) AND organization_id = ${organizationId})`;
+	await sql`DELETE FROM connections WHERE connector_key = ANY(${pgTextArray(keys)}::text[]) AND organization_id = ${organizationId}`;
+	await sql`DELETE FROM connector_definitions WHERE key = ANY(${pgTextArray(keys)}::text[]) AND organization_id = ${organizationId}`;
+}
+
+type AvailOp = Record<string, unknown> & {
+	connector_key: string;
+	operation_key: string;
+	executable: boolean;
+	readiness: string;
+	connection_count: number;
+	execution_targets: Array<{
+		connection_id: number;
+		status: string;
+		executable: boolean;
+		reason: string;
+	}>;
+	next_action: {
+		action: string;
+		sdk_method?: string;
+		arguments?: unknown[];
+		requires_input?: boolean;
+		input_schema?: Record<string, unknown>;
+		manual?: boolean;
+		view_url?: string;
+	};
+};
+
+async function listAll(
+	orgId: string,
+	userId: string,
+	args: Record<string, unknown> = {},
+): Promise<{ operations: AvailOp[]; total: number }> {
+	const res = (await manageOperations(
+		{ action: "list_available", ...args } as never,
+		TEST_ENV(),
+		ctxFor(orgId, userId),
+	)) as { operations: AvailOp[]; total: number };
+	return res;
+}
+
+function TEST_ENV() {
+	return {} as never;
+}
+
+describe("operations.listAvailable — capability discovery DTO", () => {
+	beforeAll(async () => {
+		await initWorkspaceProvider();
+	});
+
+	afterEach(async () => {
+		const sql = getTestDb();
+		const orgs = await sql`SELECT id FROM "organization"`;
+		for (const org of orgs) await purge(org.id as string);
+	});
+
+	it("returns a PUBLIC DTO: no operation leaks backend_config", async () => {
+		const org = await createTestOrganization({ name: "Ops DTO Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id, KEY_READY, "Ready Connector");
+		await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_READY,
+			status: "active",
+		});
+
+		const { operations } = await listAll(org.id, user.id);
+
+		expect(operations.length).toBeGreaterThan(0);
+		for (const op of operations) {
+			expect(op).not.toHaveProperty("backend_config");
+		}
+	});
+
+	it("keeps disconnected capabilities discoverable with a connect next_action and no connection_id", async () => {
+		const org = await createTestOrganization({ name: "Ops Disc Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id, KEY_DISCONNECTED, "Disconnected Connector");
+
+		const { operations } = await listAll(org.id, user.id, {
+			connector_key: KEY_DISCONNECTED,
+		});
+
+		expect(operations.length).toBe(2);
+		const create = operations.find((o) => o.operation_key === "create_issue")!;
+		expect(create.executable).toBe(false);
+		expect(create.readiness).toBe("disconnected");
+		expect(create.connection_count).toBe(0);
+		expect(create.execution_targets).toEqual([]);
+		expect(create.next_action.sdk_method).toBe("connections.connect");
+		expect(create.next_action.arguments).toEqual([
+			{ connector_key: KEY_DISCONNECTED },
+		]);
+	});
+
+	it("requires schema-valid input before advertising execute, while parameterless operations remain directly executable", async () => {
+		const org = await createTestOrganization({ name: "Ops Ready Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id, KEY_READY, "Ready Connector");
+		const conn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_READY,
+			status: "active",
+		});
+
+		const { operations } = await listAll(org.id, user.id, {
+			connector_key: KEY_READY,
+		});
+
+		const create = operations.find((o) => o.operation_key === "create_issue")!;
+		expect(create.executable).toBe(true);
+		expect(create.readiness).toBe("ready");
+		expect(create.connection_count).toBe(1);
+		expect(create.execution_targets).toMatchObject([
+			{ connection_id: conn.id, status: "ready", executable: true },
+		]);
+		expect(create.next_action).toMatchObject({
+			action: "provide_input",
+			sdk_method: "operations.execute",
+			requires_input: true,
+			input_schema: create.input_schema,
+			arguments: [{ connection_id: conn.id, operation_key: "create_issue" }],
+		});
+		expect(JSON.stringify(create.next_action)).not.toContain('"input":{}');
+
+		const list = operations.find((o) => o.operation_key === "list_issues")!;
+		expect(list.next_action).toEqual({
+			action: "execute",
+			sdk_method: "operations.execute",
+			arguments: [
+				{
+					connection_id: conn.id,
+					operation_key: "list_issues",
+					input: {},
+				},
+			],
+		});
+	});
+
+	it("preserves pending_auth and returns an absolute manual setup continuation instead of a get no-op", async () => {
+		const org = await createTestOrganization({ name: "Ops Inactive Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id, KEY_INACTIVE, "Inactive Connector");
+		await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_INACTIVE,
+			status: "pending_auth",
+			createDefaultFeed: false,
+		});
+
+		const { operations } = await listAll(org.id, user.id, {
+			connector_key: KEY_INACTIVE,
+		});
+
+		const create = operations.find((o) => o.operation_key === "create_issue")!;
+		expect(create.executable).toBe(false);
+		expect(create.readiness).toBe("pending_auth");
+		expect(create.connection_count).toBe(1);
+		expect(create.execution_targets).toMatchObject([
+			{ status: "pending_auth", executable: false },
+		]);
+		expect(create.next_action).toMatchObject({
+			action: "open_setup",
+			manual: true,
+		});
+		expect(create.next_action.sdk_method).toBeUndefined();
+		expect(new URL(create.next_action.view_url!).origin).toBe(
+			"https://gateway.test",
+		);
+	});
+
+	it("resumes a paused connection through the returned SDK call and becomes ready", async () => {
+		const org = await createTestOrganization({ name: "Ops Paused Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id, KEY_INACTIVE, "Paused Connector");
+		const conn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_INACTIVE,
+			status: "paused",
+			createDefaultFeed: false,
+		});
+
+		const before = await listAll(org.id, user.id, {
+			connection_id: conn.id,
+		});
+		const create = before.operations.find(
+			(operation) => operation.operation_key === "create_issue",
+		)!;
+		expect(create).toMatchObject({
+			readiness: "paused",
+			execution_targets: [
+				{ connection_id: conn.id, status: "paused", executable: false },
+			],
+			next_action: {
+				action: "resume_connection",
+				sdk_method: "connections.update",
+				arguments: [{ connection_id: conn.id, status: "active" }],
+			},
+		});
+
+		const [updateInput] = create.next_action.arguments as Array<
+			Record<string, unknown>
+		>;
+		await expect(
+			manageConnections(
+				{ action: "update", ...updateInput } as never,
+				TEST_ENV(),
+				ctxFor(org.id, user.id),
+			),
+		).resolves.toMatchObject({ action: "update" });
+
+		const after = await listAll(org.id, user.id, {
+			connection_id: conn.id,
+		});
+		expect(
+			after.operations.find(
+				(operation) => operation.operation_key === "create_issue",
+			),
+		).toMatchObject({ readiness: "ready", executable: true });
+	});
+
+	it("offers and invokes reauthenticate only for an interactive auth profile", async () => {
+		const org = await createTestOrganization({ name: "Ops Interactive Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id, KEY_INACTIVE, "Interactive Connector");
+		const profile = await createAuthProfile({
+			organizationId: org.id,
+			connectorKey: KEY_INACTIVE,
+			displayName: "Interactive repair",
+			profileKind: "interactive",
+			status: "pending_auth",
+			createdBy: user.id,
+		});
+		const conn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_INACTIVE,
+			status: "error",
+			created_by: user.id,
+			createDefaultFeed: false,
+		});
+		await getTestDb()`
+			UPDATE connections SET auth_profile_id = ${profile.id} WHERE id = ${conn.id}
+		`;
+
+		const { operations } = await listAll(org.id, user.id, {
+			connection_id: conn.id,
+		});
+		const create = operations.find(
+			(operation) => operation.operation_key === "create_issue",
+		)!;
+		expect(create.next_action).toMatchObject({
+			action: "reauthenticate",
+			sdk_method: "connections.reauthenticate",
+			arguments: [conn.id],
+		});
+		expect(new URL(create.next_action.view_url!).origin).toBe(
+			"https://gateway.test",
+		);
+
+		const [connectionId] = create.next_action.arguments as [number];
+		const repaired = await manageConnections(
+			{ action: "reauthenticate", connection_id: connectionId },
+			TEST_ENV(),
+			ctxFor(org.id, user.id),
+		);
+		expect(repaired).toMatchObject({
+			action: "reauthenticate",
+			connection_id: conn.id,
+			auth_run_id: expect.any(Number),
+		});
+	});
+
+	it.each([
+		"error",
+		"revoked",
+	])("preserves %s and returns an absolute manual repair continuation", async (status) => {
+		const org = await createTestOrganization({ name: `Ops ${status} Org` });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id, KEY_INACTIVE, `${status} Connector`);
+		const conn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_INACTIVE,
+			status,
+			createDefaultFeed: false,
+		});
+
+		const { operations } = await listAll(org.id, user.id, {
+			connection_id: conn.id,
+		});
+		const create = operations.find(
+			(operation) => operation.operation_key === "create_issue",
+		)!;
+		expect(create.readiness).toBe(status);
+		expect(create.execution_targets).toContainEqual(
+			expect.objectContaining({ status }),
+		);
+		expect(create.next_action).toMatchObject({
+			action: "open_setup",
+			manual: true,
+		});
+		expect(create.next_action.sdk_method).toBeUndefined();
+		expect(new URL(create.next_action.view_url!).origin).toBe(
+			"https://gateway.test",
+		);
+	});
+
+	it("device-bound connection whose device is offline: device_offline readiness, not executable", async () => {
+		const org = await createTestOrganization({ name: "Ops Device Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id, KEY_DEVICE, "Device Connector");
+		const workerId = await createOfflineDeviceWorker(user.id, org.id);
+		const conn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_DEVICE,
+			status: "active",
+		});
+		// Pin the connection to the offline device (the authoritative column).
+		await getTestDb()`UPDATE connections SET device_worker_id = ${workerId} WHERE id = ${conn.id}`;
+
+		const { operations } = await listAll(org.id, user.id, {
+			connector_key: KEY_DEVICE,
+		});
+
+		const create = operations.find((o) => o.operation_key === "create_issue")!;
+		expect(create.executable).toBe(false);
+		expect(create.readiness).toBe("device_offline");
+		expect(create.execution_targets).toMatchObject([
+			{ connection_id: conn.id, status: "device_offline", executable: false },
+		]);
+		expect(create.next_action).toMatchObject({
+			action: "bring_device_online",
+			manual: true,
+		});
+		expect(create.next_action.sdk_method).toBeUndefined();
+		expect(new URL(create.next_action.view_url!).origin).toBe(
+			"https://gateway.test",
+		);
+		expect(JSON.stringify(create)).not.toContain(workerId);
+	});
+
+	it("query search matches connector name + operation name across disconnected connectors", async () => {
+		const org = await createTestOrganization({ name: "Ops Search Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id, KEY_DISCONNECTED, "AcmeTracker");
+
+		const { operations } = await listAll(org.id, user.id, {
+			query: "acme create issue",
+		});
+
+		const keys = operations.map((o) => o.operation_key);
+		expect(keys).toContain("create_issue");
+		// Match should be on the AcmeTracker connector, not unrelated ones.
+		expect(operations.every((o) => o.connector_key === KEY_DISCONNECTED)).toBe(
+			true,
+		);
+	});
+
+	it("include_disconnected=false hides capabilities with no ready connection", async () => {
+		const org = await createTestOrganization({ name: "Ops Hide Disc Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id, KEY_DISCONNECTED, "Hidden Disconnected");
+
+		const { operations } = await listAll(org.id, user.id, {
+			connector_key: KEY_DISCONNECTED,
+			include_disconnected: false,
+		});
+		expect(operations).toHaveLength(0);
+	});
+
+	it("marks an operation disabled when every visible connection disables it", async () => {
+		const org = await createTestOrganization({ name: "Ops Disabled Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await seedConnector(org.id, KEY_READY, "Disabled Action Connector");
+		const conn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_READY,
+			status: "active",
+		});
+		const sql = getTestDb();
+		await sql`UPDATE connections SET config = ${sql.json({ action_modes: { create_issue: "disabled", list_issues: "approval" }, preserved: true })} WHERE id = ${conn.id}`;
+
+		const { operations } = await listAll(org.id, user.id, {
+			connector_key: KEY_READY,
+		});
+		const create = operations.find((o) => o.operation_key === "create_issue")!;
+		const list = operations.find((o) => o.operation_key === "list_issues")!;
+
+		expect(create).toMatchObject({
+			executable: false,
+			readiness: "disabled",
+			next_action: {
+				action: "enable_operation",
+				sdk_method: "connections.update",
+				arguments: [
+					{
+						connection_id: conn.id,
+						config: {
+							action_modes: {
+								create_issue: "auto",
+								list_issues: "approval",
+							},
+						},
+					},
+				],
+			},
+		});
+		expect(create.execution_targets).toMatchObject([
+			{ connection_id: conn.id, status: "disabled", executable: false },
+		]);
+		expect(list).toMatchObject({ executable: true, readiness: "ready" });
+
+		const scoped = await listAll(org.id, user.id, { connection_id: conn.id });
+		expect(
+			scoped.operations.find(
+				(operation) => operation.operation_key === "create_issue",
+			),
+		).toMatchObject({
+			executable: false,
+			readiness: "disabled",
+			next_action: {
+				action: "enable_operation",
+				sdk_method: "connections.update",
+			},
+		});
+
+		const [updateInput] = create.next_action.arguments as Array<
+			Record<string, unknown>
+		>;
+		const updated = await manageConnections(
+			{ action: "update", ...updateInput } as never,
+			TEST_ENV(),
+			ctxFor(org.id, user.id),
+		);
+		expect(updated).toMatchObject({ action: "update" });
+
+		const [stored] =
+			await sql`SELECT config FROM connections WHERE id = ${conn.id}`;
+		expect(stored.config).toMatchObject({
+			preserved: true,
+			action_modes: {
+				create_issue: "auto",
+				list_issues: "approval",
+			},
+		});
+		const afterEnable = await listAll(org.id, user.id, {
+			connection_id: conn.id,
+		});
+		expect(
+			afterEnable.operations.find(
+				(operation) => operation.operation_key === "create_issue",
+			),
+		).toMatchObject({ executable: true, readiness: "ready" });
+	});
+
+	it("points remediation at a target whose status matches mixed-target readiness", async () => {
+		const org = await createTestOrganization({ name: "Ops Mixed Targets Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		await Promise.all([
+			seedConnector(org.id, KEY_DEVICE, "Mixed Offline Connector"),
+			seedConnector(org.id, KEY_INACTIVE, "Mixed Inactive Connector"),
+			seedConnector(org.id, KEY_READY, "All Disabled Connector"),
+		]);
+		const sql = getTestDb();
+		const disabledConfig = { action_modes: { create_issue: "disabled" } };
+
+		const disabledBeforeOffline = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_DEVICE,
+			status: "active",
+		});
+		await sql`UPDATE connections SET config = ${sql.json(disabledConfig)} WHERE id = ${disabledBeforeOffline.id}`;
+		const offline = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_DEVICE,
+			status: "active",
+		});
+		const workerId = await createOfflineDeviceWorker(user.id, org.id);
+		await sql`UPDATE connections SET device_worker_id = ${workerId} WHERE id = ${offline.id}`;
+
+		const disabledBeforeInactive = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_INACTIVE,
+			status: "active",
+		});
+		await sql`UPDATE connections SET config = ${sql.json(disabledConfig)} WHERE id = ${disabledBeforeInactive.id}`;
+		const inactive = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_INACTIVE,
+			status: "pending_auth",
+			createDefaultFeed: false,
+		});
+
+		const disabled = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_READY,
+			status: "active",
+		});
+		await sql`UPDATE connections SET config = ${sql.json(disabledConfig)} WHERE id = ${disabled.id}`;
+
+		for (const expected of [
+			{ connectorKey: KEY_DEVICE, readiness: "device_offline", id: offline.id },
+			{
+				connectorKey: KEY_INACTIVE,
+				readiness: "pending_auth",
+				id: inactive.id,
+			},
+			{ connectorKey: KEY_READY, readiness: "disabled", id: disabled.id },
+		]) {
+			const { operations } = await listAll(org.id, user.id, {
+				connector_key: expected.connectorKey,
+			});
+			const create = operations.find(
+				(operation) => operation.operation_key === "create_issue",
+			)!;
+			expect(create.readiness).toBe(expected.readiness);
+			expect(create.next_action.arguments).toEqual(
+				expected.readiness === "disabled"
+					? [
+							{
+								connection_id: expected.id,
+								config: { action_modes: { create_issue: "auto" } },
+							},
+						]
+					: undefined,
+			);
+			expect(create.execution_targets).toContainEqual(
+				expect.objectContaining({
+					connection_id: expected.id,
+					status: expected.readiness,
+				}),
+			);
+		}
+	});
+
+	it("cross-org fence: another org's connectors/connections are invisible", async () => {
+		const orgA = await createTestOrganization({ name: "Ops Fence A" });
+		const orgB = await createTestOrganization({ name: "Ops Fence B" });
+		const userA = await createTestUser();
+		await addUserToOrganization(userA.id, orgA.id, "owner");
+		await seedConnector(orgA.id, KEY_READY, "Fence A Connector");
+		await createTestConnection({
+			organization_id: orgA.id,
+			connector_key: KEY_READY,
+			status: "active",
+		});
+		// org B has nothing.
+
+		const { operations } = await listAll(orgB.id, userA.id);
+		expect(operations.every((o) => o.connector_key !== KEY_READY)).toBe(true);
+	});
+
+	it("preserves every visible target and excludes another member's private connection", async () => {
+		const org = await createTestOrganization({
+			name: "Ops Private Targets Org",
+		});
+		const owner = await createTestUser();
+		const other = await createTestUser();
+		await addUserToOrganization(owner.id, org.id, "owner");
+		await addUserToOrganization(other.id, org.id, "member");
+		await seedConnector(org.id, KEY_READY, "Private Targets Connector");
+		const ownPrivate = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_READY,
+			created_by: owner.id,
+			visibility: "private",
+		});
+		const orgVisible = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_READY,
+			created_by: other.id,
+			visibility: "org",
+		});
+		const hiddenPrivate = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_READY,
+			created_by: other.id,
+			visibility: "private",
+		});
+
+		const { operations } = await listAll(org.id, owner.id, {
+			connector_key: KEY_READY,
+		});
+		const create = operations.find((o) => o.operation_key === "create_issue")!;
+		expect(
+			create.execution_targets.map((target) => target.connection_id),
+		).toEqual([ownPrivate.id, orgVisible.id]);
+		expect(create.connection_count).toBe(2);
+		expect(create.execution_targets).toHaveLength(2);
+
+		const hidden = await listAll(org.id, owner.id, {
+			connection_id: hiddenPrivate.id,
+		});
+		expect(hidden.operations).toEqual([]);
+		expect(hidden.total).toBe(0);
+
+		const executed = await manageOperations(
+			{
+				action: "execute",
+				connection_id: hiddenPrivate.id,
+				operation_key: "create_issue",
+				input: { title: "must stay private" },
+			},
+			TEST_ENV(),
+			ctxFor(org.id, owner.id),
+		);
+		expect(executed).toEqual({
+			error: "Connection not found or not visible.",
+		});
+		const runRows = await getTestDb()`
+			SELECT id FROM runs WHERE connection_id = ${hiddenPrivate.id}
+		`;
+		expect(runRows).toHaveLength(0);
+	});
+});

--- a/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
+++ b/packages/server/src/__tests__/integration/tools/workspace-instructions.test.ts
@@ -112,6 +112,19 @@ describe('buildWorkspaceInstructions render fixes', () => {
       connector_key: 'shop.sync',
       createDefaultFeed: false,
     });
+
+    // Capability discovery must not depend on a pre-existing connection.
+    await sql`
+      INSERT INTO connector_definitions (key, name, description, actions_schema, organization_id, status)
+      VALUES (
+        'shop.disconnected',
+        'Disconnected Shop',
+        'Available before setup',
+        ${sql.json({ create_order: {} })},
+        ${org.id},
+        'active'
+      )
+    `;
   });
 
   it('renders entity type descriptions and per-field descriptions from metadata_schema.properties', async () => {
@@ -139,6 +152,13 @@ describe('buildWorkspaceInstructions render fixes', () => {
     const out = await buildWorkspaceInstructions(org.id);
     expect(out).toContain(
       '- shop.sync (Order + inventory sync for the shop): list_orders, refund_order'
+    );
+  });
+
+  it('renders disconnected connector capabilities so agents can discover setup', async () => {
+    const out = await buildWorkspaceInstructions(org.id);
+    expect(out).toContain(
+      '- shop.disconnected (Available before setup): create_order'
     );
   });
 });

--- a/packages/server/src/authz/entity-policy.ts
+++ b/packages/server/src/authz/entity-policy.ts
@@ -20,7 +20,7 @@
  * high-volume provenance plumbing, not collaboration edits; gating them would
  * flood approvals. Any new user-facing entity write path MUST call this module.
  */
-import { type DbClient, getDb, pgBigintArray } from "../db/client";
+import { type DbClient, getDb, pgBigintArray, pgTextArray } from "../db/client";
 import {
 	WRITE_ACTION_MANIFEST,
 	type WriteAction,
@@ -670,6 +670,9 @@ async function loadCandidatePolicies(args: {
 	 * blanket row (operation_key IS NULL) and any row scoped to this operation; the
 	 * op-specific row wins via {@link scopeSpecificity}. */
 	operationKey?: string | null;
+	/** Batch form used by operation discovery: load the blanket plus every named
+	 * operation in one header query, then fold each operation in memory. */
+	operationKeys?: string[];
 	/** agent_config: target agents.id being updated/deleted. Loads blanket + that target. */
 	targetAgentId?: string | null;
 	sql?: DbClient;
@@ -679,6 +682,9 @@ async function loadCandidatePolicies(args: {
 	const principalKind = args.principalKind ?? null;
 	const principalId = args.principalId ?? null;
 	const ownerAgentId = args.ownerAgentId ?? null;
+	const operationKeys =
+		args.operationKeys ??
+		(args.operationKey == null ? [] : [args.operationKey]);
 	const rows = await sql<EntityApprovalPolicyRow>`
     SELECT id, organization_id, resource_class, principal_kind, principal_id,
        operation_key, target_agent_id, entity_type_slug, field_path, entity_id,
@@ -699,7 +705,7 @@ async function loadCandidatePolicies(args: {
           AND (principal_id IS NULL OR principal_id = ${ownerAgentId})
         )
       )
-      AND (operation_key IS NULL OR operation_key = ${args.operationKey ?? null})
+		AND (operation_key IS NULL OR operation_key = ANY(${pgTextArray(operationKeys)}::text[]))
       AND (target_agent_id IS NULL OR target_agent_id = ${args.targetAgentId ?? null})
       AND (entity_type_slug IS NULL OR entity_type_slug = ${args.entityTypeSlug ?? null})
       AND (entity_id IS NULL OR entity_id = ${args.entityId ?? null})
@@ -888,6 +894,54 @@ export async function resolveWriteEffect(args: {
 	});
 	return foldEffectForDecision(
 		candidates, args.resourceClass, args.action);
+}
+
+/**
+ * Batch connector-operation effects for discovery. Candidate headers and child
+ * effects are loaded once, then each operation is folded in memory.
+ */
+export async function resolveWriteEffects(args: {
+	organizationId: string;
+	resourceClass: "connector_action";
+	principalKind: EntityPolicyPrincipalKind;
+	principalId?: string | null;
+	ownerAgentId?: string | null;
+	ownerResolved?: boolean;
+	action: WriteAction;
+	operationKeys: string[];
+	sql?: DbClient;
+}): Promise<Map<string | null, EntityMutationMode>> {
+	const keys = [...new Set(args.operationKeys)];
+	const effects = new Map<string | null, EntityMutationMode>();
+	if (args.principalKind === "user" || args.ownerResolved === false) {
+		const effect = args.principalKind === "user" ? "auto" : "deny";
+		effects.set(null, effect);
+		for (const key of keys) effects.set(key, effect);
+		return effects;
+	}
+
+	const candidates = await loadCandidatePolicies({
+		organizationId: args.organizationId,
+		resourceClass: args.resourceClass,
+		principalKind: args.principalKind,
+		principalId: args.principalId ?? null,
+		ownerAgentId: args.ownerAgentId ?? null,
+		operationKeys: keys,
+		sql: args.sql,
+	});
+	const foldFor = (operationKey: string | null) =>
+		foldEffectForDecision(
+			candidates.filter(
+				(candidate) =>
+					candidate.operation_key === null ||
+					candidate.operation_key === operationKey,
+			),
+			args.resourceClass,
+			args.action,
+		);
+	effects.set(null, foldFor(null));
+	for (const key of keys) effects.set(key, foldFor(key));
+	return effects;
 }
 
 /**

--- a/packages/server/src/catalog/__tests__/connector-lifecycle-matrix.test.ts
+++ b/packages/server/src/catalog/__tests__/connector-lifecycle-matrix.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { listCatalogConnectorDefinitions } from "../../utils/connector-catalog";
+
+const EXPECTED_BUNDLED_CONNECTORS = [
+	"discord",
+	"github",
+	"google.calendar",
+	"google.gmail",
+	"gchat",
+	"hackernews",
+	"jira",
+	"linear",
+	"microsoft.outlook",
+	"postgres",
+	"producthunt",
+	"reddit",
+	"rss",
+	"slack",
+	"teams",
+	"telegram",
+	"webhook",
+	"whatsapp",
+	"x",
+	"youtube",
+];
+
+describe("bundled connector lifecycle matrix", () => {
+	it("keeps every bundled connector discoverable with a supported auth family", async () => {
+		const definitions = await listCatalogConnectorDefinitions();
+		expect(definitions.map((definition) => definition.key).sort()).toEqual(
+			[...EXPECTED_BUNDLED_CONNECTORS].sort(),
+		);
+
+		const supportedFamilies = new Set([
+			"app_installation",
+			"oauth",
+			"env_keys",
+			"browser",
+			"interactive",
+			"none",
+		]);
+		const representedFamilies = new Set<string>();
+		for (const definition of definitions) {
+			const methods = (
+				definition.auth_schema as
+					| { methods?: Array<{ type?: unknown }> }
+					| null
+			)?.methods;
+			expect(methods?.length, `${definition.key} must declare auth methods`).toBeGreaterThan(0);
+			for (const method of methods ?? []) {
+				expect(typeof method.type).toBe("string");
+				expect(
+					supportedFamilies.has(String(method.type)),
+					`${definition.key} uses unsupported auth family ${String(method.type)}`,
+				).toBe(true);
+				representedFamilies.add(String(method.type));
+			}
+		}
+		expect([...representedFamilies].sort()).toEqual(
+			["app_installation", "browser", "env_keys", "none", "oauth"],
+		);
+	});
+
+	it("keeps every bundled action connector in the executable local-action matrix", async () => {
+		const definitions = await listCatalogConnectorDefinitions();
+		const actionCounts = Object.fromEntries(
+			definitions
+				.filter((definition) => definition.actions_schema)
+				.map((definition) => [
+					definition.key,
+					Object.keys(definition.actions_schema ?? {}).length,
+				]),
+		);
+		expect(actionCounts).toEqual({
+			github: 6,
+			"google.calendar": 4,
+			"google.gmail": 5,
+			youtube: 5,
+		});
+
+		for (const definition of definitions) {
+			for (const [operationKey, raw] of Object.entries(
+				definition.actions_schema ?? {},
+			)) {
+				expect(operationKey.trim()).not.toBe("");
+				expect(raw).toBeTypeOf("object");
+			}
+		}
+	});
+});

--- a/packages/server/src/mcp-proxy/client.ts
+++ b/packages/server/src/mcp-proxy/client.ts
@@ -11,7 +11,11 @@ import { isReservedIp, stripIpv6Brackets } from '../gateway/proxy/ssrf-guard';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
 import { TtlCache } from '../utils/ttl-cache';
-import { type ResolvedCredentials, resolveCredentials } from './credential-resolver';
+import {
+  type ResolvedCredentials,
+  resolveCredentials,
+  resolveCredentialsByConnectionId,
+} from './credential-resolver';
 import type { DiscoveredTool, JsonRpcResponse, McpProxyConfig } from './types';
 
 const FETCH_TIMEOUT_INIT_MS = 10_000;
@@ -25,12 +29,16 @@ function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Pr
 }
 
 /**
- * In-memory session store: "orgId:connectorKey" → MCP session ID
+ * In-memory session store. Execution sessions include connectionId so two
+ * accounts on the same connector never reuse each other's authenticated MCP
+ * session. Discovery sessions use the connector-wide key.
  */
 const sessions = new Map<string, string>();
 
-function sessionKey(orgId: string, connectorKey: string): string {
-  return `${orgId}:${connectorKey}`;
+function sessionKey(orgId: string, connectorKey: string, connectionId?: number): string {
+  return connectionId === undefined
+    ? `${orgId}:${connectorKey}`
+    : `${orgId}:${connectorKey}:connection:${connectionId}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -73,12 +81,13 @@ async function sendRequest(
   orgId: string,
   connectorKey: string,
   body: string,
-  timeoutMs: number = FETCH_TIMEOUT_TOOL_MS
+  timeoutMs: number = FETCH_TIMEOUT_TOOL_MS,
+  connectionId?: number
 ): Promise<JsonRpcResponse> {
   // Re-validate on every outbound fetch — config may have been edited/imported
   // after the creation-time probe, so "validated at write time" is not enough.
   assertSafeUrl(upstreamUrl);
-  const key = sessionKey(orgId, connectorKey);
+  const key = sessionKey(orgId, connectorKey, connectionId);
   const mcpSessionId = sessions.get(key) ?? null;
   const headers = buildHeaders(credentials, mcpSessionId);
 
@@ -110,10 +119,11 @@ async function initializeSession(
   upstreamUrl: string,
   credentials: ResolvedCredentials | null,
   orgId: string,
-  connectorKey: string
+  connectorKey: string,
+  connectionId?: number
 ): Promise<void> {
   // Clear existing session
-  const key = sessionKey(orgId, connectorKey);
+  const key = sessionKey(orgId, connectorKey, connectionId);
   sessions.delete(key);
 
   // Send initialize
@@ -132,7 +142,8 @@ async function initializeSession(
       },
       id: 0,
     }),
-    FETCH_TIMEOUT_INIT_MS
+    FETCH_TIMEOUT_INIT_MS,
+    connectionId
   );
 
   if (initResponse.error) {
@@ -150,7 +161,8 @@ async function initializeSession(
         jsonrpc: '2.0',
         method: 'notifications/initialized',
       }),
-      FETCH_TIMEOUT_INIT_MS
+      FETCH_TIMEOUT_INIT_MS,
+      connectionId
     );
   } catch {
     // Notification delivery is best-effort
@@ -246,9 +258,10 @@ export async function callTool(
   config: McpProxyConfig,
   orgId: string,
   originalToolName: string,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
+  connectionId: number
 ): Promise<{ content: unknown[]; isError: boolean }> {
-  const credentials = await resolveCredentials(orgId, connectorKey);
+  const credentials = await resolveCredentialsByConnectionId(connectionId, orgId);
 
   const jsonRpcBody = JSON.stringify({
     jsonrpc: '2.0',
@@ -265,32 +278,47 @@ export async function callTool(
       orgId,
       connectorKey,
       jsonRpcBody,
-      FETCH_TIMEOUT_TOOL_MS
+      FETCH_TIMEOUT_TOOL_MS,
+      connectionId
     );
   } catch (_error) {
     // If there's no session yet, initialize and retry
-    await initializeSession(config.upstream_url, credentials, orgId, connectorKey);
+    await initializeSession(
+      config.upstream_url,
+      credentials,
+      orgId,
+      connectorKey,
+      connectionId
+    );
     response = await sendRequest(
       config.upstream_url,
       credentials,
       orgId,
       connectorKey,
       jsonRpcBody,
-      FETCH_TIMEOUT_TOOL_MS
+      FETCH_TIMEOUT_TOOL_MS,
+      connectionId
     );
   }
 
   // Stale session recovery: "not initialized" → reinitialize + retry once
   if (response.error && /not initialized/i.test(response.error.message || '')) {
     logger.info({ connectorKey, originalToolName }, '[McpProxy] Session expired, reinitializing');
-    await initializeSession(config.upstream_url, credentials, orgId, connectorKey);
+    await initializeSession(
+      config.upstream_url,
+      credentials,
+      orgId,
+      connectorKey,
+      connectionId
+    );
     response = await sendRequest(
       config.upstream_url,
       credentials,
       orgId,
       connectorKey,
       jsonRpcBody,
-      FETCH_TIMEOUT_TOOL_MS
+      FETCH_TIMEOUT_TOOL_MS,
+      connectionId
     );
   }
 

--- a/packages/server/src/operations/action-modes.ts
+++ b/packages/server/src/operations/action-modes.ts
@@ -19,9 +19,9 @@ function isActionMode(value: unknown): value is ActionMode {
 /**
  * Pull a sanitized `action_modes` map out of a raw connection.config blob.
  * Anything that isn't a recognized mode is dropped silently — readers must
- * then fall back to {@link defaultModeFromOperation}.
+ * then fall back to {@link defaultActionModeForOperation}.
  */
-function getActionModes(
+export function getActionModes(
   config: Record<string, unknown> | null | undefined
 ): Record<string, ActionMode> {
   if (!config || typeof config !== 'object') return {};
@@ -41,7 +41,7 @@ function getActionModes(
  * - other writes → auto
  * `disabled` requires an explicit user opt-in.
  */
-function defaultModeFromOperation(operation: {
+export function defaultActionModeForOperation(operation: {
   requires_approval: boolean;
   kind?: 'read' | 'write';
   annotations?: { destructiveHint?: boolean };
@@ -62,7 +62,7 @@ export function resolveActionMode(
   config: Record<string, unknown> | null | undefined
 ): ActionMode {
   const modes = getActionModes(config);
-  return modes[operation.operation_key] ?? defaultModeFromOperation(operation);
+  return modes[operation.operation_key] ?? defaultActionModeForOperation(operation);
 }
 
 /**

--- a/packages/server/src/operations/connector-operations.ts
+++ b/packages/server/src/operations/connector-operations.ts
@@ -555,7 +555,7 @@ export async function listOperations(params: {
 	limit?: number;
 	offset?: number;
 }): Promise<{
-	operations: AvailableOperation[];
+	operations: OperationDescriptor[];
 	total: number;
 	limit: number;
 	offset: number;

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -529,7 +529,8 @@ export default async (_ctx, client) => {
 		access: "external",
 	},
 	"operations.listAvailable": {
-		summary: "List operations exposed by the active connections.",
+		summary:
+			"Search declared connector capabilities, including disconnected connectors. Returns readiness plus every visible execution target; backend configuration is never exposed.",
 		access: "read",
 	},
 	"operations.execute": {

--- a/packages/server/src/sandbox/namespaces/operations.ts
+++ b/packages/server/src/sandbox/namespaces/operations.ts
@@ -23,7 +23,19 @@ export interface OperationsExecuteInput {
 
 export interface OperationsNamespace {
 	manage(input: Record<string, unknown>): Promise<unknown>;
-	listAvailable(input?: { entity_id?: number }): Promise<unknown>;
+	listAvailable(input?: {
+		connector_key?: string;
+		connection_id?: number;
+		entity_id?: number;
+		kind?: "read" | "write";
+		backend?: "local_action" | "mcp_tool" | "http_operation";
+		query?: string;
+		include_disconnected?: boolean;
+		include_input_schema?: boolean;
+		include_output_schema?: boolean;
+		limit?: number;
+		offset?: number;
+	}): Promise<unknown>;
 	execute(input: OperationsExecuteInput): Promise<unknown>;
 	listRuns(input?: {
 		connection_id?: number;

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -34,24 +34,36 @@ import {
 	agentExistsInOrg,
 	resolveActingPrincipal,
 	resolveWatcherOwner,
-	resolveWriteEffect,
+	resolveWriteEffects,
 	resolveWritePolicyDecision,
 	watcherIdFromPrincipalId,
 } from "../../authz/entity-policy";
+import { compileConnectionRowVisibility } from "../../authz/connection-visibility";
+import { authzScopeFromToolContext } from "../../authz/scope";
 import { notifyActionApprovalNeeded } from "../../notifications/triggers";
-import { resolveActionMode } from "../../operations/action-modes";
+import {
+	defaultActionModeForOperation,
+	getActionModes,
+	resolveActionMode,
+} from "../../operations/action-modes";
 import {
 	getOperationForConnection,
 	listOperations,
 } from "../../operations/connector-operations";
 import { validateOperationInput } from "../../operations/input-validation";
-import type { OperationDescriptor } from "../../operations/types";
+import type {
+	AvailableOperation,
+	OperationDescriptor,
+} from "../../operations/types";
 import { createConnectorOperationRun } from "../../runs/queue-service";
 import { resolveConnectorCode } from "../../utils/ensure-connector-installed";
 import { resolveExecutionAuth } from "../../utils/execution-context";
 import { insertEvent } from "../../utils/insert-event";
 import logger from "../../utils/logger";
-import { buildResourcePermalink } from "../../utils/url-builder";
+import {
+	buildConnectionsUrl,
+	buildResourcePermalink,
+} from "../../utils/url-builder";
 import { trackWatcherReaction } from "../../utils/watcher-reactions";
 import { dispatchChromeActionToExtension } from "../../worker-api/dispatch-chrome-action";
 import { isAdminOrOwnerRole } from "../access-control";
@@ -93,6 +105,33 @@ type ConnectionRow = {
   name: string;
 };
 
+type ExecutionTarget = {
+	connection_id: number;
+	slug: string;
+	display_name: string;
+	status: string;
+	executable: boolean;
+	reason: string;
+};
+
+type InternalExecutionTarget = ExecutionTarget & {
+	config: Record<string, unknown> | null;
+	auth_profile_kind: string | null;
+};
+
+type OperationTargetRow = {
+	id: number;
+	connector_key: string;
+	slug: string;
+	display_name: string | null;
+	status: string;
+	config: Record<string, unknown> | null;
+	device_worker_id: string | null;
+	device_online: boolean;
+	device_bound: boolean;
+	auth_profile_kind: string | null;
+};
+
 /**
  * The write-gate scope key for one connector operation: `${connector_key}::${op}`.
  * Operation keys (e.g. `send_message`, `create_issue`, `navigate`) are NOT unique
@@ -109,7 +148,7 @@ export function qualifiedOperationKey(
   return `${connectorKey}::${operationKey}`;
 }
 
-const manageOperationsTool = defineActionTool('manage_operations', {
+const manageOperationsTool = defineActionTool("manage_operations", {
   list_available: action(ListAvailableAction, handleListAvailable),
   execute: action(ExecuteAction, handleExecute),
   list_runs: action(ListRunsAction, handleListRuns),
@@ -158,7 +197,11 @@ export function buildActionConfig(
 	connectionCredentials: Record<string, unknown>,
 	connectionConfig: Record<string, unknown> | null | undefined,
 ): Record<string, unknown> {
-  return { ...envStrings, ...connectionCredentials, ...(connectionConfig ?? {}) };
+	return {
+		...envStrings,
+		...connectionCredentials,
+		...(connectionConfig ?? {}),
+	};
 }
 
 async function executeLocalActionInline(
@@ -280,30 +323,41 @@ async function executeMcpToolInline(
 	operation: OperationDescriptor,
 	actionInput: Record<string, unknown>,
 ): Promise<InlineExecutionResult> {
-  if (operation.backend_config.backend !== 'mcp_tool') {
-    return { status: 'failed', error_message: 'Invalid MCP operation backend config' };
+	if (operation.backend_config.backend !== "mcp_tool") {
+		return {
+			status: "failed",
+			error_message: "Invalid MCP operation backend config",
+		};
   }
 
-  const result = await callProxyTool(
+	let result: Awaited<ReturnType<typeof callProxyTool>>;
+	try {
+		result = await callProxyTool(
     connection.connector_key,
     {
       upstream_url: operation.backend_config.upstreamUrl,
-      tool_prefix: '',
+				tool_prefix: "",
     },
     organizationId,
     operation.backend_config.toolName,
-    actionInput
+			actionInput,
+			connection.id,
   );
+	} catch (error) {
+		return failRunInline(runId, organizationId, getErrorMessage(error));
+	}
 
   if (result.isError) {
     const errorText =
       (result.content as Array<{ type: string; text?: string }>).find(
-        (item) => item?.type === 'text'
-      )?.text ?? 'Upstream MCP error';
+				(item) => item?.type === "text",
+			)?.text ?? "Upstream MCP error";
     return failRunInline(runId, organizationId, errorText);
   }
 
-  return completeRunInline(runId, organizationId, { content: result.content } as Record<string, unknown>);
+	return completeRunInline(runId, organizationId, {
+		content: result.content,
+	} as Record<string, unknown>);
 }
 
 function buildResolvedUrl(
@@ -339,12 +393,19 @@ function buildResolvedUrl(
 	return url;
 }
 
-function pickInterestingHeaders(headers: Headers): Record<string, unknown> | undefined {
-  const interestingHeaders = ['content-type', 'x-ratelimit-remaining', 'x-ratelimit-reset', 'link'];
+function pickInterestingHeaders(
+	headers: Headers,
+): Record<string, unknown> | undefined {
+	const interestingHeaders = [
+		"content-type",
+		"x-ratelimit-remaining",
+		"x-ratelimit-reset",
+		"link",
+	];
   const values = Object.fromEntries(
     interestingHeaders
       .map((header) => [header, headers.get(header)])
-      .filter(([, value]) => value !== null)
+			.filter(([, value]) => value !== null),
   );
   return Object.keys(values).length > 0 ? values : undefined;
 }
@@ -470,7 +531,7 @@ async function executeOperationInline(
 	env: Env,
 	abortSignal?: AbortSignal,
 ): Promise<InlineExecutionResult> {
-  if (operation.backend === 'local_action') {
+	if (operation.backend === "local_action") {
     return executeLocalActionInline(
       runId,
       organizationId,
@@ -478,19 +539,357 @@ async function executeOperationInline(
       operation,
       actionInput,
       env,
-      abortSignal
+			abortSignal,
     );
   }
-  if (operation.backend === 'mcp_tool') {
-    return executeMcpToolInline(runId, organizationId, connection, operation, actionInput);
+	if (operation.backend === "mcp_tool") {
+		return executeMcpToolInline(
+			runId,
+			organizationId,
+			connection,
+			operation,
+			actionInput,
+		);
   }
-  return executeHttpOperationInline(runId, organizationId, connection, operation, actionInput);
+	return executeHttpOperationInline(
+		runId,
+		organizationId,
+		connection,
+		operation,
+		actionInput,
+	);
+}
+
+function executionTargetFromRow(row: OperationTargetRow): InternalExecutionTarget {
+	const base = {
+		connection_id: Number(row.id),
+		slug: row.slug,
+		display_name: row.display_name ?? row.slug,
+		config: row.config,
+		auth_profile_kind: row.auth_profile_kind,
+	};
+	if (row.status !== "active") {
+		return {
+			...base,
+			status: row.status,
+			executable: false,
+			reason: `Connection status is ${row.status}.`,
+		};
+	}
+	if (row.device_bound && !row.device_online) {
+		return {
+			...base,
+			status: "device_offline",
+			executable: false,
+			reason: "The connection's paired device is offline.",
+		};
+	}
+	return {
+		...base,
+		status: "ready",
+		executable: true,
+		reason: "Connection is ready for execution.",
+	};
+}
+
+function groupExecutionTargets(
+	rows: OperationTargetRow[],
+): Map<string, InternalExecutionTarget[]> {
+	const grouped = new Map<string, InternalExecutionTarget[]>();
+	for (const row of rows) {
+		const targets = grouped.get(row.connector_key) ?? [];
+		targets.push(executionTargetFromRow(row));
+		grouped.set(row.connector_key, targets);
+	}
+	return grouped;
+}
+
+function operationReadinessReason(
+	readiness: string,
+	executable: boolean,
+): string {
+	if (executable) return "At least one visible connection is ready.";
+	if (readiness === "disconnected") {
+		return "No visible connection exists for this connector.";
+	}
+	if (readiness === "device_offline") {
+		return "Every visible active device-bound connection is offline.";
+	}
+	if (readiness === "disabled") {
+		return "This operation is disabled on every visible connection.";
+	}
+	return `A visible connection has status ${readiness}.`;
+}
+
+function resolveOperationReadiness(targets: ExecutionTarget[]): {
+	readyTarget: ExecutionTarget | undefined;
+	executable: boolean;
+	readiness: string;
+} {
+	const readyTarget = targets.find((target) => target.executable);
+	if (readyTarget) {
+		return { readyTarget, executable: true, readiness: "ready" };
+	}
+	if (targets.length === 0) {
+		return { readyTarget: undefined, executable: false, readiness: "disconnected" };
+	}
+	if (targets.every((target) => target.status === "disabled")) {
+		return { readyTarget: undefined, executable: false, readiness: "disabled" };
+	}
+	return {
+		readyTarget: undefined,
+		executable: false,
+		readiness:
+			targets.find((target) => target.status !== "disabled")?.status ??
+			"inactive",
+	};
+}
+
+function operationMatchesQuery(
+	operation: AvailableOperation & Record<string, unknown>,
+	queryTokens: string[],
+): boolean {
+	if (queryTokens.length === 0) return true;
+	const haystack = [
+		operation.connector_key,
+		operation.connector_name,
+		operation.operation_key,
+		operation.name,
+		operation.description ?? "",
+		JSON.stringify(operation.input_schema ?? {}),
+	]
+		.join(" ")
+		.toLocaleLowerCase();
+	return queryTokens.every((token) => haystack.includes(token));
+}
+
+function buildOperationNextAction(args: {
+	operation: OperationDescriptor;
+	readyTarget: ExecutionTarget | undefined;
+	readiness: string;
+	remediationTarget: ExecutionTarget | undefined;
+	remediationConfig: Record<string, unknown> | null | undefined;
+	remediationAuthKind: string | null | undefined;
+	viewUrl: string | undefined;
+}): Record<string, unknown> {
+	const {
+		operation,
+		readyTarget,
+		readiness,
+		remediationTarget,
+		remediationConfig,
+		remediationAuthKind,
+		viewUrl,
+	} = args;
+	if (readyTarget) {
+		const requiredInput =
+			Array.isArray(operation.input_schema?.required) &&
+			operation.input_schema.required.length > 0;
+		if (requiredInput) {
+			return {
+				action: "provide_input",
+				sdk_method: "operations.execute",
+				requires_input: true,
+				input_schema: operation.input_schema,
+				arguments: [
+					{
+						connection_id: readyTarget.connection_id,
+						operation_key: operation.operation_key,
+					},
+				],
+			};
+		}
+		return {
+			action: "execute",
+			sdk_method: "operations.execute",
+			arguments: [
+				{
+					connection_id: readyTarget.connection_id,
+					operation_key: operation.operation_key,
+					input: {},
+				},
+			],
+		};
+	}
+	if (readiness === "disconnected") {
+		return {
+			action: "connect",
+			sdk_method: "connections.connect",
+			arguments: [{ connector_key: operation.connector_key }],
+		};
+	}
+	if (readiness === "disabled") {
+		return {
+			action: "enable_operation",
+			sdk_method: "connections.update",
+			arguments: [
+				{
+					connection_id: remediationTarget?.connection_id,
+					config: {
+						action_modes: {
+							...getActionModes(remediationConfig),
+							[operation.operation_key]:
+								defaultActionModeForOperation(operation),
+						},
+					},
+				},
+			],
+		};
+	}
+	if (readiness === "paused") {
+		return {
+			action: "resume_connection",
+			sdk_method: "connections.update",
+			arguments: [
+				{ connection_id: remediationTarget?.connection_id, status: "active" },
+			],
+		};
+	}
+	if (
+		["pending_auth", "error", "revoked"].includes(readiness) &&
+		remediationAuthKind === "interactive"
+	) {
+		return {
+			action: "reauthenticate",
+			sdk_method: "connections.reauthenticate",
+			arguments: [remediationTarget?.connection_id],
+			...(viewUrl ? { view_url: viewUrl } : {}),
+		};
+	}
+	return {
+		action:
+			readiness === "device_offline" ? "bring_device_online" : "open_setup",
+		manual: true,
+		...(viewUrl ? { view_url: viewUrl } : {}),
+	};
+}
+
+function buildAvailableOperation(args: {
+	operation: OperationDescriptor;
+	internalTargets: InternalExecutionTarget[];
+	includeInputSchema: boolean;
+	viewUrl: string | undefined;
+}): AvailableOperation & Record<string, unknown> {
+	const { operation, internalTargets, includeInputSchema, viewUrl } = args;
+	const { backend_config: _privateBackendConfig, ...publicOperation } = operation;
+	const targets = internalTargets.map((target): ExecutionTarget => {
+		const {
+			config,
+			auth_profile_kind: _authProfileKind,
+			...publicTarget
+		} = target;
+		if (resolveActionMode(operation, config) !== "disabled") {
+			return publicTarget;
+		}
+		return {
+			...publicTarget,
+			status: "disabled",
+			executable: false,
+			reason: "This operation is disabled on the connection.",
+		};
+	});
+	const { readyTarget, executable, readiness } =
+		resolveOperationReadiness(targets);
+	const remediationTarget =
+		targets.find((target) => target.status === readiness) ?? targets[0];
+	const remediationInternalTarget = internalTargets.find(
+		(target) => target.connection_id === remediationTarget?.connection_id,
+	);
+	return {
+		...(publicOperation as AvailableOperation),
+		...(includeInputSchema ? {} : { input_schema: undefined }),
+		executable,
+		readiness,
+		reason: operationReadinessReason(readiness, executable),
+		connection_count: targets.length,
+		execution_targets: targets,
+		next_action: buildOperationNextAction({
+			operation,
+			readyTarget,
+			readiness,
+			remediationTarget,
+			remediationConfig: remediationInternalTarget?.config,
+			remediationAuthKind: remediationInternalTarget?.auth_profile_kind,
+			viewUrl,
+		}),
+	};
+}
+
+async function loadVisibleOperationTargets(
+	args: Static<typeof ListAvailableAction>,
+	ctx: ToolContext,
+): Promise<OperationTargetRow[]> {
+	const visibility = compileConnectionRowVisibility(
+		authzScopeFromToolContext(ctx),
+		2,
+		"c",
+	);
+	return (await getDb().unsafe(
+		`SELECT c.id,
+		        c.connector_key,
+		        c.slug,
+		        c.display_name,
+		        c.status,
+		        c.config,
+		        c.device_worker_id,
+		        ap.profile_kind AS auth_profile_kind,
+		        COALESCE(dw.last_seen_at > now() - interval '20 minutes', false) AS device_online,
+		        (c.device_worker_id IS NOT NULL OR latest.runtime IS NOT NULL) AS device_bound
+		 FROM connections c
+		 LEFT JOIN device_workers dw ON dw.id = c.device_worker_id
+		 LEFT JOIN auth_profiles ap ON ap.id = c.auth_profile_id
+		 LEFT JOIN LATERAL (
+		   SELECT cd.runtime
+		   FROM connector_definitions cd
+		   WHERE cd.organization_id = c.organization_id
+		     AND cd.key = c.connector_key
+		     AND cd.status = 'active'
+		   ORDER BY cd.updated_at DESC, cd.id DESC
+		   LIMIT 1
+		 ) latest ON TRUE
+		 WHERE c.organization_id = $1
+		   AND c.deleted_at IS NULL
+		   ${visibility.sql}
+		   AND ($3::bigint IS NULL OR c.id = $3)
+		   AND ($4::text IS NULL OR c.connector_key = $4)
+		   AND ($5::bigint IS NULL OR EXISTS (
+		     SELECT 1 FROM feeds f
+		     WHERE f.connection_id = c.id
+		       AND f.deleted_at IS NULL
+		       AND $5 = ANY(f.entity_ids)
+		   ))
+		 ORDER BY c.connector_key, c.id`,
+		[
+			ctx.organizationId,
+			...visibility.params,
+			args.connection_id ?? null,
+			args.connector_key ?? null,
+			args.entity_id ?? null,
+		],
+	)) as unknown as OperationTargetRow[];
 }
 
 async function handleListAvailable(
 	args: Static<typeof ListAvailableAction>,
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
+	const targetRows = await loadVisibleOperationTargets(args, ctx);
+
+	// An explicit connection filter is also an authorization lookup. Returning
+	// an empty list for a hidden/private connection avoids leaking its connector
+	// key through the operation catalog.
+	if (args.connection_id !== undefined && targetRows.length === 0) {
+		return {
+			action: "list_available",
+			operations: [],
+			total: 0,
+			limit: args.limit ?? 100,
+			offset: args.offset ?? 0,
+		};
+	}
+
+	const targetsByConnector = groupExecutionTargets(targetRows);
+
   // A `disabled` connector_action effect turns an operation OFF for this principal
   // — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
   // which surface then gate on execute). Two levels now: the BLANKET `execute` rule
@@ -502,34 +901,30 @@ async function handleListAvailable(
     agentId: ctx.agentId,
     sessionWatcherId: ctx.actingWatcherId ?? null,
   });
-  const effectFor = (operationKey?: string | null) =>
-    resolveWriteEffect({
-      organizationId: ctx.organizationId,
-      resourceClass: 'connector_action',
-      principalKind: actor.kind,
-      principalId: actor.id,
-      ownerAgentId: actor.ownerAgentId,
-      ownerResolved: actor.ownerResolved,
-      action: 'execute',
-      operationKey: operationKey ?? null,
-    });
-  // Blanket disable hides WRITE ops only — reads always list (policy is write-only).
-  const blanketDisabled = (await effectFor(null)) === 'disabled';
-
   // Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
   // ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
   // its hidden count from the global total gives an inconsistent `total` across pages
   // and can return a short page while visible ops remain past the offset (a client
   // treating "short page = end" would silently truncate the catalog). Pagination must
   // run on the post-filter list.
+	// For an explicit connection, targetRows already performed the visibility and
+	// authorization lookup. Query the connector catalog by that row's key instead
+	// of applying listOperations' legacy per-connection action-mode filter; the
+	// readiness mapper below must retain disabled capabilities and explain how to
+	// enable them.
+	const catalogConnectorKey =
+		args.connection_id !== undefined
+			? targetRows[0]?.connector_key
+			: args.connector_key;
   const full = await listOperations({
     organizationId: ctx.organizationId,
-    connectorKey: args.connector_key,
-    connectionId: args.connection_id,
+		connectorKey: catalogConnectorKey,
     entityId: args.entity_id,
     kind: args.kind,
     backend: args.backend,
-    includeInputSchema: args.include_input_schema ?? true,
+		// Required-input detection still needs the schema when the caller hides the
+		// descriptor copy from the public response.
+		includeInputSchema: true,
     includeOutputSchema: args.include_output_schema ?? false,
     // Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
     // would silently drop ops past index 100 and make them unreachable at any
@@ -538,26 +933,70 @@ async function handleListAvailable(
     limit: Number.MAX_SAFE_INTEGER,
     offset: 0,
   });
+	const qualifiedWriteKeys = full.operations
+		.filter((operation) => operation.kind === "write")
+		.map((operation) =>
+			qualifiedOperationKey(operation.connector_key, operation.operation_key),
+		);
+	const policyEffects = await resolveWriteEffects({
+		organizationId: ctx.organizationId,
+		resourceClass: "connector_action",
+		principalKind: actor.kind,
+		principalId: actor.id,
+		ownerAgentId: actor.ownerAgentId,
+		ownerResolved: actor.ownerResolved,
+		action: "execute",
+		operationKeys: qualifiedWriteKeys,
+	});
+	const blanketDisabled = policyEffects.get(null) === "disabled";
 
   // Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
   // filtered by agent write-policy. Humans always resolve auto for policy.
-  const visibleFlags = await Promise.all(
-    full.operations.map(async (op) => {
-      if (op.kind === 'read') return 'auto' as const;
-      if (blanketDisabled) return 'disabled' as const;
-      return effectFor(qualifiedOperationKey(op.connector_key, op.operation_key));
-    }),
+	const visibleFlags = full.operations.map((op) => {
+			if (op.kind === "read") return "auto" as const;
+			if (blanketDisabled) return "disabled" as const;
+			return (
+				policyEffects.get(
+					qualifiedOperationKey(op.connector_key, op.operation_key),
+				) ?? "auto"
   );
-  const visible = full.operations.filter(
-    (_op, i) => visibleFlags[i] !== 'disabled',
+		});
+	const policyVisible = full.operations.filter(
+		(_op, i) => visibleFlags[i] !== "disabled",
   );
 
+	const queryTokens = (args.query ?? "")
+		.toLocaleLowerCase()
+		.split(/\s+/)
+		.filter(Boolean);
+	const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
+	const connectorViewUrl = (connectorKey: string): string | undefined =>
+		ownerSlug && baseUrl
+			? buildConnectionsUrl(ownerSlug, baseUrl, connectorKey)
+			: undefined;
+	const publicOperations = policyVisible
+		.map((operation) =>
+			buildAvailableOperation({
+				operation,
+				internalTargets:
+					targetsByConnector.get(operation.connector_key) ?? [],
+				includeInputSchema: args.include_input_schema !== false,
+				viewUrl: connectorViewUrl(operation.connector_key),
+			}),
+		)
+		.filter((operation) => {
+			if (args.include_disconnected === false && !operation.executable) {
+				return false;
+			}
+			return operationMatchesQuery(operation, queryTokens);
+		});
+
   const offset = args.offset ?? 0;
-  const limit = args.limit ?? visible.length;
+	const limit = args.limit ?? 100;
   return {
-    action: 'list_available',
-    operations: visible.slice(offset, offset + limit),
-    total: visible.length,
+		action: "list_available",
+		operations: publicOperations.slice(offset, offset + limit),
+		total: publicOperations.length,
     limit,
     offset,
   };
@@ -666,7 +1105,7 @@ export async function waitForDeviceActionRun(
     UPDATE runs
     SET status = 'timeout',
         completed_at = current_timestamp,
-        error_message = ${'waitForDeviceActionRun: device worker did not complete in time'}
+        error_message = ${"waitForDeviceActionRun: device worker did not complete in time"}
     WHERE id = ${runId}
       AND organization_id = ${organizationId}
       AND status IN ('pending', 'running')
@@ -716,6 +1155,23 @@ async function handleExecute(
 	env: Env,
 ): Promise<ManageOperationsResult> {
 	const sql = getDb();
+	const scope = authzScopeFromToolContext(ctx);
+	const visibility = compileConnectionRowVisibility(scope, 3, "c");
+	const visibleRows = await sql.unsafe(
+		`SELECT 1
+		 FROM connections c
+		 WHERE c.organization_id = $1
+		   AND c.id = $2
+		   AND c.deleted_at IS NULL
+		   ${visibility.sql}
+		 LIMIT 1`,
+		[ctx.organizationId, args.connection_id, ...visibility.params],
+	);
+	if (visibleRows.length === 0) {
+		return {
+			error: "Connection not found or not visible.",
+		};
+	}
 	const resolved = await getOperationForConnection(
 		ctx.organizationId,
 		args.connection_id,
@@ -791,7 +1247,8 @@ async function handleExecute(
 			error: `Policy denies '${operation.operation_key}' for this principal.`,
 		};
 	}
-	const shouldQueue = mode === "approval" || policyDecision === "require_approval";
+	const shouldQueue =
+		mode === "approval" || policyDecision === "require_approval";
 
 	// Detect device-bound connector by reading the connector definition's
 	// `runtime` field. When set (e.g. chrome-extension, macos, ios), the
@@ -1064,7 +1521,7 @@ async function handleListRuns(
   const [countResult, rows] = await Promise.all([countQuery, query]);
 
   return {
-    action: 'list_runs',
+		action: "list_runs",
     runs: rows,
     total: Number(countResult[0]?.total ?? 0),
     limit,
@@ -1089,8 +1546,8 @@ async function handleGetRun(
       AND r.run_type = 'action'
     LIMIT 1
   `;
-  if (rows.length === 0) return { error: 'Run not found' };
-  return { action: 'get_run', run: rows[0] };
+	if (rows.length === 0) return { error: "Run not found" };
+	return { action: "get_run", run: rows[0] };
 }
 
 /**
@@ -1201,7 +1658,9 @@ export async function supersedeActionEvent(
  * are web-session only (`ctx.clientId` is rejected upstream), so `ctx.userId` is
  * always a real human here; we still guard on null for safety.
  */
-async function resolveReviewer(ctx: ToolContext): Promise<ApprovalReviewer | null> {
+async function resolveReviewer(
+	ctx: ToolContext,
+): Promise<ApprovalReviewer | null> {
   if (!ctx.userId) return null;
   const rows = await getDb()<{ name: string | null }>`
     SELECT name FROM "user" WHERE id = ${ctx.userId} LIMIT 1
@@ -1537,7 +1996,7 @@ async function claimEntityChangeRun(
       : await sql`
           UPDATE runs
           SET approval_status = 'rejected', status = 'cancelled',
-              error_message = ${rejectReason ?? 'Rejected by user'}, completed_at = NOW()
+              error_message = ${rejectReason ?? "Rejected by user"}, completed_at = NOW()
           WHERE id = ${runId}
             AND organization_id = ${organizationId}
             AND approval_status = 'pending'
@@ -2145,7 +2604,10 @@ async function handleApproveBatch(
 ): Promise<ManageOperationsResult> {
 	const humanGate = requireHumanApprovalContext(ctx, "approve");
 	if (humanGate) return humanGate;
-	const runIds = await pendingRunIdsForWindow(args.window_id, ctx.organizationId);
+	const runIds = await pendingRunIdsForWindow(
+		args.window_id,
+		ctx.organizationId,
+	);
 	if (runIds.length === 0) {
 		return {
 			action: "approve_batch",
@@ -2159,7 +2621,11 @@ async function handleApproveBatch(
 	let approved = 0;
 	let failed = 0;
 	for (const runId of runIds) {
-		const result = await handleApprove({ action: "approve", run_id: runId }, ctx, env);
+		const result = await handleApprove(
+			{ action: "approve", run_id: runId },
+			ctx,
+			env,
+		);
 		if ("error" in result) failed += 1;
 		else approved += 1;
 	}
@@ -2218,11 +2684,17 @@ async function handleRejectBatch(
 ): Promise<ManageOperationsResult> {
 	const humanGate = requireHumanApprovalContext(ctx, "reject");
 	if (humanGate) return humanGate;
-	const runIds = await pendingRunIdsForWindow(args.window_id, ctx.organizationId);
+	const runIds = await pendingRunIdsForWindow(
+		args.window_id,
+		ctx.organizationId,
+	);
 	const reason = args.reason ?? "Rejected by user";
 	let rejected = 0;
 	for (const runId of runIds) {
-		const result = await handleReject({ action: "reject", run_id: runId, reason }, ctx);
+		const result = await handleReject(
+			{ action: "reject", run_id: runId, reason },
+			ctx,
+		);
 		if (!("error" in result)) rejected += 1;
 	}
 	if (rejected > 0) {

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -155,11 +155,13 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
         cd.mcp_config,
         cd.openapi_config
       FROM connector_definitions cd
-      INNER JOIN connections c
-        ON c.connector_key = cd.key
-        AND c.organization_id = ${organizationId}
       WHERE cd.status = 'active'
         AND cd.organization_id = ${organizationId}
+        AND (
+          cd.actions_schema IS NOT NULL
+          OR cd.mcp_config IS NOT NULL
+          OR cd.openapi_config IS NOT NULL
+        )
       ORDER BY cd.key
     `;
 
@@ -174,7 +176,8 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
         // `execute` dispatches on, and showing it invites the agent to look
         // for a separate MCP/HTTP tool that does not exist.
         'Run any connector operation the same way: `run_sdk` → `client.operations.execute({ connection_id, operation_key, input })`. There is no separate per-connector tool.',
-        'Discover `operation_key`s and input schemas with `query_sdk` → `client.operations.listAvailable()`; get the `connection_id` with `client.connections.list()`.',
+        'Discover capabilities with `query_sdk` → `client.operations.listAvailable({ query: "..." })`. It includes disconnected connectors, readiness, and every visible `execution_targets` entry; use the returned target directly instead of guessing a connection id.',
+        'When readiness is disconnected, call the returned `next_action`. `connections.connect` / `connections.create` may return `status: "setup_required"`: show its resolved setup/install URL, follow `next_action`, then invoke `resume_call` or poll `completion_check` exactly as returned.',
         'Execution may be policy-gated: a gated op returns `status: "pending_approval"` (a run queued for a human). Surface that to the user rather than treating it as a failure.'
       );
       for (const conn of operationConnections) {


### PR DESCRIPTION
## Summary
- keep connector actions discoverable before a connection exists, with readiness, targets, next actions, and input schemas
- execute local, device, HTTP, and upstream MCP connector actions through the selected connection without exposing backend configuration or credentials
- batch authorization checks and cover every bundled connector/action lifecycle end to end

## Validation
- `make build-packages`
- 52 focused operation/lifecycle tests
- `bun run --cwd packages/server typecheck`
- `bun run --cwd packages/core typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786587209&installation_id=136316292&pr_number=1929&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1929&signature=aaf9e74448817af2d367883e349259ad39df114eee7f4131609a24e0d6b28c00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->