### PR TITLE
fix(mcp): resolve membership role on scoped /mcp/{slug} sessions

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -836,6 +836,56 @@ describe('MCP Authentication', () => {
     });
   });
 
+  describe('Scoped /mcp/{slug} membership-role resolution', () => {
+    // Regression: scoped sessions derived org from the URL slug and user from
+    // the token but never looked up the caller's membership row, so `memberRole`
+    // stayed null even for an owner — role-gated actions (e.g.
+    // catalog.list_installed, which requires admin) wrongly denied real members.
+    it('resolves an OWNER role on a scoped session (admin-gated action allowed)', async () => {
+      const roleOrg = await createTestOrganization({ name: 'Scoped Role Org' });
+      const owner = await createTestUser({});
+      await addUserToOrganization(owner.id, roleOrg.id, 'owner');
+      const { token } = await createTestPAT(owner.id, roleOrg.id, {
+        scope: 'mcp:read mcp:write mcp:admin',
+      });
+
+      // catalog.list_installed requires admin/owner. Pre-fix this threw
+      // "requires an MCP session with admin access" on the scoped endpoint.
+      const result = await mcpToolsCall(
+        'query_sdk',
+        {
+          script:
+            'export default async (_c, client) => { const r = await client.catalog.listInstalled({ kinds: ["connectors"] }); return { ok: true }; }',
+        },
+        { token, orgSlug: roleOrg.slug }
+      );
+      expect(result.success).toBe(true);
+      expect(result.return_value?.ok).toBe(true);
+    });
+
+    it('does NOT over-grant: a plain MEMBER is still denied the admin-gated action on a scoped session', async () => {
+      const roleOrg = await createTestOrganization({ name: 'Scoped Member Org' });
+      const member = await createTestUser({});
+      await addUserToOrganization(member.id, roleOrg.id, 'member');
+      const { token } = await createTestPAT(member.id, roleOrg.id, {
+        scope: 'mcp:read mcp:write mcp:admin',
+      });
+
+      // query_sdk catches the SDK denial and returns success:false (rather than
+      // throwing), so assert on the surfaced error, not a rejection.
+      const result = await mcpToolsCall(
+        'query_sdk',
+        {
+          script:
+            'export default async (_c, client) => { await client.catalog.listInstalled({ kinds: ["connectors"] }); return { ok: true }; }',
+        },
+        { token, orgSlug: roleOrg.slug }
+      );
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toMatch(/admin or owner access|admin access/i);
+    });
+  });
+
   // The pre-#438 "JSON-RPC -32001 Organization context required" error path
   // no longer exists — anonymous calls now get HTTP 401 with WWW-Authenticate
   // before they ever reach the org-context guard. That contract is covered

--- a/packages/server/src/mcp-handler.ts
+++ b/packages/server/src/mcp-handler.ts
@@ -466,6 +466,32 @@ async function resolveMembershipRole(
   return rows.length > 0 ? ((rows[0].role as string) ?? null) : null;
 }
 
+/**
+ * Populate `memberRole` for an authenticated SCOPED (`/mcp/{slug}`) session.
+ *
+ * `extractAuthContext` derives the org from the URL slug and the user from the
+ * token, but never looks up the caller's membership row — so a scoped session's
+ * `memberRole` is null even for a real owner/admin. The UNSCOPED path already
+ * resolves it via `resolveMembershipRole`; the scoped path historically skipped
+ * that, which made every role-gated action (e.g. `manage_catalog.list_installed`,
+ * which requires admin) wrongly deny legitimate members over `/mcp/{slug}`.
+ *
+ * Anonymous public-workspace browse (no userId) keeps a null role by design —
+ * `resolveMembershipRole` returns null for a null user, so this is a no-op there.
+ */
+async function hydrateScopedMemberRole(
+  env: Env,
+  authCtx: AuthContext
+): Promise<void> {
+  if (!authCtx.scopedToOrg || !authCtx.isAuthenticated) return;
+  if (!authCtx.organizationId || !authCtx.userId) return;
+  authCtx.memberRole = await resolveMembershipRole(
+    env,
+    authCtx.organizationId,
+    authCtx.userId
+  );
+}
+
 async function recoverSessionAuthContext(
   c: Context<{ Bindings: Env }>,
   sessionId: string
@@ -489,6 +515,9 @@ async function recoverSessionAuthContext(
     if (authCtx.organizationId !== persisted.organizationId) {
       return null;
     }
+    // Scoped sessions must resolve the caller's membership role too — otherwise
+    // role-gated actions deny a legitimate owner/admin over `/mcp/{slug}`.
+    await hydrateScopedMemberRole(c.env, authCtx);
   } else {
     authCtx.organizationId = persisted.organizationId;
     authCtx.memberRole = await resolveMembershipRole(
@@ -879,6 +908,10 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
             400
           );
         }
+        // `freshCtx` (scoped) carries a null memberRole — extractAuthContext
+        // never looks up membership — so resolve it before it reaches the
+        // role-gated tools, mirroring the unscoped branch below.
+        await hydrateScopedMemberRole(c.env, freshCtx);
         session.authCtx.memberRole = freshCtx.memberRole;
         session.authCtx.instructions = freshCtx.organizationId
           ? ((await buildWorkspaceInstructions(freshCtx.organizationId)) ?? undefined)
@@ -1016,6 +1049,10 @@ export async function handleMcp(c: Context<{ Bindings: Env }>): Promise<Response
     if (bindingError) {
       return buildJsonRpcErrorResponse(bindingError, initialize?.id ?? null, 400);
     }
+    // Resolve the caller's membership role for scoped `/mcp/{slug}` sessions
+    // before the session is created/persisted — extractAuthContext leaves it
+    // null, which would deny role-gated actions to a real owner/admin.
+    await hydrateScopedMemberRole(c.env, authCtx);
     await recordMcpClientActivity(c.env, authCtx, req, initialize);
     const { transport, server } = createSessionTransport(
       c.env,


### PR DESCRIPTION
## Why

Found during a live prod e2e of the MCP connector-discovery work: on the scoped `/mcp/{slug}` endpoint, `search_sdk`'s connector enrichment returned nothing for org `buremba` — while the unscoped `/mcp` path worked. Root cause turned out to be broader than discovery.

A scoped session derives its **org** from the URL slug and its **user** from the token, but the auth path **never looked up the caller's membership row**, so `memberRole` stayed `null` even for an owner/admin. Every role-gated action then denied a legitimate member over the scoped endpoint. The first thing to actually exercise `manage_catalog.list_installed` (admin-gated) over `/mcp/{slug}` — the connector enrichment — is what surfaced it, but the bug affects **all** role-gated actions on scoped sessions.

The unscoped `/mcp` path already resolved the role via `resolveMembershipRole`; the scoped path skipped it at all three sites (initial session creation, session restore, session refresh).

## What

Add `hydrateScopedMemberRole(env, authCtx)` — resolves `memberRole` for an authenticated scoped session — and call it at all three sites, mirroring the unscoped branch. Anonymous public-workspace browse keeps a null role by design (no `userId` → no-op).

The fix resolves the caller's **actual** role; it does not over-grant. An owner gets `owner`; a plain member gets `member` and is still denied admin-gated actions.

## Evidence (red → green)

- **Red (prod, live):** scoped `/mcp/buremba` owner PAT → `catalog.listInstalled` threw *"requires an MCP session with admin access"*; `search_sdk{query:"website"}` returned `match_count: 0`.
- **Green (local, fixed):** same scoped owner session → `catalog.listInstalled` allowed; `search_sdk{query:"website"}` → connector surfaced.
- **No over-grant:** a scoped **member** session is still denied the admin-gated action.
- Integration tests added in `mcp/auth.test.ts` for both cases; full `auth.test.ts` (40) and `session-recovery.test.ts` (5) pass. `make pre-pr` clean.

## Note

`manage_catalog.list_installed` requires **admin** access, so connector discovery via `search_sdk` works for owners/admins (the common case) but returns empty for plain members. Loosening that gate for read-only discovery is a separate policy decision, out of scope here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786662750&installation_id=136316292&pr_number=1953&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1953&signature=5b18167da1d6cf016181ea30f734cc95bb1e8f4a45e11b366faff677d6ca2661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->