### PR TITLE
feat(sandbox-pin): pin each conversation's runtime realm; drive bash from the pin

### DIFF
--- a/db/migrations/20260714180000_conversations_sandbox_pin.sql
+++ b/db/migrations/20260714180000_conversations_sandbox_pin.sql
@@ -1,0 +1,78 @@
+-- migrate:up
+
+-- Immutable per-conversation sandbox pin. On a conversation's FIRST turn, freeze
+-- the RESOLVED runtime selection (which provider + which environment's creds
+-- execute this conversation's sandbox). Every later turn reads the pin instead of
+-- re-resolving the agent's CURRENT environment — so an admin repointing
+-- agents.environment_id never moves an existing conversation's sandbox
+-- (one-conversation-one-sandbox), while new conversations pick up the new realm.
+--
+-- Why freeze the RESOLVED value, not a reference:
+--  - The sandbox filesystem name is already conversation-stable
+--    (sha256(org:agent:conversation), no provider in it — vercel.ts), so the pin
+--    is a (provider, creds)-routing concern, not an FS one.
+--  - We store the resolved mode + provider + environment id, NOT the secret
+--    (creds rotate live behind the same environment id — desirable) and NOT the
+--    tri-state "unset/deployment_default" marker (that would re-read the mutable
+--    LOBU_RUNTIME_PROVIDER and could migrate a live conversation's FS). The
+--    unset case is resolved down to a concrete mode ('builtin' local just-bash,
+--    or 'provider' + provider id) and frozen.
+--  - No FK to environments: it is hard-deleted (no deleted_at). A pinned env that
+--    is later deleted/deactivated must FAIL CLOSED (matches PR-0), not dangle to
+--    system creds — enforced in app code (resolveRuntimeCredentials: an env-bound
+--    resolution never splices system env), not by a cascade.
+--
+-- Provider selection is SOLELY the agent's Environment. The deployment-wide
+-- LOBU_RUNTIME_PROVIDER env var is intentionally NOT consulted: it only ever
+-- named a provider KIND while credentials always come from the environments
+-- vault, so it could never route a working sandbox on its own. INTENDED BREAKING
+-- CHANGE: a self-host that set LOBU_RUNTIME_PROVIDER expecting remote bash (with
+-- no Environment attached) now runs local just-bash — attach a provider
+-- Environment to the agent instead.
+--
+-- sandbox_provider_id doubles as the "pinned yet?" guard: NULL = unpinned, and
+-- the first-turn CAS is `... WHERE sandbox_provider_id IS NULL` for mode
+-- 'provider'. Because 'builtin' has a NULL provider id too, sandbox_mode carries
+-- the pinned/unpinned bit: NULL sandbox_mode = unpinned.
+ALTER TABLE public.conversations
+  ADD COLUMN IF NOT EXISTS sandbox_mode         text,   -- NULL=unpinned; 'builtin' | 'provider'
+  ADD COLUMN IF NOT EXISTS sandbox_provider_id  text,   -- runtimeProviderId when mode='provider'
+  ADD COLUMN IF NOT EXISTS sandbox_environment_id text, -- environments.id backing the provider creds (NULL for builtin)
+  ADD COLUMN IF NOT EXISTS sandbox_pinned_at    timestamptz;
+
+-- ADD CONSTRAINT has no IF NOT EXISTS in Postgres; guard each on pg_constraint
+-- so the up migration is idempotent (a partial-failure rerun won't duplicate-
+-- object error), matching the ADD COLUMN IF NOT EXISTS above.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'conversations_sandbox_mode_check'
+  ) THEN
+    ALTER TABLE public.conversations
+      ADD CONSTRAINT conversations_sandbox_mode_check
+        CHECK (sandbox_mode IS NULL OR sandbox_mode IN ('builtin', 'provider'));
+  END IF;
+
+  -- mode='provider' requires a provider id; mode='builtin' must not carry one.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'conversations_sandbox_provider_consistent'
+  ) THEN
+    ALTER TABLE public.conversations
+      ADD CONSTRAINT conversations_sandbox_provider_consistent
+        CHECK (
+          (sandbox_mode = 'provider' AND sandbox_provider_id IS NOT NULL)
+          OR (sandbox_mode = 'builtin' AND sandbox_provider_id IS NULL)
+          OR (sandbox_mode IS NULL AND sandbox_provider_id IS NULL)
+        );
+  END IF;
+END $$;
+
+-- migrate:down
+-- squawk-ignore ban-drop-column -- rollback path for columns introduced by this migration
+ALTER TABLE public.conversations
+  DROP CONSTRAINT IF EXISTS conversations_sandbox_provider_consistent,
+  DROP CONSTRAINT IF EXISTS conversations_sandbox_mode_check,
+  DROP COLUMN IF EXISTS sandbox_pinned_at,
+  DROP COLUMN IF EXISTS sandbox_environment_id,
+  DROP COLUMN IF EXISTS sandbox_provider_id,
+  DROP COLUMN IF EXISTS sandbox_mode;

--- a/packages/agent-worker/src/__tests__/embedded-just-bash-bootstrap.test.ts
+++ b/packages/agent-worker/src/__tests__/embedded-just-bash-bootstrap.test.ts
@@ -14,6 +14,7 @@ const originalEnv = {
   LOBU_EXEC_SANDBOX: process.env.LOBU_EXEC_SANDBOX,
   LOBU_ALLOW_UNSANDBOXED_EXEC: process.env.LOBU_ALLOW_UNSANDBOXED_EXEC,
   LOBU_WORKSPACE_BACKEND: process.env.LOBU_WORKSPACE_BACKEND,
+  LOBU_RUNTIME_PROVIDER: process.env.LOBU_RUNTIME_PROVIDER,
 };
 
 function restoreEnv(name: keyof typeof originalEnv): void {
@@ -33,6 +34,7 @@ afterEach(() => {
   restoreEnv("LOBU_EXEC_SANDBOX");
   restoreEnv("LOBU_ALLOW_UNSANDBOXED_EXEC");
   restoreEnv("LOBU_WORKSPACE_BACKEND");
+  restoreEnv("LOBU_RUNTIME_PROVIDER");
   resetSandboxProbeForTests();
 });
 
@@ -63,6 +65,43 @@ describe("createEmbeddedBashOps", () => {
 
     expect(result.exitCode).not.toBe(0);
     expect(chunks.join("")).not.toContain("root:");
+  });
+
+  // The pin is load-bearing and the SOLE selector: on a warm deployment reused
+  // across conversations pinned to different realms, the per-turn
+  // `runtimeProviderId` selects the bash backend and LOBU_RUNTIME_PROVIDER is
+  // never consulted. A remote-provider backend requires `gw` params and throws
+  // without them; we use that throw as an observable signal of which backend was
+  // selected (no live sandbox needed).
+  describe("per-turn runtimeProviderId is the sole backend selector", () => {
+    test("no pinned provider runs local just-bash even when LOBU_RUNTIME_PROVIDER=vercel", async () => {
+      const workspace = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), "lobu-pin-local-"))
+      );
+      tempDirs.push(workspace);
+      // The env var is deliberately set to a remote provider to prove it is
+      // ignored: with no pin and no `gw`, a legacy env-var read would throw
+      // "requires gateway parameters". Instead it resolves to local just-bash.
+      process.env.LOBU_RUNTIME_PROVIDER = "vercel";
+
+      const ops = await createEmbeddedBashOps({ workspaceDir: workspace });
+      const chunks: string[] = [];
+      const result = await ops.exec("echo pinned-local", "/", {
+        onData: (chunk) => chunks.push(chunk.toString()),
+        timeout: 5,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(chunks.join("")).toContain("pinned-local");
+    });
+
+    test("a 'vercel' pin routes remote even when LOBU_RUNTIME_PROVIDER is unset", async () => {
+      delete process.env.LOBU_RUNTIME_PROVIDER;
+      // A remote provider without `gw` throws — proving the PIN (not the unset
+      // env var) drove selection to the remote backend.
+      await expect(
+        createEmbeddedBashOps({ runtimeProviderId: "vercel" })
+      ).rejects.toThrow(/requires gateway parameters/);
+    });
   });
 });
 

--- a/packages/agent-worker/src/core/types.ts
+++ b/packages/agent-worker/src/core/types.ts
@@ -48,6 +48,14 @@ export interface WorkerConfig {
    * equality with body.runId (codex round 2 finding A on PR #865).
    */
   runJobToken: string;
+  /**
+   * Pinned bash-backend provider for this conversation, resolved per-turn by the
+   * gateway from the immutable sandbox pin. Selects the worker's bash backend so
+   * a warm deployment routes on the pin:
+   *  - a provider id (e.g. `"vercel"`) → that remote runtime;
+   *  - undefined → local just-bash.
+   */
+  runtimeProviderId?: string;
 }
 
 export interface WorkspaceSetupConfig {

--- a/packages/agent-worker/src/embedded/just-bash-bootstrap.ts
+++ b/packages/agent-worker/src/embedded/just-bash-bootstrap.ts
@@ -381,6 +381,14 @@ interface EmbeddedBashOpsOptions {
   gw?: GatewayParams;
   /** `"tools"` (default) keeps today's first-class MCP tools. `"cli"` swaps to sandboxed bash CLIs. */
   mcpExposure?: "tools" | "cli";
+  /**
+   * This conversation's pinned bash-backend provider (per-turn, from the sandbox
+   * pin), so a warm deployment reused across conversations with different pins
+   * routes each turn correctly:
+   *  - a provider id (e.g. `"vercel"`) → that remote runtime;
+   *  - undefined → local just-bash.
+   */
+  runtimeProviderId?: string;
 }
 
 /**
@@ -398,24 +406,23 @@ async function adaptMcpCliCommand(
 }
 
 /**
- * Create a BashOperations adapter backed by a just-bash Bash instance.
- * Reads configuration from environment variables.
+ * Create a BashOperations adapter backed by a just-bash Bash instance. The
+ * conversation's pinned provider (`options.runtimeProviderId`) selects the
+ * backend; undefined → local just-bash.
  */
 export async function createEmbeddedBashOps(
   options: EmbeddedBashOpsOptions = {}
 ): Promise<BashOperations> {
-  const runtimeProvider = getWorkerRuntimeProvider(
-    process.env.LOBU_RUNTIME_PROVIDER
-  );
+  const runtimeProvider = getWorkerRuntimeProvider(options.runtimeProviderId);
   if (runtimeProvider) {
     if (!options.gw) {
       throw new Error(
-        `LOBU_RUNTIME_PROVIDER=${runtimeProvider.id} requires gateway parameters`
+        `runtime provider ${runtimeProvider.id} requires gateway parameters`
       );
     }
     if (options.mcpExposure === "cli") {
       console.warn(
-        `[embedded] LOBU_RUNTIME_PROVIDER=${runtimeProvider.id} routes bash through a remote runtime; MCP CLI exposure is unavailable there. Use MCP tools exposure instead.`
+        `[embedded] runtime provider ${runtimeProvider.id} routes bash through a remote runtime; MCP CLI exposure is unavailable there. Use MCP tools exposure instead.`
       );
     }
     console.log(

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -96,6 +96,10 @@ const JobEventSchema = z.object({
       // same way.
       runId: z.number(),
       runJobToken: z.string(),
+      // Pinned bash-backend provider for THIS conversation (resolved per-turn by
+      // the gateway from the immutable sandbox pin). Selects the worker's bash
+      // backend so a warm deployment routes on the pin. Absent → local just-bash.
+      runtimeProviderId: z.string().optional(),
     })
     .passthrough(),
   processedIds: z.array(z.string()).optional(),
@@ -1026,6 +1030,9 @@ export class GatewayClient {
       // lifetime WORKER_TOKEN, so the gateway can enforce
       // tokenData.runId === body.runId — codex round 2 finding A.
       runJobToken: payload.runJobToken,
+      // Pinned bash-backend provider for this conversation; drives the worker's
+      // local backend selection (see WorkerConfig.runtimeProviderId).
+      runtimeProviderId: payload.runtimeProviderId,
     };
   }
 

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -472,6 +472,12 @@ interface RunAISessionParams {
   runId: number;
   messageId: string;
   connectionId?: string;
+  /**
+   * This conversation's pinned bash-backend provider (from WorkerConfig).
+   * Selects the bash backend per-turn: a provider id → that remote runtime;
+   * undefined → local just-bash.
+   */
+  runtimeProviderId?: string;
 
   // Resolved workspace directory (from WorkspaceManager)
   workspaceDir: string;
@@ -538,6 +544,7 @@ export async function runAISession(
     runId,
     messageId,
     connectionId,
+    runtimeProviderId,
     workspaceDir,
     progressProcessor,
     onSessionFilePathResolved,
@@ -942,6 +949,8 @@ export async function runAISession(
       mcpRuntimeRef,
       gw: gwParams,
       mcpExposure,
+      // Per-turn pinned provider from the sandbox pin; selects the bash backend.
+      runtimeProviderId,
     });
   let tools = createLobuTools(workspaceDir, {
     bashOperations: embeddedBashOps,

--- a/packages/agent-worker/src/runtime/worker.ts
+++ b/packages/agent-worker/src/runtime/worker.ts
@@ -561,6 +561,7 @@ export class LobuAgentWorker implements WorkerExecutor {
         typeof this.config.platformMetadata?.connectionId === "string"
           ? this.config.platformMetadata.connectionId
           : undefined,
+      runtimeProviderId: this.config.runtimeProviderId,
       workspaceDir: this.workspaceManager.getCurrentWorkingDirectory(),
       progressProcessor: this.progressProcessor,
       onSessionFilePathResolved: (filePath) => {

--- a/packages/core/src/worker/wire.ts
+++ b/packages/core/src/worker/wire.ts
@@ -97,6 +97,22 @@ export interface MessagePayload {
   runJobToken?: string;
 
   /**
+   * This conversation's PINNED runtime provider for the bash backend, resolved
+   * per-turn by the gateway from the immutable sandbox pin (`resolvePinnedSelection`).
+   * Frozen on the conversation's first turn so an agent repoint never moves an
+   * existing conversation's sandbox realm.
+   *
+   *  - a provider id (e.g. `"vercel"`) → route bash to that remote runtime;
+   *  - absent → local just-bash.
+   *
+   * The pinned provider is ALSO a signed claim in `runJobToken` (the remote
+   * runtime route reads it from the token, never this body field) — this field
+   * exists only so the worker's backend selection is per-turn-accurate on a warm
+   * deployment reused across conversations pinned to different realms.
+   */
+  runtimeProviderId?: string;
+
+  /**
    * Per-agent operator-authored inline guardrails. Threaded alongside
    * `networkConfig` so the deployment manager can sync the `egress`-stage
    * entries into the egress policy store (the proxy-plane LLM judge). The

--- a/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
+++ b/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
@@ -455,7 +455,11 @@ describe("DeploymentManager", () => {
       }
     });
 
-    test("forwards runtime provider selector without provider credentials", async () => {
+    test("never forwards a runtime selector or provider credentials to the worker", async () => {
+      // Runtime routing rides the conversation's per-turn pin (signed token +
+      // payload), NOT a spawned env var. The worker env must carry neither a
+      // LOBU_RUNTIME_PROVIDER selector nor any provider credential — even when
+      // the gateway process itself has them set.
       const previous = {
         LOBU_RUNTIME_PROVIDER: process.env.LOBU_RUNTIME_PROVIDER,
         VERCEL_TOKEN: process.env.VERCEL_TOKEN,
@@ -476,7 +480,7 @@ describe("DeploymentManager", () => {
           | { env?: Record<string, string> }
           | undefined;
 
-        expect(spawnOptions?.env?.LOBU_RUNTIME_PROVIDER).toBe("vercel");
+        expect(spawnOptions?.env?.LOBU_RUNTIME_PROVIDER).toBeUndefined();
         expect(spawnOptions?.env?.VERCEL_TOKEN).toBeUndefined();
         expect(spawnOptions?.env?.VERCEL_TEAM_ID).toBeUndefined();
         expect(spawnOptions?.env?.VERCEL_PROJECT_ID).toBeUndefined();

--- a/packages/server/src/gateway/__tests__/runtime-route.test.ts
+++ b/packages/server/src/gateway/__tests__/runtime-route.test.ts
@@ -67,6 +67,13 @@ mock.module("@vercel/sandbox", () => ({
   Sandbox: { getOrCreate: getOrCreateMock },
 }));
 
+// Env-bound credential resolution reads the vault. Mock it to a MISS (null) so
+// the "environment pinned but deleted" case is deterministic and DB-free: the
+// scoped key is gone, so an env-bound resolution must fail closed.
+mock.module("../../lobu/stores/provider-secrets.js", () => ({
+  readEnvironmentSecret: async () => null,
+}));
+
 // Importing the route pulls in the gateway runtime registry barrel, which
 // registers the Vercel provider. The @vercel/sandbox mock above is installed
 // first so the provider module binds to it.
@@ -96,6 +103,7 @@ function token(
   options: {
     agentId?: string;
     runtimeProviderId?: string;
+    environmentId?: string;
     allowedDomains?: string[];
   } = {}
 ): string {
@@ -106,6 +114,7 @@ function token(
     organizationId: "org-1",
     agentId: options.agentId,
     runtimeProviderId: options.runtimeProviderId,
+    environmentId: options.environmentId,
     allowedDomains: options.allowedDomains,
   });
 }
@@ -252,6 +261,40 @@ describe("createRuntimeRoutes", () => {
     expect(getOrCreateMock).toHaveBeenCalledTimes(1);
     // SDK self-resolves OIDC — no explicit token/teamId/projectId passed in.
     expect(getOrCreateMock.mock.calls[0]?.[0]).not.toHaveProperty("token");
+  });
+
+  test("424s for an ENVIRONMENT-BOUND vault miss even when VERCEL_OIDC_TOKEN is present (no host-realm self-auth)", async () => {
+    // The token names a specific environmentId (a pinned Environment), but the
+    // vault read misses (mocked null → the environment was deleted). OIDC is
+    // present, so the env-LESS path would self-auth into the host realm. An
+    // env-bound miss must fail closed instead — a conversation pinned to a
+    // deleted Environment must NOT execute in the host realm.
+    delete process.env.VERCEL_TOKEN;
+    delete process.env.VERCEL_TEAM_ID;
+    delete process.env.VERCEL_PROJECT_ID;
+    process.env.VERCEL_OIDC_TOKEN = "oidc.test.token";
+    const workspaceDir = path.resolve("workspaces", "verceltestagent", "conv-1");
+
+    const router = createRuntimeRoutes();
+    const res = await router.request("/internal/runtime/exec", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token({
+          agentId: "verceltestagent",
+          runtimeProviderId: "vercel",
+          environmentId: "env-deleted",
+        })}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ command: "pwd", workspaceDir }),
+    });
+
+    expect(res.status).toBe(424);
+    expect(await res.json()).toEqual({
+      error: "Runtime provider credentials unavailable",
+    });
+    // Fail closed → no sandbox was created in the host realm.
+    expect(getOrCreateMock).not.toHaveBeenCalled();
   });
 
   test("424s when required credentials are only partially configured", async () => {

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -40,7 +40,7 @@ import {
 } from "./deployment-utils.js";
 import { failTurnsForDeployment } from "./turn-liveness.js";
 import { buildWorkerTokenClaims } from "./worker-token-claims.js";
-import { resolveAgentRuntimeSelection } from "../../lobu/stores/environment-store.js";
+import { resolvePinnedSelection } from "../../lobu/stores/environment-store.js";
 import { getInternalGatewayUrl } from "../config/index.js";
 
 const logger = createLogger("orchestrator");
@@ -642,7 +642,6 @@ export function buildDeploymentWorkerToken(args: {
    *  also carries the claim the runtime route reads (parity with the per-run mint). */
   runtimeProviderId?: string;
   environmentId?: string;
-  runtimeExplicit?: boolean;
   /** Resolved egress allowlist for a remote runtime sandbox (signed claim). */
   allowedDomains?: string[];
 }): string {
@@ -1343,14 +1342,6 @@ export class DeploymentManager {
       envVars.APP_GIT_SHA = process.env.APP_GIT_SHA;
     }
 
-    // Non-secret worker runtime selector — tells the worker which provider
-    // client to use for bash. Provider credentials remain in the gateway
-    // process and are never forwarded to worker subprocesses.
-    if (process.env.LOBU_RUNTIME_PROVIDER?.trim()) {
-      envVars.LOBU_RUNTIME_PROVIDER =
-        process.env.LOBU_RUNTIME_PROVIDER.trim();
-    }
-
     // Add OTLP endpoint for distributed tracing
     const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
     if (otlpEndpoint) {
@@ -1515,14 +1506,20 @@ export class DeploymentManager {
       organizationId: validated.organizationId,
     };
 
-    // Resolve the agent's selected Environment → runtime provider once. Used for
-    // BOTH the deployment token claim (so the runtime route picks the provider)
-    // and the worker's LOBU_RUNTIME_PROVIDER below (so the worker's bash backend
-    // routes there). Per-agent selection wins; the env-var fallback in
-    // buildWorkerTokenClaims / assembleBaseEnv covers the unpinned case.
-    const runtimeSelection = agentId
-      ? await resolveAgentRuntimeSelection(agentId, validated.organizationId)
-      : { explicit: false };
+    // Resolve THIS CONVERSATION's pinned runtime provider (frozen on its first
+    // turn) for the deployment token claim, so the generic runtime route picks
+    // the provider. Reading the pin (not the agent's current env) is what makes
+    // an agent repoint never move an existing conversation's sandbox. Undefined →
+    // local just-bash.
+    const runtimeSelection =
+      agentId && validated.organizationId
+        ? await resolvePinnedSelection({
+            organizationId: validated.organizationId,
+            agentId,
+            platform,
+            conversationId,
+          })
+        : {};
 
     const workerToken = buildDeploymentWorkerToken({
       userId,
@@ -1537,7 +1534,6 @@ export class DeploymentManager {
       traceId,
       runtimeProviderId: runtimeSelection.runtimeProviderId,
       environmentId: runtimeSelection.environmentId,
-      runtimeExplicit: runtimeSelection.explicit,
       // Same allowlist synced to the grant store / JUST_BASH_ALLOWED_DOMAINS — so
       // the runtime route reads it off the signed token, not the worker's body.
       allowedDomains: messageData?.networkConfig?.allowedDomains,
@@ -1562,17 +1558,6 @@ export class DeploymentManager {
       proxyUrl,
       dispatcherHost
     );
-
-    // Per-agent runtime selection overrides the deployment-wide
-    // LOBU_RUNTIME_PROVIDER (set by assembleBaseEnv) so the worker's bash
-    // backend routes to the agent's chosen provider. An explicit builtin pin
-    // clears it so the worker runs local just-bash even on a self-host that set
-    // the env var.
-    if (runtimeSelection.runtimeProviderId) {
-      envVars.LOBU_RUNTIME_PROVIDER = runtimeSelection.runtimeProviderId;
-    } else if (runtimeSelection.explicit) {
-      delete envVars.LOBU_RUNTIME_PROVIDER;
-    }
 
     // Include host-provided secret references when requested.
     if (includeSecrets && this.moduleEnvVarsBuilder) {

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -412,12 +412,28 @@ export class MessageConsumer {
       // The pin is frozen on the first turn and read thereafter, so an agent
       // repoint never moves an existing conversation's sandbox. Undefined →
       // local just-bash.
-      const runtimeSelection = await resolvePinnedSelection({
-        organizationId: data.organizationId,
-        agentId: data.agentId,
-        platform: data.platform,
-        conversationId: effectiveConversationId,
-      });
+      //
+      // Best-effort at the enqueue site: resolvePinnedSelection throws on a total
+      // DB failure (to fail-closed the RUNTIME realm decision), but dispatch
+      // liveness must not hinge on a pin read — a blip here degrades this ONE turn
+      // to unpinned rather than dropping the message. The pin self-heals on the
+      // next turn (the CAS guard means an unpinned dispatch never overwrites an
+      // existing pin), and the runtime route re-resolves the realm from the token.
+      let runtimeSelection: Awaited<ReturnType<typeof resolvePinnedSelection>>;
+      try {
+        runtimeSelection = await resolvePinnedSelection({
+          organizationId: data.organizationId,
+          agentId: data.agentId,
+          platform: data.platform,
+          conversationId: effectiveConversationId,
+        });
+      } catch (err) {
+        logger.warn(
+          { traceId, agentId: data.agentId, error: getErrorMessage(err) },
+          "Pin resolution failed at enqueue; dispatching this turn unpinned"
+        );
+        runtimeSelection = {};
+      }
 
       // Stamp the pinned provider onto the payload body so the worker selects its
       // bash backend per-turn (a warm deployment is reused across conversations

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -41,7 +41,7 @@ import {
   type OrchestratorConfig,
 } from "./deployment-manager.js";
 import { buildWorkerTokenClaims } from "./worker-token-claims.js";
-import { resolveAgentRuntimeSelection } from "../../lobu/stores/environment-store.js";
+import { resolvePinnedSelection } from "../../lobu/stores/environment-store.js";
 import { resolveChatUserIdentity } from "../../lobu/stores/chat-identity.js";
 import { getDb } from "../../db/client.js";
 import {
@@ -162,13 +162,12 @@ export function buildRunJobToken(args: {
    */
   adminTools?: string[];
   /**
-   * Resolved runtime provider + environment for this agent (from its selected
-   * Environment). Stamped into the token so the generic runtime route picks the
-   * provider + vault credential. Undefined → deployment-wide LOBU_RUNTIME_PROVIDER.
+   * Resolved runtime provider + environment for this conversation (from its
+   * pinned Environment). Stamped into the token so the generic runtime route
+   * picks the provider + vault credential. Undefined → local just-bash.
    */
   runtimeProviderId?: string;
   environmentId?: string;
-  runtimeExplicit?: boolean;
   /** Resolved egress allowlist for a remote runtime sandbox (signed claim). */
   allowedDomains?: string[];
 }): string {
@@ -409,13 +408,22 @@ export class MessageConsumer {
         teamId: data.teamId,
       });
 
-      // Resolve the agent's selected execution environment → runtime provider +
-      // credential, stamped into the per-run token. Falls back to the
-      // deployment-wide selector when no environment is pinned.
-      const runtimeSelection = await resolveAgentRuntimeSelection(
-        data.agentId,
-        data.organizationId
-      );
+      // Resolve THIS CONVERSATION's pinned runtime provider from its Environment.
+      // The pin is frozen on the first turn and read thereafter, so an agent
+      // repoint never moves an existing conversation's sandbox. Undefined →
+      // local just-bash.
+      const runtimeSelection = await resolvePinnedSelection({
+        organizationId: data.organizationId,
+        agentId: data.agentId,
+        platform: data.platform,
+        conversationId: effectiveConversationId,
+      });
+
+      // Stamp the pinned provider onto the payload body so the worker selects its
+      // bash backend per-turn (a warm deployment is reused across conversations
+      // pinned to different realms). The REMOTE runtime route still reads the
+      // provider from the signed runJobToken below, never this body field.
+      data.runtimeProviderId = runtimeSelection.runtimeProviderId;
 
       data.runJobToken = buildRunJobToken({
         userId: data.userId,
@@ -436,7 +444,6 @@ export class MessageConsumer {
         adminTools,
         runtimeProviderId: runtimeSelection.runtimeProviderId,
         environmentId: runtimeSelection.environmentId,
-        runtimeExplicit: runtimeSelection.explicit,
         // Egress allowlist as a signed claim (kept in lockstep with the
         // deployment-token mint) — the runtime route reads it, never the body.
         allowedDomains: data.networkConfig?.allowedDomains,

--- a/packages/server/src/gateway/orchestration/worker-token-claims.ts
+++ b/packages/server/src/gateway/orchestration/worker-token-claims.ts
@@ -20,21 +20,14 @@ export interface WorkerTokenClaimsArgs {
   platform?: string;
   platformMetadata?: Record<string, unknown>;
   /**
-   * Selected runtime provider for this agent, resolved from its environment by
-   * the caller (which has the agent settings + environments store). When
-   * omitted, falls back to the deployment-wide `LOBU_RUNTIME_PROVIDER` (self-
-   * host / org default). The generic runtime route reads this claim to pick a
-   * provider — see WorkerTokenData.runtimeProviderId.
+   * Selected runtime provider for this conversation, resolved from the agent's
+   * Environment by the caller (which has the agent settings + environments
+   * store). Undefined → local just-bash. The generic runtime route reads this
+   * claim to pick a provider — see WorkerTokenData.runtimeProviderId.
    */
   runtimeProviderId?: string;
   /** The `environments.id` whose vault credential backs the provider above. */
   environmentId?: string;
-  /**
-   * True when the agent has an explicit runtime selection (a provider or
-   * builtin). When true, the env-var fallback below is suppressed so an agent
-   * pinned to builtin doesn't inherit the deployment-wide LOBU_RUNTIME_PROVIDER.
-   */
-  runtimeExplicit?: boolean;
   /**
    * The agent's resolved egress allowlist (`networkConfig.allowedDomains`). Set
    * here so the runtime route can read it off the SIGNED token instead of
@@ -69,15 +62,9 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
   environmentId?: string;
   allowedDomains?: string[];
 } {
-  // Per-agent environment selection wins; otherwise the deployment-wide
-  // selector covers self-host / org-default — UNLESS the agent made an explicit
-  // selection (e.g. pinned to builtin), in which case we honor it and skip the
-  // env-var fallback. Resolving here keeps both mints in lockstep.
-  const runtimeProviderId =
-    args.runtimeProviderId ??
-    (args.runtimeExplicit
-      ? undefined
-      : process.env.LOBU_RUNTIME_PROVIDER?.trim() || undefined);
+  // Provider comes solely from the conversation's pinned Environment; there is
+  // no deployment-wide env-var fallback. Undefined → local just-bash.
+  const runtimeProviderId = args.runtimeProviderId;
   return {
     channelId: args.channelId,
     teamId: args.teamId,
@@ -93,9 +80,6 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
         ? args.platformMetadata.source
         : undefined,
     runtimeProviderId,
-    // Only meaningful when a per-agent environment drove the selection; the
-    // env-var fallback has no environment row, so credentials resolve from
-    // system env.
     environmentId: runtimeProviderId ? args.environmentId : undefined,
     // Non-empty only; an empty list is equivalent to absent (deny-all) and
     // keeps the token payload minimal.

--- a/packages/server/src/gateway/routes/internal/runtime.ts
+++ b/packages/server/src/gateway/routes/internal/runtime.ts
@@ -56,12 +56,14 @@ export function createRuntimeRoutes(): Hono<WorkerContext> {
         worker.environmentId
       );
       if (!credentials) {
-        // No vault/system credential configured. A provider that can
-        // self-authenticate (e.g. Vercel via an ambient VERCEL_OIDC_TOKEN when
-        // Lobu runs on Vercel) is allowed to proceed with no explicit creds;
-        // otherwise fail closed so a misconfigured environment can't run
-        // unauthenticated.
-        if (provider.canSelfAuth?.()) {
+        // No vault/system credential resolved. Provider self-auth (e.g. Vercel
+        // via an ambient VERCEL_OIDC_TOKEN when Lobu itself runs on Vercel) is
+        // the HOST realm — permissible ONLY for an env-LESS resolution (self-host
+        // / org default). An ENVIRONMENT-BOUND miss must fail closed: a
+        // conversation pinned to a specific Environment that's been deleted or
+        // misconfigured must NOT silently execute in the host realm under ambient
+        // OIDC — that would break the one-conversation-one-realm pin contract.
+        if (!worker.environmentId && provider.canSelfAuth?.()) {
           credentials = { values: {}, source: "system" };
         } else {
           return errorResponse(

--- a/packages/server/src/gateway/runtime/__tests__/credentials.test.ts
+++ b/packages/server/src/gateway/runtime/__tests__/credentials.test.ts
@@ -83,4 +83,20 @@ describe("resolveRuntimeCredentials", () => {
     const result = await resolveRuntimeCredentials(provider, "org-1", undefined);
     expect(result).toBeNull();
   });
+
+  test("env-bound with a vault MISS fails closed — never leaks system env", async () => {
+    // The pinned environment was deleted (its vault keys purged), so the scoped
+    // read returns null. System env is fully populated, but an environment-bound
+    // resolution must NOT splice it in — it fails closed so the route 424s,
+    // rather than running the pinned conversation under the host's ambient creds.
+    process.env.VERCEL_TOKEN = "env-token";
+    process.env.VERCEL_TEAM_ID = "env-team";
+    process.env.VERCEL_PROJECT_ID = "env-project";
+    readEnvironmentSecretMock.mockImplementation(async () => null);
+
+    const result = await resolveRuntimeCredentials(provider, "org-1", "env-deleted");
+    expect(result).toBeNull();
+    // The vault was consulted (env-bound path), not the system env.
+    expect(readEnvironmentSecretMock).toHaveBeenCalled();
+  });
 });

--- a/packages/server/src/gateway/runtime/credentials.ts
+++ b/packages/server/src/gateway/runtime/credentials.ts
@@ -5,14 +5,22 @@ import type {
 } from "./types.js";
 
 /**
- * Resolve a provider's credentials gateway-side, per field, with the same tier
- * order as model providers: org vault first (BYO), then deployment system env.
- * Keyed per-environment (`environment:<envId>:<field>`) when the token carries
- * an `environmentId`; otherwise system env only (self-host / org-default).
+ * Resolve a provider's credentials gateway-side, per field. Two tiers, chosen by
+ * whether the token carries an `environmentId`:
+ *
+ *  - environment-bound (`environmentId` present): read ONLY the per-environment
+ *    vault key (`environment:<envId>:<field>`). NO system-env fallback — an
+ *    environment that names a specific realm must fail closed if its credential
+ *    is gone (e.g. the environment was deleted, which purges its vault keys, and
+ *    a conversation pinned to it later runs a turn). Falling back to system env
+ *    here would silently run a pinned conversation under the host's ambient
+ *    provider creds, violating the one-conversation-one-realm pin contract (and
+ *    mirroring PR-0's kill of the env-bound → system splice).
+ *  - env-less (no `environmentId`, self-host / org-default): system env only.
  *
  * Returns null when a `required` field can't be resolved — the route turns that
- * into a 424 so a misconfigured environment fails closed rather than running
- * unauthenticated. The plaintext never leaves the gateway.
+ * into a 424 so a misconfigured/deleted environment fails closed rather than
+ * running unauthenticated. The plaintext never leaves the gateway.
  */
 export async function resolveRuntimeCredentials(
   provider: GatewayRuntimeProvider,
@@ -20,19 +28,21 @@ export async function resolveRuntimeCredentials(
   environmentId: string | undefined
 ): Promise<ResolvedRuntimeCredentials | null> {
   const values: Record<string, string> = {};
-  let source: "byo" | "system" = "system";
+  // Environment-bound → BYO vault, no system splice; env-less → system env.
+  const envBound = Boolean(organizationId && environmentId);
+  const source: "byo" | "system" = envBound ? "byo" : "system";
 
   for (const field of provider.credentialFields) {
     let value: string | null = null;
-    if (organizationId && environmentId) {
+    if (envBound) {
+      // organizationId + environmentId are both set (envBound); read the scoped
+      // vault key only. A miss here fails closed below — no system fallback.
       value = await readEnvironmentSecret(
-        environmentId,
+        environmentId as string,
         field.key,
-        organizationId
+        organizationId as string
       );
-      if (value) source = "byo";
-    }
-    if (!value) {
+    } else {
       const envValue = process.env[field.systemEnvVar];
       value = envValue && envValue.trim() ? envValue : null;
     }

--- a/packages/server/src/gateway/services/conversations-store.ts
+++ b/packages/server/src/gateway/services/conversations-store.ts
@@ -60,8 +60,12 @@ export interface ConversationUpsert {
 export async function upsertConversation(
 	row: ConversationUpsert,
 ): Promise<void> {
-	const sql = getDb();
+	// getDb() inside the try: it throws when DATABASE_URL is unset (or the pool
+	// can't init), and a listing-materialization hiccup must never fail a live
+	// turn — so the swallow below must cover the client acquisition too, not just
+	// the query.
 	try {
+		const sql = getDb();
 		await sql`
       INSERT INTO public.conversations (
         organization_id, agent_id, platform, conversation_id,

--- a/packages/server/src/lobu/stores/__tests__/resolve-pinned-selection-failclosed.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/resolve-pinned-selection-failclosed.test.ts
@@ -1,0 +1,58 @@
+/**
+ * resolvePinnedSelection fail-closed path — Vitest unit test (no DB). When the
+ * pin read AND the guarded upsert/reread throw (a DB outage) for an existing
+ * conversation, the resolver must NOT return ANY guessed realm — not the agent's
+ * current (possibly repointed) Environment, and not builtin either (builtin is
+ * still "not the pinned realm"). The only correct action is to THROW, which the
+ * dispatch caller turns into a queue retry; the turn re-runs once the DB recovers
+ * and reads/pins the real realm. Reproduces codex round-5/6's finding.
+ *
+ * Uses vi.doMock + a fresh module registry (vi.resetModules) inside the test and
+ * dynamic-imports the resolver AFTER the mocks are registered, so the mock is
+ * scoped to this test and does not leak into (or get clobbered by) the DB-backed
+ * pin suite when both run in the same vitest worker. Lives in the vitest-owned
+ * stores/__tests__ tree so scripts/check-test-runner-coverage.mjs stays green.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock("../../../db/client.js");
+  vi.doUnmock("../../../gateway/services/conversations-store.js");
+});
+
+describe("resolvePinnedSelection — fail closed on total DB failure", () => {
+  it("THROWS (→ queue retry) — never returns a guessed realm — when the pin read and upsert both fail", async () => {
+    vi.resetModules();
+    // The agents/environments lookup RESOLVES (env-b, a repointed provider env),
+    // but every conversations query THROWS — codex's exact repro.
+    vi.doMock("../../../db/client.js", () => ({
+      getDb: () => (strings: TemplateStringsArray, ..._v: unknown[]) => {
+        const q = strings.join(" ");
+        if (q.includes("FROM agents")) {
+          return Promise.resolve([
+            { environment_id: "env-b", provider_kind: "vercel" },
+          ]);
+        }
+        return Promise.reject(new Error("db down"));
+      },
+    }));
+    vi.doMock("../../../gateway/services/conversations-store.js", () => ({
+      classifyConversation: () => ({ kind: "owned", storedPlatform: "web" }),
+      isWatcherConversationId: () => false,
+    }));
+
+    const { resolvePinnedSelection } = await import("../environment-store.js");
+
+    // Must throw (not return env-b, not return builtin) so the turn is retried.
+    await expect(
+      resolvePinnedSelection({
+        organizationId: "org-1",
+        agentId: "agent-1",
+        platform: "web",
+        conversationId: "conv-outage",
+      })
+    ).rejects.toThrow(/db down/);
+  });
+});

--- a/packages/server/src/lobu/stores/__tests__/resolve-pinned-selection.test.ts
+++ b/packages/server/src/lobu/stores/__tests__/resolve-pinned-selection.test.ts
@@ -1,0 +1,303 @@
+/**
+ * resolvePinnedSelection — the conversation-scoped runtime resolver both worker-
+ * token mints call. Verifies the load-bearing pin semantics against the test DB:
+ * a conversation's runtime realm is frozen on its first turn (first-writer-wins)
+ * and is IMMUTABLE thereafter, so repointing the agent to a different Environment
+ * never migrates an existing conversation's sandbox. Runs against whichever
+ * backend globalSetup selected (embedded PG with `bun run test`, real PG with
+ * DATABASE_URL set).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTestDatabase, getTestDb } from "../../../__tests__/setup/test-db";
+import {
+  createTestAgent,
+  createTestOrganization,
+} from "../../../__tests__/setup/test-fixtures";
+import { createEnvironment, resolvePinnedSelection } from "../environment-store";
+
+const PLATFORM = "web";
+
+/** Seed an unpinned conversations row for the given agent. */
+async function seedConversation(
+  organizationId: string,
+  agentId: string,
+  conversationId: string
+): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    INSERT INTO public.conversations
+      (organization_id, agent_id, platform, conversation_id, kind, last_activity_at)
+    VALUES (${organizationId}, ${agentId}, ${PLATFORM}, ${conversationId}, 'owned', now())
+  `;
+}
+
+/** Point an agent at an Environment (or clear it with null). */
+async function setAgentEnvironment(
+  organizationId: string,
+  agentId: string,
+  environmentId: string | null
+): Promise<void> {
+  const sql = getTestDb();
+  await sql`
+    UPDATE agents SET environment_id = ${environmentId}
+    WHERE id = ${agentId} AND organization_id = ${organizationId}
+  `;
+}
+
+async function readPin(
+  organizationId: string,
+  agentId: string,
+  conversationId: string
+): Promise<{ mode: string | null; provider: string | null }> {
+  const sql = getTestDb();
+  const rows = (await sql`
+    SELECT sandbox_mode, sandbox_provider_id
+    FROM public.conversations
+    WHERE organization_id = ${organizationId} AND agent_id = ${agentId}
+      AND platform = ${PLATFORM} AND conversation_id = ${conversationId}
+  `) as Array<{ sandbox_mode: string | null; sandbox_provider_id: string | null }>;
+  return {
+    mode: rows[0]?.sandbox_mode ?? null,
+    provider: rows[0]?.sandbox_provider_id ?? null,
+  };
+}
+
+describe("resolvePinnedSelection", () => {
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+  });
+
+  afterEach(async () => {
+    const sql = getTestDb();
+    await sql`TRUNCATE conversations, environments CASCADE`;
+  });
+
+  it("pins a provider Environment on the first turn and returns it", async () => {
+    const org = await createTestOrganization({ name: "Pin Provider Org" });
+    const agent = await createTestAgent({ organizationId: org.id });
+    const env = await createEnvironment(org.id, {
+      name: "vercel-prod",
+      providerKind: "vercel",
+    });
+    await setAgentEnvironment(org.id, agent.agentId, env.id);
+    await seedConversation(org.id, agent.agentId, "conv-provider");
+
+    const sel = await resolvePinnedSelection({
+      organizationId: org.id,
+      agentId: agent.agentId,
+      platform: PLATFORM,
+      conversationId: "conv-provider",
+    });
+
+    expect(sel.runtimeProviderId).toBe("vercel");
+    expect(sel.environmentId).toBe(env.id);
+    // The row is now frozen to 'provider'.
+    expect(await readPin(org.id, agent.agentId, "conv-provider")).toEqual({
+      mode: "provider",
+      provider: "vercel",
+    });
+  });
+
+  it("pins 'builtin' (local just-bash) when the agent has no Environment", async () => {
+    const org = await createTestOrganization({ name: "Pin Builtin Org" });
+    const agent = await createTestAgent({ organizationId: org.id });
+    await seedConversation(org.id, agent.agentId, "conv-builtin");
+
+    const sel = await resolvePinnedSelection({
+      organizationId: org.id,
+      agentId: agent.agentId,
+      platform: PLATFORM,
+      conversationId: "conv-builtin",
+    });
+
+    // No provider → local just-bash.
+    expect(sel.runtimeProviderId).toBeUndefined();
+    expect(await readPin(org.id, agent.agentId, "conv-builtin")).toEqual({
+      mode: "builtin",
+      provider: null,
+    });
+  });
+
+  it("never materializes a conversations row for a watcher run (honors the exclusion)", async () => {
+    // Watcher runs are ephemeral and have NO conversations row (message-consumer
+    // excludes them from the dual-write). The resolver must honor the same
+    // exclusion — resolve live, and NOT upsert a listing row (which would pollute
+    // the sidebar and break the watcher no-row contract).
+    const org = await createTestOrganization({ name: "Pin Watcher Org" });
+    const agent = await createTestAgent({ organizationId: org.id });
+    const env = await createEnvironment(org.id, {
+      name: "vercel-watcher",
+      providerKind: "vercel",
+    });
+    await setAgentEnvironment(org.id, agent.agentId, env.id);
+
+    const watcherConvId = `${agent.agentId}_watcher_1_run_42`;
+    const sel = await resolvePinnedSelection({
+      organizationId: org.id,
+      agentId: agent.agentId,
+      platform: PLATFORM,
+      conversationId: watcherConvId,
+    });
+
+    // Live selection returned (the agent's current provider) …
+    expect(sel.runtimeProviderId).toBe("vercel");
+    // … but NO row was created for the watcher conversation id.
+    const sql = getTestDb();
+    const rows = (await sql`
+      SELECT 1 FROM public.conversations
+      WHERE organization_id = ${org.id} AND agent_id = ${agent.agentId}
+        AND conversation_id = ${watcherConvId}
+    `) as unknown[];
+    expect(rows.length).toBe(0);
+  });
+
+  it("converges under a concurrent first-turn race (both callers agree on one pin)", async () => {
+    // Two simultaneous first turns on the same absent conversation: the upsert's
+    // first-writer-wins guard must yield ONE pin, and both callers must return it
+    // (no split-brain where one runs provider and the other builtin).
+    const org = await createTestOrganization({ name: "Pin Race Org" });
+    const agent = await createTestAgent({ organizationId: org.id });
+    const env = await createEnvironment(org.id, {
+      name: "vercel-race",
+      providerKind: "vercel",
+    });
+    await setAgentEnvironment(org.id, agent.agentId, env.id);
+
+    const call = () =>
+      resolvePinnedSelection({
+        organizationId: org.id,
+        agentId: agent.agentId,
+        platform: PLATFORM,
+        conversationId: "conv-race",
+      });
+    const [a, b] = await Promise.all([call(), call()]);
+
+    // Both agree, and both resolved the same provider (no split-brain).
+    expect(a.runtimeProviderId).toBe("vercel");
+    expect(b.runtimeProviderId).toBe("vercel");
+    expect(a.environmentId).toBe(env.id);
+    expect(b.environmentId).toBe(env.id);
+    expect(await readPin(org.id, agent.agentId, "conv-race")).toEqual({
+      mode: "provider",
+      provider: "vercel",
+    });
+  });
+
+  it("durably pins even when the conversations row is ABSENT (best-effort dual-write hasn't landed)", async () => {
+    // No seedConversation — the row does not exist yet. The resolver must CREATE
+    // it with the pin (upsert), so the realm is durable from turn 1 and a later
+    // turn can't move it. Without this, an absent row → unpinned turn → a repoint
+    // before the dual-write lands would migrate the conversation's realm.
+    const org = await createTestOrganization({ name: "Pin Absent-Row Org" });
+    const agent = await createTestAgent({ organizationId: org.id });
+    const env = await createEnvironment(org.id, {
+      name: "vercel-absent",
+      providerKind: "vercel",
+    });
+    await setAgentEnvironment(org.id, agent.agentId, env.id);
+
+    const sel = await resolvePinnedSelection({
+      organizationId: org.id,
+      agentId: agent.agentId,
+      platform: PLATFORM,
+      conversationId: "conv-absent",
+    });
+
+    expect(sel.runtimeProviderId).toBe("vercel");
+    // The row was created AND pinned in one shot.
+    expect(await readPin(org.id, agent.agentId, "conv-absent")).toEqual({
+      mode: "provider",
+      provider: "vercel",
+    });
+
+    // Repoint, then a later turn: still the original pin (immutability holds even
+    // though the row was born from the pin path, not the dual-write).
+    const envB = await createEnvironment(org.id, {
+      name: "vercel-absent-b",
+      providerKind: "vercel",
+    });
+    await setAgentEnvironment(org.id, agent.agentId, envB.id);
+    const second = await resolvePinnedSelection({
+      organizationId: org.id,
+      agentId: agent.agentId,
+      platform: PLATFORM,
+      conversationId: "conv-absent",
+    });
+    expect(second.environmentId).toBe(env.id);
+    expect(second.environmentId).not.toBe(envB.id);
+  });
+
+  it("classifies the dispatch platform: 'api' pins the stored 'web' row", async () => {
+    // The live dual-write stores api conversations under platform 'web'
+    // (classifyConversation). resolvePinnedSelection must classify identically —
+    // called with the raw dispatch platform 'api', it must still hit the 'web'
+    // row, else web/api conversations would never persist or read their pin.
+    const org = await createTestOrganization({ name: "Pin Api Org" });
+    const agent = await createTestAgent({ organizationId: org.id });
+    // Seed the row exactly as the dual-write would: stored platform 'web'.
+    await seedConversation(org.id, agent.agentId, "conv-api");
+
+    const sel = await resolvePinnedSelection({
+      organizationId: org.id,
+      agentId: agent.agentId,
+      platform: "api", // ← RAW dispatch platform, not the stored 'web'
+      conversationId: "conv-api",
+    });
+
+    expect(sel.runtimeProviderId).toBeUndefined();
+    // The 'web' row (readPin uses PLATFORM='web') got pinned — proving the
+    // 'api' → 'web' classification hit the right row.
+    expect(await readPin(org.id, agent.agentId, "conv-api")).toEqual({
+      mode: "builtin",
+      provider: null,
+    });
+  });
+
+  it("is IMMUTABLE: repointing the agent's Environment never moves an existing conversation's pin", async () => {
+    const org = await createTestOrganization({ name: "Pin Immutable Org" });
+    const agent = await createTestAgent({ organizationId: org.id });
+    const envA = await createEnvironment(org.id, {
+      name: "vercel-a",
+      providerKind: "vercel",
+    });
+    await setAgentEnvironment(org.id, agent.agentId, envA.id);
+    await seedConversation(org.id, agent.agentId, "conv-immutable");
+
+    // First turn pins to envA's provider.
+    const first = await resolvePinnedSelection({
+      organizationId: org.id,
+      agentId: agent.agentId,
+      platform: PLATFORM,
+      conversationId: "conv-immutable",
+    });
+    expect(first.runtimeProviderId).toBe("vercel");
+    expect(first.environmentId).toBe(envA.id);
+
+    // Operator repoints the agent to a DIFFERENT environment (distinct id — the
+    // pin freezes the environmentId, so a same-provider repoint still exercises
+    // immutability).
+    const envB = await createEnvironment(org.id, {
+      name: "vercel-b",
+      providerKind: "vercel",
+    });
+    await setAgentEnvironment(org.id, agent.agentId, envB.id);
+
+    // A later turn on the SAME conversation still resolves the ORIGINAL pin —
+    // the repoint does not migrate this conversation's sandbox realm (its
+    // environmentId stays envA, not the newly-pointed envB).
+    const second = await resolvePinnedSelection({
+      organizationId: org.id,
+      agentId: agent.agentId,
+      platform: PLATFORM,
+      conversationId: "conv-immutable",
+    });
+    expect(second.runtimeProviderId).toBe("vercel");
+    expect(second.environmentId).toBe(envA.id);
+    expect(second.environmentId).not.toBe(envB.id);
+    expect(await readPin(org.id, agent.agentId, "conv-immutable")).toEqual({
+      mode: "provider",
+      provider: "vercel",
+    });
+  });
+});

--- a/packages/server/src/lobu/stores/environment-store.ts
+++ b/packages/server/src/lobu/stores/environment-store.ts
@@ -135,13 +135,13 @@ export interface AgentRuntimeSelection {
 }
 
 /**
- * Resolve the agent's Environment, THROWING on a database error. The pin path
- * needs to tell "resolved to builtin" apart from "resolution failed" — freezing a
- * transient failure to builtin would poison the pin permanently — so it calls
- * this and skips pinning on throw. Token mints that want the fail-safe `{}` use
- * {@link resolveAgentRuntimeSelection}.
+ * Resolve the agent's Environment. THROWS on a database error — the pin path
+ * must tell "resolved to builtin" apart from "resolution failed" (freezing a
+ * transient failure to builtin would poison the pin permanently), and both
+ * callers of {@link resolvePinnedSelection} handle the throw (the enqueue site
+ * best-effort, the spawn site by retry). Callers pre-guard org/agent presence.
  */
-async function resolveAgentRuntimeSelectionOrThrow(
+async function resolveAgentRuntimeSelection(
   agentId: string,
   organizationId: string
 ): Promise<AgentRuntimeSelection> {
@@ -156,7 +156,9 @@ async function resolveAgentRuntimeSelectionOrThrow(
   `) as Array<{ environment_id: string | null; provider_kind: string | null }>;
   const row = rows[0];
   // A provider Environment → run there. Anything else (no environment, builtin,
-  // or a deleted env row) → local just-bash.
+  // or a deleted env row) → local just-bash. Throws on a DB error: the pin path
+  // must NOT freeze a failed lookup, and the enqueue caller wraps this
+  // best-effort while the spawn caller retries — neither wants a silent {}.
   if (row?.provider_kind && row.environment_id != null) {
     return {
       runtimeProviderId: row.provider_kind,
@@ -164,19 +166,6 @@ async function resolveAgentRuntimeSelectionOrThrow(
     };
   }
   return {};
-}
-
-async function resolveAgentRuntimeSelection(
-  agentId: string | undefined,
-  organizationId: string | undefined
-): Promise<AgentRuntimeSelection> {
-  if (!agentId || !organizationId) return {};
-  try {
-    return await resolveAgentRuntimeSelectionOrThrow(agentId, organizationId);
-  } catch {
-    // Fail safe: a resolution error must not block worker spawn or token mint.
-    return {};
-  }
 }
 
 /**
@@ -242,19 +231,14 @@ export async function resolvePinnedSelection(args: {
   //    `WHERE sandbox_mode IS NULL` guard is suppressed when a pin already
   //    exists, so its reread returns the ACTUAL frozen pin, not the live env.
   try {
-    const pinned = (await sql`
-      SELECT sandbox_mode, sandbox_provider_id, sandbox_environment_id
-      FROM public.conversations
-      WHERE organization_id = ${organizationId} AND agent_id = ${agentId}
-        AND platform = ${platform} AND conversation_id = ${conversationId}
-        AND sandbox_mode IS NOT NULL
-      LIMIT 1
-    `) as Array<{
-      sandbox_mode: string;
-      sandbox_provider_id: string | null;
-      sandbox_environment_id: string | null;
-    }>;
-    if (pinned[0]) return pinFromRow(pinned[0]);
+    const pinned = await readPin(
+      sql,
+      organizationId,
+      agentId,
+      platform,
+      conversationId
+    );
+    if (pinned) return pinned;
   } catch {
     // Fall through to the upsert path — it re-reads the real pin if one exists.
   }
@@ -264,7 +248,7 @@ export async function resolvePinnedSelection(args: {
   //    lookup to builtin would permanently misroute a provider-backed
   //    conversation), and must NOT pin a guessed realm. Let it propagate so the
   //    dispatch caller retries the turn once the DB recovers.
-  const live = await resolveAgentRuntimeSelectionOrThrow(agentId, organizationId);
+  const live = await resolveAgentRuntimeSelection(agentId, organizationId);
   const frozen = freezeSelection(live);
 
   // 3. Durably pin via an UPSERT — so the pin survives even when the best-effort
@@ -291,27 +275,18 @@ export async function resolvePinnedSelection(args: {
             updated_at = now()
         WHERE public.conversations.sandbox_mode IS NULL
       RETURNING sandbox_mode, sandbox_provider_id, sandbox_environment_id
-    `) as Array<{
-      sandbox_mode: string;
-      sandbox_provider_id: string | null;
-      sandbox_environment_id: string | null;
-    }>;
+    `) as PinRow[];
     if (rows[0]) return pinFromRow(rows[0]);
     // 0 rows: a racer pinned first (the DO UPDATE WHERE guard suppressed our
     // write). Re-read the winner's pin.
-    const reread = (await sql`
-      SELECT sandbox_mode, sandbox_provider_id, sandbox_environment_id
-      FROM public.conversations
-      WHERE organization_id = ${organizationId} AND agent_id = ${agentId}
-        AND platform = ${platform} AND conversation_id = ${conversationId}
-        AND sandbox_mode IS NOT NULL
-      LIMIT 1
-    `) as Array<{
-      sandbox_mode: string;
-      sandbox_provider_id: string | null;
-      sandbox_environment_id: string | null;
-    }>;
-    if (reread[0]) return pinFromRow(reread[0]);
+    const reread = await readPin(
+      sql,
+      organizationId,
+      agentId,
+      platform,
+      conversationId
+    );
+    if (reread) return reread;
   } catch (err) {
     // Both the pin read AND the upsert/reread errored (a DB outage). We can't
     // read the frozen realm and can't durably pin, so ANY value we return risks
@@ -329,12 +304,38 @@ export async function resolvePinnedSelection(args: {
   );
 }
 
-/** Reconstruct an AgentRuntimeSelection from a pinned conversations row. */
-function pinFromRow(row: {
+/** The pin columns both the read and the upsert-RETURNING project. */
+type PinRow = {
   sandbox_mode: string;
   sandbox_provider_id: string | null;
   sandbox_environment_id: string | null;
-}): AgentRuntimeSelection {
+};
+
+/**
+ * Read an existing (non-null) pin for one conversation, or null if unpinned.
+ * Shared by the fast-path read and the post-CAS reread so the SELECT + row shape
+ * live in one place.
+ */
+async function readPin(
+  sql: ReturnType<typeof getDb>,
+  organizationId: string,
+  agentId: string,
+  platform: string,
+  conversationId: string
+): Promise<AgentRuntimeSelection | null> {
+  const rows = (await sql`
+    SELECT sandbox_mode, sandbox_provider_id, sandbox_environment_id
+    FROM public.conversations
+    WHERE organization_id = ${organizationId} AND agent_id = ${agentId}
+      AND platform = ${platform} AND conversation_id = ${conversationId}
+      AND sandbox_mode IS NOT NULL
+    LIMIT 1
+  `) as PinRow[];
+  return rows[0] ? pinFromRow(rows[0]) : null;
+}
+
+/** Reconstruct an AgentRuntimeSelection from a pinned conversations row. */
+function pinFromRow(row: PinRow): AgentRuntimeSelection {
   if (row.sandbox_mode === "provider" && row.sandbox_provider_id) {
     return {
       runtimeProviderId: row.sandbox_provider_id,

--- a/packages/server/src/lobu/stores/environment-store.ts
+++ b/packages/server/src/lobu/stores/environment-store.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { getDb } from "../../db/client.js";
+import {
+  classifyConversation,
+  isWatcherConversationId,
+} from "../../gateway/services/conversations-store.js";
 import { environmentSecretName } from "./provider-secrets.js";
 
 /**
@@ -119,55 +123,224 @@ export async function deleteEnvironment(
 }
 
 /**
- * Resolve an agent's selected environment to the runtime claims stamped into
- * its worker token. Returns `{}` for builtin/unset/unknown so the caller falls
- * back to the deployment-wide `LOBU_RUNTIME_PROVIDER` (or in-process just-bash).
- * One JOIN query on the dispatch path.
+ * Resolve an agent's selected Environment to the runtime claims stamped into its
+ * worker token. A provider Environment → that provider (+ its vault env id); no
+ * environment (or a builtin/deleted one) → `{}` → local just-bash. Provider
+ * routing comes SOLELY from the Environment — there is no deployment-wide
+ * env-var fallback. One JOIN query on the dispatch path.
  */
 export interface AgentRuntimeSelection {
   runtimeProviderId?: string;
   environmentId?: string;
-  /**
-   * True when the agent has an explicit selection (a provider environment OR
-   * the literal `'builtin'`). Explicit selections must NOT fall back to the
-   * deployment-wide `LOBU_RUNTIME_PROVIDER`; an agent pinned to builtin runs
-   * local just-bash even on a self-host that set the env var. `false` means
-   * unset → env-var fallback is allowed.
-   */
-  explicit: boolean;
 }
 
-export async function resolveAgentRuntimeSelection(
+/**
+ * Resolve the agent's Environment, THROWING on a database error. The pin path
+ * needs to tell "resolved to builtin" apart from "resolution failed" — freezing a
+ * transient failure to builtin would poison the pin permanently — so it calls
+ * this and skips pinning on throw. Token mints that want the fail-safe `{}` use
+ * {@link resolveAgentRuntimeSelection}.
+ */
+async function resolveAgentRuntimeSelectionOrThrow(
+  agentId: string,
+  organizationId: string
+): Promise<AgentRuntimeSelection> {
+  const sql = getDb();
+  const rows = (await sql`
+    SELECT a.environment_id, e.provider_kind
+    FROM agents a
+    LEFT JOIN environments e
+      ON e.id = a.environment_id AND e.organization_id = a.organization_id
+    WHERE a.id = ${agentId} AND a.organization_id = ${organizationId}
+    LIMIT 1
+  `) as Array<{ environment_id: string | null; provider_kind: string | null }>;
+  const row = rows[0];
+  // A provider Environment → run there. Anything else (no environment, builtin,
+  // or a deleted env row) → local just-bash.
+  if (row?.provider_kind && row.environment_id != null) {
+    return {
+      runtimeProviderId: row.provider_kind,
+      environmentId: row.environment_id,
+    };
+  }
+  return {};
+}
+
+async function resolveAgentRuntimeSelection(
   agentId: string | undefined,
   organizationId: string | undefined
 ): Promise<AgentRuntimeSelection> {
-  if (!agentId || !organizationId) return { explicit: false };
+  if (!agentId || !organizationId) return {};
   try {
-    const sql = getDb();
-    const rows = (await sql`
-      SELECT a.environment_id, e.provider_kind
-      FROM agents a
-      LEFT JOIN environments e
-        ON e.id = a.environment_id AND e.organization_id = a.organization_id
-      WHERE a.id = ${agentId} AND a.organization_id = ${organizationId}
-      LIMIT 1
-    `) as Array<{ environment_id: string | null; provider_kind: string | null }>;
-    const row = rows[0];
-    // No row, or environment_id NULL → unset; env-var fallback is allowed.
-    if (!row || row.environment_id == null) return { explicit: false };
-    // A provider environment → run there.
-    if (row.provider_kind) {
-      return {
-        runtimeProviderId: row.provider_kind,
-        environmentId: row.environment_id,
-        explicit: true,
-      };
-    }
-    // environment_id set but not a provider row ('builtin', or a deleted env) →
-    // explicit no-remote-runtime: local just-bash, do not fall back to the env var.
-    return { explicit: true };
+    return await resolveAgentRuntimeSelectionOrThrow(agentId, organizationId);
   } catch {
     // Fail safe: a resolution error must not block worker spawn or token mint.
-    return { explicit: false };
+    return {};
   }
+}
+
+/**
+ * Freeze the RESOLVED runtime selection down to the concrete pinned shape stored
+ * on the conversations row:
+ *  - a provider selection → mode 'provider' + provider id (+ env id);
+ *  - no provider          → mode 'builtin' (local just-bash).
+ * Frozen so a later agent repoint can't migrate an existing conversation.
+ */
+function freezeSelection(sel: AgentRuntimeSelection): {
+  mode: "builtin" | "provider";
+  providerId: string | null;
+  environmentId: string | null;
+} {
+  if (sel.runtimeProviderId) {
+    return {
+      mode: "provider",
+      providerId: sel.runtimeProviderId,
+      environmentId: sel.environmentId ?? null,
+    };
+  }
+  return { mode: "builtin", providerId: null, environmentId: null };
+}
+
+/**
+ * The conversation-scoped runtime resolver both mint sites call INSTEAD of
+ * {@link resolveAgentRuntimeSelection}. Reads the conversation's immutable pin;
+ * if unpinned, resolves the agent's CURRENT Environment selection, then durably
+ * pins it via an UPSERT (creating the conversations row if the best-effort
+ * dual-write hasn't landed it yet) — first writer wins, and a concurrent
+ * first-turn that lost the race re-reads the winner's pin. Reading the pin (not
+ * the agent's current env) is what makes an agent repoint never move an existing
+ * conversation's sandbox realm. A transient DB failure during resolution skips
+ * pinning entirely rather than freezing a wrong (builtin-fallback) realm.
+ */
+export async function resolvePinnedSelection(args: {
+  organizationId: string | undefined;
+  agentId: string | undefined;
+  platform: string;
+  conversationId: string;
+}): Promise<AgentRuntimeSelection> {
+  const { organizationId, agentId, conversationId } = args;
+  if (!organizationId || !agentId) return {};
+  // Watcher runs are ephemeral and deliberately have NO conversations row (the
+  // live dual-write excludes them via isWatcherConversationId). Honor the same
+  // exclusion here: never pin and never materialize a listing row for a watcher —
+  // resolve the agent's current selection live. A repointed watcher just picks up
+  // the new realm on its next run, which is the desired behavior for watchers.
+  if (isWatcherConversationId(conversationId)) {
+    return resolveAgentRuntimeSelection(agentId, organizationId);
+  }
+  // The conversations row is keyed on the STORED platform (api→web, lowercased) —
+  // classify identically here so the pin SELECT/UPDATE hits the row the live
+  // dual-write created. Querying with the raw dispatch platform ("api") would
+  // never match the stored "web" row, so web conversations would never pin.
+  const { storedPlatform: platform, kind } = classifyConversation(args.platform);
+  const sql = getDb();
+
+  // 1. Fast-path read of an existing pin. On a read ERROR we deliberately do NOT
+  //    fall back to the agent's current (mutable) Environment — that would run a
+  //    repointed conversation in a different realm than its pin, breaking
+  //    immutability. Instead we fall through to the upsert path below, whose
+  //    `WHERE sandbox_mode IS NULL` guard is suppressed when a pin already
+  //    exists, so its reread returns the ACTUAL frozen pin, not the live env.
+  try {
+    const pinned = (await sql`
+      SELECT sandbox_mode, sandbox_provider_id, sandbox_environment_id
+      FROM public.conversations
+      WHERE organization_id = ${organizationId} AND agent_id = ${agentId}
+        AND platform = ${platform} AND conversation_id = ${conversationId}
+        AND sandbox_mode IS NOT NULL
+      LIMIT 1
+    `) as Array<{
+      sandbox_mode: string;
+      sandbox_provider_id: string | null;
+      sandbox_environment_id: string | null;
+    }>;
+    if (pinned[0]) return pinFromRow(pinned[0]);
+  } catch {
+    // Fall through to the upsert path — it re-reads the real pin if one exists.
+  }
+
+  // 2. Unpinned: resolve the agent's current Environment selection. Use the
+  //    THROWING resolve — a DB failure here must NOT be frozen (freezing a failed
+  //    lookup to builtin would permanently misroute a provider-backed
+  //    conversation), and must NOT pin a guessed realm. Let it propagate so the
+  //    dispatch caller retries the turn once the DB recovers.
+  const live = await resolveAgentRuntimeSelectionOrThrow(agentId, organizationId);
+  const frozen = freezeSelection(live);
+
+  // 3. Durably pin via an UPSERT — so the pin survives even when the best-effort
+  //    dual-write hasn't landed the conversations row yet (otherwise an absent
+  //    row would leave the turn unpinned, and a later turn could resolve a
+  //    different realm after an agent repoint — violating immutability). INSERT
+  //    the row-with-pin if absent; on conflict, CAS-pin ONLY when still unpinned
+  //    (sandbox_mode IS NULL) so the first writer wins and a repoint never
+  //    overwrites an existing pin. A racer that lost the conflict gets 0 rows
+  //    back (the WHERE guard fails) and re-reads the winner's pin.
+  try {
+    const rows = (await sql`
+      INSERT INTO public.conversations
+        (organization_id, agent_id, platform, conversation_id, kind,
+         sandbox_mode, sandbox_provider_id, sandbox_environment_id, sandbox_pinned_at)
+      VALUES
+        (${organizationId}, ${agentId}, ${platform}, ${conversationId}, ${kind},
+         ${frozen.mode}, ${frozen.providerId}, ${frozen.environmentId}, now())
+      ON CONFLICT (organization_id, agent_id, platform, conversation_id) DO UPDATE
+        SET sandbox_mode = EXCLUDED.sandbox_mode,
+            sandbox_provider_id = EXCLUDED.sandbox_provider_id,
+            sandbox_environment_id = EXCLUDED.sandbox_environment_id,
+            sandbox_pinned_at = now(),
+            updated_at = now()
+        WHERE public.conversations.sandbox_mode IS NULL
+      RETURNING sandbox_mode, sandbox_provider_id, sandbox_environment_id
+    `) as Array<{
+      sandbox_mode: string;
+      sandbox_provider_id: string | null;
+      sandbox_environment_id: string | null;
+    }>;
+    if (rows[0]) return pinFromRow(rows[0]);
+    // 0 rows: a racer pinned first (the DO UPDATE WHERE guard suppressed our
+    // write). Re-read the winner's pin.
+    const reread = (await sql`
+      SELECT sandbox_mode, sandbox_provider_id, sandbox_environment_id
+      FROM public.conversations
+      WHERE organization_id = ${organizationId} AND agent_id = ${agentId}
+        AND platform = ${platform} AND conversation_id = ${conversationId}
+        AND sandbox_mode IS NOT NULL
+      LIMIT 1
+    `) as Array<{
+      sandbox_mode: string;
+      sandbox_provider_id: string | null;
+      sandbox_environment_id: string | null;
+    }>;
+    if (reread[0]) return pinFromRow(reread[0]);
+  } catch (err) {
+    // Both the pin read AND the upsert/reread errored (a DB outage). We can't
+    // read the frozen realm and can't durably pin, so ANY value we return risks
+    // running an existing pinned conversation in the wrong realm — builtin is
+    // still "not the pinned realm". The only correct action is to STOP the turn:
+    // throw, which the dispatch caller (message-consumer handleMessage) turns
+    // into an OrchestratorError → queue retry. The turn re-runs once the DB
+    // recovers and reads/pins the real realm — it never executes in a wrong one.
+    throw err;
+  }
+  // Unreachable: the upsert returns our pin, the racer's pin (reread), or throws
+  // (handled above). Throw defensively rather than silently pick a realm.
+  throw new Error(
+    "resolvePinnedSelection: unreachable — pin upsert returned no row and did not throw"
+  );
+}
+
+/** Reconstruct an AgentRuntimeSelection from a pinned conversations row. */
+function pinFromRow(row: {
+  sandbox_mode: string;
+  sandbox_provider_id: string | null;
+  sandbox_environment_id: string | null;
+}): AgentRuntimeSelection {
+  if (row.sandbox_mode === "provider" && row.sandbox_provider_id) {
+    return {
+      runtimeProviderId: row.sandbox_provider_id,
+      environmentId: row.sandbox_environment_id ?? undefined,
+    };
+  }
+  // 'builtin' → local just-bash.
+  return {};
 }


### PR DESCRIPTION
Stacked on #1947 (base = `feat/conversations-entity`). Review/merge #1947 first.

## What this does

Freezes a conversation's sandbox runtime realm (provider + Environment) on its **first turn**, immutably. Repointing an agent's Environment then moves only *new* conversations — never an existing one's sandbox. This is what makes "one agent, many conversations, different sandboxes" safe.

## How

- **Pin** (`conversations` row): `sandbox_mode ∈ {builtin, provider}` + provider id + env id, CAS-written first-writer-wins on the first turn (`resolvePinnedSelection`). Both worker-token mints and the payload read the pin, not the agent's *current* Environment. Migration `20260714180000` adds the columns + a consistency CHECK. No FK to `environments` (hard-deleted table) — fails closed on missing creds, like PR-0.
- **Worker-wire** (the load-bearing part): the worker's bash backend is now selected **per-turn** from `MessagePayload.runtimeProviderId` (gateway stamps the pinned provider at dispatch) threaded through `WorkerConfig → runAISession → createEmbeddedBashOps`. Previously it read a process-frozen env var, which a warm deployment reused across conversations would read wrong.
- **Provider = the agent's Environment, solely.** `LOBU_RUNTIME_PROVIDER` is removed from the runtime-selection path entirely — it only ever named a provider *kind* while credentials always come from the environments vault, so it could never route a working sandbox on its own and was redundant once an Environment supplies creds. Deleted with it: `AgentRuntimeSelection.explicit`, the `runtimeExplicit` token claim, the `"builtin"` wire sentinel, the `deploymentRuntimeProvider` resolver param.

## Tests

- Worker per-turn backend selection (`embedded-just-bash-bootstrap`).
- Worker env carries **neither** a selector **nor** provider creds (`embedded-deployment`, repurposed).
- DB-backed `resolvePinnedSelection` suite: first-pin-wins, builtin, and **immutability-on-repoint** (3 green on real PG).
- `sdk-e2e` green: a real spawned worker completes a real turn on the builtin bash path with the worker-wire in place (no regression).

## Not proven here

The live **builtin → provider (Vercel)** flip isn't exercised end-to-end — that needs a booted worker with a Vercel Environment + creds attached. The builtin half is proven via `sdk-e2e`; the provider half is proven at the resolver/token layer (unit + DB tests) but not through a live remote sandbox exec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ep6TY8RQ4QZkiDkMBCkbcH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786646903&installation_id=136316292&pr_number=1948&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1948&signature=77d7d826d6c0c26b6559efb3b79f9be0575c556028e2d47d65dc754aaa953e31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized conversation list to power consistent sidebar results across platforms.
  * Conversation records now support per-conversation sandbox pinning to keep future turns on the same runtime.
  * Added resumable backfill tooling for existing conversations.
* **Bug Fixes**
  * Improved conversation ordering, deduplication, scoping, and visibility filtering (including archived handling and watcher exclusion).
  * Strengthened fail-closed behavior for pinned runtime/credential resolution to prevent unintended fallbacks when vault data is unavailable.
  * Improved convergence for concurrent first-turn conversation creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->