### PR TITLE
fix(server): correct MCP discovery docs + save_memory exact_read shape

### DIFF
--- a/packages/connector-sdk/src/__tests__/reaction-client-types.test.ts
+++ b/packages/connector-sdk/src/__tests__/reaction-client-types.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import type { ReactionClient } from "../reaction-client-types";
+
+describe("ReactionClient knowledge.read input", () => {
+  it("accepts the content_ids (array) shape save_memory's exact_read hint advertises", () => {
+    // Compile-time contract: read_knowledge takes `content_ids: number[]` —
+    // excess-property checking here would fail if the published type regressed
+    // to the singular `content_id` the live bug advertised.
+    const call = (client: ReactionClient) =>
+      client.knowledge.read({ content_ids: [42] });
+    expect(typeof call).toBe("function");
+  });
+});

--- a/packages/connector-sdk/src/reaction-client-types.ts
+++ b/packages/connector-sdk/src/reaction-client-types.ts
@@ -43,7 +43,8 @@ export interface KnowledgeSaveInput {
 }
 
 export interface KnowledgeReadInput {
-  content_id?: number;
+  /** Fetch specific content events by id (read_knowledge takes an array). */
+  content_ids?: number[];
   watcher_id?: number;
   since?: string;
   until?: string;

--- a/packages/server/src/__tests__/integration/events/save-content-occurred-at.test.ts
+++ b/packages/server/src/__tests__/integration/events/save-content-occurred-at.test.ts
@@ -70,13 +70,15 @@ describe('saveContent > occurred_at default', () => {
     )) as {
 			id: number;
 			indexing_status: string;
-			exact_read: { method: string; content_id: number };
+			exact_read: { method: string; content_ids: number[] };
 		};
 
 		expect(result.indexing_status).toBe('pending');
+		// The hint must match knowledge.read's actual arg shape: `content_ids`
+		// (array) — a singular `content_id` is rejected as an unknown argument.
 		expect(result.exact_read).toEqual({
 			method: 'client.knowledge.read',
-			content_id: result.id,
+			content_ids: [result.id],
 		});
 
     const sql = getTestDb();

--- a/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/method-metadata.test.ts
@@ -187,18 +187,75 @@ describe("method-metadata", () => {
 		expect(connectExample).toContain("feeds.create");
 		expect(connectExample).toContain("connection_id");
 		expect(connectExample).toContain("feed_key");
-		// The website 'pages' config must use the REAL connector keys — assert the
-		// executable expression itself passes urls: [...] (or sitemap_url), not
-		// just that the word appears in a comment. A made-up key (config:{} /
-		// {url}) creates a feed that collects zero events.
-		expect(connectExample).toMatch(/config:\s*\{\s*(urls:\s*\[|sitemap_url:)/);
+		// The example must reference a connector that EXISTS in the catalog:
+		// 'website' does not (there is no packages/connectors/src/website.ts), so
+		// an agent copying the doc got "unknown connector". rss is auth-none with
+		// the 'articles' feed whose config requires feed_urls — assert the
+		// executable expression passes the real keys, not just prose mentions.
+		expect(connect.example ?? "").toContain("'rss'");
+		expect(connectExample).toContain("connector_key: 'rss'");
+		expect(connectExample).toContain("feed_key: 'articles'");
+		expect(connectExample).toMatch(/config:\s*\{\s*feed_urls:\s*\[/);
+		expect(connect.summary).not.toContain("website");
+		expect(connectExample).not.toContain("'website'");
 
 		// feeds.create must document the connection_id + feed_key it needs and
 		// point at how to discover the config shape — not leave the agent guessing.
 		const feed = METHOD_METADATA["feeds.create"];
 		expect(feed.summary).toContain("connection_id");
 		expect(feed.summary).toContain("feed_key");
+		expect(feed.summary).not.toContain("website");
 		expect(feed.signature ?? "").toContain("connection_id");
 		expect(feed.example ?? "").toContain("feed_key");
+		expect(feed.example ?? "").toContain("'articles'");
+	});
+
+	it("documents the schedules.create payload contract (discriminated union)", () => {
+		// The live failure: the summary alone ("Create a one-shot or recurring
+		// schedule") gives an MCP client no way to discover the required
+		// description/run_at fields or the payload discriminant, so every first
+		// call 400s. The signature must spell out both payload variants.
+		const create = METHOD_METADATA["schedules.create"];
+		const sig = create.signature ?? "";
+		expect(sig).toContain("description: string");
+		expect(sig).toContain("run_at: string");
+		expect(sig).toContain("cron?: string");
+		expect(sig).toContain("type: 'send_notification'");
+		expect(sig).toContain("title: string");
+		expect(sig).toContain("recipients?");
+		expect(sig).toContain("resource_url?");
+		expect(sig).toContain("type: 'wake_agent'");
+		expect(sig).toContain("agent_id: string");
+		expect(sig).toContain("prompt: string");
+		expect(sig).toContain("thread_id?");
+		expect(create.example ?? "").toContain("payload");
+		expect(create.usageExample ?? "").toContain("send_notification");
+	});
+
+	it("documents that watchers.create sources[] entries require name AND query", () => {
+		// A create call whose sources lack `name` fails validation, but the doc
+		// only described sources[].query — the client had no way to recover.
+		const create = METHOD_METADATA["watchers.create"];
+		expect(create.summary).toMatch(/sources\[\] entry REQUIRES both `name`/);
+		expect(create.summary).toContain("`query`");
+		expect(create.example ?? "").toContain("name: 'content'");
+	});
+
+	it("enumerates the valid catalog.listCatalog kinds", () => {
+		// {kind: 'connector'} and {kinds: ['connector']} both failed live with
+		// errors that never named the valid (plural) values.
+		const list = METHOD_METADATA["catalog.listCatalog"];
+		const sig = list.signature ?? "";
+		expect(sig).toContain("'connectors'");
+		expect(sig).toContain("'skills'");
+		expect(sig).toContain("'watchers'");
+		expect(list.summary).toContain("'connectors'");
+		expect(list.summary).toContain("'watchers'");
+	});
+
+	it("documents knowledge.read's content_ids (array) arg — the shape save_memory's exact_read hint points at", () => {
+		const read = METHOD_METADATA["knowledge.read"];
+		expect(read.summary).toContain("content_ids");
+		expect(read.example ?? "").toContain("content_ids: [");
 	});
 });

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -139,6 +139,16 @@ describe("sdkSearch", () => {
 		expect(result.notes).toContain("mcp:admin");
 	});
 
+	it("lists a camelCase namespace from a lowercased query without a false hidden note", async () => {
+		// The hidden-namespace hint must never fire when the namespace's methods
+		// ARE visible — 'entityschema' matches entitySchema.* case-insensitively.
+		const result = await sdkSearch({ query: "entityschema" }, stubEnv, writeCtx);
+		expect(result.match_count).toBeGreaterThan(0);
+		const joined = result.results.join("\n");
+		expect(joined).toContain("entitySchema.listTypes");
+		expect(result.notes ?? "").not.toContain("none are visible");
+	});
+
 	it("names an admin-only namespace in read mode instead of a silent dead end", async () => {
 		// Live failure: search_sdk query='agents' mode='read' returned unrelated
 		// matches with no hint that agents.* exists behind run_sdk — the client

--- a/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
+++ b/packages/server/src/__tests__/unit/sandbox/sdk-search.test.ts
@@ -139,6 +139,19 @@ describe("sdkSearch", () => {
 		expect(result.notes).toContain("mcp:admin");
 	});
 
+	it("names an admin-only namespace in read mode instead of a silent dead end", async () => {
+		// Live failure: search_sdk query='agents' mode='read' returned unrelated
+		// matches with no hint that agents.* exists behind run_sdk — the client
+		// concluded the namespace does not exist.
+		const result = await sdkSearch(
+			{ query: "agents", mode: "read" },
+			stubEnv,
+			readCtx,
+		);
+		expect(result.notes ?? "").toContain("agents.*");
+		expect(result.notes ?? "").toContain("run_sdk");
+	});
+
 	it("shows admin methods to admin-tier callers", async () => {
 		const result = await sdkSearch({ query: "agents.list" }, stubEnv, adminCtx);
 		expect(result.match_count).toBe(1);

--- a/packages/server/src/__tests__/unit/validate-args.test.ts
+++ b/packages/server/src/__tests__/unit/validate-args.test.ts
@@ -180,6 +180,36 @@ describe("validateToolArgs error humanization", () => {
     expect(msg).toMatch(/agents/);
   });
 
+  it("enumerates allowed literals for a bad ELEMENT of an array-of-literals field", () => {
+    // catalog.listCatalog({ kinds: ['connector'] }) live-failed with the bare
+    // "Expected union value": the error path is `/kinds/0`, and subschemaAtPath
+    // only walked `properties` — an array index must resolve to the array's
+    // item schema so the allowed values get named.
+    const schema = Type.Object({
+      kinds: Type.Optional(
+        Type.Array(
+          Type.Union([
+            Type.Literal("connectors"),
+            Type.Literal("skills"),
+            Type.Literal("watchers"),
+          ])
+        )
+      ),
+    });
+    let caught: unknown;
+    try {
+      validateToolArgs("t", schema, { kinds: ["connector"] });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ToolUserError);
+    const msg = (caught as ToolUserError).message;
+    expect(msg).not.toMatch(/Expected union value/);
+    expect(msg).toMatch(/connectors/);
+    expect(msg).toMatch(/skills/);
+    expect(msg).toMatch(/watchers/);
+  });
+
   it("reports a missing required field AND an unknown field together (not just the first)", () => {
     // { id: 1 } for a schema wanting { feed_id } used to report only the missing
     // feed_id, never that `id` is unknown — so the agent fixes one problem at a

--- a/packages/server/src/sandbox/method-metadata.ts
+++ b/packages/server/src/sandbox/method-metadata.ts
@@ -276,8 +276,10 @@ export default async (_ctx, client) => {
 };`,
 	},
 	"knowledge.read": {
-		summary: "Read a knowledge event by id, or watcher-window context.",
+		summary:
+			"Read knowledge events by id (`content_ids`, an array — there is no singular `content_id` arg), or watcher-window context.",
 		access: "read",
+		example: "await client.knowledge.read({ content_ids: [2321593] });",
 	},
 	"knowledge.delete": {
 		summary:
@@ -389,13 +391,25 @@ export default async (ctx, client) => {
 	},
 	"schedules.create": {
 		summary:
-			"Create a one-shot or recurring schedule (send_notification or wake_agent). Requires admin.",
+			"Create a one-shot or recurring schedule (send_notification or wake_agent). Requires admin. REQUIRES description, run_at (ISO timestamp of the first/only firing), and payload — the payload's `type` discriminant selects the handler and its required fields.",
 		access: "admin",
+		signature:
+			"schedules.create(input: { description: string; run_at: string /* ISO */; cron?: string; timezone?: string /* IANA, for cron */; until_at?: string; idempotency_key?: string; payload: { type: 'send_notification'; title: string; body?: string; recipients?: 'admins' | 'all' | string[]; resource_url?: string } | { type: 'wake_agent'; agent_id: string; prompt: string; thread_id?: string; reason?: string; model?: string } }): Promise<unknown>",
 		example: `await client.schedules.create({
   description: 'Follow up in 1h',
   run_at: '2026-07-05T12:00:00Z',
   payload: { type: 'wake_agent', agent_id: 'builder', prompt: 'Check inbox' },
 });`,
+		usageExample: `// One-shot notification (recurring: add cron + optional timezone/until_at).
+export default async (_ctx, client) => {
+  return client.schedules.create({
+    description: 'Standup reminder',
+    run_at: '2026-07-16T09:00:00Z',
+    cron: '0 9 * * MON-FRI',
+    timezone: 'Europe/London',
+    payload: { type: 'send_notification', title: 'Standup in 15m', recipients: 'all' },
+  });
+};`,
 	},
 	"schedules.update": {
 		summary: "Patch a schedule (next run, cron, wake_agent prompt). Requires admin.",
@@ -455,7 +469,7 @@ export default async (ctx, client) => {
 	},
 	"watchers.create": {
 		summary:
-			"Create a watcher. REQUIRES slug, prompt, and agent_id (the executing agent — a watcher without one is a zombie row). The output contract is not authored here: set keying_config.entity_type so extraction derives from that entity type's metadata_schema, or omit it for a free-form summary watcher. Each sources[].query must be a read-only SELECT/WITH projecting an `id` column (it runs against org-scoped virtual tables, NOT a URL). entity_id is optional (omit for an org-scoped watcher).",
+			"Create a watcher. REQUIRES slug, prompt, and agent_id (the executing agent — a watcher without one is a zombie row). The output contract is not authored here: set keying_config.entity_type so extraction derives from that entity type's metadata_schema, or omit it for a free-form summary watcher. Each sources[] entry REQUIRES both `name` (the {{placeholder}} the prompt template binds it to) and `query` — a read-only SELECT/WITH projecting an `id` column (it runs against org-scoped virtual tables, NOT a URL); optional `context: true` marks the source as context-only. entity_id is optional (omit for an org-scoped watcher).",
 		access: "admin",
 		throws: ["EntityNotFound"],
 		example:
@@ -551,9 +565,11 @@ export default async (_ctx, client) => {
 		signature: "connections.list(input?: { connector_key?: string; status?: string; setup_attempt_id?: string; limit?: number; offset?: number }): Promise<unknown>",
 	},
 	"catalog.listCatalog": {
-		summary: "List global catalog entries (connectors, skills, watchers).",
+		summary:
+			"List global catalog entries. `kinds` values are plural: 'connectors', 'skills', 'watchers' (defaults to all).",
 		access: "read",
-		signature: "catalog.listCatalog(input?: { kinds?: Array<'connectors' | 'skills'> }): Promise<unknown> // not paginated",
+		signature: "catalog.listCatalog(input?: { kinds?: Array<'connectors' | 'skills' | 'watchers'> }): Promise<unknown> // not paginated",
+		example: "await client.catalog.listCatalog({ kinds: ['connectors'] });",
 	},
 	"catalog.listInstalled": {
 		summary: "List installed org or agent resources.",
@@ -572,26 +588,26 @@ export default async (_ctx, client) => {
 	},
 	"connections.connect": {
 		summary:
-			"Recommended connector setup entry point. Handles every auth family; the result's `status` tells you what to do next. status 'active' (auth-none, e.g. website) or 'pending_auth' (OAuth waiting on the user) BOTH carry a `connection_id`. status 'setup_required' is a continuation — `connection_id` is OPTIONAL there (may be absent); follow `next_action` / `resume_call` / `completion_check` and only call feeds.create once the result actually carries a connection_id. Once you have a connection_id you must create a feed on it to collect data — connect() alone syncs nothing.",
+			"Recommended connector setup entry point. Handles every auth family; the result's `status` tells you what to do next. status 'active' (auth-none, e.g. rss or hackernews) or 'pending_auth' (OAuth waiting on the user) BOTH carry a `connection_id`. status 'setup_required' is a continuation — `connection_id` is OPTIONAL there (may be absent); follow `next_action` / `resume_call` / `completion_check` and only call feeds.create once the result actually carries a connection_id. Once you have a connection_id you must create a feed on it to collect data — connect() alone syncs nothing.",
 		access: "admin",
 		example:
-			"const c = await client.connections.connect({ connector_key: 'website' }); // c.connection_id",
+			"const c = await client.connections.connect({ connector_key: 'rss' }); // c.connection_id",
 		usageExample: `// Two-hop: connect() creates the connection; feeds.create() starts the
 // collection. connect() ALONE does not sync anything — you must create a feed
 // on the returned connection_id with a connector-declared feed_key
-// (search_sdk '<connector>' lists the feed keys, e.g. website → 'pages').
+// (search_sdk '<connector>' lists the feed keys, e.g. rss → 'articles').
 export default async (_ctx, client) => {
-  const c = await client.connections.connect({ connector_key: 'website' });
+  const c = await client.connections.connect({ connector_key: 'rss' });
   // Auth-none connectors are active immediately; auth-gated ones return a
   // connect_url / pending_auth for the user to finish first.
   // The feed's config keys come from the connector's feeds_schema — inspect it
   // via client.catalog.listInstalled({ kinds: ['connectors'] }) (each entry's
-  // detail.feeds_schema[feed_key]) if you're unsure what to pass. For website's
-  // 'pages' feed that's { urls: [...] } (or { sitemap_url }).
+  // detail.feeds_schema[feed_key]) if you're unsure what to pass. For rss's
+  // 'articles' feed that's { feed_urls: [...] }.
   return client.feeds.create({
     connection_id: c.connection_id,
-    feed_key: 'pages',
-    config: { urls: ['https://example.com'] },
+    feed_key: 'articles',
+    config: { feed_urls: ['https://example.com/feed.xml'] },
   });
 };`,
 	},
@@ -708,12 +724,12 @@ export default async (_ctx, client) => {
 	},
 	"feeds.create": {
 		summary:
-			"Create a data-sync feed for a connection — this is what actually starts collecting data. Needs the `connection_id` from connections.connect and a connector-declared `feed_key` (search_sdk '<connector>' lists the keys, e.g. website → 'pages'). Pass connector-specific settings (like the target url) in `config`.",
+			"Create a data-sync feed for a connection — this is what actually starts collecting data. Needs the `connection_id` from connections.connect and a connector-declared `feed_key` (search_sdk '<connector>' lists the keys, e.g. rss → 'articles'). Pass connector-specific settings (like the feed urls) in `config`.",
 		access: "write",
 		signature:
 			"feeds.create(input: { connection_id: number; feed_key: string; config?: object; display_name?: string; schedule?: string }): Promise<unknown>",
 		example:
-			"await client.feeds.create({ connection_id: 42, feed_key: 'pages', config: { urls: ['https://example.com'] } });",
+			"await client.feeds.create({ connection_id: 42, feed_key: 'articles', config: { feed_urls: ['https://example.com/feed.xml'] } });",
 	},
 	"feeds.update": { summary: "Update a feed.", access: "write" },
 	"feeds.delete": {

--- a/packages/server/src/sandbox/namespaces/catalog.ts
+++ b/packages/server/src/sandbox/namespaces/catalog.ts
@@ -5,7 +5,7 @@ import { createActionCaller } from "./action-call";
 
 export interface CatalogNamespace {
 	listCatalog(input?: {
-		kinds?: Array<"connectors" | "skills">;
+		kinds?: Array<"connectors" | "skills" | "watchers">;
 	}): Promise<unknown>;
 	listInstalled(input?: {
 		kinds?: string[];

--- a/packages/server/src/sandbox/namespaces/knowledge.ts
+++ b/packages/server/src/sandbox/namespaces/knowledge.ts
@@ -37,8 +37,8 @@ export interface KnowledgeSaveInput {
 }
 
 export interface KnowledgeReadInput {
-	/** Fetch a single content event by id. */
-	content_id?: number;
+	/** Fetch specific content events by id. */
+	content_ids?: number[];
 	/** Fetch knowledge for a watcher window (prompt rendering). */
 	watcher_id?: number;
 	since?: string;

--- a/packages/server/src/tools/registry.ts
+++ b/packages/server/src/tools/registry.ts
@@ -174,7 +174,7 @@ const AGENT_TOOLS: ToolDefinition[] = [
   {
     name: 'save_memory',
     description:
-      "Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_id })`; semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.",
+      "Save user-shared facts, preferences, decisions, observations, and notes to workspace memory. The write is immediately readable by returned event id via `client.knowledge.read({ content_ids: [id] })`; semantic search indexing is asynchronous and reported as `indexing_status`. Storage is append-only — pass `supersedes_event_id` to replace an existing fact (the old event is hidden from future searches without losing history). Optionally attach to entities via `entity_ids`. Always search first to avoid duplicates.",
     inputSchema: SaveContentSchema,
     annotations: { ...WRITE_WITHOUT_CONFIRM, title: 'Save memory' },
     handler: saveContent,

--- a/packages/server/src/tools/save_content.ts
+++ b/packages/server/src/tools/save_content.ts
@@ -153,7 +153,7 @@ interface SaveContentResult {
   view_url?: string;
 	/** Semantic search is asynchronous; exact reads by id are available immediately. */
 	indexing_status: 'pending';
-	exact_read: { method: 'client.knowledge.read'; content_id: number };
+	exact_read: { method: 'client.knowledge.read'; content_ids: [number] };
 }
 
 // ============================================
@@ -470,9 +470,12 @@ async function saveContentImpl(
     semantic_type: semanticType,
     created_at: String(row.created_at),
 		indexing_status: 'pending',
+		// `knowledge.read` takes `content_ids` (array) — a singular `content_id`
+		// is rejected as an unknown argument, so the self-documenting hint must
+		// use the exact shape the reader accepts.
 		exact_read: {
 			method: 'client.knowledge.read',
-			content_id: Number(row.id),
+			content_ids: [Number(row.id)],
 		},
   };
   if (args.supersedes_event_id) {

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -261,10 +261,18 @@ async function sdkSearchImpl(
 	const combined = [...connectorHits, ...methodResult.results];
 	const results = combined.slice(0, limit);
 	const dropped = combined.length - results.length;
+	// When the method search found nothing, its note may carry the real answer
+	// (e.g. "agents.* exists but requires admin") — losing it would leave only
+	// the unrelated connector hits.
 	const baseNote =
 		methodResult.results.length > 0
 			? "Top matches are live connectors (with lifecycle); method docs follow."
-			: "Matched live connectors (not SDK methods). Follow the lifecycle shown; query a namespace (e.g. 'feeds') for method signatures.";
+			: [
+					"Matched live connectors (not SDK methods). Follow the lifecycle shown; query a namespace (e.g. 'feeds') for method signatures.",
+					methodResult.notes,
+				]
+					.filter(Boolean)
+					.join(" ");
 	const truncNote =
 		dropped > 0 ? ` ${dropped} more result(s) truncated; raise \`limit\` or refine the query.` : "";
 	return {
@@ -385,11 +393,27 @@ async function sdkMethodSearch(
 		};
 	}
 
+	// A namespace query whose methods are ALL hidden at this mode/tier must say
+	// so by name (e.g. "agents" in mode='read') — otherwise the caller only sees
+	// unrelated substring/connector matches and concludes the namespace does not
+	// exist.
+	let hiddenNamespaceNote: string | undefined;
 	if (lower.indexOf(".") === -1) {
 		const prefix = `${lower}.`;
 		const ns = catalog.filter(([p]) => p.startsWith(prefix));
 		const topLevel = catalog.filter(([p]) => p === lower);
 		const combined = [...topLevel, ...ns];
+		if (combined.length === 0) {
+			const hiddenNs = Object.entries(SDK_DISCOVERY_METADATA).filter(([p]) =>
+				p.toLowerCase().startsWith(prefix),
+			);
+			if (hiddenNs.length > 0) {
+				const accesses = [...new Set(hiddenNs.map(([, m]) => m.access))]
+					.sort()
+					.join(", ");
+				hiddenNamespaceNote = `${lower}.* exists (${hiddenNs.length} method(s), access: ${accesses}) but none are visible${mode === "read" ? " in mode='read'" : ""} at your tier — call via run_sdk${accesses.includes("admin") ? " (admin methods need workspace admin/owner + mcp:admin)" : ""}.`;
+			}
+		}
 		if (combined.length > 0) {
 			return {
 				query,
@@ -458,22 +482,26 @@ async function sdkMethodSearch(
 			match_count: 0,
 			results: [],
 			notes:
+				hiddenNamespaceNote ??
 				existsButHidden ??
 				`No matches at your access tier. Try a namespace (${NAMESPACES.join(", ")}), mode='read' for query_sdk, or a verb (create, list, search).`,
 		};
 	}
 
+	const tailNote =
+		matches.length > limit
+			? `${matches.length - limit} more matches; raise \`limit\` or refine the query.`
+			: mode === "read"
+				? "Showing query_sdk-safe methods only. Pass mode='full' for write/admin methods."
+				: undefined;
 	return {
 		query,
 		match_count: matches.length,
 		results: matches
 			.slice(0, limit)
 			.map(([p, m]) => renderListLine(p, m)),
-		notes:
-			matches.length > limit
-				? `${matches.length - limit} more matches; raise \`limit\` or refine the query.`
-				: mode === "read"
-					? "Showing query_sdk-safe methods only. Pass mode='full' for write/admin methods."
-					: undefined,
+		notes: hiddenNamespaceNote
+			? [hiddenNamespaceNote, tailNote].filter(Boolean).join(" ")
+			: tailNote,
 	};
 }

--- a/packages/server/src/tools/sdk_search.ts
+++ b/packages/server/src/tools/sdk_search.ts
@@ -399,9 +399,12 @@ async function sdkMethodSearch(
 	// exist.
 	let hiddenNamespaceNote: string | undefined;
 	if (lower.indexOf(".") === -1) {
+		// Case-insensitive like METADATA_BY_LOWER_PATH: the query is lowercased,
+		// but namespaces preserve SDK casing (entitySchema, authProfiles) — a
+		// case-sensitive prefix match would misreport those as hidden.
 		const prefix = `${lower}.`;
-		const ns = catalog.filter(([p]) => p.startsWith(prefix));
-		const topLevel = catalog.filter(([p]) => p === lower);
+		const ns = catalog.filter(([p]) => p.toLowerCase().startsWith(prefix));
+		const topLevel = catalog.filter(([p]) => p.toLowerCase() === lower);
 		const combined = [...topLevel, ...ns];
 		if (combined.length === 0) {
 			const hiddenNs = Object.entries(SDK_DISCOVERY_METADATA).filter(([p]) =>

--- a/packages/server/src/tools/validate-args.ts
+++ b/packages/server/src/tools/validate-args.ts
@@ -151,14 +151,21 @@ function allowedLiterals(schema: unknown): string[] | null {
   return null;
 }
 
-/** Resolve the subschema at a TypeBox error `path` (e.g. `/list_scope`). */
+/** Resolve the subschema at a TypeBox error `path` (e.g. `/list_scope`, `/kinds/0`). */
 function subschemaAtPath(schema: TSchema, path: string): unknown {
   const segments = path.split('/').filter(Boolean);
   let current: unknown = schema;
   for (const seg of segments) {
     if (!current || typeof current !== 'object') return undefined;
-    const props = (current as { properties?: Record<string, unknown> }).properties;
-    current = props ? props[seg] : undefined;
+    const node = current as { properties?: Record<string, unknown>; items?: unknown };
+    // An array index (e.g. the `0` in `/kinds/0`) resolves to the array's item
+    // schema — so a bad element in Array(Union(literals)) still gets the
+    // humanized `Expected one of: ...` instead of "Expected union value".
+    if (node.items !== undefined && /^\d+$/.test(seg)) {
+      current = node.items;
+      continue;
+    }
+    current = node.properties ? node.properties[seg] : undefined;
   }
   return current;
 }


### PR DESCRIPTION
Fixes a cluster of MCP-client discovery/documentation bugs, each hit live by an MCP client on prod (2026-07-15).

## What
1. **save_memory `exact_read` self-documented a broken call** — `knowledge.read` takes `content_ids` (array), not `content_id`. Fixed the producer (`save_content.ts`), the save_memory tool description, the sandbox + published `@lobu/connector-sdk` ReactionClient input types, and the `knowledge.read` method doc. No back-compat alias added to knowledge.read.
2. **schedules.create had no discoverable signature** — added the full signature (description, run_at, cron/timezone/until_at/idempotency_key) with both payload variants (`send_notification` | `wake_agent`) plus a usage example.
3. **watchers.create doc omitted that `sources[].name` is required** — summary now states each sources[] entry requires `name` AND `query` (and documents optional `context`).
4. **connections.connect/feeds.create examples referenced a nonexistent `website` connector** — replaced with the real auth-none `rss` connector (feed key `articles`, config `feed_urls`).
5. **catalog.listCatalog kinds undiscoverable** — doc/signature/TS type now enumerate the plural kinds (`'connectors' | 'skills' | 'watchers'`), and the validation error for a bad array element names the allowed literals (`subschemaAtPath` now descends into array `items`, so `{kinds: ['connector']}` gets `Expected one of: ...` instead of `Expected union value`).
6. **search_sdk read-mode dead end for admin namespaces** — a namespace query whose methods are all hidden (e.g. `agents` in mode='read') now returns a note naming the namespace and pointing at run_sdk; the connector-hit merge no longer drops that note. Namespace listing is now case-insensitive (matches `METADATA_BY_LOWER_PATH`), so `entityschema` lists `entitySchema.*` without a false hidden note.

## Tests
- Red→green: 7 new assertions fail on origin/main sources, pass with the fix (unit: method-metadata, sdk-search, validate-args).
- Integration `save-content-occurred-at.test.ts` updated to pin the new `exact_read` shape (2/2 pass via vitest embedded PG).
- New compile-time contract test pins `ReactionClient.knowledge.read({ content_ids: [...] })`.

## Gates
- `make pre-pr` clean (typecheck + knip + lint).
- `make review BASE=origin/main`: bug_free 88, 0 blockers (two earlier review blockers — case-insensitive namespace listing and the stale connector-sdk type — fixed in follow-up commits).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786715260&installation_id=136316292&pr_number=1984&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1984&signature=0ccb596d29904a0e409bd4b10413329312cf7afcbb8ffc4e8a6b89307303be35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->