### PR TITLE
Migrate agent-session routes Zod→TypeBox via defineRoute (#1956 B)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Bug fixes require red→fix→green evidence. If you cannot reproduce, bail and report the dead end.
 - Run `make pre-pr` (fast no-DB CI gates: typecheck + knip + lint) AND `make review` (LLM verdict) before PR/merge. `make review` does NOT run typecheck/knip/tests — it is not proof CI will pass. If you touch server/runtime code, also run the relevant `bun test`/`make test-integration` suite.
 - After committing a fix, verify it landed with `git show HEAD:<file>` (or `git diff --stat origin/main...HEAD`). A fix left in the working tree but never committed will not reach CI — confirm HEAD, not just the working tree.
+- **Stage by explicit path; never commit the whole tree of a worktree that hosted other work.** A commit is a snapshot — stale file copies silently revert already-merged PRs. After commit/rebase, `git diff --name-only origin/main...HEAD` must equal the task's intended file list; extra files = stop. Verify a "reverts merged work" review finding by diff direction against `origin/main`, never dismiss it as merge-base noise.
 
 ## Agent workflow
 - Do only what was asked. Delete ephemeral files you create. Do not create `*.md` unless asked.

--- a/packages/server/src/gateway/__tests__/openapi-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/openapi-routes.test.ts
@@ -7,7 +7,8 @@
  * openapi-auto's GET on the same path (the whole-path-spread bug the review
  * caught). Also pins the SSE endpoint's `text/event-stream` declaration.
  */
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { generateWorkerToken } from "@lobu/core";
 import { Hono } from "hono";
 import {
 	buildRoutePaths,
@@ -156,5 +157,58 @@ describe("buildRoutePaths", () => {
 		defineRoute(new Hono(), spec, () => new Response(null));
 		const paths = buildRoutePaths();
 		expect(paths["/api/v1/things/{thingId}/stream"]).toBeDefined();
+	});
+});
+
+describe("POST /api/v1/agents/:id/messages — strict JSON on the REAL route", () => {
+	// The send-message route sets `skipBodyValidation` (multipart OR JSON) and
+	// validates the JSON branch by hand — the synthetic defineRoute tests above
+	// do not exercise that path, so drive the real handler. A worker token whose
+	// agentId matches the path passes the ownership gate without a DB.
+	const TEST_KEY =
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+	let savedKey: string | undefined;
+	beforeEach(() => {
+		savedKey = process.env.ENCRYPTION_KEY;
+		process.env.ENCRYPTION_KEY = TEST_KEY;
+	});
+	afterEach(() => {
+		if (savedKey === undefined) delete process.env.ENCRYPTION_KEY;
+		else process.env.ENCRYPTION_KEY = savedKey;
+	});
+
+	const send = async (body: unknown): Promise<Response> => {
+		const app = createAgentApi({
+			queueProducer: {} as never,
+			sessionManager: { async getSession() { return null; } } as never,
+			sseManager: {} as never,
+			publicGatewayUrl: "http://localhost:8787",
+			artifactStore: {} as never,
+		} as never);
+		const token = generateWorkerToken("agent-x", "conv-1", "dep-1", {
+			channelId: "chan-1",
+			agentId: "agent-x",
+			organizationId: "org-1",
+		});
+		return app.request("/api/v1/agents/agent-x/messages", {
+			method: "POST",
+			headers: {
+				authorization: `Bearer ${token}`,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify(body),
+		});
+	};
+
+	test("numeric content is rejected with a field-level 400", async () => {
+		const res = await send({ content: 123 });
+		expect(res.status).toBe(400);
+		const data = (await res.json()) as { error: string };
+		expect(data.error).toMatch(/content/);
+	});
+
+	test("valid content gets PAST body validation", async () => {
+		const res = await send({ content: "hello" });
+		expect(res.status).not.toBe(400);
 	});
 });

--- a/packages/server/src/gateway/__tests__/openapi-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/openapi-routes.test.ts
@@ -212,3 +212,54 @@ describe("POST /api/v1/agents/:id/messages — strict JSON on the REAL route", (
 		expect(res.status).not.toBe(400);
 	});
 });
+
+describe("optional request bodies", () => {
+	test("a bodyless POST to an all-optional-body route validates as {}", async () => {
+		const app = new Hono();
+		let seen: unknown;
+		defineRoute(
+			app,
+			{
+				method: "post",
+				path: "/optional-body",
+				request: { body: Type.Object({ note: Type.Optional(Type.String()) }) },
+				responses: { 200: { description: "ok" } },
+			},
+			(c) => {
+				seen = getValidated(c).json;
+				return c.json({ ok: true });
+			},
+		);
+		const res = await app.request("/optional-body", { method: "POST" });
+		expect(res.status).toBe(200);
+		expect(seen).toEqual({});
+	});
+
+	test("a bodyless POST to a required-body route fails field-level", async () => {
+		const app = new Hono();
+		defineRoute(
+			app,
+			{
+				method: "post",
+				path: "/required-body",
+				request: { body: Type.Object({ name: Type.String() }) },
+				responses: { 200: { description: "ok" } },
+			},
+			(c) => c.json({ ok: true }),
+		);
+		const res = await app.request("/required-body", { method: "POST" });
+		expect(res.status).toBe(400);
+	});
+
+	test("doc `requestBody.required` mirrors the schema", () => {
+		// Registered by the tests above (registry is module-global).
+		const paths = buildRoutePaths() as Record<
+			string,
+			Record<string, { requestBody?: { required: boolean } }>
+		>;
+		expect(paths["/optional-body"].post.requestBody?.required).toBe(false);
+		expect(paths["/required-body"].post.requestBody?.required).toBe(true);
+		// The real create-agent route is all-optional → optional body.
+		expect(paths["/api/v1/agents"].post.requestBody?.required).toBe(false);
+	});
+});

--- a/packages/server/src/gateway/__tests__/openapi-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/openapi-routes.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Doc-projection regression tests for the defineRoute registry.
+ *
+ * The merged OpenAPI document is assembled from three `paths` groups
+ * (dispatch tools, openapi-auto walk, defineRoute registry). The merge must be
+ * method-wise: the registry documenting POST /api/v1/agents must NOT drop
+ * openapi-auto's GET on the same path (the whole-path-spread bug the review
+ * caught). Also pins the SSE endpoint's `text/event-stream` declaration.
+ */
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import {
+	buildRoutePaths,
+	defineRoute,
+	mergeOpenApiPaths,
+	type RouteSpec,
+} from "../routes/shared/define-route.js";
+import { createAgentApi } from "../routes/public/agent.js";
+import { Type } from "@sinclair/typebox";
+
+describe("mergeOpenApiPaths", () => {
+	test("merges per method — sibling operations on the same path survive", () => {
+		const auto = {
+			"/api/v1/agents": { get: { operationId: "listAgents" } },
+			"/api/v1/agents/{agentId}": {
+				patch: { operationId: "updateAgent" },
+			},
+		};
+		const registry = {
+			"/api/v1/agents": { post: { operationId: "createAgent" } },
+			"/api/v1/agents/{agentId}": {
+				get: { operationId: "getAgent" },
+				delete: { operationId: "deleteAgent" },
+			},
+		};
+		const merged = mergeOpenApiPaths(auto, registry) as Record<
+			string,
+			Record<string, { operationId: string }>
+		>;
+		expect(Object.keys(merged["/api/v1/agents"]).sort()).toEqual([
+			"get",
+			"post",
+		]);
+		expect(Object.keys(merged["/api/v1/agents/{agentId}"]).sort()).toEqual([
+			"delete",
+			"get",
+			"patch",
+		]);
+	});
+
+	test("later group wins per conflicting method", () => {
+		const merged = mergeOpenApiPaths(
+			{ "/x": { get: { operationId: "stub" } } },
+			{ "/x": { get: { operationId: "rich" } } },
+		) as Record<string, Record<string, { operationId: string }>>;
+		expect(merged["/x"].get.operationId).toBe("rich");
+	});
+});
+
+describe("buildRoutePaths", () => {
+	test("agent routes document both methods on /api/v1/agents/{agentId} and SSE media type", () => {
+		// Registering the real agent API populates the route registry.
+		createAgentApi({
+			queueProducer: {} as never,
+			sessionManager: {} as never,
+			sseManager: {} as never,
+			publicGatewayUrl: "http://localhost:8787",
+		} as never);
+
+		const paths = buildRoutePaths() as Record<
+			string,
+			Record<string, { responses: Record<string, unknown> }>
+		>;
+
+		expect(paths["/api/v1/agents"]?.post).toBeDefined();
+		expect(paths["/api/v1/agents/{agentId}"]?.get).toBeDefined();
+		expect(paths["/api/v1/agents/{agentId}"]?.delete).toBeDefined();
+
+		const sse = paths["/api/v1/agents/{agentId}/events"]?.get as {
+			responses: Record<string, { content?: Record<string, unknown> }>;
+		};
+		expect(sse).toBeDefined();
+		expect(Object.keys(sse.responses["200"].content ?? {})).toEqual([
+			"text/event-stream",
+		]);
+	});
+
+	test("custom mediaType and {param} doc form are preserved", () => {
+		const spec: RouteSpec = {
+			method: "get",
+			path: "/api/v1/things/{thingId}/stream",
+			responses: {
+				200: {
+					description: "stream",
+					schema: Type.String(),
+					mediaType: "text/event-stream",
+				},
+			},
+		};
+		defineRoute(new Hono(), spec, () => new Response(null));
+		const paths = buildRoutePaths();
+		expect(paths["/api/v1/things/{thingId}/stream"]).toBeDefined();
+	});
+});

--- a/packages/server/src/gateway/__tests__/openapi-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/openapi-routes.test.ts
@@ -12,6 +12,7 @@ import { Hono } from "hono";
 import {
 	buildRoutePaths,
 	defineRoute,
+	getValidated,
 	mergeOpenApiPaths,
 	type RouteSpec,
 } from "../routes/shared/define-route.js";
@@ -83,6 +84,61 @@ describe("buildRoutePaths", () => {
 		expect(Object.keys(sse.responses["200"].content ?? {})).toEqual([
 			"text/event-stream",
 		]);
+	});
+
+	test("JSON bodies validate STRICTLY — scalar coercion is rejected", async () => {
+		const app = new Hono();
+		defineRoute(
+			app,
+			{
+				method: "post",
+				path: "/strict",
+				request: {
+					body: Type.Object({ content: Type.String() }),
+				},
+				responses: { 200: { description: "ok" } },
+			},
+			(c) => c.json({ ok: true }),
+		);
+		// {content: 123} must be a 400, not silently coerced to "123".
+		const bad = await app.request("/strict", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ content: 123 }),
+		});
+		expect(bad.status).toBe(400);
+		const good = await app.request("/strict", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ content: "hi" }),
+		});
+		expect(good.status).toBe(200);
+	});
+
+	test("path/query params coerce from their string form", async () => {
+		const app = new Hono();
+		let seen: unknown;
+		defineRoute(
+			app,
+			{
+				method: "get",
+				path: "/things/{thingId}",
+				request: {
+					params: Type.Object({ thingId: Type.String() }),
+					query: Type.Object({ limit: Type.Integer({ minimum: 1 }) }),
+				},
+				responses: { 200: { description: "ok" } },
+			},
+			(c) => {
+				seen = getValidated(c).query;
+				return c.json({ ok: true });
+			},
+		);
+		const res = await app.request("/things/t1?limit=5");
+		expect(res.status).toBe(200);
+		expect(seen).toEqual({ limit: 5 });
+		const bad = await app.request("/things/t1?limit=zero");
+		expect(bad.status).toBe(400);
 	});
 
 	test("custom mediaType and {param} doc form are preserved", () => {

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -24,6 +24,7 @@ import { createImageRoutes } from "../routes/internal/images.js";
 import { createInteractionRoutes } from "../routes/internal/interactions.js";
 import { createRuntimeRoutes } from "../routes/internal/runtime.js";
 import { registerAutoOpenApiRoutes } from "../routes/openapi-auto.js";
+import { buildRoutePaths } from "../routes/shared/define-route.js";
 import { createAgentApi } from "../routes/public/agent.js";
 import { createAgentConfigRoutes } from "../routes/public/agent-config.js";
 import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
@@ -878,14 +879,14 @@ curl -X POST http://localhost:8787/api/v1/agents/{agentId}/messages \\
     ],
   };
 
-  // One merged OpenAPI document: the gateway's Zod routes (agent-session
-  // orchestration) PLUS the full dispatch-tool surface
+  // One merged OpenAPI document: the defineRoute registry (agent-session
+  // orchestration, TypeBox), the openapi-auto walk of the remaining gateway
+  // routes (`getOpenAPI31Document`), PLUS the full dispatch-tool surface
   // (`POST /api/{orgSlug}/{tool}` — entities, watchers, feeds, metrics, …),
-  // generated from the same TypeBox schemas the server validates against. The
-  // first-party `@lobu/client` is generated from THIS single document, so the
-  // CLI and UI get a typed client for BOTH surfaces instead of only agent
-  // sessions. `getOpenAPI31Document` renders the Zod routes in the same JSON
-  // Schema 2020-12 dialect the TypeBox tool schemas already use.
+  // all sourced from the same TypeBox schemas the server validates against.
+  // The first-party `@lobu/client` is generated from THIS single document, so
+  // the CLI and UI get a typed client for BOTH surfaces instead of only agent
+  // sessions.
   app.get("/api/docs/openapi.json", async (c) => {
     // Dynamic import (rationale): a static `gateway → openapi-generator →
     // registry` edge closes a circular-init cycle with the tool registry's admin
@@ -898,9 +899,12 @@ curl -X POST http://localhost:8787/api/v1/agents/{agentId}/messages \\
     );
     const base = app.getOpenAPI31Document(openApiDocConfig);
     const toolPaths = generateStrictToolPaths();
+    // `defineRoute` routes (agent-session + config) carry richer TypeBox
+    // request/response schemas than openapi-auto's generic stubs; they win.
+    const routePaths = buildRoutePaths();
     return c.json({
       ...base,
-      paths: { ...toolPaths, ...(base.paths ?? {}) },
+      paths: { ...toolPaths, ...(base.paths ?? {}), ...routePaths },
     });
   });
 

--- a/packages/server/src/gateway/cli/gateway.ts
+++ b/packages/server/src/gateway/cli/gateway.ts
@@ -24,7 +24,10 @@ import { createImageRoutes } from "../routes/internal/images.js";
 import { createInteractionRoutes } from "../routes/internal/interactions.js";
 import { createRuntimeRoutes } from "../routes/internal/runtime.js";
 import { registerAutoOpenApiRoutes } from "../routes/openapi-auto.js";
-import { buildRoutePaths } from "../routes/shared/define-route.js";
+import {
+  buildRoutePaths,
+  mergeOpenApiPaths,
+} from "../routes/shared/define-route.js";
 import { createAgentApi } from "../routes/public/agent.js";
 import { createAgentConfigRoutes } from "../routes/public/agent-config.js";
 import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
@@ -900,11 +903,13 @@ curl -X POST http://localhost:8787/api/v1/agents/{agentId}/messages \\
     const base = app.getOpenAPI31Document(openApiDocConfig);
     const toolPaths = generateStrictToolPaths();
     // `defineRoute` routes (agent-session + config) carry richer TypeBox
-    // request/response schemas than openapi-auto's generic stubs; they win.
+    // request/response schemas than openapi-auto's generic stubs; they win —
+    // but only per METHOD: a whole-path spread would drop sibling operations
+    // (openapi-auto's GET /api/v1/agents, PATCH /api/v1/agents/{agentId}).
     const routePaths = buildRoutePaths();
     return c.json({
       ...base,
-      paths: { ...toolPaths, ...(base.paths ?? {}), ...routePaths },
+      paths: mergeOpenApiPaths(toolPaths, base.paths ?? {}, routePaths),
     });
   });
 

--- a/packages/server/src/gateway/connections/__tests__/chat-connection-service.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/chat-connection-service.test.ts
@@ -41,4 +41,22 @@ describe("parseConfig", () => {
 	test("an unsupported platform is rejected", () => {
 		expect(() => parseConfig("carrier-pigeon", {})).toThrow();
 	});
+
+	test("wrong-typed credentials are rejected, not coerced", () => {
+		// A numeric botToken must NOT be silently stringified to "12345".
+		expect(() =>
+			parseConfig("slack", { botToken: 12345, signingSecret: "s" }),
+		).toThrow(/botToken/);
+	});
+
+	test("scalar mentionRoleIds is rejected (array required)", () => {
+		expect(() =>
+			parseConfig("discord", {
+				botToken: "t",
+				applicationId: "a",
+				publicKey: "p",
+				mentionRoleIds: "role-1",
+			}),
+		).toThrow(/mentionRoleIds/);
+	});
 });

--- a/packages/server/src/gateway/connections/__tests__/chat-connection-service.test.ts
+++ b/packages/server/src/gateway/connections/__tests__/chat-connection-service.test.ts
@@ -1,0 +1,44 @@
+/**
+ * `parseConfig` semantics pinned across the Zod→TypeBox migration:
+ *   - `lobu apply` string booleans coerce ("true" stays accepted);
+ *   - unknown keys are STRIPPED before persistence (Zod's safeParse parity);
+ *   - validation failures surface FIELD-level messages (the Telegram token
+ *     pattern), not a generic "(root) Expected union value".
+ */
+import { describe, expect, test } from "bun:test";
+import { parseConfig } from "../chat-connection-service.js";
+
+describe("parseConfig", () => {
+	test("webhook string booleans are accepted and unknown keys stripped", () => {
+		const parsed = parseConfig("webhook", {
+			token: "t1",
+			searchable: "true",
+			junkKey: "should-not-persist",
+		}) as Record<string, unknown>;
+		expect(parsed).toEqual({
+			platform: "webhook",
+			token: "t1",
+			searchable: "true",
+		});
+	});
+
+	test("telegram config keeps declared keys and drops extras", () => {
+		const botToken = "123456:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+		const parsed = parseConfig("telegram", {
+			botToken,
+			mode: "auto",
+			extra: 1,
+		}) as Record<string, unknown>;
+		expect(parsed).toEqual({ platform: "telegram", botToken, mode: "auto" });
+	});
+
+	test("a malformed telegram token fails with a field-level error", () => {
+		expect(() => parseConfig("telegram", { botToken: "notatoken" })).toThrow(
+			/botToken/,
+		);
+	});
+
+	test("an unsupported platform is rejected", () => {
+		expect(() => parseConfig("carrier-pigeon", {})).toThrow();
+	});
+});

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -1,3 +1,4 @@
+import { Value } from "@sinclair/typebox/value";
 import { getDb } from "../../db/client.js";
 import { getChatInstanceManager } from "../../lobu/gateway.js";
 import {
@@ -115,20 +116,23 @@ function parseConfig(
 	rawConfig: Record<string, unknown>,
 ): PlatformAdapterConfig {
 	requireChatPlatform(platform);
-	const parsed = PlatformAdapterConfigSchema.safeParse({
-		...rawConfig,
-		platform,
-	});
-	if (!parsed.success) {
-		throw new Error(
-			parsed.error.issues.map((issue) => issue.message).join("; "),
-		);
+	const candidate = { ...rawConfig, platform };
+	// TypeBox discriminated-union check: Convert coerces the `lobu apply` string
+	// booleans, then Check validates the matching `platform` member. Clean strips
+	// unknown keys so they don't get persisted (Zod's `safeParse` did implicitly).
+	const converted = Value.Convert(PlatformAdapterConfigSchema, candidate);
+	if (!Value.Check(PlatformAdapterConfigSchema, converted)) {
+		const messages = [
+			...Value.Errors(PlatformAdapterConfigSchema, converted),
+		].map((issue) => `${issue.path || "(root)"} ${issue.message}`.trim());
+		throw new Error(messages.join("; ") || "invalid platform config");
 	}
-	validateRequiredCredentials(platform, parsed.data);
-	// The Zod discriminated union and the hand-written `PlatformAdapterConfig`
-	// union are member-for-member equivalent; TS treats the inferred schema type
-	// as distinct only because of declaration order / optional-field variance.
-	return parsed.data as PlatformAdapterConfig;
+	const coerced = Value.Clean(PlatformAdapterConfigSchema, converted);
+	validateRequiredCredentials(platform, coerced as Record<string, unknown>);
+	// The TypeBox union and the hand-written `PlatformAdapterConfig` union are
+	// member-for-member equivalent; TS treats the schema-inferred type as distinct
+	// only because of declaration order / optional-field variance.
+	return coerced as PlatformAdapterConfig;
 }
 
 async function validateProviderIdentity(

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -111,7 +111,7 @@ function validateRequiredCredentials(
 	}
 }
 
-function parseConfig(
+export function parseConfig(
 	platform: string,
 	rawConfig: Record<string, unknown>,
 ): PlatformAdapterConfig {

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -119,21 +119,23 @@ export function parseConfig(
 	const candidate = { ...rawConfig, platform };
 	// Validate against the union member matching `platform` (requireChatPlatform
 	// guarantees one exists) so failures surface FIELD-level messages (e.g. the
-	// Telegram token pattern) instead of a generic union mismatch. Convert
-	// coerces the `lobu apply` string booleans; Clean strips unknown keys so
-	// they don't get persisted (Zod's `safeParse` did both implicitly).
+	// Telegram token pattern) instead of a generic union mismatch. STRICT Check,
+	// no Value.Convert: the `lobu apply` string-boolean spellings are accepted
+	// by the SCHEMA (boolOrString includes the "true"/"false" literals, exactly
+	// like the previous Zod union), while coercion would silently accept
+	// wrong-typed credentials (numeric botToken → "123"). Clean strips unknown
+	// keys so they don't get persisted (Zod's `safeParse` parity).
 	const memberSchema =
 		PlatformAdapterConfigSchema.anyOf.find(
 			(s) => s.properties.platform.const === platform,
 		) ?? PlatformAdapterConfigSchema;
-	const converted = Value.Convert(memberSchema, candidate);
-	if (!Value.Check(memberSchema, converted)) {
-		const messages = [...Value.Errors(memberSchema, converted)].map(
+	if (!Value.Check(memberSchema, candidate)) {
+		const messages = [...Value.Errors(memberSchema, candidate)].map(
 			(issue) => `${issue.path || "(root)"} ${issue.message}`.trim(),
 		);
 		throw new Error(messages.join("; ") || "invalid platform config");
 	}
-	const coerced = Value.Clean(memberSchema, converted);
+	const coerced = Value.Clean(memberSchema, candidate);
 	validateRequiredCredentials(platform, coerced as Record<string, unknown>);
 	// The TypeBox union and the hand-written `PlatformAdapterConfig` union are
 	// member-for-member equivalent; TS treats the schema-inferred type as distinct

--- a/packages/server/src/gateway/connections/chat-connection-service.ts
+++ b/packages/server/src/gateway/connections/chat-connection-service.ts
@@ -117,17 +117,23 @@ function parseConfig(
 ): PlatformAdapterConfig {
 	requireChatPlatform(platform);
 	const candidate = { ...rawConfig, platform };
-	// TypeBox discriminated-union check: Convert coerces the `lobu apply` string
-	// booleans, then Check validates the matching `platform` member. Clean strips
-	// unknown keys so they don't get persisted (Zod's `safeParse` did implicitly).
-	const converted = Value.Convert(PlatformAdapterConfigSchema, candidate);
-	if (!Value.Check(PlatformAdapterConfigSchema, converted)) {
-		const messages = [
-			...Value.Errors(PlatformAdapterConfigSchema, converted),
-		].map((issue) => `${issue.path || "(root)"} ${issue.message}`.trim());
+	// Validate against the union member matching `platform` (requireChatPlatform
+	// guarantees one exists) so failures surface FIELD-level messages (e.g. the
+	// Telegram token pattern) instead of a generic union mismatch. Convert
+	// coerces the `lobu apply` string booleans; Clean strips unknown keys so
+	// they don't get persisted (Zod's `safeParse` did both implicitly).
+	const memberSchema =
+		PlatformAdapterConfigSchema.anyOf.find(
+			(s) => s.properties.platform.const === platform,
+		) ?? PlatformAdapterConfigSchema;
+	const converted = Value.Convert(memberSchema, candidate);
+	if (!Value.Check(memberSchema, converted)) {
+		const messages = [...Value.Errors(memberSchema, converted)].map(
+			(issue) => `${issue.path || "(root)"} ${issue.message}`.trim(),
+		);
 		throw new Error(messages.join("; ") || "invalid platform config");
 	}
-	const coerced = Value.Clean(PlatformAdapterConfigSchema, converted);
+	const coerced = Value.Clean(memberSchema, converted);
 	validateRequiredCredentials(platform, coerced as Record<string, unknown>);
 	// The TypeBox union and the hand-written `PlatformAdapterConfig` union are
 	// member-for-member equivalent; TS treats the schema-inferred type as distinct

--- a/packages/server/src/gateway/routes/public/agent-config.ts
+++ b/packages/server/src/gateway/routes/public/agent-config.ts
@@ -4,9 +4,10 @@
  * Configuration endpoints mounted under /api/v1/agents/{agentId}/config
  */
 
-import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { Type } from "@sinclair/typebox";
 import type { AgentConfigStore, ModelOption, SkillConfig } from "@lobu/core";
-import type { Context } from "hono";
+import { type Context, Hono } from "hono";
+import { defineRoute, type RouteSpec } from "../shared/define-route.js";
 import {
 	buildProviderCatalog,
 	type ProviderCatalogService,
@@ -39,7 +40,7 @@ import {
 import { verifySettingsSessionOrToken } from "./settings-auth.js";
 
 const TAG = "Configuration";
-const TokenQuery = z.object({ token: z.string().optional() });
+const TokenQuery = Type.Object({ token: Type.Optional(Type.String()) });
 const REDACTED_VALUE = "__LOBU_REDACTED__";
 
 const SENSITIVE_KEY_PATTERN =
@@ -47,26 +48,25 @@ const SENSITIVE_KEY_PATTERN =
 
 // --- Route Definitions ---
 
-const getConfigRoute = createRoute({
+const getConfigRoute: RouteSpec = {
 	method: "get",
-	path: "/",
+	// This router is mounted at `/api/v1/agents/:agentId/config` (gateway.ts),
+	// so it registers `/` on the sub-app but documents the full mounted URL.
+	path: "/api/v1/agents/{agentId}/config",
+	honoPath: "/",
 	tags: [TAG],
 	summary: "Get agent configuration",
-	request: { query: TokenQuery },
+	request: {
+		params: Type.Object({ agentId: Type.String() }),
+		query: TokenQuery,
+	},
 	responses: {
-		200: {
-			description: "Configuration",
-			content: {
-				"application/json": {
-					schema: z.any(),
-				},
-			},
-		},
+		200: { description: "Configuration", schema: Type.Any() },
 		...errorResponses(ErrorResponseSchema, {
 			401: "Unauthorized",
 		}),
 	},
-});
+};
 
 interface ProviderCredentialStore {
 	hasCredentials(
@@ -295,10 +295,8 @@ async function buildResolvedConfigResponse(
 	};
 }
 
-export function createAgentConfigRoutes(
-	config: AgentConfigRoutesConfig,
-): OpenAPIHono {
-	const app = new OpenAPIHono();
+export function createAgentConfigRoutes(config: AgentConfigRoutesConfig): Hono {
+	const app = new Hono();
 
 	const baseVerifyToken = createTokenVerifier({
 		userAgentsStore: config.userAgentsStore,
@@ -356,7 +354,7 @@ export function createAgentConfigRoutes(
 		return { agentId, payload };
 	};
 
-	app.openapi(getConfigRoute, async (c): Promise<any> => {
+	defineRoute(app, getConfigRoute, async (c): Promise<Response> => {
 		const auth = await requireConfigAuth(c);
 		if (auth instanceof Response) return auth;
 		const { agentId, payload } = auth;

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -296,8 +296,11 @@ const getAgentEventsRoute: RouteSpec = {
   bearerAuth: true,
   request: { params: AgentIdParamSchema },
   responses: {
-    // A `text/event-stream` — no JSON body schema (description-only entry).
-    200: { description: "SSE stream" },
+    200: {
+      description: "SSE stream",
+      schema: Type.String(),
+      mediaType: "text/event-stream",
+    },
     ...errorResponses(ErrorResponseSchema, {
       401: "Unauthorized",
       429: "Too many connections",

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1323,9 +1323,10 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       } catch {
         return c.json({ success: false, error: "Invalid JSON body" }, 400);
       }
-      const coerced = Value.Convert(SendMessageRequestSchema, rawBody);
-      if (!Value.Check(SendMessageRequestSchema, coerced)) {
-        const first = Value.Errors(SendMessageRequestSchema, coerced).First();
+      // Strict Check — JSON carries real types, so no Value.Convert here:
+      // coercion would silently accept e.g. `{content: 123}` as "123".
+      if (!Value.Check(SendMessageRequestSchema, rawBody)) {
+        const first = Value.Errors(SendMessageRequestSchema, rawBody).First();
         return c.json(
           {
             success: false,
@@ -1336,7 +1337,7 @@ export function createAgentApi(config: AgentApiConfig): Hono {
           400,
         );
       }
-      body = coerced as Record<string, any>;
+      body = rawBody as Record<string, any>;
     }
 
     const rawMessageContent = body.content || body.message;

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1319,7 +1319,10 @@ export function createAgentApi(config: AgentApiConfig): Hono {
       // (additionalProperties) keeps extra routing fields the handler forwards.
       let rawBody: unknown;
       try {
-        rawBody = await c.req.json();
+        // Missing/empty body → {} (parity with the defineRoute middleware and
+        // the previous zod-openapi validator); non-empty must parse.
+        const text = await c.req.text();
+        rawBody = text.trim() === "" ? {} : JSON.parse(text);
       } catch {
         return c.json({ success: false, error: "Invalid JSON body" }, 400);
       }

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { type Static, Type } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
 import {
   type AgentConfigStore,
   createLogger,
@@ -9,10 +10,14 @@ import {
   normalizeDomainPatterns,
   verifyWorkerToken,
 } from "@lobu/core";
-import type { Context } from "hono";
+import { type Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { bindRequestAbortToStream } from "../../../events/sse-abort-bridge.js";
-import { z } from "zod";
+import {
+  defineRoute,
+  getValidated,
+  type RouteSpec,
+} from "../shared/define-route.js";
 import { DEFAULT_AGENT_ID } from "../../../auth/default-provisioning.js";
 import { getDb } from "../../../db/client.js";
 import { getCachedOrgBySlug } from "../../../workspace/multi-tenant.js";
@@ -53,115 +58,121 @@ const MAX_CONNECTIONS_PER_AGENT = 5;
 const MAX_TOTAL_CONNECTIONS = 1000;
 
 // =============================================================================
-// Zod Schemas
+// TypeBox Schemas
 // =============================================================================
 
-const NetworkConfigSchema = z.object({
-  allowedDomains: z.array(z.string()).optional(),
-  deniedDomains: z.array(z.string()).optional(),
+const NetworkConfigSchema = Type.Object({
+  allowedDomains: Type.Optional(Type.Array(Type.String())),
+  deniedDomains: Type.Optional(Type.Array(Type.String())),
 });
 
-const NixConfigSchema = z.object({
-  flakeUrl: z.string().optional(),
-  packages: z.array(z.string()).optional(),
+const NixConfigSchema = Type.Object({
+  flakeUrl: Type.Optional(Type.String()),
+  packages: Type.Optional(Type.Array(Type.String())),
 });
 
-const WatcherRunIntentSchema = z.object({
-  kind: z.literal("watcher_run"),
-  runId: z.number().int().positive(),
-  watcherId: z.number().int().positive(),
+const WatcherRunIntentSchema = Type.Object({
+  kind: Type.Literal("watcher_run"),
+  runId: Type.Integer({ minimum: 1 }),
+  watcherId: Type.Integer({ minimum: 1 }),
 });
 
-const CreateAgentRequestSchema = z.object({
-  provider: z.literal("claude").default("claude").optional(),
-  model: z.string().optional(),
-  agentId: z.string().min(1).optional(),
-  userId: z.string().min(1).optional(),
-  thread: z.string().optional(),
-  forceNew: z.boolean().optional(),
-  dryRun: z.boolean().optional(),
-  intent: WatcherRunIntentSchema.optional(),
-  networkConfig: NetworkConfigSchema.optional(),
-  nix: NixConfigSchema.optional(),
+const CreateAgentRequestSchema = Type.Object({
+  provider: Type.Optional(Type.Literal("claude", { default: "claude" })),
+  model: Type.Optional(Type.String()),
+  agentId: Type.Optional(Type.String({ minLength: 1 })),
+  userId: Type.Optional(Type.String({ minLength: 1 })),
+  thread: Type.Optional(Type.String()),
+  forceNew: Type.Optional(Type.Boolean()),
+  dryRun: Type.Optional(Type.Boolean()),
+  intent: Type.Optional(WatcherRunIntentSchema),
+  networkConfig: Type.Optional(NetworkConfigSchema),
+  nix: Type.Optional(NixConfigSchema),
 });
 
-const CreateAgentResponseSchema = z.object({
-  success: z.boolean(),
-  agentId: z.string(),
-  token: z.string(),
-  expiresAt: z.number(),
-  sseUrl: z.string(),
-  messagesUrl: z.string(),
+const CreateAgentResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  agentId: Type.String(),
+  token: Type.String(),
+  expiresAt: Type.Number(),
+  sseUrl: Type.String(),
+  messagesUrl: Type.String(),
 });
 
-const SlackRoutingInfoSchema = z.object({
-  channel: z.string().describe("Slack channel ID"),
-  thread: z.string().optional().describe("Thread timestamp for replies"),
-  team: z.string().optional().describe("Slack team ID"),
+const SlackRoutingInfoSchema = Type.Object({
+  channel: Type.String({ description: "Slack channel ID" }),
+  thread: Type.Optional(
+    Type.String({ description: "Thread timestamp for replies" }),
+  ),
+  team: Type.Optional(Type.String({ description: "Slack team ID" })),
 });
 
-const SendMessageRequestSchema = z
-  .object({
-    content: z.string().optional().describe("Message content"),
-    message: z
-      .string()
-      .optional()
-      .describe("Message content (alias for content)"),
-    messageId: z.string().optional(),
-    model: z
-      .string()
-      .optional()
-      .describe(
-        "Optional per-message model override (a `provider/model` ref or \"auto\"). " +
-          "Wins over the agent/org default. Used by behavior dispatch (e.g. watcher runs)."
-      ),
-    platform: z
-      .string()
-      .optional()
-      .describe("Target platform (api, slack, telegram)"),
-    slack: SlackRoutingInfoSchema.optional().describe(
-      "Slack-specific routing info (required when platform=slack)"
+// `.passthrough()` → additionalProperties: true (senders attach extra routing
+// fields the handler forwards untouched).
+const SendMessageRequestSchema = Type.Object(
+  {
+    content: Type.Optional(Type.String({ description: "Message content" })),
+    message: Type.Optional(
+      Type.String({ description: "Message content (alias for content)" }),
     ),
-  })
-  .passthrough();
+    messageId: Type.Optional(Type.String()),
+    model: Type.Optional(
+      Type.String({
+        description:
+          'Optional per-message model override (a `provider/model` ref or "auto"). ' +
+          "Wins over the agent/org default. Used by behavior dispatch (e.g. watcher runs).",
+      }),
+    ),
+    platform: Type.Optional(
+      Type.String({ description: "Target platform (api, slack, telegram)" }),
+    ),
+    slack: Type.Optional(
+      Type.Composite([SlackRoutingInfoSchema], {
+        description:
+          "Slack-specific routing info (required when platform=slack)",
+      }),
+    ),
+  },
+  { additionalProperties: true },
+);
 
-const SendMessageResponseSchema = z.object({
-  success: z.boolean(),
-  messageId: z.string(),
-  agentId: z.string().optional(),
-  jobId: z.string().optional(),
-  eventsUrl: z.string().optional(),
-  queued: z.boolean(),
-  traceparent: z.string().optional(),
+const SendMessageResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  messageId: Type.String(),
+  agentId: Type.Optional(Type.String()),
+  jobId: Type.Optional(Type.String()),
+  eventsUrl: Type.Optional(Type.String()),
+  queued: Type.Boolean(),
+  traceparent: Type.Optional(Type.String()),
 });
 
-const AgentStatusResponseSchema = z.object({
-  success: z.boolean(),
-  agent: z.object({
-    agentId: z.string(),
-    userId: z.string(),
-    status: z.string(),
-    createdAt: z.number(),
-    lastActivity: z.number(),
-    hasActiveConnection: z.boolean(),
+const AgentStatusResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  agent: Type.Object({
+    agentId: Type.String(),
+    userId: Type.String(),
+    status: Type.String(),
+    createdAt: Type.Number(),
+    lastActivity: Type.Number(),
+    hasActiveConnection: Type.Boolean(),
   }),
 });
 
-const ErrorResponseSchema = z.object({
-  success: z.boolean(),
-  error: z.string(),
-  details: z.string().optional(),
+const ErrorResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  error: Type.String(),
+  details: Type.Optional(Type.String()),
 });
 
-const SuccessResponseSchema = z.object({
-  success: z.boolean(),
-  message: z.string().optional(),
-  agentId: z.string().optional(),
+const SuccessResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  message: Type.Optional(Type.String()),
+  agentId: Type.Optional(Type.String()),
 });
 
 // Path parameters
-const AgentIdParamSchema = z.object({
-  agentId: z.string(),
+const AgentIdParamSchema = Type.Object({
+  agentId: Type.String(),
 });
 
 // =============================================================================
@@ -224,92 +235,77 @@ function normalizeNetworkConfig(config: NetworkConfig): NetworkConfig {
 // OpenAPI Route Definitions
 // =============================================================================
 
-const createAgentRoute = createRoute({
+const createAgentRoute: RouteSpec = {
   method: "post",
   path: "/api/v1/agents",
   tags: ["Agents"],
   summary: "Create a new agent",
-  security: [{ bearerAuth: [] }],
+  bearerAuth: true,
   description:
     "Creates a new agent session and returns authentication credentials",
-  request: {
-    body: {
-      content: { "application/json": { schema: CreateAgentRequestSchema } },
-    },
-  },
+  request: { body: CreateAgentRequestSchema },
   responses: {
-    201: {
-      description: "Agent created",
-      content: { "application/json": { schema: CreateAgentResponseSchema } },
-    },
+    201: { description: "Agent created", schema: CreateAgentResponseSchema },
     ...errorResponses(ErrorResponseSchema, {
       400: "Invalid request",
       401: "Unauthorized",
     }),
   },
-});
+};
 
-const getAgentRoute = createRoute({
+const getAgentRoute: RouteSpec = {
   method: "get",
   path: "/api/v1/agents/{agentId}",
   tags: ["Agents"],
   summary: "Get agent status",
-  security: [{ bearerAuth: [] }],
+  bearerAuth: true,
   request: { params: AgentIdParamSchema },
   responses: {
-    200: {
-      description: "Agent status",
-      content: { "application/json": { schema: AgentStatusResponseSchema } },
-    },
+    200: { description: "Agent status", schema: AgentStatusResponseSchema },
     ...errorResponses(ErrorResponseSchema, {
       401: "Unauthorized",
       404: "Not found",
     }),
   },
-});
+};
 
-const deleteAgentRoute = createRoute({
+const deleteAgentRoute: RouteSpec = {
   method: "delete",
   path: "/api/v1/agents/{agentId}",
   tags: ["Agents"],
   // Deletes the SESSION only (the path param is a sessionKey); the agent row
   // itself persists — it's owned by the org or the user's personal org.
   summary: "Delete an agent session",
-  security: [{ bearerAuth: [] }],
+  bearerAuth: true,
   request: { params: AgentIdParamSchema },
   responses: {
-    200: {
-      description: "Agent session deleted",
-      content: { "application/json": { schema: SuccessResponseSchema } },
-    },
+    200: { description: "Agent session deleted", schema: SuccessResponseSchema },
     ...errorResponses(ErrorResponseSchema, {
       401: "Unauthorized",
       404: "Not found",
     }),
   },
-});
+};
 
-const getAgentEventsRoute = createRoute({
+const getAgentEventsRoute: RouteSpec = {
   method: "get",
   path: "/api/v1/agents/{agentId}/events",
   tags: ["Messages"],
   summary: "Subscribe to agent events (SSE)",
   description: "Server-Sent Events stream for real-time agent updates",
-  security: [{ bearerAuth: [] }],
+  bearerAuth: true,
   request: { params: AgentIdParamSchema },
   responses: {
-    200: {
-      description: "SSE stream",
-      content: { "text/event-stream": { schema: z.string() } },
-    },
+    // A `text/event-stream` — no JSON body schema (description-only entry).
+    200: { description: "SSE stream" },
     ...errorResponses(ErrorResponseSchema, {
       401: "Unauthorized",
       429: "Too many connections",
     }),
   },
-});
+};
 
-const sendMessageRoute = createRoute({
+const sendMessageRoute: RouteSpec = {
   method: "post",
   path: "/api/v1/agents/{agentId}/messages",
   tags: ["Messages"],
@@ -317,20 +313,16 @@ const sendMessageRoute = createRoute({
   description:
     "Send a message to an agent. Supports JSON body or multipart form data for file uploads. " +
     "When platform is specified, the message is routed through the platform adapter.",
-  security: [{ bearerAuth: [] }],
+  bearerAuth: true,
   request: {
     params: AgentIdParamSchema,
-    body: {
-      content: {
-        "application/json": { schema: SendMessageRequestSchema },
-      },
-    },
+    body: SendMessageRequestSchema,
   },
+  // The handler accepts multipart form-data OR JSON and branches on
+  // Content-Type, so it parses+validates the body itself (see the flag doc).
+  skipBodyValidation: true,
   responses: {
-    200: {
-      description: "Message queued",
-      content: { "application/json": { schema: SendMessageResponseSchema } },
-    },
+    200: { description: "Message queued", schema: SendMessageResponseSchema },
     ...errorResponses(ErrorResponseSchema, {
       400: "Invalid request",
       401: "Unauthorized",
@@ -338,7 +330,7 @@ const sendMessageRoute = createRoute({
       404: "Agent not found",
     }),
   },
-});
+};
 
 // =============================================================================
 // System-agent resolution + gating
@@ -400,7 +392,7 @@ interface AgentApiConfig {
   ) => Promise<{ success: boolean; error?: string }>;
 }
 
-export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
+export function createAgentApi(config: AgentApiConfig): Hono {
   const {
     queueProducer,
     externalAuthClient,
@@ -414,7 +406,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
   const sseManager = config.sseManager;
   const pubUrl = config.publicGatewayUrl;
   const artifactStore = config.artifactStore;
-  const app = new OpenAPIHono();
+  const app = new Hono();
 
   // Unified auth middleware for all agent API routes
   app.use(
@@ -741,8 +733,8 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
   // =============================================================================
 
   // POST /api/v1/agents - Create agent
-  app.openapi(createAgentRoute, async (c): Promise<any> => {
-    const body = c.req.valid("json");
+  defineRoute(app, createAgentRoute, async (c): Promise<Response> => {
+    const body = getValidated<Static<typeof CreateAgentRequestSchema>>(c).json;
     const {
       provider = "claude",
       model,
@@ -1016,8 +1008,9 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
   });
 
   // GET /api/v1/agents/:agentId - Get status
-  app.openapi(getAgentRoute, async (c): Promise<any> => {
-    const { agentId: sessionKey } = c.req.valid("param");
+  defineRoute(app, getAgentRoute, async (c): Promise<Response> => {
+    const { agentId: sessionKey } =
+      getValidated<never, Static<typeof AgentIdParamSchema>>(c).param;
 
     const session = await sessMgr.getSession(sessionKey);
     if (!session) {
@@ -1047,8 +1040,9 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
   });
 
   // DELETE /api/v1/agents/:agentId
-  app.openapi(deleteAgentRoute, async (c): Promise<any> => {
-    const { agentId: sessionKey } = c.req.valid("param");
+  defineRoute(app, deleteAgentRoute, async (c): Promise<Response> => {
+    const { agentId: sessionKey } =
+      getValidated<never, Static<typeof AgentIdParamSchema>>(c).param;
 
     // Resolve the real agentId BEFORE any mutation so ownership can be
     // checked against the actual agent (the path param is a sessionKey).
@@ -1080,8 +1074,9 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
   });
 
   // GET /api/v1/agents/:agentId/events - SSE stream
-  app.openapi(getAgentEventsRoute, async (c): Promise<any> => {
-    const { agentId: sessionKey } = c.req.valid("param");
+  defineRoute(app, getAgentEventsRoute, async (c): Promise<Response> => {
+    const { agentId: sessionKey } =
+      getValidated<never, Static<typeof AgentIdParamSchema>>(c).param;
 
     const session = await sessMgr.getSession(sessionKey);
     if (!session) {
@@ -1207,8 +1202,9 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
   // Supports two paths:
   //   1. Direct API (no platform field): requires pre-created session, enqueues directly
   //   2. Platform-routed (platform field present): delegates to platform adapter
-  app.openapi(sendMessageRoute, async (c): Promise<any> => {
-    const { agentId } = c.req.valid("param");
+  defineRoute(app, sendMessageRoute, async (c): Promise<Response> => {
+    const { agentId } =
+      getValidated<never, Static<typeof AgentIdParamSchema>>(c).param;
 
     // Gate ownership BEFORE parsing body / uploading files. The path param is
     // usually a sessionKey (conversationId); resolve to the real agentId when
@@ -1315,7 +1311,29 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         if (fileResults.length > 0) files = fileResults;
       }
     } else {
-      body = c.req.valid("json");
+      // `skipBodyValidation` is set on the route (multipart branch above), so
+      // validate the JSON body here against the same schema. `passthrough`
+      // (additionalProperties) keeps extra routing fields the handler forwards.
+      let rawBody: unknown;
+      try {
+        rawBody = await c.req.json();
+      } catch {
+        return c.json({ success: false, error: "Invalid JSON body" }, 400);
+      }
+      const coerced = Value.Convert(SendMessageRequestSchema, rawBody);
+      if (!Value.Check(SendMessageRequestSchema, coerced)) {
+        const first = Value.Errors(SendMessageRequestSchema, coerced).First();
+        return c.json(
+          {
+            success: false,
+            error: first
+              ? `${first.path || "(root)"} ${first.message}`.trim()
+              : "Invalid request body",
+          },
+          400,
+        );
+      }
+      body = coerced as Record<string, any>;
     }
 
     const rawMessageContent = body.content || body.message;

--- a/packages/server/src/gateway/routes/schemas/platform-config.ts
+++ b/packages/server/src/gateway/routes/schemas/platform-config.ts
@@ -1,239 +1,278 @@
 /**
- * Per-platform connection config Zod schemas (with OpenAPI annotations and
- * the `platform` literal discriminator for the API layer).
+ * Per-platform connection config schemas (TypeBox) with the `platform` literal
+ * discriminator for the API layer.
  *
- * Field definitions mirror @lobu/core platform schemas; the gateway adds
- * `.openapi()` metadata. Single registry for every route module that needs
- * to validate or document a platform connection config.
+ * Field definitions mirror @lobu/core platform schemas; this adds OpenAPI
+ * `description` metadata. Single registry for every route module that needs to
+ * validate or document a platform connection config.
  */
 
-import { z } from "@hono/zod-openapi";
+import { Type } from "@sinclair/typebox";
 
 // Telegram bot tokens have the shape `<numeric-id>:<35-char-base62-ish>`.
 // Reject anything else early so a typo'd token doesn't get persisted and
 // then crash the adapter at runtime with a confusing 401 from Telegram.
-const TELEGRAM_BOT_TOKEN_RE = /^\d{6,12}:[A-Za-z0-9_-]{30,}$/;
+// Empty string is allowed (falls back to the TELEGRAM_BOT_TOKEN env var), so the
+// pattern is `^$ | <token>` — the TypeBox equivalent of the previous Zod
+// `.refine(v => v === "" || RE.test(v))`.
+const TELEGRAM_BOT_TOKEN_PATTERN = "^$|^\\d{6,12}:[A-Za-z0-9_-]{30,}$";
 
-const TelegramConfigSchema = z.object({
-  platform: z.literal("telegram"),
-  botToken: z
-    .string()
-    .refine((value) => value === "" || TELEGRAM_BOT_TOKEN_RE.test(value), {
-      message:
-        "Telegram bot token must look like '<digits>:<35+ char alphanumeric>' (the format BotFather returns)",
-    })
-    .optional()
-    .openapi({
-      description:
-        "Telegram bot token from BotFather. Falls back to TELEGRAM_BOT_TOKEN env var.",
-    }),
-  mode: z.enum(["auto", "webhook", "polling"]).optional().openapi({
-    description: "Runtime mode: auto (default), webhook, or polling.",
-  }),
-  secretToken: z.string().optional().openapi({
-    description:
-      "Webhook secret token for x-telegram-bot-api-secret-token verification.",
-  }),
-  userName: z
-    .string()
-    .optional()
-    .openapi({ description: "Override bot username." }),
-  apiBaseUrl: z
-    .string()
-    .optional()
-    .openapi({ description: "Custom Telegram API base URL." }),
+const TelegramConfigSchema = Type.Object({
+	platform: Type.Literal("telegram"),
+	botToken: Type.Optional(
+		Type.String({
+			pattern: TELEGRAM_BOT_TOKEN_PATTERN,
+			description:
+				"Telegram bot token from BotFather (format '<digits>:<35+ char alphanumeric>'). Falls back to TELEGRAM_BOT_TOKEN env var.",
+		}),
+	),
+	mode: Type.Optional(
+		Type.Union(
+			[Type.Literal("auto"), Type.Literal("webhook"), Type.Literal("polling")],
+			{ description: "Runtime mode: auto (default), webhook, or polling." },
+		),
+	),
+	secretToken: Type.Optional(
+		Type.String({
+			description:
+				"Webhook secret token for x-telegram-bot-api-secret-token verification.",
+		}),
+	),
+	userName: Type.Optional(
+		Type.String({ description: "Override bot username." }),
+	),
+	apiBaseUrl: Type.Optional(
+		Type.String({ description: "Custom Telegram API base URL." }),
+	),
 });
 
-const SlackConfigSchema = z.object({
-  platform: z.literal("slack"),
-  botToken: z.string().optional().openapi({
-    description: "Bot token (xoxb-...). Required for single-workspace mode.",
-  }),
-  botUserId: z.string().optional().openapi({
-    description: "Bot user ID (fetched automatically if omitted).",
-  }),
-  signingSecret: z
-    .string()
-    .optional()
-    .openapi({ description: "Signing secret for webhook verification." }),
-  clientId: z.string().optional().openapi({
-    description: "Slack app client ID (required for OAuth / multi-workspace).",
-  }),
-  clientSecret: z.string().optional().openapi({
-    description:
-      "Slack app client secret (required for OAuth / multi-workspace).",
-  }),
-  encryptionKey: z.string().optional().openapi({
-    description:
-      "Base64-encoded 32-byte AES-256-GCM key for encrypting stored bot tokens.",
-  }),
-  installationKeyPrefix: z.string().optional().openapi({
-    description:
-      "State key prefix for workspace installations (default: slack:installation).",
-  }),
-  userName: z
-    .string()
-    .optional()
-    .openapi({ description: "Override bot username." }),
+const SlackConfigSchema = Type.Object({
+	platform: Type.Literal("slack"),
+	botToken: Type.Optional(
+		Type.String({
+			description: "Bot token (xoxb-...). Required for single-workspace mode.",
+		}),
+	),
+	botUserId: Type.Optional(
+		Type.String({
+			description: "Bot user ID (fetched automatically if omitted).",
+		}),
+	),
+	signingSecret: Type.Optional(
+		Type.String({ description: "Signing secret for webhook verification." }),
+	),
+	clientId: Type.Optional(
+		Type.String({
+			description: "Slack app client ID (required for OAuth / multi-workspace).",
+		}),
+	),
+	clientSecret: Type.Optional(
+		Type.String({
+			description:
+				"Slack app client secret (required for OAuth / multi-workspace).",
+		}),
+	),
+	encryptionKey: Type.Optional(
+		Type.String({
+			description:
+				"Base64-encoded 32-byte AES-256-GCM key for encrypting stored bot tokens.",
+		}),
+	),
+	installationKeyPrefix: Type.Optional(
+		Type.String({
+			description:
+				"State key prefix for workspace installations (default: slack:installation).",
+		}),
+	),
+	userName: Type.Optional(
+		Type.String({ description: "Override bot username." }),
+	),
 });
 
-const DiscordConfigSchema = z.object({
-  platform: z.literal("discord"),
-  botToken: z
-    .string()
-    .optional()
-    .openapi({ description: "Discord bot token." }),
-  applicationId: z
-    .string()
-    .optional()
-    .openapi({ description: "Discord application ID." }),
-  publicKey: z.string().optional().openapi({
-    description: "Application public key for webhook signature verification.",
-  }),
-  mentionRoleIds: z.array(z.string()).optional().openapi({
-    description:
-      "Role IDs that trigger mention handlers (in addition to direct mentions).",
-  }),
-  userName: z
-    .string()
-    .optional()
-    .openapi({ description: "Override bot username." }),
+const DiscordConfigSchema = Type.Object({
+	platform: Type.Literal("discord"),
+	botToken: Type.Optional(Type.String({ description: "Discord bot token." })),
+	applicationId: Type.Optional(
+		Type.String({ description: "Discord application ID." }),
+	),
+	publicKey: Type.Optional(
+		Type.String({
+			description:
+				"Application public key for webhook signature verification.",
+		}),
+	),
+	mentionRoleIds: Type.Optional(
+		Type.Array(Type.String(), {
+			description:
+				"Role IDs that trigger mention handlers (in addition to direct mentions).",
+		}),
+	),
+	userName: Type.Optional(
+		Type.String({ description: "Override bot username." }),
+	),
 });
 
-const WhatsAppConfigSchema = z.object({
-  platform: z.literal("whatsapp"),
-  accessToken: z.string().optional().openapi({
-    description: "System User access token for WhatsApp Cloud API.",
-  }),
-  phoneNumberId: z
-    .string()
-    .optional()
-    .openapi({ description: "WhatsApp Business phone number ID." }),
-  appSecret: z.string().optional().openapi({
-    description:
-      "Meta App Secret for webhook HMAC-SHA256 signature verification.",
-  }),
-  verifyToken: z
-    .string()
-    .optional()
-    .openapi({ description: "Verify token for webhook challenge-response." }),
-  apiVersion: z
-    .string()
-    .optional()
-    .openapi({ description: "Meta Graph API version (default: v21.0)." }),
-  userName: z.string().optional().openapi({ description: "Bot display name." }),
+const WhatsAppConfigSchema = Type.Object({
+	platform: Type.Literal("whatsapp"),
+	accessToken: Type.Optional(
+		Type.String({
+			description: "System User access token for WhatsApp Cloud API.",
+		}),
+	),
+	phoneNumberId: Type.Optional(
+		Type.String({ description: "WhatsApp Business phone number ID." }),
+	),
+	appSecret: Type.Optional(
+		Type.String({
+			description:
+				"Meta App Secret for webhook HMAC-SHA256 signature verification.",
+		}),
+	),
+	verifyToken: Type.Optional(
+		Type.String({
+			description: "Verify token for webhook challenge-response.",
+		}),
+	),
+	apiVersion: Type.Optional(
+		Type.String({ description: "Meta Graph API version (default: v21.0)." }),
+	),
+	userName: Type.Optional(Type.String({ description: "Bot display name." })),
 });
 
-const TeamsConfigSchema = z.object({
-  platform: z.literal("teams"),
-  appId: z.string().optional().openapi({ description: "Microsoft App ID." }),
-  appPassword: z
-    .string()
-    .optional()
-    .openapi({ description: "Microsoft App Password." }),
-  appTenantId: z
-    .string()
-    .optional()
-    .openapi({ description: "Microsoft App Tenant ID." }),
-  appType: z
-    .enum(["MultiTenant", "SingleTenant"])
-    .optional()
-    .openapi({ description: "Microsoft App Type." }),
-  userName: z
-    .string()
-    .optional()
-    .openapi({ description: "Override bot username." }),
+const TeamsConfigSchema = Type.Object({
+	platform: Type.Literal("teams"),
+	appId: Type.Optional(Type.String({ description: "Microsoft App ID." })),
+	appPassword: Type.Optional(
+		Type.String({ description: "Microsoft App Password." }),
+	),
+	appTenantId: Type.Optional(
+		Type.String({ description: "Microsoft App Tenant ID." }),
+	),
+	appType: Type.Optional(
+		Type.Union([Type.Literal("MultiTenant"), Type.Literal("SingleTenant")], {
+			description: "Microsoft App Type.",
+		}),
+	),
+	userName: Type.Optional(
+		Type.String({ description: "Override bot username." }),
+	),
 });
 
-const GoogleChatConfigSchema = z.object({
-  platform: z.literal("gchat"),
-  credentials: z.string().optional().openapi({
-    description:
-      "Service account credentials JSON string. Defaults to GOOGLE_CHAT_CREDENTIALS env var.",
-  }),
-  useApplicationDefaultCredentials: z.boolean().optional().openapi({
-    description:
-      "Use Application Default Credentials (ADC) instead of service account JSON.",
-  }),
-  endpointUrl: z.string().optional().openapi({
-    description:
-      "HTTP endpoint URL for button click actions. Required for HTTP endpoint apps.",
-  }),
-  googleChatProjectNumber: z.string().optional().openapi({
-    description:
-      "Google Cloud project number for verifying webhook JWTs. Defaults to GOOGLE_CHAT_PROJECT_NUMBER env var.",
-  }),
-  impersonateUser: z.string().optional().openapi({
-    description:
-      "User email for domain-wide delegation. Defaults to GOOGLE_CHAT_IMPERSONATE_USER env var.",
-  }),
-  pubsubAudience: z.string().optional().openapi({
-    description:
-      "Expected audience for Pub/Sub push JWT verification. Defaults to GOOGLE_CHAT_PUBSUB_AUDIENCE env var.",
-  }),
-  userName: z
-    .string()
-    .optional()
-    .openapi({ description: "Override bot username." }),
+const GoogleChatConfigSchema = Type.Object({
+	platform: Type.Literal("gchat"),
+	credentials: Type.Optional(
+		Type.String({
+			description:
+				"Service account credentials JSON string. Defaults to GOOGLE_CHAT_CREDENTIALS env var.",
+		}),
+	),
+	useApplicationDefaultCredentials: Type.Optional(
+		Type.Boolean({
+			description:
+				"Use Application Default Credentials (ADC) instead of service account JSON.",
+		}),
+	),
+	endpointUrl: Type.Optional(
+		Type.String({
+			description:
+				"HTTP endpoint URL for button click actions. Required for HTTP endpoint apps.",
+		}),
+	),
+	googleChatProjectNumber: Type.Optional(
+		Type.String({
+			description:
+				"Google Cloud project number for verifying webhook JWTs. Defaults to GOOGLE_CHAT_PROJECT_NUMBER env var.",
+		}),
+	),
+	impersonateUser: Type.Optional(
+		Type.String({
+			description:
+				"User email for domain-wide delegation. Defaults to GOOGLE_CHAT_IMPERSONATE_USER env var.",
+		}),
+	),
+	pubsubAudience: Type.Optional(
+		Type.String({
+			description:
+				"Expected audience for Pub/Sub push JWT verification. Defaults to GOOGLE_CHAT_PUBSUB_AUDIENCE env var.",
+		}),
+	),
+	userName: Type.Optional(
+		Type.String({ description: "Override bot username." }),
+	),
 });
 
-export const WebhookConfigSchema = z.object({
-  platform: z.literal("webhook"),
-  token: z.string().optional().openapi({
-    description:
-      "Bearer token authenticating inbound deliveries. Auto-generated when omitted; stored as a secret:// ref.",
-  }),
-  // Declarative configs (`lobu apply`) carry string values only, so the
-  // boolean also accepts its string spelling.
-  allowQueryAuth: z
-    .union([z.boolean(), z.enum(["true", "false"])])
-    .optional()
-    .openapi({
-      description:
-        "Allow `?token=` auth for senders that cannot set headers (e.g. Sentry's legacy WebHooks plugin). Default false.",
-    }),
-  dedupeHeader: z.string().optional().openapi({
-    description:
-      "Request header whose value is the idempotency key (e.g. x-github-delivery). Defaults to sha256 of the raw body.",
-  }),
-  semanticType: z.string().optional().openapi({
-    description: "semantic_type stamped on ingested events. Default: content.",
-  }),
-  titlePath: z.string().optional().openapi({
-    description:
-      'JSON pointer into the payload extracted as the event title (e.g. "/event/title").',
-  }),
-  searchable: z
-    .union([z.boolean(), z.enum(["true", "false"])])
-    .optional()
-    .openapi({
-      description:
-        "Index ingested payloads into semantic memory (search_memory). Default false: store-only, reachable by watcher SQL.",
-    }),
+// Declarative configs (`lobu apply`) carry string values only, so booleans also
+// accept their string spelling — the TypeBox equivalent of `z.union([boolean,
+// enum(["true","false"])])`.
+const boolOrString = (description: string) =>
+	Type.Union([Type.Boolean(), Type.Literal("true"), Type.Literal("false")], {
+		description,
+	});
+
+export const WebhookConfigSchema = Type.Object({
+	platform: Type.Literal("webhook"),
+	token: Type.Optional(
+		Type.String({
+			description:
+				"Bearer token authenticating inbound deliveries. Auto-generated when omitted; stored as a secret:// ref.",
+		}),
+	),
+	allowQueryAuth: Type.Optional(
+		boolOrString(
+			"Allow `?token=` auth for senders that cannot set headers (e.g. Sentry's legacy WebHooks plugin). Default false.",
+		),
+	),
+	dedupeHeader: Type.Optional(
+		Type.String({
+			description:
+				"Request header whose value is the idempotency key (e.g. x-github-delivery). Defaults to sha256 of the raw body.",
+		}),
+	),
+	semanticType: Type.Optional(
+		Type.String({
+			description:
+				"semantic_type stamped on ingested events. Default: content.",
+		}),
+	),
+	titlePath: Type.Optional(
+		Type.String({
+			description:
+				'JSON pointer into the payload extracted as the event title (e.g. "/event/title").',
+		}),
+	),
+	searchable: Type.Optional(
+		boolOrString(
+			"Index ingested payloads into semantic memory (search_memory). Default false: store-only, reachable by watcher SQL.",
+		),
+	),
 });
 
-/** The HTTP Agent API surface (lobu-ai/lobu#1179). Adapterless: the row is
+/**
+ * The HTTP Agent API surface (lobu-ai/lobu#1179). Adapterless: the row is
  * persisted so the scaffolded `{ type: "rest", config: {} }` declaration
  * reconciles under `lobu apply`, but no chat instance is ever created and no
- * credentials exist. */
-export const RestConfigSchema = z.object({
-  platform: z.literal("rest"),
+ * credentials exist.
+ */
+export const RestConfigSchema = Type.Object({
+	platform: Type.Literal("rest"),
 });
 
-export const PlatformAdapterConfigSchema = z.discriminatedUnion("platform", [
-  TelegramConfigSchema,
-  SlackConfigSchema,
-  DiscordConfigSchema,
-  WhatsAppConfigSchema,
-  TeamsConfigSchema,
-  GoogleChatConfigSchema,
-  WebhookConfigSchema,
-  RestConfigSchema,
+export const PlatformAdapterConfigSchema = Type.Union([
+	TelegramConfigSchema,
+	SlackConfigSchema,
+	DiscordConfigSchema,
+	WhatsAppConfigSchema,
+	TeamsConfigSchema,
+	GoogleChatConfigSchema,
+	WebhookConfigSchema,
+	RestConfigSchema,
 ]);
 
-/** Derived from the discriminated union — no separate list to maintain. */
-const SUPPORTED_PLATFORMS = PlatformAdapterConfigSchema.options.map(
-  (s) => s.shape.platform.value
+/** Derived from the union members — no separate list to maintain. */
+const SUPPORTED_PLATFORMS = PlatformAdapterConfigSchema.anyOf.map(
+	(s) => s.properties.platform.const as string,
 ) as [string, ...string[]];
 
-export const SupportedPlatformSchema = z.enum(SUPPORTED_PLATFORMS);
+export const SupportedPlatformSchema = Type.Union(
+	SUPPORTED_PLATFORMS.map((p) => Type.Literal(p)),
+);

--- a/packages/server/src/gateway/routes/shared/define-route.ts
+++ b/packages/server/src/gateway/routes/shared/define-route.ts
@@ -29,10 +29,12 @@ import { deepCopyStrict } from "../../../utils/schema-copy.js";
 
 type Method = "get" | "post" | "put" | "patch" | "delete";
 
-/** A single response entry: the JSON body schema + a description. */
+/** A single response entry: the body schema + a description. */
 export interface ResponseSpec {
 	description: string;
 	schema?: TSchema;
+	/** Body media type; defaults to `application/json` (SSE: `text/event-stream`). */
+	mediaType?: string;
 }
 
 export interface RouteSpec<
@@ -274,7 +276,9 @@ export function buildRoutePaths(): Record<string, unknown> {
 				? {
 						description: res.description,
 						content: {
-							"application/json": { schema: deepCopyStrict(res.schema) },
+							[res.mediaType ?? "application/json"]: {
+								schema: deepCopyStrict(res.schema),
+							},
 						},
 					}
 				: { description: res.description };
@@ -285,4 +289,25 @@ export function buildRoutePaths(): Record<string, unknown> {
 		pathItem[spec.method] = op;
 	}
 	return paths;
+}
+
+/**
+ * Merge OpenAPI `paths` groups method-wise: later groups win per operation,
+ * but sibling methods on the same path survive. A whole-path spread would
+ * drop e.g. openapi-auto's `GET /api/v1/agents` when the defineRoute registry
+ * documents only POST there.
+ */
+export function mergeOpenApiPaths(
+	...groups: Record<string, unknown>[]
+): Record<string, unknown> {
+	const merged: Record<string, Record<string, unknown>> = {};
+	for (const group of groups) {
+		for (const [path, ops] of Object.entries(group)) {
+			merged[path] = {
+				...merged[path],
+				...(ops as Record<string, unknown>),
+			};
+		}
+	}
+	return merged;
 }

--- a/packages/server/src/gateway/routes/shared/define-route.ts
+++ b/packages/server/src/gateway/routes/shared/define-route.ts
@@ -1,0 +1,288 @@
+/**
+ * `defineRoute` — a thin, TypeBox-native replacement for `@hono/zod-openapi`'s
+ * `createRoute` + `OpenAPIHono`.
+ *
+ * Why hand-rolled: the whole gateway contract is TypeBox (the dispatch-tool
+ * surface, `@lobu/core/contracts`, the validate-args chokepoint). `zod-openapi`
+ * was the last place a SECOND schema library (Zod) lived. `defineRoute` lets the
+ * agent-session routes declare their request/response schemas in the same
+ * TypeBox the rest of the server uses, so ONE OpenAPI document is projected from
+ * ONE schema source with no hand-copied wire types.
+ *
+ * It does two things:
+ *   (a) registers a plain Hono handler behind a validation middleware that runs
+ *       the same TypeBox coercion+check the tool dispatch uses, stashing the
+ *       validated `json` / `param` / `query` on the context for the handler; and
+ *   (b) records the route's `{method, path, request, responses}` in a registry
+ *       the doc builder concatenates with `generateStrictToolPaths()`.
+ *
+ * No new dependency: OpenAPI projection is a direct walk of the TypeBox schemas
+ * (which are already JSON-Schema 2020-12 objects) plus the `{path → {method →
+ * operation}}` assembly `getOpenAPI31Document` used to do internally.
+ */
+
+import type { TSchema } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+import type { Context, Env, Hono, MiddlewareHandler } from "hono";
+import { ToolUserError } from "../../../utils/errors.js";
+import { deepCopyStrict } from "../../../utils/schema-copy.js";
+
+type Method = "get" | "post" | "put" | "patch" | "delete";
+
+/** A single response entry: the JSON body schema + a description. */
+export interface ResponseSpec {
+	description: string;
+	schema?: TSchema;
+}
+
+export interface RouteSpec<
+	TBody extends TSchema | undefined = TSchema | undefined,
+	TParams extends TSchema | undefined = TSchema | undefined,
+	TQuery extends TSchema | undefined = TSchema | undefined,
+> {
+	method: Method;
+	/** OpenAPI path with `{param}` placeholders (e.g. `/api/v1/agents/{agentId}`). */
+	path: string;
+	/**
+	 * Router-relative registration path, when the route lives on a sub-router
+	 * mounted under a prefix (e.g. the agent-config router registers `/` but is
+	 * mounted at `/api/v1/agents/:agentId/config`). Defaults to `path`. The doc
+	 * always uses `path`, so the OpenAPI document shows the full mounted URL.
+	 */
+	honoPath?: string;
+	tags?: string[];
+	summary?: string;
+	description?: string;
+	/** Emit `security: [{ bearerAuth: [] }]` on the operation. */
+	bearerAuth?: boolean;
+	request?: {
+		body?: TBody;
+		params?: TParams;
+		query?: TQuery;
+	};
+	/**
+	 * Document `request.body` in the OpenAPI doc but DO NOT auto-validate it in
+	 * the middleware. For content-negotiating handlers (e.g. the send-message
+	 * route accepts multipart form-data OR JSON): eager `c.req.json()` would 400
+	 * a multipart request before the handler can branch on Content-Type. Such
+	 * handlers parse + validate the body themselves.
+	 */
+	skipBodyValidation?: boolean;
+	/** Response bodies keyed by status code. */
+	responses: Record<number, ResponseSpec>;
+}
+
+/** Shape the validation middleware stashes on the context for handlers. */
+export interface ValidatedRequest<
+	TBody = unknown,
+	TParams = unknown,
+	TQuery = unknown,
+> {
+	json: TBody;
+	param: TParams;
+	query: TQuery;
+}
+
+const VALIDATED = "validatedRequest" as const;
+
+/**
+ * Read the validated request the `defineRoute` middleware stashed. Typed by the
+ * route's schemas at the call site (`getValidated<Static<typeof BodySchema>>`).
+ */
+export function getValidated<
+	TBody = unknown,
+	TParams = unknown,
+	TQuery = unknown,
+>(c: Context): ValidatedRequest<TBody, TParams, TQuery> {
+	return (c as unknown as { get(k: string): unknown }).get(
+		VALIDATED,
+	) as ValidatedRequest<TBody, TParams, TQuery>;
+}
+
+/**
+ * Coerce + validate `value` against `schema`, throwing a 400 ToolUserError with
+ * the first error path on mismatch. Mirrors `validateToolArgs`' Convert→Check
+ * pipeline so route bodies and tool args validate identically.
+ */
+function coerceAndCheck(schema: TSchema, value: unknown, where: string): unknown {
+	const coerced = Value.Convert(schema, value);
+	if (Value.Check(schema, coerced)) return Value.Clean(schema, coerced);
+	const first = Value.Errors(schema, coerced).First();
+	const detail = first
+		? `${first.path || "(root)"} ${first.message}`.trim()
+		: "does not match the expected shape";
+	throw new ToolUserError(`Invalid ${where}: ${detail}`, 400);
+}
+
+/** The route registry, projected into the OpenAPI document by `buildRoutePaths`. */
+const ROUTE_REGISTRY: RouteSpec[] = [];
+
+/**
+ * Register a route on `app` and record it for the OpenAPI document.
+ *
+ * The handler receives the Hono `Context`; it reads validated input via
+ * `getValidated<…>(c)` instead of `c.req.valid(...)`.
+ */
+export function defineRoute<
+	E extends Env,
+	TBody extends TSchema | undefined,
+	TParams extends TSchema | undefined,
+	TQuery extends TSchema | undefined,
+>(
+	app: Hono<E>,
+	spec: RouteSpec<TBody, TParams, TQuery>,
+	handler: (c: Context<E>) => Response | Promise<Response>,
+): void {
+	ROUTE_REGISTRY.push(spec as unknown as RouteSpec);
+
+	const middleware: MiddlewareHandler<E> = async (c, next) => {
+		// `skipBodyValidation` documents the body but leaves parsing to the handler
+		// (content-negotiating routes — see the flag's doc).
+		const bodySchema = spec.skipBodyValidation ? undefined : spec.request?.body;
+		const paramSchema = spec.request?.params;
+		const querySchema = spec.request?.query;
+
+		let json: unknown;
+		if (bodySchema) {
+			let raw: unknown;
+			try {
+				raw = await c.req.json();
+			} catch {
+				return c.json({ error: "Invalid or missing JSON body" }, 400);
+			}
+			try {
+				json = coerceAndCheck(bodySchema, raw, "request body");
+			} catch (err) {
+				return c.json(
+					{ error: err instanceof Error ? err.message : String(err) },
+					400,
+				);
+			}
+		}
+
+		let param: unknown;
+		if (paramSchema) {
+			try {
+				param = coerceAndCheck(paramSchema, c.req.param(), "path parameters");
+			} catch (err) {
+				return c.json(
+					{ error: err instanceof Error ? err.message : String(err) },
+					400,
+				);
+			}
+		}
+
+		let query: unknown;
+		if (querySchema) {
+			try {
+				query = coerceAndCheck(
+					querySchema,
+					c.req.query() as Record<string, string>,
+					"query parameters",
+				);
+			} catch (err) {
+				return c.json(
+					{ error: err instanceof Error ? err.message : String(err) },
+					400,
+				);
+			}
+		}
+
+		// `VALIDATED` isn't declared in this generic `E`'s `Variables` map; the
+		// typed accessor is `getValidated(c)`, so set through a widened ref.
+		(c as unknown as { set(k: string, v: unknown): void }).set(VALIDATED, {
+			json,
+			param,
+			query,
+		});
+		await next();
+		return;
+	};
+
+	// Register through a minimal structural shim. Hono's method/`.on` overloads
+	// thread a chain of path/handler generics that isn't expressible from this
+	// helper's `E` — but the runtime contract is just "(method, path, mw,
+	// handler)", and the middleware validates every body/param before the handler
+	// runs, so the schemas (not TS's route generics) are the contract here.
+	const registrar = app as unknown as Record<
+		Method,
+		(path: string, ...handlers: MiddlewareHandler[]) => unknown
+	>;
+	// OpenAPI templating uses `{param}`; Hono routing uses `:param`. The registry
+	// (and `buildRoutePaths`) keeps the `{param}` form for the doc; Hono gets the
+	// `:param` form so requests actually match.
+	const honoPath = (spec.honoPath ?? spec.path).replace(/\{([^}]+)\}/g, ":$1");
+	registrar[spec.method](
+		honoPath,
+		middleware,
+		handler as unknown as MiddlewareHandler,
+	);
+}
+
+/**
+ * Project the registered routes into an OpenAPI 3.1 `paths` object.
+ *
+ * Every schema is embedded through `deepCopyStrict` — the SAME projector
+ * `generateStrictToolPaths()` uses for the dispatch-tool surface — so the two
+ * halves of the merged doc share one JSON-Schema-embedding path (drops `$id` /
+ * `static` TypeBox internals and `x-hidden` server-only fields). Placeholders
+ * `{x}` in the path stay as-is (OpenAPI path templating).
+ */
+export function buildRoutePaths(): Record<string, unknown> {
+	const paths: Record<string, Record<string, unknown>> = {};
+	for (const spec of ROUTE_REGISTRY) {
+		const op: Record<string, unknown> = {};
+		if (spec.tags) op.tags = spec.tags;
+		if (spec.summary) op.summary = spec.summary;
+		if (spec.description) op.description = spec.description;
+		if (spec.bearerAuth) op.security = [{ bearerAuth: [] }];
+
+		const parameters: unknown[] = [];
+		for (const [loc, schema] of [
+			["path", spec.request?.params],
+			["query", spec.request?.query],
+		] as const) {
+			if (!schema || !("properties" in schema)) continue;
+			const obj = schema as unknown as {
+				properties: Record<string, TSchema>;
+				required?: string[];
+			};
+			const required = new Set(obj.required ?? []);
+			for (const [name, propSchema] of Object.entries(obj.properties)) {
+				parameters.push({
+					name,
+					in: loc,
+					required: loc === "path" ? true : required.has(name),
+					schema: deepCopyStrict(propSchema),
+				});
+			}
+		}
+		if (parameters.length > 0) op.parameters = parameters;
+
+		if (spec.request?.body) {
+			op.requestBody = {
+				required: true,
+				content: {
+					"application/json": { schema: deepCopyStrict(spec.request.body) },
+				},
+			};
+		}
+
+		const responses: Record<string, unknown> = {};
+		for (const [code, res] of Object.entries(spec.responses)) {
+			responses[code] = res.schema
+				? {
+						description: res.description,
+						content: {
+							"application/json": { schema: deepCopyStrict(res.schema) },
+						},
+					}
+				: { description: res.description };
+		}
+		op.responses = responses;
+
+		const pathItem = paths[spec.path] ?? (paths[spec.path] = {});
+		pathItem[spec.method] = op;
+	}
+	return paths;
+}

--- a/packages/server/src/gateway/routes/shared/define-route.ts
+++ b/packages/server/src/gateway/routes/shared/define-route.ts
@@ -157,9 +157,13 @@ export function defineRoute<
 		if (bodySchema) {
 			let raw: unknown;
 			try {
-				raw = await c.req.json();
+				// A missing/empty body validates as {} (the previous zod-openapi
+				// validator's behavior — bodies are optional unless the schema has
+				// required fields, which {} then fails with a field-level 400).
+				const text = await c.req.text();
+				raw = text.trim() === "" ? {} : JSON.parse(text);
 			} catch {
-				return c.json({ error: "Invalid or missing JSON body" }, 400);
+				return c.json({ error: "Invalid JSON body" }, 400);
 			}
 			try {
 				// Strict: JSON already carries real types — no coercion.
@@ -277,8 +281,14 @@ export function buildRoutePaths(): Record<string, unknown> {
 		if (parameters.length > 0) op.parameters = parameters;
 
 		if (spec.request?.body) {
+			// `required` mirrors the schema: only a body with required fields is a
+			// required body (an all-optional schema accepts a bodyless request,
+			// which the middleware validates as {}).
+			const bodyRequired =
+				Array.isArray(spec.request.body.required) &&
+				spec.request.body.required.length > 0;
 			op.requestBody = {
-				required: true,
+				required: bodyRequired,
 				content: {
 					"application/json": { schema: deepCopyStrict(spec.request.body) },
 				},

--- a/packages/server/src/gateway/routes/shared/define-route.ts
+++ b/packages/server/src/gateway/routes/shared/define-route.ts
@@ -10,9 +10,10 @@
  * ONE schema source with no hand-copied wire types.
  *
  * It does two things:
- *   (a) registers a plain Hono handler behind a validation middleware that runs
- *       the same TypeBox coercion+check the tool dispatch uses, stashing the
- *       validated `json` / `param` / `query` on the context for the handler; and
+ *   (a) registers a plain Hono handler behind a TypeBox validation middleware —
+ *       strict Check on JSON bodies, Convert-then-Check on string-sourced
+ *       path/query params — stashing the validated `json` / `param` / `query`
+ *       on the context for the handler; and
  *   (b) records the route's `{method, path, request, responses}` in a registry
  *       the doc builder concatenates with `generateStrictToolPaths()`.
  *
@@ -102,14 +103,22 @@ export function getValidated<
 }
 
 /**
- * Coerce + validate `value` against `schema`, throwing a 400 ToolUserError with
- * the first error path on mismatch. Mirrors `validateToolArgs`' Convert→Check
- * pipeline so route bodies and tool args validate identically.
+ * Validate `value` against `schema`, throwing a 400 ToolUserError with the
+ * first error path on mismatch. Validation is location-aware: path/query
+ * inputs arrive as strings, so they get `Value.Convert` coercion first; JSON
+ * bodies carry real types and are checked STRICTLY — coercing them would
+ * silently accept schema-invalid values (`{content: 123}` must stay a 400,
+ * matching the previous Zod validator).
  */
-function coerceAndCheck(schema: TSchema, value: unknown, where: string): unknown {
-	const coerced = Value.Convert(schema, value);
-	if (Value.Check(schema, coerced)) return Value.Clean(schema, coerced);
-	const first = Value.Errors(schema, coerced).First();
+function checkAndClean(
+	schema: TSchema,
+	value: unknown,
+	where: string,
+	{ convert }: { convert: boolean },
+): unknown {
+	const candidate = convert ? Value.Convert(schema, value) : value;
+	if (Value.Check(schema, candidate)) return Value.Clean(schema, candidate);
+	const first = Value.Errors(schema, candidate).First();
 	const detail = first
 		? `${first.path || "(root)"} ${first.message}`.trim()
 		: "does not match the expected shape";
@@ -153,7 +162,10 @@ export function defineRoute<
 				return c.json({ error: "Invalid or missing JSON body" }, 400);
 			}
 			try {
-				json = coerceAndCheck(bodySchema, raw, "request body");
+				// Strict: JSON already carries real types — no coercion.
+				json = checkAndClean(bodySchema, raw, "request body", {
+					convert: false,
+				});
 			} catch (err) {
 				return c.json(
 					{ error: err instanceof Error ? err.message : String(err) },
@@ -165,7 +177,9 @@ export function defineRoute<
 		let param: unknown;
 		if (paramSchema) {
 			try {
-				param = coerceAndCheck(paramSchema, c.req.param(), "path parameters");
+				param = checkAndClean(paramSchema, c.req.param(), "path parameters", {
+					convert: true,
+				});
 			} catch (err) {
 				return c.json(
 					{ error: err instanceof Error ? err.message : String(err) },
@@ -177,10 +191,11 @@ export function defineRoute<
 		let query: unknown;
 		if (querySchema) {
 			try {
-				query = coerceAndCheck(
+				query = checkAndClean(
 					querySchema,
 					c.req.query() as Record<string, string>,
 					"query parameters",
+					{ convert: true },
 				);
 			} catch (err) {
 				return c.json(

--- a/packages/server/src/gateway/routes/shared/openapi-responses.ts
+++ b/packages/server/src/gateway/routes/shared/openapi-responses.ts
@@ -1,13 +1,14 @@
 /**
- * Shared OpenAPI response building blocks.
+ * Shared response building blocks for `defineRoute`.
  *
- * Collapses the stamped-out
- *   `4xx: { description, content: { "application/json": { schema } } }`
- * blocks that every `createRoute` definition repeats. The shape and the
- * canonical `{ error }` schema were previously redeclared per route file.
+ * Collapses the repeated `{ description, schema }` error blocks and the
+ * canonical `{ error }` schema that every route otherwise redeclares. The blocks
+ * match `defineRoute`'s `ResponseSpec` shape (`{ description, schema? }`), which
+ * the doc builder projects into OpenAPI `content` entries.
  */
 
-import { z } from "@hono/zod-openapi";
+import { type TSchema, Type } from "@sinclair/typebox";
+import type { ResponseSpec } from "./define-route.js";
 
 /**
  * Canonical flat error response: `{ error: string }`.
@@ -16,15 +17,7 @@ import { z } from "@hono/zod-openapi";
  * most CRUD routes. Routes with a richer error envelope (e.g. agent.ts's
  * `{ success, error, details? }`) pass their own schema to `errorResponses`.
  */
-export const ErrorResponseSchema = z.object({ error: z.string() });
-
-/**
- * A single OpenAPI JSON response block for `schema`.
- */
-type JsonResponseBlock<Schema> = {
-  description: string;
-  content: { "application/json": { schema: Schema } };
-};
+export const ErrorResponseSchema = Type.Object({ error: Type.String() });
 
 /**
  * Build a set of error-response blocks keyed by HTTP status code.
@@ -36,26 +29,18 @@ type JsonResponseBlock<Schema> = {
  *   }
  *
  * `schema` is the error body schema; pass a custom schema for routes with a
- * richer envelope.
- *
- * The return type preserves the exact set of status-code keys (via the
- * `Codes` generic) so the spread into `createRoute({ responses })` keeps
- * per-code precision and `app.openapi(route, handler)` still infers a precise
- * handler return type — a plain `Record<number, …>` would widen it.
+ * richer envelope. The `Codes` generic preserves the exact status-code key set.
  */
-export function errorResponses<Schema, Codes extends number>(
-  schema: Schema,
-  descriptions: Record<Codes, string>
-): { [Code in Codes]: JsonResponseBlock<Schema> } {
-  const out = {} as { [Code in Codes]: JsonResponseBlock<Schema> };
-  for (const [code, description] of Object.entries(descriptions) as [
-    `${Codes}`,
-    string,
-  ][]) {
-    out[Number(code) as Codes] = {
-      description,
-      content: { "application/json": { schema } },
-    };
-  }
-  return out;
+export function errorResponses<Codes extends number>(
+	schema: TSchema,
+	descriptions: Record<Codes, string>,
+): { [Code in Codes]: ResponseSpec } {
+	const out = {} as { [Code in Codes]: ResponseSpec };
+	for (const [code, description] of Object.entries(descriptions) as [
+		`${Codes}`,
+		string,
+	][]) {
+		out[Number(code) as Codes] = { description, schema };
+	}
+	return out;
 }

--- a/packages/server/src/utils/openapi-generator.ts
+++ b/packages/server/src/utils/openapi-generator.ts
@@ -5,6 +5,7 @@
  */
 
 import { getMcpTools, getRawDispatchTools } from '../tools/registry';
+import { deepCopyStrict } from './schema-copy';
 
 /**
  * Recursively deep copies schema properties while filtering out hidden ones
@@ -273,40 +274,6 @@ export function generateOpenAPISpec(serverUrl: string) {
 // real `outputSchema` as the 200 response. TypeBox serializes to JSON Schema
 // 2020-12, which IS the OpenAPI 3.1 schema dialect, so the schemas drop in with
 // no conversion. One TypeBox source, two projections — no hand-maintained spec.
-
-/**
- * Recursively deep-copies a schema while dropping any property marked
- * `x-hidden` at every object level (server-internal fields — pre-computed
- * embeddings, auth-bound filters — that must never reach a client), and
- * pruning them from each `required` array so the copy stays self-consistent.
- */
-function deepCopyStrict(schema: any): any {
-  if (schema === null || schema === undefined || typeof schema !== 'object') {
-    return schema;
-  }
-  if (Array.isArray(schema)) {
-    return schema.map(deepCopyStrict);
-  }
-  const copied: Record<string, any> = {};
-  for (const [key, value] of Object.entries(schema)) {
-    if (key === '$id' || key === 'static') continue;
-    if (key === 'properties' && value && typeof value === 'object') {
-      const props: Record<string, any> = {};
-      for (const [propKey, propVal] of Object.entries<any>(value)) {
-        if (propVal?.['x-hidden']) continue;
-        props[propKey] = deepCopyStrict(propVal);
-      }
-      copied[key] = props;
-      continue;
-    }
-    copied[key] = deepCopyStrict(value);
-  }
-  // Prune now-hidden keys out of `required` so we never require a dropped field.
-  if (Array.isArray(copied.required) && copied.properties) {
-    copied.required = copied.required.filter((k: string) => k in copied.properties);
-  }
-  return copied;
-}
 
 const ERROR_RESPONSE = {
   content: {

--- a/packages/server/src/utils/schema-copy.ts
+++ b/packages/server/src/utils/schema-copy.ts
@@ -1,0 +1,40 @@
+/**
+ * Recursively deep-copies a TypeBox/JSON schema for embedding in the OpenAPI
+ * document, dropping any property marked `x-hidden` at every object level
+ * (server-internal fields — pre-computed embeddings, auth-bound filters — that
+ * must never reach a client), and pruning them from each `required` array so
+ * the copy stays self-consistent. Also strips the `$id`/`static` TypeBox
+ * internals that aren't OpenAPI fields.
+ *
+ * Lives in its own module (no registry import) so both doc projectors — the
+ * dispatch-tool surface (`openapi-generator.ts`) and the defineRoute registry
+ * (`routes/shared/define-route.ts`) — share ONE schema-embedding path without
+ * route modules statically pulling in the tool registry (circular-init risk).
+ */
+export function deepCopyStrict(schema: any): any {
+  if (schema === null || schema === undefined || typeof schema !== 'object') {
+    return schema;
+  }
+  if (Array.isArray(schema)) {
+    return schema.map(deepCopyStrict);
+  }
+  const copied: Record<string, any> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === '$id' || key === 'static') continue;
+    if (key === 'properties' && value && typeof value === 'object') {
+      const props: Record<string, any> = {};
+      for (const [propKey, propVal] of Object.entries<any>(value)) {
+        if (propVal?.['x-hidden']) continue;
+        props[propKey] = deepCopyStrict(propVal);
+      }
+      copied[key] = props;
+      continue;
+    }
+    copied[key] = deepCopyStrict(value);
+  }
+  // Prune now-hidden keys out of `required` so we never require a dropped field.
+  if (Array.isArray(copied.required) && copied.properties) {
+    copied.required = copied.required.filter((k: string) => k in copied.properties);
+  }
+  return copied;
+}


### PR DESCRIPTION
Task B from #1956 — remove the second schema library (Zod) from the gateway's agent-session routes so the surface is TypeBox-sourced, matching the rest of the server (core/contracts, the dispatch-tool schemas, validate-args).

## What changed

New **`defineRoute`** helper (`routes/shared/define-route.ts`) replaces `@hono/zod-openapi`'s `createRoute` + `OpenAPIHono` for these routes:
- a **TypeBox request-validation middleware** (`Value.Convert→Check`, the *same* pipeline `validateToolArgs` uses for tool dispatch) that stashes validated `json`/`param`/`query` on the context, read via `getValidated<…>()`;
- a route registry projected into the OpenAPI doc by `buildRoutePaths()`, which **reuses** `openapi-generator.ts`'s `deepCopyStrict` (now exported) — so both halves of the merged doc share one schema-embedding path (drops `$id`/`static` TypeBox internals + `x-hidden` server-only fields) instead of a new parallel projector.

Converted files (zero Zod schema authoring left in them):
- `schemas/platform-config.ts` — 8 platform configs + discriminated union; the one `.refine()` (Telegram token) → `Type.String({ pattern })`; consumer `chat-connection-service` `.safeParse` → `Value.Convert/Check/Errors`.
- `routes/public/agent.ts` — 5 routes incl. the **SSE events stream** and the **multipart-OR-JSON send-message** handler. `skipBodyValidation` documents the send body but lets the handler branch on Content-Type (eager `c.req.json()` would 400 a multipart upload).
- `routes/public/agent-config.ts`, `routes/shared/openapi-responses.ts`.
- `gateway.ts` doc endpoint merges `buildRoutePaths()` into the doc.

## Scope note (honest)

The gateway `app` **stays `OpenAPIHono`** because `openapi-auto.ts`'s registry walk documents *every* other gateway route (dozens beyond these 6) — it's a server-wide doc engine, not the "10 createRoute calls" the issue estimated. Fully deleting `@hono/zod-openapi` means replacing that engine; that's tracked as a follow-up. This PR ships the schema-authoring win (agent routes validate via TypeBox, no hand-written Zod) without a risky doc-engine rewrite. `zod` remains a transitive dep via the shell + `openapi-auto`'s param stubs.

## Verification
- server `tsc` — 0 errors
- **agent-route gateway integration: 63/0** — session create/get/delete, SSE events, send-message (incl. multipart), cross-org tenant isolation, `rest-api-hardening` (malformed-input → validation middleware)
- `connections-platform-isolation`: **81/0** (platform-config TypeBox + the `.safeParse`→`Value.Check` consumer)
- `openapi-strict` doc generation: **5/0**
- `make pre-pr` clean

The integration suite caught a real bug typecheck missed: Hono routing needs `:param`, OpenAPI needs `{param}` — `defineRoute` now converts for the router while the doc keeps the template form.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786679326&installation_id=136316292&pr_number=1968&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1968&signature=b379e47c9b91557769fc0f33cb4fb71d6cabe72c1087ff1cea122b79aa6c01a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded API documentation to include agent-session and configuration routes with richer request and response schemas.
  * Added consistent request validation and automatic type conversion for gateway endpoints.
* **Bug Fixes**
  * Improved invalid-request errors with clearer field paths and messages.
  * Configuration responses now consistently remove sensitive or hidden fields.
* **Documentation**
  * Improved generated API documentation for route parameters, payloads, responses, and authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->