### PR TITLE
docs(sdk): teach the two-hop entity create/link pattern in search_sdk

### DIFF
--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -135,6 +135,15 @@ describe("method-metadata", () => {
 		const create = METHOD_METADATA["entities.create"];
 		expect(create.summary).toContain("entitySchema.createType");
 		expect(create.usageExample ?? "").toContain("entitySchema.createType");
+		// The documented error contract must be REAL: run_sdk surfaces the
+		// unknown-type ToolUserError as a ValidationError. `EntityTypeNotFound`
+		// is not a public error — recovery keyed to it could never fire.
+		expect(create.throws ?? []).toContain("ValidationError");
+		expect(create.throws ?? []).not.toContain("EntityTypeNotFound");
+		expect(create.summary).not.toContain("EntityTypeNotFound");
+		// The ensure step tolerates only the coded duplicate 409 (multi-replica
+		// race), so a concurrent caller doesn't abort the advertised flow.
+		expect(create.usageExample ?? "").toContain("entity_type_exists");
 
 		// entities.link must name entitySchema.createRelType as the relationship-
 		// type constructor. addRule does NOT create a type (it only restricts the
@@ -152,5 +161,8 @@ describe("method-metadata", () => {
 		expect(linkExample).toContain("listRelTypes");
 		expect(linkExample).toContain("createRelType");
 		expect(linkExample).toContain("entities.link");
+		// Same multi-replica race safety as entities.create: tolerate only the
+		// coded relationship_type_exists 409, don't swallow every error.
+		expect(linkExample).toContain("relationship_type_exists");
 	});
 });

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -145,5 +145,12 @@ describe("method-metadata", () => {
 		expect(link.summary).not.toMatch(
 			/call `?entitySchema\.addRule`? first|addRule.*\(or createRelType\)/
 		);
+		// The copy-paste usage example must embody the full two-hop flow (ensure
+		// the rel-type, then link) — not just mention it — so a pasted example
+		// can't reproduce the missing-type stall it's meant to prevent.
+		const linkExample = link.usageExample ?? "";
+		expect(linkExample).toContain("listRelTypes");
+		expect(linkExample).toContain("createRelType");
+		expect(linkExample).toContain("entities.link");
 	});
 });

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -128,4 +128,22 @@ describe("method-metadata", () => {
 			expect(METHOD_METADATA[path]?.example, path).toMatch(/\(\{/);
 		}
 	});
+
+	it("teaches the two-hop create-type-first pattern with the right constructors", () => {
+		// entities.create must point at entitySchema.createType (the type must
+		// exist first) — the multi-step precondition agents otherwise miss.
+		const create = METHOD_METADATA["entities.create"];
+		expect(create.summary).toContain("entitySchema.createType");
+		expect(create.usageExample ?? "").toContain("entitySchema.createType");
+
+		// entities.link must name entitySchema.createRelType as the relationship-
+		// type constructor. addRule does NOT create a type (it only restricts the
+		// allowed source/target pairs), so it must never be presented as the
+		// constructor — that was a factual error the guidance is meant to prevent.
+		const link = METHOD_METADATA["entities.link"];
+		expect(link.summary).toContain("entitySchema.createRelType");
+		expect(link.summary).not.toMatch(
+			/call `?entitySchema\.addRule`? first|addRule.*\(or createRelType\)/
+		);
+	});
 });

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -125,9 +125,15 @@ export default async (_ctx, client) => {
 		access: "write",
 		example:
 			"await client.entities.link({ from_entity_id: 42, to_entity_id: 43, relationship_type_slug: 'customer_of' });",
-		usageExample: `// Link two entities by id. Resolve the ids first (entities.list / .get),
-// and make sure the relationship_type_slug exists (entitySchema.listRelTypes).
+		usageExample: `// Two-hop: the relationship TYPE must exist before linking. Ensure it
+// (entitySchema.listRelTypes → createRelType), then resolve the two entity
+// ids (entities.list / .get) and link. createRelType is idempotent-safe here
+// because we only create when it is absent.
 export default async (_ctx, client) => {
+  const { relationship_types } = await client.entitySchema.listRelTypes();
+  if (!relationship_types.some((t) => t.slug === 'works_at')) {
+    await client.entitySchema.createRelType({ slug: 'works_at', name: 'Works at' });
+  }
   const { entities: companies } = await client.entities.list({ entity_type: 'company', search: 'Acme' });
   const { entities: people } = await client.entities.list({ entity_type: 'person', search: 'Jane' });
   return client.entities.link({

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -121,7 +121,7 @@ export default async (_ctx, client) => {
 	},
 	"entities.link": {
 		summary:
-			"Create a relationship between two entities. Needs the two entity IDs AND a relationship TYPE that already exists — if the relationship type is new, call `entitySchema.addRule` (or createRelType) first; list existing ones with `entitySchema.listRelTypes()`.",
+			"Create a relationship between two entities. Needs the two entity IDs AND a relationship TYPE that already exists — if the relationship type is new, call `entitySchema.createRelType` first; list existing ones with `entitySchema.listRelTypes()`. (`entitySchema.addRule` does NOT create a type; it restricts the allowed source/target entity-type pairs on a type that already exists.)",
 		access: "write",
 		example:
 			"await client.entities.link({ from_entity_id: 42, to_entity_id: 43, relationship_type_slug: 'customer_of' });",

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -86,11 +86,28 @@ export default async (_ctx, client) => {
 	},
 	"entities.create": {
 		summary:
-			"Create an entity with metadata validated against the entity type schema.",
+			"Create an entity of a given type. The entity TYPE must exist first — if the type is new to this workspace, call `entitySchema.createType` before this (otherwise it throws EntityTypeNotFound). Check `entitySchema.listTypes()` for existing types.",
 		access: "write",
 		throws: ["EntityTypeNotFound", "ValidationError"],
 		example:
 			"await client.entities.create({ type: 'company', name: 'Acme', metadata: {} });",
+		usageExample: `// Two-hop: ensure the entity type exists, THEN create the entity.
+// A first-of-its-kind type must be created before any entity of it.
+export default async (_ctx, client) => {
+  const { entity_types } = await client.entitySchema.listTypes();
+  if (!entity_types.some((t) => t.slug === 'company')) {
+    await client.entitySchema.createType({
+      slug: 'company',
+      name: 'Company',
+      metadata_schema: { type: 'object', properties: { team_size: { type: 'number' } } },
+    });
+  }
+  return client.entities.create({
+    type: 'company',
+    name: 'Acme',
+    metadata: { team_size: 50 },
+  });
+};`,
 	},
 	"entities.update": {
 		summary: "Update an existing entity.",
@@ -103,10 +120,22 @@ export default async (_ctx, client) => {
 			"await client.entities.delete({ entity_id: 42, force_delete_tree: true });",
 	},
 	"entities.link": {
-		summary: "Create a relationship between two entities.",
+		summary:
+			"Create a relationship between two entities. Needs the two entity IDs AND a relationship TYPE that already exists — if the relationship type is new, call `entitySchema.addRule` (or createRelType) first; list existing ones with `entitySchema.listRelTypes()`.",
 		access: "write",
 		example:
 			"await client.entities.link({ from_entity_id: 42, to_entity_id: 43, relationship_type_slug: 'customer_of' });",
+		usageExample: `// Link two entities by id. Resolve the ids first (entities.list / .get),
+// and make sure the relationship_type_slug exists (entitySchema.listRelTypes).
+export default async (_ctx, client) => {
+  const { entities: companies } = await client.entities.list({ entity_type: 'company', search: 'Acme' });
+  const { entities: people } = await client.entities.list({ entity_type: 'person', search: 'Jane' });
+  return client.entities.link({
+    from_entity_id: people[0].id,
+    to_entity_id: companies[0].id,
+    relationship_type_slug: 'works_at',
+  });
+};`,
 	},
 	"entities.unlink": {
 		summary: "Soft-delete an entity relationship.",

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -86,9 +86,9 @@ export default async (_ctx, client) => {
 	},
 	"entities.create": {
 		summary:
-			"Create an entity of a given type. The entity TYPE must exist first — if the type is new to this workspace, call `entitySchema.createType` before this (otherwise it throws EntityTypeNotFound). Check `entitySchema.listTypes()` for existing types.",
+			"Create an entity of a given type. The entity TYPE must exist first — if the type is new to this workspace, call `entitySchema.createType` before this (an unknown type fails with \"Unknown entity type '<slug>'\", surfaced as a ValidationError). Check `entitySchema.listTypes()` for existing types.",
 		access: "write",
-		throws: ["EntityTypeNotFound", "ValidationError"],
+		throws: ["ValidationError"],
 		example:
 			"await client.entities.create({ type: 'company', name: 'Acme', metadata: {} });",
 		usageExample: `// Two-hop: ensure the entity type exists, THEN create the entity.
@@ -96,11 +96,16 @@ export default async (_ctx, client) => {
 export default async (_ctx, client) => {
   const { entity_types } = await client.entitySchema.listTypes();
   if (!entity_types.some((t) => t.slug === 'company')) {
-    await client.entitySchema.createType({
-      slug: 'company',
-      name: 'Company',
-      metadata_schema: { type: 'object', properties: { team_size: { type: 'number' } } },
-    });
+    try {
+      await client.entitySchema.createType({
+        slug: 'company',
+        name: 'Company',
+        metadata_schema: { type: 'object', properties: { team_size: { type: 'number' } } },
+      });
+    } catch (e) {
+      // A concurrent caller may have created it first — the coded 409 is safe.
+      if (!/entity_type_exists/.test(String(e && e.message))) throw e;
+    }
   }
   return client.entities.create({
     type: 'company',
@@ -127,12 +132,17 @@ export default async (_ctx, client) => {
 			"await client.entities.link({ from_entity_id: 42, to_entity_id: 43, relationship_type_slug: 'customer_of' });",
 		usageExample: `// Two-hop: the relationship TYPE must exist before linking. Ensure it
 // (entitySchema.listRelTypes → createRelType), then resolve the two entity
-// ids (entities.list / .get) and link. createRelType is idempotent-safe here
-// because we only create when it is absent.
+// ids (entities.list / .get) and link. If a concurrent caller already created
+// the type, createRelType returns a coded 409 ([relationship_type_exists]) —
+// safe to ignore, the type is present either way.
 export default async (_ctx, client) => {
   const { relationship_types } = await client.entitySchema.listRelTypes();
   if (!relationship_types.some((t) => t.slug === 'works_at')) {
-    await client.entitySchema.createRelType({ slug: 'works_at', name: 'Works at' });
+    try {
+      await client.entitySchema.createRelType({ slug: 'works_at', name: 'Works at' });
+    } catch (e) {
+      if (!/relationship_type_exists/.test(String(e && e.message))) throw e;
+    }
   }
   const { entities: companies } = await client.entities.list({ entity_type: 'company', search: 'Acme' });
   const { entities: people } = await client.entities.list({ entity_type: 'person', search: 'Jane' });


### PR DESCRIPTION
## Why

The MCP discovery eval (real Gemini 2.5 Flash over the 6-tool default surface) identified exactly one *genuine* surface gap (as opposed to model variance or the #1955 scope bug): multi-step entity ops. The agent discovers `entities.create` / `entities.link` but not that a **first-of-its-kind entity type / relationship type must be created first** — it hits `EntityTypeNotFound` and stalls rather than recovering. `create-entity` and `entity-relationship` were the shakiest tasks for this reason.

## What

Enrich the `search_sdk` method metadata (what the agent reads at discovery time):
- `entities.create` summary now states the type must exist first (→ `entitySchema.createType`, `listTypes()`), plus a `usageExample` showing the ensure-type-then-create chain.
- `entities.link` likewise points at `entitySchema.listRelTypes` / rule creation, with a resolve-ids-then-link `usageExample`.

Discovery-doc surfacing only — no handler behavior changed.

## Evidence

- Live: `search_sdk{query:"entities.create"}` now returns "The entity TYPE must exist first — call `entitySchema.createType`…" + the two-hop usageExample.
- method-metadata unit tests 10/10; `make pre-pr` clean.
- Follow-up: re-run the discovery eval to measure the lift on create-entity / entity-relationship (tracked separately).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786668922&installation_id=136316292&pr_number=1958&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1958&signature=982f39bcad0f8d236c7d9fb4bd3dbd8310cbf9882fb5fc586fb0f7cad752a6fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `entities.create` guidance to clearly describe creating or reusing entity types before creating entities.
  * Updated `entities.link` guidance to cover relationship type setup, entity lookup, and linking.
  * Added handling guidance for expected duplicate-creation conflicts and validation errors.
* **Tests**
  * Added coverage to verify the updated method documentation and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->