### PR TITLE
feat(server): one TypeBox-sourced OpenAPI document for the typed client

### DIFF
--- a/config/knip.ts
+++ b/config/knip.ts
@@ -85,8 +85,10 @@ const config: KnipConfig = {
         // Test suites run in CI (vitest + bun:test).
         "src/**/*.test.ts",
         "src/**/__tests__/**/*.ts",
-        // esbuild bundler invoked as `node scripts/build-server-bundle.mjs`.
+        // esbuild bundler invoked as `node scripts/build-server-bundle.mjs`,
+        // plus standalone `bun scripts/*.ts` helpers (offline OpenAPI emit).
         "scripts/**/*.mjs",
+        "scripts/**/*.ts",
       ],
       ignoreDependencies: [
         // Activated by `vitest --coverage`.

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,3 +1,8 @@
+import type {
+  PostApiV1AgentsData,
+  PostApiV1AgentsResponses,
+} from "./generated/types.gen.js";
+
 export type TokenProvider = string | (() => string | Promise<string>);
 
 export type LobuFetch = typeof fetch;
@@ -13,41 +18,18 @@ export interface LobuClientOptions {
   headers?: LobuHeaders;
 }
 
-export interface CreateSessionRequest {
-  agentId?: string;
-  userId?: string;
-  thread?: string;
-  provider?: string;
-  model?: string;
-  forceNew?: boolean;
-  dryRun?: boolean;
-  /**
-   * Server-trusted: the worker's egress allowlist/blocklist. Mint sessions
-   * **server-side** — do not let an untrusted browser pick its own network
-   * policy.
-   */
-  networkConfig?: {
-    allowedDomains?: string[];
-    deniedDomains?: string[];
-  };
-  /**
-   * Server-trusted: nix packages provisioned into the worker runtime. Mint
-   * sessions **server-side** — do not let an untrusted browser pick packages.
-   */
-  nix?: {
-    flakeUrl?: string;
-    packages?: string[];
-  };
-}
+/**
+ * Body for `POST /api/v1/agents`. Sourced from the generated OpenAPI types so it
+ * stays in lockstep with the server's route schema — do NOT re-declare it here
+ * (the previous hand-written twin had already drifted, missing `intent`).
+ *
+ * `networkConfig` and `nix` are server-trusted: mint sessions **server-side** —
+ * never let an untrusted browser pick its own egress policy or runtime packages.
+ */
+export type CreateSessionRequest = NonNullable<PostApiV1AgentsData["body"]>;
 
-export interface CreateSessionResponse {
-  success: boolean;
-  agentId: string;
-  token: string;
-  expiresAt: number;
-  sseUrl: string;
-  messagesUrl: string;
-}
+/** `201` response of `POST /api/v1/agents`, from the generated OpenAPI types. */
+export type CreateSessionResponse = PostApiV1AgentsResponses[201];
 
 export interface SendMessageOptions {
   messageId?: string;

--- a/packages/server/scripts/emit-openapi.ts
+++ b/packages/server/scripts/emit-openapi.ts
@@ -1,0 +1,28 @@
+/**
+ * Emit the strict dispatch-tool OpenAPI paths to a standalone document.
+ *
+ * The full client-facing document (gateway routes + these tool paths) is served
+ * live at `GET /lobu/api/docs/openapi.json` and is what `@lobu/client` is
+ * generated from. This script emits ONLY the tool surface — no running server or
+ * database required — so the domain half of the contract can be inspected,
+ * diffed, or fed to `openapi-ts` offline.
+ *
+ * Usage: bun packages/server/scripts/emit-openapi.ts [outfile]
+ */
+import { writeFileSync } from "node:fs";
+import { generateStrictToolPaths } from "../src/utils/openapi-generator";
+
+const doc = {
+	openapi: "3.1.0",
+	info: {
+		title: "Lobu API — dispatch tools",
+		version: "1.0.0",
+		description:
+			"Strict projection of the dispatch-tool surface (POST /api/{orgSlug}/{tool}) from the server's TypeBox schemas.",
+	},
+	servers: [{ url: "http://localhost:8787", description: "Local development" }],
+	paths: generateStrictToolPaths(),
+};
+
+const out = process.argv[2] ?? "/dev/stdout";
+writeFileSync(out, `${JSON.stringify(doc, null, 2)}\n`);

--- a/packages/server/src/__tests__/unit/utils/openapi-strict.test.ts
+++ b/packages/server/src/__tests__/unit/utils/openapi-strict.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { RawDispatchTool } from "../../../tools/registry";
 import { getRawDispatchTools } from "../../../tools/registry";
 import { generateStrictToolPaths } from "../../../utils/openapi-generator";
 
@@ -9,8 +10,17 @@ import { generateStrictToolPaths } from "../../../utils/openapi-generator";
  * server-internal input fields never reach the client.
  */
 describe("generateStrictToolPaths", () => {
-	const paths = generateStrictToolPaths();
-	const tools = getRawDispatchTools();
+	// Compute in `beforeAll`, NOT at describe-body evaluation: walking the tool
+	// registry at module-load time races the registry's own circular-import
+	// initialization (ALL_DISPATCH_TOOLS is still in its TDZ), which throws and
+	// poisons the shared module for other suites. Production only ever calls these
+	// at request time, well after modules settle.
+	let paths: Record<string, any>;
+	let tools: RawDispatchTool[];
+	beforeAll(() => {
+		paths = generateStrictToolPaths();
+		tools = getRawDispatchTools();
+	});
 
 	it("emits one POST /api/{orgSlug}/<tool> path per dispatch tool", () => {
 		const emitted = Object.keys(paths).sort();

--- a/packages/server/src/__tests__/unit/utils/openapi-strict.test.ts
+++ b/packages/server/src/__tests__/unit/utils/openapi-strict.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { getRawDispatchTools } from "../../../tools/registry";
+import { generateStrictToolPaths } from "../../../utils/openapi-generator";
+
+/**
+ * The strict projection is the single TypeBox source rendered for the typed
+ * first-party client. These guards keep it faithful: every dispatch tool gets a
+ * path, output schemas survive, discriminated unions are NOT flattened, and
+ * server-internal input fields never reach the client.
+ */
+describe("generateStrictToolPaths", () => {
+	const paths = generateStrictToolPaths();
+	const tools = getRawDispatchTools();
+
+	it("emits one POST /api/{orgSlug}/<tool> path per dispatch tool", () => {
+		const emitted = Object.keys(paths).sort();
+		const expected = tools.map((t) => `/api/{orgSlug}/${t.name}`).sort();
+		expect(emitted).toEqual(expected);
+		for (const [path, ops] of Object.entries(paths)) {
+			expect(path).toMatch(/^\/api\/\{orgSlug\}\//);
+			expect(ops.post).toBeDefined();
+			expect(ops.post.operationId).toBe(path.split("/").pop());
+			const orgParam = ops.post.parameters?.[0];
+			expect(orgParam?.name).toBe("orgSlug");
+			expect(orgParam?.in).toBe("path");
+			expect(orgParam?.required).toBe(true);
+		}
+	});
+
+	it("renders each tool's real output schema as the 200 response", () => {
+		for (const tool of tools) {
+			if (!tool.outputSchema) continue;
+			const schema =
+				paths[`/api/{orgSlug}/${tool.name}`].post.responses["200"].content[
+					"application/json"
+				].schema;
+			// Not the permissive `{ additionalProperties: true }` fallback: a real
+			// TypeBox result carries structure (object properties or a union).
+			const hasShape =
+				schema.anyOf !== undefined ||
+				schema.oneOf !== undefined ||
+				schema.properties !== undefined;
+			expect(hasShape, `${tool.name} 200 should carry a typed shape`).toBe(
+				true,
+			);
+		}
+	});
+
+	it("preserves discriminated-union request bodies (no flattening)", () => {
+		// manage_connections is a Type.Union of per-action variants; the strict
+		// projection must keep the union so hey-api emits a discriminated type.
+		const body =
+			paths["/api/{orgSlug}/manage_connections"].post.requestBody.content[
+				"application/json"
+			].schema;
+		expect(body.anyOf ?? body.oneOf, "union must survive").toBeDefined();
+	});
+
+	it("drops server-internal input fields via the public schema", () => {
+		const body =
+			paths["/api/{orgSlug}/search_memory"].post.requestBody.content[
+				"application/json"
+			].schema;
+		expect(body.properties?.query_embedding).toBeUndefined();
+		expect(body.properties?.agent_id).toBeUndefined();
+	});
+
+	it("strips TypeBox internal $id/static keys", () => {
+		const json = JSON.stringify(paths);
+		expect(json).not.toContain('"$id"');
+		expect(json).not.toContain('"static"');
+	});
+});

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -24,6 +24,7 @@ import { createImageRoutes } from "../routes/internal/images.js";
 import { createInteractionRoutes } from "../routes/internal/interactions.js";
 import { createRuntimeRoutes } from "../routes/internal/runtime.js";
 import { registerAutoOpenApiRoutes } from "../routes/openapi-auto.js";
+import { generateStrictToolPaths } from "../../utils/openapi-generator.js";
 import { createAgentApi } from "../routes/public/agent.js";
 import { createAgentConfigRoutes } from "../routes/public/agent-config.js";
 import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
@@ -797,8 +798,8 @@ export function createGatewayApp(
 
   registerAutoOpenApiRoutes(app);
 
-  app.doc("/api/docs/openapi.json", {
-    openapi: "3.0.0",
+  const openApiDocConfig = {
+    openapi: "3.1.0",
     info: {
       title: "Lobu API",
       version: "1.0.0",
@@ -876,6 +877,23 @@ curl -X POST http://localhost:8787/api/v1/agents/{agentId}/messages \\
     servers: [
       { url: "http://localhost:8787", description: "Local development" },
     ],
+  };
+
+  // One merged OpenAPI document: the gateway's Zod routes (agent-session
+  // orchestration) PLUS the full dispatch-tool surface
+  // (`POST /api/{orgSlug}/{tool}` — entities, watchers, feeds, metrics, …),
+  // generated from the same TypeBox schemas the server validates against. The
+  // first-party `@lobu/client` is generated from THIS single document, so the
+  // CLI and UI get a typed client for BOTH surfaces instead of only agent
+  // sessions. `getOpenAPI31Document` renders the Zod routes in the same JSON
+  // Schema 2020-12 dialect the TypeBox tool schemas already use.
+  app.get("/api/docs/openapi.json", (c) => {
+    const base = app.getOpenAPI31Document(openApiDocConfig);
+    const toolPaths = generateStrictToolPaths();
+    return c.json({
+      ...base,
+      paths: { ...toolPaths, ...(base.paths ?? {}) },
+    });
   });
 
   app.get(

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -24,7 +24,6 @@ import { createImageRoutes } from "../routes/internal/images.js";
 import { createInteractionRoutes } from "../routes/internal/interactions.js";
 import { createRuntimeRoutes } from "../routes/internal/runtime.js";
 import { registerAutoOpenApiRoutes } from "../routes/openapi-auto.js";
-import { generateStrictToolPaths } from "../../utils/openapi-generator.js";
 import { createAgentApi } from "../routes/public/agent.js";
 import { createAgentConfigRoutes } from "../routes/public/agent-config.js";
 import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
@@ -887,7 +886,16 @@ curl -X POST http://localhost:8787/api/v1/agents/{agentId}/messages \\
   // CLI and UI get a typed client for BOTH surfaces instead of only agent
   // sessions. `getOpenAPI31Document` renders the Zod routes in the same JSON
   // Schema 2020-12 dialect the TypeBox tool schemas already use.
-  app.get("/api/docs/openapi.json", (c) => {
+  app.get("/api/docs/openapi.json", async (c) => {
+    // Dynamic import (rationale): a static `gateway → openapi-generator →
+    // registry` edge closes a circular-init cycle with the tool registry's admin
+    // deps, throwing a TDZ error during module load under some import orders.
+    // This docs endpoint is cold and low-traffic, and by request time every
+    // module is already loaded, so `import()` resolves from cache with no
+    // measurable cost — while keeping the cycle out of the static graph.
+    const { generateStrictToolPaths } = await import(
+      "../../utils/openapi-generator.js"
+    );
     const base = app.getOpenAPI31Document(openApiDocConfig);
     const toolPaths = generateStrictToolPaths();
     return c.json({

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -482,6 +482,44 @@ export function getAllTools(options?: ListedToolOptions) {
   );
 }
 
+export interface RawDispatchTool {
+  name: string;
+  description: string;
+  /** Original TypeBox input schema — discriminated union preserved (NOT flattened). */
+  inputSchema: any;
+  /** Original TypeBox output schema when the tool declares one. */
+  outputSchema?: any;
+  annotations?: ToolAnnotations;
+  /** True for admin/first-party dispatch tools hidden from MCP `tools/list`. */
+  internal: boolean;
+}
+
+/**
+ * Every dispatch tool with its RAW TypeBox input/output schemas, unflattened.
+ *
+ * `getAllTools`/`getMcpTools` return the MCP-listing projection: discriminated
+ * unions are collapsed by `flattenUnionSchema` (Claude/ChatGPT reject top-level
+ * `anyOf`) and per-action required fields are demoted to prose. The typed REST
+ * client has no such constraint — hey-api turns an `anyOf` of action variants
+ * into a precise discriminated-union type — so the strict OpenAPI document is
+ * built from these raw definitions to keep full per-action fidelity. One
+ * TypeBox source, two projections: flattened for MCP, faithful for the client.
+ */
+export function getRawDispatchTools(): RawDispatchTool[] {
+  return ALL_DISPATCH_TOOLS.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    // Prefer the narrower public schema (same choice as the MCP listing): it
+    // drops server-internal fields a client must never send (e.g. search_memory's
+    // pre-computed `query_embedding` and auth-bound `agent_id`). Unflattened,
+    // unlike the MCP projection.
+    inputSchema: tool.publicInputSchema ?? tool.inputSchema,
+    ...(tool.outputSchema && { outputSchema: tool.outputSchema }),
+    ...(tool.annotations && { annotations: tool.annotations }),
+    internal: INTERNAL_TOOL_NAMES.has(tool.name),
+  }));
+}
+
 function getListedTools(
   source: ToolDefinition[],
   options?: ListedToolOptions,

--- a/packages/server/src/utils/openapi-generator.ts
+++ b/packages/server/src/utils/openapi-generator.ts
@@ -4,7 +4,7 @@
  * Dynamically generates OpenAPI specification from tool registry TypeBox schemas
  */
 
-import { getMcpTools } from '../tools/registry';
+import { getMcpTools, getRawDispatchTools } from '../tools/registry';
 
 /**
  * Recursively deep copies schema properties while filtering out hidden ones
@@ -259,4 +259,108 @@ export function generateOpenAPISpec(serverUrl: string) {
     ],
     paths,
   };
+}
+
+// ============================================
+// Strict projection (typed first-party client)
+// ============================================
+//
+// The ChatGPT projection above is deliberately lossy: it flattens discriminated
+// unions, forces `additionalProperties: true`, and drops output schemas — all to
+// satisfy ChatGPT's OpenAPI validator. The generated first-party `@lobu/client`
+// has no such constraints, so it is generated from THIS projection, which keeps
+// each tool's TypeBox schema verbatim (discriminated unions intact) and emits the
+// real `outputSchema` as the 200 response. TypeBox serializes to JSON Schema
+// 2020-12, which IS the OpenAPI 3.1 schema dialect, so the schemas drop in with
+// no conversion. One TypeBox source, two projections — no hand-maintained spec.
+
+/**
+ * Recursively deep-copies a schema while dropping any property marked
+ * `x-hidden` at every object level (server-internal fields — pre-computed
+ * embeddings, auth-bound filters — that must never reach a client), and
+ * pruning them from each `required` array so the copy stays self-consistent.
+ */
+function deepCopyStrict(schema: any): any {
+  if (schema === null || schema === undefined || typeof schema !== 'object') {
+    return schema;
+  }
+  if (Array.isArray(schema)) {
+    return schema.map(deepCopyStrict);
+  }
+  const copied: Record<string, any> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === '$id' || key === 'static') continue;
+    if (key === 'properties' && value && typeof value === 'object') {
+      const props: Record<string, any> = {};
+      for (const [propKey, propVal] of Object.entries<any>(value)) {
+        if (propVal?.['x-hidden']) continue;
+        props[propKey] = deepCopyStrict(propVal);
+      }
+      copied[key] = props;
+      continue;
+    }
+    copied[key] = deepCopyStrict(value);
+  }
+  // Prune now-hidden keys out of `required` so we never require a dropped field.
+  if (Array.isArray(copied.required) && copied.properties) {
+    copied.required = copied.required.filter((k: string) => k in copied.properties);
+  }
+  return copied;
+}
+
+const ERROR_RESPONSE = {
+  content: {
+    'application/json': {
+      schema: { type: 'object', properties: { error: { type: 'string' } } },
+    },
+  },
+} as const;
+
+/**
+ * OpenAPI `paths` for the whole dispatch-tool surface (`POST /api/{orgSlug}/{tool}`),
+ * with faithful TypeBox input/output schemas. Merged into the gateway document so the
+ * generated client covers domain data (entities, watchers, feeds, metrics, …) — not
+ * only agent-session orchestration.
+ */
+export function generateStrictToolPaths(): Record<string, any> {
+  const paths: Record<string, any> = {};
+
+  for (const tool of getRawDispatchTools()) {
+    const path = `/api/{orgSlug}/${tool.name}`;
+    const responseSchema = tool.outputSchema
+      ? deepCopyStrict(tool.outputSchema)
+      : { type: 'object', additionalProperties: true };
+
+    paths[path] = {
+      post: {
+        summary: tool.description.split('.')[0],
+        description: truncateDescription(tool.description, 300),
+        operationId: tool.name,
+        ...(tool.internal && { 'x-internal': true }),
+        parameters: [
+          {
+            name: 'orgSlug',
+            in: 'path',
+            required: true,
+            description: 'Organization slug (workspace identifier)',
+            schema: { type: 'string' },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: { 'application/json': { schema: deepCopyStrict(tool.inputSchema) } },
+        },
+        responses: {
+          '200': {
+            description: 'Successful response',
+            content: { 'application/json': { schema: responseSchema } },
+          },
+          '400': { description: 'Bad request - invalid parameters', ...ERROR_RESPONSE },
+          '404': { description: 'Tool not found', ...ERROR_RESPONSE },
+        },
+      },
+    };
+  }
+
+  return paths;
 }


### PR DESCRIPTION
## Summary
- The generated `@lobu/client` was built from the gateway's Zod OpenAPI doc, which only models agent-session orchestration — the entire domain surface (entities, watchers, feeds, metrics, operations, connections, …) was reachable only through the untyped `POST /api/{orgSlug}/{tool}` proxy, so the client (and CLI + UI) had no typed methods for it and most responses generated as `unknown`.
- The tools already carry full TypeBox **input and result** schemas (validated at runtime via `validate-args`). This projects that same source faithfully (unflattened unions, real 200 schemas) and merges it into the gateway document, so **one** OpenAPI doc now describes both surfaces — one TypeBox source, no hand-written spec, no duplication.
- Also de-dups `client/src/types.ts`: `CreateSessionRequest`/`Response` now alias the generated `PostApiV1Agents*` types (restores the drifted `intent` field).

Part of the "consolidate on TypeBox, no duplication, layer everything" effort. Follow-up work that needs a DB-backed env is tracked in #1956.

## Test plan
- [x] `bun run check:fix` clean (pre-commit hook, biome across all 470 files)
- [x] `bun run typecheck` passes — `packages/server` and `packages/client` both 0 errors; `make build-packages` succeeds
- [x] New unit test `openapi-strict.test.ts` (5 tests) + `tool-registry-split.test.ts` pass; `knip --include files` clean
- [x] Verified with `@hey-api/openapi-ts`: domain tools now generate typed methods (`manageEntity`, `manageWatchers`, …) with typed 200 bodies instead of `unknown`; `getOpenAPI31Document` + merge smoke-tested against the real `@hono/zod-openapi` (28 paths, both route families, gateway responses typed)
- [ ] **Integration suite (`make test-integration`) — NOT run in the authoring env (no Postgres/pgvector); relying on CI.** The one runtime-behavior change is the merged-doc endpoint switching `app.doc` → `getOpenAPI31Document`; the doc endpoint is exercised by CI.

## Notes
- Regenerating the committed `packages/client/src/generated/**` requires a running server (`bun --cwd packages/client generate` against `/lobu/api/docs/openapi.json`) and is tracked as Task A in #1956 — this PR is the source change; the generated artifact refreshes downstream.
- Offline spec emit for inspection: `bun packages/server/scripts/emit-openapi.ts`.
- The lossy ChatGPT `/openapi.json` projection is intentionally untouched.
- Relates to #1956.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXyLTtWeBMm5QYPeKUL6vk)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786667955&installation_id=136316292&pr_number=1957&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1957&signature=561d0f2ffda9daa27a06ad352af477a187222fa49d0608fbdb331cc2b6f2ddc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->