### PR TITLE
Explain policy-driven entity merge decisions

### DIFF
--- a/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
+++ b/packages/server/src/__tests__/integration/agent-thread-list-scope-all.test.ts
@@ -145,9 +145,9 @@ describe("listAgentThreads scope=all", () => {
 			"hello from slack",
 			"2026-06-28T02:00:00Z",
 			{
-			platform: "slack",
-			kind: "platform",
-			userId: null,
+				platform: "slack",
+				kind: "platform",
+				userId: null,
 			},
 		);
 		await insertSnapshot(
@@ -330,7 +330,9 @@ describe("listAgentThreads scope=all", () => {
 		});
 
 		expect(data.runs).toEqual([]);
-		expect(JSON.stringify(data)).not.toContain("Other agent secret watcher task");
+		expect(JSON.stringify(data)).not.toContain(
+			"Other agent secret watcher task",
+		);
 	});
 
 	it("keeps terminal approval decisions attached to their watcher run", async () => {
@@ -379,6 +381,8 @@ describe("listAgentThreads scope=all", () => {
 				action: "merge",
 				tool: "entity_change",
 				resourceKind: "entity",
+				reason:
+					"The matching email is evidence, but policy still requires review.",
 				reviewed_by_name: "Reviewer",
 			},
 		});
@@ -389,12 +393,16 @@ describe("listAgentThreads scope=all", () => {
 			watcherId: WATCHER_ID,
 			limit: 20,
 		});
-		const run = data.runs.find((candidate) => candidate.runId === watcherRun.id);
+		const run = data.runs.find(
+			(candidate) => candidate.runId === watcherRun.id,
+		);
 		expect(run?.pendingActionCount).toBe(0);
 		expect(run?.actions).toEqual([
 			expect.objectContaining({
 				runId: approvalRun.id,
 				status: "rejected",
+				reason:
+					"The matching email is evidence, but policy still requires review.",
 				reviewedByName: "Reviewer",
 			}),
 		]);
@@ -446,7 +454,9 @@ describe("listAgentThreads scope=all", () => {
 			watcherId: WATCHER_ID,
 			limit: 20,
 		});
-		const run = data.runs.find((candidate) => candidate.runId === watcherRun.id);
+		const run = data.runs.find(
+			(candidate) => candidate.runId === watcherRun.id,
+		);
 		expect(run?.task).toBe("Run without a transcript");
 		expect(run?.messages).toEqual([]);
 		expect(run?.pendingActionCount).toBe(1);

--- a/packages/server/src/entity-resolution/discovery.test.ts
+++ b/packages/server/src/entity-resolution/discovery.test.ts
@@ -91,16 +91,16 @@ describe("entity resolution module", () => {
 			{ winnerId: 1, loserIds: [2] },
 			{ winnerId: 3, loserIds: [4] },
 		]);
-		expect(
-			assessEntityResolution({
-				metadataSchema: { type: "object" },
-				entityTypeSlug: "person",
-				winner: { id: 1, metadata: { email: "same@example.com" } },
-				losers: [
-					{ id: 2, metadata: { email: " SAME@example.com " } },
-				],
-			}).decision,
-		).toBe("review");
+		const assessment = assessEntityResolution({
+			metadataSchema: { type: "object" },
+			entityTypeSlug: "person",
+			winner: { id: 1, metadata: { email: "same@example.com" } },
+			losers: [{ id: 2, metadata: { email: " SAME@example.com " } }],
+		});
+		expect(assessment.decision).toBe("review");
+		expect(assessment.reason).toBe(
+			"Matching email is evidence, but this entity type does not declare it unique enough to merge automatically.",
+		);
 	});
 
 	it("auto-merges a configured unique identity but reviews conflicting strict identities", () => {

--- a/packages/server/src/entity-resolution/discovery.test.ts
+++ b/packages/server/src/entity-resolution/discovery.test.ts
@@ -99,7 +99,7 @@ describe("entity resolution module", () => {
 		});
 		expect(assessment.decision).toBe("review");
 		expect(assessment.reason).toBe(
-			"Matching email is evidence, but this entity type does not declare it unique enough to merge automatically.",
+			"Matching email is evidence, but the proposal does not satisfy this entity type's automatic merge policy.",
 		);
 	});
 
@@ -165,6 +165,24 @@ describe("entity resolution module", () => {
 			],
 		});
 		expect(changedConflict.fingerprint).not.toBe(conflict.fingerprint);
+	});
+
+	it("explains mixed-policy groups without denying configured automatic rules", () => {
+		const mixedMatch = assessEntityResolution({
+			metadataSchema: schema,
+			winner: {
+				id: 1,
+				metadata: { email: "same@example.com", phone: "1111111" },
+			},
+			losers: [
+				{ id: 2, metadata: { email: "same@example.com" } },
+				{ id: 3, metadata: { phone: "1111111" } },
+			],
+		});
+		expect(mixedMatch.decision).toBe("review");
+		expect(mixedMatch.reason).toBe(
+			"Matching email and phone is evidence, but the proposal does not satisfy this entity type's automatic merge policy.",
+		);
 	});
 
 	it("rejects malformed email and phone values as deterministic identities", () => {

--- a/packages/server/src/entity-resolution/policy.ts
+++ b/packages/server/src/entity-resolution/policy.ts
@@ -251,7 +251,7 @@ export function assessEntityResolution(input: {
 				: conflictingAutoIdentity
 					? "Configured strict identities conflict, so a person must review the merge."
 					: deduplicatedEvidence.length > 0
-						? `Matching ${evidenceKinds.join(" and ")} is evidence, but this entity type does not declare it unique enough to merge automatically.`
+						? `Matching ${evidenceKinds.join(" and ")} is evidence, but the proposal does not satisfy this entity type's automatic merge policy.`
 						: "No configured deterministic identity rule proves this merge.",
 	};
 }

--- a/packages/server/src/entity-resolution/policy.ts
+++ b/packages/server/src/entity-resolution/policy.ts
@@ -226,6 +226,9 @@ export function assessEntityResolution(input: {
 			evidence.map((item) => [`${item.kind}\u0000${item.identifier}`, item]),
 		).values(),
 	];
+	const evidenceKinds = [
+		...new Set(deduplicatedEvidence.map((item) => item.kind)),
+	];
 	const decision =
 		allLosersHaveAutoMatch && !conflictingAutoIdentity
 			? "auto_merge"
@@ -247,6 +250,8 @@ export function assessEntityResolution(input: {
 				? "The entity type declares this normalized identity unique."
 				: conflictingAutoIdentity
 					? "Configured strict identities conflict, so a person must review the merge."
-					: "No configured deterministic identity rule proves this merge.",
+					: deduplicatedEvidence.length > 0
+						? `Matching ${evidenceKinds.join(" and ")} is evidence, but this entity type does not declare it unique enough to merge automatically.`
+						: "No configured deterministic identity rule proves this merge.",
 	};
 }

--- a/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
+++ b/packages/server/src/gateway/__tests__/agent-history-routes.test.ts
@@ -9,8 +9,8 @@ import {
 import { Hono } from "hono";
 import { getDb } from "../../db/client.js";
 import { orgContext } from "../../lobu/stores/org-context.js";
-import { insertEvent } from "../../utils/insert-event.js";
 import { createPostgresAgentConfigStore } from "../../lobu/stores/postgres-stores.js";
+import { insertEvent } from "../../utils/insert-event.js";
 import { AgentMetadataStore } from "../auth/agent-metadata-store.js";
 import { UserAgentsStore } from "../auth/user-agents-store.js";
 import { createAgentHistoryRoutes } from "../routes/public/agent-history.js";
@@ -217,6 +217,7 @@ describe("agent history routes", () => {
 		});
 		const fields = { "metadata.tier": "enterprise" };
 		const current = { "metadata.tier": "free" };
+		const reason = "The CRM tier differs from the human-owned value.";
 		await orgContext.run({ organizationId: ORG_ID }, () =>
 			insertEvent({
 				entityIds: [],
@@ -237,6 +238,7 @@ describe("agent history routes", () => {
 					fields,
 					current,
 					attribution: "agent",
+					reason,
 					status: "pending_approval",
 					run_id: runId,
 				},
@@ -258,6 +260,7 @@ describe("agent history routes", () => {
 				fields: Record<string, unknown> | null;
 				current: Record<string, unknown> | null;
 				attribution: string | null;
+				reason: string | null;
 			}>;
 		};
 		expect(body.interactions).toHaveLength(1);
@@ -268,6 +271,7 @@ describe("agent history routes", () => {
 		expect(card?.fields).toMatchObject({ "metadata.tier": "enterprise" });
 		expect(card?.current).toMatchObject({ "metadata.tier": "free" });
 		expect(card?.attribution).toBe("agent");
+		expect(card?.reason).toBe(reason);
 	});
 
 	test("replays only the latest terminal agent error and clears it after success", async () => {

--- a/packages/server/src/gateway/routes/public/agent-history.ts
+++ b/packages/server/src/gateway/routes/public/agent-history.ts
@@ -18,10 +18,9 @@ import {
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { getDb } from "../../../db/client.js";
-import { buildApiConversationId } from "../../services/api-conversation-id.js";
-import type { ArtifactStore } from "../../files/artifact-store.js";
 import { resolveOrgId } from "../../../lobu/stores/org-context.js";
 import type { UserAgentsStore } from "../../auth/user-agents-store.js";
+import type { ArtifactStore } from "../../files/artifact-store.js";
 import type { WorkerConnectionManager } from "../../gateway/connection-manager.js";
 import {
 	isConversationVisible,
@@ -30,6 +29,7 @@ import {
 	readThreadMessages,
 	resolveChannelVisibility,
 } from "../../services/agent-thread-list.js";
+import { buildApiConversationId } from "../../services/api-conversation-id.js";
 import { readWatcherRunThreads } from "../../services/watcher-run-thread.js";
 import {
 	createOwnershipResolver,
@@ -74,6 +74,7 @@ type ToolApprovalHistoryInteraction = {
 	attribution: string | null;
 	/** Discriminator: "agent" | "watcher" | "entity". */
 	resourceKind: string | null;
+	reason: string | null;
 };
 
 type AgentErrorHistoryInteraction = {
@@ -178,7 +179,8 @@ async function readLatestAgentErrorInteraction(
 // load — keeping links live across reloads without ever persisting a token.
 // Matches the path only when NOT already followed by a query string (so an
 // already-signed link is left untouched).
-const TOKENLESS_FILE_REF = /\/api\/v1\/files\/([A-Za-z0-9._~-]+)(?![A-Za-z0-9._~?-])/g;
+const TOKENLESS_FILE_REF =
+	/\/api\/v1\/files\/([A-Za-z0-9._~-]+)(?![A-Za-z0-9._~?-])/g;
 
 /**
  * Recursively rewrite tokenless `/api/v1/files/:id` references in a user
@@ -528,6 +530,7 @@ export function createAgentHistoryRoutes(deps: {
 				fields: Record<string, unknown> | null;
 				attribution: string | null;
 				resource_kind: string | null;
+				reason: string | null;
 				tool: string | null;
 			}>`
 				SELECT id AS event_id,
@@ -541,6 +544,7 @@ export function createAgentHistoryRoutes(deps: {
 				       metadata->'fields' AS fields,
 				       metadata->>'attribution' AS attribution,
 				       metadata->>'resourceKind' AS resource_kind,
+				       metadata->>'reason' AS reason,
 				       metadata->>'tool' AS tool
 				FROM current_event_records
 				WHERE organization_id = ${scope.organizationId}
@@ -567,7 +571,7 @@ export function createAgentHistoryRoutes(deps: {
 					typeof rawProposal === "object" &&
 					(rawProposal as { args?: unknown }).args &&
 					typeof (rawProposal as { args: unknown }).args === "object"
-						? ((rawProposal as { args: Record<string, unknown> }).args)
+						? (rawProposal as { args: Record<string, unknown> }).args
 						: rawProposal;
 				return {
 					type: "tool-approval" as const,
@@ -579,6 +583,7 @@ export function createAgentHistoryRoutes(deps: {
 					fields: r.fields ?? null,
 					attribution: r.attribution ?? null,
 					resourceKind,
+					reason: r.reason ?? null,
 				};
 			});
 			const errorInteraction = await readLatestAgentErrorInteraction(
@@ -597,7 +602,9 @@ export function createAgentHistoryRoutes(deps: {
 		if (!scope) return errorResponse(c, "Unauthorized", 401);
 		if (!scope.organizationId) return c.json({ messages: [] });
 
-		const conversationId = decodeURIComponent(c.req.param("conversationId") || "");
+		const conversationId = decodeURIComponent(
+			c.req.param("conversationId") || "",
+		);
 		// Platform conversation ids are `{platform}:{...}` — alnum/._:- only.
 		if (!conversationId || !/^[a-zA-Z0-9._:-]+$/.test(conversationId)) {
 			return errorResponse(c, "Invalid conversation id", 400);

--- a/packages/server/src/gateway/services/watcher-run-thread.ts
+++ b/packages/server/src/gateway/services/watcher-run-thread.ts
@@ -21,19 +21,20 @@ export async function readWatcherRunThreads(args: {
 		autoAppliedCount: number;
 		messages: ReturnType<typeof paginateSessionMessages>["messages"];
 		actions: Array<{
-		type: "tool-approval";
-		eventId: number;
-		runId: number;
-		action: string | null;
-		proposal: Record<string, unknown> | null;
-		current: Record<string, unknown> | null;
-		fields: Record<string, unknown> | null;
+			type: "tool-approval";
+			eventId: number;
+			runId: number;
+			action: string | null;
+			proposal: Record<string, unknown> | null;
+			current: Record<string, unknown> | null;
+			fields: Record<string, unknown> | null;
 			attribution: string | null;
 			resourceKind: string | null;
+			reason: string | null;
 			status: string;
 			reviewedByName: string | null;
 			windowId: number | null;
-	}>;
+		}>;
 		automaticActions: Array<{
 			type: "entity-merge-result";
 			operationId: number;
@@ -131,6 +132,7 @@ export async function readWatcherRunThreads(args: {
 				fields: Record<string, unknown> | null;
 				attribution: string | null;
 				resourceKind: string | null;
+				reason: string | null;
 				status: string;
 				reviewedByName: string | null;
 				windowId: number | null;
@@ -178,6 +180,7 @@ export async function readWatcherRunThreads(args: {
 		fields: Record<string, unknown> | null;
 		attribution: string | null;
 		resource_kind: string | null;
+		reason: string | null;
 		tool: string | null;
 		window_id: number | null;
 		source_run_id: number | null;
@@ -192,6 +195,7 @@ export async function readWatcherRunThreads(args: {
 		       e.metadata->'fields' AS fields,
 		       e.metadata->>'attribution' AS attribution,
 		       e.metadata->>'resourceKind' AS resource_kind,
+		       e.metadata->>'reason' AS reason,
 		       e.metadata->>'tool' AS tool,
 		       e.interaction_status,
 		       e.metadata->>'reviewed_by_name' AS reviewed_by_name,
@@ -250,6 +254,7 @@ export async function readWatcherRunThreads(args: {
 			fields: row.fields ?? null,
 			attribution: row.attribution ?? null,
 			resourceKind,
+			reason: row.reason ?? null,
 			status: row.interaction_status,
 			reviewedByName: row.reviewed_by_name,
 		};
@@ -266,9 +271,7 @@ export async function readWatcherRunThreads(args: {
 	for (const { parentRunId, ...action } of actions) {
 		const run =
 			(parentRunId == null ? undefined : runById.get(parentRunId)) ??
-			(action.windowId == null
-				? undefined
-				: runByWindow.get(action.windowId));
+			(action.windowId == null ? undefined : runByWindow.get(action.windowId));
 		if (!run) continue;
 		run.actions.push(action);
 		if (action.status === "pending") run.pendingActionCount += 1;


### PR DESCRIPTION
## Summary
- persist and replay the entity-resolution policy reason for watcher runs and normal conversations
- explain whether a merge was automatically proven or requires human review
- point the Owletto submodule at lobu-ai/owletto#512 for the shared approval/result presentation

## Policy behavior
- entity types with an explicit normalized identity rule can auto-merge exact matches
- conflicting strict identities or proposals that do not satisfy the configured auto-merge policy require review
- the default person fallback remains review-only; workspace policy remains explicit

## Verification
- entity-resolution policy tests: 11 passed
- watcher thread API integration: 8 passed with embedded Postgres
- agent history route tests: 8 passed
- focused Owletto tests: 35 passed
- `make pre-pr` passed
- write-enabled review-fix completed and found/fixed concrete explanation defects

## Review note
The required independent Claude review was invoked but could not run because the local Claude OAuth session expired. This is reported as unavailable, not a pass; CI and production E2E remain required before merge.