### PR TITLE
docs(sdk): teach the connect→feed two-hop so setup actually collects data

### DIFF
--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -174,15 +174,20 @@ describe("method-metadata", () => {
 		const connect = METHOD_METADATA["connections.connect"];
 		expect(connect.summary).toContain("connection_id");
 		expect(connect.summary).toMatch(/create a feed|feeds\.create/);
+		// connect() does NOT always return a connection_id: the setup_required
+		// outcome has none, so the summary must warn against calling feeds.create
+		// with a missing id rather than promising an id unconditionally.
+		expect(connect.summary).toContain("setup_required");
 		const connectExample = connect.usageExample ?? "";
 		expect(connectExample).toContain("connections.connect");
 		expect(connectExample).toContain("feeds.create");
 		expect(connectExample).toContain("connection_id");
 		expect(connectExample).toContain("feed_key");
-		// The website 'pages' config must use the REAL connector keys (urls /
-		// sitemap_url) — a made-up key (config:{} or {url}) creates a feed that
-		// collects zero events, defeating the whole two-hop.
-		expect(connectExample).toMatch(/urls|sitemap_url/);
+		// The website 'pages' config must use the REAL connector keys — assert the
+		// executable expression itself passes urls: [...] (or sitemap_url), not
+		// just that the word appears in a comment. A made-up key (config:{} /
+		// {url}) creates a feed that collects zero events.
+		expect(connectExample).toMatch(/config:\s*\{\s*(urls:\s*\[|sitemap_url:)/);
 
 		// feeds.create must document the connection_id + feed_key it needs and
 		// point at how to discover the config shape — not leave the agent guessing.

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -179,6 +179,10 @@ describe("method-metadata", () => {
 		expect(connectExample).toContain("feeds.create");
 		expect(connectExample).toContain("connection_id");
 		expect(connectExample).toContain("feed_key");
+		// The website 'pages' config must use the REAL connector keys (urls /
+		// sitemap_url) — a made-up key (config:{} or {url}) creates a feed that
+		// collects zero events, defeating the whole two-hop.
+		expect(connectExample).toMatch(/urls|sitemap_url/);
 
 		// feeds.create must document the connection_id + feed_key it needs and
 		// point at how to discover the config shape — not leave the agent guessing.

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -174,10 +174,14 @@ describe("method-metadata", () => {
 		const connect = METHOD_METADATA["connections.connect"];
 		expect(connect.summary).toContain("connection_id");
 		expect(connect.summary).toMatch(/create a feed|feeds\.create/);
-		// connect() does NOT always return a connection_id: the setup_required
-		// outcome has none, so the summary must warn against calling feeds.create
-		// with a missing id rather than promising an id unconditionally.
+		// connect() does NOT always return a usable connection_id: for the
+		// setup_required continuation the field is OPTIONAL. The summary must
+		// describe it as outcome-dependent (not promise an id unconditionally,
+		// and not claim setup_required NEVER has one), so an agent waits for a
+		// real id before calling feeds.create.
 		expect(connect.summary).toContain("setup_required");
+		expect(connect.summary).toMatch(/optional/i);
+		expect(connect.summary).not.toMatch(/NO connection exists/i);
 		const connectExample = connect.usageExample ?? "";
 		expect(connectExample).toContain("connections.connect");
 		expect(connectExample).toContain("feeds.create");

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -165,4 +165,27 @@ describe("method-metadata", () => {
 		// coded relationship_type_exists 409, don't swallow every error.
 		expect(linkExample).toContain("relationship_type_exists");
 	});
+
+	it("teaches the connect→feed two-hop so setup actually collects data", () => {
+		// connections.connect alone syncs nothing — the agent must then create a
+		// feed on the returned connection_id. This is the connect-website eval gap:
+		// agents discover the connector but stall before the feed. Both entries
+		// must name the sibling call and thread connection_id.
+		const connect = METHOD_METADATA["connections.connect"];
+		expect(connect.summary).toContain("connection_id");
+		expect(connect.summary).toMatch(/create a feed|feeds\.create/);
+		const connectExample = connect.usageExample ?? "";
+		expect(connectExample).toContain("connections.connect");
+		expect(connectExample).toContain("feeds.create");
+		expect(connectExample).toContain("connection_id");
+		expect(connectExample).toContain("feed_key");
+
+		// feeds.create must document the connection_id + feed_key it needs and
+		// point at how to discover the config shape — not leave the agent guessing.
+		const feed = METHOD_METADATA["feeds.create"];
+		expect(feed.summary).toContain("connection_id");
+		expect(feed.summary).toContain("feed_key");
+		expect(feed.signature ?? "").toContain("connection_id");
+		expect(feed.example ?? "").toContain("feed_key");
+	});
 });

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -572,7 +572,7 @@ export default async (_ctx, client) => {
 	},
 	"connections.connect": {
 		summary:
-			"Recommended connector setup entry point. Handles every auth family; returns the new `connection_id`. For an auth-none connector (e.g. website) it lands active immediately; auth-gated connectors return a structured setup_required / pending_auth continuation with a connect_url for the user. To actually collect data you must then create a feed on that connection_id — connect() alone syncs nothing.",
+			"Recommended connector setup entry point. Handles every auth family; the result's `status` tells you what to do next. status 'active' (auth-none, e.g. website) or 'pending_auth' (OAuth waiting on the user) BOTH carry a `connection_id`. status 'setup_required' means NO connection exists yet — follow `next_action` / `resume_call` / `completion_check` until you get an active connection, don't call feeds.create with a missing id. Once you have a connection_id you must create a feed on it to collect data — connect() alone syncs nothing.",
 		access: "admin",
 		example:
 			"const c = await client.connections.connect({ connector_key: 'website' }); // c.connection_id",

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -586,11 +586,12 @@ export default async (_ctx, client) => {
   // connect_url / pending_auth for the user to finish first.
   // The feed's config keys come from the connector's feeds_schema — inspect it
   // via client.catalog.listInstalled({ kinds: ['connectors'] }) (each entry's
-  // detail.feeds_schema[feed_key]) if you're unsure what to pass.
+  // detail.feeds_schema[feed_key]) if you're unsure what to pass. For website's
+  // 'pages' feed that's { urls: [...] } (or { sitemap_url }).
   return client.feeds.create({
     connection_id: c.connection_id,
     feed_key: 'pages',
-    config: {},
+    config: { urls: ['https://example.com'] },
   });
 };`,
 	},
@@ -712,7 +713,7 @@ export default async (_ctx, client) => {
 		signature:
 			"feeds.create(input: { connection_id: number; feed_key: string; config?: object; display_name?: string; schedule?: string }): Promise<unknown>",
 		example:
-			"await client.feeds.create({ connection_id: 42, feed_key: 'pages', config: { url: 'https://example.com' } });",
+			"await client.feeds.create({ connection_id: 42, feed_key: 'pages', config: { urls: ['https://example.com'] } });",
 	},
 	"feeds.update": { summary: "Update a feed.", access: "write" },
 	"feeds.delete": {

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -572,7 +572,7 @@ export default async (_ctx, client) => {
 	},
 	"connections.connect": {
 		summary:
-			"Recommended connector setup entry point. Handles every auth family; the result's `status` tells you what to do next. status 'active' (auth-none, e.g. website) or 'pending_auth' (OAuth waiting on the user) BOTH carry a `connection_id`. status 'setup_required' means NO connection exists yet — follow `next_action` / `resume_call` / `completion_check` until you get an active connection, don't call feeds.create with a missing id. Once you have a connection_id you must create a feed on it to collect data — connect() alone syncs nothing.",
+			"Recommended connector setup entry point. Handles every auth family; the result's `status` tells you what to do next. status 'active' (auth-none, e.g. website) or 'pending_auth' (OAuth waiting on the user) BOTH carry a `connection_id`. status 'setup_required' is a continuation — `connection_id` is OPTIONAL there (may be absent); follow `next_action` / `resume_call` / `completion_check` and only call feeds.create once the result actually carries a connection_id. Once you have a connection_id you must create a feed on it to collect data — connect() alone syncs nothing.",
 		access: "admin",
 		example:
 			"const c = await client.connections.connect({ connector_key: 'website' }); // c.connection_id",

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -572,8 +572,27 @@ export default async (_ctx, client) => {
 	},
 	"connections.connect": {
 		summary:
-			"Recommended connector setup entry point. Handles every auth family; setup gaps return a structured setup_required continuation with resolved URLs and directly callable next steps.",
+			"Recommended connector setup entry point. Handles every auth family; returns the new `connection_id`. For an auth-none connector (e.g. website) it lands active immediately; auth-gated connectors return a structured setup_required / pending_auth continuation with a connect_url for the user. To actually collect data you must then create a feed on that connection_id — connect() alone syncs nothing.",
 		access: "admin",
+		example:
+			"const c = await client.connections.connect({ connector_key: 'website' }); // c.connection_id",
+		usageExample: `// Two-hop: connect() creates the connection; feeds.create() starts the
+// collection. connect() ALONE does not sync anything — you must create a feed
+// on the returned connection_id with a connector-declared feed_key
+// (search_sdk '<connector>' lists the feed keys, e.g. website → 'pages').
+export default async (_ctx, client) => {
+  const c = await client.connections.connect({ connector_key: 'website' });
+  // Auth-none connectors are active immediately; auth-gated ones return a
+  // connect_url / pending_auth for the user to finish first.
+  // The feed's config keys come from the connector's feeds_schema — inspect it
+  // via client.catalog.listInstalled({ kinds: ['connectors'] }) (each entry's
+  // detail.feeds_schema[feed_key]) if you're unsure what to pass.
+  return client.feeds.create({
+    connection_id: c.connection_id,
+    feed_key: 'pages',
+    config: {},
+  });
+};`,
 	},
 	"connections.update": {
 		summary: "Update connection config or auth profile.",
@@ -687,8 +706,13 @@ export default async (_ctx, client) => {
 		example: "const feeds = await client.feeds.readMany({ feed_ids: [42, 43], limit: 25 });",
 	},
 	"feeds.create": {
-		summary: "Create a data-sync feed for a connection.",
+		summary:
+			"Create a data-sync feed for a connection — this is what actually starts collecting data. Needs the `connection_id` from connections.connect and a connector-declared `feed_key` (search_sdk '<connector>' lists the keys, e.g. website → 'pages'). Pass connector-specific settings (like the target url) in `config`.",
 		access: "write",
+		signature:
+			"feeds.create(input: { connection_id: number; feed_key: string; config?: object; display_name?: string; schedule?: string }): Promise<unknown>",
+		example:
+			"await client.feeds.create({ connection_id: 42, feed_key: 'pages', config: { url: 'https://example.com' } });",
 	},
 	"feeds.update": { summary: "Update a feed.", access: "write" },
 	"feeds.delete": {


### PR DESCRIPTION
## Why
The `connect-website` eval gap: a weak agent **discovers** the website connector 4/4 but completes the setup 0/4 — it stalls after `connections.connect` and never creates the feed that actually collects data. Root cause: `connections.connect` and `feeds.create` had **no example, no arg shape, and didn't reference each other**, so an agent that knew the *sequence* (from the `search_sdk '<connector>'` lifecycle string) still didn't know how to thread the `connection_id` or what `feeds.create` needs.

Direct analog of #1958 (the entities.create/link two-hop).

## What
- **connections.connect**: summary now says it returns `connection_id` and that you must then `feeds.create` (connect alone syncs nothing). Adds an `example` + a two-hop `usageExample` (connect → feeds.create, threading `connection_id`).
- **feeds.create**: documents its `{ connection_id, feed_key, config }` shape (summary + signature + example), and points at `catalog.listInstalled` → `detail.feeds_schema[feed_key]` to discover the config keys.

Kept the examples **honest**: no fictional `config` keys (I couldn't verify the website feed's config from source, so `config: {}` + a pointer to feeds_schema), and `catalog.listInstalled` is the real method (there is no `catalog.getDetail`).

## Tests
Unit assertion locks in the connect→feed guidance (both entries name the sibling call, thread connection_id, document feed_key). `make pre-pr` clean.

Next: re-run the eval's `connect-website` task to confirm the pass rate moves off 0/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvqppirynLxpoRU4ARjQv7

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786673613&installation_id=136316292&pr_number=1964&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1964&signature=005fe1d266f701742010ead0e88ad47641fb9bee33ac898428a94f71849665dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified connection setup statuses, including when a connection ID is available and when additional setup steps are required.
  * Expanded connection examples to show that creating a connection does not begin data collection.
  * Documented how to create a feed using the returned connection ID and connector-specific feed key.
  * Added details for feed creation inputs, including optional configuration, display name, and schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->