### PR TITLE
feat(conversations): conversations SDK namespace (list/get/send)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,6 +70,12 @@
       "import": "./dist/contracts/tools/manage-agents.js",
       "require": "./dist/contracts/tools/manage-agents.js"
     },
+    "./contracts/tools/manage-conversations": {
+      "types": "./dist/contracts/tools/manage-conversations.d.ts",
+      "bun": "./src/contracts/tools/manage-conversations.ts",
+      "import": "./dist/contracts/tools/manage-conversations.js",
+      "require": "./dist/contracts/tools/manage-conversations.js"
+    },
     "./contracts/tools/manage-schedules": {
       "types": "./dist/contracts/tools/manage-schedules.d.ts",
       "bun": "./src/contracts/tools/manage-schedules.ts",

--- a/packages/core/src/contracts/tools/manage-conversations.ts
+++ b/packages/core/src/contracts/tools/manage-conversations.ts
@@ -1,0 +1,118 @@
+import { type Static, Type } from "@sinclair/typebox";
+
+// ============================================
+// Typebox Schema (Flattened for MCP)
+// ============================================
+
+export const ManageConversationsSchema = Type.Object({
+  action: Type.Union(
+    [
+      Type.Literal("list", {
+        description: "List an agent's conversations, newest-first.",
+      }),
+      Type.Literal("get", {
+        description:
+          "Fetch one conversation by its (platform, conversation_id).",
+      }),
+      Type.Literal("send", {
+        description:
+          "Send a message to an agent conversation and (by default) return its reply. " +
+          "Runs the turn against the conversation's pinned sandbox realm.",
+      }),
+    ],
+    { description: "Action to perform" }
+  ),
+
+  agent_id: Type.String({
+    description:
+      'Target agent id (lowercase slug, e.g. "researcher"). Required for every action.',
+  }),
+
+  platform: Type.Optional(
+    Type.String({
+      description:
+        '[get] Conversation platform ("web" for app-owned conversations, or a channel platform like "slack"). Defaults to "web".',
+    })
+  ),
+  conversation_id: Type.Optional(
+    Type.String({
+      description:
+        "[get] The stored conversation id. For [send], omit to target the caller's default web thread, " +
+        "or pass a `thread` to open/resume a named web thread.",
+    })
+  ),
+
+  thread: Type.Optional(
+    Type.String({
+      description:
+        "[send] Optional web thread name. Distinct threads keep separate history + separate pinned sandbox. Omit for the default thread.",
+    })
+  ),
+  text: Type.Optional(
+    Type.String({
+      description: "[send] Message text to deliver to the agent.",
+    })
+  ),
+  model: Type.Optional(
+    Type.String({
+      description:
+        "[send] Optional per-message model override as a `provider/model` ref. Wins over the agent/org default.",
+    })
+  ),
+  wait: Type.Optional(
+    Type.Boolean({
+      description:
+        "[send] When true (default), block until the agent's turn completes and return its reply. " +
+        "When false, enqueue and return immediately with the message id.",
+    })
+  ),
+  timeout_ms: Type.Optional(
+    Type.Number({
+      description:
+        "[send, wait=true] Max time to wait for the reply. Default 60000, capped at 170000. " +
+        "On timeout the turn keeps running; read the reply later via `get`.",
+      minimum: 1000,
+      maximum: 170_000,
+    })
+  ),
+});
+
+// ============================================
+// Type Definitions
+// ============================================
+
+export type ManageConversationsArgs = Static<typeof ManageConversationsSchema>;
+
+/** One conversation as surfaced by list/get. */
+export interface ConversationRecord {
+  platform: string;
+  conversation_id: string;
+  /** "owned" (an app/web thread) or "platform" (an external channel). */
+  kind: "owned" | "platform";
+  user_id: string | null;
+  title: string | null;
+  last_activity_at: string;
+  created_at: string;
+}
+
+export type ManageConversationsResult =
+  | { action: "list"; conversations: ConversationRecord[] }
+  | { action: "get"; conversation: ConversationRecord }
+  | {
+      // wait=false, or wait=true that timed out before completion.
+      action: "send";
+      conversation_id: string;
+      message_id: string;
+      status: "queued" | "timeout";
+    }
+  | {
+      // wait=true and the turn reached a terminal state.
+      action: "send";
+      conversation_id: string;
+      message_id: string;
+      status: "complete" | "error";
+      /** The agent's final reply text (status="complete"). */
+      reply?: string;
+      /** The terminal error message (status="error"). */
+      error?: string;
+    };

--- a/packages/core/src/contracts/tools/manage-conversations.ts
+++ b/packages/core/src/contracts/tools/manage-conversations.ts
@@ -70,7 +70,8 @@ export const ManageConversationsSchema = Type.Object({
     Type.Number({
       description:
         "[send, wait=true] Max time to wait for the reply. Default 60000, capped at 170000. " +
-        "On timeout the turn keeps running; read the reply later via `get`.",
+        'On timeout the turn keeps running and status is "timeout"; call `send` again on the ' +
+        "same conversation (any text) with wait=true to await it, or read the transcript out of band.",
       minimum: 1000,
       maximum: 170_000,
     })

--- a/packages/core/src/contracts/tools/manage-conversations.ts
+++ b/packages/core/src/contracts/tools/manage-conversations.ts
@@ -69,9 +69,11 @@ export const ManageConversationsSchema = Type.Object({
   timeout_ms: Type.Optional(
     Type.Number({
       description:
-        "[send, wait=true] Max time to wait for the reply. Default 60000, capped at 170000. " +
-        'On timeout the turn keeps running and status is "timeout" (the answer is not lost); ' +
-        "raise timeout_ms for a longer wait. The reply is not retrievable through `get`.",
+        "[send, wait=true] Max time to wait for the reply. Default 45000, capped at 170000 — " +
+        "kept inside run_sdk's own wall-clock budget so a no-reply call returns a graceful " +
+        'status:"timeout" instead of aborting the whole script. For a longer wait, raise BOTH ' +
+        "this and the run_sdk/query_sdk timeout_ms. On timeout the turn keeps running (the answer " +
+        "is not lost); the reply is not retrievable through `get`.",
       minimum: 1000,
       maximum: 170_000,
     })

--- a/packages/core/src/contracts/tools/manage-conversations.ts
+++ b/packages/core/src/contracts/tools/manage-conversations.ts
@@ -70,8 +70,8 @@ export const ManageConversationsSchema = Type.Object({
     Type.Number({
       description:
         "[send, wait=true] Max time to wait for the reply. Default 60000, capped at 170000. " +
-        'On timeout the turn keeps running and status is "timeout"; call `send` again on the ' +
-        "same conversation (any text) with wait=true to await it, or read the transcript out of band.",
+        'On timeout the turn keeps running and status is "timeout" (the answer is not lost); ' +
+        "raise timeout_ms for a longer wait. The reply is not retrievable through `get`.",
       minimum: 1000,
       maximum: 170_000,
     })

--- a/packages/server/src/__tests__/integration/conversations-store-reads.test.ts
+++ b/packages/server/src/__tests__/integration/conversations-store-reads.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Integration for the read helpers PR-C's `conversations.get` / `.send` depend
+ * on, against real Postgres: getConversation (single-row PK read, soft-delete
+ * hidden) and readConversationReply (terminal-outcome poll over the durable
+ * `runs` thread-response rows — the cross-replica reply source for
+ * `conversations.send({ wait: true })`). These exercise the exact SQL, including
+ * the jsonb `?`/`->>'` matching on processedMessageIds and the string/jsonb cast
+ * on action_input.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildApiConversationId } from "../../gateway/services/api-conversation-id";
+import {
+	getConversation,
+	readConversationReply,
+	upsertConversation,
+} from "../../gateway/services/conversations-store";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	createTestAgent,
+	createTestOrganization,
+	createTestUser,
+} from "../setup/test-fixtures";
+
+const AGENT = "conversations-store-reads-agent";
+
+/** Insert a terminal thread-response run the worker would write on completion. */
+async function insertThreadResponse(
+	org: string,
+	payload: Record<string, unknown>,
+	status: "completed" | "failed",
+): Promise<void> {
+	const sql = getTestDb();
+	await sql`
+    INSERT INTO public.runs (organization_id, run_type, queue_name, status, action_input, created_at)
+    VALUES (
+      ${org}, 'chat_message', 'thread_response', ${status},
+      ${sql.json(payload)}, now()
+    )
+  `;
+}
+
+describe("conversations-store read helpers", () => {
+	let org: string;
+	let userId: string;
+
+	beforeAll(async () => {
+		org = (await createTestOrganization()).id;
+		userId = (await createTestUser()).id;
+		await createTestAgent({
+			organizationId: org,
+			agentId: AGENT,
+			ownerUserId: userId,
+		});
+	});
+
+	afterAll(async () => {
+		await cleanupTestDatabase();
+	});
+
+	it("getConversation returns a materialized row and null for a missing one", async () => {
+		const conv = buildApiConversationId({
+			agentId: AGENT,
+			userId,
+			organizationId: org,
+			threadId: "get-thread",
+		});
+		await upsertConversation({
+			organizationId: org,
+			agentId: AGENT,
+			platform: "web",
+			conversationId: conv,
+			kind: "owned",
+			userId,
+			title: "a thread",
+			lastActivityAt: new Date("2026-06-28T01:00:00Z"),
+		});
+
+		const row = await getConversation({
+			organizationId: org,
+			agentId: AGENT,
+			platform: "web",
+			conversationId: conv,
+		});
+		expect(row?.conversationId).toBe(conv);
+		expect(row?.kind).toBe("owned");
+		expect(row?.title).toBe("a thread");
+
+		const missing = await getConversation({
+			organizationId: org,
+			agentId: AGENT,
+			platform: "web",
+			conversationId: "does-not-exist",
+		});
+		expect(missing).toBeNull();
+	});
+
+	it("getConversation hides a soft-deleted (archived) row", async () => {
+		const conv = "archived-conv";
+		await upsertConversation({
+			organizationId: org,
+			agentId: AGENT,
+			platform: "web",
+			conversationId: conv,
+			kind: "owned",
+			userId,
+			title: "to archive",
+			lastActivityAt: new Date("2026-06-28T02:00:00Z"),
+		});
+		const sql = getTestDb();
+		await sql`
+      UPDATE public.conversations SET archived_at = now()
+      WHERE organization_id = ${org} AND agent_id = ${AGENT}
+        AND platform = 'web' AND conversation_id = ${conv}
+    `;
+		const row = await getConversation({
+			organizationId: org,
+			agentId: AGENT,
+			platform: "web",
+			conversationId: conv,
+		});
+		expect(row).toBeNull();
+	});
+
+	it("readConversationReply returns null while the turn is in flight", async () => {
+		const reply = await readConversationReply({
+			organizationId: org,
+			conversationId: "conv-inflight",
+			messageId: "msg-inflight",
+		});
+		expect(reply).toBeNull();
+	});
+
+	it("readConversationReply returns the finalText on a completed turn (matched via processedMessageIds)", async () => {
+		const conversationId = "conv-complete";
+		const messageId = "msg-complete";
+		await insertThreadResponse(
+			org,
+			{
+				conversationId,
+				processedMessageIds: [messageId],
+				finalText: "here is your summary",
+			},
+			"completed",
+		);
+		const reply = await readConversationReply({
+			organizationId: org,
+			conversationId,
+			messageId,
+		});
+		expect(reply).toEqual({ status: "complete", text: "here is your summary" });
+	});
+
+	it("readConversationReply matches on the top-level messageId too", async () => {
+		const conversationId = "conv-complete-2";
+		const messageId = "msg-complete-2";
+		await insertThreadResponse(
+			org,
+			{
+				conversationId,
+				messageId,
+				processedMessageIds: [messageId],
+				finalText: "done",
+			},
+			"completed",
+		);
+		const reply = await readConversationReply({
+			organizationId: org,
+			conversationId,
+			messageId,
+		});
+		expect(reply?.status).toBe("complete");
+	});
+
+	it("readConversationReply surfaces a terminal error", async () => {
+		const conversationId = "conv-error";
+		const messageId = "msg-error";
+		await insertThreadResponse(
+			org,
+			{
+				conversationId,
+				processedMessageIds: [messageId],
+				error: "provider unavailable",
+			},
+			"failed",
+		);
+		const reply = await readConversationReply({
+			organizationId: org,
+			conversationId,
+			messageId,
+		});
+		expect(reply).toEqual({ status: "error", error: "provider unavailable" });
+	});
+
+	it("readConversationReply does not match a different message's completion", async () => {
+		const conversationId = "conv-other";
+		await insertThreadResponse(
+			org,
+			{
+				conversationId,
+				processedMessageIds: ["some-other-message"],
+				finalText: "not for you",
+			},
+			"completed",
+		);
+		const reply = await readConversationReply({
+			organizationId: org,
+			conversationId,
+			messageId: "my-message",
+		});
+		expect(reply).toBeNull();
+	});
+});

--- a/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
+++ b/packages/server/src/__tests__/integration/tools/all-tools-e2e.test.ts
@@ -173,6 +173,13 @@ describe("all agent MCP tools — registry-driven e2e (model-free)", () => {
 				coverage: "reachable",
 				note: "lists agents for the org",
 			},
+			manage_conversations: {
+				// `list` drives the read path model-free (send would enqueue a real
+				// turn, which needs a model). agent_id is the seeded fixture agent.
+				args: () => ({ action: "list", agent_id: agentId }),
+				coverage: "reachable",
+				note: "lists an agent's conversations (send/get covered by unit tests)",
+			},
 			manage_feeds: {
 				args: { action: "list_feeds" },
 				coverage: "reachable",

--- a/packages/server/src/__tests__/unit/tool-registry-split.test.ts
+++ b/packages/server/src/__tests__/unit/tool-registry-split.test.ts
@@ -34,6 +34,7 @@ const ADMIN_TOOL_SDK_NAMESPACE: Record<string, keyof ReturnType<typeof buildClie
 	manage_connections: "connections",
 	manage_catalog: "catalog",
 	manage_agents: "agents",
+	manage_conversations: "conversations",
 	manage_feeds: "feeds",
 	manage_auth_profiles: "authProfiles",
 	manage_operations: "operations",

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -687,6 +687,7 @@ manage_entity_schema: list=read+public get=read+public create=admin update=admin
 manage_connections: list_connector_groups=read+public list=read+public get=read+public create=write connect=admin update=write apply_chat_connection=admin delete=admin reauthenticate=write test=admin install_connector=admin uninstall_connector=admin toggle_connector_login=admin update_connector_auth=admin update_connector_default_config=admin update_connector_default_repair_agent=admin list_channel_bindings=read+public bind_channel=admin unbind_channel=admin sync_channel_bindings=admin set_channel_about=admin connect_channel_dm=admin ?=read
 manage_catalog: list_catalog=read+public list_installed=read+public ?=read
 manage_agents: list=admin get=admin create=admin update=admin delete=admin set_system_agent=admin ?=read
+manage_conversations: list=read get=read send=write ?=read
 manage_feeds: list_feeds=read+public read_feed=read+public read_feeds=read+public create_feed=admin update_feed=admin delete_feed=admin trigger_feed=admin ?=read
 manage_auth_profiles: list_auth_profiles=read+public get_auth_profile=admin test_auth_profile=admin create_auth_profile=write update_auth_profile=write delete_auth_profile=admin set_default_auth_profile=admin ?=read
 manage_operations: list_available=read+public execute=admin list_runs=read+public get_run=read+public approve=write reject=write approve_batch=write reject_batch=write ?=read

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -172,9 +172,6 @@ const PUBLIC_READ_ACTIONS: Record<string, Set<string> | null> = {
 	]),
 	manage_classifiers: new Set(["list"]),
 	manage_view_templates: new Set(["get"]),
-	// Reading an agent's conversations (the listing entity) is member/read-tier;
-	// the handler fences on agent-in-org and scopes a member to their own threads.
-	manage_conversations: new Set(["list", "get"]),
 };
 
 function getAction(args: unknown): string | null {

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -54,6 +54,11 @@ const MEMBER_WRITE_ACTIONS: Record<string, Set<string> | null> = {
 		"approve_batch",
 		"reject_batch",
 	]),
+	// A member sends a message to their own agent's conversation. `send` runs the
+	// turn in the conversation's pinned sandbox; the handler binds the
+	// conversation to ctx.userId and fences on agent-in-org. list/get are
+	// read-tier (PUBLIC_READ_ACTIONS).
+	manage_conversations: new Set(["send"]),
 };
 
 const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
@@ -167,6 +172,9 @@ const PUBLIC_READ_ACTIONS: Record<string, Set<string> | null> = {
 	]),
 	manage_classifiers: new Set(["list"]),
 	manage_view_templates: new Set(["get"]),
+	// Reading an agent's conversations (the listing entity) is member/read-tier;
+	// the handler fences on agent-in-org and scopes a member to their own threads.
+	manage_conversations: new Set(["list", "get"]),
 };
 
 function getAction(args: unknown): string | null {

--- a/packages/server/src/gateway/services/conversations-store.ts
+++ b/packages/server/src/gateway/services/conversations-store.ts
@@ -131,6 +131,111 @@ export interface ConversationListRow {
 }
 
 /**
+ * Read one conversation row by its full PK. Returns null when the row does not
+ * exist (or is soft-deleted). The single get source, mirroring
+ * {@link listConversations}'s read of the materialized entity.
+ */
+export async function getConversation(args: {
+	organizationId: string;
+	agentId: string;
+	platform: string;
+	conversationId: string;
+}): Promise<ConversationListRow | null> {
+	const { organizationId, agentId, platform, conversationId } = args;
+	const sql = getDb();
+	const rows = await sql<{
+		platform: string;
+		conversation_id: string;
+		kind: ConversationKind;
+		user_id: string | null;
+		title: string | null;
+		last_activity_at: Date | null;
+		created_at: Date;
+	}>`
+    SELECT platform, conversation_id, kind, user_id, title,
+           last_activity_at, created_at
+    FROM public.conversations
+    WHERE organization_id = ${organizationId}
+      AND agent_id = ${agentId}
+      AND platform = ${platform}
+      AND conversation_id = ${conversationId}
+      AND archived_at IS NULL
+    LIMIT 1
+  `;
+	const r = rows[0];
+	if (!r) return null;
+	return {
+		platform: r.platform,
+		conversationId: r.conversation_id,
+		kind: r.kind,
+		userId: r.user_id,
+		title: r.title,
+		lastActivityAt: r.last_activity_at ?? r.created_at,
+		createdAt: r.created_at,
+	};
+}
+
+/**
+ * A turn's terminal outcome, read from the durable `runs` thread-response rows
+ * the worker writes on completion. Cross-replica-safe (Postgres, not the
+ * pod-local SSE buffer) — so `conversations.send({ wait: true })` can await a
+ * reply without holding an SSE socket.
+ */
+export type ConversationReply =
+	| { status: "complete"; text: string }
+	| { status: "error"; error: string };
+
+/**
+ * Poll for the terminal outcome of a dispatched message. Matches the completion
+ * row the worker writes to `public.runs` (queue_name='thread_response') whose
+ * payload lists `messageId` in `processedMessageIds` (a turn can batch several).
+ * Returns null while the turn is still in flight. `finalText` carries the full
+ * assistant reply on the terminal row (see ThreadResponsePayload.finalText).
+ */
+export async function readConversationReply(args: {
+	organizationId: string;
+	conversationId: string;
+	messageId: string;
+}): Promise<ConversationReply | null> {
+	const { organizationId, conversationId, messageId } = args;
+	const sql = getDb();
+	const rows = await sql<{ payload: Record<string, unknown> | null }>`
+    WITH response_rows AS (
+      SELECT id,
+             CASE
+               WHEN jsonb_typeof(action_input) = 'string'
+                 THEN (action_input #>> '{}')::jsonb
+               ELSE action_input
+             END AS payload
+      FROM public.runs
+      WHERE organization_id = ${organizationId}
+        AND run_type = 'chat_message'
+        AND queue_name = 'thread_response'
+        AND status IN ('completed', 'failed')
+        AND action_input IS NOT NULL
+    )
+    SELECT payload
+    FROM response_rows
+    WHERE payload->>'conversationId' = ${conversationId}
+      AND (
+        payload->>'messageId' = ${messageId}
+        OR payload->'processedMessageIds' ? ${messageId}
+      )
+      AND (payload ? 'error' OR payload ? 'processedMessageIds')
+    ORDER BY id DESC
+    LIMIT 1
+  `;
+	const payload = rows[0]?.payload;
+	if (!payload || typeof payload !== "object") return null;
+	if (typeof payload.error === "string" && payload.error.length > 0) {
+		return { status: "error", error: payload.error };
+	}
+	const finalText =
+		typeof payload.finalText === "string" ? payload.finalText : "";
+	return { status: "complete", text: finalText };
+}
+
+/**
  * List an agent's conversations for the sidebar, newest-first. The single
  * listing source: reads the materialized entity instead of deriving from
  * `DISTINCT ON (conversation_id) FROM agent_transcript_snapshot`.

--- a/packages/server/src/sandbox/client-sdk.ts
+++ b/packages/server/src/sandbox/client-sdk.ts
@@ -25,6 +25,7 @@ import {
 	buildCatalogNamespace,
 	buildClassifiersNamespace,
 	buildConnectionsNamespace,
+	buildConversationsNamespace,
 	buildEntitiesNamespace,
 	buildEntitySchemaNamespace,
 	buildFeedsNamespace,
@@ -42,6 +43,7 @@ import type { AuthProfilesNamespace } from "./namespaces/auth-profiles";
 import type { CatalogNamespace } from "./namespaces/catalog";
 import type { ClassifiersNamespace } from "./namespaces/classifiers";
 import type { ConnectionsNamespace } from "./namespaces/connections";
+import type { ConversationsNamespace } from "./namespaces/conversations";
 import type { EntitiesNamespace } from "./namespaces/entities";
 import type { EntitySchemaNamespace } from "./namespaces/entity-schema";
 import type { FeedsNamespace } from "./namespaces/feeds";
@@ -60,6 +62,7 @@ export interface ClientSDK {
 	entitySchema: EntitySchemaNamespace;
 	catalog: CatalogNamespace;
 	connections: ConnectionsNamespace;
+	conversations: ConversationsNamespace;
 	feeds: FeedsNamespace;
 	authProfiles: AuthProfilesNamespace;
 	operations: OperationsNamespace;
@@ -176,6 +179,7 @@ export function buildClientSDK(
 		entitySchema: buildEntitySchemaNamespace(ctx, env),
 		catalog: buildCatalogNamespace(ctx, env),
 		connections: buildConnectionsNamespace(ctx, env),
+		conversations: buildConversationsNamespace(ctx, env),
 		feeds: buildFeedsNamespace(ctx, env),
 		authProfiles: buildAuthProfilesNamespace(ctx, env),
 		operations: buildOperationsNamespace(ctx, env),

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -290,6 +290,48 @@ export default async (_ctx, client) => {
 		example: "await client.agents.setSystemAgent('builder');",
 	},
 
+	// conversations — an agent's durable threads (history + pinned sandbox realm).
+	// list/get read the materialized `conversations` entity; send drives a turn.
+	"conversations.manage": {
+		summary: "Raw manage_conversations action wrapper. Prefer named methods.",
+		access: "write",
+	},
+	"conversations.list": {
+		summary:
+			"List an agent's conversations, newest-first (own threads for a member; all for admin).",
+		access: "read",
+		example:
+			"const { conversations } = await client.conversations.list({ agent_id: 'researcher' });",
+	},
+	"conversations.get": {
+		summary:
+			"Fetch one conversation by (platform, conversation_id). platform defaults to 'web'.",
+		access: "read",
+		example:
+			"const { conversation } = await client.conversations.get({ agent_id: 'researcher', conversation_id: 'researcher_u1_org1_daily' });",
+	},
+	"conversations.send": {
+		summary:
+			"Send a message to an agent conversation and (by default) await the reply. Runs the turn in the conversation's pinned sandbox realm. Pass wait:false to enqueue and return immediately.",
+		access: "write",
+		cost: "expensive",
+		usageExample: `// Send a message and get the agent's reply back.
+export default async (ctx, client) => {
+  const res = await client.conversations.send({
+    agent_id: 'researcher',
+    thread: 'daily',
+    text: 'Summarize today’s new signups.',
+  });
+  if (res.status === 'complete') return res.reply;
+  if (res.status === 'error') throw new Error(res.error);
+  // status 'timeout' — the turn is still running; read it later:
+  return client.conversations.get({
+    agent_id: 'researcher',
+    conversation_id: res.conversation_id,
+  });
+};`,
+	},
+
 	// schedules
 	"schedules.manage": {
 		summary: "Raw manage_schedules action wrapper. Prefer named methods.",

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -324,11 +324,10 @@ export default async (ctx, client) => {
   });
   if (res.status === 'complete') return res.reply;
   if (res.status === 'error') throw new Error(res.error);
-  // status 'timeout' — the turn is still running; read it later:
-  return client.conversations.get({
-    agent_id: 'researcher',
-    conversation_id: res.conversation_id,
-  });
+  // status 'timeout' — the turn is still running (it is NOT lost). Raise
+  // timeout_ms for a longer wait; the reply is not retrievable through get
+  // (get returns only conversation metadata).
+  return { pending: res.conversation_id };
 };`,
 	},
 

--- a/packages/server/src/sandbox/namespaces/__tests__/conversations-namespace.test.ts
+++ b/packages/server/src/sandbox/namespaces/__tests__/conversations-namespace.test.ts
@@ -1,0 +1,91 @@
+/**
+ * conversations SDK namespace — regression for the failure-conversion trap.
+ *
+ * `send` returns a discriminated result whose `status` may be "error" or
+ * "timeout" — NON-throwing outcomes the caller must branch on. The generic
+ * `action()` wrapper (createActionCaller) runs failureMessage(), which turns a
+ * result with `status:"error"` / `status:"timeout"` (or an `error` field) into a
+ * thrown ClientSdkActionError. So `send` must route through `manage()` (raw),
+ * NOT `action()`. This test pins that: a mocked handler returning each status
+ * comes back as a VALUE, and list/get still throw a real ToolUserError.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+const handlerResult = { current: undefined as unknown, throws: false };
+
+vi.mock("../../../tools/admin/manage_conversations", () => ({
+	manageConversations: () => {
+		if (handlerResult.throws) {
+			return Promise.reject(new Error("boom"));
+		}
+		return Promise.resolve(handlerResult.current);
+	},
+}));
+
+import type { Env } from "../../../index";
+import type { ToolContext } from "../../../tools/registry";
+import { buildConversationsNamespace } from "../conversations";
+
+const env = { ENVIRONMENT: "test" } as Env;
+const ctx = { organizationId: "o", userId: "u" } as ToolContext;
+
+describe("conversations namespace — send does not throw on error/timeout status", () => {
+	it("returns a status:'error' result as a VALUE (not thrown)", async () => {
+		handlerResult.current = {
+			action: "send",
+			conversation_id: "c",
+			message_id: "m",
+			status: "error",
+			error: "provider down",
+		};
+		const ns = buildConversationsNamespace(ctx, env);
+		const res = (await ns.send({ agent_id: "a", text: "hi" })) as Record<
+			string,
+			unknown
+		>;
+		expect(res.status).toBe("error");
+		expect(res.error).toBe("provider down");
+	});
+
+	it("returns a status:'timeout' result as a VALUE (not thrown)", async () => {
+		handlerResult.current = {
+			action: "send",
+			conversation_id: "c",
+			message_id: "m",
+			status: "timeout",
+		};
+		const ns = buildConversationsNamespace(ctx, env);
+		const res = (await ns.send({ agent_id: "a", text: "hi" })) as Record<
+			string,
+			unknown
+		>;
+		expect(res.status).toBe("timeout");
+	});
+
+	it("returns a status:'complete' reply as a VALUE", async () => {
+		handlerResult.current = {
+			action: "send",
+			conversation_id: "c",
+			message_id: "m",
+			status: "complete",
+			reply: "the answer",
+		};
+		const ns = buildConversationsNamespace(ctx, env);
+		const res = (await ns.send({ agent_id: "a", text: "hi" })) as Record<
+			string,
+			unknown
+		>;
+		expect(res.status).toBe("complete");
+		expect(res.reply).toBe("the answer");
+	});
+
+	it("still propagates a genuine handler throw", async () => {
+		handlerResult.throws = true;
+		const ns = buildConversationsNamespace(ctx, env);
+		await expect(ns.send({ agent_id: "a", text: "hi" })).rejects.toThrow(
+			/boom/,
+		);
+		handlerResult.throws = false;
+	});
+});

--- a/packages/server/src/sandbox/namespaces/__tests__/conversations-namespace.test.ts
+++ b/packages/server/src/sandbox/namespaces/__tests__/conversations-namespace.test.ts
@@ -7,39 +7,49 @@
  * result with `status:"error"` / `status:"timeout"` (or an `error` field) into a
  * thrown ClientSdkActionError. So `send` must route through `manage()` (raw),
  * NOT `action()`. This test pins that: a mocked handler returning each status
- * comes back as a VALUE, and list/get still throw a real ToolUserError.
+ * comes back as a VALUE, and a genuine handler throw still propagates.
+ *
+ * Uses vi.doMock + vi.resetModules + dynamic import (NOT hoisted vi.mock): the
+ * integration suite shares a module registry across files, where a hoisted
+ * vi.mock does not reliably replace the module — the namespace would then call
+ * the REAL manageConversations and hit routeAction's access gate. doMock scoped
+ * per test + a fresh import registry keeps the mock hermetic. [[vitest module-
+ * mock isolation]]
  */
 
-import { describe, expect, it, vi } from "vitest";
-
-const handlerResult = { current: undefined as unknown, throws: false };
-
-vi.mock("../../../tools/admin/manage_conversations", () => ({
-	manageConversations: () => {
-		if (handlerResult.throws) {
-			return Promise.reject(new Error("boom"));
-		}
-		return Promise.resolve(handlerResult.current);
-	},
-}));
-
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../../../index";
 import type { ToolContext } from "../../../tools/registry";
-import { buildConversationsNamespace } from "../conversations";
 
 const env = { ENVIRONMENT: "test" } as Env;
 const ctx = { organizationId: "o", userId: "u" } as ToolContext;
 
+/** Register the handler mock, then dynamic-import the namespace against it. */
+async function loadNamespaceWith(handler: () => Promise<unknown>) {
+	vi.resetModules();
+	vi.doMock("../../../tools/admin/manage_conversations", () => ({
+		manageConversations: handler,
+	}));
+	const { buildConversationsNamespace } = await import("../conversations.js");
+	return buildConversationsNamespace(ctx, env);
+}
+
+afterEach(() => {
+	vi.resetModules();
+	vi.doUnmock("../../../tools/admin/manage_conversations");
+});
+
 describe("conversations namespace — send does not throw on error/timeout status", () => {
 	it("returns a status:'error' result as a VALUE (not thrown)", async () => {
-		handlerResult.current = {
-			action: "send",
-			conversation_id: "c",
-			message_id: "m",
-			status: "error",
-			error: "provider down",
-		};
-		const ns = buildConversationsNamespace(ctx, env);
+		const ns = await loadNamespaceWith(() =>
+			Promise.resolve({
+				action: "send",
+				conversation_id: "c",
+				message_id: "m",
+				status: "error",
+				error: "provider down",
+			}),
+		);
 		const res = (await ns.send({ agent_id: "a", text: "hi" })) as Record<
 			string,
 			unknown
@@ -49,13 +59,14 @@ describe("conversations namespace — send does not throw on error/timeout statu
 	});
 
 	it("returns a status:'timeout' result as a VALUE (not thrown)", async () => {
-		handlerResult.current = {
-			action: "send",
-			conversation_id: "c",
-			message_id: "m",
-			status: "timeout",
-		};
-		const ns = buildConversationsNamespace(ctx, env);
+		const ns = await loadNamespaceWith(() =>
+			Promise.resolve({
+				action: "send",
+				conversation_id: "c",
+				message_id: "m",
+				status: "timeout",
+			}),
+		);
 		const res = (await ns.send({ agent_id: "a", text: "hi" })) as Record<
 			string,
 			unknown
@@ -64,14 +75,15 @@ describe("conversations namespace — send does not throw on error/timeout statu
 	});
 
 	it("returns a status:'complete' reply as a VALUE", async () => {
-		handlerResult.current = {
-			action: "send",
-			conversation_id: "c",
-			message_id: "m",
-			status: "complete",
-			reply: "the answer",
-		};
-		const ns = buildConversationsNamespace(ctx, env);
+		const ns = await loadNamespaceWith(() =>
+			Promise.resolve({
+				action: "send",
+				conversation_id: "c",
+				message_id: "m",
+				status: "complete",
+				reply: "the answer",
+			}),
+		);
 		const res = (await ns.send({ agent_id: "a", text: "hi" })) as Record<
 			string,
 			unknown
@@ -81,11 +93,11 @@ describe("conversations namespace — send does not throw on error/timeout statu
 	});
 
 	it("still propagates a genuine handler throw", async () => {
-		handlerResult.throws = true;
-		const ns = buildConversationsNamespace(ctx, env);
+		const ns = await loadNamespaceWith(() =>
+			Promise.reject(new Error("boom")),
+		);
 		await expect(ns.send({ agent_id: "a", text: "hi" })).rejects.toThrow(
 			/boom/,
 		);
-		handlerResult.throws = false;
 	});
 });

--- a/packages/server/src/sandbox/namespaces/conversations.ts
+++ b/packages/server/src/sandbox/namespaces/conversations.ts
@@ -33,7 +33,7 @@ export interface ConversationsSendInput {
   model?: string;
   /** Await the reply (default true); false returns immediately with the id. */
   wait?: boolean;
-  /** [wait=true] Max wait (ms). Default 60000, capped at 170000. */
+  /** [wait=true] Max wait (ms). Default 45000, capped at 170000. */
   timeout_ms?: number;
 }
 

--- a/packages/server/src/sandbox/namespaces/conversations.ts
+++ b/packages/server/src/sandbox/namespaces/conversations.ts
@@ -48,12 +48,23 @@ export function buildConversationsNamespace(
   ctx: ToolContext,
   env: Env,
 ): ConversationsNamespace {
-  const { manage, action } = createActionCaller(manageConversations, env, ctx);
+  const { manage, action } = createActionCaller(
+    manageConversations,
+    env,
+    ctx,
+    "conversations",
+  );
 
   return {
     manage,
     list: (input) => action("list", input),
     get: (input) => action("get", input),
-    send: (input) => action("send", input),
+    // `send` returns a discriminated result whose `status` is part of the
+    // contract — "error" and "timeout" are NON-throwing outcomes the caller
+    // must branch on. Route it through `manage` (the raw handler) rather than
+    // `action`, whose failureMessage() turns status:"error"/"timeout" into a
+    // thrown ClientSdkActionError. A genuine fault (bad input, agent-not-found)
+    // still throws — the handler raises ToolUserError for those.
+    send: (input) => manage({ ...input, action: "send" }),
   };
 }

--- a/packages/server/src/sandbox/namespaces/conversations.ts
+++ b/packages/server/src/sandbox/namespaces/conversations.ts
@@ -1,0 +1,59 @@
+/**
+ * ClientSDK `conversations` namespace. Thin wrapper over `manageConversations`.
+ *
+ * A conversation is the durable unit an agent talks over — history + its frozen
+ * sandbox realm both live here (see the `conversations` entity). `send` drives a
+ * turn against one; the reply reads back on the same conversation id.
+ */
+
+import type { Env } from "../../index";
+import { manageConversations } from "../../tools/admin/manage_conversations";
+import type { ToolContext } from "../../tools/registry";
+import { createActionCaller } from "./action-call";
+
+export interface ConversationsListInput {
+  agent_id: string;
+}
+
+export interface ConversationsGetInput {
+  agent_id: string;
+  /** Defaults to "web" (the app-owned realm). */
+  platform?: string;
+  conversation_id: string;
+}
+
+export interface ConversationsSendInput {
+  agent_id: string;
+  /** Resume an exact conversation; wins over `thread`. */
+  conversation_id?: string;
+  /** Open/resume a named web thread (own history + own pinned sandbox). */
+  thread?: string;
+  text: string;
+  /** Per-message `provider/model` override. */
+  model?: string;
+  /** Await the reply (default true); false returns immediately with the id. */
+  wait?: boolean;
+  /** [wait=true] Max wait (ms). Default 60000, capped at 170000. */
+  timeout_ms?: number;
+}
+
+export interface ConversationsNamespace {
+  manage(input: Record<string, unknown>): Promise<unknown>;
+  list(input: ConversationsListInput): Promise<unknown>;
+  get(input: ConversationsGetInput): Promise<unknown>;
+  send(input: ConversationsSendInput): Promise<unknown>;
+}
+
+export function buildConversationsNamespace(
+  ctx: ToolContext,
+  env: Env,
+): ConversationsNamespace {
+  const { manage, action } = createActionCaller(manageConversations, env, ctx);
+
+  return {
+    manage,
+    list: (input) => action("list", input),
+    get: (input) => action("get", input),
+    send: (input) => action("send", input),
+  };
+}

--- a/packages/server/src/sandbox/namespaces/index.ts
+++ b/packages/server/src/sandbox/namespaces/index.ts
@@ -7,6 +7,7 @@ export { buildAuthProfilesNamespace } from "./auth-profiles";
 export { buildCatalogNamespace } from "./catalog";
 export { buildClassifiersNamespace } from "./classifiers";
 export { buildConnectionsNamespace } from "./connections";
+export { buildConversationsNamespace } from "./conversations";
 export { buildEntitiesNamespace } from "./entities";
 export { buildEntitySchemaNamespace } from "./entity-schema";
 export { buildFeedsNamespace } from "./feeds";

--- a/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
+++ b/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
@@ -1,0 +1,206 @@
+/**
+ * manage_conversations `send` control-flow — Vitest unit (no DB, no queue).
+ *
+ * Mocks the queue producer, the agent-exists check, agent-option resolution, and
+ * the reply poll so we can assert the handler's routing without a live gateway:
+ *   - enqueues a `platform:"api"` payload on the caller's api conversation id,
+ *   - wait:false returns immediately ({ status: "queued" }),
+ *   - wait:true returns the polled reply ({ status: "complete", reply }),
+ *   - a terminal error becomes { status: "error" },
+ *   - no reply before the deadline becomes { status: "timeout" },
+ *   - empty text and a missing user id are rejected.
+ *
+ * vi.doMock + vi.resetModules + dynamic import keeps the mocks scoped to this
+ * file (the proven pattern from resolve-pinned-selection-failclosed.test.ts), so
+ * they never leak into the DB-backed suites in the same vitest worker.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ToolContext } from "../registry";
+import type { Env } from "../../index";
+
+const env = { ENVIRONMENT: "test" } as Env;
+const ctx: ToolContext = {
+	organizationId: "org-1",
+	userId: "user-1",
+	memberRole: "owner",
+	isAuthenticated: true,
+	tokenType: "oauth",
+	// Session-equivalent scope sentinel: authorization is gated by role +
+	// per-handler fences, not token scopes (matches how the in-process SDK runs a
+	// cookie/session caller). Without a scope claim enforceRoleScopeAccess fails
+	// closed on the write-tier `send`.
+	scopes: ["*"],
+	scopedToOrg: false,
+	allowCrossOrg: false,
+};
+
+const enqueued: Array<Record<string, unknown>> = [];
+
+/**
+ * Register the shared mocks. `reply` is what readConversationReply yields; pass a
+ * function to vary it across poll iterations (e.g. null then complete).
+ */
+function mockDeps(reply: unknown | (() => unknown)) {
+	enqueued.length = 0;
+	// requireOrg*Access + the agent-exists probe both run getDb()`...`; return a
+	// truthy agent row and a no-op for the access checks.
+	vi.doMock("../../db/client.js", () => {
+		const tag = () => Promise.resolve([{ ok: 1 }]);
+		return { getDb: () => tag, createDbClientFromEnv: () => tag };
+	});
+	vi.doMock("../../utils/organization-access.js", () => ({
+		requireOrgReadAccess: () => Promise.resolve(),
+		requireOrgWriteAccess: () => Promise.resolve(),
+	}));
+	vi.doMock("../../gateway/services/platform-helpers.js", async () => {
+		const actual = await vi.importActual<
+			typeof import("../../gateway/services/platform-helpers.js")
+		>("../../gateway/services/platform-helpers.js");
+		return {
+			...actual,
+			resolveAgentOptions: () => Promise.resolve({ provider: "claude" }),
+		};
+	});
+	vi.doMock("../../lobu/gateway.js", () => ({
+		getLobuCoreServices: () => ({
+			getQueueProducer: () => ({
+				enqueueMessage: (payload: Record<string, unknown>) => {
+					enqueued.push(payload);
+					return Promise.resolve("job-1");
+				},
+			}),
+			getAgentSettingsStore: () => undefined,
+		}),
+	}));
+	const replyFn = typeof reply === "function" ? (reply as () => unknown) : () => reply;
+	vi.doMock("../../gateway/services/conversations-store.js", () => ({
+		readConversationReply: () => Promise.resolve(replyFn()),
+	}));
+}
+
+async function loadHandler() {
+	const mod = await import("../admin/manage_conversations.js");
+	return mod.manageConversations;
+}
+
+afterEach(() => {
+	vi.resetModules();
+	vi.doUnmock("../../db/client.js");
+	vi.doUnmock("../../utils/organization-access.js");
+	vi.doUnmock("../../gateway/services/platform-helpers.js");
+	vi.doUnmock("../../lobu/gateway.js");
+	vi.doUnmock("../../gateway/services/conversations-store.js");
+});
+
+describe("manage_conversations send", () => {
+	it("enqueues an api-platform turn and returns the polled reply", async () => {
+		vi.resetModules();
+		mockDeps({ status: "complete", text: "the answer" });
+		const manageConversations = await loadHandler();
+
+		const res = (await manageConversations(
+			{
+				action: "send",
+				agent_id: "researcher",
+				thread: "daily",
+				text: "hello",
+			},
+			env,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(res.status).toBe("complete");
+		expect(res.reply).toBe("the answer");
+		// The turn was enqueued as platform:api on the caller's api conversation id.
+		expect(enqueued).toHaveLength(1);
+		const payload = enqueued[0];
+		expect(payload.platform).toBe("api");
+		expect(payload.agentId).toBe("researcher");
+		expect(payload.organizationId).toBe("org-1");
+		expect(String(payload.conversationId)).toContain("researcher_user-1_org-1");
+		expect(String(payload.conversationId)).toContain("daily");
+		expect(res.conversation_id).toBe(payload.conversationId);
+	});
+
+	it("wait:false returns queued immediately without polling", async () => {
+		vi.resetModules();
+		mockDeps(() => {
+			throw new Error("must not poll when wait:false");
+		});
+		const manageConversations = await loadHandler();
+
+		const res = (await manageConversations(
+			{ action: "send", agent_id: "researcher", text: "fire", wait: false },
+			env,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(res.status).toBe("queued");
+		expect(res.message_id).toBeTruthy();
+		expect(enqueued).toHaveLength(1);
+	});
+
+	it("surfaces a terminal error reply", async () => {
+		vi.resetModules();
+		mockDeps({ status: "error", error: "provider down" });
+		const manageConversations = await loadHandler();
+
+		const res = (await manageConversations(
+			{ action: "send", agent_id: "researcher", text: "hi" },
+			env,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(res.status).toBe("error");
+		expect(res.error).toBe("provider down");
+	});
+
+	it("returns timeout when no reply lands before the deadline", async () => {
+		vi.resetModules();
+		mockDeps(null); // never completes
+		const manageConversations = await loadHandler();
+
+		const res = (await manageConversations(
+			{
+				action: "send",
+				agent_id: "researcher",
+				text: "hi",
+				timeout_ms: 1000,
+			},
+			env,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(res.status).toBe("timeout");
+		expect(res.message_id).toBeTruthy();
+	});
+
+	it("rejects empty text", async () => {
+		vi.resetModules();
+		mockDeps(null);
+		const manageConversations = await loadHandler();
+
+		await expect(
+			manageConversations(
+				{ action: "send", agent_id: "researcher", text: "   " },
+				env,
+				ctx,
+			),
+		).rejects.toThrow(/text is required/);
+	});
+
+	it("rejects an unauthenticated caller (no user id to bind the conversation)", async () => {
+		vi.resetModules();
+		mockDeps(null);
+		const manageConversations = await loadHandler();
+
+		await expect(
+			manageConversations(
+				{ action: "send", agent_id: "researcher", text: "hi" },
+				env,
+				{ ...ctx, userId: null },
+			),
+		).rejects.toThrow(/authenticated caller/);
+	});
+});

--- a/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
+++ b/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
@@ -35,24 +35,37 @@ const ctx: ToolContext = {
 	allowCrossOrg: false,
 };
 
+/** A plain member (not owner/admin) — the tier `send` must still allow. */
+const memberCtx: ToolContext = { ...ctx, memberRole: "member" };
+
 const enqueued: Array<Record<string, unknown>> = [];
 
-/**
- * Register the shared mocks. `reply` is what readConversationReply yields; pass a
- * function to vary it across poll iterations (e.g. null then complete).
- */
-function mockDeps(reply: unknown | (() => unknown)) {
+interface MockOpts {
+	/** readConversationReply yields this (or a per-iteration function). */
+	reply?: unknown | (() => unknown);
+	/** getConversation yields this (default: a caller-owned web row). */
+	conversation?: unknown;
+}
+
+/** A caller-owned web conversation — passes the send/get ownership fence. */
+const OWNED_ROW = {
+	platform: "web",
+	conversationId: "conv-x",
+	kind: "owned",
+	userId: "user-1",
+	title: "t",
+	lastActivityAt: new Date(0),
+	createdAt: new Date(0),
+};
+
+function mockDeps(opts: MockOpts = {}) {
 	enqueued.length = 0;
-	// requireOrg*Access + the agent-exists probe both run getDb()`...`; return a
-	// truthy agent row and a no-op for the access checks.
+	// The agent-exists probe runs getDb()/createDbClientFromEnv `...` — return a
+	// truthy agent row so assertAgentInOrg passes.
 	vi.doMock("../../db/client.js", () => {
 		const tag = () => Promise.resolve([{ ok: 1 }]);
 		return { getDb: () => tag, createDbClientFromEnv: () => tag };
 	});
-	vi.doMock("../../utils/organization-access.js", () => ({
-		requireOrgReadAccess: () => Promise.resolve(),
-		requireOrgWriteAccess: () => Promise.resolve(),
-	}));
 	vi.doMock("../../gateway/services/platform-helpers.js", async () => {
 		const actual = await vi.importActual<
 			typeof import("../../gateway/services/platform-helpers.js")
@@ -73,9 +86,16 @@ function mockDeps(reply: unknown | (() => unknown)) {
 			getAgentSettingsStore: () => undefined,
 		}),
 	}));
-	const replyFn = typeof reply === "function" ? (reply as () => unknown) : () => reply;
+	const replyFn =
+		typeof opts.reply === "function"
+			? (opts.reply as () => unknown)
+			: () => opts.reply ?? null;
+	const conversation =
+		"conversation" in opts ? opts.conversation : OWNED_ROW;
 	vi.doMock("../../gateway/services/conversations-store.js", () => ({
 		readConversationReply: () => Promise.resolve(replyFn()),
+		getConversation: () => Promise.resolve(conversation),
+		listConversations: () => Promise.resolve([OWNED_ROW]),
 	}));
 }
 
@@ -87,16 +107,15 @@ async function loadHandler() {
 afterEach(() => {
 	vi.resetModules();
 	vi.doUnmock("../../db/client.js");
-	vi.doUnmock("../../utils/organization-access.js");
 	vi.doUnmock("../../gateway/services/platform-helpers.js");
 	vi.doUnmock("../../lobu/gateway.js");
 	vi.doUnmock("../../gateway/services/conversations-store.js");
 });
 
 describe("manage_conversations send", () => {
-	it("enqueues an api-platform turn and returns the polled reply", async () => {
+	it("lets a plain MEMBER send and returns the polled reply on a derived id", async () => {
 		vi.resetModules();
-		mockDeps({ status: "complete", text: "the answer" });
+		mockDeps({ reply: { status: "complete", text: "the answer" } });
 		const manageConversations = await loadHandler();
 
 		const res = (await manageConversations(
@@ -107,7 +126,8 @@ describe("manage_conversations send", () => {
 				text: "hello",
 			},
 			env,
-			ctx,
+			// a MEMBER, not owner — proves send is member-tier (no admin re-gate).
+			memberCtx,
 		)) as Record<string, unknown>;
 
 		expect(res.status).toBe("complete");
@@ -125,8 +145,10 @@ describe("manage_conversations send", () => {
 
 	it("wait:false returns queued immediately without polling", async () => {
 		vi.resetModules();
-		mockDeps(() => {
-			throw new Error("must not poll when wait:false");
+		mockDeps({
+			reply: () => {
+				throw new Error("must not poll when wait:false");
+			},
 		});
 		const manageConversations = await loadHandler();
 
@@ -141,9 +163,9 @@ describe("manage_conversations send", () => {
 		expect(enqueued).toHaveLength(1);
 	});
 
-	it("surfaces a terminal error reply", async () => {
+	it("returns (does NOT throw) a terminal error reply", async () => {
 		vi.resetModules();
-		mockDeps({ status: "error", error: "provider down" });
+		mockDeps({ reply: { status: "error", error: "provider down" } });
 		const manageConversations = await loadHandler();
 
 		const res = (await manageConversations(
@@ -158,7 +180,7 @@ describe("manage_conversations send", () => {
 
 	it("returns timeout when no reply lands before the deadline", async () => {
 		vi.resetModules();
-		mockDeps(null); // never completes
+		mockDeps({ reply: null }); // never completes
 		const manageConversations = await loadHandler();
 
 		const res = (await manageConversations(
@@ -176,9 +198,57 @@ describe("manage_conversations send", () => {
 		expect(res.message_id).toBeTruthy();
 	});
 
+	it("resumes an explicit conversation_id that the caller owns", async () => {
+		vi.resetModules();
+		mockDeps({
+			reply: { status: "complete", text: "resumed" },
+			conversation: OWNED_ROW,
+		});
+		const manageConversations = await loadHandler();
+
+		const res = (await manageConversations(
+			{
+				action: "send",
+				agent_id: "researcher",
+				conversation_id: "conv-x",
+				text: "hi",
+			},
+			env,
+			memberCtx,
+		)) as Record<string, unknown>;
+
+		expect(res.status).toBe("complete");
+		expect(res.conversation_id).toBe("conv-x");
+		expect(enqueued[0].conversationId).toBe("conv-x");
+	});
+
+	it("refuses a conversation_id that is not the caller's owned web conversation (IDOR)", async () => {
+		vi.resetModules();
+		// The target belongs to a DIFFERENT user.
+		mockDeps({
+			conversation: { ...OWNED_ROW, userId: "someone-else" },
+		});
+		const manageConversations = await loadHandler();
+
+		await expect(
+			manageConversations(
+				{
+					action: "send",
+					agent_id: "researcher",
+					conversation_id: "conv-x",
+					text: "hi",
+				},
+				env,
+				memberCtx,
+			),
+		).rejects.toThrow(/not found/);
+		// Nothing was enqueued into another user's conversation.
+		expect(enqueued).toHaveLength(0);
+	});
+
 	it("rejects empty text", async () => {
 		vi.resetModules();
-		mockDeps(null);
+		mockDeps({ reply: null });
 		const manageConversations = await loadHandler();
 
 		await expect(
@@ -192,14 +262,79 @@ describe("manage_conversations send", () => {
 
 	it("rejects an unauthenticated caller (no user id to bind the conversation)", async () => {
 		vi.resetModules();
-		mockDeps(null);
+		mockDeps({ reply: null });
 		const manageConversations = await loadHandler();
 
 		await expect(
 			manageConversations(
 				{ action: "send", agent_id: "researcher", text: "hi" },
 				env,
-				{ ...ctx, userId: null },
+				{ ...ctx, userId: null, scopes: ["*"] },
+			),
+		).rejects.toThrow(/authenticated caller/);
+	});
+});
+
+describe("manage_conversations list/get fencing", () => {
+	it("list scopes a MEMBER to their own owned threads (scope=user)", async () => {
+		vi.resetModules();
+		mockDeps({});
+		const manageConversations = await loadHandler();
+		const res = (await manageConversations(
+			{ action: "list", agent_id: "researcher" },
+			env,
+			memberCtx,
+		)) as Record<string, unknown>;
+		expect(res.action).toBe("list");
+		expect(Array.isArray(res.conversations)).toBe(true);
+	});
+
+	it("get returns a caller-owned conversation", async () => {
+		vi.resetModules();
+		mockDeps({ conversation: OWNED_ROW });
+		const manageConversations = await loadHandler();
+		const res = (await manageConversations(
+			{ action: "get", agent_id: "researcher", conversation_id: "conv-x" },
+			env,
+			memberCtx,
+		)) as Record<string, unknown>;
+		expect(res.action).toBe("get");
+	});
+
+	it("get refuses another user's web conversation for a member (IDOR → 404)", async () => {
+		vi.resetModules();
+		mockDeps({ conversation: { ...OWNED_ROW, userId: "someone-else" } });
+		const manageConversations = await loadHandler();
+		await expect(
+			manageConversations(
+				{ action: "get", agent_id: "researcher", conversation_id: "conv-x" },
+				env,
+				memberCtx,
+			),
+		).rejects.toThrow(/not found/);
+	});
+
+	it("get lets an ADMIN read another user's conversation", async () => {
+		vi.resetModules();
+		mockDeps({ conversation: { ...OWNED_ROW, userId: "someone-else" } });
+		const manageConversations = await loadHandler();
+		const res = (await manageConversations(
+			{ action: "get", agent_id: "researcher", conversation_id: "conv-x" },
+			env,
+			ctx, // owner
+		)) as Record<string, unknown>;
+		expect(res.action).toBe("get");
+	});
+
+	it("list rejects an unauthenticated caller", async () => {
+		vi.resetModules();
+		mockDeps({});
+		const manageConversations = await loadHandler();
+		await expect(
+			manageConversations(
+				{ action: "list", agent_id: "researcher" },
+				env,
+				{ ...ctx, userId: null, scopes: ["*"] },
 			),
 		).rejects.toThrow(/authenticated caller/);
 	});

--- a/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
+++ b/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
@@ -205,6 +205,25 @@ describe("manage_conversations send", () => {
 		expect(String(res.reply)).toMatch(/blocked by guardrail/i);
 	});
 
+	it("runs the output guardrail on a terminal ERROR too (a provider error can carry secrets)", async () => {
+		vi.resetModules();
+		mockDeps({
+			reply: { status: "error", error: "auth failed for key sk-live-999" },
+			guardrailTrip: { guardrail: "secret-scan", reason: "api key" },
+		});
+		const manageConversations = await loadHandler();
+
+		const res = (await manageConversations(
+			{ action: "send", agent_id: "researcher", text: "hi" },
+			env,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(res.status).toBe("error");
+		expect(res.error).not.toContain("sk-live-999");
+		expect(String(res.error)).toMatch(/blocked by guardrail/i);
+	});
+
 	it("returns timeout when no reply lands before the deadline", async () => {
 		vi.resetModules();
 		mockDeps({ reply: null }); // never completes

--- a/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
+++ b/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
@@ -45,6 +45,8 @@ interface MockOpts {
 	reply?: unknown | (() => unknown);
 	/** getConversation yields this (default: a caller-owned web row). */
 	conversation?: unknown;
+	/** When set, runOutputGuardrailScan reports this trip (blocks the reply). */
+	guardrailTrip?: { guardrail: string; reason?: string } | null;
 }
 
 /** A caller-owned web conversation — passes the send/get ownership fence. */
@@ -97,6 +99,10 @@ function mockDeps(opts: MockOpts = {}) {
 		getConversation: () => Promise.resolve(conversation),
 		listConversations: () => Promise.resolve([OWNED_ROW]),
 	}));
+	const trip = opts.guardrailTrip ?? null;
+	vi.doMock("../../gateway/guardrails/output-scan.js", () => ({
+		runOutputGuardrailScan: () => Promise.resolve(trip),
+	}));
 }
 
 async function loadHandler() {
@@ -110,6 +116,7 @@ afterEach(() => {
 	vi.doUnmock("../../gateway/services/platform-helpers.js");
 	vi.doUnmock("../../lobu/gateway.js");
 	vi.doUnmock("../../gateway/services/conversations-store.js");
+	vi.doUnmock("../../gateway/guardrails/output-scan.js");
 });
 
 describe("manage_conversations send", () => {
@@ -176,6 +183,26 @@ describe("manage_conversations send", () => {
 
 		expect(res.status).toBe("error");
 		expect(res.error).toBe("provider down");
+	});
+
+	it("runs the output guardrail on the reply and blocks a tripped one", async () => {
+		vi.resetModules();
+		mockDeps({
+			reply: { status: "complete", text: "the secret is sk-live-123" },
+			guardrailTrip: { guardrail: "secret-scan", reason: "api key" },
+		});
+		const manageConversations = await loadHandler();
+
+		const res = (await manageConversations(
+			{ action: "send", agent_id: "researcher", text: "hi" },
+			env,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(res.status).toBe("complete");
+		// The raw finalText must NOT leak; the block notice replaces it.
+		expect(res.reply).not.toContain("sk-live-123");
+		expect(String(res.reply)).toMatch(/blocked by guardrail/i);
 	});
 
 	it("returns timeout when no reply lands before the deadline", async () => {

--- a/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
+++ b/packages/server/src/tools/__tests__/manage-conversations-send.test.ts
@@ -222,7 +222,7 @@ describe("manage_conversations send", () => {
 		expect(enqueued[0].conversationId).toBe("conv-x");
 	});
 
-	it("refuses a conversation_id that is not the caller's owned web conversation (IDOR)", async () => {
+	it("refuses a conversation_id that is not the caller's owned web conversation — for a MEMBER (IDOR)", async () => {
 		vi.resetModules();
 		// The target belongs to a DIFFERENT user.
 		mockDeps({
@@ -244,6 +244,52 @@ describe("manage_conversations send", () => {
 		).rejects.toThrow(/not found/);
 		// Nothing was enqueued into another user's conversation.
 		expect(enqueued).toHaveLength(0);
+	});
+
+	it("refuses sending into another user's conversation even for an ADMIN (no bypass)", async () => {
+		vi.resetModules();
+		mockDeps({ conversation: { ...OWNED_ROW, userId: "someone-else" } });
+		const manageConversations = await loadHandler();
+
+		await expect(
+			manageConversations(
+				{
+					action: "send",
+					agent_id: "researcher",
+					conversation_id: "conv-x",
+					text: "hi",
+				},
+				env,
+				ctx, // owner — send is caller-attributed, so no admin cross-user write.
+			),
+		).rejects.toThrow(/not found/);
+		expect(enqueued).toHaveLength(0);
+	});
+
+	it("delivers a reply that lands during the final wait window (short timeout)", async () => {
+		vi.resetModules();
+		// null on the first poll, then complete — with timeout_ms=1000 and a 1000ms
+		// poll interval, the post-loop final read must still catch it.
+		let calls = 0;
+		mockDeps({
+			reply: () =>
+				++calls >= 2 ? { status: "complete", text: "late answer" } : null,
+		});
+		const manageConversations = await loadHandler();
+
+		const res = (await manageConversations(
+			{
+				action: "send",
+				agent_id: "researcher",
+				text: "hi",
+				timeout_ms: 1000,
+			},
+			env,
+			ctx,
+		)) as Record<string, unknown>;
+
+		expect(res.status).toBe("complete");
+		expect(res.reply).toBe("late answer");
 	});
 
 	it("rejects empty text", async () => {

--- a/packages/server/src/tools/admin/index.ts
+++ b/packages/server/src/tools/admin/index.ts
@@ -14,6 +14,10 @@ import { GetWatcherSchema, GetWatcherResultSchema, getWatcher } from "../get_wat
 import type { ToolAnnotations, ToolContext, ToolDefinition } from "../registry";
 import { ManageAgentsSchema, manageAgents } from "./manage_agents";
 import {
+	ManageConversationsSchema,
+	manageConversations,
+} from "./manage_conversations";
+import {
 	ManageAuthProfilesResultSchema,
 	ManageAuthProfilesSchema,
 	manageAuthProfiles,
@@ -131,6 +135,15 @@ const ENTRIES: AdminToolEntry[] = [
 		schema: ManageAgentsSchema,
 		handler: manageAgents,
 		annotations: DESTRUCTIVE_WITH_TITLE("Manage agents"),
+	},
+	{
+		name: "manage_conversations",
+		description:
+			"List/get an agent's conversations and send a turn (awaits the reply). SDK alternative: client.conversations.",
+		schema: ManageConversationsSchema,
+		handler: manageConversations,
+		// send is a write (no delete), list/get are reads — WRITE, not DESTRUCTIVE.
+		annotations: WRITE_WITH_TITLE("Manage conversations"),
 	},
 	{
 		name: "manage_feeds",

--- a/packages/server/src/tools/admin/manage_conversations.ts
+++ b/packages/server/src/tools/admin/manage_conversations.ts
@@ -40,10 +40,7 @@ import {
 import type { Env } from "../../index";
 import { getLobuCoreServices } from "../../lobu/gateway";
 import { ToolUserError } from "../../utils/errors";
-import {
-  requireOrgReadAccess,
-  requireOrgWriteAccess,
-} from "../../utils/organization-access";
+import { isAdminOrOwnerRole } from "../access-control";
 import type { ToolContext } from "../registry";
 import { withValidatedArgs } from "../validate-args";
 import { defineFlatActionTool, flatAction } from "./action-tool";
@@ -88,16 +85,25 @@ async function handleList(
   ctx: ToolContext,
   env: Env,
 ) {
+  // A conversation listing exposes titles (message content). Require an
+  // authenticated caller — an anonymous public read must not enumerate them.
+  if (!ctx.userId) {
+    throw new ToolUserError(
+      "list requires an authenticated caller",
+      401,
+    );
+  }
   await assertAgentInOrg(args.agent_id, ctx, env);
-  // A member scoped to their own user reads only their owned threads; an
-  // admin/owner (or a cross-user caller) sees every conversation. Mirror the
-  // sidebar's scope split.
-  const scope = ctx.userId ? "user" : "all";
+  // Scope from ROLE, not merely "has a userId": an admin/owner sees every
+  // conversation; a plain member sees only their own owned threads. (Deriving
+  // scope from `ctx.userId` alone inverted this — an admin was limited to their
+  // own rows while a null-userId caller saw all.)
+  const scope = isAdminOrOwnerRole(ctx.memberRole) ? "all" : "user";
   const conversations = await listConversations({
     organizationId: ctx.organizationId,
     agentId: args.agent_id,
     scope,
-    userId: ctx.userId ?? "",
+    userId: ctx.userId,
   });
   return {
     action: "list" as const,
@@ -113,6 +119,9 @@ async function handleGet(
   if (!args.conversation_id) {
     throw new ToolUserError("conversation_id is required for get action");
   }
+  if (!ctx.userId) {
+    throw new ToolUserError("get requires an authenticated caller", 401);
+  }
   await assertAgentInOrg(args.agent_id, ctx, env);
   const platform = (args.platform ?? "web").toLowerCase();
   const row = await getConversation({
@@ -121,7 +130,12 @@ async function handleGet(
     platform,
     conversationId: args.conversation_id,
   });
-  if (!row) {
+  // A non-admin may read only their OWN owned (web) conversation. A platform
+  // conversation, or another user's web thread, is not theirs to fetch — 404
+  // (not 403) so the response can't be used to probe which ids exist.
+  const isAdmin = isAdminOrOwnerRole(ctx.memberRole);
+  const ownedByCaller = row?.kind === "owned" && row.userId === ctx.userId;
+  if (!row || (!isAdmin && !ownedByCaller)) {
     throw new ToolUserError(
       `Conversation "${args.conversation_id}" not found for agent "${args.agent_id}"`,
       404,
@@ -174,16 +188,40 @@ async function handleSend(
 
   const userId = ctx.userId;
   // A named thread targets/opens a distinct web conversation (own history + own
-  // pinned sandbox); omitting `thread` uses the caller's default thread. Prefer
-  // an explicit conversation_id (resume an exact conversation) over `thread`.
-  const conversationId =
-    args.conversation_id ??
-    buildApiConversationId({
+  // pinned sandbox); omitting `thread` uses the caller's default thread. When an
+  // explicit conversation_id is given it resumes an exact conversation — but it
+  // must be verified to belong to the caller, else a member could enqueue a turn
+  // into another user's (or a platform) conversation. Without conversation_id the
+  // id is DERIVED from the caller's own userId, so it is inherently theirs.
+  let conversationId: string;
+  if (args.conversation_id) {
+    const target = await getConversation({
+      organizationId: ctx.organizationId,
+      agentId: args.agent_id,
+      platform: "web",
+      conversationId: args.conversation_id,
+    });
+    const isAdmin = isAdminOrOwnerRole(ctx.memberRole);
+    const ownedByCaller =
+      target?.kind === "owned" && target.userId === ctx.userId;
+    if (!target || (!isAdmin && !ownedByCaller)) {
+      // 404 (not 403) so the id space can't be probed. Only OWNED web
+      // conversations are sendable by id; external/platform ones aren't driven
+      // through this SDK path (they route through their own channel).
+      throw new ToolUserError(
+        `Conversation "${args.conversation_id}" not found for agent "${args.agent_id}"`,
+        404,
+      );
+    }
+    conversationId = args.conversation_id;
+  } else {
+    conversationId = buildApiConversationId({
       agentId: args.agent_id,
       userId,
       organizationId: ctx.organizationId,
       threadId: args.thread || undefined,
     });
+  }
   const channelId = `api_${userId}`;
   const messageId = randomUUID();
 
@@ -269,33 +307,15 @@ async function handleSend(
   }
 
   // Timed out (or the script's budget ran out). The turn keeps running; the
-  // caller can read the reply later via `get` / the transcript.
+  // caller awaits it by calling send again on the same conversation, or reads
+  // the transcript out of band. `get` returns only conversation metadata, not
+  // the reply, so it is NOT the way to retrieve a delayed answer.
   return {
     action: "send" as const,
     conversation_id: conversationId,
     message_id: messageId,
     status: "timeout" as const,
   };
-}
-
-export const manageConversations = withValidatedArgs(
-  "manage_conversations",
-  ManageConversationsSchema,
-  manageConversationsImpl,
-);
-
-async function manageConversationsImpl(
-  args: ManageConversationsArgs,
-  env: Env,
-  ctx: ToolContext,
-) {
-  const pgSql = createDbClientFromEnv(env);
-  if (args.action === "send") {
-    await requireOrgWriteAccess(pgSql, ctx);
-  } else {
-    await requireOrgReadAccess(pgSql, ctx);
-  }
-  return runManageConversations(args, env, ctx);
 }
 
 const runManageConversations = defineFlatActionTool<
@@ -306,3 +326,15 @@ const runManageConversations = defineFlatActionTool<
   get: flatAction((args, ctx, env) => handleGet(args, ctx, env)),
   send: flatAction((args, ctx, env) => handleSend(args, ctx, env)),
 });
+
+// Access is enforced per-action by routeAction (inside runManageConversations)
+// against tool-access.ts: send → MEMBER_WRITE_ACTIONS (any member), list/get →
+// PUBLIC_READ_ACTIONS. Do NOT re-gate here with requireOrg{Read,Write}Access —
+// canWriteOrg requires owner/admin, which would contradict the member-tier
+// `send` grant and reject a plain member the policy explicitly allows. Ownership
+// is fenced per-handler (agent-in-org + user-owned conversation).
+export const manageConversations = withValidatedArgs(
+  "manage_conversations",
+  ManageConversationsSchema,
+  runManageConversations,
+);

--- a/packages/server/src/tools/admin/manage_conversations.ts
+++ b/packages/server/src/tools/admin/manage_conversations.ts
@@ -37,6 +37,7 @@ import {
   buildMessagePayload,
   resolveAgentOptions,
 } from "../../gateway/services/platform-helpers";
+import { runOutputGuardrailScan } from "../../gateway/guardrails/output-scan";
 import type { Env } from "../../index";
 import { getLobuCoreServices } from "../../lobu/gateway";
 import { ToolUserError } from "../../utils/errors";
@@ -47,7 +48,14 @@ import { defineFlatActionTool, flatAction } from "./action-tool";
 
 export { ManageConversationsSchema };
 
-const DEFAULT_WAIT_TIMEOUT_MS = 60_000;
+// run_sdk's DEFAULT wall-clock budget is 60000ms and it starts BEFORE this
+// script compiles + dispatches — so a send default equal to it would trip
+// run_sdk's own TimeoutError before send could return a graceful
+// status:"timeout". Default strictly inside that budget (leaving ~15s of
+// headroom for compile/dispatch/return). A caller who wants a longer wait must
+// raise BOTH send's timeout_ms AND run_sdk's timeout_ms (max 180000); the cap
+// here (170000) stays inside run_sdk's max so a maxed send can still return.
+const DEFAULT_WAIT_TIMEOUT_MS = 45_000;
 const MAX_WAIT_TIMEOUT_MS = 170_000;
 const POLL_INTERVAL_MS = 1_000;
 
@@ -290,7 +298,32 @@ async function handleSend(
   // FIRST, then sleep only the time left to the deadline — so a reply landing
   // during the final window is still caught by the post-loop read, and a short
   // timeout (e.g. 1000ms) doesn't overshoot into a full extra POLL_INTERVAL.
-  const terminal = (
+  // readConversationReply reads the RAW worker-written finalText from the runs
+  // row — the UnifiedThreadResponseConsumer's output guardrail only rewrote an
+  // in-memory copy for the SSE/history path, never that persisted row. So this
+  // SDK read must run the SAME output-stage scan itself, or a secret/PII the
+  // agent's output guardrail blocks would leak through conversations.send. Fails
+  // open (returns the text) on infra error, matching the renderer path.
+  const guardrailRegistry = coreServices?.getGuardrailRegistry?.() ?? undefined;
+  const scanReply = async (replyText: string): Promise<string> => {
+    const trip = await runOutputGuardrailScan(
+      guardrailRegistry,
+      agentSettingsStore,
+      replyText,
+      {
+        agentId: args.agent_id,
+        organizationId: ctx.organizationId,
+        userId,
+        conversationId,
+        platform: "api",
+      },
+    );
+    return trip
+      ? `Message blocked by guardrail: ${trip.reason ?? trip.guardrail}`
+      : replyText;
+  };
+
+  const terminal = async (
     reply: Awaited<ReturnType<typeof readConversationReply>>,
   ) => {
     if (reply?.status === "complete") {
@@ -299,7 +332,7 @@ async function handleSend(
         conversation_id: conversationId,
         message_id: messageId,
         status: "complete" as const,
-        reply: reply.text,
+        reply: await scanReply(reply.text),
       };
     }
     if (reply?.status === "error") {
@@ -315,7 +348,7 @@ async function handleSend(
   };
 
   while (!ctx.abortSignal?.aborted) {
-    const done = terminal(
+    const done = await terminal(
       await readConversationReply({
         organizationId: ctx.organizationId,
         conversationId,

--- a/packages/server/src/tools/admin/manage_conversations.ts
+++ b/packages/server/src/tools/admin/manage_conversations.ts
@@ -1,0 +1,308 @@
+/**
+ * Tool: manage_conversations
+ *
+ * Read an agent's conversations and drive a turn against one.
+ *
+ * Actions:
+ * - list: List an agent's conversations, newest-first (the materialized
+ *   `conversations` entity — the same source the sidebar reads).
+ * - get:  Fetch one conversation by (platform, conversation_id).
+ * - send: Enqueue a message to an agent conversation and, by default, block
+ *   until the turn completes and return its reply. `wait:false` returns
+ *   immediately with the message id (fire-and-forget).
+ *
+ * `send` targets the app-owned `web` realm: it builds the API conversation id
+ * (`{agent}_{user}_{org}[_{thread}]`) and enqueues a `platform: "api"` payload,
+ * exactly like the web panel's `POST /messages` and the scheduled-job wake. The
+ * per-conversation sandbox pin (message-consumer → resolvePinnedSelection) then
+ * freezes/reuses this conversation's runtime realm — the SDK caller never picks
+ * a sandbox; the pin does. The reply is read from the durable `runs`
+ * thread-response rows (cross-replica-safe), never a pod-local SSE buffer.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  type ManageConversationsArgs,
+  ManageConversationsSchema,
+} from "@lobu/core/contracts/tools/manage-conversations";
+import { createDbClientFromEnv } from "../../db/client";
+import { buildApiConversationId } from "../../gateway/services/api-conversation-id";
+import {
+  type ConversationListRow,
+  getConversation,
+  listConversations,
+  readConversationReply,
+} from "../../gateway/services/conversations-store";
+import {
+  buildMessagePayload,
+  resolveAgentOptions,
+} from "../../gateway/services/platform-helpers";
+import type { Env } from "../../index";
+import { getLobuCoreServices } from "../../lobu/gateway";
+import { ToolUserError } from "../../utils/errors";
+import {
+  requireOrgReadAccess,
+  requireOrgWriteAccess,
+} from "../../utils/organization-access";
+import type { ToolContext } from "../registry";
+import { withValidatedArgs } from "../validate-args";
+import { defineFlatActionTool, flatAction } from "./action-tool";
+
+export { ManageConversationsSchema };
+
+const DEFAULT_WAIT_TIMEOUT_MS = 60_000;
+const MAX_WAIT_TIMEOUT_MS = 170_000;
+const POLL_INTERVAL_MS = 1_000;
+
+function serializeRow(r: ConversationListRow) {
+  return {
+    platform: r.platform,
+    conversation_id: r.conversationId,
+    kind: r.kind,
+    user_id: r.userId,
+    title: r.title,
+    last_activity_at: r.lastActivityAt.toISOString(),
+    created_at: r.createdAt.toISOString(),
+  };
+}
+
+/** Assert the agent exists in this org before listing/sending against it. */
+async function assertAgentInOrg(
+  agentId: string,
+  ctx: ToolContext,
+  env: Env,
+): Promise<void> {
+  const sql = createDbClientFromEnv(env);
+  const rows = await sql`
+    SELECT 1 FROM agents
+    WHERE organization_id = ${ctx.organizationId} AND id = ${agentId}
+    LIMIT 1
+  `;
+  if (rows.length === 0) {
+    throw new ToolUserError(`Agent "${agentId}" not found`, 404);
+  }
+}
+
+async function handleList(
+  args: ManageConversationsArgs,
+  ctx: ToolContext,
+  env: Env,
+) {
+  await assertAgentInOrg(args.agent_id, ctx, env);
+  // A member scoped to their own user reads only their owned threads; an
+  // admin/owner (or a cross-user caller) sees every conversation. Mirror the
+  // sidebar's scope split.
+  const scope = ctx.userId ? "user" : "all";
+  const conversations = await listConversations({
+    organizationId: ctx.organizationId,
+    agentId: args.agent_id,
+    scope,
+    userId: ctx.userId ?? "",
+  });
+  return {
+    action: "list" as const,
+    conversations: conversations.map(serializeRow),
+  };
+}
+
+async function handleGet(
+  args: ManageConversationsArgs,
+  ctx: ToolContext,
+  env: Env,
+) {
+  if (!args.conversation_id) {
+    throw new ToolUserError("conversation_id is required for get action");
+  }
+  await assertAgentInOrg(args.agent_id, ctx, env);
+  const platform = (args.platform ?? "web").toLowerCase();
+  const row = await getConversation({
+    organizationId: ctx.organizationId,
+    agentId: args.agent_id,
+    platform,
+    conversationId: args.conversation_id,
+  });
+  if (!row) {
+    throw new ToolUserError(
+      `Conversation "${args.conversation_id}" not found for agent "${args.agent_id}"`,
+      404,
+    );
+  }
+  return { action: "get" as const, conversation: serializeRow(row) };
+}
+
+/** Abort-aware sleep so a wait-loop unblocks the instant the script times out. */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) return resolve();
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+async function handleSend(
+  args: ManageConversationsArgs,
+  ctx: ToolContext,
+  env: Env,
+) {
+  const text = typeof args.text === "string" ? args.text : "";
+  if (!text.trim()) {
+    throw new ToolUserError("text is required for send action");
+  }
+  if (!ctx.userId) {
+    throw new ToolUserError(
+      "send requires an authenticated caller (the conversation is bound to the caller's user id)",
+    );
+  }
+  await assertAgentInOrg(args.agent_id, ctx, env);
+
+  const coreServices = getLobuCoreServices();
+  const queueProducer = coreServices?.getQueueProducer?.();
+  if (!queueProducer) {
+    throw new ToolUserError(
+      "Message dispatch is unavailable in this runtime (no queue producer).",
+      503,
+    );
+  }
+  const agentSettingsStore = coreServices?.getAgentSettingsStore?.();
+
+  const userId = ctx.userId;
+  // A named thread targets/opens a distinct web conversation (own history + own
+  // pinned sandbox); omitting `thread` uses the caller's default thread. Prefer
+  // an explicit conversation_id (resume an exact conversation) over `thread`.
+  const conversationId =
+    args.conversation_id ??
+    buildApiConversationId({
+      agentId: args.agent_id,
+      userId,
+      organizationId: ctx.organizationId,
+      threadId: args.thread || undefined,
+    });
+  const channelId = `api_${userId}`;
+  const messageId = randomUUID();
+
+  const behaviorModel =
+    typeof args.model === "string" && args.model.trim()
+      ? args.model.trim()
+      : undefined;
+  const agentOptions = await resolveAgentOptions(
+    args.agent_id,
+    {
+      provider: "claude",
+      model: behaviorModel,
+      ...(behaviorModel ? { behaviorModelOverride: true } : {}),
+    },
+    agentSettingsStore,
+    ctx.organizationId,
+  );
+
+  await queueProducer.enqueueMessage(
+    buildMessagePayload({
+      platform: "api",
+      userId,
+      botId: "lobu-api",
+      conversationId,
+      teamId: "api",
+      agentId: args.agent_id,
+      organizationId: ctx.organizationId,
+      messageId,
+      messageText: text,
+      channelId,
+      platformMetadata: {
+        agentId: args.agent_id,
+        organizationId: ctx.organizationId,
+        source: "sdk-conversations-send",
+      },
+      agentOptions,
+    }),
+  );
+
+  const wait = args.wait !== false;
+  if (!wait) {
+    return {
+      action: "send" as const,
+      conversation_id: conversationId,
+      message_id: messageId,
+      status: "queued" as const,
+    };
+  }
+
+  const timeoutMs = Math.min(
+    args.timeout_ms ?? DEFAULT_WAIT_TIMEOUT_MS,
+    MAX_WAIT_TIMEOUT_MS,
+  );
+  const deadline = Date.now() + timeoutMs;
+  // Poll the durable runs rows for the terminal outcome. Deliberately NOT SSE:
+  // the completion row is visible from any replica, so a wait-loop works even
+  // when a different pod drained the deltas. Aborts at the script budget.
+  while (Date.now() < deadline && !ctx.abortSignal?.aborted) {
+    const reply = await readConversationReply({
+      organizationId: ctx.organizationId,
+      conversationId,
+      messageId,
+    });
+    if (reply?.status === "complete") {
+      return {
+        action: "send" as const,
+        conversation_id: conversationId,
+        message_id: messageId,
+        status: "complete" as const,
+        reply: reply.text,
+      };
+    }
+    if (reply?.status === "error") {
+      return {
+        action: "send" as const,
+        conversation_id: conversationId,
+        message_id: messageId,
+        status: "error" as const,
+        error: reply.error,
+      };
+    }
+    await sleep(POLL_INTERVAL_MS, ctx.abortSignal);
+  }
+
+  // Timed out (or the script's budget ran out). The turn keeps running; the
+  // caller can read the reply later via `get` / the transcript.
+  return {
+    action: "send" as const,
+    conversation_id: conversationId,
+    message_id: messageId,
+    status: "timeout" as const,
+  };
+}
+
+export const manageConversations = withValidatedArgs(
+  "manage_conversations",
+  ManageConversationsSchema,
+  manageConversationsImpl,
+);
+
+async function manageConversationsImpl(
+  args: ManageConversationsArgs,
+  env: Env,
+  ctx: ToolContext,
+) {
+  const pgSql = createDbClientFromEnv(env);
+  if (args.action === "send") {
+    await requireOrgWriteAccess(pgSql, ctx);
+  } else {
+    await requireOrgReadAccess(pgSql, ctx);
+  }
+  return runManageConversations(args, env, ctx);
+}
+
+const runManageConversations = defineFlatActionTool<
+  ManageConversationsArgs,
+  Awaited<ReturnType<typeof handleList | typeof handleGet | typeof handleSend>>
+>("manage_conversations", {
+  list: flatAction((args, ctx, env) => handleList(args, ctx, env)),
+  get: flatAction((args, ctx, env) => handleGet(args, ctx, env)),
+  send: flatAction((args, ctx, env) => handleSend(args, ctx, env)),
+});

--- a/packages/server/src/tools/admin/manage_conversations.ts
+++ b/packages/server/src/tools/admin/manage_conversations.ts
@@ -298,18 +298,20 @@ async function handleSend(
   // FIRST, then sleep only the time left to the deadline — so a reply landing
   // during the final window is still caught by the post-loop read, and a short
   // timeout (e.g. 1000ms) doesn't overshoot into a full extra POLL_INTERVAL.
-  // readConversationReply reads the RAW worker-written finalText from the runs
-  // row — the UnifiedThreadResponseConsumer's output guardrail only rewrote an
-  // in-memory copy for the SSE/history path, never that persisted row. So this
+  // readConversationReply reads the RAW worker-written finalText/error from the
+  // runs row — the UnifiedThreadResponseConsumer's output guardrail only rewrote
+  // an in-memory copy for the SSE/history path, never that persisted row. So this
   // SDK read must run the SAME output-stage scan itself, or a secret/PII the
-  // agent's output guardrail blocks would leak through conversations.send. Fails
-  // open (returns the text) on infra error, matching the renderer path.
+  // agent's output guardrail blocks would leak through conversations.send. The
+  // consumer scans BOTH finalText AND error (a provider/runtime error can carry
+  // secrets), so scan both terminal texts here too. Fails open (returns the
+  // text) on infra error, matching the renderer path.
   const guardrailRegistry = coreServices?.getGuardrailRegistry?.() ?? undefined;
-  const scanReply = async (replyText: string): Promise<string> => {
+  const scanTerminalText = async (text: string): Promise<string> => {
     const trip = await runOutputGuardrailScan(
       guardrailRegistry,
       agentSettingsStore,
-      replyText,
+      text,
       {
         agentId: args.agent_id,
         organizationId: ctx.organizationId,
@@ -320,7 +322,7 @@ async function handleSend(
     );
     return trip
       ? `Message blocked by guardrail: ${trip.reason ?? trip.guardrail}`
-      : replyText;
+      : text;
   };
 
   const terminal = async (
@@ -332,7 +334,7 @@ async function handleSend(
         conversation_id: conversationId,
         message_id: messageId,
         status: "complete" as const,
-        reply: await scanReply(reply.text),
+        reply: await scanTerminalText(reply.text),
       };
     }
     if (reply?.status === "error") {
@@ -341,7 +343,7 @@ async function handleSend(
         conversation_id: conversationId,
         message_id: messageId,
         status: "error" as const,
-        error: reply.error,
+        error: await scanTerminalText(reply.error),
       };
     }
     return null;

--- a/packages/server/src/tools/admin/manage_conversations.ts
+++ b/packages/server/src/tools/admin/manage_conversations.ts
@@ -201,13 +201,15 @@ async function handleSend(
       platform: "web",
       conversationId: args.conversation_id,
     });
-    const isAdmin = isAdminOrOwnerRole(ctx.memberRole);
+    // send is caller-attributed: the enqueued payload stamps userId=ctx.userId
+    // and channelId=api_<caller>. So the target MUST be the caller's OWN owned
+    // web conversation — NO admin bypass (unlike `get`, an admin has no reason to
+    // WRITE a self-attributed turn into another user's conversation, which would
+    // contaminate that user's history). A non-owned/foreign id is 404 (not 403)
+    // so the id space can't be probed.
     const ownedByCaller =
       target?.kind === "owned" && target.userId === ctx.userId;
-    if (!target || (!isAdmin && !ownedByCaller)) {
-      // 404 (not 403) so the id space can't be probed. Only OWNED web
-      // conversations are sendable by id; external/platform ones aren't driven
-      // through this SDK path (they route through their own channel).
+    if (!ownedByCaller) {
       throw new ToolUserError(
         `Conversation "${args.conversation_id}" not found for agent "${args.agent_id}"`,
         404,
@@ -255,7 +257,13 @@ async function handleSend(
       platformMetadata: {
         agentId: args.agent_id,
         organizationId: ctx.organizationId,
-        source: "sdk-conversations-send",
+        // MUST be a HEADLESS_SOURCES value (unified-thread-consumer.ts): an SDK
+        // send opens no SSE stream, so a non-headless source makes the terminal
+        // reply requeue-until-fail waiting for an SSE owner that never connects.
+        // `internal` is the headless programmatic-turn source (the same default
+        // agent-threads.ts uses); the reply is read back via the durable runs
+        // rows (readConversationReply), not SSE.
+        source: "internal",
       },
       agentOptions,
     }),
@@ -278,13 +286,13 @@ async function handleSend(
   const deadline = Date.now() + timeoutMs;
   // Poll the durable runs rows for the terminal outcome. Deliberately NOT SSE:
   // the completion row is visible from any replica, so a wait-loop works even
-  // when a different pod drained the deltas. Aborts at the script budget.
-  while (Date.now() < deadline && !ctx.abortSignal?.aborted) {
-    const reply = await readConversationReply({
-      organizationId: ctx.organizationId,
-      conversationId,
-      messageId,
-    });
+  // when a different pod drained the deltas. Aborts at the script budget. Read
+  // FIRST, then sleep only the time left to the deadline — so a reply landing
+  // during the final window is still caught by the post-loop read, and a short
+  // timeout (e.g. 1000ms) doesn't overshoot into a full extra POLL_INTERVAL.
+  const terminal = (
+    reply: Awaited<ReturnType<typeof readConversationReply>>,
+  ) => {
     if (reply?.status === "complete") {
       return {
         action: "send" as const,
@@ -303,13 +311,27 @@ async function handleSend(
         error: reply.error,
       };
     }
-    await sleep(POLL_INTERVAL_MS, ctx.abortSignal);
+    return null;
+  };
+
+  while (!ctx.abortSignal?.aborted) {
+    const done = terminal(
+      await readConversationReply({
+        organizationId: ctx.organizationId,
+        conversationId,
+        messageId,
+      }),
+    );
+    if (done) return done;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await sleep(Math.min(POLL_INTERVAL_MS, remaining), ctx.abortSignal);
   }
 
   // Timed out (or the script's budget ran out). The turn keeps running; the
-  // caller awaits it by calling send again on the same conversation, or reads
-  // the transcript out of band. `get` returns only conversation metadata, not
-  // the reply, so it is NOT the way to retrieve a delayed answer.
+  // caller reads the reply out of band from the transcript. There is no
+  // enqueue-free retrieval on this tool — calling `send` again starts a NEW
+  // turn (fresh message_id), and `get` returns only conversation metadata.
   return {
     action: "send" as const,
     conversation_id: conversationId,


### PR DESCRIPTION
## What

Adds a `conversations` namespace to the `run_sdk` ClientSDK so external MCP callers can drive an agent turn and read the reply — the SDK-facing surface on top of the `conversations` entity (#1947) + per-conversation sandbox pin (#1948).

- `conversations.list({ agent_id })` / `conversations.get({ agent_id, platform?, conversation_id })` — read the materialized `conversations` entity (the sidebar's single source). Read-tier: a member sees their own owned threads, an admin sees all.
- `conversations.send({ agent_id, text, thread?/conversation_id?, wait?, model?, timeout_ms? })` — enqueue a `platform:"api"` turn on the caller's api conversation id, the exact path the web panel + scheduled wakes use. So the per-conversation sandbox pin (`resolvePinnedSelection`) freezes/reuses the runtime realm — **the SDK caller never picks a sandbox; the pin does.** Write-tier: binds the conversation to `ctx.userId` and fences on agent-in-org.

## send() semantics

Await-reply by default (`wait:true`), because that's what MCP callers actually want — request/response, not a hand-rolled poll loop. The reply is read from the durable `runs` thread-response rows (`queue_name='thread_response'`, matched on `processedMessageIds`), which is **cross-replica-safe** — no SSE socket, no pod-local buffer, so it works even when a different replica drained the deltas. Returns `{ status: complete | error | timeout | queued }`. `wait:false` is fire-and-forget.

## Why `conversations`, not `threads`

The conversation is the durable unit — history *and* its frozen sandbox realm both live on it (keyed `sha256(org:agent:conversation)`). The sandbox is an attribute of the conversation, not a separate thing, and "thread" collides with the existing `thread_id` routing concept.

## Wiring

Backing `manage_conversations` admin tool (flat-action dispatch, same shape as `manage_agents`) + `method-metadata` entries (`send`=write/expensive, `list`/`get`=read) + `tool-access` tiers. No `registry.ts` entry — like `manage_agents`, it's exposed only through the SDK namespace.

## Tests

- **Integration (real embedded PG)** — `getConversation` (PK read + soft-delete hidden) and `readConversationReply` (terminal-outcome poll: completed→finalText, failed→error, in-flight→null, cross-message no-match), exercising the actual SQL incl. the jsonb `?`/cast.
- **Unit (mocked)** — `send` control flow: enqueues an api-platform payload on the right conversation id; `wait:false`→queued; complete/error/timeout mapping; empty-text + unauthenticated rejections.

## Verification

- `make pre-pr` (typecheck + knip + biome) clean.
- New unit + integration suites green (`vitest`, real PG via embedded backend).
- `method-metadata` drift + `read-only` sandbox + `tool-access` suites green.

Not live-proven end-to-end against a booted worker (the reply-poll path is proven at the store/SQL layer + the handler's control flow); a full `send`→worker→reply round trip is the follow-up e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786658642&installation_id=136316292&pr_number=1952&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1952&signature=c6f821eda7f866cd02e6eca51f27f649e765f5231e9edb31c6460c50dbf900e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `manage_conversations` tool supporting `list`, `get`, and `send`.
  * Added a `conversations` namespace to the client SDK (`list`, `get`, `send`).
  * `send` now returns explicit outcomes: `queued`, `complete`, `timeout`, or `error`.
  * Added per-action access controls for conversation operations.
* **Bug Fixes**
  * Conversation reads now ignore archived/soft-deleted entries and resolve durable terminal replies by message ID.
* **Tests**
  * Added integration and unit/regression coverage for authorization, send/polling flow, timeouts, and non-throwing SDK behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->