### PR TITLE
fix: harden entity merge approvals

### DIFF
--- a/packages/core/src/contracts/tools/manage-entity.ts
+++ b/packages/core/src/contracts/tools/manage-entity.ts
@@ -60,6 +60,7 @@ export const ManageEntitySchema = Type.Object({
   duplicate_entity_ids: Type.Optional(
     Type.Array(Type.Number(), {
       minItems: 1,
+      maxItems: 25,
       uniqueItems: true,
       description:
         "[merge] All duplicate entities to fold into winner_entity_id. Use this for a duplicate group; entity_id remains supported for a single duplicate.",
@@ -69,11 +70,14 @@ export const ManageEntitySchema = Type.Object({
   merge_evidence: Type.Optional(
     Type.Array(
       Type.Object({
-        kind: Type.String(),
-        identifier: Type.String(),
-        identity_ids: Type.Optional(Type.Array(Type.Number())),
+        kind: Type.String({ maxLength: 64 }),
+        identifier: Type.String({ maxLength: 512 }),
+        identity_ids: Type.Optional(
+          Type.Array(Type.Number(), { maxItems: 50 })
+        ),
       }),
       {
+        maxItems: 25,
         description:
           "[merge] Structured identity evidence the reviewer should verify, such as a shared email or phone.",
       }

--- a/packages/server/src/__tests__/integration/authz/github-repo-graph.test.ts
+++ b/packages/server/src/__tests__/integration/authz/github-repo-graph.test.ts
@@ -39,6 +39,7 @@ function buildGithubRepoGraph(params: {
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
   addUserToOrganization,
+  createTestConnection,
   createTestEntity,
   createTestOrganization,
   createTestUser,
@@ -133,6 +134,43 @@ describe('github repo graph', () => {
     expect(stateRows).toHaveLength(1);
     expect(stateRows[0].acl_support).toBe('full');
     expect(stateRows[0].freshness_state).toBe('fresh');
+  });
+
+  it('scopes identity provenance lookup to the graph connector', async () => {
+    const { org, user } = await seedOrg('GitHub Provenance Org');
+    const decoy = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'slack',
+      created_by: user.id,
+      createDefaultFeed: false,
+    });
+    const github = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      created_by: user.id,
+      createDefaultFeed: false,
+    });
+    const sql = getTestDb();
+    await sql`
+      UPDATE connections
+      SET slug = ${`agentconn-${github.id}`}
+      WHERE id = ${decoy.id}
+    `;
+
+    await buildGithubRepoGraph({
+      organizationId: org.id,
+      connectionId: String(github.id),
+      repos: [{ fullName: 'lobu-ai/lobu', collaborators: [{ login: 'alice', id: 101 }] }],
+    });
+
+    const identities = await sql<{ connection_id: number | null }[]>`
+      SELECT connection_id
+      FROM entity_identities
+      WHERE organization_id = ${org.id}
+        AND source_connector = 'connector:github'
+    `;
+    expect(identities.length).toBeGreaterThan(0);
+    expect(identities.every((row) => Number(row.connection_id) === github.id)).toBe(true);
   });
 
   it('collapses a collaborator onto an existing entity carrying github_user_id (no second person)', async () => {

--- a/packages/server/src/__tests__/integration/authz/slack-channel-graph.test.ts
+++ b/packages/server/src/__tests__/integration/authz/slack-channel-graph.test.ts
@@ -43,6 +43,7 @@ function buildSlackChannelGraph(params: {
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
   addUserToOrganization,
+  createTestConnection,
   createTestEntity,
   createTestOrganization,
   createTestUser,
@@ -127,7 +128,14 @@ describe('slack channel graph', () => {
   });
 
   it('builds channel entities + member_of edges and marks the connection enforced', async () => {
-    const { org } = await seedOrg('Slack Graph Org');
+    const { org, user } = await seedOrg('Slack Graph Org');
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'slack',
+      slug: 'agentconn-conn-acme',
+      created_by: user.id,
+      createDefaultFeed: false,
+    });
 
     const result = await buildSlackChannelGraph({
       organizationId: org.id,
@@ -168,6 +176,15 @@ describe('slack channel graph', () => {
     expect(stateRows).toHaveLength(1);
     expect(stateRows[0].acl_support).toBe('full');
     expect(stateRows[0].freshness_state).toBe('fresh');
+
+    const identitySources = await sql<{ connection_id: number | null }[]>`
+      SELECT connection_id
+      FROM entity_identities
+      WHERE organization_id = ${org.id}
+        AND source_connector = 'connector:slack'
+    `;
+    expect(identitySources.length).toBeGreaterThan(0);
+    expect(identitySources.every((row) => Number(row.connection_id) === connection.id)).toBe(true);
   });
 
   it('collapses a member onto an already-signed-in $member (no second person)', async () => {

--- a/packages/server/src/__tests__/integration/connectors/github-identity-attribution.test.ts
+++ b/packages/server/src/__tests__/integration/connectors/github-identity-attribution.test.ts
@@ -27,6 +27,7 @@ import { insertEvent } from '../../../utils/insert-event';
 import { cleanupTestDatabase, getTestDb } from '../../setup/test-db';
 import {
   addUserToOrganization,
+  createTestConnection,
   createTestConnectorDefinition,
   createTestOrganization,
   createTestUser,
@@ -355,6 +356,14 @@ describe('github member-identity attribution', () => {
 
   it('webhook: resolveGithubWebhookActor resolves the actor to a person and returns entity ids + the github_login metadata slot', async () => {
     const org = await seedOrg('GitHub Webhook Org');
+    const connectionUser = await createTestUser();
+    await addUserToOrganization(connectionUser.id, org.id, 'admin');
+    const connection = await createTestConnection({
+      organization_id: org.id,
+      connector_key: 'github',
+      created_by: connectionUser.id,
+      createDefaultFeed: false,
+    });
     // The rule is loaded from the connector definition (not mirrored), so the
     // webhook path needs the github def seeded just like the poll path.
     await seedGithubConnector(org.id);
@@ -362,6 +371,7 @@ describe('github member-identity attribution', () => {
 
     const resolution = await resolveGithubWebhookActor({
       organizationId: org.id,
+      connectionId: connection.id,
       githubEvent: 'issue_comment',
       payload: {
         action: 'created',
@@ -384,6 +394,20 @@ describe('github member-identity attribution', () => {
       'github_login:hubot',
       'github_user_id:42',
     ]);
+    const identitySources = await getTestDb()<
+      { connection_id: number | null }[]
+    >`
+      SELECT connection_id
+      FROM entity_identities
+      WHERE entity_id = ${people[0].id}
+        AND deleted_at IS NULL
+    `;
+    expect(identitySources).toHaveLength(2);
+    expect(
+      identitySources.every(
+        (row) => Number(row.connection_id) === connection.id,
+      ),
+    ).toBe(true);
     // The `last_authored_at` trait populates on the webhook path too (occurred_at
     // is on the top-level item, where the rule's trait path reads it).
     expect(people[0].metadata.last_authored_at).toBeTruthy();

--- a/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
+++ b/packages/server/src/__tests__/integration/entities/entity-merge-tool.test.ts
@@ -100,6 +100,36 @@ describe("manage_entity merge action", () => {
 		).rejects.toThrow(/admin or owner/i);
 	});
 
+	it("rejects a cross-type merge before queuing approval", async () => {
+		const org = await createTestOrganization({ name: "Cross Type Tool Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const person = await createTestEntity({
+			name: "Person",
+			entity_type: "person",
+			organization_id: org.id,
+			created_by: user.id,
+		});
+		const company = await createTestEntity({
+			name: "Company",
+			entity_type: "company",
+			organization_id: org.id,
+			created_by: user.id,
+		});
+
+		await expect(
+			manageEntity(
+				{
+					action: "merge",
+					entity_id: person.id,
+					winner_entity_id: company.id,
+				},
+				env,
+				ctx(org.id, user.id, "owner"),
+			),
+		).rejects.toThrow(/same entity type/i);
+	});
+
 	it("rejects a winner from another org (org fence, 404)", async () => {
 		const orgA = await createTestOrganization({ name: "Org A" });
 		const orgB = await createTestOrganization({ name: "Org B" });
@@ -188,6 +218,64 @@ describe("manage_entity merge action", () => {
 			await sql`SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}`;
 		expect(Number(after.merged_into)).toBe(winner.id);
 		expect(after.deleted_at).not.toBeNull();
+		const [completedRun] = await sql`
+			SELECT status, approval_status FROM runs WHERE id = ${queued.approval_run_id}
+		`;
+		expect(completedRun).toMatchObject({
+			status: "completed",
+			approval_status: "approved",
+		});
+		const [completedEvent] = await sql`
+			SELECT interaction_status FROM current_event_records
+			WHERE run_id = ${queued.approval_run_id}
+		`;
+		expect(completedEvent.interaction_status).toBe("completed");
+	});
+
+	it("repairs a legacy pending run that has no approval event", async () => {
+		const org = await createTestOrganization({ name: "Orphan Approval Org" });
+		const user = await createTestUser();
+		await addUserToOrganization(user.id, org.id, "owner");
+		const { winner, loser } = await twoEntities(org.id, user.id);
+		const sql = getTestDb();
+		const [orphan] = await sql<{ id: number }[]>`
+			INSERT INTO runs (
+				organization_id, run_type, action_key, action_input,
+				approval_status, status
+			) VALUES (
+				${org.id}, 'internal', 'entity_change',
+				${sql.json({
+					operation: "merge",
+					entity_id: loser.id,
+					entity_ids: [loser.id],
+					winner_entity_id: winner.id,
+					current: { loser: {}, duplicates: [{}], winner: {} },
+				})},
+				'pending', 'pending'
+			)
+			RETURNING id
+		`;
+
+		const queued = (await manageEntity(
+			{ action: "merge", entity_id: loser.id, winner_entity_id: winner.id },
+			env,
+			{
+				...ctx(org.id, user.id, "owner"),
+				userId: null,
+				agentId: "personal-agent",
+			} as ToolContext,
+		)) as unknown as { approval_run_id: number };
+
+		expect(queued.approval_run_id).toBe(Number(orphan.id));
+		const [repaired] = await sql`
+			SELECT idempotency_key,
+			       (SELECT count(*)::int FROM current_event_records e
+			        WHERE e.run_id = runs.id AND e.interaction_status = 'pending') AS event_count
+			FROM runs
+			WHERE id = ${orphan.id}
+		`;
+		expect(repaired.idempotency_key).toMatch(/^entity-change:/);
+		expect(Number(repaired.event_count)).toBe(1);
 	});
 
 	it("queues one atomic watcher approval for a duplicate group", async () => {
@@ -244,13 +332,14 @@ describe("manage_entity merge action", () => {
 		)) as unknown as { approval_run_id: number };
 
 		const [pending] = await sql`
-      SELECT action_input FROM runs WHERE id = ${queued.approval_run_id}
-    `;
+			SELECT action_input, idempotency_key FROM runs WHERE id = ${queued.approval_run_id}
+		`;
 		expect(pending.action_input).toMatchObject({
 			operation: "merge",
 			entity_ids: [loser.id, secondLoser.id],
 			winner_entity_id: winner.id,
 		});
+		expect(pending.idempotency_key).toMatch(/^entity-change:/);
 		const [approvalEvent] = await sql`
       SELECT metadata FROM current_event_records
       WHERE run_id = ${queued.approval_run_id} AND interaction_status = 'pending'
@@ -263,6 +352,7 @@ describe("manage_entity merge action", () => {
 			}>;
 		};
 		expect(current.duplicates[0]?.href).toContain("/person/");
+		expect(current.duplicates[0]).not.toHaveProperty("metadata");
 		expect(current.duplicates[0]?.identities[0]).toMatchObject({
 			identifier: "duplicate@example.com",
 			connection_id: connection.id,
@@ -340,6 +430,21 @@ describe("manage_entity merge action", () => {
     `;
 		expect(first.merged_into).toBeNull();
 		expect(first.deleted_at).toBeNull();
+		const [run] = await sql`
+			SELECT approval_status, status
+			FROM runs
+			WHERE id = ${queued.approval_run_id}
+		`;
+		expect(run).toMatchObject({
+			approval_status: "pending",
+			status: "pending",
+		});
+		const [approvalEvent] = await sql`
+			SELECT interaction_status
+			FROM current_event_records
+			WHERE run_id = ${queued.approval_run_id}
+		`;
+		expect(approvalEvent.interaction_status).toBe("pending");
 	});
 
 	it("does not apply an approved watcher merge when the loser was deleted after proposal", async () => {

--- a/packages/server/src/__tests__/integration/events/entity-merge.test.ts
+++ b/packages/server/src/__tests__/integration/events/entity-merge.test.ts
@@ -215,6 +215,125 @@ describe('entity merge', () => {
     ).rejects.toThrow(/already merged/);
   });
 
+  it('rejects merging entities of different types', async () => {
+    const org = await createTestOrganization({ name: 'Type Guard Org' });
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const person = await createTestEntity({
+      name: 'Alice',
+      entity_type: 'person',
+      organization_id: org.id,
+      created_by: user.id,
+    });
+    const company = await createTestEntity({
+      name: 'Acme',
+      entity_type: 'company',
+      organization_id: org.id,
+      created_by: user.id,
+    });
+
+    await expect(
+      applyMerge({
+        orgId: org.id,
+        loserId: person.id,
+        winnerId: company.id,
+        mergedBy: user.id,
+      }),
+    ).rejects.toThrow(/different entity types/i);
+  });
+
+  it('tombstones colliding relationships before repointing loser edges', async () => {
+    const sql = getTestDb();
+    const org = await createTestOrganization({
+      name: 'Relationship Merge Org',
+    });
+    const user = await createTestUser();
+    await addUserToOrganization(user.id, org.id, 'owner');
+    const winner = await createTestEntity({
+      name: 'W',
+      entity_type: 'person',
+      organization_id: org.id,
+      created_by: user.id,
+    });
+    const loser = await createTestEntity({
+      name: 'L',
+      entity_type: 'person',
+      organization_id: org.id,
+      created_by: user.id,
+    });
+    const team = await createTestEntity({
+      name: 'Team',
+      entity_type: 'team',
+      organization_id: org.id,
+      created_by: user.id,
+    });
+    const otherTeam = await createTestEntity({
+      name: 'Other team',
+      entity_type: 'team',
+      organization_id: org.id,
+      created_by: user.id,
+    });
+    const [relationshipType] = await sql<{ id: number }[]>`
+      INSERT INTO entity_relationship_types
+        (organization_id, slug, name, created_by)
+      VALUES (${org.id}, 'member-of', 'Member of', ${user.id})
+      RETURNING id
+    `;
+    await sql`
+      INSERT INTO entity_relationships
+        (organization_id, from_entity_id, to_entity_id, relationship_type_id, created_by)
+      VALUES
+        (${org.id}, ${winner.id}, ${team.id}, ${relationshipType.id}, ${user.id}),
+        (${org.id}, ${loser.id}, ${team.id}, ${relationshipType.id}, ${user.id}),
+        (${org.id}, ${team.id}, ${winner.id}, ${relationshipType.id}, ${user.id}),
+        (${org.id}, ${team.id}, ${loser.id}, ${relationshipType.id}, ${user.id}),
+        (${org.id}, ${loser.id}, ${winner.id}, ${relationshipType.id}, ${user.id}),
+        (${org.id}, ${winner.id}, ${loser.id}, ${relationshipType.id}, ${user.id}),
+        (${org.id}, ${loser.id}, ${otherTeam.id}, ${relationshipType.id}, ${user.id})
+    `;
+
+    await expect(
+      applyMerge({
+        orgId: org.id,
+        loserId: loser.id,
+        winnerId: winner.id,
+        mergedBy: user.id,
+      }),
+    ).resolves.toMatchObject({ repointedEdges: 1 });
+
+    const relationships = await sql<
+      {
+        from_entity_id: number;
+        to_entity_id: number;
+        deleted_at: string | null;
+      }[]
+    >`
+      SELECT from_entity_id, to_entity_id, deleted_at
+      FROM entity_relationships
+      WHERE organization_id = ${org.id}
+        AND relationship_type_id = ${relationshipType.id}
+      ORDER BY id
+    `;
+    expect(relationships).toHaveLength(7);
+    const live = relationships.filter((row) => row.deleted_at === null);
+    expect(
+      live.map((row) => [Number(row.from_entity_id), Number(row.to_entity_id)]),
+    ).toEqual([
+      [winner.id, team.id],
+      [team.id, winner.id],
+      [winner.id, otherTeam.id],
+    ]);
+    const tombstoned = relationships.filter((row) => row.deleted_at !== null);
+    expect(tombstoned).toHaveLength(4);
+    expect(
+      tombstoned.every(
+        (row) =>
+          Number(row.from_entity_id) === loser.id ||
+          Number(row.to_entity_id) === loser.id,
+      ),
+    ).toBe(true);
+  });
+
   it('un-merge round-trips a single merge from live markers (identity moves back, loser revived)', async () => {
     const sql = getTestDb();
     const org = await createTestOrganization({ name: 'Unmerge Org' });

--- a/packages/server/src/__tests__/integration/tools/entity-change-approval-create-dedupe.test.ts
+++ b/packages/server/src/__tests__/integration/tools/entity-change-approval-create-dedupe.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression: pending create approvals must only collapse true replays.
+ * Regression: active create approvals must only collapse true replays.
  *
  * Create proposals have no entity_id, so the approval dedupe query must compare
  * the proposed entity payload. Otherwise every distinct pending create in an org
@@ -13,7 +13,7 @@ import {
 } from "../../../tools/admin/entity-field-approval";
 import type { ToolContext } from "../../../tools/registry";
 import { initWorkspaceProvider } from "../../../workspace";
-import { cleanupTestDatabase } from "../../setup/test-db";
+import { cleanupTestDatabase, getTestDb } from "../../setup/test-db";
 import { createTestOrganization } from "../../setup/test-fixtures";
 
 function createProposal(name: string): Omit<EntityCreateProposal, "operation"> {
@@ -52,12 +52,23 @@ describe("entity create approval dedupe", () => {
 		} as ToolContext;
 	});
 
-	it("queues separate runs for distinct pending creates and reuses exact replays", async () => {
+	it("separates distinct creates and reuses pending or in-flight replays", async () => {
 		const first = await proposeEntityCreate(ctx, createProposal("Call Alice"));
 		const replay = await proposeEntityCreate(ctx, createProposal("Call Alice"));
+		const sql = getTestDb();
+		await sql`
+			UPDATE runs
+			SET approval_status = 'approved', status = 'running'
+			WHERE id = ${first.runId}
+		`;
+		const inFlightReplay = await proposeEntityCreate(
+			ctx,
+			createProposal("Call Alice"),
+		);
 		const second = await proposeEntityCreate(ctx, createProposal("Call Bob"));
 
 		expect(replay.runId).toBe(first.runId);
+		expect(inFlightReplay.runId).toBe(first.runId);
 		expect(second.runId).not.toBe(first.runId);
 	});
 });

--- a/packages/server/src/__tests__/integration/tools/entity-change-approval-create-dedupe.test.ts
+++ b/packages/server/src/__tests__/integration/tools/entity-change-approval-create-dedupe.test.ts
@@ -71,4 +71,35 @@ describe("entity create approval dedupe", () => {
 		expect(inFlightReplay.runId).toBe(first.runId);
 		expect(second.runId).not.toBe(first.runId);
 	});
+
+	it("serializes concurrent replicas to one run and approval event", async () => {
+		const name = "Call Concurrent";
+		const proposals = await Promise.all(
+			Array.from({ length: 8 }, () =>
+				proposeEntityCreate(ctx, createProposal(name)),
+			),
+		);
+		const runIds = new Set(proposals.map((proposal) => proposal.runId));
+		expect(runIds.size).toBe(1);
+
+		const runId = proposals[0]?.runId;
+		expect(runId).toBeDefined();
+		const sql = getTestDb();
+		const activeRuns = await sql`
+			SELECT id
+			FROM runs
+			WHERE organization_id = ${ctx.organizationId}
+			  AND action_input->'entity_data'->>'name' = ${name}
+			  AND status IN ('pending', 'claimed', 'running')
+		`;
+		expect(activeRuns).toHaveLength(1);
+
+		const currentEvents = await sql`
+			SELECT id
+			FROM current_event_records
+			WHERE run_id = ${runId}
+			  AND interaction_type = 'approval'
+		`;
+		expect(currentEvents).toHaveLength(1);
+	});
 });

--- a/packages/server/src/authz/access-graph.ts
+++ b/packages/server/src/authz/access-graph.ts
@@ -39,6 +39,7 @@ import type {
   AccessResourceType,
 } from '@lobu/connector-sdk';
 import { getDb, pgBigintArray, pgTextArray } from '../db/client.js';
+import { runtimeConnectionIdToSlug } from '../lobu/stores/connections-projection.js';
 import { resolveEventAttributionsForItems } from '../utils/entity-link-upsert.js';
 
 const logger = createLogger('access-graph');
@@ -145,6 +146,7 @@ async function markAclEnforced(orgId: string, connectionId: string): Promise<voi
 async function resolveMembers(
   orgId: string,
   connectorKey: string,
+  connectionId: number | null,
   members: AccessMember[],
   memberIdentities: AccessIdentitySpec[],
 ): Promise<Map<string, number>> {
@@ -204,6 +206,7 @@ async function resolveMembers(
   });
   const resolved = await resolveEventAttributionsForItems({
     connectorKey,
+    connectionId,
     orgId,
     items,
     rules: {
@@ -259,6 +262,25 @@ export async function buildAccessGraph(params: {
   await ensureResourceEntityType(organizationId, resourceType);
   await ensurePersonEntityType(organizationId);
 
+  // ACL state uses a runtime connection id, while identity provenance references
+  // the stored numeric row. Resolve by slug (chat connections) or id text (data
+  // connectors) without assuming the runtime id itself is numeric.
+  const [storedConnection] = await getDb()<{ id: number }>`
+    SELECT id
+    FROM connections
+    WHERE organization_id = ${organizationId}
+      AND connector_key = ${connectorKey}
+      AND deleted_at IS NULL
+      AND (
+        slug = ${runtimeConnectionIdToSlug(connectionId)}
+        OR id::text = ${connectionId}
+      )
+    LIMIT 1
+  `;
+  const identityConnectionId = storedConnection
+    ? Number(storedConnection.id)
+    : null;
+
   // 1) Resolve every resource to its entity, keyed on the source identity namespace.
   const resourceItems = resources.map((r) => ({
     origin_type: 'access_resource',
@@ -266,6 +288,7 @@ export async function buildAccessGraph(params: {
   }));
   const resolvedResources = await resolveEventAttributionsForItems({
     connectorKey,
+    connectionId: identityConnectionId,
     orgId: organizationId,
     items: resourceItems,
     rules: {
@@ -302,6 +325,7 @@ export async function buildAccessGraph(params: {
   const memberEntityByKey = await resolveMembers(
     organizationId,
     connectorKey,
+    identityConnectionId,
     [...distinctMembers.values()],
     memberIdentities,
   );

--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -138,7 +138,7 @@ describe("agent history routes", () => {
 			name: "Weekly Digest",
 		};
 		const current = { id: "weekly-digest", name: "Old Name" };
-		await orgContext.run({ organizationId: ORG_ID }, () =>
+		const approvalEvent = await orgContext.run({ organizationId: ORG_ID }, () =>
 			insertEvent({
 				entityIds: [],
 				organizationId: ORG_ID,
@@ -172,6 +172,7 @@ describe("agent history routes", () => {
 		const body = (await res.json()) as {
 			interactions?: Array<{
 				type: string;
+				eventId: number;
 				runId: number;
 				action: string | null;
 				proposal: Record<string, unknown> | null;
@@ -181,6 +182,7 @@ describe("agent history routes", () => {
 		expect(body.interactions).toHaveLength(1);
 		const card = body.interactions?.[0];
 		expect(card?.type).toBe("tool-approval");
+		expect(card?.eventId).toBe(Number(approvalEvent.id));
 		expect(card?.runId).toBe(runId);
 		expect(card?.action).toBe("update");
 		expect(card?.proposal).toMatchObject({ agent_id: "weekly-digest" });

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -65,6 +65,7 @@ const logger = createLogger("agent-history-routes");
 
 type ToolApprovalHistoryInteraction = {
 	type: "tool-approval";
+	eventId: number;
 	runId: number;
 	action: string | null;
 	proposal: Record<string, unknown> | null;
@@ -519,6 +520,7 @@ export function createAgentHistoryRoutes(deps: {
 				threadId,
 			});
 			const rows = await getDb()<{
+				event_id: number;
 				run_id: number;
 				action: string | null;
 				proposal: Record<string, unknown> | null;
@@ -528,7 +530,8 @@ export function createAgentHistoryRoutes(deps: {
 				resource_kind: string | null;
 				tool: string | null;
 			}>`
-				SELECT run_id,
+				SELECT id AS event_id,
+				       run_id,
 				       metadata->>'action' AS action,
 				       metadata->'proposal' AS proposal,
 				       metadata->'current' AS current,
@@ -568,6 +571,7 @@ export function createAgentHistoryRoutes(deps: {
 						: rawProposal;
 				return {
 					type: "tool-approval" as const,
+					eventId: Number(r.event_id),
 					runId: Number(r.run_id),
 					action: r.action,
 					proposal,

--- a/packages/server/src/gateway/routes/public/app-webhooks.ts
+++ b/packages/server/src/gateway/routes/public/app-webhooks.ts
@@ -702,6 +702,7 @@ async function storeGithubWebhookEvent(params: {
 	// backstop re-resolves on its next run), but we log it so it isn't invisible.
 	const resolution = await resolveGithubWebhookActor({
 		organizationId: install.organizationId,
+		connectionId: target.connectionId,
 		githubEvent: event,
 		payload,
 		sql,

--- a/packages/server/src/gateway/routes/public/github-webhook-actor.ts
+++ b/packages/server/src/gateway/routes/public/github-webhook-actor.ts
@@ -98,6 +98,7 @@ export interface GithubActorResolution {
  */
 export async function resolveGithubWebhookActor(params: {
 	organizationId: string;
+	connectionId?: number | null;
 	githubEvent: string | null;
 	payload: unknown;
 	/** Optional transaction handle so the graph writes are atomic with the caller's insert. */
@@ -144,6 +145,7 @@ export async function resolveGithubWebhookActor(params: {
 	const resolved = await resolveEventAttributionsForItems(
 		{
 			connectorKey: "github",
+			connectionId: params.connectionId,
 			orgId: params.organizationId,
 			items: [item],
 			rules: { [kind]: [rule] },

--- a/packages/server/src/tools/admin/entity-field-approval.ts
+++ b/packages/server/src/tools/admin/entity-field-approval.ts
@@ -13,8 +13,9 @@
  * `supersedeActionEvent`.
  */
 
+import { createHash } from "node:crypto";
 import { resolveEntityApprovalPolicy } from "../../authz/entity-policy";
-import { getDb } from "../../db/client";
+import { type DbClient, getDb, pgBigintArray } from "../../db/client";
 import type { Env } from "../../index";
 import {
 	formatFieldChangeAction,
@@ -30,10 +31,9 @@ import {
 	deleteEntity,
 	type EntityData,
 } from "../../utils/entity-management";
-import { applyMergeGroup } from "../../utils/entity-merge";
-import { insertEvent } from "../../utils/insert-event";
+import { applyMergeGroupInTransaction } from "../../utils/entity-merge";
+import { insertEvent, stableJson } from "../../utils/insert-event";
 import logger from "../../utils/logger";
-import { isUniqueViolation } from "../../utils/pg-errors";
 import {
 	buildConnectionUrl,
 	buildEntityUrl,
@@ -61,8 +61,7 @@ export interface EntityFieldChangeProposal {
 	watcher_id?: number | null;
 	/**
 	 * The watcher-run window that produced this proposal, if any. Stamped onto the
-	 * `runs.window_id` COLUMN (never into action_input, so the md5(action_input)
-	 * dedupe identity is unaffected) so a run that produced N proposals groups them
+	 * `runs.window_id` COLUMN so a run that produced N proposals groups them
 	 * into ONE batch approval card. Stripped from action_input before the insert.
 	 */
 	window_id?: number | null;
@@ -76,9 +75,7 @@ export interface EntityFieldChangeProposal {
 	 * without an admin role. Absent for mixed/no owners — admin-only behavior.
 	 * Lives in action_input (not run_metadata) because the approve path and the
 	 * Slack bridge already load action_input for the proposal; the dedupe SELECT
-	 * compares specific fields (operation/entity_id/fields), so replays still
-	 * collapse, and the md5(action_input) race index stays stable because the
-	 * owner is recomputed deterministically from live field_controls.
+	 * compares the canonical change identity, so replays still collapse.
 	 */
 	owner_user_id?: string | null;
 }
@@ -149,29 +146,85 @@ function operationOf(
 function asUpdateProposal(
 	proposal: EntityChangeProposal,
 ): EntityFieldChangeProposal {
-	return proposal as EntityFieldChangeProposal;
+	if (proposal.operation === undefined || proposal.operation === "update") {
+		return proposal;
+	}
+	throw new Error(`Expected update proposal, got ${proposal.operation}`);
 }
 
 function asDeleteProposal(
 	proposal: EntityChangeProposal,
 ): EntityDeleteProposal {
-	return proposal as EntityDeleteProposal;
+	if (proposal.operation === "delete") return proposal;
+	throw new Error(
+		`Expected delete proposal, got ${proposal.operation ?? "update"}`,
+	);
 }
 
 function asCreateProposal(
 	proposal: EntityChangeProposal,
 ): EntityCreateProposal {
-	return proposal as EntityCreateProposal;
+	if (proposal.operation === "create") return proposal;
+	throw new Error(
+		`Expected create proposal, got ${proposal.operation ?? "update"}`,
+	);
 }
 
 function asMergeProposal(proposal: EntityChangeProposal): EntityMergeProposal {
-	return proposal as EntityMergeProposal;
+	if (proposal.operation === "merge") return proposal;
+	throw new Error(
+		`Expected merge proposal, got ${proposal.operation ?? "update"}`,
+	);
+}
+
+function changedEntityId(proposal: EntityChangeProposal): number {
+	if (proposal.operation === "create") {
+		throw new Error("Create proposals do not have an existing entity id");
+	}
+	return proposal.entity_id;
 }
 
 function mergeEntityIds(proposal: EntityMergeProposal): number[] {
 	return proposal.entity_ids ?? [proposal.entity_id];
 }
 
+function entityChangeIdempotencyKey(
+	organizationId: string,
+	windowId: number | null,
+	proposal: EntityChangeProposal,
+): string {
+	const operation = operationOf(proposal);
+	let change: Record<string, unknown>;
+	switch (operation) {
+		case "update":
+			change = {
+				entityId: asUpdateProposal(proposal).entity_id,
+				fields: asUpdateProposal(proposal).fields,
+			};
+			break;
+		case "delete":
+			change = {
+				entityId: asDeleteProposal(proposal).entity_id,
+				force: asDeleteProposal(proposal).force_delete_tree ?? false,
+			};
+			break;
+		case "create":
+			change = { entityData: asCreateProposal(proposal).entity_data };
+			break;
+		case "merge": {
+			const merge = asMergeProposal(proposal);
+			change = {
+				winnerId: merge.winner_entity_id,
+				loserIds: [...new Set(mergeEntityIds(merge))].sort((a, b) => a - b),
+			};
+			break;
+		}
+	}
+	const digest = createHash("sha256")
+		.update(stableJson({ organizationId, windowId, operation, change }))
+		.digest("hex");
+	return `entity-change:${digest}`;
+}
 async function loadWatcherLabel(
 	ctx: ToolContext,
 	watcherId: number | null | undefined,
@@ -204,10 +257,7 @@ async function loadWatcherLabel(
 	};
 }
 
-async function loadEntitySnapshot(
-	ctx: ToolContext,
-	entityId: number,
-): Promise<{
+interface EntitySnapshot {
 	id: number;
 	name: string | null;
 	entity_type: string | null;
@@ -215,7 +265,6 @@ async function loadEntitySnapshot(
 	parent_id: number | null;
 	parent_slug: string | null;
 	parent_entity_type: string | null;
-	metadata: Record<string, unknown> | null;
 	identities: Array<{
 		id: number;
 		namespace: string;
@@ -225,27 +274,15 @@ async function loadEntitySnapshot(
 		connection_name: string | null;
 		connector_key: string | null;
 	}>;
-} | null> {
-	const rows = await getDb()<{
-		id: number;
-		name: string | null;
-		entity_type: string | null;
-		slug: string | null;
-		parent_id: number | null;
-		parent_slug: string | null;
-		parent_entity_type: string | null;
-		metadata: Record<string, unknown> | null;
-		identities: Array<{
-			id: number;
-			namespace: string;
-			identifier: string;
-			source_connector: string | null;
-			connection_id: number | null;
-			connection_name: string | null;
-			connector_key: string | null;
-		}>;
-	}>`
-    SELECT e.id, e.name, et.slug AS entity_type, e.slug, e.parent_id, e.metadata,
+}
+
+async function loadEntitySnapshots(
+	ctx: ToolContext,
+	entityIds: number[],
+): Promise<EntitySnapshot[]> {
+	if (entityIds.length === 0) return [];
+	return getDb()<EntitySnapshot>`
+    SELECT e.id, e.name, et.slug AS entity_type, e.slug, e.parent_id,
            parent.slug AS parent_slug, pet.slug AS parent_entity_type,
            COALESCE((
              SELECT jsonb_agg(jsonb_build_object(
@@ -262,25 +299,24 @@ async function loadEntitySnapshot(
     JOIN entity_types et ON et.id = e.entity_type_id
     LEFT JOIN entities parent ON e.parent_id = parent.id
     LEFT JOIN entity_types pet ON pet.id = parent.entity_type_id
-    WHERE e.id = ${entityId}
+    WHERE e.id = ANY(${pgBigintArray(entityIds)}::bigint[])
       AND e.organization_id = ${ctx.organizationId}
-    LIMIT 1
   `;
+}
+
+async function loadEntitySnapshot(
+	ctx: ToolContext,
+	entityId: number,
+): Promise<EntitySnapshot | null> {
+	const rows = await loadEntitySnapshots(ctx, [entityId]);
 	return rows[0] ?? null;
 }
 
-async function addEntityReviewLinks<
-	T extends NonNullable<Awaited<ReturnType<typeof loadEntitySnapshot>>>,
->(
-	ctx: ToolContext,
-	entity: T,
-): Promise<
-	T & {
-		href?: string;
-		identities: Array<T["identities"][number] & { connection_href?: string }>;
-	}
-> {
-	const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
+function toEntityReviewSnapshot(
+	urlContext: Awaited<ReturnType<typeof getOrgUrlContext>>,
+	entity: EntitySnapshot,
+) {
+	const { ownerSlug, baseUrl } = urlContext;
 	const href =
 		ownerSlug && entity.entity_type && entity.slug
 			? buildEntityUrl(
@@ -295,7 +331,13 @@ async function addEntityReviewLinks<
 				)
 			: undefined;
 	return {
-		...entity,
+		id: entity.id,
+		name: entity.name,
+		entity_type: entity.entity_type,
+		slug: entity.slug,
+		parent_id: entity.parent_id,
+		parent_slug: entity.parent_slug,
+		parent_entity_type: entity.parent_entity_type,
 		...(href ? { href } : {}),
 		identities: entity.identities.map((identity) => ({
 			...identity,
@@ -386,20 +428,22 @@ export async function proposeEntityMerge(
 		entity_ids: number[];
 	},
 ): Promise<{ runId: number; eventId: number; approvalUrl?: string }> {
-	const duplicates = await Promise.all(
-		proposal.entity_ids.map((entityId) => loadEntitySnapshot(ctx, entityId)),
+	const ids = [...new Set([...proposal.entity_ids, proposal.winner_entity_id])];
+	const snapshots = await loadEntitySnapshots(ctx, ids);
+	const byId = new Map(snapshots.map((entity) => [Number(entity.id), entity]));
+	const requireSnapshot = (entityId: number) => {
+		const snapshot = byId.get(entityId);
+		if (!snapshot) throw new Error(`Entity ${entityId} not found`);
+		return snapshot;
+	};
+	const urlContext = await getOrgUrlContext(ctx);
+	const linkedDuplicates = proposal.entity_ids.map((entityId) =>
+		toEntityReviewSnapshot(urlContext, requireSnapshot(entityId)),
 	);
-	const winner = await loadEntitySnapshot(ctx, proposal.winner_entity_id);
-	const missingIndex = duplicates.findIndex((entity) => !entity);
-	if (missingIndex >= 0)
-		throw new Error(`Entity ${proposal.entity_ids[missingIndex]} not found`);
-	if (!winner) throw new Error(`Entity ${proposal.winner_entity_id} not found`);
-	const linkedDuplicates = await Promise.all(
-		(duplicates as Array<NonNullable<(typeof duplicates)[number]>>).map(
-			(entity) => addEntityReviewLinks(ctx, entity),
-		),
+	const linkedWinner = toEntityReviewSnapshot(
+		urlContext,
+		requireSnapshot(proposal.winner_entity_id),
 	);
-	const linkedWinner = await addEntityReviewLinks(ctx, winner);
 	const [loser, ...rest] = linkedDuplicates;
 	if (!loser) throw new Error("At least one duplicate entity is required");
 	return proposeEntityChange(ctx, {
@@ -416,9 +460,8 @@ export async function proposeEntityChange(
 ): Promise<{ runId: number; eventId: number; approvalUrl?: string }> {
 	const sql = getDb();
 	const operation = operationOf(proposal);
-	// window_id groups a run's proposals into one batch card — it rides the
-	// runs.window_id COLUMN, never action_input, so the md5(action_input) dedupe
-	// identity is byte-identical whether or not a window produced the proposal.
+	// window_id groups a run's proposals into one batch card. It rides the column,
+	// not action_input, and is part of the canonical idempotency key below.
 	const { window_id: windowId, ...actionInputProposal } = proposal;
 	const updateProposal =
 		operation === "update" ? asUpdateProposal(proposal) : null;
@@ -432,92 +475,77 @@ export async function proposeEntityChange(
 		operation === "update"
 			? ENTITY_FIELD_CHANGE_ACTION_KEY
 			: ENTITY_CHANGE_ACTION_KEY;
+	const idempotencyKey = entityChangeIdempotencyKey(
+		ctx.organizationId,
+		windowId ?? null,
+		proposal,
+	);
 
 	// Idempotency: complete_window is replay-safe (retries + concurrent replicas),
-	// so the same blocked change can be proposed more than once. Collapse to a
-	// single pending approval — if an equivalent pending run already exists for
-	// this org+entity+proposal, reuse it instead of stacking duplicate cards.
+	// so the same blocked change can be proposed more than once. Collapse to one
+	// active run — whether still pending or already applying — instead of stacking
+	// duplicate cards or colliding with the global active-run idempotency index.
 	// (Deletes match on force_delete_tree too: force and non-force are different
 	// asks and must not affirm each other.)
-	const findExisting = () => sql<{ id: number; event_id: number | null }>`
-    SELECT r.id,
-           (SELECT e.id FROM events e
+	type ExistingChangeRun = {
+		id: number;
+		approval_status: string;
+		status: string;
+		pending_event_id: number | null;
+		current_event_id: number | null;
+	};
+	const findExisting = (db: DbClient) => db<ExistingChangeRun>`
+    SELECT r.id, r.approval_status, r.status,
+           (SELECT e.id FROM current_event_records e
               WHERE e.run_id = r.id
                 AND e.interaction_status = 'pending'
-              ORDER BY e.id DESC LIMIT 1) AS event_id
+              ORDER BY e.id DESC LIMIT 1) AS pending_event_id,
+           (SELECT e.id FROM current_event_records e
+              WHERE e.run_id = r.id
+                AND e.interaction_type = 'approval'
+              ORDER BY e.id DESC LIMIT 1) AS current_event_id
     FROM runs r
     WHERE r.organization_id = ${ctx.organizationId}
       AND r.run_type = 'internal'
       AND r.action_key = ${actionKey}
-      AND r.approval_status = 'pending'
-      AND r.status = 'pending'
-      -- Same proposal from a DIFFERENT window is a distinct ask (each window gets
-      -- its own batch card); only a byte-identical replay of the SAME window
-      -- collapses. Matches the runs_entity_change_pending_dedupe unique index.
-      AND r.window_id IS NOT DISTINCT FROM ${windowId ?? null}
-      AND COALESCE(r.action_input->>'operation', 'update') = ${operation}
-      AND COALESCE(r.action_input->>'entity_id', '') = ${"entity_id" in proposal ? String(proposal.entity_id) : ""}
-	      AND (
-	        ${operation !== "update"}
-	        OR r.action_input->'fields' = ${sql.json(updateProposal?.fields ?? {})}::jsonb
-	      )
-	      AND (
-	        ${operation !== "delete"}
-	        OR COALESCE((r.action_input->>'force_delete_tree')::boolean, false) = ${deleteProposal?.force_delete_tree ?? false}
-	      )
-	      AND (
-	        ${operation !== "create"}
-	        OR r.action_input->'entity_data' = ${sql.json(createProposal?.entity_data ?? {})}::jsonb
-	      )
-	      AND (
-	        ${operation !== "merge"}
-	        OR (
-	          COALESCE(r.action_input->>'winner_entity_id', '') = ${String(mergeProposal?.winner_entity_id ?? "")}
-	          AND COALESCE(r.action_input->'entity_ids', jsonb_build_array((r.action_input->>'entity_id')::bigint)) = ${sql.json(mergeProposal ? mergeEntityIds(mergeProposal) : [])}::jsonb
-	        )
-	      )
-	    ORDER BY r.id DESC
+      AND (
+        (
+          r.idempotency_key = ${idempotencyKey}
+          AND r.status IN ('pending', 'claimed', 'running')
+        )
+        OR (
+          r.idempotency_key IS NULL
+          AND r.approval_status = 'pending'
+          AND r.status = 'pending'
+          -- Same proposal from a different window is a distinct ask. This
+          -- semantic fallback repairs pending rows created before canonical keys.
+          AND r.window_id IS NOT DISTINCT FROM ${windowId ?? null}
+          AND COALESCE(r.action_input->>'operation', 'update') = ${operation}
+          AND COALESCE(r.action_input->>'entity_id', '') = ${"entity_id" in proposal ? String(proposal.entity_id) : ""}
+          AND (
+            ${operation !== "update"}
+            OR r.action_input->'fields' = ${sql.json(updateProposal?.fields ?? {})}::jsonb
+          )
+          AND (
+            ${operation !== "delete"}
+            OR COALESCE((r.action_input->>'force_delete_tree')::boolean, false) = ${deleteProposal?.force_delete_tree ?? false}
+          )
+          AND (
+            ${operation !== "create"}
+            OR r.action_input->'entity_data' = ${sql.json(createProposal?.entity_data ?? {})}::jsonb
+          )
+          AND (
+            ${operation !== "merge"}
+            OR (
+              COALESCE(r.action_input->>'winner_entity_id', '') = ${String(mergeProposal?.winner_entity_id ?? "")}
+              AND COALESCE(r.action_input->'entity_ids', jsonb_build_array((r.action_input->>'entity_id')::bigint)) = ${sql.json(mergeProposal ? mergeEntityIds(mergeProposal) : [])}::jsonb
+            )
+          )
+        )
+      )
+    ORDER BY (r.idempotency_key = ${idempotencyKey}) DESC, r.id DESC
     LIMIT 1
   `;
-	const dedupeHit = async (row: { id: number; event_id: number | null }) => {
-		const runId = Number(row.id);
-		const eventId = row.event_id != null ? Number(row.event_id) : 0;
-		const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
-		const approvalUrl = buildResourcePermalink(
-			ownerSlug,
-			{ kind: "run", runId },
-			baseUrl,
-		);
-		return { runId, eventId, approvalUrl };
-	};
-	const existing = await findExisting();
-	if (existing.length > 0) return dedupeHit(existing[0]);
-
-	let runId: number;
-	try {
-		const inserted = await sql`
-      INSERT INTO runs (
-        organization_id, run_type, action_key, action_input, window_id, watcher_id,
-        created_by_user_id, approval_status, status, created_at
-      ) VALUES (
-        ${ctx.organizationId}, 'internal', ${actionKey},
-        ${sql.json(actionInputProposal as unknown as Record<string, unknown>)},
-        ${windowId ?? null}, ${proposal.watcher_id ?? null},
-        null, 'pending', 'pending', current_timestamp
-      )
-      RETURNING id
-    `;
-		runId = Number((inserted[0] as { id: unknown }).id);
-	} catch (err) {
-		// Two replicas raced the SELECT above with a byte-identical proposal — the
-		// partial unique index (runs_entity_change_pending_dedupe) made one lose.
-		// Resolve to the winner's pending run instead of stacking a duplicate card.
-		if (isUniqueViolation(err, "runs_entity_change_pending_dedupe_v2")) {
-			const winner = await findExisting();
-			if (winner.length > 0) return dedupeHit(winner[0]);
-		}
-		throw err;
-	}
 
 	const fieldKeys = updateProposal ? Object.keys(updateProposal.fields) : [];
 	const fieldList = fieldKeys.join(", ");
@@ -528,11 +556,7 @@ export async function proposeEntityChange(
 			loadWatcherLabel(ctx, proposal.watcher_id, attribution),
 			operation === "create"
 				? Promise.resolve(null)
-				: loadEntitySnapshot(
-						ctx,
-						(proposal as EntityFieldChangeProposal | EntityDeleteProposal)
-							.entity_id,
-					),
+				: loadEntitySnapshot(ctx, changedEntityId(proposal)),
 		]);
 	const entityType = createProposal
 		? createProposal.entity_data.entity_type
@@ -551,96 +575,160 @@ export async function proposeEntityChange(
 					? `Merge duplicate ${formatLabel(entityType ?? "entity").toLowerCase()}`
 					: `Create ${formatLabel(entityType ?? "entity").toLowerCase()}`;
 
-	const event = await insertEvent({
-		entityIds:
-			operation === "create"
-				? []
-				: operation === "merge"
-					? [
-							...mergeEntityIds(asMergeProposal(proposal)),
-							asMergeProposal(proposal).winner_entity_id,
-						]
-					: [
-							(proposal as EntityFieldChangeProposal | EntityDeleteProposal)
-								.entity_id,
-						],
-		organizationId: ctx.organizationId,
-		originId: `run_${runId}_pending`,
-		title: `${actionLabel} — pending approval`,
-		content:
-			proposal.reason ??
-			(operation === "update"
-				? `${actorNoun} proposed updating ${fieldList} on this entity.`
-				: operation === "delete"
-					? `${actorNoun} proposed deleting this entity.`
-					: operation === "merge"
-						? `${actorNoun} proposed merging these entities.`
-						: `${actorNoun} proposed creating this entity.`),
-		semanticType: "operation",
-		runId,
-		interactionType: "approval",
-		interactionStatus: "pending",
-		interactionInput: proposal as unknown as Record<string, unknown>,
-		metadata: {
-			tool: actionKey,
-			action_key: actionKey,
-			action: operation === "update" ? "change" : operation,
-			entity_id: "entity_id" in proposal ? proposal.entity_id : null,
-			fields: updateProposal ? updateProposal.fields : null,
-			current: updateProposal
-				? (updateProposal.current ?? null)
-				: deleteProposal
-					? deleteProposal.current
-					: mergeProposal
-						? mergeProposal.current
-						: null,
-			proposal: createProposal
-				? createProposal.proposal
-				: mergeProposal
-					? {
-							entity_id: mergeProposal.entity_id,
-							entity_ids: mergeEntityIds(mergeProposal),
-							winner_entity_id: mergeProposal.winner_entity_id,
-							evidence: mergeProposal.evidence ?? [],
-							names: (
-								mergeProposal.current.duplicates ?? [
-									mergeProposal.current.loser,
+	const insertApprovalEvent = (runId: number, db: DbClient) =>
+		insertEvent(
+			{
+				entityIds:
+					operation === "create"
+						? []
+						: operation === "merge"
+							? [
+									...mergeEntityIds(asMergeProposal(proposal)),
+									asMergeProposal(proposal).winner_entity_id,
 								]
-							).map((entity) => entity.name),
-							name: mergeProposal.current.loser.name,
-							winner_name: mergeProposal.current.winner.name,
-						}
-					: deleteProposal
-						? {
-								entity_id: deleteProposal.entity_id,
-								entity_type:
-									entity?.entity_type ?? deleteProposal.current.entity_type,
-								name: entity?.name ?? deleteProposal.current.name,
-								force_delete_tree: deleteProposal.force_delete_tree ?? false,
-							}
-						: null,
-			watcher_id: proposal.watcher_id ?? null,
-			watcher_name: watcherName,
-			watcher_agent_id: watcherAgentId,
-			// The run window this proposal belongs to, if any. Stamped so the UI can
-			// tell this proposal is part of a BATCH (the change-set card owns the
-			// Approve/Reject decision) and suppress this card's own duplicate buttons.
-			window_id: windowId ?? null,
-			entity_name: entityName ?? null,
-			entity_type: entityType ?? null,
-			entity_slug: createProposal ? null : (entity?.slug ?? null),
-			parent_slug: createProposal ? null : (entity?.parent_slug ?? null),
-			parent_entity_type: createProposal
-				? null
-				: (entity?.parent_entity_type ?? null),
-			attribution,
-			reason: proposal.reason ?? null,
-			status: "pending_approval",
-			run_id: runId,
-		},
-		authorName: attribution,
+							: [changedEntityId(proposal)],
+				organizationId: ctx.organizationId,
+				originId: `run_${runId}_pending`,
+				title: `${actionLabel} — pending approval`,
+				content:
+					proposal.reason ??
+					(operation === "update"
+						? `${actorNoun} proposed updating ${fieldList} on this entity.`
+						: operation === "delete"
+							? `${actorNoun} proposed deleting this entity.`
+							: operation === "merge"
+								? `${actorNoun} proposed merging these entities.`
+								: `${actorNoun} proposed creating this entity.`),
+				semanticType: "operation",
+				runId,
+				interactionType: "approval",
+				interactionStatus: "pending",
+				interactionInput: proposal as unknown as Record<string, unknown>,
+				metadata: {
+					tool: actionKey,
+					action_key: actionKey,
+					action: operation === "update" ? "change" : operation,
+					entity_id: "entity_id" in proposal ? proposal.entity_id : null,
+					fields: updateProposal ? updateProposal.fields : null,
+					current: updateProposal
+						? (updateProposal.current ?? null)
+						: deleteProposal
+							? deleteProposal.current
+							: mergeProposal
+								? mergeProposal.current
+								: null,
+					proposal: createProposal
+						? createProposal.proposal
+						: mergeProposal
+							? {
+									entity_id: mergeProposal.entity_id,
+									entity_ids: mergeEntityIds(mergeProposal),
+									winner_entity_id: mergeProposal.winner_entity_id,
+									evidence: mergeProposal.evidence ?? [],
+									names: (
+										mergeProposal.current.duplicates ?? [
+											mergeProposal.current.loser,
+										]
+									).map((entity) => entity.name),
+									name: mergeProposal.current.loser.name,
+									winner_name: mergeProposal.current.winner.name,
+								}
+							: deleteProposal
+								? {
+										entity_id: deleteProposal.entity_id,
+										entity_type:
+											entity?.entity_type ?? deleteProposal.current.entity_type,
+										name: entity?.name ?? deleteProposal.current.name,
+										force_delete_tree:
+											deleteProposal.force_delete_tree ?? false,
+									}
+								: null,
+					watcher_id: proposal.watcher_id ?? null,
+					watcher_name: watcherName,
+					watcher_agent_id: watcherAgentId,
+					// The run window this proposal belongs to, if any. Stamped so the UI can
+					// tell this proposal is part of a BATCH (the change-set card owns the
+					// Approve/Reject decision) and suppress this card's own duplicate buttons.
+					window_id: windowId ?? null,
+					entity_name: entityName ?? null,
+					entity_type: entityType ?? null,
+					entity_slug: createProposal ? null : (entity?.slug ?? null),
+					parent_slug: createProposal ? null : (entity?.parent_slug ?? null),
+					parent_entity_type: createProposal
+						? null
+						: (entity?.parent_entity_type ?? null),
+					attribution,
+					reason: proposal.reason ?? null,
+					status: "pending_approval",
+					run_id: runId,
+				},
+				authorName: attribution,
+			},
+			{ sql: db },
+		);
+	const reuseExisting = async (row: ExistingChangeRun, db: DbClient) => {
+		await db`
+			UPDATE runs
+			SET idempotency_key = ${idempotencyKey}
+			WHERE id = ${row.id} AND idempotency_key IS NULL
+		`;
+		const isPending =
+			row.approval_status === "pending" && row.status === "pending";
+		const eventId = isPending ? row.pending_event_id : row.current_event_id;
+		if (eventId != null) {
+			return {
+				runId: Number(row.id),
+				eventId: Number(eventId),
+				reused: true,
+			};
+		}
+		if (!isPending) {
+			throw new Error(
+				`Active entity change run ${row.id} has no approval event`,
+			);
+		}
+		const event = await insertApprovalEvent(Number(row.id), db);
+		return {
+			runId: Number(row.id),
+			eventId: Number(event.id),
+			reused: false,
+		};
+	};
+
+	const persisted = await sql.begin(async (tx) => {
+		await tx`SELECT pg_advisory_xact_lock(hashtextextended(${idempotencyKey}, 0))`;
+		const existing = await findExisting(tx);
+		if (existing.length > 0) {
+			return reuseExisting(existing[0], tx);
+		}
+
+		const inserted = await tx<{ id: number }>`
+			INSERT INTO runs (
+				organization_id, run_type, action_key, action_input, window_id,
+				watcher_id, created_by_user_id, approval_status, status,
+				idempotency_key, created_at
+			) VALUES (
+				${ctx.organizationId}, 'internal', ${actionKey},
+				${tx.json(actionInputProposal as unknown as Record<string, unknown>)},
+				${windowId ?? null}, ${proposal.watcher_id ?? null}, null,
+				'pending', 'pending', ${idempotencyKey}, current_timestamp
+			)
+			ON CONFLICT DO NOTHING
+			RETURNING id
+		`;
+		if (inserted.length === 0) {
+			const winner = await findExisting(tx);
+			if (winner.length === 0) {
+				throw new Error("Entity change idempotency conflict has no active run");
+			}
+			return reuseExisting(winner[0], tx);
+		}
+
+		const runId = Number(inserted[0].id);
+		const event = await insertApprovalEvent(runId, tx);
+		return { runId, eventId: Number(event.id), reused: false };
 	});
-	const eventId = Number(event.id);
+	const { runId, eventId } = persisted;
 
 	const { ownerSlug, baseUrl } = await getOrgUrlContext(ctx);
 	// Run-scoped: the pending event is superseded on approve→complete; a run link
@@ -651,6 +739,7 @@ export async function proposeEntityChange(
 		{ kind: "run", runId },
 		baseUrl,
 	);
+	if (persisted.reused) return { runId, eventId, approvalUrl };
 	const entityUrl =
 		ownerSlug && entity?.entity_type && entity.slug
 			? buildEntityUrl(
@@ -855,6 +944,7 @@ export async function applyEntityChangeProposal(
 	proposal: EntityChangeProposal,
 	ctx: ToolContext,
 	env: Env,
+	db: DbClient,
 ): Promise<unknown> {
 	const operation = operationOf(proposal);
 	if (operation === "update") {
@@ -887,12 +977,13 @@ export async function applyEntityChangeProposal(
 	}
 	if (operation === "merge") {
 		const mergeProposal = asMergeProposal(proposal);
-		return applyMergeGroup({
+		const params = {
 			orgId: ctx.organizationId,
 			loserIds: mergeEntityIds(mergeProposal),
 			winnerId: mergeProposal.winner_entity_id,
 			mergedBy: ctx.userId ?? "system",
-		});
+		};
+		return applyMergeGroupInTransaction(params, db);
 	}
 	const deleteProposal = asDeleteProposal(proposal);
 	return deleteEntity(

--- a/packages/server/src/tools/admin/manage_entity.ts
+++ b/packages/server/src/tools/admin/manage_entity.ts
@@ -634,29 +634,38 @@ async function handleMerge(
 		);
 	if (loserIds.includes(winnerId))
 		throw new ToolUserError("winner_entity_id cannot also be a duplicate", 400);
+	if (loserIds.length > 25)
+		throw new ToolUserError("A merge can include at most 25 duplicates", 400);
 
 	const sql = getDb();
 	// Every duplicate and the winner must be live and in the caller's org — never
 	// merge across a tenant boundary or into a deleted/foreign entity.
 	const rows = (await sql`
-    SELECT id FROM entities
+    SELECT id, entity_type_id FROM entities
     WHERE organization_id = ${ctx.organizationId}
 	      AND id = ANY(${pgBigintArray([...loserIds, winnerId])}::bigint[])
       AND deleted_at IS NULL
-  `) as Array<{ id: number }>;
+	`) as Array<{ id: number; entity_type_id: number }>;
 	const found = new Set(rows.map((r) => Number(r.id)));
 	for (const loserId of loserIds) {
-	if (!found.has(loserId))
-		throw new ToolUserError(
-			`Entity ${loserId} not found in this workspace`,
-			404,
-		);
+		if (!found.has(loserId))
+			throw new ToolUserError(
+				`Entity ${loserId} not found in this workspace`,
+				404,
+			);
 	}
 	if (!found.has(winnerId))
 		throw new ToolUserError(
 			`Entity ${winnerId} not found in this workspace`,
 			404,
 		);
+	const entityTypeIds = new Set(rows.map((row) => Number(row.entity_type_id)));
+	if (entityTypeIds.size !== 1) {
+		throw new ToolUserError(
+			"Duplicate and canonical entities must have the same entity type",
+			400,
+		);
+	}
 
 	if (actor.kind !== "user") {
 		const attribution = actor.kind === "watcher" ? "watcher" : "agent";

--- a/packages/server/src/tools/admin/manage_operations.ts
+++ b/packages/server/src/tools/admin/manage_operations.ts
@@ -33,6 +33,7 @@ import {
 } from "../../authz/entity-policy";
 import { authzScopeFromToolContext } from "../../authz/scope";
 import {
+	type DbClient,
 	getDb,
 	parsePgNumberArray,
 	pgBigintArray,
@@ -1294,8 +1295,9 @@ export async function supersedeActionEvent(
 	content: string,
 	extraMetadata: Record<string, unknown> = {},
 	reviewer: ApprovalReviewer | null = null,
+	db: DbClient = getDb(),
 ): Promise<number | undefined> {
-  const sql = getDb();
+  const sql = db;
   const originalEvent = await sql`
     SELECT id, entity_ids, connection_id, connector_key, metadata, author_name, interaction_input_schema, interaction_input
     FROM current_event_records
@@ -1371,7 +1373,7 @@ export async function supersedeActionEvent(
 			...extraMetadata,
 		},
 		authorName: orig.author_name ?? null,
-	});
+	}, { sql });
 
 	return Number(nextEvent.id);
 }
@@ -1714,8 +1716,9 @@ async function claimEntityChangeRun(
 	organizationId: string,
 	decision: "approved" | "rejected",
 	rejectReason?: string,
+	db: DbClient = getDb(),
 ): Promise<{ proposal: EntityChangeProposal } | null> {
-	const sql = getDb();
+	const sql = db;
 	const actionKeys = pgTextArray([...ENTITY_CHANGE_ACTION_KEYS]);
 	const rows =
 		decision === "approved"
@@ -1865,33 +1868,46 @@ async function tryApproveEntityChangeRun(
 	ctx: ToolContext,
 	env: Env,
 ): Promise<ManageOperationsResult | null> {
-	const claimed = await claimEntityChangeRun(
-		args.run_id,
-		ctx.organizationId,
-		"approved",
-	);
-	if (!claimed) return null;
-	const { proposal } = claimed;
-	const operation = entityChangeOperation(proposal);
-	const description = describeEntityChange(proposal);
+	const sql = getDb();
+	const actionKeys = pgTextArray([...ENTITY_CHANGE_ACTION_KEYS]);
+	const [pending] = await sql<{ action_input: EntityChangeProposal | null }>`
+		SELECT action_input
+		FROM runs
+		WHERE id = ${args.run_id}
+		  AND organization_id = ${ctx.organizationId}
+		  AND run_type = 'internal'
+		  AND action_key = ANY(${actionKeys}::text[])
+		  AND approval_status = 'pending'
+		  AND status = 'pending'
+		LIMIT 1
+	`;
+	if (!pending?.action_input) return null;
+	const pendingProposal = pending.action_input;
+	const pendingOperation = entityChangeOperation(pendingProposal);
 	const reviewer = await resolveReviewer(ctx);
 
-	await supersedeActionEvent(
-		args.run_id,
-		ctx.organizationId,
-		"confirmed",
-		operation === "update"
-			? "entity_field_change — applying"
-			: `entity_${operation} — applying`,
-		operation === "update"
-			? `Field change confirmed: ${description}`
-			: `Entity ${operation} confirmed: ${description}`,
-		{},
-		reviewer,
-	);
+	const completeApproval = async (
+		db: DbClient,
+		proposal: EntityChangeProposal,
+	): Promise<ManageOperationsResult> => {
+		const operation = entityChangeOperation(proposal);
+		const description = describeEntityChange(proposal);
+		await supersedeActionEvent(
+			args.run_id,
+			ctx.organizationId,
+			"confirmed",
+			operation === "update"
+				? "entity_field_change — applying"
+				: `entity_${operation} — applying`,
+			operation === "update"
+				? `Field change confirmed: ${description}`
+				: `Entity ${operation} confirmed: ${description}`,
+			{},
+			reviewer,
+			db,
+		);
 
-	try {
-		const result = await applyEntityChangeProposal(proposal, ctx, env);
+		const result = await applyEntityChangeProposal(proposal, ctx, env, db);
 		const staleFields =
 			operation === "update" &&
 			result &&
@@ -1909,9 +1925,9 @@ async function tryApproveEntityChangeRun(
 			Object.keys((result as { applied: Record<string, unknown> }).applied)
 				.length === 0 &&
 			staleFields.length > 0;
-		await getDb()`
+		await db`
       UPDATE runs SET status = 'completed', completed_at = NOW(),
-        action_output = ${getDb().json(result as unknown as Record<string, unknown>)}
+        action_output = ${db.json(result as unknown as Record<string, unknown>)}
       WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
     `;
 		const summary = allStale
@@ -1931,6 +1947,7 @@ async function tryApproveEntityChangeRun(
 			summary,
 			{ output: result as unknown as Record<string, unknown> },
 			reviewer,
+			db,
 		);
 		return {
 			action: "approve",
@@ -1943,30 +1960,74 @@ async function tryApproveEntityChangeRun(
 					? `Field change approved and applied: ${description}.`
 					: `Entity ${operation} approved and applied: ${description}.`,
 		};
-	} catch (error) {
+	};
+
+	const applyFailure = async (
+		error: unknown,
+	): Promise<ManageOperationsResult> => {
 		const errorMessage = error instanceof Error ? error.message : String(error);
 		// Apply failures here are often transient/situational (entity gained
 		// children before a non-force delete, schema changed, etc.). Put the run
 		// BACK to pending instead of burning the proposal on one errant click —
 		// the reviewer can retry after fixing the blocker, or reject it.
-		await getDb()`
+		const reset = await sql`
       UPDATE runs SET approval_status = 'pending', status = 'pending', error_message = ${errorMessage}
       WHERE id = ${args.run_id} AND organization_id = ${ctx.organizationId}
+		AND (
+		  (approval_status = 'approved' AND status = 'running')
+		  OR (approval_status = 'pending' AND status = 'pending')
+		)
+		RETURNING id
     `;
+		if (reset.length === 0) {
+			return {
+				error: `Failed to apply entity ${pendingOperation}: ${errorMessage}. The approval changed concurrently; refresh before retrying.`,
+			};
+		}
 		await supersedeActionEvent(
 			args.run_id,
 			ctx.organizationId,
 			"apply_failed",
-			operation === "update"
+			pendingOperation === "update"
 				? "entity_field_change — apply failed, still pending"
-				: `entity_${operation} — apply failed, still pending`,
+				: `entity_${pendingOperation} — apply failed, still pending`,
 			`Applying the approved change failed: ${errorMessage}. The approval is pending again — fix the blocker and approve once more, or reject it.`,
 			{ error_message: errorMessage },
 			reviewer,
 		);
 		return {
-			error: `Failed to apply entity ${operation}: ${errorMessage}. The approval is back to pending — approve again after fixing the blocker, or reject it.`,
+			error: `Failed to apply entity ${pendingOperation}: ${errorMessage}. The approval is back to pending — approve again after fixing the blocker, or reject it.`,
 		};
+	};
+
+	if (pendingOperation === "merge") {
+		try {
+			return await sql.begin(async (tx) => {
+				const claimed = await claimEntityChangeRun(
+					args.run_id,
+					ctx.organizationId,
+					"approved",
+					undefined,
+					tx,
+				);
+				if (!claimed) return null;
+				return completeApproval(tx, claimed.proposal);
+			});
+		} catch (error) {
+			return applyFailure(error);
+		}
+	}
+
+	const claimed = await claimEntityChangeRun(
+		args.run_id,
+		ctx.organizationId,
+		"approved",
+	);
+	if (!claimed) return null;
+	try {
+		return await completeApproval(sql, claimed.proposal);
+	} catch (error) {
+		return applyFailure(error);
 	}
 }
 

--- a/packages/server/src/utils/entity-merge.ts
+++ b/packages/server/src/utils/entity-merge.ts
@@ -50,54 +50,63 @@ export interface ApplyMergeGroupResult {
   repointedEdges: number;
 }
 
+export interface ApplyMergeGroupParams {
+  orgId: string;
+  loserIds: number[];
+  winnerId: number;
+  mergedBy: string;
+}
+
 /**
  * Apply a whole duplicate group under one outer transaction. Any stale or
  * invalid member rolls back every preceding member merge.
  */
 export async function applyMergeGroup(
-  params: {
-    orgId: string;
-    loserIds: number[];
-    winnerId: number;
-    mergedBy: string;
-  },
+  params: ApplyMergeGroupParams,
   db: DbClient = getDb(),
+): Promise<ApplyMergeGroupResult> {
+  return db.begin((tx) => applyMergeGroupInTransaction(params, tx));
+}
+
+export async function applyMergeGroupInTransaction(
+  params: ApplyMergeGroupParams,
+  tx: DbClient,
 ): Promise<ApplyMergeGroupResult> {
   const loserIds = [...new Set(params.loserIds)].sort((a, b) => a - b);
   if (loserIds.length === 0) throw new Error('applyMergeGroup: no duplicate entities');
   if (loserIds.includes(params.winnerId)) {
     throw new Error('applyMergeGroup: canonical entity is also a duplicate');
   }
-  return db.begin(async (tx) => {
-    // Lock the whole group in one global order before applying any member. Pairwise
-    // locking inside the loop is not sufficient: overlapping groups with different
-    // winners can otherwise each hold one entity while waiting for the other.
-    const entityIds = [...loserIds, params.winnerId].sort((a, b) => a - b);
-    await tx`
-      SELECT id
-      FROM entities
-      WHERE organization_id = ${params.orgId}
-        AND id = ANY(${pgBigintArray(entityIds)}::bigint[])
-      ORDER BY id
-      FOR UPDATE
-    `;
-    let movedIdentities = 0;
-    let repointedEdges = 0;
-    for (const loserId of loserIds) {
-      const result = await applyMergeInTransaction(
-        {
-          orgId: params.orgId,
-          loserId,
-          winnerId: params.winnerId,
-          mergedBy: params.mergedBy,
-        },
-        tx,
-      );
-      movedIdentities += result.movedIdentities;
-      repointedEdges += result.repointedEdges;
-    }
-    return { mergedEntityIds: loserIds, movedIdentities, repointedEdges };
-  });
+
+  // Lock the whole group in one global order before applying any member. Pairwise
+  // locking inside the loop is not sufficient: overlapping groups with different
+  // winners can otherwise each hold one entity while waiting for the other.
+  const entityIds = [...loserIds, params.winnerId].sort((a, b) => a - b);
+  await tx`
+    SELECT id
+    FROM entities
+    WHERE organization_id = ${params.orgId}
+      AND id = ANY(${pgBigintArray(entityIds)}::bigint[])
+    ORDER BY id
+    FOR UPDATE
+  `;
+
+  let movedIdentities = 0;
+  let repointedEdges = 0;
+  for (const loserId of loserIds) {
+    const result = await applyMergeInTransaction(
+      {
+        orgId: params.orgId,
+        loserId,
+        winnerId: params.winnerId,
+        mergedBy: params.mergedBy,
+      },
+      tx,
+    );
+    movedIdentities += result.movedIdentities;
+    repointedEdges += result.repointedEdges;
+  }
+  return { mergedEntityIds: loserIds, movedIdentities, repointedEdges };
 }
 
 /**
@@ -106,7 +115,10 @@ export async function applyMergeGroup(
  * throwing. Throws on a cross-entity-type or already-merged-elsewhere conflict so
  * the caller (tool) surfaces it rather than silently corrupting the graph.
  */
-export async function applyMerge(params: ApplyMergeParams, db: DbClient = getDb()): Promise<ApplyMergeResult> {
+export async function applyMerge(
+  params: ApplyMergeParams,
+  db: DbClient = getDb(),
+): Promise<ApplyMergeResult> {
   return db.begin((tx) => applyMergeInTransaction(params, tx));
 }
 
@@ -119,162 +131,171 @@ async function applyMergeInTransaction(
     throw new Error('applyMerge: loser and winner are the same entity');
   }
 
-    // Lock both rows in a stable order (lowest id first) to avoid deadlocks when
-    // two merges touch the overlapping pair concurrently. The explicit `ORDER BY
-    // id` pins lock-acquisition order — a bare `IN (...)` leaves it to the
-    // planner, which could lock high-then-low and deadlock a concurrent merge.
-    const [a, b] = loserId < winnerId ? [loserId, winnerId] : [winnerId, loserId];
-    const locked = (await tx<{
-      id: number;
-      merged_into: number | null;
-      deleted_at: string | null;
-    }>`
-      SELECT id, merged_into, deleted_at
-      FROM entities
-      WHERE organization_id = ${orgId} AND id IN (${a}, ${b})
-      ORDER BY id
-      FOR UPDATE
-    `) as Array<{
-      id: number;
-      merged_into: number | null;
-      deleted_at: string | null;
-    }>;
+  // Lock both rows in a stable order (lowest id first) to avoid deadlocks when
+  // two merges touch the overlapping pair concurrently.
+  const [a, b] = loserId < winnerId ? [loserId, winnerId] : [winnerId, loserId];
+  const locked = await tx<{
+    id: number;
+    entity_type_id: number;
+    merged_into: number | null;
+    deleted_at: string | null;
+  }>`
+    SELECT id, entity_type_id, merged_into, deleted_at
+    FROM entities
+    WHERE organization_id = ${orgId} AND id IN (${a}, ${b})
+    ORDER BY id
+    FOR UPDATE
+  `;
 
-    const loser = locked.find((r) => Number(r.id) === loserId);
-    const winner = locked.find((r) => Number(r.id) === winnerId);
-    if (!loser || !winner) {
-      throw new Error(`applyMerge: entity not found in org (loser=${loserId} winner=${winnerId})`);
-    }
-    // Already fused this exact way — no-op (safe re-run).
-    if (Number(loser.merged_into) === winnerId) {
-      return { movedIdentities: 0, repointedEdges: 0 };
-    }
-    if (loser.merged_into !== null) {
-      throw new Error(`applyMerge: loser ${loserId} already merged into ${loser.merged_into}`);
-    }
-    if (loser.deleted_at !== null) {
-      throw new Error(`applyMerge: loser ${loserId} is deleted`);
-    }
-    if (winner.merged_into !== null) {
-      throw new Error(`applyMerge: winner ${winnerId} is itself merged into ${winner.merged_into}`);
-    }
-    if (winner.deleted_at !== null) {
-      throw new Error(`applyMerge: winner ${winnerId} is deleted`);
-    }
+  const loser = locked.find((row) => Number(row.id) === loserId);
+  const winner = locked.find((row) => Number(row.id) === winnerId);
+  if (!loser || !winner) {
+    throw new Error(`applyMerge: entity not found in org (loser=${loserId} winner=${winnerId})`);
+  }
+  if (Number(loser.merged_into) === winnerId) {
+    return { movedIdentities: 0, repointedEdges: 0 };
+  }
+  if (loser.merged_into !== null) {
+    throw new Error(`applyMerge: loser ${loserId} already merged into ${loser.merged_into}`);
+  }
+  if (loser.deleted_at !== null) {
+    throw new Error(`applyMerge: loser ${loserId} is deleted`);
+  }
+  if (winner.merged_into !== null) {
+    throw new Error(`applyMerge: winner ${winnerId} is itself merged into ${winner.merged_into}`);
+  }
+  if (winner.deleted_at !== null) {
+    throw new Error(`applyMerge: winner ${winnerId} is deleted`);
+  }
+  if (Number(loser.entity_type_id) !== Number(winner.entity_type_id)) {
+    throw new Error('applyMerge: cannot merge entities of different entity types');
+  }
 
-    // 1. Move the loser's LIVE identities to the winner. A live loser↔live winner
-    //    collision on the SAME (org, namespace, identifier) is impossible — the
-    //    global unique index `idx_entity_identities_live_unique` forbids two live
-    //    rows for one value org-wide — so the move can never hit the index. Stamp
-    //    origin with COALESCE so an identity that already carries a marker (moved
-    //    here by an EARLIER merge, e.g. L→W then W→V) keeps its INNERMOST origin —
-    //    that's what makes `unmerge(L)` restore L's own identities post-flatten.
-    const moved = (await tx<{ id: number }>`
-      UPDATE entity_identities
-      SET entity_id = ${winnerId},
-          merged_from_entity_id = COALESCE(merged_from_entity_id, ${loserId}),
-          updated_at = current_timestamp
-      WHERE organization_id = ${orgId}
-        AND entity_id = ${loserId}
-        AND deleted_at IS NULL
-      RETURNING id
-    `) as Array<{ id: number }>;
+  // 1. Move the loser's LIVE identities to the winner. A live loser↔live winner
+  //    collision on the SAME (org, namespace, identifier) is impossible — the
+  //    global unique index `idx_entity_identities_live_unique` forbids two live
+  //    rows for one value org-wide — so the move can never hit the index. Stamp
+  //    origin with COALESCE so an identity that already carries a marker (moved
+  //    here by an EARLIER merge, e.g. L→W then W→V) keeps its INNERMOST origin —
+  //    that's what makes `unmerge(L)` restore L's own identities post-flatten.
+  const moved = (await tx<{ id: number }>`
+    UPDATE entity_identities
+    SET entity_id = ${winnerId},
+        merged_from_entity_id = COALESCE(merged_from_entity_id, ${loserId}),
+        updated_at = current_timestamp
+    WHERE organization_id = ${orgId}
+      AND entity_id = ${loserId}
+      AND deleted_at IS NULL
+    RETURNING id
+  `) as Array<{ id: number }>;
 
-    // 2. Union the loser's metadata.aliases into the winner's, so the metric
-    //    compiler (which resolves against metadata->'aliases') attributes the
-    //    loser's contact values to the winner.
-    await tx`
-      UPDATE entities w
-      SET metadata = jsonb_set(
-            COALESCE(w.metadata, '{}'::jsonb),
-            '{aliases}',
-            (
-              SELECT to_jsonb(array_agg(DISTINCT a))
-              FROM (
-                SELECT jsonb_array_elements_text(COALESCE(w.metadata->'aliases', '[]'::jsonb)) AS a
-                UNION
-                SELECT jsonb_array_elements_text(COALESCE(l.metadata->'aliases', '[]'::jsonb)) AS a
-                FROM entities l
-                WHERE l.id = ${loserId} AND l.organization_id = ${orgId}
-              ) u
-              WHERE a IS NOT NULL
-            )
-          ),
-          updated_at = current_timestamp
-      FROM entities l
-      WHERE w.id = ${winnerId} AND w.organization_id = ${orgId}
-        AND l.id = ${loserId}
-        AND COALESCE(l.metadata->'aliases', '[]'::jsonb) <> '[]'::jsonb
-    `;
-
-    // 3. Re-point relationship edges loser→winner, then drop self-loops and any
-    //    duplicate edge the winner already had (same type + other endpoint).
-    const repointed = (await tx<{ id: number }>`
-      UPDATE entity_relationships
-      SET from_entity_id = CASE WHEN from_entity_id = ${loserId} THEN ${winnerId} ELSE from_entity_id END,
-          to_entity_id   = CASE WHEN to_entity_id   = ${loserId} THEN ${winnerId} ELSE to_entity_id   END,
-          updated_at = current_timestamp
-      WHERE organization_id = ${orgId}
-        AND deleted_at IS NULL
-        AND (from_entity_id = ${loserId} OR to_entity_id = ${loserId})
-      RETURNING id
-    `) as Array<{ id: number }>;
-    // Tombstone self-loops and duplicate edges created by the re-point.
-    await tx`
-      UPDATE entity_relationships r
-      SET deleted_at = current_timestamp, updated_at = current_timestamp
-      WHERE r.organization_id = ${orgId}
-        AND r.deleted_at IS NULL
-        AND (
-          r.from_entity_id = r.to_entity_id
-          OR EXISTS (
-            SELECT 1 FROM entity_relationships o
-            WHERE o.organization_id = ${orgId}
-              AND o.deleted_at IS NULL
-              AND o.id < r.id
-              AND o.relationship_type_id = r.relationship_type_id
-              AND o.from_entity_id = r.from_entity_id
-              AND o.to_entity_id = r.to_entity_id
+  // 2. Union the loser's metadata.aliases into the winner's, so the metric
+  //    compiler (which resolves against metadata->'aliases') attributes the
+  //    loser's contact values to the winner.
+  await tx`
+    UPDATE entities w
+    SET metadata = jsonb_set(
+          COALESCE(w.metadata, '{}'::jsonb),
+          '{aliases}',
+          (
+            SELECT to_jsonb(array_agg(DISTINCT a))
+            FROM (
+              SELECT jsonb_array_elements_text(COALESCE(w.metadata->'aliases', '[]'::jsonb)) AS a
+              UNION
+              SELECT jsonb_array_elements_text(COALESCE(l.metadata->'aliases', '[]'::jsonb)) AS a
+              FROM entities l
+              WHERE l.id = ${loserId} AND l.organization_id = ${orgId}
+            ) u
+            WHERE a IS NOT NULL
           )
+        ),
+        updated_at = current_timestamp
+    FROM entities l
+    WHERE w.id = ${winnerId} AND w.organization_id = ${orgId}
+      AND l.id = ${loserId}
+      AND COALESCE(l.metadata->'aliases', '[]'::jsonb) <> '[]'::jsonb
+  `;
+
+  // 3. Tombstone loser edges that would become self-loops or collide with an
+  //    existing winner edge. This must happen before repointing: the live-edge
+  //    unique index rejects the collision during UPDATE, before a later cleanup
+  //    statement could run.
+  await tx`
+    UPDATE entity_relationships r
+    SET deleted_at = current_timestamp, updated_at = current_timestamp
+    WHERE r.organization_id = ${orgId}
+      AND r.deleted_at IS NULL
+      AND (r.from_entity_id = ${loserId} OR r.to_entity_id = ${loserId})
+      AND (
+        (CASE WHEN r.from_entity_id = ${loserId} THEN ${winnerId} ELSE r.from_entity_id END) =
+        (CASE WHEN r.to_entity_id = ${loserId} THEN ${winnerId} ELSE r.to_entity_id END)
+        OR EXISTS (
+          SELECT 1
+          FROM entity_relationships o
+          WHERE o.organization_id = ${orgId}
+            AND o.deleted_at IS NULL
+            AND o.id <> r.id
+            AND o.relationship_type_id = r.relationship_type_id
+            AND o.from_entity_id = CASE
+              WHEN r.from_entity_id = ${loserId} THEN ${winnerId}
+              ELSE r.from_entity_id
+            END
+            AND o.to_entity_id = CASE
+              WHEN r.to_entity_id = ${loserId} THEN ${winnerId}
+              ELSE r.to_entity_id
+            END
         )
-    `;
+      )
+  `;
 
-    // 4. Flatten: anything that already pointed at the loser now points at the
-    //    winner, so every redirect stays exactly one hop (no chain walk at read).
-    //    The read redirect (`entity_ids && ARRAY(… merged_into = X …)`) is a
-    //    one-time indexed lookup even when X is an outer column, which a recursive
-    //    chain walk would NOT be on list/count/order call sites. The identities'
-    //    COALESCE'd `merged_from` markers (step 1) preserve reversibility that
-    //    the flattened `merged_into` pointer alone would lose.
-    await tx`
-      UPDATE entities
-      SET merged_into = ${winnerId}, updated_at = current_timestamp
-      WHERE organization_id = ${orgId} AND merged_into = ${loserId}
-    `;
+  // Repoint only the non-colliding live edges that remain.
+  const repointed = (await tx<{ id: number }>`
+    UPDATE entity_relationships
+    SET from_entity_id = CASE WHEN from_entity_id = ${loserId} THEN ${winnerId} ELSE from_entity_id END,
+        to_entity_id   = CASE WHEN to_entity_id   = ${loserId} THEN ${winnerId} ELSE to_entity_id   END,
+        updated_at = current_timestamp
+    WHERE organization_id = ${orgId}
+      AND deleted_at IS NULL
+      AND (from_entity_id = ${loserId} OR to_entity_id = ${loserId})
+    RETURNING id
+  `) as Array<{ id: number }>;
 
-    // 5. Tombstone the loser and point it at the winner.
-    await tx`
-      UPDATE entities
-      SET merged_into = ${winnerId}, deleted_at = current_timestamp, updated_at = current_timestamp
-      WHERE organization_id = ${orgId} AND id = ${loserId}
-    `;
+  // 4. Flatten: anything that already pointed at the loser now points at the
+  //    winner, so every redirect stays exactly one hop (no chain walk at read).
+  //    The read redirect (`entity_ids && ARRAY(… merged_into = X …)`) is a
+  //    one-time indexed lookup even when X is an outer column, which a recursive
+  //    chain walk would NOT be on list/count/order call sites. The identities'
+  //    COALESCE'd `merged_from` markers (step 1) preserve reversibility that
+  //    the flattened `merged_into` pointer alone would lose.
+  await tx`
+    UPDATE entities
+    SET merged_into = ${winnerId}, updated_at = current_timestamp
+    WHERE organization_id = ${orgId} AND merged_into = ${loserId}
+  `;
 
-    logger.info(
-      {
-        orgId,
-        loserId,
-        winnerId,
-        mergedBy,
-        movedIdentities: moved.length,
-        repointedEdges: repointed.length,
-      },
-      'entity merge applied',
-    );
+  // 5. Tombstone the loser and point it at the winner.
+  await tx`
+    UPDATE entities
+    SET merged_into = ${winnerId}, deleted_at = current_timestamp, updated_at = current_timestamp
+    WHERE organization_id = ${orgId} AND id = ${loserId}
+  `;
 
-    return {
+  logger.info(
+    {
+      orgId,
+      loserId,
+      winnerId,
+      mergedBy,
       movedIdentities: moved.length,
       repointedEdges: repointed.length,
-    };
+    },
+    'entity merge applied',
+  );
+
+  return {
+    movedIdentities: moved.length,
+    repointedEdges: repointed.length,
+  };
 }
 
 export interface ApplyUnmergeParams {

--- a/packages/server/src/utils/insert-event.ts
+++ b/packages/server/src/utils/insert-event.ts
@@ -6,7 +6,7 @@
  */
 
 import { retryWithBackoff } from '@lobu/core';
-import { getDb } from '../db/client';
+import { type DbClient, getDb } from '../db/client';
 import { type ConfigResourceKind, redactConfigState } from './config-redaction';
 import {
   lookupGeoEnrichment,
@@ -119,7 +119,7 @@ function normalizedTimestamp(value?: Date | string | null): string | null {
 }
 
 async function findCurrentEventByOrigin(
-  sql: ReturnType<typeof getDb>,
+  sql: DbClient,
   params: InsertEventParams
 ): Promise<
   | {
@@ -204,7 +204,7 @@ async function upsertEmbedding(
   eventId: number,
   embedding: number[] | null | undefined,
   embeddingModel: string | null | undefined,
-  sql: ReturnType<typeof getDb> = getDb()
+  sql: DbClient = getDb()
 ): Promise<void> {
   if (!embedding || embedding.length === 0) return;
   // An unstamped vector is unusable — search scopes vector comparison to the
@@ -248,7 +248,7 @@ function isEventsClientIdForeignKeyViolation(error: unknown): boolean {
  */
 export async function insertEvent(
   params: InsertEventParams,
-  options?: { onConflictUpdate?: boolean; sql?: ReturnType<typeof getDb> }
+  options?: { onConflictUpdate?: boolean; sql?: DbClient }
 ): Promise<InsertedEvent> {
   const sql = options?.sql ?? getDb();
 
@@ -271,7 +271,7 @@ export async function insertEvent(
   // run either directly on the singleton pool or inside the dedup transaction
   // below (which holds an advisory lock for the duration).
   const runInsert = async (
-    activeSql: ReturnType<typeof getDb>
+    activeSql: DbClient
   ): Promise<InsertedEvent> => {
     let supersedesEventId = params.supersedesEventId ?? null;
 
@@ -318,7 +318,7 @@ export async function insertEvent(
   };
 
   const insertRow = async (
-    sql: ReturnType<typeof getDb>,
+    sql: DbClient,
     supersedesEventId: number | null
   ): Promise<InsertedEvent> => {
     const insertWithClientId = (clientId: string | null) => sql`
@@ -454,7 +454,7 @@ export async function insertEvent(
       await tx`
         SELECT pg_advisory_xact_lock(${EVENT_DEDUP_LOCK_NAMESPACE}, ${lockKey})
       `;
-      return runInsert(tx as unknown as ReturnType<typeof getDb>);
+      return runInsert(tx);
     }) as Promise<InsertedEvent>;
   }
 
@@ -467,7 +467,7 @@ export async function insertEvent(
   // both present, and that case is already inside the advisory-lock tx above.)
   if (params.supersedesEventId != null && !options?.sql) {
     return sql.begin(async (tx) =>
-      runInsert(tx as unknown as ReturnType<typeof getDb>)
+      runInsert(tx)
     ) as Promise<InsertedEvent>;
   }
 


### PR DESCRIPTION
## What

- make merge application, run completion, and approval-event supersession one transaction
- replace volatile proposal dedupe with a canonical multi-replica idempotency key and repair legacy orphan runs
- reject cross-type merges, pre-tombstone relationship collisions, cap merge inputs, and store minimal review snapshots
- preserve source connection provenance on ACL/webhook identities and include durable event IDs in history replay

## Why

The end-to-end entity merge work in #1997 had several crash and race windows: proposal runs/events could split, approvals could half-apply, relationship repoints could hit the live unique index, and replay dedupe depended on volatile JSON snapshots. The history API also omitted the event ID the client uses as its stable approval-card key.

## Impact

No migration. The existing pending-run index remains in place for rolling-deploy compatibility, while new replicas coordinate through `runs.idempotency_key` plus a Postgres transaction advisory lock. `events` remains append-only.

## Verification

- `make review-fix`
- `make pre-pr`
- 40 focused Postgres integration tests across merge, concurrent approval dedupe, ACL provenance, and GitHub attribution
- 8 agent-history route tests
