### PR TITLE
test(sdk-e2e): live-verify conversations.send reply-poll path

### DIFF
--- a/scripts/sdk-e2e.sh
+++ b/scripts/sdk-e2e.sh
@@ -344,6 +344,23 @@ grep -qF "$MOCK_REPLY" "$CLIENT_OUT" \
   || { cat "$CLIENT_OUT" >&2; fail "@lobu/client stream did not return the agent reply '$MOCK_REPLY'"; }
 echo "✓ @lobu/client created a session, sent a message, and streamed the agent reply ($MOCK_REPLY)"
 
+# 5c) conversations.send (run_sdk) — prove the DURABLE reply-poll path end-to-end:
+#     client.conversations.send enqueues a platform:api turn (source=internal,
+#     headless), the worker runs it against the mock LLM, writes the terminal
+#     thread_response `runs` row, and readConversationReply reads finalText back —
+#     WITHOUT SSE. This is the ONLY live coverage of that path (unit tests mock
+#     the poll + queue). Assert status="complete" and reply === the mock reply.
+CSEND="$RUN_DIR/conversations-send.json"
+api run_sdk "$(node -e 'process.stdout.write(JSON.stringify({script:`export default async (ctx, client) => { const r = await client.conversations.send({ agent_id: "echo", text: "ping", timeout_ms: 90000 }); return { status: r.status, reply: r.reply, error: r.error }; }`, timeout_ms: 120000}))')" > "$CSEND" \
+  || { cat "$CSEND" >&2; fail "run_sdk conversations.send call failed at the tool layer"; }
+CSEND_STATUS="$(jget return_value.status < "$CSEND")"
+CSEND_REPLY="$(jget return_value.reply < "$CSEND")"
+[ "$CSEND_STATUS" = "complete" ] \
+  || { cat "$CSEND" >&2; fail "conversations.send did not complete (status='$CSEND_STATUS', reply='$CSEND_REPLY') — the reply-poll path (enqueue→worker→runs row→readConversationReply) did not close"; }
+[ "$CSEND_REPLY" = "$MOCK_REPLY" ] \
+  || { cat "$CSEND" >&2; fail "conversations.send returned reply='$CSEND_REPLY', expected '$MOCK_REPLY' (worker turn / finalText read mismatch)"; }
+echo "✓ conversations.send round-tripped the agent reply via the durable runs poll ($MOCK_REPLY)"
+
 # 6) Connector sync — prove the COMPILED connector actually RUNS and emits events.
 #    Find the feed manage_feeds created from the `pulse` connection, trigger an
 #    immediate sync, wait for the run to complete, then assert ≥1 event landed.


### PR DESCRIPTION
Closes the one owed verification for #1952: proves `conversations.send`'s durable reply-poll path end-to-end, live, and pins it as a permanent CI gate.

The sdk-e2e harness already boots a real gateway + worker + mock-LLM. This adds one assertion: `run_sdk` drives `client.conversations.send({ agent_id: "echo", text: "ping" })`, and the harness asserts `status === "complete"` with `reply === $MOCK_REPLY`. That exercises the whole chain — enqueue a `platform:api` / `source=internal` (headless) turn → the worker runs it → writes the terminal `thread_response` runs row → `readConversationReply` polls Postgres and reads `finalText` back — with **no SSE**. Unit tests only mock the poll + queue; this is the sole live coverage.

Verified locally (full harness green):

```
✓ conversations.send round-tripped the agent reply via the durable runs poll (SDK_E2E_OK)
✅ SDK lifecycle e2e PASSED
```

One-line-block change to `scripts/sdk-e2e.sh` (a shell gate; no TS surface). CI's own `sdk-e2e` job re-runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786665362&installation_id=136316292&pr_number=1954&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1954&signature=1fdc88e376c5702a71cd580470cb9ac618019087282ed911ca0a2acdb0bf71ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->