### PR TITLE
fix(mcp): connector discovery works for scoped-endpoint members

### DIFF
--- a/packages/server/src/__tests__/unit/connector-discovery.test.ts
+++ b/packages/server/src/__tests__/unit/connector-discovery.test.ts
@@ -233,13 +233,23 @@ describe("searchLiveConnectors (search_sdk connector intent search)", () => {
 		expect(await searchLiveConnectors("   ", env, ctx, makeDeps())).toEqual([]);
 	});
 
-	it("returns nothing for an anonymous / non-member session (no connector inventory to strangers)", async () => {
+	it("returns nothing for a truly anonymous session (no userId) — no inventory to strangers", async () => {
 		// search_sdk is publicly readable, so an anon session on a public workspace
-		// can call it — but connector inventory is member context, not public data.
+		// can call it — but connector inventory is member context. Anon has no
+		// userId, so it's gated here (and the downstream visibility gate would also
+		// restrict it).
 		const anon = { organizationId: "org-1", userId: null } as ToolContext;
-		const nonMember = { organizationId: "org-1", userId: "u1", memberRole: null } as ToolContext;
 		expect(await searchLiveConnectors("website", env, anon, makeDeps())).toEqual([]);
-		expect(await searchLiveConnectors("website", env, nonMember, makeDeps())).toEqual([]);
+	});
+
+	it("STILL returns connectors for a logged-in user whose memberRole isn't populated (scoped /mcp/{slug} session)", async () => {
+		// Regression: scoped-endpoint sessions carry a userId but often a null
+		// memberRole. Gating on memberRole wrongly suppressed discovery for real
+		// members. Gate on userId only; the downstream handler enforces the actual
+		// per-user visibility.
+		const scopedMember = { organizationId: "org-1", userId: "u1", memberRole: null } as ToolContext;
+		const hits = await searchLiveConnectors("website", env, scopedMember, makeDeps());
+		expect(hits.some((h) => h.includes("'website'"))).toBe(true);
 	});
 
 	it("matches a dotted CONNECTOR id (google.calendar), not just single words", async () => {

--- a/packages/server/src/tools/connector-discovery.ts
+++ b/packages/server/src/tools/connector-discovery.ts
@@ -80,10 +80,13 @@ export async function searchLiveConnectors(
   if (!q) return [];
   // Connector inventory is workspace-member context, not anonymous public data.
   // `search_sdk` is publicly readable (method docs are org-independent), so an
-  // anonymous session on a public workspace can reach here — but it must NOT be
-  // handed the org's installed/configured connectors. Gate the enrichment on an
-  // authenticated member session; anon simply gets method docs, no connectors.
-  if (!ctx.userId || !ctx.memberRole) return [];
+  // anonymous session on a public workspace can reach here — it must NOT be
+  // handed the org's connectors. Gate on an authenticated user only: the
+  // downstream connections-list handler applies the real per-user visibility
+  // (anon → org-visible only; member → own; admin → all), and `memberRole` is
+  // NOT reliably populated on scoped `/mcp/{slug}` sessions, so gating on it
+  // would wrongly suppress discovery for a legitimate member.
+  if (!ctx.userId) return [];
   const lines: string[] = [];
   try {
     const [inst, cat] = await Promise.all([


### PR DESCRIPTION
## Why

Follow-up to #1950. Live prod e2e caught a regression: `search_sdk`'s connector enrichment gated on `ctx.memberRole`, but scoped `/mcp/{slug}` sessions carry a `userId` without a populated `memberRole` (the scoped auth path doesn't call `resolveMembershipRole`). So a **legitimate member** browsing via the scoped endpoint got **zero connector results**.

Reproduced on prod: `search_sdk{query:"website"}` returned `match_count: 0` on `/mcp/buremba` (scoped + PAT), while the unscoped `/mcp` path returned the connector correctly.

## What

Gate the enrichment on `ctx.userId` only. The downstream `manage_connections` list handler already enforces the real per-user visibility (anon → `visibility='org'` only; member → own + org; admin → all) by looking up the actual role — so the `memberRole` check was both redundant and wrong for scoped sessions. Anonymous sessions (no `userId`) are still gated.

## Evidence

- Red→green live: local scoped `/mcp/{slug}` + member PAT → `search_sdk{query:"website"}` now returns the `website` connector (was 0 pre-fix, matching the prod failure).
- Anonymous session still returns no connector inventory.
- `make pre-pr` green; connector-discovery unit tests updated (scoped-member-gets-results + anon-gated) — 131 changed-area tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786656458&installation_id=136316292&pr_number=1951&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1951&signature=77d8639e93b970477bc46ea988aad1faf77512b4f0a1a5b03fe2514f37a9062e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->