### PR TITLE
test(bang-bash): close follow-up coverage gaps

### DIFF
--- a/packages/agent-worker/src/__tests__/bang-bash-session.test.ts
+++ b/packages/agent-worker/src/__tests__/bang-bash-session.test.ts
@@ -117,21 +117,13 @@ describe("persistBangBashSession", () => {
   });
 
   test("no header yet → writes nothing (blocked-preflight on a virgin manager)", async () => {
-    const sessionManager = SessionManager.create(
-      tempDir,
-      join(tempDir, "sessions-virgin")
-    );
-    const sessionFile = sessionManager.getSessionFile();
-    if (sessionManager.getHeader() === null) {
-      await persistBangBashSession(sessionManager, sessionFile);
-      expect(existsSync(sessionFile)).toBe(false);
-    } else {
-      // pi mints the header at create() in this version — the guard is then
-      // unreachable and persisting a branch-less session must still round-trip.
-      await persistBangBashSession(sessionManager, sessionFile);
-      const reopened = SessionManager.open(sessionFile);
-      expect(reopened.getHeader()?.id).toBe(sessionManager.getHeader()?.id);
-    }
+    const sessionManager = {
+      getHeader: () => null,
+    } as unknown as SessionManager;
+    const sessionFile = join(tempDir, "missing-header.jsonl");
+
+    await persistBangBashSession(sessionManager, sessionFile);
+    expect(existsSync(sessionFile)).toBe(false);
   });
 });
 

--- a/packages/agent-worker/src/__tests__/bang-bash-session.test.ts
+++ b/packages/agent-worker/src/__tests__/bang-bash-session.test.ts
@@ -1,0 +1,243 @@
+/**
+ * `!`-bash session-persistence contracts and the remote-backend composition
+ * (issue #1989, PR-D4 follow-ups).
+ *
+ * - `persistBangBashSession` must be BYTE-idempotent: a same-run retry rewrites
+ *   the file with identical bytes, or the gateway's monotonic-prefix snapshot
+ *   guard 409s and wedges the run. Idempotency is by construction (stable
+ *   header + verbatim branch, never `exportToJsonl()`'s fresh timestamp) —
+ *   these tests lock it in.
+ * - `normalizeHydratedSessionFile` must truncate an assistant-less hydrated
+ *   file (pi re-appends the whole branch on the next assistant flush, which
+ *   would double the `session` header mid-file) and leave a normal session
+ *   untouched.
+ * - The `!` intercept drives `session.executeBash(cmd, undefined,
+ *   { operations, excludeFromContext })`. The remote-provider test composes
+ *   that exact call shape with the generic runtime ops (fetch-mocked gateway),
+ *   covering the `runtimeProviderId` backend path the sdk-e2e can't reach
+ *   without live sandbox credentials.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import * as fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type BashOperations,
+  SessionManager,
+} from "@mariozechner/pi-coding-agent";
+import { getWorkerRuntimeProvider } from "../embedded/runtime/index";
+import {
+  buildAgentSession,
+  normalizeHydratedSessionFile,
+  persistBangBashSession,
+} from "../runtime/session-runner";
+
+let tempDir: string;
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "bang-bash-session-"));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+  globalThis.fetch = originalFetch;
+  mock.restore();
+});
+
+/**
+ * The header timestamp has millisecond precision, and a same-run retry in prod
+ * comes seconds later. Without crossing a millisecond boundary between writes,
+ * a regenerated-timestamp regression (the exact `exportToJsonl()` bug the
+ * helper exists to avoid) would serialize identical bytes and slip through.
+ */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 3));
+}
+
+const localOps: BashOperations = {
+  exec: async (...args) => {
+    args[2].onData(Buffer.from("bang-output\n"));
+    return { exitCode: 0 };
+  },
+};
+
+/** A real pi session backed by a real on-disk session file, like the worker's. */
+async function makeSession() {
+  const sessionManager = SessionManager.create(
+    tempDir,
+    join(tempDir, "sessions")
+  );
+  const { session } = await buildAgentSession({
+    cwd: tempDir,
+    sessionManager,
+    customTools: [],
+  });
+  return {
+    session,
+    sessionManager,
+    sessionFile: sessionManager.getSessionFile(),
+  };
+}
+
+describe("persistBangBashSession", () => {
+  test("same-run retry is byte-idempotent, and the file round-trips", async () => {
+    const { session, sessionManager, sessionFile } = await makeSession();
+    await session.executeBash("echo bang", undefined, {
+      operations: localOps,
+    });
+
+    await persistBangBashSession(sessionManager, sessionFile);
+    const first = await fs.readFile(sessionFile);
+    expect(first.length).toBeGreaterThan(0);
+
+    await tick();
+    await persistBangBashSession(sessionManager, sessionFile);
+    const second = await fs.readFile(sessionFile);
+    expect(second.equals(first)).toBe(true);
+
+    // The written bytes are exactly what SessionManager.open() expects on the
+    // next hydrate: same header id, same branch entry ids, record intact.
+    const reopened = SessionManager.open(sessionFile);
+    expect(reopened.getHeader()?.id).toBe(sessionManager.getHeader()?.id);
+    expect(reopened.getBranch().map((e) => e.id)).toEqual(
+      sessionManager.getBranch().map((e) => e.id)
+    );
+
+    // A retry AFTER a rehydrate must also be byte-identical — the header and
+    // entries must survive open() verbatim (no regenerated timestamps).
+    await tick();
+    await persistBangBashSession(reopened, sessionFile);
+    const third = await fs.readFile(sessionFile);
+    expect(third.equals(first)).toBe(true);
+
+    session.dispose();
+  });
+
+  test("no header yet → writes nothing (blocked-preflight on a virgin manager)", async () => {
+    const sessionManager = SessionManager.create(
+      tempDir,
+      join(tempDir, "sessions-virgin")
+    );
+    const sessionFile = sessionManager.getSessionFile();
+    if (sessionManager.getHeader() === null) {
+      await persistBangBashSession(sessionManager, sessionFile);
+      expect(existsSync(sessionFile)).toBe(false);
+    } else {
+      // pi mints the header at create() in this version — the guard is then
+      // unreachable and persisting a branch-less session must still round-trip.
+      await persistBangBashSession(sessionManager, sessionFile);
+      const reopened = SessionManager.open(sessionFile);
+      expect(reopened.getHeader()?.id).toBe(sessionManager.getHeader()?.id);
+    }
+  });
+});
+
+describe("normalizeHydratedSessionFile", () => {
+  test("assistant-less session → file truncated so pi's re-append can't double the header", async () => {
+    const { session, sessionManager, sessionFile } = await makeSession();
+    await session.executeBash("echo bang", undefined, {
+      operations: localOps,
+    });
+    await persistBangBashSession(sessionManager, sessionFile);
+    expect((await fs.readFile(sessionFile)).length).toBeGreaterThan(0);
+
+    await normalizeHydratedSessionFile(sessionManager, sessionFile);
+    expect((await fs.readFile(sessionFile)).length).toBe(0);
+
+    session.dispose();
+  });
+
+  test("session WITH an assistant message → file left untouched", async () => {
+    const { session, sessionManager, sessionFile } = await makeSession();
+    await session.executeBash("echo bang", undefined, {
+      operations: localOps,
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "done" }],
+      timestamp: Date.now(),
+    } as never);
+    await persistBangBashSession(sessionManager, sessionFile);
+    const before = await fs.readFile(sessionFile);
+
+    await normalizeHydratedSessionFile(sessionManager, sessionFile);
+    const after = await fs.readFile(sessionFile);
+    expect(after.equals(before)).toBe(true);
+
+    session.dispose();
+  });
+
+  test("missing file (fresh conversation) → no throw", async () => {
+    const { session, sessionManager } = await makeSession();
+    await normalizeHydratedSessionFile(
+      sessionManager,
+      join(tempDir, "does-not-exist.jsonl")
+    );
+    session.dispose();
+  });
+});
+
+describe("`!` intercept call shape against the remote runtime backend", () => {
+  test("executeBash with provider ops + excludeFromContext hits the gateway and records the flagged entry", async () => {
+    const fetchMock = mock(async () =>
+      Response.json({ stdout: "remote-ok\n", stderr: "", exitCode: 0 })
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const provider = getWorkerRuntimeProvider("vercel");
+    if (!provider) throw new Error("vercel provider not registered");
+    const remoteOps = provider.createBashOps({
+      gw: {
+        gatewayUrl: "http://127.0.0.1:8787/lobu/",
+        workerToken: "worker-token",
+        channelId: "chan",
+        conversationId: "conv",
+        workspaceDir: "/workspace/conv",
+      },
+    });
+
+    const { session, sessionManager, sessionFile } = await makeSession();
+    // The exact call the `!!` intercept makes (session-runner's bangBash path).
+    const result = await session.executeBash("echo remote", undefined, {
+      operations: remoteOps,
+      excludeFromContext: true,
+    });
+
+    expect(result.cancelled).toBeFalsy();
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("remote-ok");
+
+    // The command went to the gateway's generic runtime route with the worker
+    // bearer token — not to a local shell.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:8787/lobu/internal/runtime/exec");
+    expect((init.headers as Record<string, string>).authorization).toBe(
+      "Bearer worker-token"
+    );
+    expect(JSON.parse(String(init.body)).command).toBe("echo remote");
+
+    // pi recorded the bashExecution entry carrying excludeFromContext, and the
+    // force-flush is byte-idempotent on a remote-backed record too.
+    const entry = sessionManager
+      .getBranch()
+      .find((e) => e.type === "message" && e.message.role === "bashExecution");
+    if (!entry || entry.type !== "message") {
+      throw new Error("no bashExecution entry recorded");
+    }
+    expect(
+      (entry.message as { excludeFromContext?: boolean }).excludeFromContext
+    ).toBe(true);
+
+    await persistBangBashSession(sessionManager, sessionFile);
+    const first = await fs.readFile(sessionFile);
+    await tick();
+    await persistBangBashSession(sessionManager, sessionFile);
+    expect((await fs.readFile(sessionFile)).equals(first)).toBe(true);
+
+    session.dispose();
+  });
+});

--- a/packages/agent-worker/src/runtime/session-runner.ts
+++ b/packages/agent-worker/src/runtime/session-runner.ts
@@ -555,7 +555,7 @@ function readBangBashCommand(
  * re-flush rewrites the whole branch exactly once. A normal session (has an
  * assistant) is left untouched: pi appends incrementally and never re-flushes.
  */
-async function normalizeHydratedSessionFile(
+export async function normalizeHydratedSessionFile(
   sessionManager: SessionManager,
   sessionFile: string
 ): Promise<void> {
@@ -585,7 +585,7 @@ async function normalizeHydratedSessionFile(
  * verbatim (stable ids/parentIds — the session is linear here), so re-running the
  * same turn yields byte-identical output and the snapshot upsert is idempotent.
  */
-async function persistBangBashSession(
+export async function persistBangBashSession(
   sessionManager: SessionManager,
   sessionFile: string
 ): Promise<void> {

--- a/scripts/sdk-e2e.sh
+++ b/scripts/sdk-e2e.sh
@@ -530,13 +530,17 @@ for _ in $(seq 1 30); do
 done
 [ "$EXCL_REQS_AFTER" -gt "$EXCL_REQS_BEFORE" ] || fail "!!-bash follow-up turn never produced a model request (nothing to assert exclusion against)"
 # Negative: the excluded marker must not reach the model in ANY later request.
-if tail -n "+$((EXCL_REQS_BEFORE + 1))" "$MOCK_REQLOG" | grep -q "$EXCL_MARKER"; then
+if awk -v start="$((EXCL_REQS_BEFORE + 1))" -v marker="$EXCL_MARKER" \
+  'NR >= start && index($0, marker) { found=1 } END { exit !found }' \
+  "$MOCK_REQLOG"; then
   fail "!!-bash: excluded marker '$EXCL_MARKER' leaked into a later model request (excludeFromContext broken)"
 fi
 # Positive control: the PLAIN-`!` marker from 5d must be IN that same request —
 # unexcluded bashExecution records do flow into model context. Without this the
 # negative assert would pass vacuously if bash records never reached context.
-tail -n "+$((EXCL_REQS_BEFORE + 1))" "$MOCK_REQLOG" | grep -q "$BANG_MARKER" \
+awk -v start="$((EXCL_REQS_BEFORE + 1))" -v marker="$BANG_MARKER" \
+  'NR >= start && index($0, marker) { found=1 } END { exit !found }' \
+  "$MOCK_REQLOG" \
   || fail "!!-bash positive control: plain-\`!\` marker '$BANG_MARKER' missing from the later model request — bash records aren't reaching context, absence assert is vacuous"
 echo "✓ !!-bash: record visible in transcript, absent from later model context (plain-! record present — control non-vacuous)"
 

--- a/scripts/sdk-e2e.sh
+++ b/scripts/sdk-e2e.sh
@@ -64,8 +64,11 @@ if [ -z "${DATABASE_URL:-}" ]; then
   node "$HARNESS/fix-embedded-pg-icu.mjs" || fail "could not prepare embedded-postgres ICU symlinks"
 fi
 
-# 1) Mock OpenAI-compatible provider.
-MOCK_PORT="$MOCK_PORT" MOCK_REPLY="$MOCK_REPLY" node "$HARNESS/mock-openai.mjs" > "$MOCK_LOG" 2>&1 &
+# 1) Mock OpenAI-compatible provider. MOCK_REQLOG captures every
+#    /chat/completions request body (JSONL) so gates can assert on what
+#    actually reached the model (step 5d.4's `!!` context-exclusion proof).
+MOCK_REQLOG="$RUN_DIR/model-requests.jsonl"
+MOCK_PORT="$MOCK_PORT" MOCK_REPLY="$MOCK_REPLY" MOCK_REQLOG="$MOCK_REQLOG" node "$HARNESS/mock-openai.mjs" > "$MOCK_LOG" 2>&1 &
 MOCK_PID=$!
 disown "$MOCK_PID" 2>/dev/null || true  # silence job-control "Killed" on cleanup
 for _ in $(seq 1 20); do
@@ -483,6 +486,59 @@ done
 UPSTREAM_BLK_AFTER=$(grep -c "Forwarding to upstream: POST http://127.0.0.1:$MOCK_PORT" "$RUN_LOG" 2>/dev/null || echo 0)
 [ "$UPSTREAM_BLK_AFTER" -eq "$UPSTREAM_BLK_BEFORE" ] || fail "!-bash blocked hit the model provider; a blocked \`!\` must still skip the LLM"
 echo "✓ !-bash: a preflight-blocked \`!\` on a fresh conversation completes cleanly (no checkpoint failure) and skips the LLM"
+
+# 5d.4) `!!` context exclusion. The excludeFromContext flag must keep the `!!`
+#       command AND its output out of every LATER model request, while the
+#       plain-`!` record from 5d DOES flow into context. The exclusion itself
+#       is implemented inside pi when it assembles the next turn's context, so
+#       this is the ONLY lobu-side proof the flag works end-to-end — no unit
+#       test can see it. Asserts against $MOCK_REQLOG (every /chat/completions
+#       body, JSONL). Reuses the bang-e2e thread, which already holds
+#       `!echo $BANG_MARKER` plus an assistant turn.
+EXCL_MARKER="excl_kept_out_$$_$RANDOM"
+UPSTREAM_EXCL_BEFORE=$(grep -c "Forwarding to upstream: POST http://127.0.0.1:$MOCK_PORT" "$RUN_LOG" 2>/dev/null || echo 0)
+curl -fsS -X POST "$GW/lobu/api/v1/agents/$BANG_CONV/messages" \
+  -H "authorization: Bearer $DEVTOKEN" -H 'content-type: application/json' \
+  -d "{\"content\":\"!!echo $EXCL_MARKER\"}" > "$RUN_DIR/bang-excl-send.json" \
+  || { cat "$RUN_DIR/bang-excl-send.json" >&2; fail "!!-bash: POST failed"; }
+[ "$(jget queued < "$RUN_DIR/bang-excl-send.json")" = "true" ] || { cat "$RUN_DIR/bang-excl-send.json" >&2; fail "!!-bash message was not queued"; }
+# The `!!` record must still be VISIBLE in the durable transcript — it is
+# excluded from model context only, never from the user.
+EXCL_OK=""
+for _ in $(seq 1 30); do
+  curl -fsS "$GW/lobu/api/v1/agents/echo/history/threads/bang-e2e/messages?limit=100" \
+    -H "authorization: Bearer $DEVTOKEN" > "$BANG_HIST" 2>/dev/null || { sleep 1; continue; }
+  if node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{let j;try{j=JSON.parse(s)}catch{process.exit(1)}const m=(j.messages||[]).find(x=>x.type==="bashExecution"&&JSON.stringify(x.content||"").includes(process.argv[1]));process.exit(m?0:1)})' "$EXCL_MARKER" < "$BANG_HIST"; then
+    EXCL_OK=1; break
+  fi
+  sleep 1
+done
+[ -n "$EXCL_OK" ] || { tail -c 400 "$BANG_HIST" >&2; fail "!!-bash: no visible bashExecution entry carrying '$EXCL_MARKER' (\`!!\` must hide from the model, not the transcript)"; }
+UPSTREAM_EXCL_AFTER=$(grep -c "Forwarding to upstream: POST http://127.0.0.1:$MOCK_PORT" "$RUN_LOG" 2>/dev/null || echo 0)
+[ "$UPSTREAM_EXCL_AFTER" -eq "$UPSTREAM_EXCL_BEFORE" ] || fail "!!-bash hit the model provider; a \`!!\` turn must skip the LLM"
+# Scope the request-body asserts to model requests made AFTER the `!!` turn.
+EXCL_REQS_BEFORE=$(awk 'END { print NR }' "$MOCK_REQLOG" 2>/dev/null || echo 0)
+curl -fsS -X POST "$GW/lobu/api/v1/agents/$BANG_CONV/messages" \
+  -H "authorization: Bearer $DEVTOKEN" -H 'content-type: application/json' \
+  -d '{"content":"after the double bang"}' > "$RUN_DIR/bang-excl-followup.json" \
+  || { cat "$RUN_DIR/bang-excl-followup.json" >&2; fail "!!-bash follow-up: POST failed"; }
+EXCL_REQS_AFTER="$EXCL_REQS_BEFORE"
+for _ in $(seq 1 30); do
+  EXCL_REQS_AFTER=$(awk 'END { print NR }' "$MOCK_REQLOG" 2>/dev/null || echo 0)
+  [ "$EXCL_REQS_AFTER" -gt "$EXCL_REQS_BEFORE" ] && break
+  sleep 1
+done
+[ "$EXCL_REQS_AFTER" -gt "$EXCL_REQS_BEFORE" ] || fail "!!-bash follow-up turn never produced a model request (nothing to assert exclusion against)"
+# Negative: the excluded marker must not reach the model in ANY later request.
+if tail -n "+$((EXCL_REQS_BEFORE + 1))" "$MOCK_REQLOG" | grep -q "$EXCL_MARKER"; then
+  fail "!!-bash: excluded marker '$EXCL_MARKER' leaked into a later model request (excludeFromContext broken)"
+fi
+# Positive control: the PLAIN-`!` marker from 5d must be IN that same request —
+# unexcluded bashExecution records do flow into model context. Without this the
+# negative assert would pass vacuously if bash records never reached context.
+tail -n "+$((EXCL_REQS_BEFORE + 1))" "$MOCK_REQLOG" | grep -q "$BANG_MARKER" \
+  || fail "!!-bash positive control: plain-\`!\` marker '$BANG_MARKER' missing from the later model request — bash records aren't reaching context, absence assert is vacuous"
+echo "✓ !!-bash: record visible in transcript, absent from later model context (plain-! record present — control non-vacuous)"
 
 # 6) Connector sync — prove the COMPILED connector actually RUNS and emits events.
 #    Find the feed manage_feeds created from the `pulse` connection, trigger an

--- a/scripts/sdk-e2e/mock-openai.mjs
+++ b/scripts/sdk-e2e/mock-openai.mjs
@@ -1,6 +1,12 @@
+import { appendFileSync } from "node:fs";
 import { createServer } from "node:http";
+
 const PORT = Number(process.env.MOCK_PORT || 11434);
 const REPLY = process.env.MOCK_REPLY || "PONG";
+// MOCK_REQLOG=<path> appends each /chat/completions request body as one JSONL
+// line, so a gate can assert on what actually reached the model (e.g. that a
+// `!!cmd` marker is ABSENT from later context). Opt-in: unset → no capture.
+const REQLOG = process.env.MOCK_REQLOG || "";
 // MOCK_MODE=quota-429 makes /chat/completions answer with z.ai's exact
 // production 429 body so the error-taxonomy e2e can drive a real provider
 // quota failure through the whole worker→gateway→renderer chain. `/models`
@@ -26,6 +32,12 @@ const server = createServer((req, res) => {
       return;
     }
     if (url.includes("/chat/completions")) {
+      if (REQLOG) {
+        // One line per request, verbatim body. `body` is already a complete
+        // string here (the `end` handler), and appendFileSync keeps lines
+        // whole under concurrent requests.
+        appendFileSync(REQLOG, `${JSON.stringify({ url, body })}\n`);
+      }
       if (MODE === "quota-429") {
         // z.ai's real 429 carries the reset time in the BODY text (not a
         // Retry-After header). The error e2e parses that out of the raw string


### PR DESCRIPTION
Closes the test-coverage follow-ups from #1989:

- assert `!!` command/output stays out of later model context, with a plain-`!` positive control
- lock `persistBangBashSession` byte-idempotency and hydration normalization
- cover the remote runtime-provider bash composition

Validation:
- `bun test packages/agent-worker` (700 pass)
- targeted bang-bash session suite (6 pass)
- `make test-e2e-sdk`
- `make pre-pr`
- `make review-fix`
- independent review: 0 bugs; environmental-only blocker because its read-only sandbox denied test temp-directory creation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved persistence and recovery for shell sessions, preventing duplicate session headers and preserving consistent session files.
  - Ensured shell commands excluded from context remain available in durable transcripts without being sent to subsequent model requests.

- **Tests**
  - Added coverage for session hydration, persistence idempotency, remote shell execution, and context-exclusion behavior.
  - Expanded end-to-end validation for shell command visibility and model context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->