### PR TITLE
Scope worker deployments by organization and agent

### DIFF
--- a/packages/agent-worker/src/gateway/sse-client.ts
+++ b/packages/agent-worker/src/gateway/sse-client.ts
@@ -514,13 +514,8 @@ export class GatewayClient {
       );
     }
 
-    // No per-user filtering here: deployment names intentionally hash only
-    // `platform:channelId:conversationId` (see `generateDeploymentName` in
-    // deployment-manager.ts) so a channel/thread has ONE shared worker
-    // across all posting users. DMs are single-participant, so a check would
-    // be dead there too. The WORKER_TOKEN-scoped-to-spawning-user tradeoff
-    // for shared channel workers is acknowledged and deferred to per-message
-    // JWT minting — gating here would break the core group-bot design.
+    // Deployment identity excludes the posting user so one agent's channel
+    // thread is handled by one shared worker.
 
     // Check job type and dispatch accordingly
     if (data.jobType === "exec") {

--- a/packages/server/src/gateway/__tests__/enqueue-model-gate.test.ts
+++ b/packages/server/src/gateway/__tests__/enqueue-model-gate.test.ts
@@ -34,6 +34,14 @@ const WARM_DEPLOYMENT_NAME = generateDeploymentName({
   agentId: "agent-1",
   organizationId: "org-1",
 });
+const SECOND_AGENT_DEPLOYMENT_NAME = generateDeploymentName({
+  userId: "user-1",
+  platform: "slack",
+  channelId: "chan-1",
+  conversationId: "conv-1",
+  agentId: "agent-2",
+  organizationId: "org-1",
+});
 
 process.env.ENCRYPTION_KEY ||=
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -88,6 +96,7 @@ function makeWarmDeploymentManager(
   return {
     listDeployments: mock(async () => [
       { deploymentName: WARM_DEPLOYMENT_NAME, status: "running" },
+      { deploymentName: SECOND_AGENT_DEPLOYMENT_NAME, status: "running" },
     ]),
     scaleDeployment: mock(async () => {}),
     updateDeploymentActivity: mock(async () => {}),
@@ -311,6 +320,52 @@ describe("#1: exact-model gate enforced at ENQUEUE time (covers warm/resumed)", 
       "organizationId is required for message routing"
     );
     expect(sends).toHaveLength(0);
+  });
+
+  test("a payload with no agentId is rejected before enqueue", async () => {
+    const { queue, sends } = makeCapturingQueue();
+    const consumer = new MessageConsumer(
+      makeConfig(),
+      makeWarmDeploymentManager(["openai/gpt-5"]),
+      queue,
+      recordValidInput
+    );
+
+    const payload = makePayload("openai/gpt-4o");
+    delete (payload as { agentId?: string }).agentId;
+    const dispatch = (
+      consumer as unknown as { handleMessage: (job: unknown) => Promise<void> }
+    ).handleMessage({ id: "1", data: payload });
+
+    await expect(dispatch).rejects.toThrow(
+      "agentId is required for message routing"
+    );
+    expect(sends).toHaveLength(0);
+  });
+
+  test("the same channel thread routes different agents to different worker queues", async () => {
+    const { queue, sends } = makeCapturingQueue();
+    const consumer = new MessageConsumer(
+      makeConfig(),
+      makeWarmDeploymentManager(null),
+      queue,
+      recordValidInput
+    );
+    const handleMessage = (
+      consumer as unknown as { handleMessage: (job: unknown) => Promise<void> }
+    ).handleMessage.bind(consumer);
+
+    await handleMessage({ id: "1", data: makePayload(undefined) });
+    await handleMessage({
+      id: "2",
+      data: { ...makePayload(undefined), messageId: "msg-2", agentId: "agent-2" },
+    });
+
+    expect(sends.map(({ name }) => name)).toEqual([
+      `thread_message_${WARM_DEPLOYMENT_NAME}`,
+      `thread_message_${SECOND_AGENT_DEPLOYMENT_NAME}`,
+    ]);
+    expect(sends[0]?.name).not.toBe(sends[1]?.name);
   });
 
   test("#4 ROUTABILITY: replacement picks the first non-sentinel ROUTABLE ref, not just non-sentinel", async () => {

--- a/packages/server/src/gateway/__tests__/enqueue-model-gate.test.ts
+++ b/packages/server/src/gateway/__tests__/enqueue-model-gate.test.ts
@@ -31,6 +31,8 @@ const WARM_DEPLOYMENT_NAME = generateDeploymentName({
   platform: "slack",
   channelId: "chan-1",
   conversationId: "conv-1",
+  agentId: "agent-1",
+  organizationId: "org-1",
 });
 
 process.env.ENCRYPTION_KEY ||=

--- a/packages/server/src/gateway/__tests__/orchestration-harden.test.ts
+++ b/packages/server/src/gateway/__tests__/orchestration-harden.test.ts
@@ -554,7 +554,13 @@ describe("maxDeployments concurrency limit", () => {
         mgr.createWorkerDeployment(
           "user-3",
           "c3",
-          makePayload({ agentId: "agentc", platform: "slack", conversationId: "c3", channelId: "ch3" })
+          makePayload({
+            agentId: "agentc",
+            organizationId: "testorg",
+            platform: "slack",
+            conversationId: "c3",
+            channelId: "ch3",
+          })
         )
       ).rejects.toThrow();
     } finally {
@@ -899,6 +905,8 @@ describe("generateDeploymentName / buildCanonicalConversationKey", () => {
       conversationId: "c1",
       channelId: "ch1",
       platform: "slack",
+      agentId: "a1",
+      organizationId: "org1",
     };
     const name1 = generateDeploymentName(identity);
     const name2 = generateDeploymentName(identity);
@@ -906,16 +914,54 @@ describe("generateDeploymentName / buildCanonicalConversationKey", () => {
   });
 
   test("different conversationIds produce different deployment names", () => {
-    const base = { userId: "u1", channelId: "ch1", platform: "slack" };
+    const base = {
+      userId: "u1",
+      channelId: "ch1",
+      platform: "slack",
+      agentId: "a1",
+      organizationId: "org1",
+    };
     const n1 = generateDeploymentName({ ...base, conversationId: "c1" });
     const n2 = generateDeploymentName({ ...base, conversationId: "c2" });
     expect(n1).not.toBe(n2);
   });
 
   test("different platforms produce different deployment names", () => {
-    const base = { userId: "u1", channelId: "ch1", conversationId: "c1" };
+    const base = {
+      userId: "u1",
+      channelId: "ch1",
+      conversationId: "c1",
+      agentId: "a1",
+      organizationId: "org1",
+    };
     const n1 = generateDeploymentName({ ...base, platform: "slack" });
     const n2 = generateDeploymentName({ ...base, platform: "telegram" });
+    expect(n1).not.toBe(n2);
+  });
+
+  test("different agentIds in the same channel/thread produce different deployment names", () => {
+    const base = {
+      userId: "u1",
+      channelId: "ch1",
+      conversationId: "c1",
+      platform: "slack",
+      organizationId: "org1",
+    };
+    const n1 = generateDeploymentName({ ...base, agentId: "agent-a" });
+    const n2 = generateDeploymentName({ ...base, agentId: "agent-b" });
+    expect(n1).not.toBe(n2);
+  });
+
+  test("different organizationIds produce different deployment names", () => {
+    const base = {
+      userId: "u1",
+      channelId: "ch1",
+      conversationId: "c1",
+      platform: "slack",
+      agentId: "agent-a",
+    };
+    const n1 = generateDeploymentName({ ...base, organizationId: "org1" });
+    const n2 = generateDeploymentName({ ...base, organizationId: "org2" });
     expect(n1).not.toBe(n2);
   });
 
@@ -925,6 +971,8 @@ describe("generateDeploymentName / buildCanonicalConversationKey", () => {
       conversationId: "c1",
       channelId: "ch1",
       platform: "slack",
+      agentId: "a1",
+      organizationId: "org1",
     });
     expect(/^[a-z0-9-]+$/.test(name)).toBe(true);
   });
@@ -934,21 +982,29 @@ describe("generateDeploymentName / buildCanonicalConversationKey", () => {
       conversationId: "conv",
       channelId: "ch",
       platform: "slack",
+      agentId: "a1",
+      organizationId: "org1",
     });
-    expect(key).toBe("slack:ch:conv");
+    expect(key).toBe("org1:a1:slack:ch:conv");
   });
 
   test("buildCanonicalConversationKey without platform falls back to channelId", () => {
     const key = buildCanonicalConversationKey({
       conversationId: "conv",
       channelId: "ch",
+      agentId: "a1",
+      organizationId: "org1",
     });
-    expect(key).toBe("ch:conv");
+    expect(key).toBe("org1:a1:ch:conv");
   });
 
   test("buildCanonicalConversationKey without channelId falls back to conversationId", () => {
-    const key = buildCanonicalConversationKey({ conversationId: "conv" });
-    expect(key).toBe("conv");
+    const key = buildCanonicalConversationKey({
+      conversationId: "conv",
+      agentId: "a1",
+      organizationId: "org1",
+    });
+    expect(key).toBe("org1:a1:conv");
   });
 });
 

--- a/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { encrypt } from "@lobu/core";
 
 const TEST_ENCRYPTION_KEY = Buffer.from(
@@ -206,17 +198,5 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
     ];
     const mod = makeModule(false);
     expect(await mod.hasCredentials("agent-1")).toBe(false);
-  });
-
-  // `mock.module("../../../db/client.js", ...)` above replaces the module for
-  // the rest of this bun:test process — Bun has no per-file module isolation,
-  // and CI runs every file in this __tests__ dir in one process (ci.yml).
-  // Without this reset, the last test's non-empty `inferenceProviderRows`
-  // leaks into every later file's `getDb()` calls in the same process; e.g.
-  // api-auth-middleware.test.ts's revoked-token-store lookup would see those
-  // stale rows as `SELECT jti FROM revoked_tokens ...` results and treat a
-  // fresh token's jti as revoked, turning a 200 into a 401.
-  afterAll(() => {
-    inferenceProviderRows = [];
   });
 });

--- a/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { encrypt } from "@lobu/core";
 
 const TEST_ENCRYPTION_KEY = Buffer.from(
@@ -198,5 +206,17 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
     ];
     const mod = makeModule(false);
     expect(await mod.hasCredentials("agent-1")).toBe(false);
+  });
+
+  // `mock.module("../../../db/client.js", ...)` above replaces the module for
+  // the rest of this bun:test process — Bun has no per-file module isolation,
+  // and CI runs every file in this __tests__ dir in one process (ci.yml).
+  // Without this reset, the last test's non-empty `inferenceProviderRows`
+  // leaks into every later file's `getDb()` calls in the same process; e.g.
+  // api-auth-middleware.test.ts's revoked-token-store lookup would see those
+  // stale rows as `SELECT jti FROM revoked_tokens ...` results and treat a
+  // fresh token's jti as revoked, turning a 200 into a 401.
+  afterAll(() => {
+    inferenceProviderRows = [];
   });
 });

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -709,23 +709,27 @@ interface DeploymentIdentity {
   channelId?: string;
   platform?: string;
   userId?: string;
+  agentId: string;
+  organizationId: string;
 }
 
 /**
  * Build a canonical conversation identity key for runtime routing.
- * Preferred format: platform:channelId:conversationId
+ * Preferred format: organizationId:agentId:platform:channelId:conversationId
  */
 export function buildCanonicalConversationKey(
   identity: DeploymentIdentity
 ): string {
-  const { conversationId, channelId, platform } = identity;
+  const { organizationId, agentId, conversationId, channelId, platform } =
+    identity;
+  const scope = `${organizationId}:${agentId}`;
   if (platform && channelId) {
-    return `${platform}:${channelId}:${conversationId}`;
+    return `${scope}:${platform}:${channelId}:${conversationId}`;
   }
   if (channelId) {
-    return `${channelId}:${conversationId}`;
+    return `${scope}:${channelId}:${conversationId}`;
   }
-  return conversationId;
+  return `${scope}:${conversationId}`;
 }
 
 /**
@@ -962,11 +966,21 @@ export class DeploymentManager {
     messageData?: MessagePayload,
     existingDeployments?: DeploymentInfo[]
   ): Promise<void> {
+    const agentId = messageData?.agentId;
+    const organizationId = messageData?.organizationId;
+    if (!agentId || !organizationId) {
+      throw new OrchestratorError(
+        ErrorCode.DEPLOYMENT_CREATE_FAILED,
+        "Missing agentId or organizationId in message payload"
+      );
+    }
     const deploymentIdentity: DeploymentIdentity = {
       userId,
       conversationId,
       channelId: messageData?.channelId,
       platform: messageData?.platform,
+      agentId,
+      organizationId,
     };
     const deploymentName = generateDeploymentName(deploymentIdentity);
     const canonicalConversationKey =

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -383,11 +383,15 @@ export class MessageConsumer {
       }
 
       const canonicalConversationKey = buildCanonicalConversationKey({
+        organizationId: data.organizationId,
+        agentId: data.agentId,
         platform: data.platform,
         channelId: data.channelId,
         conversationId: effectiveConversationId,
       });
       const deploymentName = generateDeploymentName({
+        organizationId: data.organizationId,
+        agentId: data.agentId,
         userId: data.userId,
         platform: data.platform,
         channelId: data.channelId,

--- a/packages/server/src/gateway/orchestration/message-consumer.ts
+++ b/packages/server/src/gateway/orchestration/message-consumer.ts
@@ -351,6 +351,15 @@ export class MessageConsumer {
         );
       }
 
+      if (!data.agentId) {
+        throw new OrchestratorError(
+          ErrorCode.QUEUE_JOB_PROCESSING_FAILED,
+          "agentId is required for message routing",
+          { jobId, messageId: data.messageId },
+          false
+        );
+      }
+
       // CRITICAL: For consistent worker naming, conversationId must be the root conversation ID
       // (e.g., Slack thread root ts), not individual message timestamps.
       const effectiveConversationId = data.conversationId;


### PR DESCRIPTION
## What changed

- Include organization and agent identity in canonical conversation keys and worker deployment names.
- Require both tenant identifiers when creating worker deployments.
- Update the worker routing comment and affected tests.

## Why

Two agents can be active in the same channel/thread. The previous deployment key used only platform, channel, and conversation, allowing those agents to resolve to the same worker process and workspace. Scoping the key by organization and agent keeps worker state isolated.

Closes #1949.

## Rollout impact

This intentionally re-keys every local worker deployment. Existing live conversations will cold-start once after deployment under their new organization-and-agent-scoped name. Pending work follows the existing worker-restart/turn-liveness recovery path; no persistent data migration is required.

## Validation

- Red→green coverage for agent and organization isolation
- `bun test packages/server/src/gateway/__tests__/orchestration-harden.test.ts packages/server/src/gateway/__tests__/enqueue-model-gate.test.ts` (66 pass, 2 platform skips)
- Full gateway test suite (passed before the final review cleanup)
- `make clean-workers`
- `make pre-pr`
- `REVIEWER_CLI=codex make review` (bug_free 94, simplicity 96, 0 bugs, 0 blockers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation routing to consistently isolate processing by workspace and agent.
  * Ensured channel threads are handled by the appropriate shared worker.
  * Added validation to prevent deployments from starting when required identity information is missing.
  * Strengthened deployment capacity and model-eligibility safeguards, including safer failure behavior when limits are reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->