### PR TITLE
Add evidence-backed watcher merge approvals

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -274,6 +274,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@sentry/react": "^10.51.0",
+        "@shadcn/react": "^0.2.1",
         "@tanstack/react-query": "^5.64.0",
         "@tanstack/react-router": "^1.95.0",
         "@tanstack/react-table": "^8.21.3",
@@ -1678,6 +1679,8 @@
     "@sentry/opentelemetry": ["@sentry/opentelemetry@9.47.1", "", { "dependencies": { "@sentry/core": "9.47.1" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0", "@opentelemetry/core": "^1.30.1 || ^2.0.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0", "@opentelemetry/semantic-conventions": "^1.34.0" } }, "sha512-STtFpjF7lwzeoedDJV+5XA6P89BfmFwFftmHSGSe3UTI8z8IoiR5yB6X2vCjSPvXlfeOs13qCNNCEZyznxM8Xw=="],
 
     "@sentry/react": ["@sentry/react@10.53.1", "", { "dependencies": { "@sentry/browser": "10.53.1", "@sentry/core": "10.53.1" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-lrwNq5T/zW84l60894TpKHPcvFuc1I/Hnohecc0TfYVpIcYYuw2orCHoU4v4wgkFaJUpegVetbgdOphViyLVjA=="],
+
+    "@shadcn/react": ["@shadcn/react@0.2.1", "", { "peerDependencies": { "@types/react": ">=19", "react": ">=19" }, "optionalPeers": ["@types/react", "react"] }, "sha512-5krgi3dRMKb5jH6a+qPzVJUy/54s0kKE4Rw4LjDfLqOdVQTWKUgxWf1kW8r912I0jX/Lzxqc+pgjkjWxUIK5BQ=="],
 
     "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
 

--- a/db/migrations/20260716010000_entity_identity_connection.sql
+++ b/db/migrations/20260716010000_entity_identity_connection.sql
@@ -3,13 +3,34 @@
 -- An identity's connector key identifies the integration type, not the exact
 -- installed account that asserted it. Keep that durable provenance on the
 -- identity claim so merge reviewers can inspect the source connection.
-ALTER TABLE public.entity_identities
-  ADD COLUMN IF NOT EXISTS connection_id bigint REFERENCES public.connections(id) ON DELETE SET NULL;
+--
+-- Metadata-only (transaction-safe): a nullable column add plus a NOT VALID FK.
+-- The referencing-side index is built CONCURRENTLY in the follow-on
+-- transaction:false migration (a CONCURRENTLY build can't run in a transaction).
 
-CREATE INDEX IF NOT EXISTS idx_entity_identities_connection_id
-  ON public.entity_identities(connection_id);
+-- Nullable column add is metadata-only (no table rewrite / no default backfill).
+ALTER TABLE public.entity_identities
+  ADD COLUMN IF NOT EXISTS connection_id bigint;
+
+-- FK added NOT VALID: skips the validating full-table scan + the SHARE ROW
+-- EXCLUSIVE lock on both tables at add time. The column was just introduced, so
+-- there are no pre-existing non-null values to validate — no VALIDATE pass is
+-- needed and none is emitted. The constraint still fully enforces every future
+-- write. Guarded by pg_constraint so a re-run is a no-op.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'entity_identities_connection_id_fkey'
+      AND conrelid = 'public.entity_identities'::regclass
+  ) THEN
+    ALTER TABLE public.entity_identities
+      ADD CONSTRAINT entity_identities_connection_id_fkey
+      FOREIGN KEY (connection_id) REFERENCES public.connections(id) ON DELETE SET NULL NOT VALID;
+  END IF;
+END $$;
 
 -- migrate:down
 
-DROP INDEX IF EXISTS public.idx_entity_identities_connection_id;
+ALTER TABLE public.entity_identities DROP CONSTRAINT IF EXISTS entity_identities_connection_id_fkey;
 ALTER TABLE public.entity_identities DROP COLUMN IF EXISTS connection_id;

--- a/db/migrations/20260716010000_entity_identity_connection.sql
+++ b/db/migrations/20260716010000_entity_identity_connection.sql
@@ -1,0 +1,15 @@
+-- migrate:up
+
+-- An identity's connector key identifies the integration type, not the exact
+-- installed account that asserted it. Keep that durable provenance on the
+-- identity claim so merge reviewers can inspect the source connection.
+ALTER TABLE public.entity_identities
+  ADD COLUMN IF NOT EXISTS connection_id bigint REFERENCES public.connections(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_entity_identities_connection_id
+  ON public.entity_identities(connection_id);
+
+-- migrate:down
+
+DROP INDEX IF EXISTS public.idx_entity_identities_connection_id;
+ALTER TABLE public.entity_identities DROP COLUMN IF EXISTS connection_id;

--- a/db/migrations/20260716010001_entity_identity_connection_id_index.sql
+++ b/db/migrations/20260716010001_entity_identity_connection_id_index.sql
@@ -1,0 +1,18 @@
+-- migrate:up transaction:false
+
+-- Index the FK referencing side: entity_identities.connection_id →
+-- connections(id). Postgres does not auto-index the referencing side, so
+-- deleting a connections row would seq-scan (and lock) entity_identities.
+-- Built CONCURRENTLY so it only takes SHARE UPDATE EXCLUSIVE and reads + writes
+-- continue. One statement per transaction:false migration: dbmate sends the up
+-- block as a single simple-query batch and Postgres wraps any multi-statement
+-- batch in an implicit transaction that CONCURRENTLY refuses to run inside.
+-- The CONCURRENTLY + IF NOT EXISTS invalid-index trap recovery is in
+-- docs/MIGRATIONS.md.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_entity_identities_connection_id
+    ON public.entity_identities (connection_id);
+
+-- migrate:down transaction:false
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_entity_identities_connection_id;

--- a/packages/core/src/contracts/tools/manage-entity.ts
+++ b/packages/core/src/contracts/tools/manage-entity.ts
@@ -452,15 +452,33 @@ export const ManageEntityResultSchema = Type.Union([
       has_more: Type.Boolean(),
     }),
   }),
-  Type.Object({
-    action: Type.Literal("merge"),
-    success: Type.Boolean(),
-    message: Type.String(),
-    winner_entity_id: Type.Integer(),
-    loser_entity_id: Type.Integer(),
-    moved_identities: Type.Integer(),
-    repointed_edges: Type.Integer(),
-  }),
+  Type.Union([
+    Type.Object({
+      action: Type.Literal("merge"),
+      success: Type.Boolean(),
+      message: Type.String(),
+      winner_entity_id: Type.Integer(),
+      loser_entity_id: Type.Integer(),
+      moved_identities: Type.Integer(),
+      repointed_edges: Type.Integer(),
+    }),
+    Type.Object({
+      action: Type.Literal("merge"),
+      approval_queued: Type.Literal(true),
+      approval_url: Type.Optional(Type.String()),
+      approval_run_id: Type.Integer(),
+      approval_action: Type.Literal("merge"),
+      approval_proposal: Type.Object({
+        entity_id: Type.Integer(),
+        winner_entity_id: Type.Integer(),
+      }),
+      approval_attribution: Type.Union([
+        Type.Literal("agent"),
+        Type.Literal("watcher"),
+      ]),
+      next_steps: Type.Array(Type.String()),
+    }),
+  ]),
   Type.Object({
     action: Type.Literal("unmerge"),
     success: Type.Boolean(),

--- a/packages/core/src/contracts/tools/manage-entity.ts
+++ b/packages/core/src/contracts/tools/manage-entity.ts
@@ -57,6 +57,29 @@ export const ManageEntitySchema = Type.Object({
     })
   ),
 
+  duplicate_entity_ids: Type.Optional(
+    Type.Array(Type.Number(), {
+      minItems: 1,
+      uniqueItems: true,
+      description:
+        "[merge] All duplicate entities to fold into winner_entity_id. Use this for a duplicate group; entity_id remains supported for a single duplicate.",
+    })
+  ),
+
+  merge_evidence: Type.Optional(
+    Type.Array(
+      Type.Object({
+        kind: Type.String(),
+        identifier: Type.String(),
+        identity_ids: Type.Optional(Type.Array(Type.Number())),
+      }),
+      {
+        description:
+          "[merge] Structured identity evidence the reviewer should verify, such as a shared email or phone.",
+      }
+    )
+  ),
+
   // Entity type (required for create, list)
   entity_type: Type.Optional(
     Type.String({
@@ -459,6 +482,7 @@ export const ManageEntityResultSchema = Type.Union([
       message: Type.String(),
       winner_entity_id: Type.Integer(),
       loser_entity_id: Type.Integer(),
+      loser_entity_ids: Type.Optional(Type.Array(Type.Integer())),
       moved_identities: Type.Integer(),
       repointed_edges: Type.Integer(),
     }),
@@ -470,6 +494,7 @@ export const ManageEntityResultSchema = Type.Union([
       approval_action: Type.Literal("merge"),
       approval_proposal: Type.Object({
         entity_id: Type.Integer(),
+        entity_ids: Type.Optional(Type.Array(Type.Integer())),
         winner_entity_id: Type.Integer(),
       }),
       approval_attribution: Type.Union([

--- a/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
+++ b/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
@@ -265,10 +265,10 @@ describe("listAgentThreads scope=all", () => {
 			"watcher run output",
 		);
 		expect(data.interactions).toEqual([
-				expect.objectContaining({
-					type: "tool-approval",
-					eventId: expect.any(Number),
-					action: "update",
+			expect.objectContaining({
+				type: "tool-approval",
+				eventId: expect.any(Number),
+				action: "update",
 				fields: { email: "new@example.com" },
 				attribution: "watcher",
 				resourceKind: "entity",

--- a/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
+++ b/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
@@ -265,9 +265,10 @@ describe("listAgentThreads scope=all", () => {
 			"watcher run output",
 		);
 		expect(data.interactions).toEqual([
-			expect.objectContaining({
-				type: "tool-approval",
-				action: "update",
+				expect.objectContaining({
+					type: "tool-approval",
+					eventId: expect.any(Number),
+					action: "update",
 				fields: { email: "new@example.com" },
 				attribution: "watcher",
 				resourceKind: "entity",

--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -5,118 +5,187 @@
  * The fusion mechanics themselves are proven in events/entity-merge.test.ts.
  */
 
-import { beforeEach, describe, expect, it } from 'vitest';
-import type { Env } from '../../../index';
-import { manageEntity } from '../../../tools/admin/manage_entity';
-import type { ToolContext } from '../../../tools/registry';
-import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../../../index";
+import { manageEntity } from "../../../tools/admin/manage_entity";
+import { manageOperations } from "../../../tools/admin/manage_operations";
+import type { ToolContext } from "../../../tools/registry";
+import { initWorkspaceProvider } from "../../../workspace";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
-  addUserToOrganization,
-  createTestEntity,
-  createTestOrganization,
-  createTestUser,
-} from '../../setup/test-fixtures';
+	addUserToOrganization,
+	createTestEntity,
+	createTestOrganization,
+	createTestUser,
+} from "../../setup/test-fixtures";
 
 const env = {} as Env;
 
 function ctx(orgId: string, userId: string, memberRole: string): ToolContext {
-  // Full MCP scopes so the action-router's scope gate passes; the test asserts
-  // the ROLE gate (admin/owner) inside the handler, not the scope tier.
-  return {
-    organizationId: orgId,
-    userId,
-    memberRole,
-    scopes: ['mcp:read', 'mcp:write', 'mcp:admin'],
-  } as ToolContext;
+	// Full MCP scopes so the action-router's scope gate passes; the test asserts
+	// the ROLE gate (admin/owner) inside the handler, not the scope tier.
+	return {
+		organizationId: orgId,
+		userId,
+		memberRole,
+		scopes: ["mcp:read", "mcp:write", "mcp:admin"],
+	} as ToolContext;
 }
 
-describe('manage_entity merge action', () => {
-  beforeEach(async () => {
-    await cleanupTestDatabase();
-  });
+describe("manage_entity merge action", () => {
+	beforeEach(async () => {
+		await cleanupTestDatabase();
+		await initWorkspaceProvider();
+	});
 
-  async function twoEntities(orgId: string, userId: string) {
-    const winner = await createTestEntity({
-      name: 'Winner',
-      entity_type: 'person',
-      organization_id: orgId,
-      created_by: userId,
-    });
-    const loser = await createTestEntity({
-      name: 'Loser',
-      entity_type: 'person',
-      organization_id: orgId,
-      created_by: userId,
-    });
-    return { winner, loser };
-  }
+	async function twoEntities(orgId: string, userId: string) {
+		const winner = await createTestEntity({
+			name: "Winner",
+			entity_type: "person",
+			organization_id: orgId,
+			created_by: userId,
+		});
+		const loser = await createTestEntity({
+			name: "Loser",
+			entity_type: "person",
+			organization_id: orgId,
+			created_by: userId,
+		});
+		return { winner, loser };
+	}
 
-  it('an owner merges the loser into the winner (loser tombstoned + forwarded)', async () => {
-    const org = await createTestOrganization({ name: 'Merge Tool Org' });
-    const user = await createTestUser();
-    await addUserToOrganization(user.id, org.id, 'owner');
-    const { winner, loser } = await twoEntities(org.id, user.id);
+	it("an owner merges the loser into the winner (loser tombstoned + forwarded)", async () => {
+		const org = await createTestOrganization({ name: "Merge Tool Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
 
-    const res = (await manageEntity(
-      { action: 'merge', entity_id: loser.id, winner_entity_id: winner.id },
-      env,
-      ctx(org.id, user.id, 'owner')
-    )) as { action: string; success: boolean; winner_entity_id: number; loser_entity_id: number };
+		const res = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			ctx(org.id, user.id, "owner"),
+		)) as {
+			action: string;
+			success: boolean;
+			winner_entity_id: number;
+			loser_entity_id: number;
+		};
 
-    expect(res.action).toBe('merge');
-    expect(res.success).toBe(true);
-    expect(res.winner_entity_id).toBe(winner.id);
-    expect(res.loser_entity_id).toBe(loser.id);
+		expect(res.action).toBe("merge");
+		expect(res.success).toBe(true);
+		expect(res.winner_entity_id).toBe(winner.id);
+		expect(res.loser_entity_id).toBe(loser.id);
 
-    const sql = getTestDb();
-    const [row] = (await sql`
+		const sql = getTestDb();
+		const [row] = (await sql`
       SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}
     `) as Array<{ merged_into: number | null; deleted_at: string | null }>;
-    expect(Number(row.merged_into)).toBe(winner.id);
-    expect(row.deleted_at).not.toBeNull();
-  });
+		expect(Number(row.merged_into)).toBe(winner.id);
+		expect(row.deleted_at).not.toBeNull();
+	});
 
-  it('rejects a non-admin member (403)', async () => {
-    const org = await createTestOrganization({ name: 'Gate Org' });
-    const user = await createTestUser();
-    await addUserToOrganization(user.id, org.id, 'member');
-    const { winner, loser } = await twoEntities(org.id, user.id);
+	it("rejects a non-admin member (403)", async () => {
+		const org = await createTestOrganization({ name: "Gate Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "member");
+		const { winner, loser } = await twoEntities(org.id, user.id);
 
-    await expect(
-      manageEntity(
-        { action: 'merge', entity_id: loser.id, winner_entity_id: winner.id },
-        env,
-        ctx(org.id, user.id, 'member')
-      )
-    ).rejects.toThrow(/admin or owner/i);
-  });
+		await expect(
+			manageEntity(
+				{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+				env,
+				ctx(org.id, user.id, "member"),
+			),
+		).rejects.toThrow(/admin or owner/i);
+	});
 
-  it('rejects a winner from another org (org fence, 404)', async () => {
-    const orgA = await createTestOrganization({ name: 'Org A' });
-    const orgB = await createTestOrganization({ name: 'Org B' });
-    const userA = await createTestUser();
-    const userB = await createTestUser();
-    await addUserToOrganization(userA.id, orgA.id, 'owner');
-    await addUserToOrganization(userB.id, orgB.id, 'owner');
-    const loser = await createTestEntity({
-      name: 'A-loser',
-      entity_type: 'person',
-      organization_id: orgA.id,
-      created_by: userA.id,
-    });
-    const foreignWinner = await createTestEntity({
-      name: 'B-winner',
-      entity_type: 'person',
-      organization_id: orgB.id,
-      created_by: userB.id,
-    });
+	it("rejects a winner from another org (org fence, 404)", async () => {
+		const orgA = await createTestOrganization({ name: "Org A" });
+		const orgB = await createTestOrganization({ name: "Org B" });
+		const userA = await createTestUser();
+		const userB = await createTestUser();
+		await addUserToOrganization(userA.id, orgA.id, "owner");
+		await addUserToOrganization(userB.id, orgB.id, "owner");
+		const loser = await createTestEntity({
+			name: "A-loser",
+			entity_type: "person",
+			organization_id: orgA.id,
+			created_by: userA.id,
+		});
+		const foreignWinner = await createTestEntity({
+			name: "B-winner",
+			entity_type: "person",
+			organization_id: orgB.id,
+			created_by: userB.id,
+		});
 
-    await expect(
-      manageEntity(
-        { action: 'merge', entity_id: loser.id, winner_entity_id: foreignWinner.id },
-        env,
-        ctx(orgA.id, userA.id, 'owner')
-      )
-    ).rejects.toThrow(/not found in this workspace/i);
-  });
+		await expect(
+			manageEntity(
+				{
+					action: "merge",
+					entity_id: loser.id,
+					winner_entity_id: foreignWinner.id,
+				},
+				env,
+				ctx(orgA.id, userA.id, "owner"),
+			),
+		).rejects.toThrow(/not found in this workspace/i);
+	});
+
+	it("queues a watcher merge for human approval and applies it only after approval", async () => {
+		const org = await createTestOrganization({
+			name: "Watcher Merge Approval Org",
+		});
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+		await sql`
+      INSERT INTO watchers
+        (id, organization_id, agent_id, created_by, watcher_group_id, name,
+         status, notification_channel, notification_priority, min_cooldown_seconds,
+         created_at, updated_at)
+      VALUES
+        (6001, ${org.id}, 'personal-agent', ${user.id}, 6001, 'Duplicate merge',
+         'active', 'canvas', 'normal', 0, now(), now())
+    `;
+
+		const watcherCtx = {
+			...ctx(org.id, user.id, "owner"),
+			userId: null,
+			agentId: "personal-agent",
+			actingWatcherId: 6001,
+		} as ToolContext;
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			watcherCtx,
+		)) as unknown as { approval_queued: boolean; approval_run_id: number };
+
+		expect(queued.approval_queued).toBe(true);
+		const [before] =
+			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
+		expect(before.merged_into).toBeNull();
+		expect(before.deleted_at).toBeNull();
+		const [pending] = await sql`
+      SELECT watcher_id, approval_status, action_input FROM runs WHERE id = ${queued.approval_run_id}
+    `;
+		expect(Number(pending.watcher_id)).toBe(6001);
+		expect(pending.approval_status).toBe("pending");
+		expect((pending.action_input as Record<string, unknown>).operation).toBe(
+			"merge",
+		);
+
+		const approved = await manageOperations(
+			{ action: "approve", run_id: queued.approval_run_id },
+			env,
+			ctx(org.id, user.id, "owner"),
+		);
+		expect("approved" in approved && approved.approved).toBe(true);
+
+		const [after] =
+			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
+		expect(Number(after.merged_into)).toBe(winner.id);
+		expect(after.deleted_at).not.toBeNull();
+	});
 });

--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -188,4 +188,46 @@ describe("manage_entity merge action", () => {
 		expect(Number(after.merged_into)).toBe(winner.id);
 		expect(after.deleted_at).not.toBeNull();
 	});
+
+	it("does not apply an approved watcher merge when the loser was deleted after proposal", async () => {
+		const org = await createTestOrganization({ name: "Stale Merge Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+		await sql`
+      INSERT INTO watchers
+        (id, organization_id, agent_id, created_by, watcher_group_id, name,
+         status, notification_channel, notification_priority, min_cooldown_seconds,
+         created_at, updated_at)
+      VALUES
+        (6002, ${org.id}, 'personal-agent', ${user.id}, 6002, 'Stale duplicate merge',
+         'active', 'canvas', 'normal', 0, now(), now())
+    `;
+
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				userId: null,
+				agentId: "personal-agent",
+				actingWatcherId: 6002,
+			} as ToolContext,
+		)) as unknown as { approval_run_id: number };
+
+		await sql`UPDATE entities SET deleted_at = now() WHERE id = ${loser.id}`;
+		const approved = await manageOperations(
+			{ action: "approve", run_id: queued.approval_run_id },
+			env,
+			ctx(org.id, user.id, "owner"),
+		);
+
+		expect("approved" in approved && approved.approved).toBe(false);
+		const [after] = await sql`
+      SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}
+    `;
+		expect(after.merged_into).toBeNull();
+		expect(after.deleted_at).not.toBeNull();
+	});
 });

--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -14,6 +14,7 @@ import { initWorkspaceProvider } from "../../../workspace";
 import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import {
 	addUserToOrganization,
+	createTestConnection,
 	createTestEntity,
 	createTestOrganization,
 	createTestUser,
@@ -187,6 +188,158 @@ describe("manage_entity merge action", () => {
 			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
 		expect(Number(after.merged_into)).toBe(winner.id);
 		expect(after.deleted_at).not.toBeNull();
+	});
+
+	it("queues one atomic watcher approval for a duplicate group", async () => {
+		const org = await createTestOrganization({
+			name: "Group Merge Approval Org",
+		});
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const secondLoser = await createTestEntity({
+			name: "Second loser",
+			entity_type: "person",
+			organization_id: org.id,
+			created_by: user.id,
+		});
+		const sql = getTestDb();
+		const connection = await createTestConnection({
+			organization_id: org.id,
+			connector_key: "google-contacts",
+			display_name: "Personal Google Contacts",
+			created_by: user.id,
+			createDefaultFeed: false,
+		});
+		await sql`
+      INSERT INTO entity_identities
+        (organization_id, entity_id, namespace, identifier, source_connector, connection_id)
+      VALUES
+        (${org.id}, ${loser.id}, 'email', 'duplicate@example.com',
+         'connector:google-contacts', ${connection.id})
+    `;
+		await sql`
+      INSERT INTO watchers
+        (id, organization_id, agent_id, created_by, watcher_group_id, name,
+         status, notification_channel, notification_priority, min_cooldown_seconds,
+         created_at, updated_at)
+      VALUES
+        (6003, ${org.id}, 'personal-agent', ${user.id}, 6003, 'Group duplicate merge',
+         'active', 'canvas', 'normal', 0, now(), now())
+    `;
+
+		const queued = (await manageEntity(
+			{
+				action: "merge",
+				duplicate_entity_ids: [loser.id, secondLoser.id],
+				winner_entity_id: winner.id,
+			},
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				userId: null,
+				agentId: "personal-agent",
+				actingWatcherId: 6003,
+			} as ToolContext,
+		)) as unknown as { approval_run_id: number };
+
+		const [pending] = await sql`
+      SELECT action_input FROM runs WHERE id = ${queued.approval_run_id}
+    `;
+		expect(pending.action_input).toMatchObject({
+			operation: "merge",
+			entity_ids: [loser.id, secondLoser.id],
+			winner_entity_id: winner.id,
+		});
+		const [approvalEvent] = await sql`
+      SELECT metadata FROM current_event_records
+      WHERE run_id = ${queued.approval_run_id} AND interaction_status = 'pending'
+    `;
+		const current = (approvalEvent.metadata as Record<string, unknown>)
+			.current as {
+			duplicates: Array<{
+				href: string;
+				identities: Array<Record<string, unknown>>;
+			}>;
+		};
+		expect(current.duplicates[0]?.href).toContain("/person/");
+		expect(current.duplicates[0]?.identities[0]).toMatchObject({
+			identifier: "duplicate@example.com",
+			connection_id: connection.id,
+			connection_name: "Personal Google Contacts",
+			connector_key: "google-contacts",
+		});
+		expect(current.duplicates[0]?.identities[0]?.connection_href).toContain(
+			`/connectors/google-contacts/${connection.id}`,
+		);
+
+		const approved = await manageOperations(
+			{ action: "approve", run_id: queued.approval_run_id },
+			env,
+			ctx(org.id, user.id, "owner"),
+		);
+		expect("approved" in approved && approved.approved).toBe(true);
+		const rows = await sql`
+      SELECT id, merged_into, deleted_at
+      FROM entities
+      WHERE id IN (${loser.id}, ${secondLoser.id})
+      ORDER BY id
+    `;
+		expect(rows).toHaveLength(2);
+		expect(rows.every((row) => Number(row.merged_into) === winner.id)).toBe(
+			true,
+		);
+		expect(rows.every((row) => row.deleted_at !== null)).toBe(true);
+	});
+
+	it("rolls back the whole duplicate group when one member is stale", async () => {
+		const org = await createTestOrganization({ name: "Stale Group Merge Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const staleLoser = await createTestEntity({
+			name: "Stale loser",
+			entity_type: "person",
+			organization_id: org.id,
+			created_by: user.id,
+		});
+		const sql = getTestDb();
+		await sql`
+      INSERT INTO watchers
+        (id, organization_id, agent_id, created_by, watcher_group_id, name,
+         status, notification_channel, notification_priority, min_cooldown_seconds,
+         created_at, updated_at)
+      VALUES
+        (6004, ${org.id}, 'personal-agent', ${user.id}, 6004, 'Stale group merge',
+         'active', 'canvas', 'normal', 0, now(), now())
+    `;
+		const queued = (await manageEntity(
+			{
+				action: "merge",
+				duplicate_entity_ids: [loser.id, staleLoser.id],
+				winner_entity_id: winner.id,
+			},
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				userId: null,
+				agentId: "personal-agent",
+				actingWatcherId: 6004,
+			} as ToolContext,
+		)) as unknown as { approval_run_id: number };
+
+		await sql`UPDATE entities SET deleted_at = now() WHERE id = ${staleLoser.id}`;
+		const approved = await manageOperations(
+			{ action: "approve", run_id: queued.approval_run_id },
+			env,
+			ctx(org.id, user.id, "owner"),
+		);
+		expect("approved" in approved && approved.approved).toBe(false);
+		const [first] = await sql`
+      SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}
+    `;
+		expect(first.merged_into).toBeNull();
+		expect(first.deleted_at).toBeNull();
 	});
 
 	it("does not apply an approved watcher merge when the loser was deleted after proposal", async () => {

--- a/packages/server/src/__tests__/unit/approval-notification-render.test.ts
+++ b/packages/server/src/__tests__/unit/approval-notification-render.test.ts
@@ -7,8 +7,8 @@ import {
 } from "../../notifications/triggers";
 
 /**
- * Golden-pins the approval card/body rendering for all three shapes
- * (field change, entity create, entity delete) plus the generic fallback —
+ * Golden-pins the approval card/body rendering for all four shapes
+ * (field change, entity create, entity delete, entity merge) plus the generic fallback —
  * captured from the pre-unification renderer, so the shared model+emitters
  * must stay byte-identical to the three historical blocks.
  */
@@ -136,6 +136,34 @@ describe("approval notification rendering", () => {
 				"*Entity:* <https://app.lobu.ai/acme/topic/old-topic|Old Topic>\n" +
 				"\n*Proposed action:* Delete this entity\n" +
 				"*Entity id:* 11\n*Entity type:* topic\n*Name:* Old &lt;Topic&gt;\n*Force delete tree:* false",
+		);
+	});
+
+	test("entity merge: names both entities and renders a merge action", () => {
+		const details: ActionApprovalDetails = {
+			kind: "entity_change",
+			operation: "merge",
+			actorLabel: "A watcher",
+			entityId: 12,
+			entityType: "person",
+			entityName: "Duplicate Person",
+			proposal: {
+				entity_id: 12,
+				winner_entity_id: 10,
+				name: "Duplicate Person",
+				winner_name: "Canonical Person",
+			},
+			reason: "Duplicate entities need approval before merging.",
+		};
+
+		expect(formatActionApprovalTitle("entity_change", details)).toBe(
+			"Review merging person",
+		);
+		expect(formatActionApprovalBody({ details })).toContain(
+			"**A watcher** wants to merge Duplicate Person (#12).",
+		);
+		expect(cardText(buildActionApprovalCard({ details }))).toContain(
+			"*Proposed action:* Merge these entities",
 		);
 	});
 

--- a/packages/server/src/catalog/watcher-templates.test.ts
+++ b/packages/server/src/catalog/watcher-templates.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { WATCHER_CATALOG_TEMPLATES } from "./watcher-templates";
+
+describe("duplicate merge watcher template", () => {
+	it("creates one approval-gated merge proposal per duplicate group", () => {
+		const template = WATCHER_CATALOG_TEMPLATES.find(
+			(entry) => entry.id === "duplicate-merge",
+		);
+		const prompt = String(template?.detail?.prompt ?? "");
+
+		expect(prompt).toContain("duplicate_entity_ids");
+		expect(prompt).toContain("merge_evidence");
+		expect(prompt).toContain("one pending human approval for the whole group");
+		expect(prompt).toContain("Never substitute textual backlog tasks");
+	});
+});

--- a/packages/server/src/catalog/watcher-templates.ts
+++ b/packages/server/src/catalog/watcher-templates.ts
@@ -93,12 +93,12 @@ export const WATCHER_CATALOG_TEMPLATES: CatalogEntry[] = [
 			schedule: "0 3 * * *",
 			// A cross-entity watcher: its source surfaces look-alike PEOPLE (shared
 			// alias / overlapping identity value) rather than events. The reader
-			// picks the pair; the agent decides confidence and calls the merge tool.
+			// groups candidates; the agent decides confidence and proposes each group.
 			// `@entity:person` gives the agent the candidate set + their aliases so
 			// it can reason about which pairs are truly the same.
 			sources: [{ name: "people", query: "@entity:person" }],
 			prompt:
-				"Some of these person entities may be duplicates — the SAME real-world person captured twice (e.g. once from a chat handle, once from an email), each holding different identifiers or aliases. Compare them: shared aliases, matching names, overlapping identity values (email, phone, handle) are strong signals; a mere name similarity alone is NOT.\n\nFor each pair you are confident is the same person, merge the duplicate into the more complete record with manage_entity(action='merge', entity_id=<duplicate>, winner_entity_id=<keep>). The duplicate's identities, aliases, edges, and events will recall against the survivor; events are never rewritten, and the merge is reversible.\n\nReturn the merges you performed and, separately, any uncertain pairs you did NOT merge (with why) so a human can review them.\n",
+				"Some of these person entities may be duplicates — the SAME real-world person captured more than once (e.g. once from a chat handle, once from an email), each holding different identifiers or aliases. Group records that represent one person. Shared aliases or overlapping identity values (email, phone, handle) are strong signals; mere name similarity alone is NOT.\n\nFor each group you are confident represents one person, choose the most complete record as canonical and call manage_entity(action='merge', duplicate_entity_ids=[<every duplicate id>], winner_entity_id=<canonical id>, merge_evidence=[{ kind: <email|phone|handle|alias>, identifier: <matching value> }]). This call creates one pending human approval for the whole group; it does not merge before approval. The duplicate identities, aliases, edges, and events will recall against the survivor after approval; events are never rewritten, and the merge is reversible.\n\nReturn the approval proposals you created and, separately, any uncertain groups you did not propose (with why). Never substitute textual backlog tasks for manage_entity calls.\n",
 			reactions_guidance:
 				"Only merge when the evidence is strong (a shared identity value or alias, not just a similar name). When unsure, leave the pair unmerged and report it for human review rather than guessing — a wrong merge is costly to notice.",
 			tags: ["identity", "deduplication", "world-model"],

--- a/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
+++ b/packages/server/src/gateway/__tests__/interaction-bridge-slack-webhook.test.ts
@@ -383,7 +383,12 @@ describe("Slack block_actions → run-approval entity_field_change (Tier B)", ()
       SELECT metadata FROM entities WHERE id = ${fx.entityId}
     `;
     expect(entity.metadata.severity).toBe("high");
-    expect(h.postMessage).toHaveBeenCalled();
+    // The webhook returns 200 before the async onAction handler finishes:
+    // the run is marked completed and the field change applied inside
+    // manageOperations, and only then does the handler post the confirmation
+    // via thread.post -> postMessage. Poll for the post so we don't race the
+    // DB-state waitFor above (matches the unverified-user test below).
+    await waitFor(() => expect(h.postMessage).toHaveBeenCalled());
   });
 
   test("signed Reject button leaves the entity unchanged", async () => {

--- a/packages/server/src/gateway/services/watcher-run-thread.ts
+++ b/packages/server/src/gateway/services/watcher-run-thread.ts
@@ -25,6 +25,7 @@ export async function readWatcherRunThreads(args: {
 	}>;
 	interactions: Array<{
 		type: "tool-approval";
+		eventId: number;
 		runId: number;
 		action: string | null;
 		proposal: Record<string, unknown> | null;
@@ -80,6 +81,7 @@ export async function readWatcherRunThreads(args: {
 	// pending approval may also belong to a run that has no completed snapshot,
 	// so fetch it independently and let the client append it to the conversation.
 	const approvalRows = await sql<{
+		event_id: number;
 		run_id: number;
 		action: string | null;
 		proposal: Record<string, unknown> | null;
@@ -89,7 +91,8 @@ export async function readWatcherRunThreads(args: {
 		resource_kind: string | null;
 		tool: string | null;
 	}>`
-		SELECT e.run_id,
+		SELECT e.id AS event_id,
+		       e.run_id,
 		       e.metadata->>'action' AS action,
 		       e.metadata->'proposal' AS proposal,
 		       e.metadata->'current' AS current,
@@ -130,6 +133,7 @@ export async function readWatcherRunThreads(args: {
 				: rawProposal;
 		return {
 			type: "tool-approval" as const,
+			eventId: Number(row.event_id),
 			runId: Number(row.run_id),
 			action: row.action,
 			proposal,

--- a/packages/server/src/gateway/services/watcher-run-thread.ts
+++ b/packages/server/src/gateway/services/watcher-run-thread.ts
@@ -47,22 +47,23 @@ export async function readWatcherRunThreads(args: {
 		created_at: Date;
 		snapshot_jsonl: string;
 	}>`
-    SELECT DISTINCT ON (conversation_id)
-      conversation_id, created_at, snapshot_jsonl
-    FROM public.agent_transcript_snapshot
-    WHERE organization_id = ${organizationId}
-      AND agent_id = ${agentId}
-      AND conversation_id LIKE ${`${prefix}_run_%`}
-      AND terminal_status = 'completed'
-    ORDER BY conversation_id, created_at DESC
-  `;
+		WITH latest_per_run AS (
+			SELECT DISTINCT ON (conversation_id)
+			  conversation_id, created_at, snapshot_jsonl
+			FROM public.agent_transcript_snapshot
+			WHERE organization_id = ${organizationId}
+			  AND agent_id = ${agentId}
+			  AND conversation_id LIKE ${`${prefix}_run_%`}
+			  AND terminal_status = 'completed'
+			ORDER BY conversation_id, created_at DESC
+		)
+		SELECT conversation_id, created_at, snapshot_jsonl
+		FROM latest_per_run
+		ORDER BY created_at DESC
+		LIMIT ${limit}
+	`;
 
-	// DISTINCT ON gives the latest snapshot per run; order across runs by recency.
-	const recent = rows
-		.sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
-		.slice(0, limit);
-
-	const runs = recent.map((row) => {
+	const runs = rows.map((row) => {
 		const runId = Number(row.conversation_id.match(/_run_(\d+)$/)?.[1] ?? 0);
 		const { messages } = paginateSessionMessages(row.snapshot_jsonl, "", 200, {
 			excludeVerbose: true,

--- a/packages/server/src/notifications/triggers.ts
+++ b/packages/server/src/notifications/triggers.ts
@@ -24,7 +24,7 @@ type FieldChangeApprovalDetails = {
 
 type EntityChangeApprovalDetails = {
 	kind: "entity_change";
-	operation: "create" | "delete";
+	operation: "create" | "delete" | "merge";
 	actorLabel?: string | null;
 	entityId?: number | null;
 	entityType?: string | null;
@@ -136,7 +136,9 @@ export function formatActionApprovalTitle(
 			: "entity";
 		return details.operation === "delete"
 			? `Review deleting ${entityLabel}`
-			: `Review creating ${entityLabel}`;
+			: details.operation === "merge"
+				? `Review merging ${entityLabel}`
+				: `Review creating ${entityLabel}`;
 	}
 	return `Action "${actionKey}" needs approval`;
 }
@@ -194,7 +196,9 @@ function buildApprovalRenderModel(
 		action:
 			details.operation === "delete"
 				? "Delete this entity"
-				: "Create this entity",
+				: details.operation === "merge"
+					? "Merge these entities"
+					: "Create this entity",
 		proposal: Object.entries(details.proposal ?? {}).map(([field, value]) => ({
 			label: formatLabel(field),
 			value: truncateNotificationLine(displayNotificationValue(value)),
@@ -230,7 +234,12 @@ function renderApprovalBody(
 		lines.push(`**${who}** wants to update ${entityLink}:`);
 		for (const d of model.diffs) lines.push(`- ${d.label}: ${d.diff}`);
 	} else {
-		const verb = model.action === "Delete this entity" ? "delete" : "create";
+		const verb =
+			model.action === "Delete this entity"
+				? "delete"
+				: model.action === "Merge these entities"
+					? "merge"
+					: "create";
 		lines.push(`**${who}** wants to ${verb} ${entityLink}.`);
 		if (model.proposal.length > 0) {
 			for (const p of model.proposal) lines.push(`- ${p.label}: ${p.value}`);

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -30,11 +30,12 @@ import {
 	deleteEntity,
 	type EntityData,
 } from "../../utils/entity-management";
-import { applyMerge } from "../../utils/entity-merge";
+import { applyMergeGroup } from "../../utils/entity-merge";
 import { insertEvent } from "../../utils/insert-event";
 import logger from "../../utils/logger";
 import { isUniqueViolation } from "../../utils/pg-errors";
 import {
+	buildConnectionUrl,
 	buildEntityUrl,
 	buildResourcePermalink,
 } from "../../utils/url-builder";
@@ -115,11 +116,18 @@ export interface EntityCreateProposal {
 export interface EntityMergeProposal {
 	operation: "merge";
 	entity_id: number;
+	entity_ids?: number[];
 	winner_entity_id: number;
 	current: {
 		loser: Record<string, unknown>;
+		duplicates?: Record<string, unknown>[];
 		winner: Record<string, unknown>;
 	};
+	evidence?: Array<{
+		kind: string;
+		identifier: string;
+		identity_ids?: number[];
+	}>;
 	watcher_id?: number | null;
 	window_id?: number | null;
 	attribution?: "watcher" | "agent";
@@ -158,6 +166,10 @@ function asCreateProposal(
 
 function asMergeProposal(proposal: EntityChangeProposal): EntityMergeProposal {
 	return proposal as EntityMergeProposal;
+}
+
+function mergeEntityIds(proposal: EntityMergeProposal): number[] {
+	return proposal.entity_ids ?? [proposal.entity_id];
 }
 
 async function loadWatcherLabel(
@@ -204,6 +216,15 @@ async function loadEntitySnapshot(
 	parent_slug: string | null;
 	parent_entity_type: string | null;
 	metadata: Record<string, unknown> | null;
+	identities: Array<{
+		id: number;
+		namespace: string;
+		identifier: string;
+		source_connector: string | null;
+		connection_id: number | null;
+		connection_name: string | null;
+		connector_key: string | null;
+	}>;
 } | null> {
 	const rows = await getDb()<{
 		id: number;
@@ -214,9 +235,29 @@ async function loadEntitySnapshot(
 		parent_slug: string | null;
 		parent_entity_type: string | null;
 		metadata: Record<string, unknown> | null;
+		identities: Array<{
+			id: number;
+			namespace: string;
+			identifier: string;
+			source_connector: string | null;
+			connection_id: number | null;
+			connection_name: string | null;
+			connector_key: string | null;
+		}>;
 	}>`
     SELECT e.id, e.name, et.slug AS entity_type, e.slug, e.parent_id, e.metadata,
-           parent.slug AS parent_slug, pet.slug AS parent_entity_type
+           parent.slug AS parent_slug, pet.slug AS parent_entity_type,
+           COALESCE((
+             SELECT jsonb_agg(jsonb_build_object(
+               'id', ei.id, 'namespace', ei.namespace, 'identifier', ei.identifier,
+               'source_connector', ei.source_connector, 'connection_id', ei.connection_id,
+               'connection_name', c.display_name, 'connector_key', c.connector_key
+             ) ORDER BY ei.id)
+             FROM entity_identities ei
+             LEFT JOIN connections c ON c.id = ei.connection_id
+             WHERE ei.entity_id = e.id AND ei.organization_id = e.organization_id
+               AND ei.deleted_at IS NULL
+           ), '[]'::jsonb) AS identities
     FROM entities e
     JOIN entity_types et ON et.id = e.entity_type_id
     LEFT JOIN entities parent ON e.parent_id = parent.id
@@ -226,6 +267,50 @@ async function loadEntitySnapshot(
     LIMIT 1
   `;
 	return rows[0] ?? null;
+}
+
+async function addEntityReviewLinks<
+	T extends NonNullable<Awaited<ReturnType<typeof loadEntitySnapshot>>>,
+>(
+	ctx: ToolContext,
+	entity: T,
+): Promise<
+	T & {
+		href?: string;
+		identities: Array<T["identities"][number] & { connection_href?: string }>;
+	}
+> {
+	const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
+	const href =
+		ownerSlug && entity.entity_type && entity.slug
+			? buildEntityUrl(
+					{
+						ownerSlug,
+						entityType: entity.entity_type,
+						slug: entity.slug,
+						parentType: entity.parent_entity_type,
+						parentSlug: entity.parent_slug,
+					},
+					baseUrl,
+				)
+			: undefined;
+	return {
+		...entity,
+		...(href ? { href } : {}),
+		identities: entity.identities.map((identity) => ({
+			...identity,
+			...(ownerSlug && identity.connection_id && identity.connector_key
+				? {
+						connection_href: buildConnectionUrl(
+							ownerSlug,
+							identity.connector_key,
+							identity.connection_id,
+							baseUrl,
+						),
+					}
+				: {}),
+		})),
+	};
 }
 
 /**
@@ -297,18 +382,31 @@ export async function proposeEntityCreate(
 
 export async function proposeEntityMerge(
 	ctx: ToolContext,
-	proposal: Omit<EntityMergeProposal, "operation" | "current">,
+	proposal: Omit<EntityMergeProposal, "operation" | "current" | "entity_id"> & {
+		entity_ids: number[];
+	},
 ): Promise<{ runId: number; eventId: number; approvalUrl?: string }> {
-	const [loser, winner] = await Promise.all([
-		loadEntitySnapshot(ctx, proposal.entity_id),
-		loadEntitySnapshot(ctx, proposal.winner_entity_id),
-	]);
-	if (!loser) throw new Error(`Entity ${proposal.entity_id} not found`);
+	const duplicates = await Promise.all(
+		proposal.entity_ids.map((entityId) => loadEntitySnapshot(ctx, entityId)),
+	);
+	const winner = await loadEntitySnapshot(ctx, proposal.winner_entity_id);
+	const missingIndex = duplicates.findIndex((entity) => !entity);
+	if (missingIndex >= 0)
+		throw new Error(`Entity ${proposal.entity_ids[missingIndex]} not found`);
 	if (!winner) throw new Error(`Entity ${proposal.winner_entity_id} not found`);
+	const linkedDuplicates = await Promise.all(
+		(duplicates as Array<NonNullable<(typeof duplicates)[number]>>).map(
+			(entity) => addEntityReviewLinks(ctx, entity),
+		),
+	);
+	const linkedWinner = await addEntityReviewLinks(ctx, winner);
+	const [loser, ...rest] = linkedDuplicates;
+	if (!loser) throw new Error("At least one duplicate entity is required");
 	return proposeEntityChange(ctx, {
 		...proposal,
+		entity_id: loser.id,
 		operation: "merge",
-		current: { loser, winner },
+		current: { loser, duplicates: [loser, ...rest], winner: linkedWinner },
 	});
 }
 
@@ -373,7 +471,10 @@ export async function proposeEntityChange(
 	      )
 	      AND (
 	        ${operation !== "merge"}
-	        OR COALESCE(r.action_input->>'winner_entity_id', '') = ${String(mergeProposal?.winner_entity_id ?? "")}
+	        OR (
+	          COALESCE(r.action_input->>'winner_entity_id', '') = ${String(mergeProposal?.winner_entity_id ?? "")}
+	          AND COALESCE(r.action_input->'entity_ids', jsonb_build_array((r.action_input->>'entity_id')::bigint)) = ${sql.json(mergeProposal ? mergeEntityIds(mergeProposal) : [])}::jsonb
+	        )
 	      )
 	    ORDER BY r.id DESC
     LIMIT 1
@@ -456,7 +557,7 @@ export async function proposeEntityChange(
 				? []
 				: operation === "merge"
 					? [
-							asMergeProposal(proposal).entity_id,
+							...mergeEntityIds(asMergeProposal(proposal)),
 							asMergeProposal(proposal).winner_entity_id,
 						]
 					: [
@@ -498,7 +599,14 @@ export async function proposeEntityChange(
 				: mergeProposal
 					? {
 							entity_id: mergeProposal.entity_id,
+							entity_ids: mergeEntityIds(mergeProposal),
 							winner_entity_id: mergeProposal.winner_entity_id,
+							evidence: mergeProposal.evidence ?? [],
+							names: (
+								mergeProposal.current.duplicates ?? [
+									mergeProposal.current.loser,
+								]
+							).map((entity) => entity.name),
 							name: mergeProposal.current.loser.name,
 							winner_name: mergeProposal.current.winner.name,
 						}
@@ -607,7 +715,14 @@ export async function proposeEntityChange(
 						proposal: mergeProposal
 							? {
 									entity_id: mergeProposal.entity_id,
+									entity_ids: mergeEntityIds(mergeProposal),
 									winner_entity_id: mergeProposal.winner_entity_id,
+									evidence: mergeProposal.evidence ?? [],
+									names: (
+										mergeProposal.current.duplicates ?? [
+											mergeProposal.current.loser,
+										]
+									).map((entity) => entity.name),
 									name: mergeProposal.current.loser.name,
 									winner_name: mergeProposal.current.winner.name,
 								}
@@ -621,8 +736,7 @@ export async function proposeEntityChange(
 											deleteProposal.force_delete_tree ?? false,
 									}
 								: (createProposal?.proposal ?? null),
-						current:
-							deleteProposal?.current ?? mergeProposal?.current ?? null,
+						current: deleteProposal?.current ?? mergeProposal?.current ?? null,
 						reason: proposal.reason ?? null,
 					},
 	}).catch((error) =>
@@ -773,9 +887,9 @@ export async function applyEntityChangeProposal(
 	}
 	if (operation === "merge") {
 		const mergeProposal = asMergeProposal(proposal);
-		return applyMerge({
+		return applyMergeGroup({
 			orgId: ctx.organizationId,
-			loserId: mergeProposal.entity_id,
+			loserIds: mergeEntityIds(mergeProposal),
 			winnerId: mergeProposal.winner_entity_id,
 			mergedBy: ctx.userId ?? "system",
 		});

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -472,7 +472,9 @@ export async function proposeEntityChange(
 				? `${actorNoun} proposed updating ${fieldList} on this entity.`
 				: operation === "delete"
 					? `${actorNoun} proposed deleting this entity.`
-					: `${actorNoun} proposed creating this entity.`),
+					: operation === "merge"
+						? `${actorNoun} proposed merging these entities.`
+						: `${actorNoun} proposed creating this entity.`),
 		semanticType: "operation",
 		runId,
 		interactionType: "approval",

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -30,6 +30,7 @@ import {
 	deleteEntity,
 	type EntityData,
 } from "../../utils/entity-management";
+import { applyMerge } from "../../utils/entity-merge";
 import { insertEvent } from "../../utils/insert-event";
 import logger from "../../utils/logger";
 import { isUniqueViolation } from "../../utils/pg-errors";
@@ -111,14 +112,29 @@ export interface EntityCreateProposal {
 	reason?: string | null;
 }
 
+export interface EntityMergeProposal {
+	operation: "merge";
+	entity_id: number;
+	winner_entity_id: number;
+	current: {
+		loser: Record<string, unknown>;
+		winner: Record<string, unknown>;
+	};
+	watcher_id?: number | null;
+	window_id?: number | null;
+	attribution?: "watcher" | "agent";
+	reason?: string | null;
+}
+
 export type EntityChangeProposal =
 	| EntityFieldChangeProposal
 	| EntityDeleteProposal
-	| EntityCreateProposal;
+	| EntityCreateProposal
+	| EntityMergeProposal;
 
 function operationOf(
 	proposal: EntityChangeProposal,
-): "create" | "update" | "delete" {
+): "create" | "update" | "delete" | "merge" {
 	return proposal.operation ?? "update";
 }
 
@@ -138,6 +154,10 @@ function asCreateProposal(
 	proposal: EntityChangeProposal,
 ): EntityCreateProposal {
 	return proposal as EntityCreateProposal;
+}
+
+function asMergeProposal(proposal: EntityChangeProposal): EntityMergeProposal {
+	return proposal as EntityMergeProposal;
 }
 
 async function loadWatcherLabel(
@@ -275,6 +295,23 @@ export async function proposeEntityCreate(
 	return proposeEntityChange(ctx, { ...proposal, operation: "create" });
 }
 
+export async function proposeEntityMerge(
+	ctx: ToolContext,
+	proposal: Omit<EntityMergeProposal, "operation" | "current">,
+): Promise<{ runId: number; eventId: number; approvalUrl?: string }> {
+	const [loser, winner] = await Promise.all([
+		loadEntitySnapshot(ctx, proposal.entity_id),
+		loadEntitySnapshot(ctx, proposal.winner_entity_id),
+	]);
+	if (!loser) throw new Error(`Entity ${proposal.entity_id} not found`);
+	if (!winner) throw new Error(`Entity ${proposal.winner_entity_id} not found`);
+	return proposeEntityChange(ctx, {
+		...proposal,
+		operation: "merge",
+		current: { loser, winner },
+	});
+}
+
 export async function proposeEntityChange(
 	ctx: ToolContext,
 	proposal: EntityChangeProposal,
@@ -291,6 +328,8 @@ export async function proposeEntityChange(
 		operation === "delete" ? asDeleteProposal(proposal) : null;
 	const createProposal =
 		operation === "create" ? asCreateProposal(proposal) : null;
+	const mergeProposal =
+		operation === "merge" ? asMergeProposal(proposal) : null;
 	const actionKey =
 		operation === "update"
 			? ENTITY_FIELD_CHANGE_ACTION_KEY
@@ -332,6 +371,10 @@ export async function proposeEntityChange(
 	        ${operation !== "create"}
 	        OR r.action_input->'entity_data' = ${sql.json(createProposal?.entity_data ?? {})}::jsonb
 	      )
+	      AND (
+	        ${operation !== "merge"}
+	        OR COALESCE(r.action_input->>'winner_entity_id', '') = ${String(mergeProposal?.winner_entity_id ?? "")}
+	      )
 	    ORDER BY r.id DESC
     LIMIT 1
   `;
@@ -353,12 +396,12 @@ export async function proposeEntityChange(
 	try {
 		const inserted = await sql`
       INSERT INTO runs (
-        organization_id, run_type, action_key, action_input, window_id,
+        organization_id, run_type, action_key, action_input, window_id, watcher_id,
         created_by_user_id, approval_status, status, created_at
       ) VALUES (
         ${ctx.organizationId}, 'internal', ${actionKey},
         ${sql.json(actionInputProposal as unknown as Record<string, unknown>)},
-        ${windowId ?? null},
+        ${windowId ?? null}, ${proposal.watcher_id ?? null},
         null, 'pending', 'pending', current_timestamp
       )
       RETURNING id
@@ -392,7 +435,9 @@ export async function proposeEntityChange(
 		]);
 	const entityType = createProposal
 		? createProposal.entity_data.entity_type
-		: entity?.entity_type;
+		: mergeProposal
+			? String(mergeProposal.current.loser.entity_type ?? "entity")
+			: entity?.entity_type;
 	const entityName = createProposal
 		? createProposal.entity_data.name
 		: entity?.name;
@@ -401,16 +446,23 @@ export async function proposeEntityChange(
 			? formatFieldChangeAction(entityType, fieldKeys)
 			: operation === "delete"
 				? `Delete ${entityType ? formatLabel(entityType).toLowerCase() : "entity"}`
-				: `Create ${formatLabel(entityType ?? "entity").toLowerCase()}`;
+				: operation === "merge"
+					? `Merge duplicate ${formatLabel(entityType ?? "entity").toLowerCase()}`
+					: `Create ${formatLabel(entityType ?? "entity").toLowerCase()}`;
 
 	const event = await insertEvent({
 		entityIds:
 			operation === "create"
 				? []
-				: [
-						(proposal as EntityFieldChangeProposal | EntityDeleteProposal)
-							.entity_id,
-					],
+				: operation === "merge"
+					? [
+							asMergeProposal(proposal).entity_id,
+							asMergeProposal(proposal).winner_entity_id,
+						]
+					: [
+							(proposal as EntityFieldChangeProposal | EntityDeleteProposal)
+								.entity_id,
+						],
 		organizationId: ctx.organizationId,
 		originId: `run_${runId}_pending`,
 		title: `${actionLabel} — pending approval`,
@@ -436,18 +488,27 @@ export async function proposeEntityChange(
 				? (updateProposal.current ?? null)
 				: deleteProposal
 					? deleteProposal.current
-					: null,
+					: mergeProposal
+						? mergeProposal.current
+						: null,
 			proposal: createProposal
 				? createProposal.proposal
-				: deleteProposal
+				: mergeProposal
 					? {
-							entity_id: deleteProposal.entity_id,
-							entity_type:
-								entity?.entity_type ?? deleteProposal.current.entity_type,
-							name: entity?.name ?? deleteProposal.current.name,
-							force_delete_tree: deleteProposal.force_delete_tree ?? false,
+							entity_id: mergeProposal.entity_id,
+							winner_entity_id: mergeProposal.winner_entity_id,
+							name: mergeProposal.current.loser.name,
+							winner_name: mergeProposal.current.winner.name,
 						}
-					: null,
+					: deleteProposal
+						? {
+								entity_id: deleteProposal.entity_id,
+								entity_type:
+									entity?.entity_type ?? deleteProposal.current.entity_type,
+								name: entity?.name ?? deleteProposal.current.name,
+								force_delete_tree: deleteProposal.force_delete_tree ?? false,
+							}
+						: null,
 			watcher_id: proposal.watcher_id ?? null,
 			watcher_name: watcherName,
 			watcher_agent_id: watcherAgentId,
@@ -536,20 +597,30 @@ export async function proposeEntityChange(
 						kind: "entity_change",
 						operation,
 						actorLabel,
-						entityId: deleteProposal ? deleteProposal.entity_id : null,
+						entityId:
+							deleteProposal?.entity_id ?? mergeProposal?.entity_id ?? null,
 						entityType: entityType ?? null,
 						entityName: entityName ?? null,
 						entityUrl,
-						proposal: deleteProposal
+						proposal: mergeProposal
 							? {
-									entity_id: deleteProposal.entity_id,
-									entity_type:
-										entity?.entity_type ?? deleteProposal.current.entity_type,
-									name: entity?.name ?? deleteProposal.current.name,
-									force_delete_tree: deleteProposal.force_delete_tree ?? false,
+									entity_id: mergeProposal.entity_id,
+									winner_entity_id: mergeProposal.winner_entity_id,
+									name: mergeProposal.current.loser.name,
+									winner_name: mergeProposal.current.winner.name,
 								}
-							: (createProposal?.proposal ?? null),
-						current: deleteProposal ? deleteProposal.current : null,
+							: deleteProposal
+								? {
+										entity_id: deleteProposal.entity_id,
+										entity_type:
+											entity?.entity_type ?? deleteProposal.current.entity_type,
+										name: entity?.name ?? deleteProposal.current.name,
+										force_delete_tree:
+											deleteProposal.force_delete_tree ?? false,
+									}
+								: (createProposal?.proposal ?? null),
+						current:
+							deleteProposal?.current ?? mergeProposal?.current ?? null,
 						reason: proposal.reason ?? null,
 					},
 	}).catch((error) =>
@@ -622,7 +693,8 @@ export async function applyEntityFieldChangeProposal(
 			}
 			const live = {
 				$name: rows[0].name ?? null,
-				$parent_id: rows[0].parent_id == null ? null : Number(rows[0].parent_id),
+				$parent_id:
+					rows[0].parent_id == null ? null : Number(rows[0].parent_id),
 				$content: rows[0].content ?? null,
 			} as Record<string, unknown>;
 			const apply: Record<string, unknown> = {};
@@ -633,7 +705,10 @@ export async function applyEntityFieldChangeProposal(
 					Object.hasOwn(proposal.current, key) &&
 					JSON.stringify(live[key] ?? null) !== JSON.stringify(expected ?? null)
 				) {
-					merge.stale[key] = { expected: expected ?? null, live: live[key] ?? null };
+					merge.stale[key] = {
+						expected: expected ?? null,
+						live: live[key] ?? null,
+					};
 					continue;
 				}
 				apply[key] = proposed;
@@ -646,12 +721,10 @@ export async function applyEntityFieldChangeProposal(
           UPDATE entities SET
             name = COALESCE(${nextName}, name),
             parent_id = CASE WHEN ${"$parent_id" in apply} THEN ${
-							("$parent_id" in apply ? apply.$parent_id : null) as
-								| number
-								| null
+							("$parent_id" in apply ? apply.$parent_id : null) as number | null
 						}::bigint ELSE parent_id END,
             content = CASE WHEN ${"$content" in apply} THEN ${
-							("$content" in apply ? (apply.$content as string | null) : null)
+							"$content" in apply ? (apply.$content as string | null) : null
 						} ELSE content END,
             updated_at = current_timestamp
           WHERE id = ${proposal.entity_id} AND deleted_at IS NULL
@@ -695,6 +768,15 @@ export async function applyEntityChangeProposal(
 				},
 			},
 		);
+	}
+	if (operation === "merge") {
+		const mergeProposal = asMergeProposal(proposal);
+		return applyMerge({
+			orgId: ctx.organizationId,
+			loserId: mergeProposal.entity_id,
+			winnerId: mergeProposal.winner_entity_id,
+			mergedBy: ctx.userId ?? "system",
+		});
 	}
 	const deleteProposal = asDeleteProposal(proposal);
 	return deleteEntity(

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -605,8 +605,8 @@ function redactMemberEmail(
  * (`winner_entity_id`). Humans must be admin/owner; agents and watchers queue a
  * human approval because a merge is destructive and hard to spot after the
  * fact. The heavy lifting (move identities/aliases/edges, tombstone + forward
- * the loser, flatten chains) is in `applyMerge`; this handler is the org-scoped
- * gate + validation.
+ * each loser, flatten chains) is in `applyMergeGroup`; this handler is the
+ * org-scoped gate + validation.
  */
 async function handleMerge(
 	args: ManageEntityArgs,
@@ -636,8 +636,8 @@ async function handleMerge(
 		throw new ToolUserError("winner_entity_id cannot also be a duplicate", 400);
 
 	const sql = getDb();
-	// Both entities must be live and in the caller's org — never merge across a
-	// tenant boundary or into a deleted/foreign entity.
+	// Every duplicate and the winner must be live and in the caller's org — never
+	// merge across a tenant boundary or into a deleted/foreign entity.
 	const rows = (await sql`
     SELECT id FROM entities
     WHERE organization_id = ${ctx.organizationId}

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -24,12 +24,12 @@ import {
 	type RelationshipCountByType,
 	type RelationshipRow,
 } from "@lobu/core/contracts/tools/manage-entity";
+import { runMutationGate } from "../../authz/entity-mutation-gate";
 import {
 	type ActingPrincipal,
 	evaluateEntityMutation,
 	resolveActingPrincipal,
 } from "../../authz/entity-policy";
-import { runMutationGate } from "../../authz/entity-mutation-gate";
 import { getDb, pgTextArray } from "../../db/client";
 import type { Env } from "../../index";
 import {
@@ -68,12 +68,13 @@ import {
 	toEntityInfo,
 } from "../view-urls";
 import { defineFlatActionTool, flatAction } from "./action-tool";
+import { proposeEntityMerge } from "./entity-field-approval";
 
 export { ManageEntityResultSchema, ManageEntitySchema };
 
 function toIsoStringOrNow(value: Date | string | null | undefined): string {
-  if (!value) return new Date().toISOString();
-  return new Date(value).toISOString();
+	if (!value) return new Date().toISOString();
+	return new Date(value).toISOString();
 }
 
 function capitalize(value: string): string {
@@ -183,42 +184,42 @@ async function manageEntityImpl(
 	env: Env,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-  const result = await runManageEntity(args, env, ctx);
+	const result = await runManageEntity(args, env, ctx);
 
-  // Track watcher reaction for mutating actions
-  if (args.watcher_source && 'action' in result) {
-    const reactionType =
-      result.action === 'create'
-        ? 'entity_created'
-        : result.action === 'update'
-          ? 'entity_updated'
-          : result.action === 'link'
-            ? 'entity_linked'
-            : null;
-    if (reactionType) {
-      const entityId =
-        result.action === 'create' && 'entity' in result
-          ? (result as any).entity.id
-          : args.entity_id;
-      await trackWatcherReaction({
-        organizationId: ctx.organizationId,
-        watcherId: args.watcher_source.watcher_id,
-        windowId: args.watcher_source.window_id,
-        reactionType,
-        toolName: 'manage_entity',
-        toolArgs: {
-          action: args.action,
-          entity_type: args.entity_type,
-          name: args.name,
-          entity_id: args.entity_id,
-        },
-        toolResult: result as Record<string, unknown>,
-        entityId,
-      });
-    }
-  }
+	// Track watcher reaction for mutating actions
+	if (args.watcher_source && "action" in result) {
+		const reactionType =
+			result.action === "create"
+				? "entity_created"
+				: result.action === "update"
+					? "entity_updated"
+					: result.action === "link"
+						? "entity_linked"
+						: null;
+		if (reactionType) {
+			const entityId =
+				result.action === "create" && "entity" in result
+					? (result as any).entity.id
+					: args.entity_id;
+			await trackWatcherReaction({
+				organizationId: ctx.organizationId,
+				watcherId: args.watcher_source.watcher_id,
+				windowId: args.watcher_source.window_id,
+				reactionType,
+				toolName: "manage_entity",
+				toolArgs: {
+					action: args.action,
+					entity_type: args.entity_type,
+					name: args.name,
+					entity_id: args.entity_id,
+				},
+				toolResult: result as Record<string, unknown>,
+				entityId,
+			});
+		}
+	}
 
-  return result;
+	return result;
 }
 
 // ============================================
@@ -388,10 +389,10 @@ async function handleUpdate(
 	env: Env,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-  const sql = getDb();
+	const sql = getDb();
 
-  // Fetch before state for change tracking and validation
-  const beforeRows = await sql`
+	// Fetch before state for change tracking and validation
+	const beforeRows = await sql`
     SELECT e.name, e.slug, e.parent_id, e.metadata, et.slug AS entity_type
     FROM entities e
     JOIN entity_types et ON et.id = e.entity_type_id
@@ -582,21 +583,21 @@ async function handleUpdate(
 //    email address.
 //  - Only admin/owner see the email field.
 function canSeeMemberList(ctx: ToolContext): boolean {
-  return !!ctx.memberRole;
+	return !!ctx.memberRole;
 }
 
 function canSeeMemberEmail(ctx: ToolContext): boolean {
-  return isAdminOrOwnerRole(ctx.memberRole);
+	return isAdminOrOwnerRole(ctx.memberRole);
 }
 
 function redactMemberEmail(
 	metadata: Record<string, unknown>,
 	schema: Record<string, unknown> | null | undefined,
 ): Record<string, unknown> {
-  const { emailField } = resolveMemberSchemaFieldsFromSchema(schema);
-  if (!(emailField in metadata)) return metadata;
-  const { [emailField]: _removed, ...rest } = metadata;
-  return rest;
+	const { emailField } = resolveMemberSchemaFieldsFromSchema(schema);
+	if (!(emailField in metadata)) return metadata;
+	const { [emailField]: _removed, ...rest } = metadata;
+	return rest;
 }
 
 /**
@@ -610,7 +611,8 @@ async function handleMerge(
 	args: ManageEntityArgs,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-	if (!isAdminOrOwnerRole(ctx.memberRole)) {
+	const actor = await actingPrincipalFor(args, ctx);
+	if (actor.kind === "user" && !isAdminOrOwnerRole(ctx.memberRole)) {
 		throw new ToolUserError("Only an admin or owner may merge entities", 403);
 	}
 	const loserId = args.entity_id;
@@ -648,6 +650,33 @@ async function handleMerge(
 			`Entity ${winnerId} not found in this workspace`,
 			404,
 		);
+
+	if (actor.kind !== "user") {
+		const attribution = actor.kind === "watcher" ? "watcher" : "agent";
+		const queued = await proposeEntityMerge(ctx, {
+			entity_id: loserId,
+			winner_entity_id: winnerId,
+			watcher_id:
+				ctx.actingWatcherId ?? args.watcher_source?.watcher_id ?? null,
+			window_id: ctx.actingWindowId ?? args.watcher_source?.window_id ?? null,
+			attribution,
+			reason:
+				"A duplicate merge needs human approval before identities and relationships are folded together.",
+		});
+		return {
+			action: "merge",
+			approval_queued: true,
+			approval_url: queued.approvalUrl,
+			approval_run_id: queued.runId,
+			approval_action: "merge",
+			approval_proposal: {
+				entity_id: loserId,
+				winner_entity_id: winnerId,
+			},
+			approval_attribution: attribution,
+			next_steps: ["The merge is waiting for human approval."],
+		};
+	}
 
 	let result: Awaited<ReturnType<typeof applyMerge>>;
 	try {
@@ -995,17 +1024,25 @@ async function resolveLinkedColumns(
                 AND et.slug = ${entityType}
                 AND (e.metadata->>${lookupField}) = ANY(${valuesLiteral}::text[])
             `;
-      if (rows.length === 0) return;
-      const bucketMap: Record<string, { slug: string; entity_type: string; name: string }> = {};
-      for (const r of rows) {
-        if (r.lookup_value == null) continue;
-        bucketMap[r.lookup_value] = { slug: r.slug, entity_type: r.entity_type, name: r.name };
-      }
-      out[bucketKey] = bucketMap;
-    })
-  );
+				if (rows.length === 0) return;
+				const bucketMap: Record<
+					string,
+					{ slug: string; entity_type: string; name: string }
+				> = {};
+				for (const r of rows) {
+					if (r.lookup_value == null) continue;
+					bucketMap[r.lookup_value] = {
+						slug: r.slug,
+						entity_type: r.entity_type,
+						name: r.name,
+					};
+				}
+				out[bucketKey] = bucketMap;
+			},
+		),
+	);
 
-  return out;
+	return out;
 }
 
 async function handleGet(
@@ -1043,26 +1080,27 @@ async function handleGet(
       WHERE slug = ${MEMBER_ENTITY_TYPE_SLUG} AND organization_id = ${ctx.organizationId} AND deleted_at IS NULL
       LIMIT 1
     `;
-    const memberSchema = (rows[0]?.metadata_schema as Record<string, unknown> | null) ?? null;
-    metadata = redactMemberEmail(metadata, memberSchema);
-  }
+		const memberSchema =
+			(rows[0]?.metadata_schema as Record<string, unknown> | null) ?? null;
+		metadata = redactMemberEmail(metadata, memberSchema);
+	}
 
-  return {
-    action: 'get',
-    entity: {
-      id: entity.id,
-      entity_type: entity.entity_type,
-      name: entity.name,
-      slug: entity.slug,
-      parent_id: entity.parent_id,
-      parent_name: entity.parent_name,
-      parent_slug: entity.parent_slug ?? null,
-      metadata,
-      enabled_classifiers: entity.enabled_classifiers,
-      created_at: toIsoStringOrNow(entity.created_at),
-      view_url: viewUrl,
-    },
-  };
+	return {
+		action: "get",
+		entity: {
+			id: entity.id,
+			entity_type: entity.entity_type,
+			name: entity.name,
+			slug: entity.slug,
+			parent_id: entity.parent_id,
+			parent_name: entity.parent_name,
+			parent_slug: entity.parent_slug ?? null,
+			metadata,
+			enabled_classifiers: entity.enabled_classifiers,
+			created_at: toIsoStringOrNow(entity.created_at),
+			view_url: viewUrl,
+		},
+	};
 }
 
 async function handleDelete(
@@ -1217,25 +1255,27 @@ async function handleLink(
     ORDER BY (rt.organization_id = ${ctx.organizationId}) DESC, rt.id ASC
     LIMIT 1
   `;
-  if (typeRows.length === 0) {
-    throw new Error(`Relationship type "${args.relationship_type_slug}" not found`);
-  }
-  const typeId = Number(typeRows[0].id);
-  const isSymmetric = Boolean(typeRows[0].is_symmetric);
+	if (typeRows.length === 0) {
+		throw new Error(
+			`Relationship type "${args.relationship_type_slug}" not found`,
+		);
+	}
+	const typeId = Number(typeRows[0].id);
+	const isSymmetric = Boolean(typeRows[0].is_symmetric);
 
-  await validateTypeRule(typeId, args.from_entity_id, args.to_entity_id, sql);
+	await validateTypeRule(typeId, args.from_entity_id, args.to_entity_id, sql);
 
-  let fromId = args.from_entity_id;
-  let toId = args.to_entity_id;
-  if (isSymmetric) {
-    // For symmetric same-org pairs we canonicalize by id so dedup catches
-    // a → b and b → a as the same edge. For cross-org pairs (target in a
-    // public catalog), keep the caller's-org entity as `from` even if its
-    // id is higher, so the stored source matches the semantic source. The
-    // canonical form would otherwise leave rows where `from_entity_id`
-    // points at a public catalog row under a tenant `organization_id` —
-    // tenant-owned but cosmetically inverted.
-    const orgRows = await sql<{ id: number; organization_id: string }>`
+	let fromId = args.from_entity_id;
+	let toId = args.to_entity_id;
+	if (isSymmetric) {
+		// For symmetric same-org pairs we canonicalize by id so dedup catches
+		// a → b and b → a as the same edge. For cross-org pairs (target in a
+		// public catalog), keep the caller's-org entity as `from` even if its
+		// id is higher, so the stored source matches the semantic source. The
+		// canonical form would otherwise leave rows where `from_entity_id`
+		// points at a public catalog row under a tenant `organization_id` —
+		// tenant-owned but cosmetically inverted.
+		const orgRows = await sql<{ id: number; organization_id: string }>`
       SELECT id, organization_id FROM entities WHERE id IN (${fromId}, ${toId})
     `;
 		const orgOf = (id: number) =>
@@ -1280,22 +1320,26 @@ async function handleLink(
     )
     RETURNING id
   `;
-  const relationshipId = Number((inserted[0] as { id: unknown }).id);
+	const relationshipId = Number((inserted[0] as { id: unknown }).id);
 
-  const created = await sql.unsafe<RelationshipRow>(
-    `SELECT ${RELATIONSHIP_SELECT} ${RELATIONSHIP_JOINS} WHERE r.id = $1`,
-    [relationshipId]
-  );
+	const created = await sql.unsafe<RelationshipRow>(
+		`SELECT ${RELATIONSHIP_SELECT} ${RELATIONSHIP_JOINS} WHERE r.id = $1`,
+		[relationshipId],
+	);
 
-  return { action: 'link', relationship: created[0] };
+	return { action: "link", relationship: created[0] };
 }
 
-async function handleUnlink(args: ManageEntityArgs, ctx: ToolContext): Promise<ManageEntityResult> {
-  if (!args.relationship_id) throw new Error('relationship_id is required for unlink');
+async function handleUnlink(
+	args: ManageEntityArgs,
+	ctx: ToolContext,
+): Promise<ManageEntityResult> {
+	if (!args.relationship_id)
+		throw new Error("relationship_id is required for unlink");
 
-  const sql = getDb();
+	const sql = getDb();
 
-  const existing = await sql`
+	const existing = await sql`
     SELECT id, organization_id FROM entity_relationships
     WHERE id = ${args.relationship_id} AND deleted_at IS NULL
     LIMIT 1
@@ -1326,11 +1370,12 @@ async function handleUpdateLink(
 	args: ManageEntityArgs,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-  if (!args.relationship_id) throw new Error('relationship_id is required for update_link');
+	if (!args.relationship_id)
+		throw new Error("relationship_id is required for update_link");
 
-  const sql = getDb();
+	const sql = getDb();
 
-  const existing = await sql`
+	const existing = await sql`
     SELECT id, organization_id FROM entity_relationships
     WHERE id = ${args.relationship_id} AND deleted_at IS NULL
     LIMIT 1
@@ -1363,12 +1408,12 @@ async function handleUpdateLink(
     WHERE id = ${args.relationship_id}
   `;
 
-  const updated = await sql.unsafe<RelationshipRow>(
-    `SELECT ${RELATIONSHIP_SELECT} ${RELATIONSHIP_JOINS} WHERE r.id = $1`,
-    [args.relationship_id]
-  );
+	const updated = await sql.unsafe<RelationshipRow>(
+		`SELECT ${RELATIONSHIP_SELECT} ${RELATIONSHIP_JOINS} WHERE r.id = $1`,
+		[args.relationship_id],
+	);
 
-  return { action: 'update_link', relationship: updated[0] };
+	return { action: "update_link", relationship: updated[0] };
 }
 
 async function handleListLinks(
@@ -1453,14 +1498,14 @@ async function handleListLinks(
      ORDER BY r.created_at DESC
      LIMIT ${limit + 1}
      OFFSET ${offset}`,
-    params
-  );
+		params,
+	);
 
-  const hasMore = rows.length > limit;
-  const relationships = hasMore ? rows.slice(0, limit) : rows;
+	const hasMore = rows.length > limit;
+	const relationships = hasMore ? rows.slice(0, limit) : rows;
 
-  const countsResult = await sql.unsafe<RelationshipCountByType>(
-    `SELECT
+	const countsResult = await sql.unsafe<RelationshipCountByType>(
+		`SELECT
       rt.slug as relationship_type_slug,
       rt.name as relationship_type_name,
       COUNT(*)::int as count
@@ -1468,13 +1513,13 @@ async function handleListLinks(
     WHERE ${whereClause}
     GROUP BY rt.slug, rt.name
     ORDER BY count DESC`,
-    params
-  );
+		params,
+	);
 
-  return {
-    action: 'list_links',
-    relationships,
-    counts_by_type: countsResult,
-    metadata: { total, limit, offset, has_more: hasMore },
-  };
+	return {
+		action: "list_links",
+		relationships,
+		counts_by_type: countsResult,
+		metadata: { total, limit, offset, has_more: hasMore },
+	};
 }

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -30,7 +30,7 @@ import {
 	evaluateEntityMutation,
 	resolveActingPrincipal,
 } from "../../authz/entity-policy";
-import { getDb, pgTextArray } from "../../db/client";
+import { getDb, pgBigintArray, pgTextArray } from "../../db/client";
 import type { Env } from "../../index";
 import {
 	batchLoadRelationships,
@@ -42,7 +42,7 @@ import {
 	type RelationshipColumnSpec,
 	updateEntity,
 } from "../../utils/entity-management";
-import { applyMerge, applyUnmerge } from "../../utils/entity-merge";
+import { applyMergeGroup, applyUnmerge } from "../../utils/entity-merge";
 import { ToolUserError } from "../../utils/errors";
 import { recordChangeEvent } from "../../utils/insert-event";
 import { resolveMemberSchemaFieldsFromSchema } from "../../utils/member-entity-type";
@@ -166,7 +166,7 @@ const runManageEntity = defineFlatActionTool<
 	update_link: flatAction(handleUpdateLink),
 	list_links: flatAction(handleListLinks),
 	merge: flatAction((args, ctx) => handleMerge(args, ctx), {
-		requires: ["entity_id", "winner_entity_id"],
+		requires: ["winner_entity_id"],
 	}),
 	unmerge: flatAction((args, ctx) => handleUnmerge(args, ctx), {
 		requires: ["entity_id"],
@@ -616,11 +616,15 @@ async function handleMerge(
 	if (actor.kind === "user" && !isAdminOrOwnerRole(ctx.memberRole)) {
 		throw new ToolUserError("Only an admin or owner may merge entities", 403);
 	}
-	const loserId = args.entity_id;
+	const loserIds = [
+		...new Set(
+			args.duplicate_entity_ids ?? (args.entity_id ? [args.entity_id] : []),
+		),
+	].sort((a, b) => a - b);
 	const winnerId = args.winner_entity_id;
-	if (!loserId)
+	if (loserIds.length === 0)
 		throw new ToolUserError(
-			"entity_id (the duplicate to fold in) is required for merge",
+			"entity_id or duplicate_entity_ids is required for merge",
 			400,
 		);
 	if (!winnerId)
@@ -628,8 +632,8 @@ async function handleMerge(
 			"winner_entity_id (the survivor) is required for merge",
 			400,
 		);
-	if (loserId === winnerId)
-		throw new ToolUserError("entity_id and winner_entity_id must differ", 400);
+	if (loserIds.includes(winnerId))
+		throw new ToolUserError("winner_entity_id cannot also be a duplicate", 400);
 
 	const sql = getDb();
 	// Both entities must be live and in the caller's org — never merge across a
@@ -637,15 +641,17 @@ async function handleMerge(
 	const rows = (await sql`
     SELECT id FROM entities
     WHERE organization_id = ${ctx.organizationId}
-      AND id IN (${loserId}, ${winnerId})
+	      AND id = ANY(${pgBigintArray([...loserIds, winnerId])}::bigint[])
       AND deleted_at IS NULL
   `) as Array<{ id: number }>;
 	const found = new Set(rows.map((r) => Number(r.id)));
-	if (!found.has(loserId))
-		throw new ToolUserError(
-			`Entity ${loserId} not found in this workspace`,
-			404,
-		);
+	for (const loserId of loserIds) {
+		if (!found.has(loserId))
+			throw new ToolUserError(
+				`Entity ${loserId} not found in this workspace`,
+				404,
+			);
+	}
 	if (!found.has(winnerId))
 		throw new ToolUserError(
 			`Entity ${winnerId} not found in this workspace`,
@@ -655,8 +661,9 @@ async function handleMerge(
 	if (actor.kind !== "user") {
 		const attribution = actor.kind === "watcher" ? "watcher" : "agent";
 		const queued = await proposeEntityMerge(ctx, {
-			entity_id: loserId,
+			entity_ids: loserIds,
 			winner_entity_id: winnerId,
+			evidence: args.merge_evidence,
 			watcher_id:
 				ctx.actingWatcherId ?? args.watcher_source?.watcher_id ?? null,
 			window_id: ctx.actingWindowId ?? args.watcher_source?.window_id ?? null,
@@ -671,7 +678,8 @@ async function handleMerge(
 			approval_run_id: queued.runId,
 			approval_action: "merge",
 			approval_proposal: {
-				entity_id: loserId,
+				entity_id: loserIds[0],
+				entity_ids: loserIds,
 				winner_entity_id: winnerId,
 			},
 			approval_attribution: attribution,
@@ -679,11 +687,11 @@ async function handleMerge(
 		};
 	}
 
-	let result: Awaited<ReturnType<typeof applyMerge>>;
+	let result: Awaited<ReturnType<typeof applyMergeGroup>>;
 	try {
-		result = await applyMerge({
+		result = await applyMergeGroup({
 			orgId: ctx.organizationId,
-			loserId,
+			loserIds,
 			winnerId,
 			mergedBy: ctx.agentId ?? ctx.userId ?? "system",
 		});
@@ -697,9 +705,10 @@ async function handleMerge(
 	return {
 		action: "merge",
 		success: true,
-		message: `Merged entity ${loserId} into ${winnerId} (${result.movedIdentities} identities moved, ${result.repointedEdges} edges re-pointed).`,
+		message: `Merged ${loserIds.length} duplicate ${loserIds.length === 1 ? "entity" : "entities"} into ${winnerId} (${result.movedIdentities} identities moved, ${result.repointedEdges} edges re-pointed).`,
 		winner_entity_id: winnerId,
-		loser_entity_id: loserId,
+		loser_entity_id: loserIds[0],
+		loser_entity_ids: loserIds,
 		moved_identities: result.movedIdentities,
 		repointed_edges: result.repointedEdges,
 	};

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -602,10 +602,11 @@ function redactMemberEmail(
 
 /**
  * Fold a duplicate entity (`entity_id`, the loser) into the one it really is
- * (`winner_entity_id`). Admin/owner only — a merge is destructive and hard to
- * spot after the fact. The heavy lifting (move identities/aliases/edges,
- * tombstone + forward the loser, flatten chains) is in `applyMerge`; this
- * handler is the org-scoped gate + validation.
+ * (`winner_entity_id`). Humans must be admin/owner; agents and watchers queue a
+ * human approval because a merge is destructive and hard to spot after the
+ * fact. The heavy lifting (move identities/aliases/edges, tombstone + forward
+ * the loser, flatten chains) is in `applyMerge`; this handler is the org-scoped
+ * gate + validation.
  */
 async function handleMerge(
 	args: ManageEntityArgs,

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -73,8 +73,8 @@ import { proposeEntityMerge } from "./entity-field-approval";
 export { ManageEntityResultSchema, ManageEntitySchema };
 
 function toIsoStringOrNow(value: Date | string | null | undefined): string {
-	if (!value) return new Date().toISOString();
-	return new Date(value).toISOString();
+  if (!value) return new Date().toISOString();
+  return new Date(value).toISOString();
 }
 
 function capitalize(value: string): string {
@@ -184,42 +184,42 @@ async function manageEntityImpl(
 	env: Env,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-	const result = await runManageEntity(args, env, ctx);
+  const result = await runManageEntity(args, env, ctx);
 
-	// Track watcher reaction for mutating actions
+  // Track watcher reaction for mutating actions
 	if (args.watcher_source && "action" in result) {
-		const reactionType =
+    const reactionType =
 			result.action === "create"
 				? "entity_created"
 				: result.action === "update"
 					? "entity_updated"
 					: result.action === "link"
 						? "entity_linked"
-						: null;
-		if (reactionType) {
-			const entityId =
+            : null;
+    if (reactionType) {
+      const entityId =
 				result.action === "create" && "entity" in result
-					? (result as any).entity.id
-					: args.entity_id;
-			await trackWatcherReaction({
-				organizationId: ctx.organizationId,
-				watcherId: args.watcher_source.watcher_id,
-				windowId: args.watcher_source.window_id,
-				reactionType,
+          ? (result as any).entity.id
+          : args.entity_id;
+      await trackWatcherReaction({
+        organizationId: ctx.organizationId,
+        watcherId: args.watcher_source.watcher_id,
+        windowId: args.watcher_source.window_id,
+        reactionType,
 				toolName: "manage_entity",
-				toolArgs: {
-					action: args.action,
-					entity_type: args.entity_type,
-					name: args.name,
-					entity_id: args.entity_id,
-				},
-				toolResult: result as Record<string, unknown>,
-				entityId,
-			});
-		}
-	}
+        toolArgs: {
+          action: args.action,
+          entity_type: args.entity_type,
+          name: args.name,
+          entity_id: args.entity_id,
+        },
+        toolResult: result as Record<string, unknown>,
+        entityId,
+      });
+    }
+  }
 
-	return result;
+  return result;
 }
 
 // ============================================
@@ -389,10 +389,10 @@ async function handleUpdate(
 	env: Env,
 	ctx: ToolContext,
 ): Promise<ManageEntityResult> {
-	const sql = getDb();
+  const sql = getDb();
 
-	// Fetch before state for change tracking and validation
-	const beforeRows = await sql`
+  // Fetch before state for change tracking and validation
+  const beforeRows = await sql`
     SELECT e.name, e.slug, e.parent_id, e.metadata, et.slug AS entity_type
     FROM entities e
     JOIN entity_types et ON et.id = e.entity_type_id
@@ -583,21 +583,21 @@ async function handleUpdate(
 //    email address.
 //  - Only admin/owner see the email field.
 function canSeeMemberList(ctx: ToolContext): boolean {
-	return !!ctx.memberRole;
+  return !!ctx.memberRole;
 }
 
 function canSeeMemberEmail(ctx: ToolContext): boolean {
-	return isAdminOrOwnerRole(ctx.memberRole);
+  return isAdminOrOwnerRole(ctx.memberRole);
 }
 
 function redactMemberEmail(
 	metadata: Record<string, unknown>,
 	schema: Record<string, unknown> | null | undefined,
 ): Record<string, unknown> {
-	const { emailField } = resolveMemberSchemaFieldsFromSchema(schema);
-	if (!(emailField in metadata)) return metadata;
-	const { [emailField]: _removed, ...rest } = metadata;
-	return rest;
+  const { emailField } = resolveMemberSchemaFieldsFromSchema(schema);
+  if (!(emailField in metadata)) return metadata;
+  const { [emailField]: _removed, ...rest } = metadata;
+  return rest;
 }
 
 /**
@@ -646,11 +646,11 @@ async function handleMerge(
   `) as Array<{ id: number }>;
 	const found = new Set(rows.map((r) => Number(r.id)));
 	for (const loserId of loserIds) {
-		if (!found.has(loserId))
-			throw new ToolUserError(
-				`Entity ${loserId} not found in this workspace`,
-				404,
-			);
+	if (!found.has(loserId))
+		throw new ToolUserError(
+			`Entity ${loserId} not found in this workspace`,
+			404,
+		);
 	}
 	if (!found.has(winnerId))
 		throw new ToolUserError(
@@ -1034,25 +1034,25 @@ async function resolveLinkedColumns(
                 AND et.slug = ${entityType}
                 AND (e.metadata->>${lookupField}) = ANY(${valuesLiteral}::text[])
             `;
-				if (rows.length === 0) return;
+      if (rows.length === 0) return;
 				const bucketMap: Record<
 					string,
 					{ slug: string; entity_type: string; name: string }
 				> = {};
-				for (const r of rows) {
-					if (r.lookup_value == null) continue;
+      for (const r of rows) {
+        if (r.lookup_value == null) continue;
 					bucketMap[r.lookup_value] = {
 						slug: r.slug,
 						entity_type: r.entity_type,
 						name: r.name,
 					};
-				}
-				out[bucketKey] = bucketMap;
+      }
+      out[bucketKey] = bucketMap;
 			},
 		),
-	);
+  );
 
-	return out;
+  return out;
 }
 
 async function handleGet(
@@ -1092,25 +1092,25 @@ async function handleGet(
     `;
 		const memberSchema =
 			(rows[0]?.metadata_schema as Record<string, unknown> | null) ?? null;
-		metadata = redactMemberEmail(metadata, memberSchema);
-	}
+    metadata = redactMemberEmail(metadata, memberSchema);
+  }
 
-	return {
+  return {
 		action: "get",
-		entity: {
-			id: entity.id,
-			entity_type: entity.entity_type,
-			name: entity.name,
-			slug: entity.slug,
-			parent_id: entity.parent_id,
-			parent_name: entity.parent_name,
-			parent_slug: entity.parent_slug ?? null,
-			metadata,
-			enabled_classifiers: entity.enabled_classifiers,
-			created_at: toIsoStringOrNow(entity.created_at),
-			view_url: viewUrl,
-		},
-	};
+    entity: {
+      id: entity.id,
+      entity_type: entity.entity_type,
+      name: entity.name,
+      slug: entity.slug,
+      parent_id: entity.parent_id,
+      parent_name: entity.parent_name,
+      parent_slug: entity.parent_slug ?? null,
+      metadata,
+      enabled_classifiers: entity.enabled_classifiers,
+      created_at: toIsoStringOrNow(entity.created_at),
+      view_url: viewUrl,
+    },
+  };
 }
 
 async function handleDelete(
@@ -1265,27 +1265,27 @@ async function handleLink(
     ORDER BY (rt.organization_id = ${ctx.organizationId}) DESC, rt.id ASC
     LIMIT 1
   `;
-	if (typeRows.length === 0) {
+  if (typeRows.length === 0) {
 		throw new Error(
 			`Relationship type "${args.relationship_type_slug}" not found`,
 		);
-	}
-	const typeId = Number(typeRows[0].id);
-	const isSymmetric = Boolean(typeRows[0].is_symmetric);
+  }
+  const typeId = Number(typeRows[0].id);
+  const isSymmetric = Boolean(typeRows[0].is_symmetric);
 
-	await validateTypeRule(typeId, args.from_entity_id, args.to_entity_id, sql);
+  await validateTypeRule(typeId, args.from_entity_id, args.to_entity_id, sql);
 
-	let fromId = args.from_entity_id;
-	let toId = args.to_entity_id;
-	if (isSymmetric) {
-		// For symmetric same-org pairs we canonicalize by id so dedup catches
-		// a → b and b → a as the same edge. For cross-org pairs (target in a
-		// public catalog), keep the caller's-org entity as `from` even if its
-		// id is higher, so the stored source matches the semantic source. The
-		// canonical form would otherwise leave rows where `from_entity_id`
-		// points at a public catalog row under a tenant `organization_id` —
-		// tenant-owned but cosmetically inverted.
-		const orgRows = await sql<{ id: number; organization_id: string }>`
+  let fromId = args.from_entity_id;
+  let toId = args.to_entity_id;
+  if (isSymmetric) {
+    // For symmetric same-org pairs we canonicalize by id so dedup catches
+    // a → b and b → a as the same edge. For cross-org pairs (target in a
+    // public catalog), keep the caller's-org entity as `from` even if its
+    // id is higher, so the stored source matches the semantic source. The
+    // canonical form would otherwise leave rows where `from_entity_id`
+    // points at a public catalog row under a tenant `organization_id` —
+    // tenant-owned but cosmetically inverted.
+    const orgRows = await sql<{ id: number; organization_id: string }>`
       SELECT id, organization_id FROM entities WHERE id IN (${fromId}, ${toId})
     `;
 		const orgOf = (id: number) =>
@@ -1330,12 +1330,12 @@ async function handleLink(
     )
     RETURNING id
   `;
-	const relationshipId = Number((inserted[0] as { id: unknown }).id);
+  const relationshipId = Number((inserted[0] as { id: unknown }).id);
 
-	const created = await sql.unsafe<RelationshipRow>(
-		`SELECT ${RELATIONSHIP_SELECT} ${RELATIONSHIP_JOINS} WHERE r.id = $1`,
+  const created = await sql.unsafe<RelationshipRow>(
+    `SELECT ${RELATIONSHIP_SELECT} ${RELATIONSHIP_JOINS} WHERE r.id = $1`,
 		[relationshipId],
-	);
+  );
 
 	return { action: "link", relationship: created[0] };
 }
@@ -1347,9 +1347,9 @@ async function handleUnlink(
 	if (!args.relationship_id)
 		throw new Error("relationship_id is required for unlink");
 
-	const sql = getDb();
+  const sql = getDb();
 
-	const existing = await sql`
+  const existing = await sql`
     SELECT id, organization_id FROM entity_relationships
     WHERE id = ${args.relationship_id} AND deleted_at IS NULL
     LIMIT 1
@@ -1383,9 +1383,9 @@ async function handleUpdateLink(
 	if (!args.relationship_id)
 		throw new Error("relationship_id is required for update_link");
 
-	const sql = getDb();
+  const sql = getDb();
 
-	const existing = await sql`
+  const existing = await sql`
     SELECT id, organization_id FROM entity_relationships
     WHERE id = ${args.relationship_id} AND deleted_at IS NULL
     LIMIT 1
@@ -1418,10 +1418,10 @@ async function handleUpdateLink(
     WHERE id = ${args.relationship_id}
   `;
 
-	const updated = await sql.unsafe<RelationshipRow>(
-		`SELECT ${RELATIONSHIP_SELECT} ${RELATIONSHIP_JOINS} WHERE r.id = $1`,
+  const updated = await sql.unsafe<RelationshipRow>(
+    `SELECT ${RELATIONSHIP_SELECT} ${RELATIONSHIP_JOINS} WHERE r.id = $1`,
 		[args.relationship_id],
-	);
+  );
 
 	return { action: "update_link", relationship: updated[0] };
 }
@@ -1509,13 +1509,13 @@ async function handleListLinks(
      LIMIT ${limit + 1}
      OFFSET ${offset}`,
 		params,
-	);
+  );
 
-	const hasMore = rows.length > limit;
-	const relationships = hasMore ? rows.slice(0, limit) : rows;
+  const hasMore = rows.length > limit;
+  const relationships = hasMore ? rows.slice(0, limit) : rows;
 
-	const countsResult = await sql.unsafe<RelationshipCountByType>(
-		`SELECT
+  const countsResult = await sql.unsafe<RelationshipCountByType>(
+    `SELECT
       rt.slug as relationship_type_slug,
       rt.name as relationship_type_name,
       COUNT(*)::int as count
@@ -1524,12 +1524,12 @@ async function handleListLinks(
     GROUP BY rt.slug, rt.name
     ORDER BY count DESC`,
 		params,
-	);
+  );
 
-	return {
+  return {
 		action: "list_links",
-		relationships,
-		counts_by_type: countsResult,
-		metadata: { total, limit, offset, has_more: hasMore },
-	};
+    relationships,
+    counts_by_type: countsResult,
+    metadata: { total, limit, offset, has_more: hasMore },
+  };
 }

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -22,14 +22,7 @@ import {
 	RejectBatchAction,
 } from "@lobu/core/contracts/tools/manage-operations";
 import type { Static } from "@sinclair/typebox";
-import {
-	getDb,
-	parsePgNumberArray,
-	pgBigintArray,
-	pgTextArray,
-} from "../../db/client";
-import type { Env } from "../../index";
-import { callTool as callProxyTool } from "../../mcp-proxy/client";
+import { compileConnectionRowVisibility } from "../../authz/connection-visibility";
 import {
 	agentExistsInOrg,
 	resolveActingPrincipal,
@@ -38,9 +31,15 @@ import {
 	resolveWritePolicyDecision,
 	watcherIdFromPrincipalId,
 } from "../../authz/entity-policy";
-import { compileConnectionRowVisibility } from "../../authz/connection-visibility";
 import { authzScopeFromToolContext } from "../../authz/scope";
-import { callerIsAdmin } from "./helpers/db-helpers";
+import {
+	getDb,
+	parsePgNumberArray,
+	pgBigintArray,
+	pgTextArray,
+} from "../../db/client";
+import type { Env } from "../../index";
+import { callTool as callProxyTool } from "../../mcp-proxy/client";
 import { notifyActionApprovalNeeded } from "../../notifications/triggers";
 import {
 	defaultActionModeForOperation,
@@ -81,6 +80,7 @@ import {
 	ENTITY_CHANGE_ACTION_KEYS,
 	type EntityChangeProposal,
 } from "./entity-field-approval";
+import { callerIsAdmin } from "./helpers/db-helpers";
 import {
 	applyManageAgentsProposal,
 	MANAGE_AGENTS_ACTION_KEY,
@@ -101,14 +101,14 @@ type InlineExecutionResult =
 	| { status: "failed"; error_message: string };
 
 type ConnectionRow = {
-  id: number;
-  connector_key: string;
-  status: string;
-  auth_profile_id: number | null;
-  app_auth_profile_id: number | null;
-  display_name: string | null;
-  config: Record<string, unknown> | null;
-  name: string;
+	id: number;
+	connector_key: string;
+	status: string;
+	auth_profile_id: number | null;
+	app_auth_profile_id: number | null;
+	display_name: string | null;
+	config: Record<string, unknown> | null;
+	name: string;
 };
 
 type ExecutionTarget = {
@@ -148,21 +148,21 @@ type OperationTargetRow = {
  * separates because operation keys themselves contain dots (`slack.send_message`).
  */
 export function qualifiedOperationKey(
-  connectorKey: string,
-  operationKey: string,
+	connectorKey: string,
+	operationKey: string,
 ): string {
-  return `${connectorKey}::${operationKey}`;
+	return `${connectorKey}::${operationKey}`;
 }
 
 const manageOperationsTool = defineActionTool("manage_operations", {
-  list_available: action(ListAvailableAction, handleListAvailable),
-  execute: action(ExecuteAction, handleExecute),
-  list_runs: action(ListRunsAction, handleListRuns),
-  get_run: action(GetRunAction, handleGetRun),
-  approve: action(ApproveAction, handleApprove),
-  reject: action(RejectAction, handleReject),
-  approve_batch: action(ApproveBatchAction, handleApproveBatch),
-  reject_batch: action(RejectBatchAction, handleRejectBatch),
+	list_available: action(ListAvailableAction, handleListAvailable),
+	execute: action(ExecuteAction, handleExecute),
+	list_runs: action(ListRunsAction, handleListRuns),
+	get_run: action(GetRunAction, handleGetRun),
+	approve: action(ApproveAction, handleApprove),
+	reject: action(RejectAction, handleReject),
+	approve_batch: action(ApproveBatchAction, handleApproveBatch),
+	reject_batch: action(RejectBatchAction, handleRejectBatch),
 });
 
 export { ManageOperationsResultSchema, ManageOperationsSchema };
@@ -324,32 +324,32 @@ async function executeMcpToolInline(
 			status: "failed",
 			error_message: "Invalid MCP operation backend config",
 		};
-  }
+	}
 
 	let result: Awaited<ReturnType<typeof callProxyTool>>;
 	try {
 		result = await callProxyTool(
-    connection.connector_key,
-    {
-      upstream_url: operation.backend_config.upstreamUrl,
+			connection.connector_key,
+			{
+				upstream_url: operation.backend_config.upstreamUrl,
 				tool_prefix: "",
-    },
-    organizationId,
-    operation.backend_config.toolName,
+			},
+			organizationId,
+			operation.backend_config.toolName,
 			actionInput,
 			connection.id,
-  );
+		);
 	} catch (error) {
 		return failRunInline(runId, organizationId, getErrorMessage(error));
 	}
 
-  if (result.isError) {
-    const errorText =
-      (result.content as Array<{ type: string; text?: string }>).find(
+	if (result.isError) {
+		const errorText =
+			(result.content as Array<{ type: string; text?: string }>).find(
 				(item) => item?.type === "text",
 			)?.text ?? "Upstream MCP error";
-    return failRunInline(runId, organizationId, errorText);
-  }
+		return failRunInline(runId, organizationId, errorText);
+	}
 
 	return completeRunInline(runId, organizationId, {
 		content: result.content,
@@ -366,16 +366,16 @@ async function executeOperationInline(
 	abortSignal?: AbortSignal,
 ): Promise<InlineExecutionResult> {
 	if (operation.backend === "local_action") {
-    return executeLocalActionInline(
-      runId,
-      organizationId,
-      connection,
-      operation,
-      actionInput,
-      env,
+		return executeLocalActionInline(
+			runId,
+			organizationId,
+			connection,
+			operation,
+			actionInput,
+			env,
 			abortSignal,
-    );
-  }
+		);
+	}
 	if (operation.backend === "mcp_tool") {
 		return executeMcpToolInline(
 			runId,
@@ -384,7 +384,7 @@ async function executeOperationInline(
 			operation,
 			actionInput,
 		);
-  }
+	}
 	return executeHttpOperation(
 		runId,
 		organizationId,
@@ -395,7 +395,9 @@ async function executeOperationInline(
 	);
 }
 
-function executionTargetFromRow(row: OperationTargetRow): InternalExecutionTarget {
+function executionTargetFromRow(
+	row: OperationTargetRow,
+): InternalExecutionTarget {
 	const base = {
 		connection_id: Number(row.id),
 		slug: row.slug,
@@ -466,7 +468,11 @@ function resolveOperationReadiness(targets: ExecutionTarget[]): {
 		return { readyTarget, executable: true, readiness: "ready" };
 	}
 	if (targets.length === 0) {
-		return { readyTarget: undefined, executable: false, readiness: "disconnected" };
+		return {
+			readyTarget: undefined,
+			executable: false,
+			readiness: "disconnected",
+		};
 	}
 	if (targets.every((target) => target.status === "disabled")) {
 		return { readyTarget: undefined, executable: false, readiness: "disabled" };
@@ -606,7 +612,8 @@ function buildAvailableOperation(args: {
 	viewUrl: string | undefined;
 }): AvailableOperation & Record<string, unknown> {
 	const { operation, internalTargets, includeInputSchema, viewUrl } = args;
-	const { backend_config: _privateBackendConfig, ...publicOperation } = operation;
+	const { backend_config: _privateBackendConfig, ...publicOperation } =
+		operation;
 	const targets = internalTargets.map((target): ExecutionTarget => {
 		const {
 			config,
@@ -743,23 +750,23 @@ async function handleListAvailable(
 
 	const targetsByConnector = groupExecutionTargets(targetRows);
 
-  // A `disabled` connector_action effect turns an operation OFF for this principal
-  // — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
-  // which surface then gate on execute). Two levels now: the BLANKET `execute` rule
-  // (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
-  // can disable a single op while the rest stay listed.
-  const actor = await resolveActingPrincipal(getDb(), {
-    organizationId: ctx.organizationId,
-    userId: ctx.userId,
-    agentId: ctx.agentId,
-    sessionWatcherId: ctx.actingWatcherId ?? null,
-  });
-  // Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
-  // ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
-  // its hidden count from the global total gives an inconsistent `total` across pages
-  // and can return a short page while visible ops remain past the offset (a client
-  // treating "short page = end" would silently truncate the catalog). Pagination must
-  // run on the post-filter list.
+	// A `disabled` connector_action effect turns an operation OFF for this principal
+	// — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
+	// which surface then gate on execute). Two levels now: the BLANKET `execute` rule
+	// (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
+	// can disable a single op while the rest stay listed.
+	const actor = await resolveActingPrincipal(getDb(), {
+		organizationId: ctx.organizationId,
+		userId: ctx.userId,
+		agentId: ctx.agentId,
+		sessionWatcherId: ctx.actingWatcherId ?? null,
+	});
+	// Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
+	// ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
+	// its hidden count from the global total gives an inconsistent `total` across pages
+	// and can return a short page while visible ops remain past the offset (a client
+	// treating "short page = end" would silently truncate the catalog). Pagination must
+	// run on the post-filter list.
 	// For an explicit connection, targetRows already performed the visibility and
 	// authorization lookup. Query the connector catalog by that row's key instead
 	// of applying listOperations' legacy per-connection action-mode filter; the
@@ -769,23 +776,23 @@ async function handleListAvailable(
 		args.connection_id !== undefined
 			? targetRows[0]?.connector_key
 			: args.connector_key;
-  const full = await listOperations({
-    organizationId: ctx.organizationId,
+	const full = await listOperations({
+		organizationId: ctx.organizationId,
 		connectorKey: catalogConnectorKey,
-    entityId: args.entity_id,
-    kind: args.kind,
-    backend: args.backend,
+		entityId: args.entity_id,
+		kind: args.kind,
+		backend: args.backend,
 		// Required-input detection still needs the schema when the caller hides the
 		// descriptor copy from the public response.
 		includeInputSchema: true,
-    includeOutputSchema: args.include_output_schema ?? false,
-    // Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
-    // would silently drop ops past index 100 and make them unreachable at any
-    // caller offset. We must filter per-op-disabled across the full set BEFORE
-    // slicing, so no internal cap here; the caller's limit/offset apply below.
-    limit: Number.MAX_SAFE_INTEGER,
-    offset: 0,
-  });
+		includeOutputSchema: args.include_output_schema ?? false,
+		// Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
+		// would silently drop ops past index 100 and make them unreachable at any
+		// caller offset. We must filter per-op-disabled across the full set BEFORE
+		// slicing, so no internal cap here; the caller's limit/offset apply below.
+		limit: Number.MAX_SAFE_INTEGER,
+		offset: 0,
+	});
 	const qualifiedWriteKeys = full.operations
 		.filter((operation) => operation.kind === "write")
 		.map((operation) =>
@@ -803,20 +810,20 @@ async function handleListAvailable(
 	});
 	const blanketDisabled = policyEffects.get(null) === "disabled";
 
-  // Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
-  // filtered by agent write-policy. Humans always resolve auto for policy.
+	// Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
+	// filtered by agent write-policy. Humans always resolve auto for policy.
 	const visibleFlags = full.operations.map((op) => {
-			if (op.kind === "read") return "auto" as const;
-			if (blanketDisabled) return "disabled" as const;
-			return (
-				policyEffects.get(
-					qualifiedOperationKey(op.connector_key, op.operation_key),
-				) ?? "auto"
-  );
-		});
+		if (op.kind === "read") return "auto" as const;
+		if (blanketDisabled) return "disabled" as const;
+		return (
+			policyEffects.get(
+				qualifiedOperationKey(op.connector_key, op.operation_key),
+			) ?? "auto"
+		);
+	});
 	const policyVisible = full.operations.filter(
 		(_op, i) => visibleFlags[i] !== "disabled",
-  );
+	);
 
 	const queryTokens = (args.query ?? "")
 		.toLocaleLowerCase()
@@ -831,8 +838,7 @@ async function handleListAvailable(
 		.map((operation) =>
 			buildAvailableOperation({
 				operation,
-				internalTargets:
-					targetsByConnector.get(operation.connector_key) ?? [],
+				internalTargets: targetsByConnector.get(operation.connector_key) ?? [],
 				includeInputSchema: args.include_input_schema !== false,
 				viewUrl: connectorViewUrl(operation.connector_key),
 			}),
@@ -844,15 +850,15 @@ async function handleListAvailable(
 			return operationMatchesQuery(operation, queryTokens);
 		});
 
-  const offset = args.offset ?? 0;
+	const offset = args.offset ?? 0;
 	const limit = args.limit ?? 100;
-  return {
+	return {
 		action: "list_available",
 		operations: publicOperations.slice(offset, offset + limit),
 		total: publicOperations.length,
-    limit,
-    offset,
-  };
+		limit,
+		offset,
+	};
 }
 
 // Poll `runs` until status flips to completed/failed/timeout or we hit
@@ -1169,58 +1175,58 @@ async function handleListRuns(
 	args: Static<typeof ListRunsAction>,
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
-  const sql = getDb();
-  const limit = args.limit ?? 20;
-  // Keyset pagination short-circuits offset whenever a cursor is supplied.
-  const hasCursor = args.before_id != null && args.before_created_at != null;
-  const offset = hasCursor ? 0 : (args.offset ?? 0);
+	const sql = getDb();
+	const limit = args.limit ?? 20;
+	// Keyset pagination short-circuits offset whenever a cursor is supplied.
+	const hasCursor = args.before_id != null && args.before_created_at != null;
+	const offset = hasCursor ? 0 : (args.offset ?? 0);
 
-  // Shared WHERE fragment so the count and page queries can't drift apart.
-  let where = sql`r.organization_id = ${ctx.organizationId}`;
-  if (args.run_types && args.run_types.length > 0) {
-    // fetch_types:false means JS arrays aren't auto-serialized — use the
-    // PG array-literal helpers (see db/client.ts).
-    where = sql`${where} AND r.run_type = ANY(${pgTextArray(args.run_types)}::text[])`;
-  }
-  // connection scope: scalar connection_id (REST/SDK), an explicit id list, or
-  // every connection pinned to a device.
-  if (args.connection_id != null) {
-    where = sql`${where} AND r.connection_id = ${args.connection_id}`;
-  }
-  if (args.connection_ids && args.connection_ids.length > 0) {
-    where = sql`${where} AND r.connection_id = ANY(${pgBigintArray(args.connection_ids)}::bigint[])`;
-  }
-  if (args.feed_ids && args.feed_ids.length > 0) {
-    where = sql`${where} AND r.feed_id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;
-  }
-  if (args.device_worker_id) {
-    where = sql`${where} AND r.connection_id IN (
+	// Shared WHERE fragment so the count and page queries can't drift apart.
+	let where = sql`r.organization_id = ${ctx.organizationId}`;
+	if (args.run_types && args.run_types.length > 0) {
+		// fetch_types:false means JS arrays aren't auto-serialized — use the
+		// PG array-literal helpers (see db/client.ts).
+		where = sql`${where} AND r.run_type = ANY(${pgTextArray(args.run_types)}::text[])`;
+	}
+	// connection scope: scalar connection_id (REST/SDK), an explicit id list, or
+	// every connection pinned to a device.
+	if (args.connection_id != null) {
+		where = sql`${where} AND r.connection_id = ${args.connection_id}`;
+	}
+	if (args.connection_ids && args.connection_ids.length > 0) {
+		where = sql`${where} AND r.connection_id = ANY(${pgBigintArray(args.connection_ids)}::bigint[])`;
+	}
+	if (args.feed_ids && args.feed_ids.length > 0) {
+		where = sql`${where} AND r.feed_id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;
+	}
+	if (args.device_worker_id) {
+		where = sql`${where} AND r.connection_id IN (
       SELECT id FROM connections
       WHERE device_worker_id = ${args.device_worker_id}
         AND organization_id = ${ctx.organizationId}
         AND deleted_at IS NULL
     )`;
-  }
-  if (args.operation_key) {
-    where = sql`${where} AND r.action_key = ${args.operation_key}`;
-  }
-  if (args.status) {
-    where = sql`${where} AND r.status = ${args.status}`;
-  }
-  if (args.approval_status) {
-    where = sql`${where} AND r.approval_status = ${args.approval_status}`;
-  }
-  if (args.watcher_ids && args.watcher_ids.length > 0) {
-    where = sql`${where} AND r.watcher_id = ANY(${pgBigintArray(args.watcher_ids)}::bigint[])`;
-  }
+	}
+	if (args.operation_key) {
+		where = sql`${where} AND r.action_key = ${args.operation_key}`;
+	}
+	if (args.status) {
+		where = sql`${where} AND r.status = ${args.status}`;
+	}
+	if (args.approval_status) {
+		where = sql`${where} AND r.approval_status = ${args.approval_status}`;
+	}
+	if (args.watcher_ids && args.watcher_ids.length > 0) {
+		where = sql`${where} AND r.watcher_id = ANY(${pgBigintArray(args.watcher_ids)}::bigint[])`;
+	}
 
-  const countQuery = sql`SELECT COUNT(*)::int AS total FROM runs r WHERE ${where}`;
+	const countQuery = sql`SELECT COUNT(*)::int AS total FROM runs r WHERE ${where}`;
 
-  let pageWhere = where;
-  if (hasCursor) {
-    pageWhere = sql`${pageWhere} AND (r.created_at, r.id) < (${args.before_created_at}::timestamptz, ${args.before_id})`;
-  }
-  const query = sql`
+	let pageWhere = where;
+	if (hasCursor) {
+		pageWhere = sql`${pageWhere} AND (r.created_at, r.id) < (${args.before_created_at}::timestamptz, ${args.before_id})`;
+	}
+	const query = sql`
     SELECT r.id, r.run_type, r.watcher_id, r.connection_id, r.feed_id, r.connector_key, r.connector_version,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.items_collected, r.checkpoint,
@@ -1235,24 +1241,24 @@ async function handleListRuns(
     LIMIT ${limit} OFFSET ${offset}
   `;
 
-  const [countResult, rows] = await Promise.all([countQuery, query]);
+	const [countResult, rows] = await Promise.all([countQuery, query]);
 
-  return {
+	return {
 		action: "list_runs",
-    runs: rows,
-    total: Number(countResult[0]?.total ?? 0),
-    limit,
-    offset,
-    has_more: rows.length === limit,
-  };
+		runs: rows,
+		total: Number(countResult[0]?.total ?? 0),
+		limit,
+		offset,
+		has_more: rows.length === limit,
+	};
 }
 
 async function handleGetRun(
 	args: Static<typeof GetRunAction>,
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
-  const sql = getDb();
-  const rows = await sql`
+	const sql = getDb();
+	const rows = await sql`
     SELECT r.id, r.connection_id, r.connector_key,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message,
@@ -1275,9 +1281,9 @@ async function handleGetRun(
  * (e.g. a worker completing a device action it was told to run).
  */
 export interface ApprovalReviewer {
-  userId: string;
-  /** Display name resolved at decision time; falls back to userId when unknown. */
-  name: string | null;
+	userId: string;
+	/** Display name resolved at decision time; falls back to userId when unknown. */
+	name: string | null;
 }
 
 export async function supersedeActionEvent(
@@ -1289,8 +1295,8 @@ export async function supersedeActionEvent(
 	extraMetadata: Record<string, unknown> = {},
 	reviewer: ApprovalReviewer | null = null,
 ): Promise<number | undefined> {
-  const sql = getDb();
-  const originalEvent = await sql`
+	const sql = getDb();
+	const originalEvent = await sql`
     SELECT id, entity_ids, connection_id, connector_key, metadata, author_name, interaction_input_schema, interaction_input
     FROM current_event_records
     WHERE run_id = ${runId}
@@ -1378,11 +1384,11 @@ export async function supersedeActionEvent(
 async function resolveReviewer(
 	ctx: ToolContext,
 ): Promise<ApprovalReviewer | null> {
-  if (!ctx.userId) return null;
-  const rows = await getDb()<{ name: string | null }>`
+	if (!ctx.userId) return null;
+	const rows = await getDb()<{ name: string | null }>`
     SELECT name FROM "user" WHERE id = ${ctx.userId} LIMIT 1
   `;
-  return { userId: ctx.userId, name: rows[0]?.name ?? null };
+	return { userId: ctx.userId, name: rows[0]?.name ?? null };
 }
 
 /**
@@ -1723,7 +1729,7 @@ async function claimEntityChangeRun(
             AND action_key = ANY(${actionKeys}::text[])
           RETURNING action_input
         `
-      : await sql`
+			: await sql`
           UPDATE runs
           SET approval_status = 'rejected', status = 'cancelled',
               error_message = ${rejectReason ?? "Rejected by user"}, completed_at = NOW()
@@ -1743,7 +1749,7 @@ async function claimEntityChangeRun(
 
 function entityChangeOperation(
 	proposal: EntityChangeProposal,
-): "create" | "update" | "delete" {
+): "create" | "update" | "delete" | "merge" {
 	return proposal.operation ?? "update";
 }
 
@@ -1761,6 +1767,13 @@ function describeEntityChange(proposal: EntityChangeProposal): string {
 			{ operation: "delete" }
 		>;
 		return deleteProposal.current?.name ?? `entity ${deleteProposal.entity_id}`;
+	}
+	if (operation === "merge") {
+		const mergeProposal = proposal as Extract<
+			EntityChangeProposal,
+			{ operation: "merge" }
+		>;
+		return `${String(mergeProposal.current.loser.name ?? `entity ${mergeProposal.entity_id}`)} into ${String(mergeProposal.current.winner.name ?? `entity ${mergeProposal.winner_entity_id}`)}`;
 	}
 	return (proposal as Extract<EntityChangeProposal, { operation: "create" }>)
 		.entity_data.name;

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1773,7 +1773,10 @@ function describeEntityChange(proposal: EntityChangeProposal): string {
 			EntityChangeProposal,
 			{ operation: "merge" }
 		>;
-		return `${String(mergeProposal.current.loser.name ?? `entity ${mergeProposal.entity_id}`)} into ${String(mergeProposal.current.winner.name ?? `entity ${mergeProposal.winner_entity_id}`)}`;
+		const duplicates = mergeProposal.current.duplicates ?? [
+			mergeProposal.current.loser,
+		];
+		return `${duplicates.map((entity) => String(entity.name ?? `entity ${entity.id}`)).join(", ")} into ${String(mergeProposal.current.winner.name ?? `entity ${mergeProposal.winner_entity_id}`)}`;
 	}
 	return (proposal as Extract<EntityChangeProposal, { operation: "create" }>)
 		.entity_data.name;

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -101,14 +101,14 @@ type InlineExecutionResult =
 	| { status: "failed"; error_message: string };
 
 type ConnectionRow = {
-	id: number;
-	connector_key: string;
-	status: string;
-	auth_profile_id: number | null;
-	app_auth_profile_id: number | null;
-	display_name: string | null;
-	config: Record<string, unknown> | null;
-	name: string;
+  id: number;
+  connector_key: string;
+  status: string;
+  auth_profile_id: number | null;
+  app_auth_profile_id: number | null;
+  display_name: string | null;
+  config: Record<string, unknown> | null;
+  name: string;
 };
 
 type ExecutionTarget = {
@@ -148,21 +148,21 @@ type OperationTargetRow = {
  * separates because operation keys themselves contain dots (`slack.send_message`).
  */
 export function qualifiedOperationKey(
-	connectorKey: string,
-	operationKey: string,
+  connectorKey: string,
+  operationKey: string,
 ): string {
-	return `${connectorKey}::${operationKey}`;
+  return `${connectorKey}::${operationKey}`;
 }
 
 const manageOperationsTool = defineActionTool("manage_operations", {
-	list_available: action(ListAvailableAction, handleListAvailable),
-	execute: action(ExecuteAction, handleExecute),
-	list_runs: action(ListRunsAction, handleListRuns),
-	get_run: action(GetRunAction, handleGetRun),
-	approve: action(ApproveAction, handleApprove),
-	reject: action(RejectAction, handleReject),
-	approve_batch: action(ApproveBatchAction, handleApproveBatch),
-	reject_batch: action(RejectBatchAction, handleRejectBatch),
+  list_available: action(ListAvailableAction, handleListAvailable),
+  execute: action(ExecuteAction, handleExecute),
+  list_runs: action(ListRunsAction, handleListRuns),
+  get_run: action(GetRunAction, handleGetRun),
+  approve: action(ApproveAction, handleApprove),
+  reject: action(RejectAction, handleReject),
+  approve_batch: action(ApproveBatchAction, handleApproveBatch),
+  reject_batch: action(RejectBatchAction, handleRejectBatch),
 });
 
 export { ManageOperationsResultSchema, ManageOperationsSchema };
@@ -324,32 +324,32 @@ async function executeMcpToolInline(
 			status: "failed",
 			error_message: "Invalid MCP operation backend config",
 		};
-	}
+  }
 
 	let result: Awaited<ReturnType<typeof callProxyTool>>;
 	try {
 		result = await callProxyTool(
-			connection.connector_key,
-			{
-				upstream_url: operation.backend_config.upstreamUrl,
+    connection.connector_key,
+    {
+      upstream_url: operation.backend_config.upstreamUrl,
 				tool_prefix: "",
-			},
-			organizationId,
-			operation.backend_config.toolName,
+    },
+    organizationId,
+    operation.backend_config.toolName,
 			actionInput,
 			connection.id,
-		);
+  );
 	} catch (error) {
 		return failRunInline(runId, organizationId, getErrorMessage(error));
 	}
 
-	if (result.isError) {
-		const errorText =
-			(result.content as Array<{ type: string; text?: string }>).find(
+  if (result.isError) {
+    const errorText =
+      (result.content as Array<{ type: string; text?: string }>).find(
 				(item) => item?.type === "text",
 			)?.text ?? "Upstream MCP error";
-		return failRunInline(runId, organizationId, errorText);
-	}
+    return failRunInline(runId, organizationId, errorText);
+  }
 
 	return completeRunInline(runId, organizationId, {
 		content: result.content,
@@ -366,16 +366,16 @@ async function executeOperationInline(
 	abortSignal?: AbortSignal,
 ): Promise<InlineExecutionResult> {
 	if (operation.backend === "local_action") {
-		return executeLocalActionInline(
-			runId,
-			organizationId,
-			connection,
-			operation,
-			actionInput,
-			env,
+    return executeLocalActionInline(
+      runId,
+      organizationId,
+      connection,
+      operation,
+      actionInput,
+      env,
 			abortSignal,
-		);
-	}
+    );
+  }
 	if (operation.backend === "mcp_tool") {
 		return executeMcpToolInline(
 			runId,
@@ -384,7 +384,7 @@ async function executeOperationInline(
 			operation,
 			actionInput,
 		);
-	}
+  }
 	return executeHttpOperation(
 		runId,
 		organizationId,
@@ -750,23 +750,23 @@ async function handleListAvailable(
 
 	const targetsByConnector = groupExecutionTargets(targetRows);
 
-	// A `disabled` connector_action effect turns an operation OFF for this principal
-	// — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
-	// which surface then gate on execute). Two levels now: the BLANKET `execute` rule
-	// (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
-	// can disable a single op while the rest stay listed.
-	const actor = await resolveActingPrincipal(getDb(), {
-		organizationId: ctx.organizationId,
-		userId: ctx.userId,
-		agentId: ctx.agentId,
-		sessionWatcherId: ctx.actingWatcherId ?? null,
-	});
-	// Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
-	// ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
-	// its hidden count from the global total gives an inconsistent `total` across pages
-	// and can return a short page while visible ops remain past the offset (a client
-	// treating "short page = end" would silently truncate the catalog). Pagination must
-	// run on the post-filter list.
+  // A `disabled` connector_action effect turns an operation OFF for this principal
+  // — it shouldn't be listed at all (Disabled HIDES the action, unlike deny/approval
+  // which surface then gate on execute). Two levels now: the BLANKET `execute` rule
+  // (operation_key NULL) can disable the whole connector, and a PER-OPERATION rule
+  // can disable a single op while the rest stay listed.
+  const actor = await resolveActingPrincipal(getDb(), {
+    organizationId: ctx.organizationId,
+    userId: ctx.userId,
+    agentId: ctx.agentId,
+    sessionWatcherId: ctx.actingWatcherId ?? null,
+  });
+  // Fetch the FULL filtered set (offset 0, no caller limit), drop per-op-disabled
+  // ops across the WHOLE set, THEN paginate. Filtering a single page and subtracting
+  // its hidden count from the global total gives an inconsistent `total` across pages
+  // and can return a short page while visible ops remain past the offset (a client
+  // treating "short page = end" would silently truncate the catalog). Pagination must
+  // run on the post-filter list.
 	// For an explicit connection, targetRows already performed the visibility and
 	// authorization lookup. Query the connector catalog by that row's key instead
 	// of applying listOperations' legacy per-connection action-mode filter; the
@@ -776,23 +776,23 @@ async function handleListAvailable(
 		args.connection_id !== undefined
 			? targetRows[0]?.connector_key
 			: args.connector_key;
-	const full = await listOperations({
-		organizationId: ctx.organizationId,
+  const full = await listOperations({
+    organizationId: ctx.organizationId,
 		connectorKey: catalogConnectorKey,
-		entityId: args.entity_id,
-		kind: args.kind,
-		backend: args.backend,
+    entityId: args.entity_id,
+    kind: args.kind,
+    backend: args.backend,
 		// Required-input detection still needs the schema when the caller hides the
 		// descriptor copy from the public response.
 		includeInputSchema: true,
-		includeOutputSchema: args.include_output_schema ?? false,
-		// Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
-		// would silently drop ops past index 100 and make them unreachable at any
-		// caller offset. We must filter per-op-disabled across the full set BEFORE
-		// slicing, so no internal cap here; the caller's limit/offset apply below.
-		limit: Number.MAX_SAFE_INTEGER,
-		offset: 0,
-	});
+    includeOutputSchema: args.include_output_schema ?? false,
+    // Fetch the WHOLE filtered set — listOperations defaults to limit 100, which
+    // would silently drop ops past index 100 and make them unreachable at any
+    // caller offset. We must filter per-op-disabled across the full set BEFORE
+    // slicing, so no internal cap here; the caller's limit/offset apply below.
+    limit: Number.MAX_SAFE_INTEGER,
+    offset: 0,
+  });
 	const qualifiedWriteKeys = full.operations
 		.filter((operation) => operation.kind === "write")
 		.map((operation) =>
@@ -810,20 +810,20 @@ async function handleListAvailable(
 	});
 	const blanketDisabled = policyEffects.get(null) === "disabled";
 
-	// Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
-	// filtered by agent write-policy. Humans always resolve auto for policy.
+  // Hide WRITE ops whose per-op (or blanket) policy is disabled. Reads are never
+  // filtered by agent write-policy. Humans always resolve auto for policy.
 	const visibleFlags = full.operations.map((op) => {
-		if (op.kind === "read") return "auto" as const;
-		if (blanketDisabled) return "disabled" as const;
-		return (
-			policyEffects.get(
-				qualifiedOperationKey(op.connector_key, op.operation_key),
-			) ?? "auto"
-		);
-	});
+			if (op.kind === "read") return "auto" as const;
+			if (blanketDisabled) return "disabled" as const;
+			return (
+				policyEffects.get(
+					qualifiedOperationKey(op.connector_key, op.operation_key),
+				) ?? "auto"
+  );
+		});
 	const policyVisible = full.operations.filter(
 		(_op, i) => visibleFlags[i] !== "disabled",
-	);
+  );
 
 	const queryTokens = (args.query ?? "")
 		.toLocaleLowerCase()
@@ -850,15 +850,15 @@ async function handleListAvailable(
 			return operationMatchesQuery(operation, queryTokens);
 		});
 
-	const offset = args.offset ?? 0;
+  const offset = args.offset ?? 0;
 	const limit = args.limit ?? 100;
-	return {
+  return {
 		action: "list_available",
 		operations: publicOperations.slice(offset, offset + limit),
 		total: publicOperations.length,
-		limit,
-		offset,
-	};
+    limit,
+    offset,
+  };
 }
 
 // Poll `runs` until status flips to completed/failed/timeout or we hit
@@ -1175,58 +1175,58 @@ async function handleListRuns(
 	args: Static<typeof ListRunsAction>,
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
-	const sql = getDb();
-	const limit = args.limit ?? 20;
-	// Keyset pagination short-circuits offset whenever a cursor is supplied.
-	const hasCursor = args.before_id != null && args.before_created_at != null;
-	const offset = hasCursor ? 0 : (args.offset ?? 0);
+  const sql = getDb();
+  const limit = args.limit ?? 20;
+  // Keyset pagination short-circuits offset whenever a cursor is supplied.
+  const hasCursor = args.before_id != null && args.before_created_at != null;
+  const offset = hasCursor ? 0 : (args.offset ?? 0);
 
-	// Shared WHERE fragment so the count and page queries can't drift apart.
-	let where = sql`r.organization_id = ${ctx.organizationId}`;
-	if (args.run_types && args.run_types.length > 0) {
-		// fetch_types:false means JS arrays aren't auto-serialized — use the
-		// PG array-literal helpers (see db/client.ts).
-		where = sql`${where} AND r.run_type = ANY(${pgTextArray(args.run_types)}::text[])`;
-	}
-	// connection scope: scalar connection_id (REST/SDK), an explicit id list, or
-	// every connection pinned to a device.
-	if (args.connection_id != null) {
-		where = sql`${where} AND r.connection_id = ${args.connection_id}`;
-	}
-	if (args.connection_ids && args.connection_ids.length > 0) {
-		where = sql`${where} AND r.connection_id = ANY(${pgBigintArray(args.connection_ids)}::bigint[])`;
-	}
-	if (args.feed_ids && args.feed_ids.length > 0) {
-		where = sql`${where} AND r.feed_id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;
-	}
-	if (args.device_worker_id) {
-		where = sql`${where} AND r.connection_id IN (
+  // Shared WHERE fragment so the count and page queries can't drift apart.
+  let where = sql`r.organization_id = ${ctx.organizationId}`;
+  if (args.run_types && args.run_types.length > 0) {
+    // fetch_types:false means JS arrays aren't auto-serialized — use the
+    // PG array-literal helpers (see db/client.ts).
+    where = sql`${where} AND r.run_type = ANY(${pgTextArray(args.run_types)}::text[])`;
+  }
+  // connection scope: scalar connection_id (REST/SDK), an explicit id list, or
+  // every connection pinned to a device.
+  if (args.connection_id != null) {
+    where = sql`${where} AND r.connection_id = ${args.connection_id}`;
+  }
+  if (args.connection_ids && args.connection_ids.length > 0) {
+    where = sql`${where} AND r.connection_id = ANY(${pgBigintArray(args.connection_ids)}::bigint[])`;
+  }
+  if (args.feed_ids && args.feed_ids.length > 0) {
+    where = sql`${where} AND r.feed_id = ANY(${pgBigintArray(args.feed_ids)}::bigint[])`;
+  }
+  if (args.device_worker_id) {
+    where = sql`${where} AND r.connection_id IN (
       SELECT id FROM connections
       WHERE device_worker_id = ${args.device_worker_id}
         AND organization_id = ${ctx.organizationId}
         AND deleted_at IS NULL
     )`;
-	}
-	if (args.operation_key) {
-		where = sql`${where} AND r.action_key = ${args.operation_key}`;
-	}
-	if (args.status) {
-		where = sql`${where} AND r.status = ${args.status}`;
-	}
-	if (args.approval_status) {
-		where = sql`${where} AND r.approval_status = ${args.approval_status}`;
-	}
-	if (args.watcher_ids && args.watcher_ids.length > 0) {
-		where = sql`${where} AND r.watcher_id = ANY(${pgBigintArray(args.watcher_ids)}::bigint[])`;
-	}
+  }
+  if (args.operation_key) {
+    where = sql`${where} AND r.action_key = ${args.operation_key}`;
+  }
+  if (args.status) {
+    where = sql`${where} AND r.status = ${args.status}`;
+  }
+  if (args.approval_status) {
+    where = sql`${where} AND r.approval_status = ${args.approval_status}`;
+  }
+  if (args.watcher_ids && args.watcher_ids.length > 0) {
+    where = sql`${where} AND r.watcher_id = ANY(${pgBigintArray(args.watcher_ids)}::bigint[])`;
+  }
 
-	const countQuery = sql`SELECT COUNT(*)::int AS total FROM runs r WHERE ${where}`;
+  const countQuery = sql`SELECT COUNT(*)::int AS total FROM runs r WHERE ${where}`;
 
-	let pageWhere = where;
-	if (hasCursor) {
-		pageWhere = sql`${pageWhere} AND (r.created_at, r.id) < (${args.before_created_at}::timestamptz, ${args.before_id})`;
-	}
-	const query = sql`
+  let pageWhere = where;
+  if (hasCursor) {
+    pageWhere = sql`${pageWhere} AND (r.created_at, r.id) < (${args.before_created_at}::timestamptz, ${args.before_id})`;
+  }
+  const query = sql`
     SELECT r.id, r.run_type, r.watcher_id, r.connection_id, r.feed_id, r.connector_key, r.connector_version,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message, r.items_collected, r.checkpoint,
@@ -1241,24 +1241,24 @@ async function handleListRuns(
     LIMIT ${limit} OFFSET ${offset}
   `;
 
-	const [countResult, rows] = await Promise.all([countQuery, query]);
+  const [countResult, rows] = await Promise.all([countQuery, query]);
 
-	return {
+  return {
 		action: "list_runs",
-		runs: rows,
-		total: Number(countResult[0]?.total ?? 0),
-		limit,
-		offset,
-		has_more: rows.length === limit,
-	};
+    runs: rows,
+    total: Number(countResult[0]?.total ?? 0),
+    limit,
+    offset,
+    has_more: rows.length === limit,
+  };
 }
 
 async function handleGetRun(
 	args: Static<typeof GetRunAction>,
 	ctx: ToolContext,
 ): Promise<ManageOperationsResult> {
-	const sql = getDb();
-	const rows = await sql`
+  const sql = getDb();
+  const rows = await sql`
     SELECT r.id, r.connection_id, r.connector_key,
            r.action_key AS operation_key, r.action_input AS input, r.action_output AS output,
            r.approval_status, r.status, r.error_message,
@@ -1281,9 +1281,9 @@ async function handleGetRun(
  * (e.g. a worker completing a device action it was told to run).
  */
 export interface ApprovalReviewer {
-	userId: string;
-	/** Display name resolved at decision time; falls back to userId when unknown. */
-	name: string | null;
+  userId: string;
+  /** Display name resolved at decision time; falls back to userId when unknown. */
+  name: string | null;
 }
 
 export async function supersedeActionEvent(
@@ -1295,8 +1295,8 @@ export async function supersedeActionEvent(
 	extraMetadata: Record<string, unknown> = {},
 	reviewer: ApprovalReviewer | null = null,
 ): Promise<number | undefined> {
-	const sql = getDb();
-	const originalEvent = await sql`
+  const sql = getDb();
+  const originalEvent = await sql`
     SELECT id, entity_ids, connection_id, connector_key, metadata, author_name, interaction_input_schema, interaction_input
     FROM current_event_records
     WHERE run_id = ${runId}
@@ -1384,11 +1384,11 @@ export async function supersedeActionEvent(
 async function resolveReviewer(
 	ctx: ToolContext,
 ): Promise<ApprovalReviewer | null> {
-	if (!ctx.userId) return null;
-	const rows = await getDb()<{ name: string | null }>`
+  if (!ctx.userId) return null;
+  const rows = await getDb()<{ name: string | null }>`
     SELECT name FROM "user" WHERE id = ${ctx.userId} LIMIT 1
   `;
-	return { userId: ctx.userId, name: rows[0]?.name ?? null };
+  return { userId: ctx.userId, name: rows[0]?.name ?? null };
 }
 
 /**
@@ -1729,7 +1729,7 @@ async function claimEntityChangeRun(
             AND action_key = ANY(${actionKeys}::text[])
           RETURNING action_input
         `
-			: await sql`
+      : await sql`
           UPDATE runs
           SET approval_status = 'rejected', status = 'cancelled',
               error_message = ${rejectReason ?? "Rejected by user"}, completed_at = NOW()

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -1705,9 +1705,9 @@ async function tryRejectBuilderRun(
 }
 
 /**
- * Claim a pending entity_field_change run (a watcher field-change held for
- * approval). Mirrors claimBuilderRun. Returns the held proposal, or null when
- * this run isn't a pending field-change run.
+ * Claim a pending entity-change run held for approval. Mirrors claimBuilderRun.
+ * Returns the held proposal, or null when this run is not a pending entity
+ * change.
  */
 async function claimEntityChangeRun(
 	runId: number,
@@ -1783,10 +1783,6 @@ function describeEntityChange(proposal: EntityChangeProposal): string {
 }
 
 /**
- * Approve + apply a pending entity_field_change run. Returns a result when the run
- * was a pending field-change run; null to fall through to other approval paths.
- */
-/**
  * Non-admin authority: a member may decide a run ONLY when it is a pending
  * entity-change proposal that records them as the field owner
  * (action_input.owner_user_id, resolved at propose time from field_controls).
@@ -1813,7 +1809,7 @@ async function isPendingEntityRunOwner(
 }
 
 /**
- * Approving/rejecting a run is a HUMAN decision — it must come from a verified
+ * Approving or rejecting a run is a HUMAN decision — it must come from a verified
  * user session, never from any non-human context. This is the security floor
  * beneath {@link requireApprovalAuthority}'s role check.
  *

--- a/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
+++ b/packages/server/src/utils/__tests__/entity-link-upsert.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanupTestDatabase, getTestDb } from '../../__tests__/setup/test-db';
 import {
   addUserToOrganization,
+  createTestConnection,
   createTestConnectorDefinition,
   createTestOrganization,
   createTestUser,
@@ -285,9 +286,17 @@ describe('applyEventAttributions', () => {
         { namespace: 'wa_jid', eventPath: 'metadata.jid' },
       ],
     });
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'whatsapp',
+      display_name: 'WhatsApp',
+      created_by: user.id,
+      createDefaultFeed: false,
+    });
 
     await applyEventAttributions({
       connectorKey: 'whatsapp',
+      connectionId: connection.id,
       feedKey: FEED_KEY,
       orgId: org.id,
       items: [
@@ -305,12 +314,16 @@ describe('applyEventAttributions', () => {
     `;
     expect(entityCount[0].count).toBe('1');
 
-    const idents = await sql<{ namespace: string }[]>`
-      SELECT namespace FROM entity_identities
+    const idents = await sql<{ namespace: string; connection_id: number | string | null }[]>`
+      SELECT namespace, connection_id FROM entity_identities
       WHERE organization_id = ${org.id} AND entity_id = ${Number(entityId)}
       ORDER BY namespace
     `;
     expect(idents.map((r) => r.namespace)).toEqual(['phone', 'wa_jid']);
+    expect(idents.map((r) => Number(r.connection_id))).toEqual([
+      connection.id,
+      connection.id,
+    ]);
   });
 
   it('skips linking when one event resolves to multiple distinct entities', async () => {

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -467,8 +467,9 @@ async function createEntityWithIdentities(
 
 /**
  * Insert identities for `entityId`, RETURNING the `(namespace, identifier)` rows
- * that actually attached. A row skipped by ON CONFLICT (identifier already owned
- * by another entity) is NOT returned, so the caller won't mis-claim it.
+ * attached to that entity. Re-observing a legacy row fills missing connection
+ * provenance; a row owned by another entity is not returned, so the caller will
+ * not mis-claim it.
  */
 async function insertIdentities(
   sql: DbClient,
@@ -492,7 +493,10 @@ async function insertIdentities(
              ${`connector:${params.connectorKey}`}, ${params.connectionId ?? null}
       FROM unnest(${pgTextArray(namespaces)}::text[], ${pgTextArray(identifiers)}::text[]) AS v(ns, ident)
       ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
-      DO NOTHING
+      DO UPDATE SET connection_id = EXCLUDED.connection_id
+      WHERE entity_identities.entity_id = EXCLUDED.entity_id
+        AND entity_identities.connection_id IS NULL
+        AND EXCLUDED.connection_id IS NOT NULL
       RETURNING namespace, identifier
     `;
     return attached.map((r) => ({ namespace: r.namespace, identifier: r.identifier }));

--- a/packages/server/src/utils/entity-link-upsert.ts
+++ b/packages/server/src/utils/entity-link-upsert.ts
@@ -24,8 +24,8 @@ import type {
   EventAttributionRule,
 } from '@lobu/connector-sdk';
 import { normalizeIdentifier } from '@lobu/connector-sdk/identity-normalize';
-import { normalizeConnectorIdentityValue } from '../identity/connector-identity-modules';
 import { type DbClient, getDb, pgTextArray } from '../db/client';
+import { normalizeConnectorIdentityValue } from '../identity/connector-identity-modules';
 import logger from './logger';
 import { getValueAtPath } from './object-path';
 import { TtlCache } from './ttl-cache';
@@ -372,6 +372,7 @@ async function createEntityWithIdentities(
   params: {
     orgId: string;
     connectorKey: string;
+    connectionId?: number | null;
     entityType: string;
     title: string;
     identities: ExtractedLink['identities'];
@@ -450,6 +451,7 @@ async function createEntityWithIdentities(
     orgId: params.orgId,
     entityId,
     connectorKey: params.connectorKey,
+    connectionId: params.connectionId,
     identities: persisted,
   });
   // Seed metadata.aliases from the identifiers that actually attached, so the
@@ -474,6 +476,7 @@ async function insertIdentities(
     orgId: string;
     entityId: number;
     connectorKey: string;
+    connectionId?: number | null;
     identities: ExtractedLink['identities'];
   }
 ): Promise<Array<{ namespace: string; identifier: string }>> {
@@ -483,9 +486,10 @@ async function insertIdentities(
   try {
     const attached = await sql<{ namespace: string; identifier: string }>`
       INSERT INTO entity_identities (
-        organization_id, entity_id, namespace, identifier, source_connector
+        organization_id, entity_id, namespace, identifier, source_connector, connection_id
       )
-      SELECT ${params.orgId}, ${params.entityId}, v.ns, v.ident, ${`connector:${params.connectorKey}`}
+      SELECT ${params.orgId}, ${params.entityId}, v.ns, v.ident,
+             ${`connector:${params.connectorKey}`}, ${params.connectionId ?? null}
       FROM unnest(${pgTextArray(namespaces)}::text[], ${pgTextArray(identifiers)}::text[]) AS v(ns, ident)
       ON CONFLICT (organization_id, namespace, identifier) WHERE deleted_at IS NULL
       DO NOTHING
@@ -567,6 +571,7 @@ async function applyTraits(
  */
 export async function applyEventAttributions(params: {
   connectorKey: string;
+  connectionId?: number | null;
   feedKey: string | null;
   orgId: string;
   items: BatchItem[];
@@ -582,6 +587,7 @@ export async function applyEventAttributions(params: {
 
   await resolveLinksByKind({
     connectorKey: params.connectorKey,
+    connectionId: params.connectionId,
     orgId: params.orgId,
     items: params.items,
     rulesByKind,
@@ -604,6 +610,7 @@ export async function applyEventAttributions(params: {
 export async function resolveEventAttributionsForItems(
   params: {
     connectorKey: string;
+    connectionId?: number | null;
     orgId: string;
     items: BatchItem[];
     rules: RuleMap;
@@ -616,6 +623,7 @@ export async function resolveEventAttributionsForItems(
   return resolveLinksByKind(
     {
       connectorKey: params.connectorKey,
+      connectionId: params.connectionId,
       orgId: params.orgId,
       items: params.items,
       rulesByKind: params.rules,
@@ -634,6 +642,7 @@ export async function resolveEventAttributionsForItems(
 async function resolveLinksByKind(
   params: {
     connectorKey: string;
+    connectionId?: number | null;
     orgId: string;
     items: BatchItem[];
     rulesByKind: RuleMap;
@@ -758,6 +767,7 @@ async function resolveLinksByKind(
           orgId: params.orgId,
           entityId,
           connectorKey: params.connectorKey,
+          connectionId: params.connectionId,
           identities: link.identities.filter((i) => !i.matchOnly),
         });
         attached = [...fresh];
@@ -789,6 +799,7 @@ async function resolveLinksByKind(
         const created = await createEntityWithIdentities(sql, {
           orgId: params.orgId,
           connectorKey: params.connectorKey,
+          connectionId: params.connectionId,
           entityType: rule.entityType,
           title: link.title,
           identities: link.identities,

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -44,31 +44,84 @@ export interface ApplyMergeResult {
   repointedEdges: number;
 }
 
+export interface ApplyMergeGroupResult {
+  mergedEntityIds: number[];
+  movedIdentities: number;
+  repointedEdges: number;
+}
+
+/** Apply a whole duplicate group under one outer transaction. Any stale or
+ * invalid member rolls back every preceding member merge. */
+export async function applyMergeGroup(
+  params: {
+    orgId: string;
+    loserIds: number[];
+    winnerId: number;
+    mergedBy: string;
+  },
+  db: DbClient = getDb(),
+): Promise<ApplyMergeGroupResult> {
+  const loserIds = [...new Set(params.loserIds)].sort((a, b) => a - b);
+  if (loserIds.length === 0) throw new Error('applyMergeGroup: no duplicate entities');
+  if (loserIds.includes(params.winnerId)) {
+    throw new Error('applyMergeGroup: canonical entity is also a duplicate');
+  }
+  return db.begin(async (tx) => {
+    let movedIdentities = 0;
+    let repointedEdges = 0;
+    for (const loserId of loserIds) {
+      const result = await applyMergeInTransaction(
+        {
+          orgId: params.orgId,
+          loserId,
+          winnerId: params.winnerId,
+          mergedBy: params.mergedBy,
+        },
+        tx,
+      );
+      movedIdentities += result.movedIdentities;
+      repointedEdges += result.repointedEdges;
+    }
+    return { mergedEntityIds: loserIds, movedIdentities, repointedEdges };
+  });
+}
+
 /**
  * Fuse `loser` into `winner` in one transaction. Idempotent-safe on re-run: a
  * loser already merged into this winner returns a zero result rather than
  * throwing. Throws on a cross-entity-type or already-merged-elsewhere conflict so
  * the caller (tool) surfaces it rather than silently corrupting the graph.
  */
-export async function applyMerge(
+export async function applyMerge(params: ApplyMergeParams, db: DbClient = getDb()): Promise<ApplyMergeResult> {
+  return db.begin((tx) => applyMergeInTransaction(params, tx));
+}
+
+async function applyMergeInTransaction(
   params: ApplyMergeParams,
-  db: DbClient = getDb(),
+  tx: DbClient,
 ): Promise<ApplyMergeResult> {
   const { orgId, loserId, winnerId, mergedBy } = params;
   if (loserId === winnerId) {
     throw new Error('applyMerge: loser and winner are the same entity');
   }
 
-  return db.begin(async (tx) => {
     // Lock both rows in a stable order (lowest id first) to avoid deadlocks when
     // two merges touch the overlapping pair concurrently.
     const [a, b] = loserId < winnerId ? [loserId, winnerId] : [winnerId, loserId];
-    const locked = (await tx<{ id: number; merged_into: number | null; deleted_at: string | null }>`
+    const locked = (await tx<{
+      id: number;
+      merged_into: number | null;
+      deleted_at: string | null;
+    }>`
       SELECT id, merged_into, deleted_at
       FROM entities
       WHERE organization_id = ${orgId} AND id IN (${a}, ${b})
       FOR UPDATE
-    `) as Array<{ id: number; merged_into: number | null; deleted_at: string | null }>;
+    `) as Array<{
+      id: number;
+      merged_into: number | null;
+      deleted_at: string | null;
+    }>;
 
     const loser = locked.find((r) => Number(r.id) === loserId);
     const winner = locked.find((r) => Number(r.id) === winnerId);
@@ -205,7 +258,6 @@ export async function applyMerge(
       movedIdentities: moved.length,
       repointedEdges: repointed.length,
     };
-  });
 }
 
 export interface ApplyUnmergeParams {
@@ -237,19 +289,24 @@ export interface ApplyUnmergeResult {
  * folded in are NOT reversed (they carry no per-merge origin) — the tool contract
  * says so; a caller that needs those back re-derives them.
  */
-export async function applyUnmerge(
-  params: ApplyUnmergeParams,
-  db: DbClient = getDb(),
-): Promise<ApplyUnmergeResult> {
+export async function applyUnmerge(params: ApplyUnmergeParams, db: DbClient = getDb()): Promise<ApplyUnmergeResult> {
   const { orgId, loserId, unmergedBy } = params;
 
   return db.begin(async (tx) => {
-    const [loserRow] = (await tx<{ id: number; merged_into: number | null; deleted_at: string | null }>`
+    const [loserRow] = (await tx<{
+      id: number;
+      merged_into: number | null;
+      deleted_at: string | null;
+    }>`
       SELECT id, merged_into, deleted_at
       FROM entities
       WHERE organization_id = ${orgId} AND id = ${loserId}
       FOR UPDATE
-    `) as Array<{ id: number; merged_into: number | null; deleted_at: string | null }>;
+    `) as Array<{
+      id: number;
+      merged_into: number | null;
+      deleted_at: string | null;
+    }>;
     if (!loserRow) {
       throw new Error(`applyUnmerge: entity ${loserId} not found in org`);
     }

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -4,7 +4,7 @@
  * The world-model keystone: when a bridge event (or a reviewer/watcher) reveals
  * two entities are the same real thing, this fuses them WITHOUT rewriting the
  * append-only `events` table. It runs off the ingest hot path — a user-configured
- * watcher's agent, or an admin, calls it via the `manage_entity_merge` tool; the
+ * watcher's agent, or an admin, calls it via `manage_entity(action='merge')`; the
  * resolver only ever LOGS a "merge candidate", never fuses inline.
  *
  * Two disjoint event populations recall the winner afterward:
@@ -50,8 +50,10 @@ export interface ApplyMergeGroupResult {
   repointedEdges: number;
 }
 
-/** Apply a whole duplicate group under one outer transaction. Any stale or
- * invalid member rolls back every preceding member merge. */
+/**
+ * Apply a whole duplicate group under one outer transaction. Any stale or
+ * invalid member rolls back every preceding member merge.
+ */
 export async function applyMergeGroup(
   params: {
     orgId: string;

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -26,7 +26,7 @@
  * independently reversible even so.
  */
 
-import { type DbClient, getDb } from '../db/client';
+import { type DbClient, getDb, pgBigintArray } from '../db/client';
 import logger from './logger';
 
 export interface ApplyMergeParams {
@@ -69,6 +69,18 @@ export async function applyMergeGroup(
     throw new Error('applyMergeGroup: canonical entity is also a duplicate');
   }
   return db.begin(async (tx) => {
+    // Lock the whole group in one global order before applying any member. Pairwise
+    // locking inside the loop is not sufficient: overlapping groups with different
+    // winners can otherwise each hold one entity while waiting for the other.
+    const entityIds = [...loserIds, params.winnerId].sort((a, b) => a - b);
+    await tx`
+      SELECT id
+      FROM entities
+      WHERE organization_id = ${params.orgId}
+        AND id = ANY(${pgBigintArray(entityIds)}::bigint[])
+      ORDER BY id
+      FOR UPDATE
+    `;
     let movedIdentities = 0;
     let repointedEdges = 0;
     for (const loserId of loserIds) {

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -82,6 +82,9 @@ export async function applyMerge(
     if (loser.merged_into !== null) {
       throw new Error(`applyMerge: loser ${loserId} already merged into ${loser.merged_into}`);
     }
+    if (loser.deleted_at !== null) {
+      throw new Error(`applyMerge: loser ${loserId} is deleted`);
+    }
     if (winner.merged_into !== null) {
       throw new Error(`applyMerge: winner ${winnerId} is itself merged into ${winner.merged_into}`);
     }

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -120,7 +120,9 @@ async function applyMergeInTransaction(
   }
 
     // Lock both rows in a stable order (lowest id first) to avoid deadlocks when
-    // two merges touch the overlapping pair concurrently.
+    // two merges touch the overlapping pair concurrently. The explicit `ORDER BY
+    // id` pins lock-acquisition order — a bare `IN (...)` leaves it to the
+    // planner, which could lock high-then-low and deadlock a concurrent merge.
     const [a, b] = loserId < winnerId ? [loserId, winnerId] : [winnerId, loserId];
     const locked = (await tx<{
       id: number;
@@ -130,6 +132,7 @@ async function applyMergeInTransaction(
       SELECT id, merged_into, deleted_at
       FROM entities
       WHERE organization_id = ${orgId} AND id IN (${a}, ${b})
+      ORDER BY id
       FOR UPDATE
     `) as Array<{
       id: number;
@@ -307,35 +310,51 @@ export async function applyUnmerge(params: ApplyUnmergeParams, db: DbClient = ge
   const { orgId, loserId, unmergedBy } = params;
 
   return db.begin(async (tx) => {
-    const [loserRow] = (await tx<{
-      id: number;
-      merged_into: number | null;
-      deleted_at: string | null;
-    }>`
-      SELECT id, merged_into, deleted_at
+    // Discover the winner WITHOUT locking first: we can't name the winner until
+    // we read merged_into, but taking the loser's lock here would grab the
+    // loser's row before the winner's — inverting applyMerge's lowest-id-first
+    // order and deadlocking a concurrent merge of the same pair whenever
+    // winnerId < loserId.
+    const [probe] = (await tx<{ merged_into: number | null }>`
+      SELECT merged_into
       FROM entities
       WHERE organization_id = ${orgId} AND id = ${loserId}
-      FOR UPDATE
-    `) as Array<{
+    `) as Array<{ merged_into: number | null }>;
+    if (!probe) {
+      throw new Error(`applyUnmerge: entity ${loserId} not found in org`);
+    }
+    if (probe.merged_into === null) {
+      throw new Error(`applyUnmerge: entity ${loserId} is not merged into anything`);
+    }
+    const winnerId = Number(probe.merged_into);
+
+    // Lock BOTH rows in one statement, ascending id (matches applyMerge), so no
+    // path ever holds these two locks in opposing orders.
+    const [lo, hi] = loserId < winnerId ? [loserId, winnerId] : [winnerId, loserId];
+    const locked = (await tx<{
       id: number;
       merged_into: number | null;
-      deleted_at: string | null;
-    }>;
+    }>`
+      SELECT id, merged_into
+      FROM entities
+      WHERE organization_id = ${orgId} AND id IN (${lo}, ${hi})
+      ORDER BY id
+      FOR UPDATE
+    `) as Array<{ id: number; merged_into: number | null }>;
+
+    // Re-validate under lock: merged_into can move between the unlocked probe and
+    // acquiring the lock (a racing unmerge/merge). Fail closed if it changed so
+    // we never operate on a stale winner we didn't lock.
+    const loserRow = locked.find((row) => Number(row.id) === loserId);
     if (!loserRow) {
       throw new Error(`applyUnmerge: entity ${loserId} not found in org`);
     }
-    if (loserRow.merged_into === null) {
+    if (
+      loserRow.merged_into === null ||
+      Number(loserRow.merged_into) !== winnerId
+    ) {
       throw new Error(`applyUnmerge: entity ${loserId} is not merged into anything`);
     }
-    const winnerId = Number(loserRow.merged_into);
-
-    // Lock the winner too, in stable id order (matches applyMerge's discipline).
-    const [lo, hi] = loserId < winnerId ? [loserId, winnerId] : [winnerId, loserId];
-    await tx`
-      SELECT id FROM entities
-      WHERE organization_id = ${orgId} AND id IN (${lo}, ${hi})
-      FOR UPDATE
-    `;
 
     // 1. Move the loser's contributed identities back off the winner. These are
     //    the live winner-owned rows still marked `merged_from = loser` (applyMerge

--- a/packages/server/src/utils/url-builder.ts
+++ b/packages/server/src/utils/url-builder.ts
@@ -279,6 +279,19 @@ export function buildConnectionsUrl(
   );
 }
 
+/** Build the exact installed-connection detail route. */
+export function buildConnectionUrl(
+  ownerSlug: string,
+  connectorKey: string,
+  connectionId: number,
+  baseUrl?: string
+): string {
+  return withBaseUrl(
+    normalizeBaseUrl(baseUrl),
+    `/${ownerSlug}/connectors/${connectorKey}/${connectionId}`
+  );
+}
+
 /**
  * A slice of the memory/events log to permalink into. One discriminated union
  * so every caller (approval_url, notification resourceUrl, agent output) picks a

--- a/packages/server/src/worker-api/run-lifecycle.ts
+++ b/packages/server/src/worker-api/run-lifecycle.ts
@@ -221,6 +221,7 @@ export async function streamContent(c: Context<{ Bindings: Env }>) {
 		// batch — cheap compared to the per-event inserts that follow.
 		await applyEventAttributions({
 			connectorKey: run.connector_key,
+			connectionId: run.connection_id,
 			feedKey: run.feed_key,
 			orgId: run.organization_id,
 			items: batch.items,

--- a/scripts/dev-native.sh
+++ b/scripts/dev-native.sh
@@ -69,6 +69,13 @@ if [ ! -d packages/core/dist ] || [ ! -d packages/connector-sdk/dist ] || [ ! -d
   make build-packages
 fi
 
+# Interactive cards run in a self-contained MCP App iframe rather than Vite's
+# SPA graph. Build that payload before boot so approvals/questions never render
+# the server's 404 response on a fresh worktree. The build is intentionally
+# repeated: Vite HMR cannot update this separately-built iframe bundle.
+echo "📦 Building Owletto interaction app…"
+( cd packages/owletto && bun run build:mcp-apps )
+
 # --- Env -------------------------------------------------------------------
 
 # Preserve explicit environment overrides from the caller while still loading


### PR DESCRIPTION
## What changed

- require human approval for watcher/agent entity merges
- support one evidence-backed proposal for an entire duplicate group
- apply grouped merges atomically with deterministic lock ordering and stale-member rollback
- persist exact connection provenance on entity identities and expose entity/connection links in approval payloads
- return pending watcher approval events in watcher conversations with durable event IDs
- update the built-in duplicate watcher to call grouped `manage_entity` approvals instead of emitting textual backlog tasks
- include the Owletto UI from lobu-ai/owletto#506

## Root cause

The production duplicate watcher was extracting textual merge-request tasks, while the watcher conversation only rendered durable approval events. The backend also only supported pairwise merge proposals, and the history API did not expose an event identity for multiple approvals belonging to one run.

## User impact

A duplicate evidence cluster now becomes one reviewable approval card containing every duplicate, the canonical entity, unmasked match evidence, source identities, and links to the exact installed connection. Approval applies the whole group or rolls it all back.

## Validation

- `make review-fix`
- `make pre-pr` — build, strict typecheck, knip, and Biome clean
- `entity-merge-tool.test.ts` — 7/7 passed with isolated embedded Postgres
- `agent-thread-list-scope-all.test.ts` — 5/5 passed with isolated embedded Postgres
- `watcher-templates.test.ts` — 1/1 passed
- Owletto watcher tests — 10/10 passed
- independent review: 0 bugs, 0 suggested fixes; its only reported blocker was its own missing `DATABASE_URL`, covered by the isolated embedded-Postgres runs above

## Dependency

- lobu-ai/owletto#506 must merge before or with this PR so the submodule commit is available.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/1997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entity merges now operate on grouped duplicates with a single canonical winner.
  * Non-administrative merges can be proposed and queued for human approval, including merge evidence and review context.
  * Approval notifications and cards now render clearer merge-specific titles, wording, and next steps.
  * Entity identity records now retain connection context for improved traceability.
* **Bug Fixes**
  * More robust merge-approval behavior for stale/deleted entities, including safer group rollback.
  * Improved performance and correctness when loading watcher run threads.
* **Developer Experience**
  * Native development startup now builds embedded interaction components automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->