### PR TITLE
Fix watcher conversation approval history

### DIFF
--- a/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
+++ b/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../gateway/services/agent-thread-list";
 import { buildApiConversationId } from "../../gateway/services/api-conversation-id";
 import { readWatcherRunThreads } from "../../gateway/services/watcher-run-thread";
+import { insertEvent } from "../../utils/insert-event";
 import { cleanupTestDatabase, getTestDb } from "../setup/test-db";
 import {
 	createTestAgent,
@@ -157,6 +158,30 @@ describe("listAgentThreads scope=all", () => {
 			"watcher run output",
 			"2026-06-28T00:30:00Z",
 		);
+		const [approvalRun] = await sql<{ id: number }[]>`
+			INSERT INTO runs
+			  (run_type, status, organization_id, watcher_id, approval_status, action_key, created_at)
+			VALUES
+			  ('internal', 'pending', ${org}, ${WATCHER_ID}, 'pending', 'entity_field_change', now())
+			RETURNING id`;
+		await insertEvent({
+			entityIds: [],
+			organizationId: org,
+			originId: `watcher-approval-${approvalRun.id}`,
+			title: "Approve watcher change",
+			content: "A watcher proposed changing a contact.",
+			semanticType: "operation",
+			runId: approvalRun.id,
+			interactionType: "approval",
+			interactionStatus: "pending",
+			metadata: {
+				action: "update",
+				tool: "entity_field_change",
+				resourceKind: "entity",
+				fields: { email: "new@example.com" },
+				attribution: "watcher",
+			},
+		});
 	});
 
 	afterAll(async () => {
@@ -239,5 +264,14 @@ describe("listAgentThreads scope=all", () => {
 		expect(JSON.stringify(data.runs[0]?.messages)).toContain(
 			"watcher run output",
 		);
+		expect(data.interactions).toEqual([
+			expect.objectContaining({
+				type: "tool-approval",
+				action: "update",
+				fields: { email: "new@example.com" },
+				attribution: "watcher",
+				resourceKind: "entity",
+			}),
+		]);
 	});
 });

--- a/packages/server/src/gateway/services/watcher-run-thread.ts
+++ b/packages/server/src/gateway/services/watcher-run-thread.ts
@@ -23,6 +23,16 @@ export async function readWatcherRunThreads(args: {
 		completedAt: string;
 		messages: ReturnType<typeof paginateSessionMessages>["messages"];
 	}>;
+	interactions: Array<{
+		type: "tool-approval";
+		runId: number;
+		action: string | null;
+		proposal: Record<string, unknown> | null;
+		current: Record<string, unknown> | null;
+		fields: Record<string, unknown> | null;
+		attribution: string | null;
+		resourceKind: string | null;
+	}>;
 }> {
 	const { agentId, watcherId, organizationId, limit } = args;
 	// `{agentId}_watcher_{watcherId}` — the org-less prefix the worker wrote.
@@ -65,5 +75,69 @@ export async function readWatcherRunThreads(args: {
 		};
 	});
 
-	return { runs };
+	// Approval cards are durable events rather than transcript JSONL parts. A
+	// pending approval may also belong to a run that has no completed snapshot,
+	// so fetch it independently and let the client append it to the conversation.
+	const approvalRows = await sql<{
+		run_id: number;
+		action: string | null;
+		proposal: Record<string, unknown> | null;
+		current: Record<string, unknown> | null;
+		fields: Record<string, unknown> | null;
+		attribution: string | null;
+		resource_kind: string | null;
+		tool: string | null;
+	}>`
+		SELECT e.run_id,
+		       e.metadata->>'action' AS action,
+		       e.metadata->'proposal' AS proposal,
+		       e.metadata->'current' AS current,
+		       e.metadata->'fields' AS fields,
+		       e.metadata->>'attribution' AS attribution,
+		       e.metadata->>'resourceKind' AS resource_kind,
+		       e.metadata->>'tool' AS tool
+		FROM current_event_records e
+		JOIN runs r ON r.id = e.run_id
+		JOIN watchers w
+		  ON w.id = r.watcher_id
+		 AND w.organization_id = r.organization_id
+		WHERE e.organization_id = ${organizationId}
+		  AND w.agent_id = ${agentId}
+		  AND r.watcher_id = ${watcherId}
+		  AND e.interaction_type = 'approval'
+		  AND e.interaction_status = 'pending'
+		ORDER BY e.run_id
+	`;
+	const interactions = approvalRows.map((row) => {
+		const resourceKind =
+			row.resource_kind ??
+			(row.tool === "manage_watchers"
+				? "watcher"
+				: row.tool === "manage_agents"
+					? "agent"
+					: row.tool === "entity_field_change" || row.tool === "entity_change"
+						? "entity"
+						: null);
+		const rawProposal = row.proposal ?? null;
+		const proposal =
+			resourceKind === "watcher" &&
+			rawProposal &&
+			typeof rawProposal === "object" &&
+			(rawProposal as { args?: unknown }).args &&
+			typeof (rawProposal as { args: unknown }).args === "object"
+				? (rawProposal as { args: Record<string, unknown> }).args
+				: rawProposal;
+		return {
+			type: "tool-approval" as const,
+			runId: Number(row.run_id),
+			action: row.action,
+			proposal,
+			current: row.current ?? null,
+			fields: row.fields ?? null,
+			attribution: row.attribution ?? null,
+			resourceKind,
+		};
+	});
+
+	return { runs, interactions };
 }


### PR DESCRIPTION
## What changed
- return pending approval interactions with Watcher run-thread history
- scope approval reads by organization, agent, and Watcher
- add an integration regression covering a pending Watcher approval alongside completed run history
- update the Owletto submodule to the UI fix

## Root cause
Watcher conversations read only completed transcript snapshots. Approval cards live in append-only events attached to pending runs, so the conversation endpoint never returned them.

## Validation
- `make pre-pr`
- server integration: `agent-thread-list-scope-all.test.ts` (5/5)
- Owletto production build
- independent review: 0 bugs, 0 blockers

Depends on lobu-ai/owletto#504.
