### PR TITLE
feat(worker-auth): signed MessageOrigin enum + fail-closed authorization (PR-D0)

### DIFF
--- a/packages/agent-worker/src/__tests__/sse-client-harden.test.ts
+++ b/packages/agent-worker/src/__tests__/sse-client-harden.test.ts
@@ -654,6 +654,36 @@ describe("live steering classification", () => {
     ).toBe(false);
   });
 
+  test("trusted origin wins over source: interactive_human is steerable", () => {
+    // A signed interactive_human origin is steerable even if some stale source
+    // string is also present — origin is the authoritative signal.
+    expect(
+      isSteerableHumanMessage({
+        ...payload,
+        origin: "interactive_human",
+        platformMetadata: { source: "internal" },
+      })
+    ).toBe(true);
+  });
+
+  test("trusted non-human origin is never steerable", () => {
+    for (const origin of ["headless", "agent"] as const) {
+      expect(isSteerableHumanMessage({ ...payload, origin })).toBe(false);
+    }
+  });
+
+  test("origin absent falls back to the legacy source denylist", () => {
+    // Rollout safety: an in-flight payload minted before `origin` existed still
+    // classifies via source. (origin undefined → source check runs.)
+    expect(
+      isSteerableHumanMessage({
+        ...payload,
+        platformMetadata: { source: "watcher-run" },
+      })
+    ).toBe(false);
+    expect(isSteerableHumanMessage({ ...payload })).toBe(true);
+  });
+
   test("recognizes only explicit cancellation controls", () => {
     expect(
       isExplicitCancelMessage({ ...payload, messageText: " /CANCEL " })

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -8,6 +8,7 @@ import {
   createLogger,
   extractTraceId,
   flushTracing,
+  isInteractiveHumanOrigin,
   type MessagePayload,
   type QueuedMessage,
   SpanStatusCode,
@@ -100,6 +101,12 @@ const JobEventSchema = z.object({
       // the gateway from the immutable sandbox pin). Selects the worker's bash
       // backend so a warm deployment routes on the pin. Absent → local just-bash.
       runtimeProviderId: z.string().optional(),
+      // Trusted authorization origin of this turn. Also a SIGNED token claim —
+      // the worker authorizes human-gated actions on the token, not this body
+      // field. Parsed here so the steer/batch routing (isSteerableHumanMessage)
+      // sees it. A value outside the enum, or absent, is dropped → the consumer
+      // reads it fail-closed to `agent` (never interactive_human).
+      origin: z.enum(["interactive_human", "headless", "agent"]).optional(),
     })
     .passthrough(),
   processedIds: z.array(z.string()).optional(),
@@ -1102,6 +1109,10 @@ export class GatewayClient {
   }
 }
 
+// Legacy fallback ONLY: the free-form `platformMetadata.source` values that
+// mean "not an interactive human". Retained so an in-flight payload minted
+// before the trusted `origin` field existed still classifies correctly during
+// the expand/contract rollout. New payloads carry `origin` — prefer it.
 const AUTOMATION_SOURCES = new Set([
   "watcher-run",
   "scheduled-job",
@@ -1116,9 +1127,18 @@ export function isSteerableHumanMessage(payload: MessagePayload): boolean {
   // session would treat the control command as ordinary text and preserve the
   // history the user explicitly asked to reset.
   if (payload.platformMetadata?.sessionReset === true) return false;
-  const source = payload.platformMetadata?.source;
-  if (typeof source === "string" && AUTOMATION_SOURCES.has(source)) {
-    return false;
+  // Trusted origin wins when present: only an interactive-human turn is
+  // steerable. `resolveMessageOrigin` reads fail-closed, so a legacy payload
+  // (origin absent) resolves to `agent` — but to preserve the exact legacy
+  // behavior during rollout, fall through to the source denylist ONLY when the
+  // origin field is genuinely absent, not when it resolved to a non-human.
+  if (payload.origin !== undefined) {
+    if (!isInteractiveHumanOrigin(payload.origin)) return false;
+  } else {
+    const source = payload.platformMetadata?.source;
+    if (typeof source === "string" && AUTOMATION_SOURCES.has(source)) {
+      return false;
+    }
   }
   const files = payload.platformMetadata?.files;
   return !Array.isArray(files) || files.length === 0;

--- a/packages/core/src/__tests__/message-origin.test.ts
+++ b/packages/core/src/__tests__/message-origin.test.ts
@@ -1,0 +1,91 @@
+/**
+ * MessageOrigin — the trusted, signed authorization-origin enum (PR-D0).
+ *
+ * The security contract is FAIL-CLOSED: any value that is not one of the three
+ * known origins — undefined (a legacy payload/token), a non-string, a typo, or
+ * a future/unknown origin — must resolve to `agent` (the most-restrictive), and
+ * must NEVER read as `interactive_human`. A missing origin can never authorize a
+ * human-gated action (e.g. `!`-shell). These tests pin that, and prove the
+ * origin round-trips through the signed worker token.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { generateWorkerToken, verifyWorkerToken } from "../worker/auth";
+import { __resetEncryptionKeyCacheForTests } from "../utils/encryption";
+import {
+  isAutomationOrigin,
+  isInteractiveHumanOrigin,
+  resolveMessageOrigin,
+} from "../worker/wire";
+
+const TEST_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("resolveMessageOrigin — fail-closed", () => {
+  test("passes through the three known origins", () => {
+    expect(resolveMessageOrigin("interactive_human")).toBe("interactive_human");
+    expect(resolveMessageOrigin("headless")).toBe("headless");
+    expect(resolveMessageOrigin("agent")).toBe("agent");
+  });
+
+  test("resolves every unknown/absent/non-string value to agent", () => {
+    for (const bad of [
+      undefined,
+      null,
+      "",
+      "human", // a plausible-but-wrong string must NOT read as human
+      "interactive-human", // wrong separator
+      "INTERACTIVE_HUMAN", // wrong case
+      "user",
+      "direct-api", // a legacy source string is NOT an origin
+      42,
+      {},
+      [],
+      true,
+    ]) {
+      expect(resolveMessageOrigin(bad)).toBe("agent");
+    }
+  });
+
+  test("isInteractiveHumanOrigin is true ONLY for the exact human origin", () => {
+    expect(isInteractiveHumanOrigin("interactive_human")).toBe(true);
+    for (const bad of ["headless", "agent", undefined, "human", "direct-api"]) {
+      expect(isInteractiveHumanOrigin(bad)).toBe(false);
+    }
+  });
+
+  test("isAutomationOrigin is the inverse — true for everything non-human", () => {
+    expect(isAutomationOrigin("interactive_human")).toBe(false);
+    for (const nonHuman of ["headless", "agent", undefined, "nonsense", null]) {
+      expect(isAutomationOrigin(nonHuman)).toBe(true);
+    }
+  });
+});
+
+describe("origin round-trips through the signed worker token", () => {
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = TEST_KEY;
+    __resetEncryptionKeyCacheForTests();
+  });
+  afterEach(() => {
+    process.env.ENCRYPTION_KEY = undefined;
+    __resetEncryptionKeyCacheForTests();
+  });
+
+  test("a signed interactive_human origin verifies back intact", () => {
+    const token = generateWorkerToken("u", "c", "deploy", {
+      channelId: "ch",
+      origin: "interactive_human",
+    });
+    expect(verifyWorkerToken(token)?.origin).toBe("interactive_human");
+  });
+
+  test("a token minted without origin (legacy) reads fail-closed to agent", () => {
+    const token = generateWorkerToken("u", "c", "deploy", { channelId: "ch" });
+    const data = verifyWorkerToken(token);
+    expect(data?.origin).toBeUndefined();
+    // The CONSUMER resolves it fail-closed — a legacy token is never a human.
+    expect(resolveMessageOrigin(data?.origin)).toBe("agent");
+    expect(isInteractiveHumanOrigin(data?.origin)).toBe(false);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,4 +147,14 @@ export type {
   WorkerTransportConfig,
 } from "./worker/transport";
 // Gateway ↔ worker wire contract (MessagePayload, JobType, QueuedMessage).
-export type { JobType, MessagePayload, QueuedMessage } from "./worker/wire";
+export type {
+  JobType,
+  MessageOrigin,
+  MessagePayload,
+  QueuedMessage,
+} from "./worker/wire";
+export {
+  isAutomationOrigin,
+  isInteractiveHumanOrigin,
+  resolveMessageOrigin,
+} from "./worker/wire";

--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { createLogger } from "../logger";
 import { decrypt, encrypt } from "../utils/encryption";
+import type { MessageOrigin } from "./wire";
 
 const logger = createLogger("worker-auth");
 
@@ -36,6 +37,16 @@ export interface WorkerTokenData {
    * interactive (browser-driven) runs.
    */
   source?: string;
+  /**
+   * Trusted authorization origin of this turn (`interactive_human | headless |
+   * agent`; see core `MessageOrigin`). Derived by the ingress from what it
+   * actually knows and SIGNED here, so the worker authorizes human-gated
+   * actions (e.g. `!`-shell) on the verified claim rather than the free-form,
+   * spoofable `source`. Absent on a legacy token → the worker reads it
+   * fail-closed to `agent` (never `interactive_human`). See `MessageOrigin` in
+   * `worker/wire.ts`.
+   */
+  origin?: MessageOrigin;
   sessionKey?: string;
   traceId?: string;
   /** Unique token ID — enables targeted revocation. */
@@ -109,6 +120,8 @@ export function generateWorkerToken(
     platform?: string;
     /** Headless run origin — see WorkerTokenData.source. */
     source?: string;
+    /** Trusted authorization origin — see WorkerTokenData.origin. */
+    origin?: MessageOrigin;
     sessionKey?: string;
     traceId?: string;
     /**
@@ -153,6 +166,7 @@ export function generateWorkerToken(
     timestamp: Date.now(),
     platform: options.platform,
     source: options.source,
+    origin: options.origin,
     sessionKey: options.sessionKey,
     traceId: options.traceId,
     jti: randomUUID(),

--- a/packages/core/src/worker/wire.ts
+++ b/packages/core/src/worker/wire.ts
@@ -29,6 +29,52 @@ import type {
 export type JobType = "message" | "exec";
 
 /**
+ * Trusted authorization origin of a turn, derived at each gateway ingress from
+ * what that ingress ACTUALLY knows — never inferred from the free-form
+ * `platformMetadata.source` string (which is optional, unstructured, and shared
+ * across unrelated subsystems). This is the authoritative signal for deciding
+ * whether a turn may do things only a real person should authorize (e.g. run a
+ * `!`-shell command in the sandbox).
+ *
+ *  - `interactive_human` — a real inbound message a human typed/sent in a live
+ *    chat (a platform DM/mention, or the web panel composer). ONLY this may
+ *    authorize human-gated actions.
+ *  - `headless` — a programmatic turn with no human at a socket: a scheduled
+ *    wake, a `conversations.send` SDK call, an internal thread. Legitimate, but
+ *    not a human gesture.
+ *  - `agent` — an agent/tool/watcher-authored turn (autonomous). Most
+ *    restrictive; also the FAIL-CLOSED default when the origin is absent or
+ *    unrecognized, so a missing claim can never be read as a human.
+ *
+ * Carried as a first-class {@link MessagePayload.origin} field AND signed into
+ * the worker token (`WorkerTokenData.origin`), so the worker authorizes on the
+ * verified claim rather than a body field it could be tricked about.
+ */
+export type MessageOrigin = "interactive_human" | "headless" | "agent";
+
+/**
+ * Read a {@link MessageOrigin} fail-closed. Any value that is not one of the
+ * three known origins — including `undefined`, a legacy payload/token minted
+ * before this field existed, or a non-string — resolves to `"agent"` (the
+ * most-restrictive origin). A missing origin must NEVER be treated as a human.
+ */
+export function resolveMessageOrigin(value: unknown): MessageOrigin {
+  return value === "interactive_human" || value === "headless"
+    ? value
+    : "agent";
+}
+
+/** True only for a verified interactive-human origin (fail-closed). */
+export function isInteractiveHumanOrigin(value: unknown): boolean {
+  return resolveMessageOrigin(value) === "interactive_human";
+}
+
+/** True for any non-interactive (headless or agent/automation) origin. */
+export function isAutomationOrigin(value: unknown): boolean {
+  return resolveMessageOrigin(value) !== "interactive_human";
+}
+
+/**
  * Universal message payload for every gateway → worker hop.
  * Used by: platform inbound → runs queue → MessageConsumer → worker.
  */
@@ -60,6 +106,16 @@ export interface MessagePayload {
   botId: string;
   /** Platform name (`slack`, `telegram`, ...). */
   platform: string;
+
+  /**
+   * Trusted authorization origin of this turn (see {@link MessageOrigin}),
+   * stamped by the ingress that built this payload from what it actually knows
+   * — NOT copied from `platformMetadata.source`. `buildWorkerTokenClaims` signs
+   * it into the worker token so the worker authorizes on the verified claim.
+   * Absent on legacy payloads → read fail-closed via {@link resolveMessageOrigin}
+   * (defaults to `agent`, never `interactive_human`).
+   */
+  origin?: MessageOrigin;
 
   // ── Message content (used by worker) ───────────────────────────────
   messageText: string;

--- a/packages/server/src/gateway/__tests__/worker-token-mint-parity.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-token-mint-parity.test.ts
@@ -51,6 +51,10 @@ const SHARED_REQUIRED: Array<keyof WorkerTokenData> = [
   // Headless run origin — interaction cards stamped headless skip the
   // SSE-owner gate; absent → owner-gated card dead-letters on a headless run.
   "source",
+  // Trusted authorization origin (interactive_human | headless | agent). The
+  // worker authorizes human-gated actions (e.g. `!`-shell) on this SIGNED claim.
+  // Always present — both mints resolve it fail-closed, so it is never absent.
+  "origin",
 ];
 
 describe("worker-token mint parity (real mint, not generateWorkerToken)", () => {
@@ -82,6 +86,9 @@ describe("worker-token mint parity (real mint, not generateWorkerToken)", () => 
     expect(decoded?.runId).toBe(42);
     expect(decoded?.connectionId).toBe(CONN);
     expect(decoded?.source).toBe("watcher-run");
+    // FAIL-CLOSED: baseArgs carries no `origin`, so the mint signs `agent`
+    // (never interactive_human). A missing origin can never authorize a human.
+    expect(decoded?.origin).toBe("agent");
 
     // The route does exactly this with the decoded context — must not throw.
     expect(() =>
@@ -123,6 +130,29 @@ describe("worker-token mint parity (real mint, not generateWorkerToken)", () => 
         `claim "${claim}" present on WORKER_TOKEN but missing on runJobToken — divergence`
       ).toBe(inDeployment);
     }
+  });
+
+  test("origin: an explicit interactive_human is signed intact; absent fails closed on BOTH mints", () => {
+    // Explicit human origin round-trips through both mints.
+    const humanArgs = { ...baseArgs, origin: "interactive_human" as const };
+    expect(
+      verifyWorkerToken(buildRunJobToken({ ...humanArgs, runId: 9 }) as string)
+        ?.origin
+    ).toBe("interactive_human");
+    expect(
+      verifyWorkerToken(buildDeploymentWorkerToken(humanArgs))?.origin
+    ).toBe("interactive_human");
+
+    // A garbage/unknown origin can NEVER be verified as a human — both mints
+    // resolve it fail-closed to `agent`.
+    const spoofed = { ...baseArgs, origin: "human" };
+    expect(
+      verifyWorkerToken(buildRunJobToken({ ...spoofed, runId: 9 }) as string)
+        ?.origin
+    ).toBe("agent");
+    expect(
+      verifyWorkerToken(buildDeploymentWorkerToken(spoofed))?.origin
+    ).toBe("agent");
   });
 
   test("the shipped bug reproduces: a chat token WITHOUT connectionId is rejected", () => {

--- a/packages/server/src/gateway/api/platform.ts
+++ b/packages/server/src/gateway/api/platform.ts
@@ -306,6 +306,9 @@ export class ApiPlatform implements PlatformAdapter {
       organizationId,
       botId: "lobu-api",
       platform: "api",
+      // API-directed programmatic send (the platform sendMessage adapter), not
+      // a human typing — headless.
+      origin: "headless",
       messageText: message,
       platformMetadata,
       agentOptions: {

--- a/packages/server/src/gateway/connections/chat-instance-manager.ts
+++ b/packages/server/src/gateway/connections/chat-instance-manager.ts
@@ -2458,6 +2458,8 @@ export class ChatInstanceManager {
       organizationId,
       botId: `${name}-platform`,
       platform: name,
+      // Programmatic chat-instance relay — no human at a socket.
+      origin: "headless",
       messageText: message,
       platformMetadata: {
         connectionId: connection.id,

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -4,7 +4,12 @@
  * settings links, allowlist, audio transcription, etc.
  */
 
-import { createLogger, createRootSpan, generateTraceId } from "@lobu/core";
+import {
+  createLogger,
+  createRootSpan,
+  generateTraceId,
+  type MessageOrigin,
+} from "@lobu/core";
 import {
   previewUnlinkedNotice,
   workspaceUnlinkedNotice,
@@ -924,6 +929,12 @@ export class MessageHandlerBridge {
     await this.enqueueUserTurn({
       agentId,
       organizationId: routingOrgId,
+      // A real inbound message from a non-self sender is interactive_human (the
+      // only origin that may authorize `!`-shell); a bot self-post (`isMe`) is
+      // `agent`. Derived from the sender the ingress actually knows, never from
+      // the free-form platformMetadata.source.
+      origin:
+        message.author?.isMe === true ? "agent" : "interactive_human",
       userId,
       channelId,
       conversationId,
@@ -960,6 +971,14 @@ export class MessageHandlerBridge {
     /** Org the turn runs under. For preview connections this is the bound
      * agent's org (cross-org), not necessarily the connection's org. */
     organizationId: string | undefined;
+    /**
+     * Trusted authorization origin of this turn (see core `MessageOrigin`).
+     * Both callers of this method are genuine human actions — a typed inbound
+     * message from a non-self sender, and a card button-click — so both pass
+     * `interactive_human`. Bot self-posts are filtered by the Chat SDK's `isMe`
+     * before `handleMessage`, so they never reach here.
+     */
+    origin: MessageOrigin;
     userId: string;
     channelId: string;
     conversationId: string;
@@ -1131,6 +1150,8 @@ export class MessageHandlerBridge {
         teamId: payloadTeamId,
         agentId,
         organizationId,
+        // Trusted origin declared by the caller (both are human actions).
+        origin: args.origin,
         messageId,
         messageText,
         channelId,
@@ -1262,6 +1283,8 @@ export class MessageHandlerBridge {
     await this.enqueueUserTurn({
       agentId,
       organizationId: routingOrgId,
+      // A card button-click is a deliberate human action → interactive_human.
+      origin: "interactive_human",
       userId,
       channelId,
       conversationId,

--- a/packages/server/src/gateway/orchestration/agent-run-input.ts
+++ b/packages/server/src/gateway/orchestration/agent-run-input.ts
@@ -85,6 +85,10 @@ export function attachFreshRunJobToken(
         connectionId: token.connectionId,
         platform: token.platform,
         source: token.source,
+        // Carry the trusted origin through a token refresh — else a re-minted
+        // token would drop the claim and the worker would fail-close to `agent`,
+        // silently disabling human-gated actions mid-conversation.
+        origin: token.origin,
         sessionKey: token.sessionKey,
         traceId: token.traceId,
         runId: token.runId,

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -637,6 +637,8 @@ export function buildDeploymentWorkerToken(args: {
   organizationId?: string;
   platform?: string;
   platformMetadata?: Record<string, unknown>;
+  /** Trusted authorization origin from the payload (see core MessageOrigin). */
+  origin?: unknown;
   traceId?: string;
   /** Resolved runtime provider + environment, so the deployment-lifetime token
    *  also carries the claim the runtime route reads (parity with the per-run mint). */
@@ -1531,6 +1533,9 @@ export class DeploymentManager {
       agentId,
       organizationId: validated.organizationId,
       platformMetadata,
+      // Trusted origin from the payload; signed fail-closed. Parity with the
+      // per-run mint so the fallback deployment token carries the same claim.
+      origin: messageData?.origin,
       traceId,
       runtimeProviderId: runtimeSelection.runtimeProviderId,
       environmentId: runtimeSelection.environmentId,

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -148,6 +148,8 @@ export function buildRunJobToken(args: {
   organizationId: string;
   platform: string;
   platformMetadata: Record<string, unknown>;
+  /** Trusted authorization origin from the payload (see core MessageOrigin). */
+  origin?: unknown;
   runId: number;
   /**
    * Per-turn binding for token refresh: the turn-timeout marker is armed with
@@ -451,6 +453,8 @@ export class MessageConsumer {
         organizationId: data.organizationId,
         platform: data.platform,
         platformMetadata: data.platformMetadata,
+        // Trusted origin from the payload; signed into the token fail-closed.
+        origin: data.origin,
         runId: data.runId,
         // Per-turn binding for token refresh: the turn-timeout marker is armed
         // below with this SAME messageId, so the refresh gate can require a live

--- a/packages/server/src/gateway/orchestration/worker-token-claims.ts
+++ b/packages/server/src/gateway/orchestration/worker-token-claims.ts
@@ -12,6 +12,8 @@
  * is set in ONE place for both mints. Mint-specific claims (runId+messageId for
  * the per-run token, traceId for the deployment token) stay with each caller.
  */
+import { type MessageOrigin, resolveMessageOrigin } from "@lobu/core";
+
 export interface WorkerTokenClaimsArgs {
   channelId: string;
   teamId?: string;
@@ -19,6 +21,15 @@ export interface WorkerTokenClaimsArgs {
   organizationId?: string;
   platform?: string;
   platformMetadata?: Record<string, unknown>;
+  /**
+   * Trusted authorization origin of this turn, stamped on the MessagePayload by
+   * the ingress that built it (see core `MessageOrigin`). Signed into the token
+   * fail-closed via `resolveMessageOrigin` — a payload minted before this field
+   * existed, or any unrecognized value, becomes `agent` (never a human). This
+   * is the authoritative signal the worker authorizes human-gated actions on,
+   * NOT the free-form `platformMetadata.source`.
+   */
+  origin?: unknown;
   /**
    * Selected runtime provider for this conversation, resolved from the agent's
    * Environment by the caller (which has the agent settings + environments
@@ -58,6 +69,7 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
   platform?: string;
   connectionId?: string;
   source?: string;
+  origin: MessageOrigin;
   runtimeProviderId?: string;
   environmentId?: string;
   allowedDomains?: string[];
@@ -79,6 +91,9 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
       typeof args.platformMetadata?.source === "string"
         ? args.platformMetadata.source
         : undefined,
+    // Fail-closed: an unrecognized/absent origin signs as `agent`, so a legacy
+    // payload or a spoofed value can never be verified as `interactive_human`.
+    origin: resolveMessageOrigin(args.origin),
     runtimeProviderId,
     environmentId: runtimeProviderId ? args.environmentId : undefined,
     // Non-empty only; an empty list is equivalent to absent (deny-all) and

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1523,6 +1523,12 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         organizationId: messageOrganizationId,
         botId: "lobu-api",
         platform: "api",
+        // A watcher-intent run is autonomous (agent); every other message on this
+        // authenticated interactive route (the web panel composer / `lobu chat`)
+        // is an interactive human. Derived from the session intent, not the
+        // free-form source string.
+        origin:
+          session.intent?.kind === "watcher_run" ? "agent" : "interactive_human",
         messageText: messageTextForTranscript,
         ...(applyEphemeralContext
           ? { ephemeralContext: rawEphemeralContext.slice(0, 2048) }

--- a/packages/server/src/gateway/services/agent-threads.ts
+++ b/packages/server/src/gateway/services/agent-threads.ts
@@ -175,6 +175,8 @@ export async function enqueueAgentMessage(
     organizationId: session.organizationId,
     botId: "lobu-api",
     platform: "api",
+    // Internal programmatic thread dispatch — no human at a socket.
+    origin: "headless",
     messageText,
     platformMetadata: {
       agentId: realAgentId,

--- a/packages/server/src/gateway/services/platform-helpers.ts
+++ b/packages/server/src/gateway/services/platform-helpers.ts
@@ -5,6 +5,7 @@
 
 import {
   createLogger,
+  type MessageOrigin,
   type MessagePayload,
 } from "@lobu/core";
 import type { AgentSettingsStore } from "../auth/settings/agent-settings-store.js";
@@ -131,6 +132,14 @@ export function buildMessagePayload(params: {
   channelId: string;
   platformMetadata: Record<string, any>;
   agentOptions: Record<string, any>;
+  /**
+   * Trusted authorization origin of this turn (see core `MessageOrigin`).
+   * REQUIRED so every ingress makes a deliberate choice — a real inbound human
+   * message is `interactive_human`; a scheduled wake / programmatic dispatch is
+   * `headless`; an agent/watcher-authored turn is `agent`. Signed into the
+   * worker token downstream; the worker authorizes human-gated actions on it.
+   */
+  origin: MessageOrigin;
 }): MessagePayload {
   const {
     networkConfig,
@@ -148,6 +157,7 @@ export function buildMessagePayload(params: {
     teamId: params.teamId,
     agentId: params.agentId,
     organizationId: params.organizationId,
+    origin: params.origin,
     messageId: params.messageId,
     messageText: params.messageText,
     channelId: params.channelId,

--- a/packages/server/src/scheduled/jobs.ts
+++ b/packages/server/src/scheduled/jobs.ts
@@ -451,6 +451,8 @@ export async function runWakeAgentTask(
         teamId: delivery.teamId ?? undefined,
         agentId: p.agent_id,
         organizationId: orgId,
+        // A scheduled wake is headless — no human is authorizing this turn.
+        origin: "headless",
         messageId: `wake_${p.__scheduled_job_id ?? p.agent_id}_${Date.now()}`,
         messageText: p.prompt,
         channelId: delivery.channelId,

--- a/packages/server/src/tools/admin/manage_conversations.ts
+++ b/packages/server/src/tools/admin/manage_conversations.ts
@@ -259,6 +259,9 @@ async function handleSend(
       teamId: "api",
       agentId: args.agent_id,
       organizationId: ctx.organizationId,
+      // A programmatic SDK send is headless — no human at a socket. It must NOT
+      // be able to authorize human-gated actions (e.g. `!`-shell) downstream.
+      origin: "headless",
       messageId,
       messageText: text,
       channelId,

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -976,6 +976,8 @@ async function preflightWatcherMemoryTools(params: {
 			agentId: params.agentId,
 			organizationId: params.organizationId,
 			platform: "api",
+			// A watcher run is autonomous — never a human origin.
+			origin: "agent",
 			sessionKey: `watcher_${params.runId}`,
 		},
 	);


### PR DESCRIPTION
**PR-D0** of the `!`-bash program (a staged rebuild after codex rejected the single-PR plan — see the design review for the 6 findings). This is the reusable security foundation the rest depends on; it also hardens origin attribution repo-wide.

## Why
`!`-bash (running a shell command from chat) must be authorized only for a real human. The naive approach — checking the free-form `platformMetadata.source` — is **fail-open**: `source` is optional, often absent, unstructured, and shared across subsystems, and `direct-api` covers both a human in the web panel and an SDK bot. It cannot *prove* a human gesture.

## What
A canonical, typed, **signed** origin instead:
- **core** `MessageOrigin = interactive_human | headless | agent` + fail-closed readers (`resolveMessageOrigin` / `isInteractiveHumanOrigin` / `isAutomationOrigin`). Any unknown / absent / non-string value resolves to `agent` — **never** a human.
- Each gateway ingress **derives** origin from what it actually knows (not from `source`): a real inbound non-self chat message / card click → `interactive_human`; `conversations.send` / scheduled wake / platform relay / internal thread → `headless`; watcher / bot-self → `agent`. `buildMessagePayload` requires `origin`, so every ingress makes a deliberate choice (typecheck enforces coverage — that's how I know none was missed).
- **Signed** into both worker-token mints (`runJobToken` + deployment `WORKER_TOKEN`) via `buildWorkerTokenClaims`, resolved fail-closed at mint, carried through token refresh. The worker authorizes on the verified claim, never a body field.
- Worker read side: `isSteerableHumanMessage` prefers the trusted origin, with a legacy `source`-denylist fallback ONLY when `origin` is absent (expand/contract rollout safety for in-flight payloads).

No `!` behavior yet.

## Tests
- core: fail-closed reader (every unknown/absent value → `agent`; only the exact `interactive_human` reads human) + signed-token round-trip (human intact; legacy-absent → fail-closed).
- server: mint-parity canary extended with `origin` (asserts both mints sign it fail-closed; an explicit human round-trips; a spoofed value → `agent`).
- agent-worker: `isSteerableHumanMessage` — trusted origin wins over source; non-human origin never steerable; absent origin falls back to the legacy denylist.

`make pre-pr` clean (typecheck + knip + biome). Next: PR-D1 (shared bash preflight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786669761&installation_id=136316292&pr_number=1960&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1960&signature=076722af7fb7331e560214482152256fc7e460ac5139f04bf68e075ac8364d96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->