### PR TITLE
fix(server): validate feed config against connector configSchema on create/update

### DIFF
--- a/packages/server/src/__tests__/integration/feed-config-schema-validation.test.ts
+++ b/packages/server/src/__tests__/integration/feed-config-schema-validation.test.ts
@@ -211,6 +211,30 @@ describe("manage_feeds config validation against connector configSchema", () => 
 		});
 	});
 
+	it("persists AJV type coercions applied during merge-update validation", async () => {
+		const created = (await owner.feeds.create({
+			connection_id: rssConnectionId,
+			feed_key: "articles",
+			display_name: "coerce-target",
+			config: { feed_urls: ["https://example.com/d.xml"] },
+		})) as { feed?: { id: number } };
+		const feedId = Number(created.feed?.id);
+
+		// coerceTypes turns "50" into 50 during validation; the STORED patch must
+		// be the coerced value, not the original string.
+		const result = (await owner.feeds.update({
+			feed_id: feedId,
+			config: { max_items_per_feed: "50" as unknown as number },
+		})) as { error?: string };
+		expect(result.error).toBeUndefined();
+
+		const sql = getTestDb();
+		const [row] = await sql<{ config: Record<string, unknown> | null }[]>`
+      SELECT config FROM feeds WHERE id = ${feedId}
+    `;
+		expect(row?.config?.max_items_per_feed).toBe(50);
+	});
+
 	it("still rejects an unknown feed_key (no regression)", async () => {
 		const error = await owner.feeds
 			.create({

--- a/packages/server/src/__tests__/integration/feed-config-schema-validation.test.ts
+++ b/packages/server/src/__tests__/integration/feed-config-schema-validation.test.ts
@@ -1,0 +1,263 @@
+/**
+ * manage_feeds create_feed / update_feed — feed `config` validation against the
+ * connector's declared feed configSchema (connector_definitions.feeds_schema).
+ *
+ * Regression (live-verified on prod 2026-07-15): `feeds.create` accepted
+ * `{ config: { url: "https://…" } }` for the rss connector even though its
+ * feeds.articles.configSchema declares `required: ['feed_urls']`. The feed row
+ * was created "successfully" and only failed at sync time with
+ * "feed_urls is required and must be a non-empty array." — zero upfront signal
+ * for an MCP client. The fix validates config against the declared JSON Schema
+ * on both create_feed and update_feed.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { ClientSdkActionError } from "../../sandbox/namespaces/action-call";
+import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
+import {
+	createTestConnection,
+	createTestConnectorDefinition,
+	createTestOrganization,
+	createTestUser,
+} from "../setup/test-fixtures";
+import { TestApiClient } from "../setup/test-mcp-client";
+
+// Mirror of packages/connectors/src/rss.ts feeds.articles.configSchema.
+const RSS_FEEDS_SCHEMA = {
+	articles: {
+		key: "articles",
+		name: "Feed Articles",
+		configSchema: {
+			type: "object",
+			required: ["feed_urls"],
+			properties: {
+				feed_urls: {
+					type: "array",
+					items: { type: "string", format: "uri" },
+					minItems: 1,
+				},
+				max_items_per_feed: { type: "integer", minimum: 1, maximum: 1000 },
+			},
+		},
+	},
+};
+
+describe("manage_feeds config validation against connector configSchema", () => {
+	let owner: TestApiClient;
+	let orgId: string;
+	let rssConnectionId: number;
+	let bareConnectionId: number;
+	let noSchemaConnectionId: number;
+
+	beforeAll(async () => {
+		await cleanupTestDatabase();
+
+		const org = await createTestOrganization({ name: "Feed Config Org" });
+		orgId = org.id;
+		const user = await createTestUser({ email: "feed-config@test.com" });
+		owner = await TestApiClient.for({
+			organizationId: org.id,
+			userId: user.id,
+			memberRole: "owner",
+		});
+
+		await createTestConnectorDefinition({
+			key: "rss",
+			name: "RSS / Atom",
+			organization_id: orgId,
+			feeds_schema: RSS_FEEDS_SCHEMA,
+		});
+		const rssConn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "rss",
+			created_by: user.id,
+			createDefaultFeed: false,
+		});
+		rssConnectionId = Number(rssConn.id);
+
+		// A connector whose feed declares NO configSchema — any config must pass.
+		await createTestConnectorDefinition({
+			key: "no-config-schema",
+			name: "No Config Schema",
+			organization_id: orgId,
+			feeds_schema: { default: { key: "default", name: "Default" } },
+		});
+		const noSchemaConn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "no-config-schema",
+			created_by: user.id,
+			createDefaultFeed: false,
+		});
+		noSchemaConnectionId = Number(noSchemaConn.id);
+
+		// A connection with NO connector definition installed at all.
+		const bareConn = await createTestConnection({
+			organization_id: orgId,
+			connector_key: "github",
+			created_by: user.id,
+			createDefaultFeed: false,
+		});
+		bareConnectionId = Number(bareConn.id);
+	});
+
+	it("rejects create_feed when config violates the declared configSchema (prod repro)", async () => {
+		const error = await owner.feeds
+			.create({
+				connection_id: rssConnectionId,
+				feed_key: "articles",
+				config: { url: "https://example.com/feed.xml" },
+			})
+			.catch((reason: unknown) => reason);
+
+		expect(error).toBeInstanceOf(ClientSdkActionError);
+		expect((error as ClientSdkActionError).message).toContain("feed_urls");
+
+		// No feed row leaked into the DB.
+		const sql = getTestDb();
+		const rows = await sql<{ id: number }[]>`
+      SELECT id FROM feeds WHERE connection_id = ${rssConnectionId} AND deleted_at IS NULL
+    `;
+		expect(rows.length).toBe(0);
+	});
+
+	it("rejects create_feed when a config field has the wrong type", async () => {
+		const error = await owner.feeds
+			.create({
+				connection_id: rssConnectionId,
+				feed_key: "articles",
+				config: { feed_urls: ["https://example.com/feed.xml"], max_items_per_feed: 5000 },
+			})
+			.catch((reason: unknown) => reason);
+
+		expect(error).toBeInstanceOf(ClientSdkActionError);
+		expect((error as ClientSdkActionError).message).toContain("max_items_per_feed");
+	});
+
+	it("accepts create_feed with a schema-valid config", async () => {
+		const result = (await owner.feeds.create({
+			connection_id: rssConnectionId,
+			feed_key: "articles",
+			config: { feed_urls: ["https://example.com/feed.xml"] },
+		})) as { error?: string; feed?: { id: number } };
+
+		expect(result.error).toBeUndefined();
+		expect(result.feed?.id).toBeDefined();
+	});
+
+	it("rejects update_feed whose merged config would violate the schema", async () => {
+		const created = (await owner.feeds.create({
+			connection_id: rssConnectionId,
+			feed_key: "articles",
+			display_name: "update-target",
+			config: { feed_urls: ["https://example.com/a.xml"] },
+		})) as { feed?: { id: number } };
+		const feedId = Number(created.feed?.id);
+		expect(feedId).toBeGreaterThan(0);
+
+		const error = await owner.feeds
+			.update({ feed_id: feedId, config: { max_items_per_feed: 5000 } })
+			.catch((reason: unknown) => reason);
+
+		expect(error).toBeInstanceOf(ClientSdkActionError);
+		expect((error as ClientSdkActionError).message).toContain("max_items_per_feed");
+
+		// Stored config unchanged.
+		const sql = getTestDb();
+		const [row] = await sql<{ config: Record<string, unknown> | null }[]>`
+      SELECT config FROM feeds WHERE id = ${feedId}
+    `;
+		expect(row?.config).toEqual({ feed_urls: ["https://example.com/a.xml"] });
+	});
+
+	it("rejects update_feed with replace_config that drops a required field", async () => {
+		const created = (await owner.feeds.create({
+			connection_id: rssConnectionId,
+			feed_key: "articles",
+			display_name: "replace-target",
+			config: { feed_urls: ["https://example.com/b.xml"] },
+		})) as { feed?: { id: number } };
+		const feedId = Number(created.feed?.id);
+		expect(feedId).toBeGreaterThan(0);
+
+		// Raw manage() returns `{ error }` instead of throwing.
+		const result = (await owner.feeds.manage({
+			action: "update_feed",
+			feed_id: feedId,
+			config: { max_items_per_feed: 10 },
+			replace_config: true,
+		})) as { error?: string };
+
+		expect(result.error).toContain("feed_urls");
+	});
+
+	it("accepts a partial update_feed whose merged config stays valid", async () => {
+		const created = (await owner.feeds.create({
+			connection_id: rssConnectionId,
+			feed_key: "articles",
+			display_name: "merge-target",
+			config: { feed_urls: ["https://example.com/c.xml"] },
+		})) as { feed?: { id: number } };
+		const feedId = Number(created.feed?.id);
+
+		const result = (await owner.feeds.update({
+			feed_id: feedId,
+			config: { max_items_per_feed: 50 },
+		})) as { error?: string; feed?: { config: Record<string, unknown> } };
+
+		expect(result.error).toBeUndefined();
+		expect(result.feed?.config).toEqual({
+			feed_urls: ["https://example.com/c.xml"],
+			max_items_per_feed: 50,
+		});
+	});
+
+	it("still rejects an unknown feed_key (no regression)", async () => {
+		const error = await owner.feeds
+			.create({
+				connection_id: rssConnectionId,
+				feed_key: "not-a-feed",
+				config: { feed_urls: ["https://example.com/feed.xml"] },
+			})
+			.catch((reason: unknown) => reason);
+
+		expect(error).toBeInstanceOf(ClientSdkActionError);
+		expect((error as ClientSdkActionError).message).toContain("Invalid feed_key");
+	});
+
+	it("allows create_feed when the feed declares no configSchema", async () => {
+		const result = (await owner.feeds.create({
+			connection_id: noSchemaConnectionId,
+			feed_key: "default",
+			config: { anything: "goes", nested: { ok: true } },
+		})) as { error?: string; feed?: { id: number } };
+
+		expect(result.error).toBeUndefined();
+		expect(result.feed?.id).toBeDefined();
+	});
+
+	it("allows create_feed when the connector has no definition installed", async () => {
+		const result = (await owner.feeds.create({
+			connection_id: bareConnectionId,
+			feed_key: "default",
+			config: { arbitrary: true },
+		})) as { error?: string; feed?: { id: number } };
+
+		expect(result.error).toBeUndefined();
+		expect(result.feed?.id).toBeDefined();
+	});
+
+	it("does not gate VIRTUAL feed creation on the sync configSchema", async () => {
+		// A virtual feed is never synced; its config (`query` scope fence) is not
+		// the sync config contract, so required sync fields must not block it.
+		const result = (await owner.feeds.manage({
+			action: "create_feed",
+			connection_id: rssConnectionId,
+			feed_key: "articles",
+			virtual: true,
+			config: { query: "recent articles" },
+		})) as { error?: string; feed?: { id: number } };
+
+		expect(result.error).toBeUndefined();
+		expect(result.feed?.id).toBeDefined();
+	});
+});

--- a/packages/server/src/__tests__/integration/feed-config-schema-validation.test.ts
+++ b/packages/server/src/__tests__/integration/feed-config-schema-validation.test.ts
@@ -235,6 +235,34 @@ describe("manage_feeds config validation against connector configSchema", () => 
 		expect(row?.config?.max_items_per_feed).toBe(50);
 	});
 
+	it("normalizes a coercible LEGACY stored key on merge-update (persisted == validated)", async () => {
+		// A pre-fix row can hold a coercible legacy value (string "75"). A merge
+		// update of a DIFFERENT key validates the whole merged object; the fix
+		// persists exactly that validated object, so the legacy key is normalized.
+		const sql = getTestDb();
+		const [legacy] = await sql<{ id: number }[]>`
+      INSERT INTO feeds (organization_id, connection_id, feed_key, display_name, status, kind, config, created_at, updated_at)
+      VALUES (${orgId}, ${rssConnectionId}, 'articles', 'legacy-config', 'active', 'collected',
+              ${sql.json({ feed_urls: ["https://example.com/legacy.xml"], max_items_per_feed: "75" })}, NOW(), NOW())
+      RETURNING id
+    `;
+		const feedId = Number(legacy?.id);
+
+		const result = (await owner.feeds.update({
+			feed_id: feedId,
+			config: { feed_urls: ["https://example.com/updated.xml"] },
+		})) as { error?: string };
+		expect(result.error).toBeUndefined();
+
+		const [row] = await sql<{ config: Record<string, unknown> | null }[]>`
+      SELECT config FROM feeds WHERE id = ${feedId}
+    `;
+		expect(row?.config).toEqual({
+			feed_urls: ["https://example.com/updated.xml"],
+			max_items_per_feed: 75,
+		});
+	});
+
 	it("still rejects an unknown feed_key (no regression)", async () => {
 		const error = await owner.feeds
 			.create({

--- a/packages/server/src/tools/admin/helpers/feed-helpers.ts
+++ b/packages/server/src/tools/admin/helpers/feed-helpers.ts
@@ -1,4 +1,6 @@
 import { getDb, pgBigintArray } from '../../../db/client';
+import { formatAjvError, getAjv } from '../../../utils/ajv-singleton';
+import { exceedsValidationLimits } from '../../../utils/metadata-limits';
 
 export interface FeedDefinition {
   key?: string;
@@ -6,7 +8,47 @@ export interface FeedDefinition {
   displayNameTemplate?: string;
   configSchema?: {
     properties?: Record<string, unknown>;
+    [keyword: string]: unknown;
   } | null;
+}
+
+/**
+ * Validate a feed `config` against the connector's declared feed configSchema
+ * (JSON Schema, `connector_definitions.feeds_schema[feed_key].configSchema`).
+ * Returns a human-readable error naming the offending field, or null when
+ * valid. A connector/feed with no declared configSchema accepts any config —
+ * the schema itself decides strictness (additionalProperties etc.).
+ *
+ * Without this check a mis-shaped config (e.g. `url` instead of rss's required
+ * `feed_urls`) is persisted "successfully" and only fails at sync time, giving
+ * an MCP caller zero upfront signal.
+ */
+export function validateFeedConfig(
+  feedsSchema: Record<string, FeedDefinition> | null,
+  feedKey: string,
+  config: Record<string, unknown>
+): string | null {
+  // Direct key lookup plus the `key` field fallback — deliberately NOT the
+  // single-entry fallback getFeedDefinition uses for display names: guessing a
+  // schema for an undeclared feed_key would reject legacy feeds cosmetically
+  // matched to the wrong definition.
+  const definition =
+    feedsSchema?.[feedKey] ??
+    Object.values(feedsSchema ?? {}).find((d) => d?.key === feedKey) ??
+    null;
+  const configSchema = definition?.configSchema;
+  if (!configSchema || Object.keys(configSchema).length === 0) return null;
+
+  // Bound untrusted input before handing it to AJV (same posture as
+  // validateEntityMetadata in schema-validation.ts).
+  if (exceedsValidationLimits(config)) {
+    return `Invalid config for feed '${feedKey}': config exceeds size/nesting limits`;
+  }
+
+  const validate = getAjv().compile(configSchema);
+  if (validate(config)) return null;
+  const detail = (validate.errors ?? []).map(formatAjvError).join('; ') || 'validation failed';
+  return `Invalid config for feed '${feedKey}': ${detail}`;
 }
 
 function getFeedDefinition(

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -548,25 +548,6 @@ async function handleUpdateFeed(
   const sql = getDb();
   const { organizationId } = ctx;
 
-  const existing = await sql`
-    SELECT f.id, f.schedule, f.timezone, f.feed_key, f.kind, f.config, c.auth_profile_id, cd.feeds_schema
-    FROM feeds f
-    JOIN connections c ON c.id = f.connection_id
-    LEFT JOIN LATERAL (
-      SELECT feeds_schema
-      FROM connector_definitions
-      WHERE key = c.connector_key
-        AND status = 'active'
-        AND organization_id = ${organizationId}
-      ORDER BY updated_at DESC
-      LIMIT 1
-    ) cd ON TRUE
-    WHERE f.id = ${args.feed_id} AND f.organization_id = ${organizationId}
-  `;
-  if (existing.length === 0) {
-    return { error: 'Feed not found' };
-  }
-
   // Reject cross-org entity_ids on update too (skip when clearing to []).
   if (args.entity_ids !== undefined && args.entity_ids.length > 0) {
     try {
@@ -594,18 +575,8 @@ async function handleUpdateFeed(
       return { error: tzError };
     }
   }
-  // Recompute next_run_at when the cadence OR its zone changes; the effective
-  // pair mixes the incoming args with the stored row for whichever side was
-  // omitted, so a timezone-only update re-anchors the pending sync.
   const hasTimezoneArg = args.timezone !== undefined;
   const touchesCadence = args.schedule !== undefined || hasTimezoneArg;
-  const currentFeed = existing[0] as { schedule: string | null; timezone: string | null };
-  const effectiveSchedule = args.schedule ?? currentFeed.schedule;
-  const effectiveTimezone = hasTimezoneArg ? (args.timezone ?? null) : currentFeed.timezone;
-  const nextRunAtVal =
-    touchesCadence && effectiveSchedule
-      ? nextRunAt(effectiveSchedule, new Date(), effectiveTimezone)
-      : null;
 
   // `repair_agent_id` is tri-state: undefined = leave alone, null = clear, string = set.
   // Use Object.hasOwn so an explicit null overwrites instead of being skipped.
@@ -615,55 +586,88 @@ async function handleUpdateFeed(
   // Declarative `lobu apply` passes `replace_config: true` so removed manifest
   // keys disappear remotely; default (merge) is preserved for the web UI.
   const replaceFeedConfig = args.replace_config === true && args.config !== undefined;
+  const hasConfigArg = args.config !== undefined;
 
-  // Validate the EFFECTIVE config (mirroring the UPDATE's merge/replace write
-  // semantics below) against the connector's declared feed configSchema, so a
-  // patch cannot push the stored config into a shape that only fails at sync
-  // time. Only collected feeds sync — virtual/streaming configs are not the
-  // sync-config contract.
-  const feedRow = existing[0] as Record<string, unknown>;
-  if (args.config !== undefined && feedRow.kind === 'collected') {
-    const effectiveConfig = replaceFeedConfig
-      ? args.config
-      : { ...parseJsonObject(feedRow.config), ...args.config };
-    const configError = validateFeedConfig(
-      feedRow.feeds_schema as Record<string, FeedDefinition> | null,
-      String(feedRow.feed_key),
-      effectiveConfig
-    );
-    if (configError) return { error: configError };
-    if (!replaceFeedConfig) {
-      // The AJV singleton runs with coerceTypes and mutated the merged COPY in
-      // place; copy the coerced values for the caller's keys back into the
-      // patch so what is persisted below is what was validated (replace mode
-      // validated args.config itself, so its coercions already landed).
-      for (const key of Object.keys(args.config)) {
-        args.config[key] = effectiveConfig[key];
-      }
+  // Row-locked read→validate→write: the stored config is read, the EFFECTIVE
+  // config (merge or replace) computed and validated against the connector's
+  // declared feed configSchema, and exactly that validated object persisted —
+  // all under one FOR UPDATE lock, so a concurrent update cannot interleave an
+  // unvalidated merge between the read and the write, and AJV coercions land
+  // in what is stored. Without the schema check a patch could push the stored
+  // config into a shape that only fails at sync time.
+  const txResult = await sql.begin(async (tx) => {
+    const existing = await tx`
+      SELECT f.id, f.schedule, f.timezone, f.feed_key, f.kind, f.config, c.auth_profile_id, cd.feeds_schema
+      FROM feeds f
+      JOIN connections c ON c.id = f.connection_id
+      LEFT JOIN LATERAL (
+        SELECT feeds_schema
+        FROM connector_definitions
+        WHERE key = c.connector_key
+          AND status = 'active'
+          AND organization_id = ${organizationId}
+        ORDER BY updated_at DESC
+        LIMIT 1
+      ) cd ON TRUE
+      WHERE f.id = ${args.feed_id} AND f.organization_id = ${organizationId}
+      FOR UPDATE OF f
+    `;
+    if (existing.length === 0) {
+      return { error: 'Feed not found' } as const;
     }
+    const feedRow = existing[0] as Record<string, unknown>;
+
+    const effectiveConfig = hasConfigArg
+      ? replaceFeedConfig
+        ? (args.config as Record<string, unknown>)
+        : { ...parseJsonObject(feedRow.config), ...args.config }
+      : null;
+    // Only collected feeds sync — virtual/streaming configs are not the
+    // sync-config contract.
+    if (effectiveConfig && feedRow.kind === 'collected') {
+      const configError = validateFeedConfig(
+        feedRow.feeds_schema as Record<string, FeedDefinition> | null,
+        String(feedRow.feed_key),
+        effectiveConfig
+      );
+      if (configError) return { error: configError } as const;
+    }
+
+    // Recompute next_run_at when the cadence OR its zone changes; the effective
+    // pair mixes the incoming args with the stored row for whichever side was
+    // omitted, so a timezone-only update re-anchors the pending sync.
+    const effectiveSchedule = args.schedule ?? (feedRow.schedule as string | null);
+    const effectiveTimezone = hasTimezoneArg
+      ? (args.timezone ?? null)
+      : (feedRow.timezone as string | null);
+    const nextRunAtVal =
+      touchesCadence && effectiveSchedule
+        ? nextRunAt(effectiveSchedule, new Date(), effectiveTimezone)
+        : null;
+
+    const updated = await tx`
+      UPDATE feeds
+      SET display_name = COALESCE(${args.display_name ?? null}::text, display_name),
+          status = COALESCE(${args.status ?? null}::text, status),
+          entity_ids = COALESCE(${entityIdsValue}::bigint[], entity_ids),
+          config = CASE WHEN ${hasConfigArg} THEN ${tx.json(effectiveConfig ?? {})}::jsonb ELSE config END,
+          schedule = COALESCE(${args.schedule ?? null}::text, schedule),
+          timezone = CASE WHEN ${hasTimezoneArg} THEN ${args.timezone ?? null} ELSE timezone END,
+          next_run_at = CASE WHEN ${touchesCadence} THEN ${nextRunAtVal}::timestamptz ELSE next_run_at END,
+          repair_agent_id = CASE WHEN ${hasRepairAgentArg} THEN ${repairAgentValue}::text ELSE repair_agent_id END,
+          updated_at = NOW()
+      WHERE id = ${args.feed_id} AND organization_id = ${organizationId}
+      RETURNING *
+    `;
+    return {
+      updated,
+      authProfileId: Number(feedRow.auth_profile_id) || null,
+    };
+  });
+  if ('error' in txResult && txResult.error !== undefined) {
+    return { error: txResult.error };
   }
-
-  const updated = await sql`
-    UPDATE feeds
-    SET display_name = COALESCE(${args.display_name ?? null}::text, display_name),
-        status = COALESCE(${args.status ?? null}::text, status),
-        entity_ids = COALESCE(${entityIdsValue}::bigint[], entity_ids),
-        config = ${
-          replaceFeedConfig
-            ? sql`${sql.json(args.config ?? {})}::jsonb`
-            : sql`CASE WHEN ${args.config ? sql.json(args.config) : null}::jsonb IS NOT NULL THEN COALESCE(config, '{}'::jsonb) || ${args.config ? sql.json(args.config) : null}::jsonb ELSE config END`
-        },
-        schedule = COALESCE(${args.schedule ?? null}::text, schedule),
-        timezone = CASE WHEN ${hasTimezoneArg} THEN ${args.timezone ?? null} ELSE timezone END,
-        next_run_at = CASE WHEN ${touchesCadence} THEN ${nextRunAtVal}::timestamptz ELSE next_run_at END,
-        repair_agent_id = CASE WHEN ${hasRepairAgentArg} THEN ${repairAgentValue}::text ELSE repair_agent_id END,
-        updated_at = NOW()
-    WHERE id = ${args.feed_id} AND organization_id = ${organizationId}
-    RETURNING *
-  `;
-
-  const authProfileId =
-    Number((existing[0] as { auth_profile_id: unknown }).auth_profile_id) || null;
+  const { updated, authProfileId } = txResult;
   if (authProfileId) {
     const authProfile = await getAuthProfileById(organizationId, authProfileId);
     if (authProfile?.profile_kind === 'oauth_account') {

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -632,6 +632,15 @@ async function handleUpdateFeed(
       effectiveConfig
     );
     if (configError) return { error: configError };
+    if (!replaceFeedConfig) {
+      // The AJV singleton runs with coerceTypes and mutated the merged COPY in
+      // place; copy the coerced values for the caller's keys back into the
+      // patch so what is persisted below is what was validated (replace mode
+      // validated args.config itself, so its coercions already landed).
+      for (const key of Object.keys(args.config)) {
+        args.config[key] = effectiveConfig[key];
+      }
+    }
   }
 
   const updated = await sql`

--- a/packages/server/src/tools/admin/manage_feeds.ts
+++ b/packages/server/src/tools/admin/manage_feeds.ts
@@ -54,7 +54,11 @@ import type { ToolContext } from '../registry';
 import { action, defineActionTool } from './action-tool';
 import { getDefaultSchedule } from './helpers/connection-helpers';
 import { assertEntityIdsInOrg } from './helpers/db-helpers';
-import { resolveFeedDisplayName } from './helpers/feed-helpers';
+import {
+  resolveFeedDisplayName,
+  validateFeedConfig,
+  type FeedDefinition,
+} from './helpers/feed-helpers';
 
 
 // ============================================
@@ -447,6 +451,16 @@ async function handleCreateFeed(
   // schedule. config.query is an optional scope fence; agents can compose further
   // filters at read time (query_sql feed_query) or pass recall terms.
   const isVirtual = args.virtual === true;
+
+  // Validate config against the connector's declared feed configSchema up
+  // front so a mis-shaped config fails HERE, not at sync time. Virtual feeds
+  // are exempt: never synced, their config (query scope fence) is not the
+  // sync-config contract.
+  if (!isVirtual) {
+    const configError = validateFeedConfig(feedsSchema, args.feed_key, args.config ?? {});
+    if (configError) return { error: configError };
+  }
+
   // Only validate the sync schedule for non-virtual feeds — a virtual feed
   // persists schedule = NULL, so a (possibly defaulted) schedule string must not
   // gate its creation.
@@ -535,9 +549,18 @@ async function handleUpdateFeed(
   const { organizationId } = ctx;
 
   const existing = await sql`
-    SELECT f.id, f.schedule, f.timezone, c.auth_profile_id
+    SELECT f.id, f.schedule, f.timezone, f.feed_key, f.kind, f.config, c.auth_profile_id, cd.feeds_schema
     FROM feeds f
     JOIN connections c ON c.id = f.connection_id
+    LEFT JOIN LATERAL (
+      SELECT feeds_schema
+      FROM connector_definitions
+      WHERE key = c.connector_key
+        AND status = 'active'
+        AND organization_id = ${organizationId}
+      ORDER BY updated_at DESC
+      LIMIT 1
+    ) cd ON TRUE
     WHERE f.id = ${args.feed_id} AND f.organization_id = ${organizationId}
   `;
   if (existing.length === 0) {
@@ -592,6 +615,24 @@ async function handleUpdateFeed(
   // Declarative `lobu apply` passes `replace_config: true` so removed manifest
   // keys disappear remotely; default (merge) is preserved for the web UI.
   const replaceFeedConfig = args.replace_config === true && args.config !== undefined;
+
+  // Validate the EFFECTIVE config (mirroring the UPDATE's merge/replace write
+  // semantics below) against the connector's declared feed configSchema, so a
+  // patch cannot push the stored config into a shape that only fails at sync
+  // time. Only collected feeds sync — virtual/streaming configs are not the
+  // sync-config contract.
+  const feedRow = existing[0] as Record<string, unknown>;
+  if (args.config !== undefined && feedRow.kind === 'collected') {
+    const effectiveConfig = replaceFeedConfig
+      ? args.config
+      : { ...parseJsonObject(feedRow.config), ...args.config };
+    const configError = validateFeedConfig(
+      feedRow.feeds_schema as Record<string, FeedDefinition> | null,
+      String(feedRow.feed_key),
+      effectiveConfig
+    );
+    if (configError) return { error: configError };
+  }
 
   const updated = await sql`
     UPDATE feeds


### PR DESCRIPTION
## Problem (live-verified on prod 2026-07-15)

\`feeds.create\` (SDK / manage_feeds path) accepted \`{ connection_id, feed_key: "articles", config: { url: "https://..." } }\` for the \`rss\` connector even though the connector's declared feed configSchema requires \`feed_urls: string[]\`. The feed row was created "successfully" and only failed at sync time with \`feed_urls is required and must be a non-empty array.\` — an MCP client gets zero upfront signal that its config is wrong.

## Fix

- \`validateFeedConfig()\` in \`helpers/feed-helpers.ts\`: validates a feed \`config\` against \`connector_definitions.feeds_schema[feed_key].configSchema\` (JSON Schema) using the server's existing AJV singleton (\`getAjv\`/\`formatAjvError\`, same posture as entity-metadata validation incl. the size/nesting bound). Returns a clear error naming the offending field. No new dependency, no new validation layer.
- \`create_feed\`: validates \`args.config\` up front (after the existing feed_key check). Virtual feeds are exempt — never synced; their \`config.query\` scope fence is not the sync-config contract.
- \`update_feed\`: computes the EFFECTIVE config (merge or replace, mirroring the write semantics) inside a \`FOR UPDATE\` transaction, validates it, and persists exactly the validated object — so AJV coercions land in what is stored and a concurrent update cannot interleave an unvalidated merge between read and write. Only \`kind='collected'\` feeds are validated (virtual/streaming exempt).

## Edge cases covered (tests)

- config violating required field / field constraints → rejected, no row leaked
- valid config → created; partial merge-update staying valid → accepted
- \`replace_config: true\` dropping a required field → rejected
- AJV type coercions persisted (merge patch AND coercible legacy stored keys normalized)
- feed with no declared configSchema → any config allowed
- connector with no definition installed → create still allowed
- unknown feed_key → still rejected (no regression)
- virtual feed creation not gated on the sync configSchema

## Follow-up (out of scope, same class)

The same unvalidated-config gap exists on **connection** config: \`manage_connections\` connect merges \`args.config\` over \`default_connection_config\` (\`handlers/connect.ts:386-388\`) and never validates it against the connector's \`options_schema\` — only feed-scoped keys are routed away and \`x-lobu-*\` markers read. Today only the CLI's \`lobu apply\` validates connector config client-side (\`@lobu/core/ajv\` docstring). Should be fixed in a separate PR with the same \`getAjv\` reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786714911&installation_id=136316292&pr_number=1983&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1983&signature=570d882ef09b2df90bd92a46c1390d1b72f48a0b6d40bb3812b34fd9c7aa32a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->