### PR TITLE
refactor(worker-bash): single hardened bash entry carries the full policy (PR-D1)

### DIFF
--- a/packages/agent-worker/src/__tests__/embedded-tools.test.ts
+++ b/packages/agent-worker/src/__tests__/embedded-tools.test.ts
@@ -262,6 +262,112 @@ describe("bash tool proxy hint", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Bash command prefix policy — now enforced INSIDE the bash tool object, so any
+// direct caller that holds the tool gets it by construction (and the forthcoming
+// `!`-bash intercept in PR-D4 can reuse the same object). Previously this was a
+// conditional re-wrap applied in session-runner AFTER createLobuTools returned;
+// the tool object itself did not carry it. This asserts the consolidation.
+// ---------------------------------------------------------------------------
+
+describe("bash tool prefix policy (carried by the tool object)", () => {
+  const passthroughOps: BashOperations = {
+    exec: async (_command, _cwd, { onData }) => {
+      onData(Buffer.from("ran\n"));
+      return { exitCode: 0 };
+    },
+  };
+
+  test("denyPrefixes rejects a matching command before exec", async () => {
+    const tools = createLobuTools(tempDir, {
+      bashOperations: passthroughOps,
+      bashPolicy: { allowAll: false, allowPrefixes: [], denyPrefixes: ["rm "] },
+    });
+    const bashTool = tools.find((t) => t.name === "bash")!;
+
+    await expect(
+      bashTool.execute(
+        "call-deny",
+        { command: "rm -rf /workspace/data" },
+        undefined,
+        undefined
+      )
+    ).rejects.toThrow("Bash command denied by policy");
+  });
+
+  test("allowlist rejects a command outside the allowed prefixes", async () => {
+    const tools = createLobuTools(tempDir, {
+      bashOperations: passthroughOps,
+      bashPolicy: {
+        allowAll: false,
+        allowPrefixes: ["ls ", "echo "],
+        denyPrefixes: [],
+      },
+    });
+    const bashTool = tools.find((t) => t.name === "bash")!;
+
+    await expect(
+      bashTool.execute(
+        "call-notallowed",
+        { command: "cat /etc/passwd" },
+        undefined,
+        undefined
+      )
+    ).rejects.toThrow("Bash command not allowed by policy");
+  });
+
+  test("allowed command passes the policy and reaches exec", async () => {
+    const seen: string[] = [];
+    const tools = createLobuTools(tempDir, {
+      bashOperations: {
+        exec: async (command, _cwd, { onData }) => {
+          seen.push(command);
+          onData(Buffer.from("ok\n"));
+          return { exitCode: 0 };
+        },
+      },
+      bashPolicy: {
+        allowAll: false,
+        allowPrefixes: ["echo "],
+        denyPrefixes: [],
+      },
+    });
+    const bashTool = tools.find((t) => t.name === "bash")!;
+
+    await bashTool.execute(
+      "call-allow",
+      { command: "echo hi" },
+      undefined,
+      undefined
+    );
+    expect(seen.some((c) => c.includes("echo hi"))).toBe(true);
+  });
+
+  test("no bashPolicy → no prefix enforcement (unchanged default)", async () => {
+    const seen: string[] = [];
+    const tools = createLobuTools(tempDir, {
+      bashOperations: {
+        exec: async (command, _cwd, { onData }) => {
+          seen.push(command);
+          onData(Buffer.from("ok\n"));
+          return { exitCode: 0 };
+        },
+      },
+    });
+    const bashTool = tools.find((t) => t.name === "bash")!;
+
+    // Without a policy, an otherwise-denyable command runs (matches the prior
+    // behavior when session-runner only re-wrapped for a non-empty policy).
+    await bashTool.execute(
+      "call-nopolicy",
+      { command: "rm -rf /workspace/data" },
+      undefined,
+      undefined
+    );
+    expect(seen.some((c) => c.includes("rm -rf"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // callMcpTool
 // ---------------------------------------------------------------------------
 

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -49,11 +49,7 @@ import {
   getAgentSessionContext,
   invalidateSessionContextCache,
 } from "./session-context";
-import {
-  buildToolPolicy,
-  enforceBashCommandPolicy,
-  isToolAllowedByPolicy,
-} from "./tool-policy";
+import { buildToolPolicy, isToolAllowedByPolicy } from "./tool-policy";
 import { buildToolUseEventPayload } from "./tool-use-events";
 import { createLobuTools } from "./tools";
 import { clearSnapshots, hydrateFromSnapshot } from "./transcript-snapshot";
@@ -952,31 +948,15 @@ export async function runAISession(
       // Per-turn pinned provider from the sandbox pin; selects the bash backend.
       runtimeProviderId,
     });
-  let tools = createLobuTools(workspaceDir, {
+  // The bash tool returned here carries the FULL hardened policy by construction
+  // (prefix allow/deny + gateway-access + package-install blocks, plus
+  // credential-strip), so the forthcoming `!`-bash intercept (PR-D4) can reuse
+  // this same object rather than a second raw path. The filter then removes bash
+  // entirely when the agent policy disallows it (strict / disallowedTools).
+  const tools = createLobuTools(workspaceDir, {
     bashOperations: embeddedBashOps,
+    bashPolicy: toolsPolicy.bashPolicy,
   }).filter((tool) => isToolAllowedByPolicy(tool.name, toolsPolicy));
-
-  if (
-    toolsPolicy.bashPolicy.allowPrefixes.length > 0 ||
-    toolsPolicy.bashPolicy.denyPrefixes.length > 0
-  ) {
-    tools = tools.map((tool) => {
-      if (tool.name !== "bash") {
-        return tool;
-      }
-      return {
-        ...tool,
-        execute: async (toolCallId, params, signal, onUpdate) => {
-          const command =
-            params && typeof params === "object" && "command" in params
-              ? String((params as { command?: unknown }).command ?? "")
-              : "";
-          enforceBashCommandPolicy(command, toolsPolicy.bashPolicy);
-          return tool.execute(toolCallId, params as any, signal, onUpdate);
-        },
-      };
-    });
-  }
 
   // Credential injection — resolve API key from the in-memory credential store,
   // falling back to process.env only for values that were present at startup.

--- a/packages/agent-worker/src/runtime/tools.ts
+++ b/packages/agent-worker/src/runtime/tools.ts
@@ -11,7 +11,11 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { stripEnv } from "@lobu/core";
-import { isDirectPackageInstallCommand } from "./tool-policy";
+import {
+  type BashCommandPolicy,
+  enforceBashCommandPolicy,
+  isDirectPackageInstallCommand,
+} from "./tool-policy";
 import { SENSITIVE_WORKER_ENV_KEYS } from "../shared/worker-env-keys";
 
 type RequiredParamGroup = {
@@ -130,7 +134,7 @@ function buildEditSchema() {
 
 export function createLobuTools(
   cwd: string,
-  options?: { bashOperations?: BashOperations }
+  options?: { bashOperations?: BashOperations; bashPolicy?: BashCommandPolicy }
 ): AgentTool<any>[] {
   const read = wrapToolWithNormalization({
     tool: createReadTool(cwd),
@@ -162,7 +166,10 @@ export function createLobuTools(
       env: stripEnv(params.env, SENSITIVE_WORKER_ENV_KEYS) as NodeJS.ProcessEnv,
     }),
   };
-  const bash = wrapBashWithProxyHint(createBashTool(cwd, bashToolOpts));
+  const bash = wrapBashWithProxyHint(
+    createBashTool(cwd, bashToolOpts),
+    options?.bashPolicy
+  );
 
   return [
     read,
@@ -229,11 +236,25 @@ function isDirectGatewayApiAccessCommand(command: string): boolean {
 }
 
 /**
- * Wrap bash tool to detect proxy CONNECT 403 errors and append a hint.
- * curl doesn't display the proxy response body for CONNECT failures,
- * so the model never sees "Domain not allowed" — only exit code 56.
+ * The single hardened bash entry point. Wraps the raw bash tool with EVERY
+ * command-inspection guard, so any caller that holds this tool object gets the
+ * full policy by construction. Today the agent's tool loop routes through here;
+ * the forthcoming `!`-bash intercept (PR-D4) is meant to reuse this same object
+ * rather than call `BashOperations.exec()` raw. The guards, in order applied to
+ * the extracted command:
+ *   - prefix allow/deny policy (`enforceBashCommandPolicy`)
+ *   - direct-gateway-API-access block
+ *   - direct-package-install block
+ * and, on failure, a proxy-403 hint (curl hides the proxy CONNECT body, so the
+ * model would otherwise see only exit code 56, not "Domain not allowed").
+ *
+ * Credential-stripping (`spawnHook`/`stripEnv`) lives inside `createBashTool`;
+ * bash *removal* when policy disallows it is a tool-list filter in the caller.
  */
-function wrapBashWithProxyHint(tool: AgentTool<any>): AgentTool<any> {
+function wrapBashWithProxyHint(
+  tool: AgentTool<any>,
+  bashPolicy?: BashCommandPolicy
+): AgentTool<any> {
   const PROXY_403_PATTERN = /Received HTTP code 403 from proxy after CONNECT/i;
 
   return {
@@ -243,6 +264,9 @@ function wrapBashWithProxyHint(tool: AgentTool<any>): AgentTool<any> {
         params && typeof params === "object" && "command" in params
           ? String((params as { command?: unknown }).command ?? "")
           : "";
+      if (bashPolicy) {
+        enforceBashCommandPolicy(command, bashPolicy);
+      }
       if (isDirectGatewayApiAccessCommand(command)) {
         throw new Error(
           "DIRECT GATEWAY API ACCESS BLOCKED. Use the registered MCP/auth tools instead of calling gateway /mcp or /internal endpoints from Bash."


### PR DESCRIPTION
## What

Consolidate **every** bash command-inspection guard into the one wrapped bash tool object, so any caller that holds it gets the full policy by construction.

Before this PR the guards were split:
- **inside** the tool object (`wrapBashWithProxyHint(createBashTool(...))`): credential-strip (`spawnHook`/`stripEnv`), direct-gateway-API-access block, direct-package-install block;
- **outside** it, applied in `session-runner` *after* `createLobuTools` returned: the `enforceBashCommandPolicy` prefix allow/deny — a **conditional re-wrap** that the tool object itself did not carry.

A caller invoking the bash tool object directly would therefore miss the prefix policy.

This moves `enforceBashCommandPolicy` **into** `wrapBashWithProxyHint` (now the single hardened bash entry point), threaded via a new optional `bashPolicy` on `createLobuTools`, and deletes the session-runner re-wrap.

## Why

Foundation for the `!`-bash program (PR-D2..D4). The `!`-bash intercept must run a command through the *exact same* hardened path the agent's own bash tool uses — never `BashOperations.exec()` raw (which skips every guard). Making the tool object self-contained is what lets the forthcoming intercept reuse it by construction instead of re-deriving the checks.

## Scope / safety

- **Behavior-preserving** for the agent tool loop: same guards, same order (prefix → gateway → package-install), same errors. The old code only re-wrapped when the policy had non-empty allow/deny prefixes; the new wrapper only calls `enforceBashCommandPolicy` when a `bashPolicy` is passed, and that function is a no-op for an empty policy — so the empty-policy default is unchanged.
- Bash **removal** (strict / `disallowedTools`) stays a tool-list `.filter` in the caller; credential-strip stays inside `createBashTool`.
- Adds tests asserting the tool object enforces deny/allow prefixes and that no-policy leaves the prior default unchanged.

## Verification

- `bun test embedded-tools.test.ts` → 31 pass (incl. 4 new prefix-policy cases)
- `bun test tool-policy*.test.ts agent-session-bash-env.test.ts` → 122 pass
- `make typecheck` clean; `make pre-pr` clean
- `make review` (codex): bug_free 92, simplicity 91, slop 8, **0 bugs, 0 blockers**, behavior_change_risk: none

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786673554&installation_id=136316292&pr_number=1963&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1963&signature=c38b0e0e6642561bea57e9445bc41ed1297db479f5559452dce2fddebe42ad4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->