### PR TITLE
fix(entity-schema): createType/createRelType survive the concurrent-create race

### DIFF
--- a/packages/server/src/__tests__/integration/entity-schema/entity-types.test.ts
+++ b/packages/server/src/__tests__/integration/entity-schema/entity-types.test.ts
@@ -105,6 +105,33 @@ describe('entity schema CRUD', () => {
       await owner.entity_schema.deleteType({ slug: 'dup-asset' });
     });
 
+    it('concurrent creates of the same slug: one wins, every loser gets the coded 409 (not raw 23505)', async () => {
+      // The precheck SELECT is not a lock, so concurrent replicas can all pass
+      // it and race the partial unique index. Fire many at once: exactly one
+      // INSERT commits, and every loser must surface the SAME coded 409 the
+      // sequential path emits — otherwise `lobu apply` sees a raw Postgres
+      // 23505 and its probe-create-then-update path aborts. Pre-fix, the losers
+      // rejected with a raw unique-violation.
+      const results = await Promise.allSettled(
+        Array.from({ length: 6 }, () =>
+          owner.entity_schema.createType({ slug: 'race-asset', name: 'Race' })
+        )
+      );
+      const fulfilled = results.filter((r) => r.status === 'fulfilled');
+      const rejected = results.filter(
+        (r): r is PromiseRejectedResult => r.status === 'rejected'
+      );
+      expect(fulfilled.length).toBe(1);
+      expect(rejected.length).toBe(5);
+      for (const r of rejected) {
+        const e = r.reason as Error & { httpStatus?: number };
+        expect(e.message).toMatch(/\[entity_type_exists\].*already exists/);
+        expect(e.message).not.toMatch(/23505|duplicate key value/);
+        expect(e.httpStatus).toBe(409);
+      }
+      await owner.entity_schema.deleteType({ slug: 'race-asset' });
+    });
+
     it('surfaces a 422 schema-validation error with the real message (issue #1177)', async () => {
       // A non-boolean x-table-column trips [invalid_schema]; before the fix
       // this surfaced through `lobu apply` as a misleading "Entity type 'task'
@@ -339,6 +366,29 @@ describe('entity schema CRUD', () => {
       expect(err?.message).toMatch(/\[relationship_type_exists\].*already exists/);
       expect(err?.httpStatus).toBe(409);
       await owner.entity_schema.deleteRelType({ slug: 'dup-rel' });
+    });
+
+    it('concurrent creates of the same slug: one wins, every loser gets the coded 409 (not raw 23505)', async () => {
+      // Same check-then-insert race as entity_type: prove the loser of the
+      // partial-unique-index race surfaces the coded 409, not a raw 23505.
+      const results = await Promise.allSettled(
+        Array.from({ length: 6 }, () =>
+          owner.entity_schema.createRelType({ slug: 'race-rel', name: 'Race' })
+        )
+      );
+      const fulfilled = results.filter((r) => r.status === 'fulfilled');
+      const rejected = results.filter(
+        (r): r is PromiseRejectedResult => r.status === 'rejected'
+      );
+      expect(fulfilled.length).toBe(1);
+      expect(rejected.length).toBe(5);
+      for (const r of rejected) {
+        const e = r.reason as Error & { httpStatus?: number };
+        expect(e.message).toMatch(/\[relationship_type_exists\].*already exists/);
+        expect(e.message).not.toMatch(/23505|duplicate key value/);
+        expect(e.httpStatus).toBe(409);
+      }
+      await owner.entity_schema.deleteRelType({ slug: 'race-rel' });
     });
   });
 

--- a/packages/server/src/tools/admin/manage_entity_schema.ts
+++ b/packages/server/src/tools/admin/manage_entity_schema.ts
@@ -36,6 +36,7 @@ import { ensureMemberEntityType } from '../../utils/member-entity-type';
 import { RESERVED_ENTITY_TYPES } from '../../utils/reserved';
 import { resolveUsernames } from '../../utils/resolve-usernames';
 import { ToolUserError } from '../../utils/errors';
+import { isUniqueViolation } from '../../utils/pg-errors';
 import type { ToolContext } from '../registry';
 import { withValidatedArgs } from '../validate-args';
 import { defineFlatActionTool, flatAction } from './action-tool';
@@ -468,7 +469,9 @@ async function etHandleCreate(
   const eventKinds = args.event_kinds ? sql.json(args.event_kinds) : null;
   const metricsConfig = args.metrics_config ? sql.json(args.metrics_config) : null;
 
-  const inserted = await sql`
+  let inserted: unknown[];
+  try {
+    inserted = await sql`
     INSERT INTO entity_types (
       slug, name, description, icon, color,
       metadata_schema, event_kinds,
@@ -493,6 +496,20 @@ async function etHandleCreate(
     )
     RETURNING ${sql.unsafe(ENTITY_TYPE_COLUMNS)}
   `;
+  } catch (err) {
+    // The precheck above is not a lock: two concurrent replicas can both pass
+    // it, and the loser hits the partial unique index. Translate that specific
+    // 23505 to the SAME coded 409 the precheck emits, so `lobu apply`'s
+    // probe-create-then-update path (and the documented ensure-then-write
+    // flow) see one stable duplicate signal instead of a raw Postgres error.
+    if (isUniqueViolation(err, 'idx_entity_types_org_slug')) {
+      throw new ToolUserError(
+        `[entity_type_exists] Entity type with slug '${slug}' already exists`,
+        409
+      );
+    }
+    throw err;
+  }
 
   if (inserted.length === 0) throw new Error('Failed to create entity type');
 
@@ -1000,7 +1017,9 @@ async function rtHandleCreate(
 
   const identityMetadata = buildRelationshipIdentityMetadata(args.auto_create_when, null);
 
-  const inserted = await sql`
+  let inserted: unknown[];
+  try {
+    inserted = await sql`
     INSERT INTO entity_relationship_types (
       slug, name, description, organization_id, created_by,
       metadata_schema, metadata, is_symmetric, inverse_type_id, status,
@@ -1021,6 +1040,19 @@ async function rtHandleCreate(
     )
     RETURNING id
   `;
+  } catch (err) {
+    // Same check-then-insert race as createType: the precheck is not a lock,
+    // so a concurrent replica can win and the loser hits the partial unique
+    // index. Translate that specific 23505 to the SAME coded 409 the precheck
+    // emits so callers see one stable duplicate signal.
+    if (isUniqueViolation(err, 'idx_entity_rel_types_org_slug')) {
+      throw new ToolUserError(
+        `[relationship_type_exists] Relationship type with slug "${args.slug}" already exists`,
+        409
+      );
+    }
+    throw err;
+  }
   const typeId = Number((inserted[0] as { id: unknown }).id);
 
   // Only write the reciprocal back-link when the caller owns the inverse type.


### PR DESCRIPTION
## Why
The unknown-slug precheck on `entitySchema.createType` / `createRelType` is a `SELECT`, not a lock. Under multi-replica concurrency two callers can both pass the precheck and race the partial unique index — the loser then surfaces a **raw Postgres 23505** (`duplicate key value violates unique constraint "idx_entity_types_org_slug"`) instead of the coded `[entity_type_exists]` / `[relationship_type_exists]` 409 the sequential path emits.

That breaks two things that depend on the *coded* duplicate signal:
- `lobu apply`'s probe-create-then-update upsert (retries as `update` only on the coded 409).
- The documented ensure-then-write flow in `search_sdk` (#1958), which catches the coded 409 to stay race-safe.

Surfaced by the codex reviewer on #1958.

## What
Wrap both INSERTs; translate the **constraint-specific** 23505 (via the existing `isUniqueViolation` helper) to the same coded `ToolUserError` (409) the precheck emits. Only that exact constraint is caught — any other unique violation still propagates.

## Tests (red→green)
Added concurrent-create tests for both entity types and relationship types: fire 6 concurrent creates of one slug, assert exactly one wins and **every** loser gets the coded 409, never a raw 23505 / "duplicate key value".
- **Red** (catch disabled): losers reject with `duplicate key value violates unique constraint "idx_entity_types_org_slug"` → test fails.
- **Green** (fix in place): all 17 tests in the file pass.

`make pre-pr` clean (typecheck + knip + biome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvqppirynLxpoRU4ARjQv7

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786672353&installation_id=136316292&pr_number=1962&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1962&signature=5b16e4e4b0e109e1d1bdef13dbdfab60c62329b3d1b1dc00976dd0691938b12f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->