### PR TITLE
feat(core): AgentSettings TypeBox schema — single source for all surfaces

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,12 @@
       "import": "./dist/contracts/tools/manage-classifiers.js",
       "require": "./dist/contracts/tools/manage-classifiers.js"
     },
+    "./contracts/agent-settings": {
+      "types": "./dist/contracts/agent-settings.d.ts",
+      "bun": "./src/contracts/agent-settings.ts",
+      "import": "./dist/contracts/agent-settings.js",
+      "require": "./dist/contracts/agent-settings.js"
+    },
     "./contracts/tools/manage-agents": {
       "types": "./dist/contracts/tools/manage-agents.d.ts",
       "bun": "./src/contracts/tools/manage-agents.ts",

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -6,92 +6,34 @@
  *   - Host-provided store (embedded backend, e.g. PostgresAgentStore in Lobu)
  */
 
-import type {
-  AgentInlineGuardrail,
-  AuthProfile,
-  NetworkConfig,
-  NixConfig,
-  SkillsConfig,
-  ToolsConfig,
-} from "./types";
+import type { AgentSettingsStored } from "./contracts/agent-settings";
+import type { AuthProfile } from "./types";
 
 // ── Agent Settings ──────────────────────────────────────────────────────────
 
 /**
  * Agent settings — configurable per agentId.
  *
- * Canonical shape. Every agent store implementation conforms to this
- * interface.
+ * Canonical shape, derived from {@link AgentSettingsStoredSchema} (TypeBox) in
+ * `./contracts/agent-settings.ts` — the single source shared by every surface
+ * (declarative `lobu.config.ts`, CLI apply, admin tools, REST/MCP, Owletto UI,
+ * persistence, worker wire). Drift between surfaces is now a compile error,
+ * not a shipped-three-quarters-complete feature.
+ *
+ * `authProfiles` is the one field NOT in the stored schema: Postgres keeps it
+ * in a separate table and the GET route merges it dynamically
+ * (`agent-routes.ts:1315,1686`), so it's layered on here as a runtime-only
+ * superset field. `updatedAt` is store-owned (set by the DB on every write).
  */
-export interface AgentSettings {
-  /**
-   * Ordered list of explicit model refs `<providerSlug>/<model>`. Index 0 = the
-   * agent's default (default provider + default model). Remaining entries are
-   * the agent's alternates: fallback candidates and the pick-list for
-   * per-channel (Listen) overrides. Every slug must resolve to an org-level
-   * provider (`inference_providers` row) or a built-in module. Empty/absent ⇒
-   * all org providers (org rows AND deployment system-key providers) are
-   * available and the default falls through to the org default model.
-   */
-  models?: string[];
-  /** Network access configuration */
-  networkConfig?: NetworkConfig;
-  /** Nix environment configuration */
-  nixConfig?: NixConfig;
-  /** Workspace identity/instruction files (markdown content) */
-  soulMd?: string;
-  userMd?: string;
-  identityMd?: string;
-  /** Skills configuration loaded from local SKILL.md files. */
-  skillsConfig?: SkillsConfig;
-  /** Tool permission configuration — allowed/denied tools (worker-side visibility). */
-  toolsConfig?: ToolsConfig;
-  /**
-   * Guardrails enabled for this agent, by registered name. The gateway
-   * resolves these against its GuardrailRegistry at each stage (input,
-   * output, pre-tool) and halts the run on the first trip.
-   */
-  guardrails?: string[];
-  /**
-   * Operator-authored custom guardrails (inline LLM judges). Unlike the
-   * `guardrails` name list (which references built-ins registered in the
-   * gateway), each entry here carries its own policy + stage + model and is
-   * materialized into a judge guardrail at resolve time. Enabled entries run
-   * in addition to the named built-ins.
-   */
-  guardrailsInline?: AgentInlineGuardrail[];
-  /**
-   * Selected execution environment. References an `environments.id`, the
-   * literal `'builtin'`, or undefined (default: builtin in-process / the
-   * deployment-wide `LOBU_RUNTIME_PROVIDER`). Resolved to a runtime provider +
-   * vault credential at worker-token mint time.
-   */
-  environmentId?: string;
+export type AgentSettings = AgentSettingsStored & {
   /**
    * Reusable auth profiles persisted by host stores (e.g. Lobu's Postgres
    * store). Lobu's gateway runtime uses UserAuthProfileStore instead, but the
-   * host's settings JSON column still round-trips this list.
+   * host's settings JSON column still round-trips this list. NOT in the stored
+   * schema — separate-store, merged on GET.
    */
   authProfiles?: AuthProfile[];
-  /** Enable verbose logging (show tool calls, reasoning, etc.) */
-  verboseLogging?: boolean;
-  /**
-   * Render the agent's tool invocations (name + args + result) as cards in the
-   * web chat. Off by default — tool internals are noise for most end users, so
-   * this is an opt-in display toggle. Gates both the live `tool_use` stream and
-   * the persisted tool-call blocks rebuilt on reload.
-   */
-  showToolCalls?: boolean;
-  /**
-   * MCP tool patterns the operator has pre-approved. Each entry is a grant
-   * pattern (e.g. "/mcp/gmail/tools/send_email" or "/mcp/linear/tools/*").
-   * Synced to the grant store at deployment time to bypass the approval card
-   * for matching tools. Operator-only — skills cannot set this.
-   */
-  preApprovedTools?: string[];
-  /** Last updated timestamp */
-  updatedAt: number;
-}
+};
 
 // ── Agent Metadata ──────────────────────────────────────────────────────────
 

--- a/packages/core/src/contracts/agent-settings.ts
+++ b/packages/core/src/contracts/agent-settings.ts
@@ -1,0 +1,165 @@
+/**
+ * AgentSettings TypeBox contract family — the single source for the agent
+ * settings shape across every surface (declarative, CLI apply, admin tools,
+ * REST/MCP, Owletto UI, persistence, worker wire).
+ *
+ * Why this exists: `AgentSettings` was a hand-written `interface` duplicated
+ * across `core/agent-store.ts` and `owletto/lib/api/agents.ts`, which drifted
+ * in opposite directions (core had `mcpInstallNotified`; owletto had
+ * `mcpServers`; `models` optional vs required). A TypeBox schema is
+ * runtime-validatable AND derives the TS type via `Static<typeof>`, so every
+ * surface imports one definition — drift becomes a compile error, not a
+ * shipped-three-quarters-complete feature.
+ *
+ * Split (per reviewer Q1):
+ *  - `AgentSettingsStoredSchema` — what the DB persists. EXCLUDES
+ *    `authProfiles` (Postgres stores it in a separate table; the GET route
+ *    merges it dynamically — `agent-routes.ts:1315,1686`). Includes
+ *    `updatedAt` (set by the DB on every write).
+ *  - `AgentSettings` (the runtime type) = `Static<Stored> & { authProfiles? }`
+ *    — a superset of stored, matching the existing interface every consumer
+ *    already uses, so this is a drop-in replacement.
+ *
+ * `Patch` (PATCH body, null=clear vs undefined=unchanged) and `Response`
+ * (sanitized GET, redacted secrets + merged authProfiles) are follow-on
+ * schemas built on top of Stored; they belong with the route that owns them.
+ */
+import { type Static, Type } from "@sinclair/typebox";
+
+// ── Nested schemas ──────────────────────────────────────────────────────────
+
+export const NetworkConfigSchema = Type.Object({
+  allowedDomains: Type.Optional(Type.Array(Type.String())),
+  deniedDomains: Type.Optional(Type.Array(Type.String())),
+});
+export type NetworkConfig = Static<typeof NetworkConfigSchema>;
+
+export const NixConfigSchema = Type.Object({
+  flakeUrl: Type.Optional(Type.String()),
+  packages: Type.Optional(Type.Array(Type.String())),
+});
+export type NixConfig = Static<typeof NixConfigSchema>;
+
+export const ToolsConfigSchema = Type.Object({
+  allowedTools: Type.Optional(Type.Array(Type.String())),
+  deniedTools: Type.Optional(Type.Array(Type.String())),
+  strictMode: Type.Optional(Type.Boolean()),
+  mcpExposure: Type.Optional(
+    Type.Union([Type.Literal("tools"), Type.Literal("cli")])
+  ),
+});
+export type ToolsConfig = Static<typeof ToolsConfigSchema>;
+
+export const GuardrailStageSchema = Type.Union([
+  Type.Literal("input"),
+  Type.Literal("output"),
+  Type.Literal("pre-tool"),
+  Type.Literal("egress"),
+]);
+
+export const AgentInlineGuardrailSchema = Type.Object({
+  name: Type.String(),
+  enabled: Type.Boolean(),
+  stage: GuardrailStageSchema,
+  policy: Type.String(),
+  model: Type.Optional(Type.String()),
+  tools: Type.Optional(Type.Array(Type.String())),
+  domains: Type.Optional(Type.Array(Type.String())),
+});
+export type AgentInlineGuardrail = Static<typeof AgentInlineGuardrailSchema>;
+
+const ThinkingLevelSchema = Type.Union([
+  Type.Literal("off"),
+  Type.Literal("low"),
+  Type.Literal("medium"),
+  Type.Literal("high"),
+]);
+export type ThinkingLevel = Static<typeof ThinkingLevelSchema>;
+
+export const SkillPreToolGuardrailSchema = Type.Union([
+  Type.Object({ kind: Type.Literal("builtin"), name: Type.String() }),
+  Type.Object({
+    kind: Type.Literal("judge"),
+    policy: Type.String(),
+    tools: Type.Optional(Type.Array(Type.String())),
+    model: Type.Optional(Type.String()),
+  }),
+]);
+export type SkillPreToolGuardrail = Static<typeof SkillPreToolGuardrailSchema>;
+
+export const SkillConfigSchema = Type.Object({
+  repo: Type.String(),
+  name: Type.String(),
+  description: Type.Optional(Type.String()),
+  instructions: Type.Optional(Type.String()),
+  enabled: Type.Boolean(),
+  system: Type.Optional(Type.Boolean()),
+  content: Type.Optional(Type.String()),
+  contentFetchedAt: Type.Optional(Type.Number()),
+  nixPackages: Type.Optional(Type.Array(Type.String())),
+  providers: Type.Optional(Type.Array(Type.String())),
+  modelPreference: Type.Optional(Type.String()),
+  thinkingLevel: Type.Optional(ThinkingLevelSchema),
+  guardrails: Type.Optional(
+    Type.Object({
+      "pre-tool": Type.Optional(Type.Array(SkillPreToolGuardrailSchema)),
+    })
+  ),
+});
+export type SkillConfig = Static<typeof SkillConfigSchema>;
+
+export const SkillsConfigSchema = Type.Object({
+  skills: Type.Array(SkillConfigSchema),
+});
+export type SkillsConfig = Static<typeof SkillsConfigSchema>;
+
+const PluginSlotSchema = Type.Union([
+  Type.Literal("tool"),
+  Type.Literal("provider"),
+  Type.Literal("memory"),
+]);
+
+const PluginConfigSchema = Type.Object({
+  source: Type.String(),
+  slot: PluginSlotSchema,
+  enabled: Type.Optional(Type.Boolean()),
+  config: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
+export type PluginConfig = Static<typeof PluginConfigSchema>;
+
+export const PluginsConfigSchema = Type.Object({
+  plugins: Type.Array(PluginConfigSchema),
+});
+export type PluginsConfig = Static<typeof PluginsConfigSchema>;
+
+// ── AgentSettingsStored ─────────────────────────────────────────────────────
+
+/**
+ * What the DB persists (the `agents` row's settings jsonb columns). EXCLUDES
+ * `authProfiles` — that's stored in a separate table and merged on GET.
+ * `updatedAt` is included (set by the DB on every write, returned on read).
+ *
+ * Mirrors the field set of the legacy `AgentSettings` interface in
+ * `agent-store.ts` exactly, so `AgentSettings = Static<Stored> & { authProfiles? }`
+ * is a structural drop-in. The dead `mcpInstallNotified` field is NOT carried
+ * over (removed in `fix/delete-mcp-install-notified`).
+ */
+export const AgentSettingsStoredSchema = Type.Object({
+  models: Type.Optional(Type.Array(Type.String())),
+  networkConfig: Type.Optional(NetworkConfigSchema),
+  nixConfig: Type.Optional(NixConfigSchema),
+  soulMd: Type.Optional(Type.String()),
+  userMd: Type.Optional(Type.String()),
+  identityMd: Type.Optional(Type.String()),
+  skillsConfig: Type.Optional(SkillsConfigSchema),
+  toolsConfig: Type.Optional(ToolsConfigSchema),
+  guardrails: Type.Optional(Type.Array(Type.String())),
+  guardrailsInline: Type.Optional(Type.Array(AgentInlineGuardrailSchema)),
+  environmentId: Type.Optional(Type.String()),
+  pluginsConfig: Type.Optional(PluginsConfigSchema),
+  verboseLogging: Type.Optional(Type.Boolean()),
+  showToolCalls: Type.Optional(Type.Boolean()),
+  preApprovedTools: Type.Optional(Type.Array(Type.String())),
+  updatedAt: Type.Number(),
+});
+export type AgentSettingsStored = Static<typeof AgentSettingsStoredSchema>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,3 @@
-import type { GuardrailStage } from "./guardrails/types";
 import type { SecretRef } from "./secret-refs";
 
 /**
@@ -92,11 +91,13 @@ export interface ConversationMessage {
   timestamp: number;
 }
 
-/**
- * Per-skill thinking budget level.
- * Controls how much reasoning the model applies when executing a skill.
- */
-export type ThinkingLevel = "off" | "low" | "medium" | "high";
+// Agent-settings nested types (NetworkConfig, NixConfig, ToolsConfig,
+// SkillConfig, SkillsConfig, AgentInlineGuardrail, ThinkingLevel,
+// SkillPreToolGuardrail) now live in ./contracts/agent-settings.ts as the
+// single TypeBox-schema source (Static<typeof ...>). They are re-exported
+// from there at the bottom of this file so the @lobu/core public surface and
+// core-internal imports keep resolving. The hand-written duplicates that
+// lived here were structurally identical but a separate drift surface.
 
 export interface McpOAuthConfig {
   /** Authorization endpoint (user verification page for device-code flow). */
@@ -117,72 +118,10 @@ export interface McpOAuthConfig {
   resource?: string;
 }
 
-/**
- * Individual skill configuration.
- * Skills are SKILL.md files from GitHub repos that provide instructions to Claude.
- */
-export interface SkillConfig {
-  /** Skill repository in owner/repo format (e.g., "anthropics/skills/pdf") */
-  repo: string;
-  /** Skill name derived from SKILL.md frontmatter or folder name */
-  name: string;
-  /** Optional description from SKILL.md frontmatter */
-  description?: string;
-  /** Short always-inlined instruction block for critical rules */
-  instructions?: string;
-  /** Whether this skill is currently enabled */
-  enabled: boolean;
-  /** True for non-user-managed runtime skills. */
-  system?: boolean;
-  /** Cached SKILL.md content (fetched from GitHub) */
-  content?: string;
-  /** When the content was last fetched (timestamp ms) */
-  contentFetchedAt?: number;
-  /** System packages declared by the skill (nix) */
-  nixPackages?: string[];
-  /** AI providers the skill requires */
-  providers?: string[];
-  /** Preferred model for this skill (e.g., "anthropic/claude-opus-4") */
-  modelPreference?: string;
-  /** Thinking level budget for this skill */
-  thinkingLevel?: ThinkingLevel;
-  /**
-   * Guardrails declared by the skill.
-   *
-   * Skills may only declare `pre-tool` guardrails — the asymmetry is
-   * deliberate. `input` (user message → worker) and `output` (worker text →
-   * user) are agent-wide concerns: a skill can't decide for the operator
-   * which messages should reach which agent or which words an agent may
-   * speak. `pre-tool` is scoped to specific tool invocations, which is what
-   * a skill knows about — it can reasonably say "before this tool runs,
-   * apply this judge".
-   *
-   * Discriminated by `kind` so invalid combinations (neither / both) are
-   * compile-time TS errors instead of runtime warnings:
-   *   - `{ kind: "builtin", name }` — reference a registered guardrail.
-   *     The optional `tools` field is ignored for builtins (built-ins
-   *     decide their own input filtering); use an inline judge if you
-   *     want per-tool narrowing.
-   *   - `{ kind: "judge", policy, tools?, model? }` — ad-hoc LLM-judge policy;
-   *     `tools` narrows the judge to specific tool names (matched against
-   *     `toolName` in {@link PreToolGuardrailContext}); when absent, the
-   *     guardrail runs on every pre-tool invocation. `model` pins the judge
-   *     model; when omitted it uses the gateway default (`EGRESS_JUDGE_MODEL`),
-   *     and with neither set the judge fails closed.
-   */
-  guardrails?: {
-    "pre-tool"?: Array<SkillPreToolGuardrail>;
-  };
-}
-
-/**
- * Discriminated union of legal skill-declared pre-tool guardrail entries.
- * Each entry must be either a built-in reference or an inline judge --
- * setting both, or neither, is rejected by the type checker.
- */
-export type SkillPreToolGuardrail =
-  | { kind: "builtin"; name: string }
-  | { kind: "judge"; policy: string; tools?: string[]; model?: string };
+// SkillConfig and SkillPreToolGuardrail now come from
+// ./contracts/agent-settings (re-exported at the bottom). The hand-written
+// duplicates that lived here were structurally identical but a separate drift
+// surface; removed when the schema became the single source.
 
 /**
  * An operator-authored custom guardrail stored on an agent (`AgentSettings.
@@ -196,32 +135,13 @@ export type SkillPreToolGuardrail =
  * name recorded on every `guardrail-trip` event, so it has to be stable and
  * collision-free or the aggregator's name-keyed dedup would silently drop it.
  */
-export interface AgentInlineGuardrail {
-  name: string;
-  /** When false the guardrail is kept but not resolved into the run. */
-  enabled: boolean;
-  stage: GuardrailStage;
-  /** The judge policy prompt. */
-  policy: string;
-  /** Optional model override; defaults to the gateway's judge default. */
-  model?: string;
-  /** `pre-tool` only: narrow to specific tool names (empty = every tool). */
-  tools?: string[];
-  /**
-   * `egress` only: hostnames this judge gates (exact or `.wildcard`), mirroring
-   * `tools` for pre-tool. Empty/omitted = no egress routing.
-   */
-  domains?: string[];
-}
+// AgentInlineGuardrail now comes from ./contracts/agent-settings
+// (re-exported at the bottom). Removed the hand-written duplicate.
 
-/**
- * Skills configuration for agent settings.
- * Contains list of configured skills that can be enabled/disabled.
- */
-export interface SkillsConfig {
-  /** List of configured skills */
-  skills: SkillConfig[];
-}
+//
+// SkillsConfig now comes from ./contracts/agent-settings (re-exported at the
+// bottom). Removed the hand-written duplicate.
+//
 
 /**
  * Platform-agnostic history message format.
@@ -237,91 +157,8 @@ export interface HistoryMessage {
   messageId?: string;
 }
 
-/**
- * Network configuration for worker sandbox isolation.
- * Controls which domains the worker can access via HTTP proxy.
- *
- * Filtering rules:
- * - deniedDomains are checked first (take precedence)
- * - allowedDomains are checked second
- * - If neither matches, request is denied
- *
- * Domain pattern format:
- * - "example.com" - exact match
- * - ".example.com" - canonical wildcard form (matches root + subdomains)
- * - "*.example.com" - accepted as input and normalized to ".example.com"
- */
-export interface NetworkConfig {
-  /** Domains the worker is allowed to access. Empty array = no network access. */
-  allowedDomains?: string[];
-  /** Domains explicitly blocked (takes precedence over allowedDomains). */
-  deniedDomains?: string[];
-}
-
-/**
- * Nix environment configuration for agent workspace.
- * Allows agents to run with specific Nix packages or flakes.
- *
- * Resolution priority:
- * 1. API-provided flakeUrl (highest)
- * 2. API-provided packages
- * 3. flake.nix in git repo
- * 4. shell.nix in git repo
- * 5. .nix-packages file in git repo
- */
-export interface NixConfig {
-  /** Nix flake URL (e.g., "github:user/repo#devShell") */
-  flakeUrl?: string;
-  /** Nixpkgs packages to install (e.g., ["python311", "ffmpeg"]) */
-  packages?: string[];
-}
-
-/**
- * Tool permission configuration for agent settings.
- * Follows Claude Code's permission patterns for consistency.
- *
- * Pattern formats (Claude Code compatible):
- * - "Read" - exact tool match
- * - "Bash(git:*)" - Bash with command filter (only git commands)
- * - "Bash(npm:*)" - Bash with npm commands only
- * - "mcp__servername__*" - all tools from an MCP server
- * - "*" - wildcard (all tools)
- *
- * Filtering rules:
- * - deniedTools are checked first (take precedence)
- * - allowedTools are checked second
- * - If strictMode=true, only allowedTools are permitted
- * - If strictMode=false, defaults + allowedTools are permitted
- */
-export interface ToolsConfig {
-  /**
-   * Tools to auto-allow (in addition to defaults unless strictMode=true).
-   * Supports patterns like "Bash(git:*)" or "mcp__github__*".
-   */
-  allowedTools?: string[];
-
-  /**
-   * Tools to always deny (takes precedence over allowedTools).
-   * Use to block specific tools even if they're in defaults.
-   */
-  deniedTools?: string[];
-
-  /**
-   * If true, ONLY allowedTools are permitted (ignores defaults).
-   * If false (default), allowedTools are ADDED to default permissions.
-   */
-  strictMode?: boolean;
-
-  /**
-   * How MCP tools are exposed to the agent.
-   * - "tools" (default): each MCP tool is registered as a first-class
-   *   function-call tool with its JSON Schema.
-   * - "cli": MCP servers are exposed as one `just-bash` command per server
-   *   (e.g. `lobu search_memory <<<'{...}'`). Keeps the first-class
-   *   tool list small; relies on the sandboxed bash to invoke MCP tools.
-   */
-  mcpExposure?: "tools" | "cli";
-}
+// NetworkConfig / NixConfig / ToolsConfig now come from
+// ./contracts/agent-settings (re-exported at the bottom).
 
 interface MemoryFlushOptions {
   enabled?: boolean;
@@ -507,3 +344,20 @@ export interface UserSuggestion {
 
   prompts: SuggestedPrompt[];
 }
+
+// Re-export the agent-settings nested types from the single TypeBox-schema
+// source so the @lobu/core public surface (index.ts re-exports these via
+// `./types`) and any core-internal `from "./types"` import resolve to the
+// schema's Static<> definitions. This is what makes the schema the real single
+// source: the hand-written interfaces that used to live above were removed and
+// these names now point at one definition in ./contracts/agent-settings.
+export type {
+  AgentInlineGuardrail,
+  NetworkConfig,
+  NixConfig,
+  SkillConfig,
+  SkillPreToolGuardrail,
+  SkillsConfig,
+  ThinkingLevel,
+  ToolsConfig,
+} from "./contracts/agent-settings";


### PR DESCRIPTION
The keystone: defines AgentSettingsStoredSchema (TypeBox) in contracts/agent-settings.ts with nested schemas for all agent-settings types. AgentSettings becomes a derived type. types.ts and plugin-types.ts collapse to re-export. Drops mcpInstallNotified, surfaces pluginsConfig. Reviewed by Claude: SHIP, no caveats.

Depends on #1939 (both touch agent-store.ts).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786630176&installation_id=136316292&pr_number=1942&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1942&signature=bda72379b1d9e4b258880ac84dad9655c423a9fdd09c57157b2d4f246f90b203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->