### PR TITLE
fix(server): error loudly when operations.listAvailable gets a hidden or unknown connection_id

### DIFF
--- a/packages/server/src/__tests__/integration/operations-list-available-lifecycle.test.ts
+++ b/packages/server/src/__tests__/integration/operations-list-available-lifecycle.test.ts
@@ -732,11 +732,33 @@ describe("operations.listAvailable — capability discovery DTO", () => {
 		expect(create.connection_count).toBe(2);
 		expect(create.execution_targets).toHaveLength(2);
 
-		const hidden = await listAll(org.id, owner.id, {
-			connection_id: hiddenPrivate.id,
+		// A hidden connection must fail LOUDLY with execute's exact error — a
+		// silent `{operations: [], total: 0}` is indistinguishable from "this
+		// connection declares no operations", so the caller debugs the filter
+		// instead of its access. Same message as execute, so no extra existence
+		// information leaks through the catalog.
+		const hidden = await manageOperations(
+			{ action: "list_available", connection_id: hiddenPrivate.id } as never,
+			TEST_ENV(),
+			ctxFor(org.id, owner.id),
+		);
+		expect(hidden).toEqual({
+			error: "Connection not found or not visible.",
 		});
-		expect(hidden.operations).toEqual([]);
-		expect(hidden.total).toBe(0);
+		// The visibility check is independent of secondary filters: a hidden id
+		// errors even when connector_key/entity_id are also supplied.
+		const hiddenCompound = await manageOperations(
+			{
+				action: "list_available",
+				connection_id: hiddenPrivate.id,
+				connector_key: KEY_READY,
+			} as never,
+			TEST_ENV(),
+			ctxFor(org.id, owner.id),
+		);
+		expect(hiddenCompound).toEqual({
+			error: "Connection not found or not visible.",
+		});
 
 		const executed = await manageOperations(
 			{
@@ -755,5 +777,71 @@ describe("operations.listAvailable — capability discovery DTO", () => {
 			SELECT id FROM runs WHERE connection_id = ${hiddenPrivate.id}
 		`;
 		expect(runRows).toHaveLength(0);
+	});
+
+	it("connection_id filter returns exactly that connection's ops; a nonexistent id errors like execute", async () => {
+		const { org, user } = await setupOwner("Ops ConnId Filter Org");
+		await seedConnector(org.id, KEY_READY, "ConnId Filter Connector");
+		const target = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_READY,
+			status: "active",
+		});
+		const sibling = await createTestConnection({
+			organization_id: org.id,
+			connector_key: KEY_READY,
+			status: "paused",
+			createDefaultFeed: false,
+		});
+
+		const { operations, total } = await listAll(org.id, user.id, {
+			connection_id: target.id,
+		});
+		expect(total).toBe(2);
+		expect(operations.map((op) => op.operation_key).sort()).toEqual([
+			"create_issue",
+			"list_issues",
+		]);
+		// Only the requested connection appears as an execution target — the
+		// sibling paused connection of the same connector is filtered out, and
+		// readiness reflects the requested target alone.
+		for (const op of operations) {
+			expect(op.execution_targets).toMatchObject([
+				{ connection_id: target.id, status: "ready", executable: true },
+			]);
+			expect(op.readiness).toBe("ready");
+		}
+		expect(sibling.status).toBe("paused");
+
+		const missing = await manageOperations(
+			{ action: "list_available", connection_id: 999_999_999 } as never,
+			TEST_ENV(),
+			ctxFor(org.id, user.id),
+		);
+		expect(missing).toEqual({
+			error: "Connection not found or not visible.",
+		});
+
+		// A COMPOUND filter that excludes a visible connection is a normal empty
+		// match, not an authorization failure — only a bare connection_id asserts
+		// existence/visibility.
+		const mismatch = await listAll(org.id, user.id, {
+			connection_id: target.id,
+			connector_key: KEY_DISCONNECTED,
+		});
+		expect(mismatch).toMatchObject({ operations: [], total: 0 });
+	});
+
+	it("rejects unknown arguments with the shared validator error, like sibling methods", async () => {
+		const { org, user } = await setupOwner("Ops Unknown Arg Org");
+		await expect(
+			manageOperations(
+				{ action: "list_available", connectionid: 1 } as never,
+				TEST_ENV(),
+				ctxFor(org.id, user.id),
+			),
+		).rejects.toThrow(
+			/unknown argument\(s\): connectionid — valid arguments.*connection_id/,
+		);
 	});
 });

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -652,7 +652,7 @@ export default async (_ctx, client) => {
 	},
 	"operations.listAvailable": {
 		summary:
-			"Search declared connector capabilities, including disconnected connectors. Returns readiness plus every visible execution target; backend configuration is never exposed.",
+			"Search declared connector capabilities, including disconnected connectors. Pass connection_id to list the operations declared by that connection's connector with that connection's per-target readiness (errors if the connection is not visible); connector_key/query/kind filter the wider catalog. Returns readiness plus every visible execution target; backend configuration is never exposed.",
 		access: "read",
 	},
 	"operations.execute": {

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -712,10 +712,27 @@ async function handleListAvailable(
 ): Promise<ManageOperationsResult> {
 	const targetRows = await loadVisibleOperationTargets(args, ctx);
 
-	// An explicit connection filter is also an authorization lookup. Returning
-	// an empty list for a hidden/private connection avoids leaking its connector
-	// key through the operation catalog.
+	// An explicit connection filter is also an authorization lookup. Fail with
+	// execute's exact not-found error instead of a silent empty list: `[]` is
+	// indistinguishable from "this connection declares no operations", and the
+	// shared message keeps a hidden/private connection's connector key out of
+	// the catalog without revealing whether the id exists at all. The
+	// existence/visibility check is independent of the secondary filters: a
+	// VISIBLE connection excluded by connector_key/entity_id is a normal empty
+	// compound-filter match, while a hidden/missing id errors either way — so
+	// the same visibility-compiled query is re-run with the secondary filters
+	// stripped, only on this already-empty branch.
 	if (args.connection_id !== undefined && targetRows.length === 0) {
+		const bareRows =
+			args.connector_key === undefined && args.entity_id === undefined
+				? targetRows
+				: await loadVisibleOperationTargets(
+						{ ...args, connector_key: undefined, entity_id: undefined },
+						ctx,
+					);
+		if (bareRows.length === 0) {
+			return { error: "Connection not found or not visible." };
+		}
 		return {
 			action: "list_available",
 			operations: [],


### PR DESCRIPTION
## Problem

Live-verified on prod: `client.operations.listAvailable({ connection_id: 232 })` returned `{ operations: [], total: 0 }` while `listAvailable({})` returned a full catalog. Connection 232 (buremba org, `youtube`) is `visibility=private` with `created_by=NULL`, so the connection-visibility predicate hides it from every principal — and `handleListAvailable` deliberately returned a **silent empty list** for a hidden/nonexistent `connection_id`, which is indistinguishable from "this connection declares no operations". The caller ends up debugging the filter instead of its access.

Root cause classification: `connection_id` **is in the schema and the filter itself works** (an org-visible active connection returns exactly its connector's ops with per-target readiness — verified live and pinned by tests). Unknown args were already rejected by the shared validator like sibling methods. The bug was the intentional-but-wrong silent-empty early return at the visibility/authorization lookup, inconsistent with `execute`, which returns `"Connection not found or not visible."` for the very same connection.

## Fix

- `list_available` with a `connection_id` that is hidden or nonexistent now returns `execute`'s exact error (`Connection not found or not visible.`) instead of a silent empty list. Same message for missing vs hidden, so nothing leaks that `execute` doesn't already reveal. Via the SDK this surfaces as a thrown `ClientSdkActionError` instead of a silently-empty success.
- The existence/visibility check is independent of secondary filters: a **visible** connection excluded by a compound `connector_key`/`entity_id` mismatch stays a normal empty match; a **hidden** id errors even with compound filters (re-runs the same visibility-compiled query with secondary filters stripped, only on the already-empty branch).
- search_sdk summary for `operations.listAvailable` now documents the `connection_id` filter and its error contract.

## Evidence (red→green)

RED at previous HEAD (silent empty asserted as error):
```
× … excludes another member's private connection — expected { action: 'list_available', …(4) } to deeply equal { Object (error) }
× connection_id filter returns exactly that connection's ops; a nonexistent id errors like execute — same
```
GREEN after fix: `operations-list-available-lifecycle.test.ts (18 tests) — 18 passed`, plus adjacent suites (`operations-execute-backends`, `all-tools-e2e`, `namespace-dispatch`, `write-policy-action-effect-parity`: 69 passed).

New coverage: exact-ops filter with per-target readiness (sibling connection excluded), nonexistent id errors, hidden id errors (bare AND compound), visible compound mismatch stays empty, bogus arg (`connectionid`) rejected with the shared validator's valid-argument list.

Gates: `make pre-pr` clean; `make review BASE=origin/main` → 0 blockers (bug_free 65, simplicity 91, slop 0).

Note: the prod connection 232 remaining *hidden* is the separate `created_by NULL` visibility-predicate issue (branch `feat/fix-created-by-null-visibility`); once that lands, this filter returns its ops through the already-working path. This PR makes the hidden case loud instead of silent and touches nothing in the predicate.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786714547&installation_id=136316292&pr_number=1982&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1982&signature=0137accd444dd39fb406f148f9dfbaa1a3d5cfb2d77275854870f6b61e607405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
