### PR TITLE
fix connector setup gateway mount URLs

### DIFF
--- a/packages/server/src/__tests__/unit/connect-base-url.test.ts
+++ b/packages/server/src/__tests__/unit/connect-base-url.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { getConnectBaseUrl } from "../../tools/admin/helpers/connection-helpers";
+import { __resetPublicOriginCachesForTests } from "../../utils/public-origin";
+
+const ORIGINAL_PUBLIC_GATEWAY_URL = process.env.PUBLIC_GATEWAY_URL;
+
+afterEach(() => {
+	if (ORIGINAL_PUBLIC_GATEWAY_URL === undefined) {
+		delete process.env.PUBLIC_GATEWAY_URL;
+	} else {
+		process.env.PUBLIC_GATEWAY_URL = ORIGINAL_PUBLIC_GATEWAY_URL;
+	}
+	__resetPublicOriginCachesForTests();
+});
+
+describe("getConnectBaseUrl", () => {
+	test("uses the configured gateway mount when the tool context has only the web origin", () => {
+		process.env.PUBLIC_GATEWAY_URL = "https://app.lobu.ai/lobu";
+		__resetPublicOriginCachesForTests();
+
+		expect(
+			getConnectBaseUrl({
+				baseUrl: "https://app.lobu.ai",
+				requestUrl: "https://app.lobu.ai/mcp",
+			} as Parameters<typeof getConnectBaseUrl>[0]),
+		).toBe("https://app.lobu.ai/lobu");
+	});
+
+	test("preserves an explicit path-aware context base in tests and self-hosted mounts", () => {
+		process.env.PUBLIC_GATEWAY_URL = "https://configured.example/lobu";
+		__resetPublicOriginCachesForTests();
+
+		expect(
+			getConnectBaseUrl({
+				baseUrl: "https://gateway.test/custom-mount/",
+			} as Parameters<typeof getConnectBaseUrl>[0]),
+		).toBe("https://gateway.test/custom-mount");
+	});
+});

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -20,6 +20,7 @@ import {
   updateAuthProfile,
 } from '../../../utils/auth-profiles';
 import { DEFAULT_SCHEDULE } from '../../../utils/cron';
+import { getConfiguredPublicGatewayUrl } from '../../../utils/public-origin';
 import {
   readGrantedScopesFromAuthData,
   readRequestedScopesFromAuthData,
@@ -440,10 +441,21 @@ export function enrichWithAuthProfiles(
 }
 
 export function getConnectBaseUrl(ctx: ToolContext): string {
-  return (ctx.baseUrl ?? (ctx.requestUrl ? new URL(ctx.requestUrl).origin : '')).replace(
-    /\/+$/,
-    ''
-  );
+  const contextBase = ctx.baseUrl?.trim().replace(/\/+$/, '');
+  if (contextBase) {
+    try {
+      const path = new URL(contextBase).pathname.replace(/\/+$/, '');
+      if (path && path !== '/') return contextBase;
+    } catch {
+      return contextBase;
+    }
+  }
+
+  return (
+    getConfiguredPublicGatewayUrl() ??
+    contextBase ??
+    (ctx.requestUrl ? new URL(ctx.requestUrl).origin : '')
+  ).replace(/\/+$/, '');
 }
 
 export async function buildViewUrl(


### PR DESCRIPTION
## Summary
- build connector install/OAuth URLs from the configured public gateway base, including its `/lobu` mount
- preserve explicit path-aware context bases for tests and custom self-hosted mounts
- prevent browser install links from falling through to the Owletto SPA 404

## Validation
- red: production-shape unit test received `https://app.lobu.ai` instead of `https://app.lobu.ai/lobu`
- green: 2/2 URL unit tests
- 29/29 connection setup integration tests
- `make build-packages`
- server typecheck
- live reproduction confirmed `/lobu/github/app/install` reaches GitHub while the old URL reaches SPA Not Found

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786588938&installation_id=136316292&pr_number=1931&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1931&signature=03fdd9c42be8abc73946d941c3cbc5812e6297a77ba6f7485cbdc6cdd262d8c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->