### PR TITLE
fix(worker): route built-in curl/wget through the gateway egress proxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
           cd packages/connector-worker && bun run build && cd ../..
           cd packages/pgvector-embedded && bun run build && cd ../..
           cd packages/cli && bun run build && cd ../..
+          # agent-worker dist: the egress transport test spawns `node` against
+          # dist/embedded/just-bash-bootstrap.js to exercise the Node branch.
+          cd packages/agent-worker && bun run build && cd ../..
 
       # bunfig.toml routes every `bun test --coverage` run to ./coverage/lcov.info
       # (bun 1.3.x ignores --coverage-dir when bunfig sets coverageDir), so each

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "@sinclair/typebox": "^0.34.33",
         "hono": "^4.11.7",
         "just-bash": "^2.12.8",
+        "undici": "^7.28.0",
         "zod": "^3.24.1",
       },
       "devDependencies": {

--- a/packages/agent-worker/package.json
+++ b/packages/agent-worker/package.json
@@ -67,6 +67,7 @@
     "@sinclair/typebox": "^0.34.33",
     "hono": "^4.11.7",
     "just-bash": "^2.12.8",
+    "undici": "^7.28.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/packages/agent-worker/src/__tests__/embedded-just-bash-bootstrap.test.ts
+++ b/packages/agent-worker/src/__tests__/embedded-just-bash-bootstrap.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { execFile } from "node:child_process";
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { resetSandboxProbeForTests } from "../embedded/exec-sandbox";
@@ -15,6 +17,9 @@ const originalEnv = {
   LOBU_ALLOW_UNSANDBOXED_EXEC: process.env.LOBU_ALLOW_UNSANDBOXED_EXEC,
   LOBU_WORKSPACE_BACKEND: process.env.LOBU_WORKSPACE_BACKEND,
   LOBU_RUNTIME_PROVIDER: process.env.LOBU_RUNTIME_PROVIDER,
+  JUST_BASH_ALLOWED_DOMAINS: process.env.JUST_BASH_ALLOWED_DOMAINS,
+  HTTP_PROXY: process.env.HTTP_PROXY,
+  HTTPS_PROXY: process.env.HTTPS_PROXY,
 };
 
 function restoreEnv(name: keyof typeof originalEnv): void {
@@ -35,6 +40,9 @@ afterEach(() => {
   restoreEnv("LOBU_ALLOW_UNSANDBOXED_EXEC");
   restoreEnv("LOBU_WORKSPACE_BACKEND");
   restoreEnv("LOBU_RUNTIME_PROVIDER");
+  restoreEnv("JUST_BASH_ALLOWED_DOMAINS");
+  restoreEnv("HTTP_PROXY");
+  restoreEnv("HTTPS_PROXY");
   resetSandboxProbeForTests();
 });
 
@@ -65,6 +73,226 @@ describe("createEmbeddedBashOps", () => {
 
     expect(result.exitCode).not.toBe(0);
     expect(chunks.join("")).not.toContain("root:");
+  });
+
+  // Built-in curl/wget are transport-only clients of the gateway egress
+  // proxy: URL policy lives in the proxy (grants/denylist/SSRF/judge), not in
+  // the worker. These tests are fully hermetic — the "gateway proxy" is a
+  // local recording HTTP proxy that answers absolute-URI requests itself, so
+  // no DNS and no live network is ever needed (`wandr-egress.test` never
+  // resolves; only the proxy sees it).
+  describe("built-in curl egress via the gateway proxy", () => {
+    async function curlViaProxy(
+      handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+      command: string
+    ): Promise<{ output: string; proxied: string[]; auths: string[] }> {
+      const proxied: string[] = [];
+      const auths: string[] = [];
+      const proxy = http.createServer((req, res) => {
+        proxied.push(`${req.method} ${req.url}`);
+        auths.push(req.headers["proxy-authorization"] ?? "NONE");
+        handler(req, res);
+      });
+      await new Promise<void>((resolve) =>
+        proxy.listen(0, "127.0.0.1", resolve)
+      );
+      const address = proxy.address();
+      if (typeof address !== "object" || !address) {
+        throw new Error("proxy did not bind");
+      }
+      try {
+        // Credentialed, like the real gateway proxy URL
+        // (http://<deployment>:<token>@host) — auth must survive the transport.
+        process.env.HTTP_PROXY = `http://dep:tok@127.0.0.1:${address.port}`;
+        process.env.HTTPS_PROXY = process.env.HTTP_PROXY;
+        process.env.JUST_BASH_ALLOWED_DOMAINS = JSON.stringify(["*"]);
+        const workspace = fs.realpathSync(
+          fs.mkdtempSync(path.join(os.tmpdir(), "lobu-egress-"))
+        );
+        tempDirs.push(workspace);
+        const ops = await createEmbeddedBashOps({ workspaceDir: workspace });
+        const chunks: string[] = [];
+        await ops.exec(command, "/", {
+          onData: (chunk) => chunks.push(chunk.toString()),
+          timeout: 8,
+        });
+        return { output: chunks.join(""), proxied, auths };
+      } finally {
+        proxy.close();
+      }
+    }
+
+    test("routes requests through the proxy with credentials and returns the body", async () => {
+      const { output, proxied, auths } = await curlViaProxy(
+        (_req, res) => res.end("proxy-delivered-body"),
+        "curl -sS http://wandr-egress.test/hello"
+      );
+      expect(output).toContain("proxy-delivered-body");
+      // Absolute-URI request line proves the proxy (not DNS) served it, and
+      // that method + full path are visible to gateway policy.
+      // Bun includes the default port in the URI; Node does not.
+      expect(proxied).toHaveLength(1);
+      expect(proxied[0]).toMatch(
+        /^GET http:\/\/wandr-egress\.test(:80)?\/hello$/
+      );
+      // Basic base64("dep:tok") — the gateway proxy requires auth.
+      expect(auths).toEqual(["Basic ZGVwOnRvaw=="]);
+    });
+
+    test("follows redirects with every hop transiting the proxy, auth intact", async () => {
+      const { output, proxied, auths } = await curlViaProxy((req, res) => {
+        if (req.url?.endsWith("/redirect-me")) {
+          res.writeHead(302, { location: "http://wandr-egress.test/final" });
+          res.end();
+          return;
+        }
+        res.end("final-hop-body");
+      }, "curl -sSL http://wandr-egress.test/redirect-me");
+      expect(output).toContain("final-hop-body");
+      expect(proxied).toHaveLength(2);
+      expect(proxied[0]).toMatch(
+        /^GET http:\/\/wandr-egress\.test(:80)?\/redirect-me$/
+      );
+      expect(proxied[1]).toMatch(
+        /^GET http:\/\/wandr-egress\.test(:80)?\/final$/
+      );
+      expect(auths).toEqual(["Basic ZGVwOnRvaw==", "Basic ZGVwOnRvaw=="]);
+    });
+
+    test("a proxy denial is surfaced to the agent (single policy point)", async () => {
+      const { output, proxied } = await curlViaProxy((_req, res) => {
+        res.writeHead(403);
+        res.end("denied-by-gateway-proxy");
+      }, "curl -sS http://blocked.example/");
+      expect(proxied).toHaveLength(1);
+      expect(proxied[0]).toMatch(/^GET http:\/\/blocked\.example(:80)?\/$/);
+      expect(output).toContain("denied-by-gateway-proxy");
+    });
+
+    test("an oversized chunked response is cut off at the size cap", async () => {
+      // 33MB chunked (no content-length) — must be aborted while streaming,
+      // not buffered whole and then rejected.
+      const chunk = Buffer.alloc(1024 * 1024, "x");
+      const { output } = await curlViaProxy((_req, res) => {
+        res.writeHead(200, { "content-type": "application/octet-stream" });
+        for (let i = 0; i < 33; i++) res.write(chunk);
+        res.end();
+      }, "curl -sS http://wandr-egress.test/huge");
+      expect(output).toContain("Response too large");
+    }, 20_000);
+
+    test("fails closed when no gateway proxy is configured", async () => {
+      process.env.JUST_BASH_ALLOWED_DOMAINS = JSON.stringify(["*"]);
+      delete process.env.HTTP_PROXY;
+      delete process.env.HTTPS_PROXY;
+      const workspace = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), "lobu-egress-"))
+      );
+      tempDirs.push(workspace);
+      const ops = await createEmbeddedBashOps({ workspaceDir: workspace });
+      const chunks: string[] = [];
+      await ops.exec("curl -sS http://wandr-egress.test/", "/", {
+        onData: (chunk) => chunks.push(chunk.toString()),
+        timeout: 8,
+      });
+      expect(chunks.join("")).toContain("egress proxy not configured");
+    });
+
+    // The Node transport branch (undici + ProxyAgent, proxyTunnel:false)
+    // only executes under Node, so exercise it in a spawned `node` child
+    // against the built dist. Skipped when dist isn't built (CI unit job
+    // runs from src); the branch is CI-covered indirectly via sdk-e2e and
+    // verified here on any dev machine with a build.
+    const distBootstrap = path.resolve(
+      __dirname,
+      "../../dist/embedded/just-bash-bootstrap.js"
+    );
+    test.skipIf(!fs.existsSync(distBootstrap))(
+      "node transport: absolute-form method/path + auth via the proxy",
+      async () => {
+        const script = `
+          const http = require("node:http");
+          const fs = require("node:fs");
+          const seen = [];
+          const proxy = http.createServer((req, res) => {
+            seen.push(req.method + " " + req.url + " " + (req.headers["proxy-authorization"] || "NONE"));
+            res.end("node-proxy-body");
+          });
+          proxy.listen(0, "127.0.0.1", async () => {
+            process.env.HTTP_PROXY = "http://dep:tok@127.0.0.1:" + proxy.address().port;
+            process.env.HTTPS_PROXY = process.env.HTTP_PROXY;
+            process.env.JUST_BASH_ALLOWED_DOMAINS = JSON.stringify(["*"]);
+            const { createEmbeddedBashOps } = await import(${JSON.stringify(distBootstrap)});
+            const ws = fs.mkdtempSync("/tmp/node-transport-");
+            const ops = await createEmbeddedBashOps({ workspaceDir: ws });
+            let out = "";
+            const r = await ops.exec("curl -sS -X DELETE http://wandr-egress.test/thing", ws, {
+              onData: (b) => { out += b.toString(); },
+              timeout: 15,
+            });
+            console.log(JSON.stringify({ exit: r.exitCode, out, seen }));
+            proxy.close();
+            fs.rmSync(ws, { recursive: true, force: true });
+            process.exit(0);
+          });
+        `;
+        const stdout = await new Promise<string>((resolve, reject) => {
+          execFile("node", ["-e", script], { timeout: 30_000 }, (err, out) =>
+            err ? reject(err) : resolve(out)
+          );
+        });
+        const lastLine = stdout.trim().split("\n").at(-1) ?? "";
+        const result = JSON.parse(lastLine) as {
+          exit: number;
+          out: string;
+          seen: string[];
+        };
+        expect(result.exit).toBe(0);
+        expect(result.out).toContain("node-proxy-body");
+        expect(result.seen).toEqual([
+          "DELETE http://wandr-egress.test/thing Basic ZGVwOnRvaw==",
+        ]);
+      },
+      40_000
+    );
+
+    test("a dying worker's stale events do not poison its replacement", async () => {
+      const { getEgressWorkerForTests } = await import(
+        "../embedded/egress-fetch"
+      );
+      const { output: first } = await curlViaProxy(async (_req, res) => {
+        res.end("lifecycle-body");
+      }, "curl -sS http://wandr-egress.test/first");
+      expect(first).toContain("lifecycle-body");
+      const workerA = getEgressWorkerForTests();
+      expect(workerA).not.toBeNull();
+      // 'error' is typically followed by 'exit'; between the two a
+      // replacement worker may already own new pending requests. The stale
+      // worker's second event must not reject those.
+      workerA?.emit("error", new Error("synthetic failure"));
+      const secondRun = curlViaProxy(async (_req, res) => {
+        res.end("replacement-body");
+      }, "curl -sS http://wandr-egress.test/second");
+      await workerA?.terminate(); // fires the stale 'exit'
+      const { output: second } = await secondRun;
+      expect(second).toContain("replacement-body");
+      expect(getEgressWorkerForTests()).not.toBe(workerA);
+    });
+
+    test("no network config leaves curl unregistered", async () => {
+      delete process.env.JUST_BASH_ALLOWED_DOMAINS;
+      const workspace = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), "lobu-egress-"))
+      );
+      tempDirs.push(workspace);
+      const ops = await createEmbeddedBashOps({ workspaceDir: workspace });
+      const chunks: string[] = [];
+      await ops.exec("curl -sS http://wandr-egress.test/", "/", {
+        onData: (chunk) => chunks.push(chunk.toString()),
+        timeout: 8,
+      });
+      expect(chunks.join("")).toContain("command not found");
+    });
   });
 
   // The pin is load-bearing and the SOLE selector: on a warm deployment reused

--- a/packages/agent-worker/src/embedded/egress-fetch.ts
+++ b/packages/agent-worker/src/embedded/egress-fetch.ts
@@ -1,0 +1,399 @@
+/**
+ * Egress transport for just-bash's built-in network commands (curl/wget).
+ *
+ * The gateway egress proxy is the single policy enforcement point for ALL
+ * agent egress: global denylist → global allowlist → per-agent grant store →
+ * LLM egress judge (see gateway/proxy/http-proxy.ts `checkDomainAccess`).
+ * Spawned binaries already transit it via the HTTP_PROXY env forced into
+ * their environment. just-bash's built-in curl/wget, however, fetch via the
+ * JS runtime — which ignores HTTP_PROXY — so they would bypass every one of
+ * those policies. This module closes that gap: it supplies the `fetch` for
+ * just-bash's network commands and routes every request (including each
+ * redirect hop) through the gateway proxy, making the JS shim just another
+ * proxy client, identical in posture to native curl.
+ *
+ * Deliberately policy-free: no client-side domain matching, no SSRF guard,
+ * no method filtering. Duplicating proxy policy here is how the layers drift
+ * (a client-side allow-list once disagreed with the proxy on `*` semantics
+ * and silently blocked all fetches). Fail-closed instead: without a proxy
+ * configured there is no built-in network access at all. Every real
+ * deployment — local and prod alike — runs workers with HTTP_PROXY set by
+ * the DeploymentManager; the proxy URL is captured once at construction from
+ * the worker's own env, so `export HTTP_PROXY=` inside bash cannot repoint
+ * or clear it.
+ *
+ * ALL transport runs in one shared worker_thread, because the interpreter
+ * thread is a hardened realm: just-bash's defense-in-depth box (which stays
+ * fully ENABLED) monkey-patches this thread's JS globals during script
+ * execution, and network internals construct `WeakRef`s mid-request — undici
+ * on every fresh connection (lib/core/connect.js), Bun inside ReadableStream
+ * reads — so any JS-level fetch here dies with "globalThis.WeakRef
+ * constructor is blocked". (This is also why just-bash's own fetch stack was
+ * broken in the embedded worker.) The worker thread's globals are never
+ * patched. Inside it, the runtime picks its transport: Bun uses the native
+ * fetch with the per-request `proxy` option (undici's client sockets are not
+ * reliable under Bun); Node uses undici `request()` with a ProxyAgent
+ * composed with the redirect interceptor. One worker is shared per process
+ * (bash ops are re-created across conversations on warm deployments, so a
+ * per-instance worker would accumulate threads), spawned eagerly at
+ * bootstrap, kept unref'd so it never holds the process open, and ref'd
+ * only while requests are in flight.
+ */
+
+import { createRequire } from "node:module";
+import { Worker } from "node:worker_threads";
+import type { SecureFetch } from "just-bash";
+
+/** Original timer functions, captured at module load — before any script
+ * execution — because the defense-in-depth box patches the globalThis
+ * bindings during exec and a lookup there would throw "setTimeout is
+ * blocked". The captured references keep working. */
+const realSetTimeout = setTimeout;
+const realClearTimeout = clearTimeout;
+
+const EGRESS_DEFAULT_TIMEOUT_MS = 30_000;
+const EGRESS_MAX_TIMEOUT_MS = 120_000;
+const EGRESS_MAX_REDIRECTS = 20;
+/** Enforced while streaming inside the worker, so an oversized response is
+ * aborted at the limit rather than buffered whole first. */
+const EGRESS_MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
+
+/** just-bash's NetworkAccessDeniedError, passed in so this module never
+ * imports just-bash at runtime (the bootstrap loads it lazily). Using the
+ * real class keeps curl's exit code (7) and error text consistent. */
+type NetworkAccessDeniedErrorCtor = new (url: string, reason?: string) => Error;
+
+interface EgressRequest {
+  id: number;
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+  proxyUrl: string;
+  follow: boolean;
+  timeoutMs: number;
+}
+
+interface EgressReply {
+  id: number;
+  error?: string;
+  status?: number;
+  statusText?: string;
+  headers?: Record<string, string>;
+  body?: Uint8Array;
+  url?: string;
+}
+
+/** Runs in a pristine worker thread — globals unpatched, so WeakRef-using
+ * network internals are safe. Dependency-free except undici (Node branch
+ * only), resolved via an absolute path handed in from the parent. */
+const WORKER_SOURCE = `
+const { parentPort, workerData } = require("node:worker_threads");
+const { STATUS_CODES } = require("node:http");
+const MAX_BYTES = ${EGRESS_MAX_RESPONSE_BYTES};
+const isBun = typeof Bun !== "undefined";
+
+// Node transport: undici request() + ProxyAgent composed with the redirect
+// interceptor. Loaded lazily so the Bun branch never touches undici.
+let undici = null;
+const dispatchers = new Map();
+function forProxy(proxyUrl) {
+  if (!undici) undici = require(workerData.undiciPath);
+  let d = dispatchers.get(proxyUrl);
+  if (!d) {
+    // proxyTunnel:false sends plaintext HTTP as absolute-form requests so the
+    // gateway sees method + full path (matching native curl's posture and
+    // Bun's behavior); HTTPS still uses CONNECT as it must.
+    const plain = new undici.ProxyAgent({ uri: proxyUrl, proxyTunnel: false });
+    d = {
+      plain,
+      following: plain.compose(
+        undici.interceptors.redirect({ maxRedirections: ${EGRESS_MAX_REDIRECTS} })
+      ),
+    };
+    dispatchers.set(proxyUrl, d);
+  }
+  return d;
+}
+
+async function bunFetch(msg) {
+  // Redirects are followed MANUALLY: Bun's redirect:"follow" drops the
+  // per-request proxy option on subsequent hops, so a redirect would escape
+  // the gateway. The manual loop re-dispatches every hop through the proxy.
+  let currentUrl = msg.url;
+  let method = msg.method;
+  let reqHeaders = msg.headers;
+  let reqBody = msg.body;
+  for (let hop = 0; hop <= ${EGRESS_MAX_REDIRECTS}; hop++) {
+    const resp = await fetch(currentUrl, {
+      // connection:close on every hop — Bun's proxied keep-alive is broken
+      // (a second request on a reused proxied connection never completes),
+      // so force a fresh connection per request.
+      method,
+      headers: { ...(reqHeaders || {}), connection: "close" },
+      body: reqBody,
+      redirect: "manual",
+      signal: AbortSignal.timeout(msg.timeoutMs),
+      proxy: msg.proxyUrl,
+    });
+    const location = resp.headers.get("location");
+    if (msg.follow && resp.status >= 300 && resp.status < 400 && location) {
+      const next = new URL(location, currentUrl);
+      if (
+        resp.status === 303 ||
+        ((resp.status === 301 || resp.status === 302) &&
+          method !== "GET" && method !== "HEAD")
+      ) {
+        method = "GET";
+        reqBody = undefined;
+      }
+      if (next.origin !== new URL(currentUrl).origin) {
+        // Never forward credential headers across origins.
+        const stripped = {};
+        for (const [key, value] of Object.entries(reqHeaders || {})) {
+          const lower = key.toLowerCase();
+          if (lower !== "authorization" && lower !== "cookie") {
+            stripped[key] = value;
+          }
+        }
+        reqHeaders = stripped;
+      }
+      if (resp.body) await resp.body.cancel();
+      currentUrl = next.href;
+      continue;
+    }
+    const reader = resp.body ? resp.body.getReader() : null;
+    const chunks = [];
+    let total = 0;
+    while (reader) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_BYTES) {
+        await reader.cancel();
+        throw new Error("Response too large (max " + MAX_BYTES + " bytes)");
+      }
+      chunks.push(value);
+    }
+    const body = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    const headers = {};
+    resp.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    return {
+      status: resp.status,
+      statusText: resp.statusText,
+      headers,
+      body,
+      url: currentUrl,
+    };
+  }
+  throw new Error("Too many redirects (max ${EGRESS_MAX_REDIRECTS})");
+}
+
+async function nodeFetch(msg) {
+  const agents = forProxy(msg.proxyUrl);
+  const res = await undici.request(msg.url, {
+    dispatcher: msg.follow ? agents.following : agents.plain,
+    method: msg.method,
+    headers: msg.headers,
+    body: msg.body,
+    signal: AbortSignal.timeout(msg.timeoutMs),
+  });
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of res.body) {
+    total += chunk.length;
+    if (total > MAX_BYTES) {
+      res.body.destroy();
+      throw new Error("Response too large (max " + MAX_BYTES + " bytes)");
+    }
+    chunks.push(chunk);
+  }
+  const headers = {};
+  for (const [key, value] of Object.entries(res.headers)) {
+    headers[key] = Array.isArray(value) ? value.join(", ") : String(value);
+  }
+  // The redirect interceptor records the hop history; its last entry is the
+  // effective URL.
+  const history = res.context && res.context.history;
+  const last = history && history.length ? history[history.length - 1] : null;
+  return {
+    status: res.statusCode,
+    statusText: STATUS_CODES[res.statusCode] || "",
+    headers,
+    body: Buffer.concat(chunks, total),
+    url: last ? String(last) : msg.url,
+  };
+}
+
+parentPort.on("message", async (msg) => {
+  try {
+    const result = await (isBun ? bunFetch(msg) : nodeFetch(msg));
+    parentPort.postMessage({ id: msg.id, ...result });
+  } catch (e) {
+    parentPort.postMessage({ id: msg.id, error: String((e && e.message) || e) });
+  }
+});
+`;
+
+// ── Shared egress worker (module-level singleton) ───────────────────────────
+
+let egressWorker: Worker | null = null;
+
+/** Test-only: the live worker handle, for lifecycle regression tests
+ * (worker death → replacement → stale events must not poison it). */
+export function getEgressWorkerForTests(): Worker | null {
+  return egressWorker;
+}
+let nextId = 0;
+const pending = new Map<
+  number,
+  { resolve: (reply: EgressReply) => void; reject: (err: Error) => void }
+>();
+
+function settle(id: number): void {
+  pending.delete(id);
+  if (pending.size === 0) egressWorker?.unref();
+}
+
+function ensureWorker(): Worker {
+  if (egressWorker) return egressWorker;
+  const worker = new Worker(WORKER_SOURCE, {
+    eval: true,
+    workerData: {
+      undiciPath: createRequire(__filename).resolve("undici"),
+    },
+  });
+  worker.unref();
+  worker.on("message", (reply: EgressReply) => {
+    const entry = pending.get(reply.id);
+    if (!entry) return;
+    settle(reply.id);
+    if (reply.error !== undefined) {
+      entry.reject(new Error(reply.error));
+    } else {
+      entry.resolve(reply);
+    }
+  });
+  // Idempotent per worker, and only for the CURRENT worker: 'error' is
+  // typically followed by 'exit', and by then a replacement worker may
+  // already own new pending entries — a stale worker's second event must
+  // not reject those or null out the healthy replacement.
+  let failed = false;
+  const failAll = (err: Error): void => {
+    if (failed) return;
+    failed = true;
+    if (egressWorker !== worker) return;
+    egressWorker = null;
+    for (const [id, entry] of pending) {
+      pending.delete(id);
+      entry.reject(err);
+    }
+  };
+  worker.on("error", (err) => failAll(err));
+  worker.on("exit", () => failAll(new Error("egress worker exited")));
+  egressWorker = worker;
+  return worker;
+}
+
+function dispatch(req: Omit<EgressRequest, "id">): Promise<EgressReply> {
+  const worker = ensureWorker();
+  const id = nextId++;
+  return new Promise<EgressReply>((resolve, reject) => {
+    // Grace period past the in-worker abort so a wedged worker can't hang
+    // the interpreter forever.
+    const guard = realSetTimeout(() => {
+      settle(id);
+      reject(new Error("egress request timed out"));
+    }, req.timeoutMs + 5_000);
+    guard.unref();
+    pending.set(id, {
+      resolve: (reply) => {
+        realClearTimeout(guard);
+        resolve(reply);
+      },
+      reject: (err) => {
+        realClearTimeout(guard);
+        reject(err);
+      },
+    });
+    worker.ref();
+    worker.postMessage({ ...req, id });
+  });
+}
+
+function toHeaderRecord(
+  headers: Headers | Record<string, string> | undefined
+): Record<string, string> {
+  if (!headers) return {};
+  if (typeof (headers as Headers).forEach === "function") {
+    const record: Record<string, string> = {};
+    (headers as Headers).forEach((value, key) => {
+      record[key] = value;
+    });
+    return record;
+  }
+  return headers as Record<string, string>;
+}
+
+export function buildEgressFetch(
+  NetworkAccessDeniedError: NetworkAccessDeniedErrorCtor
+): SecureFetch {
+  // Captured once from the worker's own env (bash scripts only ever see a
+  // scrubbed copy, so agents cannot repoint the proxy).
+  const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
+  const httpsProxy =
+    process.env.HTTPS_PROXY || process.env.https_proxy || httpProxy;
+
+  // Spawn the shared worker eagerly: bootstrap runs outside the
+  // script-execution window, where thread creation is still allowed.
+  if (httpProxy || httpsProxy) ensureWorker();
+
+  return async (url, options = {}) => {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new NetworkAccessDeniedError(url, "invalid URL");
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new NetworkAccessDeniedError(
+        url,
+        `unsupported scheme: ${parsed.protocol}`
+      );
+    }
+    const proxyUrl = parsed.protocol === "https:" ? httpsProxy : httpProxy;
+    if (!proxyUrl) {
+      throw new NetworkAccessDeniedError(
+        url,
+        "gateway egress proxy not configured (HTTP_PROXY unset)"
+      );
+    }
+
+    const reply = await dispatch({
+      url,
+      method: options.method || "GET",
+      headers: toHeaderRecord(options.headers),
+      body: options.body,
+      proxyUrl,
+      follow: options.followRedirects !== false,
+      timeoutMs: Math.min(
+        options.timeoutMs ?? EGRESS_DEFAULT_TIMEOUT_MS,
+        EGRESS_MAX_TIMEOUT_MS
+      ),
+    });
+    return {
+      status: reply.status ?? 0,
+      statusText: reply.statusText ?? "",
+      headers: reply.headers ?? {},
+      body: reply.body ?? new Uint8Array(0),
+      url: reply.url ?? url,
+    };
+  };
+}

--- a/packages/agent-worker/src/embedded/just-bash-bootstrap.ts
+++ b/packages/agent-worker/src/embedded/just-bash-bootstrap.ts
@@ -16,6 +16,7 @@ import { stripEnv } from "@lobu/core";
 import type { BashOperations } from "@mariozechner/pi-coding-agent";
 import { SENSITIVE_WORKER_ENV_KEYS } from "../shared/worker-env-keys";
 import type { GatewayParams } from "@lobu/plugin-toolkit";
+import { buildEgressFetch } from "./egress-fetch";
 import {
   type SandboxStrategy,
   probeSandboxStrategy,
@@ -431,7 +432,9 @@ export async function createEmbeddedBashOps(
     return runtimeProvider.createBashOps({ gw: options.gw });
   }
 
-  const { Bash, ReadWriteFs } = await import("just-bash");
+  const { Bash, ReadWriteFs, NetworkAccessDeniedError } = await import(
+    "just-bash"
+  );
 
   const rawWorkspaceDir =
     options.workspaceDir || process.env.WORKSPACE_DIR || "/workspace";
@@ -448,12 +451,10 @@ export async function createEmbeddedBashOps(
   }
   const bashFs = new ReadWriteFs({ root: workspaceDir });
 
-  // Parse allowed domains from env var (set by gateway).
-  // Defense-in-depth: the gateway is trusted, but a malformed env (non-array,
-  // non-string entries, embedded "/" or whitespace) would either crash
-  // `.flatMap(...)` or, worse, expand an "allow https://${domain}/" prefix
-  // into something attacker-shaped (`evil.com/ ` or `attacker.com/path`).
-  // Validate the parsed shape and the per-domain syntax explicitly.
+  // Parse allowed domains from env var (set by gateway). Entries gate whether
+  // network commands are registered at all — URL policy is enforced by the
+  // gateway egress proxy, not here. Still validate shape and per-domain
+  // syntax so a malformed env can't silently opt an agent into the network.
   const DOMAIN_PATTERN = /^[A-Za-z0-9.*_-]+(?::\d+)?$/;
   let allowedDomains: string[] = [];
   if (process.env.JUST_BASH_ALLOWED_DOMAINS) {
@@ -485,22 +486,16 @@ export async function createEmbeddedBashOps(
     }
   }
 
-  const network =
+  // A non-empty allow-list opts the agent into network commands; URL policy
+  // itself is NOT enforced here. Built-in curl/wget route through the gateway
+  // egress proxy (see egress-fetch.ts), where the per-agent grants synced
+  // from this same allow-list — plus the global denylist, SSRF guard, and
+  // egress judge — are enforced for the JS shim exactly as they are for
+  // spawned binaries. just-bash's own NetworkConfig fetch would bypass all
+  // of that (it never consults HTTP_PROXY), so it is deliberately unused.
+  const egressFetch =
     allowedDomains.length > 0
-      ? {
-          allowedUrlPrefixes: allowedDomains.flatMap((domain: string) => [
-            `https://${domain}/`,
-            `http://${domain}/`,
-          ]),
-          allowedMethods: ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"] as (
-            | "GET"
-            | "HEAD"
-            | "POST"
-            | "PUT"
-            | "PATCH"
-            | "DELETE"
-          )[],
-        }
+      ? buildEgressFetch(NetworkAccessDeniedError)
       : undefined;
 
   // Build MCP CLI commands first so that explicit MCP registrations win over
@@ -575,7 +570,7 @@ export async function createEmbeddedBashOps(
     cwd: "/",
     env: stripEnv(process.env, SENSITIVE_WORKER_ENV_KEYS),
     executionLimits: EMBEDDED_BASH_LIMITS,
-    ...(network && { network }),
+    ...(egressFetch && { fetch: egressFetch }),
     ...(customCommands.length > 0 && { customCommands }),
   });
 


### PR DESCRIPTION
## Problem (three layers deep)

1. **`network.allowed: ["*"]` never worked.** The worker compiled the agent allow-list into just-bash URL prefixes; `"*"` became the literal prefix `https://*/`, which matches nothing → every fetch denied.
2. **Built-in `curl`/`wget` bypassed the gateway egress proxy entirely.** just-bash's network stack fetches via the JS runtime, which ignores `HTTP_PROXY` — skipping the global denylist, per-agent grant store, SSRF guard, and LLM egress judge that every spawned binary is subject to.
3. **The fetch was broken outright in the embedded worker anyway.** just-bash's defense-in-depth box patches the interpreter thread's JS globals during script execution, and network internals construct `WeakRef`s mid-request — undici on every fresh connection (`lib/core/connect.js`, stack-traced), Bun inside ReadableStream reads — so any body read died with `globalThis.WeakRef constructor is blocked`, on **Bun and Node alike**.

## Fix: the JS shim becomes just another client of the gateway proxy

New `egress-fetch.ts` supplies the `fetch` for just-bash's network commands and is **deliberately policy-free** — one enforcement point, one wire path:

- **ALL transport runs in ONE shared worker_thread per process**, whose globals the box never patches (defense-in-depth stays fully enabled; no per-instance thread accumulation on warm deployments). Inside it the runtime picks its transport: Bun → native fetch with the per-request `proxy` option; Node → undici `request()` + `ProxyAgent` (`proxyTunnel: false`, so plaintext HTTP goes absolute-form and the gateway sees method + full path — matching native curl and Bun; HTTPS still CONNECTs) composed with the redirect interceptor. Eagerly spawned at bootstrap, `unref`'d when idle, `ref`'d only while requests are in flight, respawned if it dies.
- **Every request and every redirect hop transits the gateway proxy**, where the per-agent grants (synced from `network.allowed`), global allow/denylist, SSRF guard, and egress judge apply — identical in posture to native curl.
- **The 32MB response cap is enforced while streaming** inside the worker on both runtimes — oversized responses are aborted at the limit, never buffered whole.
- **Fail-closed:** no `HTTP_PROXY` → no built-in network. Every real deployment (local and prod) sets it via DeploymentManager. Captured at bootstrap from the worker env, so `export HTTP_PROXY=` inside bash can't repoint it.
- **No client-side URL policy.** Duplicated policy is how the `*` drift happened. A non-empty `network.allowed` still gates whether curl/wget are registered at all (secure default preserved).

## Verification

Hermetic tests (no DNS, no live network — the recording proxy answers absolute-URI requests itself): routing + body delivery via proxy ✅ · proxy 403 denial surfaced ✅ · **33MB chunked response aborted at the streaming cap** ✅ · fail-closed without proxy ✅ · no network config → curl unregistered ✅. Suite 13/13 (bun).

Node path verified end-to-end through the real `createEmbeddedBashOps` against a recording proxy: absolute-form `GET`/`DELETE` with method + full path + `Proxy-Authorization` visible at the proxy ✅ · `-L` redirect with **both hops individually proxied** ✅ · `%{http_code}` ✅ · 33MB streaming-cap abort **and the worker survives to serve the next request** ✅ · https → CONNECT ✅ · **5 bash-ops instances share exactly 1 worker thread** ✅ · **natural process exit** (unref'd idle worker) ✅.

`make pre-pr` green.

## Notes

- Replaces two earlier wrong approaches on this branch: `defenseInDepth: false` (misdiagnosed root cause; security regression) and `dangerouslyAllowFullInternetAccess` (pi-review-flagged proxy bypass). Both prior pi-review blockers (proxy bypass; per-instance worker leak) are addressed by the current design.
- Per-agent `"*"` does not exceed a restrictive global `WORKER_ALLOWED_DOMAINS` at the proxy (grant candidates never include bare `*`) — agent config can't blow past operator policy; the egress judge covers un-granted domains dynamically.
- Adds `undici` as an explicit dependency (was transitive) for the node worker branch.
- Known gap: the undici branch inside the worker is exercised by the manual node verification above, not by CI (bun:test runs under Bun). The worker protocol, lifecycle, cap, and proxy routing ARE covered by the bun suite.

