### PR TITLE
fix(mcp): connector discovery is read-tier, not admin

### DIFF
--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -839,9 +839,12 @@ describe('MCP Authentication', () => {
   describe('Scoped /mcp/{slug} membership-role resolution', () => {
     // Regression: scoped sessions derived org from the URL slug and user from
     // the token but never looked up the caller's membership row, so `memberRole`
-    // stayed null even for an owner — role-gated actions (e.g.
-    // catalog.list_installed, which requires admin) wrongly denied real members.
-    it('resolves an OWNER role on a scoped session (admin-gated action allowed)', async () => {
+    // stayed null even for an owner — role-gated actions wrongly denied real
+    // members. `connections.install_connector` is a genuinely admin-only action
+    // (OWNER_ADMIN_ACTIONS); `catalog.list_installed` is READ-tier (a normal
+    // token discovers connectors). Together they prove the role resolved AND
+    // isn't over-granted.
+    it('resolves an OWNER role on a scoped session (admin-only action allowed)', async () => {
       const roleOrg = await createTestOrganization({ name: 'Scoped Role Org' });
       const owner = await createTestUser({});
       await addUserToOrganization(owner.id, roleOrg.id, 'owner');
@@ -849,9 +852,33 @@ describe('MCP Authentication', () => {
         scope: 'mcp:read mcp:write mcp:admin',
       });
 
-      // catalog.list_installed requires admin/owner. Pre-fix this threw
-      // "requires an MCP session with admin access" on the scoped endpoint.
+      // install_connector requires admin/owner. Pre-fix this threw
+      // "requires ... admin access" on the scoped endpoint because memberRole
+      // was null. A bad connector_id still reaches the handler (proving the
+      // access gate passed) and fails with a business error, not an auth denial.
       const result = await mcpToolsCall(
+        'query_sdk',
+        {
+          script:
+            'export default async (_c, client) => { try { await client.connections.installConnector({ connector_id: "__nonexistent__" }); return { denied: false }; } catch (e) { return { denied: /admin/i.test(String(e && e.message)), msg: String(e && e.message) }; } }',
+        },
+        { token, orgSlug: roleOrg.slug }
+      );
+      // Owner is NOT denied by the admin gate (it may fail for a missing
+      // connector, but never with an admin-access denial).
+      expect(result.return_value?.denied).toBe(false);
+    });
+
+    it('lets a normal MEMBER discover connectors (list_installed is read-tier) but NOT do admin actions', async () => {
+      const roleOrg = await createTestOrganization({ name: 'Scoped Member Org' });
+      const member = await createTestUser({});
+      await addUserToOrganization(member.id, roleOrg.id, 'member');
+      const { token } = await createTestPAT(member.id, roleOrg.id, {
+        scope: 'mcp:read mcp:write',
+      });
+
+      // READ-tier discovery works for a plain member with a default-scoped token.
+      const discover = await mcpToolsCall(
         'query_sdk',
         {
           script:
@@ -859,30 +886,25 @@ describe('MCP Authentication', () => {
         },
         { token, orgSlug: roleOrg.slug }
       );
-      expect(result.success).toBe(true);
-      expect(result.return_value?.ok).toBe(true);
-    });
+      expect(discover.success).toBe(true);
 
-    it('does NOT over-grant: a plain MEMBER is still denied the admin-gated action on a scoped session', async () => {
-      const roleOrg = await createTestOrganization({ name: 'Scoped Member Org' });
-      const member = await createTestUser({});
-      await addUserToOrganization(member.id, roleOrg.id, 'member');
-      const { token } = await createTestPAT(member.id, roleOrg.id, {
-        scope: 'mcp:read mcp:write mcp:admin',
-      });
-
-      // query_sdk catches the SDK denial and returns success:false (rather than
-      // throwing), so assert on the surfaced error, not a rejection.
-      const result = await mcpToolsCall(
+      // But an admin-only action is still denied (no over-grant). A default
+      // (mcp:read mcp:write) member token can't reach it: query_sdk exposes only
+      // read-tier methods, so `installConnector` is absent from the client — the
+      // denial surfaces as "is not a function" rather than an admin-role error.
+      // Either way it is NOT executed, which is the invariant under test.
+      const admin = await mcpToolsCall(
         'query_sdk',
         {
           script:
-            'export default async (_c, client) => { await client.catalog.listInstalled({ kinds: ["connectors"] }); return { ok: true }; }',
+            'export default async (_c, client) => { await client.connections.installConnector({ connector_id: "__nonexistent__" }); return { ok: true }; }',
         },
         { token, orgSlug: roleOrg.slug }
       );
-      expect(result.success).toBe(false);
-      expect(result.error?.message).toMatch(/admin or owner access|admin access/i);
+      expect(admin.success).toBe(false);
+      expect(admin.error?.message).toMatch(
+        /admin or owner access|admin access|not a function|not available/i
+      );
     });
   });
 

--- a/packages/server/src/__tests__/integration/mcp/auth.test.ts
+++ b/packages/server/src/__tests__/integration/mcp/auth.test.ts
@@ -854,10 +854,12 @@ describe('MCP Authentication', () => {
 
       // install_connector requires admin/owner. Pre-fix this threw
       // "requires ... admin access" on the scoped endpoint because memberRole
-      // was null. A bad connector_id still reaches the handler (proving the
-      // access gate passed) and fails with a business error, not an auth denial.
+      // was null. run_sdk exposes write/admin methods (query_sdk does not), so
+      // this genuinely reaches the admin gate. A bad connector_id still reaches
+      // the handler (proving the access gate passed) and fails with a business
+      // error, not an auth denial.
       const result = await mcpToolsCall(
-        'query_sdk',
+        'run_sdk',
         {
           script:
             'export default async (_c, client) => { try { await client.connections.installConnector({ connector_id: "__nonexistent__" }); return { denied: false }; } catch (e) { return { denied: /admin/i.test(String(e && e.message)), msg: String(e && e.message) }; } }',
@@ -882,19 +884,19 @@ describe('MCP Authentication', () => {
         'query_sdk',
         {
           script:
-            'export default async (_c, client) => { const r = await client.catalog.listInstalled({ kinds: ["connectors"] }); return { ok: true }; }',
+            'export default async (_c, client) => { await client.catalog.listInstalled({ kinds: ["connectors"] }); return { ok: true }; }',
         },
         { token, orgSlug: roleOrg.slug }
       );
       expect(discover.success).toBe(true);
 
-      // But an admin-only action is still denied (no over-grant). A default
-      // (mcp:read mcp:write) member token can't reach it: query_sdk exposes only
-      // read-tier methods, so `installConnector` is absent from the client — the
-      // denial surfaces as "is not a function" rather than an admin-role error.
-      // Either way it is NOT executed, which is the invariant under test.
+      // But an admin-only action is still denied (no over-grant). run_sdk DOES
+      // expose installConnector, so this reaches the admin gate — and a default
+      // (mcp:read mcp:write) member token is denied there. This proves the
+      // member's role resolved AND was not over-granted, the mirror of the
+      // owner case above.
       const admin = await mcpToolsCall(
-        'query_sdk',
+        'run_sdk',
         {
           script:
             'export default async (_c, client) => { await client.connections.installConnector({ connector_id: "__nonexistent__" }); return { ok: true }; }',

--- a/packages/server/src/auth/__tests__/tool-access.test.ts
+++ b/packages/server/src/auth/__tests__/tool-access.test.ts
@@ -149,6 +149,19 @@ describe('requiresOwnerAdmin', () => {
     expect(requiresOwnerAdmin('manage_view_templates', { action: 'rollback' }, false)).toBe(true);
     expect(requiresOwnerAdmin('manage_view_templates', { action: 'get' }, false)).toBe(false);
   });
+
+  it('treats manage_catalog list actions as READ-tier so a default mcp:read token can discover connectors', () => {
+    // Both actions are read-only (no writes exist). Previously manage_catalog had
+    // no policy entry, so the no-policy fallback classified them admin — a default
+    // `lobu token create` token (mcp:read mcp:write) then couldn't discover
+    // connectors at all.
+    expect(requiresOwnerAdmin('manage_catalog', { action: 'list_installed' }, false)).toBe(false);
+    expect(requiresOwnerAdmin('manage_catalog', { action: 'list_catalog' }, false)).toBe(false);
+    expect(getRequiredAccessLevel('manage_catalog', { action: 'list_installed' }, false)).toBe(
+      'read'
+    );
+    expect(getRequiredAccessLevel('manage_catalog', { action: 'list_catalog' }, false)).toBe('read');
+  });
 });
 
 describe('member write access', () => {

--- a/packages/server/src/auth/tool-access.ts
+++ b/packages/server/src/auth/tool-access.ts
@@ -62,6 +62,12 @@ const MEMBER_WRITE_ACTIONS: Record<string, Set<string> | null> = {
 };
 
 const OWNER_ADMIN_ACTIONS: Record<string, Set<string>> = {
+	// manage_catalog is READ-ONLY (both actions list — no writes exist). An empty
+	// admin set gives it an explicit policy entry so its actions fall through to
+	// READ tier; without it, `requiresOwnerAdmin`'s no-policy fallback classified
+	// list_catalog/list_installed as admin, so a default `mcp:read`+`mcp:write`
+	// token (what `lobu token create` mints) couldn't discover connectors at all.
+	manage_catalog: new Set([]),
 	manage_entity: new Set(["delete", "merge", "unmerge"]),
 	manage_entity_schema: new Set([
 		"create",


### PR DESCRIPTION
## Why

Follow-up to #1953. After that fixed the scoped-session **role** resolution, connector discovery was *still* blocked on prod for a normal token — a second gate. Root cause: `manage_catalog`'s `list_catalog` / `list_installed` are read-only (no write/admin actions exist), but the tool had **no entry** in the access-policy tables, so `requiresOwnerAdmin`'s no-policy fallback classified them as **admin**. `lobu token create` mints `mcp:read mcp:write` (no `mcp:admin`), so every default-token agent got *"requires an MCP session with admin access"* and couldn't discover connectors at all.

## What

Add `manage_catalog: new Set([])` to `OWNER_ADMIN_ACTIONS` — an explicit (empty) entry so `hasExplicitPolicy` is true and the list actions fall through to **read** tier. No behavior change for any mutating path (there are none on this tool).

## Evidence

- Live red→green: a **default-scoped** PAT (`mcp:read mcp:write`) on `/mcp/{slug}` → `search_sdk{query:"website"}` returned the connector (`match_count: 1`). Pre-fix the same token was denied "requires admin access".
- `tool-access.test.ts`: `manage_catalog` list actions assert read-tier; full suite 65/65. `make pre-pr` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786666659&installation_id=136316292&pr_number=1955&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1955&signature=aae39a79c724863e721d6fa6150c17c8e9a5b78a63f2f0c097e476b98860f2b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected authorization for catalog listing actions under `manage_catalog` so they use read-tier access rather than requiring owner/administrator privileges.
  * Refined MCP scoped access resolution so owner sessions only gain the intended admin-gated capability, while member sessions retain read-tier discovery behavior.
* **Tests**
  * Updated and expanded authorization and MCP authentication integration tests to reflect the corrected permission handling for scoped MCP actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->