### PR TITLE
chore: replace status field with is_active boolean on asset schema

### DIFF
--- a/examples/personal-agent/lobu.config.ts
+++ b/examples/personal-agent/lobu.config.ts
@@ -226,10 +226,11 @@ const asset = defineEntityType({
   required: ["category"],
   properties: {
     value: { type: "number", description: "Current value or balance" },
-    status: {
-      type: "string",
-      enum: ["active", "sold", "closed"],
-      description: "Current status",
+    is_active: {
+      type: "boolean",
+      description: "Whether you currently own this asset",
+      "x-table-column": true,
+      "x-table-label": "Active",
     },
     category: {
       type: "string",


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asset records now use an **Active** indicator to show whether they are currently active.

* **Updates**
  * Replaced the previous multi-state status values with a simple active/inactive setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->