### PR TITLE
fix reviewer model allowlist

### DIFF
--- a/docs/REVIEW_SCHEMA.md
+++ b/docs/REVIEW_SCHEMA.md
@@ -13,7 +13,10 @@ commit is refused so the `pi-review` status has exactly one owner per sha. Codex
 environments, including Claude Code, use Codex. Set
 `REVIEWER_CLI=codex|claude` to override automatic selection. The script
 also accepts `CLAUDE_REVIEW_MODEL`, `CLAUDE_REVIEW_EFFORT`, and
-`CODEX_REVIEW_MODEL` overrides. It posts a `pi-review` commit status
+`CODEX_REVIEW_MODEL` overrides. Claude reviews fail closed unless
+`CLAUDE_REVIEW_MODEL` is `fable`, `opus`, or a full `claude-opus-*` model ID;
+Sonnet, Haiku, empty, and arbitrary model values are rejected before the
+review starts. It posts a `pi-review` commit status
 whenever GitHub auth is available; if a PR exists for the current branch, it
 also posts an idempotent PR comment (marker-keyed upsert) with the verdict.
 **GitHub Actions does not run the agent review** — it's a local-driven gate

--- a/scripts/lib/__tests__/review-reviewer.test.sh
+++ b/scripts/lib/__tests__/review-reviewer.test.sh
@@ -42,6 +42,17 @@ if review_select_reviewer invalid >/dev/null 2>&1; then
   fail "invalid reviewer override unexpectedly succeeded"
 fi
 
+for allowed_model in fable opus claude-opus-4-6 claude-opus-4-5-20251101; do
+  review_validate_claude_model "$allowed_model" ||
+    fail "allowed Claude reviewer model '$allowed_model' was rejected"
+done
+
+for rejected_model in "" sonnet claude-sonnet-4-6 haiku claude-haiku-4-5 arbitrary; do
+  if review_validate_claude_model "$rejected_model" >/dev/null 2>&1; then
+    fail "disallowed Claude reviewer model '$rejected_model' was accepted"
+  fi
+done
+
 review_should_retry_inline 0 "" || fail "empty successful output did not request an inline retry"
 review_should_retry_inline 0 $' \n\t' || fail "whitespace-only successful output did not request an inline retry"
 if review_should_retry_inline 0 '{"ok":true}'; then
@@ -68,6 +79,9 @@ esac
 review_script="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/review.sh"
 grep -Fq 'CLAUDE_REVIEW_MODEL="${CLAUDE_REVIEW_MODEL:-fable}"' "$review_script" ||
   fail "Claude reviewer must default to the Fable model"
+
+grep -Fq 'review_validate_claude_model "$CLAUDE_REVIEW_MODEL"' "$review_script" ||
+  fail "review.sh must fail closed on disallowed Claude reviewer models"
 
 schema_arg_count="$(grep -F -- '--json-schema "$(cat "$SCHEMA_FILE")"' "$review_script" | wc -l | tr -d ' ')"
 [ "$schema_arg_count" -eq 2 ] ||

--- a/scripts/lib/review-reviewer.sh
+++ b/scripts/lib/review-reviewer.sh
@@ -25,6 +25,16 @@ review_select_reviewer() {
   esac
 }
 
+review_validate_claude_model() {
+  case "$1" in
+    fable|opus|claude-opus-?*) return 0 ;;
+    *)
+      echo "invalid CLAUDE_REVIEW_MODEL=$1 (only fable, opus, or a claude-opus-* model is allowed)" >&2
+      return 2
+      ;;
+  esac
+}
+
 review_should_retry_inline() {
   [ "$1" -eq 0 ] || return 1
   [ -z "$(printf '%s' "$2" | tr -d '[:space:]')" ]

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -91,6 +91,9 @@ while [ $# -gt 0 ]; do
 done
 
 REVIEWER_CLI_SELECTED="$(review_select_reviewer "$REVIEWER_CLI")"
+if [ "$REVIEWER_CLI_SELECTED" = "claude" ]; then
+  review_validate_claude_model "$CLAUDE_REVIEW_MODEL"
+fi
 command -v "$REVIEWER_CLI_SELECTED" >/dev/null 2>&1 || {
   review_fail_closed_message "$REVIEWER_CLI_SELECTED" "command not found on PATH" >&2
   exit 2

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -92,7 +92,7 @@ done
 
 REVIEWER_CLI_SELECTED="$(review_select_reviewer "$REVIEWER_CLI")"
 if [ "$REVIEWER_CLI_SELECTED" = "claude" ]; then
-  review_validate_claude_model "$CLAUDE_REVIEW_MODEL"
+  review_validate_claude_model "$CLAUDE_REVIEW_MODEL" || exit $?
 fi
 command -v "$REVIEWER_CLI_SELECTED" >/dev/null 2>&1 || {
   review_fail_closed_message "$REVIEWER_CLI_SELECTED" "command not found on PATH" >&2


### PR DESCRIPTION
## Summary
- fail closed when Claude review selects anything other than Fable or Opus
- allow the `fable`/`opus` aliases and full `claude-opus-*` model IDs
- document and test rejection of Sonnet, Haiku, empty, and arbitrary models

## Validation
- red: reviewer selection test failed before validator existed
- green: `bash scripts/lib/__tests__/review-reviewer.test.sh`
- `bash -n` for the changed scripts
- live preflight: Sonnet exits 2 before review starts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786587621&installation_id=136316292&pr_number=1930&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1930&signature=28551eb0a7109b01a3cb279e417b1e5a3b058e4267707b0582ae92a290ddf8cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude-based reviews now reject unsupported or empty model selections before starting.
  * Explicit model overrides are honored consistently over default Claude selection behavior.

* **Documentation**
  * Clarified model override behavior and the supported Claude model values.

* **Tests**
  * Added coverage for accepted and rejected Claude model configurations, including fail-closed validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->