### PR TITLE
fix(device-connectors): re-sync connector_definitions when a device manifest changes

### DIFF
--- a/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
+++ b/packages/server/src/__tests__/integration/device-connector-manifests.test.ts
@@ -216,6 +216,54 @@ describe('device connector manifests', () => {
     expect(versionRows[0]?.source_path).toBe(`device-manifest://macos/${CONNECTOR_KEY}@0.1.0`);
   });
 
+  it('re-syncs connector_definitions when a later poll ships a changed manifest (new action)', async () => {
+    const { orgId, workerId } = await seedDeviceOwner();
+    const sql = getTestDb();
+
+    const actionsV1 = {
+      alpha: { key: 'alpha', name: 'Alpha', inputSchema: { type: 'object' } },
+    };
+    const first = await poll(workerId, [manifest({ actions_schema: actionsV1 })]);
+    expect(first.status).toBe(200);
+
+    const readActions = async () => {
+      const rows = (await sql`
+        SELECT actions_schema FROM connector_definitions
+        WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
+        LIMIT 1
+      `) as unknown as Array<{ actions_schema: Record<string, unknown> | null }>;
+      return Object.keys(rows[0]?.actions_schema ?? {}).sort();
+    };
+    expect(await readActions()).toEqual(['alpha']);
+
+    // The extension updates: same key + version, actions_schema gains `beta`
+    // (exactly what happened when console_capture shipped). The wired fast
+    // path must not strand the org catalog on the old action set.
+    const actionsV2 = {
+      ...actionsV1,
+      beta: { key: 'beta', name: 'Beta', inputSchema: { type: 'object' } },
+    };
+    const second = await poll(workerId, [manifest({ actions_schema: actionsV2 })]);
+    expect(second.status).toBe(200);
+    expect(await readActions()).toEqual(['alpha', 'beta']);
+
+    // Stability: an UNCHANGED manifest must take the fast path again (the
+    // definition upsert stamps updated_at, so a moving timestamp here would
+    // mean every poll pays the advisory-lock slow path).
+    const readUpdatedAt = async () => {
+      const rows = (await sql`
+        SELECT updated_at FROM connector_definitions
+        WHERE organization_id = ${orgId} AND key = ${CONNECTOR_KEY}
+        LIMIT 1
+      `) as unknown as Array<{ updated_at: string }>;
+      return rows[0]?.updated_at;
+    };
+    const afterResync = await readUpdatedAt();
+    const third = await poll(workerId, [manifest({ actions_schema: actionsV2 })]);
+    expect(third.status).toBe(200);
+    expect(await readUpdatedAt()).toEqual(afterResync);
+  });
+
   it('drops a manifest whose key does not belong to the polling platform', async () => {
     const { orgId, workerId } = await seedDeviceOwner();
 

--- a/packages/server/src/worker-api/device-manifests.ts
+++ b/packages/server/src/worker-api/device-manifests.ts
@@ -251,7 +251,9 @@ function isNoneAuthSchema(value: Record<string, unknown>): boolean {
   return Array.isArray(methods) && methods.every((m) => isRecord(m) && m.type === 'none');
 }
 
-function sortJson(value: unknown): unknown {
+// Exported for callers needing the same canonical form the manifest hash uses
+// (device-reconcile compares stored vs incoming definition metadata with it).
+export function sortJson(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(sortJson);
   if (!isRecord(value)) return value;
   return Object.fromEntries(

--- a/packages/server/src/worker-api/device-reconcile.ts
+++ b/packages/server/src/worker-api/device-reconcile.ts
@@ -23,7 +23,7 @@ import { upsertConnectorDefinitionRecords } from '../utils/connector-definition-
 import { ensureUniqueConnectionSlug } from '../utils/connections';
 import { errorMessage } from '../utils/errors';
 import logger from '../utils/logger';
-import { getDeviceManifestSourcesForUser, type DeviceConnectorSource } from './device-manifests';
+import { getDeviceManifestSourcesForUser, sortJson, type DeviceConnectorSource } from './device-manifests';
 
 /** A device worker counts toward "serves capability X" only if seen this recently. */
 const DEVICE_WORKER_FRESH_INTERVAL = '7 days';
@@ -88,6 +88,16 @@ async function ensureDeviceConnectorWired(
       SELECT
         c.id AS connection_id,
         cv.connector_key AS version_key,
+        cd.name AS def_name,
+        cd.description AS def_description,
+        cd.version AS def_version,
+        cd.auth_schema AS def_auth_schema,
+        cd.feeds_schema AS def_feeds_schema,
+        cd.actions_schema AS def_actions_schema,
+        cd.options_schema AS def_options_schema,
+        cd.favicon_domain AS def_favicon_domain,
+        cd.required_capability AS def_required_capability,
+        cd.runtime AS def_runtime,
         -- jsonb_agg, not array_agg: postgres.js (fetch_types:false) returns a
         -- text[] result column as the literal string "{a,b}", which would make
         -- the fast-path feed check below silently always miss. jsonb arrays are
@@ -111,20 +121,58 @@ async function ensureDeviceConnectorWired(
       WHERE cd.organization_id = ${organizationId}
         AND cd.key = ${connectorKey}
         AND cd.status = 'active'
-      GROUP BY c.id, cv.connector_key
+      GROUP BY c.id, cv.connector_key, cd.id
       LIMIT 1
     `) as unknown as Array<{
       connection_id: number | null;
       version_key: string | null;
+      def_name: string | null;
+      def_description: string | null;
+      def_version: string | null;
+      def_auth_schema: unknown;
+      def_feeds_schema: unknown;
+      def_actions_schema: unknown;
+      def_options_schema: unknown;
+      def_favicon_domain: string | null;
+      def_required_capability: string | null;
+      def_runtime: unknown;
       active_feed_keys: string[] | null;
     }>;
     if (existingReady[0]?.connection_id) {
       await reconcilePin(sql, existingReady[0].connection_id);
     }
+    // Device-manifest connectors carry their full metadata in-hand (`source`),
+    // so a changed manifest MUST break the fast path or the org catalog is
+    // stranded on the old definition forever: the extension re-sends its
+    // manifest on every poll, but nothing else ever re-runs the definition
+    // upsert once everything is wired (this exact staleness shipped
+    // console_capture to device_workers while list_available kept serving the
+    // old 12-action chrome catalog). Compare every field the definition upsert
+    // writes, in the manifest hash's canonical form. Bundled connectors
+    // (`source` undefined) are excluded on purpose — their metadata requires a
+    // compile we can't afford per poll; deploys refresh them via other paths.
+    const definitionMatchesSource = (row: (typeof existingReady)[0]): boolean => {
+      if (!source) return true;
+      const m = source.metadata;
+      const canon = (v: unknown) => JSON.stringify(sortJson(v ?? null));
+      return (
+        row.def_name === m.name &&
+        (row.def_description ?? null) === (m.description ?? null) &&
+        row.def_version === m.version &&
+        (row.def_favicon_domain ?? null) === (m.faviconDomain ?? null) &&
+        (row.def_required_capability ?? null) === (m.requiredCapability ?? null) &&
+        canon(row.def_auth_schema) === canon(m.authSchema) &&
+        canon(row.def_feeds_schema) === canon(m.feeds) &&
+        canon(row.def_actions_schema) === canon(m.actions) &&
+        canon(row.def_options_schema) === canon(m.optionsSchema) &&
+        canon(row.def_runtime) === canon(m.runtime)
+      );
+    };
     const activeFeedKeys = new Set(existingReady[0]?.active_feed_keys ?? []);
     if (
       existingReady[0]?.connection_id &&
       existingReady[0]?.version_key &&
+      definitionMatchesSource(existingReady[0]) &&
       // userManaged-only connectors (e.g. local.directory, browser/*) report
       // declaredFeedKeys=[]. Once the connection + definition are installed,
       // every subsequent poll has nothing to verify — fast-path out.


### PR DESCRIPTION
## Bug
The device-reconcile fast path returned early whenever the definition + connection (+ declared feeds) were wired — so a device shipping an **updated** manifest (same key, new actions) never propagated it. `device_workers` stored the new manifest while `connector_definitions.actions_schema` stayed frozen, and `manage_operations` `list_available`/`execute` served the stale action set forever.

**Hit in prod today:** the Owletto extension shipped `upload_file` + `console_capture_*` (owletto#501/#502); ingest accepted the new manifest (hash verified) but the org catalog stayed on the old 12 actions. Fixed on prod by hand (`connector_definitions` id 116 synced from the stored device manifest); this PR is the durable fix.

## Fix
Device-manifest sources carry their metadata in-hand (`source.metadata`), so the fast path now compares every field the definition upsert writes — canonical `sortJson` form for jsonb, plain equality for scalars — against the stored row, and falls through to the existing upsert on any drift. Bundled connectors are deliberately excluded (their metadata requires a per-poll compile; deploys refresh them via existing paths).

## Evidence
- red→green integration test: changed manifest (new action, same version) re-syncs the catalog; was RED on main.
- stability assertion: unchanged manifest still fast-paths (via `updated_at` not moving) — also proves the canonical compare round-trips jsonb without false mismatches.
- adjacent surfaces green: device-connector-manifests (6), operations-list-available-lifecycle, dispatch-chrome-autobind, mac-computer-use-action-poll, browser-affinity-poll-claim (29 total).
- `make pre-pr` clean; `make review` verdict: bug_free 78, 0 blockers, slop 0, tests_adequate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786712906&installation_id=136316292&pr_number=1976&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1976&signature=0d530005a86ddf190140f05ca6c11d23c0c14d3a21cd2ab9c8c9cd6f1f98cef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->