### PR TITLE
fix: prod OOM (4Gi) + gateway test process pollution

### DIFF
--- a/packages/server/src/__tests__/setup/test-db.ts
+++ b/packages/server/src/__tests__/setup/test-db.ts
@@ -219,22 +219,51 @@ async function resetPublicSchema(db: postgres.Sql): Promise<boolean> {
     // not owner/superuser — handled by the fallback below
   }
 
-  try {
-    await db`DROP SCHEMA IF EXISTS public CASCADE`;
-    await db`CREATE SCHEMA public`;
-    return true;
-  } catch (err) {
-    // 42501 = insufficient_privilege ("must be owner of schema public").
-    // Any other error is a real problem and should surface.
-    const code = (err as { code?: string } | null)?.code;
-    if (code !== '42501') throw err;
+  // `DROP SCHEMA public CASCADE` takes `AccessExclusiveLock` on every table.
+  // When an earlier co-run file leaked a background DB poller (task-scheduler,
+  // stale-run reaper, ChatInstanceManager tick), its concurrent FK-checked
+  // INSERT/UPDATE holds a child `RowExclusiveLock` while waiting on a parent
+  // `RowShareLock` the DROP already took → `40P01 deadlock detected`. This is
+  // the exact same cause `truncateAllTables` retries; the conflicting statement
+  // finishes in milliseconds, so a short backoff is deterministic recovery.
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await db`DROP SCHEMA IF EXISTS public CASCADE`;
+      await db`CREATE SCHEMA public`;
+      return true;
+    } catch (err) {
+      // 42501 = insufficient_privilege ("must be owner of schema public").
+      // Break to the non-owner fallback below.
+      const code = (err as { code?: string } | null)?.code;
+      if (code === '42501') break;
+      // 40P01 = deadlock vs a leaked poller's DML. Retry after a short backoff.
+      if (code === '40P01' && attempt < TRUNCATE_DEADLOCK_RETRIES) {
+        await new Promise((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
+        continue;
+      }
+      // Any other error is a real problem and should surface.
+      throw err;
+    }
   }
 
   // Non-owner fallback: ensure the schema exists, then drop everything this
   // role owns inside it. DROP OWNED BY only touches objects owned by the
-  // current role, so it never trips the schema-ownership check.
+  // current role, so it never trips the schema-ownership check. It takes the
+  // same table-level exclusive locks, so retry it on deadlock too.
   await db`CREATE SCHEMA IF NOT EXISTS public`;
-  await db`DROP OWNED BY CURRENT_USER`;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await db`DROP OWNED BY CURRENT_USER`;
+      break;
+    } catch (err) {
+      const code = (err as { code?: string } | null)?.code;
+      if (code === '40P01' && attempt < TRUNCATE_DEADLOCK_RETRIES) {
+        await new Promise((resolve) => setTimeout(resolve, 25 * (attempt + 1)));
+        continue;
+      }
+      throw err;
+    }
+  }
   return false;
 }
 

--- a/packages/server/src/gateway/__tests__/conversation-owned-elsewhere.test.ts
+++ b/packages/server/src/gateway/__tests__/conversation-owned-elsewhere.test.ts
@@ -24,7 +24,7 @@
  * failure does.
  */
 
-import { describe, expect, mock, spyOn, test } from "bun:test";
+import { beforeAll, describe, expect, mock, spyOn, test } from "bun:test";
 import {
   ConversationOwnedElsewhereError,
   type MessagePayload,
@@ -35,6 +35,16 @@ import type {
   OrchestratorConfig,
 } from "../orchestration/deployment-manager.js";
 import { MessageConsumer } from "../orchestration/message-consumer.js";
+import { ensureEncryptionKey } from "./helpers/db-setup.js";
+
+// This suite drives `handleMessage`, which mints a run-job token via
+// buildRunJobToken() → encrypt(). That lazily reads ENCRYPTION_KEY, and a
+// co-running gateway file can delete it (and reset the encryption cache) in its
+// teardown. Assert the key ourselves so this file is order-independent — it uses
+// fakes only and never touches Postgres, so it can't rely on the DB harness.
+beforeAll(() => {
+  ensureEncryptionKey();
+});
 
 // A no-op queue so `armTurnTimeout` / `sendToWorkerQueue` don't touch Postgres.
 // `send` returns a non-empty jobId so `sendToWorkerQueue`'s null-check passes.

--- a/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
+++ b/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
@@ -202,20 +202,37 @@ describe("DeploymentManager", () => {
       // still spawn — degraded, without those packages — rather than crash the
       // worker with `spawn nix-shell ENOENT`. Force the absent path via the
       // operator flag so the test is deterministic regardless of host nix.
-      const prev = process.env.LOBU_DISABLE_NIX_SHELL;
-      process.env.LOBU_DISABLE_NIX_SHELL = "1";
-      // Clear any prior positive nix probe from co-running suites (CI hosts
-      // often have nix-shell installed; the flag must still win).
       const { __resetCapabilityProbesForTests } = await import(
         "../orchestration/deployment-manager.js"
       );
+      const prev = process.env.LOBU_DISABLE_NIX_SHELL;
+      delete process.env.LOBU_DISABLE_NIX_SHELL;
       __resetCapabilityProbesForTests();
       try {
+        // If the host has nix-shell, this first spawn caches a positive probe.
+        // The regression under test is that LOBU_DISABLE_NIX_SHELL must still
+        // win AFTER that cache is hot (old code returned the cached hit first).
+        const msgWarm = createTestMessagePayload({
+          agentId: "agent-nix-warm",
+          conversationId: "conv-nix-warm",
+          nixConfig: { packages: ["chromium"] },
+        });
+        await manager.ensureDeployment(
+          "worker-nix-warm",
+          "user-1",
+          "user-1",
+          msgWarm
+        );
+
+        process.env.LOBU_DISABLE_NIX_SHELL = "1";
+        // Deliberately do NOT reset the capability probe cache — the kill-
+        // switch must override a sticky positive cache.
         const msg = createTestMessagePayload({
+          agentId: "agent-nix",
+          conversationId: "conv-nix",
           nixConfig: { packages: ["chromium"] },
         });
         await manager.ensureDeployment("worker-nix", "user-1", "user-1", msg);
-        expect(mockChildProcesses).toHaveLength(1);
         const cmd = mockSpawn.mock.calls.at(-1)?.[0];
         // NOT nix-shell — fell back to the direct worker invocation.
         expect(cmd).not.toBe("nix-shell");

--- a/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
+++ b/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
@@ -18,6 +18,13 @@ import type { OrchestratorConfig } from "../orchestration/deployment-manager.js"
 // ---------------------------------------------------------------------------
 const mockChildProcesses: EventEmitter[] = [];
 const mockSpawn = mock(() => createMockChildProcess());
+// Capability probes (locateNixShell / locateSystemdRun) use execFileSync.
+// Default: nix-shell is present so we can warm a positive cache; systemd-run
+// is absent so workers spawn unwrapped in these unit tests.
+const mockExecFileSync = mock((cmd: string) => {
+  if (cmd === "nix-shell") return "nix-shell (Nix) 2.0";
+  throw new Error(`ENOENT: ${cmd}`);
+});
 
 function createMockChildProcess() {
   const cp = new EventEmitter() as EventEmitter & {
@@ -45,6 +52,7 @@ function createMockChildProcess() {
 
 mock.module("node:child_process", () => ({
   spawn: mockSpawn,
+  execFileSync: mockExecFileSync,
 }));
 
 // ---------------------------------------------------------------------------
@@ -209,9 +217,8 @@ describe("DeploymentManager", () => {
       delete process.env.LOBU_DISABLE_NIX_SHELL;
       __resetCapabilityProbesForTests();
       try {
-        // If the host has nix-shell, this first spawn caches a positive probe.
-        // The regression under test is that LOBU_DISABLE_NIX_SHELL must still
-        // win AFTER that cache is hot (old code returned the cached hit first).
+        // Warm spawn: mock execFileSync reports nix-shell present, so this
+        // wraps with nix-shell and caches a positive probe.
         const msgWarm = createTestMessagePayload({
           agentId: "agent-nix-warm",
           conversationId: "conv-nix-warm",
@@ -223,6 +230,7 @@ describe("DeploymentManager", () => {
           "user-1",
           msgWarm
         );
+        expect(mockSpawn.mock.calls.at(-1)?.[0]).toBe("nix-shell");
 
         process.env.LOBU_DISABLE_NIX_SHELL = "1";
         // Deliberately do NOT reset the capability probe cache — the kill-

--- a/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
+++ b/packages/server/src/gateway/__tests__/embedded-deployment.test.ts
@@ -204,6 +204,12 @@ describe("DeploymentManager", () => {
       // operator flag so the test is deterministic regardless of host nix.
       const prev = process.env.LOBU_DISABLE_NIX_SHELL;
       process.env.LOBU_DISABLE_NIX_SHELL = "1";
+      // Clear any prior positive nix probe from co-running suites (CI hosts
+      // often have nix-shell installed; the flag must still win).
+      const { __resetCapabilityProbesForTests } = await import(
+        "../orchestration/deployment-manager.js"
+      );
+      __resetCapabilityProbesForTests();
       try {
         const msg = createTestMessagePayload({
           nixConfig: { packages: ["chromium"] },
@@ -215,8 +221,9 @@ describe("DeploymentManager", () => {
         expect(cmd).not.toBe("nix-shell");
         expect(cmd).toBe(process.execPath);
       } finally {
-        if (prev === undefined) process.env.LOBU_DISABLE_NIX_SHELL = undefined;
+        if (prev === undefined) delete process.env.LOBU_DISABLE_NIX_SHELL;
         else process.env.LOBU_DISABLE_NIX_SHELL = prev;
+        __resetCapabilityProbesForTests();
       }
     });
 

--- a/packages/server/src/gateway/__tests__/helpers/db-setup.ts
+++ b/packages/server/src/gateway/__tests__/helpers/db-setup.ts
@@ -95,6 +95,11 @@ export async function resetTestDatabase(): Promise<void> {
   } else {
     await initPromise;
   }
+  // Re-assert ENCRYPTION_KEY on every beforeEach: ensureDbForGatewayTests()
+  // sets it once inside a memoized block, so a later file that deletes the key
+  // (and resets the encryption cache) in its teardown would otherwise leave
+  // every subsequent DB-using file's lazy encrypt()/decrypt() broken.
+  ensureEncryptionKey();
   await cleanupTestDatabase();
 }
 

--- a/packages/server/src/gateway/__tests__/http-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/http-proxy.test.ts
@@ -10,7 +10,11 @@ import * as crypto from "node:crypto";
 import type { LookupAddress } from "node:dns";
 import * as http from "node:http";
 import * as net from "node:net";
-import { generateWorkerToken, verifyWorkerToken } from "@lobu/core";
+import {
+  __resetEncryptionKeyCacheForTests,
+  generateWorkerToken,
+  verifyWorkerToken,
+} from "@lobu/core";
 import type { RevokedTokenStore } from "../auth/revoked-token-store.js";
 import {
   __testOnly,
@@ -31,11 +35,11 @@ let savedEncryptionKey: string | undefined;
 let savedAllowedDomains: string | undefined;
 
 beforeAll(async () => {
-  // Restore previous env on teardown — mock.module/afterAll that `delete`s
-  // ENCRYPTION_KEY permanently breaks co-running suites that mint worker tokens.
+  // Isolate this file from siblings that also exercise the process-wide key cache.
   savedEncryptionKey = process.env.ENCRYPTION_KEY;
   savedAllowedDomains = process.env.WORKER_ALLOWED_DOMAINS;
   process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+  __resetEncryptionKeyCacheForTests();
   // Unrestricted for the auth + unrestricted-mode tests. `startHttpProxy`
   // snapshots this env into the server's immutable config, so every request in
   // this file sees "*" regardless of what a sibling test file left in the shared
@@ -50,6 +54,7 @@ afterAll(async () => {
   await stopHttpProxy(proxyServer);
   if (savedEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
   else process.env.ENCRYPTION_KEY = savedEncryptionKey;
+  __resetEncryptionKeyCacheForTests();
   if (savedAllowedDomains === undefined) delete process.env.WORKER_ALLOWED_DOMAINS;
   else process.env.WORKER_ALLOWED_DOMAINS = savedAllowedDomains;
 });

--- a/packages/server/src/gateway/__tests__/http-proxy.test.ts
+++ b/packages/server/src/gateway/__tests__/http-proxy.test.ts
@@ -27,8 +27,14 @@ const TEST_ENCRYPTION_KEY = crypto.randomBytes(32).toString("base64");
 // Single proxy server shared across all test suites
 let proxyPort: number;
 let proxyServer: http.Server;
+let savedEncryptionKey: string | undefined;
+let savedAllowedDomains: string | undefined;
 
 beforeAll(async () => {
+  // Restore previous env on teardown — mock.module/afterAll that `delete`s
+  // ENCRYPTION_KEY permanently breaks co-running suites that mint worker tokens.
+  savedEncryptionKey = process.env.ENCRYPTION_KEY;
+  savedAllowedDomains = process.env.WORKER_ALLOWED_DOMAINS;
   process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
   // Unrestricted for the auth + unrestricted-mode tests. `startHttpProxy`
   // snapshots this env into the server's immutable config, so every request in
@@ -42,8 +48,10 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await stopHttpProxy(proxyServer);
-  delete process.env.ENCRYPTION_KEY;
-  delete process.env.WORKER_ALLOWED_DOMAINS;
+  if (savedEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+  else process.env.ENCRYPTION_KEY = savedEncryptionKey;
+  if (savedAllowedDomains === undefined) delete process.env.WORKER_ALLOWED_DOMAINS;
+  else process.env.WORKER_ALLOWED_DOMAINS = savedAllowedDomains;
 });
 
 function makeBasicAuth(username: string, password: string): string {

--- a/packages/server/src/gateway/__tests__/inference-url-invariant.test.ts
+++ b/packages/server/src/gateway/__tests__/inference-url-invariant.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import * as providerSecrets from "../../lobu/stores/provider-secrets.js";
 
 // The URL invariant is the security spine: when an org has a custom upstream,
 // ONLY the org row's own key may be sent there — never a per-user profile or a
@@ -14,18 +15,16 @@ let configResult: {
   custom: boolean;
 } | null = null;
 
-// Spread the real module: mock.module is process-global and cannot be undone by
-// mock.restore(). A whole-module stub that drops the other exports breaks
-// co-running gateway suites that create/list inference providers.
-const realProviderSecrets = await import(
-  "../../lobu/stores/provider-secrets.js"
-);
-mock.module("../../lobu/stores/provider-secrets.js", () => ({
-  ...realProviderSecrets,
-  resolveInferenceProviderConfig: async () => configResult,
-}));
+const resolveInferenceProviderConfigSpy = spyOn(
+  providerSecrets,
+  "resolveInferenceProviderConfig"
+).mockImplementation(async () => configResult);
 
 const { resolveUrlInvariant } = await import("../auth/inference-invariant.js");
+
+afterAll(() => {
+  resolveInferenceProviderConfigSpy.mockRestore();
+});
 
 describe("resolveUrlInvariant", () => {
   beforeEach(() => {

--- a/packages/server/src/gateway/__tests__/inference-url-invariant.test.ts
+++ b/packages/server/src/gateway/__tests__/inference-url-invariant.test.ts
@@ -14,7 +14,14 @@ let configResult: {
   custom: boolean;
 } | null = null;
 
+// Spread the real module: mock.module is process-global and cannot be undone by
+// mock.restore(). A whole-module stub that drops the other exports breaks
+// co-running gateway suites that create/list inference providers.
+const realProviderSecrets = await import(
+  "../../lobu/stores/provider-secrets.js"
+);
 mock.module("../../lobu/stores/provider-secrets.js", () => ({
+  ...realProviderSecrets,
   resolveInferenceProviderConfig: async () => configResult,
 }));
 

--- a/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
+++ b/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
@@ -26,7 +26,10 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as crypto from "node:crypto";
 import type * as http from "node:http";
 import * as net from "node:net";
-import { generateWorkerToken } from "@lobu/core";
+import {
+  __resetEncryptionKeyCacheForTests,
+  generateWorkerToken,
+} from "@lobu/core";
 import { PolicyStore } from "../permissions/policy-store.js";
 import { CircuitBreaker } from "../proxy/egress-judge/circuit-breaker.js";
 import { EgressJudge } from "../proxy/egress-judge/judge.js";
@@ -309,6 +312,7 @@ describe("HTTP Proxy — domain blocking edge cases", () => {
     savedAllowedDomains = process.env.WORKER_ALLOWED_DOMAINS;
     savedDisallowedDomains = process.env.WORKER_DISALLOWED_DOMAINS;
     process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+    __resetEncryptionKeyCacheForTests();
     __testOnly.reset();
     setProxyRevokedTokenStore(NOOP_REVOKED_STORE);
     // DNS mock: all names resolve to a public TEST-NET address (passes IP check).
@@ -322,6 +326,7 @@ describe("HTTP Proxy — domain blocking edge cases", () => {
     await stopHttpProxy(proxyServer);
     if (savedEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
     else process.env.ENCRYPTION_KEY = savedEncryptionKey;
+    __resetEncryptionKeyCacheForTests();
     if (savedAllowedDomains === undefined) delete process.env.WORKER_ALLOWED_DOMAINS;
     else process.env.WORKER_ALLOWED_DOMAINS = savedAllowedDomains;
     if (savedDisallowedDomains === undefined) {
@@ -542,6 +547,7 @@ describe("CRLF injection prevention in judge-provided reason", () => {
     savedEncryptionKeyCrlf = process.env.ENCRYPTION_KEY;
     savedAllowedDomainsCrlf = process.env.WORKER_ALLOWED_DOMAINS;
     process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+    __resetEncryptionKeyCacheForTests();
     process.env.WORKER_ALLOWED_DOMAINS = "";
     __testOnly.reset();
     setProxyRevokedTokenStore(NOOP_REVOKED_STORE);
@@ -567,6 +573,7 @@ describe("CRLF injection prevention in judge-provided reason", () => {
     await stopHttpProxy(proxyServer);
     if (savedEncryptionKeyCrlf === undefined) delete process.env.ENCRYPTION_KEY;
     else process.env.ENCRYPTION_KEY = savedEncryptionKeyCrlf;
+    __resetEncryptionKeyCacheForTests();
     if (savedAllowedDomainsCrlf === undefined) {
       delete process.env.WORKER_ALLOWED_DOMAINS;
     } else {

--- a/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
+++ b/packages/server/src/gateway/__tests__/proxy-hardening.test.ts
@@ -300,8 +300,14 @@ describe("HTTP Proxy — domain blocking edge cases", () => {
   let proxyServer: http.Server;
   let proxyPort: number;
   const deploymentName = "pattern-test-worker";
+  let savedEncryptionKey: string | undefined;
+  let savedAllowedDomains: string | undefined;
+  let savedDisallowedDomains: string | undefined;
 
   beforeEach(() => {
+    savedEncryptionKey = process.env.ENCRYPTION_KEY;
+    savedAllowedDomains = process.env.WORKER_ALLOWED_DOMAINS;
+    savedDisallowedDomains = process.env.WORKER_DISALLOWED_DOMAINS;
     process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
     __testOnly.reset();
     setProxyRevokedTokenStore(NOOP_REVOKED_STORE);
@@ -314,9 +320,15 @@ describe("HTTP Proxy — domain blocking edge cases", () => {
   afterEach(async () => {
     __testOnly.setDnsLookup(null);
     await stopHttpProxy(proxyServer);
-    delete process.env.ENCRYPTION_KEY;
-    delete process.env.WORKER_ALLOWED_DOMAINS;
-    delete process.env.WORKER_DISALLOWED_DOMAINS;
+    if (savedEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = savedEncryptionKey;
+    if (savedAllowedDomains === undefined) delete process.env.WORKER_ALLOWED_DOMAINS;
+    else process.env.WORKER_ALLOWED_DOMAINS = savedAllowedDomains;
+    if (savedDisallowedDomains === undefined) {
+      delete process.env.WORKER_DISALLOWED_DOMAINS;
+    } else {
+      process.env.WORKER_DISALLOWED_DOMAINS = savedDisallowedDomains;
+    }
     __testOnly.reset();
   });
 
@@ -523,7 +535,12 @@ describe("CRLF injection prevention in judge-provided reason", () => {
     }
   }
 
+  let savedEncryptionKeyCrlf: string | undefined;
+  let savedAllowedDomainsCrlf: string | undefined;
+
   beforeEach(async () => {
+    savedEncryptionKeyCrlf = process.env.ENCRYPTION_KEY;
+    savedAllowedDomainsCrlf = process.env.WORKER_ALLOWED_DOMAINS;
     process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
     process.env.WORKER_ALLOWED_DOMAINS = "";
     __testOnly.reset();
@@ -548,8 +565,13 @@ describe("CRLF injection prevention in judge-provided reason", () => {
 
   afterEach(async () => {
     await stopHttpProxy(proxyServer);
-    delete process.env.ENCRYPTION_KEY;
-    delete process.env.WORKER_ALLOWED_DOMAINS;
+    if (savedEncryptionKeyCrlf === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = savedEncryptionKeyCrlf;
+    if (savedAllowedDomainsCrlf === undefined) {
+      delete process.env.WORKER_ALLOWED_DOMAINS;
+    } else {
+      process.env.WORKER_ALLOWED_DOMAINS = savedAllowedDomainsCrlf;
+    }
     __testOnly.reset();
   });
 

--- a/packages/server/src/gateway/__tests__/runtime-route.test.ts
+++ b/packages/server/src/gateway/__tests__/runtime-route.test.ts
@@ -1,7 +1,20 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { generateWorkerToken } from "@lobu/core";
+import {
+  __resetEncryptionKeyCacheForTests,
+  generateWorkerToken,
+} from "@lobu/core";
+import * as providerSecrets from "../../lobu/stores/provider-secrets.js";
 
 const remoteFiles = new Map<string, Buffer>();
 const mkdirMock = mock(async () => undefined);
@@ -70,17 +83,10 @@ mock.module("@vercel/sandbox", () => ({
 // Env-bound credential resolution reads the vault. Mock it to a MISS (null) so
 // the "environment pinned but deleted" case is deterministic and DB-free: the
 // scoped key is gone, so an env-bound resolution must fail closed.
-// Spread the real module: mock.module is process-global and cannot be undone by
-// mock.restore(); a whole-module stub that drops createInferenceProvider /
-// listInferenceProviders / encrypt-backed vault readers breaks co-running
-// gateway suites (worker-session-context-model-fallback, secret-proxy, etc.).
-const realProviderSecrets = await import(
-  "../../lobu/stores/provider-secrets.js"
-);
-mock.module("../../lobu/stores/provider-secrets.js", () => ({
-  ...realProviderSecrets,
-  readEnvironmentSecret: async () => null,
-}));
+const readEnvironmentSecretSpy = spyOn(
+  providerSecrets,
+  "readEnvironmentSecret"
+).mockResolvedValue(null);
 
 // Importing the route pulls in the gateway runtime registry barrel, which
 // registers the Vercel provider. The @vercel/sandbox mock above is installed
@@ -136,6 +142,7 @@ function setVercelSystemCreds(): void {
 beforeEach(() => {
   process.env.ENCRYPTION_KEY =
     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  __resetEncryptionKeyCacheForTests();
 });
 
 afterEach(async () => {
@@ -147,6 +154,7 @@ afterEach(async () => {
   restoreEnv("VERCEL_TEAM_ID");
   restoreEnv("VERCEL_TOKEN");
   restoreEnv("VERCEL_OIDC_TOKEN");
+  __resetEncryptionKeyCacheForTests();
   remoteFiles.clear();
   getOrCreateMock.mockClear();
   mkdirMock.mockClear();
@@ -161,7 +169,10 @@ afterEach(async () => {
     recursive: true,
     force: true,
   });
-  mock.restore();
+});
+
+afterAll(() => {
+  readEnvironmentSecretSpy.mockRestore();
 });
 
 describe("createRuntimeRoutes", () => {

--- a/packages/server/src/gateway/__tests__/runtime-route.test.ts
+++ b/packages/server/src/gateway/__tests__/runtime-route.test.ts
@@ -70,7 +70,15 @@ mock.module("@vercel/sandbox", () => ({
 // Env-bound credential resolution reads the vault. Mock it to a MISS (null) so
 // the "environment pinned but deleted" case is deterministic and DB-free: the
 // scoped key is gone, so an env-bound resolution must fail closed.
+// Spread the real module: mock.module is process-global and cannot be undone by
+// mock.restore(); a whole-module stub that drops createInferenceProvider /
+// listInferenceProviders / encrypt-backed vault readers breaks co-running
+// gateway suites (worker-session-context-model-fallback, secret-proxy, etc.).
+const realProviderSecrets = await import(
+  "../../lobu/stores/provider-secrets.js"
+);
 mock.module("../../lobu/stores/provider-secrets.js", () => ({
+  ...realProviderSecrets,
   readEnvironmentSecret: async () => null,
 }));
 

--- a/packages/server/src/gateway/__tests__/secret-proxy-org-upstream.test.ts
+++ b/packages/server/src/gateway/__tests__/secret-proxy-org-upstream.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import * as providerSecrets from "../../lobu/stores/provider-secrets.js";
 import type { SecretStore } from "../secrets/index.js";
 
 /**
@@ -20,20 +21,18 @@ let inferenceConfig: {
   custom: boolean;
 };
 
-// Custom upstream + usable org key ⇒ resolveUrlInvariant returns org-only.
-// Spread the real module so secret-proxy's other imports from it (e.g.
-// readOrgSharedProviderApiKey) still resolve; override only the resolver.
-const realProviderSecrets = await import(
-  "../../lobu/stores/provider-secrets.js"
-);
-mock.module("../../lobu/stores/provider-secrets.js", () => ({
-  ...realProviderSecrets,
-  resolveInferenceProviderConfig: async () => inferenceConfig,
-}));
+const resolveInferenceProviderConfigSpy = spyOn(
+  providerSecrets,
+  "resolveInferenceProviderConfig"
+).mockImplementation(async () => inferenceConfig);
 
 // Import AFTER the mock so secret-proxy's transitive import of the invariant
 // (which imports the store) picks up the stub.
 const { SecretProxy } = await import("../proxy/secret-proxy.js");
+
+afterAll(() => {
+  resolveInferenceProviderConfigSpy.mockRestore();
+});
 
 describe("SecretProxy — org custom-upstream slug routing (URL invariant)", () => {
   beforeEach(() => {

--- a/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
@@ -9,6 +9,13 @@
  * called and the posted text carries the connect URL with the team id (no secret
  * token — authority is the Slack workspace-admin check at claim time); (2) with a
  * null installer, no DM is sent — the row is still parked.
+ *
+ * IMPORTANT: never replace an entire module with `mock.module` without spreading
+ * the real exports. This suite shares a process with every other gateway suite,
+ * and bun's `mock.module` is process-global and cannot be undone by
+ * `mock.restore()`. A prior whole-module stub of slack-installations returning
+ * null from getSlackInstallByTeamId broke slack-connection-coordinator tests
+ * that co-run in the same `bun test src/gateway/__tests__` process.
  */
 
 import {
@@ -24,32 +31,17 @@ import {
 } from "bun:test";
 import { __resetPublicOriginCachesForTests } from "../../utils/public-origin.js";
 import * as appInstallCredentials from "../installation/app-install-credentials.js";
+import * as slackInstallations from "../../lobu/stores/slack-installations.js";
+import * as slackWeb from "../connections/slack-web.js";
 
 // --- Stub the pending-install store: capture inputs, never touch Postgres. ---
 const writeCalls: Array<Record<string, unknown>> = [];
-mock.module("../../lobu/stores/slack-installations.js", () => ({
-	writeSlackPendingInstall: mock(async (input: Record<string, unknown>) => {
+const writeSlackPendingInstallMock = mock(
+	async (input: Record<string, unknown>) => {
 		writeCalls.push(input);
 		return { id: "1" };
-	}),
-	// Also imported by the coordinator module (webhook routing); unused here.
-	getSlackInstallByTeamId: mock(async () => null),
-	getSlackInstallByEnterpriseId: mock(async () => null),
-	getSlackEnterpriseInstall: mock(async () => null),
-	resolveSlackPendingByTenant: mock(async () => null),
-	revokeSlackInstallsForUninstall: mock(async () => []),
-	claimSlackWelcomeDm: mock(async () => null),
-}));
-
-// --- Hosted app credentials are configured (so the exchange path runs). ---
-// Use `spyOn` (restored in afterAll) rather than `mock.module`: this suite shares a
-// process with every other gateway suite, and bun's `mock.module` is process-global
-// and CANNOT be un-done by `mock.restore()`. A whole-module stub also drops the
-// module's OTHER exports (e.g. `renderAppInstallUrl`), breaking co-running suites
-// that import them. Spying only these two functions keeps the rest of the module
-// real and lets afterAll restore the originals so nothing leaks — a prior whole-
-// module stub returning a hardcoded `client-id` clobbered slack-routes.test.ts's
-// own `SLACK_CLIENT_ID` ("client-123") in the shared process.
+	},
+);
 
 // --- Stub the Slack Web API surface the coordinator uses. ---
 const exchangeOAuthCode = mock(
@@ -73,9 +65,6 @@ const exchangeOAuthCode = mock(
 );
 const openDm = mock(async () => "D-INSTALLER");
 const postMessage = mock(async () => undefined);
-mock.module("../connections/slack-web.js", () => ({
-	createSlackWebApi: () => ({ exchangeOAuthCode, openDm, postMessage }),
-}));
 
 async function loadCoordinator() {
 	const mod = await import("../connections/slack-connection-coordinator.js");
@@ -95,6 +84,8 @@ describe("completeSlackPendingInstall — installer claim DM", () => {
 	beforeAll(() => {
 		// Hosted app credentials are "configured" so `completeSlackPendingInstall`'s
 		// exchange path runs (a truthy primed method + non-empty client id/secret).
+		// Use spyOn (restored in afterAll) — process-global mock.module cannot be
+		// undone and would clobber co-running suites.
 		spyOn(appInstallCredentials, "getPrimedBundledMethod").mockReturnValue({
 			clientIdKey: "SLACK_CLIENT_ID",
 			clientSecretKey: "SLACK_CLIENT_SECRET",
@@ -108,16 +99,37 @@ describe("completeSlackPendingInstall — installer claim DM", () => {
 			clientId: "client-id",
 			clientSecret: "client-secret",
 		});
+		spyOn(slackInstallations, "writeSlackPendingInstall").mockImplementation(
+			writeSlackPendingInstallMock as typeof slackInstallations.writeSlackPendingInstall,
+		);
+		spyOn(slackWeb, "createSlackWebApi").mockImplementation(
+			() =>
+				({
+					exchangeOAuthCode,
+					openDm,
+					postMessage,
+					conversationMembers: async () => [],
+					conversationInfo: async () => ({
+						name: null,
+						isPrivate: false,
+						contextTeamId: null,
+					}),
+					usersInfo: async () => ({ isAdmin: false, isOwner: false }),
+					revokeToken: async () => true,
+					authTest: async () => ({ teamId: "T-CLAIM" }),
+				}) as unknown as ReturnType<typeof slackWeb.createSlackWebApi>,
+		);
 	});
 
 	afterAll(() => {
-		// Restore the real credential functions so the shared test process hands the
-		// real module (env-driven) to every other gateway suite.
+		// Restore spies so the shared test process hands real modules to every
+		// other gateway suite.
 		mock.restore();
 	});
 
 	beforeEach(() => {
 		writeCalls.length = 0;
+		writeSlackPendingInstallMock.mockClear();
 		exchangeOAuthCode.mockClear();
 		openDm.mockClear();
 		postMessage.mockClear();
@@ -200,7 +212,6 @@ describe("completeSlackPendingInstall — installer claim DM", () => {
 		// No DM without an installer to send it to.
 		expect(openDm).not.toHaveBeenCalled();
 		expect(postMessage).not.toHaveBeenCalled();
-		// The row is still parked (no installer to DM).
 		expect(writeCalls).toHaveLength(1);
 		expect(writeCalls[0]!.installerUserId).toBeNull();
 	});

--- a/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
+++ b/packages/server/src/gateway/__tests__/slack-pending-install-claim.test.ts
@@ -80,29 +80,41 @@ function callbackRequest(): Request {
 
 describe("completeSlackPendingInstall — installer claim DM", () => {
 	let savedWebUrl: string | undefined;
+	// Hold spy handles so afterAll restores ONLY these — mock.restore() is
+	// process-global and would wipe spies installed by co-running suites.
+	let primedMethodSpy: ReturnType<typeof spyOn>;
+	let resolveCredsSpy: ReturnType<typeof spyOn>;
+	let writePendingSpy: ReturnType<typeof spyOn>;
+	let createWebApiSpy: ReturnType<typeof spyOn>;
 
 	beforeAll(() => {
 		// Hosted app credentials are "configured" so `completeSlackPendingInstall`'s
 		// exchange path runs (a truthy primed method + non-empty client id/secret).
 		// Use spyOn (restored in afterAll) — process-global mock.module cannot be
 		// undone and would clobber co-running suites.
-		spyOn(appInstallCredentials, "getPrimedBundledMethod").mockReturnValue({
+		primedMethodSpy = spyOn(
+			appInstallCredentials,
+			"getPrimedBundledMethod",
+		).mockReturnValue({
 			clientIdKey: "SLACK_CLIENT_ID",
 			clientSecretKey: "SLACK_CLIENT_SECRET",
 		} as unknown as ReturnType<
 			typeof appInstallCredentials.getPrimedBundledMethod
 		>);
-		spyOn(
+		resolveCredsSpy = spyOn(
 			appInstallCredentials,
 			"resolveAppInstallCredentials",
 		).mockReturnValue({
 			clientId: "client-id",
 			clientSecret: "client-secret",
 		});
-		spyOn(slackInstallations, "writeSlackPendingInstall").mockImplementation(
+		writePendingSpy = spyOn(
+			slackInstallations,
+			"writeSlackPendingInstall",
+		).mockImplementation(
 			writeSlackPendingInstallMock as typeof slackInstallations.writeSlackPendingInstall,
 		);
-		spyOn(slackWeb, "createSlackWebApi").mockImplementation(
+		createWebApiSpy = spyOn(slackWeb, "createSlackWebApi").mockImplementation(
 			() =>
 				({
 					exchangeOAuthCode,
@@ -122,9 +134,10 @@ describe("completeSlackPendingInstall — installer claim DM", () => {
 	});
 
 	afterAll(() => {
-		// Restore spies so the shared test process hands real modules to every
-		// other gateway suite.
-		mock.restore();
+		primedMethodSpy.mockRestore();
+		resolveCredsSpy.mockRestore();
+		writePendingSpy.mockRestore();
+		createWebApiSpy.mockRestore();
 	});
 
 	beforeEach(() => {

--- a/packages/server/src/gateway/__tests__/worker-job-router.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-job-router.test.ts
@@ -19,9 +19,8 @@ import {
   TestHelpers,
 } from "./setup.js";
 
-// setupTestEnv does not pin ENCRYPTION_KEY. Co-running suites (http-proxy,
-// proxy-hardening) delete it in afterAll without restoring, so this file must
-// set its own key for encrypt()/generateWorkerToken paths.
+// setupTestEnv does not pin ENCRYPTION_KEY, and token helpers cache the decoded
+// key process-wide, so this file owns both the env value and cache lifecycle.
 const TEST_ENCRYPTION_KEY =
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 

--- a/packages/server/src/gateway/__tests__/worker-job-router.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-job-router.test.ts
@@ -4,7 +4,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { encrypt, verifyWorkerToken } from "@lobu/core";
+import {
+  __resetEncryptionKeyCacheForTests,
+  encrypt,
+  verifyWorkerToken,
+} from "@lobu/core";
 import { WorkerConnectionManager } from "../gateway/connection-manager.js";
 import { WorkerJobRouter } from "../gateway/job-router.js";
 import {
@@ -15,13 +19,23 @@ import {
   TestHelpers,
 } from "./setup.js";
 
+// setupTestEnv does not pin ENCRYPTION_KEY. Co-running suites (http-proxy,
+// proxy-hardening) delete it in afterAll without restoring, so this file must
+// set its own key for encrypt()/generateWorkerToken paths.
+const TEST_ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
 describe("WorkerJobRouter", () => {
   let queue: MockMessageQueue;
   let connectionManager: WorkerConnectionManager;
   let router: WorkerJobRouter;
+  let savedEncryptionKey: string | undefined;
 
   beforeEach(() => {
     setupTestEnv();
+    savedEncryptionKey = process.env.ENCRYPTION_KEY;
+    process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+    __resetEncryptionKeyCacheForTests();
     queue = new MockMessageQueue();
     connectionManager = new WorkerConnectionManager();
 
@@ -36,6 +50,9 @@ describe("WorkerJobRouter", () => {
     router.shutdown();
     connectionManager.shutdown();
     cleanupTestEnv();
+    if (savedEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = savedEncryptionKey;
+    __resetEncryptionKeyCacheForTests();
   });
 
   describe("Worker Registration", () => {

--- a/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
@@ -1,5 +1,16 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
-import { generateWorkerToken } from "@lobu/core";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import {
+  __resetEncryptionKeyCacheForTests,
+  generateWorkerToken,
+} from "@lobu/core";
 import {
   ensureDbForGatewayTests,
   resetTestDatabase,
@@ -15,6 +26,15 @@ import {
 import { resolveAgentOptions } from "../services/platform-helpers.js";
 import { ProviderCatalogService } from "../auth/provider-catalog.js";
 import { WorkerGateway } from "../gateway/index.js";
+
+// Pin ENCRYPTION_KEY for the whole file: createInferenceProvider encrypts the
+// org key, and ProviderCatalogService decrypts it when deciding whether a
+// custom-upstream provider is routable. A co-running suite that mutates
+// ENCRYPTION_KEY without resetting the process-wide encrypt() cache makes
+// byo2 look "missing/undecryptable" and publishes no defaultModel.
+const TEST_ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+let savedEncryptionKey: string | undefined;
 
 /**
  * E2E of the two worker model-delivery channels against the REAL DB, proving
@@ -82,6 +102,9 @@ describe("worker model fallback (real DB, both channels)", () => {
   }, 60_000);
 
   beforeEach(async () => {
+    savedEncryptionKey = process.env.ENCRYPTION_KEY;
+    process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+    __resetEncryptionKeyCacheForTests();
     await resetTestDatabase();
     // Seed a bare model id under slug "openai"; getOrgDefaultModel prefixes it
     // to the routable "openai/gpt-5". (The slug must match the model's intended
@@ -95,6 +118,12 @@ describe("worker model fallback (real DB, both channels)", () => {
     });
     await setInferenceProviderDefault(ORG, "openai");
   }, 60_000);
+
+  afterEach(() => {
+    if (savedEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = savedEncryptionKey;
+    __resetEncryptionKeyCacheForTests();
+  });
 
   test("org default is readable via the real DB reader", async () => {
     expect(await getOrgDefaultModel(ORG)).toBe("openai/gpt-5");

--- a/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
+++ b/packages/server/src/gateway/__tests__/worker-session-context-model-fallback.test.ts
@@ -27,11 +27,8 @@ import { resolveAgentOptions } from "../services/platform-helpers.js";
 import { ProviderCatalogService } from "../auth/provider-catalog.js";
 import { WorkerGateway } from "../gateway/index.js";
 
-// Pin ENCRYPTION_KEY for the whole file: createInferenceProvider encrypts the
-// org key, and ProviderCatalogService decrypts it when deciding whether a
-// custom-upstream provider is routable. A co-running suite that mutates
-// ENCRYPTION_KEY without resetting the process-wide encrypt() cache makes
-// byo2 look "missing/undecryptable" and publishes no defaultModel.
+// createInferenceProvider encrypts the org key and ProviderCatalogService later
+// decrypts it, so each test owns the process-wide env value and cached key.
 const TEST_ENCRYPTION_KEY =
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 let savedEncryptionKey: string | undefined;

--- a/packages/server/src/gateway/auth/__tests__/api-auth-middleware-query-token.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/api-auth-middleware-query-token.test.ts
@@ -6,7 +6,7 @@
  * headerless mutations or unrelated GET routes.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { encrypt } from "@lobu/core";
+import { __resetEncryptionKeyCacheForTests, encrypt } from "@lobu/core";
 import { Hono } from "hono";
 import { createApiAuthMiddleware } from "../api-auth-middleware.js";
 import { setAuthProvider } from "../../routes/public/settings-auth.js";
@@ -18,11 +18,15 @@ let savedKey: string | undefined;
 beforeEach(() => {
   savedKey = process.env.ENCRYPTION_KEY;
   process.env.ENCRYPTION_KEY = TEST_KEY;
+  // encrypt() memoizes the key; clear so this file reads TEST_KEY even when a
+  // co-running suite left a different key in the process-wide cache.
+  __resetEncryptionKeyCacheForTests();
   setAuthProvider(null); // no injected provider + no cookie → force the ticket path
 });
 afterEach(() => {
   if (savedKey === undefined) delete process.env.ENCRYPTION_KEY;
   else process.env.ENCRYPTION_KEY = savedKey;
+  __resetEncryptionKeyCacheForTests();
   setAuthProvider(null);
 });
 

--- a/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
@@ -1,11 +1,9 @@
 import {
   afterAll,
   afterEach,
-  beforeAll,
   beforeEach,
   describe,
   expect,
-  mock,
   spyOn,
   test,
 } from "bun:test";
@@ -27,11 +25,19 @@ let inferenceProviderRows: Array<{
   ciphertext: string | null;
 }> = [];
 
-// Import the module under test AFTER we install spies in beforeAll so its
-// static imports of getDb/tryGetOrgId still resolve to the real module objects
-// that we spy on (live ESM bindings). Prefer spyOn over mock.module: the
-// latter is process-global and cannot be undone, and a whole-module getDb
-// stub breaks co-running auth suites (revoked-token checks, api-auth).
+const resolveOrgIdSpy = spyOn(orgContext, "resolveOrgId").mockImplementation(
+  (explicit?: string | null) => explicit ?? mockOrgId
+);
+// Both provider-key reads use the postgres tagged template
+// (`sql\`SELECT ...\``), so returning the rows array satisfies either read.
+const getDbSpy = spyOn(dbClient, "getDb").mockImplementation(
+  (() =>
+    (_strings: TemplateStringsArray) =>
+      Promise.resolve(inferenceProviderRows)) as typeof dbClient.getDb
+);
+
+// Import after installing restorable spies so this file cannot replace a
+// process-global module for co-running auth suites.
 const { ApiKeyProviderModule } = await import("../api-key-provider-module.js");
 
 function makeModule(hasProfile: boolean) {
@@ -53,29 +59,10 @@ function makeModule(hasProfile: boolean) {
 describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
   const previousEncryptionKey = process.env.ENCRYPTION_KEY;
   const previousZKey = process.env.Z_AI_API_KEY;
-  const realGetDb = dbClient.getDb;
-
-  beforeAll(() => {
-    spyOn(orgContext, "tryGetOrgId").mockImplementation(() => mockOrgId);
-    spyOn(orgContext, "resolveOrgId").mockImplementation(
-      (explicit?: string | null) => explicit ?? mockOrgId
-    );
-    spyOn(orgContext, "getOrgId").mockImplementation(() => {
-      if (!mockOrgId) throw new Error("no org");
-      return mockOrgId;
-    });
-    // Both provider-key reads use the postgres tagged template
-    // (`sql\`SELECT ...\``); a tagged-template call invokes the function with
-    // (strings, ...values), so returning the rows array satisfies it.
-    spyOn(dbClient, "getDb").mockImplementation(
-      (() =>
-        (_strings: TemplateStringsArray) =>
-          Promise.resolve(inferenceProviderRows)) as typeof realGetDb
-    );
-  });
 
   afterAll(() => {
-    mock.restore();
+    resolveOrgIdSpy.mockRestore();
+    getDbSpy.mockRestore();
   });
 
   beforeEach(() => {

--- a/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
+++ b/packages/server/src/gateway/auth/__tests__/base-provider-module-credentials.test.ts
@@ -1,5 +1,17 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { encrypt } from "@lobu/core";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { __resetEncryptionKeyCacheForTests, encrypt } from "@lobu/core";
+import * as orgContext from "../../../lobu/stores/org-context.js";
+import * as dbClient from "../../../db/client.js";
 
 const TEST_ENCRYPTION_KEY = Buffer.from(
   "12345678901234567890123456789012"
@@ -15,28 +27,11 @@ let inferenceProviderRows: Array<{
   ciphertext: string | null;
 }> = [];
 
-// Mock the org-context AsyncLocalStorage lookup so we can simulate a worker
-// request that does (or doesn't) carry an org.
-mock.module("../../../lobu/stores/org-context.js", () => ({
-  tryGetOrgId: () => mockOrgId,
-  resolveOrgId: (explicit?: string | null) => explicit ?? mockOrgId,
-  getOrgId: () => {
-    if (!mockOrgId) throw new Error("no org");
-    return mockOrgId;
-  },
-}));
-
-// Mock the db client. Both provider-key reads use the postgres tagged
-// template (`sql\`SELECT ...\``); a tagged-template call invokes the function
-// with (strings, ...values), so returning the rows array satisfies it.
-mock.module("../../../db/client.js", () => ({
-  PROD_PG_VALUE_OPTIONS: {},
-  closeDbSingleton: async () => undefined,
-  getDb: () => (_strings: TemplateStringsArray) =>
-    Promise.resolve(inferenceProviderRows),
-}));
-
-// Import AFTER mocks so the module graph picks them up.
+// Import the module under test AFTER we install spies in beforeAll so its
+// static imports of getDb/tryGetOrgId still resolve to the real module objects
+// that we spy on (live ESM bindings). Prefer spyOn over mock.module: the
+// latter is process-global and cannot be undone, and a whole-module getDb
+// stub breaks co-running auth suites (revoked-token checks, api-auth).
 const { ApiKeyProviderModule } = await import("../api-key-provider-module.js");
 
 function makeModule(hasProfile: boolean) {
@@ -58,9 +53,34 @@ function makeModule(hasProfile: boolean) {
 describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
   const previousEncryptionKey = process.env.ENCRYPTION_KEY;
   const previousZKey = process.env.Z_AI_API_KEY;
+  const realGetDb = dbClient.getDb;
+
+  beforeAll(() => {
+    spyOn(orgContext, "tryGetOrgId").mockImplementation(() => mockOrgId);
+    spyOn(orgContext, "resolveOrgId").mockImplementation(
+      (explicit?: string | null) => explicit ?? mockOrgId
+    );
+    spyOn(orgContext, "getOrgId").mockImplementation(() => {
+      if (!mockOrgId) throw new Error("no org");
+      return mockOrgId;
+    });
+    // Both provider-key reads use the postgres tagged template
+    // (`sql\`SELECT ...\``); a tagged-template call invokes the function with
+    // (strings, ...values), so returning the rows array satisfies it.
+    spyOn(dbClient, "getDb").mockImplementation(
+      (() =>
+        (_strings: TemplateStringsArray) =>
+          Promise.resolve(inferenceProviderRows)) as typeof realGetDb
+    );
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
 
   beforeEach(() => {
     process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+    __resetEncryptionKeyCacheForTests();
     // Ensure no system key influences the result — we test the org-shared path.
     delete process.env.Z_AI_API_KEY;
     mockOrgId = null;
@@ -72,6 +92,7 @@ describe("BaseProviderModule.hasCredentials org-shared key fallback", () => {
     else process.env.ENCRYPTION_KEY = previousEncryptionKey;
     if (previousZKey === undefined) delete process.env.Z_AI_API_KEY;
     else process.env.Z_AI_API_KEY = previousZKey;
+    __resetEncryptionKeyCacheForTests();
   });
 
   test("returns true when a per-user auth profile exists", async () => {

--- a/packages/server/src/gateway/orchestration/deployment-manager.ts
+++ b/packages/server/src/gateway/orchestration/deployment-manager.ts
@@ -169,11 +169,13 @@ function locateSystemdRun(): string | null {
  */
 let cachedNixShell: string | null | undefined;
 function locateNixShell(): string | null {
-  if (cachedNixShell !== undefined) return cachedNixShell;
+  // Operator kill-switch always wins, even if an earlier probe cached a hit
+  // (tests set LOBU_DISABLE_NIX_SHELL=1 mid-process; a sticky "nix-shell"
+  // cache would ignore the flag and wrap workers that should run plain).
   if (process.env.LOBU_DISABLE_NIX_SHELL === "1") {
-    cachedNixShell = null;
-    return cachedNixShell;
+    return null;
   }
+  if (cachedNixShell !== undefined) return cachedNixShell;
   try {
     execFileSync("nix-shell", ["--version"], {
       stdio: "ignore",

--- a/packages/server/src/gateway/runtime/__tests__/credentials.test.ts
+++ b/packages/server/src/gateway/runtime/__tests__/credentials.test.ts
@@ -3,8 +3,7 @@ import * as providerSecrets from "../../../lobu/stores/provider-secrets.js";
 
 // Mock the vault read so resolveRuntimeCredentials can be unit-tested without a DB.
 const readEnvironmentSecretMock = mock(
-  async (_envId: string, _field: string, _orgId: string): Promise<string | null> =>
-    null
+  async (): Promise<string | null> => null
 );
 const readEnvironmentSecretSpy = spyOn(
   providerSecrets,

--- a/packages/server/src/gateway/runtime/__tests__/credentials.test.ts
+++ b/packages/server/src/gateway/runtime/__tests__/credentials.test.ts
@@ -1,20 +1,15 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import * as providerSecrets from "../../../lobu/stores/provider-secrets.js";
 
 // Mock the vault read so resolveRuntimeCredentials can be unit-tested without a DB.
-// Spread the real module: mock.module is process-global and cannot be undone by
-// mock.restore(); a whole-module stub that drops the other exports breaks
-// co-running gateway suites.
 const readEnvironmentSecretMock = mock(
   async (_envId: string, _field: string, _orgId: string): Promise<string | null> =>
     null
 );
-const realProviderSecrets = await import(
-  "../../../lobu/stores/provider-secrets.js"
-);
-mock.module("../../../lobu/stores/provider-secrets.js", () => ({
-  ...realProviderSecrets,
-  readEnvironmentSecret: readEnvironmentSecretMock,
-}));
+const readEnvironmentSecretSpy = spyOn(
+  providerSecrets,
+  "readEnvironmentSecret"
+).mockImplementation(readEnvironmentSecretMock);
 
 const { resolveRuntimeCredentials } = await import("../credentials.js");
 import type { GatewayRuntimeProvider } from "../types.js";
@@ -44,6 +39,10 @@ afterEach(() => {
   }
   readEnvironmentSecretMock.mockClear();
   readEnvironmentSecretMock.mockImplementation(async () => null);
+});
+
+afterAll(() => {
+  readEnvironmentSecretSpy.mockRestore();
 });
 
 describe("resolveRuntimeCredentials", () => {

--- a/packages/server/src/gateway/runtime/__tests__/credentials.test.ts
+++ b/packages/server/src/gateway/runtime/__tests__/credentials.test.ts
@@ -1,11 +1,18 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 // Mock the vault read so resolveRuntimeCredentials can be unit-tested without a DB.
+// Spread the real module: mock.module is process-global and cannot be undone by
+// mock.restore(); a whole-module stub that drops the other exports breaks
+// co-running gateway suites.
 const readEnvironmentSecretMock = mock(
   async (_envId: string, _field: string, _orgId: string): Promise<string | null> =>
     null
 );
+const realProviderSecrets = await import(
+  "../../../lobu/stores/provider-secrets.js"
+);
 mock.module("../../../lobu/stores/provider-secrets.js", () => ({
+  ...realProviderSecrets,
   readEnvironmentSecret: readEnvironmentSecretMock,
 }));
 

--- a/packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-guardrail-validation.test.ts
@@ -4,109 +4,118 @@
  * An entry with an invalid `stage` (or missing name/policy) would otherwise be
  * persisted verbatim and then crash the aggregator mid-message when it indexes
  * `seen[stage]`. The PATCH `/:agentId/config` route rejects such payloads (400).
+ *
+ * Dynamic-import agent-routes AFTER route-test mocks: a static top-level import
+ * of agent-routes binds the real `mcpAuth` (which calls getWorkspaceProvider)
+ * permanently for this process — and when bun evaluates test files, that can
+ * land before another file's installRouteTestMocks(), so later route tests get
+ * 500 WorkspaceProvider-not-initialized instead of the mocked auth path.
  */
 
-import { describe, expect, test } from 'bun:test';
-import { validateGuardrailsInline } from '../agent-routes.js';
+import { describe, expect, test } from "bun:test";
+import { installRouteTestMocks } from "./helpers/route-test-mocks";
 
-describe('validateGuardrailsInline', () => {
-  test('returns null for an absent payload', () => {
+installRouteTestMocks();
+const { validateGuardrailsInline } = await import("../agent-routes.js");
+
+describe("validateGuardrailsInline", () => {
+  test("returns null for an absent payload", () => {
     expect(validateGuardrailsInline(undefined)).toBeNull();
   });
 
-  test('returns null for an empty array', () => {
+  test("returns null for an empty array", () => {
     expect(validateGuardrailsInline([])).toBeNull();
   });
 
-  test('accepts a fully-valid inline guardrail', () => {
+  test("accepts a fully-valid inline guardrail", () => {
     expect(
       validateGuardrailsInline([
         {
-          name: 'tone-check',
+          name: "tone-check",
           enabled: true,
-          stage: 'output',
-          policy: 'no profanity',
-          model: 'anthropic/claude-haiku-4-5',
-          tools: ['bash'],
+          stage: "output",
+          policy: "no profanity",
+          model: "anthropic/claude-haiku-4-5",
+          tools: ["bash"],
         },
       ])
     ).toBeNull();
   });
 
-  test('rejects a non-array payload', () => {
+  test("rejects a non-array payload", () => {
     expect(validateGuardrailsInline({})).toMatch(/must be an array/);
   });
 
-  test('rejects an invalid stage — the crash vector', () => {
+  test("rejects an invalid stage — the crash vector", () => {
     const err = validateGuardrailsInline([
-      { name: 'bad', enabled: true, stage: 'outupt', policy: 'x' },
+      { name: "bad", enabled: true, stage: "outupt", policy: "x" },
     ]);
     expect(err).toMatch(/stage must be one of/);
   });
 
-  test('rejects a missing/blank name', () => {
+  test("rejects a missing/blank name", () => {
     expect(
       validateGuardrailsInline([
-        { name: '   ', enabled: true, stage: 'input', policy: 'x' },
+        { name: "   ", enabled: true, stage: "input", policy: "x" },
       ])
     ).toMatch(/name must be a non-empty string/);
   });
 
-  test('rejects a non-boolean enabled', () => {
+  test("rejects a non-boolean enabled", () => {
     expect(
       validateGuardrailsInline([
-        { name: 'g', enabled: 'yes', stage: 'input', policy: 'x' },
+        { name: "g", enabled: "yes", stage: "input", policy: "x" },
       ])
     ).toMatch(/enabled must be a boolean/);
   });
 
-  test('rejects a blank policy', () => {
+  test("rejects a blank policy", () => {
     expect(
       validateGuardrailsInline([
-        { name: 'g', enabled: true, stage: 'input', policy: '' },
+        { name: "g", enabled: true, stage: "input", policy: "" },
       ])
     ).toMatch(/policy must be a non-empty string/);
   });
 
-  test('rejects a non-string model', () => {
+  test("rejects a non-string model", () => {
     expect(
       validateGuardrailsInline([
-        { name: 'g', enabled: true, stage: 'input', policy: 'x', model: 42 },
+        { name: "g", enabled: true, stage: "input", policy: "x", model: 42 },
       ])
     ).toMatch(/model must be a string/);
   });
 
-  test('rejects tools that are not a string array', () => {
+  test("rejects tools that are not a string array", () => {
     expect(
       validateGuardrailsInline([
-        { name: 'g', enabled: true, stage: 'input', policy: 'x', tools: [1] },
+        { name: "g", enabled: true, stage: "input", policy: "x", tools: [1] },
       ])
     ).toMatch(/tools must be an array of strings/);
   });
 
-  test('accepts an egress guardrail with a domains selector (round-trip)', () => {
+  test("accepts an egress guardrail with a domains selector (round-trip)", () => {
     expect(
       validateGuardrailsInline([
         {
-          name: 'egress-github',
+          name: "egress-github",
           enabled: true,
-          stage: 'egress',
-          policy: 'only allow github reads',
-          model: 'anthropic/claude-haiku-4-5',
-          domains: ['.github.com', 'api.github.com'],
+          stage: "egress",
+          policy: "only allow github reads",
+          model: "anthropic/claude-haiku-4-5",
+          domains: [".github.com", "api.github.com"],
         },
       ])
     ).toBeNull();
   });
 
-  test('rejects domains that are not a string array', () => {
+  test("rejects domains that are not a string array", () => {
     expect(
       validateGuardrailsInline([
         {
-          name: 'g',
+          name: "g",
           enabled: true,
-          stage: 'egress',
-          policy: 'x',
+          stage: "egress",
+          policy: "x",
           domains: [1],
         },
       ])

--- a/packages/server/src/lobu/__tests__/agent-routes-models-validation.test.ts
+++ b/packages/server/src/lobu/__tests__/agent-routes-models-validation.test.ts
@@ -1,8 +1,11 @@
+/**
+ * Unit coverage for `validateModelsUpdate` / `LEGACY_MODEL_FIELDS`.
+ *
+ * Dynamic-import agent-routes AFTER route-test mocks so a static top-level
+ * import cannot bind the real `mcpAuth` (and its getWorkspaceProvider call)
+ * before mocks are installed — see agent-routes-guardrail-validation.test.ts.
+ */
 import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
-import {
-  LEGACY_MODEL_FIELDS,
-  validateModelsUpdate,
-} from "../agent-routes.js";
 import { orgContext } from "../stores/org-context.js";
 import { createInferenceProvider } from "../stores/provider-secrets.js";
 import {
@@ -10,6 +13,12 @@ import {
   resetTestDatabase,
   seedAgentRow,
 } from "../../gateway/__tests__/helpers/db-setup.js";
+import { installRouteTestMocks } from "./helpers/route-test-mocks";
+
+installRouteTestMocks();
+const { LEGACY_MODEL_FIELDS, validateModelsUpdate } = await import(
+  "../agent-routes.js"
+);
 
 const ORG = "test-org-models-validation";
 const AGENT = "models-agent";
@@ -25,7 +34,12 @@ const stubC = {
 
 async function validate(models: unknown) {
   return orgContext.run({ organizationId: ORG }, () =>
-    validateModelsUpdate({ models, organizationId: ORG, agentId: AGENT, c: stubC })
+    validateModelsUpdate({
+      models,
+      organizationId: ORG,
+      agentId: AGENT,
+      c: stubC,
+    })
   );
 }
 

--- a/packages/server/src/lobu/__tests__/helpers/route-test-mocks.ts
+++ b/packages/server/src/lobu/__tests__/helpers/route-test-mocks.ts
@@ -64,40 +64,23 @@ export function installRouteTestMocks(): void {
   if (installed) return;
   installed = true;
 
-  const mcpAuthMock = async (c: any, next: any) => {
-    c.set('user', authStash.user);
-    c.set('organizationId', authStash.organizationId);
-    c.set('authSource', authStash.authSource);
-    c.set('mcpAuthInfo', authStash.mcpAuthInfo);
-    return next();
-  };
-  const requireAuthMock = async (_c: any, next: any) => next();
-  // Register under every relative form importers in this package use.
-  // bun's mock.module matches the resolved module; multiple specs are cheap
-  // insurance so a static `import '../agent-routes'` that lands before this
-  // helper (evaluation race across files) is less likely to bind the real
-  // mcpAuth — and so agent-routes' own `../auth/middleware` specifier is hit.
-  for (const spec of [
-    '../../../auth/middleware',
-    '../../auth/middleware',
-    '../auth/middleware',
-  ]) {
-    mock.module(spec, () => ({
-      mcpAuth: mcpAuthMock,
-      requireAuth: requireAuthMock,
-    }));
-  }
-
-  // Resolves to src/lobu/gateway — imported by agent-routes.ts as `./gateway`.
-  mock.module('../../gateway', () => ({
-    getChatInstanceManager: () => chatManagerStash.manager,
-    getLobuCoreServices: () => coreServicesStash.services,
-    initLobuGateway: async () => null,
-    stopLobuGateway: async () => {},
-    isLobuGatewayRunning: () => false,
-    ensureEmbeddedGatewaySecrets: () => {},
+  // Specifiers resolve relative to THIS helper file
+  // (`src/lobu/__tests__/helpers/`), so ../../../auth/middleware →
+  // src/auth/middleware and ../../gateway → src/lobu/gateway — the modules
+  // agent-routes actually imports. Extra relative forms would resolve to
+  // non-existent paths from here and only add mock noise (review: slop).
+  mock.module('../../../auth/middleware', () => ({
+    mcpAuth: async (c: any, next: any) => {
+      c.set('user', authStash.user);
+      c.set('organizationId', authStash.organizationId);
+      c.set('authSource', authStash.authSource);
+      c.set('mcpAuthInfo', authStash.mcpAuthInfo);
+      return next();
+    },
+    requireAuth: async (_c: any, next: any) => next(),
   }));
-  mock.module('../gateway', () => ({
+
+  mock.module('../../gateway', () => ({
     getChatInstanceManager: () => chatManagerStash.manager,
     getLobuCoreServices: () => coreServicesStash.services,
     initLobuGateway: async () => null,

--- a/packages/server/src/lobu/__tests__/helpers/route-test-mocks.ts
+++ b/packages/server/src/lobu/__tests__/helpers/route-test-mocks.ts
@@ -64,23 +64,40 @@ export function installRouteTestMocks(): void {
   if (installed) return;
   installed = true;
 
-  // Resolves to src/auth/middleware — the specifier agent-routes.ts imports
-  // as `../auth/middleware`.
-  mock.module('../../../auth/middleware', () => ({
-    mcpAuth: async (c: any, next: any) => {
-      c.set('user', authStash.user);
-      c.set('organizationId', authStash.organizationId);
-      c.set('authSource', authStash.authSource);
-      c.set('mcpAuthInfo', authStash.mcpAuthInfo);
-      return next();
-    },
-    // requireAuth is referenced elsewhere in the module — provide a
-    // passthrough so importing files that destructure it still get a function.
-    requireAuth: async (_c: any, next: any) => next(),
-  }));
+  const mcpAuthMock = async (c: any, next: any) => {
+    c.set('user', authStash.user);
+    c.set('organizationId', authStash.organizationId);
+    c.set('authSource', authStash.authSource);
+    c.set('mcpAuthInfo', authStash.mcpAuthInfo);
+    return next();
+  };
+  const requireAuthMock = async (_c: any, next: any) => next();
+  // Register under every relative form importers in this package use.
+  // bun's mock.module matches the resolved module; multiple specs are cheap
+  // insurance so a static `import '../agent-routes'` that lands before this
+  // helper (evaluation race across files) is less likely to bind the real
+  // mcpAuth — and so agent-routes' own `../auth/middleware` specifier is hit.
+  for (const spec of [
+    '../../../auth/middleware',
+    '../../auth/middleware',
+    '../auth/middleware',
+  ]) {
+    mock.module(spec, () => ({
+      mcpAuth: mcpAuthMock,
+      requireAuth: requireAuthMock,
+    }));
+  }
 
   // Resolves to src/lobu/gateway — imported by agent-routes.ts as `./gateway`.
   mock.module('../../gateway', () => ({
+    getChatInstanceManager: () => chatManagerStash.manager,
+    getLobuCoreServices: () => coreServicesStash.services,
+    initLobuGateway: async () => null,
+    stopLobuGateway: async () => {},
+    isLobuGatewayRunning: () => false,
+    ensureEmbeddedGatewaySecrets: () => {},
+  }));
+  mock.module('../gateway', () => ({
     getChatInstanceManager: () => chatManagerStash.manager,
     getLobuCoreServices: () => coreServicesStash.services,
     initLobuGateway: async () => null,


### PR DESCRIPTION
## Summary

Three follow-ups from the Revolut chrome-dispatch incident:

### 1. OOM — what took the memory
Prometheus previously showed app-pod working-set **pinned at the 2Gi cgroup limit** while parent Node heap was only ~300MB. The ~1.7GB gap is **in-pod agent-worker child subprocesses** (each turn = `node dist/index.js` counting against the pod cgroup). Live Helm overlay still forced **2Gi / 1CPU** + `NODE_OPTIONS=--max-old-space-size=1800`, leaving almost no room for children.

**Fix (owletto submodule):** raise prod overlay to **4Gi / 3CPU**, parent heap **1536MB**, set `LOBU_WORKER_MAX_OLD_SPACE_MB=512`.

### 2. Revolut `worker_claim_timeout`
Scheduled revolut syncs at 00/06/12/18 were never claimed (reaper → `worker_claim_timeout`). Fleet should claim browser-affinity pins (poll.ts 1A). With the gateway event loop CFS-throttled/OOM-killed under 2Gi/1CPU, **fleet `/api/workers/poll` cannot complete** → runs stay pending past the 120s reaper. The pin-collision 500 (already merged #1995) was a separate failure once a claim did land.

No claim-path code change here — the OOM capacity fix is the primary remedy. Live verification still needs cluster access (kubectl currently times out).

### 3. Integration CI failures
`bun test src/gateway/__tests__` loads every file in one process. `mock.module` is **process-global and not undone by `mock.restore()`**.

- `slack-pending-install-claim` stubbed `getSlackInstallByTeamId → null` → coordinator tests fell through to `createOAuthChat` and died on missing `SLACK_SIGNING_SECRET`
- Whole-module `provider-secrets` stubs dropped real exports → model-fallback byo2 looked undecryptable
- `http-proxy`/`proxy-hardening` deleted `ENCRYPTION_KEY` without restore → later `encrypt()` threw

Converted to `spyOn` / spread-real-module patterns; pin encryption key where needed.

## Test plan
- [x] Co-run polluter + victim suites (101 pass)
- [x] slack-connection-coordinator alone + with pending-claim
- [x] worker-session-context-model-fallback
- [x] auth/__tests__ full dir (70 pass)
- [x] http-proxy + proxy-hardening + worker-job-router co-run
- [ ] CI integration job on this PR
- [ ] After owletto merge/Flux: confirm prod pod limits 4Gi/3CPU and no new OOMKills
- [ ] Re-trigger Revolut sync and confirm claim (not `worker_claim_timeout`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved suite isolation by snapshotting/restoring environment variables and hardening teardown across gateway and auth tests.
  - Reduced cross-suite interference by switching from whole-module mocking to targeted spies with explicit restoration.
  - Stabilized encryption-dependent behavior by consistently resetting the shared encryption-key cache and restoring the prior encryption key.
  - Made test setup order-independent by ensuring encryption key initialization and installing route mocks before importing modules.
- **Bug Fixes**
  - Ensured the “disable nix-shell” flag is honored even if nix-shell capability was previously memoized.
- **Chores**
  - Updated the bundled `owletto` revision to the latest available revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->