### PR TITLE
test(gateway): isolate worker token encryption key

### DIFF
--- a/packages/server/src/gateway/__tests__/runjobtoken-connectionid.test.ts
+++ b/packages/server/src/gateway/__tests__/runjobtoken-connectionid.test.ts
@@ -1,6 +1,26 @@
-import { describe, expect, test } from "bun:test";
-import { generateWorkerToken, verifyWorkerToken } from "@lobu/core";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  __resetEncryptionKeyCacheForTests,
+  generateWorkerToken,
+  verifyWorkerToken,
+} from "@lobu/core";
 import { assertRoutableInteraction } from "../interactions.js";
+
+const TEST_ENCRYPTION_KEY =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+let previousEncryptionKey: string | undefined;
+beforeEach(() => {
+  previousEncryptionKey = process.env.ENCRYPTION_KEY;
+  process.env.ENCRYPTION_KEY = TEST_ENCRYPTION_KEY;
+  __resetEncryptionKeyCacheForTests();
+});
+
+afterEach(() => {
+  if (previousEncryptionKey === undefined) delete process.env.ENCRYPTION_KEY;
+  else process.env.ENCRYPTION_KEY = previousEncryptionKey;
+  __resetEncryptionKeyCacheForTests();
+});
 
 /**
  * Regression for the prod incident where every chat-platform `ask_user`


### PR DESCRIPTION
## Summary

- make the run-job-token regression test own its encryption environment
- reset the process-wide encryption-key cache before and after each test
- remove order-dependent coupling to sibling gateway suites

## Test plan

- red: `ENCRYPTION_KEY= bun test packages/server/src/gateway/__tests__/runjobtoken-connectionid.test.ts` failed 2/3 before the fix
- green: the same command passes 3/3 after the fix
- shared process: worker auth + run-job-token files pass 28/28
- `make pre-pr`

## Notes

Split from the automatic fix proposed on #2001 so the Owletto pointer bump remains one concern.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test consistency by standardizing encryption settings and resetting cached state between runs.
  * Preserved regression coverage for job tokens with and without connection identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->