### PR TITLE
fix redact secrets from HTTP logs

### DIFF
--- a/packages/server/src/utils/__tests__/logger.test.ts
+++ b/packages/server/src/utils/__tests__/logger.test.ts
@@ -12,8 +12,47 @@
  * so per-file module mocks of an already-loaded singleton are unreliable.
  */
 
-import { describe, expect, it } from 'vitest';
-import { isExpectedClientFaultLog } from '../logger';
+import { describe, expect, it, vi } from 'vitest';
+import logger, { isExpectedClientFaultLog } from '../logger';
+
+describe('HTTP secret redaction', () => {
+  it('redacts credentials from request and response headers', () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    let output = '';
+
+    try {
+      logger.info(
+        {
+          req: {
+            headers: {
+              authorization: 'Bearer request-secret',
+              cookie: 'session=request-cookie',
+              'proxy-authorization': 'Basic proxy-secret',
+              'x-api-key': 'api-key-secret',
+            },
+          },
+          res: {
+            headers: {
+              'set-cookie': 'session=response-cookie',
+            },
+          },
+        },
+        'request completed',
+      );
+      output = write.mock.calls.map(([line]) => String(line)).join('');
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(output).toContain('request completed');
+    expect(output).not.toContain('request-secret');
+    expect(output).not.toContain('request-cookie');
+    expect(output).not.toContain('proxy-secret');
+    expect(output).not.toContain('api-key-secret');
+    expect(output).not.toContain('response-cookie');
+    expect(output).toContain('[redacted]');
+  });
+});
 
 describe('isExpectedClientFaultLog', () => {
   it('skips a ToolUserError regardless of status', () => {

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -34,6 +34,14 @@ const getLogLevel = (): pino.Level => {
 // and hid `column "events.search_tsv" does not exist`.
 const errSerializer = pino.stdSerializers.err;
 
+const HTTP_SECRET_HEADER_PATHS = [
+  'req.headers.authorization',
+  'req.headers.cookie',
+  'req.headers["proxy-authorization"]',
+  'req.headers["x-api-key"]',
+  'res.headers["set-cookie"]',
+] as const;
+
 /**
  * Sentry forwarding for logger.error() and logger.fatal().
  *
@@ -173,6 +181,10 @@ const logger = pino(
       level: (label) => {
         return { level: label };
       },
+    },
+    redact: {
+      paths: [...HTTP_SECRET_HEADER_PATHS],
+      censor: '[redacted]',
     },
     serializers: {
       err: errSerializer,


### PR DESCRIPTION
## Summary
- redact authorization, cookie, proxy authorization, API key, and set-cookie headers in the shared Pino logger
- add a regression test proving credential values never reach log output

## Validation
- red: logger test exposed raw request/response credential values
- green: `bun test packages/server/src/utils/__tests__/logger.test.ts` (4/4)
- `make build-packages`
- `bun run --cwd packages/server typecheck`
- pre-commit checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786590473&installation_id=136316292&pr_number=1933&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1933&signature=bd7a95f2d626273f12a3b0ef5ef2d2d44c88d501d1a5576227e40e42d52a116b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->