### PR TITLE
Single-source the worker⇄gateway protocol in @lobu/core (#1956 E)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -174,6 +174,7 @@
       },
       "dependencies": {
         "@lobu/connector-sdk": "workspace:*",
+        "@lobu/core": "workspace:*",
         "@lobu/embeddings": "workspace:*",
         "@xenova/transformers": "^2.17.2",
         "esbuild": "^0.28.1",

--- a/packages/connector-worker/package.json
+++ b/packages/connector-worker/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@lobu/connector-sdk": "workspace:*",
+    "@lobu/core": "workspace:*",
     "@lobu/embeddings": "workspace:*",
     "@xenova/transformers": "^2.17.2",
     "esbuild": "^0.28.1",

--- a/packages/connector-worker/src/daemon/client.ts
+++ b/packages/connector-worker/src/daemon/client.ts
@@ -52,207 +52,45 @@ export interface ExecutorClient {
 // Types
 // ============================================
 
+/**
+ * The worker⇄gateway wire payloads are the SINGLE SOURCE in
+ * `@lobu/core/contracts/worker/protocol` (TypeBox). Re-exported here so this
+ * module's public surface is unchanged for importers, while the server annotates
+ * its request-body reads with the same shapes from that file.
+ */
+export type {
+  CompleteActionRequest,
+  CompleteAuthRequest,
+  CompleteEmbeddingsRequest,
+  CompleteRequest,
+  ContentItem,
+  DispatchChromeActionRequest,
+  DispatchChromeActionResponse,
+  EmbedEvent,
+  EmitAuthArtifactRequest,
+  OAuthCredentials,
+  PollAuthSignalRequest,
+  PollAuthSignalResponse,
+  PollResponse,
+  StreamBatch,
+} from "@lobu/core/contracts/worker/protocol";
+import type {
+  CompleteActionRequest,
+  CompleteAuthRequest,
+  CompleteEmbeddingsRequest,
+  CompleteRequest,
+  DispatchChromeActionRequest,
+  DispatchChromeActionResponse,
+  EmbedEvent,
+  EmitAuthArtifactRequest,
+  PollAuthSignalRequest,
+  PollAuthSignalResponse,
+  PollResponse,
+  StreamBatch,
+} from "@lobu/core/contracts/worker/protocol";
+
 /** Capability strings the worker advertises, keyed by name (e.g. `browser.debugger`). */
 export type WorkerCapabilities = Record<string, boolean>;
-
-export interface OAuthCredentials {
-  accessToken: string;
-  provider: string;
-  refreshToken?: string | null;
-  expiresAt?: string | null;
-  scope?: string | null;
-}
-
-export interface PollResponse {
-  next_poll_seconds?: number;
-  /** Run ID (replaces execution_id) */
-  run_id?: number;
-  /** Run type: 'sync', 'action', 'watcher', 'embed_backfill', or 'auth' */
-  run_type?: 'sync' | 'action' | 'watcher' | 'embed_backfill' | 'auth';
-  /** Auth profile ID (for auth runs) */
-  auth_profile_id?: number;
-  /** Previous credentials on the auth profile (for re-auth flows) */
-  previous_credentials?: Record<string, unknown> | null;
-  /** Connector key, e.g. 'google.gmail' */
-  connector_key?: string;
-  /** Feed key for sync runs, e.g. 'threads' */
-  feed_key?: string;
-  /** Feed config */
-  config?: Record<string, unknown>;
-  /**
-   * DB egress boundary the GATEWAY authoritatively decided from its own cloud
-   * mode: `'block-private'` (reject internal/metadata hosts, pin the resolved
-   * IP, force TLS) on Lobu Cloud, else `'allow-private'`. The worker installs
-   * this as `job.env.LOBU_DB_EGRESS_POLICY`, taking the STRICTER of gateway vs.
-   * its own env-derived default — a fleet worker missing `LOBU_CLOUD_MODE` can
-   * never downgrade a gateway that said block-private. Absent on legacy gateway
-   * responses; the worker then falls back to its own env-derived default.
-   */
-  db_egress_policy?: 'block-private' | 'allow-private';
-  /** Feed checkpoint */
-  checkpoint?: Record<string, unknown>;
-  /** Entity IDs from feed */
-  entity_ids?: number[];
-  /** OAuth credentials */
-  credentials?: OAuthCredentials | null;
-  /** Stored env_keys credentials from DB */
-  connection_credentials?: Record<string, unknown>;
-  /** Connection ID */
-  connection_id?: number;
-  /** Feed ID (for sync runs) */
-  feed_id?: number;
-  /**
-   * Compiled connector code, shipped inline. Used for device workers and
-   * DB-only user-uploaded connectors that don't have the connector source
-   * on disk. Fleet workers receive a bare `connector_key` only (no
-   * inline code) and resolve + compile the source from their own
-   * filesystem to keep poll responses small — see worker-api.ts handler
-   * comment + lobu#772 review for why we send the key and not an absolute
-   * path (gateway and worker images have different paths to the same
-   * sources).
-   */
-  compiled_code?: string;
-  /**
-   * Native (nixpkgs) packages the connector declared in `runtime.nix.packages`.
-   * The executor wraps the child in `nix-shell -p <packages>` so the tools are
-   * on PATH. Absent/empty = plain subprocess (the common case).
-   */
-  nix_packages?: string[];
-  /** Connection session state (browser cookies, etc.) */
-  session_state?: Record<string, unknown>;
-  /** Connector version */
-  connector_version?: string;
-  /** Action key (for action runs) */
-  action_key?: string;
-  /** Action input (for action runs) */
-  action_input?: Record<string, unknown>;
-  /** Entity info (for watcher runs) */
-  entity?: { id: number; name: string; entity_type: string; metadata: Record<string, unknown> };
-}
-
-export interface ContentItem {
-  id: string;
-  title?: string;
-  payload_text: string;
-  author_name?: string;
-  occurred_at: string;
-  source_url?: string;
-  score?: number;
-  metadata?: Record<string, unknown>;
-  origin_parent_id?: string;
-  embedding?: number[];
-  /** Model/version stamp that produced `embedding`; persisted so vector spaces never mix. */
-  embedding_model?: string;
-  origin_type?: string;
-  semantic_type?: string;
-}
-
-export interface StreamBatch {
-  type: 'batch';
-  run_id: number;
-  worker_id: string;
-  items: ContentItem[];
-  checkpoint?: Record<string, unknown>;
-}
-
-export interface CompleteRequest {
-  run_id: number;
-  worker_id: string;
-  status: 'success' | 'failed';
-  items_collected?: number;
-  error_message?: string;
-  checkpoint?: Record<string, unknown>;
-  auth_update?: Record<string, unknown>;
-  /** Tail of subprocess stdout+stderr (already redacted in the worker). */
-  output_tail?: string;
-  /** Subprocess exit code, if the child terminated without an IPC result. */
-  exit_code?: number | null;
-  /** Subprocess exit signal, if any. */
-  exit_signal?: string | null;
-  /** Categorized exit reason: ok | error_message | timeout | oom | crash. */
-  exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
-}
-
-export interface CompleteActionRequest {
-  run_id: number;
-  worker_id: string;
-  status: 'success' | 'failed';
-  action_output?: Record<string, unknown>;
-  error_message?: string;
-}
-
-export interface EmbedEvent {
-  id: number;
-  content: string;
-  title: string | null;
-}
-
-export interface CompleteEmbeddingsRequest {
-  run_id: number;
-  worker_id: string;
-  // One entry per (event, chunk). Expand phase: always chunk_index=0, one per
-  // event; the contract release starts emitting multiple (the tail chunks).
-  embeddings: Array<{
-    event_id: number;
-    chunk_index: number;
-    embedding: number[];
-    embedding_model?: string;
-  }>;
-  error_message?: string;
-}
-
-export interface EmitAuthArtifactRequest {
-  run_id: number;
-  worker_id: string;
-  artifact: Record<string, unknown>;
-}
-
-export interface PollAuthSignalRequest {
-  run_id: number;
-  worker_id: string;
-  signal_name: string;
-}
-
-export interface PollAuthSignalResponse {
-  signal?: Record<string, unknown>;
-}
-
-/**
- * Request the gateway dispatch a chrome connector action on behalf of the
- * currently-running sync. The gateway resolves a paired chrome connection
- * in the same org and posts the result back via /api/workers/complete-action,
- * the same path used by the chrome extension for its own action runs.
- */
-export interface DispatchChromeActionRequest {
-  /** run_id of the *parent* sync run (used to scope the dispatch to that org). */
-  parent_run_id: number;
-  worker_id: string;
-  action_key: string;
-  action_input: Record<string, unknown>;
-}
-
-interface DispatchChromeActionResponse {
-  status: 'completed' | 'failed' | 'timeout';
-  output?: Record<string, unknown>;
-  error_message?: string;
-}
-
-export interface CompleteAuthRequest {
-  run_id: number;
-  worker_id: string;
-  status: 'success' | 'failed';
-  credentials?: Record<string, unknown>;
-  metadata?: Record<string, unknown>;
-  error_message?: string;
-  /** Tail of subprocess stdout+stderr (already redacted in the worker). */
-  output_tail?: string;
-  /** Subprocess exit code, if the child terminated without an IPC result. */
-  exit_code?: number | null;
-  /** Subprocess exit signal, if any. */
-  exit_signal?: string | null;
-  /** Categorized exit reason: ok | error_message | timeout | oom | crash. */
-  exit_reason?: 'ok' | 'error_message' | 'timeout' | 'oom' | 'crash';
-}
 
 /**
  * Worker API Client

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,6 +64,12 @@
       "import": "./dist/contracts/agent-settings.js",
       "require": "./dist/contracts/agent-settings.js"
     },
+    "./contracts/worker/protocol": {
+      "types": "./dist/contracts/worker/protocol.d.ts",
+      "bun": "./src/contracts/worker/protocol.ts",
+      "import": "./dist/contracts/worker/protocol.js",
+      "require": "./dist/contracts/worker/protocol.js"
+    },
     "./contracts/tools/manage-agents": {
       "types": "./dist/contracts/tools/manage-agents.d.ts",
       "bun": "./src/contracts/tools/manage-agents.ts",

--- a/packages/core/src/contracts/worker/protocol.ts
+++ b/packages/core/src/contracts/worker/protocol.ts
@@ -1,0 +1,322 @@
+/**
+ * Worker ⇄ gateway HTTP protocol contract (TypeBox).
+ *
+ * Single source of truth for the device/connector-worker job protocol:
+ * `POST /api/workers/poll`, `/api/workers/complete`, `/complete-action`,
+ * `/complete-embeddings`, `/complete-watcher`, `/emit-auth-artifact`,
+ * `/poll-auth-signal`, `/stream`, and the chrome-action dispatch.
+ *
+ * Before this module the wire shapes were typed twice with no compiler link:
+ *   - the SERVER, inline as `c.req.json<{…}>()` in `worker-api/*` handlers, and
+ *   - the WORKER, as hand-written interfaces in
+ *     `connector-worker/src/daemon/client.ts`.
+ * A field added on one side and missed on the other was a silent protocol
+ * mismatch. Both sides now derive their COMPILE-TIME types from the schemas here
+ * (the worker re-exports the `Static<>` types; the server annotates its
+ * `c.req.json<T>()` bodies with them), so the type checker enforces agreement.
+ * These are TypeBox schemas, so a future pass can also validate request bodies
+ * against them at runtime — this change only wires the shared types, not
+ * runtime validation.
+ *
+ * INVARIANT — Workers never receive real credentials (see AGENTS.md). The
+ * `credentials` / `connection_credentials` on `PollResponse` carry only
+ * placeholders / proxied grants the gateway chose to expose; this contract does
+ * not change that boundary, it only types what already crosses it.
+ */
+
+import { type Static, Type } from "@sinclair/typebox";
+
+/** Run kinds the poller can hand back. */
+export const RunTypeSchema = Type.Union([
+  Type.Literal("sync"),
+  Type.Literal("action"),
+  Type.Literal("watcher"),
+  Type.Literal("embed_backfill"),
+  Type.Literal("auth"),
+]);
+
+/** Categorized subprocess exit reason on the failed-run path. */
+export const WorkerExitReasonSchema = Type.Union([
+  Type.Literal("ok"),
+  Type.Literal("error_message"),
+  Type.Literal("timeout"),
+  Type.Literal("oom"),
+  Type.Literal("crash"),
+]);
+
+/**
+ * Diagnostic fields the subprocess executor attaches on the failed-run path.
+ * The worker redacts `output_tail` before sending; the backend stores it as-is.
+ * Shared by `/complete` and `/complete-auth`.
+ */
+export const WorkerExitDiagnosticsSchema = Type.Object({
+  output_tail: Type.Optional(Type.String()),
+  exit_code: Type.Optional(Type.Union([Type.Integer(), Type.Null()])),
+  exit_signal: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  exit_reason: Type.Optional(WorkerExitReasonSchema),
+});
+
+/** OAuth grant the gateway hands a worker for a run (placeholder/proxied). */
+export const OAuthCredentialsSchema = Type.Object({
+  accessToken: Type.String(),
+  provider: Type.String(),
+  refreshToken: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  expiresAt: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  scope: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+});
+
+// ── poll ────────────────────────────────────────────────────────────────────
+
+/** `POST /api/workers/poll` request body. */
+export const PollRequestSchema = Type.Object({
+  worker_id: Type.String(),
+  capabilities: Type.Optional(Type.Record(Type.String(), Type.Boolean())),
+  platform: Type.Optional(Type.String()),
+  app_version: Type.Optional(Type.String()),
+  label: Type.Optional(Type.String()),
+  connector_manifests: Type.Optional(Type.Unknown()),
+});
+
+/** `POST /api/workers/poll` response body (a claimed run, or a poll-again). */
+export const PollResponseSchema = Type.Object({
+  next_poll_seconds: Type.Optional(Type.Number()),
+  run_id: Type.Optional(Type.Integer()),
+  run_type: Type.Optional(RunTypeSchema),
+  auth_profile_id: Type.Optional(Type.Integer()),
+  previous_credentials: Type.Optional(
+    Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])
+  ),
+  connector_key: Type.Optional(Type.String()),
+  feed_key: Type.Optional(Type.String()),
+  config: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  db_egress_policy: Type.Optional(
+    Type.Union([Type.Literal("block-private"), Type.Literal("allow-private")])
+  ),
+  checkpoint: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  entity_ids: Type.Optional(Type.Array(Type.Integer())),
+  credentials: Type.Optional(Type.Union([OAuthCredentialsSchema, Type.Null()])),
+  connection_credentials: Type.Optional(
+    Type.Record(Type.String(), Type.Unknown())
+  ),
+  connection_id: Type.Optional(Type.Integer()),
+  feed_id: Type.Optional(Type.Integer()),
+  compiled_code: Type.Optional(Type.String()),
+  nix_packages: Type.Optional(Type.Array(Type.String())),
+  session_state: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  connector_version: Type.Optional(Type.String()),
+  action_key: Type.Optional(Type.String()),
+  action_input: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  entity: Type.Optional(
+    Type.Object({
+      id: Type.Integer(),
+      name: Type.String(),
+      entity_type: Type.String(),
+      metadata: Type.Record(Type.String(), Type.Unknown()),
+    })
+  ),
+});
+
+// ── stream ──────────────────────────────────────────────────────────────────
+
+/**
+ * One collected item in a `/stream` batch. This is the SERVER-accepted superset:
+ * the connector-worker's `ContentItem` sends the plain-content subset (id,
+ * payload_text, author/source/score/embedding…), while richer producers (the
+ * chrome extension, json_template feeds) also send `payload_type` + the
+ * `payload_data`/`payload_template`/`attachments` it selects. All are optional
+ * so a bare content item still validates.
+ */
+export const ContentItemSchema = Type.Object({
+  id: Type.String(),
+  title: Type.Optional(Type.String()),
+  payload_type: Type.Optional(
+    Type.Union([
+      Type.Literal("text"),
+      Type.Literal("markdown"),
+      Type.Literal("json_template"),
+      Type.Literal("media"),
+      Type.Literal("empty"),
+    ])
+  ),
+  payload_text: Type.String(),
+  payload_data: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  payload_template: Type.Optional(
+    Type.Union([Type.Record(Type.String(), Type.Unknown()), Type.Null()])
+  ),
+  attachments: Type.Optional(Type.Array(Type.Unknown())),
+  author_name: Type.Optional(Type.String()),
+  occurred_at: Type.String(),
+  source_url: Type.Optional(Type.String()),
+  score: Type.Optional(Type.Number()),
+  metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  origin_parent_id: Type.Optional(Type.String()),
+  embedding: Type.Optional(Type.Array(Type.Number())),
+  embedding_model: Type.Optional(Type.String()),
+  origin_type: Type.Optional(Type.String()),
+  semantic_type: Type.Optional(Type.String()),
+});
+
+/**
+ * `POST /api/workers/stream` batch body. `worker_id` is optional here (unlike
+ * the /complete family): a legacy streamer may omit it, and the run-ownership
+ * gate on /stream keys off the run's claimed_by, not this field.
+ */
+export const StreamBatchSchema = Type.Object({
+  type: Type.Literal("batch"),
+  run_id: Type.Integer(),
+  worker_id: Type.Optional(Type.String()),
+  items: Type.Array(ContentItemSchema),
+  checkpoint: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
+
+// ── complete family ─────────────────────────────────────────────────────────
+
+/** `POST /api/workers/complete` (sync/watcher run terminal report). */
+export const CompleteRequestSchema = Type.Composite([
+  Type.Object({
+    run_id: Type.Integer(),
+    worker_id: Type.String(),
+    status: Type.Union([Type.Literal("success"), Type.Literal("failed")]),
+    items_collected: Type.Optional(Type.Integer()),
+    error_message: Type.Optional(Type.String()),
+    checkpoint: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+    auth_update: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  }),
+  WorkerExitDiagnosticsSchema,
+]);
+
+/** `POST /api/workers/complete-action`. */
+export const CompleteActionRequestSchema = Type.Object({
+  run_id: Type.Integer(),
+  worker_id: Type.String(),
+  status: Type.Union([Type.Literal("success"), Type.Literal("failed")]),
+  action_output: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  error_message: Type.Optional(Type.String()),
+});
+
+/** One event returned by `/fetch-events-for-embedding` for the worker to embed. */
+export const EmbedEventSchema = Type.Object({
+  id: Type.Integer(),
+  content: Type.String(),
+  title: Type.Union([Type.String(), Type.Null()]),
+});
+
+/** One (event, chunk) embedding in a `/complete-embeddings` batch. */
+export const EmbeddingEntrySchema = Type.Object({
+  event_id: Type.Integer(),
+  chunk_index: Type.Integer(),
+  embedding: Type.Array(Type.Number()),
+  embedding_model: Type.Optional(Type.String()),
+});
+
+/** `POST /api/workers/complete-embeddings`. */
+export const CompleteEmbeddingsRequestSchema = Type.Object({
+  run_id: Type.Integer(),
+  worker_id: Type.String(),
+  embeddings: Type.Array(EmbeddingEntrySchema),
+  error_message: Type.Optional(Type.String()),
+});
+
+/**
+ * `POST /api/workers/complete-auth` (auth run terminal report). Carries the
+ * same exit diagnostics as `/complete`.
+ */
+export const CompleteAuthRequestSchema = Type.Composite([
+  Type.Object({
+    run_id: Type.Integer(),
+    worker_id: Type.String(),
+    status: Type.Union([Type.Literal("success"), Type.Literal("failed")]),
+    credentials: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+    metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+    error_message: Type.Optional(Type.String()),
+  }),
+  WorkerExitDiagnosticsSchema,
+]);
+
+// ── auth signalling ─────────────────────────────────────────────────────────
+
+/** `POST /api/workers/emit-auth-artifact`. */
+export const EmitAuthArtifactRequestSchema = Type.Object({
+  run_id: Type.Integer(),
+  worker_id: Type.String(),
+  artifact: Type.Record(Type.String(), Type.Unknown()),
+});
+
+/** `POST /api/workers/poll-auth-signal` request. */
+export const PollAuthSignalRequestSchema = Type.Object({
+  run_id: Type.Integer(),
+  worker_id: Type.String(),
+  signal_name: Type.String(),
+});
+
+/** `POST /api/workers/poll-auth-signal` response. */
+export const PollAuthSignalResponseSchema = Type.Object({
+  signal: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+});
+
+/**
+ * `POST /api/workers/heartbeat`. `progress` is a coarse liveness counter, not an
+ * authoritative item count (that arrives on `/stream` + `/complete`).
+ */
+export const HeartbeatRequestSchema = Type.Object({
+  run_id: Type.Integer(),
+  worker_id: Type.String(),
+  progress: Type.Optional(
+    Type.Object({
+      items_collected_so_far: Type.Optional(Type.Integer()),
+    })
+  ),
+});
+
+/**
+ * Request the gateway dispatch a chrome connector action on behalf of a
+ * running sync. Scoped to the parent run's org.
+ */
+export const DispatchChromeActionRequestSchema = Type.Object({
+  parent_run_id: Type.Integer(),
+  worker_id: Type.String(),
+  action_key: Type.String(),
+  action_input: Type.Record(Type.String(), Type.Unknown()),
+});
+
+/** Gateway → worker result of a dispatched chrome action. */
+export const DispatchChromeActionResponseSchema = Type.Object({
+  status: Type.Union([
+    Type.Literal("completed"),
+    Type.Literal("failed"),
+    Type.Literal("timeout"),
+  ]),
+  output: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  error_message: Type.Optional(Type.String()),
+});
+
+export type RunType = Static<typeof RunTypeSchema>;
+export type WorkerExitReason = Static<typeof WorkerExitReasonSchema>;
+export type WorkerExitDiagnostics = Static<typeof WorkerExitDiagnosticsSchema>;
+export type OAuthCredentials = Static<typeof OAuthCredentialsSchema>;
+export type PollRequest = Static<typeof PollRequestSchema>;
+export type PollResponse = Static<typeof PollResponseSchema>;
+export type ContentItem = Static<typeof ContentItemSchema>;
+export type StreamBatch = Static<typeof StreamBatchSchema>;
+export type CompleteRequest = Static<typeof CompleteRequestSchema>;
+export type CompleteActionRequest = Static<typeof CompleteActionRequestSchema>;
+export type EmbedEvent = Static<typeof EmbedEventSchema>;
+export type EmbeddingEntry = Static<typeof EmbeddingEntrySchema>;
+export type CompleteEmbeddingsRequest = Static<
+  typeof CompleteEmbeddingsRequestSchema
+>;
+export type CompleteAuthRequest = Static<typeof CompleteAuthRequestSchema>;
+export type EmitAuthArtifactRequest = Static<
+  typeof EmitAuthArtifactRequestSchema
+>;
+export type PollAuthSignalRequest = Static<typeof PollAuthSignalRequestSchema>;
+export type PollAuthSignalResponse = Static<
+  typeof PollAuthSignalResponseSchema
+>;
+export type HeartbeatRequest = Static<typeof HeartbeatRequestSchema>;
+export type DispatchChromeActionRequest = Static<
+  typeof DispatchChromeActionRequestSchema
+>;
+export type DispatchChromeActionResponse = Static<
+  typeof DispatchChromeActionResponseSchema
+>;

--- a/packages/server/src/worker-api/dispatch-chrome-action.ts
+++ b/packages/server/src/worker-api/dispatch-chrome-action.ts
@@ -19,6 +19,7 @@
  * can land on any replica and finalize the run row.
  */
 
+import type { DispatchChromeActionRequest } from '@lobu/core/contracts/worker/protocol';
 import type { Context } from 'hono';
 import { getDb } from '../db/client';
 import type { Env } from '../index';
@@ -26,13 +27,6 @@ import { waitForDeviceActionRun } from '../tools/admin/manage_operations';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
 import { createConnectorOperationRun } from '../runs/queue-service';
-
-interface DispatchChromeActionBody {
-  parent_run_id: number;
-  worker_id: string;
-  action_key: string;
-  action_input: Record<string, unknown>;
-}
 
 // Online window for chrome extension device workers, in minutes. Matches
 // the /api/me/devices "online" flag.
@@ -297,9 +291,9 @@ export async function dispatchChromeActionToExtension(params: {
 }
 
 export async function dispatchChromeAction(c: Context<{ Bindings: Env }>) {
-  let body: DispatchChromeActionBody;
+  let body: DispatchChromeActionRequest;
   try {
-    body = await c.req.json<DispatchChromeActionBody>();
+    body = await c.req.json<DispatchChromeActionRequest>();
   } catch {
     return c.json({ error: 'Invalid JSON body' }, 400);
   }

--- a/packages/server/src/worker-api/poll.ts
+++ b/packages/server/src/worker-api/poll.ts
@@ -6,6 +6,7 @@
  */
 
 import { authorizeCapabilities } from '@lobu/core';
+import type { PollRequest } from '@lobu/core/contracts/worker/protocol';
 import type { Context } from 'hono';
 import { getDb, pgTextArray } from '../db/client';
 import type { KeyingConfig } from '../types/watchers';
@@ -72,14 +73,7 @@ export async function pollWorkerJob(c: Context<{ Bindings: Env }>) {
   let connectorManifestsProvided = false;
   let connectorManifestsRaw: unknown;
   try {
-    const body = await c.req.json<{
-      worker_id: string;
-      capabilities?: Record<string, boolean>;
-      platform?: string;
-      app_version?: string;
-      label?: string;
-      connector_manifests?: unknown;
-    }>();
+    const body = await c.req.json<PollRequest>();
     worker_id = body.worker_id;
     capabilities = body.capabilities ?? {};
     platform = body.platform ?? null;

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -7,6 +7,16 @@
  * poll-auth-signal.
  */
 
+import type {
+	CompleteActionRequest,
+	CompleteAuthRequest,
+	CompleteEmbeddingsRequest,
+	CompleteRequest,
+	EmitAuthArtifactRequest,
+	HeartbeatRequest,
+	PollAuthSignalRequest,
+	StreamBatch,
+} from "@lobu/core/contracts/worker/protocol";
 import type { Context } from "hono";
 import {
 	maybeCloseRepairThread,
@@ -123,11 +133,8 @@ async function reactivateProfileCascade(
  */
 export async function heartbeat(c: Context<{ Bindings: Env }>) {
 	try {
-		const { run_id, worker_id, progress } = await c.req.json<{
-			run_id: number;
-			worker_id: string;
-			progress?: { items_collected_so_far?: number };
-		}>();
+		const { run_id, worker_id, progress } =
+			await c.req.json<HeartbeatRequest>();
 
 		const denied = await authorizeRunForWorker(c, run_id, worker_id);
 		if (denied) return denied;
@@ -154,36 +161,7 @@ export async function heartbeat(c: Context<{ Bindings: Env }>) {
  */
 export async function streamContent(c: Context<{ Bindings: Env }>) {
 	try {
-		const batch = await c.req.json<{
-			type: "batch";
-			run_id: number;
-			worker_id?: string;
-			items: Array<{
-				id: string;
-				title?: string;
-				payload_type?:
-					| "text"
-					| "markdown"
-					| "json_template"
-					| "media"
-					| "empty";
-				payload_text: string;
-				payload_data?: Record<string, unknown>;
-				payload_template?: Record<string, unknown> | null;
-				attachments?: unknown[];
-				author_name?: string;
-				occurred_at: string;
-				source_url?: string;
-				score?: number;
-				metadata?: Record<string, unknown>;
-				origin_parent_id?: string;
-				origin_type?: string;
-				embedding?: number[];
-				embedding_model?: string;
-				semantic_type?: string;
-			}>;
-			checkpoint?: Record<string, unknown>;
-		}>();
+		const batch = await c.req.json<StreamBatch>();
 
 		// Connector-supplied checkpoints (LinkedIn takeout cursors, browser
 		// scrapes) can carry stray NUL (0x00), which Postgres rejects when written
@@ -391,21 +369,7 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
  */
 export async function completeWorkerJob(c: Context<{ Bindings: Env }>) {
 	try {
-		const req = await c.req.json<{
-			run_id: number;
-			worker_id: string;
-			status: "success" | "failed";
-			items_collected?: number;
-			error_message?: string;
-			checkpoint?: Record<string, unknown>;
-			auth_update?: Record<string, unknown>;
-			// Diagnostic fields from the subprocess executor (failed-run path only).
-			// The worker redacts output_tail before sending; backend stores as-is.
-			output_tail?: string;
-			exit_code?: number | null;
-			exit_signal?: string | null;
-			exit_reason?: "ok" | "error_message" | "timeout" | "oom" | "crash";
-		}>();
+		const req = await c.req.json<CompleteRequest>();
 
 		// Strip NUL (0x00) from connector-supplied jsonb payloads before they hit
 		// Postgres (see streamContent). The final checkpoint and refreshed browser
@@ -1058,17 +1022,7 @@ export async function fetchEventsForEmbedding(c: Context<{ Bindings: Env }>) {
  */
 export async function completeEmbeddings(c: Context<{ Bindings: Env }>) {
 	try {
-		const req = await c.req.json<{
-			run_id: number;
-			worker_id: string;
-			embeddings: Array<{
-				event_id: number;
-				chunk_index: number;
-				embedding: number[];
-				embedding_model?: string;
-			}>;
-			error_message?: string;
-		}>();
+		const req = await c.req.json<CompleteEmbeddingsRequest>();
 
 		// Ownership gate — a worker can only finalize runs it claimed. Mirrors the
 		// other /complete handlers; without it a leaked worker token could mark
@@ -1185,11 +1139,7 @@ export async function completeEmbeddings(c: Context<{ Bindings: Env }>) {
  */
 export async function emitAuthArtifact(c: Context<{ Bindings: Env }>) {
 	try {
-		const { run_id, artifact } = await c.req.json<{
-			run_id: number;
-			worker_id: string;
-			artifact: Record<string, unknown>;
-		}>();
+		const { run_id, artifact } = await c.req.json<EmitAuthArtifactRequest>();
 
 		const sql = getDb();
 
@@ -1214,11 +1164,7 @@ export async function emitAuthArtifact(c: Context<{ Bindings: Env }>) {
  */
 export async function pollAuthSignal(c: Context<{ Bindings: Env }>) {
 	try {
-		const { run_id, signal_name } = await c.req.json<{
-			run_id: number;
-			worker_id: string;
-			signal_name: string;
-		}>();
+		const { run_id, signal_name } = await c.req.json<PollAuthSignalRequest>();
 
 		const sql = getDb();
 
@@ -1251,20 +1197,7 @@ export async function pollAuthSignal(c: Context<{ Bindings: Env }>) {
  */
 export async function completeAuthRun(c: Context<{ Bindings: Env }>) {
 	try {
-		const req = await c.req.json<{
-			run_id: number;
-			worker_id: string;
-			status: "success" | "failed";
-			credentials?: Record<string, unknown>;
-			metadata?: Record<string, unknown>;
-			error_message?: string;
-			// Diagnostic fields from the subprocess executor (failed-run path only).
-			// The worker redacts output_tail before sending; backend stores as-is.
-			output_tail?: string;
-			exit_code?: number | null;
-			exit_signal?: string | null;
-			exit_reason?: "ok" | "error_message" | "timeout" | "oom" | "crash";
-		}>();
+		const req = await c.req.json<CompleteAuthRequest>();
 
 		// Ownership gate — a worker can only finalize runs it claimed. Mirrors the
 		// other /complete handlers. Without it a leaked worker token could finalize
@@ -1355,13 +1288,7 @@ export async function completeAuthRun(c: Context<{ Bindings: Env }>) {
  */
 export async function completeActionRun(c: Context<{ Bindings: Env }>) {
 	try {
-		const req = await c.req.json<{
-			run_id: number;
-			worker_id: string;
-			status: "success" | "failed";
-			action_output?: Record<string, unknown>;
-			error_message?: string;
-		}>();
+		const req = await c.req.json<CompleteActionRequest>();
 
 		// Same ownership check as the other /complete endpoints — a worker
 		// can only finalize runs it claimed. Without this, a leaked worker


### PR DESCRIPTION
Task E from #1956 — the worker⇄gateway HTTP protocol was a third independently-typed surface with no compiler link between the two sides.

## The duplication

The worker job protocol (`poll` / `heartbeat` / `stream` / `complete{,-action,-auth,-embeddings}` / `emit-auth-artifact` / `poll-auth-signal` / `dispatch-chrome-action`) was typed twice:
- the **server**, inline as `c.req.json<{…}>()` in `worker-api/*` handlers
- the **connector-worker**, as ~15 hand-written interfaces in `daemon/client.ts`

Writing the shared contract surfaced real drift the two copies had accumulated:
- the server's `/stream` item is a **superset** — it accepts `payload_type` + `payload_data`/`payload_template`/`attachments` that the worker's `ContentItem` never declared
- `/stream`'s `worker_id` is **optional** server-side but was typed **required** in the worker copy

## The change

New `@lobu/core/contracts/worker/protocol` (new subpath export) is the single TypeBox source: `PollRequest`/`PollResponse`, `StreamBatch` + `ContentItem` (the server-accepted superset), the complete family (with a shared `WorkerExitDiagnostics`), embeddings, auth signalling, heartbeat, and chrome-action dispatch.

- `connector-worker` re-exports the `Static<>` types (its ~15 interfaces deleted; `@lobu/core` added as an explicit dep)
- the server's handlers type their request bodies from the same schemas

**Net −240 lines** of duplicated inline/interface types → one 319-line contract that also carries runtime-checkable schemas (not previously available) for a future validation pass.

Scope notes: this **types** the wire; it does **not** add runtime body validation (a safe follow-up now that the schemas exist), and it does **not** change the credential boundary — workers still receive only placeholder/proxied grants (AGENTS.md invariant). The two session-auth/UI-facing bodies (`auth-runs.ts`, `device-management.ts`) are intentionally left inline — they're not part of the worker-token wire.

## Verification
- `tsc --noEmit` clean in core, server, connector-worker
- connector-worker unit: **52/0**
- worker-api integration against Postgres (complete / complete-auth / dispatch-chrome / poll / embeddings / device-manifests): **25/0**
- `make pre-pr` clean (build + typecheck + knip + biome)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786674535&installation_id=136316292&pr_number=1965&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1965&signature=7c9ef4faa57b95171cef330399119533c15ba1d360c865fe5fd1dff753711bcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->