### PR TITLE
fix(core): remove dead mcpInstallNotified AgentSettings field

### DIFF
--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -39,8 +39,6 @@ export interface AgentSettings {
   networkConfig?: NetworkConfig;
   /** Nix environment configuration */
   nixConfig?: NixConfig;
-  /** Internal marker: MCP IDs already acknowledged to the user in chat */
-  mcpInstallNotified?: Record<string, number>;
   /** Workspace identity/instruction files (markdown content) */
   soulMd?: string;
   userMd?: string;


### PR DESCRIPTION
Removes the dead `mcpInstallNotified` field from `AgentSettings` — defined but never read/written by any store, handler, worker, UI, or test. No DB column. Part of the schema-consolidation set. Reviewed by Claude: SHIP.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786630150&installation_id=136316292&pr_number=1939&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1939&signature=9b0aa3f0656ae41c069bfcf30d30b7512d362ae4e94a69ced455942d7251c69b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an obsolete internal agent setting.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->