### PR TITLE
fix: support atomic watcher template reactions

### DIFF
--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4018,7 +4018,7 @@ export type ManageWatchersData = {
      */
     template_version_id?: number;
     /**
-     * [set_reaction_script] TypeScript source for automated reaction. Set to empty string to remove.
+     * [create/set_reaction_script] TypeScript source for automated reaction. Create compiles and stores it atomically; set to empty string to remove with set_reaction_script.
      */
     reaction_script?: string;
     /**

--- a/packages/client/src/generated/types.gen.ts
+++ b/packages/client/src/generated/types.gen.ts
@@ -4018,7 +4018,7 @@ export type ManageWatchersData = {
      */
     template_version_id?: number;
     /**
-     * [create/set_reaction_script] TypeScript source for automated reaction. Create compiles and stores it atomically; set to empty string to remove with set_reaction_script.
+     * [create/set_reaction_script] TypeScript source for an automated reaction. On create, it is compiled before the watcher and its reaction fields are stored in one transaction. Pass an empty string to set_reaction_script to remove an existing script.
      */
     reaction_script?: string;
     /**

--- a/packages/core/src/contracts/tools/manage-watchers.ts
+++ b/packages/core/src/contracts/tools/manage-watchers.ts
@@ -373,11 +373,11 @@ export const ManageWatchersSchema = Type.Object({
     })
   ),
 
-  // Fields for action="set_reaction_script"
+  // Fields for action="create" / "set_reaction_script"
   reaction_script: Type.Optional(
     Type.String({
       description:
-        "[set_reaction_script] TypeScript source for automated reaction. Set to empty string to remove.",
+        "[create/set_reaction_script] TypeScript source for automated reaction. Create compiles and stores it atomically; set to empty string to remove with set_reaction_script.",
     })
   ),
 

--- a/packages/core/src/contracts/tools/manage-watchers.ts
+++ b/packages/core/src/contracts/tools/manage-watchers.ts
@@ -377,7 +377,7 @@ export const ManageWatchersSchema = Type.Object({
   reaction_script: Type.Optional(
     Type.String({
       description:
-        "[create/set_reaction_script] TypeScript source for automated reaction. Create compiles and stores it atomically; set to empty string to remove with set_reaction_script.",
+        "[create/set_reaction_script] TypeScript source for an automated reaction. On create, it is compiled before the watcher and its reaction fields are stored in one transaction. Pass an empty string to set_reaction_script to remove an existing script.",
     })
   ),
 

--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -22,7 +22,6 @@ describe('watcher CRUD', () => {
   let entityId: number;
   let agentId: string;
   let ownerOrgId: string;
-  let ownerUserId: string;
   let otherOrgId: string;
   let otherUserId: string;
 
@@ -32,7 +31,6 @@ describe('watcher CRUD', () => {
     const user = await createTestUser({ email: 'watcher-owner@test.com' });
     await addUserToOrganization(user.id, org.id, 'owner');
     ownerOrgId = org.id;
-    ownerUserId = user.id;
     owner = await TestApiClient.for({
       organizationId: org.id,
       userId: user.id,
@@ -88,6 +86,49 @@ describe('watcher CRUD', () => {
       watchers?: Array<{ watcher_id: string }>;
     };
     expect(list.watchers?.some((w) => w.watcher_id === watcherId)).toBe(false);
+  });
+
+  it('creates a watcher and its reaction contract atomically', async () => {
+    const sql = getTestDb();
+    const reaction = `export const input = { type: "object", properties: { merge_proposals: { type: "array" } }, required: ["merge_proposals"] }; export default async function () {}`;
+    const created = (await owner.watchers.create({
+      slug: 'atomic-reaction-watcher',
+      name: 'Atomic Reaction Watcher',
+      prompt: 'Return merge proposals.',
+      agent_id: agentId,
+      reaction_script: reaction,
+    })) as { watcher_id: string };
+
+    const [row] = await sql<{
+      reaction_script: string | null;
+      reaction_script_compiled: string | null;
+      reaction_input_schema: Record<string, unknown> | null;
+    }[]>`
+      SELECT reaction_script, reaction_script_compiled, reaction_input_schema
+      FROM watchers WHERE id = ${created.watcher_id}
+    `;
+    expect(row?.reaction_script).toBe(reaction);
+    expect(row?.reaction_script_compiled).toContain('merge_proposals');
+    expect(row?.reaction_input_schema).toMatchObject({
+      required: ['merge_proposals'],
+    });
+  });
+
+  it('does not create a watcher when its reaction fails compilation', async () => {
+    await expect(
+      owner.watchers.create({
+        slug: 'invalid-reaction-watcher',
+        name: 'Invalid Reaction Watcher',
+        prompt: 'Return merge proposals.',
+        agent_id: agentId,
+        reaction_script: 'export default async function reaction() {',
+      })
+    ).rejects.toThrow();
+
+    const [row] = await getTestDb()<{ id: number }[]>`
+      SELECT id FROM watchers WHERE slug = 'invalid-reaction-watcher'
+    `;
+    expect(row).toBeUndefined();
   });
 
   it('concurrent creates of the same slug: one wins, every loser gets the coded 409 (not raw 23505)', async () => {

--- a/packages/server/src/sandbox/namespaces/watchers.ts
+++ b/packages/server/src/sandbox/namespaces/watchers.ts
@@ -68,6 +68,7 @@ export interface WatcherCreateInput {
 	keying_config?: Record<string, unknown>;
 	classifiers?: Record<string, unknown>;
 	reactions_guidance?: string;
+	reaction_script?: string;
 	agent_id?: string;
 	scheduler_client_id?: string;
 	model_config?: Record<string, unknown>;

--- a/packages/server/src/tools/admin/manage_watchers/crud.ts
+++ b/packages/server/src/tools/admin/manage_watchers/crud.ts
@@ -43,6 +43,10 @@ import {
   extractSourcesFromPromptTokens,
   mergePromptSources,
 } from '../../../watchers/source-refs';
+import {
+  compileReactionScript,
+  extractReactionInputSchema,
+} from '../../../watchers/reaction-executor';
 
 // ============================================
 // handleCreate
@@ -190,6 +194,14 @@ export async function handleCreate(
     );
   }
 
+  const reactionScript = args.reaction_script?.trim() ? args.reaction_script : null;
+  const reactionScriptCompiled = reactionScript
+    ? await compileReactionScript(reactionScript)
+    : null;
+  const reactionInputSchema = reactionScript
+    ? await extractReactionInputSchema(reactionScript)
+    : null;
+
   const createdBy = ctx.userId ?? 'system';
 
   // Allocated inside the transaction below: getNextNumericId relies on
@@ -218,7 +230,8 @@ export async function handleCreate(
         watcher_group_id,
         device_worker_id, agent_kind,
         notification_channel, notification_priority, min_cooldown_seconds,
-        execution_config
+        execution_config,
+        reaction_script, reaction_script_compiled, reaction_input_schema
       ) VALUES (
         ${watcherId}, ${args.name ?? args.slug}, ${args.slug}, ${organizationId},
         ${`{${entityIdsArray.join(',')}}`}::bigint[],
@@ -232,11 +245,15 @@ export async function handleCreate(
         ${args.notification_channel ?? 'canvas'},
         ${args.notification_priority ?? 'normal'},
         ${args.min_cooldown_seconds ?? 0},
-        ${toJsonParam(tx, args.execution_config)}
+        ${toJsonParam(tx, args.execution_config)},
+        ${reactionScript}, ${reactionScriptCompiled},
+        ${reactionInputSchema ? tx.json(reactionInputSchema) : null}
       )
     `;
 
     // 2. Create watcher_versions row (v1)
+    // Reaction fields are group-shared and unversioned, so they live only on
+    // watchers and are omitted from watcher_versions.
     await tx`
       INSERT INTO watcher_versions (
         id, watcher_id, version, name, description,
@@ -340,6 +357,8 @@ export async function handleCreate(
         keying_config: keyingConfig ?? null,
         classifiers: classifiers ?? null,
         reactions_guidance: args.reactions_guidance ?? null,
+        reaction_script: reactionScript,
+        reaction_input_schema: reactionInputSchema ?? null,
       },
     });
   }

--- a/packages/server/src/utils/watcher-extraction-schema.ts
+++ b/packages/server/src/utils/watcher-extraction-schema.ts
@@ -90,9 +90,9 @@ export function wrapMetadataSchemaAtPath(
  *  1. Entity-typed (`keying_config.entity_type`) → the type's `metadata_schema`
  *     wrapped as an array at `entity_path`.
  *  2. Reaction watcher → the reaction's exported `input` schema, cached on
- *     `watchers.reaction_input_schema` at set_reaction_script time. This is how
- *     "the reaction owns the schema" reaches the worker: the device extracts
- *     against exactly what the reaction will `Value.Parse`.
+ *     `watchers.reaction_input_schema` when the watcher is created or its script
+ *     is set. This is how "the reaction owns the schema" reaches the worker:
+ *     the device extracts against exactly what the reaction will `Value.Parse`.
  *  3. Otherwise null — the worker runs the free-form `{ summary }` fallback.
  *
  * Both the worker payload and complete_window validation resolve through here,

--- a/packages/server/src/watchers/reaction-executor.ts
+++ b/packages/server/src/watchers/reaction-executor.ts
@@ -109,14 +109,6 @@ export async function executeReaction(options: ExecuteReactionOptions): Promise<
 }
 
 /**
- * Compile a TypeScript reaction script to JavaScript using esbuild.
- *
- * Stays exported because `manage_watchers.set_reaction_script` calls it at
- * save time to surface compile errors back to the agent. Run-time compile
- * also happens inside `runScript` itself; this is a fast-path for
- * pre-validation.
- */
-/**
  * Extract a reaction's exported `input` schema (a TypeBox schema, i.e. plain
  * JSON Schema) by loading the compiled module in the isolate WITHOUT invoking
  * its handler. This is how the watcher's extraction contract is derived from
@@ -149,6 +141,14 @@ export async function extractReactionInputSchema(
     : null;
 }
 
+/**
+ * Compile a TypeScript reaction script to JavaScript using esbuild.
+ *
+ * Stays exported because `manage_watchers` create and set_reaction_script call
+ * it at save time to surface compile errors back to the agent. Run-time compile
+ * also happens inside `runScript` itself; this is a fast-path for
+ * pre-validation.
+ */
 export async function compileReactionScript(source: string): Promise<string> {
   // Match `runScript`'s execute-time esbuild config exactly so save-time and
   // runtime accept the same set of imports. Drift here used to externalize


### PR DESCRIPTION
## Summary
- advance Owletto through watcher catalog/template changes
- make `manage_watchers.create` compile reaction code before persistence, then store the watcher, reaction source, compiled code, and input schema in one transaction
- expose `reaction_script` consistently through server, sandbox, and generated client contracts
- cover successful persistence and failed-compilation rollback

## Test plan
- watcher CRUD integration suite: 24/24
- focused Owletto template-create regression: 1/1
- `make pre-pr`
- `make review-fix`

## Notes
Watcher creation now owns its complete initial state. Catalog templates use one create request, so compilation failures cannot leave a partially created watcher or require a non-idempotent second call.

Owletto regression coverage: lobu-ai/owletto#509