### PR TITLE
feat(core): collapse plugin-types + GuardrailStage to single source

### DIFF
--- a/packages/core/src/contracts/agent-settings.ts
+++ b/packages/core/src/contracts/agent-settings.ts
@@ -125,11 +125,12 @@ export const SkillsConfigSchema = Type.Object({
 });
 export type SkillsConfig = Static<typeof SkillsConfigSchema>;
 
-const PluginSlotSchema = Type.Union([
+export const PluginSlotSchema = Type.Union([
   Type.Literal("tool"),
   Type.Literal("provider"),
   Type.Literal("memory"),
 ]);
+export type PluginSlot = Static<typeof PluginSlotSchema>;
 
 const PluginConfigSchema = Type.Object({
   source: Type.String(),

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -1,0 +1,41 @@
+/**
+ * OpenClaw plugin types for Lobu.
+ *
+ * `PluginSlot` / `PluginConfig` / `PluginsConfig` are re-exported from the
+ * AgentSettings TypeBox schema (./contracts/agent-settings.ts) — the single
+ * source, so `AgentSettings.pluginsConfig` and the public `PluginsConfig`
+ * can't drift. The hand-written interfaces that used to live here were
+ * structurally identical but a separate definition surface.
+ *
+ * `PluginManifest` and `ProviderRegistration` are NOT in the agent-settings
+ * schema (they're runtime/catalog concerns, not stored agent config) — they
+ * stay defined here.
+ */
+
+// Re-export the stored plugin shapes from the schema (single source).
+export type {
+  PluginConfig,
+  PluginSlot,
+  PluginsConfig,
+} from "./contracts/agent-settings";
+
+/** Metadata about a loaded plugin */
+export interface PluginManifest {
+  /** Source identifier (package name or path) */
+  source: string;
+  /** Plugin slot */
+  slot: import("./contracts/agent-settings").PluginSlot;
+  /** Display name (from package or source) */
+  name: string;
+}
+
+/**
+ * A provider registration captured from pi.registerProvider().
+ * The config is opaque here — it's passed directly to ModelRegistry.registerProvider().
+ */
+export interface ProviderRegistration {
+  /** Provider name (e.g., "corporate-ai", "my-proxy") */
+  name: string;
+  /** Provider config (ProviderConfigInput from pi-coding-agent) */
+  config: Record<string, unknown>;
+}


### PR DESCRIPTION
Collapses the last residuals: plugin-types.ts re-exports PluginsConfig/PluginConfig/PluginSlot from the schema; owletto's GuardrailStage copy re-exports from @lobu/core. After this set, AgentSettings + every nested type has ONE definition. Reviewed by Claude: SHIP.

Depends on the full chain (#1939 through the owletto bump).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786630183&installation_id=136316292&pr_number=1945&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1945&signature=4f2e51ae4cf856f46cb89a31ab56f9e3d1b50a222ecc9b8c2e1eb065eef72e45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->