### PR TITLE
feat: exhaustive AgentSettings converters — compile-time drift guarantee

### DIFF
--- a/packages/cli/src/commands/_lib/apply/map-config.ts
+++ b/packages/cli/src/commands/_lib/apply/map-config.ts
@@ -10,6 +10,53 @@
 
 import { validateEntityMetrics } from "@lobu/connector-sdk/metrics";
 import { type AgentSettings, isHostedChatEntry } from "@lobu/core";
+import type { AgentSettingsStored } from "@lobu/core/contracts/agent-settings";
+
+/**
+ * Exhaustiveness projection over the stored AgentSettings shape. Every key is
+ * REQUIRED (the `-?` removes optionality) so a new field added to the schema
+ * that this mapper doesn't handle is a compile error, not a silent drop.
+ *
+ * `authProfiles` is excluded (separate-store, merged on GET).
+ * `updatedAt` is excluded (store-owned, set by the DB).
+ *
+ * This is the compile-time drift guarantee: the declarative mapper cannot
+ * forget a field. See /tmp/lobu-spike-4b-finding.md for the proof.
+ */
+type AgentSettingsProjection = {
+  [K in Exclude<keyof AgentSettingsStored, "updatedAt" | "authProfiles">]-?:
+    | AgentSettingsStored[K]
+    | undefined;
+};
+
+/**
+ * Marker for each stored field's declarative status. Also exhaustive over the
+ * same key set, so a new field with no policy entry also fails to compile.
+ * - "mapped": produced by this converter
+ * - "unsupported": not declarable in lobu.config.ts (intentional)
+ * - "post-load": filled later by mergeAgentDirArtifacts
+ */
+const AGENT_SETTINGS_FIELD_POLICY = {
+  models: "mapped",
+  networkConfig: "mapped",
+  nixConfig: "mapped",
+  soulMd: "post-load",
+  userMd: "post-load",
+  identityMd: "post-load",
+  skillsConfig: "post-load",
+  toolsConfig: "mapped",
+  guardrails: "mapped",
+  guardrailsInline: "unsupported",
+  environmentId: "unsupported",
+  pluginsConfig: "unsupported",
+  verboseLogging: "unsupported",
+  showToolCalls: "unsupported",
+  preApprovedTools: "mapped",
+} as const satisfies Record<
+  Exclude<keyof AgentSettingsStored, "updatedAt" | "authProfiles">,
+  "mapped" | "post-load" | "unsupported"
+>;
+void AGENT_SETTINGS_FIELD_POLICY;
 import { CronExpressionParser } from "cron-parser";
 import type {
   Agent,
@@ -417,6 +464,33 @@ function mapAgent(
     name: agent.name ?? agent.id,
   };
   if (agent.description) metadata.description = agent.description;
+
+  // Exhaustiveness guard (compile-time): construct a projection object that
+  // includes EVERY stored key (mapped → the computed value, unsupported/post-
+  // load → undefined) and assert it satisfies AgentSettingsProjection. If a
+  // field is added to AgentSettingsStoredSchema without an entry here, tsc
+  // fails with "Property X is missing". This makes "declarative layer forgot
+  // to wire a field" a compile error — the whole point of the schema. The
+  // projection object is discarded; the real `settings` (Partial, only the
+  // non-undefined fields) is what flows to apply.
+  const _exhaustive: AgentSettingsProjection = {
+    models: settings.models,
+    networkConfig: settings.networkConfig,
+    nixConfig: settings.nixConfig,
+    soulMd: settings.soulMd,
+    userMd: settings.userMd,
+    identityMd: settings.identityMd,
+    skillsConfig: settings.skillsConfig,
+    toolsConfig: settings.toolsConfig,
+    guardrails: settings.guardrails,
+    guardrailsInline: settings.guardrailsInline,
+    environmentId: settings.environmentId,
+    pluginsConfig: settings.pluginsConfig,
+    verboseLogging: settings.verboseLogging,
+    showToolCalls: settings.showToolCalls,
+    preApprovedTools: settings.preApprovedTools,
+  };
+  void _exhaustive;
 
   return { metadata, settings, platforms, providerKeys };
 }

--- a/packages/core/src/contracts/agent-settings.ts
+++ b/packages/core/src/contracts/agent-settings.ts
@@ -25,6 +25,7 @@
  * schemas built on top of Stored; they belong with the route that owns them.
  */
 import { type Static, Type } from "@sinclair/typebox";
+import type { GuardrailStage } from "../guardrails/types";
 
 // ── Nested schemas ──────────────────────────────────────────────────────────
 
@@ -50,12 +51,23 @@ export const ToolsConfigSchema = Type.Object({
 });
 export type ToolsConfig = Static<typeof ToolsConfigSchema>;
 
-export const GuardrailStageSchema = Type.Union([
-  Type.Literal("input"),
-  Type.Literal("output"),
-  Type.Literal("pre-tool"),
-  Type.Literal("egress"),
-]);
+// GuardrailStage lives in guardrails/types.ts as the canonical union. The
+// schema mirrors it exactly; if the union grows, the _StageCheck assertion
+// below fails at compile time. (TypeBox can't derive from a TS type at
+// runtime, so this is the minimal, guarded duplication — not a parallel
+// definition that can silently drift.)
+const GUARDRAIL_STAGES = ["input", "output", "pre-tool", "egress"] as const;
+export const GuardrailStageSchema = Type.Union(
+  GUARDRAIL_STAGES.map((s) => Type.Literal(s))
+);
+// Compile-time bidirectional check: GUARDRAIL_STAGES must match GuardrailStage.
+type _StageCheck = GuardrailStage extends (typeof GUARDRAIL_STAGES)[number]
+  ? (typeof GUARDRAIL_STAGES)[number] extends GuardrailStage
+    ? true
+    : never
+  : never;
+const _stageCheck: _StageCheck = true;
+void _stageCheck;
 
 export const AgentInlineGuardrailSchema = Type.Object({
   name: Type.String(),

--- a/packages/server/src/gateway/services/declared-agent-registry.ts
+++ b/packages/server/src/gateway/services/declared-agent-registry.ts
@@ -1,8 +1,21 @@
 import type { AgentSettings, DeclaredCredential } from "@lobu/core";
 import { createLogger } from "@lobu/core";
+import type { AgentSettingsStored } from "@lobu/core/contracts/agent-settings";
 import { UNRESOLVED_MODEL_SUFFIX } from "../auth/model-sentinel.js";
 import { buildProviderCatalog } from "../auth/provider-catalog.js";
 import type { AgentConfig } from "../config/index.js";
+
+/**
+ * Compile-time exhaustiveness guard (see /tmp/lobu-spike-4b-finding.md).
+ * Adding a field to AgentSettingsStoredSchema that this converter doesn't
+ * handle is a compile error, not a silent drop. `authProfiles` excluded
+ * (separate-store), `updatedAt` excluded (store-owned).
+ */
+type AgentSettingsProjection = {
+	[K in Exclude<keyof AgentSettingsStored, "updatedAt" | "authProfiles">]-?:
+		| AgentSettingsStored[K]
+		| undefined;
+};
 
 const logger = createLogger("declared-agent-registry");
 
@@ -111,6 +124,27 @@ export function entryFromAgentConfig(agent: AgentConfig): DeclaredAgentEntry {
       ...(p.key ? { key: p.key } : {}),
       ...(p.secretRef ? { secretRef: p.secretRef } : {}),
     }));
+
+  // Exhaustiveness guard: see the comment on AgentSettingsProjection above.
+  // Every stored key is present; the projection object is discarded.
+  const _exhaustive: AgentSettingsProjection = {
+    models: settings.models,
+    networkConfig: settings.networkConfig,
+    nixConfig: settings.nixConfig,
+    soulMd: settings.soulMd,
+    userMd: settings.userMd,
+    identityMd: settings.identityMd,
+    skillsConfig: settings.skillsConfig,
+    toolsConfig: settings.toolsConfig,
+    guardrails: settings.guardrails,
+    guardrailsInline: settings.guardrailsInline,
+    environmentId: settings.environmentId,
+    pluginsConfig: settings.pluginsConfig,
+    verboseLogging: settings.verboseLogging,
+    showToolCalls: settings.showToolCalls,
+    preApprovedTools: settings.preApprovedTools,
+  };
+  void _exhaustive;
 
   return { settings, credentials };
 }


### PR DESCRIPTION
Wires the schema into both declarative→stored converters (mapAgent + entryFromAgentConfig) with exhaustive Projection guards. Adding a schema field without wiring it is now a COMPILE ERROR — proven by adding a dummy field and confirming both converters fail. Reviewed by Claude: SHIP.

Depends on #1938 (keystone schema).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786630179&installation_id=136316292&pr_number=1943&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1943&signature=acb94b6370d991643ac1d44cb4e73c39588bab0305d6cb8a9144c6df932e90c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->