### PR TITLE
fix(manage_watchers): reject version-owned fields on update instead of silently dropping

### DIFF
--- a/packages/core/src/contracts/tools/manage-watchers.ts
+++ b/packages/core/src/contracts/tools/manage-watchers.ts
@@ -196,7 +196,7 @@ export const ManageWatchersSchema = Type.Object({
   sources: Type.Optional(
     Type.Array(SourceSchema, {
       description:
-        "[create/create_version/update] Array of SQL data sources. Each source is { name, query }.",
+        "[create/create_version] Array of SQL data sources. Each source is { name, query }. Sources are version-owned — to change them on an existing watcher, publish a new version with action: 'create_version'.",
     })
   ),
   keying_config: Type.Optional(

--- a/packages/server/src/__tests__/integration/tools/manage-watchers-approval-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-watchers-approval-e2e.test.ts
@@ -437,7 +437,7 @@ describe("manage_watchers — builder gate e2e", () => {
 			{
 				action: "update",
 				watcher_id: watcherId,
-				description: "A's held edit",
+				schedule: "0 9 * * *",
 			},
 			TEST_ENV,
 			agentCtx,
@@ -465,10 +465,10 @@ describe("manage_watchers — builder gate e2e", () => {
 
 		// The held edit was NOT applied.
 		const watcherRows = await sql`
-			SELECT description FROM watchers
+			SELECT schedule FROM watchers
 			WHERE id = ${watcherId} AND organization_id = ${orgId}
 		`;
-		expect(watcherRows[0]?.description).not.toBe("A's held edit");
+		expect(watcherRows[0]?.schedule).not.toBe("0 9 * * *");
 
 		// Run marked failed; card superseded to failed.
 		const runRows = await sql`

--- a/packages/server/src/__tests__/integration/tools/manage-watchers-update-version-fields.test.ts
+++ b/packages/server/src/__tests__/integration/tools/manage-watchers-update-version-fields.test.ts
@@ -1,0 +1,208 @@
+/**
+ * manage_watchers `update` — version-owned fields must not be silently dropped.
+ *
+ * Bug (red→fix→green): `WATCHER_UPDATE_PATCH_KEYS` advertised `name`,
+ * `description`, `prompt`, `sources`, and `entity_ids` as valid
+ * `update` patch fields, but `handleUpdate`'s UPDATE SET clause writes none of
+ * them — `name`/`description`/`prompt`/`sources` are version-owned (live in
+ * `watcher_versions`; the watchers-row `name` is cascaded by version
+ * activation), `entity_ids` is `create_from_version`-only. (`status` was also
+ * listed but isn't on `ManageWatchersArgs` — it's a `list` filter; the entry
+ * was dead.) So an `update` carrying any of them passed validation and
+ * returned success with `updated_fields: []` — a silent no-op the caller
+ * believed applied.
+ *
+ * Contract intent (packages/core/src/contracts/tools/manage-watchers.ts):
+ *   name/description/prompt → "[create/create_version]"
+ *   sources                 → "[create/create_version]" (update was a doc lie)
+ *   entity_ids              → "[create_from_version]"
+ *
+ * Fix: drop those keys from `WATCHER_UPDATE_PATCH_KEYS` AND explicitly reject
+ * them on `update` with a pointer to `create_version`, so a caller can never
+ * believe a version-owned change applied.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import type { AuthContext } from "../../../tools/execute";
+import { executeTool } from "../../../tools/execute";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
+import {
+	addUserToOrganization,
+	createTestAgent,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
+
+const TEST_ENV: Env = {
+	ENVIRONMENT: "test",
+	DATABASE_URL: process.env.DATABASE_URL,
+	JWT_SECRET: "test-jwt-secret-for-testing-only",
+	BETTER_AUTH_SECRET: "test-auth-secret-for-testing-only",
+	MAX_CONSECUTIVE_FAILURES: "3",
+	RATE_LIMIT_ENABLED: "false",
+};
+
+describe("manage_watchers update — version-owned fields are not silently dropped", () => {
+	let orgId: string;
+	let ownerId: string;
+	let ownerCtx: AuthContext;
+	let agentId: string;
+	let watcherId: string;
+
+	const baseCtx = (
+		orgIdValue: string,
+		userId: string,
+	): AuthContext => ({
+		organizationId: orgIdValue,
+		tokenOrganizationId: orgIdValue,
+		userId,
+		memberRole: "owner",
+		agentId: null,
+		requestedAgentId: null,
+		isAuthenticated: true,
+		clientId: null,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+		tokenType: "oauth",
+		requestUrl: `http://localhost/api/${orgIdValue}`,
+		baseUrl: "",
+		scopedToOrg: true,
+		allowCrossOrg: false,
+	});
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+
+		const org = await createTestOrganization({ name: "watcher update fields" });
+		orgId = org.id;
+		const owner = await createTestUser({ email: "wu-owner@test.com" });
+		ownerId = owner.id;
+		await addUserToOrganization(owner.id, org.id, "owner");
+		ownerCtx = baseCtx(org.id, owner.id);
+
+		const agent = await createTestAgent({
+			organizationId: org.id,
+			agentId: "wu-agent",
+			ownerUserId: owner.id,
+		});
+		agentId = agent.agentId;
+
+		const created = (await executeTool(
+			"manage_watchers",
+			{
+				action: "create",
+				slug: "wu-target",
+				name: "Original",
+				prompt: "Original prompt.",
+				agent_id: agentId,
+			},
+			TEST_ENV,
+			ownerCtx,
+		)) as { watcher_id?: string };
+		watcherId = created.watcher_id!;
+	});
+
+	async function fetchWatcherName(): Promise<string> {
+		const sql = getTestDb();
+		const rows = await sql`SELECT name FROM watchers WHERE id = ${watcherId}`;
+		return (rows[0] as { name: string }).name;
+	}
+
+	it("rejects `update` with name only (version-owned) — points to create_version", async () => {
+		await expect(
+			executeTool(
+				"manage_watchers",
+				{ action: "update", watcher_id: watcherId, name: "Renamed" },
+				TEST_ENV,
+				ownerCtx,
+			),
+		).rejects.toThrow(/create_version/i);
+		// Name unchanged — no silent partial apply.
+		expect(await fetchWatcherName()).toBe("Original");
+	});
+
+	it("rejects `update` with description only — points to create_version", async () => {
+		await expect(
+			executeTool(
+				"manage_watchers",
+				{ action: "update", watcher_id: watcherId, description: "New desc" },
+				TEST_ENV,
+				ownerCtx,
+			),
+		).rejects.toThrow(/create_version/i);
+	});
+
+	it("rejects `update` with prompt only — points to create_version", async () => {
+		await expect(
+			executeTool(
+				"manage_watchers",
+				{ action: "update", watcher_id: watcherId, prompt: "New prompt" },
+				TEST_ENV,
+				ownerCtx,
+			),
+		).rejects.toThrow(/create_version/i);
+	});
+
+	it("rejects `update` with sources only — points to create_version", async () => {
+		await expect(
+			executeTool(
+				"manage_watchers",
+				{
+					action: "update",
+					watcher_id: watcherId,
+					sources: [{ name: "content", query: "SELECT 1" }],
+				},
+				TEST_ENV,
+				ownerCtx,
+			),
+		).rejects.toThrow(/create_version/i);
+	});
+
+	it("rejects `update` with name even when a real patch field is also present (no silent drop)", async () => {
+		// name + schedule: schedule is valid, but name must NOT be silently
+		// dropped — the whole call must reject so the caller learns name needs
+		// create_version.
+		await expect(
+			executeTool(
+				"manage_watchers",
+				{
+					action: "update",
+					watcher_id: watcherId,
+					name: "Should Not Apply",
+					schedule: "0 9 * * *",
+				},
+				TEST_ENV,
+				ownerCtx,
+			),
+		).rejects.toThrow(/create_version/i);
+		expect(await fetchWatcherName()).toBe("Original");
+	});
+
+	it("still applies a legitimate update field (schedule) without name", async () => {
+		// Control: the reject path must not break real updates.
+		const res = (await executeTool(
+			"manage_watchers",
+			{ action: "update", watcher_id: watcherId, schedule: "0 9 * * *" },
+			TEST_ENV,
+			ownerCtx,
+		)) as { updated_fields?: string[] };
+		expect(res.updated_fields).toContain("schedule");
+	});
+
+	it("create_version with a new name cascades to the watchers row", async () => {
+		// Positive path: the documented way to rename a watcher.
+		await executeTool(
+			"manage_watchers",
+			{
+				action: "create_version",
+				watcher_id: watcherId,
+				name: "Renamed Via Version",
+				set_as_current: true,
+			},
+			TEST_ENV,
+			ownerCtx,
+		);
+		expect(await fetchWatcherName()).toBe("Renamed Via Version");
+	});
+});

--- a/packages/server/src/__tests__/integration/watchers/watcher-owner-escalation.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watcher-owner-escalation.test.ts
@@ -152,7 +152,7 @@ describe("manage_watchers owner-escalation guard", () => {
 				{
 					action: "update",
 					watcher_id: bWatcher.watcher_id,
-					name: "renamed-by-a",
+					schedule: "0 9 * * *",
 				},
 				TEST_ENV,
 				agentCtx(workspace.org.id, workspace.users.owner.id, agentA),

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -105,6 +105,15 @@ async function manageWatchersImpl(
 ): Promise<ManageWatchersResult> {
   const pgSql = createDbClientFromEnv(env);
 
+  // Field-level `update` validation runs before any access check or write-gate
+  // so the human-immediate and agent-approval paths reject identically (a
+  // version-owned / no-op update can never queue or apply). See
+  // {@link assertWatcherUpdateArgs} for the version-owned / entity_ids / status
+  // rationale.
+  if (args.action === 'update') {
+    assertWatcherUpdateArgs(args);
+  }
+
   // Validate organization access based on action type
   if (args.action === 'create') {
     if (args.entity_id) {
@@ -410,23 +419,6 @@ function buildWatcherProposal(
       );
     }
   }
-  if (args.action === 'update') {
-    if (args.watcher_id == null) {
-      throw new ToolUserError('watcher_id is required for update action');
-    }
-    // Reject a no-op update: with only watcher_id (or only fields handleUpdate
-    // ignores), the apply returns updated_fields:[] but the run would be marked
-    // completed and reported "applied". Require at least one patch field so the
-    // approval reflects a real change.
-    const patchKeys = WATCHER_UPDATE_PATCH_KEYS.filter(
-      (k) => args[k as keyof ManageWatchersArgs] !== undefined,
-    );
-    if (patchKeys.length === 0) {
-      throw new ToolUserError(
-        'update requires at least one field to change (e.g. name, description, prompt, schedule, agent_id).',
-      );
-    }
-  }
   if (args.action === 'delete' && (!args.watcher_ids || args.watcher_ids.length === 0)) {
     throw new ToolUserError('watcher_ids is required for delete action');
   }
@@ -470,18 +462,19 @@ const WATCHER_APPROVAL_ROUTING_KEYS = new Set(['action']);
 const WATCHER_APPROVAL_CLEARED = '(cleared)';
 
 /**
- * Fields `handleUpdate` actually patches (mirrors its `updatedFields.push` list
- * plus the direct name/description/prompt/status/sources/entity_ids columns). An
- * `update` with none of these present is a no-op that would otherwise be reported
- * as "applied" — {@link buildWatcherProposal} rejects that.
+ * Fields `handleUpdate` actually patches — mirrors its `updatedFields.push`
+ * list and the UPDATE SET clause in crud.ts exactly. Version-owned fields
+ * (name/description/prompt/sources), `entity_ids` (create_from_version-only)
+ * are intentionally ABSENT: `handleUpdate` writes
+ * none of them, so an `update` carrying any used to pass validation and return
+ * success with `updated_fields: []` — a silent no-op the caller believed
+ * applied. {@link assertWatcherUpdateArgs} rejects them up front (before the
+ * write-gate), so neither the human-immediate nor the agent-approval path can
+ * queue or apply a version-owned change via `update`.
  */
-const WATCHER_UPDATE_PATCH_KEYS = [
-  'name',
-  'description',
-  'prompt',
-  'status',
-  'sources',
-  'entity_ids',
+const VERSION_OWNED_WATCHER_FIELDS = ['name', 'description', 'prompt', 'sources'] as const;
+
+const WATCHER_PATCHABLE_FIELDS = [
   'model_config',
   'execution_config',
   'schedule',
@@ -495,6 +488,37 @@ const WATCHER_UPDATE_PATCH_KEYS = [
   'notification_priority',
   'min_cooldown_seconds',
 ] as const;
+
+/**
+ * Validate `update` args before any access check or write-gate. Both the
+ * human-immediate and the agent-approval paths flow through `manageWatchersImpl`,
+ * so calling this there makes a version-owned / no-op `update` reject
+ * identically and never reach `handleUpdate` (which would otherwise return a
+ * silent `updated_fields: []`).
+ */
+function assertWatcherUpdateArgs(args: ManageWatchersArgs): void {
+  if (args.watcher_id == null) {
+    throw new ToolUserError('watcher_id is required for update action');
+  }
+  const present = (keys: readonly string[]): string[] =>
+    keys.filter((k) => args[k as keyof ManageWatchersArgs] !== undefined);
+  const versionOwned = present(VERSION_OWNED_WATCHER_FIELDS);
+  if (versionOwned.length > 0) {
+    throw new ToolUserError(
+      `update cannot change version-owned field(s) ${versionOwned.map((f) => `'${f}'`).join(', ')} — use action: 'create_version' to publish a new watcher version (name/description/prompt/sources inherit from the current version when omitted, and the watchers-row name cascades on set_as_current).`,
+    );
+  }
+  if (args.entity_ids !== undefined) {
+    throw new ToolUserError(
+      "update cannot change entity_ids — entity targeting is set at create / create_from_version. To re-target per entity, clone a version with action: 'create_from_version'.",
+    );
+  }
+  if (present(WATCHER_PATCHABLE_FIELDS).length === 0) {
+    throw new ToolUserError(
+      'update requires at least one field to change (e.g. schedule, timezone, agent_id, tags, model_config).',
+    );
+  }
+}
 
 /**
  * Flat watcher mutation fields for the events-tab ActionApprovalCard fallback.


### PR DESCRIPTION
Fixes a silent-drop bug: `WATCHER_UPDATE_PATCH_KEYS` advertised name/description/prompt/sources/entity_ids as valid update fields, but handleUpdate never wrote them. Now rejected with a pointer to create_version. Red→green test included. Reviewed by Claude: SHIP.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786630152&installation_id=136316292&pr_number=1940&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1940&signature=5f36f680d059b585a8ac81731b81b0d93ffa427c563f11debea8281ad3e0714c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->