### PR TITLE
Fix source-only watcher dispatch

### DIFF
--- a/packages/server/src/__tests__/unit/watchers/automation-dispatch-message.test.ts
+++ b/packages/server/src/__tests__/unit/watchers/automation-dispatch-message.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildDispatchMessage } from "../../../watchers/automation";
+
+describe("watcher dispatch message", () => {
+	it("instructs the agent to analyze source results when event content is empty", () => {
+		const message = buildDispatchMessage({
+			watcherId: 13,
+			runId: 647146,
+			agentId: "personal-agent",
+			sessionAgentId: "personal-agent_watcher_13_run_647146",
+			payload: {
+				watcher_id: 13,
+				agent_id: "personal-agent",
+				window_start: "2026-07-15T00:00:00.000Z",
+				window_end: "2026-07-16T00:00:00.000Z",
+				dispatch_source: "manual",
+			},
+		});
+
+		expect(message).toContain(
+			"Analyze every source result in the knowledge-read payload's `sources` field, even when its `content` array is empty.",
+		);
+		expect(message).toContain(
+			"Treat the watcher as having no data only when `content` and every array in `sources` are empty.",
+		);
+		expect(message).not.toContain(
+			"If there is no content, do not fabricate results.",
+		);
+	});
+});

--- a/packages/server/src/watchers/automation.ts
+++ b/packages/server/src/watchers/automation.ts
@@ -808,7 +808,7 @@ export async function runWatcherAutomationTick(
 	};
 }
 
-function buildDispatchMessage(params: {
+export function buildDispatchMessage(params: {
 	watcherId: number;
 	runId: number;
 	agentId: string;
@@ -840,7 +840,7 @@ function buildDispatchMessage(params: {
 		"",
 		"Required steps:",
 		`1. Call query_sdk with a script that runs client.knowledge.read({ watcher_id: ${params.watcherId}, since: "${readKnowledgeSince}", until: "${readKnowledgeUntil}"${params.payload.version_id != null ? `, template_version_id: ${params.payload.version_id}` : ""} }).`,
-		"2. Analyze the returned content using prompt_rendered and extraction_schema.",
+		"2. Analyze the returned payload using prompt_rendered and extraction_schema.",
 		`3. Call run_sdk with a script that runs client.watchers.completeWindow({ window_token, extracted_data, watcher_run_id: ${params.runId}${params.payload.version_id != null ? `, template_version_id: ${params.payload.version_id}` : ""} }) using the window_token from step 1.`,
 		"4. Include this run_metadata object in complete_window exactly, and add any extra provider/job fields you know:",
 		JSON.stringify(
@@ -855,7 +855,8 @@ function buildDispatchMessage(params: {
 			2,
 		),
 		"",
-		"If there is no content, do not fabricate results.",
+		"Analyze every source result in the knowledge-read payload's `sources` field, even when its `content` array is empty.",
+		"Treat the watcher as having no data only when `content` and every array in `sources` are empty. In that case, do not fabricate results.",
 	].join("\n");
 }
 


### PR DESCRIPTION
## What changed

- Tell watcher agents to analyze every array under `sources` even when event `content` is empty.
- Treat a watcher as having no data only when both `content` and all source arrays are empty.
- Add a regression test for the generated dispatch contract.

## Root cause

The global dispatcher said “If there is no content, do not fabricate results.” Source-backed watchers can legitimately return zero event content and non-empty context rows, so agents discarded real source data and completed with empty extraction arrays.

## Validation

- Focused regression: red → green
- Source watcher integration: 10/10
- `make pre-pr`
- xhigh review: 89 bug-free, 96 simplicity, 0 slop, 0 blockers

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automation watcher processing to analyze all returned source results, including sources with empty content arrays.
  - Watchers are now identified as having no data only when both content and all source results are empty.
  - Updated dispatch instructions to use the returned payload and extraction schema more accurately, preventing unsupported result fabrication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->