### PR TITLE
Make duplicate watcher approvals deterministic

### DIFF
--- a/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
+++ b/packages/server/src/__tests__/integration/watchers/watchers-crud.test.ts
@@ -120,17 +120,18 @@ describe('watcher CRUD', () => {
   });
 
   it('executes an installed merge reaction and queues exactly one pending, unapplied approval with watcher/window attribution', async () => {
-    // The atomic test above proves INSTALLATION (compile + store). This proves the
-    // rest of the contract the PR claims: the installed compiled reaction, run
-    // through executeReaction, submits its proposal via client.entities.manage and
-    // produces exactly ONE pending, unapplied merge approval attributed to the
-    // acting watcher AND window. Uses the shipped duplicate-merge template so the
-    // real reaction the catalog serves is what gets executed.
     const sql = getTestDb();
 
-    // Two duplicate person entities: the reaction proposes folding loser into winner.
+    // Three people form one exact-identity component (winner ↔ bridge by email,
+    // bridge ↔ loser by phone), proving grouping does not depend on model output.
     const winner = await createTestEntity({
       name: 'Reaction Merge Winner',
+      entity_type: 'person',
+      organization_id: ownerOrgId,
+      created_by: ownerUserId,
+    });
+    const bridge = await createTestEntity({
+      name: 'Reaction Merge Bridge',
       entity_type: 'person',
       organization_id: ownerOrgId,
       created_by: ownerUserId,
@@ -141,18 +142,26 @@ describe('watcher CRUD', () => {
       organization_id: ownerOrgId,
       created_by: ownerUserId,
     });
+    await sql`
+      UPDATE entities
+      SET metadata = CASE id
+        WHEN ${winner.id} THEN ${sql.json({ email: 'shared@test.example', phone: '+44 7700 900001', handle: 'winner' })}
+        WHEN ${bridge.id} THEN ${sql.json({ email: 'shared@test.example', phone: '+44 7700 900002' })}
+        WHEN ${loser.id} THEN ${sql.json({ phone: '+44 7700 900002' })}
+      END
+      WHERE id IN (${winner.id}, ${bridge.id}, ${loser.id})
+    `;
 
     const template = WATCHER_CATALOG_TEMPLATES.find((t) => t.id === 'duplicate-merge');
-    const reactionScript = template?.detail.reaction_script as string;
-    expect(reactionScript).toContain('client.entities.manage');
+    if (!template) throw new Error('duplicate-merge watcher template is missing');
+    const reactionScript = String(template.detail.reaction_script);
 
-    // Install the reaction on a real watcher (real agent → its owning-agent
-    // envelope resolves, so the watcher merge queues rather than being denied).
     const created = (await owner.watchers.create({
       slug: 'reaction-merge-exec-watcher',
       name: 'Reaction Merge Exec Watcher',
       prompt: 'Find and merge duplicate people.',
       agent_id: agentId,
+      sources: template.detail.sources,
       reaction_script: reactionScript,
     })) as { watcher_id: string };
     const watcherId = Number(created.watcher_id);
@@ -162,21 +171,12 @@ describe('watcher CRUD', () => {
     `;
     expect(installed?.reaction_script_compiled).toBeTruthy();
 
-    // Execute the INSTALLED compiled reaction. executeReaction stamps the acting
-    // watcher + window from context.window, so the queued approval inherits both.
     const windowId = 987654;
     const res = await executeReaction({
       compiledScript: installed?.reaction_script_compiled as string,
       context: {
         extracted_data: {
-          merge_proposals: [
-            {
-              winner_entity_id: winner.id,
-              duplicate_entity_ids: [loser.id],
-              merge_evidence: [{ kind: 'email', identifier: 'dup@example.com' }],
-              rationale: 'Same person captured from two sources.',
-            },
-          ],
+          analysis_summary: 'The source contains one exact-identity component.',
           uncertain_groups: [],
         },
         entities: [],
@@ -196,13 +196,14 @@ describe('watcher CRUD', () => {
         },
         organization_id: ownerOrgId,
       } as never,
-      env: process.env as Record<string, string | undefined>,
+      env: {
+        ...process.env,
+        JWT_SECRET: 'test-jwt-secret-for-testing-only',
+      } as Record<string, string | undefined>,
     });
     expect(res.error ?? null).toBeNull();
     expect(res.success).toBe(true);
 
-    // Exactly ONE pending merge approval for this proposal, attributed to the
-    // acting watcher AND window.
     const pending = await sql<
       {
         watcher_id: number | null;
@@ -224,14 +225,31 @@ describe('watcher CRUD', () => {
     expect(pending[0].approval_status).toBe('pending');
     expect(pending[0].status).toBe('pending');
 
-    // Unapplied before approval: the loser stays live and unmerged.
-    const [loserRow] = await sql<
-      { merged_into: number | null; deleted_at: string | null }[]
-    >`
-      SELECT merged_into, deleted_at FROM entities WHERE id = ${loser.id}
+    const [pendingInput] = await sql<{ entity_ids: number[] }[]>`
+      SELECT action_input->'entity_ids' AS entity_ids
+      FROM runs
+      WHERE organization_id = ${ownerOrgId}
+        AND run_type = 'internal'
+        AND action_input->>'operation' = 'merge'
+        AND action_input->>'winner_entity_id' = ${String(winner.id)}
     `;
-    expect(loserRow.merged_into).toBeNull();
-    expect(loserRow.deleted_at).toBeNull();
+    expect(pendingInput.entity_ids.map(Number).sort((a, b) => a - b)).toEqual(
+      [bridge.id, loser.id].sort((a, b) => a - b)
+    );
+
+    const duplicateRows = await sql<
+      { id: number; merged_into: number | null; deleted_at: string | null }[]
+    >`
+      SELECT id, merged_into, deleted_at
+      FROM entities
+      WHERE id IN (${bridge.id}, ${loser.id})
+      ORDER BY id
+    `;
+    expect(duplicateRows.map((row) => Number(row.id))).toEqual(
+      [bridge.id, loser.id].sort((a, b) => a - b)
+    );
+    expect(duplicateRows.every((row) => row.merged_into === null)).toBe(true);
+    expect(duplicateRows.every((row) => row.deleted_at === null)).toBe(true);
 
     await owner.watchers.delete({ watcher_ids: [created.watcher_id] });
   });

--- a/packages/server/src/catalog/watcher-templates.test.ts
+++ b/packages/server/src/catalog/watcher-templates.test.ts
@@ -103,6 +103,27 @@ describe("duplicate merge watcher template", () => {
 		]);
 	});
 
+	it("never infers merge evidence from unnamespaced aliases or handles", async () => {
+		const calls = await runDuplicateMergeReaction([
+			{
+				id: 1,
+				metadata: {
+					aliases: ["1234567", "@shared", "shared@example.com"],
+					handle: "shared",
+				},
+			},
+			{
+				id: 2,
+				metadata: {
+					aliases: ["1234567", "@shared", "shared@example.com"],
+					handle: "shared",
+				},
+			},
+		]);
+
+		expect(calls).toEqual([]);
+	});
+
 	it("produces the same proposal regardless of source row order", async () => {
 		const people = [
 			{

--- a/packages/server/src/catalog/watcher-templates.test.ts
+++ b/packages/server/src/catalog/watcher-templates.test.ts
@@ -1,57 +1,187 @@
 import { describe, expect, it } from "vitest";
+import type { ClientSDK } from "../sandbox/client-sdk";
+import { runScript } from "../sandbox/run-script";
 import {
 	compileReactionScript,
 	extractReactionInputSchema,
 } from "../watchers/reaction-executor";
 import { WATCHER_CATALOG_TEMPLATES } from "./watcher-templates";
 
-describe("duplicate merge watcher template", () => {
-	it("creates one approval-gated merge proposal per duplicate group", () => {
-		const template = WATCHER_CATALOG_TEMPLATES.find(
-			(entry) => entry.id === "duplicate-merge",
-		);
-		const prompt = String(template?.detail?.prompt ?? "");
-		const reaction = String(template?.detail?.reaction_script ?? "");
+const duplicateMergeTemplate = WATCHER_CATALOG_TEMPLATES.find(
+	(entry) => entry.id === "duplicate-merge",
+);
+if (!duplicateMergeTemplate) {
+	throw new Error("duplicate-merge watcher template is missing");
+}
+const duplicateMergeReaction = String(
+	duplicateMergeTemplate.detail.reaction_script,
+);
 
-		expect(prompt).toContain("duplicate_entity_ids");
-		expect(prompt).toContain("merge_evidence");
+async function executeDuplicateMergeReaction(
+	people: Array<{ id: number; metadata: Record<string, unknown> }>,
+): Promise<{
+	calls: Record<string, unknown>[];
+	result: Awaited<ReturnType<typeof runScript>>;
+}> {
+	const calls: Record<string, unknown>[] = [];
+	const sdk = {
+		knowledge: {
+			read: async () => ({ sources: { people } }),
+		},
+		entities: {
+			manage: async (input: Record<string, unknown>) => {
+				calls.push(input);
+				return { approval_queued: true };
+			},
+		},
+	} as unknown as ClientSDK;
+	const result = await runScript({
+		source: duplicateMergeReaction,
+		sdk,
+		context: {
+			window: {
+				watcher_id: 7,
+				window_start: "2026-01-01T00:00:00.000Z",
+				window_end: "2026-01-02T00:00:00.000Z",
+			},
+		},
+	});
+	return { calls, result };
+}
+
+async function runDuplicateMergeReaction(
+	people: Array<{ id: number; metadata: Record<string, unknown> }>,
+): Promise<Record<string, unknown>[]> {
+	const { calls, result } = await executeDuplicateMergeReaction(people);
+	expect(result.error ?? null).toBeNull();
+	expect(result.success).toBe(true);
+	return calls;
+}
+
+describe("duplicate merge watcher template", () => {
+	it("keeps model output explanatory and approval-gated", () => {
+		const prompt = String(duplicateMergeTemplate.detail.prompt);
+
+		expect(prompt).toContain("analysis_summary");
 		expect(prompt).toContain("pending human approval");
-		expect(prompt).toContain("Never emit textual backlog tasks");
-		expect(prompt).not.toContain("call manage_entity");
-		expect(reaction).toContain("client.entities.manage");
-		expect(reaction).toContain('action: "merge"');
+		expect(prompt).toContain("Do not call entity tools or emit backlog tasks");
 	});
 
 	it("ships a reaction script that compiles in the watcher runtime", async () => {
-		const template = WATCHER_CATALOG_TEMPLATES.find(
-			(entry) => entry.id === "duplicate-merge",
-		);
-
 		await expect(
-			compileReactionScript(String(template?.detail?.reaction_script ?? "")),
-		).resolves.toContain("client.entities.manage");
+			compileReactionScript(duplicateMergeReaction),
+		).resolves.toBeTruthy();
 	});
 
-	it("declares the extraction contract consumed by the reaction", async () => {
-		const template = WATCHER_CATALOG_TEMPLATES.find(
-			(entry) => entry.id === "duplicate-merge",
-		);
-		const schema = await extractReactionInputSchema(
-			String(template?.detail?.reaction_script ?? ""),
-		);
+	it("declares the model's explanatory extraction contract", async () => {
+		const schema = await extractReactionInputSchema(duplicateMergeReaction);
 
-		expect(schema?.required).toEqual(["merge_proposals", "uncertain_groups"]);
+		expect(schema?.required).toEqual(["analysis_summary", "uncertain_groups"]);
 		expect(schema).toMatchObject({
 			properties: {
-				merge_proposals: {
-					items: {
-						properties: {
-							winner_entity_id: { type: "integer" },
-							duplicate_entity_ids: { items: { type: "integer" } },
-						},
-					},
-				},
+				analysis_summary: { type: "string" },
+				uncertain_groups: { type: "array" },
 			},
 		});
+	});
+
+	it("normalizes valid identities without merging malformed metadata", async () => {
+		const calls = await runDuplicateMergeReaction([
+			{ id: 1, metadata: { email: "not-an-email", phone: "call 1234567" } },
+			{ id: 2, metadata: { email: "not-an-email", phone: "call 1234567" } },
+			{ id: 3, metadata: { email: " Person@Example.com " } },
+			{ id: 4, metadata: { emails: ["person@example.com"] } },
+		]);
+
+		expect(calls).toEqual([
+			{
+				action: "merge",
+				winner_entity_id: 3,
+				duplicate_entity_ids: [4],
+				merge_evidence: [{ kind: "email", identifier: "person@example.com" }],
+			},
+		]);
+	});
+
+	it("produces the same proposal regardless of source row order", async () => {
+		const people = [
+			{
+				id: 1,
+				metadata: { email: "cycle@example.com", phone: "111 111 1111" },
+			},
+			{
+				id: 2,
+				metadata: { email: "cycle@example.com", phone: "222 222 2222" },
+			},
+			{ id: 3, metadata: { phones: ["111 111 1111", "222 222 2222"] } },
+		];
+		const forward = await runDuplicateMergeReaction(people);
+		const reverse = await runDuplicateMergeReaction([...people].reverse());
+
+		expect(reverse).toEqual(forward);
+		expect(forward[0].merge_evidence).toEqual([
+			{ kind: "email", identifier: "cycle@example.com" },
+			{ kind: "phone", identifier: "1111111111" },
+		]);
+	});
+
+	it("uses bounded evidence that connects every proposed duplicate", async () => {
+		const redundantEmails = Array.from(
+			{ length: 26 },
+			(_, index) => `shared-${index}@example.com`,
+		);
+		const calls = await runDuplicateMergeReaction([
+			{ id: 1, metadata: { emails: redundantEmails } },
+			{
+				id: 2,
+				metadata: {
+					emails: [...redundantEmails, "zzz-bridge@example.com"],
+				},
+			},
+			{ id: 3, metadata: { email: "zzz-bridge@example.com" } },
+		]);
+
+		expect(calls[0].merge_evidence).toEqual([
+			{ kind: "email", identifier: "shared-0@example.com" },
+			{ kind: "email", identifier: "zzz-bridge@example.com" },
+		]);
+	});
+
+	it("stays within merge entity limits", async () => {
+		const eligible = await runDuplicateMergeReaction(
+			Array.from({ length: 26 }, (_, index) => ({
+				id: index + 1,
+				metadata: { email: "group@example.com" },
+			})),
+		);
+		expect(eligible).toHaveLength(1);
+		expect(eligible[0].duplicate_entity_ids).toHaveLength(25);
+		expect(eligible[0].merge_evidence).toHaveLength(1);
+
+		const oversized = await runDuplicateMergeReaction(
+			Array.from({ length: 27 }, (_, index) => ({
+				id: index + 1,
+				metadata: { email: "oversized@example.com" },
+			})),
+		);
+		expect(oversized).toEqual([]);
+	});
+
+	it("fails before queuing partial approvals when the SDK call budget is too small", async () => {
+		const people = Array.from({ length: 400 }, (_, index) => ({
+			id: index + 1,
+			metadata: { email: `group-${Math.floor(index / 2)}@example.com` },
+		}));
+		const atLimit = await executeDuplicateMergeReaction(people.slice(0, 398));
+		expect(atLimit.result.success).toBe(true);
+		expect(atLimit.calls).toHaveLength(199);
+
+		const { calls, result } = await executeDuplicateMergeReaction(people);
+
+		expect(result.success).toBe(false);
+		expect(result.error?.message).toContain(
+			"More than 199 identity components need merging",
+		);
+		expect(calls).toEqual([]);
 	});
 });

--- a/packages/server/src/catalog/watcher-templates.test.ts
+++ b/packages/server/src/catalog/watcher-templates.test.ts
@@ -103,6 +103,21 @@ describe("duplicate merge watcher template", () => {
 		]);
 	});
 
+	it("rejects structurally malformed emails as merge evidence", async () => {
+		const malformed = [
+			"person@.example.com",
+			"person@example..com",
+			"person@example.com.",
+		];
+		for (const email of malformed) {
+			const calls = await runDuplicateMergeReaction([
+				{ id: 1, metadata: { email } },
+				{ id: 2, metadata: { email } },
+			]);
+			expect(calls).toEqual([]);
+		}
+	});
+
 	it("never infers merge evidence from unnamespaced aliases or handles", async () => {
 		const calls = await runDuplicateMergeReaction([
 			{

--- a/packages/server/src/catalog/watcher-templates.ts
+++ b/packages/server/src/catalog/watcher-templates.ts
@@ -124,10 +124,12 @@ function normalizeIdentity(kind, value) {
 		return digits.length >= 7 && digits.length <= 15 ? digits : null;
 	}
 	const email = trimmed.toLowerCase();
-	const at = email.indexOf("@");
-	if (email.length > 512 || at <= 0 || at === email.length - 1) return null;
-	if (email.indexOf("@", at + 1) !== -1 || /\\s/.test(email)) return null;
-	return email.slice(at + 1).includes(".") ? email : null;
+	if (email.length > 512) return null;
+	// Require a dot-atom local part and dot-separated domain labels so malformed
+	// values (empty labels, leading/trailing/consecutive dots, multiple "@",
+	// whitespace) cannot be used as deterministic merge evidence.
+	if (!/^[a-z0-9_%+-]+(?:\\.[a-z0-9_%+-]+)*@[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$/.test(email)) return null;
+	return email;
 }
 
 function entityIdentities(entity) {

--- a/packages/server/src/catalog/watcher-templates.ts
+++ b/packages/server/src/catalog/watcher-templates.ts
@@ -96,7 +96,7 @@ export const WATCHER_CATALOG_TEMPLATES: CatalogEntry[] = [
 			// limits are left unapplied for the model to flag for manual review.
 			sources: [{ name: "people", query: "@entity:person" }],
 			prompt:
-				"Review every row in sources.people. Explain exact shared email, phone, or handle groups in analysis_summary. Put ambiguous name-only groups, identity components larger than 26 people, or a source with more than 199 mergeable components in uncertain_groups with why; name similarity alone is not merge evidence. Do not call entity tools or emit backlog tasks. The deterministic reaction independently creates one pending human approval for every exact identity component of at most 26 people. It fails before queuing approvals when more than 199 components need merging, and no merge happens before approval.\n",
+				"Review every row in sources.people. Explain exact shared email or phone groups in analysis_summary. Put name-only, alias-only, or handle-only matches, identity components larger than 26 people, and sources with more than 199 mergeable components in uncertain_groups with why. Aliases and handles lack connector namespaces here, so they are not automatic merge evidence. Do not call entity tools or emit backlog tasks. The deterministic reaction independently creates one pending human approval for every exact email or phone component of at most 26 people. It fails before queuing approvals when more than 199 components need merging, and no merge happens before approval.\n",
 			reaction_script: `export const input = {
 	type: "object",
 	properties: {
@@ -123,10 +123,6 @@ function normalizeIdentity(kind, value) {
 		const digits = trimmed.replace(/[^0-9]/g, "");
 		return digits.length >= 7 && digits.length <= 15 ? digits : null;
 	}
-	if (kind === "handle") {
-		const handle = trimmed.replace(/^@/, "").toLowerCase();
-		return handle && handle.length <= 512 && !/\\s/.test(handle) ? handle : null;
-	}
 	const email = trimmed.toLowerCase();
 	const at = email.indexOf("@");
 	if (email.length > 512 || at <= 0 || at === email.length - 1) return null;
@@ -145,14 +141,6 @@ function entityIdentities(entity) {
 	};
 	for (const value of [...asValues(metadata.email), ...asValues(metadata.emails)]) add("email", value);
 	for (const value of [...asValues(metadata.phone), ...asValues(metadata.phones)]) add("phone", value);
-	for (const value of [...asValues(metadata.handle), ...asValues(metadata.handles)]) add("handle", value);
-	for (const value of asValues(metadata.aliases)) {
-		if (typeof value !== "string") continue;
-		const trimmed = value.trim();
-		if (/^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$/.test(trimmed)) add("email", trimmed);
-		else if (trimmed.startsWith("@")) add("handle", trimmed);
-		else if (/^[+()0-9 .-]+$/.test(trimmed)) add("phone", trimmed);
-	}
 	return [...identities.values()];
 }
 
@@ -258,7 +246,7 @@ export default async function reaction(ctx, client) {
 	}
 }`,
 			reactions_guidance:
-				"Treat only exact shared email, phone, or handle values as merge evidence. Report every other possible match as uncertain rather than guessing.",
+				"Treat only exact shared email or phone values as merge evidence. Report aliases, handles, names, and every other possible match as uncertain rather than guessing.",
 			tags: ["identity", "deduplication", "world-model"],
 		},
 	},

--- a/packages/server/src/catalog/watcher-templates.ts
+++ b/packages/server/src/catalog/watcher-templates.ts
@@ -7,13 +7,12 @@ import type { CatalogEntry } from "./types";
  * "From catalog" picker can prefill the form directly — the same prefill shape
  * the "Clone existing" path uses.
  *
- * Templates stay entity-agnostic (no `sources` SQL, no entity binding): the
- * user picks the entity and schedule in the form. Output structure is governed
- * by the bound entity type (render + schema derive from it — see lobu#1533), so
- * templates express the desired output shape in the prompt rather than via an
- * inline extraction schema. Override or replace these by pointing
- * `LOBU_CATALOG_URIS` at your own `watchers.json` manifest (env wins outright —
- * there is no merge with these defaults).
+ * Most templates are entity-agnostic, so the user picks the entity and schedule
+ * in the form. Specialized templates may include portable `@` sources and a
+ * reaction script; an exported reaction input schema then governs extraction.
+ * Override or replace these by pointing `LOBU_CATALOG_URIS` at your own
+ * `watchers.json` manifest (env wins outright — there is no merge with these
+ * defaults).
  */
 export const WATCHER_CATALOG_TEMPLATES: CatalogEntry[] = [
 	{
@@ -85,67 +84,181 @@ export const WATCHER_CATALOG_TEMPLATES: CatalogEntry[] = [
 	{
 		id: "duplicate-merge",
 		name: "Duplicate entity merge",
-		version: "1.0.0",
+		version: "2.0.0",
 		description:
-			"Find entities that are the same real-world thing and fold the duplicate into the original.",
+			"Find entities that are the same real-world thing and fold duplicates into one canonical record.",
 		detail: {
 			slug: "duplicate-merge",
 			schedule: "0 3 * * *",
-			// A cross-entity watcher: its source surfaces look-alike PEOPLE (shared
-			// alias / overlapping identity value) rather than events. The reader
-			// groups candidates; the agent decides confidence and proposes each group.
-			// `@entity:person` gives the agent the candidate set + their aliases so
-			// it can reason about which pairs are truly the same.
+			// A cross-entity watcher: its source surfaces people rather than events.
+			// The model explains ambiguous cases; the reaction deterministically groups
+			// exact shared identity values. Groups beyond the merge API or reaction SDK
+			// limits are left unapplied for the model to flag for manual review.
 			sources: [{ name: "people", query: "@entity:person" }],
 			prompt:
-				"Some of these person entities may be duplicates — the SAME real-world person captured more than once (e.g. once from a chat handle, once from an email), each holding different identifiers or aliases. Group records that represent one person. Shared aliases or overlapping identity values (email, phone, handle) are strong signals; mere name similarity alone is NOT.\n\nFor each confident group, choose the most complete record as canonical and return one item in merge_proposals with winner_entity_id, duplicate_entity_ids (every other record in that group), merge_evidence (kind and the shared identifier), and rationale. Return uncertain groups separately with why. Never emit textual backlog tasks. The deterministic reaction submits every proposal through manage_entity so each group becomes one pending human approval and no merge happens before approval.\n",
+				"Review every row in sources.people. Explain exact shared email, phone, or handle groups in analysis_summary. Put ambiguous name-only groups, identity components larger than 26 people, or a source with more than 199 mergeable components in uncertain_groups with why; name similarity alone is not merge evidence. Do not call entity tools or emit backlog tasks. The deterministic reaction independently creates one pending human approval for every exact identity component of at most 26 people. It fails before queuing approvals when more than 199 components need merging, and no merge happens before approval.\n",
 			reaction_script: `export const input = {
 	type: "object",
 	properties: {
-		merge_proposals: {
-			type: "array",
-			items: {
-				type: "object",
-				properties: {
-					winner_entity_id: { type: "integer" },
-					duplicate_entity_ids: { type: "array", items: { type: "integer" }, minItems: 1 },
-					merge_evidence: {
-						type: "array",
-						items: {
-							type: "object",
-							properties: {
-								kind: { enum: ["email", "phone", "handle", "alias"] },
-								identifier: { type: "string" },
-							},
-							required: ["kind", "identifier"],
-							additionalProperties: false,
-						},
-						minItems: 1,
-					},
-					rationale: { type: "string" },
-				},
-				required: ["winner_entity_id", "duplicate_entity_ids", "merge_evidence", "rationale"],
-				additionalProperties: false,
-			},
-		},
+		analysis_summary: { type: "string" },
 		uncertain_groups: { type: "array", items: { type: "object" } },
 	},
-	required: ["merge_proposals", "uncertain_groups"],
+	required: ["analysis_summary", "uncertain_groups"],
 	additionalProperties: false,
 };
 
+const MAX_MERGE_COMPONENTS = 199;
+
+function asValues(value) {
+	if (value == null) return [];
+	return Array.isArray(value) ? value : [value];
+}
+
+function normalizeIdentity(kind, value) {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	if (kind === "phone") {
+		if (!/^[+()0-9 .-]+$/.test(trimmed)) return null;
+		const digits = trimmed.replace(/[^0-9]/g, "");
+		return digits.length >= 7 && digits.length <= 15 ? digits : null;
+	}
+	if (kind === "handle") {
+		const handle = trimmed.replace(/^@/, "").toLowerCase();
+		return handle && handle.length <= 512 && !/\\s/.test(handle) ? handle : null;
+	}
+	const email = trimmed.toLowerCase();
+	const at = email.indexOf("@");
+	if (email.length > 512 || at <= 0 || at === email.length - 1) return null;
+	if (email.indexOf("@", at + 1) !== -1 || /\\s/.test(email)) return null;
+	return email.slice(at + 1).includes(".") ? email : null;
+}
+
+function entityIdentities(entity) {
+	const metadata = entity && typeof entity.metadata === "object" && entity.metadata
+		? entity.metadata
+		: {};
+	const identities = new Map();
+	const add = (kind, value) => {
+		const identifier = normalizeIdentity(kind, value);
+		if (identifier) identities.set(kind + ":" + identifier, { kind, identifier });
+	};
+	for (const value of [...asValues(metadata.email), ...asValues(metadata.emails)]) add("email", value);
+	for (const value of [...asValues(metadata.phone), ...asValues(metadata.phones)]) add("phone", value);
+	for (const value of [...asValues(metadata.handle), ...asValues(metadata.handles)]) add("handle", value);
+	for (const value of asValues(metadata.aliases)) {
+		if (typeof value !== "string") continue;
+		const trimmed = value.trim();
+		if (/^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$/.test(trimmed)) add("email", trimmed);
+		else if (trimmed.startsWith("@")) add("handle", trimmed);
+		else if (/^[+()0-9 .-]+$/.test(trimmed)) add("phone", trimmed);
+	}
+	return [...identities.values()];
+}
+
+function populatedFieldCount(entity) {
+	const metadata = entity && typeof entity.metadata === "object" && entity.metadata
+		? entity.metadata
+		: {};
+	return Object.values(metadata).filter((value) => {
+		if (value == null || value === "") return false;
+		return !Array.isArray(value) || value.length > 0;
+	}).length;
+}
+
 export default async function reaction(ctx, client) {
-	for (const proposal of ctx.extracted_data.merge_proposals) {
+	const since = String(ctx.window.window_start).slice(0, 10);
+	const until = new Date(new Date(ctx.window.window_end).getTime() - 1).toISOString().slice(0, 10);
+	const knowledge = await client.knowledge.read({ watcher_id: ctx.window.watcher_id, since, until });
+	const candidates = Array.isArray(knowledge?.sources?.people) ? knowledge.sources.people : [];
+	const entities = new Map();
+	const parent = new Map();
+	const ownersByIdentity = new Map();
+	const find = (id) => {
+		let root = parent.get(id);
+		while (root !== parent.get(root)) root = parent.get(root);
+		let current = id;
+		while (parent.get(current) !== root) {
+			const next = parent.get(current);
+			parent.set(current, root);
+			current = next;
+		}
+		return root;
+	};
+	const union = (left, right) => {
+		const leftRoot = find(left);
+		const rightRoot = find(right);
+		if (leftRoot === rightRoot) return false;
+		parent.set(Math.max(leftRoot, rightRoot), Math.min(leftRoot, rightRoot));
+		return true;
+	};
+
+	for (const candidate of candidates) {
+		const id = Number(candidate?.id);
+		if (!Number.isInteger(id)) continue;
+		entities.set(id, candidate);
+		parent.set(id, id);
+	}
+	for (const [id, entity] of entities) {
+		for (const identity of entityIdentities(entity)) {
+			const key = identity.kind + ":" + identity.identifier;
+			const owners = ownersByIdentity.get(key) ?? new Set();
+			owners.add(id);
+			ownersByIdentity.set(key, owners);
+		}
+	}
+	const evidenceIdentityKeys = [];
+	for (const key of [...ownersByIdentity.keys()].sort()) {
+		const owners = [...ownersByIdentity.get(key)].sort((left, right) => left - right);
+		if (owners.length < 2) continue;
+		// A spanning set proves the component while staying within the API's
+		// 25-item evidence limit for a 26-entity merge.
+		let connectsEntities = false;
+		for (let index = 1; index < owners.length; index += 1) {
+			if (union(owners[0], owners[index])) connectsEntities = true;
+		}
+		if (connectsEntities) evidenceIdentityKeys.push(key);
+	}
+
+	const components = new Map();
+	for (const [id, entity] of entities) {
+		const root = find(id);
+		const component = components.get(root) ?? [];
+		component.push(entity);
+		components.set(root, component);
+	}
+	const orderedComponents = [...components.values()]
+		.filter((component) => component.length > 1 && component.length <= 26)
+		.sort((left, right) => Math.min(...left.map((row) => Number(row.id))) - Math.min(...right.map((row) => Number(row.id))));
+	// knowledge.read consumes one of the sandbox's 200 SDK calls. Check before
+	// writes so exceeding the remaining budget cannot leave partial approvals.
+	if (orderedComponents.length > MAX_MERGE_COMPONENTS) {
+		throw new Error("More than 199 identity components need merging; no approvals were queued");
+	}
+
+	for (const component of orderedComponents) {
+		const componentRoot = find(Number(component[0].id));
+		const evidence = [];
+		for (const key of evidenceIdentityKeys) {
+			const owner = ownersByIdentity.get(key).values().next().value;
+			if (find(owner) !== componentRoot) continue;
+			const separator = key.indexOf(":");
+			evidence.push({ kind: key.slice(0, separator), identifier: key.slice(separator + 1) });
+		}
+		const ranked = [...component].sort((left, right) => {
+			const completeness = populatedFieldCount(right) - populatedFieldCount(left);
+			return completeness || Number(left.id) - Number(right.id);
+		});
 		await client.entities.manage({
 			action: "merge",
-			winner_entity_id: proposal.winner_entity_id,
-			duplicate_entity_ids: proposal.duplicate_entity_ids,
-			merge_evidence: proposal.merge_evidence,
+			winner_entity_id: Number(ranked[0].id),
+			duplicate_entity_ids: ranked.slice(1).map((entity) => Number(entity.id)),
+			merge_evidence: evidence,
 		});
 	}
 }`,
 			reactions_guidance:
-				"Only merge when the evidence is strong (a shared identity value or alias, not just a similar name). When unsure, leave the pair unmerged and report it for human review rather than guessing — a wrong merge is costly to notice.",
+				"Treat only exact shared email, phone, or handle values as merge evidence. Report every other possible match as uncertain rather than guessing.",
 			tags: ["identity", "deduplication", "world-model"],
 		},
 	},


### PR DESCRIPTION
## What changed
- make the shipped duplicate-merge reaction reread the watcher source and deterministically group exact typed email/phone identities
- keep the model explanatory only, so proposal completeness no longer depends on model enumeration
- queue one approval-gated merge per connected component without applying any merge before human approval
- reject malformed identity values, unnamespaced aliases/handles, oversized groups, and SDK-budget overflow before partial writes

## Root cause
The production watcher source was present, but the model was responsible for enumerating every merge proposal. Real runs proved that models omitted groups or invented synthetic ones. Alias values also lack connector namespaces, so they are unsafe as deterministic merge evidence.

## Verification
- red: the old reaction throws when model output contains only analysis_summary/uncertain_groups
- focused reaction runtime: 9/9 pass
- DB-backed watchers CRUD integration: 25/25 pass
- make pre-pr: pass
- make review-fix: completed on settled diff

The live buremba watcher already uses the equivalent deterministic reaction and produced three distinct pending approval runs from real entities.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lobu-ai/codesmith/lobu/pr/2004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced duplicate-merge logic to cluster and merge entities using exact shared email or phone evidence.
  * Improved handling for larger sets of related duplicates, including uncertainty-aware grouping.

* **Bug Fixes**
  * Prevented merges when evidence is malformed or derived from aliases/handles/name-only matches.
  * Ensured merge execution fails safely when processing limits are exceeded, with no partial actions queued.
  * Made merge proposal/selection behavior deterministic and stable across processing order.

* **Documentation**
  * Clarified that bundled watcher templates are overridden by a `watchers.json` manifest when provided.

* **Tests**
  * Strengthened watcher-template tests to validate real runtime reaction behavior and failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->