### PR TITLE
Promote Gmail contacts after bidirectional interaction

### DIFF
--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -28,10 +28,11 @@ interface FakeThread {
  * lookups from the given fixtures. Header values come from the per-message
  * `from`/`date` fields; snippets are constant.
  */
-function fakeHttp(threads: FakeThread[]) {
+function fakeHttp(threads: FakeThread[], onRequest?: () => void) {
   const byId = new Map(threads.map((t) => [t.id, t]));
   return {
     raw: async (url: string) => {
+      onRequest?.();
       const u = new URL(url);
       const threadMatch = u.pathname.match(/\/threads\/([^/]+)$/);
       const body = threadMatch
@@ -81,6 +82,24 @@ async function syncThreads(threads: FakeThread[]) {
   return result.events as Array<{ origin_id: string; metadata: Record<string, unknown> }>;
 }
 
+test('the checkpoint precedes sync requests so messages arriving during sync remain eligible', async () => {
+  const connector = new GmailConnector();
+  let firstRequestAt = Number.POSITIVE_INFINITY;
+  connector.createClient = () =>
+    fakeHttp([], () => {
+      firstRequestAt = Math.min(firstRequestAt, Date.now());
+    });
+
+  const result = await connector.sync({
+    config: {},
+    credentials: { accessToken: 'tok' },
+    checkpoint: {},
+  });
+
+  expect(firstRequestAt).toBeFinite();
+  expect(new Date(result.checkpoint.last_sync_at).getTime()).toBeLessThanOrEqual(firstRequestAt);
+});
+
 describe('Gmail replied signal (promote-on-interaction)', () => {
   test('an inbound-only thread is NOT replied — a bulk sender/brand never clears the bar', async () => {
     const events = await syncThreads([
@@ -112,7 +131,7 @@ describe('Gmail replied signal (promote-on-interaction)', () => {
     expect(events[0].metadata.from_email).toBe('alice@example.com');
   });
 
-  test('an owner-started thread is NOT replied — from_email is the owner, never promote self', async () => {
+  test('an owner-started thread with a counterparty reply is bidirectional and attributes the counterparty', async () => {
     const events = await syncThreads([
       {
         id: 't-self',
@@ -123,7 +142,8 @@ describe('Gmail replied signal (promote-on-interaction)', () => {
       },
     ]);
     expect(events).toHaveLength(1);
-    expect(events[0].metadata.replied).toBe(false);
+    expect(events[0].metadata.replied).toBe(true);
+    expect(events[0].metadata.from_email).toBe('bob@example.com');
   });
 });
 

--- a/packages/connectors/src/__tests__/google_gmail.test.ts
+++ b/packages/connectors/src/__tests__/google_gmail.test.ts
@@ -1,0 +1,144 @@
+import { beforeAll, describe, expect, mock, test } from 'bun:test';
+import { connectorSdkMock } from './connector-sdk.mock';
+
+mock.module('@lobu/connector-sdk', () => connectorSdkMock());
+
+// biome-ignore lint/suspicious/noExplicitAny: dynamic import after mock
+let GmailConnector: any;
+
+beforeAll(async () => {
+  const mod = await import('../google_gmail');
+  GmailConnector = mod.default;
+});
+
+interface FakeMessage {
+  id: string;
+  labelIds?: string[];
+  from?: string;
+  date?: string;
+}
+
+interface FakeThread {
+  id: string;
+  messages: FakeMessage[];
+}
+
+/**
+ * Fake Gmail HTTP client: serves threads.list (one page) and threads/<id>
+ * lookups from the given fixtures. Header values come from the per-message
+ * `from`/`date` fields; snippets are constant.
+ */
+function fakeHttp(threads: FakeThread[]) {
+  const byId = new Map(threads.map((t) => [t.id, t]));
+  return {
+    raw: async (url: string) => {
+      const u = new URL(url);
+      const threadMatch = u.pathname.match(/\/threads\/([^/]+)$/);
+      const body = threadMatch
+        ? toThreadResponse(byId.get(threadMatch[1]))
+        : { threads: threads.map((t) => ({ id: t.id, historyId: '1', snippet: 's' })) };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => body,
+        text: async () => '',
+      } as unknown as Response;
+    },
+  };
+}
+
+function toThreadResponse(thread: FakeThread | undefined) {
+  if (!thread) return { id: 'missing', historyId: '1', messages: [] };
+  return {
+    id: thread.id,
+    historyId: '1',
+    messages: thread.messages.map((m) => ({
+      id: m.id,
+      threadId: thread.id,
+      labelIds: m.labelIds ?? [],
+      snippet: 'snippet',
+      internalDate: String(Date.parse(m.date ?? '2026-07-01T10:00:00Z')),
+      payload: {
+        mimeType: 'text/plain',
+        headers: [
+          { name: 'Subject', value: `subject ${thread.id}` },
+          { name: 'From', value: m.from ?? 'Some One <someone@example.com>' },
+          { name: 'Date', value: m.date ?? '2026-07-01T10:00:00Z' },
+        ],
+      },
+    })),
+  };
+}
+
+async function syncThreads(threads: FakeThread[]) {
+  const connector = new GmailConnector();
+  connector.createClient = () => fakeHttp(threads);
+  const result = await connector.sync({
+    config: {},
+    credentials: { accessToken: 'tok' },
+    checkpoint: {},
+  });
+  return result.events as Array<{ origin_id: string; metadata: Record<string, unknown> }>;
+}
+
+describe('Gmail replied signal (promote-on-interaction)', () => {
+  test('an inbound-only thread is NOT replied — a bulk sender/brand never clears the bar', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-brand',
+        messages: [
+          { id: 'm1', labelIds: ['INBOX'], from: 'Brand <promo@brand.example>' },
+          { id: 'm2', labelIds: ['INBOX'], from: 'Brand <promo@brand.example>' },
+        ],
+      },
+    ]);
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.replied).toBe(false);
+    expect(events[0].metadata.from_email).toBe('promo@brand.example');
+  });
+
+  test('a counterparty-started thread the owner replied in IS replied', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-alice',
+        messages: [
+          { id: 'm1', labelIds: ['INBOX'], from: 'Alice <alice@example.com>' },
+          { id: 'm2', labelIds: ['SENT'], from: 'Me <me@example.com>' },
+        ],
+      },
+    ]);
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.replied).toBe(true);
+    expect(events[0].metadata.from_email).toBe('alice@example.com');
+  });
+
+  test('an owner-started thread is NOT replied — from_email is the owner, never promote self', async () => {
+    const events = await syncThreads([
+      {
+        id: 't-self',
+        messages: [
+          { id: 'm1', labelIds: ['SENT'], from: 'Me <me@example.com>' },
+          { id: 'm2', labelIds: ['INBOX'], from: 'Bob <bob@example.com>' },
+        ],
+      },
+    ]);
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.replied).toBe(false);
+  });
+});
+
+describe('Gmail person attribution rule', () => {
+  test('autoCreate is on but gated on metadata.replied — promotion is interaction-driven', () => {
+    const connector = new GmailConnector();
+    const rules = connector.definition.feeds.threads.eventKinds.thread.attributions;
+    expect(rules).toHaveLength(1);
+    const rule = rules[0];
+    expect(rule.role).toBe('authored_by');
+    expect(rule.autoCreate).toBe(true);
+    expect(rule.target.entityType).toBe('person');
+    expect(rule.target.createWhen).toEqual({ path: 'metadata.replied', equals: true });
+    expect(rule.target.identities).toEqual([
+      { namespace: 'email', eventPath: 'metadata.from_email' },
+    ]);
+  });
+});

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -156,21 +156,30 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
                 snippet: { type: 'string' },
                 from_email: { type: 'string' },
                 from_name: { type: 'string' },
+                replied: {
+                  type: 'boolean',
+                  description:
+                    'True when the thread was started by the counterparty and the mailbox owner sent a message in it (a SENT-labeled message) — the interaction signal that gates contact promotion.',
+                },
               },
             },
             attributions: [
               {
                 role: 'authored_by',
-                // Don't mint a contact per inbound sender. Every from-address is a
-                // sender — overwhelmingly brands, newsletters, and no-reply system
-                // addresses, all of which carry a from_name, so no per-event signal
-                // separates a real contact from a brand. The identifier still lands
-                // in entity_identities and links to an existing contact on match;
-                // promoting a real email contact is interaction-driven (a reply /
-                // contacts-source bridge), handled outside ingest.
-                autoCreate: false,
+                // Promote on interaction, never on receipt. Every from-address is
+                // a sender — overwhelmingly brands, newsletters, and no-reply
+                // system addresses, all of which carry a from_name — so receipt
+                // alone must not mint a contact. `replied` (computed in sync from
+                // per-message SENT labels) marks a genuine bidirectional exchange:
+                // the counterparty wrote first AND the mailbox owner answered.
+                // Only those senders materialize a `person`; everything else still
+                // links to an existing contact on identity match. A thread replied
+                // to after its first sync re-syncs (the reply is a new message
+                // inside the `after:` window), so promotion follows the reply.
+                autoCreate: true,
                 target: {
                   entityType: 'person',
+                  createWhen: { path: 'metadata.replied', equals: true },
                   titlePath: 'metadata.from_name',
                   identities: [{ namespace: 'email', eventPath: 'metadata.from_email' }],
                 },
@@ -372,6 +381,16 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
 
           if (Number.isNaN(occurredAt.getTime())) continue;
 
+          // Interaction signal for promote-on-signal (see the attribution rule's
+          // createWhen): the thread was STARTED by the counterparty (first
+          // message is not ours) and the mailbox owner sent at least one message
+          // in it. A SENT label marks a message the account owner authored, so
+          // this needs no knowledge of the owner's own address. Owner-started
+          // threads are deliberately NOT `replied` — their from_email is the
+          // owner's own address, which must never be promoted as a contact.
+          const isSent = (m: GmailMessage) => (m.labelIds ?? []).includes('SENT');
+          const replied = !isSent(firstMessage) && thread.messages.some(isSent);
+
           const event: EventEnvelope = {
             origin_id: thread.id,
             title: subject,
@@ -384,6 +403,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
               message_count: thread.messages.length,
               label_ids: firstMessage.labelIds ?? [],
               snippet: firstMessage.snippet,
+              replied,
               ...(fromEmail ? { from_email: fromEmail } : {}),
               ...(fromName ? { from_name: fromName } : {}),
             },

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -159,7 +159,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
                 replied: {
                   type: 'boolean',
                   description:
-                    'True when the thread was started by the counterparty and the mailbox owner sent a message in it (a SENT-labeled message) — the interaction signal that gates contact promotion.',
+                    'True when the thread contains both a counterparty message and a mailbox-authored SENT-labeled message — the interaction signal that gates contact promotion.',
                 },
               },
             },
@@ -170,8 +170,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
                 // a sender — overwhelmingly brands, newsletters, and no-reply
                 // system addresses, all of which carry a from_name — so receipt
                 // alone must not mint a contact. `replied` (computed in sync from
-                // per-message SENT labels) marks a genuine bidirectional exchange:
-                // the counterparty wrote first AND the mailbox owner answered.
+                // per-message SENT labels) marks a genuine bidirectional exchange.
                 // Only those senders materialize a `person`; everything else still
                 // links to an existing contact on identity match. A thread replied
                 // to after its first sync re-syncs (the reply is a new message
@@ -372,8 +371,12 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
           if (!thread.messages || thread.messages.length === 0) continue;
 
           const firstMessage = thread.messages[0];
+          const isSent = (m: GmailMessage) => (m.labelIds ?? []).includes('SENT');
+          const counterpartyMessage = thread.messages.find((message) => !isSent(message));
           const subject = this.getHeader(firstMessage, 'Subject') || '(no subject)';
-          const from = this.getHeader(firstMessage, 'From') || 'Unknown';
+          const from = counterpartyMessage
+            ? this.getHeader(counterpartyMessage, 'From') || 'Unknown'
+            : 'Unknown';
           const { name: fromName, email: fromEmail } = this.parseFromHeader(from);
           const dateHeader = this.getHeader(firstMessage, 'Date');
           const occurredAt = dateHeader
@@ -382,15 +385,11 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
 
           if (Number.isNaN(occurredAt.getTime())) continue;
 
-          // Interaction signal for promote-on-signal (see the attribution rule's
-          // createWhen): the thread was STARTED by the counterparty (first
-          // message is not ours) and the mailbox owner sent at least one message
-          // in it. A SENT label marks a message the account owner authored, so
-          // this needs no knowledge of the owner's own address. Owner-started
-          // threads are deliberately NOT `replied` — their from_email is the
-          // owner's own address, which must never be promoted as a contact.
-          const isSent = (m: GmailMessage) => (m.labelIds ?? []).includes('SENT');
-          const replied = !isSent(firstMessage) && thread.messages.some(isSent);
+          // A bidirectional exchange has at least one mailbox-authored message
+          // and one counterparty-authored message, regardless of who started it.
+          // Attribute the event to the first counterparty message so an
+          // owner-started thread never promotes the mailbox owner's own address.
+          const replied = counterpartyMessage !== undefined && thread.messages.some(isSent);
 
           const event: EventEnvelope = {
             origin_id: thread.id,

--- a/packages/connectors/src/google_gmail.ts
+++ b/packages/connectors/src/google_gmail.ts
@@ -300,6 +300,7 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
   // -------------------------------------------------------------------------
 
   async sync(ctx: SyncContext): Promise<SyncResult> {
+    const syncStartedAt = new Date();
     const token = ctx.credentials?.accessToken;
     if (!token) {
       throw new Error('Gmail requires Google OAuth credentials.');
@@ -425,7 +426,8 @@ export default class GmailConnector extends ConnectorRuntime<GmailCheckpoint, Gm
     events.sort((a, b) => b.occurred_at.getTime() - a.occurred_at.getTime());
 
     const newCheckpoint: GmailCheckpoint = {
-      last_sync_at: new Date().toISOString(),
+      // Keep events that arrive while this sync is running inside the next window.
+      last_sync_at: syncStartedAt.toISOString(),
     };
 
     return {

--- a/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
+++ b/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
@@ -1,4 +1,5 @@
 import type { EntityIdentitySpec, EntityLinkPredicate, EntityTraitSpec, EventAttributionRule } from '@lobu/connector-sdk';
+import GmailConnector from '@lobu/connectors/google_gmail';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanupTestDatabase, getTestDb } from '../../__tests__/setup/test-db';
 import {
@@ -766,5 +767,118 @@ describe('applyEventAttributions', () => {
       WHERE organization_id = ${org.id} AND namespace = 'phone' AND identifier = '14155551111'
     `;
     expect(rows[0].count).toBe('0');
+  });
+});
+
+/**
+ * End-to-end promote-on-interaction (#1626) against the REAL Gmail connector
+ * rule — not a hand-built test rule — so a regression in the connector's
+ * declared gate (e.g. flipping autoCreate back on ungated) fails here, at the
+ * pipeline level where the raw-sender person flood would actually re-appear.
+ */
+describe('gmail promote-on-interaction (real connector rule)', () => {
+  const GMAIL_KEY = 'google.gmail';
+  const GMAIL_FEED = 'threads';
+
+  beforeEach(async () => {
+    await cleanupTestDatabase();
+    clearEntityLinkRulesCache();
+  });
+
+  async function setupGmailOrg() {
+    const { org, user } = await setupOrg('gmail promote org');
+    const sql = getTestDb();
+    // The gmail rule targets `person`; fresh test orgs only have `$member`.
+    await sql`
+      INSERT INTO entity_types (organization_id, slug, name, created_at, updated_at)
+      VALUES (${org.id}, 'person', 'Person', current_timestamp, current_timestamp)
+    `;
+    await createTestConnectorDefinition({
+      key: GMAIL_KEY,
+      name: 'Gmail',
+      organization_id: org.id,
+      feeds_schema: new GmailConnector().definition.feeds as Record<string, unknown>,
+    });
+    clearEntityLinkRulesCache();
+    return { org, user, sql };
+  }
+
+  const thread = (metadata: Record<string, unknown>) => ({
+    origin_type: 'thread',
+    metadata,
+  });
+
+  async function personRows(sql: ReturnType<typeof getTestDb>, orgId: string) {
+    return sql<{ name: string; metadata: { aliases?: string[] } }[]>`
+      SELECT e.name, e.metadata FROM entities e
+      JOIN entity_types et ON et.id = e.entity_type_id
+      WHERE e.organization_id = ${orgId} AND et.slug = 'person' AND e.deleted_at IS NULL
+      ORDER BY e.name
+    `;
+  }
+
+  it('promotes only replied-to counterparties: no raw-sender rows, bidirectional contact minted with metric aliases', async () => {
+    const { org, sql } = await setupGmailOrg();
+
+    await applyEventAttributions({
+      connectorKey: GMAIL_KEY,
+      feedKey: GMAIL_FEED,
+      orgId: org.id,
+      items: [
+        // Inbound-only brand blast — has a from_name, still must NOT mint.
+        thread({ from_email: 'promo@brand.example', from_name: 'Brand', replied: false }),
+        // Genuine bidirectional exchange — promotes.
+        thread({ from_email: 'alice@example.com', from_name: 'Alice', replied: true }),
+      ],
+    });
+
+    const people = await personRows(sql, org.id);
+    expect(people.map((p) => p.name)).toEqual(['Alice']);
+    // The promoted contact keeps participating in metrics: its email identifier
+    // is seeded into metadata.aliases (the metric compiler's resolution surface).
+    expect(people[0].metadata.aliases).toEqual(['alice@example.com']);
+
+    // The brand's identifier is not claimed by any entity.
+    const brandIdent = await sql<{ count: string }[]>`
+      SELECT COUNT(*)::text AS count FROM entity_identities
+      WHERE organization_id = ${org.id} AND namespace = 'email' AND identifier = 'promo@brand.example'
+    `;
+    expect(brandIdent[0].count).toBe('0');
+  });
+
+  it('promotion is idempotent: re-syncing the same replied thread never duplicates the contact', async () => {
+    const { org, sql } = await setupGmailOrg();
+    const items = [thread({ from_email: 'alice@example.com', from_name: 'Alice', replied: true })];
+
+    await applyEventAttributions({ connectorKey: GMAIL_KEY, feedKey: GMAIL_FEED, orgId: org.id, items });
+    await applyEventAttributions({ connectorKey: GMAIL_KEY, feedKey: GMAIL_FEED, orgId: org.id, items });
+
+    const people = await personRows(sql, org.id);
+    expect(people.map((p) => p.name)).toEqual(['Alice']);
+  });
+
+  it('an inbound-only thread from an already-promoted contact still links to it (match is never gated)', async () => {
+    const { org, sql } = await setupGmailOrg();
+
+    // Promote Alice via a replied thread, then receive an inbound-only one.
+    await applyEventAttributions({
+      connectorKey: GMAIL_KEY,
+      feedKey: GMAIL_FEED,
+      orgId: org.id,
+      items: [thread({ from_email: 'alice@example.com', from_name: 'Alice', replied: true })],
+    });
+    const later = thread({ from_email: 'alice@example.com', from_name: 'Alice', replied: false });
+    await applyEventAttributions({
+      connectorKey: GMAIL_KEY,
+      feedKey: GMAIL_FEED,
+      orgId: org.id,
+      items: [later],
+    });
+
+    // Still exactly one person, and the inbound event was stamped with the
+    // matched identity slot (the read-time JOIN key).
+    const people = await personRows(sql, org.id);
+    expect(people.map((p) => p.name)).toEqual(['Alice']);
+    expect((later.metadata as Record<string, unknown>).email).toBe('alice@example.com');
   });
 });


### PR DESCRIPTION
## What changed

- mark a Gmail thread as replied only when the counterparty started it and the mailbox owner later sent a message
- gate `person` auto-creation on that interaction signal while preserving identity matching for existing contacts
- use the sync start boundary for checkpoints so replies arriving during a sync are picked up next time
- add connector and database-pipeline coverage for inbound-only senders, promotion, matching, and idempotency

## Why

Receiving mail alone is not a strong contact signal: newsletters, brands, and no-reply senders otherwise pollute the entity model. A bidirectional exchange is the promote-on-signal threshold.

This is part of #1626. Cross-channel identity merging and legacy cleanup remain separate product decisions, so this PR does not close the umbrella issue.

## Validation

- `make pre-pr`
- `bun test ./packages/connectors/src/__tests__/google_gmail.test.ts` (4 passed)
- `node ../../node_modules/.bin/vitest run src/utils/__tests__/entity-link-upsert.test.ts` (16 passed)
- `REVIEWER_CLI=codex make review` (0 blockers; bug-free confidence 88)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->