### PR TITLE
fix(egress): enforce per-agent deniedDomains, deny-before-judge precedence, any-depth wildcard grants

### DIFF
--- a/packages/core/src/worker/auth.ts
+++ b/packages/core/src/worker/auth.ts
@@ -94,6 +94,13 @@ export interface WorkerTokenData {
    * egress policy. Absent/empty → the sandbox is `deny-all` (fail closed).
    */
   allowedDomains?: string[];
+  /**
+   * Egress denylist (the agent's `networkConfig.deniedDomains`) for a remote
+   * runtime sandbox — signed for the same reason as {@link allowedDomains}.
+   * Providers that cannot express exclusions must fail closed: drop any allow
+   * entry the denylist covers rather than granting it.
+   */
+  deniedDomains?: string[];
 }
 
 export function generateWorkerToken(
@@ -135,6 +142,8 @@ export function generateWorkerToken(
     environmentId?: string;
     /** Resolved egress allowlist for a remote runtime sandbox. See WorkerTokenData.allowedDomains. */
     allowedDomains?: string[];
+    /** Resolved egress denylist for a remote runtime sandbox. See WorkerTokenData.deniedDomains. */
+    deniedDomains?: string[];
   }
 ): string {
   if (!options.channelId) {
@@ -162,6 +171,7 @@ export function generateWorkerToken(
     runtimeProviderId: options.runtimeProviderId,
     environmentId: options.environmentId,
     allowedDomains: options.allowedDomains,
+    deniedDomains: options.deniedDomains,
   };
 
   return encrypt(JSON.stringify(payload));

--- a/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
+++ b/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
@@ -122,6 +122,55 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     ).toBe(true);
   });
 
+  test("syncs networkConfig.deniedDomains as deny grants", async () => {
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: {
+          allowedDomains: ["api.example.com"],
+          deniedDomains: ["evil.com", "*.bad.com"],
+        },
+      })
+    );
+
+    expect(await grantStore.hasGrant("agent-1", "api.example.com")).toBe(true);
+    expect(await grantStore.isDenied("agent-1", "evil.com")).toBe(true);
+    expect(await grantStore.isDenied("agent-1", "sub.bad.com")).toBe(true);
+    expect(await grantStore.hasGrant("agent-1", "evil.com")).toBe(false);
+  });
+
+  test("removing a denied domain from config revokes the deny grant", async () => {
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { deniedDomains: ["evil.com"] },
+      })
+    );
+    expect(await grantStore.isDenied("agent-1", "evil.com")).toBe(true);
+
+    await manager.syncNetworkConfigGrants(
+      buildPayload({ networkConfig: { deniedDomains: [] } })
+    );
+    expect(await grantStore.isDenied("agent-1", "evil.com")).toBe(false);
+  });
+
+  test("flipping a domain from denied to allowed updates the grant", async () => {
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { deniedDomains: ["flip.example.com"] },
+      })
+    );
+    expect(await grantStore.isDenied("agent-1", "flip.example.com")).toBe(true);
+
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { allowedDomains: ["flip.example.com"] },
+      })
+    );
+    expect(await grantStore.isDenied("agent-1", "flip.example.com")).toBe(
+      false
+    );
+    expect(await grantStore.hasGrant("agent-1", "flip.example.com")).toBe(true);
+  });
+
   test("syncs both network and pre-approved tools in one call", async () => {
     await manager.syncNetworkConfigGrants(
       buildPayload({

--- a/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
+++ b/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
@@ -196,6 +196,63 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     );
   });
 
+  test("revokes a config-removed domain even when the sync cache is cold", async () => {
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { allowedDomains: ["a.example.com"] },
+      })
+    );
+    expect(await grantStore.hasGrant("agent-1", "a.example.com")).toBe(true);
+
+    // Fresh manager = cold cache (pod restart / other replica). The domain
+    // was removed from config; revocation must not depend on pod-local state.
+    const freshManager = new TestDeploymentManager(TEST_CONFIG);
+    freshManager.setGrantStore(grantStore);
+    freshManager.setPolicyStore(policyStore);
+    await freshManager.syncNetworkConfigGrants(
+      buildPayload({ networkConfig: { allowedDomains: [] } })
+    );
+
+    expect(await grantStore.hasGrant("agent-1", "a.example.com")).toBe(false);
+  });
+
+  test("cold-cache sync does not revoke user-approved MCP tool grants", async () => {
+    // Simulates a Slack "always" tool approval — same store, mcp_tool kind,
+    // no expiry. Config sync must never treat it as config-owned.
+    await grantStore.grant(
+      "agent-1",
+      "/mcp/gmail/tools/send_email",
+      null,
+      undefined,
+      "test-org"
+    );
+
+    const freshManager = new TestDeploymentManager(TEST_CONFIG);
+    freshManager.setGrantStore(grantStore);
+    freshManager.setPolicyStore(policyStore);
+    await freshManager.syncNetworkConfigGrants(
+      buildPayload({ networkConfig: { allowedDomains: ["x.example.com"] } })
+    );
+
+    expect(
+      await grantStore.hasGrant("agent-1", "/mcp/gmail/tools/send_email")
+    ).toBe(true);
+  });
+
+  test("grants nix cache domains while nix is configured, revokes on removal", async () => {
+    await manager.syncNetworkConfigGrants(
+      buildPayload({ nixConfig: { packages: ["python311"] } })
+    );
+    expect(await grantStore.hasGrant("agent-1", "cache.nixos.org")).toBe(true);
+
+    const freshManager = new TestDeploymentManager(TEST_CONFIG);
+    freshManager.setGrantStore(grantStore);
+    freshManager.setPolicyStore(policyStore);
+    await freshManager.syncNetworkConfigGrants(buildPayload({}));
+
+    expect(await grantStore.hasGrant("agent-1", "cache.nixos.org")).toBe(false);
+  });
+
   test("syncs both network and pre-approved tools in one call", async () => {
     await manager.syncNetworkConfigGrants(
       buildPayload({

--- a/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
+++ b/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
@@ -297,6 +297,29 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     );
   });
 
+  test("a config-denied npm registry row survives reconcile as a deny", async () => {
+    // Deny the npm registry in config; the reconcile must keep the deny row
+    // (it is config-expected), and the infra exemption must not resurrect it.
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { deniedDomains: ["registry.npmjs.org"] },
+      })
+    );
+    expect(
+      await grantStore.isDenied("agent-1", "registry.npmjs.org", "test-org")
+    ).toBe(true);
+
+    // Removing the deny from config drops the row even though the domain is
+    // in the infra exempt set — a denied row is never exempt.
+    const freshManager = new TestDeploymentManager(TEST_CONFIG);
+    freshManager.setGrantStore(grantStore);
+    freshManager.setPolicyStore(policyStore);
+    await freshManager.syncNetworkConfigGrants(buildPayload({}));
+    expect(
+      await grantStore.isDenied("agent-1", "registry.npmjs.org", "test-org")
+    ).toBe(false);
+  });
+
   test("syncs both network and pre-approved tools in one call", async () => {
     await manager.syncNetworkConfigGrants(
       buildPayload({

--- a/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
+++ b/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
@@ -253,6 +253,50 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     expect(await grantStore.hasGrant("agent-1", "cache.nixos.org")).toBe(false);
   });
 
+  test("removing a deny listed under an alias spelling re-allows the domain", async () => {
+    // "*.example.com" and ".example.com" normalize to the same grant row.
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: {
+          allowedDomains: ["*.example.com"],
+          deniedDomains: [".example.com"],
+        },
+      })
+    );
+    expect(await grantStore.isDenied("agent-1", "api.example.com")).toBe(true);
+
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { allowedDomains: ["*.example.com"] },
+      })
+    );
+    expect(await grantStore.isDenied("agent-1", "api.example.com")).toBe(false);
+    expect(await grantStore.hasGrant("agent-1", "api.example.com")).toBe(true);
+  });
+
+  test("reconcile preserves infra-granted npm registry domains", async () => {
+    // Simulates the CLI-backend deploy-time auto-grant, which is not
+    // derivable from the message payload and must survive reconciliation.
+    await grantStore.grant(
+      "agent-1",
+      "registry.npmjs.org",
+      null,
+      undefined,
+      "test-org"
+    );
+
+    const freshManager = new TestDeploymentManager(TEST_CONFIG);
+    freshManager.setGrantStore(grantStore);
+    freshManager.setPolicyStore(policyStore);
+    await freshManager.syncNetworkConfigGrants(
+      buildPayload({ networkConfig: { allowedDomains: ["x.example.com"] } })
+    );
+
+    expect(await grantStore.hasGrant("agent-1", "registry.npmjs.org")).toBe(
+      true
+    );
+  });
+
   test("syncs both network and pre-approved tools in one call", async () => {
     await manager.syncNetworkConfigGrants(
       buildPayload({

--- a/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
+++ b/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
@@ -320,6 +320,29 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     ).toBe(false);
   });
 
+  test("two-replica X→Y→X: a warm stale cache must not skip reconciliation", async () => {
+    const replicaA = manager;
+    const replicaB = new TestDeploymentManager(TEST_CONFIG);
+    replicaB.setGrantStore(grantStore);
+    replicaB.setPolicyStore(policyStore);
+
+    const configX = { networkConfig: { allowedDomains: ["x.example.com"] } };
+    const configY = { networkConfig: { allowedDomains: ["y.example.com"] } };
+
+    // Replica A syncs X (warm cache = X), replica B syncs Y (DB = Y).
+    await replicaA.syncNetworkConfigGrants(buildPayload(configX));
+    await replicaB.syncNetworkConfigGrants(buildPayload(configY));
+    expect(await grantStore.hasGrant("agent-1", "y.example.com")).toBe(true);
+    expect(await grantStore.hasGrant("agent-1", "x.example.com")).toBe(false);
+
+    // Config reverts to X and the message lands on replica A, whose cache
+    // already says X. Skipping on the pod-local cache would leave Y's rows
+    // active and X's rows missing.
+    await replicaA.syncNetworkConfigGrants(buildPayload(configX));
+    expect(await grantStore.hasGrant("agent-1", "y.example.com")).toBe(false);
+    expect(await grantStore.hasGrant("agent-1", "x.example.com")).toBe(true);
+  });
+
   test("syncs both network and pre-approved tools in one call", async () => {
     await manager.syncNetworkConfigGrants(
       buildPayload({
@@ -461,10 +484,10 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     ).toBe(false);
   });
 
-  test("invalidateGrantSyncCache forces the next call to re-sync", async () => {
-    // An operator changes `networkConfig.allowedDomains` for an agent (via
-    // `lobu apply` or the web UI) — the next message should re-grant even
-    // if the cached hash says the set is unchanged.
+  test("domain sync writes only on drift, and repairs drift without invalidation", async () => {
+    // Domains reconcile against Postgres on every sync: identical repeat
+    // syncs cost zero writes, and out-of-band drift (a revoked row) is
+    // repaired on the next message with no cache invalidation involved.
     const grantSpy = spyOn(grantStore, "grant");
 
     const payload = buildPayload({
@@ -475,15 +498,15 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     const firstCallCount = grantSpy.mock.calls.length;
     expect(firstCallCount).toBe(1);
 
-    // Identical second call → cache hit → no new writes.
+    // Identical second call → rows already match → no new writes.
     await manager.syncNetworkConfigGrants(payload);
     expect(grantSpy.mock.calls.length).toBe(firstCallCount);
 
-    // Invalidate and re-sync: the manager should re-grant even though
-    // nothing in the payload changed.
-    manager.invalidateGrantSyncCache("agent-1");
+    // Simulate drift (row removed out of band): the next sync re-grants.
+    await grantStore.revoke("agent-1", "api.example.com", "test-org");
     await manager.syncNetworkConfigGrants(payload);
     expect(grantSpy.mock.calls.length).toBe(firstCallCount + 1);
+    expect(await grantStore.hasGrant("agent-1", "api.example.com")).toBe(true);
   });
 
   test("revokes all grants when the config is cleared entirely", async () => {

--- a/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
+++ b/packages/server/src/gateway/__tests__/base-deployment-grants.test.ts
@@ -171,6 +171,31 @@ describe("DeploymentManager.syncNetworkConfigGrants", () => {
     expect(await grantStore.hasGrant("agent-1", "flip.example.com")).toBe(true);
   });
 
+  test("same agent id in two orgs syncs independently (org-scoped cache)", async () => {
+    await seedAgentRow("agent-1", { organizationId: "org-b" });
+
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        networkConfig: { deniedDomains: ["evil.com"] },
+      })
+    );
+    // Identical payload for the SAME agent id under a different org must not
+    // be swallowed by the sync cache — grants rows are org-scoped.
+    await manager.syncNetworkConfigGrants(
+      buildPayload({
+        organizationId: "org-b",
+        networkConfig: { deniedDomains: ["evil.com"] },
+      })
+    );
+
+    expect(await grantStore.isDenied("agent-1", "evil.com", "test-org")).toBe(
+      true
+    );
+    expect(await grantStore.isDenied("agent-1", "evil.com", "org-b")).toBe(
+      true
+    );
+  });
+
   test("syncs both network and pre-approved tools in one call", async () => {
     await manager.syncNetworkConfigGrants(
       buildPayload({

--- a/packages/server/src/gateway/__tests__/grant-store.test.ts
+++ b/packages/server/src/gateway/__tests__/grant-store.test.ts
@@ -136,6 +136,23 @@ describe("GrantStore (PG-backed)", () => {
       });
     });
 
+    test("domain wildcard matches deeper subdomains (any depth)", async () => {
+      await withOrg(async () => {
+        await store.grant("agent-1", "*.example.com", null);
+        expect(await store.hasGrant("agent-1", "api.v2.example.com")).toBe(
+          true
+        );
+      });
+    });
+
+    test("domain wildcard deny blocks deeper subdomains (any depth)", async () => {
+      await withOrg(async () => {
+        await store.grant("agent-1", "*.evil.com", null, true);
+        expect(await store.hasGrant("agent-1", "api.v2.evil.com")).toBe(false);
+        expect(await store.isDenied("agent-1", "api.v2.evil.com")).toBe(true);
+      });
+    });
+
     test("domain wildcard does not match two-part domains", async () => {
       await withOrg(async () => {
         await store.grant("agent-1", "*.example.com", null);

--- a/packages/server/src/gateway/__tests__/http-proxy-judge.test.ts
+++ b/packages/server/src/gateway/__tests__/http-proxy-judge.test.ts
@@ -3,12 +3,14 @@ import * as crypto from "node:crypto";
 import type * as http from "node:http";
 import * as net from "node:net";
 import { generateWorkerToken } from "@lobu/core";
+import type { GrantStore } from "../permissions/grant-store.js";
 import { PolicyStore } from "../permissions/policy-store.js";
 import { EgressJudge } from "../proxy/egress-judge/judge.js";
 import type { JudgeClient, JudgeVerdict } from "../proxy/egress-judge/types.js";
 import {
   __testOnly,
   setProxyEgressJudge,
+  setProxyGrantStore,
   setProxyPolicyStore,
   startHttpProxy,
   stopHttpProxy,
@@ -230,5 +232,30 @@ describe("HTTP Proxy — egress judge integration", () => {
     };
     const res = await rawProxyRequest("http://example.com/probe", auth());
     expect(res.statusCode).toBe(403);
+  });
+
+  test("an explicit deny grant blocks before the judge is consulted", async () => {
+    // A per-agent deny grant is authoritative: even a judged domain with an
+    // allow-everything judge must never be reached.
+    const denyAllGrants = {
+      isDenied: async () => true,
+      hasGrant: async () => false,
+    } as unknown as GrantStore;
+    setProxyGrantStore(denyAllGrants);
+    try {
+      fakeClient.calls = 0;
+      fakeClient.impl = async () => ({
+        verdict: "allow",
+        reason: "judge-would-allow",
+      });
+      const res = await rawProxyRequest(
+        "http://example.com/deny-grant-path",
+        auth()
+      );
+      expect(res.statusCode).toBe(403);
+      expect(fakeClient.calls).toBe(0);
+    } finally {
+      setProxyGrantStore(null as unknown as GrantStore);
+    }
   });
 });

--- a/packages/server/src/gateway/__tests__/turn-liveness.test.ts
+++ b/packages/server/src/gateway/__tests__/turn-liveness.test.ts
@@ -14,7 +14,11 @@ import {
   expect,
   test,
 } from "bun:test";
-import { AgentErrorCode, generateWorkerToken } from "@lobu/core";
+import {
+  AgentErrorCode,
+  generateWorkerToken,
+  verifyWorkerToken,
+} from "@lobu/core";
 import { getDb } from "../../db/client.js";
 import { RunsQueue } from "../infrastructure/queue/runs-queue.js";
 import {
@@ -28,6 +32,7 @@ import {
   type TurnRouting,
 } from "../orchestration/turn-liveness.js";
 import {
+  attachFreshRunJobToken,
   listPendingAgentRunInputs,
   recordAgentRunInput,
 } from "../orchestration/agent-run-input.js";
@@ -161,6 +166,8 @@ async function durableInput(
         platform: "api",
         runId,
         messageId,
+        allowedDomains: ["api.example.com"],
+        deniedDomains: ["evil.example.com"],
       },
     ),
   };
@@ -199,6 +206,15 @@ describe("turn-liveness", () => {
       stores_token: false,
       stores_timestamp: false,
     });
+
+    // Replay re-mints from the persisted claims — BOTH egress lists must
+    // survive the durable round trip, or a replayed run executes with the
+    // allowlist but without its deny subtraction.
+    const [pending] = await listPendingAgentRunInputs("dep-durable");
+    const replayed = attachFreshRunJobToken(pending!);
+    const replayedToken = verifyWorkerToken(replayed.runJobToken!);
+    expect(replayedToken!.allowedDomains).toEqual(["api.example.com"]);
+    expect(replayedToken!.deniedDomains).toEqual(["evil.example.com"]);
 
     await commitTerminalReply(
       "dep-durable",

--- a/packages/server/src/gateway/__tests__/vercel-network-policy.test.ts
+++ b/packages/server/src/gateway/__tests__/vercel-network-policy.test.ts
@@ -49,6 +49,12 @@ describe("vercel networkPolicyFromDomains — deny subtraction", () => {
     );
   });
 
+  test("port-qualified allow does not dodge a deny on the bare host", () => {
+    expect(
+      networkPolicyFromDomains(["evil.example.com:443", "ok.com"], ["evil.example.com"])
+    ).toEqual({ allow: ["ok.com"] });
+  });
+
   test("deny matching is case-insensitive", () => {
     // DNS is case-insensitive; a mixed-case deny must still subtract.
     expect(

--- a/packages/server/src/gateway/__tests__/vercel-network-policy.test.ts
+++ b/packages/server/src/gateway/__tests__/vercel-network-policy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { __testOnly } from "../runtime/providers/vercel.js";
+
+const { networkPolicyFromDomains } = __testOnly;
+
+describe("vercel networkPolicyFromDomains — deny subtraction", () => {
+  test("no denies: wildcard stays allow-all, lists pass through", () => {
+    expect(networkPolicyFromDomains(["*"])).toBe("allow-all");
+    expect(networkPolicyFromDomains(["api.example.com"])).toEqual({
+      allow: ["api.example.com"],
+    });
+    expect(networkPolicyFromDomains(undefined)).toBe("deny-all");
+    expect(networkPolicyFromDomains([])).toBe("deny-all");
+  });
+
+  test("allow-all plus a deny fails closed instead of granting everything", () => {
+    // The sandbox policy cannot express "everything except evil.com" —
+    // an unbounded allow must not survive a configured deny.
+    expect(networkPolicyFromDomains(["*"], ["evil.com"])).toBe("deny-all");
+  });
+
+  test("denied entry is subtracted from an explicit allow list", () => {
+    expect(
+      networkPolicyFromDomains(
+        ["api.example.com", "evil.com"],
+        ["evil.com"]
+      )
+    ).toEqual({ allow: ["api.example.com"] });
+  });
+
+  test("wildcard deny removes covered allow entries", () => {
+    expect(
+      networkPolicyFromDomains(
+        ["api.example.com", "safe.other.com"],
+        [".example.com"]
+      )
+    ).toEqual({ allow: ["safe.other.com"] });
+  });
+
+  test("allow wildcard overlapping a deny is dropped (fail closed)", () => {
+    expect(
+      networkPolicyFromDomains(["*.evil.com", "ok.com"], ["evil.com"])
+    ).toEqual({ allow: ["ok.com"] });
+  });
+
+  test("all allows denied collapses to deny-all", () => {
+    expect(networkPolicyFromDomains(["evil.com"], ["evil.com"])).toBe(
+      "deny-all"
+    );
+  });
+});

--- a/packages/server/src/gateway/__tests__/vercel-network-policy.test.ts
+++ b/packages/server/src/gateway/__tests__/vercel-network-policy.test.ts
@@ -48,4 +48,14 @@ describe("vercel networkPolicyFromDomains — deny subtraction", () => {
       "deny-all"
     );
   });
+
+  test("deny matching is case-insensitive", () => {
+    // DNS is case-insensitive; a mixed-case deny must still subtract.
+    expect(
+      networkPolicyFromDomains(["*.example.com"], ["SENSITIVE.EXAMPLE.COM"])
+    ).toBe("deny-all");
+    expect(
+      networkPolicyFromDomains(["API.Example.com", "ok.com"], ["api.example.com"])
+    ).toEqual({ allow: ["ok.com"] });
+  });
 });

--- a/packages/server/src/gateway/__tests__/worker-token-mint-parity.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-token-mint-parity.test.ts
@@ -125,6 +125,27 @@ describe("worker-token mint parity (real mint, not generateWorkerToken)", () => 
     }
   });
 
+  test("PARITY: both mints carry the egress allow AND deny claims", () => {
+    const egressArgs = {
+      ...baseArgs,
+      allowedDomains: ["api.example.com"],
+      deniedDomains: ["evil.example.com"],
+    };
+    const runJob = verifyWorkerToken(
+      buildRunJobToken({ ...egressArgs, runId: 7 }) as string
+    );
+    const deployment = verifyWorkerToken(
+      buildDeploymentWorkerToken(egressArgs)
+    );
+
+    for (const decoded of [runJob, deployment]) {
+      expect(decoded?.allowedDomains).toEqual(["api.example.com"]);
+      // Dropping deniedDomains on either mint silently re-opens denied hosts
+      // on remote runtimes (the sandbox policy subtracts them).
+      expect(decoded?.deniedDomains).toEqual(["evil.example.com"]);
+    }
+  });
+
   test("the shipped bug reproduces: a chat token WITHOUT connectionId is rejected", () => {
     // Mint via the real path but with no connectionId in platformMetadata —
     // this is the state MessageConsumer produced before #1274.

--- a/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-token-refresh-route.test.ts
@@ -116,6 +116,8 @@ function mintToken(opts: { runId?: number; messageId?: string }): string {
     source: "watcher-run",
     runId: opts.runId,
     messageId: opts.messageId,
+    allowedDomains: ["api.example.com"],
+    deniedDomains: ["evil.example.com"],
   });
 }
 
@@ -154,6 +156,11 @@ describe("POST /worker/token/refresh", () => {
     expect(data!.source).toBe("watcher-run");
     expect(data!.deploymentName).toBe(DEPLOYMENT);
     expect(data!.organizationId).toBe("org-1");
+    // Egress claims must BOTH survive refresh — dropping allowedDomains
+    // breaks the sandbox network (deny-all), dropping deniedDomains
+    // silently re-opens denied hosts on remote runtimes.
+    expect(data!.allowedDomains).toEqual(["api.example.com"]);
+    expect(data!.deniedDomains).toEqual(["evil.example.com"]);
   });
 
   test("REVOCATION: denied (403) once this turn has no live marker", async () => {

--- a/packages/server/src/gateway/gateway/index.ts
+++ b/packages/server/src/gateway/gateway/index.ts
@@ -808,9 +808,11 @@ export class WorkerGateway {
         // after the token rotates mid-turn.
         runtimeProviderId: tokenData.runtimeProviderId,
         environmentId: tokenData.environmentId,
-        // Preserve the egress allowlist too — otherwise a refreshed token would
-        // fall to deny-all and break the sandbox's network mid-turn.
+        // Preserve the egress allow/deny lists too — otherwise a refreshed
+        // token would fall to deny-all (allow) or, worse, drop its exclusions
+        // (deny) and re-open denied hosts mid-turn.
         allowedDomains: tokenData.allowedDomains,
+        deniedDomains: tokenData.deniedDomains,
       }
     );
 

--- a/packages/server/src/gateway/orchestration/agent-run-input.ts
+++ b/packages/server/src/gateway/orchestration/agent-run-input.ts
@@ -36,6 +36,7 @@ function durableClaims(token: WorkerTokenData): DurableRunTokenClaims {
     runtimeProviderId: token.runtimeProviderId,
     environmentId: token.environmentId,
     allowedDomains: token.allowedDomains,
+    deniedDomains: token.deniedDomains,
   };
 }
 
@@ -93,6 +94,7 @@ export function attachFreshRunJobToken(
         runtimeProviderId: token.runtimeProviderId,
         environmentId: token.environmentId,
         allowedDomains: token.allowedDomains,
+        deniedDomains: token.deniedDomains,
       },
     ),
   };

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -11,7 +11,6 @@ import {
 	extractTraceId,
 	generateWorkerToken,
 	getErrorMessage,
-	inferGrantKind,
 	type MessagePayload,
 	normalizeDomainPattern,
 	OrchestratorError,
@@ -830,16 +829,14 @@ export class DeploymentManager {
   protected grantStore?: GrantStore;
   protected policyStore?: PolicyStore;
   /**
-   * Per-(org, agent) cache of the last-synced grant patterns (pattern →
-   * denied flag). Used to (a) skip redundant `grantStore.grant()` writes
-   * when the set is unchanged and (b) compute the revoke-diff so patterns
-   * dropped from `networkConfig.allowedDomains` / `deniedDomains` /
-   * `preApprovedTools` are removed from the grant store instead of
-   * lingering forever. Keyed by `org|agent` — agent ids are only unique
-   * within an organization, and grants are org-scoped rows, so an
-   * agent-id-only key would let org A's sync suppress org B's writes.
+   * Per-(org, agent) cache of the last-synced `preApprovedTools` patterns,
+   * used to diff tool grants/revokes (domains reconcile against Postgres
+   * instead — see syncNetworkConfigGrants). Keyed by `org|agent` — agent
+   * ids are only unique within an organization, and grants are org-scoped
+   * rows, so an agent-id-only key would let org A's sync suppress org B's
+   * writes.
    */
-  private grantSyncCache = new Map<string, Map<string, boolean>>();
+  private grantSyncCache = new Map<string, Set<string>>();
   /**
    * In-flight `ensureDeployment` promises keyed by deploymentName. Coalesces
    * concurrent calls within a single gateway process so the orchestrator-
@@ -1132,18 +1129,18 @@ export class DeploymentManager {
    * which is read by the shared HTTP proxy rather than by the worker
    * process.
    *
-   * Grant writes diff against the last-synced per-(org, agent) cache entry
-   * (deniedDomains become deny grants; a flipped allow/deny flag is
-   * re-written in place via the grant upsert).
+   * Domains reconcile against Postgres UNCONDITIONALLY — the pod-local
+   * cache is never trusted for them. Non-expiring domain rows are written
+   * only by this sync (allow, deny, nix), so the active rows ARE the
+   * previous state: rows outside the current config are revoked, expected
+   * domains whose row is missing or has a flipped allow/deny flag are
+   * (re-)granted. A cache-based skip is multi-replica-unsafe here (an
+   * X→Y→X config sequence across two replicas leaves Y's rows active on
+   * the replica whose warm cache still says X).
    *
-   * Domain revocation reconciles against Postgres, NOT the pod-local cache:
-   * non-expiring domain rows are written only by this sync (allow, deny,
-   * nix), so any active domain row outside the current config is a leftover
-   * and is revoked — even when the cache is cold (pod restart, LRU
-   * eviction, another replica wrote the row). MCP tool revocation stays
-   * cache-based: user "always" tool approvals share the store and are
-   * indistinguishable from operator `preApprovedTools`, so a durable
-   * reconcile would wrongly revoke them.
+   * MCP tool patterns stay cache-diffed: user "always" tool approvals share
+   * the store and are indistinguishable from operator `preApprovedTools`,
+   * so a durable reconcile would wrongly revoke them.
    */
   async syncNetworkConfigGrants(messageData: MessagePayload): Promise<void> {
     const agentId = messageData.agentId;
@@ -1153,85 +1150,69 @@ export class DeploymentManager {
 
     if (!this.grantStore) return;
 
-    // pattern → denied flag. Domains are keyed in NORMALIZED form so alias
-    // spellings ("*.example.com" vs ".example.com") collapse to the single
-    // grant row they share — otherwise a flag change under one alias never
-    // rewrites the row the other alias already holds. Denies are added last
-    // so a domain listed on both sides collapses to deny (matching the
-    // proxy's deny precedence).
-    const nextPatterns = new Map<string, boolean>();
+    const orgId = messageData.organizationId;
+
+    // ── Domains: PG-reconciled ──────────────────────────────────────────
+    // pattern → denied flag, keyed in NORMALIZED form so alias spellings
+    // ("*.example.com" vs ".example.com") collapse to the single grant row
+    // they share. Denies are added last so a domain listed on both sides
+    // collapses to deny (matching the proxy's deny precedence).
+    const expectedDomains = new Map<string, boolean>();
     for (const domain of messageData.networkConfig?.allowedDomains ?? []) {
-      nextPatterns.set(normalizeDomainPattern(domain), false);
-    }
-    for (const pattern of messageData.preApprovedTools ?? []) {
-      nextPatterns.set(pattern, false);
+      expectedDomains.set(normalizeDomainPattern(domain), false);
     }
     if (
       messageData.nixConfig?.packages?.length ||
       messageData.nixConfig?.flakeUrl
     ) {
       for (const domain of NIX_CACHE_DOMAINS) {
-        nextPatterns.set(domain, false);
+        expectedDomains.set(domain, false);
       }
     }
     for (const domain of messageData.networkConfig?.deniedDomains ?? []) {
-      nextPatterns.set(normalizeDomainPattern(domain), true);
+      expectedDomains.set(normalizeDomainPattern(domain), true);
     }
 
-    const orgId = messageData.organizationId;
-    const cacheKey = `${orgId ?? ""}|${agentId}`;
-    const previous = this.grantSyncCache.get(cacheKey);
-
-    // Unchanged set → skip the round-trip entirely. A warm cache entry
-    // implies Postgres was reconciled when it was written.
-    if (
-      previous &&
-      nextPatterns.size === previous.size &&
-      [...nextPatterns].every(([p, denied]) => previous.get(p) === denied)
-    ) {
-      return;
-    }
-
-    // Reconcile domain rows against Postgres (see docstring). Domain keys in
-    // `nextPatterns` are already normalized — the form grant() stores.
-    const expectedDomains = new Set<string>();
-    for (const pattern of nextPatterns.keys()) {
-      if (inferGrantKind(pattern) === "domain") {
-        expectedDomains.add(pattern);
-      }
-    }
-    const activeGrants = await this.grantStore.listGrants(agentId, orgId);
-    for (const row of activeGrants) {
+    const activeDomains = new Map<string, boolean>();
+    for (const row of await this.grantStore.listGrants(agentId, orgId)) {
       if (row.kind !== "domain" || row.expiresAt !== null) continue;
-      if (expectedDomains.has(row.pattern)) continue;
+      activeDomains.set(row.pattern, row.denied === true);
+    }
+
+    for (const [pattern, denied] of activeDomains) {
+      if (expectedDomains.has(pattern)) continue;
       // Deploy-time infra ALLOW grants (npm registries for CLI backends) are
       // not derivable from the payload — exempt them. A denied row is never
       // exempt: a config-removed deny must be reconciled away or it becomes
       // unremovable (the deploy-time grant skips denied domains).
-      if (!row.denied && NPM_REGISTRY_DOMAINS.includes(row.pattern)) continue;
-      await this.grantStore.revoke(agentId, row.pattern, orgId);
+      if (!denied && NPM_REGISTRY_DOMAINS.includes(pattern)) continue;
+      await this.grantStore.revoke(agentId, pattern, orgId);
     }
-
-    // Cache-based revocation for MCP tool patterns dropped from config.
-    for (const pattern of previous?.keys() ?? []) {
-      if (inferGrantKind(pattern) !== "mcp_tool") continue;
-      if (!nextPatterns.has(pattern)) {
-        await this.grantStore.revoke(agentId, pattern, orgId);
+    for (const [pattern, denied] of expectedDomains) {
+      if (activeDomains.get(pattern) !== denied) {
+        await this.grantStore.grant(agentId, pattern, null, denied, orgId);
       }
     }
 
-    // Grant new patterns and re-write patterns whose allow/deny flag
-    // flipped (the grant upsert updates `denied` in place). Repeating
-    // unchanged grants is idempotent, but skipping them saves writes.
-    for (const [pattern, denied] of nextPatterns) {
-      if (previous?.get(pattern) !== denied) {
-        await this.grantStore.grant(agentId, pattern, null, denied, orgId);
+    // ── MCP tool patterns: cache-diffed ─────────────────────────────────
+    const nextTools = new Set(messageData.preApprovedTools ?? []);
+    const cacheKey = `${orgId ?? ""}|${agentId}`;
+    const previousTools = this.grantSyncCache.get(cacheKey);
+
+    for (const pattern of previousTools ?? []) {
+      if (!nextTools.has(pattern)) {
+        await this.grantStore.revoke(agentId, pattern, orgId);
+      }
+    }
+    for (const pattern of nextTools) {
+      if (!previousTools?.has(pattern)) {
+        await this.grantStore.grant(agentId, pattern, null, undefined, orgId);
       }
     }
 
     // LRU touch: delete + re-insert so the agent becomes the newest key.
     this.grantSyncCache.delete(cacheKey);
-    this.grantSyncCache.set(cacheKey, nextPatterns);
+    this.grantSyncCache.set(cacheKey, nextTools);
 
     // Evict the oldest entry if we've exceeded the cap.
     if (this.grantSyncCache.size > GRANT_SYNC_CACHE_MAX) {

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -11,7 +11,9 @@ import {
 	extractTraceId,
 	generateWorkerToken,
 	getErrorMessage,
+	inferGrantKind,
 	type MessagePayload,
+	normalizeDomainPattern,
 	OrchestratorError,
 	retryWithBackoff,
 } from "@lobu/core";
@@ -683,6 +685,17 @@ const SECRET_PLACEHOLDER_TTL_SECONDS = (() => {
  */
 const GRANT_SYNC_CACHE_MAX = 1000;
 
+/**
+ * Nix binary-cache hosts auto-allowed while an agent has a Nix environment
+ * configured. Config-derived like `networkConfig` domains: granted by the
+ * sync while `nixConfig` is present, reconciled away when it is removed.
+ */
+const NIX_CACHE_DOMAINS = [
+  "cache.nixos.org",
+  "channels.nixos.org",
+  "releases.nixos.org",
+];
+
 interface DeploymentIdentity {
   conversationId: string;
   channelId?: string;
@@ -1103,58 +1116,25 @@ export class DeploymentManager {
   }
 
   /**
-   * Auto-add Nix cache domains as grants, sync per-agent grants (network +
-   * pre-approved MCP tools) and egress judge policy, and persist MCP configs
-   * for the deployment.
-   */
-  private async storeDeploymentConfigs(
-    deploymentName: string,
-    messageData: MessagePayload
-  ): Promise<void> {
-    const agentId = messageData.agentId;
-    const orgId = messageData.organizationId;
-
-    // Sync network domains (allow + deny), pre-approved MCP tool patterns,
-    // and the egress judge policy — single-sourced with the per-message
-    // refresh path so create and update can never diverge.
-    await this.syncNetworkConfigGrants(messageData);
-
-    // Auto-add Nix cache domains as permanent grants when Nix packages are configured
-    if (
-      this.grantStore &&
-      agentId &&
-      (messageData.nixConfig?.packages?.length ||
-        messageData.nixConfig?.flakeUrl)
-    ) {
-      const NIX_DOMAINS = [
-        "cache.nixos.org",
-        "channels.nixos.org",
-        "releases.nixos.org",
-      ];
-      for (const domain of NIX_DOMAINS) {
-        await this.grantStore.grant(agentId, domain, null, undefined, orgId);
-      }
-      logger.info(
-        `Added Nix cache domains as grants for ${deploymentName}: ${NIX_DOMAINS.join(", ")}`
-      );
-    }
-  }
-
-  /**
-   * Sync per-agent grants (network domains + pre-approved MCP tool patterns)
-   * to the grant store for a running worker. Called on every message so
-   * config changes pick up without redeploying. Also refreshes the in-memory
-   * egress judge policy store, which is read by the shared HTTP proxy rather
-   * than by the worker process.
+   * Sync per-agent grants (network domains + Nix cache domains +
+   * pre-approved MCP tool patterns) to the grant store. Called on worker
+   * create AND on every message so config changes pick up without
+   * redeploying. Also refreshes the in-memory egress judge policy store,
+   * which is read by the shared HTTP proxy rather than by the worker
+   * process.
    *
-   * Computes the diff against the last-synced set per agent:
-   *   - patterns in the new set but not the previous are `grant()`-ed
-   *     (deniedDomains become deny grants; a flipped allow/deny flag is
-   *     re-written in place via the grant upsert)
-   *   - patterns in the previous set but not the new are `revoke()`-d
-   * This means clearing `networkConfig.allowedDomains` / `deniedDomains` or
-   * `preApprovedTools` in lobu.config.ts actually drops the rule, instead
-   * of leaving stale grants in the store.
+   * Grant writes diff against the last-synced per-(org, agent) cache entry
+   * (deniedDomains become deny grants; a flipped allow/deny flag is
+   * re-written in place via the grant upsert).
+   *
+   * Domain revocation reconciles against Postgres, NOT the pod-local cache:
+   * non-expiring domain rows are written only by this sync (allow, deny,
+   * nix), so any active domain row outside the current config is a leftover
+   * and is revoked — even when the cache is cold (pod restart, LRU
+   * eviction, another replica wrote the row). MCP tool revocation stays
+   * cache-based: user "always" tool approvals share the store and are
+   * indistinguishable from operator `preApprovedTools`, so a durable
+   * reconcile would wrongly revoke them.
    */
   async syncNetworkConfigGrants(messageData: MessagePayload): Promise<void> {
     const agentId = messageData.agentId;
@@ -1173,26 +1153,51 @@ export class DeploymentManager {
     for (const pattern of messageData.preApprovedTools ?? []) {
       nextPatterns.set(pattern, false);
     }
+    if (
+      messageData.nixConfig?.packages?.length ||
+      messageData.nixConfig?.flakeUrl
+    ) {
+      for (const domain of NIX_CACHE_DOMAINS) {
+        nextPatterns.set(domain, false);
+      }
+    }
     for (const domain of messageData.networkConfig?.deniedDomains ?? []) {
       nextPatterns.set(domain, true);
     }
 
     const orgId = messageData.organizationId;
     const cacheKey = `${orgId ?? ""}|${agentId}`;
-    const previous =
-      this.grantSyncCache.get(cacheKey) ?? new Map<string, boolean>();
+    const previous = this.grantSyncCache.get(cacheKey);
 
-    // Unchanged set → skip the round-trip entirely.
+    // Unchanged set → skip the round-trip entirely. A warm cache entry
+    // implies Postgres was reconciled when it was written.
     if (
+      previous &&
       nextPatterns.size === previous.size &&
       [...nextPatterns].every(([p, denied]) => previous.get(p) === denied)
     ) {
       return;
     }
 
-    // Revoke patterns that were previously granted but are no longer
-    // present in the current config.
-    for (const pattern of previous.keys()) {
+    // Reconcile domain rows against Postgres (see docstring). Patterns are
+    // compared in normalized form — that is how grant() stores them.
+    const expectedDomains = new Set<string>();
+    for (const pattern of nextPatterns.keys()) {
+      if (inferGrantKind(pattern) === "domain") {
+        expectedDomains.add(normalizeDomainPattern(pattern));
+      }
+    }
+    const activeGrants = await this.grantStore.listGrants(agentId, orgId);
+    for (const row of activeGrants) {
+      if (row.kind !== "domain" || row.expiresAt !== null) continue;
+      if (!expectedDomains.has(row.pattern)) {
+        await this.grantStore.revoke(agentId, row.pattern, orgId);
+      }
+    }
+
+    // Cache-based revocation for MCP tool patterns dropped from config.
+    for (const pattern of previous?.keys() ?? []) {
+      if (inferGrantKind(pattern) !== "mcp_tool") continue;
       if (!nextPatterns.has(pattern)) {
         await this.grantStore.revoke(agentId, pattern, orgId);
       }
@@ -1202,7 +1207,7 @@ export class DeploymentManager {
     // flipped (the grant upsert updates `denied` in place). Repeating
     // unchanged grants is idempotent, but skipping them saves writes.
     for (const [pattern, denied] of nextPatterns) {
-      if (previous.get(pattern) !== denied) {
+      if (previous?.get(pattern) !== denied) {
         await this.grantStore.grant(agentId, pattern, null, denied, orgId);
       }
     }
@@ -1537,7 +1542,10 @@ export class DeploymentManager {
     });
 
     const dispatcherHost = this.getDispatcherHost();
-    await this.storeDeploymentConfigs(deploymentName, validated);
+    // Sync network domains (allow + deny + nix caches), pre-approved MCP
+    // tool patterns, and the egress judge policy — single-sourced with the
+    // per-message refresh path so create and update can never diverge.
+    await this.syncNetworkConfigGrants(validated);
 
     const proxyUrl = this.buildProxyUrl(
       deploymentName,

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -808,12 +808,14 @@ export class DeploymentManager {
   protected grantStore?: GrantStore;
   protected policyStore?: PolicyStore;
   /**
-   * Per-agent cache of the last-synced grant patterns (pattern → denied
-   * flag). Used to (a) skip redundant `grantStore.grant()` writes when the
-   * set is unchanged and (b) compute the revoke-diff so patterns dropped
-   * from `networkConfig.allowedDomains` / `deniedDomains` /
+   * Per-(org, agent) cache of the last-synced grant patterns (pattern →
+   * denied flag). Used to (a) skip redundant `grantStore.grant()` writes
+   * when the set is unchanged and (b) compute the revoke-diff so patterns
+   * dropped from `networkConfig.allowedDomains` / `deniedDomains` /
    * `preApprovedTools` are removed from the grant store instead of
-   * lingering forever.
+   * lingering forever. Keyed by `org|agent` — agent ids are only unique
+   * within an organization, and grants are org-scoped rows, so an
+   * agent-id-only key would let org A's sync suppress org B's writes.
    */
   private grantSyncCache = new Map<string, Map<string, boolean>>();
   /**
@@ -1175,8 +1177,10 @@ export class DeploymentManager {
       nextPatterns.set(domain, true);
     }
 
+    const orgId = messageData.organizationId;
+    const cacheKey = `${orgId ?? ""}|${agentId}`;
     const previous =
-      this.grantSyncCache.get(agentId) ?? new Map<string, boolean>();
+      this.grantSyncCache.get(cacheKey) ?? new Map<string, boolean>();
 
     // Unchanged set → skip the round-trip entirely.
     if (
@@ -1185,8 +1189,6 @@ export class DeploymentManager {
     ) {
       return;
     }
-
-    const orgId = messageData.organizationId;
 
     // Revoke patterns that were previously granted but are no longer
     // present in the current config.
@@ -1206,8 +1208,8 @@ export class DeploymentManager {
     }
 
     // LRU touch: delete + re-insert so the agent becomes the newest key.
-    this.grantSyncCache.delete(agentId);
-    this.grantSyncCache.set(agentId, nextPatterns);
+    this.grantSyncCache.delete(cacheKey);
+    this.grantSyncCache.set(cacheKey, nextPatterns);
 
     // Evict the oldest entry if we've exceeded the cap.
     if (this.grantSyncCache.size > GRANT_SYNC_CACHE_MAX) {
@@ -1224,7 +1226,13 @@ export class DeploymentManager {
    * reload) so the next message re-syncs grants.
    */
   invalidateGrantSyncCache(agentId: string): void {
-    this.grantSyncCache.delete(agentId);
+    // Keys are `org|agent`; drop the agent's entry across every org.
+    const suffix = `|${agentId}`;
+    for (const key of this.grantSyncCache.keys()) {
+      if (key.endsWith(suffix)) {
+        this.grantSyncCache.delete(key);
+      }
+    }
   }
 
   /** Clear the entire grant sync cache. Call on whole-config reload. */

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -696,6 +696,13 @@ const NIX_CACHE_DOMAINS = [
   "releases.nixos.org",
 ];
 
+/**
+ * npm registry hosts auto-granted at deploy time when CLI-backend providers
+ * are configured (see `generateEnvironmentVariables`). Not derivable from
+ * the message payload, so the domain reconcile must never revoke them.
+ */
+const NPM_REGISTRY_DOMAINS = ["registry.npmjs.org", "registry.npmmirror.com"];
+
 interface DeploymentIdentity {
   conversationId: string;
   channelId?: string;
@@ -1144,11 +1151,15 @@ export class DeploymentManager {
 
     if (!this.grantStore) return;
 
-    // pattern → denied flag. Denies are added last so a domain listed on
-    // both sides collapses to deny (matching the proxy's deny precedence).
+    // pattern → denied flag. Domains are keyed in NORMALIZED form so alias
+    // spellings ("*.example.com" vs ".example.com") collapse to the single
+    // grant row they share — otherwise a flag change under one alias never
+    // rewrites the row the other alias already holds. Denies are added last
+    // so a domain listed on both sides collapses to deny (matching the
+    // proxy's deny precedence).
     const nextPatterns = new Map<string, boolean>();
     for (const domain of messageData.networkConfig?.allowedDomains ?? []) {
-      nextPatterns.set(domain, false);
+      nextPatterns.set(normalizeDomainPattern(domain), false);
     }
     for (const pattern of messageData.preApprovedTools ?? []) {
       nextPatterns.set(pattern, false);
@@ -1162,7 +1173,7 @@ export class DeploymentManager {
       }
     }
     for (const domain of messageData.networkConfig?.deniedDomains ?? []) {
-      nextPatterns.set(domain, true);
+      nextPatterns.set(normalizeDomainPattern(domain), true);
     }
 
     const orgId = messageData.organizationId;
@@ -1179,12 +1190,14 @@ export class DeploymentManager {
       return;
     }
 
-    // Reconcile domain rows against Postgres (see docstring). Patterns are
-    // compared in normalized form — that is how grant() stores them.
-    const expectedDomains = new Set<string>();
+    // Reconcile domain rows against Postgres (see docstring). Domain keys in
+    // `nextPatterns` are already normalized — the form grant() stores.
+    // Deploy-time infra grants (npm registries for CLI backends) are not
+    // derivable from the payload and are exempt from revocation.
+    const expectedDomains = new Set<string>(NPM_REGISTRY_DOMAINS);
     for (const pattern of nextPatterns.keys()) {
       if (inferGrantKind(pattern) === "domain") {
-        expectedDomains.add(normalizeDomainPattern(pattern));
+        expectedDomains.add(pattern);
       }
     }
     const activeGrants = await this.grantStore.listGrants(agentId, orgId);
@@ -1730,13 +1743,12 @@ export class DeploymentManager {
       p.getCliBackendConfig?.()
     );
     if (hasCliBackendProviders && this.grantStore && agentId) {
-      const NPM_DOMAINS = ["registry.npmjs.org", "registry.npmmirror.com"];
       const orgId = validated.organizationId;
-      for (const domain of NPM_DOMAINS) {
+      for (const domain of NPM_REGISTRY_DOMAINS) {
         await this.grantStore.grant(agentId, domain, null, undefined, orgId);
       }
       logger.info(
-        `Added npm registry domains as grants for ${deploymentName}: ${NPM_DOMAINS.join(", ")}`
+        `Added npm registry domains as grants for ${deploymentName}: ${NPM_REGISTRY_DOMAINS.join(", ")}`
       );
     }
 

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -646,6 +646,8 @@ export function buildDeploymentWorkerToken(args: {
   environmentId?: string;
   /** Resolved egress allowlist for a remote runtime sandbox (signed claim). */
   allowedDomains?: string[];
+  /** Resolved egress denylist for a remote runtime sandbox (signed claim). */
+  deniedDomains?: string[];
 }): string {
   return generateWorkerToken(
     args.userId,
@@ -1192,9 +1194,7 @@ export class DeploymentManager {
 
     // Reconcile domain rows against Postgres (see docstring). Domain keys in
     // `nextPatterns` are already normalized — the form grant() stores.
-    // Deploy-time infra grants (npm registries for CLI backends) are not
-    // derivable from the payload and are exempt from revocation.
-    const expectedDomains = new Set<string>(NPM_REGISTRY_DOMAINS);
+    const expectedDomains = new Set<string>();
     for (const pattern of nextPatterns.keys()) {
       if (inferGrantKind(pattern) === "domain") {
         expectedDomains.add(pattern);
@@ -1203,9 +1203,13 @@ export class DeploymentManager {
     const activeGrants = await this.grantStore.listGrants(agentId, orgId);
     for (const row of activeGrants) {
       if (row.kind !== "domain" || row.expiresAt !== null) continue;
-      if (!expectedDomains.has(row.pattern)) {
-        await this.grantStore.revoke(agentId, row.pattern, orgId);
-      }
+      if (expectedDomains.has(row.pattern)) continue;
+      // Deploy-time infra ALLOW grants (npm registries for CLI backends) are
+      // not derivable from the payload — exempt them. A denied row is never
+      // exempt: a config-removed deny must be reconciled away or it becomes
+      // unremovable (the deploy-time grant skips denied domains).
+      if (!row.denied && NPM_REGISTRY_DOMAINS.includes(row.pattern)) continue;
+      await this.grantStore.revoke(agentId, row.pattern, orgId);
     }
 
     // Cache-based revocation for MCP tool patterns dropped from config.
@@ -1552,6 +1556,7 @@ export class DeploymentManager {
       // Same allowlist synced to the grant store / JUST_BASH_ALLOWED_DOMAINS — so
       // the runtime route reads it off the signed token, not the worker's body.
       allowedDomains: messageData?.networkConfig?.allowedDomains,
+      deniedDomains: messageData?.networkConfig?.deniedDomains,
     });
 
     const dispatcherHost = this.getDispatcherHost();
@@ -1745,6 +1750,10 @@ export class DeploymentManager {
     if (hasCliBackendProviders && this.grantStore && agentId) {
       const orgId = validated.organizationId;
       for (const domain of NPM_REGISTRY_DOMAINS) {
+        // An explicit deny (config deniedDomains) wins over the infra
+        // convenience grant — the upsert would otherwise flip the row to
+        // allowed and the warm sync cache would never restore the deny.
+        if (await this.grantStore.isDenied(agentId, domain, orgId)) continue;
         await this.grantStore.grant(agentId, domain, null, undefined, orgId);
       }
       logger.info(

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -808,13 +808,14 @@ export class DeploymentManager {
   protected grantStore?: GrantStore;
   protected policyStore?: PolicyStore;
   /**
-   * Per-agent cache of the last-synced grant pattern set. Used to
-   * (a) skip redundant `grantStore.grant()` writes when the set is
-   * unchanged and (b) compute the revoke-diff so patterns dropped from
-   * `networkConfig.allowedDomains` / `preApprovedTools` are removed from
-   * the grant store instead of lingering forever.
+   * Per-agent cache of the last-synced grant patterns (pattern → denied
+   * flag). Used to (a) skip redundant `grantStore.grant()` writes when the
+   * set is unchanged and (b) compute the revoke-diff so patterns dropped
+   * from `networkConfig.allowedDomains` / `deniedDomains` /
+   * `preApprovedTools` are removed from the grant store instead of
+   * lingering forever.
    */
-  private grantSyncCache = new Map<string, Set<string>>();
+  private grantSyncCache = new Map<string, Map<string, boolean>>();
   /**
    * In-flight `ensureDeployment` promises keyed by deploymentName. Coalesces
    * concurrent calls within a single gateway process so the orchestrator-
@@ -1111,31 +1112,10 @@ export class DeploymentManager {
     const agentId = messageData.agentId;
     const orgId = messageData.organizationId;
 
-    // Sync networkConfig.allowedDomains to grant store
-    if (
-      this.grantStore &&
-      agentId &&
-      messageData.networkConfig?.allowedDomains?.length
-    ) {
-      for (const domain of messageData.networkConfig.allowedDomains) {
-        await this.grantStore.grant(agentId, domain, null, undefined, orgId);
-      }
-      logger.info(
-        `Synced network config domains as grants for ${deploymentName}: ${messageData.networkConfig.allowedDomains.join(", ")}`
-      );
-    }
-
-    // Sync operator-pre-approved MCP tool patterns to grant store
-    if (this.grantStore && agentId && messageData.preApprovedTools?.length) {
-      for (const pattern of messageData.preApprovedTools) {
-        await this.grantStore.grant(agentId, pattern, null, undefined, orgId);
-      }
-      logger.info(
-        `Synced pre-approved tool patterns as grants for ${deploymentName}: ${messageData.preApprovedTools.join(", ")}`
-      );
-    }
-
-    this.syncEgressPolicy(messageData, deploymentName);
+    // Sync network domains (allow + deny), pre-approved MCP tool patterns,
+    // and the egress judge policy — single-sourced with the per-message
+    // refresh path so create and update can never diverge.
+    await this.syncNetworkConfigGrants(messageData);
 
     // Auto-add Nix cache domains as permanent grants when Nix packages are configured
     if (
@@ -1167,10 +1147,12 @@ export class DeploymentManager {
    *
    * Computes the diff against the last-synced set per agent:
    *   - patterns in the new set but not the previous are `grant()`-ed
+   *     (deniedDomains become deny grants; a flipped allow/deny flag is
+   *     re-written in place via the grant upsert)
    *   - patterns in the previous set but not the new are `revoke()`-d
-   * This means clearing `networkConfig.allowedDomains` or
-   * `preApprovedTools` in lobu.config.ts actually drops access, instead of
-   * leaving stale grants in the store.
+   * This means clearing `networkConfig.allowedDomains` / `deniedDomains` or
+   * `preApprovedTools` in lobu.config.ts actually drops the rule, instead
+   * of leaving stale grants in the store.
    */
   async syncNetworkConfigGrants(messageData: MessagePayload): Promise<void> {
     const agentId = messageData.agentId;
@@ -1180,20 +1162,26 @@ export class DeploymentManager {
 
     if (!this.grantStore) return;
 
-    const nextPatterns = new Set<string>();
+    // pattern → denied flag. Denies are added last so a domain listed on
+    // both sides collapses to deny (matching the proxy's deny precedence).
+    const nextPatterns = new Map<string, boolean>();
     for (const domain of messageData.networkConfig?.allowedDomains ?? []) {
-      nextPatterns.add(domain);
+      nextPatterns.set(domain, false);
     }
     for (const pattern of messageData.preApprovedTools ?? []) {
-      nextPatterns.add(pattern);
+      nextPatterns.set(pattern, false);
+    }
+    for (const domain of messageData.networkConfig?.deniedDomains ?? []) {
+      nextPatterns.set(domain, true);
     }
 
-    const previous = this.grantSyncCache.get(agentId) ?? new Set<string>();
+    const previous =
+      this.grantSyncCache.get(agentId) ?? new Map<string, boolean>();
 
     // Unchanged set → skip the round-trip entirely.
     if (
       nextPatterns.size === previous.size &&
-      [...nextPatterns].every((p) => previous.has(p))
+      [...nextPatterns].every(([p, denied]) => previous.get(p) === denied)
     ) {
       return;
     }
@@ -1202,17 +1190,18 @@ export class DeploymentManager {
 
     // Revoke patterns that were previously granted but are no longer
     // present in the current config.
-    for (const pattern of previous) {
+    for (const pattern of previous.keys()) {
       if (!nextPatterns.has(pattern)) {
         await this.grantStore.revoke(agentId, pattern, orgId);
       }
     }
 
-    // Grant any new patterns. Repeating grants for existing patterns is
-    // idempotent, but skipping them saves writes.
-    for (const pattern of nextPatterns) {
-      if (!previous.has(pattern)) {
-        await this.grantStore.grant(agentId, pattern, null, undefined, orgId);
+    // Grant new patterns and re-write patterns whose allow/deny flag
+    // flipped (the grant upsert updates `denied` in place). Repeating
+    // unchanged grants is idempotent, but skipping them saves writes.
+    for (const [pattern, denied] of nextPatterns) {
+      if (previous.get(pattern) !== denied) {
+        await this.grantStore.grant(agentId, pattern, null, denied, orgId);
       }
     }
 

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -170,6 +170,8 @@ export function buildRunJobToken(args: {
   environmentId?: string;
   /** Resolved egress allowlist for a remote runtime sandbox (signed claim). */
   allowedDomains?: string[];
+  /** Resolved egress denylist for a remote runtime sandbox (signed claim). */
+  deniedDomains?: string[];
 }): string {
   return generateWorkerToken(
     args.userId,
@@ -460,9 +462,10 @@ export class MessageConsumer {
         adminTools,
         runtimeProviderId: runtimeSelection.runtimeProviderId,
         environmentId: runtimeSelection.environmentId,
-        // Egress allowlist as a signed claim (kept in lockstep with the
-        // deployment-token mint) — the runtime route reads it, never the body.
+        // Egress allow/deny lists as signed claims (kept in lockstep with the
+        // deployment-token mint) — the runtime route reads them, never the body.
         allowedDomains: data.networkConfig?.allowedDomains,
+        deniedDomains: data.networkConfig?.deniedDomains,
       });
 
       logger.info(

--- a/packages/server/src/gateway/orchestration/worker-token-claims.ts
+++ b/packages/server/src/gateway/orchestration/worker-token-claims.ts
@@ -34,6 +34,11 @@ export interface WorkerTokenClaimsArgs {
    * trusting a worker-supplied body — see WorkerTokenData.allowedDomains.
    */
   allowedDomains?: string[];
+  /**
+   * The agent's resolved egress denylist (`networkConfig.deniedDomains`),
+   * signed for the same reason — see WorkerTokenData.deniedDomains.
+   */
+  deniedDomains?: string[];
 }
 
 /**
@@ -61,6 +66,7 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
   runtimeProviderId?: string;
   environmentId?: string;
   allowedDomains?: string[];
+  deniedDomains?: string[];
 } {
   // Provider comes solely from the conversation's pinned Environment; there is
   // no deployment-wide env-var fallback. Undefined → local just-bash.
@@ -85,5 +91,7 @@ export function buildWorkerTokenClaims(args: WorkerTokenClaimsArgs): {
     // keeps the token payload minimal.
     allowedDomains:
       args.allowedDomains && args.allowedDomains.length > 0 ? args.allowedDomains : undefined,
+    deniedDomains:
+      args.deniedDomains && args.deniedDomains.length > 0 ? args.deniedDomains : undefined,
   };
 }

--- a/packages/server/src/gateway/permissions/grant-store.ts
+++ b/packages/server/src/gateway/permissions/grant-store.ts
@@ -47,14 +47,17 @@ function buildGrantCandidates(pattern: string, kind: GrantKind): string[] {
     }
   }
 
-  // Domain wildcard: "sub.example.com" is covered by "*.example.com" or
-  // ".example.com".
+  // Domain wildcard: every ancestor suffix covers the host — "a.b.example.com"
+  // is covered by ".b.example.com" AND ".example.com", matching the proxy's
+  // `matchesDomainPattern` which suffix-matches at any depth. Candidates stay
+  // most-specific-first so `hasGrant`'s precedence loop is deterministic. The
+  // literal "*." variant is kept for rows stored before write-normalization
+  // collapsed it to the ".suffix" form.
   if (kind === "domain") {
     const parts = pattern.split(".");
-    if (parts.length > 2) {
-      const tail = parts.slice(1).join(".");
-      candidates.push(normalizeDomainPattern(`.${tail}`));
-      candidates.push(normalizeDomainPattern(`*.${tail}`));
+    for (let i = 1; i < parts.length - 1; i++) {
+      const tail = parts.slice(i).join(".");
+      candidates.push(`.${tail}`, `*.${tail}`);
     }
   }
 

--- a/packages/server/src/gateway/proxy/http-proxy.ts
+++ b/packages/server/src/gateway/proxy/http-proxy.ts
@@ -137,9 +137,11 @@ interface AccessDecision {
  * Unified domain access check: global config → grant store → LLM judge.
  *
  * 1. If denied by global blocklist → block
- * 2. If allowed by global allowlist → check grantStore.isDenied() → allow/block
- * 3. If not in global list → check grantStore.hasGrant() → allow/block
- * 4. If still not decided and the agent has a judged-domain rule for the
+ * 2. If denied by a per-agent deny grant → block (authoritative: overrides
+ *    the global allowlist, allow grants, and the judge)
+ * 3. If allowed by global allowlist → allow
+ * 4. If not in global list → check grantStore.hasGrant() → allow
+ * 5. If still not decided and the agent has a judged-domain rule for the
  *    host → invoke the LLM judge → allow/block based on verdict
  */
 async function checkDomainAccess(
@@ -168,6 +170,25 @@ async function checkDomainAccess(
     return { allowed: false, source: "global" };
   }
 
+  // A per-agent deny grant is authoritative: it overrides the global
+  // allowlist, per-agent allow grants, AND the egress judge — a judge
+  // "allow" must never resurrect an explicitly denied domain.
+  // Pass `organizationId` explicitly — `GrantStore` falls back to the ALS
+  // org context when omitted, but the raw Node HTTP proxy never sets ALS
+  // and the WHERE clause would drop its `organization_id` predicate,
+  // leaking grants/denies across tenants that share an agent id.
+  if (proxyGrantStore && agentId) {
+    const denied = await proxyGrantStore.isDenied(
+      agentId,
+      hostname,
+      organizationId
+    );
+    if (denied) {
+      logger.debug(`Domain ${hostname} denied via grant (agent: ${agentId})`);
+      return { allowed: false, source: "grant" };
+    }
+  }
+
   // Check if globally allowed (unrestricted or in allowlist)
   const globallyAllowed = isHostnameAllowed(
     hostname,
@@ -176,22 +197,6 @@ async function checkDomainAccess(
   );
 
   if (globallyAllowed) {
-    // Even if globally allowed, a per-agent deny grant can override.
-    // Pass `organizationId` explicitly — `GrantStore` falls back to the ALS
-    // org context when omitted, but the raw Node HTTP proxy never sets ALS
-    // and the WHERE clause would drop its `organization_id` predicate,
-    // leaking grants/denies across tenants that share an agent id.
-    if (proxyGrantStore && agentId) {
-      const denied = await proxyGrantStore.isDenied(
-        agentId,
-        hostname,
-        organizationId
-      );
-      if (denied) {
-        logger.debug(`Domain ${hostname} denied via grant (agent: ${agentId})`);
-        return { allowed: false, source: "grant" };
-      }
-    }
     return { allowed: true, source: "global" };
   }
 

--- a/packages/server/src/gateway/routes/internal/runtime.ts
+++ b/packages/server/src/gateway/routes/internal/runtime.ts
@@ -97,9 +97,10 @@ export function createRuntimeRoutes(): Hono<WorkerContext> {
         cwd: body.cwd,
         env: commandEnv(body.env),
         timeoutMs,
-        // Authoritative egress allowlist from the SIGNED token, never the body —
-        // a compromised worker cannot widen its own sandbox network policy.
+        // Authoritative egress allow/deny lists from the SIGNED token, never
+        // the body — a compromised worker cannot widen its own sandbox policy.
         allowedDomains: worker.allowedDomains,
+        deniedDomains: worker.deniedDomains,
       });
 
       return c.json({

--- a/packages/server/src/gateway/runtime/providers/vercel.ts
+++ b/packages/server/src/gateway/runtime/providers/vercel.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { normalizeDomainPattern } from "@lobu/core";
 import { type NetworkPolicy, Sandbox } from "@vercel/sandbox";
 import { remoteCwd } from "../workspace.js";
 import type {
@@ -139,8 +140,12 @@ function normalizeAllowedDomain(domain: string): string | null {
   if (!trimmed) return null;
   if (trimmed === "*") return "*";
   if (!/^[A-Za-z0-9.*_-]+(?::\d+)?$/.test(trimmed)) return null;
-  if (trimmed.startsWith(".")) return `*${trimmed}`;
-  return trimmed;
+  // Canonicalize (lowercase + punycode, "*.x" collapses to ".x") so
+  // allow/deny overlap checks compare the one form DNS actually resolves —
+  // a mixed-case deny must still subtract its allow entry.
+  const canonical = normalizeDomainPattern(trimmed);
+  if (canonical.startsWith(".")) return `*${canonical}`;
+  return canonical;
 }
 
 /**

--- a/packages/server/src/gateway/runtime/providers/vercel.ts
+++ b/packages/server/src/gateway/runtime/providers/vercel.ts
@@ -155,7 +155,11 @@ function normalizeAllowedDomain(domain: string): string | null {
  * covers a deny — must be dropped rather than granted (fail closed).
  */
 function overlapsDeny(entry: string, denied: string[]): boolean {
-  const bare = (p: string) => (p.startsWith("*.") ? p.slice(2) : p);
+  // Compare bare hostnames: strip the wildcard prefix AND any :port
+  // qualifier, so "evil.example.com:443" cannot dodge a deny on
+  // "evil.example.com".
+  const bare = (p: string) =>
+    (p.startsWith("*.") ? p.slice(2) : p).replace(/:\d+$/, "");
   const isWild = (p: string) => p.startsWith("*.");
   const covers = (pattern: string, host: string) =>
     isWild(pattern)

--- a/packages/server/src/gateway/runtime/providers/vercel.ts
+++ b/packages/server/src/gateway/runtime/providers/vercel.ts
@@ -143,15 +143,48 @@ function normalizeAllowedDomain(domain: string): string | null {
   return trimmed;
 }
 
-function networkPolicyFromDomains(value: unknown): NetworkPolicy {
+/**
+ * True when `entry` (a normalized allow pattern, possibly `*.suffix`) overlaps
+ * `denied` (same forms) in either direction. The sandbox network policy can
+ * only express an allow list, so any allow entry a deny covers — or that
+ * covers a deny — must be dropped rather than granted (fail closed).
+ */
+function overlapsDeny(entry: string, denied: string[]): boolean {
+  const bare = (p: string) => (p.startsWith("*.") ? p.slice(2) : p);
+  const isWild = (p: string) => p.startsWith("*.");
+  const covers = (pattern: string, host: string) =>
+    isWild(pattern)
+      ? host === bare(pattern) || host.endsWith(`.${bare(pattern)}`)
+      : host === pattern;
+  return denied.some(
+    (deny) =>
+      covers(deny, bare(entry)) ||
+      covers(entry, bare(deny)) ||
+      bare(deny) === bare(entry)
+  );
+}
+
+function networkPolicyFromDomains(
+  value: unknown,
+  deniedValue?: unknown
+): NetworkPolicy {
   if (!Array.isArray(value)) return "deny-all";
-  const domains = value
-    .filter((entry): entry is string => typeof entry === "string")
-    .map(normalizeAllowedDomain)
-    .filter((entry): entry is string => !!entry);
-  if (domains.includes("*")) return "allow-all";
-  return domains.length > 0
-    ? { allow: Array.from(new Set(domains)) }
+  const normalize = (input: unknown) =>
+    (Array.isArray(input) ? input : [])
+      .filter((entry): entry is string => typeof entry === "string")
+      .map(normalizeAllowedDomain)
+      .filter((entry): entry is string => !!entry);
+  const domains = normalize(value);
+  const denied = normalize(deniedValue);
+  if (domains.includes("*") && denied.length === 0) return "allow-all";
+  // The provider policy has no deny primitive, so denies are enforced by
+  // subtraction: drop "*" (an unbounded allow can't honor exclusions) and
+  // any allow entry that overlaps a denied pattern.
+  const allowed = domains.filter(
+    (entry) => entry !== "*" && !overlapsDeny(entry, denied)
+  );
+  return allowed.length > 0
+    ? { allow: Array.from(new Set(allowed)) }
     : "deny-all";
 }
 
@@ -209,6 +242,8 @@ async function getSandbox(params: {
  * deterministic per (org, agent, conversation) so messages resume the same
  * filesystem; the filesystem is the persistent source of truth (no file sync).
  */
+export const __testOnly = { networkPolicyFromDomains };
+
 export const vercelGatewayRuntimeProvider: GatewayRuntimeProvider = {
   id: "vercel",
   credentialFields: [
@@ -245,7 +280,10 @@ export const vercelGatewayRuntimeProvider: GatewayRuntimeProvider = {
       agentId: ctx.agentId,
       conversationId: ctx.conversationId,
     });
-    const networkPolicy = networkPolicyFromDomains(ctx.allowedDomains);
+    const networkPolicy = networkPolicyFromDomains(
+      ctx.allowedDomains,
+      ctx.deniedDomains
+    );
     const sandbox = await getSandbox({
       name: sandboxName,
       networkPolicy,

--- a/packages/server/src/gateway/runtime/types.ts
+++ b/packages/server/src/gateway/runtime/types.ts
@@ -53,6 +53,8 @@ export interface RuntimeExecContext {
   timeoutMs?: number;
   /** Raw allowed-domains list from the worker; the provider derives its policy. */
   allowedDomains: unknown;
+  /** Raw denied-domains list (signed claim); providers subtract it from the allow policy. */
+  deniedDomains: unknown;
 }
 
 export interface RuntimeExecResult {


### PR DESCRIPTION
Deep audit of the per-agent egress allow/deny feature turned up a cluster of related gaps; this PR fixes the full class (each fix red→green tested unless noted):

**Deny plane**
1. `networkConfig.deniedDomains` was accepted everywhere (API, declared agents, docs) and enforced nowhere — no writer ever fed the proxy's `isDenied()` reader. Sync now diffs allow AND deny patterns; deny wins when a domain is on both sides.
2. An explicit deny grant could be overridden by the egress judge (deny was only checked in the globally-allowed branch). Deny is now hoisted and authoritative over allowlist, allow grants, and judge.
3. Wildcard grants matched only one subdomain level (`.example.com` missed `a.b.example.com`), diverging from the proxy's any-depth matcher. Grant candidates now cover every ancestor suffix.

**Reconciliation (multi-replica correctness)**
4. Domain grants are permanent PG rows but revocation diffed against a pod-local cache — restart/LRU-eviction/another-replica made config-removed domains immortal, and an X→Y→X config sequence across two replicas left Y's rows active. Domains now reconcile against Postgres **unconditionally** (active rows are the previous state; steady state = one SELECT, zero writes). The cache only diffs `preApprovedTools` (user "always" tool approvals are indistinguishable from operator config in PG, so tools stay cache-based).
5. Nix cache domains fold into the same sync (were granted by a separate create-path loop and never revoked when nix was removed). npm-registry infra grants (CLI backends) are exempt from reconcile on the allow side only, and the deploy-time grant no longer overwrites an explicit deny.
6. `grantSyncCache` keyed by `org|agent` (agent ids are only per-org unique; org A's sync could suppress org B's writes).
7. Alias spellings (`*.example.com` vs `.example.com`) collapse to one normalized cache key so a flag flip under either alias rewrites the shared row.

**Remote runtimes**
8. Remote sandboxes derived their policy from the signed `allowedDomains` claim only — `allowed: ["*"]` + `denied: ["evil.com"]` became allow-all remotely. `deniedDomains` now rides both token mints, token refresh, and durable run replay (greped the whole claim-copy class; parity/refresh/replay tests pin all of them). The Vercel policy builder subtracts denies from the allow list, fails closed on `*`+deny, case-folds, and strips `:port` before overlap checks.

**Verification:** ~300 tests green across the affected bun suites (grant store, sync, HTTP proxy + judge over real sockets, token refresh route, turn liveness, mint parity, runtime route) against embedded Postgres; vitest guardrails-runtime 17/17; `make pre-pr` clean with rebuilt packages. Not live-tested: an actual Vercel sandbox enforcing the produced policy (SDK contract read and unit-tested; no Vercel credentials in the dev environment). Configs without `deniedDomains` produce byte-identical policies, so the remote-runtime change is inert for existing users; configs WITH denies were silently unenforced before, so behavior only tightens.