### PR TITLE
feat(session): project pi bashExecution (!command) records so they survive reload (PR-D3)

### DIFF
--- a/packages/core/src/__tests__/session-file.test.ts
+++ b/packages/core/src/__tests__/session-file.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for utils/session-file.ts.
+ *
+ * Focus: projecting pi's `bashExecution` (`!command`) records so a `!`-bash
+ * turn survives a page reload. pi writes each message wrapped as
+ * `{type:"message", message:{...}}` with the bash fields living directly on
+ * `message` (not in `message.content`). The parser must keep those fields and
+ * project them onto a `bashExecution` ParsedMessage.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { BashExecutionContent } from "../utils/session-file";
+import { entryToMessage, parseSessionEntries } from "../utils/session-file";
+
+// A session.jsonl blob mixing a normal user turn, an assistant turn, and three
+// bashExecution records (exit 0, non-zero+cancelled, and a `!!` excluded one).
+const FIXTURE = [
+  JSON.stringify({ type: "session", id: "sess-1" }),
+  JSON.stringify({
+    type: "message",
+    id: "u1",
+    parentId: null,
+    timestamp: "2026-07-15T02:00:00.000Z",
+    message: { role: "user", content: "hi" },
+  }),
+  JSON.stringify({
+    type: "message",
+    id: "a1",
+    parentId: "u1",
+    timestamp: "2026-07-15T02:00:01.000Z",
+    message: { role: "assistant", content: "hello" },
+  }),
+  JSON.stringify({
+    type: "message",
+    id: "b1",
+    parentId: "a1",
+    timestamp: "2026-07-15T02:00:02.000Z",
+    message: {
+      role: "bashExecution",
+      command: "ls /workspace",
+      output: "file1\nfile2\n",
+      exitCode: 0,
+      cancelled: false,
+      truncated: false,
+      fullOutputPath: "/tmp/x",
+      timestamp: 1752547200000,
+      excludeFromContext: false,
+    },
+  }),
+  JSON.stringify({
+    type: "message",
+    id: "b2",
+    parentId: "b1",
+    timestamp: "2026-07-15T02:00:03.000Z",
+    message: {
+      role: "bashExecution",
+      command: "sleep 100",
+      output: "partial",
+      exitCode: 130,
+      cancelled: true,
+      truncated: true,
+      timestamp: 1752547201000,
+    },
+  }),
+  JSON.stringify({
+    type: "message",
+    id: "b3",
+    parentId: "b2",
+    timestamp: "2026-07-15T02:00:04.000Z",
+    message: {
+      role: "bashExecution",
+      command: "echo secret",
+      output: "secret\n",
+      exitCode: 0,
+      cancelled: false,
+      truncated: false,
+      timestamp: 1752547202000,
+      excludeFromContext: true,
+    },
+  }),
+].join("\n");
+
+describe("parseSessionEntries + entryToMessage — bashExecution projection", () => {
+  const { entries, sessionId } = parseSessionEntries(FIXTURE);
+  const messages = entries
+    .map(entryToMessage)
+    .filter((m): m is NonNullable<typeof m> => m !== null);
+
+  test("extracts the leading session id", () => {
+    expect(sessionId).toBe("sess-1");
+  });
+
+  test("normal user/assistant messages still project unchanged", () => {
+    const user = messages.find((m) => m.id === "u1");
+    const assistant = messages.find((m) => m.id === "a1");
+    expect(user).toMatchObject({
+      type: "message",
+      role: "user",
+      content: "hi",
+    });
+    expect(assistant).toMatchObject({
+      type: "message",
+      role: "assistant",
+      content: "hello",
+    });
+  });
+
+  test("exit-0 bashExecution projects all fields with correct type", () => {
+    const b1 = messages.find((m) => m.id === "b1");
+    expect(b1?.type).toBe("bashExecution");
+    expect(b1?.role).toBe("bashExecution");
+    // Outer ISO timestamp is preserved, not the inner numeric one.
+    expect(b1?.timestamp).toBe("2026-07-15T02:00:02.000Z");
+    const content = b1?.content as BashExecutionContent;
+    expect(content).toEqual({
+      command: "ls /workspace",
+      output: "file1\nfile2\n",
+      exitCode: 0,
+      cancelled: false,
+      truncated: false,
+      excludeFromContext: false,
+      fullOutputPath: "/tmp/x",
+    });
+  });
+
+  test("non-zero exit + cancelled bashExecution keeps exitCode/cancelled/truncated", () => {
+    const b2 = messages.find((m) => m.id === "b2");
+    expect(b2?.type).toBe("bashExecution");
+    const content = b2?.content as BashExecutionContent;
+    expect(content.exitCode).toBe(130);
+    expect(content.cancelled).toBe(true);
+    expect(content.truncated).toBe(true);
+  });
+
+  test("`!!` (excludeFromContext:true) record is still returned (visible), not verbose", () => {
+    const b3 = messages.find((m) => m.id === "b3");
+    expect(b3).toBeDefined();
+    expect(b3?.isVerbose).toBe(false);
+    const content = b3?.content as BashExecutionContent;
+    expect(content.excludeFromContext).toBe(true);
+  });
+
+  test("all three bashExecution records survive projection (none dropped)", () => {
+    const bash = messages.filter((m) => m.type === "bashExecution");
+    expect(bash.map((m) => m.id)).toEqual(["b1", "b2", "b3"]);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -133,8 +133,10 @@ export * from "./utils/sanitize";
 export * from "./utils/secret-redaction";
 // Shared Lobu runtime session.jsonl parser (gateway + worker).
 export {
+  type BashExecutionContent,
   entryToMessage,
   type ParsedMessage,
+  type ParsedMessageType,
   parseSessionEntries,
   type SessionEntry,
   titleFromSessionJsonl,

--- a/packages/core/src/utils/session-file.ts
+++ b/packages/core/src/utils/session-file.ts
@@ -34,8 +34,21 @@ export interface SessionEntry {
   timestamp: string;
   message?: {
     role: string;
-    content: unknown;
+    content?: unknown;
     usage?: { inputTokens?: number; outputTokens?: number };
+    /**
+     * `bashExecution` messages (pi's `!command` records) carry their payload
+     * directly on `message` rather than in `content` — see pi's
+     * `BashExecutionMessage` / `recordBashResult`. These fields are only
+     * present when `role === "bashExecution"`.
+     */
+    command?: string;
+    output?: string;
+    exitCode?: number;
+    cancelled?: boolean;
+    truncated?: boolean;
+    fullOutputPath?: string;
+    excludeFromContext?: boolean;
   };
   summary?: string;
   provider?: string;
@@ -45,10 +58,39 @@ export interface SessionEntry {
   display?: boolean;
 }
 
+/**
+ * The set of `type` discriminants a {@link ParsedMessage} can carry. Kept as a
+ * closed union so API consumers (and the typed client) can exhaustively switch
+ * on it. `bashExecution` projects pi's `!command` records — the command and its
+ * output, so a `!`-bash turn survives a page reload.
+ */
+export type ParsedMessageType =
+  | "message"
+  | "compaction"
+  | "model_change"
+  | "custom_message"
+  | "bashExecution";
+
+/**
+ * Structured `content` for a `bashExecution` {@link ParsedMessage}. `exitCode`
+ * is `undefined` while a command is still running / was cancelled before exit.
+ * `excludeFromContext` mirrors pi's `!!` (hidden-from-model) flag — it does NOT
+ * hide the record from the transcript.
+ */
+export interface BashExecutionContent {
+  command: string;
+  output: string;
+  exitCode?: number;
+  cancelled: boolean;
+  truncated: boolean;
+  excludeFromContext?: boolean;
+  fullOutputPath?: string;
+}
+
 /** Display-friendly projection emitted to API consumers (`/session/messages`). */
 export interface ParsedMessage {
   id: string;
-  type: string;
+  type: ParsedMessageType;
   role?: string;
   content: unknown;
   model?: string;
@@ -92,11 +134,37 @@ export function parseSessionEntries(content: string): {
  * user-visible messages (everything other than `message`, `compaction`,
  * `model_change`, `custom_message`).
  *
+ * A `message` entry whose inner `role` is `bashExecution` (pi's `!command`
+ * record) is projected as a `bashExecution` message with a structured
+ * {@link BashExecutionContent} payload, so a `!`-bash turn survives reload.
+ *
  * `isVerbose` marks entries the UI hides behind a "verbose" toggle —
  * tool results, compaction/model-change markers, custom system events
- * that aren't explicitly displayed.
+ * that aren't explicitly displayed. A `bashExecution` record is never
+ * verbose: even `!!` (`excludeFromContext: true`) is hidden only from the
+ * model's context, not from the transcript.
  */
 export function entryToMessage(entry: SessionEntry): ParsedMessage | null {
+  if (entry.type === "message" && entry.message?.role === "bashExecution") {
+    const m = entry.message;
+    const content: BashExecutionContent = {
+      command: m.command ?? "",
+      output: m.output ?? "",
+      exitCode: m.exitCode,
+      cancelled: m.cancelled ?? false,
+      truncated: m.truncated ?? false,
+      excludeFromContext: m.excludeFromContext,
+      fullOutputPath: m.fullOutputPath,
+    };
+    return {
+      id: entry.id,
+      type: "bashExecution",
+      role: "bashExecution",
+      content,
+      timestamp: entry.timestamp,
+      isVerbose: false,
+    };
+  }
   if (entry.type === "message" && entry.message) {
     return {
       id: entry.id,


### PR DESCRIPTION
## What

Teach Lobu's shared session-file parser + Owletto to project pi's `bashExecution` records, so a `!command` and its output survive a page reload. Third stage of the `!`-bash program (after PR-D1 #1963).

pi persists a `!`-bash turn as a `type:"message"` line whose inner `message.role === "bashExecution"`, with the bash payload (`command`, `output`, `exitCode`, `cancelled`, `truncated`, `fullOutputPath`, `excludeFromContext`) living directly on `message` — not in `message.content`. Lobu's parser dropped those fields (its `SessionEntry.message` was typed `{role, content, usage}` and `entryToMessage` had no bashExecution branch), and Owletto dropped the row entirely (it failed the user/assistant/system role guard). So on reload a `!`-bash turn vanished.

## Changes

**`packages/core/src/utils/session-file.ts`**
- Extend `SessionEntry.message` with the optional bash fields (present only when `role === "bashExecution"`); `content` becomes optional (bash messages carry none).
- New `entryToMessage` branch: `type:"message"` + `role:"bashExecution"` → a `ParsedMessage` of `type:"bashExecution"` with a structured `BashExecutionContent`, the **outer ISO timestamp**, and `isVerbose:false` (a `!!`/`excludeFromContext` record is hidden from the MODEL, never from the transcript).
- Narrow `ParsedMessage.type` from open `string` to a closed `ParsedMessageType` union so consumers can switch exhaustively. Export both new types from `@lobu/core`.

**Owletto** (submodule bump)
- `serverRowToMessage` gains a `bashExecution` branch → a user-side `bash` `ChatPart` (a `!command` is user-initiated).
- New `BashBlock` render: command in mono, output in `<pre>`, subtle `exit N` / `cancelled` badges.

## Why now

The transcript projection is pure and independently testable — it's valuable the moment any bashExecution record exists, and PR-D4 (the `!` intercept) needs it so the turn it records is actually rendered on reload.

## Verification

- **Core parser**: `bun test session-file.test.ts` → 6 pass. Fixture covers user, assistant, exit-0 bash, non-zero+cancelled bash, and a `!!`/`excludeFromContext:true` record (asserts it's returned and not verbose).
- **Owletto seam**: `vitest run lobu-chat-store.test.tsx` → 14 pass (added 3: successful `!command` → user-side bash part; non-zero exit + cancellation preserved; `!!` row still rendered, not dropped).
- `make typecheck` clean (server + owletto strict); `make pre-pr` clean.
- `make review` (codex): bug_free 88, simplicity 91, slop 4, **0 bugs, 0 blockers**. The one flagged gap (`tests_adequate:false` — no Owletto store test) is **closed** by the 3 added store tests.

## Not verified

`BashBlock` not eyeballed in a live browser (dark-theme badge contrast, long-output scroll). Follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786674877&installation_id=136316292&pr_number=1966&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1966&signature=1ac0a8ea00c4dd3a54ddd68f6c32b3ab4848a88cc403fc968d6d335475099743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->