### PR TITLE
feat(bang-bash): run `!command` as shell in the conversation's pinned sandbox (PR-D4)

### DIFF
--- a/packages/agent-worker/src/__tests__/message-batcher.test.ts
+++ b/packages/agent-worker/src/__tests__/message-batcher.test.ts
@@ -246,6 +246,75 @@ describe("MessageBatcher — error resilience", () => {
   });
 });
 
+describe("MessageBatcher — addPriorityMessage (`!`-bash)", () => {
+  test("idle: processes immediately, skipping the batch window", async () => {
+    const processed: string[][] = [];
+    const batcher = new MessageBatcher({
+      batchWindowMs: 5000, // long window — must be skipped
+      onBatchReady: async (msgs) => {
+        processed.push(msgs.map((m) => m.payload.messageId));
+      },
+    });
+
+    // Consume the initial-batch fast path with an ordinary message first, so the
+    // priority path is exercised on a NON-first message (the case the old direct
+    // bypass existed for).
+    await batcher.addMessage(makeMsg("warm", "hello", 1));
+    processed.length = 0;
+
+    batcher.claimMessageId("bang-1");
+    await batcher.addPriorityMessage(makeMsg("bang-1", "!echo hi", 2));
+
+    // Delivered synchronously within the await — no 5000ms wait.
+    expect(processed).toEqual([["bang-1"]]);
+    expect(batcher.getPendingCount()).toBe(0);
+  });
+
+  test("busy: queues behind the active turn — never a concurrent onBatchReady", async () => {
+    // The regression guard for the concurrency bug: a `!` arriving mid-turn must
+    // NOT start a second processing run (which raced currentWorker teardown in
+    // the SSE client). It must queue and run only after the active turn drains.
+    const order: string[] = [];
+    let concurrency = 0;
+    let maxConcurrency = 0;
+    let releaseFirst: (() => void) | null = null;
+
+    const batcher = new MessageBatcher({
+      batchWindowMs: 50,
+      onBatchReady: async (msgs) => {
+        concurrency += 1;
+        maxConcurrency = Math.max(maxConcurrency, concurrency);
+        for (const m of msgs) order.push(m.payload.messageId);
+        if (order.length === 1) {
+          // Hold the first turn open while the `!` arrives.
+          await new Promise<void>((r) => {
+            releaseFirst = r;
+          });
+        }
+        concurrency -= 1;
+      },
+    });
+
+    // Start an ordinary turn and let onBatchReady begin (and block).
+    const first = batcher.addMessage(makeMsg("turn-1", "do work", 1));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(batcher.isCurrentlyProcessing()).toBe(true);
+
+    // `!` arrives mid-turn: must queue, not run concurrently.
+    batcher.claimMessageId("bang-1");
+    await batcher.addPriorityMessage(makeMsg("bang-1", "!echo hi", 2));
+    expect(batcher.getPendingCount()).toBe(1); // queued, not processing
+
+    // Release the first turn; the queued `!` runs in the follow-up batch.
+    releaseFirst?.();
+    await first;
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(maxConcurrency).toBe(1); // never two onBatchReady runs at once
+    expect(order).toEqual(["turn-1", "bang-1"]); // arrival order preserved
+  });
+});
+
 describe("MessageBatcher — durable replay deduplication", () => {
   test("processes a message id only once when Postgres replay races SSE delivery", async () => {
     const batches: QueuedMessage[][] = [];

--- a/packages/agent-worker/src/__tests__/sse-client-harden.test.ts
+++ b/packages/agent-worker/src/__tests__/sse-client-harden.test.ts
@@ -632,6 +632,20 @@ describe("live steering classification", () => {
     ).toBe(false);
   });
 
+  test("keeps a `!`-bash command as a standalone turn (never steered)", () => {
+    // Steering `!cmd` into an active turn would feed the raw text to the model
+    // instead of running the shell; it must queue as its own turn.
+    expect(
+      isSteerableHumanMessage({
+        ...payload,
+        messageText: "!ls /workspace",
+        platformMetadata: {
+          bangBash: { command: "ls /workspace", excludeFromContext: false },
+        },
+      })
+    ).toBe(false);
+  });
+
   test("keeps automation and attachments as follow-up turns", () => {
     for (const source of [
       "watcher-run",

--- a/packages/agent-worker/src/gateway/message-batcher.ts
+++ b/packages/agent-worker/src/gateway/message-batcher.ts
@@ -53,6 +53,39 @@ export class MessageBatcher {
     return true;
   }
 
+  /**
+   * Queue a control message (e.g. `!`-bash) whose ID was already reserved, and
+   * flush it as its own batch WITHOUT waiting out the batch window — but only
+   * when no turn is in flight. This preserves the batcher's serialization
+   * guarantee (never two concurrent `onBatchReady` runs): when a turn is already
+   * processing, the message is merely queued and picked up by the next batch,
+   * exactly like {@link addClaimedMessage}. It differs only in that, when idle,
+   * it processes immediately instead of opening a 2000ms window. The caller is
+   * responsible for keeping such a message batch-isolated (never merged into a
+   * combined "Message N:" prompt) inside `onBatchReady`.
+   */
+  async addPriorityMessage(message: QueuedMessage): Promise<void> {
+    this.messageQueue.push(message);
+
+    // A turn is in flight: queue only. processBatch()'s tail picks it up when
+    // the active turn finishes, so we never start a second concurrent turn.
+    if (this.isProcessing) {
+      logger.info(
+        `Priority message queued (${this.messageQueue.length} pending, processing in progress)`
+      );
+      return;
+    }
+
+    // Idle: flush now, skipping the batch window. Clear any pending timer first
+    // so a window that was about to fire doesn't double-process the queue.
+    if (this.batchTimer) {
+      clearTimeout(this.batchTimer);
+      this.batchTimer = null;
+    }
+    this.hasProcessedInitialBatch = true;
+    await this.processBatch();
+  }
+
   /** Queue a message whose ID was already reserved by claimMessageId(). */
   async addClaimedMessage(message: QueuedMessage): Promise<void> {
     this.messageQueue.push(message);

--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -570,6 +570,25 @@ export class GatewayClient {
       }
     }
 
+    // A `!`-bash command is a control action: skip the 2000ms batch window so an
+    // interactive shell command isn't delayed. It still goes THROUGH the batcher
+    // (via addPriorityMessage) so it stays on the single serialization boundary —
+    // if a turn is already in flight it queues behind it rather than starting a
+    // concurrent worker (which would race `currentWorker`/`currentWorkerUserId`).
+    // processBatchedMessages keeps it batch-isolated (never merged into a
+    // combined "Message N:" prompt).
+    if (data.platformMetadata?.bangBash) {
+      await this.messageBatcher.addPriorityMessage({
+        payload: data,
+        timestamp: Date.now(),
+      });
+      logger.info(
+        { traceId, messageId: data.messageId, conversationId },
+        "`!`-bash message queued as a priority (batch window skipped, serialization preserved)"
+      );
+      return;
+    }
+
     // Default: message job
     const queuedMessage: QueuedMessage = {
       payload: data,
@@ -777,6 +796,19 @@ export class GatewayClient {
     // into one prompt under the first message's token; preserve arrival order
     // and execute each subject with its own token instead.
     if (new Set(messages.map((message) => message.payload.userId)).size > 1) {
+      for (const message of messages) {
+        await this.processSingleMessage(message, [message.payload.messageId]);
+      }
+      return;
+    }
+
+    // A `!`-bash message must never be batch-merged: the "Message N:" join would
+    // bury the command in a combined prompt (and it carries its own bangBash
+    // control flag the worker reads). If any message in this batch is a `!`-bash
+    // action, run each individually in arrival order.
+    if (
+      messages.some((message) => message.payload.platformMetadata?.bangBash)
+    ) {
       for (const message of messages) {
         await this.processSingleMessage(message, [message.payload.messageId]);
       }
@@ -1116,6 +1148,10 @@ export function isSteerableHumanMessage(payload: MessagePayload): boolean {
   // session would treat the control command as ordinary text and preserve the
   // history the user explicitly asked to reset.
   if (payload.platformMetadata?.sessionReset === true) return false;
+  // A `!`-bash message is a control action, not model input: steering it into an
+  // active turn would feed the raw `!cmd` text to the model instead of running
+  // it. Queue it as its own turn (the worker intercept runs the shell).
+  if (payload.platformMetadata?.bangBash) return false;
   const source = payload.platformMetadata?.source;
   if (typeof source === "string" && AUTOMATION_SOURCES.has(source)) {
     return false;

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -20,6 +20,7 @@ import {
   type CreateAgentSessionResult,
   createAgentSession,
   ModelRegistry,
+  type SessionManager,
   SettingsManager,
 } from "@mariozechner/pi-coding-agent";
 import type { ProgressUpdate, SessionExecutionResult } from "../core/types";
@@ -51,7 +52,8 @@ import {
 } from "./session-context";
 import { buildToolPolicy, isToolAllowedByPolicy } from "./tool-policy";
 import { buildToolUseEventPayload } from "./tool-use-events";
-import { createLobuTools } from "./tools";
+import { checkSandboxLeak } from "./sandbox-leak";
+import { createLobuTools, enforceBashPreflight } from "./tools";
 import { clearSnapshots, hydrateFromSnapshot } from "./transcript-snapshot";
 import { TurnController, wrapToolsWithTurnGuard } from "./turn-controller";
 
@@ -516,6 +518,85 @@ interface RunAISessionParams {
   }) => Promise<void>;
 }
 
+/**
+ * Defensively read a `!`-bash control action off the untyped `platformMetadata`
+ * bag (the gateway sets `bangBash = { command, excludeFromContext }` at ingress
+ * — see core `parseBangBashCommand`). Returns null unless a non-empty string
+ * command and a boolean flag are present, so a malformed value can never trigger
+ * an execution.
+ */
+function readBangBashCommand(
+  platformMetadata: unknown
+): { command: string; excludeFromContext: boolean } | null {
+  if (!platformMetadata || typeof platformMetadata !== "object") return null;
+  const bang = (platformMetadata as Record<string, unknown>).bangBash;
+  if (!bang || typeof bang !== "object") return null;
+  const command = (bang as Record<string, unknown>).command;
+  if (typeof command !== "string" || command.trim() === "") return null;
+  return {
+    command,
+    excludeFromContext:
+      (bang as Record<string, unknown>).excludeFromContext === true,
+  };
+}
+
+/**
+ * Reconcile a just-hydrated session file with how pi's SessionManager will
+ * persist the NEXT turn — needed only for an ASSISTANT-LESS transcript, which in
+ * practice means a history whose only turns were `!`-bash (each records a
+ * `bashExecution`, never an assistant). pi's `_persist` treats an assistant-less
+ * session as an unflushed draft: on the next turn's first assistant message it
+ * re-appends the ENTIRE in-memory branch (including the `session` header) to the
+ * file — but the file is NOT empty, it holds the hydrated bytes, so the branch
+ * lands twice, producing a second `session` header mid-file that corrupts the
+ * transcript (the history parser then drops everything). pi's re-append assumes
+ * the file is empty in that state; make it so. We've already loaded the entries
+ * into memory via `open()`, so truncating the file loses nothing — the pending
+ * re-flush rewrites the whole branch exactly once. A normal session (has an
+ * assistant) is left untouched: pi appends incrementally and never re-flushes.
+ */
+async function normalizeHydratedSessionFile(
+  sessionManager: SessionManager,
+  sessionFile: string
+): Promise<void> {
+  const hasAssistant = sessionManager
+    .getBranch()
+    .some(
+      (entry) => entry.type === "message" && entry.message.role === "assistant"
+    );
+  if (hasAssistant) return;
+  try {
+    await fs.truncate(sessionFile, 0);
+  } catch {
+    // No file yet (fresh conversation) — nothing to reconcile.
+  }
+}
+
+/**
+ * Write the pinned session's current branch to disk so an assistant-less `!`-bash
+ * turn survives the worker's mandatory transcript checkpoint (pi defers its own
+ * flush until an assistant message exists — see the `!` intercept).
+ *
+ * Deliberately NOT `AgentSession.exportToJsonl()`: that regenerates the `session`
+ * header with a fresh `new Date()` timestamp on every call, so a retry of the
+ * SAME run would emit bytes that are not a prefix-extension of the first
+ * snapshot and the gateway's monotonic-prefix guard would 409, wedging the run.
+ * We reuse the EXISTING header (stable id + timestamp) and the branch entries
+ * verbatim (stable ids/parentIds — the session is linear here), so re-running the
+ * same turn yields byte-identical output and the snapshot upsert is idempotent.
+ */
+async function persistBangBashSession(
+  sessionManager: SessionManager,
+  sessionFile: string
+): Promise<void> {
+  const header = sessionManager.getHeader();
+  if (!header) return;
+  const lines = [header, ...sessionManager.getBranch()].map((entry) =>
+    JSON.stringify(entry)
+  );
+  await fs.writeFile(sessionFile, `${lines.join("\n")}\n`, "utf-8");
+}
+
 // ---------------------------------------------------------------------------
 // Main function
 // ---------------------------------------------------------------------------
@@ -875,6 +956,12 @@ export async function runAISession(
       workspaceDir
     );
   }
+  // Reconcile an assistant-less hydrated transcript (a `!`-bash-only history) so
+  // this turn's first assistant message doesn't make pi re-append the whole
+  // branch onto the already-hydrated file and double the session header. No-op
+  // for a normal session (has an assistant). Must run on the FINAL manager,
+  // after any provider-change reopen above.
+  await normalizeHydratedSessionFile(sessionManager, sessionFile);
   const settingsManager = SettingsManager.inMemory();
 
   const toolsPolicy = buildToolPolicy({
@@ -950,9 +1037,9 @@ export async function runAISession(
     });
   // The bash tool returned here carries the FULL hardened policy by construction
   // (prefix allow/deny + gateway-access + package-install blocks, plus
-  // credential-strip), so the forthcoming `!`-bash intercept (PR-D4) can reuse
-  // this same object rather than a second raw path. The filter then removes bash
-  // entirely when the agent policy disallows it (strict / disallowedTools).
+  // credential-strip), and the `!`-bash intercept reuses the same guards (via
+  // enforceBashPreflight) rather than a second raw path. The filter then removes
+  // bash entirely when the agent policy disallows it (strict / disallowedTools).
   const tools = createLobuTools(workspaceDir, {
     bashOperations: embeddedBashOps,
     bashPolicy: toolsPolicy.bashPolicy,
@@ -1488,6 +1575,102 @@ user references earlier discussion or you need prior context.`);
       if (heartbeatTimer) clearInterval(heartbeatTimer);
       if (deltaTimer) clearTimeout(deltaTimer);
 
+      return buildResult();
+    }
+
+    // `!`-bash: run the command as shell in this conversation's pinned sandbox
+    // and return the output as the reply — the LLM is skipped entirely. The
+    // command runs through the SAME hardened path the agent's own bash tool uses
+    // (enforceBashPreflight → the pinned embeddedBashOps), so it inherits the
+    // prefix policy, gateway-access block, package-install block, and
+    // credential-strip; it crosses no boundary the agent couldn't already. pi's
+    // `executeBash` records a `bashExecution` transcript entry synchronously and
+    // honors `excludeFromContext` (the `!!` form).
+    const bangBash = readBangBashCommand(platformMetadata);
+    if (bangBash && session) {
+      const bashSession = session;
+      // Bash was removed from the tool list by policy (strict / disallowedTools)
+      // → `!` is disabled, exactly as the agent's own bash would be.
+      const bashEnabled = tools.some((tool) => tool.name === "bash");
+      let replyText: string;
+      if (!bashEnabled) {
+        replyText = "Bash is disabled for this agent.";
+      } else {
+        try {
+          enforceBashPreflight(bangBash.command, toolsPolicy.bashPolicy);
+          // Make the running command cancellable: an explicit `/cancel` (or the
+          // steer/cancel path) aborts the in-flight bash, and `executeBash`
+          // returns with `cancelled: true`. Cleared in `finally` so a stale
+          // callback can't abort the next turn's bash.
+          onCancelReady(() => bashSession.abortBash());
+          let result: Awaited<ReturnType<typeof bashSession.executeBash>>;
+          try {
+            result = await bashSession.executeBash(
+              bangBash.command,
+              undefined,
+              {
+                operations: embeddedBashOps,
+                excludeFromContext: bangBash.excludeFromContext,
+              }
+            );
+          } finally {
+            onCancelReady(null);
+          }
+          // Cancelled FIRST: on cancel `exitCode` may be undefined, so a
+          // "exit N" branch would misreport. `result.output` is the full
+          // buffered output (no streaming of raw shell output).
+          if (result.cancelled) {
+            replyText = `\`${bangBash.command}\` cancelled.\n\n\`\`\`\n${result.output}\n\`\`\``;
+          } else {
+            const exit = result.exitCode ?? 0;
+            const status = exit === 0 ? "" : ` (exit ${exit})`;
+            replyText = `\`\`\`\n${result.output}\n\`\`\`${status}`;
+          }
+        } catch (err) {
+          // A preflight/backend rejection is the reply — never an agent turn.
+          replyText = `\`${bangBash.command}\` blocked: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      }
+
+      // Persist the session before the worker's mandatory transcript checkpoint.
+      // pi's SessionManager defers its on-disk flush until an ASSISTANT message
+      // exists (it treats an assistant-less session as an incomplete draft). A
+      // `!` turn never produces an assistant message, so without this the session
+      // file stays empty and `checkpointSuccessfulRun` fails ("Transcript
+      // checkpoint failed"), REJECTING the run — the record is lost and, on a
+      // fresh conversation, the whole `!` turn 500s. `persistBangBashSession`
+      // writes the full branch under the EXISTING (stable) header — the exact
+      // format `SessionManager.open()` expects on the next hydrate, and
+      // byte-idempotent across a same-run retry. This covers ALL `!` outcomes:
+      // executed (pi recorded a `bashExecution`), bash-disabled, and
+      // preflight/backend-blocked (no pi record, but the header alone is a valid
+      // non-empty checkpoint). Guard on the absence of an assistant message: with
+      // one, pi already flushed incrementally and rewriting would diverge from
+      // the bytes a later turn extends, tripping the snapshot's monotonic-prefix
+      // guard. (The complementary "a later normal turn re-appends this
+      // assistant-less branch and doubles the header" hazard is handled once, at
+      // the hydrate/open boundary — see `normalizeHydratedSessionFile`.)
+      const hasAssistant = bashSession.messages.some(
+        (message) => message.role === "assistant"
+      );
+      if (!hasAssistant) {
+        await persistBangBashSession(bashSession.sessionManager, sessionFile);
+      }
+
+      // Same file-link neutralization the agent's own replies get, applied to
+      // the COMPLETE output before the single emit (no raw pre-redaction bytes
+      // ever leave the worker for a `!` turn).
+      const redacted = checkSandboxLeak(replyText, false).redactedText;
+      await onProgress({
+        type: "output",
+        data: redacted,
+        timestamp: Date.now(),
+      });
+
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      if (deltaTimer) clearTimeout(deltaTimer);
+
+      // No `emitAgentEnd`: this was not an agent turn (the model never ran).
       return buildResult();
     }
 

--- a/packages/agent-worker/src/runtime/tools.ts
+++ b/packages/agent-worker/src/runtime/tools.ts
@@ -236,17 +236,48 @@ function isDirectGatewayApiAccessCommand(command: string): boolean {
 }
 
 /**
- * The single hardened bash entry point. Wraps the raw bash tool with EVERY
- * command-inspection guard, so any caller that holds this tool object gets the
- * full policy by construction. Today the agent's tool loop routes through here;
- * the forthcoming `!`-bash intercept (PR-D4) is meant to reuse this same object
- * rather than call `BashOperations.exec()` raw. The guards, in order applied to
- * the extracted command:
+ * The command-inspection gauntlet the hardened bash tool applies before it runs
+ * anything. Extracted so BOTH the agent's tool wrapper (below) and the `!`-bash
+ * intercept (which calls pi's `session.executeBash` for its transcript recording
+ * and so bypasses the tool wrapper) enforce the SAME guards from one source of
+ * truth. Throws on any violation; returns void when the command is allowed.
+ * Order:
  *   - prefix allow/deny policy (`enforceBashCommandPolicy`)
  *   - direct-gateway-API-access block
  *   - direct-package-install block
- * and, on failure, a proxy-403 hint (curl hides the proxy CONNECT body, so the
- * model would otherwise see only exit code 56, not "Domain not allowed").
+ *
+ * NOT included here: credential-stripping (`spawnHook`/`stripEnv`, inside
+ * `createBashTool`) and bash *removal* when policy disallows it (a tool-list
+ * filter in the caller). The `!` intercept covers those separately: it selects
+ * the same hardened `BashOperations` and only runs when bash survived the
+ * removal filter.
+ */
+export function enforceBashPreflight(
+  command: string,
+  bashPolicy?: BashCommandPolicy
+): void {
+  if (bashPolicy) {
+    enforceBashCommandPolicy(command, bashPolicy);
+  }
+  if (isDirectGatewayApiAccessCommand(command)) {
+    throw new Error(
+      "DIRECT GATEWAY API ACCESS BLOCKED. Use the registered MCP/auth tools instead of calling gateway /mcp or /internal endpoints from Bash."
+    );
+  }
+  if (isDirectPackageInstallCommand(command)) {
+    throw new Error(
+      "DIRECT PACKAGE INSTALL BLOCKED. Install system packages with nixPackages in lobu.config.ts or agent settings instead of using package managers inside the worker."
+    );
+  }
+}
+
+/**
+ * The single hardened bash entry point. Wraps the raw bash tool so any caller
+ * that holds this tool object gets the full policy by construction — the agent's
+ * tool loop routes through here. It runs {@link enforceBashPreflight} on the
+ * extracted command, then, on failure, appends a proxy-403 hint (curl hides the
+ * proxy CONNECT body, so the model would otherwise see only exit code 56, not
+ * "Domain not allowed").
  *
  * Credential-stripping (`spawnHook`/`stripEnv`) lives inside `createBashTool`;
  * bash *removal* when policy disallows it is a tool-list filter in the caller.
@@ -264,19 +295,7 @@ function wrapBashWithProxyHint(
         params && typeof params === "object" && "command" in params
           ? String((params as { command?: unknown }).command ?? "")
           : "";
-      if (bashPolicy) {
-        enforceBashCommandPolicy(command, bashPolicy);
-      }
-      if (isDirectGatewayApiAccessCommand(command)) {
-        throw new Error(
-          "DIRECT GATEWAY API ACCESS BLOCKED. Use the registered MCP/auth tools instead of calling gateway /mcp or /internal endpoints from Bash."
-        );
-      }
-      if (isDirectPackageInstallCommand(command)) {
-        throw new Error(
-          "DIRECT PACKAGE INSTALL BLOCKED. Install system packages with nixPackages in lobu.config.ts or agent settings instead of using package managers inside the worker."
-        );
-      }
+      enforceBashPreflight(command, bashPolicy);
       try {
         return await tool.execute(toolCallId, params, signal, onUpdate);
       } catch (err: any) {

--- a/packages/core/src/__tests__/bang-bash-parse.test.ts
+++ b/packages/core/src/__tests__/bang-bash-parse.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { parseBangBashCommand } from "../worker/wire";
+
+describe("parseBangBashCommand", () => {
+  test("`!cmd` → run with output kept in model context", () => {
+    expect(parseBangBashCommand("!ls /workspace")).toEqual({
+      command: "ls /workspace",
+      excludeFromContext: false,
+    });
+  });
+
+  test("`!!cmd` → run with output EXCLUDED from model context", () => {
+    expect(parseBangBashCommand("!!cat secret.txt")).toEqual({
+      command: "cat secret.txt",
+      excludeFromContext: true,
+    });
+  });
+
+  test("a leading space after the bang is allowed and trimmed", () => {
+    expect(parseBangBashCommand("! ls")).toEqual({
+      command: "ls",
+      excludeFromContext: false,
+    });
+    expect(parseBangBashCommand("!!  echo hi")).toEqual({
+      command: "echo hi",
+      excludeFromContext: true,
+    });
+  });
+
+  test("a triple `!!!…` is `!!` + a command that itself begins with `!`", () => {
+    expect(parseBangBashCommand("!!!x")).toEqual({
+      command: "!x",
+      excludeFromContext: true,
+    });
+  });
+
+  test("a bare `!` or `!!` (no command) is NOT a bash action → null", () => {
+    expect(parseBangBashCommand("!")).toBeNull();
+    expect(parseBangBashCommand("!!")).toBeNull();
+    expect(parseBangBashCommand("!  ")).toBeNull();
+    expect(parseBangBashCommand("!!   ")).toBeNull();
+  });
+
+  test("ordinary text (no leading bang) → null", () => {
+    expect(parseBangBashCommand("ls /workspace")).toBeNull();
+    expect(parseBangBashCommand("what is 2+2?")).toBeNull();
+    expect(parseBangBashCommand("")).toBeNull();
+    // A bang not at the start is ordinary text.
+    expect(parseBangBashCommand("run this: !ls")).toBeNull();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -149,4 +149,10 @@ export type {
   WorkerTransportConfig,
 } from "./worker/transport";
 // Gateway ↔ worker wire contract (MessagePayload, JobType, QueuedMessage).
-export type { JobType, MessagePayload, QueuedMessage } from "./worker/wire";
+export type {
+  BangBashCommand,
+  JobType,
+  MessagePayload,
+  QueuedMessage,
+} from "./worker/wire";
+export { parseBangBashCommand } from "./worker/wire";

--- a/packages/core/src/worker/wire.ts
+++ b/packages/core/src/worker/wire.ts
@@ -29,6 +29,35 @@ import type {
 export type JobType = "message" | "exec";
 
 /**
+ * A `!`-bash control action carried on `platformMetadata.bangBash`. Set by the
+ * gateway at ingress when the user's message is `!cmd` / `!!cmd`; read by the
+ * worker, which runs `command` through the hardened bash path in the
+ * conversation's pinned sandbox and returns the output as the reply (the LLM is
+ * skipped). `excludeFromContext` (the `!!` form) keeps the command + output out
+ * of later model context via pi's native flag.
+ */
+export interface BangBashCommand {
+  command: string;
+  excludeFromContext: boolean;
+}
+
+/**
+ * Parse a raw chat message into a {@link BangBashCommand}, or `null` when it is
+ * not a `!`-bash message. `!cmd` → run with output in context; `!!cmd` → run
+ * with output excluded from later model context. A bare `!` / `!!` (no command
+ * after trimming) is NOT a bash action — it returns `null` so the text falls
+ * through as ordinary input. A leading space after `!`/`!!` is allowed and
+ * trimmed (`! ls` == `!ls`); a triple `!!!…` is `!!` + command `!…`.
+ */
+export function parseBangBashCommand(text: string): BangBashCommand | null {
+  if (!text.startsWith("!")) return null;
+  const excludeFromContext = text.startsWith("!!");
+  const command = text.slice(excludeFromContext ? 2 : 1).trim();
+  if (!command) return null;
+  return { command, excludeFromContext };
+}
+
+/**
  * Universal message payload for every gateway → worker hop.
  * Used by: platform inbound → runs queue → MessageConsumer → worker.
  */

--- a/packages/server/src/gateway/connections/message-handler-bridge.ts
+++ b/packages/server/src/gateway/connections/message-handler-bridge.ts
@@ -4,7 +4,12 @@
  * settings links, allowlist, audio transcription, etc.
  */
 
-import { createLogger, createRootSpan, generateTraceId } from "@lobu/core";
+import {
+  createLogger,
+  createRootSpan,
+  generateTraceId,
+  parseBangBashCommand,
+} from "@lobu/core";
 import {
   previewUnlinkedNotice,
   workspaceUnlinkedNotice,
@@ -747,13 +752,24 @@ export class MessageHandlerBridge {
         .trim();
     }
 
-    // Intercept /new and /clear before slash dispatch
+    // Intercept a `!`-bash message before slash dispatch. `!cmd` runs `cmd` as
+    // shell in the conversation's pinned sandbox (LLM skipped); `!!cmd` runs it
+    // but excludes command+output from later model context (pi's
+    // excludeFromContext). This is NOT a new authority: it runs the exact same
+    // command in the exact same sandbox the agent's own bash tool already can —
+    // see the worker intercept, which routes through the D1-hardened bash path.
+    // A bare `!` / `!!` with no command falls through as ordinary text.
+    const bangBash = parseBangBashCommand(messageText);
+
+    // Intercept /new and /clear before slash dispatch. A `!`-bash message is a
+    // control action, not model input: it skips /new, /clear, and slash dispatch
+    // entirely and enqueues as its own worker turn.
     let sessionReset = false;
     const trimmedLower = messageText.trim().toLowerCase();
-    if (trimmedLower === "/new") {
+    if (!bangBash && trimmedLower === "/new") {
       messageText = "Starting new session.";
       sessionReset = true;
-    } else if (trimmedLower === "/clear") {
+    } else if (!bangBash && trimmedLower === "/clear") {
       await this.conversationState()?.clearHistory(
         this.connection.id,
         channelId,
@@ -772,6 +788,7 @@ export class MessageHandlerBridge {
     // enqueue and the previewMode menu so a pasted code binds.
     if (
       !sessionReset &&
+      !bangBash &&
       this.commandDispatcher &&
       this.connection.settings?.previewMode === true
     ) {
@@ -797,7 +814,7 @@ export class MessageHandlerBridge {
     }
 
     // Slash command dispatch — intercept before queueing to worker
-    if (!sessionReset && this.commandDispatcher) {
+    if (!sessionReset && !bangBash && this.commandDispatcher) {
       const handled = await this.commandDispatcher.tryHandleSlashText(
         messageText,
         {
@@ -940,6 +957,7 @@ export class MessageHandlerBridge {
       extraMetadata: {
         ...(ingestedFiles.length > 0 && { files: ingestedFiles }),
         ...(sessionReset && { sessionReset: true }),
+        ...(bangBash && { bangBash }),
       },
       spanName: "message_received",
       logMessage: "Message enqueued via Chat SDK bridge",

--- a/packages/server/src/gateway/connections/platform-metadata.ts
+++ b/packages/server/src/gateway/connections/platform-metadata.ts
@@ -11,6 +11,8 @@
  * absence of the field.
  */
 
+import type { BangBashCommand } from "@lobu/core";
+
 export interface PlatformMetadata {
   /** Outbound: the Chat SDK connection the response originated from. */
   connectionId?: string;
@@ -38,6 +40,15 @@ export interface PlatformMetadata {
   conversationUrl?: string;
   /** Outbound: marker for the session-reset signal from the worker. */
   sessionReset?: boolean;
+  /**
+   * Inbound: a `!`-bash control action. Set at ingress when the message text is
+   * `!cmd` (run `cmd` as shell in the conversation's pinned sandbox, LLM skipped)
+   * or `!!cmd` (same, but exclude command+output from later model context). The
+   * worker reads this after the session-reset return and runs the command
+   * through the hardened bash path; a bare `!`/`!!` with no command is treated
+   * as ordinary text and never sets this.
+   */
+  bangBash?: BangBashCommand;
   /** Outbound: distributed tracing context propagation. */
   traceparent?: string;
   /** Outbound: client-side message id correlation. */

--- a/packages/server/src/gateway/routes/public/agent.ts
+++ b/packages/server/src/gateway/routes/public/agent.ts
@@ -7,6 +7,7 @@ import {
   generateWorkerToken,
   type NetworkConfig,
   normalizeDomainPatterns,
+  parseBangBashCommand,
   verifyWorkerToken,
 } from "@lobu/core";
 import type { Context } from "hono";
@@ -1513,6 +1514,16 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
         ingestedFiles
       );
 
+      // `!`-bash from web/direct-API chat (the primary `!` surface — ChatGPT-UI
+      // style clients driving the conversation's sandbox without the LLM). Gated
+      // to genuine user chat: a watcher_run's injected text must stay ordinary
+      // text, never a deterministic shell trigger. The Chat SDK bridge does the
+      // same for platform inbound.
+      const bangBash =
+        session.intent?.kind === "watcher_run"
+          ? null
+          : parseBangBashCommand(messageContent);
+
       const jobId = await queueProducer.enqueueMessage({
         userId: session.userId,
         conversationId: session.conversationId || agentId,
@@ -1537,6 +1548,7 @@ export function createAgentApi(config: AgentApiConfig): OpenAPIHono {
           dryRun: session.dryRun || false,
           intent: session.intent,
           ...(ingestedFiles.length > 0 ? { files: ingestedFiles } : {}),
+          ...(bangBash ? { bangBash } : {}),
         },
         agentOptions: remainingOptions,
         networkConfig: session.networkConfig || settingsNetwork,

--- a/scripts/sdk-e2e.sh
+++ b/scripts/sdk-e2e.sh
@@ -361,6 +361,129 @@ CSEND_REPLY="$(jget return_value.reply < "$CSEND")"
   || { cat "$CSEND" >&2; fail "conversations.send returned reply='$CSEND_REPLY', expected '$MOCK_REPLY' (worker turn / finalText read mismatch)"; }
 echo "✓ conversations.send round-tripped the agent reply via the durable runs poll ($MOCK_REPLY)"
 
+# 5d) `!`-bash: a message starting with `!` runs shell in the conversation's
+#     pinned sandbox, records a `bashExecution` transcript entry, and returns the
+#     output as the reply — the LLM is SKIPPED. Sent over the Direct API (the
+#     primary `!` surface: a ChatGPT-UI-style client driving the sandbox without
+#     the LLM). Crucially the `!` is the FIRST message in a FRESH conversation —
+#     the real launch use case, and the case that surfaced the persistence bug:
+#     pi defers its session-file flush until an assistant message exists, so an
+#     assistant-less `!` turn left the checkpoint reading an empty file and the
+#     record was lost. The worker now force-flushes an assistant-less `!` turn.
+#     A `!` turn finishes in ~20ms (no model roundtrip), beating any SSE
+#     subscription, so the durable transcript — the same projection the web reads
+#     on reload, exercising the core `entryToMessage` bashExecution branch — is
+#     the only race-free assert. We assert:
+#       (a) the shell RAN — a `bashExecution` message whose output carries a
+#           unique marker only `echo` can produce;
+#       (b) the model was SKIPPED — no new upstream provider call for the turn;
+#       (c) a normal LLM turn AFTER the `!` still checkpoints (no snapshot
+#           monotonic-prefix 409 from the force-flush) and both records coexist.
+BANG_MARKER="bang_ran_$$_$RANDOM"
+UPSTREAM_BEFORE=$(grep -c "Forwarding to upstream: POST http://127.0.0.1:$MOCK_PORT" "$RUN_LOG" 2>/dev/null || echo 0)
+# Create a DEVTOKEN session for agent `echo` on a NAMED thread, then message
+# its conversationId — the messages route is addressed by the session's
+# conversationId, not the bare agent id. The named thread makes the read side
+# deterministic: /history/threads/bang-e2e/messages rebuilds the identical
+# conversation id from (agent, DEVTOKEN user, org, thread).
+BANG_SESS="$RUN_DIR/bang-session.json"
+curl -fsS -X POST "$GW/lobu/api/v1/agents" \
+  -H "authorization: Bearer $DEVTOKEN" -H 'content-type: application/json' \
+  -d '{"agentId":"echo","thread":"bang-e2e"}' > "$BANG_SESS" \
+  || { cat "$BANG_SESS" >&2; fail "!-bash: POST /api/v1/agents (create session) failed"; }
+BANG_CONV="$(jget agentId < "$BANG_SESS")"
+[ -n "$BANG_CONV" ] || { cat "$BANG_SESS" >&2; fail "!-bash: session create returned no conversationId"; }
+BANG_SEND="$RUN_DIR/bang-send.json"
+curl -fsS -X POST "$GW/lobu/api/v1/agents/$BANG_CONV/messages" \
+  -H "authorization: Bearer $DEVTOKEN" -H 'content-type: application/json' \
+  -d "{\"content\":\"!echo $BANG_MARKER\"}" > "$BANG_SEND" \
+  || { cat "$BANG_SEND" >&2; fail "!-bash: POST /agents/$BANG_CONV/messages failed"; }
+[ "$(jget queued < "$BANG_SEND")" = "true" ] || { cat "$BANG_SEND" >&2; fail "!-bash message was not queued"; }
+# Poll the THREAD-addressed history endpoint (the same one the web uses to
+# render a chat thread on reload — it rebuilds the conversation id from
+# (agent, DEVTOKEN user, org, thread) and reads the durable snapshot, so it
+# also exercises the core `entryToMessage` bashExecution projection). NOT
+# `/history/session/messages` — that one is proxy-or-fallback: while any live
+# agent worker is still connected it proxies to THAT worker's own session
+# (whatever conversation it holds), so the assert would flake on which earlier
+# worker was still alive.
+BANG_HIST="$RUN_DIR/bang-history.json"
+BANG_OK=""
+for _ in $(seq 1 30); do
+  curl -fsS "$GW/lobu/api/v1/agents/echo/history/threads/bang-e2e/messages?limit=100" \
+    -H "authorization: Bearer $DEVTOKEN" > "$BANG_HIST" 2>/dev/null || { sleep 1; continue; }
+  if node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{let j;try{j=JSON.parse(s)}catch{process.exit(1)}const m=(j.messages||[]).find(x=>x.type==="bashExecution"&&JSON.stringify(x.content||"").includes(process.argv[1]));process.exit(m?0:1)})' "$BANG_MARKER" < "$BANG_HIST"; then
+    BANG_OK=1; break
+  fi
+  sleep 1
+done
+[ -n "$BANG_OK" ] || { tail -c 400 "$BANG_HIST" >&2; fail "!-bash: no bashExecution transcript entry carrying marker '$BANG_MARKER' (shell did not run, or D3 projection dropped it)"; }
+# The LLM must have been SKIPPED: no new upstream provider call for the `!` turn.
+UPSTREAM_AFTER=$(grep -c "Forwarding to upstream: POST http://127.0.0.1:$MOCK_PORT" "$RUN_LOG" 2>/dev/null || echo 0)
+[ "$UPSTREAM_AFTER" -eq "$UPSTREAM_BEFORE" ] || fail "!-bash hit the model provider ($UPSTREAM_BEFORE → $UPSTREAM_AFTER upstream calls); the LLM must be skipped"
+echo "✓ !-bash ran shell in the sandbox, recorded a bashExecution transcript entry, and skipped the LLM (marker: $BANG_MARKER)"
+
+# 5d.2) A NORMAL LLM turn in the SAME conversation, right after the assistant-less
+#       `!` force-flushed the session file. This guards the cross-turn regression:
+#       the force-flush must not desync the transcript so the next turn's
+#       checkpoint hits the snapshot monotonic-prefix guard (a 409 would surface
+#       as a durable agent-error and the assistant reply would never land).
+curl -fsS -X POST "$GW/lobu/api/v1/agents/$BANG_CONV/messages" \
+  -H "authorization: Bearer $DEVTOKEN" -H 'content-type: application/json' \
+  -d '{"content":"after the bang"}' > "$RUN_DIR/bang-followup-send.json" \
+  || { cat "$RUN_DIR/bang-followup-send.json" >&2; fail "!-bash follow-up: POST failed"; }
+BANG_FOLLOW=""
+for _ in $(seq 1 30); do
+  curl -fsS "$GW/lobu/api/v1/agents/echo/history/threads/bang-e2e/messages?limit=100" \
+    -H "authorization: Bearer $DEVTOKEN" > "$BANG_HIST" 2>/dev/null || { sleep 1; continue; }
+  # Assert the follow-up turn checkpointed cleanly: EXACTLY ONE bashExecution
+  # carrying the marker (a second copy would mean the force-flush desynced the
+  # SessionManager and the assistant turn re-appended the whole branch) AND a
+  # fresh assistant reply, both in the same durable thread.
+  if node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{let j;try{j=JSON.parse(s)}catch{process.exit(1)}const ms=j.messages||[];const bangs=ms.filter(x=>x.type==="bashExecution"&&JSON.stringify(x.content||"").includes(process.argv[1]));const asst=ms.some(x=>x.role==="assistant");process.exit(bangs.length===1&&asst?0:1)})' "$BANG_MARKER" < "$BANG_HIST"; then
+    BANG_FOLLOW=1; break
+  fi
+  sleep 1
+done
+[ -n "$BANG_FOLLOW" ] || { tail -c 400 "$BANG_HIST" >&2; fail "!-bash follow-up: normal turn after the force-flushed \`!\` did not land (snapshot prefix 409?) or the bashExecution record was dropped"; }
+echo "✓ !-bash: a normal LLM turn after the force-flushed \`!\` checkpointed cleanly; both records coexist in the durable thread"
+
+# 5d.3) A preflight-BLOCKED `!` as the FIRST message of a FRESH conversation.
+#       enforceBashPreflight throws (package-install guard) → no pi bashExecution
+#       record is written, so this is the exact case where an assistant-less
+#       session would leave the checkpoint reading an empty file and REJECT the
+#       run. Assert the run reaches terminal completion (the durable runs row is
+#       `complete`, not a checkpoint-failure), proving the force-flush covers the
+#       blocked branch too — the friendly "blocked" reply still reaches the user.
+BLOCK_CONV="$RUN_DIR/bang-block-session.json"
+curl -fsS -X POST "$GW/lobu/api/v1/agents" \
+  -H "authorization: Bearer $DEVTOKEN" -H 'content-type: application/json' \
+  -d '{"agentId":"echo","thread":"bang-block"}' > "$BLOCK_CONV" \
+  || { cat "$BLOCK_CONV" >&2; fail "!-bash blocked: create session failed"; }
+BLOCK_ID="$(jget agentId < "$BLOCK_CONV")"
+UPSTREAM_BLK_BEFORE=$(grep -c "Forwarding to upstream: POST http://127.0.0.1:$MOCK_PORT" "$RUN_LOG" 2>/dev/null || echo 0)
+curl -fsS -X POST "$GW/lobu/api/v1/agents/$BLOCK_ID/messages" \
+  -H "authorization: Bearer $DEVTOKEN" -H 'content-type: application/json' \
+  -d '{"content":"!npm install left-pad"}' > "$RUN_DIR/bang-block-send.json" \
+  || { cat "$RUN_DIR/bang-block-send.json" >&2; fail "!-bash blocked: POST failed"; }
+# The run must not be rejected by a transcript-checkpoint failure. That failure
+# writes a durable agent-error interaction; assert none appears for this thread.
+BLOCK_OK=""
+for _ in $(seq 1 30); do
+  curl -fsS "$GW/lobu/api/v1/agents/echo/history/threads/bang-block/messages?limit=100" \
+    -H "authorization: Bearer $DEVTOKEN" > "$RUN_DIR/bang-block-hist.json" 2>/dev/null || { sleep 1; continue; }
+  if node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{let j;try{j=JSON.parse(s)}catch{process.exit(1)}const err=(j.interactions||[]).some(x=>x.type==="agent-error");process.exit(err?1:0)})' < "$RUN_DIR/bang-block-hist.json"; then
+    # No agent-error yet — give the run a beat to settle, then confirm it stays clean.
+    if grep -q "Transcript checkpoint failed" "$RUN_LOG"; then BLOCK_OK=""; else BLOCK_OK=1; fi
+    [ -n "$BLOCK_OK" ] && break
+  fi
+  sleep 1
+done
+[ -n "$BLOCK_OK" ] || { grep "Transcript checkpoint failed" "$RUN_LOG" | tail -2 >&2; fail "!-bash blocked: a preflight-blocked \`!\` on a fresh conversation failed the transcript checkpoint (assistant-less session not persisted)"; }
+UPSTREAM_BLK_AFTER=$(grep -c "Forwarding to upstream: POST http://127.0.0.1:$MOCK_PORT" "$RUN_LOG" 2>/dev/null || echo 0)
+[ "$UPSTREAM_BLK_AFTER" -eq "$UPSTREAM_BLK_BEFORE" ] || fail "!-bash blocked hit the model provider; a blocked \`!\` must still skip the LLM"
+echo "✓ !-bash: a preflight-blocked \`!\` on a fresh conversation completes cleanly (no checkpoint failure) and skips the LLM"
+
 # 6) Connector sync — prove the COMPILED connector actually RUNS and emits events.
 #    Find the feed manage_feeds created from the `pulse` connection, trigger an
 #    immediate sync, wait for the run to complete, then assert ≥1 event landed.


### PR DESCRIPTION
Final stage of the `!`-bash program. A chat message prefixed `!` runs the rest as a shell command in the conversation's pinned sandbox — the output is the reply, it's recorded in the transcript, and the LLM is skipped. `!!` runs but excludes the command+output from later model context (pi's `excludeFromContext`).

Builds on PR-D1 (#1963, single hardened bash entry) and PR-D3 (#1966, `bashExecution` transcript projection).

## Design: no new authorization surface
`!` reuses the agent's OWN hardened bash. The sandbox IS the boundary — `!` runs the identical command in the identical sandbox the agent's bash tool already can, through the same `enforceBashPreflight` guards (prefix policy + gateway-access block + package-install block + credential-strip). It crosses no new security boundary, so it needs no new gate. `!` is disabled exactly when the agent's own bash is (strict/disallowedTools). (Earlier `MessageOrigin` and `direct_bash` capability designs were both dropped.)

## What's here
- **Ingress** (`message-handler-bridge.ts` Chat SDK + `agent.ts` Direct API): detect a leading `!` on the raw message, set `platformMetadata.bangBash = { command, excludeFromContext }`. Gated off watcher_run injected text. Core `parseBangBashCommand` is the single parser.
- **Worker dispatch** (`sse-client.ts`): a `!` message is non-steerable and never batch-merged; it skips the 2000ms batch window via `MessageBatcher.addPriorityMessage` while staying on the batcher's single serialization boundary (so it never runs concurrently with an active turn).
- **Worker intercept** (`session-runner.ts`): run the command through the D1-hardened path → `session.executeBash` in the pinned `embeddedBashOps` → redact via `checkSandboxLeak` → single emit → return without `emitAgentEnd`. Handles `cancelled` first (exitCode may be undefined) and wires `abortBash` for `/cancel`.
- **Persistence** (`session-runner.ts`): pi defers its session-file flush until an assistant message exists, so an assistant-less `!` turn would fail the mandatory transcript checkpoint (rejecting the run) and, on a later normal turn, double the session header. Fixed with `persistBangBashSession` (stable, retry-idempotent serialization of the branch under the existing header) + `normalizeHydratedSessionFile` (truncate an assistant-less hydrated file so pi's re-append writes it exactly once).

## Tests
- Unit: `parseBangBashCommand` edge cases; `isSteerableHumanMessage` false-for-bangBash; `MessageBatcher.addPriorityMessage` (immediate-when-idle, queue-behind-active-turn — the concurrency regression guard).
- Live e2e (`scripts/sdk-e2e.sh`): `!` as the first message of a fresh conversation runs the shell, records exactly one `bashExecution`, skips the LLM; a normal LLM turn after the `!` checkpoints cleanly (single header, no duplicate); a preflight-blocked `!` on a fresh conversation completes without a checkpoint failure and skips the LLM. Verified stable across many consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ep6TY8RQ4QZkiDkMBCkbcH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786718033&installation_id=136316292&pr_number=1987&repository=lobu-ai%2Flobu&return_to=https%3A%2F%2Fgithub.com%2Flobu-ai%2Flobu%2Fpull%2F1987&signature=5084a6418b026b08b4abe0b568793bda5734d01cb74c489f166aae0c09e64f26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->