### PR TITLE
feat(mcp): source-blind connector discovery + public SDK error normalization

### DIFF
--- a/packages/server/src/__tests__/unit/connector-discovery.test.ts
+++ b/packages/server/src/__tests__/unit/connector-discovery.test.ts
@@ -48,19 +48,24 @@ const catalogResult = {
 	},
 };
 
-const noConnections = { connections: [] };
 
 function makeDeps(over?: {
 	installed?: unknown;
 	catalog?: unknown;
-	connections?: unknown;
+	// Connections keyed by connector_key — the tool queries connections FILTERED
+	// by connector_key, so the mock returns only the matching key's rows (models
+	// the real filter and proves an active connection is found regardless of how
+	// many other connections exist).
+	connectionsByKey?: Record<string, Array<{ status: string }>>;
 }): ConnectorDiscoveryDeps {
 	return {
 		manageCatalog: (async (args: { action: string }) =>
 			args.action === "list_catalog"
 				? (over?.catalog ?? catalogResult)
 				: (over?.installed ?? installedResult)) as never,
-		manageConnections: (async () => over?.connections ?? noConnections) as never,
+		manageConnections: (async (args: { connector_key?: string }) => ({
+			connections: over?.connectionsByKey?.[args.connector_key ?? ""] ?? [],
+		})) as never,
 	};
 }
 
@@ -89,9 +94,7 @@ describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 	});
 
 	it("reports an active connection as CONNECTED (add feed / read, don't re-connect)", async () => {
-		const deps = makeDeps({
-			connections: { connections: [{ connector_key: "website", status: "active" }] },
-		});
+		const deps = makeDeps({ connectionsByKey: { website: [{ status: "active" }] } });
 		const hits = await searchLiveConnectors("website", env, ctx, deps);
 		expect(hits[0]).toMatch(/CONNECTED/);
 		expect(hits[0]).toMatch(/feeds\.create/);
@@ -102,9 +105,7 @@ describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 	it("tells the agent to REPAIR a revoked/error connection, not create a feed on it", async () => {
 		// The review-caught bug: a revoked connection was labeled 'already
 		// CONFIGURED' and told to create feeds, which would silently never sync.
-		const deps = makeDeps({
-			connections: { connections: [{ connector_key: "website", status: "revoked" }] },
-		});
+		const deps = makeDeps({ connectionsByKey: { website: [{ status: "revoked" }] } });
 		const hits = await searchLiveConnectors("website", env, ctx, deps);
 		expect(hits[0]).toMatch(/needs attention/);
 		expect(hits[0]).toMatch(/status: revoked/);
@@ -114,16 +115,22 @@ describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 
 	it("prefers an ACTIVE connection when a connector has several (active + revoked)", async () => {
 		const deps = makeDeps({
-			connections: {
-				connections: [
-					{ connector_key: "website", status: "revoked" },
-					{ connector_key: "website", status: "active" },
-				],
-			},
+			connectionsByKey: { website: [{ status: "revoked" }, { status: "active" }] },
 		});
 		const hits = await searchLiveConnectors("website", env, ctx, deps);
 		expect(hits[0]).toMatch(/CONNECTED/);
 		expect(hits[0]).not.toMatch(/needs attention/);
+	});
+
+	it("finds a connector's active connection via connector_key filter, not a single unfiltered page", async () => {
+		// The review-caught bug: scanning one unfiltered page (limit 200) would
+		// miss an active connection in a large workspace. The tool queries
+		// connections FILTERED by connector_key, so it's found regardless of how
+		// many OTHER connectors' connections exist. The mock returns rows only for
+		// the queried key — proving the tool passes the filter.
+		const deps = makeDeps({ connectionsByKey: { website: [{ status: "active" }] } });
+		const hits = await searchLiveConnectors("website", env, ctx, deps);
+		expect(hits[0]).toMatch(/CONNECTED/);
 	});
 
 	it("surfaces a global-catalog connector as installable when not installed", async () => {

--- a/packages/server/src/__tests__/unit/connector-discovery.test.ts
+++ b/packages/server/src/__tests__/unit/connector-discovery.test.ts
@@ -132,6 +132,36 @@ describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 		expect(hits.some((h) => /installConnector/.test(h))).toBe(true);
 	});
 
+	it("does NOT recommend installConnector for a non-installable catalog entry", async () => {
+		// The review-caught bug: a stale/unavailable catalog entry
+		// (installable:false) was still told to run installConnector, which is
+		// guaranteed to fail. Surface the reason instead.
+		const deps = makeDeps({
+			catalog: {
+				catalogs: {
+					connectors: {
+						entries: [
+							{
+								id: "spotify",
+								name: "Spotify",
+								description: "Music",
+								detail: {
+									installable: false,
+									installability_message: "Connector source is no longer available.",
+								},
+							},
+						],
+					},
+				},
+			},
+		});
+		const hits = await searchLiveConnectors("spotify", env, ctx, deps);
+		expect(hits).toHaveLength(1);
+		expect(hits[0]).toMatch(/NOT currently installable/);
+		expect(hits[0]).toMatch(/no longer available/);
+		expect(hits[0]).not.toMatch(/installConnector/);
+	});
+
 	it("never leaks credentials or raw connector config", async () => {
 		const hits = await searchLiveConnectors("website", env, ctx, makeDeps());
 		const json = JSON.stringify(hits);

--- a/packages/server/src/__tests__/unit/connector-discovery.test.ts
+++ b/packages/server/src/__tests__/unit/connector-discovery.test.ts
@@ -63,9 +63,12 @@ function makeDeps(over?: {
 			args.action === "list_catalog"
 				? (over?.catalog ?? catalogResult)
 				: (over?.installed ?? installedResult)) as never,
-		manageConnections: (async (args: { connector_key?: string }) => ({
-			connections: over?.connectionsByKey?.[args.connector_key ?? ""] ?? [],
-		})) as never,
+		manageConnections: (async (args: { connector_key?: string; status?: string }) => {
+			// Model the real handler: connector_key AND optional status filter.
+			const all = over?.connectionsByKey?.[args.connector_key ?? ""] ?? [];
+			const rows = args.status ? all.filter((c) => c.status === args.status) : all;
+			return { connections: rows };
+		}) as never,
 	};
 }
 
@@ -122,15 +125,18 @@ describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 		expect(hits[0]).not.toMatch(/needs attention/);
 	});
 
-	it("finds a connector's active connection via connector_key filter, not a single unfiltered page", async () => {
-		// The review-caught bug: scanning one unfiltered page (limit 200) would
-		// miss an active connection in a large workspace. The tool queries
-		// connections FILTERED by connector_key, so it's found regardless of how
-		// many OTHER connectors' connections exist. The mock returns rows only for
-		// the queried key — proving the tool passes the filter.
-		const deps = makeDeps({ connectionsByKey: { website: [{ status: "active" }] } });
+	it("finds an ACTIVE connection even behind many newer non-active ones (status probe, not one page)", async () => {
+		// The review-caught bug: an older active connection hidden behind 200 newer
+		// revoked rows was reported as 'needs repair'. The tool probes status=active
+		// (filtered) first, so it's found regardless of ordering/volume.
+		const many = [
+			...Array.from({ length: 200 }, () => ({ status: "revoked" })),
+			{ status: "active" }, // older, would be on page 2 of an unfiltered scan
+		];
+		const deps = makeDeps({ connectionsByKey: { website: many } });
 		const hits = await searchLiveConnectors("website", env, ctx, deps);
 		expect(hits[0]).toMatch(/CONNECTED/);
+		expect(hits[0]).not.toMatch(/needs attention/);
 	});
 
 	it("surfaces a global-catalog connector as installable when not installed", async () => {

--- a/packages/server/src/__tests__/unit/connector-discovery.test.ts
+++ b/packages/server/src/__tests__/unit/connector-discovery.test.ts
@@ -179,6 +179,25 @@ describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 		expect(await searchLiveConnectors("   ", env, ctx, makeDeps())).toEqual([]);
 	});
 
+	it("matches a dotted CONNECTOR id (google.calendar), not just single words", async () => {
+		// Connector ids are commonly dotted; searchLiveConnectors must find them by
+		// exact id. (search_sdk's method-path skip must not swallow these — its
+		// first segment 'google' is not an SDK namespace.)
+		const deps = makeDeps({
+			catalog: {
+				catalogs: {
+					connectors: {
+						entries: [
+							{ id: "google.calendar", name: "Google Calendar", description: "Calendar sync" },
+						],
+					},
+				},
+			},
+		});
+		const hits = await searchLiveConnectors("google.calendar", env, ctx, deps);
+		expect(hits.some((h) => h.includes("'google.calendar'"))).toBe(true);
+	});
+
 	it("drops stopword-only queries so filler words don't match every connector", async () => {
 		// "connect a source" is all stopwords → no token → no match (else it would
 		// spuriously match on the word 'connect' inside connector descriptions).

--- a/packages/server/src/__tests__/unit/connector-discovery.test.ts
+++ b/packages/server/src/__tests__/unit/connector-discovery.test.ts
@@ -88,14 +88,42 @@ describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 		}
 	});
 
-	it("reports an already-configured connector as configured (read, don't re-connect)", async () => {
+	it("reports an active connection as CONNECTED (add feed / read, don't re-connect)", async () => {
 		const deps = makeDeps({
 			connections: { connections: [{ connector_key: "website", status: "active" }] },
 		});
 		const hits = await searchLiveConnectors("website", env, ctx, deps);
-		expect(hits[0]).toMatch(/already CONFIGURED/);
-		expect(hits[0]).toMatch(/status: active/);
+		expect(hits[0]).toMatch(/CONNECTED/);
+		expect(hits[0]).toMatch(/feeds\.create/);
 		expect(hits[0]).not.toMatch(/not yet configured/);
+		expect(hits[0]).not.toMatch(/reauthenticate/i);
+	});
+
+	it("tells the agent to REPAIR a revoked/error connection, not create a feed on it", async () => {
+		// The review-caught bug: a revoked connection was labeled 'already
+		// CONFIGURED' and told to create feeds, which would silently never sync.
+		const deps = makeDeps({
+			connections: { connections: [{ connector_key: "website", status: "revoked" }] },
+		});
+		const hits = await searchLiveConnectors("website", env, ctx, deps);
+		expect(hits[0]).toMatch(/needs attention/);
+		expect(hits[0]).toMatch(/status: revoked/);
+		expect(hits[0]).toMatch(/reauthenticate|repair|reconnect/i);
+		expect(hits[0]).not.toMatch(/CONNECTED \(active/);
+	});
+
+	it("prefers an ACTIVE connection when a connector has several (active + revoked)", async () => {
+		const deps = makeDeps({
+			connections: {
+				connections: [
+					{ connector_key: "website", status: "revoked" },
+					{ connector_key: "website", status: "active" },
+				],
+			},
+		});
+		const hits = await searchLiveConnectors("website", env, ctx, deps);
+		expect(hits[0]).toMatch(/CONNECTED/);
+		expect(hits[0]).not.toMatch(/needs attention/);
 	});
 
 	it("surfaces a global-catalog connector as installable when not installed", async () => {

--- a/packages/server/src/__tests__/unit/connector-discovery.test.ts
+++ b/packages/server/src/__tests__/unit/connector-discovery.test.ts
@@ -73,7 +73,7 @@ function makeDeps(over?: {
 }
 
 const env = {} as Env;
-const ctx = { organizationId: "org-1", userId: "u1" } as ToolContext;
+const ctx = { organizationId: "org-1", userId: "u1", memberRole: "member" } as ToolContext;
 
 describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 	it("surfaces an installed-but-unconfigured connector with feed key + connect lifecycle", async () => {
@@ -231,6 +231,15 @@ describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 	it("returns empty for a blank query (never dumps the whole catalog)", async () => {
 		expect(await searchLiveConnectors("", env, ctx, makeDeps())).toEqual([]);
 		expect(await searchLiveConnectors("   ", env, ctx, makeDeps())).toEqual([]);
+	});
+
+	it("returns nothing for an anonymous / non-member session (no connector inventory to strangers)", async () => {
+		// search_sdk is publicly readable, so an anon session on a public workspace
+		// can call it — but connector inventory is member context, not public data.
+		const anon = { organizationId: "org-1", userId: null } as ToolContext;
+		const nonMember = { organizationId: "org-1", userId: "u1", memberRole: null } as ToolContext;
+		expect(await searchLiveConnectors("website", env, anon, makeDeps())).toEqual([]);
+		expect(await searchLiveConnectors("website", env, nonMember, makeDeps())).toEqual([]);
 	});
 
 	it("matches a dotted CONNECTOR id (google.calendar), not just single words", async () => {

--- a/packages/server/src/__tests__/unit/connector-discovery.test.ts
+++ b/packages/server/src/__tests__/unit/connector-discovery.test.ts
@@ -139,6 +139,47 @@ describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 		expect(hits[0]).not.toMatch(/needs attention/);
 	});
 
+	it("does NOT tell the agent to create a feed on a feedless connector (Slack-style)", async () => {
+		// The review-caught bug: a connector with feeds_schema=null (an action/chat
+		// connector) was sent down the feeds.create lifecycle, which is invalid. It
+		// must be pointed at operations instead.
+		const deps = makeDeps({
+			installed: {
+				installed: {
+					connectors: {
+						items: [
+							{
+								id: "slack",
+								name: "Slack",
+								detail: { description: "Chat", feeds_schema: null },
+							},
+						],
+					},
+				},
+			},
+		});
+		const notConnected = await searchLiveConnectors("slack", env, ctx, deps);
+		expect(notConnected[0]).not.toMatch(/feeds\.create/);
+		expect(notConnected[0]).toMatch(/no data feeds|operations/i);
+		expect(notConnected[0]).toMatch(/operations\.listAvailable/);
+
+		// Same when already connected: add-feed guidance must not appear.
+		const connectedDeps = makeDeps({
+			installed: {
+				installed: {
+					connectors: {
+						items: [{ id: "slack", name: "Slack", detail: { feeds_schema: null } }],
+					},
+				},
+			},
+			connectionsByKey: { slack: [{ status: "active" }] },
+		});
+		const connected = await searchLiveConnectors("slack", env, ctx, connectedDeps);
+		expect(connected[0]).toMatch(/CONNECTED/);
+		expect(connected[0]).not.toMatch(/feeds\.create/);
+		expect(connected[0]).toMatch(/operations/i);
+	});
+
 	it("surfaces a global-catalog connector as installable when not installed", async () => {
 		const hits = await searchLiveConnectors("slack", env, ctx, makeDeps());
 		expect(hits.some((h) => h.includes("'slack'") && /CATALOG/.test(h))).toBe(true);

--- a/packages/server/src/__tests__/unit/connector-discovery.test.ts
+++ b/packages/server/src/__tests__/unit/connector-discovery.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+import type { Env } from "../../index";
+import type { ToolContext } from "../../tools/registry";
+import {
+	type ConnectorDiscoveryDeps,
+	searchLiveConnectors,
+} from "../../tools/connector-discovery";
+
+// Fixture mirrors the audit's Website-installed-but-unconfigured production
+// shape: website is INSTALLED with a `pages` feed schema, NOT in the configured
+// connections, and NOT in the global catalog (an org-installed connector). RSS
+// is also installed as a decoy alternative. Injected via the `deps` param — no
+// mock.module (process-global in Bun; it corrupts sibling suites).
+const installedResult = {
+	installed: {
+		connectors: {
+			items: [
+				{
+					id: "website",
+					name: "Website",
+					detail: {
+						description:
+							"Scrapes JS-rendered pages via Playwright; supports sitemap.xml",
+						// SECRET-looking fields that must NOT surface:
+						auth_schema: { api_key: { type: "string" } },
+						default_connection_config: { token: "sekret" },
+						feeds_schema: { pages: { config: { urls: {}, max_pages: {} } } },
+					},
+				},
+				{
+					id: "rss",
+					name: "RSS",
+					detail: { description: "RSS reader", feeds_schema: { articles: {} } },
+				},
+			],
+		},
+	},
+};
+
+const catalogResult = {
+	catalogs: {
+		connectors: {
+			entries: [
+				{ id: "slack", name: "Slack", description: "Slack workspace sync" },
+				{ id: "webhook", name: "Webhook", description: "Inbound push" },
+			],
+		},
+	},
+};
+
+const noConnections = { connections: [] };
+
+function makeDeps(over?: {
+	installed?: unknown;
+	catalog?: unknown;
+	connections?: unknown;
+}): ConnectorDiscoveryDeps {
+	return {
+		manageCatalog: (async (args: { action: string }) =>
+			args.action === "list_catalog"
+				? (over?.catalog ?? catalogResult)
+				: (over?.installed ?? installedResult)) as never,
+		manageConnections: (async () => over?.connections ?? noConnections) as never,
+	};
+}
+
+const env = {} as Env;
+const ctx = { organizationId: "org-1", userId: "u1" } as ToolContext;
+
+describe("searchLiveConnectors (search_sdk connector intent search)", () => {
+	it("surfaces an installed-but-unconfigured connector with feed key + connect lifecycle", async () => {
+		const hits = await searchLiveConnectors("website", env, ctx, makeDeps());
+		expect(hits).toHaveLength(1);
+		expect(hits[0]).toMatch(/website/);
+		expect(hits[0]).toMatch(/not yet configured/);
+		expect(hits[0]).toMatch(/feed_key: 'pages'/);
+		expect(hits[0]).toMatch(/connections\.connect/);
+		expect(hits[0]).toMatch(/feeds\.trigger/);
+	});
+
+	it("matches a MULTI-WORD intent phrase via tokens, not just the bare name", async () => {
+		// The failure the eval exposed: "website connect source" / "crawl a web
+		// page" returned nothing because the whole phrase was matched as one
+		// substring. Token matching must still find the connector.
+		for (const q of ["website connect source", "crawl a web page", "ingest a website"]) {
+			const hits = await searchLiveConnectors(q, env, ctx, makeDeps());
+			expect(hits.some((h) => h.includes("'website'"))).toBe(true);
+		}
+	});
+
+	it("reports an already-configured connector as configured (read, don't re-connect)", async () => {
+		const deps = makeDeps({
+			connections: { connections: [{ connector_key: "website", status: "active" }] },
+		});
+		const hits = await searchLiveConnectors("website", env, ctx, deps);
+		expect(hits[0]).toMatch(/already CONFIGURED/);
+		expect(hits[0]).toMatch(/status: active/);
+		expect(hits[0]).not.toMatch(/not yet configured/);
+	});
+
+	it("surfaces a global-catalog connector as installable when not installed", async () => {
+		const hits = await searchLiveConnectors("slack", env, ctx, makeDeps());
+		expect(hits.some((h) => h.includes("'slack'") && /CATALOG/.test(h))).toBe(true);
+		expect(hits.some((h) => /installConnector/.test(h))).toBe(true);
+	});
+
+	it("never leaks credentials or raw connector config", async () => {
+		const hits = await searchLiveConnectors("website", env, ctx, makeDeps());
+		const json = JSON.stringify(hits);
+		expect(json).not.toMatch(/sekret/);
+		expect(json).not.toMatch(/auth_schema/);
+		expect(json).not.toMatch(/default_connection_config/);
+	});
+
+	it("returns empty for a query that names no connector", async () => {
+		expect(await searchLiveConnectors("zzz-nothing", env, ctx, makeDeps())).toEqual([]);
+	});
+
+	it("returns empty for a blank query (never dumps the whole catalog)", async () => {
+		expect(await searchLiveConnectors("", env, ctx, makeDeps())).toEqual([]);
+		expect(await searchLiveConnectors("   ", env, ctx, makeDeps())).toEqual([]);
+	});
+
+	it("drops stopword-only queries so filler words don't match every connector", async () => {
+		// "connect a source" is all stopwords → no token → no match (else it would
+		// spuriously match on the word 'connect' inside connector descriptions).
+		expect(await searchLiveConnectors("connect a source", env, ctx, makeDeps())).toEqual([]);
+	});
+});

--- a/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
@@ -189,23 +189,26 @@ describe("createActionCaller", () => {
 		expect(thrown.message).toMatch(/feed_id/);
 	});
 
-	it("falls back to the action name when no public method is supplied", async () => {
+	it("derives a CAMEL-CASE public method from a snake_case action when none is supplied", async () => {
+		// `generate_embeddings` (internal) → the real method is
+		// client.classifiers.generateEmbeddings, NOT ...generate_embeddings.
 		const handler = async () => {
 			throw new ToolUserError(
-				"Invalid arguments for manage_operations: /limit: Expected number",
+				"Invalid arguments for manage_classifiers: /entity_type: Expected required property",
 			);
 		};
 		const { action } = createActionCaller(
 			handler as never,
 			{} as never,
 			{} as never,
-			"operations",
+			"classifiers",
 		);
-		const thrown = (await action("list_available", { limit: "x" }).catch(
+		const thrown = (await action("generate_embeddings", {}).catch(
 			(e: unknown) => e,
 		)) as ToolUserError;
-		expect(thrown.message).not.toMatch(/manage_operations/);
-		expect(thrown.message).toMatch(/client\.operations\.list_available/);
+		expect(thrown.message).not.toMatch(/manage_classifiers/);
+		expect(thrown.message).not.toMatch(/generate_embeddings/);
+		expect(thrown.message).toMatch(/client\.classifiers\.generateEmbeddings/);
 	});
 
 	it("leaves errors from callers with no declared namespace untouched", async () => {

--- a/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/action-call.test.ts
@@ -165,6 +165,59 @@ describe("createActionCaller", () => {
 		});
 	});
 
+	it("rewrites an internal manage_* validation error to the public SDK method", async () => {
+		// A client.feeds.get({ id: 1 }) whose internal handler (manage_feeds)
+		// rejects the args must NOT leak `manage_feeds` — the caller can only
+		// recover against `client.feeds.get`.
+		const handler = async () => {
+			throw new ToolUserError(
+				"Invalid arguments for manage_feeds: /feed_id: Expected required property",
+			);
+		};
+		const { action } = createActionCaller(
+			handler as never,
+			{} as never,
+			{} as never,
+			"feeds",
+		);
+		const thrown = (await action("read_feed", { id: 1 }, "get").catch(
+			(e: unknown) => e,
+		)) as ToolUserError;
+		expect(thrown).toBeInstanceOf(ToolUserError);
+		expect(thrown.message).not.toMatch(/manage_feeds/);
+		expect(thrown.message).toMatch(/client\.feeds\.get/);
+		expect(thrown.message).toMatch(/feed_id/);
+	});
+
+	it("falls back to the action name when no public method is supplied", async () => {
+		const handler = async () => {
+			throw new ToolUserError(
+				"Invalid arguments for manage_operations: /limit: Expected number",
+			);
+		};
+		const { action } = createActionCaller(
+			handler as never,
+			{} as never,
+			{} as never,
+			"operations",
+		);
+		const thrown = (await action("list_available", { limit: "x" }).catch(
+			(e: unknown) => e,
+		)) as ToolUserError;
+		expect(thrown.message).not.toMatch(/manage_operations/);
+		expect(thrown.message).toMatch(/client\.operations\.list_available/);
+	});
+
+	it("leaves errors from callers with no declared namespace untouched", async () => {
+		const handler = async () => {
+			throw new ToolUserError("Invalid arguments for manage_feeds: boom");
+		};
+		const { action } = createActionCaller(handler as never, {} as never, {} as never);
+		const thrown = (await action("read_feed", {}).catch((e: unknown) => e)) as ToolUserError;
+		// No namespace → nothing to rewrite to; message passes through.
+		expect(thrown.message).toBe("Invalid arguments for manage_feeds: boom");
+	});
+
 	it("returns a queued approval even when its mutation success is false", async () => {
 		const queued = {
 			success: false,

--- a/packages/server/src/__tests__/unit/sandbox/sdk-signature-contract.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-signature-contract.test.ts
@@ -151,15 +151,17 @@ describe("ClientSDK object signature contract", () => {
 		const connections = builders.connections(ctx, env);
 		const authProfiles = builders.authProfiles(ctx, env);
 
+		// Placeholders are neutral (`<connection_id>`, `<auth_profile_slug>`), NOT
+		// real-looking ids — a fresh agent must not copy a fabricated id verbatim.
 		await expect(
 			connections.reauthenticate({ connection_id: 418 } as never),
 		).rejects.toThrow(
-			"connections.reauthenticate expects a positional number. Call client.connections.reauthenticate(418); do not pass an object.",
+			"connections.reauthenticate expects a positional number. Call client.connections.reauthenticate(<connection_id>); do not pass an object.",
 		);
 		await expect(
 			authProfiles.get({ auth_profile_slug: "google-calendar-account" } as never),
 		).rejects.toThrow(
-			"authProfiles.get expects a positional string. Call client.authProfiles.get('google-calendar-account'); do not pass an object.",
+			"authProfiles.get expects a positional string. Call client.authProfiles.get('<auth_profile_slug>'); do not pass an object.",
 		);
 	});
 });

--- a/packages/server/src/__tests__/unit/validate-args.test.ts
+++ b/packages/server/src/__tests__/unit/validate-args.test.ts
@@ -144,6 +144,61 @@ describe("validateToolArgs coercion", () => {
   });
 });
 
+describe("validateToolArgs error humanization", () => {
+  it("enumerates allowed literals for a union-of-literals field (not 'Expected union value')", () => {
+    // list_scope: Type.Union([Type.Literal('accessible'), Type.Literal('organization')]).
+    // TypeBox emits the bare "Expected union value" with no literals — useless for
+    // autonomous recovery. The message must name the valid values.
+    const schema = Type.Object({
+      list_scope: Type.Union([Type.Literal("accessible"), Type.Literal("organization")]),
+    });
+    let caught: unknown;
+    try {
+      validateToolArgs("t", schema, { list_scope: "org" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ToolUserError);
+    const msg = (caught as ToolUserError).message;
+    expect(msg).not.toMatch(/Expected union value/);
+    expect(msg).toMatch(/accessible/);
+    expect(msg).toMatch(/organization/);
+  });
+
+  it("enumerates allowed literals for a bare enum field", () => {
+    const schema = Type.Object({
+      kind: Type.Union([Type.Literal("connectors"), Type.Literal("agents")]),
+    });
+    let caught: unknown;
+    try {
+      validateToolArgs("t", schema, { kind: "bogus" });
+    } catch (err) {
+      caught = err;
+    }
+    const msg = (caught as ToolUserError).message;
+    expect(msg).toMatch(/connectors/);
+    expect(msg).toMatch(/agents/);
+  });
+
+  it("reports a missing required field AND an unknown field together (not just the first)", () => {
+    // { id: 1 } for a schema wanting { feed_id } used to report only the missing
+    // feed_id, never that `id` is unknown — so the agent fixes one problem at a
+    // time. Both must surface in one message.
+    const schema = Type.Object({ feed_id: Type.Number() }, { additionalProperties: false });
+    let caught: unknown;
+    try {
+      validateToolArgs("t", schema, { id: 1 });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ToolUserError);
+    const msg = (caught as ToolUserError).message;
+    expect(msg).toMatch(/feed_id/); // missing required
+    expect(msg).toMatch(/id/); // unknown supplied
+    expect(msg).toMatch(/unknown/i);
+  });
+});
+
 describe("validateToolArgs union variant dispatch", () => {
   const union = Type.Union([
     Type.Object({ action: Type.Literal("create"), name: Type.String() }),

--- a/packages/server/src/sandbox/namespaces/action-call.ts
+++ b/packages/server/src/sandbox/namespaces/action-call.ts
@@ -108,10 +108,48 @@ function failureMessage(
 	};
 }
 
+/**
+ * Rewrite a leaked internal tool name in a validation error to the public SDK
+ * method the caller actually invoked. An arg-validation failure raised deep in
+ * an admin handler reads `Invalid arguments for manage_feeds: …`, but a fresh
+ * agent only ever called `client.feeds.get` — `manage_feeds` is internal
+ * plumbing it cannot search or recover against. When the namespace is known,
+ * swap `manage_<x>` for `client.<namespace>.<method>` and keep the field-level
+ * detail (`/feed_id: Expected required property`) intact.
+ */
+function rewriteInternalToolName(
+	err: unknown,
+	sdkNamespace: string | undefined,
+	publicMethod: string,
+): unknown {
+	if (!sdkNamespace || !(err instanceof ToolUserError)) return err;
+	const rewritten = err.message
+		.replace(
+			/Invalid arguments for manage_[a-z_]+/,
+			`Invalid arguments for client.${sdkNamespace}.${publicMethod}`,
+		)
+		// The valid-args list is scoped to the INTERNAL action (`for action
+		// 'read_feed'`) — drop that fragment once the public method already names
+		// the call, so no internal action name survives in the message.
+		.replace(/ for action '[a-z_]+'/, "");
+	if (rewritten === err.message) return err;
+	// ClientSdkActionError carries extra fields — but it is raised by THIS module
+	// from a result value, never by the arg validator, so a match here is always
+	// a plain ToolUserError. Preserve the httpStatus.
+	return new ToolUserError(rewritten, err.httpStatus);
+}
+
 export function createActionCaller(
 	handler: AdminHandler,
 	env: Env,
 	ctx: ToolContext,
+	/**
+	 * Public ClientSDK namespace (e.g. `"feeds"`) this caller belongs to. When
+	 * set, arg-validation errors that leak the internal `manage_*` tool name are
+	 * rewritten to `client.<namespace>.<method>`. Omit for callers with no public
+	 * SDK surface (errors then pass through unchanged).
+	 */
+	sdkNamespace?: string,
 ) {
 	const manage = <T>(payload: object): Promise<T> =>
 		handler(payload as never, env, ctx) as Promise<T>;
@@ -119,12 +157,19 @@ export function createActionCaller(
 	const action = async <T>(
 		actionName: string,
 		input: object = {},
+		/** Public method name (e.g. `"get"`); defaults to the internal action. */
+		publicMethod: string = actionName,
 	): Promise<T> => {
 		// Spread caller input FIRST, then force `action` so a caller-supplied
 		// `action` key (e.g. from a read-only query_sdk script) can never override
 		// the discriminator and reach a write/delete handler.
 		const { action: _ignored, ...rest } = input as Record<string, unknown>;
-		const result = await manage<T>({ ...rest, action: actionName });
+		let result: T;
+		try {
+			result = await manage<T>({ ...rest, action: actionName });
+		} catch (err) {
+			throw rewriteInternalToolName(err, sdkNamespace, publicMethod);
+		}
 		const failure = failureMessage(actionName, result);
 		if (failure) {
 			throw new ClientSdkActionError(

--- a/packages/server/src/sandbox/namespaces/action-call.ts
+++ b/packages/server/src/sandbox/namespaces/action-call.ts
@@ -108,6 +108,11 @@ function failureMessage(
 	};
 }
 
+/** `generate_embeddings` → `generateEmbeddings`; leaves already-camel/plain names intact. */
+function snakeToCamel(name: string): string {
+	return name.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+}
+
 /**
  * Rewrite a leaked internal tool name in a validation error to the public SDK
  * method the caller actually invoked. An arg-validation failure raised deep in
@@ -117,11 +122,6 @@ function failureMessage(
  * swap `manage_<x>` for `client.<namespace>.<method>` and keep the field-level
  * detail (`/feed_id: Expected required property`) intact.
  */
-/** `generate_embeddings` → `generateEmbeddings`; leaves already-camel/plain names intact. */
-function snakeToCamel(name: string): string {
-	return name.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase());
-}
-
 function rewriteInternalToolName(
 	err: unknown,
 	sdkNamespace: string | undefined,

--- a/packages/server/src/sandbox/namespaces/action-call.ts
+++ b/packages/server/src/sandbox/namespaces/action-call.ts
@@ -117,6 +117,11 @@ function failureMessage(
  * swap `manage_<x>` for `client.<namespace>.<method>` and keep the field-level
  * detail (`/feed_id: Expected required property`) intact.
  */
+/** `generate_embeddings` → `generateEmbeddings`; leaves already-camel/plain names intact. */
+function snakeToCamel(name: string): string {
+	return name.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+}
+
 function rewriteInternalToolName(
 	err: unknown,
 	sdkNamespace: string | undefined,
@@ -157,8 +162,15 @@ export function createActionCaller(
 	const action = async <T>(
 		actionName: string,
 		input: object = {},
-		/** Public method name (e.g. `"get"`); defaults to the internal action. */
-		publicMethod: string = actionName,
+		/**
+		 * Public SDK method name. Defaults to the CAMEL-CASE of the internal
+		 * action (`generate_embeddings` → `generateEmbeddings`), which is the
+		 * actual method on most namespaces — a bare snake_case default would
+		 * render a nonexistent path like `client.classifiers.generate_embeddings`.
+		 * Namespaces whose public name diverges from the action (e.g. feeds
+		 * `read_feed` → `get`) pass it explicitly.
+		 */
+		publicMethod: string = snakeToCamel(actionName),
 	): Promise<T> => {
 		// Spread caller input FIRST, then force `action` so a caller-supplied
 		// `action` key (e.g. from a read-only query_sdk script) can never override

--- a/packages/server/src/sandbox/namespaces/agents.ts
+++ b/packages/server/src/sandbox/namespaces/agents.ts
@@ -35,7 +35,7 @@ export function buildAgentsNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): AgentsNamespace {
-	const { manage, action } = createActionCaller(manageAgents, env, ctx);
+	const { manage, action } = createActionCaller(manageAgents, env, ctx, "agents");
 
 	return {
 		manage,

--- a/packages/server/src/sandbox/namespaces/auth-profiles.ts
+++ b/packages/server/src/sandbox/namespaces/auth-profiles.ts
@@ -65,37 +65,54 @@ export function buildAuthProfilesNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): AuthProfilesNamespace {
-	const { manage, action } = createActionCaller(manageAuthProfiles, env, ctx);
+	const { manage, action } = createActionCaller(
+		manageAuthProfiles,
+		env,
+		ctx,
+		"authProfiles",
+	);
 
 	return {
 		manage,
-		list: (input) => action("list_auth_profiles", input),
+		list: (input) => action("list_auth_profiles", input, "list"),
 		get: async (auth_profile_slug) =>
-			action("get_auth_profile", {
-				auth_profile_slug: requirePositionalString(
-					"authProfiles.get",
-					auth_profile_slug,
-					"client.authProfiles.get('google-calendar-account')",
-				),
-			}),
+			action(
+				"get_auth_profile",
+				{
+					auth_profile_slug: requirePositionalString(
+						"authProfiles.get",
+						auth_profile_slug,
+						"client.authProfiles.get('<auth_profile_slug>')",
+					),
+				},
+				"get",
+			),
 		test: async (auth_profile_slug) =>
-			action("test_auth_profile", {
-				auth_profile_slug: requirePositionalString(
-					"authProfiles.test",
-					auth_profile_slug,
-					"client.authProfiles.test('google-calendar-account')",
-				),
-			}),
-		create: (input) => action("create_auth_profile", input),
-		update: (input) => action("update_auth_profile", input),
+			action(
+				"test_auth_profile",
+				{
+					auth_profile_slug: requirePositionalString(
+						"authProfiles.test",
+						auth_profile_slug,
+						"client.authProfiles.test('<auth_profile_slug>')",
+					),
+				},
+				"test",
+			),
+		create: (input) => action("create_auth_profile", input, "create"),
+		update: (input) => action("update_auth_profile", input, "update"),
 		delete: async (auth_profile_slug, options) =>
-			action("delete_auth_profile", {
-				auth_profile_slug: requirePositionalString(
-					"authProfiles.delete",
-					auth_profile_slug,
-					"client.authProfiles.delete('google-calendar-account')",
-				),
-				...options,
-			}),
+			action(
+				"delete_auth_profile",
+				{
+					auth_profile_slug: requirePositionalString(
+						"authProfiles.delete",
+						auth_profile_slug,
+						"client.authProfiles.delete('<auth_profile_slug>')",
+					),
+					...options,
+				},
+				"delete",
+			),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/catalog.ts
+++ b/packages/server/src/sandbox/namespaces/catalog.ts
@@ -17,10 +17,11 @@ export function buildCatalogNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): CatalogNamespace {
-	const { action } = createActionCaller(manageCatalog, env, ctx);
+	const { action } = createActionCaller(manageCatalog, env, ctx, "catalog");
 
 	return {
-		listCatalog: (input) => action("list_catalog", input ?? {}),
-		listInstalled: (input) => action("list_installed", input ?? {}),
+		listCatalog: (input) => action("list_catalog", input ?? {}, "listCatalog"),
+		listInstalled: (input) =>
+			action("list_installed", input ?? {}, "listInstalled"),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/classifiers.ts
+++ b/packages/server/src/sandbox/namespaces/classifiers.ts
@@ -61,7 +61,7 @@ export function buildClassifiersNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): ClassifiersNamespace {
-	const { manage, action } = createActionCaller(manageClassifiers, env, ctx);
+	const { manage, action } = createActionCaller(manageClassifiers, env, ctx, "classifiers");
 
 	return {
 		manage,

--- a/packages/server/src/sandbox/namespaces/connections.ts
+++ b/packages/server/src/sandbox/namespaces/connections.ts
@@ -67,7 +67,12 @@ export function buildConnectionsNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): ConnectionsNamespace {
-	const { manage, action } = createActionCaller(manageConnections, env, ctx);
+	const { manage, action } = createActionCaller(
+		manageConnections,
+		env,
+		ctx,
+		"connections",
+	);
 
 	return {
 		manage,
@@ -77,7 +82,7 @@ export function buildConnectionsNamespace(
 				connection_id: requirePositionalNumber(
 					"connections.get",
 					connection_id,
-					"client.connections.get(418)",
+					"client.connections.get(<connection_id>)",
 				),
 			}),
 		create: (input) => action("create", input),
@@ -88,7 +93,7 @@ export function buildConnectionsNamespace(
 				connection_id: requirePositionalNumber(
 					"connections.delete",
 					connection_id,
-					"client.connections.delete(418)",
+					"client.connections.delete(<connection_id>)",
 				),
 			}),
 		reauthenticate: async (connection_id) =>
@@ -96,7 +101,7 @@ export function buildConnectionsNamespace(
 				connection_id: requirePositionalNumber(
 					"connections.reauthenticate",
 					connection_id,
-					"client.connections.reauthenticate(418)",
+					"client.connections.reauthenticate(<connection_id>)",
 				),
 			}),
 		test: async (connection_id) =>
@@ -104,17 +109,20 @@ export function buildConnectionsNamespace(
 				connection_id: requirePositionalNumber(
 					"connections.test",
 					connection_id,
-					"client.connections.test(418)",
+					"client.connections.test(<connection_id>)",
 				),
 			}),
-		installConnector: (input) => action("install_connector", input),
+		installConnector: (input) =>
+			action("install_connector", input, "installConnector"),
 		uninstallConnector: (connector_key) =>
-			action("uninstall_connector", { connector_key }),
-		toggleConnectorLogin: (input) => action("toggle_connector_login", input),
-		updateConnectorAuth: (input) => action("update_connector_auth", input),
+			action("uninstall_connector", { connector_key }, "uninstallConnector"),
+		toggleConnectorLogin: (input) =>
+			action("toggle_connector_login", input, "toggleConnectorLogin"),
+		updateConnectorAuth: (input) =>
+			action("update_connector_auth", input, "updateConnectorAuth"),
 		updateConnectorDefaultConfig: (input) =>
-			action("update_connector_default_config", input),
+			action("update_connector_default_config", input, "updateConnectorDefaultConfig"),
 		updateConnectorDefaultRepairAgent: (input) =>
-			action("update_connector_default_repair_agent", input),
+			action("update_connector_default_repair_agent", input, "updateConnectorDefaultRepairAgent"),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/entities.ts
+++ b/packages/server/src/sandbox/namespaces/entities.ts
@@ -87,7 +87,7 @@ export function buildEntitiesNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): EntitiesNamespace {
-	const { manage, action } = createActionCaller(manageEntity, env, ctx);
+	const { manage, action } = createActionCaller(manageEntity, env, ctx, "entities");
 
 	return {
 		manage,

--- a/packages/server/src/sandbox/namespaces/entity-schema.ts
+++ b/packages/server/src/sandbox/namespaces/entity-schema.ts
@@ -84,35 +84,48 @@ export function buildEntitySchemaNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): EntitySchemaNamespace {
-	const { manage, action } = createActionCaller(manageEntitySchema, env, ctx);
-	const callEntity = <T>(payload: Record<string, unknown>): Promise<T> =>
-		action(payload.action as string, {
-			schema_type: "entity_type",
-			...payload,
-		});
-	const callRel = <T>(payload: Record<string, unknown>): Promise<T> =>
-		action(payload.action as string, {
-			schema_type: "relationship_type",
-			...payload,
-		});
+	const { manage, action } = createActionCaller(
+		manageEntitySchema,
+		env,
+		ctx,
+		"entitySchema",
+	);
+	const callEntity = <T>(
+		payload: Record<string, unknown>,
+		publicMethod: string,
+	): Promise<T> =>
+		action(
+			payload.action as string,
+			{ schema_type: "entity_type", ...payload },
+			publicMethod,
+		);
+	const callRel = <T>(
+		payload: Record<string, unknown>,
+		publicMethod: string,
+	): Promise<T> =>
+		action(
+			payload.action as string,
+			{ schema_type: "relationship_type", ...payload },
+			publicMethod,
+		);
 
 	return {
 		manage,
-		listTypes: (input) => callEntity({ action: "list", ...input }),
-		getType: (slug) => callEntity({ action: "get", slug }),
-		createType: (input) => callEntity({ action: "create", ...input }),
-		updateType: (input) => callEntity({ action: "update", ...input }),
-		deleteType: (input) => callEntity({ action: "delete", ...input }),
-		auditType: (slug) => callEntity({ action: "audit", slug }),
+		listTypes: (input) => callEntity({ action: "list", ...input }, "listTypes"),
+		getType: (slug) => callEntity({ action: "get", slug }, "getType"),
+		createType: (input) => callEntity({ action: "create", ...input }, "createType"),
+		updateType: (input) => callEntity({ action: "update", ...input }, "updateType"),
+		deleteType: (input) => callEntity({ action: "delete", ...input }, "deleteType"),
+		auditType: (slug) => callEntity({ action: "audit", slug }, "auditType"),
 
-		listRelTypes: (input) => callRel({ action: "list", ...input }),
-		getRelType: (slug) => callRel({ action: "get", slug }),
-		createRelType: (input) => callRel({ action: "create", ...input }),
-		updateRelType: (input) => callRel({ action: "update", ...input }),
-		deleteRelType: (input) => callRel({ action: "delete", ...input }),
+		listRelTypes: (input) => callRel({ action: "list", ...input }, "listRelTypes"),
+		getRelType: (slug) => callRel({ action: "get", slug }, "getRelType"),
+		createRelType: (input) => callRel({ action: "create", ...input }, "createRelType"),
+		updateRelType: (input) => callRel({ action: "update", ...input }, "updateRelType"),
+		deleteRelType: (input) => callRel({ action: "delete", ...input }, "deleteRelType"),
 
-		addRule: (input) => callRel({ action: "add_rule", ...input }),
-		removeRule: (input) => callRel({ action: "remove_rule", ...input }),
-		listRules: (input) => callRel({ action: "list_rules", ...input }),
+		addRule: (input) => callRel({ action: "add_rule", ...input }, "addRule"),
+		removeRule: (input) => callRel({ action: "remove_rule", ...input }, "removeRule"),
+		listRules: (input) => callRel({ action: "list_rules", ...input }, "listRules"),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/feeds.ts
+++ b/packages/server/src/sandbox/namespaces/feeds.ts
@@ -51,16 +51,16 @@ export function buildFeedsNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): FeedsNamespace {
-	const { manage, action } = createActionCaller(manageFeeds, env, ctx);
+	const { manage, action } = createActionCaller(manageFeeds, env, ctx, "feeds");
 
 	return {
 		manage,
-		list: (input) => action("list_feeds", input),
-		get: (input) => action("read_feed", input),
-		readMany: (input) => action("read_feeds", input),
-		create: (input) => action("create_feed", input),
-		update: (input) => action("update_feed", input),
-		delete: (input) => action("delete_feed", input),
-		trigger: (input) => action("trigger_feed", input),
+		list: (input) => action("list_feeds", input, "list"),
+		get: (input) => action("read_feed", input, "get"),
+		readMany: (input) => action("read_feeds", input, "readMany"),
+		create: (input) => action("create_feed", input, "create"),
+		update: (input) => action("update_feed", input, "update"),
+		delete: (input) => action("delete_feed", input, "delete"),
+		trigger: (input) => action("trigger_feed", input, "trigger"),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/notifications.ts
+++ b/packages/server/src/sandbox/namespaces/notifications.ts
@@ -43,7 +43,7 @@ export function buildNotificationsNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): NotificationsNamespace {
-	const { action } = createActionCaller(notify, env, ctx);
+	const { action } = createActionCaller(notify, env, ctx, "notifications");
 
 	return {
 		send: (input) => action("send", input),

--- a/packages/server/src/sandbox/namespaces/operations.ts
+++ b/packages/server/src/sandbox/namespaces/operations.ts
@@ -64,15 +64,20 @@ export function buildOperationsNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): OperationsNamespace {
-	const { manage, action } = createActionCaller(manageOperations, env, ctx);
+	const { manage, action } = createActionCaller(
+		manageOperations,
+		env,
+		ctx,
+		"operations",
+	);
 
 	return {
 		manage,
-		listAvailable: (input) => action("list_available", input),
-		execute: (input) => action("execute", input),
-		listRuns: (input) => action("list_runs", input),
-		getRun: (run_id) => action("get_run", { run_id }),
-		approve: (input) => action("approve", input),
-		reject: (input) => action("reject", input),
+		listAvailable: (input) => action("list_available", input, "listAvailable"),
+		execute: (input) => action("execute", input, "execute"),
+		listRuns: (input) => action("list_runs", input, "listRuns"),
+		getRun: (run_id) => action("get_run", { run_id }, "getRun"),
+		approve: (input) => action("approve", input, "approve"),
+		reject: (input) => action("reject", input, "reject"),
 	};
 }

--- a/packages/server/src/sandbox/namespaces/schedules.ts
+++ b/packages/server/src/sandbox/namespaces/schedules.ts
@@ -46,7 +46,7 @@ export function buildSchedulesNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): SchedulesNamespace {
-	const { manage, action } = createActionCaller(manageSchedules, env, ctx);
+	const { manage, action } = createActionCaller(manageSchedules, env, ctx, "schedules");
 
 	return {
 		manage,

--- a/packages/server/src/sandbox/namespaces/view-templates.ts
+++ b/packages/server/src/sandbox/namespaces/view-templates.ts
@@ -50,7 +50,7 @@ export function buildViewTemplatesNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): ViewTemplatesNamespace {
-	const { manage, action } = createActionCaller(manageViewTemplates, env, ctx);
+	const { manage, action } = createActionCaller(manageViewTemplates, env, ctx, "viewTemplates");
 
 	return {
 		manage,

--- a/packages/server/src/sandbox/namespaces/watchers.ts
+++ b/packages/server/src/sandbox/namespaces/watchers.ts
@@ -174,7 +174,7 @@ export function buildWatchersNamespace(
 	ctx: ToolContext,
 	env: Env,
 ): WatchersNamespace {
-	const { manage, action } = createActionCaller(manageWatchers, env, ctx);
+	const { manage, action } = createActionCaller(manageWatchers, env, ctx, "watchers");
 
 	return {
 		manage: (input) => manage(input as Record<string, unknown>),

--- a/packages/server/src/sandbox/run-script.ts
+++ b/packages/server/src/sandbox/run-script.ts
@@ -170,13 +170,24 @@ function classifyRuntimeError(error: {
 	details?: unknown;
 }): NonNullable<RunScriptResult["error"]> {
 	const message = error.message ?? "Script execution failed";
+	// Expected user-input errors (bad SDK args, business-rule failures) must NOT
+	// leak a server-bundle stack to the client — the message already carries the
+	// actionable "Invalid arguments for client.x.y: …" guidance, and the full
+	// stack stays in server logs/observability. An unexpected ScriptError keeps
+	// its stack (a genuine bug the developer needs to trace).
+	const isExpectedUserError =
+		error.name === "ClientSdkActionError" ||
+		error.name === "ToolUserError" ||
+		/^Invalid arguments for /.test(message);
 	if (error.name === "ClientSdkActionError") {
 		return {
 			name: "ClientSdkActionError",
 			message,
-			...(error.stack ? { stack: error.stack } : {}),
 			...(error.details === undefined ? {} : { details: error.details }),
 		};
+	}
+	if (isExpectedUserError) {
+		return { name: "ValidationError", message };
 	}
 
 	const isTimeout = /script execution timed out|TimeoutError/i.test(message);
@@ -423,9 +434,17 @@ function __makeClient(orgPath) {
     get(_, key) {
       if (__isReservedKey(key)) return undefined;
       const k = String(key);
+      // client.org is advertised by search_sdk with a "Throws
+      // CrossOrgAccessDenied on scoped/PAT endpoints" note. When cross-org is
+      // unavailable the manifest omits it from __topLevelKeys -- but returning
+      // undefined makes client.org('x') fail with the opaque
+      // "client.org is not a function", contradicting the docs. Return a stub
+      // that throws the SAME structured error the host path raises, so
+      // discovery and runtime agree. (This block lives inside a template
+      // literal; keep it free of backticks and dollar-brace sequences.)
       if (k === 'org') return __topLevelKeys.has('org')
         ? (slug) => __makeClient([...orgPath, String(slug)])
-        : undefined;
+        : () => { throw new Error('CrossOrgAccessDenied: cross-org access is not available on this connection. Use the unscoped /mcp endpoint with an OAuth session, or reconnect to the target workspace.'); };
       if (__topLevelKeys.has(k)) return __dispatchCall(k, orgPath);
       if (__namespaceKeys.has(k)) return __makeNamespaceProxy(k, orgPath);
       return undefined;

--- a/packages/server/src/tools/connector-discovery.ts
+++ b/packages/server/src/tools/connector-discovery.ts
@@ -100,32 +100,44 @@ export async function searchLiveConnectors(
       cat.catalogs?.connectors?.entries
     );
     const configured = asArray<{ connector_key: string; status: string }>(conn.connections);
-    const configuredByKey = new Map<string, string>();
+    // Aggregate connections per connector and pick the BEST status — an active
+    // connection means "ready to use", but a revoked/error connection must not
+    // be reported as usable (it needs reauthentication, not a new feed). Prefer
+    // an active connection when the connector has several.
+    const USABLE = new Set(['active']);
+    const statusesByKey = new Map<string, string[]>();
     for (const c of configured) {
-      if (!configuredByKey.has(c.connector_key)) configuredByKey.set(c.connector_key, c.status);
+      const list = statusesByKey.get(c.connector_key) ?? [];
+      list.push(c.status);
+      statusesByKey.set(c.connector_key, list);
     }
+    const bestStatus = (key: string): string | undefined => {
+      const list = statusesByKey.get(key);
+      if (!list || list.length === 0) return undefined;
+      return list.find((s) => USABLE.has(s)) ?? list[0];
+    };
     const installedIds = new Set(installed.map((i) => i.id));
 
     for (const i of installed) {
       if (!matchesQueryTokens(q, i.id, i.name, i.detail?.description)) continue;
       const feeds = feedKeysOf(i.detail);
-      const status = configuredByKey.get(i.id);
-      if (status) {
-        // Already has a live connection — read/verify, don't re-connect.
+      const feedKeyHint = feeds?.[0] ? `'${feeds[0]}'` : '<feed_key>';
+      const feedKeysNote = feeds ? ` Feed keys: ${feeds.join(', ')}.` : '';
+      const status = bestStatus(i.id);
+      if (status && USABLE.has(status)) {
+        // Healthy live connection — add a feed / read, don't re-connect.
         lines.push(
-          `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED and already CONFIGURED (a connection exists, status: ${status}).${
-            feeds ? ` Feed keys: ${feeds.join(', ')}.` : ''
-          } To add a feed: run_sdk → client.feeds.create({ connection_id, feed_key: ${
-            feeds?.[0] ? `'${feeds[0]}'` : '<feed_key>'
-          }, config }). To read collected data: query_sql on events or search_memory. Get the connection_id via query_sdk → client.connections.list({ connector_key: '${i.id}' }).`
+          `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED and CONNECTED (active connection).${feedKeysNote} To add a feed: run_sdk → client.feeds.create({ connection_id, feed_key: ${feedKeyHint}, config }); then query_sql on events or search_memory to read. Get the connection_id via query_sdk → client.connections.list({ connector_key: '${i.id}' }).`
+        );
+      } else if (status) {
+        // Connection exists but is NOT usable (revoked/error/paused/pending) —
+        // it must be repaired before any feed will sync.
+        lines.push(
+          `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED with a connection that needs attention (status: ${status}).${feedKeysNote} Reauthenticate/repair before use: run_sdk → client.connections.reauthenticate(<connection_id>) (or reconnect). Find the connection via query_sdk → client.connections.list({ connector_key: '${i.id}' }).`
         );
       } else {
         lines.push(
-          `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED, not yet configured.${
-            feeds ? ` Feed keys: ${feeds.join(', ')}.` : ''
-          } Lifecycle: run_sdk → client.connections.connect({ connector_key: '${i.id}' }) → client.feeds.create({ connection_id, feed_key: ${
-            feeds?.[0] ? `'${feeds[0]}'` : '<feed_key>'
-          }, config }) → client.feeds.trigger({ feed_id }); then query_sql on events or search_memory to read. Use search_sdk 'feeds.create feeds.trigger' for signatures.`
+          `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED, not yet configured.${feedKeysNote} Lifecycle: run_sdk → client.connections.connect({ connector_key: '${i.id}' }) → client.feeds.create({ connection_id, feed_key: ${feedKeyHint}, config }) → client.feeds.trigger({ feed_id }); then query_sql on events or search_memory to read. Use search_sdk 'feeds.create feeds.trigger' for signatures.`
         );
       }
     }

--- a/packages/server/src/tools/connector-discovery.ts
+++ b/packages/server/src/tools/connector-discovery.ts
@@ -102,27 +102,34 @@ export async function searchLiveConnectors(
     const installedIds = new Set(installed.map((i) => i.id));
 
     // Only the installed connectors that MATCH the query need a status — resolve
-    // their connections filtered by connector_key. Filtering (not a single
-    // unpaginated page) is size-independent: an active connection in a large
-    // workspace can't fall off page 1 and be misreported as absent/unhealthy.
+    // their connections. Two targeted probes per connector rather than a single
+    // page: first ask "is there an ACTIVE connection?" (status filter, limit 1);
+    // only if none, fetch one connection to report its non-active state. This is
+    // fully size-independent — an older active connection can't be hidden behind
+    // a page of newer revoked ones.
     const matchedInstalled = installed.filter((i) =>
       matchesQueryTokens(q, i.id, i.name, i.detail?.description)
     );
-    const USABLE = new Set(['active']);
+    const listConnections = async (connectorKey: string, status?: string) => {
+      const res = (await manageConnections(
+        { action: 'list', connector_key: connectorKey, ...(status ? { status } : {}), limit: 1 } as never,
+        env,
+        ctx
+      )) as { connections?: unknown };
+      return asArray<{ status: string }>(res.connections);
+    };
     const bestStatusByKey = new Map<string, string>();
     await Promise.all(
       matchedInstalled.map(async (i) => {
-        const res = (await manageConnections(
-          { action: 'list', connector_key: i.id, limit: 200 } as never,
-          env,
-          ctx
-        )) as { connections?: unknown };
-        const rows = asArray<{ status: string }>(res.connections);
-        if (rows.length === 0) return;
-        const best = rows.find((r) => USABLE.has(r.status))?.status ?? rows[0].status;
-        bestStatusByKey.set(i.id, best);
+        if ((await listConnections(i.id, 'active')).length > 0) {
+          bestStatusByKey.set(i.id, 'active');
+          return;
+        }
+        const any = await listConnections(i.id);
+        if (any.length > 0) bestStatusByKey.set(i.id, any[0].status);
       })
     );
+    const USABLE = new Set(['active']);
     const bestStatus = (key: string): string | undefined => bestStatusByKey.get(key);
 
     for (const i of matchedInstalled) {

--- a/packages/server/src/tools/connector-discovery.ts
+++ b/packages/server/src/tools/connector-discovery.ts
@@ -80,15 +80,12 @@ export async function searchLiveConnectors(
   if (!q) return [];
   const lines: string[] = [];
   try {
-    const [inst, cat, conn] = await Promise.all([
+    const [inst, cat] = await Promise.all([
       manageCatalog({ action: 'list_installed', kinds: ['connectors'] } as never, env, ctx) as Promise<{
         installed?: { connectors?: { items?: unknown } };
       }>,
       manageCatalog({ action: 'list_catalog', kinds: ['connectors'] } as never, env, ctx) as Promise<{
         catalogs?: { connectors?: { entries?: unknown } };
-      }>,
-      manageConnections({ action: 'list', limit: 200 } as never, env, ctx) as Promise<{
-        connections?: unknown;
       }>,
     ]);
     const installed = asArray<{
@@ -102,27 +99,33 @@ export async function searchLiveConnectors(
       description?: string;
       detail?: { installable?: boolean; installability_message?: string; installability_reason?: string };
     }>(cat.catalogs?.connectors?.entries);
-    const configured = asArray<{ connector_key: string; status: string }>(conn.connections);
-    // Aggregate connections per connector and pick the BEST status — an active
-    // connection means "ready to use", but a revoked/error connection must not
-    // be reported as usable (it needs reauthentication, not a new feed). Prefer
-    // an active connection when the connector has several.
-    const USABLE = new Set(['active']);
-    const statusesByKey = new Map<string, string[]>();
-    for (const c of configured) {
-      const list = statusesByKey.get(c.connector_key) ?? [];
-      list.push(c.status);
-      statusesByKey.set(c.connector_key, list);
-    }
-    const bestStatus = (key: string): string | undefined => {
-      const list = statusesByKey.get(key);
-      if (!list || list.length === 0) return undefined;
-      return list.find((s) => USABLE.has(s)) ?? list[0];
-    };
     const installedIds = new Set(installed.map((i) => i.id));
 
-    for (const i of installed) {
-      if (!matchesQueryTokens(q, i.id, i.name, i.detail?.description)) continue;
+    // Only the installed connectors that MATCH the query need a status — resolve
+    // their connections filtered by connector_key. Filtering (not a single
+    // unpaginated page) is size-independent: an active connection in a large
+    // workspace can't fall off page 1 and be misreported as absent/unhealthy.
+    const matchedInstalled = installed.filter((i) =>
+      matchesQueryTokens(q, i.id, i.name, i.detail?.description)
+    );
+    const USABLE = new Set(['active']);
+    const bestStatusByKey = new Map<string, string>();
+    await Promise.all(
+      matchedInstalled.map(async (i) => {
+        const res = (await manageConnections(
+          { action: 'list', connector_key: i.id, limit: 200 } as never,
+          env,
+          ctx
+        )) as { connections?: unknown };
+        const rows = asArray<{ status: string }>(res.connections);
+        if (rows.length === 0) return;
+        const best = rows.find((r) => USABLE.has(r.status))?.status ?? rows[0].status;
+        bestStatusByKey.set(i.id, best);
+      })
+    );
+    const bestStatus = (key: string): string | undefined => bestStatusByKey.get(key);
+
+    for (const i of matchedInstalled) {
       const feeds = feedKeysOf(i.detail);
       const feedKeyHint = feeds?.[0] ? `'${feeds[0]}'` : '<feed_key>';
       const feedKeysNote = feeds ? ` Feed keys: ${feeds.join(', ')}.` : '';

--- a/packages/server/src/tools/connector-discovery.ts
+++ b/packages/server/src/tools/connector-discovery.ts
@@ -96,9 +96,12 @@ export async function searchLiveConnectors(
       name?: string;
       detail?: { description?: string; feeds_schema?: unknown };
     }>(inst.installed?.connectors?.items);
-    const catalog = asArray<{ id: string; name?: string; description?: string }>(
-      cat.catalogs?.connectors?.entries
-    );
+    const catalog = asArray<{
+      id: string;
+      name?: string;
+      description?: string;
+      detail?: { installable?: boolean; installability_message?: string; installability_reason?: string };
+    }>(cat.catalogs?.connectors?.entries);
     const configured = asArray<{ connector_key: string; status: string }>(conn.connections);
     // Aggregate connections per connector and pick the BEST status — an active
     // connection means "ready to use", but a revoked/error connection must not
@@ -144,6 +147,18 @@ export async function searchLiveConnectors(
     for (const c of catalog) {
       if (installedIds.has(c.id)) continue; // installed line already covers it
       if (!matchesQueryTokens(q, c.id, c.name, c.description)) continue;
+      // A catalog entry can be non-installable (e.g. a stale/unavailable
+      // connector). installConnector on it is guaranteed to fail, so surface the
+      // reason instead of the install lifecycle.
+      if (c.detail?.installable === false) {
+        const why = c.detail.installability_message ?? c.detail.installability_reason;
+        lines.push(
+          `connector '${c.id}' (${c.name ?? c.id}) — in the global CATALOG but NOT currently installable${
+            why ? `: ${why}` : ' here'
+          }. It cannot be configured right now.`
+        );
+        continue;
+      }
       lines.push(
         `connector '${c.id}' (${c.name ?? c.id}) — in the global CATALOG, not yet installed here. Install with run_sdk → client.connections.installConnector({ connector_id: '${c.id}' }), then connect + create feed.`
       );

--- a/packages/server/src/tools/connector-discovery.ts
+++ b/packages/server/src/tools/connector-discovery.ts
@@ -1,0 +1,143 @@
+/**
+ * Connector intent-search for `search_sdk`.
+ *
+ * A fresh agent asked to "connect a website" searches by INTENT ("website",
+ * "crawl a web page"), not by the exact SDK method path — and a connector may be
+ * installed for this org yet absent from the global catalog, so it's easy to
+ * wrongly conclude a source is unsupported (the agent-discovery audit's RSS-
+ * instead-of-Website failure). This surfaces the matching live connector — with
+ * its feed keys and the exact connect→feed→trigger lifecycle — directly in
+ * `search_sdk` results, so one discovery call finds the capability whether it's
+ * a method or a connector (the "one catalog" idea). Read-only; never emits
+ * credentials or raw connector config.
+ *
+ * Reuses the existing admin handlers (same functions the sandbox namespaces
+ * wrap) — no new data path, no cross-replica state. Handlers are injectable so
+ * tests supply fakes without `mock.module` (process-global in Bun, it corrupts
+ * sibling suites).
+ */
+
+import { manageCatalog } from './admin/manage_catalog';
+import { manageConnections } from './admin/manage_connections';
+import type { Env } from '../index';
+import type { ToolContext } from './registry';
+
+export interface ConnectorDiscoveryDeps {
+  manageCatalog: typeof manageCatalog;
+  manageConnections: typeof manageConnections;
+}
+
+const DEFAULT_DEPS: ConnectorDiscoveryDeps = { manageCatalog, manageConnections };
+
+function asArray<T = Record<string, unknown>>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+/** Feed keys are the top-level keys of a connector's feeds_schema object. */
+function feedKeysOf(detail: unknown): string[] | undefined {
+  const feeds = (detail as { feeds_schema?: unknown } | null)?.feeds_schema;
+  if (!feeds || typeof feeds !== 'object' || Array.isArray(feeds)) return undefined;
+  const keys = Object.keys(feeds as Record<string, unknown>);
+  return keys.length > 0 ? keys : undefined;
+}
+
+/**
+ * Token-aware match: an agent rarely searches the bare connector name — it
+ * searches a phrase like "website connect source" or "crawl a web page". Match
+ * when ANY meaningful token of the query hits a connector field, so a multi-word
+ * query still finds the connector. Short/stopword tokens are dropped so common
+ * filler words don't match every connector.
+ */
+const STOPWORDS = new Set([
+  'a', 'an', 'the', 'my', 'to', 'of', 'in', 'and', 'or', 'for', 'with', 'into',
+  'connect', 'connector', 'source', 'data', 'get', 'add', 'set', 'up', 'from',
+  'search', 'ingest', 'collect', 'sync', 'read', 'content', 'page', 'pages',
+]);
+function matchesQueryTokens(query: string, ...fields: Array<string | null | undefined>): boolean {
+  const tokens = query
+    .toLowerCase()
+    .split(/[^a-z0-9.]+/)
+    .filter((t) => t.length >= 3 && !STOPWORDS.has(t));
+  if (tokens.length === 0) return false;
+  const hay = fields.filter((f): f is string => typeof f === 'string').map((f) => f.toLowerCase());
+  return tokens.some((t) => hay.some((f) => f.includes(t)));
+}
+
+/**
+ * Search live connectors (installed + global catalog) for an intent keyword,
+ * returning rendered lines in `search_sdk`'s result shape. Installed connectors
+ * come first (ready to configure, or already configured), then catalog offerings
+ * (installable). Empty for a blank query or no match.
+ */
+export async function searchLiveConnectors(
+  query: string,
+  env: Env,
+  ctx: ToolContext,
+  deps: ConnectorDiscoveryDeps = DEFAULT_DEPS
+): Promise<string[]> {
+  const { manageCatalog, manageConnections } = deps;
+  const q = query.trim();
+  if (!q) return [];
+  const lines: string[] = [];
+  try {
+    const [inst, cat, conn] = await Promise.all([
+      manageCatalog({ action: 'list_installed', kinds: ['connectors'] } as never, env, ctx) as Promise<{
+        installed?: { connectors?: { items?: unknown } };
+      }>,
+      manageCatalog({ action: 'list_catalog', kinds: ['connectors'] } as never, env, ctx) as Promise<{
+        catalogs?: { connectors?: { entries?: unknown } };
+      }>,
+      manageConnections({ action: 'list', limit: 200 } as never, env, ctx) as Promise<{
+        connections?: unknown;
+      }>,
+    ]);
+    const installed = asArray<{
+      id: string;
+      name?: string;
+      detail?: { description?: string; feeds_schema?: unknown };
+    }>(inst.installed?.connectors?.items);
+    const catalog = asArray<{ id: string; name?: string; description?: string }>(
+      cat.catalogs?.connectors?.entries
+    );
+    const configured = asArray<{ connector_key: string; status: string }>(conn.connections);
+    const configuredByKey = new Map<string, string>();
+    for (const c of configured) {
+      if (!configuredByKey.has(c.connector_key)) configuredByKey.set(c.connector_key, c.status);
+    }
+    const installedIds = new Set(installed.map((i) => i.id));
+
+    for (const i of installed) {
+      if (!matchesQueryTokens(q, i.id, i.name, i.detail?.description)) continue;
+      const feeds = feedKeysOf(i.detail);
+      const status = configuredByKey.get(i.id);
+      if (status) {
+        // Already has a live connection — read/verify, don't re-connect.
+        lines.push(
+          `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED and already CONFIGURED (a connection exists, status: ${status}).${
+            feeds ? ` Feed keys: ${feeds.join(', ')}.` : ''
+          } To add a feed: run_sdk → client.feeds.create({ connection_id, feed_key: ${
+            feeds?.[0] ? `'${feeds[0]}'` : '<feed_key>'
+          }, config }). To read collected data: query_sql on events or search_memory. Get the connection_id via query_sdk → client.connections.list({ connector_key: '${i.id}' }).`
+        );
+      } else {
+        lines.push(
+          `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED, not yet configured.${
+            feeds ? ` Feed keys: ${feeds.join(', ')}.` : ''
+          } Lifecycle: run_sdk → client.connections.connect({ connector_key: '${i.id}' }) → client.feeds.create({ connection_id, feed_key: ${
+            feeds?.[0] ? `'${feeds[0]}'` : '<feed_key>'
+          }, config }) → client.feeds.trigger({ feed_id }); then query_sql on events or search_memory to read. Use search_sdk 'feeds.create feeds.trigger' for signatures.`
+        );
+      }
+    }
+    for (const c of catalog) {
+      if (installedIds.has(c.id)) continue; // installed line already covers it
+      if (!matchesQueryTokens(q, c.id, c.name, c.description)) continue;
+      lines.push(
+        `connector '${c.id}' (${c.name ?? c.id}) — in the global CATALOG, not yet installed here. Install with run_sdk → client.connections.installConnector({ connector_id: '${c.id}' }), then connect + create feed.`
+      );
+    }
+  } catch {
+    return [];
+  }
+  return lines.slice(0, 8);
+}

--- a/packages/server/src/tools/connector-discovery.ts
+++ b/packages/server/src/tools/connector-discovery.ts
@@ -78,6 +78,12 @@ export async function searchLiveConnectors(
   const { manageCatalog, manageConnections } = deps;
   const q = query.trim();
   if (!q) return [];
+  // Connector inventory is workspace-member context, not anonymous public data.
+  // `search_sdk` is publicly readable (method docs are org-independent), so an
+  // anonymous session on a public workspace can reach here — but it must NOT be
+  // handed the org's installed/configured connectors. Gate the enrichment on an
+  // authenticated member session; anon simply gets method docs, no connectors.
+  if (!ctx.userId || !ctx.memberRole) return [];
   const lines: string[] = [];
   try {
     const [inst, cat] = await Promise.all([

--- a/packages/server/src/tools/connector-discovery.ts
+++ b/packages/server/src/tools/connector-discovery.ts
@@ -136,21 +136,32 @@ export async function searchLiveConnectors(
       const feeds = feedKeysOf(i.detail);
       const feedKeyHint = feeds?.[0] ? `'${feeds[0]}'` : '<feed_key>';
       const feedKeysNote = feeds ? ` Feed keys: ${feeds.join(', ')}.` : '';
+      // A connector with NO feeds_schema (e.g. an action/chat connector like
+      // Slack) does not sync via feeds — telling the agent to feeds.create would
+      // send it down an invalid lifecycle. Point it at operations instead.
+      const hasFeeds = !!feeds;
+      const useHint = hasFeeds
+        ? `To add a feed: run_sdk → client.feeds.create({ connection_id, feed_key: ${feedKeyHint}, config }); then query_sql on events or search_memory to read.`
+        : `This connector has no data feeds — it exposes operations/actions. Discover them via query_sdk → client.operations.listAvailable({ connector_key: '${i.id}' }) and run with client.operations.execute.`;
       const status = bestStatus(i.id);
       if (status && USABLE.has(status)) {
-        // Healthy live connection — add a feed / read, don't re-connect.
         lines.push(
-          `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED and CONNECTED (active connection).${feedKeysNote} To add a feed: run_sdk → client.feeds.create({ connection_id, feed_key: ${feedKeyHint}, config }); then query_sql on events or search_memory to read. Get the connection_id via query_sdk → client.connections.list({ connector_key: '${i.id}' }).`
+          `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED and CONNECTED (active connection).${feedKeysNote} ${useHint} Get the connection_id via query_sdk → client.connections.list({ connector_key: '${i.id}' }).`
         );
       } else if (status) {
         // Connection exists but is NOT usable (revoked/error/paused/pending) —
-        // it must be repaired before any feed will sync.
+        // repair it before use.
         lines.push(
           `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED with a connection that needs attention (status: ${status}).${feedKeysNote} Reauthenticate/repair before use: run_sdk → client.connections.reauthenticate(<connection_id>) (or reconnect). Find the connection via query_sdk → client.connections.list({ connector_key: '${i.id}' }).`
         );
-      } else {
+      } else if (hasFeeds) {
         lines.push(
           `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED, not yet configured.${feedKeysNote} Lifecycle: run_sdk → client.connections.connect({ connector_key: '${i.id}' }) → client.feeds.create({ connection_id, feed_key: ${feedKeyHint}, config }) → client.feeds.trigger({ feed_id }); then query_sql on events or search_memory to read. Use search_sdk 'feeds.create feeds.trigger' for signatures.`
+        );
+      } else {
+        // Feedless connector, not yet connected — connect, then use operations.
+        lines.push(
+          `connector '${i.id}' (${i.name ?? i.id}) — INSTALLED, not yet connected. It has no data feeds — it exposes operations/actions. Lifecycle: run_sdk → client.connections.connect({ connector_key: '${i.id}' }); then query_sdk → client.operations.listAvailable({ connector_key: '${i.id}' }) and run with client.operations.execute.`
         );
       }
     }

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -234,14 +234,11 @@ async function sdkSearchImpl(
 	env: Env,
 	ctx: ToolContext,
 ): Promise<SdkSearchResult> {
-	// Unified-catalog search (executor pattern): a query like "website" or
-	// "slack" names a CONNECTOR, not an SDK method, so pure method search returns
-	// nothing useful. Search live connectors first; when the query names one,
-	// surface it (+ lifecycle) ABOVE method docs so the agent doesn't have to
-	// know that connectors and methods live in different discovery paths. Skip
-	// the (2 DB reads) connector lookup for queries that are obviously method
-	// paths — a dotted path (`feeds.create`) or a `client.`-prefixed term — since
-	// those never name a connector; a plain word like "website" still triggers it.
+	// Unified-catalog search (executor pattern): a query like "website" or "slack"
+	// names a CONNECTOR, not an SDK method, so pure method search returns nothing
+	// useful. Search live connectors and surface them (+ lifecycle) ABOVE method
+	// docs. Skip the connector lookup for obvious method paths — a dotted path
+	// (`feeds.create`) or a `client.`-prefixed term never names a connector.
 	const q = args.query.trim();
 	const looksLikeMethodPath = q.includes(".") || /^client\b/i.test(q);
 	const connectorHits = looksLikeMethodPath
@@ -249,16 +246,25 @@ async function sdkSearchImpl(
 		: await searchLiveConnectors(q, env, ctx);
 	const methodResult = await sdkMethodSearch(args, env, ctx);
 	if (connectorHits.length === 0) return methodResult;
-	const merged = [...connectorHits, ...methodResult.results];
+
+	// Cap the COMBINED list at the same limit the method search honors, so
+	// prepended connector hits can't push the response past the documented max.
+	// Connector hits are the more specific answer, so they keep priority.
+	const limit = Math.min(args.limit ?? 20, 100);
+	const combined = [...connectorHits, ...methodResult.results];
+	const results = combined.slice(0, limit);
+	const dropped = combined.length - results.length;
+	const baseNote =
+		methodResult.results.length > 0
+			? "Top matches are live connectors (with lifecycle); method docs follow."
+			: "Matched live connectors (not SDK methods). Follow the lifecycle shown; query a namespace (e.g. 'feeds') for method signatures.";
+	const truncNote =
+		dropped > 0 ? ` ${dropped} more result(s) truncated; raise \`limit\` or refine the query.` : "";
 	return {
 		query: methodResult.query,
-		match_count: merged.length,
-		results: merged,
-		notes:
-			methodResult.results.length > 0
-				? "Top matches are live connectors (with lifecycle); method docs follow. " +
-					(methodResult.notes ?? "")
-				: "Matched live connectors (not SDK methods). Follow the lifecycle shown; query a namespace (e.g. 'feeds') for method signatures.",
+		match_count: results.length,
+		results,
+		notes: `${baseNote}${truncNote}`.trim(),
 	};
 }
 

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -237,10 +237,17 @@ async function sdkSearchImpl(
 	// Unified-catalog search (executor pattern): a query like "website" or "slack"
 	// names a CONNECTOR, not an SDK method, so pure method search returns nothing
 	// useful. Search live connectors and surface them (+ lifecycle) ABOVE method
-	// docs. Skip the connector lookup for obvious method paths — a dotted path
-	// (`feeds.create`) or a `client.`-prefixed term never names a connector.
+	// docs. Skip the connector lookup ONLY for genuine method paths — a
+	// `client.`-prefixed term, or a dotted path whose FIRST segment is a real SDK
+	// namespace (`feeds.create`). A dotted CONNECTOR id (`google.calendar`) must
+	// still be searched: its first segment (`google`) is not an SDK namespace.
 	const q = args.query.trim();
-	const looksLikeMethodPath = q.includes(".") || /^client\b/i.test(q);
+	// NAMESPACES preserves SDK casing (entitySchema, authProfiles); the query is
+	// lowercased — compare case-insensitively so `entitySchema.listTypes` is
+	// recognized as a method path.
+	const firstSegment = normalizeQueryTerm(q).split(".")[0];
+	const isSdkNamespace = NAMESPACES.some((ns) => ns.toLowerCase() === firstSegment);
+	const looksLikeMethodPath = /^client\b/i.test(q) || (q.includes(".") && isSdkNamespace);
 	const connectorHits = looksLikeMethodPath
 		? []
 		: await searchLiveConnectors(q, env, ctx);

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -24,6 +24,7 @@ import {
 } from "../sandbox/sdk-method-access";
 import type { ToolContext } from "./registry";
 import { withValidatedArgs } from "./validate-args";
+import { searchLiveConnectors } from "./connector-discovery";
 
 /**
  * agents.* paths → agent_config action that must not be blanket-denied for the
@@ -230,6 +231,39 @@ export const sdkSearch = withValidatedArgs("search_sdk", SdkSearchSchema, sdkSea
 
 async function sdkSearchImpl(
 	args: SdkSearchArgs,
+	env: Env,
+	ctx: ToolContext,
+): Promise<SdkSearchResult> {
+	// Unified-catalog search (executor pattern): a query like "website" or
+	// "slack" names a CONNECTOR, not an SDK method, so pure method search returns
+	// nothing useful. Search live connectors first; when the query names one,
+	// surface it (+ lifecycle) ABOVE method docs so the agent doesn't have to
+	// know that connectors and methods live in different discovery paths. Skip
+	// the (2 DB reads) connector lookup for queries that are obviously method
+	// paths — a dotted path (`feeds.create`) or a `client.`-prefixed term — since
+	// those never name a connector; a plain word like "website" still triggers it.
+	const q = args.query.trim();
+	const looksLikeMethodPath = q.includes(".") || /^client\b/i.test(q);
+	const connectorHits = looksLikeMethodPath
+		? []
+		: await searchLiveConnectors(q, env, ctx);
+	const methodResult = await sdkMethodSearch(args, env, ctx);
+	if (connectorHits.length === 0) return methodResult;
+	const merged = [...connectorHits, ...methodResult.results];
+	return {
+		query: methodResult.query,
+		match_count: merged.length,
+		results: merged,
+		notes:
+			methodResult.results.length > 0
+				? "Top matches are live connectors (with lifecycle); method docs follow. " +
+					(methodResult.notes ?? "")
+				: "Matched live connectors (not SDK methods). Follow the lifecycle shown; query a namespace (e.g. 'feeds') for method signatures.",
+	};
+}
+
+async function sdkMethodSearch(
+	args: SdkSearchArgs,
 	_env: Env,
 	ctx: ToolContext,
 ): Promise<SdkSearchResult> {
@@ -399,6 +433,9 @@ async function sdkSearchImpl(
 	}
 
 	if (matches.length === 0) {
+		// Connector intent-search is handled by the sdkSearchImpl wrapper, which
+		// merges live-connector hits ahead of these method results — so a
+		// zero-method query like "website" still returns the connector.
 		const hiddenExact = METADATA_BY_LOWER_PATH.get(lower);
 		const existsButHidden = hiddenExact
 			? hiddenMethodNote(hiddenExact[0], hiddenExact[1], mode, policyDenied)

--- a/packages/server/src/tools/validate-args.ts
+++ b/packages/server/src/tools/validate-args.ts
@@ -134,24 +134,69 @@ function compileSchema(schema: TSchema): TypeCheck<TSchema> {
  * than `false` (e.g. `Type.Record` passthrough) or has no `properties` at
  * all — those schemas accept arbitrary keys by design.
  */
-function rejectUnknownKeys(toolName: string, schema: TSchema, coerced: unknown): void {
+/**
+ * Return the allowed string literals of a subschema when it is a single
+ * literal, an enum, or a union of literals — so an "Expected union value"
+ * error (which names none) can be rewritten as `Expected one of: "a", "b"`.
+ * Returns null for any other schema shape.
+ */
+function allowedLiterals(schema: unknown): string[] | null {
+  if (!schema || typeof schema !== 'object') return null;
+  const s = schema as {
+    const?: unknown;
+    enum?: unknown[];
+    anyOf?: unknown[];
+    oneOf?: unknown[];
+  };
+  if (Array.isArray(s.enum)) {
+    return s.enum.map((v) => String(v));
+  }
+  if (s.const !== undefined) return [String(s.const)];
+  const variants = s.anyOf ?? s.oneOf;
+  if (Array.isArray(variants)) {
+    const lits: string[] = [];
+    for (const v of variants) {
+      const inner = allowedLiterals(v);
+      if (!inner) return null; // a non-literal member → not a pure literal union
+      lits.push(...inner);
+    }
+    return lits.length > 0 ? lits : null;
+  }
+  return null;
+}
+
+/** Resolve the subschema at a TypeBox error `path` (e.g. `/list_scope`). */
+function subschemaAtPath(schema: TSchema, path: string): unknown {
+  const segments = path.split('/').filter(Boolean);
+  let current: unknown = schema;
+  for (const seg of segments) {
+    if (!current || typeof current !== 'object') return undefined;
+    const props = (current as { properties?: Record<string, unknown> }).properties;
+    current = props ? props[seg] : undefined;
+  }
+  return current;
+}
+
+/**
+ * Find top-level keys the schema does not declare, so they can be reported
+ * ALONGSIDE any missing/typed-wrong fields (a caller who passes `{ id }` for a
+ * `{ feed_id }` schema must learn both that `feed_id` is missing AND that `id`
+ * is unknown — fixing one at a time is the failure the audit flagged).
+ *
+ * Returns `null` when the schema accepts arbitrary keys by design
+ * (`additionalProperties` non-false, or no `properties`); empty array when all
+ * keys are known. Object.hasOwn (not `key in`) so prototype-named keys
+ * (`constructor`, `toString`) are correctly treated as unknown.
+ */
+function unknownKeys(schema: TSchema, coerced: unknown): string[] | null {
   const { properties, additionalProperties } = schema as {
     properties?: Record<string, unknown>;
     additionalProperties?: unknown;
   };
-  if (!properties) return;
-  if (additionalProperties !== undefined && additionalProperties !== false) return;
-  if (!coerced || typeof coerced !== 'object' || Array.isArray(coerced)) return;
-  // Object.hasOwn, NOT `key in properties`: `in` walks Object.prototype, so
-  // args named `constructor`, `toString`, `hasOwnProperty`, etc. would be
-  // wrongly accepted as "known" keys.
-  const unknown = Object.keys(coerced).filter((key) => !Object.hasOwn(properties, key));
-  if (unknown.length === 0) return;
-  const action = (properties.action as { const?: unknown } | undefined)?.const;
-  const scope = action !== undefined ? ` for action '${String(action)}'` : '';
-  throw new ToolUserError(
-    `Invalid arguments for ${toolName}: unknown argument(s): ${unknown.join(', ')} — valid arguments${scope} are: ${Object.keys(properties).join(', ')}`
-  );
+  if (!properties) return null;
+  if (additionalProperties !== undefined && additionalProperties !== false) return null;
+  if (!coerced || typeof coerced !== 'object' || Array.isArray(coerced)) return [];
+  return Object.keys(coerced).filter((key) => !Object.hasOwn(properties, key));
 }
 
 function checkAgainst(toolName: string, schema: TSchema, args: unknown): unknown {
@@ -164,22 +209,60 @@ function checkAgainst(toolName: string, schema: TSchema, args: unknown): unknown
   // path requires sort_by to be UNSET; injecting the default broke it.
   const coerced = Value.Convert(schema, normalizeArgs(args));
   const validator = compileSchema(schema);
-  if (validator.Check(coerced)) {
-    rejectUnknownKeys(toolName, schema, coerced);
+  const checkPassed = validator.Check(coerced);
+
+  const unknown = unknownKeys(schema, coerced);
+  const action = (
+    (schema as { properties?: Record<string, { const?: unknown }> }).properties?.action
+  )?.const;
+  const scope = action !== undefined ? ` for action '${String(action)}'` : '';
+
+  if (checkPassed) {
+    if (unknown && unknown.length > 0) {
+      const valid = Object.keys(
+        (schema as { properties?: Record<string, unknown> }).properties ?? {}
+      );
+      throw new ToolUserError(
+        `Invalid arguments for ${toolName}: unknown argument(s): ${unknown.join(', ')} — valid arguments${scope} are: ${valid.join(', ')}`
+      );
+    }
     return coerced;
   }
 
   // Deduplicate by path — TypeBox emits both `Expected required property` and
   // `Expected <type>` against the same missing field, which would otherwise
-  // duplicate the field name in the error message.
+  // duplicate the field name in the error message. Humanize enum failures by
+  // listing the allowed literals (TypeBox's "Expected union value" names none).
+  const unknownSet = new Set(unknown ?? []);
   const seen = new Set<string>();
   const errs: string[] = [];
   for (const e of validator.Errors(coerced)) {
     const path = e.path || '/';
     if (seen.has(path)) continue;
+    // Skip TypeBox's raw `Unexpected property` — the humanized "unknown
+    // argument(s)" line below re-reports every unknown key at once with the
+    // valid-argument set, so leaving the raw one in would double-list the key.
+    const key = path.replace(/^\//, '');
+    if (unknownSet.has(key)) continue;
     seen.add(path);
-    errs.push(`${path}: ${e.message}`);
+    const literals = allowedLiterals(subschemaAtPath(schema, path));
+    const message = literals
+      ? `Expected one of: ${literals.map((l) => JSON.stringify(l)).join(', ')}`
+      : e.message;
+    errs.push(`${path}: ${message}`);
     if (errs.length >= 3) break;
+  }
+
+  // Report unknown keys in the SAME message as the type/required failures, so a
+  // caller who supplied the wrong field name (dropping the required one) sees
+  // both problems at once instead of fixing them serially.
+  if (unknown && unknown.length > 0) {
+    const valid = Object.keys(
+      (schema as { properties?: Record<string, unknown> }).properties ?? {}
+    );
+    errs.push(
+      `unknown argument(s): ${unknown.join(', ')} — valid arguments${scope} are: ${valid.join(', ')}`
+    );
   }
   throw new ToolUserError(`Invalid arguments for ${toolName}: ${errs.join('; ')}`);
 }

--- a/packages/server/src/tools/validate-args.ts
+++ b/packages/server/src/tools/validate-args.ts
@@ -121,20 +121,6 @@ function compileSchema(schema: TSchema): TypeCheck<TSchema> {
 }
 
 /**
- * Reject top-level keys the schema does not declare. TypeBox `Type.Object`
- * accepts extra keys by default, so an unknown argument (a typo, or a field
- * that belongs to a DIFFERENT action variant) used to be silently dropped —
- * the call "succeeded" while ignoring the caller's intent. This runs against
- * the MATCHED variant's properties (never the union: clients see the
- * flattened merged schema, so only post-dispatch is the allowed key set
- * well-defined; the `action` discriminator is a declared property of every
- * variant and thus always allowed).
- *
- * Skipped when the schema declares `additionalProperties` as anything other
- * than `false` (e.g. `Type.Record` passthrough) or has no `properties` at
- * all — those schemas accept arbitrary keys by design.
- */
-/**
  * Return the allowed string literals of a subschema when it is a single
  * literal, an enum, or a union of literals — so an "Expected union value"
  * error (which names none) can be rewritten as `Expected one of: "a", "b"`.

--- a/packages/server/src/utils/workspace-instructions.ts
+++ b/packages/server/src/utils/workspace-instructions.ts
@@ -203,7 +203,11 @@ export async function buildWorkspaceInstructions(organizationId: string): Promis
     sections.push(
       '',
       '### Tool surface',
-      'External MCP tools: `search_memory`, `save_memory`, `search_sdk` (SDK discovery — pass mode=read for query_sdk methods), `query_sdk` (read-only TS), `query_sql` (paginated SQL for all members), `run_sdk` (full TS writes). Discover SDK methods with `search_sdk`, then call via `query_sdk` / `run_sdk`. Prefer `client.metrics.*` for governed metrics.',
+      'External MCP tools: `search_memory`, `save_memory`, `search_sdk` (SDK method + connector discovery — pass mode=read for query_sdk methods), `query_sdk` (read-only TS), `query_sql` (paginated SQL for all members), `run_sdk` (full TS writes). Discover with `search_sdk`, then act via `query_sdk` / `run_sdk`. Prefer `client.metrics.*` for governed metrics.',
+      '### Connecting a data source (do NOT assume a source is unsupported — enumerate first)',
+      'A connector may be INSTALLED for this org yet absent from the global catalog, so always check installed connectors before concluding a source is unsupported:',
+      '- Find the connector: `search_sdk` with the source/topic word (e.g. "website", "slack") returns any matching live connector + its feed keys + lifecycle. Or list them: `query_sdk` → `client.catalog.listInstalled({ kinds: ["connectors"] })` (installed = ready to configure; each item\'s `detail.feeds_schema` keys are the feed_key values) and `client.catalog.listCatalog({ kinds: ["connectors"] })` (global, installable) and `client.connections.list()` (already configured).',
+      '- Lifecycle: `run_sdk` → `client.connections.connect({ connector_key })` → `client.feeds.create({ connection_id, feed_key, config })` → `client.feeds.trigger({ feed_id })`; then verify with `query_sql` on the events table and search with `search_memory`.',
       'For reads beyond search_memory, prefer `query_sdk` with a TS script. For writes (entity CRUD, watchers, classifiers, connections, feeds, view templates, operations), use `run_sdk`. Use `search_sdk` to discover method names.',
       '',
       '### Saving (do this automatically)',


### PR DESCRIPTION
## Why

A fresh MCP client (no source access, no prior Lobu knowledge) scored ~4.5/10 at discovering how to connect a data source. The canonical failure: asked to "connect a website," agents recommended RSS/webhook instead of the installed Website connector, and validation errors leaked internal `manage_*` names that agents couldn't recover from.

Validated clean-room against **Gemini 3.1 Pro and 3.5 Flash** (independent models, no repo access) driving the real MCP endpoint.

## What

**Source-blind connector discovery (no new tool):**
- `search_sdk` now surfaces matching **live connectors** (installed + catalog) with their feed keys and the exact `connect → feed → trigger` lifecycle — token-matched, so a verb-phrase query like "crawl a web page" still finds the `website` connector. Handles connection health (active → add feed; revoked/error → reauthenticate) and non-installable catalog entries. Status is resolved with targeted `status=active` probes, independent of connection count.
- MCP `initialize` instructions gain an "enumerate installed connectors before assuming a source is unsupported" recipe. This is what makes discovery reliable — a connector can be org-installed yet absent from the global catalog.
- **No net tool-count change** (an earlier `workspace_context` tool was tried and dropped after evals showed the instructions + enriched `search_sdk` are reliable without it).

**Public SDK error normalization:**
- Validation errors name the public SDK method (`client.feeds.get`), not the internal `manage_*` tool; enumerate allowed enum literals; report missing + unknown fields together; use neutral placeholder ids (`<connection_id>`).
- Sandbox script errors hide the server-bundle stack for expected user errors; `client.org` on scoped/PAT sessions throws a structured `CrossOrgAccessDenied` instead of "is not a function".

## Evidence

- Clean-room: recipe in real MCP instructions, neutral prompt, no dedicated tool → **5/5 correct** across Gemini Pro + Flash on the installed-but-unconfigured Website case. Final shipped-surface confirmation: Gemini Pro solved it in ~10 calls.
- `make pre-pr` green (build + typecheck + knip + biome); 132 changed-area unit tests green.
- Error recovery, enum literals, no `manage_*` leak, no stack leak — all live-verified through the SDK path.

## Test plan

- `bun test` covers: error humanization (enum literals, missing+unknown, camelCase method rewrite, stack hidden), connector intent search (multi-word tokens, revoked/active/non-installable, dotted ids, active-behind-many-revoked), org-scope rejection.
- Integration/e2e for the sandbox runtime run under CI (isolated-vm) — not reproducible under `bun test` locally.

## Org scoping / multi-tenancy

Connector discovery is strictly single-org: `searchLiveConnectors` passes only the bound `ctx` (no cross-org param) to org-scoped handlers, so it can't reach another org's connectors. An orgless multi-org session resolves to its default org (existing auth behavior, unchanged). Configured-connection status inherits the existing connection-visibility gate (anon/non-member see only `visibility='org'` connections; never credentials). Connector enrichment is additionally gated to authenticated members — an anonymous session on a public workspace gets SDK method docs only, no org connector inventory (verified live).
