### PR TITLE
fix(db): dedicated advisory-lock pool — group-lock holders no longer starve the main pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,8 @@ jobs:
       # pgvector image (max_connections=100) starts rejecting with
       # "sorry, too many clients already" deep into the run.
       # Capping the app pool to 5 keeps the worst-case socket count at
-      # 5 (app) + 5 (test) + 1 (LISTEN) = 11, well below the CI budget.
+      # 5 (app) + 5 (test) + 3 (advisory-lock pool, db/client.ts getLockDb)
+      # + 1 (LISTEN) = 14, well below the CI budget.
       DB_POOL_MAX: '5'
     steps:
       - uses: actions/checkout@v7

--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -144,6 +144,59 @@ describe('watcher CRUD', () => {
     await owner.watchers.delete({ watcher_ids: ids });
   });
 
+  it('concurrent group-locked writes on DISTINCT groups do not exhaust the pool (holder starvation)', async () => {
+    // withWatcherGroupLock holders keep a main-pool connection for the whole
+    // handler run. With N >= DB_POOL_MAX concurrent writes on DISTINCT groups
+    // (nothing serializes them), the holders camp every slot and their own
+    // handlers can't get a connection for reads/transactions — a permanent
+    // pool-wide wedge. Regression guard for the dedicated lock pool: N
+    // concurrent create_from_version calls, each from its OWN source watcher
+    // (own group), must all complete.
+    const sql = getTestDb();
+
+    const N = 6; // > the CI pool of DB_POOL_MAX=5
+    const versionIds: number[] = [];
+    const baseIds: string[] = [];
+    for (let i = 0; i < N; i++) {
+      const base = (await owner.watchers.create({
+        entity_id: entityId,
+        slug: `cfv-group-race-base-${i}`,
+        name: `CFV Group Race Base ${i}`,
+        prompt: 'Track things.',
+        agent_id: agentId,
+        sources: [{ name: 'content', query: 'SELECT id FROM events' }],
+      })) as { watcher_id: string };
+      baseIds.push(base.watcher_id);
+      const [row] = await sql<{ current_version_id: number }[]>`
+        SELECT current_version_id FROM watchers WHERE id = ${base.watcher_id}
+      `;
+      versionIds.push(Number(row?.current_version_id));
+    }
+
+    const targets: number[] = [];
+    for (let i = 0; i < N; i++) {
+      const e = (await owner.entities.create({
+        type: 'company',
+        name: `CFV Group Race Target ${i}`,
+      })) as { entity: { id: number } };
+      targets.push(e.entity.id);
+    }
+
+    // N truly-parallel group-locked writes: distinct groups, so the group lock
+    // serializes nothing and all N handlers run concurrently.
+    const results = await Promise.all(
+      versionIds.map((vid, i) =>
+        owner.watchers.createFromVersion({ version_id: vid, entity_ids: [targets[i]] })
+      )
+    );
+    const createdIds = results.flatMap((r) =>
+      (r as { created: Array<{ watcher_id: string }> }).created.map((c) => c.watcher_id)
+    );
+    expect(createdIds.length).toBe(N);
+    expect(new Set(createdIds).size).toBe(N); // all unique — the cross-group id race
+    await owner.watchers.delete({ watcher_ids: [...baseIds, ...createdIds] });
+  });
+
   it('concurrent create_from_version fan-outs allocate unique ids (no PK collision)', async () => {
     // create_from_version allocated ids on the pooled autocommit connection —
     // the same anti-pattern the create handler had. Fire many concurrent

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -266,6 +266,62 @@ export async function closeDbSingleton(): Promise<void> {
   }
   dbSingleton = null;
   rawDbSingleton = null;
+  if (lockDbSingleton) {
+    await lockDbSingleton.end();
+    lockDbSingleton = null;
+  }
+}
+
+// =========================================================
+// Dedicated advisory-lock pool
+// =========================================================
+
+let lockDbSingleton: Sql | null = null;
+
+/**
+ * Tiny connection pool reserved for SESSION-level advisory locks
+ * (`sql.reserve()` + `pg_advisory_lock` held across a critical section).
+ *
+ * Holding a session lock requires camping on a physical connection for the
+ * whole critical section. Doing that on the MAIN pool starves it: with
+ * N >= DB_POOL_MAX concurrent holders (or blocked waiters), lock connections
+ * consume every slot and the critical sections' own queries/transactions —
+ * which run on the main pool — can never be served. That is a permanent,
+ * pool-wide deadlock (session advisory waits never time out).
+ *
+ * A separate pool breaks the cycle structurally: lock holders camp HERE while
+ * their work runs on the main pool, so the dependency is one-directional and
+ * deadlock-free for any pool size >= 1. Excess lock requests queue FIFO on
+ * this pool and progress as holders finish. `lock_timeout` bounds any
+ * advisory-lock wait so a stuck holder surfaces as a clean 55P03 error
+ * instead of an unbounded stall.
+ *
+ * Keep `max` small: these connections exist only to pin lock ownership, and
+ * every slot counts against the Postgres connection budget (see the
+ * DB_POOL_MAX note in ci.yml).
+ */
+export function getLockDb(): Sql {
+  if (!lockDbSingleton) {
+    const url = process.env.DATABASE_URL;
+    if (!url) {
+      throw new Error('DATABASE_URL is required');
+    }
+    lockDbSingleton = postgres(url, {
+      max: 3,
+      // Match the main pool: keep connections; PG owns eviction.
+      idle_timeout: 0,
+      max_lifetime: 60 * 30,
+      connection: {
+        application_name: 'server-locks',
+        // Startup GUC (milliseconds): bounds every lock wait on these
+        // sessions, advisory locks included. 55P03 (lock_not_available)
+        // on expiry.
+        lock_timeout: 30000,
+      },
+    });
+    logger.info('[DB] PostgreSQL advisory-lock pool created');
+  }
+  return lockDbSingleton;
 }
 
 /**

--- a/packages/server/src/tools/admin/manage_watchers.ts
+++ b/packages/server/src/tools/admin/manage_watchers.ts
@@ -32,12 +32,11 @@ import {
   type ManageWatchersProposal,
   type ManageWatchersResult,
 } from '@lobu/core/contracts/tools/manage-watchers';
-import type { ReservedSql } from 'postgres';
 import {
   resolveActingPrincipal,
   resolveWritePolicyDecision,
 } from '../../authz/entity-policy';
-import { createDbClientFromEnv, getDb } from '../../db/client';
+import { createDbClientFromEnv, getDb, getLockDb } from '../../db/client';
 import type { Env } from '../../index';
 import { notifyActionApprovalNeeded } from '../../notifications/triggers';
 import { insertEvent } from '../../utils/insert-event';
@@ -228,12 +227,6 @@ async function resolveTargetWatcherGroupId(
   return null;
 }
 
-/** How long a group-locked action polls for the lock before failing with a
- * coded 409. Contended holders finish in seconds (a fan-out or version bump);
- * a bounded wait turns pathological contention into a clean retryable error
- * instead of an unbounded stall. */
-const WATCHER_GROUP_LOCK_WAIT_MS = 30_000;
-
 /**
  * Run `fn` (guard + mutation) while holding a SESSION-level Postgres advisory
  * lock on the action's target watcher_group_id. A session lock (vs. the
@@ -244,13 +237,15 @@ const WATCHER_GROUP_LOCK_WAIT_MS = 30_000;
  * the session identity is stable (any pool connection could otherwise serve the
  * unlock and PG would error `you don't own a lock of type ExclusiveLock`).
  *
- * The lock is acquired with a `pg_try_advisory_lock` POLL, not a blocking
- * `pg_advisory_lock`, and the reserved connection is RELEASED between attempts.
- * A blocking wait camps on a pool slot: with N ≥ DB_POOL_MAX concurrent calls
- * on one group, the waiters consume every slot and the lock winner can never
- * get a connection for its own reads/transaction — a permanent pool-wide
- * deadlock (session advisory waits never time out). Polling holds zero slots
- * while waiting, so the winner always has pool capacity to finish and release.
+ * The reserved connection comes from the DEDICATED lock pool (getLockDb), not
+ * the main pool. Lock holders camp on a connection for the whole critical
+ * section while `fn` runs its reads/transactions on the MAIN pool; if holders
+ * camped on the main pool, N >= DB_POOL_MAX concurrent group-locked writes
+ * (same group or distinct groups alike) would consume every slot and starve
+ * their own handlers — a permanent pool-wide deadlock. With a separate pool
+ * the dependency is one-directional and deadlock-free; excess lock requests
+ * queue FIFO and progress as holders finish. The lock pool's `lock_timeout`
+ * bounds the advisory-lock wait itself (55P03 → coded 409 below).
  *
  * Only the mutating write-gate actions with a resolvable target group are locked;
  * read-only actions and `create` (no pre-existing group) run `fn` directly.
@@ -264,34 +259,29 @@ async function withWatcherGroupLock<T>(
   const groupId = await resolveTargetWatcherGroupId(args, ctx);
   if (groupId == null) return fn();
 
-  const sql = getDb();
-  const deadline = Date.now() + WATCHER_GROUP_LOCK_WAIT_MS;
-  for (;;) {
-    const reserved = (await (
-      sql as unknown as { reserve: () => Promise<ReservedSql> }
-    ).reserve()) as ReservedSql;
+  const reserved = await getLockDb().reserve();
+  try {
     try {
-      const [row] = (await reserved`
-        SELECT pg_try_advisory_lock(hashtext(${WATCHER_GROUP_LOCK_NS}), ${groupId}) AS locked
-      `) as unknown as [{ locked: boolean }];
-      if (row.locked) {
-        try {
-          return await fn();
-        } finally {
-          await reserved`SELECT pg_advisory_unlock(hashtext(${WATCHER_GROUP_LOCK_NS}), ${groupId})`;
-        }
+      await reserved`SELECT pg_advisory_lock(hashtext(${WATCHER_GROUP_LOCK_NS}), ${groupId})`;
+    } catch (err) {
+      // lock_timeout expiry (55P03): another holder kept the group busy past
+      // the bound. We do NOT hold the lock here — surface a clean retryable
+      // conflict instead of an unbounded stall.
+      if ((err as { code?: string }).code === '55P03') {
+        throw new ToolUserError(
+          'Another change to this watcher group is in progress; retry shortly.',
+          409,
+        );
       }
+      throw err;
+    }
+    try {
+      return await fn();
     } finally {
-      reserved.release();
+      await reserved`SELECT pg_advisory_unlock(hashtext(${WATCHER_GROUP_LOCK_NS}), ${groupId})`;
     }
-    if (Date.now() >= deadline) {
-      throw new ToolUserError(
-        'Another change to this watcher group is in progress; retry shortly.',
-        409,
-      );
-    }
-    // Sleep WITHOUT holding a pool slot; jitter de-synchronizes contenders.
-    await new Promise((resolve) => setTimeout(resolve, 25 + Math.floor(Math.random() * 50)));
+  } finally {
+    reserved.release();
   }
 }
 


### PR DESCRIPTION
## What

Follow-up to #1969. The polling acquire there fixed **waiters** camping on main-pool slots, but **holders** still camp: a `withWatcherGroupLock` holder keeps its reserved main-pool connection for the whole critical section while the handler's own reads/transactions also come from the main pool. With N ≥ `DB_POOL_MAX` concurrent group-locked writes on **distinct** groups (nothing serializes them), the holders consume every slot and starve their own handlers — the same permanent pool-wide wedge, different trigger. Surfaced by the #1969 review suggestion to make the id-race test use distinct source groups.

## Fix

`getLockDb()` in `db/client.ts` — a tiny (`max: 3`) postgres client reserved for session-advisory-lock ownership. Holders camp **there** while their work runs on the main pool, so the dependency is one-directional and structurally deadlock-free at any pool size; excess lock requests queue FIFO and progress as holders finish. `withWatcherGroupLock` returns to a plain blocking `pg_advisory_lock` (no polling/jitter) on the lock pool, with `lock_timeout=30s` as a startup GUC (verified live: `SHOW lock_timeout` → `30s`) translating a stuck-holder wait into a coded 409 (55P03) instead of an unbounded stall. CI socket-budget comment updated (+3).

## Evidence (red→green)

New **holder starvation** test: 6 concurrent `create_from_version` calls, each from its OWN source watcher (own group), at `DB_POOL_MAX=5` — **wedges on main** (test timeout), **passes with the lock pool**.

No regressions at pool=5 (each suite run alone): watchers-crud 22/22, group-edit 10/10, source-id-and-cross-org 10/10, watcher-owner-escalation 6/6. `make pre-pr` clean.

## Same-class follow-ups (not this PR)

`reserve()` + blocking session advisory lock on the main pool also lives in `gateway/connections/chat-connection-service.ts` and `gateway/orchestration/deployment-manager.ts` — candidates for adopting `getLockDb()`, each needs its own holder-workload analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvqppirynLxpoRU4ARjQv7

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786713651&installation_id=136316292&pr_number=1979&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1979&signature=c0c81dcab191709a89f1c8d287d4a6e76efb0e8097a1b571f7ccfde4aaad3af3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->