### PR TITLE
Fix SDK OAuth reauthentication

### DIFF
--- a/packages/connectors/src/__tests__/hackernews-budget.test.ts
+++ b/packages/connectors/src/__tests__/hackernews-budget.test.ts
@@ -109,3 +109,14 @@ test('non-HTML/non-OK results do NOT trip the egress short-circuit', async () =>
   expect(result.events[3]?.content).toBeTruthy();
   expect(result.events[0]?.content).toBeFalsy();
 }, 20_000);
+
+test('front-page schema accepts every story kind the mapper emits', async () => {
+  const { default: HackerNewsConnector } = await import('../hackernews');
+  const connector = new HackerNewsConnector();
+
+  expect(Object.keys(connector.definition.feeds.front_page.eventKinds ?? {}).sort()).toEqual([
+    'ask_hn',
+    'show_hn',
+    'story',
+  ]);
+});

--- a/packages/connectors/src/hackernews.ts
+++ b/packages/connectors/src/hackernews.ts
@@ -179,6 +179,31 @@ export default class HackerNewsConnector extends ConnectorRuntime {
               },
             },
           },
+          ask_hn: {
+            description: 'An Ask HN post on the front page',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                story_type: { type: 'string' },
+                tags: { type: 'array', items: { type: 'string' } },
+                score: { type: 'number' },
+                reply_count: { type: 'number' },
+              },
+            },
+          },
+          show_hn: {
+            description: 'A Show HN post on the front page',
+            metadataSchema: {
+              type: 'object',
+              properties: {
+                story_type: { type: 'string' },
+                tags: { type: 'array', items: { type: 'string' } },
+                external_url: { type: 'string', format: 'uri' },
+                score: { type: 'number' },
+                reply_count: { type: 'number' },
+              },
+            },
+          },
         },
       },
       comments: {

--- a/packages/core/src/contracts/tools/manage-auth-profiles.ts
+++ b/packages/core/src/contracts/tools/manage-auth-profiles.ts
@@ -190,6 +190,7 @@ export const ManageAuthProfilesResultSchema = Type.Union([
     action: Type.Literal("update_auth_profile"),
     auth_profile: Type.Record(Type.String(), Type.Unknown()),
     connect_url: Type.Optional(Type.String()),
+    expires_at: Type.Optional(Type.String()),
   }),
   Type.Object({
     action: Type.Literal("delete_auth_profile"),

--- a/packages/core/src/contracts/tools/manage-connections.ts
+++ b/packages/core/src/contracts/tools/manage-connections.ts
@@ -310,11 +310,12 @@ export const DeleteAction = Type.Object({
 
 export const ReauthenticateAction = Type.Object({
   action: Type.Literal("reauthenticate", {
-    description: "Re-pair a connection's interactive auth via a new auth run.",
+    description:
+      "Start a fresh OAuth authorization or interactive pairing flow for an existing connection.",
   }),
   connection_id: Type.Number({
     description:
-      "Connection ID whose interactive auth profile should be re-paired via a new auth run.",
+      "Connection ID whose OAuth-account or interactive auth profile should be reauthenticated.",
   }),
 });
 
@@ -762,6 +763,13 @@ export const ManageConnectionsResultSchema = Type.Union([
     action: Type.Literal("reauthenticate"),
     connection_id: Type.Integer(),
     auth_run_id: Type.Integer(),
+  }),
+  Type.Object({
+    action: Type.Literal("reauthenticate"),
+    connection_id: Type.Integer(),
+    auth_profile_slug: Type.String(),
+    connect_url: Type.String(),
+    expires_at: Type.String(),
   }),
   Type.Object({
     action: Type.Literal("test"),

--- a/packages/server/src/__tests__/integration/connectors/pending-auth-connection.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/pending-auth-connection.test.ts
@@ -14,6 +14,7 @@ import type { ToolContext } from '../../../tools/registry';
 import { manageAuthProfiles } from '../../../tools/admin/manage_auth_profiles';
 import { manageConnections } from '../../../tools/admin/manage_connections';
 import { manageFeeds } from '../../../tools/admin/manage_feeds';
+import { buildClientSDK } from '../../../sandbox/client-sdk';
 import { getTestDb, cleanupTestDatabase } from '../../setup/test-db';
 import { initWorkspaceProvider } from '../../../workspace';
 import {
@@ -37,6 +38,7 @@ function ctxFor(organizationId: string, userId: string): ToolContext {
     tokenType: 'oauth',
     scopedToOrg: true,
     allowCrossOrg: false,
+    baseUrl: 'https://gateway.test/lobu',
   } as ToolContext;
 }
 
@@ -177,6 +179,50 @@ describe('connectors — pending-auth oauth_account in the same apply', () => {
     expect(feedRows).toHaveLength(1);
     expect((feedRows[0] as { status: string }).status).toBe('paused');
     expect((feedRows[0] as { next_run_at: unknown }).next_run_at).toBeNull();
+
+    // The SDK's positional lookup and reauthentication methods must work as
+    // advertised. OAuth reauthentication issues a fresh profile-scoped token;
+    // the callback then activates every connection bound to this profile.
+    const sdk = buildClientSDK(ctx, TEST_ENV);
+    const profileResult = (await sdk.authProfiles.get('demo-account')) as {
+      auth_profile: { id: number; slug: string; profile_kind: string };
+    };
+    expect(profileResult.auth_profile).toMatchObject({
+      id: profileId,
+      slug: 'demo-account',
+      profile_kind: 'oauth_account',
+    });
+
+    const reconnectResult = (await sdk.connections.reauthenticate(connectionId)) as {
+      action: string;
+      connection_id: number;
+      auth_profile_slug: string;
+      connect_url: string;
+      expires_at: string;
+    };
+    expect(reconnectResult).toMatchObject({
+      action: 'reauthenticate',
+      connection_id: connectionId,
+      auth_profile_slug: 'demo-account',
+    });
+    expect(reconnectResult.connect_url).toMatch(
+      /^https:\/\/gateway\.test\/lobu\/connect\/[A-Za-z0-9_-]+\/oauth\/start$/
+    );
+    expect(Number.isNaN(Date.parse(reconnectResult.expires_at))).toBe(false);
+
+    const reconnectTokens = await sql`
+      SELECT connection_id, auth_profile_id
+      FROM connect_tokens
+      WHERE organization_id = ${org.id}
+        AND connector_key = 'demo.oauth'
+        AND status = 'pending'
+      ORDER BY created_at DESC
+    `;
+    expect(reconnectTokens).toHaveLength(2);
+    expect(reconnectTokens[0]).toMatchObject({
+      connection_id: null,
+      auth_profile_id: profileId,
+    });
 
     // Re-creating the account profile is idempotent — reuses the row, returns a fresh token.
     const accRes2 = await manageAuthProfiles(

--- a/packages/server/src/__tests__/integration/operations-list-available-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/operations-list-available-lifecycle.test.ts
@@ -323,7 +323,7 @@ describe("operations.listAvailable — capability discovery DTO", () => {
 		});
 	});
 
-	it("offers and invokes reauthenticate only for an interactive auth profile", async () => {
+	it("offers and invokes reauthenticate for an interactive auth profile", async () => {
 		const { org, user } = await setupOwner("Ops Interactive Org");
 		await seedConnector(org.id, KEY_INACTIVE, "Interactive Connector");
 		const profile = await createAuthProfile({
@@ -368,6 +368,71 @@ describe("operations.listAvailable — capability discovery DTO", () => {
 			action: "reauthenticate",
 			connection_id: conn.id,
 			auth_run_id: expect.any(Number),
+		});
+	});
+
+	it("offers and invokes reauthenticate for an OAuth account profile", async () => {
+		const { org, user } = await setupOwner("Ops OAuth Org");
+		await seedConnector(org.id, KEY_INACTIVE, "OAuth Connector");
+		await getTestDb()`
+			UPDATE connector_definitions
+			SET auth_schema = ${getTestDb().json({
+				methods: [
+					{
+						type: "oauth",
+						provider: "demo",
+						requiredScopes: ["read"],
+						clientIdKey: "DEMO_CLIENT_ID",
+						clientSecretKey: "DEMO_CLIENT_SECRET",
+					},
+				],
+			})}
+			WHERE organization_id = ${org.id} AND key = ${KEY_INACTIVE}
+		`;
+		const profile = await createAuthProfile({
+			organizationId: org.id,
+			connectorKey: KEY_INACTIVE,
+			displayName: "OAuth repair",
+			profileKind: "oauth_account",
+			provider: "demo",
+			status: "pending_auth",
+			createdBy: user.id,
+		});
+		const conn = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_INACTIVE,
+			status: "error",
+			created_by: user.id,
+			visibility: "private",
+			createDefaultFeed: false,
+		});
+		await getTestDb()`
+			UPDATE connections SET auth_profile_id = ${profile.id} WHERE id = ${conn.id}
+		`;
+
+		const { operations } = await listAll(org.id, user.id, {
+			connection_id: conn.id,
+		});
+		const create = getOperation(operations, "create_issue");
+		expect(create.next_action).toMatchObject({
+			action: "reauthenticate",
+			sdk_method: "connections.reauthenticate",
+			arguments: [conn.id],
+		});
+
+		const repaired = await manageConnections(
+			{ action: "reauthenticate", connection_id: conn.id },
+			TEST_ENV(),
+			ctxFor(org.id, user.id),
+		);
+		expect(repaired).toMatchObject({
+			action: "reauthenticate",
+			connection_id: conn.id,
+			auth_profile_slug: profile.slug,
+			connect_url: expect.stringMatching(
+				/^https:\/\/gateway\.test\/lobu\/connect\/[A-Za-z0-9_-]+\/oauth\/start$/,
+			),
+			expires_at: expect.any(String),
 		});
 	});
 

--- a/packages/server/src/__tests__/unit/connect-base-url.test.ts
+++ b/packages/server/src/__tests__/unit/connect-base-url.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { getConnectBaseUrl } from "../../tools/admin/helpers/connection-helpers";
+import {
+	getConnectBaseUrl,
+	getGatewayBaseUrl,
+} from "../../tools/admin/helpers/connection-helpers";
 import { __resetPublicOriginCachesForTests } from "../../utils/public-origin";
 
 const ORIGINAL_PUBLIC_GATEWAY_URL = process.env.PUBLIC_GATEWAY_URL;
@@ -14,7 +17,7 @@ afterEach(() => {
 });
 
 describe("getConnectBaseUrl", () => {
-	test("uses the configured gateway mount when the tool context has only the web origin", () => {
+	test("keeps token-gated connector auth on the app root", () => {
 		process.env.PUBLIC_GATEWAY_URL = "https://app.lobu.ai/lobu";
 		__resetPublicOriginCachesForTests();
 
@@ -23,7 +26,7 @@ describe("getConnectBaseUrl", () => {
 				baseUrl: "https://app.lobu.ai",
 				requestUrl: "https://app.lobu.ai/mcp",
 			} as Parameters<typeof getConnectBaseUrl>[0]),
-		).toBe("https://app.lobu.ai/lobu");
+		).toBe("https://app.lobu.ai");
 	});
 
 	test("preserves an explicit path-aware context base in tests and self-hosted mounts", () => {
@@ -35,5 +38,19 @@ describe("getConnectBaseUrl", () => {
 				baseUrl: "https://gateway.test/custom-mount/",
 			} as Parameters<typeof getConnectBaseUrl>[0]),
 		).toBe("https://gateway.test/custom-mount");
+	});
+});
+
+describe("getGatewayBaseUrl", () => {
+	test("uses the configured gateway mount for gateway-owned install routes", () => {
+		process.env.PUBLIC_GATEWAY_URL = "https://app.lobu.ai/lobu";
+		__resetPublicOriginCachesForTests();
+
+		expect(
+			getGatewayBaseUrl({
+				baseUrl: "https://app.lobu.ai",
+				requestUrl: "https://app.lobu.ai/mcp",
+			} as Parameters<typeof getGatewayBaseUrl>[0]),
+		).toBe("https://app.lobu.ai/lobu");
 	});
 });

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -214,4 +214,23 @@ describe("sdkSearch", () => {
 			expect(result.results[0], path).toMatch(/\(\{/);
 		}
 	});
+
+	it.each([
+		[
+			"connections.reauthenticate",
+			"connections.reauthenticate(connection_id: number)",
+			"client.connections.reauthenticate(42)",
+		],
+		[
+			"authProfiles.get",
+			"authProfiles.get(auth_profile_slug: string)",
+			"client.authProfiles.get('google-calendar-account')",
+		],
+		["authProfiles.update", "reconnect?: boolean", "reconnect: true"],
+	])("documents the exact %s call shape", async (path, signature, example) => {
+		const result = await sdkSearch({ query: path }, stubEnv, adminCtx);
+		expect(result.match_count).toBe(1);
+		expect(result.results[0]).toContain(signature);
+		expect(result.results[0]).toContain(example);
+	});
 });

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -162,6 +162,17 @@ describe("sdkSearch", () => {
 		expect(result.results[0]).toStartWith("operations.execute —");
 	});
 
+	it("recovers useful methods from natural multi-word queries", async () => {
+		const result = await sdkSearch(
+			{ query: "connections sync run", mode: "read" },
+			stubEnv,
+			readCtx,
+		);
+
+		expect(result.match_count).toBeGreaterThan(0);
+		expect(result.results.some((line) => line.startsWith("operations.listRuns —"))).toBe(true);
+	});
+
 	it("returns empty + helpful note for unknown queries", async () => {
 		const result = await sdkSearch(
 			{ query: "definitelyNotAMethod" },
@@ -216,6 +227,11 @@ describe("sdkSearch", () => {
 	});
 
 	it.each([
+		[
+			"operations.getRun",
+			"operations.getRun(run_id: number)",
+			"client.operations.getRun(123)",
+		],
 		[
 			"connections.reauthenticate",
 			"connections.reauthenticate(connection_id: number)",

--- a/packages/server/src/__tests__/unit/sandbox/sdk-signature-contract.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-signature-contract.test.ts
@@ -26,6 +26,12 @@ mock.module("../../../tools/admin/manage_schedules", () => ({
 mock.module("../../../tools/admin/manage_entity_schema", () => ({
 	manageEntitySchema: captureAction,
 }));
+mock.module("../../../tools/admin/manage_connections", () => ({
+	manageConnections: captureAction,
+}));
+mock.module("../../../tools/admin/manage_auth_profiles", () => ({
+	manageAuthProfiles: captureAction,
+}));
 
 mock.module("../../../tools/get_watchers", () => ({
 	getWatcher: async (input: Record<string, unknown>) => {
@@ -50,10 +56,21 @@ describe("ClientSDK object signature contract", () => {
 		schedules: typeof import("../../../sandbox/namespaces/schedules").buildSchedulesNamespace;
 		watchers: typeof import("../../../sandbox/namespaces/watchers").buildWatchersNamespace;
 		entitySchema: typeof import("../../../sandbox/namespaces/entity-schema").buildEntitySchemaNamespace;
+		connections: typeof import("../../../sandbox/namespaces/connections").buildConnectionsNamespace;
+		authProfiles: typeof import("../../../sandbox/namespaces/auth-profiles").buildAuthProfilesNamespace;
 	};
 
 	beforeAll(async () => {
-		const [entities, feeds, classifiers, schedules, watchers, entitySchema] =
+		const [
+			entities,
+			feeds,
+			classifiers,
+			schedules,
+			watchers,
+			entitySchema,
+			connections,
+			authProfiles,
+		] =
 			await Promise.all([
 				import("../../../sandbox/namespaces/entities"),
 				import("../../../sandbox/namespaces/feeds"),
@@ -61,6 +78,8 @@ describe("ClientSDK object signature contract", () => {
 				import("../../../sandbox/namespaces/schedules"),
 				import("../../../sandbox/namespaces/watchers"),
 				import("../../../sandbox/namespaces/entity-schema"),
+				import("../../../sandbox/namespaces/connections"),
+				import("../../../sandbox/namespaces/auth-profiles"),
 			]);
 		builders = {
 			entities: entities.buildEntitiesNamespace,
@@ -69,6 +88,8 @@ describe("ClientSDK object signature contract", () => {
 			schedules: schedules.buildSchedulesNamespace,
 			watchers: watchers.buildWatchersNamespace,
 			entitySchema: entitySchema.buildEntitySchemaNamespace,
+			connections: connections.buildConnectionsNamespace,
+			authProfiles: authProfiles.buildAuthProfilesNamespace,
 		};
 	});
 
@@ -124,5 +145,21 @@ describe("ClientSDK object signature contract", () => {
 				input: { schema_type: "relationship_type", slug: "works-at" },
 			},
 		]);
+	});
+
+	it("explains positional connection and auth-profile arguments", async () => {
+		const connections = builders.connections(ctx, env);
+		const authProfiles = builders.authProfiles(ctx, env);
+
+		await expect(
+			connections.reauthenticate({ connection_id: 418 } as never),
+		).rejects.toThrow(
+			"connections.reauthenticate expects a positional number. Call client.connections.reauthenticate(418); do not pass an object.",
+		);
+		await expect(
+			authProfiles.get({ auth_profile_slug: "google-calendar-account" } as never),
+		).rejects.toThrow(
+			"authProfiles.get expects a positional string. Call client.authProfiles.get('google-calendar-account'); do not pass an object.",
+		);
 	});
 });

--- a/packages/server/src/formatting/__tests__/markdown-formatter.test.ts
+++ b/packages/server/src/formatting/__tests__/markdown-formatter.test.ts
@@ -73,6 +73,24 @@ describe('formatToolResult', () => {
       expect(md).toContain('Alice');
     });
 
+    it('renders stable event ids for related content follow-ups', () => {
+      const result = {
+        entity: null,
+        matches: [],
+        content: [
+          {
+            id: 66,
+            title: 'A collected item',
+            platform: 'hackernews',
+            text_content: 'Collected text',
+          },
+        ],
+      };
+
+      const md = formatToolResult('search_memory', result);
+      expect(md).toContain('Lobu event ID**: 66');
+    });
+
     it('renders virtual-feed rows as a table and escapes cell delimiters', () => {
       const result = {
         entity: null,

--- a/packages/server/src/formatting/markdown-formatter.ts
+++ b/packages/server/src/formatting/markdown-formatter.ts
@@ -435,6 +435,7 @@ function formatContentSnippets(content: any[]): string {
     if (item.author_name) md += ` | **Author**: ${item.author_name}`;
     if (item.occurred_at) md += ` | **Date**: ${new Date(item.occurred_at).toLocaleDateString()}`;
     md += '\n\n';
+    if (item.id != null) md += `**Lobu event ID**: ${item.id}\n\n`;
 
     const text = item.text_content || '';
     const excerpt = text.length > 300 ? text.slice(0, 300) + '...' : text;

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -561,7 +561,12 @@ export default async (_ctx, client) => {
 		summary: "List past operation runs.",
 		access: "read",
 	},
-	"operations.getRun": { summary: "Get a single run by id.", access: "read" },
+	"operations.getRun": {
+		summary: "Get a single run by id.",
+		access: "read",
+		signature: "operations.getRun(run_id: number): Promise<unknown>",
+		example: "const run = await client.operations.getRun(123);",
+	},
 	"operations.approve": {
 		summary: "Approve a pending run that required human approval.",
 		access: "write",
@@ -582,14 +587,18 @@ export default async (_ctx, client) => {
 		signature: "feeds.list(input?: { connection_id?: number; status?: string; limit?: number; offset?: number }): Promise<unknown>",
 	},
 	"feeds.get": {
-		summary: "Get a feed by id.",
+		summary:
+			"Get a feed by id. Collected feeds return feed metadata and recent runs, not stored records; search collected records with knowledge.search/search_memory or client.query. Virtual feeds return live rows.",
 		access: "read",
+		signature: "feeds.get(input: { feed_id: number; limit?: number }): Promise<unknown>",
 		example: "const feed = await client.feeds.get({ feed_id: 42 });",
 	},
 	"feeds.readMany": {
 		summary:
-			"Read several feeds in parallel with per-feed successes/failures. Useful for live virtual feeds suggested by query_sql coverage hints.",
+			"Read several feeds in parallel with per-feed successes/failures. Collected feeds return metadata and recent runs; virtual feeds return live rows. Search collected records with knowledge.search/search_memory or client.query.",
 		access: "read",
+		signature: "feeds.readMany(input: { feed_ids: number[]; limit?: number }): Promise<unknown>",
+		example: "const feeds = await client.feeds.readMany({ feed_ids: [42, 43], limit: 25 });",
 	},
 	"feeds.create": {
 		summary: "Create a data-sync feed for a connection.",

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -473,7 +473,12 @@ export default async (_ctx, client) => {
 		summary: "List installed org or agent resources.",
 		access: "read",
 	},
-	"connections.get": { summary: "Get a connection by id.", access: "read" },
+	"connections.get": {
+		summary: "Get a connection by id.",
+		access: "read",
+		signature: "connections.get(connection_id: number): Promise<unknown>",
+		example: "await client.connections.get(42);",
+	},
 	"connections.create": {
 		summary:
 			"Create from an existing auth profile. Setup gaps return a structured setup_required continuation with next_action and an optional resume_call/completion_check.",
@@ -488,14 +493,25 @@ export default async (_ctx, client) => {
 		summary: "Update connection config or auth profile.",
 		access: "write",
 	},
-	"connections.delete": { summary: "Delete a connection.", access: "write" },
-	"connections.reauthenticate": {
-		summary: "Start a fresh auth flow for an existing connection.",
+	"connections.delete": {
+		summary: "Delete a connection.",
 		access: "write",
+		signature: "connections.delete(connection_id: number): Promise<unknown>",
+		example: "await client.connections.delete(42);",
+	},
+	"connections.reauthenticate": {
+		summary:
+			"Start a fresh auth flow for an existing OAuth-account or interactive connection. Returns connect_url for OAuth or auth_run_id for interactive pairing.",
+		access: "write",
+		signature:
+			"connections.reauthenticate(connection_id: number): Promise<unknown>",
+		example: "await client.connections.reauthenticate(42);",
 	},
 	"connections.test": {
 		summary: "Test connection credentials (sends an external probe).",
 		access: "external",
+		signature: "connections.test(connection_id: number): Promise<unknown>",
+		example: "await client.connections.test(42);",
 	},
 	"connections.installConnector": {
 		summary:
@@ -604,22 +620,39 @@ export default async (_ctx, client) => {
 	"authProfiles.get": {
 		summary: "Get an auth profile by slug.",
 		access: "read",
+		signature:
+			"authProfiles.get(auth_profile_slug: string): Promise<unknown>",
+		example:
+			"await client.authProfiles.get('google-calendar-account');",
 	},
 	"authProfiles.test": {
 		summary: "Test auth-profile credentials.",
 		access: "external",
+		signature:
+			"authProfiles.test(auth_profile_slug: string): Promise<unknown>",
+		example:
+			"await client.authProfiles.test('google-calendar-account');",
 	},
 	"authProfiles.create": {
 		summary: "Create an auth profile.",
 		access: "write",
 	},
 	"authProfiles.update": {
-		summary: "Update an auth profile.",
+		summary:
+			"Update an auth profile. Set reconnect=true on an OAuth-account profile to issue a fresh connect_url.",
 		access: "write",
+		signature:
+			"authProfiles.update(input: { auth_profile_slug: string; display_name?: string; slug?: string; credentials?: Record<string, string>; auth_data?: Record<string, unknown>; requested_scopes?: string[]; status?: string; reconnect?: boolean }): Promise<unknown>",
+		example:
+			"await client.authProfiles.update({ auth_profile_slug: 'google-calendar-account', reconnect: true });",
 	},
 	"authProfiles.delete": {
 		summary: "Delete an auth profile.",
 		access: "write",
+		signature:
+			"authProfiles.delete(auth_profile_slug: string, options?: { force?: boolean }): Promise<unknown>",
+		example:
+			"await client.authProfiles.delete('google-calendar-account');",
 	},
 
 	// classifiers

--- a/packages/server/src/sandbox/namespaces/action-call.ts
+++ b/packages/server/src/sandbox/namespaces/action-call.ts
@@ -26,6 +26,28 @@ export class ClientSdkActionError extends ToolUserError {
 	}
 }
 
+export function requirePositionalNumber(
+	method: string,
+	value: unknown,
+	example: string,
+): number {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	throw new ToolUserError(
+		`${method} expects a positional number. Call ${example}; do not pass an object.`,
+	);
+}
+
+export function requirePositionalString(
+	method: string,
+	value: unknown,
+	example: string,
+): string {
+	if (typeof value === "string") return value;
+	throw new ToolUserError(
+		`${method} expects a positional string. Call ${example}; do not pass an object.`,
+	);
+}
+
 function failureMessage(
 	actionName: string,
 	value: unknown,

--- a/packages/server/src/sandbox/namespaces/auth-profiles.ts
+++ b/packages/server/src/sandbox/namespaces/auth-profiles.ts
@@ -15,7 +15,7 @@ import type { Env } from "../../index";
 import { manageAuthProfiles } from "../../tools/admin/manage_auth_profiles";
 import type { ToolContext } from "../../tools/registry";
 import type { AuthProfileKind as StoredAuthProfileKind } from "../../utils/auth-profiles";
-import { createActionCaller } from "./action-call";
+import { createActionCaller, requirePositionalString } from "./action-call";
 
 /** Kinds manageable through the SDK — the stored kinds minus the internal-only `interactive`. */
 export type AuthProfileKind = Exclude<StoredAuthProfileKind, "interactive">;
@@ -70,13 +70,32 @@ export function buildAuthProfilesNamespace(
 	return {
 		manage,
 		list: (input) => action("list_auth_profiles", input),
-		get: (auth_profile_slug) =>
-			action("get_auth_profile", { auth_profile_slug }),
-		test: (auth_profile_slug) =>
-			action("test_auth_profile", { auth_profile_slug }),
+		get: async (auth_profile_slug) =>
+			action("get_auth_profile", {
+				auth_profile_slug: requirePositionalString(
+					"authProfiles.get",
+					auth_profile_slug,
+					"client.authProfiles.get('google-calendar-account')",
+				),
+			}),
+		test: async (auth_profile_slug) =>
+			action("test_auth_profile", {
+				auth_profile_slug: requirePositionalString(
+					"authProfiles.test",
+					auth_profile_slug,
+					"client.authProfiles.test('google-calendar-account')",
+				),
+			}),
 		create: (input) => action("create_auth_profile", input),
 		update: (input) => action("update_auth_profile", input),
-		delete: (auth_profile_slug, options) =>
-			action("delete_auth_profile", { auth_profile_slug, ...options }),
+		delete: async (auth_profile_slug, options) =>
+			action("delete_auth_profile", {
+				auth_profile_slug: requirePositionalString(
+					"authProfiles.delete",
+					auth_profile_slug,
+					"client.authProfiles.delete('google-calendar-account')",
+				),
+				...options,
+			}),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/connections.ts
+++ b/packages/server/src/sandbox/namespaces/connections.ts
@@ -2,8 +2,9 @@
  * ClientSDK `connections` namespace. Thin, action-complete wrapper over
  * `manageConnections`.
  *
- * `connect` / `reauthenticate` return a `connect_url` the caller should show to
- * the user. Field names follow the handler schema.
+ * `connect` returns a `connect_url`. `reauthenticate` returns a `connect_url`
+ * for OAuth accounts or an `auth_run_id` for interactive pairing. Field names
+ * follow the handler schema.
  */
 
 import type {
@@ -15,7 +16,7 @@ import type {
 import type { Env } from "../../index";
 import { manageConnections } from "../../tools/admin/manage_connections";
 import type { ToolContext } from "../../tools/registry";
-import { createActionCaller } from "./action-call";
+import { createActionCaller, requirePositionalNumber } from "./action-call";
 
 export type ConnectionsConnectInput = ConnectionConnectInput;
 export type ConnectionsCreateInput = ConnectionCreateInput;
@@ -71,14 +72,41 @@ export function buildConnectionsNamespace(
 	return {
 		manage,
 		list: (input) => action("list", input),
-		get: (connection_id) => action("get", { connection_id }),
+		get: async (connection_id) =>
+			action("get", {
+				connection_id: requirePositionalNumber(
+					"connections.get",
+					connection_id,
+					"client.connections.get(418)",
+				),
+			}),
 		create: (input) => action("create", input),
 		connect: (input) => action("connect", input),
 		update: (input) => action("update", input),
-		delete: (connection_id) => action("delete", { connection_id }),
-		reauthenticate: (connection_id) =>
-			action("reauthenticate", { connection_id }),
-		test: (connection_id) => action("test", { connection_id }),
+		delete: async (connection_id) =>
+			action("delete", {
+				connection_id: requirePositionalNumber(
+					"connections.delete",
+					connection_id,
+					"client.connections.delete(418)",
+				),
+			}),
+		reauthenticate: async (connection_id) =>
+			action("reauthenticate", {
+				connection_id: requirePositionalNumber(
+					"connections.reauthenticate",
+					connection_id,
+					"client.connections.reauthenticate(418)",
+				),
+			}),
+		test: async (connection_id) =>
+			action("test", {
+				connection_id: requirePositionalNumber(
+					"connections.test",
+					connection_id,
+					"client.connections.test(418)",
+				),
+			}),
 		installConnector: (input) => action("install_connector", input),
 		uninstallConnector: (connector_key) =>
 			action("uninstall_connector", { connector_key }),

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -4,6 +4,7 @@
  * Used by manage_connections, manage_feeds, and manage_auth_profiles.
  */
 
+import { getScopedConnectorDefinition } from '../../../catalog/connector-definitions';
 import { getDb } from '../../../db/client';
 import type { Env } from '../../../index';
 import {
@@ -20,6 +21,7 @@ import {
   updateAuthProfile,
 } from '../../../utils/auth-profiles';
 import { DEFAULT_SCHEDULE } from '../../../utils/cron';
+import { createConnectToken } from '../../../utils/connect-tokens';
 import { getConfiguredPublicGatewayUrl } from '../../../utils/public-origin';
 import {
   readGrantedScopesFromAuthData,
@@ -456,6 +458,84 @@ export function getConnectBaseUrl(ctx: ToolContext): string {
     contextBase ??
     (ctx.requestUrl ? new URL(ctx.requestUrl).origin : '')
   ).replace(/\/+$/, '');
+}
+
+export async function issueOAuthReconnectLink(params: {
+  authProfile: AuthProfileRow;
+  ctx: ToolContext;
+  requestedScopes?: string[];
+}): Promise<
+  | { error: string }
+  | {
+      authProfile: AuthProfileRow;
+      connectUrl: string;
+      expiresAt: string;
+    }
+> {
+  const { authProfile, ctx } = params;
+  if (
+    authProfile.profile_kind !== 'oauth_account' ||
+    !authProfile.provider ||
+    !authProfile.connector_key
+  ) {
+    return {
+      error: `Auth profile '${authProfile.slug}' is not a reconnectable OAuth account profile`,
+    };
+  }
+
+  const connector = await getScopedConnectorDefinition({
+    organizationId: ctx.organizationId,
+    connectorKey: authProfile.connector_key,
+  });
+  if (!connector) {
+    return {
+      error: `Connector '${authProfile.connector_key}' not found or not active`,
+    };
+  }
+
+  const provider = authProfile.provider.toLowerCase();
+  const oauthMethod = getOAuthMethods(connector.auth_schema).find(
+    (method) => method.provider.toLowerCase() === provider
+  );
+  if (!oauthMethod) {
+    return {
+      error: `Connector '${authProfile.connector_key}' no longer supports OAuth provider '${authProfile.provider}'`,
+    };
+  }
+
+  const requestedScopes = resolveRequestedOAuthScopes(
+    oauthMethod,
+    params.requestedScopes ??
+      (authProfile.auth_data.requested_scopes as string[] | undefined) ??
+      undefined
+  );
+  const updatedProfile =
+    (await updateAuthProfile({
+      organizationId: ctx.organizationId,
+      slug: authProfile.slug,
+      authData: {
+        ...authProfile.auth_data,
+        requested_scopes: requestedScopes,
+      },
+    })) ?? authProfile;
+
+  const connectToken = await createConnectToken({
+    organizationId: ctx.organizationId,
+    authProfileId: updatedProfile.id,
+    connectorKey: authProfile.connector_key,
+    authType: 'oauth',
+    authConfig: {
+      ...buildOAuthConnectConfig(oauthMethod, requestedScopes),
+      requestedScopes,
+    },
+    createdBy: ctx.userId,
+  });
+
+  return {
+    authProfile: updatedProfile,
+    connectUrl: `${getConnectBaseUrl(ctx)}/connect/${connectToken.token}/oauth/start`,
+    expiresAt: new Date(connectToken.expires_at).toISOString(),
+  };
 }
 
 export async function buildViewUrl(

--- a/packages/server/src/tools/admin/helpers/connection-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/connection-helpers.ts
@@ -453,6 +453,24 @@ export function getConnectBaseUrl(ctx: ToolContext): string {
     }
   }
 
+  const appBase = contextBase ?? (ctx.requestUrl ? new URL(ctx.requestUrl).origin : '');
+  if (appBase) return new URL(appBase).origin.replace(/\/+$/, '');
+
+  const configuredGateway = getConfiguredPublicGatewayUrl();
+  return configuredGateway ? new URL(configuredGateway).origin.replace(/\/+$/, '') : '';
+}
+
+export function getGatewayBaseUrl(ctx: ToolContext): string {
+  const contextBase = ctx.baseUrl?.trim().replace(/\/+$/, '');
+  if (contextBase) {
+    try {
+      const path = new URL(contextBase).pathname.replace(/\/+$/, '');
+      if (path && path !== '/') return contextBase;
+    } catch {
+      return contextBase;
+    }
+  }
+
   return (
     getConfiguredPublicGatewayUrl() ??
     contextBase ??

--- a/packages/server/src/tools/admin/manage_auth_profiles.ts
+++ b/packages/server/src/tools/admin/manage_auth_profiles.ts
@@ -57,6 +57,7 @@ import {
   getEnvKeyMethods,
   getOAuthCredentialKeys,
   getOAuthMethods,
+  issueOAuthReconnectLink,
   resolveRequestedOAuthScopes,
   serializeAuthProfile,
 } from './helpers/connection-helpers';
@@ -707,58 +708,23 @@ async function handleUpdateAuthProfile(
     }
   }
 
-  if (
-    args.reconnect &&
-    authProfile.profile_kind === 'oauth_account' &&
-    authProfileProvider &&
-    authProfile.connector_key
-  ) {
-    const profileConnectorKey = authProfile.connector_key;
-    const connector = await getScopedConnectorDefinition({
-      organizationId: ctx.organizationId,
-      connectorKey: profileConnectorKey,
+  if (args.reconnect) {
+    const reconnect = await issueOAuthReconnectLink({
+      authProfile,
+      ctx,
+      requestedScopes: args.requested_scopes,
     });
-    const oauthMethod = connector
-      ? getOAuthMethods(connector.auth_schema).find((m) => m.provider === authProfileProvider)
-      : undefined;
+    if ('error' in reconnect) return reconnect;
 
-    if (oauthMethod) {
-      const requestedScopes = resolveRequestedOAuthScopes(
-        oauthMethod,
-        args.requested_scopes ??
-          (authProfile.auth_data?.requested_scopes as string[] | undefined) ??
-          undefined
-      );
-      authProfile =
-        (await updateAuthProfile({
-          organizationId: ctx.organizationId,
-          slug: authProfile.slug,
-          authData: {
-            ...(authProfile.auth_data ?? {}),
-            requested_scopes: requestedScopes,
-          },
-        })) ?? authProfile;
+    authProfile = reconnect.authProfile;
+    emitUpdateConfigChange(authProfile);
 
-      const connectToken = await createConnectToken({
-        organizationId: ctx.organizationId,
-        authProfileId: authProfile.id,
-        connectorKey: profileConnectorKey,
-        authType: 'oauth',
-        authConfig: {
-          ...buildOAuthConnectConfig(oauthMethod, requestedScopes),
-          requestedScopes,
-        },
-        createdBy: ctx.userId,
-      });
-
-      emitUpdateConfigChange(authProfile);
-
-      return {
-        action: 'update_auth_profile',
-        auth_profile: serializeAuthProfile(authProfile),
-        connect_url: `${getConnectBaseUrl(ctx)}/connect/${connectToken.token}/oauth/start`,
-      };
-    }
+    return {
+      action: 'update_auth_profile',
+      auth_profile: serializeAuthProfile(authProfile),
+      connect_url: reconnect.connectUrl,
+      expires_at: reconnect.expiresAt,
+    };
   }
 
   if (authProfile.profile_kind === 'browser_session') {

--- a/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/auth-actions.ts
@@ -14,6 +14,7 @@ import { ACTIVE_RUN_STATUSES, runStatusLiteral } from '../../../../utils/run-sta
 import type { ToolContext } from '../../../registry';
 import type { ManageConnectionsResult, ConnectionsArgs } from '../schemas';
 import { callerIsAdmin as resolveCallerIsAdmin } from '../../helpers/db-helpers';
+import { issueOAuthReconnectLink } from '../../helpers/connection-helpers';
 
 // ============================================
 // handleReauthenticate
@@ -61,17 +62,42 @@ export async function handleReauthenticate(
     auth_profile_status: string | null;
   };
 
-  // `reauthenticate` flips the connection + its interactive profile to
-  // `pending_auth` and kicks off an auth run — that has to be the connection
-  // owner or an admin/owner. Without this gate, any org member could disrupt
-  // (or hijack the pairing of) another member's interactive connection.
+  // Starting either auth family must be limited to the connection owner or an
+  // admin/owner. Otherwise any org member could disrupt or hijack another
+  // member's personal credential flow.
   const callerIsAdmin = await resolveCallerIsAdmin(sql, { organizationId, userId: ctx.userId });
   if (!callerIsAdmin && row.connection_created_by !== ctx.userId) {
     return { error: 'You can only re-authenticate connections you created.' };
   }
 
-  if (!row.auth_profile_id || row.profile_kind !== 'interactive') {
-    return { error: 'Connection does not use an interactive auth profile' };
+  if (!row.auth_profile_id) {
+    return { error: 'Connection does not have an auth profile' };
+  }
+
+  if (row.profile_kind === 'oauth_account') {
+    const authProfile = await getAuthProfileById(organizationId, row.auth_profile_id);
+    if (!authProfile) return { error: 'Connection auth profile not found' };
+    // Defense in depth for legacy/admin-bound rows where connection and profile
+    // creators may differ: owning the connection must not grant profile access.
+    if (!callerIsAdmin && authProfile.created_by !== ctx.userId) {
+      return { error: 'You can only re-authenticate OAuth profiles you created.' };
+    }
+
+    const reconnect = await issueOAuthReconnectLink({ authProfile, ctx });
+    if ('error' in reconnect) return reconnect;
+    return {
+      action: 'reauthenticate',
+      connection_id: row.id,
+      auth_profile_slug: reconnect.authProfile.slug,
+      connect_url: reconnect.connectUrl,
+      expires_at: reconnect.expiresAt,
+    };
+  }
+
+  if (row.profile_kind !== 'interactive') {
+    return {
+      error: `Connection auth profile kind '${row.profile_kind ?? 'unknown'}' cannot be reauthenticated`,
+    };
   }
 
   const activeRuns = await sql`

--- a/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/connect.ts
@@ -22,6 +22,7 @@ import {
   buildOAuthConnectConfig,
   ensureEnvBackedOAuthAppProfile,
   getConnectBaseUrl,
+	getGatewayBaseUrl,
 	getInteractiveMethods,
   resolveConnectionAuthSelection,
   resolveConnectionDisplayName,
@@ -116,7 +117,7 @@ export async function handleConnect(
     connectorKey: args.connector_key,
     authProfileSlug: args.auth_profile_slug,
     appAuthProfileSlug: args.app_auth_profile_slug,
-    gatewayBaseUrl: getConnectBaseUrl(ctx),
+    gatewayBaseUrl: getGatewayBaseUrl(ctx),
     setupUrl,
   });
   if (appInstallGuard) {

--- a/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
+++ b/packages/server/src/tools/admin/manage_connections/handlers/crud.ts
@@ -65,7 +65,7 @@ import {
   buildViewUrl,
   enrichWithAuthProfiles,
 	ensureEnvBackedOAuthAppProfile,
-  getConnectBaseUrl,
+	getGatewayBaseUrl,
   getInteractiveMethods,
   isPersonalCredentialKind,
   isPersonalCredVisibilityViolation,
@@ -681,7 +681,7 @@ export async function handleCreate(
     connectorKey: args.connector_key,
     authProfileSlug: args.auth_profile_slug,
     appAuthProfileSlug: args.app_auth_profile_slug,
-    gatewayBaseUrl: getConnectBaseUrl(ctx),
+    gatewayBaseUrl: getGatewayBaseUrl(ctx),
     setupUrl: await buildViewUrl(ctx, args.connector_key),
   });
   if (appInstallGuard) {

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -745,7 +745,7 @@ function buildOperationNextAction(args: {
 	}
 	if (
 		["pending_auth", "error", "revoked"].includes(readiness) &&
-		remediationAuthKind === "interactive"
+		["interactive", "oauth_account"].includes(remediationAuthKind ?? "")
 	) {
 		return {
 			action: "reauthenticate",

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -375,6 +375,29 @@ async function sdkSearchImpl(
 		}
 	}
 
+	// Natural-language clients commonly search with a bag of concepts rather
+	// than an exact phrase (for example "connections sync run"). Preserve the
+	// precise phrase results above, then fall back to token-ranked matches so a
+	// single extra word does not turn valid discovery into zero results.
+	if (matches.length === 0 && terms.length > 1) {
+		const ranked = catalog
+			.map(([path, meta]) => {
+				const pathText = path.toLowerCase();
+				const summaryText = meta.summary.toLowerCase();
+				const score = terms.reduce(
+					(total, term) =>
+						total +
+						(pathText.includes(term) ? 2 : 0) +
+						(summaryText.includes(term) ? 1 : 0),
+					0,
+				);
+				return { path, meta, score };
+			})
+			.filter((entry) => entry.score > 0)
+			.sort((a, b) => b.score - a.score || a.path.localeCompare(b.path));
+		for (const { path, meta } of ranked) matches.push([path, meta]);
+	}
+
 	if (matches.length === 0) {
 		const hiddenExact = METADATA_BY_LOWER_PATH.get(lower);
 		const existsButHidden = hiddenExact


### PR DESCRIPTION
## Summary
- document positional SDK signatures and reject object-shaped calls with actionable guidance
- support OAuth-account connections in `connections.reauthenticate` using the shared profile reconnect flow
- expose OAuth reconnect URLs/expiry consistently through connection, auth-profile, and operation lifecycle surfaces

## Validation
- `make pre-pr`
- `make test-integration`
- focused SDK unit and Postgres integration tests (red to green)
- local MCP E2E: `search_sdk`, argument validation, OAuth profile creation/get, connection creation, connection reauth, and profile reconnect
- `REVIEWER_CLI=claude CLAUDE_REVIEW_MODEL=opus make review` — 0 blockers, 0 bugs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786630195&installation_id=136316292&pr_number=1946&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1946&signature=1142d47a693cd29374b1d85391bb8db5abe0bbd781307ddf489f0722d7992721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth reconnection flows with refreshed authorization links and expiration details.
  * Expanded Hacker News front-page support for Ask HN and Show HN posts.
  * Improved SDK search for multi-word queries and added clearer method signatures and examples.
  * Related content results now display stable event IDs.

* **Bug Fixes**
  * Improved routing and URL handling for connection and app-installation flows.
  * Added clearer validation when SDK methods receive incorrectly formatted arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->